### PR TITLE
feat(sources): add 5 AI-hiring boards from CrewAI thread

### DIFF
--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -69,3 +69,5 @@
   board: reveleer
 - company: GNO Partners
   board: gno-partners
+- company: Citizen Health
+  board: joincitizen

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -949,3 +949,7 @@
   board: "shippeo"
 - company: "VanOnGo"
   board: "vanongo"
+- company: "Applus IDIADA"
+  board: "ApplusIDIADA1"
+- company: "Fapon"
+  board: "Fapon"

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -666,3 +666,7 @@
   board: "yourhero-douleutaras"
 - company: "Zodia Custody"
   board: "zodia-custody"
+- company: "Adcetera"
+  board: "adcetera"
+- company: "Proximity Works"
+  board: "proximity-works"


### PR DESCRIPTION
Harvested from the CrewAI community job-listings thread; each board live-validated against its ATS public API before adding.

| Company | ATS | Board | API status |
|---|---|---|---|
| Applus IDIADA | SmartRecruiters | `ApplusIDIADA1` | 200, **167** postings |
| Fapon | SmartRecruiters | `Fapon` | 200, live (0 open now) |
| Citizen Health | Breezy | `joincitizen` | 200, live (0 open now) |
| Adcetera | Workable | `adcetera` | 200, live (0 open now) |
| Proximity Works | Workable | `proximity-works` | 200, live (0 open now) |

**Dropped (broken, not added):** FabFitFun (Greenhouse token 404s — off GH), Mindtech (Breezy `/json` 403s).

All on already-supported ATS → no code change, sources-only `--no-build` deploy.