### PR TITLE
linksource: add geekjob.ru adapter (+ shared salary/remote helpers)

### DIFF
--- a/internal/linksource/geekjob.go
+++ b/internal/linksource/geekjob.go
@@ -1,0 +1,80 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// geekjob resolves Geekjob.ru vacancies. Posts link directly to
+// geekjob.ru/vacancy/<id>; the id from the URL is the stable canonical key (the JSON-LD
+// also carries a separate internal numeric id, which we ignore so the stored id matches
+// the link and dedups across channels).
+type geekjob struct {
+	http Client
+}
+
+// NewGeekjob builds the Geekjob link-source adapter.
+func NewGeekjob(c Client) LinkSource { return geekjob{http: c} }
+
+func (geekjob) Source() string { return "geekjob" }
+
+// geekjobVacancyPath matches the canonical vacancy path, capturing the id.
+var geekjobVacancyPath = regexp.MustCompile(`^/vacancy/([0-9a-zA-Z]+)/?$`)
+
+// Match handles geekjob.ru/vacancy/<id> links only.
+func (geekjob) Match(u *url.URL) bool {
+	return host(u) == "geekjob.ru" && geekjobVacancyPath.MatchString(u.Path)
+}
+
+// geekjobPosting selects the JobPosting ld+json fields Geekjob publishes.
+type geekjobPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	BaseSalary monetaryAmount `json:"baseSalary"`
+}
+
+// Resolve fetches the vacancy page and parses its JobPosting ld+json. The id comes from the
+// URL path (the page's internal identifier differs and is ignored).
+func (g geekjob) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	m := geekjobVacancyPath.FindStringSubmatch(u.Path)
+	if m == nil {
+		return sources.Job{}, false, nil
+	}
+	id := m[1]
+
+	node, err := g.http.GetHTML(ctx, raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	var p geekjobPosting
+	if !sources.LDJobPosting(node, &p) {
+		return sources.Job{}, false, fmt.Errorf("linksource: geekjob vacancy %s has no JobPosting ld+json", id)
+	}
+
+	desc := sources.SanitizeHTML(p.Description)
+	if salary := salaryParagraph(p.BaseSalary); salary != "" {
+		desc = sources.SanitizeHTML(salary) + desc
+	}
+	return sources.Job{
+		ExternalID:  id,
+		URL:         "https://geekjob.ru/vacancy/" + id,
+		Title:       p.Title,
+		Company:     p.HiringOrganization.Name,
+		Description: desc,
+		Remote:      isTelecommute(p.JobLocationType),
+		PostedAt:    parseDate(p.DatePosted),
+	}, true, nil
+}

