### PR TITLE
feat: derive seniority from the job description (close the next dict-only gap)

### DIFF
--- a/internal/classify/description.go
+++ b/internal/classify/description.go
@@ -1,0 +1,67 @@
+package classify
+
+import "strings"
+
+// descriptionSeniorityPhrases maps a seniority grade to intent-anchored phrases
+// that signal it in a job description, checked in precedence order (highest grade
+// first, mirroring seniorityOrder). Unlike the title aliases — short, role-focused,
+// safe as bare whole words — these are tuned for PRECISION in long prose: a bare
+// "senior"/"lead"/"head of"/"staff" matches incidental text ("senior management",
+// "lead the team", "report to the head of product", "our staff"), so every phrase
+// is anchored to an unambiguous grade statement. Matching uses containsWord, so a
+// phrase only fires on word boundaries ("as a lead" never matches "as a leading
+// provider", "technical lead" never matches "technical leadership"). The detector
+// emits nothing on a weak signal and never infers a grade from a years figure.
+var descriptionSeniorityPhrases = []struct {
+	grade   string
+	phrases []string
+}{
+	{"c_level", []string{
+		"looking for a head of", "seeking a head of", "hiring a head of",
+		"as head of", "as a head of", "vp of", "vice president of",
+		"chief technology officer", "chief product officer", "chief executive officer",
+		"c-level position", "c-level role",
+	}},
+	{"principal", []string{
+		"principal engineer", "principal developer", "principal architect",
+		"principal scientist", "principal consultant", "principal position", "principal role",
+	}},
+	{"staff", []string{
+		"staff engineer", "staff developer", "staff software engineer",
+		"staff position", "staff role",
+	}},
+	{"lead", []string{
+		"lead role", "lead position", "looking for a lead", "hiring a lead",
+		"seeking a lead", "tech lead", "technical lead", "team lead position", "team lead role",
+	}},
+	{"senior", []string{
+		"senior-level", "senior position", "senior role",
+		"looking for a senior", "hiring a senior", "seeking a senior",
+	}},
+	{"middle", []string{
+		"mid-level", "intermediate-level",
+	}},
+	{"junior", []string{
+		"entry-level", "entry level", "junior position", "junior role",
+		"junior-level", "graduate position", "new grad",
+	}},
+	{"intern", []string{
+		"internship", "intern position", "intern role", "trainee position", "trainee role",
+	}},
+}
+
+// SeniorityFromDescription derives a seniority grade from a job description's prose,
+// returning "" when no anchored grade statement is present. It is the lower-priority
+// seniority source (after the title dictionary), so it only fills a value the title
+// left empty. Values are from enrich.SeniorityValues.
+func SeniorityFromDescription(desc string) string {
+	lower := strings.ToLower(desc)
+	for _, g := range descriptionSeniorityPhrases {
+		for _, p := range g.phrases {
+			if containsWord(lower, p) {
+				return g.grade
+			}
+		}
+	}
+	return ""
+}

