### PR TITLE
feat(sources): add Luxoft careers adapter

### DIFF
--- a/internal/sources/luxoft.go
+++ b/internal/sources/luxoft.go
@@ -1,0 +1,185 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// luxoft adapts Luxoft's careers site (career.luxoft.com): a server-rendered site whose
+// /jobs listing enumerates postings as /jobs/<slug>-<id> links and whose job pages carry a
+// schema.org JobPosting ld+json block. The board is the career-site host; the description
+// comes from a per-job detail fetch (bounded-concurrency), like the other ld+json detail
+// adapters (globalpayments, teamtailor). Its /ajax/filter-jobs endpoint is unusable (it
+// caps at 100 and ignores paging), so the paginated HTML listing is the enumeration path.
+type luxoft struct {
+	http HTMLGetter
+}
+
+// NewLuxoft builds the Luxoft adapter over the given HTTP client.
+func NewLuxoft(c HTMLGetter) Source { return luxoft{http: c} }
+
+func (luxoft) Provider() string { return "luxoft" }
+
+// lxMaxPages bounds listing pagination so a board that clamps ?page=N to its last page
+// (serving the same links forever) cannot loop; the no-new-links check ends it sooner.
+const lxMaxPages = 100
+
+// lxPerPage requests the largest page size Luxoft's listing offers, to keep the number of
+// listing fetches low (~1400 jobs / 60 ≈ 24 pages).
+const lxPerPage = 60
+
+func (l luxoft) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	// base carries scheme+host; the listing's relative /jobs hrefs resolve against it
+	// (an absolute href resolves to itself), so it is parsed once rather than per page.
+	base, err := url.Parse(fmt.Sprintf("https://%s/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("luxoft: board %q: %w", e.Board, err)
+	}
+
+	var urls []string
+	seen := make(map[string]bool)
+	for page := 1; page <= lxMaxPages; page++ {
+		// page=1 is the default; Luxoft 301-redirects /jobs?page=1 to a broken relative
+		// Location that resolves to a 404, so omit the page param on the first page and add
+		// it only from page 2 on.
+		listURL := fmt.Sprintf("https://%s/jobs?perPage=%d", e.Board, lxPerPage)
+		if page > 1 {
+			listURL += fmt.Sprintf("&page=%d", page)
+		}
+		root, err := l.http.GetHTML(ctx, listURL)
+		if err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("luxoft: listing %s: %w", e.Board, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		// Stop on the first page that adds no new links: an empty page, or a board that
+		// clamps ?page=N past its last page (de-dup turns the repeat into zero new).
+		newLinks := 0
+		for _, link := range lxJobLinks(base, root) {
+			if !seen[link] {
+				seen[link] = true
+				urls = append(urls, link)
+				newLinks++
+			}
+		}
+		if newLinks == 0 {
+			break
+		}
+	}
+
+	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return l.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the URL has no parseable id, the fetch fails, or the page carries no JobPosting, so
+// the caller skips just that posting.
+func (l luxoft) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := lxJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := l.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p lxPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	location := p.location()
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		// Luxoft emits no jobLocationType, so the location text is the only remote signal.
+		Remote: isRemote(location),
+		// Luxoft stamps some postings with a future datePosted; parseLayout drops a future
+		// time to nil (NotFuture), so the pipeline falls back to ingest time.
+		PostedAt: parseLayout("2006-01-02 15:04:05", p.DatePosted),
+	}, true
+}
+
+// lxJobLinks returns the absolute hrefs of all anchors linking a /jobs/<slug>-<id> job page,
+// resolved against base (the listing URL) so relative hrefs still yield fetchable URLs,
+// de-duplicated in first-seen order (a card links the same job more than once). A link is a
+// job exactly when it carries a parseable native id (the trailing numeric slug segment).
+func lxJobLinks(base *url.URL, root *html.Node) []string {
+	var out []string
+	seen := make(map[string]bool)
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := attr(n, "href")
+			if lxJobID(href) == "" {
+				return true
+			}
+			ref, err := url.Parse(href)
+			if err != nil {
+				return true // unparseable href → not a usable job link
+			}
+			abs := base.ResolveReference(ref).String()
+			if !seen[abs] {
+				seen[abs] = true
+				out = append(out, abs)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// lxJobIDPattern captures the posting id from a job URL's /jobs/<slug>-<id> path. The slug
+// segment and a trailing -<digits> are both required, so the bare /jobs listing and its
+// ?page=N / ?perPage=N controls (which share the /jobs path) are not mistaken for jobs.
+var lxJobIDPattern = regexp.MustCompile(`/jobs/[^/?#]*-(\d+)(?:[/?#]|$)`)
+
+// lxJobID extracts the native posting id (the trailing numeric slug segment, e.g. "25262")
+// from a job page URL.
+func lxJobID(u string) string {
+	if m := lxJobIDPattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// lxPosting is the schema.org JobPosting decoded from a Luxoft job page's ld+json block.
+// Unlike Global Payments, its jobLocation is a single Place object whose address is a single
+// PostalAddress object (not arrays).
+type lxPosting struct {
+	Title       string  `json:"title"`
+	Description string  `json:"description"`
+	DatePosted  string  `json:"datePosted"`
+	JobLocation lxPlace `json:"jobLocation"`
+}
+
+type lxPlace struct {
+	Name    string    `json:"name"`
+	Address lxAddress `json:"address"`
+}
+
+type lxAddress struct {
+	AddressLocality string `json:"addressLocality"`
+	AddressRegion   string `json:"addressRegion"`
+	AddressCountry  string `json:"addressCountry"`
+}
+
+// location builds the display location from the address (city, region, country), falling
+// back to the Place's pre-formatted name when the structured parts are empty.
+func (p lxPosting) location() string {
+	a := p.JobLocation.Address
+	if loc := joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry); loc != "" {
+		return loc
+	}
+	return p.JobLocation.Name
+}

--- a/internal/sources/luxoft_test.go
+++ b/internal/sources/luxoft_test.go
@@ -1,0 +1,252 @@
+package sources
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// lxListingHTML builds a Luxoft listing page linking each given job URL, plus the
+// pagination/page-size controls that must be ignored (they share the /jobs path).
+func lxListingHTML(jobURLs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jobs__list">`)
+	for _, u := range jobURLs {
+		b.WriteString(`<a href="` + u + `" class="jobs__list__job"><h2>A job</h2></a>`)
+	}
+	b.WriteString(`<a href="/jobs?page=2">Next</a>`)
+	b.WriteString(`<a href="/jobs?perPage=15">15</a>`)
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// lxDetailHTML builds a Luxoft job page carrying a JobPosting ld+json block whose
+// jobLocation is a single Place object (address a single PostalAddress object) and whose
+// datePosted is the space-separated, zoneless timestamp Luxoft emits.
+func lxDetailHTML(title, description, datePosted, locality, region, country string) string {
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + description + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"identifier":{"@type":"PropertyValue","name":"Luxoft","value":"VR-123564"},` +
+		`"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",` +
+		`"addressLocality":"` + locality + `","addressRegion":"` + region + `","addressCountry":"` + country + `"}}}` +
+		`</script></head><body></body></html>`
+}
+
+func TestLuxoftJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://career.luxoft.com/jobs/front-end-react-developer-25262": "25262",
+		"/jobs/senior-axiom-developer-25277":                             "25277",
+		"/jobs/react-18-developer-25001":                                 "25001", // a digit mid-slug; the trailing id wins
+		"https://career.luxoft.com/jobs":                                 "",      // listing root
+		"https://career.luxoft.com/jobs?page=2":                          "",      // pagination
+		"/jobs?perPage=15":                                               "",      // page-size control
+		"/jobs/no-trailing-id":                                           "",      // not a posting
+		"/about":                                                         "",
+	}
+	for u, want := range cases {
+		if got := lxJobID(u); got != want {
+			t.Errorf("lxJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestLuxoftJobLinksResolvesRelativeAndFiltersNonJobs(t *testing.T) {
+	h := `<html><body>
+		<a href="/jobs/front-end-react-developer-25262">Engineer</a>
+		<a href="/jobs/front-end-react-developer-25262">Apply</a>
+		<a href="https://career.luxoft.com/jobs/senior-axiom-developer-25277">Axiom</a>
+		<a href="/jobs?page=2">Next</a>
+		<a href="/about">About</a>
+	</body></html>`
+	base := mustURL(t, "https://career.luxoft.com/jobs?page=1")
+	got := lxJobLinks(base, parseHTML(t, h))
+	want := []string{
+		"https://career.luxoft.com/jobs/front-end-react-developer-25262",
+		"https://career.luxoft.com/jobs/senior-axiom-developer-25277",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("lxJobLinks() = %v, want %v", got, want)
+	}
+}
+
+func TestLuxoftPostingLocation(t *testing.T) {
+	// Structured city/region/country wins.
+	p := lxPosting{JobLocation: lxPlace{
+		Name:    "PUNE, INDIA",
+		Address: lxAddress{AddressLocality: "Pune", AddressRegion: "Maharashtra", AddressCountry: "IN"},
+	}}
+	if got, want := p.location(), "Pune, Maharashtra, IN"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	// Falls back to the Place name when the structured parts are empty.
+	p = lxPosting{JobLocation: lxPlace{Name: "Remote"}}
+	if got, want := p.location(), "Remote"; got != want {
+		t.Errorf("location() fallback = %q, want %q", got, want)
+	}
+	// No location at all.
+	if got := (lxPosting{}).location(); got != "" {
+		t.Errorf("location() = %q, want empty", got)
+	}
+}
+
+func TestLuxoftFetchListingThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://career.luxoft.com/jobs/front-end-react-developer-25262"
+	detail := lxDetailHTML(
+		"Front-end React Developer",
+		// Entity-encoded in the ld+json (so a literal </script> can't truncate the block),
+		// matching the html.UnescapeString the adapter applies before sanitizing.
+		"&lt;p&gt;Build &lt;b&gt;it&lt;/b&gt;.&lt;/p&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+		"2026-06-14 19:00:00", "Pune", "", "IN")
+	fake := (&routedHTTP{}).
+		route("&page=2", lxListingHTML()).
+		route("perPage=60", lxListingHTML(jobURL)).
+		route("/jobs/front-end-react-developer-25262", detail)
+
+	jobs, err := NewLuxoft(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Luxoft", Provider: "luxoft", Board: "career.luxoft.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "25262" {
+		t.Errorf("ExternalID = %q, want 25262", j.ExternalID)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Title != "Front-end React Developer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Luxoft" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Pune, IN" {
+		t.Errorf("Location = %q, want %q", j.Location, "Pune, IN")
+	}
+	if strings.Contains(j.Description, "<script>") ||
+		!strings.Contains(j.Description, "<p>") || !strings.Contains(j.Description, "<b>it</b>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 14, 19, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-14 19:00:00 UTC", j.PostedAt)
+	}
+}
+
+func TestLuxoftFutureDatePostedDropped(t *testing.T) {
+	// Luxoft stamps some postings with a future datePosted; the parser must drop it to nil
+	// (the pipeline then falls back to ingest time) rather than persist a future posted_at.
+	jobURL := "https://career.luxoft.com/jobs/senior-axiom-developer-25277"
+	detail := lxDetailHTML("Senior Axiom Developer", "<p>x</p>", "2099-08-03 00:00:00", "Pune", "", "IN")
+	fake := (&routedHTTP{}).
+		route("&page=2", lxListingHTML()).
+		route("perPage=60", lxListingHTML(jobURL)).
+		route("/jobs/senior-axiom-developer-25277", detail)
+
+	jobs, err := NewLuxoft(fake).Fetch(context.Background(), CompanyEntry{Company: "Luxoft", Board: "career.luxoft.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil (future date dropped)", jobs[0].PostedAt)
+	}
+}
+
+func TestLuxoftStopsWhenPageYieldsNoNewLinks(t *testing.T) {
+	// Luxoft clamps ?page=N past its last page, re-serving the same links; a page with no
+	// *new* links must terminate enumeration so Fetch does not loop to lxMaxPages.
+	d := lxDetailHTML("Role", "<p>x</p>", "2026-06-14 19:00:00", "Pune", "", "IN")
+	fake := (&routedHTTP{}).
+		route("perPage=60", lxListingHTML("https://b/jobs/role-1")). // every page returns the same link
+		route("/jobs/role-1", d)
+
+	jobs, err := NewLuxoft(fake).Fetch(context.Background(), CompanyEntry{Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (de-duplicated, no runaway loop)", len(jobs))
+	}
+}
+
+func TestLuxoftFailedDetailDropsOnlyThatPosting(t *testing.T) {
+	d := lxDetailHTML("Kept", "<p>x</p>", "2026-06-14 19:00:00", "Pune", "", "IN")
+	// No route for /jobs/dropped-2 → GetHTML errors → that posting drops.
+	fake := (&routedHTTP{}).
+		route("&page=2", lxListingHTML()).
+		route("perPage=60", lxListingHTML("https://b/jobs/kept-1", "https://b/jobs/dropped-2")).
+		route("/jobs/kept-1", d)
+
+	jobs, err := NewLuxoft(fake).Fetch(context.Background(), CompanyEntry{Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "1" {
+		t.Fatalf("got %v, want only the kept posting", jobs)
+	}
+}
+
+// recordingHTML captures the URLs requested, serving canned bodies by substring while
+// recording every call, so a test can assert the exact listing URLs the adapter builds.
+type recordingHTML struct {
+	urls   []string
+	routes *routedHTTP
+}
+
+func (r *recordingHTML) GetHTML(ctx context.Context, u string) (*html.Node, error) {
+	r.urls = append(r.urls, u)
+	return r.routes.GetHTML(ctx, u)
+}
+
+func TestLuxoftListingPageOneOmitsPageParam(t *testing.T) {
+	// Luxoft 301-redirects /jobs?page=1 (the default page) to a broken relative Location,
+	// which the HTTP client resolves to a 404. The adapter must request page 1 WITHOUT a
+	// page param, adding &page=N only from page 2 on.
+	rec := &recordingHTML{routes: (&routedHTTP{}).
+		route("&page=2", lxListingHTML()).
+		route("perPage=60", lxListingHTML("https://career.luxoft.com/jobs/role-1")).
+		route("/jobs/role-1", lxDetailHTML("Role", "<p>x</p>", "2026-06-14 19:00:00", "Pune", "", "IN"))}
+
+	if _, err := NewLuxoft(rec).Fetch(context.Background(), CompanyEntry{Company: "Luxoft", Board: "career.luxoft.com"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(rec.urls) == 0 {
+		t.Fatal("no listing URL requested")
+	}
+	page1 := rec.urls[0]
+	if strings.Contains(page1, "page=1") {
+		t.Errorf("page-1 listing URL %q must not carry page=1 (it 301-redirects to a 404)", page1)
+	}
+	if !strings.Contains(page1, "perPage=60") {
+		t.Errorf("page-1 listing URL %q should request perPage=60", page1)
+	}
+}
+
+func TestLuxoftProvider(t *testing.T) {
+	if got := NewLuxoft(nil).Provider(); got != "luxoft" {
+		t.Errorf("Provider() = %q, want %q", got, "luxoft")
+	}
+}
+
+func TestLuxoftRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["luxoft"]
+	if !ok {
+		t.Fatal("All() missing provider luxoft")
+	}
+	if s.Provider() != "luxoft" {
+		t.Errorf("All()[luxoft].Provider() = %q", s.Provider())
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -128,6 +128,7 @@ func All(c HTTPClient) map[string]Source {
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),
+		NewLuxoft(c),
 		NewOracle(c),
 		NewEightfold(c),
 		NewFreshteam(c),

--- a/sources/luxoft.yml
+++ b/sources/luxoft.yml
@@ -1,0 +1,5 @@
+# luxoft board. Provider is the filename; the single entry is company + board.
+# board = the careers-site host (see internal/sources/luxoft.go).
+
+- company: Luxoft
+  board: career.luxoft.com

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -91,6 +91,13 @@ export interface Job {
   regions: string[];
   work_mode?: string;
   skills: string[];
+  /**
+   * Collections is the set of curated-collection slugs (e.g. yc, bigtech) the
+   * job's company belongs to, denormalized from the company onto the job. It is a
+   * deterministic source fact (no LLM counterpart) served straight from the jobs
+   * column; an untagged job serializes it as [].
+   */
+  collections: string[];
   posted_at?: string;
   created_at?: string;
   updated_at?: string;
@@ -105,7 +112,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'deel', 'eightfold', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'himalayas', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'justjoin', 'lever', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'remotive', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'deel', 'eightfold', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'himalayas', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'remotive', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## What

Adds a **Luxoft** careers adapter — the largest remaining coverage gap from the [idagent.pro](https://www.idagent.pro/companies) Russian-roots list. Luxoft runs a custom site (`career.luxoft.com`), not a supported ATS; previously only ~9 of its ~1400 live roles were in the catalogue (via aggregators).

## How

`/ajax/filter-jobs` caps at 100 and ignores paging, so the adapter enumerates the **server-rendered `/jobs?perPage=60` listing** and parses each job page's **schema.org `JobPosting` ld+json** for title/description/location/date — the same shape as the `globalpayments`/`teamtailor` detail adapters. Dedup id = the trailing numeric slug segment (each location-posting is its own row).

## Gotchas (both caught by a live smoke against the real site)

- **`/jobs?page=1` 301-redirects** (page 1 is the default) to a *broken relative* `Location: perPage=60` that the HTTP client resolves to a 404. Fix: page 1 omits the page param; `&page=N` is added only from page 2 on.
- **`datePosted` is a zoneless `2006-01-02 15:04:05` stamp and is often a future date.** `parseLayout` drops a future time to `nil` (`NotFuture`), so the pipeline falls back to ingest time rather than persisting a future `posted_at`.

## Live smoke (real career.luxoft.com)

```
listing page 1: 60 job links
job: id=25280 title="Solution Architect" location="Warsaw, PL" remote=false posted=<nil> descLen=6545 url=.../jobs/solution-architect-25280
```

## Tests

TDD: 10 unit tests (id parse, link resolution/filtering, location, full listing→detail map, future-date drop, no-new-links stop, failed-detail isolation, page-1 omits page param, provider, registry). `go test ./internal/sources/`, `go vet`, `gofmt` all clean.

## Notes

- New provider → **needs a full image rebuild to deploy** (not a sources-rsync), plus a host cron line for `sources/luxoft.yml`.
- Regenerating `contracts.ts` adds `'luxoft'` to `SOURCE_VALUES` and also picks up a **pre-existing `collections`-field drift** (the generated file was stale vs the Go `Job` contract from #197).
- Luxoft emits ISO-2 country codes (`PL`, `IN`); whether they resolve to country facets depends on `internal/location` dict coverage (separate concern — the location text is stored regardless).
