### PR TITLE
scripts: query-driven ATS board discovery (discover_boards.py)

### DIFF
--- a/scripts/ats_boards.py
+++ b/scripts/ats_boards.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Shared ATS board core: slug extraction, live validation, dedup, YAML emit.
+
+Used by both scripts/harvest_boards.py (aggregator-driven) and
+scripts/discover_boards.py (query-driven web discovery). Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SOURCES_DIR = REPO / "sources"
+UA = "freehire-harvest/1.0 (+https://freehire.dev)"
+
+# (compiled regex, provider). Group 1 (first non-empty group) is the board slug.
+SLUG_PATTERNS = [
+    (re.compile(r"(?:boards|job-boards)(?:\.eu)?\.greenhouse\.io/(?:embed/job_app\?for=)?([A-Za-z0-9_-]+)"), "greenhouse"),
+    (re.compile(r"jobs\.(?:eu\.)?lever\.co/([A-Za-z0-9_.-]+)"), "lever"),
+    (re.compile(r"jobs\.ashbyhq\.com/([A-Za-z0-9_.-]+)"), "ashby"),
+    (re.compile(r"(?:jobs|careers)\.smartrecruiters\.com/([A-Za-z0-9_-]+)|api\.smartrecruiters\.com/v1/companies/([A-Za-z0-9_-]+)"), "smartrecruiters"),
+    (re.compile(r"apply\.workable\.com/([A-Za-z0-9_-]+)"), "workable"),
+    (re.compile(r"([A-Za-z0-9_-]+)\.recruitee\.com"), "recruitee"),
+    (re.compile(r"([A-Za-z0-9_-]+)\.bamboohr\.com"), "bamboohr"),
+    (re.compile(r"([A-Za-z0-9_-]+)\.breezy\.hr"), "breezy"),
+    (re.compile(r"([A-Za-z0-9_-]+)\.jobs\.personio\.(?:com|de)"), "personio"),
+    (re.compile(r"([A-Za-z0-9_-]+\.teamtailor\.com)"), "teamtailor"),
+]
+
+SLUG_BLOCKLIST = {
+    "embed", "jobs", "job", "j", "o", "share", "en-us", "en-gb",
+    "api", "widget", "backend", "www", "app", "auth", "referrals", "v1",
+}
+
+VALIDATORS = {
+    "greenhouse": lambda s: f"https://boards-api.greenhouse.io/v1/boards/{s}/jobs?content=true",
+    "lever": lambda s: f"https://api.lever.co/v0/postings/{s}?mode=json",
+    "ashby": lambda s: f"https://api.ashbyhq.com/posting-api/job-board/{s}",
+    "smartrecruiters": lambda s: f"https://api.smartrecruiters.com/v1/companies/{s}/postings?limit=10",
+    "workable": lambda s: f"https://apply.workable.com/api/v1/widget/accounts/{s}?details=true",
+    "recruitee": lambda s: f"https://{s}.recruitee.com/api/offers/",
+    "bamboohr": lambda s: f"https://{s}.bamboohr.com/careers/list",
+    "breezy": lambda s: f"https://{s}.breezy.hr/json",
+    "personio": lambda s: f"https://{s}.jobs.personio.com/xml",
+    "teamtailor": lambda s: f"https://{s}/jobs",
+}
+
+
+def fetch(url: str, timeout: int = 25) -> bytes | None:
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.read()
+    except Exception:
+        return None
+
+
+def yaml_name(name: str) -> str:
+    """Quote a company name only when it carries YAML-significant characters."""
+    name = name.strip()
+    if not name or name[0] in "-?:,[]{}#&*!|>'\"%@`" or any(c in name for c in ':#,"'):
+        return '"' + name.replace('\\', '\\\\').replace('"', '\\"') + '"'
+    return name
+
+
+def extract_slugs(text: str) -> set[tuple[str, str]]:
+    """Sweep raw text for ATS board URLs -> {(provider, slug)}."""
+    out: set[tuple[str, str]] = set()
+    for pat, provider in SLUG_PATTERNS:
+        for m in pat.finditer(text):
+            slug = next((g for g in m.groups() if g), None)
+            if not slug or slug.lower() in SLUG_BLOCKLIST:
+                continue
+            out.add((provider, slug))
+    return out
+
+
+def existing_slugs() -> dict[str, set[str]]:
+    out: dict[str, set[str]] = defaultdict(set)
+    for prov in VALIDATORS:
+        f = SOURCES_DIR / f"{prov}.yml"
+        if f.exists():
+            for m in re.findall(r"board:\s*\"?([^\"\n]+)\"?", f.read_text()):
+                out[prov].add(m.strip().lower())
+    return out
+
+
+def validate(provider: str, slug: str) -> int | None:
+    """Return active job count if the board is live and non-empty, else None."""
+    body = fetch(VALIDATORS[provider](slug), timeout=20)
+    if not body:
+        return None
+    if provider == "personio":
+        return body.count(b"<position>") or None
+    if provider == "teamtailor":
+        return len(set(re.findall(rb"/jobs/(\d+)", body))) or None
+    try:
+        data = json.loads(body)
+    except Exception:
+        return None
+    d = data if isinstance(data, dict) else {}
+    if provider in ("lever", "breezy"):
+        count = len(data) if isinstance(data, list) else 0
+    elif provider == "smartrecruiters":
+        count = d.get("totalFound") or len(d.get("content", []))
+    elif provider == "recruitee":
+        count = len(d.get("offers", []))
+    elif provider == "bamboohr":
+        count = len(d.get("result", []))
+    else:
+        count = len(d.get("jobs", []))
+    return count or None
+
+
+def github_fragments(query: str, pages: int) -> list[str]:
+    """Run a GitHub code-search query and return the matched text fragments."""
+    frags: list[str] = []
+    for page in range(1, pages + 1):
+        try:
+            raw = subprocess.run(
+                ["gh", "api", "-X", "GET", "search/code",
+                 "-H", "Accept: application/vnd.github.text-match+json",
+                 "-f", f"q={query} in:file", "-f", "per_page=100", "-f", f"page={page}"],
+                capture_output=True, text=True, timeout=60,
+            ).stdout
+            items = json.loads(raw).get("items", [])
+        except Exception as e:
+            print(f"  ! github query failed ({query} p{page}): {e}", file=sys.stderr)
+            break
+        if not items:
+            break
+        for it in items:
+            for m in it.get("text_matches", []):
+                frags.append(m.get("fragment", ""))
+    return frags
+
+
+def emit_survivors(cand: dict[tuple[str, str], str], write: bool) -> int:
+    """Dedup vs sources/*.yml, validate live concurrently, print/append YAML.
+
+    cand maps (provider, slug) -> best-effort company name. Returns the count of
+    new validated boards. Shared by harvest (aggregators) and discover (web search).
+    """
+    have = existing_slugs()
+    new = {(p, s): n for (p, s), n in cand.items() if s.lower() not in have[p]}
+    print(f"\n{len(cand)} unique candidates, {len(cand) - len(new)} already tracked, "
+          f"{len(new)} new to validate\n", file=sys.stderr)
+
+    items = list(new.items())
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        counts = list(ex.map(lambda kv: validate(kv[0][0], kv[0][1]), items))
+
+    best: dict[tuple[str, str], tuple[str, str, int]] = {}
+    for ((prov, slug), name), n in zip(items, counts):
+        if not n:
+            continue
+        key = (prov, slug.lower())
+        if key not in best or n > best[key][2]:
+            best[key] = (name, slug, n)
+    survivors: dict[str, list[tuple[str, str, int]]] = defaultdict(list)
+    for (prov, _), row in best.items():
+        survivors[prov].append(row)
+
+    total = 0
+    for prov in VALIDATORS:
+        rows = sorted(survivors[prov], key=lambda r: -r[2])
+        if not rows:
+            continue
+        total += len(rows)
+        print(f"\n# === {prov}: {len(rows)} new live boards ===")
+        for name, slug, n in rows:
+            print(f"- company: {yaml_name(name)}  # {n} jobs")
+            print(f"  board: {slug}")
+        if write:
+            f = SOURCES_DIR / f"{prov}.yml"
+            with f.open("a") as fh:
+                for name, slug, n in rows:
+                    fh.write(f"- company: {yaml_name(name)}\n  board: {slug}\n")
+            print(f"  -> appended {len(rows)} entries to {f.relative_to(REPO)}", file=sys.stderr)
+
+    print(f"\n{total} new validated boards total", file=sys.stderr)
+    return total

