### PR TITLE
auth: /auth/me accepts an API key (whoami)

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -115,13 +115,15 @@ func Register(app *fiber.App, pool *pgxpool.Pool, frontendOrigin, jwtSecret stri
 	api.Get("/me/api-keys", auth.RequireAuth(h.issuer), h.ListAPIKeys)
 	api.Delete("/me/api-keys/:id", auth.RequireAuth(h.issuer), h.RevokeAPIKey)
 
-	// Auth: register/login/logout are public (logout just clears the cookie);
-	// me is guarded by the auth-cookie check.
+	// Auth: register/login/logout are public (logout just clears the cookie).
+	// me is guarded and accepts a session cookie OR an API key, so a non-browser
+	// client (e.g. the CLI) can resolve its own identity with its key. It stays a
+	// read of the caller's own user — not key management, which is cookie-only.
 	authGroup := api.Group("/auth")
 	authGroup.Post("/register", h.Register)
 	authGroup.Post("/login", h.Login)
 	authGroup.Post("/logout", h.Logout)
-	authGroup.Get("/me", auth.RequireAuth(h.issuer), h.Me)
+	authGroup.Get("/me", auth.RequireAuthOrKey(h.issuer, h.queries), h.Me)
 
 	// OAuth sign-in: provider listing plus the authorization-code start and
 	// callback redirects. All public; the callback sets the session cookie.

--- a/internal/handler/me_via_key_integration_test.go
+++ b/internal/handler/me_via_key_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+// Integration test: GET /api/v1/auth/me authenticates by API key (Bearer), not
+// only the session cookie, so a key holder (e.g. the CLI) can resolve their own
+// identity (whoami). Built through handler.Register to exercise the real route
+// wiring. Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+)
+
+func TestAuthMe_AuthenticatesByAPIKey(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('whoami@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	token, hash, prefix, err := auth.GenerateAPIKey()
+	if err != nil {
+		t.Fatalf("GenerateAPIKey: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO api_keys (user_id, name, token_hash, token_prefix) VALUES ($1, 'cli', $2, $3)`,
+		userID, hash, prefix); err != nil {
+		t.Fatalf("seed api_key: %v", err)
+	}
+
+	app := fiber.New(fiber.Config{ErrorHandler: ErrorHandler})
+	Register(app, pool, "http://localhost", "test-secret", time.Hour, false, nil, nil)
+
+	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/auth/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (auth/me must accept an API key)", resp.StatusCode)
+	}
+
+	var body struct {
+		Data struct {
+			Email string `json:"email"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.Email != "whoami@example.test" {
+		t.Errorf("email = %q, want whoami@example.test", body.Data.Email)
+	}
+}

--- a/openspec/specs/user-auth/spec.md
+++ b/openspec/specs/user-auth/spec.md
@@ -106,16 +106,23 @@ cookie. It is public and idempotent.
 ### Requirement: Current user endpoint
 
 The system SHALL expose `GET /api/v1/auth/me` that returns the authenticated
-user's profile and is only reachable with a valid session cookie.
+user's profile. It is reachable with a valid session cookie OR an API key, so a
+non-browser client (e.g. the CLI) can resolve its own identity; it is a read of
+the caller's own user, not key management (which stays cookie-only).
 
-#### Scenario: Authenticated request
+#### Scenario: Authenticated by session cookie
 
-- **WHEN** an authenticated client calls `GET /api/v1/auth/me`
+- **WHEN** an authenticated client calls `GET /api/v1/auth/me` with a valid session cookie
 - **THEN** the system responds `200` with the user (id, email, created_at) and never includes the password hash
+
+#### Scenario: Authenticated by API key
+
+- **WHEN** a client calls `GET /api/v1/auth/me` with a valid `Authorization: Bearer <key>` and no cookie
+- **THEN** the system responds `200` with the key owner's user (id, email, created_at)
 
 #### Scenario: Unauthenticated request
 
-- **WHEN** a client calls `GET /api/v1/auth/me` without a valid session cookie
+- **WHEN** a client calls `GET /api/v1/auth/me` with neither a valid session cookie nor a valid API key
 - **THEN** the system responds `401`
 
 ### Requirement: Web client authentication


### PR DESCRIPTION
## Summary
- `GET /api/v1/auth/me` now authenticates by **session cookie OR API key** (`RequireAuthOrKey`), so a non-browser client (the upcoming `freehire` CLI) can resolve its own identity (id/email) with its key.
- It remains a read of the caller's own user — **key management stays cookie-only**.

## Test plan
- [x] Integration (via `Register`, testcontainers): `/auth/me` with a Bearer key → 200 + owner email
- [x] `go build/vet/test ./...` green
- [x] No migration; no DB change

🤖 Generated with [Claude Code](https://claude.com/claude-code)