### PR TITLE
fix(enrich): tolerate LLM JSON shape slips (scalar/array, float/int)

### DIFF
--- a/internal/enrich/enrichment_parse_test.go
+++ b/internal/enrich/enrichment_parse_test.go
@@ -1,0 +1,85 @@
+package enrich
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The model occasionally emits a semantically correct value in the wrong JSON
+// shape: a scalar where the contract wants an array, an array where it wants a
+// scalar, or a float where it wants an int. The data is good; only the wrapper
+// is wrong. Enrichment.UnmarshalJSON coerces these to the canonical shape so a
+// stray wrapper no longer fails the whole payload.
+
+func TestUnmarshalCoercesScalarToArray(t *testing.T) {
+	var e Enrichment
+	if err := json.Unmarshal([]byte(`{"regions":"eu"}`), &e); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(e.Regions) != 1 || e.Regions[0] != "eu" {
+		t.Errorf("regions = %v, want [eu]", e.Regions)
+	}
+}
+
+func TestUnmarshalCoercesArrayToScalar(t *testing.T) {
+	var e Enrichment
+	if err := json.Unmarshal([]byte(`{"seniority":["senior"]}`), &e); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if e.Seniority != "senior" {
+		t.Errorf("seniority = %q, want senior", e.Seniority)
+	}
+}
+
+func TestUnmarshalEmptyArrayToScalarStaysEmpty(t *testing.T) {
+	var e Enrichment
+	if err := json.Unmarshal([]byte(`{"category":[]}`), &e); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if e.Category != "" {
+		t.Errorf("category = %q, want empty", e.Category)
+	}
+}
+
+func TestUnmarshalRoundsFloatToInt(t *testing.T) {
+	var e Enrichment
+	if err := json.Unmarshal([]byte(`{"salary_min":17.5,"salary_max":209587.5,"experience_years_min":0.5}`), &e); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if e.SalaryMin == nil || *e.SalaryMin != 18 {
+		t.Errorf("salary_min = %v, want 18", e.SalaryMin)
+	}
+	if e.SalaryMax == nil || *e.SalaryMax != 209588 {
+		t.Errorf("salary_max = %v, want 209588", e.SalaryMax)
+	}
+	if e.ExperienceYearsMin == nil || *e.ExperienceYearsMin != 1 {
+		t.Errorf("experience_years_min = %v, want 1", e.ExperienceYearsMin)
+	}
+}
+
+func TestUnmarshalCanonicalShapesUnchanged(t *testing.T) {
+	raw := `{"regions":["eu","us"],"seniority":"senior","salary_min":100000,"skills":["go","postgresql"]}`
+	var e Enrichment
+	if err := json.Unmarshal([]byte(raw), &e); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(e.Regions) != 2 || e.Regions[0] != "eu" || e.Regions[1] != "us" {
+		t.Errorf("regions = %v, want [eu us]", e.Regions)
+	}
+	if e.Seniority != "senior" {
+		t.Errorf("seniority = %q, want senior", e.Seniority)
+	}
+	if e.SalaryMin == nil || *e.SalaryMin != 100000 {
+		t.Errorf("salary_min = %v, want 100000", e.SalaryMin)
+	}
+	if len(e.Skills) != 2 {
+		t.Errorf("skills = %v, want 2 entries", e.Skills)
+	}
+}
+
+func TestUnmarshalStillRejectsBrokenJSON(t *testing.T) {
+	var e Enrichment
+	if err := json.Unmarshal([]byte(`{"regions":`), &e); err == nil {
+		t.Error("expected error for truncated JSON, got nil")
+	}
+}

