### PR TITLE
refactor(web): unify URL-synced search state + infinite scroll

### DIFF
--- a/openspec/changes/unify-url-search-state/.openspec.yaml
+++ b/openspec/changes/unify-url-search-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/unify-url-search-state/design.md
+++ b/openspec/changes/unify-url-search-state/design.md
@@ -1,0 +1,155 @@
+## Context
+
+Three frontend screens implement the same "input → debounce → URL → reload"
+mechanism three different ways:
+
+- **`FilterStore`** (`web/src/lib/filters.svelte.ts`), used by `JobsView` and
+  `AnalyticsView`: mutates `value` synchronously but debounces the **URL write**
+  via `goto()` (`#commitSoon`). Because the URL write is debounced and `goto`
+  re-runs the route `load`, a navigation in flight lands its `load` result and
+  `syncFromUrl()` reverts `value` to the lagging URL — dropping characters the
+  user typed during the round-trip.
+- **`CompaniesView`**: writes the URL **synchronously** via `replaceState` in the
+  input handler and debounces only a local client `fetch`. No input race.
+- **`AnalyticsView`**: reads filters from `FilterStore` (whose `goto` commit
+  re-runs `load`) **and** debounces a second counts `fetch` in its own `$effect`
+  — a double debounce and double load.
+
+Constraint: there is no web test runner (`go test` does not cover `web/`).
+Verification is `svelte-check` plus a manual per-screen checklist. The project is
+MVP-stage with a fluid architecture, so reshaping `FilterStore` rather than
+patching it is appropriate.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One reusable primitive for URL-synced search/filter state, used by all three
+  screens, that eliminates the dropped-character bug **structurally** (not via a
+  guard).
+- Remove the duplicate debounce / double load in analytics.
+- Replace "Load more" with bottom-reach infinite scroll, keeping an accessible
+  fallback control.
+
+**Non-Goals:**
+
+- No backend, API, or DB changes.
+- No change to `Paginator` (`paginated.svelte.ts`) — infinite scroll is only a
+  new trigger for its existing `loadMore()`.
+- No change to the set of facets, the search params, or SSR-first rendering.
+- No pre-fetch-ahead tuning of the scroll trigger (explicitly "when you hit the
+  bottom"); `rootMargin` stays `0px`.
+
+## Decisions
+
+### D1: Client-driven (`replaceState`) over load-driven (`goto`)
+
+The root cause of the bug is **debouncing the URL write**. With `goto`, every URL
+write is a navigation that re-runs `load`, so it must be debounced — which opens
+the race window. Switching to `replaceState` lets the URL be written
+**synchronously** on every keystroke (cheap, no navigation, no `load`), so the
+URL is always in lockstep with the input and back/forward reconciliation can
+never observe a lagging URL. Only the *data reload* is debounced.
+
+This is the pattern `CompaniesView` already uses successfully; the change
+generalizes it. JobsView is already half client-driven (it owns a client
+`Paginator` for "load more" and a client `facetCounts` fetch), so dropping the
+"reseed list from route `load`'s `initial` on every nav" effect in favor of a
+client reload is a natural consolidation, not a new paradigm.
+
+*Alternative considered — keep `goto` + a guard* (skip `syncFromUrl` while a
+debounced commit is pending): works, but carries the race as a patch inside the
+shared primitive and keeps the double-load shape. Rejected: the brief was to do
+it right, not to encapsulate the workaround.
+
+*Trade-off:* back/forward now reloads data **client-side** (via an effect) rather
+than restoring a server-rendered `load` result. This matches `CompaniesView`
+today and is acceptable — SEO/first-paint still come from SSR on direct load,
+share, and refresh, which continue to read the URL through the route `load`.
+
+### D2: `value` (live) + `applied` (debounced) as two `$state` fields
+
+The primitive exposes two reactive fields:
+
+- `value: $state<T>` — the live model bound to the input; mutators write it and
+  **synchronously** `replaceState(serialize(value))`.
+- `applied: $state<T>` — a debounced snapshot of `value` (300 ms), the sole
+  signal consumers watch to reload.
+
+Consumers reload via `$effect(() => { state.applied; reload() })`. A screen with
+two data sources (jobs: list + counts) simply runs two effects. This keeps the
+debounce in **one** place (the `value → applied` transition) instead of copied
+into each component's effect, which is exactly what removes analytics' double
+debounce.
+
+`applied` cannot be a `$derived` of `value` (the debounce is asynchronous), so a
+private `setTimeout` inside the mutator drives it. That timer is the only timer in
+the system and is fully encapsulated.
+
+### D3: Immediate vs debounced mutators (`setNow` / `setSoon`)
+
+The primitive offers two mutators, preserving `FilterStore`'s current sensible
+behavior:
+
+- `setNow(next)` — discrete changes (facet pills, checkboxes, exclude toggle,
+  clear): write URL **and** set `applied` immediately. A click is not typed
+  fast, so debouncing it only adds latency.
+- `setSoon(next)` — continuous input (free-text query, salary slider): write URL
+  synchronously, set `applied` debounced.
+
+`FilterStore` becomes a thin wrapper: `toggle/add/remove/setExclude/clear/
+setMatchAll/setVisa/setSort → setNow`; `setQuery/setSalaryMin → setSoon`. Its
+parse/serialize are the existing `filtersFromParams`/`filtersToParams`.
+`CompaniesView` uses the primitive directly as `UrlSyncedState<string>`.
+
+### D4: Infinite scroll as a separate trigger component
+
+A new `InfiniteScroll.svelte` owns an `IntersectionObserver` on a sentinel `<div>`
+at the list bottom (`rootMargin: '0px'`), calling an `onLoad` prop when the
+sentinel enters the viewport; it disconnects the observer in the `$effect`
+cleanup and is gated by an `enabled` prop (off while a load is in flight or none
+remain). `Paginator` is untouched; the component just calls `loadMore()`. The
+existing `LoadMore` button stays mounted as the fallback (spinner, retry,
+keyboard/SR reach), so accessibility and error recovery are preserved.
+
+*Alternative considered — drop the button entirely:* rejected for accessibility
+(keyboard/SR users cannot scroll-trigger) and error recovery (a failed auto-load
+needs a retry affordance).
+
+## Risks / Trade-offs
+
+- **No automated tests for the frontend** → mitigate with `svelte-check` and a
+  fixed manual checklist per screen (fast typing, back/forward, URL share,
+  scroll-to-load, load-error retry, keyboard load); migrate one screen at a time
+  (companies → jobs → analytics) so a regression is isolated.
+- **back/forward reloads client-side instead of restoring SSR `load`** (D1
+  trade-off) → acceptable; SSR still serves direct/share/refresh. Verified by the
+  back/forward checklist item.
+- **`replaceState` does not create history entries** → intended (per-tweak
+  history was never wanted); the URL still updates so share/reload/back across
+  *real* navigations works. Matches current `replaceState`-keep behavior in
+  `FilterStore`'s `#commit`.
+- **Visible pause at the bottom** from `rootMargin: 0px` (no pre-fetch) → an
+  explicit UX choice; a one-line `rootMargin` bump can add lead time later if it
+  annoys.
+
+## Migration Plan
+
+Per-screen, smallest blast radius first, each verified before the next:
+
+1. Land the primitive (`urlSynced.svelte.ts`) and `InfiniteScroll.svelte` with no
+   consumers wired yet.
+2. **Companies** — switch search to the primitive; adopt `InfiniteScroll`.
+3. **Jobs** — rewrite `FilterStore` over the primitive; drop `#navTimer`/guard
+   and the reseed-from-`initial` effect; adopt `InfiniteScroll`.
+4. **Analytics** — consume the rewritten `FilterStore`; remove the duplicate
+   debounce, reload counts off `applied`.
+
+Rollback is per-screen (revert that screen's commit); the primitive is additive
+until a screen adopts it.
+
+## Open Questions
+
+- None blocking. The fallback button's visibility (always shown vs only on
+  error/keyboard-focus) can be settled during implementation against the existing
+  `LoadMore` styling without a spec change.

--- a/openspec/changes/unify-url-search-state/proposal.md
+++ b/openspec/changes/unify-url-search-state/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+The frontend has three divergent copies of one mechanism — "input → debounce →
+URL → reload data" — and one of them drops characters during fast typing: the
+jobs/analytics `FilterStore` debounces the *URL write* (a `goto` navigation), so
+while a navigation is in flight the late `load` result overwrites just-typed
+characters. The companies search avoids this by writing the URL synchronously,
+and analytics piles a second debounce on top of `FilterStore`'s. One correct,
+shared primitive removes the bug structurally and collapses the duplication.
+
+Separately, the jobs/companies lists page with an explicit "Load more" button;
+infinite scroll that triggers when the user reaches the bottom is the intended
+UX, with the button retained as an accessible fallback.
+
+## What Changes
+
+- Add a single reusable client-side primitive `UrlSyncedState<T>` that mirrors
+  search/filter state into the URL **synchronously** (`replaceState`) and exposes
+  a debounced `applied` snapshot as the sole "reload" signal. Synchronous URL
+  writes mean back/forward reconciliation can never clobber in-flight typing — the
+  dropped-character bug is gone by construction (no guard needed).
+- Rewrite `FilterStore` (jobs/analytics filters) as a thin wrapper over the
+  primitive; discrete changes (facet pills, checkboxes) apply immediately,
+  continuous input (text, salary slider) debounces.
+- Point the companies search and the analytics counts at the same primitive,
+  removing analytics' duplicate debounce and the double data-load.
+- **BREAKING (UX)**: Replace the "Load more" button as the *primary* paging
+  control with infinite scroll — an `IntersectionObserver` sentinel at the list
+  bottom (no pre-fetch ahead of the viewport). The existing button stays as a
+  fallback: a spinner while loading, a "Try again" on error, and a
+  keyboard/screen-reader-reachable control (these users do not scroll-trigger).
+- No backend or API changes; `Paginator` is unchanged (infinite scroll is just a
+  new trigger for its existing `loadMore()`).
+
+## Capabilities
+
+### New Capabilities
+<!-- none — this reshapes existing frontend behavior, no new capability surface -->
+
+### Modified Capabilities
+- `web-frontend`: the "Jobs list with pagination" requirement changes its paging
+  control from an explicit "Load more" button to bottom-reach infinite scroll
+  (button retained as fallback); a new requirement guarantees the search/filter
+  input stays responsive (fast typing never drops characters) and that filter
+  state round-trips through the URL for reload, sharing, and back/forward.
+
+## Impact
+
+- **Code (frontend only):**
+  - New: `web/src/lib/urlSynced.svelte.ts` (the primitive),
+    `web/src/lib/components/InfiniteScroll.svelte` (the sentinel).
+  - Rewritten: `web/src/lib/filters.svelte.ts` (`FilterStore` over the primitive).
+  - Touched: `JobsView.svelte`, `CompaniesView.svelte`, `AnalyticsView.svelte`
+    (consume the primitive; jobs/companies adopt `InfiniteScroll`),
+    `LoadMore.svelte` (fallback role).
+- **No backend / API / DB impact.** `Paginator` (`paginated.svelte.ts`) unchanged.
+- **Verification:** no web test runner exists; `svelte-check` plus a per-screen
+  manual checklist (fast typing, back/forward, URL sharing, scroll-to-load, load
+  error → retry, keyboard load). Migration proceeds one screen at a time:
+  companies → jobs → analytics.

--- a/openspec/changes/unify-url-search-state/specs/web-frontend/spec.md
+++ b/openspec/changes/unify-url-search-state/specs/web-frontend/spec.md
@@ -1,0 +1,82 @@
+# web-frontend Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Jobs list with pagination
+
+The frontend SHALL present a list of jobs from `GET /api/v1/jobs`, showing for
+each job its title, company, location, work arrangement (and, for remote roles,
+its reach), source, and posted date, and SHALL paginate using the API's
+`limit`/`offset` driven by `meta.total`. The work arrangement SHALL be derived
+from `enrichment.work_mode`; for a remote role the reach SHALL be shown from
+`enrichment.regions` (e.g. `Global`, `Europe`). The frontend SHALL NOT rely on a
+raw `remote` field (it is no longer in the API). The first page of the list
+SHALL be **server-rendered** — its rows present in the initial HTML — and then
+hydrate on the client for subsequent interaction.
+
+When more jobs remain, the frontend SHALL load the next page automatically once
+the user scrolls to the bottom of the current list (infinite scroll), without
+pre-fetching ahead of the viewport. An accessible control SHALL remain available
+as a fallback so that keyboard and screen-reader users — who do not
+scroll-trigger — can load the next page, and so that a failed page load can be
+retried.
+
+#### Scenario: Jobs are listed
+
+- **WHEN** a user opens the jobs route `/jobs`
+- **THEN** the server returns HTML already containing the first page of job rows,
+  each linking to its job detail
+
+#### Scenario: User reaches the bottom of the list
+
+- **WHEN** more jobs exist than the current page (`offset + limit < meta.total`)
+  and the user scrolls to the bottom of the loaded rows
+- **THEN** the next page is fetched and appended automatically, without the user
+  clicking a control
+
+#### Scenario: Fallback control loads and retries
+
+- **WHEN** more jobs remain but the user navigates by keyboard or a page load
+  failed
+- **THEN** an accessible control is present that fetches the next page on
+  activation, and a failed load surfaces a retry affordance rather than silently
+  stopping
+
+#### Scenario: A global-remote job shows its reach explicitly
+
+- **WHEN** a listed job has `work_mode=remote` and `regions=[global]`
+- **THEN** its row shows a "Global" reach indicator rather than a bare "Remote"
+  with no reach
+
+## ADDED Requirements
+
+### Requirement: Responsive URL-synced search and filter input
+
+The frontend's search and filter inputs SHALL stay responsive while the user
+types — across the jobs search box and facet filters, the companies name search,
+and the analytics filters — so that characters are never dropped or reverted
+during fast typing, even while a data reload triggered by an earlier keystroke is
+still in flight. The current search/filter state SHALL be mirrored into the URL
+query string so it survives reload, sharing, and browser back/forward, and the
+data reload that reflects a change SHALL be debounced so that typing does not
+issue one request per character.
+
+#### Scenario: Fast typing keeps every character
+
+- **WHEN** a user types into a search/filter input faster than the reload
+  debounce window, and an earlier reload is still in flight
+- **THEN** the input retains exactly what was typed — no characters are dropped or
+  reverted by the in-flight reload completing
+
+#### Scenario: Filter state survives back/forward
+
+- **WHEN** a user changes filters, navigates away, and returns via browser
+  back/forward
+- **THEN** the inputs and results are restored to match the URL of that history
+  entry
+
+#### Scenario: Typing debounces the reload
+
+- **WHEN** a user types a multi-character query in quick succession
+- **THEN** the URL updates to reflect the query but the data reload is coalesced
+  rather than issued once per keystroke

--- a/openspec/changes/unify-url-search-state/tasks.md
+++ b/openspec/changes/unify-url-search-state/tasks.md
@@ -1,0 +1,62 @@
+## 1. Primitives (no consumers yet)
+
+- [x] 1.1 Add `web/src/lib/urlSynced.svelte.ts`: `UrlSyncedState<T>` with `value`
+  ($state, live), `applied` ($state, debounced snapshot), constructor
+  `(params, { parse, serialize, debounceMs = 300 })`, `setNow(next)` (write URL +
+  set `applied` immediately), `setSoon(next)` (write URL synchronously + debounce
+  `applied`), `syncFromUrl()` (pull `value`+`applied` from URL, no debounce), and
+  a `dispose()` clearing the timer. URL writes use `replaceState` with
+  `keepFocus`/`noScroll`.
+- [x] 1.2 Add `web/src/lib/components/InfiniteScroll.svelte`: props `{ onLoad,
+  enabled }`; an `IntersectionObserver` (`rootMargin: '0px'`) on a sentinel
+  `<div aria-hidden="true">` that calls `onLoad` on intersect; observer created
+  and torn down in an `$effect` cleanup; no-op while `!enabled`.
+- [x] 1.3 `svelte-check` is clean; both modules build with no consumers wired.
+
+## 2. Companies screen (smallest blast radius)
+
+- [x] 2.1 Rewrite `CompaniesView.svelte` search to use `UrlSyncedState<string>`
+  (parse `p.get('q') ?? ''`, serialize `q ? {q} : {}`); reload the paginator via
+  `$effect(() => { state.applied; reload() })`; remove the hand-rolled
+  `timer`/`search()`/back-forward `$effect` now covered by the primitive.
+- [x] 2.2 Replace the `LoadMore`-only paging with `InfiniteScroll` + `LoadMore`
+  fallback (spinner while `loadingMore`, retry on `loadMoreError`,
+  keyboard/SR-reachable).
+- [x] 2.3 Verify: `svelte-check` clean; manual checklist on `/companies` — fast
+  typing keeps every character, back/forward restores query + results, URL share
+  works, scroll-to-bottom loads next page, simulated load error shows retry,
+  keyboard activation loads next page.
+
+## 3. Jobs screen
+
+- [x] 3.1 Rewrite `FilterStore` (`filters.svelte.ts`) as a thin wrapper over
+  `UrlSyncedState<JobFilters>` (parse `filtersFromParams`, serialize
+  `filtersToParams`): `toggle/add/remove/setExclude/clear/setMatchAll/setVisa/
+  setSort → setNow`; `setQuery/setSalaryMin → setSoon`. Remove `#navTimer`,
+  `#commit`, `#commitSoon`, and the pending-guard `syncFromUrl`; keep the public
+  method surface used by `JobsView`/`FiltersPanel` unchanged.
+- [x] 3.2 Update `JobsView.svelte`: drive list + counts off `filters.applied`
+  via `$effect`s; drop the reseed-from-`initial` effect (keep SSR `initial` only
+  as the first seed); keep the monotonic `countsGen` stale-guard.
+- [x] 3.3 Replace `LoadMore`-only paging with `InfiniteScroll` + `LoadMore`
+  fallback in `JobsView.svelte`.
+- [x] 3.4 Verify: `svelte-check` clean; manual checklist on `/jobs` — fast typing
+  in the search box keeps every character, facet pills apply immediately,
+  back/forward restores filters + input + results, URL share works,
+  scroll-to-bottom loads next page, load error shows retry, keyboard load works.
+
+## 4. Analytics screen
+
+- [x] 4.1 Update `AnalyticsView.svelte` to consume the rewritten `FilterStore`:
+  reload counts off `filters.applied` (single debounce in the primitive); remove
+  the component-local debounce `setTimeout`; keep the `generation` stale-guard.
+- [x] 4.2 Verify: `svelte-check` clean; manual checklist on the analytics screen —
+  fast typing/filters do not double-load or drop characters, back/forward
+  restores filters + breakdowns, URL share works.
+
+## 5. Finish
+
+- [x] 5.1 Full `svelte-check` + lint baseline check across `web/`; confirm no new
+  errors versus the known-red baseline.
+- [x] 5.2 Confirm `Paginator` (`paginated.svelte.ts`) and backend/API are
+  untouched (diff review).

--- a/web/src/lib/components/AnalyticsView.svelte
+++ b/web/src/lib/components/AnalyticsView.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { onMount, untrack } from 'svelte';
   import { page } from '$app/state';
   import { api } from '$lib/api';
   import { FilterStore, filtersToParams } from '$lib/filters.svelte';
+  import { syncOnNavigation } from '$lib/urlSynced.svelte';
   import { FACETS } from '$lib/facets';
   import type { FacetCounts } from '$lib/types';
   import FiltersPanel from './FiltersPanel.svelte';
@@ -24,43 +25,44 @@
   let status = $state<'ready' | 'loading' | 'error'>('ready');
   let drawerOpen = $state(false);
   let started = false;
-  let timer: ReturnType<typeof setTimeout>;
   // Monotonic fetch id: a response only commits if it is still the latest, so a
   // slow fetch that resolves after a newer one can't overwrite fresh counts with
-  // stale data (the debounce alone doesn't cover already-started fetches).
+  // stale data. The reload debounce now lives in FilterStore (value -> applied),
+  // so there is no second timer here.
   let generation = 0;
 
-  // Browser back/forward changes the URL query — pull it back into the filters.
-  // Track only the URL (untrack the sync, which reads filters.value) so this does
-  // not also fire on our own #commit writes. Same pattern as JobsView.
-  $effect(() => {
-    page.url.search; // track
-    untrack(() => filters.syncFromUrl());
-  });
+  // Cancel a pending debounced apply on unmount so it can't fire afterwards.
+  onMount(() => () => filters.dispose());
 
-  // Re-fetch counts when any filter changes, debounced. The first run is the
-  // seeded SSR snapshot, so skip it. The effect's cleanup clears a pending timer
-  // before the next run and on unmount (the debounce).
+  // Browser back/forward re-seeds the filters from the URL; the resulting
+  // `applied` change drives the counts effect below.
+  syncOnNavigation(filters);
+
+  // Re-fetch counts when the debounced filters change. The debounce already
+  // happened in the primitive, so fetch immediately — the `generation` guard (not
+  // a timer) is what protects against an out-of-order response. Skip the first
+  // run: the SSR `initial` counts are already shown.
   $effect(() => {
-    filtersToParams(filters.value).toString(); // track every filter field
-    if (!started) {
-      started = true;
-      return;
-    }
-    status = 'loading';
-    const params = filtersToParams(filters.value);
-    const gen = ++generation;
-    timer = setTimeout(async () => {
-      try {
-        const next = await api.facetCounts(params);
-        if (gen !== generation) return; // a newer fetch superseded this one
-        counts = next;
-        status = 'ready';
-      } catch {
-        if (gen === generation) status = 'error';
+    filters.applied; // track the debounced snapshot
+    untrack(() => {
+      if (!started) {
+        started = true;
+        return;
       }
-    }, 300);
-    return () => clearTimeout(timer);
+      status = 'loading';
+      const params = filtersToParams(filters.applied);
+      const gen = ++generation;
+      api
+        .facetCounts(params)
+        .then((next) => {
+          if (gen !== generation) return; // a newer fetch superseded this one
+          counts = next;
+          status = 'ready';
+        })
+        .catch(() => {
+          if (gen === generation) status = 'error';
+        });
+    });
   });
 
   // The salary range is only meaningful within a single currency — the stats

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import { page } from '$app/state';
-  import { replaceState } from '$app/navigation';
   import { api, type Slice } from '$lib/api';
   import { Paginator } from '$lib/paginated.svelte';
+  import { UrlSyncedState, syncOnNavigation } from '$lib/urlSynced.svelte';
   import type { CompanyListItem } from '$lib/types';
   import { Badge, Input } from '$lib/ui';
   import States from './States.svelte';
   import LoadMore from './LoadMore.svelte';
+  import InfiniteScroll from './InfiniteScroll.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
 
   // The first page is server-rendered (route `load`) for the current ?q, so the
@@ -15,66 +16,56 @@
   let { initial }: { initial: Slice<CompanyListItem> } = $props();
 
   // Search lives in the URL (?q=) so it survives reload, sharing, and
-  // back/forward — the jobs-list pattern scaled down to a single field (no
-  // FilterStore, which models job-only facets). Seeded from the current URL.
-  let q = $state(page.url.searchParams.get('q') ?? '');
+  // back/forward. The shared primitive owns the state<->URL transport and the
+  // reload debounce; here it's a single string (no FilterStore, which models
+  // job-only facets). `value` drives the input, `applied` drives the fetch.
+  const search = new UrlSyncedState<string>(page.url.searchParams, {
+    parse: (p) => p.get('q') ?? '',
+    serialize: (q) => {
+      const p = new URLSearchParams();
+      if (q) p.set('q', q);
+      return p;
+    },
+  });
 
+  // Fetch against the debounced query so typing doesn't issue a request per key.
   const makePaginator = () =>
-    new Paginator<CompanyListItem>((limit, offset) => api.listCompanies(q, limit, offset));
+    new Paginator<CompanyListItem>((limit, offset) => api.listCompanies(search.applied, limit, offset));
 
   const seeded = makePaginator();
   seeded.seed(untrack(() => initial));
   let companies = $state.raw(seeded);
+  let started = false;
 
-  let timer: ReturnType<typeof setTimeout>;
-
-  // A debounce timer left running after unmount would start a fetch for a
-  // component that no longer exists.
-  onMount(() => () => clearTimeout(timer));
+  onMount(() => () => search.dispose());
 
   function reload() {
     companies = makePaginator();
     companies.start();
   }
 
-  // Typing: update q and mirror it to the URL *synchronously* in this handler,
-  // then re-query debounced. Writing the URL here rather than in an effect keeps
-  // q and the URL in lockstep within the same tick, so the back/forward effect
-  // below never runs mid-keystroke against a stale URL and reverts the input.
-  function search(value: string) {
-    q = value;
-    const params = new URLSearchParams();
-    if (q) params.set('q', q);
-    const qs = params.toString();
-    replaceState(page.url.pathname + (qs ? `?${qs}` : ''), {});
-    clearTimeout(timer);
-    timer = setTimeout(reload, 300);
-  }
-
-  // Browser back/forward changes the URL externally — pull it into q and
-  // re-query. Track *only* the URL: reading q reactively here would also fire the
-  // effect on our own search()/replaceState write, against a page.url that hasn't
-  // updated yet (it propagates a tick later), reverting the just-typed value. So
-  // read q under untrack — the effect runs only on real URL changes, when page.url
-  // is current, and no-ops on initial mount (q is seeded from the same URL).
+  // Reload whenever the debounced query changes (typing settled, or back/forward
+  // re-seeded it). Skip the first run: the SSR `initial` already rendered page one.
   $effect(() => {
-    page.url.search; // track
+    search.applied; // track the debounced query
     untrack(() => {
-      const urlQ = page.url.searchParams.get('q') ?? '';
-      if (urlQ !== q) {
-        q = urlQ;
-        clearTimeout(timer);
-        reload();
+      if (!started) {
+        started = true;
+        return;
       }
+      reload();
     });
   });
+
+  // Browser back/forward re-seeds the query from the URL.
+  syncOnNavigation(search);
 </script>
 
 <div class="mb-4">
   <Input
     type="search"
-    value={q}
-    oninput={(e) => search(e.currentTarget.value)}
+    value={search.value}
+    oninput={(e) => search.setSoon(e.currentTarget.value)}
     placeholder="Search companies…"
     aria-label="Search companies"
     class="w-full"
@@ -86,7 +77,7 @@
 {:else if companies.status === 'error'}
   <States state="error" message="Failed to load companies." />
 {:else if companies.items.length === 0}
-  <States state="empty" message={q ? 'No matching companies.' : 'No companies yet.'} />
+  <States state="empty" message={search.value ? 'No matching companies.' : 'No companies yet.'} />
 {:else}
   <p class="mb-3 text-sm text-muted-foreground" aria-live="polite">
     {companies.total.toLocaleString()} {companies.total === 1 ? 'company' : 'companies'}
@@ -107,6 +98,12 @@
   </div>
 
   {#if companies.hasMore}
+    <!-- Scroll-to-bottom auto-load; the button below stays as the accessible
+         fallback (keyboard/screen-reader, and retry on a failed load). -->
+    <InfiniteScroll
+      onLoad={() => companies.loadMore()}
+      enabled={!companies.loadingMore && !companies.loadMoreError}
+    />
     <LoadMore
       loading={companies.loadingMore}
       error={companies.loadMoreError}

--- a/web/src/lib/components/InfiniteScroll.svelte
+++ b/web/src/lib/components/InfiniteScroll.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  // Bottom-of-list sentinel that calls `onLoad` once it scrolls into view, so the
+  // next page loads when the user reaches the end — no "Load more" click. It is only
+  // a trigger: the caller owns the Paginator and renders an accessible fallback
+  // control (the LoadMore button) for keyboard/screen-reader users and retries.
+  //
+  // `rootMargin: 0px` is deliberate — load when the sentinel actually enters the
+  // viewport ("when you hit the bottom"), not pre-fetched a screen ahead. `enabled`
+  // gates observation so we don't fire while a page is in flight or none remain.
+  let { onLoad, enabled }: { onLoad: () => void; enabled: boolean } = $props();
+
+  let sentinel: HTMLElement | undefined = $state();
+
+  $effect(() => {
+    if (!enabled || !sentinel) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) onLoad();
+      },
+      { rootMargin: '0px' },
+    );
+    io.observe(sentinel);
+    return () => io.disconnect();
+  });
+</script>
+
+<div bind:this={sentinel} aria-hidden="true" class="h-px w-full"></div>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -6,18 +6,21 @@
   import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams } from '$lib/filters.svelte';
