### PR TITLE
feat(sources): add Freshteam adapter (Simera)

### DIFF
--- a/internal/sources/freshteam.go
+++ b/internal/sources/freshteam.go
@@ -1,0 +1,171 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// freshteam adapts Freshteam (Freshworks ATS) career sites. The board is the tenant
+// subdomain (e.g. "simera-talent"), so the career site is "<board>.freshteam.com". The
+// /jobs listing HTML enumerates the postings (paginated via ?page=N); each job page is
+// server-rendered HTML carrying a schema.org JobPosting ld+json block, so the description
+// comes from a per-job detail fetch (bounded-concurrency), like the other detail adapters.
+type freshteam struct {
+	http HTMLGetter
+}
+
+// NewFreshteam builds the Freshteam adapter over the given HTTP client.
+func NewFreshteam(c HTMLGetter) Source { return freshteam{http: c} }
+
+func (freshteam) Provider() string { return "freshteam" }
+
+// ftMaxPages bounds listing pagination so a board that never returns an empty page cannot
+// loop forever.
+const ftMaxPages = 100
+
+func (f freshteam) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	// base carries the scheme+host; relative job hrefs resolve against it (an absolute href
+	// resolves to itself), so it is parsed once rather than per listing page.
+	base, err := url.Parse(fmt.Sprintf("https://%s.freshteam.com/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("freshteam: board %q: %w", e.Board, err)
+	}
+
+	var urls []string
+	seen := make(map[string]bool)
+	for page := 1; page <= ftMaxPages; page++ {
+		listURL := fmt.Sprintf("https://%s.freshteam.com/jobs?page=%d", e.Board, page)
+		root, err := f.http.GetHTML(ctx, listURL)
+		if err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("freshteam: listing %s: %w", e.Board, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		// Stop on the first page that adds no new links: an empty page, or a board that
+		// serves the same page for any ?page=N (de-dup turns the repeat into zero new).
+		newLinks := 0
+		for _, link := range ftJobLinks(base, root) {
+			if !seen[link] {
+				seen[link] = true
+				urls = append(urls, link)
+				newLinks++
+			}
+		}
+		if newLinks == 0 {
+			break
+		}
+	}
+
+	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return f.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the page fetch fails, carries no JobPosting, or has no parseable id, so the caller
+// skips just that posting.
+func (f freshteam) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := ftJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := f.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p ftPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	location := joinNonEmpty(
+		p.JobLocation.Address.AddressLocality,
+		p.JobLocation.Address.AddressRegion,
+		p.JobLocation.Address.AddressCountry,
+	)
+
+	// Freshteam carries an explicit remote flag as a string ("true"/"false"); isRemote
+	// (location) is only a fallback (never the title, which false-positives on "Remote …"
+	// role names).
+	remote := strings.EqualFold(strings.TrimSpace(p.Remote), "true") || isRemote(location)
+
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      remote,
+		WorkMode:    workModeFromRemote(remote),
+		PostedAt:    parseSpaceTime(p.DatePosted),
+	}, true
+}
+
+// ftJobIDPattern captures the native posting id from a job URL's /jobs/<id> segment. The
+// live listing slugs the permalink as /jobs/<id>/<slug>, so the id is the leading 12-char
+// [A-Za-z0-9_-] segment followed by a path boundary; the same id also appears bare in the
+// apply page's ?jobId. Anchoring to the boundary keeps non-job paths (/jobs, /jobs/search)
+// from matching.
+var ftJobIDPattern = regexp.MustCompile(`/jobs/([A-Za-z0-9_-]{12})(?:[/?#]|$)`)
+
+// ftJobID extracts the native posting id from a job page URL, or "" when the URL is not a
+// job permalink.
+func ftJobID(u string) string {
+	if m := ftJobIDPattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// ftPosting is the schema.org JobPosting decoded from a Freshteam job page's
+// application/ld+json block. Unlike Teamtailor, jobLocation is a single object.
+type ftPosting struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	DatePosted  string `json:"datePosted"`
+	// Freshteam serializes remote as a JSON string ("true"/"false"), not a bool.
+	Remote      string `json:"remote"`
+	JobLocation struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+			AddressRegion   string `json:"addressRegion"`
+			AddressCountry  string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+}
+
+// ftJobLinks returns the absolute hrefs of all anchors linking a /jobs/<id> job page,
+// resolved against base (the listing URL) so a board that emits relative hrefs still yields
+// fetchable URLs, de-duplicated in first-seen order (a card links the same job from its
+// title and apply button).
+func ftJobLinks(base *url.URL, root *html.Node) []string {
+	var out []string
+	seen := make(map[string]bool)
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := attr(n, "href")
+			if ftJobID(href) == "" {
+				return true
+			}
+			ref, err := url.Parse(href)
+			if err != nil {
+				return true // unparseable href → not a usable job link
+			}
+			abs := base.ResolveReference(ref).String()
+			if !seen[abs] {
+				seen[abs] = true
+				out = append(out, abs)
+			}
+		}
+		return true
+	})
+	return out
+}

