### PR TITLE
feat(sources): add Avito career-site adapter (career.avito.com)

### DIFF
--- a/internal/sources/avito.go
+++ b/internal/sources/avito.go
@@ -1,0 +1,166 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// avito adapts Avito's career site (career.avito.com): a single-company server-rendered
+// site with no per-tenant board id (boardless). Its vacancies are enumerated from the
+// public sitemap index — fetch the index, fetch each sub-sitemap, keep the vacancy-detail
+// URLs (/vacancies/<category>/<id>/) — and each vacancy page carries a schema.org
+// JobPosting ld+json block, so the description comes from a per-job detail fetch
+// (bounded-concurrency), like the other sitemap+ld+json adapters (radancy, successfactors).
+type avito struct {
+	http avitoHTTP
+}
+
+// avitoHTTP is the transport avito needs: an XML sitemap plus HTML detail pages.
+type avitoHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+const avitoSitemapIndexURL = "https://career.avito.com/sitemap.xml"
+
+// NewAvito builds the Avito adapter over the given HTTP client.
+func NewAvito(c avitoHTTP) Source { return avito{http: c} }
+
+func (avito) Provider() string { return "avito" }
+
+// avito is single-company, so its config entries carry no board.
+func (avito) boardless() {}
+
+// avitoLoc is one <loc> of either the sitemap index or a sub-sitemap.
+type avitoLoc struct {
+	Loc string `xml:"loc"`
+}
+
+func (a avito) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var index struct {
+		Sitemaps []avitoLoc `xml:"sitemap"`
+	}
+	if err := a.http.GetXML(ctx, avitoSitemapIndexURL, &index); err != nil {
+		return nil, fmt.Errorf("avito: sitemap index: %w", err)
+	}
+
+	// Keep every vacancy-detail loc across all sub-sitemaps, deduplicated by the numeric
+	// vacancy id (the same vacancy can appear under several category paths). A failed
+	// sub-sitemap is skipped rather than aborting the whole crawl.
+	var urls []string
+	seen := make(map[string]bool)
+	for _, sm := range index.Sitemaps {
+		var sub struct {
+			URLs []avitoLoc `xml:"url"`
+		}
+		if err := a.http.GetXML(ctx, sm.Loc, &sub); err != nil {
+			continue
+		}
+		for _, u := range sub.URLs {
+			id := avitoVacancyID(u.Loc)
+			if id == "" || seen[id] {
+				continue
+			}
+			seen[id] = true
+			urls = append(urls, u.Loc)
+		}
+	}
+
+	// Each vacancy's posting comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return a.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one vacancy page and maps its JobPosting ld+json to a Job, returning
+// ok=false when the URL has no parseable id, the fetch fails, or the page carries no
+// JobPosting, so the caller skips just that vacancy.
+func (a avito) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	id := avitoVacancyID(loc)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := a.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p avitoPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	// Avito's ld+json addressLocality reports the HQ city (Москва) even for remote roles;
+	// the authoritative display city is the page <title>'s "в городе <city>" suffix. Fall
+	// back to addressLocality when that suffix is absent.
+	location := firstNonEmpty(avitoTitleCity(root), p.JobLocation.Address.AddressLocality)
+
+	return Job{
+		ExternalID:  id,
+		URL:         loc,
+		Title:       p.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		// Avito's JobPosting omits jobLocationType (verified across pages, incl. remote
+		// roles), so unlike radancy there is no structured remote enum to read — the title's
+		// "Удалённая работа" city is the only signal. isRemote matches the Russian stem "удал".
+		Remote: isRemote(location) || isRemote(p.Title),
+		// datePosted is RFC3339 with a +03:00 offset.
+		PostedAt: parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// avitoPosting is the schema.org JobPosting decoded from an Avito vacancy page's ld+json.
+// jobLocation is a single Place whose address is a single PostalAddress; the identifier
+// field holds the category name (not the vacancy id), so it is not read.
+type avitoPosting struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	DatePosted  string `json:"datePosted"`
+	JobLocation struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+}
+
+// avitoVacancyIDPattern captures the numeric vacancy id from a /vacancies/<category>/<id>
+// detail URL. The category segment and a trailing numeric id are both required, so
+// category and landing pages (no trailing id) are not mistaken for vacancies.
+var avitoVacancyIDPattern = regexp.MustCompile(`/vacancies/[^/]+/(\d+)`)
+
+// avitoVacancyID extracts the numeric vacancy id from a detail URL, or "" when the URL is
+// not a vacancy-detail page.
+func avitoVacancyID(loc string) string {
+	if m := avitoVacancyIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// avitoTitleCityPattern captures the display city from a page <title>'s
+// "… в городе <city>" suffix (e.g. "Удалённая работа", "Москва").
+var avitoTitleCityPattern = regexp.MustCompile(`в городе\s+(.+?)\s*$`)
+
+// avitoTitleCity returns the display city parsed from the page <title>'s "в городе"
+// suffix, or "" when the page has no such title.
+func avitoTitleCity(root *html.Node) string {
+	var title string
+	walk(root, func(n *html.Node) bool {
+		if title != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "title" {
+			title = textContent(n)
+			return false
+		}
+		return true
+	})
+	if m := avitoTitleCityPattern.FindStringSubmatch(title); m != nil {
+		return m[1]
+	}
+	return ""
+}

--- a/internal/sources/avito_test.go
+++ b/internal/sources/avito_test.go
@@ -1,0 +1,193 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// avitoSitemapIndex is a sitemap index referencing one vacancy sub-sitemap and one
+// non-vacancy sub-sitemap (landing/category pages), mirroring career.avito.com's real
+// sitemap.xml shape.
+const avitoSitemapIndex = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<sitemap><loc>https://career.avito.com/sitemap-iblock-2.xml</loc></sitemap>
+<sitemap><loc>https://career.avito.com/sitemap-iblock-9.xml</loc></sitemap>
+</sitemapindex>`
+
+// avitoVacancySitemap builds a <urlset> sub-sitemap from the given locs.
+func avitoVacancySitemap(locs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	for _, l := range locs {
+		b.WriteString(`<url><loc>` + l + `</loc></url>`)
+	}
+	b.WriteString(`</urlset>`)
+	return b.String()
+}
+
+// avitoDetail is a vacancy page: the full <title> (which carries the display city as a
+// "в городе <city>" suffix), the JobPosting ld+json job title, and the ld+json
+// addressLocality (which Avito always reports as the HQ "Москва", even for remote roles).
+// The description embeds a <script> (written <\/script> so the JSON string carries it)
+// that sanitizeHTML must strip.
+func avitoDetail(fullTitle, jobTitle, ldCity, datePosted string) string {
+	return `<html><head><title>` + fullTitle + `</title></head><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + jobTitle + `",
+"description":"<p>Обязанности</p><script>alert(1)<\/script>",
+"datePosted":"` + datePosted + `",
+"identifier":{"@type":"PropertyValue","name":"Продажи"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"` + ldCity + `","addressCountry":"RU"}}}
+</script></body></html>`
+}
+
+func TestAvitoProvider(t *testing.T) {
+	if got := NewAvito(nil).Provider(); got != "avito" {
+		t.Errorf("Provider() = %q, want %q", got, "avito")
+	}
+}
+
+func TestAvitoIsBoardless(t *testing.T) {
+	if _, ok := NewAvito(nil).(boardless); !ok {
+		t.Error("avito should implement the boardless marker")
+	}
+}
+
+func TestAvitoVacancyID(t *testing.T) {
+	cases := map[string]string{
+		"https://career.avito.com/vacancies/prodazhi/19548/":   "19548",
+		"https://career.avito.com/vacancies/razrabotka/17810":  "17810",
+		"https://career.avito.com/vacancies/dizayn/":           "", // category, no id
+		"https://career.avito.com/vacancies/":                  "",
+		"https://career.avito.com/teams/auto/":                 "",
+		"https://career.avito.com/vacancies/prodazhi/19548/?x": "19548",
+	}
+	for loc, want := range cases {
+		if got := avitoVacancyID(loc); got != want {
+			t.Errorf("avitoVacancyID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestAvitoFetchEnumeratesDedupsAndMaps(t *testing.T) {
+	remoteURL := "https://career.avito.com/vacancies/prodazhi/19548/"
+	onsiteURL := "https://career.avito.com/vacancies/razrabotka/17810/"
+	dupURL := "https://career.avito.com/vacancies/marketing/19548/" // same id as remote → dedup
+	catURL := "https://career.avito.com/vacancies/dizayn/"          // no id → skipped
+
+	fake := (&routedHTTP{}).
+		route("/sitemap.xml", avitoSitemapIndex).
+		route("sitemap-iblock-2.xml", avitoVacancySitemap(remoteURL, onsiteURL, dupURL, catURL)).
+		route("sitemap-iblock-9.xml", avitoVacancySitemap("https://career.avito.com/directions/ux/")).
+		route("prodazhi/19548", avitoDetail(
+			"Вакансия Авито «Менеджер по работе с клиентами» в городе Удалённая работа",
+			"Менеджер по работе с клиентами", "Москва", "2026-05-15T16:24:19+03:00")).
+		route("razrabotka/17810", avitoDetail(
+			"Вакансия Авито «Backend-разработчик» в городе Москва",
+			"Backend-разработчик", "Москва", "2026-05-10T09:00:00+03:00"))
+
+	jobs, err := NewAvito(fake).Fetch(context.Background(), CompanyEntry{Company: "Avito", Provider: "avito"})
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (dedup by id, category skipped)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	remote, ok := byID["19548"]
+	if !ok {
+		t.Fatal("vacancy 19548 missing")
+	}
+	if remote.URL != remoteURL {
+		t.Errorf("URL = %q, want %q (first-seen wins over the marketing dup)", remote.URL, remoteURL)
+	}
+	if remote.Company != "Avito" {
+		t.Errorf("Company = %q, want Avito", remote.Company)
+	}
+	if remote.Title != "Менеджер по работе с клиентами" {
+		t.Errorf("Title = %q, want the ld+json job title", remote.Title)
+	}
+	if remote.Location != "Удалённая работа" {
+		t.Errorf("Location = %q, want %q (from <title>, not the ld+json Москва)", remote.Location, "Удалённая работа")
+	}
+	if !remote.Remote {
+		t.Error("remote role should be flagged Remote despite ld+json city Москва")
+	}
+	if !strings.Contains(remote.Description, "Обязанности") {
+		t.Errorf("Description = %q, want it to keep body text", remote.Description)
+	}
+	if strings.Contains(remote.Description, "alert") {
+		t.Errorf("Description = %q, want the <script> stripped", remote.Description)
+	}
+	if remote.PostedAt == nil || remote.PostedAt.UTC().Format("2006-01-02T15:04:05Z") != "2026-05-15T13:24:19Z" {
+		t.Errorf("PostedAt = %v, want 2026-05-15T13:24:19Z", remote.PostedAt)
+	}
+
+	onsite, ok := byID["17810"]
+	if !ok {
+		t.Fatal("vacancy 17810 missing")
+	}
+	if onsite.Location != "Москва" {
+		t.Errorf("Location = %q, want Москва", onsite.Location)
+	}
+	if onsite.Remote {
+		t.Error("on-site Moscow role should not be flagged Remote")
+	}
+}
+
+func TestAvitoLocationFallsBackToAddressLocality(t *testing.T) {
+	loc := "https://career.avito.com/vacancies/prodazhi/30001/"
+	fake := (&routedHTTP{}).
+		route("/sitemap.xml", avitoSitemapIndex).
+		route("sitemap-iblock-2.xml", avitoVacancySitemap(loc)).
+		route("sitemap-iblock-9.xml", avitoVacancySitemap()).
+		// <title> carries no "в городе" suffix → location comes from ld+json addressLocality.
+		route("prodazhi/30001", avitoDetail("Аналитик данных — Авито", "Аналитик данных", "Казань", "2026-04-01T09:00:00+03:00"))
+
+	jobs, err := NewAvito(fake).Fetch(context.Background(), CompanyEntry{Company: "Avito", Provider: "avito"})
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if jobs[0].Location != "Казань" {
+		t.Errorf("Location = %q, want Казань (addressLocality fallback)", jobs[0].Location)
+	}
+}
+
+func TestAvitoFetchSitemapIndexErrorIsBoardError(t *testing.T) {
+	fake := &routedHTTP{} // no routes → index fetch fails
+	if _, err := NewAvito(fake).Fetch(context.Background(), CompanyEntry{Company: "Avito", Provider: "avito"}); err == nil {
+		t.Fatal("Fetch() error = nil, want a board error when the sitemap index fails")
+	}
+}
+
+func TestAvitoFetchSkipsFailedDetailAndMissingJobPosting(t *testing.T) {
+	good := "https://career.avito.com/vacancies/prodazhi/40001/"
+	noLD := "https://career.avito.com/vacancies/prodazhi/40002/"
+	dead := "https://career.avito.com/vacancies/prodazhi/40003/"
+
+	fake := (&routedHTTP{}).
+		route("/sitemap.xml", avitoSitemapIndex).
+		route("sitemap-iblock-2.xml", avitoVacancySitemap(good, noLD, dead)).
+		route("sitemap-iblock-9.xml", avitoVacancySitemap()).
+		route("prodazhi/40001", avitoDetail("Вакансия Авито «Kept» в городе Москва", "Kept", "Москва", "2026-04-01T09:00:00+03:00")).
+		route("prodazhi/40002", `<html><head><title>No posting</title></head><body>nothing</body></html>`)
+	// 40003 has no route → GetHTML fails for it.
+
+	jobs, err := NewAvito(fake).Fetch(context.Background(), CompanyEntry{Company: "Avito", Provider: "avito"})
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Title != "Kept" {
+		t.Fatalf("jobs = %+v, want only the one vacancy with a JobPosting", jobs)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -167,6 +167,7 @@ func All(c HTTPClient) map[string]Source {
 		// host+language by board).
 		NewYandex(c),
 		NewOzon(c),
+		NewAvito(c),
 		NewRWB(c),
 		NewSber(c),
 		NewAlfaBank(c),

--- a/openspec/changes/add-avito-source/.openspec.yaml
+++ b/openspec/changes/add-avito-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/add-avito-source/design.md
+++ b/openspec/changes/add-avito-source/design.md
@@ -1,0 +1,95 @@
+## Context
+
+`career.avito.com` is Avito's server-rendered career site (Bitrix). It publishes ~100 open roles
+across IT and non-IT functions. Each vacancy lives at `/vacancies/<category>/<id>/` and carries a
+complete schema.org `JobPosting` JSON-LD block. The full vacancy list is enumerable from the
+public sitemap index `sitemap.xml`, which fans out to per-iblock sub-sitemaps; the vacancy-detail
+URLs currently live in `sitemap-iblock-2.xml`. No API key, no headless browser.
+
+freehire already captures Avito opportunistically through the `avito_career` Telegram channel.
+This change makes the board a first-class source, reusing the established sitemap-enumerate +
+JSON-LD-detail adapter pattern (`radancy`, `successfactors`, `luxoft`, `globalpayments`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single-company boardless `avito` adapter that enumerates every vacancy from the sitemap and
+  yields the normalized job shape under `source = "avito"`.
+- Correct remote detection — Avito's JSON-LD reports the HQ city (`Москва`) even for remote roles,
+  so the adapter must read the authoritative display city to catch "Удалённая работа".
+- Reuse the shared HTTP client, `ldJobPosting`, `sanitizeHTML`, `fetchDetails`, `isRemote`.
+
+**Non-Goals:**
+- No new pipeline, write-path, or `cmd/ingest` changes — one adapter file, one registry line, one
+  `sources/custom.yml` entry.
+- No category/team/SEO landing pages — only `/vacancies/<cat>/<id>/` detail pages.
+- No Dockerfile change; the adapter ships in the existing ingest binary.
+
+## Decisions
+
+### Enumeration: traverse the sitemap index, filter by the vacancy-detail URL pattern
+Fetch `https://career.avito.com/sitemap.xml` (a `<sitemapindex>`), fetch each sub-sitemap, and keep
+every `<loc>` matching `/vacancies/<category>/<id>/` (a numeric trailing id). Dedup by that numeric
+id (first-seen wins) before fetching details.
+
+- **Why over hardcoding `sitemap-iblock-2.xml`:** the iblock number is a Bitrix internal that can
+  be renumbered; filtering by the URL pattern across all sub-sitemaps is self-correcting and only
+  costs ~6 cheap XML fetches. The non-vacancy sub-sitemaps (directions, teams, files) contribute no
+  matching locs, and the SEO/directions vacancy sub-sitemaps that repeat a vacancy under a
+  different category path collapse via the id-dedup.
+- **Why not crawl the HTML listing:** the `/vacancies/` listing page server-renders only a partial
+  set and offers no clean pagination contract; the sitemap is the canonical, complete enumeration.
+
+### `external_id` = the numeric vacancy id from the URL path
+The JSON-LD `identifier` field holds the **category name** (e.g. "Продажи"), not the id. The stable
+per-vacancy identifier is the trailing numeric segment of `/vacancies/<cat>/<id>/`. A loc without a
+parseable id is skipped (it would collide on the dedup key). The vacancy page URL is the canonical
+`url`.
+
+- **Alternative considered:** JSON-LD `url` — but Avito emits it as `null`, so the fetched page URL
+  is the only canonical link.
+
+### Location and remote from the page `<title>`, not JSON-LD `addressLocality`
+Avito's `JobPosting.jobLocation.addressLocality` is always the HQ city (`Москва`) even for remote
+roles. The authoritative display city is the `<title>` suffix `… в городе <city>` (e.g. "Удалённая
+работа", "Москва", "Санкт-Петербург"). The adapter parses that suffix as the location and falls
+back to `addressLocality` when the suffix is absent. `Remote = isRemote(location) || isRemote(title)`
+— `isRemote` already matches the Russian stem "удал", so "Удалённая работа" classifies correctly.
+
+- **Why:** using `addressLocality` alone would silently mark every remote Avito role as on-site,
+  losing the most valuable signal for RU remote seekers.
+- **Trade-off:** the `<title>` parse depends on the "в городе" phrasing. If Avito changes it, the
+  adapter falls back to the JSON-LD city (degrading remote detection, not breaking ingest).
+
+### Title, description, post date from the JSON-LD `JobPosting`
+`title` (the clean role name, without the "Вакансия Авито «…»" wrapper), `description` (HTML, run
+through `sanitizeHTML` + `html.UnescapeString` like the other ld+json adapters), `datePosted`
+(RFC3339, parsed via `parseRFC3339`/`parseLayout`). `Company` is the static `e.Company` ("Avito").
+
+## Risks / Trade-offs
+
+- **JSON-LD city is the HQ, not the work location** → mitigated by parsing the `<title>` display
+  city as primary (above).
+- **`<title>` phrasing drift** ("в городе") → mitigated by JSON-LD `addressLocality` fallback;
+  ingest never breaks, only remote precision degrades.
+- **Sitemap iblock renumbering** → mitigated by pattern-filtering across all sub-sitemaps rather
+  than hardcoding the iblock file.
+- **Small catalogue (~100 jobs)** → acceptable; the per-provider stale sweep only closes `avito`
+  jobs after a successful crawl that ingested ≥1 job, so a transient sitemap outage can't mass-close
+  the catalogue.
+
+## Migration Plan
+
+1. Add `internal/sources/avito.go` + table-driven tests with captured fixtures.
+2. Register `"avito": NewAvito(client)` in `sources.All` (`internal/sources/source.go`).
+3. Add one entry to `sources/custom.yml` (`company: Avito`, `provider: avito`).
+4. Ship in the existing ingest image (full rebuild, no Dockerfile change); the existing
+   `cmd/ingest sources/custom.yml` cron schedule picks it up.
+
+Rollback: remove the `sources.All` line and the `sources/custom.yml` entry; existing `avito` rows
+soft-close via the stale sweep.
+
+## Open Questions
+
+None blocking. Remote-detection precision relies on the `<title>` city parse, validated against the
+live page; if future fixtures show a different phrasing, widen the parse.

--- a/openspec/changes/add-avito-source/proposal.md
+++ b/openspec/changes/add-avito-source/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Avito's career site (`career.avito.com`) is a major Russian-language employer board publishing
+hundreds of open roles (IT and beyond). Today freehire captures it only opportunistically — the
+`avito_career` Telegram channel in `sources/telegram.yml` is crawled and LLM-extracted, so a
+vacancy reaches the catalogue only if it happens to be posted there. The board itself is never
+crawled, even though every vacancy page exposes a complete, public `JobPosting` JSON-LD object and
+the full vacancy list is enumerable from a public sitemap — no headless browser, no API key.
+
+## What Changes
+
+- Add a new `avito` source adapter that crawls `career.avito.com` by enumerating its public
+  `sitemap-iblock-2.xml` (vacancy URLs of the form `/vacancies/<category>/<id>/`) and parsing each
+  vacancy page's `JobPosting` JSON-LD for title, HTML description, post date, and location.
+- Register it as a **single-company boardless** provider (one employer, no per-tenant board id),
+  mirroring the existing `ozon`/`luxoft` adapters — one new adapter file, one `sources.All` line,
+  one `sources/custom.yml` entry, no pipeline changes.
+- Derive `external_id` from the numeric vacancy id in the URL path (the JSON-LD `identifier` field
+  holds the category name, not the id) and use the vacancy page URL as the canonical job URL.
+- Reuse the established sitemap-enumerate + JSON-LD-detail pattern already proven in
+  `luxoft`/`globalpayments`/`habr_career`, including the shared HTTP client and `sanitizeHTML`
+  description cleanup.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. Reuses the source-ingest pipeline and write path unchanged. -->
+
+### Modified Capabilities
+- `source-ingest`: add a requirement that `avito` is a registered single-company boardless
+  provider — it enumerates `career.avito.com` from the public `sitemap-iblock-2.xml`, fetches each
+  vacancy page, parses its `JobPosting` JSON-LD into the normalized job shape, and yields jobs
+  under `source = "avito"` keyed by the numeric vacancy id from the URL.
+
+## Impact
+
+- **New code:** `internal/sources/avito.go` (+ tests with captured fixtures).
+- **Modified code:** `internal/sources/source.go` (`sources.All` registry line).
+- **Config:** one new entry in `sources/custom.yml` (`company: Avito`, `provider: avito`).
+- **Ops:** new adapter ships in the existing server/ingest binaries (full image rebuild, no
+  Dockerfile change); relies on the existing `cmd/ingest sources/custom.yml` cron schedule. As a
+  non-board source crawled per run, the per-provider stale-job sweep closes `avito` jobs unseen
+  for 48h.
+- **External dependency:** the public, keyless `career.avito.com` sitemap and vacancy pages.

--- a/openspec/changes/add-avito-source/specs/source-ingest/spec.md
+++ b/openspec/changes/add-avito-source/specs/source-ingest/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: avito is a registered single-company boardless provider
+
+The system SHALL register an `avito` adapter so Avito's career site (`career.avito.com`) can be
+listed in a board file as a single-company boardless source (its config entry carries no `board`,
+and the provider remains in the source facet). The adapter SHALL enumerate every vacancy from the
+public, keyless sitemap index `https://career.avito.com/sitemap.xml`: it SHALL fetch the index,
+fetch each referenced sub-sitemap, and keep every `<loc>` that matches a vacancy-detail URL
+(`/vacancies/<category>/<id>/`, a numeric trailing id), deduplicating by that numeric id. Each
+vacancy's posting SHALL come from its own detail-page fetch, fanned out under the shared
+bounded-concurrency detail pool. The adapter SHALL yield the normalized job shape with
+`external_id` set to the numeric vacancy id from the URL, `url` set to the vacancy page URL,
+`company` set to the configured company, `title`/`description`/`posted_at` parsed from the page's
+`JobPosting` ld+json, and `description` HTML-sanitized.
+
+#### Scenario: The board is enumerated from the sitemap index and vacancy pattern
+
+- **WHEN** a board file lists a boardless entry with provider `avito`
+- **THEN** the adapter fetches `https://career.avito.com/sitemap.xml`, fetches each sub-sitemap,
+  keeps only `<loc>` values matching `/vacancies/<category>/<id>/`, deduplicates by the numeric id,
+  and yields each vacancy as the normalized job shape with `external_id` set to that id and `url`
+  set to the vacancy page URL
+
+#### Scenario: A loc without a parseable vacancy id is skipped
+
+- **WHEN** a sitemap `<loc>` is a category, team, or landing page with no trailing numeric vacancy
+  id
+- **THEN** the adapter does not treat it as a vacancy and does not fetch it as a detail page
+
+#### Scenario: A failed sitemap fetch is a board error; a failed detail skips just that vacancy
+
+- **WHEN** the sitemap-index request fails
+- **THEN** the adapter returns an error for the board
+- **WHEN** a single vacancy's detail-page request fails or the page carries no `JobPosting` ld+json
+- **THEN** the adapter skips that one vacancy and still yields the rest
+
+### Requirement: avito derives location and remote from the page title, not the JSON-LD city
+
+The adapter SHALL derive the display location from the page `<title>` suffix (`… в городе <city>`),
+falling back to the JSON-LD `addressLocality` when that suffix is absent, because Avito's
+`JobPosting.jobLocation.addressLocality` reports the company HQ city (`Москва`) even for remote
+roles. The adapter SHALL mark a vacancy remote when the derived location or the title matches a
+remote signal (the existing `isRemote` check, which matches the Russian stem "удал"), so "Удалённая
+работа" roles are classified remote rather than as on-site Moscow roles.
+
+#### Scenario: A remote role is classified remote despite a Moscow JSON-LD city
+
+- **WHEN** a vacancy page's `<title>` ends with "в городе Удалённая работа" while its `JobPosting`
+  ld+json reports `addressLocality` "Москва"
+- **THEN** the adapter sets the job location to "Удалённая работа" and marks the job remote
+
+#### Scenario: An on-site role keeps its city
+
+- **WHEN** a vacancy page's `<title>` ends with "в городе Москва"
+- **THEN** the adapter sets the job location to "Москва" and does not mark the job remote

--- a/openspec/changes/add-avito-source/tasks.md
+++ b/openspec/changes/add-avito-source/tasks.md
@@ -1,0 +1,18 @@
+## 1. Avito adapter
+
+- [x] 1.1 Capture live fixtures: the sitemap index, the vacancy sub-sitemap, and two vacancy pages (one remote "Удалённая работа", one on-site city) for table-driven tests
+- [x] 1.2 Sitemap enumeration: traverse the index, fetch each sub-sitemap, keep `/vacancies/<cat>/<id>/` locs, dedup by numeric id (test-first)
+- [x] 1.3 Detail mapping from `JobPosting` ld+json: `external_id` from URL id, `url`, `title`, sanitized `description`, `posted_at`, `company` from config (test-first)
+- [x] 1.4 Location + remote: parse `<title>` "в городе <city>" suffix as location with `addressLocality` fallback; `Remote = isRemote(location)||isRemote(title)` (test-first, covers remote and on-site cases)
+- [x] 1.5 Error semantics: failed sitemap-index fetch returns a board error; a failed detail or a page with no `JobPosting` skips just that vacancy (test-first)
+- [x] 1.6 `Provider()` returns `"avito"` and the adapter implements the `boardless` marker (test-first)
+
+## 2. Registration & config
+
+- [x] 2.1 Register `"avito": NewAvito(client)` in `sources.All` (`internal/sources/source.go`)
+- [x] 2.2 Add one `company: Avito` / `provider: avito` entry to `sources/custom.yml` and confirm `cmd/ingest` validation accepts it
+
+## 3. Verification
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./internal/sources/` all green
+- [x] 3.2 Live smoke: run the adapter against `career.avito.com`, confirm vacancies enumerate, descriptions populate, and at least one remote role is classified remote

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -29,6 +29,8 @@
   provider: vk
 - company: Ozon
   provider: ozon
+- company: Avito
+  provider: avito
 - company: Sber
   provider: sber
 - company: Alfa-Bank


### PR DESCRIPTION
## What

New **single-company boardless** source adapter for **Avito** (`career.avito.com`).

- Enumerates the public sitemap index → traverses every sub-sitemap → keeps `/vacancies/<category>/<id>/` detail URLs, deduped by the numeric vacancy id.
- Parses each vacancy page's `JobPosting` ld+json (title, HTML description, `datePosted`).
- **Location/remote from the page `<title>` "в городе <city>" suffix**, not the ld+json `addressLocality` — Avito always reports the HQ city "Москва" even for remote roles, so the title suffix is the authoritative display city; `isRemote` matches the "удал" stem so "Удалённая работа" classifies correctly. Falls back to `addressLocality` when the suffix is absent.
- Mirrors the established `radancy`/`luxoft` sitemap + ld+json pattern. Registered in `sources.All` and one entry in `sources/custom.yml` (crawled by the existing `cmd/ingest sources/custom.yml` cron — no new cron, no Dockerfile change).

OpenSpec change: `add-avito-source` (proposal/design/specs/tasks).

## Verification

- `go build ./... && go vet ./... && go test ./internal/sources/` green; new table-driven tests cover enumeration/dedup/mapping, the title-city remote logic + fallback, and error semantics (index fetch = board error, sub-sitemap/detail failure = skip).
- **Live smoke** against `career.avito.com`: **165 jobs**, 11 remote, 100% with description/date/location.

## Note on Ozon (out of scope here)

Investigated extending the Ozon adapter to capture non-`external_vacancy` roles. The clean enumeration API is `ozon.tech/p-api/ozon-tech/vacancy/list` (264 IT vacancies), but the whole `ozon.tech` site + p-api sits behind Ozon's **Antibot crypto-JS challenge** (mints `abt_data`/`__Secure-ETC` cookies) → 307/403 from any keyless HTTP client. It's a **headless-tier** source, deferred. The existing `ozon` adapter (job-api.ozon.ru, 2017 external vacancies) is unchanged and already keys correctly by vacancy id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)