### PR TITLE
sources: personio falls back to the English feed for locale-gated bodies

### DIFF
--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -130,6 +130,58 @@ var nameToCountry = map[string]string{
 	"киев": "ua", "київ": "ua",
 }
 
+// subdivisionToCountry resolves a US state or Canadian province token — a postal
+// abbreviation ("tx", "on") or full name ("texas", "ontario") — to its ISO 3166-1
+// alpha-2 country code, for the "City, ST ZIP" (US) and "City, Province" (Canada)
+// formats that dominate North American ATS data. The region falls out of
+// countryToRegion (us / north_america).
+//
+// Two-letter codes that collide with a country ISO code whose city the parser
+// already keys are deliberately omitted (the country wins, so "Berlin, DE" /
+// "Bangalore, IN" / "Amsterdam, NL" stay Germany / India / Netherlands); those
+// subdivisions resolve via their full name instead. "ca" is the exception: it
+// stays California because "City, CA" is the single most common US location form —
+// the rare "Toronto, CA" mislabel is accepted. The country Georgia is unaffected:
+// the state carries the code "ga", and the name "georgia" is intentionally absent
+// here too (the country resolves via "tbilisi").
+var subdivisionToCountry = map[string]string{
+	// US states (postal codes). de/in/id omitted — they collide with Germany /
+	// India / Indonesia; see delaware/indiana/idaho below.
+	"al": "us", "ak": "us", "az": "us", "ar": "us", "ca": "us", "co": "us",
+	"ct": "us", "fl": "us", "ga": "us", "hi": "us", "ia": "us", "il": "us",
+	"ks": "us", "ky": "us", "la": "us", "ma": "us", "md": "us", "me": "us",
+	"mi": "us", "mn": "us", "mo": "us", "ms": "us", "mt": "us", "nc": "us",
+	"nd": "us", "ne": "us", "nh": "us", "nj": "us", "nm": "us", "nv": "us",
+	"ny": "us", "oh": "us", "ok": "us", "or": "us", "pa": "us", "ri": "us",
+	"sc": "us", "sd": "us", "tn": "us", "tx": "us", "ut": "us", "va": "us",
+	"vt": "us", "wa": "us", "wi": "us", "wv": "us", "wy": "us", "dc": "us",
+	// US states (full names). "georgia" omitted (collides with the country).
+	"alabama": "us", "alaska": "us", "arizona": "us", "arkansas": "us",
+	"california": "us", "colorado": "us", "connecticut": "us", "delaware": "us",
+	"florida": "us", "hawaii": "us", "idaho": "us", "illinois": "us",
+	"indiana": "us", "iowa": "us", "kansas": "us", "kentucky": "us",
+	"louisiana": "us", "maine": "us", "maryland": "us", "massachusetts": "us",
+	"michigan": "us", "minnesota": "us", "mississippi": "us", "missouri": "us",
+	"montana": "us", "nebraska": "us", "nevada": "us", "new hampshire": "us",
+	"new jersey": "us", "new mexico": "us", "new york": "us",
+	"north carolina": "us", "north dakota": "us", "ohio": "us", "oklahoma": "us",
+	"oregon": "us", "pennsylvania": "us", "rhode island": "us",
+	"south carolina": "us", "south dakota": "us", "tennessee": "us",
+	"texas": "us", "utah": "us", "vermont": "us", "virginia": "us",
+	"washington": "us", "west virginia": "us", "wisconsin": "us",
+	"wyoming": "us", "district of columbia": "us",
+	// Canadian provinces (postal codes). "nl" omitted — it collides with the
+	// Netherlands; Newfoundland resolves via its full name below.
+	"on": "ca", "bc": "ca", "qc": "ca", "ab": "ca", "mb": "ca", "sk": "ca",
+	"ns": "ca", "nb": "ca", "pe": "ca", "nt": "ca", "yt": "ca", "nu": "ca",
+	// Canadian provinces (full names).
+	"ontario": "ca", "quebec": "ca", "british columbia": "ca", "alberta": "ca",
+	"manitoba": "ca", "saskatchewan": "ca", "nova scotia": "ca",
+	"new brunswick": "ca", "newfoundland and labrador": "ca",
+	"prince edward island": "ca", "northwest territories": "ca",
+	"yukon": "ca", "nunavut": "ca",
+}
+
 // nameToRegion resolves macro-region names (and explicit open-anywhere markers)
 // directly to a region code, for tokens that name an area rather than a country.
 var nameToRegion = map[string]string{

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -62,6 +62,13 @@ func Parse(location string) Geo {
 		}
 		if r, ok := nameToRegion[tok]; ok {
 			regionSet[r] = struct{}{}
+			continue
+		}
+		if code, ok := resolveSubdivision(tok); ok {
+			countrySet[code] = struct{}{}
+			if r, ok := countryToRegion[code]; ok {
+				regionSet[r] = struct{}{}
+			}
 		}
 	}
 
