### PR TITLE
contracts: add arc + remoteok to source filter vocab

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -135,11 +135,11 @@ func skipPreamble(lines []string) int {
 }
 
 // genVocab emits every closed vocabulary. Source = non-boardless providers plus the
-// non-adapter sources set by other writers: "telegram" (the tg-extract worker) and
-// "workatastartup" (the moderator/bulk import). Stages from userjob; the rest from the
-// enrich controlled vocabularies.
+// non-adapter sources set by other writers: "telegram" (the tg-extract worker) and the
+// moderator/bulk-import origins ("workatastartup", "remoteok", "arc"). Stages from
+// userjob; the rest from the enrich controlled vocabularies.
 func genVocab() string {
-	source := append([]string{"telegram", "workatastartup"}, sources.FilterableProviders()...)
+	source := append([]string{"telegram", "workatastartup", "remoteok", "arc"}, sources.FilterableProviders()...)
 
 	var b strings.Builder
 	b.WriteString(emitVocab("Source", "SOURCE_VALUES", source))

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -54,6 +54,7 @@ function options(values: readonly string[], labels: Record<string, string> = {})
 const SOURCE: FacetOption[] = options(SOURCE_VALUES, {
   telegram: 'Telegram', greenhouse: 'Greenhouse', smartrecruiters: 'SmartRecruiters',
   bamboohr: 'BambooHR', successfactors: 'SuccessFactors',
+  workatastartup: 'Work at a Startup', remoteok: 'RemoteOK', arc: 'Arc',
 });
 
 // The backend's full `regions` reach vocabulary (enrich.RegionValues). Values mix

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -102,7 +102,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'ashby', 'bamboohr', 'breezy', 'gem', 'greenhouse', 'huntflow', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'workable', 'workday'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'greenhouse', 'huntflow', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'workable', 'workday'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## Summary
- The `arc` (4752) and `remoteok` (911) bulk-import origins are searchable by `?source=` but had no clickable filter pill. Add both to the generated `SOURCE_VALUES` (alongside the existing `telegram`/`workatastartup` non-adapter sources).
- Add label overrides in `facets.ts`: `RemoteOK`, `Arc`, and fix the existing `workatastartup` → `Work at a Startup`.

## Test plan
- [x] `go run ./cmd/gen-contracts` regenerates `contracts.ts` with arc+remoteok in SOURCE_VALUES
- [ ] After deploy: source filter shows Arc / RemoteOK / Work at a Startup pills; clicking filters correctly