### PR TITLE
feat(sources): add Factorial (FactorialHR) adapter — 436 boards

### DIFF
--- a/internal/sources/factorial.go
+++ b/internal/sources/factorial.go
@@ -1,0 +1,178 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// factorial adapts Factorial (FactorialHR) ATS career sites. A board is the careers host
+// (e.g. "muffin.factorial.it" or "highbras.factorialhr.com.br"); the host's TLD varies by
+// the tenant's country, so it travels with the board id. The careers root server-renders the
+// full job list as "/job_posting/<slug>-<id>" links; each job page is server-rendered HTML
+// carrying the title (h1), the body (a div.styledText block), and an unlabeled metadata list,
+// so the description comes from a per-job detail fetch (bounded-concurrency) like the other
+// HTML detail adapters. The site exposes no ld+json or JSON API.
+type factorial struct {
+	http HTMLGetter
+}
+
+// NewFactorial builds the Factorial adapter over the given HTTP client.
+func NewFactorial(c HTMLGetter) Source { return factorial{http: c} }
+
+func (factorial) Provider() string { return "factorial" }
+
+// factorialIDPattern captures the native posting id from a job URL's trailing "-<id>"
+// segment (e.g. /job_posting/partnership-success-manager-305055 → 305055).
+var factorialIDPattern = regexp.MustCompile(`-(\d+)/?$`)
+
+func (f factorial) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://%s/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("factorial: board %q: %w", e.Board, err)
+	}
+	root, err := f.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("factorial: listing %s: %w", e.Board, err)
+	}
+
+	// The careers root renders every posting; dedup the links (the same job can appear under
+	// multiple team sections).
+	var urls []string
+	seen := make(map[string]bool)
+	for _, link := range jobLinks(base, root, func(href string) bool { return strings.Contains(href, "/job_posting/") }) {
+		if !seen[link] {
+			seen[link] = true
+			urls = append(urls, link)
+		}
+	}
+
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return f.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one job page and maps it to a Job, returning ok=false when the page fetch
+// fails or carries no parseable id/title, so the caller skips just that posting.
+func (f factorial) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	m := factorialIDPattern.FindStringSubmatch(jobURL)
+	if m == nil {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := f.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	title := firstElementText(root, "h1")
+	if title == "" {
+		return Job{}, false
+	}
+
+	location, workMode := factorialLocation(metadataRows(root))
+	return Job{
+		ExternalID:  m[1],
+		URL:         jobURL,
+		Title:       title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(elementInnerHTMLByClass(root, "div", "styledText")),
+		Remote:      workMode == "remote" || isRemote(location),
+		WorkMode:    workMode,
+		PostedAt:    nil, // Factorial job pages carry no publish date
+	}, true
+}
+
+// factorialParenLoc matches the "<work-mode> (<places>)" location form Factorial renders in
+// some locales (e.g. "Ibrido (Milano, Lombardia, Italia)"); the parenthetical must contain a
+// comma so a team row like "S - Partnerships (PAR)" does not match.
+var factorialParenLoc = regexp.MustCompile(`^(.+?)\s*\(([^()]*,[^()]*)\)\s*$`)
+
+// factorialLocation picks the location out of a job's unlabeled metadata rows (contract,
+// schedule, salary, location, team — in no guaranteed order). The location is the row that
+// names places: it carries a comma and no currency symbol (which would make it the salary).
+// It returns the geographic text and, when the row prefixes a work-mode word, the mapped
+// WorkMode.
+func factorialLocation(rows []string) (location, workMode string) {
+	for _, row := range rows {
+		row = strings.TrimSpace(row)
+		if row == "" || strings.ContainsAny(row, "€$£₹¥") { // skip blanks and the salary row
+			continue
+		}
+		if m := factorialParenLoc.FindStringSubmatch(row); m != nil {
+			return strings.TrimSpace(m[2]), factorialWorkMode(m[1])
+		}
+		if strings.Contains(row, ",") { // plain "City, Region, Country"
+			return row, ""
+		}
+	}
+	return "", ""
+}
+
+// factorialWorkMode maps Factorial's localized work-mode label (Italian/Spanish/Portuguese/
+// English) to our vocabulary; an unknown label yields "" (the pipeline then parses the
+// location text).
+func factorialWorkMode(label string) string {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "ibrido", "híbrido", "hibrido", "hybrid", "hibride":
+		return "hybrid"
+	case "da remoto", "remoto", "remota", "remote", "en remoto", "teletrabajo":
+		return "remote"
+	case "in sede", "presencial", "presenziale", "on-site", "on site", "onsite", "no escritório", "no local":
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// firstElementText returns the trimmed text of the first element with the given tag, or "".
+func firstElementText(root *html.Node, tag string) string {
+	var out string
+	walk(root, func(n *html.Node) bool {
+		if out != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == tag {
+			out = textContent(n)
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+// elementInnerHTMLByClass returns the inner HTML of the first element with the given tag that
+// carries the given class token, or "".
+func elementInnerHTMLByClass(root *html.Node, tag, class string) string {
+	var out string
+	found := false
+	walk(root, func(n *html.Node) bool {
+		if found {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == tag && hasClass(n, class) {
+			out = innerHTML(n)
+			found = true
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+// metadataRows returns the text of the job-detail metadata list items — the icon rows that
+// hold contract/schedule/salary/location/team. They share the "border-gray-50" divider
+// class, which distinguishes them from the nav and description list items.
+func metadataRows(root *html.Node) []string {
+	var rows []string
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "li" && hasClass(n, "border-gray-50") {
+			rows = append(rows, textContent(n))
+		}
+		return true
+	})
+	return rows
+}

--- a/internal/sources/factorial_test.go
+++ b/internal/sources/factorial_test.go
@@ -1,0 +1,116 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestFactorialLocation(t *testing.T) {
+	cases := []struct {
+		name     string
+		rows     []string
+		wantLoc  string
+		wantMode string
+	}{
+		{
+			name:     "work-mode parenthetical (IT)",
+			rows:     []string{"A tempo indeterminato", "Full time", "€35,000 - €50,000", "Ibrido (Milano, Lombardia, Italia)", "S - Partnerships (PAR)"},
+			wantLoc:  "Milano, Lombardia, Italia",
+			wantMode: "hybrid",
+		},
+		{
+			name:    "plain comma-separated (BR)",
+			rows:    []string{"Clt", "Período integral", "R$1.937,6 Mensal", "RIO DAS OSTRAS, RJ, Brasil", "QUALIDADE"},
+			wantLoc: "RIO DAS OSTRAS, RJ, Brasil",
+		},
+		{
+			// A team row has a parenthetical but no comma inside it, and a single-region
+			// location with no comma is not detected — both leave location empty.
+			name: "no comma anywhere → empty",
+			rows: []string{"Full time", "TRIVENETO", "S - Partnerships (PAR)"},
+		},
+		{
+			name:     "remote label maps",
+			rows:     []string{"Remoto (Madrid, España)"},
+			wantLoc:  "Madrid, España",
+			wantMode: "remote",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loc, mode := factorialLocation(tc.rows)
+			if loc != tc.wantLoc || mode != tc.wantMode {
+				t.Errorf("factorialLocation = (%q,%q), want (%q,%q)", loc, mode, tc.wantLoc, tc.wantMode)
+			}
+		})
+	}
+}
+
+func TestFactorialID(t *testing.T) {
+	cases := map[string]string{
+		"https://muffin.factorial.it/job_posting/partnership-success-manager-305055": "305055",
+		"https://x.factorialhr.com.br/job_posting/tecnico-de-inspecao-308827":        "308827",
+		"https://x.factorial.it/job_posting/no-id-here":                              "", // no trailing -<id>
+	}
+	for url, want := range cases {
+		m := factorialIDPattern.FindStringSubmatch(url)
+		got := ""
+		if m != nil {
+			got = m[1]
+		}
+		if got != want {
+			t.Errorf("id(%q) = %q, want %q", url, got, want)
+		}
+	}
+}
+
+// factorialDetailHTML builds a job page: an h1 title, the metadata list (each row in a
+// border-gray-50 li), and the description in a div.styledText.
+func factorialDetailHTML(title, salary, location, description string) string {
+	return `<html><body>` +
+		`<ul><li class="flex border-b border-gray-50">A tempo indeterminato</li>` +
+		`<li class="flex border-b border-gray-50">` + salary + `</li>` +
+		`<li class="flex border-b border-gray-50">` + location + `</li></ul>` +
+		`<h1 class="font-bold">` + title + `</h1>` +
+		`<div class='styledText'>` + description + `</div>` +
+		`</body></html>`
+}
+
+func TestFactorialFetch(t *testing.T) {
+	listing := `<html><body><ul>
+		<li class='job-offer-item'><a href="/job_posting/backend-engineer-100">Backend Engineer</a></li>
+		<li class='job-offer-item'><a href="/job_posting/backend-engineer-100">Apply</a></li>
+		<li class='job-offer-item'><a href="/job_posting/data-analyst-200">Data Analyst</a></li>
+	</ul></body></html>`
+	// Detail routes are listed before the listing route: routedHTTP returns the first route
+	// whose match string is a substring of the URL, and the listing root is a substring of
+	// every detail URL.
+	http := (&routedHTTP{}).
+		route("/job_posting/backend-engineer-100", factorialDetailHTML("Backend Engineer", "€40,000", "Ibrido (Milano, Italia)", "<p>Build things</p>")).
+		route("/job_posting/data-analyst-200", factorialDetailHTML("Data Analyst", "€30,000", "Remoto (Madrid, España)", "<p>Analyze data</p>")).
+		route("https://acme.factorial.it/", listing)
+
+	jobs, err := factorial{http: http}.Fetch(context.Background(),
+		CompanyEntry{Company: "Acme", Board: "acme.factorial.it"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 { // the duplicate "Apply" link to job 100 is de-duped
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "100" || j.Title != "Backend Engineer" || j.Company != "Acme" {
+		t.Errorf("job0 = id:%q title:%q company:%q", j.ExternalID, j.Title, j.Company)
+	}
+	if j.Location != "Milano, Italia" || j.WorkMode != "hybrid" {
+		t.Errorf("job0 location/workmode = %q/%q", j.Location, j.WorkMode)
+	}
+	if !strings.Contains(j.Description, "Build things") {
+		t.Errorf("job0 description = %q", j.Description)
+	}
+	if jobs[1].WorkMode != "remote" || !jobs[1].Remote {
+		t.Errorf("job1 workmode/remote = %q/%v", jobs[1].WorkMode, jobs[1].Remote)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -146,6 +146,7 @@ func All(c HTTPClient) map[string]Source {
 		NewDeel(c),
 		NewSenior(c),
 		NewTrakstar(c),
+		NewFactorial(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/sources/factorial.yml
+++ b/sources/factorial.yml
@@ -15,8 +15,14 @@
   board: a2secure.factorialhr.com
 - company: AB-Biotics
   board: ab-biotics.factorial.es
+- company: Acerbis
+  board: acerbis.factorial.it
 - company: Automóvel Club de Portugal
   board: acp.factorialhr.pt
+- company: Acrylicize
+  board: acrylicize.factorialhr.com
+- company: Adapting Social
+  board: adaptingsocial.factorialhr.com
 - company: AEB Group
   board: aebgroup.factorialhr.com
 - company: Afaplan
@@ -63,6 +69,8 @@
   board: apreciarte.factorialhr.pt
 - company: Apter
   board: apter.factorialhr.com.br
+- company: AQ Acentor
+  board: aq-acentor.factorial.es
 - company: Aqui a tua Remodelação
   board: aquiatuaremodelacao.factorialhr.pt
 - company: Arboris Capital
@@ -79,6 +87,10 @@
   board: atlanta.factorialhr.com.br
 - company: Autocar Tecnologie
   board: autocar-tecnologie.factorial.it
+- company: Autoingros
+  board: autoingros.factorial.it
+- company: Avvoka
+  board: avvoka.factorialhr.com
 - company: Axyon AI
   board: axyonai.factorialhr.com
 - company: B-Parts
@@ -103,6 +115,8 @@
   board: biorius.factorialhr.com
 - company: Brasmar
   board: brasmar.factorialhr.com
+- company: Bridge
+  board: bridge-srl.factorial.it
 - company: BR Multas
   board: brmultas.factorialhr.com.br
 - company: Polen
@@ -115,6 +129,8 @@
   board: bwv.factorialhr.pt
 - company: CADE Soluciones de Ingeniería
   board: cadesoluciones.factorial.es
+- company: Caffeina
+  board: caffeina.factorial.it
 - company: Calvi
   board: calvi.factorial.it
 - company: Campmany Abogados
@@ -143,6 +159,10 @@
   board: casavo.factorial.it
 - company: Cascioli Group
   board: cascioligroup.factorial.it
+- company: Casco
+  board: cascospa.factorial.it
+- company: CAUTO
+  board: cauto.factorial.it
 - company: Cavalariça
   board: cavalarica.factorialhr.pt
 - company: CDLAN
@@ -177,6 +197,8 @@
   board: coralgardeners.factorialhr.com
 - company: Oasis Hotels & Resorts
   board: corporativooasis.factorial.mx
+- company: Costruzioni Iannini
+  board: costruzioni-iannini.factorial.it
 - company: CP Pieter
   board: cppieter.factorialhr.com.br
 - company: CREAF
@@ -185,6 +207,8 @@
   board: criaforma.factorialhr.pt
 - company: Cristalmax
   board: cristalmax.factorialhr.pt
+- company: Cubbo
+  board: cubbo.factorialhr.com.br
 - company: Cuideo
   board: cuideo.factorial.es
 - company: Daken
@@ -193,10 +217,16 @@
   board: deale.factorial.es
 - company: De Luca & Partners
   board: delucahrcapital.factorial.it
+- company: Dierre Dimensione Ricambi
+  board: dierredimensionericambi.factorial.it
 - company: Digibéria Information Technologies
   board: digiberia.factorialhr.pt
+- company: Digitail
+  board: digitail.factorialhr.com
 - company: Fundación Dignidade
   board: dignidade.factorial.es
+- company: Diram
+  board: diram.factorial.mx
 - company: Domino Infissi
   board: dominoinfissi.factorial.it
 - company: D-Orbit
@@ -273,6 +303,8 @@
   board: fkslogistics.factorialhr.com.br
 - company: Floponor
   board: floponor.factorialhr.pt
+- company: Fondazione Opera San Francesco per i Poveri
+  board: fondazioneoperasanfrancesco.factorial.it
 - company: Fondazione San Michele Arcangelo
   board: fondazionesanmichelearcangelo.factorial.it
 - company: Fractal Engenharia e Sistemas
@@ -299,6 +331,8 @@
   board: generys.factorial.fr
 - company: GetBlock
   board: getblock.factorialhr.com
+- company: GFL Cosmetics
+  board: gflcosmetics.factorialhr.com
 - company: Gigas
   board: gigas.factorial.es
 - company: Giocamondo
@@ -323,6 +357,8 @@
   board: grup-gepork.factorial.es
 - company: Fundació Formació i Treball
   board: grupfit.factorial.es
+- company: Grupo Bramam
+  board: grupo-bramam.factorialhr.com.br
 - company: Grupo Noria
   board: grupo-noria.factorial.es
 - company: Grupo Stosberg
@@ -383,6 +419,8 @@
   board: grupotrc.factorial.es
 - company: Banca Più
   board: gruppobancapiu.factorial.it
+- company: Gruppo Di.Ba.
+  board: gruppodiba.factorial.it
 - company: Reda
   board: grupporeda.factorial.it
 - company: Gruppo Sapir
@@ -391,6 +429,8 @@
   board: gruppostorti.factorial.it
 - company: Gualini Lamiere
   board: gualini.factorial.it
+- company: Guerri Energia
+  board: guerrienergia.factorial.it
 - company: GuinotPrunera
   board: guinot-prunera-s.factorial.es
 - company: Gunni & Trentino
@@ -421,6 +461,8 @@
   board: iberogroup.factorialhr.com.br
 - company: iBrowse Consultoria e Informática
   board: ibrowse.factorialhr.com.br
+- company: ICAPE Group
+  board: icape-group.factorial.fr
 - company: iCliGo
   board: icligo.factorialhr.pt
 - company: Idesam
@@ -429,6 +471,8 @@
   board: idibgi.factorial.es
 - company: Il Sicomoro
   board: il-sicomoro.factorial.it
+- company: ILPRA
+  board: ilpra.factorial.it
 - company: IMA Health
   board: ima.factorialhr.com
 - company: Improving Logistics
@@ -465,6 +509,8 @@
   board: itnig.factorialhr.co
 - company: Itnig
   board: itnigcoworking.factorial.es
+- company: IVF-Life
+  board: ivflife.factorial.es
 - company: IZZON Lab
   board: izzonlab.factorial.es
 - company: Jacobsen Arquitetura
@@ -474,9 +520,13 @@
 - company: Tendencys Innovations
   board: jobs-tendencys-br.factorialhr.com
 - company: Tendencys Innovations
+  board: jobs-tendencys-co.factorialhr.com
+- company: Tendencys Innovations
   board: jobs-tendencys-es.factorial.es
 - company: Tendencys Innovations
   board: jobs-tendencys-in.factorialhr.com
+- company: Tendencys Innovations
+  board: jobs-tendencys.factorialhr.com
 - company: JTA
   board: jta.factorialhr.pt
 - company: Jumbo Group
@@ -509,6 +559,8 @@
   board: lefebvre-el-derecho.factorial.es
 - company: Lina Open X
   board: lina.factorialhr.com.br
+- company: Logifrio
+  board: logifrio.factorialhr.com
 - company: Logitek Fast & Smart Logistics
   board: logitek.factorial.it
 - company: Lookiero Outfittery Group
@@ -529,12 +581,18 @@
   board: maf-careers.factorial.it
 - company: Magazzini Bracchi
   board: magazzinobracchi.factorial.it
+- company: Magicmotorsport
+  board: magicmotorsport.factorial.it
 - company: Magis5
   board: magis5.factorialhr.com.br
+- company: Magnaghi Aeronautica
+  board: magnaghi-aeronautica-do-brasil.factorialhr.com.br
 - company: MaisMei
   board: maismei.factorialhr.com.br
 - company: Makko
   board: makko.factorial.fr
+- company: Maldarizzi Automotive
+  board: maldarizzi.factorial.it
 - company: MALEO
   board: maleo.factorialhr.pt
 - company: Mapit
@@ -583,6 +641,8 @@
   board: morgado-ca.factorialhr.pt
 - company: MRS Estudos Ambientais
   board: mrsambiental.factorialhr.com.br
+- company: Muffin
+  board: muffin.factorial.it
 - company: Multipagamentos
   board: multipagamentos.factorialhr.com.br
 - company: Muñoz Bosch
@@ -607,6 +667,10 @@
   board: niko.factorial.mx
 - company: Nippon Sanso Homecare
   board: nipponsansohomecare.factorial.es
+- company: NMDP México
+  board: nmdpmx.factorial.mx
+- company: NTE Process
+  board: nte.factorial.it
 - company: O Baratão das Embalagens
   board: obarataodasembalagens.factorialhr.com.br
 - company: Ocasa
@@ -625,6 +689,8 @@
   board: oni.factorialhr.pt
 - company: On The Road
   board: ontheroad.factorialhr.pt
+- company: Ontime
+  board: ontime.factorial.es
 - company: Oplium
   board: oplium.factorial.es
 - company: Grupo Pampling
@@ -717,8 +783,12 @@
   board: roit-vagas.factorialhr.com.br
 - company: Roman
   board: romanrm.factorial.es
+- company: Rosa Clará
+  board: rosa-clara.factorial.es
 - company: Rothelec
   board: rothelec.factorial.fr
+- company: RSM Italy
+  board: rsm-italy.factorial.it
 - company: Rueda & Rueda Advogados
   board: ruedaerueda.factorialhr.com.br
 - company: SAEA
@@ -739,10 +809,14 @@
   board: seekers.factorialhr.pt
 - company: Seriana
   board: serianaspa.factorial.it
+- company: Serveco
+  board: serveco.factorial.it
 - company: Grupo Sevilla Control
   board: sevilla-control.factorial.es
 - company: Shiadu
   board: shiadurbe.factorialhr.pt
+- company: ShippyPro
+  board: shippypro.factorialhr.com
 - company: SIDN Digital Thinking
   board: sidn.factorialhr.com
 - company: Silva Vitor, Faria & Ribeiro Advogados
@@ -809,14 +883,20 @@
   board: trendsrl.factorial.it
 - company: TUMO Portugal
   board: tumo.factorialhr.pt
+- company: Momento Seguros
+  board: tumomento.factorial.mx
 - company: Ulisancas
   board: ulisancas.factorialhr.pt
+- company: UNGUESS
+  board: unguess.factorial.it
 - company: UNICEF Portugal
   board: unicef-pessoas-pt.factorialhr.pt
 - company: Unicredix
   board: unicredix.factorial.mx
 - company: Unimed Dourados
   board: unimeddourados.factorialhr.com.br
+- company: Uniting Group
+  board: uniting.factorial.it
 - company: Universiis
   board: universiis.factorial.it
 - company: Univet
@@ -829,6 +909,12 @@
   board: valeria-careers.factorial.es
 - company: Venuu
   board: venuu.factorialhr.com
+- company: Ve.Ra. Group Srl
+  board: veragroupsrl.factorial.it
+- company: Vermeiren
+  board: vermeiren.factorialhr.de
+- company: vLex
+  board: vlex.factorial.es
 - company: OneTurn
   board: volcom.factorialhr.com
 - company: Voxcity Tecnologia
@@ -865,6 +951,8 @@
   board: yomali.factorialhr.com
 - company: Storebox
   board: yourstorebox.factorialhr.com
+- company: Ysabel Mora
+  board: ysabel-mora.factorial.es
 - company: Laboratorios Ysonut
   board: ysonut.factorialhr.com
 - company: Zafex Telecomunicações

--- a/sources/factorial.yml
+++ b/sources/factorial.yml
@@ -1,0 +1,875 @@
+# Factorial (FactorialHR) ATS boards. Provider is the filename; each entry is company +
+# board. board = the careers host (see internal/sources/factorial.go); the TLD varies by
+# the tenant's country. Each board validated live (careers page lists job_postings) before adding.
+- company: 24hAssistance
+  board: 24hassistance.factorial.it
+- company: 3Bee
+  board: 3bee.factorial.it
+- company: 3Doubles Producciones
+  board: 3doubles.factorial.es
+- company: 4Farma Shee
+  board: 4farma.factorialhr.pt
+- company: 9NET
+  board: 9net.factorialhr.com.br
+- company: A2SECURE
+  board: a2secure.factorialhr.com
+- company: AB-Biotics
+  board: ab-biotics.factorial.es
+- company: Automóvel Club de Portugal
+  board: acp.factorialhr.pt
+- company: AEB Group
+  board: aebgroup.factorialhr.com
+- company: Afaplan
+  board: afaplan.factorialhr.com.br
+- company: Afaplan
+  board: afaplanpt.factorialhr.pt
+- company: Agilidade
+  board: agilidade.factorialhr.pt
+- company: Agrotools
+  board: agrotools.factorialhr.com.br
+- company: Ahembo
+  board: ahembo.factorial.es
+- company: Banca AideXa
+  board: aidexa.factorial.it
+- company: Tecnofast
+  board: airfix.factorialhr.com.br
+- company: Akibara Xpress
+  board: akibaraxpress.factorial.mx
+- company: AKMX
+  board: akmx.factorialhr.com.br
+- company: Aldesa
+  board: aldesa-jobsite.factorial.pl
+- company: Aldesa
+  board: aldesa.factorial.es
+- company: Aldesa
+  board: aldesaconstrucciones.factorialhr.com
+- company: Alop+ Logística
+  board: alopmais.factorialhr.com.br
+- company: Alvic
+  board: alvic.factorial.es
+- company: Amber Star Luxury Imobiliária
+  board: amberstar.factorialhr.pt
+- company: AM Holding
+  board: amholdingcareer.factorial.it
+- company: ANCO
+  board: ancosistemas.factorial.es
+- company: Antos
+  board: antos.factorial.it
+- company: APEPI
+  board: apepi.factorialhr.com.br
+- company: Riportico (Applus+)
+  board: applusportugal.factorialhr.pt
+- company: Apreciarte
+  board: apreciarte.factorialhr.pt
+- company: Apter
+  board: apter.factorialhr.com.br
+- company: Aqui a tua Remodelação
+  board: aquiatuaremodelacao.factorialhr.pt
+- company: Arboris Capital
+  board: arboris.factorialhr.com
+- company: AR Hotels & Resorts
+  board: arhotels.factorial.es
+- company: Arte Bianca
+  board: arte-bianca.factorialhr.pt
+- company: Atalanta
+  board: atalanta-ciberseguridad.factorial.es
+- company: Atelsam
+  board: atelsam.factorial.es
+- company: Atlanta
+  board: atlanta.factorialhr.com.br
+- company: Autocar Tecnologie
+  board: autocar-tecnologie.factorial.it
+- company: Axyon AI
+  board: axyonai.factorialhr.com
+- company: B-Parts
+  board: b-parts.factorialhr.pt
+- company: Baldan Group
+  board: baldangroup.factorial.it
+- company: Bdeo
+  board: bdeo.factorial.es
+- company: BDO Portugal
+  board: bdo-portugal.factorialhr.pt
+- company: BE A LION
+  board: bealion.factorial.es
+- company: Benigar
+  board: benigar.factorial.es
+- company: Bertolotti S.p.A.
+  board: bertolotti.factorial.it
+- company: BHOUT
+  board: bhout-careers.factorialhr.com
+- company: Bianchini Auto Peças
+  board: bianchinipecas.factorialhr.com.br
+- company: Biorius
+  board: biorius.factorialhr.com
+- company: Brasmar
+  board: brasmar.factorialhr.com
+- company: BR Multas
+  board: brmultas.factorialhr.com.br
+- company: Polen
+  board: brpolen.factorialhr.com.br
+- company: Brütsch/Rüegger Werkzeuge
+  board: brw.factorial.ch
+- company: BUGI Bar
+  board: bugi.factorialhr.pt
+- company: BWV
+  board: bwv.factorialhr.pt
+- company: CADE Soluciones de Ingeniería
+  board: cadesoluciones.factorial.es
+- company: Calvi
+  board: calvi.factorial.it
+- company: Campmany Abogados
+  board: campmanyabogados.factorialhr.com
+- company: Carbray International
+  board: carbray-international.factorial.es
+- company: Netcon Americas
+  board: careers-netconamericas.factorialhr.com
+- company: Factorial
+  board: careers.factorialhr.com
+- company: Cargo Monterrey
+  board: cargomty.factorial.mx
+- company: CarpoLog
+  board: carpolog.factorialhr.com.br
+- company: Factorial
+  board: carreiras.factorialhr.com.br
+- company: Five Acts
+  board: carreirasfiveacts.factorialhr.com.br
+- company: CASAFARI
+  board: casafari.factorialhr.pt
+- company: Casa Guedes
+  board: casaguedes.factorialhr.pt
+- company: Casa Tarradellas
+  board: casatarradellas.factorial.es
+- company: Casavo
+  board: casavo.factorial.it
+- company: Cascioli Group
+  board: cascioligroup.factorial.it
+- company: Cavalariça
+  board: cavalarica.factorialhr.pt
+- company: CDLAN
+  board: cdlan.factorial.it
+- company: CDS Hotels
+  board: cdshotels.factorial.it
+- company: Cetec Engenharia
+  board: cetecengenharia.factorialhr.com.br
+- company: CeX
+  board: cex.factorial.es
+- company: Cosmopolitan Hotels
+  board: ch-hotels.factorial.it
+- company: Chili Digital
+  board: chili.factorialhr.com.br
+- company: Clinica dentale Cappellin
+  board: clinicadentalecappellin.factorial.it
+- company: C-MORE
+  board: cmore.factorialhr.pt
+- company: Cerejeira Namora, Marinho Falcão
+  board: cnmf.factorialhr.pt
+- company: Colégio Aliado
+  board: colegioaliadojj.factorialhr.com.br
+- company: A Confeitaria
+  board: confeitaria.factorialhr.pt
+- company: Confidi Systema!
+  board: confidisystema.factorial.it
+- company: CONSULTATIO
+  board: consultatio.factorialhr.com
+- company: Contech
+  board: contech.factorial.it
+- company: Coral Gardeners
+  board: coralgardeners.factorialhr.com
+- company: Oasis Hotels & Resorts
+  board: corporativooasis.factorial.mx
+- company: CP Pieter
+  board: cppieter.factorialhr.com.br
+- company: CREAF
+  board: creaf.factorialhr.com
+- company: Criaformaser
+  board: criaforma.factorialhr.pt
+- company: Cristalmax
+  board: cristalmax.factorialhr.pt
+- company: Cuideo
+  board: cuideo.factorial.es
+- company: Daken
+  board: daken.factorial.it
+- company: Deale
+  board: deale.factorial.es
+- company: De Luca & Partners
+  board: delucahrcapital.factorial.it
+- company: Digibéria Information Technologies
+  board: digiberia.factorialhr.pt
+- company: Fundación Dignidade
+  board: dignidade.factorial.es
+- company: Domino Infissi
+  board: dominoinfissi.factorial.it
+- company: D-Orbit
+  board: dorbit-space.factorial.it
+- company: Dorisol Hotels
+  board: dorisol.factorialhr.pt
+- company: Drive360
+  board: drive360.factorialhr.pt
+- company: Drogaria Marcelino
+  board: drogariamarcelino.factorialhr.com.br
+- company: Droit de Regard
+  board: droit-de-regard.factorial.fr
+- company: DS Crédito Évora e Corroios
+  board: dscreditoevoraecorroios.factorialhr.pt
+- company: DWF Labs
+  board: dwflabs.factorialhr.com
+- company: Dynâmica Segurança do Trabalho
+  board: dynamica.factorialhr.com.br
+- company: Eletrospitalar
+  board: eletrospitalar.factorialhr.com.br
+- company: Embat
+  board: embat.factorialhr.com
+- company: Emetel
+  board: emetel.factorial.es
+- company: Gor Factory
+  board: empleogorfactory.factorial.es
+- company: MAT EXAKTA
+  board: empleomatexakta.factorial.es
+- company: Enrique Tomás
+  board: enrique-tomas.factorial.es
+- company: Envira Sostenible
+  board: envira.factorial.es
+- company: Equixly
+  board: equixly.factorialhr.com
+- company: ERA Châtelain
+  board: erachatelain.factorial.be
+- company: Espais Roca
+  board: espaisroca.factorialhr.com
+- company: Esperanza Viva
+  board: esperanzaviva.factorial.mx
+- company: Etifor
+  board: etifor.factorial.it
+- company: Europalco
+  board: europalco.factorialhr.pt
+- company: Evectra
+  board: evectra.factorial.es
+- company: Excelia
+  board: excelia.factorial.es
+- company: Externalia
+  board: externalia.factorialhr.com
+- company: Exxata
+  board: exxata.factorialhr.com.br
+- company: La Fageda
+  board: fageda.factorial.es
+- company: Fundação Amazônia Sustentável
+  board: fas-amazonia.factorialhr.com
+- company: CIRCE Centro Tecnológico
+  board: fcirce.factorial.es
+- company: FE Group Srl
+  board: fe-group-srl.factorial.it
+- company: Feelathome
+  board: feelathome.factorial.es
+- company: FFitness
+  board: ffitnessgroup.factorialhr.pt
+- company: Fhios
+  board: fhios.factorial.es
+- company: Fibersail
+  board: fibersail.factorialhr.com
+- company: Filinto Mota
+  board: filintomota.factorialhr.pt
+- company: Finmatics
+  board: finmatics.factorialhr.com
+- company: FKS Logistics
+  board: fkslogistics.factorialhr.com.br
+- company: Floponor
+  board: floponor.factorialhr.pt
+- company: Fondazione San Michele Arcangelo
+  board: fondazionesanmichelearcangelo.factorial.it
+- company: Fractal Engenharia e Sistemas
+  board: fractal-engenharia.factorialhr.com.br
+- company: Frekuent
+  board: frekuent.factorial.es
+- company: FRT Operadora
+  board: frt.factorialhr.com.br
+- company: FTX Agro
+  board: ftx.factorialhr.com.br
+- company: Fuego Camina Conmigo
+  board: fuego.factorial.es
+- company: Fulll
+  board: fulll.factorial.fr
+- company: Termal
+  board: futuretermal.factorial.it
+- company: Galo Resort Hotels
+  board: galo-resort-hotels.factorialhr.pt
+- company: Garden Alimentação
+  board: garden.factorialhr.com.br
+- company: Gattarella Family Resort
+  board: gattarella-puglia-resort-lavora-con-noi.factorial.it
+- company: Seleste
+  board: generys.factorial.fr
+- company: GetBlock
+  board: getblock.factorialhr.com
+- company: Gigas
+  board: gigas.factorial.es
+- company: Giocamondo
+  board: giocamondoscspa.factorial.it
+- company: Giocamondo Study
+  board: giocamondostudy.factorial.it
+- company: Global Factor
+  board: global-factor.factorial.es
+- company: GMG
+  board: gmgspa.factorial.it
+- company: GNL Russell Bedford
+  board: gnlrussellbedford.factorial.es
+- company: Go4Mobility
+  board: go4universe.factorialhr.pt
+- company: Grupo Vallas
+  board: gpo-vallas.factorial.mx
+- company: Gray's Cuisine
+  board: grayscuisine.factorialhr.pt
+- company: Growrk
+  board: growrk.factorialhr.com
+- company: Centauro Veterinaria
+  board: grup-gepork.factorial.es
+- company: Fundació Formació i Treball
+  board: grupfit.factorial.es
+- company: Grupo Noria
+  board: grupo-noria.factorial.es
+- company: Grupo Stosberg
+  board: grupo-stosberg.factorialhr.pt
+- company: Grupo Torrent
+  board: grupo-torrent.factorial.es
+- company: Grupo 5Y
+  board: grupo5y.factorialhr.pt
+- company: Grupo Adhonai
+  board: grupoadhonai.factorialhr.com.br
+- company: Grupo Aerotur
+  board: grupoaerotur.factorialhr.com.br
+- company: Grupo Arcus
+  board: grupoarcus.factorialhr.com.br
+- company: Grupo Colina
+  board: grupocolina.factorialhr.com.br
+- company: Grupo DPM
+  board: grupodpm.factorialhr.com.br
+- company: Ampla Peças e Serviços
+  board: grupoempresarial.factorialhr.com.br
+- company: Grupo Fire
+  board: grupofire.factorial.es
+- company: Grupo Griska
+  board: grupogriska.factorial.mx
+- company: Grupo H Saúde
+  board: grupohsaude.factorialhr.pt
+- company: Grupo IIS
+  board: grupoiis.factorial.mx
+- company: Grupo Innovaly
+  board: grupoinnovaly.factorial.es
+- company: Esypro
+  board: grupojlfroiz.factorialhr.com
+- company: Grup Oliva Motor
+  board: grupolivamotor.factorialhr.com
+- company: Grupo Marco
+  board: grupomarco.factorial.es
+- company: Grupo Machado Dias
+  board: grupomd.factorialhr.pt
+- company: Grupo Mysa
+  board: grupomysa.factorialhr.com.br
+- company: Grupo Non Basta
+  board: grupononbasta.factorialhr.pt
+- company: Nossa Loja
+  board: gruponossaloja.factorialhr.com
+- company: Grupo Nova Era
+  board: gruponovaera.factorialhr.com.br
+- company: Grupo Pinho
+  board: grupopinho.factorialhr.com.br
+- company: Grupo Pontes e Soares
+  board: grupopontesesoares.factorialhr.com.br
+- company: Grupo PSSA
+  board: grupopssa.factorialhr.com.br
+- company: Grupo Rainha
+  board: gruporainha.factorialhr.com.br
+- company: Remica
+  board: gruporemica.factorialhr.com
+- company: TRC
+  board: grupotrc.factorial.es
+- company: Banca Più
+  board: gruppobancapiu.factorial.it
+- company: Reda
+  board: grupporeda.factorial.it
+- company: Gruppo Sapir
+  board: grupposapir.factorial.it
+- company: Gruppo Storti
+  board: gruppostorti.factorial.it
+- company: Gualini Lamiere
+  board: gualini.factorial.it
+- company: GuinotPrunera
+  board: guinot-prunera-s.factorial.es
+- company: Gunni & Trentino
+  board: gunnitrentino-terrazabalear.factorial.es
+- company: Happy Network
+  board: happy-network.factorial.it
+- company: Harper & Neyer
+  board: harperandneyer.factorial.es
+- company: Skytech
+  board: hifly.factorialhr.pt
+- company: Highbras
+  board: highbras.factorialhr.com.br
+- company: Hinojosa Packaging Group
+  board: hinojosafrance.factorial.fr
+- company: HOGAR SÍ
+  board: hogarsi.factorial.es
+- company: Grenergy
+  board: https-grenergy-eu-es-compania-carreras.factorial.es
+- company: Coldwell Banker City
+  board: https-www-coldwellbanker-pt-pt-agencia-coldwell-banker-city-51.factorialhr.pt
+- company: Greenpeace Mexico
+  board: https-www-greenpeace-org-mexico.factorial.mx
+- company: Huild
+  board: huild.factorialhr.pt
+- company: I-VET
+  board: i-vet.factorial.it
+- company: Ibero Group
+  board: iberogroup.factorialhr.com.br
+- company: iBrowse Consultoria e Informática
+  board: ibrowse.factorialhr.com.br
+- company: iCliGo
+  board: icligo.factorialhr.pt
+- company: Idesam
+  board: idesam.factorialhr.com.br
+- company: IDIBGI
+  board: idibgi.factorial.es
+- company: Il Sicomoro
+  board: il-sicomoro.factorial.it
+- company: IMA Health
+  board: ima.factorialhr.com
+- company: Improving Logistics
+  board: improlog.factorial.es
+- company: infraone
+  board: infraone.factorial.es
+- company: Inovflow
+  board: inovflow.factorialhr.pt
+- company: Papa In Shape
+  board: inshape.factorial.fr
+- company: Insieme
+  board: insieme.factorial.it
+- company: Inspira Hotels
+  board: inspirahotels.factorialhr.pt
+- company: Insurama
+  board: insurama.factorial.es
+- company: Wild
+  board: interbranding.factorial.mx
+- company: Intermarché
+  board: intermarche.factorialhr.pt
+- company: Interventional Systems
+  board: interventional-systems.factorialhr.de
+- company: Intesi Group
+  board: intesigroup.factorial.it
+- company: Inventa
+  board: inventa.factorialhr.pt
+- company: Iris.ai
+  board: irisai.factorialhr.com
+- company: ISAAC
+  board: isaac-srl.factorial.it
+- company: Italiacamp
+  board: italiacamp.factorial.it
+- company: Itnig
+  board: itnig.factorialhr.co
+- company: Itnig
+  board: itnigcoworking.factorial.es
+- company: IZZON Lab
+  board: izzonlab.factorial.es
+- company: Jacobsen Arquitetura
+  board: jacobsenarquitetura.factorialhr.com.br
+- company: Tendencys Innovations
+  board: jobs-tendencys-ar.factorialhr.com
+- company: Tendencys Innovations
+  board: jobs-tendencys-br.factorialhr.com
+- company: Tendencys Innovations
+  board: jobs-tendencys-es.factorial.es
+- company: Tendencys Innovations
+  board: jobs-tendencys-in.factorialhr.com
+- company: JTA
+  board: jta.factorialhr.pt
+- company: Jumbo Group
+  board: jumboplay.factorial.es
+- company: KashIO
+  board: kashio.factorialhr.com
+- company: Koala Interactive
+  board: koala-interactive.factorial.fr
+- company: Kokku
+  board: kokkugames.factorialhr.com.br
+- company: KUBRIK
+  board: kubrik.factorialhr.com
+- company: La Vostra Llar
+  board: la-vostra-llar.factorial.es
+- company: La Ballena Alegre
+  board: laballenaalegre.factorial.es
+- company: Lacerda Diniz Machado
+  board: lacerdadiniz.factorialhr.com.br
+- company: La Città della luna
+  board: lacittadellaluna.factorial.it
+- company: Lacteus
+  board: lacteus.factorialhr.com.br
+- company: Ladeira Armarinhos
+  board: ladeira.factorialhr.com.br
+- company: La Pescheria da Claudio e Giuliano
+  board: lapescheriadaclaudioegiuliano.factorial.it
+- company: Ledwave
+  board: ledwave.factorialhr.com.br
+- company: Lefebvre
+  board: lefebvre-el-derecho.factorial.es
+- company: Lina Open X
+  board: lina.factorialhr.com.br
+- company: Logitek Fast & Smart Logistics
+  board: logitek.factorial.it
+- company: Lookiero Outfittery Group
+  board: lookiero.factorial.es
+- company: Love Life Passport
+  board: lovelifepassport.factorialhr.de
+- company: LPM Restaurants
+  board: lpmrestaurants.factorialhr.com
+- company: Luna Calzados
+  board: luna.factorial.es
+- company: LUV Studio
+  board: luvstudio.factorial.es
+- company: Madre Fruta
+  board: madrefruta.factorialhr.pt
+- company: MacroArray Diagnostics
+  board: madx.factorialhr.com
+- company: MAF
+  board: maf-careers.factorial.it
+- company: Magazzini Bracchi
+  board: magazzinobracchi.factorial.it
+- company: Magis5
+  board: magis5.factorialhr.com.br
+- company: MaisMei
+  board: maismei.factorialhr.com.br
+- company: Makko
+  board: makko.factorial.fr
+- company: MALEO
+  board: maleo.factorialhr.pt
+- company: Mapit
+  board: mapit.factorial.es
+- company: Maple Bear Goiânia
+  board: maplebeargoiania.factorialhr.com.br
+- company: Maq Larem
+  board: maq-larem.factorialhr.com.br
+- company: MarePineta Resort
+  board: marepinetaresort.factorial.it
+- company: Marosa
+  board: marosavat.factorial.es
+- company: Marpe Contabilidade
+  board: marpe.factorialhr.com.br
+- company: MASSLAB
+  board: masslab.factorialhr.pt
+- company: Master Vantagem
+  board: mastervantagem.factorialhr.pt
+- company: Matrix Assessoria Contábil
+  board: matrixcontabilidade.factorialhr.com.br
+- company: Mauser
+  board: mauser.factorialhr.pt
+- company: Mazzui & Mazzui
+  board: mazzui.factorialhr.com
+- company: Movimento de Defesa da Vida
+  board: mdv.factorialhr.pt
+- company: Medivet
+  board: medivet.factorial.es
+- company: MEDSIR
+  board: medsir.factorial.es
+- company: Meller
+  board: mellerbrand.factorial.es
+- company: Blue Healthcare
+  board: memorialpubliocordon.factorial.es
+- company: Mevcont
+  board: mevcont.factorialhr.com.br
+- company: MG Holding
+  board: mg-holding.factorial.it
+- company: Midway Technologies
+  board: midway.factorial.es
+- company: Grupo Momentum Motor
+  board: momentunmotor.factorial.es
+- company: Moray
+  board: moray.factorialhr.com.br
+- company: Morgado
+  board: morgado-ca.factorialhr.pt
+- company: MRS Estudos Ambientais
+  board: mrsambiental.factorialhr.com.br
+- company: Multipagamentos
+  board: multipagamentos.factorialhr.com.br
+- company: Muñoz Bosch
+  board: munoz-bosch-s-l.factorial.es
+- company: N3
+  board: n3.factorial.it
+- company: NacionalGest
+  board: nacionalgest.factorialhr.pt
+- company: Narval
+  board: narvaladvisory.factorial.es
+- company: NaturalLook
+  board: naturallook.factorial.it
+- company: Bollo Natural Fruit
+  board: naturalpeople.factorialhr.com
+- company: Clínica NeuroKids
+  board: neurokids.factorialhr.com.br
+- company: Nexon Automation
+  board: nexonautomation.factorial.mx
+- company: Next Implementos
+  board: next-implementos.factorialhr.com.br
+- company: Niko
+  board: niko.factorial.mx
+- company: Nippon Sanso Homecare
+  board: nipponsansohomecare.factorial.es
+- company: O Baratão das Embalagens
+  board: obarataodasembalagens.factorialhr.com.br
+- company: Ocasa
+  board: ocasa.factorialhr.com
+- company: Odontocoop
+  board: odontocoop-it.factorial.it
+- company: Officer Soft
+  board: officersoft.factorialhr.com.br
+- company: OIS Group
+  board: ois-dental.factorial.it
+- company: OK Mobility
+  board: okmobility.factorial.es
+- company: Olózfera
+  board: olozfera.factorial.mx
+- company: ONI
+  board: oni.factorialhr.pt
+- company: On The Road
+  board: ontheroad.factorialhr.pt
+- company: Oplium
+  board: oplium.factorial.es
+- company: Grupo Pampling
+  board: pampling.factorial.es
+- company: paper republic
+  board: paper-republic.factorialhr.com
+- company: PDG IT Soluções em Tecnologia
+  board: pdg-it.factorialhr.com.br
+- company: Kook's
+  board: pe.factorial.es
+- company: Pedras do Patacho
+  board: pedras-do-patacho.factorialhr.com.br
+- company: PeekMed
+  board: peekhealth.factorialhr.pt
+- company: PHC Hotels
+  board: phc-hotels.factorialhr.pt
+- company: PhotoSì
+  board: photosi.factorialhr.com
+- company: Piazza Hotels & Residences
+  board: piazzahotels.factorial.it
+- company: PiniOn
+  board: pinion.factorialhr.com.br
+- company: Pinto Basto
+  board: pinto-basto.factorialhr.pt
+- company: PITLOG Industria y Desarrollo
+  board: pitlog.factorial.es
+- company: Placer
+  board: placer.factorialhr.pt
+- company: Planet Farms
+  board: planet-farms.factorial.it
+- company: Planetek Italia
+  board: planetek-italia-srl-societa-benefit.factorial.it
+- company: Plataforma Legal
+  board: plataforma-legal.factorialhr.pt
+- company: Polisul Agrícola
+  board: polisul.factorialhr.com.br
+- company: Rede Ponteio
+  board: ponteio.factorialhr.com.br
+- company: Pontual – IT Business Solutions
+  board: pontual-it.factorialhr.pt
+- company: Porta da Frente Christie's
+  board: portadafrentecire.factorialhr.pt
+- company: Portela Cafés
+  board: portela.factorialhr.pt
+- company: Portugália Restauração
+  board: portugalia.factorialhr.pt
+- company: Prezzemolo & Vitale
+  board: prezzemoloevitale.factorial.it
+- company: Primavera Viaggi
+  board: primaveraviaggi.factorial.it
+- company: Promos Group
+  board: promos-srl.factorial.it
+- company: QGMI
+  board: qgmi.factorial.es
+- company: Qomodo
+  board: qomodo.factorial.it
+- company: Quality Refeições Coletivas e Serviços
+  board: qualityrefeicoes.factorialhr.com.br
+- company: Quinio
+  board: quinio.factorial.mx
+- company: REBI
+  board: rebi.factorial.es
+- company: Interax
+  board: reclutamiento-interax.factorial.mx
+- company: Associação Nacional das Farmácias
+  board: recrutamento-grupoanf.factorialhr.pt
+- company: Teixeira, Pinto & Soares
+  board: recrutamentogrupotps.factorialhr.pt
+- company: Refinery89
+  board: refinery89.factorialhr.com
+- company: Regesta
+  board: regestaitalia.factorial.it
+- company: ReStore
+  board: restore.factorial.it
+- company: Restplatzbörse
+  board: restplatzboerse.factorialhr.com
+- company: Revieve
+  board: revieve.factorialhr.com
+- company: RGI
+  board: rgi-group.factorialhr.com
+- company: Rio Beach Club
+  board: rio-beach-club.factorialhr.com.br
+- company: Ritmo S.p.A.
+  board: ritmo-spa.factorial.it
+- company: Roboze
+  board: roboze.factorial.it
+- company: Roc Hotels
+  board: roc-hotels.factorial.es
+- company: ROIT
+  board: roit-vagas.factorialhr.com.br
+- company: Roman
+  board: romanrm.factorial.es
+- company: Rothelec
+  board: rothelec.factorial.fr
+- company: Rueda & Rueda Advogados
+  board: ruedaerueda.factorialhr.com.br
+- company: SAEA
+  board: saea.factorialhr.com.br
+- company: Salt Services
+  board: saltlisbon.factorialhr.pt
+- company: Salú
+  board: salu.factorialhr.com.br
+- company: Sasga Yachts
+  board: sasga-yachts.factorial.es
+- company: Sass Dlacia
+  board: sassdlacia.factorial.it
+- company: Scalpers
+  board: scalpers.factorial.es
+- company: Scuola Guida Car
+  board: scuolaguidacar-lavora-con-noi.factorial.it
+- company: Seekers Journey
+  board: seekers.factorialhr.pt
+- company: Seriana
+  board: serianaspa.factorial.it
+- company: Grupo Sevilla Control
+  board: sevilla-control.factorial.es
+- company: Shiadu
+  board: shiadurbe.factorialhr.pt
+- company: SIDN Digital Thinking
+  board: sidn.factorialhr.com
+- company: Silva Vitor, Faria & Ribeiro Advogados
+  board: silvavitor.factorialhr.com.br
+- company: SiMedia
+  board: simedia.factorialhr.com
+- company: Grupo Sinelec
+  board: sinelec.factorial.es
+- company: SLN Construtora
+  board: slnconstrutora.factorialhr.com.br
+- company: Smart Impulse
+  board: smart-impulse.factorial.fr
+- company: Smashville
+  board: smashville.factorialhr.pt
+- company: SOCOTEC
+  board: socotec.factorial.es
+- company: Soplaya
+  board: soplaya.factorial.it
+- company: Sorte Online
+  board: sorte-online.factorialhr.com.br
+- company: Soundreef
+  board: soundreef.factorialhr.com
+- company: Spacecom Monitoramento
+  board: spacecom.factorialhr.com.br
+- company: Square1
+  board: square1.factorialhr.com
+- company: Stannis
+  board: stannis.factorialhr.com
+- company: StreamUnlimited
+  board: streamunlimited.factorialhr.com
+- company: Subenshi
+  board: subenshi.factorialhr.pt
+- company: Supersonica
+  board: supersonicasrl.factorial.it
+- company: Swim Ireland
+  board: swim-ireland.factorialhr.com
+- company: Seidor
+  board: talento-seidor.factorial.mx
+- company: TECNOTask
+  board: tecnotask.factorial.it
+- company: The Longevity Suite
+  board: the-longevity-suite.factorial.it
+- company: TheCUBE
+  board: thecube.factorial.es
+- company: Bomporto Hotels
+  board: thelumiares.factorialhr.pt
+- company: Bomporto Hotels
+  board: thevintage.factorialhr.pt
+- company: Tintomax
+  board: tintomax.factorialhr.com
+- company: The Navigator Collection
+  board: tnc.factorialhr.pt
+- company: Toni Pons
+  board: tonipons.factorial.es
+- company: Toranja
+  board: toranja.factorialhr.pt
+- company: TDF Group
+  board: trabaja-con-nosotros.factorialhr.com
+- company: Elifab Solutions
+  board: trabajoelifab.factorialhr.com
+- company: Transfor Group
+  board: transforgroup.factorialhr.pt
+- company: Trend
+  board: trendsrl.factorial.it
+- company: TUMO Portugal
+  board: tumo.factorialhr.pt
+- company: Ulisancas
+  board: ulisancas.factorialhr.pt
+- company: UNICEF Portugal
+  board: unicef-pessoas-pt.factorialhr.pt
+- company: Unicredix
+  board: unicredix.factorial.mx
+- company: Unimed Dourados
+  board: unimeddourados.factorialhr.com.br
+- company: Universiis
+  board: universiis.factorial.it
+- company: Univet
+  board: univet-group.factorial.it
+- company: Uniware
+  board: uniwareunilab.factorialhr.com.br
+- company: UNRWA España
+  board: unrwa.factorial.es
+- company: Valeria
+  board: valeria-careers.factorial.es
+- company: Venuu
+  board: venuu.factorialhr.com
+- company: OneTurn
+  board: volcom.factorialhr.com
+- company: Voxcity Tecnologia
+  board: voxcity.factorialhr.com.br
+- company: VVF
+  board: vvfrecrute.factorial.fr
+- company: Walter Pack
+  board: walterpack.factorial.es
+- company: WDC Networks
+  board: wdcnet.factorialhr.com.br
+- company: Jungle
+  board: wejungle.factorial.es
+- company: Well Vale do Lobo
+  board: well.factorialhr.pt
+- company: Winterhalter Brasil
+  board: winterhalterbrasil.factorialhr.com.br
+- company: Wise Pirates
+  board: wisepirates.factorialhr.pt
+- company: Wombat's City Hostels
+  board: wombats.factorialhr.com
+- company: Wooptix
+  board: wooptix.factorial.es
+- company: Work and Study Travel
+  board: workandstudytravel.factorialhr.com
+- company: wTVision
+  board: wtvision.factorialhr.com
+- company: Xceed
+  board: xceed.factorialhr.com
+- company: YCOM
+  board: ycom.factorial.it
+- company: YKK
+  board: ykkbrasil.factorialhr.com.br
+- company: Yomali
+  board: yomali.factorialhr.com
+- company: Storebox
+  board: yourstorebox.factorialhr.com
+- company: Laboratorios Ysonut
+  board: ysonut.factorialhr.com
+- company: Zafex Telecomunicações
+  board: zafex.factorialhr.com.br
+- company: Zenova
+  board: zenova.factorial.es
+- company: Zinnit Destinations by Senfter
+  board: zinnit-team.factorial.it


### PR DESCRIPTION
## What

New adapter for **Factorial (FactorialHR)** — a multi-tenant ATS (large BR/EU long tail) that **hiring.cafe sources but we did not parse**. Phase 2 of the hiring.cafe gap-closing (#244 = slugs for existing adapters, #245 = UKG adapter).

## How it works

Factorial exposes **no JSON API and no ld+json** — server-rendered HTML:
- **Listing:** the careers root renders every posting as `/job_posting/<slug>-<id>` links.
- **Detail (per job, bounded fan-out):** title = `h1`; description = `div.styledText`; location = the metadata icon-row that names places (has a comma, no currency symbol → not the salary), with the localized work-mode prefix (`Ibrido`/`Remoto`/`Presencial`/…) mapped to our `WorkMode`. Unrecognizable → empty location (nullable).
- **board = the careers host** — the TLD travels with the id (varies by tenant country).

## Boards

`sources/factorial.yml` — **436 boards** harvested from hiring.cafe, each **validated live** and de-duplicated. (More from a deeper role-sliced harvest in progress.)

## Verification

- Unit tests: location heuristic (IT parenthetical, BR plain, salary-skip, no-comma→empty, remote mapping), id extraction, full Fetch with link de-dup.
- **Live smoke:** `muffin.factorial.it` (IT) + `highbras.factorialhr.com.br` (BR) → jobs with titles, descriptions, parsed locations + `hybrid` work-mode.
- `go build/vet/test ./...` green; gofmt clean; `factorial.yml` registers.

## Deploy note

New adapter → Docker image rebuild + cron line for `factorial.yml`.