### PR TITLE
feat(sources): add ClinchTalent / career-pages.com adapter (clinch)

### DIFF
--- a/internal/sources/clinch.go
+++ b/internal/sources/clinch.go
@@ -1,0 +1,188 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/location"
+)
+
+// clinch adapts ClinchTalent / career-pages.com career sites (e.g. careers.withwaymo.com).
+// The board is the career-site host. Unlike the other sitemap adapters (successfactors,
+// meta) it CANNOT fetch the job detail pages: ClinchTalent fronts them with an AWS WAF
+// "challenge" action (an interactive JS proof-of-work), so a plain or fingerprint-spoofed
+// GET is served a 202 challenge, never the posting. The publicly served sitemap is the only
+// reachable surface, so a posting is reconstructed from its URL slug alone:
+//
+//	/jobs/{title-words}-{city}-{state}-{country}[-{uuid}]
+//
+// Title and location are split out of the slug (clinchSplitSlug); the description is left
+// empty (the detail page is unreachable), so enrichment and the description-derived facets
+// stay blank for these jobs while the title-derived facets and the geography facet — the
+// location dictionary resolves the slug's place tail — still populate. This mirrors the
+// sitemap-only approach the ClinchTalent platform forces on every crawler.
+type clinch struct {
+	http XMLGetter
+}
+
+// NewClinch builds the ClinchTalent adapter over the given XML client.
+func NewClinch(c XMLGetter) Source { return clinch{http: c} }
+
+func (clinch) Provider() string { return "clinch" }
+
+// clinchSitemapEntry is one <url> of the career-site sitemap: the page URL and its
+// last-modified date (used as posted_at).
+type clinchSitemapEntry struct {
+	Loc     string `xml:"loc"`
+	LastMod string `xml:"lastmod"`
+}
+
+func (c clinch) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var sitemap struct {
+		URLs []clinchSitemapEntry `xml:"url"`
+	}
+	url := fmt.Sprintf("https://%s/sitemap.xml", e.Board)
+	if err := c.http.GetXML(ctx, url, &sitemap); err != nil {
+		return nil, fmt.Errorf("clinch: sitemap %s: %w", e.Board, err)
+	}
+
+	var jobs []Job
+	for _, entry := range sitemap.URLs {
+		slug := clinchJobSlug(entry.Loc)
+		if slug == "" {
+			continue // not a /jobs/ URL (marketing page) or empty slug
+		}
+		title, loc := clinchSplitSlug(slug)
+		jobs = append(jobs, Job{
+			ExternalID:  clinchExternalID(slug),
+			URL:         entry.Loc,
+			Title:       title,
+			Company:     e.Company,
+			Location:    loc,
+			Description: "", // detail page is AWS-WAF-blocked; nothing to fetch
+			Remote:      isRemote(loc),
+			PostedAt:    parseDate(entry.LastMod),
+		})
+	}
+	return jobs, nil
+}
+
+// clinchJobSlug returns the posting slug from a career-site URL — the path segment after
+// "/jobs/" — or "" for a non-job URL (the sitemap also lists marketing pages).
+func clinchJobSlug(loc string) string {
+	const marker = "/jobs/"
+	i := strings.Index(loc, marker)
+	if i < 0 {
+		return ""
+	}
+	return strings.Trim(loc[i+len(marker):], "/")
+}
+
+// clinchUUIDSuffix matches a trailing "-{uuid}" that ClinchTalent appends to some slugs.
+var clinchUUIDSuffix = regexp.MustCompile(`-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$`)
+
+// clinchExternalID is the stable dedup id for a slug: the trailing UUID when present (it
+// survives a title edit that reshuffles the slug words), else the whole slug.
+func clinchExternalID(slug string) string {
+	if m := clinchUUIDSuffix.FindStringSubmatch(slug); m != nil {
+		return m[1]
+	}
+	return slug
+}
+
+// clinchSplitSlug splits a posting slug into a display title and a location string. The
+// location is the slug's place tail ("{city}-{state}-{country}"); the cut point is the
+// leftmost token that starts a place the location dictionary recognizes (a single- or
+// multi-word city such as "warsaw" or "mountain-view") with a country somewhere after it.
+// Bare two-letter title tokens (e.g. "be" for Backend, which is also Belgium's ISO code)
+// never start the location because the dictionary is consulted by place NAME, length > 2.
+// When nothing resolves, the whole slug becomes the title and the location is empty.
+func clinchSplitSlug(slug string) (title, locationText string) {
+	clean := clinchUUIDSuffix.ReplaceAllString(slug, "")
+	tokens := strings.Split(clean, "-")
+
+	cut := clinchLocationStart(tokens)
+	if cut < 0 {
+		return titleCase(strings.Join(tokens, " ")), ""
+	}
+	return titleCase(strings.Join(tokens[:cut], " ")), clinchFormatLocation(tokens[cut:])
+}
+
+// clinchFormatLocation joins the location tail into a comma-separated, title-cased string,
+// keeping a recognized multi-word place ("mountain view", "united states") together as one
+// segment while a token the dictionary does not resolve ("masovian", "voivodeship") stands
+// alone. The result reads cleanly AND re-resolves through location.Parse for the geo facet.
+func clinchFormatLocation(tokens []string) string {
+	var segs []string
+	for i := 0; i < len(tokens); {
+		// Take the SHORTEST window that resolves, so a multi-word place name ("mountain
+		// view") groups but a city+state phrase ("mountain view california", which
+		// resolves only via its trailing subdivision) does not swallow the next segment.
+		n := 1
+		for k := 2; k <= 3 && i+k <= len(tokens); k++ {
+			if clinchResolves(strings.Join(tokens[i:i+1], " ")) {
+				break // single token already resolves — don't extend
+			}
+			if clinchResolves(strings.Join(tokens[i:i+k], " ")) {
+				n = k
+				break
+			}
+		}
+		segs = append(segs, titleCase(strings.Join(tokens[i:i+n], " ")))
+		i += n
+	}
+	return strings.Join(segs, ", ")
+}
+
+// clinchResolves reports whether a candidate place phrase resolves to geography. The
+// length > 2 guard keeps a bare ISO code from matching as a country.
+func clinchResolves(cand string) bool {
+	if len(cand) <= 2 {
+		return false
+	}
+	geo := location.Parse(cand)
+	return len(geo.Countries) > 0 || len(geo.Regions) > 0
+}
+
+// clinchLocationStart returns the index of the first token that begins the location tail,
+// or -1 when no location resolves. A valid start is a token (or 2–3 token window, for
+// multi-word cities) the dictionary resolves to geography, with a country anywhere in the
+// remaining tail. Index 0 is never a start, so the title is never empty.
+func clinchLocationStart(tokens []string) int {
+	for i := 1; i < len(tokens); i++ {
+		if !clinchPlaceStartsAt(tokens, i) {
+			continue
+		}
+		if len(location.Parse(strings.Join(tokens[i:], ", ")).Countries) == 0 {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+// clinchPlaceStartsAt reports whether a recognized place begins at token i, trying a 1-,
+// 2-, then 3-word window so multi-word cities ("mountain view", "new york city") anchor on
+// their first word. Candidates of length ≤ 2 are skipped so a bare ISO code embedded in the
+// title cannot masquerade as a country.
+func clinchPlaceStartsAt(tokens []string, i int) bool {
+	for k := 1; k <= 3 && i+k <= len(tokens); k++ {
+		if clinchResolves(strings.Join(tokens[i:i+k], " ")) {
+			return true
+		}
+	}
+	return false
+}
+
+// titleCase upper-cases the first letter of each space-separated word, leaving the rest as
+// is. The slug tokens are lowercase ASCII, so this is enough for a readable display title
+// without pulling in a Unicode caser.
+func titleCase(s string) string {
+	words := strings.Fields(s)
+	for i, w := range words {
+		words[i] = strings.ToUpper(w[:1]) + w[1:]
+	}
+	return strings.Join(words, " ")
+}

--- a/internal/sources/clinch_test.go
+++ b/internal/sources/clinch_test.go
@@ -1,0 +1,144 @@
+package sources
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func clinchSitemapXML(locs ...string) string {
+	xml := `<?xml version="1.0"?><urlset>`
+	for _, l := range locs {
+		xml += `<url><loc>` + l + `</loc><lastmod>2026-05-04</lastmod></url>`
+	}
+	return xml + `</urlset>`
+}
+
+func TestClinchProvider(t *testing.T) {
+	if got := NewClinch(nil).Provider(); got != "clinch" {
+		t.Errorf("Provider() = %q, want %q", got, "clinch")
+	}
+}
+
+func TestClinchExternalID(t *testing.T) {
+	cases := map[string]string{
+		// No UUID suffix: the whole slug is the stable id.
+		"backend-technical-lead-manager-taas-warsaw-masovian-voivodeship-poland": "backend-technical-lead-manager-taas-warsaw-masovian-voivodeship-poland",
+		// Trailing UUID: prefer it — it survives a title edit that reshuffles the slug.
+		"machine-learning-engineer-runtime-optimization-mountain-view-california-united-states-846a7827-ae6e-4a38-a368-2606aa465931": "846a7827-ae6e-4a38-a368-2606aa465931",
+	}
+	for slug, want := range cases {
+		if got := clinchExternalID(slug); got != want {
+			t.Errorf("clinchExternalID(%q) = %q, want %q", slug, got, want)
+		}
+	}
+}
+
+func TestClinchSplitSlug(t *testing.T) {
+	cases := []struct {
+		name      string
+		slug      string
+		wantTitle string
+		wantLoc   string
+	}{
+		{
+			name:      "single-word city (Warsaw) splits cleanly, BE stays in title",
+			slug:      "software-engineer-payment-be-warsaw-masovian-voivodeship-poland",
+			wantTitle: "Software Engineer Payment Be",
+			wantLoc:   "Warsaw, Masovian, Voivodeship, Poland",
+		},
+		{
+			name:      "multiword city (Mountain View) is the cut point",
+			slug:      "machine-learning-engineer-runtime-optimization-mountain-view-california-united-states",
+			wantTitle: "Machine Learning Engineer Runtime Optimization",
+			wantLoc:   "Mountain View, California, United States",
+		},
+		{
+			name:      "London / England / United Kingdom",
+			slug:      "staff-machine-learning-engineer-simulation-london-england-united-kingdom",
+			wantTitle: "Staff Machine Learning Engineer Simulation",
+			wantLoc:   "London, England, United Kingdom",
+		},
+		{
+			name:      "UUID stripped before splitting",
+			slug:      "senior-machine-learning-engineer-simulation-london-england-united-kingdom-6da190c4-27e6-467a-85f8-a242d5a5c206",
+			wantTitle: "Senior Machine Learning Engineer Simulation",
+			wantLoc:   "London, England, United Kingdom",
+		},
+		{
+			name:      "multi-location tail all goes to location",
+			slug:      "senior-android-engineer-mountain-view-california-united-states-san-francisco",
+			wantTitle: "Senior Android Engineer",
+			wantLoc:   "Mountain View, California, United States, San Francisco",
+		},
+		{
+			name:      "no resolvable location: whole slug is the title",
+			slug:      "special-projects-lead-classified-division",
+			wantTitle: "Special Projects Lead Classified Division",
+			wantLoc:   "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			title, loc := clinchSplitSlug(c.slug)
+			if title != c.wantTitle {
+				t.Errorf("title = %q, want %q", title, c.wantTitle)
+			}
+			if loc != c.wantLoc {
+				t.Errorf("location = %q, want %q", loc, c.wantLoc)
+			}
+		})
+	}
+}
+
+func TestClinchFetchParsesSitemapAndFiltersNonJobURLs(t *testing.T) {
+	job := "https://careers.withwaymo.com/jobs/backend-technical-lead-manager-taas-warsaw-masovian-voivodeship-poland"
+	fake := (&routedHTTP{}).route("/sitemap.xml", clinchSitemapXML(
+		"https://careers.withwaymo.com/",          // marketing page — filtered out
+		"https://careers.withwaymo.com/why-waymo", // marketing page — filtered out
+		job,
+	))
+
+	jobs, err := NewClinch(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Waymo", Provider: "clinch", Board: "careers.withwaymo.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (non-job URLs filtered)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "backend-technical-lead-manager-taas-warsaw-masovian-voivodeship-poland" {
+		t.Errorf("ExternalID = %q", j.ExternalID)
+	}
+	if j.URL != job {
+		t.Errorf("URL = %q, want %q", j.URL, job)
+	}
+	if j.Title != "Backend Technical Lead Manager Taas" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Waymo" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Warsaw, Masovian, Voivodeship, Poland" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.Description != "" {
+		t.Errorf("Description = %q, want empty (detail page is WAF-blocked)", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-05-04", j.PostedAt)
+	}
+}
+
+func TestClinchFetchEmptySitemapYieldsNoJobsNoError(t *testing.T) {
+	fake := (&routedHTTP{}).route("/sitemap.xml", clinchSitemapXML())
+	jobs, err := NewClinch(fake).Fetch(context.Background(), CompanyEntry{Board: "careers.withwaymo.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -133,6 +133,7 @@ func All(c HTTPClient) map[string]Source {
 		NewADP(c),
 		NewITechArt(c),
 		NewVention(c),
+		NewClinch(c),
 		NewOracle(c),
 		NewEightfold(c),
 		NewFreshteam(c),

--- a/sources/clinch.yml
+++ b/sources/clinch.yml
@@ -1,0 +1,9 @@
+# ClinchTalent / career-pages.com career sites. Provider is the filename; each entry is
+# company + board. board = the career-site host (see internal/sources/clinch.go); the
+# adapter reads https://<board>/sitemap.xml and reconstructs each posting from its URL slug.
+# The job detail pages are AWS-WAF-blocked, so these jobs carry title + location only (no
+# description) — enrichment and the description-derived facets stay blank for them.
+# Each board validated live (sitemap lists >0 /jobs/ URLs) before adding.
+
+- company: Waymo
+  board: careers.withwaymo.com


### PR DESCRIPTION
## What

Adds a `clinch` source adapter for **ClinchTalent / career-pages.com** career sites — the multi-tenant platform behind e.g. `careers.withwaymo.com` (Waymo) and `weareroku.com` (Roku). First board: **Waymo** (`sources/clinch.yml`).

## Why it's sitemap-only (no descriptions)

ClinchTalent fronts its job **detail pages** with an **AWS WAF "challenge"** action — an interactive JS proof-of-work. A plain or fingerprint-spoofed GET is served a `202` challenge, never the posting. I confirmed this with a spike: the `tls-client` Chrome_133 transport that beats Meta's Akamai block (PR #231) gets **0/12** detail requests through. This is the "needs a headless tier" class we deliberately don't have.

The **sitemap is publicly served** (not WAF-gated), so — like the established approach other crawlers use for this exact platform (Roku/ClinchTalent) — the adapter reconstructs each posting from its URL slug alone.

## How

- Reads `https://<board>/sitemap.xml`, keeps `/jobs/` URLs (marketing pages filtered).
- Slug shape: `/jobs/{title}-{city}-{state}-{country}[-{uuid}]`.
  - **external_id** = trailing UUID when present (survives a title edit), else the whole slug.
  - **title / location split**: cut at the leftmost token the `internal/location` dictionary recognizes as a place (single- or multi-word city: "warsaw", "mountain view"), with a country somewhere after it. Bare 2-letter title tokens (e.g. `be` = Backend, also Belgium's ISO code) are guarded off by requiring name-length > 2.
  - **location** is grouped/title-cased so it reads cleanly *and* re-resolves through `location.Parse` for the geography facet.
- **description left empty** (detail page unreachable) → enrichment + description-derived facets stay blank for these jobs; title-derived facets + the geo facet still populate. Pipeline accepts empty descriptions (same as SuccessFactors/iCIMS).
- `clinch` is a normal board provider → the per-provider stale-sweep applies (sitemap re-crawled, `last_seen_at` stamped).

## Tests / verification

- Unit: provider, external_id (uuid/slug), slug-split table (single/multiword city, UK, UUID strip, multi-location, no-country fallback, the `be` landmine), Fetch (filters non-job URLs, maps fields, lastmod→posted_at), empty sitemap.
- **Live smoke**: 396 Waymo jobs parsed end-to-end through the real HTTP client — clean titles, grouped locations, 98% with a resolved country.
- `go build ./...`, `go vet ./...`, `go test ./...`, `gofmt` — all clean.

## Follow-up (not in this PR)

- Add a cron schedule for `cmd/ingest sources/clinch.yml` at deploy time (ops repo).
- Harvest more ClinchTalent tenants (CNAME → `whitelabel.go-lifted.com` / cookie domain `clinchtalent.com`,`career-pages.com`) to add boards.