### PR TITLE
feat(enrich): relax the LLM on the six dict-covered facets for discovery

### DIFF
--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -101,26 +101,26 @@ var (
 	CompanySizeValues = []string{"1-10", "11-50", "51-200", "201-500", "501-1000", "1000+"}
 )
 
-// Validate checks every enum field against its controlled vocabulary and
+// Validate checks every SERVED enum field against its controlled vocabulary and
 // returns an error identifying the first offending field. Empty (absent) fields
-// pass — every field is optional. Non-enum fields (ISO codes, free text,
-// numbers, skills) are unconstrained here. Multi-value enum fields are checked
-// element by element.
+// pass — every field is optional. Non-enum fields (ISO codes, free text, numbers,
+// skills) are unconstrained here. The six dictionary-covered facets (work_mode,
+// seniority, category, regions, plus the non-enum countries/skills) are
+// deliberately NOT validated: they are served from the deterministic dictionaries
+// (dict-only), so the LLM's values for them are unserved discovery material and an
+// out-of-vocabulary value is captured raw rather than rejected.
 func (e Enrichment) Validate() error {
-	// Single-value enum fields, in declaration order.
+	// Single-value SERVED enum fields, in declaration order.
 	scalars := []struct {
 		field string
 		value string
 		vocab []string
 	}{
-		{"work_mode", e.WorkMode, WorkModeValues},
 		{"employment_type", e.EmploymentType, EmploymentTypeValues},
 		{"relocation", e.Relocation, RelocationValues},
 		{"salary_period", e.SalaryPeriod, SalaryPeriodValues},
-		{"seniority", e.Seniority, SeniorityValues},
 		{"english_level", e.EnglishLevel, EnglishLevelValues},
 		{"education_level", e.EducationLevel, EducationLevelValues},
-		{"category", e.Category, CategoryValues},
 		{"company_type", e.CompanyType, CompanyTypeValues},
 		{"company_size", e.CompanySize, CompanySizeValues},
 	}
@@ -130,13 +130,12 @@ func (e Enrichment) Validate() error {
 		}
 	}
 
