### PR TITLE
feat(classify): split AI Engineer into its own category

### DIFF
--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -42,12 +42,21 @@ func TestParse(t *testing.T) {
 		{"Sales Manager", "", "sales"},
 		{"Support Manager", "", "support"},
 		{"Operations Manager", "", "management"},
-		// AI / GenAI roles fold into ml_ai (research/applied AI share one bucket).
-		{"GenAI Engineer", "", "ml_ai"},
-		{"LLM Engineer", "", "ml_ai"},
-		{"Senior Prompt Engineer", "senior", "ml_ai"},
-		{"Generative AI Researcher", "", "ml_ai"},
-		{"Applied AI Engineer", "", "ml_ai"},
+		// AI-application roles (RAG/agents/LLM/prompt/applied AI) are their own
+		// category; classic ML and explicitly ML-carrying titles stay ml_ai.
+		{"AI Engineer", "", "ai_engineering"},
+		{"GenAI Engineer", "", "ai_engineering"},
+		{"LLM Engineer", "", "ai_engineering"},
+		{"Senior Prompt Engineer", "senior", "ai_engineering"},
+		{"Generative AI Researcher", "", "ai_engineering"},
+		{"Applied AI Engineer", "", "ai_engineering"},
+		{"RAG Engineer", "", "ai_engineering"},
+		{"Machine Learning Engineer", "", "ml_ai"},
+		{"Deep Learning Engineer", "", "ml_ai"},
+		{"ML Engineer", "", "ml_ai"},
+		// A combined ML-carrying form keeps the ML bucket (explicit ML beats bare AI).
+		{"ML/AI Engineer", "", "ml_ai"},
+		{"AI/ML Engineer", "", "ml_ai"},
 		// SEO / social fold into marketing; "social media" beats a bare "manager".
 		{"SEO Specialist", "", "marketing"},
 		{"Social Media Manager", "", "marketing"},

--- a/internal/classify/dictionaries.go
+++ b/internal/classify/dictionaries.go
@@ -41,8 +41,11 @@ var categoryOrder = []string{
 	"data engineer", "data engineering", "дата-инженер", "инженер данных",
 	"data scientist", "data science", "data scien", "дата-сайентист",
 	"data analyst", "data analytics", "аналитик данных", "data аналитик",
-	"machine learning", "deep learning", "ml engineer", "ai engineer", "ml/ai",
-	"generative ai", "genai", "llm engineer", "prompt engineer", "applied ai", "llm",
+	// Classic ML and explicitly ML-carrying combined forms first, so a mixed
+	// "ML/AI Engineer" resolves to ml_ai before the bare AI terms below can claim it.
+	"machine learning", "deep learning", "ml engineer", "ml/ai", "ai/ml",
+	// AI-application terms (RAG/agents/LLM/prompt/applied AI) → ai_engineering.
+	"generative ai", "genai", "llm engineer", "prompt engineer", "applied ai", "rag engineer", "ai engineer", "llm",
 	"devops", "девопс",
 	"sre", "site reliability",
 	"backend", "back-end", "back end", "бэкенд", "бекенд",
@@ -78,9 +81,10 @@ var categoryAliases = map[string]string{
 	"data analyst": "data_analytics", "data analytics": "data_analytics",
 	"аналитик данных": "data_analytics", "data аналитик": "data_analytics",
 	"machine learning": "ml_ai", "deep learning": "ml_ai", "ml engineer": "ml_ai",
-	"ai engineer": "ml_ai", "ml/ai": "ml_ai",
-	"generative ai": "ml_ai", "genai": "ml_ai", "llm engineer": "ml_ai",
-	"prompt engineer": "ml_ai", "applied ai": "ml_ai", "llm": "ml_ai",
+	"ml/ai": "ml_ai", "ai/ml": "ml_ai",
+	"ai engineer": "ai_engineering", "generative ai": "ai_engineering", "genai": "ai_engineering",
+	"llm engineer": "ai_engineering", "prompt engineer": "ai_engineering", "applied ai": "ai_engineering",
+	"rag engineer": "ai_engineering", "llm": "ai_engineering",
 	"devops": "devops", "девопс": "devops",
 	"sre": "sre", "site reliability": "sre",
 	"backend": "backend", "back-end": "backend", "back end": "backend",

--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -89,7 +89,7 @@ var (
 	EducationLevelValues = []string{"none", "bachelor", "master", "phd"}
 	CategoryValues       = []string{
 		"backend", "frontend", "fullstack", "mobile", "devops", "sre",
-		"data_engineering", "data_science", "data_analytics", "ml_ai",
+		"data_engineering", "data_science", "data_analytics", "ml_ai", "ai_engineering",
 		"qa", "security", "hardware", "embedded", "blockchain",
 		"design", "product", "project_management", "management",
 		"marketing", "sales", "support", "other",

--- a/openspec/changes/add-ai-engineering-category/.openspec.yaml
+++ b/openspec/changes/add-ai-engineering-category/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-28

--- a/openspec/changes/add-ai-engineering-category/design.md
+++ b/openspec/changes/add-ai-engineering-category/design.md
@@ -1,0 +1,80 @@
+## Context
+
+Role category is a deterministic, dict-only facet. `internal/classify.Parse`
+matches a lowercased job title against an ordered alias list
+(`categoryOrder`/`categoryAliases` in `internal/classify/dictionaries.go`),
+first-match-wins, with whole-word boundaries (`containsWord`). The resolved
+canonical comes from `enrich.CategoryValues` and is stored in `jobs.category`,
+served dict-only as a Meilisearch facet. Today every AI/ML title — classic ML
+and LLM-application alike — collapses to `ml_ai`.
+
+The web SPA renders the category filter from generated contracts; the LLM
+enrichment schema enum is generated from the same `CategoryValues`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A distinct `ai_engineering` category (label "AI Engineer") separating
+  LLM-application roles from classic ML.
+- Title classification routes AI-application vs classic-ML vs mixed titles
+  correctly and deterministically.
+- The new value flows automatically into the enrichment enum and the web filter.
+
+**Non-Goals:**
+- No description-body classification for category (title-only, as today).
+- No handling of AI-infra/support titles ("AI Platform/Infrastructure Engineer")
+  — they are unclassified by title today and stay so.
+- No new source adapter (builtin.com spike returned PARTIAL — redundant with ATS
+  coverage; out of scope here).
+- No backfill code change — the existing `cmd/backfill-derive` re-derives.
+
+## Decisions
+
+**1. Separate canonical `ai_engineering`, not a rename of `ml_ai`.**
+Rationale: the two roles are genuinely distinct; keeping `ml_ai` for model work
+preserves history and existing tags. Alternative (rename whole `ml_ai`) loses the
+ML-vs-AI-app distinction the change exists to create.
+
+**2. Ordering encodes precedence: ML-carrying multiword aliases before bare AI
+terms.** `containsWord` is substring-with-boundaries, so `"ML/AI Engineer"`
+contains the substring `ai engineer`. To keep mixed titles in `ml_ai`, the
+ML-carrying aliases (`ml/ai`, `ai/ml`, `ml engineer`, `machine learning`,
+`deep learning`) are listed in `categoryOrder` ahead of the AI-application
+aliases (`ai engineer`, `applied ai`, `generative ai`, `genai`, `llm engineer`,
+`prompt engineer`, `llm`). First-match-wins then yields `ml_ai` for mixed titles
+and `ai_engineering` for pure AI-application titles. Alternative (regex / token
+classifier) is over-engineering for a curated dictionary.
+
+**3. `ai/ml` added as an explicit alias.** Current code has `ml/ai`→ml_ai but not
+`ai/ml`; the latter is caught incidentally by `ml engineer` only when "engineer"
+follows. Adding `ai/ml`→ml_ai makes the mixed-form intent explicit and robust to
+titles like "AI/ML Specialist".
+
+**4. Enrichment enum and web contracts are derived, not hand-edited.** Adding to
+`CategoryValues` extends the langchaingo enum automatically; the web filter label
+"AI Engineer" is added where category labels live and contracts are regenerated.
+
+## Risks / Trade-offs
+
+- [Title-only classification misroutes the ~28% AI-infra/support "AI Engineer"
+  postings the field guide flagged] → Accepted: this matches the existing
+  title-only heuristic for all categories; description-level disambiguation is a
+  separate, larger effort and a non-goal here.
+- [Existing `ml_ai`-tagged jobs that are really AI-engineering do not move until
+  re-derive] → Mitigation: run `cmd/backfill-derive` + `make reindex` post-deploy,
+  per the established dict-facet operational convention. No code risk; purely an
+  ops step.
+- [A stale Meili index could 500 on a new value] → Not applicable: `category` is
+  an already-filterable attribute; only the value set grows, no new attribute.
+
+## Migration Plan
+
+1. Ship code (vocabulary + dictionary + tests + web label/contracts).
+2. Post-deploy: `cmd/backfill-derive` re-derives all facet columns (re-tags
+   AI-engineering jobs), then `make reindex` rebuilds the search index.
+3. Rollback: revert the commit; `ai_engineering` tags become inert (no consumer
+   breaks on an unknown facet value), and the next re-derive restores `ml_ai`.
+
+## Open Questions
+
+None — naming (`ai_engineering` / "AI Engineer") and scope are settled.

--- a/openspec/changes/add-ai-engineering-category/proposal.md
+++ b/openspec/changes/add-ai-engineering-category/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The catalogue conflates two distinct roles under one `ml_ai` category: classic
+ML/DL model work (training, fine-tuning, computer vision) and the emerging
+"AI Engineer" role (RAG, agents, LLM applications, prompt engineering). These
+are different jobs with different skills and audiences — a field analysis of 895
+AI-Engineer postings (builtin.com, Jan 2026) found ~70% are LLM-application
+roles that have little to do with model training. Folding them into one facet
+hides a signal users want to filter on.
+
+## What Changes
+
+- Add a new role category `ai_engineering` (label "AI Engineer") to the
+  controlled vocabulary, alongside the existing `ml_ai`.
+- Split the title-classification dictionary so LLM/GenAI/agent/RAG/prompt/applied-AI
+  titles resolve to `ai_engineering`, while classic ML/DL titles
+  (`machine learning`, `deep learning`, `ml engineer`) and explicitly mixed
+  ML-carrying titles (`ml/ai`, `ai/ml`) stay `ml_ai`.
+- The LLM enrichment category enum extends automatically (it reads the same
+  vocabulary), so the model may also emit `ai_engineering`.
+- The web category filter gains the "AI Engineer" option (regenerated contracts +
+  label).
+
+No breaking change: `ml_ai` is unchanged in name; `ai_engineering` is purely
+additive to the enum. Existing jobs re-tag on the next dictionary re-derive.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `deterministic-facets`: the `category` facet vocabulary gains `ai_engineering`,
+  and the title-dictionary classification rule that currently routes all AI/ML
+  titles to `ml_ai` is split — AI-application titles resolve to `ai_engineering`,
+  classic-ML and mixed ML-carrying titles remain `ml_ai`.
+
+## Impact
+
+- `internal/enrich/enrichment.go` — `CategoryValues` gains `ai_engineering`
+  (auto-extends the langchaingo enrichment enum in `internal/enrich/langchain.go`).
+- `internal/classify/dictionaries.go` — `categoryOrder` / `categoryAliases`
+  re-routed and re-ordered (ML-carrying multiword aliases precede bare AI terms).
+- `internal/classify/classify_test.go` — existing AI-title expectations updated,
+  mixed-title boundary cases added.
+- Web SPA category filter — regenerated contracts + "AI Engineer" label.
+- No DB migration (`jobs.category` is a text column, not a PG enum).
+- Operational (post-deploy, per the dict-facet convention): `cmd/backfill-derive`
+  then `make reindex` to re-tag and re-index existing jobs.

--- a/openspec/changes/add-ai-engineering-category/specs/deterministic-facets/spec.md
+++ b/openspec/changes/add-ai-engineering-category/specs/deterministic-facets/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: The category facet distinguishes AI engineering from classic ML
+
+The `category` vocabulary SHALL include `ai_engineering` alongside `ml_ai`, and
+the title dictionary SHALL route role titles between them: titles denoting
+LLM/GenAI application work (RAG, agents, prompt engineering, applied AI, "AI
+Engineer") resolve to `ai_engineering`, while titles denoting classic machine
+learning / deep learning model work resolve to `ml_ai`. A title that explicitly
+carries the ML token in a combined form (`ML/AI`, `AI/ML`, `ML Engineer`) SHALL
+resolve to `ml_ai` — the ML signal wins over the bare AI signal. The dictionary
+never guesses: a title naming neither resolves to an empty category, unchanged.
+
+#### Scenario: An AI-application title resolves to ai_engineering
+
+- **WHEN** a job titled "Applied AI Engineer" (or "LLM Engineer",
+  "Generative AI Engineer", "Prompt Engineer", "RAG Engineer", "AI Engineer") is
+  classified by the title dictionary
+- **THEN** the derived `category` is `ai_engineering`
+
+#### Scenario: A classic-ML title resolves to ml_ai
+
+- **WHEN** a job titled "Machine Learning Engineer" (or "Deep Learning Engineer",
+  "ML Engineer") is classified by the title dictionary
+- **THEN** the derived `category` is `ml_ai`
+
+#### Scenario: A combined ML-carrying title stays ml_ai
+
+- **WHEN** a job titled "ML/AI Engineer" or "AI/ML Engineer" is classified by the
+  title dictionary
+- **THEN** the derived `category` is `ml_ai` (the explicit ML token wins over the
+  bare AI token)
+
+#### Scenario: ai_engineering is a recognized category value
+
+- **WHEN** the LLM enrichment payload or any consumer validates a `category` of
+  `ai_engineering` against the controlled vocabulary
+- **THEN** the value is accepted (it is a member of the category vocabulary), not
+  sanitized away

--- a/openspec/changes/add-ai-engineering-category/tasks.md
+++ b/openspec/changes/add-ai-engineering-category/tasks.md
@@ -1,0 +1,20 @@
+## 1. Vocabulary
+
+- [x] 1.1 Add `ai_engineering` to `enrich.CategoryValues` in `internal/enrich/enrichment.go` (next to `ml_ai`); confirm `go test ./internal/enrich/...` stays green (langchaingo enum auto-extends).
+
+## 2. Title classification (TDD)
+
+- [x] 2.1 RED: in `internal/classify/classify_test.go`, change the existing AI-title cases (GenAI / LLM / Prompt / Applied AI Engineer) to expect `ai_engineering`, and add boundary cases: `Machine Learning Engineer`/`Deep Learning Engineer`/`ML Engineer` → `ml_ai`, `ML/AI Engineer`/`AI/ML Engineer` → `ml_ai`, `RAG Engineer`/`AI Engineer` → `ai_engineering`. Run the test, watch it fail.
+- [x] 2.2 GREEN: in `internal/classify/dictionaries.go`, split the AI/ML cluster — route `ai engineer`, `applied ai`, `generative ai`, `genai`, `llm engineer`, `prompt engineer`, `llm` (and add `rag engineer`) to `ai_engineering`; keep `machine learning`, `deep learning`, `ml engineer`, `ml/ai` on `ml_ai` and add `ai/ml` → `ml_ai`. Order `categoryOrder` so the ML-carrying aliases precede the bare AI terms.
+- [x] 2.3 Run `go test ./internal/classify/...` — all green, including the canonical-membership assertion.
+
+## 3. Web category filter
+
+- [x] 3.1 Regenerate web contracts with the contract generator (`cmd/gen-contracts`) so `CATEGORY_VALUES` in `web/src/lib/generated/contracts.ts` gains `ai_engineering` (do not hand-edit the generated file).
+- [x] 3.2 Add `ai_engineering: 'AI Engineer'` to the `CATEGORY_LABELS` map in `web/src/lib/labels.ts` (next to `ml_ai`); `facets.ts` and `enrichment.ts` both consume this map, so one edit covers both.
+- [x] 3.3 Verify the web build (`svelte-check` per the project's web verification — no test runner exists).
+
+## 4. Verify
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...` all clean.
+- [x] 4.2 Record the post-deploy operational step in the change (run `cmd/backfill-derive` then `make reindex` on prod to re-tag and re-index existing jobs) — code change carries no DB migration.

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -112,7 +112,7 @@ export interface Job {
   enrichment_version: number /* int32 */;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'arbeitnow', 'ashby', 'ashbygraphql', 'bamboohr', 'breezy', 'deel', 'eightfold', 'epam', 'freshteam', 'gem', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'himalayas', 'huntflow', 'icims', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'remotive', 'rippling', 'smartrecruiters', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'vention', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'breezy', 'careerplug', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'habr_career', 'himalayas', 'huntflow', 'icims', 'inhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'personio', 'phenom', 'pinpoint', 'radancy', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'trakstar', 'ukg', 'vention', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];
@@ -120,7 +120,7 @@ export const WORK_MODE_VALUES = ['remote', 'hybrid', 'onsite'] as const;
 export type WorkMode = (typeof WORK_MODE_VALUES)[number];
 export const SENIORITY_VALUES = ['intern', 'junior', 'middle', 'senior', 'lead', 'staff', 'principal', 'c_level'] as const;
 export type Seniority = (typeof SENIORITY_VALUES)[number];
-export const CATEGORY_VALUES = ['backend', 'frontend', 'fullstack', 'mobile', 'devops', 'sre', 'data_engineering', 'data_science', 'data_analytics', 'ml_ai', 'qa', 'security', 'hardware', 'embedded', 'blockchain', 'design', 'product', 'project_management', 'management', 'marketing', 'sales', 'support', 'other'] as const;
+export const CATEGORY_VALUES = ['backend', 'frontend', 'fullstack', 'mobile', 'devops', 'sre', 'data_engineering', 'data_science', 'data_analytics', 'ml_ai', 'ai_engineering', 'qa', 'security', 'hardware', 'embedded', 'blockchain', 'design', 'product', 'project_management', 'management', 'marketing', 'sales', 'support', 'other'] as const;
 export type Category = (typeof CATEGORY_VALUES)[number];
 export const EMPLOYMENT_TYPE_VALUES = ['full_time', 'part_time', 'contract', 'internship'] as const;
 export type EmploymentType = (typeof EMPLOYMENT_TYPE_VALUES)[number];

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -29,6 +29,7 @@ export const WORK_MODE_LABELS: Record<string, string> = { onsite: 'On-site' };
 
 export const CATEGORY_LABELS: Record<string, string> = {
   ml_ai: 'ML / AI',
+  ai_engineering: 'AI Engineer',
   data_engineering: 'Data Engineering',
   data_science: 'Data Science',
   data_analytics: 'Data Analytics',


### PR DESCRIPTION
## Summary

Splits the **AI Engineer** role into its own `ai_engineering` category (label "AI Engineer"), separating LLM-application engineering (RAG, agents, prompt, applied AI, GenAI) from classic ML/DL model work — both were previously collapsed into `ml_ai`. Motivated by a field analysis of 895 AI-Engineer postings (builtin.com, Jan 2026): ~70% are LLM-application roles distinct from model training.

### What changed
- `internal/enrich/enrichment.go` — `ai_engineering` added to `CategoryValues` (auto-extends the langchaingo enrichment enum).
- `internal/classify/dictionaries.go` — AI/ML alias cluster split: AI-application terms → `ai_engineering`; classic-ML and explicitly ML-carrying combined forms (`ml/ai`, new `ai/ml`, `ml engineer`, `machine learning`, `deep learning`) → `ml_ai`. `categoryOrder` places ML-carrying aliases **before** the bare AI terms so a mixed `ML/AI Engineer` resolves to `ml_ai` (explicit ML beats bare AI).
- `internal/classify/classify_test.go` — AI-title expectations updated + mixed/classic boundary cases added.
- `web/src/lib/labels.ts` — `ai_engineering: 'AI Engineer'` label.
- `web/src/lib/generated/contracts.ts` — regenerated via `cmd/gen-contracts`. **Note:** this also syncs a pre-existing, unrelated `SOURCE_VALUES` drift that had accumulated on `main` (adapter PRs hadn't regenerated contracts) — kept because the file must match generator output.

### Design notes
- Category is a **dict-only** facet; classification is title-only and never guesses (consistent with existing facets).
- **No DB migration** — `jobs.category` is a text column, not a PG enum.
- OpenSpec change: `openspec/changes/add-ai-engineering-category/`.

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` green (classify driven RED→GREEN; mixed `ML/AI`/`AI/ML` → `ml_ai`, AI-app titles → `ai_engineering`)
- [x] `npm run check` (svelte-check) — 0 errors / 0 warnings
- [ ] **Post-deploy:** run `cmd/backfill-derive` then `make reindex` so existing `ml_ai` jobs that are actually AI-application roles get re-tagged and re-indexed