### PR TITLE
fix(enrich): drop implausible salary + per-currency analytics salary range

### DIFF
--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -181,6 +181,25 @@ func (e *Enrichment) Sanitize() {
 
 	e.Regions = keepKnown(e.Regions, RegionValues)
 	e.Domains = keepKnown(e.Domains, DomainValues)
+
+	// Drop implausible salary values: a non-positive salary is meaningless, and an
+	// inverted min>max pair is internally inconsistent. There is deliberately no
+	// absolute upper bound — high-denomination currencies (CLP, IDR, HUF, …) make
+	// millions a normal salary, so a numeric ceiling would discard valid data.
+	e.SalaryMin = positiveOrNil(e.SalaryMin)
+	e.SalaryMax = positiveOrNil(e.SalaryMax)
+	if e.SalaryMin != nil && e.SalaryMax != nil && *e.SalaryMin > *e.SalaryMax {
+		e.SalaryMin, e.SalaryMax = nil, nil
+	}
+}
+
+// positiveOrNil drops a non-positive salary figure to nil (an absent salary), so
+// a zero or negative value never persists.
+func positiveOrNil(n *int) *int {
+	if n == nil || *n > 0 {
+		return n
+	}
+	return nil
 }
 
 // keepKnown returns values restricted to those present in vocab, preserving order;

--- a/internal/enrich/enrichment_test.go
+++ b/internal/enrich/enrichment_test.go
@@ -217,3 +217,44 @@ func TestSanitizeDropsOutOfVocabValues(t *testing.T) {
 		t.Errorf("Validate after Sanitize = %v, want nil", err)
 	}
 }
+
+func TestSanitizeDropsImplausibleSalary(t *testing.T) {
+	t.Run("non-positive salary is dropped", func(t *testing.T) {
+		e := Enrichment{SalaryMin: ptr(-1), SalaryMax: ptr(0)}
+		e.Sanitize()
+		if e.SalaryMin != nil {
+			t.Errorf("SalaryMin = %v, want nil (negative dropped)", *e.SalaryMin)
+		}
+		if e.SalaryMax != nil {
+			t.Errorf("SalaryMax = %v, want nil (zero dropped)", *e.SalaryMax)
+		}
+	})
+
+	t.Run("valid positive salary kept, including high-denomination currencies", func(t *testing.T) {
+		// 58.8M CLP/year (~$61k) is a real salary — no absolute upper clamp.
+		e := Enrichment{SalaryMin: ptr(49_980_000), SalaryMax: ptr(58_800_000), SalaryCurrency: "CLP"}
+		e.Sanitize()
+		if e.SalaryMin == nil || *e.SalaryMin != 49_980_000 {
+			t.Errorf("SalaryMin = %v, want kept", e.SalaryMin)
+		}
+		if e.SalaryMax == nil || *e.SalaryMax != 58_800_000 {
+			t.Errorf("SalaryMax = %v, want kept", e.SalaryMax)
+		}
+	})
+
+	t.Run("inconsistent min > max drops both", func(t *testing.T) {
+		e := Enrichment{SalaryMin: ptr(200_000), SalaryMax: ptr(100_000)}
+		e.Sanitize()
+		if e.SalaryMin != nil || e.SalaryMax != nil {
+			t.Errorf("min>max should drop both, got min=%v max=%v", e.SalaryMin, e.SalaryMax)
+		}
+	})
+
+	t.Run("min alone or max alone is preserved when positive", func(t *testing.T) {
+		e := Enrichment{SalaryMax: ptr(120_000)}
+		e.Sanitize()
+		if e.SalaryMax == nil || *e.SalaryMax != 120_000 {
+			t.Errorf("lone positive SalaryMax = %v, want kept", e.SalaryMax)
+		}
+	})
+}

--- a/web/src/lib/components/AnalyticsView.svelte
+++ b/web/src/lib/components/AnalyticsView.svelte
@@ -63,9 +63,16 @@
     return () => clearTimeout(timer);
   });
 
-  // The salary range across the matched set: the floor of salary_min and the
-  // ceiling of salary_max (numeric facets are exposed as stats, not bars).
+  // The salary range is only meaningful within a single currency — the stats
+  // aggregate across every currency in the matched set, so a cross-currency
+  // min–max would mix e.g. USD and CLP. Show it only when exactly one currency
+  // is selected (include mode), and label it with that currency.
+  const salaryCurrency = $derived.by(() => {
+    const st = filters.facet('salary_currency');
+    return !st.exclude && st.values.length === 1 ? st.values[0] : null;
+  });
   const salary = $derived.by(() => {
+    if (!salaryCurrency) return null;
     const lo = counts.stats.salary_min?.min;
     const hi = counts.stats.salary_max?.max;
     return lo != null && hi != null && hi > 0 ? { lo, hi } : null;
@@ -92,7 +99,7 @@
         </p>
         {#if salary}
           <p class="mt-1 text-xs text-muted-foreground">
-            Salary range: {salary.lo.toLocaleString()}–{salary.hi.toLocaleString()}
+            Salary range ({salaryCurrency}): {salary.lo.toLocaleString()}–{salary.hi.toLocaleString()}
           </p>
         {/if}
       </div>


### PR DESCRIPTION
Follow-up to the analytics page (#85): the "Salary range" stat showed `-1 … 58,800,000`.

## Investigation
Checked prod data: the millions are **legit** salaries in high-denomination currencies (58.8M CLP/yr ≈ $61k, 25M IDR/mo, HUF/JPY/ISK/INR). The only real garbage was one `salary_min = -1` (+ one negative max). An absolute upper clamp would destroy valid data. Two separate issues:

## Fixes
1. **`enrich.Sanitize`** drops non-positive `salary_min`/`salary_max` and inverted `min > max` pairs — same "salvage the payload, never persist an invalid value" philosophy as the existing enum sanitize. **No** absolute upper bound (currency-dependent). Prevents the garbage going forward.
2. **`/analytics` salary range** is inherently cross-currency in `facetStats` (mixing USD + CLP is meaningless, and it's what surfaced the `-1`). Now shown **only when a single `salary_currency` is selected**, labeled with that currency.

## Tests
- TDD: `TestSanitizeDropsImplausibleSalary` (non-positive dropped, high-currency kept, min>max drops both, lone value kept).
- `go test ./...` green; `svelte-check` 0/0.

## Deploy note
Existing rows keep their bad value until re-enriched — a one-off prod cleanup (`UPDATE … SET enrichment = enrichment - 'salary_min'` where ≤0) + reindex clears the 2 stale rows immediately.