### PR TITLE
feat(sources): Jibe adapter (github.careers) + Confluence pinpoint board

### DIFF
--- a/internal/sources/jibe.go
+++ b/internal/sources/jibe.go
@@ -1,0 +1,100 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// jibe adapts Jibe career sites (the career-site product fronting iCIMS, e.g.
+// github.careers). The board is the site's public host (e.g. "www.github.careers"),
+// forming the JSON listing API "https://<board>/api/jobs". That list endpoint already
+// carries the full posting HTML in "description", so there is no per-job detail fetch —
+// the separate responsibilities/qualifications fields are redundant re-extractions of
+// the same body (verified: every posting's description already contains them) and are
+// intentionally not appended.
+
+// jibePageLimit is the listing page size. The API reports the catalogue total, so the
+// crawl pages until every posting is collected.
+const jibePageLimit = 100
+
+// jibeDateLayout is Jibe's posted_date format: RFC3339 with a numeric, colon-less zone
+// offset ("2026-06-16T20:41:00+0000"), which time.RFC3339 cannot parse.
+const jibeDateLayout = "2006-01-02T15:04:05-0700"
+
+type jibe struct {
+	http JSONGetter
+}
+
+// NewJibe builds the Jibe adapter over the given HTTP client.
+func NewJibe(c JSONGetter) Source { return jibe{http: c} }
+
+func (jibe) Provider() string { return "jibe" }
+
+// jibeListing is one /api/jobs page: the postings plus the catalogue total used as the
+// stop condition.
+type jibeListing struct {
+	Jobs []struct {
+		Data jibePosting `json:"data"`
+	} `json:"jobs"`
+	TotalCount int `json:"totalCount"`
+}
+
+// jibePosting is one posting's "data" object; only the fields the Job shape needs are
+// decoded.
+type jibePosting struct {
+	Slug               string `json:"slug"`
+	ReqID              string `json:"req_id"`
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	LocationName       string `json:"location_name"`
+	FullLocation       string `json:"full_location"`
+	LocationType       string `json:"location_type"`
+	HiringOrganization string `json:"hiring_organization"`
+	PostedDate         string `json:"posted_date"`
+}
+
+func (s jibe) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; ; page++ {
+		url := fmt.Sprintf("https://%s/api/jobs?page=%d&limit=%d", e.Board, page, jibePageLimit)
+		var listing jibeListing
+		if err := s.http.GetJSON(ctx, url, &listing); err != nil {
+			return nil, fmt.Errorf("jibe: list board %s: %w", e.Board, err)
+		}
+		if len(listing.Jobs) == 0 {
+			break
+		}
+		for _, item := range listing.Jobs {
+			jobs = append(jobs, s.toJob(e, item.Data))
+		}
+		// Stop once the catalogue total is reached; the empty-page check above is the
+		// fallback if totalCount is ever absent or wrong.
+		if len(jobs) >= listing.TotalCount {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps one Jibe posting to the normalized Job shape. The id is the posting slug
+// (the public job-page path segment), falling back to req_id.
+func (s jibe) toJob(e CompanyEntry, p jibePosting) Job {
+	id := firstNonEmpty(p.Slug, p.ReqID)
+	location := firstNonEmpty(p.LocationName, p.FullLocation)
+	// location_type is the structured work-arrangement signal (REMOTE/HYBRID/ONSITE);
+	// "ANY" and unknown values yield no mode, leaving the pipeline to fall back to the
+	// location string.
+	workMode := workplaceTypeMode(p.LocationType)
+	return Job{
+		ExternalID:  id,
+		URL:         fmt.Sprintf("https://%s/careers-home/jobs/%s", e.Board, id),
+		Title:       strings.TrimSpace(p.Title),
+		Company:     firstNonEmpty(p.HiringOrganization, e.Company),
+		Location:    location,
+		Description: sanitizeHTML(p.Description),
+		Remote:      workMode == "remote" || isRemote(location),
+		WorkMode:    workMode,
+		PostedAt:    parseLayout(jibeDateLayout, p.PostedDate),
+	}
+}

--- a/internal/sources/jibe_test.go
+++ b/internal/sources/jibe_test.go
@@ -1,0 +1,95 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestJibeProvider(t *testing.T) {
+	if got := NewJibe(nil).Provider(); got != "jibe" {
+		t.Errorf("Provider() = %q, want %q", got, "jibe")
+	}
+}
+
+// jibeJob renders one /api/jobs "data" object with the fields the adapter reads.
+func jibeJob(slug, title, locName, locType, org, posted string) string {
+	return `{"data": {
+		"slug": "` + slug + `",
+		"req_id": "` + slug + `",
+		"title": "` + title + `",
+		"description": "<strong>About</strong><br>` + title + ` does the work.",
+		"location_name": "` + locName + `",
+		"full_location": "United States",
+		"location_type": "` + locType + `",
+		"hiring_organization": "` + org + `",
+		"posted_date": "` + posted + `"
+	}}`
+}
+
+func TestJibeFetchPaginatesAndMaps(t *testing.T) {
+	// totalCount 3 forces a second page: page 1 returns 2, page 2 the last.
+	fake := (&routedHTTP{}).
+		route("page=1", `{"totalCount": 3, "jobs": [`+
+			jibeJob("5441", "Software Engineer III", "US Remote", "ANY", "GitHub, Inc.", "2026-06-16T20:41:00+0000")+`,`+
+			jibeJob("5500", "Hybrid Role", "Berlin", "HYBRID", "GitHub, Inc.", "2026-06-15T10:00:00+0000")+
+			`]}`).
+		route("page=2", `{"totalCount": 3, "jobs": [`+
+			jibeJob("5600", "Onsite Role", "London", "REMOTE", "", "2026-06-14T09:30:00+0000")+
+			`]}`)
+
+	jobs, err := NewJibe(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "GitHub", Provider: "jibe", Board: "www.github.careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 across two pages", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j := byID["5441"]
+	if j.Title != "Software Engineer III" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.URL != "https://www.github.careers/careers-home/jobs/5441" {
+		t.Errorf("URL = %q, want the public job page built from board+slug", j.URL)
+	}
+	if j.Company != "GitHub, Inc." {
+		t.Errorf("Company = %q, want the posting's hiring_organization", j.Company)
+	}
+	if j.Location != "US Remote" {
+		t.Errorf("Location = %q, want location_name", j.Location)
+	}
+	// location_type "ANY" gives no structured mode, but the "US Remote" string flags remote.
+	if j.WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty for location_type ANY", j.WorkMode)
+	}
+	if !j.Remote {
+		t.Error("Remote = false, want true from the location string heuristic")
+	}
+	if !strings.Contains(j.Description, "does the work") {
+		t.Errorf("Description = %q, want the posting body", j.Description)
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed posted_date (2026)", j.PostedAt)
+	}
+
+	// HYBRID/REMOTE location_type map to the structured work mode.
+	if got := byID["5500"].WorkMode; got != "hybrid" {
+		t.Errorf("WorkMode(5500) = %q, want hybrid", got)
+	}
+	if got := byID["5600"].WorkMode; got != "remote" {
+		t.Errorf("WorkMode(5600) = %q, want remote", got)
+	}
+
+	// hiring_organization empty -> fall back to the configured company.
+	if got := byID["5600"].Company; got != "GitHub" {
+		t.Errorf("Company(5600) = %q, want configured company fallback", got)
+	}
+}

--- a/internal/sources/pinpoint.go
+++ b/internal/sources/pinpoint.go
@@ -34,6 +34,7 @@ func (p pinpoint) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location                 struct {
 				City     string `json:"city"`
 				Province string `json:"province"`
+				Name     string `json:"name"`
 			} `json:"location"`
 		} `json:"data"`
 	}
