### PR TITLE
feat(sources): add Lumenalta careers adapter

### DIFF
--- a/internal/sources/lumenalta.go
+++ b/internal/sources/lumenalta.go
@@ -1,0 +1,83 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// lumenalta adapts Lumenalta's public careers API (lumenalta.com/api/jobs), a single-company
+// source with no per-tenant board id (boardless). The list endpoint returns each posting —
+// including the full plain-text description — inline, so one paged call assembles every Job
+// with no per-job detail fetch. Lumenalta is a remote-only consultancy, so its postings carry
+// no location field; the catalogue is paged and meta.total bounds it.
+type lumenalta struct {
+	http JSONGetter
+}
+
+const (
+	lumenaltaListURL   = "https://lumenalta.com/api/jobs?page=%d&limit=%d"
+	lumenaltaJobURL    = "https://lumenalta.com/careers/"
+	lumenaltaPageLimit = 100
+)
+
+// NewLumenalta builds the Lumenalta adapter over the given HTTP client.
+func NewLumenalta(c JSONGetter) Source { return lumenalta{http: c} }
+
+func (lumenalta) Provider() string { return "lumenalta" }
+
+// lumenalta is single-company, so its config entries carry no board.
+func (lumenalta) boardless() {}
+
+// lumenaltaResponse is the list response. Meta.Total is the catalogue size, used to stop
+// paging; Data is empty past the last page.
+type lumenaltaResponse struct {
+	Data []lumenaltaJob `json:"data"`
+	Meta struct {
+		Total int `json:"total"`
+	} `json:"meta"`
+}
+
+// lumenaltaJob is one posting from the list response. Description is plain text and the
+// public page URL is built from slug.
+type lumenaltaJob struct {
+	ID          string `json:"_id"`
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func (l lumenalta) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; ; page++ {
+		var resp lumenaltaResponse
+		url := fmt.Sprintf(lumenaltaListURL, page, lumenaltaPageLimit)
+		if err := l.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("lumenalta: list page %d: %w", page, err)
+		}
+		if len(resp.Data) == 0 {
+			break
+		}
+		for _, j := range resp.Data {
+			jobs = append(jobs, l.toJob(e, j))
+		}
+		if len(jobs) >= resp.Meta.Total {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a list result to a Job. Lumenalta is remote-only and exposes no location, so the
+// location is set to "Remote" (which the pipeline's dictionary derives a remote work-mode from).
+func (lumenalta) toJob(e CompanyEntry, j lumenaltaJob) Job {
+	return Job{
+		ExternalID:  j.ID,
+		URL:         lumenaltaJobURL + j.Slug,
+		Title:       strings.TrimSpace(j.Name),
+		Company:     e.Company,
+		Location:    "Remote",
+		Description: strings.TrimSpace(j.Description),
+		Remote:      true,
+	}
+}

--- a/internal/sources/lumenalta_test.go
+++ b/internal/sources/lumenalta_test.go
@@ -1,0 +1,68 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestLumenaltaProvider(t *testing.T) {
+	if got := NewLumenalta(nil).Provider(); got != "lumenalta" {
+		t.Errorf("Provider() = %q, want %q", got, "lumenalta")
+	}
+}
+
+func TestLumenaltaIsBoardless(t *testing.T) {
+	if _, ok := NewLumenalta(nil).(boardless); !ok {
+		t.Error("Lumenalta is a single-company source and must be boardless")
+	}
+}
+
+func TestLumenaltaFetch(t *testing.T) {
+	// One page whose meta.total matches its data length, so the pager stops after it.
+	fake := &fakeHTTP{body: `{
+		"data": [
+			{
+				"_id": "68dee35f8c9481db144ea376",
+				"slug": "ai-engineer-ai-engineer-551",
+				"name": "Senior AI Engineer",
+				"description": "  At Lumenalta, we build technology that scales.  "
+			}
+		],
+		"meta": {"page": 1, "limit": 100, "total": 1}
+	}`}
+
+	jobs, err := NewLumenalta(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Lumenalta", Provider: "lumenalta",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fake.gotURL, "lumenalta.com/api/jobs") {
+		t.Errorf("requested URL %q should target the jobs API", fake.gotURL)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "68dee35f8c9481db144ea376" {
+		t.Errorf("ExternalID = %q, want the Mongo _id", j.ExternalID)
+	}
+	if j.URL != "https://lumenalta.com/careers/ai-engineer-ai-engineer-551" {
+		t.Errorf("URL = %q, want the careers page built from slug", j.URL)
+	}
+	if j.Title != "Senior AI Engineer" {
+		t.Errorf("Title = %q, want name", j.Title)
+	}
+	if j.Company != "Lumenalta" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Description != "At Lumenalta, we build technology that scales." {
+		t.Errorf("Description = %q, want trimmed plain text", j.Description)
+	}
+	// Lumenalta is a remote-only consultancy; the API carries no location field.
+	if j.Location != "Remote" || !j.Remote {
+		t.Errorf("Location/Remote = %q/%v, want Remote/true", j.Location, j.Remote)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -116,6 +116,7 @@ func All(c HTTPClient) map[string]Source {
 		NewUber(c),
 		NewAmazon(c),
 		NewGoogle(c),
+		NewLumenalta(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -9,6 +9,8 @@
   provider: amazon
 - company: Google
   provider: google
+- company: Lumenalta
+  provider: lumenalta
 
 - company: VK
   provider: vk


### PR DESCRIPTION
Lumenalta (remote-first IT consultancy) hires on its **own site**, not an ATS — so it had no ingestable board until now.

Its public list endpoint `lumenalta.com/api/jobs?page=N&limit=100` returns every posting with the **full plain-text description inline** (`{data:[…], meta:{total}}`), so a single paged call (bounded by `meta.total`) assembles the whole catalogue with no per-job detail fetch — the same shape as the existing Amazon adapter. Single-company ⇒ **boardless**.

**Live: 16 jobs.** URL built from slug (`/careers/<slug>`, verified 200); remote-only company ⇒ `Location: Remote`.

TDD: provider / boardless-marker / fetch-mapping tests written first (RED on the stub), then implemented to green. Full suite + `go vet` clean.

Files: `lumenalta.go` (+test), `source.go` (register in `All`), `custom.yml` (entry). New boardless single-company adapter = one file + one line in `All` + one config entry, per the source-adapter convention.