### PR TITLE
feat(sources): harvest +1864 Brazilian boards (inhire/solides/senior/trakstar)

### DIFF
--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -6,3 +6,699 @@
   board: involves
 - company: Neoway
   board: neoway
+
+# --- harvested via Wayback CDX + live API validation 2026-06-21 ---
+- company: "V4 Company"
+  board: v4company
+- company: "Vitru Educação"
+  board: vitru
+- company: "Grupo Comolatti"
+  board: grupocomolatti
+- company: "Priner"
+  board: priner
+- company: "Essencial Nutrição"
+  board: essencialnutricao
+- company: "Grupo Lider"
+  board: grupolider
+- company: "Saúde do TEA"
+  board: tela
+- company: "Deloitte"
+  board: deloitte
+- company: "Grupo Protege "
+  board: grupoprotege
+- company: "KPMG"
+  board: kpmg
+- company: "mazzatech"
+  board: mazzatech
+- company: "Pantheon"
+  board: pantheon
+- company: "Infotec Brasil"
+  board: infotecbrasil
+- company: "BRQ"
+  board: brq
+- company: "ICON Solutions do Brasil"
+  board: iconit
+- company: "Intertechne"
+  board: intertechne
+- company: "Grupo Taking"
+  board: grupotaking
+- company: "AGROSearch"
+  board: agrosearch
+- company: "Radix"
+  board: radix
+- company: "Gogroup"
+  board: gogroup
+- company: "Grupo LOS"
+  board: grupolos
+- company: "Contabilizei"
+  board: contabilizei
+- company: "Orbia Amanco Wavin"
+  board: wavin
+- company: "Mottu"
+  board: mottu
+- company: "Share People Hub"
+  board: sharepeoplehub
+- company: "Lyncas"
+  board: lyncas
+- company: "Viseu Secondment"
+  board: viseu
+- company: "MJV INNOVATION"
+  board: mjv
+- company: "vocedm"
+  board: vocedm
+- company: "DUX Company"
+  board: duxcompany
+- company: "Pedra Agroindustrial"
+  board: pedraagroindustrial
+- company: "ASA"
+  board: asa
+- company: "GEX"
+  board: gex
+- company: "Zerezes"
+  board: zerezes
+- company: "Insider Store"
+  board: insiderstore
+- company: "Grupo UNINTER"
+  board: uninter
+- company: "IPNET by Vivo"
+  board: ipnet
+- company: "Nomad"
+  board: nomadglobal
+- company: "DB1 Group"
+  board: db1
+- company: "EQI"
+  board: eqi
+- company: "SRM"
+  board: gruposrm
+- company: "Westwing Brasil"
+  board: westwing
+- company: "QI Tech"
+  board: qitech
+- company: "Clam"
+  board: clam
+- company: "Premiersoft"
+  board: premiersoft
+- company: "Qeevo"
+  board: queroeducacao
+- company: "Pravaler"
+  board: pravaler
+- company: "Framework"
+  board: frameworkdigital
+- company: "iHunters"
+  board: ihunters
+- company: "Magna Executive Search"
+  board: magnasearch
+- company: "Sanar"
+  board: sanar
+- company: "Sympla"
+  board: sympla
+- company: "Venturus"
+  board: venturus
+- company: "Oliveira & Antunes Advogados Associados"
+  board: oliveiraeantunes
+- company: "Paytrack"
+  board: paytrack
+- company: "frete.com"
+  board: frete
+- company: "Appmax"
+  board: appmax
+- company: "Magazine Luiza"
+  board: magazineluiza
+- company: "Movecta"
+  board: movecta
+- company: "Ável "
+  board: avel
+- company: "Brivia"
+  board: brivia
+- company: "Melnick"
+  board: melnick
+- company: "Poliedro Educação"
+  board: poliedroeducacao
+- company: "Seu Estágio"
+  board: seuestagio
+- company: "TalentX Digital"
+  board: talentx
+- company: "Cielo"
+  board: cielo
+- company: "FiberHome Brasil"
+  board: fiberhome
+- company: "Nuvemshop"
+  board: nuvemshop-tiendanube
+- company: "tecer"
+  board: tecer
+- company: "Asper"
+  board: asper
+- company: "Ligga"
+  board: liggatelecom
+- company: "Zig"
+  board: zig
+- company: "Betha"
+  board: betha
+- company: "FIAP/Alura/PM3"
+  board: alun
+- company: "AMcom"
+  board: amcom
+- company: "Reclame AQUI"
+  board: reclameaqui
+- company: "Guaracamp"
+  board: guaracamp
+- company: "Schulze"
+  board: schulze
+- company: "Trinnus RH"
+  board: trinnus
+- company: "Vórtx"
+  board: vortx
+- company: "CashMe"
+  board: cashme
+- company: "Deal Group"
+  board: deal
+- company: "Fitting"
+  board: fitting
+- company: "IDG"
+  board: idg
+- company: "LiveMode"
+  board: livemode
+- company: "RH Lótus Solution"
+  board: lotussolution
+- company: "Auvo Tecnologia"
+  board: auvotecnologia
+- company: "CredAluga"
+  board: credaluga
+- company: "DBServices"
+  board: dbservices
+- company: "Kstack"
+  board: kstack
+- company: "Orizon "
+  board: orizon
+- company: "CTC"
+  board: ctctech
+- company: "Resid Club"
+  board: residclub
+- company: "Zallpy Digital"
+  board: zallpy
+- company: "ASCAS"
+  board: ascasconsultoria
+- company: "Carbigdata"
+  board: carbigdata
+- company: "Cescon Barrieu"
+  board: cesconbarrieu
+- company: "e-Core"
+  board: ecore
+- company: "Grupo AG Capital"
+  board: grupoagcapital
+- company: "Magazord"
+  board: magazord
+- company: "Skyone"
+  board: skyone
+- company: "Superlógica Tecnologias"
+  board: superlogica
+- company: "Sylvamo"
+  board: sylvamo
+- company: "TQI"
+  board: tqi
+- company: "Turbi"
+  board: turbi
+- company: "Wilson Sons Offshore"
+  board: wsut
+- company: "Alice"
+  board: alice
+- company: " Grupo Central"
+  board: grupocentral
+- company: "GCB"
+  board: grupogcb
+- company: "Indicium"
+  board: indicium
+- company: "Luby"
+  board: luby
+- company: "Solfácil"
+  board: solfacil
+- company: "Solutis"
+  board: solutis
+- company: "Zappts"
+  board: zappts
+- company: "Aarin Techfin"
+  board: aarin
+- company: "FIAP"
+  board: alura-fiap-pm3
+- company: "Cayena "
+  board: cayena
+- company: "Eclipseworks"
+  board: eclipseworks
+- company: "IVENTIS"
+  board: iventis
+- company: "Octafy"
+  board: octafy
+- company: "Alelo"
+  board: alelo
+- company: "BIX Tecnologia - Consultoria de Dados"
+  board: bixtecnologia
+- company: "Bridge & Co."
+  board: bridge
+- company: "CERC"
+  board: cerc
+- company: "Construtora Elevação"
+  board: construtoraelevacao
+- company: "CrediPronto"
+  board: credipronto
+- company: "Cubos Tecnologia"
+  board: cubos
+- company: "EVEO"
+  board: eveo
+- company: "Extreme Digital Solutions"
+  board: extremegroup
+- company: "Objective"
+  board: objective
+- company: "Turbo"
+  board: turbo
+- company: "Yolo Recruit"
+  board: yolo
+- company: "DOT Group"
+  board: dotgroup
+- company: "FIT Energia"
+  board: fitenergia
+- company: "Flutter Brazil"
+  board: flutterbrazil
+- company: "Infleet"
+  board: infleet
+- company: "Listo"
+  board: listo
+- company: "Yandeh"
+  board: yandeh
+- company: "Grupo Autoglass"
+  board: autoglass
+- company: "idwall"
+  board: idwall
+- company: "InstaCarro"
+  board: instacarro
+- company: "Leader & Talent"
+  board: leaderetalent
+- company: "MK Solutions"
+  board: mksolutions
+- company: "Olist"
+  board: olist
+- company: "Rentcars"
+  board: rentcars
+- company: "Tecsul"
+  board: tecsul
+- company: "WINDCRAFT"
+  board: windcraft
+- company: "Avenue"
+  board: avenue
+- company: "Azos"
+  board: azos
+- company: "Elements"
+  board: elements
+- company: "Final Level "
+  board: finallevel
+- company: "FSB Holding"
+  board: fsbholding
+- company: "Harpia"
+  board: harpia
+- company: "Lemon Energia"
+  board: lemonenergia
+- company: "Matera"
+  board: matera
+- company: "Medway"
+  board: medway
+- company: "Miner Tecnologia"
+  board: minertecnologia
+- company: "Pitang"
+  board: pitang
+- company: "Praso"
+  board: praso
+- company: "Banco Toyota do Brasil"
+  board: bancotoyota
+- company: "dti digital"
+  board: dtidigital
+- company: "GoFlow Consultoria"
+  board: goflow
+- company: "Think IT"
+  board: grupothink
+- company: "Heads"
+  board: heads
+- company: "Mercado Bitcoin"
+  board: mb
+- company: "M7 Soluções Financeiras"
+  board: multi7
+- company: "Procfit"
+  board: procfit
+- company: "Stoque"
+  board: stoque
+- company: "Warren"
+  board: warren
+- company: "Wevy"
+  board: wevy-cloud
+- company: "aTip"
+  board: atip
+- company: "Brasil Paralelo"
+  board: brasilparalelo
+- company: "Cidadania Já"
+  board: cidadaniaja
+- company: "coaktion"
+  board: coaktion
+- company: "DQR Tech"
+  board: dqrtech
+- company: "EXA"
+  board: exa
+- company: "Global System"
+  board: globalsystem
+- company: "Grupo GCB"
+  board: grupogcbinvestimentos
+- company: "MATH"
+  board: mathgroup
+- company: "Media Hero"
+  board: mediahero
+- company: "Petit.RH"
+  board: petitrh
+- company: "Pipo Saúde"
+  board: piposaude
+- company: "Qive"
+  board: qive
+- company: "RankMyApp"
+  board: rankmyapp
+- company: "Sancor Seguros"
+  board: sancorsegurosbrasil
+- company: "Seazone"
+  board: seazone
+- company: "Segura®"
+  board: segura
+- company: "Telavita"
+  board: telavita
+- company: "Vatto"
+  board: vatto
+- company: "Bankme."
+  board: bankme
+- company: "Dartz Ideal Recruitment"
+  board: dartz
+- company: "Digix"
+  board: digix
+- company: "EDGE"
+  board: edge
+- company: "Essence"
+  board: essenceit
+- company: "J.Assy"
+  board: jassy
+- company: "Luzandreya Consultoria e Assessoria de RH"
+  board: luzandreyaconsultoria
+- company: "Platform Builders"
+  board: platformbuilders
+- company: "Programmers - AI, Data & Software"
+  board: programmers
+- company: "QuickSoft"
+  board: quicksoft
+- company: "TownSq"
+  board: townsq
+- company: "TPGROUP"
+  board: tpgroup
+- company: "Ubots"
+  board: ubots
+- company: "V360"
+  board: v360
+- company: "Vertigo Tecnologia"
+  board: vertigo
+- company: "Grupo 3C"
+  board: 3cplusnow
+- company: "Atlântico"
+  board: atlantico
+- company: "CAF"
+  board: caf
+- company: "Celcoin"
+  board: celcoin
+- company: "CAF"
+  board: certta
+- company: "Construtora Patriani"
+  board: construtorapatriani
+- company: "Cora"
+  board: cora
+- company: "EloGroup"
+  board: elogroup
+- company: "Farmtech"
+  board: farmtech
+- company: "Fretadão"
+  board: fretadao
+- company: "Vem ser GX2"
+  board: gx2
+- company: "Intera"
+  board: intera
+- company: "IORQ"
+  board: iorq
+- company: "Jeitto"
+  board: jeitto
+- company: "MOTIM"
+  board: motim
+- company: "NTS Brasil"
+  board: nts
+- company: "Querodelivery"
+  board: querodelivery
+- company: "RIOgaleão"
+  board: riogaleao
+- company: "Sotran"
+  board: sotran
+- company: "Tempest"
+  board: tempest
+- company: "Tinnova"
+  board: tinnova
+- company: "Tripla"
+  board: tripla
+- company: "Ume"
+  board: ume
+- company: "AltoQi"
+  board: altoqi
+- company: "Atlas"
+  board: atlastechnol
+- company: "Barros & Advogados"
+  board: barrosadvogados
+- company: "BR Media Group"
+  board: brmediagroup
+- company: "InHire"
+  board: carreiras
+- company: "ecx"
+  board: ecx
+- company: "erural"
+  board: erural
+- company: "Exati"
+  board: exati
+- company: "Fleming Educação"
+  board: flemingeducacao
+- company: "iSystems"
+  board: isystems
+- company: "Kanastra"
+  board: kanastra
+- company: "Labi Saúde"
+  board: labisaude
+- company: "Pier Seguradora"
+  board: pier
+- company: "Qeevo"
+  board: qeevo
+- company: "VerticalRH"
+  board: verticalrh
+- company: "wehandle"
+  board: wehandle
+- company: "A.Dias"
+  board: adias
+- company: "Aiko"
+  board: aiko
+- company: "Autopass"
+  board: autopass
+- company: "Grupo Ciranda Cultural"
+  board: cirandacultural
+- company: "Emerge Ventures"
+  board: emergeventures
+- company: "EstrelaBet"
+  board: estrelabet
+- company: "GEO3D ENGENHARIA DE MAPEAMENTO"
+  board: geo3d
+- company: "Jaé"
+  board: jae
+- company: "Kobe Apps"
+  board: kobe
+- company: "Lima Consulting Group"
+  board: limaconsulting
+- company: "Paipe "
+  board: paipe
+- company: "Prizma Mídia"
+  board: prizmamidia
+- company: "Shape Digital"
+  board: shapedigital
+- company: "Silicon"
+  board: silicon
+- company: "Instituto Alana"
+  board: alana
+- company: "Automind"
+  board: automind
+- company: "Avivatec"
+  board: avivatec
+- company: "BetMGM Brasil"
+  board: betmgm
+- company: "Cinga Tech"
+  board: cinga
+- company: "Estapar"
+  board: estapar-trial
+- company: "FacilitaPay"
+  board: facilitapay
+- company: "Genyo"
+  board: genyo
+- company: "Grupo Food Nation"
+  board: grupofoodnation
+- company: "Imaflora"
+  board: imaflora
+- company: "JOTA"
+  board: jota
+- company: "Kife"
+  board: kife
+- company: "klavi"
+  board: klavi
+- company: "Ocean Drop"
+  board: oceandrop
+- company: "Quero Passagem"
+  board: queropassagem
+- company: "Remessa Online"
+  board: remessaonline
+- company: "Rentbrella"
+  board: rentbrella
+- company: "Samsung"
+  board: samsung
+- company: "Sunne"
+  board: sunne
+- company: "Tera"
+  board: tera
+- company: "Unimar"
+  board: unimar
+- company: "UpFlux"
+  board: upflux
+- company: "Vixtra"
+  board: vixtra
+- company: "Votorantim"
+  board: votorantim
+- company: "180 Seguros"
+  board: 180seguros
+- company: "Alloyal"
+  board: alloyal
+- company: "Aprix"
+  board: aprix
+- company: "Banni"
+  board: banni
+- company: "benup"
+  board: benup
+- company: "Cobli"
+  board: cobli
+- company: "dtLabs"
+  board: dtlabs
+- company: "Escola DNC"
+  board: escoladnc
+- company: "Eyxo Content Co."
+  board: eyxo
+- company: "FindUP"
+  board: findup
+- company: "fluke"
+  board: fluke
+- company: "Grupo Eximio"
+  board: grupoeximio
+- company: "Uello"
+  board: hh-uello
+- company: "iNNOVEA HUB"
+  board: innoveahub
+- company: "Kamino"
+  board: kamino
+- company: "Laboclin"
+  board: laboclin
+- company: "Lumine"
+  board: lumine
+- company: "match.mt"
+  board: match-mt
+- company: "Midhaus"
+  board: midhaus
+- company: "VEM PRA TURMA"
+  board: mspestudios
+- company: "Nuvidio"
+  board: nuvidio
+- company: "Raro Labs"
+  board: rarolabs
+- company: "Rhitmo Tech"
+  board: rhitmotech
+- company: "Same Engenharia"
+  board: same-engenharia
+- company: "Softvaro"
+  board: softvaro
+- company: "SuperFrete"
+  board: superfrete
+- company: "Trampay"
+  board: trampay
+- company: "UPDA"
+  board: upda
+- company: "Vinta"
+  board: vinta
+- company: "Vockan"
+  board: vockan
+- company: "Autom"
+  board: autom
+- company: "Bipa"
+  board: bipa
+- company: "Eiti Gestão de Ti"
+  board: eiti
+- company: "Fintalk"
+  board: fintalk
+- company: "floraconsultoria"
+  board: floraconsultoria
+- company: "Grupo Boticário"
+  board: grupoboticario
+- company: "Grupo Permaneo"
+  board: grupopermaneo
+- company: "ImpulsoGov"
+  board: impulsogov
+- company: "Lastlink"
+  board: lastlink
+- company: "Líber"
+  board: liber
+- company: "Lightfarm"
+  board: lightfarmstudios
+- company: "Mirum"
+  board: mirum
+- company: "Nexaas"
+  board: nexaas
+- company: "Nibo"
+  board: nibo
+- company: "Transfero"
+  board: transfero
+- company: "Via"
+  board: via
+- company: "Wellz by Wellhub"
+  board: wellz
+- company: "Allintra"
+  board: allintra
+- company: "Big Data"
+  board: bigdata
+- company: "Brange Media"
+  board: brangemedia
+- company: "Breezy Seguros"
+  board: breezyseguros
+- company: "Trinuscool"
+  board: centraldevagas
+- company: "Crown"
+  board: crown
+- company: "Ocean Health"
+  board: dhg
+- company: "Foxbit"
+  board: foxbit
+- company: "Escola Conquer"
+  board: hh-escolaconquer
+- company: "Lello Condomínios"
+  board: hh-lello
+- company: "Kiwify"
+  board: kiwify
+- company: "CTA Smart"
+  board: link2pump
+- company: "Monkey"
+  board: monkey
+- company: "sim.digital"
+  board: simdigital
+- company: "Strm Music"
+  board: strm-music
+- company: "TC"
+  board: tc
+- company: "Ticket360"
+  board: ticket360
+- company: "Toro Investimentos"
+  board: toroinvestimentos
+- company: "Voltta"
+  board: volttaenergy

--- a/sources/senior.yml
+++ b/sources/senior.yml
@@ -3,3 +3,165 @@
   board: intelbras
 - company: Senior Sistemas
   board: vemprasenior
