### PR TITLE
feat(sources): add Eightfold AI adapter (Microsoft careers, +1388 jobs)

### DIFF
--- a/internal/sources/eightfold.go
+++ b/internal/sources/eightfold.go
@@ -12,9 +12,10 @@ import (
 const eightfoldPageLimit = 10
 
 // eightfold adapts Eightfold AI career sites (e.g. apply.careers.microsoft.com). Both
-// endpoints are public GET JSON: the position list /api/pcsx/search (which requires the tenant
-// domain and carries no description) and each position's detail /api/apply/v2/jobs/<id>, fetched
-// to assemble the description and canonical URL.
+// endpoints are public GET JSON. Two list-API generations exist and a tenant supports exactly
+// one (the other returns 403): the newer /api/pcsx/search and the legacy /api/apply/v2/jobs.
+// The list carries no description, so each position's detail /api/apply/v2/jobs/<id> (shared by
+// both generations) is fetched to assemble the description and canonical URL.
 type eightfold struct {
 	http JSONGetter
 }
@@ -40,22 +41,34 @@ func parseEightfoldBoard(board string) (eightfoldBoard, error) {
 	return eightfoldBoard{host: host, domain: domain}, nil
 }
 
-// eightfoldPosition is one item from the /api/pcsx/search list (no description here).
+// eightfoldPosition is one list item, decoding both generations' field names: the newer pcsx
+// list uses postedTs/workLocationOption and only locations[]; the legacy v2 list uses
+// t_create/work_location_option and a single-string location (plus a canonical URL). Unused
+// fields stay zero, so one struct decodes either shape.
 type eightfoldPosition struct {
-	ID                 int64    `json:"id"`
-	Name               string   `json:"name"`
-	Locations          []string `json:"locations"`
-	PostedTs           int64    `json:"postedTs"`
-	WorkLocationOption string   `json:"workLocationOption"`
+	ID                   int64    `json:"id"`
+	Name                 string   `json:"name"`
+	Location             string   `json:"location"`  // legacy v2 single-string
+	Locations            []string `json:"locations"` // both generations
+	PostedTs             int64    `json:"postedTs"`  // pcsx
+	TCreate              int64    `json:"t_create"`  // legacy v2
+	WorkLocationOption   string   `json:"workLocationOption"`
+	WorkLocationOptionV2 string   `json:"work_location_option"`
+	CanonicalPositionURL string   `json:"canonicalPositionUrl"` // present in the legacy v2 list
 }
 
-// eightfoldListResponse wraps a search page: the positions plus the catalogue total used as
-// the stop condition.
-type eightfoldListResponse struct {
+// pcsxListResponse is one /api/pcsx/search page (positions nest under data).
+type pcsxListResponse struct {
 	Data struct {
 		Positions []eightfoldPosition `json:"positions"`
 		Count     int                 `json:"count"`
 	} `json:"data"`
+}
+
+// v2ListResponse is one legacy /api/apply/v2/jobs page (positions and count are top-level).
+type v2ListResponse struct {
+	Positions []eightfoldPosition `json:"positions"`
+	Count     int                 `json:"count"`
 }
 
 // eightfoldDetail is the part of /api/apply/v2/jobs/<id> the Job shape needs.
@@ -80,34 +93,74 @@ func (s eightfold) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	}), nil
 }
 
-// listPositions pages through the board's positions, advancing start by the page size the
-// server returns and stopping when a page is empty or the collected count reaches the
-// catalogue total. The empty-page check is the backstop if count is ever wrong.
+// listPositions returns the board's positions, auto-detecting the list-API generation: it
+// tries the newer pcsx list and, if that fails (a legacy tenant returns 403), falls back to
+// the v2 list. A tenant supports exactly one, so whichever paginates successfully is
+// authoritative; the fallback restarts from the first page.
 func (s eightfold) listPositions(ctx context.Context, b eightfoldBoard) ([]eightfoldPosition, error) {
+	positions, err := s.pageList(ctx, b, s.pcsxPage)
+	if err != nil {
+		positions, err = s.pageList(ctx, b, s.v2Page)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("eightfold: list domain %s: %w", b.domain, err)
+	}
+	return positions, nil
+}
+
+// pageList walks one list generation, fetching pages via fetchPage and advancing start by the
+// page size the server returns, stopping when a page is empty or the collected count reaches
+// the catalogue total. The empty-page check is the backstop if count is ever wrong.
+func (s eightfold) pageList(
+	ctx context.Context, b eightfoldBoard,
+	fetchPage func(ctx context.Context, b eightfoldBoard, start int) ([]eightfoldPosition, int, error),
+) ([]eightfoldPosition, error) {
 	var positions []eightfoldPosition
 	for start := 0; ; {
-		url := fmt.Sprintf(
-			"https://%s/api/pcsx/search?domain=%s&query=&start=%d&num=%d&sort_by=relevance",
-			b.host, b.domain, start, eightfoldPageLimit)
-		var resp eightfoldListResponse
-		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
-			return nil, fmt.Errorf("eightfold: list domain %s: %w", b.domain, err)
+		page, count, err := fetchPage(ctx, b, start)
+		if err != nil {
+			return nil, err
 		}
-		if len(resp.Data.Positions) == 0 {
+		if len(page) == 0 {
 			break
 		}
-		positions = append(positions, resp.Data.Positions...)
-		start += len(resp.Data.Positions)
-		if start >= resp.Data.Count {
+		positions = append(positions, page...)
+		start += len(page)
+		if start >= count {
 			break
 		}
 	}
 	return positions, nil
 }
 
+// pcsxPage fetches one newer /api/pcsx/search page.
+func (s eightfold) pcsxPage(ctx context.Context, b eightfoldBoard, start int) ([]eightfoldPosition, int, error) {
+	url := fmt.Sprintf(
+		"https://%s/api/pcsx/search?domain=%s&query=&start=%d&num=%d&sort_by=relevance",
+		b.host, b.domain, start, eightfoldPageLimit)
+	var resp pcsxListResponse
+	if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+		return nil, 0, err
+	}
+	return resp.Data.Positions, resp.Data.Count, nil
+}
+
+// v2Page fetches one legacy /api/apply/v2/jobs page.
+func (s eightfold) v2Page(ctx context.Context, b eightfoldBoard, start int) ([]eightfoldPosition, int, error) {
+	url := fmt.Sprintf(
+		"https://%s/api/apply/v2/jobs?domain=%s&query=&start=%d&num=%d&sort_by=relevance",
+		b.host, b.domain, start, eightfoldPageLimit)
+	var resp v2ListResponse
+	if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+		return nil, 0, err
+	}
+	return resp.Positions, resp.Count, nil
+}
+
 // detail fetches one position's detail and maps it to a Job, returning ok=false when the
 // detail request fails so the caller can skip just that position. Metadata comes from the
