### PR TITLE
feat(sources): +5 boards harvested from hitmarker.net

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -585,6 +585,8 @@
   board: junction
 - company: Juniper Square
   board: junipersquare
+- company: JustPlay GmbH
+  board: justplay-gmbh
 - company: Kalshi
   board: kalshi
 - company: Kastle

--- a/sources/eightfold.yml
+++ b/sources/eightfold.yml
@@ -117,3 +117,5 @@
   board: mercadolibre.eightfold.ai/mercadolibre.com
 - company: NetApp
   board: netapp.eightfold.ai/netapp.com
+- company: Hasbro
+  board: careers.hasbro.com/hasbro.com

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -91,3 +91,7 @@
   board: www.pgcareers.com
 - company: Yelp
   board: www.yelp.careers
+- company: King
+  board: careers.king.com
+- company: Activision
+  board: careers.activision.com

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -139,6 +139,8 @@
   board: bilh.wd1.myworkdayjobs.com/External
 - company: Cleveland Clinic
   board: ccf.wd1.myworkdayjobs.com/ClevelandClinicCareers
+- company: Cloud Imperium Games
+  board: cloudimperiumgames.wd503.myworkdayjobs.com/CIG_Global_Careers
 - company: Booz Allen
   board: bah.wd1.myworkdayjobs.com/bah_jobs
 - company: Applied Materials


### PR DESCRIPTION
## What

Boards harvested from [hitmarker.net/jobs](https://hitmarker.net/jobs) (gaming/esports aggregator), each mapped to an adapter we already run and **validated live** before adding:

| File | Company | board | Platform |
|---|---|---|---|
| `ashby.yml` | JustPlay GmbH | `justplay-gmbh` | Ashby (9 jobs) |
| `workday.yml` | Cloud Imperium Games | `cloudimperiumgames.wd503.myworkdayjobs.com/CIG_Global_Careers` | Workday (64) |
| `phenom.yml` | King | `careers.king.com` | Phenom |
| `phenom.yml` | Activision | `careers.activision.com` | Phenom |
| `eightfold.yml` | Hasbro | `careers.hasbro.com/hasbro.com` | Eightfold (pcsx) |

## How

hitmarker re-exports other ATS boards. I mined all **6062** of its job pages for the outbound apply URL (hidden in the page's Sprig `job-apply` component), classified each by backing ATS, and deduped against our catalogue. Many "custom" career hosts turned out to front an ATS we already parse (resolved by fingerprinting the host): **Blizzard → Phenom, Gameloft → SmartRecruiters, Netflix → Eightfold, Nintendo → Greenhouse** were already present and not re-added. King/Activision (Phenom) and Hasbro (Eightfold) were the genuinely new ones.

## Out of scope (need new adapters)

~400 hitmarker vacancies sit on platforms we have no adapter for: **EA (Avature, 184), Cornerstone/csod (36), Jobvite (21), Comeet (17), Paycom (13)**, plus custom studio sites (Playrix, Kojima, Garena, Supercell, …) and hitmarker-hosted (18). Tracked separately.

## Test
`go test ./internal/sources/` — `ok`.