### PR TITLE
feat(location): broaden geography coverage (cities, ISO codes, multilingual, dash formats)

### DIFF
--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -13,13 +13,27 @@ var regionCountries = map[string][]string{
 		"de", "fr", "nl", "es", "se", "pl", "ie", "pt", "it", "be", "dk",
 		"fi", "at", "cz", "ro", "gr", "hu", "bg", "hr", "sk", "si", "lt",
 		"lv", "ee", "lu", "ch", "no", "ua", "is",
+		// Rest of geographic Europe (the Balkans, micro-states, Cyprus/Malta).
+		"rs", "ba", "mk", "al", "me", "xk", "cy", "mt", "li", "mc", "ad", "sm",
 	},
 	"uk":            {"gb"},
 	"north_america": {"us", "ca"},
-	"latam":         {"ar", "br", "mx", "cl", "co", "pe", "uy"},
-	"apac":          {"sg", "jp", "au", "nz", "in", "hk", "tw", "kr", "cn", "my", "th", "ph", "vn", "id"},
-	"mena":          {"ae", "sa", "il", "eg", "tr", "qa"},
-	"africa":        {"za", "ng", "ke"},
+	"latam": {
+		"ar", "br", "mx", "cl", "co", "pe", "uy",
+		"ec", "bo", "py", "ve", "cr", "pa", "gt", "do", "hn", "sv", "ni", "pr",
+	},
+	"apac": {
+		"sg", "jp", "au", "nz", "in", "hk", "tw", "kr", "cn", "my", "th", "ph", "vn", "id",
+		"bd", "pk", "lk", "np", "kh", "la", "mm", "mn", "bn", "mo",
+	},
+	"mena": {
+		"ae", "sa", "il", "eg", "tr", "qa",
+		"kw", "bh", "om", "jo", "lb", "iq", "ir", "ma", "dz", "tn", "ly", "ye", "ps",
+	},
+	"africa": {
+		"za", "ng", "ke",
+		"gh", "et", "tz", "ug", "rw", "sn", "ci", "cm", "ao", "mz", "zm", "zw", "mu",
+	},
 	// CIS — the whole post-Soviet space (the RU-segment geography of the Telegram
 	// sources): Russia, Belarus, Moldova, the Caucasus, and the five Central Asian
 	// republics. Russia is not its own region; ua stays eu.
