### PR TITLE
feat(harvest-boards): discover gupy boards from the global feed

### DIFF
--- a/cmd/harvest-boards/discover_test.go
+++ b/cmd/harvest-boards/discover_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+// fakeDiscoverer is a prober that also discovers a canned candidate list, standing in for
+// a discovery-capable provider (e.g. gupy) without hitting any API.
+type fakeDiscoverer struct{ ids []string }
+
+func (fakeDiscoverer) probe(context.Context, httpClient, string) (string, int, error) {
+	return "", 0, nil
+}
+
+func (f fakeDiscoverer) discover(context.Context, httpClient) ([]string, error) {
+	return f.ids, nil
+}
+
+func TestResolveCandidatesDiscoversWhenNoSeed(t *testing.T) {
+	got, err := resolveCandidates(context.Background(), fakeDiscoverer{ids: []string{"316", "89896"}}, nil, "")
+	if err != nil {
+		t.Fatalf("resolveCandidates: %v", err)
+	}
+	if len(got) != 2 || got[0] != "316" || got[1] != "89896" {
+		t.Errorf("candidates = %v, want discovered [316 89896]", got)
+	}
+}
+
+func TestResolveCandidatesNonDiscovererNeedsSeed(t *testing.T) {
+	_, err := resolveCandidates(context.Background(), greenhouseProber{}, nil, "")
+	if err == nil {
+		t.Error("a non-discoverer prober with no seed file should error, not silently no-op")
+	}
+}

--- a/cmd/harvest-boards/gupy.go
+++ b/cmd/harvest-boards/gupy.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+)
+
+// gupyFeedURL is Gupy's public portal jobs API (mirrors sources.gupyBaseURL, which is
+// unexported; this tool lives outside the sources package). Keyed by companyId it lists one
+// company's jobs; unkeyed it is a global feed across all employers (see discover).
+const gupyFeedURL = "https://employability-portal.gupy.io/api/v1/jobs"
+
+const (
+	// gupyPageSize is the discovery page size for the global feed.
+	gupyPageSize = 100
+	// gupyMaxOffset bounds the discovery sweep so a feed that never empties cannot loop
+	// forever; it sits well above Gupy's live-job count, and the empty-page check ends the
+	// sweep sooner in practice.
+	gupyMaxOffset = 100000
+)
+
+// gupyProber probes and discovers Gupy boards. A Gupy board is a numeric companyId; unlike
+// the ATS providers there is no public seed list of ids, so the prober also discovers its
+// own candidates from the global feed (see discover).
+type gupyProber struct{}
+
+// gupyResponse is the portal feed envelope: a page of postings plus the pagination total.
+type gupyResponse struct {
+	Data []struct {
+		CompanyID      int64  `json:"companyId"`
+		CareerPageName string `json:"careerPageName"`
+	} `json:"data"`
+	Pagination struct {
+		Total int `json:"total"`
+	} `json:"pagination"`
+}
+
+// probe queries one company's feed for its open-job count and career-page name. A missing
+// company (getter error) or one with no open jobs yields ("", 0, nil) — a skip — and the
+// name falls back to the companyId when the feed reports none.
+func (gupyProber) probe(ctx context.Context, c httpClient, companyID string) (string, int, error) {
+	var resp gupyResponse
+	if err := c.GetJSON(ctx, fmt.Sprintf("%s?companyId=%s&limit=1", gupyFeedURL, companyID), &resp); err != nil {
+		return "", 0, nil
+	}
+	// Liveness is "the feed returned a posting", like every other prober — not the
+	// pagination total, which the adapter documents as unreliable when limit==page size.
+	if len(resp.Data) == 0 {
+		return "", 0, nil
+	}
+	name := companyID
+	if len(resp.Data) > 0 && resp.Data[0].CareerPageName != "" {
+		name = resp.Data[0].CareerPageName
+	}
+	return name, resp.Pagination.Total, nil
+}
+
+// discover pages the global feed (across all companies, no job-category filter) collecting
+// each posting's distinct companyId in first-seen order, until a page returns no postings or
+// the offset reaches gupyMaxOffset. A page that fails to fetch ends the sweep with the ids
+// gathered so far, so one bad page truncates rather than aborts the harvest.
+func (gupyProber) discover(ctx context.Context, c httpClient) ([]string, error) {
+	var ids []string
+	seen := make(map[int64]bool)
+	for offset := 0; offset < gupyMaxOffset; offset += gupyPageSize {
+		var resp gupyResponse
+		url := fmt.Sprintf("%s?limit=%d&offset=%d", gupyFeedURL, gupyPageSize, offset)
+		if err := c.GetJSON(ctx, url, &resp); err != nil {
+			// A page failing mid-sweep truncates rather than aborts; log so a short harvest
+			// is not mistaken for an exhausted feed.
+			log.Printf("gupy discover: offset %d: %v (returning %d ids so far)", offset, err, len(ids))
+			break
+		}
+		if len(resp.Data) == 0 {
+			break
+		}
+		for _, j := range resp.Data {
+			if j.CompanyID != 0 && !seen[j.CompanyID] {
+				seen[j.CompanyID] = true
+				ids = append(ids, strconv.FormatInt(j.CompanyID, 10))
+			}
+		}
+	}
+	return ids, nil
+}

