### PR TITLE
linksource: identity-aligned greenhouse adapter for ATS links

### DIFF
--- a/internal/linksource/greenhouse.go
+++ b/internal/linksource/greenhouse.go
@@ -1,0 +1,86 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// greenhouse resolves Greenhouse-hosted vacancies. Greenhouse is multi-tenant, so a TG
+// link points at an arbitrary company's board — many of which sources.yml does not list.
+// The adapter writes the SAME identity the ingest pipeline would (source="greenhouse",
+// external_id="<board>:<id>"), so UpsertJob's ON CONFLICT dedups against an already-crawled
+// company and a not-yet-crawled one is added under the canonical key rather than as a
+// thin telegram-source duplicate.
+type greenhouse struct {
+	http Client
+}
+
+// NewGreenhouse builds the Greenhouse link-source adapter.
+func NewGreenhouse(c Client) LinkSource { return greenhouse{http: c} }
+
+func (greenhouse) Source() string { return "greenhouse" }
+
+// greenhouseJobPath captures the board and numeric job id from a job link path
+// (job-boards.greenhouse.io/<board>/jobs/<id>, and the boards.* / EU variants).
+var greenhouseJobPath = regexp.MustCompile(`^/([^/]+)/jobs/(\d+)/?$`)
+
+// Match handles any greenhouse.io job link (job-boards/boards, US or EU host).
+func (greenhouse) Match(u *url.URL) bool {
+	return strings.HasSuffix(host(u), "greenhouse.io") && greenhouseJobPath.MatchString(u.Path)
+}
+
+// Resolve reads the public per-job boards API for the linked board+id and maps it exactly
+// as the ingest greenhouse adapter does, namespacing the external id by board to match.
+func (g greenhouse) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	m := greenhouseJobPath.FindStringSubmatch(u.Path)
+	if m == nil {
+		return sources.Job{}, false, nil
+	}
+	board, id := m[1], m[2]
+
+	// EU-hosted boards are served by the EU API host; everything else by the global one.
+	apiHost := "boards-api.greenhouse.io"
+	if strings.Contains(host(u), "eu.greenhouse.io") {
+		apiHost = "boards-api.eu.greenhouse.io"
+	}
+	api := fmt.Sprintf("https://%s/v1/boards/%s/jobs/%s?content=true", apiHost, board, id)
+
+	var j struct {
+		ID          int64  `json:"id"`
+		Title       string `json:"title"`
+		AbsoluteURL string `json:"absolute_url"`
+		UpdatedAt   string `json:"updated_at"`
+		Content     string `json:"content"`
+		CompanyName string `json:"company_name"`
+		Location    struct {
+			Name string `json:"name"`
+		} `json:"location"`
+	}
+	if err := g.http.GetJSON(ctx, api, &j); err != nil {
+		return sources.Job{}, false, err
+	}
+	if j.ID == 0 {
+		return sources.Job{}, false, nil // not a live posting (closed/removed) — skip
+	}
+
+	return sources.Job{
+		ExternalID:  board + ":" + id,
+		URL:         j.AbsoluteURL,
+		Title:       j.Title,
+		Company:     j.CompanyName,
+		Location:    j.Location.Name,
+		Description: sources.SanitizeHTML(html.UnescapeString(j.Content)),
+		Remote:      sources.IsRemote(j.Location.Name),
+		PostedAt:    parseRFC3339(j.UpdatedAt),
+	}, true, nil
+}

--- a/internal/linksource/greenhouse_test.go
+++ b/internal/linksource/greenhouse_test.go
@@ -1,0 +1,64 @@
+package linksource
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// greenhouseJobJSON mirrors the public per-job boards API: content is HTML-escaped (the
+// adapter unescapes then sanitizes), and company_name gives a real company.
+const greenhouseJobJSON = `{
+ "id": 5745893004,
+ "title": "Sales Engineer - MENA",
+ "absolute_url": "https://job-boards.greenhouse.io/alpaca/jobs/5745893004",
+ "updated_at": "2026-04-15T12:28:38-04:00",
+ "company_name": "Alpaca",
+ "location": {"name": "Remote - MENA"},
+ "content": "&lt;p&gt;Build it.&lt;/p&gt;&lt;script&gt;evil()&lt;/script&gt;"
+}`
+
+func TestGreenhouseResolvesAlignedIdentity(t *testing.T) {
+	const link = "https://job-boards.greenhouse.io/alpaca/jobs/5745893004?utm_source=telegram"
+	c := (&fakeClient{}).route("boards-api.greenhouse.io/v1/boards/alpaca/jobs/5745893004", greenhouseJobJSON, "")
+
+	job, ok, err := NewGreenhouse(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	// External id is namespaced by board, matching what the ingest pipeline writes, so the
+	// same vacancy crawled directly dedups on (source=greenhouse, external_id) instead of
+	// duplicating.
+	if job.ExternalID != "alpaca:5745893004" {
+		t.Errorf("ExternalID = %q, want alpaca:5745893004", job.ExternalID)
+	}
+	if job.URL != "https://job-boards.greenhouse.io/alpaca/jobs/5745893004" {
+		t.Errorf("URL = %q", job.URL)
+	}
+	if job.Title != "Sales Engineer - MENA" {
+		t.Errorf("Title = %q", job.Title)
+	}
+	if job.Company != "Alpaca" {
+		t.Errorf("Company = %q, want Alpaca", job.Company)
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true (Remote - MENA)")
+	}
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "Build it.") {
+		t.Errorf("Description not unescaped/sanitized: %q", job.Description)
+	}
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2026, 4, 15, 16, 28, 38, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-04-15T16:28:38Z", job.PostedAt)
+	}
+}
+
+func TestGreenhouseSourceKeyMatchesIngestProvider(t *testing.T) {
+	// Identity alignment hinges on the source key being exactly the ingest provider.
+	if got := NewGreenhouse(nil).Source(); got != "greenhouse" {
+		t.Errorf("Source() = %q, want greenhouse", got)
+	}
+}

