### PR TITLE
feat(sources): Phenom People adapter (DHL)

### DIFF
--- a/internal/sources/phenom.go
+++ b/internal/sources/phenom.go
@@ -1,0 +1,139 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// phenom adapts Phenom People career sites (e.g. careers.dhl.com). The board is the
+// site host; both the listing and the per-job detail are POSTs to
+// "https://<board>/widgets" distinguished by a "ddoKey" — refineSearch for the paged
+// job list, jobDetail for one posting's full HTML description. The list carries only a
+// teaser, so each posting needs a detail fetch (bounded-concurrency), like the other
+// detail adapters.
+
+// phenomPageSize is the refineSearch page size; the list pages by "from" and stops on a
+// short/empty page (the API's totalHits is not relied upon).
+const phenomPageSize = 100
+
+// phenomDateLayout is Phenom's postedDate format: RFC3339 with milliseconds and a
+// numeric, colon-less zone offset ("2026-05-17T22:00:00.000+0000").
+const phenomDateLayout = "2006-01-02T15:04:05.000-0700"
+
+type phenom struct {
+	http JSONPoster
+}
+
+// NewPhenom builds the Phenom adapter over the given HTTP client.
+func NewPhenom(c JSONPoster) Source { return phenom{http: c} }
+
+func (phenom) Provider() string { return "phenom" }
+
+// phenomPosting is one job from the refineSearch list (no full description here).
+type phenomPosting struct {
+	JobSeqNo   string `json:"jobSeqNo"`
+	Title      string `json:"title"`
+	CityState  string `json:"cityState"`
+	Locale     string `json:"locale"`
+	PostedDate string `json:"postedDate"`
+}
+
+func (s phenom) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	postings, err := s.list(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+	// Each posting's full description comes from its own jobDetail request, fanned out
+	// under a bounded worker pool.
+	return fetchDetails(postings, defaultDetailWorkers, func(p phenomPosting) (Job, bool) {
+		return s.detail(ctx, e, p)
+	}), nil
+}
+
+// list pages the refineSearch widget. lang/country are deliberately omitted from the
+// body: they do not change the result set (verified), so the board host is the only
+// per-tenant input.
+func (s phenom) list(ctx context.Context, board string) ([]phenomPosting, error) {
+	url := fmt.Sprintf("https://%s/widgets", board)
+	var postings []phenomPosting
+	for from := 0; ; from += phenomPageSize {
+		body := map[string]any{
+			"deviceType": "desktop",
+			"ddoKey":     "refineSearch",
+			"jobs":       true,
+			"from":       from,
+			"size":       phenomPageSize,
+		}
+		var resp struct {
+			RefineSearch struct {
+				Data struct {
+					Jobs []phenomPosting `json:"jobs"`
+				} `json:"data"`
+			} `json:"refineSearch"`
+		}
+		if err := s.http.PostJSON(ctx, url, body, &resp); err != nil {
+			return nil, fmt.Errorf("phenom: list board %s: %w", board, err)
+		}
+		page := resp.RefineSearch.Data.Jobs
+		if len(page) == 0 {
+			break
+		}
+		postings = append(postings, page...)
+		if len(page) < phenomPageSize {
+			break
+		}
+	}
+	return postings, nil
+}
+
+// detail fetches one posting's jobDetail and maps it to a Job, returning ok=false when
+// the request fails or carries no description so the caller skips just that posting.
+func (s phenom) detail(ctx context.Context, e CompanyEntry, p phenomPosting) (Job, bool) {
+	url := fmt.Sprintf("https://%s/widgets", e.Board)
+	body := map[string]any{
+		"deviceType": "desktop",
+		"ddoKey":     "jobDetail",
+		"pageName":   "job-details",
+		"jobSeqNo":   p.JobSeqNo,
+	}
+	var resp struct {
+		JobDetail struct {
+			Data struct {
+				Job struct {
+					Description string `json:"description"`
+					Title       string `json:"title"`
+				} `json:"job"`
+			} `json:"data"`
+		} `json:"jobDetail"`
+	}
+	if err := s.http.PostJSON(ctx, url, body, &resp); err != nil {
+		return Job{}, false
+	}
+	job := resp.JobDetail.Data.Job
+	if job.Description == "" {
+		return Job{}, false
+	}
+
+	return Job{
+		ExternalID:  p.JobSeqNo,
+		URL:         phenomJobURL(e.Board, p.Locale, p.JobSeqNo),
+		Title:       firstNonEmpty(p.Title, job.Title),
+		Company:     e.Company,
+		Location:    p.CityState,
+		Description: sanitizeHTML(job.Description),
+		Remote:      isRemote(p.CityState),
+		PostedAt:    parseLayout(phenomDateLayout, p.PostedDate),
+	}, true
+}
+
+// phenomJobURL builds a posting's public page from its locale and sequence id. Phenom
+// paths are "/<country>/<lang>/job/<jobSeqNo>" and the list locale is "<lang>_<COUNTRY>"
+// (e.g. "en_GLOBAL" -> "/global/en/job/..."). A locale without an underscore falls back
+// to the unlocalized "/job/<jobSeqNo>".
+func phenomJobURL(board, locale, seq string) string {
+	if lang, country, ok := strings.Cut(locale, "_"); ok && lang != "" && country != "" {
+		return fmt.Sprintf("https://%s/%s/%s/job/%s", board, strings.ToLower(country), strings.ToLower(lang), seq)
+	}
+	return fmt.Sprintf("https://%s/job/%s", board, seq)
+}

