### PR TITLE
feat(sources): add Apple careers adapter

### DIFF
--- a/internal/sources/apple.go
+++ b/internal/sources/apple.go
@@ -1,0 +1,198 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// apple adapts Apple's public careers search API (jobs.apple.com/api/v1), a single-company
+// source with no per-tenant board id (boardless). The listing is a POST to /api/v1/search,
+// paged 20 at a time (the page size is server-fixed; a larger request is ignored). Its
+// results carry only a generic team summary, so each posting's role-specific description
+// comes from a /api/v1/jobDetails/<positionId> GET, fanned out under a bounded worker pool
+// like the other detail adapters.
+//
+// Two non-obvious API facts, both learned from the live endpoint:
+//   - The request body's filters object is REQUIRED even when empty. Omitting it makes the
+//     API reject the body with HTTP 436 ("jobsite.general.serviceError"), so an empty
+//     filters:{} is always sent. No CSRF token or session cookie is needed.
+//   - The listing returns one row per (position, location), so a multi-location role recurs
+//     under the same positionId across the result set; it is deduped to one job before the
+//     detail fan-out so its detail is fetched once.
+type apple struct {
+	http appleHTTP
+}
+
+// appleHTTP is the transport apple needs: a JSON POST for the paged listing and a JSON GET
+// for each posting's detail.
+type appleHTTP interface {
+	JSONPoster
+	JSONGetter
+}
+
+const (
+	appleSearchURL = "https://jobs.apple.com/api/v1/search"
+	appleDetailURL = "https://jobs.apple.com/api/v1/jobDetails/%s?locale=" + appleLocale
+	appleJobURL    = "https://jobs.apple.com/" + appleLocale + "/details/%s/%s"
+	// appleLocale is the single locale crawled; the en-us catalogue is the global superset.
+	appleLocale = "en-us"
+)
+
+// NewApple builds the Apple careers adapter over the given HTTP client.
+func NewApple(c appleHTTP) Source { return apple{http: c} }
+
+func (apple) Provider() string { return "apple" }
+
+// apple is single-company, so its config entries carry no board.
+func (apple) boardless() {}
+
+// appleLocation is one location on a posting; name is the human display string.
+type appleLocation struct {
+	Name string `json:"name"`
+}
+
+// applePosting is one result from the search listing. positionId is the stable id used for
+// the detail fetch, the public URL, and the dedup key; the rich, role-specific description
+// is NOT here — it comes from the detail fetch.
+type applePosting struct {
+	PositionID    string          `json:"positionId"`
+	PostingTitle  string          `json:"postingTitle"`
+	Slug          string          `json:"transformedPostingTitle"`
+	Locations     []appleLocation `json:"locations"`
+	PostDateInGMT string          `json:"postDateInGMT"`
+	HomeOffice    bool            `json:"homeOffice"`
+}
+
+// appleSearchResponse wraps the search listing payload; every response nests its body under
+// "res".
+type appleSearchResponse struct {
+	Res struct {
+		SearchResults []applePosting `json:"searchResults"`
+		TotalRecords  int            `json:"totalRecords"`
+	} `json:"res"`
+}
+
+func (s apple) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	postings, err := s.list(ctx)
+	if err != nil {
+		return nil, err
+	}
+	postings = dedupApplePostings(postings)
+	return fetchDetails(postings, defaultDetailWorkers, func(p applePosting) (Job, bool) {
+		return s.detail(ctx, e, p)
+	}), nil
+}
+
+// list pages /api/v1/search until a page comes back empty or the catalogue total is reached.
+func (s apple) list(ctx context.Context) ([]applePosting, error) {
+	var postings []applePosting
+	for page := 1; ; page++ {
+		var resp appleSearchResponse
+		if err := s.http.PostJSON(ctx, appleSearchURL, appleSearchBody(page), &resp); err != nil {
+			return nil, fmt.Errorf("apple: list page %d: %w", page, err)
+		}
+		results := resp.Res.SearchResults
+		if len(results) == 0 {
+			break
+		}
+		postings = append(postings, results...)
+		if resp.Res.TotalRecords > 0 && len(postings) >= resp.Res.TotalRecords {
+			break
+		}
+	}
+	return postings, nil
+}
+
+// appleSearchBody is the search request for one page. filters is sent as an empty object
+// because the API rejects a body without it (see the type comment); format mirrors what the
+// site sends and governs the human-readable date strings (which the adapter ignores).
+func appleSearchBody(page int) map[string]any {
+	return map[string]any{
+		"query":   "",
+		"filters": map[string]any{},
+		"page":    page,
+		"locale":  appleLocale,
+		"sort":    "newest",
+		"format": map[string]string{
+			"longDate":   "MMMM D, YYYY",
+			"mediumDate": "MMM D, YYYY",
+		},
+	}
+}
+
+// detail fetches one posting's jobDetails and maps it to a Job, returning ok=false when the
+// request fails or the posting has no id/description so the caller skips just that posting.
+func (s apple) detail(ctx context.Context, e CompanyEntry, p applePosting) (Job, bool) {
+	if p.PositionID == "" {
+		return Job{}, false
+	}
+	var resp struct {
+		Res struct {
+			Description             string `json:"description"`
+			MinimumQualifications   string `json:"minimumQualifications"`
+			PreferredQualifications string `json:"preferredQualifications"`
+		} `json:"res"`
+	}
+	if err := s.http.GetJSON(ctx, fmt.Sprintf(appleDetailURL, p.PositionID), &resp); err != nil {
+		return Job{}, false
+	}
+	desc := appleDescription(resp.Res.Description, resp.Res.MinimumQualifications, resp.Res.PreferredQualifications)
+	if desc == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  p.PositionID,
+		URL:         fmt.Sprintf(appleJobURL, p.PositionID, p.Slug),
+		Title:       strings.TrimSpace(p.PostingTitle),
+		Company:     e.Company,
+		Location:    appleLocationString(p.Locations),
+		Description: desc,
+		Remote:      p.HomeOffice,
+		WorkMode:    workModeFromRemote(p.HomeOffice),
+		PostedAt:    parseRFC3339(p.PostDateInGMT),
+	}, true
+}
+
+// dedupApplePostings keeps the first posting per positionId, preserving listing order, so a
+// multi-location role (which recurs once per location) is fetched and stored once.
+func dedupApplePostings(in []applePosting) []applePosting {
+	seen := make(map[string]bool, len(in))
+	out := make([]applePosting, 0, len(in))
+	for _, p := range in {
+		if p.PositionID == "" || seen[p.PositionID] {
+			continue
+		}
+		seen[p.PositionID] = true
+		out = append(out, p)
+	}
+	return out
+}
+
+// appleLocationString joins a posting's location display names with "; ", skipping blanks.
+func appleLocationString(locs []appleLocation) string {
+	names := make([]string, 0, len(locs))
+	for _, l := range locs {
+		if n := strings.TrimSpace(l.Name); n != "" {
+			names = append(names, n)
+		}
+	}
+	return strings.Join(names, "; ")
+}
+
+// appleDescription assembles the role's full description from the detail fields. Apple serves
+// these as plain text (no markup), so they are joined with blank lines under their section
+// headers rather than HTML-sanitized; an empty section is omitted.
+func appleDescription(description, minQual, prefQual string) string {
+	parts := make([]string, 0, 3)
+	if d := strings.TrimSpace(description); d != "" {
+		parts = append(parts, d)
+	}
+	if m := strings.TrimSpace(minQual); m != "" {
+		parts = append(parts, "Minimum Qualifications\n"+m)
+	}
+	if p := strings.TrimSpace(prefQual); p != "" {
+		parts = append(parts, "Preferred Qualifications\n"+p)
+	}
+	return strings.Join(parts, "\n\n")
+}

