### PR TITLE
feat(sources): add InHire ATS adapter (inhire)

### DIFF
--- a/internal/sources/inhire.go
+++ b/internal/sources/inhire.go
@@ -1,0 +1,91 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"strings"
+)
+
+// inhire adapts InHire's public careers API (api.inhire.app), the ATS behind a number of
+// Brazilian (Florianópolis-rooted) company career sites. A board is the tenant slug, passed
+// on every request as the X-Tenant header. The listing call carries no description, so each
+// post's body and publish date come from its own detail call, fanned out like the other
+// detail-fetching adapters.
+type inhire struct {
+	http HeaderJSONGetter
+}
+
+const (
+	inhireListURL    = "https://api.inhire.app/job-posts/public/pages"
+	inhireDetailURL  = "https://api.inhire.app/job-posts/public/pages/%s"
+	inhireVacancyURL = "https://%s.inhire.com.br/vagas/%s"
+)
+
+// NewInhire builds the InHire adapter over the given HTTP client.
+func NewInhire(c HeaderJSONGetter) Source { return inhire{http: c} }
+
+func (inhire) Provider() string { return "inhire" }
+
+// inhirePost is one job post from the listing (no description here).
+type inhirePost struct {
+	JobID         string `json:"jobId"`
+	DisplayName   string `json:"displayName"`
+	WorkplaceType string `json:"workplaceType"`
+	Location      string `json:"location"`
+	Status        string `json:"status"`
+}
+
+func (h inhire) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	posts, err := h.list(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+
+	return fetchDetails(posts, defaultDetailWorkers, func(p inhirePost) (Job, bool) {
+		return h.detail(ctx, e, p)
+	}), nil
+}
+
+// tenantHeader is the per-tenant routing header every InHire call carries.
+func tenantHeader(board string) map[string]string {
+	return map[string]string{"X-Tenant": board}
+}
+
+// list fetches a board's job-post list (no pagination).
+func (h inhire) list(ctx context.Context, board string) ([]inhirePost, error) {
+	var resp struct {
+		JobsPage []inhirePost `json:"jobsPage"`
+	}
+	if err := h.http.GetJSONWithHeaders(ctx, inhireListURL, tenantHeader(board), &resp); err != nil {
+		return nil, fmt.Errorf("inhire: list board %s: %w", board, err)
+	}
+	return resp.JobsPage, nil
+}
+
+// detail fetches one post's body and publish date and maps it to a Job, returning ok=false
+// when the fetch or decode fails so the caller skips just that post.
+func (h inhire) detail(ctx context.Context, e CompanyEntry, p inhirePost) (Job, bool) {
+	var d struct {
+		Description string `json:"description"`
+		PublishedAt string `json:"publishedAt"`
+		CreatedAt   string `json:"createdAt"`
+	}
+	url := fmt.Sprintf(inhireDetailURL, p.JobID)
+	if err := h.http.GetJSONWithHeaders(ctx, url, tenantHeader(e.Board), &d); err != nil {
+		return Job{}, false
+	}
+
+	mode := workplaceTypeMode(p.WorkplaceType)
+	return Job{
+		ExternalID:  p.JobID,
+		URL:         fmt.Sprintf(inhireVacancyURL, e.Board, p.JobID),
+		Title:       strings.TrimSpace(p.DisplayName),
+		Company:     e.Company,
+		Location:    p.Location,
+		Description: sanitizeHTML(html.UnescapeString(d.Description)),
+		Remote:      mode == "remote",
+		PostedAt:    parseRFC3339(firstNonEmpty(d.PublishedAt, d.CreatedAt)),
+		WorkMode:    mode,
+	}, true
+}