-// list position; only the description and canonical URL come from the detail.
+// list position; the description and canonical URL come from the detail (with the list
+// position's canonical URL and a host fallback for the URL).
 func (s eightfold) detail(ctx context.Context, e CompanyEntry, b eightfoldBoard, p eightfoldPosition) (Job, bool) {
 	id := strconv.FormatInt(p.ID, 10)
 	url := fmt.Sprintf("https://%s/api/apply/v2/jobs/%s?domain=%s", b.host, id, b.domain)
@@ -116,17 +169,24 @@ func (s eightfold) detail(ctx context.Context, e CompanyEntry, b eightfoldBoard,
 		return Job{}, false
 	}
 
-	location := firstNonEmpty(p.Locations...)
-	workMode := workplaceTypeMode(p.WorkLocationOption)
+	location := firstNonEmpty(p.Location, firstNonEmpty(p.Locations...))
+	workMode := workplaceTypeMode(firstNonEmpty(p.WorkLocationOption, p.WorkLocationOptionV2))
+	postedTs := p.PostedTs
+	if postedTs == 0 {
+		postedTs = p.TCreate
+	}
+	pageURL := firstNonEmpty(
+		d.CanonicalPositionURL, p.CanonicalPositionURL,
+		fmt.Sprintf("https://%s/careers/job/%s", b.host, id))
 	return Job{
 		ExternalID:  id,
-		URL:         firstNonEmpty(d.CanonicalPositionURL, fmt.Sprintf("https://%s/careers/job/%s", b.host, id)),
+		URL:         pageURL,
 		Title:       strings.TrimSpace(p.Name),
 		Company:     e.Company,
 		Location:    location,
 		Description: sanitizeHTML(d.JobDescription),
 		Remote:      workMode == "remote" || isRemote(location),
 		WorkMode:    workMode,
-		PostedAt:    parseEpochSeconds(p.PostedTs),
+		PostedAt:    parseEpochSeconds(postedTs),
 	}, true
 }

--- a/internal/sources/eightfold.go
+++ b/internal/sources/eightfold.go
@@ -1,0 +1,132 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// eightfoldPageLimit is the position-list page size. The Eightfold server caps a page at 10
+// regardless of the requested num, so this is fixed and start is the only pagination lever.
+const eightfoldPageLimit = 10
+
+// eightfold adapts Eightfold AI career sites (e.g. apply.careers.microsoft.com). Both
+// endpoints are public GET JSON: the position list /api/pcsx/search (which requires the tenant
+// domain and carries no description) and each position's detail /api/apply/v2/jobs/<id>, fetched
+// to assemble the description and canonical URL.
+type eightfold struct {
+	http JSONGetter
+}
+
+// NewEightfold builds the Eightfold adapter over the given HTTP client.
+func NewEightfold(c JSONGetter) Source { return eightfold{http: c} }
+
+func (eightfold) Provider() string { return "eightfold" }
+
+// eightfoldBoard is a configured board split into the host and tenant domain the endpoints need.
+type eightfoldBoard struct {
+	host, domain string
+}
+
+// parseEightfoldBoard splits "host/domain" (e.g.
+// "apply.careers.microsoft.com/microsoft.com"). The host paths the requests; the domain is
+// the Eightfold tenant key the endpoints require as a query parameter.
+func parseEightfoldBoard(board string) (eightfoldBoard, error) {
+	host, domain, ok := strings.Cut(board, "/")
+	if !ok || host == "" || domain == "" {
+		return eightfoldBoard{}, fmt.Errorf("eightfold: board %q must be \"host/domain\"", board)
+	}
+	return eightfoldBoard{host: host, domain: domain}, nil
+}
+
+// eightfoldPosition is one item from the /api/pcsx/search list (no description here).
+type eightfoldPosition struct {
+	ID                 int64    `json:"id"`
+	Name               string   `json:"name"`
+	Locations          []string `json:"locations"`
+	PostedTs           int64    `json:"postedTs"`
+	WorkLocationOption string   `json:"workLocationOption"`
+}
+
+// eightfoldListResponse wraps a search page: the positions plus the catalogue total used as
+// the stop condition.
+type eightfoldListResponse struct {
+	Data struct {
+		Positions []eightfoldPosition `json:"positions"`
+		Count     int                 `json:"count"`
+	} `json:"data"`
+}
+
+// eightfoldDetail is the part of /api/apply/v2/jobs/<id> the Job shape needs.
+type eightfoldDetail struct {
+	JobDescription       string `json:"job_description"`
+	CanonicalPositionURL string `json:"canonicalPositionUrl"`
+}
+
+func (s eightfold) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	b, err := parseEightfoldBoard(e.Board)
+	if err != nil {
+		return nil, err
+	}
+
+	positions, err := s.listPositions(ctx, b)
+	if err != nil {
+		return nil, err
+	}
+
+	return fetchDetails(positions, defaultDetailWorkers, func(p eightfoldPosition) (Job, bool) {
+		return s.detail(ctx, e, b, p)
+	}), nil
+}
+
+// listPositions pages through the board's positions, advancing start by the page size the
+// server returns and stopping when a page is empty or the collected count reaches the
+// catalogue total. The empty-page check is the backstop if count is ever wrong.
+func (s eightfold) listPositions(ctx context.Context, b eightfoldBoard) ([]eightfoldPosition, error) {
+	var positions []eightfoldPosition
+	for start := 0; ; {
+		url := fmt.Sprintf(
+			"https://%s/api/pcsx/search?domain=%s&query=&start=%d&num=%d&sort_by=relevance",
+			b.host, b.domain, start, eightfoldPageLimit)
+		var resp eightfoldListResponse
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("eightfold: list domain %s: %w", b.domain, err)
+		}
+		if len(resp.Data.Positions) == 0 {
+			break
+		}
+		positions = append(positions, resp.Data.Positions...)
+		start += len(resp.Data.Positions)
+		if start >= resp.Data.Count {
+			break
+		}
+	}
+	return positions, nil
+}
+
+// detail fetches one position's detail and maps it to a Job, returning ok=false when the
+// detail request fails so the caller can skip just that position. Metadata comes from the
+// list position; only the description and canonical URL come from the detail.
+func (s eightfold) detail(ctx context.Context, e CompanyEntry, b eightfoldBoard, p eightfoldPosition) (Job, bool) {
+	id := strconv.FormatInt(p.ID, 10)
+	url := fmt.Sprintf("https://%s/api/apply/v2/jobs/%s?domain=%s", b.host, id, b.domain)
+	var d eightfoldDetail
+	if err := s.http.GetJSON(ctx, url, &d); err != nil {
+		return Job{}, false
+	}
+
+	location := firstNonEmpty(p.Locations...)
+	workMode := workplaceTypeMode(p.WorkLocationOption)
+	return Job{
+		ExternalID:  id,
+		URL:         firstNonEmpty(d.CanonicalPositionURL, fmt.Sprintf("https://%s/careers/job/%s", b.host, id)),
+		Title:       strings.TrimSpace(p.Name),
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(d.JobDescription),
+		Remote:      workMode == "remote" || isRemote(location),
+		WorkMode:    workMode,
+		PostedAt:    parseEpochSeconds(p.PostedTs),
+	}, true
+}

