### PR TITLE
fix(search): similar jobs returns empty when source has no vector

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -373,6 +374,12 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 	return SearchResult{Hits: hits, Total: resp.EstimatedTotalHits}, nil
 }
 
+// similarSourceMissingCode is the Meilisearch error code for "the similar-query
+// source id is not a document in the index". The semantic index is built
+// incrementally (reindex --semantic), so a job present in Postgres can still lack
+// a vector — its /similar is then "no neighbours", not an error.
+const similarSourceMissingCode = "not_found_similar_id"
+
 // SimilarJobs returns the jobs nearest to job id in embedding space, queried
 // against the semantic index by the document's stored vector (no query text, no
 // re-embedding). The semantic index holds open jobs only, so neighbours are open
@@ -380,6 +387,11 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 // the source document, but we over-fetch by one and drop it defensively rather
 // than depend on that — and to avoid making the primary key a filterable
 // attribute just to express "id != source".
+//
+// A job with no vector in the semantic index yet (the index lags ingest) yields
+// an empty list, not an error: Meilisearch answers such a source id with
+// not_found_similar_id, which we map to "no neighbours" so the detail-page
+// section simply hides.
 func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDocument, error) {
 	var resp meilisearch.SimilarDocumentResult
 	err := c.semantic.SearchSimilarDocumentsWithContext(ctx, &meilisearch.SimilarDocumentQuery{
@@ -388,6 +400,10 @@ func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDoc
 		Limit:    int64(limit) + 1,
 	}, &resp)
 	if err != nil {
+		var meiliErr *meilisearch.Error
+		if errors.As(err, &meiliErr) && meiliErr.MeilisearchApiError.Code == similarSourceMissingCode {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("search: similar: %w", err)
 	}
 

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -346,6 +346,20 @@ func TestIntegration_SimilarJobs(t *testing.T) {
 			t.Errorf("limit 2 returned %d hits", len(hits))
 		}
 	})
+
+	// The semantic index is built incrementally, so a job can exist in Postgres
+	// (and thus reach this call) without a vector in the index yet. Meilisearch
+	// answers that with a 400 not_found_similar_id, which must degrade to an empty
+	// list — not a hard error — so the detail page just hides the section.
+	t.Run("source absent from the index yields empty, not an error", func(t *testing.T) {
+		hits, err := c.SimilarJobs(ctx, 9999, 10) // never indexed
+		if err != nil {
+			t.Fatalf("SimilarJobs for an unindexed id must not error: %v", err)
+		}
+		if len(hits) != 0 {
+			t.Errorf("expected no neighbours for an unindexed id, got %d", len(hits))
+		}
+	})
 }
 
 func toDocs(t *testing.T, jobs []db.Job) []JobDocument {


### PR DESCRIPTION
## Problem
`GET /api/v1/jobs/:slug/similar` returned **500** for any job whose vector isn't in `jobs_semantic` yet. The semantic index is built incrementally (`reindex --semantic --since 50h` + weekly full), so most of the catalogue isn't embedded at any given time → Meilisearch answers the `/similar` query with `400 not_found_similar_id`, which `SimilarJobs` propagated as an error.

Caught live right after deploying #173: a job that *is* in the index returns 200 with neighbours; one that isn't 500'd.

## Fix
Map Meilisearch's `not_found_similar_id` to an **empty** result (`nil, nil`) — the intended graceful degradation (the SPA section simply hides). All other errors still propagate.

## Test
- New `internal/search` integration subtest: `SimilarJobs` for an unindexed source id returns empty + no error (reproduced the exact prod 400 first → RED, then GREEN).
- Existing subtests (neighbours returned, source excluded, limit honoured) still pass.
- `go build/vet`, `gofmt`, unit tests clean.

Follow-up to #173.