### PR TITLE
feat(sources): add Telegram careers-page adapter

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -153,6 +153,7 @@ func All(c HTTPClient) map[string]Source {
 		NewRemotive(c),
 		NewJustJoin(c),
 		// International single-company adapters (boardless).
+		NewTelegramCareers(c),
 		NewUber(c),
 		NewAmazon(c),
 		NewGoogle(c),

--- a/internal/sources/telegramcareers.go
+++ b/internal/sources/telegramcareers.go
@@ -1,0 +1,89 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/normalize"
+	"golang.org/x/net/html"
+)
+
+// telegramcareers adapts Telegram's official jobs page (telegram.org/jobs), a single,
+// hand-maintained page (boardless, one company) rather than an ATS. The page server-renders
+// each role as an <h3> title followed by its description markup inside #dev_page_content, so
+// the adapter splits on the headings — no per-role URL, date, or location is published, so
+// the dedup id is the title slug and the URL is the shared jobs page.
+type telegramcareers struct {
+	http HTMLGetter
+}
+
+const telegramJobsURL = "https://telegram.org/jobs"
+
+// NewTelegramCareers builds the Telegram careers-page adapter over the given HTTP client.
+func NewTelegramCareers(c HTMLGetter) Source { return telegramcareers{http: c} }
+
+func (telegramcareers) Provider() string { return "telegramcareers" }
+
+// telegramcareers serves a single company, so its config entry carries no board.
+func (telegramcareers) boardless() {}
+
+func (t telegramcareers) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	root, err := t.http.GetHTML(ctx, telegramJobsURL)
+	if err != nil {
+		return nil, fmt.Errorf("telegramcareers: fetch jobs page: %w", err)
+	}
+	content := elementByID(root, "dev_page_content")
+	if content == nil {
+		return nil, fmt.Errorf("telegramcareers: jobs content not found")
+	}
+
+	// Walk the content's children in document order: an <h3> opens a new role and every
+	// node after it (until the next <h3>) is that role's description body.
+	var jobs []Job
+	var title string
+	var body strings.Builder
+	flush := func() {
+		if title == "" {
+			return
+		}
+		jobs = append(jobs, Job{
+			ExternalID:  normalize.Slug(title),
+			URL:         telegramJobsURL,
+			Title:       title,
+			Company:     e.Company,
+			Description: sanitizeHTML(body.String()),
+			// The page states no location; applications route to @jobs_bot. Leave location
+			// empty and the remote flag false rather than guessing.
+		})
+	}
+	for c := content.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == "h3" {
+			flush()
+			title = textContent(c)
+			body.Reset()
+			continue
+		}
+		if title != "" {
+			_ = html.Render(&body, c)
+		}
+	}
+	flush()
+	return jobs, nil
+}
+
+// elementByID returns the first element node whose id attribute equals id, or nil.
+func elementByID(root *html.Node, id string) *html.Node {
+	var found *html.Node
+	walk(root, func(n *html.Node) bool {
+		if found != nil {
+			return false
+		}
+		if n.Type == html.ElementNode && attr(n, "id") == id {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/internal/sources/telegramcareers_test.go
+++ b/internal/sources/telegramcareers_test.go
@@ -1,0 +1,79 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// telegramJobsHTML builds a telegram.org/jobs-shaped page: a #dev_page_content wrapper
+// whose each role is an <h3> title followed by its description markup until the next <h3>.
+func telegramJobsHTML(titlesAndBodies ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div id="dev_page_content"><h1>Jobs</h1><p>intro</p>`)
+	for i := 0; i+1 < len(titlesAndBodies); i += 2 {
+		b.WriteString(`<h3>` + titlesAndBodies[i] + `</h3>` + titlesAndBodies[i+1])
+	}
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+func TestTelegramCareersFetchParsesJobs(t *testing.T) {
+	page := telegramJobsHTML(
+		"Content Moderator", `<p>Responsibilities: <b>sort</b> content.</p><ul><li>care</li></ul>`,
+		"C/C++ Software Engineer", `<p>Work on storage engines.</p><script>x</script>`,
+	)
+	fake := (&routedHTTP{}).route("telegram.org/jobs", page)
+
+	jobs, err := NewTelegramCareers(fake).Fetch(context.Background(), CompanyEntry{Company: "Telegram", Provider: "telegramcareers"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.Title != "Content Moderator" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.ExternalID != "content-moderator" {
+		t.Errorf("ExternalID = %q, want content-moderator", j.ExternalID)
+	}
+	if j.Company != "Telegram" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.URL != "https://telegram.org/jobs" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if !strings.Contains(j.Description, "Responsibilities") || !strings.Contains(j.Description, "<b>sort</b>") {
+		t.Errorf("Description missing body: %q", j.Description)
+	}
+	// The next role's content must not bleed into this one.
+	if strings.Contains(j.Description, "storage engines") {
+		t.Errorf("Description bled into the next role: %q", j.Description)
+	}
+	// Second role's description is sanitized (script stripped).
+	if strings.Contains(jobs[1].Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", jobs[1].Description)
+	}
+	if jobs[1].ExternalID != "c-c-software-engineer" {
+		t.Errorf("ExternalID = %q, want c-c-software-engineer", jobs[1].ExternalID)
+	}
+}
+
+func TestTelegramCareersProvider(t *testing.T) {
+	if got := NewTelegramCareers(nil).Provider(); got != "telegramcareers" {
+		t.Errorf("Provider() = %q, want telegramcareers", got)
+	}
+}
+
+func TestTelegramCareersRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["telegramcareers"]
+	if !ok {
+		t.Fatal("All() missing provider telegramcareers")
+	}
+	if s.Provider() != "telegramcareers" {
+		t.Errorf("All()[telegramcareers].Provider() = %q", s.Provider())
+	}
+}

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -19,6 +19,8 @@
   provider: google
 - company: Lumenalta
   provider: lumenalta
+- company: Telegram
+  provider: telegramcareers
 
 - company: VK
   provider: vk


### PR DESCRIPTION
## What

Adds a **Telegram** careers-page adapter — covering the last reachable company on the idagent.pro list that had nothing in the catalogue.

Telegram has no ATS; its jobs live on one hand-maintained page, `telegram.org/jobs`, which server-renders each role as an `<h3>` title followed by its description markup inside `#dev_page_content`. This **boardless single-company** adapter (like aviasales/uber) splits the page on those headings.

## Notes

- No per-role URL/date/location is published (applications route to `@jobs_bot`), so the dedup id is the **title slug**, the URL is the shared jobs page, and location is left empty rather than guessed.
- Provider key is **`telegramcareers`**, deliberately *not* `telegram`: that value is the Telegram-**channel** extraction source, and reusing it would let the ingest per-provider stale-sweep close the channel-sourced jobs this crawl never sees.
- Config is one entry in the existing `sources/custom.yml` → rides its cron; **no new file or schedule**.

## Live smoke (real telegram.org/jobs)

```
telegram jobs: 6
  [Content Moderator] id=content-moderator descLen=854
  [Translator] id=translator descLen=946
  [C/C++ Software Engineer] id=c-c-software-engineer descLen=630
  [Site Reliability Engineer] id=site-reliability-engineer descLen=565
  [Junior Accountant] id=junior-accountant descLen=677
  [Assistant to the CEO] id=assistant-to-the-ceo descLen=514
```

## Tests

TDD: heading-split parsing (incl. no-bleed-into-next-role + sanitize), provider, registry. `go test ./internal/sources/`, `go vet`, `gofmt`, `go build ./...` clean.

## Deploy

New adapter → full image rebuild; no new cron (rides custom.yml). ~6 jobs.
