### PR TITLE
web: neutral drag drop-target frame + monochrome note icon on My jobs board

### DIFF
--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -24,7 +24,20 @@
       <Badge variant="secondary">{humanizeStage(item.stage)}</Badge>
     {/if}
     {#if hasNotes}
-      <span class="text-xs text-muted-foreground" title="Has notes" aria-label="Has notes">📝</span>
+      <svg
+        class="size-3 shrink-0 text-muted-foreground"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        role="img"
+        aria-label="Has notes"
+      >
+        <title>Has notes</title>
+        <path d="M8 7h8M8 12h8M8 17h5" />
+      </svg>
     {/if}
   </span>
 </button>

--- a/web/src/lib/components/BoardColumn.svelte
+++ b/web/src/lib/components/BoardColumn.svelte
@@ -21,6 +21,10 @@
     // which satisfies MyJob. The parent can widen back to BoardItem via cast.
     onopen: (item: MyJob) => void;
   } = $props();
+
+  // Neutral drop-target frame — overrides svelte-dnd-action's default yellow
+  // outline, which clashes with the monochrome palette.
+  const dropTargetStyle = { outline: '2px solid var(--ring)', borderRadius: 'var(--radius-md)' };
 </script>
 
 <section class="flex w-72 shrink-0 flex-col gap-2 rounded-xl bg-secondary/40 p-2">
@@ -30,7 +34,7 @@
   </header>
   <div
     class="flex min-h-24 flex-col gap-2"
-    use:dndzone={{ items, flipDurationMs: 150, type: 'board' }}
+    use:dndzone={{ items, flipDurationMs: 150, type: 'board', dropTargetStyle }}
     onconsider={(e) => onconsider(id, e.detail.items as BoardItem[])}
     onfinalize={(e) => onfinalize(id, e.detail.items as BoardItem[])}
   >


### PR DESCRIPTION
## Summary
Two small visual fixes on the `/my/jobs` Kanban board (the board feature itself already landed via #61):

- **Drag drop-target frame** no longer uses svelte-dnd-action's default yellow outline — replaced with a neutral `--ring` frame matching the monochrome palette.
- **Note indicator** on cards: the colored 📝 emoji is replaced with a clean monochrome inline-SVG "note lines" icon (12px, `muted-foreground`), keeping the same hover tooltip + accessible label.

## Test plan
- `svelte-check` clean (0 errors / 0 warnings).
- Verified live on a 390px mobile viewport: board scrolls horizontally, drawer renders as a bottom sheet, both tweaks render correctly.
- Drag border color only manifests during an active drag (CSS via `dropTargetStyle`).