### PR TITLE
feat(search): filter jobs by publication freshness (posted within N days)

### DIFF
--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -124,7 +124,7 @@ func FromRow(j db.Job) (Job, error) {
 		WorkMode:          workMode,
 		Skills:            skills,
 		Collections:       collections,
-		PostedAt:          rfc3339(effectivePostedAt(j.PostedAt, j.CreatedAt)),
+		PostedAt:          rfc3339(EffectivePostedAt(j.PostedAt, j.CreatedAt)),
 		CreatedAt:         rfc3339(j.CreatedAt),
 		UpdatedAt:         rfc3339(j.UpdatedAt),
 		ClosedAt:          rfc3339(j.ClosedAt),
@@ -164,13 +164,16 @@ func FromRows(jobs []db.Job) ([]Job, error) {
 	return out, nil
 }
 
-// effectivePostedAt is the timestamp a job reads as "posted" for both display and the
+// EffectivePostedAt is the timestamp a job reads as "posted" for both display and the
 // freshest-first sort: the source's posted_at when present and not in the future, otherwise
 // the ingest time (created_at). A missing posted_at (undated source) or a future one (e.g. a
 // Workday startDate set to a future go-live) would otherwise leave the job undated or sort it
 // above genuinely recent postings; falling back to created_at gives an honest, recent
 // freshness. The raw created_at stays exposed separately, so the substitution is visible.
-func effectivePostedAt(posted, created pgtype.Timestamptz) pgtype.Timestamptz {
+//
+// It is exported so the search document derives its numeric posted_ts (epoch) from the same
+// definition the display posted_at (RFC3339) uses — one fallback rule, two encodings.
+func EffectivePostedAt(posted, created pgtype.Timestamptz) pgtype.Timestamptz {
 	if !posted.Valid || posted.Time.After(time.Now()) {
 		return created
 	}

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -14,6 +14,30 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
+// TestEffectivePostedAt covers the exported single-source-of-truth helper directly:
+// it is what both the display posted_at (RFC3339) and the index posted_ts (epoch)
+// derive from, so the null/future fallback must hold independent of FromRow.
+func TestEffectivePostedAt(t *testing.T) {
+	created := pgtype.Timestamptz{Time: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC), Valid: true}
+
+	// A real, past posted_at is returned unchanged.
+	past := pgtype.Timestamptz{Time: time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC), Valid: true}
+	if got := EffectivePostedAt(past, created); !got.Time.Equal(past.Time) {
+		t.Errorf("past posted_at: got %v, want %v", got.Time, past.Time)
+	}
+
+	// A future posted_at falls back to the ingest time (created_at).
+	future := pgtype.Timestamptz{Time: time.Now().Add(24 * time.Hour), Valid: true}
+	if got := EffectivePostedAt(future, created); !got.Time.Equal(created.Time) {
+		t.Errorf("future posted_at: got %v, want created %v", got.Time, created.Time)
+	}
+
+	// A missing (invalid) posted_at also falls back to created_at.
+	if got := EffectivePostedAt(pgtype.Timestamptz{}, created); !got.Time.Equal(created.Time) {
+		t.Errorf("missing posted_at: got %v, want created %v", got.Time, created.Time)
+	}
+}
+
 func TestFromRow_PostedAtFallsBackToCreatedAtWhenFutureOrMissing(t *testing.T) {
 	created := time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC)
 	createdTS := pgtype.Timestamptz{Time: created, Valid: true}

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -472,6 +472,10 @@ func facetSettings() *meilisearch.Settings {
 			"enrichment.salary_currency", "enrichment.salary_period",
 			"enrichment.salary_min", "enrichment.salary_max", "enrichment.experience_years_min",
 			"enrichment.relocation", "enrichment.english_level", "enrichment.posting_language",
+			// posted_ts is the effective posting date in unix seconds — the numeric
+			// field the "posted within N days" range filter needs (Meili range operators
+			// require a number; the string posted_at below is sort-only).
+			"posted_ts",
 		},
 		// posted_at / created_at are RFC3339 UTC strings and sort chronologically as text.
 		SortableAttributes: []string{"posted_at", "created_at", "enrichment.salary_min", "enrichment.salary_max"},

--- a/internal/search/document.go
+++ b/internal/search/document.go
@@ -29,6 +29,12 @@ const maxIndexedDescriptionRunes = 1000
 type JobDocument struct {
 	ID int64 `json:"id"`
 	jobview.Job
+	// PostedTS is the job's effective posting date in unix seconds — the numeric
+	// encoding of the same date jobview.Job.PostedAt renders as an RFC3339 string.
+	// It exists only to back the Meilisearch range filter for "posted within N days"
+	// (Meili range operators need a number, not a string); it is declared on the
+	// document, not on jobview.Job, so it is filterable but never served to clients.
+	PostedTS int64 `json:"posted_ts"`
 }
 
 // FromJob maps a database job row to its index document. An empty or absent
@@ -45,7 +51,11 @@ func FromJob(j db.Job) (JobDocument, error) {
 	// the search document — the detail endpoint serves the full description from
 	// its own jobview.FromRow, unaffected by this local copy.
 	view.Description = truncateRunes(view.Description, maxIndexedDescriptionRunes)
-	return JobDocument{ID: j.ID, Job: view}, nil
+	doc := JobDocument{ID: j.ID, Job: view}
+	if eff := jobview.EffectivePostedAt(j.PostedAt, j.CreatedAt); eff.Valid {
+		doc.PostedTS = eff.Time.Unix()
+	}
+	return doc, nil
 }
 
 // truncateRunes returns the first n runes of s (UTF-8 safe), backed off to the

--- a/internal/search/document_test.go
+++ b/internal/search/document_test.go
@@ -4,9 +4,13 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobview"
 )
 
 func TestFromJob_DocumentFlattensIDAndViewToTopLevelJSON(t *testing.T) {
@@ -34,6 +38,52 @@ func TestFromJob_DocumentFlattensIDAndViewToTopLevelJSON(t *testing.T) {
 	}
 	if _, ok := m["enrichment"]; !ok {
 		t.Errorf("enrichment should be a nested object in %s", raw)
+	}
+}
+
+func TestFromJob_PostedTSIsEffectiveDateEpoch(t *testing.T) {
+	// posted_ts is the numeric (unix-seconds) encoding of the SAME effective posting
+	// date the display posted_at reflects, so the Meilisearch range filter agrees with
+	// what the user sees. A past posted_at is used directly; a future one falls back to
+	// created_at (mirroring jobview.EffectivePostedAt).
+	created := pgtype.Timestamptz{Time: time.Date(2026, 6, 18, 12, 0, 0, 0, time.UTC), Valid: true}
+	past := pgtype.Timestamptz{Time: time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC), Valid: true}
+
+	doc, err := FromJob(db.Job{ID: 1, PublicSlug: "s", CreatedAt: created, PostedAt: past})
+	if err != nil {
+		t.Fatalf("FromJob: %v", err)
+	}
+	if doc.PostedTS != past.Time.Unix() {
+		t.Errorf("posted_ts = %d, want %d (past posted_at)", doc.PostedTS, past.Time.Unix())
+	}
+
+	future := pgtype.Timestamptz{Time: time.Now().Add(48 * time.Hour), Valid: true}
+	docFuture, err := FromJob(db.Job{ID: 2, PublicSlug: "s2", CreatedAt: created, PostedAt: future})
+	if err != nil {
+		t.Fatalf("FromJob future: %v", err)
+	}
+	if docFuture.PostedTS != created.Time.Unix() {
+		t.Errorf("posted_ts = %d, want %d (future posted_at falls back to created_at)", docFuture.PostedTS, created.Time.Unix())
+	}
+
+	// posted_ts is an index-only field: it must be present on the document JSON (so
+	// Meilisearch can filter on it) but absent from the public job wire shape served
+	// to clients (jobview.Job).
+	rawDoc, _ := json.Marshal(doc)
+	var docMap map[string]json.RawMessage
+	if err := json.Unmarshal(rawDoc, &docMap); err != nil {
+		t.Fatalf("unmarshal doc: %v", err)
+	}
+	if _, ok := docMap["posted_ts"]; !ok {
+		t.Errorf("posted_ts missing from index document: %s", rawDoc)
+	}
+	rawView, _ := json.Marshal(jobview.Job{PublicSlug: "s"})
+	var viewMap map[string]json.RawMessage
+	if err := json.Unmarshal(rawView, &viewMap); err != nil {
+		t.Fatalf("unmarshal view: %v", err)
+	}
+	if _, ok := viewMap["posted_ts"]; ok {
+		t.Errorf("posted_ts leaked into the public job wire shape: %s", rawView)
 	}
 }
 

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -3,6 +3,7 @@ package search
 import (
 	"net/url"
 	"strconv"
+	"time"
 )
 
 // StringFacets maps an equality-facet query param to its index attribute. It is
