### PR TITLE
feat(sources): add Tractian (gem) and MercadoLibre (eightfold) boards

### DIFF
--- a/openspec/changes/add-company-lazy-list/.openspec.yaml
+++ b/openspec/changes/add-company-lazy-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-19

--- a/openspec/changes/add-company-lazy-list/design.md
+++ b/openspec/changes/add-company-lazy-list/design.md
@@ -1,0 +1,123 @@
+## Context
+
+The sidebar Company filter (shipped in PR#202) is a `dynamic` Meilisearch facet,
+the same machinery as `skills`/`countries`. That works for bounded vocabularies —
+`skills` has 238 distinct values (under Meili's `maxValuesPerFacet=300` cap) and
+`countries` 129 — so their distributions load fully and client-side search finds
+everything. Companies are different: the catalogue has ~1.54M jobs across
+thousands of companies. Meili returns only the first 300 facet values **in
+alphabetical order**, so the company list is junk (`0-compromise-recruitment…`,
+`01-tech`, counts of 1) and excludes popular employers — "google" finds nothing.
+
+The companies endpoint (`GET /api/v1/companies?q=`) already exists and already
+returns `{slug, name, job_count}` with a case-insensitive name search and
+pagination. The `/companies` page already renders job-count badges, search,
+debounce, and infinite scroll. So the data source and one consumer already exist;
+they are just (a) name-ordered and (b) computing `job_count` via a query-time
+`LEFT JOIN ... GROUP BY count()` over 1.54M jobs on every request.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A sidebar Company filter that searches the whole catalogue by name and lists
+  companies most-active first, showing real names and job counts.
+- A cheap, popularity-ordered `GET /api/v1/companies` reused by both the sidebar
+  typeahead and the `/companies` page.
+- Keep the company filter wired through the existing `company_slug` search param
+  so URL sync, exclusion, chips, and active-filter-count are unchanged.
+
+**Non-Goals:**
+- Real-time exactness of `job_count` (eventual consistency within the recompute
+  interval is acceptable).
+- Per-filter *contextual* company counts (the count is global open-job count).
+- Changing the `skills`/`countries` facets — they are within the cap and fine.
+- Any Meili reindex (the document shape is unchanged).
+
+## Decisions
+
+### Denormalize `job_count`, maintained by a periodic recompute (not triggers)
+
+Add `companies.job_count INT NOT NULL DEFAULT 0` plus an index on `(job_count
+DESC)`. A new one-shot worker `cmd/recount-companies` runs a single set-based
+`UPDATE` that sets every company's `job_count` from `GROUP BY company_slug` over
+`jobs WHERE closed_at IS NULL` (companies with no open jobs → 0). Scheduled hourly
+by host cron with `flock`, following the existing worker pattern
+(`worker.Bootstrap`, run-once, exit codes), like `cmd/backfill-derive`.
+
+- **Why over PG triggers:** the count changes both on ingest and on *close*
+  (`closed_at` set by the ingest sweep and the liveness worker), across 1.54M
+  rows crawled frequently. Triggers would add write overhead to every upsert and
+  risk drift on any path that bypasses them. A periodic full recompute is simple,
+  self-healing, and off the hot path. The user chose this explicitly.
+- **Why over query-time count:** sorting all companies by an on-the-fly
+  `GROUP BY` over 1.54M jobs on every `/companies` and every typeahead keystroke
+  is the cost we are removing.
+
+### Reuse the companies endpoint; change only ordering and the count source
+
+`ListCompanies` drops the `LEFT JOIN`/`GROUP BY`/`count()`, reads `c.job_count`,
+and orders `job_count DESC, name`. `q` ILIKE search and `CountCompanies` are
+unchanged. `GetCompany` is `SELECT *`, so `job_count` flows into `db.Company`
+automatically. No new endpoint — the sidebar typeahead and `/companies` share it.
+
+### Frontend: a `control: 'remote'` facet type, state still keyed by `company_slug`
+
+Add a new control type to the facet registry and a `RemoteSearchSelect.svelte`
+that debounce-fetches `api.listCompanies(q, limit, 0)`, renders name + count,
+shows the popular first page on an empty query, and on select calls the existing
+`store.toggle('company_slug', slug)`. Because state stays keyed by the
+`company_slug` param, `filtersToParams`/`filtersFromParams`, exclusion, chips, and
+active-filter-count all keep working untouched — only the *option source* changes
+from the Meili distribution to the endpoint.
+
+- **Why a control type over a bespoke component:** it is the natural extension of
+  the existing `pills`/`select`/`tokens` pattern and keeps the company filter
+  inside the registry-driven system. The component takes a fetch function, so it
+  is not company-hardcoded, but company is its only consumer for now (no further
+  generalization until a second remote facet appears).
+- **Selected-chip labels:** accumulate a session-local `slug → name` map from
+  results so chips show real names; fall back to the existing `companyLabel(slug)`
+  humanizer for URL-preselected slugs not yet seen (e.g. `?company_slug=stripe`).
+  No batch slug→name endpoint is added (YAGNI).
+
+### Stop requesting the unused `company_slug` facet distribution
+
+`company_slug` stays in `search.StringFacets` (still needed for `?company_slug=`
+filtering), but is excluded from the attributes the facets endpoint requests
+distributions for (`facetAttributes()` in `internal/handler/facets.go`). We were
+computing a 300-bucket distribution on every sidebar interaction that the UI no
+longer reads.
+
+## Risks / Trade-offs
+
+- **Stale counts between recomputes** → hourly cron keeps drift small; counts are
+  popularity hints and sort keys, not exact figures. Acceptable per Goals.
+- **Recompute cost on 1.54M jobs** → it is a single aggregate + set `UPDATE`, not
+  per-row; runs off the hot path under `flock` so runs can't stack.
+- **Empty `job_count` immediately after deploy** → the column defaults to 0 until
+  the first recompute, so the list would look empty/unsorted. Mitigation: run
+  `cmd/recount-companies` once manually right after the migration, before relying
+  on the UI (captured as a deploy task).
+- **Global (non-contextual) company count** differs from other facets' contextual
+  counts → intended and documented in the spec; the contextual path is the broken
+  one being replaced.
+
+## Migration Plan
+
+1. Ship migration `0025_companies_job_count.sql` (column + index). On prod, apply
+   it manually via `psql` (initdb runs only on first volume init).
+2. Deploy a **full** Go image rebuild (new `cmd/recount-companies` binary) — not a
+   sources-only deploy. Deploy the web image for the new facet control.
+3. Run `cmd/recount-companies` once manually to populate `job_count`.
+4. Add the hourly cron line (`flock` + `docker compose run --rm -T
+   recount-companies`) and the compose worker service.
+5. Verify: `/api/v1/companies` is count-ordered; sidebar typeahead finds "google";
+   `/companies` page ordered by popularity.
+
+Rollback: the change is additive (new column, new binary, new optional cron).
+Reverting the web image restores the prior facet; the column can be left in place
+harmlessly.
+
+## Open Questions
+
+None — scope and semantics were confirmed with the user during brainstorming.

--- a/openspec/changes/add-company-lazy-list/proposal.md
+++ b/openspec/changes/add-company-lazy-list/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The sidebar "Company" filter is backed by a Meilisearch facet distribution,
+which Meili caps at `maxValuesPerFacet=300` and returns in **alphabetical**
+order, not by popularity. Over a ~1.54M-job catalogue the list is therefore
+dominated by junk `0-`/`1-`-prefixed company slugs and excludes popular
+employers entirely — typing "google" finds nothing. The filter is effectively
+unusable. The fix is to source the company list from the database, sorted by job
+count, and to make that sort cheap with a denormalized counter.
+
+## What Changes
+
+- Add a denormalized `companies.job_count` column (open jobs only), maintained by
+  a new periodic recompute worker `cmd/recount-companies` (cron, hourly).
+- `GET /api/v1/companies` reads `job_count` from the column instead of a
+  query-time `count()` join, and orders by `job_count DESC, name` so the most
+  active companies surface first. The `q` name-search and pagination are
+  unchanged. **BREAKING** (internal): the list is no longer name-ordered.
+- Replace the sidebar Company filter's broken dynamic Meili facet with a lazy,
+  server-backed typeahead that queries the (now count-sorted) companies endpoint,
+  shows real company names and global open-job counts, and on an empty query
+  shows the most popular companies. The filter still applies via the existing
+  `company_slug` search param, so URL state, exclusion, and chips are unchanged.
+- The `/companies` page needs no frontend change — it already renders the job
+  count and search; it simply inherits the count-sorted ordering.
+- Cheap win: stop requesting the unused `company_slug` facet distribution in the
+  analytics facets endpoint, while keeping `company_slug` filterable.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `companies`: the company list gains a denormalized `job_count` maintained by a
+  periodic recompute, and is ordered by job count descending; the prior
+  requirement that no denormalized counter is required is superseded.
+- `web-frontend`: the Company filter facet becomes a lazy, server-backed
+  typeahead sourced from the companies endpoint (sorted by job count), replacing
+  the capped Meilisearch facet distribution.
+
+## Impact
+
+- **Schema**: migration `0025_companies_job_count.sql` (new column + index).
+  Applied manually on prod (initdb runs only on first volume init).
+- **Backend**: `internal/db/queries/companies.sql` (ListCompanies, new
+  RecountCompanyJobCounts), regenerated `internal/db`; new `cmd/recount-companies`
+  worker; `internal/handler/facets.go` (drop company_slug from requested facets).
+- **Build/ops**: root `Dockerfile` (new binary build + COPY); a new Go image
+  (full rebuild, not sources-only); `freehire-ops/docker-compose.prod.yml` worker
+  service + hourly host cron line; one manual `recount-companies` run post-deploy
+  to populate the column.
+- **Frontend**: new `web/src/lib/components/facets/RemoteSearchSelect.svelte`, a
+  `control: 'remote'` facet type, and the `company_slug` FACETS entry switched to
+  it; no `/companies` page change.
+- **No reindex** required (this does not change the Meili document shape).

--- a/openspec/changes/add-company-lazy-list/specs/companies/spec.md
+++ b/openspec/changes/add-company-lazy-list/specs/companies/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Company list is served without joining jobs
+
+The system SHALL expose `GET /api/v1/companies` returning companies read from the
+`companies` table. Each company's job count SHALL be read from the denormalized
+`companies.job_count` column (open jobs only), not computed at query time, so the
+read path performs no join to the `jobs` table. The list SHALL be ordered by
+`job_count` descending, then `name` ascending, so the most active companies
+surface first.
+
+The endpoint SHALL accept an optional `q` query parameter that filters companies
+by a case-insensitive substring match on the company `name`. An absent or empty
+`q` SHALL return the unfiltered list. When `q` is non-empty, the list `meta.total`
+SHALL report the count of companies matching `q`, so pagination over the filtered
+results is correct.
+
+#### Scenario: Listing companies most-active first
+
+- **WHEN** a client requests `GET /api/v1/companies`
+- **THEN** the response contains companies under `data` with list `meta`,
+  ordered by `job_count` descending (ties broken by `name`), each carrying its
+  denormalized `job_count`
+
+#### Scenario: Searching companies by name
+
+- **WHEN** a client requests `GET /api/v1/companies?q=acme`
+- **THEN** the response contains only companies whose name matches `acme`
+  case-insensitively, ordered by `job_count` descending, and `meta.total` is the
+  count of matching companies
+
+#### Scenario: Empty query returns the full list
+
+- **WHEN** a client requests `GET /api/v1/companies?q=` (empty or absent)
+- **THEN** the response is the unfiltered company list, identical to omitting the
+  parameter
+
+## ADDED Requirements
+
+### Requirement: Company job counts are denormalized and periodically recomputed
+
+The system SHALL store each company's count of open jobs (`closed_at IS NULL`) in
+a denormalized `companies.job_count` column. The column SHALL be maintained by a
+periodic recompute (a scheduled worker), not by a synchronous write on the job
+ingest/close paths, so it is eventually consistent with the `jobs` table within
+the recompute interval. A company with no open jobs SHALL have `job_count = 0`.
+
+#### Scenario: Recompute reflects only open jobs
+
+- **WHEN** the recompute runs and a company has 3 open jobs and 2 closed jobs
+  (`closed_at` set)
+- **THEN** that company's `job_count` is set to 3
+
+#### Scenario: Recompute zeroes a company whose jobs all closed
+
+- **WHEN** every job of a company has been closed since the last recompute and the
+  recompute runs again
+- **THEN** that company's `job_count` is set to 0
+
+#### Scenario: Counts are eventually consistent
+
+- **WHEN** a new job is ingested for a company between recompute runs
+- **THEN** the company's `job_count` does not change until the next recompute,
+  which then includes the new job

--- a/openspec/changes/add-company-lazy-list/specs/web-frontend/spec.md
+++ b/openspec/changes/add-company-lazy-list/specs/web-frontend/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Company filter facet is a lazy, server-backed typeahead
+
+The frontend job-search filter UI SHALL offer a "Company" facet that sources its
+options from the companies endpoint (`GET /api/v1/companies?q=`), not from the
+Meilisearch facet distribution. As the user types, the facet SHALL query the
+endpoint (debounced) and present matching companies by their display `name`
+alongside their global open-job count, ordered most-active first. With an empty
+query the facet SHALL present the most popular companies (the endpoint's
+count-ordered first page). Selecting a company SHALL apply the existing
+`company_slug` search parameter, so URL state, exclusion, and the selected-value
+chips behave identically to the other facets. The count shown for a company is
+its global open-job count, not a count contextual to the other active filters.
+
+#### Scenario: Typing finds a company outside the top results
+
+- **WHEN** a user types "google" into the Company facet
+- **THEN** the facet queries `GET /api/v1/companies?q=google` and lists matching
+  companies by name with their job counts, even though "google" is not among the
+  most popular companies shown for an empty query
+
+#### Scenario: Empty query shows the most popular companies
+
+- **WHEN** a user opens the Company facet without typing
+- **THEN** the facet shows the most active companies first (highest job count),
+  sourced from the endpoint's first page
+
+#### Scenario: Selecting a company filters the job list
+
+- **WHEN** a user selects a company in the facet
+- **THEN** the search request carries that company's `company_slug` and the job
+  results are limited to that company, and a removable chip shows the company's
+  display name
+
+#### Scenario: A pre-selected company from the URL is shown by name
+
+- **WHEN** the page loads with `?company_slug=stripe` already set
+- **THEN** the Company facet shows the selection as a removable chip with a
+  human-readable label, without requiring the user to first search for it

--- a/openspec/changes/add-company-lazy-list/tasks.md
+++ b/openspec/changes/add-company-lazy-list/tasks.md
@@ -1,0 +1,29 @@
+## 1. Schema + DB query layer
+
+- [ ] 1.1 Add migration `migrations/0025_companies_job_count.sql`: `ALTER TABLE companies ADD COLUMN IF NOT EXISTS job_count INT NOT NULL DEFAULT 0;` plus `CREATE INDEX IF NOT EXISTS companies_job_count_idx ON companies (job_count DESC);`
+- [ ] 1.2 Edit `internal/db/queries/companies.sql` `ListCompanies`: drop the `LEFT JOIN jobs` / `GROUP BY` / `count()`, select `c.job_count`, and `ORDER BY c.job_count DESC, c.name`. Keep the `q` ILIKE filter and `CountCompanies` unchanged.
+- [ ] 1.3 Add a `RecountCompanyJobCounts` query to `companies.sql`: a single set-based `UPDATE companies SET job_count = COALESCE(sub.cnt, 0)` deriving `sub` from `GROUP BY company_slug` over `jobs WHERE closed_at IS NULL`, covering companies with zero open jobs (→ 0).
+- [ ] 1.4 Run `make sqlc` (or `go install sqlc` fallback) and confirm `internal/db` regenerates: `db.Company` gains `JobCount`, `ListCompanies` returns it, `RecountCompanyJobCounts` exists. `go build ./...` is green.
+
+## 2. Recount worker
+
+- [ ] 2.1 RED: integration test (`//go:build integration`, testcontainers) asserting `RecountCompanyJobCounts` sets `job_count` to the number of open jobs per company (ignoring `closed_at` rows) and zeroes a company whose jobs all closed.
+- [ ] 2.2 RED: integration test asserting `ListCompanies` returns companies ordered by `job_count DESC` (tie-broken by name) and that the `q` filter still matches by name.
+- [ ] 2.3 GREEN: add `cmd/recount-companies/main.go` (template: `cmd/backfill-derive` + `internal/worker.Bootstrap`): run `RecountCompanyJobCounts` once, log rows affected, return exit code 0/1. Make tests pass.
+- [ ] 2.4 Add `cmd/recount-companies` to the root `Dockerfile` (the `go build` chain and the final-stage `COPY` list). `go vet ./...` + `go build ./...` green.
+
+## 3. Backend facet cheap-win
+
+- [ ] 3.1 In `internal/handler/facets.go`, exclude `company_slug` from the attributes `facetAttributes()` requests distributions for, while leaving it in `search.StringFacets` (so `?company_slug=` filtering is unaffected). Verify the `/jobs/facets` response no longer carries a `company_slug` key but `?company_slug=` filtering on `/jobs` still works.
+
+## 4. Frontend lazy company filter
+
+- [ ] 4.1 Add a `control: 'remote'` option to the `FacetControl` type / `FacetDef` in `web/src/lib/facets.ts`, and switch the `company_slug` FACETS entry from `{ dynamic: true, control: 'select' }` to `{ control: 'remote', ... }`. Keep `companyLabel`/`dynamicLabel`.
+- [ ] 4.2 Create `web/src/lib/components/facets/RemoteSearchSelect.svelte`: debounced fetch via `api.listCompanies(q, limit, 0)`, render company `name` + `job_count`, show the popular first page on empty query, call `onToggle(slug)` on select, render selected values as removable chips using a session `slug→name` map with `companyLabel(slug)` fallback.
+- [ ] 4.3 Route `control === 'remote'` to `RemoteSearchSelect` in `FacetSection.svelte`, passing the store-keyed `company_slug` state (selected values, exclude) so URL-sync/exclude/chips keep working.
+- [ ] 4.4 `cd web && npm run check` (svelte-check) is green; manually confirm (dev or prod-API) that typing "google" returns Google and selecting a company filters the job list.
+
+## 5. Verification + deploy notes
+
+- [ ] 5.1 `go build ./... && go vet ./...` and `go test ./...` green; `go test -tags=integration ./internal/db/` (or the relevant package) green for the new tests.
+- [ ] 5.2 Document the deploy steps in the change (full Go image rebuild for the new binary; web image; apply migration 0025 manually via `psql`; run `cmd/recount-companies` once to populate; add the compose worker service + hourly `flock` cron line in `freehire-ops`).

--- a/sources/eightfold.yml
+++ b/sources/eightfold.yml
@@ -113,3 +113,5 @@
   board: symetra.eightfold.ai/symetra.com
 - company: Albemarle
   board: albemarle.eightfold.ai/albemarle.com
+- company: MercadoLibre
+  board: mercadolibre.eightfold.ai/mercadolibre.com

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -64,6 +64,8 @@
   board: supio
 - company: TensorStax
   board: tensorstax-com
+- company: Tractian
+  board: tractian-technologies-inc-
 - company: Transluce
   board: transluce
 - company: UP.Labs


### PR DESCRIPTION
## What

Add two ATS boards behind already-registered adapters (board-file-only change):

| Company | Provider | Board | Live count |
|---|---|---|---|
| Tractian | gem | `tractian-technologies-inc-` | 102 |
| MercadoLibre | eightfold | `mercadolibre.eightfold.ai/mercadolibre.com` | 710 |

## Context

Checked 8 incoming URLs; 6 were already covered (Bosch/SmartRecruiters, Nubank/Greenhouse, Wise/SmartRecruiters, CloudWalk/Lever, Airbnb/Greenhouse, Veriff/Greenhouse). These two were the gaps.

## Verification

- Both boards live-validated against their public APIs (counts above).
- `go build ./...` passes.
- YAML format matches existing entries; no adapter or image change needed (sources-only deploy).