### PR TITLE
feat(submissions): link approved submissions to their live vacancy

### DIFF
--- a/internal/db/job_submissions.sql.go
+++ b/internal/db/job_submissions.sql.go
@@ -171,21 +171,45 @@ func (q *Queries) ListPendingSubmissions(ctx context.Context) ([]ListPendingSubm
 }
 
 const listSubmissionsByUser = `-- name: ListSubmissionsByUser :many
-SELECT id, submitted_by, url, source, title, company, location, remote, description, posted_at, status, review_reason, reviewed_by, reviewed_at, job_id, created_at FROM job_submissions
-WHERE submitted_by = $1
-ORDER BY created_at DESC
+SELECT s.id, s.submitted_by, s.url, s.source, s.title, s.company, s.location, s.remote, s.description, s.posted_at, s.status, s.review_reason, s.reviewed_by, s.reviewed_at, s.job_id, s.created_at, j.public_slug AS job_slug
+FROM job_submissions s
+LEFT JOIN jobs j ON j.id = s.job_id
+WHERE s.submitted_by = $1
+ORDER BY s.created_at DESC
 `
 
+type ListSubmissionsByUserRow struct {
+	ID           int64              `json:"id"`
+	SubmittedBy  int64              `json:"submitted_by"`
+	URL          string             `json:"url"`
+	Source       string             `json:"source"`
+	Title        string             `json:"title"`
+	Company      string             `json:"company"`
+	Location     string             `json:"location"`
+	Remote       bool               `json:"remote"`
+	Description  string             `json:"description"`
+	PostedAt     pgtype.Timestamptz `json:"posted_at"`
+	Status       string             `json:"status"`
+	ReviewReason string             `json:"review_reason"`
+	ReviewedBy   pgtype.Int8        `json:"reviewed_by"`
+	ReviewedAt   pgtype.Timestamptz `json:"reviewed_at"`
+	JobID        pgtype.Int8        `json:"job_id"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	JobSlug      pgtype.Text        `json:"job_slug"`
+}
+
 // "My submissions": one user's submissions, newest first, whatever their status.
-func (q *Queries) ListSubmissionsByUser(ctx context.Context, submittedBy int64) ([]JobSubmission, error) {
+// LEFT JOIN the minted job (present only once approved) to surface its public_slug,
+// so the UI can link an approved submission straight to its live vacancy page.
+func (q *Queries) ListSubmissionsByUser(ctx context.Context, submittedBy int64) ([]ListSubmissionsByUserRow, error) {
 	rows, err := q.db.Query(ctx, listSubmissionsByUser, submittedBy)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []JobSubmission{}
+	items := []ListSubmissionsByUserRow{}
 	for rows.Next() {
-		var i JobSubmission
+		var i ListSubmissionsByUserRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.SubmittedBy,
@@ -203,6 +227,7 @@ func (q *Queries) ListSubmissionsByUser(ctx context.Context, submittedBy int64) 
 			&i.ReviewedAt,
 			&i.JobID,
 			&i.CreatedAt,
+			&i.JobSlug,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -134,7 +134,9 @@ type Querier interface {
 	// email so the moderator can judge provenance.
 	ListPendingSubmissions(ctx context.Context) ([]ListPendingSubmissionsRow, error)
 	// "My submissions": one user's submissions, newest first, whatever their status.
-	ListSubmissionsByUser(ctx context.Context, submittedBy int64) ([]JobSubmission, error)
+	// LEFT JOIN the minted job (present only once approved) to surface its public_slug,
+	// so the UI can link an approved submission straight to its live vacancy page.
+	ListSubmissionsByUser(ctx context.Context, submittedBy int64) ([]ListSubmissionsByUserRow, error)
 	// A user's job interactions joined with the job rows, most recently touched
 	// first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
 	// viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is

--- a/internal/db/queries/job_submissions.sql
+++ b/internal/db/queries/job_submissions.sql
@@ -28,9 +28,13 @@ ORDER BY s.created_at DESC;
 
 -- name: ListSubmissionsByUser :many
 -- "My submissions": one user's submissions, newest first, whatever their status.
-SELECT * FROM job_submissions
-WHERE submitted_by = $1
-ORDER BY created_at DESC;
+-- LEFT JOIN the minted job (present only once approved) to surface its public_slug,
+-- so the UI can link an approved submission straight to its live vacancy page.
+SELECT s.*, j.public_slug AS job_slug
+FROM job_submissions s
+LEFT JOIN jobs j ON j.id = s.job_id
+WHERE s.submitted_by = $1
+ORDER BY s.created_at DESC;
 
 -- name: MarkSubmissionApproved :one
 -- Mark a pending submission approved, recording the deciding moderator and the minted job.

--- a/internal/handler/submissions.go
+++ b/internal/handler/submissions.go
@@ -31,6 +31,9 @@ type submissionResponse struct {
 	ReviewedAt     *time.Time `json:"reviewed_at,omitempty"`
 	CreatedAt      *time.Time `json:"created_at"`
 	SubmitterEmail string     `json:"submitter_email,omitempty"`
+	// JobSlug is the public slug of the minted live vacancy, set only on an approved
+	// submission in the "my submissions" view, so the UI can link to /jobs/<slug>.
+	JobSlug string `json:"job_slug,omitempty"`
 }
 
 // toSubmissionResponse maps a stored submission to its wire shape (no submitter email).
@@ -69,6 +72,27 @@ func toPendingSubmissionResponse(r db.ListPendingSubmissionsRow) submissionRespo
 		ReviewedAt:     timePtr(r.ReviewedAt),
 		CreatedAt:      timePtr(r.CreatedAt),
 		SubmitterEmail: r.SubmitterEmail,
+	}
+}
+
+// toMySubmissionResponse maps a "my submissions" row, adding the minted job's slug when
+// the submission was approved (job_slug is NULL otherwise).
+func toMySubmissionResponse(r db.ListSubmissionsByUserRow) submissionResponse {
+	return submissionResponse{
+		ID:           r.ID,
+		URL:          r.URL,
+		Source:       r.Source,
+		Title:        r.Title,
+		Company:      r.Company,
+		Location:     r.Location,
+		Remote:       r.Remote,
+		Description:  r.Description,
+		PostedAt:     timePtr(r.PostedAt),
+		Status:       r.Status,
+		ReviewReason: r.ReviewReason,
+		ReviewedAt:   timePtr(r.ReviewedAt),
+		CreatedAt:    timePtr(r.CreatedAt),
+		JobSlug:      r.JobSlug.String,
 	}
 }
 
@@ -125,7 +149,7 @@ func (a *API) ListMySubmissions(c *fiber.Ctx) error {
 	}
 	out := make([]submissionResponse, len(subs))
 	for i, s := range subs {
-		out[i] = toSubmissionResponse(s)
+		out[i] = toMySubmissionResponse(s)
 	}
 	return c.JSON(fiber.Map{"data": out})
 }

--- a/internal/handler/submissions_integration_test.go
+++ b/internal/handler/submissions_integration_test.go
@@ -280,8 +280,9 @@ func TestSubmissionsEndToEnd(t *testing.T) {
 		}
 		var out struct {
 			Data []struct {
-				ID     int64  `json:"id"`
-				Status string `json:"status"`
+				ID      int64  `json:"id"`
+				Status  string `json:"status"`
+				JobSlug string `json:"job_slug"`
 			} `json:"data"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -291,6 +292,10 @@ func TestSubmissionsEndToEnd(t *testing.T) {
 		for _, s := range out.Data {
 			if s.ID == sub1ID {
 				sawOwn = true
+				// sub1 was approved earlier, so it links to the minted live vacancy.
+				if s.Status != "approved" || s.JobSlug == "" {
+					t.Errorf("approved submission missing job_slug: status=%q job_slug=%q", s.Status, s.JobSlug)
+				}
 			}
 			// user1 must never see user2's submission (url2).
 			var owner int64

--- a/internal/submission/repository.go
+++ b/internal/submission/repository.go
@@ -56,8 +56,8 @@ func (r *QueriesRepository) ListPending(ctx context.Context) ([]db.ListPendingSu
 	return r.q.ListPendingSubmissions(ctx)
 }
 
-// ListByUser returns one user's submissions.
-func (r *QueriesRepository) ListByUser(ctx context.Context, userID int64) ([]db.JobSubmission, error) {
+// ListByUser returns one user's submissions, each with the minted job's slug when approved.
+func (r *QueriesRepository) ListByUser(ctx context.Context, userID int64) ([]db.ListSubmissionsByUserRow, error) {
 	return r.q.ListSubmissionsByUser(ctx, userID)
 }
 

--- a/internal/submission/submission.go
+++ b/internal/submission/submission.go
@@ -40,7 +40,7 @@ type Repository interface {
 	Create(ctx context.Context, p db.CreateSubmissionParams) (db.JobSubmission, error)
 	Get(ctx context.Context, id int64) (db.JobSubmission, error)
 	ListPending(ctx context.Context) ([]db.ListPendingSubmissionsRow, error)
-	ListByUser(ctx context.Context, userID int64) ([]db.JobSubmission, error)
+	ListByUser(ctx context.Context, userID int64) ([]db.ListSubmissionsByUserRow, error)
 	MarkApproved(ctx context.Context, p db.MarkSubmissionApprovedParams) (db.JobSubmission, error)
 	MarkRejected(ctx context.Context, p db.MarkSubmissionRejectedParams) (db.JobSubmission, error)
 }
@@ -77,8 +77,9 @@ func (s *Service) Submit(ctx context.Context, submittedBy int64, in moderation.C
 	})
 }
 
-// ListMine returns the given user's submissions, newest first.
-func (s *Service) ListMine(ctx context.Context, userID int64) ([]db.JobSubmission, error) {
+// ListMine returns the given user's submissions, newest first. Each row carries the
+// minted job's slug (when approved) so the UI can link to the live vacancy.
+func (s *Service) ListMine(ctx context.Context, userID int64) ([]db.ListSubmissionsByUserRow, error) {
 	return s.repo.ListByUser(ctx, userID)
 }
 

--- a/internal/submission/submission_test.go
+++ b/internal/submission/submission_test.go
@@ -45,7 +45,7 @@ func (f *fakeRepo) ListPending(_ context.Context) ([]db.ListPendingSubmissionsRo
 	return nil, nil
 }
 
-func (f *fakeRepo) ListByUser(_ context.Context, _ int64) ([]db.JobSubmission, error) {
+func (f *fakeRepo) ListByUser(_ context.Context, _ int64) ([]db.ListSubmissionsByUserRow, error) {
 	return nil, nil
 }
 

--- a/web/src/lib/components/MySubmissionsView.svelte
+++ b/web/src/lib/components/MySubmissionsView.svelte
@@ -67,6 +67,14 @@
               {#if s.status === 'rejected' && s.review_reason}
                 <span class="text-xs text-destructive">Reason: {s.review_reason}</span>
               {/if}
+              {#if s.status === 'approved' && s.job_slug}
+                <a
+                  href={`/jobs/${s.job_slug}`}
+                  class="text-xs font-medium text-foreground hover:underline"
+                >
+                  View vacancy →
+                </a>
+              {/if}
             </div>
             <span class="rounded-md px-2 py-0.5 text-xs font-medium {statusClass[s.status]}">
               {s.status}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -64,6 +64,9 @@ export interface Submission {
   reviewed_at?: string | null;
   created_at: string | null;
   submitter_email?: string;
+  // Public slug of the minted live vacancy, present on an approved submission in the
+  // caller's own list, so the UI can link to /jobs/<job_slug>.
+  job_slug?: string;
 }
 
 /** The content a user submits for review (mirrors the moderator create body). */


### PR DESCRIPTION
Follow-up on #91. After a submission is approved, the user had no way to reach the live vacancy from the UI (My submissions only linked the original URL, and the search-backed /jobs list lags until the Meili reindex runs).

## Change
- `ListSubmissionsByUser` LEFT JOINs `jobs` to surface the minted job's `public_slug`.
- `job_slug` flows onto the `/me/submissions` wire shape (approved rows only; NULL otherwise).
- `MySubmissionsView` renders a **"View vacancy →"** link to `/jobs/<slug>` when `status=approved`.

The detail page serves from Postgres, so the link works immediately — no reindex wait.

## Test plan
- [x] `go build`/`vet`/`gofmt` clean; `go test ./...` green
- [x] `go test -tags=integration -run TestSubmissionsEndToEnd` green — asserts the approved row carries `job_slug`
- [x] web `svelte-check` 0 errors

No migration (query-only change). Deploy app + web.