### PR TITLE
tg: follow outbound post links into full vacancies (habr_career + remoteyeah)

### DIFF
--- a/cmd/tg-extract/main.go
+++ b/cmd/tg-extract/main.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/database"
+	"github.com/strelov1/freehire/internal/linksource"
+	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/telegram"
 )
 
@@ -57,6 +59,7 @@ func main() {
 		Extractor: extractor,
 		Store:     newExtractStore(pool),
 		Kinds:     kinds,
+		Links:     linkResolver{reg: linksource.All(sources.NewClient())},
 	}
 
 	stats, err := runner.Run(ctx)

--- a/cmd/tg-extract/resolver.go
+++ b/cmd/tg-extract/resolver.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+
+	"github.com/strelov1/freehire/internal/linksource"
+	"github.com/strelov1/freehire/internal/telegram"
+)
+
+// linkResolver adapts the linksource registry to telegram.LinkResolver: it follows a
+// post's links to full vacancies and maps each to a ResolvedJob carrying the destination
+// platform's source identity.
+type linkResolver struct {
+	reg []linksource.LinkSource
+}
+
+func (r linkResolver) Resolve(ctx context.Context, links []telegram.Link) ([]telegram.ResolvedJob, error) {
+	urls := make([]string, len(links))
+	for i, l := range links {
+		urls[i] = l.URL
+	}
+
+	resolved, err := linksource.ResolveLinks(ctx, r.reg, urls)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]telegram.ResolvedJob, len(resolved))
+	for i, rj := range resolved {
+		out[i] = telegram.ResolvedJob{
+			Source:      rj.Source,
+			ExternalID:  rj.Job.ExternalID,
+			URL:         rj.Job.URL,
+			Title:       rj.Job.Title,
+			Company:     rj.Job.Company,
+			Location:    rj.Job.Location,
+			Description: rj.Job.Description,
+			Remote:      rj.Job.Remote,
+			PostedAt:    rj.Job.PostedAt,
+			WorkMode:    rj.Job.WorkMode,
+		}
+	}
+	return out, nil
+}
+
+var _ telegram.LinkResolver = linkResolver{}

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -48,9 +49,22 @@ func (s *extractStore) Claim(ctx context.Context, leaseSeconds, batchSize int32)
 			MsgID:    r.MsgID,
 			Text:     r.Text,
 			PostedAt: r.PostedAt.Time,
+			Links:    decodeLinks(r.Links),
 		}
 	}
 	return posts, nil
+}
+
+// decodeLinks unmarshals the stored links JSON, tolerating an empty/legacy NULL column.
+func decodeLinks(b []byte) []telegram.Link {
+	if len(b) == 0 {
+		return nil
+	}
+	var links []telegram.Link
+	if err := json.Unmarshal(b, &links); err != nil {
+		return nil
+	}
+	return links
 }
 
 func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, jobs []telegram.ExtractedJob) error {
@@ -97,6 +111,64 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 		MsgID:   post.MsgID,
 	}); err != nil {
 		return fmt.Errorf("mark extracted %s: %w", base, err)
+	}
+	return tx.Commit(ctx)
+}
+
+// CompleteLinks writes link-resolved jobs — each under the destination platform's own
+// source identity — through the canonical UpsertJob + enrichment enqueue, and marks the
+// post extracted, all in one transaction. Same shape as Complete; the identity (source,
+// external_id, url) comes from the resolved job rather than the Telegram post.
+func (s *extractStore) CompleteLinks(ctx context.Context, post telegram.PendingPost, jobs []telegram.ResolvedJob) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.q.WithTx(tx)
+
+	for _, j := range jobs {
+		geo := location.Parse(j.Location)
+		workMode := j.WorkMode
+		if workMode == "" {
+			workMode = geo.WorkMode
+		}
+		postedAt := pgtype.Timestamptz{Time: post.PostedAt, Valid: true}
+		if j.PostedAt != nil {
+			postedAt = pgtype.Timestamptz{Time: *j.PostedAt, Valid: true}
+		}
+		saved, err := qtx.UpsertJob(ctx, db.UpsertJobParams{
+			Source:      j.Source,
+			ExternalID:  j.ExternalID,
+			URL:         j.URL,
+			Title:       j.Title,
+			Company:     j.Company,
+			CompanySlug: normalize.Slug(j.Company),
+			PublicSlug:  normalize.JobSlug(j.Title, j.Company, j.Source, j.ExternalID),
+			Location:    j.Location,
+			Remote:      j.Remote,
+			Description: j.Description,
+			PostedAt:    postedAt,
+			Countries:   geo.Countries,
+			Regions:     geo.Regions,
+			WorkMode:    workMode,
+		})
+		if err != nil {
+			return fmt.Errorf("upsert job %s/%s: %w", j.Source, j.ExternalID, err)
+		}
+		if _, err := qtx.EnqueueJobEnrichment(ctx, db.EnqueueJobEnrichmentParams{
+			TargetVersion: int32(enrich.Version),
+			JobID:         saved.ID,
+		}); err != nil {
+			return fmt.Errorf("enqueue enrichment %s/%s: %w", j.Source, j.ExternalID, err)
+		}
+	}
+
+	if err := qtx.MarkTelegramPostExtracted(ctx, db.MarkTelegramPostExtractedParams{
+		Channel: post.Channel,
+		MsgID:   post.MsgID,
+	}); err != nil {
+		return fmt.Errorf("mark extracted %s/%d: %w", post.Channel, post.MsgID, err)
 	}
 	return tx.Commit(ctx)
 }

--- a/cmd/tg-ingest/main.go
+++ b/cmd/tg-ingest/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 	"time"
@@ -16,6 +17,8 @@ import (
 	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/linksource"
+	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/telegram"
 )
 
@@ -47,6 +50,7 @@ func main() {
 		Fetcher: telegram.NewFetcher(),
 		Store:   &postStore{q: db.New(pool)},
 		Delay:   2 * time.Second, // polite pacing toward t.me
+		Links:   linkMatcher{reg: linksource.All(sources.NewClient())},
 	}
 
 	stats, err := runner.Run(ctx, chanCfg.Channels)
