### PR TITLE
feat(sources): add Articulate board (lever)

### DIFF
--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4048,3 +4048,5 @@
   board: digitalfish
 - company: sunstudio
   board: sunstudio
+- company: Articulate
+  board: articulate


### PR DESCRIPTION
Articulate → Lever board `articulate`, validated live (api.lever.co/v0/postings/articulate). Only gap from the 40 remote-hiring-companies list; the other 39 were already tracked.