### PR TITLE
feat(sources): add Mayflower (Recruitee) board

### DIFF
--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -233,3 +233,5 @@
   board: "wisemen"
 - company: MacPaw
   board: macpaw
+- company: Mayflower
+  board: mayflower


### PR DESCRIPTION
Adds the **Mayflower** board to `sources/recruitee.yml` (`mayflower.recruitee.com`).

- ATS: Recruitee — adapter already registered, no code change.
- Single-company board (not an aggregator): all 44 offers are Mayflower's own.
- Live-verified through the real adapter + HTTP client: 44 postings normalize cleanly (ExternalID/Title/URL/Location/Remote/Description all populated; remote flag read correctly).

Sources-only change → deploy is `--no-build` config sync.