### PR TITLE
web: fix companies search input reverting on each keystroke

### DIFF
--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -52,15 +52,21 @@
   }
 
   // Browser back/forward changes the URL externally — pull it into q and
-  // re-query. No-ops on initial mount (q is seeded from the same URL) and while
-  // typing (search() already synced the URL), so it fires only on real navigation.
+  // re-query. Track *only* the URL: reading q reactively here would also fire the
+  // effect on our own search()/replaceState write, against a page.url that hasn't
+  // updated yet (it propagates a tick later), reverting the just-typed value. So
+  // read q under untrack — the effect runs only on real URL changes, when page.url
+  // is current, and no-ops on initial mount (q is seeded from the same URL).
   $effect(() => {
-    const urlQ = page.url.searchParams.get('q') ?? '';
-    if (urlQ !== q) {
-      q = urlQ;
-      clearTimeout(timer);
-      reload();
-    }
+    page.url.search; // track
+    untrack(() => {
+      const urlQ = page.url.searchParams.get('q') ?? '';
+      if (urlQ !== q) {
+        q = urlQ;
+        clearTimeout(timer);
+        reload();
+      }
+    });
   });
 </script>
 


### PR DESCRIPTION
## Problem

On `/companies?q=…` the search field accepted no input — every keystroke was instantly reverted.

## Cause

The back/forward sync `$effect` in `CompaniesView.svelte` read `q` reactively in its `urlQ !== q` condition, so it also fired on our own `search()`/`replaceState` write. `replaceState` updates `page.url` a tick later, so at that moment `urlQ` still held the old text while `q` held the new one → the effect reset `q` back. Each typed character was wiped.

## Fix

Track only `page.url.search` and read `q` under `untrack` — the same proven pattern already used in `JobsView.svelte`. The effect now runs only on real URL navigation (back/forward), when `page.url` is current, and never on our own write.

## Verification

`npm run check` (svelte-check): 0 errors, 0 warnings.