### PR TITLE
feat(sources): add jobstash Web3 aggregator adapter

### DIFF
--- a/internal/sources/jobstash.go
+++ b/internal/sources/jobstash.go
@@ -1,0 +1,156 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"strings"
+)
+
+// jobstash adapts JobStash (middleware.jobstash.xyz), a Web3 job aggregator. Unlike the
+// per-company ATS adapters it is boardless (one API, no per-tenant board) yet aggregates
+// many employers, so it is also an aggregator (stays in the source facet) and takes each
+// posting's company from its own organization.name. The list endpoint carries every
+// posting's body inline, so there is no per-posting detail request; it paginates by page.
+type jobstash struct {
+	http JSONGetter
+}
+
+const (
+	jobstashListURL = "https://middleware.jobstash.xyz/jobs/list?page=%d&limit=%d"
+	// jobstashDetailURL is the public posting page, used as the link for a protected
+	// posting whose url is null (the /jobs/list feed omits the gated apply link).
+	jobstashDetailURL = "https://jobstash.xyz/jobs/%s/details"
+	jobstashPageSize  = 200
+	// jobstashMaxPages bounds pagination so a server that mis-reports total (never
+	// emptying its data) cannot loop forever; the empty-page check ends it sooner.
+	jobstashMaxPages = 200
+)
+
+// NewJobStash builds the JobStash adapter over the given HTTP client.
+func NewJobStash(c JSONGetter) Source { return jobstash{http: c} }
+
+func (jobstash) Provider() string { return "jobstash" }
+
+// jobstash needs no board id (one API), so its config carries no board.
+func (jobstash) boardless() {}
+
+// jobstash aggregates postings from many companies, so it stays in the source facet.
+func (jobstash) aggregator() {}
+
+// jobstashPosting is one posting with its body inline (no detail call). url is already the
+// right target: the downstream ATS link for a public posting, the JobStash page for a
+// protected one.
+type jobstashPosting struct {
+	ShortUUID        string   `json:"shortUUID"`
+	Title            string   `json:"title"`
+	URL              string   `json:"url"`
+	Location         string   `json:"location"`
+	LocationType     string   `json:"locationType"`
+	Timestamp        int64    `json:"timestamp"`
+	Description      string   `json:"description"`
+	Responsibilities []string `json:"responsibilities"`
+	Requirements     []string `json:"requirements"`
+	Benefits         []string `json:"benefits"`
+	Organization     struct {
+		Name string `json:"name"`
+	} `json:"organization"`
+}
+
+func (j jobstash) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	postings, err := j.list(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// list walks the job-list endpoint page by page (page size jobstashPageSize) until the
+// reported total is reached or a page returns no postings, whichever comes first. Each page
+// carries postings with their body inline.
+func (j jobstash) list(ctx context.Context) ([]jobstashPosting, error) {
+	var all []jobstashPosting
+	for page := 1; page <= jobstashMaxPages; page++ {
+		var resp struct {
+			Total int               `json:"total"`
+			Data  []jobstashPosting `json:"data"`
+		}
+		url := fmt.Sprintf(jobstashListURL, page, jobstashPageSize)
+		if err := j.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("jobstash: page %d: %w", page, err)
+		}
+		all = append(all, resp.Data...)
+		if len(resp.Data) == 0 || len(all) >= resp.Total {
+			break
+		}
+	}
+	return all, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
+// native id, which would collide on the dedup key, or no company, which would break the
+// slug) so the caller drops just that one. Company comes from the posting's own
+// organization; the structured locationType sets the work mode, with the remote flag
+// falling back to the location text.
+func (p jobstashPosting) toJob() (Job, bool) {
+	if p.ShortUUID == "" || p.Organization.Name == "" {
+		return Job{}, false
+	}
+	workMode := workplaceTypeMode(p.LocationType)
+	return Job{
+		ExternalID:  p.ShortUUID,
+		URL:         p.url(),
+		Title:       p.Title,
+		Company:     p.Organization.Name,
+		Location:    p.Location,
+		Description: p.description(),
+		WorkMode:    workMode,
+		Remote:      workMode == "remote" || isRemote(p.Location),
+		PostedAt:    parseEpochMillis(p.Timestamp),
+	}, true
+}
+
+// url is the posting's link: the inline url when present (the downstream ATS link for a
+// public posting), else the JobStash detail page built from shortUUID (a protected
+// posting's apply link is gated, so the feed leaves url null — we link to its JobStash
+// page instead of dropping the vacancy).
+func (p jobstashPosting) url() string {
+	if p.URL != "" {
+		return p.URL
+	}
+	return fmt.Sprintf(jobstashDetailURL, p.ShortUUID)
+}
+
+// description assembles the posting's prose and its responsibilities/requirements/benefits
+// lists into sanitized HTML. Each text value is HTML-escaped before wrapping, so a stray
+// angle bracket in source text cannot inject markup; a section with no items is omitted.
+func (p jobstashPosting) description() string {
+	var b strings.Builder
+	if p.Description != "" {
+		b.WriteString("<p>" + html.EscapeString(p.Description) + "</p>")
+	}
+	writeJobstashSection(&b, "Responsibilities", p.Responsibilities)
+	writeJobstashSection(&b, "Requirements", p.Requirements)
+	writeJobstashSection(&b, "Benefits", p.Benefits)
+	return sanitizeHTML(b.String())
+}
+
+// writeJobstashSection appends an <h3> heading and a bulleted list for the items, or nothing
+// when items is empty.
+func writeJobstashSection(b *strings.Builder, heading string, items []string) {
+	if len(items) == 0 {
+		return
+	}
+	b.WriteString("<h3>" + heading + "</h3><ul>")
+	for _, it := range items {
+		b.WriteString("<li>" + html.EscapeString(it) + "</li>")
+	}
+	b.WriteString("</ul>")
+}

--- a/internal/sources/jobstash_test.go
+++ b/internal/sources/jobstash_test.go
@@ -1,0 +1,190 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// jobstashJob builds one inline posting fragment (body inline — no detail call). access is
+// "public" (url is the downstream ATS link) or "protected" (url is the JobStash page).
+func jobstashJob(shortUUID, title, org, url, access, location, locationType string, ts int64, responsibilities, requirements string) string {
+	return `{"shortUUID":"` + shortUUID + `","title":"` + title +
+		`","organization":{"name":"` + org + `"},"url":"` + url +
+		`","access":"` + access + `","location":"` + location +
+		`","locationType":"` + locationType + `","timestamp":` + itoa64(ts) +
+		`,"description":"Build things.","responsibilities":["` + responsibilities +
+		`"],"requirements":["` + requirements + `"],"benefits":[]}`
+}
+
+// jobstashListPage wraps postings in the page/count/total/data envelope.
+func jobstashListPage(total int, jobs ...string) string {
+	return `{"page":1,"count":` + itoa(len(jobs)) + `,"total":` + itoa(total) +
+		`,"data":[` + strings.Join(jobs, ",") + `]}`
+}
+
+func itoa64(n int64) string { return itoa(int(n)) }
+
+func TestJobStashProvider(t *testing.T) {
+	if got := NewJobStash(nil).Provider(); got != "jobstash" {
+		t.Errorf("Provider() = %q, want %q", got, "jobstash")
+	}
+}
+
+func TestJobStashIsBoardlessAggregator(t *testing.T) {
+	s := NewJobStash(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("jobstash should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("jobstash should implement the aggregator marker (multi-company)")
+	}
+}
+
+func TestJobStashRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["jobstash"]; !ok {
+		t.Error("All() should register provider jobstash")
+	}
+	if !slices.Contains(FilterableProviders(), "jobstash") {
+		t.Error("FilterableProviders() should include the jobstash aggregator")
+	}
+}
+
+func TestJobStashBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/jobstash.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig(sources/jobstash.yml): %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/jobstash.yml fails registry validation: %v", err)
+	}
+}
+
+func TestJobStashFetchPaginatesAndMaps(t *testing.T) {
+	// total=300 with page size 200: page 1 then page 2 (after which len(all)=2... the
+	// loop stops on the empty page 3). Each posting's body is inline — no detail call.
+	fake := (&routedHTTP{}).
+		route("page=1", jobstashListPage(300,
+			jobstashJob("Z2IGg7", "Associate Tech Lead", "KAST",
+				"https://kastcard.pinpointhq.com/en/postings/abc", "public",
+				"Remote", "HYBRID", 1781521356188,
+				"Design back-end components", "6+ years experience"),
+		)).
+		route("page=2", jobstashListPage(300,
+			jobstashJob("PqCopo", "Head of Capital", "Symbiotic",
+				"https://jobstash.xyz/jobs/PqCopo/details", "protected",
+				"New York", "REMOTE", 1746057600000,
+				"Lead fundraising", "Network"),
+		)).
+		route("page=3", jobstashListPage(300)) // empty tail page ends pagination
+
+	jobs, err := NewJobStash(fake).Fetch(context.Background(), CompanyEntry{Provider: "jobstash"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 across two pages", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	// Public posting: company from organization.name, url is the downstream ATS link.
+	a, ok := byID["Z2IGg7"]
+	if !ok {
+		t.Fatal("posting Z2IGg7 missing")
+	}
+	if a.Title != "Associate Tech Lead" {
+		t.Errorf("Title = %q", a.Title)
+	}
+	if a.Company != "KAST" {
+		t.Errorf("Company = %q, want organization.name KAST", a.Company)
+	}
+	if want := "https://kastcard.pinpointhq.com/en/postings/abc"; a.URL != want {
+		t.Errorf("URL = %q, want downstream ATS link %q", a.URL, want)
+	}
+	if a.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid from locationType HYBRID", a.WorkMode)
+	}
+	for _, want := range []string{"Build things", "Design back-end components", "6+ years experience"} {
+		if !strings.Contains(a.Description, want) {
+			t.Errorf("Description missing %q, got %q", want, a.Description)
+		}
+	}
+	// HYBRID work mode, but the location text "Remote" still flags the job remote
+	// (the isRemote fallback wins over a non-remote work mode).
+	if !a.Remote {
+		t.Error("Remote = false, want true: location text 'Remote' triggers the isRemote fallback")
+	}
+	if a.PostedAt == nil || a.PostedAt.Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed from epoch-ms timestamp", a.PostedAt)
+	}
+
+	// Protected posting: url is the JobStash detail page; REMOTE → remote work mode + flag.
+	b := byID["PqCopo"]
+	if want := "https://jobstash.xyz/jobs/PqCopo/details"; b.URL != want {
+		t.Errorf("protected URL = %q, want JobStash page %q", b.URL, want)
+	}
+	if b.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote from locationType REMOTE", b.WorkMode)
+	}
+	if !b.Remote {
+		t.Error("Remote = false, want true for a REMOTE posting")
+	}
+}
+
+// On /jobs/list a protected posting can carry url:null (unlike /public/jobs). The adapter
+// falls back to the JobStash detail page built from shortUUID, so the job keeps a working
+// link instead of an empty URL.
+func TestJobStashProtectedNullURLFallsBackToJobStashPage(t *testing.T) {
+	nullURLJob := `{"shortUUID":"UHWdXV","title":"Head of Product","organization":{"name":"Layer3"},` +
+		`"url":null,"access":"protected","location":"","locationType":"REMOTE","timestamp":1746057600000,` +
+		`"description":"d","responsibilities":[],"requirements":[],"benefits":[]}`
+	fake := (&routedHTTP{}).route("page=1", `{"total":1,"data":[`+nullURLJob+`]}`)
+
+	jobs, err := NewJobStash(fake).Fetch(context.Background(), CompanyEntry{Provider: "jobstash"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if want := "https://jobstash.xyz/jobs/UHWdXV/details"; jobs[0].URL != want {
+		t.Errorf("URL = %q, want synthesized JobStash page %q for a null-url protected posting", jobs[0].URL, want)
+	}
+}
+
+// A posting with no company (empty organization.name) or no native id would break the
+// company slug / dedup key, so it is dropped rather than persisted.
+func TestJobStashSkipsPostingWithoutCompanyOrID(t *testing.T) {
+	noCompany := `{"shortUUID":"X1","title":"T","organization":{"name":""},"url":"https://x.co/a",` +
+		`"access":"public","location":"","locationType":"","timestamp":0,"description":"d",` +
+		`"responsibilities":[],"requirements":[],"benefits":[]}`
+	noID := `{"shortUUID":"","title":"T2","organization":{"name":"Acme"},"url":"https://x.co/b",` +
+		`"access":"public","location":"","locationType":"","timestamp":0,"description":"d",` +
+		`"responsibilities":[],"requirements":[],"benefits":[]}`
+	fake := (&routedHTTP{}).route("page=1", `{"total":2,"data":[`+noCompany+`,`+noID+`]}`)
+
+	jobs, err := NewJobStash(fake).Fetch(context.Background(), CompanyEntry{Provider: "jobstash"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("len(jobs) = %d, want 0 (both postings are unusable)", len(jobs))
+	}
+}
+
+func TestJobStashEmptyListYieldsNoJobsNoError(t *testing.T) {
+	fake := (&routedHTTP{}).route("page=1", jobstashListPage(0))
+
+	jobs, err := NewJobStash(fake).Fetch(context.Background(), CompanyEntry{Provider: "jobstash"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -49,21 +49,33 @@ type Source interface {
 	Fetch(ctx context.Context, e CompanyEntry) ([]Job, error)
 }
 
-// boardless marks an adapter whose source is one company's own API, with no per-tenant
-// board id. Config validation lets a boardless provider's entries omit board. Multi-tenant
-// ATS adapters (greenhouse, lever, …) do not implement it and still require a board.
+// boardless marks an adapter whose API has no per-tenant board id, so config
+// validation lets its entries omit board. A boardless adapter may serve one company
+// (greenhouse/lever and the other multi-tenant ATS adapters are NOT boardless and
+// still require a board) or aggregate many (see aggregator).
 type boardless interface{ boardless() }
 
-// FilterableProviders returns the sorted provider keys of the multi-tenant ATS
-// adapters — those NOT implementing the boardless marker. The source facet filters
-// by platform, and a single-company (boardless) platform is redundant with the
-// company filter, so it is excluded. Passing a nil client is safe: Provider() and
-// the boardless assertion never touch the transport.
-func FilterableProviders() []string {
+// aggregator marks a boardless adapter that aggregates postings from many companies
+// (e.g. jobstash) rather than serving a single company. It keeps such an adapter in
+// the source facet: a single-company boardless platform is redundant with the company
+// filter and excluded, but filtering by an aggregator is not.
+type aggregator interface{ aggregator() }
+
+// FilterableProviders returns the sorted provider keys the source facet offers.
+// Passing a nil client is safe: Provider() and the marker assertions never touch the
+// transport.
+func FilterableProviders() []string { return filterableProviders(All(nil)) }
+
+// filterableProviders selects the source-facet provider keys from a registry. A
+// single-company boardless platform is redundant with the company filter and excluded;
+// a board-based platform or a multi-company aggregator stays listed.
+func filterableProviders(registry map[string]Source) []string {
 	var out []string
-	for key, src := range All(nil) {
+	for key, src := range registry {
 		if _, isBoardless := src.(boardless); isBoardless {
-			continue
+			if _, isAggregator := src.(aggregator); !isAggregator {
+				continue
+			}
 		}
 		out = append(out, key)
 	}
@@ -94,8 +106,9 @@ func All(c HTTPClient) map[string]Source {
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),
-		// Marketplace aggregator (boardless): one global feed, company per posting.
+		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
+		NewJobStash(c),
 		// International single-company adapters (boardless).
 		NewUber(c),
 		NewAmazon(c),

--- a/internal/sources/source_test.go
+++ b/internal/sources/source_test.go
@@ -22,6 +22,19 @@ func (f fakeBoardlessSource) Fetch(context.Context, CompanyEntry) ([]Job, error)
 
 func (f fakeBoardlessSource) boardless() {}
 
+// fakeAggregatorSource is boardless (no board id) but aggregates many companies,
+// so it declares itself an aggregator and must stay in the source facet.
+type fakeAggregatorSource struct{ provider string }
+
+func (f fakeAggregatorSource) Provider() string { return f.provider }
+
+func (f fakeAggregatorSource) Fetch(context.Context, CompanyEntry) ([]Job, error) {
+	return nil, nil
+}
+
+func (f fakeAggregatorSource) boardless()  {}
+func (f fakeAggregatorSource) aggregator() {}
+
 func TestRegIndexesByProvider(t *testing.T) {
 	r := reg(fakeSource{"greenhouse"}, fakeSource{"lever"})
 
@@ -63,5 +76,23 @@ func TestFilterableProviders(t *testing.T) {
 	}
 	if !slices.IsSorted(got) {
 		t.Errorf("FilterableProviders() not sorted: %v", got)
+	}
+}
+
+func TestFilterableProvidersKeepsAggregatorsDropsSingleCompany(t *testing.T) {
+	got := filterableProviders(reg(
+		fakeSource{"greenhouse"},         // board-based → listed
+		fakeBoardlessSource{"ozon"},      // single-company boardless → excluded
+		fakeAggregatorSource{"jobstash"}, // aggregator boardless → listed
+	))
+
+	if !slices.Contains(got, "greenhouse") {
+		t.Errorf("filterableProviders() missing board-based %q", "greenhouse")
+	}
+	if !slices.Contains(got, "jobstash") {
+		t.Errorf("filterableProviders() should list aggregator %q", "jobstash")
+	}
+	if slices.Contains(got, "ozon") {
+		t.Errorf("filterableProviders() should exclude single-company boardless %q", "ozon")
 	}
 }

--- a/internal/sources/tecla.go
+++ b/internal/sources/tecla.go
@@ -36,6 +36,9 @@ func (tecla) Provider() string { return "tecla" }
 // tecla is a marketplace with one global feed, so its config entries carry no board.
 func (tecla) boardless() {}
 
+// tecla aggregates postings from many companies, so it stays in the source facet.
+func (tecla) aggregator() {}
+
 // teclaResponse is the getPublicJobs response: Data.Jobs is the page, Data.Pagination.CountPages
 // the total page count used to stop pagination.
 type teclaResponse struct {

--- a/internal/sources/tecla_test.go
+++ b/internal/sources/tecla_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -132,5 +133,12 @@ func TestTeclaRegisteredInAllAndBoardless(t *testing.T) {
 	}
 	if _, isBoardless := s.(boardless); !isBoardless {
 		t.Error("tecla should be boardless (one global feed, no board id)")
+	}
+	// tecla aggregates many companies, so it must stay in the source facet.
+	if _, isAggregator := s.(aggregator); !isAggregator {
+		t.Error("tecla should be an aggregator (multi-company marketplace)")
+	}
+	if !slices.Contains(FilterableProviders(), "tecla") {
+		t.Error("FilterableProviders() should include the tecla aggregator")
 	}
 }

--- a/openspec/changes/jobstash-source/.openspec.yaml
+++ b/openspec/changes/jobstash-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/jobstash-source/design.md
+++ b/openspec/changes/jobstash-source/design.md
@@ -1,0 +1,110 @@
+# Design — jobstash-source
+
+## Context
+
+JobStash exposes `GET https://middleware.jobstash.xyz/jobs/list?page=&limit=`
+(no auth). The response is `{page, count, total, data: [job]}`. Each job carries
+the full posting inline (no per-posting detail call needed): `title`, `summary`,
+`description`, `responsibilities[]`, `requirements[]`, `benefits[]`, `url`,
+`access` (`public`/`protected`), `shortUUID`, `location`, `locationType`
+(`ONSITE`/`REMOTE`/`HYBRID`/null), `timestamp` (epoch ms), and `organization`
+(an object whose `name` is the employer). A probe confirmed ~3058 postings; a
+public posting carries the downstream ATS link in `url`, while a **protected
+posting's `url` is null** on this feed (~18% of postings — the gated apply link
+is omitted). For a null `url` the adapter synthesizes the JobStash detail page
+`jobstash.xyz/jobs/{shortUUID}/details` (what `/public/jobs` serves server-side),
+so a protected vacancy keeps a working link rather than an empty URL.
+
+This fits the existing single-stage adapter pattern (like Sber/AlfaBank: list
+endpoint carries the body inline, walk pages to `total`, no detail fan-out).
+
+## Goals / Non-goals
+
+- **Goal:** one `jobstash` adapter yielding all postings across companies, kept
+  filterable in the source facet.
+- **Non-goal:** cross-source dedup against the direct ATS crawls (accepted
+  overlap), enrichment changes, or any schema/migration change.
+
+## Decisions
+
+### Adapter shape (single-stage, paginated)
+
+`Fetch` ignores `e.Board` (boardless) and loops `page=1..` with a fixed
+`limit=200`, accumulating `data` until `page*limit >= total` (or `data` is
+empty). Context cancellation is honoured between pages. The list body is
+complete, so there is no `fetchDetails` fan-out.
+
+### Field mapping (`sources.Job`)
+
+| Job field    | Source                                                                 |
+|--------------|------------------------------------------------------------------------|
+| `Title`      | `title`                                                                 |
+| `Company`    | `organization.name`                                                    |
+| `URL`        | `url` when set (public = ATS link); else synthesized JobStash page from `shortUUID` (null on protected) |
+| `ExternalID` | `shortUUID` (stable; also the id in the protected URL)                  |
+| `Location`   | `location`                                                             |
+| `WorkMode`   | `locationType` via the shared `workplaceTypeMode` (lowercases + maps)   |
+| `Remote`     | `WorkMode == "remote"` OR `isRemote(Location)`                          |
+| `Description`| compose `description` + responsibilities + requirements + benefits      |
+| `PostedAt`   | `timestamp` (epoch ms) via `parseEpochMillis`                          |
+
+`workplaceTypeMode` already lowercases and maps `remote`/`hybrid`/`onsite`, so
+`REMOTE`/`HYBRID`/`ONSITE` map cleanly; null/unknown → `""`.
+
+The description is assembled into sanitized HTML consistent with the other
+adapters: the prose `description`, then `<h*>`/`<ul>` sections for
+Responsibilities, Requirements, and Benefits when present. A posting missing all
+of these still yields (empty body is acceptable, as elsewhere).
+
+### `external_id` and dedup
+
+The pipeline namespaces as `"<board>:<ExternalID>"`. With an empty board the
+stored `external_id` is `:<shortUUID>` — consistent with every existing boardless
+adapter (`ozon`, `uber`, …). `shortUUID` is unique across the whole JobStash
+catalogue, so this is collision-free. Overlap with the direct ATS crawls is by
+design (different `source`), and is accepted.
+
+### `boardless` vs `aggregator` (the marker split)
+
+`boardless` currently does double duty: "needs no board id" AND "single company,
+so excluded from the source facet". JobStash breaks the second half. The surgical
+fix keeps `boardless` meaning only "no board id" and introduces a second opt-in
+marker:
+
+```go
+type aggregator interface{ aggregator() }
+```
+
+`FilterableProviders` changes from "exclude boardless" to "exclude boardless that
+is NOT an aggregator":
+
+```go
+if bl, ok := src.(boardless); ok {
+    if _, agg := src.(aggregator); !agg { continue } // single-company boardless: skip
+}
+```
+
+`JobStash` and the already-merged `tecla` marketplace implement `aggregator()`
+(both are `boardless()` multi-company feeds); `tecla` was wrongly excluded from
+the facet before this marker existed, so it adopts it here. The single-company
+boardless adapters are untouched and stay excluded. Board-based adapters never
+matched the boardless branch, so they stay listed. Regenerating the web contract
+also surfaces `globalpayments`, which had drifted out of the stale `SOURCE_VALUES`.
+
+## Risks / Trade-offs
+
+- **Undocumented endpoint.** `/jobs/list` is the site's own frontend API, not the
+  smaller documented `/public/jobs` (278 postings). It is richer and 10× the
+  coverage; the trade is a contract that could shift. Mitigation: the adapter
+  decodes only the handful of fields it maps and tolerates missing fields, so a
+  field addition is harmless and a removal degrades one field rather than failing
+  the board.
+- **Catalogue growth from dupes.** Accepted per the proposal; no mitigation in
+  scope.
+
+## Migration / Rollout
+
+No schema or data migration. After merge, add the cron entry for
+`sources/jobstash.yml` and regenerate the web contract (`make gen-contracts`) so
+`jobstash` appears in the source facet. First ingest run populates the new
+`source = "jobstash"` jobs; the normal enrichment/reindex pipeline picks them up.

--- a/openspec/changes/jobstash-source/proposal.md
+++ b/openspec/changes/jobstash-source/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The catalogue has no crypto/Web3 coverage. JobStash (`middleware.jobstash.xyz`)
+is a Web3 job aggregator exposing a public, no-auth JSON API of ~3000 open
+postings with structured fields (organization, location type, salary, seniority,
+tags). It fits the existing `Source` adapter shape, so a single adapter adds a
+whole vertical the direct ATS crawls miss (small Web3 shops off the mainstream
+ATS platforms).
+
+## What Changes
+
+- **Add a `jobstash` source adapter** that paginates JobStash's
+  `GET /jobs/list?page=&limit=` by the response `total` and yields every posting
+  as the normalized job shape. The posting's `url` is passed through as-is — for
+  a `public` posting it is the real downstream ATS apply link, for a `protected`
+  posting it is the JobStash detail page (apply with the real link when present,
+  else the best link available). Company comes from each posting's
+  `organization.name`, not from configuration. Registered in `sources.All` with
+  one entry in `sources/jobstash.yml`.
+- **Decouple `boardless` from "single company".** Today the `boardless` marker
+  means both "needs no board id" *and* "is one company, so redundant with the
+  company filter and excluded from the source facet". JobStash is boardless (one
+  API, no per-tenant board) but aggregates many companies, so it must stay a
+  selectable value in the source facet. A new opt-in `aggregator` marker keeps
+  the source facet listing such a provider; the existing single-company boardless
+  adapters stay excluded and untouched. The already-merged `tecla` marketplace
+  (PR #130) is the same case — a boardless aggregator currently (wrongly) absent
+  from the source facet — so it adopts the new marker too.
+- **Regenerate the stale source-facet contract.** The generated `SOURCE_VALUES`
+  had drifted: `globalpayments` and `tecla` landed without a contract regen, so
+  neither was selectable. Regenerating restores both alongside the new `jobstash`
+  (and adds proper UI labels for `JobStash`/`Global Payments`).
+- **Dedup overlap is accepted.** JobStash republishes postings that the direct
+  greenhouse/lever/ashby crawls already ingest, under a separate `source`
+  (`jobstash`) and `external_id`, so the same vacancy may appear twice. This is
+  acceptable for the crypto-vertical coverage gain; no cross-source dedup is in
+  scope.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `source-ingest`: a boardless provider may aggregate many companies (not only
+  one), and such an aggregator stays a source-facet value; the `jobstash`
+  aggregator adapter is registered.
+
+## Impact
+
+- `internal/sources/jobstash.go` (new adapter) + `jobstash_test.go` + a captured
+  JSON fixture.
+- `internal/sources/source.go`: new `aggregator` marker; `FilterableProviders`
+  excludes `boardless && !aggregator`; register `NewJobStash` in `All`.
+- `internal/sources/tecla.go`: adopts the `aggregator()` marker (one line) so the
+  existing marketplace becomes source-filterable.
+- `sources/jobstash.yml` (new board file, one boardless entry).
+- `web/src/lib/generated/contracts.ts` regenerated (`SOURCE_VALUES` gains
+  `globalpayments`, `jobstash`, `tecla`); `web/src/lib/facets.ts` gains the
+  `JobStash`/`Global Payments` label overrides.
+- No schema, migration, or API-surface change. New jobs ingest under
+  `source = "jobstash"`.

--- a/openspec/changes/jobstash-source/specs/source-ingest/spec.md
+++ b/openspec/changes/jobstash-source/specs/source-ingest/spec.md
@@ -1,0 +1,98 @@
+# source-ingest (delta)
+
+## MODIFIED Requirements
+
+### Requirement: A boardless provider may omit its board id
+
+A source adapter SHALL be able to declare itself `boardless` when its API has no
+per-tenant board id, so its configured entries MAY omit `board`. A `boardless`
+provider MAY serve exactly one company or MAY aggregate postings from many
+companies; the marker concerns only the absence of a board id, not the number of
+companies. A provider that has a board or tenant concept SHALL NOT be boardless
+and SHALL continue to require a non-empty `board`; this includes `yandex`, whose
+`board` selects host and language.
+
+#### Scenario: Boardless adapter is dispatched without a board
+
+- **WHEN** a `boardless` provider's entry is crawled with an empty `board`
+- **THEN** the adapter fetches its postings without requiring a board id and
+  yields the normalized job shape
+
+#### Scenario: Yandex requires its board
+
+- **WHEN** a `yandex` entry is configured with an empty `board`
+- **THEN** validation fails fast, because `yandex` selects host and language (`ru`/`com`)
+  by its `board` and is not boardless
+
+## ADDED Requirements
+
+### Requirement: A multi-company aggregator stays in the source facet
+
+The source facet (the provider list a user filters results by) SHALL exclude a
+`boardless` provider that serves a single company, because filtering by it is
+redundant with the company filter. A `boardless` provider that aggregates
+postings from many companies SHALL declare itself an `aggregator` and SHALL
+remain a value in the source facet, because filtering by "this aggregator" is not
+redundant with any single company. A provider that has a board concept (not
+boardless) SHALL remain in the source facet as before.
+
+#### Scenario: Single-company boardless provider is excluded from the source facet
+
+- **WHEN** the source-facet provider list is built (e.g. for the web contract)
+- **THEN** a single-company boardless provider such as `ozon` is not listed
+
+#### Scenario: Aggregator boardless provider stays in the source facet
+
+- **WHEN** the source-facet provider list is built
+- **THEN** an `aggregator` boardless provider such as `jobstash` or the existing
+  `tecla` marketplace is listed, while the board-based providers (`greenhouse`,
+  `lever`, …) remain listed as before
+
+### Requirement: JobStash crypto-job aggregator is registered
+
+The system SHALL register a `jobstash` adapter for the JobStash Web3 job
+aggregator, configurable as a single `boardless` entry. The adapter SHALL
+paginate JobStash's job-list endpoint by the reported total and yield every
+posting as the normalized job shape (at least title, url, location, remote flag,
+description, and the platform's native posting id). The company of each posting
+SHALL be taken from the posting's `organization.name`, so one board yields jobs
+across many companies. A posting carrying a `url` (a `public` posting's downstream
+ATS apply link) SHALL use it unchanged; a posting with no `url` (a `protected`
+posting, whose gated link the feed omits) SHALL link to the JobStash detail page
+derived from its native id, so the stored job links to the real apply target when
+one exists and to the best available link otherwise. A posting with no native id
+or no company SHALL be dropped rather than persisted, since it would break the
+dedup key or the company slug. The structured location type
+(`ONSITE`/`REMOTE`/`HYBRID`) SHALL set the structured `work_mode`, and the publish
+timestamp SHALL set `posted_at`. The adapter SHALL be both `boardless` and an
+`aggregator`.
+
+#### Scenario: JobStash board is fully crawled across companies
+
+- **WHEN** a `jobstash` entry is crawled with an empty `board`
+- **THEN** the adapter walks the list endpoint to the reported total and yields
+  each posting as the normalized job shape, with `company` taken from the
+  posting's `organization.name` and `external_id` set to the posting's native id
+
+#### Scenario: A public posting links to its downstream ATS
+
+- **WHEN** JobStash returns a posting whose `access` is `public` with a downstream
+  ATS `url`
+- **THEN** the yielded job's `url` is that downstream ATS link
+
+#### Scenario: A protected posting with no url links to its JobStash page
+
+- **WHEN** JobStash returns a `protected` posting whose `url` is null
+- **THEN** the yielded job's `url` is the JobStash detail page derived from the
+  posting's native id
+
+#### Scenario: A posting with no company or id is dropped
+
+- **WHEN** JobStash returns a posting with an empty `organization.name` or an
+  empty native id
+- **THEN** that posting is not yielded, while the other postings are
+
+#### Scenario: Location type sets the structured work mode
+
+- **WHEN** a posting reports `locationType` `REMOTE`
+- **THEN** the yielded job's structured `work_mode` is `remote`

--- a/openspec/changes/jobstash-source/tasks.md
+++ b/openspec/changes/jobstash-source/tasks.md
@@ -1,0 +1,45 @@
+# Tasks
+
+## 1. Marker split (boardless vs aggregator)
+
+- [x] 1.1 Add the opt-in `aggregator` marker interface to
+      `internal/sources/source.go` and change `FilterableProviders` to exclude a
+      provider only when it is `boardless && !aggregator` (single-company
+      boardless stays excluded; aggregators stay listed). Cover with a unit test
+      asserting an existing single-company boardless provider (e.g. `ozon`) is
+      absent and the board-based providers are present.
+
+## 2. JobStash adapter
+
+- [x] 2.1 Add `internal/sources/jobstash.go`: `NewJobStash(c)` /
+      `Provider() == "jobstash"`, implementing `boardless()` and `aggregator()`.
+      `Fetch` paginates `/jobs/list?page=&limit=200` by `total`, decodes the
+      inline list, and maps each posting to `sources.Job` per the design table
+      (company ← `organization.name`, url passthrough, `shortUUID` external id,
+      `locationType` → `workplaceTypeMode`, epoch-ms `timestamp` → `PostedAt`,
+      composed sanitized-HTML description). Drive with a table-driven test over a
+      captured JSON fixture in `testdata/`, served by an `httptest` server,
+      covering: field mapping, pagination across pages to `total`, public-vs-
+      protected `url`, work-mode from `locationType`, and `organization.name` →
+      `company`.
+- [x] 2.2 Register `NewJobStash(c)` in `sources.All` and assert (test) the
+      registry resolves provider `jobstash` and that `FilterableProviders`
+      includes `jobstash`.
+
+## 3. Configuration + contract
+
+- [x] 3.1 Add `sources/jobstash.yml` with one boardless entry (no `board`);
+      verify it loads and validates against the registry (config validation test
+      or `go run ./cmd/ingest sources/jobstash.yml` dry path — at minimum
+      `parseSourcesFile` accepts the empty board for `jobstash`).
+- [x] 3.2 Regenerate the web source-facet contract (`make gen-contracts`) so
+      `jobstash` appears in the generated source list; commit the regenerated
+      output.
+
+## 4. Verification
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...` green; gofmt clean;
+      openspec validate passes. Live smoke against the real JobStash API (gated
+      test, run once then removed) fetched 3058 jobs with url=3058/3058 (null-url
+      fallback verified), desc=3056, work-mode remote=1399/hybrid=639/onsite=701,
+      and no empty company — confirming the decode shape matches production.

--- a/sources/jobstash.yml
+++ b/sources/jobstash.yml
@@ -1,0 +1,5 @@
+# JobStash Web3 job aggregator. Boardless: one global public feed
+# (middleware.jobstash.xyz/jobs/list), so the entry carries no board, and each job's company
+# comes from the posting's organization, not this placeholder.
+- company: JobStash
+  provider: jobstash

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -87,6 +87,7 @@ const SOURCE: FacetOption[] = options(SOURCE_VALUES, {
   telegram: 'Telegram', greenhouse: 'Greenhouse', smartrecruiters: 'SmartRecruiters',
   bamboohr: 'BambooHR', successfactors: 'SuccessFactors',
   workatastartup: 'Work at a Startup', remoteok: 'RemoteOK', arc: 'Arc',
+  jobstash: 'JobStash', globalpayments: 'Global Payments',
 });
 
 // The backend's `regions` reach vocabulary (enrich.RegionValues): one consistent

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -105,7 +105,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'greenhouse', 'gupy', 'huntflow', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'workable', 'workday'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'jobstash', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'workable', 'workday'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## Summary

Adds a `jobstash` source adapter for [JobStash](https://jobstash.xyz)
(`middleware.jobstash.xyz`), a Web3 job aggregator with a public, no-auth JSON
API — a crypto/Web3 vertical the direct ATS crawls miss. The adapter paginates
`GET /jobs/list` by the reported total and maps each inline posting to the
normalized job shape:

- **Company** ← each posting's `organization.name` (it is a multi-company
  aggregator, not a single board).
- **URL** ← the posting's `url` when present (a `public` posting's downstream ATS
  apply link); for a `protected` posting the feed leaves `url` null (~18% of
  postings), so it links to the JobStash detail page derived from `shortUUID`
  instead of dropping the vacancy.
- **work_mode** ← `locationType` (`ONSITE`/`REMOTE`/`HYBRID`); **posted_at** ←
  the epoch-ms `timestamp`; **description** ← sanitized HTML composed from the
  prose plus the responsibilities/requirements/benefits lists.
- A posting with no native id or no company is dropped (would break the dedup
  key / company slug).

### Marker split: `boardless` vs `aggregator`

`boardless` conflated "needs no board id" with "single company → excluded from
the source facet". JobStash is boardless but multi-company, so a new opt-in
`aggregator` marker keeps such a source in the facet. The already-merged `tecla`
marketplace (#130) is the same case — a boardless aggregator wrongly absent from
the facet — so it adopts the marker too.

### Web contract

Regenerated the drifted `SOURCE_VALUES` (restores `globalpayments` and `tecla`,
which had landed without a regen, alongside the new `jobstash`) and added the
`JobStash`/`Global Payments` UI label overrides.

Dedup overlap with the direct greenhouse/lever/ashby crawls is accepted (separate
`source` key) — see the OpenSpec proposal under `openspec/changes/jobstash-source/`.

## Test Plan

- [x] `go build ./... && go vet ./... && go test ./...` green; gofmt clean
- [x] Unit tests cover pagination across pages, public-vs-protected (null) url,
      work-mode mapping, `organization.name` → company, the drop guards, and the
      `boardless && !aggregator` facet logic
- [x] `openspec validate jobstash-source --strict` passes
- [x] Live smoke against the real API: **3058 jobs, url=3058/3058** (null-url
      fallback exercised), desc=3056, work-mode remote=1399/hybrid=639/onsite=701
- [ ] Deploy: add a cron entry for `sources/jobstash.yml`; first ingest run
      populates `source = "jobstash"`, then enrichment/reindex pick it up