### PR TITLE
web: landing 'for agents' CLI section

### DIFF
--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -2,6 +2,7 @@
   import { Button } from '$lib/ui';
 
   const GITHUB = 'https://github.com/strelov1/freehire';
+  const CLI = 'https://github.com/strelov1/freehire-cli';
 
   // The real adapters behind the pipeline — listed verbatim so the page never
   // overpromises sources the ingest worker can't actually crawl.
@@ -142,6 +143,49 @@
           <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{step.body}</p>
         </div>
       {/each}
+    </div>
+  </section>
+
+  <!-- CLI / agents — the same API from the terminal. Mirrors the open-source
+       section's two-column copy + terminal figure. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// for agents</p>
+    <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
+      <div>
+        <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+          Use it from the terminal. Built for agents.
+        </h2>
+        <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
+          freehire is also a CLI, so an AI agent or a script can search, open and apply to jobs over the
+          same API — no browser. Create an API key and it lives in
+          <code class="font-mono text-foreground">~/.freehire/creds.json</code>; add
+          <code class="font-mono text-foreground">--json</code> for machine-readable output.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <Button href={CLI} target="_blank" rel="noopener noreferrer" variant="primary" size="lg">
+            freehire-cli on GitHub ↗
+          </Button>
+          <Button href="/my/api-keys" variant="ghost" size="lg">Get an API key</Button>
+        </div>
+      </div>
+
+      <figure
+        class="overflow-hidden rounded-xl border border-border bg-secondary/60 font-mono text-sm shadow-sm"
+      >
+        <figcaption
+          class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground"
+        >
+          <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+          terminal
+        </figcaption>
+        <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># install — no Go needed</span>
+curl -fsSL <span class="text-foreground">.../freehire-cli/main/install.sh</span> | sh
+
+<span class="text-muted-foreground"># authenticate once, then search &amp; apply</span>
+freehire auth login --token <span class="text-foreground">fhk_…</span>
+freehire search <span class="text-foreground">"golang"</span> --remote --region eu
+freehire apply <span class="text-foreground">&lt;slug&gt;</span></pre>
+      </figure>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Adds a **"for agents"** section to the freehire.dev landing page: what the CLI is, the `curl … | sh` install one-liner, and `auth login` / `search --remote --region` / `apply` examples.
- Links to the `freehire-cli` repo and to `/my/api-keys`. Matches the existing open-source section's two-column copy + terminal figure.

## Test plan
- [x] `svelte-check` 0 errors / 0 warnings
- [x] `vite build` succeeds
- [x] No new lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)