### PR TITLE
fix(sources): hold Apple out of the ingest crawl (prod ingest hang)

### DIFF
--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -17,8 +17,11 @@
   provider: amazon
 - company: Google
   provider: google
-- company: Apple
-  provider: apple
+# Apple (provider: apple) is held out of the crawl: the adapter works (verified by
+# curl from the prod host — search/detail both 200), but a full ingest run hangs in
+# the detail-fetch phase from the prod host (the Go client stalls under sustained load
+# while serial curl does not — root cause still under investigation). Re-add this entry
+# once the hang is fixed; the adapter stays registered in sources.All meanwhile.
 - company: Lumenalta
   provider: lumenalta
 - company: Telegram


### PR DESCRIPTION
Holds the `Apple` entry out of `sources/custom.yml` because a full ingest run **hangs in the detail-fetch phase from the prod host**.

## Evidence
- The adapter is correct: unit tests pass, and a live smoke (residential IP) maps real postings fine.
- **From the prod host**, serial curl works perfectly: 150× search @ ~0.53s (keep-alive *and* new-connection), 20× detail @ ~1.8s — zero non-200, zero slow. So Apple does **not** rate-limit/block the prod IP.
- But the Go ingest container stalls mid-crawl (NET flat, CPU 0, no timeout error, `http.Client.Timeout=15s` not firing) and never completes — holding the custom flock so the hourly cron would hang every run.

## This change
Removes only the `Apple` board entry (with an explaining comment). The adapter (`internal/sources/apple.go`) stays registered in `sources.All`, so re-enabling once the hang is root-caused is a one-line revert.

## Follow-up
Debug the runtime hang with a Go harness from the prod host (request-level logging, likely the SSRF-guarded transport / detail fan-out interaction); consider listing-only mode and request pacing.