### PR TITLE
sources: backfill empty descriptions for personio and lamoda

### DIFF
--- a/internal/sources/lamoda.go
+++ b/internal/sources/lamoda.go
@@ -94,6 +94,9 @@ func (l lamoda) detail(ctx context.Context, e CompanyEntry, it lamodaItem) (Job,
 				Duties       string `json:"duties"`
 				Requirements string `json:"requirements"`
 				Conditions   string `json:"conditions"`
+				// Retail vacancies leave the four fields above empty and carry the whole
+				// body here instead.
+				Common string `json:"common"`
 			} `json:"attributes"`
 		} `json:"data"`
 	}
@@ -103,6 +106,9 @@ func (l lamoda) detail(ctx context.Context, e CompanyEntry, it lamodaItem) (Job,
 
 	a := d.Data.Attributes
 	body := a.Introduction + a.Duties + a.Requirements + a.Conditions
+	if body == "" {
+		body = a.Common
+	}
 
 	return Job{
 		ExternalID:  strconv.FormatInt(it.ID, 10),

--- a/internal/sources/lamoda_test.go
+++ b/internal/sources/lamoda_test.go
@@ -104,6 +104,33 @@ func TestLamodaFetchPaginatesAndFetchesDetail(t *testing.T) {
 	}
 }
 
+func TestLamodaDetailFallsBackToCommonWhenStructuredFieldsEmpty(t *testing.T) {
+	// Retail vacancies leave the four structured fields empty and carry the whole body in
+	// the "common" HTML attribute instead; the adapter falls back to it.
+	detail := `{"data":{"attributes":{` +
+		`"name":"Менеджер ПВЗ","slug":"lipetsk/menedzher-2414",` +
+		`"externalPublicationDate":"2026-06-11T16:04:39.000Z",` +
+		`"introduction":"","duties":"","requirements":"","conditions":"",` +
+		`"common":"<p>Работа в пункте выдачи заказов.</p>"}}}`
+
+	fake := (&routedHTTP{}).
+		route("start%5D=0", lamodaListPage(0, 2, 1,
+			lamodaListItem(2414, "Менеджер ПВЗ", "lipetsk/menedzher-2414", "Липецк"),
+		)).
+		route("/vacancies/2414", detail)
+
+	jobs, err := NewLamoda(fake).Fetch(context.Background(), CompanyEntry{Company: "Lamoda", Provider: "lamoda"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "Работа в пункте выдачи заказов.") {
+		t.Errorf("Description = %q, want the common-field body", jobs[0].Description)
+	}
+}
+
 func TestLamodaFetchSkipsFailedDetail(t *testing.T) {
 	// 2467 has no detail route -> its detail fetch errors and the posting is skipped,
 	// but 2466 still comes through.

--- a/internal/sources/personio.go
+++ b/internal/sources/personio.go
@@ -3,6 +3,8 @@ package sources
 import (
 	"context"
 	"fmt"
+
+	"golang.org/x/net/html"
 )
 
 // personio adapts the Personio public XML feed. Each board is its own subdomain and
@@ -43,16 +45,42 @@ func (p personio) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		for _, d := range pos.Descriptions {
 			body += d.Value
 		}
+		url := fmt.Sprintf("%s/job/%s", host, pos.ID)
+		description := sanitizeHTML(body)
+		// The board's default-locale feed omits a posting's body when it is published in
+		// another locale (jobDescriptions comes back empty); the detail page still
+		// server-renders it as a schema.org JobPosting, so fall back to that.
+		if description == "" {
+			if d, ok := p.detailDescription(ctx, url); ok {
+				description = d
+			}
+		}
 		jobs = append(jobs, Job{
 			ExternalID:  pos.ID,
-			URL:         fmt.Sprintf("%s/job/%s", host, pos.ID),
+			URL:         url,
 			Title:       pos.Name,
 			Company:     e.Company,
 			Location:    pos.Office,
-			Description: sanitizeHTML(body),
+			Description: description,
 			Remote:      isRemote(pos.Office), // the feed has no remote flag
 			PostedAt:    parseRFC3339(pos.CreatedAt),
 		})
 	}
 	return jobs, nil
+}
+
+// detailDescription fetches a posting's detail page and returns its schema.org JobPosting
+// body, sanitized, with ok=false when the page fetch fails or carries no such block.
+func (p personio) detailDescription(ctx context.Context, url string) (string, bool) {
+	root, err := p.http.GetHTML(ctx, url)
+	if err != nil {
+		return "", false
+	}
+	var ld struct {
+		Description string `json:"description"`
+	}
+	if !ldJobPosting(root, &ld) || ld.Description == "" {
+		return "", false
+	}
+	return sanitizeHTML(html.UnescapeString(ld.Description)), true
 }

--- a/internal/sources/personio_test.go
+++ b/internal/sources/personio_test.go
@@ -85,6 +85,43 @@ func TestPersonioFetch(t *testing.T) {
 	}
 }
 
