### PR TITLE
feat(sources): +20 ATS boards from remote-jobs audit

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -4793,3 +4793,17 @@
   board: zoe
 - company: zyphra
   board: zyphra
+- company: "Clerky, Inc."
+  board: clerky
+- company: Contra
+  board: contra
+- company: Nomad Labs
+  board: nomad
+- company: Paymentology
+  board: paymentology
+- company: Raptive
+  board: raptive
+- company: Recharge
+  board: recharge
+- company: TestGorilla
+  board: testgorilla

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -63,3 +63,9 @@
   board: caribou
 - company: Beatdapp
   board: beatdapp
+- company: Localize
+  board: localize
+- company: Reveleer
+  board: reveleer
+- company: GNO Partners
+  board: gno-partners

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -41,3 +41,5 @@
   board: welevel
 - company: BIT Capital
   board: bitcap
+- company: Leadfeeder
+  board: leadfeeder

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -149,3 +149,9 @@
   board: zeromotorcycles
 - company: Exeon
   board: exeon
+- company: MailerLite
+  board: mailerlite
+- company: Podia
+  board: podia
+- company: New Law Business Model
+  board: newlawbusinessmodel

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -931,3 +931,11 @@
   board: pubx
 - company: Second Nature
   board: secondnature
+- company: JLS Trading Co
+  board: jlstradingco
+- company: Livingston Research
+  board: livingstonresearch
+- company: ServiceTitan
+  board: servicetitan
+- company: Forager
+  board: forager

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -559,3 +559,7 @@
   board: haiilo-1
 - company: Mercier Consultancy
   board: mercier-consultancy
+- company: NoGigiddy
+  board: nogigiddy
+- company: Awesome Motive
+  board: awesomemotive


### PR DESCRIPTION
Live-validated ATS boards for companies surfaced from two remote-job lists (top-100 remote employers + WWR top-trending).

Each slug was **probed against its platform API** (must return open jobs) and the **company identity confirmed** via og:title / API `company_name`, not guessed.

| Provider | + | Companies |
|---|---|---|
| ashby | 7 | Contra, Recharge, TestGorilla, Paymentology, Raptive (CafeMedia), Clerky, Nomad Labs |
| smartrecruiters | 4 | JLS Trading Co, Livingston Research, ServiceTitan, Forager |
| recruitee | 3 | MailerLite, Podia, New Law Business Model |
| breezy | 3 | Localize, Reveleer, GNO Partners |
| workable | 2 | NoGigiddy (~1822 jobs), Awesome Motive |
| personio | 1 | Leadfeeder (Dealfront) |

**Skipped slug collisions:** `greenhouse:aha` resolves to *Animal Health Associates* (a vet clinic, not Aha.io); `greenhouse:skedda` has 0 open jobs.

ashby/greenhouse went through `cmd/harvest-boards` (live re-probe + canonical name); the rest were hand-added with names pulled from each API. All files pass structural + registry validation. No new adapter needed — boards reach prod on the next ingest cron per provider.