### PR TITLE
build: add backfill-class binary to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/reslug ./cmd/reslug \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-geo ./cmd/backfill-geo \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-skills ./cmd/backfill-skills \
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-class ./cmd/backfill-class \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/liveness ./cmd/liveness
 
 # --- runtime stage ---
 FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /app
-COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-geo /out/backfill-skills /out/liveness /app/
+COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-geo /out/backfill-skills /out/backfill-class /out/liveness /app/
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/app/hire"]


### PR DESCRIPTION
Follow-up to #57. The Dockerfile build list and runtime COPY were missing the new `cmd/backfill-class` binary (the deterministic classification backfill worker), so the compose `backfill-class` service would fail with no such file. Adds it next to backfill-geo/backfill-skills.