### PR TITLE
feat: application stage pipeline + notes

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -98,4 +98,6 @@ type UserJob struct {
 	ViewedAt  pgtype.Timestamptz `json:"viewed_at"`
 	AppliedAt pgtype.Timestamptz `json:"applied_at"`
 	SavedAt   pgtype.Timestamptz `json:"saved_at"`
+	Stage     pgtype.Text        `json:"stage"`
+	Notes     pgtype.Text        `json:"notes"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -110,7 +110,9 @@ type Querier interface {
 	// listed: a user's history must not shrink when a posting closes.
 	ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error)
 	// Mark a job as applied for a user. Idempotent and independent of a prior view:
-	// it inserts the row (viewed_at defaults) or updates applied_at in place.
+	// it inserts the row (viewed_at defaults) or updates applied_at in place, and
+	// seeds stage='applied' only when the stage is unset (an advanced stage survives
+	// a re-apply, via COALESCE).
 	MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) (UserJob, error)
 	// Completion: the post was processed (jobs written, or no vacancy found). Run in
 	// the same transaction as the extracted jobs' UpsertJob calls.
@@ -150,6 +152,11 @@ type Querier interface {
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's
 	// name variants; ON CONFLICT folds collisions and refreshes existing rows.
 	SyncCompaniesFromJobs(ctx context.Context) error
+	// Set an application's stage and/or notes for a user, idempotently. Upserts the
+	// (user, job) row (viewed_at defaults). Partial update: a NULL param leaves that
+	// column unchanged (COALESCE keeps the existing value), so the caller can set the
+	// stage, the notes, or both in one call. Returns the row.
+	TrackJob(ctx context.Context, arg TrackJobParams) (UserJob, error)
 	// Clear a job's saved mark without deleting the interaction row, so view and
 	// apply history survive unsaving. No interaction row -> pgx.ErrNoRows; the
 	// handler treats that as "already not saved", never as a failure.

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -9,10 +9,13 @@ RETURNING *;
 
 -- name: MarkJobApplied :one
 -- Mark a job as applied for a user. Idempotent and independent of a prior view:
--- it inserts the row (viewed_at defaults) or updates applied_at in place.
-INSERT INTO user_jobs (user_id, job_id, applied_at)
-VALUES ($1, $2, now())
-ON CONFLICT (user_id, job_id) DO UPDATE SET applied_at = now()
+-- it inserts the row (viewed_at defaults) or updates applied_at in place, and
+-- seeds stage='applied' only when the stage is unset (an advanced stage survives
+-- a re-apply, via COALESCE).
+INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
+VALUES ($1, $2, now(), 'applied')
+ON CONFLICT (user_id, job_id) DO UPDATE
+  SET applied_at = now(), stage = COALESCE(user_jobs.stage, 'applied')
 RETURNING *;
 
 -- name: SaveJob :one
@@ -32,13 +35,25 @@ SET saved_at = NULL
 WHERE user_id = $1 AND job_id = $2
 RETURNING *;
 
+-- name: TrackJob :one
+-- Set an application's stage and/or notes for a user, idempotently. Upserts the
+-- (user, job) row (viewed_at defaults). Partial update: a NULL param leaves that
+-- column unchanged (COALESCE keeps the existing value), so the caller can set the
+-- stage, the notes, or both in one call. Returns the row.
+INSERT INTO user_jobs (user_id, job_id, stage, notes)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (user_id, job_id) DO UPDATE
+  SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage),
+      notes = COALESCE(EXCLUDED.notes, user_jobs.notes)
+RETURNING *;
+
 -- name: ListUserJobs :many
 -- A user's job interactions joined with the job rows, most recently touched
 -- first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
 -- viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is
 -- the passive history (rows neither saved nor applied). Closed jobs stay
 -- listed: a user's history must not shrink when a posting closes.
-SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at
+SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -44,7 +44,7 @@ func (q *Queries) CountUserJobs(ctx context.Context, userID int64) (CountUserJob
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, uj.viewed_at, uj.saved_at, uj.applied_at
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -68,6 +68,8 @@ type ListUserJobsRow struct {
 	ViewedAt  pgtype.Timestamptz `json:"viewed_at"`
 	SavedAt   pgtype.Timestamptz `json:"saved_at"`
 	AppliedAt pgtype.Timestamptz `json:"applied_at"`
+	Stage     pgtype.Text        `json:"stage"`
+	Notes     pgtype.Text        `json:"notes"`
 }
 
 // A user's job interactions joined with the job rows, most recently touched
@@ -115,6 +117,8 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,
+			&i.Stage,
+			&i.Notes,
 		); err != nil {
 			return nil, err
 		}
@@ -127,10 +131,11 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 }
 
 const markJobApplied = `-- name: MarkJobApplied :one
-INSERT INTO user_jobs (user_id, job_id, applied_at)
-VALUES ($1, $2, now())
-ON CONFLICT (user_id, job_id) DO UPDATE SET applied_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at
+INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
+VALUES ($1, $2, now(), 'applied')
+ON CONFLICT (user_id, job_id) DO UPDATE
+  SET applied_at = now(), stage = COALESCE(user_jobs.stage, 'applied')
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes
 `
 
 type MarkJobAppliedParams struct {
@@ -139,7 +144,9 @@ type MarkJobAppliedParams struct {
 }
 
 // Mark a job as applied for a user. Idempotent and independent of a prior view:
-// it inserts the row (viewed_at defaults) or updates applied_at in place.
+// it inserts the row (viewed_at defaults) or updates applied_at in place, and
+// seeds stage='applied' only when the stage is unset (an advanced stage survives
+// a re-apply, via COALESCE).
 func (q *Queries) MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) (UserJob, error) {
 	row := q.db.QueryRow(ctx, markJobApplied, arg.UserID, arg.JobID)
 	var i UserJob
@@ -149,6 +156,8 @@ func (q *Queries) MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) 
 		&i.ViewedAt,
 		&i.AppliedAt,
 		&i.SavedAt,
+		&i.Stage,
+		&i.Notes,
 	)
 	return i, err
 }
@@ -157,7 +166,7 @@ const recordJobView = `-- name: RecordJobView :one
 INSERT INTO user_jobs (user_id, job_id)
 VALUES ($1, $2)
 ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes
 `
 
 type RecordJobViewParams struct {
@@ -177,6 +186,8 @@ func (q *Queries) RecordJobView(ctx context.Context, arg RecordJobViewParams) (U
 		&i.ViewedAt,
 		&i.AppliedAt,
 		&i.SavedAt,
+		&i.Stage,
+		&i.Notes,
 	)
 	return i, err
 }
@@ -185,7 +196,7 @@ const saveJob = `-- name: SaveJob :one
 INSERT INTO user_jobs (user_id, job_id, saved_at)
 VALUES ($1, $2, now())
 ON CONFLICT (user_id, job_id) DO UPDATE SET saved_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes
 `
 
 type SaveJobParams struct {
@@ -204,6 +215,48 @@ func (q *Queries) SaveJob(ctx context.Context, arg SaveJobParams) (UserJob, erro
 		&i.ViewedAt,
 		&i.AppliedAt,
 		&i.SavedAt,
+		&i.Stage,
+		&i.Notes,
+	)
+	return i, err
+}
+
+const trackJob = `-- name: TrackJob :one
+INSERT INTO user_jobs (user_id, job_id, stage, notes)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (user_id, job_id) DO UPDATE
+  SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage),
+      notes = COALESCE(EXCLUDED.notes, user_jobs.notes)
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes
+`
+
+type TrackJobParams struct {
+	UserID int64       `json:"user_id"`
+	JobID  int64       `json:"job_id"`
+	Stage  pgtype.Text `json:"stage"`
+	Notes  pgtype.Text `json:"notes"`
+}
+
+// Set an application's stage and/or notes for a user, idempotently. Upserts the
+// (user, job) row (viewed_at defaults). Partial update: a NULL param leaves that
+// column unchanged (COALESCE keeps the existing value), so the caller can set the
+// stage, the notes, or both in one call. Returns the row.
+func (q *Queries) TrackJob(ctx context.Context, arg TrackJobParams) (UserJob, error) {
+	row := q.db.QueryRow(ctx, trackJob,
+		arg.UserID,
+		arg.JobID,
+		arg.Stage,
+		arg.Notes,
+	)
+	var i UserJob
+	err := row.Scan(
+		&i.UserID,
+		&i.JobID,
+		&i.ViewedAt,
+		&i.AppliedAt,
+		&i.SavedAt,
+		&i.Stage,
+		&i.Notes,
 	)
 	return i, err
 }
@@ -212,7 +265,7 @@ const unsaveJob = `-- name: UnsaveJob :one
 UPDATE user_jobs
 SET saved_at = NULL
 WHERE user_id = $1 AND job_id = $2
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at
+RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes
 `
 
 type UnsaveJobParams struct {
@@ -232,6 +285,8 @@ func (q *Queries) UnsaveJob(ctx context.Context, arg UnsaveJobParams) (UserJob, 
 		&i.ViewedAt,
 		&i.AppliedAt,
 		&i.SavedAt,
+		&i.Stage,
+		&i.Notes,
 	)
 	return i, err
 }

--- a/internal/db/user_jobs_stage_integration_test.go
+++ b/internal/db/user_jobs_stage_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+// Integration tests for the application-stage SQL semantics — TrackJob's partial
+// (COALESCE) upsert and MarkJobApplied seeding stage='applied' only when unset —
+// which are SQL behavior and can only be verified against a real Postgres. Run
+// with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestTrackJobAndStageSeeding(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	uid := seedAPIKeyUser(t, pool, "tracker@example.test")
+	jid := insertJob(t, pool, "track-1")
+
+	t.Run("track stage-only creates the row and leaves notes null", func(t *testing.T) {
+		row, err := q.TrackJob(ctx, TrackJobParams{
+			UserID: uid, JobID: jid, Stage: pgtype.Text{String: "interview", Valid: true},
+		})
+		if err != nil {
+			t.Fatalf("TrackJob: %v", err)
+		}
+		if row.Stage.String != "interview" {
+			t.Errorf("stage = %q, want interview", row.Stage.String)
+		}
+		if row.Notes.Valid {
+			t.Errorf("notes should be null, got %q", row.Notes.String)
+		}
+	})
+
+	t.Run("track notes-only leaves the stage unchanged (partial update)", func(t *testing.T) {
+		row, err := q.TrackJob(ctx, TrackJobParams{
+			UserID: uid, JobID: jid, Notes: pgtype.Text{String: "recruiter called back", Valid: true},
+		})
+		if err != nil {
+			t.Fatalf("TrackJob: %v", err)
+		}
+		if row.Stage.String != "interview" {
+			t.Errorf("stage changed to %q, want it left at interview", row.Stage.String)
+		}
+		if row.Notes.String != "recruiter called back" {
+			t.Errorf("notes = %q", row.Notes.String)
+		}
+	})
+
+	t.Run("MarkApplied seeds stage='applied' only when unset", func(t *testing.T) {
+		jid2 := insertJob(t, pool, "track-2")
+
+		row, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: uid, JobID: jid2})
+		if err != nil {
+			t.Fatalf("MarkJobApplied: %v", err)
+		}
+		if row.Stage.String != "applied" {
+			t.Errorf("first apply: stage = %q, want applied", row.Stage.String)
+		}
+
+		// Advance the stage, then re-apply: the advanced stage must survive.
+		if _, err := q.TrackJob(ctx, TrackJobParams{
+			UserID: uid, JobID: jid2, Stage: pgtype.Text{String: "offer", Valid: true},
+		}); err != nil {
+			t.Fatalf("TrackJob(offer): %v", err)
+		}
+		row, err = q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: uid, JobID: jid2})
+		if err != nil {
+			t.Fatalf("re-apply: %v", err)
+		}
+		if row.Stage.String != "offer" {
+			t.Errorf("re-apply clobbered stage to %q, want offer", row.Stage.String)
+		}
+	})
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -103,6 +103,7 @@ func Register(app *fiber.App, pool *pgxpool.Pool, frontendOrigin, jwtSecret stri
 	api.Post("/jobs/:slug/apply", keyAuth, h.MarkApplied)
 	api.Post("/jobs/:slug/save", keyAuth, h.SaveJob)
 	api.Delete("/jobs/:slug/save", keyAuth, h.UnsaveJob)
+	api.Patch("/jobs/:slug/track", keyAuth, h.TrackJob)
 
 	// User-scoped reads live under /me (consistent with /auth/me): the my-jobs
 	// listing joins the caller's interactions with the jobs they touch.

--- a/internal/handler/me_jobs.go
+++ b/internal/handler/me_jobs.go
@@ -17,6 +17,8 @@ type myJobResponse struct {
 	ViewedAt  pgtype.Timestamptz `json:"viewed_at"`
 	SavedAt   pgtype.Timestamptz `json:"saved_at"`
 	AppliedAt pgtype.Timestamptz `json:"applied_at"`
+	Stage     pgtype.Text        `json:"stage"`
+	Notes     pgtype.Text        `json:"notes"`
 }
 
 // ListMyJobs returns the authenticated user's job interactions joined with the
@@ -62,6 +64,8 @@ func (h *Handler) ListMyJobs(c *fiber.Ctx) error {
 			ViewedAt:  row.ViewedAt,
 			SavedAt:   row.SavedAt,
 			AppliedAt: row.AppliedAt,
+			Stage:     row.Stage,
+			Notes:     row.Notes,
 		})
 	}
 

--- a/internal/handler/track_test.go
+++ b/internal/handler/track_test.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+)
+
+// trackApp mounts the track route on a handler with no DB. The auth gate and the
+// body validation (empty / unknown stage) all reject before any query runs, so
+// the nil queries is never dereferenced. The DB-backed path is covered by the
+// user_jobs integration tests.
+func trackApp() (*fiber.App, *auth.Issuer) {
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &Handler{issuer: iss}
+	app := fiber.New()
+	app.Patch("/jobs/:slug/track", auth.RequireAuth(iss), h.TrackJob)
+	return app, iss
+}
+
+func TestTrackJob_RejectsEmptyAndUnknownStage(t *testing.T) {
+	app, iss := trackApp()
+	token, _ := iss.Issue(7)
+	cases := []struct {
+		name, body string
+	}{
+		{"empty body", `{}`},
+		{"unknown stage", `{"stage":"banana"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+			resp, err := app.Test(req)
+			if err != nil {
+				t.Fatalf("Test: %v", err)
+			}
+			if resp.StatusCode != fiber.StatusBadRequest {
+				t.Errorf("status = %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestTrackJob_RequiresAuth(t *testing.T) {
+	app, _ := trackApp()
+	req := httptest.NewRequest(fiber.MethodPatch, "/jobs/go-dev/track", strings.NewReader(`{"stage":"interview"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestIsValidStage(t *testing.T) {
+	for _, s := range []string{"applied", "screening", "responded", "interview", "offer", "accepted", "rejected", "withdrawn"} {
+		if !isValidStage(s) {
+			t.Errorf("%q should be a valid stage", s)
+		}
+	}
+	for _, s := range []string{"banana", "", "Applied", "interviewing"} {
+		if isValidStage(s) {
+			t.Errorf("%q should be invalid", s)
+		}
+	}
+}
+
+// The interaction shape now carries stage and notes alongside the timestamps.
+func TestInteractionResponse_HasStageAndNotes(t *testing.T) {
+	fields := marshalToFields(t, interactionResponse{JobID: 7})
+	for _, want := range []string{"job_id", "viewed_at", "saved_at", "applied_at", "stage", "notes"} {
+		if _, ok := fields[want]; !ok {
+			t.Errorf("interactionResponse missing %q", want)
+		}
+	}
+}

--- a/internal/handler/user_jobs.go
+++ b/internal/handler/user_jobs.go
@@ -12,17 +12,26 @@ import (
 )
 
 // interactionResponse is the public shape of a user's interaction with a job. It
-// omits user_id (the caller is the user) and carries saved_at/applied_at as null
-// until the job is saved/applied to.
+// omits user_id (the caller is the user) and carries saved_at/applied_at/stage/
+// notes as null until the job is saved, applied to, or tracked.
 type interactionResponse struct {
 	JobID     int64              `json:"job_id"`
 	ViewedAt  pgtype.Timestamptz `json:"viewed_at"`
 	SavedAt   pgtype.Timestamptz `json:"saved_at"`
 	AppliedAt pgtype.Timestamptz `json:"applied_at"`
+	Stage     pgtype.Text        `json:"stage"`
+	Notes     pgtype.Text        `json:"notes"`
 }
 
 func toInteraction(row db.UserJob) interactionResponse {
-	return interactionResponse{JobID: row.JobID, ViewedAt: row.ViewedAt, SavedAt: row.SavedAt, AppliedAt: row.AppliedAt}
+	return interactionResponse{
+		JobID:     row.JobID,
+		ViewedAt:  row.ViewedAt,
+		SavedAt:   row.SavedAt,
+		AppliedAt: row.AppliedAt,
+		Stage:     row.Stage,
+		Notes:     row.Notes,
+	}
 }
 
 // RecordView records that the authenticated user viewed a job and returns the
@@ -91,6 +100,64 @@ func (h *Handler) UnsaveJob(c *fiber.Ctx) error {
 		return err
 	}
 
+	return c.JSON(fiber.Map{"data": toInteraction(row)})
+}
+
+// validStages is the controlled application-stage vocabulary and the source of
+// truth: the track endpoint rejects any value not in this set (the SPA mirrors
+// it). Active pipeline then terminal states.
+var validStages = map[string]bool{
+	"applied": true, "screening": true, "responded": true, "interview": true,
+	"offer": true, "accepted": true, "rejected": true, "withdrawn": true,
+}
+
+func isValidStage(s string) bool { return validStages[s] }
+
+// trackRequest is the track body: an optional stage and/or notes. A nil field is
+// left unchanged by the upsert; at least one must be present.
+type trackRequest struct {
+	Stage *string `json:"stage"`
+	Notes *string `json:"notes"`
+}
+
+// TrackJob sets the application stage and/or notes for the authenticated user's
+// interaction with a job (session cookie or API key). The body is validated
+// before the slug lookup, so a bad request never touches the DB: an empty body or
+// an unknown stage is a 400. A nil field is left unchanged by the upsert. Returns
+// the updated interaction.
+func (h *Handler) TrackJob(c *fiber.Ctx) error {
+	userID, ok := auth.UserID(c)
+	if !ok {
+		return fiber.NewError(fiber.StatusUnauthorized, "unauthorized")
+	}
+
+	var in trackRequest
+	if err := c.BodyParser(&in); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	}
+	if in.Stage == nil && in.Notes == nil {
+		return fiber.NewError(fiber.StatusBadRequest, "provide stage and/or notes")
+	}
+	if in.Stage != nil && !isValidStage(*in.Stage) {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid stage")
+	}
+
+	jobID, err := h.queries.GetJobIDBySlug(c.Context(), c.Params("slug"))
+	if err != nil {
+		return err
+	}
+
+	params := db.TrackJobParams{UserID: userID, JobID: jobID}
+	if in.Stage != nil {
+		params.Stage = pgtype.Text{String: *in.Stage, Valid: true}
+	}
+	if in.Notes != nil {
+		params.Notes = pgtype.Text{String: *in.Notes, Valid: true}
+	}
+	row, err := h.queries.TrackJob(c.Context(), params)
+	if err != nil {
+		return err
+	}
 	return c.JSON(fiber.Map{"data": toInteraction(row)})
 }
 

--- a/migrations/0014_application_stage.sql
+++ b/migrations/0014_application_stage.sql
@@ -1,0 +1,11 @@
+-- Application stage + notes on the per-(user, job) interaction. `stage` tracks
+-- where an application stands — a controlled vocabulary validated in Go
+-- (applied/screening/responded/interview/offer + accepted/rejected/withdrawn);
+-- NULL = not in the pipeline. `notes` is free text; NULL = none. Both live on the
+-- same one-row-per-(user, job) interaction as viewed_at/saved_at/applied_at.
+-- Applied automatically by Postgres on first volume init (same as 0001) and also
+-- serves as schema source for sqlc. Existing volumes/prod need a manual apply
+-- (the versioned-migration-runner seam from AGENT.md remains open).
+
+ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS stage TEXT;
+ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS notes TEXT;

--- a/openspec/changes/add-application-stages/.openspec.yaml
+++ b/openspec/changes/add-application-stages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-13

--- a/openspec/changes/add-application-stages/design.md
+++ b/openspec/changes/add-application-stages/design.md
@@ -1,0 +1,78 @@
+## Context
+
+`user_jobs` is one row per `(user, job)` carrying `viewed_at`, `saved_at`, and
+`applied_at`. `RecordView` / `MarkApplied` / `SaveJob` / `UnsaveJob` upsert it;
+`ListMyJobs` lists and filters it. Handlers resolve the user via `auth.UserID`,
+populated by `RequireAuthOrKey` (session cookie or API key). Nothing tracks where
+an application stands once applied, and there is nowhere to keep a note —
+`hire/CLAUDE.md` flags exactly this (`stage` column + notes) as the next slice.
+
+## Goals / Non-Goals
+
+**Goals:** track an application's position through a controlled stage pipeline and
+hold free-text notes; settable by cookie or API key (so the CLI / career-ops can
+use it); shown and editable on My Jobs; fully additive and backward-compatible.
+
+**Non-Goals:** a stage-specific filter tab; a notes timeline/log; forward-only
+transition enforcement; funnel analytics (career-ops owns those); the
+freehire-cli `stage`/`note` commands (separate repo, downstream follow-up).
+
+## Decisions
+
+- **D1 — `stage` + `notes` as nullable `TEXT` columns on `user_jobs`, not a new
+  table.** They are attributes of the existing interaction; NULL stage = not in
+  the pipeline. *Alternative:* a separate applications table — rejected: the
+  one-row-per-(user,job) interaction already is the application.
+- **D2 — the stage vocabulary is validated in Go, not a DB `CHECK`.** Mirrors the
+  enrichment vocabularies; adding a stage needs no migration, and an unknown
+  value is a clean `400`. *Alternative:* a Postgres enum/CHECK — rejected: rigid,
+  needs a migration to evolve.
+- **D3 — transitions are free** (the handler validates the value is in the
+  vocabulary, not the order). A personal tracker: users jump or correct.
+  Forward-only enforcement is over-engineering.
+- **D4 — one endpoint `PATCH /api/v1/jobs/:slug/track` with `{stage?, notes?}`,
+  partial update.** The query upserts the row (like save/apply) and uses
+  `COALESCE(EXCLUDED.col, user_jobs.col)` so a `nil` field leaves the column
+  untouched. Behind `RequireAuthOrKey` — same access as the other per-user
+  writes. At least one field required (else `400`).
+- **D5 — `MarkApplied` seeds `stage='applied'` only when it is NULL**
+  (`COALESCE(user_jobs.stage, 'applied')` on conflict), so applying enters the
+  pipeline while a manually-advanced stage survives a re-apply.
+- **D6 — `stage`/`notes` are added to `interactionResponse` and `myJobResponse`**,
+  so every interaction read carries them; no new read endpoint.
+- **D7 — My Jobs UI:** a stage badge + a dropdown to change it (calls `track`)
+  and an inline notes textarea saved on blur (calls `track`). Folded into the
+  existing page; no separate Applications page.
+
+## Risks / Trade-offs
+
+- **Stage vocabulary is duplicated (Go backend ↔ SPA labels ↔ future CLI)** → Go
+  is the source of truth; the SPA mirrors it with a documented note (as
+  `facets.ts` mirrors the enrich vocab). Drift renders an unknown stage as a
+  humanized label, never a crash.
+- **No migration runner; `0014` is manual** → recreate the dev volume; prod
+  applies `0014` via psql (`ADD COLUMN IF NOT EXISTS`). Columns are additive +
+  nullable; rollback is reverting the code (dropping the columns is optional and
+  harmless).
+- **Free transitions allow nonsensical jumps** → acceptable for a personal
+  tracker; the UI presents stages in pipeline order.
+- **`notes` empty-string vs NULL** → partial update keys on field *presence*: a
+  body omitting `notes` leaves it untouched; sending `notes:""` clears it to
+  empty. Both are intentional.
+
+## Migration Plan
+
+1. Add `migrations/0014_application_stage.sql` (`ALTER TABLE user_jobs ADD COLUMN
+   IF NOT EXISTS stage TEXT; ... ADD COLUMN IF NOT EXISTS notes TEXT`); run
+   `make sqlc`; recreate the dev volume.
+2. Ship code (queries, handler + route, SPA).
+3. Prod: apply `0014` via psql per the ops runbook (the columns are additive, so
+   it is safe on the live table), then deploy the app + web images.
+
+Rollback: revert the code; the columns can stay (ignored) or be dropped — nothing
+else references them.
+
+## Open Questions
+
+None — the vocabulary, free transitions, single-field notes, and the single
+`track` endpoint were confirmed during design.

--- a/openspec/changes/add-application-stages/proposal.md
+++ b/openspec/changes/add-application-stages/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+A signed-in user can record that they viewed, saved, or applied to a job — but
+once they apply, there is nowhere to track what happens next (recruiter reply,
+screen, interview, offer) or to keep a note. The `user_jobs` model was built as
+the first slice of a personal application tracker; `hire/CLAUDE.md` flags a
+`stage` column (Applied→…→Offer) and notes as the designed-but-unbuilt next
+slice. This change adds them, so a user — or an API-key client, the freehire
+CLI, or career-ops — can move an application through its pipeline and jot notes.
+
+## What Changes
+
+- Two new **nullable** columns on `user_jobs`: `stage` (application pipeline
+  position; NULL = not in the pipeline) and `notes` (free text; NULL = none).
+- A **stage vocabulary**, validated in Go (like the enrichment vocabularies, not
+  a DB constraint): active `applied, screening, responded, interview, offer`;
+  terminal `accepted, rejected, withdrawn`. Transitions are free (any valid
+  stage from any other — a personal tracker, the user may jump or correct).
+- `MarkApplied` seeds `stage = 'applied'` when it is NULL, so applying enters the
+  pipeline; an existing stage is left untouched. stage/notes are otherwise
+  independent of `applied_at`.
+- New endpoint **`PATCH /api/v1/jobs/:slug/track`** with `{stage?, notes?}`,
+  authenticated by session cookie **or** API key. It upserts the interaction row
+  and sets the provided fields (partial update), validating the stage. At least
+  one field is required.
+- The interaction record and the "my jobs" listing rows gain `stage` and `notes`.
+- The **My Jobs** SPA page shows each application's stage as a badge, lets the
+  user change it from a dropdown, and edit notes inline.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `user-job-tracking`: applications gain a **stage** and **notes** — a new
+  `track` endpoint, `MarkApplied` seeding `stage='applied'`, the stage
+  vocabulary with validation, `stage`/`notes` on the interaction and my-jobs
+  response shapes, and the My Jobs SPA surface that shows and edits them. (This
+  capability already owns the SPA's interaction-state requirements, so the UI
+  part lives here rather than in `web-frontend`.)
+
+## Impact
+
+- **Database:** `migrations/0014_application_stage.sql` adds `stage` + `notes` to
+  `user_jobs`; regenerate sqlc; `internal/db/queries/user_jobs.sql` gains
+  `TrackJob` and tweaks `MarkJobApplied` to seed `stage='applied'`.
+- **internal/handler:** a `TrackJob` handler + `PATCH /jobs/:slug/track` wired
+  behind `RequireAuthOrKey`; the stage vocabulary + validation; `stage`/`notes`
+  added to `interactionResponse` and `myJobResponse`.
+- **web/ (SPA):** `MyJobsView.svelte` (stage badge + dropdown + notes textarea),
+  a `trackJob` function in `lib/api.ts`, and `stage`/`notes` on the `UserJob` /
+  `MyJob` types.
+- **No breaking changes:** additive columns + a new endpoint; existing endpoints
+  only gain fields. **Prod:** apply `0014` manually via psql per the ops runbook,
+  then deploy the app + web images.
+- **Out of scope:** a stage-specific filter tab, a notes timeline/log,
+  forward-only transition enforcement, and funnel analytics (career-ops owns
+  those); the freehire-cli `stage`/`note` commands live in the separate
+  `freehire-cli` repo as a downstream follow-up.

--- a/openspec/changes/add-application-stages/specs/user-job-tracking/spec.md
+++ b/openspec/changes/add-application-stages/specs/user-job-tracking/spec.md
@@ -1,0 +1,140 @@
+## MODIFIED Requirements
+
+### Requirement: Marking a job applied
+
+The system SHALL let an authenticated user mark a job as applied, idempotently,
+and SHALL seed `stage = 'applied'` when the stage is currently unset (an
+already-set stage is left untouched). Authentication MAY be by session cookie or
+by API key; either identifies the acting user identically. Marking applied sets
+`applied_at`; it works whether or not a view was recorded first, and repeating it
+does not create a duplicate or error. The endpoint SHALL return the updated
+interaction record.
+
+#### Scenario: Mark applied after viewing
+
+- **WHEN** an authenticated user who has viewed a job sends
+  `POST /api/v1/jobs/:id/apply`
+- **THEN** the job's `applied_at` is set
+- **AND** the response is `200` with `{"data": {job_id, viewed_at, applied_at}}`
+  where `applied_at` is non-null
+
+#### Scenario: Mark applied is idempotent
+
+- **WHEN** an authenticated user marks the same job applied twice
+- **THEN** the row is updated in place each time
+- **AND** no duplicate row is created and no error is returned
+
+#### Scenario: Applying seeds the initial stage
+
+- **WHEN** an authenticated user applies to a job whose `stage` is unset
+- **THEN** the interaction's `stage` becomes `applied`
+- **AND** applying again, or after the stage has been advanced, leaves the
+  existing stage unchanged
+
+#### Scenario: Apply requires authentication
+
+- **WHEN** a request to `POST /api/v1/jobs/:id/apply` carries neither a valid auth
+  cookie nor a valid API key
+- **THEN** the system responds `401` and records nothing
+
+#### Scenario: Apply authenticated by an API key
+
+- **WHEN** a request to `POST /api/v1/jobs/:id/apply` carries a valid
+  `Authorization: Bearer <key>` and no cookie
+- **THEN** the system marks the job applied for the key's owning user exactly as a
+  cookie session would and responds `200` with the updated interaction record
+
+#### Scenario: Apply to a non-existent job
+
+- **WHEN** an authenticated user sends `POST /api/v1/jobs/:id/apply` with a
+  numeric `:id` that has no corresponding job row
+- **THEN** the foreign-key violation surfaces as `404`, not `500`
+
+## ADDED Requirements
+
+### Requirement: Tracking application stage and notes
+
+The system SHALL let an authenticated user set an application's `stage` and/or
+free-text `notes` via `PATCH /api/v1/jobs/:slug/track`, authenticated by session
+cookie or API key. The body carries optional `stage` and `notes`, of which at
+least one MUST be present (else `400`). The endpoint SHALL upsert the
+`(user, job)` interaction (creating it if absent) and apply a partial update — a
+field omitted from the body leaves its stored column unchanged. A provided
+`stage` MUST be one of the controlled vocabulary values, and an unknown value
+SHALL be rejected with `400`. The endpoint SHALL return the updated interaction
+record.
+
+The stage vocabulary SHALL be the active stages `applied`, `screening`,
+`responded`, `interview`, `offer` and the terminal stages `accepted`,
+`rejected`, `withdrawn`. Transitions are unrestricted: any valid stage may be set
+from any other.
+
+#### Scenario: Set a stage
+
+- **WHEN** an authenticated user sends `PATCH /api/v1/jobs/:slug/track` with
+  `{"stage":"interview"}` for a job they have not interacted with
+- **THEN** the system creates the interaction with `stage = interview` and
+  responds `200` with the record
+
+#### Scenario: Set notes without changing the stage
+
+- **WHEN** the user sends `{"notes":"recruiter called Friday"}` with no `stage`
+- **THEN** `notes` is updated and the existing `stage` is left unchanged
+
+#### Scenario: Unknown stage is rejected
+
+- **WHEN** the user sends `{"stage":"banana"}`
+- **THEN** the system responds `400` and changes nothing
+
+#### Scenario: Empty track is rejected
+
+- **WHEN** the user sends `track` with neither `stage` nor `notes`
+- **THEN** the system responds `400`
+
+#### Scenario: Track authenticated by an API key
+
+- **WHEN** a `track` request carries a valid `Authorization: Bearer <key>` and no
+  cookie
+- **THEN** the stage/notes are set for the key's owning user exactly as a cookie
+  session would
+
+#### Scenario: Track requires authentication
+
+- **WHEN** a `track` request carries neither a valid cookie nor a valid API key
+- **THEN** the system responds `401` and changes nothing
+
+### Requirement: Interaction records carry stage and notes
+
+Interaction records SHALL carry the application's `stage` and `notes` (null when
+unset) — on the view, apply, save, unsave, and track responses and on every
+my-jobs listing row. No other field of the existing interaction or my-jobs shapes
+changes.
+
+#### Scenario: Stage and notes on the interaction response
+
+- **WHEN** any per-user interaction endpoint returns the interaction record
+- **THEN** the JSON includes `stage` and `notes` (null when unset) alongside
+  `job_id`, `viewed_at`, `saved_at`, `applied_at`
+
+#### Scenario: Stage and notes on the my-jobs listing
+
+- **WHEN** `GET /api/v1/me/jobs` returns the user's tracked jobs
+- **THEN** each row includes the job's `stage` and `notes`
+
+### Requirement: SPA shows and edits application stage and notes
+
+The web SPA's My Jobs page SHALL, for a signed-in user, show each tracked job's
+`stage` as a humanized badge when set, let the user change the stage from a
+control offering the stage vocabulary (persisting via the track endpoint), and
+let the user edit `notes` inline (persisting via the track endpoint). A signed-out
+user SHALL see no such controls.
+
+#### Scenario: Change a stage
+
+- **WHEN** a signed-in user selects a new stage for a job on My Jobs
+- **THEN** the SPA persists it via the track endpoint and reflects the new stage
+
+#### Scenario: Edit notes
+
+- **WHEN** a signed-in user edits a job's notes and the field loses focus
+- **THEN** the SPA persists the notes via the track endpoint

--- a/openspec/changes/add-application-stages/tasks.md
+++ b/openspec/changes/add-application-stages/tasks.md
@@ -1,0 +1,33 @@
+## 1. Database schema & queries
+
+- [ ] 1.1 Add `migrations/0014_application_stage.sql` (confirm the next free number with `ls migrations/`): `ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS stage TEXT; ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS notes TEXT;` with a comment on the controlled-vocabulary stage and the initdb/manual-apply note.
+- [ ] 1.2 In `internal/db/queries/user_jobs.sql`: add `TrackJob` (:one) — `INSERT ... (user_id, job_id, stage, notes) ... ON CONFLICT (user_id, job_id) DO UPDATE SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage), notes = COALESCE(EXCLUDED.notes, user_jobs.notes) RETURNING *`; tweak `MarkJobApplied` so the conflict update sets `stage = COALESCE(user_jobs.stage, 'applied')`.
+- [ ] 1.3 Run `make sqlc`; commit the regenerated `internal/db`. Confirm the row structs gain `Stage`/`Notes` and `TrackJobParams` carries nil-able `pgtype.Text` stage/notes.
+- [ ] 1.4 Recreate the dev volume (`docker compose down -v && make up`) so initdb applies `0014`. _Deferred manual step (env-affecting); the `0014` schema is validated by the group-3 testcontainers tests._
+
+## 2. Handler: track endpoint, stage vocabulary, response fields
+
+- [ ] 2.1 Add the stage vocabulary as a Go set + an `isValidStage` helper (active: applied/screening/responded/interview/offer; terminal: accepted/rejected/withdrawn). Unit tests: known values valid, unknown invalid.
+- [ ] 2.2 Add a `TrackJob` handler in `user_jobs.go`: parse `{stage?, notes?}` (pointers), require at least one (else `400`), validate a provided stage (else `400`), call `db.TrackJob` with `pgtype.Text` (Valid only when the field was present), return `toInteraction`. Unit tests (no DB): empty body → 400; unknown stage → 400; track behind cookie/key (the gate). DB-backed behavior in group 3.
+- [ ] 2.3 Add `Stage`/`Notes` to `interactionResponse` and `myJobResponse` (and `toInteraction`/the my-jobs mapper); marshal as null when unset. Shape tests: the fields are present.
+- [ ] 2.4 Wire `PATCH /api/v1/jobs/:slug/track` behind `auth.RequireAuthOrKey(h.issuer, h.queries)` in `Register`.
+- [ ] 2.5 Confirm `MarkApplied` seeds `stage='applied'` (via the query) without a handler change — covered by the group-3 integration test.
+
+## 3. DB integration tests (testcontainers)
+
+- [ ] 3.1 `TrackJob` partial-update: stage-only leaves notes unchanged; notes-only leaves stage unchanged; first track creates the row (upsert).
+- [ ] 3.2 `MarkJobApplied` seeds `stage='applied'` when stage is NULL, and leaves an already-advanced stage untouched on re-apply.
+
+## 4. SPA: stage + notes on My Jobs
+
+- [ ] 4.1 `lib/types.ts`: `UserJob` / `MyJob` gain `stage: string | null` and `notes: string | null`. `lib/api.ts`: add `trackJob(slug, { stage?, notes? })` → `PATCH /api/v1/jobs/:slug/track`.
+- [ ] 4.2 Add the stage vocabulary + humanized labels in the SPA (mirroring `facets.ts`; note the Go source of truth).
+- [ ] 4.3 `MyJobsView.svelte`: per row, a stage badge (humanized) when set, a dropdown to change the stage (calls `trackJob({stage})`), and a notes textarea saved on blur (calls `trackJob({notes})`); optimistic local update.
+- [ ] 4.4 Verify the SPA: `npm run check` (svelte-check) + lint pass. No unit runner added.
+
+## 5. Verification & rollout
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green; `go test -tags=integration ./internal/db/ ./internal/handler/` passes with Docker.
+- [ ] 5.2 End-to-end by hand: `curl -X PATCH -H "Authorization: Bearer fhk_…" -d '{"stage":"interview"}' …/jobs/<slug>/track` sets the stage; set notes; confirm both appear in `GET /me/jobs`; exercise the My Jobs UI.
+- [ ] 5.3 Record the prod migration step (apply `0014_application_stage.sql` via psql per the ops runbook) in the PR; deploy app + web.
+- [ ] 5.4 Follow-up (separate `freehire-cli` repo, not this change): add `freehire stage <slug> <stage>` and `freehire note <slug> <text>` (→ PATCH track) and show stage/notes in `my`.

--- a/openspec/changes/add-application-stages/tasks.md
+++ b/openspec/changes/add-application-stages/tasks.md
@@ -20,10 +20,10 @@
 
 ## 4. SPA: stage + notes on My Jobs
 
-- [ ] 4.1 `lib/types.ts`: `UserJob` / `MyJob` gain `stage: string | null` and `notes: string | null`. `lib/api.ts`: add `trackJob(slug, { stage?, notes? })` → `PATCH /api/v1/jobs/:slug/track`.
-- [ ] 4.2 Add the stage vocabulary + humanized labels in the SPA (mirroring `facets.ts`; note the Go source of truth).
-- [ ] 4.3 `MyJobsView.svelte`: per row, a stage badge (humanized) when set, a dropdown to change the stage (calls `trackJob({stage})`), and a notes textarea saved on blur (calls `trackJob({notes})`); optimistic local update.
-- [ ] 4.4 Verify the SPA: `npm run check` (svelte-check) + lint pass. No unit runner added.
+- [x] 4.1 `lib/types.ts`: `UserJob` / `MyJob` gain `stage: string | null` and `notes: string | null`. `lib/api.ts`: add `trackJob(slug, { stage?, notes? })` → `PATCH /api/v1/jobs/:slug/track`.
+- [x] 4.2 Add the stage vocabulary + humanized labels in the SPA (mirroring `facets.ts`; note the Go source of truth).
+- [x] 4.3 `MyJobsView.svelte`: per row, a stage badge (humanized) when set, a dropdown to change the stage (calls `trackJob({stage})`), and a notes textarea saved on blur (calls `trackJob({notes})`); optimistic local update.
+- [x] 4.4 Verify the SPA: `npm run check` (svelte-check) + lint pass. No unit runner added.
 
 ## 5. Verification & rollout
 

--- a/openspec/changes/add-application-stages/tasks.md
+++ b/openspec/changes/add-application-stages/tasks.md
@@ -1,22 +1,22 @@
 ## 1. Database schema & queries
 
-- [ ] 1.1 Add `migrations/0014_application_stage.sql` (confirm the next free number with `ls migrations/`): `ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS stage TEXT; ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS notes TEXT;` with a comment on the controlled-vocabulary stage and the initdb/manual-apply note.
-- [ ] 1.2 In `internal/db/queries/user_jobs.sql`: add `TrackJob` (:one) — `INSERT ... (user_id, job_id, stage, notes) ... ON CONFLICT (user_id, job_id) DO UPDATE SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage), notes = COALESCE(EXCLUDED.notes, user_jobs.notes) RETURNING *`; tweak `MarkJobApplied` so the conflict update sets `stage = COALESCE(user_jobs.stage, 'applied')`.
-- [ ] 1.3 Run `make sqlc`; commit the regenerated `internal/db`. Confirm the row structs gain `Stage`/`Notes` and `TrackJobParams` carries nil-able `pgtype.Text` stage/notes.
+- [x] 1.1 Add `migrations/0014_application_stage.sql` (confirm the next free number with `ls migrations/`): `ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS stage TEXT; ALTER TABLE user_jobs ADD COLUMN IF NOT EXISTS notes TEXT;` with a comment on the controlled-vocabulary stage and the initdb/manual-apply note.
+- [x] 1.2 In `internal/db/queries/user_jobs.sql`: add `TrackJob` (:one) — `INSERT ... (user_id, job_id, stage, notes) ... ON CONFLICT (user_id, job_id) DO UPDATE SET stage = COALESCE(EXCLUDED.stage, user_jobs.stage), notes = COALESCE(EXCLUDED.notes, user_jobs.notes) RETURNING *`; tweak `MarkJobApplied` so the conflict update sets `stage = COALESCE(user_jobs.stage, 'applied')`.
+- [x] 1.3 Run `make sqlc`; commit the regenerated `internal/db`. Confirm the row structs gain `Stage`/`Notes` and `TrackJobParams` carries nil-able `pgtype.Text` stage/notes.
 - [ ] 1.4 Recreate the dev volume (`docker compose down -v && make up`) so initdb applies `0014`. _Deferred manual step (env-affecting); the `0014` schema is validated by the group-3 testcontainers tests._
 
 ## 2. Handler: track endpoint, stage vocabulary, response fields
 
-- [ ] 2.1 Add the stage vocabulary as a Go set + an `isValidStage` helper (active: applied/screening/responded/interview/offer; terminal: accepted/rejected/withdrawn). Unit tests: known values valid, unknown invalid.
-- [ ] 2.2 Add a `TrackJob` handler in `user_jobs.go`: parse `{stage?, notes?}` (pointers), require at least one (else `400`), validate a provided stage (else `400`), call `db.TrackJob` with `pgtype.Text` (Valid only when the field was present), return `toInteraction`. Unit tests (no DB): empty body → 400; unknown stage → 400; track behind cookie/key (the gate). DB-backed behavior in group 3.
-- [ ] 2.3 Add `Stage`/`Notes` to `interactionResponse` and `myJobResponse` (and `toInteraction`/the my-jobs mapper); marshal as null when unset. Shape tests: the fields are present.
-- [ ] 2.4 Wire `PATCH /api/v1/jobs/:slug/track` behind `auth.RequireAuthOrKey(h.issuer, h.queries)` in `Register`.
-- [ ] 2.5 Confirm `MarkApplied` seeds `stage='applied'` (via the query) without a handler change — covered by the group-3 integration test.
+- [x] 2.1 Add the stage vocabulary as a Go set + an `isValidStage` helper (active: applied/screening/responded/interview/offer; terminal: accepted/rejected/withdrawn). Unit tests: known values valid, unknown invalid.
+- [x] 2.2 Add a `TrackJob` handler in `user_jobs.go`: parse `{stage?, notes?}` (pointers), require at least one (else `400`), validate a provided stage (else `400`), call `db.TrackJob` with `pgtype.Text` (Valid only when the field was present), return `toInteraction`. Unit tests (no DB): empty body → 400; unknown stage → 400; track behind cookie/key (the gate). DB-backed behavior in group 3.
+- [x] 2.3 Add `Stage`/`Notes` to `interactionResponse` and `myJobResponse` (and `toInteraction`/the my-jobs mapper); marshal as null when unset. Shape tests: the fields are present.
+- [x] 2.4 Wire `PATCH /api/v1/jobs/:slug/track` behind `auth.RequireAuthOrKey(h.issuer, h.queries)` in `Register`.
+- [x] 2.5 Confirm `MarkApplied` seeds `stage='applied'` (via the query) without a handler change — covered by the group-3 integration test.
 
 ## 3. DB integration tests (testcontainers)
 
-- [ ] 3.1 `TrackJob` partial-update: stage-only leaves notes unchanged; notes-only leaves stage unchanged; first track creates the row (upsert).
-- [ ] 3.2 `MarkJobApplied` seeds `stage='applied'` when stage is NULL, and leaves an already-advanced stage untouched on re-apply.
+- [x] 3.1 `TrackJob` partial-update: stage-only leaves notes unchanged; notes-only leaves stage unchanged; first track creates the row (upsert).
+- [x] 3.2 `MarkJobApplied` seeds `stage='applied'` when stage is NULL, and leaves an already-advanced stage untouched on re-apply.
 
 ## 4. SPA: stage + notes on My Jobs
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -199,6 +199,20 @@ export function unsaveJob(slug: string): Promise<UserJob> {
   return jobInteraction(slug, 'save', 'DELETE');
 }
 
+/** Set a job's application stage and/or notes (partial update — omit a field to
+ *  leave it unchanged). Returns the updated interaction. */
+export async function trackJob(
+  slug: string,
+  patch: { stage?: string; notes?: string },
+): Promise<UserJob> {
+  const res = await request<{ data: UserJob }>(`/api/v1/jobs/${slug}/track`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  return res.data;
+}
+
 export type MyJobsFilter = 'all' | 'viewed' | 'saved' | 'applied';
 
 /** The current user's job interactions, newest activity first. Alongside the

--- a/web/src/lib/components/MyJobsView.svelte
+++ b/web/src/lib/components/MyJobsView.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { listMyJobs, type MyJobsFilter } from '$lib/api';
+  import { listMyJobs, trackJob, type MyJobsFilter } from '$lib/api';
   import { authStore } from '$lib/auth.svelte';
   import { Paginator } from '$lib/paginated.svelte';
-  import type { MyJobCounts } from '$lib/types';
+  import type { MyJob, MyJobCounts } from '$lib/types';
+  import { STAGES, humanizeStage } from '$lib/stages';
   import { Badge } from '$lib/ui';
   import { cn, timeAgo } from '$lib/utils';
   import JobRow from './JobRow.svelte';
@@ -50,6 +51,37 @@
     applied: 'No applications yet. Confirm "Did you apply?" on a job to track it here.',
   };
   const emptyMessage = $derived(emptyMessages[filter]);
+
+  // Optimistic per-job stage/notes overrides (keyed by slug) so an edit shows
+  // immediately without refetching the paginator. oninput keeps the override in
+  // sync as the user types (a controlled value otherwise reverts mid-keystroke).
+  let edits = $state<Record<string, { stage?: string; notes?: string }>>({});
+
+  const stageOf = (item: MyJob) => edits[item.job.public_slug]?.stage ?? item.stage ?? '';
+  const notesOf = (item: MyJob) => edits[item.job.public_slug]?.notes ?? item.notes ?? '';
+
+  function patch(slug: string, p: { stage?: string; notes?: string }) {
+    edits[slug] = { ...edits[slug], ...p };
+  }
+
+  async function setStage(item: MyJob, stage: string) {
+    if (!stage) return; // the "Set stage…" placeholder, not a real change
+    patch(item.job.public_slug, { stage });
+    try {
+      await trackJob(item.job.public_slug, { stage });
+    } catch {
+      // Keep the optimistic value; a transient failure shouldn't drop the edit.
+    }
+  }
+
+  async function saveNotes(item: MyJob, notes: string) {
+    if (notes === (item.notes ?? '')) return; // unchanged since the server value
+    try {
+      await trackJob(item.job.public_slug, { notes });
+    } catch {
+      /* keep the optimistic value */
+    }
+  }
 </script>
 
 {#if !authStore.isAuthenticated}
@@ -93,15 +125,39 @@
         {#each page.items as item (item.job.public_slug)}
           <li class="flex flex-col gap-1">
             <JobRow job={item.job} />
-            <div class="flex items-center gap-2 px-1 text-xs text-muted-foreground">
+            <div class="flex flex-wrap items-center gap-2 px-1 text-xs text-muted-foreground">
               {#if item.applied_at}
                 <Badge variant="secondary">Applied</Badge>
               {/if}
               {#if item.saved_at}
                 <Badge variant="secondary">Saved</Badge>
               {/if}
+              {#if stageOf(item)}
+                <Badge variant="secondary">{humanizeStage(stageOf(item))}</Badge>
+              {/if}
               <span>Viewed {timeAgo(item.viewed_at)}</span>
+              <label class="ml-auto flex items-center gap-1">
+                <span class="sr-only">Application stage</span>
+                <select
+                  value={stageOf(item)}
+                  onchange={(e) => setStage(item, e.currentTarget.value)}
+                  class="rounded-md border border-input bg-transparent px-1.5 py-0.5 text-xs"
+                >
+                  <option value="">Set stage…</option>
+                  {#each STAGES as s (s.value)}
+                    <option value={s.value}>{s.label}</option>
+                  {/each}
+                </select>
+              </label>
             </div>
+            <textarea
+              value={notesOf(item)}
+              oninput={(e) => patch(item.job.public_slug, { notes: e.currentTarget.value })}
+              onblur={(e) => saveNotes(item, e.currentTarget.value)}
+              placeholder="Notes…"
+              rows="1"
+              class="mx-1 resize-y rounded-md border border-input bg-transparent px-2 py-1 text-xs placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            ></textarea>
           </li>
         {/each}
       </ul>

--- a/web/src/lib/stages.ts
+++ b/web/src/lib/stages.ts
@@ -1,0 +1,28 @@
+// The application-stage vocabulary, in pipeline order (active stages then
+// terminal). SOURCE OF TRUTH is the Go `validStages` set in
+// internal/handler/user_jobs.go — keep this in sync when it changes. Drift is not
+// fatal: humanizeStage renders an unknown value as a readable label.
+
+export interface StageOption {
+  value: string;
+  label: string;
+}
+
+export const STAGES: StageOption[] = [
+  { value: 'applied', label: 'Applied' },
+  { value: 'screening', label: 'Screening' },
+  { value: 'responded', label: 'Responded' },
+  { value: 'interview', label: 'Interview' },
+  { value: 'offer', label: 'Offer' },
+  { value: 'accepted', label: 'Accepted' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'withdrawn', label: 'Withdrawn' },
+];
+
+const LABELS = new Map(STAGES.map((s) => [s.value, s.label]));
+
+/** A human label for a stage value; the value itself (title-cased fallback) when
+ *  not in the known vocabulary. */
+export function humanizeStage(stage: string): string {
+  return LABELS.get(stage) ?? stage.charAt(0).toUpperCase() + stage.slice(1);
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -107,6 +107,9 @@ export interface UserJob {
   viewed_at: string;
   saved_at: string | null;
   applied_at: string | null;
+  // Application pipeline stage + free-text notes; null until set via `track`.
+  stage: string | null;
+  notes: string | null;
 }
 
 /** One item of the my-jobs listing: the job in the shared wire shape with the
@@ -116,6 +119,8 @@ export interface MyJob {
   viewed_at: string;
   saved_at: string | null;
   applied_at: string | null;
+  stage: string | null;
+  notes: string | null;
 }
 
 /** Per-tab row counts for the my-jobs page, from the listing's meta. `viewed`


### PR DESCRIPTION
## Summary
- **Backend:** `user_jobs` gains `stage` + `notes` (migration **0014**). New `PATCH /api/v1/jobs/:slug/track {stage?, notes?}` (cookie or API key) — partial COALESCE upsert, stage validated against a Go vocabulary (applied/screening/responded/interview/offer + accepted/rejected/withdrawn). `MarkApplied` seeds `stage='applied'` when unset. `stage`/`notes` added to the interaction + my-jobs responses.
- **SPA:** My Jobs rows show a stage badge, a stage dropdown, and an inline notes textarea (saved on blur).

## ⚠️ Deploy note
Apply `migrations/0014_application_stage.sql` to the **prod DB via psql** (additive `ADD COLUMN IF NOT EXISTS`, safe on the live table) **before/with** the deploy, then deploy **app + web**.

## Test plan
- [x] `go build/vet/test ./...` green
- [x] Integration (testcontainers): TrackJob partial update + MarkApplied stage seeding
- [x] Handler unit: track 400 on empty/unknown stage, auth gate, shape
- [x] `svelte-check` 0/0, `vite build` OK
- [ ] Manual: PATCH track by key + My Jobs UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)