### PR TITLE
fix(sources): correct T-Bank apply URL to the live careers route

### DIFF
--- a/internal/sources/tbank.go
+++ b/internal/sources/tbank.go
@@ -125,8 +125,12 @@ func (b tbank) detail(ctx context.Context, e CompanyEntry, it tbankVacancyItem) 
 
 	return Job{
 		ExternalID: it.URLSlug,
-		// SPA route UNCONFIRMED — best-effort from seoSlug; verify against the live careers UI.
-		URL:         fmt.Sprintf("https://www.tbank.ru/career/vacancy/%s/", it.SeoSlug),
+		// The careers SPA addresses a vacancy solely by its urlSlug (a UUID) in the final path
+		// segment — the section/city/seoSlug segments are cosmetic (any non-empty value resolves
+		// the same vacancy), but the route's five-segment shape must be intact or the server
+		// 404s. "it" is a real, universally-rendering section; "all" is a neutral city; the real
+		// seoSlug keeps the URL readable. (Verified against the live careers UI, 2026-06.)
+		URL:         fmt.Sprintf("https://www.tbank.ru/career/it/vacancy/all/%s/%s/", it.SeoSlug, it.URLSlug),
 		Title:       it.Title,
 		Company:     e.Company,
 		Location:    it.Subtitle,

--- a/internal/sources/tbank_test.go
+++ b/internal/sources/tbank_test.go
@@ -134,7 +134,7 @@ func TestTBankFetchPaginatesAndMapsMixedBlocks(t *testing.T) {
 	if j1.Company != "T-Bank" {
 		t.Errorf("Company = %q, want T-Bank", j1.Company)
 	}
-	if want := "https://www.tbank.ru/career/vacancy/backend-engineer/"; j1.URL != want {
+	if want := "https://www.tbank.ru/career/it/vacancy/all/backend-engineer/slug-1/"; j1.URL != want {
 		t.Errorf("URL = %q, want %q", j1.URL, want)
 	}
 	if j1.Location != "Москва" {


### PR DESCRIPTION
## Problem

A T-Bank vacancy on the site links to a dead apply URL — e.g. `/jobs/predstavitel-t-bank-icnlq7pg` → `https://www.tbank.ru/career/vacancy/predstavitel/` **404**.

The `tbank` adapter built the apply URL from `seoSlug` alone (`/career/vacancy/<seoSlug>/`) — a route the original author explicitly flagged `// SPA route UNCONFIRMED`. Two reasons it can't work:

1. **Wrong route shape.** The live careers SPA uses five segments: `/career/<section>/vacancy/<city>/<seoSlug>/<urlSlug>/`. The short path SSR-404s.
2. **`seoSlug` is non-unique** — shared across cities for the same role, so it can never address one vacancy. Only `urlSlug` (a UUID) is unique.

## Fix

Verified live via headless render that a vacancy is resolved **solely by `urlSlug` (UUID)** in the final path segment; `section`/`city`/`seoSlug` are cosmetic (the page self-corrects its own breadcrumb/title) but the five-segment shape must be intact (`section` is validated against `it`/`service`/`back-office`; `it` renders any vacancy). Build the URL as:

```
https://www.tbank.ru/career/it/vacancy/all/<seoSlug>/<urlSlug>/
```

## Migration

None. `ExternalID` is already `urlSlug`, so existing prod rows heal on the next T-Bank crawl via `UpsertJob` (ON CONFLICT source+external_id).

## Test

Updated the URL assertion in `tbank_test.go`; `go test ./internal/sources/ -run TestTBank` passes; build/vet/gofmt clean.