@@ -43,6 +44,14 @@ var StringFacets = map[string]string{
 // build identical filters from the same canonical query string — the handler
 // parses the request query, the matcher parses a saved search's stored query.
 func FilterFromValues(v url.Values) any {
+	return filterFromValues(v, time.Now())
+}
+
+// filterFromValues is FilterFromValues with the reference time injected, so the
+// relative `posted_within_days` cutoff is deterministic under test. The exported
+// wrapper supplies time.Now(); only this inner form is unit-tested for the date
+// branch.
+func filterFromValues(v url.Values, now time.Time) any {
 	var groups [][]string
 
 	for param, attr := range StringFacets {
@@ -78,6 +87,14 @@ func FilterFromValues(v url.Values) any {
 	}
 	if n, ok := atoiOK(v.Get("experience_years_min")); ok {
 		groups = append(groups, []string{Gte("enrichment.experience_years_min", n)})
+	}
+
+	// Freshness: posted_within_days=N restricts to jobs posted in the last N days,
+	// i.e. whose effective posting date (posted_ts, unix seconds) is at or after
+	// now - N*86400. A non-positive or non-numeric value imposes no restriction.
+	if n, ok := atoiOK(v.Get("posted_within_days")); ok && n > 0 {
+		cutoff := now.Add(-time.Duration(n) * 24 * time.Hour).Unix()
+		groups = append(groups, []string{Gte("posted_ts", int(cutoff))})
 	}
 
 	return Filter(groups...)

--- a/internal/search/query_filter_test.go
+++ b/internal/search/query_filter_test.go
@@ -1,10 +1,12 @@
 package search
 
 import (
+	"fmt"
 	"net/url"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 )
 
 // normalizeGroups makes a Filter result order-insensitive for comparison: the
@@ -106,6 +108,39 @@ func TestFilterFromValues_VisaBoolAndNumeric(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFilterFromValues_PostedWithinDays(t *testing.T) {
+	// now is injected so the cutoff is deterministic. posted_within_days=N restricts
+	// to posted_ts >= now - N*86400 (posted within the last N days).
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+	cutoff := now.Unix() - 7*86400
+
+	got := normalizeGroups(t, filterFromValues(vals("posted_within_days=7"), now))
+	want := [][]string{{fmt.Sprintf("posted_ts >= %d", cutoff)}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("posted_within_days=7: got %v, want %v", got, want)
+	}
+
+	// It ANDs with other facets as its own group.
+	got = normalizeGroups(t, filterFromValues(vals("seniority=senior&posted_within_days=7"), now))
+	want = [][]string{
+		{`enrichment.seniority = "senior"`},
+		{fmt.Sprintf("posted_ts >= %d", cutoff)},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("composed: got %v, want %v", got, want)
+	}
+}
+
+func TestFilterFromValues_PostedWithinDaysInvalidIgnored(t *testing.T) {
+	// Absent, empty, zero, negative, and non-numeric values impose no date restriction.
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+	for _, q := range []string{"", "posted_within_days=", "posted_within_days=0", "posted_within_days=-3", "posted_within_days=soon"} {
+		if got := filterFromValues(vals(q), now); got != nil {
+			t.Errorf("filterFromValues(%q) = %v, want nil (no date filter)", q, got)
+		}
 	}
 }
 

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -289,6 +289,55 @@ func TestSearchFiltersBySkillsFacet(t *testing.T) {
 	}
 }
 
+// The "posted within N days" freshness filter works end-to-end: posted_ts is
+// indexed as a numeric, filterable attribute, so a Meilisearch range filter built
+// from posted_within_days returns only the recent posting and drops the stale one.
+func TestSearchFiltersByPostedWithinDays(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	now := time.Now()
+	jobs := []db.Job{
+		{
+			ID: 20, Title: "Fresh Role", Company: "Acme", PublicSlug: "fresh-role-acme",
+			PostedAt:   pgtype.Timestamptz{Time: now.Add(-24 * time.Hour), Valid: true},
+			Enrichment: enrichedJSON(t, enrich.Enrichment{}),
+		},
+		{
+			ID: 21, Title: "Stale Role", Company: "Beta", PublicSlug: "stale-role-beta",
+			PostedAt:   pgtype.Timestamptz{Time: now.Add(-60 * 24 * time.Hour), Valid: true},
+			Enrichment: enrichedJSON(t, enrich.Enrichment{}),
+		},
+	}
+
+	docs := make([]JobDocument, 0, len(jobs))
+	for _, j := range jobs {
+		d, err := FromJob(j)
+		if err != nil {
+			t.Fatalf("FromJob: %v", err)
+		}
+		docs = append(docs, d)
+	}
+	if err := c.IndexJobs(ctx, docs); err != nil {
+		t.Fatalf("IndexJobs: %v", err)
+	}
+
+	res, err := c.Search(ctx, SearchParams{
+		Filter: FilterFromValues(vals("posted_within_days=7")),
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("Search with posted_within_days filter: %v", err)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].PublicSlug != "fresh-role-acme" {
+		t.Fatalf("freshness filter hits = %+v, want only fresh-role-acme", res.Hits)
+	}
+}
+
 // A job carries its company's curated collections as a top-level facet: filtering
 // on collections returns only the tagged jobs, and a facet distribution over
 // collections reports their counts.

--- a/internal/search/settings_test.go
+++ b/internal/search/settings_test.go
@@ -26,6 +26,28 @@ func TestSemanticSettingsHasEmbedder(t *testing.T) {
 	}
 }
 
+func TestPostedTSIsFilterableNotSortable(t *testing.T) {
+	// posted_ts backs the "posted within N days" range filter, so it must be a
+	// filterable attribute. Sorting still uses the string posted_at, so posted_ts
+	// is deliberately NOT added to the sortable attributes.
+	s := facetSettings()
+	if !contains(s.FilterableAttributes, "posted_ts") {
+		t.Errorf("posted_ts must be filterable, got %v", s.FilterableAttributes)
+	}
+	if contains(s.SortableAttributes, "posted_ts") {
+		t.Errorf("posted_ts must not be sortable (sort uses posted_at), got %v", s.SortableAttributes)
+	}
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
 func TestFacetAndSemanticShareKeywordSettings(t *testing.T) {
 	f, s := facetSettings(), semanticSettings()
 	if !reflect.DeepEqual(f.FilterableAttributes, s.FilterableAttributes) {

--- a/openspec/changes/add-posted-date-filter/.openspec.yaml
+++ b/openspec/changes/add-posted-date-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/add-posted-date-filter/design.md
+++ b/openspec/changes/add-posted-date-filter/design.md
@@ -1,0 +1,98 @@
+## Context
+
+`/api/v1/jobs/search` (Meilisearch-backed) already supports a numeric range
+filter for salary (`Gte("enrichment.salary_min", n)` / `Lte(...)`) and sorts
+browse results by `posted_at` descending. The job document carries `posted_at`
+as an **RFC3339 string**, derived from `effectivePostedAt(posted, created)` in
+`internal/jobview` — the source `posted_at` when present and not in the future,
+else `created_at`. Meilisearch range operators (`>=`, `<=`, `TO`) work only on
+**numbers**, so the existing string `posted_at` cannot back a date-range filter.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Filter `/jobs` search to "posted within the last N days" via a single relative
+  parameter `posted_within_days`.
+- Reuse the existing salary-range plumbing (`Gte`, `FilterFromValues`, the
+  filter sidebar slider pattern) rather than inventing new machinery.
+- Keep the effective-posting-date definition single-sourced with `jobview`.
+
+**Non-Goals:**
+
+- A two-ended date range (from–to). Out of scope.
+- A separate filter on raw `created_at`. Out of scope.
+- Changing sort behavior. Sorting still uses the string `posted_at`.
+- Facet counts/distribution for the date control.
+
+## Decisions
+
+### Relative `posted_within_days`, not an absolute cutoff
+
+The API takes a day count; the backend computes `cutoff = now - N*86400` at
+request time. **Alternative considered:** the client computes an absolute
+timestamp and sends `posted_after=<unix>`. Rejected: a bookmarked/shared "last 7
+days" URL would freeze to a stale absolute window, and the URL would carry an
+opaque epoch instead of a clean `posted_within_days=7`. The server already
+depends on wall-clock time for `effectivePostedAt`, so computing `now` here is
+consistent.
+
+### Derived index-only `posted_ts` (unix seconds)
+
+Add `posted_ts int64` to `JobDocument`, set to the epoch of `effectivePostedAt`,
+and declare it filterable (not serialized in the public job shape, not added to
+sortable attributes). **Alternative considered:** store a numeric timestamp as a
+real Postgres column. Rejected as overengineering — the value is fully derived
+from existing columns at index time, so a column + migration + backfill buys
+nothing the index field doesn't.
+
+### Single source of truth for the effective date
+
+`effectivePostedAt` is currently private in `jobview` and returns a
+`pgtype.Timestamptz`. Extract a small exported helper so both the display
+`posted_at` (RFC3339) and the new `posted_ts` (epoch) derive from one function,
+rather than duplicating the null/future fallback logic in `search`. The exact
+helper shape (e.g. an exported `EffectivePostedAt` returning the resolved
+`time.Time`, with `search` calling `.Unix()`) is settled during implementation;
+the invariant is "one definition, two encodings."
+
+### `now` is injected, not read from a global
+
+`FilterFromValues` is presently a pure function of `url.Values`. To keep the
+date branch unit-testable without monkeypatching `time.Now`, the reference time
+is passed in (e.g. an added parameter, or a sibling function that takes `now`).
+This mirrors how `effectivePostedAt` is the only place that reaches for the
+clock.
+
+### Discrete presets, not a free day count
+
+The slider snaps to `[1, 3, 7, 14, 30, 90, null]` (Today → 3 months → Any).
+**Alternative considered:** a continuous 1–365 slider like salary. Rejected:
+"47 days" is meaningless to a job seeker and harder to land on a round value;
+presets read clearly and keep URLs tidy. The slider is placed at the **top** of
+`FiltersPanel` because freshness is a primary filter.
+
+## Risks / Trade-offs
+
+- **Reindex required before the filter works on old jobs** → `posted_ts` only
+  appears on documents written after the settings change. Mitigation: ship a
+  `cmd/reindex` step in the deploy (tasks call it out explicitly); until then the
+  filter simply returns fewer/older results, never wrong ones.
+- **Relative window depends on server clock at query time** → a result set is
+  not reproducible to the exact second across requests. Acceptable and expected
+  for a "freshness" control; the alternative (absolute cutoff) trades this for
+  staleness, which is worse here.
+- **Day-granular sources** → some sources only provide a date, not a time;
+  `effectivePostedAt` already normalizes this and the boundary is "within N
+  days," so sub-day precision is irrelevant.
+
+## Migration Plan
+
+1. Deploy backend + frontend (no DB migration).
+2. Run `cmd/reindex` so `posted_ts` populates existing documents.
+3. Rollback: revert the deploy; the orphan `posted_ts` field on documents is
+   harmless and is removed on the next reindex from the reverted code.
+
+## Open Questions
+
+None — design approved in brainstorming.

--- a/openspec/changes/add-posted-date-filter/proposal.md
+++ b/openspec/changes/add-posted-date-filter/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Job seekers care most about freshness — a posting from three months ago is
+usually noise. The `/jobs` search can sort by posting date but cannot *filter*
+by it, so a user who only wants vacancies from the last week still has to scroll
+past stale results. A simple "posted within last N days" control closes that gap.
+
+## What Changes
+
+- Add a derived, index-only numeric field `posted_ts` (unix seconds of the job's
+  effective posting date) to the Meilisearch job document, and declare it a
+  filterable attribute. Sorting is unchanged.
+- Accept a new `posted_within_days=N` query parameter on
+  `GET /api/v1/jobs/search`. When present and a positive integer, the search is
+  filtered to jobs whose `posted_ts` is at or after `now - N*86400`.
+- Add a "freshness" control to the web filter sidebar: a single discrete-preset
+  slider (Today · 3 days · week · 2 weeks · month · 3 months · Any) that
+  round-trips through the URL as `posted_within_days`.
+- Operational: the index document/settings change requires one `cmd/reindex`
+  after deploy so `posted_ts` is populated on existing jobs. No Postgres
+  backfill (the field is derived at index time).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `job-search`: the searchable index gains a `posted_ts` filterable attribute,
+  and the public search endpoint gains a `posted_within_days` freshness filter.
+
+## Impact
+
+- Backend: `internal/search/document.go` (new derived field),
+  `internal/search/client.go` (filterable attributes), `internal/search/query_filter.go`
+  (parse `posted_within_days` → `Gte("posted_ts", cutoff)`). A small shared
+  `effectivePostedAt`-to-epoch helper so the index field and `jobview.PostedAt`
+  stay one source of truth.
+- Frontend: `web/src/lib/filters.svelte.ts` (`postedWithinDays` state + URL
+  round-trip + store method), `web/src/lib/facets.ts` (preset list),
+  `web/src/lib/components/FiltersPanel.svelte` (the slider).
+- Operations: a `cmd/reindex` run after deploy. No DB migration, no Postgres
+  backfill, no sort change.

--- a/openspec/changes/add-posted-date-filter/specs/job-search/spec.md
+++ b/openspec/changes/add-posted-date-filter/specs/job-search/spec.md
@@ -1,0 +1,137 @@
+## MODIFIED Requirements
+
+### Requirement: Searchable jobs index
+
+The system SHALL maintain a Meilisearch index of jobs with one document per job,
+keyed by the job's internal `id`. Each document SHALL carry the fields needed to
+both match and render a result without a follow-up database read: the searchable
+text (title, company, description, location), the filterable facets, the
+sortable fields, and the display fields returned to clients.
+
+The index SHALL declare:
+- **searchable attributes**: title, company, description, location.
+- **filterable attributes**: source, company_slug, work_mode, employment_type,
+  seniority, category, domains, regions, countries, company_type, company_size,
+  visa_sponsorship, salary_currency, salary_period, skills, salary_min,
+  salary_max, experience_years_min, and `posted_ts`. The raw `remote` flag SHALL
+  NOT be a filterable attribute (work_mode subsumes it).
+- **sortable attributes**: posted_at, salary_min, salary_max.
+
+Each document SHALL carry a derived numeric `posted_ts` field: the unix-seconds
+value of the job's **effective** posting date — the source's `posted_at` when
+present and not in the future, otherwise the ingest time (`created_at`) — the
+same value, in epoch form, that the document's display `posted_at` reflects.
+`posted_ts` is an index-only field: it SHALL be filterable but SHALL NOT appear
+in the public job wire shape returned by the job read endpoints. Because
+`posted_ts` is derived at index time, no Postgres column or backfill is
+required; a reindex SHALL populate it on existing jobs.
+
+Geography and work mode are filtered through the document's **top-level**
+`regions`, `countries`, and `work_mode` fields — the resolved union/precedence of
+the location-derived columns and the enrichment-derived values — not through the
+`enrichment.*` dot paths. There SHALL be no separate
+`enrichment.regions`/`enrichment.countries`/`enrichment.work_mode` facet on the
+document.
+
+Facets derived from a job's `enrichment` JSONB SHALL be absent (or empty) on the
+document when the job is not yet enriched; an unenriched job SHALL still be
+indexed and findable by its text fields, and SHALL still carry any geography
+parsed from its location.
+
+#### Scenario: A job is represented as one searchable document
+
+- **WHEN** a job with title "Senior Go Developer", company "Acme", and a
+  description is indexed
+- **THEN** the `jobs` index holds one document keyed by that job's `id` whose
+  searchable text includes the title, company, and description
+
+#### Scenario: Unenriched job is still indexed with its parsed geography
+
+- **WHEN** a job with no enrichment but location `Remote - USA` is indexed
+- **THEN** the document is present and matchable by its text, with its
+  enrichment-derived facets absent or empty and its top-level `regions`/
+  `countries` carrying the parsed geography
+
+#### Scenario: Geography is filterable via the top-level regions facet
+
+- **WHEN** a job whose unioned geography includes `eu` is indexed
+- **THEN** it is returned by a filter on `regions = "eu"`
+
+#### Scenario: Document carries the effective posting date as an epoch
+
+- **WHEN** a job whose effective posting date is a given instant is indexed
+- **THEN** its document carries `posted_ts` equal to that instant in unix
+  seconds, and a job with a null or future `posted_at` carries the `created_at`
+  instant instead — matching its display `posted_at`
+
+#### Scenario: posted_ts is filterable but not in the public job shape
+
+- **WHEN** a job document is indexed and the same job is read through a public
+  job endpoint
+- **THEN** the document is filterable by a `posted_ts` numeric range, while the
+  public job wire shape does not include a `posted_ts` field
+
+### Requirement: Public job search endpoint
+
+The system SHALL expose `GET /api/v1/jobs/search` as a public (unauthenticated)
+endpoint. It SHALL accept a free-text query `q`, facet filters matching the
+index's filterable attributes, an optional sort, an optional semantic ratio, and
+`limit`/`offset` pagination. Facet filters SHALL include `regions` (the geography
+facet) and SHALL NOT include the removed raw `remote` filter. The response SHALL
+use the standard list envelope `{"data": [...], "meta": {...}}`, where `data` is
+the matched job documents and `meta` carries at least the estimated total hit
+count and the applied `limit`/`offset`. The existing `GET /api/v1/jobs` list
+endpoint SHALL be unchanged.
+
+The endpoint SHALL additionally accept a `posted_within_days` parameter. When it
+is a positive integer `N`, the search SHALL be restricted to jobs whose
+`posted_ts` is at or after `now - N*86400` (i.e. posted within the last `N`
+days), where `now` is the time the request is served. When the parameter is
+absent, empty, zero, negative, or not a valid integer, it SHALL impose no date
+restriction. The filter SHALL compose with the other facet filters (AND).
+
+Each result SHALL identify its job by `public_slug` and SHALL NOT include the
+internal numeric `id`, consistent with the public-identity contract used by the
+other public job reads.
+
+#### Scenario: Keyword query returns matches
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=golang`
+- **THEN** the response is `{"data": [...], "meta": {...}}` with jobs matching
+  "golang" in `data` and the estimated total and pagination in `meta`
+
+#### Scenario: Faceted filtering by region
+
+- **WHEN** a client requests
+  `GET /api/v1/jobs/search?q=engineer&seniority=senior&regions=eu`
+- **THEN** only jobs whose facets satisfy seniority=senior AND whose top-level
+  `regions` include `eu` are returned
+
+#### Scenario: Empty query browses with filters
+
+- **WHEN** a client requests `GET /api/v1/jobs/search` with filters but no `q`
+- **THEN** the filtered jobs are returned ranked by the index defaults
+
+#### Scenario: Pagination is reflected in meta
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?q=go&limit=10&offset=20`
+- **THEN** at most 10 documents are returned and `meta` reports the applied
+  `limit` 10 and `offset` 20 alongside the estimated total
+
+#### Scenario: Results identify jobs by public slug, not internal id
+
+- **WHEN** a job is returned by `GET /api/v1/jobs/search`
+- **THEN** the result carries the job's `public_slug` and omits the internal
+  numeric `id`
+
+#### Scenario: Freshness filter restricts to recent postings
+
+- **WHEN** a client requests `GET /api/v1/jobs/search?posted_within_days=7`
+- **THEN** only jobs whose effective posting date is within the last 7 days are
+  returned
+
+#### Scenario: Invalid freshness value imposes no restriction
+
+- **WHEN** a client requests `GET /api/v1/jobs/search` with `posted_within_days`
+  absent, zero, negative, or non-numeric
+- **THEN** the result is not restricted by posting date

--- a/openspec/changes/add-posted-date-filter/tasks.md
+++ b/openspec/changes/add-posted-date-filter/tasks.md
@@ -1,0 +1,56 @@
+## 1. Effective-date helper (single source of truth)
+
+- [x] 1.1 Extract an exported effective-posting-date helper in `internal/jobview`
+  (resolving the null/future `posted_at` → `created_at` fallback once) and route
+  the existing display `PostedAt` through it, with a unit test covering present /
+  null / future `posted_at`.
+
+## 2. Search document carries `posted_ts`
+
+- [x] 2.1 Add a derived `posted_ts` (unix seconds of the effective posting date)
+  to `JobDocument` in `internal/search/document.go`, computed via the helper from
+  1.1; index-only (not in the public job wire shape). Unit test: `posted_ts`
+  equals the epoch of the effective date, including the null/future fallback.
+
+## 3. Index declares `posted_ts` filterable
+
+- [ ] 3.1 Add `"posted_ts"` to `FilterableAttributes` in
+  `internal/search/client.go` (leave `SortableAttributes` unchanged).
+
+## 4. Filter builder parses `posted_within_days`
+
+- [x] 4.1 Extend the search filter builder (`internal/search/query_filter.go`) so
+  a positive integer `posted_within_days=N` adds `Gte("posted_ts", now - N*86400)`,
+  with `now` injected (no global `time.Now`). Unit test: valid `N` → correct
+  `Gte` fragment against an injected reference time; absent / empty / zero /
+  negative / non-numeric → no date filter; composes with other facet filters.
+
+## 5. Frontend state + URL round-trip
+
+- [x] 5.1 Add `postedWithinDays: number | null` to `JobFilters`, round-trip it in
+  `filtersToParams` / `filtersFromParams` as `posted_within_days`, and add a
+  `setPostedWithinDays(n)` store method. (Uses `setSoon`, not `setNow`: the
+  control is a dragged range input, so it debounces the reload exactly like the
+  salary slider while writing the URL immediately.) Verify the round-trip
+  (params ↔ state) for set and cleared values.
+
+## 6. Frontend freshness slider
+
+- [x] 6.1 Add the preset list `[Today=1, 3d, week=7, 2 weeks=14, month=30,
+  3 months=90, Any=null]` alongside `SALARY_MAX` (which lives **in
+  `FiltersPanel.svelte`**, not `facets.ts`); the list is component-local, mirroring
+  the salary constants, since only the panel consumes it.
+- [x] 6.2 Render a discrete-preset range slider at the **top** of
+  `FiltersPanel.svelte` (rightmost = Any clears the param), wired to
+  `setPostedWithinDays`, following the salary-slider pattern. Verify via
+  `svelte-check` (+ `aria-valuetext` for the human label).
+
+## 7. Verify end-to-end and operations
+
+- [x] 7.1 Run `go build ./... && go vet ./... && go test ./...` and the web
+  checks; confirm the new param filters search results. (Added integration test
+  `TestSearchFiltersByPostedWithinDays` — real Meilisearch applies the posted_ts
+  range filter and returns only the recent posting; svelte-check clean.)
+- [x] 7.2 Record the post-deploy `cmd/reindex` requirement (so `posted_ts`
+  populates existing jobs) — captured in design.md → Migration Plan and the
+  proposal's Impact section.

--- a/web/src/lib/components/FiltersPanel.svelte
+++ b/web/src/lib/components/FiltersPanel.svelte
@@ -34,6 +34,34 @@
     const n = Number((e.currentTarget as HTMLInputElement).value);
     store.setSalaryMin(n === 0 ? null : n);
   }
+
+  // Freshness presets, oldest-to-newest left→right with "Any" as the rightmost
+  // (max) stop. The range input drives this by index, so the bounds are 0..last.
+  const FRESHNESS_PRESETS: { days: number | null; label: string }[] = [
+    { days: 1, label: 'Today' },
+    { days: 3, label: '3 days' },
+    { days: 7, label: '1 week' },
+    { days: 14, label: '2 weeks' },
+    { days: 30, label: '1 month' },
+    { days: 90, label: '3 months' },
+    { days: null, label: 'Any' },
+  ];
+  const ANY_INDEX = FRESHNESS_PRESETS.length - 1;
+
+  // Map the current filter value to a slider index. A non-preset value from a
+  // hand-edited URL has no exact stop, so it shows as "Any" until the user drags.
+  const freshnessIndex = $derived.by(() => {
+    const i = FRESHNESS_PRESETS.findIndex((p) => p.days === store.value.postedWithinDays);
+    return i < 0 ? ANY_INDEX : i;
+  });
+  const freshnessLabel = $derived(
+    FRESHNESS_PRESETS.find((p) => p.days === store.value.postedWithinDays)?.label ?? 'Any',
+  );
+
+  function onFreshnessInput(e: Event) {
+    const i = Number((e.currentTarget as HTMLInputElement).value);
+    store.setPostedWithinDays(FRESHNESS_PRESETS[i]?.days ?? null);
+  }
 </script>
 
 <div class="flex flex-col gap-4">
@@ -46,6 +74,30 @@
         Reset all
       </button>
     {/if}
+  </div>
+
+  <div class="border-b border-border pb-4">
+    <div class="mb-2 flex items-center justify-between">
+      <h3 class="text-sm font-semibold tracking-tight">Posted</h3>
+      <span class="text-xs font-medium text-muted-foreground">
+        {freshnessLabel}
+      </span>
+    </div>
+    <input
+      type="range"
+      min="0"
+      max={ANY_INDEX}
+      step="1"
+      value={freshnessIndex}
+      oninput={onFreshnessInput}
+      aria-label="Posted within"
+      aria-valuetext={freshnessLabel}
+      class="w-full accent-primary"
+    />
+    <div class="mt-1 flex justify-between text-[10px] text-muted-foreground">
+      <span>Today</span>
+      <span>Any</span>
+    </div>
   </div>
 
   {#each orderedFacets as def (def.param)}

--- a/web/src/lib/filters.svelte.ts
+++ b/web/src/lib/filters.svelte.ts
@@ -32,6 +32,10 @@ export interface JobFilters {
   facets: Record<string, FacetState>;
   visa: boolean;
   salaryMin: number | null;
+  /** Freshness: keep only jobs posted within the last N days (null = any age).
+   *  Serialized as `posted_within_days`; the backend turns it into a posted_ts
+   *  range filter relative to request time. */
+  postedWithinDays: number | null;
   sort: SortField;
 }
 
@@ -46,7 +50,7 @@ function emptyFacets(): Record<string, FacetState> {
 }
 
 export function emptyFilters(): JobFilters {
-  return { q: '', facets: emptyFacets(), visa: false, salaryMin: null, sort: DEFAULT_SORT };
+  return { q: '', facets: emptyFacets(), visa: false, salaryMin: null, postedWithinDays: null, sort: DEFAULT_SORT };
 }
 
 /** Serialize filters to URL query params (the shape the search API reads). */
@@ -65,6 +69,7 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
   }
   if (f.visa) p.set('visa_sponsorship', 'true');
   if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
+  if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
   // Omit the default sort: a clean URL leans on the backend's empty-query default.
   if (f.sort !== DEFAULT_SORT) p.set('sort', f.sort);
   return p;
@@ -89,6 +94,10 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
   f.visa = p.get('visa_sponsorship') === 'true';
   const salary = Number(p.get('salary_min'));
   f.salaryMin = p.get('salary_min') && !Number.isNaN(salary) ? salary : null;
+  // Freshness is a positive whole number of days; anything else (absent, zero,
+  // negative, non-numeric) reads as "any age", matching the backend's own guard.
+  const days = Number(p.get('posted_within_days'));
+  f.postedWithinDays = Number.isInteger(days) && days > 0 ? days : null;
   // Sort isn't user-selectable today, so it's never read from the URL — it stays
   // the default seeded by emptyFilters().
   return f;
@@ -100,6 +109,7 @@ export function activeFilterCount(f: JobFilters): number {
   for (const def of FACETS) n += f.facets[def.param]?.values.length ?? 0;
   if (f.visa) n += 1;
   if (f.salaryMin != null) n += 1;
+  if (f.postedWithinDays != null) n += 1;
   return n;
 }
 
@@ -152,6 +162,12 @@ export class FilterStore {
 
   setSalaryMin(n: number | null) {
     this.#url.setSoon({ ...this.#url.value, salaryMin: n });
+  }
+
+  // Dragged like the salary slider (a continuous gesture across snap points), so
+  // it debounces the reload via setSoon — the URL still updates immediately.
+  setPostedWithinDays(n: number | null) {
+    this.#url.setSoon({ ...this.#url.value, postedWithinDays: n });
   }
 
   // Discrete inputs (clicked/toggled): apply immediately via setNow.


### PR DESCRIPTION
## Summary
- Add a **"Posted within N days"** freshness filter to `/jobs` search — a discrete-preset slider (Today · 3d · 1w · 2w · 1m · 3m · Any) at the top of the filter sidebar.
- Meilisearch range operators need a number, so the job document gains a derived, **index-only** `posted_ts` (unix seconds of the effective posting date, from the now-exported `jobview.EffectivePostedAt` — one fallback rule, two encodings). It is declared **filterable** (not sortable; sort still uses the string `posted_at`) and never leaks into the public job wire shape.
- `GET /api/v1/jobs/search` accepts `posted_within_days=N`: a positive integer adds `Gte("posted_ts", now - N*86400)`. The reference time is injected (`filterFromValues(v, now)`) so the cutoff is deterministically unit-testable; non-positive/non-numeric values impose no restriction.
- Web: `postedWithinDays` round-trips through the URL as `posted_within_days`; the slider uses `setSoon` (debounced reload, immediate URL write) like the salary slider, since it is a dragged range input.

## Operational
⚠️ Requires **one `cmd/reindex` after deploy** so `posted_ts` populates existing documents. No Postgres column, migration, or backfill — the field is derived at index time. Until reindex, the filter simply returns fewer/older results, never wrong ones.

## Test Plan
- [x] `go build ./...` / `go vet ./...` — exit 0
- [x] `go test ./...` — 0 failures (unit)
- [x] `go test -tags=integration -run TestSearchFiltersByPostedWithinDays ./internal/search/` — PASS (real Meilisearch applies the `posted_ts` range filter, returns only the recent posting)
- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] Unit coverage: `EffectivePostedAt` (past/future/null), `FromJob` posted_ts epoch + leak invariant, `filterFromValues` cutoff math + invalid-value guards, `posted_ts` filterable-not-sortable
- [ ] Post-merge: run `cmd/reindex`

OpenSpec: `add-posted-date-filter` (modifies `job-search`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)