### PR TITLE
feat(sources): Lever EU data-residency host via region field

### DIFF
--- a/internal/sources/lever.go
+++ b/internal/sources/lever.go
@@ -6,8 +6,13 @@ import (
 	"strings"
 )
 
-// leverBaseURL is the Lever postings API root.
-const leverBaseURL = "https://api.lever.co/v0/postings"
+// leverBaseURL is the Lever postings API root (default/US host). leverEUBaseURL is the
+// EU data-residency host, selected by a board entry's region: eu — boards provisioned
+// in the EU 404 on the default host.
+const (
+	leverBaseURL   = "https://api.lever.co/v0/postings"
+	leverEUBaseURL = "https://api.eu.lever.co/v0/postings"
+)
 
 // lever adapts the Lever postings API. The JSON-mode endpoint returns a bare array of
 // postings whose body is split across HTML description/lists/additional fields, which
@@ -22,7 +27,11 @@ func NewLever(c JSONGetter) Source { return lever{http: c} }
 func (lever) Provider() string { return "lever" }
 
 func (l lever) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	url := fmt.Sprintf("%s/%s?mode=json", leverBaseURL, e.Board)
+	base := leverBaseURL
+	if e.Region == "eu" {
+		base = leverEUBaseURL
+	}
+	url := fmt.Sprintf("%s/%s?mode=json", base, e.Board)
 
 	var postings []struct {
 		ID            string `json:"id"`

--- a/internal/sources/lever_test.go
+++ b/internal/sources/lever_test.go
@@ -145,3 +145,30 @@ func TestLeverFetchHandlesEmptyHeadingsAndFields(t *testing.T) {
 		t.Errorf("emitted an empty heading for a blank list title\ngot: %s", got)
 	}
 }
+
+func TestLeverFetchDefaultsToGlobalHost(t *testing.T) {
+	// No region set: the board lives on Lever's default (US) API host.
+	fake := &fakeHTTP{body: `[]`}
+	if _, err := NewLever(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Smile.io", Provider: "lever", Board: "Smile.io",
+	}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.HasPrefix(fake.gotURL, "https://api.lever.co/v0/postings/") {
+		t.Errorf("default board should hit api.lever.co, got %q", fake.gotURL)
+	}
+}
+
+func TestLeverFetchEURegionUsesEUHost(t *testing.T) {
+	// region: eu selects Lever's EU data-residency host (e.g. XM, Silverfin live there;
+	// their boards 404 on the default host).
+	fake := &fakeHTTP{body: `[]`}
+	if _, err := NewLever(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "XM", Provider: "lever", Board: "xm", Region: "eu",
+	}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.HasPrefix(fake.gotURL, "https://api.eu.lever.co/v0/postings/xm") {
+		t.Errorf("eu-region board should hit api.eu.lever.co, got %q", fake.gotURL)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -13,11 +13,13 @@ import (
 
 // CompanyEntry is one configured board from a board file (sources/<provider>.yml): the
 // company whose jobs we crawl, the platform it uses (Provider), and the platform-specific
-// board id.
+// board id. Region is an optional per-entry hint for ATS platforms that host tenants on
+// regional API domains (e.g. Lever's EU data-residency host); empty means the default host.
 type CompanyEntry struct {
 	Company  string `yaml:"company"`
 	Provider string `yaml:"provider"`
 	Board    string `yaml:"board"`
+	Region   string `yaml:"region"`
 }
 
 // Job is a raw posting as an adapter yields it, before the pipeline normalizes it

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -3503,3 +3503,9 @@
   board: vedatechlabs
 - company: Smile.io
   board: Smile.io
+- company: XM
+  board: xm
+  region: eu
+- company: Silverfin
+  board: silverfin
+  region: eu


### PR DESCRIPTION
Lever provisions some tenants on its **EU API host** (`api.eu.lever.co`); those boards 404 on the default `api.lever.co`, so our adapter couldn't reach them.

Adds an optional per-entry **`region`** to `CompanyEntry` — `region: eu` selects the EU host, empty keeps the default (chosen over auto-fallback: explicit, no wasted requests, no error-masking).

**Unblocks (live-verified):** XM (**112 jobs**), Silverfin (**11 jobs**) — both EU-hosted.

```yaml
- company: XM
  board: xm
  region: eu
```

TDD: host-selection tests written first (default→api.lever.co, eu→api.eu.lever.co); full suite + vet green.

Files: `source.go` (Region field), `lever.go` (leverEUBaseURL + select), `lever.yml` (XM, Silverfin).