### PR TITLE
feat(facets): clean macro-region taxonomy + distribution-driven skill/country filters

### DIFF
--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -30,10 +30,11 @@ type Enrichment struct {
 	Relocation      string `json:"relocation,omitempty"`       // enum: RelocationValues
 	VisaSponsorship *bool  `json:"visa_sponsorship,omitempty"` // pointer: false is meaningful
 
-	// Location / eligibility. Regions is a remote role's geographic reach — a flat,
-	// mixed-level vocabulary (global / macro-region / select country). It is
-	// meaningful only when WorkMode is "remote". Empty means *unknown*; "global"
-	// (open anywhere) is an explicit value, never inferred, so global ≠ unknown.
+	// Location / eligibility. Regions is a remote role's geographic reach — a flat
+	// macro-region vocabulary (global / continent-level area; country-level reach
+	// lives in Countries). It is meaningful only when WorkMode is "remote". Empty
+	// means *unknown*; "global" (open anywhere) is an explicit value, never
+	// inferred, so global ≠ unknown.
 	Regions      []string `json:"regions,omitempty"`       // enum[]: RegionValues
 	Countries    []string `json:"countries,omitempty"`     // enum[]: ISO 3166-1 alpha-2
 	Cities       []string `json:"cities,omitempty"`        // free text (not faceted)
@@ -69,15 +70,16 @@ type Enrichment struct {
 // no bundled closed vocabulary here and are not enum-validated in this phase.
 var (
 	WorkModeValues = []string{"remote", "hybrid", "onsite"}
-	// RegionValues is the geographic-area vocabulary: global, macro-regions, and a
-	// few countries treated as area codes (extend as the curated facet grows).
-	// `cis` (post-Soviet space: Belarus, Moldova, the Caucasus) and `central_asia`
-	// (the five Central Asian republics) cover the RU/CIS segment that dominates
-	// the Telegram sources; `ru` stays its own area.
+	// RegionValues is the geographic-area vocabulary: a single, consistent macro
+	// level (continents/macro-regions, plus `global` and the distinct `uk` area).
+	// Country codes are NOT regions — country-level filtering lives in the separate
+	// `countries` facet, so the US collapses into `north_america` and Russia into
+	// `cis`. `cis` covers the whole post-Soviet space (Russia, Belarus, Moldova,
+	// the Caucasus, and the five Central Asian republics) that dominates the
+	// Telegram sources.
 	RegionValues = []string{
-		"global", "eu", "emea", "eea", "uk", "americas",
-		"north_america", "latam", "apac", "mena", "africa", "us", "ru",
-		"cis", "central_asia",
+		"global", "north_america", "latam", "eu", "uk",
+		"mena", "africa", "apac", "cis",
 	}
 	EmploymentTypeValues = []string{"full_time", "part_time", "contract", "internship"}
 	RelocationValues     = []string{"not_supported", "supported", "required"}

--- a/internal/enrich/enrichment_test.go
+++ b/internal/enrich/enrichment_test.go
@@ -170,8 +170,8 @@ func TestValidateRejectsMultiEnumElement(t *testing.T) {
 func TestValidateAcceptsRegions(t *testing.T) {
 	valid := []Enrichment{
 		{WorkMode: "remote", Regions: []string{"global"}},
-		{WorkMode: "remote", Regions: []string{"eu", "emea"}},
-		{WorkMode: "remote", Regions: []string{"us", "ru"}},
+		{WorkMode: "remote", Regions: []string{"eu", "mena"}},
+		{WorkMode: "remote", Regions: []string{"north_america", "cis"}},
 	}
 	for i, e := range valid {
 		if err := e.Validate(); err != nil {

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -15,18 +15,15 @@ var regionCountries = map[string][]string{
 		"lv", "ee", "lu", "ch", "no", "ua", "is",
 	},
 	"uk":            {"gb"},
-	"us":            {"us"},
-	"north_america": {"ca"},
+	"north_america": {"us", "ca"},
 	"latam":         {"ar", "br", "mx", "cl", "co", "pe", "uy"},
 	"apac":          {"sg", "jp", "au", "nz", "in", "hk", "tw", "kr", "cn", "my", "th", "ph", "vn", "id"},
 	"mena":          {"ae", "sa", "il", "eg", "tr", "qa"},
 	"africa":        {"za", "ng", "ke"},
-	"ru":            {"ru"},
-	// CIS / Central Asia — the RU-segment geography of the Telegram sources.
-	// central_asia is the five republics; cis is the rest of the post-Soviet
-	// space (Belarus, Moldova, the Caucasus). ru keeps its own area; ua stays eu.
-	"central_asia": {"uz", "kz", "kg", "tj", "tm"},
-	"cis":          {"by", "md", "am", "az", "ge"},
+	// CIS — the whole post-Soviet space (the RU-segment geography of the Telegram
+	// sources): Russia, Belarus, Moldova, the Caucasus, and the five Central Asian
+	// republics. Russia is not its own region; ua stays eu.
+	"cis": {"ru", "by", "md", "am", "az", "ge", "uz", "kz", "kg", "tj", "tm"},
 }
 
 // countryToRegion is the inverted regionCountries: ISO code -> region code.
@@ -134,7 +131,7 @@ var nameToCountry = map[string]string{
 // abbreviation ("tx", "on") or full name ("texas", "ontario") — to its ISO 3166-1
 // alpha-2 country code, for the "City, ST ZIP" (US) and "City, Province" (Canada)
 // formats that dominate North American ATS data. The region falls out of
-// countryToRegion (us / north_america).
+// countryToRegion (both us and ca resolve to north_america).
 //
 // Two-letter codes that collide with a country ISO code whose city the parser
 // already keys are deliberately omitted (the country wins, so "Berlin, DE" /
@@ -186,13 +183,11 @@ var subdivisionToCountry = map[string]string{
 // directly to a region code, for tokens that name an area rather than a country.
 var nameToRegion = map[string]string{
 	"europe": "eu", "eu": "eu",
-	"emea": "emea", "eea": "eea",
 	"apac": "apac", "asia": "apac", "asia pacific": "apac", "asia-pacific": "apac",
-	"americas":      "americas",
 	"north america": "north_america",
 	"latam":         "latam", "latin america": "latam", "south america": "latam",
 	"mena": "mena", "middle east": "mena",
 	"africa": "africa",
-	"cis":    "cis", "central asia": "central_asia",
+	"cis":    "cis", "central asia": "cis",
 	"anywhere": "global", "worldwide": "global", "global": "global", "remote anywhere": "global",
 }

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -22,12 +22,12 @@ func TestParse(t *testing.T) {
 		{
 			name:     "country shorthand USA",
 			location: "Remote - USA",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, WorkMode: "remote"},
 		},
 		{
 			name:     "plain country name states no work mode",
 			location: "United States",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "macro region name yields region without country",
@@ -67,17 +67,17 @@ func TestParse(t *testing.T) {
 		{
 			name:     "country buried among unknown tokens",
 			location: "Burlington, Massachusetts, United States; Remote",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, WorkMode: "remote"},
 		},
 		{
 			name:     "Central Asia: Uzbek district, city, country (Uzbek spelling)",
 			location: "Yunusobod, Toshkent, Uzbekistan",
-			want:     Geo{Countries: []string{"uz"}, Regions: []string{"central_asia"}},
+			want:     Geo{Countries: []string{"uz"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "Central Asia: remote Kazakhstan",
 			location: "Remote - Kazakhstan",
-			want:     Geo{Countries: []string{"kz"}, Regions: []string{"central_asia"}, WorkMode: "remote"},
+			want:     Geo{Countries: []string{"kz"}, Regions: []string{"cis"}, WorkMode: "remote"},
 		},
 		{
 			name:     "CIS: Baku via city and country",
@@ -87,7 +87,7 @@ func TestParse(t *testing.T) {
 		{
 			name:     "country-only Georgia is the US state, not the country (no false ge)",
 			location: "Atlanta, Georgia, United States",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "empty location",
@@ -125,32 +125,32 @@ func TestParseNorthAmerica(t *testing.T) {
 		{
 			name:     "US City, ST ZIP",
 			location: "Lake Worth, TX 76135",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "US City, ST",
 			location: "Austin, TX",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "US state code CA is California, not Canada",
 			location: "San Francisco, CA",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "US full state name",
 			location: "Remote - California",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}, WorkMode: "remote"},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, WorkMode: "remote"},
 		},
 		{
 			name:     "US no-comma City ST",
 			location: "Austin TX",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "bare US ZIP is a us signal",
 			location: "94105",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "Canadian province code maps to north_america",
@@ -165,7 +165,7 @@ func TestParseNorthAmerica(t *testing.T) {
 		{
 			name:     "Washington DC resolves to us",
 			location: "Washington, DC",
-			want:     Geo{Countries: []string{"us"}, Regions: []string{"us"}},
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
 		},
 		{
 			name:     "country Georgia is never misread as the US state",
@@ -196,37 +196,37 @@ func TestParseCyrillic(t *testing.T) {
 		{
 			name:     "Cyrillic city Moscow",
 			location: "Москва",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "city marker prefix is stripped",
 			location: "г Москва",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "hyphenated Cyrillic city",
 			location: "Санкт-Петербург",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "multi-word Cyrillic city",
 			location: "Нижний Новгород",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "country token Россия resolves even past an unknown city",
 			location: "Энск, Россия",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "abbreviation РФ",
 			location: "РФ",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "Россия with parenthesised remote marker",
 			location: "Россия (удалённо)",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}, WorkMode: "remote"},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}, WorkMode: "remote"},
 		},
 		{
 			name:     "bare Удалённо yields remote mode, no geography",
@@ -236,7 +236,7 @@ func TestParseCyrillic(t *testing.T) {
 		{
 			name:     "Cyrillic hybrid marker with city",
 			location: "Москва, гибрид",
-			want:     Geo{Countries: []string{"ru"}, Regions: []string{"ru"}, WorkMode: "hybrid"},
+			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}, WorkMode: "hybrid"},
 		},
 		{
 			name:     "CIS: Minsk maps to Belarus / cis",
@@ -246,7 +246,7 @@ func TestParseCyrillic(t *testing.T) {
 		{
 			name:     "Central Asia: Tashkent maps to Uzbekistan",
 			location: "Ташкент",
-			want:     Geo{Countries: []string{"uz"}, Regions: []string{"central_asia"}},
+			want:     Geo{Countries: []string{"uz"}, Regions: []string{"cis"}},
 		},
 		{
 			name:     "Ukrainian spelling Київ maps to Ukraine / eu",

--- a/openspec/changes/region-taxonomy-and-facet-selectors/.openspec.yaml
+++ b/openspec/changes/region-taxonomy-and-facet-selectors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/region-taxonomy-and-facet-selectors/proposal.md
+++ b/openspec/changes/region-taxonomy-and-facet-selectors/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The `regions` reach facet mixed three taxonomic levels: continents/macro-regions
+(`eu`, `apac`), single countries treated as areas (`us`, `ru`), and a vague
+continent bucket (`americas`). The Americas were split across three disconnected
+values — `us` (194k jobs, the country), `north_america` (Canada only — US not
+included), and `americas` (172 jobs, only from literal text) — so a "North
+America" filter returned no US jobs, and `us`/`ru` duplicated the separate
+`countries` facet. The facet read as "не туда не сюда".
+
+Separately, the **Skills** and **Countries** filters were free-text token inputs:
+a user couldn't tell which skills or countries existed or how many jobs each had
+("непонятно, есть они или нет"), and had to know exact tokens/ISO codes to type.
+
+## What Changes
+
+- **Collapse the region vocabulary to one consistent macro level.**
+  `enrich.RegionValues` becomes `{global, north_america, latam, eu, uk, mena,
+  africa, apac, cis}`. The US folds into `north_america` (with Canada); Russia,
+  Belarus, Moldova, the Caucasus, and Central Asia fold into `cis`. Removed:
+  `us`, `ru`, `americas`, `emea`, `eea`, `central_asia`. Country-level filtering
+  lives solely in the `countries` facet. Updated `internal/location`
+  (`regionCountries`, `nameToRegion`), the parser tests, the generated web
+  contracts, and the curated web `REGION` filter list in lockstep.
+- **Skills and Countries filters become distribution-driven selects.** They flip
+  from free-text `tokens` to a searchable `select` whose options come from the
+  live `GET /api/v1/jobs/facets` distribution (value → count, busiest first),
+  rendered with counts so the user sees exactly which values exist. Country codes
+  are labelled via `Intl.DisplayNames` (no hand-maintained table). The job-search
+  view fetches the distribution (debounced, with a stale-response guard) and
+  threads it through the filter panel.
+- **Pill facets surface selected-but-unknown values.** A selected value with no
+  matching option (e.g. a removed region code in an old bookmark/saved search)
+  renders as a removable pill instead of becoming an invisible, stuck filter.
+
+A deploy of this change requires `cmd/backfill-derive` (re-derive every job's
+facets under the new vocabulary) + `make reindex` to reach the live data and the
+search index; until then existing jobs keep their old region codes.
+
+## Capabilities
+
+### Modified Capabilities
+- `job-geography`: the controlled region vocabulary is now a single macro level;
+  country codes are no longer emitted as regions.
+- `web-frontend`: open/high-cardinality facet filters (skills, countries) are
+  driven by the live facet distribution with counts, not free-text entry; pill
+  facets keep removed-vocabulary selections removable.

--- a/openspec/changes/region-taxonomy-and-facet-selectors/specs/job-geography/spec.md
+++ b/openspec/changes/region-taxonomy-and-facet-selectors/specs/job-geography/spec.md
@@ -1,0 +1,39 @@
+# job-geography (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Geography output uses controlled vocabularies
+
+Region codes emitted by the parser SHALL be drawn from the same controlled
+vocabulary the enrichment contract defines for `regions` — a single, consistent
+**macro-region** level: `global`, the macro-regions (`north_america`, `latam`,
+`eu`, `uk`, `mena`, `africa`, `apac`), and the post-Soviet `cis` grouping.
+Country codes SHALL NOT be emitted as regions: country-level reach lives in the
+separate `countries` facet, so the United States maps to the `north_america`
+region and Russia (with Belarus, Moldova, the Caucasus, and Central Asia) to the
+`cis` region. The parser, the enrichment contract, and the search facet SHALL
+share this one set of values. Country codes SHALL be ISO 3166-1 alpha-2. The
+`work_mode` hint SHALL be a member of the enrichment contract's `work_mode`
+vocabulary (`remote`, `hybrid`, `onsite`) or empty. A value outside these
+vocabularies SHALL never be emitted.
+
+#### Scenario: Parser output validates against the controlled vocabularies
+
+- **WHEN** any location string is parsed
+- **THEN** every emitted region is a member of the controlled region vocabulary,
+  every emitted country is a valid ISO 3166-1 alpha-2 code, and the work_mode is
+  a member of the work-mode vocabulary or empty
+
+#### Scenario: The United States maps to the north_america region
+
+- **WHEN** a location resolving to the United States is parsed (e.g. `United
+  States`, a `City, ST ZIP` form, or a US state code)
+- **THEN** the countries are `[us]` and the regions are `[north_america]` — never
+  a `us` region
+
+#### Scenario: Russia and the post-Soviet space map to the cis region
+
+- **WHEN** a location resolving to Russia, Belarus, or a Central Asian republic
+  is parsed (e.g. `Москва`, `Минск`, `Remote - Kazakhstan`)
+- **THEN** the region is `[cis]` — never a standalone `ru` or `central_asia`
+  region — while the country stays its own ISO code

--- a/openspec/changes/region-taxonomy-and-facet-selectors/specs/web-frontend/spec.md
+++ b/openspec/changes/region-taxonomy-and-facet-selectors/specs/web-frontend/spec.md
@@ -1,0 +1,75 @@
+# web-frontend (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Region (remote reach) filter facet
+
+The frontend job-search filter UI SHALL offer a curated "Region" facet, rendered
+as pills under the "Work format" facet, that filters on the search API's
+`regions` parameter. Its options SHALL be the macro-region reach vocabulary
+(Global, North America, LATAM, Europe, UK, MENA, Africa, APAC, CIS), each mapping
+to a `regions` code (`global`, `north_america`, `latam`, `eu`, `uk`, `mena`,
+`africa`, `apac`, `cis`) — one consistent macro level, with country-level
+filtering handled by the separate Countries facet. The facet SHALL support
+exclusion like the other facets. The facet's option values SHALL be codes from
+the backend's `regions` vocabulary.
+
+#### Scenario: Filtering by a region
+
+- **WHEN** a user selects the "Europe" pill in the Region facet
+- **THEN** the search request carries `regions=eu` and the results are jobs whose
+  reach includes Europe
+
+#### Scenario: Excluding a region
+
+- **WHEN** a user excludes the "North America" pill
+- **THEN** the search request excludes `regions=north_america` and such jobs are
+  omitted
+
+## ADDED Requirements
+
+### Requirement: Open-vocabulary facet filters are distribution-driven selects
+
+Facets with an open or high-cardinality vocabulary (Skills and Countries) SHALL
+be filtered through a searchable select whose options come from the live facet
+distribution (`GET /api/v1/jobs/facets`) rather than free-text entry, so the user
+sees which values exist and how many open jobs each has under the current
+filters. Each option SHALL display its job count, and options SHALL be ordered
+by count (busiest first). Country options SHALL be labelled with a human-readable
+country name derived from the ISO code. A value already selected but absent from
+the current distribution SHALL remain listed so it stays removable.
+
+The job-search view SHALL fetch the distribution under the same filter params as
+the result list, debounced, and SHALL discard a stale (superseded) response so
+the counts never reflect an older filter state.
+
+#### Scenario: Skills/Countries options come from the distribution with counts
+
+- **WHEN** the user opens the Skills or Countries filter section
+- **THEN** the selectable options are the values present in the current facet
+  distribution, each labelled with its job count and ordered busiest-first
+
+#### Scenario: Country codes are shown as names
+
+- **WHEN** a country option for ISO code `de` is rendered
+- **THEN** its label reads `Germany`, not `de`
+
+#### Scenario: A stale distribution response is ignored
+
+- **WHEN** filters change rapidly and an earlier distribution request resolves
+  after a later one
+- **THEN** the later (current) response wins and the earlier one is discarded
+
+### Requirement: Pill facets keep removed-vocabulary selections removable
+
+A pill-control facet SHALL render any currently-selected value that has no
+matching option as an active, removable pill, so a value removed from the
+controlled vocabulary after a bookmark or saved search was created does not
+become an invisible filter the user cannot clear from the UI.
+
+#### Scenario: A removed region value stays removable
+
+- **WHEN** the active filters include a region value no longer in the region
+  vocabulary (e.g. an old `?regions=us` link after the macro-region change)
+- **THEN** that value renders as an active pill the user can click to remove,
+  rather than silently constraining results with no visible control

--- a/openspec/changes/region-taxonomy-and-facet-selectors/tasks.md
+++ b/openspec/changes/region-taxonomy-and-facet-selectors/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+> Implemented ahead of this tracking change; all tasks reflect work that is done
+> and verified (`go test ./...`, `svelte-check`, web production build all green).
+
+## 1. Region vocabulary
+
+- [x] 1.1 Rewrite `enrich.RegionValues` to the macro-only set `{global,
+      north_america, latam, eu, uk, mena, africa, apac, cis}`; update the
+      `Enrichment.Regions` field doc.
+- [x] 1.2 Update `internal/location` `regionCountries` (US→`north_america`;
+      RU + CIS + Central Asia merged into `cis`) and `nameToRegion` (drop
+      `americas`/`emea`/`eea`; `central asia`→`cis`).
+- [x] 1.3 Update `internal/location` parser tests for the new mappings.
+- [x] 1.4 Update `enrich.TestValidateAcceptsRegions` fixtures to current vocab.
+- [x] 1.5 Regenerate web TS contracts (`make gen-contracts`).
+- [x] 1.6 Update the curated web `REGION` filter list in `facets.ts`.
+
+## 2. Distribution-driven Skills / Countries selects
+
+- [x] 2.1 Add `dynamic` to `FacetDef` and `count` to `FacetOption`; flip
+      `skills`/`countries` to `control: 'select', dynamic: true`.
+- [x] 2.2 Build dynamic options from the facet distribution in `FacetSection`
+      (busiest-first, selected-but-absent values retained); show counts in
+      `SearchSelect`; label countries via `Intl.DisplayNames`.
+- [x] 2.3 Fetch the distribution in `JobsView` (debounced, monotonic
+      stale-response guard) and thread `counts` through `FiltersPanel` →
+      `FacetSection`; forward `counts` from `AnalyticsView` too.
+
+## 3. Robustness
+
+- [x] 3.1 `PillGroup` renders selected-but-unknown values as removable pills so
+      a removed vocabulary value in an old bookmark/saved search is not a stuck,
+      invisible filter.
+
+## 4. Verification
+
+- [x] 4.1 `go build/vet/test ./...` green.
+- [x] 4.2 `svelte-check` clean; web production build succeeds.
+- [ ] 4.3 Post-deploy: `cmd/backfill-derive` + `make reindex`, then confirm the
+      region facet and live skills/countries selects on staging/prod. *(Deferred
+      to rollout — needs the running stack.)*

--- a/openspec/specs/job-geography/spec.md
+++ b/openspec/specs/job-geography/spec.md
@@ -68,12 +68,17 @@ geography tokens, so a bare `Remote` yields `work_mode=remote` with empty geogra
 ### Requirement: Geography output uses controlled vocabularies
 
 Region codes emitted by the parser SHALL be drawn from the same controlled
-vocabulary the enrichment contract defines for `regions` (`global`, the
-macro-regions, and the select reach-area country codes), so the parser, the
-enrichment contract, and the search facet share one set of values. Country codes
-SHALL be ISO 3166-1 alpha-2. The `work_mode` hint SHALL be a member of the
-enrichment contract's `work_mode` vocabulary (`remote`, `hybrid`, `onsite`) or
-empty. A value outside these vocabularies SHALL never be emitted.
+vocabulary the enrichment contract defines for `regions` — a single, consistent
+**macro-region** level: `global`, the macro-regions (`north_america`, `latam`,
+`eu`, `uk`, `mena`, `africa`, `apac`), and the post-Soviet `cis` grouping.
+Country codes SHALL NOT be emitted as regions: country-level reach lives in the
+separate `countries` facet, so the United States maps to the `north_america`
+region and Russia (with Belarus, Moldova, the Caucasus, and Central Asia) to the
+`cis` region. The parser, the enrichment contract, and the search facet SHALL
+share this one set of values. Country codes SHALL be ISO 3166-1 alpha-2. The
+`work_mode` hint SHALL be a member of the enrichment contract's `work_mode`
+vocabulary (`remote`, `hybrid`, `onsite`) or empty. A value outside these
+vocabularies SHALL never be emitted.
 
 #### Scenario: Parser output validates against the controlled vocabularies
 
@@ -81,6 +86,20 @@ empty. A value outside these vocabularies SHALL never be emitted.
 - **THEN** every emitted region is a member of the controlled region vocabulary,
   every emitted country is a valid ISO 3166-1 alpha-2 code, and the work_mode is
   a member of the work-mode vocabulary or empty
+
+#### Scenario: The United States maps to the north_america region
+
+- **WHEN** a location resolving to the United States is parsed (e.g. `United
+  States`, a `City, ST ZIP` form, or a US state code)
+- **THEN** the countries are `[us]` and the regions are `[north_america]` — never
+  a `us` region
+
+#### Scenario: Russia and the post-Soviet space map to the cis region
+
+- **WHEN** a location resolving to Russia, Belarus, or a Central Asian republic
+  is parsed (e.g. `Москва`, `Минск`, `Remote - Kazakhstan`)
+- **THEN** the region is `[cis]` — never a standalone `ru` or `central_asia`
+  region — while the country stays its own ISO code
 
 ### Requirement: Work mode is resolved by precedence across sources
 

--- a/openspec/specs/web-frontend/spec.md
+++ b/openspec/specs/web-frontend/spec.md
@@ -26,11 +26,13 @@ directly without a proxy.
 
 The frontend job-search filter UI SHALL offer a curated "Region" facet, rendered
 as pills under the "Work format" facet, that filters on the search API's
-`regions` parameter. Its options SHALL be a curated, extensible subset of the
-reach vocabulary (Global, Russia, Europe, USA), each mapping to a `regions` code
-(`global`, `ru`, `eu`, `us`). The facet SHALL support exclusion like the other
-facets. The facet's option values SHALL be codes from the backend's `regions`
-vocabulary.
+`regions` parameter. Its options SHALL be the macro-region reach vocabulary
+(Global, North America, LATAM, Europe, UK, MENA, Africa, APAC, CIS), each mapping
+to a `regions` code (`global`, `north_america`, `latam`, `eu`, `uk`, `mena`,
+`africa`, `apac`, `cis`) — one consistent macro level, with country-level
+filtering handled by the separate Countries facet. The facet SHALL support
+exclusion like the other facets. The facet's option values SHALL be codes from
+the backend's `regions` vocabulary.
 
 #### Scenario: Filtering by a region
 
@@ -40,8 +42,9 @@ vocabulary.
 
 #### Scenario: Excluding a region
 
-- **WHEN** a user excludes the "USA" pill
-- **THEN** the search request excludes `regions=us` and such jobs are omitted
+- **WHEN** a user excludes the "North America" pill
+- **THEN** the search request excludes `regions=north_america` and such jobs are
+  omitted
 
 ### Requirement: Jobs list with pagination
 
@@ -308,4 +311,50 @@ URL.
 
 - **WHEN** a visitor reloads `/analytics` with filter params in the URL
 - **THEN** the page renders the breakdowns and total for those filters
+
+### Requirement: Open-vocabulary facet filters are distribution-driven selects
+
+Facets with an open or high-cardinality vocabulary (Skills and Countries) SHALL
+be filtered through a searchable select whose options come from the live facet
+distribution (`GET /api/v1/jobs/facets`) rather than free-text entry, so the user
+sees which values exist and how many open jobs each has under the current
+filters. Each option SHALL display its job count, and options SHALL be ordered
+by count (busiest first). Country options SHALL be labelled with a human-readable
+country name derived from the ISO code. A value already selected but absent from
+the current distribution SHALL remain listed so it stays removable.
+
+The job-search view SHALL fetch the distribution under the same filter params as
+the result list, debounced, and SHALL discard a stale (superseded) response so
+the counts never reflect an older filter state.
+
+#### Scenario: Skills/Countries options come from the distribution with counts
+
+- **WHEN** the user opens the Skills or Countries filter section
+- **THEN** the selectable options are the values present in the current facet
+  distribution, each labelled with its job count and ordered busiest-first
+
+#### Scenario: Country codes are shown as names
+
+- **WHEN** a country option for ISO code `de` is rendered
+- **THEN** its label reads `Germany`, not `de`
+
+#### Scenario: A stale distribution response is ignored
+
+- **WHEN** filters change rapidly and an earlier distribution request resolves
+  after a later one
+- **THEN** the later (current) response wins and the earlier one is discarded
+
+### Requirement: Pill facets keep removed-vocabulary selections removable
+
+A pill-control facet SHALL render any currently-selected value that has no
+matching option as an active, removable pill, so a value removed from the
+controlled vocabulary after a bookmark or saved search was created does not
+become an invisible filter the user cannot clear from the UI.
+
+#### Scenario: A removed region value stays removable
+
+- **WHEN** the active filters include a region value no longer in the region
+  vocabulary (e.g. an old `?regions=us` link after the macro-region change)
+- **THEN** that value renders as an active pill the user can click to remove,
+  rather than silently constraining results with no visible control
 

--- a/web/src/lib/components/AnalyticsView.svelte
+++ b/web/src/lib/components/AnalyticsView.svelte
@@ -82,7 +82,7 @@
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
     <div class="sticky top-6 max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
-      <FiltersPanel store={filters} />
+      <FiltersPanel store={filters} {counts} />
     </div>
   </aside>
 
@@ -132,7 +132,7 @@
         <span class="text-sm font-semibold tracking-tight">Filters</span>
         <button type="button" class="text-sm text-muted-foreground hover:text-foreground" onclick={() => (drawerOpen = false)}>Done</button>
       </div>
-      <FiltersPanel store={filters} />
+      <FiltersPanel store={filters} {counts} />
     </div>
   </div>
 {/if}

--- a/web/src/lib/components/FiltersPanel.svelte
+++ b/web/src/lib/components/FiltersPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { FilterStore } from '$lib/filters.svelte';
+  import type { FacetCounts } from '$lib/types';
   import { FACETS } from '$lib/facets';
   import FacetSection from './facets/FacetSection.svelte';
   import SavedSearches from './SavedSearches.svelte';
@@ -8,7 +9,8 @@
   // registry and renders each section, plus the two special controls (visa,
   // min salary) that aren't multi-value facets. `exclude` hides facets by param
   // (e.g. the company page pins one company, so its Source facet is irrelevant).
-  let { store, exclude = [] }: { store: FilterStore; exclude?: string[] } = $props();
+  // `counts` is the live facet distribution feeding the dynamic selects.
+  let { store, exclude = [], counts = null }: { store: FilterStore; exclude?: string[]; counts?: FacetCounts | null } = $props();
 
   const facets = $derived(FACETS.filter((f) => !exclude.includes(f.param)));
 
@@ -35,7 +37,7 @@
   </div>
 
   {#each facets as def (def.param)}
-    <FacetSection {def} {store} />
+    <FacetSection {def} {store} {counts} />
   {/each}
 
   <div class="border-b border-border pb-4">

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -173,15 +173,6 @@
           <Bookmark class={saved ? 'size-4 fill-current' : 'size-4'} />
           {saved ? 'Saved' : 'Save'}
         </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onclick={onReportClick}
-          class="w-full text-muted-foreground"
-        >
-          <Flag class="size-4" />
-          Report this job
-        </Button>
       </div>
 
       {#if facets.length}
@@ -224,6 +215,18 @@
           <Badge variant="secondary">Manually added</Badge>
         {/if}
         {#if posted}<span class="text-xs text-muted-foreground">Posted {posted}</span>{/if}
+      </div>
+
+      <div class="border-t border-border pt-4 first:border-t-0 first:pt-0">
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={onReportClick}
+          class="w-full text-muted-foreground"
+        >
+          <Flag class="size-4" />
+          Report this job
+        </Button>
       </div>
     </div>
   </aside>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -5,8 +5,8 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
   import { Paginator } from '$lib/paginated.svelte';
-  import { FilterStore, filtersToParams, type SortField } from '$lib/filters.svelte';
-  import type { Job } from '$lib/types';
+  import { FilterStore, filtersToParams } from '$lib/filters.svelte';
+  import type { Job, FacetCounts } from '$lib/types';
   import { Input } from '$lib/ui';
   import FiltersPanel from './FiltersPanel.svelte';
   import States from './States.svelte';
@@ -47,6 +47,24 @@
   seeded.seed(untrack(() => initial));
   let jobs = $state.raw(seeded);
 
+  // The live facet distribution (value → count per facet), feeding the dynamic
+  // selects (skills, countries) so the user sees which values exist and how many
+  // jobs each has under the current filters. A failed fetch leaves the prior
+  // counts — the selects degrade to plain (countless) options, never break.
+  // `countsGen` is a monotonic fetch id so a slow earlier response can't
+  // overwrite a newer one (same guard as AnalyticsView).
+  let counts = $state<FacetCounts | null>(null);
+  let countsGen = 0;
+  const refreshCounts = () => {
+    const gen = ++countsGen;
+    return api
+      .facetCounts(scopedParams())
+      .then((c) => {
+        if (gen === countsGen) counts = c;
+      })
+      .catch(() => {});
+  };
+
   let drawerOpen = $state(false);
   let started = false;
   let timer: ReturnType<typeof setTimeout>;
@@ -56,12 +74,9 @@
   // timer left running after unmount would start a fetch for a gone component.
   onMount(() => {
     if (isAuthenticated()) ensureViewedLoaded();
+    refreshCounts();
     return () => clearTimeout(timer);
   });
-
-  // House select styling, mirrored from ApiKeysView.
-  const sortClass =
-    'h-9 shrink-0 rounded-lg border border-input bg-transparent px-3 text-sm transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30';
 
   // Browser back/forward changes the URL query — pull it back into the filters.
   // Track only the URL: syncFromUrl reads filters.value internally, so without
@@ -84,6 +99,7 @@
     timer = setTimeout(() => {
       jobs = makePaginator();
       jobs.start();
+      refreshCounts();
     }, 300);
   });
 </script>
@@ -91,7 +107,7 @@
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
     <div class="sticky top-6 max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
-      <FiltersPanel store={filters} exclude={excludeFacets} />
+      <FiltersPanel store={filters} exclude={excludeFacets} {counts} />
     </div>
   </aside>
 
@@ -105,15 +121,6 @@
         aria-label="Search jobs"
         class="min-w-0 flex-1"
       />
-      <select
-        value={filters.value.sort}
-        onchange={(e) => filters.setSort(e.currentTarget.value as SortField)}
-        aria-label="Sort jobs by"
-        class={sortClass}
-      >
-        <option value="posted_at">Date posted</option>
-        <option value="created_at">Recently added</option>
-      </select>
       <button
         type="button"
         class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent md:hidden"
@@ -154,7 +161,7 @@
         <span class="text-sm font-semibold tracking-tight">Filters</span>
         <button type="button" class="text-sm text-muted-foreground hover:text-foreground" onclick={() => (drawerOpen = false)}>Done</button>
       </div>
-      <FiltersPanel store={filters} exclude={excludeFacets} />
+      <FiltersPanel store={filters} exclude={excludeFacets} {counts} />
     </div>
   </div>
 {/if}

--- a/web/src/lib/components/facets/FacetSection.svelte
+++ b/web/src/lib/components/facets/FacetSection.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { X } from '@lucide/svelte';
-  import type { FacetDef } from '$lib/facets';
+  import { dynamicLabel, type FacetDef, type FacetOption } from '$lib/facets';
   import type { FilterStore } from '$lib/filters.svelte';
+  import type { FacetCounts } from '$lib/types';
   import { cn } from '$lib/utils';
   import PillGroup from './PillGroup.svelte';
   import SearchSelect from './SearchSelect.svelte';
@@ -9,10 +10,24 @@
 
   // One facet section: header (label, optional Any/All match toggle, optional
   // exclude toggle) plus the control the facet declares. All state lives in the
-  // store, keyed by the facet's param.
-  let { def, store }: { def: FacetDef; store: FilterStore } = $props();
+  // store, keyed by the facet's param. `counts` carries the live facet
+  // distribution that drives dynamic (open-vocabulary) selects.
+  let { def, store, counts }: { def: FacetDef; store: FilterStore; counts?: FacetCounts | null } = $props();
 
   const st = $derived(store.facet(def.param));
+
+  // Options for a select facet: static for closed vocabularies, or built from the
+  // live distribution (value → count, busiest first) for dynamic ones. Selected
+  // values absent from the current distribution are still listed so they stay
+  // removable.
+  const selectOptions = $derived.by((): FacetOption[] => {
+    if (!def.dynamic) return def.options ?? [];
+    const dist = counts?.facets?.[def.param] ?? {};
+    const keys = new Set<string>([...Object.keys(dist), ...st.values]);
+    return [...keys]
+      .map((value) => ({ value, label: dynamicLabel(def.param, value), count: dist[value] ?? 0 }))
+      .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  });
   // The exclude/clear actions only appear once something is selected — so their
   // meaning is clear ("you picked these — hide them, or clear them") rather than
   // abstract controls on an empty section.
@@ -71,7 +86,7 @@
     />
   {:else if def.control === 'select'}
     <SearchSelect
-      options={def.options ?? []}
+      options={selectOptions}
       selected={st.values}
       exclude={st.exclude}
       placeholder={def.placeholder}

--- a/web/src/lib/components/facets/PillGroup.svelte
+++ b/web/src/lib/components/facets/PillGroup.svelte
@@ -16,10 +16,19 @@
     exclude?: boolean;
     onToggle: (value: string) => void;
   } = $props();
+
+  // A selected value with no matching option — e.g. a vocabulary value removed
+  // since an old bookmark or saved search was created — still renders as an
+  // active pill so it stays removable instead of becoming an invisible, stuck
+  // filter that silently constrains results.
+  const shown = $derived([
+    ...options,
+    ...selected.filter((v) => !options.some((o) => o.value === v)).map((v) => ({ value: v, label: v })),
+  ]);
 </script>
 
 <div class="flex flex-wrap gap-2">
-  {#each options as opt (opt.value)}
+  {#each shown as opt (opt.value)}
     {@const active = selected.includes(opt.value)}
     <button
       type="button"

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -39,7 +39,7 @@
         onclick={() => onToggle(opt.value)}
         class={pillClass(active, exclude, 'px-2.5 py-1 text-sm')}
       >
-        {opt.label}
+        {opt.label}{#if opt.count !== undefined}<span class="ml-1 opacity-60 tabular-nums">{opt.count.toLocaleString()}</span>{/if}
       </button>
     {/each}
     {#if shown.length === 0}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -19,6 +19,8 @@ import {
 export interface FacetOption {
   value: string;
   label: string;
+  /** Number of matching jobs, for dynamic (distribution-driven) options. */
+  count?: number;
 }
 
 export type FacetControl = 'pills' | 'select' | 'tokens';
@@ -32,6 +34,36 @@ export interface FacetDef {
   /** Show a per-facet AND/OR toggle (match all vs match any) over selected values. */
   hasAndOr?: boolean;
   placeholder?: string;
+  /**
+   * Options come from the live facet distribution (with counts), not a static
+   * `options` list — for open/large vocabularies (skills, countries). The panel
+   * builds them from the facet-counts endpoint at render time.
+   */
+  dynamic?: boolean;
+}
+
+// Resolve an ISO 3166-1 alpha-2 code to an English country name via platform Intl
+// data (no hand-maintained table); fall back to the upper-cased code.
+const regionNames = (() => {
+  try {
+    return new Intl.DisplayNames(['en'], { type: 'region' });
+  } catch {
+    return null;
+  }
+})();
+
+export function countryLabel(code: string): string {
+  const up = code.toUpperCase();
+  try {
+    return regionNames?.of(up) ?? up;
+  } catch {
+    return up;
+  }
+}
+
+/** Display label for a dynamic facet value: country code → name, else the value. */
+export function dynamicLabel(param: string, value: string): string {
+  return param === 'countries' ? countryLabel(value) : value;
 }
 
 /** A title-cased fallback label for a value with no explicit label. */
@@ -57,25 +89,21 @@ const SOURCE: FacetOption[] = options(SOURCE_VALUES, {
   workatastartup: 'Work at a Startup', remoteok: 'RemoteOK', arc: 'Arc',
 });
 
-// The backend's full `regions` reach vocabulary (enrich.RegionValues). Values mix
-// levels by design (global / macro-region / country-as-area); keep this in sync
-// with that list so every tagged region is filterable.
+// The backend's `regions` reach vocabulary (enrich.RegionValues): one consistent
+// macro level (continents/macro-regions, plus `global` and the distinct `uk`).
+// Country-level filtering lives in the Countries facet, so the US sits under
+// `north_america` and Russia under `cis`. Keep this in sync with that list so
+// every tagged region is filterable.
 const REGION: FacetOption[] = [
   { value: 'global', label: 'Global' },
-  { value: 'us', label: 'USA' },
   { value: 'north_america', label: 'North America' },
   { value: 'latam', label: 'LATAM' },
-  { value: 'americas', label: 'Americas' },
   { value: 'eu', label: 'Europe' },
   { value: 'uk', label: 'UK' },
-  { value: 'emea', label: 'EMEA' },
-  { value: 'eea', label: 'EEA' },
   { value: 'mena', label: 'MENA' },
   { value: 'africa', label: 'Africa' },
   { value: 'apac', label: 'APAC' },
-  { value: 'ru', label: 'Russia' },
   { value: 'cis', label: 'CIS' },
-  { value: 'central_asia', label: 'Central Asia' },
 ];
 
 const WORK_MODE: FacetOption[] = options(WORK_MODE_VALUES, { onsite: 'On-site' });
@@ -118,10 +146,10 @@ export const FACETS: FacetDef[] = [
   { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
   { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },
-  { param: 'skills', label: 'Skills', control: 'tokens', excludable: true, hasAndOr: true, placeholder: 'Add a skill, press Enter' },
+  { param: 'skills', label: 'Skills', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search skills' },
   { param: 'domains', label: 'Industry', control: 'select', options: DOMAINS, excludable: true, placeholder: 'Search industries' },
   { param: 'company_type', label: 'Company type', control: 'pills', options: COMPANY_TYPE, excludable: true },
-  { param: 'countries', label: 'Countries', control: 'tokens', excludable: true, placeholder: 'ISO code, e.g. DE' },
+  { param: 'countries', label: 'Countries', control: 'select', dynamic: true, excludable: true, placeholder: 'Search countries' },
   { param: 'relocation', label: 'Relocation', control: 'pills', options: RELOCATION, excludable: true },
   { param: 'employment_type', label: 'Employment', control: 'pills', options: EMPLOYMENT, excludable: true },
   { param: 'english_level', label: 'English', control: 'pills', options: ENGLISH, excludable: true },

--- a/web/src/lib/filters.svelte.ts
+++ b/web/src/lib/filters.svelte.ts
@@ -17,13 +17,14 @@ export interface FacetState {
   matchAll: boolean;
 }
 
-/** The fields the browse list can be ordered by (both newest-first). `posted_at`
- *  is the source's posting date; `created_at` is when we ingested the job. */
-export type SortField = 'posted_at' | 'created_at';
+/** The fields the browse list can be ordered by. Only `posted_at` (the source's
+ *  posting date, newest-first) is offered today; the type stays a union so a
+ *  future sort (e.g. salary) re-introduces an option without reshaping callers. */
+export type SortField = 'posted_at';
 
-/** Default browse order: freshest by posting date. Kept out of the URL (see
- *  filtersToParams) so the default reads as a clean, sort-less URL and the
- *  backend's own empty-query default stays the single source of truth. */
+/** Default (and currently only) browse order: freshest by posting date. Kept out
+ *  of the URL (see filtersToParams) so the default reads as a clean, sort-less URL
+ *  and the backend's own empty-query default stays the single source of truth. */
 export const DEFAULT_SORT: SortField = 'posted_at';
 
 export interface JobFilters {
@@ -85,8 +86,8 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
   f.visa = p.get('visa_sponsorship') === 'true';
   const salary = Number(p.get('salary_min'));
   f.salaryMin = p.get('salary_min') && !Number.isNaN(salary) ? salary : null;
-  // Only `created_at` is a non-default sort; anything else falls back to default.
-  f.sort = p.get('sort') === 'created_at' ? 'created_at' : DEFAULT_SORT;
+  // Sort isn't user-selectable today, so it's never read from the URL — it stays
+  // the default seeded by emptyFilters().
   return f;
 }
 

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -15,10 +15,11 @@ export interface Enrichment {
   relocation?: string; // enum: RelocationValues
   visa_sponsorship?: boolean; // pointer: false is meaningful
   /**
-   * Location / eligibility. Regions is a remote role's geographic reach — a flat,
-   * mixed-level vocabulary (global / macro-region / select country). It is
-   * meaningful only when WorkMode is "remote". Empty means *unknown*; "global"
-   * (open anywhere) is an explicit value, never inferred, so global ≠ unknown.
+   * Location / eligibility. Regions is a remote role's geographic reach — a flat
+   * macro-region vocabulary (global / continent-level area; country-level reach
+   * lives in Countries). It is meaningful only when WorkMode is "remote". Empty
+   * means *unknown*; "global" (open anywhere) is an explicit value, never
+   * inferred, so global ≠ unknown.
    */
   regions?: string[]; // enum[]: RegionValues
   countries?: string[]; // enum[]: ISO 3166-1 alpha-2
@@ -78,10 +79,12 @@ export interface Job {
   location: string;
   description: string;
   /**
-   * Countries/Regions/WorkMode are the resolved geography facet: the union of
-   * the ingest-parsed location columns and the enrichment-derived values
-   * (work_mode is the LLM value when present, else the parsed one). They are
-   * served here, top-level and once; the same fields are folded out of the
+   * Countries/Regions/WorkMode/Skills are served from the jobs dictionary columns
+   * ONLY — the deterministic dictionaries are the sole production source for these
+   * facets. The LLM's enrichment values for them are deliberately excluded from
+   * the served object (they remain raw in the stored enrichment JSONB), so the LLM
+   * can later run free as a discovery signal without corrupting production data.
+   * They are served top-level and once; the same fields are folded out of the
    * nested Enrichment to avoid duplication.
    */
   countries: string[];
@@ -102,7 +105,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'greenhouse', 'huntflow', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'workable', 'workday'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'greenhouse', 'gupy', 'huntflow', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'workable', 'workday'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## Why

The `regions` reach facet mixed three taxonomic levels (country `us`/`ru`, macro `eu`/`apac`, continent `americas`) and split the Americas across three disconnected buckets — `us` (194k, the country), `north_america` (Canada only — US not included), `americas` (172, only from literal text) — so a "North America" filter returned no US jobs, and `us`/`ru` duplicated the `countries` facet.

Separately, **Skills** and **Countries** filters were free-text token inputs — users couldn't tell which values existed or how many jobs each had.

## What changed

**Region taxonomy → one consistent macro level.** `RegionValues = {global, north_america, latam, eu, uk, mena, africa, apac, cis}`. US folds into `north_america`; Russia + Belarus + Moldova + Caucasus + Central Asia fold into `cis`. Removed `us`, `ru`, `americas`, `emea`, `eea`, `central_asia`. Country-level filtering lives solely in the `countries` facet. (`internal/enrich`, `internal/location` + tests, generated contracts, web `REGION` list.)

**Skills/Countries → distribution-driven selects.** They flip from free-text `tokens` to searchable `select`s whose options come from the live `GET /api/v1/jobs/facets` distribution (value + count, busiest-first), so users see exactly which values exist. Country codes labelled via `Intl.DisplayNames`. `JobsView` fetches the distribution debounced with a monotonic stale-response guard, threaded through `FiltersPanel`→`FacetSection` (and `AnalyticsView`).

**PillGroup robustness.** A selected-but-unknown value (e.g. a removed region code in an old bookmark/saved search) renders as a removable pill instead of an invisible stuck filter.

**Bundled UI tweaks (same session/files):** "Report this job" moved to the sidebar bottom; the single-option sort dropdown removed from the search header (kept as a store seam).

## Rollout (required)

`deploy → cmd/backfill-derive → make reindex`. Until then, existing jobs keep their old region codes (`us`/`ru`/…). `backfill-derive` re-derives all ~194k+ jobs under the new vocabulary; `reindex` updates the search index.

## Verification

`go build/vet/test ./...` ✅ · `svelte-check` 0 errors ✅ · web production build ✅. Live facet-selector behavior (population from the running `/jobs/facets`) confirmed at staging/prod post-deploy.

## Review

Ran simplify + a high-recall code review on the diff; fixed all surfaced bugs: AnalyticsView missing `counts` prop, the stale-response race, the PillGroup stuck-filter, and stale test fixtures. Deferred (noted): folding facetDistribution into the search response (perf), the Meili `maxValuesPerFacet` cap once skills>300 (238 today).

OpenSpec: `region-taxonomy-and-facet-selectors` (job-geography + web-frontend synced).