--- a/internal/sources/apple_test.go
+++ b/internal/sources/apple_test.go
@@ -1,0 +1,182 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// appleFake is a test transport for the Apple adapter: the listing is a POST whose page
+// number drives the canned search response, and each posting's detail is a GET keyed by the
+// positionId in the URL. An unrequested page returns an empty result set (the natural
+// end-of-list response that stops pagination); an unknown detail id returns an empty body.
+type appleFake struct {
+	pages     map[int]string    // search page -> /api/v1/search response JSON
+	details   map[string]string // positionId -> /api/v1/jobDetails response JSON
+	postFail  bool
+	postCalls int
+	getURLs   []string
+}
+
+var appleDetailRE = regexp.MustCompile(`jobDetails/([^?]+)`)
+
+func (f *appleFake) PostJSON(_ context.Context, _ string, body, v any) error {
+	f.postCalls++
+	if f.postFail {
+		return errors.New("appleFake: boom")
+	}
+	page, _ := body.(map[string]any)["page"].(int)
+	raw, ok := f.pages[page]
+	if !ok {
+		raw = `{"res":{"searchResults":[],"totalRecords":0}}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func (f *appleFake) GetJSON(_ context.Context, url string, v any) error {
+	f.getURLs = append(f.getURLs, url)
+	id := ""
+	if m := appleDetailRE.FindStringSubmatch(url); m != nil {
+		id = m[1]
+	}
+	raw, ok := f.details[id]
+	if !ok {
+		raw = `{"res":{}}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestAppleProvider(t *testing.T) {
+	if got := NewApple(nil).Provider(); got != "apple" {
+		t.Errorf("Provider() = %q, want %q", got, "apple")
+	}
+}
+
+func TestAppleFetchPaginatesDedupsAndMaps(t *testing.T) {
+	fake := &appleFake{
+		pages: map[int]string{
+			1: `{"res":{"totalRecords":3,"searchResults":[
+				{"positionId":"200600664","postingTitle":"Software Engineer, Watch Software","transformedPostingTitle":"software-engineer-watch-software","postDateInGMT":"2025-12-02T08:30:00.000Z","homeOffice":false,"locations":[{"name":"San Diego"}]},
+				{"positionId":"200600664","postingTitle":"Software Engineer, Watch Software","transformedPostingTitle":"software-engineer-watch-software","postDateInGMT":"2025-12-02T08:30:00.000Z","homeOffice":false,"locations":[{"name":"Cupertino"}]}
+			]}}`,
+			2: `{"res":{"totalRecords":3,"searchResults":[
+				{"positionId":"200659431","postingTitle":"Site Reliability Engineer","transformedPostingTitle":"site-reliability-engineer","postDateInGMT":"2026-04-22T14:44:56.003755186Z","homeOffice":true,"locations":[{"name":"Seattle"}]}
+			]}}`,
+		},
+		details: map[string]string{
+			"200600664": `{"res":{"description":"Build the Watch software.","minimumQualifications":"5+ years experience.","preferredQualifications":"Swift expertise."}}`,
+			"200659431": `{"res":{"description":"Keep services running.","minimumQualifications":"","preferredQualifications":""}}`,
+		},
+	}
+
+	jobs, err := NewApple(fake).Fetch(context.Background(), CompanyEntry{Company: "Apple", Provider: "apple"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// Three listing rows but only two distinct positionIds: the multi-location role is
+	// deduped to one job and its detail fetched once.
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (deduped by positionId)", len(jobs))
+	}
+	if n := len(fake.getURLs); n != 2 {
+		t.Errorf("detail fetched %d times, want 2 (one per distinct position)", n)
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j := byID["200600664"]
+	if j.Title != "Software Engineer, Watch Software" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Apple" {
+		t.Errorf("Company = %q, want Apple", j.Company)
+	}
+	if want := "https://jobs.apple.com/en-us/details/200600664/software-engineer-watch-software"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if want := "San Diego"; j.Location != want {
+		t.Errorf("Location = %q, want first-seen %q", j.Location, want)
+	}
+	for _, part := range []string{"Build the Watch software.", "5+ years experience.", "Swift expertise."} {
+		if !strings.Contains(j.Description, part) {
+			t.Errorf("Description missing %q: %q", part, j.Description)
+		}
+	}
+	if j.Remote || j.WorkMode != "" {
+		t.Errorf("homeOffice=false should be onsite-unknown, got Remote=%v WorkMode=%q", j.Remote, j.WorkMode)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2025, 12, 2, 8, 30, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2025-12-02T08:30:00Z", j.PostedAt)
+	}
+
+	r := byID["200659431"]
+	if !r.Remote || r.WorkMode != "remote" {
+		t.Errorf("homeOffice=true should map to remote, got Remote=%v WorkMode=%q", r.Remote, r.WorkMode)
+	}
+	if r.PostedAt == nil || !r.PostedAt.Equal(time.Date(2026, 4, 22, 14, 44, 56, 3755186, time.UTC)) {
+		t.Errorf("PostedAt = %v, want the nanosecond RFC3339 value parsed", r.PostedAt)
+	}
+}
+
+func TestAppleStopsAtEmptyPage(t *testing.T) {
+	// totalRecords claims 9 but page 2 is empty: the adapter must stop on the empty page
+	// rather than loop forever chasing the count.
+	fake := &appleFake{
+		pages: map[int]string{
+			1: `{"res":{"totalRecords":9,"searchResults":[
+				{"positionId":"1","postingTitle":"Only","transformedPostingTitle":"only","postDateInGMT":"","homeOffice":false,"locations":[{"name":"Remote"}]}
+			]}}`,
+		},
+		details: map[string]string{"1": `{"res":{"description":"x"}}`},
+	}
+	jobs, err := NewApple(fake).Fetch(context.Background(), CompanyEntry{Company: "Apple"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (stop at empty page)", len(jobs))
+	}
+}
+
+func TestAppleSkipsPostingWithoutDescription(t *testing.T) {
+	// A posting whose detail carries no description is dropped (ok=false), not emitted blank.
+	fake := &appleFake{
+		pages: map[int]string{
+			1: `{"res":{"totalRecords":1,"searchResults":[
+				{"positionId":"42","postingTitle":"Ghost","transformedPostingTitle":"ghost","postDateInGMT":"","homeOffice":false,"locations":[{"name":"Cupertino"}]}
+			]}}`,
+		},
+		details: map[string]string{"42": `{"res":{"description":""}}`},
+	}
+	jobs, err := NewApple(fake).Fetch(context.Background(), CompanyEntry{Company: "Apple"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (no description -> dropped)", len(jobs))
+	}
+}
+
+func TestAppleTransportErrorFailsBoard(t *testing.T) {
+	fake := &appleFake{postFail: true}
+	if _, err := NewApple(fake).Fetch(context.Background(), CompanyEntry{Company: "Apple"}); err == nil {
+		t.Fatal("Fetch: want transport error, got nil")
+	}
+}
+
+func TestAppleRegisteredInAllAndBoardless(t *testing.T) {
+	s, ok := All(nil)["apple"]
+	if !ok {
+		t.Fatal(`All(nil)["apple"] missing`)
+	}
+	if _, isBoardless := s.(boardless); !isBoardless {
+		t.Error("apple should be boardless (single company, no board id)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -157,6 +157,7 @@ func All(c HTTPClient) map[string]Source {
 		NewUber(c),
 		NewAmazon(c),
 		NewGoogle(c),
+		NewApple(c),
 		NewLumenalta(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -17,6 +17,8 @@
   provider: amazon
 - company: Google
   provider: google
+- company: Apple
+  provider: apple
 - company: Lumenalta
   provider: lumenalta
 - company: Telegram


### PR DESCRIPTION
## What

Adds a boardless single-company source adapter for **Apple** careers (`jobs.apple.com/api/v1`), alongside the existing bigtech adapters (Uber/Amazon/Google/Microsoft).

## How it works (verified against the live API)

- **List:** `POST /api/v1/search` with body `{"query":"","filters":{},"page":N,"locale":"en-us","sort":"newest","format":{…}}` → `{"res":{"searchResults":[…],"totalRecords":6495}}`. Page size is server-fixed at 20.
- **Detail:** `GET /api/v1/jobDetails/<positionId>?locale=en-us` → role-specific `description` + `minimum`/`preferredQualifications` (plain text). The listing's `jobSummary` is generic team boilerplate, so each posting needs a detail fetch (shared bounded pool, like SuccessFactors/Phenom).
- No CSRF token, session cookie, or headless browser needed.

### Gotcha worth knowing
Omitting `filters` from the request body makes the API answer **HTTP 436** with `{"error":"jobsite.general.serviceError"}`. That is an *application-level* rejection, **not** an Akamai bot-block (a real edge block is HTML from `errors.edgesuite.net`, which the dead legacy `/api/role/search` returns). Sending an empty `filters:{}` is all that's required.

The listing returns one row per (position, location), so a multi-location role recurs under one `positionId`; the adapter dedups by `positionId` before the detail fan-out so each role is fetched and stored once.

## Scope
Ingests all postings (REQ concrete openings + PIPE evergreen talent-pipeline roles).

## Changes
- `internal/sources/apple.go` — the adapter
- `internal/sources/apple_test.go` — pagination, multi-location dedup, drop-on-no-description, RFC3339(ns) date parse, remote mapping, registry/boardless
- `internal/sources/source.go` — `NewApple(c)` in `sources.All`
- `sources/custom.yml` — `company: Apple / provider: apple`

## Verification
- `go build ./...`, `go vet`, `gofmt -l` clean
- `go test ./internal/sources/` green
- Live smoke against the real API: `totalRecords=6495`, real postings map correctly (title, location, remote, `postedAt`, 2k–3k-char descriptions, valid URLs)

## Deploy note
New adapter compiles into the existing `ingest` binary (no Dockerfile change). Apple lives in `custom.yml`, so the existing `custom.yml` ingest cron picks it up — no new cron needed.