### PR TITLE
fix(sources): label web.wd1 Workday tenant as Newfold Digital + dedupe sites

### DIFF
--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -9813,12 +9813,10 @@
   board: wealthenhancement.wd1.myworkdayjobs.com/weg_careers
 - company: weareeverise
   board: weareeverise.wd1.myworkdayjobs.com/everisecareers
-- company: web
+- company: Newfold Digital
+  board: web.wd1.myworkdayjobs.com/ExternalCareerSite
+- company: Newfold Digital
   board: web.wd1.myworkdayjobs.com/dn1
-- company: web
-  board: web.wd1.myworkdayjobs.com/externalcareersite
-- company: web
-  board: web.wd1.myworkdayjobs.com/hostgator
 - company: webberwentzel
   board: webberwentzel.wd3.myworkdayjobs.com/ww_earlycareers
 - company: webcotube


### PR DESCRIPTION
## Summary
The `web.wd1.myworkdayjobs.com` Workday tenant (Web.com Group / **Newfold Digital** — HostGator, Network Solutions, Web.com) had three auto-harvested board entries, all mislabelled with the placeholder company **`web`**, with overlapping sites:

| board | jobs | issue |
|---|---|---|
| `externalcareersite` | 82 | duplicate of the canonical `ExternalCareerSite` (Workday site path is case-insensitive) |
| `hostgator` | 7 | Brazil subset of `ExternalCareerSite` — same jobs (`_R14205` vs `_R14205-2`) → duplicate rows |
| `dn1` | 6 | disjoint brand (APAC/EU, `R1xxx`) |

Collapses to:
- `web.wd1.myworkdayjobs.com/ExternalCareerSite` → **Newfold Digital** (canonical case, the 82-job superset; includes the HostGator-Brazil roles, e.g. the AI Backend req that prompted this)
- `web.wd1.myworkdayjobs.com/dn1` → **Newfold Digital** (kept; disjoint)

Removes the lowercase `externalcareersite` duplicate and the `hostgator` subset. The orphaned/duplicate rows close via the existing 48h unseen sweep; job URLs are unaffected (built from the API `externalUrl`, which is already canonical).

Note: the Ashby `dualentry` board from the other link is already present in `sources/ashby.yml` — no change needed there.

## Test Plan
- [x] Live: `POST /wday/cxs/web/ExternalCareerSite/jobs` returns 82 postings (incl. R14205); `dn1` returns 6 disjoint (`R1xxx`)
- [x] `go test ./internal/sources/` green (board file still parses/validates)
- [x] `go build ./internal/...` clean