--- a/internal/linksource/geekjob_test.go
+++ b/internal/linksource/geekjob_test.go
@@ -1,0 +1,58 @@
+package linksource
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// geekjobVacancyHTML mirrors a real geekjob.ru vacancy page's JobPosting ld+json: a hex id
+// in the URL (and a separate internal numeric identifier we ignore), a clean company, a
+// MonetaryAmount salary with a unitText, and an HTML description.
+const geekjobVacancyHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Head of HR в IT Consulting, remote",
+ "datePosted":"2026-06-02",
+ "description":"<h4>О компании</h4><p>Build &amp; grow.</p><script>evil()<\/script>",
+ "identifier":{"@type":"PropertyValue","name":"Geekjob 6a1ebb8520ad023342091661","value":"171018"},
+ "hiringOrganization":{"@type":"Organization","name":"Агентство NEWHR"},
+ "baseSalary":{"@type":"MonetaryAmount","currency":"USD","value":{"@type":"QuantitativeValue","unitText":"MONTH","minValue":4000,"maxValue":5000}}}
+</script></head><body></body></html>`
+
+func TestGeekjobResolvesVacancy(t *testing.T) {
+	const link = "https://geekjob.ru/vacancy/6a1ebb8520ad023342091661?utm_source=telegram"
+	c := (&fakeClient{}).route("/vacancy/6a1ebb8520ad023342091661", geekjobVacancyHTML, "")
+
+	job, ok, err := NewGeekjob(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	// The canonical id is the hex from the URL, not the internal identifier value (171018).
+	if job.ExternalID != "6a1ebb8520ad023342091661" {
+		t.Errorf("ExternalID = %q, want the URL hex id", job.ExternalID)
+	}
+	if job.URL != "https://geekjob.ru/vacancy/6a1ebb8520ad023342091661" {
+		t.Errorf("URL = %q, want canonical without utm", job.URL)
+	}
+	if !strings.Contains(job.Title, "Head of HR") {
+		t.Errorf("Title = %q", job.Title)
+	}
+	if job.Company != "Агентство NEWHR" {
+		t.Errorf("Company = %q, want Агентство NEWHR", job.Company)
+	}
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "Build &amp; grow.") {
+		t.Errorf("Description not sanitized/decoded: %q", job.Description)
+	}
+	if !strings.Contains(job.Description, "4000") || !strings.Contains(job.Description, "5000") ||
+		!strings.Contains(job.Description, "USD") || !strings.Contains(job.Description, "month") {
+		t.Errorf("Description missing folded salary (4000–5000 USD/month): %q", job.Description)
+	}
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-02", job.PostedAt)
+	}
+}

--- a/internal/linksource/helpers.go
+++ b/internal/linksource/helpers.go
@@ -1,6 +1,64 @@
 package linksource
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// monetaryAmount is the schema.org MonetaryAmount shape JobPosting ld+json uses for
+// baseSalary, shared by the adapters that fold a structured salary into the description.
+type monetaryAmount struct {
+	Currency string `json:"currency"`
+	Value    struct {
+		MinValue float64 `json:"minValue"`
+		MaxValue float64 `json:"maxValue"`
+		UnitText string  `json:"unitText"`
+	} `json:"value"`
+}
+
+// salaryParagraph renders a structured salary range as a leading <p>, or "" when no amount
+// is stated. sources.Job has no dedicated salary field, so adapters fold it into the
+// description (sanitize the result — currency is third-party text) to keep it visible and
+// available to enrichment.
+func salaryParagraph(s monetaryAmount) string {
+	min, max := s.Value.MinValue, s.Value.MaxValue
+	if min <= 0 && max <= 0 {
+		return ""
+	}
+	cur, unit := s.Currency, salaryUnit(s.Value.UnitText)
+	switch {
+	case min > 0 && max > 0:
+		return fmt.Sprintf("<p>Salary: %.0f–%.0f %s%s</p>", min, max, cur, unit)
+	case min > 0:
+		return fmt.Sprintf("<p>Salary: from %.0f %s%s</p>", min, cur, unit)
+	default:
+		return fmt.Sprintf("<p>Salary: up to %.0f %s%s</p>", max, cur, unit)
+	}
+}
+
+// isTelecommute reports whether a schema.org jobLocationType marks a fully-remote role.
+func isTelecommute(jobLocationType string) bool {
+	return strings.EqualFold(jobLocationType, "TELECOMMUTE")
+}
+
+// salaryUnit maps a schema.org UnitText to a "/period" suffix, or "" when absent/unknown.
+func salaryUnit(u string) string {
+	switch strings.ToUpper(u) {
+	case "HOUR":
+		return "/hour"
+	case "DAY":
+		return "/day"
+	case "WEEK":
+		return "/week"
+	case "MONTH":
+		return "/month"
+	case "YEAR":
+		return "/year"
+	default:
+		return ""
+	}
+}
 
 // parseDate parses a date-only timestamp ("2006-01-02", as Habr's datePosted emits),
 // returning nil for an empty or unparseable value (posted_at is nullable).

--- a/internal/linksource/registry.go
+++ b/internal/linksource/registry.go
@@ -41,6 +41,7 @@ func All(c Client) []LinkSource {
 	return []LinkSource{
 		NewHabrCareer(c),
 		NewRemoteYeah(c),
+		NewGeekjob(c),
 	}
 }
 

--- a/internal/linksource/registry_test.go
+++ b/internal/linksource/registry_test.go
@@ -15,6 +15,8 @@ func TestFindMatchesAdapterByLinkHost(t *testing.T) {
 		{"https://u.habr.com/PnBO7", "habr_career"},
 		{"https://career.habr.com/vacancies/1000166712", "habr_career"},
 		{"https://remoteyeah.com/jobs/remote-senior-quality-engineer-peek", "remoteyeah"},
+		{"https://geekjob.ru/vacancy/6a1ebb8520ad023342091661", "geekjob"},
+		{"https://geekjob.ru/", ""},            // homepage, not a /vacancy/<id> link
 		{"https://remoteyeah.com/", ""},        // homepage, not a /jobs/<slug> link
 		{"https://example.com/jobs/x", ""},     // unknown domain
 		{"https://t.me/habr_career/75410", ""}, // the post itself, not an outbound link

--- a/internal/linksource/remoteyeah.go
+++ b/internal/linksource/remoteyeah.go
@@ -36,13 +36,7 @@ type remoteYeahPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	BaseSalary struct {
-		Currency string `json:"currency"`
-		Value    struct {
-			MinValue float64 `json:"minValue"`
-			MaxValue float64 `json:"maxValue"`
-		} `json:"value"`
-	} `json:"baseSalary"`
+	BaseSalary monetaryAmount `json:"baseSalary"`
 }
 
 // Resolve fetches the job page and parses its JobPosting ld+json. The slug from the link
@@ -67,7 +61,7 @@ func (r remoteYeah) Resolve(ctx context.Context, raw string) (sources.Job, bool,
 	}
 
 	desc := sources.SanitizeHTML(p.Description)
-	if salary := remoteYeahSalary(p); salary != "" {
+	if salary := salaryParagraph(p.BaseSalary); salary != "" {
 		// Sanitize the salary fragment too: its currency is third-party JSON-LD text and
 		// the description is rendered with {@html}, so an unsanitized prefix is stored XSS.
 		desc = sources.SanitizeHTML(salary) + desc
@@ -78,26 +72,7 @@ func (r remoteYeah) Resolve(ctx context.Context, raw string) (sources.Job, bool,
 		Title:       p.Title,
 		Company:     p.HiringOrganization.Name,
 		Description: desc,
-		Remote:      strings.EqualFold(p.JobLocationType, "TELECOMMUTE"),
+		Remote:      isTelecommute(p.JobLocationType),
 		PostedAt:    parseRFC3339(p.DatePosted),
 	}, true, nil
-}
-
-// remoteYeahSalary renders a structured baseSalary range as a leading paragraph, or "" when
-// the page states no amount. Folding it into the description keeps it visible and lets
-// enrichment pick it up (sources.Job has no dedicated salary field).
-func remoteYeahSalary(p remoteYeahPosting) string {
-	min, max := p.BaseSalary.Value.MinValue, p.BaseSalary.Value.MaxValue
-	if min <= 0 && max <= 0 {
-		return ""
-	}
-	cur := p.BaseSalary.Currency
-	switch {
-	case min > 0 && max > 0:
-		return fmt.Sprintf("<p>Salary: %.0f–%.0f %s</p>", min, max, cur)
-	case min > 0:
-		return fmt.Sprintf("<p>Salary: from %.0f %s</p>", min, cur)
-	default:
-		return fmt.Sprintf("<p>Salary: up to %.0f %s</p>", max, cur)
-	}
 }


### PR DESCRIPTION
## Summary
Adds the next destination domain to the TG link-following registry (#27). `geekjob.ru` was the second-most-frequent outbound domain in the channel survey (~6 channels) and serves a clean schema.org `JobPosting` JSON-LD — the same shape as habr/remoteyeah, so it slots in as **one adapter + one registry line**, auto-wired through `linksource.All` (no DB, migration, config, or worker changes).

- **geekjob**: `geekjob.ru/vacancy/<id>` → JSON-LD `JobPosting`. `external_id` = the id from the URL path (the JSON-LD also carries a separate internal numeric id, ignored, so the stored id matches the link and dedups across channels). `source="geekjob"`.
- **DRY**: extracted a shared `salaryParagraph(monetaryAmount)` + `isTelecommute` helper and refactored `remoteyeah` onto them. geekjob adds salary `unitText` → renders `/month` etc.
- Live-verified against a real geekjob vacancy (company "Агентство NEWHR", ~6k-char description with folded salary).

Backlog remaining (same seam): `vseti.app`, `yandex.ru/jobs`, `budu.jobs`, `tgwork.pro`, `ashbyhq`. (`youngjunior.ru` evaluated and deferred — no JSON-LD/API, hashed-class DOM, aggregator-of-aggregator with TG-handle "company" → low value/high fragility.)

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` — all pass (TDD: registry routing + geekjob Resolve via fixture; remoteyeah refactor keeps its tests incl. salary-XSS green)
- [x] Live-verified geekjob resolves a real page (throwaway test, removed)
- [ ] No deploy changes needed beyond the already-pending #27 migration; after deploy, a geekjob link in any crawled channel resolves to a full vacancy