--- a/cmd/harvest-boards/gupy_test.go
+++ b/cmd/harvest-boards/gupy_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+)
+
+func TestGupyRegisteredAsDiscoverer(t *testing.T) {
+	p, ok := probers["gupy"]
+	if !ok {
+		t.Fatal(`probers["gupy"] missing`)
+	}
+	if _, isDiscoverer := p.(discoverer); !isDiscoverer {
+		t.Error("gupy prober should implement the discoverer interface")
+	}
+}
+
+func TestGupyProbe(t *testing.T) {
+	g := gupyProber{}
+	getter := fakeGetter{
+		gupyFeedURL + "?companyId=316&limit=1":   `{"data":[{"careerPageName":"Vivo Digital","companyId":316}],"pagination":{"total":823}}`,
+		gupyFeedURL + "?companyId=89896&limit=1": `{"data":[{"careerPageName":"Starian","companyId":89896}],"pagination":{"total":3}}`,
+		// has jobs but the feed reports no name -> falls back to the companyId
+		gupyFeedURL + "?companyId=555&limit=1": `{"data":[{"careerPageName":"","companyId":555}],"pagination":{"total":4}}`,
+		// present company, zero open jobs -> skip
+		gupyFeedURL + "?companyId=999&limit=1": `{"data":[],"pagination":{"total":0}}`,
+	}
+
+	cases := []struct {
+		id       string
+		wantName string
+		wantN    int
+	}{
+		{"316", "Vivo Digital", 823},
+		{"89896", "Starian", 3},
+		{"555", "555", 4},
+		{"999", "", 0},
+		{"missing", "", 0}, // unmapped URL -> getter error -> skip, never fatal
+	}
+	for _, c := range cases {
+		name, n, err := g.probe(context.Background(), getter, c.id)
+		if err != nil {
+			t.Errorf("probe(%s) err = %v, want nil", c.id, err)
+		}
+		if name != c.wantName || n != c.wantN {
+			t.Errorf("probe(%s) = (%q, %d), want (%q, %d)", c.id, name, n, c.wantName, c.wantN)
+		}
+	}
+}
+
+func gupyPage(t *testing.T, ids ...int64) string {
+	t.Helper()
+	body := `{"data":[`
+	for i, id := range ids {
+		if i > 0 {
+			body += ","
+		}
+		body += fmt.Sprintf(`{"companyId":%d,"careerPageName":"c%d"}`, id, id)
+	}
+	return body + `],"pagination":{"total":9999}}`
+}
+
+func TestGupyDiscoverPaginatesDedupsAndStops(t *testing.T) {
+	g := gupyProber{}
+	getter := fakeGetter{
+		gupyFeedURL + fmt.Sprintf("?limit=%d&offset=0", gupyPageSize):                  gupyPage(t, 1, 2, 1),                      // 1 repeats within the page
+		gupyFeedURL + fmt.Sprintf("?limit=%d&offset=%d", gupyPageSize, gupyPageSize):   gupyPage(t, 2, 3),                         // 2 repeats across pages
+		gupyFeedURL + fmt.Sprintf("?limit=%d&offset=%d", gupyPageSize, 2*gupyPageSize): `{"data":[],"pagination":{"total":9999}}`, // empty page -> stop
+	}
+
+	got, err := g.discover(context.Background(), getter)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	want := []string{"1", "2", "3"} // distinct companyIds, first-seen order
+	if !slices.Equal(got, want) {
+		t.Errorf("discover() = %v, want %v (distinct, first-seen)", got, want)
+	}
+}
+
+// A page that fails to fetch mid-sweep truncates the discovery to what was collected so far,
+// rather than aborting the whole harvest.
+func TestGupyDiscoverTruncatesOnPageError(t *testing.T) {
+	g := gupyProber{}
+	getter := fakeGetter{
+		gupyFeedURL + fmt.Sprintf("?limit=%d&offset=0", gupyPageSize): gupyPage(t, 1, 2),
+		// offset=gupyPageSize is unmapped -> getter error -> stop with [1 2] collected
+	}
+
+	got, err := g.discover(context.Background(), getter)
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if want := []string{"1", "2"}; !slices.Equal(got, want) {
+		t.Errorf("discover() = %v, want %v (truncated at the failed page)", got, want)
+	}
+}

