### PR TITLE
feat(sources): +54 boards from TeamBlind harvest

### DIFF
--- a/internal/sources/greenhouse.go
+++ b/internal/sources/greenhouse.go
@@ -7,7 +7,9 @@ import (
 	"strconv"
 )
 
-// greenhouseBaseURL is the Greenhouse public boards API root.
+// greenhouseBaseURL is the Greenhouse public boards API root. Unlike Lever, Greenhouse
+// serves EU-hosted boards (job-boards.eu.greenhouse.io front-ends) from this same single
+// API host, so no per-region host selection is needed.
 const greenhouseBaseURL = "https://boards-api.greenhouse.io/v1/boards"
 
 // greenhouse adapts the Greenhouse public boards API. The list endpoint carries the

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -9857,3 +9857,109 @@
   board: sandstonecare
 - company: Uplifter Inc.
   board: uplifter
+
+- company: Goken America
+  board: gokenamericallc
+- company: IDB Bank
+  board: idbny
+- company: Access Systems
+  board: accesssystemsadminsales
+- company: VitalCaring
+  board: vitalcaringgroup
+- company: Atto Trading
+  board: attotrading
+- company: Sage Eldercare Solutions
+  board: sageeldercare
+- company: BathWorks Michigan
+  board: bathworksmichigan
+- company: J-Bear Child Development Center
+  board: jbearcdc
+- company: ReBath
+  board: rebathcorporate
+- company: Marketech International Corporation USA
+  board: marketechinternationalcorporationusa
+- company: All Four Seasons Garage
+  board: all4seasons
+- company: LTS - Video Solutions for Security Professionals
+  board: lts
+- company: Jetson Home
+  board: jetsonhome
+- company: ASSYST
+  board: assystinc
+- company: Jack Morton Worldwide
+  board: jackmortonworldwide
+- company: Compliance Management International
+  board: compliancemanagementinternational
+- company: Built In
+  board: builtin
+- company: Doxim
+  board: doxim
+- company: "United Vein & Vascular Centers"
+  board: unitedveincenters
+- company: Kepora
+  board: kepora
+- company: Homeland Safety Systems
+  board: homeland
+- company: Hillpointe
+  board: hillpointe
+- company: O2EPCM
+  board: o2epcminc
+- company: Digi Security Systems
+  board: digisecuritysystems
+- company: "King Quality Roofing & Siding"
+  board: kingquality
+- company: Reliant at Home
+  board: reliantathome
+- company: "Arc Hospice & Palliative Care"
+  board: archospice
+- company: Certified Group
+  board: certifiedgroup
+- company: Reolink
+  board: reolink
+- company: Stronghouse
+  board: stronghouse
+- company: CBCS
+  board: cbcs
+- company: IntelliChoice Home Care
+  board: choosebettercare
+- company: Sauce Labs
+  board: saucelabs
+- company: Vailexa
+  board: vailexa
+- company: TIMEPROOFUSA
+  board: timeproofusa
+- company: Interpath Laboratory
+  board: interpath
+- company: Praxis Health
+  board: praxis-health
+- company: Czinger
+  board: czinger
+- company: "Gottlieb & Greenspan"
+  board: gottliebgreenspan
+- company: Adams Clinical
+  board: adamsclinical
+- company: United Integrated Services
+  board: unitedintegratedservices
+- company: HighGround
+  board: highground
+- company: Suncoast Skin Solutions
+  board: suncoastskinsolutionsinc
+- company: Main Street Auto
+  board: msautomotive
+- company: Rocket EMS
+  board: rocketems
+- company: "Wolcott, Wood and Taylor"
+  board: wolcottwoodandtaylor
+
+- company: think-cell
+  board: thinkcellsoftware
+- company: Third Bridge Group
+  board: thirdbridge
+- company: Indeed Flex
+  board: indeedflex
+- company: Trinity Claims
+  board: trinityclaims
+- company: JOE & THE JUICE
+  board: jjfr
+- company: SolarWinds
+  board: solarwinds

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -3525,3 +3525,6 @@
   board: leverdemo-8
 - company: talentwerx.io
   board: talentwerx.io
+
+- company: Earnest
+  board: Earnestpartners

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -569,3 +569,8 @@
   board: whitespectre
 - company: Bask Health
   board: bask-health-1
+
+- company: Rokt
+  board: rokt
+- company: Riverlane
+  board: riverlane


### PR DESCRIPTION
## What

Mined **teamblind.com/jobs** for board coverage gaps and added the live, not-yet-covered boards.

Blind is an aggregator: each `/jobs/<id>` SSR page links out to the company's own ATS apply URL (`job-boards.greenhouse.io/<slug>/…?gh_src=Blind`). I replicated Blind's encrypted listing API (sjcl AES + RSA envelope), harvested **7080 unique jobs / 1048 companies**, extracted outbound apply URLs, parsed `(provider, slug)`, and diffed against our `sources/*.yml`.

## Result

- **413** distinct external boards on Blind → **351 already ours**, **56 missing**.
- Of the 635 "Recruiting on Blind" companies (apply on Blind itself), **0** expose an external board.

## Added (55, every slug live-validated against its ATS API)

| provider | added | notes |
|---|---|---|
| greenhouse | 52 | incl. 5 EU front-hosted (think-cell, Third Bridge, Indeed Flex, Trinity Claims, JOE & THE JUICE) served by the **unified** `boards-api.greenhouse.io` — no region field needed (unlike Lever); + SolarWinds, recovered from a custom careers host (`jobs.solarwinds.com?gh_jid=…` = Greenhouse behind a vanity domain) |
| lever | 1 | Earnest (`Earnestpartners`) |
| workable | 2 | Rokt, Riverlane |

## Investigated, not added

- **6 custom careers hosts**: 4 carried `gh_jid` (= Greenhouse behind a vanity domain) → Elastic/Dropbox/Collective Health already ours, **SolarWinds recovered & added**. Asana is a Gem application *form* (no vanity board path), Antora is a diversityjobs repost — neither fits an existing adapter.
- Blind is broader than IT — many added greenhouse boards are non-IT (clinics, trades). Kept per request; prune if undesired.

## Test

- `go build ./...`, `go vet`, `go test ./internal/sources/` green.
- Confirmed `boards-api.eu.greenhouse.io` does **not** resolve; the default API host serves EU boards (think-cell 18, Third Bridge 108, …), so the greenhouse adapter only gained a clarifying comment.