### PR TITLE
feat(pipeline,sources): incremental save for streaming sources (eightfold)

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -169,6 +169,13 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 		return 0, 1, 0
 	}
 
+	// A streaming adapter persists postings as it crawls, so a long rate-limited board's
+	// progress is saved incrementally (and survives an interrupted run) rather than buffered
+	// until the whole board finishes.
+	if ss, streaming := src.(sources.StreamingSource); streaming {
+		return r.ingestStream(ctx, e, ss)
+	}
+
 	raw, err := src.Fetch(ctx, e)
 	if err != nil {
 		// Log the cause so a failed board is diagnosable (the source error carries
@@ -193,6 +200,44 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 	if skipped > 0 {
 		log.Printf("ingest: %s board %q (%s): skipped %d/%d jobs on save error (e.g. %v)",
 			e.Provider, e.Board, e.Company, skipped, len(raw), firstErr)
+	}
+	return ingested, 0, skipped
+}
+
+// ingestStream drives a streaming board: it persists each posting the adapter emits as it is
+// crawled, so progress is durable mid-run. The emit sink normalizes and saves under a mutex
+// (the adapter may emit concurrently) and tallies the same ingested/skipped counts as the
+// buffered path; a board-level FetchStream error counts the board failed but keeps whatever was
+// already saved (the 48h unseen-sweep guards against a short crawl closing the un-reached tail).
+func (r Runner) ingestStream(ctx context.Context, e sources.CompanyEntry, ss sources.StreamingSource) (ingested, failed, skipped int) {
+	var (
+		mu       sync.Mutex
+		firstErr error
+		total    int
+	)
+	emit := func(j sources.Job) {
+		mu.Lock()
+		defer mu.Unlock()
+		total++
+		if err := r.Store.Save(ctx, normalizeJob(e, j)); err != nil {
+			skipped++
+			if firstErr == nil {
+				firstErr = err
+			}
+			return
+		}
+		ingested++
+	}
+
+	err := ss.FetchStream(ctx, e, emit)
+	if skipped > 0 {
+		log.Printf("ingest: %s board %q (%s): skipped %d/%d jobs on save error (e.g. %v)",
+			e.Provider, e.Board, e.Company, skipped, total, firstErr)
+	}
+	if err != nil {
+		log.Printf("ingest: %s board %q (%s) failed after %d saved: %v",
+			e.Provider, e.Board, e.Company, ingested, err)
+		return ingested, 1, skipped
 	}
 	return ingested, 0, skipped
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -41,12 +41,87 @@ func (f fakeSource) Fetch(context.Context, sources.CompanyEntry) ([]sources.Job,
 	return f.jobs, f.err
 }
 
+// fakeStreamingSource implements sources.StreamingSource: FetchStream emits jobs through the
+// sink, optionally failing after failAfter jobs (-1 = never), so a test can prove the runner
+// persists incrementally and keeps the jobs emitted before a mid-crawl error. Its Fetch returns
+// ALL jobs with no error, so a test that sees a partial/failed result proves the streaming path
+// (not Fetch) was used.
+type fakeStreamingSource struct {
+	provider  string
+	jobs      []sources.Job
+	failAfter int
+}
+
+func (f fakeStreamingSource) Provider() string { return f.provider }
+
+func (f fakeStreamingSource) Fetch(context.Context, sources.CompanyEntry) ([]sources.Job, error) {
+	return f.jobs, nil
+}
+
+func (f fakeStreamingSource) FetchStream(_ context.Context, _ sources.CompanyEntry, emit func(sources.Job)) error {
+	for i, j := range f.jobs {
+		if f.failAfter >= 0 && i >= f.failAfter {
+			return errors.New("stream failed midway")
+		}
+		emit(j)
+	}
+	return nil
+}
+
 func registry(srcs ...sources.Source) map[string]sources.Source {
 	m := make(map[string]sources.Source)
 	for _, s := range srcs {
 		m[s.Provider()] = s
 	}
 	return m
+}
+
+// TestRunStreamsAndPersistsPartialBeforeError proves the runner consumes a StreamingSource via
+// FetchStream and persists each job as it is emitted: when the stream fails mid-crawl, the jobs
+// emitted before the error stay saved (incremental), and the board is counted failed. Via the
+// old Fetch path this source would save all 3 with no failure, so this result is unique to the
+// streaming path.
+func TestRunStreamsAndPersistsPartialBeforeError(t *testing.T) {
+	src := fakeStreamingSource{provider: "eightfold", failAfter: 2, jobs: []sources.Job{
+		{ExternalID: "1", Title: "A", Company: "C", URL: "u"},
+		{ExternalID: "2", Title: "B", Company: "C", URL: "u"},
+		{ExternalID: "3", Title: "D", Company: "C", URL: "u"},
+	}}
+	store := &fakeStore{}
+	r := Runner{Registry: registry(src), Store: store}
+
+	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "C", Provider: "eightfold", Board: "host.example/dom"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.saved) != 2 {
+		t.Fatalf("len(saved) = %d, want 2 (jobs emitted before the error persist)", len(store.saved))
+	}
+	if stats.Total().Ingested != 2 || stats.Total().Failed != 1 {
+		t.Fatalf("stats = %+v, want Ingested=2 Failed=1", stats.Total())
+	}
+}
+
+// TestRunStreamsAllJobs verifies a clean streaming crawl saves every emitted job.
+func TestRunStreamsAllJobs(t *testing.T) {
+	src := fakeStreamingSource{provider: "eightfold", failAfter: -1, jobs: []sources.Job{
+		{ExternalID: "1", Title: "A", Company: "C", URL: "u"},
+		{ExternalID: "2", Title: "B", Company: "C", URL: "u"},
+	}}
+	store := &fakeStore{}
+	r := Runner{Registry: registry(src), Store: store}
+
+	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "C", Provider: "eightfold", Board: "host.example/dom"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.saved) != 2 || stats.Total().Ingested != 2 || stats.Total().Failed != 0 {
+		t.Fatalf("saved=%d stats=%+v, want 2 saved Ingested=2 Failed=0", len(store.saved), stats.Total())
+	}
 }
 
 func TestRunNormalizesAndNamespaces(t *testing.T) {

--- a/internal/sources/eightfold.go
+++ b/internal/sources/eightfold.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -91,20 +92,37 @@ type eightfoldDetail struct {
 	CanonicalPositionURL string `json:"canonicalPositionUrl"`
 }
 
+// Fetch buffers the whole board by collecting the streamed postings. The pipeline prefers
+// FetchStream (incremental save); Fetch stays for non-streaming callers and tests.
 func (s eightfold) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var (
+		mu   sync.Mutex
+		jobs []Job
+	)
+	err := s.FetchStream(ctx, e, func(j Job) {
+		mu.Lock()
+		jobs = append(jobs, j)
+		mu.Unlock()
+	})
+	return jobs, err
+}
+
+// FetchStream lists the board's positions, then fetches each one's detail concurrently and
+// emits the assembled Job the moment its detail completes — so the pipeline persists a long,
+// rate-limited crawl incrementally. A failed detail is dropped (not emitted); only a listing
+// failure is returned as a board-level error.
+func (s eightfold) FetchStream(ctx context.Context, e CompanyEntry, emit func(Job)) error {
 	b, err := parseEightfoldBoard(e.Board)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
 	positions, err := s.listPositions(ctx, b)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return fetchDetails(positions, eightfoldDetailWorkers, func(p eightfoldPosition) (Job, bool) {
-		return s.detail(ctx, e, b, p)
-	}), nil
+	fetchDetailsStream(positions, eightfoldDetailWorkers,
+		func(p eightfoldPosition) (Job, bool) { return s.detail(ctx, e, b, p) }, emit)
+	return nil
 }
 
 // getJSONRetrying GETs url, retrying rate-limit responses (403/429) with exponential backoff

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -51,6 +51,19 @@ type Source interface {
 	Fetch(ctx context.Context, e CompanyEntry) ([]Job, error)
 }
 