--- a/internal/classify/description_test.go
+++ b/internal/classify/description_test.go
@@ -1,0 +1,48 @@
+package classify
+
+import "testing"
+
+func TestSeniorityFromDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want string
+	}{
+		// Positives — intent-anchored grade statements.
+		{"head of via intent anchor", "We are looking for a Head of Engineering to lead the team.", "c_level"},
+		{"vp of", "You will be our VP of Engineering.", "c_level"},
+		{"principal engineer", "This is a principal engineer position.", "principal"},
+		{"staff engineer", "Join us as a staff engineer.", "staff"},
+		{"lead role", "This is a lead role on the platform team.", "lead"},
+		{"looking for a lead", "We are looking for a lead developer.", "lead"},
+		{"senior-level", "A senior-level backend opening.", "senior"},
+		{"senior position", "This senior position is fully remote.", "senior"},
+		{"looking for a senior", "We are looking for a senior engineer.", "senior"},
+		{"mid-level", "A mid-level role with growth.", "middle"},
+		{"entry-level", "An entry-level opportunity for grads.", "junior"},
+		{"junior position", "This junior position suits new grads.", "junior"},
+		{"internship", "A summer internship in our Berlin office.", "intern"},
+
+		// Priority — a higher grade wins when two appear.
+		{"principal beats senior", "A principal engineer mentoring senior staff.", "principal"},
+
+		// Trap negatives — incidental prose that must NOT set a grade.
+		{"senior management", "You will collaborate with senior management.", ""},
+		{"lead the team", "You will lead the team of five engineers.", ""},
+		{"junior colleagues", "Mentor junior colleagues across the org.", ""},
+		{"our staff", "We care deeply about our staff and culture.", ""},
+		{"principal component analysis", "Experience with principal component analysis.", ""},
+		{"report to head of", "You will report to the Head of Product.", ""},
+		{"years of experience", "We require 5+ years of experience in Go.", ""},
+		{"senior level of commitment", "We expect a senior level of commitment.", ""},
+		{"no grade phrase", "Build resilient payment systems with us.", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SeniorityFromDescription(tt.desc); got != tt.want {
+				t.Errorf("SeniorityFromDescription(%q) = %q, want %q", tt.desc, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -40,9 +40,9 @@ type Derived struct {
 
 // Derive computes the slugs and dictionary facets for a job. Geography, skills, and the
 // title classification (seniority/category) come from the curated dictionaries (which
-// emit nothing for what they cannot resolve); the work-mode precedence is structured
-// signal first, then the location parser's hint, then a conservative phrase match in
-// the description.
+// emit nothing for what they cannot resolve). Two facets fall back to a conservative
+// description phrase match when their primary source is silent: work-mode (structured
+// signal → location hint → description) and seniority (title → description).
 func Derive(in Input) Derived {
 	geo := location.Parse(in.Location)
 	// Work-mode precedence: structured (ATS) → location marker → description phrase.
@@ -55,6 +55,13 @@ func Derive(in Input) Derived {
 		workMode = location.WorkModeFromDescription(in.Description)
 	}
 	class := classify.Parse(in.Title)
+	// Seniority precedence: title dictionary → description phrase. The description
+	// only fills a grade the title left empty. Category stays title-only (its prose
+	// signal is too noisy to derive deterministically).
+	seniority := class.Seniority
+	if seniority == "" {
+		seniority = classify.SeniorityFromDescription(in.Description)
+	}
 	return Derived{
 		CompanySlug: normalize.Slug(in.Company),
 		PublicSlug:  normalize.JobSlug(in.Title, in.Company, in.Source, in.ExternalID),
@@ -62,7 +69,7 @@ func Derive(in Input) Derived {
 		Regions:     geo.Regions,
 		WorkMode:    workMode,
 		Skills:      skilltag.Parse(in.Description),
-		Seniority:   class.Seniority,
+		Seniority:   seniority,
 		Category:    class.Category,
 	}
 }

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -111,3 +111,47 @@ func TestDerive_NoisyDescriptionYieldsNoWorkMode(t *testing.T) {
 		t.Errorf("WorkMode = %q, want empty (noisy description, no real phrase)", got.WorkMode)
 	}
 }
+
+// Seniority source precedence: title dictionary → description. The description
+// only fills a grade the title left empty; category is unaffected.
+func TestDerive_DescriptionFillsSeniorityWhenTitleSilent(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Backend Developer", // no grade word
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Description: "We are looking for a senior engineer to own the platform.",
+	})
+	if got.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior (description fills when title silent)", got.Seniority)
+	}
+	if got.Category != "backend" {
+		t.Errorf("Category = %q, want backend (unaffected)", got.Category)
+	}
+}
+
+func TestDerive_TitleSeniorityBeatsDescription(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Lead Backend Engineer", // title → lead
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Description: "You will work with a senior team.", // description → senior, but loses
+	})
+	if got.Seniority != "lead" {
+		t.Errorf("Seniority = %q, want lead (title beats description)", got.Seniority)
+	}
+}
+
+func TestDerive_NoisyDescriptionYieldsNoSeniority(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Backend Developer", // no grade
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Description: "Collaborate with senior management and lead the team to success.",
+	})
+	if got.Seniority != "" {
+		t.Errorf("Seniority = %q, want empty (noisy description, no anchored grade)", got.Seniority)
+	}
+}

