### PR TITLE
feat(sources): add 37 ATS boards from LinkedIn offsite alerts

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -1433,3 +1433,35 @@
   board: checkly
 - company: Mubit
   board: mubit
+
+# --- added from LinkedIn offsite job alerts (2026-06-15) ---
+- company: Acorns
+  board: acorns
+- company: Avra
+  board: avra
+- company: Clipbook
+  board: clipbook
+- company: Flock
+  board: flock
+- company: HavocAI
+  board: havocai
+- company: Kyra
+  board: kyra
+- company: Omaze
+  board: omaze
+- company: Partyhat
+  board: partyhat
+- company: Preply
+  board: preply
+- company: Siro
+  board: siro
+- company: "Solvd, Inc."
+  board: solvd
+- company: Synctera
+  board: synctera
+- company: TELUS Digital
+  board: telus-digital
+- company: tem
+  board: tem
+- company: Thought Machine
+  board: thought-machine

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -2279,3 +2279,37 @@
   board: piramidalinc
 - company: Kinelo
   board: kinelo
+
+# --- added from LinkedIn offsite job alerts (2026-06-15) ---
+- company: Amperity
+  board: amperity
+- company: ApartmentIQ
+  board: apartmentiq
+- company: Arco Educação
+  board: arco
+- company: ArcTouch
+  board: arctouch
+- company: Artefact
+  board: artefact
+- company: AutogenAI
+  board: autogenai
+- company: ClassPass
+  board: classpass
+- company: DistroKid
+  board: distrokid
+- company: "Dragos, Inc."
+  board: dragos
+- company: Factored
+  board: factored
+- company: isaac
+  board: isaac
+- company: Netcracker Technology
+  board: netcracker
+- company: SciLeads
+  board: scileads
+- company: SeatGeek
+  board: seatgeek
+- company: Twindo
+  board: twindo
+- company: Unqork
+  board: unqork

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -861,3 +861,11 @@
   board: UpMetrics
 - company: Skysafe
   board: skysafe
+
+# --- added from LinkedIn offsite job alerts (2026-06-15) ---
+- company: PPRO
+  board: ppro
+- company: rePurpose Global
+  board: repurposeglobal
+- company: Swile
+  board: swile

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -923,3 +923,11 @@
   board: Allegro
 - company: Sectigo
   board: Sectigo
+
+# --- added from LinkedIn offsite job alerts (2026-06-15) ---
+- company: Genomics England
+  board: genomicsengland
+- company: pubX
+  board: pubx
+- company: Second Nature
+  board: secondnature


### PR DESCRIPTION
Cross-referenced 135 offsite companies from LinkedIn job-alert emails against the existing board lists; 37 uncovered companies resolved to a live public ATS board (ashby +15, greenhouse +16, lever +3, smartrecruiters +3).

Every slug was probed live (HTTP 200 + non-empty postings) before adding. Recruiters/aggregators and false-positive slug matches (Felix→flix = FlixBus, Remote Leverage→remote = General Assembly, Harmonic Security→harmonic.fun, etc.) were rejected after verifying each board's org name against the company.