### PR TITLE
feat(sources): add Cornerstone OnDemand (CSOD) adapter

### DIFF
--- a/internal/sources/cornerstone.go
+++ b/internal/sources/cornerstone.go
@@ -1,0 +1,167 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// cornerstone adapts Cornerstone OnDemand (CSOD) career sites. The board is the tenant
+// subdomain (e.g. "nintendoeurope" → nintendoeurope.csod.com). The careersite home shell
+// embeds a JSON config blob carrying the regional API base and a JWT read token; with the
+// token as a Bearer credential, the rec-job-search/external/jobs endpoint returns every
+// requisition with its description inline, so no per-posting detail fetch is needed.
+type cornerstoneHTTP interface {
+	TextGetter
+	HeaderJSONPoster
+}
+
+type cornerstone struct {
+	http cornerstoneHTTP
+}
+
+// NewCornerstone builds the Cornerstone adapter over the given HTTP client.
+func NewCornerstone(c cornerstoneHTTP) Source { return cornerstone{http: c} }
+
+func (cornerstone) Provider() string { return "cornerstone" }
+
+// cornerstonePageSize is the search page size; the loop paginates until totalCount is reached.
+const cornerstonePageSize = 100
+
+// cornerstoneLocation is one of a requisition's locations.
+type cornerstoneLocation struct {
+	City    string `json:"city"`
+	Country string `json:"country"`
+}
+
+type cornerstoneRequisition struct {
+	RequisitionID        int                   `json:"requisitionId"`
+	DisplayJobTitle      string                `json:"displayJobTitle"`
+	PostingEffectiveDate string                `json:"postingEffectiveDate"`
+	Locations            []cornerstoneLocation `json:"locations"`
+	ExternalDescription  string                `json:"externalDescription"`
+}
+
+type cornerstoneResponse struct {
+	Data struct {
+		TotalCount   int                      `json:"totalCount"`
+		Requisitions []cornerstoneRequisition `json:"requisitions"`
+	} `json:"data"`
+}
+
+func (s cornerstone) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	homeURL := fmt.Sprintf("https://%s.csod.com/ux/ats/careersite/1/home?c=%s", e.Board, e.Board)
+	home, err := s.http.GetText(ctx, homeURL)
+	if err != nil {
+		return nil, fmt.Errorf("cornerstone: home %s: %w", e.Board, err)
+	}
+	cloud := firstSubmatch(cornerstoneCloudPattern, home)
+	token := firstSubmatch(cornerstoneTokenPattern, home)
+	if cloud == "" || token == "" {
+		return nil, fmt.Errorf("cornerstone: no token/cloud endpoint on %s home", e.Board)
+	}
+	cultureID, _ := strconv.Atoi(firstSubmatch(cornerstoneCultureIDPattern, home))
+	if cultureID == 0 {
+		cultureID = 1
+	}
+	cultureName := firstSubmatch(cornerstoneCultureNamePattern, home)
+	if cultureName == "" {
+		cultureName = "en-US"
+	}
+
+	apiURL := strings.TrimRight(cloud, "/") + "/rec-job-search/external/jobs"
+	headers := map[string]string{"Authorization": "Bearer " + token}
+
+	var reqs []cornerstoneRequisition
+	for page := 1; page <= 100; page++ {
+		body := map[string]any{
+			"careerSiteId":            1,
+			"careerSitePageId":        1,
+			"pageNumber":              page,
+			"pageSize":                cornerstonePageSize,
+			"cultureId":               cultureID,
+			"cultureName":             cultureName,
+			"searchText":              "",
+			"states":                  []any{},
+			"countryCodes":            []any{},
+			"cities":                  []any{},
+			"customFieldCheckboxKeys": []any{},
+			"customFieldDropdowns":    []any{},
+			"customFieldRadios":       []any{},
+		}
+		var resp cornerstoneResponse
+		if err := s.http.PostJSONWithHeaders(ctx, apiURL, headers, body, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("cornerstone: search %s: %w", e.Board, err)
+			}
+			break // a later page failing ends enumeration with what we have
+		}
+		if len(resp.Data.Requisitions) == 0 {
+			break
+		}
+		reqs = append(reqs, resp.Data.Requisitions...)
+		if len(reqs) >= resp.Data.TotalCount {
+			break
+		}
+	}
+
+	jobs := make([]Job, 0, len(reqs))
+	for _, r := range reqs {
+		if j, ok := s.toJob(r, e); ok {
+			jobs = append(jobs, j)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a requisition to a Job, returning ok=false when it has no id (which would
+// collide on the dedup key). Company comes from config; the description is served inline.
+func (cornerstone) toJob(r cornerstoneRequisition, e CompanyEntry) (Job, bool) {
+	if r.RequisitionID == 0 {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID: strconv.Itoa(r.RequisitionID),
+		URL: fmt.Sprintf("https://%s.csod.com/ux/ats/careersite/1/home/requisition/%d?c=%s",
+			e.Board, r.RequisitionID, e.Board),
+		Title:       r.DisplayJobTitle,
+		Company:     e.Company,
+		Location:    cornerstonePrimaryLocation(r.Locations),
+		Description: sanitizeHTML(r.ExternalDescription),
+		PostedAt:    parseLayout("1/2/2006", r.PostingEffectiveDate),
+	}, true
+}
+
+// cornerstonePrimaryLocation renders the first location as "City, Country", falling back to
+// whichever of the two is present, or "" when there are none.
+func cornerstonePrimaryLocation(locs []cornerstoneLocation) string {
+	if len(locs) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, p := range []string{locs[0].City, locs[0].Country} {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+var (
+	// cloud is read from inside the "endpoints" object and must be an absolute URL, so a
+	// stray "cloud" key in an unrelated inline script can't be mistaken for the API base.
+	cornerstoneCloudPattern       = regexp.MustCompile(`"endpoints"\s*:\s*\{[^}]*"cloud"\s*:\s*"(https?://[^"]+)"`)
+	cornerstoneTokenPattern       = regexp.MustCompile(`"token"\s*:\s*"(eyJ[^"]+)"`)
+	cornerstoneCultureIDPattern   = regexp.MustCompile(`(?i)"cultureID"\s*:\s*(\d+)`)
+	cornerstoneCultureNamePattern = regexp.MustCompile(`(?i)"cultureName"\s*:\s*"([^"]+)"`)
+)
+
+// firstSubmatch returns the first capture group of pattern in s, or "".
+func firstSubmatch(pattern *regexp.Regexp, s string) string {
+	if m := pattern.FindStringSubmatch(s); m != nil {
+		return m[1]
+	}
+	return ""
+}

--- a/internal/sources/cornerstone_test.go
+++ b/internal/sources/cornerstone_test.go
@@ -1,0 +1,160 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// cornerstoneHomeHTML mirrors a CSOD careersite home shell: the JSON config blob embeds the
+// regional API base ("cloud") and a JWT read token used as the Bearer credential.
+const cornerstoneHomeHTML = `<html><head></head><body>
+<script>window.__cfg = {"applicationBase":"/","endpoints":{"cloud":"https://eu-fra.api.csod.com/","api":"/"},"token":"eyJhbGciTESTtoken123","cultureID":1,"cultureName":"en-US"};</script>
+</body></html>`
+
+// cornerstoneJobsJSON mirrors the rec-job-search/external/jobs response: data.requisitions
+// carries the postings with the description inline (no per-job detail fetch needed).
+const cornerstoneJobsJSON = `{
+  "status": "200",
+  "data": {
+    "totalCount": 1,
+    "requisitions": [
+      {
+        "requisitionId": 494,
+        "postingEffectiveDate": "6/15/2026",
+        "displayJobTitle": "European Operations Administrator",
+        "locations": [{"city": "Frankfurt am Main", "country": "DE"}],
+        "externalDescription": "<p>Coordinate shipments.</p><script>alert(1)</script>"
+      }
+    ]
+  }
+}`
+
+func newCornerstoneFake() *routedHTTP {
+	return (&routedHTTP{}).
+		route("/ux/ats/careersite/1/home", cornerstoneHomeHTML).
+		route("rec-job-search/external/jobs", cornerstoneJobsJSON)
+}
+
+func TestCornerstoneProvider(t *testing.T) {
+	if got := NewCornerstone(nil).Provider(); got != "cornerstone" {
+		t.Errorf("Provider() = %q, want %q", got, "cornerstone")
+	}
+}
+
+func TestCornerstoneFetchScrapesTokenThenMapsRequisitions(t *testing.T) {
+	jobs, err := NewCornerstone(newCornerstoneFake()).Fetch(context.Background(), CompanyEntry{
+		Company: "Nintendo of Europe", Provider: "cornerstone", Board: "nintendoeurope",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "494" {
+		t.Errorf("ExternalID = %q, want 494", j.ExternalID)
+	}
+	if j.Title != "European Operations Administrator" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Nintendo of Europe" {
+		t.Errorf("Company = %q, want config company", j.Company)
+	}
+	if j.Location != "Frankfurt am Main, DE" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	want := "https://nintendoeurope.csod.com/ux/ats/careersite/1/home/requisition/494?c=nintendoeurope"
+	if j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if strings.Contains(j.Description, "<script>") || !strings.Contains(j.Description, "Coordinate shipments.") {
+		t.Errorf("Description not sanitized/assembled: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-15", j.PostedAt)
+	}
+}
+
+func TestCornerstoneLocationString(t *testing.T) {
+	cases := []struct {
+		locs []cornerstoneLocation
+		want string
+	}{
+		{[]cornerstoneLocation{{City: "Frankfurt am Main", Country: "DE"}}, "Frankfurt am Main, DE"},
+		{[]cornerstoneLocation{{City: "Berlin"}}, "Berlin"},
+		{[]cornerstoneLocation{{Country: "US"}}, "US"},
+		{[]cornerstoneLocation{{City: "Tokyo"}, {City: "Osaka"}}, "Tokyo"}, // first location only
+		{nil, ""},
+	}
+	for _, c := range cases {
+		if got := cornerstonePrimaryLocation(c.locs); got != c.want {
+			t.Errorf("cornerstonePrimaryLocation(%v) = %q, want %q", c.locs, got, c.want)
+		}
+	}
+}
+
+// cornerstonePagedHTTP serves the home page, then one requisition per search page up to
+// total — exercising the pagination-continues branch and totalCount termination.
+type cornerstonePagedHTTP struct {
+	total int
+	calls int
+}
+
+func (h *cornerstonePagedHTTP) GetText(context.Context, string) (string, error) {
+	return cornerstoneHomeHTML, nil
+}
+
+func (h *cornerstonePagedHTTP) PostJSONWithHeaders(_ context.Context, _ string, _ map[string]string, _, v any) error {
+	h.calls++
+	reqs := ""
+	if h.calls <= h.total {
+		reqs = fmt.Sprintf(`{"requisitionId":%d,"displayJobTitle":"Job %d","externalDescription":"<p>x</p>"}`, h.calls, h.calls)
+	}
+	body := fmt.Sprintf(`{"data":{"totalCount":%d,"requisitions":[%s]}}`, h.total, reqs)
+	return json.Unmarshal([]byte(body), v)
+}
+
+func TestCornerstonePaginatesUntilTotalCount(t *testing.T) {
+	fake := &cornerstonePagedHTTP{total: 3}
+	jobs, err := NewCornerstone(fake).Fetch(context.Background(), CompanyEntry{Board: "tenant"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 across pages", len(jobs))
+	}
+	seen := map[string]bool{}
+	for _, j := range jobs {
+		seen[j.ExternalID] = true
+	}
+	if len(seen) != 3 {
+		t.Errorf("expected 3 distinct requisitions across pages, got ids %v", seen)
+	}
+}
+
+func TestCornerstoneMissingTokenErrors(t *testing.T) {
+	fake := (&routedHTTP{}).route("/ux/ats/careersite/1/home", `<html><body>no config blob</body></html>`)
+	_, err := NewCornerstone(fake).Fetch(context.Background(), CompanyEntry{Board: "nintendoeurope"})
+	if err == nil {
+		t.Fatal("expected error when the home page exposes no token/cloud endpoint")
+	}
+}
+
+func TestCornerstoneDropsRequisitionWithNoID(t *testing.T) {
+	jobs := `{"data":{"totalCount":1,"requisitions":[{"displayJobTitle":"No ID","externalDescription":"<p>x</p>"}]}}`
+	fake := (&routedHTTP{}).
+		route("/ux/ats/careersite/1/home", cornerstoneHomeHTML).
+		route("rec-job-search/external/jobs", jobs)
+	got, err := NewCornerstone(fake).Fetch(context.Background(), CompanyEntry{Board: "nintendoeurope"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d jobs, want 0 (requisition with no id dropped)", len(got))
+	}
+}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -41,6 +41,12 @@ type HTMLGetter interface {
 	GetHTML(ctx context.Context, url string) (*html.Node, error)
 }
 
+// TextGetter fetches a URL and returns its raw response body, for adapters that regex a
+// token or config blob out of a page rather than parsing its DOM (e.g. Cornerstone).
+type TextGetter interface {
+	GetText(ctx context.Context, url string) (string, error)
+}
+
 // JSONPoster sends a JSON request body and decodes the JSON response (platforms whose
 // listing API is POST-only, e.g. Workday).
 type JSONPoster interface {
@@ -65,6 +71,7 @@ type HTTPClient interface {
 	JSONGetter
 	XMLGetter
 	HTMLGetter
+	TextGetter
 	JSONPoster
 	HeaderJSONGetter
 	HeaderJSONPoster

--- a/internal/sources/smartrecruiters_test.go
+++ b/internal/sources/smartrecruiters_test.go
@@ -58,6 +58,18 @@ func (r *routedHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) 
 	return nil, fmt.Errorf("routedHTTP: no route for %s", url)
 }
 
+func (r *routedHTTP) GetText(_ context.Context, url string) (string, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	for _, rt := range r.routes {
+		if strings.Contains(url, rt.match) {
+			return rt.body, nil
+		}
+	}
+	return "", fmt.Errorf("routedHTTP: no route for %s", url)
+}
+
 func (r *routedHTTP) decode(url string, unmarshal func([]byte, any) error, v any) error {
 	r.mu.Lock()
 	r.calls++

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -131,6 +131,7 @@ func All(c HTTPClient) map[string]Source {
 		NewPhenom(c),
 		NewAvature(c),
 		NewComeet(c),
+		NewCornerstone(c),
 		NewRadancy(c),
 		NewJazzHR(c),
 		NewWPYoast(c),

--- a/sources/cornerstone.yml
+++ b/sources/cornerstone.yml
@@ -1,0 +1,8 @@
+# Cornerstone OnDemand (CSOD) career sites. Provider is the filename; each entry is
+# company + board. board = the tenant subdomain (forming <board>.csod.com); see
+# internal/sources/cornerstone.go. The adapter scrapes the careersite home shell for the
+# regional API base + JWT read token, then pages rec-job-search/external/jobs (description
+# inline). Each board validated live (search returned >0 requisitions) before adding.
+
+- company: Nintendo of Europe
+  board: nintendoeurope


### PR DESCRIPTION
## What

New `cornerstone` adapter for Cornerstone OnDemand (CSOD) career sites — a major multi-tenant enterprise ATS. First board: **Nintendo of Europe** (`nintendoeurope`, harvested from the hitmarker pass). `board` = the tenant subdomain.

## How it works

Cracked via browser network capture, then reproduced headless:

1. `GET https://<board>.csod.com/ux/ats/careersite/1/home?c=<board>` as raw text → regex out the **regional API base** (`endpoints.cloud`, e.g. `https://eu-fra.api.csod.com/`) and the **JWT read token** embedded in the page config.
2. `POST <cloud>/rec-job-search/external/jobs` with `Authorization: Bearer <token>` and a search body, **paginating** until `totalCount` is reached.
3. The response carries each requisition's **description inline** (`externalDescription`) — no per-posting detail fetch.

Mapping: `requisitionId` → ExternalID + canonical requisition URL, `displayJobTitle` → Title, `locations[0]` → "City, Country", `externalDescription` → sanitized description, `postingEffectiveDate` (M/D/YYYY) → PostedAt, company from config.

Adds a `TextGetter` transport interface (raw-body fetch) for the token/config scrape.

## Review feedback addressed
- `cloud` regex anchored inside the `endpoints` object + requires an absolute URL (can't match a stray `"cloud"` key from analytics).
- Added a multi-page pagination test (continue branch + `totalCount` termination).
- culture key regex made case-insensitive.

## Tests
TDD, 6 unit tests in `cornerstone_test.go`. `go test ./internal/sources/` — `ok`; vet + gofmt clean.

Live-validated against Nintendo of Europe: **13 requisitions**, clean title/location/description/date, fully headless (no browser at runtime).

Any other CSOD tenant = one `sources/cornerstone.yml` entry (the tenant subdomain).