### PR TITLE
fix(sources): mycareersfuture tolerates mid-sweep rate-limit (partial ingest)

### DIFF
--- a/internal/sources/mycareersfuture.go
+++ b/internal/sources/mycareersfuture.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"log"
 )
 
 // mycareersfuture adapts mycareersfuture.gov.sg, the Singapore government job portal.
@@ -57,7 +58,15 @@ func (s mycareersfuture) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, erro
 		}
 		url := fmt.Sprintf(mcfListURL, mcfPageSize, page)
 		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
-			return nil, fmt.Errorf("mycareersfuture: page %d: %w", page, err)
+			if page == 0 {
+				return nil, fmt.Errorf("mycareersfuture: page %d: %w", page, err)
+			}
+			// The portal rate-limits (429) a long paginated sweep partway through. Stop with
+			// the jobs gathered so far rather than discarding the whole crawl — the next run
+			// re-fetches idempotently. Erroring only on the very first page keeps a genuinely
+			// dead board a failure.
+			log.Printf("mycareersfuture: stopping at page %d (%v); keeping %d jobs gathered so far", page, err, len(jobs))
+			break
 		}
 		if len(resp.Results) == 0 {
 			break

--- a/internal/sources/mycareersfuture_test.go
+++ b/internal/sources/mycareersfuture_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -83,5 +84,39 @@ func TestMyCareersFutureOverseasLocation(t *testing.T) {
 	jobs, _ := NewMyCareersFuture(fake).Fetch(context.Background(), CompanyEntry{})
 	if len(jobs) != 1 || jobs[0].Location != "Malaysia" {
 		t.Fatalf("Location = %q, want Malaysia (overseas)", jobs[0].Location)
+	}
+}
+
+// TestMyCareersFuturePartialOnPageError verifies that a later-page failure (e.g. the gov
+// API rate-limiting a long sweep) keeps the jobs gathered so far instead of discarding the
+// whole crawl, and is not surfaced as an error.
+func TestMyCareersFuturePartialOnPageError(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"results":[`)
+	for i := 0; i < mcfPageSize; i++ { // a full page → adapter continues to page 1
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"uuid":"u%d","title":"Role %d","description":"<p>x</p>","postedCompany":{"name":"Acme"},"address":{},"metadata":{"newPostingDate":"2026-06-18"}}`, i, i)
+	}
+	b.WriteString(`]}`)
+	// Route only page=0; page=1 has no route → GetJSON errors → adapter breaks with partials.
+	fake := (&routedHTTP{}).route("page=0", b.String())
+
+	jobs, err := NewMyCareersFuture(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch should not error on a later-page failure: %v", err)
+	}
+	if len(jobs) != mcfPageSize {
+		t.Fatalf("got %d jobs, want %d (page 0 kept, page 1 failure tolerated)", len(jobs), mcfPageSize)
+	}
+}
+
+// TestMyCareersFutureFirstPageErrorFails verifies a page-0 failure is still a hard error
+// (a genuinely dead board, not a mid-sweep rate-limit).
+func TestMyCareersFutureFirstPageErrorFails(t *testing.T) {
+	fake := &routedHTTP{} // no routes → page 0 errors
+	if _, err := NewMyCareersFuture(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("Fetch should error when the very first page fails")
 	}
 }


### PR DESCRIPTION
## Problem
The mycareersfuture adapter (#166) failed in prod with **0 ingested**:
```
mycareersfuture: page 452: GET .../v2/jobs?...&page=452 ... status 429
ingest done: ... ingested=0 failed=1
```
The SG gov API rate-limits a long paginated sweep partway through (~page 452, ~45k jobs in). `Fetch` returned that error, so the pipeline discarded the **entire** crawl — all-or-nothing over ~850 pages is brittle.

## Fix
A failure on a **later** page now stops pagination and returns the jobs gathered so far (logged), instead of erroring out. The next run re-fetches idempotently. A **page-0** failure is still a hard error (a genuinely dead board, not a mid-sweep throttle).

This is the same tolerance other large feeds use; scoped to mycareersfuture (the only source hitting the wall — getonbrd/wantedkr/arbeitnow paginate far fewer pages and ingest fine).

## Tests
- `TestMyCareersFuturePartialOnPageError`: full page 0 + failing page 1 → keeps page 0's jobs, no error.
- `TestMyCareersFutureFirstPageErrorFails`: page-0 failure still errors.
- `go build`/`go vet`/`go test ./...` green.

## Deploy
App-only rebuild (no web/contract change). After deploy, mycareersfuture ingests the reachable prefix (~45k) instead of 0; full coverage is bounded by the gov API's rate limit from the datacenter IP.