### PR TITLE
feat(sources): add Avature adapter (EA jobs.ea.com)

### DIFF
--- a/internal/sources/avature.go
+++ b/internal/sources/avature.go
@@ -1,0 +1,263 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// avature adapts Avature career sites (e.g. EA's jobs.ea.com, canonically ea.avature.net).
+// The board is the career-site host. A sitemap index advertises one sitemap per locale; the
+// adapter crawls the en_US one (the other locales list the same postings) and reads its
+// JobDetail URLs. Each job page is server-rendered HTML with no schema.org JSON-LD, so the
+// title comes from og:title and the location/work-model/description from the page's
+// article__content__view__field label/value blocks (description = the richest value).
+type avatureHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+type avature struct {
+	http avatureHTTP
+}
+
+// NewAvature builds the Avature adapter over the given HTTP client.
+func NewAvature(c avatureHTTP) Source { return avature{http: c} }
+
+func (avature) Provider() string { return "avature" }
+
+// avatureEntry is one JobDetail URL plus its sitemap last-modified date (used as posted_at).
+type avatureEntry struct {
+	loc     string
+	lastMod string
+}
+
+func (s avature) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var index struct {
+		Sitemaps []struct {
+			Loc string `xml:"loc"`
+		} `xml:"sitemap"`
+	}
+	indexURL := fmt.Sprintf("https://%s/careers/sitemap_index.xml", e.Board)
+	if err := s.http.GetXML(ctx, indexURL, &index); err != nil {
+		return nil, fmt.Errorf("avature: sitemap index %s: %w", e.Board, err)
+	}
+
+	// One sitemap per locale lists the same postings; crawl en_US to avoid duplicates.
+	var listURL string
+	for _, sm := range index.Sitemaps {
+		if strings.Contains(sm.Loc, "/en_US/") {
+			listURL = sm.Loc
+			break
+		}
+	}
+	if listURL == "" {
+		return nil, fmt.Errorf("avature: no en_US sitemap advertised for %s", e.Board)
+	}
+
+	var urlset struct {
+		URLs []struct {
+			Loc     string `xml:"loc"`
+			LastMod string `xml:"lastmod"`
+		} `xml:"url"`
+	}
+	if err := s.http.GetXML(ctx, listURL, &urlset); err != nil {
+		return nil, fmt.Errorf("avature: sitemap %s: %w", listURL, err)
+	}
+
+	// The locale sitemap mixes JobDetail pages with utility pages (AgentCreate, …); keep
+	// only the postings.
+	var entries []avatureEntry
+	for _, u := range urlset.URLs {
+		if strings.Contains(u.Loc, "/careers/JobDetail/") {
+			entries = append(entries, avatureEntry{loc: u.Loc, lastMod: u.LastMod})
+		}
+	}
+
+	return fetchDetails(entries, defaultDetailWorkers, func(entry avatureEntry) (Job, bool) {
+		return s.detail(ctx, e, entry)
+	}), nil
+}
+
+// detail fetches one job page and maps it to a Job, returning ok=false when the page fetch
+// fails, carries no parseable id, or renders no description — so the caller skips just that
+// posting.
+func (s avature) detail(ctx context.Context, e CompanyEntry, entry avatureEntry) (Job, bool) {
+	id := avatureJobID(entry.loc)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+
+	root, err := s.http.GetHTML(ctx, entry.loc)
+	if err != nil {
+		return Job{}, false
+	}
+
+	title := metaProperty(root, "og:title")
+	description := sanitizeHTML(avatureDescription(root))
+	if title == "" || description == "" {
+		return Job{}, false // an unrendered/blocked page → skip rather than persist a husk
+	}
+
+	workMode := avatureWorkMode(avatureFieldValue(root, "Work Model"))
+	return Job{
+		ExternalID:  id,
+		URL:         entry.loc,
+		Title:       title,
+		Company:     e.Company,
+		Location:    avatureLabeledValue(root, "Locations"),
+		Description: description,
+		Remote:      workMode == "remote",
+		WorkMode:    workMode,
+		PostedAt:    parseDate(entry.lastMod),
+	}, true
+}
+
+// avatureJobIDPattern captures the trailing numeric posting id of a JobDetail URL
+// (".../JobDetail/<title-slug>/<id>", optional trailing slash).
+var avatureJobIDPattern = regexp.MustCompile(`/JobDetail/[^/]+/(\d+)/?$`)
+
+// avatureJobID extracts the native numeric posting id from a job page URL.
+func avatureJobID(loc string) string {
+	if m := avatureJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// avatureWorkMode maps an Avature "Work Model" field value to the controlled work-mode
+// vocabulary, returning "" for an absent or unrecognized value (no structured signal).
+func avatureWorkMode(v string) string {
+	switch l := strings.ToLower(strings.TrimSpace(v)); {
+	case strings.Contains(l, "remote"):
+		return "remote"
+	case strings.Contains(l, "hybrid"):
+		return "hybrid"
+	case strings.Contains(l, "on-site"), strings.Contains(l, "on site"),
+		strings.Contains(l, "onsite"), strings.Contains(l, "in-office"),
+		strings.Contains(l, "in office"):
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// avatureFieldValue returns the trimmed text of the article__content__view__field whose
+// label matches label (case-insensitively), or "" when no such field exists.
+func avatureFieldValue(root *html.Node, label string) string {
+	var out string
+	walk(root, func(n *html.Node) bool {
+		if out != "" {
+			return false
+		}
+		if n.Type != html.ElementNode || !hasClass(n, "article__content__view__field") {
+			return true
+		}
+		var lab, val string
+		walk(n, func(c *html.Node) bool {
+			if c.Type != html.ElementNode {
+				return true
+			}
+			switch {
+			case hasClass(c, "article__content__view__field__label"):
+				lab = strings.TrimSpace(textContent(c))
+			case hasClass(c, "article__content__view__field__value"):
+				val = strings.TrimSpace(textContent(c))
+			}
+			return true
+		})
+		if strings.EqualFold(lab, label) {
+			out = val
+			return false
+		}
+		return true
+	})
+	return out
+}
+
+// avatureLabeledValue returns the value of an inline-labeled field — an
+// article__content__view__field__value rendered as "<strong>Label</strong>: value"
+// (how Avature shows Locations) — for the given label, or "" when no such field exists.
+// It is distinct from avatureFieldValue, which reads the sidebar __label/__value pairs.
+func avatureLabeledValue(root *html.Node, label string) string {
+	var out string
+	found := false
+	walk(root, func(n *html.Node) bool {
+		if found {
+			return false
+		}
+		if n.Type != html.ElementNode || !hasClass(n, "article__content__view__field__value") {
+			return true
+		}
+		var strongText string
+		walk(n, func(c *html.Node) bool {
+			if strongText == "" && c.Type == html.ElementNode && c.Data == "strong" {
+				strongText = strings.TrimSpace(textContent(c))
+				return false
+			}
+			return true
+		})
+		if !strings.EqualFold(strongText, label) {
+			return true
+		}
+		found = true
+		v := textContent(n)
+		// Avature appends a hidden multi-location list after the primary value, separated
+		// by a non-breaking space; keep only the primary value.
+		if i := strings.IndexRune(v, '\u00A0'); i >= 0 {
+			v = v[:i]
+		}
+		v = strings.TrimSpace(v)
+		v = strings.TrimSpace(strings.TrimPrefix(v, strongText))
+		out = strings.TrimSpace(strings.TrimLeft(v, ":  "))
+		return false
+	})
+	return out
+}
+
+// avatureDescription returns the inner HTML of the job ad body — the richest (most text)
+// field value that carries prose markup (a paragraph/heading/list). The prose requirement
+// keeps a long inline value such as the Locations field's hidden multi-location dump (plain
+// text, no block tags) from being mistaken for the description. It falls back to the richest
+// value overall if none carries prose markup.
+func avatureDescription(root *html.Node) string {
+	var prose, any string
+	proseLen, anyLen := 0, 0
+	walk(root, func(n *html.Node) bool {
+		if n.Type != html.ElementNode || !hasClass(n, "article__content__view__field__value") {
+			return true
+		}
+		l := len(textContent(n))
+		if l > anyLen {
+			anyLen, any = l, innerHTML(n)
+		}
+		if l > proseLen && hasProseMarkup(n) {
+			proseLen, prose = l, innerHTML(n)
+		}
+		return true
+	})
+	if prose != "" {
+		return prose
+	}
+	return any
+}
+
+// hasProseMarkup reports whether n contains a block-level prose element (paragraph,
+// heading, or list) — the structure of a job ad body, absent from inline-labeled fields.
+func hasProseMarkup(n *html.Node) bool {
+	found := false
+	walk(n, func(c *html.Node) bool {
+		if c.Type == html.ElementNode {
+			switch c.Data {
+			case "p", "ul", "ol", "li", "h1", "h2", "h3", "h4", "h5", "h6", "table":
+				found = true
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}

--- a/internal/sources/avature_test.go
+++ b/internal/sources/avature_test.go
@@ -1,0 +1,189 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// avatureDetailHTML mirrors an Avature JobDetail page: og:title carries the title, and the
+// body is a series of article__content__view__field blocks, each a __label + __value. The
+// description is the richest (longest) field value and carries markup to verify sanitizing.
+const avatureDetailHTML = `<html><head>
+<meta property="og:title" content="Senior Product Manager"/>
+<meta property="og:site_name" content="Electronic Arts"/>
+</head><body class="body--job-detail">
+<div class='article__content'>
+  <div class='article__content__view__field'>
+    <div class='article__content__view__field__label'>Role ID</div>
+    <div class='article__content__view__field__value'>214840</div>
+  </div>
+  <div class='article__content__view__field'>
+    <div class='article__content__view__field__label'>Work Model</div>
+    <div class='article__content__view__field__value'>Hybrid</div>
+  </div>
+  <div class='article__content__view__field'>
+    <div class='article__content__view__field__value'><strong>Locations</strong>: Austin, Texas, United States of America&nbsp; <br></div>
+  </div>
+  <div class='article__content__view__field'>
+    <div class='article__content__view__field__value'><h2>About</h2><p>Build the games that connect the world. We are looking for a Senior Product Manager to lead our roadmap, partner with engineering, and ship features players love every single day.</p><script>alert(1)</script></div>
+  </div>
+</div></body></html>`
+
+func avatureSitemapIndex(locs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><sitemapindex>`)
+	for _, l := range locs {
+		b.WriteString(`<sitemap><loc>` + l + `</loc></sitemap>`)
+	}
+	b.WriteString(`</sitemapindex>`)
+	return b.String()
+}
+
+func avatureURLset(locs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><urlset>`)
+	for _, l := range locs {
+		b.WriteString(`<url><loc>` + l + `</loc><lastmod>2026-06-06</lastmod></url>`)
+	}
+	b.WriteString(`</urlset>`)
+	return b.String()
+}
+
+func TestAvatureProvider(t *testing.T) {
+	if got := NewAvature(nil).Provider(); got != "avature" {
+		t.Errorf("Provider() = %q, want %q", got, "avature")
+	}
+}
+
+func TestAvatureJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.ea.com/en_US/careers/JobDetail/Senior-Product-Manager/214840": "214840",
+		"https://jobs.ea.com/en_US/careers/JobDetail/Quality-Designer/208332/":      "208332",
+		"https://jobs.ea.com/en_US/careers/JobDetail/No-Id":                         "",
+	}
+	for loc, want := range cases {
+		if got := avatureJobID(loc); got != want {
+			t.Errorf("avatureJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestAvatureFetchSelectsEnUSSitemapAndMaps(t *testing.T) {
+	job := "https://jobs.ea.com/en_US/careers/JobDetail/Senior-Product-Manager/214840"
+	util := "https://jobs.ea.com/en_US/careers/AgentCreate" // non-JobDetail utility page, must be skipped
+	fake := (&routedHTTP{}).
+		route("/careers/sitemap_index.xml", avatureSitemapIndex(
+			"https://jobs.ea.com/en_US/careers/sitemap.xml",
+			"https://jobs.ea.com/es_ES/careers/sitemap.xml",
+		)).
+		route("/en_US/careers/sitemap.xml", avatureURLset(job, util)).
+		route("/JobDetail/Senior-Product-Manager/214840", avatureDetailHTML)
+
+	jobs, err := NewAvature(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Electronic Arts", Provider: "avature", Board: "jobs.ea.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (utility page must be filtered)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "214840" {
+		t.Errorf("ExternalID = %q, want 214840", j.ExternalID)
+	}
+	if j.URL != job {
+		t.Errorf("URL = %q, want %q", j.URL, job)
+	}
+	if j.Title != "Senior Product Manager" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Electronic Arts" {
+		t.Errorf("Company = %q, want config company", j.Company)
+	}
+	if j.Location != "Austin, Texas, United States of America" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid", j.WorkMode)
+	}
+	if j.Remote {
+		t.Error("Remote = true, want false for a hybrid posting")
+	}
+	if strings.Contains(j.Description, "<script>") || !strings.Contains(j.Description, "<h2>About</h2>") {
+		t.Errorf("Description not sanitized/assembled: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-06", j.PostedAt)
+	}
+}
+
+func TestAvatureWorkModeNormalization(t *testing.T) {
+	cases := map[string]string{
+		"Remote":       "remote",
+		"Fully Remote": "remote",
+		"Hybrid":       "hybrid",
+		"On-site":      "onsite",
+		"Onsite":       "onsite",
+		"In-office":    "onsite",
+		"":             "",
+		"Flexible":     "", // unknown → no structured signal
+	}
+	for in, want := range cases {
+		if got := avatureWorkMode(in); got != want {
+			t.Errorf("avatureWorkMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAvatureLabeledValueTakesPrimaryLocation(t *testing.T) {
+	// A multi-location posting appends a hidden location list after the primary value,
+	// separated by a non-breaking space; only the first (primary) location is kept.
+	h := `<div class="article__content__view__field__value"><strong>Locations</strong>: Redwood City, California, United States of America&nbsp; Location: AustinState: TexasCountry: United States of America</div>`
+	root := parseHTML(t, h)
+	if got := avatureLabeledValue(root, "Locations"); got != "Redwood City, California, United States of America" {
+		t.Errorf("avatureLabeledValue = %q, want primary location only", got)
+	}
+}
+
+func TestAvatureDescriptionIgnoresLongLocationDump(t *testing.T) {
+	// A many-location posting renders a long concatenated location dump inside the Locations
+	// field value; it must not be mistaken for the (shorter) job description, which is the
+	// value carrying prose markup.
+	h := `<div class='article__content'>
+	  <div class='article__content__view__field'><div class='article__content__view__field__value'><strong>Locations</strong>: A, B&nbsp; Location: CState: DCountry: ELocation: FState: GCountry: HLocation: IState: JCountry: KLocation: LState: MCountry: NLocation: OState: PCountry: Q</div></div>
+	  <div class='article__content__view__field'><div class='article__content__view__field__value'><p>Short job body.</p></div></div>
+	</div>`
+	root := parseHTML(t, h)
+	got := avatureDescription(root)
+	if !strings.Contains(got, "Short job body.") || strings.Contains(got, "Location:") {
+		t.Errorf("description picked the location dump instead of the prose body: %q", got)
+	}
+}
+
+func TestAvatureDropsJobWithNoParseableID(t *testing.T) {
+	loc := "https://jobs.ea.com/en_US/careers/JobDetail/No-Numeric-Id"
+	fake := (&routedHTTP{}).
+		route("/careers/sitemap_index.xml", avatureSitemapIndex("https://jobs.ea.com/en_US/careers/sitemap.xml")).
+		route("/en_US/careers/sitemap.xml", avatureURLset(loc)).
+		route("/JobDetail/No-Numeric-Id", avatureDetailHTML)
+	jobs, err := NewAvature(fake).Fetch(context.Background(), CompanyEntry{Board: "jobs.ea.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (unparseable id dropped)", len(jobs))
+	}
+}
+
+func TestAvatureMissingEnUSSitemapErrors(t *testing.T) {
+	// The index must advertise an en_US locale sitemap; without it the board can't be crawled.
+	fake := (&routedHTTP{}).
+		route("/careers/sitemap_index.xml", avatureSitemapIndex("https://jobs.ea.com/es_ES/careers/sitemap.xml"))
+	_, err := NewAvature(fake).Fetch(context.Background(), CompanyEntry{Board: "jobs.ea.com"})
+	if err == nil {
+		t.Fatal("expected error when no en_US sitemap is advertised")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -129,6 +129,7 @@ func All(c HTTPClient) map[string]Source {
 		NewICIMS(c),
 		NewJibe(c),
 		NewPhenom(c),
+		NewAvature(c),
 		NewRadancy(c),
 		NewJazzHR(c),
 		NewWPYoast(c),

--- a/sources/avature.yml
+++ b/sources/avature.yml
@@ -1,0 +1,8 @@
+# Avature career sites. Provider is the filename; each entry is company + board.
+# board = the career-site host (see internal/sources/avature.go); the adapter reads
+# https://<board>/careers/sitemap_index.xml, crawls the en_US locale sitemap, and parses
+# each JobDetail page's og:title + article__content__view__field blocks (no JSON-LD).
+# Each board validated live (en_US sitemap lists JobDetail postings) before adding.
+
+- company: Electronic Arts
+  board: jobs.ea.com


### PR DESCRIPTION
## What

New `avature` ATS adapter for Avature career sites, with EA's `jobs.ea.com` as the first board. Harvested from the hitmarker pass (EA = 184 jobs there, the largest no-adapter pocket); the adapter pulls EA's full board (~404 postings).

## How it works

Mirrors the `successfactors` pattern (sitemap + HTML detail):

1. `GET https://<board>/careers/sitemap_index.xml` → pick the **en_US** locale sub-sitemap (the other locales list the same postings).
2. Read its `<loc>`s, keep only `/careers/JobDetail/` URLs (utility pages like `AgentCreate` filtered).
3. Bounded detail fan-out per URL. Pages carry **no schema.org JSON-LD**, so fields come from HTML:
   - **Title** ← `og:title`; **Company** ← config; **ExternalID** ← trailing numeric id; **PostedAt** ← sitemap `lastmod`.
   - **WorkMode** ← the sidebar `Work Model` field (`article__content__view__field` label/value) → remote/hybrid/onsite.
   - **Location** ← the inline `<strong>Locations</strong>: …` value (a hidden multi-location dump after a non-breaking space is dropped — primary location only).
   - **Description** ← the richest field value carrying prose markup (paragraph/heading/list), so a long location dump can't be mistaken for the body.

`board` = the career-site host, so the adapter serves any Avature tenant by adding one `sources/avature.yml` entry.

## Tests

TDD, 8 unit tests in `avature_test.go` (sitemap-index → en_US selection → JobDetail filter → field mapping, work-mode normalization, primary-location extraction, description-vs-location-dump, unparseable-id drop, missing-en_US error). `go test ./internal/sources/` — `ok`; `go vet` clean; gofmt clean.

Live-validated against EA: **404 postings**, clean title/location/work-model/description.

## ⚠️ Deploy caveat

EA's nginx **rate-limits bursty crawling with HTTP 406** (tripped during testing after repeated full crawls). A single daily cron crawl (8-worker detail fan-out) is far gentler, but **smoke from the prod host before enabling the cron** — prod datacenter IPs are sometimes blocked where a residential IP passes (cf. EPAM/iTechArt). Until verified, add the board without scheduling its cron.