### PR TITLE
enrich: bound the LLM call with a timeout

### DIFF
--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -5,16 +5,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/openai"
 )
 
+// defaultEnrichTimeout bounds a single LLM call. Without it a stalled gateway hangs
+// the worker indefinitely (a run-once worker holding its cron flock open forever,
+// stalling the whole queue). The lease/retry machinery then reclaims the job.
+const defaultEnrichTimeout = 90 * time.Second
+
 // LangChainProvider implements Provider over any OpenAI-compatible endpoint via
 // langchaingo. The endpoint, credential, and model are injected at construction;
 // the model is asked for a JSON object matching the Enrichment contract.
 type LangChainProvider struct {
-	llm llms.Model
+	llm     llms.Model
+	timeout time.Duration
 }
 
 // NewLangChainProvider builds a provider against an OpenAI-compatible endpoint.
@@ -30,12 +37,19 @@ func NewLangChainProvider(baseURL, apiKey, model string) (*LangChainProvider, er
 	if err != nil {
 		return nil, fmt.Errorf("enrich: build llm client: %w", err)
 	}
-	return &LangChainProvider{llm: llm}, nil
+	return &LangChainProvider{llm: llm, timeout: defaultEnrichTimeout}, nil
 }
 
 // Enrich asks the model for a structured Enrichment for the job and parses the JSON
 // response. It does not validate the result — the caller validates before persisting.
+// The LLM call is bounded by the provider timeout so a stalled gateway cannot hang
+// the worker.
 func (p *LangChainProvider) Enrich(ctx context.Context, job JobInput) (Enrichment, error) {
+	if p.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.timeout)
+		defer cancel()
+	}
 	messages := []llms.MessageContent{
 		llms.TextParts(llms.ChatMessageTypeSystem, systemPrompt),
 		llms.TextParts(llms.ChatMessageTypeHuman, userPrompt(job)),

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -1,9 +1,44 @@
 package enrich
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/tmc/langchaingo/llms"
 )
+
+// blockingLLM hangs until its context is cancelled, modelling a stalled gateway.
+type blockingLLM struct{}
+
+func (blockingLLM) GenerateContent(ctx context.Context, _ []llms.MessageContent, _ ...llms.CallOption) (*llms.ContentResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (blockingLLM) Call(context.Context, string, ...llms.CallOption) (string, error) { return "", nil }
+
+// A stalled gateway must not hang the worker: the provider's own timeout cancels
+// the call so Enrich returns an error instead of blocking forever.
+func TestEnrichTimesOutOnStalledModel(t *testing.T) {
+	p := &LangChainProvider{llm: blockingLLM{}, timeout: 20 * time.Millisecond}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.Enrich(context.Background(), JobInput{Description: "x"})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Enrich returned nil error, want a timeout error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Enrich did not return; the per-call timeout did not fire")
+	}
+}
 
 // The system prompt must pin the region (reach) vocabulary it asks the model to
 // use, drawn from the same list Validate enforces, so prompt and validator


### PR DESCRIPTION
A stalled LLM gateway left the enrich worker hung for 17h on prod — a run-once cron worker that holds a flock, so the entire enrichment queue stalled (50k+ pending) behind it. Wrap each GenerateContent call in a 90s timeout; on expiry the call errors and the outbox lease/retry machinery reclaims the job on the next run. New test asserts a stalled model no longer hangs Enrich.