### PR TITLE
feat(sources): +11 ATS boards from remote-jobs recon (round 2)

### DIFF
--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -3501,3 +3501,5 @@
   board: sylndr
 - company: vedatechlabs
   board: vedatechlabs
+- company: Smile.io
+  board: Smile.io

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -7,3 +7,11 @@
   board: aawdc
 - company: Actica Consulting
   board: actica
+- company: AgencyAnalytics
+  board: agencyanalytics
+- company: SafetyWing
+  board: safetywing
+- company: Creative Force
+  board: creativeforce
+- company: Seeq
+  board: seeq

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -155,3 +155,5 @@
   board: podia
 - company: New Law Business Model
   board: newlawbusinessmodel
+- company: Time Doctor
+  board: timedoctor

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -939,3 +939,7 @@
   board: servicetitan
 - company: Forager
   board: forager
+- company: Greenback Expat Tax Services
+  board: greenbackexpattaxservices
+- company: VIPKID
+  board: vipkid

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -563,3 +563,9 @@
   board: nogigiddy
 - company: Awesome Motive
   board: awesomemotive
+- company: CoverGo
+  board: covergo
+- company: Whitespectre
+  board: whitespectre
+- company: Bask Health
+  board: bask-health-1


### PR DESCRIPTION
Round-2 board additions from a parallel careers-page recon (6 agents) over two more remote-job lists.

Each slug **probed live** (returns open jobs) + **identity confirmed** (og:title / API company name).

| Provider | + | Companies (open jobs) |
|---|---|---|
| pinpoint | 4 | AgencyAnalytics (3), SafetyWing (3), Creative Force (8), Seeq (4) |
| workable | 3 | CoverGo (203), Bask Health (61), Whitespectre (2) |
| smartrecruiters | 2 | Greenback Expat Tax Services (1), VIPKID (1) |
| lever | 1 | Smile.io (2) |
| recruitee | 1 | Time Doctor (4) |

**Rejected slug collisions:** `ashby:omni` (omni.co BI startup ≠ Omni Interactions), `bamboohr:tortuga` (Kingston warehouse ≠ Tortuga Backpacks), `greenhouse:aha` (Animal Health Associates ≠ Aha.io), `recruitee:fmtc` (front-desk ≠ FMTC affiliate SaaS).

**Deferred (adapter can't reach):** Toggl & Chainlink Labs (Ashby public posting-api disabled, GraphQL-embed only); Silverfin & XM (Lever EU-region host `api.eu.lever.co` — adapter uses default host); Proxify (Teamtailor custom-domain SPA listing, no server-rendered `/jobs/<id>` links).

No new adapter needed — boards reach prod on the next ingest cron per provider.