### PR TITLE
feat(linksource): follow Lever + Workable post links; add 3 ATS boards

### DIFF
--- a/internal/linksource/helpers.go
+++ b/internal/linksource/helpers.go
@@ -75,6 +75,16 @@ func parseDate(s string) *time.Time {
 	return sources.NotFuture(&t)
 }
 
+// parseEpochMillis converts a Unix-millis timestamp into a posted_at, returning nil for a
+// zero value. Lever dates postings with createdAt in epoch millis.
+func parseEpochMillis(ms int64) *time.Time {
+	if ms == 0 {
+		return nil
+	}
+	t := time.UnixMilli(ms).UTC()
+	return sources.NotFuture(&t)
+}
+
 // parseRFC3339 parses an RFC3339 timestamp in UTC, returning nil for an empty or
 // unparseable value. RFC3339Nano accepts both fractional (Ashby's publishedAt) and plain
 // (RemoteYeah's datePosted) second forms.

--- a/internal/linksource/lever.go
+++ b/internal/linksource/lever.go
@@ -1,0 +1,98 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// lever resolves Lever-hosted vacancies. Lever is multi-tenant, so a TG link points at an
+// arbitrary company's board — many of which sources/lever.yml does not list. The adapter
+// writes the SAME identity the ingest pipeline would (source="lever", external_id=<posting
+// id>), so UpsertJob's ON CONFLICT dedups against an already-crawled company and a
+// not-yet-crawled one is added under the canonical key rather than a thin telegram dup.
+type lever struct {
+	http Client
+}
+
+// NewLever builds the Lever link-source adapter.
+func NewLever(c Client) Source { return lever{http: c} }
+
+func (lever) Source() string { return "lever" }
+
+// leverJobPath captures the company and posting UUID from a job link
+// (jobs.lever.co/<company>/<uuid>, optionally trailing /apply).
+var leverJobPath = regexp.MustCompile(`^/([^/]+)/([0-9a-fA-F-]{36})(?:/apply)?/?$`)
+
+// Match handles jobs.lever.co posting links only — a board listing (no posting id) is left
+// for the ingest adapter.
+func (lever) Match(u *url.URL) bool {
+	return host(u) == "jobs.lever.co" && leverJobPath.MatchString(u.Path)
+}
+
+// Resolve reads the public per-posting API for the linked company+id and maps it exactly as
+// the ingest lever adapter does. The posting id is globally unique, so external_id is the
+// bare id (no board prefix), matching the ingest key.
+func (l lever) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	m := leverJobPath.FindStringSubmatch(u.Path)
+	if m == nil {
+		return sources.Job{}, false, nil
+	}
+	company, id := m[1], m[2]
+
+	api := fmt.Sprintf("https://api.lever.co/v0/postings/%s/%s?mode=json", company, id)
+	var p struct {
+		ID          string `json:"id"`
+		Text        string `json:"text"`
+		HostedURL   string `json:"hostedUrl"`
+		CreatedAt   int64  `json:"createdAt"`
+		Description string `json:"description"`
+		Additional  string `json:"additional"`
+		Lists       []struct {
+			Text    string `json:"text"`
+			Content string `json:"content"`
+		} `json:"lists"`
+		Categories struct {
+			Location string `json:"location"`
+		} `json:"categories"`
+	}
+	if err := l.http.GetJSON(ctx, api, &p); err != nil {
+		return sources.Job{}, false, err
+	}
+	if p.ID == "" {
+		return sources.Job{}, false, nil // not a live posting (closed/removed) — skip
+	}
+
+	// Lever splits the body across description + lists (each a heading and its HTML items) +
+	// additional; assemble them into one document, mirroring the ingest adapter.
+	var body strings.Builder
+	body.WriteString(p.Description)
+	for _, list := range p.Lists {
+		if list.Text != "" {
+			body.WriteString("<h3>")
+			body.WriteString(list.Text)
+			body.WriteString("</h3>")
+		}
+		body.WriteString(list.Content)
+	}
+	body.WriteString(p.Additional)
+
+	return sources.Job{
+		ExternalID:  p.ID,
+		URL:         p.HostedURL,
+		Title:       p.Text,
+		Company:     humanizeBoard(company), // the per-posting API carries no company name
+		Location:    p.Categories.Location,
+		Description: sources.SanitizeHTML(body.String()),
+		Remote:      sources.IsRemote(p.Categories.Location),
+		PostedAt:    parseEpochMillis(p.CreatedAt),
+	}, true, nil
+}

