### PR TITLE
feat(sources): Work at a Startup (YC) adapter via session-keyed Algolia

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -133,6 +133,7 @@ func All(c HTTPClient) map[string]Source {
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
+		NewWorkAtAStartup(c),
 		NewJobStash(c),
 		NewArbeitnow(c),
 		NewRemoteOK(c),

--- a/internal/sources/workatastartup.go
+++ b/internal/sources/workatastartup.go
@@ -1,0 +1,139 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// workatastartup adapts Work at a Startup (workatastartup.com), Y Combinator's job board.
+// Boardless (one Algolia-backed index, no per-tenant board) and multi-company, so it stays
+// in the source facet and takes each posting's company from the hit. The board is gated:
+// the public page ships an Algolia key neutered to return nothing, and a working key is only
+// embedded in a logged-in session. So this adapter needs that session's Algolia search key,
+// supplied out-of-band via WAAS_ALGOLIA_KEY (a long-lived secured search key, not a login).
+// With the key, the index is queried directly — every hit carries the full posting (company,
+// title, markdown description, location, remote, date), so there is no per-job detail call.
+//
+// Coverage caveat: Algolia caps offset pagination at 1000 hits per query (paginationLimitedTo),
+// while the index holds somewhat more; a single sweep therefore returns the first 1000 and
+// logs how many it left behind rather than silently truncating.
+type workatastartup struct {
+	http HeaderJSONPoster
+}
+
+const (
+	waasKeyEnv      = "WAAS_ALGOLIA_KEY"
+	waasAlgoliaApp  = "45BWZJ1SGC"
+	waasAlgoliaIdx  = "WaaSPublicCompanyJob_production"
+	waasHitsPerPage = 1000
+	// waasMaxPages bounds pagination; Algolia's 1000-hit cap means this is rarely > 1.
+	waasMaxPages = 5
+)
+
+// NewWorkAtAStartup builds the Work at a Startup adapter over the given HTTP client.
+func NewWorkAtAStartup(c HeaderJSONPoster) Source { return workatastartup{http: c} }
+
+func (workatastartup) Provider() string { return "workatastartup" }
+
+func (workatastartup) boardless() {}
+
+func (workatastartup) aggregator() {}
+
+// waasHit is one job from the Algolia index, body inline (no detail call). remote is
+// "no" | "yes" | "only"; search_path is the canonical job URL.
+type waasHit struct {
+	ID               json.Number `json:"id"`
+	Title            string      `json:"title"`
+	Description      string      `json:"description"`
+	Remote           string      `json:"remote"`
+	CreatedAt        string      `json:"created_at"`
+	CompanyName      string      `json:"company_name"`
+	LocationsForSrch []string    `json:"locations_for_search"`
+	SearchPath       string      `json:"search_path"`
+}
+
+func (s workatastartup) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	key := os.Getenv(waasKeyEnv)
+	if key == "" {
+		return nil, fmt.Errorf("workatastartup: %s is not set (needs a logged-in session's Algolia search key)", waasKeyEnv)
+	}
+	headers := map[string]string{
+		"X-Algolia-Application-Id": waasAlgoliaApp,
+		"X-Algolia-API-Key":        key,
+	}
+	url := fmt.Sprintf("https://%s-dsn.algolia.net/1/indexes/%s/query", waasAlgoliaApp, waasAlgoliaIdx)
+
+	var jobs []Job
+	for page := 0; page < waasMaxPages; page++ {
+		body := map[string]any{"params": fmt.Sprintf("hitsPerPage=%d&page=%d&query=", waasHitsPerPage, page)}
+		var resp struct {
+			Hits    []waasHit `json:"hits"`
+			NbHits  int       `json:"nbHits"`
+			NbPages int       `json:"nbPages"`
+		}
+		if err := s.http.PostJSONWithHeaders(ctx, url, headers, body, &resp); err != nil {
+			return nil, fmt.Errorf("workatastartup: page %d: %w", page, err)
+		}
+		for _, h := range resp.Hits {
+			if job, ok := h.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		if page == 0 && resp.NbHits > len(resp.Hits) {
+			// Algolia's 1000-hit pagination cap: report what the sweep cannot reach.
+			log.Printf("workatastartup: index has %d jobs, retrievable cap is %d — %d not fetched this run",
+				resp.NbHits, len(resp.Hits)*max(resp.NbPages, 1), resp.NbHits-len(resp.Hits)*max(resp.NbPages, 1))
+		}
+		if page+1 >= resp.NbPages || len(resp.Hits) == 0 {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an Algolia hit to a Job, returning ok=false for an unusable hit (no id, which
+// would collide on the dedup key, or no company which would break the slug). The markdown
+// description is rendered to sanitized HTML; remote "only"/"yes" set the work mode.
+func (h waasHit) toJob() (Job, bool) {
+	id := h.ID.String()
+	if id == "" || id == "0" || h.CompanyName == "" {
+		return Job{}, false
+	}
+	location := ""
+	if len(h.LocationsForSrch) > 0 {
+		location = h.LocationsForSrch[0]
+	}
+	url := h.SearchPath
+	if url == "" {
+		url = fmt.Sprintf("https://www.workatastartup.com/jobs/%s", id)
+	}
+	workMode := waasWorkMode(h.Remote)
+	return Job{
+		ExternalID:  id,
+		URL:         url,
+		Title:       h.Title,
+		Company:     h.CompanyName,
+		Location:    location,
+		Description: sanitizeHTML(markdownToHTML(h.Description)),
+		Remote:      workMode == "remote" || workMode == "hybrid",
+		WorkMode:    workMode,
+		PostedAt:    parseRFC3339(h.CreatedAt),
+	}, true
+}
+
+// waasWorkMode maps WaaS's remote flag to the controlled work-mode vocabulary:
+// "only" = remote-only, "yes" = remote allowed, "no" = in-office.
+func waasWorkMode(remote string) string {
+	switch strings.ToLower(remote) {
+	case "only", "yes":
+		return "remote"
+	case "no":
+		return "onsite"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/workatastartup_test.go
+++ b/internal/sources/workatastartup_test.go
@@ -1,0 +1,108 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWorkAtAStartupProvider(t *testing.T) {
+	if got := NewWorkAtAStartup(nil).Provider(); got != "workatastartup" {
+		t.Errorf("Provider() = %q, want workatastartup", got)
+	}
+}
+
+func TestWorkAtAStartupIsBoardlessAggregator(t *testing.T) {
+	s := NewWorkAtAStartup(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("workatastartup should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("workatastartup should implement the aggregator marker")
+	}
+}
+
+func TestWorkAtAStartupRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["workatastartup"]; !ok {
+		t.Error("All() should register provider workatastartup")
+	}
+	if !slices.Contains(FilterableProviders(), "workatastartup") {
+		t.Error("FilterableProviders() should include workatastartup")
+	}
+}
+
+func TestWorkAtAStartupBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/workatastartup.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/workatastartup.yml fails validation: %v", err)
+	}
+}
+
+func TestWorkAtAStartupMissingKeyErrors(t *testing.T) {
+	t.Setenv(waasKeyEnv, "")
+	_, err := NewWorkAtAStartup(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{})
+	if err == nil {
+		t.Fatal("Fetch should error when WAAS_ALGOLIA_KEY is unset")
+	}
+}
+
+func TestWorkAtAStartupWorkMode(t *testing.T) {
+	cases := map[string]string{"only": "remote", "yes": "remote", "no": "onsite", "": ""}
+	for in, want := range cases {
+		if got := waasWorkMode(in); got != want {
+			t.Errorf("waasWorkMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWorkAtAStartupFetchMapsHits(t *testing.T) {
+	t.Setenv(waasKeyEnv, "test-key")
+	resp := `{"hits":[
+{"id":96853,"title":"Founding Account Executive","description":"## About\n\nSell **stuff**.","remote":"only","created_at":"2026-06-17T17:44:11.932Z","company_name":"Ergo","locations_for_search":["San Francisco, CA, US","San Francisco","CA","US"],"search_path":"https://www.ycombinator.com/companies/ergo/jobs/VDySCKB-founding-account-executive"},
+{"id":0,"title":"NoID","company_name":"x"},
+{"id":12,"title":"NoCompany","company_name":"","remote":"no"}
+],"nbHits":2,"nbPages":1}`
+	fake := (&routedHTTP{}).route("algolia.net", resp)
+
+	jobs, err := NewWorkAtAStartup(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (zero-id and no-company dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "96853" || j.Company != "Ergo" || j.Title != "Founding Account Executive" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://www.ycombinator.com/companies/ergo/jobs/VDySCKB-founding-account-executive" {
+		t.Errorf("URL should use search_path: %q", j.URL)
+	}
+	if j.Location != "San Francisco, CA, US" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.WorkMode != "remote" || !j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want remote/true", j.WorkMode, j.Remote)
+	}
+	if !strings.Contains(j.Description, "<h2") || !strings.Contains(j.Description, "<strong>stuff</strong>") {
+		t.Errorf("Description should be markdown-rendered HTML: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 17, 17, 44, 11, 932000000, time.UTC)) {
+		t.Errorf("PostedAt = %v", j.PostedAt)
+	}
+}
+
+func TestWorkAtAStartupURLFallsBackToId(t *testing.T) {
+	t.Setenv(waasKeyEnv, "test-key")
+	resp := `{"hits":[{"id":555,"title":"Role","company_name":"Acme","remote":"no"}],"nbHits":1,"nbPages":1}`
+	fake := (&routedHTTP{}).route("algolia.net", resp)
+	jobs, _ := NewWorkAtAStartup(fake).Fetch(context.Background(), CompanyEntry{})
+	if len(jobs) != 1 || jobs[0].URL != "https://www.workatastartup.com/jobs/555" {
+		t.Fatalf("URL = %q, want id-built fallback", jobs[0].URL)
+	}
+}

--- a/sources/workatastartup.yml
+++ b/sources/workatastartup.yml
@@ -1,0 +1,6 @@
+# Work at a Startup (workatastartup.com), Y Combinator's job board. Boardless: one
+# Algolia-backed index, so the entry carries no board; each job's company comes from the
+# index. Gated — the ingest worker needs WAAS_ALGOLIA_KEY (a logged-in session's Algolia
+# search key) in its environment, else the run errors (it does not crash other sources).
+- company: Work at a Startup
+  provider: workatastartup


### PR DESCRIPTION
## What
Adds a **workatastartup** source adapter (Y Combinator's Work at a Startup), replacing the stale one-time manual import with a live source.

## How (from the spike)
workatastartup is gated:
- The public `/jobs` page ships an Algolia key **neutered** with `tagFilters=[["none"]]` → **0 hits**.
- A **logged-in session** embeds a working secured key (`tagFilters=[["jobs_applicant"]]`, no `validUntil` → long-lived). With it, the Algolia index `WaaSPublicCompanyJob_production` returns the full postings (~1358) directly — **no per-job detail call** needed.

So the adapter takes that search key **out-of-band via `WAAS_ALGOLIA_KEY`** (a key, not a login flow) and queries Algolia (`HeaderJSONPoster`, `X-Algolia-*` headers — same pattern as MTS's public header key).

Mapping: boardless aggregator (company per posting); markdown description → HTML via the shared goldmark helper; URL from the hit's `search_path` (canonical YC URL) else built from the id; `remote` only/yes→remote, no→onsite; `created_at`→posted_at. Unit-tested + live-smoked (**1000 jobs**, correct company/location/work-mode/markdown).

## Coverage caveat (no silent cap)
Algolia caps offset pagination at **1000 hits/query** (`paginationLimitedTo`) while the index holds ~1358. The sweep returns the first 1000 and **logs** the remainder. Full coverage would need facet sharding (the natural `role` facet doesn't help — `role:eng` alone is 1112 > 1000) — left as a follow-up; hourly cron + freshest-first keeps active hiring well covered.

## Verification
- `go build`/`go vet`/`go test ./...` green (35 ok, 0 fail); gofmt clean.
- Contracts regenerated — `workatastartup` appears once in `SOURCE_VALUES` (the gen-contracts seed already listed it as a bulk-import origin; `dedup()` collapses it now that it's a real provider).

## Deploy
- Set **`WAAS_ALGOLIA_KEY`** in the ingest worker env (`/opt/freehire/.env` + compose). The worker **errors cleanly** without it and never crashes other sources.
- On go-live, **delete the stale manual-import `workatastartup` rows** (URL-keyed) so the adapter (`:numeric` ids) owns the source — same dedup we just did for the remoteok manual import.
- Add a cron schedule for `sources/workatastartup.yml`.