### PR TITLE
fix: stop nbsp-glued descriptions overflowing the job page

### DIFF
--- a/internal/sources/sanitize.go
+++ b/internal/sources/sanitize.go
@@ -1,6 +1,21 @@
 package sources
 
-import "github.com/microcosm-cc/bluemonday"
+import (
+	"strings"
+
+	"github.com/microcosm-cc/bluemonday"
+)
+
+// noBreakSpaces normalizes the no-break space characters that some ATS boards use
+// in place of regular spaces (commonly the &nbsp; entity, which bluemonday decodes
+// to the raw U+00A0 rune). Left as-is, a description whose every word is glued by
+// U+00A0 renders as one unbreakable line that overflows the page horizontally, so
+// we fold them to a regular space, restoring word-boundary wrapping. Compiled once
+// and safe for concurrent use, like descriptionPolicy.
+var noBreakSpaces = strings.NewReplacer(
+	" ", " ", // NO-BREAK SPACE
+	" ", " ", // NARROW NO-BREAK SPACE
+)
 
 // descriptionPolicy sanitizes source-provided job description HTML. It is compiled
 // once and reused: bluemonday policies are safe for concurrent use.
@@ -33,7 +48,7 @@ func newDescriptionPolicy() *bluemonday.Policy {
 // safe to render directly in a browser. Adapters call it on their assembled description
 // HTML before yielding a job, so the catalogue stores only sanitized markup.
 func sanitizeHTML(s string) string {
-	return descriptionPolicy.Sanitize(s)
+	return noBreakSpaces.Replace(descriptionPolicy.Sanitize(s))
 }
 
 // SanitizeHTML is the exported description sanitizer, for sibling packages that build

--- a/internal/sources/sanitize_test.go
+++ b/internal/sources/sanitize_test.go
@@ -33,3 +33,22 @@ func TestSanitizeHTML(t *testing.T) {
 		t.Errorf("sanitizeHTML should mark links nofollow\ngot: %s", got)
 	}
 }
+
+// Some ATS boards emit descriptions whose words are glued by non-breaking spaces
+// (U+00A0, often as the &nbsp; entity) instead of regular spaces. Rendered with
+// {@html} this becomes one unbreakable line that overflows the page horizontally,
+// so the sanitizer normalizes no-break spaces to regular ones, restoring word-boundary
+// wrapping. bluemonday decodes &nbsp; to the raw U+00A0 rune, so normalizing the
+// sanitized output catches both the entity and raw-character forms.
+func TestSanitizeHTMLNormalizesNoBreakSpaces(t *testing.T) {
+	cases := map[string]struct{ in, want string }{
+		"entity form":   {"<p>Java&nbsp;Spring&nbsp;Boot</p>", "<p>Java Spring Boot</p>"},
+		"raw U+00A0":    {"<p>Java Spring Boot</p>", "<p>Java Spring Boot</p>"},
+		"narrow U+202F": {"<p>5 years</p>", "<p>5 years</p>"},
+	}
+	for name, c := range cases {
+		if got := sanitizeHTML(c.in); got != c.want {
+			t.Errorf("%s: sanitizeHTML(%q) = %q, want %q", name, c.in, got, c.want)
+		}
+	}
+}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -252,6 +252,12 @@
 {/if}
 
 <style>
+  /* Descriptions are arbitrary scraped HTML: a long URL — or words glued by
+     non-breaking spaces — must wrap instead of forcing a horizontal page scroll. */
+  .job-description {
+    overflow-wrap: break-word;
+  }
+
   .job-description :global(h1),
   .job-description :global(h2),
   .job-description :global(h3),


### PR DESCRIPTION
## Problem
Some ATS boards separate every word with a non-breaking space (U+00A0, often the `&nbsp;` entity) instead of a regular space. Rendered with `{@html}`, the whole description becomes one unbreakable line that overflows the page horizontally.

Reproduced on [backend-developer-stefanini-latam](https://freehire.dev/jobs/backend-developer-stefanini-latam-lbep5dzy): 374 U+00A0 vs 5 regular spaces → the 3.4k-char description measured **~3919px wide at a 390px viewport**, forcing a full-page horizontal scroll (text appeared clipped).

## Fix (defense-in-depth, two layers)
- **`internal/sources/sanitize.go`** — fold no-break spaces (U+00A0, U+202F) to a regular space at the `sanitizeHTML` choke-point all adapters + linksource share, restoring word-boundary wrapping. bluemonday decodes `&nbsp;` to the raw U+00A0 rune, so normalizing the sanitized output catches both the entity and raw-character forms. Board sources self-heal on re-crawl (`UpsertJob` refreshes `description`) — no backfill needed.
- **`web/.../JobView.svelte`** — `overflow-wrap: break-word` on `.job-description` as a render-layer guard for any pathological content (long URLs, legacy nbsp rows), fixing all existing jobs immediately.

## Verification
- New `TestSanitizeHTMLNormalizesNoBreakSpaces` (red before fix, green after); full `go test ./...` green; `gofmt`/`go vet` clean.
- Frontend: confirmed in the live DOM that the rule drops `scrollWidth` 3935→390px at a 390px viewport.