### PR TITLE
feat(search,web): similar jobs via Meilisearch semantic index

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -180,6 +180,7 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/jobs/search", a.SearchJobs)
 	api.Get("/jobs/facets", a.JobFacets)
 	api.Get("/jobs/:slug", a.GetJob)
+	api.Get("/jobs/:slug/similar", a.SimilarJobs)
 	api.Get("/companies", a.ListCompanies)
 	api.Get("/companies/:slug", a.GetCompany)
 

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -15,6 +15,7 @@ import (
 // configured (no MEILI_MASTER_KEY) and the endpoint reports 503.
 type searcher interface {
 	Search(ctx context.Context, p search.SearchParams) (search.SearchResult, error)
+	SimilarJobs(ctx context.Context, id int64, limit int) ([]search.JobDocument, error)
 }
 
 // defaultSemanticRatio is 0 — pure keyword search against the always-fresh facet

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -16,11 +16,20 @@ type fakeSearcher struct {
 	got search.SearchParams
 	res search.SearchResult
 	err error
+	// similar-jobs call recording
+	similarLimit int
+	similarHits  []search.JobDocument
+	similarErr   error
 }
 
 func (f *fakeSearcher) Search(_ context.Context, p search.SearchParams) (search.SearchResult, error) {
 	f.got = p
 	return f.res, f.err
+}
+
+func (f *fakeSearcher) SimilarJobs(_ context.Context, _ int64, limit int) ([]search.JobDocument, error) {
+	f.similarLimit = limit
+	return f.similarHits, f.similarErr
 }
 
 func searchApp(s searcher) *fiber.App {

--- a/internal/handler/similar.go
+++ b/internal/handler/similar.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/jobview"
+)
+
+// defaultSimilarLimit / maxSimilarLimit bound how many neighbours the similar-jobs
+// endpoint returns: a small default sized for a "Similar jobs" row on the detail
+// page, capped so a client cannot ask for an unbounded fan-out of embedder queries.
+const (
+	defaultSimilarLimit = 6
+	maxSimilarLimit     = 20
+)
+
+// SimilarJobs returns jobs semantically nearest to the one addressed by :slug,
+// from the semantic index. Public (unauthenticated) like the other job reads.
+// Response: {"data": [job view...]} — neighbours carry public_slug and never the
+// internal id, and the source job is excluded by the search backend.
+func (a *API) SimilarJobs(c *fiber.Ctx) error {
+	if a.search == nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
+	}
+
+	id, err := a.queries.GetJobIDBySlug(c.Context(), c.Params("slug"))
+	if err != nil {
+		// RenderError maps pgx.ErrNoRows to 404, anything else to 500.
+		return err
+	}
+
+	limit := min(max(c.QueryInt("limit", defaultSimilarLimit), 1), maxSimilarLimit)
+	hits, err := a.search.SimilarJobs(c.Context(), id, limit)
+	if err != nil {
+		return err
+	}
+
+	views := make([]jobview.Job, len(hits))
+	for i, hit := range hits {
+		views[i] = hit.Job
+	}
+
+	return c.JSON(fiber.Map{"data": views})
+}

