### PR TITLE
fix(web): commit filters via goto so back/forward keeps them

### DIFF
--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -13,9 +13,11 @@
   import JobRow from './JobRow.svelte';
   import LoadMore from './LoadMore.svelte';
 
-  // The first page is server-rendered (route `load`) and arrives as `initial`,
-  // so the rows are in the initial HTML. Filters live in the URL; the list is
-  // driven by the search endpoint (an empty query browses everything).
+  // Filters live in the URL; the route `load` searches by them and returns the
+  // first page as `initial`, so the rows are in the initial HTML. Each filter
+  // change is a real navigation (FilterStore commits via goto), which re-runs
+  // `load` and delivers a fresh `initial` here; "load more" then pages the rest
+  // client-side over the same filters.
   //
   // `scope` pins extra search params that the user can't change (e.g. the company
   // page passes `{ company_slug }`): they're merged into every search but kept out
@@ -66,41 +68,42 @@
   };
 
   let drawerOpen = $state(false);
-  let started = false;
-  let timer: ReturnType<typeof setTimeout>;
+  let primed = false;
 
   // For a signed-in user, load the set of already-viewed slugs so JobRow can dim
-  // seen cards (no-op when signed out — the set stays empty). Cleanup: a debounce
-  // timer left running after unmount would start a fetch for a gone component.
+  // seen cards (no-op when signed out — the set stays empty). Cleanup: cancel any
+  // debounced filter navigation so it can't fire after this view is gone.
   onMount(() => {
     if (isAuthenticated()) ensureViewedLoaded();
-    refreshCounts();
-    return () => clearTimeout(timer);
+    return () => filters.dispose();
   });
 
-  // Browser back/forward changes the URL query — pull it back into the filters.
-  // Track only the URL: syncFromUrl reads filters.value internally, so without
-  // untrack this effect would also fire on our own setQuery/#commit writes and
-  // clobber the just-typed value against a not-yet-updated page.url.
+  // Keep the panel synced with the URL and refresh its facet counts. Runs on
+  // mount and on every URL change — a filter commit (goto) or browser
+  // back/forward. Track only the URL: syncFromUrl reads filters.value internally,
+  // so untrack stops this from looping on its own write. It's a no-op when
+  // already in sync (our own commits) and re-seeds the panel on back/forward;
+  // either way the counts refresh for the new filters.
   $effect(() => {
     page.url.search; // track
-    untrack(() => filters.syncFromUrl());
+    untrack(() => {
+      filters.syncFromUrl();
+      refreshCounts();
+    });
   });
 
-  // Re-run the search when any filter changes, debounced. The first effect run
-  // is the initial mount, already server-rendered/seeded, so skip it.
+  // The list mirrors the route `load`: each filter change navigates and re-runs
+  // it, so a fresh `initial` arrives as this prop — reseed a paginator from it.
+  // The first run is the server-rendered page already seeded above, so skip it.
   $effect(() => {
-    filtersToParams(filters.value).toString(); // track every filter field
-    if (!started) {
-      started = true;
+    const slice = initial; // track the prop
+    if (!primed) {
+      primed = true;
       return;
     }
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      jobs = makePaginator();
-      jobs.start();
-      refreshCounts();
-    }, 300);
+    const next = makePaginator();
+    next.seed(slice);
+    jobs = next;
   });
 </script>
 

--- a/web/src/lib/filters.svelte.ts
+++ b/web/src/lib/filters.svelte.ts
@@ -5,7 +5,7 @@
 // `<param>_mode=and` conventions.
 
 import { page } from '$app/state';
