### PR TITLE
feat(web): embed brand mark in the OG card footer

### DIFF
--- a/web/src/lib/server/og/card.ts
+++ b/web/src/lib/server/og/card.ts
@@ -18,6 +18,15 @@ export const OG_HEIGHT = 630;
 
 const SKILL_LIMIT = 3;
 
+// The freehire brand mark (a circle with a diamond cut-out), inlined as a base64
+// data-URI so satori embeds it with no network fetch (satori cannot fetch remote
+// images). Coloured #0a0a0a to match the footer wordmark beside it.
+const MARK_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">' +
+  '<path fill-rule="evenodd" clip-rule="evenodd" d="M256 56C366.457 56 456 145.543 456 256C456 366.457 366.457 456 256 456C145.543 456 56 366.457 56 256C56 145.543 145.543 56 256 56ZM256 166L346 256L256 346L166 256L256 166Z" fill="#0a0a0a"/>' +
+  '</svg>';
+const MARK_DATA_URI = `data:image/svg+xml;base64,${Buffer.from(MARK_SVG).toString('base64')}`;
+
 function esc(s: string): string {
   return s
     .replace(/&/g, '&amp;')
@@ -100,7 +109,10 @@ export function buildCard(job: Job, opts: { logo: string | null }): string {
   <div style="display:flex;font-size:${titleSize}px;font-weight:700;letter-spacing:-0.03em;line-height:1.05;overflow:hidden">${esc(job.title)}</div>
   <div style="display:flex;flex-wrap:wrap;gap:12px">${chipRow}</div>
   <div style="display:flex;align-items:center;justify-content:space-between">
-    <div style="display:flex;font-size:30px;font-weight:700;letter-spacing:-0.03em">freehire</div>
+    <div style="display:flex;align-items:center;gap:14px">
+      <img src="${MARK_DATA_URI}" style="width:34px;height:34px" />
+      <div style="display:flex;font-size:30px;font-weight:700;letter-spacing:-0.03em">freehire</div>
+    </div>
     <div style="display:flex;font-size:22px;color:#a3a3a3">freehire.dev</div>
   </div>
 </div>`.trim();


### PR DESCRIPTION
Adds the freehire mark beside the footer wordmark on the per-job 1200×630 Open Graph image.

- Inlined as a base64 SVG data-URI in `card.ts` — satori cannot fetch remote images.
- Image dimensions in `style` (the documented satori gotcha), not HTML attrs.
- Coloured `#0a0a0a` to match the wordmark.

## Verification
`npm run og:smoke` — all 4 fixtures render valid PNGs; mark visible in the footer. `svelte-check` clean.