### PR TITLE
chore: workatastartup in Source filter vocab

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -135,10 +135,11 @@ func skipPreamble(lines []string) int {
 }
 
 // genVocab emits every closed vocabulary. Source = non-boardless providers plus the
-// literal "telegram" set by the tg-extract worker. Stages from userjob; the rest from
-// the enrich controlled vocabularies.
+// non-adapter sources set by other writers: "telegram" (the tg-extract worker) and
+// "workatastartup" (the moderator/bulk import). Stages from userjob; the rest from the
+// enrich controlled vocabularies.
 func genVocab() string {
-	source := append([]string{"telegram"}, sources.FilterableProviders()...)
+	source := append([]string{"telegram", "workatastartup"}, sources.FilterableProviders()...)
 
 	var b strings.Builder
 	b.WriteString(emitVocab("Source", "SOURCE_VALUES", source))

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -102,7 +102,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'ashby', 'bamboohr', 'breezy', 'gem', 'greenhouse', 'huntflow', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'workable', 'workday'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'ashby', 'bamboohr', 'breezy', 'gem', 'greenhouse', 'huntflow', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'workable', 'workday'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
Adds `workatastartup` to the generated `SOURCE_VALUES` (alongside `telegram`) so the SPA Source filter shows a pill for it. `source` is already a filterable Meili attribute; this just surfaces the closed-vocab pill. Pairs with the bulk import of workatastartup postings.