### PR TITLE
web: job detail metadata sidebar with clickable facet filters

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -3,7 +3,7 @@
   import { ArrowRight, Bookmark, Check } from '@lucide/svelte';
   import { markJobApplied, recordJobView, saveJob, unsaveJob } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
-  import { formatSalary, summaryFacets } from '$lib/enrichment';
+  import { filterHref, formatSalary, summaryFacets } from '$lib/enrichment';
   import type { Job, UserJob } from '$lib/types';
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
@@ -75,57 +75,48 @@
   }
 </script>
 
-<article class="flex flex-col gap-6">
-  <header class="flex flex-col gap-4">
-    <div class="flex items-start justify-between gap-4">
-      <div class="flex items-start gap-3">
-        <CompanyLogo name={job.company} size="size-10" />
-        <div class="flex flex-col gap-1">
-          <p class="text-sm text-muted-foreground">
-            {#if job.company_slug}
-              <a href={`/companies/${job.company_slug}`} class="hover:text-foreground hover:underline">
-                {job.company || 'Unknown company'}
-              </a>
-            {:else}
-              {job.company || 'Unknown company'}
-            {/if}
-            {#if job.location}· {job.location}{/if}
-          </p>
-          <h1 class="text-2xl font-semibold tracking-tight">{job.title}</h1>
+<!-- Wide layout mirroring /jobs. The company line spans the very top; below it a
+     sticky left sidebar (salary + actions + metadata) starts level with the title,
+     and the description reads in the right column. On mobile everything stacks:
+     company → title + apply CTA → metadata → description. -->
+<article class="flex flex-col gap-4 lg:grid lg:grid-cols-[20rem_minmax(0,1fr)] lg:gap-x-6 lg:gap-y-4">
+  <div class="flex items-center gap-3 lg:col-start-2 lg:row-start-1">
+    <CompanyLogo name={job.company} size="size-8" />
+    <p class="text-sm text-muted-foreground">
+      {#if job.company_slug}
+        <a href={`/companies/${job.company_slug}`} class="hover:text-foreground hover:underline">
+          {job.company || 'Unknown company'}
+        </a>
+      {:else}
+        {job.company || 'Unknown company'}
+      {/if}
+    </p>
+  </div>
+
+  <header class="flex flex-col gap-4 lg:col-start-2 lg:row-start-2">
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+      <h1 class="text-2xl font-semibold tracking-tight">{job.title}</h1>
+
+      {#if !job.closed_at || applied}
+        <div class="flex shrink-0 flex-col gap-2 sm:items-end">
+          {#if !job.closed_at}
+            <Button
+              variant="primary"
+              href={job.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onclick={onApplyClick}
+              class="w-full sm:w-auto"
+            >
+              Show <ArrowRight class="size-4" />
+            </Button>
+          {/if}
+          {#if applied}
+            <Badge variant="secondary"><Check class="mr-1 size-3.5" /> You applied</Badge>
+          {/if}
         </div>
-      </div>
-
-      <div class="flex shrink-0 flex-col items-end gap-2">
-        {#if !job.closed_at}
-          <Button
-            variant="primary"
-            href={job.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            onclick={onApplyClick}
-          >
-            Show <ArrowRight class="size-4" />
-          </Button>
-        {/if}
-        {#if isAuthenticated()}
-          <Button variant="outline" size="sm" onclick={toggleSave} aria-pressed={saved}>
-            <Bookmark class={saved ? 'size-4 fill-current' : 'size-4'} />
-            {saved ? 'Saved' : 'Save'}
-          </Button>
-        {/if}
-        {#if applied}
-          <Badge variant="secondary"><Check class="mr-1 size-3.5" /> You applied</Badge>
-        {/if}
-      </div>
+      {/if}
     </div>
-
-    {#if job.closed_at}
-      {@const closed = formatDate(job.closed_at)}
-      <div class="rounded-md border border-border bg-secondary px-4 py-3 text-sm">
-        This position is no longer accepting applications{#if closed}
-          (closed {closed}){/if}.
-      </div>
-    {/if}
 
     {#if showApplyPrompt && !applied}
       <div
@@ -138,40 +129,82 @@
         </div>
       </div>
     {/if}
-
-    {#if salary}
-      <p class="text-xl font-semibold tabular-nums tracking-tight">{salary}</p>
-    {/if}
-
-    {#if facets.length}
-      <dl class="flex flex-wrap gap-x-6 gap-y-2 text-sm">
-        {#each facets as facet (facet.label)}
-          <div class="flex items-baseline gap-1.5">
-            <dt class="text-muted-foreground">{facet.label}</dt>
-            <dd class="font-medium">{facet.value}</dd>
-          </div>
-        {/each}
-      </dl>
-    {/if}
-
-    {#if e.skills?.length}
-      <ul class="flex flex-wrap gap-1.5">
-        {#each e.skills as skill}
-          <li><Badge variant="secondary">{skill}</Badge></li>
-        {/each}
-      </ul>
-    {/if}
   </header>
 
-  <div class="flex flex-wrap items-center gap-2 border-t border-border pt-4">
-    <Badge variant="outline">{job.source}</Badge>
-    {#if posted}<span class="text-xs text-muted-foreground">Posted {posted}</span>{/if}
-  </div>
+  <aside class="w-full shrink-0 lg:col-start-1 lg:row-span-3 lg:row-start-1">
+    <div class="sticky top-6 flex flex-col gap-4 rounded-xl border border-border bg-card p-4">
+      {#if salary}
+        <p
+          class="border-t border-border pt-4 text-xl font-semibold tabular-nums tracking-tight first:border-t-0 first:pt-0"
+        >
+          {salary}
+        </p>
+      {/if}
 
-  {#if job.description}
-    <!-- Description is server-sanitized HTML (see internal/sources), safe to render. -->
-    <div class="job-description text-sm leading-relaxed">{@html job.description}</div>
-  {/if}
+      {#if isAuthenticated()}
+        <div class="border-t border-border pt-4 first:border-t-0 first:pt-0">
+          <Button variant="outline" onclick={toggleSave} aria-pressed={saved} class="w-full">
+            <Bookmark class={saved ? 'size-4 fill-current' : 'size-4'} />
+            {saved ? 'Saved' : 'Save'}
+          </Button>
+        </div>
+      {/if}
+
+      {#if facets.length}
+        <dl class="flex flex-col gap-2 border-t border-border pt-4 text-sm first:border-t-0 first:pt-0">
+          {#each facets as facet (facet.label)}
+            <div class="flex items-baseline justify-between gap-3">
+              <dt class="text-muted-foreground">{facet.label}</dt>
+              <dd class="text-right font-medium"
+                >{#each facet.values as v, i (v.text)}{#if i > 0}, {/if}{#if v.href}<a
+                      href={v.href}
+                      class="hover:text-foreground hover:underline">{v.text}</a
+                    >{:else}{v.text}{/if}{/each}</dd
+              >
+            </div>
+          {/each}
+        </dl>
+      {/if}
+
+      {#if e.skills?.length}
+        <ul class="flex flex-wrap gap-1.5 border-t border-border pt-4 first:border-t-0 first:pt-0">
+          {#each e.skills as skill}
+            <li>
+              <a href={filterHref('skills', skill)}>
+                <Badge variant="secondary" class="transition-colors hover:bg-accent">{skill}</Badge>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+
+      <div
+        class="flex flex-wrap items-center gap-2 border-t border-border pt-4 first:border-t-0 first:pt-0"
+      >
+        <a href={filterHref('source', job.source)}>
+          <Badge variant="outline" class="transition-colors hover:bg-accent hover:text-foreground">
+            {job.source}
+          </Badge>
+        </a>
+        {#if posted}<span class="text-xs text-muted-foreground">Posted {posted}</span>{/if}
+      </div>
+    </div>
+  </aside>
+
+  <div class="flex min-w-0 flex-col gap-6 lg:col-start-2 lg:row-start-3">
+    {#if job.closed_at}
+      {@const closed = formatDate(job.closed_at)}
+      <div class="rounded-md border border-border bg-secondary px-4 py-3 text-sm">
+        This position is no longer accepting applications{#if closed}
+          (closed {closed}){/if}.
+      </div>
+    {/if}
+
+    {#if job.description}
+      <!-- Description is server-sanitized HTML (see internal/sources), safe to render. -->
+      <div class="job-description text-sm leading-relaxed">{@html job.description}</div>
+    {/if}
+  </div>
 </article>
 
 <style>

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -5,10 +5,19 @@
 
 import type { Enrichment, Job } from './types';
 
-/** A single label/value pair in the summary meta-row. */
+/** One value within a facet row: its display text and, when the facet maps to a
+ *  job-search filter, the /jobs URL that applies it. */
+export interface FacetValue {
+  text: string;
+  href?: string;
+}
+
+/** A labelled facet row. Most facets carry a single value; the array-valued ones
+ *  (region, country, industry) carry one entry per code, each independently
+ *  clickable. */
 export interface Facet {
   label: string;
-  value: string;
+  values: FacetValue[];
 }
 
 const SENIORITY: Record<string, string> = {
@@ -120,6 +129,12 @@ function label(map: Record<string, string>, value: string): string {
   return map[value] ?? humanize(value);
 }
 
+/** The /jobs URL that filters by a single facet value. Param names match the
+ *  search API (see facets.ts / filters.svelte.ts). */
+export function filterHref(param: string, value: string): string {
+  return `/jobs?${param}=${encodeURIComponent(value)}`;
+}
+
 /** Group thousands with thin spaces, matching the salary line in the design. */
 function groupThousands(n: number): string {
   return n.toLocaleString('en-US').replace(/,/g, ' ');
@@ -200,29 +215,53 @@ export function cardTags(job: Job): string[] {
 export function summaryFacets(job: Job): Facet[] {
   const e = job.enrichment ?? {};
   const facets: Facet[] = [];
-  const push = (name: string, value: string | null | undefined) => {
-    if (value) facets.push({ label: name, value });
+
+  // A scalar facet that maps to a search filter: one clickable value.
+  const link = (
+    name: string,
+    param: string,
+    code: string | null | undefined,
+    text: string | null | undefined,
+  ) => {
+    if (code && text) facets.push({ label: name, values: [{ text, href: filterHref(param, code) }] });
+  };
+  // An array facet (region/country/industry): one clickable value per code.
+  const links = (
+    name: string,
+    param: string,
+    codes: string[] | undefined,
+    toText: (code: string) => string,
+  ) => {
+    if (codes?.length) {
+      facets.push({ label: name, values: codes.map((c) => ({ text: toText(c), href: filterHref(param, c) })) });
+    }
+  };
+  // A facet with no matching filter: plain, non-clickable text.
+  const plain = (name: string, text: string | null | undefined) => {
+    if (text) facets.push({ label: name, values: [{ text }] });
   };
 
-  push('Work format', job.work_mode && label(WORK_MODE, job.work_mode));
-  push('Region', regionLabel(job));
-  push('Work type', e.employment_type && label(EMPLOYMENT, e.employment_type));
-  push('Grade', e.seniority && label(SENIORITY, e.seniority));
-  push(
-    'Experience',
-    e.experience_years_min != null ? `${e.experience_years_min}+ yrs` : null,
-  );
-  push(
+  link('Work format', 'work_mode', job.work_mode, job.work_mode && label(WORK_MODE, job.work_mode));
+  plain('Location', job.location);
+  links('Region', 'regions', job.regions, (r) => label(REGION, r));
+  link('Work type', 'employment_type', e.employment_type, e.employment_type && label(EMPLOYMENT, e.employment_type));
+  link('Grade', 'seniority', e.seniority, e.seniority && label(SENIORITY, e.seniority));
+  plain('Experience', e.experience_years_min != null ? `${e.experience_years_min}+ yrs` : null);
+  link(
     'English',
+    'english_level',
+    e.english_level && e.english_level !== 'none' ? e.english_level : null,
     e.english_level && e.english_level !== 'none' ? label(ENGLISH_LEVEL, e.english_level) : null,
   );
-  push('Category', e.category && label(CATEGORY, e.category));
-  push('Country', job.countries?.length ? job.countries.map((c) => c.toUpperCase()).join(', ') : null);
-  push('Relocation', e.relocation && label(RELOCATION, e.relocation));
-  push('Visa', e.visa_sponsorship === true ? 'Sponsored' : null);
-  push('Company', e.company_type && label(COMPANY_TYPE, e.company_type));
-  push('Size', e.company_size);
-  push('Domains', e.domains?.length ? e.domains.map((d) => label(DOMAINS, d)).join(', ') : null);
+  link('Category', 'category', e.category, e.category && label(CATEGORY, e.category));
+  links('Country', 'countries', job.countries, (c) => c.toUpperCase());
+  link('Relocation', 'relocation', e.relocation, e.relocation && label(RELOCATION, e.relocation));
+  if (e.visa_sponsorship === true) {
+    facets.push({ label: 'Visa', values: [{ text: 'Sponsored', href: filterHref('visa_sponsorship', 'true') }] });
+  }
+  link('Company', 'company_type', e.company_type, e.company_type && label(COMPANY_TYPE, e.company_type));
+  plain('Size', e.company_size);
+  links('Domains', 'domains', e.domains, (d) => label(DOMAINS, d));
 
   return facets;
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { initTheme } from '$lib/theme.svelte';
   import TopBar from '$lib/components/TopBar.svelte';
+  import ProviderIcon from '$lib/components/ProviderIcon.svelte';
   import '../app.css';
 
   let { children } = $props();
@@ -30,9 +31,9 @@
         href="https://github.com/strelov1/freehire"
         target="_blank"
         rel="noopener noreferrer"
-        class="shrink-0 font-medium text-foreground transition-colors hover:text-muted-foreground"
+        class="inline-flex shrink-0 items-center gap-1.5 font-medium text-foreground transition-colors hover:text-muted-foreground"
       >
-        GitHub ↗
+        <ProviderIcon provider="github" /> GitHub
       </a>
     </div>
   </footer>

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -20,6 +20,6 @@
   {@html jsonLd}
 </svelte:head>
 
-<div class="mx-auto w-full max-w-3xl px-4 py-6">
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
   <JobView job={data.job} />
 </div>


### PR DESCRIPTION
## What

Redesigns the job detail page to mirror the `/jobs` layout and makes the metadata actionable.

- **Metadata sidebar.** Salary, work format, location, region, country, grade, English, category, relocation, visa, company type/size, industry, skills and source move into a sticky left sidebar; the page widens from `max-w-3xl` to `max-w-6xl`.
- **Clean header.** The company line spans the top (logo no longer overhangs the sidebar); title + apply CTA + description sit in the right column. `Show` goes full-width on mobile so it no longer collides with the title.
- **Clickable facets.** Every filterable facet, each skill, and the source badge link to `/jobs?<param>=<code>` with the filter pre-applied (`filterHref` maps to the search params in `facets.ts`). The free-text location stays a plain `Location` row (no city facet exists).
- **Footer.** GitHub link now shows the GitHub mark (reuses `ProviderIcon`).

## Verification

- `svelte-check`: 0 errors / 0 warnings; `npm run build` (adapter-node) succeeds.
- Manually verified on a SvelteKit dev server against the prod API: desktop + mobile layout, clickable Region facet navigates to `/jobs?regions=eu` (16,834 filtered results, Region facet active), skill/source links, footer icon. Auth-gated Save + 'Did you apply?' confirmed working with a mocked session.