### PR TITLE
feat(sources): add EPAM careers adapter

### DIFF
--- a/internal/sources/epam.go
+++ b/internal/sources/epam.go
@@ -1,0 +1,134 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// epam adapts EPAM's careers site (careers.epam.com). EPAM's job-search API
+// (www.epam.com/api/jobs/search) is behind a Cloudflare challenge, but the gzip sitemap
+// enumerates every vacancy and each vacancy page server-renders a schema.org JobPosting
+// ld+json block (not Cloudflare-gated), so this adapter is the SuccessFactors shape —
+// sitemap to enumerate, per-job detail fetch for the posting — over the shared ld+json
+// helper. The board is the career-site host.
+type epam struct {
+	http epamHTTP
+}
+
+// epamHTTP is the transport epam needs: the gzip XML sitemap (the Go transport
+// transparently decodes the Content-Encoding: gzip response) plus HTML detail pages.
+type epamHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+// NewEPAM builds the EPAM adapter over the given HTTP client.
+func NewEPAM(c epamHTTP) Source { return epam{http: c} }
+
+func (epam) Provider() string { return "epam" }
+
+func (e epam) Fetch(ctx context.Context, ce CompanyEntry) ([]Job, error) {
+	var sitemap struct {
+		URLs []struct {
+			Loc string `xml:"loc"`
+		} `xml:"url"`
+	}
+	sitemapURL := fmt.Sprintf("https://%s/sitemap.xml.gz", ce.Board)
+	if err := e.http.GetXML(ctx, sitemapURL, &sitemap); err != nil {
+		return nil, fmt.Errorf("epam: sitemap %s: %w", ce.Board, err)
+	}
+
+	// Keep only English vacancy pages (epamJobID is empty for the listing, language roots,
+	// and the /uk//de/… localisations, so each vacancy is ingested once under its English url).
+	var urls []string
+	for _, u := range sitemap.URLs {
+		if epamJobID(u.Loc) != "" {
+			urls = append(urls, u.Loc)
+		}
+	}
+
+	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return e.detail(ctx, ce, u)
+	}), nil
+}
+
+// detail fetches one vacancy page and maps its JobPosting ld+json to a Job, returning
+// ok=false when the URL has no parseable id, the fetch fails, or the page carries no
+// JobPosting, so the caller skips just that posting.
+func (e epam) detail(ctx context.Context, ce CompanyEntry, jobURL string) (Job, bool) {
+	id := epamJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := e.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p epamPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	location := p.location()
+	// jobLocationType is EPAM's only structured work-arrangement signal: TELECOMMUTE means
+	// remote. Absent → leave WorkMode empty and fall back to the location text for remote.
+	remote := p.JobLocationType == "TELECOMMUTE"
+	workMode := ""
+	if remote {
+		workMode = "remote"
+	}
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     ce.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      remote || isRemote(location),
+		WorkMode:    workMode,
+		PostedAt:    parseDate(p.DatePosted),
+	}, true
+}
+
+// epamJobIDPattern captures the Contentstack vacancy uid (e.g. "blt01b3u51rnautbmxq") from
+// an /en/vacancy/<slug>-<uid>_en URL. Restricting to /en/vacancy/ and the _en suffix both
+// filters the sitemap to English vacancies and yields the dedup id in one match.
+var epamJobIDPattern = regexp.MustCompile(`/en/vacancy/[^/?#]*-(blt[a-z0-9]+)_en(?:[/?#]|$)`)
+
+// epamJobID extracts the vacancy uid from an English vacancy URL, returning "" for the
+// listing, language roots, and non-English vacancy localisations.
+func epamJobID(u string) string {
+	if m := epamJobIDPattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// epamPosting is the schema.org JobPosting decoded from an EPAM vacancy page's ld+json
+// block. EPAM emits no jobLocation; the location is built from applicantLocationRequirements
+// (an array of Country) and the work arrangement from jobLocationType.
+type epamPosting struct {
+	Title                         string        `json:"title"`
+	Description                   string        `json:"description"`
+	DatePosted                    string        `json:"datePosted"`
+	JobLocationType               string        `json:"jobLocationType"`
+	ApplicantLocationRequirements []epamCountry `json:"applicantLocationRequirements"`
+}
+
+type epamCountry struct {
+	Name string `json:"name"`
+}
+
+// location joins the applicant-location countries (the only location signal EPAM exposes
+// in the JobPosting), so a job open to several countries lists them all.
+func (p epamPosting) location() string {
+	names := make([]string, 0, len(p.ApplicantLocationRequirements))
+	for _, c := range p.ApplicantLocationRequirements {
+		names = append(names, c.Name)
+	}
+	return joinNonEmpty(names...)
+}

--- a/internal/sources/epam_test.go
+++ b/internal/sources/epam_test.go
@@ -1,0 +1,168 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// epamSitemapXML builds the (gzip-decoded) sitemap urlset linking the given <loc> URLs.
+func epamSitemapXML(locs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><urlset>`)
+	for _, l := range locs {
+		b.WriteString(`<url><loc>` + l + `</loc></url>`)
+	}
+	b.WriteString(`</urlset>`)
+	return b.String()
+}
+
+// epamDetailHTML builds an EPAM vacancy page carrying a JobPosting ld+json block. EPAM
+// emits no jobLocation; location comes from applicantLocationRequirements (an array of
+// Country) and the remote flag from jobLocationType ("TELECOMMUTE").
+func epamDetailHTML(title, description, datePosted, locType string, countries ...string) string {
+	var alr strings.Builder
+	for i, c := range countries {
+		if i > 0 {
+			alr.WriteString(",")
+		}
+		alr.WriteString(`{"@type":"Country","name":"` + c + `"}`)
+	}
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + description + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"jobLocationType":"` + locType + `",` +
+		`"applicantLocationRequirements":[` + alr.String() + `],` +
+		`"identifier":{"@type":"PropertyValue","name":"EPAM Systems","value":"ignored"}}` +
+		`</script></head><body></body></html>`
+}
+
+func TestEPAMJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://careers.epam.com/en/vacancy/abap-software-engineer-bltmoen02larol38uw0_en": "bltmoen02larol38uw0",
+		"https://careers.epam.com/en/vacancy/abap-tech-lead-blt17cb77be1b13b884_en":         "blt17cb77be1b13b884",
+		"https://careers.epam.com/uk/vacancy/x-bltabc123_uk":                                "", // non-English → filtered out (no id)
+		"https://careers.epam.com/en/jobs":                                                  "", // listing
+		"https://careers.epam.com/en":                                                       "",
+	}
+	for u, want := range cases {
+		if got := epamJobID(u); got != want {
+			t.Errorf("epamJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestEPAMPostingLocation(t *testing.T) {
+	p := epamPosting{ApplicantLocationRequirements: []epamCountry{{Name: "Colombia"}, {Name: "Mexico"}}}
+	if got, want := p.location(), "Colombia, Mexico"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	if got := (epamPosting{}).location(); got != "" {
+		t.Errorf("location() = %q, want empty", got)
+	}
+}
+
+func TestEPAMFetchSitemapThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://careers.epam.com/en/vacancy/data-technology-consultant-blt01b3u51rnautbmxq_en"
+	detail := epamDetailHTML(
+		"Data Technology Consultant",
+		"&lt;p&gt;Lead &lt;b&gt;data&lt;/b&gt;.&lt;/p&gt;&lt;script&gt;x&lt;/script&gt;",
+		"2026-06-18", "TELECOMMUTE", "Colombia", "Mexico")
+	fake := (&routedHTTP{}).
+		route("sitemap.xml.gz", epamSitemapXML(jobURL)).
+		route("/en/vacancy/data-technology-consultant-blt01b3u51rnautbmxq_en", detail)
+
+	jobs, err := NewEPAM(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "EPAM Systems", Provider: "epam", Board: "careers.epam.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "blt01b3u51rnautbmxq" {
+		t.Errorf("ExternalID = %q, want blt01b3u51rnautbmxq", j.ExternalID)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Data Technology Consultant" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "EPAM Systems" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Colombia, Mexico" {
+		t.Errorf("Location = %q, want %q", j.Location, "Colombia, Mexico")
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want true/remote (jobLocationType TELECOMMUTE)", j.Remote, j.WorkMode)
+	}
+	if strings.Contains(j.Description, "<script>") ||
+		!strings.Contains(j.Description, "<p>") || !strings.Contains(j.Description, "<b>data</b>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 18, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-18", j.PostedAt)
+	}
+}
+
+func TestEPAMFiltersNonEnglishAndNonVacancyURLs(t *testing.T) {
+	en := "https://careers.epam.com/en/vacancy/role-blt111aaa_en"
+	detail := epamDetailHTML("Role", "&lt;p&gt;x&lt;/p&gt;", "2026-06-18", "TELECOMMUTE", "Poland")
+	fake := (&routedHTTP{}).
+		route("sitemap.xml.gz", epamSitemapXML(
+			"https://careers.epam.com/en",
+			"https://careers.epam.com/en/jobs",
+			"https://careers.epam.com/uk/vacancy/role-blt222bbb_uk", // non-English vacancy → skip
+			en,
+		)).
+		route("/en/vacancy/role-blt111aaa_en", detail)
+
+	jobs, err := NewEPAM(fake).Fetch(context.Background(), CompanyEntry{Company: "EPAM Systems", Board: "careers.epam.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "blt111aaa" {
+		t.Fatalf("got %v, want only the single English vacancy", jobs)
+	}
+}
+
+func TestEPAMFailedDetailDropsOnlyThatPosting(t *testing.T) {
+	kept := "https://careers.epam.com/en/vacancy/kept-blt1keep_en"
+	dropped := "https://careers.epam.com/en/vacancy/dropped-blt2drop_en"
+	detail := epamDetailHTML("Kept", "&lt;p&gt;x&lt;/p&gt;", "2026-06-18", "TELECOMMUTE", "Poland")
+	// No route for the dropped vacancy → GetHTML errors → that posting drops.
+	fake := (&routedHTTP{}).
+		route("sitemap.xml.gz", epamSitemapXML(kept, dropped)).
+		route("/en/vacancy/kept-blt1keep_en", detail)
+
+	jobs, err := NewEPAM(fake).Fetch(context.Background(), CompanyEntry{Company: "EPAM Systems", Board: "careers.epam.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "blt1keep" {
+		t.Fatalf("got %v, want only the kept posting", jobs)
+	}
+}
+
+func TestEPAMProvider(t *testing.T) {
+	if got := NewEPAM(nil).Provider(); got != "epam" {
+		t.Errorf("Provider() = %q, want %q", got, "epam")
+	}
+}
+
+func TestEPAMRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["epam"]
+	if !ok {
+		t.Fatal("All() missing provider epam")
+	}
+	if s.Provider() != "epam" {
+		t.Errorf("All()[epam].Provider() = %q", s.Provider())
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -129,6 +129,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJoin(c),
 		NewGlobalPayments(c),
 		NewLuxoft(c),
+		NewEPAM(c),
 		NewOracle(c),
 		NewEightfold(c),
 		NewFreshteam(c),

--- a/openspec/changes/add-company-lazy-list/.openspec.yaml
+++ b/openspec/changes/add-company-lazy-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-company-lazy-list/design.md
+++ b/openspec/changes/add-company-lazy-list/design.md
@@ -1,0 +1,123 @@
+## Context
+
+The sidebar Company filter (shipped in PR#202) is a `dynamic` Meilisearch facet,
+the same machinery as `skills`/`countries`. That works for bounded vocabularies —
+`skills` has 238 distinct values (under Meili's `maxValuesPerFacet=300` cap) and
+`countries` 129 — so their distributions load fully and client-side search finds
+everything. Companies are different: the catalogue has ~1.54M jobs across
+thousands of companies. Meili returns only the first 300 facet values **in
+alphabetical order**, so the company list is junk (`0-compromise-recruitment…`,
+`01-tech`, counts of 1) and excludes popular employers — "google" finds nothing.
+
+The companies endpoint (`GET /api/v1/companies?q=`) already exists and already
+returns `{slug, name, job_count}` with a case-insensitive name search and
+pagination. The `/companies` page already renders job-count badges, search,
+debounce, and infinite scroll. So the data source and one consumer already exist;
+they are just (a) name-ordered and (b) computing `job_count` via a query-time
+`LEFT JOIN ... GROUP BY count()` over 1.54M jobs on every request.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A sidebar Company filter that searches the whole catalogue by name and lists
+  companies most-active first, showing real names and job counts.
+- A cheap, popularity-ordered `GET /api/v1/companies` reused by both the sidebar
+  typeahead and the `/companies` page.
+- Keep the company filter wired through the existing `company_slug` search param
+  so URL sync, exclusion, chips, and active-filter-count are unchanged.
+
+**Non-Goals:**
+- Real-time exactness of `job_count` (eventual consistency within the recompute
+  interval is acceptable).
+- Per-filter *contextual* company counts (the count is global open-job count).
+- Changing the `skills`/`countries` facets — they are within the cap and fine.
+- Any Meili reindex (the document shape is unchanged).
+
+## Decisions
+
+### Denormalize `job_count`, maintained by a periodic recompute (not triggers)
+
+Add `companies.job_count INT NOT NULL DEFAULT 0` plus an index on `(job_count
+DESC)`. A new one-shot worker `cmd/recount-companies` runs a single set-based
+`UPDATE` that sets every company's `job_count` from `GROUP BY company_slug` over
+`jobs WHERE closed_at IS NULL` (companies with no open jobs → 0). Scheduled hourly
+by host cron with `flock`, following the existing worker pattern
+(`worker.Bootstrap`, run-once, exit codes), like `cmd/backfill-derive`.
+
+- **Why over PG triggers:** the count changes both on ingest and on *close*
+  (`closed_at` set by the ingest sweep and the liveness worker), across 1.54M
+  rows crawled frequently. Triggers would add write overhead to every upsert and
+  risk drift on any path that bypasses them. A periodic full recompute is simple,
+  self-healing, and off the hot path. The user chose this explicitly.
+- **Why over query-time count:** sorting all companies by an on-the-fly
+  `GROUP BY` over 1.54M jobs on every `/companies` and every typeahead keystroke
+  is the cost we are removing.
+
+### Reuse the companies endpoint; change only ordering and the count source
+
+`ListCompanies` drops the `LEFT JOIN`/`GROUP BY`/`count()`, reads `c.job_count`,
+and orders `job_count DESC, name`. `q` ILIKE search and `CountCompanies` are
+unchanged. `GetCompany` is `SELECT *`, so `job_count` flows into `db.Company`
+automatically. No new endpoint — the sidebar typeahead and `/companies` share it.
+
+### Frontend: a `control: 'remote'` facet type, state still keyed by `company_slug`
+
+Add a new control type to the facet registry and a `RemoteSearchSelect.svelte`
+that debounce-fetches `api.listCompanies(q, limit, 0)`, renders name + count,
+shows the popular first page on an empty query, and on select calls the existing
+`store.toggle('company_slug', slug)`. Because state stays keyed by the
+`company_slug` param, `filtersToParams`/`filtersFromParams`, exclusion, chips, and
+active-filter-count all keep working untouched — only the *option source* changes
+from the Meili distribution to the endpoint.
+
+- **Why a control type over a bespoke component:** it is the natural extension of
+  the existing `pills`/`select`/`tokens` pattern and keeps the company filter
+  inside the registry-driven system. The component takes a fetch function, so it
+  is not company-hardcoded, but company is its only consumer for now (no further
+  generalization until a second remote facet appears).
+- **Selected-chip labels:** accumulate a session-local `slug → name` map from
+  results so chips show real names; fall back to the existing `companyLabel(slug)`
+  humanizer for URL-preselected slugs not yet seen (e.g. `?company_slug=stripe`).
+  No batch slug→name endpoint is added (YAGNI).
+
+### Stop requesting the unused `company_slug` facet distribution
+
+`company_slug` stays in `search.StringFacets` (still needed for `?company_slug=`
+filtering), but is excluded from the attributes the facets endpoint requests
+distributions for (`facetAttributes()` in `internal/handler/facets.go`). We were
+computing a 300-bucket distribution on every sidebar interaction that the UI no
+longer reads.
+
+## Risks / Trade-offs
+
+- **Stale counts between recomputes** → hourly cron keeps drift small; counts are
+  popularity hints and sort keys, not exact figures. Acceptable per Goals.
+- **Recompute cost on 1.54M jobs** → it is a single aggregate + set `UPDATE`, not
+  per-row; runs off the hot path under `flock` so runs can't stack.
+- **Empty `job_count` immediately after deploy** → the column defaults to 0 until
+  the first recompute, so the list would look empty/unsorted. Mitigation: run
+  `cmd/recount-companies` once manually right after the migration, before relying
+  on the UI (captured as a deploy task).
+- **Global (non-contextual) company count** differs from other facets' contextual
+  counts → intended and documented in the spec; the contextual path is the broken
+  one being replaced.
+
+## Migration Plan
+
+1. Ship migration `0025_companies_job_count.sql` (column + index). On prod, apply
+   it manually via `psql` (initdb runs only on first volume init).
+2. Deploy a **full** Go image rebuild (new `cmd/recount-companies` binary) — not a
+   sources-only deploy. Deploy the web image for the new facet control.
+3. Run `cmd/recount-companies` once manually to populate `job_count`.
+4. Add the hourly cron line (`flock` + `docker compose run --rm -T
+   recount-companies`) and the compose worker service.
+5. Verify: `/api/v1/companies` is count-ordered; sidebar typeahead finds "google";
+   `/companies` page ordered by popularity.
+
+Rollback: the change is additive (new column, new binary, new optional cron).
+Reverting the web image restores the prior facet; the column can be left in place
+harmlessly.
+
+## Open Questions
+
+None — scope and semantics were confirmed with the user during brainstorming.

--- a/openspec/changes/add-company-lazy-list/proposal.md
+++ b/openspec/changes/add-company-lazy-list/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The sidebar "Company" filter is backed by a Meilisearch facet distribution,
+which Meili caps at `maxValuesPerFacet=300` and returns in **alphabetical**
+order, not by popularity. Over a ~1.54M-job catalogue the list is therefore
+dominated by junk `0-`/`1-`-prefixed company slugs and excludes popular
+employers entirely — typing "google" finds nothing. The filter is effectively
+unusable. The fix is to source the company list from the database, sorted by job
+count, and to make that sort cheap with a denormalized counter.
+
+## What Changes
+
+- Add a denormalized `companies.job_count` column (open jobs only), maintained by
+  a new periodic recompute worker `cmd/recount-companies` (cron, hourly).
+- `GET /api/v1/companies` reads `job_count` from the column instead of a
+  query-time `count()` join, and orders by `job_count DESC, name` so the most
+  active companies surface first. The `q` name-search and pagination are
+  unchanged. **BREAKING** (internal): the list is no longer name-ordered.
+- Replace the sidebar Company filter's broken dynamic Meili facet with a lazy,
+  server-backed typeahead that queries the (now count-sorted) companies endpoint,
+  shows real company names and global open-job counts, and on an empty query
+  shows the most popular companies. The filter still applies via the existing
+  `company_slug` search param, so URL state, exclusion, and chips are unchanged.
+- The `/companies` page needs no frontend change — it already renders the job
+  count and search; it simply inherits the count-sorted ordering.
+- Cheap win: stop requesting the unused `company_slug` facet distribution in the
+  analytics facets endpoint, while keeping `company_slug` filterable.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `companies`: the company list gains a denormalized `job_count` maintained by a
+  periodic recompute, and is ordered by job count descending; the prior
+  requirement that no denormalized counter is required is superseded.
+- `web-frontend`: the Company filter facet becomes a lazy, server-backed
+  typeahead sourced from the companies endpoint (sorted by job count), replacing
+  the capped Meilisearch facet distribution.
+
+## Impact
+
+- **Schema**: migration `0025_companies_job_count.sql` (new column + index).
+  Applied manually on prod (initdb runs only on first volume init).
+- **Backend**: `internal/db/queries/companies.sql` (ListCompanies, new
+  RecountCompanyJobCounts), regenerated `internal/db`; new `cmd/recount-companies`
+  worker; `internal/handler/facets.go` (drop company_slug from requested facets).
+- **Build/ops**: root `Dockerfile` (new binary build + COPY); a new Go image
+  (full rebuild, not sources-only); `freehire-ops/docker-compose.prod.yml` worker
+  service + hourly host cron line; one manual `recount-companies` run post-deploy
+  to populate the column.
+- **Frontend**: new `web/src/lib/components/facets/RemoteSearchSelect.svelte`, a
+  `control: 'remote'` facet type, and the `company_slug` FACETS entry switched to
+  it; no `/companies` page change.
+- **No reindex** required (this does not change the Meili document shape).

--- a/openspec/changes/add-company-lazy-list/specs/companies/spec.md
+++ b/openspec/changes/add-company-lazy-list/specs/companies/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Company list is served without joining jobs
+
+The system SHALL expose `GET /api/v1/companies` returning companies read from the
+`companies` table. Each company's job count SHALL be read from the denormalized
+`companies.job_count` column (open jobs only), not computed at query time, so the
+read path performs no join to the `jobs` table. The list SHALL be ordered by
+`job_count` descending, then `name` ascending, so the most active companies
+surface first.
+
+The endpoint SHALL accept an optional `q` query parameter that filters companies
+by a case-insensitive substring match on the company `name`. An absent or empty
+`q` SHALL return the unfiltered list. When `q` is non-empty, the list `meta.total`
+SHALL report the count of companies matching `q`, so pagination over the filtered
+results is correct.
+
+#### Scenario: Listing companies most-active first
+
+- **WHEN** a client requests `GET /api/v1/companies`
+- **THEN** the response contains companies under `data` with list `meta`,
+  ordered by `job_count` descending (ties broken by `name`), each carrying its
+  denormalized `job_count`
+
+#### Scenario: Searching companies by name
+
+- **WHEN** a client requests `GET /api/v1/companies?q=acme`
+- **THEN** the response contains only companies whose name matches `acme`
+  case-insensitively, ordered by `job_count` descending, and `meta.total` is the
+  count of matching companies
+
+#### Scenario: Empty query returns the full list
+
+- **WHEN** a client requests `GET /api/v1/companies?q=` (empty or absent)
+- **THEN** the response is the unfiltered company list, identical to omitting the
+  parameter
+
+## ADDED Requirements
+
+### Requirement: Company job counts are denormalized and periodically recomputed
+
+The system SHALL store each company's count of open jobs (`closed_at IS NULL`) in
+a denormalized `companies.job_count` column. The column SHALL be maintained by a
+periodic recompute (a scheduled worker), not by a synchronous write on the job
+ingest/close paths, so it is eventually consistent with the `jobs` table within
+the recompute interval. A company with no open jobs SHALL have `job_count = 0`.
+
+#### Scenario: Recompute reflects only open jobs
+
+- **WHEN** the recompute runs and a company has 3 open jobs and 2 closed jobs
+  (`closed_at` set)
+- **THEN** that company's `job_count` is set to 3
+
+#### Scenario: Recompute zeroes a company whose jobs all closed
+
+- **WHEN** every job of a company has been closed since the last recompute and the
+  recompute runs again
+- **THEN** that company's `job_count` is set to 0
+
+#### Scenario: Counts are eventually consistent
+
+- **WHEN** a new job is ingested for a company between recompute runs
+- **THEN** the company's `job_count` does not change until the next recompute,
+  which then includes the new job

--- a/openspec/changes/add-company-lazy-list/specs/web-frontend/spec.md
+++ b/openspec/changes/add-company-lazy-list/specs/web-frontend/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Company filter facet is a lazy, server-backed typeahead
+
+The frontend job-search filter UI SHALL offer a "Company" facet that sources its
+options from the companies endpoint (`GET /api/v1/companies?q=`), not from the
+Meilisearch facet distribution. As the user types, the facet SHALL query the
+endpoint (debounced) and present matching companies by their display `name`
+alongside their global open-job count, ordered most-active first. With an empty
+query the facet SHALL present the most popular companies (the endpoint's
+count-ordered first page). Selecting a company SHALL apply the existing
+`company_slug` search parameter, so URL state, exclusion, and the selected-value
+chips behave identically to the other facets. The count shown for a company is
+its global open-job count, not a count contextual to the other active filters.
+
+#### Scenario: Typing finds a company outside the top results
+
+- **WHEN** a user types "google" into the Company facet
+- **THEN** the facet queries `GET /api/v1/companies?q=google` and lists matching
+  companies by name with their job counts, even though "google" is not among the
+  most popular companies shown for an empty query
+
+#### Scenario: Empty query shows the most popular companies
+
+- **WHEN** a user opens the Company facet without typing
+- **THEN** the facet shows the most active companies first (highest job count),
+  sourced from the endpoint's first page
+
+#### Scenario: Selecting a company filters the job list
+
+- **WHEN** a user selects a company in the facet
+- **THEN** the search request carries that company's `company_slug` and the job
+  results are limited to that company, and a removable chip shows the company's
+  display name
+
+#### Scenario: A pre-selected company from the URL is shown by name
+
+- **WHEN** the page loads with `?company_slug=stripe` already set
+- **THEN** the Company facet shows the selection as a removable chip with a
+  human-readable label, without requiring the user to first search for it

--- a/openspec/changes/add-company-lazy-list/tasks.md
+++ b/openspec/changes/add-company-lazy-list/tasks.md
@@ -1,0 +1,29 @@
+## 1. Schema + DB query layer
+
+- [ ] 1.1 Add migration `migrations/0025_companies_job_count.sql`: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS job_count INT NOT NULL DEFAULT 0;` plus `CREATE INDEX IF NOT EXISTS companies_job_count_idx ON companies (job_count DESC);`
+- [ ] 1.2 Edit `internal/db/queries/companies.sql` `ListCompanies`: drop the `LEFT JOIN jobs` / `GROUP BY` / `count()`, select `c.job_count`, and `ORDER BY c.job_count DESC, c.name`. Keep the `q` ILIKE filter and `CountCompanies` unchanged.
+- [ ] 1.3 Add a `RecountCompanyJobCounts` query to `companies.sql`: a single set-based `UPDATE companies SET job_count = COALESCE(sub.cnt, 0)` deriving `sub` from `GROUP BY company_slug` over `jobs WHERE closed_at IS NULL`, covering companies with zero open jobs (→ 0).
+- [ ] 1.4 Run `make sqlc` (or `go install sqlc` fallback) and confirm `internal/db` regenerates: `db.Company` gains `JobCount`, `ListCompanies` returns it, `RecountCompanyJobCounts` exists. `go build ./...` is green.
+
+## 2. Recount worker
+
+- [ ] 2.1 RED: integration test (`//go:build integration`, testcontainers) asserting `RecountCompanyJobCounts` sets `job_count` to the number of open jobs per company (ignoring `closed_at` rows) and zeroes a company whose jobs all closed.
+- [ ] 2.2 RED: integration test asserting `ListCompanies` returns companies ordered by `job_count DESC` (tie-broken by name) and that the `q` filter still matches by name.
+- [ ] 2.3 GREEN: add `cmd/recount-companies/main.go` (template: `cmd/backfill-derive` + `internal/worker.Bootstrap`): run `RecountCompanyJobCounts` once, log rows affected, return exit code 0/1. Make tests pass.
+- [ ] 2.4 Add `cmd/recount-companies` to the root `Dockerfile` (the `go build` chain and the final-stage `COPY` list). `go vet ./...` + `go build ./...` green.
+
+## 3. Backend facet cheap-win
+
+- [ ] 3.1 In `internal/handler/facets.go`, exclude `company_slug` from the attributes `facetAttributes()` requests distributions for, while leaving it in `search.StringFacets` (so `?company_slug=` filtering is unaffected). Verify the `/jobs/facets` response no longer carries a `company_slug` key but `?company_slug=` filtering on `/jobs` still works.
+
+## 4. Frontend lazy company filter
+
+- [ ] 4.1 Add a `control: 'remote'` option to the `FacetControl` type / `FacetDef` in `web/src/lib/facets.ts`, and switch the `company_slug` FACETS entry from `{ dynamic: true, control: 'select' }` to `{ control: 'remote', ... }`. Keep `companyLabel`/`dynamicLabel`.
+- [ ] 4.2 Create `web/src/lib/components/facets/RemoteSearchSelect.svelte`: debounced fetch via `api.listCompanies(q, limit, 0)`, render company `name` + `job_count`, show the popular first page on empty query, call `onToggle(slug)` on select, render selected values as removable chips using a session `slug→name` map with `companyLabel(slug)` fallback.
+- [ ] 4.3 Route `control === 'remote'` to `RemoteSearchSelect` in `FacetSection.svelte`, passing the store-keyed `company_slug` state (selected values, exclude) so URL-sync/exclude/chips keep working.
+- [ ] 4.4 `cd web && npm run check` (svelte-check) is green; manually confirm (dev or prod-API) that typing "google" returns Google and selecting a company filters the job list.
+
+## 5. Verification + deploy notes
+
+- [ ] 5.1 `go build ./... && go vet ./...` and `go test ./...` green; `go test -tags=integration ./internal/db/` (or the relevant package) green for the new tests.
+- [ ] 5.2 Document the deploy steps in the change (full Go image rebuild for the new binary; web image; apply migration 0025 manually via `psql`; run `cmd/recount-companies` once to populate; add the compose worker service + hourly `flock` cron line in `freehire-ops`).

--- a/sources/epam.yml
+++ b/sources/epam.yml
@@ -1,0 +1,6 @@
+# epam board. Provider is the filename; the single entry is company + board.
+# board = the careers-site host (see internal/sources/epam.go). The gzip sitemap
+# enumerates every vacancy; each vacancy page server-renders a JobPosting ld+json.
+
+- company: EPAM Systems
+  board: careers.epam.com

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -112,7 +112,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'deel', 'eightfold', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'himalayas', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'remotive', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'deel', 'eightfold', 'epam', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'himalayas', 'huntflow', 'icims', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'remotive', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## What

Adds an **EPAM** careers adapter — closing the largest still-open gap from the idagent.pro Russian-roots list. EPAM has ~2900 vacancies but no supported ATS; aggregators only surfaced ~115. This enumerates all ~2894 English vacancies.

## Why this works where the API doesn't

- `www.epam.com/api/jobs/search` (the real listing API) is behind a **Cloudflare JS challenge** — unreachable by the keyless HTTP client.
- The server-rendered listing page exposes only ~20 of ~2900 (no server-side pagination).
- **But** `careers.epam.com/sitemap.xml.gz` lists every vacancy, and each `/en/vacancy/<slug>-<uid>_en` page **server-renders a schema.org `JobPosting` ld+json** that is *not* Cloudflare-gated.

So the adapter is the **SuccessFactors shape** (sitemap → per-job detail) over the shared `ldJobPosting` helper.

## Design notes

- **board** = `careers.epam.com` (one entry in `sources/epam.yml`).
- The sitemap is served `Content-Encoding: gzip` → the Go transport decodes it transparently, so `GetXML` works directly (no manual gunzip).
- One regex `/en/vacancy/<slug>-(blt…)_en` does double duty: filters the sitemap to **English** vacancies (skipping `/uk//de/…` localisations so each vacancy is ingested once) **and** yields the Contentstack uid as the dedup id.
- EPAM emits no `jobLocation`; location = `applicantLocationRequirements` (countries), remote = `jobLocationType == "TELECOMMUTE"`.

## Live smoke (real careers.epam.com)

```
sitemap: 3097 urls, 2894 english vacancies
EPAM job: id=bltacah426esr6pex8p title="Senior .NET Developer" loc="Argentina" remote=true workmode="remote" posted=2026-06-18 descLen=1837
```

## Tests

TDD: 7 unit tests (uid/filter, location, sitemap→detail map, English-only filtering, failed-detail isolation, provider, registry). `go test ./internal/sources/`, `go vet`, `gofmt`, `go build ./...` all clean.

## Deploy

New provider → **full image rebuild** (not sources-rsync) + a host cron line for `sources/epam.yml` (daily — ~2894 detail fetches per crawl, like SuccessFactors/iCIMS).
