### PR TITLE
feat(sources): CareerPlug adapter (+231 boards from role.com)

### DIFF
--- a/cmd/harvest-boards/careerplug_prober.go
+++ b/cmd/harvest-boards/careerplug_prober.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// careerplugProber validates a CareerPlug board "<slug>" by counting the postings linked
+// from its /jobs listing page ("<slug>.careerplug.com/jobs"). CareerPlug's listing exposes
+// no single account name (the adapter reads a per-posting employer from each job's JSON-LD),
+// so the prober returns an empty name.
+type careerplugProber struct{}
+
+// careerplugJobLink captures a posting's numeric id from a CareerPlug job link (/jobs/<id>),
+// so duplicate links to the same posting (title + row) count once and pagination/listing
+// links are ignored.
+var careerplugJobLink = regexp.MustCompile(`/jobs/(\d+)`)
+
+func (careerplugProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
+	root, err := c.GetHTML(ctx, fmt.Sprintf("https://%s.careerplug.com/jobs", slug))
+	if err != nil {
+		return "", 0, nil
+	}
+	ids := map[string]bool{}
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			for _, a := range n.Attr {
+				if a.Key == "href" {
+					if m := careerplugJobLink.FindStringSubmatch(a.Val); m != nil {
+						ids[m[1]] = true
+					}
+				}
+			}
+		}
+		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+			walk(ch)
+		}
+	}
+	walk(root)
+	if len(ids) == 0 {
+		return "", 0, nil
+	}
+	return "", len(ids), nil
+}

--- a/cmd/harvest-boards/careerplug_prober_test.go
+++ b/cmd/harvest-boards/careerplug_prober_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCareerPlugProbe(t *testing.T) {
+	p := careerplugProber{}
+	listing := `<html><body><div id="job_table">
+<a href="/jobs/100"><span class="name">Server</span></a>
+<a href="/jobs/100">Apply</a>
+<a href="/jobs/200">Cook</a>
+<a href="/about">About</a>
+<a href="/jobs?page=2">Next</a>
+</div></body></html>`
+	getter := fakeGetter{
+		"https://acme.careerplug.com/jobs":  listing,
+		"https://empty.careerplug.com/jobs": `<html><body><a href="/about">About</a></body></html>`,
+	}
+	// live: two DISTINCT postings (the duplicate link counts once), no API name.
+	if name, n, err := p.probe(context.Background(), getter, "acme"); err != nil || name != "" || n != 2 {
+		t.Errorf("live: got (%q,%d,%v), want (\"\",2,nil)", name, n, err)
+	}
+	if _, n, err := p.probe(context.Background(), getter, "empty"); err != nil || n != 0 {
+		t.Errorf("empty: got n=%d err=%v, want 0,nil", n, err)
+	}
+	if _, n, err := p.probe(context.Background(), getter, "gone"); err != nil || n != 0 {
+		t.Errorf("gone: got n=%d err=%v, want 0,nil", n, err)
+	}
+}

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -562,4 +562,5 @@ var probers = map[string]prober{
 	"join":            joinProber{},
 	"oracle":          oracleProber{},
 	"jazzhr":          jazzhrProber{},
+	"careerplug":      careerplugProber{},
 }

