### PR TITLE
feat(sources): add 112 Nordic boards (Teamtailor-heavy)

### DIFF
--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -4263,3 +4263,5 @@
   board: xppower2
 - company: zooplus
   board: zooplusse
+- company: Vattenfall AB
+  board: Vattenfall

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -2376,3 +2376,225 @@
   board: italentplus.teamtailor.com
 - company: Dnpphotoimagingeurope
   board: dnpphotoimagingeurope-1732191906.teamtailor.com
+- company: Above Agency
+  board: above.teamtailor.com
+- company: addpeople
+  board: addpeople.teamtailor.com
+- company: Aker BP
+  board: akerbp.teamtailor.com
+- company: Astek Sweden AB
+  board: astekswedenab.teamtailor.com
+- company: Axel Arigato
+  board: axelarigato.teamtailor.com
+- company: Capalo AI
+  board: capaloai.teamtailor.com
+- company: 2550 Engineering
+  board: career.2550.engineering
+- company: Accelerate
+  board: career.accelerate-iver.com
+- company: Aira
+  board: career.airahome.com
+- company: Aura Group
+  board: career.aura.group
+- company: Bannerflow
+  board: career.bannerflow.com
+- company: Cabeza
+  board: career.cabeza.se
+- company: Coretura
+  board: career.coretura.com
+- company: Culligan Nordic Group Sweden
+  board: career.culligan.se
+- company: Everone
+  board: career.everone.se
+- company: Extenda Retail
+  board: career.extendaretail.com
+- company: Fellowmind Sweden
+  board: career.fellowmind.se
+- company: Forefront Amplify
+  board: career.forefrontamplify.se
+- company: MCT Brattberg
+  board: career.mctbrattberg.com
+- company: Natural Cycles
+  board: career.naturalcycles.com
+- company: Neoventa Medical AB
+  board: career.neoventa.com
+- company: Nextory
+  board: career.nextory.com
+- company: Nordnet
+  board: career.nordnetab.com
+- company: PS Finance Group
+  board: career.psfinancegroup.com
+- company: 'Regin '
+  board: career.regincontrols.se
+- company: RISE Research Institutes of Sweden AB
+  board: career.ri.se
+- company: Snowprint Studios
+  board: career.snowprintstudios.com
+- company: Stegra
+  board: career.stegra.com
+- company: Telavox
+  board: career.telavox.com
+- company: TOBLOR Consulting
+  board: career.toblor.se
+- company: Together Tech
+  board: career.togethertech.com
+- company: Vertiseit
+  board: career.vertiseit.com
+- company: Abilia
+  board: careers.abilia.com
+- company: Acast
+  board: careers.acast.com
+- company: Aiforia Technologies Plc
+  board: careers.aiforia.com
+- company: ATICC Sweden AB
+  board: careers.aticc.se
+- company: Blykalla
+  board: careers.blykalla.com
+- company: Empir Industry
+  board: careers.empirindustry.com
+- company: Envoke Talent AB
+  board: careers.envoketalent.com
+- company: Futurice
+  board: careers.futurice.com
+- company: Insurely
+  board: careers.insurely.com
+- company: Klättermusen
+  board: careers.klattermusen.com
+- company: Lendo Group
+  board: careers.lendo.se
+- company: Minso Solutions
+  board: careers.minso.se
+- company: MittLogik
+  board: careers.mittlogik.se
+- company: Performativ
+  board: careers.performativ.com
+- company: Professional Galaxy AB
+  board: careers.progalaxy.se
+- company: 'Q Sverige '
+  board: careers.qbemanning.se
+- company: Quartr
+  board: careers.quartr.com
+- company: Soundtrack
+  board: careers.soundtrack.io
+- company: Spiideo
+  board: careers.spiideo.com
+- company: Spobik
+  board: careers.spobik.se
+- company: Spond
+  board: careers.spond.com
+- company: Sustainium
+  board: careers.sustainium.se
+- company: Swappie
+  board: careers.swappie.com
+- company: Umain
+  board: careers.umain.com
+- company: Velory
+  board: careers.velory.com
+- company: Viaplay Group
+  board: careers.viaplaygroup.com
+- company: Wrknest
+  board: careers.wrknest.se
+- company: Xensam
+  board: careers.xensam.com
+- company: Younium
+  board: careers.younium.com
+- company: Compendia
+  board: compendia.teamtailor.com
+- company: Din Rekryteringspartner i Umeå
+  board: dinrekryteringspartneriumea-1741688263.teamtailor.com
+- company: Ed:Za
+  board: edzagroup.teamtailor.com
+- company: Idax
+  board: idax.teamtailor.com
+- company: Intertek
+  board: interteksemkoab.teamtailor.com
+- company: 0TO9
+  board: jobs.0to9.com
+- company: Binogi
+  board: jobs.binogi.com
+- company: DynamicSource
+  board: jobs.dynamicsource.se
+- company: 'Gigstep '
+  board: jobs.gigstep.se
+- company: Logikfabriken AB
+  board: jobs.logikfabriken.se
+- company: Lynqa
+  board: jobs.lynqa.se
+- company: Net Insight
+  board: jobs.netinsight.net
+- company: New Minds
+  board: jobs.newminds.se
+- company: Sigma Embedded Engineering
+  board: jobs.sigmaembeddedengineering.se
+- company: SiNIX
+  board: jobs.sinix.se
+- company: 'Solidsport '
+  board: jobs.solidsport.com
+- company: Star Stable Entertainment
+  board: jobs.starstableentertainment.com
+- company: Swedbank
+  board: jobs.swedbank.com
+- company: Taigatech
+  board: jobs.taigatech.se
+- company: Vitec in Sweden
+  board: jobs.vitecsoftware.se
+- company: Drakryggen
+  board: join.drakryggen.com
+- company: Justera Group
+  board: justergroupab.teamtailor.com
+- company: Maersk
+  board: maersk.teamtailor.com
+- company: Nipromec Group
+  board: nipromec.teamtailor.com
+- company: Omexom Sverige
+  board: omexom.teamtailor.com
+- company: Precis
+  board: precisdigital.teamtailor.com
+- company: Prevas Test & Measurement
+  board: prevastm.teamtailor.com
+- company: Purple Rekrytering & Interim
+  board: purplerekrytering.teamtailor.com
+- company: Repli5
+  board: repli5.teamtailor.com
+- company: SallyQ AB
+  board: sallyqab.teamtailor.com
+- company: Schibsted
+  board: schibsted-svenska-dagbladet.teamtailor.com
+- company: Trifork UK
+  board: trifork.teamtailor.com
+- company: Vipps
+  board: vipps.teamtailor.com
+- company: ChopChop
+  board: work.chopchop.se
+- company: Emajsi
+  board: work.emajsi.se
+- company: XXL Sverige
+  board: xxlsverige.teamtailor.com
+- company: Zitac
+  board: zitac.teamtailor.com
+- company: 2LCollection
+  board: 2lcollection.teamtailor.com
+- company: 4C Associates
+  board: 4cassociates.teamtailor.com
+- company: adobe
+  board: adobe.teamtailor.com
+- company: Àlber Blanc Capital
+  board: alberblanc.teamtailor.com
+- company: ALEA
+  board: alea.teamtailor.com
+- company: Aleido Group
+  board: aleidogroup.teamtailor.com
+- company: 'Atlassian '
+  board: atlassian.teamtailor.com
+- company: Creditspring
+  board: creditspring.teamtailor.com
+- company: ESADE Faculty Positions
+  board: esadefaculty.teamtailor.com
+- company: Founders Pledge
+  board: founderspledge.teamtailor.com
+- company: Fully
+  board: fully.teamtailor.com
+- company: Heroes
+  board: heroes-1713787424.teamtailor.com
+- company: Huawei Sweden R&D
+  board: huaweisweden.teamtailor.com


