### PR TITLE
feat(sources): add Ashby embed-GraphQL adapter

### DIFF
--- a/internal/sources/ashbygraphql.go
+++ b/internal/sources/ashbygraphql.go
@@ -1,0 +1,107 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+)
+
+// ashbyGraphQL adapts Ashby boards whose public Posting API (see ashby.go) is disabled, so
+// the only machine-readable source is the same embed GraphQL endpoint Ashby's own hosted
+// careers widget calls. It is a separate provider from ashby on purpose: the 2400+ boards on
+// the stable Posting API stay untouched, and only the handful that 404 there (e.g. Chainlink
+// Labs, Toggl) opt into this path. The list query returns brief postings without a
+// description, so each posting takes a detail query — the same list+detail shape as
+// SmartRecruiters.
+type ashbyGraphQL struct {
+	http JSONPoster
+}
+
+const (
+	ashbyGQLURL      = "https://jobs.ashbyhq.com/api/non-user-graphql"
+	ashbyGQLJobURL   = "https://jobs.ashbyhq.com/" // + <board>/<id>
+	ashbyGQLListOp   = "ApiJobBoardWithTeams"
+	ashbyGQLDetailOp = "ApiJobPosting"
+
+	ashbyGQLListQuery = `query ApiJobBoardWithTeams($organizationHostedJobsPageName: String!) { ` +
+		`jobBoard: jobBoardWithTeams(organizationHostedJobsPageName: $organizationHostedJobsPageName) ` +
+		`{ jobPostings { id title locationName employmentType } } }`
+
+	ashbyGQLDetailQuery = `query ApiJobPosting($organizationHostedJobsPageName: String!, $jobPostingId: String!) { ` +
+		`jobPosting(organizationHostedJobsPageName: $organizationHostedJobsPageName, jobPostingId: $jobPostingId) ` +
+		`{ id title descriptionHtml locationName } }`
+)
+
+// NewAshbyGraphQL builds the Ashby embed-GraphQL adapter over the given HTTP client.
+func NewAshbyGraphQL(c JSONPoster) Source { return ashbyGraphQL{http: c} }
+
+func (ashbyGraphQL) Provider() string { return "ashbygraphql" }
+
+// ashbyGQLRequest is the GraphQL POST body the embed endpoint expects.
+type ashbyGQLRequest struct {
+	OperationName string         `json:"operationName"`
+	Variables     map[string]any `json:"variables"`
+	Query         string         `json:"query"`
+}
+
+// ashbyGQLBrief is one posting from the list query (no description).
+type ashbyGQLBrief struct {
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	LocationName string `json:"locationName"`
+}
+
+func (a ashbyGraphQL) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	body := ashbyGQLRequest{
+		OperationName: ashbyGQLListOp,
+		Variables:     map[string]any{"organizationHostedJobsPageName": e.Board},
+		Query:         ashbyGQLListQuery,
+	}
+	var resp struct {
+		Data struct {
+			JobBoard struct {
+				JobPostings []ashbyGQLBrief `json:"jobPostings"`
+			} `json:"jobBoard"`
+		} `json:"data"`
+	}
+	if err := a.http.PostJSON(ctx, ashbyGQLURL+"?op="+ashbyGQLListOp, body, &resp); err != nil {
+		return nil, fmt.Errorf("ashbygraphql: list board %s: %w", e.Board, err)
+	}
+
+	postings := resp.Data.JobBoard.JobPostings
+	return fetchDetails(postings, defaultDetailWorkers, func(p ashbyGQLBrief) (Job, bool) {
+		return a.detail(ctx, e, p)
+	}), nil
+}
+
+// detail fetches one posting's descriptionHtml and maps it to a Job, returning ok=false when
+// the detail request fails so the caller skips just that posting.
+func (a ashbyGraphQL) detail(ctx context.Context, e CompanyEntry, p ashbyGQLBrief) (Job, bool) {
+	body := ashbyGQLRequest{
+		OperationName: ashbyGQLDetailOp,
+		Variables: map[string]any{
+			"organizationHostedJobsPageName": e.Board,
+			"jobPostingId":                   p.ID,
+		},
+		Query: ashbyGQLDetailQuery,
+	}
+	var resp struct {
+		Data struct {
+			JobPosting struct {
+				DescriptionHTML string `json:"descriptionHtml"`
+			} `json:"jobPosting"`
+		} `json:"data"`
+	}
+	if err := a.http.PostJSON(ctx, ashbyGQLURL+"?op="+ashbyGQLDetailOp, body, &resp); err != nil {
+		return Job{}, false
+	}
+
+	return Job{
+		ExternalID:  p.ID,
+		URL:         ashbyGQLJobURL + e.Board + "/" + p.ID,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    p.LocationName,
+		Description: sanitizeHTML(resp.Data.JobPosting.DescriptionHTML),
+		Remote:      isRemote(p.LocationName),
+	}, true
+}

