### PR TITLE
feat(sources): per-vacancy employer on huntflow community-hub boards

### DIFF
--- a/internal/sources/huntflow.go
+++ b/internal/sources/huntflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // huntflow adapts the public career sites Huntflow hosts at <board>.huntflow.io. Those
@@ -21,6 +22,10 @@ const (
 	huntflowDetailURL  = "https://%s.huntflow.io/vacancy/%s/_payload.json"
 	huntflowVacancyURL = "https://%s.huntflow.io/vacancy/%s"
 )
+
+// huntflowHubFolder is the division-breadcrumb folder a community hub nests every partner
+// company under (see companyFromDivision).
+const huntflowHubFolder = "Partners"
 
 // NewHuntflow builds the Huntflow adapter over the given HTTP client.
 func NewHuntflow(c JSONGetter) Source { return huntflow{http: c} }
@@ -87,6 +92,7 @@ func (h huntflow) detail(ctx context.Context, e CompanyEntry, it hfItem) (Job, b
 	var d struct {
 		City         string `json:"city"`
 		Money        string `json:"money"`
+		Division     string `json:"division"`
 		Intro        string `json:"intro"`
 		Body         string `json:"body"`
 		Requirements string `json:"requirements"`
@@ -103,16 +109,43 @@ func (h huntflow) detail(ctx context.Context, e CompanyEntry, it hfItem) (Job, b
 		body = "<p>" + d.Money + "</p>" + body
 	}
 
+	// On a community hub the real employer lives in the vacancy's division breadcrumb, not in
+	// the configured (hub) company; an ordinary board keeps its configured company.
+	company := e.Company
+	if e.Hub {
+		company = companyFromDivision(d.Division, e.Company)
+	}
+
 	return Job{
 		ExternalID:  strconv.FormatInt(it.ID, 10),
 		URL:         fmt.Sprintf(huntflowVacancyURL, e.Board, it.Slug),
 		Title:       it.Position,
-		Company:     e.Company,
+		Company:     company,
 		Location:    d.City,
 		Description: sanitizeHTML(body),
 		Remote:      isRemote(d.City),
 		PostedAt:    nil, // the public career feed carries no publish date
 	}, true
+}
+
+// companyFromDivision resolves a hub board's per-vacancy employer from Huntflow's division
+// breadcrumb. Huntflow encodes division leaf-first as
+// "<sub-team> · … · <Company> · Partners · Vacancies", where the huntflowHubFolder holds every
+// partner company, so the employer is the segment immediately before that folder; deeper
+// segments are the company's own sub-teams. The separator is "·" (U+00B7) in the list payload
+// and "•" (U+2022) in the detail payload. Falls back to the given company when the division has
+// no such structure (e.g. the hub's own internal roles).
+func companyFromDivision(division, fallback string) string {
+	segments := strings.Split(strings.ReplaceAll(division, "•", "·"), "·")
+	for i, seg := range segments {
+		if i > 0 && strings.TrimSpace(seg) == huntflowHubFolder {
+			if company := strings.TrimSpace(segments[i-1]); company != "" {
+				return company
+			}
+			break
+		}
+	}
+	return fallback
 }
 
 // payload fetches a Nuxt _payload.json and resolves its devalue references into a plain

--- a/internal/sources/huntflow_test.go
+++ b/internal/sources/huntflow_test.go
@@ -82,6 +82,55 @@ func hfDetailBody(id int, position, city, money, body string) string {
 	]`
 }
 
+// hfDetailBodyWithDivision builds a detail payload that includes the division breadcrumb,
+// used to test a community hub's per-vacancy employer resolution.
+func hfDetailBodyWithDivision(id int, position, division, body string) string {
+	return `[
+		{"data":1},{"vacancy":2},
+		{"id":3,"position":4,"city":5,"money":5,"division":6,"intro":5,"body":7,"requirements":8,"conditions":8,"is_archived":9},
+		` + strconv.Itoa(id) + `,"` + position + `",null,"` + division + `","` + body + `","",false
+	]`
+}
+
+func TestHuntflowFetchHubResolvesEmployerFromDivision(t *testing.T) {
+	detail := hfDetailBodyWithDivision(27611, "Senior Fullstack Engineer",
+		"Fluently • Partners • Vacancies", "<p>Build.</p>")
+	fake := (&routedHTTP{}).
+		route("/vacancy/eng/_payload.json", detail).
+		route(".huntflow.io/_payload.json", hfListBody(27611, "eng", "Senior Fullstack Engineer", "null"))
+
+	jobs, err := NewHuntflow(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "AlumniHub", Provider: "huntflow", Board: "alumnihub-career", Hub: true,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if jobs[0].Company != "Fluently" {
+		t.Errorf("Company = %q, want Fluently (resolved from division on a hub board)", jobs[0].Company)
+	}
+}
+
+func TestHuntflowFetchNonHubKeepsConfiguredCompany(t *testing.T) {
+	// A division is present, but a non-hub board still attributes to the configured company.
+	detail := hfDetailBodyWithDivision(1, "Role", "Fluently • Partners • Vacancies", "<p>x</p>")
+	fake := (&routedHTTP{}).
+		route("/vacancy/r/_payload.json", detail).
+		route(".huntflow.io/_payload.json", hfListBody(1, "r", "Role", "null"))
+
+	jobs, _ := NewHuntflow(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Banki.ru", Provider: "huntflow", Board: "banki",
+	})
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if jobs[0].Company != "Banki.ru" {
+		t.Errorf("Company = %q, want Banki.ru (a non-hub board keeps the configured company)", jobs[0].Company)
+	}
+}
+
 func TestHuntflowFetchMapsListAndDetail(t *testing.T) {
 	fake := (&routedHTTP{}).
 		route("/vacancy/senior-backend-developer-2/_payload.json",
@@ -115,6 +164,30 @@ func TestHuntflowFetchMapsListAndDetail(t *testing.T) {
 	}
 	if j.PostedAt != nil {
 		t.Errorf("PostedAt = %v, want nil (feed has no date)", j.PostedAt)
+	}
+}
+
+func TestHuntflowCompanyFromDivision(t *testing.T) {
+	const fallback = "AlumniHub"
+	tests := []struct {
+		name     string
+		division string
+		want     string
+	}{
+		{"three segments", "Mirai · Partners · Vacancies", "Mirai"},
+		{"sub-team before company", "Remote · Sparkland · Partners · Vacancies", "Sparkland"},
+		{"bullet separator", "Fluently • Partners • Vacancies", "Fluently"},
+		{"company with punctuation", "NDA (Hedge Fund) · Partners · Vacancies", "NDA (Hedge Fund)"},
+		{"empty falls back", "", fallback},
+		{"no partners folder falls back", "Engineering · Acme", fallback},
+		{"partners first falls back", "Partners · Vacancies", fallback},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := companyFromDivision(tt.division, fallback); got != tt.want {
+				t.Errorf("companyFromDivision(%q) = %q, want %q", tt.division, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -16,11 +16,16 @@ import (
 // company whose jobs we crawl, the platform it uses (Provider), and the platform-specific
 // board id. Region is an optional per-entry hint for ATS platforms that host tenants on
 // regional API domains (e.g. Lever's EU data-residency host); empty means the default host.
+// Hub is an optional per-entry flag marking a board as a community/agency hub whose vacancies
+// belong to many partner companies; an adapter that honours it resolves each job's employer from
+// the posting and uses Company only as the hub name and per-vacancy fallback (e.g. huntflow's
+// AlumniHub). It is ignored by adapters that do not implement hub resolution.
 type CompanyEntry struct {
 	Company  string `yaml:"company"`
 	Provider string `yaml:"provider"`
 	Board    string `yaml:"board"`
 	Region   string `yaml:"region"`
+	Hub      bool   `yaml:"hub"`
 }
 
 // Job is a raw posting as an adapter yields it, before the pipeline normalizes it

--- a/openspec/changes/huntflow-hub-employer/.openspec.yaml
+++ b/openspec/changes/huntflow-hub-employer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-21

--- a/openspec/changes/huntflow-hub-employer/design.md
+++ b/openspec/changes/huntflow-hub-employer/design.md
@@ -1,0 +1,82 @@
+## Context
+
+The `huntflow` adapter (`internal/sources/huntflow.go`) crawls Huntflow-hosted career sites,
+one board per `<board>.huntflow.io` subdomain, and stamps the board's configured `company` on
+every vacancy. That assumption breaks for **community hubs** like AlumniHub, where each vacancy
+belongs to a different partner company. The true employer is already in the vacancy's `division`
+breadcrumb; we only need to read it — but solely for boards that opt in, because on an ordinary
+single-company Huntflow site `division` is a department, not an employer.
+
+This mirrors the existing `tecla` aggregator (per-job company), but differs in one structural
+way: `tecla` is **boardless** (one global feed). Huntflow is **board-based** and *mixed* — most
+boards are single companies and only some are hubs. So the existing boardless-`aggregator`
+mechanism does not fit; the hub property must be **per board entry**, not per provider.
+
+## Goals / Non-Goals
+
+**Goals**
+- Attribute AlumniHub vacancies to their real employer (Fluently, Mirai, Sparkland, …).
+- Leave every non-hub board (Banki.ru, Flowwow, …) completely unchanged.
+- No new source, schema, env var, migration, or dedup change.
+
+**Non-Goals**
+- Generalising the hub mechanism to non-huntflow providers (none need it yet).
+- Making the `Partners` container folder name configurable (YAGNI — one hub today).
+- Mapping salary or other new fields.
+
+## Decisions
+
+### Per-entry opt-in flag (`CompanyEntry.Hub bool`), not a provider marker or heuristic
+- **Chosen**: add an optional `Hub bool` field (`yaml:"hub"`) to `CompanyEntry`, set only on the
+  `alumnihub-career` entry. The adapter branches on it.
+- **Why**: explicit, safe (untouched boards behave identically), and follows the existing
+  precedent of `CompanyEntry.Region` — an optional per-entry field used by a single provider
+  (Lever's EU host). Validation is unaffected (`company` stays required as the hub name +
+  fallback).
+- **Alternatives considered**:
+  - *Pure heuristic* (always parse division when it ends in `Partners · Vacancies`): no config,
+    but applies the `Partners` assumption implicitly to every huntflow board and would misfire
+    if an ordinary company named a department `Partners`. Rejected — magic and unsafe.
+  - *Provider-level `aggregator()` marker*: wrong granularity — huntflow is mixed, most boards
+    are single companies. Rejected.
+  - *String marker in config* (`hub_marker: "Partners"`): most general, but overengineered for
+    the single hub we have. Deferred as the documented seam (see Risks).
+
+### Employer = segment immediately before the `Partners` folder
+- **Chosen**: split `division` on either separator (`·`/`•`), find the `Partners` segment, take
+  the segment before it; fall back to the configured company otherwise.
+- **Why**: robust against the real data. The naive "first segment" breaks on
+  `Remote · Sparkland · Partners · Vacancies` (yields `Remote`, a sub-team). The breadcrumb is
+  leaf-first and `Partners` is AlumniHub's stable container folder for all partners, so the
+  segment before it is always the partner company; deeper segments are sub-teams.
+- **Alternatives considered**: "second-to-last segment" — fails for the 3-segment case
+  (`Mirai · Partners · Vacancies` → `Partners`). Rejected.
+
+### Read `division` in `detail()` where the `Job` is already built
+- The detail payload (already fetched per vacancy) carries `division`; extract it there
+  alongside the existing fields and branch the `Company` assignment. No extra request.
+
+## Risks / Trade-offs
+
+- **Hard-coded `Partners` marker couples to AlumniHub's org tree** → if a future hub uses a
+  differently named root folder, the parser returns the fallback (the hub name) rather than a
+  wrong company — a safe degradation, not data corruption. Mitigation/seam: promote the bool
+  flag to a string marker in config when a second hub appears.
+- **Re-attribution churn**: existing AlumniHub rows change company on the next crawl. This is the
+  intended correction; `UpsertJob` handles it (same `source`+`external_id`), and `company_slug`
+  re-derives. No data loss (soft state only).
+- **A partner with no sub-division but no `Partners` parent** would fall back to the hub name.
+  Acceptable: better an honest "AlumniHub" than a wrong employer. Live data shows every partner
+  vacancy carries the `Partners` folder, so this is the rare/own-roles case by design.
+
+## Migration Plan
+
+1. Ship code + `hub: true` on `alumnihub-career`.
+2. Next scheduled `cmd/ingest sources/huntflow.yml` re-attributes AlumniHub vacancies to real
+   employers via `UpsertJob`; a follow-up reindex (existing cron) refreshes the search facet.
+3. **Rollback**: remove `hub: true` (or revert the adapter branch) — the next crawl re-stamps
+   `AlumniHub`. No schema or data migration to undo.
+
+## Open Questions
+
+None.

--- a/openspec/changes/huntflow-hub-employer/proposal.md
+++ b/openspec/changes/huntflow-hub-employer/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Some Huntflow career sites are not a single employer's board but a **community/agency hub**
+that posts vacancies on behalf of many partner companies — the same shape as our `tecla`
+marketplace adapter. AlumniHub (`alumnihub-career.huntflow.io`) is one: every vacancy belongs
+to a different partner (Fluently, Mirai, Sparkland, "NDA (Hedge Fund)", …), yet our `huntflow`
+adapter stamps the configured board company (`AlumniHub`) on all of them. The catalogue
+therefore shows the wrong employer and groups unrelated jobs under one fake company.
+
+The real employer is already present in each vacancy's `division` breadcrumb (leaf-first):
+`<sub-team> · <Company> · Partners · Vacancies` — the company is the segment immediately before
+the hub's `Partners` container folder. We can surface the true employer without any new source
+or schema, just by reading what the feed already gives us — but only for boards explicitly
+marked as such, since on an ordinary single-company Huntflow site `division` is a department,
+not an employer.
+
+## What Changes
+
+- Add an **opt-in per-entry flag** to a board-file entry (`CompanyEntry.Hub bool`,
+  `yaml:"hub"`, optional) marking a Huntflow board as a community hub whose real employer lives
+  in each vacancy's `division`. Absent/`false` keeps today's behaviour for every other board.
+- In the `huntflow` adapter, when the entry is a hub, set each job's `Company` from its
+  `division` (the segment immediately before the literal `Partners` folder), falling back to
+  the entry's configured company when the division has no such structure (e.g. the hub's own
+  internal roles). When the entry is not a hub, behaviour is unchanged (`Company = e.Company`).
+- Set `hub: true` on the `alumnihub-career` entry in `sources/huntflow.yml`.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. Reuses the source-ingest pipeline, write path, and dedup key unchanged. -->
+
+### Modified Capabilities
+- `source-ingest`: a board-file entry MAY be marked as a community hub; for a hub entry the
+  `huntflow` adapter resolves each vacancy's employer from its own `division` breadcrumb
+  (segment before the `Partners` folder) instead of from the configured company, falling back
+  to the configured company when the division carries no employer.
+
+## Impact
+
+- **Code**: `internal/sources/source.go` (one optional field on `CompanyEntry`);
+  `internal/sources/huntflow.go` (read `division`, add `companyFromDivision`, branch on the hub
+  flag); `internal/sources/huntflow_test.go` (parser + hub/non-hub mapping tests).
+- **Config**: `sources/huntflow.yml` — `hub: true` on `alumnihub-career` only. No other board
+  file changes; the field is optional and ignored where absent.
+- **Validation**: `Config.Validate` unchanged — `company` stays required (it is the hub's name
+  and the per-vacancy fallback).
+- **DB / dedup / search**: unchanged — `source = "huntflow"`, `external_id = <vacancy id>`. Only
+  the displayed `Company` (and its derived `company_slug`) changes for hub boards; existing
+  AlumniHub rows re-attribute to the real employer on the next crawl via `UpsertJob`.
+- **Out of scope (known seam)**: the `Partners` container marker is hard-coded in the adapter
+  for AlumniHub's org tree. If a future hub uses a differently named root folder, lift the
+  marker into the config field (string instead of bool) — noted, not built now (YAGNI).

--- a/openspec/changes/huntflow-hub-employer/specs/source-ingest/spec.md
+++ b/openspec/changes/huntflow-hub-employer/specs/source-ingest/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: A board entry MAY be marked as a community hub whose employer comes from each posting
+
+The system SHALL support an optional `hub` flag on a board-file entry that marks a board-based
+provider's board as a community/agency hub: a board that lists vacancies on behalf of many
+partner companies rather than a single employer. Unlike a boardless aggregator (one global feed,
+no board id), a hub entry still names a board id and still requires a `company` — that configured
+company is the hub's own name and the per-vacancy fallback employer. When the flag is absent or
+false, the provider's existing behaviour SHALL be unchanged and each job's company SHALL be the
+configured entry company.
+
+For a hub entry, the provider SHALL resolve each vacancy's employer from the posting itself
+rather than from the configured company, falling back to the configured company when the posting
+carries no resolvable employer (for example the hub's own internal roles).
+
+#### Scenario: A non-hub entry attributes every job to the configured company
+
+- **WHEN** a board file lists an entry without the `hub` flag (or with `hub: false`)
+- **THEN** each crawled job's company is the entry's configured `company`, exactly as before
+
+#### Scenario: A hub entry attributes each job to the employer named in the posting
+
+- **WHEN** a board file lists an entry with `hub: true`
+- **THEN** each crawled job's company is resolved from that vacancy's own payload, and only a
+  vacancy with no resolvable employer falls back to the configured `company`
+
+### Requirement: The huntflow adapter resolves a hub board's employer from the vacancy division
+
+For a `huntflow` board marked as a community hub, the adapter SHALL set each vacancy's company
+from the vacancy's `division` breadcrumb. Huntflow encodes `division` leaf-first as
+`<sub-team> · … · <Company> · Partners · Vacancies`, where the literal `Partners` folder
+contains every partner company; the employer is therefore the segment immediately preceding the
+`Partners` segment. The adapter SHALL accept either separator Huntflow emits (`·` U+00B7 in the
+list payload, `•` U+2022 in the detail payload). When the division has no `Partners` segment, or
+no segment precedes it, or the resolved segment is empty, the adapter SHALL fall back to the
+configured entry company. A non-hub `huntflow` board's behaviour is unchanged (company is the
+configured entry company).
+
+#### Scenario: The employer is the segment before the Partners folder
+
+- **WHEN** a hub vacancy's division is `Mirai · Partners · Vacancies`
+- **THEN** the job's company is `Mirai`
+
+#### Scenario: A deeper sub-team does not displace the employer
+
+- **WHEN** a hub vacancy's division is `Remote · Sparkland · Partners · Vacancies`
+- **THEN** the job's company is `Sparkland` (the segment before `Partners`), not the deeper
+  `Remote` sub-team
+
+#### Scenario: Either separator is accepted
+
+- **WHEN** a hub vacancy's division uses the bullet separator, e.g. `Fluently • Partners • Vacancies`
+- **THEN** the job's company is `Fluently`
+
+#### Scenario: A division without a partner structure falls back to the hub company
+
+- **WHEN** a hub vacancy's division is empty or lacks a `Partners` segment
+- **THEN** the job's company is the configured entry company (the hub's own name)

--- a/openspec/changes/huntflow-hub-employer/tasks.md
+++ b/openspec/changes/huntflow-hub-employer/tasks.md
@@ -1,0 +1,30 @@
+## 1. Division parser (pure function, TDD)
+
+- [ ] 1.1 RED: add `huntflow_test.go` cases for `companyFromDivision(division, fallback)` —
+  `Mirai · Partners · Vacancies`→`Mirai`; `Remote · Sparkland · Partners · Vacancies`→`Sparkland`;
+  `Fluently • Partners • Vacancies`→`Fluently`; `NDA (Hedge Fund) · Partners · Vacancies`→`NDA (Hedge Fund)`;
+  empty / no-`Partners` / `Partners`-first → `fallback`.
+- [ ] 1.2 GREEN: implement `companyFromDivision` in `huntflow.go` (normalize `•`→`·`, split, trim,
+  take segment before `Partners`, else fallback).
+
+## 2. Hub flag on the config entry
+
+- [ ] 2.1 Add optional `Hub bool` field (`yaml:"hub"`) to `CompanyEntry` in `source.go`, documented
+  like `Region` (optional, provider-specific). Confirm `Config.Validate` is unaffected.
+
+## 3. Wire the parser into the adapter (TDD)
+
+- [ ] 3.1 RED: add a `detail()`/`Fetch` test proving a hub entry (`Hub: true`) sets `Company` from the
+  vacancy `division`, and a non-hub entry keeps `Company = e.Company`, using a devalue fixture.
+- [ ] 3.2 GREEN: read `division` in `detail()`; when `e.Hub`, set `Company = companyFromDivision(div, e.Company)`,
+  else `Company = e.Company`.
+
+## 4. Enable on AlumniHub
+
+- [ ] 4.1 Set `hub: true` on the `alumnihub-career` entry in `sources/huntflow.yml`.
+
+## 5. Verify
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./internal/sources/` green.
+- [ ] 5.2 Live smoke: run the huntflow adapter against `alumnihub-career` and confirm real
+  employers (Fluently/Mirai/Sparkland/…) instead of `AlumniHub`.

--- a/openspec/changes/huntflow-hub-employer/tasks.md
+++ b/openspec/changes/huntflow-hub-employer/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Division parser (pure function, TDD)
 
-- [ ] 1.1 RED: add `huntflow_test.go` cases for `companyFromDivision(division, fallback)` —
+- [x] 1.1 RED: add `huntflow_test.go` cases for `companyFromDivision(division, fallback)` —
   `Mirai · Partners · Vacancies`→`Mirai`; `Remote · Sparkland · Partners · Vacancies`→`Sparkland`;
   `Fluently • Partners • Vacancies`→`Fluently`; `NDA (Hedge Fund) · Partners · Vacancies`→`NDA (Hedge Fund)`;
   empty / no-`Partners` / `Partners`-first → `fallback`.
-- [ ] 1.2 GREEN: implement `companyFromDivision` in `huntflow.go` (normalize `•`→`·`, split, trim,
+- [x] 1.2 GREEN: implement `companyFromDivision` in `huntflow.go` (normalize `•`→`·`, split, trim,
   take segment before `Partners`, else fallback).
 
 ## 2. Hub flag on the config entry
 
-- [ ] 2.1 Add optional `Hub bool` field (`yaml:"hub"`) to `CompanyEntry` in `source.go`, documented
+- [x] 2.1 Add optional `Hub bool` field (`yaml:"hub"`) to `CompanyEntry` in `source.go`, documented
   like `Region` (optional, provider-specific). Confirm `Config.Validate` is unaffected.
 
 ## 3. Wire the parser into the adapter (TDD)
 
-- [ ] 3.1 RED: add a `detail()`/`Fetch` test proving a hub entry (`Hub: true`) sets `Company` from the
+- [x] 3.1 RED: add a `detail()`/`Fetch` test proving a hub entry (`Hub: true`) sets `Company` from the
   vacancy `division`, and a non-hub entry keeps `Company = e.Company`, using a devalue fixture.
-- [ ] 3.2 GREEN: read `division` in `detail()`; when `e.Hub`, set `Company = companyFromDivision(div, e.Company)`,
+- [x] 3.2 GREEN: read `division` in `detail()`; when `e.Hub`, set `Company = companyFromDivision(div, e.Company)`,
   else `Company = e.Company`.
 
 ## 4. Enable on AlumniHub
 
-- [ ] 4.1 Set `hub: true` on the `alumnihub-career` entry in `sources/huntflow.yml`.
+- [x] 4.1 Set `hub: true` on the `alumnihub-career` entry in `sources/huntflow.yml`.
 
 ## 5. Verify
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./internal/sources/` green.
-- [ ] 5.2 Live smoke: run the huntflow adapter against `alumnihub-career` and confirm real
+- [x] 5.1 `go build ./... && go vet ./... && go test ./internal/sources/` green.
+- [x] 5.2 Live smoke: run the huntflow adapter against `alumnihub-career` and confirm real
   employers (Fluently/Mirai/Sparkland/…) instead of `AlumniHub`.

--- a/sources/huntflow.yml
+++ b/sources/huntflow.yml
@@ -1,9 +1,12 @@
 # huntflow boards. Provider is the filename; each entry is company + board.
 # board = the <board>.huntflow.io subdomain (see internal/sources/huntflow.go).
 # Each subdomain validated live (>0 open vacancies via _payload.json) before adding.
+# hub: true marks a community/agency board whose real employer is per-vacancy (from the
+# division breadcrumb); company then names the hub and is the fallback employer.
 
 - company: AlumniHub
   board: alumnihub-career
+  hub: true
 - company: Banki.ru
   board: banki
 - company: Coffeemania


### PR DESCRIPTION
## Summary
- AlumniHub (`alumnihub-career.huntflow.io`) is a community/agency **hub** on Huntflow: every vacancy belongs to a different partner company (Fluently, Mirai, Sparkland, "NDA (Hedge Fund)", …), named in the vacancy's `division` breadcrumb. The adapter previously stamped the configured board company (`AlumniHub`) on all of them — wrong employer, all jobs grouped under one fake company.
- Adds an **opt-in** `CompanyEntry.Hub bool` (`yaml:"hub"`) flag (mirrors the existing optional `Region` precedent). For a hub board the `huntflow` adapter resolves each job's employer from its `division` (the segment immediately before the `Partners` folder), falling back to the configured company. **Non-hub boards are byte-identical to before.**
- Enables `hub: true` on the `alumnihub-career` entry only.

The `division` breadcrumb is leaf-first (`<sub-team> · … · <Company> · Partners · Vacancies`), so the naive "first segment" breaks on `Remote · Sparkland · Partners · Vacancies` (→ `Remote`); taking the segment before `Partners` yields the correct `Sparkland`. Both separators (`·` U+00B7 in the list payload, `•` U+2022 in the detail payload) are handled.

No schema/dedup change: `source = "huntflow"`, `external_id = <vacancy id>` unchanged; existing AlumniHub rows re-attribute on the next crawl via `UpsertJob`.

OpenSpec change: `openspec/changes/huntflow-hub-employer/`.

## Test Plan
- [x] `go build ./...` + `go vet ./...` clean
- [x] `go test -count=1 ./internal/sources/` green (table test for `companyFromDivision` covers the 3-segment, sub-team, bullet-separator, punctuation, empty, no-`Partners`, and `Partners`-first cases; Fetch-level tests prove hub resolves from division and non-hub keeps the configured company)
- [x] `openspec validate huntflow-hub-employer --strict` valid
- [x] Live smoke against `alumnihub-career` → real employers (Fluently/Mirai/**Sparkland**/NDA (Hedge Fund)/Silver Mont), zero `AlumniHub`