### PR TITLE
sources: split HTTPClient into capability interfaces (interface segregation)

### DIFF
--- a/internal/sources/alfabank.go
+++ b/internal/sources/alfabank.go
@@ -11,7 +11,7 @@ import (
 // carries the description inline, so no detail fan-out is needed. cityId is a code resolved
 // against a cities dictionary fetched once per Fetch.
 type alfabank struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -22,7 +22,7 @@ const (
 )
 
 // NewAlfaBank builds the Alfa-Bank adapter over the given HTTP client.
-func NewAlfaBank(c HTTPClient) Source { return alfabank{http: c} }
+func NewAlfaBank(c JSONGetter) Source { return alfabank{http: c} }
 
 func (alfabank) Provider() string { return "alfabank" }
 

--- a/internal/sources/ashby.go
+++ b/internal/sources/ashby.go
@@ -11,11 +11,11 @@ const ashbyBaseURL = "https://api.ashbyhq.com/posting-api/job-board"
 // ashby adapts the Ashby public job-board API. The list endpoint carries an HTML
 // description and an explicit remote flag, so no per-posting detail request is needed.
 type ashby struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewAshby builds the Ashby adapter over the given HTTP client.
-func NewAshby(c HTTPClient) Source { return ashby{http: c} }
+func NewAshby(c JSONGetter) Source { return ashby{http: c} }
 
 func (ashby) Provider() string { return "ashby" }
 

--- a/internal/sources/aviasales.go
+++ b/internal/sources/aviasales.go
@@ -11,7 +11,7 @@ import (
 // plain JSON array carrying no description, so each vacancy's body comes from its own
 // Remix-loader detail request, fanned out like SmartRecruiters.
 type aviasales struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -23,7 +23,7 @@ const (
 )
 
 // NewAviasales builds the Aviasales adapter over the given HTTP client.
-func NewAviasales(c HTTPClient) Source { return aviasales{http: c} }
+func NewAviasales(c JSONGetter) Source { return aviasales{http: c} }
 
 func (aviasales) Provider() string { return "aviasales" }
 

--- a/internal/sources/bamboohr.go
+++ b/internal/sources/bamboohr.go
@@ -9,11 +9,11 @@ import (
 // description, so it fetches each posting's detail (bounded-concurrency) to assemble the
 // body, like the SmartRecruiters and Rippling adapters.
 type bambooHR struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewBambooHR builds the BambooHR adapter over the given HTTP client.
-func NewBambooHR(c HTTPClient) Source { return bambooHR{http: c} }
+func NewBambooHR(c JSONGetter) Source { return bambooHR{http: c} }
 
 func (bambooHR) Provider() string { return "bamboohr" }
 

--- a/internal/sources/breezy.go
+++ b/internal/sources/breezy.go
@@ -13,12 +13,18 @@ import (
 // server-rendered HTML carrying a schema.org JobPosting ld+json block, so the description
 // comes from a per-position detail fetch (bounded-concurrency), like the other detail
 // adapters.
+// breezyHTTP is the transport breezy needs: a JSON listing plus HTML detail pages.
+type breezyHTTP interface {
+	JSONGetter
+	HTMLGetter
+}
+
 type breezy struct {
-	http HTTPClient
+	http breezyHTTP
 }
 
 // NewBreezy builds the Breezy adapter over the given HTTP client.
-func NewBreezy(c HTTPClient) Source { return breezy{http: c} }
+func NewBreezy(c breezyHTTP) Source { return breezy{http: c} }
 
 func (breezy) Provider() string { return "breezy" }
 

--- a/internal/sources/dodo.go
+++ b/internal/sources/dodo.go
@@ -13,7 +13,7 @@ import (
 // and each body is assembled from its detail page's content blocks, fanned out like
 // SmartRecruiters.
 type dodo struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -34,7 +34,7 @@ var dodoBodyTypes = map[string]bool{
 }
 
 // NewDodo builds the Dodo adapter over the given HTTP client.
-func NewDodo(c HTTPClient) Source { return dodo{http: c} }
+func NewDodo(c JSONGetter) Source { return dodo{http: c} }
 
 func (dodo) Provider() string { return "dodo" }
 

--- a/internal/sources/domclick.go
+++ b/internal/sources/domclick.go
@@ -10,7 +10,7 @@ import (
 // description, so each vacancy's body comes from its own slug-keyed detail request,
 // fanned out like SmartRecruiters.
 type domclick struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -21,7 +21,7 @@ const (
 )
 
 // NewDomclick builds the DomClick adapter over the given HTTP client.
-func NewDomclick(c HTTPClient) Source { return domclick{http: c} }
+func NewDomclick(c JSONGetter) Source { return domclick{http: c} }
 
 func (domclick) Provider() string { return "domclick" }
 

--- a/internal/sources/gem.go
+++ b/internal/sources/gem.go
@@ -37,11 +37,11 @@ const (
 // so it fetches each posting's detail (bounded-concurrency) to assemble the body, like the
 // SmartRecruiters and Rippling adapters.
 type gem struct {
-	http HTTPClient
+	http JSONPoster
 }
 
 // NewGem builds the Gem adapter over the given HTTP client.
-func NewGem(c HTTPClient) Source { return gem{http: c} }
+func NewGem(c JSONPoster) Source { return gem{http: c} }
 
 func (gem) Provider() string { return "gem" }
 

--- a/internal/sources/gem_test.go
+++ b/internal/sources/gem_test.go
@@ -8,11 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/net/html"
 )
 
-// gqlHTTP is a body-aware test HTTPClient for the GraphQL adapters: Gem sends both its
+// gqlHTTP is a body-aware test JSONPoster for the GraphQL adapters: Gem sends both its
 // list and its detail request as POST to the same URL, distinguished only by the request
 // body, so this fake routes the canned response on the operation name and (for detail)
 // the extId in the variables — not the URL. A detail extId listed in failExtIDs returns
@@ -22,26 +20,6 @@ type gqlHTTP struct {
 	detail     map[string]string // extId -> canned ExternalJobPostingQuery response
 	failExtIDs map[string]bool   // extIds whose detail request errors
 	gotURL     string
-}
-
-func (f *gqlHTTP) GetJSON(context.Context, string, any) error {
-	return errors.New("gqlHTTP: unexpected GetJSON")
-}
-
-func (f *gqlHTTP) GetXML(context.Context, string, any) error {
-	return errors.New("gqlHTTP: unexpected GetXML")
-}
-
-func (f *gqlHTTP) GetHTML(context.Context, string) (*html.Node, error) {
-	return nil, errors.New("gqlHTTP: unexpected GetHTML")
-}
-
-func (f *gqlHTTP) GetJSONWithHeaders(context.Context, string, map[string]string, any) error {
-	return errors.New("gqlHTTP: unexpected GetJSONWithHeaders")
-}
-
-func (f *gqlHTTP) PostJSONWithHeaders(context.Context, string, map[string]string, any, any) error {
-	return errors.New("gqlHTTP: unexpected PostJSONWithHeaders")
 }
 
 func (f *gqlHTTP) PostJSON(_ context.Context, url string, body, v any) error {

--- a/internal/sources/greenhouse.go
+++ b/internal/sources/greenhouse.go
@@ -14,11 +14,11 @@ const greenhouseBaseURL = "https://boards-api.greenhouse.io/v1/boards"
 // description inline when asked with content=true, so no per-posting detail request
 // is needed.
 type greenhouse struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewGreenhouse builds the Greenhouse adapter over the given HTTP client.
-func NewGreenhouse(c HTTPClient) Source { return greenhouse{http: c} }
+func NewGreenhouse(c JSONGetter) Source { return greenhouse{http: c} }
 
 func (greenhouse) Provider() string { return "greenhouse" }
 

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -15,22 +15,57 @@ import (
 	"golang.org/x/net/html"
 )
 
-// HTTPClient is the narrow transport an adapter needs: fetch a URL and decode its
-// JSON (or XML) body into v. PostJSON sends a JSON request body (Workday's listing
-// API is POST-only). Adapters depend on this interface so tests inject a fake and
-// never touch the network; the real client is Client below.
-type HTTPClient interface {
+// The capability interfaces below are the narrow transport roles an adapter depends
+// on (interface segregation): a JSON-list adapter takes a JSONGetter, an HTML-detail
+// adapter an HTMLGetter, and so on. The real Client implements them all, so one Client
+// serves every adapter; a test fake implements only the role(s) its adapter uses
+// rather than stubbing a six-method surface. Composed roles (e.g. JSON list + HTML
+// detail) are declared as a small embedded interface at the adapter that needs them.
+
+// JSONGetter fetches a URL and decodes its JSON body into v.
+type JSONGetter interface {
 	GetJSON(ctx context.Context, url string, v any) error
+}
+
+// XMLGetter fetches a URL and decodes its XML body into v (platforms publishing an XML
+// feed, e.g. Personio).
+type XMLGetter interface {
 	GetXML(ctx context.Context, url string, v any) error
-	PostJSON(ctx context.Context, url string, body, v any) error
-	// GetHTML fetches url and returns its parsed HTML tree, for adapters whose detail is
-	// server-rendered HTML rather than a structured body (e.g. SuccessFactors).
+}
+
+// HTMLGetter fetches a URL and returns its parsed HTML tree, for adapters whose detail
+// is server-rendered HTML rather than a structured body (e.g. SuccessFactors).
+type HTMLGetter interface {
 	GetHTML(ctx context.Context, url string) (*html.Node, error)
-	// GetJSONWithHeaders and PostJSONWithHeaders behave like GetJSON/PostJSON but attach
-	// extra request headers, for an API gated behind a non-secret header (e.g. MTS's public
-	// x-api-key). The custom headers never override the standard User-Agent/Accept.
+}
+
+// JSONPoster sends a JSON request body and decodes the JSON response (platforms whose
+// listing API is POST-only, e.g. Workday).
+type JSONPoster interface {
+	PostJSON(ctx context.Context, url string, body, v any) error
+}
+
+// HeaderJSONGetter and HeaderJSONPoster behave like JSONGetter/JSONPoster but attach
+// extra request headers, for an API gated behind a non-secret header (e.g. MTS's public
+// x-api-key). The custom headers never override the standard User-Agent/Accept.
+type HeaderJSONGetter interface {
 	GetJSONWithHeaders(ctx context.Context, url string, headers map[string]string, v any) error
+}
+
+type HeaderJSONPoster interface {
 	PostJSONWithHeaders(ctx context.Context, url string, headers map[string]string, body, v any) error
+}
+
+// HTTPClient is the full transport surface, composing every capability role. The real
+// Client implements it; sources.All holds one and passes it to each adapter, which then
+// narrows it to the role(s) it actually uses.
+type HTTPClient interface {
+	JSONGetter
+	XMLGetter
+	HTMLGetter
+	JSONPoster
+	HeaderJSONGetter
+	HeaderJSONPoster
 }
 
 // Client is the real HTTPClient: a timeout-bounded GET with a project User-Agent and

--- a/internal/sources/huntflow.go
+++ b/internal/sources/huntflow.go
@@ -13,7 +13,7 @@ import (
 // payload carries no description, so each open vacancy's body comes from its own detail
 // payload, fanned out like SmartRecruiters.
 type huntflow struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -23,7 +23,7 @@ const (
 )
 
 // NewHuntflow builds the Huntflow adapter over the given HTTP client.
-func NewHuntflow(c HTTPClient) Source { return huntflow{http: c} }
+func NewHuntflow(c JSONGetter) Source { return huntflow{http: c} }
 
 func (huntflow) Provider() string { return "huntflow" }
 

--- a/internal/sources/join.go
+++ b/internal/sources/join.go
@@ -18,11 +18,11 @@ const (
 // company id. The list endpoint carries no description, so each posting's body comes from its
 // own detail request (bounded-concurrency), like the SmartRecruiters and Gem adapters.
 type join struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewJoin builds the Join.com adapter over the given HTTP client.
-func NewJoin(c HTTPClient) Source { return join{http: c} }
+func NewJoin(c JSONGetter) Source { return join{http: c} }
 
 func (join) Provider() string { return "join" }
 

--- a/internal/sources/kuper.go
+++ b/internal/sources/kuper.go
@@ -13,7 +13,7 @@ import (
 // list of category blocks; the pagination block carries the page count and the vacancies
 // block carries the postings.
 type kuper struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -22,7 +22,7 @@ const (
 )
 
 // NewKuper builds the Kuper adapter over the given HTTP client.
-func NewKuper(c HTTPClient) Source { return kuper{http: c} }
+func NewKuper(c JSONGetter) Source { return kuper{http: c} }
 
 func (kuper) Provider() string { return "kuper" }
 

--- a/internal/sources/lamoda.go
+++ b/internal/sources/lamoda.go
@@ -11,7 +11,7 @@ import (
 // per-tenant board id (boardless). The list endpoint paginates by offset and carries only
 // a summary, so each posting's body comes from its own detail request, fanned out.
 type lamoda struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -22,7 +22,7 @@ const (
 )
 
 // NewLamoda builds the Lamoda adapter over the given HTTP client.
-func NewLamoda(c HTTPClient) Source { return lamoda{http: c} }
+func NewLamoda(c JSONGetter) Source { return lamoda{http: c} }
 
 func (lamoda) Provider() string { return "lamoda" }
 

--- a/internal/sources/lever.go
+++ b/internal/sources/lever.go
@@ -13,11 +13,11 @@ const leverBaseURL = "https://api.lever.co/v0/postings"
 // postings whose body is split across HTML description/lists/additional fields, which
 // the adapter assembles, so no per-posting detail request is needed.
 type lever struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewLever builds the Lever adapter over the given HTTP client.
-func NewLever(c HTTPClient) Source { return lever{http: c} }
+func NewLever(c JSONGetter) Source { return lever{http: c} }
 
 func (lever) Provider() string { return "lever" }
 

--- a/internal/sources/mts.go
+++ b/internal/sources/mts.go
@@ -13,8 +13,16 @@ import (
 // that the public SPA bakes into its Nuxt runtime config, so each run harvests the key from
 // job.mts.ru first, then pages the list and fans out per-vacancy detail fetches like the
 // other detail-fetching adapters.
+// mtsHTTP is the transport mts needs: HTML (to harvest the x-api-key from the SPA) plus
+// header-bearing JSON GET/POST for the gated list and detail endpoints.
+type mtsHTTP interface {
+	HTMLGetter
+	HeaderJSONGetter
+	HeaderJSONPoster
+}
+
 type mts struct {
-	http HTTPClient
+	http mtsHTTP
 }
 
 const (
@@ -26,7 +34,7 @@ const (
 )
 
 // NewMTS builds the MTS adapter over the given HTTP client.
-func NewMTS(c HTTPClient) Source { return mts{http: c} }
+func NewMTS(c mtsHTTP) Source { return mts{http: c} }
 
 func (mts) Provider() string { return "mts" }
 

--- a/internal/sources/mts_test.go
+++ b/internal/sources/mts_test.go
@@ -10,12 +10,12 @@ import (
 	"golang.org/x/net/html"
 )
 
-// mtsHTTP is a body-aware test HTTPClient for MTS: the list is a POST that paginates on the
+// fakeMTS is a body-aware test fake for MTS (the mtsHTTP roles): the list is a POST that paginates on the
 // request body's offset, the detail is a GET keyed by the vacancy id in the URL, and both
 // must carry the harvested x-api-key header. The fake records the header seen on each call
 // so the test can assert it is sent. GetHTML serves a canned config page for the apiKey
 // harvest. A detail id in failIDs errors so detail-isolation can be exercised.
-type mtsHTTP struct {
+type fakeMTS struct {
 	configHTML string            // page served by GetHTML (carries apiKey)
 	pages      map[int]string    // offset -> canned list payload
 	detail     map[string]string // id -> canned detail payload
@@ -25,42 +25,32 @@ type mtsHTTP struct {
 	detailKey string // x-api-key seen on a detail GET
 }
 
-func (f *mtsHTTP) GetJSON(context.Context, string, any) error {
-	return errors.New("mtsHTTP: unexpected GetJSON")
-}
-func (f *mtsHTTP) GetXML(context.Context, string, any) error {
-	return errors.New("mtsHTTP: unexpected GetXML")
-}
-func (f *mtsHTTP) PostJSON(context.Context, string, any, any) error {
-	return errors.New("mtsHTTP: unexpected PostJSON")
-}
-
-func (f *mtsHTTP) GetHTML(_ context.Context, _ string) (*html.Node, error) {
+func (f *fakeMTS) GetHTML(_ context.Context, _ string) (*html.Node, error) {
 	return html.Parse(strings.NewReader(f.configHTML))
 }
 
-func (f *mtsHTTP) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
+func (f *fakeMTS) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
 	f.detailKey = headers["x-api-key"]
 	id := url[strings.LastIndex(url, "/")+1:]
 	if f.failIDs[id] {
-		return errors.New("mtsHTTP: detail boom for " + id)
+		return errors.New("fakeMTS: detail boom for " + id)
 	}
 	raw, ok := f.detail[id]
 	if !ok {
-		return errors.New("mtsHTTP: no canned detail for " + id)
+		return errors.New("fakeMTS: no canned detail for " + id)
 	}
 	return json.Unmarshal([]byte(raw), v)
 }
 
-func (f *mtsHTTP) PostJSONWithHeaders(_ context.Context, _ string, headers map[string]string, body, v any) error {
+func (f *fakeMTS) PostJSONWithHeaders(_ context.Context, _ string, headers map[string]string, body, v any) error {
 	f.listKey = headers["x-api-key"]
 	req, ok := body.(mtsListRequest)
 	if !ok {
-		return errors.New("mtsHTTP: list body is not a mtsListRequest")
+		return errors.New("fakeMTS: list body is not a mtsListRequest")
 	}
 	raw, ok := f.pages[req.Offset]
 	if !ok {
-		return errors.New("mtsHTTP: no canned page for offset")
+		return errors.New("fakeMTS: no canned page for offset")
 	}
 	return json.Unmarshal([]byte(raw), v)
 }
@@ -116,7 +106,7 @@ func TestMTSAPIKeyExtractionMissing(t *testing.T) {
 
 func TestMTSFetchPaginatesMapsAndSendsKey(t *testing.T) {
 	// total=400 forces two pages at the fixed 200 page size: offset 0 then offset 200.
-	fake := &mtsHTTP{
+	fake := &fakeMTS{
 		configHTML: mtsConfigHTML,
 		pages: map[int]string{
 			0: mtsListPage(400,
@@ -187,7 +177,7 @@ func TestMTSFetchPaginatesMapsAndSendsKey(t *testing.T) {
 }
 
 func TestMTSFailedDetailDropsOnlyThatPosting(t *testing.T) {
-	fake := &mtsHTTP{
+	fake := &fakeMTS{
 		configHTML: mtsConfigHTML,
 		pages: map[int]string{
 			0: mtsListPage(1,
@@ -210,14 +200,14 @@ func TestMTSFailedDetailDropsOnlyThatPosting(t *testing.T) {
 
 func TestMTSHarvestFailureErrors(t *testing.T) {
 	// Config page without an apiKey → harvest fails → Fetch errors so the board is isolated.
-	fake := &mtsHTTP{configHTML: `<html><body><script>window.x=1</script></body></html>`}
+	fake := &fakeMTS{configHTML: `<html><body><script>window.x=1</script></body></html>`}
 	if _, err := NewMTS(fake).Fetch(context.Background(), CompanyEntry{Company: "MTS"}); err == nil {
 		t.Fatal("Fetch: want error when apiKey harvest fails, got nil")
 	}
 }
 
 func TestMTSEmptyListYieldsNoJobsNoError(t *testing.T) {
-	fake := &mtsHTTP{configHTML: mtsConfigHTML, pages: map[int]string{0: mtsListPage(0)}}
+	fake := &fakeMTS{configHTML: mtsConfigHTML, pages: map[int]string{0: mtsListPage(0)}}
 
 	jobs, err := NewMTS(fake).Fetch(context.Background(), CompanyEntry{Company: "MTS"})
 	if err != nil {

--- a/internal/sources/mtslink.go
+++ b/internal/sources/mtslink.go
@@ -11,7 +11,7 @@ import (
 // returns every vacancy with empty body fields, so each open vacancy's body comes from
 // its own detail request, fanned out like SmartRecruiters. Only OPEN vacancies are kept.
 type mtslink struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -23,7 +23,7 @@ const (
 )
 
 // NewMtslink builds the MTS Link adapter over the given HTTP client.
-func NewMtslink(c HTTPClient) Source { return mtslink{http: c} }
+func NewMtslink(c JSONGetter) Source { return mtslink{http: c} }
 
 func (mtslink) Provider() string { return "mtslink" }
 

--- a/internal/sources/ozon.go
+++ b/internal/sources/ozon.go
@@ -13,7 +13,7 @@ import (
 // like SmartRecruiters. Only external_vacancy items are real Ozon postings; the rest are
 // dropped.
 type ozon struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -25,7 +25,7 @@ const (
 )
 
 // NewOzon builds the Ozon adapter over the given HTTP client.
-func NewOzon(c HTTPClient) Source { return ozon{http: c} }
+func NewOzon(c JSONGetter) Source { return ozon{http: c} }
 
 func (ozon) Provider() string { return "ozon" }
 

--- a/internal/sources/personio.go
+++ b/internal/sources/personio.go
@@ -11,12 +11,18 @@ import (
 // publishes every open position in one document, with the body inline across one or
 // more jobDescription HTML values — so no per-posting detail request is needed. The
 // feed carries no posting URL, so the adapter builds one from the board and position id.
+// personioHTTP is the transport personio needs: an XML feed plus HTML detail pages.
+type personioHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
 type personio struct {
-	http HTTPClient
+	http personioHTTP
 }
 
 // NewPersonio builds the Personio adapter over the given HTTP client.
-func NewPersonio(c HTTPClient) Source { return personio{http: c} }
+func NewPersonio(c personioHTTP) Source { return personio{http: c} }
 
 func (personio) Provider() string { return "personio" }
 

--- a/internal/sources/pinpoint.go
+++ b/internal/sources/pinpoint.go
@@ -10,11 +10,11 @@ import (
 // HTML sections (description, responsibilities, skills, benefits), so no per-posting
 // detail request is needed.
 type pinpoint struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewPinpoint builds the Pinpoint adapter over the given HTTP client.
-func NewPinpoint(c HTTPClient) Source { return pinpoint{http: c} }
+func NewPinpoint(c JSONGetter) Source { return pinpoint{http: c} }
 
 func (pinpoint) Provider() string { return "pinpoint" }
 

--- a/internal/sources/recruitee.go
+++ b/internal/sources/recruitee.go
@@ -14,11 +14,11 @@ const recruiteeBaseURL = "https://%s.recruitee.com/api/offers/"
 // across separate description and requirements HTML fields, which the adapter combines,
 // so no per-posting detail request is needed.
 type recruitee struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewRecruitee builds the Recruitee adapter over the given HTTP client.
-func NewRecruitee(c HTTPClient) Source { return recruitee{http: c} }
+func NewRecruitee(c JSONGetter) Source { return recruitee{http: c} }
 
 func (recruitee) Provider() string { return "recruitee" }
 

--- a/internal/sources/rippling.go
+++ b/internal/sources/rippling.go
@@ -14,11 +14,11 @@ const (
 // description, so it fetches each posting's detail (bounded-concurrency) to assemble the
 // body, like the SmartRecruiters adapter.
 type rippling struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewRippling builds the Rippling adapter over the given HTTP client.
-func NewRippling(c HTTPClient) Source { return rippling{http: c} }
+func NewRippling(c JSONGetter) Source { return rippling{http: c} }
 
 func (rippling) Provider() string { return "rippling" }
 

--- a/internal/sources/rwb.go
+++ b/internal/sources/rwb.go
@@ -12,7 +12,7 @@ import (
 // city and employment types but no body, so each vacancy's description comes from its own
 // detail request, fanned out like SmartRecruiters.
 type rwb struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -23,7 +23,7 @@ const (
 )
 
 // NewRWB builds the Wildberries adapter over the given HTTP client.
-func NewRWB(c HTTPClient) Source { return rwb{http: c} }
+func NewRWB(c JSONGetter) Source { return rwb{http: c} }
 
 func (rwb) Provider() string { return "rwb" }
 

--- a/internal/sources/sber.go
+++ b/internal/sources/sber.go
@@ -11,7 +11,7 @@ import (
 // paginates by skip/take. Sber publishes for many employer entities (СберТех, etc.), so each
 // vacancy's own company is the employer, with the configured entry as a fallback.
 type sber struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -21,7 +21,7 @@ const (
 )
 
 // NewSber builds the Sber adapter over the given HTTP client.
-func NewSber(c HTTPClient) Source { return sber{http: c} }
+func NewSber(c JSONGetter) Source { return sber{http: c} }
 
 func (sber) Provider() string { return "sber" }
 

--- a/internal/sources/smartrecruiters.go
+++ b/internal/sources/smartrecruiters.go
@@ -18,11 +18,11 @@ const (
 // list endpoint carries no description, so it paginates the postings and fetches each
 // posting's detail (bounded-concurrency) to assemble the description.
 type smartRecruiters struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewSmartRecruiters builds the SmartRecruiters adapter over the given HTTP client.
-func NewSmartRecruiters(c HTTPClient) Source { return smartRecruiters{http: c} }
+func NewSmartRecruiters(c JSONGetter) Source { return smartRecruiters{http: c} }
 
 func (smartRecruiters) Provider() string { return "smartrecruiters" }
 

--- a/internal/sources/successfactors.go
+++ b/internal/sources/successfactors.go
@@ -11,12 +11,19 @@ import (
 // job page is server-rendered HTML carrying schema.org JobPosting microdata, so the
 // description comes from a per-job detail fetch (bounded-concurrency), like the other
 // detail-fetching adapters.
+// successfactorsHTTP is the transport successfactors needs: an XML sitemap plus HTML
+// detail pages.
+type successfactorsHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
 type successfactors struct {
-	http HTTPClient
+	http successfactorsHTTP
 }
 
 // NewSuccessFactors builds the SuccessFactors adapter over the given HTTP client.
-func NewSuccessFactors(c HTTPClient) Source { return successfactors{http: c} }
+func NewSuccessFactors(c successfactorsHTTP) Source { return successfactors{http: c} }
 
 func (successfactors) Provider() string { return "successfactors" }
 

--- a/internal/sources/tbank.go
+++ b/internal/sources/tbank.go
@@ -12,7 +12,7 @@ import (
 // and carries no body, so each vacancy's description comes from its own POST detail request,
 // fanned out like the other detail-fetching adapters. The "publisher" source covers all roles.
 type tbank struct {
-	http HTTPClient
+	http JSONPoster
 }
 
 const (
@@ -23,7 +23,7 @@ const (
 )
 
 // NewTBank builds the T-Bank adapter over the given HTTP client.
-func NewTBank(c HTTPClient) Source { return tbank{http: c} }
+func NewTBank(c JSONPoster) Source { return tbank{http: c} }
 
 func (tbank) Provider() string { return "tbank" }
 

--- a/internal/sources/tbank_test.go
+++ b/internal/sources/tbank_test.go
@@ -6,11 +6,9 @@ import (
 	"errors"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/html"
 )
 
-// tbankHTTP is a body-aware test HTTPClient for T-Bank: both the list and the detail are
+// tbankHTTP is a body-aware test JSONPoster for T-Bank: both the list and the detail are
 // POSTs to fixed URLs, distinguished by the request body. The list fake paginates on the
 // requested offset (page 1 → page 2, then isFinished); the detail fake routes the canned
 // description[] on the request's urlSlug. A urlSlug in failSlugs errors so detail-isolation
@@ -20,22 +18,6 @@ type tbankHTTP struct {
 	detail    map[string]string // urlSlug -> canned getVacancyDescription payload
 	failSlugs map[string]bool   // urlSlugs whose detail request errors
 	listCalls int               // number of getVacancies requests served (loop-termination guard)
-}
-
-func (f *tbankHTTP) GetJSON(context.Context, string, any) error {
-	return errors.New("tbankHTTP: unexpected GetJSON")
-}
-func (f *tbankHTTP) GetXML(context.Context, string, any) error {
-	return errors.New("tbankHTTP: unexpected GetXML")
-}
-func (f *tbankHTTP) GetHTML(context.Context, string) (*html.Node, error) {
-	return nil, errors.New("tbankHTTP: unexpected GetHTML")
-}
-func (f *tbankHTTP) GetJSONWithHeaders(context.Context, string, map[string]string, any) error {
-	return errors.New("tbankHTTP: unexpected GetJSONWithHeaders")
-}
-func (f *tbankHTTP) PostJSONWithHeaders(context.Context, string, map[string]string, any, any) error {
-	return errors.New("tbankHTTP: unexpected PostJSONWithHeaders")
 }
 
 func (f *tbankHTTP) PostJSON(_ context.Context, url string, body, v any) error {

--- a/internal/sources/teamtailor.go
+++ b/internal/sources/teamtailor.go
@@ -14,11 +14,11 @@ import (
 // server-rendered HTML carrying a schema.org JobPosting ld+json block, so the description
 // comes from a per-job detail fetch (bounded-concurrency), like the other detail adapters.
 type teamtailor struct {
-	http HTTPClient
+	http HTMLGetter
 }
 
 // NewTeamtailor builds the Teamtailor adapter over the given HTTP client.
-func NewTeamtailor(c HTTPClient) Source { return teamtailor{http: c} }
+func NewTeamtailor(c HTMLGetter) Source { return teamtailor{http: c} }
 
 func (teamtailor) Provider() string { return "teamtailor" }
 

--- a/internal/sources/vk.go
+++ b/internal/sources/vk.go
@@ -18,8 +18,14 @@ import (
 // details serially with a pause between requests (interval) to stay under the limit. A
 // posting that is still challenged keeps its list fields with an empty description rather
 // than being dropped, so the worst case is identical to no pacing — never a regression.
+// vkHTTP is the transport vk needs: a JSON listing plus HTML detail pages.
+type vkHTTP interface {
+	JSONGetter
+	HTMLGetter
+}
+
 type vk struct {
-	http     HTTPClient
+	http     vkHTTP
 	interval time.Duration
 }
 
@@ -31,10 +37,10 @@ const (
 )
 
 // NewVK builds the VK adapter over the given HTTP client.
-func NewVK(c HTTPClient) Source { return newVK(c, vkDetailInterval) }
+func NewVK(c vkHTTP) Source { return newVK(c, vkDetailInterval) }
 
 // newVK builds the adapter with an explicit detail-fetch pace, so tests can disable it.
-func newVK(c HTTPClient, interval time.Duration) vk { return vk{http: c, interval: interval} }
+func newVK(c vkHTTP, interval time.Duration) vk { return vk{http: c, interval: interval} }
 
 func (vk) Provider() string { return "vk" }
 

--- a/internal/sources/workable.go
+++ b/internal/sources/workable.go
@@ -11,11 +11,11 @@ const workableBaseURL = "https://apply.workable.com/api/v1/widget/accounts"
 // workable adapts the Workable public widget API. With details=true the list endpoint
 // carries an inline HTML description, so no per-posting detail request is needed.
 type workable struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 // NewWorkable builds the Workable adapter over the given HTTP client.
-func NewWorkable(c HTTPClient) Source { return workable{http: c} }
+func NewWorkable(c JSONGetter) Source { return workable{http: c} }
 
 func (workable) Provider() string { return "workable" }
 

--- a/internal/sources/workday.go
+++ b/internal/sources/workday.go
@@ -17,12 +17,18 @@ const (
 // the API tenant is the host's first label (here "ringcentral"). The listing endpoint
 // is POST-only and carries no description, so it pages the postings and fetches each
 // posting's detail (bounded-concurrency) to assemble the description.
+// workdayHTTP is the transport workday needs: a POST-only JSON listing plus JSON detail.
+type workdayHTTP interface {
+	JSONGetter
+	JSONPoster
+}
+
 type workday struct {
-	http HTTPClient
+	http workdayHTTP
 }
 
 // NewWorkday builds the Workday adapter over the given HTTP client.
-func NewWorkday(c HTTPClient) Source { return workday{http: c} }
+func NewWorkday(c workdayHTTP) Source { return workday{http: c} }
 
 func (workday) Provider() string { return "workday" }
 

--- a/internal/sources/yandex.go
+++ b/internal/sources/yandex.go
@@ -16,7 +16,7 @@ import (
 // fanned out like SmartRecruiters. List items that redirect out (redirect_url) or belong to
 // a hiring event (fast_track) are not real vacancies and are dropped.
 type yandex struct {
-	http HTTPClient
+	http JSONGetter
 }
 
 const (
@@ -26,7 +26,7 @@ const (
 )
 
 // NewYandex builds the Yandex adapter over the given HTTP client.
-func NewYandex(c HTTPClient) Source { return yandex{http: c} }
+func NewYandex(c JSONGetter) Source { return yandex{http: c} }
 
 func (yandex) Provider() string { return "yandex" }
 


### PR DESCRIPTION
## What

Splits the fat six-method `HTTPClient` interface in `internal/sources` into narrow capability roles (interface segregation), so each adapter — and each test fake — depends only on the transport it actually uses.

## Why

The single `HTTPClient` (GetJSON/GetXML/PostJSON/GetHTML/GetJSONWithHeaders/PostJSONWithHeaders) forced every adapter to depend on all six methods even when it used one. The pain showed up in tests: bespoke fakes (tbank, gem, mts) stubbed 5 methods with `unexpected …` errors just to satisfy the interface.

## How

- `http.go`: define six role interfaces — `JSONGetter`, `XMLGetter`, `HTMLGetter`, `JSONPoster`, `HeaderJSONGetter`, `HeaderJSONPoster` — and keep `HTTPClient` as their **composite** (embedding). `*Client`, `sources.All`, and `NewClient` are unchanged, so one client is still constructed and handed to every adapter; each adapter narrows it.
- 31 adapters narrowed to the role(s) they call: 22 -> `JSONGetter`, gem/tbank -> `JSONPoster`, teamtailor -> `HTMLGetter`. Multi-role adapters declare a small embedded interface at the point of use: breezy/vk (JSON+HTML), personio/successfactors (XML+HTML), workday (JSON+POST), mts (HTML+header-JSON).
- Shrank the three bespoke test fakes (gem, tbank, mts) to the methods their adapter calls; renamed the mts fake `mtsHTTP` -> `fakeMTS` to free the name for the new interface. Shared `fakeHTTP`/`routedHTTP` fakes are unchanged.

No behaviour change — pure refactor.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all green.
- Code review (high effort): 0 correctness findings.