### PR TITLE
build: compile cmd/backfill-geo into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reindex ./cmd/reindex \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-ingest ./cmd/tg-ingest \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-extract ./cmd/tg-extract \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reslug ./cmd/reslug
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reslug ./cmd/reslug \
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-geo ./cmd/backfill-geo
 
 # --- runtime stage ---
 FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /app
-COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /app/
+COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-geo /app/
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/app/hire"]


### PR DESCRIPTION
Follow-up to #19: the geography backfill is a run-once worker, so the Docker image must build and carry the `backfill-geo` binary for `docker compose run --rm backfill-geo` on prod. Mirrors the existing `reslug` wiring.