### PR TITLE
web: fix search input, reorder filters, search-back the company page

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -37,12 +37,27 @@ interface Page<T> {
 }
 
 /** A non-2xx API response. Carries the HTTP status so callers can branch on it
- *  (e.g. 401 invalid credentials, 409 email taken) instead of parsing strings. */
+ *  (e.g. 401 invalid credentials, 409 email taken) instead of parsing strings.
+ *  `message` is the backend's `{ "error": msg }` text when present, so logs and
+ *  any raw-error surface read the real reason rather than a bare status line. */
 export class ApiError extends Error {
   constructor(public readonly status: number, message: string) {
     super(message);
     this.name = 'ApiError';
   }
+}
+
+/** Extract a human-readable message from a failed response. The backend's
+ *  standard error envelope is `{ "error": msg }`; surface that when present,
+ *  falling back to the status line for a non-JSON error (e.g. a proxy 502). */
+async function errorMessage(res: Response): Promise<string> {
+  try {
+    const body = await res.json();
+    if (body && typeof body.error === 'string') return body.error;
+  } catch {
+    // Body was not JSON (proxy/HTML error page) — fall through to the status line.
+  }
+  return `${res.status} ${res.statusText}`;
 }
 
 function query(limit: number, offset: number): string {
@@ -81,7 +96,7 @@ export function createApi(
       headers: { ...defaultHeaders, ...init?.headers },
     });
     if (!res.ok) {
-      throw new ApiError(res.status, `${res.status} ${res.statusText}`);
+      throw new ApiError(res.status, await errorMessage(res));
     }
     return res;
   }

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -1,35 +1,15 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
-  import { api } from '$lib/api';
+  import type { Slice } from '$lib/api';
   import type { Company, Job } from '$lib/types';
-  import { Paginator } from '$lib/paginated.svelte';
-  import States from './States.svelte';
-  import JobRow from './JobRow.svelte';
-  import LoadMore from './LoadMore.svelte';
+  import JobsView from './JobsView.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
 
-  // Company and its first page of jobs are server-rendered (route `load`), so the
-  // header and rows are in the initial HTML. `slug` drives client-side paging.
-  // The route remounts this component on slug change (#key), so the seed below
-  // always reflects the current company.
-  let {
-    company,
-    jobs,
-    hasMore,
-    slug,
-  }: { company: Company; jobs: Job[]; hasMore: boolean; slug: string } = $props();
-
-  const LIMIT = 20;
-
-  // Seed the paginator from the server-rendered first page; "load more" fetches
-  // subsequent pages client-side. The endpoint omits a total, so "more" is
-  // inferred from a full page. The seed is an intentional one-time snapshot of
-  // the initial props (untrack), not reactive state.
-  const pager = new Paginator<Job>(async (limit, offset) => {
-    const res = await api.getCompany(slug, limit, offset);
-    return { items: res.jobs, hasMore: res.jobs.length === limit };
-  }, LIMIT);
-  pager.seed(untrack(() => ({ items: jobs, hasMore })));
+  // The company and its first page of search results are server-rendered (route
+  // `load`), so the header and rows are in the initial HTML. The job list reuses
+  // the same filterable, counted search view as /jobs, pinned to this company:
+  // `company_slug` is fixed (not a selectable facet) and the Source facet is
+  // hidden, since a single company's postings share one source.
+  let { company, initial, slug }: { company: Company; initial: Slice<Job>; slug: string } = $props();
 </script>
 
 <div class="flex items-center gap-3">
@@ -37,18 +17,6 @@
   <h1 class="text-xl font-semibold tracking-tight">{company.name}</h1>
 </div>
 
