### PR TITLE
refactor: code-review follow-ups (service layer, enrich retry, liveness lock, hardening)

### DIFF
--- a/cmd/enrich/store.go
+++ b/cmd/enrich/store.go
@@ -68,7 +68,7 @@ func (s *dbStore) Complete(ctx context.Context, entry enrich.Claimed, payload js
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx)
+	defer func() { _ = tx.Rollback(ctx) }()
 
 	qtx := s.q.WithTx(tx)
 	if err := qtx.SetJobEnrichment(ctx, db.SetJobEnrichmentParams{

--- a/cmd/liveness/main.go
+++ b/cmd/liveness/main.go
@@ -35,6 +35,12 @@ const (
 	// concurrency caps simultaneous probes: orphan postings span many hosts, so this
 	// keeps the worker from hammering any single employer site while staying brisk.
 	concurrency = 8
+	// lockKey is the Postgres advisory-lock key that serializes liveness runs. Cron
+	// offers no host-level guarantee against stacking, and two runs probing the same
+	// orphan seconds apart would collapse the "two consecutive expired reads" grace
+	// into one burst — closing a job on a transient blip. A second run that can't take
+	// the lock exits cleanly. The value is an arbitrary constant unique to this worker.
+	lockKey = 0x66686c76 // "fhlv" — freehire liveness
 )
 
 func main() {
@@ -47,6 +53,29 @@ func main() {
 	}
 	defer pool.Close()
 	queries := db.New(pool)
+
+	// Single-flight: hold a session-scoped advisory lock on a dedicated connection
+	// for the whole run so overlapping cron invocations can't strike the same orphan
+	// twice within one burst. A run that can't take the lock exits cleanly.
+	lockConn, err := pool.Acquire(ctx)
+	if err != nil {
+		log.Fatalf("acquire lock connection: %v", err)
+	}
+	var locked bool
+	if err := lockConn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", int64(lockKey)).Scan(&locked); err != nil {
+		lockConn.Release()
+		log.Fatalf("liveness lock: %v", err)
+	}
+	if !locked {
+		lockConn.Release()
+		log.Print("liveness: another run holds the lock — exiting")
+		return
+	}
+	defer func() {
+		// Best-effort unlock; releasing/closing the connection drops the session lock anyway.
+		_, _ = lockConn.Exec(ctx, "SELECT pg_advisory_unlock($1)", int64(lockKey))
+		lockConn.Release()
+	}()
 
 	// The candidate set is "every open job whose source is not a registered ATS
 	// provider" — the registry keys are the exclusion list, so a new adapter never

--- a/internal/auth/oauth/github.go
+++ b/internal/auth/oauth/github.go
@@ -2,6 +2,7 @@ package oauth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -38,6 +39,7 @@ func (p *githubProvider) AuthCodeURL(state string) string {
 }
 
 func (p *githubProvider) FetchIdentity(ctx context.Context, code string) (Identity, error) {
+	ctx = guardedOAuthContext(ctx)
 	tok, err := p.cfg.Exchange(ctx, code)
 	if err != nil {
 		return Identity{}, fmt.Errorf("github: exchange code: %w", err)
@@ -51,7 +53,7 @@ func (p *githubProvider) FetchIdentity(ctx context.Context, code string) (Identi
 		return Identity{}, fmt.Errorf("github: user: %w", err)
 	}
 	if user.ID == 0 {
-		return Identity{}, fmt.Errorf("github: user has no id")
+		return Identity{}, errors.New("github: user has no id")
 	}
 
 	var emails []struct {

--- a/internal/auth/oauth/github_test.go
+++ b/internal/auth/oauth/github_test.go
@@ -1,7 +1,6 @@
 package oauth
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -49,7 +48,7 @@ func TestGitHub_FetchIdentityPrimaryVerifiedEmail(t *testing.T) {
 		{"email": "old@e.com", "primary": false, "verified": true},
 		{"email": "main@e.com", "primary": true, "verified": true},
 	})
-	got, err := githubForTest(srv).FetchIdentity(context.Background(), "code")
+	got, err := githubForTest(srv).FetchIdentity(testClientCtx(srv), "code")
 	if err != nil {
 		t.Fatalf("FetchIdentity: %v", err)
 	}
@@ -64,7 +63,7 @@ func TestGitHub_FetchIdentityFallsBackToAnyVerified(t *testing.T) {
 		{"email": "unverified@e.com", "primary": true, "verified": false},
 		{"email": "side@e.com", "primary": false, "verified": true},
 	})
-	got, err := githubForTest(srv).FetchIdentity(context.Background(), "code")
+	got, err := githubForTest(srv).FetchIdentity(testClientCtx(srv), "code")
 	if err != nil {
 		t.Fatalf("FetchIdentity: %v", err)
 	}
@@ -77,7 +76,7 @@ func TestGitHub_FetchIdentityNoVerifiedEmail(t *testing.T) {
 	srv := stubGitHub(t, []map[string]any{
 		{"email": "unverified@e.com", "primary": true, "verified": false},
 	})
-	got, err := githubForTest(srv).FetchIdentity(context.Background(), "code")
+	got, err := githubForTest(srv).FetchIdentity(testClientCtx(srv), "code")
 	if err != nil {
 		t.Fatalf("FetchIdentity: %v", err)
 	}

--- a/internal/auth/oauth/oidc.go
+++ b/internal/auth/oauth/oidc.go
@@ -5,11 +5,37 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/endpoints"
+
+	"github.com/strelov1/freehire/internal/safehttp"
 )
+
+// maxUserinfoBytes caps an identity-provider JSON response. Userinfo payloads are
+// small; a multi-MB body is a misbehaving or hostile endpoint, not a real payload.
+const maxUserinfoBytes = 1 << 20 // 1 MiB
+
+// userinfoTimeout bounds the OAuth token-exchange and userinfo round-trips.
+const userinfoTimeout = 15 * time.Second
+
+// guardedOAuthContext returns ctx carrying an SSRF-guarded HTTP client, so the
+// oauth2 token exchange and the userinfo fetch both dial through safehttp — every
+// other outbound fetch in this service does. The provider endpoints are fixed
+// public constants, so this is defense-in-depth and consistency, not a live fix.
+//
+// A caller-supplied oauth2.HTTPClient is respected (tests inject an httptest
+// client for their loopback stub); the production handler never sets one, so it
+// always gets the guard.
+func guardedOAuthContext(ctx context.Context) context.Context {
+	if _, ok := ctx.Value(oauth2.HTTPClient).(*http.Client); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, oauth2.HTTPClient, safehttp.NewClient(userinfoTimeout))
+}
 
 // oidcProvider covers every provider that exposes a standard OIDC userinfo
 // endpoint (Google, LinkedIn): exchange the code, then one GET for
@@ -58,6 +84,7 @@ func (p *oidcProvider) AuthCodeURL(state string) string {
 }
 
 func (p *oidcProvider) FetchIdentity(ctx context.Context, code string) (Identity, error) {
+	ctx = guardedOAuthContext(ctx)
 	tok, err := p.cfg.Exchange(ctx, code)
 	if err != nil {
 		return Identity{}, fmt.Errorf("%s: exchange code: %w", p.name, err)
@@ -91,5 +118,5 @@ func getJSON(ctx context.Context, client *http.Client, url string, out any) erro
 	if resp.StatusCode != http.StatusOK {
 		return errors.New(resp.Status)
 	}
-	return json.NewDecoder(resp.Body).Decode(out)
+	return json.NewDecoder(io.LimitReader(resp.Body, maxUserinfoBytes)).Decode(out)
 }

--- a/internal/auth/oauth/oidc_test.go
+++ b/internal/auth/oauth/oidc_test.go
@@ -35,6 +35,13 @@ func stubOIDC(t *testing.T, userinfo map[string]any) *httptest.Server {
 	return srv
 }
 
+// testClientCtx injects the stub server's client so the SSRF guard — which would
+// reject the loopback httptest server — is bypassed in tests. The production code
+// path supplies no client and always gets the guard.
+func testClientCtx(srv *httptest.Server) context.Context {
+	return context.WithValue(context.Background(), oauth2.HTTPClient, srv.Client())
+}
+
 func oidcForTest(srv *httptest.Server) *oidcProvider {
 	return &oidcProvider{
 		name: "google",
@@ -63,7 +70,7 @@ func TestOIDC_FetchIdentity(t *testing.T) {
 		"email":          "User@Example.com",
 		"email_verified": true,
 	})
-	got, err := oidcForTest(srv).FetchIdentity(context.Background(), "code")
+	got, err := oidcForTest(srv).FetchIdentity(testClientCtx(srv), "code")
 	if err != nil {
 		t.Fatalf("FetchIdentity: %v", err)
 	}
@@ -75,7 +82,7 @@ func TestOIDC_FetchIdentity(t *testing.T) {
 
 func TestOIDC_FetchIdentityUnverifiedEmail(t *testing.T) {
 	srv := stubOIDC(t, map[string]any{"sub": "uid-2", "email": "u@e.com", "email_verified": false})
-	got, err := oidcForTest(srv).FetchIdentity(context.Background(), "code")
+	got, err := oidcForTest(srv).FetchIdentity(testClientCtx(srv), "code")
 	if err != nil {
 		t.Fatalf("FetchIdentity: %v", err)
 	}
@@ -86,7 +93,7 @@ func TestOIDC_FetchIdentityUnverifiedEmail(t *testing.T) {
 
 func TestOIDC_FetchIdentityMissingSub(t *testing.T) {
 	srv := stubOIDC(t, map[string]any{"email": "u@e.com"})
-	if _, err := oidcForTest(srv).FetchIdentity(context.Background(), "code"); err == nil {
+	if _, err := oidcForTest(srv).FetchIdentity(testClientCtx(srv), "code"); err == nil {
 		t.Error("want error for userinfo without sub")
 	}
 }

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -3,6 +3,7 @@ package enrich
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -73,10 +74,16 @@ func (p *LangChainProvider) Enrich(ctx context.Context, job JobInput) (Enrichmen
 		return Enrichment{}, fmt.Errorf("enrich: generate: %w", err)
 	}
 	if len(resp.Choices) == 0 {
-		return Enrichment{}, fmt.Errorf("enrich: model returned no choices")
+		return Enrichment{}, errors.New("enrich: model returned no choices")
 	}
 	return parseEnrichment(resp.Choices[0].Content)
 }
+
+// errUnparseableResponse marks a model response that wasn't valid JSON. It is
+// deterministic for the prompt, so the runner skips its in-process retry on it
+// (the outbox attempts counter still re-tries on the next cron run, drawing a
+// fresh sample). Transport failures, by contrast, are worth an immediate retry.
+var errUnparseableResponse = errors.New("enrich: unparseable model response")
 
 // parseEnrichment unmarshals a model's JSON response into an Enrichment, tolerating
 // a markdown code fence some models add despite JSON mode.
@@ -89,7 +96,7 @@ func parseEnrichment(raw string) (Enrichment, error) {
 
 	var e Enrichment
 	if err := json.Unmarshal([]byte(s), &e); err != nil {
-		return Enrichment{}, fmt.Errorf("enrich: parse response: %w", err)
+		return Enrichment{}, fmt.Errorf("%w: %v", errUnparseableResponse, err)
 	}
 	return e, nil
 }

--- a/internal/enrich/runner.go
+++ b/internal/enrich/runner.go
@@ -3,6 +3,7 @@ package enrich
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -144,22 +145,30 @@ func (rn *run) process(ctx context.Context, entry Claimed) {
 	log.Printf("enrich: job=%d ok in %s", entry.JobID, time.Since(start).Round(time.Millisecond))
 }
 
-// enrich asks the provider for a payload and validates it, retrying once. An
-// invalid payload is treated as an error so it is never persisted.
+// enrich asks the provider for a payload and validates it, retrying once on a
+// transient transport failure. An invalid payload is treated as an error so it
+// is never persisted. Deterministic failures (an unparseable response, or a
+// payload that fails validation even after sanitizing) are not retried
+// in-process — an identical re-call would reproduce them; the outbox attempts
+// counter re-tries them on the next cron run, drawing a fresh sample.
 func (rn *run) enrich(ctx context.Context, job JobInput) (Enrichment, error) {
 	var lastErr error
 	for range 2 {
 		enr, err := rn.provider.Enrich(ctx, job)
 		if err != nil {
 			lastErr = err
+			if errors.Is(err, errUnparseableResponse) {
+				break
+			}
 			continue
 		}
 		// Drop any out-of-vocabulary enum values rather than failing the whole
 		// payload over one stray field; Validate is then a guard that should pass.
 		enr.Sanitize()
 		if err := enr.Validate(); err != nil {
-			lastErr = err
-			continue
+			// Sanitize already dropped out-of-vocab values, so a Validate failure
+			// is a structural problem a retry won't fix.
+			return Enrichment{}, err
 		}
 		return enr, nil
 	}

--- a/internal/enrich/runner_test.go
+++ b/internal/enrich/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -157,6 +158,44 @@ func TestRun_providerErrorIsFailed(t *testing.T) {
 	}
 	if stats.Failed != 1 {
 		t.Errorf("stats = %+v, want Failed:1", stats)
+	}
+}
+
+func TestRun_transportErrorIsRetried(t *testing.T) {
+	store := &fakeStore{
+		claims: [][]Claimed{{{OutboxID: 8, JobID: 100, TargetVersion: Version}}},
+		jobs:   map[int64]JobInput{100: {Title: "x"}},
+	}
+	prov := &funcProvider{fn: func(JobInput) (Enrichment, error) {
+		return Enrichment{}, errors.New("gateway timeout")
+	}}
+
+	stats, _ := Runner{Provider: prov, Store: store}.Run(context.Background(), opts())
+	if prov.callCount() != 2 {
+		t.Errorf("provider called %d times, want 2 (a transport error is retried once)", prov.callCount())
+	}
+	if stats.Failed != 1 {
+		t.Errorf("stats = %+v, want Failed:1", stats)
+	}
+}
+
+func TestRun_unparseableResponseIsNotRetried(t *testing.T) {
+	store := &fakeStore{
+		claims: [][]Claimed{{{OutboxID: 4, JobID: 100, TargetVersion: Version}}},
+		jobs:   map[int64]JobInput{100: {Title: "x"}},
+	}
+	prov := &funcProvider{fn: func(JobInput) (Enrichment, error) {
+		// A non-JSON model response is deterministic for the prompt: an in-process
+		// retry would re-send the identical call. The next cron run re-attempts it.
+		return Enrichment{}, fmt.Errorf("%w: trailing garbage", errUnparseableResponse)
+	}}
+
+	stats, _ := Runner{Provider: prov, Store: store}.Run(context.Background(), opts())
+	if prov.callCount() != 1 {
+		t.Errorf("provider called %d times, want 1 (an unparseable response must not be retried in-process)", prov.callCount())
+	}
+	if len(store.failed) != 1 || stats.Failed != 1 {
+		t.Errorf("failed=%v stats=%+v, want one failure", store.failed, stats)
 	}
 }
 

--- a/internal/handler/me_jobs.go
+++ b/internal/handler/me_jobs.go
@@ -1,11 +1,11 @@
 package handler
 
 import (
+	"time"
+
 	"github.com/gofiber/fiber/v2"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/auth"
-	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
 )
 
@@ -13,12 +13,12 @@ import (
 // jobview wire shape with the caller's interaction timestamps riding alongside
 // (not flattened in — the job shape stays identical to every other job surface).
 type myJobResponse struct {
-	Job       jobview.Job        `json:"job"`
-	ViewedAt  pgtype.Timestamptz `json:"viewed_at"`
-	SavedAt   pgtype.Timestamptz `json:"saved_at"`
-	AppliedAt pgtype.Timestamptz `json:"applied_at"`
-	Stage     pgtype.Text        `json:"stage"`
-	Notes     pgtype.Text        `json:"notes"`
+	Job       jobview.Job `json:"job"`
+	ViewedAt  *time.Time  `json:"viewed_at"`
+	SavedAt   *time.Time  `json:"saved_at"`
+	AppliedAt *time.Time  `json:"applied_at"`
+	Stage     *string     `json:"stage"`
+	Notes     *string     `json:"notes"`
 }
 
 // ListMyJobs returns the authenticated user's job interactions joined with the
@@ -35,68 +35,36 @@ func (a *API) ListMyJobs(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "unauthorized")
 	}
 
-	filter := c.Query("filter", "all")
-	switch filter {
-	case "all", "viewed", "saved", "applied", "board":
-	default:
-		return fiber.NewError(fiber.StatusBadRequest, "filter must be one of: all, viewed, saved, applied, board")
-	}
 	limit, offset := pageParams(c)
-
-	rows, err := a.queries.ListUserJobs(c.Context(), db.ListUserJobsParams{
-		UserID: userID,
-		Filter: filter,
-		Limit:  int32(limit),
-		Offset: int32(offset),
-	})
+	listing, err := a.tracking.ListTracked(c.Context(), userID, c.Query("filter"), int32(limit), int32(offset))
 	if err != nil {
-		return err
-	}
-	counts, err := a.queries.CountUserJobs(c.Context(), userID)
-	if err != nil {
-		return err
+		return trackingError(err)
 	}
 
-	items := make([]myJobResponse, 0, len(rows))
-	for _, row := range rows {
-		view, err := jobview.FromRow(row.Job)
-		if err != nil {
-			return err
-		}
+	items := make([]myJobResponse, 0, len(listing.Items))
+	for _, it := range listing.Items {
 		items = append(items, myJobResponse{
-			Job:       view,
-			ViewedAt:  row.ViewedAt,
-			SavedAt:   row.SavedAt,
-			AppliedAt: row.AppliedAt,
-			Stage:     row.Stage,
-			Notes:     row.Notes,
+			Job:       it.Job,
+			ViewedAt:  it.ViewedAt,
+			SavedAt:   it.SavedAt,
+			AppliedAt: it.AppliedAt,
+			Stage:     it.Stage,
+			Notes:     it.Notes,
 		})
-	}
-
-	total := counts.All
-	switch filter {
-	case "viewed":
-		total = counts.Viewed
-	case "saved":
-		total = counts.Saved
-	case "applied":
-		total = counts.Applied
-	case "board":
-		total = counts.Board
 	}
 
 	return c.JSON(fiber.Map{
 		"data": items,
 		"meta": fiber.Map{
-			"total":  total,
+			"total":  listing.Total(),
 			"limit":  limit,
 			"offset": offset,
 			"counts": fiber.Map{
-				"all":     counts.All,
-				"viewed":  counts.Viewed,
-				"saved":   counts.Saved,
-				"applied": counts.Applied,
-				"board":   counts.Board,
+				"all":     listing.Counts.All,
+				"viewed":  listing.Counts.Viewed,
+				"saved":   listing.Counts.Saved,
+				"applied": listing.Counts.Applied,
+				"board":   listing.Counts.Board,
 			},
 		},
 	})
@@ -114,7 +82,7 @@ func (a *API) ListViewedSlugs(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusUnauthorized, "unauthorized")
 	}
 
-	slugs, err := a.queries.ListViewedJobSlugs(c.Context(), userID)
+	slugs, err := a.tracking.ViewedSlugs(c.Context(), userID)
 	if err != nil {
 		return err
 	}

--- a/internal/handler/me_jobs_integration_test.go
+++ b/internal/handler/me_jobs_integration_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobtracking"
 )
 
 func TestListMyJobsEndpoint(t *testing.T) {
@@ -60,7 +61,7 @@ func TestListMyJobsEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("issue token: %v", err)
 	}
-	h := &API{pool: pool, queries: queries, issuer: iss}
+	h := &API{pool: pool, queries: queries, issuer: iss, tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries))}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/me/jobs", auth.RequireAuth(iss), h.ListMyJobs)
 
@@ -201,7 +202,7 @@ func TestListMyJobsBoardFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("issue token: %v", err)
 	}
-	h := &API{pool: pool, queries: queries, issuer: iss}
+	h := &API{pool: pool, queries: queries, issuer: iss, tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries))}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/me/jobs", auth.RequireAuth(iss), h.ListMyJobs)
 

--- a/internal/handler/me_viewed_integration_test.go
+++ b/internal/handler/me_viewed_integration_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobtracking"
 )
 
 func TestListViewedSlugsEndpoint(t *testing.T) {
@@ -70,7 +71,7 @@ func TestListViewedSlugsEndpoint(t *testing.T) {
 	}
 
 	iss := auth.NewIssuer("test-secret", time.Hour)
-	h := &API{pool: pool, queries: queries, issuer: iss}
+	h := &API{pool: pool, queries: queries, issuer: iss, tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries))}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/me/jobs/viewed", auth.RequireAuthOrKey(iss, queries), h.ListViewedSlugs)
 

