### PR TITLE
feat(workers): non-zero exit on failure + shared signal-aware bootstrap

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -15,12 +15,12 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 	"slices"
 
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobderive"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // backfillBatchSize bounds how many jobs are read per keyset page.
@@ -35,20 +35,24 @@ type facetStore interface {
 }
 
 func main() {
-	cfg := config.Load()
-	ctx := context.Background()
+	os.Exit(run())
+}
 
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 
 	scanned, updated, err := backfillAll(ctx, db.New(pool))
 	if err != nil {
-		log.Fatalf("backfill-derive: %v", err)
+		log.Printf("backfill-derive: %v", err)
+		return 1
 	}
 	log.Printf("backfill-derive done: scanned=%d updated=%d", scanned, updated)
+	return 0
 }
 
 // backfillAll re-derives every job's six facet columns and rewrites the rows whose

--- a/cmd/enrich/main.go
+++ b/cmd/enrich/main.go
@@ -1,36 +1,44 @@
 // Command enrich is the standalone enrichment worker. It enqueues jobs that need
 // enriching, then drains the outbox queue: for each claimed job it asks the LLM for
 // a structured Enrichment, validates it, and writes it back. Run it on a schedule
-// (e.g. cron); it processes a bounded batch and exits.
+// (e.g. cron); it processes a bounded batch and exits. It exits non-zero when the
+// run finished with any failures or dead-letters, so cron can alert.
 package main
 
 import (
 	"context"
 	"log"
+	"os"
 
 	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 func main() {
-	cfg := config.Load()
+	os.Exit(run())
+}
+
+func run() int {
+	// LLM config is loaded first so a misconfigured worker fails before it opens
+	// the pool.
 	ecfg, err := config.LoadEnrich()
 	if err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 
 	provider, err := enrich.NewLangChainProvider(ecfg.LLMBaseURL, ecfg.LLMAPIKey, ecfg.LLMModel)
 	if err != nil {
-		log.Fatalf("provider: %v", err)
+		log.Printf("provider: %v", err)
+		return 1
 	}
 
 	runner := enrich.Runner{Provider: provider, Store: newDBStore(pool)}
@@ -42,9 +50,11 @@ func main() {
 		MaxAttempts:   ecfg.MaxAttempts,
 	})
 	if err != nil {
-		log.Fatalf("enrich: %v", err)
+		log.Printf("enrich: %v", err)
+		return 1
 	}
 
 	log.Printf("enrichment done: enriched=%d failed=%d dead_lettered=%d",
 		stats.Enriched, stats.Failed, stats.DeadLettered)
+	return worker.ExitCode(stats.Failed, stats.DeadLettered)
 }

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -17,12 +17,11 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/pipeline"
 	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // staleAfter is the grace window before an unseen job is closed: many crawl cycles
