### PR TITLE
feat(sources): cover full Bertelsmann group via rtl-prod master index

### DIFF
--- a/sources/recruitingsolutions.yml
+++ b/sources/recruitingsolutions.yml
@@ -4,6 +4,8 @@
 # several operating companies, so the company below is just the tenant's display name — each
 # posting carries its own employer.
 
-# Bertelsmann group, Riverty/BFS financial-services customer (createyourowncareer.com).
-- company: Riverty
-  board: riv-prod
+# Bertelsmann group (createyourowncareer.com). rtl-prod is the portal's master Azure index —
+# it spans all ~39 group brands (Arvato, RTL, Riverty, Penguin Random House, BMG, Relias,
+# TERRITORY, …), each posting carrying its own operating company. One board covers the group.
+- company: Bertelsmann
+  board: rtl-prod


### PR DESCRIPTION
## What
Follow-up to #261. The recruiting-solutions.org portal (`createyourowncareer.com`) exposes a **master Azure search index**, customerId `rtl-prod`, that spans **all ~39 Bertelsmann group brands** — Arvato, RTL, Riverty, Penguin Random House (all regions), BMG, Relias, TERRITORY, VIVENO, Alliant, BCE, Mohn Media, … — not just the Riverty/BFS subset `riv-prod` covered.

Each posting still carries its own operating company, so **one board now ingests the whole group**.

## Verified (live, through the adapter)
- **699 deduped jobs across 101 companies**, 0 empty descriptions, 0 duplicate external_ids.
- Top employers: Arvato USA/Netherlands/Polska/Systems, Penguin Random House (LLC + Grupo), Alliant University, VIVENO, Bertelsmann Corporate, Relias, …

## Change
One line in `sources/recruitingsolutions.yml`: `riv-prod` → `rtl-prod` (`company: Bertelsmann`, a display label — the adapter takes the real company per posting). **No code change** — the adapter shipped in #261 handles it; deploy is a config-only sources sync.

`riv-prod` was a strict subset (Riverty family, 67 jobs), so this replaces it. The base-jobId dedup key (`(source, external_id)`) means even keeping both would not have double-ingested.