### PR TITLE
feat(sources): add Senior Portal de Talentos adapter (senior)

### DIFF
--- a/internal/sources/senior.go
+++ b/internal/sources/senior.go
@@ -1,0 +1,169 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// senior adapts Senior's "Portal de Talentos" recruiting platform (the careersmanager
+// candidate bridge API on platform.senior.com.br). The board id is the tenant subdomain
+// (e.g. "intelbras"). The API is keyless and POST-only in three steps: resolve the tenant
+// subdomain to a profile id, page the vacancy search filtered by that profile, then fetch
+// each vacancy's detail for its description (the search listing carries no description).
+const (
+	seniorBase     = "https://platform.senior.com.br/t/senior.com.br/bridge/1.0/anonymous/rest/hcm/careersmanagercandidate"
+	seniorPageSize = 50
+)
+
+// seniorHTTPClient is the transport senior needs: the whole flow is POST-only JSON.
+type seniorHTTPClient interface {
+	JSONPoster
+}
+
+type senior struct {
+	http seniorHTTPClient
+}
+
+// NewSenior builds the Senior Portal de Talentos adapter over the given HTTP client.
+func NewSenior(c seniorHTTPClient) Source { return senior{http: c} }
+
+func (senior) Provider() string { return "senior" }
+
+// seniorContent is one item from the vacancy search listing (no description here).
+type seniorContent struct {
+	Vacancy struct {
+		ID           string `json:"id"`
+		Title        string `json:"title"`
+		Localization struct {
+			City     string `json:"city"`
+			Province string `json:"province"`
+			Country  string `json:"country"`
+		} `json:"localization"`
+		JobModel    []string `json:"jobModel"`
+		Publication struct {
+			StartDate string `json:"startDate"`
+		} `json:"publication"`
+	} `json:"vacancy"`
+}
+
+func (s senior) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	profileID, err := s.resolveProfileID(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+
+	contents, err := s.searchVacancies(ctx, profileID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Each vacancy's description comes from its own detail request, fanned out under a
+	// bounded worker pool; a failed detail skips just that vacancy.
+	return fetchDetails(contents, defaultDetailWorkers, func(c seniorContent) (Job, bool) {
+		return s.detail(ctx, e, c)
+	}), nil
+}
+
+// resolveProfileID maps the tenant subdomain to its profile id; a non-tenant subdomain
+// fails (a bad board, not an empty one), aborting the board.
+func (s senior) resolveProfileID(ctx context.Context, board string) (string, error) {
+	url := seniorBase + "/actions/getProfileIdBySubdomain"
+	var res struct {
+		ProfileID string `json:"profileId"`
+	}
+	if err := s.http.PostJSON(ctx, url, map[string]any{"subdomain": board}, &res); err != nil {
+		return "", fmt.Errorf("senior: resolve subdomain %q: %w", board, err)
+	}
+	if res.ProfileID == "" {
+		return "", fmt.Errorf("senior: subdomain %q has no profile id", board)
+	}
+	return res.ProfileID, nil
+}
+
+// searchVacancies pages through the profile's vacancies via the POST-only search endpoint,
+// stopping once every reported page has been collected (page is 0-based).
+func (s senior) searchVacancies(ctx context.Context, profileID string) ([]seniorContent, error) {
+	url := seniorBase + "/queries/searchVacancies"
+	var contents []seniorContent
+	for page := 0; ; page++ {
+		reqBody := map[string]any{
+			"page":   page,
+			"size":   seniorPageSize,
+			"filter": "",
+			"match": map[string]any{
+				"companies":     []map[string]any{{"id": profileID}},
+				"localizations": []any{},
+			},
+		}
+		var res struct {
+			TotalPages int             `json:"totalPages"`
+			Contents   []seniorContent `json:"contents"`
+		}
+		if err := s.http.PostJSON(ctx, url, reqBody, &res); err != nil {
+			return nil, fmt.Errorf("senior: search profile %s: %w", profileID, err)
+		}
+		contents = append(contents, res.Contents...)
+		if page+1 >= res.TotalPages {
+			break
+		}
+	}
+	return contents, nil
+}
+
+// detail fetches one vacancy's detail and maps it to a Job, returning ok=false when the
+// detail request fails so the caller can skip just that vacancy.
+func (s senior) detail(ctx context.Context, e CompanyEntry, c seniorContent) (Job, bool) {
+	url := seniorBase + "/queries/findVacancyById"
+	var d struct {
+		Vacancy struct {
+			About struct {
+				Description string `json:"description"`
+			} `json:"about"`
+		} `json:"vacancy"`
+	}
+	if err := s.http.PostJSON(ctx, url, map[string]any{"id": c.Vacancy.ID}, &d); err != nil {
+		return Job{}, false
+	}
+
+	loc := c.Vacancy.Localization
+	location := joinNonEmpty(loc.City, loc.Province, loc.Country)
+	remote := seniorHasModel(c.Vacancy.JobModel, "REMOTE")
+
+	return Job{
+		ExternalID:  c.Vacancy.ID,
+		URL:         fmt.Sprintf("https://%s.portaldetalentos.senior.com.br/vacancy/%s", e.Board, c.Vacancy.ID),
+		Title:       c.Vacancy.Title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(d.Vacancy.About.Description),
+		Remote:      remote,
+		PostedAt:    parseDate(c.Vacancy.Publication.StartDate),
+		WorkMode:    seniorWorkMode(c.Vacancy.JobModel),
+	}, true
+}
+
+// seniorWorkMode maps Senior's jobModel enum to our work-mode vocabulary, preferring the
+// most-remote signal when a vacancy lists several models; an empty or unknown set yields "".
+func seniorWorkMode(models []string) string {
+	switch {
+	case seniorHasModel(models, "REMOTE"):
+		return "remote"
+	case seniorHasModel(models, "HYBRID"):
+		return "hybrid"
+	case seniorHasModel(models, "IN_PERSON"):
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// seniorHasModel reports whether models contains the given jobModel enum (case-insensitive).
+func seniorHasModel(models []string, want string) bool {
+	for _, m := range models {
+		if strings.EqualFold(strings.TrimSpace(m), want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sources/senior_test.go
+++ b/internal/sources/senior_test.go
@@ -1,0 +1,205 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSeniorProvider(t *testing.T) {
+	if got := NewSenior(nil).Provider(); got != "senior" {
+		t.Errorf("Provider() = %q, want %q", got, "senior")
+	}
+}
+
+// seniorHTTP is a body-aware test JSONPoster for the Senior bridge API: the resolve,
+// search, and detail endpoints share one host and differ by path, and the paged search
+// carries its page number in the POST body (not the URL). It routes on the path suffix
+// and, for the search endpoint, on the requested page parsed from the body.
+type seniorHTTP struct {
+	profileID   string // resolve response; empty -> resolve fails (non-tenant)
+	pages       map[int]string
+	details     map[string]string // vacancy id -> findVacancyById response
+	failDetails map[string]bool   // vacancy id -> detail request errors
+}
+
+func (f *seniorHTTP) PostJSON(_ context.Context, url string, body, v any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	switch {
+	case strings.Contains(url, "getProfileIdBySubdomain"):
+		if f.profileID == "" {
+			return errors.New("seniorHTTP: subdomain not found")
+		}
+		return json.Unmarshal([]byte(`{"profileId":"`+f.profileID+`"}`), v)
+	case strings.Contains(url, "searchVacancies"):
+		var req struct {
+			Page int `json:"page"`
+		}
+		if err := json.Unmarshal(raw, &req); err != nil {
+			return err
+		}
+		page, ok := f.pages[req.Page]
+		if !ok {
+			page = `{"totalPages":0,"totalElements":0,"contents":[]}`
+		}
+		return json.Unmarshal([]byte(page), v)
+	case strings.Contains(url, "findVacancyById"):
+		var req struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal(raw, &req); err != nil {
+			return err
+		}
+		if f.failDetails[req.ID] {
+			return errors.New("seniorHTTP: detail boom")
+		}
+		d, ok := f.details[req.ID]
+		if !ok {
+			return errors.New("seniorHTTP: no detail for " + req.ID)
+		}
+		return json.Unmarshal([]byte(d), v)
+	}
+	return errors.New("seniorHTTP: no route for " + url)
+}
+
+func TestSeniorFetchResolvesSearchesAndMaps(t *testing.T) {
+	fake := &seniorHTTP{
+		profileID: "GUID-1",
+		pages: map[int]string{
+			0: `{"totalPages":2,"totalElements":3,"contents":[
+				{"vacancy":{
+					"id":"v1","title":"Backend Engineer",
+					"localization":{"city":"Florianópolis","province":"SC","country":"Brasil"},
+					"jobModel":["IN_PERSON"],
+					"publication":{"startDate":"2026-06-10"}
+				},"company":{"tenant":"intelbras","name":"Intelbras"}},
+				{"vacancy":{
+					"id":"v2","title":"Remote Data Engineer",
+					"localization":{"city":"","province":"","country":"Brasil"},
+					"jobModel":["REMOTE"],
+					"publication":{"startDate":"2026-06-11"}
+				},"company":{"tenant":"intelbras","name":"Intelbras"}}
+			]}`,
+			1: `{"totalPages":2,"totalElements":3,"contents":[
+				{"vacancy":{
+					"id":"v3","title":"Hybrid Product Manager",
+					"localization":{"city":"São Paulo","province":"SP","country":"Brasil"},
+					"jobModel":["HYBRID"],
+					"publication":{"startDate":"2026-06-12"}
+				},"company":{"tenant":"intelbras","name":"Intelbras"}}
+			]}`,
+		},
+		details: map[string]string{
+			"v1": `{"vacancy":{"about":{"description":"<p>Build the backend.</p><script>alert(1)</script>"}}}`,
+			"v2": `{"vacancy":{"about":{"description":"<p>Crunch data remotely.</p>"}}}`,
+			"v3": `{"vacancy":{"about":{"description":"<p>Own the roadmap.</p>"}}}`,
+		},
+	}
+
+	jobs, err := NewSenior(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Intelbras", Provider: "senior", Board: "intelbras",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 (both pages)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	v1, ok := byID["v1"]
+	if !ok {
+		t.Fatal("vacancy v1 missing")
+	}
+	if v1.Title != "Backend Engineer" {
+		t.Errorf("Title = %q", v1.Title)
+	}
+	if v1.Company != "Intelbras" {
+		t.Errorf("Company = %q", v1.Company)
+	}
+	if v1.Location != "Florianópolis, SC, Brasil" {
+		t.Errorf("Location = %q, want joined city/province/country", v1.Location)
+	}
+	if v1.WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want onsite from IN_PERSON", v1.WorkMode)
+	}
+	if v1.Remote {
+		t.Error("Remote = true, want false for IN_PERSON")
+	}
+	if v1.URL != "https://intelbras.portaldetalentos.senior.com.br/vacancy/v1" {
+		t.Errorf("URL = %q", v1.URL)
+	}
+	if v1.PostedAt == nil || v1.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed startDate (2026)", v1.PostedAt)
+	}
+	if !strings.Contains(v1.Description, "Build the backend.") {
+		t.Errorf("Description = %q, want sanitized about.description", v1.Description)
+	}
+	if strings.Contains(v1.Description, "<script>") {
+		t.Errorf("Description = %q, want script stripped", v1.Description)
+	}
+
+	v2 := byID["v2"]
+	if v2.Location != "Brasil" {
+		t.Errorf("v2 Location = %q, want empty city/province skipped", v2.Location)
+	}
+	if v2.WorkMode != "remote" {
+		t.Errorf("v2 WorkMode = %q, want remote", v2.WorkMode)
+	}
+	if !v2.Remote {
+		t.Error("v2 Remote = false, want true from REMOTE jobModel")
+	}
+
+	v3 := byID["v3"]
+	if v3.WorkMode != "hybrid" {
+		t.Errorf("v3 WorkMode = %q, want hybrid", v3.WorkMode)
+	}
+	if v3.Remote {
+		t.Error("v3 Remote = true, want false for HYBRID")
+	}
+}
+
+func TestSeniorFetchSkipsFailedDetail(t *testing.T) {
+	// v2's detail errors -> it is skipped, v1 still comes through.
+	fake := &seniorHTTP{
+		profileID: "GUID-1",
+		pages: map[int]string{
+			0: `{"totalPages":1,"totalElements":2,"contents":[
+				{"vacancy":{"id":"v1","title":"Engineer","localization":{"city":"Blumenau","province":"SC","country":"Brasil"},"jobModel":["IN_PERSON"],"publication":{"startDate":"2026-06-10"}},"company":{"tenant":"intelbras","name":"Intelbras"}},
+				{"vacancy":{"id":"v2","title":"Broken","localization":{"city":"NYC"},"jobModel":[],"publication":{"startDate":""}},"company":{"tenant":"intelbras","name":"Intelbras"}}
+			]}`,
+		},
+		details:     map[string]string{"v1": `{"vacancy":{"about":{"description":"<p>ok</p>"}}}`},
+		failDetails: map[string]bool{"v2": true},
+	}
+
+	jobs, err := NewSenior(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Intelbras", Provider: "senior", Board: "intelbras",
+	})
+	if err != nil {
+		t.Fatalf("Fetch should not abort the board on one failed detail: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "v1" {
+		t.Fatalf("want only v1 to survive, got %d jobs", len(jobs))
+	}
+}
+
+func TestSeniorFetchFailsWhenSubdomainUnresolved(t *testing.T) {
+	// A non-tenant subdomain fails resolve -> Fetch returns an error (the board is bad,
+	// not an empty board).
+	fake := &seniorHTTP{}
+	if _, err := NewSenior(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Nope", Provider: "senior", Board: "not-a-tenant",
+	}); err == nil {
+		t.Fatal("Fetch = nil error, want error when resolve fails")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -142,6 +142,7 @@ func All(c HTTPClient) map[string]Source {
 		NewEightfold(c),
 		NewFreshteam(c),
 		NewDeel(c),
+		NewSenior(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/sources/senior.yml
+++ b/sources/senior.yml
@@ -1,0 +1,5 @@
+# Senior "Portal de Talentos" boards. Board = the tenant subdomain.
+- company: Intelbras
+  board: intelbras
+- company: Senior Sistemas
+  board: vemprasenior


### PR DESCRIPTION
## Summary

Adds a `senior` job-source adapter for Senior's **"Portal de Talentos"** recruiting platform (the keyless `careersmanagercandidate` bridge API on `platform.senior.com.br`). Brings in Florianópolis/SC-rooted Brazilian companies — **Intelbras** and **Senior Sistemas** — as the first two boards.

The board id is the tenant **subdomain** (e.g. `intelbras`, `vemprasenior`). The API is keyless and POST-only in three steps, mirroring the Workday adapter's resolve + paged-listing + per-job-detail-fan-out shape:

1. **Resolve** the subdomain to a profile id (`actions/getProfileIdBySubdomain`); a non-tenant subdomain fails the board.
2. **Search** the profile's vacancies, paged 0-based with the page in the POST body (`queries/searchVacancies`), looping until every reported page is collected.
3. **Detail** per vacancy for the description (`queries/findVacancyById`, keyed `"id"`), fanned out under the shared bounded worker pool; a failed detail skips just that vacancy.

Mapping: `ExternalID`=vacancy id; `Location`=joined city/province/country (blanks skipped); `WorkMode` from `jobModel` (IN_PERSON→onsite, REMOTE→remote, HYBRID→hybrid, else ""); `Remote` true when jobModel contains REMOTE; `PostedAt` from `publication.startDate` ("2006-01-02"); `URL`=`https://<board>.portaldetalentos.senior.com.br/vacancy/<id>`; `Description`=sanitized `about.description`.

Files: `internal/sources/senior.go`, `internal/sources/senior_test.go`, one line in `internal/sources/source.go` (`reg`), and `sources/senior.yml`.

## Test Plan

- `go build ./...`, `go vet ./internal/sources/`, `gofmt -l` (clean) — all pass.
- `go test -count=1 ./internal/sources/` — green. New `senior_test.go` covers: `Provider()=="senior"`; full resolve→search→detail flow with field mapping (location join with empty fields skipped, work-mode/remote per IN_PERSON/REMOTE/HYBRID, posted-date parse, vacancy URL, sanitized description with `<script>` stripped); **multi-page** search (page in body); a failed detail skips only that vacancy; and resolve-failure aborting the board.
- **Live smoke** (prod API, keyless POST bridge): resolved `intelbras` → profileId, searched → `totalElements:47` over paged results, fetched a vacancy detail → 6.6 KB HTML `about.description`. Covers the Florianópolis/SC companies Intelbras and Senior Sistemas.
