### PR TITLE
fix(telegram): deep-link token must fit Telegram start-param limit

### DIFF
--- a/internal/telegramnotify/token.go
+++ b/internal/telegramnotify/token.go
@@ -1,29 +1,39 @@
 // Package telegramnotify is the outbound Telegram channel for filter-subscription
 // notifications — the sibling of the inbound internal/telegram crawl. It mints the
-// signed deep-link token that links a user's chat, talks to the Bot API
+// deep-link token that links a user's chat, talks to the Bot API
 // (sendMessage/setWebhook), parses inbound webhook updates, and implements
 // notify.Notifier by rendering a digest into a Telegram message.
 package telegramnotify
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"errors"
-	"fmt"
-	"strconv"
 	"time"
-
-	"github.com/golang-jwt/jwt/v5"
 )
 
-// linkPurpose scopes the link token so a session JWT (or any other token) cannot
-// be replayed as a link token, and vice versa.
-const linkPurpose = "tg-link"
+// ErrInvalidToken is returned for a link token that is malformed, has a bad
+// signature, or has expired.
+var ErrInvalidToken = errors.New("telegramnotify: invalid or expired link token")
 
-// ErrWrongPurpose is returned when a structurally valid token is not a link token.
-var ErrWrongPurpose = errors.New("telegramnotify: token is not a link token")
+// linkTokenPurpose is mixed into the MAC for domain separation, so a token signed
+// for another purpose with the same secret cannot pass here.
+const linkTokenPurpose = "tg-link"
 
-// LinkTokens mints and verifies short-lived signed tokens a user carries into the
-// bot via the t.me deep link. The token identifies the user (subject) and is
-// purpose-scoped; it is stateless (no server-side token store) and expires.
+// linkTokenMACLen truncates the HMAC to 16 bytes (128 bits) — ample for a
+// short-lived token — to keep the encoded token small.
+const linkTokenMACLen = 16
+
+// linkTokenPayloadLen is the fixed payload: 8-byte user id + 8-byte expiry unix.
+const linkTokenPayloadLen = 16
+
+// LinkTokens mints and verifies the short, stateless token a user carries into the
+// bot via the t.me deep link. The encoding is deliberately NOT a JWT: Telegram's
+// deep-link `start` parameter allows only 1–64 chars from [A-Za-z0-9_-], which a
+// JWT (dotted, ~200 chars) violates. This token is a base64url(payload‖MAC) blob
+// of ~43 chars using exactly that alphabet, so it survives the deep link intact.
 type LinkTokens struct {
 	secret []byte
 	ttl    time.Duration
@@ -35,44 +45,36 @@ func NewLinkTokens(secret string, ttl time.Duration) *LinkTokens {
 	return &LinkTokens{secret: []byte(secret), ttl: ttl}
 }
 
-type linkClaims struct {
-	Purpose string `json:"purpose"`
-	jwt.RegisteredClaims
-}
-
-// Issue returns a signed link token for userID, expiring after the configured TTL.
+// Issue returns a deep-link token for userID, expiring after the configured TTL.
+// The result is base64url (no padding) so it is safe as a Telegram start param.
 func (l *LinkTokens) Issue(userID int64) (string, error) {
-	now := time.Now()
-	claims := linkClaims{
-		Purpose: linkPurpose,
-		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   strconv.FormatInt(userID, 10),
-			IssuedAt:  jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(now.Add(l.ttl)),
-		},
-	}
-	return jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(l.secret)
+	payload := make([]byte, linkTokenPayloadLen)
+	binary.BigEndian.PutUint64(payload[0:8], uint64(userID))
+	binary.BigEndian.PutUint64(payload[8:16], uint64(time.Now().Add(l.ttl).Unix()))
+	token := append(payload, l.mac(payload)...)
+	return base64.RawURLEncoding.EncodeToString(token), nil
 }
 
