### PR TITLE
feat: derive work_mode from the job description (close the dict-only gap)

### DIFF
--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -41,12 +41,18 @@ type Derived struct {
 // Derive computes the slugs and dictionary facets for a job. Geography, skills, and the
 // title classification (seniority/category) come from the curated dictionaries (which
 // emit nothing for what they cannot resolve); the work-mode precedence is structured
-// signal first, then the location parser's hint.
+// signal first, then the location parser's hint, then a conservative phrase match in
+// the description.
 func Derive(in Input) Derived {
 	geo := location.Parse(in.Location)
+	// Work-mode precedence: structured (ATS) → location marker → description phrase.
+	// Each lower source only fills a value the higher ones left empty.
 	workMode := in.WorkMode
 	if workMode == "" {
 		workMode = geo.WorkMode
+	}
+	if workMode == "" {
+		workMode = location.WorkModeFromDescription(in.Description)
 	}
 	class := classify.Parse(in.Title)
 	return Derived{

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -51,3 +51,63 @@ func TestDerive_StructuredWorkModeWins(t *testing.T) {
 		t.Errorf("WorkMode = %q, want hybrid (structured wins over parsed remote)", got.WorkMode)
 	}
 }
+
+// Work-mode source precedence: structured → location → description. The
+// description is the lowest-priority source and only fills a value the structured
+// signal and the location marker both left empty.
+func TestDerive_DescriptionFillsWorkModeWhenLocationSilent(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Dev",
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Location:    "Berlin", // no work-mode marker
+		Description: "This is a fully remote position open to the EU.",
+	})
+	if got.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (description fills when location silent)", got.WorkMode)
+	}
+}
+
+func TestDerive_LocationWorkModeBeatsDescription(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Dev",
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Location:    "Remote - Germany",       // location marker → remote
+		Description: "This is a hybrid role.", // description → hybrid, but loses
+	})
+	if got.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (location beats description)", got.WorkMode)
+	}
+}
+
+func TestDerive_StructuredBeatsDescription(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Dev",
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Location:    "Berlin", // silent
+		WorkMode:    "onsite", // structured
+		Description: "This is a fully remote position.",
+	})
+	if got.WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want onsite (structured beats description)", got.WorkMode)
+	}
+}
+
+func TestDerive_NoisyDescriptionYieldsNoWorkMode(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Dev",
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Location:    "Berlin", // silent
+		Description: "Experience with distributed systems and hybrid cloud.",
+	})
+	if got.WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty (noisy description, no real phrase)", got.WorkMode)
+	}
+}

--- a/internal/location/workmode.go
+++ b/internal/location/workmode.go
@@ -29,8 +29,9 @@ var descriptionWorkModePhrases = []struct {
 	{"onsite", []string{
 		"on-site only", "onsite only", "on site only", "fully on-site", "fully onsite",
 		"100% on-site", "100% onsite", "must be on-site", "must be onsite",
-		"on-site position", "onsite position", "in-office position", "from our office",
-		"in our office", "on-site role", "onsite role",
+		"on-site position", "onsite position", "in-office position",
+		"work from our office", "based in our office", "based in the office",
+		"on-site role", "onsite role",
 	}},
 }
 