--- a/internal/sources/inhire_test.go
+++ b/internal/sources/inhire_test.go
@@ -1,0 +1,167 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestInhireProvider(t *testing.T) {
+	if got := NewInhire(nil).Provider(); got != "inhire" {
+		t.Errorf("Provider() = %q, want %q", got, "inhire")
+	}
+}
+
+// inhireListBody builds a listing response with one job post.
+func inhireListBody(jobID, displayName, workplaceType, location string) string {
+	return `{"jobsPage":[
+		{"jobId":"` + jobID + `","displayName":"` + displayName + `","workplaceType":"` + workplaceType + `","location":"` + location + `","status":"published"}
+	]}`
+}
+
+// inhireDetailBody builds a detail response for one job post.
+func inhireDetailBody(workplaceType, location, description, publishedAt, createdAt string) string {
+	return `{"description":"` + description + `","workplaceType":"` + workplaceType + `","location":"` + location +
+		`","publishedAt":"` + publishedAt + `","createdAt":"` + createdAt + `"}`
+}
+
+func TestInhireFetchMapsListAndDetail(t *testing.T) {
+	const jobID = "11111111-2222-3333-4444-555555555555"
+	fake := (&routedHTTP{}).
+		route("/job-posts/public/pages/"+jobID,
+			inhireDetailBody("Remote", "São Paulo, BR",
+				"&lt;p&gt;Build &amp; ship.&lt;/p&gt;", "2026-06-15T10:00:00Z", "2026-06-10T10:00:00Z")).
+		route("/job-posts/public/pages",
+			inhireListBody(jobID, "  Senior Backend Engineer  ", "Remote", "São Paulo, BR"))
+
+	jobs, err := NewInhire(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Conta Azul", Provider: "inhire", Board: "contaazul",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != jobID {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, jobID)
+	}
+	if j.Title != "Senior Backend Engineer" {
+		t.Errorf("Title = %q, want the trimmed display name", j.Title)
+	}
+	if j.Company != "Conta Azul" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Location != "São Paulo, BR" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.URL != "https://contaazul.inhire.com.br/vagas/"+jobID {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote", j.WorkMode)
+	}
+	if !j.Remote {
+		t.Errorf("Remote = false, want true for a Remote workplace type")
+	}
+	if !strings.Contains(j.Description, "Build &amp; ship.") {
+		t.Errorf("Description = %q, want the unescaped+sanitized HTML body", j.Description)
+	}
+	if strings.Contains(j.Description, "&lt;p&gt;") {
+		t.Errorf("Description still HTML-entity-encoded: %q", j.Description)
+	}
+	if j.PostedAt == nil {
+		t.Fatalf("PostedAt = nil, want the parsed publishedAt")
+	}
+	if got := j.PostedAt.UTC().Format("2006-01-02"); got != "2026-06-15" {
+		t.Errorf("PostedAt = %s, want 2026-06-15 (publishedAt)", got)
+	}
+}
+
+func TestInhireFetchMapsWorkModes(t *testing.T) {
+	tests := []struct {
+		workplaceType string
+		wantMode      string
+		wantRemote    bool
+	}{
+		{"Remote", "remote", true},
+		{"Hybrid", "hybrid", false},
+		{"On-site", "onsite", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.workplaceType, func(t *testing.T) {
+			const jobID = "aaaa"
+			fake := (&routedHTTP{}).
+				route("/job-posts/public/pages/"+jobID,
+					inhireDetailBody(tt.workplaceType, "Florianópolis, BR", "<p>x</p>", "", "2026-06-10T10:00:00Z")).
+				route("/job-posts/public/pages",
+					inhireListBody(jobID, "Role", tt.workplaceType, "Florianópolis, BR"))
+
+			jobs, err := NewInhire(fake).Fetch(context.Background(), CompanyEntry{
+				Company: "Involves", Provider: "inhire", Board: "involves",
+			})
+			if err != nil {
+				t.Fatalf("Fetch: %v", err)
+			}
+			if len(jobs) != 1 {
+				t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+			}
+			if jobs[0].WorkMode != tt.wantMode {
+				t.Errorf("WorkMode = %q, want %q", jobs[0].WorkMode, tt.wantMode)
+			}
+			if jobs[0].Remote != tt.wantRemote {
+				t.Errorf("Remote = %v, want %v", jobs[0].Remote, tt.wantRemote)
+			}
+		})
+	}
+}
+
+func TestInhireFetchFallsBackToCreatedAt(t *testing.T) {
+	const jobID = "bbbb"
+	fake := (&routedHTTP{}).
+		route("/job-posts/public/pages/"+jobID,
+			inhireDetailBody("Remote", "", "<p>x</p>", "", "2026-06-08T09:00:00Z")).
+		route("/job-posts/public/pages",
+			inhireListBody(jobID, "Role", "Remote", ""))
+
+	jobs, err := NewInhire(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Neoway", Provider: "inhire", Board: "neoway",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if jobs[0].PostedAt == nil {
+		t.Fatalf("PostedAt = nil, want createdAt fallback")
+	}
+	if got := jobs[0].PostedAt.UTC().Format("2006-01-02"); got != "2026-06-08" {
+		t.Errorf("PostedAt = %s, want 2026-06-08 (createdAt fallback)", got)
+	}
+}
+
+func TestInhireFetchSkipsFailedDetail(t *testing.T) {
+	// The second post's detail returns invalid JSON -> its detail decode errors and it is
+	// skipped, but the first still comes through.
+	list := `{"jobsPage":[
+		{"jobId":"good","displayName":"Good","workplaceType":"Remote","location":"BR","status":"published"},
+		{"jobId":"broken","displayName":"Broken","workplaceType":"Remote","location":"BR","status":"published"}
+	]}`
+	fake := (&routedHTTP{}).
+		route("/job-posts/public/pages/good",
+			inhireDetailBody("Remote", "BR", "<p>ok</p>", "2026-06-10T10:00:00Z", "")).
+		route("/job-posts/public/pages/broken", `}{ not json`).
+		route("/job-posts/public/pages", list)
+
+	jobs, err := NewInhire(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "inhire", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch should not abort on one failed detail: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "good" {
+		t.Fatalf("want only the good post, got %d jobs", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -121,6 +121,7 @@ func All(c HTTPClient) map[string]Source {
 		NewBambooHR(c),
 		NewWorkday(c),
 		NewHuntflow(c),
+		NewInhire(c),
 		NewGem(c),
 		NewSuccessFactors(c),
 		NewTeamtailor(c),

--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -1,0 +1,8 @@
+# InHire boards. Provider is the filename; each entry is company + board.
+# board = the InHire tenant slug, sent as the X-Tenant header (see internal/sources/inhire.go).
+- company: Conta Azul
+  board: contaazul
+- company: Involves
+  board: involves
+- company: Neoway
+  board: neoway


### PR DESCRIPTION
## Summary

Adds an `inhire` job-source adapter for [InHire](https://inhire.app) (`api.inhire.app`), the ATS behind a number of Brazilian (Florianópolis-rooted) company career sites.

- **Keyless, no headless.** The only requirement is per-request routing via the `X-Tenant: <board>` header; a board id is the tenant slug.
- **N+1 detail fan-out.** The listing call (`GET /job-posts/public/pages`) carries no description, so each post's body and publish date come from its own detail call (`GET /job-posts/public/pages/{jobId}`), fanned out concurrently via the shared `fetchDetails` helper (mirrors huntflow/mts). A failed detail fetch skips just that post.
- **Mapping:** `jobId`→ExternalID; trimmed `displayName`→Title; `location`→Location; `workplaceType` (Remote/Hybrid/On-site) → WorkMode via `workplaceTypeMode` (+ Remote bool); `publishedAt` else `createdAt` (RFC3339) → PostedAt; description is HTML-entity-encoded so it runs through `html.UnescapeString` then `sanitizeHTML`; URL = `https://<board>.inhire.com.br/vagas/<jobId>`.
- Seeds `sources/inhire.yml` with **Conta Azul, Involves, Neoway**.

Files touched: `internal/sources/inhire.go`, `internal/sources/inhire_test.go`, `internal/sources/source.go` (one registration line), `sources/inhire.yml`.

## Test Plan

- `go build ./...` — exit 0
- `go vet ./internal/sources/` — clean
- `gofmt -l` on the new/changed files — no output
- `go test -count=1 ./internal/sources/` — green; new table-driven unit tests cover Provider()=="inhire", listing→detail field mapping (title trim, location, work mode + remote bool, posted date, URL, entity-unescaped+sanitized description), `publishedAt`→`createdAt` fallback, and that one failed detail skips only that job (the rest survive).
- **Live smoke** confirmed the recipe still works: `contaazul` 19 jobs, `involves` 11, `neoway` 5; detail returns entity-encoded `description` + RFC3339 `publishedAt`/`createdAt`.