--- a/internal/linksource/lever_test.go
+++ b/internal/linksource/lever_test.go
@@ -1,0 +1,89 @@
+package linksource
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// leverPostingJSON mirrors the public per-posting API (mode=json): a single posting whose
+// body is split across description/lists/additional, with createdAt in epoch millis.
+const leverPostingJSON = `{
+ "id": "52c01c91-582c-42fc-8722-82c3eeb9ed24",
+ "text": "Senior Backend Engineer",
+ "hostedUrl": "https://jobs.lever.co/offchainlabs/52c01c91-582c-42fc-8722-82c3eeb9ed24",
+ "createdAt": 1700000000000,
+ "description": "<p>Build it.</p>",
+ "additional": "<p>Perks.</p><script>evil()</script>",
+ "lists": [{"text": "Requirements", "content": "<ul><li>Go</li></ul>"}],
+ "categories": {"location": "Remote"}
+}`
+
+func TestLeverResolvesAlignedIdentity(t *testing.T) {
+	const link = "https://jobs.lever.co/offchainlabs/52c01c91-582c-42fc-8722-82c3eeb9ed24/apply?source=web3.career"
+	c := (&fakeClient{}).route("api.lever.co/v0/postings/offchainlabs/52c01c91-582c-42fc-8722-82c3eeb9ed24", leverPostingJSON, "")
+
+	job, ok, err := NewLever(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	// Lever posting ids are globally unique, so the ingest adapter keys external_id on the
+	// bare id; the link-source must match that exactly to dedup against an ingested board
+	// rather than write a thin telegram-source duplicate.
+	if job.ExternalID != "52c01c91-582c-42fc-8722-82c3eeb9ed24" {
+		t.Errorf("ExternalID = %q, want the bare posting id", job.ExternalID)
+	}
+	if job.URL != "https://jobs.lever.co/offchainlabs/52c01c91-582c-42fc-8722-82c3eeb9ed24" {
+		t.Errorf("URL = %q", job.URL)
+	}
+	if job.Title != "Senior Backend Engineer" {
+		t.Errorf("Title = %q", job.Title)
+	}
+	// The per-posting API carries no company name, so the board slug is humanized.
+	if job.Company != "Offchainlabs" {
+		t.Errorf("Company = %q, want Offchainlabs", job.Company)
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true (Remote)")
+	}
+	if strings.Contains(job.Description, "<script>") || strings.Contains(job.Description, "evil()") {
+		t.Errorf("Description not sanitized: %q", job.Description)
+	}
+	for _, want := range []string{"Build it.", "Requirements", "Go", "Perks."} {
+		if !strings.Contains(job.Description, want) {
+			t.Errorf("Description missing %q: %q", want, job.Description)
+		}
+	}
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2023, 11, 14, 22, 13, 20, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2023-11-14T22:13:20Z", job.PostedAt)
+	}
+}
+
+func TestLeverMatch(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"https://jobs.lever.co/offchainlabs/52c01c91-582c-42fc-8722-82c3eeb9ed24", true},
+		{"https://jobs.lever.co/offchainlabs/52c01c91-582c-42fc-8722-82c3eeb9ed24/apply", true},
+		{"https://jobs.lever.co/offchainlabs", false},        // board listing, not one posting
+		{"https://job-boards.greenhouse.io/x/jobs/1", false}, // other host
+	}
+	for _, tc := range cases {
+		u, _ := url.Parse(tc.raw)
+		if got := NewLever(nil).Match(u); got != tc.want {
+			t.Errorf("Match(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestLeverSourceKeyMatchesIngestProvider(t *testing.T) {
+	if got := NewLever(nil).Source(); got != "lever" {
+		t.Errorf("Source() = %q, want lever", got)
+	}
+}

--- a/internal/linksource/registry.go
+++ b/internal/linksource/registry.go
@@ -46,6 +46,8 @@ func All(c Client) []Source {
 		NewGeekjob(c),
 		NewGreenhouse(c),
 		NewAshby(c),
+		NewLever(c),
+		NewWorkable(c),
 	}
 }
 

--- a/internal/linksource/workable.go
+++ b/internal/linksource/workable.go
@@ -1,0 +1,97 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// workable resolves Workable-hosted vacancies. Workable is multi-tenant, so a TG link points
+// at an arbitrary account's board. The adapter writes the SAME identity the ingest pipeline
+// would (source="workable", external_id=<shortcode>), so UpsertJob's ON CONFLICT dedups
+// against an already-crawled account rather than writing a thin telegram duplicate.
+type workable struct {
+	http Client
+}
+
+// NewWorkable builds the Workable link-source adapter.
+func NewWorkable(c Client) Source { return workable{http: c} }
+
+func (workable) Source() string { return "workable" }
+
+// workableJobPath captures the account and posting shortcode from a job link
+// (apply.workable.com/<account>/j/<shortcode>, optionally trailing /apply).
+var workableJobPath = regexp.MustCompile(`^/([^/]+)/j/([0-9A-Za-z]+)(?:/apply)?/?$`)
+
+// Match handles apply.workable.com posting links only — an account's board (no /j/<code>) is
+// left for the ingest adapter.
+func (workable) Match(u *url.URL) bool {
+	return host(u) == "apply.workable.com" && workableJobPath.MatchString(u.Path)
+}
+
+// Resolve reads the account's public widget board (the only public endpoint; it carries
+// every job inline with details=true) and returns the job whose shortcode the link names,
+// mapped exactly as the ingest workable adapter does. A shortcode no longer on the board
+// (closed/removed) yields ok=false.
+func (w workable) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	m := workableJobPath.FindStringSubmatch(u.Path)
+	if m == nil {
+		return sources.Job{}, false, nil
+	}
+	account, shortcode := m[1], m[2]
+
+	api := fmt.Sprintf("https://apply.workable.com/api/v1/widget/accounts/%s?details=true", account)
+	var resp struct {
+		Jobs []struct {
+			Title         string `json:"title"`
+			Shortcode     string `json:"shortcode"`
+			URL           string `json:"url"`
+			Description   string `json:"description"`
+			PublishedOn   string `json:"published_on"`
+			City          string `json:"city"`
+			State         string `json:"state"`
+			Country       string `json:"country"`
+			Telecommuting bool   `json:"telecommuting"`
+		} `json:"jobs"`
+	}
+	if err := w.http.GetJSON(ctx, api, &resp); err != nil {
+		return sources.Job{}, false, err
+	}
+
+	for _, j := range resp.Jobs {
+		if j.Shortcode != shortcode {
+			continue
+		}
+		return sources.Job{
+			ExternalID:  j.Shortcode,
+			URL:         j.URL,
+			Title:       j.Title,
+			Company:     humanizeBoard(account), // the widget API carries no company name
+			Location:    joinNonEmpty(j.City, j.State, j.Country),
+			Description: sources.SanitizeHTML(j.Description),
+			Remote:      j.Telecommuting,
+			PostedAt:    parseDate(j.PublishedOn),
+		}, true, nil
+	}
+	return sources.Job{}, false, nil // shortcode not on the board — closed/removed
+}
+
+// joinNonEmpty joins the non-blank parts with ", " — Workable splits location across
+// city/state/country, any of which may be empty.
+func joinNonEmpty(parts ...string) string {
+	var kept []string
+	for _, p := range parts {
+		if strings.TrimSpace(p) != "" {
+			kept = append(kept, p)
+		}
+	}
+	return strings.Join(kept, ", ")
+}