+
+# --- harvested via Wayback CDX + live API validation 2026-06-21 ---
+- company: "Atrio Hoteis SA"
+  board: atriohoteis
+- company: "CONDOR - CENTRAL"
+  board: grupozonta
+- company: "Marista Brasil"
+  board: maristabrasil
+- company: "Grupo Lins Ferrão"
+  board: grupolinsferrao
+- company: "FOCSI"
+  board: focsi
+- company: "G4F"
+  board: g4f
+- company: "Rede Cooper"
+  board: cooper
+- company: "Grupo Zema"
+  board: zema
+- company: "GRUPO SINOVA"
+  board: gruposinova
+- company: "CMAA - CIA MINEIRA DE AÇÚCAR E ÁLCOOL"
+  board: cmaa
+- company: "USINA CORURIPE (PRD)"
+  board: usinacoruripe
+- company: "REDE MAIS BARATO"
+  board: grupomaisbarato
+- company: "PAMPLONA ALIMENTOS S/A"
+  board: pamplonaalimentossa
+- company: "NATER COOP"
+  board: natercoop
+- company: "CERRADINHO BIOENERGIA SA"
+  board: grupocerradinhobio
+- company: "Granvita"
+  board: quatree
+- company: "COPACOL"
+  board: vemsercopacol
+- company: "PICCADILLY COMPANY"
+  board: piccadilly
+- company: "GRUPO ADN S/A"
+  board: vagasadn
+- company: "CONSTRUTORA FONTANA"
+  board: estilofontana
+- company: "Docile Alimentos"
+  board: docile
+- company: "Grupo Cantinho Doce"
+  board: lojascantinhodoce
+- company: "Unimed Maringá"
+  board: unimedmaringa
+- company: "Construtora Planeta"
+  board: conexaoconstrutoraplaneta
+- company: "SETE SOLUÇÕES E TECNOLOGIA AMBIENTAL"
+  board: sete
+- company: "UNIMED DE SOROCABA COOP DE TRABALHO MEDI"
+  board: unimedsorocaba
+- company: "Associação Beneficente Síria"
+  board: hcor
+- company: "UNIMED VTRP"
+  board: unimedvtrp
+- company: "Fiagril Ltda"
+  board: fiagril
+- company: "HOSPITAL DE BASE"
+  board: vagashospitaldebase
+- company: "AGRODANIELI"
+  board: agrodanieli
+- company: "3Z Movimentação Inteligente Ltda"
+  board: movimentacao3z
+- company: "PERTO"
+  board: perto
+- company: "Unimed Fesp"
+  board: unimedfesp
+- company: "AgroSB"
+  board: agrosb
+- company: "HOSPITAL MATERNO INFANTIL - FRANCISCO DE ASSIS"
+  board: hifa
+- company: "PERKONS"
+  board: perkons
+- company: "GRUPO PERIM - SUPERMERCADO PERIM"
+  board: supermercadoperim
+- company: "ORTHOMETRIC"
+  board: vagasorthometric
+- company: "UNIMED NATAL"
+  board: vagasunimednatal
+- company: "MINERITA"
+  board: grupominerita
+- company: "HOSPITAL MUNICIPAL DR. MOYSÉS DEUTSCH - M`BOI MIRIM"
+  board: hospitalmboimirim
+- company: "ATRHOL"
+  board: atrhol
+- company: "Karina"
+  board: karina
+- company: "Líder Atacadista"
+  board: lider
+- company: "TARRAF"
+  board: tarraf
+- company: "UNIMED LONDRINA"
+  board: unimedlondrina
+- company: "CORPAL LOTEAMENTOS"
+  board: vagascorpal
+- company: "ATLAS ELETRODOMESTICOS"
+  board: atlaseletrodomesticos
+- company: "DARCY PACHECO"
+  board: darcypacheco
+- company: "GRUPO VALDIR SARAIVA"
+  board: grupovaldirsaraiva
+- company: "WeDo Tecnologia"
+  board: wedo
+- company: "BELEM BIOENERGIA BRASIL"
+  board: belembioenergia
+- company: "BERGHEM"
+  board: berghem
+- company: "COOXUPÉ"
+  board: cooxupe
+- company: "FourC"
+  board: escolafourc
+- company: "VSG VIGILANCIA."
+  board: grupovsg
+- company: "Brudden"
+  board: bruddencorporativo
+- company: "ONR"
+  board: onr
+- company: "Thega Indústria e Comércio Ltda"
+  board: thega
+- company: "FUNDESTE"
+  board: uno
+- company: "COTRISOJA"
+  board: cotrisoja
+- company: "MUELLER PARTICIPAÇÕES S/A"
+  board: grupomueller
+- company: "HOSPITAL GERAL E MATERNIDADE DE CUIABA"
+  board: hgcuiaba
+- company: "OMNI"
+  board: omnibr
+- company: "Sementes Roos"
+  board: sementesroos
+- company: "CAVALETTI S/A"
+  board: cavaletti
+- company: "UNIMED PONTA GROSSA"
+  board: unimedpg
+- company: "MAINHARDT OUTSOURCING LTDA"
+  board: vempramainhardtcontabilidade
+- company: "YOU SENIOR"
+  board: yousenior
+- company: "Sancon"
+  board: gruposancon
+- company: "Novamérica Agrícola"
+  board: novamerica
+- company: "Placas do Brasil S/A"
+  board: placasdobrasil
+- company: "SENIOR NOROESTE PAULISTA"
+  board: seniornoroeste
+- company: "Brasil Terminal Portuario"
+  board: btp
+- company: "Canatiba Têxtil"
+  board: canatibatextil
+- company: "COTTON STAR INDUSTRIAL"
+  board: cottonstar
+- company: "MISSÃO"
+  board: missaosaldaterra
+- company: "UNUS SOLUTIONS LTDA"
+  board: vempraunusoutsourcing
+- company: "WOLBITO DO BRASIL"
+  board: wolbito

--- a/sources/solides.yml
+++ b/sources/solides.yml
@@ -4,3 +4,2313 @@
   board: dynamox
 - company: Reivax
   board: reivax
