### PR TITLE
geo: add cis + central_asia regions for the RU/CIS Telegram segment

### DIFF
--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -69,11 +69,15 @@ type Enrichment struct {
 // no bundled closed vocabulary here and are not enum-validated in this phase.
 var (
 	WorkModeValues = []string{"remote", "hybrid", "onsite"}
-	// RegionValues is the remote-reach vocabulary: global, macro-regions, and a few
-	// countries treated as reach areas (extend as the curated facet grows).
+	// RegionValues is the geographic-area vocabulary: global, macro-regions, and a
+	// few countries treated as area codes (extend as the curated facet grows).
+	// `cis` (post-Soviet space: Belarus, Moldova, the Caucasus) and `central_asia`
+	// (the five Central Asian republics) cover the RU/CIS segment that dominates
+	// the Telegram sources; `ru` stays its own area.
 	RegionValues = []string{
 		"global", "eu", "emea", "eea", "uk", "americas",
 		"north_america", "latam", "apac", "mena", "africa", "us", "ru",
+		"cis", "central_asia",
 	}
 	EmploymentTypeValues = []string{"full_time", "part_time", "contract", "internship"}
 	RelocationValues     = []string{"not_supported", "supported", "required"}

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -22,6 +22,11 @@ var regionCountries = map[string][]string{
 	"mena":          {"ae", "sa", "il", "eg", "tr", "qa"},
 	"africa":        {"za", "ng", "ke"},
 	"ru":            {"ru"},
+	// CIS / Central Asia — the RU-segment geography of the Telegram sources.
+	// central_asia is the five republics; cis is the rest of the post-Soviet
+	// space (Belarus, Moldova, the Caucasus). ru keeps its own area; ua stays eu.
+	"central_asia": {"uz", "kz", "kg", "tj", "tm"},
+	"cis":          {"by", "md", "am", "az", "ge"},
 }
 
 // countryToRegion is the inverted regionCountries: ISO code -> region code.
@@ -71,6 +76,20 @@ var nameToCountry = map[string]string{
 	"israel": "il", "tel aviv": "il",
 	"united arab emirates": "ae", "dubai": "ae",
 	"south africa": "za",
+	// RU / CIS / Central Asia. "georgia" is deliberately absent — it collides with
+	// the US state; the country resolves via its capital "tbilisi" only.
+	"russia": "ru", "moscow": "ru", "saint petersburg": "ru", "st petersburg": "ru",
+	"kyiv": "ua", "kiev": "ua",
+	"uzbekistan": "uz", "tashkent": "uz", "toshkent": "uz", "samarkand": "uz",
+	"kazakhstan": "kz", "almaty": "kz", "astana": "kz", "nur-sultan": "kz",
+	"kyrgyzstan": "kg", "bishkek": "kg",
+	"tajikistan": "tj", "dushanbe": "tj",
+	"turkmenistan": "tm", "ashgabat": "tm",
+	"belarus": "by", "minsk": "by",
+	"moldova": "md", "chisinau": "md",
+	"armenia": "am", "yerevan": "am",
+	"azerbaijan": "az", "baku": "az",
+	"tbilisi": "ge",
 }
 
 // nameToRegion resolves macro-region names (and explicit open-anywhere markers)
@@ -83,6 +102,7 @@ var nameToRegion = map[string]string{
 	"north america": "north_america",
 	"latam":         "latam", "latin america": "latam", "south america": "latam",
 	"mena": "mena", "middle east": "mena",
-	"africa":   "africa",
+	"africa": "africa",
+	"cis":    "cis", "central asia": "central_asia",
 	"anywhere": "global", "worldwide": "global", "global": "global", "remote anywhere": "global",
 }

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -70,6 +70,26 @@ func TestParse(t *testing.T) {
 			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
 		},
 		{
+			name:     "Central Asia: Uzbek district, city, country (Uzbek spelling)",
+			location: "Yunusobod, Toshkent, Uzbekistan",
+			want:     Geo{Countries: []string{"uz"}, Regions: []string{"central_asia"}},
+		},
+		{
+			name:     "Central Asia: remote Kazakhstan",
+			location: "Remote - Kazakhstan",
+			want:     Geo{Countries: []string{"kz"}, Regions: []string{"central_asia"}, WorkMode: "remote"},
+		},
+		{
+			name:     "CIS: Baku via city and country",
+			location: "Baku, Azerbaijan",
+			want:     Geo{Countries: []string{"az"}, Regions: []string{"cis"}},
+		},
+		{
+			name:     "country-only Georgia is the US state, not the country (no false ge)",
+			location: "Atlanta, Georgia, United States",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
 			name:     "empty location",
 			location: "",
 			want:     Geo{},

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -49,6 +49,8 @@ const REGION: Record<string, string> = {
   africa: 'Africa',
   us: 'USA',
   ru: 'Russia',
+  cis: 'CIS',
+  central_asia: 'Central Asia',
 };
 
 const RELOCATION: Record<string, string> = {

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -61,6 +61,8 @@ const SOURCE: FacetOption[] = [
 const REGION: FacetOption[] = [
   { value: 'global', label: 'Global' },
   { value: 'ru', label: 'Russia' },
+  { value: 'cis', label: 'CIS' },
+  { value: 'central_asia', label: 'Central Asia' },
   { value: 'eu', label: 'Europe' },
   { value: 'us', label: 'USA' },
 ];


### PR DESCRIPTION
The Telegram sources are RU/CIS/Central-Asia heavy (Tashkent dominates), but the location dictionary AND the region vocabulary were Western-ATS-centric, so those jobs resolved ~5% geography.

- `enrich.RegionValues` += `cis`, `central_asia` (contract change — prompt + search facet pick them up automatically).
- `internal/location` dictionaries += CIS/Central-Asian countries + beacon cities (incl. the Uzbek spelling **Toshkent** from prod). `georgia` omitted (US-state collision) → country via `tbilisi` only; `ua`→eu and `ru`→ru unchanged.
- SPA: region labels + filter pills for CIS / Central Asia.

TDD; Go build/vet/test + svelte-check green. Applies to existing rows via `backfill-geo`; no `enrich.Version` bump.