--- a/internal/handler/similar_integration_test.go
+++ b/internal/handler/similar_integration_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+// End-to-end HTTP test for the similar-jobs endpoint against a real Postgres: the
+// route resolves the public :slug to the internal id, queries the (faked) search
+// backend, and shapes the public list envelope. The search backend is faked — slug
+// resolution is the only part that needs a real DB; Meilisearch is exercised in the
+// search package's own integration test. Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/search"
+)
+
+func TestSimilarJobsEndToEnd(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	const knownSlug = "go-dev-acme-aaaa1111"
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, public_slug)
+		 VALUES ('greenhouse', 'gh:1', 'http://ats.test/1', 'Go Dev', $1)`, knownSlug); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+
+	fake := &fakeSearcher{similarHits: []search.JobDocument{
+		{ID: 2, Job: jobview.Job{PublicSlug: "py-dev-beta-bbbb2222", Title: "Py Dev"}},
+		{ID: 3, Job: jobview.Job{PublicSlug: "rust-dev-ceta-cccc3333", Title: "Rust Dev"}},
+	}}
+	h := &API{pool: pool, queries: db.New(pool), search: fake}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/jobs/:slug/similar", h.SimilarJobs)
+
+	get := func(target string) (*http.Response, map[string]any) {
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, target, nil))
+		if err != nil {
+			t.Fatalf("request %s: %v", target, err)
+		}
+		var body map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp, body
+	}
+
+	t.Run("known slug returns neighbours without internal id", func(t *testing.T) {
+		resp, body := get("/api/v1/jobs/" + knownSlug + "/similar")
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		data, _ := body["data"].([]any)
+		if len(data) != 2 {
+			t.Fatalf("data len = %d, want 2", len(data))
+		}
+		first, _ := data[0].(map[string]any)
+		if first["public_slug"] != "py-dev-beta-bbbb2222" {
+			t.Errorf("public_slug = %v", first["public_slug"])
+		}
+		if _, leaked := first["id"]; leaked {
+			t.Errorf("internal id leaked: %v", first)
+		}
+	})
+
+	t.Run("limit is parsed, defaulted, and clamped", func(t *testing.T) {
+		if _, _ = get("/api/v1/jobs/" + knownSlug + "/similar?limit=3"); fake.similarLimit != 3 {
+			t.Errorf("explicit limit = %d, want 3", fake.similarLimit)
+		}
+		if _, _ = get("/api/v1/jobs/" + knownSlug + "/similar"); fake.similarLimit != defaultSimilarLimit {
+			t.Errorf("default limit = %d, want %d", fake.similarLimit, defaultSimilarLimit)
+		}
+		if _, _ = get("/api/v1/jobs/" + knownSlug + "/similar?limit=999"); fake.similarLimit != maxSimilarLimit {
+			t.Errorf("clamped limit = %d, want %d", fake.similarLimit, maxSimilarLimit)
+		}
+	})
+
+	t.Run("unknown slug is a 404 and never reaches the backend", func(t *testing.T) {
+		fake.similarLimit = 0
+		resp, _ := get("/api/v1/jobs/no-such-slug/similar")
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+		if fake.similarLimit != 0 {
+			t.Errorf("backend was queried for an unknown slug (limit=%d)", fake.similarLimit)
+		}
+	})
+}

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -371,6 +371,42 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 	return SearchResult{Hits: hits, Total: resp.EstimatedTotalHits}, nil
 }
 
+// SimilarJobs returns the jobs nearest to job id in embedding space, queried
+// against the semantic index by the document's stored vector (no query text, no
+// re-embedding). The semantic index holds open jobs only, so neighbours are open
+// jobs without any added filter. Meilisearch's similar endpoint already excludes
+// the source document, but we over-fetch by one and drop it defensively rather
+// than depend on that — and to avoid making the primary key a filterable
+// attribute just to express "id != source".
+func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDocument, error) {
+	var resp meilisearch.SimilarDocumentResult
+	err := c.semantic.SearchSimilarDocumentsWithContext(ctx, &meilisearch.SimilarDocumentQuery{
+		Id:       id,
+		Embedder: embedderName,
+		Limit:    int64(limit) + 1,
+	}, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("search: similar: %w", err)
+	}
+
+	var hits []JobDocument
+	if err := resp.Hits.DecodeInto(&hits); err != nil {
+		return nil, fmt.Errorf("search: decode similar hits: %w", err)
+	}
+
+	out := make([]JobDocument, 0, limit)
+	for _, h := range hits {
+		if h.ID == id {
+			continue
+		}
+		if len(out) == limit {
+			break
+		}
+		out = append(out, h)
+	}
+	return out, nil
+}
+
 // awaitTask blocks until a Meilisearch task settles and reports a failed task as
 // an error.
 func (c *Client) awaitTask(ctx context.Context, idx meilisearch.IndexManager, taskUID int64) error {

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -289,6 +289,65 @@ func TestSearchFiltersBySkillsFacet(t *testing.T) {
 	}
 }
 
+// SimilarJobs returns the nearest neighbours of a job from the semantic index:
+// other jobs are returned (ranked by embedding proximity), the source job is never
+// in its own list, and the caller's limit is honoured.
+func TestIntegration_SimilarJobs(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	if err := c.EnsureSemanticIndex(ctx); err != nil {
+		t.Fatalf("EnsureSemanticIndex: %v", err)
+	}
+
+	jobs := []db.Job{
+		{ID: 1, Title: "Senior Golang Backend Engineer", Company: "Acme", Location: "Berlin",
+			Description: "Build distributed backend services and APIs in Go.",
+			PublicSlug:  "senior-golang-backend-engineer-acme-aaa",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
+		{ID: 2, Title: "Backend Software Engineer (Go)", Company: "Beta", Location: "Remote",
+			Description: "Design server-side microservices and REST APIs in Golang.",
+			PublicSlug:  "backend-software-engineer-go-beta-bbb",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
+		{ID: 3, Title: "Frontend React Developer", Company: "Gamma", Location: "Remote",
+			Description: "Build user interfaces with React and TypeScript.",
+			PublicSlug:  "frontend-react-developer-gamma-ccc",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
+		{ID: 4, Title: "Data Scientist", Company: "Delta", Location: "London",
+			Description: "Train machine learning models and analyse datasets in Python.",
+			PublicSlug:  "data-scientist-delta-ddd",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
+	}
+	if err := c.IndexSemanticJobs(ctx, toDocs(t, jobs)); err != nil {
+		t.Fatalf("IndexSemanticJobs: %v", err)
+	}
+
+	t.Run("returns neighbours and excludes the source job", func(t *testing.T) {
+		hits, err := c.SimilarJobs(ctx, 1, 10)
+		if err != nil {
+			t.Fatalf("SimilarJobs: %v", err)
+		}
+		if len(hits) == 0 {
+			t.Fatal("SimilarJobs returned no neighbours")
+		}
+		for _, h := range hits {
+			if h.ID == 1 {
+				t.Errorf("source job id 1 must not appear in its own similar list: %+v", hits)
+			}
+		}
+	})
+
+	t.Run("honours the limit", func(t *testing.T) {
+		hits, err := c.SimilarJobs(ctx, 1, 2)
+		if err != nil {
+			t.Fatalf("SimilarJobs: %v", err)
+		}
+		if len(hits) > 2 {
+			t.Errorf("limit 2 returned %d hits", len(hits))
+		}
+	})
+}
+
 func toDocs(t *testing.T, jobs []db.Job) []JobDocument {
 	t.Helper()
 	docs := make([]JobDocument, 0, len(jobs))

--- a/openspec/changes/add-similar-jobs/.openspec.yaml
+++ b/openspec/changes/add-similar-jobs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/add-similar-jobs/design.md
+++ b/openspec/changes/add-similar-jobs/design.md
@@ -1,0 +1,78 @@
+## Context
+
+Hybrid search already runs against a second Meilisearch index, `jobs_semantic`,
+configured with an in-engine huggingFace embedder (`internal/search/client.go`).
+The reindex command indexes **open jobs only** into both indexes
+(`cmd/reindex/main.go` `splitJobs`), so closed jobs are physically absent from
+`jobs_semantic`. The pinned SDK (`meilisearch-go v0.36.3`) exposes
+`SearchSimilarDocuments` / `SearchSimilarDocumentsWithContext`
+(`SimilarDocumentQuery{ Id, Embedder, Limit, Filter, ... }`), and the engine
+(`v1.13`) supports the similar-documents endpoint as a stable feature.
+
+Slug→id resolution already has a lightweight query, `GetJobIDBySlug`
+(`internal/db/queries/jobs.sql`), used as the hot-path read precedent by the
+view-tracking endpoint. The job detail page is a SvelteKit route under
+`web/src/routes/jobs/[slug]/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Surface semantically nearest open jobs for a given job through a public
+  per-job endpoint and a job-detail section.
+- Reuse the existing semantic index and embedder with zero indexing/settings
+  changes.
+
+**Non-Goals:**
+- No change to the embedder, document template, index settings, or reindex.
+- No personalization, no cross-filtering by category/region (a plain nearest-
+  neighbour list, per the agreed scope).
+- No new persistence; no caching layer (revisit only if latency demands it).
+
+## Decisions
+
+**1. Query via `SearchSimilarDocuments` against `c.semantic`, embedder
+`"default"`.** This is the purpose-built primitive: it ranks by the source
+document's already-computed vector — no query text to synthesize and no
+re-embedding. Alternative considered: reuse `Search` with `SemanticRatio=1` and
+the job's title as the query. Rejected — that re-embeds a lossy text proxy of the
+job instead of using its stored vector, and would rank the source job itself
+highly.
+
+**2. Exclude the source job defensively in Go, not via a Meili filter.**
+Meilisearch's similar endpoint excludes the source document by design, but rather
+than depend on that (and rather than make the primary key `id` filterable just to
+express `id != X`), request `limit+1` and drop any hit whose `id` equals the
+requested id, then truncate to `limit`. Keeps the index settings untouched.
+
+**3. No "open jobs" filter.** `jobs_semantic` already holds open jobs only
+(reindex contract). Adding a `closed_at` filter would require making it a
+filterable attribute and a reindex — unnecessary given the index invariant.
+
+**4. New `search.Client.SimilarJobs(ctx, id int64, limit int) ([]JobDocument,
+error)`.** Mirrors `Search`: callers never touch the SDK. Decodes hits into
+`[]JobDocument` via `resp.Hits.DecodeInto`, the same path `Search` uses.
+
+**5. Handler resolves slug→id with `GetJobIDBySlug`, then calls `SimilarJobs`.**
+Unknown slug → `pgx.ErrNoRows` → 404 via the central `ErrorHandler` (no per-
+handler error JSON). Response is `{"data": [...]}` of `jobview.Job` (the embedded
+view inside each `JobDocument`), `id` omitted — identical shape to search hits.
+Route `GET /api/v1/jobs/:slug/similar`, public, wired in `handler.Register`
+beside the existing `/jobs/:slug`.
+
+**6. SPA loads `/similar` for the detail page and renders a "Similar jobs"
+section.** Failure or empty → render nothing (must not break the page), matching
+the existing silent-failure convention for the view-tracking call.
+
+## Risks / Trade-offs
+
+- **Semantic index staleness** → A job closed since the last `reindex --semantic`
+  may still appear as a neighbour until the next pass. Mitigation: accepted — this
+  is the same staleness every semantic surface already has, and the detail page
+  still renders a closed job; no new guarantee is promised.
+- **Newly ingested jobs have no vector yet** → Their `/similar` is empty until the
+  next semantic reindex, and they won't appear as neighbours. Mitigation: accepted
+  inherited seam (the semantic pass runs on its own looser schedule); the section
+  degrades silently to nothing.
+- **Embedder latency per request** → similar queries hit the embedder index.
+  Mitigation: bounded `limit`, no fan-out; revisit caching only if measured
+  latency warrants it (Non-Goal for now).

