### PR TITLE
feat(sources): add Comeet adapter (Overwolf)

### DIFF
--- a/internal/sources/comeet.go
+++ b/internal/sources/comeet.go
@@ -1,0 +1,165 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// comeet adapts Comeet career sites. The board is "<slug>/<companyUID>" (taken straight
+// from a public job URL, comeet.com/jobs/<slug>/<companyUID>). The company page embeds a
+// public read token; with it, one careers-api call returns every position fully populated
+// (structured location, a workplace_type enum, and a description split into named HTML
+// sections), so no per-posting detail fetch is needed.
+type comeetHTTP interface {
+	HTMLGetter
+	JSONGetter
+}
+
+type comeet struct {
+	http comeetHTTP
+}
+
+// NewComeet builds the Comeet adapter over the given HTTP client.
+func NewComeet(c comeetHTTP) Source { return comeet{http: c} }
+
+func (comeet) Provider() string { return "comeet" }
+
+// comeetLocation is a position's structured location.
+type comeetLocation struct {
+	Name    string `json:"name"`
+	Country string `json:"country"`
+	City    string `json:"city"`
+	State   string `json:"state"`
+}
+
+// String renders the location as "City, State", falling back to the country code, then the
+// free-text name, then "".
+func (l comeetLocation) String() string {
+	var parts []string
+	for _, p := range []string{l.City, l.State} {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, ", ")
+	}
+	if c := strings.TrimSpace(l.Country); c != "" {
+		return c
+	}
+	return strings.TrimSpace(l.Name)
+}
+
+// comeetSection is one named HTML block of a position's description (Description,
+// Responsibilities, Requirements, …).
+type comeetSection struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type comeetPosition struct {
+	UID           string          `json:"uid"`
+	Name          string          `json:"name"`
+	CompanyName   string          `json:"company_name"`
+	URLActivePage string          `json:"url_active_page"`
+	WorkplaceType string          `json:"workplace_type"`
+	TimeUpdated   string          `json:"time_updated"`
+	Location      comeetLocation  `json:"location"`
+	Details       []comeetSection `json:"details"`
+}
+
+func (c comeet) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	slash := strings.LastIndex(e.Board, "/")
+	if slash < 0 {
+		return nil, fmt.Errorf("comeet: board %q must be %q", e.Board, "<slug>/<companyUID>")
+	}
+	uid := e.Board[slash+1:]
+
+	root, err := c.http.GetHTML(ctx, "https://www.comeet.com/jobs/"+e.Board)
+	if err != nil {
+		return nil, fmt.Errorf("comeet: page %s: %w", e.Board, err)
+	}
+	token := comeetToken(root)
+	if token == "" {
+		return nil, fmt.Errorf("comeet: no token found for board %s", e.Board)
+	}
+
+	url := fmt.Sprintf("https://www.comeet.co/careers-api/2.0/company/%s/positions?token=%s&details=true", uid, token)
+	var positions []comeetPosition
+	if err := c.http.GetJSON(ctx, url, &positions); err != nil {
+		return nil, fmt.Errorf("comeet: positions %s: %w", uid, err)
+	}
+
+	jobs := make([]Job, 0, len(positions))
+	for _, p := range positions {
+		if j, ok := c.toJob(p, e); ok {
+			jobs = append(jobs, j)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a position to a Job, returning ok=false when it carries no uid (which would
+// collide on the dedup key). Company comes from config, falling back to the payload.
+func (comeet) toJob(p comeetPosition, e CompanyEntry) (Job, bool) {
+	if p.UID == "" {
+		return Job{}, false
+	}
+
+	var desc strings.Builder
+	for _, s := range p.Details {
+		if strings.TrimSpace(s.Value) == "" {
+			continue
+		}
+		// The intro section is unlabeled prose; the rest (Responsibilities, Requirements)
+		// keep their heading so the assembled body stays readable.
+		if s.Name != "" && !strings.EqualFold(s.Name, "Description") {
+			desc.WriteString("<h3>" + html.EscapeString(s.Name) + "</h3>")
+		}
+		desc.WriteString(s.Value)
+	}
+
+	company := e.Company
+	if company == "" {
+		company = p.CompanyName
+	}
+
+	mode := workplaceTypeMode(p.WorkplaceType)
+	return Job{
+		ExternalID:  p.UID,
+		URL:         p.URLActivePage,
+		Title:       p.Name,
+		Company:     company,
+		Location:    p.Location.String(),
+		Description: sanitizeHTML(desc.String()),
+		Remote:      mode == "remote",
+		WorkMode:    mode,
+		PostedAt:    parseRFC3339(p.TimeUpdated),
+	}, true
+}
+
+// comeetTokenPattern captures the public read token Comeet embeds in the careers page.
+// The length floor avoids matching shorter, unrelated "token" keys other inline scripts
+// (analytics, consent, …) may carry; the real careers token is a long alphanumeric string.
+var comeetTokenPattern = regexp.MustCompile(`"token"\s*:\s*"([A-Za-z0-9]{20,})"`)
+
+// comeetToken extracts the careers read token from the page's inline script state.
+func comeetToken(root *html.Node) string {
+	var token string
+	walk(root, func(n *html.Node) bool {
+		if token != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "script" {
+			if m := comeetTokenPattern.FindStringSubmatch(textContent(n)); m != nil {
+				token = m[1]
+			}
+		}
+		return true
+	})
+	return token
+}

--- a/internal/sources/comeet_test.go
+++ b/internal/sources/comeet_test.go
@@ -1,0 +1,154 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// comeetPageHTML mirrors a Comeet careers page: the public read token is embedded in an
+// inline script's JSON state.
+const comeetPageHTML = `<html><head><title>Overwolf Careers</title></head><body>
+<div id="comeet"></div>
+<script>window.__data = {"company":{"uid":"B1.001"},"token":"1B16C4BD7005131B1A26F391B1"};</script>
+</body></html>`
+
+// comeetPositionsJSON mirrors the careers-api positions payload: a list of positions, each
+// with structured location, a workplace_type enum, and details split into named HTML sections.
+const comeetPositionsJSON = `[
+  {
+    "uid": "BC.26F",
+    "name": "Data Analyst Lead",
+    "company_name": "Overwolf",
+    "url_active_page": "https://careers.overwolf.com/career/BC.26F",
+    "workplace_type": "Hybrid",
+    "time_updated": "2026-06-22T18:23:19Z",
+    "location": {"name": "HQ", "country": "IL", "city": "Ramat Gan", "state": "Israel"},
+    "details": [
+      {"name": "Description", "value": "<p>Lead our data team.</p>", "order": 1},
+      {"name": "Requirements", "value": "<ul><li>SQL</li></ul><script>alert(1)</script>", "order": 2}
+    ]
+  }
+]`
+
+func newComeetFake() *routedHTTP {
+	return (&routedHTTP{}).
+		route("/jobs/overwolf/B1.001", comeetPageHTML).
+		route("/careers-api/2.0/company/B1.001/positions", comeetPositionsJSON)
+}
+
+func TestComeetProvider(t *testing.T) {
+	if got := NewComeet(nil).Provider(); got != "comeet" {
+		t.Errorf("Provider() = %q, want %q", got, "comeet")
+	}
+}
+
+func TestComeetFetchScrapesTokenThenMapsPositions(t *testing.T) {
+	jobs, err := NewComeet(newComeetFake()).Fetch(context.Background(), CompanyEntry{
+		Company: "Overwolf", Provider: "comeet", Board: "overwolf/B1.001",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "BC.26F" {
+		t.Errorf("ExternalID = %q, want BC.26F", j.ExternalID)
+	}
+	if j.Title != "Data Analyst Lead" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Overwolf" {
+		t.Errorf("Company = %q, want config company", j.Company)
+	}
+	if j.URL != "https://careers.overwolf.com/career/BC.26F" {
+		t.Errorf("URL = %q, want the active careers page", j.URL)
+	}
+	if j.Location != "Ramat Gan, Israel" {
+		t.Errorf("Location = %q, want \"Ramat Gan, Israel\"", j.Location)
+	}
+	if j.WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid", j.WorkMode)
+	}
+	if j.Remote {
+		t.Error("Remote = true, want false for a hybrid posting")
+	}
+	if strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Lead our data team.") || !strings.Contains(j.Description, "<li>SQL</li>") {
+		t.Errorf("Description missing section content: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Requirements") {
+		t.Errorf("Description should label non-intro sections: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 22, 18, 23, 19, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-22T18:23:19Z", j.PostedAt)
+	}
+}
+
+func TestComeetLocation(t *testing.T) {
+	cases := []struct {
+		loc  comeetLocation
+		want string
+	}{
+		{comeetLocation{City: "Ramat Gan", State: "Israel"}, "Ramat Gan, Israel"},
+		{comeetLocation{City: "Berlin"}, "Berlin"},
+		{comeetLocation{Country: "DE"}, "DE"},
+		{comeetLocation{Name: "Remote"}, "Remote"},
+		{comeetLocation{}, ""},
+	}
+	for _, c := range cases {
+		if got := c.loc.String(); got != c.want {
+			t.Errorf("comeetLocation%+v = %q, want %q", c.loc, got, c.want)
+		}
+	}
+}
+
+func TestComeetMissingTokenErrors(t *testing.T) {
+	fake := (&routedHTTP{}).route("/jobs/overwolf/B1.001", `<html><body>no token here</body></html>`)
+	_, err := NewComeet(fake).Fetch(context.Background(), CompanyEntry{Board: "overwolf/B1.001"})
+	if err == nil {
+		t.Fatal("expected error when the page exposes no token")
+	}
+}
+
+func TestComeetDropsPositionWithNoUID(t *testing.T) {
+	page := `<html><body><script>{"token":"ABCDEF1234567890ABCDEF12"}</script></body></html>`
+	positions := `[{"name":"No UID","workplace_type":"On-site"}]`
+	fake := (&routedHTTP{}).
+		route("/jobs/x/UID.1", page).
+		route("/careers-api/2.0/company/UID.1/positions", positions)
+	jobs, err := NewComeet(fake).Fetch(context.Background(), CompanyEntry{Board: "x/UID.1"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (no-uid dropped)", len(jobs))
+	}
+}
+
+func TestComeetRemotePositionSetsRemote(t *testing.T) {
+	page := `<html><body><script>{"token":"ABCDEF1234567890ABCDEF12"}</script></body></html>`
+	positions := `[{"uid":"R1.A0","name":"SRE","workplace_type":"Remote","details":[{"name":"Description","value":"<p>x</p>"}]}]`
+	fake := (&routedHTTP{}).
+		route("/jobs/x/UID.1", page).
+		route("/careers-api/2.0/company/UID.1/positions", positions)
+	jobs, err := NewComeet(fake).Fetch(context.Background(), CompanyEntry{Board: "x/UID.1"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].WorkMode != "remote" || !jobs[0].Remote {
+		t.Fatalf("remote mapping failed: %+v", jobs)
+	}
+}
+
+func TestComeetBoardWithoutUIDErrors(t *testing.T) {
+	_, err := NewComeet(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Board: "noslug"})
+	if err == nil {
+		t.Fatal("expected error for a board without a /companyUID segment")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -130,6 +130,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJibe(c),
 		NewPhenom(c),
 		NewAvature(c),
+		NewComeet(c),
 		NewRadancy(c),
 		NewJazzHR(c),
 		NewWPYoast(c),

--- a/sources/comeet.yml
+++ b/sources/comeet.yml
@@ -1,0 +1,8 @@
+# Comeet career sites. Provider is the filename; each entry is company + board.
+# board = "<slug>/<companyUID>" taken from a public job URL
+# (comeet.com/jobs/<slug>/<companyUID>); see internal/sources/comeet.go. The adapter
+# scrapes the page's public read token, then one careers-api call returns every position.
+# Each board validated live (positions API returned >0) before adding.
+
+- company: Overwolf
+  board: overwolf/B1.001


### PR DESCRIPTION
## What

New `comeet` ATS adapter for Comeet career sites, first board = **Overwolf** (harvested from the hitmarker pass). `board` = `<slug>/<companyUID>` taken straight from a public Comeet job URL (`comeet.com/jobs/<slug>/<companyUID>`).

## How it works

Clean two-call flow, no per-posting detail fetch:

1. `GET https://www.comeet.com/jobs/<board>` → scrape the page's embedded public **read token** from inline script state.
2. `GET https://www.comeet.co/careers-api/2.0/company/<companyUID>/positions?token=<token>&details=true` → a JSON list of fully-populated positions.

Mapping: `uid` → ExternalID, `url_active_page` → URL, `name` → Title, config company (fallback `company_name`), structured `location` → "City, State", `workplace_type` → WorkMode via the shared `workplaceTypeMode`, `time_updated` → PostedAt (`parseRFC3339`), and the `details` named HTML sections joined into a sanitized description (non-intro section names escaped and kept as headings).

## Review feedback addressed
- Token regex tightened (length floor) so it can't match a shorter unrelated `"token"` key from another inline script.
- Fast-fail with a clear error when `board` lacks the `/companyUID` segment.
- Section heading names HTML-escaped before assembly.

## Tests
TDD, 7 unit tests in `comeet_test.go` (token scrape → positions map, location rendering, remote round-trip, missing-token error, malformed-board error, no-uid drop). `go test ./internal/sources/` — `ok`; `go vet` + gofmt clean.

Live-validated against Overwolf: **12 postings**, clean location/work-mode/description (hybrid 10 / on-site 1 / remote 1).

Adding any other Comeet tenant = one `sources/comeet.yml` entry (`<slug>/<companyUID>` from its job URL).