### PR TITLE
feat(sources): add Trakstar Hire adapter (trakstar)

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -142,6 +142,7 @@ func All(c HTTPClient) map[string]Source {
 		NewEightfold(c),
 		NewFreshteam(c),
 		NewDeel(c),
+		NewTrakstar(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/internal/sources/trakstar.go
+++ b/internal/sources/trakstar.go
@@ -1,0 +1,85 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"strings"
+	"time"
+)
+
+// trakstar adapts the Trakstar Hire (formerly Recruiterbox) public RSS job feed. Each
+// board is its own tenant subdomain and publishes every open position in one RSS
+// document with the body inline per item — so one GET per board, no pagination and no
+// per-posting detail request. The job: namespace carries structured location and
+// position-type fields alongside the standard RSS item fields.
+type trakstar struct {
+	http XMLGetter
+}
+
+// NewTrakstar builds the Trakstar Hire adapter over the given HTTP client.
+func NewTrakstar(c XMLGetter) Source { return trakstar{http: c} }
+
+func (trakstar) Provider() string { return "trakstar" }
+
+// trakstarFeed is the RSS document a board publishes: a single channel of items.
+type trakstarFeed struct {
+	Items []trakstarItem `xml:"channel>item"`
+}
+
+// trakstarItem is one open position. The job: namespaced elements are bound by their
+// full namespace URI (https://recruiterbox.com/rss/job/) so encoding/xml matches them
+// regardless of the prefix the feed declares.
+type trakstarItem struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	PubDate     string `xml:"pubDate"`
+	Description string `xml:"description"`
+	City        string `xml:"https://recruiterbox.com/rss/job/ locationCity"`
+	State       string `xml:"https://recruiterbox.com/rss/job/ locationState"`
+	Country     string `xml:"https://recruiterbox.com/rss/job/ locationCountry"`
+}
+
+func (t trakstar) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	url := fmt.Sprintf("https://%s.hire.trakstar.com/jobfeeds/%s", e.Board, e.Board)
+
+	var feed trakstarFeed
+	if err := t.http.GetXML(ctx, url, &feed); err != nil {
+		return nil, fmt.Errorf("trakstar: fetch board %s: %w", e.Board, err)
+	}
+
+	jobs := make([]Job, 0, len(feed.Items))
+	for _, it := range feed.Items {
+		jobs = append(jobs, Job{
+			ExternalID:  jobIDFromLink(it.Link),
+			URL:         strings.Replace(it.Link, "http://", "https://", 1),
+			Title:       it.Title,
+			Company:     e.Company,
+			Location:    joinNonEmpty(it.City, it.State, it.Country),
+			Description: sanitizeHTML(html.UnescapeString(it.Description)),
+			Remote:      isRemote(it.City),
+			PostedAt:    parsePubDate(it.PubDate),
+		})
+	}
+	return jobs, nil
+}
+
+// jobIDFromLink extracts the posting id from a Trakstar job URL's last path segment
+// (e.g. http://<board>.hire.trakstar.com/jobs/fk0zjzb → fk0zjzb).
+func jobIDFromLink(link string) string {
+	link = strings.TrimRight(link, "/")
+	if i := strings.LastIndex(link, "/"); i >= 0 {
+		return link[i+1:]
+	}
+	return link
+}
+
+// parsePubDate parses a Trakstar RSS pubDate, which is RFC1123Z (numeric zone offset),
+// falling back to RFC1123 (named zone) for feeds that emit one. Returns nil on an empty
+// or unparseable value (posted_at is nullable).
+func parsePubDate(s string) *time.Time {
+	if t := parseLayout(time.RFC1123Z, s); t != nil {
+		return t
+	}
+	return parseLayout(time.RFC1123, s)
+}