--- a/openspec/changes/add-similar-jobs/proposal.md
+++ b/openspec/changes/add-similar-jobs/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+A job seeker who lands on one vacancy has nowhere to go next within the same
+topic — the detail page is a dead end. The semantic embedder that already powers
+hybrid search (the `jobs_semantic` index) can surface vacancies close in meaning
+to the one being viewed, turning every job page into an entry point for
+discovery without any new indexing infrastructure.
+
+## What Changes
+
+- Add a public endpoint `GET /api/v1/jobs/:slug/similar` that returns jobs
+  semantically nearest to the one identified by `:slug`, using Meilisearch's
+  similar-documents query against the existing `jobs_semantic` index and its
+  already-configured embedder.
+- The result reuses the standard list envelope and the public job wire shape
+  (`{"data": [...]}`), identifying jobs by `public_slug` and never exposing the
+  internal numeric `id` — consistent with the other public job reads. The source
+  job itself is never included in its own similar list.
+- Add a "Similar jobs" section to the job detail page in the SPA, rendered from
+  the new endpoint and degrading silently to nothing when there are no neighbours
+  or the call fails (it must not break the page).
+- No change to the embedder, the document template, the index settings, or any
+  reindex path: closed jobs are already absent from `jobs_semantic` (the reindex
+  command indexes open jobs only), so similar results are open jobs without any
+  added filter, settings change, or re-embedding.
+
+## Capabilities
+
+### New Capabilities
+- `similar-jobs`: surface vacancies semantically close to a given job — the
+  similar-documents query against the semantic index, the public per-job
+  `/similar` endpoint, and the job-detail "Similar jobs" section.
+
+### Modified Capabilities
+<!-- None: the embedder, index settings, and reindex behavior in job-search are
+     unchanged; this capability consumes the existing semantic index as-is. -->
+
+## Impact
+
+- **API**: new route `GET /api/v1/jobs/:slug/similar` (public, unauthenticated).
+- **Code**: `internal/search` (new `SimilarJobs` client method over the SDK's
+  `SearchSimilarDocuments`), `internal/handler` (new handler + route wiring),
+  `web/src/routes/jobs/[slug]` (new UI section + data load).
+- **Dependencies**: none new — uses the pinned `meilisearch-go` and the existing
+  `jobs_semantic` index/embedder.
+- **No** DB migration, schema change, index settings change, or reindex required.