--- a/internal/linksource/workable_test.go
+++ b/internal/linksource/workable_test.go
@@ -1,0 +1,88 @@
+package linksource
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// workableBoardJSON mirrors the public widget API (details=true): all of an account's jobs
+// inline, each with its shortcode — the link-source picks the one the link names.
+const workableBoardJSON = `{
+ "jobs": [
+   {"title": "Frontend Engineer", "shortcode": "AAAA111111", "url": "https://apply.workable.com/jobhire/j/AAAA111111", "description": "<p>Other role.</p>", "published_on": "2026-05-01", "city": "Limassol", "country": "Cyprus", "telecommuting": false},
+   {"title": "Lead AI Product Manager", "shortcode": "915C6E469E", "url": "https://apply.workable.com/jobhire/j/915C6E469E", "description": "<p>Own it.</p><script>x()</script>", "published_on": "2026-06-10", "city": "", "country": "Cyprus", "telecommuting": true}
+ ]
+}`
+
+func TestWorkableResolvesNamedShortcode(t *testing.T) {
+	const link = "https://apply.workable.com/jobhire/j/915C6E469E"
+	c := (&fakeClient{}).route("api/v1/widget/accounts/jobhire", workableBoardJSON, "")
+
+	job, ok, err := NewWorkable(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the named vacancy resolved")
+	}
+	// external_id is the shortcode, matching what the ingest workable adapter writes, so the
+	// same vacancy crawled directly dedups instead of duplicating.
+	if job.ExternalID != "915C6E469E" {
+		t.Errorf("ExternalID = %q, want 915C6E469E", job.ExternalID)
+	}
+	if job.Title != "Lead AI Product Manager" {
+		t.Errorf("Title = %q (picked wrong shortcode?)", job.Title)
+	}
+	if job.Company != "Jobhire" {
+		t.Errorf("Company = %q, want Jobhire (humanized account)", job.Company)
+	}
+	if job.Location != "Cyprus" {
+		t.Errorf("Location = %q, want Cyprus", job.Location)
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true (telecommuting)")
+	}
+	if got := job.Description; strings.Contains(got, "<script>") || strings.Contains(got, "x()") || !strings.Contains(got, "Own it.") {
+		t.Errorf("Description not sanitized/assembled: %q", got)
+	}
+}
+
+// A link whose shortcode is not on the board (closed/removed) is matched but unresolved.
+func TestWorkableUnknownShortcodeSkips(t *testing.T) {
+	const link = "https://apply.workable.com/jobhire/j/ZZZZ999999"
+	c := (&fakeClient{}).route("api/v1/widget/accounts/jobhire", workableBoardJSON, "")
+
+	_, ok, err := NewWorkable(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ok {
+		t.Error("ok=true, want false for a shortcode not on the board")
+	}
+}
+
+func TestWorkableMatch(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"https://apply.workable.com/jobhire/j/915C6E469E", true},
+		{"https://apply.workable.com/jobhire/j/915C6E469E/apply", true},
+		{"https://apply.workable.com/jobhire", false}, // board, not one posting
+		{"https://jobs.lever.co/x/abc", false},        // other host
+	}
+	for _, tc := range cases {
+		u, _ := url.Parse(tc.raw)
+		if got := NewWorkable(nil).Match(u); got != tc.want {
+			t.Errorf("Match(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestWorkableSourceKeyMatchesIngestProvider(t *testing.T) {
+	if got := NewWorkable(nil).Source(); got != "workable" {
+		t.Errorf("Source() = %q, want workable", got)
+	}
+}

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -185,6 +185,8 @@
   board: nkarchitects
 - company: Ogilvy
   board: ogilvy
+- company: OneMarketData
+  board: onemarketdata
 - company: Onward Search
   board: onwardsearch
 - company: Outpost

--- a/sources/huntflow.yml
+++ b/sources/huntflow.yml
@@ -28,3 +28,5 @@
   board: telematika
 - company: Tripster
   board: tripster
+- company: Vinou
+  board: vinou

--- a/sources/telegram.yml
+++ b/sources/telegram.yml
@@ -18,6 +18,8 @@ channels:
     kind: authored
   - channel: budujobs
     kind: authored
+  - channel: streltsova_anastasiya
+    kind: authored
 
   # --- General IT boards ---
   - channel: it_vakansii_jobs

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -75,6 +75,8 @@
   board: integrant
 - company: Jagex
   board: jagex-limited
+- company: JobHire
+  board: jobhire
 - company: KingsIsle Entertainment
   board: kingsisle-entertainment-inc
 - company: Lakshya Digital


### PR DESCRIPTION
## What

- **New link-source adapters: Lever + Workable.** Outbound `jobs.lever.co/<co>/<id>` and `apply.workable.com/<acct>/j/<shortcode>` links in Telegram posts now resolve to a full vacancy under the destination's own ATS identity (`source=lever`/`workable`, `external_id` = posting id / shortcode), so they dedup against the same posting the ingest crawl writes instead of producing a thin `source=telegram` duplicate. Mirrors the existing Greenhouse/Ashby link-source adapters.
- **3 live-validated boards** added to their per-provider files: `JobHire` (workable, 32 jobs), `OneMarketData` (bamboohr, 16), `Vinou` (huntflow).
- **Track `streltsova_anastasiya`** Telegram channel (authored GameDev).

## Why

Both Lever and Workable already have ingest **source** adapters, but no **linksource** adapter — so links to them in TG posts fell through to the LLM text path instead of resolving cleanly. This closes that gap (the two ATSes most-linked in our channels).

## Verification

- TDD: `internal/linksource/{lever,workable}_test.go` (RED→GREEN), fake-client mapping + `Match` + identity-alignment.
- Live end-to-end: both real links resolve 2/2 against the public APIs.
- `go test ./internal/...` green; `go build`, `go vet`, `gofmt` clean.
- All board files validate against the adapter registry.

No migrations, no schema/search-field changes.