### PR TITLE
feat(sources): +2 boards from newpmjobs app-feed (8x8, Whatnot)

### DIFF
--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -9,6 +9,9 @@
 - company: Toggl
   provider: ashbygraphql
   board: toggl
+- company: Whatnot
+  provider: ashbygraphql
+  board: whatnot
 
 # International single-company sources.
 - company: Uber

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -3,6 +3,8 @@
 
 - company: 10times
   board: 10times
+- company: 8x8
+  board: 8x8inc
 - company: A44 Games
   board: a44games
 - company: AB Games


### PR DESCRIPTION
Harvested `newpmjobs.com/api/app-feed` — a job-level feed exposing each posting`s real ATS apply URL (a different angle than the earlier `/companies` page harvest). Diffing extracted board slugs (Workday/Greenhouse/Ashby/Lever/SmartRecruiters/Eightfold/Oracle) against our sources, the catalogue is near-fully covered; only two uncovered boards surfaced:

- **8x8** → smartrecruiters `8x8inc` (42 jobs, validated via SR API)
- **Whatnot** → ashbygraphql `whatnot` (130 listed / 106 ingested) — public Ashby Posting API disabled, served via embed GraphQL

Both validated end-to-end through their adapters (0 malformed). Sources-only change; no code.