--- a/openspec/changes/add-similar-jobs/specs/similar-jobs/spec.md
+++ b/openspec/changes/add-similar-jobs/specs/similar-jobs/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Similar-documents query over the semantic index
+
+The system SHALL provide a way to retrieve the jobs whose embeddings are nearest
+to a given job, by querying the existing `jobs_semantic` index with
+Meilisearch's similar-documents operation keyed by the job's internal `id` and
+the configured embedder. It SHALL NOT change the embedder, the document
+template, the index settings, or any reindex path.
+
+The source job SHALL never appear in its own similar list. The number of results
+SHALL be bounded by a caller-supplied limit. Because the semantic index contains
+documents only for open jobs, similar results SHALL be open jobs without any
+additional filter.
+
+#### Scenario: Nearest neighbours are returned for a job
+
+- **WHEN** the similar-documents query is run for a job that has indexed
+  neighbours in the semantic index
+- **THEN** other jobs close to it in embedding space are returned, up to the
+  requested limit
+
+#### Scenario: The source job is excluded from its own results
+
+- **WHEN** the similar-documents query is run for a job
+- **THEN** that same job is not present in the returned list
+
+#### Scenario: A job with no neighbours yields an empty list
+
+- **WHEN** the similar-documents query is run and no other documents are close
+  enough (or the index holds only the source job)
+- **THEN** an empty list is returned rather than an error
+
+### Requirement: Public similar-jobs endpoint
+
+The system SHALL expose `GET /api/v1/jobs/:slug/similar` as a public
+(unauthenticated) endpoint. It SHALL resolve `:slug` to the job's internal `id`,
+run the similar-documents query, and respond with the standard list envelope
+`{"data": [...]}` whose `data` is the neighbouring jobs in the public job wire
+shape. Each result SHALL identify its job by `public_slug` and SHALL NOT include
+the internal numeric `id`, consistent with the other public job reads. An
+optional `limit` query parameter SHALL bound the number of results, clamped to a
+sane maximum, with a default when absent.
+
+Requesting similar jobs for an unknown slug SHALL return 404. The existing public
+job reads SHALL be unchanged.
+
+#### Scenario: Similar jobs for a known slug
+
+- **WHEN** a client requests `GET /api/v1/jobs/<known-slug>/similar`
+- **THEN** the response is `{"data": [...]}` listing neighbouring open jobs, each
+  carrying its `public_slug` and omitting the internal numeric `id`
+
+#### Scenario: Limit bounds the result count
+
+- **WHEN** a client requests `GET /api/v1/jobs/<known-slug>/similar?limit=3`
+- **THEN** at most 3 jobs are returned
+
+#### Scenario: Unknown slug is a 404
+
+- **WHEN** a client requests `GET /api/v1/jobs/<unknown-slug>/similar`
+- **THEN** the response status is 404
+
+### Requirement: Similar-jobs section on the job detail page
+
+The SPA job detail page SHALL display a "Similar jobs" section populated from the
+`/similar` endpoint, linking each neighbour to its own detail page. The section
+SHALL degrade silently when there are no neighbours or the request fails: it
+SHALL render nothing and SHALL NOT break or block the rest of the page.
+
+#### Scenario: Section shows neighbours
+
+- **WHEN** a user opens a job detail page that has similar jobs
+- **THEN** a "Similar jobs" section lists those jobs, each linking to its detail
+  page
+
+#### Scenario: Section is absent when there are none
+
+- **WHEN** a user opens a job detail page with no similar jobs (or the similar
+  request fails)
+- **THEN** no "Similar jobs" section is shown and the rest of the page renders
+  normally

