### PR TITLE
fix(jobview): effective posted_at (created_at fallback for future/missing dates)

### DIFF
--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -115,7 +115,7 @@ func FromRow(j db.Job) (Job, error) {
 		Regions:           regions,
 		WorkMode:          workMode,
 		Skills:            skills,
-		PostedAt:          rfc3339(j.PostedAt),
+		PostedAt:          rfc3339(effectivePostedAt(j.PostedAt, j.CreatedAt)),
 		CreatedAt:         rfc3339(j.CreatedAt),
 		UpdatedAt:         rfc3339(j.UpdatedAt),
 		ClosedAt:          rfc3339(j.ClosedAt),
@@ -153,6 +153,19 @@ func FromRows(jobs []db.Job) ([]Job, error) {
 		out[i] = v
 	}
 	return out, nil
+}
+
+// effectivePostedAt is the timestamp a job reads as "posted" for both display and the
+// freshest-first sort: the source's posted_at when present and not in the future, otherwise
+// the ingest time (created_at). A missing posted_at (undated source) or a future one (e.g. a
+// Workday startDate set to a future go-live) would otherwise leave the job undated or sort it
+// above genuinely recent postings; falling back to created_at gives an honest, recent
+// freshness. The raw created_at stays exposed separately, so the substitution is visible.
+func effectivePostedAt(posted, created pgtype.Timestamptz) pgtype.Timestamptz {
+	if !posted.Valid || posted.Time.After(time.Now()) {
+		return created
+	}
+	return posted
 }
 
 // rfc3339 renders a nullable Postgres timestamp as an RFC3339 UTC string, or nil

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -14,6 +14,50 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
+func TestFromRow_PostedAtFallsBackToCreatedAtWhenFutureOrMissing(t *testing.T) {
+	created := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
+	createdTS := pgtype.Timestamptz{Time: created, Valid: true}
+	const wantCreated = "2026-06-18T12:00:00Z"
+	base := db.Job{Source: "workday", ExternalID: "1", PublicSlug: "s", CreatedAt: createdTS, Enrichment: []byte("{}")}
+
+	// A future posted_at (e.g. a Workday startDate set to a go-live date) must not sort the
+	// job to the top of the freshest-first browse — it reads as its ingest time instead.
+	future := base
+	future.PostedAt = pgtype.Timestamptz{Time: time.Now().Add(24 * time.Hour), Valid: true}
+	v, err := FromRow(future)
+	if err != nil {
+		t.Fatalf("FromRow(future): %v", err)
+	}
+	if v.PostedAt == nil || *v.PostedAt != wantCreated {
+		t.Errorf("future posted_at: PostedAt = %v, want created_at %s", v.PostedAt, wantCreated)
+	}
+	if v.CreatedAt == nil || *v.CreatedAt != wantCreated {
+		t.Errorf("CreatedAt should still be exposed raw, got %v", v.CreatedAt)
+	}
+
+	// A missing posted_at (undated source) also falls back to the ingest time.
+	missing := base
+	missing.PostedAt = pgtype.Timestamptz{}
+	v2, err := FromRow(missing)
+	if err != nil {
+		t.Fatalf("FromRow(missing): %v", err)
+	}
+	if v2.PostedAt == nil || *v2.PostedAt != wantCreated {
+		t.Errorf("missing posted_at: PostedAt = %v, want created_at %s", v2.PostedAt, wantCreated)
+	}
+
+	// A real, past posted_at is left untouched.
+	past := base
+	past.PostedAt = pgtype.Timestamptz{Time: time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC), Valid: true}
+	v3, err := FromRow(past)
+	if err != nil {
+		t.Fatalf("FromRow(past): %v", err)
+	}
+	if v3.PostedAt == nil || *v3.PostedAt != "2026-06-10T09:00:00Z" {
+		t.Errorf("past posted_at should stay unchanged, got %v", v3.PostedAt)
+	}
+}
+
 func TestFromRow_MapsCoreAndNestedEnrichment(t *testing.T) {
 	posted := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
 	// LLM-only fields (domains, visa, salary) stay nested; the six dictionary


### PR DESCRIPTION
## Summary

`/jobs` sorts by `posted_at DESC`, but a handful of sources emit a **future** posting date — e.g. Workday's `startDate` set to a go-live date (73 open jobs dated *tomorrow*) and a Phenom one dated +2 days. The `NotFuture` guard only drops values >48h ahead, so "tomorrow" passed and these sorted to the **top** of the freshest-first list, burying genuinely recent jobs and making the list look stale (a filtered view like `?company_type=startup`, which excluded them, looked fresher).

`jobview.FromRow` now serves an **effective `posted_at`**: the source's value when present and not in the future, otherwise the ingest time (`created_at`). Undated postings get the same fallback. Because `FromRow` feeds **both the API response and the search document**, this fixes the displayed date and the search sort in one place. Raw `created_at` stays exposed separately, so the substitution is visible.

No DB mutation — existing future/undated rows pick up the effective value on the next reindex.

## Test Plan
- [x] `go test ./internal/jobview/` — new `TestFromRow_PostedAtFallsBackToCreatedAtWhenFutureOrMissing` (future→created_at, missing→created_at, past→unchanged) + existing tests.
- [x] `go test ./...` full unit suite green; `go build/vet/gofmt` clean.
- [ ] After deploy + reindex: `/jobs` top no longer shows future-dated (Workday/Phenom) postings.