### PR TITLE
feat(skilltag): add missing tech/methodology skill aliases

### DIFF
--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -254,6 +254,21 @@ var wordAliases = map[string]string{
 	"jira":       "jira",
 	"confluence": "confluence",
 	"elk":        "elk",
+
+	// methodologies / practices / architecture
+	"agile":         "agile",
+	"scrum":         "scrum",
+	"kanban":        "kanban",
+	"devops":        "devops",
+	"microservices": "microservices",
+	"microservice":  "microservices",
+	"observability": "observability",
+	"restful":       "rest",
+
+	// platforms (Salesforce/SAP/Oracle read unambiguously in IT job text)
+	"salesforce": "salesforce",
+	"sap":        "sap",
+	"oracle":     "oracle",
 }
 
 // phraseAlias is a punctuated or multi-word term matched against the normalized
@@ -281,6 +296,7 @@ var phraseAliases = []phraseAlias{
 	{"c developer", "c"}, {"c programming", "c"}, {"ansi c", "c"},
 	{"machine learning", "machine-learning"},
 	// additional phrases
+	{"rest api", "rest"}, {"rest apis", "rest"},
 	{"github actions", "github-actions"},
 	{"cloudformation", "cloudformation"},
 	{"scikit-learn", "scikit-learn"},

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -50,3 +50,46 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+// New tech/methodology vocabulary (skills-vocab-gaps): each resolves from a
+// realistic description; bare "rest" never tags (only "REST API"/"RESTful").
+func TestParse_NewTechVocab(t *testing.T) {
+	contains := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+	cases := []struct {
+		name   string
+		in     string
+		want   []string // all must be present
+		absent []string // none may be present
+	}{
+		{"methodologies", "We work in an Agile environment using Scrum and Kanban.", []string{"agile", "scrum", "kanban"}, nil},
+		{"platforms", "Experience with Salesforce, SAP and Oracle is required.", []string{"salesforce", "sap", "oracle"}, nil},
+		{"practices", "You will own our DevOps and observability across microservices.", []string{"devops", "observability", "microservices"}, nil},
+		{"microservice singular", "Designing a microservice architecture.", []string{"microservices"}, nil},
+		{"rest via restful", "Build RESTful APIs in Go.", []string{"rest"}, nil},
+		{"rest via rest api", "You will design a REST API.", []string{"rest"}, nil},
+		{"power bi", "Dashboards in Power BI.", []string{"powerbi"}, nil},
+		{"rest trap", "You will support the rest of the team and ship features.", nil, []string{"rest"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Parse(c.in)
+			for _, w := range c.want {
+				if !contains(got, w) {
+					t.Errorf("Parse(%q) = %v, missing %q", c.in, got, w)
+				}
+			}
+			for _, a := range c.absent {
+				if contains(got, a) {
+					t.Errorf("Parse(%q) = %v, must NOT contain %q", c.in, got, a)
+				}
+			}
+		})
+	}
+}

--- a/openspec/changes/skills-vocab-gaps/.openspec.yaml
+++ b/openspec/changes/skills-vocab-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-15

--- a/openspec/changes/skills-vocab-gaps/proposal.md
+++ b/openspec/changes/skills-vocab-gaps/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Under the dict-only doctrine, the `skills` facet is served from the `skilltag`
+dictionary only. Mining prod (open jobs' `enrichment.skills`) shows the dictionary
+is already comprehensive on languages/frameworks/datastores/infra, but misses a
+small set of high-frequency **methodologies and platforms** — `agile` (3568),
+`salesforce` (3548), `sap` (2447), `microservices` (1842), `devops` (1446),
+`observability` (1352), `scrum` (1228), `rest` (1213), `oracle` (1131). These are
+genuine tech-skill gaps (the soft-skill and domain terms the LLM also emits —
+communication, retail, nursing — are deliberately OUT of scope: `skilltag` is a
+technology dictionary, and adding them would dilute the facet with low-signal noise).
+
+## What Changes
+
+- Add to `internal/skilltag` the missing tech/methodology aliases, keeping the
+  dictionary's technology focus: `agile`, `scrum`, `kanban`, `salesforce`, `sap`,
+  `oracle`, `devops`, `microservices` (+ `microservice`), `observability` (word
+  pass); `rest api`/`rest apis`/`restful` → `rest`, and `power bi`/`power-bi` →
+  `powerbi` (phrase pass). **Bare `rest` is deliberately excluded** (it matches "the
+  rest of the team").
+- No engine change, no schema, no new command: `cmd/backfill-derive` re-derives
+  through `skilltag`, so a post-deploy backfill recovers existing jobs.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+(none — this is a pure vocabulary expansion; the "skills are derived from a curated
+dictionary" requirement is unchanged, only its data grows.)
+
+## Impact
+
+- Code: `internal/skilltag/dictionaries.go` (new aliases) + `internal/skilltag/*_test.go`.
+- Deploy: shared deferred dict-only tail (`cmd/backfill-derive` + one `reindex`).
+- Out of scope: soft skills, domain terms, category-from-description, work_mode/seniority (already done).

--- a/openspec/changes/skills-vocab-gaps/specs/deterministic-facets/spec.md
+++ b/openspec/changes/skills-vocab-gaps/specs/deterministic-facets/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: The skills dictionary covers technologies, not soft skills or domains
+
+The `skills` facet SHALL be derived from a curated **technology** dictionary —
+languages, frameworks, datastores, infrastructure, platforms, and engineering
+methodologies — and SHALL NOT include soft skills (e.g. communication, leadership)
+or industry/domain terms (e.g. retail, nursing), keeping the facet a high-signal
+technology filter. The dictionary resolves only known aliases and emits nothing for
+what it cannot match (it never guesses).
+
+#### Scenario: A common methodology resolves
+
+- **WHEN** a job description states "we work in an agile environment using scrum"
+- **THEN** the derived `skills` include `agile` and `scrum`
+
+#### Scenario: A platform resolves
+
+- **WHEN** a job description mentions "Salesforce and SAP integration experience"
+- **THEN** the derived `skills` include `salesforce` and `sap`
+
+#### Scenario: An incidental word does not tag
+
+- **WHEN** a job description says "you will support the rest of the team" but states
+  no REST API
+- **THEN** the derived `skills` do not include `rest`

--- a/openspec/changes/skills-vocab-gaps/tasks.md
+++ b/openspec/changes/skills-vocab-gaps/tasks.md
@@ -1,0 +1,9 @@
+## 1. Add the missing tech aliases (TDD)
+
+- [ ] 1.1 Add failing tests in `internal/skilltag` (Parse over a realistic description): each new skill resolves — `agile`, `scrum`, `kanban`, `salesforce`, `sap`, `oracle`, `devops`, `microservices`, `observability`, `rest` (via "RESTful APIs" / "REST API"), `powerbi` (via "Power BI"); and a trap: a description with "the rest of the team" (and none of the real phrases) does NOT tag `rest`.
+- [ ] 1.2 Add the word aliases (`agile`, `scrum`, `kanban`, `salesforce`, `sap`, `oracle`, `devops`, `microservices`, `microservice`, `observability`, `restful`) to `wordAliases` and the phrase aliases (`rest api`/`rest apis` → `rest`, `power bi`/`power-bi` → `powerbi`) to `phraseAliases` in `dictionaries.go`. No engine change.
+- [ ] 1.3 Run `go test ./internal/skilltag/` green (incl. the existing canonical-slug invariant test).
+
+## 2. Verify
+
+- [ ] 2.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean; confirm no other package regressed.

--- a/openspec/changes/skills-vocab-gaps/tasks.md
+++ b/openspec/changes/skills-vocab-gaps/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Add the missing tech aliases (TDD)
 
-- [ ] 1.1 Add failing tests in `internal/skilltag` (Parse over a realistic description): each new skill resolves — `agile`, `scrum`, `kanban`, `salesforce`, `sap`, `oracle`, `devops`, `microservices`, `observability`, `rest` (via "RESTful APIs" / "REST API"), `powerbi` (via "Power BI"); and a trap: a description with "the rest of the team" (and none of the real phrases) does NOT tag `rest`.
-- [ ] 1.2 Add the word aliases (`agile`, `scrum`, `kanban`, `salesforce`, `sap`, `oracle`, `devops`, `microservices`, `microservice`, `observability`, `restful`) to `wordAliases` and the phrase aliases (`rest api`/`rest apis` → `rest`, `power bi`/`power-bi` → `powerbi`) to `phraseAliases` in `dictionaries.go`. No engine change.
-- [ ] 1.3 Run `go test ./internal/skilltag/` green (incl. the existing canonical-slug invariant test).
+- [x] 1.1 Add failing tests in `internal/skilltag` (Parse over a realistic description): each new skill resolves — `agile`, `scrum`, `kanban`, `salesforce`, `sap`, `oracle`, `devops`, `microservices`, `observability`, `rest` (via "RESTful APIs" / "REST API"), `powerbi` (via "Power BI"); and a trap: a description with "the rest of the team" (and none of the real phrases) does NOT tag `rest`.
+- [x] 1.2 Add the word aliases (`agile`, `scrum`, `kanban`, `salesforce`, `sap`, `oracle`, `devops`, `microservices`, `microservice`, `observability`, `restful`) to `wordAliases` and the phrase aliases (`rest api`/`rest apis` → `rest`, `power bi`/`power-bi` → `powerbi`) to `phraseAliases` in `dictionaries.go`. No engine change.
+- [x] 1.3 Run `go test ./internal/skilltag/` green (incl. the existing canonical-slug invariant test).
 
 ## 2. Verify
 
-- [ ] 2.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean; confirm no other package regressed.
+- [x] 2.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean; confirm no other package regressed.


### PR DESCRIPTION
## Why

Follow-up enrichment in the deferred dict-only sequence (#106 → #107 → #109 → this). Mining prod (open jobs' `enrichment.skills`) showed `skilltag` is already comprehensive on languages/frameworks/datastores/infra, but misses a few **high-frequency methodologies and platforms**: agile (3568), salesforce (3548), sap (2447), microservices (1842), devops (1446), observability (1352), scrum (1228), rest (1213), oracle (1131).

The soft-skill (communication 13k, leadership) and domain (retail, nursing) terms the LLM also emits are **deliberately excluded** — `skilltag` is a technology dictionary and adding them would dilute the facet into a low-signal keyword soup.

## What changes

- **word pass:** `agile`, `scrum`, `kanban`, `devops`, `microservices` (+ `microservice`), `observability`, `salesforce`, `sap`, `oracle`, `restful`→`rest`.
- **phrase pass:** `rest api`/`rest apis`→`rest`. (`power bi`→`powerbi` already existed.)
- **Bare `rest` deliberately excluded** — it matches "the rest of the team".
- No engine change, no schema. `cmd/backfill-derive` recovers existing jobs.

## Tests (TDD)

Per-skill resolution from realistic descriptions + a `rest of the team` trap (must not tag `rest`). Existing canonical-slug invariant test still passes. Full suite + vet + gofmt clean.

## Sequencing

Closes the deterministic skills coverage on the genuine tech gaps. Remaining: `category` from description (deferred — too noisy). Shared deploy tail: app image → `cmd/backfill-derive` → one `reindex`.

OpenSpec: `openspec/changes/skills-vocab-gaps/` (deterministic-facets scope scenario).