-// Parse verifies a link token's signature, expiry, and purpose, returning its
-// subject user id. It rejects any token not signed with HMAC (algorithm-confusion
-// guard) and any whose purpose is not the link purpose.
+// Parse verifies a token's signature and expiry and returns its user id.
 func (l *LinkTokens) Parse(token string) (int64, error) {
-	claims := &linkClaims{}
-	if _, err := jwt.ParseWithClaims(token, claims, func(t *jwt.Token) (any, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
-		return l.secret, nil
-	}); err != nil {
-		return 0, err
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(raw) != linkTokenPayloadLen+linkTokenMACLen {
+		return 0, ErrInvalidToken
 	}
-	if claims.Purpose != linkPurpose {
-		return 0, ErrWrongPurpose
+	payload, mac := raw[:linkTokenPayloadLen], raw[linkTokenPayloadLen:]
+	if !hmac.Equal(mac, l.mac(payload)) {
+		return 0, ErrInvalidToken
 	}
-	id, err := strconv.ParseInt(claims.Subject, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("invalid token subject: %w", err)
+	if exp := int64(binary.BigEndian.Uint64(payload[8:16])); time.Now().Unix() > exp {
+		return 0, ErrInvalidToken
 	}
-	return id, nil
+	return int64(binary.BigEndian.Uint64(payload[0:8])), nil
+}
+
+// mac is the truncated HMAC-SHA256 over the purpose tag and payload.
+func (l *LinkTokens) mac(payload []byte) []byte {
+	h := hmac.New(sha256.New, l.secret)
+	h.Write([]byte(linkTokenPurpose))
+	h.Write(payload)
+	return h.Sum(nil)[:linkTokenMACLen]
 }

--- a/internal/telegramnotify/token_test.go
+++ b/internal/telegramnotify/token_test.go
@@ -2,10 +2,9 @@ package telegramnotify
 
 import (
 	"errors"
+	"regexp"
 	"testing"
 	"time"
-
-	"github.com/golang-jwt/jwt/v5"
 )
 
 func TestLinkTokens_RoundTrip(t *testing.T) {
@@ -20,14 +19,30 @@ func TestLinkTokens_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestLinkTokens_TelegramStartParamSafe guards the bug that broke linking in prod:
+// a JWT token exceeded Telegram's deep-link `start` limit (1–64 chars,
+// [A-Za-z0-9_-]) and was silently dropped. The token MUST fit that constraint.
+func TestLinkTokens_TelegramStartParamSafe(t *testing.T) {
+	tok, err := NewLinkTokens("secret", 10*time.Minute).Issue(9223372036854775807) // max int64
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tok) < 1 || len(tok) > 64 {
+		t.Errorf("token length = %d, want 1..64 (Telegram start-param limit)", len(tok))
+	}
+	if !regexp.MustCompile(`^[A-Za-z0-9_-]+$`).MatchString(tok) {
+		t.Errorf("token %q has chars outside [A-Za-z0-9_-] (Telegram start-param alphabet)", tok)
+	}
+}
+
 func TestLinkTokens_Expired(t *testing.T) {
 	lt := NewLinkTokens("secret", -time.Minute) // already expired
 	tok, err := lt.Issue(1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := lt.Parse(tok); !errors.Is(err, jwt.ErrTokenExpired) {
-		t.Errorf("Parse(expired) err = %v, want token-expired", err)
+	if _, err := lt.Parse(tok); !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("Parse(expired) err = %v, want ErrInvalidToken", err)
 	}
 }
 
@@ -36,23 +51,16 @@ func TestLinkTokens_WrongSecretRejected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := NewLinkTokens("forged", time.Minute).Parse(tok); err == nil {
-		t.Error("Parse with wrong secret succeeded, want signature error")
+	if _, err := NewLinkTokens("forged", time.Minute).Parse(tok); !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("Parse with wrong secret err = %v, want ErrInvalidToken", err)
 	}
 }
 
-func TestLinkTokens_WrongPurposeRejected(t *testing.T) {
-	// A token signed with the same secret but lacking the link purpose (as a
-	// session JWT would) must not pass as a link token.
-	claims := jwt.RegisteredClaims{
-		Subject:   "1",
-		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
-	}
-	tok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte("secret"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := NewLinkTokens("secret", time.Minute).Parse(tok); !errors.Is(err, ErrWrongPurpose) {
-		t.Errorf("Parse(no purpose) err = %v, want ErrWrongPurpose", err)
+func TestLinkTokens_GarbageRejected(t *testing.T) {
+	lt := NewLinkTokens("secret", time.Minute)
+	for _, bad := range []string{"", "not-base64-!!!", "short", "/start"} {
+		if _, err := lt.Parse(bad); !errors.Is(err, ErrInvalidToken) {
+			t.Errorf("Parse(%q) err = %v, want ErrInvalidToken", bad, err)
+		}
 	}
 }


### PR DESCRIPTION
## Problem
Telegram linking silently failed in prod: clicking **Connect Telegram** → tapping Start did nothing (`/my/notifications` stayed on "I've connected", no `telegram_links` row, webhook logged 200 with no app-level line).

**Root cause:** the deep-link token was a JWT (~200 chars, contains `.`). Telegram's `t.me/<bot>?start=<param>` allows only **1–64 chars from `[A-Za-z0-9_-]`**, so it dropped the invalid param — the bot received a bare `/start` with no token, and `StartToken` returned not-ok (200, no link).

## Fix
Re-encode the link token as a compact `base64url(payload‖HMAC)` blob (~43 chars, exactly the allowed alphabet, stateless, purpose-bound via the HMAC, TTL-checked). `Issue`/`Parse` signatures are unchanged, so **no handler, migration, or web change** — only `internal/telegramnotify/token.go`.

## Test Plan
- [x] Unit: round-trip, expiry, wrong-secret, garbage rejected, and a regression test asserting the token length ≤64 and charset `[A-Za-z0-9_-]`
- [x] `go test -tags=integration -run TestTelegramLinkAndWebhook ./internal/handler/` (link mint → /start <token> → chat linked)
- [ ] Post-deploy: Connect Telegram on freehire.dev completes the link