### PR TITLE
test(db): fix lifecycle test for denormalized companies.job_count

### DIFF
--- a/internal/db/job_lifecycle_integration_test.go
+++ b/internal/db/job_lifecycle_integration_test.go
@@ -164,6 +164,12 @@ func TestClosedJobsLeaveListSurfacesButResolveOnDetail(t *testing.T) {
 		t.Fatalf("company jobs must contain only the open job, got %d rows", len(byCompany))
 	}
 
+	// companies.job_count is denormalized: UpsertJob does not maintain it,
+	// cmd/recount-companies does. Recompute before asserting on the column.
+	if _, err := q.RecountCompanyJobCounts(ctx); err != nil {
+		t.Fatalf("recount company job counts: %v", err)
+	}
+
 	companies, err := q.ListCompanies(ctx, ListCompaniesParams{Search: "", Limit: 10, Offset: 0})
 	if err != nil {
 		t.Fatalf("list companies: %v", err)


### PR DESCRIPTION
## Why

CI has been red on `main` and every branch off it since #207 (e.g. runs for #209, #210, and PR #211). The failing test:

```
--- FAIL: TestClosedJobsLeaveListSurfacesButResolveOnDetail
    job_lifecycle_integration_test.go:172: company job_count must count only open jobs,
    got [{Slug:acme Name:Acme JobCount:0}]
```

## Root cause

#207 denormalized `companies.job_count` (migration 0025) — `ListCompanies` now reads the column and orders by it instead of `LEFT JOIN`-counting jobs on every request. The column is maintained out-of-band by `cmd/recount-companies`, **not** by `UpsertJob`.

The pre-existing `TestClosedJobsLeaveListSurfacesButResolveOnDetail` still asserted `ListCompanies()[0].JobCount == 1` immediately after `UpsertJob`, so it now reads the stale default `0`. #207 updated its own new tests but missed this older lifecycle test.

## Fix

Call `RecountCompanyJobCounts` before the assertion — same pattern as the dedicated `companies_job_count_integration_test.go` added in #207. One-line behavior change, test-only.

## Verification

```
go test -tags=integration -run TestClosedJobsLeaveListSurfacesButResolveOnDetail ./internal/db/ -v
--- PASS: TestClosedJobsLeaveListSurfacesButResolveOnDetail (5.11s)
```
