### PR TITLE
fix(sources): bound yandex cursor pagination to stop runaway loop

### DIFF
--- a/internal/sources/yandex.go
+++ b/internal/sources/yandex.go
@@ -77,14 +77,26 @@ func (y yandex) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	}), nil
 }
 
+// yandexMaxListPages bounds the cursor pagination. Yandex's API tarpits datacenter IPs and
+// under throttling can return a "next" cursor that never empties; without a cap the loop
+// runs forever (it hung a prod custom.yml ingest for ~4h, holding its flock). The bound sits
+// far above the real page count (~1250 jobs total) so it never truncates a legitimate crawl.
+const yandexMaxListPages = 500
+
 // list walks the cursor-paginated publication list. The first request hits the bare
 // endpoint; each response's "next" is an absolute URL on Yandex's internal host carrying a
-// ?cursor= query, which list re-issues against the public host until next is empty.
+// ?cursor= query, which list re-issues against the public host until next is empty. A
+// repeated cursor (the upstream cycling under throttling) or the page cap ends the walk, so
+// a misbehaving feed can never spin the loop forever.
 func (y yandex) list(ctx context.Context, board string) ([]yandexItem, error) {
 	base := fmt.Sprintf(yandexListURL, board)
 	url := base
 	var all []yandexItem
-	for url != "" {
+	seen := make(map[string]bool)
+	for page := 0; url != ""; page++ {
+		if page >= yandexMaxListPages {
+			return nil, fmt.Errorf("yandex: list board %s: exceeded %d pages (runaway cursor)", board, yandexMaxListPages)
+		}
 		var resp struct {
 			Results []yandexItem `json:"results"`
 			Next    string       `json:"next"`
@@ -95,9 +107,10 @@ func (y yandex) list(ctx context.Context, board string) ([]yandexItem, error) {
 		all = append(all, resp.Results...)
 
 		cursor := cursorParam(resp.Next)
-		if cursor == "" {
+		if cursor == "" || seen[cursor] {
 			break
 		}
+		seen[cursor] = true
 		url = base + "?cursor=" + cursor
 	}
 	return all, nil

--- a/internal/sources/yandex_test.go
+++ b/internal/sources/yandex_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 // yandexListItem builds one list item fragment. cities and workModes are inline JSON
@@ -172,6 +173,29 @@ func TestYandexEmptyListYieldsNoJobsNoError(t *testing.T) {
 	}
 	if len(jobs) != 0 {
 		t.Fatalf("got %d jobs, want 0", len(jobs))
+	}
+}
+
+func TestYandexListBoundsRunawayCursor(t *testing.T) {
+	// Yandex's API tarpits datacenter IPs: under throttling it can return a `next`
+	// cursor that never empties, so the cursor loop appends pages forever. In prod this
+	// hung the whole custom.yml ingest for ~4h, holding its flock (one HTTP/2 keepalive
+	// connection, frozen "16/17 boards crawled"). list() must bound the pagination
+	// instead of trusting the upstream to terminate. The fake always replies with the
+	// same non-empty next cursor, so unbounded code loops indefinitely.
+	loop := yandexListPage("https://yandex.ru/jobs/api/publications?cursor=LOOP")
+	fake := (&routedHTTP{}).route("/jobs/api/publications", loop)
+	y := yandex{http: fake}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = y.list(context.Background(), "ru")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("yandex.list did not terminate: runaway cursor pagination is unbounded")
 	}
 }
 


### PR DESCRIPTION
## Symptom
A prod `custom.yml` ingest hung for ~4h, frozen at `progress 16/17 boards crawled`, holding its per-file flock and starving every other single-source RU/intl adapter (vk, ozon, sber, …) behind it. `nsenter` into the container's netns showed one ESTAB HTTP/2 keepalive to `77.88.55.88:443` (yandex.ru).

## Root cause
`yandex.list()` paginates by cursor and breaks **only** when Yandex returns an empty `next`:
```go
for url != "" {
    GetJSON(url, &resp)
    cursor := cursorParam(resp.Next)
    if cursor == "" { break }
    url = base + "?cursor=" + cursor
}
```
Yandex's API tarpits datacenter IPs; under throttling it returns a `next` cursor that never empties, so the loop runs forever. Each request stays within the 15s client timeout (one reused HTTP/2 connection), so the per-request timeout never fires — the *loop* is unbounded, not any single call.

## Fix
Bound the walk two ways (mirrors the existing `gupyMaxOffset` convention):
- **break on a repeated cursor** — catches the cycling-upstream case immediately;
- **hard-cap at 500 pages** — backstop for an ever-advancing cursor, far above the ~1250-job real count so a legitimate crawl is never truncated.

TDD: the test fakes a feed that always returns the same non-empty cursor and asserts `list()` terminates (RED: 2s timeout → FAIL; GREEN: instant). All sources tests green, vet + gofmt clean.

Follow-up (not in this PR): the same unbounded-pagination shape could exist in other cursor/page adapters — worth an audit.