### PR TITLE
feat(workers): heartbeat progress logs for ingest + reindex

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"log"
 	"os"
+	"sync/atomic"
+	"time"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
@@ -17,6 +19,12 @@ import (
 // reindexBatchSize bounds how many jobs are read from Postgres and pushed to
 // Meilisearch per round. A const for now; promote to config if it needs tuning.
 const reindexBatchSize = 500
+
+// progressInterval is how often reindex emits a heartbeat with its running totals.
+// A full reindex pushes hundreds of thousands of docs to Meilisearch and otherwise
+// logs only on completion, so the heartbeat distinguishes a slow run from a stalled
+// one (the totals stop advancing).
+const progressInterval = 60 * time.Second
 
 func main() {
 	os.Exit(run())
@@ -54,10 +62,19 @@ func run() int {
 // returning how many documents were indexed (open jobs) and deleted (closed
 // jobs). It pages by keyset (id > last seen), so rows inserted or re-ordered
 // during the run cannot be skipped or repeated.
-func reindexAll(ctx context.Context, q *db.Queries, client *search.Client) (indexed, deleted int, err error) {
+func reindexAll(ctx context.Context, q *db.Queries, client *search.Client) (int, int, error) {
 	if err := client.EnsureIndex(ctx); err != nil {
 		return 0, 0, err
 	}
+
+	// Atomic so the heartbeat goroutine can read the running totals while the loop
+	// advances them. Without the heartbeat a long reindex is silent until "done",
+	// indistinguishable from a stalled push to Meilisearch.
+	var indexed, deleted atomic.Int64
+	stopHeartbeat := worker.Heartbeat(progressInterval, func() {
+		log.Printf("reindex: progress indexed=%d deleted=%d", indexed.Load(), deleted.Load())
+	})
+	defer stopHeartbeat()
 
 	var afterID int64
 	for {
@@ -66,7 +83,7 @@ func reindexAll(ctx context.Context, q *db.Queries, client *search.Client) (inde
 			BatchSize: reindexBatchSize,
 		})
 		if err != nil {
-			return indexed, deleted, err
+			return int(indexed.Load()), int(deleted.Load()), err
 		}
 		if len(jobs) == 0 {
 			break
@@ -75,23 +92,23 @@ func reindexAll(ctx context.Context, q *db.Queries, client *search.Client) (inde
 
 		docs, deleteIDs, err := splitJobs(jobs)
 		if err != nil {
-			return indexed, deleted, err
+			return int(indexed.Load()), int(deleted.Load()), err
 		}
 		if err := client.IndexJobs(ctx, docs); err != nil {
-			return indexed, deleted, err
+			return int(indexed.Load()), int(deleted.Load()), err
 		}
 		if err := client.DeleteJobs(ctx, deleteIDs); err != nil {
-			return indexed, deleted, err
+			return int(indexed.Load()), int(deleted.Load()), err
 		}
-		indexed += len(docs)
-		deleted += len(deleteIDs)
+		indexed.Add(int64(len(docs)))
+		deleted.Add(int64(len(deleteIDs)))
 
 		if len(jobs) < reindexBatchSize {
 			break
 		}
 	}
 
-	return indexed, deleted, nil
+	return int(indexed.Load()), int(deleted.Load()), nil
 }
 
 // splitJobs partitions a batch from the (deliberately unfiltered) reindex feed:

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -8,14 +8,21 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/strelov1/freehire/internal/jobderive"
 	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // defaultConcurrency bounds how many boards are fetched at once.
 const defaultConcurrency = 8
+
+// progressInterval is how often the run emits a heartbeat with the count of boards
+// crawled so far, so a stalled board (one whose fetch hangs) is visible — the count
+// stops advancing — instead of the run going silent until it finishes.
+const progressInterval = 60 * time.Second
 
 // Job is a normalized posting ready to persist: the pipeline has set the platform as
 // source, namespaced the external id by board, derived the company slug, and minted
@@ -98,6 +105,15 @@ func (r Runner) Run(ctx context.Context, entries []sources.CompanyEntry) (RunSta
 		byProv = RunStats{}
 		wg     sync.WaitGroup
 	)
+
+	// Heartbeat the crawl progress: boards run concurrently and a successful board
+	// logs nothing, so without this a run that stalls on one hung board is silent.
+	var crawled atomic.Int64
+	total := len(entries)
+	stopHeartbeat := worker.Heartbeat(progressInterval, func() {
+		log.Printf("ingest: progress %d/%d boards crawled", crawled.Load(), total)
+	})
+	defer stopHeartbeat()
 	sem := make(chan struct{}, defaultConcurrency)
 
 	for _, e := range entries {
@@ -118,6 +134,7 @@ func (r Runner) Run(ctx context.Context, entries []sources.CompanyEntry) (RunSta
 			}
 
 			ingested, failed, skipped := r.ingestBoard(ctx, e)
+			crawled.Add(1)
 
 			mu.Lock()
 			s := byProv[e.Provider]

--- a/internal/worker/heartbeat.go
+++ b/internal/worker/heartbeat.go
@@ -1,0 +1,28 @@
+package worker
+
+import "time"
+
+// Heartbeat calls report every interval until the returned stop is invoked, on a
+// background goroutine. Long workers that otherwise log only on completion use it
+// to emit a periodic progress line, so a stalled run is visible (the line stops
+// advancing) instead of going silent for hours. report runs concurrently with the
+// work, so any counters it reads must be safe for concurrent access (e.g.
+// atomic). stop halts the ticker and the goroutine; call it with defer.
+func Heartbeat(interval time.Duration, report func()) (stop func()) {
+	ticker := time.NewTicker(interval)
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				report()
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() {
+		ticker.Stop()
+		close(done)
+	}
+}

--- a/internal/worker/heartbeat_test.go
+++ b/internal/worker/heartbeat_test.go
@@ -1,0 +1,26 @@
+package worker
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHeartbeatFiresUntilStopped(t *testing.T) {
+	var calls atomic.Int64
+	stop := Heartbeat(15*time.Millisecond, func() { calls.Add(1) })
+
+	time.Sleep(80 * time.Millisecond)
+	stop()
+
+	fired := calls.Load()
+	if fired < 2 {
+		t.Fatalf("expected the heartbeat to fire at least twice in ~80ms, got %d", fired)
+	}
+
+	// After stop, the ticker goroutine must be gone — no further calls.
+	time.Sleep(50 * time.Millisecond)
+	if after := calls.Load(); after != fired {
+		t.Fatalf("heartbeat kept firing after stop: %d -> %d", fired, after)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #110. When debugging hung prod workers we found `ingest` and `reindex` log only on completion (or per-board failure), so a run stalled on one hung board / a slow Meili push is **silent** — indistinguishable from a healthy long run without sampling CPU by hand.

- New `worker.Heartbeat(interval, report)`: background ticker emitting a progress line every interval until `stop()`. Unit-tested (fires repeatedly, stops cleanly, race-clean).
- `internal/pipeline`: `ingest: progress N/M boards crawled` — atomic counter incremented per finished board; a stall freezes the count (and shows where).
- `cmd/reindex`: `reindex: progress indexed=N deleted=M` — running totals made atomic so the heartbeat reads them while the loop advances.

A **time-based** heartbeat (not per-N-items) is deliberate: it catches an *early* hang that a count threshold would never reach. Interval 60s.

## Test Plan
- [x] `go build ./...`, `go vet ./...` — exit 0
- [x] `gofmt -l` — clean
- [x] `go test -race ./internal/worker/ ./internal/pipeline/` — pass (no data race on the shared counters)
- [x] `go test ./...` — 0 failures