--- a/internal/linksource/helpers_test.go
+++ b/internal/linksource/helpers_test.go
@@ -2,6 +2,7 @@ package linksource
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -54,4 +55,12 @@ func (c *fakeClient) GetHTMLResolved(_ context.Context, url string) (*html.Node,
 	}
 	n, err := html.Parse(strings.NewReader(r.body))
 	return n, final, err
+}
+
+func (c *fakeClient) GetJSON(_ context.Context, url string, v any) error {
+	r, ok := c.find(url)
+	if !ok {
+		return fmt.Errorf("fakeClient: no route for %s", url)
+	}
+	return json.Unmarshal([]byte(r.body), v)
 }

--- a/internal/linksource/registry.go
+++ b/internal/linksource/registry.go
@@ -14,12 +14,14 @@ import (
 	"github.com/strelov1/freehire/internal/sources"
 )
 
-// Client is the narrow transport a LinkSource needs: fetch a server-rendered detail page,
-// optionally following a shortener redirect to learn the canonical URL. *sources.Client
+// Client is the transport a LinkSource needs: a server-rendered detail page (optionally
+// following a shortener redirect to learn the canonical URL) or a structured JSON API
+// (multi-tenant ATS adapters read the platform's public per-job endpoint). *sources.Client
 // satisfies it.
 type Client interface {
 	GetHTML(ctx context.Context, url string) (*html.Node, error)
 	GetHTMLResolved(ctx context.Context, url string) (*html.Node, string, error)
+	GetJSON(ctx context.Context, url string, v any) error
 }
 
 // LinkSource adapts one destination site reachable from a post link. Source is the key
@@ -42,6 +44,7 @@ func All(c Client) []LinkSource {
 		NewHabrCareer(c),
 		NewRemoteYeah(c),
 		NewGeekjob(c),
+		NewGreenhouse(c),
 	}
 }
 

--- a/internal/linksource/registry_test.go
+++ b/internal/linksource/registry_test.go
@@ -16,10 +16,13 @@ func TestFindMatchesAdapterByLinkHost(t *testing.T) {
 		{"https://career.habr.com/vacancies/1000166712", "habr_career"},
 		{"https://remoteyeah.com/jobs/remote-senior-quality-engineer-peek", "remoteyeah"},
 		{"https://geekjob.ru/vacancy/6a1ebb8520ad023342091661", "geekjob"},
-		{"https://geekjob.ru/", ""},            // homepage, not a /vacancy/<id> link
-		{"https://remoteyeah.com/", ""},        // homepage, not a /jobs/<slug> link
-		{"https://example.com/jobs/x", ""},     // unknown domain
-		{"https://t.me/habr_career/75410", ""}, // the post itself, not an outbound link
+		{"https://job-boards.greenhouse.io/alpaca/jobs/5745893004", "greenhouse"},
+		{"https://boards.eu.greenhouse.io/acme/jobs/123", "greenhouse"},
+		{"https://job-boards.greenhouse.io/alpaca", ""}, // board page, not a /jobs/<id> link
+		{"https://geekjob.ru/", ""},                     // homepage, not a /vacancy/<id> link
+		{"https://remoteyeah.com/", ""},                 // homepage, not a /jobs/<slug> link
+		{"https://example.com/jobs/x", ""},              // unknown domain
+		{"https://t.me/habr_career/75410", ""},          // the post itself, not an outbound link
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
## Summary
Handles multi-tenant ATS links (Greenhouse) from TG channels (`job_web3`, `young_relocate`) **without creating duplicates**.

Unlike `yandex.ru/jobs` (one board we already crawl whole → pure dup → ignore the channel), Greenhouse links point at **arbitrary companies**, many not in `sources.yml`. Routing them through the LLM would write thin `source=telegram` rows that duplicate companies we *do* crawl.

This adapter writes the **same identity the ingest pipeline does** — `source="greenhouse"`, `external_id="<board>:<id>"` — by reading the public per-job boards API (`boards-api.greenhouse.io/v1/boards/<board>/jobs/<id>`). So:
- a company we already crawl → `UpsertJob` `ON CONFLICT (source, external_id)` **merges** (no dup);
- a company we don't → added under the canonical key (long-tail coverage), not as a thin telegram row.

Mapping mirrors `internal/sources/greenhouse.go` exactly (unescape + sanitize content, `IsRemote(location)`, `parseRFC3339(updated_at)`); `company_name` from the API gives a real company. Handles US and EU (`boards-api.eu.greenhouse.io`) hosts. Widens `linksource.Client` with `GetJSON` (ATS APIs are JSON).

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` — all pass (registry routing incl. EU host; Resolve maps to `alpaca:5745893004` with dedup-aligned id; source key == ingest provider)
- [x] Live-verified against a real Greenhouse posting (Alpaca, namespaced id, ~6k desc)
- [ ] No deploy changes beyond the pending #27 migration

## Notes / backlog
- `ashbyhq` is the analogous next ATS (same identity-alignment approach; `jobs.ashbyhq.com/<board>/<uuid>`).
- `yandex.ru/jobs` deliberately **not** added (already fully crawled by `sources/yandex`); recommend dropping the pure-mirror channels `ya_jobs`/`ya_jobs_pm` from `telegram.yml`. `mtsbankcareer` (job.mtsbank.ru = МТС Банк) is **not** covered by `sources/mts` (job.mts.ru) → keep.