### PR TITLE
feat(sources): add Bolt (greenhouse) + eeze (teamtailor)

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -10811,3 +10811,5 @@
   board: nuitee
 - company: Yondr Group
   board: yondrgroup
+- company: Bolt
+  board: boltv2

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -144,3 +144,5 @@
   board: "veesionvf.teamtailor.com"
 - company: "YEGO"
   board: "yego.teamtailor.com"
+- company: eeze
+  board: careers.eeze.com


### PR DESCRIPTION
Two new boards, both validated live:

| Company | Provider | Board | Live count | Notes |
|---|---|---|---|---|
| **Bolt** | greenhouse | `boltv2` | 294 jobs | Greenhouse behind the `bolt.eu/careers` vanity domain. Token resolved via `boards.greenhouse.io/embed/job_app?token=<jobid>` → 302 → `?for=boltv2`. Sample job 8524769002 present. |
| **eeze** | teamtailor | `careers.eeze.com` | 20+/page | Teamtailor career site on a custom domain. |

Both files pass `LoadConfig`+`Validate` against the registry. Sources-only change → deploy via sources rsync (no rebuild).