### PR TITLE
feat(sources): +41 Jibe/Phenom boards (career-site harvest)

### DIFF
--- a/sources/jibe.yml
+++ b/sources/jibe.yml
@@ -7,3 +7,23 @@
 
 - company: GitHub
   board: www.github.careers
+
+# --- harvested 2026-06-17 (live-validated against the platform API) ---
+- company: AMD
+  board: careers.amd.com
+- company: Costco
+  board: careers.costco.com
+- company: Dollar General
+  board: careers.dollargeneral.com
+- company: Foot Locker
+  board: careers.footlocker.com
+- company: General Mills
+  board: careers.generalmills.com
+- company: Paychex
+  board: careers.paychex.com
+- company: PepsiCo
+  board: careers.pepsico.com
+- company: State Farm
+  board: jobs.statefarm.com
+- company: Ulta Beauty
+  board: careers.ulta.com

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -5,3 +5,69 @@
 
 - company: DHL
   board: careers.dhl.com
+
+# --- harvested 2026-06-17 (live-validated against the platform API) ---
+- company: Adobe
+  board: careers.adobe.com
+- company: Applied Industrial Technologies
+  board: jobs.applied.com
+- company: Baker Hughes
+  board: careers.bakerhughes.com
+- company: Cisco
+  board: careers.cisco.com
+- company: Danaher
+  board: jobs.danaher.com
+- company: Dollar Tree
+  board: careers.dollartree.com
+- company: DuPont
+  board: careers.dupont.com
+- company: Ecolab
+  board: jobs.ecolab.com
+- company: Eli Lilly
+  board: careers.lilly.com
+- company: GSK
+  board: jobs.gsk.com
+- company: Hewlett Packard Enterprise
+  board: careers.hpe.com
+- company: Honda
+  board: careers.honda.com
+- company: Humana
+  board: careers.humana.com
+- company: Illinois Tool Works
+  board: careers.itw.com
+- company: Kohl's
+  board: careers.kohls.com
+- company: Mars
+  board: careers.mars.com
+- company: Mastercard
+  board: careers.mastercard.com
+- company: Merck
+  board: jobs.merck.com
+- company: PNC
+  board: careers.pnc.com
+- company: PPG
+  board: careers.ppg.com
+- company: Regions Bank
+  board: careers.regions.com
+- company: Roche
+  board: careers.roche.com
+- company: RTX
+  board: careers.rtx.com
+- company: Snowflake
+  board: careers.snowflake.com
+- company: State Street
+  board: careers.statestreet.com
+- company: Thermo Fisher Scientific
+  board: jobs.thermofisher.com
+- company: TJX Companies
+  board: jobs.tjx.com
+- company: Toyota
+  board: careers.toyota.com
+- company: Truist
+  board: careers.truist.com
+- company: U.S. Bank
+  board: careers.usbank.com
+- company: United Airlines
+  board: careers.united.com
+- company: Zimmer Biomet
+  board: careers.zimmerbiomet.com


### PR DESCRIPTION
## What
Adds **41 new boards** to the existing `jibe` and `phenom` adapters — no code change, both adapters already shipped (#149/#155) and the host cron already runs `jibe.yml`/`phenom.yml`.

Every host was **live-validated against the platform API** before adding (Jibe `GET /api/jobs`, Phenom `POST /widgets` refineSearch; Phenom `jobDetail` spot-checked for full descriptions):

**Jibe (+9):** Costco (26k), Dollar General (89k), Ulta Beauty (10k), PepsiCo, Foot Locker, AMD, Paychex, General Mills, State Farm

**Phenom (+32):** Adobe, Cisco, Snowflake, Mastercard, HPE, RTX, Thermo Fisher, Danaher, Ecolab, Roche, GSK, Merck, Eli Lilly, Baker Hughes, PPG, DuPont, Mars, Illinois Tool Works, Zimmer Biomet, Applied Industrial, Honda, Toyota, United Airlines, Humana, PNC, Kohl's, State Street, U.S. Bank, Truist, Regions, Dollar Tree (14k), TJX (8k)

~188k postings total.

## Discovery method
`.careers` gTLD is almost exclusively iCIMS/Jibe; `careers.<company>.com` on large enterprises is frequently Phenom. Brute-probing those patterns over ~120 big employers against both platform APIs gave a ~7% hit rate.

## Validation
Both files pass `LoadConfig` + `Config.Validate` against the registry (the same check `cmd/ingest` runs at startup). `go build`/`go vet` unaffected (no Go change).

## Note
Catalogue mix shifts toward non-IT (retail/logistics: Dollar General, Costco, Dollar Tree, Ulta, TJX). Explicitly chosen — maximize coverage; the category/geo facets filter downstream. Every new posting will be LLM-enriched, so expect a one-time enrichment-budget bump as the backlog drains.

## Deploy
Sources-only: rsync `sources/` to the host (`deploy.sh --no-build`); no image rebuild, no cron change.