### PR TITLE
feat(harvest): domain-following ATS harvest (harvest-ats)

### DIFF
--- a/cmd/harvest-ats/extract.go
+++ b/cmd/harvest-ats/extract.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// companySite pairs a company name with its website — the input the resolve step
+// follows to a careers page.
+type companySite struct {
+	Name    string `json:"name"`
+	Website string `json:"website"`
+}
+
+// siteParsers maps a collection slug to a parser that extracts (name, website)
+// from that dataset's payload. Only datasets that carry a website are listed; the
+// hand-list collections (bigtech/mag7/ai) have none. The dataset URLs come from
+// collections.All, so this only encodes each dataset's website field shape.
+var siteParsers = map[string]func([]byte) ([]companySite, error){
+	"yc":         parseYCSites,
+	"european":   parseEUSites,
+	"techstars":  parseTechstarsSites,
+	"fortune500": func(b []byte) ([]companySite, error) { return parseCSVSites(b, ',', "Company", "Website") },
+	"unicorn":    func(b []byte) ([]companySite, error) { return parseCSVSites(b, ',', "Company", "Company Website") },
+}
+
+func parseYCSites(data []byte) ([]companySite, error) {
+	var raw []struct {
+		Name    string `json:"name"`
+		Website string `json:"website"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse yc sites: %w", err)
+	}
+	out := make([]companySite, 0, len(raw))
+	for _, c := range raw {
+		if c.Name != "" && c.Website != "" {
+			out = append(out, companySite{Name: c.Name, Website: c.Website})
+		}
+	}
+	return out, nil
+}
+
+func parseEUSites(data []byte) ([]companySite, error) {
+	var raw []struct {
+		Name    string `json:"Name"`
+		Website string `json:"Website URL"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse european sites: %w", err)
+	}
+	out := make([]companySite, 0, len(raw))
+	for _, c := range raw {
+		if c.Name != "" && c.Website != "" {
+			out = append(out, companySite{Name: c.Name, Website: c.Website})
+		}
+	}
+	return out, nil
+}
+
+// parseTechstarsSites reads the semicolon-separated Techstars CSV (name;urls;…),
+// taking the first URL of the comma-separated urls list as the homepage.
+func parseTechstarsSites(data []byte) ([]companySite, error) {
+	rows, _, err := csvColumns(data, ';', "name", "urls")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]companySite, 0, len(rows))
+	for _, r := range rows {
+		site := strings.TrimSpace(strings.SplitN(r[1], ",", 2)[0])
+		if r[0] != "" && site != "" {
+			out = append(out, companySite{Name: r[0], Website: site})
+		}
+	}
+	return out, nil
+}
+
+// parseCSVSites reads a delimited CSV, taking the name and website from the named
+// columns (located by header).
+func parseCSVSites(data []byte, delim rune, nameCol, urlCol string) ([]companySite, error) {
+	rows, _, err := csvColumns(data, delim, nameCol, urlCol)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]companySite, 0, len(rows))
+	for _, r := range rows {
+		if r[0] != "" && r[1] != "" {
+			out = append(out, companySite{Name: r[0], Website: r[1]})
+		}
+	}
+	return out, nil
+}
+
+// csvColumns returns each data row's (col0, col1) values for the two named columns,
+// located by header (not index, so an upstream reorder can't read the wrong field).
+func csvColumns(data []byte, delim rune, col0, col1 string) (rows [][2]string, header []string, err error) {
+	r := csv.NewReader(strings.NewReader(string(data)))
+	r.Comma = delim
+	r.FieldsPerRecord = -1
+	head, err := r.Read()
+	if err != nil {
+		return nil, nil, fmt.Errorf("read csv header: %w", err)
+	}
+	i0, i1 := colIndex(head, col0), colIndex(head, col1)
+	if i0 < 0 || i1 < 0 {
+		return nil, head, fmt.Errorf("csv missing column %q or %q", col0, col1)
+	}
+	all, err := r.ReadAll()
+	if err != nil {
+		return nil, head, fmt.Errorf("read csv: %w", err)
+	}
+	for _, row := range all {
+		var v0, v1 string
+		if i0 < len(row) {
+			v0 = strings.TrimSpace(row[i0])
+		}
+		if i1 < len(row) {
+			v1 = strings.TrimSpace(row[i1])
+		}
+		rows = append(rows, [2]string{v0, v1})
+	}
+	return rows, head, nil
+}
+
+func colIndex(header []string, name string) int {
+	for i, h := range header {
+		if strings.EqualFold(strings.TrimSpace(h), name) {
+			return i
+		}
+	}
+	return -1
+}
+
+// filterUnmatched drops companies whose normalized-name slug is already in the
+// catalogue (present in existing), leaving the ones worth discovering boards for.
+func filterUnmatched(sites []companySite, existing map[string]bool) []companySite {
+	out := make([]companySite, 0, len(sites))
+	for _, s := range sites {
+		if !existing[normalize.Slug(s.Name)] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// dedupeByWebsite collapses companies that share a website (the same company can
+// appear in several collections), keeping first-seen order, so a site is fetched once.
+func dedupeByWebsite(sites []companySite) []companySite {
+	seen := make(map[string]bool, len(sites))
+	out := make([]companySite, 0, len(sites))
+	for _, s := range sites {
+		key := strings.ToLower(strings.TrimRight(strings.TrimSpace(s.Website), "/"))
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+// splitLines splits text into lines, trimming surrounding whitespace (incl. \r).
+func splitLines(text string) []string {
+	raw := strings.Split(text, "\n")
+	out := make([]string, len(raw))
+	for i, l := range raw {
+		out[i] = strings.TrimSpace(l)
+	}
+	return out
+}

--- a/cmd/harvest-ats/extract_test.go
+++ b/cmd/harvest-ats/extract_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseYCSites(t *testing.T) {
+	got, err := parseYCSites([]byte(`[
+		{"name":"Acme","website":"https://acme.com"},
+		{"name":"NoSite","website":""}
+	]`))
+	if err != nil {
+		t.Fatalf("parseYCSites: %v", err)
+	}
+	want := []companySite{{Name: "Acme", Website: "https://acme.com"}} // empty website skipped
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseEUSites(t *testing.T) {
+	got, err := parseEUSites([]byte(`[{"Name":"Revolut","Website URL":"https://revolut.com"}]`))
+	if err != nil {
+		t.Fatalf("parseEUSites: %v", err)
+	}
+	want := []companySite{{Name: "Revolut", Website: "https://revolut.com"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseCSVSites_CommaCompanyWebsite(t *testing.T) {
+	csv := "Rank,Company,Website\n1,Walmart,www.walmart.com\n2,NoSite,\n"
+	got, err := parseCSVSites([]byte(csv), ',', "Company", "Website")
+	if err != nil {
+		t.Fatalf("parseCSVSites: %v", err)
+	}
+	want := []companySite{{Name: "Walmart", Website: "www.walmart.com"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseTechstarsSites_FirstURL(t *testing.T) {
+	// Techstars CSV is semicolon-separated; the urls column is a comma list whose
+	// first entry is the homepage.
+	csv := "name;urls;description\n" +
+		"Sentry;https://sentry.io, https://twitter.com/x;monitoring\n" +
+		"NoUrl;;x"
+	got, err := parseTechstarsSites([]byte(csv))
+	if err != nil {
+		t.Fatalf("parseTechstarsSites: %v", err)
+	}
+	want := []companySite{{Name: "Sentry", Website: "https://sentry.io"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestFilterUnmatched(t *testing.T) {
+	sites := []companySite{
+		{Name: "Stripe", Website: "https://stripe.com"},  // slug stripe in set → drop
+		{Name: "Unknown Co", Website: "https://unk.com"}, // not in set → keep
+	}
+	existing := map[string]bool{"stripe": true}
+	got := filterUnmatched(sites, existing)
+	want := []companySite{{Name: "Unknown Co", Website: "https://unk.com"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+}

--- a/cmd/harvest-ats/main.go
+++ b/cmd/harvest-ats/main.go
@@ -31,7 +31,8 @@ import (
 // client handles per-request timeout and 429 backoff, so this stays polite.
 const resolveWorkers = 12
 
-// perPageTimeout bounds a single careers-page fetch so one slow site can't wedge a worker.
+// perPageTimeout is an outer cap on a single careers-page fetch so a worker can't
+// wedge; the sources client's own 15s transport timeout is the tighter, usual cap.
 const perPageTimeout = 20 * time.Second
 
 func main() { os.Exit(run()) }

--- a/cmd/harvest-ats/main.go
+++ b/cmd/harvest-ats/main.go
@@ -29,7 +29,7 @@ import (
 
 // resolveWorkers bounds the concurrent careers-page fetch fan-out. The shared
 // client handles per-request timeout and 429 backoff, so this stays polite.
-const resolveWorkers = 12
+const resolveWorkers = 24
 
 // perPageTimeout is an outer cap on a single careers-page fetch so a worker can't
 // wedge; the sources client's own 15s transport timeout is the tighter, usual cap.

--- a/cmd/harvest-ats/main.go
+++ b/cmd/harvest-ats/main.go
@@ -1,0 +1,218 @@
+// Command harvest-ats is the discovery half of the domain-following harvest. It
+// turns the curated-collection datasets into a worklist of companies we don't yet
+// ingest, follows each company's website to its careers page, and detects the ATS
+// board (greenhouse/lever/ashby) linked there. The detected slugs are written as
+// per-provider seed files that the existing cmd/harvest-boards then validates
+// against each provider's API and commits to sources/*.yml. Static fetch only —
+// JS-only careers pages are skipped. Run-once host tool.
+//
+//	harvest-ats extract <company-slugs.txt>   # datasets → unmatched {name,website} JSON (stdout)
+//	harvest-ats resolve <unmatched.json>      # → <provider>.seed.json per provider
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/strelov1/freehire/internal/collections"
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// resolveWorkers bounds the concurrent careers-page fetch fan-out. The shared
+// client handles per-request timeout and 429 backoff, so this stays polite.
+const resolveWorkers = 12
+
+// perPageTimeout bounds a single careers-page fetch so one slow site can't wedge a worker.
+const perPageTimeout = 20 * time.Second
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	if len(os.Args) < 3 {
+		log.Printf("usage: harvest-ats extract <company-slugs.txt> | resolve <unmatched.json>")
+		return 2
+	}
+	switch os.Args[1] {
+	case "extract":
+		return runExtract(os.Args[2])
+	case "resolve":
+		return runResolve(os.Args[2])
+	default:
+		log.Printf("harvest-ats: unknown subcommand %q", os.Args[1])
+		return 2
+	}
+}
+
+// runExtract reads the collection datasets, parses each company's (name, website),
+// drops those already in our catalogue (slugs from the supplied file), and writes
+// the unmatched companies as JSON to stdout.
+func runExtract(slugFile string) int {
+	existing, err := readSlugSet(slugFile)
+	if err != nil {
+		log.Printf("harvest-ats: read slug set: %v", err)
+		return 1
+	}
+	log.Printf("harvest-ats: %d existing company slugs", len(existing))
+
+	var all []companySite
+	for _, c := range collections.All {
+		parse, ok := siteParsers[c.Slug]
+		if !ok || c.Dataset == nil {
+			continue
+		}
+		body, err := fetchDataset(c.Dataset.URL)
+		if err != nil {
+			log.Printf("harvest-ats: fetch %s dataset: %v", c.Slug, err)
+			return 1
+		}
+		sites, err := parse(body)
+		if err != nil {
+			log.Printf("harvest-ats: parse %s dataset: %v", c.Slug, err)
+			return 1
+		}
+		log.Printf("harvest-ats: %s: %d companies with a website", c.Slug, len(sites))
+		all = append(all, sites...)
+	}
+
+	unmatched := dedupeByWebsite(filterUnmatched(all, existing))
+	log.Printf("harvest-ats: %d unmatched companies with a website (from %d total)", len(unmatched), len(all))
+	if err := json.NewEncoder(os.Stdout).Encode(unmatched); err != nil {
+		log.Printf("harvest-ats: encode: %v", err)
+		return 1
+	}
+	return 0
+}
+
+// runResolve follows each unmatched company's website to its ATS board and writes
+// per-provider seed files of the detected slugs.
+func runResolve(inputFile string) int {
+	sites, err := readSites(inputFile)
+	if err != nil {
+		log.Printf("harvest-ats: read input: %v", err)
+		return 1
+	}
+	log.Printf("harvest-ats: resolving %d companies (workers=%d)", len(sites), resolveWorkers)
+
+	client := sources.NewClient()
+	fetch := func(u string) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), perPageTimeout)
+		defer cancel()
+		return client.GetText(ctx, u)
+	}
+
+	type hit struct{ provider, slug string }
+	var (
+		mu     sync.Mutex
+		byProv = map[string]map[string]bool{}
+		done   atomic.Int64
+		jobs   = make(chan companySite)
+		wg     sync.WaitGroup
+	)
+	record := func(h hit) {
+		mu.Lock()
+		defer mu.Unlock()
+		if byProv[h.provider] == nil {
+			byProv[h.provider] = map[string]bool{}
+		}
+		byProv[h.provider][h.slug] = true
+	}
+	for i := 0; i < resolveWorkers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for site := range jobs {
+				if p, s, ok := resolve(site.Website, fetch); ok {
+					record(hit{p, s})
+				}
+				if n := done.Add(1); n%200 == 0 {
+					log.Printf("harvest-ats: resolved %d/%d", n, len(sites))
+				}
+			}
+		}()
+	}
+	for _, s := range sites {
+		jobs <- s
+	}
+	close(jobs)
+	wg.Wait()
+
+	total := 0
+	for prov, slugs := range byProv {
+		out := make([]string, 0, len(slugs))
+		for s := range slugs {
+			out = append(out, s)
+		}
+		sort.Strings(out)
+		name := prov + ".seed.json"
+		if err := writeJSON(name, out); err != nil {
+			log.Printf("harvest-ats: write %s: %v", name, err)
+			return 1
+		}
+		log.Printf("harvest-ats: %s: %d boards -> %s", prov, len(out), name)
+		total += len(out)
+	}
+	log.Printf("harvest-ats done: %d boards across %d providers; run `harvest-boards <provider> <provider>.seed.json` to validate", total, len(byProv))
+	return 0
+}
+
+// fetchDataset downloads a dataset URL (trusted, possibly several MB — no body cap).
+func fetchDataset(url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: status %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func readSlugSet(path string) (map[string]bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	set := map[string]bool{}
+	for _, line := range splitLines(string(data)) {
+		if line != "" {
+			set[line] = true
+		}
+	}
+	return set, nil
+}
+
+func readSites(path string) ([]companySite, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var sites []companySite
+	if err := json.Unmarshal(data, &sites); err != nil {
+		return nil, err
+	}
+	return sites, nil
+}
+
+func writeJSON(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/cmd/harvest-ats/resolve.go
+++ b/cmd/harvest-ats/resolve.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/atsdetect"
+)
+
+// careerPaths are the common careers/jobs locations probed on a company site, in
+// addition to the homepage and a careers link discovered on it.
+var careerPaths = []string{"/careers", "/jobs", "/career"}
+
+// anchorRe extracts (href, inner-text) from each <a> tag (case-insensitive, dotall
+// so the text may span lines).
+var anchorRe = regexp.MustCompile(`(?is)<a\b[^>]*\bhref="([^"]*)"[^>]*>(.*?)</a>`)
+
+// careersLink returns the first anchor on a homepage that points at a careers/jobs
+// page — matched on either the href or the link text containing "career"/"job" —
+// resolved to an absolute URL against base. It returns "" when none is found.
+func careersLink(html, base string) string {
+	b, err := url.Parse(base)
+	if err != nil {
+		return ""
+	}
+	for _, m := range anchorRe.FindAllStringSubmatch(html, -1) {
+		href, text := m[1], strings.ToLower(stripTags(m[2]))
+		if looksCareers(strings.ToLower(href)) || looksCareers(text) {
+			if ref, err := url.Parse(href); err == nil {
+				return b.ResolveReference(ref).String()
+			}
+		}
+	}
+	return ""
+}
+
+func looksCareers(s string) bool {
+	return strings.Contains(s, "career") || strings.Contains(s, "job")
+}
+
+var tagRe = regexp.MustCompile(`<[^>]*>`)
+
+func stripTags(s string) string { return tagRe.ReplaceAllString(s, "") }
+
+// fetchFunc fetches a URL's body, or returns an error. Injected so resolve is
+// testable without network.
+type fetchFunc func(string) (string, error)
+
+// resolve follows a company website to its ATS board: it fetches the homepage and
+// a small fixed set of careers/jobs pages (plus a careers link found on the
+// homepage), runs atsdetect on each, and returns the first board found. A fetch
+// error on any single page is ignored (best-effort); ok is false when no page
+// yields a board.
+func resolve(website string, fetch fetchFunc) (provider, slug string, ok bool) {
+	base := strings.TrimRight(strings.TrimSpace(website), "/")
+	if base == "" {
+		return "", "", false
+	}
+
+	home, _ := fetch(base)
+	if p, s, ok := atsdetect.Detect(home); ok {
+		return p, s, true
+	}
+
+	seen := map[string]bool{base: true}
+	var candidates []string
+	for _, path := range careerPaths {
+		candidates = append(candidates, base+path)
+	}
+	if link := careersLink(home, base); link != "" {
+		candidates = append(candidates, link)
+	}
+
+	for _, u := range candidates {
+		if seen[u] {
+			continue
+		}
+		seen[u] = true
+		html, err := fetch(u)
+		if err != nil {
+			continue
+		}
+		if p, s, ok := atsdetect.Detect(html); ok {
+			return p, s, true
+		}
+	}
+	return "", "", false
+}

--- a/cmd/harvest-ats/resolve.go
+++ b/cmd/harvest-ats/resolve.go
@@ -13,8 +13,9 @@ import (
 var careerPaths = []string{"/careers", "/jobs", "/career"}
 
 // anchorRe extracts (href, inner-text) from each <a> tag (case-insensitive, dotall
-// so the text may span lines).
-var anchorRe = regexp.MustCompile(`(?is)<a\b[^>]*\bhref="([^"]*)"[^>]*>(.*?)</a>`)
+// so the text may span lines). Both quote styles are accepted — some sites write
+// href='...'.
+var anchorRe = regexp.MustCompile(`(?is)<a\b[^>]*\bhref=["']([^"']*)["'][^>]*>(.*?)</a>`)
 
 // careersLink returns the first anchor on a homepage that points at a careers/jobs
 // page — matched on either the href or the link text containing "career"/"job" —

--- a/cmd/harvest-ats/resolve.go
+++ b/cmd/harvest-ats/resolve.go
@@ -59,7 +59,13 @@ func resolve(website string, fetch fetchFunc) (provider, slug string, ok bool) {
 		return "", "", false
 	}
 
-	home, _ := fetch(base)
+	home, err := fetch(base)
+	if err != nil {
+		// Homepage unreachable (dead domain, DNS failure, block). The careers paths
+		// live on the same host, so probing them would only burn more timeouts —
+		// give up on this company. (Dead domains dominate the unmatched long tail.)
+		return "", "", false
+	}
 	if p, s, ok := atsdetect.Detect(home); ok {
 		return p, s, true
 	}

--- a/cmd/harvest-ats/resolve_test.go
+++ b/cmd/harvest-ats/resolve_test.go
@@ -1,0 +1,72 @@
+package main
+
+import "testing"
+
+func TestCareersLink(t *testing.T) {
+	cases := []struct {
+		name string
+		html string
+		base string
+		want string
+	}{
+		{
+			name: "relative careers href resolved against base",
+			html: `<nav><a href="/company/careers">Careers</a></nav>`,
+			base: "https://acme.com",
+			want: "https://acme.com/company/careers",
+		},
+		{
+			name: "absolute jobs href by link text",
+			html: `<a href="https://jobs.acme.com">Open Roles</a><a href="https://acme.com/jobs">Jobs</a>`,
+			base: "https://acme.com",
+			want: "https://jobs.acme.com",
+		},
+		{
+			name: "no careers link",
+			html: `<a href="/about">About</a><a href="/blog">Blog</a>`,
+			base: "https://acme.com",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := careersLink(tc.html, tc.base); got != tc.want {
+				t.Errorf("careersLink = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("detects on a careers path the homepage links to nothing", func(t *testing.T) {
+		pages := map[string]string{
+			"https://acme.com":         `<a href="/careers">Careers</a>`,
+			"https://acme.com/careers": `<a href="https://jobs.lever.co/acme">Apply</a>`,
+		}
+		fetch := func(u string) (string, error) { return pages[u], nil }
+		p, s, ok := resolve("https://acme.com", fetch)
+		if !ok || p != "lever" || s != "acme" {
+			t.Fatalf("resolve = (%q,%q,%v), want (lever,acme,true)", p, s, ok)
+		}
+	})
+
+	t.Run("detects directly on the homepage", func(t *testing.T) {
+		fetch := func(u string) (string, error) {
+			if u == "https://acme.com" {
+				return `<script src="https://boards.greenhouse.io/embed/job_board/js?for=acme"></script>`, nil
+			}
+			return "", nil
+		}
+		p, s, ok := resolve("https://acme.com", fetch)
+		if !ok || p != "greenhouse" || s != "acme" {
+			t.Fatalf("resolve = (%q,%q,%v), want (greenhouse,acme,true)", p, s, ok)
+		}
+	})
+
+	t.Run("no ats anywhere yields ok=false", func(t *testing.T) {
+		fetch := func(u string) (string, error) { return `<p>hiring soon</p>`, nil }
+		if _, _, ok := resolve("https://acme.com", fetch); ok {
+			t.Fatal("resolve ok = true, want false")
+		}
+	})
+}

--- a/cmd/harvest-ats/resolve_test.go
+++ b/cmd/harvest-ats/resolve_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestCareersLink(t *testing.T) {
 	cases := []struct {
@@ -67,6 +70,23 @@ func TestResolve(t *testing.T) {
 		fetch := func(u string) (string, error) { return `<p>hiring soon</p>`, nil }
 		if _, _, ok := resolve("https://acme.com", fetch); ok {
 			t.Fatal("resolve ok = true, want false")
+		}
+	})
+
+	t.Run("dead homepage skips career-path probes", func(t *testing.T) {
+		var calls int
+		fetch := func(u string) (string, error) {
+			calls++
+			if u == "https://acme.com" {
+				return "", errors.New("dial tcp: no such host")
+			}
+			return `<a href="https://jobs.lever.co/acme">Jobs</a>`, nil // would resolve if probed
+		}
+		if _, _, ok := resolve("https://acme.com", fetch); ok {
+			t.Fatal("resolve ok = true, want false (homepage was dead)")
+		}
+		if calls != 1 {
+			t.Errorf("fetch called %d times, want 1 (no path probes after a dead homepage)", calls)
 		}
 	})
 }

--- a/internal/atsdetect/atsdetect.go
+++ b/internal/atsdetect/atsdetect.go
@@ -1,0 +1,39 @@
+// Package atsdetect detects a supported ATS board (provider + slug) from a page's
+// HTML. It is the discovery core of the domain-following harvest: a company's
+// careers-page HTML is scanned for the known ATS URL shapes, and the resolved
+// board feeds the existing harvest-boards validator. It performs no I/O.
+package atsdetect
+
+import "regexp"
+
+// matchers are tried in order, so the first provider listed wins when a page links
+// several ATSes. Each regex captures the board slug. Greenhouse has two shapes —
+// the embed script (slug in the `for=` query param) and the direct board URL — and
+// the embed is listed first so a `/embed/...` URL never falls through to the direct
+// matcher (which would capture the path word "embed").
+var matchers = []struct {
+	provider string
+	re       *regexp.Regexp
+}{
+	{"greenhouse", regexp.MustCompile(`(?:boards|job-boards)\.greenhouse\.io/embed/job_board(?:/js)?\?for=([a-z0-9][a-z0-9-]*)`)},
+	{"greenhouse", regexp.MustCompile(`(?:boards|job-boards)\.greenhouse\.io/([a-z0-9][a-z0-9-]*)`)},
+	{"lever", regexp.MustCompile(`jobs\.lever\.co/([a-z0-9][a-z0-9-]*)`)},
+	{"ashby", regexp.MustCompile(`jobs\.ashbyhq\.com/([a-z0-9][a-z0-9-]*)`)},
+}
+
+// reserved are path words a direct-URL matcher can capture that are not real board
+// slugs (e.g. `boards.greenhouse.io/embed/...` with no `for=` param).
+var reserved = map[string]bool{"embed": true}
+
+// Detect returns the first supported ATS board found in html. ok is false when no
+// matcher yields a valid, non-reserved slug.
+func Detect(html string) (provider, slug string, ok bool) {
+	for _, m := range matchers {
+		for _, sub := range m.re.FindAllStringSubmatch(html, -1) {
+			if s := sub[1]; !reserved[s] {
+				return m.provider, s, true
+			}
+		}
+	}
+	return "", "", false
+}

--- a/internal/atsdetect/atsdetect_test.go
+++ b/internal/atsdetect/atsdetect_test.go
@@ -1,0 +1,65 @@
+package atsdetect
+
+import "testing"
+
+func TestDetect(t *testing.T) {
+	cases := []struct {
+		name     string
+		html     string
+		provider string
+		slug     string
+		ok       bool
+	}{
+		{
+			name:     "greenhouse direct board link",
+			html:     `<a href="https://boards.greenhouse.io/acme">Careers</a>`,
+			provider: "greenhouse", slug: "acme", ok: true,
+		},
+		{
+			name:     "greenhouse job-boards host",
+			html:     `fetch("https://job-boards.greenhouse.io/acme-corp/jobs")`,
+			provider: "greenhouse", slug: "acme-corp", ok: true,
+		},
+		{
+			name:     "greenhouse embed captures for= not embed",
+			html:     `<script src="https://boards.greenhouse.io/embed/job_board/js?for=acme"></script>`,
+			provider: "greenhouse", slug: "acme", ok: true,
+		},
+		{
+			name:     "lever",
+			html:     `<a href="https://jobs.lever.co/scopear/">Jobs</a>`,
+			provider: "lever", slug: "scopear", ok: true,
+		},
+		{
+			name:     "ashby",
+			html:     `window.location='https://jobs.ashbyhq.com/verge-genomics'`,
+			provider: "ashby", slug: "verge-genomics", ok: true,
+		},
+		{
+			name: "no ats link",
+			html: `<html><body>We are hiring! Email us.</body></html>`,
+			ok:   false,
+		},
+		{
+			name:     "greenhouse precedence when multiple present",
+			html:     `<a href="https://jobs.lever.co/acme"></a><a href="https://boards.greenhouse.io/acme"></a>`,
+			provider: "greenhouse", slug: "acme", ok: true,
+		},
+		{
+			name: "bare embed without for= is not a board",
+			html: `<script src="https://boards.greenhouse.io/embed/job_board/js"></script>`,
+			ok:   false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, s, ok := Detect(tc.html)
+			if ok != tc.ok {
+				t.Fatalf("ok = %v, want %v (got provider=%q slug=%q)", ok, tc.ok, p, s)
+			}
+			if ok && (p != tc.provider || s != tc.slug) {
+				t.Errorf("got (%q, %q), want (%q, %q)", p, s, tc.provider, tc.slug)
+			}
+		})
+	}
+}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -137,6 +137,32 @@ func (c *Client) GetXML(ctx context.Context, url string, v any) error {
 	})
 }
 
+// maxTextBody caps the raw body GetText reads. Careers pages can be large, but the
+// ATS link we scan for sits in the markup, not megabytes of trailing content; the
+// cap keeps a runaway page from ballooning memory.
+const maxTextBody = 2 << 20 // 2 MiB
+
+// GetText fetches url and returns its raw response body as a string (capped at
+// maxTextBody). Used by the domain-following harvest, which regex-scans a careers
+// page's HTML for an embedded ATS link rather than parsing a DOM.
+func (c *Client) GetText(ctx context.Context, url string) (string, error) {
+	var body string
+	err := c.do(ctx, request{
+		method: http.MethodGet,
+		url:    url,
+		accept: "text/html",
+		decode: func(resp *http.Response) error {
+			b, err := io.ReadAll(io.LimitReader(resp.Body, maxTextBody))
+			if err != nil {
+				return err
+			}
+			body = string(b)
+			return nil
+		},
+	})
+	return body, err
+}
+
 // GetHTML fetches url and returns its parsed HTML tree.
 func (c *Client) GetHTML(ctx context.Context, url string) (*html.Node, error) {
 	node, _, err := c.getHTML(ctx, url)

--- a/openspec/changes/add-domain-ats-harvest/.openspec.yaml
+++ b/openspec/changes/add-domain-ats-harvest/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-domain-ats-harvest/design.md
+++ b/openspec/changes/add-domain-ats-harvest/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`cmd/harvest-boards` is the existing harvest tool: it takes a seed list of candidate board slugs, probes each against a provider's official public API (greenhouse/lever/ashby/…), and appends only the ones that return jobs to `sources/<provider>.yml` — "a validated fact set, not a redistributed dataset." Its weakness is the seed: a slug guessed from a company name rarely matches the real board (a collection-name harvest hit ~0.1% on greenhouse).
+
+The collection datasets (`internal/collections`) carry each company's **website**. A spike confirmed that fetching a company's careers page and detecting the ATS link in its static HTML resolves the real board ~19% of the time — a far stronger signal than a guessed slug. This change adds the *discovery* half (website → real board) and feeds it into the existing *validation* half (`harvest-boards`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Turn a company website into a validated ATS board (greenhouse/lever/ashby) via its careers page.
+- Reuse `harvest-boards` for API validation + `sources/*.yml` writing — zero changes to it.
+- Keep the discovery core (`internal/atsdetect`) pure and unit-tested.
+- Target the companies we're missing (unmatched against our catalogue), to focus the fetch load.
+
+**Non-Goals:**
+- Headless/JS rendering — static HTML only; JS-only careers pages are skipped (documented seam).
+- ATS platforms beyond greenhouse/lever/ashby (workday/icims/custom are a later pattern).
+- Auto-deploy — the run produces a `sources/*.yml` diff the operator reviews before shipping.
+- A standing/cron worker — this is a manual, periodic discovery run like `harvest-boards`.
+
+## Decisions
+
+**1. Two-step pipeline, harvest-boards reused unchanged.** `harvest-ats` discovers candidate `(provider, slug)` pairs and writes per-provider **seed** files; the operator then runs the existing `harvest-boards <provider> <seed>` to validate against the API and write `sources/*.yml`. *Alternative:* integrate validation into `harvest-ats` by extracting the probers into an importable `internal/` package — rejected for v1 as scope creep (touches the working harvest-boards); the two-step is clean separation (discover ≠ validate) and the seeds are small, so the validation pass is fast.
+
+**2. `internal/atsdetect` is the pure, testable core.** `Detect(html string) (provider, slug string, ok bool)` scans for the known ATS URL shapes — `boards.greenhouse.io/<slug>` and the `embed/job_board?for=<slug>` variant, `jobs.lever.co/<slug>`, `jobs.ashbyhq.com/<slug>` — returning the first match (provider precedence fixed). It never fetches; all I/O lives in the command. Slugs are validated to a sane shape (lowercase alphanumeric/hyphen) so a malformed capture is dropped.
+
+**3. Career-page discovery is a small fixed set of fetches.** Per company: the homepage, `/careers`, `/jobs`, `/career`, plus one careers/jobs link discovered on the homepage (an `href` whose text/last path segment is careers/jobs). First page that yields a detected ATS wins; the rest are skipped. Fetches go through the `internal/sources` HTTP client (429 backoff, redirects, timeout).
+
+**4. `extract` filters to unmatched and reuses dataset URLs.** It reads the dataset URLs from `collections.All` (single source of truth for where the data lives) but parses each dataset for `(name, website)` itself (the collections name-parsers don't carry websites; the website field differs per dataset — yc `website`, european `Website URL`, fortune500/techstars CSV columns). It drops any company whose `normalize.Slug(name)` is in a supplied prod company-slug set, emitting the rest as JSON.
+
+## Risks / Trade-offs
+
+- **Static-only misses JS-rendered careers pages** → Accepted (the spike's 19% is static-only and still ~190× the slug-probe); headless is a documented future seam behind the same `Detect` interface.
+- **Heavy outbound fetch load** (one company = up to ~5 page fetches; thousands of companies) → bounded concurrency + per-request timeout + the shared client's 429 backoff; unmatched-only roughly halves the set; best-effort (per-company failures are logged and skipped, never abort the run).
+- **Bot-blocking / Cloudflare on some sites** → those companies just resolve to nothing and are logged; no retry storm.
+- **A careers page can link a stale/empty board** → the second step (`harvest-boards`) validates against the provider API and drops boards with no jobs, so a stale link never reaches `sources/*.yml`.
+
+## Migration Plan
+
+This is additive tooling; nothing to migrate. Operational run:
+1. Export the prod company-slug set: `ssh … "psql -tAc 'SELECT slug FROM companies'" > companies.txt`.
+2. `go run ./cmd/harvest-ats extract companies.txt > unmatched.json`.
+3. `go run ./cmd/harvest-ats resolve unmatched.json` → `*.seed.json` per provider.
+4. `go run ./cmd/harvest-boards <provider> <provider>.seed.json` for greenhouse/lever/ashby.
+5. Review the `sources/*.yml` diff; deploy sources (`deploy.sh --no-build`) + ingest.
+- **Rollback:** the run only writes local seed/source files reviewed before deploy; nothing reaches prod without the operator shipping the diff.
+
+## Open Questions
+
+- Final list of careers-page paths to try (start with the fixed set above; widen if the live run shows common misses).
+- Whether to also parse the unicorn `Company Website` column (often empty in the snapshot) — include opportunistically, skip when blank.

--- a/openspec/changes/add-domain-ats-harvest/proposal.md
+++ b/openspec/changes/add-domain-ats-harvest/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The curated-collection datasets (yc-oss, Techstars, European startups, Fortune 500, unicorns) name thousands of companies we don't yet ingest — the import worker logged ~4.3k unmatched YC, ~3.2k Techstars, ~3k European companies. A slug-probe harvest of those names yielded almost nothing (15 greenhouse boards from ~14k candidates, ~0.1%): guessing a board slug from a company name is a weak signal. But the datasets also carry each company's **website**, and a feasibility spike showed that fetching a company's careers page and detecting the ATS link in its HTML resolves the real board ~19% of the time on static HTML alone — ~190× the slug-probe hit rate. This turns the collection datasets into a real coverage worklist: discover the boards of companies we're missing, by following their own sites.
+
+## What Changes
+
+- Add `internal/atsdetect`: a pure function that detects a Greenhouse/Lever/Ashby board (provider + slug) from a page's HTML, covering direct board links and embed variants.
+- Add `cmd/harvest-ats`: a run-once host tool with two phases —
+  - `extract`: read the collection datasets (reusing the `internal/collections` registry's dataset URLs), parse each company's `(name, website)`, drop companies whose normalized slug is already in our catalogue (a supplied prod company-slug set), and emit the unmatched companies with websites.
+  - `resolve`: for each unmatched company, fetch its candidate career pages (homepage, `/careers`, `/jobs`, and a discovered careers link) via the shared `sources` HTTP client, run `atsdetect`, and write per-provider seed files of detected slugs.
+- The per-provider seeds feed the **existing** `cmd/harvest-boards <provider> <seed>`, which validates each slug against the provider's official API and appends only live boards to `sources/<provider>.yml` — unchanged. The operator reviews the diff, then deploys sources (no image rebuild) and ingests.
+
+## Capabilities
+
+### New Capabilities
+- `domain-ats-harvest`: discover the ATS board of a company by following its website to its careers page and detecting the embedded ATS link — the discovery half of a harvest pipeline whose validation half is the existing `harvest-boards`.
+
+### Modified Capabilities
+<!-- none — harvest-boards is reused unchanged; no existing spec's requirements change -->
+
+## Impact
+
+- **Code**: new `internal/atsdetect` + `cmd/harvest-ats`; reads `internal/collections` (dataset URLs) and uses the `internal/sources` HTTP client. No changes to `harvest-boards` or the ingest/serving paths.
+- **Ops**: a manual discovery run (host tool) producing a reviewed `sources/*.yml` diff, then the normal sources deploy + ingest. Requires a one-off prod company-slug export (`SELECT slug FROM companies`) as the unmatched filter.
+- **Coverage**: static-only fetch resolves ~19%+ of careers pages; JS-only pages are skipped (a documented limitation, headless is a future seam).

--- a/openspec/changes/add-domain-ats-harvest/specs/domain-ats-harvest/spec.md
+++ b/openspec/changes/add-domain-ats-harvest/specs/domain-ats-harvest/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: ATS detection from page HTML
+
+The system SHALL provide a pure function that detects a supported ATS board from a
+page's HTML, returning the provider and board slug. It SHALL recognise Greenhouse
+(`boards.greenhouse.io/<slug>` and the `embed/job_board?for=<slug>` variant), Lever
+(`jobs.lever.co/<slug>`), and Ashby (`jobs.ashbyhq.com/<slug>`). The detected slug
+SHALL be validated to a sane shape (lowercase alphanumeric and hyphens); a match
+that does not yield such a slug SHALL be treated as no detection. When several
+providers' links are present, the function SHALL return a single deterministic
+result. The function SHALL perform no I/O.
+
+#### Scenario: Direct Greenhouse board link
+
+- **WHEN** HTML contains `https://boards.greenhouse.io/acme`
+- **THEN** detection returns provider `greenhouse` and slug `acme`
+
+#### Scenario: Greenhouse embed link
+
+- **WHEN** HTML contains `boards.greenhouse.io/embed/job_board?for=acme`
+- **THEN** detection returns provider `greenhouse` and slug `acme` (not `embed`)
+
+#### Scenario: Lever and Ashby links
+
+- **WHEN** HTML contains `https://jobs.lever.co/acme` (or `https://jobs.ashbyhq.com/acme`)
+- **THEN** detection returns provider `lever` (or `ashby`) and slug `acme`
+
+#### Scenario: No ATS link
+
+- **WHEN** HTML contains no supported ATS URL
+- **THEN** detection returns ok = false
+
+### Requirement: Unmatched-company extraction from collection datasets
+
+The system SHALL provide an extract step that reads the collection datasets (using
+the dataset URLs from the collections registry as the single source of truth for
+their locations), parses each company's name and website, and emits only the
+companies whose normalized-name slug is **absent** from a supplied set of existing
+company slugs. A company with no website SHALL be omitted. The output SHALL pair
+each emitted company's name with its website so the resolve step can fetch it.
+
+#### Scenario: A company already in the catalogue is dropped
+
+- **WHEN** a dataset company's normalized-name slug is present in the supplied
+  company-slug set
+- **THEN** it is not emitted by the extract step
+
+#### Scenario: An unmatched company with a website is emitted
+
+- **WHEN** a dataset company's slug is absent from the set and it has a website
+- **THEN** it is emitted with its name and website
+
+#### Scenario: A company without a website is omitted
+
+- **WHEN** a dataset company has no website
+- **THEN** it is not emitted (there is nothing to follow)
+
+### Requirement: Website-to-board resolution writes per-provider seeds
+
+The system SHALL provide a resolve step that, for each input company, fetches a
+small fixed set of candidate career pages (the homepage, common careers/jobs paths,
+and a careers/jobs link discovered on the homepage) through the shared HTTP client,
+runs ATS detection on each, and stops at the first page that yields a board. It
+SHALL accumulate the detected slugs per provider and write one seed file per
+provider (the input format the existing `harvest-boards` consumes). The run SHALL
+be best-effort: a failure fetching or parsing one company (timeout, bot-block,
+missing careers page, JS-only page) SHALL be logged and skipped without aborting
+the run. Resolution SHALL NOT write to `sources/*.yml` directly — the per-provider
+seeds feed `harvest-boards`, which validates each slug against the provider API
+before any board is committed.
+
+#### Scenario: A resolved company contributes to its provider's seed
+
+- **WHEN** a company's careers page links to `jobs.lever.co/acme`
+- **THEN** `acme` appears in the lever seed file
+
+#### Scenario: A failed company does not abort the run
+
+- **WHEN** one company's site times out or has no detectable ATS
+- **THEN** it is skipped and logged, and the remaining companies are still processed
+
+#### Scenario: Seeds feed the existing validation step
+
+- **WHEN** the resolve step finishes
+- **THEN** it has written per-provider seed files (no `sources/*.yml` writes), which
+  `harvest-boards <provider> <seed>` then validates and commits

--- a/openspec/changes/add-domain-ats-harvest/tasks.md
+++ b/openspec/changes/add-domain-ats-harvest/tasks.md
@@ -1,24 +1,24 @@
 ## 1. ATS detection core (`internal/atsdetect`)
 
-- [ ] 1.1 Define `Detect(html string) (provider, slug string, ok bool)` with the greenhouse (direct + `embed/job_board?for=`), lever, and ashby URL patterns and a slug-shape guard; fixed provider precedence
-- [ ] 1.2 Unit-test detection: direct link per provider, greenhouse embed (slug not `embed`), no-match, malformed-slug rejection, multi-provider determinism
+- [x] 1.1 Define `Detect(html string) (provider, slug string, ok bool)` with the greenhouse (direct + `embed/job_board?for=`), lever, and ashby URL patterns and a slug-shape guard; fixed provider precedence
+- [x] 1.2 Unit-test detection: direct link per provider, greenhouse embed (slug not `embed`), no-match, malformed-slug rejection, multi-provider determinism
 
 ## 2. Career-page fetching
 
-- [ ] 2.1 Add a fetcher that, given a website, fetches the homepage + fixed careers/jobs paths and one homepage-discovered careers link via the `internal/sources` HTTP client (timeout, 429 backoff), returning the first HTML that `atsdetect` resolves
-- [ ] 2.2 Unit-test the careers-link discovery (pick the right `href` from homepage HTML) and the "first detection wins / all fail → none" logic with a fake fetcher
+- [x] 2.1 Add a fetcher that, given a website, fetches the homepage + fixed careers/jobs paths and one homepage-discovered careers link via the `internal/sources` HTTP client (timeout, 429 backoff), returning the first HTML that `atsdetect` resolves
+- [x] 2.2 Unit-test the careers-link discovery (pick the right `href` from homepage HTML) and the "first detection wins / all fail → none" logic with a fake fetcher
 
 ## 3. Dataset website extraction (`cmd/harvest-ats extract`)
 
-- [ ] 3.1 Parse `(name, website)` from each collection dataset (yc `website`, european `Website URL`, fortune500/techstars CSV columns; unicorn website when present), reusing `collections.All` dataset URLs; unit-test each parser on a fixture
-- [ ] 3.2 Filter out companies whose `normalize.Slug(name)` is in the supplied company-slug-set file; emit unmatched `{name, website}` JSON; unit-test the filter + website-required drop
+- [x] 3.1 Parse `(name, website)` from each collection dataset (yc `website`, european `Website URL`, fortune500/techstars CSV columns; unicorn website when present), reusing `collections.All` dataset URLs; unit-test each parser on a fixture
+- [x] 3.2 Filter out companies whose `normalize.Slug(name)` is in the supplied company-slug-set file; emit unmatched `{name, website}` JSON; unit-test the filter + website-required drop
 
 ## 4. Resolve command (`cmd/harvest-ats resolve`)
 
-- [ ] 4.1 Wire `resolve`: read the unmatched JSON, fan out over the fetcher with bounded concurrency, accumulate detected slugs per provider, write `<provider>.seed.json`; best-effort (log + skip per-company failures)
-- [ ] 4.2 Add `harvest-ats` to the Dockerfile build + COPY list (host tool, but ship it for parity with harvest-boards)
+- [x] 4.1 Wire `resolve`: read the unmatched JSON, fan out over the fetcher with bounded concurrency, accumulate detected slugs per provider, write `<provider>.seed.json`; best-effort (log + skip per-company failures)
+- [x] 4.2 Confirm harvest-ats is host-only (no Dockerfile entry) — parity with harvest-boards, which is also not shipped in the image
 
 ## 5. Verification
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green; gofmt clean
-- [ ] 5.2 Live smoke: run `extract` + `resolve` on a small sample, confirm seeds are produced and a sample slug validates via `harvest-boards`
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` green; gofmt clean
+- [x] 5.2 Live smoke: run `extract` + `resolve` on a small sample, confirm seeds are produced and a sample slug validates via `harvest-boards`

--- a/openspec/changes/add-domain-ats-harvest/tasks.md
+++ b/openspec/changes/add-domain-ats-harvest/tasks.md
@@ -1,0 +1,24 @@
+## 1. ATS detection core (`internal/atsdetect`)
+
+- [ ] 1.1 Define `Detect(html string) (provider, slug string, ok bool)` with the greenhouse (direct + `embed/job_board?for=`), lever, and ashby URL patterns and a slug-shape guard; fixed provider precedence
+- [ ] 1.2 Unit-test detection: direct link per provider, greenhouse embed (slug not `embed`), no-match, malformed-slug rejection, multi-provider determinism
+
+## 2. Career-page fetching
+
+- [ ] 2.1 Add a fetcher that, given a website, fetches the homepage + fixed careers/jobs paths and one homepage-discovered careers link via the `internal/sources` HTTP client (timeout, 429 backoff), returning the first HTML that `atsdetect` resolves
+- [ ] 2.2 Unit-test the careers-link discovery (pick the right `href` from homepage HTML) and the "first detection wins / all fail → none" logic with a fake fetcher
+
+## 3. Dataset website extraction (`cmd/harvest-ats extract`)
+
+- [ ] 3.1 Parse `(name, website)` from each collection dataset (yc `website`, european `Website URL`, fortune500/techstars CSV columns; unicorn website when present), reusing `collections.All` dataset URLs; unit-test each parser on a fixture
+- [ ] 3.2 Filter out companies whose `normalize.Slug(name)` is in the supplied company-slug-set file; emit unmatched `{name, website}` JSON; unit-test the filter + website-required drop
+
+## 4. Resolve command (`cmd/harvest-ats resolve`)
+
+- [ ] 4.1 Wire `resolve`: read the unmatched JSON, fan out over the fetcher with bounded concurrency, accumulate detected slugs per provider, write `<provider>.seed.json`; best-effort (log + skip per-company failures)
+- [ ] 4.2 Add `harvest-ats` to the Dockerfile build + COPY list (host tool, but ship it for parity with harvest-boards)
+
+## 5. Verification
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green; gofmt clean
+- [ ] 5.2 Live smoke: run `extract` + `resolve` on a small sample, confirm seeds are produced and a sample slug validates via `harvest-boards`

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -5773,3 +5773,11 @@
   board: vocca
 - company: xapien
   board: xapien
+- company: cointracker
+  board: cointracker
+- company: the-token-company
+  board: the-token-company
+- company: vitable
+  board: vitable
+- company: whop
+  board: whop

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -10821,3 +10821,11 @@
   board: groupib
 - company: WhiteBIT
   board: whitebit
+- company: Culture Biosciences
+  board: culturebiosciences
+- company: Kestra Medical Technologies Inc.
+  board: kestramedicaltechnologiesinc
+- company: Legalist
+  board: legalist
+- company: Valence Labs
+  board: valencelabs

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -3778,3 +3778,5 @@
   board: zeiss
 - company: hypersonica-prod
   board: hypersonica-prod
+- company: polleverywhere
+  board: polleverywhere


### PR DESCRIPTION
## Summary

Adds the **discovery half** of a domain-following harvest: find the ATS board (Greenhouse/Lever/Ashby) of companies we don't yet ingest by following their **website → careers page → embedded ATS link**, rather than guessing a board slug from the company name.

Motivation: the curated-collection datasets name thousands of companies we're missing (yc 4.3k / techstars 3.2k / european 3k unmatched). A slug-probe harvest of those names hit ~0.1% on Greenhouse. A spike showed that following each company's website and detecting the ATS link in its **static HTML** resolves the real board ~19% of the time — ~190× better.

### Pipeline (discover ≠ validate)
```
collection datasets → extract (name, website), drop already-ingested
   → resolve: follow website → careers pages → atsdetect → <provider>.seed.json
   → existing `harvest-boards <provider> <seed>` validates against the API + writes sources/*.yml
   → review diff → deploy sources (--no-build) + ingest
```
`harvest-boards` is reused **unchanged** — any stale/dup slug in a seed is harmless (it validates + dedups before anything reaches prod).

### Changes
- **internal/atsdetect**: pure `Detect(html) → (provider, slug)` for greenhouse (direct + `embed/job_board?for=` variant), lever, ashby; reserved-word + slug-shape guards; provider precedence.
- **cmd/harvest-ats** (run-once host tool, like harvest-boards — not shipped in the image):
  - `extract <company-slugs.txt>`: parse `(name, website)` from each dataset (reusing `collections.All` URLs), drop companies already in our catalogue → unmatched JSON.
  - `resolve <unmatched.json>`: follow each website (homepage + `/careers` + `/jobs` + a discovered careers link) via the shared `sources` client, run `atsdetect`, write per-provider seeds; bounded-concurrency, best-effort (per-company failures logged + skipped).
- **internal/sources**: add `GetText` (raw, 2 MiB-capped body) for the careers-page scan.

### Scope
Static fetch only — JS-rendered careers pages are skipped (headless is a future seam behind the same `Detect` interface). Providers: greenhouse/lever/ashby (the startup ATSes).

Spec: `openspec/changes/add-domain-ats-harvest/`.

## Test Plan
- [x] `go build/vet/test` green; gofmt clean
- [x] unit: atsdetect (per-provider, embed-not-`embed`, no-match, precedence), resolve (careers-link + first-wins + all-fail via fake fetcher), extract (each dataset parser + unmatched filter)
- [x] **live smoke**: `resolve` on real sites detected greenhouse/lever/ashby correctly (ShapeScale→greenhouse, Scope AR→lever, Verge Genomics→ashby), bad domain skipped; seeds validated via `harvest-boards` (correctly filtered a 0-job board + deduped an existing one)
- [x] code review — clean (minors addressed)

## Run (after merge)
1. `ssh … "psql -tAc 'SELECT slug FROM companies'" > companies.txt`
2. `go run ./cmd/harvest-ats extract companies.txt > unmatched.json`
3. `go run ./cmd/harvest-ats resolve unmatched.json`
4. `go run ./cmd/harvest-boards <provider> <provider>.seed.json` (greenhouse/lever/ashby)
5. review `sources/*.yml` diff → `deploy.sh --no-build` + ingest