### PR TITLE
feat(sources): add Global Payments adapter

### DIFF
--- a/internal/sources/globalpayments.go
+++ b/internal/sources/globalpayments.go
@@ -1,0 +1,181 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// globalpayments adapts the Global Payments careers site (jobs.globalpayments.com): a
+// server-rendered site whose /en/jobs listing enumerates postings as /en/jobs/<id>/<slug>
+// links and whose job pages carry a schema.org JobPosting ld+json block. The board is the
+// career-site host; the description comes from a per-job detail fetch (bounded-concurrency),
+// like the other ld+json detail adapters (teamtailor, breezy). It exposes no jobLocationType,
+// so the remote flag falls back to the location text.
+type globalpayments struct {
+	http HTMLGetter
+}
+
+// NewGlobalPayments builds the Global Payments adapter over the given HTTP client.
+func NewGlobalPayments(c HTMLGetter) Source { return globalpayments{http: c} }
+
+func (globalpayments) Provider() string { return "globalpayments" }
+
+// gpMaxPages bounds listing pagination so a board that clamps ?page=N to its last page
+// (serving the same links forever) cannot loop; the no-new-links check ends it sooner.
+const gpMaxPages = 100
+
+func (g globalpayments) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	// base carries scheme+host; the listing's relative /en/jobs hrefs resolve against it
+	// (an absolute href resolves to itself), so it is parsed once rather than per page.
+	base, err := url.Parse(fmt.Sprintf("https://%s/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("globalpayments: board %q: %w", e.Board, err)
+	}
+
+	var urls []string
+	seen := make(map[string]bool)
+	for page := 1; page <= gpMaxPages; page++ {
+		listURL := fmt.Sprintf("https://%s/en/jobs/?page=%d", e.Board, page)
+		root, err := g.http.GetHTML(ctx, listURL)
+		if err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("globalpayments: listing %s: %w", e.Board, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		// Stop on the first page that adds no new links: an empty page, or a board that
+		// clamps ?page=N past its last page (de-dup turns the repeat into zero new).
+		newLinks := 0
+		for _, link := range gpJobLinks(base, root) {
+			if !seen[link] {
+				seen[link] = true
+				urls = append(urls, link)
+				newLinks++
+			}
+		}
+		if newLinks == 0 {
+			break
+		}
+	}
+
+	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return g.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the page fetch fails, carries no JobPosting, or has no parseable id, so the caller
+// skips just that posting.
+func (g globalpayments) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := gpJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := g.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p gpPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	location := p.location()
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		// No jobLocationType is emitted, so the location text is the only remote signal
+		// (never the title, which false-positives on "Remote …" role names).
+		Remote:   isRemote(location),
+		PostedAt: parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// gpJobLinks returns the absolute hrefs of all anchors linking a /en/jobs/<id>/<slug> job
+// page, resolved against base (the listing URL) so relative hrefs still yield fetchable
+// URLs, de-duplicated in first-seen order (a card links the same job from its title and
+// other controls). A link is a job exactly when it carries a parseable native id.
+func gpJobLinks(base *url.URL, root *html.Node) []string {
+	var out []string
+	seen := make(map[string]bool)
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := attr(n, "href")
+			if gpJobID(href) == "" {
+				return true
+			}
+			ref, err := url.Parse(href)
+			if err != nil {
+				return true // unparseable href → not a usable job link
+			}
+			abs := base.ResolveReference(ref).String()
+			if !seen[abs] {
+				seen[abs] = true
+				out = append(out, abs)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// gpJobIDPattern captures the posting id from a job URL's /en/jobs/<id>/<slug> path. The
+// trailing /<slug> segment is required so the bare /en/jobs/ listing (and its ?page=N
+// variants) is not mistaken for a job.
+var gpJobIDPattern = regexp.MustCompile(`/en/jobs/([^/?#]+)/[^/?#]+`)
+
+// gpJobID extracts the native posting id (e.g. "r0072212") from a job page URL.
+func gpJobID(u string) string {
+	if m := gpJobIDPattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// gpPosting is the schema.org JobPosting decoded from a Global Payments job page's
+// application/ld+json block. Its jobLocation entries nest address as an ARRAY (unlike
+// Teamtailor's single object), and a Place/address carries a ready "City, Region, Country"
+// name used as a fallback when the structured parts are absent.
+type gpPosting struct {
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	DatePosted  string    `json:"datePosted"`
+	JobLocation []gpPlace `json:"jobLocation"`
+}
+
+type gpPlace struct {
+	Name    string      `json:"name"`
+	Address []gpAddress `json:"address"`
+}
+
+type gpAddress struct {
+	AddressLocality string `json:"addressLocality"`
+	AddressRegion   string `json:"addressRegion"`
+	AddressCountry  string `json:"addressCountry"`
+}
+
+// location builds the display location from the first jobLocation's first address
+// (city, region, country), falling back to the Place's pre-formatted name when the
+// structured parts are empty.
+func (p gpPosting) location() string {
+	if len(p.JobLocation) == 0 {
+		return ""
+	}
+	pl := p.JobLocation[0]
+	if len(pl.Address) > 0 {
+		a := pl.Address[0]
+		if loc := joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry); loc != "" {
+			return loc
+		}
+	}
+	return pl.Name
+}

--- a/internal/sources/globalpayments_test.go
+++ b/internal/sources/globalpayments_test.go
@@ -1,0 +1,184 @@
+package sources
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gpListingHTML builds a Global Payments listing page linking each given job URL.
+func gpListingHTML(jobURLs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><ul class="jobs">`)
+	for _, u := range jobURLs {
+		b.WriteString(`<li><a href="` + u + `">A job</a></li>`)
+	}
+	// A non-job link (pagination/listing root) must be ignored.
+	b.WriteString(`<li><a href="/en/jobs/?page=2">Next</a></li>`)
+	b.WriteString(`</ul></body></html>`)
+	return b.String()
+}
+
+// gpDetailHTML builds a job page carrying a JobPosting ld+json block whose jobLocation
+// nests address as an array (the Global Payments shape) plus a pre-formatted Place name.
+func gpDetailHTML(title, encodedDescription, datePosted, locality, region, country, placeName string) string {
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"http://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + encodedDescription + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"jobLocation":[{"@type":"Place","name":"` + placeName + `","address":[{"@type":"PostalAddress",` +
+		`"addressLocality":"` + locality + `","addressRegion":"` + region + `","addressCountry":"` + country + `"}]}]}` +
+		`</script></head><body></body></html>`
+}
+
+func TestGPJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.globalpayments.com/en/jobs/r0072212/devops-engineer": "r0072212",
+		"/en/jobs/r0071138/software-engineer-iii":                          "r0071138",
+		"https://jobs.globalpayments.com/en/jobs/":                         "", // listing root
+		"https://jobs.globalpayments.com/en/jobs/?page=2":                  "", // pagination
+		"https://jobs.globalpayments.com/en/about":                         "",
+	}
+	for u, want := range cases {
+		if got := gpJobID(u); got != want {
+			t.Errorf("gpJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestGPJobLinksResolvesRelativeAndFiltersNonJobs(t *testing.T) {
+	h := `<html><body>
+		<a href="/en/jobs/r0071138/software-engineer-iii">Engineer</a>
+		<a href="/en/jobs/r0071138/software-engineer-iii">Apply</a>
+		<a href="https://jobs.globalpayments.com/en/jobs/r0072212/devops-engineer">DevOps</a>
+		<a href="/en/jobs/?page=2">Next</a>
+		<a href="/en/about">About</a>
+	</body></html>`
+	base := mustURL(t, "https://jobs.globalpayments.com/en/jobs/?page=1")
+	got := gpJobLinks(base, parseHTML(t, h))
+	want := []string{
+		"https://jobs.globalpayments.com/en/jobs/r0071138/software-engineer-iii",
+		"https://jobs.globalpayments.com/en/jobs/r0072212/devops-engineer",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("gpJobLinks() = %v, want %v", got, want)
+	}
+}
+
+func TestGPPostingLocation(t *testing.T) {
+	// Structured city/region/country wins.
+	p := gpPosting{JobLocation: []gpPlace{{
+		Name:    "XIAN, SHAANXI, CHINA",
+		Address: []gpAddress{{AddressLocality: "Xian", AddressRegion: "Shaanxi", AddressCountry: "China"}},
+	}}}
+	if got, want := p.location(), "Xian, Shaanxi, China"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	// Falls back to the Place name when the structured parts are empty.
+	p = gpPosting{JobLocation: []gpPlace{{Name: "Remote, USA", Address: []gpAddress{{}}}}}
+	if got, want := p.location(), "Remote, USA"; got != want {
+		t.Errorf("location() fallback = %q, want %q", got, want)
+	}
+	// No location at all.
+	if got := (gpPosting{}).location(); got != "" {
+		t.Errorf("location() = %q, want empty", got)
+	}
+}
+
+func TestGlobalPaymentsFetchListingThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://jobs.globalpayments.com/en/jobs/r0072212/devops-engineer"
+	detail := gpDetailHTML(
+		"DevOps Engineer",
+		"&lt;p&gt;Build &lt;b&gt;it&lt;/b&gt;.&lt;/p&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+		"2026-06-14T19:00:00-05:00", "Xian", "Shaanxi", "China", "XIAN, SHAANXI, CHINA")
+	fake := (&routedHTTP{}).
+		route("page=1", gpListingHTML(jobURL)).
+		route("page=2", gpListingHTML()).
+		route("/en/jobs/r0072212", detail)
+
+	jobs, err := NewGlobalPayments(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Global Payments", Provider: "globalpayments", Board: "jobs.globalpayments.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "r0072212" {
+		t.Errorf("ExternalID = %q, want r0072212", j.ExternalID)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Title != "DevOps Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Global Payments" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Xian, Shaanxi, China" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") ||
+		!strings.Contains(j.Description, "<p>") || !strings.Contains(j.Description, "<b>it</b>") {
+		t.Errorf("Description not unescaped/sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-14T19:00:00-05:00 (= 2026-06-15T00:00Z)", j.PostedAt)
+	}
+}
+
+func TestGlobalPaymentsStopsWhenPageYieldsNoNewLinks(t *testing.T) {
+	// The site clamps ?page=N past its last page, serving the same links; a page with no
+	// *new* links must terminate enumeration so Fetch does not loop to gpMaxPages.
+	d := gpDetailHTML("Role", "&lt;p&gt;x&lt;/p&gt;", "2026-06-14T19:00:00-05:00", "Atlanta", "GA", "USA", "ATLANTA, GA, USA")
+	fake := (&routedHTTP{}).
+		route("/en/jobs/?page", gpListingHTML("https://b/en/jobs/r1/a")). // every page returns the same link
+		route("/en/jobs/r1", d)
+
+	jobs, err := NewGlobalPayments(fake).Fetch(context.Background(), CompanyEntry{Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (de-duplicated, no runaway loop)", len(jobs))
+	}
+}
+
+func TestGlobalPaymentsFailedDetailDropsOnlyThatPosting(t *testing.T) {
+	d := gpDetailHTML("Kept", "&lt;p&gt;x&lt;/p&gt;", "2026-06-14T19:00:00-05:00", "Atlanta", "GA", "USA", "ATLANTA, GA, USA")
+	// No route for /en/jobs/r2 → GetHTML errors → that posting drops.
+	fake := (&routedHTTP{}).
+		route("page=1", gpListingHTML("https://b/en/jobs/r1/kept", "https://b/en/jobs/r2/dropped")).
+		route("page=2", gpListingHTML()).
+		route("/en/jobs/r1", d)
+
+	jobs, err := NewGlobalPayments(fake).Fetch(context.Background(), CompanyEntry{Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "r1" {
+		t.Fatalf("got %v, want only the kept posting", jobs)
+	}
+}
+
+func TestGlobalPaymentsProvider(t *testing.T) {
+	if got := NewGlobalPayments(nil).Provider(); got != "globalpayments" {
+		t.Errorf("Provider() = %q, want %q", got, "globalpayments")
+	}
+}
+
+func TestGlobalPaymentsRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["globalpayments"]
+	if !ok {
+		t.Fatal("All() missing provider globalpayments")
+	}
+	if s.Provider() != "globalpayments" {
+		t.Errorf("All()[globalpayments].Provider() = %q", s.Provider())
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -93,6 +93,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTeamtailor(c),
 		NewBreezy(c),
 		NewJoin(c),
+		NewGlobalPayments(c),
 		// International single-company adapters (boardless).
 		NewUber(c),
 		NewAmazon(c),

--- a/sources/globalpayments.yml
+++ b/sources/globalpayments.yml
@@ -1,0 +1,5 @@
+# globalpayments boards. Provider is the filename; each entry is company + board.
+# board = the careers-site host (see internal/sources/globalpayments.go).
+
+- company: Global Payments
+  board: jobs.globalpayments.com


### PR DESCRIPTION
Adds a board-keyed source adapter for **jobs.globalpayments.com**.

## What
- Paginate `/en/jobs/?page=N` listing HTML → extract `/en/jobs/<id>/<slug>` permalinks → fetch each job page and map its schema.org `JobPosting` ld+json (title, description, location, datePosted). Same shape as teamtailor/breezy; reuses `ldJobPosting`.
- GP-specific: `jobLocation[].address` is an **array** (not a single object) and there's **no** `jobLocationType`, so the remote flag falls back to the location text. Pagination clamps past the last page, so enumeration stops on the first page with no new links.
- Registered in `sources.All`; board file `sources/globalpayments.yml`.

## Origin
Surfaced via a hirify.me harvest spike (most hirify board links were already-covered Workday tenants; Global Payments was the one gap). The careers platform looks generic (Radancy-style `jobs.<company>.com`), so additional companies on it can be added with a board entry alone — rename the provider to `radancy` if that pans out.

## Tests
8 unit tests (id/link extraction, location array+fallback, fetch→map, pagination stop, failed-detail isolation, provider, registry). Verified live against the real site: page 1 → 20 links, first job mapped (id r0072212, full description).

No migration, no search-field change.