### PR TITLE
ingest: derive job geography (country/region/work_mode) from location + ATS structured fields

### DIFF
--- a/cmd/backfill-geo/main.go
+++ b/cmd/backfill-geo/main.go
@@ -1,0 +1,94 @@
+// Command backfill-geo populates the location-derived columns (countries,
+// regions, work_mode) on existing jobs after the geography feature ships. Ingest
+// fills these on every crawl, but rows that predate the change — and closed jobs
+// that never re-crawl — keep the empty defaults until this one-off worker parses
+// their stored location and writes the result. It pages the whole table and
+// exits. Idempotent: geography is a pure function of the location, so a second
+// run rewrites nothing.
+//
+// work_mode is preserved when already set: a row may carry a structured work_mode
+// from the adapter (richer than the free-text parse), so backfill only fills
+// work_mode from the parsed location when it is currently empty.
+package main
+
+import (
+	"context"
+	"log"
+	"slices"
+
+	"github.com/strelov1/freehire/internal/config"
+	"github.com/strelov1/freehire/internal/database"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/location"
+)
+
+// backfillBatchSize bounds how many jobs are read per keyset page.
+const backfillBatchSize = 500
+
+func main() {
+	cfg := config.Load()
+	ctx := context.Background()
+
+	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("database: %v", err)
+	}
+	defer pool.Close()
+
+	scanned, updated, err := backfillAll(ctx, db.New(pool))
+	if err != nil {
+		log.Fatalf("backfill-geo: %v", err)
+	}
+	log.Printf("backfill-geo done: scanned=%d updated=%d", scanned, updated)
+}
+
+// backfillAll parses every job's stored location and rewrites the rows whose
+// location-derived columns differ. It pages by keyset (id > last seen) so
+// concurrent writes cannot skip or repeat rows.
+func backfillAll(ctx context.Context, q *db.Queries) (scanned, updated int, err error) {
+	var afterID int64
+	for {
+		jobs, err := q.ListJobsByIDAfter(ctx, db.ListJobsByIDAfterParams{
+			AfterID:   afterID,
+			BatchSize: backfillBatchSize,
+		})
+		if err != nil {
+			return scanned, updated, err
+		}
+		if len(jobs) == 0 {
+			break
+		}
+		afterID = jobs[len(jobs)-1].ID
+
+		for _, j := range jobs {
+			scanned++
+			geo := location.Parse(j.Location)
+			// Preserve an existing (possibly adapter-structured) work_mode; the
+			// parsed value only fills an empty one.
+			workMode := j.WorkMode
+			if workMode == "" {
+				workMode = geo.WorkMode
+			}
+			if slices.Equal(geo.Countries, j.Countries) &&
+				slices.Equal(geo.Regions, j.Regions) &&
+				workMode == j.WorkMode {
+				continue
+			}
+			if err := q.SetJobLocation(ctx, db.SetJobLocationParams{
+				ID:        j.ID,
+				Countries: geo.Countries,
+				Regions:   geo.Regions,
+				WorkMode:  workMode,
+			}); err != nil {
+				return scanned, updated, err
+			}
+			updated++
+		}
+
+		if len(jobs) < backfillBatchSize {
+			break
+		}
+	}
+
+	return scanned, updated, nil
+}

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -45,6 +45,9 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 		Remote:      job.Remote,
 		Description: job.Description,
 		PostedAt:    toTimestamptz(job.PostedAt),
+		Countries:   job.Countries,
+		Regions:     job.Regions,
+		WorkMode:    job.WorkMode,
 	})
 	if err != nil {
 		return fmt.Errorf("upsert job: %w", err)

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/location"
 	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/telegram"
 )
@@ -63,6 +64,7 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 	base := post.Channel + "/" + strconv.FormatInt(post.MsgID, 10)
 	for i, j := range jobs {
 		externalID := base + "/" + strconv.Itoa(i)
+		geo := location.Parse(j.Location)
 		saved, err := qtx.UpsertJob(ctx, db.UpsertJobParams{
 			Source:      "telegram",
 			ExternalID:  externalID,
@@ -75,6 +77,9 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 			Remote:      j.Remote,
 			Description: telegram.TextToHTML(j.Description),
 			PostedAt:    pgtype.Timestamptz{Time: post.PostedAt, Valid: true},
+			Countries:   geo.Countries,
+			Regions:     geo.Regions,
+			WorkMode:    geo.WorkMode,
 		})
 		if err != nil {
 			return fmt.Errorf("upsert job %s: %w", externalID, err)

--- a/internal/db/job_lifecycle_integration_test.go
+++ b/internal/db/job_lifecycle_integration_test.go
@@ -87,7 +87,7 @@ func TestCloseUnseenJobsClosesOnlyStaleJobs(t *testing.T) {
 	ageJob(t, pool, stale.ID, 49*time.Hour)
 	ageJob(t, pool, fresh.ID, 6*time.Hour)
 
-	closed, err := q.CloseUnseenJobs(ctx, pgTimestamptz(time.Now().Add(-48*time.Hour)))
+	closed, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{Source: "greenhouse", Cutoff: pgTimestamptz(time.Now().Add(-48 * time.Hour))})
 	if err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestCloseUnseenJobsClosesOnlyStaleJobs(t *testing.T) {
 	}
 
 	// Idempotent: a second sweep with the same cutoff closes nothing.
-	again, err := q.CloseUnseenJobs(ctx, pgTimestamptz(time.Now().Add(-48*time.Hour)))
+	again, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{Source: "greenhouse", Cutoff: pgTimestamptz(time.Now().Add(-48 * time.Hour))})
 	if err != nil {
 		t.Fatalf("second sweep: %v", err)
 	}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -80,7 +80,7 @@ func (q *Queries) EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrich
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode
 FROM jobs
 WHERE id = $1
 `
@@ -108,12 +108,15 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.PublicSlug,
 		&i.LastSeenAt,
 		&i.ClosedAt,
+		&i.Countries,
+		&i.Regions,
+		&i.WorkMode,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode
 FROM jobs
 WHERE public_slug = $1
 `
@@ -141,6 +144,9 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.PublicSlug,
 		&i.LastSeenAt,
 		&i.ClosedAt,
+		&i.Countries,
+		&i.Regions,
+		&i.WorkMode,
 	)
 	return i, err
 }
@@ -163,7 +169,7 @@ func (q *Queries) GetJobIDBySlug(ctx context.Context, publicSlug string) (int64,
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode
 FROM jobs
 WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -207,6 +213,9 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.PublicSlug,
 			&i.LastSeenAt,
 			&i.ClosedAt,
+			&i.Countries,
+			&i.Regions,
+			&i.WorkMode,
 		); err != nil {
 			return nil, err
 		}
@@ -219,7 +228,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -261,6 +270,9 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.PublicSlug,
 			&i.LastSeenAt,
 			&i.ClosedAt,
+			&i.Countries,
+			&i.Regions,
+			&i.WorkMode,
 		); err != nil {
 			return nil, err
 		}
@@ -273,7 +285,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -317,6 +329,9 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.PublicSlug,
 			&i.LastSeenAt,
 			&i.ClosedAt,
+			&i.Countries,
+			&i.Regions,
+			&i.WorkMode,
 		); err != nil {
 			return nil, err
 		}
@@ -357,6 +372,39 @@ func (q *Queries) SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentPara
 	return err
 }
 
+const setJobLocation = `-- name: SetJobLocation :exec
+UPDATE jobs
+SET countries = COALESCE($1::text[], '{}'),
+    regions   = COALESCE($2::text[], '{}'),
+    work_mode = $3
+WHERE id = $4
+`
+
+type SetJobLocationParams struct {
+	Countries []string `json:"countries"`
+	Regions   []string `json:"regions"`
+	WorkMode  string   `json:"work_mode"`
+	ID        int64    `json:"id"`
+}
+
+// One-off backfill (cmd/backfill-geo): rewrite the location-derived columns from
+// the row's stored location text. They are deterministic from `location`, so this
+// is idempotent. updated_at is deliberately left untouched (like UpdateJobSlugs)
+// so a backfill does not churn every row's timestamp. COALESCE maps a nil arg to
+// '{}' to satisfy the NOT NULL array columns. work_mode here is parser-derived
+// only (the original structured ATS signal is not available at backfill time);
+// a later re-crawl overwrites it with the structured value where the adapter has
+// one.
+func (q *Queries) SetJobLocation(ctx context.Context, arg SetJobLocationParams) error {
+	_, err := q.db.Exec(ctx, setJobLocation,
+		arg.Countries,
+		arg.Regions,
+		arg.WorkMode,
+		arg.ID,
+	)
+	return err
+}
+
 const updateJobSlugs = `-- name: UpdateJobSlugs :exec
 UPDATE jobs
 SET public_slug  = $1,
@@ -389,12 +437,14 @@ WITH company_upsert AS (
 )
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
-    public_slug
+    public_slug, countries, regions, work_mode
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7, $8,
     $9, $10,
-    $11
+    $11,
+    COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'),
+    $14
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -405,11 +455,14 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     remote       = EXCLUDED.remote,
     description  = EXCLUDED.description,
     posted_at    = EXCLUDED.posted_at,
+    countries    = EXCLUDED.countries,
+    regions      = EXCLUDED.regions,
+    work_mode    = EXCLUDED.work_mode,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed.
     last_seen_at = now(),
     closed_at    = NULL,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode
 `
 
 type UpsertJobParams struct {
@@ -424,6 +477,9 @@ type UpsertJobParams struct {
 	Description string             `json:"description"`
 	PostedAt    pgtype.Timestamptz `json:"posted_at"`
 	PublicSlug  string             `json:"public_slug"`
+	Countries   []string           `json:"countries"`
+	Regions     []string           `json:"regions"`
+	WorkMode    string             `json:"work_mode"`
 }
 
 // Single atomic write: upsert the company (only when the slug is non-empty,
@@ -433,6 +489,9 @@ type UpsertJobParams struct {
 // enrichment, so a new row takes the table defaults ('{}' / NULL / 0) and a
 // re-ingest leaves any existing enrichment untouched. SetJobEnrichment (the
 // enrichment worker) is the sole writer of those columns.
+// countries/regions ARE written here: they are source facts parsed from the
+// location, not enrichment. COALESCE maps a nil arg to '{}', so a location that
+// yields no geography stores empty arrays (the columns are NOT NULL).
 // public_slug is deliberately NOT in the DO UPDATE SET: the slug is minted once
 // at insert and is the row's stable public identity. Re-ingest of the same
 // (source, external_id) must not rewrite it, so external links stay valid even
@@ -450,6 +509,9 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (Job, erro
 		arg.Description,
 		arg.PostedAt,
 		arg.PublicSlug,
+		arg.Countries,
+		arg.Regions,
+		arg.WorkMode,
 	)
 	var i Job
 	err := row.Scan(
@@ -472,6 +534,9 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (Job, erro
 		&i.PublicSlug,
 		&i.LastSeenAt,
 		&i.ClosedAt,
+		&i.Countries,
+		&i.Regions,
+		&i.WorkMode,
 	)
 	return i, err
 }

--- a/internal/db/jobs_integration_test.go
+++ b/internal/db/jobs_integration_test.go
@@ -156,6 +156,80 @@ func TestEnqueueJobEnrichmentGating(t *testing.T) {
 	})
 }
 