@@ -88,6 +95,62 @@ func stripCityPrefix(tok string) string {
 		}
 	}
 	return tok
+}
+
+// resolveSubdivision resolves a US-state / Canadian-province token to its ISO
+// country code, covering the "City, ST ZIP" and "City, Province" ATS formats. It
+// tries, in order: a direct match ("tx", "texas", "ontario"); a trailing US ZIP
+// preceded by a state code ("tx 76135" -> "tx"); a bare trailing code in a
+// multi-word token ("austin tx"); and a standalone US ZIP ("94105") as a us
+// signal. It returns ("", false) for anything it cannot resolve — it never
+// guesses past the curated subdivision table.
+func resolveSubdivision(tok string) (string, bool) {
+	if code, ok := subdivisionToCountry[tok]; ok {
+		return code, true
+	}
+	fields := strings.Fields(tok)
+	switch len(fields) {
+	case 0:
+		return "", false
+	case 1:
+		if isUSZip(fields[0]) {
+			return "us", true
+		}
+		return "", false
+	}
+	last := fields[len(fields)-1]
+	if isUSZip(last) {
+		if code, ok := subdivisionToCountry[fields[len(fields)-2]]; ok {
+			return code, true
+		}
+		return "us", true
+	}
+	if code, ok := subdivisionToCountry[last]; ok {
+		return code, true
+	}
+	return "", false
+}
+
+// isUSZip reports whether s is a US ZIP code: five digits, optionally followed by
+// a "-" and the four-digit ZIP+4 extension ("76135" or "76135-1234").
+func isUSZip(s string) bool {
+	switch len(s) {
+	case 5:
+		return allDigits(s)
+	case 10:
+		return s[5] == '-' && allDigits(s[:5]) && allDigits(s[6:])
+	default:
+		return false
+	}
+}
+
+func allDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return s != ""
 }
 
 // workModeMarkers maps a work mode to the substrings that signal it, checked in

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -111,6 +111,79 @@ func TestParse(t *testing.T) {
 	}
 }
 