+  import { syncOnNavigation } from '$lib/urlSynced.svelte';
   import type { Job, FacetCounts } from '$lib/types';
   import { Input } from '$lib/ui';
   import FiltersPanel from './FiltersPanel.svelte';
   import States from './States.svelte';
   import JobRow from './JobRow.svelte';
   import LoadMore from './LoadMore.svelte';
+  import InfiniteScroll from './InfiniteScroll.svelte';
 
   // Filters live in the URL; the route `load` searches by them and returns the
-  // first page as `initial`, so the rows are in the initial HTML. Each filter
-  // change is a real navigation (FilterStore commits via goto), which re-runs
-  // `load` and delivers a fresh `initial` here; "load more" then pages the rest
-  // client-side over the same filters.
+  // first page as `initial`, so the rows are in the initial HTML for SSR/share/
+  // reload. After hydration the view is client-driven: FilterStore writes the URL
+  // synchronously and exposes a debounced `applied` snapshot; a filter change
+  // reloads the list + counts client-side off `applied` (no navigation), and
+  // infinite scroll pages the rest.
   //
   // `scope` pins extra search params that the user can't change (e.g. the company
   // page passes `{ company_slug }`): they're merged into every search but kept out
@@ -33,9 +36,10 @@
   // render the same filtered view.
   const filters = new FilterStore(page.url.searchParams);
 
