### PR TITLE
feat(sources): +79 gupy boards resolved from telagon subdomains

### DIFF
--- a/sources/gupy.yml
+++ b/sources/gupy.yml
@@ -2747,3 +2747,161 @@
   board: "993"
 - company: Grupo Real
   board: "996"
+- company: Pulsus
+  board: "1000"
+- company: Bernhoeft GRT
+  board: "1100"
+- company: Icaro Tech
+  board: "1186"
+- company: 'Vagas 3S Checkout '
+  board: "1253"
+- company: Grupo Hive | Omnibees, Bee2Pay e Niara - Brasil
+  board: "15482"
+- company: DB
+  board: "15580"
+- company: Mais Diversidade
+  board: "1666"
+- company: Embraer
+  board: "175"
+- company: Unimed Teresina
+  board: "1832"
+- company: Carreiras Méliuz
+  board: "1872"
+- company: 'Techne '
+  board: "189"
+- company: 'CAPEMISA Seguradora '
+  board: "1915"
+- company: PagBrasil
+  board: "1957"
+- company: ZEN
+  board: "1967"
+- company: ZG Soluções
+  board: "1992"
+- company: Gupy
+  board: "2"
+- company: Vsoft
+  board: "2007"
+- company: Giro.Tech - Infraestrutura para Crédito
+  board: "20134"
+- company: SolarGrid
+  board: "2054"
+- company: Nefex
+  board: "2058"
+- company: ISH Tecnologia
+  board: "2083"
+- company: dataRain Consulting - Careers
+  board: "22115"
+- company: Solinftec
+  board: "2216"
+- company: Vagas MRM Brasil
+  board: "2236"
+- company: Viceri SEIDOR
+  board: "2364"
+- company: Atlas Governance
+  board: "24721"
+- company: Sabium Sistemas
+  board: "26734"
+- company: B4A
+  board: "27064"
+- company: Lumis Experience
+  board: "29902"
+- company: SolvePlan
+  board: "31651"
+- company: Smarthis
+  board: "32146"
+- company: Evoluservices
+  board: "33202"
+- company: SPC Brasil
+  board: "33763"
+- company: 'Vem #SerHype'
+  board: "33961"
+- company: Grupo Leste
+  board: "35380"
+- company: Nexa Vagas
+  board: "36667"
+- company: Confitec
+  board: "388"
+- company: Akross
+  board: "40726"
+- company: BR agro
+  board: "41188"
+- company: Class Solutions
+  board: "41755"
+- company: SoftDesign
+  board: "433"
+- company: Programa de Estágio Anbima 2026
+  board: "43366"
+- company: VExpenses
+  board: "43829"
+- company: Aoop Cloud Solutions
+  board: "440"
+- company: Ipê Digital
+  board: "4558"
+- company: 'Vem Pra Pixeon '
+  board: "45775"
+- company: Certsys
+  board: "45841"
+- company: Mundiale
+  board: "45973"
+- company: FINDES
+  board: "46468"
+- company: DataHub Analytics
+  board: "4888"
+- company: Sigga Technolgies
+  board: "49471"
+- company: Programas Núclea
+  board: "51691"
+- company: Target Sistemas
+  board: "519"
+- company: Hyperativa
+  board: "58612"
+- company: Carreiras - Empresa Confidencial
+  board: "59635"
+- company: Dentsu World Services Brazil
+  board: "59833"
+- company: Nomus
+  board: "60889"
+- company: Nomos - Melhores Investidores
+  board: "6109"
+- company: TEKNA.ROCKS
+  board: "659"
+- company: Foresea
+  board: "66367"
+- company: Transform and grow in Digital
+  board: "68193"
+- company: betunel-oficial
+  board: "68323"
+- company: Ativa GR
+  board: "68685"
+- company: ioasys
+  board: "702"
+- company: Itix
+  board: "722"
+- company: We Believe in Great Ideas - WBGI
+  board: "726"
+- company: Gaudium
+  board: "75343"
+- company: CSU Digital
+  board: "774"
+- company: Monks
+  board: "777"
+- company: Produttivo
+  board: "7858"
+- company: Cortex
+  board: "803"
+- company: Soluções eSales
+  board: "805"
+- company: Monte Carlo Joias
+  board: "806"
+- company: Claranet Technology S.A.
+  board: "85441"
+- company: 'Mark Up '
+  board: "879"
+- company: STUDIO SOL
+  board: "939"
+- company: Escola Mais
+  board: "956"
+- company: Sofist
+  board: "958"
+- company: Grupo CM
+  board: "974"


### PR DESCRIPTION
Gupy `discover()` (shipped in #141) is capped at the global feed's offset-10000 wall — every companyId it can reach is already in `sources/gupy.yml` (this run: `new-candidates=0`).

Telagon posts surface Gupy companies **beyond** that wall. Recipe:
1. Extracted 538 distinct `*.gupy.io` subdomains from the telagon corpus.
2. Resolved each to its numeric `companyId` via the page's `careerPage` block — 290 are real Gupy boards, the rest were false regex extractions (filtered out for free).
3. Diffed against our 1371 existing ids → 93 net-new.
4. Live-probed via `cmd/harvest-boards gupy <seed>` — **79** returned open jobs and were appended.

Real BR employers: Embraer, Méliuz, PagBrasil, Pulsus, CAPEMISA, Icaro Tech…

Build + `internal/sources` tests green.