### PR TITLE
feat(sources): add Dwelly greenhouse board

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -637,6 +637,8 @@
   board: duolingo
 - company: DV Trading
   board: dvtrading
+- company: Dwelly
+  board: dwelly
 - company: Dynamis Inc
   board: dynamisinc
 - company: e2 open


### PR DESCRIPTION
Adds the `dwelly` Greenhouse board (`job-boards.eu.greenhouse.io/dwelly`), ~20 open roles via the public Greenhouse API (one-host, EU vanity domain maps to the same token). One line in `sources/greenhouse.yml`; picked up by the existing greenhouse ingest cron. Sources-only — deployable via `deploy.sh --no-build`.