### PR TITLE
feat(sources): harvest game-dev ATS boards from workingames.com (+22 boards)

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -6661,3 +6661,7 @@
   board: spellbook.legal
 - company: The Browser Company
   board: the browser company
+- company: intangible.ai
+  board: intangible.ai
+- company: scorewarrior
+  board: scorewarrior

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -14737,3 +14737,5 @@
   board: zonafacta
 - company: ccem
   board: ccem
+- company: ludia
+  board: ludia

--- a/sources/comeet.yml
+++ b/sources/comeet.yml
@@ -6,3 +6,9 @@
 
 - company: Overwolf
   board: overwolf/B1.001
+- company: CrazyLabs
+  board: crazylabs/32.00E
+- company: Ludeo
+  board: ludeo/D7.008
+- company: Moon Active
+  board: moonactive/A2.00C

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -12217,3 +12217,7 @@
   board: thgingenuity
 - company: USA Mechanical & Energy Services
   board: usamechasp
+- company: Loonshot Games
+  board: loonshotgames
+- company: Ravenwake Games
+  board: ravenwakegames

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4044,3 +4044,7 @@
   board: servicewire
 - company: Sandberg Goldberg Bernthal Family Foundation
   board: sgff.org
+- company: digitalfish
+  board: digitalfish
+- company: sunstudio
+  board: sunstudio

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1014,3 +1014,27 @@
   board: healthop-solutions
 - company: Greenberg Larraby Gli
   board: greenberg-larraby-inc-gli
+- company: Astrid Entertainment
+  board: astrid-entertainment
+- company: Big Viking Games
+  board: big-viking-games-3
+- company: One Of Us
+  board: one-of-us
+- company: Owlchemy Labs
+  board: owlchemy-labs
+- company: Panic Stations
+  board: panic-stations
+- company: Parallelz
+  board: parallelz
+- company: Pulse Games
+  board: pulsegames
+- company: Pixomondo
+  board: pxo
+- company: Rhino Entertainment Group
+  board: rhino-entertainment
+- company: SNK
+  board: snk
+- company: Soulbound
+  board: soulbound
+- company: UserWise Services
+  board: userwise-services


### PR DESCRIPTION
## What

Harvested ATS boards by following the apply links on **workingames.com** (a game-dev jobs aggregator, 4843 postings via sitemap). Extracted board slugs per provider, dropped non-slug URL noise (`embed`, `j`), and **validated every candidate live** before adding — `harvest-boards` probes against each platform's public API; comeet (no prober) validated through the adapter itself (token-scrape + careers-api).

## Boards added (+22)

| Provider | + | Slugs |
|---|---|---|
| workable | 12 | astrid-entertainment, big-viking-games-3, one-of-us, owlchemy-labs, panic-stations, parallelz, pulsegames, pxo (Pixomondo), rhino-entertainment, snk, soulbound, userwise-services |
| comeet | 3 | crazylabs/32.00E (CrazyLabs), ludeo/D7.008 (Ludeo), moonactive/A2.00C (Moon Active) |
| greenhouse | 2 | loonshotgames, ravenwakegames |
| lever | 2 | digitalfish, sunstudio |
| ashby | 2 | intangible.ai, scorewarrior |
| bamboohr | 1 | ludia |

## Skipped

- **iCIMS `careers-zenimax`** — prober returned 0 jobs (likely a Jibe front / different API). Biasing toward under-adding rather than committing a dead board.
- LinkedIn / Tencent / EA / Riot / Roblox / Epic / Keka / PeopleForce and other custom career sites — no adapter for them.

## Also reviewed: legaloperationsjobboard.com

Walked the full board (108 postings). Every ATS slug — greenhouse (komodohealth, lightningai, mercury, thenewyorktimes, verkada, cortex), ashby (august, beaconai, gamma, harvey, legora, notion, openai, wordsmith), workday (gtlaw, innocap, athena), recruitingsolutions (riv-prod) — **already exists**, so nothing to add there.

## Verification

- `go build ./...` ✅
- All 6 changed YAML files parse ✅
- Each added board validated live (positions/jobs API returned > 0) ✅