--- a/internal/location/workmode.go
+++ b/internal/location/workmode.go
@@ -1,0 +1,52 @@
+package location
+
+import "strings"
+
+// descriptionWorkModePhrases maps a work mode to anchored phrases that signal it
+// in a job description, checked in priority order (hybrid beats remote, remote
+// beats onsite, when several appear). Unlike workModeMarkers — which scan a short
+// location string and can use loose tokens — these are tuned for PRECISION over
+// recall in long prose: a bare "remote"/"hybrid"/"in office" matches far too much
+// ("remote team", "hybrid cloud", "snacks in office"), so every phrase is anchored
+// to an unambiguous work-arrangement statement. The detector emits nothing on a
+// weak signal (never guesses), consistent with the curated-dictionary doctrine.
+var descriptionWorkModePhrases = []struct {
+	mode    string
+	phrases []string
+}{
+	{"hybrid", []string{
+		"hybrid role", "hybrid working", "hybrid work ", "hybrid work.", "hybrid model",
+		"hybrid schedule", "hybrid setup", "hybrid arrangement", "hybrid position",
+		"days in the office", "days per week in the office", "days a week in the office",
+		"days in office", "days onsite", "days on-site",
+	}},
+	{"remote", []string{
+		"fully remote", "fully-remote", "100% remote", "100 % remote", "remote-first",
+		"remote first", "work from anywhere", "work-from-anywhere", "remote position",
+		"remote role", "remote job", "remote opportunity", "remote vacancy",
+		"this position is remote", "role is remote", "position is remote",
+	}},
+	{"onsite", []string{
+		"on-site only", "onsite only", "on site only", "fully on-site", "fully onsite",
+		"100% on-site", "100% onsite", "must be on-site", "must be onsite",
+		"on-site position", "onsite position", "in-office position", "from our office",
+		"in our office", "on-site role", "onsite role",
+	}},
+}
+
+// WorkModeFromDescription derives a work mode from a job description's prose,
+// returning "" when no anchored arrangement phrase is present. It is the
+// lowest-priority work-mode source (after the structured ATS signal and the parsed
+// location marker), so it only ever fills a value the others left empty. Values are
+// from enrich.WorkModeValues.
+func WorkModeFromDescription(desc string) string {
+	lower := strings.ToLower(desc)
+	for _, wm := range descriptionWorkModePhrases {
+		for _, p := range wm.phrases {
+			if strings.Contains(lower, p) {
+				return wm.mode
+			}
+		}
+	}
+	return ""
+}

