### PR TITLE
feat(sources): add tecla marketplace adapter (boardless aggregator)

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -94,6 +94,8 @@ func All(c HTTPClient) map[string]Source {
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),
+		// Marketplace aggregator (boardless): one global feed, company per posting.
+		NewTecla(c),
 		// International single-company adapters (boardless).
 		NewUber(c),
 		NewAmazon(c),

--- a/internal/sources/tecla.go
+++ b/internal/sources/tecla.go
@@ -1,0 +1,98 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+)
+
+// tecla adapts app.tecla.io, a remote-only marketplace of LatAm engineering vacancies. Its
+// public getPublicJobs API returns a paginated, structured list — including each posting's
+// own employer — so one paged list call assembles every Job with no per-job detail fetch.
+// Unlike a single-company adapter, the company comes from the posting (the marketplace lists
+// many employers), so its boardless config entry's company is only a validation placeholder.
+// The public payload truncates the description (the full text is auth-gated and not fetched);
+// the platform is remote-only, so every job is marked remote.
+type tecla struct {
+	http JSONGetter
+}
+
+const (
+	teclaListURL = "https://api.tecla.io/api/jobs/getPublicJobs/?page=%d"
+	teclaJobURL  = "https://app.tecla.io/job?id=%d"
+	// teclaMaxPages bounds pagination so a wrong or missing countPages cannot loop.
+	teclaMaxPages = 100
+	// teclaDateLayout matches the zone-less createdAt tecla emits ("2026-05-25T17:02:00.864421").
+	// The .9 fractional form parses any sub-second width (or none), so the digit count is not
+	// load-bearing — the conventional 9-nine form just states "arbitrary precision".
+	teclaDateLayout = "2006-01-02T15:04:05.999999999"
+)
+
+// NewTecla builds the Tecla adapter over the given HTTP client.
+func NewTecla(c JSONGetter) Source { return tecla{http: c} }
+
+func (tecla) Provider() string { return "tecla" }
+
+// tecla is a marketplace with one global feed, so its config entries carry no board.
+func (tecla) boardless() {}
+
+// teclaResponse is the getPublicJobs response: Data.Jobs is the page, Data.Pagination.CountPages
+// the total page count used to stop pagination.
+type teclaResponse struct {
+	Data struct {
+		Jobs       []teclaJob `json:"jobs"`
+		Pagination struct {
+			CountPages int `json:"countPages"`
+		} `json:"pagination"`
+	} `json:"data"`
+}
+
+// teclaJob is one posting. Company nests the employer's own name (the marketplace lists many
+// employers); Description is the truncated public text.
+type teclaJob struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	Company struct {
+		Name string `json:"name"`
+	} `json:"company"`
+	CreatedAt   string `json:"createdAt"`
+	Description string `json:"description"`
+}
+
+func (t tecla) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; page <= teclaMaxPages; page++ {
+		var resp teclaResponse
+		if err := t.http.GetJSON(ctx, fmt.Sprintf(teclaListURL, page), &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("tecla: list page %d: %w", page, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		if len(resp.Data.Jobs) == 0 {
+			break
+		}
+		for _, p := range resp.Data.Jobs {
+			jobs = append(jobs, t.toJob(p))
+		}
+		if page >= resp.Data.Pagination.CountPages {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a posting to a Job. The company is the posting's own employer, not the
+// configured entry; every job is remote (the marketplace is remote-only).
+func (tecla) toJob(p teclaJob) Job {
+	return Job{
+		ExternalID:  strconv.Itoa(p.ID),
+		URL:         fmt.Sprintf(teclaJobURL, p.ID),
+		Title:       p.Name,
+		Company:     p.Company.Name,
+		Description: sanitizeHTML(p.Description),
+		Remote:      true,
+		WorkMode:    "remote",
+		PostedAt:    parseLayout(teclaDateLayout, p.CreatedAt),
+	}
+}

--- a/internal/sources/tecla_test.go
+++ b/internal/sources/tecla_test.go
@@ -1,0 +1,136 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// teclaHTTP is a page-aware test JSONGetter: tecla's getPublicJobs is paged by a page
+// query parameter, so this fake routes a canned response on the page parsed from the URL.
+// An unrequested page returns an empty job list — the end-of-list response that stops
+// pagination. gotPages records which pages were fetched so a test can assert the adapter
+// stops at the API-reported page count instead of over-fetching.
+type teclaHTTP struct {
+	pages    map[int]string
+	fail     bool
+	gotPages []int
+}
+
+var teclaPageRE = regexp.MustCompile(`page=(\d+)`)
+
+func (f *teclaHTTP) GetJSON(_ context.Context, url string, v any) error {
+	if f.fail {
+		return errors.New("teclaHTTP: boom")
+	}
+	page := 1
+	if m := teclaPageRE.FindStringSubmatch(url); m != nil {
+		page, _ = strconv.Atoi(m[1])
+	}
+	f.gotPages = append(f.gotPages, page)
+	raw, ok := f.pages[page]
+	if !ok {
+		raw = `{"success":true,"data":{"jobs":[],"pagination":{"countPages":0,"current":1}}}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestTeclaProvider(t *testing.T) {
+	if got := NewTecla(nil).Provider(); got != "tecla" {
+		t.Errorf("Provider() = %q, want %q", got, "tecla")
+	}
+}
+
+func TestTeclaFetchPaginatesAndMaps(t *testing.T) {
+	fake := &teclaHTTP{pages: map[int]string{
+		1: `{"success":true,"data":{"jobs":[
+			{"id":3301,"name":"Practice / Business Development","company":{"name":"Sliiip"},"createdAt":"2026-05-25T17:02:00.864421","description":"<p>Grow it</p><script>alert(1)</script>"},
+			{"id":3308,"name":"Founding Software Engineer","company":{"name":"Psyflo"},"createdAt":"2026-06-09T01:28:17.971898","description":"<p>Own it</p>"}
+		],"pagination":{"countPages":2,"current":1}}}`,
+		2: `{"success":true,"data":{"jobs":[
+			{"id":3400,"name":"Product Designer","company":{"name":"Acme"},"createdAt":"","description":"<p>Design</p>"}
+		],"pagination":{"countPages":2,"current":2}}}`,
+	}}
+
+	jobs, err := NewTecla(fake).Fetch(context.Background(), CompanyEntry{Company: "Tecla", Provider: "tecla"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (two pages)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j := byID["3301"]
+	if j.Title != "Practice / Business Development" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	// The marketplace posting carries its OWN employer — not the configured placeholder.
+	if j.Company != "Sliiip" {
+		t.Errorf("Company = %q, want Sliiip (per-job, not the entry's Tecla)", j.Company)
+	}
+	if want := "https://app.tecla.io/job?id=3301"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want true/remote (remote-only marketplace)", j.Remote, j.WorkMode)
+	}
+	if !strings.Contains(j.Description, "<p>Grow it</p>") || strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 5, 25, 17, 2, 0, 864421000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-05-25T17:02:00.864421 (no-tz layout)", j.PostedAt)
+	}
+
+	if byID["3308"].Company != "Psyflo" {
+		t.Errorf("Company = %q, want Psyflo", byID["3308"].Company)
+	}
+	if byID["3400"].PostedAt != nil {
+		t.Errorf("blank createdAt should yield nil PostedAt, got %v", byID["3400"].PostedAt)
+	}
+}
+
+func TestTeclaStopsAtReportedPageCount(t *testing.T) {
+	// countPages=1, so the adapter must stop after page 1 and never request page 2,
+	// even though a page-2 response exists in the fake.
+	fake := &teclaHTTP{pages: map[int]string{
+		1: `{"success":true,"data":{"jobs":[{"id":1,"name":"Only","company":{"name":"X"},"createdAt":"","description":"x"}],"pagination":{"countPages":1,"current":1}}}`,
+		2: `{"success":true,"data":{"jobs":[{"id":2,"name":"Nope","company":{"name":"Y"},"createdAt":"","description":"y"}],"pagination":{"countPages":1,"current":2}}}`,
+	}}
+	jobs, err := NewTecla(fake).Fetch(context.Background(), CompanyEntry{Company: "Tecla"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (stop at reported page count)", len(jobs))
+	}
+	if len(fake.gotPages) != 1 || fake.gotPages[0] != 1 {
+		t.Errorf("fetched pages = %v, want only [1]", fake.gotPages)
+	}
+}
+
+func TestTeclaTransportErrorFailsBoard(t *testing.T) {
+	fake := &teclaHTTP{fail: true}
+	if _, err := NewTecla(fake).Fetch(context.Background(), CompanyEntry{Company: "Tecla"}); err == nil {
+		t.Fatal("Fetch: want transport error, got nil")
+	}
+}
+
+func TestTeclaRegisteredInAllAndBoardless(t *testing.T) {
+	s, ok := All(nil)["tecla"]
+	if !ok {
+		t.Fatal(`All(nil)["tecla"] missing`)
+	}
+	if _, isBoardless := s.(boardless); !isBoardless {
+		t.Error("tecla should be boardless (one global feed, no board id)")
+	}
+}

--- a/openspec/changes/tecla-source/.openspec.yaml
+++ b/openspec/changes/tecla-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/tecla-source/design.md
+++ b/openspec/changes/tecla-source/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The `internal/sources` package is a registry of one adapter per ATS/job platform, all
+implementing `Source.Fetch(ctx, CompanyEntry) ([]Job, error)`. Single-company adapters
+(`uber`, `amazon`) implement the `boardless` marker so their board-file entries may omit
+`board`. `app.tecla.io` is a React SPA backed by a public JSON API (`api.tecla.io`); its
+`getPublicJobs` endpoint returns a paginated, structured list of postings — but it is a
+**marketplace**, so each posting names its own employer, and the description it returns is
+truncated (the full text sits behind login).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `tecla` adapter that crawls the whole marketplace through `getPublicJobs` pagination and
+  yields normalized `Job`s with the correct per-posting company.
+- Mark every job remote (the platform is remote-only) and date it from `createdAt`.
+- Follow the established boardless-adapter shape so the feature fits without restructuring.
+
+**Non-Goals:**
+- Salary (no field on `Job`), skills/seniority parsing (ingest dictionaries own that).
+- Authenticated full-description fetch — out of scope; we accept the truncated public text.
+- Cron scheduling — lives in the `freehire-ops` repo.
+
+## Decisions
+
+- **Adapter over `internal/sources`, not `linksource`.** Tecla exposes a whole board (a paginated
+  list), which is what `Source` adapts; `linksource` resolves a single detail URL. The shape
+  matches `uber`/`amazon` (boardless single endpoint), with the one twist below.
+- **Per-job company from the payload.** Unlike every existing adapter, `Job.Company` comes from
+  `posting.company.name`, not `e.Company`. `e.Company` ("Tecla") is only a validation placeholder.
+  This is the one genuinely new behavior and is captured as a spec requirement.
+- **JSON over the shared `HTTPClient`**, decoded into a typed `teclaResponse` (`data.jobs[]` +
+  `data.pagination.countPages`). Paginate `?page=N` from 1 through `countPages`, bounded by a
+  defensive `teclaMaxPages` cap (mirrors `gpMaxPages`) so a misbehaving `countPages` can't loop.
+- **Remote is a source property, not a guess.** `Remote=true` / `WorkMode="remote"` for all jobs
+  because the marketplace is remote-only — the same justification a "remote jobs" board would use.
+  Location is left empty (`city`/`state` are blank in the payload).
+- **`createdAt` layout.** The API emits `2026-05-25T17:02:00.864421` (no zone), which `parseRFC3339`
+  rejects; a dedicated `time.Parse` layout `2006-01-02T15:04:05.999999` handles it, funneled through
+  the shared `NotFuture` guard.
+- **Description taken as-is, sanitized** with the shared `sanitizeHTML`, consistent with other adapters.
+
+## Risks / Trade-offs
+
+- [Truncated descriptions weaken the catalogue entry and LLM enrichment] → Accepted per product
+  decision; the alternative (auth-gated fetch + credential storage) was judged not worth the
+  complexity for an MVP daily ingest. The seam (an authenticated `jobDetail` fetch) is noted, not built.
+- [`getPublicJobs` is an undocumented endpoint that could change shape] → The typed decode fails
+  loudly and the per-board isolation means a tecla break is counted, not fatal to the ingest run.
+- [Marketplace reposts a vacancy that also exists on its real ATS] → No cross-source dedup (dedup key
+  is `(source, external_id)`); a duplicate under `source="tecla"` is acceptable and consistent with
+  how every other source behaves.
+
+## Open Questions
+
+None — scope and behavior are settled.

--- a/openspec/changes/tecla-source/proposal.md
+++ b/openspec/changes/tecla-source/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`app.tecla.io` is a remote-only marketplace of LatAm engineering vacancies behind a
+clean, paginated public JSON API. It is a worthwhile catalogue source, but it does not
+fit any existing adapter shape: unlike every current source it is an **aggregator** whose
+postings each carry their **own** employer, so the company cannot come from board-file
+config the way it does for a single-company (`uber`, `amazon`) or per-tenant (`greenhouse`)
+board.
+
+## What Changes
+
+- Add a `tecla` source adapter (`internal/sources/tecla.go`) implementing `Source` and the
+  `boardless` marker, paginating `https://api.tecla.io/api/jobs/getPublicJobs/?page=N` over
+  `data.pagination.countPages` (bounded by a defensive max-page cap).
+- Map each posting to `sources.Job`: `ExternalID=id`, `URL=https://app.tecla.io/job?id=<id>`,
+  `Title=name`, **`Company=` the posting's own `company.name`** (the new aggregator behavior),
+  `Description=` the public (sanitized) text, `Remote=true` + `WorkMode="remote"` (the platform
+  is remote-only), `PostedAt=createdAt` parsed with a no-timezone layout.
+- Register `NewTecla(c)` in `sources.All` and add `sources/tecla.yml` (one entry: `company: Tecla`,
+  `provider: tecla`; boardless, so no `board`).
+- Out of scope (intentional): salary (no field on `Job`), skills/seniority parsing (the ingest
+  dictionaries own that), and the auth-gated full-description fetch — the public API truncates
+  the description and we take it as-is. The daily cron lives in the separate `freehire-ops` repo.
+
+## Capabilities
+
+### New Capabilities
+<!-- none — this extends the existing source-ingest capability -->
+
+### Modified Capabilities
+- `source-ingest`: adds the requirement that an **aggregator** provider derives each job's company
+  from the posting itself rather than from the configured board entry, and registers `tecla` as a
+  boardless provider.
+
+## Impact
+
+- New: `internal/sources/tecla.go`, `internal/sources/tecla_test.go`, `sources/tecla.yml`.
+- Modified: `internal/sources/source.go` (one line in `All`).
+- No schema, migration, or API change. New jobs flow through the existing `UpsertJob`/enrichment
+  path unchanged; reaching the catalogue is a `freehire-ops` cron addition (out of this repo).

--- a/openspec/changes/tecla-source/specs/source-ingest/spec.md
+++ b/openspec/changes/tecla-source/specs/source-ingest/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: An aggregator provider derives each job's company from the posting
+
+An aggregator provider MUST set each job's company from the posting payload itself, not from the configured board entry. An aggregator is a provider that crawls a marketplace whose postings each name a different employer. The configured entry's company field is a placeholder used only to satisfy board-file validation. An aggregator provider MUST be boardless (one global feed, no per-tenant board id), so its entry omits the board id.
+
+#### Scenario: Each posting keeps its own employer
+
+- **WHEN** an aggregator board returns postings whose payloads name employers "Sliiip" and "Psyflo"
+- **THEN** the corresponding jobs carry `Company` "Sliiip" and "Psyflo" respectively
+- **AND** neither inherits the configured entry's placeholder company
+
+### Requirement: Tecla is a registered boardless aggregator provider
+
+The `tecla` provider SHALL crawl the `app.tecla.io` marketplace through its public JSON API,
+paginating `getPublicJobs` over the API-reported page count up to a defensive cap, and map
+each posting to the normalized job shape. Tecla is a remote-only marketplace, so every job
+SHALL be marked remote. The public API truncates the description; the adapter SHALL persist
+that public text as-is (the full, auth-gated text is intentionally not fetched).
+
+#### Scenario: Tecla board is crawled across pages
+
+- **WHEN** the `tecla` provider crawls its boardless entry and the API reports more than one page
+- **THEN** the adapter requests each page through the API-reported page count
+- **AND** every returned posting becomes a job with `ExternalID` set to the posting id and `URL` pointing at `app.tecla.io/job?id=<id>`
+
+#### Scenario: Tecla posting maps to a remote job with its own employer
+
+- **WHEN** a tecla posting carries a title, an employer name, a created timestamp, and a (truncated) description
+- **THEN** the job's `Title`, `Company`, `PostedAt`, and `Description` come from that payload
+- **AND** the job is marked remote (`Remote` true, `WorkMode` "remote")

--- a/openspec/changes/tecla-source/tasks.md
+++ b/openspec/changes/tecla-source/tasks.md
@@ -1,0 +1,14 @@
+## 1. Adapter
+
+- [x] 1.1 Write table-driven `tecla_test.go` on a fake `HTTPClient`: assert pagination across `countPages`, per-job company from the payload, `ExternalID`/`URL`/`Title`/`PostedAt`/`Description` mapping, `Remote`/`WorkMode="remote"`, and the boardless marker (RED)
+- [x] 1.2 Implement `internal/sources/tecla.go`: `NewTecla`, `Provider()`, `boardless()`, `Fetch` paginating `getPublicJobs` over `countPages` (capped), typed JSON decode, posting→`Job` mapping with the no-timezone `createdAt` layout (GREEN)
+
+## 2. Wiring
+
+- [x] 2.1 Register `NewTecla(c)` in `sources.All` (`internal/sources/source.go`)
+- [x] 2.2 Add `sources/tecla.yml` with one boardless entry (`company: Tecla`, `provider: tecla`)
+
+## 3. Verify
+
+- [x] 3.1 `go build ./...`, `go vet ./...`, `go test ./internal/sources/` green
+- [x] 3.2 Live smoke against the real API: `go run ./cmd/ingest sources/tecla.yml` (or an equivalent fetch) returns real postings with correct per-job company and remote flag

--- a/sources/tecla.yml
+++ b/sources/tecla.yml
@@ -1,0 +1,4 @@
+# tecla marketplace. Boardless: one global public feed (api.tecla.io/getPublicJobs), so the
+# entry carries no board, and each job's company comes from the posting, not this placeholder.
+- company: Tecla
+  provider: tecla


### PR DESCRIPTION
## Summary
- New `tecla` source adapter ingesting remote LatAm vacancies from `app.tecla.io`'s public `getPublicJobs` JSON API.
- First **marketplace aggregator** source: a single global paginated feed where each posting names its own employer, so `Company` comes from the payload — not the board-file entry (captured as a `source-ingest` spec delta).
- `boardless` (no per-tenant board id); paginates `?page=N` over `data.pagination.countPages` bounded by a defensive cap; `Remote=true`/`WorkMode="remote"` (remote-only marketplace); zone-less `createdAt` layout; sanitized (truncated) public description.
- Wiring: `NewTecla(c)` in `sources.All` + one-entry `sources/tecla.yml`.

## Out of scope (intentional)
- Salary (no field on `sources.Job`), skills/seniority parsing (ingest dictionaries own that), and the auth-gated full-description fetch (public API truncates the description — accepted).
- Daily cron lives in the separate `freehire-ops` repo.

## Test Plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/sources/` green (table-driven: pagination stop-at-countPages without over-fetching, per-job company, remote flag, transport-error, boardless registration)
- [x] Live smoke against the real API: 51 jobs across 9 pages, per-job company (Sliiip, VIP Software, Levatas, …), `remote=true`, `createdAt` parsed correctly
- [ ] After merge: add the daily `ingest sources/tecla.yml` cron in `freehire-ops`; reindex so the jobs surface in search

🤖 Generated with [Claude Code](https://claude.com/claude-code)