--- a/internal/sources/eightfold_test.go
+++ b/internal/sources/eightfold_test.go
@@ -1,0 +1,178 @@
+package sources
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// eightfoldEntry is the shared configured board for the Fetch tests.
+var eightfoldEntry = CompanyEntry{
+	Company: "Microsoft", Provider: "eightfold",
+	Board: "apply.careers.microsoft.com/microsoft.com",
+}
+
+func TestEightfoldProvider(t *testing.T) {
+	if got := NewEightfold(nil).Provider(); got != "eightfold" {
+		t.Errorf("Provider() = %q, want %q", got, "eightfold")
+	}
+}
+
+func TestParseEightfoldBoard(t *testing.T) {
+	t.Run("valid host/domain", func(t *testing.T) {
+		b, err := parseEightfoldBoard("apply.careers.microsoft.com/microsoft.com")
+		if err != nil {
+			t.Fatalf("parseEightfoldBoard: %v", err)
+		}
+		if b.host != "apply.careers.microsoft.com" {
+			t.Errorf("host = %q", b.host)
+		}
+		if b.domain != "microsoft.com" {
+			t.Errorf("domain = %q", b.domain)
+		}
+	})
+
+	for _, board := range []string{
+		"apply.careers.microsoft.com", // no slash → no domain
+		"/microsoft.com",              // empty host
+		"apply.careers.microsoft.com/", // empty domain
+		"",
+	} {
+		t.Run("rejects "+board, func(t *testing.T) {
+			if _, err := parseEightfoldBoard(board); err == nil {
+				t.Errorf("parseEightfoldBoard(%q) = nil error, want error", board)
+			}
+		})
+	}
+}
+
+// eightfoldList builds a /api/pcsx/search response body with the given count and raw positions.
+func eightfoldList(count int, positions ...string) string {
+	return `{"data": {"count": ` + strconv.Itoa(count) + `, "positions": [` + strings.Join(positions, ",") + `]}}`
+}
+
+// TestEightfoldFetchListsAndFetchesDetail covers the core path: page the position list, fetch
+// each position's detail for the description and canonical URL, and map every field. The list
+// carries metadata (title, location, postedTs, workLocationOption) while the detail carries the
+// description and canonicalPositionUrl.
+func TestEightfoldFetchListsAndFetchesDetail(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("pcsx/search", eightfoldList(2,
+			`{"id": 111, "displayJobId": "200001", "name": "Backend Engineer",
+			  "locations": ["United States, Washington, Redmond"], "postedTs": 1781691482,
+			  "workLocationOption": "onsite", "atsJobId": "200001"}`,
+			`{"id": 222, "name": "Data Engineer", "locations": ["Remote"], "postedTs": 0,
+			  "workLocationOption": "remote"}`)).
+		route("jobs/111", `{"id": 111, "job_description": "<p>Build the backend.</p>",
+			"canonicalPositionUrl": "https://apply.careers.microsoft.com/careers/job/111"}`).
+		route("jobs/222", `{"id": 222, "job_description": "<p>Crunch data.</p>"}`)
+
+	jobs, err := NewEightfold(fake).Fetch(context.Background(), eightfoldEntry)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j, ok := byID["111"]
+	if !ok {
+		t.Fatal("position 111 missing")
+	}
+	if j.Title != "Backend Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Microsoft" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Location != "United States, Washington, Redmond" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.URL != "https://apply.careers.microsoft.com/careers/job/111" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want onsite", j.WorkMode)
+	}
+	if j.Remote {
+		t.Error("Remote = true, want false for an onsite role")
+	}
+	if !strings.Contains(j.Description, "Build the backend.") {
+		t.Errorf("Description = %q", j.Description)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-06-17" {
+		t.Errorf("PostedAt = %v, want 2026-06-17", j.PostedAt)
+	}
+
+	data := byID["222"]
+	if data.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote", data.WorkMode)
+	}
+	if !data.Remote {
+		t.Error("Remote = false, want true for a remote role")
+	}
+	// canonicalPositionUrl absent → fall back to the public position page.
+	if data.URL != "https://apply.careers.microsoft.com/careers/job/222" {
+		t.Errorf("URL = %q, want the host/careers/job fallback", data.URL)
+	}
+	if data.PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil for postedTs=0", data.PostedAt)
+	}
+}
+
+// TestEightfoldPaginatesUntilEmptyPage verifies the lister advances start past the first page
+// and stops on an empty page even when count would not be reached.
+func TestEightfoldPaginatesUntilEmptyPage(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("start=0", eightfoldList(99,
+			`{"id": 1, "name": "Role 1", "locations": ["Remote"]}`,
+			`{"id": 2, "name": "Role 2", "locations": ["Remote"]}`)).
+		route("start=2", eightfoldList(99)).
+		route("jobs/", `{"job_description": "<p>desc</p>"}`)
+
+	jobs, err := NewEightfold(fake).Fetch(context.Background(), eightfoldEntry)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 across the non-empty page", len(jobs))
+	}
+}
+
+// TestEightfoldDropsFailedDetail verifies one position whose detail request fails is skipped
+// while the rest of the board still yields.
+func TestEightfoldDropsFailedDetail(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("pcsx/search", eightfoldList(2,
+			`{"id": 111, "name": "Kept", "locations": ["Remote"]}`,
+			`{"id": 222, "name": "Dropped", "locations": ["Remote"]}`)).
+		route("jobs/111", `{"id": 111, "job_description": "<p>kept</p>"}`)
+	// no route for jobs/222 → its detail GET errors → that posting is dropped.
+
+	jobs, err := NewEightfold(fake).Fetch(context.Background(), eightfoldEntry)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (failed detail dropped)", len(jobs))
+	}
+	if jobs[0].ExternalID != "111" {
+		t.Errorf("kept job = %q, want 111", jobs[0].ExternalID)
+	}
+}
+
+// TestEightfoldFetchRejectsBadBoard verifies a malformed board fails fast before any request.
+func TestEightfoldFetchRejectsBadBoard(t *testing.T) {
+	_, err := NewEightfold(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{
+		Company: "Microsoft", Provider: "eightfold", Board: "apply.careers.microsoft.com",
+	})
+	if err == nil {
+		t.Fatal("Fetch with a board missing the domain half = nil error, want error")
+	}
+}

