### PR TITLE
feat(sources): add NetApp eightfold board from newpmjobs harvest

### DIFF
--- a/sources/eightfold.yml
+++ b/sources/eightfold.yml
@@ -115,3 +115,5 @@
   board: albemarle.eightfold.ai/albemarle.com
 - company: MercadoLibre
   board: mercadolibre.eightfold.ai/mercadolibre.com
+- company: NetApp
+  board: netapp.eightfold.ai/netapp.com


### PR DESCRIPTION
## What

Audited **newpmjobs.com** (a PM-job aggregator curating ~448 big-name tech/finance/pharma companies) for ATS board slugs we don't yet have.

Adds **one** new board:
- **NetApp** — `netapp.eightfold.ai/netapp.com` (274 live positions via the legacy Eightfold v2 list API)

## How

- `sitemap.xml` → ~448 public `/companies/<slug>` pages (only the singular `/company/` is robots-disallowed; the plural `/companies/` is allowed and sitemapped) → bulk fetch → grep outbound apply hosts.
- Providers seen: greenhouse, workday, oracle, ashby, lever, eightfold, smartrecruiters, icims, jobvite.
- Cracked 24 vanity `gh_jid` tokens via the Greenhouse embed endpoint (airbnb/stripe/datadog/databricks/brex/compass→urbancompass/coupang/digitalocean98/esri/fastly/duolingo/ripple/nuro/block/asana/dropbox/…).
- Ran greenhouse/lever/ashby/workday/icims candidates through `cmd/harvest-boards` (live-validated against each platform's official API); eightfold/smartrecruiters/oracle checked manually against the public list APIs.

## Result

Near-total existing coverage — everything was already in our files (greenhouse 6073, workday 6105, ashby 3320, lever 2009, smartrecruiters 1846, oracle 174, eightfold 52). NetApp was the only genuine gap.

American Express (`aexp.eightfold.ai/aexp.com`) was **skipped**: the domain is valid but the public list API returns 0 positions (dormant/gated tenant), and newpmjobs carried no detail URLs for it. jobvite has no adapter (deferred).

## Verification

- `go build ./...` ✓
- `go test ./internal/sources/` ✓
- `netapp.eightfold.ai/netapp.com` live-probed: 274 positions via `/api/apply/v2/jobs`