--- a/internal/handler/track_test.go
+++ b/internal/handler/track_test.go
@@ -43,6 +43,13 @@ func (stubTrackingRepo) ClearJobProgress(context.Context, int64, int64) (jobtrac
 func (stubTrackingRepo) UntrackJob(context.Context, int64, int64) (jobtracking.Interaction, error) {
 	return jobtracking.Interaction{JobID: 1}, nil
 }
+func (stubTrackingRepo) ListInteractions(context.Context, int64, jobtracking.Filter, int32, int32) ([]jobtracking.TrackedJob, error) {
+	return nil, nil
+}
+func (stubTrackingRepo) CountInteractions(context.Context, int64) (jobtracking.Counts, error) {
+	return jobtracking.Counts{}, nil
+}
+func (stubTrackingRepo) ViewedSlugs(context.Context, int64) ([]string, error) { return nil, nil }
 
 // trackApp mounts the track route on a handler whose tracking service is backed
 // by a stub repository (no DB). The auth gate and the service's body validation

--- a/internal/handler/user_jobs.go
+++ b/internal/handler/user_jobs.go
@@ -45,6 +45,8 @@ func trackingError(err error) error {
 		return fiber.NewError(fiber.StatusNotFound, "job not found")
 	case errors.Is(err, jobtracking.ErrInvalidStage):
 		return fiber.NewError(fiber.StatusBadRequest, "invalid stage")
+	case errors.Is(err, jobtracking.ErrInvalidFilter):
+		return fiber.NewError(fiber.StatusBadRequest, "filter must be one of: all, viewed, saved, applied, board")
 	case errors.Is(err, jobtracking.ErrEmptyTrack):
 		return fiber.NewError(fiber.StatusBadRequest, "provide stage and/or notes")
 	default:

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/userjob"
 )
 
@@ -22,11 +23,85 @@ type Interaction struct {
 	Notes     *string
 }
 
+// Filter selects which interactions a listing returns. It is a controlled
+// vocabulary owned here (mirroring userjob.Stage): "all" is every interaction,
+// "viewed" the passive history (neither saved nor applied), "saved"/"applied"
+// the respective subsets, and "board" the Kanban set (saved, applied, or staged).
+type Filter string
+
+const (
+	FilterAll     Filter = "all"
+	FilterViewed  Filter = "viewed"
+	FilterSaved   Filter = "saved"
+	FilterApplied Filter = "applied"
+	FilterBoard   Filter = "board"
+)
+
+// ParseFilter validates a raw filter string against the vocabulary. An empty
+// string defaults to FilterAll, so the whole filter policy (including the default)
+// lives here rather than leaking into the HTTP layer. An unknown value is
+// ErrInvalidFilter.
+func ParseFilter(s string) (Filter, error) {
+	switch Filter(s) {
+	case "", FilterAll:
+		return FilterAll, nil
+	case FilterViewed, FilterSaved, FilterApplied, FilterBoard:
+		return Filter(s), nil
+	}
+	return "", ErrInvalidFilter
+}
+
+// Counts are the per-filter interaction totals for the my-jobs tab badges.
+type Counts struct {
+	All     int64
+	Viewed  int64
+	Saved   int64
+	Applied int64
+	Board   int64
+}
+
+// Total returns the count matching the active filter — the value the listing's
+// meta.total should report.
+func (c Counts) Total(f Filter) int64 {
+	switch f {
+	case FilterViewed:
+		return c.Viewed
+	case FilterSaved:
+		return c.Saved
+	case FilterApplied:
+		return c.Applied
+	case FilterBoard:
+		return c.Board
+	default:
+		return c.All
+	}
+}
+
+// TrackedJob pairs a job in its canonical wire shape with the caller's
+// interaction marks. The job carries identity via its slug; the embedded
+// Interaction's JobID is the internal id, never serialized.
+type TrackedJob struct {
+	Job jobview.Job
+	Interaction
+}
+
+// Listing is the result of ListTracked: a page of tracked jobs for the active
+// filter plus the per-filter counts for the tab badges.
+type Listing struct {
+	Filter Filter
+	Items  []TrackedJob
+	Counts Counts
+}
+
+// Total is the count for the active filter — the listing's meta.total.
+func (l Listing) Total() int64 { return l.Counts.Total(l.Filter) }
+
 // Sentinel errors returned by the Service and Repository.
 var (
-	ErrJobNotFound  = errors.New("jobtracking: job not found")
-	ErrInvalidStage = errors.New("jobtracking: invalid stage")
-	ErrEmptyTrack   = errors.New("jobtracking: provide stage and/or notes")
+	ErrJobNotFound   = errors.New("jobtracking: job not found")
+	ErrInvalidStage  = errors.New("jobtracking: invalid stage")
+	ErrInvalidFilter = errors.New("jobtracking: invalid filter")
+	ErrEmptyTrack    = errors.New("jobtracking: provide stage and/or notes")
 	// ErrNoInteraction is returned by Repository.UnsaveJob when there is no
 	// interaction row to clear. The Service converts it into a zero-interaction
 	// success; it is never surfaced to the caller.
@@ -59,6 +134,16 @@ type Repository interface {
 	// UntrackJob removes a job from the board entirely: clears saved_at, applied_at,
 	// stage, and notes, keeping viewed_at so the job stays in view history.
 	UntrackJob(ctx context.Context, userID, jobID int64) (Interaction, error)
+
+	// ListInteractions returns the caller's interactions joined with the jobs,
+	// narrowed by an already-validated filter, most recently touched first.
+	ListInteractions(ctx context.Context, userID int64, filter Filter, limit, offset int32) ([]TrackedJob, error)
+
+	// CountInteractions returns the per-filter counts for the caller in one pass.
+	CountInteractions(ctx context.Context, userID int64) (Counts, error)
+
+	// ViewedSlugs returns every public job slug the caller has interacted with.
+	ViewedSlugs(ctx context.Context, userID int64) ([]string, error)
 }
 
 // Service implements the per-user job-tracking use cases.
@@ -69,6 +154,31 @@ type Service struct {
 // New creates a Service backed by the given Repository.
 func New(repo Repository) *Service {
 	return &Service{repo: repo}
+}
+
+// ListTracked validates the filter (the vocabulary and its default live in
+// ParseFilter, not the HTTP layer), then reads the caller's interactions and the
+// per-filter counts. The returned Listing knows its active filter, so Total picks
+// the matching count.
+func (s *Service) ListTracked(ctx context.Context, userID int64, filter string, limit, offset int32) (Listing, error) {
+	f, err := ParseFilter(filter)
+	if err != nil {
+		return Listing{}, err
+	}
+	items, err := s.repo.ListInteractions(ctx, userID, f, limit, offset)
+	if err != nil {
+		return Listing{}, err
+	}
+	counts, err := s.repo.CountInteractions(ctx, userID)
+	if err != nil {
+		return Listing{}, err
+	}
+	return Listing{Filter: f, Items: items, Counts: counts}, nil
+}
+
+// ViewedSlugs returns every public job slug the caller has interacted with.
+func (s *Service) ViewedSlugs(ctx context.Context, userID int64) ([]string, error) {
+	return s.repo.ViewedSlugs(ctx, userID)
 }
 
 // RecordView resolves slug → jobID then delegates to the repository.

--- a/internal/jobtracking/jobtracking_test.go
+++ b/internal/jobtracking/jobtracking_test.go
@@ -29,9 +29,17 @@ type fakeRepo struct {
 	clearProgressErr    error
 	untrackResult       jobtracking.Interaction
 	untrackErr          error
+	listResult          []jobtracking.TrackedJob
+	listErr             error
+	countResult         jobtracking.Counts
+	countErr            error
+	viewedResult        []string
+	viewedErr           error
 
 	// recorded calls
 	slugCalls  int
+	listCalls  int
+	listFilter jobtracking.Filter
 	trackStage *string
 	trackNotes *string
 }
@@ -73,6 +81,20 @@ func (f *fakeRepo) ClearJobProgress(_ context.Context, _, _ int64) (jobtracking.
 
 func (f *fakeRepo) UntrackJob(_ context.Context, _, _ int64) (jobtracking.Interaction, error) {
 	return f.untrackResult, f.untrackErr
+}
+
+func (f *fakeRepo) ListInteractions(_ context.Context, _ int64, filter jobtracking.Filter, _, _ int32) ([]jobtracking.TrackedJob, error) {
+	f.listCalls++
+	f.listFilter = filter
+	return f.listResult, f.listErr
+}
+
+func (f *fakeRepo) CountInteractions(_ context.Context, _ int64) (jobtracking.Counts, error) {
+	return f.countResult, f.countErr
+}
+
+func (f *fakeRepo) ViewedSlugs(_ context.Context, _ int64) ([]string, error) {
+	return f.viewedResult, f.viewedErr
 }
 
 // helpers
@@ -407,5 +429,78 @@ func TestUntrack_UnknownSlug(t *testing.T) {
 	// The untrack repo method must not be called when slug resolution fails.
 	if repo.untrackErr != nil {
 		t.Error("untrackErr should not be set (repo untrack must not be called)")
+	}
+}
+
+// ---
+// 6. ListTracked — filter validation, default, and total selection
+// ---
+
+func TestListTracked_InvalidFilter_ShortCircuits(t *testing.T) {
+	repo := newRepo()
+	svc := jobtracking.New(repo)
+
+	_, err := svc.ListTracked(ctx(), userID, "bogus", 20, 0)
+	if !errors.Is(err, jobtracking.ErrInvalidFilter) {
+		t.Errorf("err = %v, want ErrInvalidFilter", err)
+	}
+	// A bad filter must be rejected before any DB read.
+	if repo.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (validation should short-circuit before the listing)", repo.listCalls)
+	}
+}
+
+func TestListTracked_EmptyFilterDefaultsToAll(t *testing.T) {
+	repo := newRepo()
+	repo.countResult = jobtracking.Counts{All: 9, Viewed: 4, Saved: 2, Applied: 3, Board: 5}
+	svc := jobtracking.New(repo)
+
+	listing, err := svc.ListTracked(ctx(), userID, "", 20, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if listing.Filter != jobtracking.FilterAll {
+		t.Errorf("Filter = %q, want %q (empty defaults to all)", listing.Filter, jobtracking.FilterAll)
+	}
+	if repo.listFilter != jobtracking.FilterAll {
+		t.Errorf("repo received filter %q, want %q", repo.listFilter, jobtracking.FilterAll)
+	}
+	if listing.Total() != 9 {
+		t.Errorf("Total() = %d, want 9 (the all count)", listing.Total())
+	}
+}
+
+func TestListTracked_BoardFilterSelectsBoardTotal(t *testing.T) {
+	repo := newRepo()
+	repo.countResult = jobtracking.Counts{All: 9, Viewed: 4, Saved: 2, Applied: 3, Board: 5}
+	repo.listResult = []jobtracking.TrackedJob{{Interaction: jobtracking.Interaction{JobID: jobID}}}
+	svc := jobtracking.New(repo)
+
+	listing, err := svc.ListTracked(ctx(), userID, "board", 20, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.listFilter != jobtracking.FilterBoard {
+		t.Errorf("repo received filter %q, want %q", repo.listFilter, jobtracking.FilterBoard)
+	}
+	if listing.Total() != 5 {
+		t.Errorf("Total() = %d, want 5 (the board count, not all)", listing.Total())
+	}
+	if len(listing.Items) != 1 {
+		t.Errorf("Items = %d, want 1 (passed through from the repo)", len(listing.Items))
+	}
+}
+
+func TestViewedSlugs_Passthrough(t *testing.T) {
+	repo := newRepo()
+	repo.viewedResult = []string{"job-a", "job-b"}
+	svc := jobtracking.New(repo)
+
+	slugs, err := svc.ViewedSlugs(ctx(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(slugs) != 2 || slugs[0] != "job-a" {
+		t.Errorf("slugs = %v, want [job-a job-b]", slugs)
 	}
 }

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobview"
 )
 
 // Compile-time proof that QueriesRepository satisfies Repository.
@@ -110,46 +111,92 @@ func (r *QueriesRepository) UntrackJob(ctx context.Context, userID, jobID int64)
 	return toInteraction(row), nil
 }
 
+// ListInteractions returns the caller's interactions joined with the jobs in the
+// canonical jobview shape, narrowed by the already-validated filter.
+func (r *QueriesRepository) ListInteractions(
+	ctx context.Context,
+	userID int64,
+	filter Filter,
+	limit, offset int32,
+) ([]TrackedJob, error) {
+	rows, err := r.q.ListUserJobs(ctx, db.ListUserJobsParams{
+		UserID: userID,
+		Filter: string(filter),
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+	items := make([]TrackedJob, 0, len(rows))
+	for _, row := range rows {
+		view, err := jobview.FromRow(row.Job)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, TrackedJob{
+			Job: view,
+			Interaction: Interaction{
+				JobID:     row.Job.ID,
+				ViewedAt:  timePtr(row.ViewedAt),
+				SavedAt:   timePtr(row.SavedAt),
+				AppliedAt: timePtr(row.AppliedAt),
+				Stage:     textPtr(row.Stage),
+				Notes:     textPtr(row.Notes),
+			},
+		})
+	}
+	return items, nil
+}
+
+// CountInteractions returns the per-filter counts for the caller in one pass.
+func (r *QueriesRepository) CountInteractions(ctx context.Context, userID int64) (Counts, error) {
+	row, err := r.q.CountUserJobs(ctx, userID)
+	if err != nil {
+		return Counts{}, err
+	}
+	return Counts{
+		All:     row.All,
+		Viewed:  row.Viewed,
+		Saved:   row.Saved,
+		Applied: row.Applied,
+		Board:   row.Board,
+	}, nil
+}
+
+// ViewedSlugs returns every public job slug the caller has interacted with.
+func (r *QueriesRepository) ViewedSlugs(ctx context.Context, userID int64) ([]string, error) {
+	return r.q.ListViewedJobSlugs(ctx, userID)
+}
+
 // toInteraction converts a db.UserJob row to the domain Interaction type.
 func toInteraction(r db.UserJob) Interaction {
-	var viewedAt *time.Time
-	if r.ViewedAt.Valid {
-		t := r.ViewedAt.Time
-		viewedAt = &t
-	}
-
-	var appliedAt *time.Time
-	if r.AppliedAt.Valid {
-		t := r.AppliedAt.Time
-		appliedAt = &t
-	}
-
-	var savedAt *time.Time
-	if r.SavedAt.Valid {
-		t := r.SavedAt.Time
-		savedAt = &t
-	}
-
-	var stage *string
-	if r.Stage.Valid {
-		s := r.Stage.String
-		stage = &s
-	}
-
-	var notes *string
-	if r.Notes.Valid {
-		s := r.Notes.String
-		notes = &s
-	}
-
 	return Interaction{
 		JobID:     r.JobID,
-		ViewedAt:  viewedAt,
-		AppliedAt: appliedAt,
-		SavedAt:   savedAt,
-		Stage:     stage,
-		Notes:     notes,
+		ViewedAt:  timePtr(r.ViewedAt),
+		AppliedAt: timePtr(r.AppliedAt),
+		SavedAt:   timePtr(r.SavedAt),
+		Stage:     textPtr(r.Stage),
+		Notes:     textPtr(r.Notes),
 	}
+}
+
+// timePtr converts a pgtype.Timestamptz to *time.Time (nil when NULL).
+func timePtr(t pgtype.Timestamptz) *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	v := t.Time
+	return &v
+}
+
+// textPtr converts a pgtype.Text to *string (nil when NULL).
+func textPtr(t pgtype.Text) *string {
+	if !t.Valid {
+		return nil
+	}
+	v := t.String
+	return &v
 }
 
 // textFromPtr converts a *string to pgtype.Text. A nil pointer produces an

--- a/internal/sources/mts.go
+++ b/internal/sources/mts.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -83,7 +84,7 @@ func (m mts) apiKey(ctx context.Context) (string, error) {
 	}
 	key := mtsExtractAPIKey(root)
 	if key == "" {
-		return "", fmt.Errorf("mts: apiKey not found in site config")
+		return "", errors.New("mts: apiKey not found in site config")
 	}
 	return key, nil
 }

--- a/internal/telegram/llm.go
+++ b/internal/telegram/llm.go
@@ -3,6 +3,7 @@ package telegram
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -68,7 +69,7 @@ func (e *LangChainExtractor) Extract(ctx context.Context, text string, kind Kind
 		return Extraction{}, fmt.Errorf("telegram: generate: %w", err)
 	}
 	if len(resp.Choices) == 0 {
-		return Extraction{}, fmt.Errorf("telegram: model returned no choices")
+		return Extraction{}, errors.New("telegram: model returned no choices")
 	}
 	return parseExtraction(resp.Choices[0].Content)
 }


### PR DESCRIPTION
Follow-ups from a code-quality + architecture-boundary review. No behavior change to public wire contracts (verified by the me_jobs/viewed integration tests).

## Changes
- **jobtracking** — move the `/me/jobs` read use case behind the service. The filter vocabulary (`all|viewed|saved|applied|board`, incl. the default) and active-total selection now live in `jobtracking` (`Filter`/`ParseFilter`, `Counts.Total`, `Listing`), mirroring `userjob.Stage`; the handler is thin. `ListInteractions`/`CountInteractions`/`ViewedSlugs` join through the `QueriesRepository`, returning jobs in the canonical `jobview` shape.
- **enrich** — retry only transient transport failures. An unparseable model response (`errUnparseableResponse`) and a post-`Sanitize` `Validate` failure are no longer re-called in-process (identical call reproduces them); the outbox attempts counter still re-tries on the next cron run.
- **liveness** — serialize runs with a Postgres session advisory lock, so overlapping cron runs can't strike the same orphan twice in one burst (collapsing the two-consecutive-expired-reads grace). A run that can't take the lock exits cleanly.
- **oauth** — route token-exchange + userinfo through `safehttp` (SSRF guard, like every other outbound fetch) with a 1 MiB userinfo cap; a caller-supplied client is respected for tests.
- **cleanups** — `errors.New` for no-arg error literals (enrich/telegram/oauth/sources); consistent deferred `tx.Rollback` in `cmd/enrich`.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` clean (go1.25.11)
- full unit suite + `go test -tags=integration ./internal/handler/` green
- new TDD tests: enrich transport-vs-unparseable retry; jobtracking filter/total/passthrough
- liveness lock-held path verified manually against a containerized Postgres