### PR TITLE
test(db): fix telegram_posts queue integration test (nil links → SQL NULL)

### DIFF
--- a/internal/db/telegram_posts_integration_test.go
+++ b/internal/db/telegram_posts_integration_test.go
@@ -30,9 +30,13 @@ func insertPost(t *testing.T, q *Queries, channel string, msgID int64, extracted
 		extractedAt = pgtype.Timestamptz{Time: time.Now(), Valid: true}
 	}
 	_, err := q.InsertTelegramPost(context.Background(), InsertTelegramPostParams{
-		Channel:     channel,
-		MsgID:       msgID,
-		Text:        "We are hiring a Go engineer",
+		Channel: channel,
+		MsgID:   msgID,
+		Text:    "We are hiring a Go engineer",
+		// links is JSONB NOT NULL; the real caller (postStore.Insert) always passes
+		// a valid array, defaulting to "[]" for a linkless post — mirror that here so
+		// a nil []byte is not sent as SQL NULL.
+		Links:       []byte("[]"),
 		PostedAt:    pgtype.Timestamptz{Time: time.Now().Add(-time.Hour), Valid: true},
 		ExtractedAt: extractedAt,
 	})


### PR DESCRIPTION
## Summary
`go test -tags=integration ./internal/db/` failed every `TestTelegramPostsQueue` subtest with `null value in column "links" violates not-null constraint`.

**Root cause:** the `insertPost` test helper omitted `Links`, so `InsertTelegramPostParams.Links` was a nil `[]byte`, which pgx encodes as SQL **NULL** — violating `telegram_posts.links JSONB NOT NULL`. The column's `DEFAULT '[]'` does not apply because the `InsertTelegramPost` query lists `links` explicitly. The real production caller (`cmd/tg-ingest` `postStore.Insert`) always passes `[]byte("[]")` for a linkless post, so **production was never affected** — only the test bypassed that contract.

**Fix:** the helper now passes `Links: []byte("[]")`, mirroring the production caller.

## Test plan
- [x] `go test -tags=integration ./internal/db/ -run TestTelegramPostsQueue` — was failing, now passes
- [x] `go test -tags=integration ./internal/db/` — full suite green
- [x] `go build ./... && go vet ./... && go test ./...` — green

## Noted separately (NOT addressed here)
There are two migrations numbered `0010` (`0010_telegram_post_links.sql`, `0010_user_identities.sql`). Both apply on initdb (deterministic alphabetical order, no cross-dependency), so it is a cosmetic numbering collision, not a functional bug. Renumbering an already-applied migration is risky on persistent volumes (no versioned runner) and is left out of this surgical test fix.