@@ -46,11 +47,14 @@ func (p pinpoint) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		// Pinpoint splits the body across separate HTML sections.
 		body := d.Description + d.KeyResponsibilities + d.SkillsKnowledgeExpertise + d.Benefits
 		jobs = append(jobs, Job{
-			ExternalID:  d.ID,
-			URL:         d.URL,
-			Title:       d.Title,
-			Company:     e.Company,
-			Location:    joinNonEmpty(d.Location.City, d.Location.Province),
+			ExternalID: d.ID,
+			URL:        d.URL,
+			Title:      d.Title,
+			Company:    e.Company,
+			// Prefer the structured city/province; some boards leave both empty and
+			// only fill the human-readable name ("Remote", "Pittsburgh, PA"), so fall
+			// back to it rather than yielding a blank location.
+			Location:    firstNonEmpty(joinNonEmpty(d.Location.City, d.Location.Province), d.Location.Name),
 			Description: sanitizeHTML(body),
 			Remote:      d.WorkplaceType == "remote",
 			PostedAt:    nil, // the postings feed carries no publish date

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -104,6 +104,7 @@ func All(c HTTPClient) map[string]Source {
 		NewSuccessFactors(c),
 		NewTeamtailor(c),
 		NewICIMS(c),
+		NewJibe(c),
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),

--- a/sources/jibe.yml
+++ b/sources/jibe.yml
@@ -1,0 +1,9 @@
+# Jibe career sites (the career-site product fronting iCIMS). Provider is the filename;
+# each entry is company + board.
+# board = the site's public host, forming https://<board>/api/jobs (see
+# internal/sources/jibe.go). The listing JSON carries the full description, so there is
+# no per-job detail fetch.
+# Each board validated live (/api/jobs returns postings) before adding.
+
+- company: GitHub
+  board: www.github.careers

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -15,3 +15,5 @@
   board: creativeforce
 - company: Seeq
   board: seeq
+- company: Confluence
+  board: confluence


### PR DESCRIPTION
## What

Two new job sources plus a Pinpoint location fix.

### 1. Jibe career-site adapter (`internal/sources/jibe.go`)
`github.careers` is a tenant on **Jibe** — iCIMS's public career-site product (the iCIMS backend itself is IP-gated, but the Jibe front exposes a clean keyed JSON API). New board-based adapter, `board` = the site host:

- Lists `https://<board>/api/jobs?page=N&limit=100`, paginating until `totalCount` is reached.
- The listing carries the full posting HTML in `description` (verified: it already subsumes the separate `responsibilities`/`qualifications` fields), so **no per-job detail fetch**.
- Maps `location_type` (REMOTE/HYBRID/ONSITE) via the shared `workplaceTypeMode`; custom `-0700` date layout funnelled through `NotFuture`.
- `url` is the public job page `…/careers-home/jobs/<slug>` (the `apply_url` points to the gated iCIMS login).

Adds **GitHub** in `sources/jibe.yml` — **75 jobs, live-verified**.

### 2. Confluence on the existing `pinpoint` adapter
`confluence.pinpointhq.com` is a standard Pinpoint board → one line in `sources/pinpoint.yml`.

While adding it, fixed a latent bug: some boards leave `location.city`/`province` empty and only fill the human-readable `location.name`, so those postings produced a **blank** location (e.g. SafetyWing). Now falls back to `name`. Confluence: **20 jobs, 0 empty locations** after the fix.

## Test
`go build ./...`, `go vet`, `go test ./internal/sources/` — all green; gofmt clean. New `jibe_test.go` covers pagination, work-mode mapping, and the company fallback; existing pinpoint tests still pass.

## Not in scope (assessed, deferred)
- **careers.confluent.io** — custom Next.js on Vercel behind a Bot Challenge (`x-vercel-mitigated: challenge`); needs a headless/challenge tier.
- **careers.dhl.com** — Phenom People platform; no adapter yet (separate, larger effort).