### PR TITLE
feat(sources): add workingnomads, himalayas, remotive, justjoin aggregators

### DIFF
--- a/internal/sources/himalayas.go
+++ b/internal/sources/himalayas.go
@@ -1,0 +1,91 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+)
+
+// himalayas adapts himalayas.app, a remote-jobs aggregator. Boardless (one public API, no
+// per-tenant board) and multi-company, so it stays in the source facet and takes each
+// posting's company from the feed. The /jobs/api endpoint pages by offset/limit over a
+// reported totalCount; the site is remote-only, so every job is remote.
+type himalayas struct {
+	http JSONGetter
+}
+
+const (
+	// himalayasLimit is the page size requested per offset page.
+	himalayasLimit = 100
+	// himalayasMaxPages caps pagination so a runaway/over-reported totalCount cannot loop
+	// indefinitely (the same defensive bound the other paginating adapters carry).
+	himalayasMaxPages = 400
+	himalayasListURL  = "https://himalayas.app/jobs/api?limit=%d&offset=%d"
+)
+
+// NewHimalayas builds the Himalayas adapter over the given HTTP client.
+func NewHimalayas(c JSONGetter) Source { return himalayas{http: c} }
+
+func (himalayas) Provider() string { return "himalayas" }
+
+func (himalayas) boardless() {}
+
+func (himalayas) aggregator() {}
+
+// himalayasResponse is one offset page: the postings plus the catalogue-wide total used to
+// decide whether another page is due.
+type himalayasResponse struct {
+	TotalCount int                `json:"totalCount"`
+	Jobs       []himalayasPosting `json:"jobs"`
+}
+
+// himalayasPosting is one posting, body inline (no detail call). pubDate is epoch seconds.
+type himalayasPosting struct {
+	Title                string   `json:"title"`
+	CompanyName          string   `json:"companyName"`
+	ApplicationLink      string   `json:"applicationLink"`
+	GUID                 string   `json:"guid"`
+	LocationRestrictions []string `json:"locationRestrictions"`
+	Description          string   `json:"description"`
+	PubDate              int64    `json:"pubDate"`
+}
+
+func (s himalayas) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for offset, page := 0, 0; page < himalayasMaxPages; offset, page = offset+himalayasLimit, page+1 {
+		var resp himalayasResponse
+		url := fmt.Sprintf(himalayasListURL, himalayasLimit, offset)
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("himalayas: list offset %d: %w", offset, err)
+		}
+		for _, p := range resp.Jobs {
+			if job, ok := p.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		// Stop once this page's offset covers the reported total, or the page came back
+		// empty (defensive against a total that never shrinks).
+		if len(resp.Jobs) == 0 || offset+himalayasLimit >= resp.TotalCount {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
+// guid to key on, or no company which would break the slug). Himalayas lists only remote jobs.
+func (p himalayasPosting) toJob() (Job, bool) {
+	if p.GUID == "" || p.CompanyName == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  p.GUID,
+		URL:         p.ApplicationLink,
+		Title:       p.Title,
+		Company:     p.CompanyName,
+		Location:    joinNonEmpty(p.LocationRestrictions...),
+		Description: sanitizeHTML(p.Description),
+		Remote:      true,
+		WorkMode:    "remote",
+		PostedAt:    parseEpochSeconds(p.PubDate),
+	}, true
+}

--- a/internal/sources/himalayas_test.go
+++ b/internal/sources/himalayas_test.go
@@ -1,0 +1,84 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestHimalayasProvider(t *testing.T) {
+	if got := NewHimalayas(nil).Provider(); got != "himalayas" {
+		t.Errorf("Provider() = %q, want himalayas", got)
+	}
+}
+
+func TestHimalayasIsBoardlessAggregator(t *testing.T) {
+	s := NewHimalayas(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("himalayas should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("himalayas should implement the aggregator marker")
+	}
+}
+
+func TestHimalayasRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["himalayas"]; !ok {
+		t.Error("All() should register provider himalayas")
+	}
+	if !slices.Contains(FilterableProviders(), "himalayas") {
+		t.Error("FilterableProviders() should include himalayas")
+	}
+}
+
+func TestHimalayasBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/himalayas.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/himalayas.yml fails validation: %v", err)
+	}
+}
+
+func TestHimalayasFetchPaginatesAndMaps(t *testing.T) {
+	// totalCount (150) exceeds one page (limit 100), so the adapter must fetch a second
+	// offset page and stop once offset passes totalCount.
+	page1 := `{"totalCount":150,"jobs":[
+{"title":"Web Engineer","companyName":"KraftPixel","applicationLink":"https://himalayas.app/companies/kraftpixel/jobs/web-engineer","guid":"https://himalayas.app/companies/kraftpixel/jobs/web-engineer","locationRestrictions":["United States","Canada"],"description":"<p>Build web.</p>","pubDate":1747699200},
+{"title":"NoGUID drop","companyName":"Ghost","guid":""}
+]}`
+	page2 := `{"totalCount":150,"jobs":[
+{"title":"Data Analyst","companyName":"Peroptyx","applicationLink":"https://himalayas.app/companies/peroptyx/jobs/data-analyst","guid":"https://himalayas.app/companies/peroptyx/jobs/data-analyst","locationRestrictions":["Ireland"],"description":"<p>Analyze.</p>","pubDate":1781725000}
+]}`
+	fake := (&routedHTTP{}).route("offset=100", page2).route("offset=0", page1)
+	jobs, err := NewHimalayas(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.calls != 2 {
+		t.Errorf("made %d requests, want 2 (one per offset page)", fake.calls)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (empty-guid dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "https://himalayas.app/companies/kraftpixel/jobs/web-engineer" {
+		t.Errorf("ExternalID = %q, want the guid", j.ExternalID)
+	}
+	if j.Company != "KraftPixel" || j.Title != "Web Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://himalayas.app/companies/kraftpixel/jobs/web-engineer" {
+		t.Errorf("URL = %q, want applicationLink", j.URL)
+	}
+	if j.Location != "United States, Canada" {
+		t.Errorf("Location = %q, want joined locationRestrictions", j.Location)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote (himalayas is remote-only)", j.Remote, j.WorkMode)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed epoch seconds")
+	}
+}

--- a/internal/sources/justjoin.go
+++ b/internal/sources/justjoin.go
@@ -1,0 +1,102 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+)
+
+// justjoin adapts justjoin.it, a Polish/CEE IT job marketplace. Boardless (one public API,
+// no per-tenant board) and multi-company, so it stays in the source facet and takes each
+// posting's company from the feed. The by-cursor endpoint pages by a numeric cursor returned
+// in meta.next; the list response has no apply link, so the canonical URL is synthesized from
+// the posting slug.
+type justjoin struct {
+	http JSONGetter
+}
+
+const (
+	// justJoinMaxPages caps pagination as a backstop (the strictly-increasing cursor guard
+	// below is the primary stop; this bounds a pathological feed).
+	justJoinMaxPages = 600
+	justJoinBaseURL  = "https://api.justjoin.it/v2/user-panel/offers/by-cursor"
+	// justJoinOfferURL builds the canonical detail URL the feed omits, from the slug.
+	justJoinOfferURL = "https://justjoin.it/job-offer/%s"
+)
+
+// NewJustJoin builds the JustJoin adapter over the given HTTP client.
+func NewJustJoin(c JSONGetter) Source { return justjoin{http: c} }
+
+func (justjoin) Provider() string { return "justjoin" }
+
+func (justjoin) boardless() {}
+
+func (justjoin) aggregator() {}
+
+// justJoinResponse is one cursor page: the offers plus the cursor for the next page (nil at
+// the end of the feed).
+type justJoinResponse struct {
+	Data []justJoinOffer `json:"data"`
+	Meta struct {
+		Next *struct {
+			Cursor int `json:"cursor"`
+		} `json:"next"`
+	} `json:"meta"`
+}
+
+// justJoinOffer is one offer. publishedAt is RFC3339 with millisecond precision.
+type justJoinOffer struct {
+	GUID          string `json:"guid"`
+	Slug          string `json:"slug"`
+	Title         string `json:"title"`
+	CompanyName   string `json:"companyName"`
+	City          string `json:"city"`
+	WorkplaceType string `json:"workplaceType"`
+	PublishedAt   string `json:"publishedAt"`
+}
+
+func (s justjoin) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	cursor := 0
+	for page := 0; page < justJoinMaxPages; page++ {
+		url := justJoinBaseURL
+		if cursor > 0 {
+			// The cursor value from meta.next.cursor is passed back as the `from` query
+			// parameter (verified live — `?cursor=` is silently ignored and never advances).
+			url = fmt.Sprintf("%s?from=%d", justJoinBaseURL, cursor)
+		}
+		var resp justJoinResponse
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("justjoin: list cursor %d: %w", cursor, err)
+		}
+		for _, o := range resp.Data {
+			if job, ok := o.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		// Stop at the end of the feed, or whenever the cursor fails to advance — a
+		// non-increasing cursor means the page param was ignored (refetching page 1) or
+		// the feed looped, so one extra request is the worst case, never an endless loop.
+		if resp.Meta.Next == nil || resp.Meta.Next.Cursor <= cursor {
+			break
+		}
+		cursor = resp.Meta.Next.Cursor
+	}
+	return jobs, nil
+}
+
+// toJob maps an offer to a Job, returning ok=false for an unusable offer (no slug to build
+// the URL, no guid to key on, or no company which would break the slug).
+func (o justJoinOffer) toJob() (Job, bool) {
+	if o.Slug == "" || o.GUID == "" || o.CompanyName == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID: o.GUID,
+		URL:        fmt.Sprintf(justJoinOfferURL, o.Slug),
+		Title:      o.Title,
+		Company:    o.CompanyName,
+		Location:   o.City,
+		WorkMode:   workplaceTypeMode(o.WorkplaceType),
+		PostedAt:   parseRFC3339(o.PublishedAt),
+	}, true
+}