--- a/internal/atsdetect/fromurl.go
+++ b/internal/atsdetect/fromurl.go
@@ -61,6 +61,10 @@ func FromURL(rawurl string) (provider, board string, ok bool) {
 		if sub := subdomain(host, ".pinpointhq.com"); sub != "" {
 			return "pinpoint", sub, true
 		}
+	case strings.HasSuffix(host, ".careerplug.com"):
+		if sub := subdomain(host, ".careerplug.com"); sub != "" {
+			return "careerplug", sub, true
+		}
 	case strings.HasSuffix(host, ".icims.com"):
 		// Our icims adapter builds the host "careers-<board>.icims.com", so only a
 		// careers-prefixed subdomain yields a crawlable board.

--- a/internal/atsdetect/fromurl_test.go
+++ b/internal/atsdetect/fromurl_test.go
@@ -76,6 +76,11 @@ func TestFromURL(t *testing.T) {
 			url:      "https://therapymgmt.pinpointhq.com/en/postings/88dfb239-bb43",
 			provider: "pinpoint", board: "therapymgmt", ok: true,
 		},
+		{
+			name:     "careerplug",
+			url:      "https://golden-corral-careers.careerplug.com/jobs/1334156?utm_source=Role",
+			provider: "careerplug", board: "golden-corral-careers", ok: true,
+		},
 		// iCIMS: board is the tenant in careers-<board>.icims.com.
 		{
 			name:     "icims careers prefix",

--- a/internal/sources/careerplug.go
+++ b/internal/sources/careerplug.go
@@ -1,0 +1,167 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// careerplug adapts CareerPlug career sites (<board>.careerplug.com): a server-rendered ATS
+// whose /jobs listing paginates with ?page=N and links each posting as /jobs/<id>, and whose
+// job pages carry a schema.org JobPosting ld+json. The board is the account subdomain. Like
+// the other ld+json detail adapters it fetches each posting's page for the description; the
+// employer comes per-posting from the JSON-LD (CareerPlug accounts are often franchises whose
+// postings name the individual location), falling back to the configured company. It exposes
+// no jobLocationType, so the remote flag falls back to the location text.
+type careerplug struct {
+	http HTMLGetter
+}
+
+// NewCareerPlug builds the CareerPlug adapter over the given HTTP client.
+func NewCareerPlug(c HTMLGetter) Source { return careerplug{http: c} }
+
+func (careerplug) Provider() string { return "careerplug" }
+
+// careerplugMaxPages bounds listing pagination so a board that clamps ?page=N to its last
+// page (serving the same links forever) cannot loop; the no-new-links check ends it sooner.
+const careerplugMaxPages = 100
+
+func (s careerplug) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	host := fmt.Sprintf("%s.careerplug.com", e.Board)
+	// base carries scheme+host so the listing's relative /jobs/<id> hrefs resolve to
+	// fetchable URLs; parsed once rather than per page.
+	base, err := url.Parse(fmt.Sprintf("https://%s/", host))
+	if err != nil {
+		return nil, fmt.Errorf("careerplug: board %q: %w", e.Board, err)
+	}
+
+	var urls []string
+	seen := make(map[string]bool)
+	for page := 1; page <= careerplugMaxPages; page++ {
+		listURL := fmt.Sprintf("https://%s/jobs", host)
+		if page > 1 {
+			listURL = fmt.Sprintf("https://%s/jobs?page=%d", host, page)
+		}
+		root, err := s.http.GetHTML(ctx, listURL)
+		if err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("careerplug: listing %s: %w", e.Board, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		newLinks := 0
+		for _, link := range careerplugJobLinks(base, root) {
+			if !seen[link] {
+				seen[link] = true
+				urls = append(urls, link)
+				newLinks++
+			}
+		}
+		if newLinks == 0 { // empty page, or a board clamping ?page=N past its last page
+			break
+		}
+	}
+
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return s.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the page fetch fails, carries no JobPosting, or has no parseable id, so the caller
+// skips just that posting.
+func (s careerplug) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := careerplugJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := s.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p careerplugPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	location := p.location()
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     firstNonEmpty(p.HiringOrganization.Name, e.Company),
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		// No jobLocationType is emitted, so the location text is the only remote signal
+		// (never the title, which false-positives on "Remote …" role names).
+		Remote:   isRemote(location),
+		PostedAt: parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// careerplugJobIDPattern captures the numeric posting id from a /jobs/<id> URL. The digit
+// requirement keeps the bare /jobs listing and its ?page=N variants from being mistaken for
+// a job.
+var careerplugJobIDPattern = regexp.MustCompile(`/jobs/(\d+)`)
+
+// careerplugJobID extracts the native posting id from a job URL, or "" when absent.
+func careerplugJobID(u string) string {
+	if m := careerplugJobIDPattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// careerplugJobLinks returns the absolute hrefs of all /jobs/<id> job-page anchors, resolved
+// against base so relative hrefs yield fetchable URLs, de-duplicated in first-seen order (a
+// card links the same job from its title and other controls).
+func careerplugJobLinks(base *url.URL, root *html.Node) []string {
+	var out []string
+	seen := make(map[string]bool)
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := attr(n, "href")
+			if careerplugJobID(href) == "" {
+				return true
+			}
+			ref, err := url.Parse(href)
+			if err != nil {
+				return true
+			}
+			abs := base.ResolveReference(ref).String()
+			if !seen[abs] {
+				seen[abs] = true
+				out = append(out, abs)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// careerplugPosting is the schema.org JobPosting decoded from a CareerPlug job page's
+// ld+json. jobLocation is a single Place (not an array).
+type careerplugPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+			AddressRegion   string `json:"addressRegion"`
+			AddressCountry  string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+}
+
+// location builds the display location from the posting's address (city, region, country).
+func (p careerplugPosting) location() string {
+	a := p.JobLocation.Address
+	return joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry)
+}

--- a/internal/sources/careerplug_test.go
+++ b/internal/sources/careerplug_test.go
@@ -1,0 +1,106 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// careerplugDetailA/B are CareerPlug job pages: server-rendered HTML whose payload is the
+// schema.org JobPosting ld+json. jobLocation is a single Place; hiringOrganization names the
+// (per-posting, franchise-level) employer.
+const careerplugDetailA = `<html><head>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Restaurant Team Member","description":"<div>Serve guests.</div><script>x()<\/script>",
+"datePosted":"2026-06-20T12:00:00+00:00","employmentType":"FULL_TIME",
+"hiringOrganization":{"@type":"Organization","name":"Golden Corral - Concord"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Concord","addressRegion":"CA","addressCountry":"US"}}}</script>
+</head><body>Apply</body></html>`
+
+const careerplugDetailB = `<html><head>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Shift Lead","description":"<p>Lead a shift.</p>","datePosted":"2026-06-19T09:00:00+00:00",
+"hiringOrganization":{"@type":"Organization","name":"Golden Corral - Reno"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Reno","addressRegion":"NV","addressCountry":"US"}}}</script>
+</head><body>Apply</body></html>`
+
+// careerplugList1/2 are the paginated /jobs listing pages: each links its postings as
+// /jobs/<id>, and a job is linked twice (title + row) so the adapter must de-dup.
+const careerplugList1 = `<html><body><div id="job_table">
+<a href="/jobs/100"><span class="name">Restaurant Team Member</span></a>
+<a href="/jobs/100">Apply</a>
+<a href="/about">About</a>
+<a href="/jobs?page=2">Next</a>
+</div></body></html>`
+
+const careerplugList2 = `<html><body><div id="job_table">
+<a href="/jobs/200"><span class="name">Shift Lead</span></a>
+</div></body></html>`
+
+func TestCareerPlugProvider(t *testing.T) {
+	if got := NewCareerPlug(nil).Provider(); got != "careerplug" {
+		t.Errorf("Provider() = %q, want %q", got, "careerplug")
+	}
+}
+
+func TestCareerPlugJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://acme.careerplug.com/jobs/932346": "932346",
+		"/jobs/100":    "100",
+		"/jobs?page=2": "",
+		"/jobs":        "",
+		"/about":       "",
+	}
+	for u, want := range cases {
+		if got := careerplugJobID(u); got != want {
+			t.Errorf("careerplugJobID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestCareerPlugFetchPaginatesThenMaps(t *testing.T) {
+	// Contains-matching, so the most specific routes (the detail ids, then page=2) come
+	// before the bare /jobs page-1 listing.
+	fake := (&routedHTTP{}).
+		route("/jobs/100", careerplugDetailA).
+		route("/jobs/200", careerplugDetailB).
+		route("/jobs?page=2", careerplugList2).
+		route("/jobs", careerplugList1)
+
+	jobs, err := NewCareerPlug(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Golden Corral", Provider: "careerplug", Board: "golden-corral-careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (paginated across two listing pages, links de-duped)", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	a, ok := byID["100"]
+	if !ok {
+		t.Fatalf("missing job 100; got %v", byID)
+	}
+	if a.Title != "Restaurant Team Member" || a.Company != "Golden Corral - Concord" {
+		t.Errorf("job 100: got title=%q company=%q", a.Title, a.Company)
+	}
+	if a.Location != "Concord, CA, US" {
+		t.Errorf("job 100 location = %q, want %q", a.Location, "Concord, CA, US")
+	}
+	if a.URL != "https://golden-corral-careers.careerplug.com/jobs/100" {
+		t.Errorf("job 100 URL = %q (relative href must resolve against the board host)", a.URL)
+	}
+	if strings.Contains(a.Description, "<script>") {
+		t.Errorf("job 100 description not sanitized: %q", a.Description)
+	}
+	if a.PostedAt == nil || !a.PostedAt.Equal(time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("job 100 PostedAt = %v", a.PostedAt)
+	}
+	if _, ok := byID["200"]; !ok {
+		t.Errorf("missing job 200 (second listing page not followed)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -136,6 +136,7 @@ func All(c HTTPClient) map[string]Source {
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),
+		NewCareerPlug(c),
 		NewLuxoft(c),
 		NewEPAM(c),
 		NewADP(c),

--- a/sources/careerplug.yml
+++ b/sources/careerplug.yml
@@ -1,0 +1,464 @@
+# careerplug boards. Provider is the filename; each entry is company + board.
+# board = the account subdomain in <board>.careerplug.com (see internal/sources/careerplug.go).
+- company: 1-800 WATER DAMAGE
+  board: 1-800-water-damage-careers
+- company: 360clean | Complete Facility Care
+  board: 360clean-careers
+- company: Abita Roasting Company
+  board: abita-roasting
+- company: Air Conditioning Contractors of America (ACCA)
+  board: acca-careers
+- company: Ace Handyman Services
+  board: acehandymanservicescareers
+- company: Assisting Hands Home Care, LLC
+  board: ahhc-careers
+- company: AKIVA AI
+  board: akiva-technologies-llc
+- company: AlphaGraphics
+  board: alphagraphics-careers
+- company: American Family Care
+  board: american-family-care-careers
+- company: Anatomy
+  board: anatomy-fitness
+- company: Andy's Frozen Custard
+  board: andysfrozencustard
+- company: Golden Corral Corporation
+  board: annettes-corral-llc-dba-golden-corral
+- company: Any Lab Test Now
+  board: anylabtestnowcareers
+- company: Anytime Fitness
+  board: anytime-fitness-careers
+- company: Art of Drawers
+  board: art-of-drawers-careers
+- company: At Your Side Home Care
+  board: ayscareers
+- company: Woodhouse
+  board: batonrougeneworleansslidellwoodhousespas
+- company: Beef 'O'​ Brady's
+  board: beef-o-bradys-careers
+- company: Benjamin Franklin Plumbing, LLC
+  board: benjamin-franklin-plumbing-careers
+- company: Big Red F Restaurant Group
+  board: big-red-f-jobs
+- company: Big Sandy Superstore
+  board: big-sandy-distribution-inc
+- company: Big O Tires
+  board: bigotires-careers
+- company: Blake's Lotaburger
+  board: blakes-lotaburger
+- company: BODY20
+  board: body20-careers
+- company: BODYBAR Pilates
+  board: bodybar-pilates-careers
+- company: BODYROK
+  board: bodyrok
+- company: BODYROK
+  board: bodyrok-careers
+- company: BODYROK
+  board: bodyrok-east-bay-north-bay-peninsula
+- company: Bird Rock Coffee Roasters, Inc
+  board: brcr
+- company: Bridge Marina, Inc.
+  board: bridge-marina-inc
+- company: British Swim School - Hudson Waterfront
+  board: britishswimschool-careers
+- company: The Brothers that just do Gutters
+  board: brothersgutterscareers
+- company: Capital Ale House
+  board: capital-ale-house
+- company: Capriotti's Sandwich Shop
+  board: capriottis-careers
+- company: CertaPro Painters
+  board: certapro-careers
+- company: Subway
+  board: cgi-subway
+- company: ChargeTronix
+  board: chargetronix
+- company: Charleston Hospitality Group
+  board: charleston-hospitality-group
+- company: Chick-fil-A Restaurants
+  board: chick-fil-a-at-north-hills-in-line
+- company: Chick-fil-A Restaurants
+  board: chick-fil-a-charlotte-pike---nashville
+- company: COASTAL HOME REHABILITATION
+  board: coastal-home-rehabilitaton
+- company: Code Ninjas
+  board: code-ninjas-careers
+- company: ComForCare
+  board: comforcare-careerdays
+- company: ComForCare
+  board: comforcarecareers
+- company: Comfort Keepers
+  board: comfort-keepers
+- company: Cooper Tacia General Contracting Company
+  board: cooper-tacia-general-contracting-company
+- company: Creative World School
+  board: creative-world-school-rivercrest
+- company: Crunch Fitness - Fitness Holdings North America, LLC.
+  board: crunch
+- company: Culinary Khancepts
+  board: culinary-khancepts
+- company: Culinary Khancepts
+  board: culinary-khancepts-star-cinema-grill-careers
+- company: Culligan International
+  board: culligan-careers
+- company: D1 TRAINING
+  board: d1-training-careers
+- company: Daiquiri Deck
+  board: daiquiri-deck
+- company: Dinges Fire Company
+  board: dingesfire
+- company: Discovery Point
+  board: discovery-point-careers
+- company: Discovery Point
+  board: discovery-point-post-road
+- company: Diverse Lynx
+  board: diverse-lynx-llc
+- company: Do it Best
+  board: do-it-best-careers
+- company: Easy Tiger Bake Shop & Beer Garden
+  board: easy-tiger-careers
+- company: Ellie Mental Health
+  board: ellie-careers
+- company: Emagine Entertainment
+  board: emagine-entertainment
+- company: Evergreen Life Services
+  board: evergreenls
+- company: Evergreen Life Services
+  board: evergreenlstx
+- company: EverLine Coatings and Services - USA
+  board: everline-coatings-usa-careers
+- company: EVTKS
+  board: evotek-llc
+- company: Executive Home Care
+  board: executive-care-careers
+- company: Fairfield Property Management
+  board: fairfieldmanagement
+- company: FASTSIGNS®
+  board: fastsigns-careers
+- company: Federal American Grill
+  board: federal-american-grill
+- company: Fish Window Cleaning
+  board: fishwindowcleaningcareers
+- company: Five Star Painting®
+  board: fivestarpaintingcareers
+- company: Flippers Pizzeria
+  board: flippers-pizzeria
+- company: Floor Coverings International
+  board: floor-coverings-international-careers
+- company: Frenchies Modern Nail Care
+  board: frenchies-careers
+- company: Frontall USA
+  board: frontall-usa-llc
+- company: Generator Supercenter
+  board: generator-supercenter-careers
+- company: Golden Corral Corporation
+  board: golden-corral-careers
+- company: Golden Corral Corporation
+  board: golden-corral-zeal-group
+- company: Golden Heart Senior Care Corporate
+  board: golden-heart-clermont
+- company: Goldfish Swim School Franchising, LLC
+  board: goldfish-careers
+- company: Gold's Gym
+  board: goldscareers
+- company: Grease Monkey International, LLC
+  board: grease-monkey-843
+- company: Grease Monkey International, LLC
+  board: grease-monkey-careers
+- company: Golden Corral Corporation
+  board: great-western-restaurants-inc-dba-golden-corral
+- company: Golden Corral Corporation
+  board: guyer-corral-ventures-llc-dba-golden-corral
+- company: GVCS Inc.
+  board: gvcs
+- company: Gymboree Play & Music
+  board: gymboreeplaymusic-careers
+- company: GYMGUYZ
+  board: gymguyz-careers
+- company: Hand & Stone Massage and Facial Spa
+  board: handandstonecareers
+- company: Handyman Connection
+  board: handyman-connection-careers
+- company: Home Care Association of America
+  board: hcaoa-careers
+- company: Home Care Evolution
+  board: hce-careers
+- company: HCOA Fitness
+  board: hcoa-fitness
+- company: Healthtrax Fitness & Wellness
+  board: healthtrax-fitness-wellness
+- company: Home Helpers Home Care
+  board: home-helpers-careers
+- company: HTE (home technology experts)
+  board: home-technology-experts-inc
+- company: HomeWell Care Services
+  board: homewell-care-services-careers
+- company: HOPE MONTESSORI ACADEMY
+  board: hope-montessori-academy
+- company: Huddle House
+  board: huddle-house
+- company: Huddle House
+  board: huddle-house-careers
+- company: Synergen
+  board: hydrolinellc-careers
+- company: i9 Sports
+  board: i9-sports-careers
+- company: IICRC
+  board: iicrc-careers
+- company: InMotion Wellness Studio
+  board: inmotion-wellness-studio-careers
+- company: (ISSA) International Sports Sciences Association
+  board: issa-fitness-careers
+- company: Jackson Hewitt Tax Service Inc.
+  board: jackson-hewitt-careers
+- company: Jeremiah's Italian Ice
+  board: jeremiahs-italian-ice
+- company: Jet Enterprises, LLC
+  board: jjs-grill
+- company: The Junkluggers
+  board: junkluggers-careers
+- company: Kaskaid Hospitality
+  board: kaskaid-careers
+- company: Kidcreate Studio
+  board: kidcreate-studio-careers
+- company: KidStrong
+  board: kidstrong-plantation
+- company: KidStrong
+  board: kidstrong-raleigh
+- company: KidStrong
+  board: kidstrongcareers
+- company: Kid to Kid
+  board: kidtokidcareers
+- company: Kitchen Tune-Up Franchise System
+  board: kitchentuneupcareers
+- company: La Farm Bakery
+  board: la-farm-bakery
+- company: The Lash Lounge
+  board: lash-lounge-careers
+- company: Lil' Kickers Franchising
+  board: lil-kickers-careers
+- company: LIQUISERVE, LLC
+  board: liquiserve-llc
+- company: The Little Gym International
+  board: little-gym-careers
+- company: London Drugs
+  board: london-drugs-internal
+- company: Maryhill Winery
+  board: maryhillwinery
+- company: Heights Wellness Retreat
+  board: massageheightscareers
+- company: Mathnasium - The Math Learning Center
+  board: mathnasium-careers
+- company: Meadowbrook
+  board: meadowbrook-restaurant-company-inc
+- company: Meineke Car Care Centers, Inc.
+  board: meineke-careers
+- company: Merry Maids®
+  board: merrymaidscareers
+- company: Wenco Industries Inc- Midas and Big O Tires
+  board: midas-careers
+- company: Wenco Industries Inc- Midas and Big O Tires
+  board: midas-tire-auto-experts
+- company: Mister Sparky Electric
+  board: mister-sparky-careers
+- company: Golden Corral Corporation
+  board: mohave-gc-llc-dba-golden-corral
+- company: Molly Maid USA
+  board: molly-maid-of-southern-miami-palmetto-bay
+- company: The Mosquito Authority
+  board: mosquito-authority-careers
+- company: Mr. Appliance
+  board: mr-appliance-of-brooklyn
+- company: Mugshots Grill & Bar
+  board: mugshots-grill
+- company: MÜV Fitness
+  board: muv-fitness
+- company: My Gym
+  board: mygymcareers
+- company: NerdsToGo
+  board: nerdstogo-careers
+- company: Nino Salvaggio International Marketplace
+  board: nino-salvaggio
+- company: Nothing Bundt Cakes
+  board: nothing-bundt-cakes-careers
+- company: Nudy's Cafes
+  board: nudys-cafe
+- company: Office Pride Commercial Cleaning Services
+  board: office-pride-careers
+- company: One Hour Heating & Air Conditioning
+  board: one-hour-careers
+- company: OnePack Hospitality Group
+  board: onepack-hospitality-careers
+- company: Orangetheory Fitness
+  board: orangetheory-fitness-careers
+- company: Orangetheory Fitness
+  board: orangetheory-franchise-0318
+- company: Original Roadhouse Grill
+  board: original-roadhouse-grill
+- company: Owais Construction Group
+  board: owais-construction-group
+- company: P. Terry's Burger Stand
+  board: p-terry-s-burger-stand
+- company: Palm Beach Tan
+  board: palm-beach-tan-lst-austin-i-ltd
+- company: Parrish Medical Center
+  board: parrishhealthcare
+- company: Paul Davis Restoration, Inc.
+  board: pauldaviscareers
+- company: Palm Beach Tan
+  board: pbt-careers
+- company: Vellum Health
+  board: peak-mobile-holdings-inc
+- company: Perkins American Food Co.
+  board: perkins-careers
+- company: Taymax Group
+  board: pfcareers
+- company: PIRTEK USA
+  board: pirtek-careers
+- company: PJ's Coffee of New Orleans
+  board: pjs-coffee-careers
+- company: Polly's Pies
+  board: polly-pies
+- company: PostNet International Franchise Corporation
+  board: postnet-careers
+- company: Primrose Schools
+  board: primrose-school-woburn
+- company: ProSource
+  board: prosource-careers
+- company: PuroClean
+  board: puroclean
+- company: The Purple Cow Restaurants
+  board: purple-cow
+- company: Rainbow Restoration
+  board: rainbowintlcareers
+- company: Ramirez Hospitality Group
+  board: ramirez-hospitality-group-careers
+- company: redbox+ Dumpsters
+  board: redbox-plus-dumpsters-careers
+- company: Resource Metrix
+  board: resource-metrix
+- company: Restaurant 604
+  board: restaurant-604
+- company: Restore Hyper Wellness
+  board: restore-hyper-wellness-careers
+- company: Retro Fitness
+  board: retro-fitness-careers
+- company: Retro Fitness
+  board: retrofitnesscareers
+- company: Reunion Kitchen + Drink
+  board: reunion-kitchen-drink
+- company: Right at Home
+  board: right-at-home-central-orange-county-ca
+- company: Right at Home
+  board: right-at-home-indianapolis-southeast-in
+- company: Right at Home
+  board: right-at-home-miami-metro-fl
+- company: Right at Home
+  board: right-at-home-modesto-ca
+- company: Right at Home
+  board: right-at-home-peachtree-city
+- company: Right at Home
+  board: right-at-home-san-jose-ca
+- company: R.Salerno Restaurant Group
+  board: salernos-hospitality-careers
+- company: Save A Lot
+  board: save-a-lot-raj-al-moultrie-llc
+- company: Saver Group, Inc
+  board: saver-group-careers
+- company: Buffalo Wild Wings
+  board: sc-wings-block-llc
+- company: Scenthound
+  board: scenthound-careers
+- company: Scratch Restaurants Group
+  board: scratchrestaurants
+- company: Steel Erectors Association of America
+  board: seaa-careers
+- company: ServiceMaster Clean®
+  board: servicemaster-clean-careers
+- company: ServiceMaster Restore®
+  board: servicemaster-restore-usa-careers
+- company: SERVPRO
+  board: servpro-careers
+- company: Sharkey's Franchising Company
+  board: sharkeys-careers
+- company: Shine Window Care and Holiday Lighting of Cedar Park
+  board: shinecareers
+- company: Sizzler USA
+  board: sizzler
+- company: Snapology
+  board: snapology-careers
+- company: So Hospitality Group
+  board: so-hospitality-careers
+- company: Soccer Shots Franchising
+  board: soccershotscareers
+- company: Soulman's Bar-B-Que
+  board: soulmans-bar-b-que
+- company: Special Strong
+  board: special-strong-careers
+- company: Spectrum Resorts
+  board: spectrum-resorts
+- company: SPENGA
+  board: spenga-careers
+- company: Sport Clips Haircuts
+  board: sportclipshv
+- company: Storm Guard Roofing
+  board: storm-guard-careers
+- company: StretchLab Franchise
+  board: stretchlab-north-dallas
+- company: Stretch Zone
+  board: stretchzonecareers
+- company: Sun Tan City
+  board: sun-tan-city-careers
+- company: Surface Experts
+  board: surface-experts-careers
+- company: Taco Boy
+  board: taco-boy-1
+- company: Talem Home Care & Placement Services
+  board: talem-home-care-careers
+- company: Taziki's Mediterranean Cafe
+  board: tazikis
+- company: TeamLogic IT
+  board: teamlogic-it-careers
+- company: The Goddard School
+  board: the-goddard-school-careers
+- company: The Little Gym International
+  board: the-little-gym-of-fresno-and-clovis
+- company: Titan Brands Hospitality Group
+  board: titan-brands-inc
+- company: The Learning Experience
+  board: tle-careers
+- company: The Tuckey Companies
+  board: tuckey
+- company: Tuffy Tire & Auto Service
+  board: tuffy-careers
+- company: Two Maids
+  board: two-maids-careers
+- company: United Appliance Servicers Association
+  board: uasa-careers
+- company: UFC GYM
+  board: ufc-gym-careers
+- company: Uptown Cheapskate
+  board: uptowncheapskatecareers
+- company: US Swim School Association
+  board: usssa-careers
+- company: Village Inn
+  board: village-inn-walker-group
+- company: Visiting Angels
+  board: visiting-angels
+- company: Visiting Angels
+  board: visiting-angels-lenoir-nc
+- company: Whataburger
+  board: whataburger
+- company: Window Hero Franchising
+  board: window-hero-careers
+- company: Window World
+  board: window-world-of-southwest-florida
+- company: Workout Anytime Franchising Systems, LLC
+  board: woacareers
+- company: Woodbury Corporation
+  board: woodburycareers
+- company: Woodhouse
+  board: woodhousecareers
+- company: Precision Scans Inc.
+  board: www-precisionscans-net


### PR DESCRIPTION
Follow-up to #258. CareerPlug was the biggest no-adapter destination in role.com's apply links; #258 merged before this commit landed, so it ships separately.

- **`internal/sources/careerplug.go`** — CareerPlug (`<board>.careerplug.com`): server-rendered `/jobs` listing (paginated `?page=N`) linking each posting as `/jobs/<id>`, per-detail schema.org JobPosting ld+json. Board = account subdomain; employer per-posting from JSON-LD (franchises) with configured-company fallback. Same shape as globalpayments/jazzhr.
- **`atsdetect.FromURL`** — `careerplug` case (subdomain board).
- **`cmd/harvest-boards`** — `careerplugProber` (counts `/jobs/<id>` links on the listing).
- **`sources/careerplug.yml`** — 231 boards harvested from role.com apply links (company labels carried from role's JSON-LD), mostly US franchise brands.

TDD-covered; live-smoked (`fmmla` → 24 jobs parsed correctly).

**Deploy:** new adapter ships in the ingest image → full image rebuild + a cron line for `sources/careerplug.yml`.