-  // The user's facet filters plus the fixed `scope` params (company_slug, …).
+  // The user's (debounced) facet filters plus the fixed `scope` params
+  // (company_slug, …). Reads `applied` so typing doesn't fetch per keystroke.
   const scopedParams = () => {
-    const p = filtersToParams(filters.value);
+    const p = filtersToParams(filters.applied);
     for (const [k, v] of Object.entries(scope)) p.set(k, v);
     return p;
   };
@@ -68,43 +72,41 @@
   };
 
   let drawerOpen = $state(false);
-  let primed = false;
+  let started = false;
 
   // For a signed-in user, load the set of already-viewed slugs so JobRow can dim
   // seen cards (no-op when signed out — the set stays empty). Cleanup: cancel any
-  // debounced filter navigation so it can't fire after this view is gone.
+  // pending debounced reload so it can't fire after this view is gone.
   onMount(() => {
     if (isAuthenticated()) ensureViewedLoaded();
     return () => filters.dispose();
   });
 
-  // Keep the panel synced with the URL and refresh its facet counts. Runs on
-  // mount and on every URL change — a filter commit (goto) or browser
-  // back/forward. Track only the URL: syncFromUrl reads filters.value internally,
-  // so untrack stops this from looping on its own write. It's a no-op when
-  // already in sync (our own commits) and re-seeds the panel on back/forward;
-  // either way the counts refresh for the new filters.
+  function reloadList() {
+    const next = makePaginator();
+    next.start();
+    jobs = next;
+  }
+
+  // Reload list + counts whenever the debounced filters change — a settled
+  // keystroke, an immediate facet toggle, or a back/forward re-seed. Skip the
+  // first run for the list (the SSR `initial` already seeded page one); still
+  // fetch counts on mount since they aren't server-rendered into this view.
   $effect(() => {
-    page.url.search; // track
+    filters.applied; // track the debounced snapshot
     untrack(() => {
-      filters.syncFromUrl();
       refreshCounts();
+      if (!started) {
+        started = true;
+        return;
+      }
+      reloadList();
     });
   });
 