+func TestPersonioFetchFallsBackToDetailWhenFeedDescriptionEmpty(t *testing.T) {
+	// The board's default-locale feed omits this posting's body (it is published in
+	// another locale), so jobDescriptions is empty. The detail page still server-renders
+	// the body as a schema.org JobPosting, and the adapter falls back to it.
+	feed := `<?xml version="1.0" encoding="UTF-8"?>
+<workzag-jobs>
+  <position>
+    <id>2514154</id>
+    <office>Munich (Hybrid)</office>
+    <name>Marketing Intern (f/m/x)</name>
+    <jobDescriptions></jobDescriptions>
+    <createdAt>2026-01-30T16:17:59+00:00</createdAt>
+  </position>
+</workzag-jobs>`
+	detail := `<html><head><script type="application/ld+json">` +
+		`{"@context":"http://schema.org/","@type":"JobPosting",` +
+		`"description":"&lt;p&gt;Your mission as our Marketing Intern.&lt;/p&gt;"}` +
+		`</script></head><body></body></html>`
+
+	fake := (&routedHTTP{}).
+		route("/xml", feed).
+		route("/job/2514154", detail)
+
+	jobs, err := NewPersonio(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "4screen", Provider: "personio", Board: "4screen",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "Your mission as our Marketing Intern.") {
+		t.Errorf("Description = %q, want the detail-page JobPosting body", jobs[0].Description)
+	}
+}
+
 func TestPersonioFetchEmptyFeed(t *testing.T) {
 	fake := &fakeHTTP{body: `<?xml version="1.0" encoding="UTF-8"?><workzag-jobs></workzag-jobs>`}
 	jobs, err := NewPersonio(fake).Fetch(context.Background(), CompanyEntry{


### PR DESCRIPTION
## Problem
Reported: a 4screen Personio job on freehire.dev showed no content. Investigation found this is **systemic** — empty descriptions across several sources. Production counts (open jobs):

| source | empty | total |
|---|---|---|
| personio | 81 | 455 |
| lamoda | 61 | 113 |
| vk | 234 | 248 |

## Root causes & fixes (this PR: personio + lamoda)
- **Personio**: the XML feed is locale-gated — a posting published in a non-default board locale comes back with an empty `<jobDescriptions>`. The description is still server-rendered on the detail page as a schema.org `JobPosting`. Fix: fall back to the detail page via the existing `ldJobPosting` helper (same pattern as teamtailor/breezy) when the feed body is empty.
- **Lamoda**: retail vacancies leave the four structured body fields empty and carry the whole posting in the `common` attribute. Fix: fall back to `common`.

`UpsertJob` already updates `description = EXCLUDED.description`, so a re-ingest backfills existing rows.

## Out of scope
- **VK** (234 empty) is a different root cause: the `kittenx` edge rate-limit-challenges the 8-worker fan-out (302 → `/challenge.html`), and the HTTP client silently follows it and stores the challenge page as an empty description. Needs a throttle + challenge-detection in the shared client — tracked separately.

## Tests
TDD (RED→GREEN). New cases: `TestPersonioFetchFallsBackToDetailWhenFeedDescriptionEmpty`, `TestLamodaDetailFallsBackToCommonWhenStructuredFieldsEmpty`. Full `go test ./...` + `go vet` green.