-	// Multi-value enum fields, in declaration order.
+	// Multi-value SERVED enum fields (regions is a discovery facet, not validated).
 	multi := []struct {
 		field  string
 		values []string
 		vocab  []string
 	}{
-		{"regions", e.Regions, RegionValues},
 		{"domains", e.Domains, DomainValues},
 	}
 	for _, m := range multi {
@@ -150,26 +149,24 @@ func (e Enrichment) Validate() error {
 	return nil
 }
 
-// Sanitize drops enum values the model emitted outside their controlled
-// vocabulary: a scalar field is blanked, a multi-value field keeps only known
-// members. This salvages the rest of an otherwise-good payload instead of
-// dead-lettering the whole job over one stray value (the model occasionally
-// invents a category/region no matter how the vocabulary grows). The invariant
-// "never persist an out-of-vocabulary value" still holds — the value is dropped,
-// not stored — so Validate passes afterwards.
+// Sanitize drops out-of-vocabulary values from the SERVED enum fields (a scalar is
+// blanked, a multi-value field keeps only known members) so no stray value reaches
+// the served wire shape. The six dictionary-covered facets (work_mode, seniority,
+// category, regions) are deliberately left untouched: they are unserved discovery
+// material under dict-only, so the LLM's raw values — including novel,
+// out-of-vocabulary labels — are kept for later mining. The invariant "never serve
+// an out-of-vocabulary value" still holds for the served fields, and Validate passes
+// afterwards.
 func (e *Enrichment) Sanitize() {
 	scalars := []struct {
 		value *string
 		vocab []string
 	}{
-		{&e.WorkMode, WorkModeValues},
 		{&e.EmploymentType, EmploymentTypeValues},
 		{&e.Relocation, RelocationValues},
 		{&e.SalaryPeriod, SalaryPeriodValues},
-		{&e.Seniority, SeniorityValues},
 		{&e.EnglishLevel, EnglishLevelValues},
 		{&e.EducationLevel, EducationLevelValues},
-		{&e.Category, CategoryValues},
 		{&e.CompanyType, CompanyTypeValues},
 		{&e.CompanySize, CompanySizeValues},
 	}
@@ -179,7 +176,7 @@ func (e *Enrichment) Sanitize() {
 		}
 	}
 
-	e.Regions = keepKnown(e.Regions, RegionValues)
+	// regions is a discovery facet — left raw (not filtered).
 	e.Domains = keepKnown(e.Domains, DomainValues)
 
 	// Drop implausible salary values: a non-positive salary is meaningless, and an

--- a/internal/enrich/enrichment_test.go
+++ b/internal/enrich/enrichment_test.go
@@ -115,27 +115,45 @@ func TestValidateAccepts(t *testing.T) {
 }
 
 func TestValidateRejectsScalarEnum(t *testing.T) {
-	err := Enrichment{Seniority: "sr"}.Validate()
+	// A SERVED enum field is still validated (employment_type reaches the wire shape).
+	err := Enrichment{EmploymentType: "seasonal"}.Validate()
 	if err == nil {
-		t.Fatal("expected error for seniority \"sr\"")
+		t.Fatal("expected error for employment_type \"seasonal\"")
 	}
-	if !strings.Contains(err.Error(), "seniority") {
+	if !strings.Contains(err.Error(), "employment_type") {
 		t.Errorf("error must identify the offending field, got: %v", err)
 	}
 }
 
-// When several enum fields are invalid, Validate reports the first one in
-// declaration order (work_mode is checked before seniority).
+// When several SERVED enum fields are invalid, Validate reports the first one in
+// declaration order (employment_type is checked before english_level).
 func TestValidateReportsFirstOffender(t *testing.T) {
-	err := Enrichment{WorkMode: "telepathic", Seniority: "sr"}.Validate()
+	err := Enrichment{EmploymentType: "telepathic", EnglishLevel: "sr"}.Validate()
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "work_mode") {
-		t.Errorf("want first offender work_mode, got: %v", err)
+	if !strings.Contains(err.Error(), "employment_type") {
+		t.Errorf("want first offender employment_type, got: %v", err)
 	}
-	if strings.Contains(err.Error(), "seniority") {
+	if strings.Contains(err.Error(), "english_level") {
 		t.Errorf("should report only the first offender, got: %v", err)
+	}
+}
+
+// Relax: the six dict-covered discovery facets are captured raw — an out-of-vocab
+// work_mode/seniority/category and a non-vocab regions element pass Validate (they
+// are unserved, so they cannot corrupt production data).
+func TestValidateAcceptsOutOfVocabDiscoveryFacets(t *testing.T) {
+	discovery := []Enrichment{
+		{Seniority: "staff_plus"},
+		{Category: "ml_platform"},
+		{WorkMode: "remote_first"},
+		{Regions: []string{"eu", "europe"}},
+	}
+	for i, e := range discovery {
+		if err := e.Validate(); err != nil {
+			t.Errorf("case %d: discovery facet should pass Validate, got: %v", i, err)
+		}
 	}
 }
 
@@ -162,16 +180,6 @@ func TestValidateAcceptsRegions(t *testing.T) {
 	}
 }
 
-func TestValidateRejectsRegionElement(t *testing.T) {
-	err := Enrichment{Regions: []string{"eu", "europe"}}.Validate()
-	if err == nil {
-		t.Fatal("expected error for invalid region element")
-	}
-	if !strings.Contains(err.Error(), "regions") {
-		t.Errorf("error must identify the offending field, got: %v", err)
-	}
-}
-
 // Global reach must be distinguishable from unknown reach: an explicit "global"
 // region serializes the key, an unknown (empty regions) payload omits it.
 func TestGlobalReachDistinctFromUnknown(t *testing.T) {
@@ -194,24 +202,34 @@ func TestGlobalReachDistinctFromUnknown(t *testing.T) {
 
 func TestSanitizeDropsOutOfVocabValues(t *testing.T) {
 	e := Enrichment{
-		Seniority: "senior",                     // valid -> kept
-		Category:  "astrology",                  // invalid scalar -> blanked
-		Domains:   []string{"fintech", "bogus"}, // keep only known
-		Regions:   []string{"nope"},             // all unknown -> nil
+		EmploymentType: "seasonal",                   // SERVED invalid scalar -> blanked
+		EnglishLevel:   "b2",                         // SERVED valid -> kept
+		Domains:        []string{"fintech", "bogus"}, // SERVED multi -> keep only known
+		// Discovery facets are captured raw (unserved):
+		Category:  "astrology",      // kept
+		Seniority: "staff_plus",     // kept
+		Regions:   []string{"nope"}, // kept
 	}
 	e.Sanitize()
 
-	if e.Seniority != "senior" {
-		t.Errorf("Seniority = %q, want it kept", e.Seniority)
+	if e.EmploymentType != "" {
+		t.Errorf("EmploymentType = %q, want blanked (served field)", e.EmploymentType)
 	}
-	if e.Category != "" {
-		t.Errorf("Category = %q, want blanked", e.Category)
+	if e.EnglishLevel != "b2" {
+		t.Errorf("EnglishLevel = %q, want kept", e.EnglishLevel)
 	}
 	if len(e.Domains) != 1 || e.Domains[0] != "fintech" {
-		t.Errorf("Domains = %v, want [fintech]", e.Domains)
+		t.Errorf("Domains = %v, want [fintech] (served multi filtered)", e.Domains)
 	}
-	if e.Regions != nil {
-		t.Errorf("Regions = %v, want nil", e.Regions)
+	// Discovery facets survive untouched.
+	if e.Category != "astrology" {
+		t.Errorf("Category = %q, want kept raw (discovery)", e.Category)
+	}
+	if e.Seniority != "staff_plus" {
+		t.Errorf("Seniority = %q, want kept raw (discovery)", e.Seniority)
+	}
+	if len(e.Regions) != 1 || e.Regions[0] != "nope" {
+		t.Errorf("Regions = %v, want kept raw (discovery)", e.Regions)
 	}
 	if err := e.Validate(); err != nil {
 		t.Errorf("Validate after Sanitize = %v, want nil", err)

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -101,9 +101,12 @@ func parseEnrichment(raw string) (Enrichment, error) {
 	return e, nil
 }
 
-// systemPrompt instructs the model to emit only stated fields and to draw enum
-// values from the controlled vocabularies — the same lists Validate enforces, so
-// the prompt and the validator can never drift.
+// systemPrompt instructs the model to emit only stated fields and to draw the
+// SERVED enum values from the controlled vocabularies — the same lists Validate
+// enforces. The six dictionary-covered discovery facets (work_mode, regions,
+// seniority, category) are deliberately relaxed: the prompt invites a novel label
+// when none fits, and Validate does not reject it (it is unserved discovery
+// material), so prompt and validator diverge there on purpose.
 var systemPrompt = buildSystemPrompt()
 
 func buildSystemPrompt() string {
@@ -128,6 +131,15 @@ func buildSystemPrompt() string {
 	enum("domains (array)", DomainValues)
 	enum("company_type", CompanyTypeValues)
 	enum("company_size", CompanySizeValues)
+
+	// Discovery facets: these four (plus the open countries/skills) are served from
+	// our own dictionaries, not from your value, so they are a discovery signal.
+	// Prefer an allowed value, but emit your own label when none fits — this surfaces
+	// vocabulary we are missing. The other enum fields above stay strict.
+	b.WriteString("\nException for work_mode, regions, seniority, category: prefer an allowed ")
+	b.WriteString("value above, but if none accurately fits, you MAY return a concise lowercase ")
+	b.WriteString("label of your own (e.g. seniority \"staff_plus\", category \"ml_platform\"). ")
+	b.WriteString("Still omit the key when the posting does not state it.\n")
 
 	b.WriteString("\nOther keys (omit when unstated): ")
 	b.WriteString("visa_sponsorship (boolean), countries (array of ISO 3166-1 alpha-2), ")

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -67,3 +67,20 @@ func TestSystemPromptIncludesRegionVocabulary(t *testing.T) {
 		}
 	}
 }
+
+// Relax: the prompt permits a novel own-label for the six discovery facets while
+// keeping the strict "exactly one allowed value" instruction for the served fields.
+func TestSystemPromptRelaxesDiscoveryFacets(t *testing.T) {
+	p := buildSystemPrompt()
+	if !strings.Contains(p, "exactly one of the allowed values") {
+		t.Errorf("served enum fields must keep the strict instruction")
+	}
+	if !strings.Contains(p, "concise lowercase label of your own") {
+		t.Errorf("discovery facets must permit a novel own label")
+	}
+	for _, f := range []string{"work_mode", "regions", "seniority", "category"} {
+		if !strings.Contains(p, f) {
+			t.Errorf("discovery instruction should name the facet %q", f)
+		}
+	}
+}

--- a/openspec/changes/relax-llm-discovery/.openspec.yaml
+++ b/openspec/changes/relax-llm-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/relax-llm-discovery/proposal.md
+++ b/openspec/changes/relax-llm-discovery/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The dict-only doctrine made the deterministic dictionaries the sole production source of the six dictionary-covered facets (`countries`, `regions`, `work_mode`, `skills`, `seniority`, `category`); the LLM's values for them are no longer served — they sit raw in the `enrichment` JSONB. That unblocks the final original goal: **relax the LLM on exactly those six facets** so its free-form output becomes a discovery signal. Mining that signal surfaces values the curated dictionaries miss, which the maintainer normalizes back into the dictionaries (closing the loop). Because the six facets are unserved, relaxing them cannot corrupt production data.
+
+## What Changes
+
+- Stop sanitizing/validating the six dict-covered facets in `internal/enrich`: `Sanitize` no longer blanks an out-of-vocabulary `work_mode`/`seniority`/`category` nor filters `regions`; `Validate` no longer rejects them. Their raw LLM values (including novel, out-of-vocabulary labels) persist in the `enrichment` JSONB.
+- The **served** enrichment enum fields stay strict: `employment_type`, `relocation`, `salary_period`, `english_level`, `education_level`, `company_type`, `company_size`, and `domains` are still sanitized and validated (a stray value there would reach the served object), and salary clamping is unchanged.
+- Loosen the **prompt** for the six discovery facets: prefer an allowed value, but emit a concise lowercase label of your own when none fits. The served fields keep the strict "use exactly one of the allowed values" instruction.
+- **Going-forward only:** `enrich.Version` is NOT bumped and nothing is re-enriched. New enrichments accumulate the raw variety; existing (already-sanitized) payloads are untouched. No deploy tail (no backfill, no reindex) — only the enrich worker ships.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `ai-enrichment`: the validated-write-back path exempts the six unserved discovery facets from sanitize/validate (captured raw), while the served enum fields stay validated; the prompt permits novel labels for the discovery facets.
+
+## Impact
+
+- Code: `internal/enrich/enrichment.go` (Sanitize/Validate field partition), `internal/enrich/langchain.go` (prompt), plus their tests.
+- Served data: unchanged — `jobview.FromRow` already ignores the six facets in `enrichment` (dict-only), so out-of-vocabulary values there are inert except as discovery material.
+- Ops: deploy the enrich worker image; no backfill, no reindex, no version bump.
+- Discovery use: a `GROUP BY enrichment->>'category'` over freshly-enriched jobs surfaces novel labels to fold into `classify`/the vocabularies.
+- Out of scope: re-enriching existing jobs, category-from-description, any served-field change.

--- a/openspec/changes/relax-llm-discovery/specs/ai-enrichment/spec.md
+++ b/openspec/changes/relax-llm-discovery/specs/ai-enrichment/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Unserved discovery facets are captured raw, not validated
+
+Because the six dictionary-covered facets (`countries`, `regions`, `work_mode`, `skills`, `seniority`, `category`) are served from the deterministic dictionaries only (dict-only) and the enrichment copies of them are not served, the enrichment worker SHALL capture the LLM's values for those facets **raw**. `Sanitize` SHALL NOT blank or filter an out-of-vocabulary `work_mode`, `seniority`, `category`, or `regions`, and `Validate` SHALL NOT reject the payload for an out-of-vocabulary value in those facets. The served enum fields (`employment_type`, `relocation`, `salary_period`, `english_level`, `education_level`, `company_type`, `company_size`, `domains`) SHALL still be sanitized and validated, and salary clamping is unchanged. The prompt SHALL permit a concise lowercase label of the model's own for the discovery facets when no allowed value fits, while keeping the strict instruction for the served fields. This applies going forward only — `enrich.Version` MUST NOT be bumped and existing payloads MUST NOT be re-enriched.
+
+#### Scenario: An out-of-vocabulary discovery value is persisted, not dropped
+
+- **WHEN** the LLM returns `category="ml_platform"` (not a defined value) for a job
+- **THEN** `Sanitize` keeps it, `Validate` passes, and `ml_platform` is written to the job's `enrichment` JSONB
+
+#### Scenario: An out-of-vocabulary served value is still rejected
+
+- **WHEN** the LLM returns `employment_type="seasonal"` (not a defined value)
+- **THEN** `Sanitize` blanks it, so no out-of-vocabulary value reaches the served `employment_type`
+
+#### Scenario: The discovery values do not reach the served object
+
+- **WHEN** a job's `enrichment` carries a raw `seniority="staff_plus"` discovery value
+- **THEN** the served job object's `seniority` is the dictionary value (or empty), never the raw LLM discovery value

--- a/openspec/changes/relax-llm-discovery/tasks.md
+++ b/openspec/changes/relax-llm-discovery/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Partition Sanitize/Validate (TDD)
 
-- [ ] 1.1 Add failing tests in `internal/enrich`: an out-of-vocabulary `work_mode`/`seniority`/`category` and a non-vocab `regions` element SURVIVE `Sanitize` and PASS `Validate` (captured raw); an out-of-vocabulary served field (`employment_type`, `english_level`, `company_type`, `domains`) is still blanked/filtered by `Sanitize` and still fails `Validate`; salary clamping unchanged.
-- [ ] 1.2 In `enrichment.go`, remove `work_mode`/`seniority`/`category` from the `Sanitize` and `Validate` scalar lists and `regions` from their multi-value lists, keeping the served scalars + `domains` + salary clamping. (`countries`/`skills` are already non-enum.)
-- [ ] 1.3 Run `go test ./internal/enrich/` green.
+- [x] 1.1 Add failing tests in `internal/enrich`: an out-of-vocabulary `work_mode`/`seniority`/`category` and a non-vocab `regions` element SURVIVE `Sanitize` and PASS `Validate` (captured raw); an out-of-vocabulary served field (`employment_type`, `english_level`, `company_type`, `domains`) is still blanked/filtered by `Sanitize` and still fails `Validate`; salary clamping unchanged.
+- [x] 1.2 In `enrichment.go`, remove `work_mode`/`seniority`/`category` from the `Sanitize` and `Validate` scalar lists and `regions` from their multi-value lists, keeping the served scalars + `domains` + salary clamping. (`countries`/`skills` are already non-enum.)
+- [x] 1.3 Run `go test ./internal/enrich/` green.
 
 ## 2. Loosen the prompt for the discovery facets (TDD)
 
-- [ ] 2.1 Add a failing test asserting the built system prompt (a) permits a novel/own label for the discovery facets (work_mode, regions, seniority, category) and (b) still instructs "exactly one of the allowed values" for the served enum fields.
-- [ ] 2.2 In `langchain.go`, split the enum instruction: a relaxed line for the discovery facets (prefer allowed, else a concise lowercase label) and the strict line for the served fields. Keep listing allowed values for all as guidance.
-- [ ] 2.3 Run `go test ./internal/enrich/` green.
+- [x] 2.1 Add a failing test asserting the built system prompt (a) permits a novel/own label for the discovery facets (work_mode, regions, seniority, category) and (b) still instructs "exactly one of the allowed values" for the served enum fields.
+- [x] 2.2 In `langchain.go`, split the enum instruction: a relaxed line for the discovery facets (prefer allowed, else a concise lowercase label) and the strict line for the served fields. Keep listing allowed values for all as guidance.
+- [x] 2.3 Run `go test ./internal/enrich/` green.
 
 ## 3. Verify
 
-- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean; confirm no other package regressed. Do NOT bump enrich.Version.
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean; confirm no other package regressed. Do NOT bump enrich.Version.

--- a/openspec/changes/relax-llm-discovery/tasks.md
+++ b/openspec/changes/relax-llm-discovery/tasks.md
@@ -1,0 +1,15 @@
+## 1. Partition Sanitize/Validate (TDD)
+
+- [ ] 1.1 Add failing tests in `internal/enrich`: an out-of-vocabulary `work_mode`/`seniority`/`category` and a non-vocab `regions` element SURVIVE `Sanitize` and PASS `Validate` (captured raw); an out-of-vocabulary served field (`employment_type`, `english_level`, `company_type`, `domains`) is still blanked/filtered by `Sanitize` and still fails `Validate`; salary clamping unchanged.
+- [ ] 1.2 In `enrichment.go`, remove `work_mode`/`seniority`/`category` from the `Sanitize` and `Validate` scalar lists and `regions` from their multi-value lists, keeping the served scalars + `domains` + salary clamping. (`countries`/`skills` are already non-enum.)
+- [ ] 1.3 Run `go test ./internal/enrich/` green.
+
+## 2. Loosen the prompt for the discovery facets (TDD)
+
+- [ ] 2.1 Add a failing test asserting the built system prompt (a) permits a novel/own label for the discovery facets (work_mode, regions, seniority, category) and (b) still instructs "exactly one of the allowed values" for the served enum fields.
+- [ ] 2.2 In `langchain.go`, split the enum instruction: a relaxed line for the discovery facets (prefer allowed, else a concise lowercase label) and the strict line for the served fields. Keep listing allowed values for all as guidance.
+- [ ] 2.3 Run `go test ./internal/enrich/` green.
+
+## 3. Verify
+
+- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green; `gofmt -l` clean; confirm no other package regressed. Do NOT bump enrich.Version.


### PR DESCRIPTION
## Why

Final thread of the dict-only vision (#106 → #107/#109/#112 enrichment → **this**). Under dict-only the six facets (countries/regions/work_mode/skills/seniority/category) are served from the deterministic dictionaries, never from the LLM — so the LLM's values for them are **unserved**. That makes it safe to relax the LLM on exactly those facets, turning its free-form output into a **discovery signal**: novel labels accumulate raw in the `enrichment` JSONB, the maintainer mines them (`GROUP BY enrichment->>'category'`) and folds them back into the dictionaries — closing the loop.

## What changes (`internal/enrich`)

- **Sanitize/Validate** stop touching `work_mode`/`seniority`/`category`/`regions` — out-of-vocabulary values for these persist raw. The **served** enum fields (`employment_type`, `relocation`, `salary_period`, `english_level`, `education_level`, `company_type`, `company_size`, `domains`) stay strict; salary clamping unchanged.
- **Prompt** gains a relaxed line for the four discovery enums (prefer an allowed value, else a concise lowercase label of your own), keeping the strict line for served fields.
- **Going-forward only:** `enrich.Version` is NOT bumped; nothing re-enriched. **No deploy tail** (no backfill, no reindex) — only the enrich worker ships.

## Safety

`jobview.FromRow` already ignores the six facets in `enrichment` (dict-only), so out-of-vocabulary values there are inert except as discovery material — they can't reach the served object or the search facets.

## Tests (TDD)

Discovery out-of-vocab survives Sanitize+Validate; served out-of-vocab still blanked/rejected; prompt carries both the relaxed discovery line and the strict served line. Full suite + vet + gofmt clean.

OpenSpec: `openspec/changes/relax-llm-discovery/` (ai-enrichment delta).