### PR TITLE
feat(sources): give Apple its own board file on a daily slot

### DIFF
--- a/sources/apple.yml
+++ b/sources/apple.yml
@@ -1,0 +1,7 @@
+# Apple (jobs.apple.com). Boardless: one careers API (provider: apple), so the entry
+# carries no board. Kept in its own file — not in custom.yml — because the adapter fetches
+# each posting's full description from a per-job detail endpoint, so a full crawl of the
+# ~6.5k listing rows (~5k unique roles) takes ~30 min. It runs on its own daily cron slot
+# so its long crawl never blocks the small single-company boards in custom.yml.
+- company: Apple
+  provider: apple

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -17,11 +17,9 @@
   provider: amazon
 - company: Google
   provider: google
-# Apple (provider: apple) is held out of the crawl: the adapter works (verified by
-# curl from the prod host — search/detail both 200), but a full ingest run hangs in
-# the detail-fetch phase from the prod host (the Go client stalls under sustained load
-# while serial curl does not — root cause still under investigation). Re-add this entry
-# once the hang is fixed; the adapter stays registered in sources.All meanwhile.
+# Apple (provider: apple) lives in its own sources/apple.yml on a daily cron slot: its
+# per-posting detail fan-out makes a full crawl ~30 min, too slow to share this hourly
+# custom slot (it would block the small providers below and overrun the hour).
 - company: Lumenalta
   provider: lumenalta
 - company: Telegram


### PR DESCRIPTION
Re-enables Apple ingest (paused in #218) the right way, after root-causing the earlier "hang".

## Root cause (it was never a hang)
A full Apple crawl is **slow, not stuck**: the adapter fetches each posting's full description from a per-job detail endpoint (~1.8s each from the prod host), so ~5k unique roles at 8-way concurrency take **~30 min**. Verified end-to-end **from the prod host**: `ingest done: ingested=5036 failed=0 skipped=0`, 5036 Apple jobs in the prod DB.

The earlier "hang" diagnosis was wrong: `docker stats` rounds NET to 3 sig-figs, so Apple's slow progress (~25 kB/s) was invisible against the ~260 MB run-total, and the container got killed prematurely. With an isolated (from-zero) NET sample the progress is plainly steady.

## Change
- New `sources/apple.yml` (boardless, one entry) — Apple gets its own file like the other large/slow boards.
- Remove Apple from `sources/custom.yml` (a 30-min board in the shared hourly slot would block the small single-company boards and overrun the hour).
- Deployed with a dedicated **daily** cron slot (`10 2 * * *`).

No adapter code change — `internal/sources/apple.go` (from #216) already works in prod.