### PR TITLE
web: self-host the CLI install script at freehire.dev/install.sh

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -23,6 +23,13 @@ server {
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
+    # The CLI install script (web/public/install.sh), served as plain text so
+    # `curl -fsSL https://freehire.dev/install.sh | sh` works and a browser can
+    # read it before piping to a shell.
+    location = /install.sh {
+        default_type text/plain;
+    }
+
     # SPA fallback: client-side router owns all other paths.
     location / {
         try_files $uri /index.html;

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Install the freehire CLI: download the prebuilt binary for this OS/arch from the
+# latest GitHub release and place it on PATH.
+#   curl -fsSL https://freehire.dev/install.sh | sh
+#
+# Served at https://freehire.dev/install.sh (Vite copies web/public/ into the SPA
+# build). Kept in sync with the canonical script in the freehire-cli repo.
+set -eu
+
+REPO="strelov1/freehire-cli"
+BIN="freehire"
+INSTALL_DIR="${FREEHIRE_INSTALL_DIR:-/usr/local/bin}"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+case "$os" in
+  linux | darwin) ;;
+  *) echo "freehire: unsupported OS '$os' (use 'go install $REPO/cmd/$BIN@latest')" >&2; exit 1 ;;
+esac
+
+arch=$(uname -m)
+case "$arch" in
+  x86_64 | amd64) arch=amd64 ;;
+  arm64 | aarch64) arch=arm64 ;;
+  *) echo "freehire: unsupported arch '$arch' (use 'go install $REPO/cmd/$BIN@latest')" >&2; exit 1 ;;
+esac
+
+asset="${BIN}_${os}_${arch}"
+url="https://github.com/${REPO}/releases/latest/download/${asset}"
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+echo "Downloading ${asset} …"
+curl -fsSL "$url" -o "$tmp"
+chmod +x "$tmp"
+
+target="${INSTALL_DIR}/${BIN}"
+if [ -w "$INSTALL_DIR" ]; then
+  mv "$tmp" "$target"
+else
+  echo "Installing to ${target} (requires sudo) …"
+  sudo mv "$tmp" "$target"
+fi
+trap - EXIT
+
+echo "Installed ${BIN} → ${target}"
+echo "Next: ${BIN} auth login --token fhk_…    (create a key at https://freehire.dev → API keys)"

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -179,7 +179,7 @@
           terminal
         </figcaption>
         <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># install — no Go needed</span>
-curl -fsSL <span class="text-foreground">.../freehire-cli/main/install.sh</span> | sh
+curl -fsSL <span class="text-foreground">https://freehire.dev/install.sh</span> | sh
 
 <span class="text-muted-foreground"># authenticate once, then search &amp; apply</span>
 freehire auth login --token <span class="text-foreground">fhk_…</span>


### PR DESCRIPTION
## Summary
The landing's install command showed a raw `…/freehire-cli/main/install.sh` URL (no domain — looks broken). Self-host the installer on our own origin.

- **web/public/install.sh** — the install script. Vite copies `public/` into the SPA build (`dist/install.sh`), and `web/Dockerfile` copies `dist` into the nginx root, so it serves at `https://freehire.dev/install.sh`. Content is the canonical `freehire-cli/install.sh` (downloads the latest release binary for the host OS/arch).
- **nginx.conf** — serve `/install.sh` as `text/plain` (an exact-match location; `curl … | sh` works and a browser can inspect it).
- **HomeView** — the landing terminal now shows `curl -fsSL https://freehire.dev/install.sh | sh`.

## Test Plan
- [x] `npm run check` (svelte-check) 0 errors; `npm run build` OK; `dist/install.sh` present with the freehire.dev header.
- [ ] After deploy: `curl -fsSL https://freehire.dev/install.sh | sh` installs `freehire`; the script is viewable in a browser.