+// StreamingSource is a Source that can also stream its postings to a sink as it crawls, so the
+// pipeline persists them incrementally rather than buffering the whole board until Fetch
+// returns. An adapter with an expensive per-posting detail fan-out (eightfold, whose large
+// catalogues take many minutes under the source's rate limit) implements it so a long crawl's
+// progress is saved as it goes — partial work survives an interrupted or rate-limited run, and
+// the catalogue converges across runs. emit is called once per ready posting and may be called
+// concurrently. FetchStream returns an error only for a board-level failure (e.g. the listing
+// failed); a single dropped posting is simply not emitted.
+type StreamingSource interface {
+	Source
+	FetchStream(ctx context.Context, e CompanyEntry, emit func(Job)) error
+}
+
 // boardless marks an adapter whose API has no per-tenant board id, so config
 // validation lets its entries omit board. A boardless adapter may serve one company
 // (greenhouse/lever and the other multi-tenant ATS adapters are NOT boardless and
@@ -177,6 +190,28 @@ func fetchDetails[P any](postings []P, workers int, fetch func(P) (Job, bool)) [
 		}
 	}
 	return out
+}
+
+// fetchDetailsStream maps each posting to a Job via fetch, concurrently with a bounded worker
+// pool, emitting each successful Job to emit as soon as its detail completes (a posting whose
+// fetch returns ok=false is dropped). Unlike fetchDetails it does not buffer or preserve order,
+// so a streaming adapter persists postings incrementally. emit is called from worker goroutines
+// — the caller must make it concurrency-safe. It blocks until every posting has been attempted.
+func fetchDetailsStream[P any](postings []P, workers int, fetch func(P) (Job, bool), emit func(Job)) {
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	for _, p := range postings {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(p P) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if j, ok := fetch(p); ok {
+				emit(j)
+			}
+		}(p)
+	}
+	wg.Wait()
 }
 
 // isRemote infers a job's remote flag from its location text. Adapters share it so