@@ -67,10 +71,19 @@ func (s *postStore) Insert(ctx context.Context, channel string, p telegram.Post,
 	if done {
 		extractedAt = pgtype.Timestamptz{Time: time.Now(), Valid: true}
 	}
+	links := []byte("[]")
+	if len(p.Links) > 0 {
+		if b, err := json.Marshal(p.Links); err == nil {
+			links = b
+		} else {
+			return false, err
+		}
+	}
 	rows, err := s.q.InsertTelegramPost(ctx, db.InsertTelegramPostParams{
 		Channel:     channel,
 		MsgID:       p.MsgID,
 		Text:        p.Text,
+		Links:       links,
 		PostedAt:    pgtype.Timestamptz{Time: p.PostedAt, Valid: true},
 		ExtractedAt: extractedAt,
 	})
@@ -81,3 +94,19 @@ func (s *postStore) Insert(ctx context.Context, channel string, p telegram.Post,
 }
 
 var _ telegram.PostStore = (*postStore)(nil)
+
+// linkMatcher adapts the linksource registry to telegram.LinkMatcher, so the crawl keeps
+// link-out digest posts whose teaser text alone does not look like a vacancy.
+type linkMatcher struct {
+	reg []linksource.LinkSource
+}
+
+func (m linkMatcher) Matches(links []telegram.Link) bool {
+	urls := make([]string, len(links))
+	for i, l := range links {
+		urls[i] = l.URL
+	}
+	return linksource.MatchesAny(m.reg, urls)
+}
+
+var _ telegram.LinkMatcher = linkMatcher{}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -75,6 +75,7 @@ type TelegramPost struct {
 	FailedAt    pgtype.Timestamptz `json:"failed_at"`
 	LastError   string             `json:"last_error"`
 	ExtractedAt pgtype.Timestamptz `json:"extracted_at"`
+	Links       []byte             `json:"links"`
 }
 
 type User struct {

--- a/internal/db/queries/telegram_posts.sql
+++ b/internal/db/queries/telegram_posts.sql
@@ -3,8 +3,8 @@
 -- re-crawling idempotent — a stored post (pending, done, or dead-lettered) is
 -- never reset. extracted_at is non-NULL when the ingest prefilter already
 -- decided the post holds no vacancy, so it is recorded but never queued.
-INSERT INTO telegram_posts (channel, msg_id, text, posted_at, extracted_at)
-VALUES (sqlc.arg(channel), sqlc.arg(msg_id), sqlc.arg(text), sqlc.arg(posted_at), sqlc.arg(extracted_at))
+INSERT INTO telegram_posts (channel, msg_id, text, links, posted_at, extracted_at)
+VALUES (sqlc.arg(channel), sqlc.arg(msg_id), sqlc.arg(text), sqlc.arg(links), sqlc.arg(posted_at), sqlc.arg(extracted_at))
 ON CONFLICT (channel, msg_id) DO NOTHING;
 
 -- name: ClaimTelegramPosts :many
@@ -27,7 +27,7 @@ UPDATE telegram_posts p
 SET claimed_at = now()
 FROM claimable c
 WHERE p.channel = c.channel AND p.msg_id = c.msg_id
-RETURNING p.channel, p.msg_id, p.text, p.posted_at;
+RETURNING p.channel, p.msg_id, p.text, p.links, p.posted_at;
 
 -- name: MarkTelegramPostExtracted :exec
 -- Completion: the post was processed (jobs written, or no vacancy found). Run in

--- a/internal/db/telegram_posts.sql.go
+++ b/internal/db/telegram_posts.sql.go
@@ -27,7 +27,7 @@ UPDATE telegram_posts p
 SET claimed_at = now()
 FROM claimable c
 WHERE p.channel = c.channel AND p.msg_id = c.msg_id
-RETURNING p.channel, p.msg_id, p.text, p.posted_at
+RETURNING p.channel, p.msg_id, p.text, p.links, p.posted_at
 `
 
 type ClaimTelegramPostsParams struct {
@@ -39,6 +39,7 @@ type ClaimTelegramPostsRow struct {
 	Channel  string             `json:"channel"`
 	MsgID    int64              `json:"msg_id"`
 	Text     string             `json:"text"`
+	Links    []byte             `json:"links"`
 	PostedAt pgtype.Timestamptz `json:"posted_at"`
 }
 
@@ -59,6 +60,7 @@ func (q *Queries) ClaimTelegramPosts(ctx context.Context, arg ClaimTelegramPosts
 			&i.Channel,
 			&i.MsgID,
 			&i.Text,
+			&i.Links,
 			&i.PostedAt,
 		); err != nil {
 			return nil, err
@@ -72,8 +74,8 @@ func (q *Queries) ClaimTelegramPosts(ctx context.Context, arg ClaimTelegramPosts
 }
 
 const insertTelegramPost = `-- name: InsertTelegramPost :execrows
-INSERT INTO telegram_posts (channel, msg_id, text, posted_at, extracted_at)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO telegram_posts (channel, msg_id, text, links, posted_at, extracted_at)
+VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (channel, msg_id) DO NOTHING
 `
 
@@ -81,6 +83,7 @@ type InsertTelegramPostParams struct {
 	Channel     string             `json:"channel"`
 	MsgID       int64              `json:"msg_id"`
 	Text        string             `json:"text"`
+	Links       []byte             `json:"links"`
 	PostedAt    pgtype.Timestamptz `json:"posted_at"`
 	ExtractedAt pgtype.Timestamptz `json:"extracted_at"`
 }
@@ -94,6 +97,7 @@ func (q *Queries) InsertTelegramPost(ctx context.Context, arg InsertTelegramPost
 		arg.Channel,
 		arg.MsgID,
 		arg.Text,
+		arg.Links,
 		arg.PostedAt,
 		arg.ExtractedAt,
 	)

--- a/internal/linksource/habrcareer.go
+++ b/internal/linksource/habrcareer.go
@@ -1,0 +1,128 @@
+package linksource
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// habrCareer resolves Habr Career vacancies. Channels link them through the u.habr.com
+// shortener, which 301s to career.habr.com/vacancies/<id>; the canonical id and URL come
+// from the resolved location, so the same vacancy linked from several channels dedups to
+// one row.
+type habrCareer struct {
+	http Client
+}
+
+// NewHabrCareer builds the Habr Career link-source adapter.
+func NewHabrCareer(c Client) LinkSource { return habrCareer{http: c} }
+
+func (habrCareer) Source() string { return "habr_career" }
+
+// Match handles both the u.habr.com shortener and direct career.habr.com links.
+func (habrCareer) Match(u *url.URL) bool {
+	switch host(u) {
+	case "u.habr.com", "career.habr.com":
+		return true
+	default:
+		return false
+	}
+}
+
+// habrVacancyPath matches the canonical vacancy path, capturing the numeric id.
+var habrVacancyPath = regexp.MustCompile(`^/vacancies/(\d+)/?$`)
+
+// habrPosting selects the JobPosting ld+json fields Habr publishes on a vacancy page.
+type habrPosting struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	DatePosted  string `json:"datePosted"`
+	Identifier  struct {
+		Value string `json:"value"`
+	} `json:"identifier"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation []struct {
+		Address habrAddress `json:"address"`
+	} `json:"jobLocation"`
+}
+
+// habrAddress reads jobLocation.address, which Habr emits as a bare string but schema.org
+// types as a PostalAddress object — so it accepts either shape.
+type habrAddress struct{ Text string }
+
+func (a *habrAddress) UnmarshalJSON(b []byte) error {
+	var s string
+	if json.Unmarshal(b, &s) == nil {
+		a.Text = s
+		return nil
+	}
+	var o struct {
+		AddressLocality string `json:"addressLocality"`
+		AddressCountry  string `json:"addressCountry"`
+	}
+	if json.Unmarshal(b, &o) == nil {
+		a.Text = strings.TrimPrefix(strings.TrimSpace(o.AddressLocality+", "+o.AddressCountry), ", ")
+		a.Text = strings.TrimSuffix(a.Text, ", ")
+	}
+	return nil
+}
+
+// Resolve follows the link to its career.habr.com landing, and when that is a single
+// vacancy parses its JobPosting ld+json into a job. A matched link that lands somewhere
+// other than /vacancies/<id> (e.g. the "Больше вакансий" index) is skipped (ok=false).
+func (h habrCareer) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	node, final, err := h.http.GetHTMLResolved(ctx, raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	u, err := url.Parse(final)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	// The link came from untrusted post content and the client follows redirects to any
+	// host; only parse the page when the shortener landed on Habr itself, so a hijacked
+	// short code cannot make us ingest an arbitrary (e.g. internal) host's HTML.
+	if host(u) != "career.habr.com" {
+		return sources.Job{}, false, fmt.Errorf("linksource: habr link resolved to unexpected host %q", u.Host)
+	}
+	m := habrVacancyPath.FindStringSubmatch(u.Path)
+	if m == nil {
+		return sources.Job{}, false, nil // landed on Habr but not a single vacancy — skip
+	}
+	id := m[1]
+
+	var p habrPosting
+	if !sources.LDJobPosting(node, &p) {
+		return sources.Job{}, false, fmt.Errorf("linksource: habr vacancy %s has no JobPosting ld+json", id)
+	}
+	if p.Identifier.Value != "" {
+		id = p.Identifier.Value
+	}
+
+	var loc string
+	if len(p.JobLocation) > 0 {
+		loc = p.JobLocation[0].Address.Text
+	}
+	return sources.Job{
+		ExternalID:  id,
+		URL:         "https://career.habr.com/vacancies/" + id,
+		Title:       p.Title,
+		Company:     p.HiringOrganization.Name,
+		Location:    loc,
+		Description: sources.SanitizeHTML(p.Description),
+		Remote:      sources.IsRemote(loc),
+		PostedAt:    parseDate(p.DatePosted),
+	}, true, nil
+}
+
+// host returns u's lowercased hostname with a leading "www." stripped.
+func host(u *url.URL) string {
+	return strings.TrimPrefix(strings.ToLower(u.Hostname()), "www.")
+}

--- a/internal/linksource/habrcareer_test.go
+++ b/internal/linksource/habrcareer_test.go
@@ -1,0 +1,107 @@
+package linksource
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// habrVacancyHTML is a career.habr.com vacancy page reduced to the schema.org JobPosting
+// ld+json block the adapter reads (address is a bare string, as Habr emits it; the
+// description carries an entity and a <script> to prove sanitization).
+const habrVacancyHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Junior Product Manager (Дистанционный мониторинг)",
+ "datePosted":"2026-05-28",
+ "description":"<p>Обязанности &amp; требования</p><script>alert(1)<\/script><ul><li>REST</li></ul>",
+ "identifier":{"@type":"PropertyValue","name":"СберЗдоровье","value":"1000166712"},
+ "hiringOrganization":{"@type":"Organization","name":"СберЗдоровье"},
+ "jobLocation":[{"@type":"Place","address":"Москва"}],
+ "employmentType":"FULL_TIME"}
+</script></head><body><h1>Junior Product Manager</h1></body></html>`
+
+// habrListingHTML is what u.habr.com/fq3n5 ("Больше вакансий") resolves to: the vacancies
+// index, which carries no single JobPosting.
+const habrListingHTML = `<html><head><title>Вакансии</title></head><body></body></html>`
+
+func TestHabrCareerResolvesShortLinkToVacancy(t *testing.T) {
+	const short = "https://u.habr.com/PnBO7"
+	const final = "https://career.habr.com/vacancies/1000166712?utm_source=telegram_career"
+	c := (&fakeClient{}).route("u.habr.com/PnBO7", habrVacancyHTML, final)
+
+	job, ok, err := NewHabrCareer(c).Resolve(context.Background(), short)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	if job.ExternalID != "1000166712" {
+		t.Errorf("ExternalID = %q, want 1000166712", job.ExternalID)
+	}
+	if job.URL != "https://career.habr.com/vacancies/1000166712" {
+		t.Errorf("URL = %q, want canonical vacancy URL without utm", job.URL)
+	}
+	if !strings.Contains(job.Title, "Junior Product Manager") {
+		t.Errorf("Title = %q", job.Title)
+	}
+	if job.Company != "СберЗдоровье" {
+		t.Errorf("Company = %q, want СберЗдоровье", job.Company)
+	}
+	if job.Location != "Москва" {
+		t.Errorf("Location = %q, want Москва", job.Location)
+	}
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "<li>REST</li>") {
+		t.Errorf("Description not sanitized/decoded: %q", job.Description)
+	}
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-05-28", job.PostedAt)
+	}
+}
+
+func TestHabrCareerResolvesDirectVacancyLink(t *testing.T) {
+	const direct = "https://career.habr.com/vacancies/1000166712"
+	c := (&fakeClient{}).route("career.habr.com/vacancies/1000166712", habrVacancyHTML, "")
+
+	job, ok, err := NewHabrCareer(c).Resolve(context.Background(), direct)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok || job.ExternalID != "1000166712" {
+		t.Fatalf("direct link not resolved: ok=%v id=%q", ok, job.ExternalID)
+	}
+}
+
+func TestHabrCareerRejectsRedirectToForeignHost(t *testing.T) {
+	// The shortener is untrusted and the client follows redirects to any host. A code that
+	// resolves off-Habr (even to a vacancy-shaped path) must not be parsed/ingested.
+	const short = "https://u.habr.com/EVIL"
+	const final = "https://169.254.169.254/vacancies/123"
+	c := (&fakeClient{}).route("u.habr.com/EVIL", habrVacancyHTML, final)
+
+	job, ok, err := NewHabrCareer(c).Resolve(context.Background(), short)
+	if err == nil {
+		t.Fatalf("want error for a redirect off career.habr.com; got job %+v", job)
+	}
+	if ok {
+		t.Errorf("ok=true, want false for a foreign-host redirect")
+	}
+}
+
+func TestHabrCareerSkipsNonVacancyLink(t *testing.T) {
+	// "Больше вакансий" 301s to the vacancies index — matched host, but not a single
+	// vacancy, so it is skipped (ok=false), not an error.
+	const short = "https://u.habr.com/fq3n5"
+	const final = "https://career.habr.com/vacancies"
+	c := (&fakeClient{}).route("u.habr.com/fq3n5", habrListingHTML, final)
+
+	job, ok, err := NewHabrCareer(c).Resolve(context.Background(), short)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ok {
+		t.Errorf("ok=true, want skip for a non-vacancy link; got job %+v", job)
+	}
+}

--- a/internal/linksource/helpers.go
+++ b/internal/linksource/helpers.go
@@ -1,0 +1,30 @@
+package linksource
+
+import "time"
+
+// parseDate parses a date-only timestamp ("2006-01-02", as Habr's datePosted emits),
+// returning nil for an empty or unparseable value (posted_at is nullable).
+func parseDate(s string) *time.Time {
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// parseRFC3339 parses an RFC3339 timestamp (as RemoteYeah's datePosted emits), in UTC,
+// returning nil for an empty or unparseable value.
+func parseRFC3339(s string) *time.Time {
+	if s == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return nil
+	}
+	t = t.UTC()
+	return &t
+}

--- a/internal/linksource/helpers_test.go
+++ b/internal/linksource/helpers_test.go
@@ -1,0 +1,57 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// fakeClient is a test linksource.Client: it returns a canned HTML body for the first
+// route whose match substring is contained in the requested URL, and reports a configured
+// final URL (defaulting to the requested URL) so a shortener redirect can be simulated.
+type fakeClient struct {
+	routes []fakeRoute
+}
+
+type fakeRoute struct {
+	match string
+	body  string
+	final string // resolved URL after redirects; "" = same as requested
+}
+
+func (c *fakeClient) route(match, body, final string) *fakeClient {
+	c.routes = append(c.routes, fakeRoute{match: match, body: body, final: final})
+	return c
+}
+
+func (c *fakeClient) find(url string) (fakeRoute, bool) {
+	for _, r := range c.routes {
+		if strings.Contains(url, r.match) {
+			return r, true
+		}
+	}
+	return fakeRoute{}, false
+}
+
+func (c *fakeClient) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	r, ok := c.find(url)
+	if !ok {
+		return nil, fmt.Errorf("fakeClient: no route for %s", url)
+	}
+	return html.Parse(strings.NewReader(r.body))
+}
+
+func (c *fakeClient) GetHTMLResolved(_ context.Context, url string) (*html.Node, string, error) {
+	r, ok := c.find(url)
+	if !ok {
+		return nil, "", fmt.Errorf("fakeClient: no route for %s", url)
+	}
+	final := r.final
+	if final == "" {
+		final = url
+	}
+	n, err := html.Parse(strings.NewReader(r.body))
+	return n, final, err
+}

--- a/internal/linksource/registry.go
+++ b/internal/linksource/registry.go
@@ -1,0 +1,55 @@
+// Package linksource turns an outbound job link found in a Telegram post into a fully
+// parsed vacancy under the destination's own identity. Where internal/sources adapts a
+// whole ATS board by id, a LinkSource adapts a single job-detail URL: it matches the
+// link's host and resolves that one page. Adding a destination is a new adapter plus one
+// line in All — the same shape as sources.All.
+package linksource
+
+import (
+	"context"
+	"net/url"
+
+	"golang.org/x/net/html"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// Client is the narrow transport a LinkSource needs: fetch a server-rendered detail page,
+// optionally following a shortener redirect to learn the canonical URL. *sources.Client
+// satisfies it.
+type Client interface {
+	GetHTML(ctx context.Context, url string) (*html.Node, error)
+	GetHTMLResolved(ctx context.Context, url string) (*html.Node, string, error)
+}
+
+// LinkSource adapts one destination site reachable from a post link. Source is the key
+// stored as jobs.source; Match reports whether this adapter handles a link URL (by host,
+// including any shortener that fronts the site); Resolve fetches and parses that one
+// vacancy.
+type LinkSource interface {
+	Source() string
+	Match(u *url.URL) bool
+	// Resolve fetches and parses the destination vacancy at raw. ok=false means the link
+	// is matched but is not a single vacancy (e.g. a listing/search page) and should be
+	// skipped — not an error. A non-nil error is a transient/parse failure worth retrying.
+	Resolve(ctx context.Context, raw string) (job sources.Job, ok bool, err error)
+}
+
+// All assembles the registered link-source adapters, sharing one HTTP client. Adding a
+// destination is a new adapter plus one line here.
+func All(c Client) []LinkSource {
+	return []LinkSource{
+		NewHabrCareer(c),
+		NewRemoteYeah(c),
+	}
+}
+
+// Find returns the first adapter that matches u, or nil when no destination handles it.
+func Find(reg []LinkSource, u *url.URL) LinkSource {
+	for _, ls := range reg {
+		if ls.Match(u) {
+			return ls
+		}
+	}
+	return nil
+}

--- a/internal/linksource/registry_test.go
+++ b/internal/linksource/registry_test.go
@@ -1,0 +1,37 @@
+package linksource
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestFindMatchesAdapterByLinkHost(t *testing.T) {
+	reg := All(nil) // Match inspects only the URL, so a nil client is fine here.
+
+	cases := []struct {
+		raw  string
+		want string // expected adapter Source(), "" = no match
+	}{
+		{"https://u.habr.com/PnBO7", "habr_career"},
+		{"https://career.habr.com/vacancies/1000166712", "habr_career"},
+		{"https://remoteyeah.com/jobs/remote-senior-quality-engineer-peek", "remoteyeah"},
+		{"https://remoteyeah.com/", ""},        // homepage, not a /jobs/<slug> link
+		{"https://example.com/jobs/x", ""},     // unknown domain
+		{"https://t.me/habr_career/75410", ""}, // the post itself, not an outbound link
+	}
+
+	for _, c := range cases {
+		u, err := url.Parse(c.raw)
+		if err != nil {
+			t.Fatalf("parse %q: %v", c.raw, err)
+		}
+		ls := Find(reg, u)
+		got := ""
+		if ls != nil {
+			got = ls.Source()
+		}
+		if got != c.want {
+			t.Errorf("Find(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}

--- a/internal/linksource/remoteyeah.go
+++ b/internal/linksource/remoteyeah.go
@@ -1,0 +1,103 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// remoteYeah resolves RemoteYeah vacancies. Posts link directly to
+// remoteyeah.com/jobs/<slug>; the slug is the stable id.
+type remoteYeah struct {
+	http Client
+}
+
+// NewRemoteYeah builds the RemoteYeah link-source adapter.
+func NewRemoteYeah(c Client) LinkSource { return remoteYeah{http: c} }
+
+func (remoteYeah) Source() string { return "remoteyeah" }
+
+// Match handles remoteyeah.com/jobs/<slug> links only — the homepage and other paths are
+// not vacancies.
+func (remoteYeah) Match(u *url.URL) bool {
+	return host(u) == "remoteyeah.com" && strings.HasPrefix(u.Path, "/jobs/") &&
+		strings.TrimPrefix(u.Path, "/jobs/") != ""
+}
+
+// remoteYeahPosting selects the JobPosting ld+json fields RemoteYeah publishes.
+type remoteYeahPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	BaseSalary struct {
+		Currency string `json:"currency"`
+		Value    struct {
+			MinValue float64 `json:"minValue"`
+			MaxValue float64 `json:"maxValue"`
+		} `json:"value"`
+	} `json:"baseSalary"`
+}
+
+// Resolve fetches the job page and parses its JobPosting ld+json. The slug from the link
+// path is the id; the page carries no native identifier.
+func (r remoteYeah) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	slug := strings.Trim(strings.TrimPrefix(u.Path, "/jobs/"), "/")
+	if slug == "" {
+		return sources.Job{}, false, nil
+	}
+
+	node, err := r.http.GetHTML(ctx, raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	var p remoteYeahPosting
+	if !sources.LDJobPosting(node, &p) {
+		return sources.Job{}, false, fmt.Errorf("linksource: remoteyeah job %s has no JobPosting ld+json", slug)
+	}
+
+	desc := sources.SanitizeHTML(p.Description)
+	if salary := remoteYeahSalary(p); salary != "" {
+		// Sanitize the salary fragment too: its currency is third-party JSON-LD text and
+		// the description is rendered with {@html}, so an unsanitized prefix is stored XSS.
+		desc = sources.SanitizeHTML(salary) + desc
+	}
+	return sources.Job{
+		ExternalID:  slug,
+		URL:         "https://remoteyeah.com/jobs/" + slug,
+		Title:       p.Title,
+		Company:     p.HiringOrganization.Name,
+		Description: desc,
+		Remote:      strings.EqualFold(p.JobLocationType, "TELECOMMUTE"),
+		PostedAt:    parseRFC3339(p.DatePosted),
+	}, true, nil
+}
+
+// remoteYeahSalary renders a structured baseSalary range as a leading paragraph, or "" when
+// the page states no amount. Folding it into the description keeps it visible and lets
+// enrichment pick it up (sources.Job has no dedicated salary field).
+func remoteYeahSalary(p remoteYeahPosting) string {
+	min, max := p.BaseSalary.Value.MinValue, p.BaseSalary.Value.MaxValue
+	if min <= 0 && max <= 0 {
+		return ""
+	}
+	cur := p.BaseSalary.Currency
+	switch {
+	case min > 0 && max > 0:
+		return fmt.Sprintf("<p>Salary: %.0f–%.0f %s</p>", min, max, cur)
+	case min > 0:
+		return fmt.Sprintf("<p>Salary: from %.0f %s</p>", min, cur)
+	default:
+		return fmt.Sprintf("<p>Salary: up to %.0f %s</p>", max, cur)
+	}
+}

--- a/internal/linksource/remoteyeah_test.go
+++ b/internal/linksource/remoteyeah_test.go
@@ -1,0 +1,88 @@
+package linksource
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// remoteYeahJobHTML is a remoteyeah.com/jobs/<slug> page reduced to the JobPosting block
+// (alongside the other ld+json blocks the real page carries, to prove the adapter picks
+// the JobPosting one). identifier is null — the slug is the id; jobLocationType marks it
+// remote; baseSalary is structured.
+const remoteYeahJobHTML = `<html><head>
+<script type="application/ld+json">{"@context":"https://schema.org/","@type":"WebSite","name":"RemoteYeah"}</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Senior Platform & Security Engineer",
+ "datePosted":"2026-06-13T11:31:17+00:00",
+ "description":"<p>Build it.</p><script>alert(1)<\/script>",
+ "identifier":null,
+ "hiringOrganization":{"@type":"Organization","name":"Taekus"},
+ "jobLocation":null,
+ "jobLocationType":"TELECOMMUTE",
+ "baseSalary":{"@type":"MonetaryAmount","currency":"USD","value":{"@type":"QuantitativeValue","minValue":175000,"maxValue":230000}},
+ "employmentType":["FULL_TIME"]}
+</script></head><body></body></html>`
+
+// remoteYeahXSSHTML carries a malicious currency in the structured salary — the adapter
+// folds salary into the {@html}-rendered description, so it must be sanitized.
+const remoteYeahXSSHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Engineer","description":"<p>Build it.</p>",
+ "hiringOrganization":{"@type":"Organization","name":"Acme"},
+ "baseSalary":{"@type":"MonetaryAmount","currency":"USD</p><script>alert(1)<\/script><p>","value":{"@type":"QuantitativeValue","minValue":100000,"maxValue":120000}}}
+</script></head><body></body></html>`
+
+func TestRemoteYeahSanitizesFoldedSalary(t *testing.T) {
+	c := (&fakeClient{}).route("/jobs/evil", remoteYeahXSSHTML, "")
+	job, ok, err := NewRemoteYeah(c).Resolve(context.Background(), "https://remoteyeah.com/jobs/evil")
+	if err != nil || !ok {
+		t.Fatalf("resolve: ok=%v err=%v", ok, err)
+	}
+	if strings.Contains(job.Description, "<script>") {
+		t.Errorf("description carries unsanitized salary markup: %q", job.Description)
+	}
+	if !strings.Contains(job.Description, "100000") {
+		t.Errorf("salary range dropped: %q", job.Description)
+	}
+}
+
+func TestRemoteYeahResolvesJobPage(t *testing.T) {
+	const link = "https://remoteyeah.com/jobs/remote-senior-platform-security-engineer-taekus?utm_source=telegram"
+	c := (&fakeClient{}).route("/jobs/remote-senior-platform-security-engineer-taekus", remoteYeahJobHTML, "")
+
+	job, ok, err := NewRemoteYeah(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	if job.ExternalID != "remote-senior-platform-security-engineer-taekus" {
+		t.Errorf("ExternalID = %q, want the slug", job.ExternalID)
+	}
+	if job.URL != "https://remoteyeah.com/jobs/remote-senior-platform-security-engineer-taekus" {
+		t.Errorf("URL = %q, want canonical job URL without utm", job.URL)
+	}
+	if job.Title != "Senior Platform & Security Engineer" {
+		t.Errorf("Title = %q", job.Title)
+	}
+	if job.Company != "Taekus" {
+		t.Errorf("Company = %q, want Taekus", job.Company)
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true (jobLocationType TELECOMMUTE)")
+	}
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "Build it.") {
+		t.Errorf("Description not sanitized: %q", job.Description)
+	}
+	if !strings.Contains(job.Description, "175000") || !strings.Contains(job.Description, "230000") {
+		t.Errorf("Description missing folded salary range: %q", job.Description)
+	}
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2026, 6, 13, 11, 31, 17, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-13T11:31:17Z", job.PostedAt)
+	}
+}