-import { replaceState } from '$app/navigation';
+import { goto } from '$app/navigation';
 import { FACETS } from './facets';
 
 /** One facet's selection: the chosen values, whether it filters by inclusion or
@@ -112,6 +112,12 @@ export function canonicalQuery(query: string): string {
 export class FilterStore {
   value = $state<JobFilters>(emptyFilters());
 
+  // Debounce handle for the continuous inputs (free-text query, salary slider),
+  // which fire on every keystroke / drag tick. Their URL commit — a real
+  // navigation that re-runs `load` — is coalesced so typing doesn't round-trip
+  // per character; `value` still updates synchronously so the input stays live.
+  #navTimer: ReturnType<typeof setTimeout> | undefined;
+
   /** Seed from the current URL params (passed by the view from `page.url`), so
    *  the same filters render on the server and hydrate on the client. */
   constructor(initial?: URLSearchParams) {
@@ -128,7 +134,7 @@ export class FilterStore {
 
   setQuery(q: string) {
     this.value = { ...this.value, q };
-    this.#commit();
+    this.#commitSoon();
   }
 
   setVisa(on: boolean) {
@@ -138,7 +144,7 @@ export class FilterStore {
 
   setSalaryMin(n: number | null) {
     this.value = { ...this.value, salaryMin: n };
-    this.#commit();
+    this.#commitSoon();
   }
 
   setSort(sort: SortField) {
@@ -196,11 +202,17 @@ export class FilterStore {
 
   /** Re-read filters from the current URL (browser back/forward). No-op when
    *  already in sync, which also breaks the write-back loop after our own
-   *  setQuery. */
+   *  commit. */
   syncFromUrl() {
     const current = page.url.searchParams;
     if (current.toString() === filtersToParams(this.value).toString()) return;
     this.value = filtersFromParams(current);
+  }
+
+  /** Cancel any pending debounced navigation — call from the owning view's
+   *  cleanup so a late commit can't navigate after unmount. */
+  dispose() {
+    clearTimeout(this.#navTimer);
   }
 
   #setFacet(param: string, st: FacetState) {
@@ -208,13 +220,24 @@ export class FilterStore {
     this.#commit();
   }
 
-  /** Mirror the current filters into the URL in place — `replaceState` updates
-   *  the address bar and history without re-running `load`, so toggling a facet
-   *  doesn't round-trip to the server; the view re-searches reactively. Called
-   *  synchronously from each mutation (never a separate effect) so a controlled
-   *  input never reverts mid-keystroke. Browser-only (mutations are user events). */
+  /** Mirror the current filters into the URL via a real navigation. `goto` (not
+   *  the shallow `replaceState`) registers the change with the router, so the URL
+   *  and its `load`-produced results are stored on the history entry and restored
+   *  correctly on browser back/forward — shallow routing leaves `page.url` (and
+   *  thus `load`) stale on a back navigation. `replaceState: true` updates in
+   *  place (no per-tweak history entry); `keepFocus`/`noScroll` keep the page
+   *  steady. The route `load` re-runs for the new query and drives the list.
+   *  Browser-only (mutations are user events). */
   #commit() {
+    clearTimeout(this.#navTimer); // a pending debounced nav is now subsumed
     const qs = filtersToParams(this.value).toString();
-    replaceState(page.url.pathname + (qs ? `?${qs}` : ''), {});
+    goto(page.url.pathname + (qs ? `?${qs}` : ''), { replaceState: true, keepFocus: true, noScroll: true });
+  }
+
+  /** Debounced #commit for the continuous inputs, so each keystroke / slider tick
+   *  doesn't trigger its own navigation + `load`. */
+  #commitSoon() {
+    clearTimeout(this.#navTimer);
+    this.#navTimer = setTimeout(() => this.#commit(), 300);
   }
 }


### PR DESCRIPTION
## Problem

On `/jobs`, applying a filter via the UI, opening a job, then pressing browser **Back** left `?regions=global` in the address bar but the filter **not applied**: `FilterStore` empty, no "Reset all", and the list showed the full catalogue instead of the filtered count.

## Root cause

`FilterStore.#commit` mirrored filters into the URL with **`replaceState`** from `$app/navigation` (shallow routing). Shallow routing is for state `load` doesn't depend on; it doesn't register a real navigation. On Back, SvelteKit restores the history entry from a snapshot taken **before** the `replaceState`, so `page.url` and the `load` `url` drop the query while the browser keeps it in the address bar → URL right, app state empty. Direct loads of `/jobs?regions=global` (real navigations) were never affected — only the click-to-apply path.

## Fix

- `filters.svelte.ts`: `#commit` now uses `goto(url, { replaceState: true, keepFocus: true, noScroll: true })` — a real navigation, so the URL and its `load` results live on the history entry and restore on back/forward. Continuous inputs (text query, salary slider) debounce the commit (`#commitSoon`, 300ms) so typing/dragging doesn't re-run `load` per tick; `dispose()` clears the timer on unmount.
- `JobsView.svelte`: drops the client reactive double-search. The list is driven by the route `load`'s `data.initial`, reseeded on each URL change; facet counts refresh on `page.url` change. URL = single source of truth, `load` = single source of the list.

## Verification

Live-tested with a clean browser session against a local `npm run dev` pointed at the prod API:

| Scenario | Before | After |
|---|---|---|
| apply Global → open job → Back | 853k jobs, filter lost | **1,429 jobs, filter kept** |
| facet change (+Senior) | — | 142 jobs from `load` |
| text search `golang` (debounced) | — | 3,261 jobs, `?q=golang` |
| back/forward, console errors | — | works, 0 errors |

`svelte-check`: 0 errors, 0 warnings.