### PR TITLE
fix(web): dedup facet values from URL (each_key_duplicate crash)

### DIFF
--- a/web/src/lib/filters.svelte.ts
+++ b/web/src/lib/filters.svelte.ts
@@ -77,8 +77,12 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
   const f = emptyFilters();
   f.q = p.get('q') ?? '';
   for (const def of FACETS) {
-    const exclude = p.getAll(`${def.param}_exclude`);
-    const include = p.getAll(def.param);
+    // URL params aren't guaranteed unique (shared/edited links, crawlers), but a
+    // facet's values are a set — `add`/`toggle` enforce that on user input, so the
+    // URL parse must too. A repeated value otherwise reaches TokenInput, which keys
+    // each chip by its value, and Svelte throws `each_key_duplicate` on hydration.
+    const exclude = [...new Set(p.getAll(`${def.param}_exclude`))];
+    const include = [...new Set(p.getAll(def.param))];
     const matchAll = p.get(`${def.param}_mode`) === 'and';
     if (exclude.length > 0) f.facets[def.param] = { values: exclude, exclude: true, matchAll };
     else if (include.length > 0) f.facets[def.param] = { values: include, exclude: false, matchAll };


### PR DESCRIPTION
## Problem
Prod throws `Uncaught (in promise) Error: each_key_duplicate` (`https://svelte.dev/e/each_key_duplicate`) on client navigation/hydration (observed on `/analytics`, but the defect is in the shared filter layer so `/jobs` is affected too).

## Root cause
`filtersFromParams` (`web/src/lib/filters.svelte.ts`) read facet values with `URLSearchParams.getAll()`, which returns **every** repeat with no dedup. A URL with a duplicate facet value (shared/hand-edited link, crawler, stale saved search) yields `values: ['x','x']`. That feeds `TokenInput`, whose `{#each tokens as token (token)}` keys each chip by its value → duplicate key → Svelte throws on reconciliation.

SSR doesn't reconcile keyed-each, so the server HTML renders fine and the crash only surfaces on client hydration — matching the "in promise" trace.

`add()`/`toggle()` already enforce value uniqueness on user input; only the URL-parse path violated the invariant.

## Fix
Dedup values via `Set` at the URL parse boundary (single source). Covers `TokenInput`, saved-search `apply()`, and `canonicalQuery`. Symptom (index keys) deliberately not used — that would mask dirty data and break chip identity.

## Verify
`npx svelte-check` — no new errors (pre-existing OG-module/`$types` errors unrelated).