### PR TITLE
fix(sources): page Oracle by offset inside the finder (recover full coverage)

### DIFF
--- a/internal/sources/oracle.go
+++ b/internal/sources/oracle.go
@@ -78,10 +78,13 @@ func (s oracle) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 func (s oracle) listRequisitions(ctx context.Context, b oracleBoard) ([]oracleRequisition, error) {
 	var reqs []oracleRequisition
 	for offset := 0; ; {
+		// offset must sit INSIDE the finder clause (next to limit). Oracle ignores a
+		// top-level &offset= query param, so a misplaced offset silently re-fetches the
+		// first page every iteration and only the newest page of jobs is ever collected.
 		url := fmt.Sprintf(
 			"https://%s/hcmRestApi/resources/latest/recruitingCEJobRequisitions"+
 				"?onlyData=true&expand=requisitionList.secondaryLocations,requisitionList.workLocation"+
-				"&finder=findReqs;siteNumber=%s,limit=%d,sortBy=POSTING_DATES_DESC&offset=%d",
+				"&finder=findReqs;siteNumber=%s,limit=%d,offset=%d,sortBy=POSTING_DATES_DESC",
 			b.host, b.site, oraclePageLimit, offset)
 		var resp oracleListResponse
 		if err := s.http.GetJSON(ctx, url, &resp); err != nil {

--- a/internal/sources/oracle_test.go
+++ b/internal/sources/oracle_test.go
@@ -98,6 +98,36 @@ func TestOracleFetchListsAndFetchesDetail(t *testing.T) {
 	}
 }
 
+// TestOracleOffsetIsInsideFinder guards the pagination fix: Oracle ignores a top-level
+// &offset= query param (it only honors offset INSIDE the finder clause, alongside limit),
+// so a top-level offset silently re-fetches the first page forever. The fake routes each
+// page on ",offset=N" — the comma prefix matches only when offset sits inside the
+// finder list — so a regression to a top-level "&offset=N" leaves page two unrouted and
+// fails the run.
+func TestOracleOffsetIsInsideFinder(t *testing.T) {
+	page := func(ids ...string) string {
+		var items []string
+		for _, id := range ids {
+			items = append(items, `{"Id": "`+id+`", "Title": "Role `+id+`", "PrimaryLocation": "Remote", "WorkplaceTypeCode": "ORA_REMOTE"}`)
+		}
+		return `{"items": [{"TotalJobsCount": 3, "requisitionList": [` + strings.Join(items, ",") + `]}]}`
+	}
+	fake := (&routedHTTP{}).
+		route(",offset=0", page("1", "2")).
+		route(",offset=2", page("3")).
+		route("ById", `{"items": [{"ExternalDescriptionStr": "<p>desc</p>"}]}`)
+
+	jobs, err := NewOracle(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "oracle", Board: "fa-test.fa.ocs.oraclecloud.com/CX_1",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 (offset must be inside the finder so page two advances)", len(jobs))
+	}
+}
+
 // TestOraclePaginatesByTotal verifies the lister keeps requesting pages until it has
 // gathered TotalJobsCount requisitions, not just the first page.
 func TestOraclePaginatesByTotal(t *testing.T) {


### PR DESCRIPTION
## Problem

Oracle Recruiting Cloud **ignores a top-level `&offset=` query param** — it only honors `offset` *inside* the `findReqs` finder clause (next to `limit`). The lister placed `offset` at the top level, so every pagination iteration silently re-fetched the **newest page**, and only ~1 page of jobs per board ever landed.

Real impact in prod (Goldman Sachs / `hdpc.fa.us2.oraclecloud.com/LateralHiring`): **190 of 1508** jobs ingested. This affects **all ~173 oracle boards**.

### Root cause (verified)
```
offset=0  -> ids [149771, 152679, 152872 ...]
offset=50 (top-level &offset=, current)  -> SAME ids   (offset ignored)
offset=50 (inside finder, fixed)         -> different ids (real paging)
```

## Fix
Move `offset` into the finder: `findReqs;siteNumber=…,limit=100,offset=N,sortBy=…`.

## Verification
- New regression test `TestOracleOffsetIsInsideFinder` (routes pages on `,offset=N` — a top-level offset leaves page two unrouted and fails). Fails before, passes after.
- `go test ./internal/sources/` ✅, `go vet` ✅
- **Live**: replaying the fixed URL against the GS board collects **1508/1508** distinct requisitions (was one page); the specific job 169308 is now reachable.

## Deploy note
Code change → needs image rebuild + redeploy. After deploy, the next hourly oracle ingest will backfill the missing ~87% of each oracle board (then a reindex).