### PR TITLE
feat(sources): add 9 Russian-roots company boards from idagent.pro list

### DIFF
--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -16,6 +16,8 @@
   board: go-cadre
 - company: Charta Health
   board: chartahealth
+- company: CodeSignal
+  board: codesignal
 - company: Converge
   board: converge
 - company: Fireflies

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -10813,3 +10813,11 @@
   board: yondrgroup
 - company: Bolt
   board: boltv2
+- company: EXANTE
+  board: xntltd
+- company: Wargaming
+  board: wargamingen
+- company: Group-IB
+  board: groupib
+- company: WhiteBIT
+  board: whitebit

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -350,3 +350,5 @@
   board: fa-evfm-saasfaprod1.fa.ocs.oraclecloud.com/CX_1029
 - company: Zensar
   board: fa-etvl-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
+- company: Ciklum
+  board: ialmme.fa.ocs.oraclecloud.com/CX_1001

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -17,3 +17,5 @@
   board: seeq
 - company: Confluence
   board: confluence
+- company: inDrive
+  board: indrive

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -231,3 +231,5 @@
   board: "tylko"
 - company: "Eevee mobility"
   board: "wisemen"
+- company: MacPaw
+  board: macpaw

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -146,3 +146,5 @@
   board: "yego.teamtailor.com"
 - company: eeze
   board: careers.eeze.com
+- company: Replika
+  board: careers.replika.com


### PR DESCRIPTION
## What

Adds **9 company boards** resolved from [idagent.pro/companies](https://www.idagent.pro/companies) — the "42 компании с русскоязычными корнями" (companies with Russian-speaking roots) list. The site links careers landing pages, not ATS boards, so each was resolved to its underlying supported-provider board and **live-validated**:

| Company | Provider | board | Live jobs |
|---|---|---|---|
| inDrive | pinpoint | `indrive` | 225 |
| Ciklum | oracle | `ialmme.fa.ocs.oraclecloud.com/CX_1001` | 163 |
| EXANTE | greenhouse | `xntltd` | 31 |
| Group-IB | greenhouse | `groupib` | 25 |
| MacPaw | recruitee | `macpaw` | 15 |
| CodeSignal | gem | `codesignal` | 11 |
| Replika | teamtailor | `careers.replika.com` | 4 |
| WhiteBIT | greenhouse | `whitebit` | 4 |
| Wargaming | greenhouse | `wargamingen` | 0 (valid board, empty right now) |

## Notes

- **Group-IB** and **WhiteBIT** front their careers with HiBob/HURMA respectively, but run a **parallel live Greenhouse behind the vanity domain** (`absolute_url` carries `?gh_jid=`/`?gh_src=`). A first careers-page pass mislabeled them "unsupported"; a search-first pass caught the hidden Greenhouse.
- All entries are on **existing providers** — no adapter changes. Deploys via sources-rsync (`--no-build`); existing per-provider crons cover them.
- Loader validation (`Config.Validate` against the provider registry) passes for all six touched files.

## Out of scope (custom/unsupported ATS — searched, no supported board)

Revolut (in-house portal + Cloudflare), EPAM (in-house HRMS), Kaspersky (in-house Next.js), Parallels (ADP Workforce Now), Plesk (UKG Pro Recruiting), DataArt (custom Webflow), Luxoft (custom site), iTechArt→Vention (custom Next.js), Bitfury (careers removed), Telegram (static page). **Grammarly** consolidated onto Superhuman's Ashby board (empty mid-migration) — deferred.
