### PR TITLE
location: resolve Cyrillic RU-segment locations

### DIFF
--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -90,6 +90,44 @@ var nameToCountry = map[string]string{
 	"armenia": "am", "yerevan": "am",
 	"azerbaijan": "az", "baku": "az",
 	"tbilisi": "ge",
+
+	// Cyrillic, for the RU-segment ATS sources (sber, mts, alfabank, tbank, vk,
+	// huntflow, …) whose location fields are in Russian. Seeded from the
+	// high-frequency unresolved strings observed in production; grow by
+	// observation. "россия"/"рф" are the country catch-all (the comma tokenizer
+	// resolves "Самара, Россия" via the country token even when the city is
+	// unknown). The "г "/"город " city-marker prefix is stripped before lookup
+	// (stripCityPrefix), so only the bare city name is keyed.
+	"россия": "ru", "рф": "ru",
+	"москва": "ru", "санкт-петербург": "ru", "спб": "ru", "питер": "ru",
+	"екатеринбург": "ru", "новосибирск": "ru", "нижний новгород": "ru",
+	"казань": "ru", "самара": "ru", "краснодар": "ru", "ростов-на-дону": "ru",
+	"воронеж": "ru", "уфа": "ru", "пермь": "ru", "челябинск": "ru",
+	"волгоград": "ru", "красноярск": "ru", "омск": "ru", "тюмень": "ru",
+	"саратов": "ru", "тольятти": "ru", "ижевск": "ru", "ульяновск": "ru",
+	"барнаул": "ru", "владивосток": "ru", "хабаровск": "ru", "иркутск": "ru",
+	"ярославль": "ru", "томск": "ru", "оренбург": "ru", "кемерово": "ru",
+	"рязань": "ru", "набережные челны": "ru", "пенза": "ru", "липецк": "ru",
+	"тула": "ru", "киров": "ru", "чебоксары": "ru", "калининград": "ru",
+	"ставрополь": "ru", "сочи": "ru", "иваново": "ru", "брянск": "ru",
+	"белгород": "ru", "сургут": "ru", "владимир": "ru", "архангельск": "ru",
+	"калуга": "ru", "смоленск": "ru", "волжский": "ru", "курск": "ru",
+	"орёл": "ru", "череповец": "ru", "вологда": "ru", "магнитогорск": "ru",
+	"тамбов": "ru", "мурманск": "ru", "тверь": "ru", "новокузнецк": "ru",
+	"астрахань": "ru", "великий новгород": "ru", "псков": "ru", "чита": "ru",
+	"улан-удэ": "ru", "якутск": "ru", "норильск": "ru", "новороссийск": "ru",
+	"таганрог": "ru", "сарапул": "ru", "майкоп": "ru", "подольск": "ru",
+	"химки": "ru", "мытищи": "ru", "балашиха": "ru", "курган": "ru",
+	"саранск": "ru", "йошкар-ола": "ru", "благовещенск": "ru", "кисловодск": "ru",
+	"петропавловск-камчатский": "ru", "комсомольск-на-амуре": "ru",
+	"новый уренгой": "ru",
+
+	// CIS / Central Asia / Ukraine in Cyrillic, mirroring their Latin entries.
+	"минск": "by", "беларусь": "by",
+	"ташкент": "uz", "узбекистан": "uz",
+	"алматы": "kz", "астана": "kz", "казахстан": "kz",
+	"ереван": "am", "баку": "az", "бишкек": "kg",
+	"киев": "ua", "київ": "ua",
 }
 
 // nameToRegion resolves macro-region names (and explicit open-anywhere markers)

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -52,6 +52,7 @@ func Parse(location string) Geo {
 		if tok == "" {
 			continue
 		}
+		tok = stripCityPrefix(tok)
 		if code, ok := nameToCountry[tok]; ok {
 			countrySet[code] = struct{}{}
 			if r, ok := countryToRegion[code]; ok {
@@ -71,6 +72,24 @@ func Parse(location string) Geo {
 	}
 }
 
+// cityMarkerPrefixes are the Russian "city" abbreviations that RU-segment ATS
+// data prepends to a bare city name ("г Москва", "город Самара"). Stripped from a
+// token before lookup so the city resolves; checked longest-first so "город "
+// wins over "г ". A city whose name merely starts with "г" ("Грозный") is
+// untouched — every prefix ends in a separator the name doesn't.
+var cityMarkerPrefixes = []string{"город ", "г. ", "г.", "г "}
+
+// stripCityPrefix removes a leading Russian city marker from an already-lowercased,
+// trimmed token, returning the bare city name (or the token unchanged).
+func stripCityPrefix(tok string) string {
+	for _, p := range cityMarkerPrefixes {
+		if rest, ok := strings.CutPrefix(tok, p); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return tok
+}
+
 // workModeMarkers maps a work mode to the substrings that signal it, checked in
 // priority order: hybrid (most specific) beats a remote marker in the same
 // string, and an explicit onsite marker is the last resort. A location with no
@@ -79,8 +98,8 @@ var workModeMarkers = []struct {
 	mode    string
 	markers []string
 }{
-	{"hybrid", []string{"hybrid"}},
-	{"remote", []string{"remote", "work from home", "wfh", "anywhere", "worldwide", "distributed"}},
+	{"hybrid", []string{"hybrid", "гибрид"}},
+	{"remote", []string{"remote", "work from home", "wfh", "anywhere", "worldwide", "distributed", "удал"}},
 	{"onsite", []string{"on-site", "onsite", "on site", "in office", "in-office"}},
 }
 

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -111,6 +111,92 @@ func TestParse(t *testing.T) {
 	}
 }
 
+// TestParseCyrillic covers the RU-segment ATS data, whose location fields are in
+// Cyrillic ("Москва"), sometimes prefixed with the Russian city marker "г"
+// ("г Москва"), and which name a remote/hybrid mode in Russian ("Удалённо").
+func TestParseCyrillic(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     Geo
+	}{
+		{
+			name:     "Cyrillic city Moscow",
+			location: "Москва",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+		},
+		{
+			name:     "city marker prefix is stripped",
+			location: "г Москва",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+		},
+		{
+			name:     "hyphenated Cyrillic city",
+			location: "Санкт-Петербург",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+		},
+		{
+			name:     "multi-word Cyrillic city",
+			location: "Нижний Новгород",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+		},
+		{
+			name:     "country token Россия resolves even past an unknown city",
+			location: "Энск, Россия",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+		},
+		{
+			name:     "abbreviation РФ",
+			location: "РФ",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+		},
+		{
+			name:     "Россия with parenthesised remote marker",
+			location: "Россия (удалённо)",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}, WorkMode: "remote"},
+		},
+		{
+			name:     "bare Удалённо yields remote mode, no geography",
+			location: "Удалённо",
+			want:     Geo{WorkMode: "remote"},
+		},
+		{
+			name:     "Cyrillic hybrid marker with city",
+			location: "Москва, гибрид",
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}, WorkMode: "hybrid"},
+		},
+		{
+			name:     "CIS: Minsk maps to Belarus / cis",
+			location: "Минск",
+			want:     Geo{Countries: []string{"by"}, Regions: []string{"cis"}},
+		},
+		{
+			name:     "Central Asia: Tashkent maps to Uzbekistan",
+			location: "Ташкент",
+			want:     Geo{Countries: []string{"uz"}, Regions: []string{"central_asia"}},
+		},
+		{
+			name:     "Ukrainian spelling Київ maps to Ukraine / eu",
+			location: "Київ",
+			want:     Geo{Countries: []string{"ua"}, Regions: []string{"eu"}},
+		},
+		{
+			name:     "city starting with г is not mistaken for the marker",
+			location: "Грозный",
+			want:     Geo{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.location)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse(%q) = %+v, want %+v", tt.location, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestParseEmitsOnlyKnownVocabulary guards the controlled-vocabulary invariant:
 // every region the parser emits is a member of enrich.RegionValues and every
 // work mode a member of enrich.WorkModeValues — the parser never invents a value


### PR DESCRIPTION
## Problem

`/jobs?regions=ru` shows ~95 jobs, but the DB holds **~9000 Russian-market jobs** (Sber 1900, MTS 2468, Alfa 2327, T-Bank 950, VK 248, …). They were invisible because the `internal/location` dictionary is **Latin-only** (`moscow`→ru), while these sources emit **Cyrillic** location fields:

```
sber:     «г Москва» ×671, «г Санкт-Петербург» ×64 …
mts:      «Москва» ×562, «Новосибирск» ×62 …
alfabank: «Москва» ×416 …   (+1497 empty — out of scope, parser never guesses)
```

None matched → `regions=[]` → not on the `ru` facet.

## Change (dictionary-only, "grow by observation")

- **Cyrillic city/country keys** seeded from the high-frequency unresolved prod strings → `ru` (+ CIS/CA/UA mirrors: минск→by, ташкент→uz, астана/алматы→kz, ереван→am, баку→az, київ→ua).
- **`россия`/`рф` catch-all** — the comma tokenizer resolves "Самара, Россия" via the country token even when the city is unknown.
- **Strip the `г `/`город ` city-marker prefix** before lookup (`stripCityPrefix`) — collapses «г Москва»→«москва» instead of doubling every key. A city merely starting with «г» (Грозный) is untouched.
- **Cyrillic work-mode markers**: `удал`→remote, `гибрид`→hybrid.
- **Deliberately not mapped**: contested territories (Донецк/Луганск/Севастополь/…) and placeholders (мир/другой/регионы) — left unresolved to avoid a political stance / garbage.

## Tests

New `TestParseCyrillic` (TDD: written failing first) covers cities, the «г » prefix, the `россия` catch-all, RU remote/hybrid, CIS/CA/UA, and a guard that «Грозный» isn't mistaken for the marker. Vocabulary-invariant guard still green.

## Rollout

Code change → needs an **app image build** + a **backfill-geo** run (recomputes `regions` for existing rows; idempotent) + **reindex** (refresh Meilisearch facets). New crawls fill geography automatically.