### PR TITLE
fix(sources): dedupe Palo Alto Networks workday board

### DIFF
--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -10423,8 +10423,6 @@
   board: organon.wd5.myworkdayjobs.com/search_jobs
 - company: pacificsmiles
   board: pacificsmiles.wd105.myworkdayjobs.com/external_psg
-- company: paloaltonetworks
-  board: paloaltonetworks.wd5.myworkdayjobs.com/panwexternalcareers
 - company: parissaintgermain
   board: parissaintgermain.wd3.myworkdayjobs.com/evenementiel
 - company: parklandhospital


### PR DESCRIPTION
workday.yml had two entries for the same board `paloaltonetworks.wd5.myworkdayjobs.com/panwexternalcareers` (`paloaltonetworks` + `Palo Alto Networks`, the latter added in #282 over a pre-existing one). Drops the lowercase dup, keeps the proper name. Harmless before (last-in-file won deterministically) but avoids a redundant double-crawl.