### PR TITLE
feat(web): dim already-viewed jobs in the browse list

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -125,6 +125,12 @@ type Querier interface {
 	// the passive history (rows neither saved nor applied). Closed jobs stay
 	// listed: a user's history must not shrink when a posting closes.
 	ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error)
+	// Every public_slug the user has interacted with (viewed_at is always set, so
+	// any interaction row counts as viewed). Used by the SPA to dim already-seen
+	// cards in the browse list without authenticating the public job-read path.
+	// Closed jobs are included: dimming a closed posting that still shows in a
+	// history surface is correct, and the browse list filters closed jobs itself.
+	ListViewedJobSlugs(ctx context.Context, userID int64) ([]string, error)
 	// Mark a job as applied for a user. Idempotent and independent of a prior view:
 	// it inserts the row (viewed_at defaults) or updates applied_at in place, and
 	// seeds stage='applied' only when the stage is unset (an advanced stage survives

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -81,6 +81,17 @@ WHERE uj.user_id = $1
 ORDER BY GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at) DESC, uj.job_id DESC
 LIMIT $2 OFFSET $3;
 
+-- name: ListViewedJobSlugs :many
+-- Every public_slug the user has interacted with (viewed_at is always set, so
+-- any interaction row counts as viewed). Used by the SPA to dim already-seen
+-- cards in the browse list without authenticating the public job-read path.
+-- Closed jobs are included: dimming a closed posting that still shows in a
+-- history surface is correct, and the browse list filters closed jobs itself.
+SELECT jobs.public_slug
+FROM user_jobs uj
+JOIN jobs ON jobs.id = uj.job_id
+WHERE uj.user_id = $1;
+
 -- name: CountUserJobs :one
 -- Per-filter row counts for the my-jobs tabs, in one aggregate pass. "all" is
 -- every interaction row; "viewed" is the view-only subset (neither saved nor

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -172,6 +172,38 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 	return items, nil
 }
 