--- a/internal/sources/phenom_test.go
+++ b/internal/sources/phenom_test.go
@@ -1,0 +1,123 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// phenomFake is a JSONPoster that routes by the request body's ddoKey: a refineSearch
+// returns the canned page for its "from" offset, a jobDetail returns the canned detail
+// for its jobSeqNo (or errors when absent, so the adapter skips that posting).
+type phenomFake struct {
+	pages   map[int]string
+	details map[string]string
+}
+
+func (f phenomFake) PostJSON(_ context.Context, _ string, body, v any) error {
+	m := body.(map[string]any)
+	switch m["ddoKey"] {
+	case "refineSearch":
+		return json.Unmarshal([]byte(f.pages[m["from"].(int)]), v)
+	case "jobDetail":
+		js, ok := f.details[m["jobSeqNo"].(string)]
+		if !ok {
+			return fmt.Errorf("no detail for %v", m["jobSeqNo"])
+		}
+		return json.Unmarshal([]byte(js), v)
+	}
+	return fmt.Errorf("unexpected ddoKey %v", m["ddoKey"])
+}
+
+// phenomListPage renders a refineSearch page from a list of jobSeqNos.
+func phenomListPage(seqs ...string) string {
+	jobs := make([]string, len(seqs))
+	for i, s := range seqs {
+		jobs[i] = fmt.Sprintf(`{"jobSeqNo":%q,"title":"Engineer %s","cityState":"Bonn, NRW","locale":"en_GLOBAL","postedDate":"2026-05-17T22:00:00.000+0000"}`, s, s)
+	}
+	return `{"refineSearch":{"data":{"jobs":[` + strings.Join(jobs, ",") + `]}}}`
+}
+
+func phenomDetail(desc string) string {
+	return fmt.Sprintf(`{"jobDetail":{"data":{"job":{"description":%q,"title":"Detail Title"}}}}`, desc)
+}
+
+func TestPhenomProvider(t *testing.T) {
+	if got := NewPhenom(nil).Provider(); got != "phenom" {
+		t.Errorf("Provider() = %q, want %q", got, "phenom")
+	}
+}
+
+func TestPhenomFetchPaginatesAndFetchesDetail(t *testing.T) {
+	// A full first page (phenomPageSize seqs) forces a second request; the short second
+	// page stops the loop.
+	first := make([]string, phenomPageSize)
+	for i := range first {
+		first[i] = fmt.Sprintf("S%d", i)
+	}
+	fake := phenomFake{
+		pages: map[int]string{
+			0:              phenomListPage(first...),
+			phenomPageSize: phenomListPage("LAST", "NODETAIL"),
+		},
+		details: map[string]string{},
+	}
+	for _, s := range first {
+		fake.details[s] = phenomDetail("<p>full body for " + s + "</p>")
+	}
+	fake.details["LAST"] = phenomDetail("<p>last one</p>")
+	// "NODETAIL" has no detail route -> its detail fetch errors and it is skipped.
+
+	jobs, err := NewPhenom(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "DHL", Provider: "phenom", Board: "careers.dhl.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if want := phenomPageSize + 1; len(jobs) != want {
+		t.Fatalf("len(jobs) = %d, want %d (full page + LAST, NODETAIL skipped)", len(jobs), want)
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if _, present := byID["NODETAIL"]; present {
+		t.Error("NODETAIL should have been skipped (no detail)")
+	}
+
+	j, ok := byID["S0"]
+	if !ok {
+		t.Fatal("posting S0 missing")
+	}
+	if j.Title != "Engineer S0" {
+		t.Errorf("Title = %q, want the list title", j.Title)
+	}
+	if j.URL != "https://careers.dhl.com/global/en/job/S0" {
+		t.Errorf("URL = %q, want locale-derived public page", j.URL)
+	}
+	if j.Location != "Bonn, NRW" {
+		t.Errorf("Location = %q, want cityState", j.Location)
+	}
+	if !strings.Contains(j.Description, "full body for S0") {
+		t.Errorf("Description = %q, want the detail body", j.Description)
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed postedDate (2026)", j.PostedAt)
+	}
+}
+
+func TestPhenomJobURL(t *testing.T) {
+	cases := []struct{ board, locale, seq, want string }{
+		{"careers.dhl.com", "en_GLOBAL", "X1", "https://careers.dhl.com/global/en/job/X1"},
+		{"careers.dhl.com", "en_us", "X2", "https://careers.dhl.com/us/en/job/X2"},
+		{"careers.dhl.com", "", "X3", "https://careers.dhl.com/job/X3"},
+	}
+	for _, c := range cases {
+		if got := phenomJobURL(c.board, c.locale, c.seq); got != c.want {
+			t.Errorf("phenomJobURL(%q,%q,%q) = %q, want %q", c.board, c.locale, c.seq, got, c.want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -107,6 +107,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTeamtailor(c),
 		NewICIMS(c),
 		NewJibe(c),
+		NewPhenom(c),
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -1,0 +1,7 @@
+# Phenom People career sites. Provider is the filename; each entry is company + board.
+# board = the site's public host; the adapter POSTs https://<board>/widgets
+# (refineSearch for the list, jobDetail for each posting). See internal/sources/phenom.go.
+# Each board validated live (refineSearch returns postings) before adding.
+
+- company: DHL
+  board: careers.dhl.com


### PR DESCRIPTION
## What
New `phenom` adapter for **Phenom People** career sites (`internal/sources/phenom.go`), `board` = the site host.

Phenom serves everything from POSTs to `https://<board>/widgets`, distinguished by a `ddoKey`:
- **`refineSearch`** — the paged job list. Paginated by `from` (size 100), stopping on a short/empty page. `lang`/`country` are deliberately omitted from the body: live-verified they don't change the result set, so the host is the only per-tenant input.
- **`jobDetail`** — one posting's full HTML `description`. The list carries only a teaser, so each posting gets a detail fetch under the shared bounded-concurrency pool (same shape as iCIMS/SmartRecruiters).

The public job URL is derived from the list `locale` (`en_GLOBAL` → `/global/en/job/<jobSeqNo>`; `<lang>_<COUNTRY>` → `/<country>/<lang>/job/<seq>`); the list `applyUrl` points to the external ATS apply, not the source page.

Adds **DHL** in `sources/phenom.yml` — **8280 jobs, 0 empty descriptions, live-verified** end-to-end through the adapter.

## Test
`go build ./...`, `go vet`, `go test ./internal/sources/` — all green; gofmt clean. `phenom_test.go` covers from-pagination with the short-page stop, the body-keyed list/detail routing, skip-on-missing-detail, and the locale→URL derivation.

## Notes
- DHL's catalogue is large and global (logistics-heavy, many non-IT/LATAM roles) — consistent with how the other broad adapters ingest whole catalogues; the category/geo facets handle filtering downstream.
- No new binary; `cmd/ingest` picks up `sources/phenom.yml`. Deploy needs a full image rebuild (new adapter, not a sources-only rsync) + a cron entry for the file.

## Context
Built while finishing the deferred sources from #149. The other deferred one, **careers.confluent.io**, stays blocked: it's custom Next.js on Vercel behind a Bot Challenge (`x-vercel-mitigated: challenge`) that 429s **every** route including `/api/*`, so there is no plain-HTTP data API to target — it needs a headless/challenge tier the project doesn't have.