### PR TITLE
fix+feat(sources): eightfold rate-limit backoff + 48 verified tenant boards

### DIFF
--- a/internal/sources/eightfold.go
+++ b/internal/sources/eightfold.go
@@ -5,11 +5,25 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // eightfoldPageLimit is the position-list page size. The Eightfold server caps a page at 10
 // regardless of the requested num, so this is fixed and start is the only pagination lever.
 const eightfoldPageLimit = 10
+
+// eightfoldDetailWorkers bounds the per-board detail fan-out. Eightfold rate-limits an IP to
+// ~290 requests per window (returning 403), so the detail crawl uses a low concurrency — far
+// below the shared defaultDetailWorkers — to keep the burst gentle and lean on backoff retry
+// (getJSONRetrying) for the rest, rather than slamming the cap and dropping postings.
+const eightfoldDetailWorkers = 2
+
+// eightfoldMaxRetries bounds how many times a rate-limited (403/429) request is retried before
+// giving up. eightfoldRetryBase is the first backoff delay (doubled each attempt, capped); it
+// is a var so tests can set it to 0 and not sleep.
+const eightfoldMaxRetries = 6
+
+var eightfoldRetryBase = time.Second
 
 // eightfold adapts Eightfold AI career sites (e.g. apply.careers.microsoft.com). Both
 // endpoints are public GET JSON. Two list-API generations exist and a tenant supports exactly
@@ -88,9 +102,43 @@ func (s eightfold) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, err
 	}
 
-	return fetchDetails(positions, defaultDetailWorkers, func(p eightfoldPosition) (Job, bool) {
+	return fetchDetails(positions, eightfoldDetailWorkers, func(p eightfoldPosition) (Job, bool) {
 		return s.detail(ctx, e, b, p)
 	}), nil
+}
+
+// getJSONRetrying GETs url, retrying rate-limit responses (403/429) with exponential backoff
+// so the crawl rides out Eightfold's per-IP request cap (~290/window) instead of dropping the
+// postings beyond it. The shared client already retries 429/5xx/network; this adds 403, which
+// Eightfold returns for rate-limiting (not auth) here, and longer waits to clear a full window.
+// A non-rate-limit error (e.g. 404) returns immediately so retry stays scoped.
+func (s eightfold) getJSONRetrying(ctx context.Context, url string, v any) error {
+	delay := eightfoldRetryBase
+	var err error
+	for attempt := 0; attempt <= eightfoldMaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(delay):
+			}
+			if delay < 30*time.Second {
+				delay *= 2
+			}
+		}
+		if err = s.http.GetJSON(ctx, url, v); err == nil || !isRateLimited(err) {
+			return err
+		}
+	}
+	return err
+}
+
+// isRateLimited reports whether err is an Eightfold rate-limit response (HTTP 403 or 429). The
+// shared client formats a status failure as "... status <code>", so the code is matched in the
+// error text — the client does not surface the status any other way.
+func isRateLimited(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "status 403") || strings.Contains(msg, "status 429")
 }
 
 // listPositions returns the board's positions, auto-detecting the list-API generation: it