-  // The list mirrors the route `load`: each filter change navigates and re-runs
-  // it, so a fresh `initial` arrives as this prop — reseed a paginator from it.
-  // The first run is the server-rendered page already seeded above, so skip it.
-  $effect(() => {
-    const slice = initial; // track the prop
-    if (!primed) {
-      primed = true;
-      return;
-    }
-    const next = makePaginator();
-    next.seed(slice);
-    jobs = next;
-  });
+  // Browser back/forward re-seeds the filters from the URL; the resulting
+  // `applied` change drives the reload effect above.
+  syncOnNavigation(filters);
 </script>
 
 <div class="flex gap-6">
@@ -150,6 +152,9 @@
       </div>
 
       {#if jobs.hasMore}
+        <!-- Scroll-to-bottom auto-load; the button stays as the accessible
+             fallback (keyboard/screen-reader, and retry on a failed load). -->
+        <InfiniteScroll onLoad={() => jobs.loadMore()} enabled={!jobs.loadingMore && !jobs.loadMoreError} />
         <LoadMore loading={jobs.loadingMore} error={jobs.loadMoreError} onclick={() => jobs.loadMore()} />
       {/if}
     {/if}

--- a/web/src/lib/filters.svelte.ts
+++ b/web/src/lib/filters.svelte.ts
@@ -4,9 +4,8 @@
 // (GET /api/v1/jobs/search) expects, including the `<param>_exclude` and
 // `<param>_mode=and` conventions.
 
-import { page } from '$app/state';
-import { goto } from '$app/navigation';
 import { FACETS } from './facets';
+import { UrlSyncedState } from './urlSynced.svelte';
 
 /** One facet's selection: the chosen values, whether it filters by inclusion or
  *  exclusion, and (for facets that allow it) whether selected values are ANDed
@@ -111,49 +110,57 @@ export function canonicalQuery(query: string): string {
   return filtersToParams(filtersFromParams(new URLSearchParams(query))).toString();
 }
 
-/** Reactive filter state mirrored into the URL. Owned by the jobs view; all
- *  mutations go through its methods so every change updates state and URL. */
+/** Reactive job filters mirrored into the URL. A thin wrapper over the shared
+ *  `UrlSyncedState` primitive: it owns the job-specific shape (facets/visa/salary/
+ *  sort) and the discrete-vs-continuous policy, while the primitive owns the
+ *  state<->URL transport and the reload debounce. Read `value` to drive inputs and
+ *  `applied` (the debounced snapshot) to drive the data reload. */
 export class FilterStore {
-  value = $state<JobFilters>(emptyFilters());
-
-  // Debounce handle for the continuous inputs (free-text query, salary slider),
-  // which fire on every keystroke / drag tick. Their URL commit — a real
-  // navigation that re-runs `load` — is coalesced so typing doesn't round-trip
-  // per character; `value` still updates synchronously so the input stays live.
-  #navTimer: ReturnType<typeof setTimeout> | undefined;
+  #url: UrlSyncedState<JobFilters>;
 
   /** Seed from the current URL params (passed by the view from `page.url`), so
    *  the same filters render on the server and hydrate on the client. */
   constructor(initial?: URLSearchParams) {
-    this.value = filtersFromParams(initial ?? new URLSearchParams());
+    this.#url = new UrlSyncedState<JobFilters>(initial ?? new URLSearchParams(), {
+      parse: filtersFromParams,
+      serialize: filtersToParams,
+    });
+  }
+
+  /** Live filters — bind inputs to this. */
+  get value(): JobFilters {
+    return this.#url.value;
+  }
+
+  /** Debounced filters — drive the list/counts reload off this. */
+  get applied(): JobFilters {
+    return this.#url.applied;
   }
 
   get active(): number {
-    return activeFilterCount(this.value);
+    return activeFilterCount(this.#url.value);
   }
 
   facet(param: string): FacetState {
-    return this.value.facets[param] ?? emptyFacet();
+    return this.#url.value.facets[param] ?? emptyFacet();
   }
 
+  // Continuous inputs (typed/dragged): debounce the reload via setSoon.
   setQuery(q: string) {
-    this.value = { ...this.value, q };
-    this.#commitSoon();
-  }
-
-  setVisa(on: boolean) {
-    this.value = { ...this.value, visa: on };
-    this.#commit();
+    this.#url.setSoon({ ...this.#url.value, q });
   }
 
   setSalaryMin(n: number | null) {
-    this.value = { ...this.value, salaryMin: n };
-    this.#commitSoon();
+    this.#url.setSoon({ ...this.#url.value, salaryMin: n });
+  }
+
+  // Discrete inputs (clicked/toggled): apply immediately via setNow.
+  setVisa(on: boolean) {
+    this.#url.setNow({ ...this.#url.value, visa: on });
   }
 
   setSort(sort: SortField) {
-    this.value = { ...this.value, sort };
-    this.#commit();
+    this.#url.setNow({ ...this.#url.value, sort });
   }
 
   /** Toggle a facet between match-all (AND) and match-any (OR) of its values. */
@@ -192,56 +199,27 @@ export class FilterStore {
   }
 
   clear() {
-    this.value = emptyFilters();
-    this.#commit();
+    this.#url.setNow(emptyFilters());
   }
 
   /** Replace the entire filter state from a saved query string and mirror it to
    *  the URL — applies a saved search. Unknown params are ignored by
    *  filtersFromParams, so a stale save degrades to a partial filter. */
   apply(query: string) {
-    this.value = filtersFromParams(new URLSearchParams(query));
-    this.#commit();
+    this.#url.setNow(filtersFromParams(new URLSearchParams(query)));
   }
 
-  /** Re-read filters from the current URL (browser back/forward). No-op when
-   *  already in sync, which also breaks the write-back loop after our own
-   *  commit. */
+  /** Re-read filters from the current URL (browser back/forward). */
   syncFromUrl() {
-    const current = page.url.searchParams;
-    if (current.toString() === filtersToParams(this.value).toString()) return;
-    this.value = filtersFromParams(current);
+    this.#url.syncFromUrl();
   }
 
-  /** Cancel any pending debounced navigation — call from the owning view's
-   *  cleanup so a late commit can't navigate after unmount. */
+  /** Cancel any pending debounced reload — call from the owning view's cleanup. */
   dispose() {
-    clearTimeout(this.#navTimer);
+    this.#url.dispose();
   }
 
   #setFacet(param: string, st: FacetState) {
-    this.value = { ...this.value, facets: { ...this.value.facets, [param]: st } };
-    this.#commit();
-  }
-
-  /** Mirror the current filters into the URL via a real navigation. `goto` (not
-   *  the shallow `replaceState`) registers the change with the router, so the URL
-   *  and its `load`-produced results are stored on the history entry and restored
-   *  correctly on browser back/forward — shallow routing leaves `page.url` (and
-   *  thus `load`) stale on a back navigation. `replaceState: true` updates in
-   *  place (no per-tweak history entry); `keepFocus`/`noScroll` keep the page
-   *  steady. The route `load` re-runs for the new query and drives the list.
-   *  Browser-only (mutations are user events). */
-  #commit() {
-    clearTimeout(this.#navTimer); // a pending debounced nav is now subsumed
-    const qs = filtersToParams(this.value).toString();
-    goto(page.url.pathname + (qs ? `?${qs}` : ''), { replaceState: true, keepFocus: true, noScroll: true });
-  }
-
-  /** Debounced #commit for the continuous inputs, so each keystroke / slider tick
-   *  doesn't trigger its own navigation + `load`. */
-  #commitSoon() {
-    clearTimeout(this.#navTimer);
-    this.#navTimer = setTimeout(() => this.#commit(), 300);
+    this.#url.setNow({ ...this.#url.value, facets: { ...this.#url.value.facets, [param]: st } });
   }
 }

