### PR TITLE
fix(search): degrade SimilarJobs to empty when the semantic index is absent

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -380,6 +380,12 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 // a vector — its /similar is then "no neighbours", not an error.
 const similarSourceMissingCode = "not_found_similar_id"
 
+// semanticIndexMissingCode is Meilisearch's code when the semantic index itself
+// is absent (e.g. it was dropped to reclaim disk and its rebuild is paused). Like
+// a missing source document, this degrades to "no neighbours" so the detail page
+// hides the section instead of erroring.
+const semanticIndexMissingCode = "index_not_found"
+
 // SimilarJobs returns the jobs nearest to job id in embedding space, queried
 // against the semantic index by the document's stored vector (no query text, no
 // re-embedding). The semantic index holds open jobs only, so neighbours are open
@@ -391,7 +397,8 @@ const similarSourceMissingCode = "not_found_similar_id"
 // A job with no vector in the semantic index yet (the index lags ingest) yields
 // an empty list, not an error: Meilisearch answers such a source id with
 // not_found_similar_id, which we map to "no neighbours" so the detail-page
-// section simply hides.
+// section simply hides. A wholly absent semantic index (index_not_found, e.g.
+// dropped to reclaim disk) degrades the same way.
 func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDocument, error) {
 	var resp meilisearch.SimilarDocumentResult
 	err := c.semantic.SearchSimilarDocumentsWithContext(ctx, &meilisearch.SimilarDocumentQuery{
@@ -401,8 +408,11 @@ func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDoc
 	}, &resp)
 	if err != nil {
 		var meiliErr *meilisearch.Error
-		if errors.As(err, &meiliErr) && meiliErr.MeilisearchApiError.Code == similarSourceMissingCode {
-			return nil, nil
+		if errors.As(err, &meiliErr) {
+			switch meiliErr.MeilisearchApiError.Code {
+			case similarSourceMissingCode, semanticIndexMissingCode:
+				return nil, nil
+			}
 		}
 		return nil, fmt.Errorf("search: similar: %w", err)
 	}

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -468,6 +468,23 @@ func TestIntegration_SimilarJobs(t *testing.T) {
 			t.Errorf("expected no neighbours for an unindexed id, got %d", len(hits))
 		}
 	})
+
+	// The semantic index may be dropped entirely to reclaim disk while its rebuild
+	// is paused. Meilisearch then answers with index_not_found, which must degrade
+	// to an empty list — exactly like a missing source — so the detail page hides
+	// the section rather than 500ing. Runs last: it removes the shared index.
+	t.Run("absent semantic index yields empty, not an error", func(t *testing.T) {
+		if err := c.dropIndex(ctx, semanticIndexUID); err != nil {
+			t.Fatalf("dropIndex: %v", err)
+		}
+		hits, err := c.SimilarJobs(ctx, 1, 10)
+		if err != nil {
+			t.Fatalf("SimilarJobs against an absent index must not error: %v", err)
+		}
+		if len(hits) != 0 {
+			t.Errorf("expected no neighbours when the index is absent, got %d", len(hits))
+		}
+	})
 }
 
 func toDocs(t *testing.T, jobs []db.Job) []JobDocument {


### PR DESCRIPTION
## Context

The `jobs_semantic` index was dropped in prod (2026-06-26) to reclaim ~28G of disk so the facet reindex cron could be re-enabled without the disk-full loop. While the semantic rebuild stays paused, `jobs_semantic` does not exist.

## Problem

`SimilarJobs` mapped only `not_found_similar_id` (a missing **source document**) to "no neighbours". A wholly absent index makes Meilisearch answer with `index_not_found`, which fell through to a 500 on `GET /api/v1/jobs/:slug/similar`.

The SvelteKit detail page already wraps this fetch in `.catch(() => [])`, so users see no breakage — but the backend still emits 500s (log noise / bad API behaviour).

## Change

- Map `index_not_found` the same way as `not_found_similar_id` → return an empty list, so the "Similar jobs" section simply hides.
- Add an integration subtest that drops the semantic index and asserts the empty, error-free result.

## Test

- `go build ./...`, `go vet`, `go test ./internal/search/` green.
- New integration subtest compiles under `-tags=integration`.

## Follow-ups (not in this PR)

- Semantic / "Similar jobs" stays off until `jobs_semantic` is rebuilt (needs disk capacity).
- Facet reindex is back on as a full-swap every 3h; the durable fix to allow cheap in-place `--since` is to bump `updated_at` only on real content change in `UpsertJob`.