### PR TITLE
build: ship backfill-skills and liveness worker binaries in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,14 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-ingest ./cmd/tg-ingest \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/tg-extract ./cmd/tg-extract \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reslug ./cmd/reslug \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-geo ./cmd/backfill-geo
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-geo ./cmd/backfill-geo \
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-skills ./cmd/backfill-skills \
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/liveness ./cmd/liveness
 
 # --- runtime stage ---
 FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /app
-COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-geo /app/
+COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-geo /out/backfill-skills /out/liveness /app/
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/app/hire"]


### PR DESCRIPTION
## Summary
`cmd/backfill-skills` (skill-tagging backfill) and `cmd/liveness` (orphan-job liveness) were merged but never added to the Dockerfile's build/COPY list, so the production image shipped without them:
- `backfill-skills` could not be run in prod (binary absent) — the deterministic `jobs.skills` column can't be backfilled for pre-existing jobs.
- `liveness` worker could not be scheduled — that feature is effectively undeployed.

This builds and copies both, matching the other workers (ingest/enrich/reindex/…).

## Test plan
- [x] `go build ./cmd/backfill-skills ./cmd/liveness`
- [x] `docker build --target build .` compiles all 10 binaries (incl. the two added)
- [ ] After deploy: `docker compose run --rm app /app/backfill-skills` runs; liveness cron has its binary