### PR TITLE
fix(search): raise maxTotalHits to 10M so the total count stays accurate

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -43,7 +43,9 @@ const (
 	// index size to keep the reported count honest. It is NOT the pagination guard
 	// — deep offset paging is bounded separately by maxSearchWindow in the search
 	// handler — so a large value here costs nothing beyond an accurate total.
-	maxTotalHits = 1000000
+	// Keep it comfortably above the open-job catalogue (which crossed 1M in
+	// 2026-06): once the real total exceeds this cap, every count saturates at it.
+	maxTotalHits = 10000000
 
 	// maxValuesPerFacet raises the per-facet value cap above Meili's default of
 	// 100 so the analytics facet distribution is not truncated for


### PR DESCRIPTION
The open-job catalogue crossed **1M** (the reindex fix in #167 indexed the whole catalogue, 1.25M). Meili caps `estimatedTotalHits` at `Pagination.MaxTotalHits`, so the site reported a flat **1,000,000** instead of the real total.

Raise the cap to **10,000,000** (years of headroom). Below the cap the reported total is exact, so this restores the accurate count (~1.25M now). Deep-offset paging is bounded separately by `maxSearchWindow` in the handler, so a larger cap only buys an honest count — no perf cost.

After merge: deploy + apply the pagination setting to the live index (a PATCH, no full reindex needed).