--- a/scripts/ats_boards.py
+++ b/scripts/ats_boards.py
@@ -11,7 +11,6 @@ import json
 import re
 import subprocess
 import sys
-import urllib.error
 import urllib.request
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -32,6 +31,9 @@ SLUG_PATTERNS = [
     (re.compile(r"([A-Za-z0-9_-]+)\.bamboohr\.com"), "bamboohr"),
     (re.compile(r"([A-Za-z0-9_-]+)\.breezy\.hr"), "breezy"),
     (re.compile(r"([A-Za-z0-9_-]+)\.jobs\.personio\.(?:com|de)"), "personio"),
+    # Teamtailor's "slug" is the whole board host — the adapter takes board = hostname.
+    # Only *.teamtailor.com hosts are detectable here; boards on a custom domain
+    # (e.g. jobs.tibber.com) carry no teamtailor marker in the URL and are missed.
     (re.compile(r"([A-Za-z0-9_-]+\.teamtailor\.com)"), "teamtailor"),
 ]
 
@@ -40,6 +42,8 @@ SLUG_BLOCKLIST = {
     "api", "widget", "backend", "www", "app", "auth", "referrals", "v1",
 }
 
+# Validation endpoints — each identical to the one its internal/sources/<provider>.go
+# adapter calls. bamboohr returns JSON, personio XML, teamtailor HTML (see validate()).
 VALIDATORS = {
     "greenhouse": lambda s: f"https://boards-api.greenhouse.io/v1/boards/{s}/jobs?content=true",
     "lever": lambda s: f"https://api.lever.co/v0/postings/{s}?mode=json",
@@ -48,9 +52,9 @@ VALIDATORS = {
     "workable": lambda s: f"https://apply.workable.com/api/v1/widget/accounts/{s}?details=true",
     "recruitee": lambda s: f"https://{s}.recruitee.com/api/offers/",
     "bamboohr": lambda s: f"https://{s}.bamboohr.com/careers/list",
-    "breezy": lambda s: f"https://{s}.breezy.hr/json",
+    "breezy": lambda s: f"https://{s}.breezy.hr/json",  # top-level JSON array of positions
     "personio": lambda s: f"https://{s}.jobs.personio.com/xml",
-    "teamtailor": lambda s: f"https://{s}/jobs",
+    "teamtailor": lambda s: f"https://{s}/jobs",  # s is the board host, not a slug
 }
 
 
@@ -72,7 +76,11 @@ def yaml_name(name: str) -> str:
 
 
 def extract_slugs(text: str) -> set[tuple[str, str]]:
-    """Sweep raw text for ATS board URLs -> {(provider, slug)}."""
+    """Sweep raw text for ATS board URLs -> {(provider, slug)}.
+
+    Patterns may carry multiple alternation groups (e.g. SmartRecruiters' two host
+    forms), so take the first non-empty group of each match as the slug.
+    """
     out: set[tuple[str, str]] = set()
     for pat, provider in SLUG_PATTERNS:
         for m in pat.finditer(text):

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -14,6 +14,7 @@ Stdlib only; the github channel shells out to `gh`; google needs GOOGLE_CSE_KEY/
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
@@ -23,7 +24,7 @@ import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from ats_boards import VALIDATORS, github_fragments  # noqa: E402
+from ats_boards import VALIDATORS, github_fragments, extract_slugs, emit_survivors  # noqa: E402
 
 # Provider -> the ATS host to put in a `site:` search / Common Crawl prefix.
 PROVIDER_HOSTS = {
@@ -139,3 +140,65 @@ def channel_cc(host: str, query: str, limit: int) -> set[str]:
     cap = (limit or 100) * 5  # over-fetch; many rows collapse to one slug
     url = f"{base}?url={urllib.parse.quote(host)}/*&output=json&limit={cap}"
     return parse_cc_jsonl(get_text(url, timeout=60))
+
+
+CHANNELS = {
+    "ddg": channel_ddg,
+    "google": channel_google,
+    "github": channel_github,
+    "cc": lambda host, query, limit: channel_cc(host, query, limit),
+}
+
+
+def collect_candidates(providers: list[str], channels: list[str], query: str,
+                       limit: int) -> dict[tuple[str, str], str]:
+    """Run each channel for each provider; return {(provider, slug): slug}.
+
+    Results are filtered to the queried provider so noise from other ATS links on a
+    results page is dropped. Company name is best-effort (the slug) for web sources.
+    """
+    cand: dict[tuple[str, str], str] = {}
+    for provider in providers:
+        host = PROVIDER_HOSTS[provider]
+        for ch in channels:
+            urls = CHANNELS[ch](host, query, limit)
+            found = set()
+            for u in urls:
+                found |= extract_slugs(u)
+            keep = {(p, s) for (p, s) in found if p == provider}
+            for p, s in keep:
+                cand.setdefault((p, s), s)
+            print(f"  [{ch}/{provider}] {len(urls)} urls -> {len(keep)} {provider} slugs",
+                  file=sys.stderr)
+    return cand
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Query-driven ATS board discovery")
+    ap.add_argument("--query", default="", help="search term for this run")
+    ap.add_argument("--provider", default="", help="comma list; default = all")
+    ap.add_argument("--channel", default="ddg", help="comma list from ddg,google,github,cc")
+    ap.add_argument("--write", action="store_true", help="append survivors to sources/<provider>.yml")
+    ap.add_argument("--limit", type=int, default=20, help="cap results per channel/provider")
+    args = ap.parse_args()
+
+    providers = [p.strip() for p in args.provider.split(",") if p.strip()] or list(PROVIDER_HOSTS)
+    channels = [c.strip() for c in args.channel.split(",") if c.strip()]
+    bad_p = [p for p in providers if p not in PROVIDER_HOSTS]
+    bad_c = [c for c in channels if c not in CHANNELS]
+    if bad_p:
+        ap.error(f"unknown provider(s): {bad_p}; choose from {list(PROVIDER_HOSTS)}")
+    if bad_c:
+        ap.error(f"unknown channel(s): {bad_c}; choose from {list(CHANNELS)}")
+    if not args.query and channels != ["cc"]:
+        ap.error("--query is required for keyword channels (ddg/google/github)")
+
+    print(f"== discovering: query={args.query!r} providers={providers} channels={channels} ==",
+          file=sys.stderr)
+    cand = collect_candidates(providers, channels, args.query, args.limit)
+    emit_survivors(cand, args.write)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -23,7 +23,7 @@ import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from ats_boards import VALIDATORS  # noqa: E402
+from ats_boards import VALIDATORS, github_fragments  # noqa: E402
 
 # Provider -> the ATS host to put in a `site:` search / Common Crawl prefix.
 PROVIDER_HOSTS = {
@@ -90,3 +90,10 @@ def channel_google(host: str, query: str, limit: int) -> set[str]:
         return parse_cse_items(json.loads(body))
     except Exception:
         return set()
+
+
+def channel_github(host: str, query: str, limit: int, pages: int = 2) -> set[str]:
+    """`<query> <host>` via GitHub code search -> the matched fragments as text."""
+    frags = github_fragments(f"{query} {host}", pages)
+    out = set(frags)
+    return set(list(out)[:limit]) if limit else out

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -133,7 +133,13 @@ def parse_cc_jsonl(text: str) -> set[str]:
 
 
 def channel_cc(host: str, query: str, limit: int) -> set[str]:
-    """Bulk-dump board URLs for <host>/* from Common Crawl. Ignores the keyword."""
+    """Bulk-dump board URLs for <host>/* from Common Crawl. Ignores the keyword.
+
+    Only effective for path-based providers (greenhouse/lever/ashby/smartrecruiters/
+    workable). Subdomain-board providers (recruitee, bamboohr, breezy, personio,
+    teamtailor) sit on <slug>.<host>, which a <host>/* prefix never matches — they
+    yield zero here; use ddg/google/github for those.
+    """
     base = cc_api_base()
     if not base:
         return set()
@@ -146,7 +152,7 @@ CHANNELS = {
     "ddg": channel_ddg,
     "google": channel_google,
     "github": channel_github,
-    "cc": lambda host, query, limit: channel_cc(host, query, limit),
+    "cc": channel_cc,
 }
 
 

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Query-driven open-web ATS board discovery.
+
+Run a free-text query across search channels (DuckDuckGo, Google CSE, GitHub code
+search, Common Crawl), extract ATS board URLs, dedup against sources/*.yml,
+validate each board live, and print (or --write) ready-to-paste YAML.
+
+Usage:
+    python3 scripts/discover_boards.py --query "fintech berlin" \
+            --provider ashby,lever --channel ddg,github,google,cc [--write] [--limit N]
+
+Stdlib only; the github channel shells out to `gh`; google needs GOOGLE_CSE_KEY/_CX.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from ats_boards import VALIDATORS  # noqa: E402
+
+# Provider -> the ATS host to put in a `site:` search / Common Crawl prefix.
+PROVIDER_HOSTS = {
+    "greenhouse": "job-boards.greenhouse.io",
+    "lever": "jobs.lever.co",
+    "ashby": "jobs.ashbyhq.com",
+    "smartrecruiters": "jobs.smartrecruiters.com",
+    "workable": "apply.workable.com",
+    "recruitee": "recruitee.com",
+    "bamboohr": "bamboohr.com",
+    "breezy": "breezy.hr",
+    "personio": "jobs.personio.com",
+    "teamtailor": "teamtailor.com",
+}

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -14,6 +14,8 @@ Stdlib only; the github channel shells out to `gh`; google needs GOOGLE_CSE_KEY/
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import sys
 import urllib.parse
@@ -66,3 +68,25 @@ def channel_ddg(host: str, query: str, limit: int) -> set[str]:
     html = get_text(f"https://html.duckduckgo.com/html/?q={q}")
     urls = parse_ddg_html(html)
     return set(list(urls)[:limit]) if limit else urls
+
+
+def parse_cse_items(obj: dict) -> set[str]:
+    """Extract result links from a Google Custom Search JSON response."""
+    return {it["link"] for it in obj.get("items", []) if it.get("link")}
+
+
+def channel_google(host: str, query: str, limit: int) -> set[str]:
+    """site:<host> <query> via Google Custom Search JSON API (env-gated)."""
+    key, cx = os.environ.get("GOOGLE_CSE_KEY"), os.environ.get("GOOGLE_CSE_CX")
+    if not (key and cx):
+        print("  ! google channel skipped (set GOOGLE_CSE_KEY and GOOGLE_CSE_CX)", file=sys.stderr)
+        return set()
+    q = urllib.parse.quote(f"site:{host} {query}")
+    num = min(limit, 10) if limit else 10
+    body = get_text(
+        f"https://www.googleapis.com/customsearch/v1?key={key}&cx={cx}&q={q}&num={num}"
+    )
+    try:
+        return parse_cse_items(json.loads(body))
+    except Exception:
+        return set()

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -97,3 +97,45 @@ def channel_github(host: str, query: str, limit: int, pages: int = 2) -> set[str
     frags = github_fragments(f"{query} {host}", pages)
     out = set(frags)
     return set(list(out)[:limit]) if limit else out
+
+
+_CC_BASE: str | None = None
+
+
+def cc_api_base() -> str | None:
+    """Latest Common Crawl URL-index CDX API base (cached). None if unreachable."""
+    global _CC_BASE
+    if _CC_BASE is None:
+        body = get_text("https://index.commoncrawl.org/collinfo.json")
+        try:
+            _CC_BASE = json.loads(body)[0]["cdx-api"]
+        except Exception:
+            print("  ! common-crawl index list unreachable", file=sys.stderr)
+            _CC_BASE = ""
+    return _CC_BASE or None
+
+
+def parse_cc_jsonl(text: str) -> set[str]:
+    """Collect the `url` field from a Common Crawl CDX JSONL response."""
+    urls: set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(row, dict) and row.get("url"):
+            urls.add(row["url"])
+    return urls
+
+
+def channel_cc(host: str, query: str, limit: int) -> set[str]:
+    """Bulk-dump board URLs for <host>/* from Common Crawl. Ignores the keyword."""
+    base = cc_api_base()
+    if not base:
+        return set()
+    cap = (limit or 100) * 5  # over-fetch; many rows collapse to one slug
+    url = f"{base}?url={urllib.parse.quote(host)}/*&output=json&limit={cap}"
+    return parse_cc_jsonl(get_text(url, timeout=60))

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -24,7 +24,7 @@ import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from ats_boards import VALIDATORS, github_fragments, extract_slugs, emit_survivors  # noqa: E402
+from ats_boards import github_fragments, extract_slugs, emit_survivors  # noqa: E402
 
 # Provider -> the ATS host to put in a `site:` search / Common Crawl prefix.
 PROVIDER_HOSTS = {

--- a/scripts/discover_boards.py
+++ b/scripts/discover_boards.py
@@ -14,7 +14,10 @@ Stdlib only; the github channel shells out to `gh`; google needs GOOGLE_CSE_KEY/
 
 from __future__ import annotations
 
+import re
 import sys
+import urllib.parse
+import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -33,3 +36,33 @@ PROVIDER_HOSTS = {
     "personio": "jobs.personio.com",
     "teamtailor": "teamtailor.com",
 }
+
+# DuckDuckGo's HTML endpoint rejects unusual UAs; use a browser-like one.
+BROWSER_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+
+
+def get_text(url: str, timeout: int = 25) -> str:
+    """GET a URL with a browser UA, returning decoded text ('' on failure)."""
+    req = urllib.request.Request(url, headers={"User-Agent": BROWSER_UA})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.read().decode("utf-8", "replace")
+    except Exception as e:
+        print(f"  ! GET failed ({url[:60]}...): {e}", file=sys.stderr)
+        return ""
+
+
+def parse_ddg_html(html: str) -> set[str]:
+    """Extract target URLs from DuckDuckGo HTML results (unwrap ?uddg= redirects)."""
+    return {urllib.parse.unquote(m) for m in re.findall(r"uddg=([^\"&]+)", html)}
+
+
+def channel_ddg(host: str, query: str, limit: int) -> set[str]:
+    """site:<host> <query> via DuckDuckGo HTML -> raw target URLs."""
+    q = urllib.parse.quote(f"site:{host} {query}")
+    html = get_text(f"https://html.duckduckgo.com/html/?q={q}")
+    urls = parse_ddg_html(html)
+    return set(list(urls)[:limit]) if limit else urls

--- a/scripts/harvest_boards.py
+++ b/scripts/harvest_boards.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys
@@ -30,9 +29,12 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
-SOURCES_DIR = REPO / "sources"
-UA = "freehire-harvest/1.0 (+https://freehire.dev)"
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from ats_boards import (  # noqa: E402
+    REPO, SOURCES_DIR, UA, SLUG_PATTERNS, SLUG_BLOCKLIST, VALIDATORS,
+    fetch, yaml_name, extract_slugs, existing_slugs, validate,
+    github_fragments, emit_survivors,
+)
 
 # Aggregator JSON files. We sweep the raw text with regex, so the per-file schema
 # (key names) does not matter — only that ATS URLs appear somewhere in the JSON.
@@ -45,84 +47,12 @@ AGGREGATORS = [
     "https://raw.githubusercontent.com/crypto-jobs-fyi/crawler/HEAD/tech_companies.json",
 ]
 
-# (compiled regex, provider). Group 1 is the board slug.
-SLUG_PATTERNS = [
-    (re.compile(r"(?:boards|job-boards)(?:\.eu)?\.greenhouse\.io/(?:embed/job_app\?for=)?([A-Za-z0-9_-]+)"), "greenhouse"),
-    (re.compile(r"jobs\.(?:eu\.)?lever\.co/([A-Za-z0-9_.-]+)"), "lever"),
-    (re.compile(r"jobs\.ashbyhq\.com/([A-Za-z0-9_.-]+)"), "ashby"),
-    (re.compile(r"(?:jobs|careers)\.smartrecruiters\.com/([A-Za-z0-9_-]+)|api\.smartrecruiters\.com/v1/companies/([A-Za-z0-9_-]+)"), "smartrecruiters"),
-    (re.compile(r"apply\.workable\.com/([A-Za-z0-9_-]+)"), "workable"),
-    (re.compile(r"([A-Za-z0-9_-]+)\.recruitee\.com"), "recruitee"),
-    (re.compile(r"([A-Za-z0-9_-]+)\.bamboohr\.com"), "bamboohr"),
-    (re.compile(r"([A-Za-z0-9_-]+)\.breezy\.hr"), "breezy"),
-    (re.compile(r"([A-Za-z0-9_-]+)\.jobs\.personio\.(?:com|de)"), "personio"),
-    # Teamtailor's "slug" is the whole board host — the adapter takes board = hostname.
-    # Only *.teamtailor.com hosts are detectable here; boards on a custom domain
-    # (e.g. jobs.tibber.com) carry no teamtailor marker in the URL and are missed.
-    (re.compile(r"([A-Za-z0-9_-]+\.teamtailor\.com)"), "teamtailor"),
-]
-
-# Slugs that are path segments of the ATS host itself, not real boards.
-SLUG_BLOCKLIST = {
-    "embed", "jobs", "job", "j", "o", "share", "en-us", "en-gb",
-    "api", "widget", "backend", "www", "app", "auth", "referrals", "v1",
-}
-
 # Workday is a separate beast: a board is host + career-site path (e.g.
 # "logitech.wd5.myworkdayjobs.com/Logitech"), and the site segment sits before
 # /job/ or /details/ in a posting URL, after an optional locale prefix.
 WORKDAY_RE = re.compile(
     r"https?://([a-z0-9-]+\.wd\d+\.myworkdayjobs\.com)/(?:[a-zA-Z]{2}-[a-zA-Z]{2}/)?([^/?\"]+)/(?:job|details)/"
 )
-
-# Validation endpoints — each identical to the one its internal/sources/<provider>.go
-# adapter calls, so a board the harvester accepts is one ingest can actually crawl.
-# bamboohr returns JSON, personio XML, teamtailor HTML (see validate()).
-VALIDATORS = {
-    "greenhouse": lambda s: f"https://boards-api.greenhouse.io/v1/boards/{s}/jobs?content=true",
-    "lever": lambda s: f"https://api.lever.co/v0/postings/{s}?mode=json",
-    "ashby": lambda s: f"https://api.ashbyhq.com/posting-api/job-board/{s}",
-    "smartrecruiters": lambda s: f"https://api.smartrecruiters.com/v1/companies/{s}/postings?limit=10",
-    "workable": lambda s: f"https://apply.workable.com/api/v1/widget/accounts/{s}?details=true",
-    "recruitee": lambda s: f"https://{s}.recruitee.com/api/offers/",
-    "bamboohr": lambda s: f"https://{s}.bamboohr.com/careers/list",
-    "breezy": lambda s: f"https://{s}.breezy.hr/json",  # top-level JSON array of positions
-    "personio": lambda s: f"https://{s}.jobs.personio.com/xml",
-    "teamtailor": lambda s: f"https://{s}/jobs",  # s is the board host, not a slug
-}
-
-
-def fetch(url: str, timeout: int = 25) -> bytes | None:
-    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "application/json"})
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as r:
-            return r.read()
-    except Exception:
-        return None
-
-
-def yaml_name(name: str) -> str:
-    """Quote a company name only when it carries YAML-significant characters."""
-    name = name.strip()
-    if not name or name[0] in "-?:,[]{}#&*!|>'\"%@`" or any(c in name for c in ':#,"'):
-        return '"' + name.replace('\\', '\\\\').replace('"', '\\"') + '"'
-    return name
-
-
-def extract_slugs(text: str) -> set[tuple[str, str]]:
-    """Sweep raw text for ATS board URLs -> {(provider, slug)}.
-
-    Patterns may carry multiple alternation groups (e.g. SmartRecruiters' two host
-    forms), so take the first non-empty group of each match as the slug.
-    """
-    out: set[tuple[str, str]] = set()
-    for pat, provider in SLUG_PATTERNS:
-        for m in pat.finditer(text):
-            slug = next((g for g in m.groups() if g), None)
-            if not slug or slug.lower() in SLUG_BLOCKLIST:
-                continue
-            out.add((provider, slug))
-    return out
 
 
 def harvest_aggregators() -> dict[tuple[str, str], str]:
@@ -198,47 +128,6 @@ def harvest_github(per_provider_pages: int = 3) -> set[tuple[str, str]]:
     return out
 
 
-def existing_slugs() -> dict[str, set[str]]:
-    out: dict[str, set[str]] = defaultdict(set)
-    for prov in VALIDATORS:
-        f = SOURCES_DIR / f"{prov}.yml"
-        if f.exists():
-            for m in re.findall(r"board:\s*\"?([^\"\n]+)\"?", f.read_text()):
-                out[prov].add(m.strip().lower())
-    return out
-
-
-def validate(provider: str, slug: str) -> int | None:
-    """Return active job count if the board is live and non-empty, else None."""
-    body = fetch(VALIDATORS[provider](slug), timeout=20)
-    if not body:
-        return None
-    # personio (XML) and teamtailor (HTML) are not JSON — count off the raw bytes the
-    # same way their adapters do: <position> elements and /jobs/<id> links.
-    if provider == "personio":
-        return body.count(b"<position>") or None
-    if provider == "teamtailor":
-        return len(set(re.findall(rb"/jobs/(\d+)", body))) or None
-    try:
-        data = json.loads(body)
-    except Exception:
-        return None
-    d = data if isinstance(data, dict) else {}
-    if provider in ("lever", "breezy"):  # both return a top-level JSON array
-        count = len(data) if isinstance(data, list) else 0
-    elif provider == "smartrecruiters":
-        count = d.get("totalFound") or len(d.get("content", []))
-    elif provider == "recruitee":
-        count = len(d.get("offers", []))
-    elif provider == "bamboohr":
-        count = len(d.get("result", []))
-    else:  # greenhouse / ashby / workable all expose a "jobs" array
-        count = len(d.get("jobs", []))
-    # is_worth_adding: a board earns a slot only if it currently lists jobs.
-    # Tune here if you want a higher bar (e.g. >= 5 jobs, or tech-only titles).
-    return count or None
-
-
 def harvest_workday() -> dict[tuple[str, str], str]:
     """Return {(host, site): company_name} for Workday boards in the aggregators."""
     out: dict[tuple[str, str], str] = {}
@@ -273,29 +162,6 @@ def workday_names(text: str) -> dict[tuple[str, str], str]:
                 for host, site in WORKDAY_RE.findall(v):
                     names.setdefault((host, site), str(name).strip())
     return names
-
-
-def github_fragments(query: str, pages: int) -> list[str]:
-    """Run a GitHub code-search query and return the matched text fragments."""
-    frags: list[str] = []
-    for page in range(1, pages + 1):
-        try:
-            raw = subprocess.run(
-                ["gh", "api", "-X", "GET", "search/code",
-                 "-H", "Accept: application/vnd.github.text-match+json",
-                 "-f", f"q={query} in:file", "-f", "per_page=100", "-f", f"page={page}"],
-                capture_output=True, text=True, timeout=60,
-            ).stdout
-            items = json.loads(raw).get("items", [])
-        except Exception as e:
-            print(f"  ! github query failed ({query} p{page}): {e}", file=sys.stderr)
-            break
-        if not items:
-            break
-        for it in items:
-            for m in it.get("text_matches", []):
-                frags.append(m.get("fragment", ""))
-    return frags
 
 
 def harvest_github_workday(pages: int = 5) -> dict[tuple[str, str], str]:
@@ -406,47 +272,7 @@ def main() -> int:
         for key in harvest_github():
             cand.setdefault(key, key[1])
 
-    have = existing_slugs()
-    new = {(p, s): n for (p, s), n in cand.items() if s.lower() not in have[p]}
-    print(f"\n{len(cand)} unique candidates, {len(cand) - len(new)} already tracked, "
-          f"{len(new)} new to validate\n", file=sys.stderr)
-
-    # Validate concurrently.
-    items = list(new.items())
-    with ThreadPoolExecutor(max_workers=16) as ex:
-        counts = list(ex.map(lambda kv: validate(kv[0][0], kv[0][1]), items))
-
-    # Collapse case-variant slugs of the same board (e.g. Etched/etched) — they
-    # resolve to one board, so keep the highest-job-count spelling only.
-    best: dict[tuple[str, str], tuple[str, str, int]] = {}
-    for ((prov, slug), name), n in zip(items, counts):
-        if not n:
-            continue
-        key = (prov, slug.lower())
-        if key not in best or n > best[key][2]:
-            best[key] = (name, slug, n)
-    survivors: dict[str, list[tuple[str, str, int]]] = defaultdict(list)
-    for (prov, _), row in best.items():
-        survivors[prov].append(row)
-
-    total = 0
-    for prov in VALIDATORS:
-        rows = sorted(survivors[prov], key=lambda r: -r[2])
-        if not rows:
-            continue
-        total += len(rows)
-        print(f"\n# === {prov}: {len(rows)} new live boards ===")
-        for name, slug, n in rows:
-            print(f"- company: {yaml_name(name)}  # {n} jobs")
-            print(f"  board: {slug}")
-        if args.write:
-            f = SOURCES_DIR / f"{prov}.yml"
-            with f.open("a") as fh:
-                for name, slug, n in rows:
-                    fh.write(f"- company: {yaml_name(name)}\n  board: {slug}\n")
-            print(f"  -> appended {len(rows)} entries to {f.relative_to(REPO)}", file=sys.stderr)
-
-    print(f"\n{total} new validated boards total", file=sys.stderr)
+    emit_survivors(cand, args.write)
     return 0
 
 

--- a/scripts/harvest_boards.py
+++ b/scripts/harvest_boards.py
@@ -25,7 +25,6 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 

--- a/scripts/test_discover_boards.py
+++ b/scripts/test_discover_boards.py
@@ -73,6 +73,24 @@ def test_parse_cc_jsonl_collects_urls_and_skips_garbage():
     }
 
 
+def test_collect_candidates_filters_to_provider():
+    import discover_boards as dd
+    saved = dd.CHANNELS.copy()
+    # ashby search accidentally also surfaces a lever URL; keep only ashby for the ashby host.
+    dd.CHANNELS = {
+        "stub": lambda host, query, limit: {
+            "https://jobs.ashbyhq.com/Clipbook",
+            "https://jobs.lever.co/strayco",
+        }
+    }
+    try:
+        cand = dd.collect_candidates(["ashby"], ["stub"], "anything", limit=10)
+    finally:
+        dd.CHANNELS = saved
+    assert ("ashby", "Clipbook") in cand
+    assert ("lever", "strayco") not in cand  # filtered: not the queried provider
+
+
 def _run():
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0

--- a/scripts/test_discover_boards.py
+++ b/scripts/test_discover_boards.py
@@ -49,6 +49,17 @@ def test_parse_cse_items_empty_on_no_items():
     assert d.parse_cse_items({}) == set()
 
 
+def test_channel_github_extracts_from_fragments():
+    import discover_boards as dd
+    orig = dd.github_fragments
+    dd.github_fragments = lambda query, pages: ["see https://jobs.ashbyhq.com/Clipbook here"]
+    try:
+        urls = dd.channel_github("jobs.ashbyhq.com", "fintech", limit=10)
+    finally:
+        dd.github_fragments = orig
+    assert any("jobs.ashbyhq.com/Clipbook" in u for u in urls)
+
+
 def _run():
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0

--- a/scripts/test_discover_boards.py
+++ b/scripts/test_discover_boards.py
@@ -34,6 +34,21 @@ def test_parse_ddg_html_passes_decoded_url_to_extract_slugs():
     assert ("ashby", "Clipbook") in slugs
 
 
+def test_parse_cse_items_extracts_links():
+    obj = {"items": [
+        {"link": "https://jobs.ashbyhq.com/Clipbook/abc"},
+        {"link": "https://jobs.ashbyhq.com/Other"},
+    ]}
+    assert d.parse_cse_items(obj) == {
+        "https://jobs.ashbyhq.com/Clipbook/abc",
+        "https://jobs.ashbyhq.com/Other",
+    }
+
+
+def test_parse_cse_items_empty_on_no_items():
+    assert d.parse_cse_items({}) == set()
+
+
 def _run():
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0

--- a/scripts/test_discover_boards.py
+++ b/scripts/test_discover_boards.py
@@ -60,6 +60,19 @@ def test_channel_github_extracts_from_fragments():
     assert any("jobs.ashbyhq.com/Clipbook" in u for u in urls)
 
 
+def test_parse_cc_jsonl_collects_urls_and_skips_garbage():
+    text = (
+        '{"url":"https://jobs.ashbyhq.com/Clipbook/abc","status":"200"}\n'
+        '{"url":"https://jobs.ashbyhq.com/Other"}\n'
+        'not-json-line\n'
+    )
+    urls = d.parse_cc_jsonl(text)
+    assert urls == {
+        "https://jobs.ashbyhq.com/Clipbook/abc",
+        "https://jobs.ashbyhq.com/Other",
+    }
+
+
 def _run():
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0

--- a/scripts/test_discover_boards.py
+++ b/scripts/test_discover_boards.py
@@ -16,6 +16,24 @@ def test_provider_hosts_subset_of_validators():
     assert d.PROVIDER_HOSTS["ashby"] == "jobs.ashbyhq.com"
 
 
+def test_parse_ddg_html_decodes_uddg_redirect():
+    html = (
+        '<a class="result__a" '
+        'href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fjobs.ashbyhq.com%2FClipbook%2Fabc&rut=x">'
+        'Clipbook</a>'
+    )
+    urls = d.parse_ddg_html(html)
+    assert "https://jobs.ashbyhq.com/Clipbook/abc" in urls
+
+
+def test_parse_ddg_html_passes_decoded_url_to_extract_slugs():
+    html = '<a href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fjobs.ashbyhq.com%2FClipbook&rut=x">x</a>'
+    slugs = set()
+    for url in d.parse_ddg_html(html):
+        slugs |= ats_boards.extract_slugs(url)
+    assert ("ashby", "Clipbook") in slugs
+
+
 def _run():
     fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0

--- a/scripts/test_discover_boards.py
+++ b/scripts/test_discover_boards.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Plain-assert tests for discover_boards (no pytest). Run: python3 scripts/test_discover_boards.py"""
+
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ats_boards  # noqa: E402
+import discover_boards as d  # noqa: E402
+
+
+def test_provider_hosts_subset_of_validators():
+    assert set(d.PROVIDER_HOSTS) <= set(ats_boards.VALIDATORS), \
+        "every discoverable provider must have a validator"
+    assert d.PROVIDER_HOSTS["ashby"] == "jobs.ashbyhq.com"
+
+
+def _run():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"ok   {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run())


### PR DESCRIPTION
## Summary

Adds `scripts/discover_boards.py` — a query-driven open-web ATS board finder that complements the aggregator-blob `harvest_boards.py` by reaching the long tail of small boards (e.g. `jobs.ashbyhq.com/Clipbook`) that no aggregator lists.

- **Shared core extracted** to `scripts/ats_boards.py` (constants, `fetch`, `extract_slugs`, `validate`, `existing_slugs`, `github_fragments`, and a shared `emit_survivors`). `harvest_boards.py` now imports it — behaviour-preserving refactor.
- **Four discovery channels**, uniform `(host, query, limit) -> set[str]`:
  - `ddg` — `site:<host> <query>` via DuckDuckGo HTML (keyless, default)
  - `google` — same via Google Custom Search JSON API (env-gated on `GOOGLE_CSE_KEY`/`GOOGLE_CSE_CX`)
  - `github` — `<query> <host>` via `gh` code search
  - `cc` — bulk-dump `<host>/*` from the Common Crawl index (keyword-agnostic; path-based providers only)
- **Pipeline:** channels → `extract_slugs` → provider filter → `emit_survivors` (dedup vs `sources/*.yml` → live-validate → ready-to-paste YAML, `--write` to append).
- **CLI:** `--query --provider --channel --write --limit`; unknown providers/channels and missing-query (for keyword channels) fail fast.
- stdlib-only; `gh`/Common Crawl/Google are optional and degrade gracefully.

\`\`\`
python3 scripts/discover_boards.py --query "fintech berlin" --provider ashby,lever --channel ddg,github
\`\`\`

## Test Plan

- [x] `python3 scripts/test_discover_boards.py` — 8/8 pass (pure parsers: ddg/cse/cc + provider-filter + host-map invariant)
- [x] `python3 -m py_compile scripts/{ats_boards,discover_boards,harvest_boards}.py`
- [x] Live: `--channel cc --provider ashby` found 2 new live boards (10xteam 125 jobs, 0g); `--channel ddg --provider ashby --query engineer` found 6 (allen-control-systems 64 jobs, eagle, confiant, …)
- [x] `harvest_boards.py` still imports/runs after the shared-core extraction