+const listViewedJobSlugs = `-- name: ListViewedJobSlugs :many
+SELECT jobs.public_slug
+FROM user_jobs uj
+JOIN jobs ON jobs.id = uj.job_id
+WHERE uj.user_id = $1
+`
+
+// Every public_slug the user has interacted with (viewed_at is always set, so
+// any interaction row counts as viewed). Used by the SPA to dim already-seen
+// cards in the browse list without authenticating the public job-read path.
+// Closed jobs are included: dimming a closed posting that still shows in a
+// history surface is correct, and the browse list filters closed jobs itself.
+func (q *Queries) ListViewedJobSlugs(ctx context.Context, userID int64) ([]string, error) {
+	rows, err := q.db.Query(ctx, listViewedJobSlugs, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var public_slug string
+		if err := rows.Scan(&public_slug); err != nil {
+			return nil, err
+		}
+		items = append(items, public_slug)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markJobApplied = `-- name: MarkJobApplied :one
 INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
 VALUES ($1, $2, now(), 'applied')

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -144,8 +144,11 @@ func Register(app *fiber.App, cfg Config) {
 	api.Patch("/jobs/:slug", keyAuth, requireModerator, a.UpdateJob)
 
 	// User-scoped reads live under /me (consistent with /auth/me): the my-jobs
-	// listing joins the caller's interactions with the jobs they touch.
+	// listing joins the caller's interactions with the jobs they touch, and the
+	// viewed-slugs set lets the SPA dim already-seen cards in the public browse
+	// list without making that list authenticated.
 	api.Get("/me/jobs", keyAuth, a.ListMyJobs)
+	api.Get("/me/jobs/viewed", keyAuth, a.ListViewedSlugs)
 
 	// API-key management is cookie-only (RequireAuth): a leaked key must not be
 	// able to create, list, or revoke keys. The create endpoint returns the

--- a/internal/handler/me_jobs.go
+++ b/internal/handler/me_jobs.go
@@ -101,3 +101,23 @@ func (a *API) ListMyJobs(c *fiber.Ctx) error {
 		},
 	})
 }
+
+// ListViewedSlugs returns the set of public job slugs the authenticated caller
+// has interacted with (every user_jobs row counts as viewed). The SPA reads this
+// to dim already-seen cards in the browse list and search results without
+// authenticating the public job-read path — viewed state is cross-referenced
+// client-side, never joined into ListJobs/SearchJobs. The response is a flat
+// {"data": [slug, ...]} list scoped to the caller.
+func (a *API) ListViewedSlugs(c *fiber.Ctx) error {
+	userID, ok := auth.UserID(c)
+	if !ok {
+		return fiber.NewError(fiber.StatusUnauthorized, "unauthorized")
+	}
+
+	slugs, err := a.queries.ListViewedJobSlugs(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{"data": slugs})
+}

--- a/internal/handler/me_viewed_integration_test.go
+++ b/internal/handler/me_viewed_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+// Integration test for the viewed-slugs wire contract: GET /api/v1/me/jobs/viewed
+// must return exactly the public_slugs the authenticated caller has interacted
+// with, scoped to that caller, as a flat {"data": [...]} list, and reject an
+// unauthenticated request. The SPA reads this to dim already-seen cards without
+// authenticating the public job-read path. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestListViewedSlugsEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	seedUser := func(t *testing.T, email string) int64 {
+		t.Helper()
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+			t.Fatalf("seed user %q: %v", email, err)
+		}
+		return id
+	}
+	seedJob := func(t *testing.T, ext string) int64 {
+		t.Helper()
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug)
+			 VALUES ('test', $1, 'http://example.test', 'Job ' || $1, 'job-' || $1)
+			 RETURNING id`, ext).Scan(&id); err != nil {
+			t.Fatalf("seed job %q: %v", ext, err)
+		}
+		return id
+	}
+
+	viewer := seedUser(t, "viewer@example.test")
+	other := seedUser(t, "other@example.test")
+	jobA := seedJob(t, "viewed-a")
+	jobB := seedJob(t, "viewed-b")
+	jobC := seedJob(t, "other-c")
+
+	// viewer interacted with A (view) and B (apply — also counts as viewed).
+	if _, err := queries.RecordJobView(ctx, db.RecordJobViewParams{UserID: viewer, JobID: jobA}); err != nil {
+		t.Fatalf("view A: %v", err)
+	}
+	if _, err := queries.MarkJobApplied(ctx, db.MarkJobAppliedParams{UserID: viewer, JobID: jobB}); err != nil {
+		t.Fatalf("apply B: %v", err)
+	}
+	// other user viewed C — must never leak into viewer's set.
+	if _, err := queries.RecordJobView(ctx, db.RecordJobViewParams{UserID: other, JobID: jobC}); err != nil {
+		t.Fatalf("view C: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &API{pool: pool, queries: queries, issuer: iss}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/jobs/viewed", auth.RequireAuthOrKey(iss, queries), h.ListViewedSlugs)
+
+	getSlugs := func(t *testing.T, userID int64) []string {
+		t.Helper()
+		token, err := iss.Issue(userID)
+		if err != nil {
+			t.Fatalf("issue token: %v", err)
+		}
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/jobs/viewed", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET viewed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+		var body struct {
+			Data []string `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		sort.Strings(body.Data)
+		return body.Data
+	}
+
+	t.Run("returns the caller's viewed slugs, scoped to the caller", func(t *testing.T) {
+		got := getSlugs(t, viewer)
+		want := []string{"job-viewed-a", "job-viewed-b"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("viewer slugs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("user with no interactions gets an empty list", func(t *testing.T) {
+		fresh := seedUser(t, "fresh@example.test")
+		got := getSlugs(t, fresh)
+		if len(got) != 0 {
+			t.Fatalf("fresh user slugs = %v, want []", got)
+		}
+	})
+
+	t.Run("unauthenticated request is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/jobs/viewed", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET viewed (no auth): %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+}

--- a/openspec/changes/mark-viewed-jobs/.openspec.yaml
+++ b/openspec/changes/mark-viewed-jobs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/mark-viewed-jobs/design.md
+++ b/openspec/changes/mark-viewed-jobs/design.md
@@ -1,0 +1,71 @@
+## Context
+
+Per-user view tracking already exists: opening a job detail records a `user_jobs`
+row (`viewed_at NOT NULL DEFAULT now()`), and `/api/v1/me/jobs` can read it back.
+But the browse list (`ListJobs`) and search (`SearchJobs`) are deliberately
+public and unauthenticated, and the `jobview.Job` wire shape carries no per-user
+state — so a signed-in user cannot see which postings they already opened.
+
+Two architectural constraints shape the solution:
+- **"Public job reads stay unauthenticated"** is a standing project convention.
+  We do not want to make `ListJobs`/`SearchJobs` auth-aware.
+- **Search runs through Meilisearch, not Postgres.** A per-job `viewed` flag
+  joined into the read path would not reach search hits without a separate
+  cross-reference anyway.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A signed-in user can tell, at a glance, which jobs in the list and in search
+  results they have already opened.
+- Keep the public read path unauthenticated and the `jobview.Job` wire shape
+  (and generated TS contracts) unchanged.
+- Reuse the existing server-side `user_jobs` data so the marking is cross-device
+  and reflects history recorded before this feature shipped.
+
+**Non-Goals:**
+- No per-job `viewed` field on the public job shape.
+- No SSR of viewed state (no extra request on every page load).
+- No new "mark unviewed" / clear-history affordance.
+
+## Decisions
+
+**Decision: ship viewed state as a separate slug-set endpoint, cross-referenced
+client-side.** A new `GET /api/v1/me/jobs/viewed` returns the set of
+`public_slug`s the caller has viewed (`{"data": [slug, ...]}`), guarded by
+`RequireAuthOrKey` like the other `/me` reads. The SPA loads it once when a
+signed-in user opens the browse view, holds it in a small reactive store, and a
+job card dims when its slug is in the set.
+- *Why over an auth-aware list:* keeps the public list/search endpoints
+  untouched (honours the convention) and works identically for Postgres-backed
+  list results and Meilisearch-backed search results, since the match is a pure
+  client-side set lookup on `public_slug`.
+- *Why over localStorage-only:* the source of truth is already server-side
+  (`user_jobs`), so a slug set is cross-device and includes pre-feature history;
+  a localStorage cache would silently diverge from it.
+
+**Decision: dim the whole card via opacity, restore on hover.** `JobRow` gets
+`class:opacity-60={isViewed}` plus `hover:opacity-100`, so a viewed card reads as
+"already seen" but returns to full strength on hover to signal it is still
+clickable. A `dimViewed` prop (default `true`) lets the My Jobs surfaces
+(History tab, board) opt out — there every card is viewed, so dimming all of them
+would be noise.
+
+**Decision: unbounded slug list, no pagination.** The query is keyed on the
+`user_jobs` primary key `(user_id, job_id)` and returns compact slug strings;
+returning the full set is the simplest correct behaviour. If a power user's set
+ever grows large enough to matter, pagination is the documented seam.
+
+## Risks / Trade-offs
+
+- **Hydration flash** → The first SSR-rendered page paints before the viewed-slug
+  fetch resolves, so viewed cards dim ~100ms after hydration. Accepted; avoids an
+  extra blocking request on every page load. Mitigated for the common case
+  (opening a job then going back) by `markViewed(slug)` updating the store
+  locally on view-record.
+- **Growing slug set** → For a heavy user the payload grows unbounded. Low risk
+  at current scale (compact strings, one cheap indexed query); pagination is the
+  noted seam if it ever bites.
+- **Stale set within a session** → The set is loaded once per browse view, so a
+  job viewed in another tab is not reflected until reload. Acceptable for a
+  passive convenience cue; `markViewed` keeps the current tab consistent.

--- a/openspec/changes/mark-viewed-jobs/proposal.md
+++ b/openspec/changes/mark-viewed-jobs/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+A signed-in user browsing the job list has no way to tell which postings they have already opened. They re-open the same vacancies and waste time re-reading them. The view data already exists (`user_jobs.viewed_at` is recorded on every job-detail open), but the browse list never surfaces it.
+
+## What Changes
+
+- Add a read endpoint that returns the set of `public_slug`s the signed-in user has viewed, so the SPA can cross-reference the browse list client-side.
+- The SPA dims already-viewed job cards in the list and search results (whole-card opacity reduction, restored to full on hover), gated to signed-in users.
+- The public job list/search endpoints stay unauthenticated — viewed state is fetched separately, not joined into the public read path.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `user-job-tracking`: adds a new requirement — the API exposes the set of viewed job slugs for the authenticated caller.
+- `web-frontend`: adds a new requirement — the job browse list and search results visually mark jobs the signed-in user has already viewed.
+
+## Impact
+
+- **Backend**: new `ListViewedJobSlugs` query (`internal/db/queries/user_jobs.sql`), regenerated sqlc, new `ListViewedSlugs` handler + route `GET /api/v1/me/jobs/viewed` (`internal/handler/me_jobs.go`, `handler.go`). No change to the `jobs`/`user_jobs` schema and no change to the `jobview.Job` wire shape (so the generated TS contracts are untouched).
+- **Frontend**: new API client method, a small reactive viewed-slugs store, and edits to `JobsView.svelte` (load on mount when authed), `JobRow.svelte` (dim when viewed, opt-out prop for the My Jobs surfaces), and `JobView.svelte` (mark viewed after recording).
+- **No breaking changes**; unauthenticated browsing is unaffected.

--- a/openspec/changes/mark-viewed-jobs/specs/user-job-tracking/spec.md
+++ b/openspec/changes/mark-viewed-jobs/specs/user-job-tracking/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Listing the caller's viewed job slugs
+
+The system SHALL let an authenticated caller read the set of public job slugs
+they have viewed, so a client can mark already-seen jobs without making the
+public job-read path authenticated. Authentication MAY be by session cookie or by
+API key; either identifies the acting user identically. The endpoint SHALL return
+every `public_slug` for which the caller has a `user_jobs` interaction row,
+including closed jobs, as a flat list under `{"data": [...]}`. The public job
+list and search endpoints SHALL remain unauthenticated and unchanged.
+
+#### Scenario: Signed-in user reads their viewed slugs
+
+- **WHEN** an authenticated user sends `GET /api/v1/me/jobs/viewed` and has
+  previously viewed two jobs
+- **THEN** the system responds `200` with `{"data": [slug_a, slug_b]}` containing
+  exactly the `public_slug`s of those two jobs
+
+#### Scenario: User with no interactions
+
+- **WHEN** an authenticated user who has viewed no jobs sends
+  `GET /api/v1/me/jobs/viewed`
+- **THEN** the system responds `200` with `{"data": []}`
+
+#### Scenario: Viewed slugs require authentication
+
+- **WHEN** a request to `GET /api/v1/me/jobs/viewed` carries neither a valid auth
+  cookie nor a valid API key
+- **THEN** the system responds `401` and returns no slug data
+
+#### Scenario: Viewed slugs are scoped to the caller
+
+- **WHEN** an authenticated user reads their viewed slugs
+- **THEN** the response contains only slugs from that user's own `user_jobs`
+  rows and never another user's interactions

--- a/openspec/changes/mark-viewed-jobs/specs/web-frontend/spec.md
+++ b/openspec/changes/mark-viewed-jobs/specs/web-frontend/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Already-viewed jobs are visually marked in the browse list
+
+The SPA SHALL visually de-emphasise job cards that the signed-in user has already
+viewed, in both the jobs list and the search results, so they can tell at a
+glance what they have already opened. The marking SHALL be driven by the set of
+viewed slugs read from `GET /api/v1/me/jobs/viewed`, loaded once when a signed-in
+user opens the browse view. A viewed card SHALL be dimmed (reduced opacity) and
+SHALL return to full strength on hover to signal it remains clickable. For
+anonymous (signed-out) visitors no card SHALL be dimmed. Surfaces where every
+listed job is by definition already viewed (the My Jobs history and board) SHALL
+NOT dim their cards.
+
+#### Scenario: Signed-in user sees viewed jobs dimmed
+
+- **WHEN** a signed-in user who has viewed some jobs opens the jobs list or runs
+  a search
+- **THEN** the cards for jobs in their viewed-slug set are rendered dimmed
+- **AND** cards for jobs they have not viewed are rendered at full strength
+
+#### Scenario: Hovering a viewed card restores it
+
+- **WHEN** the user hovers a dimmed (viewed) job card
+- **THEN** the card returns to full strength while hovered
+
+#### Scenario: Anonymous visitor sees no dimming
+
+- **WHEN** a signed-out visitor opens the jobs list or runs a search
+- **THEN** no job card is dimmed
+
+#### Scenario: Opening a job marks it viewed without a reload
+
+- **WHEN** a signed-in user opens a job from the list and navigates back
+- **THEN** that job's card is shown dimmed without requiring a full reload
+
+#### Scenario: My Jobs surfaces are not dimmed
+
+- **WHEN** a signed-in user opens the My Jobs history or board, where every card
+  is already viewed
+- **THEN** no card is dimmed

--- a/openspec/changes/mark-viewed-jobs/tasks.md
+++ b/openspec/changes/mark-viewed-jobs/tasks.md
@@ -1,0 +1,21 @@
+## 1. Backend — viewed-slugs endpoint
+
+- [x] 1.1 Add `ListViewedJobSlugs` query to `internal/db/queries/user_jobs.sql` (`SELECT jobs.public_slug FROM user_jobs uj JOIN jobs ON jobs.id = uj.job_id WHERE uj.user_id = $1`) and regenerate sqlc; verify `go build ./...` compiles with the generated method.
+- [x] 1.2 Implement `ListViewedSlugs` handler in `internal/handler/me_jobs.go` returning `{"data": [slug, ...]}`, and register `GET /api/v1/me/jobs/viewed` under `RequireAuthOrKey` in `internal/handler/handler.go`. Cover with an integration test (`//go:build integration`): returns the caller's slugs only, `[]` when none, `401` unauthenticated.
+
+## 2. Frontend — viewed-slugs data layer
+
+- [x] 2.1 Add `listViewedSlugs(): Promise<string[]>` to `web/src/lib/api.ts` calling `GET /api/v1/me/jobs/viewed` and returning `data`.
+- [x] 2.2 Add a reactive viewed-jobs store `web/src/lib/viewedJobs.svelte.ts`: a `$state` `Set<string>`, `hasViewed(slug)`, `markViewed(slug)`, and `ensureViewedLoaded()` that fetches once (guarded against repeat loads) and is a no-op for signed-out users.
+
+## 3. Frontend — wire into the UI
+
+- [x] 3.1 In `JobsView.svelte`, call `ensureViewedLoaded()` on mount when the user is authenticated (covers both list and search, which render through this component).
+- [x] 3.2 In `JobRow.svelte`, add a `dimViewed = true` prop and dim the card when viewed: `class:opacity-60={dimViewed && hasViewed(job.public_slug)}` plus `hover:opacity-100`.
+- [x] 3.3 In `JobView.svelte`, call `markViewed(slug)` after `recordJobView` resolves so the card is dimmed on back-navigation without a reload.
+- [x] 3.4 Pass `dimViewed={false}` from the My Jobs surfaces (`JobHistory.svelte` and any board `JobRow` usage) so already-viewed-by-definition lists are not uniformly dimmed.
+
+## 4. Verification
+
+- [x] 4.1 Backend: `go build ./... && go vet ./...`, `go test ./...`, and the new handler integration test (`go test -tags=integration ./internal/handler/`) all green.
+- [x] 4.2 Frontend: `npm run check` (svelte-check) and `npm run build` green; manually confirm viewed cards dim for a signed-in user and not for an anonymous visitor.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -269,6 +269,14 @@ export function createApi(
     return { ...toSlice(res, offset), counts: res.meta.counts };
   }
 
+  /** The public slugs of every job the current user has interacted with. The
+   *  browse UI cross-references this set to dim already-viewed cards without
+   *  authenticating the public job list. */
+  async function listViewedSlugs(): Promise<string[]> {
+    const res = await request<{ data: string[] }>('/api/v1/me/jobs/viewed');
+    return res.data;
+  }
+
   // --- API keys -------------------------------------------------------------
   //
   // Personal API keys for non-browser access. Management is cookie-only (these
@@ -316,6 +324,7 @@ export function createApi(
     untrackJob,
     trackJob,
     listMyJobs,
+    listViewedSlugs,
     listApiKeys,
     createApiKey,
     revokeApiKey,
@@ -351,6 +360,7 @@ export const {
   untrackJob,
   trackJob,
   listMyJobs,
+  listViewedSlugs,
   listApiKeys,
   createApiKey,
   revokeApiKey,

--- a/web/src/lib/components/JobHistory.svelte
+++ b/web/src/lib/components/JobHistory.svelte
@@ -25,7 +25,7 @@
 {:else}
   <ul class="flex flex-col gap-3">
     {#each page.items as item (item.job.public_slug)}
-      <li><JobRow job={item.job} /></li>
+      <li><JobRow job={item.job} dimViewed={false} /></li>
     {/each}
   </ul>
   {#if page.hasMore}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -4,10 +4,17 @@
   import type { Job } from '$lib/types';
   import { Badge } from '$lib/ui';
   import { timeAgo } from '$lib/utils';
+  import { hasViewed } from '$lib/viewedJobs.svelte';
 
   // Single source of truth for how a job appears in any list (jobs list and
   // company detail). The whole card is a link to the job detail.
-  let { job }: { job: Job } = $props();
+  //
+  // `dimViewed` dims the card when the signed-in user has already viewed this
+  // job, so the browse list shows what's been seen. The My Jobs surfaces (where
+  // every card is viewed by definition) pass `dimViewed={false}` to opt out.
+  let { job, dimViewed = true }: { job: Job; dimViewed?: boolean } = $props();
+
+  const isViewed = $derived(dimViewed && hasViewed(job.public_slug));
 
   const tags = $derived(cardTags(job));
   const salary = $derived(job.enrichment ? formatSalary(job.enrichment) : null);
@@ -22,7 +29,8 @@
 
 <a
   href={`/jobs/${job.public_slug}`}
-  class="block rounded-xl border border-border bg-card p-4 transition-colors hover:bg-accent"
+  class="block rounded-xl border border-border bg-card p-4 transition hover:bg-accent hover:opacity-100"
+  class:opacity-60={isViewed}
 >
   <div class="flex items-start justify-between gap-3">
     <div class="flex min-w-0 flex-wrap items-center gap-2">

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -5,6 +5,7 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { filterHref, formatSalary, summaryFacets } from '$lib/enrichment';
+  import { markViewed } from '$lib/viewedJobs.svelte';
   import type { Job, UserJob } from '$lib/types';
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
@@ -39,6 +40,8 @@
     if (!browser || !isAuthenticated()) return;
     recordJobView(slug)
       .then((rec) => {
+        // Mark it locally so its card dims on back-navigation without a reload.
+        markViewed(slug);
         if (job.public_slug === slug) interaction = rec;
       })
       .catch(() => {});

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -2,6 +2,8 @@
   import { onMount, untrack } from 'svelte';
   import { page } from '$app/state';
   import { api, type Slice } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams, type SortField } from '$lib/filters.svelte';
   import type { Job } from '$lib/types';
@@ -49,9 +51,13 @@
   let started = false;
   let timer: ReturnType<typeof setTimeout>;
 
-  // Cleanup: a debounce timer left running after unmount would start a fetch for
-  // a component that no longer exists.
-  onMount(() => () => clearTimeout(timer));
+  // For a signed-in user, load the set of already-viewed slugs so JobRow can dim
+  // seen cards (no-op when signed out — the set stays empty). Cleanup: a debounce
+  // timer left running after unmount would start a fetch for a gone component.
+  onMount(() => {
+    if (isAuthenticated()) ensureViewedLoaded();
+    return () => clearTimeout(timer);
+  });
 
   // House select styling, mirrored from ApiKeysView.
   const sortClass =

--- a/web/src/lib/viewedJobs.svelte.ts
+++ b/web/src/lib/viewedJobs.svelte.ts
@@ -1,0 +1,68 @@
+// Tracks which jobs the signed-in user has already viewed, so the browse list
+// and search results can dim already-seen cards. The set of viewed public_slugs
+// is read once from GET /api/v1/me/jobs/viewed (the browse view triggers the
+// load); recording a view on a job detail page marks its slug locally too, so a
+// card dims on back-navigation without waiting for a reload.
+//
+// SSR-safe and auth-agnostic: `ensureLoaded` is a no-op off the browser, and the
+// set simply stays empty for signed-out users (callers gate the load on auth, so
+// no user lookup lives here). A failed load leaves the set empty — nothing dims,
+// which is the correct degraded state.
+
+import { SvelteSet } from 'svelte/reactivity';
+import { browser } from '$app/environment';
+import { listViewedSlugs } from '$lib/api';
+
+class ViewedJobs {
+  // SvelteSet (not a plain Set): a plain Set in $state is not deeply reactive, so
+  // an in-place `.add` in `mark` would not re-run readers. SvelteSet makes both
+  // the `.add` mutation and the `ensureLoaded` reassignment trigger dependent
+  // $derived/$effect (e.g. JobRow's `isViewed`).
+  #slugs = $state(new SvelteSet<string>());
+  #loaded = false;
+  // The in-flight load, shared so concurrent callers issue one request.
+  #loading: Promise<void> | null = null;
+
+  has(slug: string): boolean {
+    return this.#slugs.has(slug);
+  }
+
+  /** Mark a slug viewed locally (e.g. right after recording a view), so its card
+   *  dims immediately without re-fetching the whole set. */
+  mark(slug: string) {
+    this.#slugs.add(slug);
+  }
+
+  /** Load the viewed set once. Repeat calls reuse the first load (or its
+   *  in-flight promise). No-op on the server. */
+  async ensureLoaded(): Promise<void> {
+    if (!browser || this.#loaded) return;
+    if (this.#loading) return this.#loading;
+    this.#loading = listViewedSlugs()
+      .then((slugs) => {
+        this.#slugs = new SvelteSet(slugs);
+        this.#loaded = true;
+      })
+      .catch(() => {
+        // best-effort: an unreachable/failed load just means nothing dims.
+      })
+      .finally(() => {
+        this.#loading = null;
+      });
+    return this.#loading;
+  }
+}
+
+const viewedJobs = new ViewedJobs();
+
+export function hasViewed(slug: string): boolean {
+  return viewedJobs.has(slug);
+}
+
+export function markViewed(slug: string) {
+  viewedJobs.mark(slug);
+}
+
+export function ensureViewedLoaded(): Promise<void> {
+  return viewedJobs.ensureLoaded();
+}


### PR DESCRIPTION
## Summary
- Signed-in users can now tell at a glance which jobs they've already opened: viewed cards are dimmed in the browse list and search results (restored to full on hover).
- New endpoint `GET /api/v1/me/jobs/viewed` returns the caller's viewed `public_slug`s, guarded by `RequireAuthOrKey`. The public `ListJobs`/`SearchJobs` stay **unauthenticated** — viewed state is cross-referenced client-side, so it works for both the Postgres list and Meilisearch search.
- The SPA loads the set once per browse view (authed only) into a reactive `SvelteSet` store; `markViewed` updates it on view-record so a card dims on back-navigation without a reload. My Jobs surfaces opt out via `dimViewed={false}`.

Planned and tracked under `openspec/changes/mark-viewed-jobs/` (proposal/design/specs/tasks).

## Notable design choices
- **Slug-set endpoint over an auth-aware list:** honours the "public job reads stay unauthenticated" convention and works uniformly for list + Meilisearch search.
- **`SvelteSet`, not a plain `Set` in `$state`:** a plain Set's in-place `.add` is not reactive in Svelte 5, which would have made `markViewed` silently no-op (caught in review).
- No change to the `jobview.Job` wire shape → generated TS contracts untouched.

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` (unit) green
- [x] `go test -tags=integration ./internal/handler/` green — incl. new `TestListViewedSlugsEndpoint` (caller-scoped slugs, empty set, 401 unauth) and all existing handler tests
- [x] `npm run check` (svelte-check) 0 errors / 0 warnings; `npm run build` green
- [ ] Manual: signed-in user sees viewed cards dimmed (and restored on hover); anonymous visitor sees no dimming; My Jobs history not dimmed