--- a/openspec/changes/seniority-from-description/.openspec.yaml
+++ b/openspec/changes/seniority-from-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/seniority-from-description/design.md
+++ b/openspec/changes/seniority-from-description/design.md
@@ -1,0 +1,62 @@
+## Context
+
+`internal/classify` derives `seniority`/`category` from the **title** via
+`containsWord` whole-word matching of EN+RU aliases in priority order. The title is
+short and role-focused, so whole-word alias matching is safe there. The description
+is long prose where the same aliases are noisy (`senior management`, `lead the
+team`, `report to the head of product`), so the title approach cannot be reused.
+`jobderive.Derive` resolves `seniority` from the title only; ~64% of enriched jobs
+have a description-stated grade the title misses.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A deterministic, high-precision `seniority` derivation from the description.
+- Description is the lower-priority source: title → description.
+
+**Non-Goals:**
+- `category` from the description (its prose signal — tech-stack mentions — is too
+  noisy; deferred to its own careful change).
+- Years-of-experience → grade banding (the boundaries are a judgment call, not a
+  fact; excluded per "never guess").
+- Any LLM change; any schema or command change.
+
+## Decisions
+
+**Decision: intent-anchored phrases, not the bare title aliases.** The detector
+uses a separate curated set of anchored phrases (`senior-level`, `senior
+position/role`, `we are looking for a senior`, `principal engineer`, `staff
+engineer`, `entry-level`, `internship`, …). Ambiguous grade words get an intent
+anchor: `head of` is matched only as `looking for a head of` / `as head of`, never
+bare, so "report to the head of product" does not misfire. Priority follows the
+title order: c_level > principal > staff > lead > senior > middle > junior > intern.
+It emits `""` on a weak signal — the dictionary doctrine ("never guess") holds.
+*Why not reuse `containsWord` with the title aliases:* the bare aliases are unsafe
+in prose; precision is the whole point.
+
+**Decision: lives in `internal/classify` as `SeniorityFromDescription(desc) string`.**
+The package already owns the seniority vocabulary (aligned to
+`enrich.SeniorityValues`); a one-function addition keeps the grade logic in one
+place. The phrase set goes in a new file (`description.go`) to keep `classify.go`
+focused.
+
+**Decision: wire as a fallback in `jobderive.Derive`.** After
+`class := classify.Parse(in.Title)`, add `seniority := class.Seniority; if
+seniority == "" { seniority = classify.SeniorityFromDescription(in.Description) }`,
+and return that `seniority`. `class.Category` is returned unchanged.
+`cmd/backfill-derive` inherits the new source with no edit.
+
+## Risks / Trade-offs
+
+- **False positives from noisy prose** → Mitigation: intent-anchored phrase set plus
+  explicit negative ("trap") tests (`senior management`, `lead the team`, `junior
+  colleagues`, `our staff`, `principal component analysis`, `report to the head of
+  product` → empty). Bias to precision; missed grades stay empty.
+- **Low recall vs years-banding** → Accepted: explicit-phrase recall is lower, but a
+  defensible grade beats a guessed one; the LLM discovery layer still has the rest raw.
+
+## Migration Plan
+
+Ships with the deferred dict-only deploy: deploy the app image, run
+`cmd/backfill-derive` once (now recovers description-derived seniority), then one
+`reindex`. No schema change; re-derivation is idempotent.

--- a/openspec/changes/seniority-from-description/proposal.md
+++ b/openspec/changes/seniority-from-description/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Follow-up to the dict-only doctrine (`dict-production-facets`) and `workmode-from-description`. The `classify` dictionary derives `seniority` from the job **title** only, but the grade is often stated in the **description** body. Measured on prod, ~56k open jobs (64% of the enriched set) carry a seniority the LLM found but the title dictionary cannot. Teaching `classify` to read the description — with high-precision, intent-anchored phrases — recovers the subset that explicitly states the grade, the next-largest coverage gap after work_mode.
+
+## What Changes
+
+- Add `classify.SeniorityFromDescription(desc string) string`: scans the lowercased description for **intent-anchored** seniority phrases (NOT the bare title aliases — a bare `senior`/`lead`/`head of` in prose matches "senior management", "lead the team", "report to the head of product"), priority c_level > principal > staff > lead > senior > middle > junior > intern, returning `""` when there is no clear grade statement (never guesses). Years-of-experience banding is deliberately excluded (the band boundaries are a judgment call, not a fact).
+- Wire it into `jobderive.Derive` as the lowest-priority seniority source: title dictionary first, then the description. `category` is unchanged (deferred — its description signal is too noisy).
+- No schema change, no new command, no LLM change: `cmd/backfill-derive` re-derives through `jobderive`, so a post-deploy backfill recovers existing jobs.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `deterministic-facets`: the seniority facet gains the description as a second, lowest-priority derivation source (after the title).
+
+## Impact
+
+- Code: `internal/classify/classify.go` + a new phrase set (e.g. `classify/description.go`), `internal/classify/*_test.go`; `internal/jobderive/jobderive.go` (one fallback) + its test.
+- Deploy: re-derives on next ingest automatically; existing jobs recovered by the shared deferred deploy tail (`cmd/backfill-derive` + one `reindex`) of the dict-only sequence.
+- Out of scope: category from the description (deferred — too noisy), skill-vocabulary expansion, any LLM change.