+func TestUpsertJobWritesAndRefreshesGeography(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	p := ingestParams("acme:geo", "Geo Job")
+	p.Countries = []string{"us"}
+	p.Regions = []string{"us"}
+	first, err := q.UpsertJob(ctx, p)
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if !reflect.DeepEqual(first.Countries, []string{"us"}) || !reflect.DeepEqual(first.Regions, []string{"us"}) {
+		t.Fatalf("countries=%v regions=%v, want [us]/[us]", first.Countries, first.Regions)
+	}
+
+	// Re-ingest with different geography: EXCLUDED.* refreshes the columns.
+	p2 := ingestParams("acme:geo", "Geo Job")
+	p2.Countries = []string{"gb"}
+	p2.Regions = []string{"uk"}
+	second, err := q.UpsertJob(ctx, p2)
+	if err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("re-ingest created a new row — dedup broken")
+	}
+	if !reflect.DeepEqual(second.Countries, []string{"gb"}) || !reflect.DeepEqual(second.Regions, []string{"uk"}) {
+		t.Errorf("after re-ingest countries=%v regions=%v, want [gb]/[uk]", second.Countries, second.Regions)
+	}
+
+	// A posting with no parsed geography (nil args) stores empty arrays via
+	// COALESCE, not NULL — and reads back as empty (emit_empty_slices), not nil.
+	nilJob, err := q.UpsertJob(ctx, ingestParams("acme:nilgeo", "No Geo"))
+	if err != nil {
+		t.Fatalf("upsert nil geo: %v", err)
+	}
+	if len(nilJob.Countries) != 0 || len(nilJob.Regions) != 0 {
+		t.Errorf("countries=%v regions=%v, want empty arrays for unresolved location", nilJob.Countries, nilJob.Regions)
+	}
+}
+
+func TestSetJobLocationBackfillsGeography(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	job, err := q.UpsertJob(ctx, ingestParams("acme:backfill", "Backfill Job"))
+	if err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if len(job.Countries) != 0 {
+		t.Fatalf("precondition: want empty geography, got %v", job.Countries)
+	}
+
+	if err := q.SetJobLocation(ctx, SetJobLocationParams{
+		Countries: []string{"de"},
+		Regions:   []string{"eu"},
+		ID:        job.ID,
+	}); err != nil {
+		t.Fatalf("set location: %v", err)
+	}
+
+	got, err := q.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !reflect.DeepEqual(got.Countries, []string{"de"}) || !reflect.DeepEqual(got.Regions, []string{"eu"}) {
+		t.Errorf("after backfill countries=%v regions=%v, want [de]/[eu]", got.Countries, got.Regions)
+	}
+}
+
 func TestListJobsOrdersByNewestAdded(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -48,6 +48,9 @@ type Job struct {
 	PublicSlug        string             `json:"public_slug"`
 	LastSeenAt        pgtype.Timestamptz `json:"last_seen_at"`
 	ClosedAt          pgtype.Timestamptz `json:"closed_at"`
+	Countries         []string           `json:"countries"`
+	Regions           []string           `json:"regions"`
+	WorkMode          string             `json:"work_mode"`
 }
 
 type TelegramPost struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -108,6 +108,15 @@ type Querier interface {
 	// and the provenance stamp, touching no raw source field. Kept separate from
 	// UpsertJob (the ingest full-upsert path) so ingest and enrichment stay decoupled.
 	SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentParams) error
+	// One-off backfill (cmd/backfill-geo): rewrite the location-derived columns from
+	// the row's stored location text. They are deterministic from `location`, so this
+	// is idempotent. updated_at is deliberately left untouched (like UpdateJobSlugs)
+	// so a backfill does not churn every row's timestamp. COALESCE maps a nil arg to
+	// '{}' to satisfy the NOT NULL array columns. work_mode here is parser-derived
+	// only (the original structured ATS signal is not available at backfill time);
+	// a later re-crawl overwrites it with the structured value where the adapter has
+	// one.
+	SetJobLocation(ctx context.Context, arg SetJobLocationParams) error
 	// Rebuild the companies catalogue from jobs. The companies table is derivable
 	// from jobs (slug = company_slug, name = company), so after a slug-builder change
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's
@@ -124,6 +133,9 @@ type Querier interface {
 	// enrichment, so a new row takes the table defaults ('{}' / NULL / 0) and a
 	// re-ingest leaves any existing enrichment untouched. SetJobEnrichment (the
 	// enrichment worker) is the sole writer of those columns.
+	// countries/regions ARE written here: they are source facts parsed from the
+	// location, not enrichment. COALESCE maps a nil arg to '{}', so a location that
+	// yields no geography stores empty arrays (the columns are NOT NULL).
 	// public_slug is deliberately NOT in the DO UPDATE SET: the slug is minted once
 	// at insert and is the row's stable public identity. Re-ingest of the same
 	// (source, external_id) must not rewrite it, so external links stay valid even

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -57,6 +57,9 @@ LIMIT $2 OFFSET $3;
 -- enrichment, so a new row takes the table defaults ('{}' / NULL / 0) and a
 -- re-ingest leaves any existing enrichment untouched. SetJobEnrichment (the
 -- enrichment worker) is the sole writer of those columns.
+-- countries/regions ARE written here: they are source facts parsed from the
+-- location, not enrichment. COALESCE maps a nil arg to '{}', so a location that
+-- yields no geography stores empty arrays (the columns are NOT NULL).
 WITH company_upsert AS (
     INSERT INTO companies (slug, name)
     SELECT sqlc.arg(company_slug), sqlc.arg(company)
@@ -67,12 +70,14 @@ WITH company_upsert AS (
 )
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
-    public_slug
+    public_slug, countries, regions, work_mode
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
     sqlc.arg(company), sqlc.arg(company_slug), sqlc.arg(location), sqlc.arg(remote),
     sqlc.arg(description), sqlc.arg(posted_at),
-    sqlc.arg(public_slug)
+    sqlc.arg(public_slug),
+    COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'),
+    sqlc.arg(work_mode)
 )
 -- public_slug is deliberately NOT in the DO UPDATE SET: the slug is minted once
 -- at insert and is the row's stable public identity. Re-ingest of the same
@@ -87,6 +92,9 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     remote       = EXCLUDED.remote,
     description  = EXCLUDED.description,
     posted_at    = EXCLUDED.posted_at,
+    countries    = EXCLUDED.countries,
+    regions      = EXCLUDED.regions,
+    work_mode    = EXCLUDED.work_mode,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed.
     last_seen_at = now(),
     closed_at    = NULL,
@@ -113,6 +121,21 @@ WHERE closed_at IS NULL
 UPDATE jobs
 SET public_slug  = sqlc.arg(public_slug),
     company_slug = sqlc.arg(company_slug)
+WHERE id = sqlc.arg(id);
+
+-- name: SetJobLocation :exec
+-- One-off backfill (cmd/backfill-geo): rewrite the location-derived columns from
+-- the row's stored location text. They are deterministic from `location`, so this
+-- is idempotent. updated_at is deliberately left untouched (like UpdateJobSlugs)
+-- so a backfill does not churn every row's timestamp. COALESCE maps a nil arg to
+-- '{}' to satisfy the NOT NULL array columns. work_mode here is parser-derived
+-- only (the original structured ATS signal is not available at backfill time);
+-- a later re-crawl overwrites it with the structured value where the adapter has
+-- one.
+UPDATE jobs
+SET countries = COALESCE(sqlc.arg(countries)::text[], '{}'),
+    regions   = COALESCE(sqlc.arg(regions)::text[], '{}'),
+    work_mode = sqlc.arg(work_mode)
 WHERE id = sqlc.arg(id);
 
 -- name: EnqueueJobEnrichment :execrows

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -116,10 +116,11 @@ func buildSystemPrompt() string {
 	b.WriteString("skills (array of lowercase tokens, e.g. go, postgresql), ")
 	b.WriteString("posting_language (ISO 639-1, e.g. en, uk, ru).\n")
 
-	b.WriteString("\nregions is the remote role's reach (only when work_mode is remote; omit otherwise): ")
+	b.WriteString("\nregions is the job's geographic area, for ANY work mode — a remote role's ")
+	b.WriteString("reach or an onsite/hybrid role's location: ")
 	b.WriteString("use 'global' ONLY when the posting explicitly says the role is open worldwide / ")
 	b.WriteString("anywhere / from any country; otherwise list the region(s) or country code(s) ")
-	b.WriteString("the role is open to, from the allowed values. Omit when unstated (unknown is not global).\n")
+	b.WriteString("the role covers, from the allowed values. Omit when unstated (unknown is not global).\n")
 	return b.String()
 }
 

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -24,17 +24,19 @@ const defaultSemanticRatio = 0.5
 
 // searchStringFacets maps an equality-facet query param to its index attribute.
 // Enrichment facets live under the nested "enrichment" object, so they filter on
-// a dot path. Repeated params (?seniority=a&seniority=b) are ORed.
+// a dot path. Geography (regions/countries) and work_mode are resolved facets
+// served top-level (the union of parsed-location and enrichment values), so they
+// filter on a bare attribute. Repeated params (?seniority=a&seniority=b) are ORed.
 var searchStringFacets = map[string]string{
 	"source":           "source",
 	"company_slug":     "company_slug",
-	"regions":          "enrichment.regions",
-	"work_mode":        "enrichment.work_mode",
+	"regions":          "regions",
+	"work_mode":        "work_mode",
 	"employment_type":  "enrichment.employment_type",
 	"seniority":        "enrichment.seniority",
 	"category":         "enrichment.category",
 	"domains":          "enrichment.domains",
-	"countries":        "enrichment.countries",
+	"countries":        "countries",
 	"company_type":     "enrichment.company_type",
 	"company_size":     "enrichment.company_size",
 	"salary_currency":  "enrichment.salary_currency",

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -75,7 +75,7 @@ func TestSearchJobs_PassesParamsAndShapesResponse(t *testing.T) {
 	if !ok {
 		t.Fatalf("Filter = %#v, want [][]string", fake.got.Filter)
 	}
-	if !filterHas(groups, `enrichment.seniority = "senior"`) || !filterHas(groups, `enrichment.regions = "eu"`) {
+	if !filterHas(groups, `enrichment.seniority = "senior"`) || !filterHas(groups, `regions = "eu"`) {
 		t.Errorf("Filter missing facets: %#v", groups)
 	}
 

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -7,6 +7,8 @@ package jobview
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -23,18 +25,26 @@ import (
 // it as `{}`. Timestamps are RFC3339 UTC strings (or null) — the lexicographic
 // order is chronological, which the search index relies on for sorting.
 type Job struct {
-	PublicSlug  string  `json:"public_slug"`
-	Source      string  `json:"source"`
-	ExternalID  string  `json:"external_id"`
-	URL         string  `json:"url"`
-	Title       string  `json:"title"`
-	Company     string  `json:"company"`
-	CompanySlug string  `json:"company_slug"`
-	Location    string  `json:"location"`
-	Description string  `json:"description"`
-	PostedAt    *string `json:"posted_at"`
-	CreatedAt   *string `json:"created_at"`
-	UpdatedAt   *string `json:"updated_at"`
+	PublicSlug  string `json:"public_slug"`
+	Source      string `json:"source"`
+	ExternalID  string `json:"external_id"`
+	URL         string `json:"url"`
+	Title       string `json:"title"`
+	Company     string `json:"company"`
+	CompanySlug string `json:"company_slug"`
+	Location    string `json:"location"`
+	Description string `json:"description"`
+	// Countries/Regions/WorkMode are the resolved geography facet: the union of
+	// the ingest-parsed location columns and the enrichment-derived values
+	// (work_mode is the LLM value when present, else the parsed one). They are
+	// served here, top-level and once; the same fields are folded out of the
+	// nested Enrichment to avoid duplication.
+	Countries []string `json:"countries"`
+	Regions   []string `json:"regions"`
+	WorkMode  string   `json:"work_mode,omitempty"`
+	PostedAt  *string  `json:"posted_at"`
+	CreatedAt *string  `json:"created_at"`
+	UpdatedAt *string  `json:"updated_at"`
 	// ClosedAt is non-null when the posting is no longer open. Lists and the
 	// search index never contain closed jobs; only the detail endpoint serves
 	// them, and the SPA renders the closed state from this field.
@@ -55,6 +65,18 @@ func FromRow(j db.Job) (Job, error) {
 		}
 	}
 
+	// Merge the two geography sources into the top-level facet. Countries/regions
+	// union both; work_mode is the richer LLM value when present, else the parsed
+	// one. The folded fields are then cleared on the enrichment copy so the served
+	// object reports them exactly once (the stored JSONB is untouched).
+	countries := mergeSets(j.Countries, e.Countries)
+	regions := mergeSets(j.Regions, e.Regions)
+	workMode := e.WorkMode
+	if workMode == "" {
+		workMode = j.WorkMode
+	}
+	e.Countries, e.Regions, e.WorkMode = nil, nil, ""
+
 	return Job{
 		PublicSlug:        j.PublicSlug,
 		Source:            j.Source,
@@ -65,6 +87,9 @@ func FromRow(j db.Job) (Job, error) {
 		CompanySlug:       j.CompanySlug,
 		Location:          j.Location,
 		Description:       j.Description,
+		Countries:         countries,
+		Regions:           regions,
+		WorkMode:          workMode,
 		PostedAt:          rfc3339(j.PostedAt),
 		CreatedAt:         rfc3339(j.CreatedAt),
 		UpdatedAt:         rfc3339(j.UpdatedAt),
@@ -73,6 +98,28 @@ func FromRow(j db.Job) (Job, error) {
 		EnrichedAt:        rfc3339(j.EnrichedAt),
 		EnrichmentVersion: j.EnrichmentVersion,
 	}, nil
+}
+
+// mergeSets returns the sorted, deduplicated, lowercased union of two string
+// slices. Case-folding is load-bearing: the parser emits country/region codes
+// lowercase, but the LLM emits ISO country codes uppercase ("DE"), so without it
+// the same country splits into two facet buckets ("DE" and "de"). The result is
+// always non-nil so the geography facet serializes as a JSON array (matching the
+// text[] columns' empty-array default) rather than null.
+func mergeSets(a, b []string) []string {
+	set := make(map[string]struct{}, len(a)+len(b))
+	for _, v := range a {
+		set[strings.ToLower(v)] = struct{}{}
+	}
+	for _, v := range b {
+		set[strings.ToLower(v)] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // FromRows maps a batch of database rows to the public wire shape.

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -66,6 +66,81 @@ func TestFromRow_MapsCoreAndNestedEnrichment(t *testing.T) {
 	}
 }
 
+// Geography is the union of the parsed-location columns and the enrichment-derived
+// values; work_mode is the LLM value when present, else the parsed one. All three
+// are served top-level and folded out of the enrichment object.
+func TestFromRow_MergesGeographyAndWorkMode(t *testing.T) {
+	raw, err := json.Marshal(enrich.Enrichment{
+		Regions:   []string{"emea"},
+		Countries: []string{"us"},
+		WorkMode:  "remote",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	view, err := FromRow(db.Job{
+		ID:         1,
+		Title:      "Dev",
+		PublicSlug: "dev-1",
+		Countries:  []string{"us"}, // parsed from location
+		Regions:    []string{"us"}, // parsed from location
+		WorkMode:   "onsite",       // parsed from location (loses to the LLM)
+		Enrichment: raw,
+	})
+	if err != nil {
+		t.Fatalf("FromRow: %v", err)
+	}
+
+	if got := view.Countries; len(got) != 1 || got[0] != "us" {
+		t.Errorf("Countries = %v, want [us] (deduped union)", got)
+	}
+	if got := view.Regions; len(got) != 2 || got[0] != "emea" || got[1] != "us" {
+		t.Errorf("Regions = %v, want [emea us] (sorted union)", got)
+	}
+	if view.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (LLM wins over parsed onsite)", view.WorkMode)
+	}
+	// Folded out of enrichment so geography/work_mode are reported once.
+	if len(view.Enrichment.Regions) != 0 || len(view.Enrichment.Countries) != 0 || view.Enrichment.WorkMode != "" {
+		t.Errorf("enrichment still carries folded fields: %+v", view.Enrichment)
+	}
+}
+
+// The LLM emits ISO country codes uppercase ("DE"); the parser emits them
+// lowercase ("de"). The merge must case-fold to one canonical form so the facet
+// is not split into duplicate buckets and a lowercase filter matches both.
+func TestFromRow_CountryCaseIsFolded(t *testing.T) {
+	raw, err := json.Marshal(enrich.Enrichment{Countries: []string{"DE", "FR"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	view, err := FromRow(db.Job{
+		ID:         1,
+		Title:      "x",
+		PublicSlug: "x-1",
+		Countries:  []string{"de"}, // parser, lowercase
+		Enrichment: raw,
+	})
+	if err != nil {
+		t.Fatalf("FromRow: %v", err)
+	}
+	want := []string{"de", "fr"}
+	if len(view.Countries) != 2 || view.Countries[0] != want[0] || view.Countries[1] != want[1] {
+		t.Errorf("Countries = %v, want %v (case-folded, deduped)", view.Countries, want)
+	}
+}
+
+func TestFromRow_WorkModeFallsBackToParsed(t *testing.T) {
+	// No enrichment: the parsed-location work_mode surfaces.
+	view, err := FromRow(db.Job{ID: 1, Title: "x", PublicSlug: "x-1", WorkMode: "hybrid"})
+	if err != nil {
+		t.Fatalf("FromRow: %v", err)
+	}
+	if view.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid (parser fallback when no LLM value)", view.WorkMode)
+	}
+}
+
 func TestFromRow_EmptyEnrichmentIsZero(t *testing.T) {
 	// An unenriched job's column arrives as "{}" (the table default) or, in
 	// edge cases, a nil byte slice. Both must decode to the zero Enrichment,
@@ -148,8 +223,15 @@ func TestJobJSON_Enriched(t *testing.T) {
 	if err := json.Unmarshal(fields["enrichment"], &enrichment); err != nil {
 		t.Fatalf("enrichment is not a JSON object: %v", err)
 	}
-	if enrichment["seniority"] != "senior" || enrichment["work_mode"] != "remote" {
+	if enrichment["seniority"] != "senior" {
 		t.Errorf("enrichment payload not preserved: %v", enrichment)
+	}
+	// work_mode is folded into the top-level facet, not duplicated under enrichment.
+	if got := string(fields["work_mode"]); got != `"remote"` {
+		t.Errorf("work_mode: want top-level \"remote\", got %s", got)
+	}
+	if _, dup := enrichment["work_mode"]; dup {
+		t.Error("work_mode must not also appear under enrichment")
 	}
 	if got := string(fields["enriched_at"]); got != `"2026-06-09T12:00:00Z"` {
 		t.Errorf("enriched_at: want the timestamp, got %s", got)

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -1,0 +1,88 @@
+package location
+
+// The dictionaries below are seeded from the high-frequency location strings
+// observed in production ATS data. They are meant to grow by observation — add
+// the names/cities that show up unresolved, not a full gazetteer up front.
+
+// regionCountries groups ISO 3166-1 alpha-2 country codes under one canonical
+// region code from enrich.RegionValues. Each country maps to exactly one region
+// (the coarse facet a user filters on); countryToRegion is the inverted lookup.
+// "eu" is used in the broad geographic sense of Europe (not only EU members).
+var regionCountries = map[string][]string{
+	"eu": {
+		"de", "fr", "nl", "es", "se", "pl", "ie", "pt", "it", "be", "dk",
+		"fi", "at", "cz", "ro", "gr", "hu", "bg", "hr", "sk", "si", "lt",
+		"lv", "ee", "lu", "ch", "no", "ua", "is",
+	},
+	"uk":            {"gb"},
+	"us":            {"us"},
+	"north_america": {"ca"},
+	"latam":         {"ar", "br", "mx", "cl", "co", "pe", "uy"},
+	"apac":          {"sg", "jp", "au", "nz", "in", "hk", "tw", "kr", "cn", "my", "th", "ph", "vn", "id"},
+	"mena":          {"ae", "sa", "il", "eg", "tr", "qa"},
+	"africa":        {"za", "ng", "ke"},
+	"ru":            {"ru"},
+}
+
+// countryToRegion is the inverted regionCountries: ISO code -> region code.
+var countryToRegion = invertRegionCountries()
+
+func invertRegionCountries() map[string]string {
+	out := make(map[string]string)
+	for region, codes := range regionCountries {
+		for _, code := range codes {
+			out[code] = region
+		}
+	}
+	return out
+}
+
+// nameToCountry resolves lowercase country names, common ATS shorthands, and a
+// few beacon cities to an ISO 3166-1 alpha-2 code. The region falls out of
+// countryToRegion, so shorthands like "uk" yield both the country (gb) and its
+// region (uk) without a separate entry.
+var nameToCountry = map[string]string{
+	"united states": "us", "united states of america": "us",
+	"usa": "us", "us": "us", "u.s.": "us", "u.s.a.": "us",
+	"united kingdom": "gb", "uk": "gb", "u.k.": "gb",
+	"england": "gb", "britain": "gb", "great britain": "gb", "london": "gb",
+	"germany": "de", "deutschland": "de", "berlin": "de", "munich": "de", "münchen": "de", "hamburg": "de",
+	"france": "fr", "paris": "fr",
+	"netherlands": "nl", "the netherlands": "nl", "amsterdam": "nl",
+	"spain": "es", "madrid": "es", "barcelona": "es",
+	"sweden": "se", "stockholm": "se",
+	"poland": "pl", "warsaw": "pl",
+	"ireland": "ie", "dublin": "ie",
+	"portugal": "pt", "lisbon": "pt",
+	"italy": "it", "milan": "it", "rome": "it",
+	"belgium": "be", "brussels": "be",
+	"denmark": "dk", "copenhagen": "dk",
+	"finland": "fi", "helsinki": "fi",
+	"austria": "at", "vienna": "at",
+	"switzerland": "ch", "zurich": "ch",
+	"norway": "no", "ukraine": "ua",
+	"canada": "ca", "toronto": "ca", "vancouver": "ca", "montreal": "ca",
+	"singapore": "sg",
+	"australia": "au", "sydney": "au", "melbourne": "au",
+	"new zealand": "nz",
+	"japan":       "jp", "tokyo": "jp",
+	"india": "in", "pune": "in", "bangalore": "in", "bengaluru": "in", "mumbai": "in", "hyderabad": "in",
+	"argentina": "ar", "brazil": "br", "mexico": "mx",
+	"israel": "il", "tel aviv": "il",
+	"united arab emirates": "ae", "dubai": "ae",
+	"south africa": "za",
+}
+
+// nameToRegion resolves macro-region names (and explicit open-anywhere markers)
+// directly to a region code, for tokens that name an area rather than a country.
+var nameToRegion = map[string]string{
+	"europe": "eu", "eu": "eu",
+	"emea": "emea", "eea": "eea",
+	"apac": "apac", "asia": "apac", "asia pacific": "apac", "asia-pacific": "apac",
+	"americas":      "americas",
+	"north america": "north_america",
+	"latam":         "latam", "latin america": "latam", "south america": "latam",
+	"mena": "mena", "middle east": "mena",
+	"africa":   "africa",
+	"anywhere": "global", "worldwide": "global", "global": "global", "remote anywhere": "global",
+}

--- a/internal/location/dictionaries_test.go
+++ b/internal/location/dictionaries_test.go
@@ -1,0 +1,54 @@
+package location
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/enrich"
+)
+
+// TestDictionariesStayInVocabulary pins the hand-maintained dictionaries to the
+// enrichment contract's vocabularies exhaustively (not just for sampled inputs):
+// every region code the parser can ever emit is a member of enrich.RegionValues,
+// and every country code is a plausible ISO 3166-1 alpha-2 (two lowercase
+// letters). It guards against a future dictionary edit introducing a region the
+// search facet would expose but the enrichment path would Sanitize away.
+func TestDictionariesStayInVocabulary(t *testing.T) {
+	for region, codes := range regionCountries {
+		if !slices.Contains(enrich.RegionValues, region) {
+			t.Errorf("regionCountries key %q is not in enrich.RegionValues", region)
+		}
+		for _, code := range codes {
+			if !isAlpha2(code) {
+				t.Errorf("regionCountries[%q] has non-alpha2 country code %q", region, code)
+			}
+		}
+	}
+
+	for name, code := range nameToCountry {
+		if !isAlpha2(code) {
+			t.Errorf("nameToCountry[%q] = %q is not a two-letter lowercase code", name, code)
+		}
+		if _, ok := countryToRegion[code]; !ok {
+			t.Errorf("nameToCountry[%q] = %q has no region in countryToRegion", name, code)
+		}
+	}
+
+	for name, region := range nameToRegion {
+		if !slices.Contains(enrich.RegionValues, region) {
+			t.Errorf("nameToRegion[%q] = %q is not in enrich.RegionValues", name, region)
+		}
+	}
+}
+
+func isAlpha2(s string) bool {
+	if len(s) != 2 {
+		return false
+	}
+	for _, r := range s {
+		if r < 'a' || r > 'z' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -1,0 +1,113 @@
+// Package location derives a job's geography — ISO 3166-1 alpha-2 country codes
+// and region codes — and a work-mode hint deterministically from the free-text
+// ATS location string.
+//
+// It is a curated dictionary, not a geocoder: it resolves the high-frequency
+// country names, ATS shorthands ("USA", "UK"), macro-region names ("Europe",
+// "APAC"), and a few beacon cities that real ATS location fields use, and emits
+// nothing for anything it cannot resolve (it never guesses). Region codes are
+// drawn from the same controlled vocabulary the enrichment contract defines
+// (enrich.RegionValues), and work modes from enrich.WorkModeValues, so the
+// parser, the enrichment payload, and the search facet all speak one set of
+// values.
+package location
+
+import (
+	"sort"
+	"strings"
+)
+
+// Geo is the geography parsed from a location string: zero or more country codes
+// and region codes, and an optional work-mode hint. Each field is empty when the
+// location states nothing the parser can resolve.
+type Geo struct {
+	Countries []string
+	Regions   []string
+	WorkMode  string // "", "remote", "hybrid", or "onsite" — only on an explicit marker
+}
+
+// separatorReplacer normalizes every token separator to a comma in one pass so a
+// single Split yields the geography tokens. The multi-character forms (" - ",
+// " or ") and parentheses are included, so "Berlin (On-site)" -> "berlin",
+// "on-site".
+var separatorReplacer = strings.NewReplacer(
+	";", ",", "/", ",", "|", ",", "(", ",", ")", ",", " - ", ",", " or ", ",",
+)
+
+// Parse maps a location string to its geography. Countries/regions are
+// deduplicated and sorted; nil when nothing resolves. WorkMode is set only from
+// an explicit marker — a bare "Remote" yields WorkMode "remote" with no
+// geography, while a plain city/country yields geography with no WorkMode. The
+// "global" region is emitted only from an explicit open-anywhere marker, never
+// inferred from a bare "Remote".
+func Parse(location string) Geo {
+	lower := strings.ToLower(location)
+
+	s := separatorReplacer.Replace(lower)
+
+	countrySet := map[string]struct{}{}
+	regionSet := map[string]struct{}{}
+	for _, tok := range strings.Split(s, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		if code, ok := nameToCountry[tok]; ok {
+			countrySet[code] = struct{}{}
+			if r, ok := countryToRegion[code]; ok {
+				regionSet[r] = struct{}{}
+			}
+			continue
+		}
+		if r, ok := nameToRegion[tok]; ok {
+			regionSet[r] = struct{}{}
+		}
+	}
+
+	return Geo{
+		Countries: sortedKeys(countrySet),
+		Regions:   sortedKeys(regionSet),
+		WorkMode:  detectWorkMode(lower),
+	}
+}
+
+// workModeMarkers maps a work mode to the substrings that signal it, checked in
+// priority order: hybrid (most specific) beats a remote marker in the same
+// string, and an explicit onsite marker is the last resort. A location with no
+// marker yields "" — onsite is never assumed from a bare city.
+var workModeMarkers = []struct {
+	mode    string
+	markers []string
+}{
+	{"hybrid", []string{"hybrid"}},
+	{"remote", []string{"remote", "work from home", "wfh", "anywhere", "worldwide", "distributed"}},
+	{"onsite", []string{"on-site", "onsite", "on site", "in office", "in-office"}},
+}
+
+// detectWorkMode scans the whole lowercased location for a work-mode marker,
+// independent of tokenization so a marker embedded in a token ("Berlin
+// (On-site)") is still found.
+func detectWorkMode(lower string) string {
+	for _, wm := range workModeMarkers {
+		for _, m := range wm.markers {
+			if strings.Contains(lower, m) {
+				return wm.mode
+			}
+		}
+	}
+	return ""
+}
+
+// sortedKeys returns the set's keys sorted ascending, or nil when empty so an
+// absent facet omits cleanly (and matches the text[] default '{}').
+func sortedKeys(set map[string]struct{}) []string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -1,0 +1,116 @@
+package location
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/enrich"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     Geo
+	}{
+		{
+			name:     "named country yields code, region and remote mode",
+			location: "Remote - Germany",
+			want:     Geo{Countries: []string{"de"}, Regions: []string{"eu"}, WorkMode: "remote"},
+		},
+		{
+			name:     "country shorthand USA",
+			location: "Remote - USA",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
+		},
+		{
+			name:     "plain country name states no work mode",
+			location: "United States",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "macro region name yields region without country",
+			location: "Remote - Europe",
+			want:     Geo{Regions: []string{"eu"}, WorkMode: "remote"},
+		},
+		{
+			name:     "multiple locations union and dedup",
+			location: "Remote - UK or Europe",
+			want:     Geo{Countries: []string{"gb"}, Regions: []string{"eu", "uk"}, WorkMode: "remote"},
+		},
+		{
+			name:     "bare remote yields work mode but no geography",
+			location: "Remote",
+			want:     Geo{WorkMode: "remote"},
+		},
+		{
+			name:     "explicit anywhere yields global and remote",
+			location: "Remote - Anywhere",
+			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
+		},
+		{
+			name:     "hybrid marker with city",
+			location: "Hybrid - London",
+			want:     Geo{Countries: []string{"gb"}, Regions: []string{"uk"}, WorkMode: "hybrid"},
+		},
+		{
+			name:     "onsite marker in parentheses keeps the city",
+			location: "Berlin (On-site)",
+			want:     Geo{Countries: []string{"de"}, Regions: []string{"eu"}, WorkMode: "onsite"},
+		},
+		{
+			name:     "hybrid wins over a remote marker in the same string",
+			location: "Hybrid / Remote - London",
+			want:     Geo{Countries: []string{"gb"}, Regions: []string{"uk"}, WorkMode: "hybrid"},
+		},
+		{
+			name:     "country buried among unknown tokens",
+			location: "Burlington, Massachusetts, United States; Remote",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
+		},
+		{
+			name:     "empty location",
+			location: "",
+			want:     Geo{},
+		},
+		{
+			name:     "unresolvable token guesses nothing",
+			location: "Atlantis",
+			want:     Geo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.location)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse(%q) = %+v, want %+v", tt.location, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseEmitsOnlyKnownVocabulary guards the controlled-vocabulary invariant:
+// every region the parser emits is a member of enrich.RegionValues and every
+// work mode a member of enrich.WorkModeValues — the parser never invents a value
+// outside the enrichment contract's vocabularies.
+func TestParseEmitsOnlyKnownVocabulary(t *testing.T) {
+	samples := []string{
+		"Remote - Germany", "Remote - UK or Europe", "Remote - Anywhere",
+		"Remote - USA", "Remote - Singapore", "Remote - Canada",
+		"Hybrid - London", "Berlin (On-site)",
+		"Burlington, Massachusetts, United States; Remote", "Remote", "",
+	}
+	for _, s := range samples {
+		got := Parse(s)
+		for _, r := range got.Regions {
+			if !slices.Contains(enrich.RegionValues, r) {
+				t.Errorf("Parse(%q) emitted region %q outside RegionValues", s, r)
+			}
+		}
+		if got.WorkMode != "" && !slices.Contains(enrich.WorkModeValues, got.WorkMode) {
+			t.Errorf("Parse(%q) emitted work_mode %q outside WorkModeValues", s, got.WorkMode)
+		}
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/strelov1/freehire/internal/location"
 	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/sources"
 )
@@ -32,6 +33,12 @@ type Job struct {
 	Remote      bool
 	Description string
 	PostedAt    *time.Time
+	// Countries/Regions/WorkMode are parsed from Location: ISO alpha-2 codes,
+	// region codes, and a work-mode hint. Each is empty when the location states
+	// nothing the parser can resolve.
+	Countries []string
+	Regions   []string
+	WorkMode  string
 }
 
 // Store persists one normalized job and enqueues it for enrichment when needed,
@@ -131,6 +138,14 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 func normalizeJob(e sources.CompanyEntry, j sources.Job) Job {
 	source := e.Provider
 	externalID := fmt.Sprintf("%s:%s", e.Board, j.ExternalID)
+	geo := location.Parse(j.Location)
+	// Work mode precedence: the adapter's structured signal (a workplace-type enum
+	// or explicit remote flag) beats the parser's free-text heuristic. The LLM,
+	// richer still, wins over both later at read time.
+	workMode := j.WorkMode
+	if workMode == "" {
+		workMode = geo.WorkMode
+	}
 	return Job{
 		Source:      source,
 		ExternalID:  externalID,
@@ -143,5 +158,8 @@ func normalizeJob(e sources.CompanyEntry, j sources.Job) Job {
 		Remote:      j.Remote,
 		Description: j.Description,
 		PostedAt:    j.PostedAt,
+		Countries:   geo.Countries,
+		Regions:     geo.Regions,
+		WorkMode:    workMode,
 	}
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -86,6 +87,38 @@ func TestRunNormalizesAndNamespaces(t *testing.T) {
 	wantSlug := normalize.JobSlug(j.Title, j.Company, j.Source, j.ExternalID)
 	if j.PublicSlug == "" || j.PublicSlug != wantSlug {
 		t.Errorf("PublicSlug = %q, want %q", j.PublicSlug, wantSlug)
+	}
+}
+
+func TestNormalizeJobParsesGeographyFromLocation(t *testing.T) {
+	e := sources.CompanyEntry{Company: "Acme", Provider: "greenhouse", Board: "acme"}
+
+	geo := normalizeJob(e, sources.Job{ExternalID: "1", Title: "Dev", Company: "Acme", Location: "Remote - Germany"})
+	if !reflect.DeepEqual(geo.Countries, []string{"de"}) || !reflect.DeepEqual(geo.Regions, []string{"eu"}) {
+		t.Errorf("geography = %v/%v, want [de]/[eu]", geo.Countries, geo.Regions)
+	}
+
+	// A location with no resolvable place leaves geography empty (never guessed).
+	bare := normalizeJob(e, sources.Job{ExternalID: "2", Title: "Dev", Company: "Acme", Location: "Remote"})
+	if len(bare.Countries) != 0 || len(bare.Regions) != 0 {
+		t.Errorf("bare remote geography = %v/%v, want empty", bare.Countries, bare.Regions)
+	}
+}
+
+func TestNormalizeJobPrefersAdapterWorkModeOverParser(t *testing.T) {
+	e := sources.CompanyEntry{Company: "Acme", Provider: "greenhouse", Board: "acme"}
+
+	// The adapter states hybrid structurally; the location text would parse as
+	// remote. The structured signal wins.
+	structured := normalizeJob(e, sources.Job{ExternalID: "1", Title: "Dev", Company: "Acme", Location: "Remote", WorkMode: "hybrid"})
+	if structured.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid (adapter structured wins over parser)", structured.WorkMode)
+	}
+
+	// No structured signal: the parser fills from the location text.
+	parsed := normalizeJob(e, sources.Job{ExternalID: "2", Title: "Dev", Company: "Acme", Location: "Remote"})
+	if parsed.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (parser fallback)", parsed.WorkMode)
 	}
 }
 

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -165,11 +165,15 @@ func (c *Client) awaitTask(ctx context.Context, taskUID int64) error {
 func indexSettings() *meilisearch.Settings {
 	return &meilisearch.Settings{
 		SearchableAttributes: []string{"title", "company", "description", "location"},
-		// Enrichment facets are nested, so they are filtered via dot paths.
+		// Enrichment facets are nested, so they are filtered via dot paths. The
+		// resolved geography facet (regions/countries) and work_mode are served
+		// top-level — the union of parsed-location and enrichment values — so they
+		// are filtered on a bare attribute, not the enrichment dot path.
 		FilterableAttributes: []string{
 			"source", "company_slug",
-			"enrichment.work_mode", "enrichment.employment_type", "enrichment.seniority",
-			"enrichment.category", "enrichment.domains", "enrichment.regions", "enrichment.countries",
+			"work_mode", "regions", "countries",
+			"enrichment.employment_type", "enrichment.seniority",
+			"enrichment.category", "enrichment.domains",
 			"enrichment.company_type", "enrichment.company_size", "enrichment.visa_sponsorship",
 			"enrichment.salary_currency", "enrichment.salary_period", "enrichment.skills",
 			"enrichment.salary_min", "enrichment.salary_max", "enrichment.experience_years_min",

--- a/internal/search/document.go
+++ b/internal/search/document.go
@@ -20,8 +20,9 @@ type JobDocument struct {
 
 // FromJob maps a database job row to its index document. An empty or absent
 // enrichment payload yields the zero Enrichment (the job is still fully
-// searchable by its text). Remote reach rides the embedded enrichment as
-// `enrichment.regions` and is filtered via that dot path.
+// searchable by its text). Geography (regions/countries) and work_mode ride the
+// document top-level — the resolved union of parsed-location and enrichment
+// values — and are filtered via those bare attributes.
 func FromJob(j db.Job) (JobDocument, error) {
 	view, err := jobview.FromRow(j)
 	if err != nil {

--- a/internal/sources/ashby.go
+++ b/internal/sources/ashby.go
@@ -47,6 +47,7 @@ func (a ashby) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location:    j.Location,
 			Description: sanitizeHTML(j.DescriptionHTML),
 			Remote:      j.IsRemote,
+			WorkMode:    workModeFromRemote(j.IsRemote),
 			PostedAt:    parseRFC3339(j.PublishedAt),
 		})
 	}

--- a/internal/sources/ashby_test.go
+++ b/internal/sources/ashby_test.go
@@ -68,6 +68,10 @@ func TestAshbyFetch(t *testing.T) {
 	if !j.Remote {
 		t.Error("Remote = false, want true from the explicit isRemote field")
 	}
+	// The explicit isRemote flag also yields a structured work mode.
+	if j.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote from the explicit isRemote field", j.WorkMode)
+	}
 	if j.PostedAt == nil {
 		t.Error("PostedAt = nil, want parsed publishedAt with milliseconds")
 	}

--- a/internal/sources/lever.go
+++ b/internal/sources/lever.go
@@ -25,13 +25,14 @@ func (l lever) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	url := fmt.Sprintf("%s/%s?mode=json", leverBaseURL, e.Board)
 
 	var postings []struct {
-		ID          string `json:"id"`
-		Text        string `json:"text"`
-		HostedURL   string `json:"hostedUrl"`
-		CreatedAt   int64  `json:"createdAt"`
-		Description string `json:"description"`
-		Additional  string `json:"additional"`
-		Lists       []struct {
+		ID            string `json:"id"`
+		Text          string `json:"text"`
+		HostedURL     string `json:"hostedUrl"`
+		CreatedAt     int64  `json:"createdAt"`
+		Description   string `json:"description"`
+		Additional    string `json:"additional"`
+		WorkplaceType string `json:"workplaceType"`
+		Lists         []struct {
 			Text    string `json:"text"`
 			Content string `json:"content"`
 		} `json:"lists"`
@@ -68,6 +69,7 @@ func (l lever) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location:    p.Categories.Location,
 			Description: sanitizeHTML(body.String()),
 			Remote:      isRemote(p.Categories.Location),
+			WorkMode:    workplaceTypeMode(p.WorkplaceType),
 			PostedAt:    parseEpochMillis(p.CreatedAt),
 		})
 	}

--- a/internal/sources/lever_test.go
+++ b/internal/sources/lever_test.go
@@ -20,6 +20,7 @@ func TestLeverFetch(t *testing.T) {
 			"hostedUrl": "https://jobs.lever.co/lever/abc-123",
 			"createdAt": 1705312800000,
 			"categories": {"location": "Remote"},
+			"workplaceType": "hybrid",
 			"description": "<p>Write Go.</p>"
 		}
 	]`}
@@ -39,6 +40,9 @@ func TestLeverFetch(t *testing.T) {
 	}
 
 	j := jobs[0]
+	if j.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid from Lever's workplaceType", j.WorkMode)
+	}
 	if j.ExternalID != "abc-123" {
 		t.Errorf("ExternalID = %q, want %q", j.ExternalID, "abc-123")
 	}

--- a/internal/sources/recruitee.go
+++ b/internal/sources/recruitee.go
@@ -52,6 +52,7 @@ func (r recruitee) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location:    o.Location,
 			Description: sanitizeHTML(o.Description + o.Requirements),
 			Remote:      o.Remote,
+			WorkMode:    workModeFromRemote(o.Remote),
 			PostedAt:    parseSpaceTime(o.CreatedAt),
 		})
 	}

--- a/internal/sources/smartrecruiters.go
+++ b/internal/sources/smartrecruiters.go
@@ -115,6 +115,7 @@ func (s smartRecruiters) detail(ctx context.Context, e CompanyEntry, p smartRecr
 		Location:    joinNonEmpty(p.Location.City, p.Location.Region, p.Location.Country),
 		Description: sanitizeHTML(body),
 		Remote:      p.Location.Remote,
+		WorkMode:    workModeFromRemote(p.Location.Remote),
 		PostedAt:    parseRFC3339(p.ReleasedDate),
 	}, true
 }

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -30,6 +30,13 @@ type Job struct {
 	Description string
 	Remote      bool
 	PostedAt    *time.Time
+	// WorkMode is the work arrangement when the platform states it in a STRUCTURED
+	// field (a workplace-type enum or an explicit remote flag) — "remote",
+	// "hybrid", or "onsite", else "". It is left empty for adapters that only
+	// expose free-text location; the pipeline then falls back to parsing the
+	// location string. Provenance stays clean: this carries structured signal only,
+	// never the location heuristic.
+	WorkMode string
 }
 
 // Source adapts one job-source platform. Provider is the platform key that selects
@@ -98,6 +105,32 @@ func fetchDetails[P any](postings []P, workers int, fetch func(P) (Job, bool)) [
 func isRemote(location string) bool {
 	l := strings.ToLower(location)
 	return strings.Contains(l, "remote") || strings.Contains(l, "удал")
+}
+
+// workModeFromRemote maps an adapter's STRUCTURED remote flag to a work mode:
+// "remote" when set, else "" (a false flag does not imply onsite vs hybrid, so it
+// is left unknown for the parser/LLM to resolve). Adapters whose API exposes an
+// explicit remote boolean (Ashby, Recruitee, SmartRecruiters, Workable) use this.
+func workModeFromRemote(remote bool) string {
+	if remote {
+		return "remote"
+	}
+	return ""
+}
+
+// workplaceTypeMode maps an ATS workplace-type enum (as Lever exposes) to our work
+// mode vocabulary; an unspecified/unknown value yields "".
+func workplaceTypeMode(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "remote":
+		return "remote"
+	case "hybrid":
+		return "hybrid"
+	case "on-site", "onsite", "on site":
+		return "onsite"
+	default:
+		return ""
+	}
 }
 
 // parseLayout parses a platform timestamp with the given layout into a posted_at,

--- a/internal/sources/workable.go
+++ b/internal/sources/workable.go
@@ -49,6 +49,7 @@ func (w workable) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location:    joinNonEmpty(j.City, j.State, j.Country),
 			Description: sanitizeHTML(j.Description),
 			Remote:      j.Telecommuting,
+			WorkMode:    workModeFromRemote(j.Telecommuting),
 			PostedAt:    parseDate(j.PublishedOn),
 		})
 	}

--- a/internal/sources/workmode_test.go
+++ b/internal/sources/workmode_test.go
@@ -1,0 +1,31 @@
+package sources
+
+import "testing"
+
+func TestWorkModeFromRemote(t *testing.T) {
+	if got := workModeFromRemote(true); got != "remote" {
+		t.Errorf("workModeFromRemote(true) = %q, want remote", got)
+	}
+	// A false flag does not imply onsite vs hybrid — leave it unknown.
+	if got := workModeFromRemote(false); got != "" {
+		t.Errorf("workModeFromRemote(false) = %q, want empty", got)
+	}
+}
+
+func TestWorkplaceTypeMode(t *testing.T) {
+	cases := map[string]string{
+		"remote":      "remote",
+		"hybrid":      "hybrid",
+		"on-site":     "onsite",
+		"onsite":      "onsite",
+		"On-Site":     "onsite",
+		"unspecified": "",
+		"":            "",
+		"weird":       "",
+	}
+	for in, want := range cases {
+		if got := workplaceTypeMode(in); got != want {
+			t.Errorf("workplaceTypeMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/migrations/0011_job_geography.sql
+++ b/migrations/0011_job_geography.sql
@@ -1,0 +1,11 @@
+-- Job geography (see openspec change ingest-job-geography): countries/regions and
+-- a work_mode hint derived at ingest. These are SOURCE facts (from the structured
+-- ATS fields and/or the parsed location string), distinct from the AI-derived
+-- `enrichment` payload. countries/regions DEFAULT '{}' and work_mode DEFAULT ''
+-- backfill existing rows as empty at migration time; the backfill command
+-- (cmd/backfill-geo) then fills them from each row's stored location text, and
+-- ingest keeps them fresh on every re-crawl.
+ALTER TABLE jobs
+    ADD COLUMN IF NOT EXISTS countries TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS regions   TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS work_mode TEXT   NOT NULL DEFAULT '';

--- a/openspec/changes/ingest-job-geography/.openspec.yaml
+++ b/openspec/changes/ingest-job-geography/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/ingest-job-geography/design.md
+++ b/openspec/changes/ingest-job-geography/design.md
@@ -1,0 +1,107 @@
+## Context
+
+Job geography drives the most-used filter, but it is nearly empty. Of ~72k jobs
+only 4% are enriched, and `enrichment.regions` is filled for just 16% of remote
+jobs. A prod investigation showed the geographic signal is already present in the
+structured `location` field for ~90% of remote jobs lacking regions
+(`Remote - USA`, `Remote - UK`, `United States`, …); the LLM drops it because the
+enrichment prompt forbids inference ("never guess"). Today `regions` lives only
+in the `jobs.enrichment` JSONB (an AI-derived blob) and is faceted by Meilisearch
+via the `enrichment.regions` dot path.
+
+Constraints: sqlc is the only DB layer (edit `queries/*.sql`, run `make sqlc`);
+migrations apply only on first volume init, so prod gets them by manual `psql`;
+search-field changes require a reindex; the SPA has no test runner (verify via
+svelte-check + lint); enrichment (`SetJobEnrichment`) and ingest (`UpsertJob`)
+are deliberately decoupled write paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Populate `countries` + `regions` for every job deterministically from its
+  `location` string, independent of enrichment.
+- Redefine `regions` as the geographic area of a job (any work mode), so the
+  facet is useful for onsite/hybrid roles too.
+- Present geography as a single top-level facet that unions the ingest-derived
+  values with whatever the LLM additionally found in the description body.
+- Backfill existing rows so the facet is immediately populated, including closed
+  jobs that never re-crawl.
+
+**Non-Goals:**
+- A full geocoder. The parser is a curated dictionary seeded from real prod
+  locations; unresolvable single cities are omitted, not guessed.
+- Changing `work_mode`/`remote` detection — that stays the LLM's job.
+- Postgres-side region filtering / GIN indexes — faceting stays in Meilisearch.
+- Materializing the union into the DB.
+
+## Decisions
+
+**1. Parse at ingest, not (only) at enrichment.** The location field is short and
+structured-ish, so a deterministic parser hits ~100% where the LLM hit 16%, runs
+on all jobs (not just the enriched 4%), and costs no LLM latency. The LLM is kept
+as an additive source for reach stated only in the description body.
+*Alternative — fix the prompt:* rejected; still gated on the enrichment backlog
+and the model's conservatism, and non-deterministic.
+
+**2. Union at READ time in `jobview.FromRow`, not materialized.** Ingest
+(`UpsertJob`) and enrichment (`SetJobEnrichment`) are separate writers; a
+materialized union would need both to keep it in sync — exactly the coupling the
+codebase avoids. `jobview` already decodes enrichment on read, so the union is a
+natural extension there. `FromRow` computes `jobs.regions ∪ enrichment.regions`
+(and countries) into new top-level `Regions`/`Countries`, then blanks
+`enrichment.regions`/`enrichment.countries` in the *served* copy so geography is
+reported once (the stored JSONB is untouched — the LLM data stays intact).
+*Alternative — pre-fill `enrichment.regions` at ingest:* rejected; pollutes the
+"AI-derived" blob and creates write-path precedence conflicts.
+
+**3. New `internal/location` package owning a hand-curated dictionary.**
+`Parse(location string) (countries, regions []string)` over three maps:
+`nameToCountry` (lowercase name / ATS shorthand / beacon city → ISO alpha-2),
+`nameToRegion` (macro names → region, e.g. `europe→eu`, `worldwide→global`), and
+`countryToRegion` (ISO → region from the existing `enrich.RegionValues` vocab).
+Tokenize on `, ; / |`, ` - `, ` or `. Emit only values in `RegionValues` / valid
+ISO, deduped. Bare `Remote` with no country → empty (`global` only from explicit
+anywhere/worldwide). Output values are constrained to the same vocabulary the
+search facet uses, so they need no further validation.
+*Alternative — a countries library:* rejected; libs match formal names, not ATS
+shorthand ("USA", "Remote - UK"), and still need our `ISO → region` map.
+
+**4. Geography columns are source facts on `jobs`, written by `UpsertJob`.** They
+sit beside `location`/`remote` and follow its INSERT + `ON CONFLICT DO UPDATE`
+pattern, so a re-crawl refreshes them. This is distinct from the enrichment
+columns `UpsertJob` deliberately never writes.
+
+**5. Backfill via a run-once `cmd/backfill-geo`.** Keyset scan
+(`ListJobsByIDAfter`), `location.Parse`, write through a new `SetJobLocation`
+query. Deterministic and idempotent — re-running converges. Follows the existing
+run-once worker/command pattern (enrich, reindex, reslug).
+
+## Risks / Trade-offs
+
+- **Facet semantics change is breaking** → A `regions` filter now also matches
+  onsite offices, not just remote reach. This is the intended new meaning;
+  documented in the spec and the proposal. The SPA filter label/behavior follows.
+- **Dictionary coverage is partial at launch** → Seed from the real prod location
+  distribution (high-frequency strings first); unresolved locations simply yield
+  no geography (no wrong data). Dictionary grows by observation — note the seam.
+- **Search facet move requires reindex** → Without it, `/jobs/search` filters on a
+  stale attribute. Mitigation: reindex is a known post-deploy step; call it out in
+  the migration plan.
+- **Prod migration is manual** → Adding two columns must be applied by hand on the
+  existing volume before the new code filters on them. Apply migration first, then
+  deploy, then backfill, then reindex.
+
+## Migration Plan
+
+1. Add migration (`jobs.countries`, `jobs.regions`), `make sqlc`, ship code.
+2. On prod: apply the migration manually via `psql` against the existing volume.
+3. Deploy the new image (ingest starts populating geography on each crawl).
+4. Run `cmd/backfill-geo` once to populate existing rows (incl. closed).
+5. Run `reindex` to update Meilisearch filterable attributes and re-push docs.
+Rollback: the columns are additive and default `'{}'`; reverting the code leaves
+them unused and harmless. The facet falls back to `enrichment.regions` only if
+the search settings are also reverted + reindexed.
+
+## Open Questions
+
+None — design approved in brainstorming.

--- a/openspec/changes/ingest-job-geography/proposal.md
+++ b/openspec/changes/ingest-job-geography/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+Geography is the facet users filter on most, yet it is almost empty: only 4% of
+jobs are enriched, and among those only 16% of remote jobs carry a `regions`
+value. Prod evidence shows the signal is already present in the structured
+`location` field — 90% of remote jobs missing regions have geo text like
+`Remote - USA`, `Remote - UK`, `United States` — but the LLM under-extracts it
+because its prompt is deliberately conservative ("never guess"). Parsing the
+location string deterministically is more reliable (100% vs 16%), covers all
+~72k jobs immediately instead of waiting on a 26‑day enrichment backlog, and
+adds zero LLM latency.
+
+## What Changes
+
+- Derive job geography (`countries` + `regions`) deterministically from the ATS
+  `location` string during ingest, and persist it on `jobs`.
+- Redefine `regions` from "remote reach" to **the geographic area of the job**,
+  meaningful for every work mode (so a `regions = eu` filter matches both
+  remote‑EU roles and offices in Berlin). **BREAKING** for the existing
+  `enrichment.regions` facet semantics.
+- Union the ingest‑derived geography with the LLM‑derived
+  `enrichment.regions`/`countries` at read time and expose it as a **top‑level**
+  job facet (`regions`, `countries`), reported once.
+- Move the search region/country facet from `enrichment.regions` to the
+  top‑level merged fields; the SPA filters on the new fields.
+- One‑off backfill of the new columns over existing rows from their stored
+  `location` text.
+
+## Capabilities
+
+### New Capabilities
+- `job-geography`: the deterministic `location` → (`countries`, `regions`)
+  parser, its controlled output vocabularies (reusing the enrichment region
+  vocabulary + ISO‑3166 country codes), the read‑time union with LLM‑derived
+  geography, and the public top‑level geography contract.
+
+### Modified Capabilities
+- `source-ingest`: the ingest write path now parses the location string and
+  persists `jobs.countries`/`jobs.regions` alongside the raw posting.
+- `job-enrichment`: `regions` is redefined as geographic area (any work mode),
+  and `enrichment.regions`/`enrichment.countries` are no longer served as
+  independent fields — they fold into the top‑level union; the enrichment prompt
+  drops the "only when remote" restriction.
+- `job-search`: the region/country facet filters on the top‑level merged
+  geography instead of `enrichment.regions`.
+
+## Impact
+
+- **Schema**: new migration adds `jobs.countries text[]` and `jobs.regions
+  text[]` (manual apply on prod — migrations run only on first volume init).
+- **Code**: new `internal/location` package; `internal/pipeline` (normalize),
+  `internal/db/queries/jobs.sql` (`UpsertJob`, new `SetJobLocation`),
+  `internal/jobview`, `internal/search` (document + filterable attributes),
+  `internal/enrich/langchain.go` (prompt), new `cmd/backfill-geo`.
+- **Search**: Meilisearch filterable‑attributes change → reindex required after
+  deploy.
+- **Web**: SPA region filter maps to the top‑level `regions` field
+  (verified via svelte-check + lint; no SPA test runner).

--- a/openspec/changes/ingest-job-geography/specs/job-enrichment/spec.md
+++ b/openspec/changes/ingest-job-geography/specs/job-enrichment/spec.md
@@ -1,0 +1,99 @@
+## MODIFIED Requirements
+
+### Requirement: Enrichment fields follow a typed contract with controlled vocabularies
+
+The system SHALL define the enrichment payload as a single typed Go contract in
+`internal/enrich` whose fields and allowed values are the schema's source of
+truth. Every field SHALL be optional and omitted when not determined. Enum
+fields SHALL accept only their defined vocabulary values; `skills`, `cities`,
+`countries`, and `regions` SHALL be arrays; `skills` values SHALL be normalized
+lowercase tokens. The contract SHALL provide validation of a payload against the
+vocabularies.
+
+The contract SHALL capture a job's geographic area in a single `regions` field —
+an enum array of codes drawn from one controlled vocabulary that mixes levels:
+`global` (open anywhere), macro-regions (`eu`, `emea`, `eea`, `uk`, `americas`,
+`north_america`, `latam`, `apac`, `mena`, `africa`), and select countries treated
+as area codes (e.g. `us`, `ru`). `regions` denotes the geographic area of the job
+and is meaningful for any `work_mode` (for a remote role its reach, for an onsite
+role its office area); the prior restriction to remote roles is removed. There
+SHALL be no separate scope discriminator field: an absent/empty `regions` means
+*unknown*, and `global` is an explicit value (never inferred from the absence of
+other codes), so open-anywhere is distinct from unknown. Validation SHALL check
+each `regions` element against the vocabulary. The enrichment-derived `regions`,
+`countries`, and `work_mode` are an *additive* source: at read time they fold into
+the top-level job geography facet (see the job-geography capability) — geography by
+union, `work_mode` by precedence (the LLM value winning over the ingest one) —
+rather than being served as independent enrichment fields.
+
+#### Scenario: Payload round-trips through the typed contract
+
+- **WHEN** an `Enrichment` value (e.g. `seniority=senior`, `work_mode=remote`,
+  `regions=[eu]`, `skills=[go, postgresql]`) is marshalled to JSON, stored, read
+  back, and unmarshalled
+- **THEN** the resulting value equals the original
+
+#### Scenario: Undetermined fields are omitted, not zero-filled
+
+- **WHEN** an enrichment payload does not determine salary
+- **THEN** the `salary_min`, `salary_max`, `salary_currency`, and
+  `salary_period` keys are absent from the stored JSON rather than present with
+  zero/empty values
+
+#### Scenario: A value outside a vocabulary is reported invalid
+
+- **WHEN** the contract validates a payload whose `seniority` is `"sr"` (not a
+  defined value)
+- **THEN** validation reports the payload as invalid, identifying the offending
+  field
+
+#### Scenario: An out-of-vocabulary region is reported invalid
+
+- **WHEN** the contract validates a payload whose `regions` contains `"europe"`
+  (not a defined value)
+- **THEN** validation reports the payload as invalid, identifying the offending
+  `regions` field
+
+#### Scenario: Global reach is distinct from unknown reach
+
+- **WHEN** one job's enrichment has `regions=[global]`, and another's has empty
+  `regions`
+- **THEN** the two payloads are distinguishable: the first denotes open-anywhere,
+  the second denotes unknown
+
+### Requirement: The jobs read API exposes enrichment and provenance
+
+The system SHALL include `enrichment`, `enriched_at`, and `enrichment_version` in
+the job objects returned by the jobs read endpoints (`GET /api/v1/jobs`,
+`GET /api/v1/jobs/:id`, and jobs nested under a company). The public job object
+SHALL expose geography as top-level `regions` and `countries` fields (the union of
+the parsed-location columns and the enrichment-derived values) and `work_mode` as
+a top-level field (the LLM value when present, else the ingest-derived one); these
+fields SHALL NOT additionally appear as independent fields under `enrichment`. The
+public job object SHALL NOT include the raw `remote` boolean: the public notion of
+"remote" is expressed solely through the top-level `work_mode` (and the top-level
+geography for area), which subsume it. The `jobs.remote` column itself SHALL be
+retained as an internal enrichment input and SHALL NOT be removed.
+
+#### Scenario: Job detail includes enrichment and provenance
+
+- **WHEN** a client requests `GET /api/v1/jobs/:id` for an existing job
+- **THEN** the returned object under `data` includes `enrichment`,
+  `enriched_at`, and `enrichment_version` alongside the existing fields
+
+#### Scenario: Empty enrichment serializes as an object
+
+- **WHEN** a job that has not been enriched is returned by a read endpoint
+- **THEN** its `enrichment` is serialized as an empty object (`{}`), not null
+
+#### Scenario: Geography and work mode are served top-level, not duplicated under enrichment
+
+- **WHEN** a client reads a job whose enrichment contained
+  `regions`/`countries`/`work_mode`
+- **THEN** the returned object carries top-level `regions`/`countries`/`work_mode`
+  and its `enrichment` object does not separately repeat those fields
+
+#### Scenario: The raw remote flag is absent from the public job object
+
+- **WHEN** a client requests any jobs read endpoint
+- **THEN** the returned job objects do not contain a top-level `remote` field

--- a/openspec/changes/ingest-job-geography/specs/job-geography/spec.md
+++ b/openspec/changes/ingest-job-geography/specs/job-geography/spec.md
@@ -1,0 +1,167 @@
+## ADDED Requirements
+
+### Requirement: Job geography is derived deterministically from the location string
+
+The system SHALL provide a deterministic parser that maps a job's free-text
+`location` string to a set of ISO 3166-1 alpha-2 country codes and a set of
+region codes. The parser SHALL tokenize the location on the separators `,`, `;`,
+`/`, `|`, ` - `, and ` or `, and resolve each token against curated dictionaries:
+country/city/shorthand names to country codes, macro-region names to region
+codes, and country codes to their region. It SHALL emit only values present in
+the controlled vocabularies (see below), deduplicated, and SHALL emit nothing for
+tokens it cannot resolve (it never guesses). A bare remote marker (e.g. `Remote`)
+with no geographic token SHALL yield empty geography; the `global` region SHALL be
+emitted only from an explicit open-anywhere marker (e.g. `Anywhere`, `Worldwide`,
+`Global`), never inferred from a bare `Remote`.
+
+The parser SHALL also derive a `work_mode` hint from an explicit marker in the
+location string — `remote`, `hybrid`, or `onsite` — checked in priority order
+hybrid > remote > onsite (the most specific arrangement wins when several markers
+co-occur). A location with no work-mode marker SHALL yield an empty work_mode (a
+bare city is never assumed to be onsite). The marker scan is independent of the
+geography tokens, so a bare `Remote` yields `work_mode=remote` with empty geography.
+
+#### Scenario: A named country yields its code and region
+
+- **WHEN** the location `Remote - Germany` is parsed
+- **THEN** the countries are `[de]` and the regions include `eu`
+
+#### Scenario: A bare remote marker yields a work mode but no geography
+
+- **WHEN** the location `Remote` is parsed
+- **THEN** the work_mode is `remote` and both countries and regions are empty
+
+#### Scenario: Work mode marker priority
+
+- **WHEN** a location names both a hybrid and a remote marker (e.g.
+  `Hybrid / Remote - London`)
+- **THEN** the work_mode is `hybrid`
+
+#### Scenario: A macro region name yields a region without a country
+
+- **WHEN** the location `Remote - Europe` is parsed
+- **THEN** the regions are `[eu]` and the countries are empty
+
+#### Scenario: Multiple locations union into the result
+
+- **WHEN** the location `Remote - UK or Europe` is parsed
+- **THEN** the countries are `[gb]` and the regions include both `uk` and `eu`
+
+#### Scenario: A bare remote marker yields no geography
+
+- **WHEN** the location `Remote` is parsed
+- **THEN** both countries and regions are empty
+
+#### Scenario: An explicit open-anywhere marker yields global
+
+- **WHEN** the location `Remote - Anywhere` is parsed
+- **THEN** the regions are `[global]`
+
+#### Scenario: An unresolvable location yields no geography
+
+- **WHEN** the location is a token absent from every dictionary
+- **THEN** both countries and regions are empty rather than a guessed value
+
+### Requirement: Geography output uses controlled vocabularies
+
+Region codes emitted by the parser SHALL be drawn from the same controlled
+vocabulary the enrichment contract defines for `regions` (`global`, the
+macro-regions, and the select reach-area country codes), so the parser, the
+enrichment contract, and the search facet share one set of values. Country codes
+SHALL be ISO 3166-1 alpha-2. The `work_mode` hint SHALL be a member of the
+enrichment contract's `work_mode` vocabulary (`remote`, `hybrid`, `onsite`) or
+empty. A value outside these vocabularies SHALL never be emitted.
+
+#### Scenario: Parser output validates against the controlled vocabularies
+
+- **WHEN** any location string is parsed
+- **THEN** every emitted region is a member of the controlled region vocabulary,
+  every emitted country is a valid ISO 3166-1 alpha-2 code, and the work_mode is
+  a member of the work-mode vocabulary or empty
+
+### Requirement: Job geography is stored on jobs and unioned with enrichment geography at read time
+
+The system SHALL store the parsed geography in `jobs` columns `countries` and
+`regions` (text arrays, default empty) and `work_mode` (text, default empty), as
+source facts — distinct from the AI-derived `enrichment` payload. The public read
+model SHALL compute a job's geography as the union of these columns with the
+`enrichment.regions`/`enrichment.countries` the enrichment worker produced,
+deduplicated. The union SHALL be computed at read time; it SHALL NOT be
+materialized into the database, so the ingest and enrichment write paths stay
+decoupled.
+
+#### Scenario: Ingest-derived and enrichment-derived geography are unioned
+
+- **WHEN** a job has `regions=[eu]` from its parsed location and
+  `enrichment.regions=[emea]` from enrichment, and is read
+- **THEN** its geography regions are the deduplicated union `[eu, emea]`
+
+#### Scenario: A job with only parsed geography still reports it
+
+- **WHEN** an unenriched job has `regions=[us]` from its parsed location and is read
+- **THEN** its geography regions are `[us]`
+
+### Requirement: Work mode is resolved by precedence across sources
+
+`work_mode` is a scalar, so it SHALL be resolved by precedence, not union. At
+ingest the adapter's STRUCTURED work mode (a workplace-type enum or explicit
+remote flag from the ATS) SHALL take precedence over the parser's free-text
+heuristic, and the result SHALL be stored in `jobs.work_mode`. At read time the
+LLM-derived `enrichment.work_mode` SHALL take precedence over the stored
+`jobs.work_mode`, since the LLM reads the whole description. The net order, most
+authoritative first, is LLM, then adapter-structured, then parsed location.
+
+#### Scenario: Structured adapter work mode beats the parser
+
+- **WHEN** an adapter reports a structured `work_mode=hybrid` for a posting whose
+  location text would parse as `remote`
+- **THEN** the stored `jobs.work_mode` is `hybrid`
+
+#### Scenario: The LLM work mode beats the ingest value at read time
+
+- **WHEN** a job has `jobs.work_mode=onsite` from ingest and
+  `enrichment.work_mode=remote` from the LLM, and is read
+- **THEN** the resolved top-level `work_mode` is `remote`
+
+#### Scenario: The ingest value fills when the LLM did not state work mode
+
+- **WHEN** a job has `jobs.work_mode=hybrid` and no enrichment work_mode, and is read
+- **THEN** the resolved top-level `work_mode` is `hybrid`
+
+### Requirement: The public job object exposes geography and work mode as a top-level facet
+
+The public job object SHALL expose geography as top-level `regions` and
+`countries` fields carrying the union, and `work_mode` as a top-level field
+carrying the resolved value, each reported exactly once. The
+`enrichment.regions`, `enrichment.countries`, and `enrichment.work_mode` fields
+SHALL NOT additionally appear as independent fields in the served object; their
+values fold into the top-level facet. The stored `enrichment` JSONB SHALL be left
+untouched (the enrichment worker's data is preserved).
+
+#### Scenario: Geography and work mode appear once, at the top level
+
+- **WHEN** a client reads a job whose enrichment contained `regions` and `work_mode`
+- **THEN** the returned object carries top-level `regions`/`countries`/`work_mode`
+  and does not separately repeat those fields under `enrichment`
+
+### Requirement: Existing jobs are backfilled with parsed geography
+
+The system SHALL provide a run-once command that parses the stored `location` of
+every existing job and writes the resulting `countries`/`regions`/`work_mode`, so
+the location-derived facets are populated for rows that predate this change,
+including closed jobs that never re-crawl. The backfill SHALL be idempotent —
+re-running it converges to the same result. Because the original structured ATS
+signal is not available at backfill time, the backfill SHALL fill `work_mode` from
+the parsed location only when the row's `work_mode` is empty, preserving any value
+already set (a later re-crawl refreshes it with the structured value).
+
+#### Scenario: Backfill populates an existing row from its location
+
+- **WHEN** the backfill runs over a job whose `location` is `Remote - USA` and
+  whose geography columns are empty
+- **THEN** the job's `countries` becomes `[us]` and its `regions` include `us`
+
+#### Scenario: Backfill is idempotent
+
+- **WHEN** the backfill is run twice over the same jobs
+- **THEN** the second run produces the same geography as the first

--- a/openspec/changes/ingest-job-geography/specs/job-search/spec.md
+++ b/openspec/changes/ingest-job-geography/specs/job-search/spec.md
@@ -1,0 +1,95 @@
+## MODIFIED Requirements
+
+### Requirement: Searchable jobs index
+
+The system SHALL maintain a Meilisearch index of jobs with one document per job,
+keyed by the job's internal `id`. Each document SHALL carry the fields needed to
+both match and render a result without a follow-up database read: the searchable
+text (title, company, description, location), the filterable facets, the
+sortable fields, and the display fields returned to clients.
+
+The index SHALL declare:
+- **searchable attributes**: title, company, description, location.
+- **filterable attributes**: source, company_slug, work_mode, employment_type,
+  seniority, category, domains, regions, countries, company_type, company_size,
+  visa_sponsorship, salary_currency, salary_period, skills, salary_min,
+  salary_max, experience_years_min. The raw `remote` flag SHALL NOT be a
+  filterable attribute (work_mode subsumes it).
+- **sortable attributes**: posted_at, salary_min, salary_max.
+
+Geography and work mode are filtered through the document's **top-level**
+`regions`, `countries`, and `work_mode` fields — the resolved union/precedence of
+the location-derived columns and the enrichment-derived values — not through the
+`enrichment.*` dot paths. There SHALL be no separate
+`enrichment.regions`/`enrichment.countries`/`enrichment.work_mode` facet on the
+document.
+
+Facets derived from a job's `enrichment` JSONB SHALL be absent (or empty) on the
+document when the job is not yet enriched; an unenriched job SHALL still be
+indexed and findable by its text fields, and SHALL still carry any geography
+parsed from its location.
+
+#### Scenario: A job is represented as one searchable document
+
+- **WHEN** a job with title "Senior Go Developer", company "Acme", and a
+  description is indexed
+- **THEN** the `jobs` index holds one document keyed by that job's `id` whose
+  searchable text includes the title, company, and description
+
+#### Scenario: Unenriched job is still indexed with its parsed geography
+
+- **WHEN** a job with no enrichment but location `Remote - USA` is indexed
+- **THEN** the document is present and matchable by its text, with its
+  enrichment-derived facets absent or empty and its top-level `regions`/
+  `countries` carrying the parsed geography
+
+#### Scenario: Geography is filterable via the top-level regions facet
+
+- **WHEN** a job whose unioned geography includes `eu` is indexed
+- **THEN** it is returned by a filter on `regions = "eu"`
+
+### Requirement: Public job search endpoint
+
+The system SHALL expose `GET /api/v1/jobs/search` as a public (unauthenticated)
+endpoint. It SHALL accept a free-text query `q`, facet filters matching the
+index's filterable attributes, an optional sort, an optional semantic ratio, and
+`limit`/`offset` pagination. Facet filters SHALL include `regions` (the geography
+facet) and SHALL NOT include the removed raw `remote` filter. The response SHALL
+use the standard list envelope `{"data": [...], "meta": {...}}`, where `data` is
+the matched job documents and `meta` carries at least the estimated total hit
+count and the applied `limit`/`offset`. The existing `GET /api/v1/jobs` list
+endpoint SHALL be unchanged.
+
+Each result SHALL identify its job by `public_slug` and SHALL NOT include the
+internal numeric `id`, consistent with the public-identity contract used by the
+other public job reads.
+
+#### Scenario: Keyword query returns matches
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=golang`
+- **THEN** the response is `{"data": [...], "meta": {...}}` with jobs matching
+  "golang" in `data` and the estimated total and pagination in `meta`
+
+#### Scenario: Faceted filtering by region
+
+- **WHEN** a client requests
+  `GET /api/v1/jobs/search?q=engineer&seniority=senior&regions=eu`
+- **THEN** only jobs whose facets satisfy seniority=senior AND whose top-level
+  `regions` include `eu` are returned
+
+#### Scenario: Empty query browses with filters
+
+- **WHEN** a client requests `GET /api/v1/jobs/search` with filters but no `q`
+- **THEN** the filtered jobs are returned ranked by the index defaults
+
+#### Scenario: Pagination is reflected in meta
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=go&limit=10&offset=20`
+- **THEN** at most 10 documents are returned and `meta` reports the applied
+  `limit` 10 and `offset` 20 alongside the estimated total
+
+#### Scenario: Results identify jobs by public slug, not internal id
+
+- **WHEN** a job is returned by `GET /api/v1/jobs/search`
+- **THEN** the result carries the job's `public_slug` and omits the internal
+  numeric `id`

--- a/openspec/changes/ingest-job-geography/specs/source-ingest/spec.md
+++ b/openspec/changes/ingest-job-geography/specs/source-ingest/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Ingest persists job geography and work mode
+
+The ingest write path SHALL parse each posting's `location` string into
+`countries`/`regions`/`work_mode` (via the job-geography parser) and persist them
+on the job row. These columns SHALL be written on insert and refreshed on
+re-ingest, like the other raw source fields and unlike the enrichment payload
+(which ingest never writes). A posting whose location yields no geography SHALL
+store empty arrays.
+
+For `work_mode`, when the adapter exposes a STRUCTURED work mode (a workplace-type
+enum or an explicit remote flag from the ATS API) it SHALL take precedence over
+the parser's free-text heuristic; the parser fills `work_mode` only when the
+adapter has no structured signal.
+
+#### Scenario: A new posting stores its parsed geography
+
+- **WHEN** a posting with location `Remote - Germany` is ingested
+- **THEN** the stored job has `countries=[de]` and `regions` including `eu`
+
+#### Scenario: Re-ingest refreshes geography from the updated location
+
+- **WHEN** an already-ingested posting is re-ingested with its location changed
+  from `Remote - UK` to `Remote - USA`
+- **THEN** the job's `countries` updates to `[us]` and its `regions` update
+  accordingly
+
+#### Scenario: A location with no geography stores empty arrays
+
+- **WHEN** a posting with location `Remote` is ingested
+- **THEN** the stored job has empty `countries` and empty `regions`
+
+#### Scenario: A structured adapter work mode is persisted over the parsed one
+
+- **WHEN** an adapter reports a structured `work_mode` (e.g. Lever's
+  `workplaceType=hybrid`) for a posting whose location parses as `remote`
+- **THEN** the stored `jobs.work_mode` is the structured value `hybrid`

--- a/openspec/changes/ingest-job-geography/tasks.md
+++ b/openspec/changes/ingest-job-geography/tasks.md
@@ -1,0 +1,81 @@
+## 1. Location parser (`internal/location`)
+
+- [x] 1.1 Write table tests for `location.Parse` covering real prod strings:
+  `Remote - Germany`, `Remote - Europe`, `Remote - UK or Europe`, `Remote`,
+  `Remote - Anywhere`, `Burlington, Massachusetts, United States; Remote`,
+  `United States`, empty, and an unresolvable token (RED).
+- [x] 1.2 Implement `Parse(location string) (countries, regions []string)` with the
+  three dictionaries (name→country, name→region, country→region drawn from
+  `enrich.RegionValues`), tokenization on `, ; / | " - " " or "`, dedup, and the
+  "never guess / global only on explicit anywhere" rules (GREEN).
+- [x] 1.3 Seed the dictionaries from the high-frequency prod location strings; add a
+  test asserting every emitted region ∈ `RegionValues` and every country is ISO
+  alpha-2.
+- [x] 1.4 Extend `Parse` to return a `Geo` struct that also carries a `WorkMode`
+  hint detected from explicit markers (remote/hybrid/onsite, priority
+  hybrid>remote>onsite); guard it against `enrich.WorkModeValues`.
+
+## 2. Schema + DB access
+
+- [x] 2.1 Add migration: `jobs.countries text[] NOT NULL DEFAULT '{}'`,
+  `jobs.regions text[] NOT NULL DEFAULT '{}'` (follow existing `migrations/`
+  numbering).
+- [x] 2.2 Update `UpsertJob` in `internal/db/queries/jobs.sql` to write `countries`
+  and `regions` in INSERT and in `ON CONFLICT DO UPDATE SET`.
+- [x] 2.3 Add `SetJobLocation` query (set `countries`/`regions` by id) for the
+  backfill path.
+- [x] 2.4 Run `make sqlc` and commit the regenerated `internal/db`.
+- [x] 2.5 Add `jobs.work_mode TEXT NOT NULL DEFAULT ''` to the same migration;
+  write it in `UpsertJob` and `SetJobLocation`.
+
+## 3. Ingest write path
+
+- [x] 3.1 Add `Countries`/`Regions`/`WorkMode` to `pipeline.Job`; have
+  `normalizeJob` call `location.Parse(j.Location)` (RED test on `normalizeJob`).
+- [x] 3.2 Thread the new fields through the `Store.Save` implementation into
+  `UpsertJob`; verify a re-ingest refreshes geography.
+- [x] 3.3 Add structured `WorkMode` to `sources.Job`; populate it from the ATS
+  structured fields (ashby/recruitee/smartrecruiters/workable remote flag →
+  "remote"; lever `workplaceType` → mapped). Helpers + adapter/helper tests.
+- [x] 3.4 `normalizeJob` work-mode precedence: adapter-structured ?? parser
+  (RED test first).
+
+## 4. Read-time merge (`internal/jobview`)
+
+- [x] 4.1 Add top-level `Regions`, `Countries`, `WorkMode` to `jobview.Job`;
+  `FromRow` unions `jobs.regions ∪ enrichment.regions` (and countries) deduped,
+  sets `WorkMode = enrichment.work_mode ?? jobs.work_mode`, then blanks the
+  folded `enrichment.regions/countries/work_mode` in the served copy (RED tests
+  for union, dedup, work-mode precedence, and blanking first).
+
+## 5. Search
+
+- [x] 5.1 Update the index settings: filterable attributes use top-level
+  `regions`/`countries`/`work_mode`, not the `enrichment.*` dot-paths; remove the
+  folded enrichment geography/work_mode facets.
+- [x] 5.2 Update the search handler's region/country/work_mode filters to build
+  against the top-level path; adjust `internal/search` document/filter tests.
+
+## 6. Enrichment prompt
+
+- [x] 6.1 Update the `regions` block in `internal/enrich/langchain.go`
+  `buildSystemPrompt` to describe `regions` as geographic area for any work mode
+  (drop "only when remote"); adjust the prompt test if it asserts that wording.
+
+## 7. Web SPA
+
+- [x] 7.1 Map the SPA region/work_mode filter query-params to the top-level
+  fields; verify via `svelte-check` + lint (no SPA test runner).
+
+## 8. Backfill
+
+- [x] 8.1 Add run-once `cmd/backfill-geo`: keyset scan via `ListJobsByIDAfter`,
+  `location.Parse`, write countries/regions/work_mode via `SetJobLocation`
+  (work_mode is parser-only at backfill; re-crawl later refreshes structured);
+  idempotent and safe to re-run.
+
+## 9. Verification
+
+- [x] 9.1 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 9.2 Manually confirm the migration → deploy → backfill → reindex order is
+  documented (design Migration Plan) and the reindex step is noted for ops.

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -79,7 +79,7 @@
   {@const posted = formatDate(job.posted_at)}
   {@const e = job.enrichment ?? {}}
   {@const salary = formatSalary(e)}
-  {@const facets = summaryFacets(e)}
+  {@const facets = summaryFacets(job)}
   <article class="flex flex-col gap-6">
     <header class="flex flex-col gap-4">
       <div class="flex items-start justify-between gap-4">

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -3,7 +3,7 @@
 // Unknown codes fall back to a humanized form so a future vocabulary addition
 // never renders blank — the SPA never re-validates, it only formats.
 
-import type { Enrichment } from './types';
+import type { Enrichment, Job } from './types';
 
 /** A single label/value pair in the summary meta-row. */
 export interface Facet {
@@ -34,7 +34,7 @@ const WORK_MODE: Record<string, string> = {
   onsite: 'On-site',
 };
 
-// Reach codes (enrichment.regions) → readable labels. Unmapped codes humanize.
+// Region codes (the top-level `regions` facet) → readable labels. Unmapped codes humanize.
 const REGION: Record<string, string> = {
   global: 'Global',
   eu: 'Europe',
@@ -151,38 +151,38 @@ export function formatSalary(e: Enrichment): string | null {
 }
 
 /**
- * The work-arrangement label for compact contexts (list cards): the enriched
- * `work_mode`, or null when unenriched. "Remote" is purely an enrichment concept
- * now — there is no raw flag to fall back to.
+ * The work-arrangement label for compact contexts (list cards): the resolved
+ * top-level `work_mode` (LLM value, else the one parsed from the location), or
+ * null when neither stated it.
  */
-export function workArrangement(job: { enrichment?: Enrichment }): string | null {
-  const mode = job.enrichment?.work_mode;
-  return mode ? label(WORK_MODE, mode) : null;
+export function workArrangement(job: Pick<Job, 'work_mode'>): string | null {
+  return job.work_mode ? label(WORK_MODE, job.work_mode) : null;
 }
 
 /**
- * A remote role's geographic reach as a concise label from `regions` — e.g.
- * `Global`, `Europe`, `USA`. Null when the job is not a known remote role or its
- * reach is unknown (empty `regions` is unknown, not global).
+ * The job's geographic area as a concise label from the top-level `regions` —
+ * e.g. `Global`, `Europe`, `USA`. Meaningful for any work mode (a remote role's
+ * reach or an onsite role's area). Null when regions is unknown (empty is
+ * unknown, not global).
  */
-export function remoteReach(e: Enrichment | undefined): string | null {
-  if (!e || e.work_mode !== 'remote' || !e.regions?.length) return null;
-  return e.regions.map((r) => label(REGION, r)).join(', ');
+export function regionLabel(job: Pick<Job, 'regions'>): string | null {
+  if (!job.regions?.length) return null;
+  return job.regions.map((r) => label(REGION, r)).join(', ');
 }
 
 /**
- * The short tag row shown on a list card's header: work arrangement, primary
- * country, employment type, and grade — only those that are stated, in that
- * order. Compact by design (the full facet set lives on the detail page).
+ * The short tag row shown on a list card's header: work arrangement, region,
+ * employment type, and grade — only those that are stated, in that order.
+ * Compact by design (the full facet set lives on the detail page).
  */
-export function cardTags(job: { enrichment?: Enrichment }): string[] {
+export function cardTags(job: Job): string[] {
   const e = job.enrichment;
   const tags: string[] = [];
 
   const arrangement = workArrangement(job);
   if (arrangement) tags.push(arrangement);
-  const reach = remoteReach(e);
-  if (reach) tags.push(reach);
+  const region = regionLabel(job);
+  if (region) tags.push(region);
   if (e?.employment_type) tags.push(label(EMPLOYMENT, e.employment_type));
   if (e?.seniority) tags.push(label(SENIORITY, e.seniority));
 
@@ -195,14 +195,15 @@ export function cardTags(job: { enrichment?: Enrichment }): string[] {
  * entirely. Order moves from work arrangement → role → eligibility → company,
  * mirroring the reference layout.
  */
-export function summaryFacets(e: Enrichment): Facet[] {
+export function summaryFacets(job: Job): Facet[] {
+  const e = job.enrichment ?? {};
   const facets: Facet[] = [];
   const push = (name: string, value: string | null | undefined) => {
     if (value) facets.push({ label: name, value });
   };
 
-  push('Work format', e.work_mode && label(WORK_MODE, e.work_mode));
-  push('Reach', remoteReach(e));
+  push('Work format', job.work_mode && label(WORK_MODE, job.work_mode));
+  push('Region', regionLabel(job));
   push('Work type', e.employment_type && label(EMPLOYMENT, e.employment_type));
   push('Grade', e.seniority && label(SENIORITY, e.seniority));
   push(
@@ -214,7 +215,7 @@ export function summaryFacets(e: Enrichment): Facet[] {
     e.english_level && e.english_level !== 'none' ? label(ENGLISH_LEVEL, e.english_level) : null,
   );
   push('Category', e.category && label(CATEGORY, e.category));
-  push('Country', e.countries?.length ? e.countries.map((c) => c.toUpperCase()).join(', ') : null);
+  push('Country', job.countries?.length ? job.countries.map((c) => c.toUpperCase()).join(', ') : null);
   push('Relocation', e.relocation && label(RELOCATION, e.relocation));
   push('Visa', e.visa_sponsorship === true ? 'Sponsored' : null);
   push('Company', e.company_type && label(COMPANY_TYPE, e.company_type));

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -19,6 +19,13 @@ export interface Job {
   // Non-null when the posting is no longer open. Lists never serve closed
   // jobs; the detail page renders the closed state from this field.
   closed_at: string | null;
+  // Resolved geography facet, served top-level: the union of the parsed-location
+  // columns and the enrichment-derived values. work_mode is the LLM value when
+  // present, else the one parsed from the location. regions is the job's
+  // geographic area (any work mode); empty = unknown, 'global' is explicit.
+  regions?: string[];
+  countries?: string[];
+  work_mode?: string;
   enrichment?: Enrichment;
   enriched_at?: string | null;
   enrichment_version?: number;
@@ -31,17 +38,13 @@ export interface Job {
  * validated server-side before storage, so the SPA only formats them.
  */
 export interface Enrichment {
-  // Work arrangement.
-  work_mode?: string;
+  // Work arrangement. work_mode, regions, and countries are NOT here: they are
+  // folded into the top-level Job geography facet (see Job above) and served once.
   employment_type?: string;
   relocation?: string;
   visa_sponsorship?: boolean;
 
-  // Location / eligibility. regions is a remote role's reach (meaningful only
-  // when work_mode is remote): 'global' + macro-regions + select countries.
-  // Empty = unknown; 'global' is explicit, distinct from unknown.
-  regions?: string[];
-  countries?: string[];
+  // Location / eligibility.
   cities?: string[];
   timezone_note?: string;
 


### PR DESCRIPTION
## Why

Geography is the most-used job filter, yet nearly empty: only **4%** of jobs are enriched and just **16%** of remote ones carried a region — even though prod data shows ~**90%** of those state the country in the structured `location` field (`Remote - USA`, `Remote - UK`, …). The LLM under-extracts it under its conservative *"never guess"* prompt, and it only covers the 4% enriched anyway.

This derives geography **deterministically at ingest** — reliable, 100% coverage, zero LLM latency — with the LLM as an additive source.

## What

- **`internal/location`** — curated parser: location string → ISO alpha-2 `countries`, region codes (from `enrich.RegionValues`), and a `work_mode` hint (explicit marker only, priority hybrid>remote>onsite).
- **Boards** — adapters expose a **structured** `work_mode` where the ATS API has one (ashby/recruitee/smartrecruiters/workable remote flag; lever `workplaceType`); the parser is the free-text fallback.
- **Schema `0011`** — `jobs.countries/regions/work_mode`; `UpsertJob` writes them, new `SetJobLocation` backfills.
- **`jobview`** — geography resolved at **read time**: countries/regions **union** both sources (case-folded — the LLM emits country codes uppercase), `work_mode` by **precedence** (LLM > adapter-structured > parser); served **top-level once**, folded out of the enrichment object.
- **search / SPA** — region/country/work_mode facets move to the top-level fields.
- **enrich prompt** — `regions` redefined as the job's **geographic area** (any work mode).
- **`cmd/backfill-geo`** — one-off fill for existing rows (preserves a structured `work_mode`, fills only empty ones).

⚠️ **BREAKING** for the `regions` facet semantics (remote-reach → geographic area).

## Deploy order

`migrate` (manual on prod — initdb only runs once) → deploy → `cmd/backfill-geo` → `reindex` (filterable attributes changed).

## Verification

- TDD throughout; `go build/vet ./...`, full unit suite, and `internal/db` integration tests (testcontainers) green; `svelte-check` 0 errors.
- Code review (5 finder angles + verify): fixed a confirmed country-case facet split (LLM `US` vs parser `us`), `gofmt`, single-pass tokenizer, and added an exhaustive dictionary↔vocabulary guard test.
- Also fixes a stale `CloseUnseenJobs` call that left the db integration suite uncompilable.

Spec: `openspec/changes/ingest-job-geography/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)