### PR TITLE
feat(moderation): real source + manually_added provenance flag

### DIFF
--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -618,7 +618,7 @@ SET title        = $1,
     category     = $13,
     updated_by   = $14::bigint,
     updated_at   = now()
-WHERE public_slug = $15 AND source = 'manual'
+WHERE public_slug = $15 AND created_by IS NOT NULL
 RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by
 `
 
@@ -641,8 +641,9 @@ type UpdateManualJobParams struct {
 }
 
 // Moderator edit of a hand-curated job, addressed by public_slug and scoped to
-// source = 'manual' so this path can never rewrite an ATS/telegram vacancy. The
-// partial merge (nil = unchanged) and facet re-derivation happen in the service; this
+// created_by IS NOT NULL so this path can only rewrite a moderator-authored posting,
+// never an automated-source (ingest/telegram) one — regardless of the declared source.
+// The partial merge (nil = unchanged) and facet re-derivation happen in the service; this
 // query writes the resulting full field set, so geography/skills/company_slug stay
 // consistent with the edited content. The source identity (url/external_id/public_slug)
 // is deliberately NOT updatable here. The company row is upserted when a slug is present,
@@ -836,8 +837,8 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (Job, erro
 const upsertManualJob = `-- name: UpsertManualJob :one
 WITH company_upsert AS (
     INSERT INTO companies (slug, name)
-    SELECT $5, $4
-    WHERE $5 <> ''
+    SELECT $6, $5
+    WHERE $6 <> ''
     ON CONFLICT (slug) DO UPDATE SET
         name       = EXCLUDED.name,
         updated_at = now()
@@ -846,13 +847,13 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category, created_by
 ) VALUES (
-    'manual', $1, $2, $3,
-    $4, $5, $6, $7,
-    $8, $9,
-    $10,
-    COALESCE($11::text[], '{}'), COALESCE($12::text[], '{}'),
-    $13, COALESCE($14::text[], '{}'),
-    $15, $16, $17::bigint
+    $1, $2, $3, $4,
+    $5, $6, $7, $8,
+    $9, $10,
+    $11,
+    COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'),
+    $14, COALESCE($15::text[], '{}'),
+    $16, $17, $18::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -869,13 +870,14 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     skills       = EXCLUDED.skills,
     seniority    = EXCLUDED.seniority,
     category     = EXCLUDED.category,
-    updated_by   = $18::bigint,
+    updated_by   = $19::bigint,
     closed_at    = NULL,
     updated_at   = now()
 RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by
 `
 
 type UpsertManualJobParams struct {
+	Source      string             `json:"source"`
 	ExternalID  string             `json:"external_id"`
 	URL         string             `json:"url"`
 	Title       string             `json:"title"`
@@ -896,15 +898,19 @@ type UpsertManualJobParams struct {
 	UpdatedBy   int64              `json:"updated_by"`
 }
 
-// Moderator-authored write: the manual-source analogue of UpsertJob. source is fixed
-// to 'manual' and the dedup key is (source, external_id = url), so re-POSTing the same
-// URL updates the row idempotently instead of duplicating it. created_by is stamped
-// once at insert; updated_by is (re)written on the conflict update. Like UpsertJob,
-// public_slug is minted once and never rewritten, and the enrichment columns are left
-// to SetJobEnrichment. The conflict reopens a previously closed posting (closed_at =
-// NULL) since the moderator is re-asserting it.
+// Moderator-authored write: the hand-curated analogue of UpsertJob. source is the
+// posting's real origin (e.g. 'workatastartup'), supplied by the moderator and
+// defaulting to 'manual'; the dedup key is (source, external_id = url), so re-POSTing
+// the same URL updates the row idempotently instead of duplicating it. The manual
+// provenance is recorded by created_by (set here, NULL for every automated source) —
+// not by the source value. created_by is stamped once at insert; updated_by is
+// (re)written on the conflict update. Like UpsertJob, public_slug is minted once and
+// never rewritten, and the enrichment columns are left to SetJobEnrichment. The conflict
+// reopens a previously closed posting (closed_at = NULL) since the moderator is
+// re-asserting it.
 func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams) (Job, error) {
 	row := q.db.QueryRow(ctx, upsertManualJob,
+		arg.Source,
 		arg.ExternalID,
 		arg.URL,
 		arg.Title,

--- a/internal/db/jobs_moderation_integration_test.go
+++ b/internal/db/jobs_moderation_integration_test.go
@@ -1,8 +1,9 @@
 //go:build integration
 
-// Integration tests for the moderator-authored write path's SQL contract: the manual
-// upsert dedups on the URL and records authorship, a manual job enqueues for enrichment,
-// and the edit query is scoped to source='manual' so it can never touch another source.
+// Integration tests for the moderator-authored write path's SQL contract: the upsert
+// dedups on (source, URL) and records authorship, a manual job enqueues for enrichment,
+// and the edit query is scoped to created_by IS NOT NULL so it can only touch a
+// moderator-authored posting, never an automated source.
 // Run with: go test -tags=integration ./internal/db/
 package db
 
@@ -16,6 +17,7 @@ import (
 
 func manualParams(url, title string, createdBy, updatedBy int64) UpsertManualJobParams {
 	return UpsertManualJobParams{
+		Source:      "manual",
 		ExternalID:  url,
 		URL:         url,
 		Title:       title,
@@ -100,7 +102,7 @@ func updateManualParams(slug, title string, updatedBy int64) UpdateManualJobPara
 	}
 }
 
-func TestUpdateManualJobIsManualScoped(t *testing.T) {
+func TestUpdateManualJobScopedByCreatedBy(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
 	ctx := context.Background()
@@ -126,13 +128,14 @@ func TestUpdateManualJobIsManualScoped(t *testing.T) {
 		t.Errorf("UpdatedBy = %+v, want %d", updated.UpdatedBy, editor)
 	}
 
-	// A non-manual (ingested) job is invisible to the manual update — no row matches the
-	// source='manual' scope, so the moderator path can never rewrite an ATS vacancy.
+	// An automated-source (ingested) job has created_by NULL, so it is invisible to the
+	// moderator update — no row matches the created_by IS NOT NULL scope, and the moderator
+	// path can never rewrite an ATS vacancy.
 	ats, err := q.UpsertJob(ctx, ingestParams("gh:1", "ATS Job"))
 	if err != nil {
 		t.Fatalf("create ats: %v", err)
 	}
 	if _, err := q.UpdateManualJob(ctx, updateManualParams(ats.PublicSlug, "Hijacked", editor)); !errors.Is(err, pgx.ErrNoRows) {
-		t.Errorf("update of a non-manual job: err = %v, want pgx.ErrNoRows", err)
+		t.Errorf("update of an automated-source job: err = %v, want pgx.ErrNoRows", err)
 	}
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -205,8 +205,9 @@ type Querier interface {
 	// from the row's immutable fields, so recomputing and rewriting them is idempotent.
 	UpdateJobSlugs(ctx context.Context, arg UpdateJobSlugsParams) error
 	// Moderator edit of a hand-curated job, addressed by public_slug and scoped to
-	// source = 'manual' so this path can never rewrite an ATS/telegram vacancy. The
-	// partial merge (nil = unchanged) and facet re-derivation happen in the service; this
+	// created_by IS NOT NULL so this path can only rewrite a moderator-authored posting,
+	// never an automated-source (ingest/telegram) one — regardless of the declared source.
+	// The partial merge (nil = unchanged) and facet re-derivation happen in the service; this
 	// query writes the resulting full field set, so geography/skills/company_slug stay
 	// consistent with the edited content. The source identity (url/external_id/public_slug)
 	// is deliberately NOT updatable here. The company row is upserted when a slug is present,
@@ -231,13 +232,16 @@ type Querier interface {
 	// (source, external_id) must not rewrite it, so external links stay valid even
 	// if the slug builder changes later (that would be a deliberate migration).
 	UpsertJob(ctx context.Context, arg UpsertJobParams) (Job, error)
-	// Moderator-authored write: the manual-source analogue of UpsertJob. source is fixed
-	// to 'manual' and the dedup key is (source, external_id = url), so re-POSTing the same
-	// URL updates the row idempotently instead of duplicating it. created_by is stamped
-	// once at insert; updated_by is (re)written on the conflict update. Like UpsertJob,
-	// public_slug is minted once and never rewritten, and the enrichment columns are left
-	// to SetJobEnrichment. The conflict reopens a previously closed posting (closed_at =
-	// NULL) since the moderator is re-asserting it.
+	// Moderator-authored write: the hand-curated analogue of UpsertJob. source is the
+	// posting's real origin (e.g. 'workatastartup'), supplied by the moderator and
+	// defaulting to 'manual'; the dedup key is (source, external_id = url), so re-POSTing
+	// the same URL updates the row idempotently instead of duplicating it. The manual
+	// provenance is recorded by created_by (set here, NULL for every automated source) —
+	// not by the source value. created_by is stamped once at insert; updated_by is
+	// (re)written on the conflict update. Like UpsertJob, public_slug is minted once and
+	// never rewritten, and the enrichment columns are left to SetJobEnrichment. The conflict
+	// reopens a previously closed posting (closed_at = NULL) since the moderator is
+	// re-asserting it.
 	UpsertManualJob(ctx context.Context, arg UpsertManualJobParams) (Job, error)
 }
 

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -105,13 +105,16 @@ ON CONFLICT (source, external_id) DO UPDATE SET
 RETURNING *;
 
 -- name: UpsertManualJob :one
--- Moderator-authored write: the manual-source analogue of UpsertJob. source is fixed
--- to 'manual' and the dedup key is (source, external_id = url), so re-POSTing the same
--- URL updates the row idempotently instead of duplicating it. created_by is stamped
--- once at insert; updated_by is (re)written on the conflict update. Like UpsertJob,
--- public_slug is minted once and never rewritten, and the enrichment columns are left
--- to SetJobEnrichment. The conflict reopens a previously closed posting (closed_at =
--- NULL) since the moderator is re-asserting it.
+-- Moderator-authored write: the hand-curated analogue of UpsertJob. source is the
+-- posting's real origin (e.g. 'workatastartup'), supplied by the moderator and
+-- defaulting to 'manual'; the dedup key is (source, external_id = url), so re-POSTing
+-- the same URL updates the row idempotently instead of duplicating it. The manual
+-- provenance is recorded by created_by (set here, NULL for every automated source) —
+-- not by the source value. created_by is stamped once at insert; updated_by is
+-- (re)written on the conflict update. Like UpsertJob, public_slug is minted once and
+-- never rewritten, and the enrichment columns are left to SetJobEnrichment. The conflict
+-- reopens a previously closed posting (closed_at = NULL) since the moderator is
+-- re-asserting it.
 WITH company_upsert AS (
     INSERT INTO companies (slug, name)
     SELECT sqlc.arg(company_slug), sqlc.arg(company)
@@ -124,7 +127,7 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category, created_by
 ) VALUES (
-    'manual', sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
+    sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
     sqlc.arg(company), sqlc.arg(company_slug), sqlc.arg(location), sqlc.arg(remote),
     sqlc.arg(description), sqlc.arg(posted_at),
     sqlc.arg(public_slug),
@@ -154,8 +157,9 @@ RETURNING *;
 
 -- name: UpdateManualJob :one
 -- Moderator edit of a hand-curated job, addressed by public_slug and scoped to
--- source = 'manual' so this path can never rewrite an ATS/telegram vacancy. The
--- partial merge (nil = unchanged) and facet re-derivation happen in the service; this
+-- created_by IS NOT NULL so this path can only rewrite a moderator-authored posting,
+-- never an automated-source (ingest/telegram) one — regardless of the declared source.
+-- The partial merge (nil = unchanged) and facet re-derivation happen in the service; this
 -- query writes the resulting full field set, so geography/skills/company_slug stay
 -- consistent with the edited content. The source identity (url/external_id/public_slug)
 -- is deliberately NOT updatable here. The company row is upserted when a slug is present,
@@ -188,7 +192,7 @@ SET title        = sqlc.arg(title),
     category     = sqlc.arg(category),
     updated_by   = sqlc.arg(updated_by)::bigint,
     updated_at   = now()
-WHERE public_slug = sqlc.arg(public_slug) AND source = 'manual'
+WHERE public_slug = sqlc.arg(public_slug) AND created_by IS NOT NULL
 RETURNING *;
 
 -- name: CloseUnseenJobs :execrows

--- a/internal/handler/jobs_moderation.go
+++ b/internal/handler/jobs_moderation.go
@@ -12,10 +12,12 @@ import (
 )
 
 // createJobRequest is the moderator create-job body. url/title/company are required
-// (validated by the service); remote defaults to false when absent; posted_at is an
-// optional RFC3339 timestamp.
+// (validated by the service); source is the posting's real origin (defaults to "manual"
+// when absent); remote defaults to false when absent; posted_at is an optional RFC3339
+// timestamp.
 type createJobRequest struct {
 	URL         string     `json:"url"`
+	Source      string     `json:"source"`
 	Title       string     `json:"title"`
 	Company     string     `json:"company"`
 	Location    string     `json:"location"`
@@ -65,6 +67,7 @@ func (h *Handler) CreateJob(c *fiber.Ctx) error {
 
 	job, err := h.moderation.Create(c.Context(), actorID, moderation.CreateInput{
 		URL:         in.URL,
+		Source:      in.Source,
 		Title:       in.Title,
 		Company:     in.Company,
 		Location:    in.Location,

--- a/internal/jobview/audit_test.go
+++ b/internal/jobview/audit_test.go
@@ -30,4 +30,19 @@ func TestFromRow_OmitsAuthorshipAudit(t *testing.T) {
 	if s := string(b); strings.Contains(s, "created_by") || strings.Contains(s, "updated_by") {
 		t.Errorf("wire shape leaks authorship audit: %s", s)
 	}
+	// created_by is set → the posting is flagged manually added (the provenance signal).
+	if !view.ManuallyAdded {
+		t.Error("ManuallyAdded = false, want true when created_by is set")
+	}
+}
+
+// An automated-source job (created_by NULL) is not flagged manually added.
+func TestFromRow_ManuallyAddedFalseForAutomated(t *testing.T) {
+	view, err := FromRow(db.Job{ID: 2, Title: "Dev", PublicSlug: "dev-2", Source: "greenhouse"})
+	if err != nil {
+		t.Fatalf("FromRow: %v", err)
+	}
+	if view.ManuallyAdded {
+		t.Error("ManuallyAdded = true, want false for an automated source (no created_by)")
+	}
 }

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -25,9 +25,14 @@ import (
 // it as `{}`. Timestamps are RFC3339 UTC strings (or null) — the lexicographic
 // order is chronological, which the search index relies on for sorting.
 type Job struct {
-	PublicSlug  string `json:"public_slug"`
-	Source      string `json:"source"`
-	ExternalID  string `json:"external_id"`
+	PublicSlug string `json:"public_slug"`
+	Source     string `json:"source"`
+	// ManuallyAdded marks a hand-curated posting added by a moderator (created_by is
+	// set), as opposed to an automated source. It is the provenance signal, decoupled
+	// from Source (which is the real origin); the authoring user id itself is internal
+	// and never exposed.
+	ManuallyAdded bool   `json:"manually_added"`
+	ExternalID    string `json:"external_id"`
 	URL         string `json:"url"`
 	Title       string `json:"title"`
 	Company     string `json:"company"`
@@ -92,6 +97,7 @@ func FromRow(j db.Job) (Job, error) {
 	return Job{
 		PublicSlug:        j.PublicSlug,
 		Source:            j.Source,
+		ManuallyAdded:     j.CreatedBy.Valid,
 		ExternalID:        j.ExternalID,
 		URL:               j.URL,
 		Title:             j.Title,

--- a/internal/moderation/moderation.go
+++ b/internal/moderation/moderation.go
@@ -30,14 +30,17 @@ var (
 	ErrJobNotFound = errors.New("moderation: job not found")
 )
 
-// manualSource is the fixed source identity for moderator-authored jobs; the URL is the
-// external id, so re-creating the same URL is an idempotent upsert.
-const manualSource = "manual"
+// defaultSource is the origin recorded when the moderator does not name one. The URL is
+// the external id, so re-creating the same URL under the same source is an idempotent
+// upsert. Manual provenance is tracked by created_by, not by this value.
+const defaultSource = "manual"
 
 // CreateInput is the moderator-supplied content for a new vacancy. URL (the dedup key),
-// Title, and Company are required; the rest is optional.
+// Title, and Company are required; the rest is optional. Source is the posting's real
+// origin (e.g. "workatastartup"); empty defaults to "manual".
 type CreateInput struct {
 	URL         string
+	Source      string
 	Title       string
 	Company     string
 	Location    string
@@ -58,8 +61,8 @@ type UpdatePatch struct {
 }
 
 // Repository is the persistence contract. Create runs the upsert and enrichment enqueue
-// atomically; BySlug loads a manual job (ErrJobNotFound when missing or not manual);
-// Update writes the full resulting row, scoped to the manual source.
+// atomically; BySlug loads a moderator-authored job (ErrJobNotFound when missing or not
+// moderator-created); Update writes the full resulting row, scoped to created_by IS NOT NULL.
 type Repository interface {
 	Create(ctx context.Context, p db.UpsertManualJobParams) (db.Job, error)
 	BySlug(ctx context.Context, slug string) (db.Job, error)
@@ -84,16 +87,21 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 	if err := in.validate(); err != nil {
 		return db.Job{}, err
 	}
+	source := strings.TrimSpace(in.Source)
+	if source == "" {
+		source = defaultSource
+	}
 	d := jobderive.Derive(jobderive.Input{
 		Title:       in.Title,
 		Company:     in.Company,
-		Source:      manualSource,
+		Source:      source,
 		ExternalID:  in.URL,
 		Location:    in.Location,
 		Description: in.Description,
 		WorkMode:    remoteWorkMode(in.Remote),
 	})
 	return s.repo.Create(ctx, db.UpsertManualJobParams{
+		Source:      source,
 		ExternalID:  in.URL,
 		URL:         in.URL,
 		Title:       in.Title,
@@ -119,7 +127,7 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 // re-derives the deterministic facets from the merged content — so editing the location,
 // description, or company keeps geography/skills/company-slug consistent. The source
 // identity (url/external_id/public_slug) is never recomputed, keeping the public slug
-// stable. A missing or non-manual slug surfaces ErrJobNotFound.
+// stable. A missing or non-moderator-created slug surfaces ErrJobNotFound.
 func (s *Service) Update(ctx context.Context, actorID int64, slug string, p UpdatePatch) (db.Job, error) {
 	if err := p.validate(); err != nil {
 		return db.Job{}, err
@@ -142,11 +150,12 @@ func (s *Service) Update(ctx context.Context, actorID int64, slug string, p Upda
 		postedAt = toTimestamptz(p.PostedAt)
 	}
 
-	// External id stays the create-time identity; only the dictionary facets re-derive.
+	// External id and source stay the create-time identity; only the dictionary facets
+	// re-derive (the recomputed public slug is discarded — identity is immutable).
 	d := jobderive.Derive(jobderive.Input{
 		Title:       title,
 		Company:     company,
-		Source:      manualSource,
+		Source:      cur.Source,
 		ExternalID:  cur.ExternalID,
 		Location:    location,
 		Description: description,

--- a/internal/moderation/moderation_test.go
+++ b/internal/moderation/moderation_test.go
@@ -75,6 +75,30 @@ func TestCreate_DerivesAndPersists(t *testing.T) {
 	if got.CreatedBy != 7 || got.UpdatedBy != 7 {
 		t.Errorf("audit = created %d / updated %d, want both 7", got.CreatedBy, got.UpdatedBy)
 	}
+	if got.Source != "manual" {
+		t.Errorf("Source = %q, want manual (default when none given)", got.Source)
+	}
+}
+
+func TestCreate_SourceIsRecordedAndSlugsFromIt(t *testing.T) {
+	repo := &fakeRepo{}
+	const url = "https://www.workatastartup.com/jobs/96572"
+	_, err := moderation.New(repo).Create(context.Background(), 7, moderation.CreateInput{
+		URL:     url,
+		Source:  "workatastartup",
+		Title:   "Senior Frontend Engineer",
+		Company: "Dalus",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if repo.created.Source != "workatastartup" {
+		t.Errorf("Source = %q, want workatastartup", repo.created.Source)
+	}
+	// The public slug is minted from the real source, not the literal "manual".
+	if want := normalize.JobSlug("Senior Frontend Engineer", "Dalus", "workatastartup", url); repo.created.PublicSlug != want {
+		t.Errorf("PublicSlug = %q, want %q", repo.created.PublicSlug, want)
+	}
 }
 
 func TestCreate_ValidationRejects(t *testing.T) {

--- a/internal/moderation/repository.go
+++ b/internal/moderation/repository.go
@@ -56,8 +56,8 @@ func (r *QueriesRepository) Create(ctx context.Context, p db.UpsertManualJobPara
 }
 
 // BySlug loads a job by its public slug, returning ErrJobNotFound when no job matches or
-// the matched job is not a manual one — so the edit path can never touch an ATS/telegram
-// vacancy.
+// the matched job was not moderator-authored (created_by IS NULL) — so the edit path can
+// never touch an automated-source (ATS/telegram) vacancy, whatever its declared source.
 func (r *QueriesRepository) BySlug(ctx context.Context, slug string) (db.Job, error) {
 	job, err := r.q.GetJobBySlug(ctx, slug)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -66,14 +66,15 @@ func (r *QueriesRepository) BySlug(ctx context.Context, slug string) (db.Job, er
 	if err != nil {
 		return db.Job{}, err
 	}
-	if job.Source != manualSource {
+	if !job.CreatedBy.Valid {
 		return db.Job{}, ErrJobNotFound
 	}
 	return job, nil
 }
 
-// Update writes the full resulting row for a manual job. The query's source scope means a
-// missing or non-manual slug affects no row (ErrNoRows → ErrJobNotFound).
+// Update writes the full resulting row for a moderator-authored job. The query's
+// created_by scope means a missing or non-moderator-created slug affects no row
+// (ErrNoRows → ErrJobNotFound).
 func (r *QueriesRepository) Update(ctx context.Context, p db.UpdateManualJobParams) (db.Job, error) {
 	job, err := r.q.UpdateManualJob(ctx, p)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -195,6 +195,9 @@
             {job.source}
           </Badge>
         </a>
+        {#if job.manually_added}
+          <Badge variant="secondary">Manually added</Badge>
+        {/if}
         {#if posted}<span class="text-xs text-muted-foreground">Posted {posted}</span>{/if}
       </div>
     </div>

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -63,6 +63,13 @@ export interface Enrichment {
 export interface Job {
   public_slug: string;
   source: string;
+  /**
+   * ManuallyAdded marks a hand-curated posting added by a moderator (created_by is
+   * set), as opposed to an automated source. It is the provenance signal, decoupled
+   * from Source (which is the real origin); the authoring user id itself is internal
+   * and never exposed.
+   */
+  manually_added: boolean;
   external_id: string;
   url: string;
   title: string;


### PR DESCRIPTION
Follow-up to #59: a moderator-added posting that originates elsewhere (e.g. workatastartup) should record its **real source**, while the *manual* provenance is read from `created_by` (already set only on the moderator path) — not by overloading `source='manual'`.

- `source` is moderator-supplied (`--source`), defaults to `manual`; the public slug mints from the real source.
- Edit scope moves from `WHERE source='manual'` to **`WHERE created_by IS NOT NULL`** — a moderator edits only their own postings, never an automated source, regardless of declared origin (security invariant preserved, decoupled from the magic value). `moderation.Repository.BySlug` guards on `created_by` too.
- Wire shape gains `manually_added: bool` (= `created_by IS NOT NULL`); the user id stays internal. SPA shows the real source badge + a "Manually added" badge.
- No schema migration (created_by is the marker; source is already free-text). Contracts regenerated.

## Test Plan
- [x] `go build/vet/test ./...`
- [x] integration: upsert dedups on (source,url) + audit; UpdateManualJob scoped by created_by (automated-source job → no row); handler e2e
- [x] unit: source recorded + slug from real source; manually_added true/false; validation
- [x] `svelte-check` 0 errors