--- a/internal/sources/justjoin_test.go
+++ b/internal/sources/justjoin_test.go
@@ -1,0 +1,83 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestJustJoinProvider(t *testing.T) {
+	if got := NewJustJoin(nil).Provider(); got != "justjoin" {
+		t.Errorf("Provider() = %q, want justjoin", got)
+	}
+}
+
+func TestJustJoinIsBoardlessAggregator(t *testing.T) {
+	s := NewJustJoin(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("justjoin should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("justjoin should implement the aggregator marker")
+	}
+}
+
+func TestJustJoinRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["justjoin"]; !ok {
+		t.Error("All() should register provider justjoin")
+	}
+	if !slices.Contains(FilterableProviders(), "justjoin") {
+		t.Error("FilterableProviders() should include justjoin")
+	}
+}
+
+func TestJustJoinBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/justjoin.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/justjoin.yml fails validation: %v", err)
+	}
+}
+
+func TestJustJoinFetchPaginatesAndMaps(t *testing.T) {
+	page1 := `{"data":[
+{"guid":"135d4e26","slug":"coder-security-engineer--warszawa","title":"Security Engineer","companyName":"Coder","city":"Warszawa","workplaceType":"remote","publishedAt":"2026-05-19T00:41:27.040Z"},
+{"guid":"noslug","slug":"","title":"drop","companyName":"Ghost"}
+],"meta":{"next":{"cursor":20}}}`
+	page2 := `{"data":[
+{"guid":"77aa","slug":"acme-go-dev--krakow","title":"Go Developer","companyName":"Acme","city":"Kraków","workplaceType":"office","publishedAt":"2026-05-18T10:00:00.000Z"}
+],"meta":{"next":null}}`
+	fake := (&routedHTTP{}).route("from=20", page2).route("by-cursor", page1)
+	jobs, err := NewJustJoin(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.calls != 2 {
+		t.Errorf("made %d requests, want 2 (one per cursor page)", fake.calls)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (empty-slug dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "135d4e26" || j.Company != "Coder" || j.Title != "Security Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://justjoin.it/job-offer/coder-security-engineer--warszawa" {
+		t.Errorf("URL = %q, want synthesized job-offer URL", j.URL)
+	}
+	if j.Location != "Warszawa" {
+		t.Errorf("Location = %q, want city", j.Location)
+	}
+	if j.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (from workplaceType)", j.WorkMode)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed RFC3339 with millis")
+	}
+	// Second page's "office" workplaceType maps to onsite.
+	if jobs[1].WorkMode != "onsite" {
+		t.Errorf("jobs[1].WorkMode = %q, want onsite (office)", jobs[1].WorkMode)
+	}
+}

--- a/internal/sources/remotive.go
+++ b/internal/sources/remotive.go
@@ -1,0 +1,77 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+)
+
+// remotive adapts remotive.com, a remote-jobs aggregator. Boardless (one public API, no
+// per-tenant board) and multi-company, so it stays in the source facet and takes each
+// posting's company from the feed. The /api/remote-jobs feed carries every posting's body
+// inline and is fetched ONCE per run: the API is rate-limited (data is 24h-delayed and the
+// provider asks for at most a few requests a day), so the adapter never paginates or polls.
+// Remotive lists only remote jobs.
+type remotive struct {
+	http JSONGetter
+}
+
+const remotiveListURL = "https://remotive.com/api/remote-jobs"
+
+// remotivePubLayout is Remotive's publication_date format: ISO 8601 with no timezone
+// ("2026-06-16T06:59:30"), so RFC3339 parsing would reject it.
+const remotivePubLayout = "2006-01-02T15:04:05"
+
+// NewRemotive builds the Remotive adapter over the given HTTP client.
+func NewRemotive(c JSONGetter) Source { return remotive{http: c} }
+
+func (remotive) Provider() string { return "remotive" }
+
+func (remotive) boardless() {}
+
+func (remotive) aggregator() {}
+
+// remotivePosting is one posting from the /api/remote-jobs feed, body inline (no detail call).
+type remotivePosting struct {
+	ID                        int64  `json:"id"`
+	URL                       string `json:"url"`
+	Title                     string `json:"title"`
+	CompanyName               string `json:"company_name"`
+	CandidateRequiredLocation string `json:"candidate_required_location"`
+	Description               string `json:"description"`
+	PublicationDate           string `json:"publication_date"`
+}
+
+func (s remotive) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var resp struct {
+		Jobs []remotivePosting `json:"jobs"`
+	}
+	if err := s.http.GetJSON(ctx, remotiveListURL, &resp); err != nil {
+		return nil, fmt.Errorf("remotive: list: %w", err)
+	}
+	jobs := make([]Job, 0, len(resp.Jobs))
+	for _, p := range resp.Jobs {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
+// native id, or no company which would break the slug). Remotive lists only remote jobs.
+func (p remotivePosting) toJob() (Job, bool) {
+	if p.ID == 0 || p.CompanyName == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  fmt.Sprintf("%d", p.ID),
+		URL:         p.URL,
+		Title:       p.Title,
+		Company:     p.CompanyName,
+		Location:    p.CandidateRequiredLocation,
+		Description: sanitizeHTML(p.Description),
+		Remote:      true,
+		WorkMode:    "remote",
+		PostedAt:    parseLayout(remotivePubLayout, p.PublicationDate),
+	}, true
+}