+
+# --- harvested via Wayback CDX + live API validation 2026-06-21 ---
+- company: "DROGAL FARMACEUTICA LTDA"
+  board: drogal
+- company: "Relou RH Especializado"
+  board: relourh
+- company: "Grupo Bringel"
+  board: grupobringel
+- company: "GENTIL NEGOCIOS"
+  board: gentilnegocios
+- company: "MCA AUDITORIA E GERENCIAMENTO LTDA"
+  board: mca
+- company: "LONGITUDE INCORPORACAO & URBANISMO LTDA"
+  board: longitude
+- company: "CONSULTORIA CAMILLA TERRA LTDA"
+  board: grupocamillaterraconsultoria
+- company: "Estar Bem Distribuidora De Alimentos Eireli"
+  board: estarbem
+- company: "ZUKKIN BRASIL INTELIGENCIA DE MERCADO S/A"
+  board: zukkin
+- company: "UMUARAMA ADMINISTRACAO E PARTICIPACAO CONCESSIONARIA LTDA"
+  board: umuaramaconcessionarias
+- company: "RHBH GESTAO DE PESSOAS LTDA"
+  board: rhbh
+- company: "GRUPO INDAIA"
+  board: vagasht
+- company: "Construai"
+  board: construai
+- company: "SOLUCAO LOCACAO E TRANSPORTES LTDA"
+  board: sltlog
+- company: "REDEFLEX COMERCIO E SERVICO DE TELEFONIA LTDA"
+  board: redeflex
+- company: "COMERCIAL GALA LTDA"
+  board: supercordeiro
+- company: "Wlm Participacoes E Comercio De Maquinas E Veiculos S.a."
+  board: wlmscania
+- company: "Fashion Shoes Comercio De Calcados E Confeccoes Eireli"
+  board: gruponomura
+- company: "LUIZ TONIN ATACADISTA E SUPERMERCADOS S. A."
+  board: redetonin
+- company: "BRASIL CARD INSTITUICAO DE PAGAMENTOS LTDA"
+  board: grupoadrianocobuccio
+- company: "HEALTH BRASIL COMERCIO ATACADISTA DE MEDICAMENTOS LTDA"
+  board: amoedodistribuidora
+- company: "SANTOS DE ARAUJO COMERCIO E SERVICOS LTDA"
+  board: hunterh
+- company: "IPECONT ESTRATEGIA E NEGOCIOS LTDA"
+  board: ipecont
+- company: "Grupo Artesanal"
+  board: vagasfarmaciaartesanal
+- company: "ANA LEITE CONSULTORIA E GESTAO LTDA"
+  board: leadd
+- company: "COMERCIAL DRUGSTORE LTDA"
+  board: farmaciapermanente
+- company: "OSCAR CALCADOS LTDA"
+  board: grupooscar
+- company: "ASSOCIACAO BENEFICENTE CISNE"
+  board: institutocisnece
+- company: "TEAM CONTABILIDADE RECIFE LTDA"
+  board: team
+- company: "SOCIEDADE DE CONCERTOS DE SAO PAULO"
+  board: baccarelli
+- company: "BIG MAIS SUPERMERCADOS LTDA"
+  board: bigmais
+- company: "PATRIMAR ENGENHARIA S.A."
+  board: grupopatrimar
+- company: "Mineracao Serras Do Oeste Eireli"
+  board: jaguarmining
+- company: "INNOVA"
+  board: innova
+- company: "TMatheaço"
+  board: tmatheaco
+- company: "Maza Tarraf"
+  board: mazatarraf
+- company: "Suecia Veiculos S/A"
+  board: gruposuecia
+- company: "DISTRIBUIDORA DE ALIMENTOS ALBUQUERQUE LTDA"
+  board: vemsercbox
+- company: "CENTRO VETERINARIO 004 LTDA"
+  board: petcare
+- company: "ROTAS DE VIACAO DO TRIANGULO LTDA - EM RECUPERACAO JUDICIAL"
+  board: vagasroderotas
+- company: "W PREMIUM GROUP SERVICOS AUXILIARES EM PORTOS E AEROPORTOS L"
+  board: vagaswpremium
+- company: "GEOTECH BRASIL LTDA"
+  board: geotechbrasil
+- company: "SÓ MOTOR PARTS"
+  board: somotorparts
+- company: "GRAFICO EMPREENDIMENTOS LTDA"
+  board: graficoltda
+- company: "CARRIEL CONSULTORIA EMPRESARIAL LTDA"
+  board: audacy
+- company: "Carmel Hotéis"
+  board: carmelhoteis
+- company: "ASSOCIACAO VOLUNTARIOS PARA O SERVICO INTERNACIONAL - BRASIL"
+  board: avsibrasil
+- company: "REVENDA VALLE DA INTEGRACAO LTDA"
+  board: revalle
+- company: "BEACH PARK HOTEIS E TURISMO S/A"
+  board: beachpark
+- company: "CEDRO SISTEMAS E TECNOLOGIA LTDA"
+  board: cedrotech
+- company: "Conecta Telecom Ltda"
+  board: itanet
+- company: "IPV7 TECNOLOGIA DA INFORMACAO LTDA"
+  board: vagasipv7
+- company: "ELEVATO MATERIAIS DE CONSTRUCAO E DECORACAO LTDA"
+  board: grupoelevato
+- company: "VIZZELA"
+  board: vizzela
+- company: "CALEBITO SORVETERIA ARTESANAL"
+  board: calebito
+- company: "CONTRAIL LOGISTICA S.A."
+  board: contrail
+- company: "JERONIMO DA VEIGA"
+  board: jeronimodaveiga
+- company: "Mosaico Consultoria"
+  board: mosaico
+- company: "GRUPO PRIME"
+  board: grupoprimees
+- company: "FRISA FRIGORIFICO RIO DOCE S A"
+  board: frisa
+- company: "SOCIEDADE INTELIGÊNCIA E CORAÇÃO"
+  board: redeliusagostinianos
+- company: "SIMAS LOGISTICA LTDA"
+  board: simaslog
+- company: "UNIMED JOAO PESSOA COOPERATIVA DE TRABALHO MEDICO"
+  board: unimedjp
+- company: "VIX COMERCIO DE CONFECCOES LTDA"
+  board: vixbrasil
+- company: "BP STIP LTDA"
+  board: bemprotege
+- company: "BENDICASA"
+  board: bendicasa
+- company: "Grupo Projeta"
+  board: grupoprojeta
+- company: "CAPRETZ EMPREENDIMENTOS IMOBILIARIOS LTDA"
+  board: caprem
+- company: "MB IMPORTACAO E DISTRIBUICAO LTDA"
+  board: lm2rodas
+- company: "PLASCAR INDUSTRIA DE COMPONENTES PLASTICOS LTDA"
+  board: plascar
+- company: "RESTAURANTE ENTRE AMIGOS"
+  board: entreamigos
+- company: "SUPERMERCADO BRASIL"
+  board: supermercadosbrasilcl
+- company: "DUO GROUP"
+  board: duogroup
+- company: "Grupo Larch"
+  board: grupolarch
+- company: "CESED - CENTRO DE ENSINO SUPERIOR E DESENVOLVIMENTO LTDA"
+  board: unifacisa
+- company: "AG CONSULTORIA LTDA"
+  board: agconsultoria
+- company: "MACIEL & MENEZES LTDA"
+  board: casadocelular
+- company: "GUEDES & PAIXAO LTDA"
+  board: drogariaminasbrasil
+- company: "DANIELA SCHERER FERNANDES COSTA 07307757710"
+  board: oidconsultoriaempresarial
+- company: "SANDECH CONSULTORIA EM ENGENHARIA E GESTAO LTDA"
+  board: sandech
+- company: "REDE CINE A LTDA"
+  board: cinea
+- company: "Fundação Cristiano Varella"
+  board: fcv
+- company: "GRUPO ASTÓRIA"
+  board: grupoastoria
+- company: "CSRH RECURSOS HUMANOS LTDA"
+  board: csinstituto
+- company: "Grupo FAN"
+  board: grupofan
+- company: "ITS TELECOMUNICACOES LTDA"
+  board: itsbrasil
+- company: "UZE PROMOTORA DE VENDAS LTDA"
+  board: uze
+- company: "HIPOLABOR FARMACEUTICA LTDA"
+  board: hipolabor
+- company: "RICARDO ALMEIDA"
+  board: ricardoalmeida
+- company: "SILIMED - INDUSTRIA DE IMPLANTES LTDA"
+  board: silimed
+- company: "Sólides Tecnologia"
+  board: solides
+- company: "AMORIM GLOBAL LTDA"
+  board: amorimglobal
+- company: "BUDEL TRANSPORTES LTDA"
+  board: budeltransportes
+- company: "Nobre Distribuidora De Veiculos E Pecas Ltda"
+  board: grupofaberge
+- company: "HENRIQUE TOMMASI NETTO ANALISES CLINICAS LTDA"
+  board: grupotommasi
+- company: "AFECC - Hospital Santa Rita"
+  board: hospitalsantarita
+- company: "Pionnier Atendimento Domiciliar"
+  board: pionnier
+- company: "VETORIAL SIDERURGIA LTDA"
+  board: vetorial
+- company: "WEBCONTINENTAL LTDA"
+  board: webcontinental
+- company: "EDN UTILIDADES DOMESTICAS IMPORTACAO E EXPORTACAO LTDA"
+  board: biglar
+- company: "CABRAL & SOUSA LTDA"
+  board: cabralesousa
+- company: "GRUPO BRASILEIRO - DIVISÃO HONDA"
+  board: grupobrasileirohonda
+- company: "NATUREZA COMERCIO SA"
+  board: gruponatureza
+- company: "Macêdo RH"
+  board: macedorh
+- company: "RIALE HOTÉIS"
+  board: rederialehoteis
+- company: "ASA BRANCA INDL. COML. E IMPORTADORA LTDA"
+  board: asabranca
+- company: "ATUAL CARGAS TRANSPORTES LTDA"
+  board: atualcargas
+- company: "B2"
+  board: b2agencia
+- company: "GENTE - DESENVOLVENDO PESSOAS E NEGÓCIOS"
+  board: gentedho
+- company: "Grupo Rojemac"
+  board: gruporojemac
+- company: "JC LOGISTICA E TRANSPORTE LTDA"
+  board: jclogistica
+- company: "REDE HOSPITAL CASA"
+  board: redehospitalcasa
+- company: "SOLARZ TECNOLOGIA LTDA"
+  board: solarz
+- company: "R. C. DE FREITAS ADMINISTRADORA DE PLANOS FUNERARIOS LTDA"
+  board: afagu
+- company: "CLARIENS EDUCACAO S.A"
+  board: clariens
+- company: "Colégio Catarinense"
+  board: colegiocatarinense
+- company: "SISTEMA INTEGRADO DE ENSINO ANA NERY LTDA"
+  board: cursoinvictus
+- company: "Grupo Fácil"
+  board: grupofacil
+- company: "Kijeme Travel Hoteis Ltda"
+  board: resortlatorre
+- company: "STANLEY ELECTRIC DO BRASIL LTDA."
+  board: stanleyelectric
+- company: "REM PARTICIPACOES E ADMINISTRACAO DE FRANQUIAS LTDA"
+  board: vagasbiscoitosmineiros
+- company: "FUNDACAO CSN PARA O DESENVOLVIMENTO SOCIAL E A CONSTRUCAO DA"
+  board: aprendizagemfundacaocsn
+- company: "CORTEZ ENGENHARIA LTDA."
+  board: cortezengenharia
+- company: "SONDOTECNICA ENGENHARIA DE SOLOS S A"
+  board: sondotecnica
+- company: "UNIGUACU HUB LTDA"
+  board: uniguacu
+- company: "DJ COMERCIO E DISTRIBUIDORA DE ALIMENTOS LTDA"
+  board: voita
+- company: "BCB TELECOM INTERNET BANDA LARGA LTDA"
+  board: bbgtelecom
+- company: "O BODE DO NO LTDA"
+  board: bodedono
+- company: "GOOD SALES PERFUMARIA E COSMETICOS LTDA"
+  board: grupordz
+- company: "IMX INDUSTRIA E COMERCIO LTDA"
+  board: imexmedical
+- company: "INSPETORIA SALESIANA DO NORDESTE DO BRASIL"
+  board: inspetoriasalesiana
+- company: "L & G ALIMENTOS DO BRASIL LTDA"
+  board: mercale
+- company: "PROJETA SUSTENTAVEL LTDA"
+  board: projecaodetalentos
+- company: "VERMONT TI E CALL CENTER LTDA."
+  board: vermontxcenter
+- company: "ZINHO INDUSTRIA E COMERCIO DE ALIMENTOS LTDA"
+  board: zinhoindustria
+- company: "ALPHA CONSULTORIA E RECURSOS HUMANOS LTDA"
+  board: alphaconsultoriarh
+- company: "COSTA RICA MALHAS E CONFECCOES LTDA"
+  board: costarica
+- company: "DIEFRA"
+  board: diefra
+- company: "CCPG HOLDING DE PARTICIPACOES LTDA"
+  board: grupovorp
+- company: "LOJAS DUJUCA"
+  board: lojasdujuca
+- company: "MEDICAMENTAL DISTRIBUIDORA LTDA"
+  board: medicamentaldistribuidora
+- company: "ROMMANEL GRUPO ROMMATIAN"
+  board: rommanelrommatian
+- company: "PHV ENGENHARIA LTDA"
+  board: paginadecarreirasphv
+- company: "LME COMERCIO DE ALIMENTOS LTDA"
+  board: restaurantejoaquina
+- company: "CIMSAL COM E IND DE MOAGEM E REFINACAO STA CECILIA LTDA"
+  board: cimsal
+- company: "LOGIKS CONSULTORIA E SERVICOS EM TECNOLOGIA DA INFORMACAO LTDA"
+  board: logiks
+- company: "Unique Proteção Veicular"
+  board: uniquepv
+- company: "ALCANS TELECOM LTDA"
+  board: alcans
+- company: "CAPIVARI SOLUÇÕES LOGISTICAS"
+  board: capivarisolucoeslogisticas
+- company: "CNP - People solutions"
+  board: cnp
+- company: "COSTAO DO SANTINHO TURISMO E LAZER LTDA"
+  board: costao
+- company: "ENOTEL - HOTELS & RESORTS S/A"
+  board: enotel
+- company: "DISMOTOR COMERCIO DE MOTORES ELETRICOS LTDA"
+  board: grupodismotor
+- company: "MEIRELES E FREITAS SERVICOS DE COBRANCAS LTDA"
+  board: meirelesefreitas
+- company: "MORAR CONSTRUTORA E INCORPORADORA LTDA"
+  board: morar
+- company: "MAPDATA-TECNOLOGIA,INFORMATICA E COMERCIO LTDA"
+  board: ntibrasil
+- company: "ESPECIALISTAS INTELIGENCIA CONTABIL LTDA"
+  board: redeespecialistas
+- company: "TESTATO SERVICOS TECNICOS LTDA"
+  board: testato
+- company: "UNILOG EXPRESS LOGÍSTICA S.A."
+  board: unilogexpress
+- company: "AMH"
+  board: americashealth
+- company: "CONTEGO CONSULTORIA LTDA"
+  board: contegosecurity
+- company: "MOVEEDU INOVACAO E EDUCACAO LTDA"
+  board: moveedu
+- company: "OMNILINK TECNOLOGIA S.A."
+  board: omnilinkcarreiras
+- company: "CONTINENTAL INN HOTEL LTDA."
+  board: redesoul
+- company: "SUPPORTE ARMAZENAGEM, VENDAS E LOGISTICA INTEGRADA LTDA"
+  board: supporte
+- company: "SEMPRE TELECOMUNICACOES LTDA"
+  board: trabalhenasempre
+- company: "Conecta"
+  board: conectaoficial
+- company: "CORTEL HOLDING S.A."
+  board: cortel
+- company: "DELUNA SERVICOS DE TRANSPORTES LTDA"
+  board: deluna
+- company: "FIBRACEM TELEINFORMATICA LTDA"
+  board: fibracem
+- company: "OPL LOGISTICA LTDA"
+  board: grupobergton
+- company: "FLAMBOYAN MODAS LIMITADA"
+  board: grupoflamboyan
+- company: "Rede Salvatoriana"
+  board: redesalvatoriana
+- company: "FILLER ALIMENTOS E BEBIDAS LTDA"
+  board: timefiller
+- company: "Sicoob Amazônia"
+  board: vagasicoobamazonia
+- company: "AMO TELECOM E SOLUCOES LIMITADA"
+  board: amointernetk2telecom
+- company: "APLUS ENGENHARIA LTDA"
+  board: aplusengenharia-trabalheconosco
+- company: "FRIBEL INDUSTRIA E COMERCIO DE ALIMENTOS LTDA"
+  board: fribel
+- company: "Grupo Gérbera"
+  board: grupogerbera
+- company: "Grupo Netway"
+  board: gruponetway
+- company: "SANTOS E CIA SERVICOS LTDA"
+  board: jamesmotoshop
+- company: "R F CRISTOVAO-KATO SOLUCOES EMPRESARIAIS"
+  board: kato
+- company: "Labchecap - Laboratorios De Analises Clinicas Ltda."
+  board: labchecapseimi
+- company: "LACO DE FITA COMERCIO DE BIJUTERIAS LTDA"
+  board: lacodefitabiju
+- company: "ROSA MASTER"
+  board: rosamaster
+- company: "Social Digital Commerce"
+  board: socialsa
+- company: "AGRO VETERINARIA TIMBO LTDA"
+  board: agrotimbo
+- company: "Codgo.X"
+  board: codgox
+- company: "GHENOVA BRASIL PROJETOS LTDA."
+  board: ghenovabrasil
+- company: "B R A SERVICOS DE COMUNICACAO LTDA"
+  board: netturbotelecom
+- company: "ZAKAT DISTRIBUIDORA DE COSMETICOS LTDA"
+  board: salonline
+- company: "TECSERVICE LTDA"
+  board: tecserviceengenharia
+- company: "Ujob Brasil"
+  board: ujobbrasill
+- company: "LOJAS EMES"
+  board: vagaslojasemes
+- company: "ARESE PHARMA LTDA."
+  board: aresepharma
+- company: "BUYCO TECNOLOGIA EM NEGOCIOS S.A."
+  board: buyco
+- company: "FAMINAS BH"
+  board: faminasbh
+- company: "FIXTELL TELECOM NE LTDA"
+  board: fixtellnordeste
+- company: "CLIGED MACAE CLINICA DE ENDOSCOPIA LTDA"
+  board: grupocliged
+- company: "GUARULHOS COMERCIO DE SUCATAS LTDA"
+  board: guarulhossucatas
+- company: "MOTOCA MOTORES TOCANTINS LTDA."
+  board: motoca
+- company: "MERCANTIL DE MOVEIS CASA VERDE LTDA"
+  board: moveiscasaverde
+- company: "R CERVELLINI REVESTIMENTOS LTDA"
+  board: rcervellini
+- company: "Solo Network Brasil S.A."
+  board: solonetwork
+- company: "SAVI COSMETICOS LTDA"
+  board: wepink
+- company: "Cajueiro Motos Ltda"
+  board: cajueiromotos
+- company: "CETRO SOLUCOES EM EMBALAGENS LTDA"
+  board: cetromaquinas
+- company: "CENTRO DE INTEGRACAO EMPRESA ESCOLA DO E RIO DE JANEIRO"
+  board: cieerio
+- company: "Coopama - Cooperativa Agrária de Machado"
+  board: coopama
+- company: "Cpe Comercio De Equipamentos Topograficos Eireli"
+  board: cpetecnologia
+- company: "Decolores Marmores E Granitos Do Brasil Ltda"
+  board: decolores
+- company: "Dr.Hato"
+  board: drhato
+- company: "VILAROUCA PERFUMARIA CEARA LTDA"
+  board: grupovilarouca
+- company: "Luiza Barcelos Calcados S/a"
+  board: luizabarcelos
+- company: "MAGBAN MARMORES E GRANITOS AQUIDABAN LTDA"
+  board: magban
+- company: "SYMBIOSIS INVESTIMENTOS E PARTICIPACOES S.A."
+  board: symbiosis
+- company: "PEGASUS PROMOCOES EVENTOS E SERVICOS LTDA"
+  board: agenciapegasus
+- company: "PACIOLI SERVICOS CONTABEIS SOCIEDADE SIMPLES LTDA"
+  board: contratosc
+- company: "SEFE - SISTEMA EDUCACIONAL FAMILIA E ESCOLA LTDA"
+  board: editoraopet
+- company: "EISEN DISTRIBUICAO ESPECIALIZADA LTDA"
+  board: eisen
+- company: "RedeTV"
+  board: empresaredetv
+- company: "ATLAS DE IGUACU DISTRIBUIDORA DE ALIMENTOS LTDA"
+  board: grupoatlas
+- company: "MODENA & SILVA LTDA"
+  board: grupomodenaesilvaro
+- company: "SARITUR SANTA RITA TRANSPORTE URBANO E RODOVIARIO LTDA"
+  board: gruposaritur
+- company: "M4PAR"
+  board: m4par
+- company: "MUNDO APTO EMPREENDIMENTOS E PARTICIPACOES LTDA"
+  board: mundoapto
+- company: "COOPERATIVA CENTRAL DE CREDITO DO ESPIRITO SANTO"
+  board: sicoobes
+- company: "SKA AUTOMACAO DE ENGENHARIAS LTDA"
+  board: ska
+- company: "OK ENERGY, IMPORTACAO E EXPORTACAO LTDA"
+  board: souenergy
+- company: "Supermercado Jepsen Ltda"
+  board: supermercadosjepsen
+- company: "SOCIEDADE EDUCACIONAL EDICE PORTELA LTDA"
+  board: uniateneutrabalheconosco
+- company: "Vilarejo De Macae Materiais De Construcao Ltda"
+  board: vilarejo
+- company: "Agropeu-Agro Industrial De Pompeu S/a"
+  board: agropeu
+- company: "CASA DO CONSTRUTOR"
+  board: casadoconstrutor
+- company: "COLEGIO MOTIVA LTDA"
+  board: colegiomotiva
+- company: "D1 INDUSTRIA E COMERCIO LTDA"
+  board: d1fitness
+- company: "FERTGROUP S.A."
+  board: fertgroupselecao
+- company: "GRP SERVICOS LTDA"
+  board: groupsoftware
+- company: "HE-NET MANUTENCAO E SERVICOS DIGITAIS LTDA"
+  board: henet
+- company: "JSB DISTRIBUIDORA LTDA"
+  board: jsbdistribuidora
+- company: "NINFA INDUSTRIA DE ALIMENTOS LTDA"
+  board: ninfaalimentos
+- company: "OPUS LOCACOES E CONSTRUCOES MODULARES LTDA"
+  board: opuscm
+- company: "PANCRISTAL LTDA"
+  board: pancristal
+- company: "PLACE TECNOLOGIA E INOVACAO S. A."
+  board: placeti
+- company: "Programa Leilões"
+  board: programaleiloes
+- company: "Service Informatica Ltda"
+  board: serviceit
+- company: "TWIST COMUNICACAO LTDA"
+  board: twist
+- company: "UNIMED CENTRO RONDÔNIA COOPERATIVA DE TRABALHO MEDICO"
+  board: unimedjpr
+- company: "EDITORA DIALÉTICA"
+  board: vagaseditoradialetica
+- company: "VELLON"
+  board: vellon
+- company: "BK IMPORTACOES DE ADESIVOS PLASTICOS LTDA"
+  board: bluetechvagas
+- company: "BRB SERVICOS S/A"
+  board: brbservicos
+- company: "BUP Hotels"
+  board: buphotels
+- company: "TECNO QUIMICA COMERCIO DE TINTAS LTDA"
+  board: casatintas
+- company: "CITTA TELECOM LTDA"
+  board: cittatelecom
+- company: "FIT ECONOMIA DE ENERGIA S.A."
+  board: fitenergia
+- company: "FACULDADE BRASILEIRA DE MEDICINA LTDA"
+  board: grupoeducarmais
+- company: "GRUPO RANGEL CONTABILIDADE EIRELI"
+  board: gruporangel
+- company: "Grupo Sapiens"
+  board: gruposapiens
+- company: "LESTE FLU SERVICOS DE TELECOM LTDA"
+  board: lestetelecom
+- company: "QUATTROR COMERCIAL LTDA"
+  board: quattror
+- company: "LR COMERCIO DE VEICULOS LTDA"
+  board: recrutamentogrupogeracao
+- company: "TELEVISAO VITORIA S/A"
+  board: redevitoria
+- company: "SYNERGIA - CONSULTORIA URBANA E SOCIAL LTDA."
+  board: synergiasocioambiental
+- company: "VALOR INVESTIMENTOS ASSESSORIA DE INVESTIMENTOS LTDA"
+  board: valorinvestimentos
+- company: "AMERICA FUTEBOL CLUBE SOCIEDADE ANONIMA DO FUTEBOL"
+  board: americamineiro
+- company: "BMP"
+  board: bmp
+- company: "CIARAMA MAQUINAS"
+  board: ciarama
+- company: "MAPPTV.COM TECNOLOGIA COMERCIO E SERVICOS DE VALOR ADICIONAD"
+  board: expotelecom
+- company: "G&B AUTO PEÇAS ALTERNATIVAS LTDA"
+  board: gbautopecas
+- company: "GRUPO MOOVEN"
+  board: grupomooven
+- company: "Grupo Odilon Santos"
+  board: grupoodilonsantos
+- company: "WT HOLDING PARTICIPACOES LTDA"
+  board: grupowt
+- company: "LAGOTELA EIRELI"
+  board: lagotela
+- company: "Locmed"
+  board: locmed
+- company: "OUROBRAS COMERCIO DE JOIAS LTDA"
+  board: ourodobrasil
+- company: "CLINICA SAO CAMILO LTDA"
+  board: redesaocamiloba
+- company: "TIELI SUPERMERCADO LTDA"
+  board: tieli
+- company: "Empresa Prudentina de Educacão e Cultura - Epec"
+  board: unoeste
+- company: "ANJUSS"
+  board: vemvoarcomaanjuss
+- company: "VERSANIA SAUDE BRASIL LTDA"
+  board: versaniabrasil-vagas
+- company: "VOKKAN PARTICIPACOES S.A"
+  board: vokkan
+- company: "A3 DATA CONSULTORIA S.A."
+  board: a3dataconsultoria
+- company: "ARBAZA ALIMENTOS LTDA"
+  board: arbaza
+- company: "ALTAVE Intelligent Monitoring"
+  board: carreirasaltave
+- company: "CICAL SERVICOS DE DESPACHANTES LTDA"
+  board: cical
+- company: "ClickCannabis"
+  board: clickcannabis
+- company: "DELP ENGENHARIA MECANICA S/A"
+  board: delp
+- company: "DESENVOLVE TECNOLOGIA, TREINAMENTO E GESTAO POR RESULTADO PA"
+  board: desenvolvecidade
+- company: "DRATEC ENGENHARIA LTDA"
+  board: dratec
+- company: "ATLAS S.A"
+  board: drogavet
+- company: "FAMINAS MURIAÉ"
+  board: faminasmuriae
+- company: "FitBank"
+  board: fitbank
+- company: "MED4U PARTICIPACOES SOCIETARIAS S/A"
+  board: grupomed4u
+- company: "INSTITUTO SAO LUCAS"
+  board: hospitalhilda
+- company: "HUBIO BIOPAR AGRO INDUSTRIA E COMERCIO DE PRODUTOS QUIMICOS"
+  board: hubioagro
+- company: "LACOS SAUDE S.A."
+  board: lacosgrupo
+- company: "LRV Serviços e Montagens Ltda"
+  board: lrv
+- company: "EFG SAUDE S.A."
+  board: mais60saude
+- company: "MAXINUTRI"
+  board: maxinutri
+- company: "MEIRELES E FREITAS SERVICOS DE COBRANCAS LTDA"
+  board: meirelesefreitasgo
+- company: "COMERCIAL MOTOCICLO S/A"
+  board: motociclo
+- company: "OIL STATES INDUSTRIES DO BRASIL"
+  board: oilstatescareers
+- company: "Osten Group"
+  board: ostengroup
+- company: "PIONEIRO COMBUSTIVEIS LTDA"
+  board: pioneirobr
+- company: "AMEV IMPORTADORA E DISTRIBUIDORA LTDA"
+  board: reporatacadista
+- company: "TEXTILE XTRA CO. LTDA"
+  board: txc
+- company: "UJOB BRASIL"
+  board: ujobbrasil
+- company: "CONDOR S/A INDUSTRIA QUIMICA"
+  board: vagascondornaoletal
+- company: "PROATIVE SOLUÇÕES EM TECNOLOGIA DA INFORMAÇÃO LTDA"
+  board: vemserproative
+- company: "4 Elos Distribuidora Ltda"
+  board: 4elosdistribuidora
+- company: "ANCORA ADMINISTRADORA DE CONSORCIOS S.A."
+  board: ancoraconsorcios
+- company: "Atex Do Brasil Locacao De Equipamentos Ltda"
+  board: atex
+- company: "Braúna"
+  board: brauna
+- company: "CONTATO SEGURO PREVENCAO DE RISCOS EMPRESARIAIS LTDA"
+  board: contatoseguro
+- company: "FACELL COMERCIO DE CELULARES LTDA"
+  board: facell
+- company: "VD LOCATELLI PERFUMARIA LTDA"
+  board: franquiairmaoslocatellioboticario
+- company: "FATIMA COMERCIAL DE PERFUMES LTDA"
+  board: grupopinheiro
+- company: "HECT CONSULTORIA"
+  board: hect
+- company: "IN.PACTO COMUNICACAO CORPORATIVA E DIGITAL SS"
+  board: holdinginpacto
+- company: "LACMAR - LABORATORIO DE ANALISES CLINICAS DO MARANHAO LTDA"
+  board: lacmar
+- company: "NOXTEC SERVICOS LTDA"
+  board: noxtec
+- company: "OLINDA DISTRIBUIDORA E COMERCIO DE ALIMENTOS LTDA"
+  board: olindadistribuidora
+- company: "CADEX GESTAO DE NEGOCIOS LTDA"
+  board: recrutamentomirandex
+- company: "REPRODUZINDO TALENTOS MARKETING LTDA"
+  board: reproduzindotalentos
+- company: "SECURITY FIRST LTDA"
+  board: securityfirst
+- company: "SIC GESTÃO RH"
+  board: sicgestaorh
+- company: "RVT SERVICOS DE TELECOMUNICACOES LTDA"
+  board: simdigital
+- company: "SUBCONDOMINIO DO CARUARU SHOPPING"
+  board: vagascaruarushopping
+- company: "ZAMIX MULTIPLAY TELECOMUNICACOES LTDA"
+  board: zamix
+- company: "AIRY HOTELS & LEISURE"
+  board: airyhotelsandleisure
+- company: "ARENA BSB SPE S/A"
+  board: arena360
+- company: "ARPEJO COMUNICACAO INTEGRADA LTDA"
+  board: arpejo
+- company: "AVALYST SERVICOS DE COBRANCA S.A."
+  board: avalyst
+- company: "BLUEVIX COMERCIO E SERVICO LTDA"
+  board: bluevix
+- company: "BRASIL VIDA TAXI AEREO LTDA"
+  board: brasilvida
+- company: "CHEIL BRASIL COMUNICACOES LTDA"
+  board: cheilbrasil
+- company: "Construcasa Bordignon"
+  board: construcasa
+- company: "EUCATUR-EMPRESA UNIAO CASCAVEL DE TRANSPORTES E TURISMO LTDA"
+  board: eucatur
+- company: "FALCON HOTEIS LTDA"
+  board: falconhoteis
+- company: "RAINMAKER SERVICE CONSULTORIA LTDA"
+  board: fotona
+- company: "BOOMER GESTAO DE TRAFEGO ONLINE LTDA"
+  board: gestaoboomer
+- company: "GRUPO LEAUTO"
+  board: grupoleauto
+- company: "LZT TURISMO LTDA"
+  board: grupolzt
+- company: "PROJECTO COMERCIO DE ROUPAS, ACESSORIOS E CALCADOS LTDA"
+  board: gruposyndicate
+- company: "TCAA ANALISE CADASTRAL EIRELI"
+  board: gvndigital
+- company: "TECNOSERVE PROVEDORES DIGITAIS"
+  board: ibipar
+- company: "METROPAX S/A"
+  board: metropax
+- company: "RESOLUTTO LTDA"
+  board: resoluttorecrutamento
+- company: "SIDERAL LINHAS AEREAS LTDA"
+  board: siderallinhasaereas
+- company: "SNEF ENERGIA E TELECOMUNICACOES LTDA"
+  board: snefbrasil
+- company: "TRANSJORDANO LTDA"
+  board: transjordano
+- company: "APPLAUSO NISSAN VEICULOS LTDA"
+  board: vagasapplauso
+- company: "WI CONSULTORIA E ASSESSORIA EMPRESARIAL LTDA"
+  board: wigroup
+- company: "MESTRE SEO OTIMIZACAO DE SITES PARA FERRAMENTAS DE BUSCA LTD"
+  board: agenciamestre
+- company: "Alta Rede Corporate Ltda"
+  board: altarede
+- company: "BOMFIM CARGAS E ENCOMENDAS LTDA"
+  board: bomfimcargas
+- company: "BSA CORP LTDA"
+  board: bsatech
+- company: "CAKTO PAY LTDA"
+  board: cakto
+- company: "CLICKNET TELECOMUNICACOES PROVEDOR DE INTERNET LTDA"
+  board: carreirasclicknet
+- company: "CHAIN TECNOLOGIA E SERVICOS LTDA"
+  board: chaintech
+- company: "COLEGIO DARWIN"
+  board: colegiodarwin
+- company: "CONSTRUTORA SUDOESTE LTDA"
+  board: construtorasudoeste
+- company: "DEVELCODE INFORMATICA LTDA"
+  board: develcode
+- company: "J. C. S. DE ALMEIDA & CIA LTDA"
+  board: distribuidoraalmeida
+- company: "ECODIESEL COMERCIO DE COMBUSTIVEIS LTDA"
+  board: ecodiesel
+- company: "Equipe de RH Carolina Pache."
+  board: equipecarolinapache
+- company: "EVOLUA ENERGIA PARTICIPACOES S/A"
+  board: evoluaenergia
+- company: "GERIBELLO ENGENHARIA"
+  board: geribello
+- company: "ALVES DA CUNHA ENGENHARIA, CONSTRUCOES E SERVICOS LTDA"
+  board: grupoalvesdacunha
+- company: "GRUPO DDM COBRANCA, CREDITO E CONTACT CENTER LTDA"
+  board: grupoddm
+- company: "NATIVA COMERCIO DE PERFUMES E COSMETICOS LTDA"
+  board: gsa
+- company: "HOME DOCTOR FORNECIMENTO DE INFRAESTRUTURA DE APOIO E ASSISTENCIA AO PACIENTE EM DOMICILIO LTDA."
+  board: homedoctor
+- company: "INDUMAK MAQUINAS LTDA"
+  board: indumak
+- company: "C E M SANTOS LTDA"
+  board: jbclube
+- company: "LKM SERVICOS E SOLUCOES LTDA"
+  board: lkm
+- company: "LOCCUS DO BRASIL LTDA"
+  board: loccus
+- company: "MOSELE"
+  board: lojasmosele
+- company: "LUIS ALBERT DOS SANTOS OLIVEIRA LTDA"
+  board: luisalbertadv
+- company: "MAKER SOLUCOES TECNOLOGICAS LTDA"
+  board: makersolucoes
+- company: "MASTER SUL COMEX LTDA"
+  board: mastersul
+- company: "MERCOSUL VEICULOS LTDA"
+  board: mercosulveiculos
+- company: "Motocar"
+  board: motocar
+- company: "CR NEGOCIOS DIGITAIS LTDA"
+  board: muranojoias
+- company: "HARMONIA SFA PARTICIPACOES SOCIETARIAS LTDA"
+  board: novaharmonia
+- company: "ÓTICAS CAROL - Grupo Katz"
+  board: oticascarolgrupokatz
+- company: "KI-KAKAU INDUSTRIA E COMERCIO DE CHOCOLATES LTDA"
+  board: recrutamentokikakau
+- company: "CRED URNA PLANOS FUNERARIOS LTDA"
+  board: redememorialfortaleza
+- company: "SET9 Group"
+  board: set9group
+- company: "SHERWIN-WILLIAMS DO BRASIL INDUSTRIA E COMERCIO LTDA."
+  board: sherwin-williams
+- company: "SOLUCAO NETWORK PROVEDOR LTDA"
+  board: solucaonetwork
+- company: "LATICINIOS VERDE CAMPO S.A."
+  board: verdecampo
+- company: "WEBBY TELECOM LTDA"
+  board: webbytalentos
+- company: "AGILITY SEGURANCA ELETRONICA LTDA"
+  board: agility
+- company: "Alpha Fitness"
+  board: alphafitness
+- company: "ANDREA VIEIRA"
+  board: andreavieirarh
+- company: "Aprosoja MT"
+  board: aprosoja-mt
+- company: "J. ARAUJO DISTRIBUIDORA IMPORTACAO E EXPORTACAO S.A"
+  board: arcofoods
+- company: "BE Bioinsight & Ecoa"
+  board: bebioinsightecoa
+- company: "BIOMM S.A."
+  board: biomm
+- company: "BOLT ENERGY COMERCIALIZADORA DE ENERGIA LTDA."
+  board: boltenergy
+- company: "SIEG SOLUCOES INTELIGENTES LTDA"
+  board: carreirasieg
+- company: "CDM Contabilidade"
+  board: cdmcontabilidade
+- company: "NOGUEIRA & MACHADO COMERCIO DE TINTAS E VERNIZES LTDA"
+  board: ciadistribuidora
+- company: "CREDITO REAL IMOVEIS E CONDOMINIOS S A"
+  board: creditoreal
+- company: "CTM - CENTRO TECNOLOGICO DE METROLOGIA, COMERCIO DE INSTRUMENTOS E SERVICOS LTDA"
+  board: ctm-calibracao
+- company: "Df Generica - Comercio De Produtos Farmaceuticos Ltda"
+  board: dfdistribuidora
+- company: "BRASILPLAST EMBALAGENS E DESCARTAVEIS LTDA"
+  board: embol
+- company: "SCRIBE INFORMATICA LTDA"
+  board: escriba
+- company: "FGR INCORPORACOES S/A"
+  board: fgr
+- company: "FRIAS NETO CONSULTORIA DE IMÓVEIS"
+  board: friasneto
+- company: "FRI ON LINE LTDA"
+  board: frionline
+- company: "GESTORH PALESTRAS E TREINAMENTOS LTDA."
+  board: gestordepessoas
+- company: "BT EQUIPAMENTOS INDUSTRIAIS LTDA"
+  board: grupobtepiemro
+- company: "CENTRO EDUCACIONAL FATECIE LTDA"
+  board: grupofatecie
+- company: "REAL COMERCIAL LTDA"
+  board: grupolapastina
+- company: "GRUPO LARA"
+  board: grupolarabahia
+- company: "COMERCIAL SUPERKIBARATO SANTA RITA LTDA"
+  board: gruposk
+- company: "HITA COMERCIO E SERVICOS S/A"
+  board: hita
+- company: "HUPDATA CONSULTORIA EM ESTATISTICA E TREINAMENTO PROFISSIONAL LTDA"
+  board: hupdata
+- company: "IMIGRANTES MERCANTIL LTDA"
+  board: imigrantesbebidas
+- company: "INATA PRODUTOS BIOLOGICOS LTDA"
+  board: inatabiologicos
+- company: "Irrah Tech"
+  board: irrahtech
+- company: "JOSE CARLOS CARNEIRO LIMA & CIA LTDA"
+  board: laboratoriolpc
+- company: "LEAF BACKOFFICE LTDA"
+  board: leafconsultoria
+- company: "MIRANDA IMPORTACAO, FABRICACAO E VENDA DE CONTAINER E MODULO"
+  board: mirandacontainer
+- company: "NEON COMERCIAL REAGENTES ANALITICOS LTDA."
+  board: neoncomercial
+- company: "NORTH"
+  board: northtelecom
+- company: "ONIX TECNOLOGIA DO BRASIL LTDA"
+  board: onixtecnologia
+- company: "OTTIMIZZA SISTEMAS CONTABEIS LTDA"
+  board: ottimizza
+- company: "PAKETA SERVICOS FINANCEIROS SA"
+  board: paketa
+- company: "PIPE CONTENT HOUSE - COMERCIO DE CONFECCOES LTDA"
+  board: pipecontenthouse
+- company: "Prolar Netimóveis"
+  board: prolarimoveis
+- company: "RARO RECRUTAMENTO EM TI LTDA."
+  board: rarolabs
+- company: "REDE BR TELECOMUNICACOES LTDA"
+  board: redebr
+- company: "DEPOSITO DE PAPEL SANTA CECILIA LTDA"
+  board: rhsantaceciliaresiduos
+- company: "SEANET TELECOM"
+  board: seanetsc
+- company: "BJ & L COMERCIO E SERVICOS DE INFORMATICA LTDA"
+  board: softwaresul
+- company: "SONHART CONFECCOES LTDA"
+  board: sonhart
+- company: "FONTECRED - SOCIEDADE DE CREDITO DIRETO S/A"
+  board: talentosfontecred
+- company: "TALENTS | Gestão de Pessoas"
+  board: talents
+- company: "CENTRAL DE ADUBOS COMERCIO E REPRESENTACOES LTDA"
+  board: trabalheconoscocda
+- company: "Grupo Integração"
+  board: tvintegracao
+- company: "CENTRO DE SERVICOS MEMORIAL VALE DA SAUDADE LTDA"
+  board: valedasaudade
+- company: "WSI Marketing Digital"
+  board: wsidm
+- company: "CAMARA DE COM E IND BRASIL ALEMANHA SAO PAULO"
+  board: ahkbrasil
+- company: "ALFAIATARIA DE IDEIAS LTDA"
+  board: alfaiatariadeideias
+- company: "AML CONSULTING SOLUCOES LTDA."
+  board: amlreputacional
+- company: "Amo Promo Eireli"
+  board: amopromo
+- company: "ARTTA SOCIEDADE DE CREDITO DIRETO S.A."
+  board: artta
+- company: "ASTRA ENERGIA SOLAR S/A"
+  board: astrasolar
+- company: "BUGBEE"
+  board: bugbee
+- company: "CAJUGRAM GRANITOS E MARMORES DO BRASIL LTDA"
+  board: cajugram
+- company: "CLASSE COURO INDUSTRIA DE ARTEFATOS DE COURO LTDA"
+  board: classecouro
+- company: "APAM - ASSOCIACAO DE PAIS, ALUNOS E MESTRES DO COLEGIO MILIT"
+  board: cmdpii
+- company: "C-NIVEL ENERGIAS RENOVAVEIS LTDA"
+  board: cnivelenergias
+- company: "EFICAZ TECNOLOGIA E SERVICOS LTDA"
+  board: eficazmarketing
+- company: "REDE DE FARMACIAS ESPIRITO SANTENSE-FARMES"
+  board: farmes
+- company: "FUTURE TECHNOLOGIES INFORMATICA LTDA"
+  board: futurevagas
+- company: "Gescon Empresarial"
+  board: gescon
+- company: "GLOBAL TECH HOLDING PARTICIPACOES & INVESTIMENTOS LTDA"
+  board: globaltech
+- company: "Grupo Garbo"
+  board: grupogarbo
+- company: "Grupo GBI"
+  board: grupogbi
+- company: "Uniao Comercial Barao Ltda"
+  board: grupolafaete
+- company: "BOMFIM MAQUINAS AGRICOLAS LTDA"
+  board: grupotratorpecas
+- company: "INSTITUTO HARDWARE BR - HBR"
+  board: hbr
+- company: "INET TECNOLOGIA LTDA"
+  board: inetvip
+- company: "INSIDE GESTAO DE TRAFEGO LTDA"
+  board: inside
+- company: "Karizoda Growth & IA"
+  board: karizoda
+- company: "LCR Contadores"
+  board: lcr
+- company: "Lotti Cucina"
+  board: lotti
+- company: "MLUZ DESIGN LTDA"
+  board: martinluz
+- company: "MM Rent a Car Ltda"
+  board: mmalugueldecarros
+- company: "NEXT SHIPPING LOGISTICA INTERNACIONAL LTDA"
+  board: nextshipping
+- company: "JAMC CONSULTORIA E REPRESENTACAO DE SOFTWARE LTDA"
+  board: petacorp
+- company: "RHAMA CONSULTORIA AMBIENTAL LTDA"
+  board: rhama-analysis
+- company: "SENHOR CONTABIL LTDA"
+  board: senhorcontabil
+- company: "MAO DUPLA COMERCIO E REPRESENTACOES LTDA"
+  board: shopdope
+- company: "COOPERATIVA DE CREDITO DA REGIAO E COLAR METROPOLITANO DO VA"
+  board: sicoobcosmipa
+- company: "ARENA IPANEMA HOTEL LTDA"
+  board: talentosarena
+- company: "CIEDS"
+  board: trabalhenocieds
+- company: "Grupo Contty"
+  board: vemsercontty
+- company: "VITA ASSESSORIA EM SAUDE LTDA."
+  board: vitacheckup
+- company: "VIVVER SISTEMAS LTDA."
+  board: vivversistemas
+- company: "WAE TECNOLOGIA LTDA"
+  board: waetecnologia
+- company: "4MATT"
+  board: 4matt
+- company: "ASSOCIACAO COMERCIAL E INDUSTRIAL DE CAMPO GRANDE"
+  board: acicg
+- company: "AEROMOT-AERONAVES E MOTORES S.A."
+  board: aeromot
+- company: "ALD BIOENERGIA DECIOLANDIA SA"
+  board: aldbioenergia
+- company: "Analise Group"
+  board: analisegroupoficial
+- company: "MC MEDICINA E CONSULTORIA OCUPACIONAL LTDA"
+  board: atentasaude
+- company: "Bella Capri Pizzaria"
+  board: bellacapri
+- company: "EUROPA COMERCIAL LTDA"
+  board: civitt
+- company: "COPAFER COMERCIAL LTDA"
+  board: copafer
+- company: "GRUPO COSAMPA"
+  board: cosampa
+- company: "CENTRO UNIVERSITÁRIO FAG"
+  board: fag
+- company: "FREITAS FERRAZ CAPURUÇO BRAICHI RICCIO SOCIED"
+  board: freitasferraz
+- company: "VIA GABSTER SISTEMAS E TECNOLOGIA LTDA"
+  board: gabster
+- company: "INSTITUTO GLOBAL ATTITUDE"
+  board: globalattitude
+- company: "Calusa"
+  board: grupocalusa
+- company: "EDUARDO ALBUQUERQUE - ADVOGADOS ASSOCIADOS"
+  board: grupoea
+- company: "KOLPLAST CI LTDA"
+  board: grupokolplast
+- company: "REDESUL CORRETAGEM DE CONSORCIOS LTDA"
+  board: gruporedesul
+- company: "CLINICA REUNIDAS SAO VICTOR LTDA"
+  board: gruposaovictor
+- company: "HOSPITAL EVANDRO RIBEIRO LTDA"
+  board: hospitalevandroribeiro
+- company: "KONICA MINOLTA HEALTHCARE DO BRASIL INDUSTRIA DE EQUIPAMENTO"
+  board: konicaminoltahc
+- company: "LAVVI EMPREENDIMENTOS IMOBILIARIOS S.A."
+  board: lavvi
+- company: "LEAD SOLUCOES AMBIENTAIS LTDA"
+  board: lead-sa
+- company: "LINI & PANDOLFI ADVOGADOS ASSOCIADOS"
+  board: lpdbadvogados
+- company: "MAXIFROTA SERVICOS DE MANUTENCAO DE FROTA LTDA"
+  board: maxifrotanutricash
+- company: "MIX ALIMENTOS LTDA"
+  board: mixalimentos
+- company: "Momo Gelato"
+  board: momogelato
+- company: "MSTECH EDUCACAO E TECNOLOGIA LTDA"
+  board: mstech
+- company: "NP Digital Brasil"
+  board: npdigitalbrasil
+- company: "O2 Filmes"
+  board: o2filmes
+- company: "TALENTOS HUMANOS PRESTADORA DE SERVICOS LTDA"
+  board: progenth
+- company: "ROCHA AUTO PEÇAS"
+  board: rochaautopecas
+- company: "GRUPO ABRIL"
+  board: talentosabril
+- company: "TMAC IMPORT"
+  board: tmacimport
+- company: "UNIMED NORTE DE MINAS"
+  board: unimednortedeminas
+- company: "X-ONE IT SOLUTIONS LTDA"
+  board: x-oneit
+- company: "Aggrandize"
+  board: aggrandize
+- company: "ALFA GROUP PARTICIPACOES SOCIETARIAS LTDA"
+  board: alfagroup
+- company: "SUPERMERCADO DA FAMILIA LTDA"
+  board: arcomix
+- company: "Grupo Nicósia - franquia o Boticário Videira, Fraiburgo, Caçador, União da Vitória e Taió"
+  board: boticarionicosia
+- company: "BEST WAY TRIPS AGENCIA DE VIAGENS E TURISMO LTDA"
+  board: bwtoperadora
+- company: "CALUBA PRODUCAO E COMERCIO DE SEMENTES LTDA"
+  board: calubasementes
+- company: "CENTRAL DE EXAMES"
+  board: centraldeexames
+- company: "CLUBE SOCIAL PERTENCE LTDA"
+  board: clubesocialpertence
+- company: "SALVATORE SERVICOS FUNERARIOS LTDA"
+  board: complexosalvatore
+- company: "Cooperativa Agropecuária do Alto Paranaíba"
+  board: coopadap
+- company: "CTC INFRA & CONSTRUCOES LTDA"
+  board: ctcinfra
+- company: "Damapel"
+  board: damapel
+- company: "DATA STONE"
+  board: datastone
+- company: "DFA DISTRIBUICAO E LOGISTICA LTDA"
+  board: dfanestle
+- company: "LABORATORIO DNA LTDA"
+  board: dnacenter
+- company: "E4 AGENCIA LTDA"
+  board: e4agencia
+- company: "echope"
+  board: echope
+- company: "GSM BAHIA PROVEDOR DE INTERNET LTDA"
+  board: empresagsmbahia
+- company: "ENVEL CONTABILIDADE LTDA"
+  board: envelcontabilidade
+- company: "EXIMIA ROTINAS TRABALHISTAS LTDA"
+  board: eximia
+- company: "FAISTON"
+  board: faiston
+- company: "FORTLEV ENERGIA SOLAR LTDA"
+  board: fortlevsolar
+- company: "AUDIOFRAHM INDUSTRIA E COMERCIO DE ELETROELETRONICOS LTDA"
+  board: frahm
+- company: "FREEDOM VEICULOS ELETRICOS LTDA"
+  board: freedom
+- company: "ELIT DISTRIBUIDORA DE TINTAS E REVESTIMENTOS LTDA"
+  board: grupoargalit
+- company: "GRUPO COSTA NORTE DE COMUNICAÇÃO"
+  board: grupocostanorte
+- company: "GRUPO RCN DE COMUNICAÇÃO"
+  board: gruporcn
+- company: "TECHBIZ FORENSE DIGITAL LTDA"
+  board: grupotechbiz
+- company: "HORIZONTE DO SUCESSO ASSESSORIA DIGITAL LTDA"
+  board: hsmarketing
+- company: "INSTITUTO ANIMA SOCIESC DE INOVACAO, PESQUISA E CULTURA"
+  board: institutoanima
+- company: "INTELLTECH TECNOLOGIAS INTELIGENTES S.A"
+  board: intelltech
+- company: "INTERAGE RH"
+  board: interagerh
+- company: "IRRIGA GLOBAL"
+  board: irrigaglobal
+- company: "ISMA"
+  board: isma
+- company: "ITA EMPRESA DE TRANSPORTES LTDA"
+  board: itafrotas
+- company: "ITAPOÇOS"
+  board: itapocos
+- company: "RADIO ITATIAIA S.A"
+  board: itatiaia
+- company: "JS CONTADORES LTDA"
+  board: jscontadores
+- company: "Grupo Liderança"
+  board: liderancaservicos
+- company: "MIVITA CONSTRUTORA E INCORPORADORA LTDA"
+  board: mivita
+- company: "Nagro.co"
+  board: nagro
+- company: "Nayax Brasil"
+  board: nayaxbrasil
+- company: "NEOVIA INFRAESTRUTURA RODOVIARIA LTDA"
+  board: neovia
+- company: "NEVOLI TELECOM"
+  board: nevolitelecom
+- company: "OMAR DO RIO"
+  board: omardorio
+- company: "OrthoMundi"
+  board: orthomundi
+- company: "LM PANIFICACAO LTDA"
+  board: paesdoleo
+- company: "FOZ TROPICANA PARQUE DE AVES LTDA"
+  board: parquedasaves
+- company: "PLANTEC DISTRIBUIDORA DE PRODUTOS DE TELECOMUNICACOES E INFO"
+  board: plantec
+- company: "PRIMAQ AGRICOLA LTDA"
+  board: primaq
+- company: "QUALITYCERT CERTIFICACAO LTDA"
+  board: qualitycert
+- company: "R1 SERVICOS DE ENTREGA E LOGISTICA LTDA"
+  board: r3express
+- company: "RECHE.CO"
+  board: recheco
+- company: "ALERGOIMUNO W. ANTUNES LTDA"
+  board: redealis
+- company: "REDE HG COMBUSTIVEIS"
+  board: redehgcombustiveis
+- company: "Rehagro - Recursos Humanos No Agronegocio Ltda"
+  board: rehagro
+- company: "SAMBATECH"
+  board: sambatech
+- company: "SEAL SISTEMAS E TECNOLOGIA DE INFORMACAO LTDA"
+  board: sealsistemas
+- company: "SEFIT SERVICOS ESPECIALIZADOS DE FISIOTERAPIA DO TRABALHO LT"
+  board: sefit
+- company: "SERRA VERDE EXPRESS LTDA"
+  board: serraverdeexpress
+- company: "SGA TECNOLOGIA INTELIGENTE S.A."
+  board: sga
+- company: "SHAKERS CONSULTORIA E-COMMERCE E MIDIA DIGITAL LTDA"
+  board: shakersagencia
+- company: "SERVICOS MARITIMOS CONTINENTAL S.A."
+  board: smcontinental
+- company: "SUMMIT COSMETICS LATIN AMERICA ESPECIALIDADES COSMETICAS LTD"
+  board: summitcosmetics
+- company: "TEN Internet"
+  board: teninternet
+- company: "UNIMED PATOS DE MINAS COOPERATIVA DO TRABALHO MEDICO LT"
+  board: unimedpatosdeminas
+- company: "UNIMED DE SANTOS COOPERATIVA DE TRABALHO MEDICO"
+  board: unimedsantos
+- company: "NILO MAIA DISTRIBUIDORA LTDA"
+  board: vagasnilomaia
+- company: "VASCO DA GAMA SAF"
+  board: vascodagamasaf
+- company: "BLU"
+  board: vemprablu
+- company: "Vulcaflex Industria E Comercio Ltda"
+  board: vulcaflex
+- company: "AADVANCE - CONSULTORIA EM CREDITO E COBRANCA LTDA"
+  board: aadvance
+- company: "ASSOCIACAO BRASILEIRA DE RECURSOS EM TELECOMUNICACOES"
+  board: abrtelecom
+- company: "ADVICE OUTSOURCING LTDA"
+  board: advicegroup-vagas
+- company: "AMBSOLUTION ENGENHARIA AMBIENTAL LTDA"
+  board: ambsolution
+- company: "Ativa Gestão Contábil"
+  board: ativacontabil
+- company: "AVANTETECH SISTEMAS E SOLUCOES DIGITAIS LTDA"
+  board: avanteempresas
+- company: "Baratao Das Tintas Rondon Ltda"
+  board: barataodastintas
+- company: "Bertholdo Consultoria E Informatica Ltda"
+  board: bertholdo
+- company: "Beside Media"
+  board: besidemedia
+- company: "BLUWE COMERCIO E IMP DE COSMETICOS E CUTELARIA LTDA"
+  board: bluwe
+- company: "BOOP MIDIA LTDA"
+  board: boopmidia
+- company: "Ciapetro Distribuidora De Combustiveis Ltda"
+  board: ciapetro
+- company: "CORAB PERFORMANCE DIGITAL LTDA"
+  board: corabperformance
+- company: "CP CLAUDETE"
+  board: cpclaudeteboticario
+- company: "PRODUTOS ALIMENTICIOS CROQUES LTDA"
+  board: croques
+- company: "PW CUPOLA COMUNICACAO LTDA"
+  board: cupola
+- company: "DOCSTAGE SERVICOS CONTABEIS LTDA"
+  board: docstage
+- company: "DUX TELECOM LTDA"
+  board: duxnettelecom
+- company: "Elifegroup"
+  board: elifegroup
+- company: "EVO AGENCIA DE MARKETING DIGITAL LTDA"
+  board: evolu2on
+- company: "ASSOCIACAO EDUCACIONAL DE CIENCIAS DA SAUDE - AECISA"
+  board: faculdadepernambucanadesaude
+- company: "FUNDACAO ESCOLA DE COMERCIO ALVARES PENTEADO - FECAP"
+  board: fecap
+- company: "FLUKKA FARMACIA DE MANIPULACAO LTDA"
+  board: flukkapharma
+- company: "GH SOLUCIONADOR LOGÍSTICO"
+  board: ghlogistica
+- company: "AUTOFOZ VEICULOS LTDA"
+  board: gnpveiculos
+- company: "Golfleet Tecnologia Ltda"
+  board: golfleet
+- company: "DALE CONSTRUCOES E INCORPORACOES LTDA"
+  board: grupodalle
+- company: "Grupo GS"
+  board: grupogs
+- company: "HIPER SAUDE LTDA"
+  board: grupohipersaude
+- company: "GAIA SILVA GAEDE ADVOGADOS -PR"
+  board: gsgapr
+- company: "NAF NEGOCIOS IMOBILIARIOS LTDA"
+  board: guairaimoveis
+- company: "INSTRUVAL INSTRUMENTOS E SERVICOS LTDA"
+  board: instruval
+- company: "ISOCORD BPO & RH LTDA"
+  board: isocordrh
+- company: "Junqueira Empreendimentos Imobiliários Ltda"
+  board: junqueira
+- company: "LEV NEGÓCIOS"
+  board: levnegocios
+- company: "LOJAS TÁ QUE TÁ"
+  board: lojastaqueta
+- company: "Lonax Industria Brasileira de Lonas"
+  board: lonax
+- company: "MAXSOY ALIMENTOS LTDA"
+  board: maxsoy
+- company: "PX AGENCIAMENTO DE SERVICOS LTDA"
+  board: motoristapx
+- company: "MULTITTECH ENGENHARIA LTDA"
+  board: multittech
+- company: "MV PREC - SOLUÇÕES EM PRECATÓRIOS"
+  board: mvprec
+- company: "NBS SERVIÇOS DE COMUNICAÇÕES"
+  board: nbs
+- company: "NC EMPREENDIMENTOS PARTICIPACOES S/A"
+  board: nefrotalents
+- company: "NEO NEGOCIOS INOVADORES CORPORATIVOS LTDA"
+  board: neoventures
+- company: "PERFECT PAY TECNOLOGIA, SERVICOS E INTERMEDIACAO LTDA"
+  board: perfectpay
+- company: "PKNET SERVICOS DE TELECOMUNICACOES LTDA"
+  board: pknet
+- company: "ASSOCIACAO DE PROTECAO E BENEFICIO AO PROPRIETARIO DE VEICUL"
+  board: pluro
+- company: "PREVISA ASSESSORIA CONTABIL E EMPRESARIAL"
+  board: previsajobs
+- company: "QUANTICA SERVICOS ADMINISTRATIVOS LTDA"
+  board: quantica
+- company: "ONE7 SECURITIZADORA DE CREDITOS COMERCIAIS S/A"
+  board: queroserone7
+- company: "AZAP SISTEMAS PARA LOGISTICA LTDA"
+  board: recrutamentoazapfy
+- company: "ROCKFELLER BRASIL EDITORA E TREINAMENTO LTDA"
+  board: rockfeller
+- company: "RODOSAFRA TRANSPORTES RODOVIARIOS LTDA"
+  board: rodosafra
+- company: "Santa Maria Imóveis"
+  board: santamariaimoveis
+- company: "SETRAB ASSESSORIA EM SEGURANCA E MEDICINA DO TRABALHO LTDA"
+  board: setrabgroup
+- company: "SOMA URBANISMO S/A"
+  board: soma
+- company: "STAGE CONSULTING"
+  board: stageconsulting
+- company: "STAVIAS STANOSKI TERRAPLENAGEM PAVIMENTACAO E OBRAS LTDA"
+  board: stavias
+- company: "MOTORFORT COMERCIO ATACADISTA DE AUTO PECAS LTDA"
+  board: talentosmotorfort
+- company: "Universidade Católica Dom Bosco"
+  board: ucdb
+- company: "UNEED UNIVERSITY LTDA"
+  board: uneed
+- company: "UNIBEN ADMINISTRADORA DE BENEFICIOS EIRELI"
+  board: unibensaude
+- company: "UNIVAL INDUSTRIA E COMERCIO DE VALVULAS E ACESSORIOS INDUSTR"
+  board: unival
+- company: "Go.k Digital"
+  board: vagasgok
+- company: "CPG EMPREENDIMENTOS S/A"
+  board: valedocerrado
+- company: "VAMTEC GROUP"
+  board: vamtecgroup
+- company: "WEBER CONSULTORIA E ENGENHARIA AMBIENTAL LIMITADA"
+  board: weberambiental
+- company: "WINKER SOLUCOES TECNOLOGICAS S/A"
+  board: winker
+- company: "HASS & ARRUDA LTDA"
+  board: zoofertil
+- company: "ZUKKIN BRASIL INTELIGENCIA DE MERCADO LTDA"
+  board: zukkinbr
+- company: "4E EQUIPAMENTOS PARA CAMINHOES LTDA"
+  board: 4eatacadista
+- company: "ALTAS NETWORKS & TELECOM LTDA"
+  board: altasnet
+- company: "BARRETO E DOLABELLA ADVOGADOS ASSOCIADOS"
+  board: barretodolabella
+- company: "BIOCATH COMERCIO DE PRODUTOS HOSPITALARES LTDA."
+  board: biocath
+- company: "CAPTEI INTELIGENCIA EM NEGOCIOS IMOBILIARIOS LTDA"
+  board: capteii
+- company: "G2C ADMINISTRADORA DE BENEFICIOS"
+  board: carreirag2c
+- company: "Sense Bike"
+  board: carreiras2
+- company: "IWILL BRASIL IMPORTADORA E COMERCIO DE ARTIGOS DE INFORMATICA LTDA"
+  board: carreirasgrupoiwx
+- company: "BIGCARD ADMINISTRADORA DE CONVENIOS E SERVICOS LTDA"
+  board: cartaobigcard
+- company: "CASA COM VIDRO"
+  board: casacomvidro
+- company: "CHENUT, OLIVEIRA, SANTIAGO - SOCIEDADE DE ADVOGADOS"
+  board: chenut
+- company: "China Gate"
+  board: chinagate
+- company: "R B Dantas LTDA"
+  board: coagro
+- company: "CONSTRUIR LOTEADORA LTDA"
+  board: construirloteadora
+- company: "CPMH - COMERCIO E INDUSTRIA DE PRODUTOS MEDICO - HOSPITALARE"
+  board: cpmhdigital
+- company: "CST SERVICOS DE TI LTDA"
+  board: cst
+- company: "DELTA SOLUCOES EM INFORMATICA LTDA"
+  board: deltagestaopublica
+- company: "DIAS COSTA SOCIEDADE DE ADVOGADOS"
+  board: diascosta
+- company: "DIVINÍSSIMO"
+  board: divinissimoalimentos
+- company: "ECCOX SOFTWARE S.A."
+  board: eccox
+- company: "EEMOVEL SERVICOS DE INFORMACOES S/A"
+  board: eemovel
+- company: "F&B HOSPEDAGENS LTDA"
+  board: elmistihostels
+- company: "EM VIDROS INDUSTRIA E COMERCIO LTDA"
+  board: emvidros
+- company: "Eteg Tecnologia Da Informação S/a"
+  board: eteg
+- company: "EVOLUUM"
+  board: evoluum
+- company: "EXM PARTNERS ASSESSORIA EMPRESARIAL LTDA"
+  board: exmpartnerss
+- company: "Fundação FEAC"
+  board: feacvagas
+- company: "FINANTER - SERVICOS FINANCEIROS LTDA"
+  board: finanter
+- company: "FLUXO EQUIPAMENTOS ELETRONICOS LTDA"
+  board: fluxotesla
+- company: "Droom Investimento em Ativos Judiciais"
+  board: gaeadvocacia
+- company: "GERAIS EMPREENDIMENTOS HOSPITALARES LTDA"
+  board: gehospitalar
+- company: "GET RECURSOS HUMANOS LTDA"
+  board: getrh
+- company: "GOAT DIGITAL LTDA"
+  board: goatdigital
+- company: "Goo Resultados"
+  board: gooresultados
+- company: "FIBRATECH SPAZIO ACADEMIA LTDA"
+  board: grupofibratech
+- company: "MULTI INFORMATICA TECNOLOGIA E SERVICOS LTDA"
+  board: grupomulti
+- company: "OTIMIZA UGC CONSULTORIA EM TECNOLOGIA DA INFORMACAO LTDA"
+  board: grupootimiza
+- company: "GRUPO PROMINAS"
+  board: grupoprominas
+- company: "WIMOVEIS NEGOCIOS IMOBILIARIOS LTDA"
+  board: gruposilvanacarvalho
+- company: "SKILLCONSULTING, TECNOLOGIA E INFORMATICA LTDA"
+  board: gruposkill
+- company: "Haix Rental"
+  board: haixrental
+- company: "HASKELL COSMÉTICOS E OH MY! COSMETICS"
+  board: haskelleohmy
+- company: "ICRED SOLUCOES FINANCEIRAS S.A"
+  board: icred
+- company: "IGUAÇU DISTRIBUIDORA DE PRODUTOS ÓTICOS"
+  board: iguacudistribuidora
+- company: "INDOMITUM DESIGN LTDA"
+  board: incentiveme
+- company: "INSTITUTO CORDIAL DE DESENVOLVIMENTO SOCIAL LTDA"
+  board: institutocordial
+- company: "INSTITUTO NEUROSABER DE ENSINO - EIRELI"
+  board: institutoneurosaber
+- company: "INVENZI TECNOLOGIA LTDA."
+  board: invenzi
+- company: "IQNUS TECNOLOGIA COMERCIO E SERVICOS DE INFORMATICA LTDA"
+  board: iqnus
+- company: "ISSACAR SOLUÇÕES EMPRESARIAIS LTDA"
+  board: issacar
+- company: "JCA Contadores"
+  board: jcacontadores
+- company: "JETIMOB LTDA."
+  board: jetimob
+- company: "KUKA SYSTEMS DO BRASIL LTDA"
+  board: kuka
+- company: "Exame Análises Clínicas"
+  board: laboratorioexame
+- company: "LV NETWORK E TELECOMUNICACOES LTDA"
+  board: lvnetwork
+- company: "Macroplan Consultoria e Analytics"
+  board: macroplan
+- company: "Centro Espírita Caminho da Redenção"
+  board: mansaodocaminho
+- company: "MED-REVIEW EDUCACAO MEDICA LTDA"
+  board: medreview
+- company: "MUNDO MAKER EDUCACAO LTDA."
+  board: mundomaker
+- company: "NEVINE"
+  board: nevine
+- company: "ODONTOBIZ COMPANY LTDA"
+  board: odontobiz
+- company: "ORDAKOVSKI E TAVARES JUNIOR ADVOGADOS ASSOCIADOS"
+  board: otjadvogados
+- company: "PEDRO MONTELEONE VEICULOS E MOTORES LIMITADA"
+  board: pedromonteleone
+- company: "PLASTICA PRA TODOS LTDA"
+  board: plasticapratodos
+- company: "PLASTICOS M B LTDA."
+  board: plasticosmb
+- company: "PROJELET PROJETOS DE SISTEMAS PREDIAIS LTDA"
+  board: projelet
+- company: "Global AD Marketing Ltda"
+  board: queroserglobalader
+- company: "R3 INTERNET LTDA"
+  board: r3internet
+- company: "RELIEVE TECNOLOGIA"
+  board: relieve
+- company: "CENTRO DE ESTUDOS DA CULTURA E DO MEIO AMBIENTE DA AMAZÔNIA RIO TERRA"
+  board: rioterra
+- company: "SEMPRE TECNOLOGIA"
+  board: sempretecnologia
+- company: "SERVIPLAN SERVICOS ASSOCIADOS LTDA"
+  board: serviplan
+- company: "SIARCON ENGENHARIA LTDA"
+  board: siarconengenharia
+- company: "NOW SOLUCOES TECNOLOGICAS LTDA"
+  board: spacecontrata
+- company: "STEEL F. DESIGN ARQUITETURA LTDA"
+  board: steelfdesign
+- company: "SYNERGIE CONSULTING"
+  board: synergieconsulting
+- company: "TAGIA COMERCIO E IMPORTACAO LTDA"
+  board: tagia
+- company: "TAIPA SERVICOS E INFORMACOES CADASTRAIS LTDA"
+  board: taipafidc
+- company: "TECNOPLANTA FLORESTAL LTDA"
+  board: tecnoplanta
+- company: "Unimed Nordeste Paulista"
+  board: trabalheconoscoufenesp
+- company: "DUBAI CONSTRUTORA E INCORPORADORA LTDA"
+  board: vagasdubai
+- company: "HERMANUS VAN ASS E OUTROS"
+  board: vanasssementes
+- company: "VIACAO CARAVELAS LTDA"
+  board: vicaltransportes
+- company: "Wareline Do Brasil Desenvolvimento De Software Ltda"
+  board: wareline
+- company: "ABOISSA REPRESENTACOES LTDA"
+  board: aboissa
+- company: "ACTIVAS PLASTICOS INDUSTRIAIS LTDA"
+  board: activasbrasil
+- company: "Administradora de Imóveis Renascença"
+  board: admrenascenca
+- company: "Afixcode Patrimonio E Avaliacoes Ltda"
+  board: afixcode
+- company: "A Fórmula - Farmácia de Manipulação"
+  board: aformularecife
+- company: "AFORT INDUSTRIA DE PLASTICOS LTDA"
+  board: afort
+- company: "GRUPO AGROMERCANTIL"
+  board: agromercantil
+- company: "ARTHA PESQUISAS CLINICAS E CONSULTORIA LTDA"
+  board: arthapesquisas
+- company: "ASELCO INDUSTRIA, COMERCIO, IMPORTACAO E EXPORTACAO DE INSTR"
+  board: aselco
+- company: "AUDITSAFE CONSULTORIA EM RISCOS CORPORATIVOS LTDA."
+  board: auditsafe
+- company: "BANCO PAULISTA S.A."
+  board: bancopaulista
+- company: "BILHETERIA DIGITAL PROMOCAO E ENTRETENIMENTO LTDA"
+  board: bdtalentos
+- company: "BH-E LTDA"
+  board: bhever
+- company: "BMI - TELECOMUNICACOES E IMPORTACAO LTDA"
+  board: bmitelecom
+- company: "BROS LOGISTICA E TRANSPORTES LTDA"
+  board: broslogistica
+- company: "BUZZMONITOR TECNOLOGIA LTDA"
+  board: buzzmonitor
+- company: "COBMAIS TECNOLOGIA PARA RECUPERAÇÃO DE CRÉDITO LTDA"
+  board: cobmais
+- company: "COIMBRA & CHAVES SOCIEDADE DE ADVOGADOS"
+  board: coimbrachaves
+- company: "COMERCIAL DE AUTOPECAS KYB DO BRASIL LTDA"
+  board: comercialkybdobrasil
+- company: "CONEX ELETROMECANICA INDUSTRIA E COMERCIO LTDA"
+  board: conexled
+- company: "CK CONSTRUCOES E EMPREENDIMENTOS LTDA."
+  board: construtorack
+- company: "CORRETA AMBIENTAL LTDA"
+  board: corretaambiental
+- company: "DATA SYSTEM SOFTWARES LTDA"
+  board: datasystem
+- company: "MB HOTEIS E TURISMO S/A"
+  board: delmarhotel
+- company: "EVOLUCIONAL EDITORA E SERVICOS DE INFORMACAO EM INTERNET LTD"
+  board: evolucional
+- company: "FADESP"
+  board: fadesptivagas
+- company: "FISCAL.IO TECNOLOGIA DA INFORMACAO LTDA"
+  board: fiscalio
+- company: "PREVTOTAL LABORATORIO DE IMAGEM LTDA"
+  board: fonteimagem
+- company: "BC COMERCIALIZADORA DE ENERGIA LTDA"
+  board: grupobcenergia
+- company: "COMIDA BRASIL LTDA"
+  board: grupocastro
+- company: "PRIMAVERA AGRO S.A."
+  board: grupoprimavera
+- company: "ET DO BRASIL LTDA"
+  board: grupotracker
+- company: "Gshield"
+  board: gshield
+- company: "HOUER CONSULTORIA E CONCESSOES LTDA"
+  board: houer
+- company: "Ideia Glass"
+  board: ideiaglass
+- company: "Idg Engenharia E Consultoria Ltda"
+  board: idgengenharia
+- company: "IMPERIO DESENTUPIDORA E DEDETIZADORA LTDA"
+  board: imperio
+- company: "ION Sistemas"
+  board: ionsistemas
+- company: "LABORATORIO IMUNE LTDA"
+  board: laboratorioimune
+- company: "Leilo"
+  board: leilo
+- company: "Liga Norte Riograndense Contra O Cancer"
+  board: ligacontraocancer
+- company: "Comercial De Construcao 2001 Ltda"
+  board: lojas2001
+- company: "MakeOne Tecnologia Digital Ltda."
+  board: makeone
+- company: "MARINS BERTOLDI ADVOGADOS"
+  board: marinsbertoldiadvogados
+- company: "MARCOS DELLI RIBEIRO RODRIGUES SOCIEDADE INDIVIDUAL DE ADVOCACIA"
+  board: mdradvocacia
+- company: "MENTAL CLEAN PSICOLOGIA CLINICA E ASSESSORIA EM SAUDE MENTAL"
+  board: mentalclean
+- company: "SANTOS RIBEIRO SOCIEDADE INDIVIDUAL DE ADVOCACIA"
+  board: monteiroribeiro
+- company: "MULTPRIVATE AI LTDA"
+  board: multprivate
+- company: "NET FLEX LTDA"
+  board: netflex
+- company: "NOVA FUTURA INVESTIMENTOS"
+  board: novafutura
+- company: "NUCLEOGOV ASSESSORIA E TECNOLOGIA LTDA"
+  board: nucleogov
+- company: "PARADISO CORPORATE EMPREENDIMENTOS TURISTICOS LTDA"
+  board: paradisohoteis
+- company: "Bela Iaça Polpas De Frutas Ind. E Com. Ltda"
+  board: petruz
+- company: "POPCODE SERVICOS DE TECNOLOGIA DA INFORMACAO LTDA"
+  board: popcode
+- company: "NUCLEO DE GESTAO DO PORTO DIGITAL"
+  board: portodigital
+- company: "PRONTOMED PLANOS DE SAUDE LTDA"
+  board: prontomedmg
+- company: "Mlearn Educação Móvel Ltda"
+  board: qualifica
+- company: "KAPA CAPITAL FACILITIES LTDA"
+  board: recrutamentorh
+- company: "JARDIM ATLANTICO BEACH RESORT"
+  board: resortjardimatlantico
+- company: "Rodoparaná Implementos Rodoviários Ltda"
+  board: rodoparana
+- company: "ACOS F SACCHELLI LIMITADA"
+  board: sacchelli
+- company: "ACE SCHMERSAL ELETROELETRONICA INDUSTRIAL LTDA"
+  board: schmersal
+- company: "NOVA DISTRIBUIDORA ES LTDA"
+  board: sdedistribuidora
+- company: "CENTRO UNIVERSITARIO FAMA"
+  board: selecaofama
+- company: "SEMENTE CONSULTORIA EM NEGOCIOS E FINANCAS LTDA"
+  board: sementenegocios
+- company: "Seprol - IT by Experts"
+  board: seprol
+- company: "Silva E Freitas Sociedade De Advogados"
+  board: silvaefreitas
+- company: "SPEED IO - SERVICOS ESPECIALIZADOS LTDA"
+  board: speediojobs
+- company: "ST1 INTERNET"
+  board: st1internet
+- company: "SUPER LIGAS INDUSTRIA E COMERCIO DE METAIS LTDA"
+  board: superligas
+- company: "Symbiomics"
+  board: symbiomics
+- company: "SYSTEMICA INTELIGENCIA EM SUSTENTABILIDADE SA"
+  board: systemica-net-zero
+- company: "SISTEMA OESTE DE COMUNICACAO LTDA"
+  board: tcmtelecom
+- company: "TECNOLOG TRANSPORTE RODO AEREO E LOGISTICA EIRELI"
+  board: tecnolog
+- company: "LABORATORIO SOLOS E PLANTAS ANALISES AGRONOMICAS LTDA"
+  board: trabalheconoscosoloseplantas
+- company: "CONSTRUTORA TERRAZZAS LTDA"
+  board: trabalheconoscoterrazzas
+- company: "BRAINY HOTEL CONSULTING LTDA"
+  board: trulhoteis
+- company: "OURO INVESTIMENTOS"
+  board: tutorsparticipacoes
+- company: "Twygo"
+  board: twygo
+- company: "UNIMED RIO BRANCO"
+  board: unimedrb
+- company: "UNIMED VILHENA COOPERATIVA DE TRABALHO MEDICO"
+  board: unimedvilhena
+- company: "UPIX NETWORKS"
+  board: upixnetworks
+- company: "ALLBIOM SOLUÇÕES EM BIOPROCESSOS LTDA"
+  board: vagasallbiom
+- company: "EPH INCORPORADORA"
+  board: vagasephincorporadora
+- company: "FAESA - CENTRO UNIVERSITÁRIO"
+  board: vagasfaesa
+- company: "ZILLI ARMAZENS GERAIS S.A."
+  board: vagasterca
+- company: "PRINCIPIA EDUCACAO TECNOLOGIA E SERVICOS LTDA"
+  board: vempraprincipia
+- company: "MERINO BRASIL SHOES COMERCIO DE CALCADOS S/A"
+  board: yuool
+- company: "12 MIX SOLUCOES LTDA"
+  board: 12mixconcreto
+- company: "ABASTEK AUTOMACAO LTDA"
+  board: abastek
+- company: "INDORAMA BRASIL LTDA"
+  board: adfert
+- company: "AGAFARMA-ASSOCIACAO GAUCHA DE FARMACIAS E DROGARIAS INDEPEND"
+  board: agafarma
+- company: "ESCALA COMUNICACAO & MARKETING LTDA"
+  board: agenciaescala
+- company: "AGROCETE INDUSTRIA DE FERTILIZANTES LTDA"
+  board: agrocete
+- company: "ALPINO INDUSTRIA METALURGICA LTDA"
+  board: alpino
+- company: "APIS FLORA INDUSTRIAL E COMERCIAL LTDA"
+  board: apisflora
+- company: "APISNUTRI PRODUTOS ALIMENTICIOS LTDA"
+  board: apisnutri
+- company: "PRESENCA GLOBAL PREPARACAO DE DOCUMENTOS LTDA"
+  board: aquila
+- company: "BESA Medical Group"
+  board: besamedicalgroup
+- company: "Rede Biomax"
+  board: biomaxfarma
+- company: "Biomig Brasil"
+  board: biomigbrasil
+- company: "B.LOTTI MOVIMENTACAO DE CARGAS LTDA"
+  board: blotti
+- company: "BOWE LTDA"
+  board: bowe
+- company: "BRANDT MEIO AMBIENTE LTDA"
+  board: brandt
+- company: "BRIGANTI SOCIEDADE DE ADVOGADOS"
+  board: briganti
+- company: "Casarão Imóveis"
+  board: casaraoimoveis
+- company: "CIA DO LEITE"
+  board: ciadoleite
+- company: "CENTRO DE INVESTIGACAO E TRATAMENTO DA INFERTILIDADE HINODE"
+  board: citi
+- company: "CARVALHO, MACHADO E TIMM ADVOGADOS"
+  board: cmtadv
+- company: "COLABORATIVA"
+  board: colaborativa
+- company: "ALIANCA TECNOLOGIA S/A"
+  board: conciliadora
+- company: "CONSISANET SISTEMAS DE INFORMACAO LTDA"
+  board: consisasistemas
+- company: "CONTA JUNTO ASSESSORIA CONTABIL"
+  board: contajunto
+- company: "Copymaster"
+  board: copymaster
+- company: "Darwin Seguros"
+  board: darwinseguros
+- company: "DEBIAN SIGNAL COMUNICACAO MULTIMIDIA LTDA"
+  board: dbneton
+- company: "Disk Bananas"
+  board: diskbananas
+- company: "DPONET DESENVOLVIMENTO DE SISTEMAS E CONSULTORIA EM SEGURANC"
+  board: dponet
+- company: "DROGARIA NEISE LTDA"
+  board: drogariaconsolacao
+- company: "DUNEXA ENGENHARIA ELETRICA LTDA"
+  board: dunexa
+- company: "AOGE SISTEMAS S.A."
+  board: eloca
+- company: "DIGITIZEI INFORMATICA LTDA"
+  board: escalate
+- company: "INSTITUTO ESCOLA DO TEATRO BOLSHOI NO BRASIL"
+  board: escolabolshoi
+- company: "Esquadromil"
+  board: esquadromil
+- company: "FUNDACAO DE APOIO AO DESENVOLVIMENTO DA COMPUTACAO CIENTIFICA - FACC"
+  board: facc10
+- company: "FAST APLICATIVOS E SOLUCOES TECNOLOGICAS LTDA"
+  board: fastsolucoes
+- company: "FAZENDAS REUNIDAS BAUMGART LTDA"
+  board: fazendasreunidas
+- company: "FIVE VALIDATION LTDA"
+  board: fivevalidation
+- company: "ACADEMIA FORCE ONE LTDA"
+  board: forceoneacademia
+- company: "FRACTAL - Engenharia Hospitalar"
+  board: fractalengenharia
+- company: "GABRIEL MALHEIROS ADVOGADOS"
+  board: gabrielmalheiros
+- company: "GARCIA & GARCIA ADVOGADOS ASSOCIADOS"
+  board: garciaegarcia
+- company: "GESCONTABILIZE ASSESSORIA CONTABIL LTDA"
+  board: gescontabilize
+- company: "JUNGLE CONSULTORIA E SOLUCOES SOCIAIS LTDA"
+  board: gesuas
+- company: "GOBOTS SOLUCOES INTELIGENTES LTDA"
+  board: gobots
+- company: "CLASSIC MENS CLUB COMERCIO DE VESTUARIO E ACESSORIOS LTDA."
+  board: grupoclassic
+- company: "ESSENT JUS CONTABILIDADE E CONSULTORIA LTDA"
+  board: grupoessent
+- company: "INFINITY CLINIC CONSULTORIA E TREINAMENTOS LTDA."
+  board: grupoicom
+- company: "XEQUE MATE BEBIDAS LTDA"
+  board: grupoxequematebebidas
+- company: "HEALTHINK GESTAO ESTRATEGICA E INTELIGENCIA DE NEGOCIOS LTDA"
+  board: healthink
+- company: "HEAT COMPANY LTDA"
+  board: heatcompany
+- company: "Hexagon"
+  board: hexagonagriculture
+- company: "HomeHub"
+  board: homehub
+- company: "HOSPITAL DE OLHOS DE VITORIA"
+  board: hovitoria
+- company: "IAMIT SOLUCOES EM TECNOLOGIA LTDA"
+  board: iamitjobs
+- company: "inChurch"
+  board: inchurch
+- company: "INFLUENCY.ME & SUATV"
+  board: influencyme
+- company: "INOVADORA SISTEMAS DE GESTAO LTDA"
+  board: inovadorasistemas
+- company: "Inside Out PR"
+  board: insideoutcomunicacao
+- company: "INTERCOFFEE COMERCIO E INDUSTRIA LTDA"
+  board: intercoffee
+- company: "INTERTOX LTDA"
+  board: intertox
+- company: "KARAVELA - CONSULTORIA & CONTABILIDADE LTDA"
+  board: karavela
+- company: "KLINI PLANOS DE SAUDE LTDA"
+  board: klinisaude
+- company: "M2d Consultoria E Assessoria Em Informática E"
+  board: kognit
+- company: "LSL - LABORATORIO DE ANALISES CLINICAS LTDA"
+  board: laboratoriosaolucas
+- company: "KRAKEN PRODUTOS DIGITAIS LTDA."
+  board: loot-studios
+- company: "MADE4NOC SOLUCOES EM TI LTDA"
+  board: made4it
+- company: "MAQBUSCA LOCACAO DE MAQUINAS E EQUIPAMENTOS LTDA"
+  board: maqbusca
+- company: "MCAA ARQUITETOS LTDA"
+  board: mcaaarquitetos
+- company: "MEISKIN SWISS INOVACOES EM COMESTICA LTDA"
+  board: meiskin
+- company: "NEW OESTE SERVICOS DIGITAIS LTDA"
+  board: newoestetelecom
+- company: "NOBRE ASSESSORIA ORGANIZACIONAL LTDA"
+  board: nobreassessoriaorganizacional
+- company: "NOVI GESTAO INTELIGENTE DE IMOVEIS E CONDOMINIOS LTDA"
+  board: novi
+- company: "NUCLEO TECNOLOGIA E COMUNICACAO LTDA"
+  board: nucleotecnologia
+- company: "NWI TELECOM"
+  board: nwi
+- company: "ORGAFARMA ORGANIZACAO FARMACEUTICA LTDA"
+  board: orgafarmaorganizacaofarmaceutica
+- company: "OWNERINC DEVELOPERS S.A."
+  board: owntime
+- company: "Packis Industria e Comércio LTDA"
+  board: packis
+- company: "PAROMED ASSESSORIA EMPRESARIAL S/S LTDA"
+  board: paromed
+- company: "PAVESYS ENGENHARIA S/S LTDA"
+  board: pavesys
+- company: "DIANA CONFECÇÕES & CIA LTDA"
+  board: peixotogoncalves
+- company: "PERSEUS TECNOLOGIA DA INFORMACAO S.A."
+  board: perseus
+- company: "PERSONALGLOBAL ASSESSORIA ACADEMICA LTDA"
+  board: personalglobal
+- company: "PROFITTO GESTAO DE CONTRATOS LTDA"
+  board: profitto
+- company: "PROPER MARINE PROJETOS, CONSULTORIA E SERVICOS DE ENGENHARIA"
+  board: propermarine
+- company: "ROBERTA BONET ASSESSORIA E DESENVOLVIMENTO LTDA"
+  board: rbmindtraining
+- company: "REALCLOUD SISTEMAS LTDA"
+  board: realcloud
+- company: "REDE MULHER EMPREENDEDORA LTDA"
+  board: redemulherempreendedora
+- company: "Redesul"
+  board: redesul
+- company: "REPUTALE COMUNICACAO LTDA"
+  board: reputaletrama
+- company: "RETORNAR TECNOLOGIA LTDA"
+  board: retornar
+- company: "Vonex Telecom"
+  board: rhvonex
+- company: "Rotula Metalúrgica Ltda"
+  board: rotula
+- company: "ROYAL CONSTRUTORA E ENGENHARIA RIO PRETO LTDA"
+  board: royalconstrutora
+- company: "COLEGIO SALESIANO NOSSA SENHORA AUXILIADORA"
+  board: saleasianos-ba
+- company: "Grupo TEAGA"
+  board: seletivateaga
+- company: "COOPERATIVA DE CREDITO DE LIVRE ADMISSAO DA REGIAO DO CIRCUI"
+  board: sicoobcopermec
+- company: "SICOOB CREDICOPA"
+  board: sicoobcredicopa
+- company: "SOBE COMUNICACAO & NEGOCIOS LTDA"
+  board: sobe
+- company: "LABORATORIO DE PATOLOGIA CIRURGICA E CITOLOGIA LTDA"
+  board: solimlaboratorios
+- company: "CONCESSIONARIA SPMAR S.A"
+  board: spmar
+- company: "Mrh Veiculos Ltda."
+  board: stuttgart
+- company: "SULTS TECNOLOGIA LTDA"
+  board: sults
+- company: "C B MAGALHAES"
+  board: supermercadouniverso
+- company: "SUPER SAFRA COMERCIAL AGRICOLA LTDA."
+  board: supersafra
+- company: "Surfe Digital Ltda"
+  board: surfedigital
+- company: "S V INSTALACOES LTDA"
+  board: svinstalacoes
+- company: "TECNOEND SERVICOS DE INSPECAO, FABRICACAO E MONTAGEM INDUSTRIAL LTDA"
+  board: tecnoendmmb
+- company: "TERRA FIRME DA BAHIA LTDA"
+  board: terrafirme
+- company: "TECELAGEM NORTE CATARINENSE LTDA"
+  board: tnc
+- company: "CHQ GESTAO EMPRESARIAL E FRANCHISING LTDA"
+  board: trabalheconoscogrupochq
+- company: "TRANSIT BR LOGISTICA LTDA"
+  board: trabalheconoscotransitbr
+- company: "Cooperativa De Trabalho Medico De Pouso Alegre"
+  board: unimedsulmineira
+- company: "UNIMEK COMERCIO DE MATERIAL MEDICO-HOSPITALAR LTDA"
+  board: unimek
+- company: "PINBANK BRASIL INSTITUIÇAO DE PAGAMENTO S.A."
+  board: vemserpinbank
+- company: "WISER EDUCACAO S.A"
+  board: vende-c
+- company: "VICIO DE UMA ESTUDANTE CURSO PREPARATORIO PARA CONCURSOS LTD"
+  board: viciodeumaestudante
+- company: "WEB ESTRATEGICA"
+  board: webestrategica
+- company: "4U ED TECH DESENVOLVIMENTO DE SISTEMAS DE TECNOLOGIA PARA ED"
+  board: 4uedtech
+- company: "ABELV ENGENHARIA LTDA"
+  board: abelvtalentos
+- company: "ADVANTECH BRASIL LTDA"
+  board: advantech
+- company: "Alfaneo Legal AI"
+  board: alfaneo
+- company: "ALUGA MAIS APP LTDA"
+  board: alugamaisapp
+- company: "AMPLUS SAUDE E SEGURANCA DO TRABALHO EIRELI"
+  board: amplusaude
+- company: "APROVA TOTAL EDUCACAO S.A"
+  board: aprovatotalcarreiras
+- company: "ARTIA"
+  board: artia
+- company: "ASSOCIACAO DOS SERVIDORES MUNICIPAIS DA PREFEITURA DE BELO H"
+  board: assemp
+- company: "Astrus Digital"
+  board: astrusdigital
+- company: "ALMEIDA MACHADO SERVICOS EM GESTAO DE NEGOCIOS LTDA"
+  board: bluetechnology
+- company: "CONSORCIO BOULEVARD SHOPPING VILA VELHA"
+  board: boulevardshoppingvilavelha
+- company: "BRAYTON SELOS MECANICOS INDUSTRIAL LTDA."
+  board: brayton
+- company: "BRPHONIA PROVEDOR IP LTDA"
+  board: brphonia
+- company: "SELECT HOME EMPREENDIMENTOS IMOBILIARIOS LTDA"
+  board: cadenaimoveis
+- company: "FUNDACAO VISCONDE DE CAIRU EM RECUPERACAO JUDICIAL"
+  board: cairu
+- company: "PINHEIRO E SANTOS LTDA"
+  board: campelo
+- company: "CARTORIO DO 1º OFICIO 2ª ZONA DA SERRA"
+  board: cartorioserra
+- company: "SYNGULARID TECNOLOGIA LTDA"
+  board: certifica
+- company: "Cia Ambiental"
+  board: ciaambiental
+- company: "CONECTA ADS LTDA"
+  board: conectaads
+- company: "ACQUA DISTRIBUIDORA DE PERFUMES & COSMETICOS LTDA"
+  board: cpalcina
+- company: "DELFOS SERVICOS INTELIGENTES LTDA"
+  board: delfosim
+- company: "Dental Ita"
+  board: dentalita
+- company: "DE SANGOSSE"
+  board: desangosse
+- company: "DI2WIN TECNOLOGIA LTDA"
+  board: di2win
+- company: "E 21 Agencia De Multicomunicacao Ltda"
+  board: e21
+- company: "ELEVAR TELECOM LTDA"
+  board: elevartelecom
+- company: "ELEVE SOLUCOES EMPRESARIAIS LTDA"
+  board: elevesolucoes
+- company: "EM VIDROS IMPERATRIZ INDUSTRIA E COMERCIO LTDA"
+  board: emvidrosimperatriz
+- company: "ENGEHALL COMERCIO E TREINAMENTO LTDA"
+  board: engehalltreinamentos
+- company: "ENGENHO DE IDEIAS COMUNICACAO LTDA"
+  board: engenhodeideias
+- company: "ENGEPRED"
+  board: engepred
+- company: "COMPASS.UOL TECNOLOGIA LTDA"
+  board: everymind
+- company: "FABRICA DO LIVRO GRAFICA EDITORIAL LTDA"
+  board: fabricadolivro
+- company: "FERRAMAC FERRAMENTAS E EQUIPAMENTOS DE SEGURANCA LTDA"
+  board: ferramac
+- company: "FIKA FRIO"
+  board: fikafrio
+- company: "FINDME TECNOLOGIA LTDA"
+  board: findme
+- company: "FLEXPAG"
+  board: flexpag
+- company: "Fmx Solucoes Em Tecnologia Ltda"
+  board: fmx
+- company: "FONNET COMERCIO DE EQUIPAMENTOS DE TELECOMUNICACOES LTDA"
+  board: fonnet
+- company: "FORSETI TECNOLOGIA E COMUNICACAO LTDA"
+  board: forseti
+- company: "FUNDACAO DE DESENVOLVIMENTO CIENTIFICO E CULTURAL"
+  board: fundecc
+- company: "NIMBUS CONSULTORIA ESTRATEGICA LTDA"
+  board: gruponimbus
+- company: "ODONTOTOP FRANCHISING LTDA"
+  board: grupoodontotop
+- company: "PRIME ENERGY COMERCIALIZADORA DE ENERGIA LTDA"
+  board: grupoprime
+- company: "Organizacao Sete De Setembro De Cultura E Ensino Ltda"
+  board: gruposetedesetembro
+- company: "Grupo Terra Firme"
+  board: grupoterrafirme
+- company: "VERDÃO CONSTRUÇÃO E ACABAMENTO"
+  board: grupoverdao
+- company: "GAIA SILVA GAEDE ADVOGADOS-BH"
+  board: gsgabh
+- company: "GAIA, SILVA, GAEDE & ASSOCIADOS - SOCIEDADE DE ADVOGADOS"
+  board: gsgasp
+- company: "Head5 Engenharia Ltda"
+  board: head5
+- company: "Centro Paraibano De Clinica E Cirurgia De Olhos Ltda"
+  board: hospitalvisao
+- company: "JACO COELHO ADVOGADOS"
+  board: jacocoelhoadvogados
+- company: "K8 FINTECH"
+  board: k8fintech
+- company: "KEEPS"
+  board: keepslearning
+- company: "Kurier Tecnologia Em Informacao LTDA"
+  board: kurier
+- company: "LABORATORIO SANTA CECÍLIA"
+  board: labsantacecilia
+- company: "Laboratório Samuel Pessoa"
+  board: labspessoa
+- company: "M8 SISTEMAS DE INFORMATICA LTDA"
+  board: m8sistemas
+- company: "Madeiranit Brasília SIA"
+  board: madeiranitsia
+- company: "MANYMINDS"
+  board: manyminds
+- company: "MAX.IA EDUCATION S.A"
+  board: maxiaeducation
+- company: "MORAIS DE CASTRO COMERCIO E IMPORTACAO DE PRODUTOS QUIMICOS LTDA"
+  board: moraisdecastro
+- company: "MUSASHI DO BRASIL LTDA"
+  board: musashidobrasil
+- company: "Netwire Global"
+  board: netwireglobal
+- company: "NICEPLANET APOIO ADMINISTRATIVO LTDA"
+  board: niceplanet
+- company: "Now Contabilidade Digital"
+  board: nowcontabilidade
+- company: "OBUC GERENCIAMENTO DE INFORMACOES LTDA"
+  board: obuc
+- company: "TERMINAL DE COMBUSTIVEIS PAULINIA S.A"
+  board: oplalogistica
+- company: "Traterra Terraplenagem E Reflorestamento Ltda"
+  board: oportunidadestraterra
+- company: "POSTO SIMON LTDA"
+  board: postosimonimbituba
+- company: "Pronutrir"
+  board: pronutrir
+- company: "PSICO GESTOR TECNOLOGIA LTDA"
+  board: psicomanager
+- company: "QUICKLY TRAVEL AGENCIA DE VIAGENS E TURISMO LTDA."
+  board: quicklytravel
+- company: "READY TECNOLOGIA DA INFORMACAO LTDA."
+  board: readyti
+- company: "ZEN INTERNET E TELECOMUNICACAO LTDA"
+  board: recrutamentozentelecom
+- company: "RHF  Talentos - Unidade Nordeste"
+  board: rhfnordeste
+- company: "River Refrigerantes Ltda"
+  board: riverbebidas
+- company: "SEEG FIBRAS TELECOMUNICACOES LTDA"
+  board: seegfibras
+- company: "COOPERATIVA DE CREDITO SICOOB 3 COLINAS"
+  board: sicoob3colinas
+- company: "SIMOVA TECNOLOGIA E SERVICOS DE INFORMATICA LTDA"
+  board: simova
+- company: "AGENCIA SOCIAL TAILORS LTDA."
+  board: socialtailors
+- company: "STI CONSULTORIA"
+  board: sticonsultoria
+- company: "PRODUTOS ALIMENTICIOS SUPERBOM INDUSTRIA E COMERCIO LTD"
+  board: superbom
+- company: "TRANSPORTADORA FG EXPRESS LTDA"
+  board: transportadorafgexpress
+- company: "Agência Tribo"
+  board: tribo
+- company: "UNIATIVA UNIVERSIDADE CORPORATIVA LTDA"
+  board: uniativa
+- company: "UNIMED SERGIPE - COOPERATIVA DE TRABALHO MEDICO"
+  board: unimedsergipe
+- company: "UNIODONTO PORTO ALEGRE COOPERATIVA ODONTOLOGICA LTDA"
+  board: uniodontopoa
+- company: "FUCK DISTRIBUIDORA DE AUTO PECAS LTDA"
+  board: vagasfuckautopecas
+- company: "IVR LIVROS LTDA"
+  board: vagasivrnet
+- company: "MAURICEA ALIMENTOS DO NORDESTE LTDA"
+  board: vagasmauriceaba
+- company: "VATA DOJO TREINAMENTO PROFISSIONAL E EDUCACAO FINANCEIRA LTD"
+  board: vatadojo
+- company: "VEIGA & CASTRO LTDA"
+  board: veigacastro
+- company: "Trans Kothe Transportes Rodoviarios S/a"
+  board: vemprakothe
+- company: "Brazmax"
+  board: vemserbrazmax
+- company: "VILLA CAMARÃO"
+  board: villacamarao
+- company: "ZABALETA CONSTRUTORA E INCORPORADORA LTDA"
+  board: zabaleta
+- company: "ZURIEL CONTABIL LTDA"
+  board: zurielcontabil
+- company: "4blue"
+  board: 4blue
+- company: "94 MARKETING & FOOTBALL LTDA"
+  board: 94marketingefootball
+- company: "Acimaq"
+  board: acimaqequipamentos
+- company: "ACS SERVICOS E SOLUCOES EM INFORMATICA LTDA"
+  board: activecs
+- company: "ALFALAGOS LTDA."
+  board: alfalagos
+- company: "ALIATTO SERVICOS LTDA"
+  board: aliatto
+- company: "ASSOCIACAO PAULISTA DE CIRURGIOES DENTISTAS"
+  board: apcd
+- company: "ASSOCIACAO DAS EMPRESAS DE COMUNICACAO E PUBLICIDADE - ABAP"
+  board: banco-de-talentos-abap
+- company: "BERTUZZI ASSESSORIA E GESTAO DE NEGOCIOS LTDA"
+  board: bertuzzi
+- company: "BEST LIFE GESTAO DE PESSOAS E SERVICOS LTDA"
+  board: bestlife
+- company: "BOTAFOGO DE FUTEBOL E REGATAS"
+  board: botafogofr
+- company: "CARTORIO DO 7 TABELIONATO DE NOTAS DA COMARCA DA CAPITAL"
+  board: cartoriofioretti
+- company: "CLASSE INDUSTRIA E ARTEFATOS DE COURO LTDA"
+  board: classe
+- company: "CLIMATE VENTURES"
+  board: climateventures
+- company: "INSTITUTO CORACAO DE JESUS LTDA"
+  board: colegioicj
+- company: "CREDIPRONTO"
+  board: credipronto
+- company: "DYNAMIC TRAVEL GROUP VIAGENS S.A."
+  board: dynamictravel
+- company: "EGESTAO SERVICOS DE TECNOLOGIA DA INFORMACAO LTDA."
+  board: e-gestao
+- company: "ENGEHALL ELETRICA BRASIL LTDA"
+  board: engehall
+- company: "ESL CONSULTORIA E SERVICOS EM INFORMATICA LTDA"
+  board: eslsistemas
+- company: "Fabíola Fois Gestão de Pessoas"
+  board: fabiolafois
+- company: "GEP SOLUCOES EM COMPLIANCE LTDA"
+  board: gepcompliance
+- company: "GI INDUSTRIA DE PRODUTOS PLASTICOS LTDA"
+  board: granplast
+- company: "GRLIS SECURITIZADORA S.A."
+  board: grlis
+- company: "Inacio Carlos Urban e Outros - Fazenda Farroupilha"
+  board: grupofarroupilha
+- company: "JUNIOR CLUBE DE BENEFICIOS"
+  board: grupolins
+- company: "MVT EDUCACAO LTDA"
+  board: grupomovimenta
+- company: "GRUPO PARQUE DAS FLORES"
+  board: grupoparquedasflores
+- company: "SABAD SOLUCOES EM SERVICOS ADMINISTRATIVOS LTDA."
+  board: grupovic
+- company: "IGREJA BATISTA ATITUDE DA BARRA DA TIJUCA"
+  board: igrejabatistaatitude
+- company: "IMUNOVA ANALISES BIOLOGICAS LTDA"
+  board: imunova
+- company: "INMETA SISTEMA LTDA"
+  board: inmeta
+- company: "INTERNACIONAL ASSESSORIA ADUANEIRA LTDA"
+  board: internacionalsrv
+- company: "JBT MAREL BRASIL LTDA"
+  board: jbt
+- company: "JOAO DOMINGOS ADVOGADOS ASSOCIADOS"
+  board: joaodomingosadv
+- company: "José Roberto Santos"
+  board: jrscalculojudicial
+- company: "Juscon Assessoria Contábil Ltda - EPP"
+  board: juscon
+- company: "KYTE TECNOLOGIA DE SOFTWARE LTDA"
+  board: kyte
+- company: "LABVITAL ANÁLISES CLÍNICAS E SAÚDE LTDA"
+  board: labvital
+- company: "LAER RJ ENGENHARIA LTDA"
+  board: laerrj
+- company: "Lemobs"
+  board: lemobs
+- company: "LISTRA TECNOLOGIA E MARKETING LTDA"
+  board: listradigital
+- company: "LIT SOLUTIONS LTDA"
+  board: litsolutions
+- company: "LONDRICIR COMERCIO DE MATERIAL HOSPITALAR LTDA"
+  board: londricir
+- company: "MACHADO & PEREIRA ADVOGADOS ASSOCIADOS S/S"
+  board: machadoepereira
+- company: "K M O TELECOMUNICACOES LTDA"
+  board: meetasolutions
+- company: "MERCADÃO DOS MEDICAMENTOS"
+  board: mercadaodosmedicamentos
+- company: "METHA ENERGIA S/A"
+  board: methaenergia
+- company: "MINASLASER LTDA"
+  board: minaslaser
+- company: "MULTIPEDIDOS"
+  board: multipedidos
+- company: "NATURATIVA FARMACIA LTDA"
+  board: naturativa
+- company: "NOVAFORMA PLASTICOS LTDA"
+  board: novaforma
+- company: "ORGAO DE GESTAO DE MAO DE OBRA DO TRABALHO PORT AVULSO"
+  board: ogmo-itaqui
+- company: "O NOVO MERCADO ESCOLA DE MARKETING LTDA"
+  board: onovomercado
+- company: "OPEA SECURITIZADORA S.A."
+  board: opea
+- company: "CEICO - CENTRO DE IMAGEM"
+  board: oportunidadesceico
+- company: "APUANA COMERCIO E SERVICOS LTDA"
+  board: optivisionbrasil
+- company: "reidospaes.com"
+  board: oreidospaes
+- company: "Orienta Desenvolvimento Humano Ltda ME"
+  board: orienta
+- company: "F5 SOFTWARE LTDA"
+  board: osbsoftware
+- company: "DINIZ FRANCHISING ADMINISTRACAO LTDA"
+  board: oticasdiniz
+- company: "FABIANA DE SOUZA LIRA"
+  board: palaciodeoyo
+- company: "SOLUA COMERCIAL LTDA."
+  board: phytoterapica
+- company: "PINTOS LTDA"
+  board: pintos
+- company: "POROS CONSTRUTORA LTDA"
+  board: porosconstrutora
+- company: "Power Tuning"
+  board: powertuning
+- company: "PROD AGENCIA DIGITAL LTDA"
+  board: prod
+- company: "RAVEL TECNOLOGIA EIRELI"
+  board: ravel
+- company: "REDE DE ENSINO GENOMA"
+  board: redegenoma
+- company: "Robbu - Soluções para comunicação de negócios"
+  board: robbu
+- company: "SAAM Auditoria"
+  board: saamauditoria
+- company: "SANTINVEST S/A CREDITO FINANCIAMENTO E INVESTIMENTOS"
+  board: santinvest
+- company: "SEMEAR ENGENHARIA AGRONOMICA LTDA"
+  board: semear
+- company: "OILEMA COMÉRCIO DE SEMENTES"
+  board: sementesoilema
+- company: "Shield Bank"
+  board: shieldbank
+- company: "COOPERATIVA DE CREDITO DE LIVRE ADMISSAO DE SANTA CRUZ DAS P"
+  board: sicoobcredicucar
+- company: "SICOOB CREDIMONTES - COOPERATIVA DE CREDITO DE LIVRE ADMISSA"
+  board: sicoobcredimontes
+- company: "SIG 2000 INFORMATICA LTDA"
+  board: sig2000
+- company: "SMARTI TECNOLOGIA LTDA"
+  board: smarti
+- company: "STATTUS4 CIDADES INTELIGENTES E SUSTENTABILIDADE LTDA"
+  board: stattus4
+- company: "SW CAPITAL HUMANO LTDA"
+  board: swcapitalhumano
+- company: "T2M Test to Market Ltda"
+  board: t2mlab
+- company: "Tasken"
+  board: tasken
+- company: "Tiflux Sistema De Gestao Ltda"
+  board: tiflux
+- company: "TOLEDO DISTRIBUIDOR DE FERRAGENS LTDA"
+  board: timetoledo
+- company: "Contmatic"
+  board: trabalhecomacontmatic
+- company: "DISTRIBUIDORA DE BEBIDAS HEYDER CURY LTDA"
+  board: trabalheconoscocurydistribuidora
+- company: "MAZZUTTI COMERCIO DE VEICULOS LTDA"
+  board: trabalhenogrupomazzutti
+- company: "Ultra LIMS"
+  board: ultralims
+- company: "UMOV.ME TECNOLOGIA S.A."
+  board: umovme
+- company: "CLICK SPEED SERVICOS DE TELECOMUNICACOES EIRELI"
+  board: velfibra
+- company: "VENÂNCIO SHOPPING"
+  board: venancioshopping
+- company: "Vertus Agency"
+  board: vertusagency
+- company: "VIA EDUCATION S.A"
+  board: viaeducation
+- company: "VIK S.A."
+  board: vik
+- company: "VIPPHONE CONTACT CENTER SOLUTIONS"
+  board: vipphone
+- company: "VISAO ASSISTENCIA TECNICA E ADMINISTRATIVA LTDA"
+  board: visanco
+- company: "EDITORA VISEU LTDA"
+  board: viseu
+- company: "WORLDNET SERVICOS DE TELECOMUNICACOES LTDA"
+  board: worldnet
+- company: "LINE UP EVENTOS S/A"
+  board: zumbrazil

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -6,3 +6,571 @@
   board: cheesecakelabs
 - company: Way2
   board: way2