### PR DESCRIPTION
## What

Adds **112 live job boards** (111 Teamtailor + 1 SmartRecruiters), Nordic-focused (SE/NO/DK/FI), to the source files.

## Where they came from

1. **`TrendTweekers/Nordic-Signals`** (GitHub) — a Nordic tech-hiring dataset whose `data/classified/*.json` carry **real** scraped job URLs tagged by company + country. Real URLs ⇒ the career hosts are guaranteed live. Extracted unique hosts per ATS for SE/NO/DK/FI.
2. A broader **GitHub code search** for `*.teamtailor.com` hosts in company-list/config files (caught some non-Nordic Teamtailor companies too — all live boards, so kept).

## How they were validated

Every candidate was run through `cmd/harvest-boards <provider> <seed.json>`, which probes each board against the platform's live contract and keeps **only boards returning open jobs**, deduped against the existing files. Nothing was added on faith — the committed entries are our own validated fact set.

## Why Teamtailor

Teamtailor is the **Nordic-dominant ATS** (Swedish company) and was our biggest Nordic gap. The other ATS in the dataset (lever/ashby/greenhouse) were already covered — 0 new live candidates there.

## Yield
| provider | candidates probed | new live boards |
|---|---|---|
| teamtailor | 295 | 111 |
| smartrecruiters | 7 | 1 |
| ashby/lever/greenhouse/workable/deel | 28 | 0 (already covered) |

Data-only change; `go build ./...` clean, both files parse and validate against the source registry with 0 unknown providers and no duplicate boards.