### PR TITLE
fix(web): dedup Source facet values + harden facet render against dup keys

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -138,8 +138,13 @@ func skipPreamble(lines []string) int {
 // non-adapter sources set by other writers: "telegram" (the tg-extract worker) and the
 // moderator/bulk-import origins ("workatastartup", "remoteok", "arc"). Stages from
 // userjob; the rest from the enrich controlled vocabularies.
+//
+// An origin that started as a manual/bulk-import name can later gain a registered
+// adapter (e.g. remoteok), so it appears in both the hardcoded prefix and
+// FilterableProviders — dedup to keep SOURCE_VALUES a set. A duplicate value
+// otherwise reaches the SPA's keyed Source facet and throws each_key_duplicate.
 func genVocab() string {
-	source := append([]string{"telegram", "workatastartup", "remoteok", "arc"}, sources.FilterableProviders()...)
+	source := dedup(append([]string{"telegram", "workatastartup", "remoteok", "arc"}, sources.FilterableProviders()...))
 
 	var b strings.Builder
 	b.WriteString(emitVocab("Source", "SOURCE_VALUES", source))
@@ -153,4 +158,18 @@ func genVocab() string {
 	b.WriteString(emitVocab("CompanyType", "COMPANY_TYPE_VALUES", enrich.CompanyTypeValues))
 	b.WriteString(emitVocab("Domain", "DOMAIN_VALUES", enrich.DomainValues))
 	return b.String()
+}
+
+// dedup returns the slice with duplicates removed, preserving first-occurrence order.
+func dedup(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := values[:0]
+	for _, v := range values {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
 }

--- a/web/src/lib/components/facets/PillGroup.svelte
+++ b/web/src/lib/components/facets/PillGroup.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { FacetOption } from '$lib/facets';
+  import { uniqueByValue, type FacetOption } from '$lib/facets';
   import { pillClass } from './pill';
 
   // A wrap of toggle pills for one facet. Selected pills fill with the primary
@@ -21,10 +21,12 @@
   // since an old bookmark or saved search was created — still renders as an
   // active pill so it stays removable instead of becoming an invisible, stuck
   // filter that silently constrains results.
-  const shown = $derived([
-    ...options,
-    ...selected.filter((v) => !options.some((o) => o.value === v)).map((v) => ({ value: v, label: v })),
-  ]);
+  const shown = $derived(
+    uniqueByValue([
+      ...options,
+      ...selected.filter((v) => !options.some((o) => o.value === v)).map((v) => ({ value: v, label: v })),
+    ]),
+  );
 </script>
 
 <div class="flex flex-wrap gap-2">

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { FacetOption } from '$lib/facets';
+  import { uniqueByValue, type FacetOption } from '$lib/facets';
   import { Input } from '$lib/ui';
   import { pillClass } from './pill';
 
@@ -23,7 +23,7 @@
   let filter = $state('');
 
   const shown = $derived(
-    options
+    uniqueByValue(options)
       .filter((o) => o.label.toLowerCase().includes(filter.trim().toLowerCase()))
       .sort((a, b) => Number(selected.includes(b.value)) - Number(selected.includes(a.value))),
   );

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -66,6 +66,16 @@ export function dynamicLabel(param: string, value: string): string {
   return param === 'countries' ? countryLabel(value) : value;
 }
 
+/** Drop options with a duplicate `value`, keeping the first. The facet controls
+ *  render a keyed `{#each}` on `value`, and Svelte aborts the whole render with
+ *  `each_key_duplicate` on a collision — so a single stray duplicate (e.g. a
+ *  generated-vocabulary regression) would take down every page with a filter
+ *  panel. This makes that failure mode a harmless repeat instead of a crash. */
+export function uniqueByValue(opts: FacetOption[]): FacetOption[] {
+  const seen = new Set<string>();
+  return opts.filter((o) => (seen.has(o.value) ? false : seen.add(o.value)));
+}
+
 /** A title-cased fallback label for a value with no explicit label. */
 function humanize(value: string): string {
   return value

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -105,7 +105,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'eightfold', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'lever', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'remoteok', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'wpyoast'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'eightfold', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'lever', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'wpyoast'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## The real root cause (follow-up to #168)

#168 fixed a *latent* dup-key path (URL facet values) but not the actual prod crash. The site-wide `each_key_duplicate` (pages stopped switching; `/jobs` and `/analytics` rendered zero content) came from **`SOURCE_VALUES` carrying `'remoteok'` twice**.

`cmd/gen-contracts` builds the source vocabulary as a hardcoded prefix of non-adapter origins (`telegram`, `workatastartup`, `remoteok`, `arc`) + `sources.FilterableProviders()`. Once `remoteok` gained a registered adapter, it appeared in **both** lists → duplicate value (introduced when contracts were regenerated in #166). The Source facet is a `pills` control whose `PillGroup` renders `{#each shown as opt (opt.value)}`; the duplicate value threw `each_key_duplicate`, which in Svelte 5 aborts the whole render and kills hydration/SPA navigation on every page with the filter panel.

## Fix — two layers

1. **Root:** `cmd/gen-contracts` now dedups the source list (order-preserving), so the hardcoded prefix overlapping the registry can't regress again. `contracts.ts` regenerated (`remoteok` ×1).
2. **Defense-in-depth:** `uniqueByValue()` dedups options at the render boundary in `PillGroup` and `SearchSelect`. Any future stray duplicate becomes a harmless repeated pill instead of taking the whole site down.

## Verify
- Reproduced in dev mode (Svelte dev) against the prod API: crash present on `origin/main`, gone with this branch — both pages render, **0 `each_key` errors**.
- Re-injected a duplicate source value: page still renders (defense confirmed).
- `go build/vet/gofmt` clean; `svelte-check` clean (only pre-existing OG-module dep errors).