--- a/web/src/lib/urlSynced.svelte.ts
+++ b/web/src/lib/urlSynced.svelte.ts
@@ -1,0 +1,109 @@
+// A reactive search/filter model mirrored into the URL query string. Owns the
+// state <-> URL transport and the reload debounce; it knows nothing about the API
+// or what data a screen loads. Consumers bind an input to `value` (live) and
+// reload off `applied` (the debounced snapshot) — see the jobs/companies/analytics
+// views.
+//
+// Why client-driven (replaceState) and not goto: the URL is written
+// *synchronously* on every change, so it is always in lockstep with the input.
+// Because of that, `syncFromUrl` (browser back/forward) can never observe a URL
+// lagging behind what the user just typed, so it can never revert in-flight
+// characters. Only the data reload is debounced — never the URL write. This is the
+// structural fix for the dropped-character race the goto+debounce design had.
+
+import { untrack } from 'svelte';
+import { page } from '$app/state';
+import { replaceState } from '$app/navigation';
+
+/** Translates the model to/from URL query params — the only screen-specific part. */
+export interface UrlCodec<T> {
+  parse: (params: URLSearchParams) => T;
+  serialize: (value: T) => URLSearchParams;
+}
+
+/** Re-seed a synced state from the URL on browser back/forward. Call once during a
+ *  component's init. Tracks only the URL: `syncFromUrl` reads the state's own
+ *  `value`, so untrack stops this from looping on our synchronous URL writes (and
+ *  it no-ops when already in sync, which is exactly that case). The state's
+ *  resulting `applied` change is what a consumer's reload effect then watches. */
+export function syncOnNavigation(state: { syncFromUrl: () => void }): void {
+  $effect(() => {
+    page.url.search; // track
+    untrack(() => state.syncFromUrl());
+  });
+}
+
+export class UrlSyncedState<T> {
+  /** Live model — bind inputs to this; every keystroke updates it synchronously. */
+  value = $state<T>(undefined as T);
+  /** Debounced snapshot of `value` — the sole signal a consumer watches to reload. */
+  applied = $state<T>(undefined as T);
+
+  #codec: UrlCodec<T>;
+  #debounceMs: number;
+  // The one timer in the system: coalesces `value` -> `applied` so typing doesn't
+  // reload per keystroke. `undefined` means no reload is queued (back/forward relies
+  // on this being truthful — see syncFromUrl).
+  #timer: ReturnType<typeof setTimeout> | undefined;
+
+  /** Seed from the current URL params (passed by the view from `page.url`), so the
+   *  same state renders on the server and hydrates on the client. */
+  constructor(initial: URLSearchParams, codec: UrlCodec<T>, debounceMs = 300) {
+    this.#codec = codec;
+    this.#debounceMs = debounceMs;
+    // Fields above are placeholders; the real seed lands before any consumer reads.
+    const seeded = codec.parse(initial);
+    this.value = seeded;
+    this.applied = seeded;
+  }
+
+  /** Discrete change (facet pill, checkbox, clear): write the URL and apply at once.
+   *  A click is never typed fast, so debouncing it would only add latency. */
+  setNow(next: T) {
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+    this.#write(next);
+    this.applied = next;
+  }
+
+  /** Continuous input (free text, slider): write the URL synchronously, debounce the
+   *  reload. `value` stays live so the input never lags; `applied` follows after the
+   *  quiet window. */
+  setSoon(next: T) {
+    this.#write(next);
+    clearTimeout(this.#timer);
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined;
+      this.applied = this.value;
+    }, this.#debounceMs);
+  }
+
+  /** Re-read from the current URL (browser back/forward). No-op when already in sync,
+   *  which also breaks the write-back loop after our own replaceState. Because URL
+   *  writes are synchronous, a mismatch here is a genuine external navigation — never
+   *  a stale-our-own-commit, so reseeding can't eat in-flight typing. */
+  syncFromUrl() {
+    const current = page.url.searchParams;
+    if (current.toString() === this.#codec.serialize(this.value).toString()) return;
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+    const seeded = this.#codec.parse(current);
+    this.value = seeded;
+    this.applied = seeded;
+  }
+
+  /** Cancel a pending reload — call from the owning view's cleanup so a late apply
+   *  can't fire after unmount. */
+  dispose() {
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+  }
+
+  #write(next: T) {
+    this.value = next;
+    const qs = this.#codec.serialize(next).toString();
+    // Shallow routing: updates the URL in place without a navigation or load, so the
+    // write is cheap and synchronous. Browser-only (mutations are user events).
+    replaceState(page.url.pathname + (qs ? `?${qs}` : ''), {});
+  }
+}


