### PR TITLE
fix(web): align eslint-plugin-oxlint with oxlint 1.71 (unblocks web CI)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,7 +25,7 @@
         "@tsconfig/svelte": "^5.0.4",
         "@types/node": "^25.9.3",
         "eslint": "^10.5.0",
-        "eslint-plugin-oxlint": "^1.70.0",
+        "eslint-plugin-oxlint": "^1.71.0",
         "eslint-plugin-svelte": "^3.19.0",
         "globals": "^17.7.0",
         "oxlint": "^1.71.0",
@@ -859,9 +859,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -879,9 +876,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -899,9 +893,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -919,9 +910,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -939,9 +927,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -959,9 +944,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -979,9 +961,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -999,9 +978,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2942,16 +2918,16 @@
       }
     },
     "node_modules/eslint-plugin-oxlint": {
-      "version": "1.70.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-1.70.0.tgz",
-      "integrity": "sha512-SmpX0KdQptEzGm98wEEUR2BFAQTCTyXVdxlMkTOetxRak4NWb6GsYtHvU+Xh9AvnOKBzmO0ikPjxEG30pkmNUg==",
+      "version": "1.71.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-1.71.0.tgz",
+      "integrity": "sha512-940aSzHoks+uIlVEoUGIXdtHmrs9ewoeN+r0CrSN4UnkoYIfy4lUPNp21JuwfzNrZ5NCBH3CBmG+ugS+2CXtsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "jsonc-parser": "^3.3.1"
       },
       "peerDependencies": {
-        "oxlint": "~1.70.0"
+        "oxlint": "~1.71.0"
       }
     },
     "node_modules/eslint-plugin-svelte": {

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "@tsconfig/svelte": "^5.0.4",
     "@types/node": "^25.9.3",
     "eslint": "^10.5.0",
-    "eslint-plugin-oxlint": "^1.70.0",
+    "eslint-plugin-oxlint": "^1.71.0",
     "eslint-plugin-svelte": "^3.19.0",
     "globals": "^17.7.0",
     "oxlint": "^1.71.0",


### PR DESCRIPTION
## Problem

Every PR's `web` check fails at `npm ci` with `ERESOLVE`:

```
peer oxlint@"~1.70.0" from eslint-plugin-oxlint@1.70.0
Found: oxlint@1.71.0
```

`oxlint` was bumped to `^1.71.0` but `eslint-plugin-oxlint` stayed at `^1.70.0`, and 1.70.0 peers `oxlint ~1.70.0`.

## Fix

Bump `eslint-plugin-oxlint` to `^1.71.0` (its 1.71.0 peers `oxlint ~1.71.0`) and regenerate `package-lock.json`. Verified locally: `npm ci`, `npm run check` (0 errors), and `npm run build` all pass. Two-file diff (package.json + lockfile).