@@ -139,7 +187,7 @@ func (s eightfold) pcsxPage(ctx context.Context, b eightfoldBoard, start int) ([
 		"https://%s/api/pcsx/search?domain=%s&query=&start=%d&num=%d&sort_by=relevance",
 		b.host, b.domain, start, eightfoldPageLimit)
 	var resp pcsxListResponse
-	if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+	if err := s.getJSONRetrying(ctx, url, &resp); err != nil {
 		return nil, 0, err
 	}
 	return resp.Data.Positions, resp.Data.Count, nil
@@ -151,7 +199,7 @@ func (s eightfold) v2Page(ctx context.Context, b eightfoldBoard, start int) ([]e
 		"https://%s/api/apply/v2/jobs?domain=%s&query=&start=%d&num=%d&sort_by=relevance",
 		b.host, b.domain, start, eightfoldPageLimit)
 	var resp v2ListResponse
-	if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+	if err := s.getJSONRetrying(ctx, url, &resp); err != nil {
 		return nil, 0, err
 	}
 	return resp.Positions, resp.Count, nil
@@ -165,7 +213,7 @@ func (s eightfold) detail(ctx context.Context, e CompanyEntry, b eightfoldBoard,
 	id := strconv.FormatInt(p.ID, 10)
 	url := fmt.Sprintf("https://%s/api/apply/v2/jobs/%s?domain=%s", b.host, id, b.domain)
 	var d eightfoldDetail
-	if err := s.http.GetJSON(ctx, url, &d); err != nil {
+	if err := s.getJSONRetrying(ctx, url, &d); err != nil {
 		return Job{}, false
 	}
 

--- a/internal/sources/eightfold_test.go
+++ b/internal/sources/eightfold_test.go
@@ -2,10 +2,83 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 )
+
+// rateLimitedHTTP serves the pcsx list, then fails detail GETs with failErr for the first
+// detailFails attempts before serving detail — mimicking Eightfold's ~290-requests/window
+// per-IP cap (a 403). detailCalls counts detail attempts so a test can assert retry behaviour.
+type rateLimitedHTTP struct {
+	mu          sync.Mutex
+	list        string
+	detail      string
+	failErr     string
+	detailFails int
+	detailCalls int
+}
+
+func (r *rateLimitedHTTP) GetJSON(_ context.Context, url string, v any) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if strings.Contains(url, "/api/pcsx/search") {
+		return json.Unmarshal([]byte(r.list), v)
+	}
+	r.detailCalls++
+	if r.detailFails > 0 {
+		r.detailFails--
+		return fmt.Errorf("sources: GET %s: %s", url, r.failErr)
+	}
+	return json.Unmarshal([]byte(r.detail), v)
+}
+
+// TestEightfoldRetriesRateLimitedDetail verifies a rate-limit (403) detail response is retried
+// with backoff rather than dropped, so the catalogue is not capped at the per-window limit.
+func TestEightfoldRetriesRateLimitedDetail(t *testing.T) {
+	eightfoldRetryBase = 0 // no real sleeping in tests
+	fake := &rateLimitedHTTP{
+		list:        eightfoldList(1, `{"id": 111, "name": "Role", "locations": ["Remote"]}`),
+		detail:      `{"id": 111, "job_description": "<p>desc</p>"}`,
+		failErr:     "status 403",
+		detailFails: 3,
+	}
+	jobs, err := NewEightfold(fake).Fetch(context.Background(), eightfoldEntry)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (a rate-limited detail must retry past the 403)", len(jobs))
+	}
+	if fake.detailCalls != 4 {
+		t.Errorf("detailCalls = %d, want 4 (3 retries then success)", fake.detailCalls)
+	}
+}
+
+// TestEightfoldDoesNotRetryNonRateLimitError verifies a non-rate-limit failure (e.g. 404) is
+// dropped immediately, so retry stays scoped to the rate-limit case.
+func TestEightfoldDoesNotRetryNonRateLimitError(t *testing.T) {
+	eightfoldRetryBase = 0
+	fake := &rateLimitedHTTP{
+		list:        eightfoldList(1, `{"id": 222, "name": "Gone", "locations": ["Remote"]}`),
+		detail:      `{}`,
+		failErr:     "status 404",
+		detailFails: 99,
+	}
+	jobs, err := NewEightfold(fake).Fetch(context.Background(), eightfoldEntry)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("len(jobs) = %d, want 0 (a 404 detail is dropped)", len(jobs))
+	}
+	if fake.detailCalls != 1 {
+		t.Errorf("detailCalls = %d, want 1 (a 404 must not be retried)", fake.detailCalls)
+	}
+}
 
 // eightfoldEntry is the shared configured board for the Fetch tests.
 var eightfoldEntry = CompanyEntry{

--- a/sources/eightfold.yml
+++ b/sources/eightfold.yml
@@ -3,12 +3,113 @@
 # public API and domain is the Eightfold tenant key required as a query parameter,
 # e.g. apply.careers.microsoft.com/microsoft.com. The adapter auto-detects the
 # list-API generation (newer /api/pcsx/search vs legacy /api/apply/v2/jobs), so a
-# board is just host/domain either way. Each board validated live (one of the two
-# list endpoints returned >0 positions) before adding.
+# board is just host/domain either way, and rides out Eightfold's per-IP rate limit
+# with backoff. Each board validated live (one of the two list endpoints returned
+# >0 positions) before adding.
+#
+# NOTE: domain is NOT always the registrable domain — configure it per board, do not
+# derive it (e.g. Match Group → gotinder.com, Keurig Dr Pepper → kdrp.com). Where a
+# tenant has alias hosts, the named/custom host is listed.
 
-- company: Microsoft
-  board: apply.careers.microsoft.com/microsoft.com
+- company: Starbucks
+  board: apply.starbucks.com/starbucks.com
+- company: Citi
+  board: citi.eightfold.ai/citi.com
 - company: Micron
   board: careers.micron.com/micron.com
+- company: Northrop Grumman
+  board: ngc.eightfold.ai/ngc.com
+- company: NVIDIA
+  board: nvidia.eightfold.ai/nvidia.com
+- company: Eaton
+  board: eaton.eightfold.ai/eaton.com
+- company: Applied Materials
+  board: appliedmaterials.eightfold.ai/appliedmaterials.com
+- company: HSBC
+  board: hsbc.eightfold.ai/hsbc.com
+- company: Qualcomm
+  board: qualcomm.eightfold.ai/qualcomm.com
+- company: Vodafone
+  board: vodafone.eightfold.ai/vodafone.com
+- company: Microsoft
+  board: apply.careers.microsoft.com/microsoft.com
+- company: NTT DATA
+  board: nttdata.eightfold.ai/nttdata.com
+- company: Morgan Stanley
+  board: morganstanley.eightfold.ai/morganstanley.com
+- company: Lam Research
+  board: lamresearch.eightfold.ai/lamresearch.com
+- company: Infineon
+  board: infineon.eightfold.ai/infineon.com
+- company: Estée Lauder
+  board: careers.elcompanies.com/elcompanies.com
+- company: AstraZeneca
+  board: astrazeneca.eightfold.ai/astrazeneca.com
+- company: Bristol Myers Squibb
+  board: bms.eightfold.ai/bms.com
+- company: Bayer
+  board: bayer.eightfold.ai/bayer.com
+- company: HP
+  board: hp.eightfold.ai/hp.com
+- company: GlobalFoundries
+  board: globalfoundries.eightfold.ai/globalfoundries.com
+- company: Keurig Dr Pepper
+  board: kdrp.eightfold.ai/kdrp.com
+- company: Boston Scientific
+  board: bostonscientific.eightfold.ai/bostonscientific.com
+- company: Ford
+  board: ford.eightfold.ai/ford.com
 - company: Netflix
   board: explore.jobs.netflix.net/netflix.com
+- company: STMicroelectronics
+  board: stmicroelectronics.eightfold.ai/stmicroelectronics.com
+- company: Ericsson
+  board: ericsson.eightfold.ai/ericsson.com
+- company: dsm-firmenich
+  board: dsm.eightfold.ai/dsm.com
+- company: SLB
+  board: slb.eightfold.ai/slb.com
+- company: Faurecia
+  board: faurecia.eightfold.ai/faurecia.com
+- company: Dexcom
+  board: dexcom.eightfold.ai/dexcom.com
+- company: Softtek
+  board: softtek.eightfold.ai/softtek.com
+- company: Fortive
+  board: fortive.eightfold.ai/fortive.com
+- company: Liberty Mutual
+  board: libertymutual.eightfold.ai/libertymutual.com
+- company: UKG
+  board: ukg.eightfold.ai/ukg.com
+- company: PayPal
+  board: paypal.eightfold.ai/paypal.com
+- company: John Deere
+  board: johndeere.eightfold.ai/johndeere.com
+- company: Whirlpool
+  board: whirlpool.eightfold.ai/whirlpool.com
+- company: PTC
+  board: ptc.eightfold.ai/ptc.com
+- company: Vizient
+  board: careers.vizientinc.com/vizientinc.com
+- company: Insight Enterprises
+  board: insight.eightfold.ai/insight.com
+- company: Vialto Partners
+  board: vialto.eightfold.ai/vialto.com
+- company: Vale
+  board: vale.eightfold.ai/vale.com
+- company: Dolby
+  board: dolby.eightfold.ai/dolby.com
+- company: Amdocs
+  board: amdocs.eightfold.ai/amdocs.com
+- company: Frontier Communications
+  board: ftr.eightfold.ai/ftr.com
+- company: Deutsche Telekom
+  board: telekom.eightfold.ai/telekom.com
+- company: Match Group
+  board: join.matchgroupcareers.com/gotinder.com
+- company: Coca-Cola Europacific Partners
+  board: ccep.eightfold.ai/ccep.com
+- company: Symetra
+  board: symetra.eightfold.ai/symetra.com
+- company: Albemarle
+  board: albemarle.eightfold.ai/albemarle.com


### PR DESCRIPTION
Builds on #159. Two parts:

## 1. Rate-limit fix (found in prod verification of #159)
Eightfold/CloudFront caps an IP at **~290 requests/window** then returns **403** (the shared client doesn't retry 403), so the N+1 detail crawl silently dropped everything past the cap — catalogues stuck at ~290/board.
- `getJSONRetrying`: exponential backoff (1s→×2→cap 30s, 6 attempts) retrying **only** rate-limit responses (403/429); other errors (e.g. 404) drop immediately.
- Detail fan-out lowered to **2** (`eightfoldDetailWorkers`).

## 2. +48 verified tenant boards
Live-verified Eightfold tenants (200 + count>0 on a list endpoint), ~70k+ open jobs: Starbucks (20k), Citi, NVIDIA, Qualcomm, Morgan Stanley, Northrop Grumman, Eaton, Applied Materials, HSBC, Vodafone, PayPal, Ford, HP, AstraZeneca, Bayer, … `domain` configured per board (not always the registrable domain, e.g. Match Group → gotinder.com).

## Test Plan
- [x] `go build/vet ./...`, `gofmt`, `go test ./...` green
- [x] New unit tests: 403 detail retried past the cap (asserts survival + retry count); 404 dropped without retry. 6 existing eightfold tests green.
- [x] 51-board eightfold.yml validates against the registry.
- [ ] Prod re-verify after deploy: isolated Micron run ingests ≫290 (~3024).

## Deploy
Code change → image rebuild + redeploy; eightfold cron from #159 stays (consider daily given Starbucks ~20k volume).