--- a/internal/sources/ashbygraphql_test.go
+++ b/internal/sources/ashbygraphql_test.go
@@ -1,0 +1,82 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestAshbyGraphQLProvider(t *testing.T) {
+	if got := NewAshbyGraphQL(nil).Provider(); got != "ashbygraphql" {
+		t.Errorf("Provider() = %q, want %q", got, "ashbygraphql")
+	}
+}
+
+func TestAshbyGraphQLFetch(t *testing.T) {
+	// The embed GraphQL endpoint lists brief postings (no description), then a per-posting
+	// detail query carries descriptionHtml. Routes are keyed by the ?op= operation.
+	fake := (&routedHTTP{}).
+		route("op=ApiJobBoardWithTeams", `{"data":{"jobBoard":{"jobPostings":[
+			{"id":"961b9946","title":"Blockchain Security Analyst","locationName":"Remote - US","employmentType":"FullTime"}
+		]}}}`).
+		route("op=ApiJobPosting", `{"data":{"jobPosting":{
+			"id":"961b9946","title":"Blockchain Security Analyst","locationName":"Remote - US",
+			"descriptionHtml":"<p>About Chainlink</p>  "
+		}}}`)
+
+	jobs, err := NewAshbyGraphQL(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Chainlink Labs", Provider: "ashbygraphql", Board: "chainlink-labs",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fake.routes[0].match, "ApiJobBoardWithTeams") {
+		t.Fatal("test wiring: list route missing")
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "961b9946" {
+		t.Errorf("ExternalID = %q, want the posting id", j.ExternalID)
+	}
+	if j.URL != "https://jobs.ashbyhq.com/chainlink-labs/961b9946" {
+		t.Errorf("URL = %q, want jobs.ashbyhq.com/<board>/<id>", j.URL)
+	}
+	if j.Title != "Blockchain Security Analyst" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Chainlink Labs" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Location != "Remote - US" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if !strings.Contains(j.Description, "About Chainlink") {
+		t.Errorf("Description = %q, want detail descriptionHtml", j.Description)
+	}
+	if !j.Remote {
+		t.Error("Remote = false, want true from a remote location")
+	}
+}
+
+func TestAshbyGraphQLFetchSkipsFailedDetail(t *testing.T) {
+	// Two briefs but only one has a working detail route; the other's detail errors and
+	// that posting is dropped, never aborting the board.
+	fake := (&routedHTTP{}).
+		route("op=ApiJobBoardWithTeams", `{"data":{"jobBoard":{"jobPostings":[
+			{"id":"ok-1","title":"Engineer","locationName":"Remote"},
+			{"id":"missing-2","title":"Designer","locationName":"Remote"}
+		]}}}`)
+	// No op=ApiJobPosting route → every detail call errors → both dropped.
+	jobs, err := NewAshbyGraphQL(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Chainlink Labs", Provider: "ashbygraphql", Board: "chainlink-labs",
+	})
+	if err != nil {
+		t.Fatalf("Fetch should not abort on a failed detail: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("len(jobs) = %d, want 0 (all details failed, skipped not fatal)", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -110,6 +110,8 @@ func All(c HTTPClient) map[string]Source {
 		NewJoin(c),
 		NewGlobalPayments(c),
 		NewOracle(c),
+		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
+		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
 		NewJobStash(c),

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -2,6 +2,14 @@
 # provider (the file name "custom" is not a provider). Multi-tenant board lists
 # (greenhouse.yml, gem.yml, …) keep their own per-provider files.
 
+# Ashby boards whose public Posting API is disabled (served via the embed GraphQL adapter).
+- company: Chainlink Labs
+  provider: ashbygraphql
+  board: chainlink-labs
+- company: Toggl
+  provider: ashbygraphql
+  board: toggl
+
 # International single-company sources.
 - company: Uber
   provider: uber


### PR DESCRIPTION
Some Ashby boards don't enable the **public Posting API** (`ashby.go`), so its REST endpoint 404s for them even though the board is live — e.g. **Chainlink Labs (29 jobs)**, **Toggl**.

Adds a **separate provider** (`ashbygraphql`) that reads the same **embed GraphQL** endpoint Ashby's own hosted careers widget calls (`POST jobs.ashbyhq.com/api/non-user-graphql`). Deliberately separate from `ashby`: the **2400+ Posting-API boards stay byte-for-byte untouched** — zero regression surface — and only the handful that 404 there opt in via `provider: ashbygraphql`.

The list query (`ApiJobBoardWithTeams`) returns brief postings without a description, so each posting takes a detail query (`ApiJobPosting`) — the same list+detail shape as SmartRecruiters (`fetchDetails`, a failed detail skipped not fatal). Board = the org hosted-page name (`chainlink-labs`, `toggl`).

**TDD:** provider / fetch-mapping / skip-failed-detail tests first (RED on stub → green). **Live smoke:** chainlink-labs 29 jobs + toggl 1, all with descriptions, correct `jobs.ashbyhq.com/<board>/<id>` URLs. Full suite + vet clean.

Files: `ashbygraphql.go` (+test), `source.go` (register), `custom.yml` (2 entries).