### PR TITLE
feat(sources): telagon-discovered telegram channels + ATS boards

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -4807,3 +4807,21 @@
   board: recharge
 - company: TestGorilla
   board: testgorilla
+- company: ava-labs
+  board: ava-labs
+- company: crackenagi
+  board: crackenagi
+- company: farel
+  board: farel
+- company: glacis-ai
+  board: glacis-ai
+- company: moonshot
+  board: moonshot
+- company: morpho
+  board: morpho
+- company: ramielcapital
+  board: ramielcapital
+- company: safe
+  board: safe
+- company: yeifinance
+  board: yeifinance

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -9803,3 +9803,25 @@
   board: zwift
 - company: 'Zynga '
   board: zyngacareers
+- company: Beacon Power Services
+  board: beaconpowerservices
+- company: bswift India
+  board: bswiftindia
+- company: Datavations
+  board: datavations
+- company: Kerv
+  board: kerv
+- company: Marketdata&Match
+  board: marketdata
+- company: Nirmata
+  board: nirmata
+- company: 'One Acre Fund - Ethiopia '
+  board: oneacrefundethiopia
+- company: Open Energy Transition
+  board: openenergytransition
+- company: Sporty Group
+  board: sportygroup
+- company: StraitsX
+  board: straitsx
+- company: StubHub
+  board: stubhubinc

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -3487,3 +3487,17 @@
   board: zurichinstruments
 - company: zurigroup
   board: zurigroup
+- company: assist-world
+  board: assist-world
+- company: get-vocal-pbc
+  board: get-vocal-pbc
+- company: quantcast
+  board: quantcast
+- company: stable-money1
+  board: stable-money1
+- company: strategicgears
+  board: strategicgears
+- company: sylndr
+  board: sylndr
+- company: vedatechlabs
+  board: vedatechlabs

--- a/sources/telegram.yml
+++ b/sources/telegram.yml
@@ -101,3 +101,90 @@ channels:
     kind: board
   - channel: careers_crypto
     kind: board
+
+  # --- Discovered via telagon 2026-06-16 (top channels by ATS-link volume) ---
+  # All 34 verified to have a live public t.me/s preview at discovery time.
+  # Mostly EN India/global + a few RU/PT/AR/FA/Web3 aggregators — geography the
+  # curated RU/IT tier above did not cover.
+
+  # Global / India tech job boards
+  - channel: dot_aware
+    kind: board
+  - channel: gocareers
+    kind: board
+  - channel: getjobss
+    kind: board
+  - channel: jobs_and_internships_updates
+    kind: board
+  - channel: jobsandinternshipsupdates
+    kind: board
+  - channel: off_campus_jobs_and_internships
+    kind: board
+  - channel: offcampus_phodenge
+    kind: board
+  - channel: freshercareersdotin
+    kind: board
+  - channel: OceanOfJobs
+    kind: board
+  - channel: JobsPur
+    kind: board
+  - channel: jobvila
+    kind: board
+  - channel: hiringdaily
+    kind: board
+  - channel: TorchBearerr
+    kind: board
+  - channel: jobsstation_official
+    kind: board
+  - channel: tamilanjobupdates
+    kind: board
+
+  # India personal-brand / editorial (posts may bundle several vacancies)
+  - channel: arunchauhanofficial
+    kind: authored
+  - channel: jobwithmayra
+    kind: authored
+  - channel: goyalarsh
+    kind: authored
+  - channel: vijaykushal
+    kind: authored
+  - channel: PrepTrain
+    kind: authored
+  - channel: cs_algo
+    kind: authored
+
+  # Data / analytics niche
+  - channel: dataanalyticsbuddy
+    kind: board
+  - channel: cv_2essence
+    kind: board
+
+  # Nigeria
+  - channel: tohire_ng
+    kind: board
+  - channel: jobnetworkng
+    kind: board
+  - channel: dejob_global
+    kind: board
+  - channel: DeJob_official
+    kind: board
+
+  # STEM / students
+  - channel: STEMJobsCR
+    kind: board
+
+  # Other languages (ar / fa / pt / ru)
+  - channel: amalw3amal1
+    kind: board
+  - channel: seekingyourjobs
+    kind: board
+  - channel: cafeinavagas
+    kind: board
+  - channel: youritjob
+    kind: board
+
+  # Web3
+  - channel: worklinketh
+    kind: board
+  - channel: talentatweb3
+    kind: board


### PR DESCRIPTION
Mined the telagon corpus (613M posts / 252k channels) for job sources we don't yet cover.

## Telegram channels (+34)
Top channels by ATS-link volume, each verified to have a live public \`t.me/s\` preview at discovery time. Mostly EN India/global + a few NG/AR/FA/PT/RU/Web3 aggregators — geography the curated RU/IT tier did not cover. \`kind\`: \`board\` for aggregators, \`authored\` for personal-brand/editorial channels that bundle multiple vacancies per post.

## ATS boards (+27)
Board slugs extracted from ATS links in telagon posts, then live-probed via \`cmd/harvest-boards\` — only boards whose public API returns jobs are kept (the rest were noise or already covered):

| provider | candidates | kept |
|---|---|---|
| greenhouse | 275 | +11 (StubHub, Quantcast, Sporty Group, StraitsX, One Acre Fund…) |
| lever | 309 | +7 |
| ashby | 96 | +9 (Avalanche, Morpho, Safe, Moonshot…) |

Build + \`internal/sources\` + \`internal/telegram\` tests green.