### PR TITLE
linksource: ashby ATS adapter + drop yandex-mirror TG channels

### DIFF
--- a/internal/linksource/ashby.go
+++ b/internal/linksource/ashby.go
@@ -1,0 +1,84 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// ashby resolves Ashby-hosted vacancies. Like Greenhouse it is multi-tenant, so it writes
+// the SAME identity the ingest pipeline does (source="ashby", external_id="<board>:<id>")
+// to dedup against an already-crawled board and add an unlisted one under the canonical key.
+// Ashby's public posting API is per-board (no per-job endpoint and no company name), so the
+// adapter fetches the board and finds the linked job; the company is derived from the slug.
+type ashby struct {
+	http Client
+}
+
+// NewAshby builds the Ashby link-source adapter.
+func NewAshby(c Client) LinkSource { return ashby{http: c} }
+
+func (ashby) Source() string { return "ashby" }
+
+// ashbyJobPath captures the board and the job's UUID from a job link path
+// (jobs.ashbyhq.com/<board>/<uuid>).
+var ashbyJobPath = regexp.MustCompile(`^/([^/]+)/([0-9a-fA-F-]{36})/?$`)
+
+// Match handles jobs.ashbyhq.com/<board>/<uuid> links only.
+func (ashby) Match(u *url.URL) bool {
+	return host(u) == "jobs.ashbyhq.com" && ashbyJobPath.MatchString(u.Path)
+}
+
+// Resolve reads the board's public posting API and maps the linked job, mirroring the
+// ingest ashby adapter and namespacing the external id by board to match.
+func (a ashby) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	m := ashbyJobPath.FindStringSubmatch(u.Path)
+	if m == nil {
+		return sources.Job{}, false, nil
+	}
+	board, id := m[1], m[2]
+
+	var resp struct {
+		Jobs []struct {
+			ID              string `json:"id"`
+			Title           string `json:"title"`
+			Location        string `json:"location"`
+			JobURL          string `json:"jobUrl"`
+			PublishedAt     string `json:"publishedAt"`
+			DescriptionHTML string `json:"descriptionHtml"`
+			IsRemote        bool   `json:"isRemote"`
+		} `json:"jobs"`
+	}
+	api := fmt.Sprintf("https://api.ashbyhq.com/posting-api/job-board/%s", board)
+	if err := a.http.GetJSON(ctx, api, &resp); err != nil {
+		return sources.Job{}, false, err
+	}
+
+	for _, j := range resp.Jobs {
+		if j.ID != id {
+			continue
+		}
+		jobURL := j.JobURL
+		if jobURL == "" {
+			jobURL = "https://jobs.ashbyhq.com/" + board + "/" + id
+		}
+		return sources.Job{
+			ExternalID:  board + ":" + id,
+			URL:         jobURL,
+			Title:       j.Title,
+			Company:     humanizeBoard(board),
+			Location:    j.Location,
+			Description: sources.SanitizeHTML(j.DescriptionHTML),
+			Remote:      j.IsRemote || sources.IsRemote(j.Location),
+			PostedAt:    parseRFC3339(j.PublishedAt),
+		}, true, nil
+	}
+	return sources.Job{}, false, nil // not on the board anymore (delisted) — skip
+}