-<div class="mt-4">
-  {#if pager.items.length === 0}
-    <States state="empty" message="No jobs for this company yet." />
-  {:else}
-    <div class="flex flex-col gap-3">
-      {#each pager.items as job (job.public_slug)}
-        <JobRow {job} />
-      {/each}
-    </div>
-
-    {#if pager.hasMore}
-      <LoadMore loading={pager.loadingMore} error={pager.loadMoreError} onclick={() => pager.loadMore()} />
-    {/if}
-  {/if}
+<div class="mt-6">
+  <JobsView {initial} scope={{ company_slug: slug }} excludeFacets={['source']} />
 </div>

--- a/web/src/lib/components/FiltersPanel.svelte
+++ b/web/src/lib/components/FiltersPanel.svelte
@@ -5,8 +5,11 @@
 
   // The panel is pure presentation over the store: it iterates the facet
   // registry and renders each section, plus the two special controls (visa,
-  // min salary) that aren't multi-value facets.
-  let { store }: { store: FilterStore } = $props();
+  // min salary) that aren't multi-value facets. `exclude` hides facets by param
+  // (e.g. the company page pins one company, so its Source facet is irrelevant).
+  let { store, exclude = [] }: { store: FilterStore; exclude?: string[] } = $props();
+
+  const facets = $derived(FACETS.filter((f) => !exclude.includes(f.param)));
 
   // Slider bounds for the min-salary filter. 0 means "no minimum".
   const SALARY_MAX = 300000;
@@ -27,6 +30,10 @@
       </button>
     {/if}
   </div>
+
+  {#each facets as def (def.param)}
+    <FacetSection {def} {store} />
+  {/each}
 
   <div class="border-b border-border pb-4">
     <div class="mb-2 flex items-center justify-between">
@@ -50,10 +57,6 @@
       <span>{SALARY_MAX.toLocaleString('en-US')}+</span>
     </div>
   </div>
-
-  {#each FACETS as def (def.param)}
-    <FacetSection {def} {store} />
-  {/each}
 
   <div>
     <h3 class="mb-2 text-sm font-semibold tracking-tight">Visa</h3>

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -154,8 +154,8 @@
         <dl class="flex flex-col gap-2 border-t border-border pt-4 text-sm first:border-t-0 first:pt-0">
           {#each facets as facet (facet.label)}
             <div class="flex items-baseline justify-between gap-3">
-              <dt class="text-muted-foreground">{facet.label}</dt>
-              <dd class="text-right font-medium"
+              <dt class="shrink-0 text-muted-foreground">{facet.label}</dt>
+              <dd class="min-w-0 break-words text-right font-medium"
                 >{#each facet.values as v, i (v.text)}{#if i > 0}, {/if}{#if v.href}<a
                       href={v.href}
                       class="hover:text-foreground hover:underline">{v.text}</a

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -14,14 +14,30 @@
   // The first page is server-rendered (route `load`) and arrives as `initial`,
   // so the rows are in the initial HTML. Filters live in the URL; the list is
   // driven by the search endpoint (an empty query browses everything).
-  let { initial }: { initial: Slice<Job> } = $props();
+  //
+  // `scope` pins extra search params that the user can't change (e.g. the company
+  // page passes `{ company_slug }`): they're merged into every search but kept out
+  // of `filters`/the URL, so they're not user-selectable facets. `excludeFacets`
+  // hides facets that are redundant under that scope (e.g. Source on a company).
+  let {
+    initial,
+    scope = {},
+    excludeFacets = [],
+  }: { initial: Slice<Job>; scope?: Record<string, string>; excludeFacets?: string[] } = $props();
 
   // Seed filters from the current URL so the server and the hydrated client
   // render the same filtered view.
   const filters = new FilterStore(page.url.searchParams);
 
+  // The user's facet filters plus the fixed `scope` params (company_slug, …).
+  const scopedParams = () => {
+    const p = filtersToParams(filters.value);
+    for (const [k, v] of Object.entries(scope)) p.set(k, v);
+    return p;
+  };
+
   const makePaginator = () =>
-    new Paginator<Job>((limit, offset) => api.searchJobs(filtersToParams(filters.value), limit, offset));
+    new Paginator<Job>((limit, offset) => api.searchJobs(scopedParams(), limit, offset));
 
   // Seeded with the server-rendered first page (an intentional one-time snapshot
   // of the initial prop); "load more" and filter changes fetch client-side.
@@ -42,9 +58,12 @@
     'h-9 shrink-0 rounded-lg border border-input bg-transparent px-3 text-sm transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30';
 
   // Browser back/forward changes the URL query — pull it back into the filters.
+  // Track only the URL: syncFromUrl reads filters.value internally, so without
+  // untrack this effect would also fire on our own setQuery/#commit writes and
+  // clobber the just-typed value against a not-yet-updated page.url.
   $effect(() => {
     page.url.search; // track
-    filters.syncFromUrl();
+    untrack(() => filters.syncFromUrl());
   });
 
   // Re-run the search when any filter changes, debounced. The first effect run
@@ -66,7 +85,7 @@
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
     <div class="sticky top-6 max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
-      <FiltersPanel store={filters} />
+      <FiltersPanel store={filters} exclude={excludeFacets} />
     </div>
   </aside>
 
@@ -129,7 +148,7 @@
         <span class="text-sm font-semibold tracking-tight">Filters</span>
         <button type="button" class="text-sm text-muted-foreground hover:text-foreground" onclick={() => (drawerOpen = false)}>Done</button>
       </div>
-      <FiltersPanel store={filters} />
+      <FiltersPanel store={filters} exclude={excludeFacets} />
     </div>
   </div>
 {/if}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -37,9 +37,12 @@ const WORK_MODE: FacetOption[] = [
 
 // The platform a job was ingested from. Unlike the enrichment facets below, this
 // value is always present (the ingest pipeline sets it), so it is the one fully
-// reliable filter. SOURCE OF TRUTH for these values: the Provider() strings of the
+// reliable filter. Values are the Provider() strings of the multi-tenant ATS
 // adapters in internal/sources (sources.All) plus the literal "telegram" set by
-// the tg-extract worker. A new adapter means a new entry here.
+// the tg-extract worker. Single-company boardless adapters (Yandex, Ozon, Sber,
+// T-Bank, VK, … — those implementing the boardless marker) are deliberately
+// omitted: filtering by a one-company platform is redundant with the company
+// filter and would clutter the list. A new ATS platform means a new entry here.
 const SOURCE: FacetOption[] = [
   { value: 'telegram', label: 'Telegram' },
   { value: 'greenhouse', label: 'Greenhouse' },
@@ -53,18 +56,33 @@ const SOURCE: FacetOption[] = [
   { value: 'rippling', label: 'Rippling' },
   { value: 'bamboohr', label: 'BambooHR' },
   { value: 'workday', label: 'Workday' },
+  { value: 'huntflow', label: 'Huntflow' },
+  { value: 'gem', label: 'Gem' },
+  { value: 'successfactors', label: 'SuccessFactors' },
+  { value: 'teamtailor', label: 'Teamtailor' },
+  { value: 'breezy', label: 'Breezy' },
+  { value: 'join', label: 'Join' },
 ];
 
-// A curated, extensible subset of the backend's `regions` reach vocabulary. Its
-// values mix levels by design (global / region / country); the field's full
-// vocabulary holds more than these pills surface.
+// The backend's full `regions` reach vocabulary (enrich.RegionValues). Values mix
+// levels by design (global / macro-region / country-as-area); keep this in sync
+// with that list so every tagged region is filterable.
 const REGION: FacetOption[] = [
   { value: 'global', label: 'Global' },
+  { value: 'us', label: 'USA' },
+  { value: 'north_america', label: 'North America' },
+  { value: 'latam', label: 'LATAM' },
+  { value: 'americas', label: 'Americas' },
+  { value: 'eu', label: 'Europe' },
+  { value: 'uk', label: 'UK' },
+  { value: 'emea', label: 'EMEA' },
+  { value: 'eea', label: 'EEA' },
+  { value: 'mena', label: 'MENA' },
+  { value: 'africa', label: 'Africa' },
+  { value: 'apac', label: 'APAC' },
   { value: 'ru', label: 'Russia' },
   { value: 'cis', label: 'CIS' },
   { value: 'central_asia', label: 'Central Asia' },
-  { value: 'eu', label: 'Europe' },
-  { value: 'us', label: 'USA' },
 ];
 
 const SENIORITY: FacetOption[] = [
@@ -162,11 +180,10 @@ const DOMAINS: FacetOption[] = [
 ];
 
 export const FACETS: FacetDef[] = [
-  { param: 'source', label: 'Source', control: 'pills', options: SOURCE, excludable: true },
-  { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
   { param: 'regions', label: 'Region', control: 'pills', options: REGION, excludable: true },
-  { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },
+  { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
+  { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },
   { param: 'skills', label: 'Skills', control: 'tokens', excludable: true, hasAndOr: true, placeholder: 'Add a skill, press Enter' },
   { param: 'domains', label: 'Industry', control: 'select', options: DOMAINS, excludable: true, placeholder: 'Search industries' },
   { param: 'company_type', label: 'Company type', control: 'pills', options: COMPANY_TYPE, excludable: true },
@@ -176,4 +193,5 @@ export const FACETS: FacetDef[] = [
   { param: 'english_level', label: 'English', control: 'pills', options: ENGLISH, excludable: true },
   { param: 'posting_language', label: 'Job language', control: 'pills', options: POSTING_LANGUAGE, excludable: true },
   { param: 'salary_currency', label: 'Currency', control: 'pills', options: CURRENCY, excludable: true },
+  { param: 'source', label: 'Source', control: 'pills', options: SOURCE, excludable: true },
 ];

--- a/web/src/routes/companies/[slug]/+page.server.ts
+++ b/web/src/routes/companies/[slug]/+page.server.ts
@@ -5,13 +5,21 @@ import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
 
-// Server-render the company and its first page of jobs. The endpoint omits a
-// total, so "more" is inferred from a full page. A 404 becomes a SvelteKit 404
-// page; other failures bubble to the 500 page.
-export const load: PageServerLoad = async ({ params, fetch }) => {
+// Server-render the company and its first page of search results. The job list is
+// search-backed and scoped to this company (company_slug), so it carries a true
+// total (the vacancy count) and supports the same URL filters as /jobs. The
+// company entity is fetched separately because search returns only jobs. A 404
+// (unknown company) becomes a SvelteKit 404; other failures bubble to the 500 page.
+export const load: PageServerLoad = async ({ params, url, fetch }) => {
+  const client = serverApi(fetch);
+  const facets = new URLSearchParams(url.searchParams);
+  facets.set('company_slug', params.slug);
   try {
-    const { company, jobs } = await serverApi(fetch).getCompany(params.slug, LIMIT, 0);
-    return { company, jobs, hasMore: jobs.length === LIMIT, slug: params.slug };
+    const [{ company }, initial] = await Promise.all([
+      client.getCompany(params.slug, 1, 0),
+      client.searchJobs(facets, LIMIT, 0),
+    ]);
+    return { company, initial, slug: params.slug };
   } catch (e) {
     if (e instanceof ApiError && e.status === 404) {
       error(404, 'Company not found');

--- a/web/src/routes/companies/[slug]/+page.svelte
+++ b/web/src/routes/companies/[slug]/+page.svelte
@@ -19,9 +19,9 @@
   {@html jsonLd}
 </svelte:head>
 
-<div class="mx-auto w-full max-w-3xl px-4 py-6">
-  <!-- Remount on slug change so the seeded paginator starts fresh per company. -->
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <!-- Remount on slug change so the seeded paginator/filters start fresh per company. -->
   {#key data.slug}
-    <CompanyView company={data.company} jobs={data.jobs} hasMore={data.hasMore} slug={data.slug} />
+    <CompanyView company={data.company} initial={data.initial} slug={data.slug} />
   {/key}
 </div>


### PR DESCRIPTION
## Summary

UI fixes and improvements to the jobs/company browse experience.

### Search input was frozen (`/jobs`)
Every keystroke in the search box reverted to empty. Root cause (regression from the SSR migration): the back/forward `$effect` calls `filters.syncFromUrl()`, whose guard reads `filters.value` — so the effect depended on the filter *state*, not just the URL. `replaceState` (from `$app/navigation`) doesn't update `$app/state`'s `page.url` synchronously, so each keystroke fired the effect against a **stale empty URL** and reset the typed value. Fix: wrap the call in `untrack` so the effect observes only `page.url.search`.

### Filters panel
- Reordered facets: **Region → Work format → Specialization → … → Source (last)**; moved **Min salary** below the facet list.
- **REGION** now mirrors the backend's full `enrich.RegionValues` (adds LATAM, UK, EMEA, EEA, MENA, Africa, APAC, Americas, North America) — previously a 6-item subset, so jobs tagged with the other regions weren't filterable.
- `FiltersPanel` gains an optional `exclude` prop to hide facets by param.

### Company page is now search-backed
`/companies/[slug]` reuses `JobsView` (now parameterized with `scope` + `excludeFacets`) instead of the Postgres-only `getCompany` job list. It gains:
- a **true vacancy count** (from the search `meta.total`),
- the **same filter sidebar** as `/jobs`,
- the company **pinned** via `company_slug` (not a selectable facet; not leaked into the URL), with the redundant **Source** facet hidden.

> Note: this couples the company page's job list to the search index (Meilisearch), like `/jobs` — an intentional, accepted tradeoff for the count + filters.

### Misc
- **Job detail:** Domains metadata row no longer overflows the card (`min-w-0` + `break-words` on the value, `shrink-0` on the label).
- **api:** `ApiError` now surfaces the backend's `{"error": msg}` envelope text instead of a bare status line.

## Testing
- `svelte-check` — 0 errors.
- Manual e2e (agent-browser) against prod API: search input accumulates + updates URL; SSR seed and back/forward sync intact; company page shows count, filters scope within the company (Remote → 4, EU → 2 for 1inch), company stays pinned (no `company_slug` in URL); no page overflow on the job detail.

## Review notes (non-blocking)
- Count line isn't shown in the 0-results state (`No matching jobs.`) — pre-existing `/jobs` behavior, inherited.
- `?source=…` manually placed in a company URL is applied but its panel control is hidden — only clearable via "Reset all". Low impact (requires a crafted URL).
- SOURCE facet omits the three `linksource` identities (`remoteyeah`/`habr_career`/`geekjob`) — currently 0 jobs on prod, so latent.