### PR TITLE
location: resolve US states/ZIP and Canadian provinces

### DIFF
--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -130,6 +130,58 @@ var nameToCountry = map[string]string{
 	"киев": "ua", "київ": "ua",
 }
 
+// subdivisionToCountry resolves a US state or Canadian province token — a postal
+// abbreviation ("tx", "on") or full name ("texas", "ontario") — to its ISO 3166-1
+// alpha-2 country code, for the "City, ST ZIP" (US) and "City, Province" (Canada)
+// formats that dominate North American ATS data. The region falls out of
+// countryToRegion (us / north_america).
+//
+// Two-letter codes that collide with a country ISO code whose city the parser
+// already keys are deliberately omitted (the country wins, so "Berlin, DE" /
+// "Bangalore, IN" / "Amsterdam, NL" stay Germany / India / Netherlands); those
+// subdivisions resolve via their full name instead. "ca" is the exception: it
+// stays California because "City, CA" is the single most common US location form —
+// the rare "Toronto, CA" mislabel is accepted. The country Georgia is unaffected:
+// the state carries the code "ga", and the name "georgia" is intentionally absent
+// here too (the country resolves via "tbilisi").
+var subdivisionToCountry = map[string]string{
+	// US states (postal codes). de/in/id omitted — they collide with Germany /
+	// India / Indonesia; see delaware/indiana/idaho below.
+	"al": "us", "ak": "us", "az": "us", "ar": "us", "ca": "us", "co": "us",
+	"ct": "us", "fl": "us", "ga": "us", "hi": "us", "ia": "us", "il": "us",
+	"ks": "us", "ky": "us", "la": "us", "ma": "us", "md": "us", "me": "us",
+	"mi": "us", "mn": "us", "mo": "us", "ms": "us", "mt": "us", "nc": "us",
+	"nd": "us", "ne": "us", "nh": "us", "nj": "us", "nm": "us", "nv": "us",
+	"ny": "us", "oh": "us", "ok": "us", "or": "us", "pa": "us", "ri": "us",
+	"sc": "us", "sd": "us", "tn": "us", "tx": "us", "ut": "us", "va": "us",
+	"vt": "us", "wa": "us", "wi": "us", "wv": "us", "wy": "us", "dc": "us",
+	// US states (full names). "georgia" omitted (collides with the country).
+	"alabama": "us", "alaska": "us", "arizona": "us", "arkansas": "us",
+	"california": "us", "colorado": "us", "connecticut": "us", "delaware": "us",
+	"florida": "us", "hawaii": "us", "idaho": "us", "illinois": "us",
+	"indiana": "us", "iowa": "us", "kansas": "us", "kentucky": "us",
+	"louisiana": "us", "maine": "us", "maryland": "us", "massachusetts": "us",
+	"michigan": "us", "minnesota": "us", "mississippi": "us", "missouri": "us",
+	"montana": "us", "nebraska": "us", "nevada": "us", "new hampshire": "us",
+	"new jersey": "us", "new mexico": "us", "new york": "us",
+	"north carolina": "us", "north dakota": "us", "ohio": "us", "oklahoma": "us",
+	"oregon": "us", "pennsylvania": "us", "rhode island": "us",
+	"south carolina": "us", "south dakota": "us", "tennessee": "us",
+	"texas": "us", "utah": "us", "vermont": "us", "virginia": "us",
+	"washington": "us", "west virginia": "us", "wisconsin": "us",
+	"wyoming": "us", "district of columbia": "us",
+	// Canadian provinces (postal codes). "nl" omitted — it collides with the
+	// Netherlands; Newfoundland resolves via its full name below.
+	"on": "ca", "bc": "ca", "qc": "ca", "ab": "ca", "mb": "ca", "sk": "ca",
+	"ns": "ca", "nb": "ca", "pe": "ca", "nt": "ca", "yt": "ca", "nu": "ca",
+	// Canadian provinces (full names).
+	"ontario": "ca", "quebec": "ca", "british columbia": "ca", "alberta": "ca",
+	"manitoba": "ca", "saskatchewan": "ca", "nova scotia": "ca",
+	"new brunswick": "ca", "newfoundland and labrador": "ca",
+	"prince edward island": "ca", "northwest territories": "ca",
+	"yukon": "ca", "nunavut": "ca",
+}
+
 // nameToRegion resolves macro-region names (and explicit open-anywhere markers)
 // directly to a region code, for tokens that name an area rather than a country.
 var nameToRegion = map[string]string{

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -62,6 +62,13 @@ func Parse(location string) Geo {
 		}
 		if r, ok := nameToRegion[tok]; ok {
 			regionSet[r] = struct{}{}
+			continue
+		}
+		if code, ok := resolveSubdivision(tok); ok {
+			countrySet[code] = struct{}{}
+			if r, ok := countryToRegion[code]; ok {
+				regionSet[r] = struct{}{}
+			}
 		}
 	}
 
@@ -88,6 +95,62 @@ func stripCityPrefix(tok string) string {
 		}
 	}
 	return tok