+
+# --- harvested via Wayback CDX + live API validation 2026-06-21 ---
+- company: "Gulfstream Strategic Placements, LLC"
+  board: gulfstreamsp
+- company: "FutureRecruit"
+  board: futurerecruit
+- company: "Bonaventure Senior Living"
+  board: bonaventureseniorliving
+- company: "Electrical Consultants, Inc."
+  board: eciusa
+- company: "Adidev Technologies Inc"
+  board: adidevtechnologies
+- company: "Cityview Helicopter Tours"
+  board: cityviewhelicoptertours
+- company: "The Cannabist Company"
+  board: colcare
+- company: "Allen Online"
+  board: allendigital
+- company: "Anderson Columbia Co. Inc."
+  board: andersoncolumbia
+- company: "A Services Group (ASG)"
+  board: aservicesgroup
+- company: "Exotel Techcom Pvt Ltd"
+  board: exotel
+- company: "Batson-Cook Construction"
+  board: batsoncook
+- company: "Datawords"
+  board: datawords
+- company: "American University In the Emirates (AUE)"
+  board: americanuniversity
+- company: "ALICE + OLIVIA"
+  board: aliceandolivia
+- company: "Easebuzz Pvt Ltd"
+  board: easebuzz
+- company: "Elliott-Lewis | Sautter Crane | AA Duckett"
+  board: elliottlewis
+- company: "EPC Services Company"
+  board: epcservices
+- company: "Caixa Mágica Software"
+  board: caixamagica
+- company: "D4C Dental Brands"
+  board: dentistryforchildren
+- company: "Counsyl"
+  board: counsyl
+- company: "Flying Teachers"
+  board: flyingteachers
+- company: "Muehlhan Wind Service"
+  board: endiprev
+- company: "2 WorkOnline"
+  board: 2workonline1
+- company: "American Jewish Committee"
+  board: ajc
+- company: "Data Entry Direct"
+  board: dataentrydirect
+- company: "1-Stop Asia"
+  board: 1stopasia
+- company: "Angel Of The Winds Casino Resort"
+  board: angelofthewinds
+- company: "BookMyShow"
+  board: bookmyshow
+- company: "Bassett Mechanical"
+  board: bassettmechanical
+- company: "Bay Area Community Services"
+  board: bayareacs
+- company: "Beblue"
+  board: beblue
+- company: "APS Bank plc"
+  board: apsbank
+- company: "Great Plains Communications"
+  board: gpcom
+- company: "Cambridge Computer Services, Inc"
+  board: cambridgecomputer
+- company: "ECM Energy Services"
+  board: ecmenergy
+- company: "Frontline Managed Services"
+  board: frontlinems
+- company: "AXON-Networks"
+  board: axon-networks
+- company: "ClinicMind"
+  board: clinicmind
+- company: "AllianceIT"
+  board: allianceit65001
+- company: "CAST Software Inc."
+  board: castsoftware
+- company: "Ekya Schools"
+  board: ekyaschools
+- company: "GhFly"
+  board: ghfly
+- company: "Celero Commerce"
+  board: celerocommerce
+- company: "Dental Choice"
+  board: dentalchoice
+- company: "Gerald Group"
+  board: gerald
+- company: "FarMart"
+  board: farmart
+- company: "Bennington College"
+  board: bennington
+- company: "BRAC INTERNATIONAL"
+  board: bracinternational
+- company: "Celtra, Inc."
+  board: celtra
+- company: "CMR University"
+  board: cmruni
+- company: "EDCLUB, INC"
+  board: edclubinc
+- company: "Agara"
+  board: agaralabs
+- company: "Alvine"
+  board: alvine
+- company: "Anadarko"
+  board: anadarko
+- company: "Bill Dodge Auto Group"
+  board: bdag
+- company: "Conco, Inc."
+  board: concoconstruction
+- company: "DogPlanet"
+  board: dogplanet
+- company: "Domino´s Pizza RD"
+  board: dominospizzard
+- company: "Environment for the Americas"
+  board: environmentamericas
+- company: "Freestone Property Group"
+  board: freestonepg
+- company: "Grassroots Voter Outreach"
+  board: grassrootsvoter
+- company: "First Baptist Church of Rogers"
+  board: fbcrogers
+- company: "Growth Acceleration Partners"
+  board: growthaccelerationpartners
+- company: "24x7Table"
+  board: 24x7table
+- company: "Abesse Zrt."
+  board: abesse
+- company: "Christ Community Church"
+  board: cccjobs
+- company: "The Chapin School"
+  board: chapin
+- company: "Codemotion"
+  board: codemotion
+- company: "CS50"
+  board: cs50
+- company: "Didion Orf Recycling"
+  board: didionorfrecycling
+- company: "Dito"
+  board: dito
+- company: "Foodora France"
+  board: foodorafrance
+- company: "Giltner Logistics"
+  board: giltner
+- company: "Grapevine"
+  board: grapevine
+- company: "Agencia Mestre"
+  board: agenciamestre
+- company: "Allisonville Nursery by Sullivan"
+  board: allisonville
+- company: "Cybrilla"
+  board: cybrilla
+- company: "4Theweb"
+  board: 4theweb
+- company: "Anduin Transactions"
+  board: anduin
+- company: "Aplopio1"
+  board: aplopio1
+- company: "Bergmeyer Associates"
+  board: bergmeyer
+- company: "Cityflo"
+  board: cityflo
+- company: "Cupix"
+  board: cupix
+- company: "Darwin Labs Pvt Ltd."
+  board: darwinlabs
+- company: "Dreamclinic Massage &amp; Acupuncture"
+  board: dreamclinic84937
+- company: "Dyverse"
+  board: dyversemarketing
+- company: "Focus School Software"
+  board: focusschoolsoftware
+- company: "Forum voor Democratie"
+  board: forumvoordemocratie
+- company: "Aerosonic"
+  board: aerosonic
+- company: "Anchor"
+  board: anchor
+- company: "Advertising Production Resources"
+  board: aprco
+- company: "Boxmyspace"
+  board: boxmyspace
+- company: "BRCondos S/A."
+  board: brcondos
+- company: "CaribbeanCatalyst"
+  board: caribbeancatalyst
+- company: "Certegy Payment Solutions, LLC"
+  board: certegy
+- company: "doyouconvert.com"
+  board: doyouconvert
+- company: "Eagle Technologies, Inc."
+  board: eagletechva
+- company: "Eclypsium"
+  board: eclypsium
+- company: "Fitfyles LLP"
+  board: fitfyles
+- company: "Grote Family of Companies"
+  board: groteenterprises
+- company: "Lattice Technologies Pvt Ltd"
+  board: 1lattice
+- company: "Ambrosia Labs"
+  board: ambrosialabs
+- company: "Ardent Learning, Inc."
+  board: ardentlearninginc
+- company: "BDS Marketing"
+  board: bdsmktg
+- company: "Bionews, Inc."
+  board: bionews
+- company: "CRNCY Group"
+  board: crncybelize
+- company: "CV Ease"
+  board: cvease
+- company: "dealerVERO"
+  board: dealervero
+- company: "Develer Srl"
+  board: develer
+- company: "DreamYard Project"
+  board: dreamyard
+- company: "Eroslabs"
+  board: eroslabs
+- company: "Finario"
+  board: finario
+- company: "Frontier Foundry"
+  board: frontierfoundry
+- company: "Airwoot"
+  board: airwoot
+- company: "Altair Real Estate Services"
+  board: altair
+- company: "Aquila Software Group"
+  board: aquilasw
+- company: "Ascella Technologies, Inc."
+  board: ascellatech
+- company: "BuyAnyCoin"
+  board: buyanycoin
+- company: "Career Advancement Group"
+  board: careeradvancementgroup
+- company: "Chatter Buzz"
+  board: chatterbuzzmedia
+- company: "Classe365"
+  board: classe365
+- company: "Crowdlinker"
+  board: crowdlinker
+- company: "DataCore Software"
+  board: datacore
+- company: "Dayton Leadership Academies"
+  board: daytonleadershipacademies
+- company: "www.exigotechnology.com"
+  board: exigo
+- company: "Forge Performance Group"
+  board: forgeperform
+- company: "Fresh Kitchen + Juice Bar"
+  board: fresh
+- company: "Acquis Consulting"
+  board: acquisconsulting
+- company: "Animal Emergency &amp; Specialty Center of Knoxville"
+  board: aesc
+- company: "AQUILA Commercial"
+  board: aquilacommercial
+- company: "Servicolt"
+  board: avisbudgetpaylessrd
+- company: "AZ-Recruiting"
+  board: azrecruiting
+- company: "Beevolve"
+  board: beevolve
+- company: "Big Wangs"
+  board: bigwangs
+- company: "Berman Sobin Gross LLP"
+  board: bsglaw
+- company: "C2 Labs, Inc"
+  board: c2labs
+- company: "Cactus Communications"
+  board: cactus
+- company: "CarDekho"
+  board: cardekho
+- company: "Coos-Curry Electric Cooperative, Inc."
+  board: cooscurryelectric
+- company: "Desert View Schools"
+  board: desertviewschools
+- company: "Eagle Brook Church"
+  board: eaglebrookchurch
+- company: "Editor"
+  board: editor
+- company: "Embark"
+  board: embark
+- company: "Oakland Children's Fairyland"
+  board: fairyland
+- company: "Glenrecruiter"
+  board: glenrecruiter
+- company: "Alameda County Community Food Bank"
+  board: accfb
+- company: "Altana Federal Credit Union"
+  board: altanafcu
+- company: "AB PAC"
+  board: americanbridgepac
+- company: "Apexft"
+  board: apexft
+- company: "Advanced Research Projects Agency-Energy (ARPA-E)"
+  board: arpae
+- company: "ART Engineering LLC"
+  board: artengineeringllc
+- company: "Athens Micro"
+  board: athensmicro
+- company: "BRECOflex CO., L.L.C"
+  board: brecoflex
+- company: "Bryan Construction"
+  board: bryanconstruction
+- company: "Caliber Corporate Advisers"
+  board: calibercorporateadvisers
+- company: "Careers From Home"
+  board: careers
+- company: "CASE"
+  board: case
+- company: "Clean Power Research"
+  board: cleanpower
+- company: "Cloudscaling / EMC"
+  board: cloudscaling
+- company: "Clover Search Works"
+  board: cloversearchworks
+- company: "Defense Trade Solutions"
+  board: defensetrade
+- company: "Drip Capital"
+  board: dripcapital
+- company: "Durbar Software"
+  board: durbar
+- company: "Element Technology, LLC"
+  board: elementtech
+- company: "encircle.io"
+  board: encircleio
+- company: "Franklin County Memorial Hospital"
+  board: fcmh
+- company: "Firespring"
+  board: firespring
+- company: "Football Radar"
+  board: footballradar
+- company: "Fx2 Software Factory"
+  board: fx2sf
+- company: "Development Counsellors International"
+  board: aboutdci
+- company: "Adaptas Solutions"
+  board: adaptas
+- company: "Addepar"
+  board: addepar
+- company: "AMS"
+  board: akamaisolutions
+- company: "Art Escape"
+  board: artescapenh
+- company: "Artificial Solutions"
+  board: artificialsolutions46581
+- company: "AUC Ventures Private Limited"
+  board: aucventures
+- company: "Baker Tilly - Management Partners"
+  board: bakertilly
+- company: "Boonjob370"
+  board: boonjob370
+- company: "Boston Technology"
+  board: bostontechnology
+- company: "Bostwick Bakery"
+  board: bostwickbakery
+- company: "The Cathedral School of St. John the Divine"
+  board: cathedralnyc
+- company: "Commsignia"
+  board: commsignia
+- company: "Convenia"
+  board: convenia
+- company: "Cultivate"
+  board: cultivateteam
+- company: "DN Capital"
+  board: dncapital
+- company: "Stratforce and ESP"
+  board: estrat
+- company: "Eventifier"
+  board: eventifier
+- company: "Everest Minds"
+  board: everestminds
+- company: "Fancandy"
+  board: fancandy
+- company: "Flatle"
+  board: flatle
+- company: "GBSH Consult Group"
+  board: gbshconsult
+- company: "GharPay"
+  board: gharpay
+- company: "Gloss"
+  board: gloss
+- company: "Grupo Rodz"
+  board: gruporodz
+- company: "Golden State Farm Credit"
+  board: gsfarmcredit
+- company: "1FORCE"
+  board: 1force
+- company: "A&amp;L Royal Event Planning"
+  board: aandlroyaleventplanning
+- company: "Admatic"
+  board: admatic
+- company: "AE Works"
+  board: aeworks
+- company: "Aixial Group"
+  board: aixialgroup
+- company: "aja"
+  board: aja
+- company: "Allianz Worldwide Care"
+  board: allianz
+- company: "Âncora Offices Escritórios Virtuais"
+  board: ancoraoffices
+- company: "American Personnel Managers &amp; Consultants"
+  board: apmci
+- company: "Appco"
+  board: appco
+- company: "AppliancePartsPros.com"
+  board: appliancepartspros
+- company: "Avaaz"
+  board: avaaz
+- company: "Aversoft"
+  board: aversoft
+- company: "Basetao"
+  board: basetao
+- company: "Bazirkl"
+  board: bazirkl
+- company: "B&amp;C Call Center Solutions"
+  board: bcrecruiting
+- company: "Beaconcollege"
+  board: beaconcollege
+- company: "Beaird Group"
+  board: beaird
+- company: "Bench Accounting"
+  board: bench
+- company: "Bigshen Technologies"
+  board: bigshen
+- company: "Biosyntia"
+  board: biosyntia
+- company: "BlueBolt"
+  board: bluebolt
+- company: "Bluegrass Live Operators"
+  board: blueops
+- company: "BMNY"
+  board: bmny
+- company: "BoaConsulta"
+  board: boaconsulta
+- company: "Borda Technology"
+  board: bordatech
+- company: "Brand Impact Marketing"
+  board: brandimpact
+- company: "Brand Lovers"
+  board: brandlovers
+- company: "breakwater"
+  board: breakwater
+- company: "Bristol &amp; Bates"
+  board: bristol
+- company: "Bud Lab"
+  board: budlab
+- company: "CARE S.A. (Cactus shoppi)"
+  board: cactusshoppi
+- company: "Calebjwilson"
+  board: calebjwilson
+- company: "B&amp;C Call Center Solutions"
+  board: callcentersolutions
+- company: "Caltech Surveillance"
+  board: caltechsecure
+- company: "CAMARA &amp; COMPANY"
+  board: camaraandcompany1
+- company: "Carnegie Foundation"
+  board: carnegiefoundationcareers
+- company: "Cascadia Consulting Group, Inc."
+  board: cascadiaconsulting
+- company: "Cassaday &amp; Company"
+  board: cassaday
+- company: "CCJK Technologies"
+  board: ccjk
+- company: "Ceros"
+  board: ceros
+- company: "Children'sHealthCenter"
+  board: childrenshealthcenter
+- company: "Medsave Healthcare TPA Ltd"
+  board: cipla
+- company: "Ciplex"
+  board: ciplex
+- company: "Climate Action Campaign"
+  board: climateactioncampaign
+- company: "Cloudeeva Inc"
+  board: cloudeeva
+- company: "Cloudspace"
+  board: cloudspace
+- company: "Cold Spark Media"
+  board: coldspark
+- company: "Compliance Team"
+  board: complianceteamllc
+- company: "City of Conyers, GA"
+  board: conyersga
+- company: "Cousin &amp; Co. Inc"
+  board: cousinco
+- company: "C.A. Curtze Co."
+  board: curtzefoodservice
+- company: "Custom Orthopaedic Solutions"
+  board: customorthopaedics
+- company: "cwrs"
+  board: cwrs
+- company: "Datatrax"
+  board: datatrax
+- company: "Decathlon China"
+  board: decathlonchina
+- company: "Dexterous Organizing"
+  board: dexterousorganizing
+- company: "Helios and Matheson Analytics Inc"
+  board: dhiraj
+- company: "DIAMIER INC"
+  board: diamier
+- company: "Digital Shift Corporation"
+  board: digitalshift
+- company: "Matador Experiential"
+  board: discovermatador
+- company: "MFS WealthCare"
+  board: drsuechicago
+- company: "DSG Call Center"
+  board: dsgcallcenter
+- company: "LegalShield"
+  board: dslindwall
+- company: "Ebates"
+  board: ebates
+- company: "Echoglobe"
+  board: echoglobe
+- company: "Egifter"
+  board: egifter
+- company: "Elevate97"
+  board: elevate97
+- company: "Elite Tournaments"
+  board: elitetournaments
+- company: "enFocus"
+  board: enfocus
+- company: "Epyx Professional"
+  board: epyxprofessional
+- company: "Estron Chemical"
+  board: estron
+- company: "Fiduciaire Nordstrooss N7 S.A."
+  board: fiduciairen7
+- company: "Fieldworks"
+  board: fieldworks
+- company: "Flextrip"
+  board: flextrip
+- company: "Focusinc Group Corp"
+  board: focusincgroup
+- company: "fosila"
+  board: fosila
+- company: "GBA LLP Chartered Professional Accountants"
+  board: gballp
+- company: "Gcommerce Solutions"
+  board: gcommercesolutions
+- company: "Georgia Institute of Technology"
+  board: georgiatech
+- company: "Getharvest"
+  board: getharvest
+- company: "GGV Inteligência em Vendas"
+  board: ggvinteligencia
+- company: "glitchtank"
+  board: glitchtank
+- company: "PrimeFlight"
+  board: globalgse
+- company: "glossybox"
+  board: glossybox
+- company: "goFLUENT"
+  board: gofluent
+- company: "Golden Greek Fresh"
+  board: goldengreekfresh


