### PR TITLE
fix(search): reset embedder on the facet index explicitly

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -65,7 +65,19 @@ func NewClient(url, key string) *Client {
 // settings. It is idempotent — safe to call on every reindex. This is the fast
 // production index that all default (keyword) traffic and faceting hit.
 func (c *Client) EnsureIndex(ctx context.Context) error {
-	return c.ensure(ctx, c.facet, facetIndexUID, facetSettings())
+	if err := c.ensure(ctx, c.facet, facetIndexUID, facetSettings()); err != nil {
+		return err
+	}
+	// Meilisearch settings updates MERGE: facetSettings omits the embedder, but an
+	// omitted (nil or empty) embedders map LEAVES any embedder a prior version put
+	// on this index in place — so a `jobs` index that once carried the embedder
+	// would keep embedding on every facet reindex, defeating the split. Reset it
+	// explicitly. On an index that never had one this is a harmless no-op.
+	task, err := c.facet.ResetEmbeddersWithContext(ctx)
+	if err != nil {
+		return fmt.Errorf("search: reset facet embedders: %w", err)
+	}
+	return c.awaitTask(ctx, c.facet, task.TaskUID)
 }
 
 // EnsureSemanticIndex creates the hybrid jobs index (with the in-engine embedder)

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/meilisearch/meilisearch-go"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 
@@ -199,6 +200,44 @@ func TestIntegration_EnsureIndexIndexAndSearch(t *testing.T) {
 			t.Error("hybrid search returned no hits")
 		}
 	})
+}
+
+// TestIntegration_EnsureIndexResetsExistingEmbedder guards the merge-semantics
+// trap: facetSettings omits the embedder, but a Meilisearch settings update only
+// MERGES, so an embedder a prior version put on the `jobs` index would survive and
+// keep embedding on every facet reindex. EnsureIndex must reset it explicitly.
+func TestIntegration_EnsureIndexResetsExistingEmbedder(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	// Put an embedder on the facet index. userProvided needs no model download.
+	task, err := c.facet.UpdateEmbeddersWithContext(ctx, map[string]meilisearch.Embedder{
+		"manual": {Source: "userProvided", Dimensions: 3},
+	})
+	if err != nil {
+		t.Fatalf("UpdateEmbedders: %v", err)
+	}
+	if _, err := c.facet.WaitForTaskWithContext(ctx, task.TaskUID, 50*time.Millisecond); err != nil {
+		t.Fatalf("await embedder set: %v", err)
+	}
+	if emb, err := c.facet.GetEmbeddersWithContext(ctx); err != nil || len(emb) == 0 {
+		t.Fatalf("precondition: embedder should be set (emb=%v err=%v)", emb, err)
+	}
+
+	// EnsureIndex must strip it, leaving the facet index embedder-free.
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex (reset): %v", err)
+	}
+	emb, err := c.facet.GetEmbeddersWithContext(ctx)
+	if err != nil {
+		t.Fatalf("GetEmbedders: %v", err)
+	}
+	if len(emb) != 0 {
+		t.Errorf("EnsureIndex left embedders on the facet index: %v", emb)
+	}
 }
 
 func TestSearchFiltersBySkillsFacet(t *testing.T) {


### PR DESCRIPTION
Follow-up to #125. `facetSettings` omits the embedder, but Meilisearch settings updates **merge** and the SDK tags `embedders` `omitempty`, so a nil/empty map is dropped from the request — an embedder a prior version configured on the existing `jobs` index survives and keeps embedding on every facet reindex, defeating the split.

`EnsureIndex` now calls `ResetEmbedders` after applying `facetSettings` (a no-op on an index that never had one). Covered by a new integration test that puts a `userProvided` embedder on the index and asserts `EnsureIndex` strips it.

Found while deploying #125: the prod facet reindex was still embedding because the pre-existing embedder was not removed.