### PR TITLE
ingest: fix staleAfter comment cadence

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -83,8 +83,9 @@ func main() {
 	}
 }
 
-// staleAfter is the grace window before an unseen job is closed: ~8 crawl cycles
-// at the 6h cadence, so a board failing a few runs in a row keeps its jobs open.
+// staleAfter is the grace window before an unseen job is closed: many crawl cycles
+// at the hourly per-provider cadence, so a board failing several runs in a row keeps
+// its jobs open.
 const staleAfter = 48 * time.Hour
 
 // shouldSweep reports whether the run saw enough of the world to justify closing


### PR DESCRIPTION
Comment-only follow-up from /simplify: `staleAfter` referenced the old 6h ingest cadence, now hourly per provider. No behavior change.