--- a/cmd/harvest-boards/main.go
+++ b/cmd/harvest-boards/main.go
@@ -26,11 +26,16 @@ const probeWorkers = 16
 func main() { os.Exit(run()) }
 
 func run() int {
-	if len(os.Args) != 3 {
-		log.Printf("usage: harvest-boards <provider> <seed.json>")
+	// 3 args = seed path; 2 args = discovery (the prober must support it).
+	if len(os.Args) != 2 && len(os.Args) != 3 {
+		log.Printf("usage: harvest-boards <provider> [seed.json]")
 		return 2
 	}
-	provider, seedPath := os.Args[1], os.Args[2]
+	provider := os.Args[1]
+	seedPath := ""
+	if len(os.Args) == 3 {
+		seedPath = os.Args[2]
+	}
 
 	p, ok := probers[provider]
 	if !ok {
@@ -38,7 +43,10 @@ func run() int {
 		return 2
 	}
 
-	seed, err := loadSeed(seedPath)
+	ctx := context.Background()
+	client := sources.NewClient()
+
+	raw, err := resolveCandidates(ctx, p, client, seedPath)
 	if err != nil {
 		log.Printf("harvest-boards: %v", err)
 		return 1
@@ -55,11 +63,11 @@ func run() int {
 		existing[e.Board] = true
 	}
 
-	candidates := newBoards(mapSeeds(p, seed), existing, dedupKeyOf(p))
-	log.Printf("harvest-boards: %s seed=%d existing=%d new-candidates=%d",
-		provider, len(seed), len(existing), len(candidates))
+	candidates := newBoards(raw, existing, dedupKeyOf(p))
+	log.Printf("harvest-boards: %s candidates=%d existing=%d new-candidates=%d",
+		provider, len(raw), len(existing), len(candidates))
 
-	kept := probeAll(context.Background(), p, candidates)
+	kept := probeAll(ctx, client, p, candidates)
 	log.Printf("harvest-boards: live boards found=%d", len(kept))
 	if len(kept) == 0 {
 		return 0
@@ -83,6 +91,26 @@ func run() int {
 	return 0
 }
 
+// resolveCandidates supplies a run's candidate board ids. With no seed file the prober must
+// support discovery and enumerates its own candidates from the platform API; otherwise the
+// candidates come from the seed file, mapped through the prober. This is the only step that
+// differs between a discovery provider and a seed-list one — dedup, probe, and append are
+// shared downstream.
+func resolveCandidates(ctx context.Context, p prober, c httpClient, seedPath string) ([]string, error) {
+	if seedPath == "" {
+		d, ok := p.(discoverer)
+		if !ok {
+			return nil, fmt.Errorf("provider needs a seed file (it has no discovery support)")
+		}
+		return d.discover(ctx, c)
+	}
+	seed, err := loadSeed(seedPath)
+	if err != nil {
+		return nil, err
+	}
+	return mapSeeds(p, seed), nil
+}
+
 // loadSeed reads a JSON array of slug strings.
 func loadSeed(path string) ([]string, error) {
 	data, err := os.ReadFile(path)
@@ -99,8 +127,7 @@ func loadSeed(path string) ([]string, error) {
 // probeAll probes every candidate concurrently (bounded), returning the live boards as
 // emit-ready entries sorted by board. A probe error is logged and the candidate skipped, so
 // one dead board never aborts the harvest.
-func probeAll(ctx context.Context, p prober, candidates []string) []entry {
-	client := sources.NewClient()
+func probeAll(ctx context.Context, client httpClient, p prober, candidates []string) []entry {
 	sem := make(chan struct{}, probeWorkers)
 	var (
 		mu   sync.Mutex

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -193,6 +193,15 @@ func (icimsProber) probe(ctx context.Context, c httpClient, slug string) (string
 	return slug, n, nil
 }
 
+// discoverer is the opt-in capability of a prober whose boards are not available as a seed
+// list: it enumerates its own candidate board ids from the platform API. When a provider's
+// prober implements it and the tool is run with no seed file, discovery supplies the
+// candidates that a seed would otherwise provide. Mirrors the optional-marker idiom of
+// seedMapper/dedupKeyer.
+type discoverer interface {
+	discover(ctx context.Context, c httpClient) ([]string, error)
+}
+
 // seedMapper converts a provider's raw seed token into its canonical board id. Providers
 // whose seed token already IS the board id (greenhouse/lever/ashby/bamboohr/icims) do not
 // implement it. Mirrors the optional-marker idiom of sources.boardless.
@@ -230,4 +239,5 @@ var probers = map[string]prober{
 	"bamboohr":   bamboohrProber{},
 	"workday":    workdayProber{},
 	"icims":      icimsProber{},
+	"gupy":       gupyProber{},
 }

--- a/openspec/changes/gupy-board-discovery/.openspec.yaml
+++ b/openspec/changes/gupy-board-discovery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/gupy-board-discovery/design.md
+++ b/openspec/changes/gupy-board-discovery/design.md
@@ -1,0 +1,99 @@
+# Design — gupy-board-discovery
+
+## Context
+
+`cmd/harvest-boards` today: `harvest-boards <provider> <seed.json>` →
+`loadSeed` → `mapSeeds` → `newBoards` (dedup vs `sources/<provider>.yml`) →
+`probeAll` (concurrent `prober.probe(slug) → (name, openJobs, err)`, keep
+`openJobs>0`) → `appendEntries`. Probers live in `prober.go` behind the `prober`
+interface, with optional markers `seedMapper`/`dedupKeyer` — the established
+opt-in-interface idiom.
+
+Gupy boards are numeric `companyId`s with no public seed list. They are only
+found by enumerating Gupy's global feed
+`https://employability-portal.gupy.io/api/v1/jobs?limit=&offset=`, which returns
+postings across all employers (~25 distinct companies per 40-job page) and
+paginates by `offset` past the first 100. `?companyId=<id>&limit=1` returns that
+company's `careerPageName` and open-job `total`.
+
+## Decisions
+
+### Discovery replaces only the candidate source
+
+The seed (`loadSeed`+`mapSeeds`) is just the *source of candidate ids*. Everything
+after — dedup, concurrent probe, append — is provider-agnostic and stays as is.
+So discovery is modeled as an alternative candidate source, not a parallel
+pipeline. A new opt-in interface mirrors `seedMapper`/`dedupKeyer`:
+
+```go
+type discoverer interface {
+    discover(ctx context.Context, c httpClient) ([]string, error)
+}
+```
+
+`run()` chooses the candidate source:
+- 3 args (`<provider> <seed.json>`) → seed path, unchanged.
+- 2 args (`<provider>`) **and** the prober implements `discoverer` → candidates =
+  `discover(...)`.
+- 2 args and not a discoverer → usage error (unchanged behavior for seed-only
+  providers).
+
+Discovered ids then flow through the **same** `newBoards` → `probeAll` →
+`appendEntries`. So a discovered `companyId` is still probed (gets the
+authoritative name + count and re-confirms it is live), preserving the
+"committed file = our validated facts" doctrine.
+
+### gupyProber
+
+Implements both `prober.probe` and `discoverer.discover`.
+
+- `probe(ctx, c, companyId)`: `GET …/jobs?companyId=<id>&limit=1`, decode
+  `{data:[{careerPageName}], <count>}`. Return `(careerPageName, total, nil)`;
+  name falls back to `companyId`, `total==0`/error → `("",0,nil)` (skip). Same
+  shape as `greenhouseProber`.
+- `discover(ctx, c)`: loop `offset = 0, gupyPageSize, 2·gupyPageSize, …`,
+  `GET …/jobs?limit=<gupyPageSize>&offset=<offset>`, collect each posting's
+  `companyId` into an ordered de-duplicated slice (first-seen order); stop when a
+  page returns zero postings or `offset` reaches `gupyMaxOffset` (safety against a
+  feed that never empties). Return the distinct ids as strings.
+
+Constants: `gupyFeedURL`, `gupyPageSize` (100), `gupyMaxOffset` (bounds the sweep;
+sized well above Gupy's live-job count). The feed host is duplicated as a local
+const (the tool lives outside `internal/sources`, mirroring `greenhouseBoardsAPI`).
+
+Register `probers["gupy"] = gupyProber{}`.
+
+### Open-job count for dedup vs. probe
+
+Discovery yields companies that already have ≥1 open job (they are in the feed),
+but probe still runs: it returns the authoritative `careerPageName` (the feed
+posting carries it too, but probing is uniform and re-confirms liveness) and the
+total count. The double round-trip (enumerate + probe-each) is acceptable for a
+run-once host tool with 16 workers and client 429-backoff.
+
+## Risks / Trade-offs
+
+- **Volume.** "All companies" can be thousands of distinct ids → thousands of
+  probe requests. Bounded concurrency (16) + 429 backoff keep it polite; it is a
+  run-once host tool, not a cron job. `gupyMaxOffset` caps the enumeration.
+- **Messy names.** `careerPageName` is sometimes a marketing slogan. We keep the
+  slug-fallback doctrine (id when empty) and rely on diff review before ingest;
+  no name-cleaning (YAGNI).
+- **Feed pagination shape.** Assumes `offset` pages the feed to exhaustion. If the
+  feed caps `offset`, the sweep ends early (fewer companies) rather than failing —
+  `gupyMaxOffset` and the empty-page stop both terminate cleanly.
+
+## Testing
+
+`prober_test.go`-style fake `httpClient` (routed by URL substring):
+- `discover`: multi-page feed with repeated companies → distinct ids in order;
+  empty page stops paging; `gupyMaxOffset` bound respected.
+- `probe`: `companyId` → `(careerPageName, total)`; empty/zero → `("",0,nil)`;
+  missing name → id fallback.
+- `run()`: discoverer branch (no seed) vs seed branch vs non-discoverer-no-seed
+  usage error.
+
+## Migration / Rollout
+
+None automated. Run `harvest-boards gupy` on a host, review the `sources/gupy.yml`
+diff, commit, deploy via sources rsync. No schema/runtime change.

--- a/openspec/changes/gupy-board-discovery/proposal.md
+++ b/openspec/changes/gupy-board-discovery/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+`cmd/harvest-boards` expands a board file by live-validating a **seed list** of
+candidate slugs. Gupy has no such seed: its boards are numeric `companyId`s that
+appear nowhere as a public list — they are only discoverable by enumerating
+Gupy's global jobs feed (`employability-portal.gupy.io/api/v1/jobs`), which
+returns ~25 distinct companies per 40-job page across all employers. So Gupy
+coverage cannot grow through the seed path; we currently hold 33 Gupy boards and
+could reach hundreds.
+
+## What Changes
+
+- **Add a discovery mode to `cmd/harvest-boards`.** A new opt-in `discoverer`
+  interface lets a provider's prober enumerate its own candidate boards from the
+  platform API when no seed file is given, instead of reading a seed list. The
+  rest of the pipeline (dedup against the existing board file, concurrent probe,
+  append) is unchanged — discovery only replaces the seed as the candidate source.
+- **Add a `gupy` prober** implementing both:
+  - `discover` — pages the Gupy global jobs feed (no `jobName` filter, so **all**
+    companies with open jobs, not only IT) collecting distinct `companyId`s until
+    a page yields no postings (bounded by a max-offset safety).
+  - `probe(companyId)` — queries `?companyId=<id>&limit=1` for the company's
+    `careerPageName` (name; falls back to the id) and open-job `total`, the same
+    contract every other prober honours. Discovered ids run through this probe, so
+    the committed file stays our own live-validated fact set.
+- **Invocation:** `harvest-boards gupy` (no seed argument) discovers; the existing
+  `harvest-boards <provider> <seed.json>` path is untouched.
+
+## Capabilities
+
+### New Capabilities
+
+- `board-harvest`: the host dev tool that expands a board file with
+  live-validated boards, by seed-list validation or by platform discovery.
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+- `cmd/harvest-boards/prober.go`: new `discoverer` interface + `gupyProber`
+  (`discover` + `probe`); register `probers["gupy"]`.
+- `cmd/harvest-boards/main.go`: `run()` selects discovery when the prober is a
+  discoverer and no seed path is given; the probe/dedup/append flow is shared.
+- `sources/gupy.yml`: grows by the discovered boards on each run (committed after
+  diff review; sources-only, deploys via rsync, no image rebuild).
+- No runtime/server change; this is a run-once host tool.

--- a/openspec/changes/gupy-board-discovery/specs/board-harvest/spec.md
+++ b/openspec/changes/gupy-board-discovery/specs/board-harvest/spec.md
@@ -1,0 +1,85 @@
+# board-harvest (delta)
+
+## ADDED Requirements
+
+### Requirement: The harvest tool validates candidate boards against the live platform API
+
+The `harvest-boards` host tool SHALL expand a board file (`sources/<provider>.yml`)
+only with boards it has live-validated: each candidate board SHALL be probed
+against the platform's official public API and kept only if the API reports at
+least one open job, so the committed file is the project's own validated fact set
+rather than a redistributed dataset. A candidate that is absent, closed, or
+unreachable SHALL be skipped, never abort the run. A kept board SHALL be appended
+to the provider's board file with the company name the platform reports (or the
+board id when the platform exposes none), de-duplicated against the boards already
+in the file.
+
+#### Scenario: A candidate with open jobs is kept
+
+- **WHEN** a candidate board is probed and the platform API reports one or more
+  open jobs
+- **THEN** the board is appended to `sources/<provider>.yml` with the reported
+  company name (or the board id as a fallback)
+
+#### Scenario: A candidate with no open jobs is skipped
+
+- **WHEN** a candidate board is probed and the platform API reports zero jobs or
+  is unreachable
+- **THEN** the board is not appended and the run continues with the other
+  candidates
+
+#### Scenario: An already-known board is not duplicated
+
+- **WHEN** a candidate board id already appears in `sources/<provider>.yml`
+- **THEN** it is filtered out before probing and not appended again
+
+### Requirement: A provider may supply its own candidate boards by discovery
+
+The harvest tool SHALL allow a provider whose boards are not available as a seed
+list to discover its candidate boards from the platform API, by implementing an
+opt-in discovery capability. When a provider supports discovery and the tool is
+run with no seed file, the tool SHALL obtain the candidate boards from discovery
+instead of from a seed list; every discovered candidate SHALL then pass through
+the same live-validation, de-duplication, and append steps as a seeded candidate.
+A provider that does not support discovery SHALL continue to require a seed file.
+
+#### Scenario: Discovery supplies candidates when no seed is given
+
+- **WHEN** the tool is run for a provider that supports discovery and no seed file
+  is given
+- **THEN** the candidate boards come from the provider's discovery, and each is
+  live-validated, de-duplicated, and appended exactly as a seeded candidate would be
+
+#### Scenario: A provider without discovery still needs a seed
+
+- **WHEN** the tool is run for a provider that does not support discovery and no
+  seed file is given
+- **THEN** the tool reports a usage error and makes no changes
+
+### Requirement: Gupy boards are discovered from the global jobs feed
+
+The harvest tool SHALL support discovering Gupy boards from Gupy's global jobs
+feed. Discovery SHALL page the feed (across all companies, not filtered to any job
+category) collecting each posting's distinct numeric `companyId`, stopping when a
+page returns no postings or a bounded maximum is reached. Each discovered
+`companyId` SHALL be validated by querying the company's feed for its open-job
+count and its reported career-page name, kept only when it has at least one open
+job, with the name falling back to the `companyId` when the feed reports none.
+
+#### Scenario: Gupy discovery collects distinct companies from the feed
+
+- **WHEN** Gupy discovery pages the global jobs feed and the pages name several
+  companies, some more than once
+- **THEN** each distinct `companyId` is collected once as a candidate board
+
+#### Scenario: Gupy discovery stops at an empty page
+
+- **WHEN** a Gupy feed page returns no postings
+- **THEN** discovery stops paging and returns the companies collected so far
+
+#### Scenario: A discovered Gupy company is validated and named
+
+- **WHEN** a discovered `companyId` is probed and its feed reports open jobs and a
+  career-page name
+- **THEN** the board is kept with that name; a company whose feed reports no name
+  falls back to the `companyId`, and one with no open jobs is skipped

--- a/openspec/changes/gupy-board-discovery/tasks.md
+++ b/openspec/changes/gupy-board-discovery/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## 1. Discoverer interface + run() branch
+
+- [x] 1.1 Add the opt-in `discoverer` interface to
+      `cmd/harvest-boards/prober.go`. In `main.go`, make `run()` accept the
+      `harvest-boards <provider>` (2-arg) form: when the provider's prober
+      implements `discoverer`, the candidate ids come from `discover(...)`;
+      otherwise (or with 3 args) the seed path is unchanged; a 2-arg run for a
+      non-discoverer prober is a usage error. Drive with a test asserting the
+      branch selection (a fake discoverer prober supplies candidates without a
+      seed; a non-discoverer with no seed errors).
+
+## 2. gupyProber
+
+- [x] 2.1 Add `gupyProber` with `probe(ctx, c, companyId)` →
+      `(careerPageName, total)` via `?companyId=<id>&limit=1` (name falls back to
+      id; zero/error → skip). Table-test the mapping with a fake `httpClient`.
+- [x] 2.2 Add `gupyProber.discover(ctx, c)` paging the global feed
+      (`?limit=&offset=`), collecting distinct `companyId`s in first-seen order,
+      stopping on an empty page or `gupyMaxOffset`. Test: multi-page feed with
+      repeated companies → distinct ids; empty-page termination; max-offset bound.
+- [x] 2.3 Register `probers["gupy"] = gupyProber{}`; assert (test) the registry
+      resolves `gupy` and that it implements `discoverer`.
+
+## 3. Verification
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green; gofmt clean;
+      `openspec validate gupy-board-discovery --strict` passes. Optional live
+      smoke: `go run ./cmd/harvest-boards gupy` against a scratch copy enumerates
+      and appends boards (review diff; do not commit the bulk append in this PR).


### PR DESCRIPTION
## Summary

Adds a **discovery mode** to the `cmd/harvest-boards` host tool for providers
whose boards aren't available as a seed list. Gupy boards are numeric
`companyId`s with no public seed — they're only found by enumerating Gupy's
global jobs feed. We hold 33 Gupy boards today and can reach hundreds.

- New opt-in **`discoverer`** interface (mirrors `seedMapper`/`dedupKeyer`): a
  prober enumerates its own candidates from the platform API. When supported and
  run with no seed file, discovery supplies the candidates; the existing
  dedup → probe → append pipeline is shared unchanged.
- **`gupyProber`**:
  - `probe(companyId)` → `?companyId=&limit=1` → `(careerPageName||id, openJobs)`;
    liveness is a returned posting, not the pagination total (which the adapter
    documents as unreliable).
  - `discover()` pages the global feed (`?limit=100&offset=N`, **no `jobName`
    filter — all companies**, not only IT) collecting distinct `companyId`s
    first-seen until an empty page or `gupyMaxOffset`; a mid-sweep page error
    truncates-and-logs rather than aborting.
- `run()` accepts `harvest-boards gupy` (2-arg discovery) alongside the existing
  `harvest-boards <provider> <seed.json>`; `probeAll` takes a shared client.

Spec: new `board-harvest` capability under `openspec/changes/gupy-board-discovery/`.

## Test Plan

- [x] `go build ./... && go vet ./... && go test ./...` green; gofmt clean
- [x] Unit tests: discover pagination + within/cross-page dedup + empty-page stop
      + mid-sweep error truncation; probe name/fallback/zero-jobs-skip/error-skip;
      resolveCandidates discover-vs-seed branch; registry+discoverer
- [x] `openspec validate gupy-board-discovery --strict` passes
- [x] Live smoke: `probe(316)` → "Vivo Vita", 823 open jobs (decode matches prod)
- [ ] Operator: run `harvest-boards gupy` on a host, review the `sources/gupy.yml`
      diff, commit the appended boards separately (not in this PR)