+// TestParseNorthAmerica covers the US "City, ST ZIP" and Canadian "City, Province"
+// ATS formats: a trailing US state / Canadian province code or full name resolves
+// the country (and its region) even when the city is unknown, and a US ZIP code is
+// a standalone "us" signal. The country Georgia must never be misread as the US
+// state (the code "ga" carries the state; the name stays out of the dictionary).
+func TestParseNorthAmerica(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		want     Geo
+	}{
+		{
+			name:     "US City, ST ZIP",
+			location: "Lake Worth, TX 76135",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "US City, ST",
+			location: "Austin, TX",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "US state code CA is California, not Canada",
+			location: "San Francisco, CA",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "US full state name",
+			location: "Remote - California",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
+		},
+		{
+			name:     "US no-comma City ST",
+			location: "Austin TX",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "bare US ZIP is a us signal",
+			location: "94105",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "Canadian province code maps to north_america",
+			location: "Toronto, ON",
+			want:     Geo{Countries: []string{"ca"}, Regions: []string{"north_america"}},
+		},
+		{
+			name:     "Canadian full province name",
+			location: "Vancouver, British Columbia",
+			want:     Geo{Countries: []string{"ca"}, Regions: []string{"north_america"}},
+		},
+		{
+			name:     "Washington DC resolves to us",
+			location: "Washington, DC",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+		},
+		{
+			name:     "country Georgia is never misread as the US state",
+			location: "Tbilisi, Georgia",
+			want:     Geo{Countries: []string{"ge"}, Regions: []string{"cis"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Parse(tt.location)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse(%q) = %+v, want %+v", tt.location, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestParseCyrillic covers the RU-segment ATS data, whose location fields are in
 // Cyrillic ("Москва"), sometimes prefixed with the Russian city marker "г"
 // ("г Москва"), and which name a remote/hybrid mode in Russian ("Удалённо").

--- a/internal/sources/personio.go
+++ b/internal/sources/personio.go
@@ -20,36 +20,50 @@ func NewPersonio(c HTTPClient) Source { return personio{http: c} }
 
 func (personio) Provider() string { return "personio" }
 
+// personioPosition is one open position in a board's XML feed. Personio splits the body
+// across one or more jobDescription HTML values, concatenated by body().
+type personioPosition struct {
+	ID           string `xml:"id"`
+	Office       string `xml:"office"`
+	Name         string `xml:"name"`
+	CreatedAt    string `xml:"createdAt"`
+	Descriptions []struct {
+		Value string `xml:"value"`
+	} `xml:"jobDescriptions>jobDescription"`
+}
+
+func (pos personioPosition) body() string {
+	var b string
+	for _, d := range pos.Descriptions {
+		b += d.Value
+	}
+	return b
+}
+
 func (p personio) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	host := fmt.Sprintf("https://%s.jobs.personio.com", e.Board)
 
-	var resp struct {
-		Positions []struct {
-			ID           string `xml:"id"`
-			Office       string `xml:"office"`
-			Name         string `xml:"name"`
-			CreatedAt    string `xml:"createdAt"`
-			Descriptions []struct {
-				Value string `xml:"value"`
-			} `xml:"jobDescriptions>jobDescription"`
-		} `xml:"position"`
-	}
-	if err := p.http.GetXML(ctx, host+"/xml", &resp); err != nil {
+	positions, err := p.feed(ctx, host, "")
+	if err != nil {
 		return nil, fmt.Errorf("personio: fetch board %s: %w", e.Board, err)
 	}
 
-	jobs := make([]Job, 0, len(resp.Positions))
-	for _, pos := range resp.Positions {
-		// Personio splits the body across one or more jobDescription HTML values.
-		var body string
-		for _, d := range pos.Descriptions {
-			body += d.Value
+	// The default feed is locale-gated: a posting published only in a non-default locale
+	// comes back with an empty body. Fetch the English feed once (best-effort) and index
+	// it by id, to fill those gaps.
+	enBodies := p.englishBodies(ctx, host, positions)
+
+	jobs := make([]Job, 0, len(positions))
+	for _, pos := range positions {
+		body := pos.body()
+		if body == "" {
+			body = enBodies[pos.ID]
 		}
 		url := fmt.Sprintf("%s/job/%s", host, pos.ID)
 		description := sanitizeHTML(body)
-		// The board's default-locale feed omits a posting's body when it is published in
-		// another locale (jobDescriptions comes back empty); the detail page still
-		// server-renders it as a schema.org JobPosting, so fall back to that.
+		// Still empty (the posting is in neither the default nor the English feed): some
+		// boards' detail pages server-render the body as a schema.org JobPosting, so fall
+		// back to that as a last resort.
 		if description == "" {
 			if d, ok := p.detailDescription(ctx, url); ok {
 				description = d
@@ -67,6 +81,47 @@ func (p personio) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		})
 	}
 	return jobs, nil
+}
+
+// feed fetches a board's XML feed for the given language ("" for the board default) and
+// returns its positions.
+func (p personio) feed(ctx context.Context, host, lang string) ([]personioPosition, error) {
+	url := host + "/xml"
+	if lang != "" {
+		url += "?language=" + lang
+	}
+	var resp struct {
+		Positions []personioPosition `xml:"position"`
+	}
+	if err := p.http.GetXML(ctx, url, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Positions, nil
+}
+
+// englishBodies returns id→body from the English feed, fetched only when some position's
+// default-feed body is empty. A failed English fetch is non-fatal — the caller still has
+// the detail-page fallback — so it returns nil on error.
+func (p personio) englishBodies(ctx context.Context, host string, positions []personioPosition) map[string]string {
+	missing := false
+	for _, pos := range positions {
+		if pos.body() == "" {
+			missing = true
+			break
+		}
+	}
+	if !missing {
+		return nil
+	}
+	en, err := p.feed(ctx, host, "en")
+	if err != nil {
+		return nil
+	}
+	bodies := make(map[string]string, len(en))
+	for _, pos := range en {
+		bodies[pos.ID] = pos.body()
+	}
+	return bodies
 }
 
 // detailDescription fetches a posting's detail page and returns its schema.org JobPosting

--- a/internal/sources/personio_test.go
+++ b/internal/sources/personio_test.go
@@ -122,6 +122,53 @@ func TestPersonioFetchFallsBackToDetailWhenFeedDescriptionEmpty(t *testing.T) {
 	}
 }
 
+func TestPersonioFetchFallsBackToEnglishFeedWhenDefaultLocaleEmpty(t *testing.T) {
+	// The default-locale feed omits this posting's body, and its detail page carries no
+	// JobPosting ld+json — but the ?language=en feed does have the body. The adapter
+	// fetches the English feed once and fills the gap from it.
+	defaultFeed := `<?xml version="1.0" encoding="UTF-8"?>
+<workzag-jobs>
+  <position>
+    <id>2632015</id>
+    <office>Hamburg</office>
+    <name>Game Designer</name>
+    <jobDescriptions></jobDescriptions>
+    <createdAt>2026-01-30T16:17:59+00:00</createdAt>
+  </position>
+</workzag-jobs>`
+	enFeed := `<?xml version="1.0" encoding="UTF-8"?>
+<workzag-jobs>
+  <position>
+    <id>2632015</id>
+    <office>Hamburg</office>
+    <name>Game Designer</name>
+    <jobDescriptions>
+      <jobDescription><name>Tasks</name><value><![CDATA[<p>Design the game.</p>]]></value></jobDescription>
+    </jobDescriptions>
+    <createdAt>2026-01-30T16:17:59+00:00</createdAt>
+  </position>
+</workzag-jobs>`
+
+	// Route the English feed before the default one: the ?language=en URL also contains
+	// "/xml", so the more specific match must come first.
+	fake := (&routedHTTP{}).
+		route("language=en", enFeed).
+		route("/xml", defaultFeed)
+
+	jobs, err := NewPersonio(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Tonies", Provider: "personio", Board: "tonies",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "Design the game.") {
+		t.Errorf("Description = %q, want the English-feed body", jobs[0].Description)
+	}
+}
+
 func TestPersonioFetchEmptyFeed(t *testing.T) {
 	fake := &fakeHTTP{body: `<?xml version="1.0" encoding="UTF-8"?><workzag-jobs></workzag-jobs>`}
 	jobs, err := NewPersonio(fake).Fetch(context.Background(), CompanyEntry{


### PR DESCRIPTION
Follow-up to #35. After that fix, 5 personio jobs (tonies×3, stratosphere-games×2) were still empty: their detail pages carry **no** JobPosting ld+json, so the JSON-LD fallback can't reach them — but the `?language=en` feed does have the body.

This fetches the English feed once per board (only when some default-feed body is empty), indexes it by id, and fills the gaps; the detail-page ld+json stays as a last resort for boards whose English feed also lacks the posting.

TDD: new `TestPersonioFetchFallsBackToEnglishFeedWhenDefaultLocaleEmpty`; existing personio tests still green.