--- a/internal/sources/eightfold_test.go
+++ b/internal/sources/eightfold_test.go
@@ -167,6 +167,69 @@ func TestEightfoldDropsFailedDetail(t *testing.T) {
 	}
 }
 
+// TestEightfoldFetchFallsBackToLegacyV2List covers the old Eightfold generation (e.g.
+// Netflix), whose listing lives at /api/apply/v2/jobs (top-level positions/count, t_create
+// date) instead of /api/pcsx/search. With no pcsx route the pcsx request errors and the
+// adapter falls back to the v2 list; the shared detail endpoint is unchanged.
+func TestEightfoldFetchFallsBackToLegacyV2List(t *testing.T) {
+	fake := (&routedHTTP{}).
+		// note: "apply/v2/jobs?" matches the LIST, "jobs/<id>" matches the DETAIL.
+		route("apply/v2/jobs?", `{"count": 2, "positions": [
+			{"id": 790, "name": "UX Designer", "location": "Helsinki,Finland",
+			 "t_create": 1779926400, "work_location_option": "onsite",
+			 "canonicalPositionUrl": "https://explore.jobs.netflix.net/careers/job/790"},
+			{"id": 791, "name": "Finance Manager", "location": "Sao Paulo,Brazil", "t_create": 0}
+		]}`).
+		route("jobs/790", `{"id": 790, "job_description": "<p>Design.</p>",
+			"canonicalPositionUrl": "https://explore.jobs.netflix.net/careers/job/790?microsite=netflix.com"}`).
+		route("jobs/791", `{"id": 791, "job_description": "<p>Finance.</p>"}`)
+
+	jobs, err := NewEightfold(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Netflix", Provider: "eightfold",
+		Board: "explore.jobs.netflix.net/netflix.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j := byID["790"]
+	if j.Title != "UX Designer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Location != "Helsinki,Finland" {
+		t.Errorf("Location = %q (want the v2 single-string location)", j.Location)
+	}
+	if j.WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want onsite", j.WorkMode)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt = nil, want a date from t_create")
+	}
+	// detail's canonicalPositionUrl wins over the list's.
+	if j.URL != "https://explore.jobs.netflix.net/careers/job/790?microsite=netflix.com" {
+		t.Errorf("URL = %q, want the detail canonical url", j.URL)
+	}
+	if !strings.Contains(j.Description, "Design.") {
+		t.Errorf("Description = %q", j.Description)
+	}
+
+	data := byID["791"]
+	// detail lacks a canonical url and the list position lacks one → host/careers/job fallback.
+	if data.URL != "https://explore.jobs.netflix.net/careers/job/791" {
+		t.Errorf("URL = %q, want the host fallback", data.URL)
+	}
+	if data.PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil for t_create=0", data.PostedAt)
+	}
+}
+
 // TestEightfoldFetchRejectsBadBoard verifies a malformed board fails fast before any request.
 func TestEightfoldFetchRejectsBadBoard(t *testing.T) {
 	_, err := NewEightfold(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{

--- a/internal/sources/eightfold_test.go
+++ b/internal/sources/eightfold_test.go
@@ -34,8 +34,8 @@ func TestParseEightfoldBoard(t *testing.T) {
 	})
 
 	for _, board := range []string{
-		"apply.careers.microsoft.com", // no slash → no domain
-		"/microsoft.com",              // empty host
+		"apply.careers.microsoft.com",  // no slash → no domain
+		"/microsoft.com",               // empty host
 		"apply.careers.microsoft.com/", // empty domain
 		"",
 	} {

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -112,6 +112,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJoin(c),
 		NewGlobalPayments(c),
 		NewOracle(c),
+		NewEightfold(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/openspec/changes/eightfold-source/.openspec.yaml
+++ b/openspec/changes/eightfold-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/eightfold-source/design.md
+++ b/openspec/changes/eightfold-source/design.md
@@ -1,0 +1,77 @@
+## Context
+
+`internal/sources` is a registry of single-purpose adapters, each implementing `Source`
+(`Provider()` + `Fetch(ctx, CompanyEntry) []Job`). Board-based adapters whose list endpoint
+omits the description (`oracle`, `icims`, smartrecruiters, …) page a list, then fetch each
+posting's detail concurrently through the shared `fetchDetails(postings, defaultDetailWorkers,
+fetch)` helper. `apply.careers.microsoft.com` runs on **Eightfold AI**, which exposes two
+public GET-JSON endpoints reached over the shared `HTTPClient.GetJSON`:
+
+- `GET https://<host>/api/pcsx/search?domain=<domain>&query=&start=<n>&num=10&sort_by=relevance`
+  → `{ "data": { "positions": [ … ], "count": <int> } }`. Each position carries `id`,
+  `displayJobId`, `name`, `locations[]`, `postedTs` (Unix sec), `workLocationOption`, and
+  `atsJobId` — **but no description**.
+- `GET https://<host>/api/apply/v2/jobs/<id>?domain=<domain>` → the full posting, including
+  `job_description` (HTML) and `canonicalPositionUrl`.
+
+This is the same list+detail shape as `oracle`, differing only in the endpoint specifics.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A reusable `eightfold` board-based adapter that yields the normalized `Job` shape for a
+  tenant's whole catalogue.
+- Page the `/api/pcsx/search` list and fetch each position's detail for the description.
+- A fixture-backed unit test that pins the list and detail JSON shapes and the mapping.
+
+**Non-Goals:**
+- No headless browser, proxy, or auth (both endpoints are public GET JSON).
+- No new env vars, DB columns, or migrations.
+- No search-by-query/work-site filtering — the crawl walks the full catalogue (empty query),
+  which is what ingest needs.
+
+## Decisions
+
+- **Board id is `"host/domain"`, parsed like `oracle`'s `"host/site"`.** Eightfold needs the
+  public host for request paths AND a required `domain` query parameter (the tenant key, e.g.
+  `microsoft.com`), and the two are not reliably derivable from each other (a tenant's `domain`
+  need not equal the host's registrable domain). So the board carries both explicitly;
+  `parseEightfoldBoard` splits on the first `/` and rejects a board missing either half. This
+  reuses the established two-part board convention rather than guessing a domain from the host.
+- **Page by `start`; the server caps `num` at 10.** Requesting `num=200` still returns 10
+  positions, so the page size is fixed at 10 and `start` is the only lever. The loop advances
+  `start` by the number of positions actually returned and stops when a page is empty OR the
+  running count reaches `data.count`. The empty-page check is the correctness backstop if
+  `count` is ever wrong/absent; `count` is the optimization, mirroring `oracle`/`jibe`.
+- **Detail fetch via the shared `fetchDetails`.** The list omits the description, so each
+  position maps through `detail()` which GETs `/api/apply/v2/jobs/<id>?domain=<domain>`. A
+  failed detail request returns `ok=false` so that one posting is dropped without aborting the
+  board — the standard isolation `oracle`/`icims` use, with `defaultDetailWorkers` concurrency.
+- **List carries the metadata, detail carries the description.** `external_id`, `title`,
+  `location`, `posted_at`, and `work_mode` come from the list position (the detail's
+  `work_location_option` was observed null while the list's `workLocationOption` is populated);
+  only `description` and the canonical `url` come from the detail. This keeps each request's
+  role explicit and avoids re-reading list fields from the detail.
+- **`url` is the detail's `canonicalPositionUrl`, with a deterministic fallback.** When the
+  detail omits it, build `https://<host>/careers/job/<id>` (the public position page the
+  listing's relative `positionUrl` points at).
+- **`external_id` is the numeric position `id` (stringified).** It keys the detail endpoint and
+  the canonical URL; `displayJobId`/`atsJobId` are human-facing labels, not the API key.
+- **Work mode reuses `workplaceTypeMode`.** Eightfold's `workLocationOption` is already
+  `remote`/`hybrid`/`onsite` (lowercase), which the existing helper maps to our vocabulary; an
+  unknown/empty value yields `""` and the pipeline falls back to the location string. No new
+  mapping function is warranted.
+- **Dates via `parseEpochSeconds`.** `postedTs` is a Unix-second timestamp; reuse the existing
+  helper so `NotFuture` guarding stays consistent with the other epoch-dated adapters.
+
+## Risks / Trade-offs
+
+- **N+1 request cost.** One detail GET per posting (Microsoft's tenant lists ~1.4k positions),
+  the same cost profile as `oracle`/`icims`; `fetchDetails` bounds the fan-out and isolates
+  failures. Accepted: the list has no description, so there is no cheaper path.
+- **`domain` is a hard requirement.** Omitting it returns `422`. The `"host/domain"` board
+  format makes it explicit and config validation already requires a non-empty board for a
+  board-based provider; `parseEightfoldBoard` fails fast on a malformed half.
+- **Brittle to an Eightfold API rename.** If the `/api/pcsx/search` or `/api/apply/v2/jobs`
+  shape changes, the mapping breaks — guarded by the committed fixtures + unit test, the same
+  posture as every other JSON adapter.

--- a/openspec/changes/eightfold-source/design.md
+++ b/openspec/changes/eightfold-source/design.md
@@ -38,6 +38,19 @@ This is the same list+detail shape as `oracle`, differing only in the endpoint s
   need not equal the host's registrable domain). So the board carries both explicitly;
   `parseEightfoldBoard` splits on the first `/` and rejects a board missing either half. This
   reuses the established two-part board convention rather than guessing a domain from the host.
+- **Two list-API generations, auto-detected.** Eightfold tenants run one of two list APIs: the
+  newer `/api/pcsx/search` (positions under `data`, `postedTs`, `workLocationOption`; e.g.
+  Microsoft, Micron) or the legacy `/api/apply/v2/jobs` (top-level positions/count, `t_create`,
+  `work_location_option`, and a list-level `canonicalPositionUrl`; e.g. Netflix). A tenant
+  supports exactly one — the other returns `403` — so `listPositions` tries pcsx first and, on
+  any error, falls back to the v2 list (restarting from the first page). This keeps the board id
+  uniform (`host/domain`) for every tenant, which matters for bulk-adding discovered tenants
+  without knowing each one's generation; the cost is one wasted (fast, 403) request per legacy
+  board per crawl. One `eightfoldPosition` struct decodes both shapes (both field-name variants
+  as separate tags, unused ones stay zero); the detail endpoint `/api/apply/v2/jobs/<id>` is
+  shared, so only the list URL + envelope differ. `posted_at` takes `postedTs` else `t_create`;
+  `location` takes the v2 single-string `location` else the first of `locations[]`; `work_mode`
+  takes whichever work-option field is set.
 - **Page by `start`; the server caps `num` at 10.** Requesting `num=200` still returns 10
   positions, so the page size is fixed at 10 and `start` is the only lever. The loop advances
   `start` by the number of positions actually returned and stops when a page is empty OR the

--- a/openspec/changes/eightfold-source/proposal.md
+++ b/openspec/changes/eightfold-source/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+Microsoft's careers catalogue at `apply.careers.microsoft.com` is not the old
+`careers.microsoft.com` site an earlier feasibility pass marked "blocked" — it is a fresh
+front built on **Eightfold AI**, a multi-tenant ATS many companies use. A probe shows two
+public, auth-free GET-JSON endpoints behind it:
+
+- **List** — `GET /api/pcsx/search?domain=<domain>&query=&start=<n>&num=10` returns
+  `data.positions[]` plus `data.count`. (`num` is server-capped at 10, so `start` is the only
+  pagination lever; the higher-level `/api/apply/v2/jobs` list returns `403 PCSX`.)
+- **Detail** — `GET /api/apply/v2/jobs/<id>?domain=<domain>` returns the full posting,
+  including the `job_description` HTML and a `canonicalPositionUrl`, which the list omits.
+
+Because the endpoints are generic to Eightfold (not Microsoft-specific), the right shape is a
+reusable `eightfold` adapter keyed by board — exactly like the host-keyed `jibe`/`icims`
+adapters and the host/site-keyed `oracle` adapter — with Microsoft as its first configured
+board.
+
+## What Changes
+
+- Add an `eightfold` source adapter (`internal/sources/eightfold.go`) speaking the existing
+  `Source` interface, registered with one `NewEightfold(c)` line in `sources.All`.
+- It is a **board-based** adapter (NOT boardless). Eightfold needs two values — the public
+  host (for request paths) and the required `domain` query parameter (the tenant key) — so the
+  board id is `"host/domain"`, e.g. `"apply.careers.microsoft.com/microsoft.com"`, parsed the
+  same way `oracle` splits `"host/site"`.
+- List via `GET /api/pcsx/search`, paging by `start` (page size fixed at 10 by the server)
+  until a page yields no positions or the running count reaches `data.count`. The list omits
+  the description, so each position's detail is fetched (bounded concurrent fan-out via the
+  shared `fetchDetails`) for the `job_description` HTML.
+- Each posting maps to the normalized job shape: `external_id` = Eightfold's numeric position
+  id; `url` = the detail's `canonicalPositionUrl` (falling back to
+  `https://<host>/careers/job/<id>`); `title`, `location` (first of the list `locations`), and
+  `posted_at` (from the list `postedTs` Unix-epoch) from the list; `work_mode` from the list
+  `workLocationOption` via the existing `workplaceTypeMode` helper; `description` = sanitized
+  HTML from the detail's `job_description`.
+- Add a `sources/eightfold.yml` board file with the Microsoft entry.
+- Regenerate the web TS contracts (`make gen-contracts`): `eightfold` is a non-boardless
+  provider, so `sources.FilterableProviders()` adds it to `SOURCE_VALUES` automatically.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. Reuses the source-ingest pipeline and write path unchanged. -->
+
+### Modified Capabilities
+- `source-ingest`: add a requirement that `eightfold` is a registered board-based provider — a
+  list+detail adapter over the Eightfold `/api/pcsx/search` and `/api/apply/v2/jobs/<id>`
+  endpoints, keyed by a `"host/domain"` board, yielding the normalized job shape with a
+  sanitized-HTML description and paging until the catalogue is exhausted.
+
+## Impact
+
+- **New code**: `internal/sources/eightfold.go` + `internal/sources/eightfold_test.go`; one
+  registration line in `internal/sources/source.go` (`sources.All`).
+- **Config**: a new `sources/eightfold.yml` board file (Microsoft entry). No new env vars.
+- **DB**: none — reuses `UpsertJob` (`source = "eightfold"`, namespaced `external_id`). No
+  migration.
+- **Contracts**: `web/src/lib/generated/contracts.ts` regenerated (adds `eightfold` to
+  `SOURCE_VALUES`).
+- **Dependencies**: none — uses the existing shared `HTTPClient.GetJSON`, `fetchDetails`,
+  `workplaceTypeMode`, `parseEpochSeconds`, and `sanitizeHTML`.
+- **Deploy**: the adapter compiles into the existing ingest binary, so a new adapter needs an
+  image rebuild + redeploy (not just a sources rsync) to run in prod, plus a cron schedule for
+  the new board file.
+- **Out of scope (known seams)**: the `/api/pcsx/search` list omits the description, so the
+  crawl costs one detail request per posting (≈1 list page + N details), the same cost profile
+  as `oracle`/`icims`. No work-site filter param is used — the crawl walks the whole catalogue
+  (empty query). Other Eightfold tenants are added later as more `sources/eightfold.yml`
+  entries, no code change.

--- a/openspec/changes/eightfold-source/proposal.md
+++ b/openspec/changes/eightfold-source/proposal.md
@@ -24,17 +24,24 @@ board.
   host (for request paths) and the required `domain` query parameter (the tenant key) — so the
   board id is `"host/domain"`, e.g. `"apply.careers.microsoft.com/microsoft.com"`, parsed the
   same way `oracle` splits `"host/site"`.
-- List via `GET /api/pcsx/search`, paging by `start` (page size fixed at 10 by the server)
-  until a page yields no positions or the running count reaches `data.count`. The list omits
-  the description, so each position's detail is fetched (bounded concurrent fan-out via the
-  shared `fetchDetails`) for the `job_description` HTML.
+- Eightfold has **two list-API generations** and a tenant supports exactly one (the other
+  returns `403`): the newer `GET /api/pcsx/search` (positions under `data`, `postedTs` date —
+  e.g. Microsoft, Micron) and the legacy `GET /api/apply/v2/jobs` (top-level positions,
+  `t_create` date — e.g. Netflix). The adapter **auto-detects**: it tries the pcsx list and, on
+  error, falls back to the v2 list, so a board is just `host/domain` for either generation. The
+  detail endpoint `/api/apply/v2/jobs/<id>` is shared by both.
+- List paging is by `start` (page size fixed at 10 by the server) until a page yields no
+  positions or the running count reaches the catalogue total. The list omits the description,
+  so each position's detail is fetched (bounded concurrent fan-out via the shared
+  `fetchDetails`) for the `job_description` HTML.
 - Each posting maps to the normalized job shape: `external_id` = Eightfold's numeric position
   id; `url` = the detail's `canonicalPositionUrl` (falling back to
   `https://<host>/careers/job/<id>`); `title`, `location` (first of the list `locations`), and
   `posted_at` (from the list `postedTs` Unix-epoch) from the list; `work_mode` from the list
   `workLocationOption` via the existing `workplaceTypeMode` helper; `description` = sanitized
   HTML from the detail's `job_description`.
-- Add a `sources/eightfold.yml` board file with the Microsoft entry.
+- Add a `sources/eightfold.yml` board file (Microsoft, Micron on pcsx; Netflix on the legacy
+  list).
 - Regenerate the web TS contracts (`make gen-contracts`): `eightfold` is a non-boardless
   provider, so `sources.FilterableProviders()` adds it to `SOURCE_VALUES` automatically.
 
@@ -53,7 +60,8 @@ board.
 
 - **New code**: `internal/sources/eightfold.go` + `internal/sources/eightfold_test.go`; one
   registration line in `internal/sources/source.go` (`sources.All`).
-- **Config**: a new `sources/eightfold.yml` board file (Microsoft entry). No new env vars.
+- **Config**: a new `sources/eightfold.yml` board file (Microsoft, Micron, Netflix). No new env
+  vars.
 - **DB**: none — reuses `UpsertJob` (`source = "eightfold"`, namespaced `external_id`). No
   migration.
 - **Contracts**: `web/src/lib/generated/contracts.ts` regenerated (adds `eightfold` to

--- a/openspec/changes/eightfold-source/specs/source-ingest/spec.md
+++ b/openspec/changes/eightfold-source/specs/source-ingest/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Eightfold is a registered provider
+
+The system SHALL register an `eightfold` adapter so an Eightfold-hosted careers catalogue
+(e.g. Microsoft's `apply.careers.microsoft.com`) can be listed in a `sources/*.yml` board
+file. The adapter SHALL be **board-based** (not boardless): its board id SHALL be
+`"host/domain"` — the public host used for request paths and the required `domain` query
+parameter (the Eightfold tenant key) — and the adapter SHALL reject a board missing either
+half. It SHALL fetch postings over the shared `HTTPClient` from two public GET-JSON endpoints:
+the position list `GET https://<host>/api/pcsx/search?domain=<domain>&query=&start=<n>&num=10`
+and, because that list omits the description, each position's detail
+`GET https://<host>/api/apply/v2/jobs/<id>?domain=<domain>`. The adapter SHALL yield the
+normalized job shape (at least title, url, location, description, and the platform's native
+posting id), with `external_id` set to the position's numeric id, `url` set to the detail's
+`canonicalPositionUrl` (falling back to `https://<host>/careers/job/<id>`), `description` as
+sanitized HTML from the detail's `job_description`, `posted_at` from the list position's
+Unix-epoch `postedTs`, and `work_mode` derived from the list position's `workLocationOption`.
+
+#### Scenario: Eightfold catalogue is crawled page by page
+
+- **WHEN** a `sources/*.yml` board lists provider `eightfold` with board `"host/domain"`
+- **THEN** the adapter requests
+  `https://<host>/api/pcsx/search?domain=<domain>&query=&start=0&num=10&sort_by=relevance`,
+  reads `data.positions`, advances `start` by the number of positions returned, and continues
+  until a page yields no positions or the running yielded count reaches `data.count`
+
+#### Scenario: Job is assembled from the list position and its detail
+
+- **WHEN** a position from `/api/pcsx/search` is processed
+- **THEN** the adapter requests that position's `/api/apply/v2/jobs/<id>?domain=<domain>` detail
+  and yields a job whose `external_id` is the position's numeric id, whose `title`, `location`
+  (first of the position's `locations`), `posted_at` (from `postedTs`), and `work_mode` (from
+  `workLocationOption`) come from the list position, whose `url` is the detail's
+  `canonicalPositionUrl` (or `https://<host>/careers/job/<id>` when that is absent), and whose
+  `description` is sanitized HTML from the detail's `job_description`
+
+#### Scenario: A failed detail request drops only that posting
+
+- **WHEN** one position's detail request fails while crawling a board
+- **THEN** the adapter skips that single posting and still yields the remaining postings,
+  without aborting the board
+
+#### Scenario: A board missing the host or domain half is rejected
+
+- **WHEN** an `eightfold` board id is not of the form `"host/domain"` (no `/`, or an empty host
+  or domain)
+- **THEN** `Fetch` returns an error rather than issuing a malformed request

--- a/openspec/changes/eightfold-source/specs/source-ingest/spec.md
+++ b/openspec/changes/eightfold-source/specs/source-ingest/spec.md
@@ -7,10 +7,13 @@ The system SHALL register an `eightfold` adapter so an Eightfold-hosted careers 
 file. The adapter SHALL be **board-based** (not boardless): its board id SHALL be
 `"host/domain"` — the public host used for request paths and the required `domain` query
 parameter (the Eightfold tenant key) — and the adapter SHALL reject a board missing either
-half. It SHALL fetch postings over the shared `HTTPClient` from two public GET-JSON endpoints:
-the position list `GET https://<host>/api/pcsx/search?domain=<domain>&query=&start=<n>&num=10`
-and, because that list omits the description, each position's detail
-`GET https://<host>/api/apply/v2/jobs/<id>?domain=<domain>`. The adapter SHALL yield the
+half. It SHALL fetch postings over the shared `HTTPClient`. Because Eightfold runs two list-API
+generations and a tenant supports exactly one, the adapter SHALL auto-detect: it SHALL try the
+newer position list `GET https://<host>/api/pcsx/search?domain=<domain>&query=&start=<n>&num=10`
+and, if that fails, fall back to the legacy list
+`GET https://<host>/api/apply/v2/jobs?domain=<domain>&query=&start=<n>&num=10`. Because the list
+omits the description, the adapter SHALL fetch each position's detail
+`GET https://<host>/api/apply/v2/jobs/<id>?domain=<domain>` (shared by both generations). The adapter SHALL yield the
 normalized job shape (at least title, url, location, description, and the platform's native
 posting id), with `external_id` set to the position's numeric id, `url` set to the detail's
 `canonicalPositionUrl` (falling back to `https://<host>/careers/job/<id>`), `description` as
@@ -34,6 +37,14 @@ Unix-epoch `postedTs`, and `work_mode` derived from the list position's `workLoc
   `workLocationOption`) come from the list position, whose `url` is the detail's
   `canonicalPositionUrl` (or `https://<host>/careers/job/<id>` when that is absent), and whose
   `description` is sanitized HTML from the detail's `job_description`
+
+#### Scenario: A legacy tenant falls back to the v2 list
+
+- **WHEN** a board's `/api/pcsx/search` request fails (a legacy tenant returns `403`)
+- **THEN** the adapter falls back to `GET https://<host>/api/apply/v2/jobs?domain=<domain>&…`,
+  reads the top-level `positions`/`count`, and maps each position (taking `posted_at` from
+  `t_create`, `location` from the single-string `location` field, and `work_mode` from
+  `work_location_option`) — yielding the same normalized job shape as the pcsx generation
 
 #### Scenario: A failed detail request drops only that posting
 

--- a/openspec/changes/eightfold-source/tasks.md
+++ b/openspec/changes/eightfold-source/tasks.md
@@ -23,7 +23,12 @@
   bodies, asserting all positions are yielded once, the loop stops, and a detail-fetch failure
   drops only that one posting.
 - [x] 3.2 Register `NewEightfold(c)` in `sources.All` and add the `sources/eightfold.yml` board
-  file with the Microsoft entry (`board: "apply.careers.microsoft.com/microsoft.com"`).
+  file (Microsoft + Micron on pcsx; Netflix on the legacy list).
+- [x] 3.3 (RED→GREEN) Support the legacy `/api/apply/v2/jobs` list generation with auto-detect:
+  `listPositions` tries pcsx, then falls back to the v2 list (top-level positions/count,
+  `t_create` date, single-string `location`, `work_location_option`). One `eightfoldPosition`
+  decodes both field-name variants; the detail endpoint is shared. Test the fallback with a fake
+  serving no pcsx route + a v2 list, asserting the v2 fields map correctly.
 
 ## 4. Quality & integration
 

--- a/openspec/changes/eightfold-source/tasks.md
+++ b/openspec/changes/eightfold-source/tasks.md
@@ -1,0 +1,34 @@
+## 1. Board parsing
+
+- [x] 1.1 (RED→GREEN) Implement `parseEightfoldBoard("host/domain")` returning the host and
+  domain, erroring on a board missing either half. Test a valid board, a board with no `/`, and
+  a board with an empty half.
+
+## 2. Job mapping (list + detail)
+
+- [x] 2.1 (RED→GREEN) Map a list position plus its detail to the normalized `Job` (in the
+  `detail` method): `external_id` = numeric id stringified, `url` = `canonicalPositionUrl` else
+  `https://<host>/careers/job/<id>`, `title`, `location` (first of `locations`), `work_mode` via
+  `workplaceTypeMode(workLocationOption)`, `posted_at` via `parseEpochSeconds(postedTs)`,
+  `description` = `sanitizeHTML(job_description)`. Test the full mapping field by field against
+  canned JSON, including the URL fallback when `canonicalPositionUrl` is empty and a nil date
+  when `postedTs` is zero.
+
+## 3. Adapter, paging & detail fan-out
+
+- [x] 3.1 (RED→GREEN) Implement the `eightfold` adapter type, `NewEightfold`, `Provider()`, and
+  `Fetch`: parse the board, page `/api/pcsx/search` by `start` (stop on empty page or running
+  count ≥ `data.count`), then fetch each position's detail via `fetchDetails`. Test `Fetch`
+  with a fake `JSONGetter` serving a page-1 fixture then an empty page plus per-id detail
+  bodies, asserting all positions are yielded once, the loop stops, and a detail-fetch failure
+  drops only that one posting.
+- [x] 3.2 Register `NewEightfold(c)` in `sources.All` and add the `sources/eightfold.yml` board
+  file with the Microsoft entry (`board: "apply.careers.microsoft.com/microsoft.com"`).
+
+## 4. Quality & integration
+
+- [x] 4.1 `simplify` pass over the diff, then `go build ./... && go vet ./... && go test
+  ./internal/sources/` green; `make gen-contracts` and commit the regenerated
+  `web/src/lib/generated/contracts.ts` (adds `eightfold` to `SOURCE_VALUES`).
+- [x] 4.2 Live smoke: a one-off `Fetch` against the real Microsoft board confirms real jobs are
+  returned and mapped sanely (title, url, location, non-empty description, dated).

--- a/sources/eightfold.yml
+++ b/sources/eightfold.yml
@@ -1,8 +1,14 @@
 # eightfold (Eightfold AI) career sites. Provider is the filename; board =
 # "<host>/<domain>" (see internal/sources/eightfold.go), where host paths the
 # public API and domain is the Eightfold tenant key required as a query parameter,
-# e.g. apply.careers.microsoft.com/microsoft.com. Each board validated live
-# (/api/pcsx/search returned >0 positions) before adding.
+# e.g. apply.careers.microsoft.com/microsoft.com. The adapter auto-detects the
+# list-API generation (newer /api/pcsx/search vs legacy /api/apply/v2/jobs), so a
+# board is just host/domain either way. Each board validated live (one of the two
+# list endpoints returned >0 positions) before adding.
 
 - company: Microsoft
   board: apply.careers.microsoft.com/microsoft.com
+- company: Micron
+  board: careers.micron.com/micron.com
+- company: Netflix
+  board: explore.jobs.netflix.net/netflix.com

--- a/sources/eightfold.yml
+++ b/sources/eightfold.yml
@@ -1,0 +1,8 @@
+# eightfold (Eightfold AI) career sites. Provider is the filename; board =
+# "<host>/<domain>" (see internal/sources/eightfold.go), where host paths the
+# public API and domain is the Eightfold tenant key required as a query parameter,
+# e.g. apply.careers.microsoft.com/microsoft.com. Each board validated live
+# (/api/pcsx/search returned >0 positions) before adding.
+
+- company: Microsoft
+  board: apply.careers.microsoft.com/microsoft.com

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -105,7 +105,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'bamboohr', 'breezy', 'gem', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jobstash', 'join', 'lever', 'oracle', 'personio', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'workable', 'workday'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'eightfold', 'gem', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jibe', 'jobstash', 'join', 'lever', 'oracle', 'personio', 'phenom', 'pinpoint', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'workable', 'workday'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## Summary

- New `eightfold` source adapter (`internal/sources/eightfold.go`) for **Eightfold AI**, a multi-tenant ATS. First configured board is **Microsoft** (`apply.careers.microsoft.com`, ~1388 open positions).
- Board-based (NOT boardless), modeled on `oracle`: board id is `"host/domain"` (e.g. `apply.careers.microsoft.com/microsoft.com`) — host paths requests, domain is the required Eightfold tenant query param.
- **List** `GET /api/pcsx/search?domain=…&start=…&num=10` (server caps page at 10 → `start` is the only pager; the higher-level `/api/apply/v2/jobs` list returns `403 PCSX`); **detail** `GET /api/apply/v2/jobs/<id>?domain=…` carries the `job_description` HTML + `canonicalPositionUrl` the list omits, fetched per position via the shared bounded `fetchDetails`.
- Mapping: `external_id`=numeric id; `url`=`canonicalPositionUrl` (fallback `https://<host>/careers/job/<id>`); `location`=first of `locations`; `work_mode` via `workplaceTypeMode(workLocationOption)`; `posted_at` via `parseEpochSeconds(postedTs)`; `description`=`sanitizeHTML(job_description)`.
- One registration line in `sources.All`, a `sources/eightfold.yml` board file, and regenerated `web/src/lib/generated/contracts.ts`.
- Planned/tracked under OpenSpec `openspec/changes/eightfold-source/`.

> Note: the contracts regen adds **four** `SOURCE_VALUES` (`eightfold`, plus `jibe`/`phenom`/`ashbygraphql` which were registered earlier but missing from the committed contracts) — the generated file was stale on `main`; regen reflects the real registry.

## Test Plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` green; 6 fixture-backed unit tests cover board parsing, full field-by-field mapping, `start` pagination (stops on empty page), `count`-based stop, detail-failure isolation (one bad detail drops only that posting), URL fallback, and `postedTs=0`→nil date
- [x] Live smoke against the real Microsoft board: `count=1388`, real jobs mapped sanely (title, url, location, work-mode, dated, 6k+ char descriptions)

## Deploy

New adapter compiles into the ingest binary → needs an **image rebuild + redeploy** (not a sources rsync) and a cron schedule for `sources/eightfold.yml`.