### PR TITLE
feat(sources): add getmatch.ru marketplace adapter

### DIFF
--- a/internal/sources/getmatch.go
+++ b/internal/sources/getmatch.go
@@ -1,0 +1,165 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// getmatch adapts getmatch.ru, a curated Russian IT job marketplace. Its public, keyless feed
+// (/api/offers) returns a paginated list where every offer carries its own employer, so one
+// paged crawl assembles every Job — but the list description is a short summary, so each offer
+// is enriched from the per-offer detail endpoint (/api/offers/{id}) for the full HTML body.
+// Unlike a single-company adapter, the company comes from the offer (the marketplace lists many
+// employers), so its boardless config entry's company is only a validation placeholder.
+type getmatch struct {
+	http JSONGetter
+}
+
+const (
+	getmatchBaseURL   = "https://getmatch.ru"
+	getmatchListURL   = "https://getmatch.ru/api/offers?offset=%d&limit=%d"
+	getmatchDetailURL = "https://getmatch.ru/api/offers/%d"
+	getmatchPageLimit = 100
+	// getmatchMaxPages bounds pagination so a wrong or missing meta.total cannot loop.
+	getmatchMaxPages = 200
+	// getmatchDateLayout matches the zone-less published_at getmatch emits
+	// ("2026-06-19T12:55:17.948391"). The .9 fractional form parses any sub-second width.
+	getmatchDateLayout = "2006-01-02T15:04:05.999999999"
+)
+
+// NewGetmatch builds the getmatch adapter over the given HTTP client.
+func NewGetmatch(c JSONGetter) Source { return getmatch{http: c} }
+
+func (getmatch) Provider() string { return "getmatch" }
+
+// getmatch is a marketplace with one global feed, so its config entries carry no board.
+func (getmatch) boardless() {}
+
+// getmatch aggregates postings from many companies, so it stays in the source facet.
+func (getmatch) aggregator() {}
+
+// getmatchListResponse is the /api/offers page: Meta.Total is the catalogue size used to stop
+// pagination; Offers is the page.
+type getmatchListResponse struct {
+	Meta struct {
+		Total int `json:"total"`
+	} `json:"meta"`
+	Offers []getmatchOffer `json:"offers"`
+}
+
+// getmatchOffer is one posting. Company nests the employer's own name (the marketplace lists
+// many employers); OfferDescription is the list summary and Description the full detail body.
+type getmatchOffer struct {
+	ID               int    `json:"id"`
+	Position         string `json:"position"`
+	URL              string `json:"url"`
+	PublishedAt      string `json:"published_at"`
+	OfferDescription string `json:"offer_description"`
+	Description      string `json:"description"`
+	Company          struct {
+		Name string `json:"name"`
+	} `json:"company"`
+	LocationItems []getmatchLocation `json:"location_items"`
+}
+
+// getmatchLocation is one of an offer's locations: a display Label and a Format that is either
+// a work mode (remote/hybrid/office) or a relocation flag (relocation_company/_candidate).
+type getmatchLocation struct {
+	Label  string `json:"label"`
+	Format string `json:"format"`
+}
+
+func (g getmatch) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 0; page < getmatchMaxPages; page++ {
+		offset := page * getmatchPageLimit
+		var resp getmatchListResponse
+		if err := g.http.GetJSON(ctx, fmt.Sprintf(getmatchListURL, offset, getmatchPageLimit), &resp); err != nil {
+			if offset == 0 {
+				return nil, fmt.Errorf("getmatch: list offset %d: %w", offset, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		if len(resp.Offers) == 0 {
+			break
+		}
+		for _, o := range resp.Offers {
+			jobs = append(jobs, g.toJob(ctx, o))
+		}
+		if resp.Meta.Total > 0 && offset+getmatchPageLimit >= resp.Meta.Total {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an offer to a Job. The company is the offer's own employer, not the configured
+// entry; the work mode is structured only when the offer's locations agree on one (see
+// getmatchWorkMode).
+func (g getmatch) toJob(ctx context.Context, o getmatchOffer) Job {
+	mode := getmatchWorkMode(o.LocationItems)
+	return Job{
+		ExternalID:  strconv.Itoa(o.ID),
+		URL:         getmatchBaseURL + o.URL,
+		Title:       o.Position,
+		Company:     o.Company.Name,
+		Description: sanitizeHTML(g.description(ctx, o)),
+		Location:    getmatchLocationString(o.LocationItems),
+		Remote:      mode == "remote",
+		WorkMode:    mode,
+		PostedAt:    parseLayout(getmatchDateLayout, o.PublishedAt),
+	}
+}
+
+// description returns the offer's full HTML body from the detail endpoint, falling back to the
+// list summary when the detail body is empty (e.g. event cards) or its request fails, so an
+// offer is never dropped over a missing description.
+func (g getmatch) description(ctx context.Context, o getmatchOffer) string {
+	var detail getmatchOffer
+	if err := g.http.GetJSON(ctx, fmt.Sprintf(getmatchDetailURL, o.ID), &detail); err == nil {
+		if strings.TrimSpace(detail.Description) != "" {
+			return detail.Description
+		}
+	}
+	return o.OfferDescription
+}
+
+// getmatchWorkMode derives the structured work mode from the offer's location formats, mapping
+// remote/hybrid/office via the shared workplaceTypeMode (which yields "" for the relocation
+// flags, so they are ignored). It returns a mode only when the offer's locations resolve to a
+// single distinct one; a mix (or none) yields "" so the pipeline's location parser decides.
+func getmatchWorkMode(items []getmatchLocation) string {
+	var mode string
+	for _, it := range items {
+		m := workplaceTypeMode(it.Format)
+		if m == "" {
+			continue
+		}
+		if mode == "" {
+			mode = m
+		} else if mode != m {
+			return ""
+		}
+	}
+	return mode
+}
+
+// getmatchLocationString joins an offer's distinct location labels in order.
+func getmatchLocationString(items []getmatchLocation) string {
+	var labels []string
+	seen := map[string]struct{}{}
+	for _, it := range items {
+		l := strings.TrimSpace(it.Label)
+		if l == "" {
+			continue
+		}
+		if _, ok := seen[l]; ok {
+			continue
+		}
+		seen[l] = struct{}{}
+		labels = append(labels, l)
+	}
+	return strings.Join(labels, ", ")
+}

--- a/internal/sources/getmatch_test.go
+++ b/internal/sources/getmatch_test.go
@@ -1,0 +1,247 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// getmatchHTTP is a route-aware test JSONGetter. getmatch has two endpoints: a paged list
+// (/api/offers?offset=) and a per-offer detail (/api/offers/{id}). This fake routes detail
+// requests by the id in the path and list requests by the offset query parameter, recording
+// both so a test can assert pagination stops at meta.total and a detail is fetched per offer.
+type getmatchHTTP struct {
+	pages      map[int]string // list body keyed by requested offset
+	details    map[int]string // detail body keyed by offer id
+	failList   bool           // every list request fails
+	failPage   map[int]bool   // a specific offset's list request fails
+	detailErr  map[int]bool   // a specific offer's detail request fails
+	gotOffsets []int
+	gotDetails []int
+}
+
+var (
+	getmatchDetailRE = regexp.MustCompile(`/api/offers/(\d+)`)
+	getmatchOffsetRE = regexp.MustCompile(`offset=(\d+)`)
+)
+
+func (f *getmatchHTTP) GetJSON(_ context.Context, url string, v any) error {
+	if m := getmatchDetailRE.FindStringSubmatch(url); m != nil {
+		id, _ := strconv.Atoi(m[1])
+		f.gotDetails = append(f.gotDetails, id)
+		if f.detailErr[id] {
+			return errors.New("getmatchHTTP: detail boom")
+		}
+		raw, ok := f.details[id]
+		if !ok {
+			return errors.New("getmatchHTTP: no detail for id")
+		}
+		return json.Unmarshal([]byte(raw), v)
+	}
+	offset := 0
+	if m := getmatchOffsetRE.FindStringSubmatch(url); m != nil {
+		offset, _ = strconv.Atoi(m[1])
+	}
+	f.gotOffsets = append(f.gotOffsets, offset)
+	if f.failList || f.failPage[offset] {
+		return errors.New("getmatchHTTP: list boom")
+	}
+	raw, ok := f.pages[offset]
+	if !ok {
+		raw = `{"meta":{"total":0,"offset":0,"limit":100},"offers":[]}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestGetmatchProvider(t *testing.T) {
+	if got := NewGetmatch(nil).Provider(); got != "getmatch" {
+		t.Errorf("Provider() = %q, want %q", got, "getmatch")
+	}
+}
+
+func TestGetmatchFetchMapsOffer(t *testing.T) {
+	fake := &getmatchHTTP{
+		pages: map[int]string{0: `{"meta":{"total":1,"offset":0,"limit":100},"offers":[
+			{"id":34895,"position":"Senior Golang Developer","url":"/vacancies/34895-senior-golang",
+			 "published_at":"2026-06-19T12:55:17.948391","offer_description":"short summary",
+			 "company":{"name":"HR Prime"},
+			 "location_items":[{"label":"Москва","format":"office"},{"label":"Москва","format":"office"}]}
+		]}`},
+		details: map[int]string{34895: `{"id":34895,"description":"<h2>О компании</h2><p>Full body</p><script>x()</script>"}`},
+	}
+
+	jobs, err := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{Company: "getmatch", Provider: "getmatch"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "34895" {
+		t.Errorf("ExternalID = %q, want 34895", j.ExternalID)
+	}
+	if want := "https://getmatch.ru/vacancies/34895-senior-golang"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.Title != "Senior Golang Developer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	// The marketplace posting carries its OWN employer, not the configured placeholder.
+	if j.Company != "HR Prime" {
+		t.Errorf("Company = %q, want HR Prime (per-offer, not the entry's getmatch)", j.Company)
+	}
+	// Full HTML comes from the detail endpoint, sanitized (script stripped).
+	if !strings.Contains(j.Description, "Full body") || strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not detail-sourced+sanitized: %q", j.Description)
+	}
+	// A single distinct work mode (office) → onsite; not remote.
+	if j.WorkMode != "onsite" || j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want onsite/false", j.WorkMode, j.Remote)
+	}
+	if want := "Москва"; j.Location != want {
+		t.Errorf("Location = %q, want %q (distinct labels joined)", j.Location, want)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 19, 12, 55, 17, 948391000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-19T12:55:17.948391 (no-tz layout)", j.PostedAt)
+	}
+}
+
+func TestGetmatchWorkMode(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []getmatchLocation
+		want  string
+	}{
+		{"single remote", []getmatchLocation{{Format: "remote"}}, "remote"},
+		{"all hybrid", []getmatchLocation{{Format: "hybrid"}, {Format: "hybrid"}}, "hybrid"},
+		{"all office", []getmatchLocation{{Format: "office"}}, "onsite"},
+		{"mixed remote+office", []getmatchLocation{{Format: "remote"}, {Format: "office"}}, ""},
+		{"office plus relocation flags only", []getmatchLocation{
+			{Format: "office"}, {Format: "relocation_company"}, {Format: "relocation_candidate"}}, "onsite"},
+		{"relocation only", []getmatchLocation{{Format: "relocation_company"}}, ""},
+		{"none", nil, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getmatchWorkMode(tc.items); got != tc.want {
+				t.Errorf("getmatchWorkMode = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetmatchRemoteFlagSetOnlyForRemote(t *testing.T) {
+	fake := &getmatchHTTP{
+		pages: map[int]string{0: `{"meta":{"total":1,"offset":0,"limit":100},"offers":[
+			{"id":1,"position":"Remote Eng","url":"/vacancies/1-x","company":{"name":"Acme"},
+			 "offer_description":"x","location_items":[{"label":"Россия","format":"remote"}]}
+		]}`},
+		details: map[int]string{1: `{"id":1,"description":"<p>body</p>"}`},
+	}
+	jobs, _ := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{})
+	if len(jobs) != 1 || jobs[0].WorkMode != "remote" || !jobs[0].Remote {
+		t.Fatalf("remote offer: WorkMode=%q Remote=%v, want remote/true", jobs[0].WorkMode, jobs[0].Remote)
+	}
+}
+
+func TestGetmatchDescriptionFallback(t *testing.T) {
+	fake := &getmatchHTTP{
+		pages: map[int]string{0: `{"meta":{"total":2,"offset":0,"limit":100},"offers":[
+			{"id":10,"position":"Empty detail","url":"/vacancies/10-x","company":{"name":"A"},
+			 "offer_description":"<p>summary ten</p>","location_items":[{"label":"X","format":"remote"}]},
+			{"id":11,"position":"Detail errors","url":"/vacancies/11-y","company":{"name":"B"},
+			 "offer_description":"<p>summary eleven</p>","location_items":[{"label":"Y","format":"remote"}]}
+		]}`},
+		details:   map[int]string{10: `{"id":10,"description":""}`},
+		detailErr: map[int]bool{11: true},
+	}
+	jobs, err := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	// Empty detail description → fall back to the list offer_description.
+	if !strings.Contains(byID["10"].Description, "summary ten") {
+		t.Errorf("id 10 description = %q, want fallback to offer_description", byID["10"].Description)
+	}
+	// A failed detail request → also fall back, never drop the offer.
+	if _, ok := byID["11"]; !ok {
+		t.Fatal("id 11 dropped on detail error, want it kept via fallback")
+	}
+	if !strings.Contains(byID["11"].Description, "summary eleven") {
+		t.Errorf("id 11 description = %q, want fallback to offer_description", byID["11"].Description)
+	}
+}
+
+func TestGetmatchPaginatesAndStopsAtTotal(t *testing.T) {
+	// total=150 with a 100 page size: offsets 0 and 100 are fetched, then 100+100>=150 stops.
+	page := func(id int) string {
+		return `{"meta":{"total":150,"offset":0,"limit":100},"offers":[
+			{"id":` + strconv.Itoa(id) + `,"position":"P","url":"/vacancies/x","company":{"name":"C"},
+			 "offer_description":"d","location_items":[{"label":"L","format":"remote"}]}]}`
+	}
+	fake := &getmatchHTTP{
+		pages:   map[int]string{0: page(1), 100: page(2)},
+		details: map[int]string{1: `{"description":"<p>a</p>"}`, 2: `{"description":"<p>b</p>"}`},
+	}
+	jobs, err := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (two pages)", len(jobs))
+	}
+	if !slices.Equal(fake.gotOffsets, []int{0, 100}) {
+		t.Errorf("fetched offsets = %v, want [0 100] (stop at total)", fake.gotOffsets)
+	}
+}
+
+func TestGetmatchFirstPageErrorFailsBoard(t *testing.T) {
+	fake := &getmatchHTTP{failList: true}
+	if _, err := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("Fetch: want first-page error, got nil")
+	}
+}
+
+func TestGetmatchLaterPageErrorEndsEnumeration(t *testing.T) {
+	fake := &getmatchHTTP{
+		pages: map[int]string{0: `{"meta":{"total":150,"offset":0,"limit":100},"offers":[
+			{"id":1,"position":"P","url":"/vacancies/x","company":{"name":"C"},
+			 "offer_description":"d","location_items":[{"label":"L","format":"remote"}]}]}`},
+		details:  map[int]string{1: `{"description":"<p>a</p>"}`},
+		failPage: map[int]bool{100: true},
+	}
+	jobs, err := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: want no error on later-page failure, got %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (gathered before the failing page)", len(jobs))
+	}
+}
+
+func TestGetmatchRegisteredInAllAndBoardless(t *testing.T) {
+	s, ok := All(nil)["getmatch"]
+	if !ok {
+		t.Fatal(`All(nil)["getmatch"] missing`)
+	}
+	if _, isBoardless := s.(boardless); !isBoardless {
+		t.Error("getmatch should be boardless (one global feed, no board id)")
+	}
+	if _, isAggregator := s.(aggregator); !isAggregator {
+		t.Error("getmatch should be an aggregator (multi-company marketplace)")
+	}
+	if !slices.Contains(FilterableProviders(), "getmatch") {
+		t.Error("FilterableProviders() should include the getmatch aggregator")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -141,6 +141,7 @@ func All(c HTTPClient) map[string]Source {
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
+		NewGetmatch(c),
 		NewWorkAtAStartup(c),
 		NewJobStash(c),
 		NewArbeitnow(c),

--- a/openspec/changes/add-getmatch-source/.openspec.yaml
+++ b/openspec/changes/add-getmatch-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-getmatch-source/design.md
+++ b/openspec/changes/add-getmatch-source/design.md
@@ -1,0 +1,93 @@
+## Context
+
+getmatch.ru is a Next.js IT job marketplace. Its public listing (`/vacancies`) is backed by a
+keyless JSON API. A short reconnaissance established the surface:
+
+- `GET /api/offers?offset=N&limit=M` → `{ meta: {total, offset, limit}, offers: [...] }`.
+  `limit` defaults to 20; `total` was ~760 at survey time (755 `vacancy` + 5 `one_day_offer`).
+- `GET /api/offers/{id}` → the same offer object plus richer fields, notably `description`
+  (full HTML, ~1155 chars in the sample) vs the list's shorter `offer_description` (~459).
+- `GET /api/vacancies` → `401 {"detail":"Login required"}` — a personalized surface, not used.
+
+Each offer carries its own employer (`company.name`), so getmatch is a **marketplace
+aggregator**, not a single-company board. This matches the existing `tecla`/`jobstash`
+adapters: boardless, `aggregator()`-marked, with a placeholder company in the config entry.
+
+`location_items[]` gives a per-location `format` from the vocabulary observed across the full
+catalogue: `remote` (447), `hybrid` (609), `office` (124), `relocation_company` (77),
+`relocation_candidate` (6). 614/760 offers have a single distinct format; 146 mix two or three.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ingest getmatch.ru into the catalogue under `source = "getmatch"` via the existing pipeline,
+  with full HTML descriptions and a clean structured work mode where unambiguous.
+- Follow the established boardless-aggregator adapter pattern (tecla) so the change is one new
+  adapter file + one registry line + one board file, with no pipeline changes.
+
+**Non-Goals:**
+
+- Salary ingestion (no field in the raw `Job` shape; enrichment owns compensation).
+- Skill extraction from `skills_objects` (the project derives skills via `internal/skilltag`).
+- `StreamingSource` / incremental persistence (noted seam; the fan-out is moderate today).
+- Mapping department/specialization/seniority/team-size detail fields (classification is
+  derived deterministically downstream).
+
+## Decisions
+
+**1. Boardless aggregator, mirroring `tecla`.** getmatch lists many employers behind one feed,
+so the adapter implements `boardless()` (config entry needs no `board`) and `aggregator()` (it
+stays in the source facet, unlike a single-company boardless adapter). The `company` comes from
+each offer, not the config. *Alternative considered:* a board-per-company model — rejected, the
+API has no per-company board id and the feed is global.
+
+**2. Full description via per-offer detail fetch.** The list's `offer_description` is a short
+summary; the detail endpoint's `description` is the full HTML body. We fetch
+`/api/offers/{id}` per offer for the full text, since description quality drives both search and
+AI enrichment. *Alternative considered:* list-only (1 request/page, ~8 total) — rejected for
+the project's quality bar (tecla explicitly flags its truncated description as a downside). The
+cost is ~755 extra requests per crawl, which is acceptable for a once-and-exit cron worker.
+
+**3. Detail-description fallback.** Event cards (`one_day_offer`) carry their copy in
+`offer_description` and may have an empty detail `description`. The adapter prefers the detail
+`description` and falls back to the list `offer_description` when it is empty, so no posting is
+dropped and event cards still carry usable text. A failed *detail request* for one offer also
+falls back to the list summary rather than dropping the offer.
+
+**4. Structured work mode only when unambiguous.** `Job.WorkMode` carries structured signal
+only (never the location heuristic — that is the pipeline's job). We map the work-mode formats
+`remote→remote`, `hybrid→hybrid`, `office→onsite` and ignore the `relocation_*` flags (they are
+relocation support, orthogonal to work mode). We emit `WorkMode` only when the offer's locations
+resolve to a **single** distinct work mode; a mixed offer leaves it empty so the pipeline's
+location-string parser decides. *Alternative considered:* collapsing mixed remote+office to
+`hybrid` — rejected as an inference that would muddy the structured field's provenance.
+
+**5. Pagination by `meta.total` with a safety bound.** Page with `limit=100` and stop when
+`offset >= meta.total`, bounded by a `maxPages` constant so a bad/absent total cannot loop —
+the same guard `tecla` uses. A failed first page is a board error; a failed later page ends
+enumeration with what was gathered.
+
+## Risks / Trade-offs
+
+- **Per-crawl request volume (~755 detail fetches)** → Mitigated by the shared HTTP client's
+  rate limiting and the run-once-and-exit cron model; the `StreamingSource` seam is noted if it
+  later needs incremental persistence.
+- **API shape drift** (undocumented endpoint) → The adapter unmarshals only the fields it needs
+  and fails the board loudly on a list-decode error rather than silently emptying the catalogue;
+  the test pins the mapping against inline real-shaped JSON fixtures (mirroring `tecla_test.go`).
+- **HTML descriptions** → Run through the shared `sanitizeHTML` (active content stripped,
+  structure kept), as other HTML-yielding adapters do.
+- **Mixed-format offers lose a structured work mode (146/760)** → Accepted; the location-string
+  parser still derives a hint, and provenance stays clean.
+
+## Migration Plan
+
+Additive only — no schema or pipeline change. Deploy is a full image rebuild (new adapter
+compiled in) plus one cron schedule for `sources/getmatch.yml`. Rollback is removing the cron
+line and the registry entry; ingested rows are inert (`source = "getmatch"`) and soft-close
+naturally via the existing sweep if the crawl stops.
+
+## Open Questions
+
+None — the two scope decisions (full-description detail-fetch; include event cards) are settled.

--- a/openspec/changes/add-getmatch-source/proposal.md
+++ b/openspec/changes/add-getmatch-source/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+[getmatch.ru](https://getmatch.ru/vacancies) is a curated Russian IT job marketplace that
+publishes salaries up-front and aggregates ~760 active postings from many employers (X5, Т-Банк,
+VK, МегаФон, CIAN, Островок, …). We do not ingest it yet — it is a net-new coverage gap in the
+Russian-market segment we already serve (yandex, vk, tbank, sber, telegram).
+
+Its listing is backed by a **public, keyless JSON API**: `GET https://getmatch.ru/api/offers`
+returns a paginated (`offset`/`limit`) feed where every offer already carries its own employer,
+title, salary, locations (with a structured work-mode per location), and a short description. A
+companion detail endpoint `GET https://getmatch.ru/api/offers/{id}` adds the full HTML
+description. No headless browser, no private API, no auth (the `/api/vacancies` endpoint that
+demands login is a personalized surface — the public feed lives at `/api/offers`).
+
+## What Changes
+
+- Add a `getmatch` source adapter (`internal/sources/getmatch.go`) speaking the existing
+  `Source` interface, registered with one `NewGetmatch(c)` line in `sources.All`. Like
+  `tecla`/`jobstash` it is a **boardless aggregator** (`boardless()` + `aggregator()`): one
+  global feed, the employer comes from each posting, and the `sources/getmatch.yml` entry's
+  company is only a validation placeholder.
+- **Fetch**: paginate `GET https://getmatch.ru/api/offers?offset=N&limit=100` using
+  `meta.total` to stop (with a `maxPages` safety bound, as `tecla`). For each offer, issue a
+  detail request `GET https://getmatch.ru/api/offers/{id}` to obtain the full HTML
+  `description`, falling back to the list's short `offer_description` when the detail
+  description is empty (e.g. one-day-offer event cards).
+- **Field mapping** per offer:
+  - `ExternalID` = the numeric `id`.
+  - `URL` = `https://getmatch.ru` + the relative `url`.
+  - `Title` = `position`.
+  - `Company` = `company.name`.
+  - `Description` = `sanitizeHTML(detail.description)`, falling back to `offer_description`.
+  - `Location` = the distinct `location_items[].label` values, joined.
+  - `WorkMode` (structured) = derived from `location_items[].format`
+    (`remote`→`remote`, `hybrid`→`hybrid`, `office`→`onsite`; the `relocation_*` flags are
+    ignored as they are not work modes). Emitted **only when a single distinct work mode** is
+    present across the offer's locations; otherwise left empty so the pipeline's location-string
+    parser decides (keeping the structured field's provenance clean). `Remote` = `WorkMode ==
+    "remote"`.
+  - `PostedAt` = `published_at` (zone-less timestamp layout, as `tecla`).
+- Include all `offer_type` values (`vacancy` and the handful of `one_day_offer` event cards).
+- Add `sources/getmatch.yml` with one boardless placeholder entry, and a cron schedule for
+  `cmd/ingest sources/getmatch.yml` (ops, out of this repo's code scope).
+
+## Capabilities
+
+### New Capabilities
+<!-- None. Reuses the source-ingest pipeline and write path unchanged. -->
+
+### Modified Capabilities
+- `source-ingest`: add a requirement that `getmatch` is a registered boardless aggregator
+  provider — it enumerates the getmatch.ru marketplace from the public `/api/offers` feed
+  (paginated, per-offer employer), fetches each offer's full HTML description from the
+  `/api/offers/{id}` detail endpoint, and yields the normalized job shape with a structured
+  work mode derived from the offer's per-location formats.
+
+## Impact
+
+- **New code**: `internal/sources/getmatch.go` + `getmatch_test.go` (inline real-shaped JSON
+  fixtures, mirroring `tecla_test.go`); one registration line in `sources.All`.
+- **Dependencies**: none new (HTML sanitize + JSON stdlib already present).
+- **Config**: one new board file (`sources/getmatch.yml`). No new env vars (keyless).
+- **Cron**: one new schedule for `sources/getmatch.yml` — ops change, out of code scope.
+- **DB**: none — reuses `UpsertJob` (`source = "getmatch"`, namespaced `external_id`).
+- **Out of scope (known seams)**:
+  - **Salary** (`salary_display_from`/`_to`/`_currency`) is not mapped — the raw `Job` shape
+    carries no salary field; compensation is enrichment's domain.
+  - **`skills_objects`** are not mapped — the project derives skills from its own deterministic
+    `internal/skilltag` dictionary at ingest.
+  - **`StreamingSource`** is not implemented — the ~755 per-offer detail requests are a moderate
+    fan-out; the streaming/incremental-persist seam (as `eightfold`) is noted for later if the
+    catalogue grows or the crawl gets slow.

--- a/openspec/changes/add-getmatch-source/specs/source-ingest/spec.md
+++ b/openspec/changes/add-getmatch-source/specs/source-ingest/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: getmatch is a registered boardless aggregator provider
+
+The system SHALL register a `getmatch` adapter so the getmatch.ru IT job marketplace can be
+listed in a board file as a boardless aggregator (its config entry carries no `board`, and the
+provider remains in the source facet). The adapter SHALL enumerate the marketplace from the
+public, keyless feed `GET https://getmatch.ru/api/offers`, paginating with `offset`/`limit` and
+stopping when `offset` reaches the response's `meta.total`, bounded by a maximum page count so a
+missing or invalid total cannot loop. Each offer's employer SHALL come from the offer's own
+`company.name` (not the configured company, which is a validation placeholder). The adapter
+SHALL yield the normalized job shape with `external_id` set to the offer's numeric `id`, `url`
+set to `https://getmatch.ru` joined with the offer's relative `url`, `title` set to `position`,
+`location` set to the offer's distinct `location_items[].label` values joined, and `posted_at`
+parsed from `published_at`. The adapter SHALL include all `offer_type` values (both regular
+vacancies and one-day-offer event cards).
+
+#### Scenario: The marketplace is enumerated from the paginated public feed
+
+- **WHEN** a board file lists a boardless entry with provider `getmatch`
+- **THEN** the adapter requests `https://getmatch.ru/api/offers` with increasing `offset`,
+  stops once `offset` reaches `meta.total`, and yields each offer as the normalized job shape
+  with `external_id` set to the offer `id`, `url` set to the absolute offer URL, `company` set
+  to the offer's own `company.name`, and `posted_at` parsed from `published_at`
+
+#### Scenario: A failed first page is a board error; a failed later page ends enumeration
+
+- **WHEN** the first `/api/offers` page request fails
+- **THEN** the adapter returns an error for the board
+- **WHEN** a later page request fails after at least one page succeeded
+- **THEN** the adapter stops paginating and returns the jobs gathered so far without error
+
+### Requirement: getmatch descriptions come from the per-offer detail endpoint
+
+The adapter SHALL fetch each offer's full HTML description from the detail endpoint
+`GET https://getmatch.ru/api/offers/{id}` and yield it as the job `description` after HTML
+sanitization. When the detail `description` is empty (for example one-day-offer event cards) or
+the detail request fails, the adapter SHALL fall back to the list offer's short
+`offer_description` rather than dropping the offer.
+
+#### Scenario: Full description is taken from the detail endpoint and sanitized
+
+- **WHEN** an offer's detail endpoint returns a non-empty HTML `description`
+- **THEN** the adapter yields that HTML as the job `description`, sanitized (active content
+  stripped, structure such as paragraphs and lists kept)
+
+#### Scenario: Empty or failed detail falls back to the list summary
+
+- **WHEN** an offer's detail `description` is empty or the detail request fails
+- **THEN** the adapter yields the list offer's `offer_description` as the job `description` and
+  still yields the offer
+
+### Requirement: getmatch derives a structured work mode from per-location formats
+
+The adapter SHALL derive the structured work mode from the offer's `location_items[].format`,
+mapping `remote` to `remote`, `hybrid` to `hybrid`, and `office` to `onsite`, and ignoring the
+`relocation_company` and `relocation_candidate` flags (which denote relocation support, not a
+work mode). The adapter SHALL set the structured work mode only when the offer's locations
+resolve to a single distinct work mode; when they resolve to more than one (or none), the
+structured work mode SHALL be left empty so the pipeline's location parser decides. The job
+SHALL be marked remote when and only when the derived work mode is `remote`.
+
+#### Scenario: A single work mode is emitted as the structured work mode
+
+- **WHEN** every work-mode-bearing `location_items` entry of an offer has the same `format`
+  (e.g. all `office`)
+- **THEN** the adapter sets the structured work mode to the mapped value (`onsite`), and marks
+  the job remote only when that value is `remote`
+
+#### Scenario: Mixed work modes leave the structured field empty
+
+- **WHEN** an offer's `location_items` resolve to more than one distinct work mode (e.g. one
+  `remote` and one `office`)
+- **THEN** the adapter leaves the structured work mode empty, so the pipeline falls back to
+  parsing the location string
+
+#### Scenario: Relocation flags do not count as a work mode
+
+- **WHEN** an offer's only non-`relocation_*` format is a single work mode and the remaining
+  entries are `relocation_company`/`relocation_candidate`
+- **THEN** the relocation entries are ignored and the single work mode is emitted as the
+  structured work mode

--- a/openspec/changes/add-getmatch-source/tasks.md
+++ b/openspec/changes/add-getmatch-source/tasks.md
@@ -1,0 +1,30 @@
+## 1. Test fixtures
+
+- [x] 1.1 Write the route-aware test fake and inline real-shaped JSON fixtures (offers spanning
+  single-mode, mixed-mode, relocation-only-plus-one-mode, and a one-day-offer card, plus a
+  `/api/offers/{id}` detail body), mirroring `tecla_test.go`.
+
+## 2. Adapter core
+
+- [x] 2.1 Define the response/offer structs and the `getmatch` adapter type with `Provider()`,
+  `boardless()`, `aggregator()`, and `NewGetmatch(c JSONGetter)` (mirroring `tecla`).
+- [x] 2.2 Implement `Fetch` pagination over `/api/offers?offset=&limit=100` stopping at
+  `meta.total` with a `maxPages` bound, and map each offer to `Job` (`ExternalID`=`id`,
+  `URL`=absolute, `Title`=`position`, `Company`=`company.name`, `Location`=distinct labels,
+  `PostedAt`=`published_at`); first-page failure errors, later-page failure ends enumeration.
+- [x] 2.3 Fetch the per-offer detail `/api/offers/{id}`, use its sanitized HTML `description`,
+  and fall back to the list `offer_description` when the detail description is empty or the
+  detail request fails (never drop the offer).
+- [x] 2.4 Derive the structured `WorkMode` from `location_items[].format`
+  (`remote`/`hybrid`/`office`→`remote`/`hybrid`/`onsite`, ignoring `relocation_*`), emitting it
+  only on a single distinct work mode; set `Remote` iff the work mode is `remote`.
+
+## 3. Registration and config
+
+- [x] 3.1 Register `getmatch` in `sources.All` (one `NewGetmatch(c)` line).
+- [x] 3.2 Add `sources/getmatch.yml` with one boardless placeholder entry.
+
+## 4. Verification
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./internal/sources/` all green, and a live
+  smoke run of the adapter against the real API yields normalized jobs with full descriptions.

--- a/sources/getmatch.yml
+++ b/sources/getmatch.yml
@@ -1,0 +1,4 @@
+# getmatch.ru IT job marketplace. Boardless: one global public feed (getmatch.ru/api/offers),
+# so the entry carries no board, and each job's company comes from the offer, not this placeholder.
+- company: getmatch
+  provider: getmatch


### PR DESCRIPTION
## Summary

Adds a `getmatch` source adapter for [getmatch.ru](https://getmatch.ru/vacancies), a curated Russian IT job marketplace exposed via a public, keyless JSON API. It is a **boardless aggregator** (mirrors `tecla`/`jobstash`): one global feed, per-offer employer.

- **Fetch** paginates `GET /api/offers?offset=&limit=100`, stopping at `meta.total` with a `maxPages` safety bound. First-page error fails the board; a later-page error ends enumeration with what was gathered.
- **Full descriptions** come from the per-offer detail endpoint `GET /api/offers/{id}`, falling back to the list's short `offer_description` when the detail body is empty (event cards) or the detail request fails — an offer is never dropped.
- **Structured WorkMode** is derived from `location_items[].format` via the shared `workplaceTypeMode` (`remote`/`hybrid`/`office`→`remote`/`hybrid`/`onsite`; `relocation_*` ignored), emitted only when the offer resolves to a single distinct work mode (mixed → empty, so the pipeline's location parser decides).
- Per-offer company; `sources/getmatch.yml` carries one boardless placeholder entry; one `NewGetmatch(c)` line in `sources.All`.

Planned and tracked under OpenSpec change `add-getmatch-source` (proposal/design/specs/tasks included).

**Out of scope (noted seams):** salary (no `Job` field), `skills_objects` (project uses `internal/skilltag`), `StreamingSource` (moderate ~755-fetch fan-out).

## Test Plan

- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` green (incl. 11 new getmatch tests: mapping, detail-fallback, work-mode single/mixed/relocation, pagination stop-at-total, page-error handling, registration)
- [x] Live smoke against the real API: 755 offers, full HTML descriptions, correct work-mode derivation (`remote`/`onsite`/empty-for-mixed), single-host URLs
- [x] `sources/getmatch.yml` validates against the registry
- [ ] Ops follow-up (out of repo): cron schedule for `cmd/ingest sources/getmatch.yml` + image rebuild (new adapter)