--- a/internal/enrich/enrichment_unmarshal.go
+++ b/internal/enrich/enrichment_unmarshal.go
@@ -1,0 +1,149 @@
+package enrich
+
+import (
+	"encoding/json"
+	"math"
+)
+
+// Tolerant JSON decoding for Enrichment. The model reliably picks the right
+// *value* but occasionally wraps it in the wrong *shape*: a scalar where the
+// contract wants an array ("eu" vs ["eu"]), an array where it wants a scalar
+// (["senior"] vs "senior"), or a float where it wants an int (17.5 vs 17). A
+// strict json.Unmarshal rejects the whole payload over one such wrapper, burning
+// an outbox attempt on data that was otherwise fine. UnmarshalJSON below coerces
+// each mis-shaped field to its canonical form so the value survives.
+//
+// The exported Enrichment field types are unchanged (string / []string / *int);
+// the tolerance lives only in this decode boundary. Sanitize/Validate then run on
+// the canonical shapes exactly as before.
+
+// flexString decodes a JSON string, or an array of strings (taking the first
+// element — an empty array yields an empty string).
+type flexString string
+
+func (f *flexString) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		*f = flexString(s)
+		return nil
+	}
+	var arr []string
+	if err := json.Unmarshal(b, &arr); err != nil {
+		return err
+	}
+	if len(arr) > 0 {
+		*f = flexString(arr[0])
+	}
+	return nil
+}
+
+// flexStringSlice decodes a JSON array of strings, or a single string (wrapped
+// into a one-element slice — an empty string yields an empty slice).
+type flexStringSlice []string
+
+func (f *flexStringSlice) UnmarshalJSON(b []byte) error {
+	var arr []string
+	if err := json.Unmarshal(b, &arr); err == nil {
+		*f = arr
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if s != "" {
+		*f = flexStringSlice{s}
+	}
+	return nil
+}
+
+// flexInt decodes any JSON number, rounding to the nearest integer so a
+// fractional value (an hourly rate like 17.5, or 0.5 years) is preserved instead
+// of failing the decode.
+type flexInt int
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	var n float64
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*f = flexInt(math.Round(n))
+	return nil
+}
+
+// enrichmentJSON mirrors Enrichment field-for-field (identical json tags) but
+// types every string/[]string/int field as its flex* counterpart, so decoding
+// tolerates the model's shape slips. It is a distinct type from Enrichment, so
+// Enrichment.UnmarshalJSON does not recurse.
+type enrichmentJSON struct {
+	WorkMode        flexString `json:"work_mode,omitempty"`
+	EmploymentType  flexString `json:"employment_type,omitempty"`
+	Relocation      flexString `json:"relocation,omitempty"`
+	VisaSponsorship *bool      `json:"visa_sponsorship,omitempty"`
+
+	Regions      flexStringSlice `json:"regions,omitempty"`
+	Countries    flexStringSlice `json:"countries,omitempty"`
+	Cities       flexStringSlice `json:"cities,omitempty"`
+	TimezoneNote flexString      `json:"timezone_note,omitempty"`
+
+	SalaryMin      *flexInt   `json:"salary_min,omitempty"`
+	SalaryMax      *flexInt   `json:"salary_max,omitempty"`
+	SalaryCurrency flexString `json:"salary_currency,omitempty"`
+	SalaryPeriod   flexString `json:"salary_period,omitempty"`
+
+	Seniority          flexString      `json:"seniority,omitempty"`
+	ExperienceYearsMin *flexInt        `json:"experience_years_min,omitempty"`
+	EnglishLevel       flexString      `json:"english_level,omitempty"`
+	EducationLevel     flexString      `json:"education_level,omitempty"`
+	Skills             flexStringSlice `json:"skills,omitempty"`
+
+	Category        flexString      `json:"category,omitempty"`
+	Domains         flexStringSlice `json:"domains,omitempty"`
+	PostingLanguage flexString      `json:"posting_language,omitempty"`
+
+	CompanyType flexString `json:"company_type,omitempty"`
+	CompanySize flexString `json:"company_size,omitempty"`
+}
+
+// UnmarshalJSON decodes into the tolerant shadow struct, then copies into the
+// canonical Enrichment shapes. A genuinely malformed document still errors.
+func (e *Enrichment) UnmarshalJSON(data []byte) error {
+	var s enrichmentJSON
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	*e = Enrichment{
+		WorkMode:           string(s.WorkMode),
+		EmploymentType:     string(s.EmploymentType),
+		Relocation:         string(s.Relocation),
+		VisaSponsorship:    s.VisaSponsorship,
+		Regions:            []string(s.Regions),
+		Countries:          []string(s.Countries),
+		Cities:             []string(s.Cities),
+		TimezoneNote:       string(s.TimezoneNote),
+		SalaryMin:          flexIntPtr(s.SalaryMin),
+		SalaryMax:          flexIntPtr(s.SalaryMax),
+		SalaryCurrency:     string(s.SalaryCurrency),
+		SalaryPeriod:       string(s.SalaryPeriod),
+		Seniority:          string(s.Seniority),
+		ExperienceYearsMin: flexIntPtr(s.ExperienceYearsMin),
+		EnglishLevel:       string(s.EnglishLevel),
+		EducationLevel:     string(s.EducationLevel),
+		Skills:             []string(s.Skills),
+		Category:           string(s.Category),
+		Domains:            []string(s.Domains),
+		PostingLanguage:    string(s.PostingLanguage),
+		CompanyType:        string(s.CompanyType),
+		CompanySize:        string(s.CompanySize),
+	}
+	return nil
+}
+
+// flexIntPtr converts an optional flexInt to an optional int, preserving absence.
+func flexIntPtr(n *flexInt) *int {
+	if n == nil {
+		return nil
+	}
+	v := int(*n)
+	return &v
+}


### PR DESCRIPTION
## Problem

Under the live enrich run, the entire actionable failure surface (the 502s from the gateway are a separate, currently-zero infra issue) is the LLM emitting a **semantically correct value in the wrong JSON shape**:

| Shape slip | Example | Count (log history) |
|---|---|---|
| scalar → array | `"regions": "eu"` instead of `["eu"]` | 84 |
| array → scalar | `"seniority": ["senior"]` instead of `"senior"` | ~70 |
| float → int | `"salary_min": 17.5`, `"experience_years_min": 0.5` | ~50 |

A strict `json.Unmarshal` rejects the **whole** payload over one such wrapper, burning an outbox attempt and eventually dead-lettering otherwise-good data — plus re-sampling wastes LLM budget.

## Fix

Custom `Enrichment.UnmarshalJSON` that decodes through a tolerant shadow struct (`flexString` / `flexStringSlice` / `flexInt`) and copies into the canonical shapes:

- **scalar↔array** coerced in both directions (empty array → empty scalar; empty string → empty slice)
- **float→int** rounds to nearest (`17.5`→`18`, `0.5`→`1`)

The exported `Enrichment` field types are **unchanged** (`string`/`[]string`/`*int`); tolerance lives only at the decode boundary, so `Sanitize`/`Validate` and every consumer (jobview, search) run exactly as before. Genuinely malformed JSON still errors.

## Tests

TDD: tests written first, verified RED against the exact prod error messages, then GREEN. Covers each coercion class, canonical-shape passthrough, empty-array edge, and broken-JSON rejection. Full suite green; `go vet` + `gofmt` clean.