### PR TITLE
feat(sources): add Uber and Amazon adapters (boardless)

### DIFF
--- a/internal/sources/amazon.go
+++ b/internal/sources/amazon.go
@@ -1,0 +1,86 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// amazon adapts Amazon's public careers search API (www.amazon.jobs/en/search.json), a
+// single-company source with no per-tenant board id (boardless). The search endpoint
+// returns each posting — including the full HTML description — inline, so one paged list
+// call assembles every Job with no per-job detail fetch. An empty base_query returns the
+// whole catalogue; pagination is by offset.
+type amazon struct {
+	http JSONGetter
+}
+
+const (
+	amazonSearchURL = "https://www.amazon.jobs/en/search.json?result_limit=%d&offset=%d&sort=recent"
+	amazonBaseURL   = "https://www.amazon.jobs"
+	// amazonPageLimit is how many postings to request per page.
+	amazonPageLimit = 100
+	// amazonDateLayout matches the human posted_date Amazon emits ("June 15, 2026").
+	amazonDateLayout = "January 2, 2006"
+)
+
+// NewAmazon builds the Amazon adapter over the given HTTP client.
+func NewAmazon(c JSONGetter) Source { return amazon{http: c} }
+
+func (amazon) Provider() string { return "amazon" }
+
+// amazon is single-company, so its config entries carry no board.
+func (amazon) boardless() {}
+
+// amazonResponse is the search response. Hits is the catalogue size; Jobs is empty past
+// the last page.
+type amazonResponse struct {
+	Hits int         `json:"hits"`
+	Jobs []amazonJob `json:"jobs"`
+}
+
+// amazonJob is one posting from the search response. The description is HTML; id_icims
+// arrives as a quoted string, not a number.
+type amazonJob struct {
+	IDICIMS            string `json:"id_icims"`
+	Title              string `json:"title"`
+	JobPath            string `json:"job_path"`
+	NormalizedLocation string `json:"normalized_location"`
+	Description        string `json:"description"`
+	PostedDate         string `json:"posted_date"`
+}
+
+func (a amazon) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for offset := 0; ; offset += amazonPageLimit {
+		var resp amazonResponse
+		url := fmt.Sprintf(amazonSearchURL, amazonPageLimit, offset)
+		if err := a.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("amazon: list offset %d: %w", offset, err)
+		}
+		if len(resp.Jobs) == 0 {
+			break
+		}
+		for _, j := range resp.Jobs {
+			jobs = append(jobs, a.toJob(e, j))
+		}
+		if len(jobs) >= resp.Hits {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a search result to a Job. The HTML description is sanitized; the job_path is
+// resolved against the site origin.
+func (amazon) toJob(e CompanyEntry, j amazonJob) Job {
+	return Job{
+		ExternalID:  j.IDICIMS,
+		URL:         amazonBaseURL + j.JobPath,
+		Title:       strings.TrimSpace(j.Title),
+		Company:     e.Company,
+		Location:    j.NormalizedLocation,
+		Description: sanitizeHTML(j.Description),
+		PostedAt:    parseLayout(amazonDateLayout, j.PostedDate),
+	}
+}

--- a/internal/sources/amazon_test.go
+++ b/internal/sources/amazon_test.go
@@ -1,0 +1,127 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// amazonHTTP is an offset-aware test JSONGetter: amazon.jobs pages its search.json by an
+// offset query parameter, so this fake routes a canned response on the offset parsed from
+// the URL. An unrequested offset returns an empty, zero-hit page — the natural end-of-list
+// response that stops pagination.
+type amazonHTTP struct {
+	pages   map[int]string
+	fail    bool
+	gotURLs []string
+}
+
+var amazonOffsetRE = regexp.MustCompile(`offset=(\d+)`)
+
+func (f *amazonHTTP) GetJSON(_ context.Context, url string, v any) error {
+	f.gotURLs = append(f.gotURLs, url)
+	if f.fail {
+		return errors.New("amazonHTTP: boom")
+	}
+	off := 0
+	if m := amazonOffsetRE.FindStringSubmatch(url); m != nil {
+		off, _ = strconv.Atoi(m[1])
+	}
+	raw, ok := f.pages[off]
+	if !ok {
+		raw = `{"hits":0,"jobs":[]}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestAmazonProvider(t *testing.T) {
+	if got := NewAmazon(nil).Provider(); got != "amazon" {
+		t.Errorf("Provider() = %q, want %q", got, "amazon")
+	}
+}
+
+func TestAmazonFetchPaginatesAndMaps(t *testing.T) {
+	fake := &amazonHTTP{pages: map[int]string{
+		0: `{"hits":3,"jobs":[
+			{"id_icims":"10449371","title":"Software Development Engineer III ","job_path":"/en/jobs/10449371/sde-iii","normalized_location":"Redmond, Washington, USA","description":"<p>Build it</p><script>alert(1)</script>","posted_date":"June 15, 2026"},
+			{"id_icims":"10449999","title":"Data Engineer","job_path":"/en/jobs/10449999/data-engineer","normalized_location":"Vancouver, BC, Canada","description":"<p>Pipelines</p>","posted_date":""}
+		]}`,
+		100: `{"hits":3,"jobs":[
+			{"id_icims":"10450000","title":"SRE","job_path":"/en/jobs/10450000/sre","normalized_location":"Dublin, Ireland","description":"<p>Keep it up</p>","posted_date":"June 14, 2026"}
+		]}`,
+	}}
+
+	jobs, err := NewAmazon(fake).Fetch(context.Background(), CompanyEntry{Company: "Amazon", Provider: "amazon"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (two pages)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j := byID["10449371"]
+	if j.Title != "Software Development Engineer III" {
+		t.Errorf("Title = %q, want trimmed", j.Title)
+	}
+	if j.Company != "Amazon" {
+		t.Errorf("Company = %q, want Amazon", j.Company)
+	}
+	if want := "https://www.amazon.jobs/en/jobs/10449371/sde-iii"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if want := "Redmond, Washington, USA"; j.Location != want {
+		t.Errorf("Location = %q, want %q", j.Location, want)
+	}
+	if !strings.Contains(j.Description, "<p>Build it</p>") || strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-15", j.PostedAt)
+	}
+
+	if byID["10449999"].PostedAt != nil {
+		t.Errorf("blank posted_date should yield nil PostedAt, got %v", byID["10449999"].PostedAt)
+	}
+}
+
+func TestAmazonStopsAtEmptyPage(t *testing.T) {
+	// hits claims 9 but the source returns one job then an empty page: the adapter must
+	// stop on the empty page rather than loop forever chasing the count.
+	fake := &amazonHTTP{pages: map[int]string{
+		0: `{"hits":9,"jobs":[{"id_icims":"1","title":"Only","job_path":"/en/jobs/1/only","normalized_location":"Remote","description":"x","posted_date":""}]}`,
+	}}
+	jobs, err := NewAmazon(fake).Fetch(context.Background(), CompanyEntry{Company: "Amazon"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (stop at empty page)", len(jobs))
+	}
+}
+
+func TestAmazonTransportErrorFailsBoard(t *testing.T) {
+	fake := &amazonHTTP{fail: true}
+	if _, err := NewAmazon(fake).Fetch(context.Background(), CompanyEntry{Company: "Amazon"}); err == nil {
+		t.Fatal("Fetch: want transport error, got nil")
+	}
+}
+
+func TestAmazonRegisteredInAllAndBoardless(t *testing.T) {
+	s, ok := All(nil)["amazon"]
+	if !ok {
+		t.Fatal(`All(nil)["amazon"] missing`)
+	}
+	if _, isBoardless := s.(boardless); !isBoardless {
+		t.Error("amazon should be boardless (single company, no board id)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -94,6 +94,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJoin(c),
 		// International single-company adapters (boardless).
 		NewUber(c),
+		NewAmazon(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -92,6 +92,8 @@ func All(c HTTPClient) map[string]Source {
 		NewTeamtailor(c),
 		NewBreezy(c),
 		NewJoin(c),
+		// International single-company adapters (boardless).
+		NewUber(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/internal/sources/uber.go
+++ b/internal/sources/uber.go
@@ -1,0 +1,107 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// uber adapts Uber's public careers search API (www.uber.com/api/loadSearchJobsResults),
+// a single-company source with no per-tenant board id (boardless). The search endpoint is
+// a POST that returns the full posting — including the Markdown description — inline, so
+// unlike Ozon/Gem there is no per-job detail request: one paged list call assembles every
+// Job. The HTML career pages sit behind bot protection, but this JSON API is open.
+type uber struct {
+	http HeaderJSONPoster
+}
+
+const (
+	uberSearchURL  = "https://www.uber.com/api/loadSearchJobsResults?localeCode=en"
+	uberVacancyURL = "https://www.uber.com/global/en/careers/list/%d/"
+	// uberPageLimit is how many postings to request per page.
+	uberPageLimit = 100
+	// uberCSRFToken is a non-secret header Uber's search API requires: any value is
+	// accepted, but without it the endpoint 403s (it gates casual scraping, not auth).
+	uberCSRFToken = "x"
+)
+
+// NewUber builds the Uber adapter over the given HTTP client.
+func NewUber(c HeaderJSONPoster) Source { return uber{http: c} }
+
+func (uber) Provider() string { return "uber" }
+
+// uber is single-company, so its config entries carry no board.
+func (uber) boardless() {}
+
+// uberRequest is the search POST body. An empty Params returns the whole catalogue;
+// pagination is driven by Page (0-based) at a fixed Limit.
+type uberRequest struct {
+	Params map[string]any `json:"params"`
+	Page   int            `json:"page"`
+	Limit  int            `json:"limit"`
+}
+
+// uberResponse is the search response. Status is "success" on a healthy read; Results is
+// null past the last page. TotalResults.Low is the catalogue size (the API splits a 64-bit
+// count into low/high words; the job count never overflows Low).
+type uberResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		Results      []uberResult `json:"results"`
+		TotalResults struct {
+			Low int `json:"low"`
+		} `json:"totalResults"`
+	} `json:"data"`
+}
+
+// uberResult is one posting from the search response. The description is Markdown.
+type uberResult struct {
+	ID          int64  `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Location    struct {
+		City        string `json:"city"`
+		Region      string `json:"region"`
+		CountryName string `json:"countryName"`
+	} `json:"location"`
+	CreationDate string `json:"creationDate"`
+}
+
+func (u uber) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 0; ; page++ {
+		var resp uberResponse
+		req := uberRequest{Params: map[string]any{}, Page: page, Limit: uberPageLimit}
+		headers := map[string]string{"x-csrf-token": uberCSRFToken}
+		if err := u.http.PostJSONWithHeaders(ctx, uberSearchURL, headers, req, &resp); err != nil {
+			return nil, fmt.Errorf("uber: list page %d: %w", page, err)
+		}
+		if resp.Status != "success" {
+			return nil, fmt.Errorf("uber: list page %d: status %q", page, resp.Status)
+		}
+		if len(resp.Data.Results) == 0 {
+			break
+		}
+		for _, r := range resp.Data.Results {
+			jobs = append(jobs, u.toJob(e, r))
+		}
+		if len(jobs) >= resp.Data.TotalResults.Low {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a search result to a Job. The Markdown description is rendered to HTML and
+// sanitized; the location collapses blank city/region fields.
+func (uber) toJob(e CompanyEntry, r uberResult) Job {
+	return Job{
+		ExternalID:  strconv.FormatInt(r.ID, 10),
+		URL:         fmt.Sprintf(uberVacancyURL, r.ID),
+		Title:       r.Title,
+		Company:     e.Company,
+		Location:    joinNonEmpty(r.Location.City, r.Location.Region, r.Location.CountryName),
+		Description: sanitizeHTML(markdownToHTML(r.Description)),
+		PostedAt:    parseRFC3339(r.CreationDate),
+	}
+}

--- a/internal/sources/uber_test.go
+++ b/internal/sources/uber_test.go
@@ -1,0 +1,169 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// uberHTTP is a body-aware test JSONPoster: Uber pages its search results by the page
+// number in the POST body (the URL is constant), so this fake routes a canned response
+// on req.Page. An unknown page returns an empty, successful result set — the natural
+// "past the end" response that ends pagination.
+type uberHTTP struct {
+	pages      map[int]string
+	fail       bool
+	gotURL     string
+	gotPages   []int
+	gotHeaders map[string]string
+}
+
+func (f *uberHTTP) PostJSONWithHeaders(_ context.Context, url string, headers map[string]string, body, v any) error {
+	f.gotURL = url
+	f.gotHeaders = headers
+	req, ok := body.(uberRequest)
+	if !ok {
+		return errors.New("uberHTTP: body is not a uberRequest")
+	}
+	f.gotPages = append(f.gotPages, req.Page)
+	if f.fail {
+		return errors.New("uberHTTP: boom")
+	}
+	raw, ok := f.pages[req.Page]
+	if !ok {
+		raw = `{"status":"success","data":{"results":[],"totalResults":{"low":0}}}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestUberProvider(t *testing.T) {
+	if got := NewUber(nil).Provider(); got != "uber" {
+		t.Errorf("Provider() = %q, want %q", got, "uber")
+	}
+}
+
+func TestUberFetchPaginatesAndMaps(t *testing.T) {
+	fake := &uberHTTP{pages: map[int]string{
+		0: `{"status":"success","data":{"totalResults":{"low":3},"results":[
+			{"id":153366,"title":"Engineering Manager","description":"**Hybrid** role\n\n<script>alert(1)</script>","location":{"city":"Seattle","region":"Washington","countryName":"United States"},"creationDate":"2026-01-08T22:29:00.000Z"},
+			{"id":159903,"title":"Solutions Architect","description":"About the role","location":{"city":"Sao Paulo","region":"Sao Paulo","countryName":"Brazil"},"creationDate":"2026-06-12T17:50:00.000Z"}
+		]}}`,
+		1: `{"status":"success","data":{"totalResults":{"low":3},"results":[
+			{"id":160000,"title":"Data Scientist","description":"Numbers","location":{"city":"","region":"","countryName":"India"},"creationDate":""}
+		]}}`,
+	}}
+
+	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber", Provider: "uber"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (two pages)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j := byID["153366"]
+	if j.Title != "Engineering Manager" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Uber" {
+		t.Errorf("Company = %q, want Uber", j.Company)
+	}
+	if want := "https://www.uber.com/global/en/careers/list/153366/"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if want := "Seattle, Washington, United States"; j.Location != want {
+		t.Errorf("Location = %q, want %q", j.Location, want)
+	}
+	if !strings.Contains(j.Description, "<strong>Hybrid</strong>") {
+		t.Errorf("Description not rendered from Markdown: %q", j.Description)
+	}
+	if strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 1, 8, 22, 29, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-01-08T22:29:00Z", j.PostedAt)
+	}
+
+	// Empty city/region collapse to just the country; empty creationDate -> nil PostedAt.
+	jd := byID["160000"]
+	if jd.Location != "India" {
+		t.Errorf("Location = %q, want India (blank city/region skipped)", jd.Location)
+	}
+	if jd.PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil (blank creationDate)", jd.PostedAt)
+	}
+}
+
+func TestUberStopsAtEmptyPage(t *testing.T) {
+	// totalResults says 5 but the source only returns 1 then an empty page: the adapter
+	// must stop on the empty page rather than loop forever chasing the count.
+	fake := &uberHTTP{pages: map[int]string{
+		0: `{"status":"success","data":{"totalResults":{"low":5},"results":[
+			{"id":1,"title":"Only One","description":"x","location":{"countryName":"US"},"creationDate":""}
+		]}}`,
+	}}
+	jobs, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (stop at empty page)", len(jobs))
+	}
+}
+
+func TestUberPostsToSearchURL(t *testing.T) {
+	fake := &uberHTTP{pages: map[int]string{}}
+	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.HasPrefix(fake.gotURL, "https://www.uber.com/api/loadSearchJobsResults") {
+		t.Errorf("posted to %q, want the loadSearchJobsResults endpoint", fake.gotURL)
+	}
+}
+
+func TestUberSendsCSRFHeader(t *testing.T) {
+	// Uber's search API 403s without an x-csrf-token header (any value is accepted); the
+	// adapter must send it or every board fails.
+	fake := &uberHTTP{pages: map[int]string{}}
+	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.gotHeaders["x-csrf-token"] == "" {
+		t.Errorf("missing x-csrf-token header; sent %v", fake.gotHeaders)
+	}
+}
+
+func TestUberNonSuccessFailsBoard(t *testing.T) {
+	// A 200 whose status is not "success" must fail the board, not read as empty.
+	fake := &uberHTTP{pages: map[int]string{
+		0: `{"status":"error","data":{"results":null,"totalResults":{"low":0}}}`,
+	}}
+	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err == nil {
+		t.Fatal("Fetch: want error on non-success status, got nil")
+	}
+}
+
+func TestUberTransportErrorFailsBoard(t *testing.T) {
+	fake := &uberHTTP{fail: true}
+	if _, err := NewUber(fake).Fetch(context.Background(), CompanyEntry{Company: "Uber"}); err == nil {
+		t.Fatal("Fetch: want transport error, got nil")
+	}
+}
+
+func TestUberRegisteredInAllAndBoardless(t *testing.T) {
+	s, ok := All(nil)["uber"]
+	if !ok {
+		t.Fatal(`All(nil)["uber"] missing`)
+	}
+	if _, isBoardless := s.(boardless); !isBoardless {
+		t.Error("uber should be boardless (single company, no board id)")
+	}
+}

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -2,6 +2,10 @@
 # provider (the file name "custom" is not a provider). Multi-tenant board lists
 # (greenhouse.yml, gem.yml, …) keep their own per-provider files.
 
+# International single-company sources.
+- company: Uber
+  provider: uber
+
 - company: VK
   provider: vk
 - company: Ozon

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -5,6 +5,8 @@
 # International single-company sources.
 - company: Uber
   provider: uber
+- company: Amazon
+  provider: amazon
 
 - company: VK
   provider: vk


### PR DESCRIPTION
Two boardless single-company adapters over open JSON careers APIs, same pattern as vk/ozon.

**Uber** — POST www.uber.com/api/loadSearchJobsResults; needs a non-secret x-csrf-token header (403 without). Markdown description inline → goldmark+sanitize. Verified live: 699 postings.

**Amazon** — GET www.amazon.jobs/en/search.json; full HTML description inline, id_icims is a quoted string, posted_date is 'January 2, 2006'. Verified live end-to-end (API caps result_limit=100, hits=10000).

Both registered in sources.All + one custom.yml entry each. TDD with body/offset-aware fakes.