--- a/internal/linksource/resolve.go
+++ b/internal/linksource/resolve.go
@@ -1,0 +1,72 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// Resolved is one vacancy parsed from a post link, tagged with the destination platform
+// that produced it (which becomes jobs.source).
+type Resolved struct {
+	Source string
+	Job    sources.Job
+}
+
+// ResolveLinks runs each url through the registry and returns the vacancies from every
+// link a destination adapter both matched and resolved. A matched link that is not a
+// single vacancy (ok=false) is skipped; a matched link whose fetch/parse errors is logged.
+// err is non-nil only when matched links existed but all of them failed — a transient
+// outcome the caller should retry. Links no adapter matches are ignored, yielding
+// (nil, nil) so the caller can fall back to its own extraction.
+func ResolveLinks(ctx context.Context, reg []LinkSource, urls []string) ([]Resolved, error) {
+	var out []Resolved
+	matched, failed := 0, 0
+	var firstErr error
+
+	for _, raw := range urls {
+		u, err := url.Parse(raw)
+		if err != nil {
+			continue
+		}
+		ls := Find(reg, u)
+		if ls == nil {
+			continue
+		}
+		matched++
+
+		job, ok, err := ls.Resolve(ctx, raw)
+		if err != nil {
+			failed++
+			if firstErr == nil {
+				firstErr = err
+			}
+			log.Printf("linksource: resolve %s (%s) failed: %v", raw, ls.Source(), err)
+			continue
+		}
+		if !ok {
+			continue // matched host but not a single vacancy — skip
+		}
+		out = append(out, Resolved{Source: ls.Source(), Job: job})
+	}
+
+	if len(out) == 0 && failed > 0 {
+		return nil, fmt.Errorf("linksource: all %d resolvable link(s) failed: %w", failed, firstErr)
+	}
+	return out, nil
+}
+
+// MatchesAny reports whether any url is a link a destination adapter handles. The crawl
+// prefilter uses it so a link-out digest post is kept even when its teaser text alone does
+// not look like a vacancy.
+func MatchesAny(reg []LinkSource, urls []string) bool {
+	for _, raw := range urls {
+		if u, err := url.Parse(raw); err == nil && Find(reg, u) != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/linksource/resolve_test.go
+++ b/internal/linksource/resolve_test.go
@@ -1,0 +1,63 @@
+package linksource
+
+import (
+	"context"
+	"testing"
+)
+
+// resolveReg builds the real registry over a fake client routing the habr short link to a
+// vacancy, a second short link to a failing fetch, and a third to the non-vacancy index.
+func resolveReg() []LinkSource {
+	c := (&fakeClient{}).
+		route("u.habr.com/PnBO7", habrVacancyHTML, "https://career.habr.com/vacancies/1000166712?utm_source=telegram").
+		route("u.habr.com/fq3n5", habrListingHTML, "https://career.habr.com/vacancies")
+	// u.habr.com/BROKEN is intentionally unrouted → fakeClient returns an error.
+	return All(c)
+}
+
+func TestResolveLinksReturnsMatchedVacanciesAndSkipsRest(t *testing.T) {
+	urls := []string{
+		"https://t.me/habr_career/75410", // not an outbound link — no adapter
+		"https://u.habr.com/PnBO7",       // → vacancy
+		"https://example.com/whatever",   // unknown domain
+		"https://u.habr.com/fq3n5",       // → vacancies index (skip, ok=false)
+	}
+	got, err := ResolveLinks(context.Background(), resolveReg(), urls)
+	if err != nil {
+		t.Fatalf("ResolveLinks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("resolved = %d (%+v), want 1", len(got), got)
+	}
+	if got[0].Source != "habr_career" || got[0].Job.ExternalID != "1000166712" {
+		t.Errorf("resolved = %+v, want habr_career/1000166712", got[0])
+	}
+}
+
+func TestResolveLinksErrorsWhenAllMatchedLinksFail(t *testing.T) {
+	// Only a matched-but-failing link: the fetch errors, nothing resolves → retry signal.
+	urls := []string{"https://u.habr.com/BROKEN"}
+	got, err := ResolveLinks(context.Background(), resolveReg(), urls)
+	if err == nil {
+		t.Fatalf("want an error so the post is retried; got jobs %+v", got)
+	}
+}
+
+func TestResolveLinksNoMatchIsNotAnError(t *testing.T) {
+	// Links present but no destination adapter matches → fall back to the LLM (nil, nil).
+	urls := []string{"https://example.com/a", "https://t.me/x/1"}
+	got, err := ResolveLinks(context.Background(), resolveReg(), urls)
+	if err != nil || got != nil {
+		t.Fatalf("got (%+v, %v), want (nil, nil)", got, err)
+	}
+}
+
+func TestMatchesAny(t *testing.T) {
+	reg := resolveReg()
+	if !MatchesAny(reg, []string{"https://t.me/x/1", "https://u.habr.com/PnBO7"}) {
+		t.Error("MatchesAny = false, want true (a habr link is present)")
+	}
+	if MatchesAny(reg, []string{"https://example.com/a", "https://t.me/x/1"}) {
+		t.Error("MatchesAny = true, want false (no destination link)")
+	}
+}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -61,31 +61,47 @@ func (c *Client) GetJSON(ctx context.Context, url string, v any) error {
 // GetJSONWithHeaders fetches url with extra request headers and decodes its JSON body
 // into v.
 func (c *Client) GetJSONWithHeaders(ctx context.Context, url string, headers map[string]string, v any) error {
-	return c.do(ctx, http.MethodGet, url, nil, "application/json", headers, func(r io.Reader) error {
-		return json.NewDecoder(r).Decode(v)
+	return c.do(ctx, http.MethodGet, url, nil, "application/json", headers, func(resp *http.Response) error {
+		return json.NewDecoder(resp.Body).Decode(v)
 	})
 }
 
 // GetXML fetches url and decodes its XML body into v (used by adapters whose platform
 // publishes an XML feed, e.g. Personio).
 func (c *Client) GetXML(ctx context.Context, url string, v any) error {
-	return c.do(ctx, http.MethodGet, url, nil, "application/xml", nil, func(r io.Reader) error {
-		return xml.NewDecoder(r).Decode(v)
+	return c.do(ctx, http.MethodGet, url, nil, "application/xml", nil, func(resp *http.Response) error {
+		return xml.NewDecoder(resp.Body).Decode(v)
 	})
 }
 
 // GetHTML fetches url and returns its parsed HTML tree.
 func (c *Client) GetHTML(ctx context.Context, url string) (*html.Node, error) {
+	node, _, err := c.getHTML(ctx, url)
+	return node, err
+}
+
+// GetHTMLResolved fetches url, following redirects, and returns its parsed HTML tree
+// together with the final URL after redirects — for shortener-fronted detail pages
+// (e.g. a u.habr.com link that 301s to career.habr.com/vacancies/<id>).
+func (c *Client) GetHTMLResolved(ctx context.Context, url string) (*html.Node, string, error) {
+	return c.getHTML(ctx, url)
+}
+
+// getHTML fetches url and returns its parsed tree plus the final URL after redirects,
+// backing both GetHTML and GetHTMLResolved.
+func (c *Client) getHTML(ctx context.Context, url string) (*html.Node, string, error) {
 	var node *html.Node
-	err := c.do(ctx, http.MethodGet, url, nil, "text/html", nil, func(r io.Reader) error {
-		n, err := html.Parse(r)
+	var final string
+	err := c.do(ctx, http.MethodGet, url, nil, "text/html", nil, func(resp *http.Response) error {
+		final = resp.Request.URL.String()
+		n, err := html.Parse(resp.Body)
 		if err != nil {
 			return err
 		}
 		node = n
 		return nil
 	})
-	return node, err
+	return node, final, err
 }
 
 // PostJSON marshals body to JSON, POSTs it to url, and decodes the JSON response into
@@ -100,8 +116,8 @@ func (c *Client) PostJSONWithHeaders(ctx context.Context, url string, headers ma
 	if err != nil {
 		return fmt.Errorf("sources: marshal request %s: %w", url, err)
 	}
-	return c.do(ctx, http.MethodPost, url, payload, "application/json", headers, func(r io.Reader) error {
-		return json.NewDecoder(r).Decode(v)
+	return c.do(ctx, http.MethodPost, url, payload, "application/json", headers, func(resp *http.Response) error {
+		return json.NewDecoder(resp.Body).Decode(v)
 	})
 }
 
@@ -111,7 +127,7 @@ func (c *Client) PostJSONWithHeaders(ctx context.Context, url string, headers ma
 // the server's Retry-After hint — busy ATS APIs (SmartRecruiters) throttle by IP
 // under the concurrent crawl and recover on a brief wait. Other 4xx are not retried.
 // A non-nil body is re-sent on each attempt.
-func (c *Client) do(ctx context.Context, method, url string, body []byte, accept string, headers map[string]string, decode func(io.Reader) error) error {
+func (c *Client) do(ctx context.Context, method, url string, body []byte, accept string, headers map[string]string, decode func(*http.Response) error) error {
 	var lastErr error
 	delay := c.retryDelay
 	for attempt := 0; attempt <= c.maxRetries; attempt++ {
@@ -153,7 +169,7 @@ func (c *Client) do(ctx context.Context, method, url string, body []byte, accept
 
 		switch {
 		case resp.StatusCode >= 200 && resp.StatusCode < 300:
-			err := decode(resp.Body)
+			err := decode(resp)
 			resp.Body.Close()
 			if err != nil {
 				return fmt.Errorf("sources: decode %s: %w", url, err)

--- a/internal/sources/http_test.go
+++ b/internal/sources/http_test.go
@@ -152,6 +152,35 @@ func TestClientGetJSONErrorsOnClientError(t *testing.T) {
 	}
 }
 
+func TestClientGetHTMLResolvedFollowsRedirectAndReturnsFinalURL(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/short", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/vacancies/1000166712", http.StatusMovedPermanently)
+	})
+	mux.HandleFunc("/vacancies/1000166712", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><h1>Product manager</h1></body></html>`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client()}
+
+	node, final, err := c.GetHTMLResolved(context.Background(), srv.URL+"/short")
+	if err != nil {
+		t.Fatalf("GetHTMLResolved: %v", err)
+	}
+	if node == nil {
+		t.Fatal("node is nil, want a parsed tree")
+	}
+	if !strings.HasSuffix(final, "/vacancies/1000166712") {
+		t.Errorf("final URL = %q, want it to end at the redirect target", final)
+	}
+	if got := textContent(node); !strings.Contains(got, "Product manager") {
+		t.Errorf("parsed text = %q, want the destination page body", got)
+	}
+}
+
 func TestClientRetriesOn429ThenSucceeds(t *testing.T) {
 	var attempts int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/sources/jsonld.go
+++ b/internal/sources/jsonld.go
@@ -7,6 +7,10 @@ import (
 	"golang.org/x/net/html"
 )
 
+// LDJobPosting is the exported form of ldJobPosting, for sibling packages that parse a
+// server-rendered detail page into a sources.Job (e.g. internal/linksource).
+func LDJobPosting(root *html.Node, v any) bool { return ldJobPosting(root, v) }
+
 // ldJobPosting decodes the first application/ld+json JobPosting block on the page into v,
 // returning false when the page carries no such block. Shared by the HTML detail adapters
 // (teamtailor, breezy) whose job pages server-render a schema.org JobPosting; each passes

--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -35,3 +35,11 @@ func newDescriptionPolicy() *bluemonday.Policy {
 func sanitizeHTML(s string) string {
 	return descriptionPolicy.Sanitize(s)
 }
+
+// SanitizeHTML is the exported description sanitizer, for sibling packages that build
+// sources.Job values outside this package (e.g. internal/linksource).
+func SanitizeHTML(s string) string { return sanitizeHTML(s) }
+
+// IsRemote is the exported form of the shared location-based remote heuristic, so sibling
+// packages flag remote jobs consistently with the ATS adapters.
+func IsRemote(location string) bool { return isRemote(location) }

--- a/internal/telegram/crawl.go
+++ b/internal/telegram/crawl.go
@@ -18,6 +18,13 @@ type PostStore interface {
 	Insert(ctx context.Context, channel string, p Post, done bool) (bool, error)
 }
 
+// LinkMatcher reports whether a post's outbound links include one a destination adapter
+// handles. The crawl keeps such a post even when its teaser text alone does not look like
+// a vacancy, so a link-out digest is not filtered out before the extractor can follow it.
+type LinkMatcher interface {
+	Matches(links []Link) bool
+}
+
 // CrawlStats summarizes one crawl run.
 type CrawlStats struct {
 	Stored   int // new posts queued for extraction
@@ -32,6 +39,7 @@ type CrawlRunner struct {
 	Fetcher PostFetcher
 	Store   PostStore
 	Delay   time.Duration // pause between channels; zero in tests
+	Links   LinkMatcher   // optional; keeps link-out digest posts the text filter would drop
 }
 
 // Run crawls the channels, isolating failures: a channel whose fetch or store
@@ -56,7 +64,7 @@ func (r CrawlRunner) Run(ctx context.Context, channels []ChannelEntry) (CrawlSta
 
 		failed := false
 		for _, p := range posts {
-			isVacancy := LooksLikeVacancy(p.Text)
+			isVacancy := LooksLikeVacancy(p.Text) || r.hasDestinationLink(p.Links)
 			inserted, err := r.Store.Insert(ctx, ch.Channel, p, !isVacancy)
 			if err != nil {
 				log.Printf("telegram: store %s/%d failed: %v", ch.Channel, p.MsgID, err)
@@ -77,4 +85,10 @@ func (r CrawlRunner) Run(ctx context.Context, channels []ChannelEntry) (CrawlSta
 		}
 	}
 	return stats, nil
+}
+
+// hasDestinationLink reports whether a post links out to a vacancy a destination adapter
+// can resolve, returning false when no matcher is configured.
+func (r CrawlRunner) hasDestinationLink(links []Link) bool {
+	return r.Links != nil && r.Links.Matches(links)
 }

--- a/internal/telegram/crawl_test.go
+++ b/internal/telegram/crawl_test.go
@@ -79,6 +79,31 @@ func TestCrawlStoresVacanciesAndFiltersNoise(t *testing.T) {
 	}
 }
 
+type fakeLinkMatcher struct{ match bool }
+
+func (m fakeLinkMatcher) Matches(_ []Link) bool { return m.match }
+
+func TestCrawlKeepsLinkOutDigestDespiteNoisyText(t *testing.T) {
+	// A digest whose teaser text alone reads as noise, but which links out to a vacancy
+	// page, must be queued (not filtered) so the extractor can follow the link.
+	digest := memePost(3)
+	digest.Links = []Link{{Text: "Product manager", URL: "https://u.habr.com/PnBO7"}}
+	f := &fakeFetcher{posts: map[string][]Post{"jobs": {digest}}}
+	store := &fakePostStore{}
+	r := CrawlRunner{Fetcher: f, Store: store, Links: fakeLinkMatcher{match: true}}
+
+	stats, err := r.Run(context.Background(), []ChannelEntry{{Channel: "jobs", Kind: KindBoard}})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Stored != 1 || stats.Filtered != 0 {
+		t.Errorf("stats = %+v, want Stored=1 Filtered=0 (link-out digest kept)", stats)
+	}
+	if len(store.stored) != 1 || store.stored[0].done {
+		t.Errorf("post stored done=%v, want pending (false)", store.stored)
+	}
+}
+
 func TestCrawlOneFailingChannelDoesNotAbortTheRun(t *testing.T) {
 	f := &fakeFetcher{
 		posts: map[string][]Post{"good": {vacancyPost(1)}},

--- a/internal/telegram/extract.go
+++ b/internal/telegram/extract.go
@@ -12,6 +12,7 @@ type PendingPost struct {
 	MsgID    int64
 	Text     string
 	PostedAt time.Time
+	Links    []Link
 }
 
 // Extractor classifies a post and extracts its vacancies via an LLM. The kind
@@ -21,6 +22,31 @@ type Extractor interface {
 	Extract(ctx context.Context, text string, kind Kind) (Extraction, error)
 }
 
+// ResolvedJob is a fully-identified vacancy parsed by following a post's outbound link to
+// its destination site (e.g. career.habr.com). Unlike an ExtractedJob it carries its own
+// source identity, so it is stored under the destination platform, not "telegram".
+type ResolvedJob struct {
+	Source      string
+	ExternalID  string
+	URL         string
+	Title       string
+	Company     string
+	Location    string
+	Description string
+	Remote      bool
+	PostedAt    *time.Time
+	WorkMode    string
+}
+
+// LinkResolver turns a post's outbound links into fully-identified jobs by fetching and
+// parsing their destination pages. It returns the jobs from every link a destination
+// adapter matched; a non-nil error means matched links existed but all failed (a transient
+// failure worth retrying), while no matched link yields (nil, nil) so the caller falls back
+// to the LLM. Per-link parse skips and failures are the resolver's concern to log.
+type LinkResolver interface {
+	Resolve(ctx context.Context, links []Link) ([]ResolvedJob, error)
+}
+
 // ExtractStore is the persistence boundary of the extraction worker. Complete
 // writes the extracted jobs through the canonical job upsert and marks the post
 // extracted in one transaction; Fail counts a failed attempt (dead-lettering at
@@ -28,6 +54,9 @@ type Extractor interface {
 type ExtractStore interface {
 	Claim(ctx context.Context, leaseSeconds, batchSize int32) ([]PendingPost, error)
 	Complete(ctx context.Context, post PendingPost, jobs []ExtractedJob) error
+	// CompleteLinks writes link-resolved jobs (each under its own source identity) and
+	// marks the post extracted, the same transactional shape as Complete.
+	CompleteLinks(ctx context.Context, post PendingPost, jobs []ResolvedJob) error
 	Fail(ctx context.Context, post PendingPost, errMsg string) error
 }
 
@@ -53,9 +82,12 @@ type ExtractRunner struct {
 	Extractor Extractor
 	Store     ExtractStore
 	Kinds     map[string]Kind // channel → kind, from channels.yml
+	Links     LinkResolver    // optional; resolves outbound job links to full vacancies
 }
 
-// Run processes one claimed batch and returns its stats.
+// Run processes one claimed batch and returns its stats. A post whose links a destination
+// adapter resolves is stored from those (deterministic) jobs and the LLM is skipped; any
+// other post takes the LLM path.
 func (r ExtractRunner) Run(ctx context.Context) (ExtractStats, error) {
 	var stats ExtractStats
 
@@ -65,6 +97,25 @@ func (r ExtractRunner) Run(ctx context.Context) (ExtractStats, error) {
 	}
 
 	for _, post := range posts {
+		linkJobs, err := r.resolveLinks(ctx, post)
+		if err != nil {
+			// Matched links existed but all failed — fail the post so the lease retries it.
+			log.Printf("telegram: resolve links %s/%d failed: %v", post.Channel, post.MsgID, err)
+			stats.Failed++
+			if ferr := r.Store.Fail(ctx, post, err.Error()); ferr != nil {
+				return stats, ferr
+			}
+			continue
+		}
+		if len(linkJobs) > 0 {
+			if err := r.Store.CompleteLinks(ctx, post, linkJobs); err != nil {
+				return stats, err
+			}
+			stats.Processed++
+			stats.Jobs += len(linkJobs)
+			continue
+		}
+
 		extraction, err := r.Extractor.Extract(ctx, post.Text, r.kind(post.Channel))
 		if err == nil {
 			err = extraction.Validate()
@@ -85,6 +136,15 @@ func (r ExtractRunner) Run(ctx context.Context) (ExtractStats, error) {
 		stats.Jobs += len(extraction.Jobs)
 	}
 	return stats, nil
+}
+
+// resolveLinks follows a post's outbound links to full vacancies, returning nil when no
+// resolver is configured or the post has no links.
+func (r ExtractRunner) resolveLinks(ctx context.Context, post PendingPost) ([]ResolvedJob, error) {
+	if r.Links == nil || len(post.Links) == 0 {
+		return nil, nil
+	}
+	return r.Links.Resolve(ctx, post.Links)
 }
 
 // kind resolves a channel's configured kind, defaulting to board for a post

--- a/internal/telegram/extract_test.go
+++ b/internal/telegram/extract_test.go
@@ -26,10 +26,28 @@ type completion struct {
 	jobs []ExtractedJob
 }
 
+type linkCompletion struct {
+	post PendingPost
+	jobs []ResolvedJob
+}
+
 type fakeExtractStore struct {
-	pending   []PendingPost
-	completed []completion
-	failures  []string
+	pending       []PendingPost
+	completed     []completion
+	linkCompleted []linkCompletion
+	failures      []string
+}
+
+// fakeLinkResolver returns canned resolved jobs (and/or an error) for any post's links.
+type fakeLinkResolver struct {
+	jobs  []ResolvedJob
+	err   error
+	calls int
+}
+
+func (f *fakeLinkResolver) Resolve(_ context.Context, _ []Link) ([]ResolvedJob, error) {
+	f.calls++
+	return f.jobs, f.err
 }
 
 func (s *fakeExtractStore) Claim(_ context.Context, _ int32, batch int32) ([]PendingPost, error) {
@@ -44,6 +62,11 @@ func (s *fakeExtractStore) Claim(_ context.Context, _ int32, batch int32) ([]Pen
 
 func (s *fakeExtractStore) Complete(_ context.Context, post PendingPost, jobs []ExtractedJob) error {
 	s.completed = append(s.completed, completion{post: post, jobs: jobs})
+	return nil
+}
+
+func (s *fakeExtractStore) CompleteLinks(_ context.Context, post PendingPost, jobs []ResolvedJob) error {
+	s.linkCompleted = append(s.linkCompleted, linkCompletion{post: post, jobs: jobs})
 	return nil
 }
 
@@ -136,6 +159,83 @@ func TestExtractLLMErrorIsFailed(t *testing.T) {
 	}
 	if stats.Failed != 1 {
 		t.Errorf("stats = %+v, want Failed=1", stats)
+	}
+}
+
+func linkPost() PendingPost {
+	p := pendingPost()
+	p.Links = []Link{{Text: "Product manager в СберЗдоровье", URL: "https://u.habr.com/PnBO7"}}
+	return p
+}
+
+func TestExtractRoutesLinkPostToResolverAndSkipsLLM(t *testing.T) {
+	resolver := &fakeLinkResolver{jobs: []ResolvedJob{
+		{Source: "habr_career", ExternalID: "1000166712", Title: "Product manager", Company: "СберЗдоровье", Description: "<p>...</p>"},
+	}}
+	ex := &fakeExtractor{result: Extraction{Jobs: []ExtractedJob{{Title: "should not be used"}}}}
+	store := &fakeExtractStore{pending: []PendingPost{linkPost()}}
+	r := ExtractRunner{Extractor: ex, Store: store, Kinds: kinds(), Links: resolver}
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Processed != 1 || stats.Jobs != 1 || stats.Failed != 0 {
+		t.Errorf("stats = %+v, want Processed=1 Jobs=1 Failed=0", stats)
+	}
+	if len(store.linkCompleted) != 1 || len(store.linkCompleted[0].jobs) != 1 {
+		t.Fatalf("linkCompleted = %+v, want one completion with 1 job", store.linkCompleted)
+	}
+	if store.linkCompleted[0].jobs[0].Source != "habr_career" {
+		t.Errorf("resolved job source = %q, want habr_career", store.linkCompleted[0].jobs[0].Source)
+	}
+	if len(ex.prompts) != 0 {
+		t.Errorf("LLM extractor was called %d times, want 0 (link post bypasses the LLM)", len(ex.prompts))
+	}
+	if len(store.completed) != 0 {
+		t.Errorf("LLM completion path used: %+v", store.completed)
+	}
+}
+
+func TestExtractFallsBackToLLMWhenNoLinkMatches(t *testing.T) {
+	resolver := &fakeLinkResolver{jobs: nil} // links present but none matched a destination
+	ex := &fakeExtractor{result: Extraction{Jobs: []ExtractedJob{{Title: "ML Engineer", Company: "Acme", Description: "x"}}}}
+	store := &fakeExtractStore{pending: []PendingPost{linkPost()}}
+	r := ExtractRunner{Extractor: ex, Store: store, Kinds: kinds(), Links: resolver}
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Processed != 1 || stats.Jobs != 1 {
+		t.Errorf("stats = %+v, want Processed=1 Jobs=1 via the LLM fallback", stats)
+	}
+	if len(ex.prompts) != 1 {
+		t.Errorf("LLM extractor calls = %d, want 1 (fallback)", len(ex.prompts))
+	}
+	if len(store.completed) != 1 || len(store.linkCompleted) != 0 {
+		t.Errorf("want one LLM completion and no link completion; got completed=%+v link=%+v", store.completed, store.linkCompleted)
+	}
+}
+
+func TestExtractFailsPostWhenAllLinksFail(t *testing.T) {
+	resolver := &fakeLinkResolver{err: errors.New("habr 503")}
+	ex := &fakeExtractor{result: Extraction{Jobs: []ExtractedJob{{Title: "should not run"}}}}
+	store := &fakeExtractStore{pending: []PendingPost{linkPost()}}
+	r := ExtractRunner{Extractor: ex, Store: store, Kinds: kinds(), Links: resolver}
+
+	stats, err := r.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if stats.Failed != 1 || stats.Processed != 0 {
+		t.Errorf("stats = %+v, want Failed=1 Processed=0", stats)
+	}
+	if len(ex.prompts) != 0 {
+		t.Errorf("LLM was called on a failed-link post: %d times", len(ex.prompts))
+	}
+	if len(store.failures) != 1 {
+		t.Errorf("failures = %v, want 1 (retry via lease)", store.failures)
 	}
 }
 

--- a/internal/telegram/preview.go
+++ b/internal/telegram/preview.go
@@ -15,6 +15,15 @@ type Post struct {
 	MsgID    int64
 	PostedAt time.Time
 	Text     string
+	// Links are the message's outbound hyperlinks (anchor text + href), preserved so the
+	// extraction step can follow them; nodeText keeps Text itself clean of raw URLs.
+	Links []Link
+}
+
+// Link is one hyperlink found in a message: its visible anchor text and its href.
+type Link struct {
+	Text string `json:"text"`
+	URL  string `json:"url"`
 }
 
 // ParsePreview extracts the posts from a t.me/s/<channel> preview page. The page
@@ -74,6 +83,7 @@ func postID(n *html.Node, prefix string) (int64, bool) {
 func parseMessage(n *html.Node, id int64) (Post, bool) {
 	var postedAt time.Time
 	var text string
+	var links []Link
 
 	var walk func(*html.Node)
 	walk = func(n *html.Node) {
@@ -87,6 +97,7 @@ func parseMessage(n *html.Node, id int64) (Post, bool) {
 				}
 			case hasClass(n, "tgme_widget_message_text"):
 				text = nodeText(n)
+				links = messageLinks(n)
 				return
 			}
 		}
@@ -100,7 +111,27 @@ func parseMessage(n *html.Node, id int64) (Post, bool) {
 	if postedAt.IsZero() || text == "" {
 		return Post{}, false
 	}
-	return Post{MsgID: id, PostedAt: postedAt, Text: text}, true
+	return Post{MsgID: id, PostedAt: postedAt, Text: text, Links: links}, true
+}
+
+// messageLinks collects the message's anchors as {text, href} in document order. A blank
+// href is skipped; the anchor text is flattened the same way as the body so it reads
+// cleanly. The hrefs are dropped from nodeText, so this is the only place they survive.
+func messageLinks(n *html.Node) []Link {
+	var links []Link
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			if href := attr(n, "href"); href != "" {
+				links = append(links, Link{Text: strings.TrimSpace(nodeText(n)), URL: href})
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return links
 }
 
 // nodeText flattens a node to plain text: entities are already decoded by the

--- a/internal/telegram/preview_test.go
+++ b/internal/telegram/preview_test.go
@@ -54,6 +54,41 @@ func TestParsePreviewYieldsPostsInPageOrder(t *testing.T) {
 	}
 }
 
+func TestParsePreviewCapturesMessageLinks(t *testing.T) {
+	// A digest post: the teaser text plus outbound vacancy links whose hrefs nodeText
+	// would otherwise drop. The links must survive for the link-following step.
+	const page = `<html><body>
+<div class="tgme_widget_message" data-post="habr_career/75410">
+  <time datetime="2026-06-13T10:19:00+00:00">10:19</time>
+  <div class="tgme_widget_message_text">Работа для начинающих на Хабр Карьере.
+    <a href="https://u.habr.com/PnBO7">Product manager в СберЗдоровье</a>.
+    <a href="https://u.habr.com/fq3n5">Больше вакансий</a>
+  </div>
+</div></body></html>`
+
+	posts, err := ParsePreview("habr_career", []byte(page))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(posts) != 1 {
+		t.Fatalf("posts = %d, want 1", len(posts))
+	}
+	links := posts[0].Links
+	if len(links) != 2 {
+		t.Fatalf("links = %d (%+v), want 2", len(links), links)
+	}
+	if links[0].URL != "https://u.habr.com/PnBO7" || links[0].Text != "Product manager в СберЗдоровье" {
+		t.Errorf("links[0] = %+v", links[0])
+	}
+	if links[1].URL != "https://u.habr.com/fq3n5" || links[1].Text != "Больше вакансий" {
+		t.Errorf("links[1] = %+v", links[1])
+	}
+	// The plain text stays clean (no raw hrefs leaked into it).
+	if strings.Contains(posts[0].Text, "u.habr.com") {
+		t.Errorf("text leaked a href: %q", posts[0].Text)
+	}
+}
+
 func TestParsePreviewZeroPostsIsAnError(t *testing.T) {
 	// A page with no recognizable posts means the markup drifted or the channel
 	// has no preview — the caller must count the channel failed, loudly.

--- a/migrations/0010_telegram_post_links.sql
+++ b/migrations/0010_telegram_post_links.sql
@@ -1,0 +1,9 @@
+-- Preserve a post's outbound hyperlinks (anchor text + href) alongside its plain text.
+-- The crawl parser drops hrefs from `text` (it stays clean for the LLM), so the links go
+-- here as a JSON array of {text, url}. The extraction worker follows them to fetch full
+-- vacancies from destination sites (e.g. career.habr.com) instead of the thin teaser.
+--
+-- Applied by Postgres on first volume init (same as 0001-0009) and read by sqlc. On an
+-- existing volume this must be applied manually (no versioned migration runner yet).
+ALTER TABLE telegram_posts
+    ADD COLUMN IF NOT EXISTS links JSONB NOT NULL DEFAULT '[]';


### PR DESCRIPTION
## Summary
Shop-window Telegram channels post a teaser + a link to the real vacancy page; the crawl stripped `href`s, so the LLM only ever saw the teaser (thin/empty jobs). A survey of `sources/telegram.yml` found this LINK-OUT pattern in ~22/37 channels — so this unlocks the majority, not an edge case.

- **`internal/linksource`** — a domain-keyed adapter registry (parallel to `sources.All`) that turns one job-detail URL into a full `sources.Job` from the page's schema.org `JobPosting` JSON-LD. Two adapters this iteration:
  - **habr_career**: `u.habr.com` → 301 → `career.habr.com/vacancies/<id>` (e.g. the digest `t.me/habr_career/75410` now yields full ~6k-char descriptions instead of teaser stubs).
  - **remoteyeah**: `remoteyeah.com/jobs/<slug>`.
- **Own identity / dedup**: stored as `source="habr_career"`/`"remoteyeah"`, `external_id`=vacancy id/slug → the same vacancy linked from several channels dedups to one row.
- **Routing (automatic, by link domain)**: `tg-extract` resolves a post's links first; if any resolve, it writes those (`CompleteLinks`, same UpsertJob + enrichment-enqueue tx) and skips the LLM; otherwise the existing LLM path runs unchanged.
- **Crawl**: anchors preserved in `telegram_posts.links` (jsonb, migration `0010`); a `LinkMatcher` keeps link-out digests the text prefilter would otherwise drop. `nodeText` untouched, so `text` stays clean for the LLM.
- **HTTP**: `sources.Client.GetHTMLResolved` exposes the final URL after redirects.
- **Security**: habr bounds SSRF by requiring the resolved host be `career.habr.com`; remoteyeah sanitizes the structured salary it folds into the `{@html}`-rendered description.

Backlog (same seam, deferred): `youngjunior.ru`, `geekjob.ru`, `vseti.app`, `yandex.ru/jobs`, `budu.jobs`, `tgwork.pro`, `ashbyhq`. `hh.ru` excluded (off-limits).

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` — all pass (TDD: red→green per unit; http client, registry, both adapters, link capture, routing, prefilter matcher, resolver, + SSRF & salary-XSS regression tests)
- [x] Live-verified both adapters resolve real pages (throwaway test, removed)
- [ ] **Prod**: apply `migrations/0010_telegram_post_links.sql` manually (initdb does not re-run on an existing volume)
- [ ] After deploy, run `tg-ingest` then `tg-extract`; confirm `habr_career`/`remoteyeah` jobs land with full descriptions