### PR DESCRIPTION
Follow-up to #159/#163. Makes large Eightfold catalogues viable under the per-IP rate limit by persisting postings **as they are crawled** instead of buffering the whole board until `Fetch` returns.

## Why
Eightfold's ~290-req/window rate limit makes big boards very slow (Micron 3k took >24 min; Starbucks 20k ~hours). With the buffered path, nothing lands in the DB until the entire board finishes — an interrupted/rate-limited run lost all progress and large boards never converged.

## What
- New opt-in `sources.StreamingSource` interface: `FetchStream(ctx, e, emit)`. The runner persists each emitted job immediately (under a mutex; the adapter may emit concurrently), tallying the same ingested/skipped stats. A board-level error keeps whatever was already saved (the 48h unseen-sweep guards a short crawl from closing the un-reached tail).
- `eightfold` implements it: list, then emit each posting the moment its detail completes (`fetchDetailsStream`). `Fetch` now buffers via `FetchStream`, so behaviour for non-streaming callers is unchanged.
- All other adapters are untouched (buffered `Fetch` path).

## Effect
Big boards now converge across daily runs — each run durably saves whatever it fetched before the rate limit/clock cut it off, rather than discarding it.

## Test Plan
- [x] `go build/vet ./...`, `gofmt`, `go test ./...` green
- [x] New pipeline tests: streaming source persists incrementally; a mid-crawl error keeps the jobs emitted before it (uniquely the streaming path). eightfold's 8 tests still green (Fetch routes through FetchStream).
- [x] `-race` clean for the new pipeline + eightfold code (pre-existing gem/mts test-fake races are unrelated).
- [ ] Prod re-verify: an isolated Micron run shows the count climbing during the crawl (incremental), not only at the end.

## Deploy
Code change → image rebuild + redeploy.