+}
+
+// resolveSubdivision resolves a US-state / Canadian-province token to its ISO
+// country code, covering the "City, ST ZIP" and "City, Province" ATS formats. It
+// tries, in order: a direct match ("tx", "texas", "ontario"); a trailing US ZIP
+// preceded by a state code ("tx 76135" -> "tx"); a bare trailing code in a
+// multi-word token ("austin tx"); and a standalone US ZIP ("94105") as a us
+// signal. It returns ("", false) for anything it cannot resolve — it never
+// guesses past the curated subdivision table.
+func resolveSubdivision(tok string) (string, bool) {
+	if code, ok := subdivisionToCountry[tok]; ok {
+		return code, true
+	}
+	fields := strings.Fields(tok)
+	switch len(fields) {
+	case 0:
+		return "", false
+	case 1:
+		if isUSZip(fields[0]) {
+			return "us", true
+		}
+		return "", false
+	}
+	last := fields[len(fields)-1]
+	if isUSZip(last) {
+		if code, ok := subdivisionToCountry[fields[len(fields)-2]]; ok {
+			return code, true
+		}
+		return "us", true
+	}
+	if code, ok := subdivisionToCountry[last]; ok {
+		return code, true
+	}
+	return "", false
+}
+
+// isUSZip reports whether s is a US ZIP code: five digits, optionally followed by
+// a "-" and the four-digit ZIP+4 extension ("76135" or "76135-1234").
+func isUSZip(s string) bool {
+	switch len(s) {
+	case 5:
+		return allDigits(s)
+	case 10:
+		return s[5] == '-' && allDigits(s[:5]) && allDigits(s[6:])
+	default:
+		return false
+	}
+}
+
+func allDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
 }
 
 // workModeMarkers maps a work mode to the substrings that signal it, checked in

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -111,6 +111,79 @@ func TestParse(t *testing.T) {
 	}
 }
 
+// TestParseNorthAmerica covers the US "City, ST ZIP" and Canadian "City, Province"
+// ATS formats: a trailing US state / Canadian province code or full name resolves
+// the country (and its region) even when the city is unknown, and a US ZIP code is
+// a standalone "us" signal. The country Georgia must never be misread as the US
+// state (the code "ga" carries the state; the name stays out of the dictionary).
+func TestParseNorthAmerica(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     Geo
+	}{
+		{
+			name:     "US City, ST ZIP",
+			location: "Lake Worth, TX 76135",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "US City, ST",
+			location: "Austin, TX",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "US state code CA is California, not Canada",
+			location: "San Francisco, CA",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "US full state name",
+			location: "Remote - California",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
+		},
+		{
+			name:     "US no-comma City ST",
+			location: "Austin TX",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "bare US ZIP is a us signal",
+			location: "94105",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "Canadian province code maps to north_america",
+			location: "Toronto, ON",
+			want:     Geo{Countries: []string{"ca"}, Regions: []string{"north_america"}},
+		},
+		{
+			name:     "Canadian full province name",
+			location: "Vancouver, British Columbia",
+			want:     Geo{Countries: []string{"ca"}, Regions: []string{"north_america"}},
+		},
+		{
+			name:     "Washington DC resolves to us",
+			location: "Washington, DC",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "country Georgia is never misread as the US state",
+			location: "Tbilisi, Georgia",
+			want:     Geo{Countries: []string{"ge"}, Regions: []string{"cis"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.location)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse(%q) = %+v, want %+v", tt.location, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestParseCyrillic covers the RU-segment ATS data, whose location fields are in
 // Cyrillic ("Москва"), sometimes prefixed with the Russian city marker "г"
 // ("г Москва"), and which name a remote/hybrid mode in Russian ("Удалённо").


### PR DESCRIPTION
## What

Teach the static location parser the dominant North American ATS formats so US
and Canadian jobs resolve a country + region **before enrichment**, instead of
falling through to nothing.

Motivating example: `Lake Worth, TX 76135` (a real prod job) resolved to no
country and no region — the city isn't keyed and `TX`/ZIP weren't recognized.

## How

- New curated `subdivisionToCountry` table in `internal/location`: US state and
  Canadian province postal codes **and** full names → ISO country code (region
  falls out of the existing `countryToRegion`: `us` / `north_america`).
- New `resolveSubdivision` step in `Parse` (runs only after country/region
  lookups, preserving "never guess past the dictionary"): direct match, trailing
  US ZIP stripping (`tx 76135` → `tx`), bare trailing code (`austin tx`), and a
  standalone US ZIP as a `us` signal.

### Collision handling (deliberate)

- Two-letter codes colliding with a keyed country ISO — `DE` (Germany), `IN`
  (India), `NL` (Netherlands) — are **omitted**; those subdivisions resolve via
  their full name, so `Berlin, DE` / `Bangalore, IN` / `Amsterdam, NL` stay the
  country.
- `CA` stays **California** (the single most common US form); the rare
  `Toronto, CA` mislabel is accepted.
- The country **Georgia** is unaffected: the state carries the code `ga`, and the
  name `georgia` is intentionally absent (the country resolves via `tbilisi`).

## Tests

New `TestParseNorthAmerica` covers `City, ST ZIP`, `City, ST`, full names,
no-comma `City ST`, bare ZIP, Canadian provinces, Washington DC, and an
anti-regression for `Tbilisi, Georgia` → only `ge`. Full suite + `go vet` green.
No schema/sqlc/API change.

## Rollout

No migration. After merge: deploy from `origin/main`, then
`docker compose run --rm backfill-geo` (re-parses existing rows; idempotent),
then `docker compose run --rm reindex`.
