### PR TITLE
fix(sources): drop future-dated posted_at + read Habr's real date; add Edia/Stone boards

### DIFF
--- a/internal/linksource/habrcareer.go
+++ b/internal/linksource/habrcareer.go
@@ -38,10 +38,12 @@ func (habrCareer) Match(u *url.URL) bool {
 var habrVacancyPath = regexp.MustCompile(`^/vacancies/(\d+)/?$`)
 
 // habrPosting selects the JobPosting ld+json fields Habr publishes on a vacancy page.
+// datePosted is deliberately absent: Habr's ld+json datePosted is unreliable (it runs ~a
+// month ahead of the real publish date), so the posting date is read from the page's
+// <time> element instead — see Resolve.
 type habrPosting struct {
 	Title       string `json:"title"`
 	Description string `json:"description"`
-	DatePosted  string `json:"datePosted"`
 	Identifier  struct {
 		Value string `json:"value"`
 	} `json:"identifier"`
@@ -118,7 +120,11 @@ func (h habrCareer) Resolve(ctx context.Context, raw string) (sources.Job, bool,
 		Location:    loc,
 		Description: sources.SanitizeHTML(p.Description),
 		Remote:      sources.IsRemote(loc),
-		PostedAt:    parseDate(p.DatePosted),
+		// Habr's ld+json datePosted is bogus (~a month ahead of the real date, with a later
+		// validThrough), which would pin every Habr job to the top of the freshest-first
+		// browse. The trustworthy publish timestamp is the visible <time class="basic-date"
+		// datetime> element, so read that; a missing element leaves posted_at unset.
+		PostedAt: parseRFC3339(sources.ElementAttr(node, "time", "basic-date", "datetime")),
 	}, true, nil
 }
 

--- a/internal/linksource/habrcareer_test.go
+++ b/internal/linksource/habrcareer_test.go
@@ -9,18 +9,23 @@ import (
 
 // habrVacancyHTML is a career.habr.com vacancy page reduced to the schema.org JobPosting
 // ld+json block the adapter reads (address is a bare string, as Habr emits it; the
-// description carries an entity and a <script> to prove sanitization).
+// description carries an entity and a <script> to prove sanitization). The ld+json
+// datePosted is intentionally bogus (a month ahead, like Habr's real output) and the
+// trustworthy date lives in the <time class="basic-date" datetime> element — the adapter
+// must read the <time>, not datePosted.
 const habrVacancyHTML = `<html><head>
 <script type="application/ld+json">
 {"@context":"https://schema.org/","@type":"JobPosting",
  "title":"Junior Product Manager (Дистанционный мониторинг)",
- "datePosted":"2026-05-28",
+ "datePosted":"2026-07-14",
+ "validThrough":"2026-08-13",
  "description":"<p>Обязанности &amp; требования</p><script>alert(1)<\/script><ul><li>REST</li></ul>",
  "identifier":{"@type":"PropertyValue","name":"СберЗдоровье","value":"1000166712"},
  "hiringOrganization":{"@type":"Organization","name":"СберЗдоровье"},
  "jobLocation":[{"@type":"Place","address":"Москва"}],
  "employmentType":"FULL_TIME"}
-</script></head><body><h1>Junior Product Manager</h1></body></html>`
+</script></head><body><h1>Junior Product Manager</h1>
+<time class="basic-date" datetime="2026-05-28T12:27:19+03:00">28 мая</time></body></html>`
 
 // habrListingHTML is what u.habr.com/fq3n5 ("Больше вакансий") resolves to: the vacancies
 // index, which carries no single JobPosting.
@@ -56,8 +61,10 @@ func TestHabrCareerResolvesShortLinkToVacancy(t *testing.T) {
 	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "<li>REST</li>") {
 		t.Errorf("Description not sanitized/decoded: %q", job.Description)
 	}
-	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC)) {
-		t.Errorf("PostedAt = %v, want 2026-05-28", job.PostedAt)
+	// From the <time datetime> (12:27:19+03:00 → 09:27:19 UTC), NOT the bogus ld+json
+	// datePosted (2026-07-14).
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2026, 5, 28, 9, 27, 19, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-05-28T09:27:19Z from <time>, not ld+json datePosted", job.PostedAt)
 	}
 }
 

--- a/internal/linksource/helpers.go
+++ b/internal/linksource/helpers.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/strelov1/freehire/internal/sources"
 )
 
 // monetaryAmount is the schema.org MonetaryAmount shape JobPosting ld+json uses for
@@ -70,7 +72,7 @@ func parseDate(s string) *time.Time {
 	if err != nil {
 		return nil
 	}
-	return &t
+	return sources.NotFuture(&t)
 }
 
 // parseRFC3339 parses an RFC3339 timestamp in UTC, returning nil for an empty or
@@ -85,7 +87,7 @@ func parseRFC3339(s string) *time.Time {
 		return nil
 	}
 	t = t.UTC()
-	return &t
+	return sources.NotFuture(&t)
 }
 
 // humanizeBoard turns an ATS board slug into a display company name ("ruby-labs" → "Ruby

--- a/internal/sources/helpers_unit_test.go
+++ b/internal/sources/helpers_unit_test.go
@@ -1,6 +1,29 @@
 package sources
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+func TestNotFuture(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-72 * time.Hour)
+	soon := now.Add(time.Hour) // within the skew grace (clock skew / timezone-ahead date-only)
+	future := now.Add(30 * 24 * time.Hour)
+
+	if got := NotFuture(nil); got != nil {
+		t.Errorf("NotFuture(nil) = %v, want nil", got)
+	}
+	if got := NotFuture(&past); got == nil || !got.Equal(past) {
+		t.Errorf("NotFuture(past) = %v, want it unchanged", got)
+	}
+	if got := NotFuture(&soon); got == nil || !got.Equal(soon) {
+		t.Errorf("NotFuture(now+1h) = %v, want it kept within the skew grace", got)
+	}
+	if got := NotFuture(&future); got != nil {
+		t.Errorf("NotFuture(now+30d) = %v, want nil (a posting can't be from the future)", got)
+	}
+}
 
 func TestFirstNonEmpty(t *testing.T) {
 	cases := []struct {

--- a/internal/sources/html.go
+++ b/internal/sources/html.go
@@ -93,6 +93,44 @@ func itempropHTML(root *html.Node, prop string) string {
 	return innerHTML(best)
 }
 
+// ElementAttr is the exported form of elementAttr, for sibling packages (e.g.
+// internal/linksource) that read a single attribute off a server-rendered element — e.g.
+// the datetime of a <time class="..."> publish-date element.
+func ElementAttr(root *html.Node, tag, class, name string) string {
+	return elementAttr(root, tag, class, name)
+}
+
+// elementAttr returns the named attribute of the first <tag> element whose class list
+// contains class, or "" when none matches. An empty class matches any element of that tag.
+func elementAttr(root *html.Node, tag, class, name string) string {
+	var found string
+	walk(root, func(n *html.Node) bool {
+		if found != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == tag && hasClass(n, class) {
+			found = attr(n, name)
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// hasClass reports whether n's space-separated class attribute contains class; an empty
+// class matches any element.
+func hasClass(n *html.Node, class string) bool {
+	if class == "" {
+		return true
+	}
+	for _, c := range strings.Fields(attr(n, "class")) {
+		if c == class {
+			return true
+		}
+	}
+	return false
+}
+
 // metaProperty returns the content of <meta property="..."> (e.g. og:title), or "".
 func metaProperty(root *html.Node, property string) string {
 	var found string

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -187,6 +187,25 @@ func workplaceTypeMode(t string) string {
 	}
 }
 
+// maxPostedAtSkew is how far past "now" a posted_at may sit before NotFuture treats it as
+// bogus rather than clock skew or a timezone-ahead date-only value (a UTC+14 "today" parses
+// to a UTC instant a few hours ahead). Comfortably larger than any real skew, far smaller
+// than the month-scale errors a misread deadline/validThrough or wrong year produces.
+const maxPostedAtSkew = 48 * time.Hour
+
+// NotFuture drops a posted_at that lies meaningfully in the future: a posting cannot be
+// published after now, so such a value is a source or parse artifact (a deadline misread as
+// the publish date, a wrong year) that would otherwise sort the job to the very top of the
+// "freshest first" browse. It returns nil — the job reads as undated rather than freshest —
+// instead of clamping to now, so a bogus date can't masquerade as fresh. A nil or in-range
+// time passes through unchanged. Every adapter's date parser funnels through it.
+func NotFuture(t *time.Time) *time.Time {
+	if t != nil && t.After(time.Now().Add(maxPostedAtSkew)) {
+		return nil
+	}
+	return t
+}
+
 // parseLayout parses a platform timestamp with the given layout into a posted_at,
 // returning nil on an empty or unparseable value (posted_at is nullable — a missing or
 // malformed date is not an error).
@@ -198,7 +217,7 @@ func parseLayout(layout, s string) *time.Time {
 	if err != nil {
 		return nil
 	}
-	return &t
+	return NotFuture(&t)
 }
 
 // parseRFC3339 parses an RFC3339 timestamp (the common ATS format).
@@ -246,7 +265,7 @@ func parseEpochMillis(ms int64) *time.Time {
 		return nil
 	}
 	t := time.UnixMilli(ms).UTC()
-	return &t
+	return NotFuture(&t)
 }
 
 // parseEpochSeconds converts a Unix-second timestamp into a posted_at, returning nil for
@@ -256,7 +275,7 @@ func parseEpochSeconds(s int64) *time.Time {
 		return nil
 	}
 	t := time.Unix(s, 0).UTC()
-	return &t
+	return NotFuture(&t)
 }
 
 // reg indexes sources by provider key. A duplicate key means two adapters claim the

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -339,6 +339,8 @@
   board: dune
 - company: dust
   board: dust
+- company: Edia
+  board: edia
 - company: Eigen Labs
   board: eigen-labs
 - company: Eight Sleep

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -1887,6 +1887,8 @@
   board: scminternships
 - company: StockX
   board: stockx
+- company: Stone
+  board: stone
 - company: STR
   board: systemstechnologyresearch
 - company: Strand Therapeutics


### PR DESCRIPTION
## Why

A Habr Career vacancy sat pinned to the top of the freshest-first browse despite being old: Habr's JobPosting ld+json emits a `datePosted` ~a month in the future (its `validThrough` later still), so every Habr job got a future `posted_at` and sorted to the very top under `posted_at:desc`.

## What

- **`NotFuture` clamp** (48h skew grace) in the shared `sources`/`linksource` date parsers: a `posted_at` meaningfully in the future is dropped to `nil` rather than trusted, so no source can sort a bogus-dated job to the top. Backstop for any adapter.
- **Habr reads the real date**: `habrcareer` now reads the page's `<time class="basic-date" datetime>` element (the trustworthy publish timestamp) instead of the bogus ld+json `datePosted`, via a new exported `sources.ElementAttr` helper.
- **Two new boards**: Edia (Ashby, `edia`) and Stone (Greenhouse, `stone`, ~420 postings) — both validated live against the adapters' endpoints and the registry loader.

## Test

`go build/vet/test ./...` green; `gofmt` clean. New `TestNotFuture`; `habrcareer_test` fixture updated to carry a bogus future `datePosted` + a real `<time>`, asserting the `<time>` wins.

## Ops note

This stops new bad dates. Existing Habr rows in prod keep their future `posted_at` until re-ingested — a one-off `UPDATE jobs SET posted_at = NULL WHERE posted_at > now() + interval '48 hours';` + reindex clears them.