@@ -125,6 +139,122 @@ var nameToCountry = map[string]string{
 	"алматы": "kz", "астана": "kz", "казахстан": "kz",
 	"ереван": "am", "баку": "az", "бишкек": "kg",
 	"киев": "ua", "київ": "ua",
+
+	// --- Country names: English + native + ES/PT/DE, seeded from the unresolved
+	// production strings. (Names already keyed above are not repeated.)
+	"china": "cn", "greece": "gr", "brasil": "br", "philippines": "ph",
+	"colombia": "co", "cyprus": "cy", "taiwan": "tw", "malaysia": "my",
+	"romania": "ro", "hungary": "hu", "bulgaria": "bg", "thailand": "th",
+	"indonesia": "id", "vietnam": "vn", "south korea": "kr", "korea": "kr",
+	"turkey": "tr", "türkiye": "tr", "egypt": "eg", "saudi arabia": "sa",
+	"lebanon": "lb", "hong kong": "hk", "qatar": "qa", "kuwait": "kw",
+	"bahrain": "bh", "oman": "om", "jordan": "jo", "iraq": "iq", "iran": "ir",
+	"morocco": "ma", "algeria": "dz", "tunisia": "tn", "pakistan": "pk",
+	"bangladesh": "bd", "sri lanka": "lk", "nepal": "np", "peru": "pe",
+	"chile": "cl", "uruguay": "uy", "ecuador": "ec", "bolivia": "bo",
+	"paraguay": "py", "venezuela": "ve", "costa rica": "cr", "panama": "pa",
+	"guatemala": "gt", "dominican republic": "do", "puerto rico": "pr",
+	"nigeria": "ng", "kenya": "ke", "ghana": "gh", "ethiopia": "et",
+	"czech republic": "cz", "czechia": "cz", "serbia": "rs", "croatia": "hr",
+	"slovenia": "si", "slovakia": "sk", "lithuania": "lt", "latvia": "lv",
+	"estonia": "ee", "luxembourg": "lu", "iceland": "is", "malta": "mt",
+	"monaco": "mc", "north macedonia": "mk", "bosnia and herzegovina": "ba",
+	"albania": "al", "montenegro": "me", "kosovo": "xk", "mauritius": "mu",
+	// Spanish.
+	"españa": "es", "alemania": "de", "méxico": "mx", "méjico": "mx",
+	"grecia": "gr", "francia": "fr", "italia": "it", "países bajos": "nl",
+	"reino unido": "gb", "estados unidos": "us", "suiza": "ch", "suecia": "se",
+	"polonia": "pl", "rumanía": "ro", "hungría": "hu", "turquía": "tr",
+	"japón": "jp", "filipinas": "ph", "malasia": "my", "tailandia": "th",
+	"corea del sur": "kr", "emiratos árabes unidos": "ae", "arabia saudita": "sa",
+	"egipto": "eg", "perú": "pe",
+	// Portuguese.
+	"espanha": "es", "alemanha": "de", "frança": "fr", "grécia": "gr",
+	"países baixos": "nl", "suíça": "ch", "polónia": "pl", "roménia": "ro",
+	"hungria": "hu", "turquia": "tr", "japão": "jp", "coreia do sul": "kr",
+	"emirados árabes unidos": "ae", "arábia saudita": "sa", "egito": "eg",
+	// German.
+	"frankreich": "fr", "spanien": "es", "italien": "it", "niederlande": "nl",
+	"vereinigtes königreich": "gb", "vereinigte staaten": "us", "schweiz": "ch",
+	"schweden": "se", "polen": "pl", "rumänien": "ro", "ungarn": "hu",
+	"türkei": "tr", "griechenland": "gr", "philippinen": "ph", "indonesien": "id",
+	"südkorea": "kr", "ägypten": "eg", "österreich": "at", "belgien": "be",
+	"dänemark": "dk", "finnland": "fi", "irland": "ie", "norwegen": "no",
+	"tschechien": "cz", "bulgarien": "bg", "saudi-arabien": "sa",
+	"vereinigte arabische emirate": "ae", "bundesweit": "de",
+
+	// --- Beacon cities (high-frequency, unambiguous), region falls out of the code.
+	// North America (US).
+	"san francisco": "us", "san francisco bay area": "us", "south san francisco": "us",
+	"new york city": "us", "nyc": "us", "brooklyn": "us", "manhattan": "us",
+	"boston": "us", "chicago": "us", "los angeles": "us", "san jose": "us",
+	"austin": "us", "charlotte": "us", "atlanta": "us", "seattle": "us",
+	"houston": "us", "palo alto": "us", "denver": "us", "dallas": "us",
+	"san antonio": "us", "san diego": "us", "menlo park": "us", "san mateo": "us",
+	"indianapolis": "us", "miami": "us", "philadelphia": "us", "phoenix": "us",
+	"raleigh": "us", "durham": "us", "detroit": "us", "minneapolis": "us",
+	"nashville": "us", "pittsburgh": "us", "salt lake city": "us", "baltimore": "us",
+	"sacramento": "us", "irvine": "us", "santa clara": "us", "sunnyvale": "us",
+	"mountain view": "us", "redmond": "us", "bellevue": "us", "washington dc": "us",
+	"washington, d.c.": "us", "kansas city": "us", "st. louis": "us", "cincinnati": "us",
+	// Canada.
+	"ottawa": "ca", "calgary": "ca", "edmonton": "ca", "mississauga": "ca",
+	// LATAM.
+	"são paulo": "br", "sao paulo": "br", "rio de janeiro": "br", "belo horizonte": "br",
+	"brasília": "br", "brasilia": "br", "curitiba": "br", "porto alegre": "br",
+	"campinas": "br", "florianópolis": "br",
+	"mexico city": "mx", "méxico city": "mx", "ciudad de méxico": "mx",
+	"guadalajara": "mx", "monterrey": "mx",
+	"buenos aires": "ar", "bogotá": "co", "bogota": "co", "medellín": "co",
+	"medellin": "co", "lima": "pe", "santiago": "cl", "montevideo": "uy",
+	// APAC — China.
+	"shanghai": "cn", "beijing": "cn", "shenzhen": "cn", "guangzhou": "cn",
+	"suzhou": "cn", "wuxi": "cn", "hangzhou": "cn", "chengdu": "cn",
+	"nanjing": "cn", "tianjin": "cn",
+	"taipei": "tw", "taichung": "tw", "hsinchu": "tw", "kaohsiung": "tw",
+	"seoul": "kr", "pangyo": "kr", "busan": "kr",
+	"osaka": "jp", "kyoto": "jp", "yokohama": "jp", "nagoya": "jp", "fukuoka": "jp",
+	"bangkok": "th", "kuala lumpur": "my", "jakarta": "id",
+	"manila": "ph", "makati": "ph", "taguig": "ph", "cebu": "ph",
+	"chennai": "in", "noida": "in", "gurugram": "in", "gurgaon": "in",
+	"new delhi": "in", "delhi": "in", "kolkata": "in", "ahmedabad": "in",
+	"kochi": "in", "coimbatore": "in", "jaipur": "in", "indore": "in",
+	"chandigarh": "in", "thiruvananthapuram": "in",
+	"ho chi minh city": "vn", "hanoi": "vn",
+	"karachi": "pk", "lahore": "pk", "islamabad": "pk", "dhaka": "bd", "colombo": "lk",
+	// Europe.
+	"athens": "gr", "thessaloniki": "gr",
+	"lisboa": "pt", "porto": "pt",
+	"toulouse": "fr", "lyon": "fr", "nantes": "fr", "bordeaux": "fr", "nice": "fr",
+	"lille": "fr", "villeurbanne": "fr", "courbevoie": "fr", "levallois-perret": "fr",
+	"strasbourg": "fr", "marseille": "fr", "montpellier": "fr", "rennes": "fr", "grenoble": "fr",
+	"prague": "cz", "sofia": "bg", "budapest": "hu",
+	"bucharest": "ro", "bucurești": "ro", "timișoara": "ro", "timisoara": "ro",
+	"cluj-napoca": "ro", "cluj": "ro",
+	"kraków": "pl", "krakow": "pl", "wrocław": "pl", "wroclaw": "pl",
+	"gdańsk": "pl", "gdansk": "pl", "poznań": "pl", "poznan": "pl",
+	"frankfurt": "de", "cologne": "de", "köln": "de", "stuttgart": "de",
+	"düsseldorf": "de", "dusseldorf": "de", "leipzig": "de", "dresden": "de",
+	"geneva": "ch", "genève": "ch", "geneve": "ch", "basel": "ch", "lausanne": "ch",
+	"turin": "it", "naples": "it", "bologna": "it", "florence": "it",
+	"valencia": "es", "sevilla": "es", "seville": "es", "málaga": "es",
+	"malaga": "es", "bilbao": "es", "zaragoza": "es",
+	"antwerp": "be", "ghent": "be",
+	"rotterdam": "nl", "the hague": "nl", "den haag": "nl", "eindhoven": "nl", "utrecht": "nl",
+	"oslo": "no", "bergen": "no", "gothenburg": "se", "göteborg": "se",
+	"malmö": "se", "malmo": "se", "aarhus": "dk", "tampere": "fi", "espoo": "fi",
+	"tallinn": "ee", "riga": "lv", "vilnius": "lt", "ljubljana": "si",
+	"zagreb": "hr", "belgrade": "rs", "beograd": "rs", "bratislava": "sk",
+	"nicosia": "cy", "valletta": "mt", "reykjavik": "is", "reykjavík": "is",
+	// MENA.
+	"riyadh": "sa", "jeddah": "sa", "dammam": "sa", "beirut": "lb",
+	"cairo": "eg", "istanbul": "tr", "ankara": "tr", "izmir": "tr",
+	"doha": "qa", "abu dhabi": "ae", "sharjah": "ae", "kuwait city": "kw",
+	"manama": "bh", "muscat": "om", "amman": "jo",
+	"casablanca": "ma", "rabat": "ma", "tunis": "tn", "algiers": "dz",
+	// Africa.
+	"cape town": "za", "johannesburg": "za", "durban": "za", "pretoria": "za",
+	"nairobi": "ke", "lagos": "ng", "abuja": "ng", "accra": "gh", "addis ababa": "et",
 }
 
 // subdivisionToCountry resolves a US state or Canadian province token — a postal