--- a/internal/sources/trakstar_test.go
+++ b/internal/sources/trakstar_test.go
@@ -1,0 +1,109 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestTrakstarProvider(t *testing.T) {
+	if got := NewTrakstar(nil).Provider(); got != "trakstar" {
+		t.Errorf("Provider() = %q, want %q", got, "trakstar")
+	}
+}
+
+func TestTrakstarFetch(t *testing.T) {
+	fake := &fakeHTTP{body: `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:job="https://recruiterbox.com/rss/job/">
+  <channel>
+    <title>Cheesecake Labs Jobs</title>
+    <item>
+      <title>Senior Go Engineer</title>
+      <link>http://cheesecakelabs.hire.trakstar.com/jobs/fk0zjzb</link>
+      <guid>http://cheesecakelabs.hire.trakstar.com/jobs/fk0zjzb</guid>
+      <pubDate>Thu, 18 Jun 2026 00:00:00 +0530</pubDate>
+      <description>&lt;p&gt;Build the &lt;strong&gt;pipeline&lt;/strong&gt;.&lt;/p&gt;</description>
+      <job:locationCity>Florian&#243;polis</job:locationCity>
+      <job:locationState>SC</job:locationState>
+      <job:locationCountry>Brazil</job:locationCountry>
+      <job:positionType>full_time</job:positionType>
+    </item>
+    <item>
+      <title>Remote Platform Engineer</title>
+      <link>http://cheesecakelabs.hire.trakstar.com/jobs/ab1cdef</link>
+      <guid>http://cheesecakelabs.hire.trakstar.com/jobs/ab1cdef</guid>
+      <pubDate>Thu, 18 Jun 2026 00:00:00 +0530</pubDate>
+      <description>&lt;p&gt;Work from anywhere.&lt;/p&gt;</description>
+      <job:locationCity>Remote</job:locationCity>
+      <job:locationCountry>Brazil</job:locationCountry>
+      <job:positionType>full_time</job:positionType>
+    </item>
+  </channel>
+</rss>`}
+
+	jobs, err := NewTrakstar(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Cheesecake Labs", Provider: "trakstar", Board: "cheesecakelabs",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fake.gotURL, "cheesecakelabs.hire.trakstar.com/jobfeeds/cheesecakelabs") {
+		t.Errorf("requested URL %q should target the board jobfeed", fake.gotURL)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "fk0zjzb" {
+		t.Errorf("ExternalID = %q, want the job id parsed from the link", j.ExternalID)
+	}
+	if j.Title != "Senior Go Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Cheesecake Labs" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	// http→https upgrade on the posting URL.
+	if j.URL != "https://cheesecakelabs.hire.trakstar.com/jobs/fk0zjzb" {
+		t.Errorf("URL = %q, want the https posting URL", j.URL)
+	}
+	// Location joins city + state + country, skipping empties.
+	if j.Location != "Florianópolis, SC, Brazil" {
+		t.Errorf("Location = %q, want city/state/country joined", j.Location)
+	}
+	// Description is entity-unescaped then sanitized.
+	if !strings.Contains(j.Description, "Build the") || !strings.Contains(j.Description, "<strong>pipeline</strong>") {
+		t.Errorf("Description = %q, want unescaped + sanitized HTML", j.Description)
+	}
+	if j.Remote {
+		t.Error("Remote = true for a Florianópolis office, want false")
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed pubDate (2026)", j.PostedAt)
+	}
+
+	// Second job: locationCity contains "Remote" → remote, and state is empty so the
+	// location join skips it.
+	r := jobs[1]
+	if !r.Remote {
+		t.Error("second job locationCity=Remote should set Remote = true")
+	}
+	if r.Location != "Remote, Brazil" {
+		t.Errorf("Location = %q, want city + country with empty state skipped", r.Location)
+	}
+}
+
+func TestTrakstarFetchEmptyFeed(t *testing.T) {
+	fake := &fakeHTTP{body: `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel><title>Empty</title></channel></rss>`}
+	jobs, err := NewTrakstar(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Way2", Provider: "trakstar", Board: "way2",
+	})
+	if err != nil {
+		t.Fatalf("Fetch on empty feed should not error: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("len(jobs) = %d, want 0 for an empty feed", len(jobs))
+	}
+}

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1,0 +1,8 @@
+# trakstar (Trakstar Hire / Recruiterbox) boards. Provider is the filename; each
+# entry is company + board. board = the tenant slug (RSS feed is
+# <board>.hire.trakstar.com/jobfeeds/<board>; see internal/sources/trakstar.go).
+
+- company: Cheesecake Labs
+  board: cheesecakelabs
+- company: Way2
+  board: way2


### PR DESCRIPTION
## Summary

Adds a `trakstar` job-source adapter for **Trakstar Hire** (formerly Recruiterbox). Keyless, no headless: one RSS GET per board returns the whole board with descriptions inline — no pagination, no per-posting detail fan-out.

- Board id = tenant slug; feed is `https://<board>.hire.trakstar.com/jobfeeds/<board>` (RSS XML).
- Per-item mapping: `ExternalID` parsed from the `<link>` last path segment (e.g. `fk0zjzb`); URL upgraded `http`→`https`; `Title` from `<title>`; `Location` joins the `job:locationCity/State/Country` namespaced fields (skipping empties); `Remote` inferred from the city text; `Description` is `html.UnescapeString` then `sanitizeHTML`; `PostedAt` parsed from `<pubDate>` (RFC1123Z, falling back to RFC1123).
- `job:` elements bound by full namespace URI (`https://recruiterbox.com/rss/job/`) so `encoding/xml` matches regardless of the feed's declared prefix.
- An empty board returns a valid channel with zero items → zero jobs, no error.

Registered in `sources.All`; ships `sources/trakstar.yml` seeded with the Florianópolis (Brazil) companies **Cheesecake Labs** and **Way2**.

Files touched: `internal/sources/trakstar.go`, `internal/sources/trakstar_test.go`, `internal/sources/source.go`, `sources/trakstar.yml`.

## Test Plan

- `go build ./...`, `go vet ./internal/sources/`, `gofmt -l` (clean), `go test -count=1 ./internal/sources/` — all green.
- Unit tests (`trakstar_test.go`, written first, TDD): `Provider()=="trakstar"`; field mapping (id from link, https URL, RFC1123Z pubDate, city/state/country join, remote detection, entity-unescaped + sanitized description); empty feed yields zero jobs and no error.
- Live smoke (throwaway, not committed) against the real **Cheesecake Labs** feed: 3 jobs parsed, correct id/https-URL/remote/posted-date, 7.8 KB sanitized description. **Way2** currently returns an empty board (0 items) — exercises the empty-feed path live.