### PR TITLE
perf(search): split reindex into fast facet pass + rare embedder pass

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -10,14 +10,23 @@
 //   - reindex --semantic: the hybrid index (adds the in-engine embedder). Slower
 //     (it embeds new/changed documents); run on its own, looser schedule and only
 //     while semantic search is enabled — it never blocks the facet pass.
+//
+// --since <duration> scopes either pass to jobs changed within that window
+// (keyed on updated_at), so a frequent run re-pushes only the delta instead of
+// the whole table. Meilisearch already skips re-embedding unchanged documents;
+// --since additionally skips reading and re-pushing them at all.
 package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
@@ -49,6 +58,26 @@ func semanticOps(c *search.Client) indexOps {
 	return indexOps{"semantic", c.EnsureSemanticIndex, c.IndexSemanticJobs, c.DeleteSemanticJobs}
 }
 
+// pageFetcher returns the next keyset page of jobs after the given id (empty when
+// the scan is exhausted). The full scan returns every job; the incremental scan
+// (reindex --since) returns only those changed at or after a cutoff.
+type pageFetcher func(ctx context.Context, afterID int64) ([]db.Job, error)
+
+func fullScan(q *db.Queries) pageFetcher {
+	return func(ctx context.Context, afterID int64) ([]db.Job, error) {
+		return q.ListJobsByIDAfter(ctx, db.ListJobsByIDAfterParams{AfterID: afterID, BatchSize: reindexBatchSize})
+	}
+}
+
+func incrementalScan(q *db.Queries, since time.Time) pageFetcher {
+	cutoff := pgtype.Timestamptz{Time: since, Valid: true}
+	return func(ctx context.Context, afterID int64) ([]db.Job, error) {
+		return q.ListJobsUpdatedAfter(ctx, db.ListJobsUpdatedAfterParams{
+			AfterID: afterID, Since: cutoff, BatchSize: reindexBatchSize,
+		})
+	}
+}
+
 // progressInterval is how often reindex emits a heartbeat with its running totals.
 // A full reindex pushes hundreds of thousands of docs to Meilisearch and otherwise
 // logs only on completion, so the heartbeat distinguishes a slow run from a stalled
@@ -76,21 +105,63 @@ func run() int {
 	}
 
 	client := search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
+	q := db.New(pool)
 
 	ops := facetOps(client)
 	if semanticRequested(os.Args[1:]) {
 		ops = semanticOps(client)
 	}
-	log.Printf("reindex: target=%s index", ops.name)
 
-	indexed, deleted, err := reindexAll(ctx, db.New(pool), ops)
+	fetch := fullScan(q)
+	scope := "full"
+	since, incremental, err := sinceFrom(os.Args[1:])
+	if err != nil {
+		log.Printf("reindex: %v", err)
+		return 1
+	}
+	if incremental {
+		fetch = incrementalScan(q, time.Now().Add(-since))
+		scope = "since " + since.String()
+	}
+	log.Printf("reindex: target=%s scope=%s", ops.name, scope)
+
+	indexed, deleted, err := reindexAll(ctx, fetch, ops)
 	if err != nil {
 		log.Printf("reindex: %v", err)
 		return 1
 	}
 
-	log.Printf("reindex done: target=%s indexed=%d deleted=%d", ops.name, indexed, deleted)
+	log.Printf("reindex done: target=%s scope=%s indexed=%d deleted=%d", ops.name, scope, indexed, deleted)
 	return 0
+}
+
+// sinceFrom parses an optional --since <duration> / --since=<duration> flag (e.g.
+// "50h"). It reports (duration, true, nil) when present, (0, false, nil) when
+// absent, and an error for a missing or unparseable value.
+func sinceFrom(args []string) (time.Duration, bool, error) {
+	for i, a := range args {
+		var raw string
+		switch {
+		case a == "--since":
+			if i+1 >= len(args) {
+				return 0, false, fmt.Errorf("--since needs a duration (e.g. 50h)")
+			}
+			raw = args[i+1]
+		case strings.HasPrefix(a, "--since="):
+			raw = strings.TrimPrefix(a, "--since=")
+		default:
+			continue
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return 0, false, fmt.Errorf("--since %q: %w", raw, err)
+		}
+		if d <= 0 {
+			return 0, false, fmt.Errorf("--since must be positive, got %q", raw)
+		}
+		return d, true, nil
+	}
+	return 0, false, nil
 }
 
 // semanticRequested reports whether the args ask for the hybrid (embedder) pass.
@@ -103,11 +174,11 @@ func semanticRequested(args []string) bool {
 	return false
 }
 