--- a/openspec/changes/seniority-from-description/specs/deterministic-facets/spec.md
+++ b/openspec/changes/seniority-from-description/specs/deterministic-facets/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Seniority is derived from the description when the title is silent
+
+The seniority facet SHALL be derived at ingest from two sources, most
+authoritative first: (1) the title dictionary (`classify.Parse`), and (2) a
+conservative, intent-anchored phrase match in the job **description**. The
+description SHALL fill `seniority` only when the title dictionary resolved
+nothing. The description detector SHALL use anchored phrases (not the bare title
+aliases) so incidental prose does not match, and SHALL emit nothing when there is
+no clear grade statement (it never guesses, and it does not infer a grade from a
+years-of-experience figure). The category facet is unaffected by this requirement.
+
+#### Scenario: The description fills seniority when the title is silent
+
+- **WHEN** a job's title states no grade and its description says "we are looking
+  for a senior engineer"
+- **THEN** the derived `seniority` is `senior`
+
+#### Scenario: The title grade beats the description
+
+- **WHEN** a job's title resolves to `lead` and its description mentions a senior
+  engineer
+- **THEN** the derived `seniority` is `lead` (the title wins; description only fills)
+
+#### Scenario: Incidental prose does not set seniority
+
+- **WHEN** a job's title states no grade and its description contains incidental
+  phrases like "senior management", "lead the team", "junior colleagues", or
+  "report to the head of product" — but no anchored grade statement
+- **THEN** the derived `seniority` is empty
+
+#### Scenario: A years-of-experience figure does not set seniority
+
+- **WHEN** a job's title states no grade and its description only says "5+ years of
+  experience required"
+- **THEN** the derived `seniority` is empty (no band is inferred)

--- a/openspec/changes/seniority-from-description/tasks.md
+++ b/openspec/changes/seniority-from-description/tasks.md
@@ -1,15 +1,15 @@
 ## 1. SeniorityFromDescription (the detector)
 
-- [ ] 1.1 Add failing tests in `internal/classify` for `SeniorityFromDescription`: positives per grade (c_level: "head of engineering" via intent anchor, "vp of engineering"; principal: "principal engineer"; staff: "staff engineer"; lead: "lead role", "we are looking for a lead"; senior: "senior-level", "senior position", "we are looking for a senior"; middle: "mid-level"; junior: "entry-level", "junior position"; intern: "internship"); priority (a higher grade wins when two appear); and trap negatives that MUST yield "" ("senior management", "lead the team", "junior colleagues", "our staff", "principal component analysis", "report to the head of product", "5+ years of experience").
-- [ ] 1.2 Implement `SeniorityFromDescription(desc string) string` in `internal/classify` (new `description.go`): lowercase the input, scan a curated intent-anchored phrase set in priority order c_level > principal > staff > lead > senior > middle > junior > intern, return "" on no match. Canonical values are `enrich.SeniorityValues`.
-- [ ] 1.3 Run `go test ./internal/classify/` green.
+- [x] 1.1 Add failing tests in `internal/classify` for `SeniorityFromDescription`: positives per grade (c_level: "head of engineering" via intent anchor, "vp of engineering"; principal: "principal engineer"; staff: "staff engineer"; lead: "lead role", "we are looking for a lead"; senior: "senior-level", "senior position", "we are looking for a senior"; middle: "mid-level"; junior: "entry-level", "junior position"; intern: "internship"); priority (a higher grade wins when two appear); and trap negatives that MUST yield "" ("senior management", "lead the team", "junior colleagues", "our staff", "principal component analysis", "report to the head of product", "5+ years of experience").
+- [x] 1.2 Implement `SeniorityFromDescription(desc string) string` in `internal/classify` (new `description.go`): lowercase the input, scan a curated intent-anchored phrase set in priority order c_level > principal > staff > lead > senior > middle > junior > intern, return "" on no match. Canonical values are `enrich.SeniorityValues`.
+- [x] 1.3 Run `go test ./internal/classify/` green.
 
 ## 2. Wire into jobderive (description as the lower-priority seniority source)
 
