### PR TITLE
feat(sources): add LawnStarter + 6 Workable boards

### DIFF
--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -543,3 +543,17 @@
   board: deducta
 - company: Revelare Networks
   board: revelare-networks
+- company: LawnStarter
+  board: lawnstarter
+- company: Mellon Group of Companies
+  board: mellongroup
+- company: Athens Technology Center
+  board: athens-technology-center-1
+- company: Tatum
+  board: "534471"
+- company: Trustmi Network Ltd.
+  board: "567673"
+- company: Haiilo
+  board: haiilo-1
+- company: Mercier Consultancy
+  board: mercier-consultancy


### PR DESCRIPTION
Adds 7 Workable companies harvested from public GitHub references and **validated live** against the Workable widget API (`jobs > 0`):

| board | company | jobs |
|---|---|---|
| `lawnstarter` | LawnStarter | 44 |
| `mellongroup` | Mellon Group of Companies | 52 |
| `athens-technology-center-1` | Athens Technology Center | 2 |
| `534471` | Tatum | 1 |
| `567673` | Trustmi Network Ltd. | 1 |
| `haiilo-1` | Haiilo | 1 |
| `mercier-consultancy` | Mercier Consultancy | 980 |

Skipped: numeric DataVisor dup (already `datavisor-jobs`), and ~280 harvested candidates that returned 0 jobs / 404 / the Workable demo fallback account.

Config-only change; YAML parses and passes registry validation.