@@ -182,12 +312,19 @@ var subdivisionToCountry = map[string]string{
 // nameToRegion resolves macro-region names (and explicit open-anywhere markers)
 // directly to a region code, for tokens that name an area rather than a country.
 var nameToRegion = map[string]string{
-	"europe": "eu", "eu": "eu",
+	"europe": "eu", "eu": "eu", "europa": "eu",
 	"apac": "apac", "asia": "apac", "asia pacific": "apac", "asia-pacific": "apac",
 	"north america": "north_america",
 	"latam":         "latam", "latin america": "latam", "south america": "latam",
 	"mena": "mena", "middle east": "mena",
 	"africa": "africa",
 	"cis":    "cis", "central asia": "cis",
-	"anywhere": "global", "worldwide": "global", "global": "global", "remote anywhere": "global",
+	// Open-anywhere markers, multilingual. A bare "remote" stays geography-less
+	// (work mode only); these are explicit "the whole world" phrasings.
+	"anywhere": "global", "worldwide": "global", "global": "global",
+	"remote anywhere": "global", "world wide": "global", "world-wide": "global",
+	"everywhere": "global", "fully distributed": "global",
+	"по всему миру": "global", "весь мир": "global",
+	"en todo el mundo": "global", "todo el mundo": "global",
+	"em todo o mundo": "global", "weltweit": "global",
 }

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -53,21 +53,29 @@ func Parse(location string) Geo {
 			continue
 		}
 		tok = stripCityPrefix(tok)
-		if code, ok := nameToCountry[tok]; ok {
-			countrySet[code] = struct{}{}
-			if r, ok := countryToRegion[code]; ok {
-				regionSet[r] = struct{}{}
-			}
+		// Strip embedded work-mode words so the place still resolves ("US Remote" ->
+		// "us"); a token that is ONLY a work-mode marker ("Remote", "On-site") strips
+		// to "" and is skipped — its work mode is detected separately from the whole
+		// string. Skipping also keeps it out of the dash-split below.
+		tok = stripWorkmodeWords(tok)
+		if tok == "" {
 			continue
 		}
-		if r, ok := nameToRegion[tok]; ok {
-			regionSet[r] = struct{}{}
+		if resolveGeoToken(tok, countrySet, regionSet) {
 			continue
 		}
-		if code, ok := resolveSubdivision(tok); ok {
-			countrySet[code] = struct{}{}
-			if r, ok := countryToRegion[code]; ok {
-				regionSet[r] = struct{}{}
+		// Dash-delimited exports carry the geography either first ("United
+		// States-Utah-Roy", "TX-Houston") or last ("Nisku-Alberta-Canada"). The
+		// first segment is resolved fully (a leading bare code like "tx" is a real
+		// signal); every other segment is resolved by NAME only, so a 2-letter code
+		// buried in a hyphenated city name ("stoke-on-trent" -> "on") cannot misfire
+		// while a country/region word ("alberta", "canada", "china") still does.
+		// Tried only after the whole token failed, so "cluj-napoca"/"nur-sultan"
+		// (dictionary keys) still win as a unit.
+		if segs := strings.Split(tok, "-"); len(segs) > 1 {
+			resolveGeoToken(strings.TrimSpace(segs[0]), countrySet, regionSet)
+			for _, seg := range segs[1:] {
+				resolveGeoName(strings.TrimSpace(seg), countrySet, regionSet)
 			}
 		}
 	}
@@ -79,12 +87,99 @@ func Parse(location string) Geo {
 	}
 }
 
+// resolveGeoToken resolves one already-normalized token to a country and/or
+// region, writing into the sets, and reports whether anything matched. Order: a
+// country/city name, a macro-region name, a US/Canada subdivision, then a bare
+// ISO 3166-1 alpha-2 country code (last, so a same-spelled subdivision wins).
+func resolveGeoToken(tok string, countrySet, regionSet map[string]struct{}) bool {
+	if tok == "" {
+		return false
+	}
+	if code, ok := nameToCountry[tok]; ok {
+		countrySet[code] = struct{}{}
+		if r, ok := countryToRegion[code]; ok {
+			regionSet[r] = struct{}{}
+		}
+		return true
+	}
+	if r, ok := nameToRegion[tok]; ok {
+		regionSet[r] = struct{}{}
+		return true
+	}
+	if code, ok := resolveSubdivision(tok); ok {
+		countrySet[code] = struct{}{}
+		if r, ok := countryToRegion[code]; ok {
+			regionSet[r] = struct{}{}
+		}
+		return true
+	}
+	if r, ok := countryToRegion[tok]; ok {
+		countrySet[tok] = struct{}{}
+		regionSet[r] = struct{}{}
+		return true
+	}
+	return false
+}
+
+// resolveGeoName resolves a token by place NAME only — a country/city name, a
+// macro-region name, or a full (len>2) US/Canada subdivision name. It deliberately
+// skips bare 2-letter codes (subdivision or ISO), so it is safe to run on every
+// non-leading dash segment of a hyphenated city ("stoke-on-trent") without "on"
+// or "in" misfiring.
+func resolveGeoName(tok string, countrySet, regionSet map[string]struct{}) bool {
+	if code, ok := nameToCountry[tok]; ok {
+		countrySet[code] = struct{}{}
+		if r, ok := countryToRegion[code]; ok {
+			regionSet[r] = struct{}{}
+		}
+		return true
+	}
+	if r, ok := nameToRegion[tok]; ok {
+		regionSet[r] = struct{}{}
+		return true
+	}
+	if len(tok) > 2 {
+		if code, ok := subdivisionToCountry[tok]; ok {
+			countrySet[code] = struct{}{}
+			if r, ok := countryToRegion[code]; ok {
+				regionSet[r] = struct{}{}
+			}
+			return true
+		}
+	}
+	return false
+}
+
 // cityMarkerPrefixes are the Russian "city" abbreviations that RU-segment ATS
 // data prepends to a bare city name ("г Москва", "город Самара"). Stripped from a
 // token before lookup so the city resolves; checked longest-first so "город "
 // wins over "г ". A city whose name merely starts with "г" ("Грозный") is
 // untouched — every prefix ends in a separator the name doesn't.
 var cityMarkerPrefixes = []string{"город ", "г. ", "г.", "г "}
+
+// noiseTokenWords are dropped from a geography token so an embedded place still
+// resolves: work-mode words ("US Remote" -> "us") and site suffixes ("San
+// Francisco Office" / "... HQ" -> "san francisco"). Matched as whole
+// space-separated words; the work mode is detected separately (detectWorkMode).
+var noiseTokenWords = map[string]struct{}{
+	"remote": {}, "hybrid": {}, "onsite": {}, "on-site": {},
+	"office": {}, "hq": {}, "headquarters": {},
+}
+
+// stripWorkmodeWords drops any noise words from a token, returning the rest
+// (possibly ""). "us remote" -> "us"; "remote" -> ""; "san francisco office" ->
+// "san francisco".
+func stripWorkmodeWords(tok string) string {
+	fields := strings.Fields(tok)
+	kept := fields[:0]
+	for _, f := range fields {
+		if _, drop := noiseTokenWords[f]; drop {
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return strings.Join(kept, " ")
+}
 
 // stripCityPrefix removes a leading Russian city marker from an already-lowercased,
 // trimmed token, returning the bare city name (or the token unchanged).

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -293,3 +293,40 @@ func TestParseEmitsOnlyKnownVocabulary(t *testing.T) {
 		}
 	}
 }
+
+// TestParseExpandedCoverage exercises the dictionary expansion: trailing ISO
+// country codes, beacon cities, multilingual country names, multilingual
+// open-anywhere markers, and work-mode-word stripping inside a token.
+func TestParseExpandedCoverage(t *testing.T) {
+	tests := []struct {
+		location string
+		want     Geo
+	}{
+		// Trailing bare ISO 3166-1 alpha-2 code ("City, Region, code").
+		{"Shanghai, Shanghai, cn", Geo{Countries: []string{"cn"}, Regions: []string{"apac"}}},
+		{"Riyadh, sa", Geo{Countries: []string{"sa"}, Regions: []string{"mena"}}},
+		{"Lisboa, Lisboa, pt", Geo{Countries: []string{"pt"}, Regions: []string{"eu"}}},
+		{"São Paulo, SP, br", Geo{Countries: []string{"br"}, Regions: []string{"latam"}}},
+		// Beacon cities.
+		{"San Francisco", Geo{Countries: []string{"us"}, Regions: []string{"north_america"}}},
+		{"Athens, Attica, Greece", Geo{Countries: []string{"gr"}, Regions: []string{"eu"}}},
+		{"Seoul, South Korea", Geo{Countries: []string{"kr"}, Regions: []string{"apac"}}},
+		// Country names: English + native + ES/PT/DE.
+		{"China", Geo{Countries: []string{"cn"}, Regions: []string{"apac"}}},
+		{"Brasil", Geo{Countries: []string{"br"}, Regions: []string{"latam"}}},
+		{"España", Geo{Countries: []string{"es"}, Regions: []string{"eu"}}},
+		{"Grécia", Geo{Countries: []string{"gr"}, Regions: []string{"eu"}}},
+		// Open-anywhere markers, multilingual.
+		{"World Wide - Remote", Geo{Regions: []string{"global"}, WorkMode: "remote"}},
+		{"по всему миру", Geo{Regions: []string{"global"}}},
+		{"weltweit", Geo{Regions: []string{"global"}}},
+		// Work-mode word stripped so the place still resolves.
+		{"US Remote", Geo{Countries: []string{"us"}, Regions: []string{"north_america"}, WorkMode: "remote"}},
+	}
+	for _, tt := range tests {
+		got := Parse(tt.location)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("Parse(%q) = %+v, want %+v", tt.location, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Investigating a user report of 'too few jobs' under region filters, prod showed **38% of open jobs had no region** and **77% no work_mode** — the location dictionary missed huge swaths of common ATS location strings (San Francisco, China, Brasil, 'Shanghai, Shanghai, cn', 'TX-Houston', 'по всему миру', …).

## What (data-driven, mined from prod's top unresolved locations)

- **Trailing bare ISO 3166-1 alpha-2 code** ('…, cn' / 'Riyadh, sa') — resolved *last* so a same-spelled US/CA subdivision still wins.
- **~200 beacon cities** → country (SF, São Paulo, Shanghai, Athens, Seoul, Riyadh, …).
- **Country names** in English + native + **ES/PT/DE** (China, Brasil, España, Grécia, Griechenland, Filipinas, …) + a comprehensive country→region table.
- **Multilingual open-anywhere markers** (World Wide, по всему миру, en todo el mundo, weltweit).
- **Noise-word stripping** inside a token ('US Remote' → us, 'SF Office' → sf).
- **Dash-delimited** Country-State-City / City-State-Country exports ('TX-Houston', 'Nisku-Alberta-Canada'), with a names-only rule on non-leading segments so a code buried in a hyphenated city ('stoke-on-trent' → 'on') cannot misfire.

## Impact

Recovers **~76%** of previously-unresolved jobs in the top-300 prod sample; the remainder is genuinely region-less ('Remote') or venue names. No new region/work_mode vocabulary — the controlled-vocabulary invariant test still holds.

## Tests

New `TestParseExpandedCoverage` (ISO tails, cities, multilingual names/markers, work-mode stripping); existing `TestParse` + vocabulary-invariant tests green.

## Deploy

Dictionary change → needs `backfill-derive` + `reindex` to reach existing rows.