### PR TITLE
feat(sources): add recruiting-solutions.org adapter + YPOG (personio)

### DIFF
--- a/internal/sources/recruitingsolutions.go
+++ b/internal/sources/recruitingsolutions.go
@@ -1,0 +1,160 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// recruitingSolutions adapts career sites built on the recruiting-solutions.org "Career Site
+// Builder" platform (e.g. Bertelsmann's createyourowncareer.com). The career page is a client
+// rendered SPA, but it is backed by a keyless Azure Cognitive Search endpoint that returns the
+// full posting — title, HTML description, the operating company, location and dates — so the
+// adapter speaks to that API directly rather than scraping the SPA.
+//
+// The board is the platform tenant key (its Azure index, sent as the customerId header — e.g.
+// "riv-prod" for the Riverty/BFS customer). One tenant can host several operating companies, so
+// the company is taken per posting from the record, not from the board entry. The link field
+// carries the canonical apply URL, keeping the adapter independent of the tenant's own host.
+//
+// The index stores each posting once per UI locale (jobId "<id>-de_DE", "<id>-en_GB", …) with an
+// identical description, so the adapter dedups by the numeric base id, preferring the English
+// locale for the human-facing title and location text.
+const (
+	recruitingSolutionsAPI      = "https://production.api.recruiting-solutions.org/search"
+	recruitingSolutionsPageSize = 50
+)
+
+type recruitingSolutions struct {
+	http HeaderJSONPoster
+}
+
+// NewRecruitingSolutions builds the recruiting-solutions.org adapter over the given HTTP client.
+func NewRecruitingSolutions(c HeaderJSONPoster) Source { return recruitingSolutions{http: c} }
+
+func (recruitingSolutions) Provider() string { return "recruitingsolutions" }
+
+// rsSearchResponse is the Azure Cognitive Search reply: the total match count and one page of
+// records.
+type rsSearchResponse struct {
+	Count int     `json:"@odata.count"`
+	Value []rsJob `json:"value"`
+}
+
+// rsJob is one posting record (one locale of one posting) as the search index returns it.
+type rsJob struct {
+	JobID        string `json:"jobId"`
+	Title        string `json:"title"`
+	Company      string `json:"company"`
+	Description  string `json:"description"`
+	Link         string `json:"link"`
+	DatePosted   string `json:"datePosted"`
+	TeleComuteID string `json:"teleComuteId"`
+	IsActive     bool   `json:"isActive"`
+	Country      string `json:"country"`
+	Location     struct {
+		City            string `json:"city"`
+		CountryProvince string `json:"countryProvince"`
+	} `json:"location"`
+}
+
+func (s recruitingSolutions) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	headers := map[string]string{"customerId": e.Board}
+
+	best := map[string]rsJob{} // base id → chosen locale's record
+	var order []string         // base ids in first-seen order
+
+	for skip := 0; ; skip += recruitingSolutionsPageSize {
+		body := map[string]any{"count": true, "facets": []any{}, "filter": "", "search": "*", "skip": skip}
+		var resp rsSearchResponse
+		if err := s.http.PostJSONWithHeaders(ctx, recruitingSolutionsAPI, headers, body, &resp); err != nil {
+			return nil, fmt.Errorf("recruitingsolutions: search %s skip %d: %w", e.Board, skip, err)
+		}
+		if len(resp.Value) == 0 {
+			break
+		}
+		for _, r := range resp.Value {
+			if !r.IsActive {
+				continue // closed posting in this locale; an active locale (if any) still keeps it
+			}
+			base := rsBaseID(r.JobID)
+			if base == "" {
+				continue // no native id → would collide on the dedup key; skip it
+			}
+			cur, seen := best[base]
+			if !seen {
+				order = append(order, base)
+				best[base] = r
+			} else if rsLocaleRank(r.JobID) > rsLocaleRank(cur.JobID) {
+				best[base] = r
+			}
+		}
+		if skip+recruitingSolutionsPageSize >= resp.Count {
+			break
+		}
+	}
+
+	jobs := make([]Job, 0, len(order))
+	for _, base := range order {
+		jobs = append(jobs, recruitingSolutionsJob(base, best[base]))
+	}
+	return jobs, nil
+}
+
+// recruitingSolutionsJob maps a chosen record to a normalized Job under its base id.
+func recruitingSolutionsJob(base string, r rsJob) Job {
+	mode := rsWorkMode(r.TeleComuteID)
+	return Job{
+		ExternalID:  base,
+		URL:         rsCanonicalURL(r.Link),
+		Title:       r.Title,
+		Company:     r.Company,
+		Location:    joinNonEmpty(r.Location.City, r.Country),
+		Description: sanitizeHTML(r.Description),
+		Remote:      mode == "remote",
+		WorkMode:    mode,
+		PostedAt:    parseRFC3339(r.DatePosted),
+	}
+}
+
+// rsBaseID strips the trailing UI-locale suffix from a record's jobId ("274342-en_GB" → "274342"),
+// so the locale copies of one posting dedup to a single job.
+func rsBaseID(jobID string) string {
+	base, _, _ := strings.Cut(jobID, "-")
+	return base
+}
+
+// rsLocaleRank ranks a record's locale so dedup keeps the most English-friendly copy for the
+// title and location text (the description is identical across locales). Higher wins.
+func rsLocaleRank(jobID string) int {
+	switch _, lang, _ := strings.Cut(jobID, "-"); lang {
+	case "en_GB":
+		return 3
+	case "en_US":
+		return 2
+	default:
+		return 1
+	}
+}
+
+// rsWorkMode maps the platform's telecommute enum to our work-mode vocabulary; an unknown value
+// yields "".
+func rsWorkMode(teleID string) string {
+	switch teleID {
+	case "telecommute1":
+		return "hybrid"
+	case "telecommute2":
+		return "remote"
+	case "telecommute3":
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// rsCanonicalURL drops the locale query from a posting link, so every locale copy yields one
+// canonical apply URL.
+func rsCanonicalURL(link string) string {
+	url, _, _ := strings.Cut(link, "?")
+	return url
+}

--- a/internal/sources/recruitingsolutions_test.go
+++ b/internal/sources/recruitingsolutions_test.go
@@ -1,0 +1,148 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// rsFake is a HeaderJSONPoster that records the customerId header and returns the canned
+// page for the request body's "skip" offset (an absent offset yields an empty page, so the
+// pagination loop terminates).
+type rsFake struct {
+	pages      map[int]string
+	customerID string
+	calls      int
+}
+
+func (f *rsFake) PostJSONWithHeaders(_ context.Context, _ string, headers map[string]string, body, v any) error {
+	f.customerID = headers["customerId"]
+	f.calls++
+	skip := rsBodySkip(body)
+	page, ok := f.pages[skip]
+	if !ok {
+		page = `{"@odata.count":0,"value":[]}`
+	}
+	return json.Unmarshal([]byte(page), v)
+}
+
+// rsBodySkip extracts the skip offset from the adapter's request body regardless of whether
+// it is a map or a typed struct, by round-tripping through JSON.
+func rsBodySkip(body any) int {
+	b, _ := json.Marshal(body)
+	var req struct {
+		Skip int `json:"skip"`
+	}
+	_ = json.Unmarshal(b, &req)
+	return req.Skip
+}
+
+// rsRecord renders one Azure-search record (one locale of one posting) as the API returns it.
+func rsRecord(baseID, lang, title, company, desc, teleID string, active bool) string {
+	return fmt.Sprintf(`{"jobId":"%s-%s","title":%q,"company":%q,"description":%q,`+
+		`"teleComuteId":%q,"isActive":%t,"datePosted":"2026-05-29T07:58:01Z","country":"Germany",`+
+		`"location":{"city":"Berlin","countryProvince":"DE-BE"},`+
+		`"link":"https://jobsearch.createyourowncareer.com/job-invite/%s/?locale=%s"}`,
+		baseID, lang, title, company, desc, teleID, active, baseID, lang)
+}
+
+func rsPage(count int, records ...string) string {
+	return fmt.Sprintf(`{"@odata.count":%d,"value":[%s]}`, count, strings.Join(records, ","))
+}
+
+func TestRecruitingSolutionsProvider(t *testing.T) {
+	if got := NewRecruitingSolutions(nil).Provider(); got != "recruitingsolutions" {
+		t.Errorf("Provider() = %q, want %q", got, "recruitingsolutions")
+	}
+}
+
+func TestRecruitingSolutionsFetchDedupsLocalesAndMaps(t *testing.T) {
+	page := rsPage(3,
+		// base 100: three locales of one posting; en_GB is the English title we want kept.
+		rsRecord("100", "de_DE", "Ingenieur", "Riverty Group GmbH", "<p>Body</p>", "telecommute1", true),
+		rsRecord("100", "en_GB", "Engineer", "Riverty Group GmbH", "<p>Body</p>", "telecommute1", true),
+		rsRecord("100", "en_US", "Engineer US", "Riverty Group GmbH", "<p>Body</p>", "telecommute1", true),
+		// base 200: only a non-English locale — kept as the fallback. Office-based.
+		rsRecord("200", "de_DE", "Buchhalter", "BFS Health Finance GmbH", "<p>Zahlen</p>", "telecommute3", true),
+		// base 300: every locale inactive — dropped entirely.
+		rsRecord("300", "en_GB", "Closed Role", "Riverty Norway AS", "<p>gone</p>", "telecommute1", false),
+	)
+	fake := &rsFake{pages: map[int]string{0: page}}
+
+	jobs, err := NewRecruitingSolutions(fake).Fetch(context.Background(), CompanyEntry{Board: "riv-prod"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.customerID != "riv-prod" {
+		t.Errorf("customerId header = %q, want %q", fake.customerID, "riv-prod")
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (locales deduped, inactive dropped): %+v", len(jobs), jobs)
+	}
+
+	by := map[string]Job{}
+	for _, j := range jobs {
+		by[j.ExternalID] = j
+	}
+
+	j100, ok := by["100"]
+	if !ok {
+		t.Fatal("missing job 100")
+	}
+	if j100.Title != "Engineer" {
+		t.Errorf("job 100 Title = %q, want %q (English locale preferred)", j100.Title, "Engineer")
+	}
+	if j100.Company != "Riverty Group GmbH" {
+		t.Errorf("job 100 Company = %q", j100.Company)
+	}
+	if want := "https://jobsearch.createyourowncareer.com/job-invite/100/"; j100.URL != want {
+		t.Errorf("job 100 URL = %q, want %q (locale query stripped)", j100.URL, want)
+	}
+	if !strings.Contains(j100.Description, "Body") {
+		t.Errorf("job 100 Description = %q, want it to carry the body", j100.Description)
+	}
+	if j100.WorkMode != "hybrid" {
+		t.Errorf("job 100 WorkMode = %q, want hybrid (telecommute1)", j100.WorkMode)
+	}
+	if j100.PostedAt == nil {
+		t.Error("job 100 PostedAt is nil, want parsed datePosted")
+	}
+
+	j200, ok := by["200"]
+	if !ok {
+		t.Fatal("missing job 200 (non-English fallback)")
+	}
+	if j200.WorkMode != "onsite" {
+		t.Errorf("job 200 WorkMode = %q, want onsite (telecommute3)", j200.WorkMode)
+	}
+}
+
+func TestRecruitingSolutionsPaginates(t *testing.T) {
+	// A full first page forces a second request; the short second page completes the count.
+	total := recruitingSolutionsPageSize + 2
+	first := make([]string, recruitingSolutionsPageSize)
+	for i := range first {
+		first[i] = rsRecord(fmt.Sprintf("%d", i), "en_GB", "Role", "Riverty Group GmbH", "<p>x</p>", "telecommute1", true)
+	}
+	second := []string{
+		rsRecord("9001", "en_GB", "Late A", "Riverty Group GmbH", "<p>x</p>", "telecommute1", true),
+		rsRecord("9002", "en_GB", "Late B", "Riverty Group GmbH", "<p>x</p>", "telecommute1", true),
+	}
+	fake := &rsFake{pages: map[int]string{
+		0:                           rsPage(total, first...),
+		recruitingSolutionsPageSize: rsPage(total, second...),
+	}}
+
+	jobs, err := NewRecruitingSolutions(fake).Fetch(context.Background(), CompanyEntry{Board: "riv-prod"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != total {
+		t.Errorf("got %d jobs, want %d (both pages collected)", len(jobs), total)
+	}
+	if fake.calls < 2 {
+		t.Errorf("made %d requests, want at least 2 (pagination)", fake.calls)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -146,6 +146,7 @@ func All(c HTTPClient) map[string]Source {
 		NewEightfold(c),
 		NewFreshteam(c),
 		NewDeel(c),
+		NewRecruitingSolutions(c),
 		NewUKG(c),
 		NewSenior(c),
 		NewTrakstar(c),

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -753,5 +753,7 @@
   board: wwp
 - company: yohumanize
   board: yohumanize
+- company: YPOG
+  board: ypog-law
 - company: zellerfeld
   board: zellerfeld

--- a/sources/recruitingsolutions.yml
+++ b/sources/recruitingsolutions.yml
@@ -1,0 +1,9 @@
+# recruiting-solutions.org (Career Site Builder) boards. Provider is the filename; each
+# entry is company + board. board = the platform tenant key, sent as the customerId header
+# to the Azure search API (see internal/sources/recruitingsolutions.go). One tenant can host
+# several operating companies, so the company below is just the tenant's display name — each
+# posting carries its own employer.
+
+# Bertelsmann group, Riverty/BFS financial-services customer (createyourowncareer.com).
+- company: Riverty
+  board: riv-prod


### PR DESCRIPTION
## What

Harvest of [legaloperationsjobboard.com](https://legaloperationsjobboard.com/job-board): I traced every outbound apply link to its real ATS. All ATS-resolving links were **already covered** (Ashby/Greenhouse incl. Clay/Databricks/Fivetran vanity domains, Workday gtlaw/innocap, DoorDash→Greenhouse, LEGO→Workday) **except two**, added here.

### 1. `recruitingsolutions` — new adapter
recruiting-solutions.org "Career Site Builder" sites (e.g. Bertelsmann's `createyourowncareer.com`).

- The careers page is a **client-rendered SPA**; its schema.org microdata is JS template junk and the description isn't server-rendered, so the existing `successfactors` adapter (server-rendered microdata) **can't extract it**.
- The SPA is backed by a **keyless Azure Cognitive Search** endpoint — `POST production.api.recruiting-solutions.org/search` with a `customerId` header (no api-key, no cookie/CSRF) — that returns the full posting: title, HTML description, the **real operating company** (not the parent "Bertelsmann SE"), location, dates, work mode.
- **board = tenant `customerId`.** One tenant hosts many operating companies, so the company is taken **per record**. The index stores each posting once per UI locale (`<id>-de_DE`, `<id>-en_GB`, …) with identical description, so the adapter **dedups by base id**, preferring English for the title/location text.
- board `riv-prod` (Riverty/BFS financial cluster) = **67 jobs, 0 empty descriptions** — live-verified end-to-end through `cmd/ingest` (ingested=67, failed=0).

### 2. `personio` — add YPOG (`board: ypog-law`)
YPOG's HubSpot careers site just fronts `ypog-law.jobs.personio.com` — no custom adapter needed (the recurring "custom site fronts a standard ATS" lesson). 23 positions live.

## Deferred
**Heineken** (`careers.theheinekencompany.com`) — the one remaining uncovered link — is a **Cloudflare-gated** custom SPA whose `sitemap.xml` lists only landing pages (no jobs). Would need a single-company SPA reverse-engineer and is likely prod-IP-blocked; deferred.

## Tests
- New adapter unit tests (provider key, locale dedup + field mapping + inactive-skip, skip pagination).
- `go build ./...`, `go vet ./...`, `gofmt`, full `go test ./...` clean.
- Live smoke + full `cmd/ingest` run against production (67 jobs, all with descriptions, correct per-posting companies).

## Deploy notes
- **New adapter** = full image rebuild + a cron line for `sources/recruitingsolutions.yml` (no Dockerfile change).
- YPOG ships with the existing personio cron.
- More Bertelsmann brands (ARVATO, RTL, Penguin Random House, BMG…) live on the same host under their **own customerIds** — each is one more line in `sources/recruitingsolutions.yml` (capture the `customerId` header from the brand's pages).