### PR TITLE
sources: add successfactors provider (sitemap→detail HTML scrape)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/tmc/langchaingo v0.1.14
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.55.0
+	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -80,7 +81,6 @@ require (
 	go.opentelemetry.io/otel v1.41.0 // indirect
 	go.opentelemetry.io/otel/metric v1.41.0 // indirect
 	go.opentelemetry.io/otel/trace v1.41.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/internal/sources/gem_test.go
+++ b/internal/sources/gem_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/net/html"
 )
 
 // gqlHTTP is a body-aware test HTTPClient for the GraphQL adapters: Gem sends both its
@@ -28,6 +30,10 @@ func (f *gqlHTTP) GetJSON(context.Context, string, any) error {
 
 func (f *gqlHTTP) GetXML(context.Context, string, any) error {
 	return errors.New("gqlHTTP: unexpected GetXML")
+}
+
+func (f *gqlHTTP) GetHTML(context.Context, string) (*html.Node, error) {
+	return nil, errors.New("gqlHTTP: unexpected GetHTML")
 }
 
 func (f *gqlHTTP) PostJSON(_ context.Context, url string, body, v any) error {

--- a/internal/sources/helpers_test.go
+++ b/internal/sources/helpers_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"strings"
+
+	"golang.org/x/net/html"
 )
 
 // fakeHTTP is a test HTTPClient: it records the requested URL and decodes a canned
@@ -37,4 +40,12 @@ func (f *fakeHTTP) PostJSON(_ context.Context, url string, _, v any) error {
 		return f.err
 	}
 	return json.Unmarshal([]byte(f.body), v)
+}
+
+func (f *fakeHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	f.gotURL = url
+	if f.err != nil {
+		return nil, f.err
+	}
+	return html.Parse(strings.NewReader(f.body))
 }

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/net/html"
 )
 
 // HTTPClient is the narrow transport an adapter needs: fetch a URL and decode its
@@ -21,6 +23,9 @@ type HTTPClient interface {
 	GetJSON(ctx context.Context, url string, v any) error
 	GetXML(ctx context.Context, url string, v any) error
 	PostJSON(ctx context.Context, url string, body, v any) error
+	// GetHTML fetches url and returns its parsed HTML tree, for adapters whose detail is
+	// server-rendered HTML rather than a structured body (e.g. SuccessFactors).
+	GetHTML(ctx context.Context, url string) (*html.Node, error)
 }
 
 // Client is the real HTTPClient: a timeout-bounded GET with a project User-Agent and
@@ -56,6 +61,20 @@ func (c *Client) GetXML(ctx context.Context, url string, v any) error {
 	return c.do(ctx, http.MethodGet, url, nil, "application/xml", func(r io.Reader) error {
 		return xml.NewDecoder(r).Decode(v)
 	})
+}
+
+// GetHTML fetches url and returns its parsed HTML tree.
+func (c *Client) GetHTML(ctx context.Context, url string) (*html.Node, error) {
+	var node *html.Node
+	err := c.do(ctx, http.MethodGet, url, nil, "text/html", func(r io.Reader) error {
+		n, err := html.Parse(r)
+		if err != nil {
+			return err
+		}
+		node = n
+		return nil
+	})
+	return node, err
 }
 
 // PostJSON marshals body to JSON, POSTs it to url, and decodes the JSON response into

--- a/internal/sources/smartrecruiters_test.go
+++ b/internal/sources/smartrecruiters_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"golang.org/x/net/html"
 )
 
 // routedHTTP is a test HTTPClient that returns a different canned body per URL,