@@ -31,8 +30,10 @@ import (
 const staleAfter = 48 * time.Hour
 
 func main() {
-	cfg := config.Load()
+	os.Exit(run())
+}
 
+func run() int {
 	// The board file is usually one provider's list (sources/<provider>.yml, provider =
 	// file name), but an entry may name its own provider, so it may be a mixed file
 	// (sources/custom.yml). Accept it as the first argument (cron passes the file) or via
@@ -42,26 +43,28 @@ func main() {
 		path = os.Args[1]
 	}
 	if path == "" {
-		log.Fatal("config: no board file given (pass sources/<provider>.yml as an argument or set SOURCES_FILE)")
+		log.Print("config: no board file given (pass sources/<provider>.yml as an argument or set SOURCES_FILE)")
+		return 1
 	}
 	sourceCfg, err := sources.LoadConfig(path)
 	if err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 
 	registry := sources.All(sources.NewClient())
 	// Fail fast before touching the DB: a misconfigured board should not start a run.
 	if err := sourceCfg.Validate(registry); err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 
 	runner := pipeline.Runner{
 		Registry: registry,
@@ -70,12 +73,17 @@ func main() {
 
 	runStats, err := runner.Run(ctx, sourceCfg.Sources)
 	if err != nil {
-		log.Fatalf("ingest: %v", err)
+		log.Printf("ingest: %v", err)
+		return 1
 	}
 
 	total := runStats.Total()
 	log.Printf("ingest done: file=%s providers=%d ingested=%d failed=%d skipped=%d",
 		path, len(runStats), total.Ingested, total.Failed, total.Skipped)
+
+	// A failed board is counted in total.Failed; surface it (and any sweep failure
+	// below) through the exit code so cron alerts on a degraded run.
+	failed := total.Failed
 
 	// Post-run sweep (job-lifecycle spec): per provider, close that provider's open jobs
 	// unseen for the whole grace window. Scoped per provider so one provider's run never
@@ -90,10 +98,15 @@ func main() {
 			Cutoff: cutoff,
 		})
 		if err != nil {
-			log.Fatalf("close stale jobs: %v", err)
+			// Count and continue: one provider's sweep failure must not skip the rest,
+			// but the run still exits non-zero.
+			failed++
+			log.Printf("close stale jobs (%s): %v", provider, err)
+			continue
 		}
 		log.Printf("closed %d stale %s jobs (unseen for %s)", closed, provider, staleAfter)
 	}
+	return worker.ExitCode(failed, 0)
 }
 
 // sweepableProviders returns, sorted, the providers in a run that ingested at least one

--- a/cmd/liveness/main.go
+++ b/cmd/liveness/main.go
@@ -7,22 +7,23 @@
 // candidates, probe each over plain HTTP, classify, apply the strike/close/reset
 // update, and exit. Re-running is safe; only a definitive death signal confirmed
 // twice in a row closes a job, biasing toward leaving orphans open over a false
-// close (orphans have no re-ingest to reopen them).
+// close (orphans have no re-ingest to reopen them). It exits non-zero when a probe
+// could not apply its DB update, so cron can alert.
 package main
 
 import (
 	"context"
 	"log"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/liveness"
 	"github.com/strelov1/freehire/internal/safehttp"
 	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 const (
@@ -44,14 +45,16 @@ const (
 )
 
 func main() {
-	cfg := config.Load()
-	ctx := context.Background()
+	os.Exit(run())
+}
 
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 	queries := db.New(pool)
 
 	// Single-flight: hold a session-scoped advisory lock on a dedicated connection
@@ -59,17 +62,19 @@ func main() {
 	// twice within one burst. A run that can't take the lock exits cleanly.
 	lockConn, err := pool.Acquire(ctx)
 	if err != nil {
-		log.Fatalf("acquire lock connection: %v", err)
+		log.Printf("acquire lock connection: %v", err)
+		return 1
 	}
 	var locked bool
 	if err := lockConn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", int64(lockKey)).Scan(&locked); err != nil {
 		lockConn.Release()
-		log.Fatalf("liveness lock: %v", err)
+		log.Printf("liveness lock: %v", err)
+		return 1
 	}
 	if !locked {
 		lockConn.Release()
 		log.Print("liveness: another run holds the lock — exiting")
-		return
+		return 0
 	}
 	defer func() {
 		// Best-effort unlock; releasing/closing the connection drops the session lock anyway.
@@ -85,19 +90,21 @@ func main() {
 	// exclusion list would select EVERY open job — including board jobs the ingest
 	// sweep owns. Refuse to run rather than risk URL-closing the whole catalogue.
 	if len(atsProviders) == 0 {
-		log.Fatal("liveness: no ATS providers registered — refusing to run (would probe every open job)")
+		log.Print("liveness: no ATS providers registered — refusing to run (would probe every open job)")
+		return 1
 	}
 
 	candidates, err := queries.SelectOrphanLivenessCandidates(ctx, atsProviders)
 	if err != nil {
-		log.Fatalf("select candidates: %v", err)
+		log.Printf("select candidates: %v", err)
+		return 1
 	}
 	log.Printf("liveness: %d orphan candidates (excluding %d ATS providers)", len(candidates), len(atsProviders))
 
 	// Probe targets are orphan-job URLs that originated from attacker-influenced
 	// sources (telegram posts), so the probe must refuse internal/metadata targets.
 	client := safehttp.NewClient(probeTimeout)
-	var probed, closed, struck int64
+	var probed, closed, struck, failed int64
 
 	sem := make(chan struct{}, concurrency)
 	var wg sync.WaitGroup
@@ -113,7 +120,7 @@ func main() {
 			if ferr != nil {
 				// A probe that could not reach the page is Uncertain (status 0), so the
 				// switch below takes no action — a fetch failure never advances or
-				// clears a strike.
+				// clears a strike, and is not counted as a worker failure.
 				log.Printf("liveness: probe %s failed: %v", c.PublicSlug, ferr)
 			}
 
@@ -124,6 +131,9 @@ func main() {
 					Threshold: closeThreshold,
 				})
 				if err != nil {
+					// The verdict was reached but the DB update did not apply — a real
+					// failure the exit code must surface, not a silent log-and-continue.
+					atomic.AddInt64(&failed, 1)
 					log.Printf("liveness: mark expired %s: %v", c.PublicSlug, err)
 					return
 				}
@@ -139,6 +149,7 @@ func main() {
 				// clear so a healthy catalogue does not issue an UPDATE per open job.
 				if c.LivenessStrikes != 0 {
 					if err := queries.ResetLivenessStrikes(ctx, c.ID); err != nil {
+						atomic.AddInt64(&failed, 1)
 						log.Printf("liveness: reset %s: %v", c.PublicSlug, err)
 					}
 				}
@@ -149,7 +160,8 @@ func main() {
 	}
 	wg.Wait()
 
-	log.Printf("liveness done: probed=%d closed=%d struck=%d", probed, closed, struck)
+	log.Printf("liveness done: probed=%d closed=%d struck=%d failed=%d", probed, closed, struck, failed)
+	return worker.ExitCode(int(failed), 0)
 }
 
 // providerKeys returns the registered ATS provider keys — the sources the ingest

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -7,11 +7,11 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // reindexBatchSize bounds how many jobs are read from Postgres and pushed to
@@ -19,27 +19,35 @@ import (
 const reindexBatchSize = 500
 
 func main() {
-	cfg := config.Load()
-	if cfg.MeiliKey == "" {
-		log.Fatal("config: MEILI_MASTER_KEY is required")
-	}
+	os.Exit(run())
+}
 
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+func run() int {
+	ctx, cfg, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
+
+	// Bootstrap owns config + pool, so this required-config check lands just after
+	// the pool opens rather than before it. The connect is cheap and cleanup closes
+	// it on this early return, so the only cost of a missing key is one DB handshake.
+	if cfg.MeiliKey == "" {
+		log.Print("config: MEILI_MASTER_KEY is required")
+		return 1
+	}
 
 	client := search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
 
 	indexed, deleted, err := reindexAll(ctx, db.New(pool), client)
 	if err != nil {
-		log.Fatalf("reindex: %v", err)
+		log.Printf("reindex: %v", err)
+		return 1
 	}
 
 	log.Printf("reindex done: indexed=%d deleted=%d", indexed, deleted)
+	return 0
 }
 
 // reindexAll ensures the index and streams every job through it in batches,

--- a/cmd/reslug/main.go
+++ b/cmd/reslug/main.go
@@ -9,45 +9,50 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/normalize"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // reslugBatchSize bounds how many jobs are read per keyset page.
 const reslugBatchSize = 500
 
 func main() {
-	cfg := config.Load()
+	os.Exit(run())
+}
 
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 
 	queries := db.New(pool)
 
 	scanned, updated, err := reslugAll(ctx, queries)
 	if err != nil {
-		log.Fatalf("reslug: %v", err)
+		log.Printf("reslug: %v", err)
+		return 1
 	}
 
 	// jobs.company_slug now carries the new slugs; re-key the companies catalogue
 	// to match (and drop the rows orphaned by the change) so company pages resolve.
 	if err := queries.SyncCompaniesFromJobs(ctx); err != nil {
-		log.Fatalf("reslug: sync companies: %v", err)
+		log.Printf("reslug: sync companies: %v", err)
+		return 1
 	}
 	orphans, err := queries.DeleteOrphanCompanies(ctx)
 	if err != nil {
-		log.Fatalf("reslug: delete orphan companies: %v", err)
+		log.Printf("reslug: delete orphan companies: %v", err)
+		return 1
 	}
 
 	log.Printf("reslug done: scanned=%d updated=%d companies_orphaned=%d", scanned, updated, orphans)
+	return 0
 }
 
 // reslugAll recomputes every job's slug and rewrites the ones that differ. It

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"log"
-	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -29,7 +28,13 @@ func main() {
 		log.Fatal("config: JWT_SECRET is required and must be at least 32 bytes")
 	}
 
-	pool, err := database.Connect(context.Background(), cfg.DatabaseURL)
+	// One signal-bound context drives both startup and shutdown: it cancels the pool
+	// connect if a signal arrives mid-startup, and its Done channel is the shutdown
+	// trigger below.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	pool, err := database.Connect(ctx, cfg.DatabaseURL)
 	if err != nil {
 		log.Fatalf("database: %v", err)
 	}
@@ -89,10 +94,9 @@ func main() {
 	}()
 	log.Printf("hire listening on :%s", cfg.Port)
 
-	// Graceful shutdown on SIGINT/SIGTERM.
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
+	// Graceful shutdown on SIGINT/SIGTERM: block until the signal-bound context is
+	// cancelled (the signal arrived) or startup cancelled it.
+	<-ctx.Done()
 	log.Println("shutting down...")
 
 	if err := app.ShutdownWithTimeout(10 * time.Second); err != nil {

--- a/cmd/tg-extract/main.go
+++ b/cmd/tg-extract/main.go
@@ -3,7 +3,8 @@
 // and extract its vacancies, validates the payload, and writes the jobs through
 // the canonical upsert — enqueuing them for enrichment in the same transaction as
 // marking the post extracted. Run it on a schedule (e.g. cron); it processes a
-// bounded batch and exits.
+// bounded batch and exits. It exits non-zero when the run finished with any
+// failures, so cron can alert.
 package main
 
 import (
@@ -12,17 +13,23 @@ import (
 	"os"
 
 	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/linksource"
 	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/telegram"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 func main() {
-	cfg := config.Load()
+	os.Exit(run())
+}
+
+func run() int {
+	// LLM and channel config are loaded first so a misconfigured worker fails before
+	// it opens the pool.
 	ecfg, err := config.LoadEnrich()
 	if err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 
 	// sources/telegram.yml supplies each channel's kind, steering the extraction prompt.
@@ -32,27 +39,29 @@ func main() {
 	}
 	chanCfg, err := telegram.LoadConfig(path)
 	if err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 	if err := chanCfg.Validate(); err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 	kinds := make(map[string]telegram.Kind, len(chanCfg.Channels))
 	for _, e := range chanCfg.Channels {
 		kinds[e.Channel] = e.Kind
 	}
 
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 
 	extractor, err := telegram.NewLangChainExtractor(ecfg.LLMBaseURL, ecfg.LLMAPIKey, ecfg.LLMModel)
 	if err != nil {
-		log.Fatalf("extractor: %v", err)
+		log.Printf("extractor: %v", err)
+		return 1
 	}
 
 	runner := telegram.ExtractRunner{
@@ -64,8 +73,10 @@ func main() {
 
 	stats, err := runner.Run(ctx)
 	if err != nil {
-		log.Fatalf("extract: %v", err)
+		log.Printf("extract: %v", err)
+		return 1
 	}
 	log.Printf("tg-extract done: processed=%d jobs=%d failed=%d",
 		stats.Processed, stats.Jobs, stats.Failed)
+	return worker.ExitCode(stats.Failed, 0)
 }

--- a/cmd/tg-ingest/main.go
+++ b/cmd/tg-ingest/main.go
@@ -2,7 +2,8 @@
 // configured channels from sources/telegram.yml, fetches each channel's latest posts from
 // the public t.me web preview, prefilters obvious non-vacancies, and stores new
 // posts in the telegram_posts queue for the extraction worker (cmd/tg-extract).
-// Run it on a schedule (e.g. cron); it crawls every channel once and exits.
+// Run it on a schedule (e.g. cron); it crawls every channel once and exits. It
+// exits non-zero when the run finished with any failures, so cron can alert.
 package main
 
 import (
@@ -14,37 +15,39 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
-	"github.com/strelov1/freehire/internal/config"
-	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/linksource"
 	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/telegram"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 func main() {
-	cfg := config.Load()
+	os.Exit(run())
+}
 
+func run() int {
 	path := os.Getenv("CHANNELS_FILE")
 	if path == "" {
 		path = "sources/telegram.yml"
 	}
 	chanCfg, err := telegram.LoadConfig(path)
 	if err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 	// Fail fast before touching the DB: a misconfigured channel should not start a run.
 	if err := chanCfg.Validate(); err != nil {
-		log.Fatalf("config: %v", err)
+		log.Printf("config: %v", err)
+		return 1
 	}
 
-	ctx := context.Background()
-
-	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
 	if err != nil {
-		log.Fatalf("database: %v", err)
+		log.Printf("database: %v", err)
+		return 1
 	}
-	defer pool.Close()
+	defer cleanup()
 
 	runner := telegram.CrawlRunner{
 		Fetcher: telegram.NewFetcher(),
@@ -55,10 +58,12 @@ func main() {
 
 	stats, err := runner.Run(ctx, chanCfg.Channels)
 	if err != nil {
-		log.Fatalf("crawl: %v", err)
+		log.Printf("crawl: %v", err)
+		return 1
 	}
 	log.Printf("tg-ingest done: stored=%d filtered=%d failed=%d",
 		stats.Stored, stats.Filtered, stats.Failed)
+	return worker.ExitCode(stats.Failed, 0)
 }
 
 // postStore adapts the generated queries to telegram.PostStore.

--- a/internal/enrich/runner.go
+++ b/internal/enrich/runner.go
@@ -177,6 +177,12 @@ func (rn *run) enrich(ctx context.Context, job JobInput) (Enrichment, error) {
 
 func (rn *run) fail(ctx context.Context, entry Claimed, cause error) {
 	dead, err := rn.store.Fail(ctx, entry.OutboxID, cause.Error(), rn.opt.MaxAttempts)
+	if err != nil {
+		// The attempt still counts as a failure below, but log the cause: a
+		// bookkeeping outage (e.g. the DB going unreachable mid-drain) would
+		// otherwise hide behind an opaque Failed tally with no way to diagnose it.
+		log.Printf("enrich: outbox=%d fail-bookkeeping error: %v", entry.OutboxID, err)
+	}
 	rn.mu.Lock()
 	defer rn.mu.Unlock()
 	// Only a recorded dead-letter is distinct; a non-dead attempt and a Fail that

--- a/internal/worker/bootstrap.go
+++ b/internal/worker/bootstrap.go
@@ -1,0 +1,42 @@
+package worker
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/config"
+	"github.com/strelov1/freehire/internal/database"
+)
+
+// signalContext returns a context that is cancelled when the process receives
+// SIGINT or SIGTERM, plus a stop function that releases the signal notification.
+// A cron timeout or redeploy delivers SIGTERM, so a worker built on this context
+// observes the cancellation and unwinds in-flight work instead of being killed.
+func signalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)
+}
+
+// Bootstrap performs the setup every standalone worker shares: it loads config,
+// derives a signal-cancellable root context, and opens the database pool. The
+// returned cleanup stops the signal notification and closes the pool; call it
+// with defer. On a connection failure it returns the error with no usable pool
+// (and releases the signal notification), so the caller fails fast.
+func Bootstrap(parent context.Context) (context.Context, config.Settings, *pgxpool.Pool, func(), error) {
+	cfg := config.Load()
+	ctx, stop := signalContext(parent)
+
+	pool, err := database.Connect(ctx, cfg.DatabaseURL)
+	if err != nil {
+		stop()
+		return nil, cfg, nil, nil, err
+	}
+
+	cleanup := func() {
+		stop()
+		pool.Close()
+	}
+	return ctx, cfg, pool, cleanup, nil
+}

--- a/internal/worker/bootstrap_test.go
+++ b/internal/worker/bootstrap_test.go
@@ -1,0 +1,49 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestSignalContextCancelsOnSignal(t *testing.T) {
+	ctx, stop := signalContext(context.Background())
+	defer stop()
+
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("find process: %v", err)
+	}
+	if err := proc.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+		// cancelled as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("context not cancelled after SIGTERM")
+	}
+}
+
+func TestBootstrapFailsFastWhenDatabaseUnreachable(t *testing.T) {
+	// Port 1 on loopback refuses immediately, so Connect's ping fails fast
+	// without waiting on a timeout and without needing a live database.
+	t.Setenv("DATABASE_URL", "postgres://hire:hire@127.0.0.1:1/hire?sslmode=disable")
+
+	ctx, _, pool, cleanup, err := Bootstrap(context.Background())
+	if cleanup != nil {
+		cleanup()
+	}
+	if err == nil {
+		t.Fatal("expected an error when the database is unreachable, got nil")
+	}
+	if pool != nil {
+		t.Fatal("expected a nil pool on bootstrap failure")
+	}
+	if ctx != nil {
+		t.Fatal("expected a nil context on bootstrap failure")
+	}
+}

--- a/internal/worker/exit.go
+++ b/internal/worker/exit.go
@@ -1,0 +1,16 @@
+// Package worker holds the shared bootstrap and run-outcome plumbing for the
+// standalone run-once-and-exit cron workers under cmd/. It centralizes config +
+// pool + signal-bound context setup and the convention that maps a run's failure
+// counts to a process exit code, so a degraded run is visible to cron.
+package worker
+
+// ExitCode maps a worker run's failure tallies to a process exit code: 0 when the
+// run completed cleanly, 1 when it finished with any per-item failures or
+// dead-lettered items. A non-zero code lets cron alert on a partially-failed run
+// that would otherwise look successful.
+func ExitCode(failed, deadLettered int) int {
+	if failed > 0 || deadLettered > 0 {
+		return 1
+	}
+	return 0
+}

--- a/internal/worker/exit_test.go
+++ b/internal/worker/exit_test.go
@@ -1,0 +1,24 @@
+package worker
+
+import "testing"
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name         string
+		failed       int
+		deadLettered int
+		want         int
+	}{
+		{"clean run exits zero", 0, 0, 0},
+		{"failures exit non-zero", 1, 0, 1},
+		{"dead-letters exit non-zero", 0, 1, 1},
+		{"both failures and dead-letters exit non-zero", 3, 2, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExitCode(tt.failed, tt.deadLettered); got != tt.want {
+				t.Errorf("ExitCode(%d, %d) = %d, want %d", tt.failed, tt.deadLettered, got, tt.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/reliable-worker-bootstrap/.openspec.yaml
+++ b/openspec/changes/reliable-worker-bootstrap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/reliable-worker-bootstrap/design.md
+++ b/openspec/changes/reliable-worker-bootstrap/design.md
@@ -1,0 +1,141 @@
+## Context
+
+Ten standalone workers under `cmd/` (`ingest`, `enrich`, `liveness`, `tg-ingest`,
+`tg-extract`, `reindex`, `reslug`, `backfill-geo`, `backfill-skills`,
+`backfill-class`) each open with the same block:
+
+```go
+cfg := config.Load()
+ctx := context.Background()
+pool, err := database.Connect(ctx, cfg.DatabaseURL)
+if err != nil { log.Fatalf("database: %v", err) }
+defer pool.Close()
+```
+
+They then call a package `Runner.Run(ctx, ...)` (or a maintenance loop) that
+returns a stats struct (`Enriched/Failed/DeadLettered`, `RunStats`, etc.) plus an
+error that is only non-nil on a hard abort (context cancellation, a fatal sweep
+error). Per-item failures are counted into stats but never reach the exit code,
+so the worker logs the counts and returns `0`. `cmd/server` already does
+signal-based graceful shutdown and is the reference for the pattern, but even it
+connects the pool on `context.Background()`.
+
+The audit also found `internal/enrich/runner.go:188` discards the error from the
+queue's `Fail` call entirely (neither logged nor counted).
+
+## Goals / Non-Goals
+
+**Goals:**
+- One shared bootstrap helper: config + pool + signal-bound context + cleanup.
+- A uniform, testable exit-code contract: non-zero when a run finished with any
+  `Failed`/`DeadLettered` > 0; zero otherwise.
+- Graceful cancellation: the root context cancels on SIGINT/SIGTERM and is
+  propagated into each worker's run/sweep calls.
+- Fix the swallowed `store.Fail` error so bookkeeping failures count.
+
+**Non-Goals:**
+- No change to the run-once-and-exit cadence, cron entries, flags, or env vars.
+- No change to per-item failure isolation (one bad board/post still must not
+  abort the rest).
+- No retry/backoff or alerting logic beyond the exit code itself.
+- Not touching the domain meaning of enrichment/lifecycle (those specs are
+  unchanged); this is purely worker process behavior.
+
+## Decisions
+
+### Decision 1: A small `internal/worker` bootstrap package
+
+Add `internal/worker` with a single entry point, roughly:
+
+```go
+// Bootstrap loads config, opens the pool, and returns a context that is
+// cancelled on SIGINT/SIGTERM. cleanup closes the pool and stops the signal
+// notification; call it with defer.
+func Bootstrap(parent context.Context) (ctx context.Context, cfg config.Config, pool *pgxpool.Pool, cleanup func(), err error)
+```
+
+Internally it uses `signal.NotifyContext(parent, syscall.SIGINT, syscall.SIGTERM)`
+(stdlib, already used conceptually by `cmd/server`) and `database.Connect`.
+`cleanup` runs `stop()` then `pool.Close()`.
+
+**Why over alternatives:** a free function returning a cleanup closure matches the
+existing thin-`main` style and is trivially used with `defer`. A struct/`Run`-
+callback wrapper (passing the whole worker body into the helper) was considered
+but would force every `main` into a callback shape and obscure each worker's
+distinct post-run logic (ingest's per-provider sweep, enrich's provider setup).
+Keeping `main` linear keeps diffs small and per-worker logic visible.
+
+### Decision 2: `run() (stats, error)` + thin `main` for testable exit codes
+
+`os.Exit` is untestable, so the exit-code decision must live in a function a test
+can call. Each worker keeps its logic in a helper that returns its stats (already
+true — `runner.Run` returns stats); `main` becomes:
+
+```go
+func main() {
+    code := run()
+    os.Exit(code)
+}
+```
+
+where `run()` does the bootstrap + work and maps the outcome to a code via one
+shared helper:
+
+```go
+// exitCode returns 1 when a run finished with any failures or dead-letters.
+func exitCode(failed, deadLettered int) int
+```
+
+This `exitCode` (or a `RunOutcome` with a `Failed()` predicate) lives in
+`internal/worker` and is unit-tested directly: clean → 0, any failure → non-zero.
+Workers that already `log.Fatalf` on bootstrap errors keep failing fast (exit !=
+0), so only the *successful-Run-with-failures* path is new.
+
+**Why over alternatives:** returning a richer error from `Runner.Run` when stats
+show failures was considered, but that conflates "the run aborted" with "the run
+completed but some items failed" — callers (and the existing logs) treat those
+differently. Keeping stats as the signal and mapping to a code in one place is
+clearer and leaves `Runner.Run`'s contract intact.
+
+### Decision 3: Fix `runner.go:188` by counting the `Fail` error
+
+The swallowed `Fail` error becomes a counted failure (increment the run's failure
+tally and continue the drain — the per-item isolation rule still holds). This
+makes the bookkeeping failure visible both in the logged stats and, via Decision
+2, in the exit code.
+
+## Risks / Trade-offs
+
+- **[Cron entries that ignored exit codes now surface failures]** → Intended.
+  Operators may suddenly see alerts that were previously masked; documented as a
+  behavior change in the proposal Impact. No silent regression — a degraded run
+  was already degraded.
+- **[A worker that legitimately has nonzero `Failed` every run would always
+  alert]** → Per-item failures are real failures by the audit's definition; if a
+  source is chronically failing that is exactly what should alert. No threshold
+  tuning in this change (out of scope; can follow later).
+- **[Touching ten `main.go` files at once]** → Mitigated by doing the shared
+  helper first with its own tests, then migrating workers one at a time under the
+  per-task TDD loop, each verified by `go build ./...` + `go vet`.
+- **[Signal context cancels mid-write]** → That is the desired behavior; existing
+  DB calls already take a context and pgx propagates cancellation. Maintenance
+  backfills use transactions that roll back on a cancelled context.
+
+## Migration Plan
+
+1. Land `internal/worker` (bootstrap + `exitCode`) with unit tests — no behavior
+   change yet.
+2. Migrate each worker `main.go` to use the helper + `run()/os.Exit` shape, one
+   per task, keeping its post-run logic intact.
+3. Fix `internal/enrich/runner.go` to count the `Fail` error.
+4. No deploy ordering constraints (no schema/API change); ship normally. Rollback
+   is a plain revert — no data migration involved.
+
+## Open Questions
+
+- Should maintenance backfills (`reindex`/`reslug`/`backfill-*`) that have no
+  natural "Failed" counter also adopt the helper purely for the signal context +
+  bootstrap dedup? **Proposed:** yes for bootstrap/signals (they benefit from
+  graceful cancellation on long runs), and they exit non-zero only on a hard
+  error (their existing `log.Fatalf` paths), since they have no per-item failure
+  tally to surface.

--- a/openspec/changes/reliable-worker-bootstrap/proposal.md
+++ b/openspec/changes/reliable-worker-bootstrap/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The standalone cron workers (`cmd/ingest`, `cmd/enrich`, `cmd/liveness`, the
+`tg-*` crawlers, and the `backfill-*`/`reindex`/`reslug` maintenance jobs) report
+success to cron even when a run partially or wholly fails: a DB outage, a
+fully-failed crawl, or an entire enrichment wave that dead-letters all exit `0`.
+A code audit flagged this as the single highest-impact reliability gap — cron
+alerting is effectively blind, so a silently-degrading pipeline looks healthy.
+Two related defects compound it: the same ~80 lines of bootstrap are copy-pasted
+across ten workers, and none of them handle `SIGINT`/`SIGTERM`, so a cron
+timeout or redeploy hard-kills a worker mid-transaction.
+
+## What Changes
+
+- Introduce a single shared worker-bootstrap helper that every standalone worker
+  uses to: load config, open the pgx pool, and obtain a root `context.Context`
+  wired to `signal.NotifyContext(SIGINT, SIGTERM)` for graceful cancellation —
+  replacing the duplicated `config.Load → context.Background → database.Connect →
+  log.Fatalf → defer pool.Close` block in each `main`.
+- Establish a uniform **exit-code contract**: a worker run that finishes with any
+  per-item failures or dead-letters exits non-zero (so cron can alert), while a
+  fully-clean run exits `0`. Run-once-and-exit shape and per-item failure
+  isolation (one bad board/post never aborts the rest) stay intentional.
+- Fix the swallowed `store.Fail` error in the enrichment runner
+  (`internal/enrich/runner.go:188`) so a bookkeeping failure during the drain is
+  surfaced (counted and propagated), not discarded.
+- Propagate the signal-aware context through each worker's existing `Run`/sweep
+  calls so in-flight DB work unwinds on shutdown instead of being killed.
+
+## Capabilities
+
+### New Capabilities
+- `worker-lifecycle`: how standalone run-once-and-exit cron workers bootstrap
+  (shared config/pool/context setup), handle termination signals (graceful
+  cancellation via a signal-bound context), and report run outcome through the
+  process exit code (non-zero on any failure or dead-letter).
+
+### Modified Capabilities
+<!-- None. The enrichment/lifecycle domain rules are unchanged; this change only
+     governs worker process behavior (bootstrap, signals, exit codes). -->
+
+## Impact
+
+- **Code**: new `internal/worker` (or equivalent) bootstrap package; edits to all
+  ten worker `main.go` files plus `cmd/server` (adopts the shared bootstrap where
+  it overlaps); one error-propagation fix in `internal/enrich/runner.go`.
+- **Operations**: cron jobs now receive non-zero exit codes on degraded runs —
+  monitoring/alerting can finally trigger. No change to scheduling, flags, or the
+  run-once cadence; existing cron entries keep working.
+- **No API, DB schema, or wire-shape changes.** No new dependencies (uses stdlib
+  `os/signal`, already used by `cmd/server`).

--- a/openspec/changes/reliable-worker-bootstrap/specs/worker-lifecycle/spec.md
+++ b/openspec/changes/reliable-worker-bootstrap/specs/worker-lifecycle/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Shared worker bootstrap
+
+Every standalone run-once-and-exit worker SHALL obtain its runtime dependencies
+(loaded config, an open database pool, and a root context) from one shared
+bootstrap helper rather than re-implementing the setup inline. The helper SHALL
+open the pgx pool and return a cleanup function that closes it.
+
+#### Scenario: Bootstrap provides pool and cleanup
+
+- **WHEN** a worker calls the shared bootstrap helper with a valid database URL
+- **THEN** it receives a usable database pool, a root context, and a cleanup
+  function that closes the pool when invoked
+
+#### Scenario: Bootstrap fails fast on an unreachable database
+
+- **WHEN** the bootstrap helper cannot connect to the database
+- **THEN** it returns an error (no usable pool), and the worker terminates with a
+  non-zero exit code rather than proceeding
+
+### Requirement: Graceful cancellation on termination signals
+
+The root context returned by the shared bootstrap SHALL be cancelled when the
+process receives `SIGINT` or `SIGTERM`, so in-flight work observes cancellation
+and unwinds instead of being hard-killed. Workers SHALL propagate this context
+into their run/sweep calls.
+
+#### Scenario: SIGTERM cancels the worker context
+
+- **WHEN** the process receives `SIGTERM` during a run
+- **THEN** the bootstrap context is cancelled and the in-flight database/run
+  operations observe the cancellation through the propagated context
+
+#### Scenario: Signal handler is released after the run
+
+- **WHEN** the worker finishes and invokes its cleanup function
+- **THEN** the signal notification is stopped (the process no longer intercepts
+  `SIGINT`/`SIGTERM` for the cancelled context)
+
+### Requirement: Run outcome reported through exit code
+
+A worker process SHALL exit with a non-zero code when its run completes with one
+or more per-item failures or dead-lettered items, and SHALL exit `0` when the run
+completes with zero failures. Per-item failure isolation is
+preserved — a single failing item MUST NOT abort the remaining items — but the
+aggregate failure MUST be reflected in the exit code so cron can alert.
+
+#### Scenario: Clean run exits zero
+
+- **WHEN** a worker run completes with no failures and no dead-letters
+- **THEN** the process exits with code `0`
+
+#### Scenario: Run with failures exits non-zero
+
+- **WHEN** a worker run completes but its run stats report at least one failure
+  or dead-lettered item
+- **THEN** the process exits with a non-zero code
+
+#### Scenario: One bad item does not abort the run
+
+- **WHEN** a single item in a run fails (e.g. one unreachable board or one
+  unparseable post)
+- **THEN** the remaining items are still processed, and the run still exits
+  non-zero afterward to signal the partial failure
+
+### Requirement: Bookkeeping failures are logged and counted
+
+The enrichment drain MUST count a failure of the queue bookkeeping call that
+records a job as failed toward the run's failure total (so the run reports a
+non-zero outcome), and SHALL log the error cause — so an operator can diagnose
+why the bookkeeping write failed instead of seeing only an opaque failure tally.
+
+#### Scenario: A failed bookkeeping write is counted and logged
+
+- **WHEN** the runner's call to mark a job as failed itself returns an error
+- **THEN** the failure is counted toward the run's failure total (the run's
+  outcome is non-zero) and the error cause is written to the log

--- a/openspec/changes/reliable-worker-bootstrap/tasks.md
+++ b/openspec/changes/reliable-worker-bootstrap/tasks.md
@@ -1,0 +1,31 @@
+## 1. Shared worker package (foundation, fully unit-tested)
+
+- [x] 1.1 Add `internal/worker` with `exitCode(failed, deadLettered int) int` (or a `RunOutcome` predicate): RED a test asserting clean→0 and any failure/dead-letter→non-zero, then implement.
+- [x] 1.2 Add `worker.Bootstrap(parent) (ctx, cfg, pool, cleanup, err)` using `signal.NotifyContext(SIGINT,SIGTERM)` + `database.Connect`; `cleanup` stops the signal notify and closes the pool. Test: context cancels when the bound signal fires, and `cleanup` releases the notification (no `os.Exit` in the tested path).
+
+## 2. Surface swallowed bookkeeping failures
+
+- [x] 2.1 `internal/enrich/runner.go` `fail()`: the `store.Fail` error is already counted as a failure (it falls through to `stats.Failed++`), so the real gap is observability — its cause is never logged. Add a `log.Printf` for the `store.Fail` error cause so a bookkeeping outage is diagnosable. No TDD test for the log line (consistent with the runner's other `log.Printf` observability calls); verify via `go build`/`go vet` and the existing runner tests staying green.
+
+## 3. Migrate failure-counting workers (exit non-zero on Failed/DeadLettered)
+
+- [x] 3.1 `cmd/enrich`: adopt `worker.Bootstrap`, move logic into `run() int`, map `stats.Failed`/`stats.DeadLettered` through `exitCode`, `main` calls `os.Exit(run())`. Preserve provider setup and existing logs.
+- [x] 3.2 `cmd/ingest`: same shape; map `runStats.Total().Failed` (and any sweep error) through `exitCode`; keep the per-provider stale-sweep intact and pass the signal context into `Run`/`CloseUnseenJobs`.
+- [x] 3.3 `cmd/tg-extract`: adopt bootstrap + `run()/os.Exit`; surface `stats.Failed` via `exitCode`.
+- [x] 3.4 `cmd/tg-ingest`: adopt bootstrap + `run()/os.Exit`; surface `stats.Failed` via `exitCode`; keep the channels.yml load/validate fail-fast.
+- [x] 3.5 `cmd/liveness`: adopt bootstrap + `run()/os.Exit`; surface per-probe DB failures as a non-zero outcome (count them) instead of logging-and-continuing-to-exit-0.
+
+## 4. Migrate maintenance workers (bootstrap + signals; exit non-zero only on hard error)
+
+> Note: origin/main (PR#106) consolidated the three `backfill-{geo,skills,class}`
+> binaries into a single `cmd/backfill-derive`, so the maintenance set is
+> reindex / reslug / backfill-derive.
+
+- [x] 4.1 `cmd/reindex`: adopt `worker.Bootstrap`; keep its existing fatal-on-error paths as non-zero exits; propagate the signal context.
+- [x] 4.2 `cmd/reslug`: same.
+- [x] 4.3 `cmd/backfill-derive`: same; ensure the keyset-pagination loop honours context cancellation (keep its existing `main_test.go` green).
+
+## 5. Align server + verify
+
+- [x] 5.1 `cmd/server`: server is a long-lived process (not a run-once worker), so it does NOT use `worker.Bootstrap` (which would add a second, conflicting signal handler). Instead unify its signal handling on one `signal.NotifyContext`: the same signal-bound context cancels the pool connect AND triggers shutdown (replacing the separate quit-channel), behavior-identical (wait for signal → `ShutdownWithTimeout`).
+- [x] 5.2 Full verification: `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -tags=integration -run XXNONE ./internal/...` to recompile integration-tagged tests; confirm green.


### PR DESCRIPTION
## Summary

Cron workers reported success to cron even when a run partially or wholly failed (a DB outage, a fully-failed crawl, or an enrichment wave that dead-lettered everything all exited `0`), so monitoring was blind to a degrading pipeline. This change — the first of several from a codebase audit — surfaces failure through the exit code, deduplicates worker bootstrap, and adds graceful signal handling.

- **`internal/worker`** (new): `Bootstrap(parent)` returns a context cancelled on `SIGINT`/`SIGTERM`, an open pool, and a `cleanup` (stop signal-notify + close pool); `ExitCode(failed, deadLettered)` maps a run's tallies to a process exit code. Both unit-tested.
- **Run-once workers** (`enrich`, `ingest`, `tg-ingest`, `tg-extract`, `liveness`, `reindex`, `reslug`, `backfill-derive`) moved to `os.Exit(run())`, replacing the duplicated `config.Load → context.Background → database.Connect → log.Fatalf → defer pool.Close` block. `log.Fatalf` → `log.Printf` + `return` so deferred cleanup actually runs.
- **Exit-code contract**: failure-counting workers exit non-zero when a run finished with any per-item failures/dead-letters. `ingest` also counts per-provider sweep failures (counted-and-continued, not aborting); `liveness` counts per-probe DB-update failures (a fetch failure stays `Uncertain` by design). Per-item failure isolation preserved.
- **enrich runner**: log the `store.Fail` error cause (it was already counted as a failure) so a bookkeeping outage is diagnosable rather than opaque.
- **server**: unified onto one `signal.NotifyContext` driving both the pool connect and shutdown (behavior-identical to the previous quit-channel); not migrated to `Bootstrap` (it is long-lived, not run-once).

Spec: `openspec/changes/reliable-worker-bootstrap` (new `worker-lifecycle` capability). Archive after merge.

## Test Plan

- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `gofmt -l cmd/ internal/` — no files flagged
- [x] `go test ./...` — 0 failures (new `internal/worker` unit tests: ExitCode clean→0 / failure→non-zero; signal-context cancellation; Bootstrap fail-fast)
- [x] `go test -tags=integration -run XXNONE ./...` — integration-tagged tests recompile clean
- [ ] Smoke a worker in staging and confirm a degraded run now exits non-zero (cron-alertable)