--- a/internal/sources/freshteam_test.go
+++ b/internal/sources/freshteam_test.go
@@ -1,0 +1,174 @@
+package sources
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ftListingHTML builds a Freshteam /jobs listing page linking each given job URL.
+func ftListingHTML(jobURLs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jobs">`)
+	for _, u := range jobURLs {
+		b.WriteString(`<a href="` + u + `">A job</a>`)
+	}
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// ftDetailHTML builds a Freshteam job page carrying a schema.org JobPosting ld+json block.
+// Freshteam emits jobLocation as a single object (not an array) and a top-level remote bool.
+func ftDetailHTML(title, encodedDescription, datePosted, region, country string, remote bool) string {
+	rem := "false"
+	if remote {
+		rem = "true"
+	}
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"http://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + encodedDescription + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"employmentType":"FULL_TIME",` +
+		// Freshteam emits remote as a JSON string ("true"/"false"), not a bare bool.
+		`"remote":"` + rem + `",` +
+		`"hiringOrganization":{"@type":"Organization","name":"Simera"},` +
+		`"jobLocation":{"@type":"Place","address":{"addressRegion":"` + region + `","addressCountry":"` + country + `"}}}` +
+		`</script></head><body></body></html>`
+}
+
+func TestFreshteamProvider(t *testing.T) {
+	if got := NewFreshteam(nil).Provider(); got != "freshteam" {
+		t.Errorf("Provider() = %q, want %q", got, "freshteam")
+	}
+}
+
+func TestFTJobID(t *testing.T) {
+	cases := map[string]string{
+		// The live listing slugs the permalink as /jobs/<id>/<slug>; the id is the leading
+		// 12-char segment regardless of any trailing slug.
+		"https://simera-talent.freshteam.com/jobs/8OA37qwQgD2C/back-end-developer-br-3": "8OA37qwQgD2C",
+		"/jobs/_-MH_W5oSn7f/seo-manager-bolivia":                                        "_-MH_W5oSn7f",
+		"https://simera-talent.freshteam.com/jobs/-9IgOtRyhpgD":                         "-9IgOtRyhpgD", // bare id (apply page passes it as ?jobId)
+		"https://simera-talent.freshteam.com/jobs":                                      "",             // listing, no id
+		"https://simera-talent.freshteam.com/jobs/search":                               "",             // not a 12-char id
+		"https://simera-talent.freshteam.com/about":                                     "",
+	}
+	for u, want := range cases {
+		if got := ftJobID(u); got != want {
+			t.Errorf("ftJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestFTJobLinksResolvesRelativeHrefs(t *testing.T) {
+	// A relative href must still yield an absolute, fetchable URL — otherwise the detail
+	// GET fails on a bare path and the posting silently drops.
+	// Each card links the same job twice (heading + apply); de-dup keeps it once.
+	h := `<html><body>
+		<a href="/jobs/8OA37qwQgD2C/back-end-developer-br-3" class="heading">Engineer</a>
+		<a href="/jobs/8OA37qwQgD2C/back-end-developer-br-3" class="apply">Apply</a>
+		<a href="https://simera-talent.freshteam.com/jobs/_-MH_W5oSn7f/seo-manager-bolivia">Designer</a>
+		<a href="/jobs">All jobs</a>
+		<a href="/about">About</a>
+	</body></html>`
+	base := mustURL(t, "https://simera-talent.freshteam.com/jobs?page=1")
+	got := ftJobLinks(base, parseHTML(t, h))
+	want := []string{
+		"https://simera-talent.freshteam.com/jobs/8OA37qwQgD2C/back-end-developer-br-3",
+		"https://simera-talent.freshteam.com/jobs/_-MH_W5oSn7f/seo-manager-bolivia",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ftJobLinks() = %v, want %v", got, want)
+	}
+}
+
+func TestFreshteamFetchListingThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://simera-talent.freshteam.com/jobs/8OA37qwQgD2C/back-end-developer-br-3"
+	detail := ftDetailHTML(
+		"Back End Developer",
+		"&lt;p&gt;Build &lt;b&gt;it&lt;/b&gt;.&lt;/p&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+		"2026-06-17 20:44:40 UTC", "San Francisco", "United States of America", true)
+	fake := (&routedHTTP{}).
+		route("page=1", ftListingHTML(jobURL)).
+		route("page=2", ftListingHTML()).
+		route("/jobs/8OA37qwQgD2C", detail)
+
+	jobs, err := NewFreshteam(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Simera", Provider: "freshteam", Board: "simera-talent",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "8OA37qwQgD2C" {
+		t.Errorf("ExternalID = %q, want 8OA37qwQgD2C", j.ExternalID)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Title != "Back End Developer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Simera" {
+		t.Errorf("Company = %q, want Simera", j.Company)
+	}
+	if j.Location != "San Francisco, United States of America" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if !j.Remote {
+		t.Errorf("Remote = false, want true (JSON-LD remote:true)")
+	}
+	if strings.Contains(j.Description, "<script>") ||
+		!strings.Contains(j.Description, "<p>") || !strings.Contains(j.Description, "<b>it</b>") {
+		t.Errorf("Description not unescaped/sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 17, 20, 44, 40, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-17 20:44:40 UTC", j.PostedAt)
+	}
+}
+
+func TestFreshteamPaginatesUntilNoNewLinks(t *testing.T) {
+	d := ftDetailHTML("Role", "&lt;p&gt;x&lt;/p&gt;", "2026-06-17 20:44:40 UTC", "Berlin", "Germany", false)
+	fake := (&routedHTTP{}).
+		route("page=1", ftListingHTML(
+			"https://b.freshteam.com/jobs/aaaaaaaaaaaa",
+			"https://b.freshteam.com/jobs/bbbbbbbbbbbb")).
+		route("page=2", ftListingHTML("https://b.freshteam.com/jobs/cccccccccccc")).
+		route("page=3", ftListingHTML()).
+		route("/jobs/aaaaaaaaaaaa", d).
+		route("/jobs/bbbbbbbbbbbb", d).
+		route("/jobs/cccccccccccc", d)
+
+	jobs, err := NewFreshteam(fake).Fetch(context.Background(), CompanyEntry{Company: "B", Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (two pages enumerated)", len(jobs))
+	}
+}
+
+func TestFreshteamDropsUnfetchableDetail(t *testing.T) {
+	// A detail page that 404s drops just that posting; the rest of the board still ingests.
+	d := ftDetailHTML("Role", "&lt;p&gt;x&lt;/p&gt;", "2026-06-17 20:44:40 UTC", "Oslo", "Norway", false)
+	fake := (&routedHTTP{}).
+		route("page=1", ftListingHTML(
+			"https://b.freshteam.com/jobs/aaaaaaaaaaaa",
+			"https://b.freshteam.com/jobs/bbbbbbbbbbbb")).
+		route("page=2", ftListingHTML()).
+		route("/jobs/aaaaaaaaaaaa", d) // no route for bbbb → GetHTML errors → drops
+
+	jobs, err := NewFreshteam(fake).Fetch(context.Background(), CompanyEntry{Company: "B", Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (one detail dropped)", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -129,6 +129,7 @@ func All(c HTTPClient) map[string]Source {
 		NewGlobalPayments(c),
 		NewOracle(c),
 		NewEightfold(c),
+		NewFreshteam(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/sources/freshteam.yml
+++ b/sources/freshteam.yml
@@ -1,0 +1,6 @@
+# freshteam boards. Provider is the filename; each entry is company + board.
+# board = the Freshteam tenant subdomain (career site is <board>.freshteam.com;
+# see internal/sources/freshteam.go).
+
+- company: Simera
+  board: simera-talent

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -105,7 +105,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'eightfold', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'lever', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'wpyoast'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'eightfold', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'lever', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'wpyoast'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## What

New `freshteam` source adapter for **Freshteam** (Freshworks ATS) career sites, seeded with **Simera** (`simera-talent`).

Simera's public `simeras-spectacular-site.webflow.io/...?jobId=<id>` apply page is a Webflow shell with no job content — but its embedded `widget.js` fronts a Freshteam tenant (`simera-talent.freshteam.com`), where each `jobId` is a real `/jobs/<id>` posting with a schema.org `JobPosting` ld+json. ~1.4k open postings.

## How

Mirrors the `teamtailor` shape (the closest existing pattern):
- **board** = tenant subdomain (`<board>.freshteam.com`).
- **Listing**: paginate `/jobs?page=N`, extract `/jobs/<id>` anchors, de-dup, stop when a page yields no new links (live: converges at page 3).
- **Detail**: fetch each `/jobs/<id>` under bounded concurrency, decode its `JobPosting` ld+json via the shared `ldJobPosting` helper.

## Live-data quirks the fixtures mirror (caught by an end-to-end smoke, not unit tests)

- Permalink is **slugged**: `/jobs/<12-char-id>/<slug>`; ExternalID is the id, so dedup is stable across slug variants.
- `remote` is a JSON **string** (`"true"`/`"false"`), **not a bool** — decoding it as bool made `json.Unmarshal` error mid-decode and silently dropped *every* posting. `Remote string` + compare.
- `datePosted` is `2006-01-02 15:04:05 MST` → existing `parseSpaceTime`.

Verified live: all 5 user-supplied job ids parse (title/location/remote/description). Geography dict resolves the SF/US address; work_mode `remote` from the flag.

## Tests / checks

- 6 unit tests (id regex incl. slug, link resolution + de-dup, fetch→map, pagination, detail-drop).
- `go build ./... && go vet ./... && go test ./...` green; gofmt clean.
- `SOURCE_VALUES` regenerated (gen-contracts) so the SPA Source facet knows `freshteam`.

## Deploy

New Go adapter → **full image rebuild** (not sources-rsync). Add a cron schedule for `sources/freshteam.yml`.