### PR TITLE
feat(sources): add ClickBus to the gupy board list

### DIFF
--- a/sources/gupy.yml
+++ b/sources/gupy.yml
@@ -2905,3 +2905,5 @@
   board: "958"
 - company: Grupo CM
   board: "974"
+- company: ClickBus
+  board: "82405"


### PR DESCRIPTION
## Summary
- Adds **ClickBus** to `sources/gupy.yml`. ClickBus runs its careers on Gupy (`clickbus.gupy.io`); the `huntflow`-style provider already exists, so this is one board entry.
- `board` is the Gupy numeric `companyId` **82405** (read from `clickbus.gupy.io`'s `__NEXT_DATA__`).

## Test Plan
- [x] Verified live against the portal API: `GET https://employability-portal.gupy.io/api/v1/jobs?companyId=82405` returns open ClickBus vacancies with valid `jobUrl`s
- [x] `go test ./internal/sources/ -run TestParseConfig` green (board file still parses/validates)