### PR TITLE
fix(sources): himalayas honors 20-item page cap + tolerates rate-limit

### DIFF
--- a/internal/sources/himalayas.go
+++ b/internal/sources/himalayas.go
@@ -14,11 +14,15 @@ type himalayas struct {
 }
 
 const (
-	// himalayasLimit is the page size requested per offset page.
-	himalayasLimit = 100
+	// himalayasLimit is the page size requested per offset page. Himalayas caps the page
+	// size at 20 regardless of the requested value, so this matches the cap; the loop
+	// advances by the count actually returned (not by this), staying correct even if the
+	// cap changes.
+	himalayasLimit = 20
 	// himalayasMaxPages caps pagination so a runaway/over-reported totalCount cannot loop
-	// indefinitely (the same defensive bound the other paginating adapters carry).
-	himalayasMaxPages = 400
+	// indefinitely (the same defensive bound the other paginating adapters carry). Sized for
+	// the small page cap; in practice the API's rate limit ends a run far sooner.
+	himalayasMaxPages = 5000
 	himalayasListURL  = "https://himalayas.app/jobs/api?limit=%d&offset=%d"
 )
 
@@ -51,20 +55,30 @@ type himalayasPosting struct {
 
 func (s himalayas) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 	var jobs []Job
-	for offset, page := 0, 0; page < himalayasMaxPages; offset, page = offset+himalayasLimit, page+1 {
+	for offset, page := 0, 0; page < himalayasMaxPages; page++ {
 		var resp himalayasResponse
 		url := fmt.Sprintf(himalayasListURL, himalayasLimit, offset)
 		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
-			return nil, fmt.Errorf("himalayas: list offset %d: %w", offset, err)
+			// Himalayas rate-limits (429) after a number of rapid pages. Once we have
+			// collected jobs, treat a page failure as the end of what we can fetch this run
+			// and return the partial result (freshest jobs first) rather than discarding
+			// everything; the idempotent upsert means the next run picks up where the rate
+			// limit allows. Only a failure on the very first page is a real board error.
+			if len(jobs) == 0 {
+				return nil, fmt.Errorf("himalayas: list offset %d: %w", offset, err)
+			}
+			return jobs, nil
 		}
 		for _, p := range resp.Jobs {
 			if job, ok := p.toJob(); ok {
 				jobs = append(jobs, job)
 			}
 		}
-		// Stop once this page's offset covers the reported total, or the page came back
-		// empty (defensive against a total that never shrinks).
-		if len(resp.Jobs) == 0 || offset+himalayasLimit >= resp.TotalCount {
+		// Advance by the count actually returned: Himalayas caps the page size below the
+		// requested limit, so a fixed stride would skip postings. Stop on an empty page or
+		// once the offset covers the reported total.
+		offset += len(resp.Jobs)
+		if len(resp.Jobs) == 0 || offset >= resp.TotalCount {
 			break
 		}
 	}

--- a/internal/sources/himalayas_test.go
+++ b/internal/sources/himalayas_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 )
@@ -42,16 +43,17 @@ func TestHimalayasBoardFileValidates(t *testing.T) {
 }
 
 func TestHimalayasFetchPaginatesAndMaps(t *testing.T) {
-	// totalCount (150) exceeds one page (limit 100), so the adapter must fetch a second
-	// offset page and stop once offset passes totalCount.
-	page1 := `{"totalCount":150,"jobs":[
+	// totalCount (3) exceeds the first page, so the adapter must fetch a second offset page.
+	// The offset advances by the count actually returned (page1 has 2 postings → next
+	// offset is 2), not by the requested limit — Himalayas caps the page size below it.
+	page1 := `{"totalCount":3,"jobs":[
 {"title":"Web Engineer","companyName":"KraftPixel","applicationLink":"https://himalayas.app/companies/kraftpixel/jobs/web-engineer","guid":"https://himalayas.app/companies/kraftpixel/jobs/web-engineer","locationRestrictions":["United States","Canada"],"description":"<p>Build web.</p>","pubDate":1747699200},
 {"title":"NoGUID drop","companyName":"Ghost","guid":""}
 ]}`
-	page2 := `{"totalCount":150,"jobs":[
+	page2 := `{"totalCount":3,"jobs":[
 {"title":"Data Analyst","companyName":"Peroptyx","applicationLink":"https://himalayas.app/companies/peroptyx/jobs/data-analyst","guid":"https://himalayas.app/companies/peroptyx/jobs/data-analyst","locationRestrictions":["Ireland"],"description":"<p>Analyze.</p>","pubDate":1781725000}
 ]}`
-	fake := (&routedHTTP{}).route("offset=100", page2).route("offset=0", page1)
+	fake := (&routedHTTP{}).route("offset=2", page2).route("offset=0", page1)
 	jobs, err := NewHimalayas(fake).Fetch(context.Background(), CompanyEntry{})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
@@ -80,5 +82,32 @@ func TestHimalayasFetchPaginatesAndMaps(t *testing.T) {
 	}
 	if j.PostedAt == nil {
 		t.Error("PostedAt nil, want parsed epoch seconds")
+	}
+}
+
+func TestHimalayasReturnsPartialOnPageError(t *testing.T) {
+	// Himalayas rate-limits (429) mid-crawl. A page failure after we have already collected
+	// jobs must return the partial result, not discard everything: the first page succeeds,
+	// the second (offset=2) has no route → the fake errors, and Fetch returns page 1's job.
+	page1 := `{"totalCount":999,"jobs":[
+{"title":"Web Engineer","companyName":"KraftPixel","applicationLink":"https://himalayas.app/x","guid":"https://himalayas.app/x","pubDate":1747699200},
+{"title":"Data Analyst","companyName":"Peroptyx","applicationLink":"https://himalayas.app/y","guid":"https://himalayas.app/y","pubDate":1747699200}
+]}`
+	fake := (&routedHTTP{}).route("offset=0", page1) // offset=2 has no route → error
+	jobs, err := NewHimalayas(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch should swallow a mid-crawl page error, got: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (partial result from the first page before the error)", len(jobs))
+	}
+}
+
+func TestHimalayasErrorsWhenFirstPageFails(t *testing.T) {
+	// A failure on the very first page yields no jobs at all, so it is a genuine board error
+	// (not a partial result to keep).
+	fake := &fakeHTTP{err: errors.New("boom")}
+	if _, err := NewHimalayas(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Error("Fetch should return an error when the first page fails")
 	}
 }


### PR DESCRIPTION
Found during production verification of #180 (himalayas ingested 0 jobs).

**Bug 1 — page-size skip:** Himalayas caps page size at 20 regardless of the requested `limit`. The adapter requested 100 and advanced `offset` by 100 → skipped 80% of postings. Fix: request `limit=20` and advance by the count actually returned.

**Bug 2 — all-or-nothing on 429:** the API rate-limits after ~150 rapid pages; the adapter returned `nil, err` on the first failed page, discarding ~15k jobs already collected. Fix: return the partial (freshest-first) result on a mid-crawl page error; only a first-page failure is a genuine board error. Idempotent upsert advances coverage across cron runs.

Tests added: partial-on-rate-limit, first-page-error. Full `go test ./...` green.

Verified: the other three adapters from #180 are confirmed live in prod (workingnomads 46, remotive 30, justjoin 9977).