### PR TITLE
feat(sources): +1338 gupy boards via global-feed discovery

### DIFF
--- a/sources/gupy.yml
+++ b/sources/gupy.yml
@@ -71,3 +71,2679 @@
   board: "89896"
 - company: Vivo Digital
   board: "316"
+- company: Santa Colomba
+  board: "10"
+- company: AVANTE ADMINISTRADORA
+  board: "1000000060"
+- company: I DECOR SHOP
+  board: "1000001617"
+- company: SOAUDIO
+  board: "1000002211"
+- company: GXT CAPITAL
+  board: "1000002508"
+- company: VELOCE MOTO PECAS
+  board: "1000003201"
+- company: TRACAO VEICULOS
+  board: "1000003630"
+- company: TGK TURISMO LTDA.
+  board: "1000004125"
+- company: 66.556.949 SHAYRA HUANNA GALVAO DE OLIVEIRA
+  board: "1000004554"
+- company: MORAR EUA - CONSULTORIA E ASSESSORIA
+  board: "1000004983"
+- company: SOQUIMICA LABORATORIOS LTDA
+  board: "1000005447"
+- company: JACARANDA CORRETORA DE SEGUROS LTDA
+  board: "1000005544"
+- company: BRIGHTLED ILUMINACAO
+  board: "1000005808"
+- company: LIBERTA ASSESSORIA
+  board: "1000006138"
+- company: FREE SHOP WEB
+  board: "1000006171"
+- company: GRUPO BRAMOR
+  board: "1000006204"
+- company: DEXYI
+  board: "1000006237"
+- company: MANIA CELL
+  board: "1000006270"
+- company: Dominium
+  board: "1000006303"
+- company: EL PRIME DISTRIBUIDORA
+  board: "1000006336"
+- company: COPYHOUSE
+  board: "1000006337"
+- company: MR. CHENEY
+  board: "1000006369"
+- company: Teknisa
+  board: "10003"
+- company: Grupo Positivo
+  board: "1015"
+- company: NORSUL
+  board: "1021"
+- company: Hospital Geral de Guarulhos - SPDM Afiliadas
+  board: "1023"
+- company: Grupo HDI
+  board: "1027"
+- company: Usina Alta Mogiana
+  board: "1034"
+- company: SPDM/PAIS
+  board: "1036"
+- company: CONEXA
+  board: "1040"
+- company: ' BAT Brasil '
+  board: "1042"
+- company: Unimed Belém
+  board: "1059"
+- company: Baterias Moura
+  board: "1061"
+- company: Madesa Móveis
+  board: "1068"
+- company: Fast Shop S/A
+  board: "10729"
+- company: Ocyan
+  board: "1076"
+- company: Rizatti
+  board: "1077"
+- company: TELEMONT
+  board: "1085"
+- company: KRYPTUS
+  board: "1099"
+- company: Barcelos
+  board: "1110"
+- company: Schumann
+  board: "1113"
+- company: Toledo do Brasil
+  board: "1115"
+- company: Gurpo Afeet
+  board: "11292"
+- company: Petz
+  board: "1130"
+- company: Mattos Filho
+  board: "1131"
+- company: Winover
+  board: "1133"
+- company: Hidrovias do Brasil
+  board: "1137"
+- company: Grupo NewChase
+  board: "11389"
+- company: Vitus
+  board: "1141"
+- company: Vertem
+  board: "1144"
+- company: EuroChem
+  board: "1146"
+- company: Venha trabalhar no CTE!
+  board: "1150"
+- company: Quem somos
+  board: "1154"
+- company: Uberlândia Refrescos
+  board: "1156"
+- company: Grupo L'Occitane
+  board: "1157"
+- company: Ajinomoto do Brasil
+  board: "11587"
+- company: Brasilprev
+  board: "1162"
+- company: JF ENERGIA E AUTOMAÇÃO
+  board: "11653"
+- company: Maple Bear Escolas
+  board: "117"
+- company: Expresso São Miguel
+  board: "1173"
+- company: DRUID CREATIVE
+  board: "1177"
+- company: Eurobike
+  board: "1179"
+- company: Agrofel
+  board: "11818"
+- company: Alloha Fibra
+  board: "1188"
+- company: Ambev
+  board: "119"
+- company: Todeschini S.A.
+  board: "11950"
+- company: '#SejaSBT'
+  board: "1199"
+- company: 'MacPonta Agro '
+  board: "12018"
+- company: "Venha fazer parte do nosso time de Cellerers \U0001F49B"
+  board: "12019"
+- company: 'CNA Idiomas '
+  board: "12049"
+- company: Grupo Indiana
+  board: "1205"
+- company: Sandvik Mining and Rock Technology
+  board: "12082"
+- company: Santa Casa BH
+  board: "12115"
+- company: Vagas Corporativas, Administrativas e de Atendimento Hospital Alemão Oswaldo Cruz
+  board: "1216"
+- company: umauma
+  board: "12181"
+- company: SYN
+  board: "12214"
+- company: Grupo Santa Helena
+  board: "1222"
+- company: Randoncorp
+  board: "123"
+- company: Mantiqueira Brasil
+  board: "1232"
+- company: OXXO Brasil - Jovem Aprendiz
+  board: "12379"
+- company: Dexco
+  board: "1256"
+- company: Grupo Coringa
+  board: "1262"
+- company: 'Confidencial '
+  board: "1263"
+- company: Neugebauer Alimentos S/A
+  board: "12643"
+- company: HBR Realty
+  board: "1265"
+- company: Grupo Mater
+  board: "1272"
+- company: Lanlink Informática
+  board: "1274"
+- company: Programa de Estágio Quod - 2026
+  board: "12808"
+- company: Light
+  board: "1290"
+- company: Colégio Uirapuru
+  board: "12973"
+- company: GAV Resorts
+  board: "13006"
+- company: WayCarbon
+  board: "13138"
+- company: samirjereissatiadv
+  board: "13172"
+- company: Junto Seguros
+  board: "1324"
+- company: Code n' App
+  board: "13337"
+- company: Grupo Vila Nova
+  board: "13435"
+- company: EIXO SP
+  board: "1391"
+- company: Mercedes-Benz Caminhões & Ônibus
+  board: "1392"
+- company: Rede Verbita de Educação
+  board: "13930"
+- company: 'Riachuelo '
+  board: "14062"
+- company: Special Dog Company
+  board: "14227"
+- company: Oportunidades InBetta
+  board: "14326"
+- company: BrasPine
+  board: "14425"
+- company: Globo Pharma
+  board: "14426"
+- company: Grupo Piracanjuba
+  board: "14458"
+- company: SENAI CETIQT
+  board: "14467"
+- company: Sem Parar Corpay
+  board: "14491"
+- company: STEMAC
+  board: "14656"
+- company: Grupo Yamaha Brasil
+  board: "14986"
+- company: Grupo Ramiro Campelo
+  board: "15052"
+- company: FCC
+  board: "15118"
+- company: Colégio QI
+  board: "15217"
+- company: Bruning Tecnometal
+  board: "15250"
+- company: confidencioso
+  board: "15283"
+- company: Confidencial
+  board: "15613"
+- company: Vagas Faber-Castell Brasil
+  board: "15614"
+- company: Stocche Forbes Advogados
+  board: "15712"
+- company: CCEE
+  board: "1588"
+- company: Coco Bambu
+  board: "16042"
+- company: Brasilseg
+  board: "16108"
+- company: Tegra Incorporadora
+  board: "162"
+- company: Auto Avaliar
+  board: "16372"
+- company: 'Cadastra '
+  board: "165"
+- company: Conac
+  board: "16603"
+- company: Árvore
+  board: "1668"
+- company: Vitta Residencial
+  board: "1669"
+- company: S3 Gestão em Saúde
+  board: "1671"
+- company: CIEE - Centro de Integração Empresa-Escola
+  board: "1685"
+- company: Vetta Tecnologia
+  board: "1687"
+- company: Inpasa Brasil
+  board: "16900"
+- company: Grupo Sinosserra
+  board: "1693"
+- company: COTY
+  board: "1696"
+- company: Tirolez
+  board: "1699"
+- company: Deltasul Utilidades Ltda
+  board: "1702"
+- company: Daniel Advogados
+  board: "1705"
+- company: Plena Alimentos
+  board: "1706"
+- company: Seg Imob Seguros Imobiliários
+  board: "1707"
+- company: Bernoulli Educação
+  board: "1709"
+- company: USINA SANTA TEREZINHA
+  board: "1714"
+- company: Grupo Panvel
+  board: "1715"
+- company: Eletromidia
+  board: "1717"
+- company: IMC Vagas
+  board: "17296"
+- company: Projedata
+  board: "17494"
+- company: Lumini IT Solutions
+  board: "17527"
+- company: BMA Advogados
+  board: "17659"
+- company: https://br.linkedin.com/company/imdepa
+  board: "17792"
+- company: 'Castrolanda Cooperativa Agroindustrial '
+  board: "17857"
+- company: Venha ser Santa Casa
+  board: "1786"
+- company: Elecnor do Brasil
+  board: "1787"
+- company: 'AUVP '
+  board: "17989"
+- company: FirstLab
+  board: "18022"
+- company: i4pro
+  board: "1804"
+- company: Grupo Conduzir
+  board: "18088"
+- company: NWADV
+  board: "1812"
+- company: Cellular.com
+  board: "1816"
+- company: Um Telecom
+  board: "1817"
+- company: Volkswagen do Brasil
+  board: "1818"
+- company: Colliers
+  board: "18220"
+- company: Cooperativa Agrária
+  board: "1830"
+- company: Editora do Brasil
+  board: "18319"
+- company: ofi
+  board: "18385"
+- company: PRIO
+  board: "184"
+- company: +A Educação
+  board: "1850"
+- company: Walsywa - Fixação para Construção Civil
+  board: "1853"
+- company: Condor
+  board: "1854"
+- company: KLA Advogados
+  board: "1867"
+- company: Torrent do Brasil
+  board: "18682"
+- company: Matrix Energia
+  board: "1870"
+- company: CoreX Copper Brasil
+  board: "1871"
+- company: Vem ser Ourofino Agrociência!
+  board: "18715"
+- company: Tokio Marine Seguradora
+  board: "1884"
+- company: Kaizen - A Casa da Autopeça
+  board: "1885"
+- company: 'Shift '
+  board: "1886"
+- company: Craft Group
+  board: "18913"
+- company: Supermercados Guanabara
+  board: "1898"
+- company: Aramis
+  board: "1904"
+- company: Studio Z
+  board: "1905"
+- company: 'Empresas Brasif '
+  board: "1908"
+- company: Fortbras
+  board: "1909"
+- company: Planit Gerenciamento de Projetos
+  board: "1912"
+- company: Quatá Alimentos
+  board: "19178"
+- company: Cury Construtora
+  board: "1923"
+- company: Unifique Telecomunicações
+  board: "1926"
+- company: 'Faculdade Unimed '
+  board: "19276"
+- company: Maqcampo | John Deere
+  board: "19309"
+- company: 'Raízen '
+  board: "1934"
+- company: 'HYVA DO BRASIL '
+  board: "1935"
+- company: ALS LIFE SCIENCES
+  board: "1937"
+- company: Grupo MAG
+  board: "19375"
+- company: Marcopolo S.A
+  board: "1938"
+- company: '#Vem Ser Dana'
+  board: "1948"
+- company: Fluency Academy
+  board: "1949"
+- company: Croda
+  board: "1950"
+- company: 'M. Dias Branco '
+  board: "1952"
+- company: Faça parte do time Vieira Rezende Advogados!
+  board: "19573"
+- company: HT Micron
+  board: "1958"
+- company: Be.Aliant
+  board: "19607"
+- company: Globo
+  board: "1963"
+- company: Vagas Confidenciais
+  board: "19672"
+- company: F360
+  board: "19738"
+- company: Santa Marcelina Educação
+  board: "1976"
+- company: Unimed Vale do Sinos
+  board: "19771"
+- company: Viacredi
+  board: "1979"
+- company: Unidas
+  board: "1980"
+- company: Selfit Academias
+  board: "19804"
+- company: Unimed Poços de Caldas
+  board: "19837"
+- company: Grupo Tracan
+  board: "1986"
+- company: Empresa confidencial
+  board: "1989"
+- company: Sicoob Sarom
+  board: "1993"
+- company: Creche Paulo VI
+  board: "19969"
+- company: ICI – Instituto das Cidades Inteligentes
+  board: "1999"
+- company: 'ibyte #JuntosSomosMaisFortes'
+  board: "2005"
+- company: Tauste Supermercados
+  board: "20101"
+- company: Grupo Oré
+  board: "20103"
+- company: TATU MARCHESAN
+  board: "2017"
+- company: 'SMS group '
+  board: "2019"
+- company: Itaú Unibanco
+  board: "2022"
+- company: Americanas S.A.
+  board: "203"
+- company: Grendene
+  board: "2051"
+- company: Venha fazer parte do nosso time!
+  board: "2052"
+- company: GPS TEC
+  board: "2053"
+- company: Uma Empresa que trabalha para conectar o mundo com pessoas
+  board: "2061"
+- company: Brasol Renewables Investment Company
+  board: "20629"
+- company: AGP do Brasil
+  board: "20794"
+- company: Governançabrasil
+  board: "21025"
+- company: Pagaleve
+  board: "21124"
+- company: Banco Bmg
+  board: "2119"
+- company: Karoon Energy Brasil
+  board: "21256"
+- company: 'Carreiras Vera Cruz Hospital '
+  board: "2127"
+- company: Gomes de Matos Consultoria
+  board: "213"
+- company: Programas de Entrada Usiminas
+  board: "2133"
+- company: Check Up Hospital
+  board: "2137"
+- company: Bichara Advogados
+  board: "2140"
+- company: 'Daiichi Sankyo Brasil Farmacêutica '
+  board: "2141"
+- company: BAGAGGIO
+  board: "2142"
+- company: Rio Energy
+  board: "21421"
+- company: Oportunidade na Servimex!
+  board: "2143"
+- company: Rennova
+  board: "2145"
+- company: Voke
+  board: "2157"
+- company: VERO
+  board: "21586"
+- company: Motz
+  board: "21652"
+- company: DPaschoal
+  board: "2177"
+- company: TKMS Estaleiro Brasil Sul
+  board: "2179"
+- company: Binario.cloud
+  board: "21850"
+- company: Carreiras nas Lojas | Azzas 2154 Shoes & Bags
+  board: "2188"
+- company: Tribanco
+  board: "2190"
+- company: 'VEM SER #GENTEALGAR'
+  board: "2191"
+- company: 'Beep Saúde '
+  board: "2192"
+- company: Bauducco
+  board: "2193"
+- company: GRUPO ND
+  board: "22016"
+- company: iPlace - Apple Premium Reseller - Oficial
+  board: "2215"
+- company: EDAG Group
+  board: "2220"
+- company: Movida Aluguel de Carros
+  board: "2221"
+- company: Academia Wave
+  board: "2228"
+- company: WEG
+  board: "22312"
+- company: Carreiras Dutyfree Avolta
+  board: "22477"
+- company: Ourofino Saúde Animal
+  board: "2250"
+- company: Sítio da Serra
+  board: "2252"
+- company: Empresa de Construção Civil - Venha Trabalhar com a gente!
+  board: "2254"
+- company: Brain - Centro de Inovação
+  board: "226"
+- company: ISA ENERGIA BRASIL
+  board: "2267"
+- company: ALLOS
+  board: "22708"
+- company: 'Vem ser um Conecter. '
+  board: "2274"
+- company: Tecnogera Geradores
+  board: "2276"
+- company: Petrobahia
+  board: "2277"
+- company: BUNGE
+  board: "2280"
+- company: 'Fundação Dorina Nowill para Cegos '
+  board: "22807"
+- company: Grupo Elfa
+  board: "2284"
+- company: MCassab Distribuição
+  board: "2293"
+- company: Claretiano - Colégio
+  board: "22939"
+- company: Sumitomo Rubber do Brasil | Dunlop Pneus
+  board: "2294"
+- company: Cocal
+  board: "2298"
+- company: Knewin
+  board: "2300"
+- company: Baldan Implementos Agrícolas S/A
+  board: "23006"
+- company: Grupo Henry Schein Brasil
+  board: "2306"
+- company: Atlantic Nickel
+  board: "231"
+- company: JHSF | JHSF Malls e Fashion Retail
+  board: "2310"
+- company: Grupo Tigre
+  board: "232"
+- company: Sistema Indústria - CNI SESI SENAI IEL - Departamento Nacional
+  board: "2328"
+- company: Grupo Bertolini
+  board: "23302"
+- company: CISER
+  board: "2334"
+- company: Cimed
+  board: "2335"
+- company: Adeste
+  board: "2337"
+- company: Demarest Advogados
+  board: "2350"
+- company: Benner
+  board: "2358"
+- company: Força de Vendas Eurofarma
+  board: "237"
+- company: EMBRACON ADMINISTRADORA DE CONSÓRCIO
+  board: "238"
+- company: 'ITAPEVA Recuperação de Créditos '
+  board: "23897"
+- company: Página de Carreira
+  board: "23930"
+- company: Grupo Nexxees
+  board: "240"
+- company: inpEV
+  board: "24061"
+- company: 'Oceânica '
+  board: "24160"
+- company: SSA - São Salvador Alimentos
+  board: "24325"
+- company: Casa dos Ventos
+  board: "24426"
+- company: Natto
+  board: "24432"
+- company: Vem ser CASSI
+  board: "2446"
+- company: Lojas Renner S.A.
+  board: "246"
+- company: Lojas Torra
+  board: "24688"
+- company: Anhanguera Ferramentas
+  board: "2479"
+- company: green4T
+  board: "24853"
+- company: Confidencial
+  board: "24886"
+- company: Nasajon
+  board: "24887"
+- company: 'Lumma Despachante '
+  board: "25150"
+- company: Unimed Fortaleza
+  board: "252"
+- company: Cocamar Cooperativa Agroindustrial
+  board: "25216"
+- company: NIO
+  board: "25315"
+- company: Instituto Infnet - Venha ser estagiário ou trainee!
+  board: "25447"
+- company: https://www.linkedin.com/company/avantiatecnologiaeseguranca/mycompany/
+  board: "25612"
+- company: 'Prime Results '
+  board: "25810"
+- company: GRUPO EP
+  board: "25812"
+- company: Ayko, juntos para transformar!
+  board: "25843"
+- company: vezzilapolla.legal
+  board: "263"
+- company: NÚCLEO ENGENHARIA CONSULTIVA S.A.
+  board: "26305"
+- company: Orguel
+  board: "26371"
+- company: 'Vagas Tatico Goiânia '
+  board: "26407"
+- company: Grupo GSH
+  board: "26439"
+- company: Cena5
+  board: "26472"
+- company: Lojas Bemol
+  board: "26503"
+- company: Paciente 360
+  board: "26510"
+- company: Albieri e Associados
+  board: "26513"
+- company: VOLL
+  board: "26603"
+- company: Vem pra família Sangue Azul!
+  board: "26635"
+- company: Blue3 Investimentos
+  board: "26833"
+- company: MRO
+  board: "26932"
+- company: Urbia Parques
+  board: "27097"
+- company: Faça parte do nosso time
+  board: "27230"
+- company: Synvia
+  board: "2743"
+- company: Mycon
+  board: "27493"
+- company: Paschoalotto
+  board: "27592"
+- company: PensoJobs
+  board: "27791"
+- company: Confidencial
+  board: "27823"
+- company: Cencosud Brasil
+  board: "27857"
+- company: Midea Carrier
+  board: "279"
+- company: Hospital Nipo-Brasileiro
+  board: "27922"
+- company: Close-up International
+  board: "28087"
+- company: RioMar Recife
+  board: "28120"
+- company: COCRED
+  board: "28125"
+- company: Engeform
+  board: "28126"
+- company: Grupo JCA
+  board: "28186"
+- company: Allonda
+  board: "28483"
+- company: Marisol SA
+  board: "290"
+- company: Vaga Confidencial
+  board: "29110"
+- company: Grupo Trigo
+  board: "292"
+- company: "#VemserEcoRodovias\U0001F343"
+  board: "29210"
+- company: 'Copersucar '
+  board: "29242"
+- company: Grupo Boticário
+  board: "295"
+- company: Grupo Santa Maria
+  board: "29605"
+- company: Korp ERP
+  board: "29606"
+- company: Polinutri
+  board: "29770"
+- company: Auxiliadora Predial
+  board: "298"
+- company: Sicoob Cooplivre
+  board: "29870"
+- company: Viasoft
+  board: "30364"
+- company: ERO
+  board: "3041"
+- company: Grupo CRM
+  board: "30498"
+- company: Karsten
+  board: "306"
+- company: CAIXA Vida e Previdência
+  board: "30662"
+- company: Grupo IESA
+  board: "30760"
+- company: Ecolab
+  board: "30925"
+- company: BRN Construtora
+  board: "30931"
+- company: Almaviva Solutions
+  board: "30932"
+- company: Zaraplast
+  board: "30935"
+- company: Finx
+  board: "30938"
+- company: Lar Sant`Ana
+  board: "30939"
+- company: Loxam Brasil
+  board: "30941"
+- company: Renov
+  board: "30942"
+- company: Reis Advogados
+  board: "30943"
+- company: GWCloud
+  board: "30945"
+- company: Colégio Marupiara - São Paulo/SP
+  board: "30946"
+- company: 'C-PRO SERVIÇOS '
+  board: "30950"
+- company: NeoOrtho Medartis Group
+  board: "30951"
+- company: Empresa Confidencial 0
+  board: "30952"
+- company: TAM Aviação Executiva
+  board: "30991"
+- company: Unimed Maceió
+  board: "3106"
+- company: Portobello Shop
+  board: "31123"
+- company: 3CON | IT & Digital
+  board: "31189"
+- company: Cinpal
+  board: "31255"
+- company: Unimed CNU
+  board: "31288"
+- company: Aurora Coop
+  board: "31388"
+- company: Sipolatti
+  board: "3139"
+- company: 'Coopercitrus '
+  board: "31552"
+- company: Método Grupo
+  board: "31684"
+- company: Nidec Global Appliance (Brasil)
+  board: "317"
+- company: Saipos | Sistema para Restaurante
+  board: "31750"
+- company: Gestores Prisionais Associados - GPA
+  board: "31915"
+- company: BIP Brasil
+  board: "31982"
+- company: Lefosse
+  board: "3205"
+- company: ESSENTIA GROUP
+  board: "32213"
+- company: Alterdata Software
+  board: "32278"
+- company: C&A Brasil
+  board: "32311"
+- company: ALE Combustíveis
+  board: "32378"
+- company: Cataguá Soluções Imobiliárias
+  board: "32476"
+- company: Catupiry ®
+  board: "32509"
+- company: Hospital Moinhos de Vento
+  board: "32575"
+- company: Votorantim Cimentos
+  board: "326"
+- company: Efí Bank
+  board: "32740"
+- company: Agronegócio
+  board: "32773"
+- company: Invent Software
+  board: "32872"
+- company: Ambar Tech
+  board: "32938"
+- company: Ibema
+  board: "32971"
+- company: Finnet
+  board: "33009"
+- company: Aegro
+  board: "33103"
+- company: Cruzeiro do Sul Educacional S/A
+  board: "33235"
+- company: Soul Malls
+  board: "33598"
+- company: SicoobCocre
+  board: "33697"
+- company: 'Alqia '
+  board: "338"
+- company: Trabalhe conosco - help!
+  board: "34027"
+- company: Unimed Guarulhos
+  board: "34227"
+- company: Ploomes
+  board: "344"
+- company: '#sejaveriter'
+  board: "34423"
+- company: Grupo Autoglass Estágio
+  board: "345"
+- company: Vialaser Depilação
+  board: "34588"
+- company: Carreiras Ypê
+  board: "34621"
+- company: Conasa Águas de Itapema
+  board: "34654"
+- company: 'MPD Engenharia '
+  board: "34753"
+- company: Escola Bahiana de Medicina e Saúde Pública
+  board: "35083"
+- company: CEL Intercultural School
+  board: "35347"
+- company: Dengo Chocolates
+  board: "35353"
+- company: 'Centauro Talentos '
+  board: "35479"
+- company: 'Mind Lab '
+  board: "35512"
+- company: 'Teltec Solutions '
+  board: "35545"
+- company: Vernalha Pereira
+  board: "35710"
+- company: Vagas Grupo Sabin
+  board: "35776"
+- company: MDS Group
+  board: "35809"
+- company: Grupo Vigorito
+  board: "35942"
+- company: Grupo HTB
+  board: "35943"
+- company: Solví - Soluções Para A Vida
+  board: "35974"
+- company: Mobyan
+  board: "36139"
+- company: Autbank
+  board: "36239"
+- company: "Somos BHS \U0001F499"
+  board: "36240"
+- company: JDREL
+  board: "36337"
+- company: Sicredi
+  board: "364"
+- company: AlmapBBDO
+  board: "36436"
+- company: Quality Digital
+  board: "36502"
+- company: 'Daikin Brasil '
+  board: "36832"
+- company: Grupo Nortis
+  board: "36997"
+- company: Terral Incorporadora
+  board: "371"
+- company: Scanntech Brasil
+  board: "37162"
+- company: LM Mobilidade
+  board: "37195"
+- company: Limppano
+  board: "37294"
+- company: Galapagos Capital
+  board: "37459"
+- company: Veolia Brasil
+  board: "37723"
+- company: Crown Brasil
+  board: "378"
+- company: GRUPO COMETA
+  board: "37822"
+- company: OU
+  board: "379"
+- company: Elo
+  board: "37921"
+- company: 'Grupo Carbel '
+  board: "37987"
+- company: Saint-Gobain Brasil
+  board: "38020"
+- company: Grupo PG Prime
+  board: "38086"
+- company: 'Lojacorr - Carreiras '
+  board: "38152"
+- company: '#SejaShopper'
+  board: "383"
+- company: Vagas Fruki
+  board: "38416"
+- company: Coca-Cola Andina Brasil
+  board: "38515"
+- company: Weber Shandwick
+  board: "38548"
+- company: '#QueroSerMercantil'
+  board: "38581"
+- company: 'Italac '
+  board: "38647"
+- company: Grupo Marquise
+  board: "38713"
+- company: Telium Networks
+  board: "38746"
+- company: Cuattro
+  board: "38779"
+- company: Sistema Fiemt | Fiemt, Sesi MT, Senai MT e IEL MT
+  board: "39043"
+- company: Genial Investimentos
+  board: "39076"
+- company: Trabalhe na Mills
+  board: "39109"
+- company: Padtec
+  board: "39175"
+- company: 'Souto Correa Advogados '
+  board: "392"
+- company: Conquer Business School
+  board: "39208"
+- company: ALPLA
+  board: "3931"
+- company: Bun/Buntech
+  board: "39374"
+- company: 'JS PEÇAS '
+  board: "39407"
+- company: Aegea Saneamento
+  board: "39505"
+- company: Instituto de Responsabilidade Social Sírio-Libanês
+  board: "39571"
+- company: Ecogen Brasil
+  board: "39604"
+- company: Mitre Realty
+  board: "397"
+- company: Stefanini Group
+  board: "39703"
+- company: Brasil Terrenos
+  board: "39704"
+- company: Cajuina São Geraldo
+  board: "39737"
+- company: Fluxo Soluções Integradas
+  board: "39773"
+- company: NCS
+  board: "39802"
+- company: 'GL events Brasil '
+  board: "39835"
+- company: COPASTUR VIAGENS E TURISMO
+  board: "399"
+- company: PagBank
+  board: "400"
+- company: Instituto de Pesquisas ELDORADO
+  board: "40033"
+- company: AGROTIS
+  board: "401"
+- company: FEY
+  board: "40166"
+- company: Grupo Roma Brasil
+  board: "40198"
+- company: Unimed Juiz de Fora
+  board: "402"
+- company: STRATA ENGENHARIA
+  board: "40231"
+- company: Certisign
+  board: "40330"
+- company: Aurum
+  board: "40397"
+- company: Humanitarian
+  board: "40530"
+- company: 3tentos
+  board: "4063"
+- company: CBC
+  board: "40792"
+- company: Stormx
+  board: "40825"
+- company: 'Unilider Distribuidora '
+  board: "409"
+- company: Vagas Inmetrics
+  board: "40924"
+- company: 3corações
+  board: "40991"
+- company: ILPEA
+  board: "40992"
+- company: Avita
+  board: "41023"
+- company: 'Copa Energia '
+  board: "41057"
+- company: BIOSPHERA.NTWK
+  board: "41090"
+- company: Casa do Construtor
+  board: "41122"
+- company: Funcional Health Tech
+  board: "41155"
+- company: Viveo
+  board: "4129"
+- company: FuelTech
+  board: "41419"
+- company: Unimed São José dos Campos
+  board: "41452"
+- company: credsystem
+  board: "415"
+- company: Bel Cosméticos
+  board: "41782"
+- company: Vagas Banco Sofisa
+  board: "41881"
+- company: 'FP Serviços '
+  board: "41914"
+- company: Solar Coca-Cola
+  board: "422"
+- company: recrutamentoGMO
+  board: "42215"
+- company: Techub
+  board: "42244"
+- company: QCA
+  board: "42412"
+- company: 'Vem Ser Credi-Rural! '
+  board: "42475"
+- company: Vistra
+  board: "42542"
+- company: Villares Metals
+  board: "4261"
+- company: Nitro
+  board: "42673"
+- company: Nexdom Healthtech
+  board: "42706"
+- company: Colégio Católica Brasília
+  board: "42838"
+- company: Grupo BOM JESUS IELUSC
+  board: "42937"
+- company: BRB Seguros
+  board: "43036"
+- company: Geopixel
+  board: "43135"
+- company: Sabará Hospital Infantil
+  board: "43333"
+- company: PatBO
+  board: "43432"
+- company: Construtora Alliance
+  board: "43498"
+- company: Orthopride
+  board: "43564"
+- company: Allianz Partners Brasil
+  board: "4360"
+- company: Grupo Raymundo da Fonte
+  board: "43630"
+- company: Cetrel
+  board: "43830"
+- company: 'Ituran Brasil '
+  board: "43863"
+- company: Redbelt Security
+  board: "43960"
+- company: Marka Veículos
+  board: "43993"
+- company: Queonetics
+  board: "44026"
+- company: Leveros
+  board: "44027"
+- company: 'Supremo Secil Cimentos '
+  board: "44069"
+- company: '#vempraot'
+  board: "44082"
+- company: Aviator, Asas para Voar.
+  board: "44092"
+- company: Contajá Contabilidade Online
+  board: "44098"
+- company: SENAI - GO
+  board: "44100"
+- company: sejacnn
+  board: "44103"
+- company: Grupo Simões
+  board: "44104"
+- company: Engetrens | Grupo Comporte
+  board: "44105"
+- company: Vedamotors
+  board: "44125"
+- company: Plaenge
+  board: "4426"
+- company: Softplan
+  board: "44323"
+- company: GPA
+  board: "444"
+- company: Senac Minas
+  board: "44424"
+- company: CIATC
+  board: "44554"
+- company: vaga confidencial
+  board: "4459"
+- company: Unimed Grande Florianópolis
+  board: "44785"
+- company: Mercafacil
+  board: "449"
+- company: WPP Media Services
+  board: "44951"
+- company: Echoenergia
+  board: "44983"
+- company: Linea Alimentos
+  board: "450"
+- company: BYD Brasil
+  board: "45247"
+- company: Astra
+  board: "45280"
+- company: Vivara Lojas
+  board: "456"
+- company: Mobilize Financial Services
+  board: "45709"
+- company: Somat
+  board: "45876"
+- company: 'Assaí Atacadista - O atacadista com 50 anos de tradição! #VemserAssaí '
+  board: "459"
+- company: Vagas AACD
+  board: "45940"
+- company: Valenet Carreiras
+  board: "46046"
+- company: TPC Logística Inteligente
+  board: "461"
+- company: 'EMPRESA CONFIDENCIAL '
+  board: "46105"
+- company: Aché Laboratórios Farmacêuticos
+  board: "46303"
+- company: Grupo TecnoSpeed
+  board: "46369"
+- company: Alper Carreiras
+  board: "46534"
+- company: GrupoVillela | Gestão de Carreiras
+  board: "46666"
+- company: WEBJUMP
+  board: "46699"
+- company: Rodobens
+  board: "46798"
+- company: Cimento Apodi
+  board: "46897"
+- company: Santa Casa da Bahia
+  board: "46930"
+- company: AMG Brasil
+  board: "46963"
+- company: CVC Viagens
+  board: "47029"
+- company: Confiance Jobs
+  board: "47062"
+- company: Kenner
+  board: "47063"
+- company: Reserva
+  board: "472"
+- company: Timbro Trading
+  board: "47293"
+- company: SPX Imagem
+  board: "47326"
+- company: Ambev Tech
+  board: "474"
+- company: Brava Energia
+  board: "47525"
+- company: Nossas vagas
+  board: "47557"
+- company: JANAINA RODRIGUES ASSESSORIA
+  board: "47590"
+- company: PremieRpet®
+  board: "47656"
+- company: Energisa
+  board: "47657"
+- company: Hospital São Francisco
+  board: "47755"
+- company: Britvic Brasil
+  board: "47789"
+- company: Flamengo
+  board: "47821"
+- company: '@novarotadooeste'
+  board: "47888"
+- company: Agility
+  board: "48052"
+- company: América Jeans
+  board: "48250"
+- company: estadao
+  board: "48316"
+- company: Órigo Energia
+  board: "48481"
+- company: Digio
+  board: "485"
+- company: Grupo Brasiliense
+  board: "48515"
+- company: Andorinha Hiper Center
+  board: "48548"
+- company: Rede Batista de Educação
+  board: "4855"
+- company: Grupo Valence
+  board: "48587"
+- company: Brasil PCH S.A.
+  board: "48588"
+- company: OdontoCompany SA
+  board: "48624"
+- company: Rede Américas
+  board: "487"
+- company: 'Damásio motopeças '
+  board: "48849"
+- company: Honda
+  board: "48910"
+- company: 'Company Hero '
+  board: "4922"
+- company: CSN - Companhia Siderúrgica Nacional
+  board: "49306"
+- company: Grupo RBS
+  board: "49441"
+- company: 'Mendelics '
+  board: "495"
+- company: Sicoob UniMais Rio
+  board: "49537"
+- company: Clinicorp Solutions
+  board: "49702"
+- company: BeFly
+  board: "49735"
+- company: 'HouseCricket '
+  board: "49834"
+- company: 'Inatel '
+  board: "49966"
+- company: VEM SER BRASILEIRISSIMA
+  board: "49999"
+- company: '#VemSerBesni'
+  board: "50065"
+- company: Grupo Caio
+  board: "50131"
+- company: LOTS Group
+  board: "505"
+- company: Grupo Carburgo
+  board: "50593"
+- company: LBCA - Lee, Brock, Camargo Advogados
+  board: "51253"
+- company: MTP Métodos e Tecnologia – Brasil
+  board: "51286"
+- company: Cinemark Brasil
+  board: "513"
+- company: Livraria da Vila
+  board: "51319"
+- company: Grupo Açotubo
+  board: "51484"
+- company: HM Engenharia
+  board: "515"
+- company: Alvoar Lácteos
+  board: "51517"
+- company: Grupo Elo
+  board: "5155"
+- company: Oportunidades Santa Massa
+  board: "51550"
+- company: Vagas Baruel
+  board: "51616"
+- company: Engbras
+  board: "51781"
+- company: Real H
+  board: "51782"
+- company: Hospital Adventista de Manaus
+  board: "51814"
+- company: Confidencial
+  board: "51848"
+- company: IXC Soft - Sistema de Gerenciamento para Provedores
+  board: "51913"
+- company: Vem ser Balaroti
+  board: "51946"
+- company: Atendimento e Lojas TIM
+  board: "51983"
+- company: Silcar Pneus
+  board: "51985"
+- company: 'Grupo Capema '
+  board: "51986"
+- company: Oportunidades Grupo Althaia
+  board: "51987"
+- company: Trakto
+  board: "51988"
+- company: Samtronic
+  board: "51990"
+- company: Suhai Seguradora
+  board: "51992"
+- company: DMS Logistics
+  board: "51994"
+- company: Hydronorth
+  board: "51999"
+- company: Forno de Minas
+  board: "52144"
+- company: Vagas Redion
+  board: "52177"
+- company: ABRH Estágio
+  board: "52276"
+- company: Trabalhe Conosco Unimed Goiânia
+  board: "52309"
+- company: SLC Agrícola
+  board: "524"
+- company: Perbras
+  board: "525"
+- company: Pacaembu Autopeças
+  board: "52614"
+- company: Auren Energia
+  board: "52615"
+- company: Carreiras Decathlon
+  board: "52672"
+- company: UNIG Carreiras
+  board: "52706"
+- company: CBA
+  board: "528"
+- company: D21 MOTORS
+  board: "52804"
+- company: Kumon Brasil
+  board: "52970"
+- company: Braveo
+  board: "530"
+- company: Libbs Farmacêutica
+  board: "53002"
+- company: Bimbo Brasil
+  board: "53035"
+- company: Grupo Marista
+  board: "53101"
+- company: Eldorado Brasil
+  board: "53167"
+- company: FGM Dental Group
+  board: "53200"
+- company: Fundação São Paulo
+  board: "53233"
+- company: Freitas
+  board: "53398"
+- company: Unimed Porto Alegre
+  board: "534"
+- company: Premix
+  board: "53563"
+- company: Tegma Gestão Logística
+  board: "53662"
+- company: Colégio Nota 10
+  board: "537"
+- company: PlayMais Fibra
+  board: "53761"
+- company: Forluz
+  board: "53926"
+- company: Fiscaltech
+  board: "53959"
+- company: Unimed Sul Capixaba
+  board: "54157"
+- company: vemsercbmm
+  board: "54191"
+- company: Vagas Valgroup
+  board: "54228"
+- company: GRPCOM
+  board: "544"
+- company: Porto
+  board: "54421"
+- company: Bellinati Perez
+  board: "54454"
+- company: Lynx Process
+  board: "54521"
+- company: Disfer Distribuidora de Produtos Alimentícios
+  board: "54553"
+- company: Hospital São Lucas da PUCRS
+  board: "54586"
+- company: Alpargatas
+  board: "546"
+- company: NSG Group
+  board: "54652"
+- company: Smurfit Westrock Brasil
+  board: "54685"
+- company: Trabalhe com a RSM
+  board: "54718"
+- company: Biotrop
+  board: "54753"
+- company: Grupo Fornecedora
+  board: "54754"
+- company: Strattner
+  board: "5482"
+- company: Cebrace
+  board: "54850"
+- company: SIGILOSA
+  board: "54982"
+- company: Rôgga
+  board: "5515"
+- company: CNP Seguros Holding Brasil
+  board: "55151"
+- company: Amcham Carreiras
+  board: "55214"
+- company: Crown Lift Trucks Brasil
+  board: "55279"
+- company: Ceres Investimentos
+  board: "55378"
+- company: Saúde PASA
+  board: "55411"
+- company: Oportunidades OVD!
+  board: "5548"
+- company: 'caedu '
+  board: "55510"
+- company: IC Transportes
+  board: "556"
+- company: Agrivalle Brasil
+  board: "55675"
+- company: TECMAR TRANSPORTES
+  board: "557"
+- company: Hospital Metropolitano Dr. Célio de Castro
+  board: "55708"
+- company: Soprano
+  board: "559"
+- company: Grupo Equatorial
+  board: "56138"
+- company: Deliver IT
+  board: "562"
+- company: 'CICV '
+  board: "56203"
+- company: Nazária
+  board: "56269"
+- company: Keep Simple
+  board: "5647"
+- company: Central Máquinas Agrícolas
+  board: "56599"
+- company: Carreiras - igc partners
+  board: "56803"
+- company: REDE CACIQUE
+  board: "56863"
+- company: Cantu Inc
+  board: "571"
+- company: 'Andrade Gutierrez '
+  board: "57325"
+- company: Gold Pão
+  board: "57391"
+- company: Vulcabras
+  board: "57392"
+- company: Unicred Regional Conexão
+  board: "5746"
+- company: Astral Pães e Massas
+  board: "57491"
+- company: INNOVA - TRABALHE CONOSCO
+  board: "57492"
+- company: Shoulder
+  board: "575"
+- company: 'Lhg Mining - Oportunidades '
+  board: "57655"
+- company: Eckermann & Santos - Sociedade de Advogados
+  board: "57754"
+- company: RECORD
+  board: "5779"
+- company: "\U0001F680 A seleção já está rolando na Track&Field! Vem com a gente?"
+  board: "57820"
+- company: Supergasbras
+  board: "579"
+- company: Technomar Engenharia
+  board: "57954"
+- company: Seconci-SP
+  board: "58051"
+- company: Localiza&Co
+  board: "581"
+- company: Araguaia
+  board: "5812"
+- company: Vem pra S.I.N.!
+  board: "58150"
+- company: Adimax
+  board: "58216"
+- company: Celeo
+  board: "58381"
+- company: 'Junte-se a Nós! Seja um Logithinker :) '
+  board: "58414"
+- company: Terraverde Grupo
+  board: "5845"
+- company: Tecban
+  board: "587"
+- company: Camed Microcrédito
+  board: "58876"
+- company: Venha construir o futuro com a gente!
+  board: "58909"
+- company: Centro de Excelência Votorantim
+  board: "58942"
+- company: Programa de Estágio do CEPEL
+  board: "59008"
+- company: VIVA Eventos
+  board: "59107"
+- company: https://juparana.com.br/
+  board: "59239"
+- company: Safra
+  board: "59404"
+- company: Quebec S.A.
+  board: "59437"
+- company: Neogrid Carreiras
+  board: "59668"
+- company: Log
+  board: "59701"
+- company: Serilon
+  board: "598"
+- company: Traga seu talento para o Inec
+  board: "600"
+- company: Mobit Tecnologia
+  board: "60032"
+- company: 'Grupo Diagmed - Unidade: Campinas'
+  board: "60033"
+- company: Confidencial ok
+  board: "60097"
+- company: Talent Gestão de Pessoas
+  board: "607"
+- company: Talentos SC
+  board: "60724"
+- company: ROFE
+  board: "60757"
+- company: Aliare | Agrosys
+  board: "60856"
+- company: Mercado Brasco
+  board: "60923"
+- company: (IFF) Instituto Fernando Filgueiras
+  board: "61054"
+- company: Red House International School
+  board: "61186"
+- company: Unimed Costa Verde
+  board: "61285"
+- company: LENNY NIEMEYER
+  board: "61450"
+- company: Apex Partners
+  board: "61615"
+- company: Construtora Mega
+  board: "61747"
+- company: Víssimo
+  board: "618"
+- company: 'Sicoob UniCentro Br '
+  board: "61879"
+- company: Colégio Visconde de Porto Seguro
+  board: "61912"
+- company: Pmweb
+  board: "622"
+- company: Veirano Advogados
+  board: "62210"
+- company: Confidencial
+  board: "62276"
+- company: Confidencial
+  board: "62308"
+- company: BP - A Beneficência Portuguesa de São Paulo
+  board: "62374"
+- company: Qualidados
+  board: "624"
+- company: Unicred - Núcleo Geração
+  board: "625"
+- company: Vagas e oportunidades no Grupo Rodonaves
+  board: "62506"
+- company: Novas oportunidades na Onfly!
+  board: "62539"
+- company: "Vem ser Convenia! \U0001F49A"
+  board: "627"
+- company: Dress to
+  board: "62869"
+- company: 'J&F Investimentos '
+  board: "629"
+- company: Unimed Pelotas/RS
+  board: "62935"
+- company: 77Sol
+  board: "62936"
+- company: Fundação José Silveira
+  board: "63331"
+- company: Grupo Lipetral
+  board: "63496"
+- company: PETRONAS
+  board: "635"
+- company: Brado | Carreiras
+  board: "63563"
+- company: Sesi Senai Alagoas
+  board: "63595"
+- company: Suzano
+  board: "63760"
+- company: CASA & VIDEO
+  board: "638"
+- company: Vem ser Agro Serra
+  board: "63862"
+- company: 'Cia. da Consulta '
+  board: "639"
+- company: 'Transportes Jorgeto '
+  board: "63958"
+- company: Cyrela
+  board: "641"
+- company: MODEC
+  board: "64190"
+- company: Machado Meyer Advogados
+  board: "643"
+- company: VLI - portal de vagas externas
+  board: "64387"
+- company: Unibeer
+  board: "6439"
+- company: Atento Brasil
+  board: "646"
+- company: Skill Consultoria Empresarial
+  board: "64618"
+- company: Araforros Indústria e Comércio de Perfilados LTDA
+  board: "64717"
+- company: Level Group
+  board: "648"
+- company: Tommasi Ambiental
+  board: "64816"
+- company: Rocontec - Rocha Construção e Tecnologia
+  board: "64981"
+- company: Olsen Indústria e Comércio
+  board: "65015"
+- company: UNICASA INDÚSTRIA DE MÓVEIS S/A
+  board: "6505"
+- company: Instituto Jô Clemente (IJC)
+  board: "65179"
+- company: Makro Engenharia
+  board: "65212"
+- company: TACO - Roupas, Moda / Varejo
+  board: "65278"
+- company: Vyttra
+  board: "6538"
+- company: Pif Paf Alimentos Administrativo
+  board: "65641"
+- company: KONA TRANSPORTES
+  board: "6571"
+- company: Hospital São Marcos
+  board: "65872"
+- company: Vem ser Bombril
+  board: "65938"
+- company: Gabardo & Terra Advogados Associados
+  board: "66136"
+- company: Unicred
+  board: "6670"
+- company: Agis Distribuição
+  board: "66763"
+- company: Vagas Grupo Digna
+  board: "668"
+- company: Flora Cosméticos e Limpeza
+  board: "671"
+- company: Würth SW Industry
+  board: "67126"
+- company: 'Comgás '
+  board: "67159"
+- company: TozziniFreire Advogados
+  board: "67324"
+- company: Dental Uni
+  board: "67687"
+- company: BSM Engenharia
+  board: "67720"
+- company: Grupo Rehael
+  board: "67753"
+- company: Grupo CEV
+  board: "67819"
+- company: Origem Energia
+  board: "67852"
+- company: Vibra Energia
+  board: "679"
+- company: McDonald's Restaurante - Arcos Dorados
+  board: "68123"
+- company: Scala Data Centers
+  board: "68134"
+- company: Natter
+  board: "68142"
+- company: Tradição Mineira
+  board: "68145"
+- company: Transpanorama Transportes
+  board: "68149"
+- company: Norte Marketing
+  board: "68154"
+- company: Modular Data Centers
+  board: "68156"
+- company: Importadora Bagé
+  board: "68160"
+- company: AVIVA DESENVOLVIMENTO INFANTIL
+  board: "68170"
+- company: Ipiranga
+  board: "68174"
+- company: Forma Turismo
+  board: "68184"
+- company: Grupo OLX
+  board: "68185"
+- company: Bemisa Holding S.A.
+  board: "68186"
+- company: dnata Brasil | Confira nossas vagas!
+  board: "68189"
+- company: Universo AGV
+  board: "68197"
+- company: 'Caloi '
+  board: "68200"
+- company: Farmácias Pague Menos
+  board: "68224"
+- company: Cedro Mineração
+  board: "68231"
+- company: Integralmédica Suplementos Nutricionais
+  board: "68235"
+- company: Gertec Brasil
+  board: "68240"
+- company: Atlantica Hospitality International
+  board: "68247"
+- company: Acrisure
+  board: "68250"
+- company: ' Veralana Recursos Humanos'
+  board: "68251"
+- company: Grupo Mega Rio
+  board: "68258"
+- company: Obras Sociais Irmã Dulce
+  board: "68259"
+- company: Aviva
+  board: "68260"
+- company: 'EXPRESSO GUANABARA '
+  board: "68266"
+- company: LYX
+  board: "68269"
+- company: Silveiro Advogados
+  board: "68270"
+- company: Tania Bulhões
+  board: "68271"
+- company: Hospital Prontocardio
+  board: "68277"
+- company: gupy
+  board: "68278"
+- company: Confidencial
+  board: "68282"
+- company: Gelato Borelli
+  board: "68284"
+- company: Omint
+  board: "68286"
+- company: Alfajores Odara
+  board: "68287"
+- company: Cedisa Central de Aço S/A
+  board: "68289"
+- company: confidencial
+  board: "68291"
+- company: Autolife Blindagens
+  board: "68292"
+- company: Greenlife Academias
+  board: "68298"
+- company: Amara NZero - Página de talentos
+  board: "68300"
+- company: Farmácias São João
+  board: "68305"
+- company: CNP Seguradora
+  board: "68310"
+- company: Clínica Rio de Janeiro
+  board: "68313"
+- company: Vagas no Sistema Fiems
+  board: "68319"
+- company: Boxer Soldas
+  board: "68330"
+- company: Grupo Marilan
+  board: "68343"
+- company: 'Abakids '
+  board: "68346"
+- company: grupozenir.gupy.io
+  board: "68349"
+- company: CIEE-PR
+  board: "68353"
+- company: confidencial
+  board: "68360"
+- company: Confidencial3
+  board: "68370"
+- company: Estágio MTC
+  board: "68371"
+- company: Democrata Calçados e Artef. de Couro LTDA
+  board: "68374"
+- company: 'Alvorada Produtos Agropecuários '
+  board: "68381"
+- company: 'Empresa no Segmento Jurídico '
+  board: "68382"
+- company: AFIP - Associação Fundo de Incentivo à Pesquisa
+  board: "68384"
+- company: 'Vagas Efetivas Saber '
+  board: "68385"
+- company: Grupo Vyas
+  board: "68386"
+- company: Red Balloon
+  board: "68390"
+- company: Grupo Vertical
+  board: "68391"
+- company: Apoio Administrativo no Cuidado ao Paciente
+  board: "684"
+- company: Confidencial
+  board: "68401"
+- company: Faça parte do Time CMMM.
+  board: "68402"
+- company: Faça parte do nosso time de sucesso
+  board: "68439"
+- company: 'Armac '
+  board: "68440"
+- company: 'Rede de Educação Notre Dame '
+  board: "68443"
+- company: 'Mundial Logistics '
+  board: "68445"
+- company: Arklok Tecnologia
+  board: "68446"
+- company: Cinex Inovação e Emoção
+  board: "68447"
+- company: Embrasil Segurança e Serviços
+  board: "68466"
+- company: Talentos Internos
+  board: "68467"
+- company: TMSA - TECNOLOGIA EM MOVIMENTAÇÃO S/A
+  board: "68468"
+- company: Imediato Nexway
+  board: "68470"
+- company: Carreiras SoftExpert
+  board: "68472"
+- company: 'EMFLORA: Cultivando Talentos, Regando Paixões, e Colhendo o Brilho Único de Pessoas Inspiradoras!'
+  board: "68485"
+- company: AXIA Energia
+  board: "68489"
+- company: Hospital Veterinário VFP
+  board: "68495"
+- company: Odontoprev
+  board: "68496"
+- company: RBD IMAGEM
+  board: "68497"
+- company: Pontifícia Universidade Católica do Rio Grande do Sul - PUCRS
+  board: "68501"
+- company: Concrejato Engenharia
+  board: "68508"
+- company: IGC
+  board: "68515"
+- company: Ivan Negócios
+  board: "68516"
+- company: Centralsul Car Care
+  board: "68522"
+- company: Volkswagen Group Services South America
+  board: "68534"
+- company: Dialli Distribuidora de Alimentos Ltda
+  board: "68538"
+- company: CIEE SC
+  board: "68539"
+- company: 'Loxam - A Geradora '
+  board: "68543"
+- company: '#VemParaAltona'
+  board: "68547"
+- company: BrasilTecpar - VagasBH
+  board: "68548"
+- company: Companhia Minuano de Alimentos
+  board: "68551"
+- company: Coplana - Cooperativa Agroindustrial
+  board: "68554"
+- company: Grupo Ei Beleza
+  board: "68611"
+- company: Liga de Mossoró - De Estudos e Combate ao Câncer
+  board: "68613"
+- company: Hospital Felício Rocho
+  board: "68618"
+- company: PWR Gestão
+  board: "68619"
+- company: Cepêra
+  board: "68622"
+- company: Oportunidades
+  board: "68645"
+- company: Duty Cosméticos
+  board: "68646"
+- company: Agrovale - Agro Indústrias do Vale do São Francisco S.A
+  board: "68681"
+- company: Cialne
+  board: "68682"
+- company: Scheffer oficial
+  board: "68693"
+- company: Belliz Company
+  board: "68745"
+- company: Bioo
+  board: "68748"
+- company: ' Grupo Carmehil'
+  board: "68750"
+- company: Implacil De Bortoli
+  board: "68753"
+- company: EBM Desenvolvimento Imobiliário
+  board: "68842"
+- company: '#vempranexa Brasil '
+  board: "689"
+- company: MIGNOW
+  board: "69139"
+- company: Grupo Level
+  board: "69173"
+- company: Elevemed
+  board: "6934"
+- company: 'DC Group '
+  board: "69370"
+- company: Pharlab Indústria Farmacêutica
+  board: "694"
+- company: Gelita
+  board: "69403"
+- company: Colchões Polar
+  board: "69469"
+- company: 'Grupo Bergerson '
+  board: "69535"
+- company: Transpes
+  board: "69568"
+- company: Prati-Donaduzzi
+  board: "69700"
+- company: Unimed Cuiabá
+  board: "69832"
+- company: Página de Carreiras Pacco
+  board: "69833"
+- company: 'Software.com.br '
+  board: "69834"
+- company: ATK Construções & Services
+  board: "69844"
+- company: Evolve
+  board: "69898"
+- company: Grupo Friopeças
+  board: "69964"
+- company: Motiva Rodovias - Engenharia
+  board: "69997"
+- company: Escola Lourenço Castanho - Vila Nova Conceição
+  board: "70063"
+- company: IBS - International Business School Americas
+  board: "70098"
+- company: 'Grupo EBEG '
+  board: "70195"
+- company: Grupo BAUMINAS
+  board: "7033"
+- company: Serhum Consultoria em RH
+  board: "706"
+- company: Smartspace
+  board: "70624"
+- company: Visagio
+  board: "7066"
+- company: Hayamax  Distribuidora
+  board: "70789"
+- company: Diagonal
+  board: "70987"
+- company: 'Empresa Confidencial no ramo da Construção Civil '
+  board: "710"
+- company: Vagas Tijuca Alimentos
+  board: "71121"
+- company: CAAL - Cooperativa Agroindustrial Alegrete Ltda
+  board: "71218"
+- company: MedSênior
+  board: "71317"
+- company: Sociedade Fogás
+  board: "71350"
+- company: Vetlog Distribuidora
+  board: "71383"
+- company: ENGIE Brasil
+  board: "714"
+- company: Nardini Agroindustrial
+  board: "71416"
+- company: GRUPO BFFC
+  board: "71482"
+- company: CONFIDENCIAL - INDÚSTRIA
+  board: "715"
+- company: Emergent Cold LatAm
+  board: "71779"
+- company: Grupo Brinox
+  board: "719"
+- company: 'Dolly Refrigerantes '
+  board: "71977"
+- company: Franq
+  board: "7198"
+- company: APAS - Associação Paulista de Supermercados
+  board: "72010"
+- company: Allink Neutral Provider
+  board: "72043"
+- company: GNL Brasil Logística
+  board: "72044"
+- company: COCA-COLA FEMSA BRASIL
+  board: "72045"
+- company: Centro Educacional Objetivo Baixada Santista
+  board: "72109"
+- company: Buschle & Lepper
+  board: "72142"
+- company: Oral Sin Implantes
+  board: "72175"
+- company: Pluxee Brasil
+  board: "724"
+- company: Valec Renault
+  board: "72505"
+- company: CiX | Citizen Experience
+  board: "72539"
+- company: Brasal
+  board: "72540"
+- company: Oportunidades Exclusivas
+  board: "72638"
+- company: Azul Linhas Aéreas Brasileiras
+  board: "727"
+- company: Pellegrina & Monteiro Advogados
+  board: "72736"
+- company: Iguá Saneamento
+  board: "728"
+- company: Sabesp
+  board: "72802"
+- company: Grupo GSS
+  board: "73001"
+- company: Colégio Anglo-Americano
+  board: "73035"
+- company: 'ACIF - Associação Empresarial de Florianópolis '
+  board: "73099"
+- company: 'Mais Pet Planos Veterinários '
+  board: "73132"
+- company: Grupo Comercial Mariano
+  board: "73165"
+- company: RD Saúde - Centro de Distribuição
+  board: "73231"
+- company: Axia Agro
+  board: "73297"
+- company: CQA - Centro de Qualidade Analítica
+  board: "73462"
+- company: Sicoob Metropolitano
+  board: "73464"
+- company: AMBAAR Lounge
+  board: "73530"
+- company: Autoamerica Group
+  board: "73561"
+- company: Rede Mais Saúde
+  board: "73726"
+- company: Maismobi
+  board: "74123"
+- company: Euro Colchões
+  board: "7429"
+- company: Arcor do Brasil - Conectando Pessoas a Oportunidades
+  board: "743"
+- company: 'Página de Carreiras - Confidencial '
+  board: "74320"
+- company: IAP Cosméticos
+  board: "74386"
+- company: Rede Damas Educacional
+  board: "745"
+- company: Foton Diamantina
+  board: "74650"
+- company: Way Brasil
+  board: "74651"
+- company: Saque e Pague
+  board: "749"
+- company: Dannemann
+  board: "7495"
+- company: ORTHODONTIC BRASIL
+  board: "7497"
+- company: Vagas Grupo Santa Joana
+  board: "75013"
+- company: Febracis Coaching
+  board: "75112"
+- company: FHO | Fundação Hermínio Ometto
+  board: "75310"
+- company: Tecsa® Group
+  board: "75376"
+- company: Tom Educação
+  board: "75673"
+- company: 'Grupo Monto '
+  board: "75838"
+- company: '#VEMPRAIT4US'
+  board: "759"
+- company: Construtora Stanza
+  board: "75904"
+- company: 'Transportes Della Volpe '
+  board: "75970"
+- company: Master Cargas Brasil
+  board: "76003"
+- company: Usina Pagrisa
+  board: "76168"
+- company: 'Grupo Domingão '
+  board: "76201"
+- company: Grupo Normatel
+  board: "76267"
+- company: Total Express
+  board: "7627"
+- company: Redepharma
+  board: "76399"
+- company: Vibra
+  board: "765"
+- company: CGN Brasil
+  board: "76630"
+- company: AFPESP
+  board: "76663"
+- company: 'Guararapes Painéis '
+  board: "76795"
+- company: TIMAC Agro Brasil
+  board: "768"
+- company: VB Alimentos
+  board: "76993"
+- company: 'Ad Clinic '
+  board: "77026"
+- company: Grupo Urca Energia
+  board: "77158"
+- company: JCDecaux Brasil
+  board: "77224"
+- company: Mohawk Brasil
+  board: "77225"
+- company: Instituto Social Mais Saúde
+  board: "77226"
+- company: Centro Nacional de Pesquisa em Energia e Materiais (CNPEM)
+  board: "77257"
+- company: SPE INOVA BH
+  board: "77323"
+- company: JWM Soluções Logísticas
+  board: "77488"
+- company: Hinode Group
+  board: "775"
+- company: A3 Consultoria
+  board: "77554"
+- company: Wilson Sons
+  board: "776"
+- company: Lojas Koerich
+  board: "77719"
+- company: Orizon Valorização de Resíduos
+  board: "77752"
+- company: TranspoTech Equipamentos
+  board: "77851"
+- company: Vagas Imed
+  board: "77884"
+- company: Farmarin Indústria e Comércio Ltda
+  board: "77983"
+- company: Hypera Pharma
+  board: "780"
+- company: Instituto Transforma Edu
+  board: "78049"
+- company: Cargolift
+  board: "781"
+- company: CAC Engenharia
+  board: "78148"
+- company: Cootravale
+  board: "78214"
+- company: VIC ENGENHARIA
+  board: "78247"
+- company: '¡Únete al equipo Decathlon! '
+  board: "78478"
+- company: Grupo JRCA
+  board: "78544"
+- company: 'Motor Group Brasil '
+  board: "78577"
+- company: Usina Santa Adélia
+  board: "786"
+- company: Unimed Campina Grande
+  board: "78610"
+- company: Grupo Universal Soluções Automotivas
+  board: "78643"
+- company: Administração
+  board: "78742"
+- company: Legião Da Boa Vontade
+  board: "78808"
+- company: Via de Acesso
+  board: "78973"
+- company: Light Conecta
+  board: "79039"
+- company: Leads2b
+  board: "791"
+- company: Via Appia Concessões
+  board: "79105"
+- company: Unimed Campinas
+  board: "79138"
+- company: 7LM
+  board: "79237"
+- company: Volkswagen Caminhões e Ônibus
+  board: "7925"
+- company: Agriness
+  board: "7926"
+- company: Lazzo Secondment
+  board: "79370"
+- company: Graal Engenharia
+  board: "79435"
+- company: Gran
+  board: "795"
+- company: JBS
+  board: "79535"
+- company: Inspira Rede de Educadores
+  board: "79567"
+- company: Museu de Arte de São Paulo Assis Chateaubriand - MASP
+  board: "79616"
+- company: Global
+  board: "799"
+- company: Nutrien Soluções Agrícolas
+  board: "7990"
+- company: Décio Freire Advogados
+  board: "80029"
+- company: Glasscamp
+  board: "80030"
+- company: 'Comexport '
+  board: "804"
+- company: Trabaja con nosotros Decathlon Colombia
+  board: "80425"
+- company: FMU
+  board: "80524"
+- company: GRUPO VPL
+  board: "80591"
+- company: Conta Simples
+  board: "80755"
+- company: 'Conorte '
+  board: "80821"
+- company: Vigor Alimentos
+  board: "80889"
+- company: Cresol Oficial
+  board: "8089"
+- company: Esportes Gaming Brasil
+  board: "81020"
+- company: CONFIDENCIAL
+  board: "81054"
+- company: Martin Brower Brasil
+  board: "81056"
+- company: Grupo Itavema
+  board: "81063"
+- company: Confidencial
+  board: "81151"
+- company: BENOLIEL
+  board: "81349"
+- company: LBR Engenharia
+  board: "81415"
+- company: GERAR - Geração de Emprego, Renda e Apoio ao Desenvolvimento Regional
+  board: "81416"
+- company: Concessionária Nova 381
+  board: "81481"
+- company: Intervalor
+  board: "815"
+- company: Cimento Nacional
+  board: "81547"
+- company: Almeida Santos Advogados
+  board: "81646"
+- company: Cerpa Cervejaria Paraense
+  board: "81679"
+- company: Elson's Produtos Alimentícios
+  board: "817"
+- company: Trombini Embalagens S.A.
+  board: "81745"
+- company: market4u
+  board: "81811"
+- company: 'Dafiti '
+  board: "81910"
+- company: Vagas CASP
+  board: "81944"
+- company: Sonho Dos Pés
+  board: "81945"
+- company: Plano&Plano
+  board: "82075"
+- company: Ultragaz
+  board: "82141"
+- company: Mercos
+  board: "822"
+- company: Oceanus
+  board: "82207"
+- company: VERT Capital
+  board: "8221"
+- company: Grupo Passalacqua
+  board: "82240"
+- company: Rottas Construtora e Incorporadora
+  board: "824"
+- company: Prumo Engenharia
+  board: "82438"
+- company: Construtora Alea
+  board: "8254"
+- company: Zanini Renk
+  board: "82571"
+- company: Grupo Moura
+  board: "826"
+- company: Grupo Sinal
+  board: "82604"
+- company: Grupo Rái
+  board: "82636"
+- company: Grupo DX Soluções em EPI
+  board: "82669"
+- company: 'Usaflex '
+  board: "827"
+- company: ICONIC
+  board: "82735"
+- company: Decathlon Mexico
+  board: "82768"
+- company: Nemak Brasil
+  board: "82935"
+- company: Pampulha Iate Clube
+  board: "82999"
+- company: Silva Gym
+  board: "83032"
+- company: Segala's Alimentos
+  board: "83230"
+- company: Eletrobidu Energia Solar
+  board: "83263"
+- company: Doce D'ocê
+  board: "83296"
+- company: LICAV – Estamparia de Metais
+  board: "83329"
+- company: ORGANIZACAO EDUCACIONAL FARIAS BRITO LTDA
+  board: "83362"
+- company: Rede Mário Penna
+  board: "83395"
+- company: Laboratório Cristália
+  board: "83428"
+- company: Unimed Vale do Caí
+  board: "83461"
+- company: Impacta
+  board: "8353"
+- company: Grupo FIT - Oportunidades
+  board: "83560"
+- company: Rede Hakuo de Supermercados
+  board: "83593"
+- company: Grupo Hennings
+  board: "836"
+- company: Concessionária Novo Litoral
+  board: "83629"
+- company: CBA Corp
+  board: "83636"
+- company: Qualicorp
+  board: "8386"
+- company: Bemobi
+  board: "840"
+- company: AME
+  board: "84022"
+- company: BANCO INDUSTRIAL DO BRASIL
+  board: "84122"
+- company: Garage In Estacionamentos
+  board: "84154"
+- company: San Paolo Gelato e Café
+  board: "84187"
+- company: Wyntech
+  board: "84220"
+- company: Recrutamento para área de tecnologia com Fit Cultural e Aderência Técnica.
+  board: "843"
+- company: Vagas Confidenciais
+  board: "84319"
+- company: Grupo ARO
+  board: "84320"
+- company: NetSecurity Brasil
+  board: "84321"
+- company: Grupo Itadil
+  board: "84353"
+- company: 'Vemkitem Atacarejo '
+  board: "84385"
+- company: Pacto Global - Rede Brasil
+  board: "84418"
+- company: 'CULTURA INGLESA '
+  board: "84419"
+- company: Pimenta de Ávila Consultoria
+  board: "84421"
+- company: 'Dermage '
+  board: "84451"
+- company: Grupo SA
+  board: "84550"
+- company: GF Pneus
+  board: "84781"
+- company: Roldão Atacadista
+  board: "8485"
+- company: Jesuítas Brasil
+  board: "849"
+- company: Clínica Fares
+  board: "85045"
+- company: Gedore Brasil
+  board: "851"
+- company: Ux Group
+  board: "85177"
+- company: Conexão Talento
+  board: "852"
+- company: Lumar Metals
+  board: "85210"
+- company: Fundação Cásper Líbero
+  board: "85276"
+- company: 'GRUPO MOAS '
+  board: "85309"
+- company: 100% Cidades Participacoes Ltda
+  board: "85408"
+- company: Sun Pharma
+  board: "85474"
+- company: Altera&Ocyan
+  board: "85672"
+- company: Leve Saúde
+  board: "85771"
+- company: Sanchez e Sanchez Sociedade de Advogados
+  board: "85837"
+- company: GOL Linhas Aéreas
+  board: "859"
+- company: 'Dorben Group '
+  board: "85936"
+- company: Sesc em Minas Gerais
+  board: "85969"
+- company: Denso-SA
+  board: "86068"
+- company: CaptaMed
+  board: "86233"
+- company: BioCAZ Bioinsumos
+  board: "86299"
+- company: COPAG
+  board: "86365"
+- company: La Moda
+  board: "864"
+- company: 'CARVALIMA TRANSPORTES '
+  board: "86464"
+- company: Harald
+  board: "865"
+- company: Extractta
+  board: "86530"
+- company: Comercial Lucar
+  board: "86629"
+- company: Mamtech Tecnologia
+  board: "86696"
+- company: Grupo Minipreço
+  board: "86697"
+- company: MAMINFO SOLUCOES E SERVICOS EM TECNOLOGIA S.A.
+  board: "86698"
+- company: P.A GOLD MINERAÇÃO E METALURGIA S.A
+  board: "86700"
+- company: CONCILIG
+  board: "86701"
+- company: Grupo Paraná
+  board: "86761"
+- company: Grupo Oceanic
+  board: "86860"
+- company: Inbrands
+  board: "86959"
+- company: Escola Americana do Rio de Janeiro (EARJ)
+  board: "86960"
+- company: Grupo meia sola
+  board: "87092"
+- company: DAXIA
+  board: "871"
+- company: Confidencial
+  board: "87223"
+- company: Magnum Tires
+  board: "87256"
+- company: LOCAGORA LOCADORA DE VEICULOS SA.
+  board: "87421"
+- company: Grupo Adriana Vilarinho
+  board: "87422"
+- company: St. Marche Supermercados
+  board: "87455"
+- company: METALSIDER LTDA
+  board: "87488"
+- company: KFC Brasil
+  board: "87490"
+- company: ABT Atividades
+  board: "87553"
+- company: MERCUR SA
+  board: "87652"
+- company: Deliz Fashion Group
+  board: "87685"
+- company: Rumo Logística
+  board: "87687"
+- company: Stampline Metais Estampados Ltda
+  board: "87688"
+- company: IOBH - Instituto de Olhos de Belo Horizonte
+  board: "87817"
+- company: nola
+  board: "8782"
+- company: DAFYNE
+  board: "87850"
+- company: Biza
+  board: "87883"
+- company: Nutrimental
+  board: "87982"
+- company: Vinci Compass
+  board: "880"
+- company: '#TimeGO – Vem Fazer Parte!'
+  board: "88017"
+- company: Grupo Breitkopf
+  board: "88180"
+- company: 'Food Brands Alimentos '
+  board: "88213"
+- company: Elinsa do Brasil
+  board: "88246"
+- company: Igarapé - New Holland
+  board: "88247"
+- company: Grupo Farmax
+  board: "88279"
+- company: Prodal Saude S/A
+  board: "88312"
+- company: Logicalis Chile
+  board: "88345"
+- company: Masipack | Brasil
+  board: "88378"
+- company: TEM Saúde
+  board: "88444"
+- company: Confidencial
+  board: "88445"
+- company: Club Athletico Paranaense
+  board: "8848"
+- company: FIDI
+  board: "885"
+- company: Arteris Administrativo
+  board: "88510"
+- company: SUMIG - Soluções para Solda e Corte
+  board: "88543"
+- company: Ecossistema ARGENTA
+  board: "88544"
+- company: Agroadvance Escola de Négocios Agro
+  board: "88576"
+- company: PLAMONT ENGENHARIA
+  board: "88609"
+- company: Grupo Nantes
+  board: "88642"
+- company: Kapazi
+  board: "88675"
+- company: teste
+  board: "88708"
+- company: 'Brisanet '
+  board: "88807"
+- company: Viação Minas Gerais
+  board: "88873"
+- company: Tax.Co
+  board: "889"
+- company: Bora fazer acontecer com a gente?
+  board: "88906"
+- company: Alupar
+  board: "88972"
+- company: INSTITUTO NACIONAL DE AMPARO A MODERNIZACAO DA GESTAO PUBLICA - IMODERNIZAR
+  board: "89137"
+- company: Kamino
+  board: "89269"
+- company: Grupo Diamantes
+  board: "89336"
+- company: Casale Equipamentos Ltda
+  board: "89337"
+- company: Digibee
+  board: "89467"
+- company: 'Ultrassonografia Veterinária Móvel '
+  board: "89500"
+- company: Mira Transportes
+  board: "89501"
+- company: Sicoob Credicom
+  board: "89566"
+- company: Grupo Zaffari
+  board: "89731"
+- company: Grupo DRSUL Concessionárias
+  board: "89864"
+- company: SiDi
+  board: "899"
+- company: Grupo Verona
+  board: "89962"
+- company: Simpress
+  board: "89963"
+- company: Moveon Consulting - Servicos de Consultoria Ltda
+  board: "89995"
+- company: Página de Carreiras Heringer
+  board: "90061"
+- company: ENERWATT Engenharia e Comércio ltda
+  board: "90095"
+- company: Grupo Doce Mel
+  board: "90160"
+- company: MESTRO ALIMENTOS
+  board: "90226"
+- company: Grupo Franzen
+  board: "90259"
+- company: Join | Creative Tech
+  board: "903"
+- company: Positivo Tecnologia
+  board: "90325"
+- company: EuroChem Brasil
+  board: "90358"
+- company: Grupo Maratá
+  board: "90490"
+- company: Marsil
+  board: "90523"
+- company: Seguralta
+  board: "90556"
+- company: 'CARDWAY '
+  board: "90622"
+- company: Grupo Mendes
+  board: "90655"
+- company: MEDRADIUS - CLINICA DE MEDICINA NUCLEAR E RADIOLOGIA DE MACEIO S/S LTDA.
+  board: "90754"
+- company: Grupo D. Center
+  board: "90787"
+- company: Zenvia Jobs
+  board: "90952"
+- company: PWS Cloud
+  board: "91018"
+- company: HERBARIUM LABORATÓRIO BOTÂNICO
+  board: "91084"
+- company: IDS Software e Assessoria
+  board: "91118"
+- company: VAGAS TESTES BONDY
+  board: "91216"
+- company: Z Deli
+  board: "91249"
+- company: SELPE GENTE & GESTÃO
+  board: "91282"
+- company: Direction Soluções Empresariais
+  board: "91283"
+- company: Confidencial
+  board: "91448"
+- company: Neohype
+  board: "91513"
+- company: 'Triunfo Transbrasiliana - Concessionária de Rodovia '
+  board: "91547"
+- company: Confidencial
+  board: "91678"
+- company: GRUPO MINAS VERDE
+  board: "91744"
+- company: Grupo PD
+  board: "91810"
+- company: GDSUL - Construção Inteligente
+  board: "91844"
+- company: 'Confidencial '
+  board: "91876"
+- company: Página Externa
+  board: "91942"
+- company: Brasterápica Industria Farmacêutica
+  board: "91975"
+- company: Trust Group
+  board: "92008"
+- company: TRR Cacique
+  board: "92041"
+- company: Nexxa Food Service Solutions
+  board: "92042"
+- company: 'ISA SAÚDE '
+  board: "92107"
+- company: Layer Up
+  board: "92173"
+- company: Chiptronic
+  board: "92174"
+- company: 'SPL ENGENHARIA '
+  board: "92177"
+- company: Unijuí
+  board: "92245"
+- company: Tempo
+  board: "92305"
+- company: Trabalhe Conosco- Rodrigues Colchões
+  board: "92371"
+- company: Vagas Leo Madeiras
+  board: "92404"
+- company: Tereos
+  board: "92405"
+- company: Espaçolaser
+  board: "9244"
+- company: OVAL - VAGAS
+  board: "92470"
+- company: Rede D'Or
+  board: "92503"
+- company: Centro Universitário FEI
+  board: "92569"
+- company: 'DICON CONTABILIDADE '
+  board: "92701"
+- company: Luuna Brasil
+  board: "92702"
+- company: Brandness
+  board: "92703"
+- company: Vagas abertas • Grupo Alpha
+  board: "92768"
+- company: 'MTO Administração de Franquias | O Matuto '
+  board: "92800"
+- company: TXT Build
+  board: "92833"
+- company: Work On Time
+  board: "92899"
+- company: Carreiras AGE Fibra
+  board: "92933"
+- company: Mandū Inovação Social
+  board: "93064"
+- company: Vision Cybersecurity
+  board: "93098"
+- company: WeScale
+  board: "93163"
+- company: CONTACTUS RH
+  board: "93196"
+- company: Tortoro, Madureira & Ragazzi Advogados
+  board: "93295"
+- company: Biofoods Alimentacao LTDA
+  board: "93361"
+- company: Coplan Contabilidade
+  board: "93362"
+- company: 'OMNIA '
+  board: "93395"
+- company: Jclm Industria e Comercio Ltda
+  board: "93526"
+- company: Fiberhome Brasil
+  board: "93559"
+- company: PG Advogados
+  board: "93593"
+- company: FIREDEV SERVICOS EM TECNOLOGIA DA INFORMACAO LTDA
+  board: "93691"
+- company: Consolare
+  board: "93693"
+- company: GABRIEL MALHEIROS ADVOGADOS
+  board: "93694"
+- company: NEOBAG
+  board: "93724"
+- company: IMPAKTO SISTEMAS DE LIMPEZA E DESCARTAVEIS
+  board: "93757"
+- company: Unifeob
+  board: "938"
+- company: ITAM Transformadores
+  board: "93889"
+- company: Valid
+  board: "941"
+- company: Steck Indústria Elétrica
+  board: "9508"
+- company: Fattu
+  board: "960"
+- company: CLAMED Lojas
+  board: "961"
+- company: '#SejaSicoobSul '
+  board: "962"
+- company: Yusen Logistics
+  board: "9673"
+- company: 'Elgin '
+  board: "976"
+- company: Wyden
+  board: "981"
+- company: Leega Consultoria
+  board: "986"
+- company: Wama Oportunidades
+  board: "9872"
+- company: Expresso Nepomuceno
+  board: "988"
+- company: Urbitec Construções
+  board: "993"
+- company: Grupo Real
+  board: "996"


### PR DESCRIPTION
## Summary

Bulk-adds **1338 new Gupy boards** (`sources/gupy.yml`: 33 → 1371), generated by
the `harvest-boards gupy` discovery mode (#139) and **live-validated** — every
board was probed against Gupy's portal API and kept only with ≥1 open job.

### How / scope

Discovery pages Gupy's **global** jobs feed collecting distinct `companyId`s
(user chose *all companies*, no IT keyword filter). The feed **caps `offset` at
10000** (HTTP 400 beyond), so one sweep covers the ~10k **freshest** postings →
**1362 distinct companies, 1338 new** after dedup. A later sweep (or keyword
slices) would surface more from the 83k-job long tail.

### What to know before merging

- **Composition: Brazilian, all sectors.** Gupy is BR-wide — these include
  logistics / construction / retail / consultoria companies, not only tech. Their
  postings will mostly be non-IT; `enrich`/`classify` categorize them downstream.
- **~37 slogan-style names** (≈2.7%): `careerPageName` is sometimes a recruiting
  campaign title (e.g. `#SejaSBT`, `Vem ser Ourofino Agrociência!`). Kept as-is
  per the harvest doctrine; easy to grep/trim if undesired.
- **Scale.** +1338 boards ≈ proportional ingest-crawl + enrichment-queue growth.

### Validation

- [x] `sources/gupy.yml` parses + passes registry validation (1371 entries)
- [x] No empty company names
- [x] Every board live-validated by the harvest probe (≥1 open job)

Depends conceptually on #139 (the discovery tool) but is standalone data — the
`gupy` ingest adapter is already in `main`. Deploys via sources rsync, no rebuild.