### PR TITLE
search: decouple reported total from the pagination cap

### DIFF
--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -22,6 +22,13 @@ type searcher interface {
 // keyword search.
 const defaultSemanticRatio = 0.5
 
+// maxSearchWindow bounds how deep search pagination may reach (offset+limit). It
+// is the explicit pagination guard, decoupled from the index's maxTotalHits
+// (which now only sets how high the reported total may count): the total can read
+// the true filtered count while deep offset paging — the expensive part — stays
+// refused. ~500 pages at the default limit is far beyond any real browsing.
+const maxSearchWindow = 10000
+
 // searchStringFacets maps an equality-facet query param to its index attribute.
 // Enrichment facets live under the nested "enrichment" object, so they filter on
 // a dot path. Geography (regions/countries) and work_mode are resolved facets
@@ -66,6 +73,9 @@ func (h *Handler) SearchJobs(c *fiber.Ctx) error {
 	}
 
 	limit, offset := pageParams(c)
+	if offset+limit > maxSearchWindow {
+		return fiber.NewError(fiber.StatusBadRequest, "pagination too deep")
+	}
 	ratio := min(max(c.QueryFloat("semantic_ratio", defaultSemanticRatio), 0), 1)
 
 	res, err := h.search.Search(c.Context(), search.SearchParams{

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -97,6 +97,37 @@ func TestSearchJobs_PassesParamsAndShapesResponse(t *testing.T) {
 	}
 }
 
+func TestSearchJobs_DeepPaginationRejected(t *testing.T) {
+	fake := &fakeSearcher{}
+	app := searchApp(fake)
+
+	// offset+limit past the window must be refused before the backend is touched.
+	status, body := doGet(t, app, "/jobs/search?offset=10000&limit=100")
+	if status != fiber.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if fake.got.Limit != 0 {
+		t.Errorf("searcher was called despite deep pagination: %#v", fake.got)
+	}
+	if body["error"] == nil {
+		t.Errorf("expected an error message, got %v", body)
+	}
+}
+
+func TestSearchJobs_PaginationAtWindowBoundaryAllowed(t *testing.T) {
+	fake := &fakeSearcher{}
+	app := searchApp(fake)
+
+	// offset+limit exactly at the window is still allowed and reaches the backend.
+	status, _ := doGet(t, app, "/jobs/search?offset=9900&limit=100")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if fake.got.Offset != 9900 || fake.got.Limit != 100 {
+		t.Errorf("offset/limit = %d/%d, want 9900/100 (within window)", fake.got.Offset, fake.got.Limit)
+	}
+}
+
 func TestSearchJobs_DefaultsToHybridSemanticRatio(t *testing.T) {
 	fake := &fakeSearcher{}
 	app := searchApp(fake)

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -22,9 +22,12 @@ const (
 	// search needs no external API key. Multilingual + CPU-friendly.
 	embedderModel = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 
-	// maxTotalHits caps how deep pagination can reach; estimatedTotalHits may
-	// report more.
-	maxTotalHits = 100000
+	// maxTotalHits caps how high a search counts its results: below it,
+	// estimatedTotalHits is the true filtered total, so it is set well above the
+	// index size to keep the reported count honest. It is NOT the pagination guard
+	// — deep offset paging is bounded separately by maxSearchWindow in the search
+	// handler — so a large value here costs nothing beyond an accurate total.
+	maxTotalHits = 1000000
 
 	taskPollInterval = 50 * time.Millisecond
 )


### PR DESCRIPTION
## What

The job count in the UI showed a misleading flat **`100,000`**. That number is
not a job count — it is the Meilisearch `maxTotalHits` pagination cap. The search
endpoint reports `meta.total = estimatedTotalHits`, which Meili bounds by
`maxTotalHits` (100000), so with ~250k indexed jobs the headline always pinned to
the cap instead of the real (filtered) total.

## How

`maxTotalHits` was doing two jobs at once: limiting how high results are counted
**and** how deep pagination can reach. Split them:

- **Count** — raise `maxTotalHits` to `1_000_000` (`internal/search/client.go`).
  Below the cap `estimatedTotalHits` is the exact filtered total, so the headline
  is now honest and still tracks the active filters. A large value here costs
  nothing but an accurate count.
- **Pagination guard** — add `maxSearchWindow` (`offset+limit <= 10000`, ~500
  pages) in `SearchJobs` (`internal/handler/search.go`), returning
  `400 "pagination too deep"` before the backend is touched. This is now the
  explicit guard against expensive deep-offset paging that the cap used to block
  as a side effect.

## Tests

New `TestSearchJobs_DeepPaginationRejected` (400 + backend not called) and
`TestSearchJobs_PaginationAtWindowBoundaryAllowed` (boundary still reaches the
backend). Full suite + `go vet` green.

## Rollout

`maxTotalHits` is an index setting applied via the index config. After
merge+deploy, apply it live with a one-shot
`PATCH /indexes/jobs/settings/pagination {"maxTotalHits": 1000000}` (instant, no
reindex), or let the next reindex pick it up. The handler guard ships with the
app image. Deploy both together so deep paging is bounded the moment the cap
rises.