--- a/openspec/changes/add-similar-jobs/tasks.md
+++ b/openspec/changes/add-similar-jobs/tasks.md
@@ -1,0 +1,20 @@
+## 1. Search client: SimilarJobs
+
+- [x] 1.1 Add a failing integration test in `internal/search/search_integration_test.go` that indexes several semantic docs, calls `SimilarJobs` for one job's id, and asserts: neighbours are returned, the source job's id is absent, and the result honours the limit.
+- [x] 1.2 Implement `SimilarJobs(ctx, id int64, limit int) ([]JobDocument, error)` in `internal/search/client.go` over `SearchSimilarDocuments` against `c.semantic` with embedder `"default"`; request `limit+1`, drop the hit whose id equals `id`, truncate to `limit`, decode via `resp.Hits.DecodeInto`.
+
+## 2. HTTP endpoint
+
+- [x] 2.1 Add a failing handler integration test (build tag `integration`) covering: known slug returns `{"data":[...]}` with `public_slug` and no internal `id`; `?limit=N` bounds the count; unknown slug returns 404.
+- [x] 2.2 Implement the `SimilarJobs` handler: resolve slug→id via `GetJobIDBySlug` (return `err` on `ErrNoRows` → 404 via central `ErrorHandler`), parse+clamp `limit` with a default, call `search.SimilarJobs`, respond with the list envelope of `jobview.Job`.
+- [x] 2.3 Wire `GET /api/v1/jobs/:slug/similar` (public) in `handler.Register` beside the existing `/jobs/:slug` route.
+
+## 3. SPA job-detail section
+
+- [x] 3.1 Load `/api/v1/jobs/<slug>/similar` for the detail route (in its `load`/data path), tolerating failure as empty.
+- [x] 3.2 Render a "Similar jobs" section on `web/src/routes/jobs/[slug]/+page.svelte` that lists neighbours linking to their detail pages, and renders nothing when the list is empty.
+- [x] 3.3 Regenerate web contracts if any shared shape changed, then verify the frontend with `svelte-check` (no new errors against the red baseline). [No shared shape changed — reuses the existing Job contract; svelte-check: 0 errors.]
+
+## 4. Verify
+
+- [x] 4.1 `go build ./... && go vet ./...`; run the new search + handler integration tests; confirm no settings/reindex change was needed. [build+vet clean; TestIntegration_SimilarJobs PASS (29s), TestSimilarJobsEndToEnd PASS (4.6s); no index settings or reindex touched.]

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -123,6 +123,14 @@ export function createApi(
     return body.data;
   }
 