-// reindexAll ensures the index and streams every job through it in batches,
-// returning how many documents were indexed (open jobs) and deleted (closed
-// jobs). It pages by keyset (id > last seen), so rows inserted or re-ordered
-// during the run cannot be skipped or repeated.
-func reindexAll(ctx context.Context, q *db.Queries, ops indexOps) (int, int, error) {
+// reindexAll ensures the index and streams jobs through it in batches, returning
+// how many documents were indexed (open jobs) and deleted (closed jobs). fetch
+// pages by keyset (id > last seen) — full or incremental (--since) — so rows
+// inserted or re-ordered during the run cannot be skipped or repeated.
+func reindexAll(ctx context.Context, fetch pageFetcher, ops indexOps) (int, int, error) {
 	if err := ops.ensure(ctx); err != nil {
 		return 0, 0, err
 	}
@@ -123,10 +194,7 @@ func reindexAll(ctx context.Context, q *db.Queries, ops indexOps) (int, int, err
 
 	var afterID int64
 	for {
-		jobs, err := q.ListJobsByIDAfter(ctx, db.ListJobsByIDAfterParams{
-			AfterID:   afterID,
-			BatchSize: reindexBatchSize,
-		})
+		jobs, err := fetch(ctx, afterID)
 		if err != nil {
 			return int(indexed.Load()), int(deleted.Load()), err
 		}

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -1,7 +1,15 @@
-// Command reindex rebuilds the Meilisearch jobs index from Postgres. It ensures
-// the index settings exist, then scans jobs in batches and upserts their
-// documents. Run it on a schedule (e.g. cron); it processes the whole table and
-// exits. Indexing is idempotent (upsert by id), so re-runs are safe.
+// Command reindex rebuilds a Meilisearch jobs index from Postgres. It ensures the
+// index settings exist, then scans jobs in batches and upserts their documents.
+// Run it on a schedule (e.g. cron); it processes the whole table and exits.
+// Indexing is idempotent (upsert by id), so re-runs are safe.
+//
+// Two passes share this binary:
+//
+//   - default: the facet/keyword index (no embedder) — the fast, always-fresh
+//     production search. A full rebuild is minutes, not hours.
+//   - reindex --semantic: the hybrid index (adds the in-engine embedder). Slower
+//     (it embeds new/changed documents); run on its own, looser schedule and only
+//     while semantic search is enabled — it never blocks the facet pass.
 package main
 
 import (
@@ -17,8 +25,29 @@ import (
 )
 
 // reindexBatchSize bounds how many jobs are read from Postgres and pushed to
-// Meilisearch per round. A const for now; promote to config if it needs tuning.
-const reindexBatchSize = 500
+// Meilisearch per round. Once the facet index dropped the per-document embedder,
+// the per-batch round-trip became the throughput lever, so the batch is sized up
+// from 500 to amortize it (Postgres read and the ~7KB-doc payload are both cheap
+// at this size). A const for now; promote to config if it needs tuning.
+const reindexBatchSize = 2000
+
+// indexOps is the set of index operations a reindex pass drives. The default pass
+// targets the facet/keyword index; --semantic targets the hybrid index. Selecting
+// ops up front keeps the streaming loop identical for both.
+type indexOps struct {
+	name   string
+	ensure func(context.Context) error
+	index  func(context.Context, []search.JobDocument) error
+	remove func(context.Context, []int64) error
+}
+
+func facetOps(c *search.Client) indexOps {
+	return indexOps{"facet", c.EnsureIndex, c.IndexJobs, c.DeleteJobs}
+}
+
+func semanticOps(c *search.Client) indexOps {
+	return indexOps{"semantic", c.EnsureSemanticIndex, c.IndexSemanticJobs, c.DeleteSemanticJobs}
+}
 
 // progressInterval is how often reindex emits a heartbeat with its running totals.
 // A full reindex pushes hundreds of thousands of docs to Meilisearch and otherwise
@@ -48,22 +77,38 @@ func run() int {
 
 	client := search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
 
-	indexed, deleted, err := reindexAll(ctx, db.New(pool), client)
+	ops := facetOps(client)
+	if semanticRequested(os.Args[1:]) {
+		ops = semanticOps(client)
+	}
+	log.Printf("reindex: target=%s index", ops.name)
+
+	indexed, deleted, err := reindexAll(ctx, db.New(pool), ops)
 	if err != nil {
 		log.Printf("reindex: %v", err)
 		return 1
 	}
 
-	log.Printf("reindex done: indexed=%d deleted=%d", indexed, deleted)
+	log.Printf("reindex done: target=%s indexed=%d deleted=%d", ops.name, indexed, deleted)
 	return 0
+}
+
+// semanticRequested reports whether the args ask for the hybrid (embedder) pass.
+func semanticRequested(args []string) bool {
+	for _, a := range args {
+		if a == "--semantic" || a == "semantic" {
+			return true
+		}
+	}
+	return false
 }
 
 // reindexAll ensures the index and streams every job through it in batches,
 // returning how many documents were indexed (open jobs) and deleted (closed
 // jobs). It pages by keyset (id > last seen), so rows inserted or re-ordered
 // during the run cannot be skipped or repeated.
-func reindexAll(ctx context.Context, q *db.Queries, client *search.Client) (int, int, error) {
-	if err := client.EnsureIndex(ctx); err != nil {
+func reindexAll(ctx context.Context, q *db.Queries, ops indexOps) (int, int, error) {
+	if err := ops.ensure(ctx); err != nil {
 		return 0, 0, err
 	}
 
@@ -94,10 +139,10 @@ func reindexAll(ctx context.Context, q *db.Queries, client *search.Client) (int,
 		if err != nil {
 			return int(indexed.Load()), int(deleted.Load()), err
 		}
-		if err := client.IndexJobs(ctx, docs); err != nil {
+		if err := ops.index(ctx, docs); err != nil {
 			return int(indexed.Load()), int(deleted.Load()), err
 		}
-		if err := client.DeleteJobs(ctx, deleteIDs); err != nil {
+		if err := ops.remove(ctx, deleteIDs); err != nil {
 			return int(indexed.Load()), int(deleted.Load()), err
 		}
 		indexed.Add(int64(len(docs)))

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -2,11 +2,49 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 )
+
+func TestSinceFrom(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantDur time.Duration
+		wantOK  bool
+		wantErr bool
+	}{
+		{"absent", []string{"--semantic"}, 0, false, false},
+		{"space form", []string{"--semantic", "--since", "50h"}, 50 * time.Hour, true, false},
+		{"equals form", []string{"--since=24h"}, 24 * time.Hour, true, false},
+		{"missing value", []string{"--since"}, 0, false, true},
+		{"unparseable", []string{"--since", "soon"}, 0, false, true},
+		{"non-positive", []string{"--since", "0h"}, 0, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dur, ok, err := sinceFrom(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if ok != tt.wantOK || dur != tt.wantDur {
+				t.Errorf("got (%v, %v), want (%v, %v)", dur, ok, tt.wantDur, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestSemanticRequested(t *testing.T) {
+	if !semanticRequested([]string{"--since", "50h", "--semantic"}) {
+		t.Error("--semantic should be detected among other args")
+	}
+	if semanticRequested([]string{"--since", "50h"}) {
+		t.Error("facet pass must not be misread as semantic")
+	}
+}
 
 // The reindex feed deliberately includes closed jobs: open ones are upserted as
 // documents, closed ones become deletions so they leave the index (job-search

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -394,6 +394,75 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 	return items, nil
 }
 
+const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by
+FROM jobs
+WHERE id > $1 AND updated_at >= $2
+ORDER BY id
+LIMIT $3
+`
+
+type ListJobsUpdatedAfterParams struct {
+	AfterID   int64              `json:"after_id"`
+	Since     pgtype.Timestamptz `json:"since"`
+	BatchSize int32              `json:"batch_size"`
+}
+
+// Incremental keyset scan for `reindex --since`: like ListJobsByIDAfter but only
+// rows changed at or after the cutoff. Every write path (UpsertJob, the close
+// sweeps, SetJobEnrichment, UpdateJobFacets) stamps updated_at = now(), so this
+// captures new, re-crawled, closed, and re-enriched jobs — enough to bring an
+// index current without re-pushing the whole table. Returns closed rows too, so
+// the caller deletes a freshly-closed job from the index.
+func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedAfterParams) ([]Job, error) {
+	rows, err := q.db.Query(ctx, listJobsUpdatedAfter, arg.AfterID, arg.Since, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Job{}
+	for rows.Next() {
+		var i Job
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.ExternalID,
+			&i.URL,
+			&i.Title,
+			&i.Company,
+			&i.Location,
+			&i.Remote,
+			&i.Description,
+			&i.PostedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.CompanySlug,
+			&i.Enrichment,
+			&i.EnrichedAt,
+			&i.EnrichmentVersion,
+			&i.PublicSlug,
+			&i.LastSeenAt,
+			&i.ClosedAt,
+			&i.Countries,
+			&i.Regions,
+			&i.WorkMode,
+			&i.LivenessStrikes,
+			&i.Skills,
+			&i.Seniority,
+			&i.Category,
+			&i.CreatedBy,
+			&i.UpdatedBy,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markLivenessExpired = `-- name: MarkLivenessExpired :one
 UPDATE jobs
 SET liveness_strikes = liveness_strikes + 1,

--- a/internal/db/jobs_reindex_integration_test.go
+++ b/internal/db/jobs_reindex_integration_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+// Integration test for the incremental reindex feed (ListJobsUpdatedAfter): it
+// must return only rows changed at or after the cutoff, and must include
+// freshly-closed rows (so the reindex --since pass can delete them from the
+// index). Verifiable only against real Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestListJobsUpdatedAfter(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	old, err := q.UpsertJob(ctx, ingestParams("acme:old", "Old"))
+	if err != nil {
+		t.Fatalf("upsert old: %v", err)
+	}
+	recent, err := q.UpsertJob(ctx, ingestParams("acme:recent", "Recent"))
+	if err != nil {
+		t.Fatalf("upsert recent: %v", err)
+	}
+
+	// Pin updated_at to controlled instants so the cutoff boundary is deterministic
+	// (UpsertJob stamps now(), which would put both rows on the same side).
+	before := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	after := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	cutoff := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET updated_at = $1 WHERE id = $2`, before, old.ID); err != nil {
+		t.Fatalf("pin old updated_at: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE jobs SET updated_at = $1 WHERE id = $2`, after, recent.ID); err != nil {
+		t.Fatalf("pin recent updated_at: %v", err)
+	}
+
+	params := func(since time.Time) ListJobsUpdatedAfterParams {
+		return ListJobsUpdatedAfterParams{
+			AfterID:   0,
+			Since:     pgtype.Timestamptz{Time: since, Valid: true},
+			BatchSize: 100,
+		}
+	}
+
+	t.Run("returns only rows at or after the cutoff", func(t *testing.T) {
+		got, err := q.ListJobsUpdatedAfter(ctx, params(cutoff))
+		if err != nil {
+			t.Fatalf("ListJobsUpdatedAfter: %v", err)
+		}
+		if len(got) != 1 || got[0].ID != recent.ID {
+			t.Fatalf("got %v, want only the recent job %d", jobIDs(got), recent.ID)
+		}
+	})
+
+	t.Run("includes a freshly-closed row so it can leave the index", func(t *testing.T) {
+		// Closing stamps updated_at = now(); simulate that landing after the cutoff.
+		if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = $1, updated_at = $1 WHERE id = $2`, after, old.ID); err != nil {
+			t.Fatalf("close old: %v", err)
+		}
+		got, err := q.ListJobsUpdatedAfter(ctx, params(cutoff))
+		if err != nil {
+			t.Fatalf("ListJobsUpdatedAfter: %v", err)
+		}
+		var sawClosedOld bool
+		for _, j := range got {
+			if j.ID == old.ID {
+				sawClosedOld = j.ClosedAt.Valid
+			}
+		}
+		if !sawClosedOld {
+			t.Fatalf("recently-closed job %d missing from incremental feed (ids %v)", old.ID, jobIDs(got))
+		}
+	})
+}
+
+func jobIDs(jobs []Job) []int64 {
+	out := make([]int64, len(jobs))
+	for i, j := range jobs {
+		out[i] = j.ID
+	}
+	return out
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -155,6 +155,13 @@ type Querier interface {
 	// concurrent inserts/updates (which shift posted_at ordering) cannot make the
 	// scan skip or repeat rows the way OFFSET pagination would.
 	ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterParams) ([]Job, error)
+	// Incremental keyset scan for `reindex --since`: like ListJobsByIDAfter but only
+	// rows changed at or after the cutoff. Every write path (UpsertJob, the close
+	// sweeps, SetJobEnrichment, UpdateJobFacets) stamps updated_at = now(), so this
+	// captures new, re-crawled, closed, and re-enriched jobs — enough to bring an
+	// index current without re-pushing the whole table. Returns closed rows too, so
+	// the caller deletes a freshly-closed job from the index.
+	ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedAfterParams) ([]Job, error)
 	// The moderator review queue: every pending report, newest first, with the reporter's email
 	// and the reported job's slug and title so the moderator can judge it and link to it.
 	ListPendingReports(ctx context.Context) ([]ListPendingReportsRow, error)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -18,6 +18,19 @@ WHERE id > sqlc.arg(after_id)
 ORDER BY id
 LIMIT sqlc.arg(batch_size);
 
+-- name: ListJobsUpdatedAfter :many
+-- Incremental keyset scan for `reindex --since`: like ListJobsByIDAfter but only
+-- rows changed at or after the cutoff. Every write path (UpsertJob, the close
+-- sweeps, SetJobEnrichment, UpdateJobFacets) stamps updated_at = now(), so this
+-- captures new, re-crawled, closed, and re-enriched jobs — enough to bring an
+-- index current without re-pushing the whole table. Returns closed rows too, so
+-- the caller deletes a freshly-closed job from the index.
+SELECT *
+FROM jobs
+WHERE id > sqlc.arg(after_id) AND updated_at >= sqlc.arg(since)
+ORDER BY id
+LIMIT sqlc.arg(batch_size);
+
 -- name: GetJob :one
 SELECT *
 FROM jobs

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -17,10 +17,12 @@ type searcher interface {
 	Search(ctx context.Context, p search.SearchParams) (search.SearchResult, error)
 }
 
-// defaultSemanticRatio blends keyword and semantic ranking by default (hybrid
-// search is the headline feature). Clients can pass semantic_ratio=0 for pure
-// keyword search.
-const defaultSemanticRatio = 0.5
+// defaultSemanticRatio is 0 — pure keyword search against the always-fresh facet
+// index — because semantic search is opt-in: the embedder lives on a separate
+// index built by an optional reindex --semantic pass, so a default of 0 never
+// routes unprepared traffic to a stale or absent semantic index. A client opts in
+// per request with semantic_ratio>0; the SPA already does so explicitly.
+const defaultSemanticRatio = 0
 
 // maxSearchWindow bounds how deep search pagination may reach (offset+limit). It
 // is the explicit pagination guard, decoupled from the index's maxTotalHits

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -128,12 +128,24 @@ func TestSearchJobs_PaginationAtWindowBoundaryAllowed(t *testing.T) {
 	}
 }
 
-func TestSearchJobs_DefaultsToHybridSemanticRatio(t *testing.T) {
+func TestSearchJobs_DefaultsToKeywordSemanticRatio(t *testing.T) {
+	// Semantic search is opt-in: the default routes to the always-fresh facet
+	// index (ratio 0), never the separate, optionally-built semantic index.
 	fake := &fakeSearcher{}
 	app := searchApp(fake)
 	doGet(t, app, "/jobs/search?q=go")
+	if fake.got.SemanticRatio != 0 {
+		t.Errorf("default SemanticRatio = %v, want 0 (keyword)", fake.got.SemanticRatio)
+	}
+}
+
+func TestSearchJobs_SemanticRatioOptIn(t *testing.T) {
+	// An explicit semantic_ratio>0 still reaches the backend (routes to hybrid).
+	fake := &fakeSearcher{}
+	app := searchApp(fake)
+	doGet(t, app, "/jobs/search?q=go&semantic_ratio=0.5")
 	if fake.got.SemanticRatio != 0.5 {
-		t.Errorf("default SemanticRatio = %v, want 0.5", fake.got.SemanticRatio)
+		t.Errorf("opt-in SemanticRatio = %v, want 0.5", fake.got.SemanticRatio)
 	}
 }
 

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -1,8 +1,9 @@
 // Package search provides Meilisearch-backed full-text and hybrid (keyword +
-// semantic) search over jobs. It owns the index document shape, the index
-// settings (including the in-engine huggingFace embedder), and the read/write
-// helpers, so callers (the search handler and the reindex command) never touch
-// the meilisearch-go SDK directly.
+// semantic) search over jobs. It owns the document shape and two index
+// configurations — a facet/keyword index (no embedder, the fast default) and a
+// semantic index that adds the in-engine huggingFace embedder — plus the
+// read/write helpers, so callers (the search handler and the reindex command)
+// never touch the meilisearch-go SDK directly.
 package search
 
 import (
@@ -15,9 +16,17 @@ import (
 )
 
 const (
-	indexUID     = "jobs"
-	primaryKey   = "id"
-	embedderName = "default"
+	// facetIndexUID is the production search index: keyword + facets, NO embedder,
+	// so a full rebuild is ~25x faster than embedding every document. It serves all
+	// default (keyword) traffic and the facet analytics.
+	facetIndexUID = "jobs"
+	// semanticIndexUID is the optional hybrid index: the same documents plus the
+	// in-engine embedder. It is built by a separate, slower pass (reindex
+	// --semantic) and only queried when SemanticRatio > 0, so embedding never
+	// blocks facet/keyword freshness.
+	semanticIndexUID = "jobs_semantic"
+	primaryKey       = "id"
+	embedderName     = "default"
 	// embedderModel runs inside Meilisearch (source huggingFace), so hybrid
 	// search needs no external API key. Multilingual + CPU-friendly.
 	embedderModel = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
@@ -37,32 +46,46 @@ const (
 	taskPollInterval = 50 * time.Millisecond
 )
 
-// Client is a thin wrapper over the Meilisearch service scoped to the jobs index.
+// Client is a thin wrapper over the Meilisearch service scoped to the two job
+// indexes: facet (keyword + facets, no embedder) and semantic (adds the embedder).
 type Client struct {
-	manager meilisearch.ServiceManager
-	index   meilisearch.IndexManager
+	manager  meilisearch.ServiceManager
+	facet    meilisearch.IndexManager
+	semantic meilisearch.IndexManager
 }
 
 // NewClient connects to Meilisearch at url authenticated by key. It does no I/O
 // — the connection is exercised lazily by the first request (or EnsureIndex).
 func NewClient(url, key string) *Client {
 	m := meilisearch.New(url, meilisearch.WithAPIKey(key))
-	return &Client{manager: m, index: m.Index(indexUID)}
+	return &Client{manager: m, facet: m.Index(facetIndexUID), semantic: m.Index(semanticIndexUID)}
 }
 
-// EnsureIndex creates the jobs index (keyed by the internal id) if absent and
-// applies its settings: the searchable/filterable/sortable attributes, ranking
-// rules, typo tolerance, pagination cap, and the hybrid embedder. It is
-// idempotent — safe to call on every reindex.
+// EnsureIndex creates the facet/keyword jobs index (no embedder) and applies its
+// settings. It is idempotent — safe to call on every reindex. This is the fast
+// production index that all default (keyword) traffic and faceting hit.
 func (c *Client) EnsureIndex(ctx context.Context) error {
+	return c.ensure(ctx, c.facet, facetIndexUID, facetSettings())
+}
+
+// EnsureSemanticIndex creates the hybrid jobs index (with the in-engine embedder)
+// and applies its settings. It is built by the separate reindex --semantic pass;
+// querying it embeds documents, so it is kept off the default reindex path.
+func (c *Client) EnsureSemanticIndex(ctx context.Context) error {
+	return c.ensure(ctx, c.semantic, semanticIndexUID, semanticSettings())
+}
+
+// ensure creates the named index (keyed by the internal id) if absent and applies
+// its settings. Shared by the facet and semantic ensure paths.
+func (c *Client) ensure(ctx context.Context, idx meilisearch.IndexManager, uid string, settings *meilisearch.Settings) error {
 	create, err := c.manager.CreateIndexWithContext(ctx, &meilisearch.IndexConfig{
-		Uid:        indexUID,
+		Uid:        uid,
 		PrimaryKey: primaryKey,
 	})
 	if err != nil {
 		return fmt.Errorf("search: create index: %w", err)
 	}
-	created, err := c.index.WaitForTaskWithContext(ctx, create.TaskUID, taskPollInterval)
+	created, err := idx.WaitForTaskWithContext(ctx, create.TaskUID, taskPollInterval)
 	if err != nil {
 		return fmt.Errorf("search: await create index: %w", err)
 	}
@@ -71,31 +94,51 @@ func (c *Client) EnsureIndex(ctx context.Context) error {
 		return fmt.Errorf("search: create index failed: %s", created.Error.Message)
 	}
 
-	settings, err := c.index.UpdateSettingsWithContext(ctx, indexSettings())
+	st, err := idx.UpdateSettingsWithContext(ctx, settings)
 	if err != nil {
 		return fmt.Errorf("search: update settings: %w", err)
 	}
-	return c.awaitTask(ctx, settings.TaskUID)
+	return c.awaitTask(ctx, idx, st.TaskUID)
 }
 
-// IndexJobs upserts a batch of documents by primary key. A re-run with the same
-// data is a no-op upsert, keeping reindex idempotent.
+// IndexJobs upserts a batch of documents into the facet index by primary key. A
+// re-run with the same data is a no-op upsert, keeping reindex idempotent.
 func (c *Client) IndexJobs(ctx context.Context, docs []JobDocument) error {
+	return c.indexInto(ctx, c.facet, docs)
+}
+
+// IndexSemanticJobs upserts a batch into the semantic index (which embeds new or
+// changed documents). Used by the reindex --semantic pass.
+func (c *Client) IndexSemanticJobs(ctx context.Context, docs []JobDocument) error {
+	return c.indexInto(ctx, c.semantic, docs)
+}
+
+func (c *Client) indexInto(ctx context.Context, idx meilisearch.IndexManager, docs []JobDocument) error {
 	if len(docs) == 0 {
 		return nil
 	}
 	pk := primaryKey
-	task, err := c.index.UpdateDocumentsWithContext(ctx, docs, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+	task, err := idx.UpdateDocumentsWithContext(ctx, docs, &meilisearch.DocumentOptions{PrimaryKey: &pk})
 	if err != nil {
 		return fmt.Errorf("search: index documents: %w", err)
 	}
-	return c.awaitTask(ctx, task.TaskUID)
+	return c.awaitTask(ctx, idx, task.TaskUID)
 }
 
-// DeleteJobs removes documents by primary key. Used by reindex to drop closed
-// jobs from the index; deleting an id that is not indexed is a no-op, keeping
-// re-runs idempotent.
+// DeleteJobs removes documents from the facet index by primary key. Used by
+// reindex to drop closed jobs; deleting an id that is not indexed is a no-op,
+// keeping re-runs idempotent.
 func (c *Client) DeleteJobs(ctx context.Context, ids []int64) error {
+	return c.deleteFrom(ctx, c.facet, ids)
+}
+
+// DeleteSemanticJobs removes documents from the semantic index. Used by the
+// reindex --semantic pass.
+func (c *Client) DeleteSemanticJobs(ctx context.Context, ids []int64) error {
+	return c.deleteFrom(ctx, c.semantic, ids)
+}
+
+func (c *Client) deleteFrom(ctx context.Context, idx meilisearch.IndexManager, ids []int64) error {
 	if len(ids) == 0 {
 		return nil
 	}
@@ -103,11 +146,11 @@ func (c *Client) DeleteJobs(ctx context.Context, ids []int64) error {
 	for i, id := range ids {
 		keys[i] = strconv.FormatInt(id, 10)
 	}
-	task, err := c.index.DeleteDocumentsWithContext(ctx, keys, nil)
+	task, err := idx.DeleteDocumentsWithContext(ctx, keys, nil)
 	if err != nil {
 		return fmt.Errorf("search: delete documents: %w", err)
 	}
-	return c.awaitTask(ctx, task.TaskUID)
+	return c.awaitTask(ctx, idx, task.TaskUID)
 }
 
 // SearchParams is a backend-agnostic search request. Filter is the value built
@@ -137,14 +180,18 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 		Limit:  int64(p.Limit),
 		Offset: int64(p.Offset),
 	}
+	// Default (keyword) traffic hits the facet index — always fresh, no embedder.
+	// A semantic request routes to the semantic index and engages the embedder.
+	idx := c.facet
 	if p.SemanticRatio > 0 {
+		idx = c.semantic
 		req.Hybrid = &meilisearch.SearchRequestHybrid{
 			Embedder:      embedderName,
 			SemanticRatio: p.SemanticRatio,
 		}
 	}
 
-	resp, err := c.index.SearchWithContext(ctx, p.Query, req)
+	resp, err := idx.SearchWithContext(ctx, p.Query, req)
 	if err != nil {
 		return SearchResult{}, fmt.Errorf("search: query: %w", err)
 	}
@@ -158,8 +205,8 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 
 // awaitTask blocks until a Meilisearch task settles and reports a failed task as
 // an error.
-func (c *Client) awaitTask(ctx context.Context, taskUID int64) error {
-	t, err := c.index.WaitForTaskWithContext(ctx, taskUID, taskPollInterval)
+func (c *Client) awaitTask(ctx context.Context, idx meilisearch.IndexManager, taskUID int64) error {
+	t, err := idx.WaitForTaskWithContext(ctx, taskUID, taskPollInterval)
 	if err != nil {
 		return fmt.Errorf("search: await task %d: %w", taskUID, err)
 	}
@@ -169,8 +216,11 @@ func (c *Client) awaitTask(ctx context.Context, taskUID int64) error {
 	return nil
 }
 
-// indexSettings is the single source of truth for the jobs index configuration.
-func indexSettings() *meilisearch.Settings {
+// facetSettings is the single source of truth for the facet/keyword index
+// configuration — everything EXCEPT the embedder. Indexing into it costs no
+// per-document embedding, so a full rebuild runs ~25x faster than the semantic
+// index. semanticSettings layers the embedder on top of this.
+func facetSettings() *meilisearch.Settings {
 	return &meilisearch.Settings{
 		SearchableAttributes: []string{"title", "company", "description", "location"},
 		// Enrichment facets are nested, so they are filtered via dot paths. The
@@ -204,12 +254,21 @@ func indexSettings() *meilisearch.Settings {
 		// left unset (see the TypoTolerance note above on the SDK over-serializing
 		// newer fields). Requires a reindex to take effect on an existing index.
 		Faceting: &meilisearch.Faceting{MaxValuesPerFacet: maxValuesPerFacet},
-		Embedders: map[string]meilisearch.Embedder{
-			embedderName: {
-				Source:           "huggingFace",
-				Model:            embedderModel,
-				DocumentTemplate: "{{ doc.title }} at {{ doc.company }}. {{ doc.description }}",
-			},
+	}
+}
+
+// semanticSettings is the hybrid index configuration: the facet/keyword settings
+// plus the in-engine huggingFace embedder. Meilisearch embeds each new or changed
+// document at index time (and skips unchanged ones), so this index is built by the
+// separate, slower reindex --semantic pass and never on the default reindex path.
+func semanticSettings() *meilisearch.Settings {
+	s := facetSettings()
+	s.Embedders = map[string]meilisearch.Embedder{
+		embedderName: {
+			Source:           "huggingFace",
+			Model:            embedderModel,
+			DocumentTemplate: "{{ doc.title }} at {{ doc.company }}. {{ doc.description }}",
 		},
 	}
+	return s
 }

--- a/internal/search/facets.go
+++ b/internal/search/facets.go
@@ -38,7 +38,7 @@ type FacetStat struct {
 // responsibility from returning ranked hits, so it runs with limit 0 (no
 // documents), no sort, and no hybrid embedder — just the distribution.
 func (c *Client) FacetCounts(ctx context.Context, p FacetParams) (FacetResult, error) {
-	resp, err := c.index.SearchWithContext(ctx, p.Query, &meilisearch.SearchRequest{
+	resp, err := c.facet.SearchWithContext(ctx, p.Query, &meilisearch.SearchRequest{
 		Filter: p.Filter,
 		Facets: p.Facets,
 		Limit:  0,

--- a/internal/search/facets_test.go
+++ b/internal/search/facets_test.go
@@ -52,9 +52,9 @@ func TestBuildFacetResult(t *testing.T) {
 func TestIndexSettings_FacetingRaisesValueCap(t *testing.T) {
 	// The Meili default of 100 truncates high-cardinality facets (skills,
 	// countries) in the distribution; the analytics page needs the full set.
-	f := indexSettings().Faceting
+	f := facetSettings().Faceting
 	if f == nil {
-		t.Fatal("indexSettings().Faceting is nil; expected maxValuesPerFacet override")
+		t.Fatal("facetSettings().Faceting is nil; expected maxValuesPerFacet override")
 	}
 	if f.MaxValuesPerFacet <= 100 {
 		t.Errorf("MaxValuesPerFacet = %d, want > 100", f.MaxValuesPerFacet)

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -182,7 +182,15 @@ func TestIntegration_EnsureIndexIndexAndSearch(t *testing.T) {
 		}
 	})
 
-	t.Run("hybrid search engages the embedder without error", func(t *testing.T) {
+	t.Run("hybrid search hits the separate semantic index", func(t *testing.T) {
+		// Semantic search rides a second index built by the --semantic pass (the
+		// facet index above carries no embedder), so build and populate it here.
+		if err := c.EnsureSemanticIndex(ctx); err != nil {
+			t.Fatalf("EnsureSemanticIndex: %v", err)
+		}
+		if err := c.IndexSemanticJobs(ctx, docs); err != nil {
+			t.Fatalf("IndexSemanticJobs: %v", err)
+		}
 		res, err := c.Search(ctx, SearchParams{Query: "backend engineering role", SemanticRatio: 0.5, Limit: 10})
 		if err != nil {
 			t.Fatalf("hybrid Search: %v", err)

--- a/internal/search/settings_test.go
+++ b/internal/search/settings_test.go
@@ -1,0 +1,40 @@
+package search
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The reindex split keeps two index configurations: a facet/keyword index with NO
+// embedder (the fast, always-fresh production search) and a semantic index that
+// adds the embedder (built by a separate, optional pass). Both must share the
+// facet/keyword settings so keyword search and faceting behave identically.
+
+func TestFacetSettingsHasNoEmbedder(t *testing.T) {
+	if facetSettings().Embedders != nil {
+		t.Error("facetSettings() must not configure an embedder (keeps the facet reindex fast)")
+	}
+}
+
+func TestSemanticSettingsHasEmbedder(t *testing.T) {
+	s := semanticSettings()
+	if s.Embedders == nil {
+		t.Fatal("semanticSettings() must configure the embedder")
+	}
+	if _, ok := s.Embedders[embedderName]; !ok {
+		t.Errorf("semanticSettings() missing the %q embedder", embedderName)
+	}
+}
+
+func TestFacetAndSemanticShareKeywordSettings(t *testing.T) {
+	f, s := facetSettings(), semanticSettings()
+	if !reflect.DeepEqual(f.FilterableAttributes, s.FilterableAttributes) {
+		t.Error("facet and semantic settings must share FilterableAttributes")
+	}
+	if !reflect.DeepEqual(f.SearchableAttributes, s.SearchableAttributes) {
+		t.Error("facet and semantic settings must share SearchableAttributes")
+	}
+	if !reflect.DeepEqual(f.SortableAttributes, s.SortableAttributes) {
+		t.Error("facet and semantic settings must share SortableAttributes")
+	}
+}


### PR DESCRIPTION
## Why

A full reindex took **~5.5h**. Benchmarking on 219k real docs isolated the cause: the in-engine huggingFace embedder computes a vector per document at index time (**~23 docs/sec**), while keyword+facet indexing alone runs **~640 docs/sec** — the embedder is ~96% of the cost. Postgres read+build (2795 docs/sec) and the await/batch strategy are *not* the bottleneck. The SPA hardcodes `semantic_ratio=0`, so this embedding cost buys nothing for real traffic.

## What

Split the single embedder-bearing `jobs` index into two, so the embedder runs on its own **rare** schedule instead of every reindex:

- **`jobs`** (facet/keyword, no embedder) — the default production index. Full rebuild drops from hours to **~12 min**. Serves all keyword + facet traffic.
- **`jobs_semantic`** (adds the embedder) — built by a separate `reindex --semantic` pass, queried only when `semantic_ratio>0`. Embedding never blocks facet freshness; Meili skips re-embedding unchanged docs, so the pass is cheap in steady state.

`cmd/reindex` gains a `--semantic` flag (default = facet) and a larger batch (500→2000). The search handler defaults `semantic_ratio` to 0 so default traffic never routes to the optional (possibly absent) semantic index.

## Benchmarks (219k real docs, local Meili)

| strategy | docs/sec |
|---|---|
| PG read+build | 2795 |
| keyword+facets (no embedder) | ~640 |
| **with embedder** | **23** |
| re-index unchanged (embedder skips) | 3404 |

## Verification

- TDD: new `internal/search/settings_test.go` (facet vs semantic settings split).
- Full search integration test builds + queries **both** indexes (facet keyword/facet/sort/delete + semantic hybrid).
- handler tests updated for the keyword default; `go vet` + gofmt clean.

## Deploy notes

- Code change → needs a build deploy (not config-sync).
- First `reindex` removes the embedder from the existing prod `jobs` index (embeddings drop — intended). Default search (ratio=0) keeps working throughout.
- `jobs_semantic` appears only once `reindex --semantic` runs. Add a separate, infrequent cron line for it (e.g. daily/weekly) — the frequent `15 */6` cron now runs the fast facet pass.