### PR DESCRIPTION
## Summary

Fixes dropped characters when typing fast in search/filter inputs, and replaces the "Load more" button with bottom-reach infinite scroll.

The frontend had **three divergent copies** of "input → debounce → URL → reload data". The jobs/analytics `FilterStore` debounced the *URL write* (a `goto` navigation), so while a navigation was in flight the late `load` result reverted just-typed characters. This unifies all three on one primitive and fixes the bug **structurally**:

- **`UrlSyncedState<T>`** (`web/src/lib/urlSynced.svelte.ts`) — the single primitive. Writes the URL **synchronously** on every change via `replaceState` (so back/forward reconciliation can never clobber in-flight typing — no guard needed), and exposes a **debounced `applied` snapshot** as the sole reload signal. `setNow` (discrete: facet pills/checkboxes) vs `setSoon` (continuous: text/slider). Plus `syncOnNavigation` helper for back/forward.
- **`FilterStore`** rewritten as a thin wrapper over the primitive (public surface unchanged).
- **CompaniesView / JobsView / AnalyticsView** consume the primitive; reload list/counts off `applied`. AnalyticsView loses its **duplicate debounce / double load**.
- **`InfiniteScroll.svelte`** — `IntersectionObserver` sentinel (`rootMargin: 0px`, no pre-fetch). `Paginator` unchanged. The `LoadMore` button stays as an **accessible fallback** (keyboard/screen-reader + retry on error).

No backend / API / DB changes.

OpenSpec change: `unify-url-search-state` (proposal/design/spec/tasks included).

## Test Plan

No web test runner exists (intentional). Verified via `svelte-check` (0 errors) + live browser against real data:

- [x] **Fast typing keeps every character** — `/companies` "javascript" and `/jobs` "golang developer" retained immediately and after settle; URL synced.
- [x] **Back/forward** — `replaceState` adds no per-keystroke history; Forward restored `?q=javascript` and the input value.
- [x] **Infinite scroll** — `/jobs` auto-loaded 20 → 60 rows on scroll-to-bottom, no clicks.
- [x] **Accessible fallback** — `LoadMore` button present at list bottom.
- [x] **Analytics** renders, no double-load; zero page errors / zero SSR 500s.
- [x] `go build ./... && go vet ./...` clean (branch based on current main).