### PR TITLE
chore: add Buy Me a Coffee sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: i_strelov


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so GitHub renders a **Sponsor** button in the repo header linking to [buymeacoffee.com/i_strelov](https://buymeacoffee.com/i_strelov).

Uses the platform-specific `buy_me_a_coffee` key (username only — GitHub builds the URL).