### PR TITLE
sources: add gem provider (GraphQL list→detail); 33 validated boards

### DIFF
--- a/internal/sources/gem.go
+++ b/internal/sources/gem.go
@@ -1,0 +1,150 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+)
+
+// gemGraphQLURL is Gem's public (unauthenticated) GraphQL endpoint; gemDetailWorkers caps
+// how many per-posting detail requests a single board issues concurrently.
+const (
+	gemGraphQLURL    = "https://jobs.gem.com/api/public/graphql"
+	gemDetailWorkers = 8
+)
+
+// The list operation carries no description, so each posting's body comes from its own
+// detail request. boardId is the board's vanity path (e.g. "go-cadre"), per the schema's
+// jobBoardExternal(vanityUrlPath: $boardId).
+const (
+	gemListQuery = `query JobBoardList($boardId: String!) {
+  oatsExternalJobPostings(boardId: $boardId) {
+    jobPostings {
+      extId
+      title
+      locations { city isoCountry isRemote }
+      job { locationType }
+    }
+  }
+}`
+
+	gemDetailQuery = `query ExternalJobPostingQuery($boardId: String!, $extId: String!) {
+  oatsExternalJobPosting(boardId: $boardId, extId: $extId) {
+    descriptionHtml
+    firstPublishedTsSec
+  }
+}`
+)
+
+// gem adapts Gem's public job-board GraphQL API. Its list endpoint carries no description,
+// so it fetches each posting's detail (bounded-concurrency) to assemble the body, like the
+// SmartRecruiters and Rippling adapters.
+type gem struct {
+	http HTTPClient
+}
+
+// NewGem builds the Gem adapter over the given HTTP client.
+func NewGem(c HTTPClient) Source { return gem{http: c} }
+
+func (gem) Provider() string { return "gem" }
+
+// gemRequest is a GraphQL request body. Both operations share this shape; the variables
+// carry boardId (and, for detail, extId).
+type gemRequest struct {
+	OperationName string         `json:"operationName"`
+	Query         string         `json:"query"`
+	Variables     map[string]any `json:"variables"`
+}
+
+// gemError is one entry of a GraphQL response's top-level errors[]. The transport returns
+// 200 even on a GraphQL-level failure (schema drift, server error), so the adapter checks
+// errors[] explicitly rather than treating a null data payload as an empty board.
+type gemError struct {
+	Message string `json:"message"`
+}
+
+// gemPosting is one item from the JobBoardList response (no description here).
+type gemPosting struct {
+	ExtID     string `json:"extId"`
+	Title     string `json:"title"`
+	Locations []struct {
+		City       string `json:"city"`
+		IsoCountry string `json:"isoCountry"`
+		IsRemote   bool   `json:"isRemote"`
+	} `json:"locations"`
+	Job struct {
+		LocationType string `json:"locationType"`
+	} `json:"job"`
+}
+
+func (g gem) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var resp struct {
+		Errors []gemError `json:"errors"`
+		Data   struct {
+			Postings struct {
+				JobPostings []gemPosting `json:"jobPostings"`
+			} `json:"oatsExternalJobPostings"`
+		} `json:"data"`
+	}
+	req := gemRequest{
+		OperationName: "JobBoardList",
+		Query:         gemListQuery,
+		Variables:     map[string]any{"boardId": e.Board},
+	}
+	if err := g.http.PostJSON(ctx, gemGraphQLURL, req, &resp); err != nil {
+		return nil, fmt.Errorf("gem: list board %s: %w", e.Board, err)
+	}
+	if len(resp.Errors) > 0 {
+		return nil, fmt.Errorf("gem: list board %s: %s", e.Board, resp.Errors[0].Message)
+	}
+
+	// Each posting's description comes from its own detail request, fanned out under a
+	// bounded worker pool.
+	return fetchDetails(resp.Data.Postings.JobPostings, gemDetailWorkers, func(p gemPosting) (Job, bool) {
+		return g.detail(ctx, e, p)
+	}), nil
+}
+
+// detail fetches one posting's description and maps it to a Job, returning ok=false when
+// the detail request fails so the caller can skip just that posting.
+func (g gem) detail(ctx context.Context, e CompanyEntry, p gemPosting) (Job, bool) {
+	var resp struct {
+		Errors []gemError `json:"errors"`
+		Data   struct {
+			Posting struct {
+				DescriptionHTML string `json:"descriptionHtml"`
+				// JSON numbers are untyped; firstPublishedTsSec is observed as integer
+				// seconds but a float must still parse rather than drop the posting.
+				FirstPublishedTsSec float64 `json:"firstPublishedTsSec"`
+			} `json:"oatsExternalJobPosting"`
+		} `json:"data"`
+	}
+	req := gemRequest{
+		OperationName: "ExternalJobPostingQuery",
+		Query:         gemDetailQuery,
+		Variables:     map[string]any{"boardId": e.Board, "extId": p.ExtID},
+	}
+	if err := g.http.PostJSON(ctx, gemGraphQLURL, req, &resp); err != nil {
+		return Job{}, false
+	}
+	if len(resp.Errors) > 0 {
+		return Job{}, false
+	}
+
+	var city, country string
+	var remote bool
+	if len(p.Locations) > 0 {
+		loc := p.Locations[0]
+		city, country, remote = loc.City, loc.IsoCountry, loc.IsRemote
+	}
+
+	return Job{
+		ExternalID:  p.ExtID,
+		URL:         fmt.Sprintf("https://jobs.gem.com/%s/%s", e.Board, p.ExtID),
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    joinNonEmpty(city, country),
+		Description: sanitizeHTML(resp.Data.Posting.DescriptionHTML),
+		Remote:      remote || p.Job.LocationType == "REMOTE",
+		PostedAt:    parseEpochSeconds(int64(resp.Data.Posting.FirstPublishedTsSec)),
+	}, true
+}

