### PR TITLE
feat(web): add /cli docs page for the freehire CLI

### DIFF
--- a/web/src/lib/components/ApiKeysView.svelte
+++ b/web/src/lib/components/ApiKeysView.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { page } from '$app/state';
   import { createApiKey, listApiKeys, revokeApiKey } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import type { ApiKey, CreatedApiKey } from '$lib/types';
@@ -27,9 +26,12 @@
   let revealed = $state.raw<CreatedApiKey | null>(null);
   let copied = $state(false);
 
-  const curlExample = $derived(
+  // Show the fastest path to actually using the key: hand it to the CLI and
+  // search. The raw Bearer-header call still works (noted in the page intro),
+  // but the CLI is the intended client — see /cli.
+  const cliExample = $derived(
     revealed
-      ? `curl -H "Authorization: Bearer ${revealed.token}" \\\n  ${page.url.origin}/api/v1/jobs/search?q=golang`
+      ? `freehire auth login --token ${revealed.token}\nfreehire search "golang" --remote`
       : '',
   );
 
@@ -108,7 +110,8 @@
       <h1 class="text-2xl font-semibold tracking-tight">API keys</h1>
       <p class="text-sm text-muted-foreground">
         Reach the API without a browser — search, open jobs, and track applications from a script.
-        Send the key as
+        Use the <a href="/cli" class="font-medium text-foreground underline-offset-4 hover:underline">freehire CLI</a>,
+        or send the key directly as
         <code class="rounded bg-muted px-1 py-0.5 font-mono text-xs">Authorization: Bearer &lt;key&gt;</code>.
       </p>
     </div>
@@ -136,7 +139,10 @@
           <Button variant="secondary" size="sm" onclick={copyToken}>{copied ? 'Copied' : 'Copy'}</Button>
         </div>
         <pre
-          class="overflow-x-auto rounded bg-background px-3 py-2 font-mono text-xs text-muted-foreground">{curlExample}</pre>
+          class="overflow-x-auto rounded bg-background px-3 py-2 font-mono text-xs text-muted-foreground">{cliExample}</pre>
+        <p class="text-xs text-muted-foreground">
+          New to the CLI? See the <a href="/cli" class="font-medium text-foreground underline-offset-4 hover:underline">command reference</a>.
+        </p>
       </div>
     {/if}
 

--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+  import { Button } from '$lib/ui';
+
+  const CLI_REPO = 'https://github.com/strelov1/freehire-cli';
+  const INSTALL = 'curl -fsSL https://freehire.dev/install.sh | sh';
+
+  // Command reference, mirroring the freehire-cli README verbatim. Two groups:
+  // first you find jobs, then you track your interaction with them.
+  const discover = [
+    { cmd: 'search <query>', desc: 'List matching jobs (add --remote, --region, --company).' },
+    { cmd: 'job <slug>', desc: "Show a job's full content." },
+    { cmd: 'company <slug>', desc: 'Show a company and its open jobs.' },
+  ];
+
+  const track = [
+    { cmd: 'apply <slug>', desc: 'Mark a job applied for your account.' },
+    { cmd: 'save <slug>', desc: 'Bookmark a job (unsave to remove).' },
+    { cmd: 'stage <slug> <stage>', desc: 'Set the application stage.' },
+    { cmd: 'note <slug> <text>', desc: 'Attach a free-text note.' },
+    { cmd: 'my --filter applied', desc: 'Your tracked jobs (all|viewed|saved|applied).' },
+  ];
+
+  // Tasteful micro-interaction: copy the install one-liner, flash a confirmation.
+  let copied = $state(false);
+  let copyTimer: ReturnType<typeof setTimeout> | undefined;
+  async function copyInstall() {
+    try {
+      await navigator.clipboard.writeText(INSTALL);
+      copied = true;
+      clearTimeout(copyTimer);
+      copyTimer = setTimeout(() => (copied = false), 1600);
+    } catch {
+      // Clipboard can be blocked (no permission / insecure context) — the command
+      // is plainly visible to select by hand, so a failed copy needs no fallback.
+    }
+  }
+</script>
+
+<div class="cli">
+  <!-- Hero. Left: the pitch, framed for agents. Right: the only terminal on the
+       page — install, authenticate, search. -->
+  <section class="grid-bg relative -mx-4 px-4 pb-16 pt-12 sm:pt-16">
+    <div class="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
+      <div>
+        <p class="reveal font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground" style="--d:0ms">
+          // freehire on the command line
+        </p>
+
+        <h1
+          class="reveal mt-6 max-w-2xl text-balance text-4xl font-semibold leading-[0.98] tracking-tighter sm:text-6xl"
+          style="--d:80ms"
+        >
+          Search and track<br />from the terminal.
+        </h1>
+
+        <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
+          <code class="font-mono text-foreground">freehire</code> is a small CLI over the same job API the
+          site runs on — so an <span class="text-foreground">AI agent</span> or a script can search and open
+          jobs, then track applications and notes without a browser. (You still apply on the employer's
+          site; the CLI records that you did.)
+        </p>
+
+        <div class="reveal mt-9 flex flex-wrap items-center gap-3" style="--d:240ms">
+          <Button href="/my/api-keys" variant="primary" size="lg">Get an API key</Button>
+          <Button href={CLI_REPO} target="_blank" rel="noopener noreferrer" variant="outline" size="lg">
+            Source ↗
+          </Button>
+        </div>
+      </div>
+
+      <figure
+        class="reveal overflow-hidden rounded-xl border border-border bg-secondary/60 font-mono text-sm shadow-sm"
+        style="--d:320ms"
+      >
+        <figcaption
+          class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground"
+        >
+          <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+          terminal
+          <button
+            type="button"
+            onclick={copyInstall}
+            class="ml-auto rounded-md border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {copied ? 'copied ✓' : 'copy'}
+          </button>
+        </figcaption>
+        <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># install — no Go needed</span>
+curl -fsSL <span class="text-foreground">https://freehire.dev/install.sh</span> | sh
+
+<span class="text-muted-foreground"># authenticate once (key from /my/api-keys)</span>
+freehire auth login --token <span class="text-foreground">fhk_…</span>
+
+<span class="text-muted-foreground"># search</span>
+freehire search <span class="text-foreground">"golang"</span> --remote --region eu</pre>
+      </figure>
+    </div>
+  </section>
+
+  <!-- Commands — the whole reference, compact. -->
+  <section class="border-t border-border py-14 sm:py-16">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// commands</p>
+    <div class="mt-8 grid gap-x-12 gap-y-8 sm:grid-cols-2">
+      <div>
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Discover</h2>
+        <dl class="mt-4 space-y-3">
+          {#each discover as row (row.cmd)}
+            <div>
+              <dt class="font-mono text-sm">
+                <span class="text-muted-foreground">freehire</span> {row.cmd}
+              </dt>
+              <dd class="text-sm leading-relaxed text-muted-foreground">{row.desc}</dd>
+            </div>
+          {/each}
+        </dl>
+      </div>
+      <div>
+        <h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Track applications &amp; notes
+        </h2>
+        <dl class="mt-4 space-y-3">
+          {#each track as row (row.cmd)}
+            <div>
+              <dt class="font-mono text-sm">
+                <span class="text-muted-foreground">freehire</span> {row.cmd}
+              </dt>
+              <dd class="text-sm leading-relaxed text-muted-foreground">{row.desc}</dd>
+            </div>
+          {/each}
+        </dl>
+      </div>
+    </div>
+    <p class="mt-8 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      Everything you save, apply to and stage shows up on your
+      <a href="/my/jobs" class="font-medium text-foreground underline-offset-4 hover:underline">My jobs</a>
+      board.
+      <code class="font-mono text-foreground">stage</code> takes a controlled value:
+      <span class="font-mono text-foreground"
+        >applied → screening → responded → interview → offer → accepted</span
+      >, plus <span class="font-mono text-foreground">rejected</span> /
+      <span class="font-mono text-foreground">withdrawn</span>. For scripts and agents, add
+      <code class="font-mono text-foreground">--json</code> for the raw API payload; results go to stdout,
+      errors to stderr, and a non-zero exit code signals failure.
+    </p>
+  </section>
+
+  <!-- Moderators — gated authoring, kept to one line + two commands. -->
+  <section class="border-t border-border py-14 sm:py-16">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// moderators</p>
+    <p class="mt-6 max-w-2xl leading-relaxed text-muted-foreground">
+      With the <code class="font-mono text-foreground">moderator</code> role you can author postings (a
+      regular key gets <code class="font-mono text-foreground">403</code>):
+    </p>
+    <pre
+      class="mt-4 max-w-2xl overflow-x-auto rounded-lg border border-border bg-secondary/60 p-3 font-mono text-sm leading-relaxed">freehire jobs add --url &lt;url&gt; --title "Senior Go Developer" --company Acme
+freehire jobs edit &lt;slug&gt; --title "Staff Go Developer"</pre>
+  </section>
+
+  <!-- Free / open-source / transparent — the project's promise, with the source. -->
+  <section class="border-t border-border py-10">
+    <p class="text-sm leading-relaxed text-muted-foreground">
+      Free and open source — no tracking, no lock-in. Read every line on
+      <a
+        href={CLI_REPO}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="font-medium text-foreground underline-offset-4 hover:underline">GitHub ↗</a
+      >.
+    </p>
+  </section>
+</div>
+
+<style>
+  /* Dotted hero background, faded toward the edges with a radial mask — the same
+     device the homepage hero uses, so the CLI page reads as the same product.
+     Component styles are scoped, so this is duplicated rather than shared. */
+  .grid-bg::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background-image: radial-gradient(var(--muted-foreground) 1px, transparent 1.2px);
+    background-size: 22px 22px;
+    opacity: 0.16;
+    -webkit-mask-image: radial-gradient(ellipse 90% 75% at 25% 0%, #000 18%, transparent 80%);
+    mask-image: radial-gradient(ellipse 90% 75% at 25% 0%, #000 18%, transparent 80%);
+  }
+
+  /* One orchestrated page-load: each .reveal rises in, staggered by its --d. */
+  .reveal {
+    opacity: 0;
+    animation: rise 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+    animation-delay: var(--d, 0ms);
+  }
+  @keyframes rise {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reveal {
+      animation: none;
+      opacity: 1;
+    }
+  }
+</style>

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -3,6 +3,8 @@
 
   const GITHUB = 'https://github.com/strelov1/freehire';
   const CLI = 'https://github.com/strelov1/freehire-cli';
+  // Deep-link to the file a contributor edits to add their own source.
+  const SOURCES = `${GITHUB}/blob/main/sources.yml`;
 
   // The real adapters behind the pipeline — listed verbatim so the page never
   // overpromises sources the ingest worker can't actually crawl.
@@ -51,7 +53,7 @@
     <div class="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
       <div>
         <p class="reveal font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground" style="--d:0ms">
-          // open-source · free forever
+          // open-source · free &amp; transparent
         </p>
 
         <h1
@@ -156,16 +158,16 @@
           Use it from the terminal. Built for agents.
         </h2>
         <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
-          freehire is also a CLI, so an AI agent or a script can search, open and apply to jobs over the
+          freehire is also a CLI, so an AI agent or a script can search, open and track jobs over the
           same API — no browser. Create an API key and it lives in
           <code class="font-mono text-foreground">~/.freehire/creds.json</code>; add
           <code class="font-mono text-foreground">--json</code> for machine-readable output.
         </p>
         <div class="mt-8 flex flex-wrap gap-3">
-          <Button href={CLI} target="_blank" rel="noopener noreferrer" variant="primary" size="lg">
-            freehire-cli on GitHub ↗
+          <Button href="/cli" variant="primary" size="lg">Explore the CLI</Button>
+          <Button href={CLI} target="_blank" rel="noopener noreferrer" variant="ghost" size="lg">
+            View on GitHub ↗
           </Button>
-          <Button href="/my/api-keys" variant="ghost" size="lg">Get an API key</Button>
         </div>
       </div>
 
@@ -181,10 +183,10 @@
         <pre class="overflow-x-auto p-4 leading-relaxed"><span class="text-muted-foreground"># install — no Go needed</span>
 curl -fsSL <span class="text-foreground">https://freehire.dev/install.sh</span> | sh
 
-<span class="text-muted-foreground"># authenticate once, then search &amp; apply</span>
+<span class="text-muted-foreground"># authenticate once, then search &amp; track</span>
 freehire auth login --token <span class="text-foreground">fhk_…</span>
 freehire search <span class="text-foreground">"golang"</span> --remote --region eu
-freehire apply <span class="text-foreground">&lt;slug&gt;</span></pre>
+freehire save <span class="text-foreground">&lt;slug&gt;</span></pre>
       </figure>
     </div>
   </section>
@@ -196,18 +198,20 @@ freehire apply <span class="text-foreground">&lt;slug&gt;</span></pre>
     <div class="mt-6 grid gap-10 lg:grid-cols-2 lg:items-center">
       <div>
         <h2 class="max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
-          Built in the open. Add the company you want to see.
+          Built in the open. Add your own source.
         </h2>
         <p class="mt-5 max-w-md leading-relaxed text-muted-foreground">
-          Adding a company is one entry in <code class="font-mono text-foreground">sources.yml</code>. A
-          new ATS platform is one adapter. The backend is Go, the frontend is Svelte, the license is MIT —
-          issues and pull requests welcome.
+          Missing a company? Add it yourself — one entry in
+          <code class="font-mono text-foreground">sources.yml</code>. A new ATS platform is one adapter. The
+          backend is Go, the frontend is Svelte, the license is MIT — issues and pull requests welcome.
         </p>
         <div class="mt-8 flex flex-wrap gap-3">
-          <Button href={GITHUB} target="_blank" rel="noopener noreferrer" variant="primary" size="lg">
+          <Button href={SOURCES} target="_blank" rel="noopener noreferrer" variant="primary" size="lg">
+            Add a source ↗
+          </Button>
+          <Button href={GITHUB} target="_blank" rel="noopener noreferrer" variant="ghost" size="lg">
             Star on GitHub ↗
           </Button>
-          <Button href="/jobs" variant="ghost" size="lg">Start searching</Button>
         </div>
       </div>
 

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -16,6 +16,7 @@
     { href: '/jobs', label: 'Jobs' },
     { href: '/companies', label: 'Companies' },
     { href: '/analytics', label: 'Analytics' },
+    { href: '/cli', label: 'CLI' },
   ];
 
   // A link is active for its own path and any sub-route (e.g. /jobs and

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -27,14 +27,22 @@
       class="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-3 text-xs text-muted-foreground"
     >
       <p>Free, open-source IT job aggregator.</p>
-      <a
-        href="https://github.com/strelov1/freehire"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="inline-flex shrink-0 items-center gap-1.5 font-medium text-foreground transition-colors hover:text-muted-foreground"
-      >
-        <ProviderIcon provider="github" /> GitHub
-      </a>
+      <div class="flex shrink-0 items-center gap-4">
+        <a
+          href="/cli"
+          class="shrink-0 font-medium text-foreground transition-colors hover:text-muted-foreground"
+        >
+          CLI
+        </a>
+        <a
+          href="https://github.com/strelov1/freehire"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex shrink-0 items-center gap-1.5 font-medium text-foreground transition-colors hover:text-muted-foreground"
+        >
+          <ProviderIcon provider="github" /> GitHub
+        </a>
+      </div>
     </div>
   </footer>
 </div>

--- a/web/src/routes/cli/+page.svelte
+++ b/web/src/routes/cli/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import CliView from '$lib/components/CliView.svelte';
+  import Seo from '$lib/components/Seo.svelte';
+
+  const canonical = $derived(`${page.url.origin}/cli`);
+</script>
+
+<Seo
+  title="freehire CLI — search and track jobs from the terminal"
+  description="A small Go CLI over the freehire job API, built so an AI agent or a script can search, open and track jobs from the terminal — no browser. Authenticate once with an API key."
+  {canonical}
+/>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <CliView />
+</div>

--- a/web/src/routes/sitemap.xml/+server.ts
+++ b/web/src/routes/sitemap.xml/+server.ts
@@ -66,6 +66,7 @@ export const GET: RequestHandler = async ({ url, fetch }) => {
     { loc: `${origin}/` },
     { loc: `${origin}/jobs` },
     { loc: `${origin}/companies` },
+    { loc: `${origin}/cli` },
   ];
 
   const [jobs, companies] = await Promise.all([


### PR DESCRIPTION
## What

A dedicated, agent-focused documentation page at `/cli` for the freehire CLI.

### `/cli` page (`CliView.svelte` + `routes/cli/+page.svelte`)
- **Install** (curl one-liner with copy button), **authenticate**, and a compact **command reference**: `search`/`job`/`company` (Discover) and `apply`/`save`/`stage`/`note`/`my` (Track).
- `stage` controlled vocabulary + `--json`/stdout/stderr/exit-code note for agents.
- **Moderators** block (`jobs add`/`jobs edit`, role-gated).
- Links to the **/my/jobs** tracking board and to the source on GitHub ("free & transparent").

### Wiring
- CLI link in the header nav and footer.
- Homepage CLI section button → `/cli`.
- `/cli` added to `sitemap.xml`.

### Copy / honesty
- Homepage "// open source" section reframed to **"Add your own source"**, primary button deep-links to `sources.yml`.
- Hero kicker: `free forever` → **`free & transparent`**.
- API-keys page example now uses the **CLI** (`freehire auth login` + `search`) instead of a raw `curl` call.
- `apply` is a tracking mark (the real application is on the employer's site), so the headline is **"Search and track from the terminal"** rather than "apply".

## Verification
- `npm run check` (svelte-kit sync + svelte-check): 0 errors / 0 warnings.
- Reviewed live in the browser (light + dark).