### PR TITLE
feat(sources): add gupy boards Starian + Vivo Digital

### DIFF
--- a/sources/gupy.yml
+++ b/sources/gupy.yml
@@ -67,3 +67,7 @@
   board: "2258"
 - company: InfoPrice
   board: "92244"
+- company: Starian
+  board: "89896"
+- company: Vivo Digital
+  board: "316"


### PR DESCRIPTION
Adds two Gupy boards requested ad-hoc, both live-validated against the portal feed (`employability-portal.gupy.io/api/v1/jobs?companyId=`); companyId read from each portal's `__NEXT_DATA__`.

- **Starian** — companyId `89896` (starian.gupy.io)
- **Vivo Digital** — companyId `316` (vivodigital.gupy.io)

`sources/gupy.yml` validates against the registry (33 entries). Sources-only change — deploys via sources rsync, no image rebuild.