### PR TITLE
feat(web): add Company filter to the jobs sidebar

### DIFF
--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -62,9 +62,20 @@ export function countryLabel(code: string): string {
   }
 }
 
-/** Display label for a dynamic facet value: country code → name, else the value. */
+// Company facet values are slugs (group-ib, epam); the live distribution carries
+// no display name, so humanize the slug for a readable label. Imperfect for
+// acronyms (group-ib → "Group Ib") but consistent with the other facets — a real
+// slug→name lookup would need a per-company fetch, which this facet forgoes.
+export function companyLabel(slug: string): string {
+  return humanize(slug.replace(/-/g, '_'));
+}
+
+/** Display label for a dynamic facet value: country code → name, company slug →
+ *  humanized name, else the value. */
 export function dynamicLabel(param: string, value: string): string {
-  return param === 'countries' ? countryLabel(value) : value;
+  if (param === 'countries') return countryLabel(value);
+  if (param === 'company_slug') return companyLabel(value);
+  return value;
 }
 
 /** Drop options with a duplicate `value`, keeping the first. The facet controls
@@ -172,5 +183,6 @@ export const FACETS: FacetDef[] = [
   { param: 'english_level', label: 'English', control: 'pills', options: ENGLISH, excludable: true },
   { param: 'posting_language', label: 'Job language', control: 'pills', options: POSTING_LANGUAGE, excludable: true },
   { param: 'salary_currency', label: 'Currency', control: 'pills', options: CURRENCY, excludable: true },
+  { param: 'company_slug', label: 'Company', control: 'select', dynamic: true, excludable: true, placeholder: 'Search companies' },
   { param: 'source', label: 'Source', control: 'pills', options: SOURCE, excludable: true },
 ];


### PR DESCRIPTION
## What

Adds a **Company** filter to the `/jobs` sidebar, near the bottom (above Source).

Company is surfaced as a *dynamic, distribution-driven* facet — the same UX as the existing `skills`/`countries` selects: a search box over a live, count-annotated list, with multi-select (OR), Exclude, and URL round-trip.

## Why it's a one-file change

`company_slug` was **already** a first-class search facet on the backend:

- `internal/search/query_filter.go` — `company_slug` is in `StringFacets`, so `?company_slug=…` filtering and facet-counting are already wired.
- `internal/handler/facets.go` — `facetAttributes()` derives requested facets from `StringFacets`, so company counts were already returned under the public `company_slug` key.
- `internal/search/client.go` — `company_slug` is already a Meili `FilterableAttribute`.

The frontend filter system is registry-driven (`filtersToParams`/`filtersFromParams` iterate `FACETS`), so the whole feature is **one `FACETS` entry** plus a `companyLabel` helper that humanizes the slug for display (the live facet distribution carries slugs, not names).

## Accepted limitations (chosen over a server-side typeahead)

- Only the **top companies by job count** appear — Meili `maxValuesPerFacet=300`.
- Labels are **humanized slugs** (`group-ib` → `Group Ib`), imperfect for acronyms.

The upgrade path, if company-by-name becomes a real need, is a server-side typeahead against the existing `GET /api/v1/companies?q=` endpoint. Deferred intentionally.

## Verification

- `svelte-check`: 0 errors, 0 warnings.
- `web/` has no test runner (no vitest); svelte-check is the standard frontend gate here.
- Code-reviewed: backend claims (filter + counts + filterable attribute + indexed `company_slug` field) verified end-to-end — the facet both appears *and* filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)