### PR TITLE
fix(web): truncate long company-filter chips

### DIFF
--- a/web/src/lib/components/facets/RemoteSearchSelect.svelte
+++ b/web/src/lib/components/facets/RemoteSearchSelect.svelte
@@ -74,9 +74,11 @@
         <button
           type="button"
           onclick={() => onToggle(value)}
-          class={pillClass(true, exclude, 'inline-flex items-center px-2.5 py-1 text-sm')}
+          title={labelOf(value)}
+          class={pillClass(true, exclude, 'inline-flex max-w-full items-center px-2.5 py-1 text-sm')}
         >
-          {labelOf(value)}<X class="ml-1 size-3" />
+          <span class="min-w-0 truncate">{labelOf(value)}</span>
+          <X class="ml-1 size-3 shrink-0" />
         </button>
       {/each}
     </div>


### PR DESCRIPTION
A long selected-company name (`GOOGLE ASIA PACIFIC PTE. LTD.`) stretched the chip to full width and wrapped onto two lines (reported with a screenshot).

Fix: cap the chip at the panel width (`max-w-full`) and ellipsis-truncate the label (`min-w-0` + `truncate`) so it stays one line; keep the `×` pinned (`shrink-0`); full name available on hover via `title`. Web-only, no backend.

svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)