### PR TITLE
feat(sources): add Habr Career (habr_career) board adapter

### DIFF
--- a/internal/linksource/habrcareer.go
+++ b/internal/linksource/habrcareer.go
@@ -2,7 +2,6 @@ package linksource
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -37,45 +36,6 @@ func (habrCareer) Match(u *url.URL) bool {
 // habrVacancyPath matches the canonical vacancy path, capturing the numeric id.
 var habrVacancyPath = regexp.MustCompile(`^/vacancies/(\d+)/?$`)
 
-// habrPosting selects the JobPosting ld+json fields Habr publishes on a vacancy page.
-// datePosted is deliberately absent: Habr's ld+json datePosted is unreliable (it runs ~a
-// month ahead of the real publish date), so the posting date is read from the page's
-// <time> element instead — see Resolve.
-type habrPosting struct {
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Identifier  struct {
-		Value string `json:"value"`
-	} `json:"identifier"`
-	HiringOrganization struct {
-		Name string `json:"name"`
-	} `json:"hiringOrganization"`
-	JobLocation []struct {
-		Address habrAddress `json:"address"`
-	} `json:"jobLocation"`
-}
-
-// habrAddress reads jobLocation.address, which Habr emits as a bare string but schema.org
-// types as a PostalAddress object — so it accepts either shape.
-type habrAddress struct{ Text string }
-
-func (a *habrAddress) UnmarshalJSON(b []byte) error {
-	var s string
-	if json.Unmarshal(b, &s) == nil {
-		a.Text = s
-		return nil
-	}
-	var o struct {
-		AddressLocality string `json:"addressLocality"`
-		AddressCountry  string `json:"addressCountry"`
-	}
-	if json.Unmarshal(b, &o) == nil {
-		a.Text = strings.TrimPrefix(strings.TrimSpace(o.AddressLocality+", "+o.AddressCountry), ", ")
-		a.Text = strings.TrimSuffix(a.Text, ", ")
-	}
-	return nil
-}
-
 // Resolve follows the link to its career.habr.com landing, and when that is a single
 // vacancy parses its JobPosting ld+json into a job. A matched link that lands somewhere
 // other than /vacancies/<id> (e.g. the "Больше вакансий" index) is skipped (ok=false).
@@ -100,26 +60,24 @@ func (h habrCareer) Resolve(ctx context.Context, raw string) (sources.Job, bool,
 	}
 	id := m[1]
 
-	var p habrPosting
-	if !sources.LDJobPosting(node, &p) {
+	// The detail-page JobPosting parse is shared with the habr_career board adapter so the two
+	// read a Habr vacancy identically.
+	p, ok := sources.ParseHabrPosting(node)
+	if !ok {
 		return sources.Job{}, false, fmt.Errorf("linksource: habr vacancy %s has no JobPosting ld+json", id)
 	}
-	if p.Identifier.Value != "" {
-		id = p.Identifier.Value
+	if p.Identifier != "" {
+		id = p.Identifier
 	}
 
-	var loc string
-	if len(p.JobLocation) > 0 {
-		loc = p.JobLocation[0].Address.Text
-	}
 	return sources.Job{
 		ExternalID:  id,
 		URL:         "https://career.habr.com/vacancies/" + id,
 		Title:       p.Title,
-		Company:     p.HiringOrganization.Name,
-		Location:    loc,
+		Company:     p.Company,
+		Location:    p.Location,
 		Description: sources.SanitizeHTML(p.Description),
-		Remote:      sources.IsRemote(loc),
+		Remote:      sources.IsRemote(p.Location),
 		// Habr's ld+json datePosted is bogus (~a month ahead of the real date, with a later
 		// validThrough), which would pin every Habr job to the top of the freshest-first
 		// browse. The trustworthy publish timestamp is the visible <time class="basic-date"

--- a/internal/sources/habrcareer.go
+++ b/internal/sources/habrcareer.go
@@ -1,0 +1,242 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// habrCareer adapts Habr Career (career.habr.com), a Russian-language IT job board. Its public,
+// keyless listing API (/api/frontend/vacancies) returns a paginated list where every item
+// carries its own employer, so one paged crawl assembles every Job — but the list omits the
+// description, so each vacancy is enriched from its detail page's JobPosting ld+json (the same
+// block the linksource adapter reads; see ParseHabrPosting). Unlike a single-company board the
+// employer comes from the listing item, so its boardless config entry's company is only a
+// validation placeholder.
+//
+// Coverage ceiling: the API reports ~974 vacancies but paginates only to ~748; the cap sits on
+// the result-set itself (every sort ordering, the s[]/qid filters, and the RSS feed return the
+// same ids), so the unreachable remainder needs an authenticated session and is out of scope.
+type habrCareer struct {
+	http habrCareerHTTP
+}
+
+// habrCareerHTTP is the transport habr_career needs: a JSON listing (with custom headers) plus
+// HTML detail pages.
+type habrCareerHTTP interface {
+	HeaderJSONGetter
+	HTMLGetter
+}
+
+const (
+	habrListURL    = "https://career.habr.com/api/frontend/vacancies?type=all&sort=date&page=%d"
+	habrVacancyURL = "https://career.habr.com/vacancies/%d"
+	// habrMaxPages bounds pagination so a wrong or missing meta.totalPages cannot loop. The API
+	// caps the listing at ~30 pages (the ~748 reachable vacancies of the package-doc ceiling), so
+	// 50 is a safe headroom over that cap.
+	habrMaxPages = 50
+)
+
+// habrHeaders mirror what a browser sends to the JSON API; Habr serves the listing without them
+// but the public Career.habr-parser project sends them and they reduce block risk.
+var habrHeaders = map[string]string{
+	"Accept":  "application/json",
+	"Referer": "https://career.habr.com/vacancies",
+}
+
+// NewHabrCareer builds the Habr Career adapter over the given HTTP client.
+func NewHabrCareer(c habrCareerHTTP) Source { return habrCareer{http: c} }
+
+func (habrCareer) Provider() string { return "habr_career" }
+
+// habr_career has one global listing, so its config entries carry no board.
+func (habrCareer) boardless() {}
+
+// habr_career aggregates postings from many companies, so it stays in the source facet.
+func (habrCareer) aggregator() {}
+
+// habrListResponse is one /api/frontend/vacancies page: List is the page, Meta.TotalPages bounds
+// pagination.
+type habrListResponse struct {
+	List []habrVacancy `json:"list"`
+	Meta struct {
+		CurrentPage int `json:"currentPage"`
+		TotalPages  int `json:"totalPages"`
+	} `json:"meta"`
+}
+
+// habrVacancy is one listing item. Company nests the employer's own title (the board lists many
+// employers); the description is not here — it lives on the detail page (see description).
+type habrVacancy struct {
+	ID            int    `json:"id"`
+	Title         string `json:"title"`
+	RemoteWork    bool   `json:"remoteWork"`
+	PublishedDate struct {
+		Date string `json:"date"`
+	} `json:"publishedDate"`
+	Company struct {
+		Title string `json:"title"`
+	} `json:"company"`
+	Locations []habrLocation `json:"locations"`
+}
+
+// habrLocation is one of a vacancy's listed locations.
+type habrLocation struct {
+	Title string `json:"title"`
+}
+
+func (h habrCareer) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var vacancies []habrVacancy
+	for page := 1; page <= habrMaxPages; page++ {
+		var resp habrListResponse
+		if err := h.http.GetJSONWithHeaders(ctx, fmt.Sprintf(habrListURL, page), habrHeaders, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("habr_career: list page %d: %w", page, err)
+			}
+			break // a later page failing ends enumeration with the vacancies gathered so far
+		}
+		if len(resp.List) == 0 {
+			break
+		}
+		vacancies = append(vacancies, resp.List...)
+		if resp.Meta.TotalPages > 0 && page >= resp.Meta.TotalPages {
+			break
+		}
+	}
+
+	// A vacancy is always yielded; only its description depends on the detail fetch, so the
+	// detail closure never returns ok=false (a missing description must not drop the vacancy).
+	return fetchDetails(vacancies, defaultDetailWorkers, func(v habrVacancy) (Job, bool) {
+		return h.toJob(ctx, v), true
+	}), nil
+}
+
+// toJob maps a listing item to a Job. ExternalID/URL match the linksource adapter exactly so the
+// same vacancy crawled here and followed from a Telegram link dedups into one row. The posted
+// date comes from the listing's publishedDate.date (an RFC 3339 timestamp), not the detail
+// page's basic-date element (which is the page render time).
+func (h habrCareer) toJob(ctx context.Context, v habrVacancy) Job {
+	mode := ""
+	if v.RemoteWork {
+		mode = "remote"
+	}
+	return Job{
+		ExternalID:  strconv.Itoa(v.ID),
+		URL:         fmt.Sprintf(habrVacancyURL, v.ID),
+		Title:       v.Title,
+		Company:     v.Company.Title,
+		Location:    habrLocationString(v.Locations),
+		Description: h.description(ctx, v.ID),
+		Remote:      v.RemoteWork,
+		WorkMode:    mode,
+		PostedAt:    parseRFC3339(v.PublishedDate.Date),
+	}
+}
+
+// description fetches the vacancy detail page and returns its JobPosting description, sanitized.
+// A failed fetch or a page without a JobPosting yields an empty description (the vacancy is still
+// kept) rather than dropping the vacancy.
+func (h habrCareer) description(ctx context.Context, id int) string {
+	node, err := h.http.GetHTML(ctx, fmt.Sprintf(habrVacancyURL, id))
+	if err != nil {
+		return ""
+	}
+	p, ok := ParseHabrPosting(node)
+	if !ok {
+		return ""
+	}
+	return sanitizeHTML(p.Description)
+}
+
+// habrLocationString joins a vacancy's distinct location titles in order.
+func habrLocationString(items []habrLocation) string {
+	var titles []string
+	seen := map[string]struct{}{}
+	for _, it := range items {
+		t := strings.TrimSpace(it.Title)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		titles = append(titles, t)
+	}
+	return strings.Join(titles, ", ")
+}
+
+// HabrPosting is the schema.org JobPosting a Habr Career vacancy page carries, flattened into the
+// fields both the board adapter (internal/sources) and the link-following adapter
+// (internal/linksource) need, so the two parse a Habr detail page identically. Description is raw
+// HTML; callers sanitize it.
+type HabrPosting struct {
+	Title       string
+	Description string
+	Company     string
+	Location    string
+	Identifier  string
+}
+
+// ParseHabrPosting reads the JobPosting ld+json from a Habr vacancy page into a HabrPosting,
+// returning ok=false when the page carries no JobPosting block.
+func ParseHabrPosting(root *html.Node) (HabrPosting, bool) {
+	var raw habrRawPosting
+	if !ldJobPosting(root, &raw) {
+		return HabrPosting{}, false
+	}
+	p := HabrPosting{
+		Title:       raw.Title,
+		Description: raw.Description,
+		Company:     raw.HiringOrganization.Name,
+		Identifier:  raw.Identifier.Value,
+	}
+	if len(raw.JobLocation) > 0 {
+		p.Location = raw.JobLocation[0].Address.Text
+	}
+	return p, true
+}
+
+// habrRawPosting selects the JobPosting fields Habr publishes on a vacancy page. datePosted is
+// deliberately absent: it is unreliable (it runs ahead of the real publish date), so callers
+// read the posting date from elsewhere (the board adapter from the listing, the linksource
+// adapter from the page's <time> element).
+type habrRawPosting struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Identifier  struct {
+		Value string `json:"value"`
+	} `json:"identifier"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation []struct {
+		Address habrAddress `json:"address"`
+	} `json:"jobLocation"`
+}
+
+// habrAddress reads jobLocation.address, which Habr emits as a bare string but schema.org types
+// as a PostalAddress object — so it accepts either shape.
+type habrAddress struct{ Text string }
+
+func (a *habrAddress) UnmarshalJSON(b []byte) error {
+	var s string
+	if json.Unmarshal(b, &s) == nil {
+		a.Text = s
+		return nil
+	}
+	var o struct {
+		AddressLocality string `json:"addressLocality"`
+		AddressCountry  string `json:"addressCountry"`
+	}
+	if json.Unmarshal(b, &o) == nil {
+		a.Text = strings.TrimSpace(o.AddressLocality + ", " + o.AddressCountry)
+		a.Text = strings.TrimPrefix(a.Text, ", ")
+		a.Text = strings.TrimSuffix(a.Text, ", ")
+	}
+	return nil
+}

--- a/internal/sources/habrcareer_test.go
+++ b/internal/sources/habrcareer_test.go
@@ -1,0 +1,240 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// fakeHabrCareer is a route-aware test client for the two Habr endpoints: the paged listing
+// JSON (/api/frontend/vacancies?page=N, via GetJSONWithHeaders) and a per-vacancy detail page
+// (/vacancies/<id>, via GetHTML). It records the pages requested, the headers sent on the
+// listing, and the detail ids fetched, so tests can assert pagination, the API headers, and the
+// per-vacancy detail fan-out. Detail fetches run concurrently, so its recorders are mutexed.
+type fakeHabrCareer struct {
+	pages     map[int]string // listing body keyed by requested page
+	details   map[int]string // detail HTML keyed by vacancy id
+	failList  bool           // every listing request fails
+	failPage  map[int]bool   // a specific page's listing request fails
+	detailErr map[int]bool   // a specific vacancy's detail request fails
+
+	mu          sync.Mutex
+	gotPages    []int
+	gotDetails  []int
+	listHeaders map[string]string
+}
+
+var (
+	habrPageRE   = regexp.MustCompile(`[?&]page=(\d+)`)
+	habrDetailRE = regexp.MustCompile(`/vacancies/(\d+)`)
+)
+
+func (f *fakeHabrCareer) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
+	page := 1
+	if m := habrPageRE.FindStringSubmatch(url); m != nil {
+		page, _ = strconv.Atoi(m[1])
+	}
+	f.mu.Lock()
+	f.gotPages = append(f.gotPages, page)
+	f.listHeaders = headers
+	f.mu.Unlock()
+	if f.failList || f.failPage[page] {
+		return errors.New("fakeHabrCareer: list boom")
+	}
+	raw, ok := f.pages[page]
+	if !ok {
+		p := strconv.Itoa(page)
+		raw = `{"list":[],"meta":{"currentPage":` + p + `,"totalPages":` + p + `}}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func (f *fakeHabrCareer) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	id := 0
+	if m := habrDetailRE.FindStringSubmatch(url); m != nil {
+		id, _ = strconv.Atoi(m[1])
+	}
+	f.mu.Lock()
+	f.gotDetails = append(f.gotDetails, id)
+	f.mu.Unlock()
+	if f.detailErr[id] {
+		return nil, errors.New("fakeHabrCareer: detail boom")
+	}
+	raw, ok := f.details[id]
+	if !ok {
+		raw = `<html><body><h1>no posting</h1></body></html>` // a page without JobPosting ld+json
+	}
+	return html.Parse(strings.NewReader(raw))
+}
+
+func habrFixture(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func newHabrFake(t *testing.T) *fakeHabrCareer {
+	return &fakeHabrCareer{
+		pages: map[int]string{
+			1: habrFixture(t, "habr_vacancies_p1.json"),
+			2: habrFixture(t, "habr_vacancies_p2.json"),
+		},
+		details: map[int]string{
+			1000166598: habrFixture(t, "habr_vacancy_detail.html"),
+		},
+		failPage:  map[int]bool{},
+		detailErr: map[int]bool{},
+	}
+}
+
+func jobByID(jobs []Job, id string) (Job, bool) {
+	for _, j := range jobs {
+		if j.ExternalID == id {
+			return j, true
+		}
+	}
+	return Job{}, false
+}
+
+func TestHabrCareerBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/habrcareer.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig(sources/habrcareer.yml): %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/habrcareer.yml fails registry validation: %v", err)
+	}
+}
+
+func TestHabrCareerProvider(t *testing.T) {
+	if got := NewHabrCareer(nil).Provider(); got != "habr_career" {
+		t.Errorf("Provider() = %q, want habr_career", got)
+	}
+}
+
+func TestHabrCareerIsBoardlessAggregator(t *testing.T) {
+	s := NewHabrCareer(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("habr_career must be boardless (no per-tenant board id)")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("habr_career must be an aggregator (stays in the source facet)")
+	}
+}
+
+func TestHabrCareerFetchPaginatesAndMaps(t *testing.T) {
+	fake := newHabrFake(t)
+	fake.detailErr[1000167078] = true // detail fails → vacancy still yielded, empty description
+
+	jobs, err := NewHabrCareer(fake).Fetch(context.Background(), CompanyEntry{Provider: "habr_career"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3", len(jobs))
+	}
+	if !slices.Equal(fake.gotPages, []int{1, 2}) {
+		t.Errorf("requested pages = %v, want [1 2]", fake.gotPages)
+	}
+
+	// Vacancy with a full detail page: identity, fields, sanitized description, date.
+	j, ok := jobByID(jobs, "1000166598")
+	if !ok {
+		t.Fatal("vacancy 1000166598 missing")
+	}
+	if j.URL != "https://career.habr.com/vacancies/1000166598" {
+		t.Errorf("URL = %q, want canonical vacancy URL (dedups with linksource)", j.URL)
+	}
+	if j.Title != "Специалист по работе с документами" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "ИТ Контакт" {
+		t.Errorf("Company = %q, want the listing company.title", j.Company)
+	}
+	if j.Location != "Санкт-Петербург" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.Remote || j.WorkMode != "" {
+		t.Errorf("Remote=%v WorkMode=%q, want false/empty for remoteWork:false", j.Remote, j.WorkMode)
+	}
+	// publishedDate.date 2026-05-29T10:00:00+03:00 → 07:00:00Z; NOT the detail basic-date.
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 5, 29, 7, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-05-29T07:00:00Z from listing publishedDate.date", j.PostedAt)
+	}
+	if strings.Contains(j.Description, "<script>") || !strings.Contains(j.Description, "<li>Работа с документами</li>") {
+		t.Errorf("Description not sanitized from detail JobPosting: %q", j.Description)
+	}
+
+	// Remote vacancy whose detail fetch failed: still yielded, empty description, remote signal.
+	r, ok := jobByID(jobs, "1000167078")
+	if !ok {
+		t.Fatal("vacancy 1000167078 missing — a failed detail must not drop it")
+	}
+	if !r.Remote || r.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want true/remote for remoteWork:true", r.Remote, r.WorkMode)
+	}
+	if r.Location != "Минск, Удалённо" {
+		t.Errorf("Location = %q, want distinct locations joined", r.Location)
+	}
+	if r.Description != "" {
+		t.Errorf("Description = %q, want empty when detail fetch failed", r.Description)
+	}
+
+	// Vacancy whose detail page has no JobPosting: still yielded, empty description, empty company.
+	q, ok := jobByID(jobs, "1000160000")
+	if !ok {
+		t.Fatal("vacancy 1000160000 missing — a page without JobPosting must not drop it")
+	}
+	if q.Description != "" {
+		t.Errorf("Description = %q, want empty when detail has no JobPosting", q.Description)
+	}
+	if q.Company != "" || q.Location != "" {
+		t.Errorf("Company=%q Location=%q, want empty for the no-company/no-location edge", q.Company, q.Location)
+	}
+}
+
+func TestHabrCareerSendsAPIHeaders(t *testing.T) {
+	fake := newHabrFake(t)
+	if _, err := NewHabrCareer(fake).Fetch(context.Background(), CompanyEntry{Provider: "habr_career"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fake.listHeaders["Accept"]; got != "application/json" {
+		t.Errorf("Accept header = %q, want application/json", got)
+	}
+	if got := fake.listHeaders["Referer"]; got != "https://career.habr.com/vacancies" {
+		t.Errorf("Referer header = %q, want https://career.habr.com/vacancies", got)
+	}
+}
+
+func TestHabrCareerFirstPageErrorIsBoardError(t *testing.T) {
+	fake := newHabrFake(t)
+	fake.failPage = map[int]bool{1: true}
+	if _, err := NewHabrCareer(fake).Fetch(context.Background(), CompanyEntry{Provider: "habr_career"}); err == nil {
+		t.Fatal("want an error when the first listing page fails")
+	}
+}
+
+func TestHabrCareerLaterPageErrorEndsEnumeration(t *testing.T) {
+	fake := newHabrFake(t)
+	fake.failPage = map[int]bool{2: true}
+	jobs, err := NewHabrCareer(fake).Fetch(context.Background(), CompanyEntry{Provider: "habr_career"})
+	if err != nil {
+		t.Fatalf("a later-page failure must not error: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (page 1 only, page 2 failed)", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -142,6 +142,7 @@ func All(c HTTPClient) map[string]Source {
 		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
 		NewGetmatch(c),
+		NewHabrCareer(c),
 		NewWorkAtAStartup(c),
 		NewJobStash(c),
 		NewArbeitnow(c),

--- a/internal/sources/testdata/habr_vacancies_p1.json
+++ b/internal/sources/testdata/habr_vacancies_p1.json
@@ -1,0 +1,26 @@
+{
+  "list": [
+    {
+      "id": 1000166598,
+      "href": "/vacancies/1000166598",
+      "title": "Специалист по работе с документами",
+      "remoteWork": false,
+      "publishedDate": { "date": "2026-05-29T10:00:00+03:00", "title": "29 мая" },
+      "company": { "id": 1000121509, "title": "ИТ Контакт" },
+      "locations": [{ "title": "Санкт-Петербург", "href": "/vacancies?city_id=679" }],
+      "skills": [{ "title": "Английский язык" }]
+    },
+    {
+      "id": 1000167078,
+      "href": "/vacancies/1000167078",
+      "title": "Пентестер/кодер C++",
+      "remoteWork": true,
+      "publishedDate": { "date": "2026-06-19T21:03:53+03:00", "title": "19 июня" },
+      "company": { "id": 1000100777, "title": "SecureCo" },
+      "locations": [{ "title": "Минск" }, { "title": "Удалённо" }],
+      "skills": [{ "title": "C++" }, { "title": "Reverse Engineering" }]
+    }
+  ],
+  "meta": { "totalResults": 3, "perPage": 2, "currentPage": 1, "totalPages": 2 },
+  "recommendedQuickVacancies": []
+}

--- a/internal/sources/testdata/habr_vacancies_p2.json
+++ b/internal/sources/testdata/habr_vacancies_p2.json
@@ -1,0 +1,16 @@
+{
+  "list": [
+    {
+      "id": 1000160000,
+      "href": "/vacancies/1000160000",
+      "title": "QA Engineer",
+      "remoteWork": false,
+      "publishedDate": { "date": "2026-05-01T09:00:00+03:00", "title": "1 мая" },
+      "company": { "id": 1000100999, "title": "" },
+      "locations": [],
+      "skills": []
+    }
+  ],
+  "meta": { "totalResults": 3, "perPage": 2, "currentPage": 2, "totalPages": 2 },
+  "recommendedQuickVacancies": []
+}

--- a/internal/sources/testdata/habr_vacancy_detail.html
+++ b/internal/sources/testdata/habr_vacancy_detail.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ru"><head>
+<meta charset="utf-8">
+<title>Специалист по работе с документами — Хабр Карьера</title>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Специалист по работе с документами",
+ "datePosted":"2026-06-29",
+ "validThrough":"2026-07-29",
+ "description":"<p>Обязанности &amp; требования:</p><script>alert('xss')<\/script><ul><li>Работа с документами</li><li>Английский язык</li></ul>",
+ "identifier":{"@type":"PropertyValue","name":"ИТ Контакт","value":"1000166598"},
+ "hiringOrganization":{"@type":"Organization","name":"ИТ Контакт"},
+ "jobLocation":[{"@type":"Place","address":"Санкт-Петербург"}],
+ "employmentType":"FULL_TIME"}
+</script></head>
+<body>
+<h1>Специалист по работе с документами</h1>
+<time class="basic-date" datetime="2026-06-19T19:36:02+03:00">19 июня</time>
+</body></html>

--- a/openspec/changes/add-habr-career-source/.openspec.yaml
+++ b/openspec/changes/add-habr-career-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-habr-career-source/design.md
+++ b/openspec/changes/add-habr-career-source/design.md
@@ -1,0 +1,119 @@
+## Context
+
+Habr Career (`career.habr.com`) is a Rails app whose public vacancy listing is backed by a
+keyless JSON API. Reconnaissance (live, 2026-06-19) established the surface:
+
+- `GET /api/frontend/vacancies?type=all&sort=date&page=N` →
+  `{ list: [...], meta: { totalResults, perPage: 25, currentPage, totalPages }, recommendedQuickVacancies: [] }`.
+  At survey time `totalResults` was 974 across 30 `totalPages`.
+- Each list item carries the employer (`company.title`), so Habr Career is a **marketplace
+  aggregator**, not a single-company board — matching the existing `getmatch`/`tecla`/`jobstash`
+  adapters: boardless, `aggregator()`-marked, with a placeholder company in the config entry.
+- List item fields used: `id` (int), `href`, `title`, `company.title`, `remoteWork` (bool),
+  `locations[].title`, `skills[].title`, `salary{from,to,currency,formatted}`,
+  `publishedDate.date` (RFC 3339).
+- The list has **no description**. The full description lives on the detail page
+  `GET /vacancies/<id>` (HTML) as a `JobPosting` ld+json `description` — the exact shape the
+  existing `internal/linksource/habrcareer.go` already parses.
+- `GET /api/frontend/vacancies/<id>` → `404` (no detail JSON API).
+- `robots.txt` permits `/vacancies` (only sub-paths like `/responses`, `/profile` are blocked).
+- Request headers `Accept: application/json` + `Referer: https://career.habr.com/vacancies`
+  are sent (the public Umalanif/Career.habr-parser project uses the same; reduces block risk).
+
+**Coverage ceiling (hard limitation).** The API reports `totalResults: 974` but paginates only
+to a flat ~748. This cap sits on the underlying result-set, not on a single ordering — verified
+empirically that the union of: all sort orderings (`date`/`salary_asc`/`salary_desc`), every
+`s[]` specialization filter, every `qid` qualification filter, and the RSS feed
+(`/vacancies/rss`, 15 pages) all return the **same ~748 ids** (0 new beyond the flat set). The
+sitemap lists ~114k historical URLs with no open/closed signal (unusable for an "open only"
+crawl). The remaining ~225 are unreachable by any anonymous channel — they would require an
+authenticated/personalized session, which is out of scope and ToS-sensitive. v1 therefore
+ingests the reachable ~748 freshest; the existing Telegram linksource already pulls some of the
+hidden ones in via dedup.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ingest Habr Career into the catalogue under `source = "habr_career"` via the existing
+  pipeline, with full HTML descriptions and a structured work mode where unambiguous.
+- Follow the established boardless-aggregator adapter pattern so the change is one new adapter
+  file + one registry line + one board file, with no pipeline changes.
+- Dedup board-crawled vacancies with the existing Habr linksource adapter by emitting an
+  identical identity; extract the shared detail-page parse into one helper.
+
+**Non-Goals:**
+
+- Reaching the hidden ~225 vacancies (authenticated/personalized access).
+- Specialization/qualification slicing — empirically adds zero ids beyond the flat 748.
+- Salary ingestion (no field in the raw `Job` shape; enrichment owns compensation).
+- Skill ingestion from the listing's `skills[]` (the project derives skills via
+  `internal/skilltag` from the description).
+- `StreamingSource` / incremental persistence (noted seam; the ~748 detail fan-out is moderate).
+
+## Decisions
+
+**1. Boardless aggregator, mirroring `getmatch`/`tecla`.** Habr lists many employers behind one
+feed, so the adapter implements `boardless()` (config entry needs no `board`) and `aggregator()`
+(it stays in the source facet). Like the other aggregators it gets a **dedicated**
+`sources/habrcareer.yml` (one placeholder entry), not a line in `custom.yml`, so its per-vacancy
+detail fan-out crawls on its own cron slot without blocking the hourly single-source providers.
+
+**2. JSON listing + HTML detail, via a private combined client interface.** Like `breezy`, the
+adapter declares a private interface embedding `HeaderJSONGetter` (listing needs custom headers)
+and `HTMLGetter` (detail page). The shared `*sources.Client` satisfies both. Listing uses
+`GetJSONWithHeaders` with the `Accept`/`Referer` headers; detail uses `GetHTML`.
+
+**3. Pagination.** Request `page=1`, read `meta.totalPages`, then fetch `page=2..totalPages`,
+stopping early on an empty `list`. A max-page guard (e.g. 50) prevents a bad `totalPages` from
+looping. First-page failure → board error; a later-page failure → stop and return what we have
+(mirrors `getmatch`).
+
+**4. Identity shared with linksource.** `external_id` = numeric vacancy id; `url` =
+`https://career.habr.com/vacancies/<id>`. This is byte-identical to what
+`internal/linksource/habrcareer.go` emits, so the pipeline's `(source, external_id)` dedup key
+collapses board and link-followed rows into one.
+
+**5. Extract the shared Habr detail parse.** The `JobPosting` ld+json description parse currently
+lives inline in `internal/linksource/habrcareer.go`. Extract a small helper in `internal/sources`
+(e.g. `habrVacancyDescription(node) string`, reusing `sources.LDJobPosting` + `sources.SanitizeHTML`)
+and call it from both the board adapter and the linksource adapter, so the two never diverge.
+The board adapter only needs the **description** from the detail page (title/company/location/
+date already come from the listing); linksource keeps deriving the rest from the page as it does
+today.
+
+**6. Posted date from the listing, not `basic-date`.** Use the listing item's
+`publishedDate.date` (clean RFC 3339). The linksource comment claims the detail page's
+`datePosted` ld+json runs ~a month ahead and trusts `<time class="basic-date">` instead — but
+recon showed `basic-date` is the page **render** time (it equalled "now" on fetch), so it is
+also wrong as a publish date. The listing `publishedDate.date` is the authoritative value; this
+change uses it for the board adapter and leaves the linksource path's date handling untouched
+unless the extraction refactor naturally touches it (note as a follow-up, do not expand scope).
+
+**7. Work mode / remote.** Mark remote and set structured work mode `remote` iff the listing
+item's `remoteWork` is `true`; otherwise leave work mode empty so the pipeline's location parser
+decides. (Habr's structured signal is a boolean, so we cannot distinguish onsite vs hybrid.)
+
+**8. Description fallback.** If the detail page has no `JobPosting` ld+json or the request fails,
+yield the vacancy anyway with an empty description (listing metadata is still useful and
+enrichment/skilltag degrade gracefully). A single dropped detail must not drop the vacancy.
+
+## Risks / Trade-offs
+
+- **~748/974 coverage.** Documented hard ceiling, not a fixable seam; mitigated by the existing
+  linksource pulling some hidden vacancies. Re-survey if Habr changes the cap.
+- **~748 detail fetches per run.** Comparable to existing detail-per-job adapters (USAJobs,
+  Reed, getmatch) under the shared rate-limited client; acceptable for a daily cron. If it grows,
+  `StreamingSource` is the noted upgrade path.
+- **Refactor risk on linksource.** Extracting the shared parse touches a working adapter; its
+  existing tests must stay green, and the extraction must preserve current linksource behavior.
+
+## Migration / Rollout
+
+- New adapter ships inside the existing server/ingest binaries — full image rebuild, **no**
+  Dockerfile change.
+- Needs a new `cmd/ingest sources/habrcareer.yml` cron line (an ops change, mirroring the
+  existing `getmatch`/`tecla` aggregator cron slots) so the detail fan-out crawls independently.
+- The per-provider stale-job sweep closes `habr_career` jobs unseen for 48h; a reappearing
+  vacancy reopens via the upsert. No migration, no reindex required at ingest time (the standard
+  facet derivation + enrichment run downstream).

--- a/openspec/changes/add-habr-career-source/proposal.md
+++ b/openspec/changes/add-habr-career-source/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Habr Career (`career.habr.com`) is a major Russian-language IT job board. Today freehire only
+captures its vacancies opportunistically — `internal/linksource/habrcareer.go` resolves a Habr
+vacancy only when a Telegram post happens to link to it. The board itself is never crawled, so
+the catalogue misses ~hundreds of open Russian IT roles that Habr publishes through a clean,
+public, keyless JSON API.
+
+## What Changes
+
+- Add a new `habr_career` source adapter that crawls `career.habr.com` through its public
+  listing API `GET /api/frontend/vacancies` (paginated), fetching each vacancy's full HTML
+  description from its public detail page.
+- Register it as a **boardless aggregator** provider (many employers behind one feed), mirroring
+  the existing `getmatch`/`tecla`/`jobstash` adapters — one new adapter file, one `sources.All`
+  line, one `sources/custom.yml` entry, no pipeline changes.
+- Yield vacancies under `source = "habr_career"` with an `external_id`/`url` **identical** to the
+  existing linksource adapter, so board-crawled and Telegram-link-followed Habr vacancies dedup
+  into one row.
+- Extract the shared Habr detail-page description parse so the board adapter and the linksource
+  adapter use one helper instead of duplicating it.
+- Document a hard coverage ceiling: the public API exposes only ~748 of the ~974 vacancies it
+  reports; the remaining ~225 are unreachable by any anonymous channel (verified) and are out of
+  scope for v1.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. Reuses the source-ingest pipeline and write path unchanged. -->
+
+### Modified Capabilities
+- `source-ingest`: add a requirement that `habr_career` is a registered boardless aggregator
+  provider — it enumerates Habr Career from the public `/api/frontend/vacancies` JSON feed
+  (paginated, per-vacancy employer), fetches each vacancy's full HTML description from its
+  `career.habr.com/vacancies/<id>` detail page, and yields the normalized job shape under an
+  identity that dedups with the existing Habr linksource adapter.
+
+## Impact
+
+- **New code:** `internal/sources/habrcareer.go` (+ tests with captured fixtures).
+- **Modified code:** `internal/sources/source.go` (`sources.All` registry line); a shared
+  Habr description-parse helper reused by `internal/linksource/habrcareer.go`.
+- **Config:** one new entry in `sources/custom.yml`.
+- **Ops:** new adapter ships in the existing server/ingest binaries (full image rebuild, no
+  Dockerfile change); relies on the existing `cmd/ingest sources/custom.yml` cron schedule. The
+  per-provider stale-job sweep closes `habr_career` jobs unseen for 48h.
+- **External dependency:** the public, keyless `career.habr.com` API; `robots.txt` permits
+  `/vacancies`.

--- a/openspec/changes/add-habr-career-source/specs/source-ingest/spec.md
+++ b/openspec/changes/add-habr-career-source/specs/source-ingest/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: habr_career is a registered boardless aggregator provider
+
+The system SHALL register a `habr_career` adapter so the Habr Career (`career.habr.com`) IT job
+board can be listed in a board file as a boardless aggregator (its config entry carries no
+`board`, and the provider remains in the source facet). The adapter SHALL enumerate the board
+from the public, keyless listing API `GET https://career.habr.com/api/frontend/vacancies`,
+sending `type=all` and `sort=date` and paginating with an increasing `page`, and SHALL send the
+request headers `Accept: application/json` and `Referer: https://career.habr.com/vacancies`.
+Pagination SHALL stop when the response's `meta.currentPage` reaches `meta.totalPages` (or the
+`list` is empty), bounded by a maximum page count so a missing or invalid total cannot loop.
+Each vacancy's employer SHALL come from the vacancy's own `company.title` (not the configured
+company, which is a validation placeholder). The adapter SHALL yield the normalized job shape
+with `external_id` set to the vacancy's numeric `id`, `url` set to
+`https://career.habr.com/vacancies/<id>`, `title` set to `title`, `location` set to the
+vacancy's distinct `locations[].title` values joined, and `posted_at` parsed from
+`publishedDate.date`.
+
+#### Scenario: The board is enumerated from the paginated public listing API
+
+- **WHEN** a board file lists a boardless entry with provider `habr_career`
+- **THEN** the adapter requests `https://career.habr.com/api/frontend/vacancies?type=all&sort=date`
+  with increasing `page`, stops once `meta.currentPage` reaches `meta.totalPages`, and yields
+  each listed vacancy as the normalized job shape with `external_id` set to the vacancy `id`,
+  `url` set to `https://career.habr.com/vacancies/<id>`, `company` set to the vacancy's own
+  `company.title`, and `posted_at` parsed from `publishedDate.date`
+
+#### Scenario: A failed first page is a board error; a failed later page ends enumeration
+
+- **WHEN** the first listing-API page request fails
+- **THEN** the adapter returns an error for the board
+- **WHEN** a later page request fails after at least one page succeeded
+- **THEN** the adapter stops paginating and returns the jobs gathered so far without error
+
+### Requirement: habr_career deduplicates with the Habr linksource adapter
+
+The `habr_career` board adapter SHALL emit the same identity as the existing Habr Career
+link-following adapter (`internal/linksource`) for the same vacancy, so a vacancy crawled from
+the board and the same vacancy followed from a Telegram link resolve to one catalogue row.
+Both SHALL use `source = "habr_career"`, `external_id` set to the numeric vacancy id, and `url`
+set to the canonical `https://career.habr.com/vacancies/<id>`. The shared logic that parses a
+Habr vacancy detail page's `JobPosting` ld+json into a description SHALL live in one helper used
+by both adapters rather than being duplicated.
+
+#### Scenario: Board-crawled and link-followed Habr vacancies dedup into one row
+
+- **WHEN** the same Habr vacancy is both crawled by the `habr_career` board adapter and resolved
+  from a Telegram link by the linksource adapter
+- **THEN** both yield `source = "habr_career"`, the same numeric `external_id`, and the same
+  canonical `url`, so the pipeline's upsert dedup key collapses them into a single row
+
+### Requirement: habr_career descriptions come from the per-vacancy detail page
+
+The listing API does not include vacancy descriptions, so the adapter SHALL fetch each
+vacancy's detail page `GET https://career.habr.com/vacancies/<id>` and parse the `JobPosting`
+ld+json `description`, yielding it as the job `description` after HTML sanitization (active
+content stripped, structure such as paragraphs and lists kept). When the detail page has no
+`JobPosting` ld+json or the detail request fails, the adapter SHALL still yield the vacancy with
+the metadata available from the listing rather than dropping it.
+
+#### Scenario: Full description is taken from the detail page and sanitized
+
+- **WHEN** a vacancy's detail page exposes a `JobPosting` ld+json with a non-empty `description`
+- **THEN** the adapter yields that HTML as the job `description`, sanitized
+
+#### Scenario: Missing or failed detail still yields the vacancy
+
+- **WHEN** a vacancy's detail page has no `JobPosting` ld+json or its request fails
+- **THEN** the adapter yields the vacancy with its listing-derived fields and an empty
+  `description` rather than dropping it
+
+### Requirement: habr_career derives work mode and posted date from structured listing fields
+
+The adapter SHALL mark a vacancy remote when and only when the listing item's `remoteWork` is
+`true`, and SHALL set the structured work mode to `remote` in that case (leaving it empty
+otherwise, so the pipeline's location parser decides on-site/hybrid). The posted date SHALL be
+parsed from the listing item's `publishedDate.date` (an RFC 3339 timestamp); the adapter SHALL
+NOT read the detail page's `<time class="basic-date">` element, which is the page render time
+rather than the publish date.
+
+#### Scenario: Remote flag drives the structured work mode
+
+- **WHEN** a listing item has `remoteWork` set to `true`
+- **THEN** the adapter marks the job remote and sets the structured work mode to `remote`
+- **WHEN** a listing item has `remoteWork` set to `false`
+- **THEN** the adapter leaves the structured work mode empty and the job not-remote, so the
+  pipeline falls back to parsing the location string
+
+#### Scenario: Posted date comes from the listing, not the detail page
+
+- **WHEN** the adapter maps a vacancy
+- **THEN** `posted_at` is parsed from the listing item's `publishedDate.date` and the detail
+  page's `basic-date` time element is not used

--- a/openspec/changes/add-habr-career-source/tasks.md
+++ b/openspec/changes/add-habr-career-source/tasks.md
@@ -1,0 +1,45 @@
+## 1. Test fixtures
+
+- [x] 1.1 Capture a trimmed real `/api/frontend/vacancies?type=all&sort=date&page=1` list
+  response (a few vacancies spanning `remoteWork: true`/`false`, multi-location, and a missing
+  `company`/`publishedDate` edge) and one `vacancies/<id>` detail HTML (with a `JobPosting`
+  ld+json description) into `internal/sources/testdata/` for the adapter test. No network in
+  tests.
+
+## 2. Shared detail parse extraction
+
+- [x] 2.1 Extract the Habr `JobPosting` ld+json description parse currently inline in
+  `internal/linksource/habrcareer.go` into one reusable helper (in `internal/sources`, reusing
+  `sources.LDJobPosting` + `sources.SanitizeHTML`), and call it from the linksource adapter
+  unchanged. Keep linksource's existing tests green (preserve current behavior).
+
+## 3. Adapter core
+
+- [x] 3.1 Define the listing response/item structs and the `habrCareer` adapter type with
+  `Provider()` returning `"habr_career"`, `boardless()`, `aggregator()`, and a constructor over
+  a private interface embedding `HeaderJSONGetter` + `HTMLGetter` (mirroring `breezy`).
+- [x] 3.2 Implement `Fetch`: request `page=1` of
+  `/api/frontend/vacancies?type=all&sort=date` with headers `Accept: application/json` and
+  `Referer: https://career.habr.com/vacancies`, read `meta.totalPages`, paginate `page=2..N`
+  (max-page guard), stop early on empty `list`; first-page failure errors, later-page failure
+  ends enumeration returning jobs so far.
+- [x] 3.3 Map each list item to `Job`: `ExternalID`=`id`, `URL`=`https://career.habr.com/vacancies/<id>`,
+  `Title`=`title`, `Company`=`company.title`, `Location`=distinct `locations[].title` joined,
+  `PostedAt`=`publishedDate.date`; set `Remote` and `WorkMode="remote"` iff `remoteWork` is true.
+- [x] 3.4 For each vacancy, GET the detail page `vacancies/<id>` and set `Description` from the
+  shared helper (2.1); on missing ld+json or a failed detail request, yield the vacancy with an
+  empty description rather than dropping it.
+
+## 4. Registration and config
+
+- [x] 4.1 Register `habr_career` in `sources.All` (one constructor line).
+- [x] 4.2 Add a dedicated `sources/habrcareer.yml` with one boardless placeholder entry
+  (mirroring `getmatch.yml`/`tecla.yml`: aggregators get their own file + cron slot so the
+  per-vacancy detail fan-out crawls independently). A new `cmd/ingest sources/habrcareer.yml`
+  cron line is an ops change at deploy time (not in this repo).
+
+## 5. Verification
+
+- [x] 5.1 `go build ./... && go vet ./... && go test ./internal/sources/ ./internal/linksource/`
+  all green, and a live smoke run of the adapter against the real API yields ~748 normalized
+  jobs with full descriptions and correct dedup identity with the linksource adapter.

--- a/sources/habrcareer.yml
+++ b/sources/habrcareer.yml
@@ -1,0 +1,6 @@
+# Habr Career (career.habr.com), a Russian-language IT job board. Boardless aggregator: one
+# public listing API (career.habr.com/api/frontend/vacancies), so the entry carries no board,
+# and each job's company comes from the listing item, not this placeholder. The crawl fetches a
+# detail page per vacancy for the description, so it gets its own cron slot (like getmatch).
+- company: Habr Career
+  provider: habr_career


### PR DESCRIPTION
## Summary

- Add a `habr_career` source adapter that crawls **career.habr.com** via its public, keyless JSON listing API (`/api/frontend/vacancies`, paginated), fetching each vacancy's full HTML description from its detail page's `JobPosting` ld+json.
- Registered as a **boardless aggregator** (many employers, one feed), mirroring `getmatch`/`tecla`/`jobstash` — one adapter file + one `sources.All` line + a dedicated `sources/habrcareer.yml`.
- Emitted identity (`external_id` = numeric id, `url` = `https://career.habr.com/vacancies/<id>`) is **identical to the existing Habr `linksource` adapter**, so board-crawled and Telegram-link-followed Habr vacancies dedup into one row.
- Extracted the shared Habr detail parse into `sources.ParseHabrPosting`, now reused by `internal/linksource/habrcareer.go` (was a private copy) — behavior preserved.
- Posted date comes from the listing's `publishedDate.date` (the detail `basic-date` element is the page render time, not the publish date).
- A failed detail fetch or a page without `JobPosting` still yields the vacancy (empty description), never drops it.

### Coverage ceiling (documented hard limit)
The API reports ~974 vacancies but paginates to only ~748; the cap sits on the result-set itself — verified that every sort ordering, the `s[]`/`qid` filters, and the RSS feed return the **same ~748 ids**. The remaining ~225 need an authenticated session (out of scope). The existing Telegram linksource pulls some of them in via dedup.

OpenSpec change: `openspec/changes/add-habr-career-source/`.

## Test Plan

- [x] `go build ./... && go vet ./internal/sources/ ./internal/linksource/` clean
- [x] `go test ./internal/sources/ ./internal/linksource/` green (incl. pagination, API headers, first/later-page failure, missing-detail-still-yields, remote/work-mode, date provenance, board-file validation, linksource regression)
- [x] New adapter tests race-clean under `-race`
- [x] Live smoke against the real API: 749 jobs, canonical URLs, descriptions parse on live detail pages
- [ ] Ops: new image build + a `cmd/ingest sources/habrcareer.yml` cron slot (like getmatch)

> Note: pre-existing `-race` data races in unrelated adapter test fakes (Apple/Gem/MTS) are out of scope for this PR.