### PR TITLE
feat(sources): Oracle Recruiting Cloud adapter (+173 boards, ~102k jobs)

### DIFF
--- a/internal/sources/oracle.go
+++ b/internal/sources/oracle.go
@@ -1,0 +1,158 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// oraclePageLimit is the requisition-list page size. The API caps a page well above this;
+// a modest page keeps each request cheap and the pagination loop simple.
+const oraclePageLimit = 100
+
+// oracle adapts Oracle Recruiting Cloud (a.k.a. Oracle Fusion / ORC) career sites. The
+// board id is the public host and site number, e.g.
+// "fa-evmr-saasfaprod1.fa.ocs.oraclecloud.com/CX_1". Both endpoints are public GET JSON:
+// the requisition list (which must expand requisitionList or it comes back empty) carries
+// no description, so each requisition's detail is fetched to assemble it.
+type oracle struct {
+	http JSONGetter
+}
+
+// NewOracle builds the Oracle Recruiting Cloud adapter over the given HTTP client.
+func NewOracle(c JSONGetter) Source { return oracle{http: c} }
+
+func (oracle) Provider() string { return "oracle" }
+
+// oracleBoard is a configured board split into the host and site number the endpoints need.
+type oracleBoard struct {
+	host, site string
+}
+
+// parseOracleBoard splits "host/site" (e.g. "acme.fa.ocs.oraclecloud.com/CX_1").
+func parseOracleBoard(board string) (oracleBoard, error) {
+	host, site, ok := strings.Cut(board, "/")
+	if !ok || host == "" || site == "" {
+		return oracleBoard{}, fmt.Errorf("oracle: board %q must be \"host/site\"", board)
+	}
+	return oracleBoard{host: host, site: site}, nil
+}
+
+// oracleRequisition is one item from the requisition list (no description here).
+type oracleRequisition struct {
+	ID                string `json:"Id"`
+	Title             string `json:"Title"`
+	PostedDate        string `json:"PostedDate"`
+	PrimaryLocation   string `json:"PrimaryLocation"`
+	WorkplaceTypeCode string `json:"WorkplaceTypeCode"`
+}
+
+// oracleListResponse wraps the page. The requisitions and the total both nest under
+// items[0] (items itself is a single search-result envelope).
+type oracleListResponse struct {
+	Items []struct {
+		TotalJobsCount  int                 `json:"TotalJobsCount"`
+		RequisitionList []oracleRequisition `json:"requisitionList"`
+	} `json:"items"`
+}
+
+func (s oracle) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	b, err := parseOracleBoard(e.Board)
+	if err != nil {
+		return nil, err
+	}
+
+	reqs, err := s.listRequisitions(ctx, b)
+	if err != nil {
+		return nil, err
+	}
+
+	return fetchDetails(reqs, defaultDetailWorkers, func(r oracleRequisition) (Job, bool) {
+		return s.detail(ctx, e, b, r)
+	}), nil
+}
+
+// listRequisitions pages through the board's requisitions, stopping when a page is empty
+// or the collected count reaches TotalJobsCount. The expand keeps requisitionList populated
+// (without it the API returns an empty list under a non-zero total).
+func (s oracle) listRequisitions(ctx context.Context, b oracleBoard) ([]oracleRequisition, error) {
+	var reqs []oracleRequisition
+	for offset := 0; ; {
+		url := fmt.Sprintf(
+			"https://%s/hcmRestApi/resources/latest/recruitingCEJobRequisitions"+
+				"?onlyData=true&expand=requisitionList.secondaryLocations,requisitionList.workLocation"+
+				"&finder=findReqs;siteNumber=%s,limit=%d,sortBy=POSTING_DATES_DESC&offset=%d",
+			b.host, b.site, oraclePageLimit, offset)
+		var resp oracleListResponse
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("oracle: list site %s: %w", b.site, err)
+		}
+		if len(resp.Items) == 0 {
+			break
+		}
+		page := resp.Items[0]
+		if len(page.RequisitionList) == 0 {
+			break
+		}
+		reqs = append(reqs, page.RequisitionList...)
+		offset += len(page.RequisitionList)
+		if offset >= page.TotalJobsCount {
+			break
+		}
+	}
+	return reqs, nil
+}
+
+// detail fetches one requisition's detail and maps it to a Job, returning ok=false when
+// the detail request fails so the caller can skip just that requisition.
+func (s oracle) detail(ctx context.Context, e CompanyEntry, b oracleBoard, r oracleRequisition) (Job, bool) {
+	url := fmt.Sprintf(
+		"https://%s/hcmRestApi/resources/latest/recruitingCEJobRequisitionDetails"+
+			"?onlyData=true&expand=all&finder=ById;Id=%%22%s%%22,siteNumber=%s",
+		b.host, r.ID, b.site)
+
+	var resp struct {
+		Items []struct {
+			ExternalDescriptionStr      string `json:"ExternalDescriptionStr"`
+			ExternalResponsibilitiesStr string `json:"ExternalResponsibilitiesStr"`
+			ExternalQualificationsStr   string `json:"ExternalQualificationsStr"`
+		} `json:"items"`
+	}
+	if err := s.http.GetJSON(ctx, url, &resp); err != nil || len(resp.Items) == 0 {
+		return Job{}, false
+	}
+	d := resp.Items[0]
+	// The three external fields are block-level HTML fragments, so they concatenate
+	// directly (an empty field contributes nothing) before sanitizing.
+	description := sanitizeHTML(
+		d.ExternalDescriptionStr + d.ExternalResponsibilitiesStr + d.ExternalQualificationsStr)
+
+	workMode := oracleWorkMode(r.WorkplaceTypeCode)
+	return Job{
+		ExternalID: r.ID,
+		URL: fmt.Sprintf("https://%s/hcmUI/CandidateExperience/en/sites/%s/job/%s",
+			b.host, b.site, r.ID),
+		Title:       r.Title,
+		Company:     e.Company,
+		Location:    r.PrimaryLocation,
+		Description: description,
+		Remote:      workMode == "remote" || isRemote(r.PrimaryLocation),
+		WorkMode:    workMode,
+		PostedAt:    parseDate(r.PostedDate),
+	}, true
+}
+
+// oracleWorkMode maps an ORC workplace-type code to our work-mode vocabulary; an empty or
+// unrecognized code yields "".
+func oracleWorkMode(code string) string {
+	switch code {
+	case "ORA_REMOTE":
+		return "remote"
+	case "ORA_HYBRID":
+		return "hybrid"
+	case "ORA_ON_SITE":
+		return "onsite"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/oracle_test.go
+++ b/internal/sources/oracle_test.go
@@ -1,0 +1,126 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestOracleProvider(t *testing.T) {
+	if got := NewOracle(nil).Provider(); got != "oracle" {
+		t.Errorf("Provider() = %q, want %q", got, "oracle")
+	}
+}
+
+// TestOracleFetchListsAndFetchesDetail covers the core path: page the requisition list,
+// fetch each requisition's detail for the description, and map work-mode + posted date.
+// Fixtures mirror the live Oracle Recruiting Cloud shapes (requisitions nest under
+// items[0].requisitionList; the on-site code is ORA_ON_SITE; description is split across
+// three external fields).
+func TestOracleFetchListsAndFetchesDetail(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("findReqs", `{"hasMore": false, "items": [{
+			"TotalJobsCount": 2,
+			"requisitionList": [
+				{"Id": "30607", "Title": "Backend Engineer", "PostedDate": "2026-06-16",
+				 "PrimaryLocation": "Berlin, Germany", "PrimaryLocationCountry": "DE",
+				 "WorkplaceTypeCode": "ORA_ON_SITE"},
+				{"Id": "30610", "Title": "Data Engineer", "PostedDate": "2026-06-12",
+				 "PrimaryLocation": "United States", "PrimaryLocationCountry": "US",
+				 "WorkplaceTypeCode": "ORA_REMOTE"}
+			]
+		}]}`).
+		route("30607", `{"items": [{
+			"Id": "30607",
+			"ExternalDescriptionStr": "<p>Build the backend.</p>",
+			"ExternalResponsibilitiesStr": "<ul><li>Own services</li></ul>",
+			"ExternalQualificationsStr": "<p>Go experience.</p>"
+		}]}`).
+		route("30610", `{"items": [{
+			"Id": "30610",
+			"ExternalDescriptionStr": "<p>Crunch data.</p>"
+		}]}`)
+
+	jobs, err := NewOracle(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "oracle",
+		Board: "fa-test.fa.ocs.oraclecloud.com/CX_1",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j, ok := byID["30607"]
+	if !ok {
+		t.Fatal("requisition 30607 missing")
+	}
+	if j.Title != "Backend Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Acme" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Location != "Berlin, Germany" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	wantURL := "https://fa-test.fa.ocs.oraclecloud.com/hcmUI/CandidateExperience/en/sites/CX_1/job/30607"
+	if j.URL != wantURL {
+		t.Errorf("URL = %q, want %q", j.URL, wantURL)
+	}
+	if j.WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want onsite for ORA_ON_SITE", j.WorkMode)
+	}
+	if j.Remote {
+		t.Error("Remote = true, want false for an on-site role")
+	}
+	for _, want := range []string{"Build the backend.", "Own services", "Go experience."} {
+		if !strings.Contains(j.Description, want) {
+			t.Errorf("Description missing %q: %q", want, j.Description)
+		}
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-06-16" {
+		t.Errorf("PostedAt = %v, want 2026-06-16", j.PostedAt)
+	}
+
+	data := byID["30610"]
+	if data.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote for ORA_REMOTE", data.WorkMode)
+	}
+	if !data.Remote {
+		t.Error("Remote = false, want true for a remote role")
+	}
+}
+
+// TestOraclePaginatesByTotal verifies the lister keeps requesting pages until it has
+// gathered TotalJobsCount requisitions, not just the first page.
+func TestOraclePaginatesByTotal(t *testing.T) {
+	page := func(ids ...string) string {
+		var items []string
+		for _, id := range ids {
+			items = append(items, `{"Id": "`+id+`", "Title": "Role `+id+`", "PrimaryLocation": "Remote", "WorkplaceTypeCode": "ORA_REMOTE"}`)
+		}
+		return `{"TotalJobsCount": 3, "requisitionList": [` + strings.Join(items, ",") + `]}`
+	}
+	fake := &routedHTTP{}
+	// Two list pages then detail stubs. offset=0 returns two, offset=2 returns one.
+	fake.route("offset=0", `{"items": [`+page("1", "2")+`]}`).
+		route("offset=2", `{"items": [`+page("3")+`]}`).
+		route("ById", `{"items": [{"ExternalDescriptionStr": "<p>desc</p>"}]}`)
+
+	jobs, err := NewOracle(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "oracle", Board: "fa-test.fa.ocs.oraclecloud.com/CX_1",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 across two pages", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -109,6 +109,7 @@ func All(c HTTPClient) map[string]Source {
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),
+		NewOracle(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
 		NewJobStash(c),

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1,0 +1,352 @@
+# oracle (Oracle Recruiting Cloud / Fusion) boards. Provider is the filename;
+# board = "<host>/<siteNumber>" (see internal/sources/oracle.go), e.g.
+# fa-evmr-saasfaprod1.fa.ocs.oraclecloud.com/CX_1. Company names come from the
+# SimplifyJobs discovery repos (the ORC host is an opaque tenant code); each board
+# validated live (recruitingCEJobRequisitions returned >0 jobs) before adding.
+
+- company: ACI Worldwide
+  board: ebwg.fa.us2.oraclecloud.com/CX
+- company: ADI Global Distribution
+  board: ehtl.fa.us6.oraclecloud.com/CX_2
+- company: ADT
+  board: fa-erqb-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Adventist Health
+  board: ecvz.fa.us2.oraclecloud.com/CX_1
+- company: Akamai Technologies
+  board: fa-extu-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Albertsons
+  board: eofd.fa.us6.oraclecloud.com/CX_1001
+- company: American Bureau of Shipping
+  board: hbbq.fa.us2.oraclecloud.com/CX_1
+- company: American Express
+  board: egug.fa.us2.oraclecloud.com/CX_1
+- company: American Tower
+  board: hdsn.fa.us6.oraclecloud.com/CX_1
+- company: APL Logistics
+  board: hcut.fa.ap2.oraclecloud.com/CX_1
+- company: Arcadis
+  board: ebcs.fa.em2.oraclecloud.com/CX_1
+- company: Arconic
+  board: hdnn.fa.us6.oraclecloud.com/CX
+- company: Arlington County VA
+  board: fa-exkk-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Arqiva
+  board: ehik.fa.em3.oraclecloud.com/CX
+- company: Ascot
+  board: fa-emkq-saasfaprod1.fa.ocs.oraclecloud.com/CX
+- company: ATCO
+  board: eezy.fa.ca2.oraclecloud.com/CX
+- company: Atlantic Health System
+  board: erqh.fa.us2.oraclecloud.com/CX_1001
+- company: BC Pensions
+  board: fa-exby-saasfaprod1.fa.ocs.oraclecloud.com/CX_1013
+- company: BGIS
+  board: fa-evcg-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Black Box
+  board: eoje.fa.us2.oraclecloud.com/CX_1001
+- company: Blue Cross Blue Shield of Michigan
+  board: ejko.fa.us2.oraclecloud.com/CX_3
+- company: Blue Shield of California
+  board: ecge.fa.us2.oraclecloud.com/CX_1003
+- company: BNY
+  board: eofe.fa.us2.oraclecloud.com/CX_1001
+- company: Boston Properties
+  board: edxn.fa.us2.oraclecloud.com/CX_5001
+- company: Brent Council
+  board: fa-epzg-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Caesars Entertainment
+  board: edmn.fa.us2.oraclecloud.com/CX_1
+- company: Carmeuse
+  board: ekiz.fa.em2.oraclecloud.com/CX
+- company: Cetera Financial Group
+  board: ebhu.fa.us2.oraclecloud.com/CX
+- company: Chubb
+  board: fa-ewgu-saasfaprod1.fa.ocs.oraclecloud.com/CX_2001
+- company: Citco
+  board: fa-euxc-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Citizens Financial Group
+  board: hcgn.fa.us2.oraclecloud.com/CX_1
+- company: City Of Chattanooga
+  board: fa-eqto-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: City of Greeley
+  board: elvp.fa.us2.oraclecloud.com/CX_1001
+- company: City of Oklahoma City
+  board: fa-etyr-saasfaprod1.fa.ocs.oraclecloud.com/CX_2
+- company: Coherent
+  board: hcwp.fa.us2.oraclecloud.com/CX_1
+- company: Cohu
+  board: hcbo.fa.us2.oraclecloud.com/CX_1
+- company: Community Health Systems
+  board: fa-evxo-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Computershare
+  board: fa-evdq-saasfaprod1.fa.ocs.oraclecloud.com/CX_2001
+- company: Conduent
+  board: egua.fa.us2.oraclecloud.com/CX_1
+- company: Consolidated Edison
+  board: ejcu.fa.us6.oraclecloud.com/CX_1033
+- company: Cooper Companies
+  board: hcjy.fa.us2.oraclecloud.com/CX_1
+- company: Corsair
+  board: edix.fa.us2.oraclecloud.com/CX_1
+- company: CSC
+  board: hczw.fa.us2.oraclecloud.com/CX_1001
+- company: CSX
+  board: fa-eowa-saasfaprod1.fa.ocs.oraclecloud.com/CSXCareers
+- company: CTB
+  board: emsl.fa.us2.oraclecloud.com/CX_1001
+- company: Cummins
+  board: fa-espx-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: DC Water
+  board: elxb.fa.us2.oraclecloud.com/CX
+- company: Definity Financial
+  board: hdks.fa.ca2.oraclecloud.com/CX_1
+- company: Denso
+  board: hcwt.fa.us2.oraclecloud.com/CX
+- company: Diebold Nixdorf
+  board: eeug.fa.us6.oraclecloud.com/CX
+- company: Digital Realty
+  board: hdep.fa.us2.oraclecloud.com/CX
+- company: DNV
+  board: ecyq.fa.em2.oraclecloud.com/CX_1
+- company: DP World
+  board: ehpv.fa.em2.oraclecloud.com/CX_1
+- company: DTCC
+  board: ebxr.fa.us2.oraclecloud.com/CX_1
+- company: Duracell
+  board: fa-ewub-saasfaprod1.fa.ocs.oraclecloud.com/CX_26
+- company: Emergent Holdings
+  board: ejko.fa.us2.oraclecloud.com/CX_2
+- company: Emerson Electric
+  board: hdjq.fa.us2.oraclecloud.com/CX_1
+- company: EXL
+  board: fa-ewjt-saasfaprod1.fa.ocs.oraclecloud.com/CX_2
+- company: EXP
+  board: elcn.fa.us2.oraclecloud.com/CX
+- company: Fanatics
+  board: fa-exki-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Fife Council
+  board: ekmu.fa.em3.oraclecloud.com/CX_6009
+- company: First West Credit Union
+  board: fa-eomj-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: Ford Motor Company
+  board: efds.fa.em5.oraclecloud.com/CX_1
+- company: Fortinet
+  board: edel.fa.us2.oraclecloud.com/CX_2001
+- company: Fortive
+  board: ejta.fa.us6.oraclecloud.com/CX_2001
+- company: Fujitsu
+  board: edzt.fa.em4.oraclecloud.com/CX
+- company: Garrett Motion
+  board: ehth.fa.em2.oraclecloud.com/CX_2001
+- company: GCI
+  board: edqv.fa.us2.oraclecloud.com/CX
+- company: GHD
+  board: ejov.fa.ca2.oraclecloud.com/CX
+- company: GM financial
+  board: fa-exvu-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Goldman Sachs
+  board: hdpc.fa.us2.oraclecloud.com/LateralHiring
+- company: Grant Thornton
+  board: ehzq.fa.us2.oraclecloud.com/CX_1
+- company: Greenwood Village South
+  board: eexs.fa.us2.oraclecloud.com/GreenwoodVillageSouth
+- company: GuideWell Mutual
+  board: fa-etum-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Hearst
+  board: eevd.fa.us6.oraclecloud.com/CX_1
+- company: Hertz
+  board: fa-evlf-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: HEXAWARE
+  board: fa-etqo-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Hillsborough County
+  board: fa-eqsg-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Hologic
+  board: ebwb.fa.us2.oraclecloud.com/CX
+- company: Honeywell
+  board: ibqbjb.fa.ocs.oraclecloud.com/Honeywell
+- company: Hormel Foods
+  board: ekkh.fa.us2.oraclecloud.com/CX_2002
+- company: Howmet Aerospace
+  board: fa-exty-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Hub Group
+  board: hdat.fa.us2.oraclecloud.com/CX
+- company: Hunt Oil Company
+  board: fa-eqcd-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: IHG
+  board: fa-evax-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: INTEGRIS Health
+  board: ertr.fa.us2.oraclecloud.com/CX_3001
+- company: Intertek
+  board: hcog.fa.em2.oraclecloud.com/CX_1
+- company: Jefferies
+  board: hdid.fa.us2.oraclecloud.com/CX_1
+- company: JP Morgan Chase
+  board: jpmc.fa.oraclecloud.com/CX_1001
+- company: Kent
+  board: fa-emqh-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: KL Discovery
+  board: ekug.fa.us6.oraclecloud.com/CX_1001
+- company: Kroll
+  board: hcxs.fa.us2.oraclecloud.com/CX_1
+- company: Lifepoint Health
+  board: ibnjjb.fa.ocs.oraclecloud.com/CX_1
+- company: Linamar
+  board: fa-epmd-saasfaprod1.fa.ocs.oraclecloud.com/CX_3001
+- company: "Macy's"
+  board: ebwh.fa.us2.oraclecloud.com/CX_1001
+- company: "Manhattan District Attorney's Office"
+  board: fa-elzs-saasfaprod1.fa.ocs.oraclecloud.com/CX
+- company: Marriott International
+  board: ejwl.fa.us2.oraclecloud.com/CX
+- company: Masimo
+  board: egcu.fa.us6.oraclecloud.com/CX
+- company: Metrolinx
+  board: ehtc.fa.ca2.oraclecloud.com/CX_1
+- company: Michael Baker International
+  board: ebxs.fa.us2.oraclecloud.com/CX_2
+- company: Midmark
+  board: hcor.fa.us2.oraclecloud.com/CX_1
+- company: Molina Healthcare
+  board: hckd.fa.us2.oraclecloud.com/CX_1
+- company: Montenson
+  board: fa-esgu-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Mycronic
+  board: ehtv.fa.em2.oraclecloud.com/CX_1
+- company: Myriad Genetics
+  board: ekgn.fa.us6.oraclecloud.com/CX_2001
+- company: Nevada National Security
+  board: ewij.fa.us8.oraclecloud.com/CX_2
+- company: Newham
+  board: elyq.fa.em3.oraclecloud.com/CX
+- company: Newmark Group
+  board: hdow.fa.us6.oraclecloud.com/CX_1001
+- company: Nokia
+  board: fa-evmr-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Northumbria University
+  board: fa-etnb-saasfaprod1.fa.ocs.oraclecloud.com/CX_1001
+- company: Northwell Health
+  board: eppr.fa.us2.oraclecloud.com/CX_2
+- company: NOV
+  board: egay.fa.us6.oraclecloud.com/CX_4001
+- company: onsemi
+  board: hctz.fa.us2.oraclecloud.com/CX_1001
+- company: Oracle
+  board: eeho.fa.us2.oraclecloud.com/CX_45001
+- company: Pearson
+  board: hccz.fa.em3.oraclecloud.com/CX_2
+- company: Perficient
+  board: fa-etqd-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Phoenix Group
+  board: fa-enor-saasfaprod1.fa.ocs.oraclecloud.com/CX
+- company: Photon
+  board: fa-ertb-saasfaprod1.fa.ocs.oraclecloud.com/CX_2
+- company: Polk County
+  board: fa-eqpz-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Powell
+  board: ekcf.fa.us6.oraclecloud.com/CX_1
+- company: R+L Global Logistics
+  board: erhk.fa.us2.oraclecloud.com/CX_4
+- company: Rheem
+  board: hdde.fa.us2.oraclecloud.com/CX
+- company: Rice University
+  board: emdz.fa.us2.oraclecloud.com/CX_2001
+- company: "S&C Electric Company"
+  board: ejia.fa.us6.oraclecloud.com/CX_1001
+- company: "Sainsbury's"
+  board: hdhe.fa.em3.oraclecloud.com/CX
+- company: Samsonite
+  board: ekkf.fa.em2.oraclecloud.com/CX
+- company: Savannah River National Laboratory
+  board: ewvl.fa.us8.oraclecloud.com/CX_1
+- company: Schroders
+  board: ekbq.fa.em2.oraclecloud.com/CX_2
+- company: SCOR
+  board: fa-errt-saasfaprod1.fa.ocs.oraclecloud.com/CX_2001
+- company: Seaspan
+  board: hckz.fa.us2.oraclecloud.com/CX_1
+- company: Securitas
+  board: ekaw.fa.us2.oraclecloud.com/CX
+- company: SHEIN
+  board: fa-exjq-saasfaprod1.fa.ocs.oraclecloud.com/SHEIN
+- company: Sherwin-Williams
+  board: ejhp.fa.us6.oraclecloud.com/CX_2
+- company: Sinclair
+  board: edyy.fa.us2.oraclecloud.com/CX_2002
+- company: Southern Company
+  board: emje.fa.us6.oraclecloud.com/CX_1001
+- company: Standard Aero
+  board: cva.fa.us1.oraclecloud.com/CX_3
+- company: Stantec
+  board: hdhl.fa.us6.oraclecloud.com/CX_1
+- company: Strathcona County
+  board: fa-erjf-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Subaru
+  board: hcal.fa.us2.oraclecloud.com/CX_1001
+- company: Suffolk County
+  board: eoce.fa.em3.oraclecloud.com/CX_1004
+- company: Sundt
+  board: eewl.fa.us6.oraclecloud.com/CX
+- company: Synlab
+  board: fa-eugp-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Texas Instruments
+  board: ebgj.fa.us2.oraclecloud.com/CX_1
+- company: The State Bar of California
+  board: egsd.fa.us2.oraclecloud.com/CX
+- company: The University of Edinburgh
+  board: elxw.fa.em3.oraclecloud.com/CX_1001
+- company: "Tiffany & Co."
+  board: eljs.fa.us2.oraclecloud.com/CX
+- company: TPI Composites
+  board: fa-elwc-saasfaprod1.fa.ocs.oraclecloud.com/CX
+- company: Tradeweb
+  board: ecnf.fa.us2.oraclecloud.com/CX
+- company: Tri-State Generation and Transmission Association
+  board: fa-exbd-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: TriNet
+  board: fa-etgw-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: UC Health
+  board: eswt.fa.us6.oraclecloud.com/CX_1001
+- company: UL Solutions
+  board: fa-eups-saasfaprod1.fa.ocs.oraclecloud.com/ULSolutionsCareers
+- company: University of Maine System
+  board: fa-ewca-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: University of Wyoming
+  board: eeik.fa.us2.oraclecloud.com/CX_1
+- company: UTHealth Houston
+  board: fa-eomf-saasfaprod1.fa.ocs.oraclecloud.com/CX_1002
+- company: UW Health
+  board: eimy.fa.us6.oraclecloud.com/CX_1
+- company: Vanderbilt University
+  board: ecsr.fa.us2.oraclecloud.com/CX_1
+- company: Verisk
+  board: fa-ewmy-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Vertiv
+  board: egup.fa.us2.oraclecloud.com/CX
+- company: Virginia Department of Transportation
+  board: etgi.fa.us8.oraclecloud.com/CX_4005
+- company: VITAS Healthcare
+  board: ejrz.fa.us2.oraclecloud.com/CX_5001
+- company: Wagner College
+  board: fa-exad-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Wayne County
+  board: emqz.fa.us2.oraclecloud.com/CX_1
+- company: Weatherford
+  board: fa-exmi-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Wells Enterprises
+  board: hcsb.fa.us2.oraclecloud.com/CX_1
+- company: Williams-Sonoma
+  board: ehac.fa.us6.oraclecloud.com/CX_1
+- company: Wood
+  board: ehif.fa.em2.oraclecloud.com/CX_1
+- company: Worthington Enterprises
+  board: fa-eygo-saasfaprod1.fa.ocs.oraclecloud.com/CX_2001
+- company: WSP
+  board: emit.fa.ca3.oraclecloud.com/CX_2001
+- company: WTW
+  board: eedu.fa.em3.oraclecloud.com/CX_1003
+- company: "Yum! Brands"
+  board: eczd.fa.us2.oraclecloud.com/CX_1
+- company: Zachry Group
+  board: fa-evfm-saasfaprod1.fa.ocs.oraclecloud.com/CX_1029
+- company: Zensar
+  board: fa-etvl-saasfaprod1.fa.ocs.oraclecloud.com/CX_1

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -105,7 +105,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'jobstash', 'join', 'lever', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'workable', 'workday'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jobstash', 'join', 'lever', 'oracle', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'workable', 'workday'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## What

New source adapter for **Oracle Recruiting Cloud** (Oracle Fusion / ORC) — the largest ATS that was missing from the catalogue. Surfaced as the top uncovered host family while mining the SimplifyJobs discovery repos (see #148).

`+173 live-validated boards · ~102,300 open jobs.`

## How

Both ORC endpoints are public GET JSON — **no auth, no headless, no bot defense**. Adapter mirrors the Workday shape (opaque per-tenant host + site, list + per-posting detail).

- **board** = `<host>/<siteNumber>` (e.g. `fa-evmr-saasfaprod1.fa.ocs.oraclecloud.com/CX_1`)
- **list** `recruitingCEJobRequisitions`, paged by `items[0].TotalJobsCount`
- **detail** `recruitingCEJobRequisitionDetails` merges the three external HTML fields (description / responsibilities / qualifications), sanitized
- **work_mode** from `WorkplaceTypeCode`

## Live-confirmed gotchas (in fixtures)
- `expand=requisitionList.*` is **required** — without it the list returns empty under a non-zero total (silent "0 jobs").
- on-site code is `ORA_ON_SITE` (underscore), not `ORA_ONSITE`.
- canonical URL is `.../job/<id>` (the `.../jobs/job/<id>` form 302-redirects).

## Company names
`sources/oracle.yml` boards are seeded with **real company names from the discovery repos**, not the harvest-prober host fallback: the ORC host is an opaque tenant code (`fa-evmr-saasfaprod1`), so a host-fallback name would pollute the company facet. Each board was live-validated (>0 jobs) before adding. A reusable `harvest-boards` prober is left as a seam for future bulk ORC discovery (needs an external name source).

## Tests
- TDD: `oracle_test.go` (provider, list+detail+mapping, pagination) written first, RED→GREEN.
- Live-smoke fetched **900 jobs** from a real board (correct work_mode/URL/description/dates).
- `go build ./...`, `go vet`, `go test ./internal/sources/` all pass.

## Contract
`contracts.ts` regenerated → adds `oracle` to `SOURCE_VALUES` (also pulls in `icims`, which had drifted out of the generated file).

## Deploy note
New adapter ⇒ needs a full image rebuild (not a sources-only rsync) + a cron entry for `ingest sources/oracle.yml`.