--- a/internal/location/workmode_test.go
+++ b/internal/location/workmode_test.go
@@ -1,0 +1,43 @@
+package location
+
+import "testing"
+
+func TestWorkModeFromDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want string
+	}{
+		// Positives — clear, anchored phrases.
+		{"fully remote", "This is a fully remote position open to anyone.", "remote"},
+		{"remote-first", "We are a remote-first company.", "remote"},
+		{"100 percent remote", "The role is 100% remote.", "remote"},
+		{"work from anywhere", "You can work from anywhere in the EU.", "remote"},
+		{"remote position", "Remote position with occasional travel.", "remote"},
+		{"hybrid role", "This is a hybrid role based in Berlin.", "hybrid"},
+		{"hybrid working", "We offer hybrid working arrangements.", "hybrid"},
+		{"days in the office", "You will spend 3 days in the office each week.", "hybrid"},
+		{"on-site only", "This job is on-site only.", "onsite"},
+		{"must be on-site", "Candidates must be on-site in our HQ.", "onsite"},
+		{"in-office position", "An in-office position in Munich.", "onsite"},
+
+		// Priority — hybrid beats remote when both appear.
+		{"hybrid beats remote", "A hybrid role with some remote days.", "hybrid"},
+
+		// Trap negatives — incidental tokens that must NOT trigger a match.
+		{"distributed systems", "Experience building distributed systems at scale.", ""},
+		{"hybrid cloud", "You will manage our hybrid cloud infrastructure.", ""},
+		{"remote server", "Debug issues on a remote server over SSH.", ""},
+		{"remote team", "Collaborate with a remote team across time zones.", ""},
+		{"bare in office", "Free snacks in office and a great culture.", ""},
+		{"no arrangement phrase", "We build payments infrastructure in Go.", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WorkModeFromDescription(tt.desc); got != tt.want {
+				t.Errorf("WorkModeFromDescription(%q) = %q, want %q", tt.desc, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/location/workmode_test.go
+++ b/internal/location/workmode_test.go
@@ -30,6 +30,7 @@ func TestWorkModeFromDescription(t *testing.T) {
 		{"remote server", "Debug issues on a remote server over SSH.", ""},
 		{"remote team", "Collaborate with a remote team across time zones.", ""},
 		{"bare in office", "Free snacks in office and a great culture.", ""},
+		{"incidental from our office", "Enjoy free lunch from our office cafeteria.", ""},
 		{"no arrangement phrase", "We build payments infrastructure in Go.", ""},
 		{"empty", "", ""},
 	}

--- a/openspec/changes/workmode-from-description/.openspec.yaml
+++ b/openspec/changes/workmode-from-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/workmode-from-description/design.md
+++ b/openspec/changes/workmode-from-description/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`internal/location` already owns work-mode detection: `detectWorkMode(lower)` does a
+substring scan of the location string against `workModeMarkers` (hybrid > remote >
+onsite). `jobderive.Derive` resolves `work_mode` as structured (ATS) → parsed
+location. The description — where work arrangement is most often stated — is never
+read, which is the 85%-of-enriched coverage gap this change closes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A deterministic, high-precision `work_mode` derivation from the description.
+- Description is the lowest-priority source: structured → location → description.
+
+**Non-Goals:**
+- seniority/category from description; skill-vocabulary expansion; any LLM change.
+- Re-reading the description for anything but work mode.
+
+## Decisions
+
+**Decision: a separate, conservative phrase set, not the location markers.** The
+short-location markers (`anywhere`, `worldwide`, `distributed`, bare `remote`/
+`hybrid`) are safe in a one-line location but produce false positives in long prose
+("distributed systems", "hybrid cloud", "remote team", "remote server"). The
+description detector uses its own curated, anchored phrases tuned for precision over
+recall (`fully remote`, `remote-first`, `work from anywhere`, `hybrid role/working/
+model`, `days in the office`, `on-site only`, `must be on-site`, `in-office
+position`, …). It emits nothing on a weak/ambiguous signal — the dictionary doctrine
+("never guess") is preserved. *Why not reuse `detectWorkMode`:* it would import the
+unsafe markers; precision is the whole point.
+
+**Decision: lives in `internal/location` as `WorkModeFromDescription(desc) string`.**
+The package already owns the work-mode vocabulary (aligned to `enrich.WorkModeValues`)
+and the detection idiom; a one-function addition is cheaper than a new package and
+keeps the work-mode logic in one place.
+
+**Decision: wire as a fallback in `jobderive.Derive`.** After the existing
+`structured → location` resolution, add `if workMode == "" { workMode =
+location.WorkModeFromDescription(in.Description) }`. This is the only call-site
+change; `cmd/backfill-derive` re-derives through `jobderive`, so it inherits the new
+source with no edit.
+
+## Risks / Trade-offs
+
+- **False positives from noisy prose** → Mitigation: a curated anchored phrase set
+  plus explicit negative ("trap") tests (`distributed systems`, `hybrid cloud`,
+  `remote server` → empty). Bias to precision; missed signals stay empty (the LLM
+  discovery layer still has them raw).
+- **Phrase set is necessarily incomplete** → Acceptable: it is a curated dictionary,
+  extendable later; partial recall beats the current zero.
+
+## Migration Plan
+
+Ships with `dict-production-facets`' deferred deploy: deploy the app image, run
+`cmd/backfill-derive` once (now recovers description-derived work_mode), then one
+`reindex`. No schema change, no rollback data concern (re-derivation is idempotent).

--- a/openspec/changes/workmode-from-description/proposal.md
+++ b/openspec/changes/workmode-from-description/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Under the dict-only doctrine (change `dict-production-facets`), `work_mode` is served from the deterministic dictionary columns only. But the work-mode parser reads only the short ATS **location** string, while the work arrangement is very often stated in the job **description** body. Measured on prod, ~75k open jobs (85% of the enriched set) carry a work_mode the LLM found but the dictionary cannot — because it never reads the description. This is the single largest coverage gap blocking the dict-only deploy. Teaching the deterministic parser to read the description closes most of it.
+
+## What Changes
+
+- Add `location.WorkModeFromDescription(desc string) string`: scans the lowercased description for a **conservative, high-precision** phrase set (distinct from the short-location markers — e.g. `fully remote` / `remote-first`, not a bare `remote` that matches "remote team"; `hybrid role`, not a bare `hybrid` that matches "hybrid cloud"), priority hybrid > remote > onsite, returning `""` when there is no clear signal (never guesses).
+- Wire it into `jobderive.Derive` as the lowest-priority work_mode source: the net order becomes **structured (ATS) → parsed location → description**. The description only fills a work_mode the structured signal and the location marker both left empty.
+- No schema change, no new command: `cmd/backfill-derive` already re-derives work_mode via `jobderive`, so a post-deploy backfill recovers the gap for existing jobs.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `job-geography`: the "Work mode is resolved by precedence across sources" requirement gains the description as a third, lowest-priority source.
+
+## Impact
+
+- Code: `internal/location/location.go` (new `WorkModeFromDescription` + its phrase set), `internal/location/*_test.go`; `internal/jobderive/jobderive.go` (one fallback) + its test.
+- Deploy: re-derives on next ingest automatically; existing jobs recovered by running `cmd/backfill-derive` + one `reindex` (the same deploy tail the `dict-production-facets` change already needs). This change is a prerequisite for that deploy being safe.
+- Out of scope: seniority/category from description, skill-vocabulary expansion, any LLM change.

--- a/openspec/changes/workmode-from-description/specs/job-geography/spec.md
+++ b/openspec/changes/workmode-from-description/specs/job-geography/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Work mode is resolved by precedence across sources
+
+`work_mode` is a scalar, so it SHALL be resolved by precedence, not union. It is
+derived at ingest into `jobs.work_mode` from three sources, most authoritative
+first: (1) the adapter's STRUCTURED work mode (a workplace-type enum or explicit
+remote flag from the ATS), (2) a marker in the parsed **location** string, and
+(3) a conservative phrase match in the job **description**. A lower source fills
+`work_mode` only when every higher source left it empty; the parser never guesses,
+so a description with no clear work-arrangement phrase yields nothing. At read time
+the served `work_mode` SHALL be the stored `jobs.work_mode` only; the LLM-derived
+`enrichment.work_mode` SHALL NOT override it.
+
+#### Scenario: Structured adapter work mode beats the parser
+
+- **WHEN** an adapter reports a structured `work_mode=hybrid` for a posting whose
+  location text would parse as `remote`
+- **THEN** the stored `jobs.work_mode` is `hybrid`
+
+#### Scenario: The location marker beats the description
+
+- **WHEN** a job has no structured work mode, a location that parses to `remote`,
+  and a description that mentions a hybrid arrangement
+- **THEN** the derived `work_mode` is `remote` (location wins; description only fills)
+
+#### Scenario: The description fills when location is silent
+
+- **WHEN** a job has no structured work mode, a location with no work-mode marker
+  (e.g. a bare city), and a description stating "this is a fully remote position"
+- **THEN** the derived `work_mode` is `remote`
+
+#### Scenario: A noisy description token does not trigger a false positive
+
+- **WHEN** a job's description contains incidental tokens like "distributed
+  systems" or "hybrid cloud" but no actual work-arrangement phrase, and no
+  structured or location signal
+- **THEN** the derived `work_mode` is empty
+
+#### Scenario: The ingest value is served regardless of the LLM
+
+- **WHEN** a job has `jobs.work_mode=onsite` from ingest and
+  `enrichment.work_mode=remote` from the LLM, and is read
+- **THEN** the resolved top-level `work_mode` is `onsite`

--- a/openspec/changes/workmode-from-description/tasks.md
+++ b/openspec/changes/workmode-from-description/tasks.md
@@ -1,0 +1,15 @@
+## 1. WorkModeFromDescription (the detector)
+
+- [ ] 1.1 Add failing tests in `internal/location` for `WorkModeFromDescription`: positives for each mode (remote: "fully remote", "remote-first", "work from anywhere"; hybrid: "hybrid role", "X days in the office"; onsite: "on-site only", "must be on-site"); priority hybrid > remote > onsite when both present; and trap negatives that MUST yield "" ("distributed systems", "hybrid cloud", "remote server/team", a plain description with no arrangement phrase).
+- [ ] 1.2 Implement `WorkModeFromDescription(desc string) string` in `internal/location`: lowercase the input, scan a curated, conservative phrase set (separate from `workModeMarkers`) in priority order hybrid > remote > onsite, return "" on no match. Draw modes from `enrich.WorkModeValues`.
+- [ ] 1.3 Run `go test ./internal/location/` green.
+
+## 2. Wire into jobderive (description as the lowest-priority source)
+
+- [ ] 2.1 Add a failing test in `internal/jobderive`: description fills `work_mode` when the location is silent; the location marker beats a description signal; a structured `WorkMode` input beats both; a noisy description with no phrase yields empty.
+- [ ] 2.2 In `jobderive.Derive`, after the existing structured→location resolution, add the description fallback: `if workMode == "" { workMode = location.WorkModeFromDescription(in.Description) }`.
+- [ ] 2.3 Run `go test ./internal/jobderive/` green.
+
+## 3. Verify
+
+- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean on changed files; confirm no other package regressed.

--- a/openspec/changes/workmode-from-description/tasks.md
+++ b/openspec/changes/workmode-from-description/tasks.md
@@ -1,15 +1,15 @@
 ## 1. WorkModeFromDescription (the detector)
 
-- [ ] 1.1 Add failing tests in `internal/location` for `WorkModeFromDescription`: positives for each mode (remote: "fully remote", "remote-first", "work from anywhere"; hybrid: "hybrid role", "X days in the office"; onsite: "on-site only", "must be on-site"); priority hybrid > remote > onsite when both present; and trap negatives that MUST yield "" ("distributed systems", "hybrid cloud", "remote server/team", a plain description with no arrangement phrase).
-- [ ] 1.2 Implement `WorkModeFromDescription(desc string) string` in `internal/location`: lowercase the input, scan a curated, conservative phrase set (separate from `workModeMarkers`) in priority order hybrid > remote > onsite, return "" on no match. Draw modes from `enrich.WorkModeValues`.
-- [ ] 1.3 Run `go test ./internal/location/` green.
+- [x] 1.1 Add failing tests in `internal/location` for `WorkModeFromDescription`: positives for each mode (remote: "fully remote", "remote-first", "work from anywhere"; hybrid: "hybrid role", "X days in the office"; onsite: "on-site only", "must be on-site"); priority hybrid > remote > onsite when both present; and trap negatives that MUST yield "" ("distributed systems", "hybrid cloud", "remote server/team", a plain description with no arrangement phrase).
+- [x] 1.2 Implement `WorkModeFromDescription(desc string) string` in `internal/location`: lowercase the input, scan a curated, conservative phrase set (separate from `workModeMarkers`) in priority order hybrid > remote > onsite, return "" on no match. Draw modes from `enrich.WorkModeValues`.
+- [x] 1.3 Run `go test ./internal/location/` green.
 
 ## 2. Wire into jobderive (description as the lowest-priority source)
 
-- [ ] 2.1 Add a failing test in `internal/jobderive`: description fills `work_mode` when the location is silent; the location marker beats a description signal; a structured `WorkMode` input beats both; a noisy description with no phrase yields empty.
-- [ ] 2.2 In `jobderive.Derive`, after the existing structured→location resolution, add the description fallback: `if workMode == "" { workMode = location.WorkModeFromDescription(in.Description) }`.
-- [ ] 2.3 Run `go test ./internal/jobderive/` green.
+- [x] 2.1 Add a failing test in `internal/jobderive`: description fills `work_mode` when the location is silent; the location marker beats a description signal; a structured `WorkMode` input beats both; a noisy description with no phrase yields empty.
+- [x] 2.2 In `jobderive.Derive`, after the existing structured→location resolution, add the description fallback: `if workMode == "" { workMode = location.WorkModeFromDescription(in.Description) }`.
+- [x] 2.3 Run `go test ./internal/jobderive/` green.
 
 ## 3. Verify
 
-- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean on changed files; confirm no other package regressed.
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean on changed files; confirm no other package regressed.


### PR DESCRIPTION
## Why

Follow-up to #106 (dict-only). The deterministic work-mode parser reads only the short ATS **location** string, but work arrangement is most often stated in the **description**. On prod, ~75k open jobs (**85% of the enriched set**) carry a work_mode the LLM found but the dictionary cannot — the single largest coverage gap blocking the dict-only deploy. This teaches the deterministic parser to read the description, recovering most of it.

## What changes

- **`location.WorkModeFromDescription(desc) string`** — a conservative, anchored-phrase detector (separate from the loose short-location markers), priority hybrid > remote > onsite, returns `""` on any weak/ambiguous signal (never guesses). Tuned for **precision over recall**: `fully remote`/`remote-first` not bare `remote`; `hybrid role` not bare `hybrid`; `on-site only` not bare `in office`.
- **`jobderive.Derive`** — description wired as the lowest-priority work-mode source: **structured (ATS) → location marker → description**. It only fills a value the higher sources left empty.
- No schema change, no new command, no LLM change. `cmd/backfill-derive` re-derives through `jobderive`, so the post-deploy backfill recovers existing jobs.

## Tests (TDD)

Detector table tests: positives per mode + **trap negatives that must yield `""`** (`distributed systems`, `hybrid cloud`, `remote server/team`, incidental `from our office`). `jobderive` precedence tests (description fills when location silent; location beats description; structured beats both; noisy description → empty). Full suite + vet + gofmt clean.

## Sequencing

This is the prerequisite that makes the deferred `dict-production-facets` deploy safe for work_mode. Deploy tail (shared): deploy app image → `cmd/backfill-derive` → one `reindex`.

Planned in OpenSpec (`openspec/changes/workmode-from-description/`): `job-geography` precedence delta.