### PR TITLE
fix(search): cap indexed description to keep facet rebuilds disk-bounded

### DIFF
--- a/internal/search/document.go
+++ b/internal/search/document.go
@@ -1,9 +1,22 @@
 package search
 
 import (
+	"strings"
+
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
 )
+
+// maxIndexedDescriptionRunes caps the description text stored in the search
+// document. The full description lives in Postgres and is served verbatim by the
+// detail endpoint (its own jobview.FromRow); the index only needs enough of it
+// for keyword matching. The inverted index over `description` dominates the facet
+// index size (~5x the raw document bytes), and a full rebuild's transient on-disk
+// footprint scales with it — capping the indexed text to the meaningful opening
+// keeps a fresh rebuild small enough to swap in within the host's free disk.
+// Descriptions average ~4900 runes; 1000 captures the role summary and the first
+// requirements, where keyword matches that matter overwhelmingly land.
+const maxIndexedDescriptionRunes = 1000
 
 // JobDocument is a job as stored in the Meilisearch index: the internal id (the
 // primary key) plus the public jobview.Job — the exact wire shape served by the
@@ -28,5 +41,24 @@ func FromJob(j db.Job) (JobDocument, error) {
 	if err != nil {
 		return JobDocument{}, err
 	}
+	// Cap the indexed description (see maxIndexedDescriptionRunes). This trims only
+	// the search document — the detail endpoint serves the full description from
+	// its own jobview.FromRow, unaffected by this local copy.
+	view.Description = truncateRunes(view.Description, maxIndexedDescriptionRunes)
 	return JobDocument{ID: j.ID, Job: view}, nil
+}
+
+// truncateRunes returns the first n runes of s (UTF-8 safe), backed off to the
+// last space within the cut so a word is not split mid-token. Strings already
+// within the cap are returned unchanged.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	cut := string(r[:n])
+	if i := strings.LastIndexByte(cut, ' '); i > 0 {
+		cut = cut[:i]
+	}
+	return cut
 }

--- a/internal/search/document_test.go
+++ b/internal/search/document_test.go
@@ -2,7 +2,9 @@ package search
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/strelov1/freehire/internal/db"
 )
@@ -32,5 +34,32 @@ func TestFromJob_DocumentFlattensIDAndViewToTopLevelJSON(t *testing.T) {
 	}
 	if _, ok := m["enrichment"]; !ok {
 		t.Errorf("enrichment should be a nested object in %s", raw)
+	}
+}
+
+func TestFromJob_CapsIndexedDescription(t *testing.T) {
+	// The search document caps the description so the inverted index (and a full
+	// rebuild's transient disk footprint) stays small; the detail endpoint still
+	// serves the full text from Postgres. A long description is trimmed to at most
+	// maxIndexedDescriptionRunes runes; a short one is left verbatim.
+	long := strings.Repeat("alpha beta ", 600) // ~6000 runes
+	doc, err := FromJob(db.Job{ID: 1, Title: "Go Dev", Description: long})
+	if err != nil {
+		t.Fatalf("FromJob: %v", err)
+	}
+	if n := utf8.RuneCountInString(doc.Description); n > maxIndexedDescriptionRunes {
+		t.Errorf("indexed description = %d runes, want <= %d", n, maxIndexedDescriptionRunes)
+	}
+	if !strings.HasPrefix(long, doc.Description) {
+		t.Errorf("truncated description is not a prefix of the original")
+	}
+
+	short := "Build backend services in Go."
+	docShort, err := FromJob(db.Job{ID: 2, Title: "Go Dev", Description: short})
+	if err != nil {
+		t.Fatalf("FromJob short: %v", err)
+	}
+	if docShort.Description != short {
+		t.Errorf("short description altered: got %q, want %q", docShort.Description, short)
 	}
 }


### PR DESCRIPTION
## Problem

The facet search index (`jobs`) stores the full job description as a searchable attribute. Its inverted index dominates the on-disk size — **45.7G for ~9.3G of raw documents** (~5×). A full reindex builds a fresh copy and atomically swaps it in (PR #167), so the transient footprint is ~2× the index. On the shared prod host the rebuild of the ~1.3M-doc catalogue bloats past free disk mid-merge and dies with `No space left on device`; the swap never completes and **search goes stale** (newly ingested jobs never become searchable).

## Fix

Cap the description stored in the search document to the first **1000 runes** (avg description is ~4900; the opening carries the role summary and first requirements, where keyword matches overwhelmingly land). The cap lives in `FromJob`'s local `view` copy, so:

- the detail endpoint still serves the **full** description from Postgres (its own `jobview.FromRow`) — unaffected;
- only the **indexed text** and the search-hit snippet are trimmed;
- `SearchableAttributes` is unchanged — `description` stays searchable, now over the prefix.

This shrinks a fresh facet rebuild to ~18–20G, so the swap fits within host free disk again.

Truncation is rune-based (UTF-8 safe) and backs off to the last space so it never splits a word or a multibyte char.

## Test

`TestFromJob_CapsIndexedDescription` covers the long→trimmed-to-prefix and short→verbatim cases. `go build ./...` + `go test ./internal/search/` green.

## Deploy note

Pairs with a `ulimits.nofile=524288` bump on the Meilisearch container (separate freehire-ops change) — the other half of the rebuild-reliability fix. After deploy, run a full facet reindex to land the smaller index.