+  /** Jobs semantically nearest to the one addressed by `slug` — the "Similar jobs"
+   *  section on the detail page. Same Job wire shape as the list, so the same card
+   *  renders them; the source job is excluded by the backend. */
+  async function getSimilarJobs(slug: string): Promise<Job[]> {
+    const body = await request<{ data: Job[] }>(`/api/v1/jobs/${slug}/similar`);
+    return body.data;
+  }
+
   /** Full-text search over jobs. `facets` carries the query text and any facet
    *  filters (built by the caller); pagination is appended here. Results are the
    *  same Job wire shape as listJobs, so views render them with the same
@@ -486,6 +494,7 @@ export function createApi(
   return {
     listJobs,
     getJob,
+    getSimilarJobs,
     searchJobs,
     facetCounts,
     listCompanies,
@@ -543,6 +552,7 @@ export const api = createApi();
 export const {
   listJobs,
   getJob,
+  getSimilarJobs,
   searchJobs,
   facetCounts,
   listCompanies,

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -7,13 +7,13 @@ import type { PageServerLoad } from './$types';
 // initial HTML. A 404 from the API becomes a SvelteKit 404 page (not a 200
 // shell); other failures bubble to the 500 page.
 export const load: PageServerLoad = async ({ params, fetch }) => {
-  try {
-    const job = await serverApi(fetch).getJob(params.slug);
-    return { job };
-  } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
-      error(404, 'Job not found');
-    }
+  const api = serverApi(fetch);
+  const job = await api.getJob(params.slug).catch((e) => {
+    if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
     throw e;
-  }
+  });
+  // Similar jobs are a non-essential discovery aid: a failure (search disabled,
+  // no neighbours yet) must not break the page, so it degrades to an empty list.
+  const similar = await api.getSimilarJobs(params.slug).catch(() => []);
+  return { job, similar };
 };

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import JobRow from '$lib/components/JobRow.svelte';
   import JobView from '$lib/components/JobView.svelte';
   import Seo from '$lib/components/Seo.svelte';
   import { jobPageTitle, jobPostingJsonLd, jsonLdScript, metaDescription } from '$lib/seo';
@@ -24,4 +25,15 @@
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <JobView job={data.job} />
+
+  {#if data.similar.length > 0}
+    <section class="mt-10">
+      <h2 class="mb-4 text-lg font-semibold">Similar jobs</h2>
+      <div class="flex flex-col gap-3">
+        {#each data.similar as job (job.public_slug)}
+          <JobRow {job} />
+        {/each}
+      </div>
+    </section>
+  {/if}
 </div>


### PR DESCRIPTION
## Summary
- Adds a **"Similar jobs"** surface keyed off the existing `jobs_semantic` embedder index — **no new indexing, settings, or reindex** (closed jobs are already absent from the semantic index per the reindex contract, so no `closed_at` filter is needed).
- `search.Client.SimilarJobs` over the SDK's `SearchSimilarDocuments` (embedder `"default"`): over-fetches `limit+1` and drops the source job defensively (Meili already excludes it, but this avoids depending on that and avoids making the PK filterable).
- Public `GET /api/v1/jobs/:slug/similar`: resolves slug→id via `GetJobIDBySlug`, clamps `limit` (default 6, max 20), returns `{"data":[jobview.Job...]}` (public_slug only, no internal id), unknown slug → 404, `a.search==nil` → 503.
- SPA job-detail page loads `/similar` in SSR (degrades silently to empty on failure/none) and renders a section reusing `JobRow`.

## Test Plan
- [x] `go build ./...` + `go vet ./...` clean; `gofmt -l` clean
- [x] Unit tests pass (`go test ./...`)
- [x] `internal/search` integration: `TestIntegration_SimilarJobs` — neighbours returned, source excluded, limit honoured (real Meilisearch)
- [x] `internal/handler` integration: `TestSimilarJobsEndToEnd` — known slug 200 + no leaked id, limit default/clamp, unknown slug 404 before backend (real Postgres + fake searcher)
- [x] `svelte-check` 0 errors
- [ ] Post-merge: ensure the `reindex --semantic` cron is running so neighbours stay fresh (no schema/settings change required)

Planned via OpenSpec change `add-similar-jobs` (proposal/design/specs/tasks included).