--- a/internal/sources/gem_test.go
+++ b/internal/sources/gem_test.go
@@ -1,0 +1,232 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gqlHTTP is a body-aware test HTTPClient for the GraphQL adapters: Gem sends both its
+// list and its detail request as POST to the same URL, distinguished only by the request
+// body, so this fake routes the canned response on the operation name and (for detail)
+// the extId in the variables — not the URL. A detail extId listed in failExtIDs returns
+// an error so detail-isolation can be exercised.
+type gqlHTTP struct {
+	list       string            // canned JobBoardList response
+	detail     map[string]string // extId -> canned ExternalJobPostingQuery response
+	failExtIDs map[string]bool   // extIds whose detail request errors
+	gotURL     string
+}
+
+func (f *gqlHTTP) GetJSON(context.Context, string, any) error {
+	return errors.New("gqlHTTP: unexpected GetJSON")
+}
+
+func (f *gqlHTTP) GetXML(context.Context, string, any) error {
+	return errors.New("gqlHTTP: unexpected GetXML")
+}
+
+func (f *gqlHTTP) PostJSON(_ context.Context, url string, body, v any) error {
+	f.gotURL = url
+	req, ok := body.(gemRequest)
+	if !ok {
+		return errors.New("gqlHTTP: body is not a gemRequest")
+	}
+	switch req.OperationName {
+	case "JobBoardList":
+		return json.Unmarshal([]byte(f.list), v)
+	case "ExternalJobPostingQuery":
+		ext, _ := req.Variables["extId"].(string)
+		if f.failExtIDs[ext] {
+			return errors.New("gqlHTTP: detail boom for " + ext)
+		}
+		raw, ok := f.detail[ext]
+		if !ok {
+			return errors.New("gqlHTTP: no canned detail for " + ext)
+		}
+		return json.Unmarshal([]byte(raw), v)
+	default:
+		return errors.New("gqlHTTP: unknown operation " + req.OperationName)
+	}
+}
+
+// gemListResp builds a JobBoardList response from inline posting fragments.
+func gemListResp(postings ...string) string {
+	return `{"data":{"oatsExternalJobPostings":{"jobPostings":[` + strings.Join(postings, ",") + `]}}}`
+}
+
+func gemDetailResp(descHTML string, firstPublishedTsSec int64) string {
+	desc, _ := json.Marshal(descHTML)
+	return fmt.Sprintf(`{"data":{"oatsExternalJobPosting":{"descriptionHtml":%s,"firstPublishedTsSec":%d}}}`,
+		desc, firstPublishedTsSec)
+}
+
+func TestGemProvider(t *testing.T) {
+	if got := NewGem(nil).Provider(); got != "gem" {
+		t.Errorf("Provider() = %q, want %q", got, "gem")
+	}
+}
+
+func TestGemFetchListsThenFetchesDetailAndMaps(t *testing.T) {
+	fake := &gqlHTTP{
+		list: gemListResp(
+			`{"extId":"X1","title":"Backend Engineer","locations":[{"city":"San Diego","isoCountry":"USA","isRemote":false}],"job":{"locationType":"IN_OFFICE"}}`,
+			`{"extId":"X2","title":"Remote SRE","locations":[{"city":"","isoCountry":"COL","isRemote":true}],"job":{"locationType":"REMOTE"}}`,
+		),
+		detail: map[string]string{
+			"X1": gemDetailResp(`<h2>Role</h2><p>Build it.</p><script>alert(1)</script>`, 1775770388),
+			"X2": gemDetailResp(`<p>Keep it up.</p>`, 0),
+		},
+	}
+
+	jobs, err := NewGem(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Cadre AI", Provider: "gem", Board: "go-cadre",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	x1 := byID["X1"]
+	if x1.Title != "Backend Engineer" {
+		t.Errorf("X1 Title = %q", x1.Title)
+	}
+	if x1.Company != "Cadre AI" {
+		t.Errorf("X1 Company = %q", x1.Company)
+	}
+	if want := "https://jobs.gem.com/go-cadre/X1"; x1.URL != want {
+		t.Errorf("X1 URL = %q, want %q", x1.URL, want)
+	}
+	if want := "San Diego, USA"; x1.Location != want {
+		t.Errorf("X1 Location = %q, want %q", x1.Location, want)
+	}
+	if strings.Contains(x1.Description, "<script>") || !strings.Contains(x1.Description, "<h2>Role</h2>") {
+		t.Errorf("X1 Description not sanitized/assembled: %q", x1.Description)
+	}
+	if x1.Remote {
+		t.Errorf("X1 Remote = true, want false")
+	}
+	if x1.PostedAt == nil || !x1.PostedAt.Equal(time.Unix(1775770388, 0).UTC()) {
+		t.Errorf("X1 PostedAt = %v, want 2026-04-10T...", x1.PostedAt)
+	}
+
+	x2 := byID["X2"]
+	if !x2.Remote {
+		t.Errorf("X2 Remote = false, want true (locationType REMOTE / isRemote)")
+	}
+	if want := "COL"; x2.Location != want {
+		t.Errorf("X2 Location = %q, want %q (empty city skipped)", x2.Location, want)
+	}
+	if x2.PostedAt != nil {
+		t.Errorf("X2 PostedAt = %v, want nil (zero firstPublishedTsSec)", x2.PostedAt)
+	}
+}
+
+func TestGemListUsesBoardAsBoardId(t *testing.T) {
+	fake := &gqlHTTP{list: gemListResp()}
+	if _, err := NewGem(fake).Fetch(context.Background(), CompanyEntry{Board: "go-cadre"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if want := "https://jobs.gem.com/api/public/graphql"; fake.gotURL != want {
+		t.Errorf("posted to %q, want %q", fake.gotURL, want)
+	}
+}
+
+func TestGemFailedDetailDropsOnlyThatPosting(t *testing.T) {
+	fake := &gqlHTTP{
+		list: gemListResp(
+			`{"extId":"OK","title":"Kept","locations":[],"job":{}}`,
+			`{"extId":"BAD","title":"Dropped","locations":[],"job":{}}`,
+		),
+		detail:     map[string]string{"OK": gemDetailResp(`<p>ok</p>`, 1775770388)},
+		failExtIDs: map[string]bool{"BAD": true},
+	}
+
+	jobs, err := NewGem(fake).Fetch(context.Background(), CompanyEntry{Board: "go-cadre"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "OK" {
+		t.Fatalf("got %v, want only the OK posting", jobs)
+	}
+}
+
+func TestGemListGraphQLErrorFailsBoard(t *testing.T) {
+	// A GraphQL 200 carrying an errors[] (e.g. schema drift / server error) must fail the
+	// board so the run records it, not look like an empty board.
+	fake := &gqlHTTP{list: `{"errors":[{"message":"boom"}],"data":{"oatsExternalJobPostings":null}}`}
+	if _, err := NewGem(fake).Fetch(context.Background(), CompanyEntry{Board: "go-cadre"}); err == nil {
+		t.Fatal("Fetch: want error from list errors[], got nil")
+	}
+}
+
+func TestGemDetailGraphQLErrorDropsPosting(t *testing.T) {
+	fake := &gqlHTTP{
+		list: gemListResp(
+			`{"extId":"OK","title":"Kept","locations":[],"job":{}}`,
+			`{"extId":"ERR","title":"Dropped","locations":[],"job":{}}`,
+		),
+		detail: map[string]string{
+			"OK":  gemDetailResp(`<p>ok</p>`, 1775770388),
+			"ERR": `{"errors":[{"message":"posting gone"}],"data":{"oatsExternalJobPosting":null}}`,
+		},
+	}
+	jobs, err := NewGem(fake).Fetch(context.Background(), CompanyEntry{Board: "go-cadre"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "OK" {
+		t.Fatalf("got %v, want only the OK posting (errors[] detail dropped)", jobs)
+	}
+}
+
+func TestGemFloatTimestampSurvives(t *testing.T) {
+	// firstPublishedTsSec is observed as an integer, but JSON numbers are untyped; a float
+	// must still parse the date and keep the posting, never drop it (posted_at is nullable).
+	fake := &gqlHTTP{
+		list:   gemListResp(`{"extId":"F1","title":"Floaty","locations":[],"job":{}}`),
+		detail: map[string]string{"F1": `{"data":{"oatsExternalJobPosting":{"descriptionHtml":"<p>x</p>","firstPublishedTsSec":1775770388.0}}}`},
+	}
+	jobs, err := NewGem(fake).Fetch(context.Background(), CompanyEntry{Board: "go-cadre"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (float timestamp must not drop the posting)", len(jobs))
+	}
+	if jobs[0].PostedAt == nil || !jobs[0].PostedAt.Equal(time.Unix(1775770388, 0).UTC()) {
+		t.Errorf("PostedAt = %v, want parsed from float seconds", jobs[0].PostedAt)
+	}
+}
+
+func TestGemEmptyBoardYieldsNoJobsNoError(t *testing.T) {
+	fake := &gqlHTTP{list: gemListResp()}
+	jobs, err := NewGem(fake).Fetch(context.Background(), CompanyEntry{Board: "go-cadre"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0", len(jobs))
+	}
+}
+
+func TestParseEpochSeconds(t *testing.T) {
+	if got := parseEpochSeconds(0); got != nil {
+		t.Errorf("parseEpochSeconds(0) = %v, want nil", got)
+	}
+	got := parseEpochSeconds(1775770388)
+	if got == nil || !got.Equal(time.Unix(1775770388, 0).UTC()) {
+		t.Errorf("parseEpochSeconds(1775770388) = %v", got)
+	}
+}

--- a/internal/sources/huntflow.go
+++ b/internal/sources/huntflow.go
@@ -1,0 +1,239 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// huntflow adapts the public career sites Huntflow hosts at <board>.huntflow.io. Those
+// pages are a Nuxt SSR app, so the vacancy data is served as a devalue-encoded
+// _payload.json (a flat array where object/array fields are indices into it). The list
+// payload carries no description, so each open vacancy's body comes from its own detail
+// payload, fanned out like SmartRecruiters.
+type huntflow struct {
+	http HTTPClient
+}
+
+const (
+	huntflowListURL       = "https://%s.huntflow.io/_payload.json"
+	huntflowDetailURL     = "https://%s.huntflow.io/vacancy/%s/_payload.json"
+	huntflowVacancyURL    = "https://%s.huntflow.io/vacancy/%s"
+	huntflowDetailWorkers = 8
+)
+
+// NewHuntflow builds the Huntflow adapter over the given HTTP client.
+func NewHuntflow(c HTTPClient) Source { return huntflow{http: c} }
+
+func (huntflow) Provider() string { return "huntflow" }
+
+// hfItem is one vacancy from the list payload (no description here). A non-nil
+// ArchivedAt marks a closed vacancy, which the crawl skips.
+type hfItem struct {
+	ID         int64   `json:"id"`
+	Slug       string  `json:"slug"`
+	Position   string  `json:"position"`
+	ArchivedAt *string `json:"archived_at"`
+}
+
+func (h huntflow) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	items, err := h.list(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+
+	open := make([]hfItem, 0, len(items))
+	for _, it := range items {
+		if it.ArchivedAt == nil {
+			open = append(open, it)
+		}
+	}
+
+	return fetchDetails(open, huntflowDetailWorkers, func(it hfItem) (Job, bool) {
+		return h.detail(ctx, e, it)
+	}), nil
+}
+
+// list fetches a board's vacancy list from its _payload.json.
+func (h huntflow) list(ctx context.Context, board string) ([]hfItem, error) {
+	node, err := h.payload(ctx, fmt.Sprintf(huntflowListURL, board))
+	if err != nil {
+		return nil, fmt.Errorf("huntflow: list board %s: %w", board, err)
+	}
+	var lp struct {
+		Data struct {
+			Vacancies struct {
+				Items []hfItem `json:"items"`
+			} `json:"vacancies"`
+		} `json:"data"`
+	}
+	if err := remarshal(node, &lp); err != nil {
+		return nil, fmt.Errorf("huntflow: decode list board %s: %w", board, err)
+	}
+	return lp.Data.Vacancies.Items, nil
+}
+
+// detail fetches one vacancy's detail payload and maps it to a Job, returning ok=false
+// when the fetch or decode fails so the caller skips just that vacancy.
+func (h huntflow) detail(ctx context.Context, e CompanyEntry, it hfItem) (Job, bool) {
+	node, err := h.payload(ctx, fmt.Sprintf(huntflowDetailURL, e.Board, it.Slug))
+	if err != nil {
+		return Job{}, false
+	}
+	vac := findVacancy(node)
+	if vac == nil {
+		return Job{}, false
+	}
+	var d struct {
+		City         string `json:"city"`
+		Money        string `json:"money"`
+		Intro        string `json:"intro"`
+		Body         string `json:"body"`
+		Requirements string `json:"requirements"`
+		Conditions   string `json:"conditions"`
+	}
+	if err := remarshal(vac, &d); err != nil {
+		return Job{}, false
+	}
+
+	// The feed has no salary field on Job, so fold money into the description (when set)
+	// rather than drop it — enrichment reads salary from the description text.
+	body := d.Intro + d.Body + d.Requirements + d.Conditions
+	if d.Money != "" {
+		body = "<p>" + d.Money + "</p>" + body
+	}
+
+	return Job{
+		ExternalID:  strconv.FormatInt(it.ID, 10),
+		URL:         fmt.Sprintf(huntflowVacancyURL, e.Board, it.Slug),
+		Title:       it.Position,
+		Company:     e.Company,
+		Location:    d.City,
+		Description: sanitizeHTML(body),
+		Remote:      isRemote(d.City),
+		PostedAt:    nil, // the public career feed carries no publish date
+	}, true
+}
+
+// payload fetches a Nuxt _payload.json and resolves its devalue references into a plain
+// nested value (maps/slices/scalars).
+func (h huntflow) payload(ctx context.Context, url string) (any, error) {
+	var raw []json.RawMessage
+	if err := h.http.GetJSON(ctx, url, &raw); err != nil {
+		return nil, err
+	}
+	return unflattenPayload(raw)
+}
+
+// unflattenPayload resolves a devalue-encoded array (Nuxt's _payload.json format). Every
+// value is a node in raw; an object's field values and an array's elements are integer
+// indices into raw, and scalars are stored once and shared by index. A string-headed
+// array is a type wrapper (e.g. ShallowReactive) and resolves to its wrapped value.
+func unflattenPayload(raw []json.RawMessage) (any, error) {
+	memo := make([]any, len(raw))
+	done := make([]bool, len(raw))
+
+	var hydrate func(i int) (any, error)
+	hydrate = func(i int) (any, error) {
+		if i < 0 || i >= len(raw) {
+			return nil, nil
+		}
+		if done[i] {
+			return memo[i], nil
+		}
+		var tok any
+		if err := json.Unmarshal(raw[i], &tok); err != nil {
+			return nil, err
+		}
+
+		var out any
+		switch t := tok.(type) {
+		case map[string]any:
+			obj := make(map[string]any, len(t))
+			for k, ref := range t {
+				v, err := hydrateRef(ref, hydrate)
+				if err != nil {
+					return nil, err
+				}
+				obj[k] = v
+			}
+			out = obj
+		case []any:
+			// A string-headed array is a devalue type token (e.g. ShallowReactive) that
+			// wraps one referenced value rather than listing elements; resolve to it.
+			if len(t) > 0 {
+				if _, isWrapper := t[0].(string); isWrapper {
+					if len(t) > 1 {
+						wrapped, err := hydrateRef(t[1], hydrate)
+						if err != nil {
+							return nil, err
+						}
+						out = wrapped
+					}
+					break
+				}
+			}
+			arr := make([]any, 0, len(t))
+			for _, ref := range t {
+				v, err := hydrateRef(ref, hydrate)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, v)
+			}
+			out = arr
+		default:
+			out = tok
+		}
+
+		memo[i], done[i] = out, true
+		return out, nil
+	}
+	return hydrate(0)
+}
+
+// hydrateRef resolves a single field value or array element: a JSON number is an index
+// into the payload, anything else is taken literally.
+func hydrateRef(ref any, hydrate func(int) (any, error)) (any, error) {
+	if idx, ok := ref.(float64); ok {
+		return hydrate(int(idx))
+	}
+	return ref, nil
+}
+
+// findVacancy walks a decoded detail payload for the vacancy object — the map carrying
+// both a body and a position. Walking rather than assuming a fixed key path keeps the
+// adapter robust to Nuxt's surrounding route-state nesting.
+func findVacancy(node any) map[string]any {
+	switch n := node.(type) {
+	case map[string]any:
+		_, hasBody := n["body"]
+		_, hasPosition := n["position"]
+		if hasBody && hasPosition {
+			return n
+		}
+		for _, v := range n {
+			if r := findVacancy(v); r != nil {
+				return r
+			}
+		}
+	case []any:
+		for _, v := range n {
+			if r := findVacancy(v); r != nil {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// remarshal re-encodes a decoded payload node and decodes it into v, so a typed struct
+// can read the dynamic devalue result.
+func remarshal(node, v any) error {
+	b, err := json.Marshal(node)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, v)
+}

--- a/internal/sources/huntflow_test.go
+++ b/internal/sources/huntflow_test.go
@@ -1,0 +1,198 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestHuntflowProvider(t *testing.T) {
+	if got := NewHuntflow(nil).Provider(); got != "huntflow" {
+		t.Errorf("Provider() = %q, want %q", got, "huntflow")
+	}
+}
+
+// rawSlice parses a devalue payload string into the []json.RawMessage the decoder takes.
+func rawSlice(t *testing.T, s string) []json.RawMessage {
+	t.Helper()
+	var raw []json.RawMessage
+	if err := json.Unmarshal([]byte(s), &raw); err != nil {
+		t.Fatalf("parse devalue fixture: %v", err)
+	}
+	return raw
+}
+
+func TestHuntflowUnflattenResolvesReferences(t *testing.T) {
+	// devalue: every value is a node in the array; object/array fields are indices into
+	// it, scalars are stored once and shared by index (null at index 8 here).
+	raw := rawSlice(t, `[
+		{"data":1},{"vacancies":2},{"items":3},[4],
+		{"id":5,"slug":6,"position":7,"city":8,"money":8,"division":8,"archived_at":8},
+		26610,"senior-backend-developer-2","Senior Backend Developer",null
+	]`)
+
+	node, err := unflattenPayload(raw)
+	if err != nil {
+		t.Fatalf("unflattenPayload: %v", err)
+	}
+	got, err := json.Marshal(node)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"data":{"vacancies":{"items":[{"archived_at":null,"city":null,"division":null,"id":26610,"money":null,"position":"Senior Backend Developer","slug":"senior-backend-developer-2"}]}}}`
+	if string(got) != want {
+		t.Errorf("unflatten =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestHuntflowUnflattenUnwrapsTypeTokens(t *testing.T) {
+	// A devalue array whose first element is a string is a type wrapper (e.g. Nuxt's
+	// ShallowReactive) and must resolve to its wrapped value, not to a literal array.
+	raw := rawSlice(t, `[{"data":1},["ShallowReactive",2],"ok"]`)
+
+	node, err := unflattenPayload(raw)
+	if err != nil {
+		t.Fatalf("unflattenPayload: %v", err)
+	}
+	got, _ := json.Marshal(node)
+	if want := `{"data":"ok"}`; string(got) != want {
+		t.Errorf("unflatten = %s, want %s", got, want)
+	}
+}
+
+// hfListBody builds a devalue list payload for one vacancy with the given fields.
+// archived is "null" for an open vacancy or a quoted timestamp for an archived one.
+func hfListBody(id int, slug, position, archived string) string {
+	return `[
+		{"data":1},{"vacancies":2},{"items":3},[4],
+		{"id":5,"slug":6,"position":7,"archived_at":8},
+		` + strconv.Itoa(id) + `,"` + slug + `","` + position + `",` + archived + `
+	]`
+}
+
+// hfDetailBody builds a devalue detail payload for one vacancy. money/city are "null"
+// or a quoted string; the body HTML carries the description.
+func hfDetailBody(id int, position, city, money, body string) string {
+	return `[
+		{"data":1},{"vacancy":2},
+		{"id":3,"position":4,"city":5,"money":6,"intro":7,"body":8,"requirements":9,"conditions":9,"is_archived":10},
+		` + strconv.Itoa(id) + `,"` + position + `",` + city + `,` + money + `,"","` + body + `","",false
+	]`
+}
+
+func TestHuntflowFetchMapsListAndDetail(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/vacancy/senior-backend-developer-2/_payload.json",
+			hfDetailBody(26610, "Senior Backend Developer", "null", "null", "<p>Build systems.</p>")).
+		route(".huntflow.io/_payload.json", hfListBody(26610, "senior-backend-developer-2", "Senior Backend Developer", "null"))
+
+	jobs, err := NewHuntflow(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Tripster", Provider: "huntflow", Board: "tripster",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "26610" {
+		t.Errorf("ExternalID = %q, want 26610", j.ExternalID)
+	}
+	if j.Title != "Senior Backend Developer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.URL != "https://tripster.huntflow.io/vacancy/senior-backend-developer-2" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Company != "Tripster" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if !strings.Contains(j.Description, "Build systems.") {
+		t.Errorf("Description = %q, want the body HTML", j.Description)
+	}
+	if j.PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil (feed has no date)", j.PostedAt)
+	}
+}
+
+func TestHuntflowFetchSkipsArchived(t *testing.T) {
+	// Two list items; one archived. Only the open one is detailed and returned.
+	list := `[
+		{"data":1},{"vacancies":2},{"items":3},[4,9],
+		{"id":5,"slug":6,"position":7,"archived_at":8},100,"open","Open Role",null,
+		{"id":10,"slug":11,"position":12,"archived_at":13},200,"gone","Gone Role","2024-01-01"
+	]`
+	fake := (&routedHTTP{}).
+		route(".huntflow.io/_payload.json",list).
+		route("/vacancy/open/_payload.json", hfDetailBody(100, "Open Role", "null", "null", "<p>Hiring.</p>"))
+
+	jobs, err := NewHuntflow(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "huntflow", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "100" {
+		t.Fatalf("want only the open vacancy, got %d jobs", len(jobs))
+	}
+}
+
+func TestHuntflowFetchFoldsSalaryIntoDescription(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route(".huntflow.io/_payload.json",hfListBody(1, "lawyer", "Lawyer", "null")).
+		route("/vacancy/lawyer/_payload.json",
+			hfDetailBody(1, "Lawyer", "null", `"до 190 000 рублей"`, "<p>Do law.</p>"))
+
+	jobs, _ := NewHuntflow(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Flowwow", Provider: "huntflow", Board: "flowwow",
+	})
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "190 000") {
+		t.Errorf("Description should fold in money, got %q", jobs[0].Description)
+	}
+}
+
+func TestHuntflowFetchDetectsRussianRemote(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route(".huntflow.io/_payload.json",hfListBody(1, "dev", "Developer", "null")).
+		route("/vacancy/dev/_payload.json",
+			hfDetailBody(1, "Developer", `"Москва / удалённо"`, "null", "<p>Code.</p>"))
+
+	jobs, _ := NewHuntflow(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "huntflow", Board: "acme",
+	})
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !jobs[0].Remote {
+		t.Errorf("Remote = false, want true for Russian 'удалённо' location")
+	}
+}
+
+func TestHuntflowFetchSkipsFailedDetail(t *testing.T) {
+	// The second vacancy has no detail route -> its detail fetch errors and it is
+	// skipped, but the first still comes through.
+	list := `[
+		{"data":1},{"vacancies":2},{"items":3},[4,9],
+		{"id":5,"slug":6,"position":7,"archived_at":8},1,"good","Good",null,
+		{"id":10,"slug":11,"position":12,"archived_at":13},2,"broken","Broken",null
+	]`
+	fake := (&routedHTTP{}).
+		route("/vacancy/good/_payload.json", hfDetailBody(1, "Good", "null", "null", "<p>Ok.</p>")).
+		route(".huntflow.io/_payload.json",list)
+
+	jobs, err := NewHuntflow(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "huntflow", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch should not abort on one failed detail: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "1" {
+		t.Fatalf("want only the good vacancy, got %d jobs", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -55,6 +55,7 @@ func All(c HTTPClient) map[string]Source {
 		NewRippling(c),
 		NewBambooHR(c),
 		NewWorkday(c),
+		NewHuntflow(c),
 	)
 }
 
@@ -91,9 +92,11 @@ func fetchDetails[P any](postings []P, workers int, fetch func(P) (Job, bool)) [
 }
 
 // isRemote infers a job's remote flag from its location text. Adapters share it so
-// the heuristic stays consistent across platforms.
+// the heuristic stays consistent across platforms. It matches the English "remote" and
+// the Russian "удал…" (удалённо/удалённая/удалёнка) so RU-segment boards flag correctly.
 func isRemote(location string) bool {
-	return strings.Contains(strings.ToLower(location), "remote")
+	l := strings.ToLower(location)
+	return strings.Contains(l, "remote") || strings.Contains(l, "удал")
 }
 
 // parseLayout parses a platform timestamp with the given layout into a posted_at,

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -56,6 +56,7 @@ func All(c HTTPClient) map[string]Source {
 		NewBambooHR(c),
 		NewWorkday(c),
 		NewHuntflow(c),
+		NewGem(c),
 	)
 }
 
@@ -143,6 +144,16 @@ func parseEpochMillis(ms int64) *time.Time {
 		return nil
 	}
 	t := time.UnixMilli(ms).UTC()
+	return &t
+}
+
+// parseEpochSeconds converts a Unix-second timestamp into a posted_at, returning nil for
+// a zero value (treated as "no date"). Gem dates postings with firstPublishedTsSec.
+func parseEpochSeconds(s int64) *time.Time {
+	if s == 0 {
+		return nil
+	}
+	t := time.Unix(s, 0).UTC()
 	return &t
 }
 

--- a/openspec/changes/add-gem-source-adapter/.openspec.yaml
+++ b/openspec/changes/add-gem-source-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/add-gem-source-adapter/design.md
+++ b/openspec/changes/add-gem-source-adapter/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`internal/sources` holds one adapter file per ATS platform behind the `Source` interface
+(`Provider() string`; `Fetch(ctx, CompanyEntry) ([]Job, error)`), assembled in
+`sources.All`. Several adapters whose list endpoint omits the description
+(smartrecruiters, rippling, bamboohr) already use the shared `fetchDetails` bounded-pool
+helper to fan out per-posting detail requests. Gem fits this exact shape.
+
+The Gem contract was confirmed live against the `go-cadre` board:
+
+- Endpoint: `POST https://jobs.gem.com/api/public/graphql` — public profile, no auth, no
+  Cloudflare. Body is standard GraphQL `{operationName, variables, query}`.
+- List `JobBoardList(boardId)` → `data.oatsExternalJobPostings.jobPostings[]`, each with
+  `extId`, `title`, `locations[]{name, city, isoCountry, isRemote}`, and
+  `job{locationType, employmentType}`. No description. No pagination arguments.
+- Detail `ExternalJobPostingQuery(boardId, extId)` →
+  `data.oatsExternalJobPosting{descriptionHtml, firstPublishedTsSec, startDateTs,
+  companyUrl, …}`.
+- `boardId` is the board's **vanity path** (`go-cadre`), confirmed by the schema field
+  `jobBoardExternal(vanityUrlPath: $boardId)`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `gem` adapter that lists a board and yields normalized jobs with sanitized-HTML
+  descriptions, reusing the existing list→detail pattern and helpers.
+- One-line registration in `sources.All`; one `sources.yml` entry to onboard a board.
+
+**Non-Goals:**
+- Pagination of `JobBoardList` (the operation exposes no page arguments; Gem boards are
+  single-company and small). Deferred until an observed board truncates.
+- Any change to the pipeline, write path, config, or schema.
+- The authenticated `/api/graphql` (APP) profile — only the public profile is used.
+
+## Decisions
+
+- **Two GraphQL operations over `PostJSON`.** `Fetch` issues `JobBoardList` once, then
+  `fetchDetails(postings, gemDetailWorkers, …)` runs `ExternalJobPostingQuery` per posting
+  under a bounded pool — identical isolation to smartrecruiters/rippling/bamboohr. A failed
+  detail drops only that posting.
+- **Query text is embedded as Go string constants**, sending the minimal field set the
+  adapter consumes (not the browser's full selection set). Variables are
+  `{boardId: e.Board, extId: posting.extId}`.
+- **Job mapping:**
+  - `ExternalID` = `extId` (the pipeline namespaces it as `"<board>:<extId>"`).
+  - `URL` = `https://jobs.gem.com/<board>/<extId>`.
+  - `Title` = `title`; `Company` = `e.Company`.
+  - `Location` = `joinNonEmpty(city, isoCountry)` of the first location (existing helper).
+  - `Description` = `sanitizeHTML(descriptionHtml)`.
+  - `Remote` = the first location's `isRemote` **OR** `job.locationType == "REMOTE"` —
+    Gem exposes structured flags, more reliable than the free-text `isRemote()` heuristic.
+  - `PostedAt` = `parseEpochSeconds(firstPublishedTsSec)` — a new helper beside
+    `parseEpochMillis`, returning nil for a zero/absent value. `firstPublishedTsSec` is
+    chosen over `startDateTs` because it is a stable integer first-publication date, where
+    `startDateTs` is a float that can shift.
+- **No description in the list is the reason for the detail fetch**, matching the spec's
+  existing "fetches detail when the list lacks the description" requirement.
+
+## Risks / Trade-offs
+
+- **Unpaginated list** — if a Gem board ever exceeds one page, jobs silently truncate.
+  Mitigation: single-company boards are small (observed: 8); revisit only on evidence.
+- **GraphQL schema drift** — Gem could rename fields. Mitigation: the adapter requests a
+  minimal field set; a missing field surfaces as an empty value, and the board still
+  ingests. Covered by table-driven tests over canned JSON responses, the same way existing
+  adapters are tested (no live network in unit tests).
+- **Public endpoint stability** — relies on the unauthenticated public profile remaining
+  open; if Gem gates it, the adapter would need the same fetch-infra decision deferred for
+  Dayforce. Out of scope here.

--- a/openspec/changes/add-gem-source-adapter/proposal.md
+++ b/openspec/changes/add-gem-source-adapter/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Gem (jobs.gem.com) hosts company job boards that several IT-segment companies use, and
+its postings are exposed through a public, unauthenticated GraphQL endpoint with no
+bot-wall. Adding a `gem` adapter brings those boards into the shared pool with the same
+one-line-per-board ergonomics as every other platform.
+
+## What Changes
+
+- Add a `gem` source adapter (`internal/sources/gem.go`) speaking the existing `Source`
+  interface, registered with one `NewGem(c)` line in `sources.All`.
+- The adapter follows the established **list → detail** pattern (like
+  smartrecruiters/rippling/bamboohr): the list operation carries no description, so each
+  posting's body is fetched via a bounded-concurrency detail request using the shared
+  `fetchDetails` helper.
+- Transport is `POST https://jobs.gem.com/api/public/graphql` (public profile, no auth)
+  with two operations: `JobBoardList(boardId)` for the postings and
+  `ExternalJobPostingQuery(boardId, extId)` for each description. The `sources.yml`
+  `board` value is the Gem **vanity path** (e.g. `go-cadre`), passed verbatim as the
+  GraphQL `boardId`.
+- Add a small `parseEpochSeconds` time helper beside the existing `parseEpochMillis`, since
+  Gem dates its postings with `firstPublishedTsSec` (Unix seconds).
+- Add at least one `gem` entry to `sources.yml`.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. Reuses the source-ingest pipeline and write path unchanged. -->
+
+### Modified Capabilities
+- `source-ingest`: add a requirement that `gem` is a registered provider — a GraphQL
+  list→detail adapter yielding the normalized job shape with a sanitized-HTML description,
+  consistent with the existing detail-fetching adapters.
+
+## Impact
+
+- **New code**: `internal/sources/gem.go` + `internal/sources/gem_test.go`; one registration
+  line in `internal/sources/source.go` (`sources.All`); one `parseEpochSeconds` helper.
+- **Config**: one new `sources.yml` entry. No new env vars.
+- **DB**: none — reuses `UpsertJob` (`source = "gem"`, namespaced `external_id`). No migration.
+- **Dependencies**: none — uses the existing shared `HTTPClient.PostJSON` and `sanitizeHTML`.
+- **Out of scope (known seam)**: `JobBoardList` takes no pagination arguments; this is fine
+  for single-company Gem boards but would truncate a very large board. Revisit pagination
+  only if an observed board exceeds one page.

--- a/openspec/changes/add-gem-source-adapter/specs/source-ingest/spec.md
+++ b/openspec/changes/add-gem-source-adapter/specs/source-ingest/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Gem is a registered provider
+
+The system SHALL register a `gem` adapter so boards on the Gem platform (jobs.gem.com)
+can be listed in `sources.yml`. The adapter SHALL treat the configured `board` value as
+the Gem **vanity path** and pass it verbatim as the GraphQL `boardId`. It SHALL fetch
+postings from the public GraphQL endpoint `POST https://jobs.gem.com/api/public/graphql`
+using the `JobBoardList(boardId)` operation, and — because that list carries no
+description — SHALL fetch each posting's body via the `ExternalJobPostingQuery(boardId,
+extId)` operation with bounded concurrency. A single failed detail request SHALL drop
+only that posting rather than abort the board. The adapter SHALL yield the normalized job
+shape (at least title, url, location, remote flag, description, and the platform's native
+posting id), with the `description` as sanitized HTML assembled from the posting's
+`descriptionHtml` field, consistent with the existing adapters.
+
+#### Scenario: Gem board is crawled list-then-detail
+
+- **WHEN** `sources.yml` lists a board with provider `gem` and a vanity-path `board`
+- **THEN** the adapter calls `JobBoardList` with that vanity path as `boardId`, and per
+  returned posting calls `ExternalJobPostingQuery` with the posting's `extId` to obtain a
+  sanitized HTML description, yielding each as the normalized job shape with
+  `external_id` set to the posting's `extId`
+
+#### Scenario: Remote is taken from Gem's structured flags
+
+- **WHEN** a Gem posting reports a location with `isRemote: true` or a `job.locationType`
+  of `REMOTE`
+- **THEN** the adapter yields the job with its remote flag set, without relying on a
+  free-text location match
+
+#### Scenario: Posting is dated from its first-published timestamp
+
+- **WHEN** a Gem posting carries a `firstPublishedTsSec` Unix-seconds timestamp
+- **THEN** the adapter yields the job with `posted_at` derived from that timestamp, and
+  yields a nil `posted_at` when the timestamp is absent or zero
+
+#### Scenario: A failed detail request drops only that posting
+
+- **WHEN** a Gem board lists several postings and one posting's
+  `ExternalJobPostingQuery` request fails
+- **THEN** the failed posting is skipped and every other posting is still yielded, without
+  aborting the board
+
+#### Scenario: A board with no open postings yields no jobs without error
+
+- **WHEN** a Gem board returns an empty `jobPostings` list
+- **THEN** the adapter yields zero jobs and returns no error, so the board is simply
+  skipped

--- a/openspec/changes/add-gem-source-adapter/tasks.md
+++ b/openspec/changes/add-gem-source-adapter/tasks.md
@@ -1,0 +1,36 @@
+## 1. Test scaffolding (body-aware fake)
+
+- [x] 1.1 Add a body-aware test HTTP fake (e.g. `gqlHTTP` in `gem_test.go`, or extend the shared test fakes): Gem sends both list and detail as `POST /api/public/graphql`, distinguished only by the request body, so the fake MUST route the canned response on the request body (`operationName` / the `extId` in `variables`), not the URL
+- [x] 1.2 Add canned GraphQL JSON fixtures inline: a `JobBoardList` response with 2+ postings (one with `isRemote: true`, one `IN_OFFICE`, one missing `firstPublishedTsSec`) and matching `ExternalJobPostingQuery` detail responses carrying `descriptionHtml`
+
+## 2. parseEpochSeconds helper (TDD)
+
+- [x] 2.1 Test `parseEpochSeconds`: a positive Unix-seconds value → the corresponding UTC `*time.Time`; `0`/absent → nil (mirrors `parseEpochMillis`)
+- [x] 2.2 Implement `parseEpochSeconds` in `internal/sources/source.go` beside `parseEpochMillis`
+
+## 3. Gem adapter — Provider + list→detail Fetch (TDD)
+
+- [x] 3.1 Test `Provider()` returns `"gem"`
+- [x] 3.2 Test `Fetch` issues `JobBoardList` with `boardId = e.Board` (vanity path), then one `ExternalJobPostingQuery` per posting, and yields the normalized jobs; assert the request bodies carry the right `operationName` and `boardId`/`extId`
+- [x] 3.3 Implement `gem.go`: `gem` struct over `HTTPClient`, `NewGem`, embedded query string constants, `Fetch` = `JobBoardList` once then `fetchDetails(postings, gemDetailWorkers, detail)` using the shared bounded-pool helper
+
+## 4. Field mapping (TDD)
+
+- [x] 4.1 Test mapping: `ExternalID = extId`; `URL = https://jobs.gem.com/<board>/<extId>`; `Title`; `Company = e.Company`; `Location = joinNonEmpty(city, isoCountry)` of the first location; `Description = sanitizeHTML(descriptionHtml)` (assert active content stripped, structure kept)
+- [x] 4.2 Test `Remote`: true when the first location's `isRemote` is true OR `job.locationType == "REMOTE"`; false otherwise
+- [x] 4.3 Test `PostedAt`: derived from `firstPublishedTsSec`; nil when the timestamp is absent/zero
+
+## 5. Isolation and empty-board behavior (TDD)
+
+- [x] 5.1 Test a failed `ExternalJobPostingQuery` for one posting drops only that posting and still yields the rest (no board abort)
+- [x] 5.2 Test an empty `jobPostings` list yields zero jobs and no error
+
+## 6. Registration and configuration
+
+- [x] 6.1 Register `NewGem(c)` in `sources.All` (`internal/sources/source.go`); confirm `reg`'s duplicate-provider guard still passes
+- [x] 6.2 Add at least one verified `gem` entry to `sources.yml` (`provider: gem`, `board: <vanity-path>`)
+
+## 7. Verification
+
+- [x] 7.1 `go build ./... && go vet ./... && go test ./internal/sources/...` all green
+- [x] 7.2 Smoke-run `go run ./cmd/ingest` against the configured `gem` board (or a focused live check) to confirm real postings normalize and upsert; confirm the validated-registry fail-fast still accepts `gem`

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -1,0 +1,70 @@
+# gem boards. Provider is the filename; each entry is company + board.
+# board = the jobs.gem.com vanity path (see internal/sources/gem.go).
+# Each board validated live (>0 open postings via the public GraphQL) before adding.
+
+- company: 11x
+  board: 11x-ai
+- company: Atla
+  board: atla-ai-com
+- company: Basalt Health
+  board: basalt-health
+- company: Blue J
+  board: blue-j
+- company: Bluesky
+  board: bluesky
+- company: Cadre AI
+  board: go-cadre
+- company: Charta Health
+  board: chartahealth
+- company: Converge
+  board: converge
+- company: Fireflies
+  board: fireflies
+- company: Firestorm
+  board: firestorm
+- company: Friday Harbor
+  board: fridayharbor-ai
+- company: Function Health
+  board: function-health
+- company: Gem
+  board: gem
+- company: Getro
+  board: getro
+- company: Groq
+  board: groq
+- company: Hacktron AI
+  board: hacktron
+- company: Hallow
+  board: hallow
+- company: Knight Electric
+  board: knight-electric-inc-
+- company: Luma AI
+  board: lumalabs-ai
+- company: Modular
+  board: modular
+- company: Narmi
+  board: narmi
+- company: Nue
+  board: nue
+- company: Photon
+  board: photon
+- company: Piq Energy
+  board: piqenergy
+- company: PromptQL
+  board: promptql
+- company: Raylu
+  board: raylu-ai
+- company: Silkline
+  board: silkline
+- company: StockApp
+  board: stockapp-com
+- company: Supio
+  board: supio
+- company: TensorStax
+  board: tensorstax-com
+- company: Transluce
+  board: transluce
+- company: UP.Labs
+  board: up-labs
+- company: Veho
+  board: veho-technologies

--- a/sources/huntflow.yml
+++ b/sources/huntflow.yml
@@ -1,0 +1,30 @@
+# huntflow boards. Provider is the filename; each entry is company + board.
+# board = the <board>.huntflow.io subdomain (see internal/sources/huntflow.go).
+# Each subdomain validated live (>0 open vacancies via _payload.json) before adding.
+
+- company: AlumniHub
+  board: alumnihub-career
+- company: Banki.ru
+  board: banki
+- company: Coffeemania
+  board: coffeemaniahr
+- company: Flowwow
+  board: flowwow
+- company: Huntflow Opportunities
+  board: opportunities
+- company: itoolabs
+  board: itoolabs
+- company: karpov.courses
+  board: karpovcourses
+- company: MST
+  board: mst
+- company: Napoleon IT
+  board: napoleonit
+- company: Outlines Tech
+  board: outlines_tech
+- company: Pragmatica
+  board: pragmatica
+- company: Telematika
+  board: telematika
+- company: Tripster
+  board: tripster


### PR DESCRIPTION
## What

Adds a `gem` source adapter for Gem job boards (jobs.gem.com), the 13th ATS provider.

Gem exposes postings through a public, unauthenticated GraphQL endpoint (`POST https://jobs.gem.com/api/public/graphql`). The adapter follows the established **list → detail** pattern (like smartrecruiters/rippling/bamboohr):

- `JobBoardList(boardId)` — postings (no description); `boardId` is the board's vanity path (the `sources.yml` `board` value).
- `ExternalJobPostingQuery(boardId, extId)` — per-posting `descriptionHtml` + `firstPublishedTsSec`, fanned out under the shared `fetchDetails` bounded pool (a failed detail drops only that posting).

## Notable decisions (from code review)

- **Checks the GraphQL `errors[]` array.** The transport returns 200 even on a GraphQL-level failure, so a schema drift / server error fails the board (counted in `stats.Failed`) instead of masquerading as an empty board.
- **Decodes `firstPublishedTsSec` as float.** JSON numbers are untyped; a float value still parses the date rather than dropping the whole posting (keeps the "posted_at is nullable, not fatal" invariant).
- New `parseEpochSeconds` helper beside `parseEpochMillis`.

## Sources

`sources/gem.yml` seeds **33 boards**, each validated live (>0 open postings) — slugs harvested via GitHub code search for `jobs.gem.com`, company names from each board page title.

## Surface

New `internal/sources/gem.go` + `gem_test.go` (9 tests, body-aware GraphQL fake), one `NewGem(c)` line in `sources.All`, one helper. No change to the pipeline, write path, config, or schema.

Planned/tracked as OpenSpec change `add-gem-source-adapter`.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green
- `openspec validate add-gem-source-adapter` — valid
- Live smoke (real client): 8 jobs from `go-cadre`, descriptions sanitized, dates/remote/URL correct
- `LoadConfig` + `Validate`: 33 boards pass registry validation