--- a/internal/linksource/ashby_test.go
+++ b/internal/linksource/ashby_test.go
@@ -1,0 +1,63 @@
+package linksource
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ashbyBoardJSON mirrors the per-board posting API (no company name; the linked job is
+// found by its UUID among the board's jobs).
+const ashbyBoardJSON = `{"apiVersion":"1","jobs":[
+ {"id":"00000000-0000-0000-0000-000000000000","title":"Other Role","location":"NY","jobUrl":"https://jobs.ashbyhq.com/ruby-labs/00000000-0000-0000-0000-000000000000","publishedAt":"2025-01-01T00:00:00.000+00:00","descriptionHtml":"<p>x</p>","isRemote":false},
+ {"id":"62661b07-ac6b-4283-ae38-6c3255c47bd4","title":"Head of User Acquisition","location":"Ukraine","jobUrl":"https://jobs.ashbyhq.com/ruby-labs/62661b07-ac6b-4283-ae38-6c3255c47bd4","publishedAt":"2025-05-05T14:02:49.272+00:00","descriptionHtml":"<p>Lead it.</p><script>evil()</script>","isRemote":true}
+]}`
+
+func TestAshbyResolvesAlignedIdentity(t *testing.T) {
+	const link = "https://jobs.ashbyhq.com/ruby-labs/62661b07-ac6b-4283-ae38-6c3255c47bd4?utm_source=telegram"
+	c := (&fakeClient{}).route("api.ashbyhq.com/posting-api/job-board/ruby-labs", ashbyBoardJSON, "")
+
+	job, ok, err := NewAshby(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	if job.ExternalID != "ruby-labs:62661b07-ac6b-4283-ae38-6c3255c47bd4" {
+		t.Errorf("ExternalID = %q, want board-namespaced uuid", job.ExternalID)
+	}
+	if job.Title != "Head of User Acquisition" {
+		t.Errorf("Title = %q", job.Title)
+	}
+	if job.Company != "Ruby Labs" {
+		t.Errorf("Company = %q, want Ruby Labs (humanized board slug)", job.Company)
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true")
+	}
+	if job.Location != "Ukraine" {
+		t.Errorf("Location = %q", job.Location)
+	}
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "Lead it.") {
+		t.Errorf("Description not sanitized: %q", job.Description)
+	}
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2025, 5, 5, 14, 2, 49, 272000000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2025-05-05T14:02:49.272Z (fractional seconds)", job.PostedAt)
+	}
+}
+
+func TestAshbySkipsWhenJobNotOnBoard(t *testing.T) {
+	// A delisted job: matched host, board fetch succeeds, but the UUID is gone → skip.
+	const link = "https://jobs.ashbyhq.com/ruby-labs/ffffffff-ffff-ffff-ffff-ffffffffffff"
+	c := (&fakeClient{}).route("api.ashbyhq.com/posting-api/job-board/ruby-labs", ashbyBoardJSON, "")
+
+	_, ok, err := NewAshby(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ok {
+		t.Error("ok=true, want skip for a job no longer on the board")
+	}
+}

--- a/internal/linksource/helpers.go
+++ b/internal/linksource/helpers.go
@@ -73,16 +73,30 @@ func parseDate(s string) *time.Time {
 	return &t
 }
 
-// parseRFC3339 parses an RFC3339 timestamp (as RemoteYeah's datePosted emits), in UTC,
-// returning nil for an empty or unparseable value.
+// parseRFC3339 parses an RFC3339 timestamp in UTC, returning nil for an empty or
+// unparseable value. RFC3339Nano accepts both fractional (Ashby's publishedAt) and plain
+// (RemoteYeah's datePosted) second forms.
 func parseRFC3339(s string) *time.Time {
 	if s == "" {
 		return nil
 	}
-	t, err := time.Parse(time.RFC3339, s)
+	t, err := time.Parse(time.RFC3339Nano, s)
 	if err != nil {
 		return nil
 	}
 	t = t.UTC()
 	return &t
+}
+
+// humanizeBoard turns an ATS board slug into a display company name ("ruby-labs" → "Ruby
+// Labs"), used when the platform's API carries no company name. Its slug matches a curated
+// sources.yml company name's slug for the common case, so the companies table aligns.
+func humanizeBoard(slug string) string {
+	words := strings.FieldsFunc(slug, func(r rune) bool { return r == '-' || r == '_' })
+	for i, w := range words {
+		if w != "" {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
 }

--- a/internal/linksource/registry.go
+++ b/internal/linksource/registry.go
@@ -45,6 +45,7 @@ func All(c Client) []LinkSource {
 		NewRemoteYeah(c),
 		NewGeekjob(c),
 		NewGreenhouse(c),
+		NewAshby(c),
 	}
 }
 

--- a/internal/linksource/registry_test.go
+++ b/internal/linksource/registry_test.go
@@ -18,6 +18,8 @@ func TestFindMatchesAdapterByLinkHost(t *testing.T) {
 		{"https://geekjob.ru/vacancy/6a1ebb8520ad023342091661", "geekjob"},
 		{"https://job-boards.greenhouse.io/alpaca/jobs/5745893004", "greenhouse"},
 		{"https://boards.eu.greenhouse.io/acme/jobs/123", "greenhouse"},
+		{"https://jobs.ashbyhq.com/ruby-labs/62661b07-ac6b-4283-ae38-6c3255c47bd4", "ashby"},
+		{"https://jobs.ashbyhq.com/ruby-labs", ""},      // board page, not a /<board>/<id> link
 		{"https://job-boards.greenhouse.io/alpaca", ""}, // board page, not a /jobs/<id> link
 		{"https://geekjob.ru/", ""},                     // homepage, not a /vacancy/<id> link
 		{"https://remoteyeah.com/", ""},                 // homepage, not a /jobs/<slug> link

--- a/sources/telegram.yml
+++ b/sources/telegram.yml
@@ -84,10 +84,9 @@ channels:
     kind: board
 
   # --- Corporate ---
-  - channel: ya_jobs
-    kind: board
-  - channel: ya_jobs_pm
-    kind: board
+  # ya_jobs / ya_jobs_pm dropped: they mirror Yandex's own board, which sources/yandex
+  # already crawls in full — keeping them only produced thin duplicate (source=telegram)
+  # rows of vacancies we ingest canonically as source=yandex.
   - channel: avito_career
     kind: board
   - channel: mtsbankcareer


### PR DESCRIPTION
## Summary
Two related link-following cleanups.

**1. Ashby identity-aligned link-source** (`young_relocate` → `jobs.ashbyhq.com/<board>/<uuid>`). Same approach as the greenhouse adapter (#33): writes `source="ashby"`, `external_id="<board>:<uuid>"` so `UpsertJob ON CONFLICT` dedups against an already-crawled board and adds an unlisted one under the canonical key (no thin telegram duplicates). Ashby's posting API is per-board with no company name → fetch the board, find the linked UUID, derive company from the slug (`humanizeBoard`: `ruby-labs` → `Ruby Labs`). `parseRFC3339` now uses `RFC3339Nano` to accept Ashby's fractional-second `publishedAt`.

**2. Drop `ya_jobs` / `ya_jobs_pm` channels.** They repost Yandex's own board, which `sources/yandex` already crawls in full. Without a yandex link-source they hit the LLM path and produced thin `source=telegram` duplicates of vacancies we ingest canonically as `source=yandex`. Building a yandex link-source isn't worth it (whole board already covered), so dropping the channels is the clean fix — matches the file's existing "aggregator-bot channels excluded" policy.

This completes the multi-tenant-ATS handling: greenhouse + ashby covered with dedup-safe identity; the one whole-board mirror (yandex) is removed rather than re-crawled.

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` — all pass (ashby: aligned `ruby-labs:<uuid>` id, humanized company, fractional-second date, delisted-job skip; registry routing)
- [x] Live-verified against a real Ashby posting (Ruby Labs, namespaced id, ~9.5k desc)
- [x] telegram config still valid after channel removal
- [ ] No deploy changes beyond the pending #27 migration

## Backlog after this
Remaining genuine candidates (RU aggregators NOT in sources): `budu.jobs`, `vseti.app`, `tgwork.pro`, `hirify.me`, `app.huntmegroup.com`. ATS domains already covered by sources adapters are intentionally excluded.