### PR DESCRIPTION
## Summary
Bulk-harvested tenant slugs for the four new Brazilian ATS adapters and added the live ones to their board files.

| Provider | +boards | ~jobs |
|---|---|---|
| solides | 1154 | 15.8k |
| inhire | 347 | 8.0k |
| trakstar | 283 | 3.6k |
| senior | 80 | 1.7k |
| **total** | **1864** | **~29k** |

**Method:** Wayback CDX subdomain enumeration (`*.<platform-host>`) → ~2992 candidate slugs → live-validated each against the adapter's public API, keeping only boards with >0 active jobs. Verified no false positives (bogus slugs return empty across all four platforms). Deduped against the existing curated entries; dropped demo/test/numeric-junk slugs.

Company display names pulled from each API (solides row `companyName`, inhire `tenantName`, senior `contents[].company.name`, trakstar feed `<title>`).

No code change — these four adapters already shipped (#239–242) and their ingest crons already exist, so the new boards are crawled automatically. All four files load and pass registry validation.

## Test Plan
- [x] `yaml.safe_load` + every entry has company+board
- [x] `LoadConfig` + `Config.Validate(registry)` pass for all four files (350/1156/82/285 entries)
- [x] `go test ./internal/sources/ -run Config` green
- [x] Live API validation per slug (no false positives)