### PR TITLE
feat(sources): add Solides ATS adapter (solides)

### DIFF
--- a/internal/sources/solides.go
+++ b/internal/sources/solides.go
@@ -1,0 +1,128 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// solidesBaseURL is the Solides public jobs API. Solides is a broad Brazilian ATS;
+// a company's career page lives at <slug>.vagas.solides.com.br, but the listing API
+// is this one central gateway host keyed by the tenant slug.
+const solidesBaseURL = "https://apigw.solides.com.br/jobs/v3/home/vacancy"
+
+// solidesPageSize is the listing page size. The server caps take at 25, so this is
+// also the maximum.
+const solidesPageSize = 25
+
+// solidesMaxPages bounds the page walk. The stop signal is the response's totalPages,
+// but this caps a misbehaving API at 25000 postings — well above any single tenant.
+const solidesMaxPages = 1000
+
+// solidesOpenState is the currentState value marking an open vacancy; any other
+// present value (e.g. "encerrada") means the posting is closed and is skipped.
+const solidesOpenState = "em_andamento"
+
+// solides adapts the Solides jobs API. Its list endpoint carries the description
+// inline, so — like Gupy — it needs no per-posting detail request. The board id is
+// the tenant's subdomain slug.
+type solides struct {
+	http JSONGetter
+}
+
+// NewSolides builds the Solides adapter over the given HTTP client.
+func NewSolides(c JSONGetter) Source { return solides{http: c} }
+
+func (solides) Provider() string { return "solides" }
+
+// solidesJob is one posting from the Solides listing. The description is full HTML
+// inline; city/state are nested objects; homeOffice is a structured remote flag and
+// jobType a structured "remoto"/"hibrido"/"presencial" enum.
+type solidesJob struct {
+	ID           int64  `json:"id"`
+	Title        string `json:"title"`
+	Description  string `json:"description"`
+	CurrentState string `json:"currentState"`
+	City         struct {
+		Name string `json:"name"`
+	} `json:"city"`
+	State struct {
+		Name string `json:"name"`
+		Code string `json:"code"`
+	} `json:"state"`
+	HomeOffice bool   `json:"homeOffice"`
+	JobType    string `json:"jobType"`
+	CreatedAt  string `json:"createdAt"`
+}
+
+func (s solides) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	postings, err := s.list(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		// Skip a posting whose state is present and not open; a missing state is
+		// treated as open (the API only emits the field on real vacancies).
+		if p.CurrentState != "" && p.CurrentState != solidesOpenState {
+			continue
+		}
+		jobs = append(jobs, Job{
+			ExternalID:  strconv.FormatInt(p.ID, 10),
+			URL:         fmt.Sprintf("https://%s.vagas.solides.com.br/vaga/%d", e.Board, p.ID),
+			Title:       strings.TrimSpace(p.Title),
+			Company:     e.Company,
+			Location:    joinNonEmpty(p.City.Name, p.State.Code),
+			Description: sanitizeHTML(p.Description),
+			Remote:      p.HomeOffice,
+			WorkMode:    solidesWorkMode(p.JobType),
+			PostedAt:    parseDate(p.CreatedAt),
+		})
+	}
+	return jobs, nil
+}
+
+// list pages through the tenant's postings, stopping at the response's totalPages.
+// A first-page failure aborts (the board yields nothing); a later-page failure after
+// at least one page succeeded stops the walk and returns what was gathered, so a
+// transient mid-walk error does not discard the postings already collected.
+func (s solides) list(ctx context.Context, board string) ([]solidesJob, error) {
+	var postings []solidesJob
+	for page := 1; page <= solidesMaxPages; page++ {
+		url := fmt.Sprintf("%s?slug=%s&take=%d&page=%d", solidesBaseURL, board, solidesPageSize, page)
+		var resp struct {
+			Data struct {
+				TotalPages int          `json:"totalPages"`
+				Data       []solidesJob `json:"data"`
+			} `json:"data"`
+		}
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("solides: list tenant %s: %w", board, err)
+			}
+			break // partial: keep what earlier pages yielded
+		}
+		postings = append(postings, resp.Data.Data...)
+		if page >= resp.Data.TotalPages {
+			break // reached the last page the server reports
+		}
+	}
+	return postings, nil
+}
+
+// solidesWorkMode maps Solides's jobType enum to our work-mode vocabulary; an
+// unrecognized value yields "".
+func solidesWorkMode(jobType string) string {
+	switch strings.ToLower(strings.TrimSpace(jobType)) {
+	case "remoto":
+		return "remote"
+	case "hibrido":
+		return "hybrid"
+	case "presencial":
+		return "onsite"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/solides_test.go
+++ b/internal/sources/solides_test.go
@@ -1,0 +1,134 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestSolidesProvider(t *testing.T) {
+	if got := NewSolides(nil).Provider(); got != "solides" {
+		t.Errorf("Provider() = %q, want %q", got, "solides")
+	}
+}
+
+func TestSolidesFetchMapsFieldsAndPaginates(t *testing.T) {
+	// Page 1 declares totalPages=2, so the walk continues to page 2. The first job
+	// exercises every mapping; the closed job (currentState != "em_andamento") is
+	// dropped before page 2's open job.
+	page1 := `{"data":{"count":3,"currentPage":1,"totalPages":2,"data":[
+		{"id":2001,"title":"  Backend Engineer  ",
+		 "description":"<p>Build things</p><script>evil()</script>",
+		 "currentState":"em_andamento",
+		 "city":{"name":"Florianópolis"},"state":{"name":"Santa Catarina","code":"SC"},
+		 "homeOffice":false,"jobType":"hibrido","createdAt":"2026-06-11",
+		 "redirectLink":"https://malformed/x"},
+		{"id":2002,"title":"Closed Role","currentState":"encerrada",
+		 "city":{"name":"São Paulo"},"state":{"name":"São Paulo","code":"SP"},
+		 "homeOffice":false,"jobType":"presencial","createdAt":"2026-06-10"}
+	]}}`
+
+	page2 := `{"data":{"count":3,"currentPage":2,"totalPages":2,"data":[
+		{"id":2003,"title":"Remote SRE","description":"<p>On call</p>",
+		 "currentState":"em_andamento",
+		 "city":{"name":""},"state":{"name":"","code":""},
+		 "homeOffice":true,"jobType":"remoto","createdAt":"2026-06-09"}
+	]}}`
+
+	fake := (&routedHTTP{}).
+		route("page=1", page1).
+		route("page=2", page2)
+
+	jobs, err := NewSolides(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Dynamox", Provider: "solides", Board: "dynamox",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// 1 open from page 1 (closed one dropped) + 1 open from page 2 = 2.
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (one closed job dropped across two pages)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	be, ok := byID["2001"]
+	if !ok {
+		t.Fatal("posting 2001 missing")
+	}
+	if be.Title != "Backend Engineer" {
+		t.Errorf("Title = %q, want trimmed title", be.Title)
+	}
+	if be.URL != "https://dynamox.vagas.solides.com.br/vaga/2001" {
+		t.Errorf("URL = %q, want built vaga URL (not redirectLink)", be.URL)
+	}
+	if be.Company != "Dynamox" {
+		t.Errorf("Company = %q, want configured company", be.Company)
+	}
+	if be.Location != "Florianópolis, SC" {
+		t.Errorf("Location = %q, want city.name + state.code joined", be.Location)
+	}
+	if be.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid from jobType hibrido", be.WorkMode)
+	}
+	if be.Remote {
+		t.Error("Remote = true, want false from homeOffice")
+	}
+	if !strings.Contains(be.Description, "Build things") {
+		t.Errorf("Description missing body, got %q", be.Description)
+	}
+	if strings.Contains(be.Description, "evil") {
+		t.Errorf("Description must be sanitized, got %q", be.Description)
+	}
+	if be.PostedAt == nil || be.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed createdAt (2026)", be.PostedAt)
+	}
+
+	if _, present := byID["2002"]; present {
+		t.Error("posting 2002 is not em_andamento and must be dropped")
+	}
+
+	sre, ok := byID["2003"]
+	if !ok {
+		t.Fatal("posting 2003 missing")
+	}
+	if !sre.Remote {
+		t.Error("Remote = false, want true from homeOffice")
+	}
+	if sre.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote from jobType remoto", sre.WorkMode)
+	}
+	if sre.Location != "" {
+		t.Errorf("Location = %q, want empty when city/state are blank", sre.Location)
+	}
+}
+
+func TestSolidesFetchStopsAtLastPage(t *testing.T) {
+	// A single-page board (totalPages=1) ends the walk after one request.
+	fake := (&routedHTTP{}).
+		route("page=1", `{"data":{"count":1,"currentPage":1,"totalPages":1,"data":[
+			{"id":1,"title":"Only Role","currentState":"em_andamento",
+			 "city":{"name":"Joinville"},"state":{"code":"SC"},
+			 "homeOffice":false,"jobType":"presencial","createdAt":"2026-06-01"}
+		]}}`)
+
+	jobs, err := NewSolides(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Reivax", Provider: "solides", Board: "reivax",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 from the single page", len(jobs))
+	}
+	if jobs[0].WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want onsite from jobType presencial", jobs[0].WorkMode)
+	}
+	if fake.calls != 1 {
+		t.Errorf("made %d HTTP calls, want 1 (totalPages=1 must stop the walk)", fake.calls)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -115,6 +115,7 @@ func All(c HTTPClient) map[string]Source {
 		NewRecruitee(c),
 		NewSmartRecruiters(c),
 		NewGupy(c),
+		NewSolides(c),
 		NewPersonio(c),
 		NewPinpoint(c),
 		NewRippling(c),

--- a/sources/solides.yml
+++ b/sources/solides.yml
@@ -1,0 +1,6 @@
+# Solides ATS boards (apigw.solides.com.br). board = the tenant subdomain slug
+# (<board>.vagas.solides.com.br). Broad Brazilian ATS; description is inline in the listing.
+- company: Dynamox
+  board: dynamox
+- company: Reivax
+  board: reivax


### PR DESCRIPTION
## Summary

Adds the `solides` job-source adapter. Solides is a broad Brazilian ATS; each
tenant's career page lives at `<slug>.vagas.solides.com.br`, but the listing API
is one central gateway host (`apigw.solides.com.br`) keyed by the tenant slug.

- Keyless, public JSON; description is **inline** in the listing, so — like Gupy —
  no per-posting detail request is needed.
- Board id = the tenant subdomain slug (e.g. `dynamox`).
- Paginated `GET .../jobs/v3/home/vacancy?slug=<board>&take=25&page=<N>`; the walk
  loops `page=1..data.totalPages` (server caps `take` at 25).
- Mapping: `id`→ExternalID, `title`→Title, `city.name`+`state.code`→Location,
  `homeOffice`→Remote, `jobType` (remoto/hibrido/presencial)→WorkMode, `createdAt`
  (zone-less `2006-01-02`)→PostedAt, `description`→sanitized HTML. URL is built as
  `https://<board>.vagas.solides.com.br/vaga/<id>` (the row's `redirectLink` is
  malformed and not used). Postings whose `currentState` is present and not
  `em_andamento` (closed) are skipped.
- New board file `sources/solides.yml` seeds Florianópolis-area companies Dynamox
  and Reivax; registered in `sources.All`.

## Test Plan

- `go build ./...` — exit 0
- `go vet ./internal/sources/` — clean
- `gofmt -l` on the new files + `source.go` — prints nothing
- `go test -count=1 ./internal/sources/` — green (new `TestSolides*`: provider key,
  field mapping incl. location join / work-mode / remote / posted-date / built URL /
  sanitized description, multi-page pagination via `totalPages`, and skipping
  non-`em_andamento` postings)
- Live smoke (`curl` for `dynamox`): real envelope `{data:{totalPages,count,data:[…]}}`
  with inline HTML descriptions — matches the adapter.

Notes: broad Brazilian ATS; keyless; description inline; paginated.
