### PR TITLE
feat(collections): add the russian-roots curated collection

### DIFF
--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -89,6 +89,12 @@ var All = []Collection{
 		Description: "Open roles at Fortune 500 companies — the largest US corporations by revenue.",
 		Dataset:     &Dataset{URL: fortune500DatasetURL, Parse: ParseCompanyCSV},
 	},
+	{
+		Slug:        "russian-roots",
+		Title:       "Russian Roots",
+		Description: "Open roles at globally distributed companies founded by Russian-speaking founders or with Russian-speaking engineering roots.",
+		Slugs:       RussianRootsSlugs,
+	},
 }
 
 // Default dataset URLs (overridable per collection via <SLUG>_DATASET_URL in the
@@ -171,6 +177,27 @@ var BigTechSlugs = []string{
 	"amd",
 	"dell",
 	"servicenow",
+}
+
+// RussianRootsSlugs is a hand-curated list of companies with Russian-speaking
+// founding roots that operate internationally (the idagent.pro "42 companies with
+// Russian-speaking roots" list + RingCentral). "Russian roots" is a fact about the
+// company, so all of its roles belong here. Entries are canonical company slugs (as
+// produced by normalize.Slug), matched against the catalogue at import time; the
+// first group is present today, the second is listed so a company tags in if it ever
+// enters the catalogue. Unmatched entries are simply logged.
+var RussianRootsSlugs = []string{
+	// Present in the catalogue.
+	"abbyy", "acronis", "aviasales", "ciklum", "clickhouse",
+	"codesignal", "dataart", "epam-systems", "epam-systems-pte-ltd", "exante",
+	"group-ib", "indrive", "jetbrains", "joom", "kaspersky",
+	"kaspersky-lab", "lokalise", "luxoft", "macpaw", "miro",
+	"nebius", "pandadoc", "picsart", "plata", "playrix",
+	"preply", "replika", "restream", "revolut", "ringcentral",
+	"semrush", "toloka", "toloka-ai", "veeam", "wallarm",
+	"wargaming", "whitebit", "wirex", "wrike",
+	// Not yet in the catalogue (future-proofing the membership).
+	"bitfury", "grammarly", "nginx", "parallels", "plesk", "telegram",
 }
 
 // Lookup returns the registry entry for a slug, or ok=false when no collection has

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -54,4 +54,10 @@ export const COLLECTIONS: Collection[] = [
     title: 'Fortune 500',
     description: 'Open roles at Fortune 500 companies — the largest US corporations by revenue.',
   },
+  {
+    slug: 'russian-roots',
+    title: 'Russian Roots',
+    description:
+      'Open roles at globally distributed companies founded by Russian-speaking founders or with Russian-speaking engineering roots.',
+  },
 ];


### PR DESCRIPTION
## What

Adds a 9th curated collection — **Russian Roots** — to the existing collections feature (yc/techstars/european/ai/mag7/bigtech/unicorn/fortune500). It groups globally distributed companies founded by Russian-speaking founders or with Russian-speaking engineering roots: the [idagent.pro](https://www.idagent.pro/companies) "42 companies with Russian roots" list **+ RingCentral**.

Like `ai`/`mag7`/`bigtech`, it's a hand-curated `Slugs` list (no public dataset for "Russian roots").

## Membership

Canonical company slugs **validated against the prod catalogue** (with current open-job counts): EPAM (1478), Luxoft (1384), Toloka (762+11), Nebius (345), Veeam (283), inDrive (239), ClickHouse (187), Ciklum (175), Preply (155), Plata (146), JetBrains (136), Semrush (56), PandaDoc (54), Wrike (52), **RingCentral (52)**, Miro (47), Acronis (42), Aviasales (40), EXANTE (34), ABBYY (30), DataArt (29), Group-IB (26), Joom (21), Wirex (17), MacPaw (15), CodeSignal (11), Restream (8), Playrix (7), Replika (6), Revolut (6), Lokalise (5), WhiteBIT (4), Kaspersky (2), Picsart (1), Wallarm (1), Wargaming (1).

Plus a few not yet ingested (`nginx`, `plesk`, `grammarly`, `parallels`, `bitfury`, `telegram`) listed so they tag in automatically once their company enters the catalogue (unmatched entries just no-op + log).

## Changes

- `internal/collections/collections.go` — registry entry + `RussianRootsSlugs` (the source of truth).
- `web/src/lib/collections.ts` — hand-kept mirror (drives the `/collections` hub + `/jobs` facet pill).
- **No migration** — `jobs.collections` is a free `TEXT[]`.

`go build/vet`, `go test ./internal/collections/` (incl. the canonical-slug assertion) pass.

## Deploy

Full image rebuild (the slug list compiles into `cmd/import-collections`), then run `import-collections` (populates `companies.collections` → propagates to `jobs.collections`) and `reindex` to surface the facet — same as the original collections rollout.
