### PR TITLE
security: harden SSRF, stored XSS, and auth surface (full review)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,15 @@
 /bin/
 /out/
 hire
+# Build output of cmd/gen-contracts (regenerated via `make gen-contracts`).
+/gen-contracts
+
+# Local scratch: scraped pages and ad-hoc source dumps used while spiking new
+# adapters. Multi-MB and sometimes carry third-party keys embedded in saved pages —
+# never commit.
+/remoteok.txt
+/workatastartup.html
+/native-boards.md
 
 # Environment
 .env

--- a/cmd/liveness/main.go
+++ b/cmd/liveness/main.go
@@ -13,7 +13,6 @@ package main
 import (
 	"context"
 	"log"
-	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/liveness"
+	"github.com/strelov1/freehire/internal/safehttp"
 	"github.com/strelov1/freehire/internal/sources"
 )
 
@@ -65,7 +65,9 @@ func main() {
 	}
 	log.Printf("liveness: %d orphan candidates (excluding %d ATS providers)", len(candidates), len(atsProviders))
 
-	client := &http.Client{Timeout: probeTimeout}
+	// Probe targets are orphan-job URLs that originated from attacker-influenced
+	// sources (telegram posts), so the probe must refuse internal/metadata targets.
+	client := safehttp.NewClient(probeTimeout)
 	var probed, closed, struck int64
 
 	sem := make(chan struct{}, concurrency)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,9 +22,11 @@ import (
 func main() {
 	cfg := config.Load()
 
-	// Never boot the auth surface with a guessable signing key.
-	if cfg.JWTSecret == "" {
-		log.Fatal("config: JWT_SECRET is required")
+	// Never boot the auth surface with a guessable signing key. HS256 security rests
+	// entirely on secret entropy, so a short secret is brute-forceable offline against
+	// any captured token; require at least 32 bytes.
+	if len(cfg.JWTSecret) < 32 {
+		log.Fatal("config: JWT_SECRET is required and must be at least 32 bytes")
 	}
 
 	pool, err := database.Connect(context.Background(), cfg.DatabaseURL)
@@ -37,7 +39,18 @@ func main() {
 		AppName:      "hire",
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
+		// Cap request bodies well under Fiber's 4MB default: the largest write is a
+		// single moderator job description, so 1MB bounds a memory-amplification body.
+		BodyLimit:    1 * 1024 * 1024,
 		ErrorHandler: handler.RenderError,
+		// The app sits behind the in-network nginx proxy (web/nginx.conf), which sets
+		// X-Forwarded-For. Trust that header for c.IP() — so the rate limiter keys on
+		// the real client, not the proxy — but ONLY when the immediate peer is in a
+		// private range (the nginx container). A direct public caller is not trusted,
+		// so it cannot spoof XFF to evade the limit.
+		ProxyHeader:             fiber.HeaderXForwardedFor,
+		EnableTrustedProxyCheck: true,
+		TrustedProxies:          []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1/32"},
 	})
 
 	app.Use(recover.New())

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -43,12 +43,14 @@ func main() {
 		// single moderator job description, so 1MB bounds a memory-amplification body.
 		BodyLimit:    1 * 1024 * 1024,
 		ErrorHandler: handler.RenderError,
-		// The app sits behind the in-network nginx proxy (web/nginx.conf), which sets
-		// X-Forwarded-For. Trust that header for c.IP() — so the rate limiter keys on
-		// the real client, not the proxy — but ONLY when the immediate peer is in a
-		// private range (the nginx container). A direct public caller is not trusted,
-		// so it cannot spoof XFF to evade the limit.
-		ProxyHeader:             fiber.HeaderXForwardedFor,
+		// The app sits behind the in-network nginx proxy (web/nginx.conf). Key c.IP()
+		// (and thus the rate limiter) on X-Real-IP, which nginx OVERWRITES with the real
+		// peer — a single value the client cannot spoof. X-Forwarded-For is deliberately
+		// NOT used here: Fiber returns the whole (client-appendable) XFF list, so a
+		// spoofed prefix would mint a fresh limiter key per request and evade the limit.
+		// The header is only honoured when the immediate peer is a trusted private range
+		// (the nginx container); a direct public caller is not trusted.
+		ProxyHeader:             "X-Real-IP", // Fiber has no constant for this header
 		EnableTrustedProxyCheck: true,
 		TrustedProxies:          []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1/32"},
 	})

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/moby/term v0.5.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
+	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pkoukk/tiktoken-go v0.1.6 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
@@ -73,6 +74,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/tinylib/msgp v1.2.5 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pkoukk/tiktoken-go v0.1.6 h1:JF0TlJzhTbrI30wCvFuiw6FzP2+/bR+FIxUdgEAcUsw=
 github.com/pkoukk/tiktoken-go v0.1.6/go.mod h1:9NiV+i9mJKGj1rYOT+njbv+ZwA/zJxYdewGl6qVatpg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -146,6 +148,8 @@ github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44Xt
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0 h1:GCbb1ndrF7OTDiIvxXyItaDab4qkzTFJ48LKFdM7EIo=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0/go.mod h1:IRPBaI8jXdrNfD0e4Zm7Fbcgaz5shKxOQv4axiL09xs=
+github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
+github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -12,6 +12,10 @@ import (
 
 const minPasswordLen = 8
 
+// maxPasswordLen is bcrypt's input ceiling: it silently truncates beyond 72 bytes,
+// so a longer password would have its tail ignored. Reject rather than mislead.
+const maxPasswordLen = 72
+
 // User is the public representation of a local account.
 type User struct {
 	ID        int64
@@ -42,6 +46,7 @@ var (
 
 	ErrInvalidEmail       = errors.New("accounts: invalid email")
 	ErrPasswordTooShort   = errors.New("accounts: password too short")
+	ErrPasswordTooLong    = errors.New("accounts: password too long")
 	ErrEmailTaken         = errors.New("accounts: email already registered")
 	ErrInvalidCredentials = errors.New("accounts: invalid credentials")
 	ErrUserNotFound       = errors.New("accounts: user not found")
@@ -127,6 +132,9 @@ func (s *Service) Register(ctx context.Context, email, password string) (User, e
 	}
 	if len(password) < minPasswordLen {
 		return User{}, ErrPasswordTooShort
+	}
+	if len(password) > maxPasswordLen {
+		return User{}, ErrPasswordTooLong
 	}
 	hash, err := s.hasher.Hash(password)
 	if err != nil {

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -3,6 +3,7 @@ package accounts
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -294,6 +295,22 @@ func TestRegister_ShortPassword(t *testing.T) {
 	_, err := svc.Register(context.Background(), "user@example.com", "short")
 	if !errors.Is(err, ErrPasswordTooShort) {
 		t.Errorf("want ErrPasswordTooShort, got %v", err)
+	}
+	if len(repo.createUserCalls) != 0 {
+		t.Errorf("CreateUser should NOT be called, got %d calls", len(repo.createUserCalls))
+	}
+}
+
+// Register long password → ErrPasswordTooLong; CreateUser NOT called. bcrypt silently
+// truncates past 72 bytes, so accepting a longer password would ignore its tail.
+func TestRegister_LongPassword(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := New(repo, &fakeHasher{})
+
+	long := strings.Repeat("a", 73)
+	_, err := svc.Register(context.Background(), "user@example.com", long)
+	if !errors.Is(err, ErrPasswordTooLong) {
+		t.Errorf("want ErrPasswordTooLong, got %v", err)
 	}
 	if len(repo.createUserCalls) != 0 {
 		t.Errorf("CreateUser should NOT be called, got %d calls", len(repo.createUserCalls))

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -21,13 +21,13 @@ const defaultEnrichTimeout = 90 * time.Second
 // oversized posting from amplifying per-call token cost.
 const maxDescriptionRunes = 24000
 
-// truncateRunes returns s clamped to at most max runes, never splitting a rune.
-func truncateRunes(s string, max int) string {
+// truncateRunes returns s clamped to at most limit runes, never splitting a rune.
+func truncateRunes(s string, limit int) string {
 	r := []rune(s)
-	if len(r) <= max {
+	if len(r) <= limit {
 		return s
 	}
-	return string(r[:max])
+	return string(r[:limit])
 }
 
 // LangChainProvider implements Provider over any OpenAI-compatible endpoint via

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -16,6 +16,20 @@ import (
 // stalling the whole queue). The lease/retry machinery then reclaims the job.
 const defaultEnrichTimeout = 90 * time.Second
 
+// maxDescriptionRunes caps the job description sent to the model. Descriptions are
+// attacker-influenced (scraped/extracted), so bounding the length keeps a single
+// oversized posting from amplifying per-call token cost.
+const maxDescriptionRunes = 24000
+
+// truncateRunes returns s clamped to at most max runes, never splitting a rune.
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max])
+}
+
 // LangChainProvider implements Provider over any OpenAI-compatible endpoint via
 // langchaingo. The endpoint, credential, and model are injected at construction;
 // the model is asked for a JSON object matching the Enrichment contract.
@@ -137,6 +151,6 @@ func userPrompt(job JobInput) string {
 	// Source-provided remote hint (from the ATS API or the location text) — a
 	// prior for the model, not a guarantee of scope.
 	fmt.Fprintf(&b, "Remote flag: %t\n", job.Remote)
-	fmt.Fprintf(&b, "Description:\n%s\n", job.Description)
+	fmt.Fprintf(&b, "Description:\n%s\n", truncateRunes(job.Description, maxDescriptionRunes))
 	return b.String()
 }

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -36,6 +36,8 @@ func accountsError(err error) error {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid email")
 	case errors.Is(err, accounts.ErrPasswordTooShort):
 		return fiber.NewError(fiber.StatusBadRequest, "password must be at least 8 characters")
+	case errors.Is(err, accounts.ErrPasswordTooLong):
+		return fiber.NewError(fiber.StatusBadRequest, "password must be at most 72 characters")
 	case errors.Is(err, accounts.ErrEmailTaken):
 		return fiber.NewError(fiber.StatusConflict, "email already registered")
 	case errors.Is(err, accounts.ErrInvalidCredentials):

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2/middleware/limiter"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/accounts"
@@ -161,9 +162,13 @@ func Register(app *fiber.App, cfg Config) {
 	// me is guarded and accepts a session cookie OR an API key, so a non-browser
 	// client (e.g. the CLI) can resolve its own identity with its key. It stays a
 	// read of the caller's own user — not key management, which is cookie-only.
+	// Throttle the credential endpoints against online brute-force / credential
+	// stuffing. Keyed on c.IP() (the real client, via the trusted-proxy config); the
+	// per-instance in-memory window is enough friction for a single-node deployment.
+	authLimiter := limiter.New(limiter.Config{Max: 10, Expiration: time.Minute})
 	authGroup := api.Group("/auth")
-	authGroup.Post("/register", a.Register)
-	authGroup.Post("/login", a.Login)
+	authGroup.Post("/register", authLimiter, a.Register)
+	authGroup.Post("/login", authLimiter, a.Login)
 	authGroup.Post("/logout", a.Logout)
 	authGroup.Get("/me", auth.RequireAuthOrKey(a.issuer, a.queries), a.Me)
 

--- a/internal/linksource/geekjob.go
+++ b/internal/linksource/geekjob.go
@@ -55,9 +55,15 @@ func (g geekjob) Resolve(ctx context.Context, raw string) (sources.Job, bool, er
 	}
 	id := m[1]
 
-	node, err := g.http.GetHTML(ctx, raw)
+	node, final, err := g.http.GetHTMLResolved(ctx, raw)
 	if err != nil {
 		return sources.Job{}, false, err
+	}
+	// The link came from untrusted post content and the client follows redirects to
+	// any host; only parse the page when it stayed on Geekjob, so a hijacked link or
+	// open redirect cannot make us ingest an arbitrary (e.g. internal) host's HTML.
+	if fu, err := url.Parse(final); err != nil || host(fu) != "geekjob.ru" {
+		return sources.Job{}, false, fmt.Errorf("linksource: geekjob link resolved to unexpected host %q", final)
 	}
 	var p geekjobPosting
 	if !sources.LDJobPosting(node, &p) {

--- a/internal/linksource/geekjob_test.go
+++ b/internal/linksource/geekjob_test.go
@@ -21,6 +21,16 @@ const geekjobVacancyHTML = `<html><head>
  "baseSalary":{"@type":"MonetaryAmount","currency":"USD","value":{"@type":"QuantitativeValue","unitText":"MONTH","minValue":4000,"maxValue":5000}}}
 </script></head><body></body></html>`
 
+func TestGeekjobRejectsRedirectToForeignHost(t *testing.T) {
+	// The link host matches, but the page resolves to an internal target; the adapter
+	// must refuse to ingest a foreign host's HTML.
+	c := (&fakeClient{}).route("/vacancy/6a1ebb8520ad023342091661", geekjobVacancyHTML, "http://10.0.0.1/internal")
+	_, ok, err := NewGeekjob(c).Resolve(context.Background(), "https://geekjob.ru/vacancy/6a1ebb8520ad023342091661")
+	if err == nil {
+		t.Fatalf("expected rejection of redirect to a foreign host, got ok=%v err=nil", ok)
+	}
+}
+
 func TestGeekjobResolvesVacancy(t *testing.T) {
 	const link = "https://geekjob.ru/vacancy/6a1ebb8520ad023342091661?utm_source=telegram"
 	c := (&fakeClient{}).route("/vacancy/6a1ebb8520ad023342091661", geekjobVacancyHTML, "")

--- a/internal/linksource/remoteyeah.go
+++ b/internal/linksource/remoteyeah.go
@@ -51,9 +51,15 @@ func (r remoteYeah) Resolve(ctx context.Context, raw string) (sources.Job, bool,
 		return sources.Job{}, false, nil
 	}
 
-	node, err := r.http.GetHTML(ctx, raw)
+	node, final, err := r.http.GetHTMLResolved(ctx, raw)
 	if err != nil {
 		return sources.Job{}, false, err
+	}
+	// The link came from untrusted post content and the client follows redirects to
+	// any host; only parse the page when it stayed on RemoteYeah, so a hijacked link
+	// or open redirect cannot make us ingest an arbitrary (e.g. internal) host's HTML.
+	if fu, err := url.Parse(final); err != nil || host(fu) != "remoteyeah.com" {
+		return sources.Job{}, false, fmt.Errorf("linksource: remoteyeah link resolved to unexpected host %q", final)
 	}
 	var p remoteYeahPosting
 	if !sources.LDJobPosting(node, &p) {

--- a/internal/linksource/remoteyeah_test.go
+++ b/internal/linksource/remoteyeah_test.go
@@ -50,6 +50,16 @@ func TestRemoteYeahSanitizesFoldedSalary(t *testing.T) {
 	}
 }
 
+func TestRemoteYeahRejectsRedirectToForeignHost(t *testing.T) {
+	// The link host matches, but the page resolves (via redirect) to an internal
+	// target. The adapter must refuse to ingest a foreign host's HTML.
+	c := (&fakeClient{}).route("/jobs/evil", remoteYeahJobHTML, "http://169.254.169.254/latest/meta-data/")
+	_, ok, err := NewRemoteYeah(c).Resolve(context.Background(), "https://remoteyeah.com/jobs/evil")
+	if err == nil {
+		t.Fatalf("expected rejection of redirect to a foreign host, got ok=%v err=nil", ok)
+	}
+}
+
 func TestRemoteYeahResolvesJobPage(t *testing.T) {
 	const link = "https://remoteyeah.com/jobs/remote-senior-platform-security-engineer-taekus?utm_source=telegram"
 	c := (&fakeClient{}).route("/jobs/remote-senior-platform-security-engineer-taekus", remoteYeahJobHTML, "")

--- a/internal/moderation/moderation.go
+++ b/internal/moderation/moderation.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobderive"
+	"github.com/strelov1/freehire/internal/sources"
 )
 
 // Sentinel errors. ErrInvalid wraps every validation failure (the handler maps it to
@@ -124,13 +125,17 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 	if source == "" {
 		source = defaultSource
 	}
+	// Moderator descriptions are bulk-imported from scraped pages and rendered with
+	// {@html}; sanitize to the same allowlist as every other source so no active
+	// markup is ever persisted (stored XSS). Done once and reused for derivation.
+	description := sources.SanitizeHTML(in.Description)
 	d := jobderive.Derive(jobderive.Input{
 		Title:       in.Title,
 		Company:     in.Company,
 		Source:      source,
 		ExternalID:  in.URL,
 		Location:    in.Location,
-		Description: in.Description,
+		Description: description,
 		WorkMode:    remoteWorkMode(in.Remote),
 	})
 	return s.repo.Create(ctx, db.UpsertManualJobParams{
@@ -142,7 +147,7 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 		CompanySlug: d.CompanySlug,
 		Location:    in.Location,
 		Remote:      in.Remote,
-		Description: in.Description,
+		Description: description,
 		PostedAt:    toTimestamptz(in.PostedAt),
 		PublicSlug:  d.PublicSlug,
 		Countries:   d.Countries,
@@ -173,7 +178,9 @@ func (s *Service) Update(ctx context.Context, actorID int64, slug string, p Upda
 	title := stringOr(p.Title, cur.Title)
 	company := stringOr(p.Company, cur.Company)
 	location := stringOr(p.Location, cur.Location)
-	description := stringOr(p.Description, cur.Description)
+	// Sanitize a supplied description before persisting (stored XSS); re-sanitizing the
+	// already-clean current value is idempotent.
+	description := sources.SanitizeHTML(stringOr(p.Description, cur.Description))
 	remote := cur.Remote
 	if p.Remote != nil {
 		remote = *p.Remote

--- a/internal/moderation/moderation_test.go
+++ b/internal/moderation/moderation_test.go
@@ -3,6 +3,7 @@ package moderation_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -98,6 +99,39 @@ func TestCreate_SourceIsRecordedAndSlugsFromIt(t *testing.T) {
 	// The public slug is minted from the real source, not the literal "manual".
 	if want := normalize.JobSlug("Senior Frontend Engineer", "Dalus", "workatastartup", url); repo.created.PublicSlug != want {
 		t.Errorf("PublicSlug = %q, want %q", repo.created.PublicSlug, want)
+	}
+}
+
+func TestCreate_SanitizesDescription(t *testing.T) {
+	// Moderator descriptions are bulk-imported from scraped pages and rendered with
+	// {@html}, so the service must strip active markup before persisting (stored XSS).
+	repo := &fakeRepo{}
+	_, err := moderation.New(repo).Create(context.Background(), 7, moderation.CreateInput{
+		URL:         "https://acme.example/jobs/1",
+		Title:       "Dev",
+		Company:     "Acme",
+		Description: `<p>Build it.</p><script>alert(document.cookie)</script><img src=x onerror=alert(1)>`,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := repo.created.Description; strings.Contains(got, "<script>") || strings.Contains(got, "onerror") {
+		t.Errorf("description not sanitized: %q", got)
+	}
+	if !strings.Contains(repo.created.Description, "Build it.") {
+		t.Errorf("sanitizer dropped legitimate content: %q", repo.created.Description)
+	}
+}
+
+func TestUpdate_SanitizesDescription(t *testing.T) {
+	repo := &fakeRepo{bySlugJob: db.Job{Source: "manual", PublicSlug: "s", Description: "old"}}
+	evil := `<script>alert(1)</script><b>new</b>`
+	_, err := moderation.New(repo).Update(context.Background(), 9, "s", moderation.UpdatePatch{Description: &evil})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := repo.updated.Description; strings.Contains(got, "<script>") {
+		t.Errorf("description not sanitized on update: %q", got)
 	}
 }
 

--- a/internal/safehttp/safehttp.go
+++ b/internal/safehttp/safehttp.go
@@ -21,15 +21,25 @@ import (
 	"time"
 )
 
+// cgnat is the RFC6598 shared address space (100.64.0.0/10). IsPrivate does not
+// cover it, but cloud providers (AWS/GCP) use it for internal/infra addressing and
+// it is reachable from instances — so an SSRF guard must block it too.
+var cgnat = func() *net.IPNet {
+	_, n, _ := net.ParseCIDR("100.64.0.0/10")
+	return n
+}()
+
 // blocked reports whether ip must not be dialed: loopback, RFC1918/ULA private,
-// link-local (which includes the 169.254.169.254 cloud-metadata address),
-// multicast, and the unspecified address. nil is treated as blocked (fail closed).
+// CGNAT shared space, link-local (which includes the 169.254.169.254 cloud-metadata
+// address), multicast, and the unspecified address. nil is treated as blocked (fail
+// closed).
 func blocked(ip net.IP) bool {
 	if ip == nil {
 		return true
 	}
 	return ip.IsLoopback() ||
 		ip.IsPrivate() ||
+		cgnat.Contains(ip) ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
 		ip.IsInterfaceLocalMulticast() ||

--- a/internal/safehttp/safehttp.go
+++ b/internal/safehttp/safehttp.go
@@ -1,0 +1,84 @@
+// Package safehttp builds HTTP clients that refuse to connect to non-public
+// network addresses. Every outbound fetcher in this service can be pointed at an
+// attacker-influenced URL — Telegram posts carry arbitrary links, and orphan-job
+// liveness probes URLs that originated from those posts — so a plain http.Client
+// is an SSRF primitive: it would happily fetch http://169.254.169.254/ (cloud
+// metadata) or an internal RFC1918 service.
+//
+// The guard runs in the dialer's Control hook, which fires AFTER DNS resolution
+// with the concrete IP:port about to be connected. Checking there (rather than the
+// hostname in the URL) closes DNS-rebinding: a public-looking host that resolves to
+// 127.0.0.1 is rejected at connect time, on the original request and on every
+// redirect hop (each hop dials through the same transport).
+package safehttp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// blocked reports whether ip must not be dialed: loopback, RFC1918/ULA private,
+// link-local (which includes the 169.254.169.254 cloud-metadata address),
+// multicast, and the unspecified address. nil is treated as blocked (fail closed).
+func blocked(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	return ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
+}
+
+// guardedDialer returns a net.Dialer whose Control hook rejects a connection to any
+// non-public resolved address. The hook receives the post-resolution IP:port, so it
+// defeats both direct-IP targets and DNS-rebinding.
+func guardedDialer(timeout time.Duration) *net.Dialer {
+	return &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		Control: func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("safehttp: blocked malformed address %q", address)
+			}
+			if ip := net.ParseIP(host); ip == nil || blocked(ip) {
+				return fmt.Errorf("safehttp: blocked non-public address %s", address)
+			}
+			return nil
+		},
+	}
+}
+
+// NewTransport returns an *http.Transport that dials through the SSRF guard, with
+// sane handshake/idle timeouts so a stalled peer cannot pin a connection open.
+func NewTransport(dialTimeout time.Duration) *http.Transport {
+	d := guardedDialer(dialTimeout)
+	return &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return d.DialContext(ctx, network, addr)
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
+
+// NewClient returns an *http.Client with the SSRF-guarded transport and the given
+// overall timeout. Redirects use the default policy (capped at 10 hops); each hop
+// re-dials through the guard, so a redirect to an internal address is refused.
+func NewClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: NewTransport(5 * time.Second),
+	}
+}

--- a/internal/safehttp/safehttp_test.go
+++ b/internal/safehttp/safehttp_test.go
@@ -22,6 +22,8 @@ func TestBlockedClassifiesAddresses(t *testing.T) {
 		{"192.168.1.1", true},     // RFC1918
 		{"169.254.169.254", true}, // cloud metadata (link-local)
 		{"169.254.1.1", true},     // link-local
+		{"100.64.0.1", true},      // CGNAT / RFC6598 (cloud infra addressing)
+		{"100.127.255.255", true}, // CGNAT upper bound
 		{"0.0.0.0", true},         // unspecified
 		{"fc00::1", true},         // unique local v6
 		{"8.8.8.8", false},        // public

--- a/internal/safehttp/safehttp_test.go
+++ b/internal/safehttp/safehttp_test.go
@@ -1,0 +1,72 @@
+package safehttp
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBlockedClassifiesAddresses(t *testing.T) {
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"127.0.0.1", true},       // loopback
+		{"::1", true},             // loopback v6
+		{"10.0.0.5", true},        // RFC1918
+		{"172.16.3.4", true},      // RFC1918
+		{"192.168.1.1", true},     // RFC1918
+		{"169.254.169.254", true}, // cloud metadata (link-local)
+		{"169.254.1.1", true},     // link-local
+		{"0.0.0.0", true},         // unspecified
+		{"fc00::1", true},         // unique local v6
+		{"8.8.8.8", false},        // public
+		{"1.1.1.1", false},        // public
+		{"93.184.216.34", false},  // public
+	}
+	for _, tc := range cases {
+		ip := net.ParseIP(tc.ip)
+		if ip == nil {
+			t.Fatalf("bad test ip %q", tc.ip)
+		}
+		if got := blocked(ip); got != tc.want {
+			t.Errorf("blocked(%s) = %v, want %v", tc.ip, got, tc.want)
+		}
+	}
+}
+
+func TestClientRefusesLoopback(t *testing.T) {
+	// A server on 127.0.0.1 represents an internal target an SSRF would try to reach.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client := NewClient(5 * time.Second)
+	_, err := client.Get(srv.URL)
+	if err == nil {
+		t.Fatal("expected the guarded client to refuse a loopback target, got nil error")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("error %q does not mention the block", err)
+	}
+}
+
+func TestClientReachesPublicViaControl(t *testing.T) {
+	// A dialer whose Control passes (public IP) must still connect. We can't bind a
+	// public IP locally, so assert the guard lets a public address through by calling
+	// the control hook directly via a custom resolver-free dial to a public literal.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	// Dial a public, non-routable-in-test address: it should fail with a network
+	// error (timeout/unreachable), NOT the safehttp block error.
+	d := guardedDialer(200 * time.Millisecond)
+	_, err := d.DialContext(ctx, "tcp", "8.8.8.8:9")
+	if err != nil && strings.Contains(err.Error(), "blocked") {
+		t.Errorf("public address was blocked: %v", err)
+	}
+}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/net/html"
+
+	"github.com/strelov1/freehire/internal/safehttp"
 )
 
 // The capability interfaces below are the narrow transport roles an adapter depends
@@ -68,6 +70,19 @@ type HTTPClient interface {
 	HeaderJSONPoster
 }
 
+// maxResponseBody caps how many bytes a decoder reads from any response. ATS list
+// feeds run to a few MB at most; this generous ceiling bounds a hostile or buggy
+// endpoint returning a multi-GB body (or a gzip bomb the transport transparently
+// inflates) so it cannot exhaust the worker's memory.
+const maxResponseBody = 32 << 20 // 32 MiB
+
+// limitedBody caps how many bytes a decoder reads from a response while preserving
+// the original Closer, so the connection is still released after the bounded read.
+type limitedBody struct {
+	io.Reader
+	io.Closer
+}
+
 // Client is the real HTTPClient: a timeout-bounded GET with a project User-Agent and
 // a bounded retry-with-backoff on transient (5xx / network) failures. A 4xx is not
 // retried — it will not recover on its own.
@@ -81,7 +96,9 @@ type Client struct {
 // NewClient builds the default ingest HTTP client.
 func NewClient() *Client {
 	return &Client{
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		// Guarded transport: adapters and link-following fetch attacker-influenced
+		// URLs, so the client must refuse internal/metadata targets (SSRF).
+		httpClient: safehttp.NewClient(15 * time.Second),
 		userAgent:  "freehire/0.1 (+https://freehire.dev)",
 		maxRetries: 2,
 		retryDelay: 500 * time.Millisecond,
@@ -237,6 +254,9 @@ func (c *Client) do(ctx context.Context, r request) error {
 
 		switch {
 		case resp.StatusCode >= 200 && resp.StatusCode < 300:
+			// Bound the read so a pathological body cannot OOM the worker; Close still
+			// runs on the underlying body to release the connection.
+			resp.Body = limitedBody{Reader: io.LimitReader(resp.Body, maxResponseBody), Closer: resp.Body}
 			err := r.decode(resp)
 			resp.Body.Close()
 			if err != nil {

--- a/internal/telegram/fetch.go
+++ b/internal/telegram/fetch.go
@@ -6,7 +6,14 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/strelov1/freehire/internal/safehttp"
 )
+
+// maxPreviewBody caps how much of a t.me preview page is read into memory. The
+// preview of a busy channel is tens of KiB; this bounds a hostile or oversized
+// response (including a gzip bomb the transport transparently inflates).
+const maxPreviewBody = 8 << 20 // 8 MiB
 
 // Fetcher reads a channel's latest posts from the public t.me web preview. It is
 // the single transport boundary of the crawl: a future MTProto-based reader (for
@@ -20,7 +27,9 @@ type Fetcher struct {
 // NewFetcher builds the default preview fetcher.
 func NewFetcher() *Fetcher {
 	return &Fetcher{
-		httpClient: &http.Client{Timeout: 15 * time.Second},
+		// Channel names come from config, but the preview host is fixed; the guarded
+		// transport is defence-in-depth against a redirect to an internal target.
+		httpClient: safehttp.NewClient(15 * time.Second),
 		baseURL:    "https://t.me",
 		userAgent:  "freehire/0.1 (+https://freehire.dev)",
 	}
@@ -46,7 +55,7 @@ func (f *Fetcher) Fetch(ctx context.Context, channel string) ([]Post, error) {
 		return nil, fmt.Errorf("telegram: GET %s: status %d", url, resp.StatusCode)
 	}
 
-	page, err := io.ReadAll(resp.Body)
+	page, err := io.ReadAll(io.LimitReader(resp.Body, maxPreviewBody))
 	if err != nil {
 		return nil, fmt.Errorf("telegram: read %s: %w", url, err)
 	}

--- a/internal/telegram/fetch_test.go
+++ b/internal/telegram/fetch_test.go
@@ -22,6 +22,7 @@ func TestFetcherFetchesAndParses(t *testing.T) {
 
 	f := NewFetcher()
 	f.baseURL = srv.URL
+	f.httpClient = srv.Client() // reach the loopback test server past the SSRF guard
 
 	posts, err := f.Fetch(context.Background(), "hrlunapark")
 	if err != nil {
@@ -43,6 +44,7 @@ func TestFetcherErrorsOnHTTPFailure(t *testing.T) {
 
 	f := NewFetcher()
 	f.baseURL = srv.URL
+	f.httpClient = srv.Client() // reach the loopback test server past the SSRF guard
 
 	if _, err := f.Fetch(context.Background(), "foo"); err == nil {
 		t.Fatal("want error on 429, got nil")

--- a/internal/telegram/llm.go
+++ b/internal/telegram/llm.go
@@ -5,16 +5,36 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/tmc/langchaingo/llms"
 	"github.com/tmc/langchaingo/llms/openai"
 )
 
+// defaultExtractTimeout bounds a single LLM call, mirroring the enrichment worker.
+// Without it a stalled gateway hangs the run-once worker indefinitely, holding its
+// cron flock open and stalling the whole telegram_posts queue.
+const defaultExtractTimeout = 90 * time.Second
+
+// maxInputRunes caps the post text sent to the model. Channel posts are short; this
+// bounds a hostile/oversized post so it cannot amplify per-call token cost.
+const maxInputRunes = 24000
+
 // LangChainExtractor implements Extractor over any OpenAI-compatible endpoint via
 // langchaingo — the same provider-agnostic setup as the enrichment worker. The
 // model is asked for a JSON object matching the Extraction contract.
 type LangChainExtractor struct {
-	llm llms.Model
+	llm     llms.Model
+	timeout time.Duration
+}
+
+// truncateRunes returns s clamped to at most max runes, never splitting a rune.
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max])
 }
 
 // NewLangChainExtractor builds an extractor against an OpenAI-compatible endpoint.
@@ -28,15 +48,20 @@ func NewLangChainExtractor(baseURL, apiKey, model string) (*LangChainExtractor, 
 	if err != nil {
 		return nil, fmt.Errorf("telegram: build llm client: %w", err)
 	}
-	return &LangChainExtractor{llm: llm}, nil
+	return &LangChainExtractor{llm: llm, timeout: defaultExtractTimeout}, nil
 }
 
 // Extract asks the model to classify the post and extract its vacancies. It does
 // not validate the result — the runner validates before persisting.
 func (e *LangChainExtractor) Extract(ctx context.Context, text string, kind Kind) (Extraction, error) {
+	if e.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, e.timeout)
+		defer cancel()
+	}
 	messages := []llms.MessageContent{
 		llms.TextParts(llms.ChatMessageTypeSystem, extractSystemPrompt(kind)),
-		llms.TextParts(llms.ChatMessageTypeHuman, text),
+		llms.TextParts(llms.ChatMessageTypeHuman, truncateRunes(text, maxInputRunes)),
 	}
 	resp, err := e.llm.GenerateContent(ctx, messages, llms.WithJSONMode())
 	if err != nil {

--- a/internal/telegram/llm.go
+++ b/internal/telegram/llm.go
@@ -28,13 +28,13 @@ type LangChainExtractor struct {
 	timeout time.Duration
 }
 
-// truncateRunes returns s clamped to at most max runes, never splitting a rune.
-func truncateRunes(s string, max int) string {
+// truncateRunes returns s clamped to at most limit runes, never splitting a rune.
+func truncateRunes(s string, limit int) string {
 	r := []rune(s)
-	if len(r) <= max {
+	if len(r) <= limit {
 		return s
 	}
-	return string(r[:max])
+	return string(r[:limit])
 }
 
 // NewLangChainExtractor builds an extractor against an OpenAI-compatible endpoint.

--- a/internal/telegram/truncate_test.go
+++ b/internal/telegram/truncate_test.go
@@ -1,0 +1,20 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateRunes(t *testing.T) {
+	if got := truncateRunes("hello", 10); got != "hello" {
+		t.Errorf("short input changed: %q", got)
+	}
+	long := strings.Repeat("я", 100) // multi-byte runes
+	got := truncateRunes(long, 10)
+	if n := len([]rune(got)); n != 10 {
+		t.Errorf("rune length = %d, want 10", n)
+	}
+	if strings.ContainsRune(got, '�') {
+		t.Error("truncation split a multi-byte rune")
+	}
+}

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -5,6 +5,15 @@
 server {
     listen 80;
 
+    # Security headers applied to every response. TLS is terminated upstream, so the
+    # browser sees these over HTTPS. These are the non-breaking baseline; a script-src
+    # CSP is configured in svelte.config.js (nonce-based) so it doesn't break SSR
+    # hydration. `always` emits them on error responses too.
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
     # Resolve the backend hostname at request time (Docker's embedded DNS), not at
     # startup — so the web container boots even if `app` is briefly down/unresolved
     # instead of nginx refusing to start. The literal Node upstream needs no resolver.

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -26,6 +26,10 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # The backend keys its rate limiter on X-Real-IP. nginx OVERWRITES it with the
+        # real peer ($remote_addr), so a client cannot spoof it — unlike X-Forwarded-For,
+        # which is a client-appendable list.
+        proxy_set_header X-Real-IP $remote_addr;
     }
 
     location = /health {

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -25,6 +25,10 @@ export default {
       mode: 'auto',
       directives: {
         'script-src': ['self', 'sha256-qvzE1AlG+fDQlxleonlMQaOrsjjgE6qfHfnkE0pD/bo='],
+        // Cheap defence-in-depth: pin the document base (no <base> injection) and
+        // forbid legacy plugin/embed vectors.
+        'base-uri': ['self'],
+        'object-src': ['none'],
       },
     },
   },

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -9,5 +9,23 @@ export default {
     // fronts it and proxies /api + /health to the Go backend, keeping the SPA
     // and API same-origin for the SameSite=Lax auth cookie.
     adapter: adapter(),
+
+    // Content-Security-Policy: defence-in-depth against stored/reflected XSS. Only
+    // same-origin scripts run; SvelteKit auto-adds a per-response nonce (mode 'auto')
+    // to the inline scripts IT injects (the hydration bootstrap). Inline JSON-LD
+    // (<script type="application/ld+json">) is non-executable and unaffected.
+    // style-src/img-src are left unset (no default-src), so styles/fonts/logo.dev
+    // images are unrestricted.
+    //
+    // The anti-FOUC theme script in app.html is author-written, so SvelteKit does NOT
+    // nonce it — it is allowed by the SHA-256 of its exact contents below. WARNING:
+    // editing that <script> in app.html changes its hash and will silently break the
+    // no-flash theme load; recompute and update this hash when you touch it.
+    csp: {
+      mode: 'auto',
+      directives: {
+        'script-src': ['self', 'sha256-qvzE1AlG+fDQlxleonlMQaOrsjjgE6qfHfnkE0pD/bo='],
+      },
+    },
   },
 };


### PR DESCRIPTION
Fixes from a whole-project security review (no Critical found; all verified by tests + build + runtime).

## High
- **Stored XSS (moderator/bulk-import):** `internal/moderation` now sanitizes job descriptions on Create/Update via `sources.SanitizeHTML`. The path rendered scraped HTML through `{@html}` unsanitized — every other source already sanitized.
- **SSRF egress filter:** new `internal/safehttp` builds an HTTP client whose dialer `Control` refuses private/loopback/link-local/metadata IPs **after DNS resolution** (defeats DNS rebinding and direct-IP targets, on every redirect hop). Wired into the `sources`, `telegram`, and `liveness` fetchers.

## Medium
- **SSRF via redirect (linksource):** `remoteyeah`/`geekjob` now revalidate the resolved host after redirects (mirrors `habrcareer`).
- **Unbounded body reads:** `io.LimitReader` on `sources` (32 MiB) and the telegram preview (8 MiB) — guards memory exhaustion / gzip bombs.
- **LLM availability/cost:** per-call timeout in `tg-extract` (mirrors `enrich`) + input-size cap on both extraction and enrichment.

## Low
- `JWT_SECRET` must be ≥ 32 bytes (fail-fast).
- `BodyLimit` 1 MB (was Fiber's 4 MB default).
- Rate-limit `login`/`register` (10/min) with proxy-aware client IP (XFF trusted only from the in-network nginx).
- Reject passwords > 72 bytes (bcrypt silently truncates).
- nginx security headers (`X-Frame-Options`/`nosniff`/`Referrer-Policy`/`HSTS`) + SvelteKit CSP `script-src 'self'` (nonce for SvelteKit scripts, SHA-256 for the app.html theme script).
- `.gitignore` scratch artifacts + the `gen-contracts` binary.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` — green; new tests for safehttp IP classification, linksource redirect rejection, moderation sanitize, bcrypt max-length, truncate.
- `web`: `npm run build` OK; SSR runtime-checked — CSP header carries the nonce **and** the theme-script hash, every emitted `<script>` is nonce/hash/`'self'`-covered (no FOUC regression).

## Notes / assumptions
- **CSP hash is byte-fragile:** editing the anti-FOUC `<script>` in `web/src/app.html` changes its hash and silently breaks the no-flash theme load — `svelte.config.js` carries a warning to recompute it.
- **L2 proxy trust:** XFF is trusted only from RFC1918 peers (the compose nginx). If the API is ever exposed publicly without a proxy, the limiter is XFF-spoofable — confirm topology.
- Deliberately skipped: per-field length caps on moderation (asymmetric vs ATS sources; `BodyLimit` covers the DoS root) and rate-limiting `/jobs/search` (throttling core UX > benefit).