-- [ ] 2.1 Add a failing test in `internal/jobderive`: description fills `seniority` when the title is silent; the title grade beats a description signal; a noisy description with no anchored phrase yields empty; `category` is unaffected.
-- [ ] 2.2 In `jobderive.Derive`, capture `class := classify.Parse(in.Title)`, then `seniority := class.Seniority; if seniority == "" { seniority = classify.SeniorityFromDescription(in.Description) }`, and return that seniority (category unchanged).
-- [ ] 2.3 Run `go test ./internal/jobderive/` green.
+- [x] 2.1 Add a failing test in `internal/jobderive`: description fills `seniority` when the title is silent; the title grade beats a description signal; a noisy description with no anchored phrase yields empty; `category` is unaffected.
+- [x] 2.2 In `jobderive.Derive`, capture `class := classify.Parse(in.Title)`, then `seniority := class.Seniority; if seniority == "" { seniority = classify.SeniorityFromDescription(in.Description) }`, and return that seniority (category unchanged).
+- [x] 2.3 Run `go test ./internal/jobderive/` green.
 
 ## 3. Verify
 
-- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean on changed files; confirm no other package regressed.
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean on changed files; confirm no other package regressed.

--- a/openspec/changes/seniority-from-description/tasks.md
+++ b/openspec/changes/seniority-from-description/tasks.md
@@ -1,0 +1,15 @@
+## 1. SeniorityFromDescription (the detector)
+
+- [ ] 1.1 Add failing tests in `internal/classify` for `SeniorityFromDescription`: positives per grade (c_level: "head of engineering" via intent anchor, "vp of engineering"; principal: "principal engineer"; staff: "staff engineer"; lead: "lead role", "we are looking for a lead"; senior: "senior-level", "senior position", "we are looking for a senior"; middle: "mid-level"; junior: "entry-level", "junior position"; intern: "internship"); priority (a higher grade wins when two appear); and trap negatives that MUST yield "" ("senior management", "lead the team", "junior colleagues", "our staff", "principal component analysis", "report to the head of product", "5+ years of experience").
+- [ ] 1.2 Implement `SeniorityFromDescription(desc string) string` in `internal/classify` (new `description.go`): lowercase the input, scan a curated intent-anchored phrase set in priority order c_level > principal > staff > lead > senior > middle > junior > intern, return "" on no match. Canonical values are `enrich.SeniorityValues`.
+- [ ] 1.3 Run `go test ./internal/classify/` green.
+
+## 2. Wire into jobderive (description as the lower-priority seniority source)
+
+- [ ] 2.1 Add a failing test in `internal/jobderive`: description fills `seniority` when the title is silent; the title grade beats a description signal; a noisy description with no anchored phrase yields empty; `category` is unaffected.
+- [ ] 2.2 In `jobderive.Derive`, capture `class := classify.Parse(in.Title)`, then `seniority := class.Seniority; if seniority == "" { seniority = classify.SeniorityFromDescription(in.Description) }`, and return that seniority (category unchanged).
+- [ ] 2.3 Run `go test ./internal/jobderive/` green.
+
+## 3. Verify
+
+- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean on changed files; confirm no other package regressed.


### PR DESCRIPTION
## Why

Follow-up to #106 (dict-only) and #107 (work_mode from description). `classify` derives `seniority` from the **title** only, but the grade is often in the **description**. On prod, ~56k open jobs (**64% of the enriched set**) carry a seniority the title dictionary misses — the next-largest coverage gap after work_mode.

## What changes

- **`classify.SeniorityFromDescription(desc) string`** — intent-anchored grade phrases (NOT the bare title aliases), matched with the boundary-aware `containsWord`, priority c_level > principal > staff > lead > senior > middle > junior > intern, `""` on no clear statement. Boundary matching + intent anchors keep prose from misfiring: `senior management`, `lead the team`, `our staff`, `principal component analysis`, `report to the head of product`, `technical leadership`, `senior level of commitment` all yield empty. **Years-of-experience banding is excluded** (the boundaries are a judgment, not a fact — per 'never guess').
- **`jobderive.Derive`** — seniority wired as the lower-priority source: **title → description**. **`category` is unchanged** (its prose signal — tech-stack mentions — is too noisy; deferred).
- No schema/command/LLM change. `cmd/backfill-derive` recovers existing jobs.

## Tests (TDD)

Detector table tests: positives per grade + **trap negatives** that must yield `""`. `jobderive` precedence tests (description fills when title silent; title beats description; category unaffected; noisy → empty). Full suite + vet + gofmt clean.

## Sequencing

Third in the deferred dict-only deploy sequence (#106 → #107 → this). Shared deploy tail: app image → `cmd/backfill-derive` → one `reindex`. Remaining gap after this: `category` (deferred) and `skills` vocab.

Planned in OpenSpec (`openspec/changes/seniority-from-description/`).