@@ -34,6 +36,18 @@ func (r *routedHTTP) GetXML(_ context.Context, url string, v any) error {
 
 func (r *routedHTTP) PostJSON(_ context.Context, url string, _, v any) error {
 	return r.decode(url, json.Unmarshal, v)
+}
+
+func (r *routedHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	for _, rt := range r.routes {
+		if strings.Contains(url, rt.match) {
+			return html.Parse(strings.NewReader(rt.body))
+		}
+	}
+	return nil, fmt.Errorf("routedHTTP: no route for %s", url)
 }
 
 func (r *routedHTTP) decode(url string, unmarshal func([]byte, any) error, v any) error {

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -57,6 +57,7 @@ func All(c HTTPClient) map[string]Source {
 		NewWorkday(c),
 		NewHuntflow(c),
 		NewGem(c),
+		NewSuccessFactors(c),
 	)
 }
 

--- a/internal/sources/successfactors.go
+++ b/internal/sources/successfactors.go
@@ -1,0 +1,195 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// sfDetailWorkers caps how many per-job detail page requests a single board issues
+// concurrently.
+const sfDetailWorkers = 8
+
+// successfactors adapts SAP SuccessFactors career sites. The board is the career-site
+// host (e.g. "jobs.tetrapak.com"). The site's job sitemap enumerates the postings; each
+// job page is server-rendered HTML carrying schema.org JobPosting microdata, so the
+// description comes from a per-job detail fetch (bounded-concurrency), like the other
+// detail-fetching adapters.
+type successfactors struct {
+	http HTTPClient
+}
+
+// NewSuccessFactors builds the SuccessFactors adapter over the given HTTP client.
+func NewSuccessFactors(c HTTPClient) Source { return successfactors{http: c} }
+
+func (successfactors) Provider() string { return "successfactors" }
+
+// sfSitemapEntry is one <url> of the job sitemap: the job page URL and its last-modified
+// date (used as posted_at).
+type sfSitemapEntry struct {
+	Loc     string `xml:"loc"`
+	LastMod string `xml:"lastmod"`
+}
+
+func (s successfactors) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var sitemap struct {
+		URLs []sfSitemapEntry `xml:"url"`
+	}
+	url := fmt.Sprintf("https://%s/job_sitemap.xml", e.Board)
+	if err := s.http.GetXML(ctx, url, &sitemap); err != nil {
+		return nil, fmt.Errorf("successfactors: sitemap %s: %w", e.Board, err)
+	}
+
+	// Each job's title and description come from its own page fetch, fanned out under a
+	// bounded worker pool.
+	return fetchDetails(sitemap.URLs, sfDetailWorkers, func(entry sfSitemapEntry) (Job, bool) {
+		return s.detail(ctx, e, entry)
+	}), nil
+}
+
+// detail fetches one job page and maps it to a Job, returning ok=false when the page
+// fetch fails so the caller can skip just that posting.
+func (s successfactors) detail(ctx context.Context, e CompanyEntry, entry sfSitemapEntry) (Job, bool) {
+	id := sfJobID(entry.Loc)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+
+	root, err := s.http.GetHTML(ctx, entry.Loc)
+	if err != nil {
+		return Job{}, false
+	}
+
+	title := itempropText(root, "title")
+	if title == "" {
+		title = metaProperty(root, "og:title")
+	}
+
+	return Job{
+		ExternalID: id,
+		URL:        entry.Loc,
+		Title:      title,
+		Company:    e.Company,
+		// Location is intentionally empty: SuccessFactors does not expose it in the
+		// microdata, and enrichment derives it from the description.
+		Location:    "",
+		Description: sanitizeHTML(itempropHTML(root, "description")),
+		Remote:      isRemote(title),
+		PostedAt:    parseDate(entry.LastMod),
+	}, true
+}
+
+// sfJobIDPattern captures the leading digits of a job URL's last path segment, ignoring a
+// trailing locale suffix (e.g. ".../98012-en_GB" → "98012", ".../12345/" → "12345").
+var sfJobIDPattern = regexp.MustCompile(`/(\d+)(?:-[^/]*)?/?$`)
+
+// sfJobID extracts the native numeric posting id from a job page URL.
+func sfJobID(loc string) string {
+	if m := sfJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// itempropText returns the concatenated text of the first element carrying the given
+// schema.org itemprop, or "" when none is present.
+func itempropText(root *html.Node, prop string) string {
+	ns := findItemprops(root, prop)
+	if len(ns) == 0 {
+		return ""
+	}
+	return textContent(ns[0])
+}
+
+// itempropHTML returns the rendered inner HTML of the richest element carrying the given
+// itemprop, so it can be sanitized, or "" when none is present. SuccessFactors wraps
+// several near-empty itemprop="description" layout regions around the real body, so the
+// element with the most text content is chosen rather than the first.
+func itempropHTML(root *html.Node, prop string) string {
+	ns := findItemprops(root, prop)
+	if len(ns) == 0 {
+		return ""
+	}
+	best, bestLen := ns[0], len(textContent(ns[0]))
+	for _, n := range ns[1:] {
+		if l := len(textContent(n)); l > bestLen {
+			best, bestLen = n, l
+		}
+	}
+	return innerHTML(best)
+}
+
+// metaProperty returns the content of <meta property="..."> (e.g. og:title), or "".
+func metaProperty(root *html.Node, property string) string {
+	var found string
+	walk(root, func(n *html.Node) bool {
+		if found != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "meta" &&
+			attr(n, "property") == property {
+			found = attr(n, "content")
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// findItemprops returns every element node whose itemprop attribute equals prop, in
+// document order.
+func findItemprops(root *html.Node, prop string) []*html.Node {
+	var out []*html.Node
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && attr(n, "itemprop") == prop {
+			out = append(out, n)
+		}
+		return true
+	})
+	return out
+}
+
+// walk visits nodes depth-first, descending into a node's children only while visit
+// returns true for it.
+func walk(n *html.Node, visit func(*html.Node) bool) {
+	if !visit(n) {
+		return
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		walk(c, visit)
+	}
+}
+
+// attr returns the value of the named attribute, or "".
+func attr(n *html.Node, name string) string {
+	for _, a := range n.Attr {
+		if a.Key == name {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+// textContent returns the concatenated text of n's descendants, trimmed.
+func textContent(n *html.Node) string {
+	var b strings.Builder
+	walk(n, func(c *html.Node) bool {
+		if c.Type == html.TextNode {
+			b.WriteString(c.Data)
+		}
+		return true
+	})
+	return strings.TrimSpace(b.String())
+}
+
+// innerHTML renders n's children back to HTML markup.
+func innerHTML(n *html.Node) string {
+	var b strings.Builder
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		_ = html.Render(&b, c)
+	}
+	return b.String()
+}

--- a/internal/sources/successfactors_test.go
+++ b/internal/sources/successfactors_test.go
@@ -1,0 +1,193 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+func parseHTML(t *testing.T, s string) *html.Node {
+	t.Helper()
+	n, err := html.Parse(strings.NewReader(s))
+	if err != nil {
+		t.Fatalf("parse html: %v", err)
+	}
+	return n
+}
+
+const sfDetailHTML = `<html><head>
+<meta property="og:title" content="Fallback Title"/>
+</head><body>
+<div itemscope itemtype="http://schema.org/JobPosting">
+  <span itemprop="title">Commissioning Engineer</span>
+  <div itemprop="description"><h2>Role</h2><p>Build it.</p><script>alert(1)</script></div>
+</div></body></html>`
+
+func sfSitemapXML(locs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><urlset>`)
+	for _, l := range locs {
+		b.WriteString(`<url><loc>` + l + `</loc><lastmod>2026-06-06</lastmod></url>`)
+	}
+	b.WriteString(`</urlset>`)
+	return b.String()
+}
+
+func TestSuccessFactorsProvider(t *testing.T) {
+	if got := NewSuccessFactors(nil).Provider(); got != "successfactors" {
+		t.Errorf("Provider() = %q, want %q", got, "successfactors")
+	}
+}
+
+func TestSFJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.tetrapak.com/job/Munich-Engineer/12345/":        "12345",
+		"https://jobs.tetrapak.com/job/Commissioning-Engineer/98012-en_GB": "98012",
+		"https://jobs.tetrapak.com/job/Slug/883999301":                "883999301",
+	}
+	for loc, want := range cases {
+		if got := sfJobID(loc); got != want {
+			t.Errorf("sfJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestSFItempropHelpers(t *testing.T) {
+	root := parseHTML(t, sfDetailHTML)
+	if got := itempropText(root, "title"); got != "Commissioning Engineer" {
+		t.Errorf("itempropText(title) = %q", got)
+	}
+	if got := itempropText(root, "missing"); got != "" {
+		t.Errorf("itempropText(missing) = %q, want empty", got)
+	}
+	inner := itempropHTML(root, "description")
+	if !strings.Contains(inner, "<h2>Role</h2>") || !strings.Contains(inner, "<p>Build it.</p>") {
+		t.Errorf("itempropHTML(description) lost structure: %q", inner)
+	}
+	if got := metaProperty(root, "og:title"); got != "Fallback Title" {
+		t.Errorf("metaProperty(og:title) = %q", got)
+	}
+}
+
+func TestSFItempropHTMLPicksRichest(t *testing.T) {
+	// SuccessFactors wraps several near-empty itemprop="description" layout regions around
+	// the real body; the adapter must pick the one with the most content, not the first.
+	h := `<div itemscope itemtype="http://schema.org/JobPosting">
+		<div itemprop="description">   </div>
+		<div itemprop="description"><h2>Real Body</h2><p>The actual job description text.</p></div>
+		<div itemprop="description"> </div>
+	</div>`
+	root := parseHTML(t, h)
+	got := itempropHTML(root, "description")
+	if !strings.Contains(got, "Real Body") || !strings.Contains(got, "actual job description") {
+		t.Errorf("itempropHTML should pick the richest description, got %q", got)
+	}
+}
+
+func TestSuccessFactorsFetchSitemapThenDetailAndMaps(t *testing.T) {
+	loc := "https://jobs.tetrapak.com/job/Munich-Engineer/12345/"
+	fake := (&routedHTTP{}).
+		route("/job_sitemap.xml", sfSitemapXML(loc)).
+		route("/job/Munich-Engineer/12345", sfDetailHTML)
+
+	jobs, err := NewSuccessFactors(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Tetra Pak", Provider: "successfactors", Board: "jobs.tetrapak.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "12345" {
+		t.Errorf("ExternalID = %q, want 12345", j.ExternalID)
+	}
+	if j.URL != loc {
+		t.Errorf("URL = %q, want %q", j.URL, loc)
+	}
+	if j.Title != "Commissioning Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Tetra Pak" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "" {
+		t.Errorf("Location = %q, want empty (enrichment fills it)", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") || !strings.Contains(j.Description, "<h2>Role</h2>") {
+		t.Errorf("Description not sanitized/assembled: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-06", j.PostedAt)
+	}
+}
+
+func TestSuccessFactorsTitleFallsBackToOgTitle(t *testing.T) {
+	noTitle := `<html><head><meta property="og:title" content="OG Only"/></head>
+<body><div itemscope itemtype="http://schema.org/JobPosting">
+<div itemprop="description"><p>body</p></div></div></body></html>`
+	loc := "https://jobs.tetrapak.com/job/X/777/"
+	fake := (&routedHTTP{}).route("/job_sitemap.xml", sfSitemapXML(loc)).route("/job/X/777", noTitle)
+	jobs, err := NewSuccessFactors(fake).Fetch(context.Background(), CompanyEntry{Board: "jobs.tetrapak.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Title != "OG Only" {
+		t.Fatalf("title fallback failed: %v", jobs)
+	}
+}
+
+func TestSuccessFactorsFailedDetailDropsOnlyThatPosting(t *testing.T) {
+	ok := "https://jobs.tetrapak.com/job/Kept/111/"
+	bad := "https://jobs.tetrapak.com/job/Dropped/222/"
+	// No route for /job/Dropped/222 → GetHTML errors → that posting drops.
+	fake := (&routedHTTP{}).
+		route("/job_sitemap.xml", sfSitemapXML(ok, bad)).
+		route("/job/Kept/111", sfDetailHTML)
+
+	jobs, err := NewSuccessFactors(fake).Fetch(context.Background(), CompanyEntry{Board: "jobs.tetrapak.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "111" {
+		t.Fatalf("got %v, want only the kept posting", jobs)
+	}
+}
+
+func TestSuccessFactorsDropsJobWithNoParseableID(t *testing.T) {
+	// A loc with no numeric id would yield an empty external_id, which collides on the
+	// (source, external_id) dedup key — drop the posting instead.
+	loc := "https://jobs.tetrapak.com/job/No-Numeric-Id/"
+	fake := (&routedHTTP{}).
+		route("/job_sitemap.xml", sfSitemapXML(loc)).
+		route("/job/No-Numeric-Id", sfDetailHTML)
+	jobs, err := NewSuccessFactors(fake).Fetch(context.Background(), CompanyEntry{Board: "jobs.tetrapak.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (unparseable id dropped)", len(jobs))
+	}
+}
+
+func TestSFMetaPropertyReturnsFirst(t *testing.T) {
+	root := parseHTML(t, `<head><meta property="og:title" content="First"/><meta property="og:title" content="Second"/></head>`)
+	if got := metaProperty(root, "og:title"); got != "First" {
+		t.Errorf("metaProperty(og:title) = %q, want First", got)
+	}
+}
+
+func TestSuccessFactorsEmptySitemapYieldsNoJobsNoError(t *testing.T) {
+	fake := (&routedHTTP{}).route("/job_sitemap.xml", sfSitemapXML())
+	jobs, err := NewSuccessFactors(fake).Fetch(context.Background(), CompanyEntry{Board: "jobs.tetrapak.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0", len(jobs))
+	}
+}

--- a/openspec/changes/add-successfactors-source-adapter/.openspec.yaml
+++ b/openspec/changes/add-successfactors-source-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/add-successfactors-source-adapter/design.md
+++ b/openspec/changes/add-successfactors-source-adapter/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`internal/sources` holds one adapter per ATS behind the `Source` interface, with several
+(smartrecruiters, rippling, bamboohr, gem) using the shared `fetchDetails` bounded pool when
+the list lacks the description. The shared `HTTPClient` exposes `GetJSON`, `GetXML`,
+`PostJSON` — all decode structured bodies. SuccessFactors is the first source whose detail is
+HTML, so the interface must grow a raw-HTML fetch.
+
+Contract confirmed live against `jobs.tetrapak.com`:
+
+- `GET https://<host>/job_sitemap.xml` → `<urlset>` of `<url>{<loc>, <lastmod>, …}` — 256
+  job URLs of the form `/job/<slug>/<numeric-id>/`, each with a `<lastmod>` date. Plain XML,
+  no auth, no Cloudflare.
+- `GET <loc>` → server-rendered HTML with an `itemtype="http://schema.org/JobPosting"` scope
+  exposing `itemprop="title"` and `itemprop="description"` (the description's inner HTML is
+  the full job body). Location/date are NOT in the microdata.
+- The JS search widget (`xweb/rmk-jobs-search`, backed by `performancemanager.successfactors.eu`)
+  and `tile-search-results` are runtime-constructed and return nothing useful to a plain
+  client — the sitemap is the clean enumeration path instead.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `successfactors` adapter that enumerates a site's sitemap and yields normalized jobs with
+  sanitized-HTML descriptions, reusing the list→detail pattern and helpers.
+- A reusable `GetHTML` on `HTTPClient` so future HTML-scraping adapters share one transport.
+
+**Non-Goals:**
+- Structured location/department extraction (left empty → enrichment fills it).
+- Locale negotiation — read the site's default-locale pages.
+- The JS widget / `tile-search-results` API.
+
+## Decisions
+
+- **Enumerate via the sitemap, detail via the job page.** `Fetch` GETs `job_sitemap.xml`
+  (decoded with the existing `GetXML`), then `fetchDetails(entries, workers, …)` GETs each
+  job page (`GetHTML`) and maps it. A failed page drops only that posting.
+- **Extend `HTTPClient` with `GetHTML(ctx, url) (*html.Node, error)`** using
+  `golang.org/x/net/html` (already transitive via bluemonday; promote to direct). The real
+  `Client` adds it alongside `GetJSON`; the test fakes (`fakeHTTP`, `routedHTTP`, and the
+  gem `gqlHTTP`) gain a `GetHTML` that parses a canned HTML string. This is the seam for all
+  HTML-rendered ATS, not a SuccessFactors-only shim.
+- **Microdata extraction** walks the parsed tree for the first element with
+  `itemprop="title"` (text) and `itemprop="description"` (rendered inner HTML), via small
+  helpers over `html.Node`. Title falls back to the `og:title` meta if microdata is absent.
+- **Job mapping:**
+  - `ExternalID` = the numeric id parsed from the `<loc>` path (pipeline namespaces it).
+  - `URL` = the `<loc>`.
+  - `Title` = `itemprop="title"` (fallback `og:title`); `Company` = `e.Company`.
+  - `Location` = "" (enrichment derives it).
+  - `Description` = `sanitizeHTML(<inner HTML of itemprop="description">)`.
+  - `Remote` = `isRemote(title)` (location is empty; enrichment refines remote).
+  - `PostedAt` = the entry's `<lastmod>` via the existing `parseDate` ("2006-01-02").
+
+## Risks / Trade-offs
+
+- **HTML scraping is more fragile than JSON.** Mitigation: rely on schema.org microdata
+  (`itemprop`), the most stable hook SuccessFactors exposes, not on CSS classes or CSB
+  template tokens. A missing field yields an empty value, and the posting still ingests.
+  Covered by table-driven tests over canned HTML, no live network in unit tests.
+- **Per-job detail fetches** — a large site (256 here) issues one GET per job under the
+  bounded pool, like other detail-fetching adapters; acceptable for a scheduled crawl.
+- **Empty location** weakens filtering until enrichment runs; accepted deliberately over a
+  fragile heuristic (decided with the user).
+- **Sitemap dependence** — a site that disables `job_sitemap.xml` is unsupported; none
+  observed. That would require the JS search API (a separate fetch-infra decision).

--- a/openspec/changes/add-successfactors-source-adapter/proposal.md
+++ b/openspec/changes/add-successfactors-source-adapter/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+SAP SuccessFactors powers the career sites of a large share of enterprise employers
+(e.g. Tetra Pak at jobs.tetrapak.com). Those sites are JS/widget-rendered, but each one
+publishes a plain-XML job sitemap and server-renders every job page with schema.org
+JobPosting microdata — so the postings are reachable with simple GET requests, no browser
+or bot-wall. Adding a `successfactors` adapter brings this large segment into the pool.
+
+## What Changes
+
+- Add a `successfactors` source adapter (`internal/sources/successfactors.go`) speaking the
+  existing `Source` interface, registered with one `NewSuccessFactors(c)` line in `sources.All`.
+- It follows the established **list → detail** pattern: enumerate jobs from the site's
+  `GET /job_sitemap.xml` (each `<url>` carries the job `<loc>` and a `<lastmod>` date),
+  then GET each job page and extract the title + description from its schema.org JobPosting
+  microdata, fanned out with the shared `fetchDetails` bounded-concurrency helper.
+- The `sources.yml` `board` value is the **career-site host** (e.g. `jobs.tetrapak.com`);
+  the adapter builds `https://<board>/job_sitemap.xml` and GETs each `<loc>` for detail.
+- **Extend the shared `HTTPClient` interface with `GetHTML`** (fetch a URL and return its
+  parsed HTML tree via `golang.org/x/net/html`, already in the module graph). SuccessFactors
+  is the first HTML-scraping adapter; this is the reusable seam for future HTML-rendered
+  ATS, rather than a one-off shim. The real `Client` implements it; the test fakes gain it.
+- **Location is left empty on purpose** — SuccessFactors does not expose it in the
+  microdata, and AI enrichment already derives structured fields (including location) from
+  the description. No fragile URL-slug or template-token heuristic.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. Reuses the source-ingest pipeline and write path unchanged. -->
+
+### Modified Capabilities
+- `source-ingest`: add a requirement that `successfactors` is a registered provider — a
+  sitemap-enumerated, HTML-microdata detail adapter yielding the normalized job shape with a
+  sanitized-HTML description, consistent with the existing detail-fetching adapters.
+
+## Impact
+
+- **New code**: `internal/sources/successfactors.go` + `successfactors_test.go`; one
+  registration line in `sources.All`; a `GetHTML` method on `HTTPClient`/`Client` and the
+  test fakes.
+- **Dependencies**: promote `golang.org/x/net/html` to a direct dependency (already present
+  transitively via bluemonday). No new third-party code.
+- **Config**: one new `sources.yml` entry (`sources/successfactors.yml`). No new env vars.
+- **DB**: none — reuses `UpsertJob` (`source = "successfactors"`, namespaced `external_id`).
+- **Out of scope (known seams)**: structured location/department parsing from CSB template
+  tokens (left to enrichment); locale handling (the adapter reads the default-locale pages);
+  sites that disable the job sitemap (none observed; would need the JS search API).

--- a/openspec/changes/add-successfactors-source-adapter/specs/source-ingest/spec.md
+++ b/openspec/changes/add-successfactors-source-adapter/specs/source-ingest/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: successfactors is a registered provider
+
+The system SHALL register a `successfactors` adapter so SAP SuccessFactors career sites
+can be listed in `sources.yml`. The adapter SHALL treat the configured `board` value as the
+career-site host and enumerate jobs from that site's `GET https://<board>/job_sitemap.xml`,
+taking each `<url>`'s `<loc>` as the job page URL (with the job's native id as the numeric
+segment of that path) and its `<lastmod>` as the posting date. Because the sitemap carries
+no description, the adapter SHALL fetch each job page and extract the title and description
+from the page's schema.org JobPosting microdata (`itemprop="title"` and
+`itemprop="description"`), with bounded concurrency; a single failed page fetch SHALL drop
+only that posting rather than abort the board. The adapter SHALL yield the normalized job
+shape (at least title, url, remote flag, description, and the platform's native posting id),
+with the `description` as sanitized HTML, consistent with the existing adapters. The job
+`location` MAY be empty, since SuccessFactors does not expose it in the microdata and
+enrichment derives it from the description.
+
+#### Scenario: SuccessFactors board is enumerated from its sitemap
+
+- **WHEN** `sources.yml` lists a board with provider `successfactors` and a career-site host
+- **THEN** the adapter fetches `https://<host>/job_sitemap.xml`, and per `<loc>` fetches the
+  job page, yielding each as the normalized job shape with `external_id` set to the numeric
+  id from the job URL and `posted_at` derived from the entry's `<lastmod>`
+
+#### Scenario: Title and description come from JobPosting microdata
+
+- **WHEN** a SuccessFactors job page is fetched
+- **THEN** the adapter yields the job's title from `itemprop="title"` and a sanitized HTML
+  description from the inner markup of `itemprop="description"`
+
+#### Scenario: A failed job-page fetch drops only that posting
+
+- **WHEN** a board's sitemap lists several jobs and one job page's fetch fails
+- **THEN** the failed posting is skipped and every other posting is still yielded, without
+  aborting the board
+
+#### Scenario: An empty sitemap yields no jobs without error
+
+- **WHEN** a board's `job_sitemap.xml` lists no job URLs
+- **THEN** the adapter yields zero jobs and returns no error, so the board is simply skipped

--- a/openspec/changes/add-successfactors-source-adapter/tasks.md
+++ b/openspec/changes/add-successfactors-source-adapter/tasks.md
@@ -1,0 +1,37 @@
+## 1. Extend HTTPClient with GetHTML
+
+- [x] 1.1 Add `GetHTML(ctx, url string) (*html.Node, error)` to the `HTTPClient` interface; implement it on `Client` (GET via the existing `do`, parse the body with `golang.org/x/net/html`); promote `golang.org/x/net/html` to a direct dependency (`go mod tidy`)
+- [x] 1.2 Add a `GetHTML` method to the existing test fakes (`fakeHTTP`, `routedHTTP`, `gqlHTTP`) that parses a canned HTML string, so the package still compiles and the fakes can serve detail pages
+
+## 2. Microdata extraction helpers (TDD)
+
+- [x] 2.1 Test a helper that, given a parsed `*html.Node`, returns the text of the first element with a given `itemprop` (e.g. `title`) and "" when absent
+- [x] 2.2 Test a helper that returns the rendered inner HTML of the first element with `itemprop="description"` (so it can be sanitized), and "" when absent
+- [x] 2.3 Implement the two helpers over `html.Node` (depth-first walk; render children for the inner-HTML case)
+
+## 3. SuccessFactors adapter — Provider + sitemap→detail Fetch (TDD)
+
+- [x] 3.1 Test `Provider()` returns `"successfactors"`
+- [x] 3.2 Test `Fetch` GETs `https://<board>/job_sitemap.xml`, and per `<loc>` GETs the job page, yielding the normalized jobs; assert the sitemap URL and that each `<loc>` is fetched
+- [x] 3.3 Implement `successfactors.go`: `successfactors` struct over `HTTPClient`, `NewSuccessFactors`, a `sitemap` XML struct decoded via `GetXML`, then `fetchDetails(entries, workers, detail)` GET-ting each page with `GetHTML`
+
+## 4. Field mapping (TDD)
+
+- [x] 4.1 Test mapping: `ExternalID` = numeric id parsed from the `<loc>` path; `URL` = `<loc>`; `Title` from `itemprop="title"` (fallback `og:title`); `Company = e.Company`; `Description = sanitizeHTML(inner HTML of itemprop="description")` (active content stripped, structure kept); `Location` = "" 
+- [x] 4.2 Test `PostedAt` derived from the entry's `<lastmod>` (`2006-01-02`); nil when absent/unparseable
+- [x] 4.3 Test `Remote` via `isRemote(title)`
+
+## 5. Isolation and empty-board behavior (TDD)
+
+- [x] 5.1 Test a failed job-page fetch for one `<loc>` drops only that posting and still yields the rest (no board abort)
+- [x] 5.2 Test an empty sitemap (no `<url>` entries) yields zero jobs and no error
+
+## 6. Registration and configuration
+
+- [x] 6.1 Register `NewSuccessFactors(c)` in `sources.All`; confirm `reg`'s duplicate-provider guard still passes
+- [x] 6.2 Add at least one verified `successfactors` entry to `sources/successfactors.yml` (`board: <career-site-host>`), validated live (>0 jobs in its sitemap)
+
+## 7. Verification
+
+- [x] 7.1 `go build ./... && go vet ./... && go test ./internal/sources/...` all green
+- [x] 7.2 Focused live check: run the adapter (real `Client`) against the configured board and confirm real postings normalize (title + sanitized description + id + url + lastmod date); confirm the validated-registry fail-fast still accepts `successfactors`

--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -1,0 +1,7 @@
+# successfactors boards. Provider is the filename; each entry is company + board.
+# board = the SAP SuccessFactors career-site host (see internal/sources/successfactors.go);
+# the adapter reads https://<board>/job_sitemap.xml.
+# Each board validated live (>0 jobs in its sitemap) before adding.
+
+- company: Tetra Pak
+  board: jobs.tetrapak.com


### PR DESCRIPTION
## What

Adds a `successfactors` source adapter for SAP SuccessFactors career sites — the 14th ATS provider, and the **first HTML-scraping** one.

SuccessFactors sites are JS/widget-rendered, but each publishes a plain-XML job sitemap and server-renders every job page with schema.org `JobPosting` microdata — reachable with plain GETs, no browser or bot-wall. The adapter follows the **list → detail** pattern:

- `GET https://<board>/job_sitemap.xml` → each `<url>` carries the job `<loc>` and `<lastmod>`.
- `GET <loc>` (a 302 redirects to the localized page; the client follows it) → title from `itemprop="title"` (fallback `og:title`), description from the richest `itemprop="description"`, fanned out via the shared `fetchDetails` bounded pool.

`board` (sources.yml) = the career-site host (e.g. `jobs.tetrapak.com`).

## New shared seam

Extends the `HTTPClient` interface with **`GetHTML(ctx, url) (*html.Node, error)`** (parsed via `golang.org/x/net/html`, promoted to a direct dep — already transitive via bluemonday). This is the reusable transport for future HTML-rendered ATS, not a one-off. The real `Client` and all three test fakes implement it.

## Notable decisions (incl. code review + live debugging)

- **Richest `itemprop="description"`.** A live run revealed SuccessFactors wraps several near-empty layout regions in `itemprop="description"`; the adapter picks the element with the most text (confirmed: all 256 Tetra Pak jobs then get full bodies, not 5-byte stubs).
- **Drop a job with no parseable numeric id** — an empty `external_id` would collide on the `(source, external_id)` dedup key.
- **Location left empty on purpose** — SuccessFactors doesn't expose it in microdata; enrichment derives it from the description (decided with the maintainer). No fragile slug/token heuristic.
- `metaProperty` returns the first match deterministically.

## Surface

New `internal/sources/successfactors.go` + `successfactors_test.go` (microdata helpers + adapter), `GetHTML` on `HTTPClient`/`Client` + the three fakes, one `NewSuccessFactors(c)` line in `sources.All`, `sources/successfactors.yml`. No change to the pipeline, write path, config, or schema.

Tracked as OpenSpec change `add-successfactors-source-adapter`.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` — all green
- `openspec validate add-successfactors-source-adapter` — valid
- Live smoke (real client): **256** Tetra Pak jobs, 0 with empty title/description/id, lastmod dates parsed
- `LoadConfig` + `Validate`: the board passes registry validation