--- a/internal/sources/remotive_test.go
+++ b/internal/sources/remotive_test.go
@@ -1,0 +1,70 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestRemotiveProvider(t *testing.T) {
+	if got := NewRemotive(nil).Provider(); got != "remotive" {
+		t.Errorf("Provider() = %q, want remotive", got)
+	}
+}
+
+func TestRemotiveIsBoardlessAggregator(t *testing.T) {
+	s := NewRemotive(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("remotive should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("remotive should implement the aggregator marker")
+	}
+}
+
+func TestRemotiveRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["remotive"]; !ok {
+		t.Error("All() should register provider remotive")
+	}
+	if !slices.Contains(FilterableProviders(), "remotive") {
+		t.Error("FilterableProviders() should include remotive")
+	}
+}
+
+func TestRemotiveBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/remotive.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/remotive.yml fails validation: %v", err)
+	}
+}
+
+func TestRemotiveFetchSingleRequestAndMaps(t *testing.T) {
+	feed := `{"jobs":[
+{"id":2090991,"url":"https://remotive.com/remote-jobs/software-development/frontend-developer-2090991","title":"Frontend Developer","company_name":"Quinncia Inc","category":"Software Development","job_type":"full_time","publication_date":"2026-06-16T06:59:30","candidate_required_location":"Worldwide","description":"<p>Build UIs.</p>"},
+{"id":0,"company_name":"NoID","title":"skip"}
+]}`
+	fake := (&routedHTTP{}).route("remote-jobs", feed)
+	jobs, err := NewRemotive(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.calls != 1 {
+		t.Errorf("made %d requests, want exactly 1 (rate-limited API, no pagination)", fake.calls)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (zero-id dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "2090991" || j.Company != "Quinncia Inc" || j.Title != "Frontend Developer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.Location != "Worldwide" || !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Location=%q Remote=%v WorkMode=%q", j.Location, j.Remote, j.WorkMode)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed zoneless ISO timestamp")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -144,6 +144,10 @@ func All(c HTTPClient) map[string]Source {
 		NewGetonbrd(c),
 		NewWantedKR(c),
 		NewMyCareersFuture(c),
+		NewWorkingNomads(c),
+		NewHimalayas(c),
+		NewRemotive(c),
+		NewJustJoin(c),
 		// International single-company adapters (boardless).
 		NewUber(c),
 		NewAmazon(c),
@@ -246,15 +250,15 @@ func workModeFromRemote(remote bool) string {
 	return ""
 }
 
-// workplaceTypeMode maps an ATS workplace-type enum (as Lever exposes) to our work
-// mode vocabulary; an unspecified/unknown value yields "".
+// workplaceTypeMode maps an ATS workplace-type enum (as Lever and JustJoin expose) to our
+// work mode vocabulary; an unspecified/unknown value yields "".
 func workplaceTypeMode(t string) string {
 	switch strings.ToLower(strings.TrimSpace(t)) {
 	case "remote":
 		return "remote"
 	case "hybrid":
 		return "hybrid"
-	case "on-site", "onsite", "on site":
+	case "on-site", "onsite", "on site", "office":
 		return "onsite"
 	default:
 		return ""

--- a/internal/sources/workingnomads.go
+++ b/internal/sources/workingnomads.go
@@ -1,0 +1,77 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// workingnomads adapts workingnomads.com, a remote-jobs aggregator. Boardless (one public
+// feed, no per-tenant board) and multi-company, so it stays in the source facet and takes
+// each posting's company from the feed. The /api/exposed_jobs/ endpoint returns a single
+// flat array with every posting's body inline (no detail call); the response is the recent
+// window, so coverage is that window. The site is remote-only, so every job is remote.
+type workingnomads struct {
+	http JSONGetter
+}
+
+const workingNomadsListURL = "https://www.workingnomads.com/api/exposed_jobs/"
+
+// workingNomadsIDRE pulls the posting id from the trailing path segment of the job URL
+// (e.g. https://www.workingnomads.com/job/go/1663269/), because the feed carries no id
+// field. A URL without a numeric tail yields no id and the posting is dropped.
+var workingNomadsIDRE = regexp.MustCompile(`/(\d+)/?$`)
+
+// NewWorkingNomads builds the Working Nomads adapter over the given HTTP client.
+func NewWorkingNomads(c JSONGetter) Source { return workingnomads{http: c} }
+
+func (workingnomads) Provider() string { return "workingnomads" }
+
+func (workingnomads) boardless() {}
+
+func (workingnomads) aggregator() {}
+
+// workingNomadsPosting is one posting from the /api/exposed_jobs/ feed, body inline.
+type workingNomadsPosting struct {
+	URL         string `json:"url"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	CompanyName string `json:"company_name"`
+	Location    string `json:"location"`
+	PubDate     string `json:"pub_date"`
+}
+
+func (s workingnomads) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var postings []workingNomadsPosting
+	if err := s.http.GetJSON(ctx, workingNomadsListURL, &postings); err != nil {
+		return nil, fmt.Errorf("workingnomads: list: %w", err)
+	}
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no id
+// derivable from the URL, or no company which would break the slug). Working Nomads lists
+// only remote jobs.
+func (p workingNomadsPosting) toJob() (Job, bool) {
+	m := workingNomadsIDRE.FindStringSubmatch(p.URL)
+	if m == nil || p.CompanyName == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  m[1],
+		URL:         p.URL,
+		Title:       p.Title,
+		Company:     p.CompanyName,
+		Location:    p.Location,
+		Description: sanitizeHTML(p.Description),
+		Remote:      true,
+		WorkMode:    "remote",
+		PostedAt:    parseRFC3339(p.PubDate),
+	}, true
+}

--- a/internal/sources/workingnomads_test.go
+++ b/internal/sources/workingnomads_test.go
@@ -1,0 +1,73 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestWorkingNomadsProvider(t *testing.T) {
+	if got := NewWorkingNomads(nil).Provider(); got != "workingnomads" {
+		t.Errorf("Provider() = %q, want workingnomads", got)
+	}
+}
+
+func TestWorkingNomadsIsBoardlessAggregator(t *testing.T) {
+	s := NewWorkingNomads(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("workingnomads should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("workingnomads should implement the aggregator marker")
+	}
+}
+
+func TestWorkingNomadsRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["workingnomads"]; !ok {
+		t.Error("All() should register provider workingnomads")
+	}
+	if !slices.Contains(FilterableProviders(), "workingnomads") {
+		t.Error("FilterableProviders() should include workingnomads")
+	}
+}
+
+func TestWorkingNomadsBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/workingnomads.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/workingnomads.yml fails validation: %v", err)
+	}
+}
+
+func TestWorkingNomadsFetchMaps(t *testing.T) {
+	feed := `[
+{"url":"https://www.workingnomads.com/job/go/1663269/","title":"Senior React Native Developer","description":"<p>Build apps.</p>","company_name":"Lemon.io","category_name":"Development","tags":"react native,react,nodejs","location":"Europe, North America","pub_date":"2026-06-12T11:32:31-04:00"},
+{"url":"https://www.workingnomads.com/about/","title":"No numeric id","company_name":"Nope"}
+]`
+	fake := (&routedHTTP{}).route("exposed_jobs", feed)
+	jobs, err := NewWorkingNomads(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (no-id posting dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "1663269" {
+		t.Errorf("ExternalID = %q, want 1663269 (parsed from URL)", j.ExternalID)
+	}
+	if j.Company != "Lemon.io" || j.Title != "Senior React Native Developer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://www.workingnomads.com/job/go/1663269/" || j.Location != "Europe, North America" {
+		t.Errorf("URL=%q Location=%q", j.URL, j.Location)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote (workingnomads is remote-only)", j.Remote, j.WorkMode)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed RFC3339")
+	}
+}

--- a/openspec/changes/add-api-aggregator-sources/.openspec.yaml
+++ b/openspec/changes/add-api-aggregator-sources/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-17

--- a/openspec/changes/add-api-aggregator-sources/design.md
+++ b/openspec/changes/add-api-aggregator-sources/design.md
@@ -1,0 +1,79 @@
+## Context
+
+Five public job boards were verified live this session to expose clean JSON APIs with their
+own inventory. They all fit the established **aggregator** adapter shape — boardless, one
+global feed, company-per-posting — already used by `jobicy`, `remoteok`, and `tecla`. No new
+abstraction is needed; this change is five instances of an existing pattern plus wiring.
+
+## Goals / Non-Goals
+
+**Goals:** add `workingnomads`, `himalayas`, `landingjobs`, `remotive`, `justjoin` as
+boardless aggregator sources, each with a unit test over a captured fixture, registered in
+`sources.All` and surfaced in the source facet.
+
+**Non-Goals:** salary capture (no field on `sources.Job`); skills/seniority/geo parsing
+(owned by the ingest dictionaries, applied downstream); cron scheduling (lives in
+`freehire-ops`); any schema/migration/API change; a headless tier (this repo has none).
+
+## Decisions
+
+- **One change, five adapters.** They are homogeneous and share the pattern, so a single
+  change/PR (one image rebuild, one deploy) is simpler than five near-identical PRs. Each
+  adapter is still an independent task with its own RED→GREEN→review cycle.
+- **`ExternalID` source per provider.** Use the platform's stable id where present
+  (`himalayas.guid`, `remotive.id`, `landingjobs.id`, `justjoin.guid`). Working Nomads has
+  **no** id field, so parse it from the `/job/go/<id>/` URL path; drop a posting whose URL
+  yields no id rather than persist an empty id (which would collide under the
+  `(source, external_id)` dedup key).
+- **Canonical `URL`.** Use the feed's link where given. JustJoin's list response omits the
+  apply link, so synthesize `https://justjoin.it/job-offer/<slug>` (the `jobstash` precedent
+  for a protected/absent URL).
+- **`WorkMode` from structured fields only.** `landingjobs.remote` (bool) →
+  `workModeFromRemote`; `justjoin.workplaceType` → `workplaceTypeMode`. Remotive is
+  remote-only → `"remote"` for all. Working Nomads and Himalayas expose only free-text
+  location → leave `WorkMode` empty and let the ingest location dictionary resolve it
+  (provenance stays clean: structured signal only, never the location heuristic).
+- **Pagination, bounded.** Himalayas (offset/limit over `totalCount`) and JustJoin (follow
+  `meta.next.cursor`) paginate under a defensive max-page cap (the `yandex` runaway-cursor
+  incident: a tarpitted host must not loop forever). Remotive is fetched **once** — its API
+  is rate-limited (~4 req/day, 24h delay), so a pagination loop is both unnecessary and
+  abusive. Working Nomads returns its window in a single array.
+- **Description sanitization.** All feeds carry HTML bodies inline → route through the shared
+  `sanitizeHTML` (which also folds the nbsp-overflow characters per the existing fix).
+
+## Rejected alternatives (from the same spike)
+
+- **landing.jobs** — passed the spike (clean public `/api/v1/jobs` array, rich salary/location)
+  but **dropped during implementation**: the list response carries **no structured company
+  field**. The employer appears only as a URL slug (`/at/cliftonlarsonallen/…`) and inside the
+  description prose. An aggregator's whole contract is a clean per-posting company → a clean
+  `company_slug`; deriving it from a concatenated slug (`cliftonlarsonallen`) would pollute the
+  companies table with malformed names — exactly the MVP-shortcut the project forbids. Re-add
+  only if a structured company field is found (e.g. a detail/company endpoint) and the
+  per-job cost is justified.
+- **aidevboard** — clean API, but `apply_url` points at Greenhouse/Ashby boards we already
+  crawl directly. Ingesting it as its own source would duplicate those jobs under a second
+  `(source, external_id)`. It is only worth adding if resolved through `linksource` to dedup
+  against the canonical ATS posting — deferred as a separate, harder change.
+- **gitjobs.dev, WorksHub (`*.works-hub.com`)** — no public JSON API path discovered without
+  a browser/repo dig; deferred.
+- **nofluffjobs** — Cloudflare-fronted (fetch blocked); needs a headless tier this repo lacks.
+- **jobscollider → remotefirstjobs** — `/api/v1/jobs` returns 401 (key-gated) and it
+  re-aggregates ATS we already have; skipped.
+- **devitjobs.com** — parked, redirects to a jobcopilot signup; dead.
+- **Welcome to the Jungle** — job search behind an Algolia/private key; skipped.
+- **Wellfound / Built In / HiringCafe** — auth/antibot and heavy re-aggregation of our own
+  ATS (dup risk); skipped.
+- **LinkedIn / Indeed / Glassdoor / Adzuna / Careerjet** — ToS / partner-key; out.
+
+## Risks
+
+- **Cross-source duplication** is the main risk for any aggregator. Mitigated by source
+  selection: the five chosen feeds carry their own inventory (their `URL` points at
+  themselves, or — landing.jobs/justjoin — at EU/PL companies under-represented in our ATS
+  coverage), so overlap with our 28 ATS adapters is low. Residual dupes are the existing,
+  accepted behavior (dedup is per `(source, external_id)`; the same vacancy from two sources
+  is two rows by design).
+- **API drift / rate-limits.** Each adapter fails its own board independently (the per-board
+  crawl isolation already in the pipeline), so one feed breaking does not abort a run.
+  Remotive's documented limit is respected by the single-fetch design.

--- a/openspec/changes/add-api-aggregator-sources/proposal.md
+++ b/openspec/changes/add-api-aggregator-sources/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+A spike of the public job-board ecosystem (the `awesome-job-boards` family of lists)
+surfaced multi-company job boards that each expose a **clean, public JSON API** and carry
+their **own** inventory — i.e. their postings are not just re-listings of the
+Greenhouse/Lever/Ashby boards we already crawl, so they add net-new vacancies with a low
+cross-source duplication risk. They all fit the existing **aggregator** adapter shape
+(`jobicy`, `remoteok`, `tecla`): one boardless feed, company taken per posting. Several
+neighbouring boards were rejected in the same spike (key-gated, parked, or Algolia/Cloudflare
+behind a headless wall — which this repo has no tier for), and `landing.jobs` was dropped
+during implementation when its list API turned out to carry no structured company field (see
+design). The four kept here are both additive and reachable without a browser.
+
+## What Changes
+
+- Add four `boardless` + `aggregator` source adapters, each over a verified public JSON API,
+  each mapping a posting to `sources.Job` with the employer taken from the posting:
+  - **`workingnomads`** — `GET https://www.workingnomads.com/api/exposed_jobs/` (flat JSON
+    array; no `id` field → `ExternalID` parsed from the `/job/go/<id>/` URL path).
+  - **`himalayas`** — `GET https://himalayas.app/jobs/api` (offset/limit pagination over
+    `totalCount`, ~90k jobs; bounded by a defensive max-page cap).
+  - **`remotive`** — `GET https://remotive.com/api/remote-jobs` (single fetch only — the API
+    is rate-limited to ~4 requests/day with a 24h data delay, so no pagination loop).
+  - **`justjoin`** — `GET https://api.justjoin.it/v2/user-panel/offers/by-cursor` (PL/CEE IT;
+    cursor pagination via `meta.next.cursor`; `workplaceType` → `WorkMode`; apply URL absent
+    from the list response → canonical `URL` synthesized as `https://justjoin.it/job-offer/<slug>`).
+- Register each `New…(c)` in `sources.All` and add a placeholder `sources/<provider>.yml`
+  (one entry: `company` + `provider`, boardless so no `board`).
+- The four providers join the source facet via `gen-contracts` (they are aggregators, so
+  `FilterableProviders` keeps them) — `web/src/lib/generated/contracts.ts` SOURCE_VALUES is
+  regenerated.
+- Each adapter ships a table-driven unit test over a captured live fixture, matching the
+  existing `internal/sources/*_test.go` pattern.
+
+Out of scope (intentional): no salary/skills/seniority handling beyond what the ingest
+dictionaries already derive (no salary field on `sources.Job`); the per-provider daily cron
+lives in the separate `freehire-ops` repo (a follow-up, one schedule per provider). Rejected
+sources from the same spike (recorded in design): `aidevboard` (apply_url is Greenhouse/Ashby
+→ would duplicate our existing ATS jobs unless resolved through `linksource`), `gitjobs.dev`
+and WorksHub (no public API path found), `nofluffjobs` (Cloudflare/headless), `jobscollider`
+(now `remotefirstjobs`, 401 key-gated), `devitjobs` (parked → signup redirect),
+Welcome-to-the-Jungle (Algolia key), Wellfound/BuiltIn/HiringCafe (auth/antibot + heavy
+re-aggregation of our own ATS), and the LinkedIn/Indeed/Glassdoor giants (ToS).
+
+## Capabilities
+
+### New Capabilities
+<!-- none — this extends the existing source-ingest capability -->
+
+### Modified Capabilities
+- `source-ingest`: registers four new **aggregator** (boardless, company-per-posting)
+  providers — `workingnomads`, `himalayas`, `remotive`, `justjoin` — each crawling a single
+  public JSON API. Reinforces the existing aggregator requirement (company derived from the
+  posting, not the configured board) and adds the provider-specific constraints: `remotive`
+  performs a single rate-limited fetch (no pagination), and `justjoin` synthesizes a canonical
+  detail URL from the posting slug when the feed omits the apply link.
+
+## Impact
+
+- New: `internal/sources/{workingnomads,himalayas,remotive,justjoin}.go` + a `_test.go` for
+  each, and `sources/{…}.yml` for each.
+- Modified: `internal/sources/source.go` (four lines in `All`); regenerated
+  `web/src/lib/generated/contracts.ts` (four new SOURCE_VALUES entries).
+- No schema, migration, or HTTP-API change. New jobs flow through the existing
+  `UpsertJob`/enrichment path unchanged. Reaching the catalogue in production is a
+  `freehire-ops` cron addition (out of this repo) plus a `make reindex`.

--- a/openspec/changes/add-api-aggregator-sources/specs/source-ingest/spec.md
+++ b/openspec/changes/add-api-aggregator-sources/specs/source-ingest/spec.md
@@ -1,0 +1,68 @@
+# source-ingest (delta)
+
+## ADDED Requirements
+
+### Requirement: Working Nomads is a registered boardless aggregator provider
+
+The `workingnomads` provider SHALL crawl `workingnomads.com` through its public JSON feed
+(`/api/exposed_jobs/`), a single flat array of postings with the body inline (no detail
+call). Each posting maps to the normalized job shape with the employer taken from the
+posting. The feed carries no numeric id field, so the adapter SHALL derive `ExternalID`
+from the posting URL path (`/job/go/<id>/`); a posting whose URL yields no id SHALL be
+dropped rather than persisted with an empty id.
+
+#### Scenario: Working Nomads posting maps to a job with id from its URL
+
+- **WHEN** a `workingnomads` posting carries URL `.../job/go/1663269/`, a title, a company name, an inline HTML description, and a `pub_date`
+- **THEN** the job's `ExternalID` is `1663269`, its `Company` comes from the posting, and `Title`/`Description`/`PostedAt` come from that payload
+
+#### Scenario: Posting with an unparseable URL is dropped
+
+- **WHEN** a `workingnomads` posting has a URL with no `/job/go/<id>/` segment
+- **THEN** the adapter drops it and does not emit a job with an empty `ExternalID`
+
+### Requirement: Himalayas is a registered boardless aggregator provider
+
+The `himalayas` provider SHALL crawl `himalayas.app` through its public JSON API
+(`/jobs/api`), paginating by offset/limit over the API-reported `totalCount` up to a
+defensive maximum-page cap. Each posting maps to the normalized job shape with the employer
+taken from `companyName` and the canonical link from `applicationLink`.
+
+#### Scenario: Himalayas is crawled across offset pages
+
+- **WHEN** the `himalayas` provider crawls its boardless entry and the API reports a `totalCount` larger than one page
+- **THEN** the adapter requests successive offset pages until the catalogue is exhausted or the defensive page cap is reached
+- **AND** every posting becomes a job whose `Company` is its `companyName` and whose `ExternalID` is the posting's stable id (`guid`)
+
+### Requirement: Remotive is a registered boardless aggregator provider
+
+The `remotive` provider SHALL crawl `remotive.com` through its public JSON API
+(`/api/remote-jobs`) with a **single** request per run — the API is rate-limited and serves
+24h-delayed data, so the adapter SHALL NOT paginate or poll. Each posting maps to the
+normalized job shape with the employer from `company_name`; Remotive lists only remote jobs,
+so every job SHALL be marked remote.
+
+#### Scenario: Remotive performs a single fetch and marks jobs remote
+
+- **WHEN** the `remotive` provider crawls its boardless entry
+- **THEN** the adapter makes exactly one request to the feed (no pagination loop)
+- **AND** every returned posting becomes a remote job (`Remote` true, `WorkMode` "remote") with `Company` from `company_name` and `ExternalID` from the posting id
+
+### Requirement: JustJoin is a registered boardless aggregator provider
+
+The `justjoin` provider SHALL crawl `justjoin.it` through its public JSON API
+(`api.justjoin.it/v2/user-panel/offers/by-cursor`), paginating by following `meta.next.cursor`
+up to a defensive maximum-page cap. Each posting maps to the normalized job shape with the
+employer from `companyName` and `WorkMode` derived from the structured `workplaceType`
+(`remote`/`hybrid`/`office`). The list response carries no apply link, so the adapter SHALL
+synthesize the canonical `URL` from the posting `slug` as `https://justjoin.it/job-offer/<slug>`.
+
+#### Scenario: JustJoin posting maps to a job with synthesized URL and structured work mode
+
+- **WHEN** a `justjoin` posting has slug `acme-senior-go`, `companyName` "Acme", and `workplaceType` "remote"
+- **THEN** the job's `URL` is `https://justjoin.it/job-offer/acme-senior-go`, its `Company` is "Acme", and its `WorkMode` is "remote"
+
+#### Scenario: JustJoin is crawled across cursor pages
+
+- **WHEN** the API response includes a non-null `meta.next.cursor`
+- **THEN** the adapter requests the next page with that cursor until the cursor is absent or the defensive page cap is reached

--- a/openspec/changes/add-api-aggregator-sources/tasks.md
+++ b/openspec/changes/add-api-aggregator-sources/tasks.md
@@ -1,0 +1,39 @@
+## 1. Working Nomads adapter (pattern-locker, build first)
+
+- [x] 1.1 Wrote table-driven `workingnomads_test.go` on the `routedHTTP` fake (live fixture inlined per the package convention): asserts per-job company from the payload, `ExternalID` parsed from the `/job/go/<id>/` URL, drop of a no-id URL, `Title`/`Description`(sanitized)/`Location`/`PostedAt` mapping, `Remote`+`WorkMode="remote"` (remote-only board), and the `boardless`+`aggregator` markers (RED ✓ — undefined NewWorkingNomads)
+- [x] 1.2 Implemented `internal/sources/workingnomads.go`: `NewWorkingNomads`, `Provider()`, `boardless()`, `aggregator()`, `Fetch` single-request decode of the flat array, posting→`Job` with `workingNomadsIDRE` id-from-URL (GREEN ✓ — 5/5 tests pass, build+vet+package tests green)
+
+## 2. Himalayas adapter
+
+- [x] 2.1 Wrote `himalayas_test.go`: asserts offset pagination across `totalCount` (totalCount 150 > limit 100 → exactly 2 requests via `fake.calls`), `Company=companyName`, `ExternalID=guid` (empty-guid dropped), `URL=applicationLink`, `Location` joined from `locationRestrictions`, epoch-seconds `pubDate`, `Remote`+`WorkMode="remote"` (RED ✓)
+- [x] 2.2 Implemented `internal/sources/himalayas.go`: offset/limit loop driven by `totalCount` under `himalayasMaxPages` cap, `parseEpochSeconds(pubDate)`, `joinNonEmpty(locationRestrictions...)` (GREEN ✓ — 5/5 pass)
+
+## 3. Landing.jobs adapter — DROPPED
+
+- [x] 3.1 DROPPED during implementation: the `/api/v1/jobs` list response has **no structured
+  company field** (employer only as a URL slug `/at/<slug>/` and in description prose).
+  Deriving company from a concatenated slug would pollute the companies table — an MVP-shortcut
+  the project forbids. Moved to design's rejected alternatives. No `landingjobs.go` written.
+- [x] 3.2 DROPPED (see 3.1)
+
+## 4. Remotive adapter
+
+- [x] 4.1 Wrote `remotive_test.go`: asserts a **single** fetch (`fake.calls==1`), `Remote`+`WorkMode="remote"`, `Company=company_name`, `ExternalID=id` (zero-id dropped), zoneless-ISO date mapping (RED ✓)
+- [x] 4.2 Implemented `internal/sources/remotive.go`: single `GetJSON`, dedicated `remotivePubLayout="2006-01-02T15:04:05"` (RFC3339 would reject Remotive's zoneless timestamp — confirmed live) (GREEN ✓)
+
+## 5. JustJoin adapter
+
+- [x] 5.1 Wrote `justjoin_test.go`: asserts cursor pagination (2 pages via `fake.calls==2`), synthesized `URL=https://justjoin.it/job-offer/<slug>`, `WorkMode` from `workplaceType` (incl. `office`→onsite), `Company=companyName`, `ExternalID=guid` (empty-slug dropped), RFC3339-millis date (RED ✓)
+- [x] 5.2 Implemented `internal/sources/justjoin.go`: cursor loop with strictly-increasing guard + `justJoinMaxPages` cap; **live-smoke corrected the pagination param `?cursor=`→`?from=`** (`?cursor=` is silently ignored — caught by live curl, the guard meant the wrong param degraded to 20 jobs, never an infinite loop); added `office` to the shared `workplaceTypeMode` (GREEN ✓)
+
+## 6. Wiring
+
+- [x] 6.1 Registered all four `New…(c)` in `sources.All` (`internal/sources/source.go`), boardless-aggregator block
+- [x] 6.2 Added `sources/{workingnomads,himalayas,remotive,justjoin}.yml`, each one boardless entry
+- [x] 6.3 Ran `make gen-contracts`; confirmed all four providers in `SOURCE_VALUES` (`landingjobs` correctly absent)
+
+## 7. Verify
+
+- [x] 7.1 `go build ./...`, `go vet ./...`, full `go test ./...` green; `gofmt` clean
+- [x] 7.2 Live smoke: single-fetch adapters run end-to-end against the real APIs via a throwaway gated test (since deleted) — **workingnomads 46 jobs**, **remotive 30 jobs**, each with correct per-job company/id/url/`WorkMode="remote"`/date. JustJoin `?from=` pagination advance verified by live curl (page1 guid ≠ page2 guid). Himalayas decode verified against the live-captured fixture. Full-catalogue paginating crawl deferred to the deploy-time ingest (would fetch tens of thousands).
+- [x] 7.3 Follow-up (for PR description): per-provider daily cron in `freehire-ops` (one schedule per `sources/<provider>.yml`) + a `make reindex` after first ingest, both out of this repo. Respect Remotive's documented ~4 req/day limit when scheduling.

--- a/sources/himalayas.yml
+++ b/sources/himalayas.yml
@@ -1,0 +1,5 @@
+# Himalayas remote-jobs aggregator. Boardless: one public API (himalayas.app/jobs/api),
+# so the entry carries no board; each job's company comes from the posting, not this
+# placeholder.
+- company: Himalayas
+  provider: himalayas

--- a/sources/justjoin.yml
+++ b/sources/justjoin.yml
@@ -1,0 +1,5 @@
+# JustJoin.it Polish/CEE IT marketplace. Boardless: one public API
+# (api.justjoin.it/v2/user-panel/offers/by-cursor), so the entry carries no board; each job's
+# company comes from the posting, not this placeholder.
+- company: JustJoin
+  provider: justjoin

--- a/sources/remotive.yml
+++ b/sources/remotive.yml
@@ -1,0 +1,5 @@
+# Remotive remote-jobs aggregator. Boardless: one public API (remotive.com/api/remote-jobs),
+# so the entry carries no board; each job's company comes from the posting, not this
+# placeholder. The adapter fetches once per run (the API is rate-limited).
+- company: Remotive
+  provider: remotive

--- a/sources/workingnomads.yml
+++ b/sources/workingnomads.yml
@@ -1,0 +1,5 @@
+# Working Nomads remote-jobs aggregator. Boardless: one public feed
+# (workingnomads.com/api/exposed_jobs/), so the entry carries no board; each job's company
+# comes from the posting, not this placeholder.
+- company: Working Nomads
+  provider: workingnomads

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -105,7 +105,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'eightfold', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'lever', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'wpyoast'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'eightfold', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'himalayas', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'justjoin', 'lever', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'remotive', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## Summary

Adds four `boardless` + `aggregator` job-source adapters over verified public JSON APIs, found by spiking the `awesome-job-boards` repo family. Each mirrors the existing aggregator pattern (`internal/sources/jobicy.go`, `tecla.go`): one global feed, company taken per posting, joins the source facet via `gen-contracts`.

| Provider | API | Notes |
|---|---|---|
| **workingnomads** | `workingnomads.com/api/exposed_jobs/` | flat array, single fetch; no id field → `ExternalID` parsed from `/job/go/<id>/` URL (drop no-id) |
| **himalayas** | `himalayas.app/jobs/api` | offset-paginated over `totalCount` (~90k) under a max-page cap; `guid` id, epoch-seconds dates |
| **remotive** | `remotive.com/api/remote-jobs` | **single** rate-limited fetch (≈4 req/day, 24h delay — no pagination); zoneless ISO date layout |
| **justjoin** (PL/CEE) | `api.justjoin.it/v2/user-panel/offers/by-cursor` | cursor pagination (`meta.next.cursor` passed as `?from=`), synthesized `job-offer/<slug>` URL, `workplaceType`→`WorkMode` |

**Dropped during implementation — landing.jobs:** its `/api/v1/jobs` list response carries no structured company field (employer only as a URL slug / in prose). Deriving company from a slug would pollute the companies table, so it's recorded as a rejected alternative in the OpenSpec design rather than shipped.

Why these four and not the rest of the lists: most awesome-list entries are end-user boards that are already covered, single-company, or re-aggregate the Greenhouse/Lever/Ashby boards we already crawl (cross-source dup). These four carry their own inventory → low dup risk. Full skip-log (nofluffjobs/Cloudflare, jobscollider 401, WTTJ Algolia, etc.) is in the OpenSpec design.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, full `go test ./...` green; `gofmt` clean
- [x] Code review (pr-review-toolkit) — no high-confidence issues; fixed a near-future test-fixture flake it flagged
- [x] Live smoke (single-fetch adapters, throwaway gated test): **workingnomads 46 jobs**, **remotive 30 jobs**, correct per-job company/id/url/`WorkMode=remote`/date
- [x] Live curl confirmed JustJoin `?from=` pagination advances (the spike's `?cursor=` guess is silently ignored — caught here, not by fixtures; adapter's strictly-increasing-cursor guard kept it safe regardless)
- [ ] Full-catalogue paginating crawl — deferred to deploy-time ingest

## Follow-up (out of this repo)

- New adapter = full image rebuild (not sources-rsync)
- Per-provider daily cron in `freehire-ops` (one schedule per `sources/<provider>.yml`; respect Remotive's ~4 req/day) + `make reindex` after first ingest

OpenSpec change: `add-api-aggregator-sources`