### PR TITLE
feat(web): mobile nav menu + recruiters width + footer Telegram link

### DIFF
--- a/web/src/lib/components/CliView.svelte
+++ b/web/src/lib/components/CliView.svelte
@@ -148,8 +148,7 @@ freehire search <span class="text-foreground">"golang"</span> --remote --region 
   <section class="border-t border-border py-14 sm:py-16">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// moderators</p>
     <p class="mt-6 max-w-2xl leading-relaxed text-muted-foreground">
-      With the <code class="font-mono text-foreground">moderator</code> role you can author postings (a
-      regular key gets <code class="font-mono text-foreground">403</code>):
+      With the <code class="font-mono text-foreground">moderator</code> role you can author postings:
     </p>
     <pre
       class="mt-4 max-w-2xl overflow-x-auto rounded-lg border border-border bg-secondary/60 p-3 font-mono text-sm leading-relaxed">freehire jobs add --url &lt;url&gt; --title "Senior Go Developer" --company Acme

--- a/web/src/lib/components/ProviderIcon.svelte
+++ b/web/src/lib/components/ProviderIcon.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  // Brand marks for the OAuth sign-in buttons, inlined because icon libraries
-  // (lucide) do not ship brand logos. Google keeps its official colors; GitHub
-  // follows the current text color so it adapts to the theme; LinkedIn uses
-  // its brand blue.
+  // Brand marks (OAuth sign-in buttons, footer links), inlined because icon
+  // libraries (lucide) do not ship brand logos. Google keeps its official
+  // colors; GitHub and Telegram follow the current text color so they adapt to
+  // the theme; LinkedIn uses its brand blue.
   let { provider }: { provider: string } = $props();
 </script>
 
@@ -29,6 +29,12 @@
   <svg viewBox="0 0 24 24" class="size-4" fill="currentColor" aria-hidden="true">
     <path
       d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+    />
+  </svg>
+{:else if provider === 'telegram'}
+  <svg viewBox="0 0 24 24" class="size-4" fill="currentColor" aria-hidden="true">
+    <path
+      d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.139-5.061 3.345-.479.329-.913.489-1.302.481-.428-.009-1.252-.242-1.865-.44-.752-.244-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"
     />
   </svg>
 {:else if provider === 'linkedin'}

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { page } from '$app/state';
   import { replaceState } from '$app/navigation';
+  import { Menu, X } from '@lucide/svelte';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { authDialog, openAuthDialog, closeAuthDialog } from '$lib/auth-dialog.svelte';
   import { cn } from '$lib/utils';
@@ -11,6 +12,11 @@
   import UserMenu from './UserMenu.svelte';
 
   const path = $derived(page.url.pathname);
+
+  // The nav links collapse behind a hamburger below the `sm` breakpoint, where
+  // five inline links would overflow the bar. The panel closes on link tap,
+  // Escape, and whenever the route changes.
+  let mobileOpen = $state(false);
 
   const links = [
     { href: '/jobs', label: 'Jobs' },
@@ -38,16 +44,19 @@
   });
 </script>
 
+<svelte:window onkeydown={(e) => e.key === 'Escape' && (mobileOpen = false)} />
+
 <header class="border-b border-border">
   <div class="mx-auto flex h-14 max-w-6xl items-center gap-3 px-4 sm:gap-6">
     <a href="/" class="text-sm font-semibold tracking-tight">FreeHire</a>
 
-    <nav class="flex items-center gap-4 text-sm">
+    <!-- Desktop nav: inline links from `sm` up. -->
+    <nav class="hidden items-center gap-4 text-sm sm:flex">
       {#each links as link (link.href)}
         <a
           href={link.href}
           class={cn(
-            'transition-colors hover:text-foreground',
+            'whitespace-nowrap transition-colors hover:text-foreground',
             isActive(link.href) ? 'text-foreground' : 'text-muted-foreground',
           )}
         >
@@ -56,15 +65,48 @@
       {/each}
     </nav>
 
-    <div class="ml-auto flex items-center gap-3">
+    <div class="ml-auto flex items-center gap-2 sm:gap-3">
       {#if isAuthenticated()}
         <UserMenu />
       {:else}
         <Button variant="primary" size="sm" onclick={() => openAuthDialog('login')}>Sign in</Button>
       {/if}
       <ThemeToggle />
+
+      <!-- Mobile nav toggle: only below `sm`. -->
+      <button
+        type="button"
+        onclick={() => (mobileOpen = !mobileOpen)}
+        aria-label="Toggle navigation menu"
+        aria-expanded={mobileOpen}
+        class="inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground sm:hidden"
+      >
+        {#if mobileOpen}
+          <X class="size-5" />
+        {:else}
+          <Menu class="size-5" />
+        {/if}
+      </button>
     </div>
   </div>
+
+  <!-- Mobile nav panel: stacked links, shown when the hamburger is open. -->
+  {#if mobileOpen}
+    <nav class="flex flex-col border-t border-border px-4 py-1 sm:hidden">
+      {#each links as link (link.href)}
+        <a
+          href={link.href}
+          onclick={() => (mobileOpen = false)}
+          class={cn(
+            'rounded-md px-2 py-2.5 text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
+            isActive(link.href) ? 'text-foreground' : 'text-muted-foreground',
+          )}
+        >
+          {link.label}
+        </a>
+      {/each}
+    </nav>
+  {/if}
 </header>
 
 {#if authDialog.open}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -35,6 +35,14 @@
           CLI
         </a>
         <a
+          href="https://t.me/freehiredev"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex shrink-0 items-center gap-1.5 font-medium text-foreground transition-colors hover:text-muted-foreground"
+        >
+          <ProviderIcon provider="telegram" /> Ask a question
+        </a>
+        <a
           href="https://github.com/strelov1/freehire"
           target="_blank"
           rel="noopener noreferrer"

--- a/web/src/routes/recruiters/+page.svelte
+++ b/web/src/routes/recruiters/+page.svelte
@@ -10,6 +10,6 @@
   />
 </svelte:head>
 
-<div class="mx-auto w-full max-w-4xl px-4 py-10">
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
   <RecruitersView />
 </div>


### PR DESCRIPTION
Follow-up web polish on top of #91.

## Changes
- **Mobile header**: the nav links (Jobs/Companies/Analytics/CLI/For recruiters) overflowed on phones. They now collapse behind a hamburger below the `sm` breakpoint and open in a stacked panel (closes on tap/Escape). Desktop nav unchanged.
- **/recruiters**: container width now matches the home page (`max-w-6xl`, was `max-w-4xl`).
- **Footer**: Telegram "Ask a question" link → https://t.me/freehiredev + a CLI link, with a Telegram brand mark in `ProviderIcon`.
- **/cli**: removed the "(a regular key gets 403)" aside.

## Verification
Driven on a 390px mobile viewport (iPhone 14, headless): no horizontal overflow on any page; hamburger + avatar dropdown + submit/moderation/my-submissions/recruiters/cli/companies all render correctly. `svelte-check` 0 errors, SSR build clean.