### PR TITLE
feat(sources): getmatch structured facets (seniority/category/skills/experience)

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -4,12 +4,21 @@
 // (backfill-geo/-skills/-class). Ingest fills these on every crawl via
 // jobderive.Derive; rows that predate a dictionary change — and closed jobs that
 // never re-crawl — keep the stale values until this one-off worker rewrites them.
-// It pages the whole table and exits. Idempotent: the facets are a pure function
-// of the title/location/description, so a second run rewrites nothing.
+// It pages the whole table and exits. Idempotent for jobs whose facets come from
+// the title/location/description dictionaries alone: re-deriving is a pure function
+// of those fields, so a second run rewrites nothing.
 //
 // Slugs are deliberately not touched (re-slugging stays cmd/reslug). work_mode is
 // preserved when already set: jobderive keeps a row's existing (possibly
-// adapter-structured) work_mode over the parsed-location hint.
+// adapter-structured) work_mode over the parsed-location hint. The other
+// structured-source facets are NOT preserved: an adapter that emits a grade,
+// category, skills, or required-experience directly (e.g. getmatch) supplies those
+// only at ingest, and this command re-derives seniority/category/skills/
+// experience_years_min from the stored description columns — so running it
+// overwrites such structured values with the dictionary's. This is intentional:
+// the command's job is to propagate dictionary changes, which must keep updating
+// those facets for the dictionary-derived majority. A boardless adapter like
+// getmatch re-supplies the structured facets on its next full crawl.
 package main
 
 import (

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -6,6 +6,8 @@
 package jobderive
 
 import (
+	"sort"
+
 	"github.com/strelov1/freehire/internal/classify"
 	"github.com/strelov1/freehire/internal/jobfacts"
 	"github.com/strelov1/freehire/internal/lang"
@@ -16,16 +18,28 @@ import (
 
 // Input is the raw job content the derivation reads. Source and ExternalID are the
 // already-resolved storage identity (the caller decides how to namespace them); they
-// feed the public slug so it is stable with the dedup key. WorkMode is the caller's
-// structured signal (an ATS workplace-type enum), if any — it wins over the parsed hint.
+// feed the public slug so it is stable with the dedup key.
+//
+// WorkMode, Seniority, Category, Skills, and ExperienceYearsMin are the caller's
+// STRUCTURED signals — values the source states explicitly (an enum, a grade, a tag
+// list, a numeric field), already mapped into freehire's vocabularies. Each takes
+// precedence over the dictionary derivation: the scalar signals win when present and
+// the dictionary fills only when they are empty/nil; the multi-valued Skills are
+// unioned with the dictionary skills. They carry structured signal only, never a
+// heuristic an adapter inferred from free text; an adapter with no signal leaves them
+// empty/nil so the dictionary decides.
 type Input struct {
-	Title       string
-	Company     string
-	Source      string
-	ExternalID  string
-	Location    string
-	Description string
-	WorkMode    string
+	Title              string
+	Company            string
+	Source             string
+	ExternalID         string
+	Location           string
+	Description        string
+	WorkMode           string
+	Seniority          string
+	Category           string
+	Skills             []string
+	ExperienceYearsMin *int
 }
 
 // Derived is the set of facets computed from an Input.
@@ -49,9 +63,11 @@ type Derived struct {
 
 // Derive computes the slugs and dictionary facets for a job. Geography, skills, and the
 // title classification (seniority/category) come from the curated dictionaries (which
-// emit nothing for what they cannot resolve). Two facets fall back to a conservative
-// description phrase match when their primary source is silent: work-mode (structured
-// signal → location hint → description) and seniority (title → description).
+// emit nothing for what they cannot resolve). A structured signal supplied on the Input
+// takes precedence over the dictionary for the facets that carry one: work-mode
+// (structured → location hint → description), seniority (structured → title →
+// description), category (structured → title), experience (structured → description),
+// and skills (structured ∪ dictionary).
 func Derive(in Input) Derived {
 	geo := location.Parse(in.Location)
 	// Work-mode precedence: structured (ATS) → location marker → description phrase.
@@ -64,25 +80,63 @@ func Derive(in Input) Derived {
 		workMode = location.WorkModeFromDescription(in.Description)
 	}
 	class := classify.Parse(in.Title)
-	// Seniority precedence: title dictionary → description phrase. The description
-	// only fills a grade the title left empty. Category stays title-only (its prose
-	// signal is too noisy to derive deterministically).
-	seniority := class.Seniority
+	// Seniority precedence: structured source signal → title dictionary → description
+	// phrase. Each lower source only fills a grade the higher ones left empty.
+	seniority := in.Seniority
+	if seniority == "" {
+		seniority = class.Seniority
+	}
 	if seniority == "" {
 		seniority = classify.SeniorityFromDescription(in.Description)
 	}
+	// Category precedence: structured source signal → title dictionary. (Description
+	// prose is too noisy to derive a category deterministically.)
+	category := in.Category
+	if category == "" {
+		category = class.Category
+	}
+	// Experience precedence: structured source signal → description text parse.
+	experience := in.ExperienceYearsMin
+	if experience == nil {
+		experience = jobfacts.ExperienceYearsMin(in.Description)
+	}
 	return Derived{
-		CompanySlug:        normalize.Slug(in.Company),
-		PublicSlug:         normalize.JobSlug(in.Title, in.Company, in.Source, in.ExternalID),
-		Countries:          geo.Countries,
-		Regions:            geo.Regions,
-		WorkMode:           workMode,
-		Skills:             skilltag.Parse(in.Description),
+		CompanySlug: normalize.Slug(in.Company),
+		PublicSlug:  normalize.JobSlug(in.Title, in.Company, in.Source, in.ExternalID),
+		Countries:   geo.Countries,
+		Regions:     geo.Regions,
+		WorkMode:    workMode,
+		// Skills is a set: the structured source skills are unioned with the
+		// dictionary skills, neither replacing the other.
+		Skills:             unionSkills(in.Skills, skilltag.Parse(in.Description)),
 		Seniority:          seniority,
-		Category:           class.Category,
+		Category:           category,
 		PostingLanguage:    lang.Detect(in.Description),
 		EmploymentType:     jobfacts.EmploymentType(in.Title, in.Description),
 		EducationLevel:     jobfacts.EducationLevel(in.Description),
-		ExperienceYearsMin: jobfacts.ExperienceYearsMin(in.Description),
+		ExperienceYearsMin: experience,
 	}
+}
+
+// unionSkills merges the structured source skills with the dictionary skills into a
+// deduped, sorted set. Both inputs are already canonical skill names; the result is
+// nil when both are empty (the dictionary's empty-not-nil contract is preserved by
+// callers that read Skills, which treat nil and empty alike).
+func unionSkills(source, dict []string) []string {
+	if len(source) == 0 {
+		return dict
+	}
+	set := make(map[string]struct{}, len(source)+len(dict))
+	for _, s := range source {
+		set[s] = struct{}{}
+	}
+	for _, s := range dict {
+		set[s] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -198,3 +198,101 @@ func TestDerive_NoisyDescriptionYieldsNoSeniority(t *testing.T) {
 		t.Errorf("Seniority = %q, want empty (noisy description, no anchored grade)", got.Seniority)
 	}
 }
+
+// A structured seniority from the source (e.g. a marketplace's grade field) wins
+// over both the title dictionary and the description.
+func TestDerive_StructuredSeniorityWins(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Lead Backend Engineer", // title → lead
+		Company:     "Acme",
+		Source:      "getmatch",
+		ExternalID:  "1",
+		Seniority:   "senior", // structured source signal
+		Description: "We want a junior to grow.",
+	})
+	if got.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior (structured source wins)", got.Seniority)
+	}
+}
+
+// When the source carries no structured seniority, the dictionary fills it.
+func TestDerive_DictionaryFillsSeniorityWhenSourceSilent(t *testing.T) {
+	got := Derive(Input{
+		Title:      "Lead Backend Engineer", // title → lead
+		Company:    "Acme",
+		Source:     "getmatch",
+		ExternalID: "1",
+	})
+	if got.Seniority != "lead" {
+		t.Errorf("Seniority = %q, want lead (dictionary fills when source silent)", got.Seniority)
+	}
+}
+
+// A structured category from the source wins over the title dictionary; when the
+// source is silent the dictionary fills it.
+func TestDerive_StructuredCategoryWinsAndDictionaryFills(t *testing.T) {
+	withSource := Derive(Input{
+		Title:      "Backend Developer", // title → backend
+		Company:    "Acme",
+		Source:     "getmatch",
+		ExternalID: "1",
+		Category:   "data_engineering", // structured source signal
+	})
+	if withSource.Category != "data_engineering" {
+		t.Errorf("Category = %q, want data_engineering (structured source wins)", withSource.Category)
+	}
+
+	silent := Derive(Input{
+		Title:      "Backend Developer", // title → backend
+		Company:    "Acme",
+		Source:     "getmatch",
+		ExternalID: "2",
+	})
+	if silent.Category != "backend" {
+		t.Errorf("Category = %q, want backend (dictionary fills when source silent)", silent.Category)
+	}
+}
+
+// A structured minimum-experience from the source wins over the jobfacts text
+// parse; when the source is nil the text parse fills it.
+func TestDerive_StructuredExperienceWinsAndTextFills(t *testing.T) {
+	src := 7
+	withSource := Derive(Input{
+		Title:              "Dev",
+		Company:            "Acme",
+		Source:             "getmatch",
+		ExternalID:         "1",
+		ExperienceYearsMin: &src,
+		Description:        "at least 3 years of experience required",
+	})
+	if withSource.ExperienceYearsMin == nil || *withSource.ExperienceYearsMin != 7 {
+		t.Errorf("ExperienceYearsMin = %v, want 7 (structured source wins)", withSource.ExperienceYearsMin)
+	}
+
+	silent := Derive(Input{
+		Title:       "Dev",
+		Company:     "Acme",
+		Source:      "getmatch",
+		ExternalID:  "2",
+		Description: "at least 3 years of experience required",
+	})
+	if silent.ExperienceYearsMin == nil || *silent.ExperienceYearsMin != 3 {
+		t.Errorf("ExperienceYearsMin = %v, want 3 (text fills when source nil)", silent.ExperienceYearsMin)
+	}
+}
+
+// Skills is a set: the structured source skills are UNIONED with the dictionary
+// skills (deduped, sorted), neither replacing the other.
+func TestDerive_SourceSkillsUnionWithDictionary(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Dev",
+		Company:     "Acme",
+		Source:      "getmatch",
+		ExternalID:  "1",
+		Skills:      []string{"go"},               // structured source signal
+		Description: "We use Kubernetes and Go.", // dictionary → go, kubernetes
+	})
+	if !reflect.DeepEqual(got.Skills, []string{"go", "kubernetes"}) {
+		t.Errorf("Skills = %v, want [go kubernetes] (source ∪ dictionary, deduped+sorted)", got.Skills)
+	}
+}

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -289,7 +289,7 @@ func TestDerive_SourceSkillsUnionWithDictionary(t *testing.T) {
 		Company:     "Acme",
 		Source:      "getmatch",
 		ExternalID:  "1",
-		Skills:      []string{"go"},               // structured source signal
+		Skills:      []string{"go"},              // structured source signal
 		Description: "We use Kubernetes and Go.", // dictionary → go, kubernetes
 	})
 	if !reflect.DeepEqual(got.Skills, []string{"go", "kubernetes"}) {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -286,16 +286,21 @@ func normalizeJob(e sources.CompanyEntry, j sources.Job) Job {
 	source, externalID := jobIdentity(e, j)
 	// The slugs and dictionary facets (geography/work-mode/skills/classification) are
 	// derived by the shared jobderive helper, so ingest and the moderator write path
-	// produce identical facets. Work-mode precedence (structured signal over the parser
-	// hint) lives there.
+	// produce identical facets. The adapter's structured facet signals (work-mode,
+	// seniority, category, skills, experience) take precedence over the dictionary
+	// there; an unset signal lets the dictionary decide.
 	d := jobderive.Derive(jobderive.Input{
-		Title:       j.Title,
-		Company:     j.Company,
-		Source:      source,
-		ExternalID:  externalID,
-		Location:    j.Location,
-		Description: j.Description,
-		WorkMode:    j.WorkMode,
+		Title:              j.Title,
+		Company:            j.Company,
+		Source:             source,
+		ExternalID:         externalID,
+		Location:           j.Location,
+		Description:        j.Description,
+		WorkMode:           j.WorkMode,
+		Seniority:          j.Seniority,
+		Category:           j.Category,
+		Skills:             j.Skills,
+		ExperienceYearsMin: j.ExperienceYearsMin,
 	})
 	return Job{
 		Source:      source,

--- a/internal/sources/getmatch.go
+++ b/internal/sources/getmatch.go
@@ -3,8 +3,12 @@ package sources
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/skilltag"
 )
 
 // getmatch adapts getmatch.ru, a curated Russian IT job marketplace. Its public, keyless feed
@@ -51,6 +55,8 @@ type getmatchListResponse struct {
 
 // getmatchOffer is one posting. Company nests the employer's own name (the marketplace lists
 // many employers); OfferDescription is the list summary and Description the full detail body.
+// Seniority, Specializations, SkillsObjects, and RequiredYearsOfExperience are structured
+// facet fields the platform exposes only on the detail endpoint (the list page omits them).
 type getmatchOffer struct {
 	ID               int    `json:"id"`
 	Position         string `json:"position"`
@@ -61,7 +67,17 @@ type getmatchOffer struct {
 	Company          struct {
 		Name string `json:"name"`
 	} `json:"company"`
-	LocationItems []getmatchLocation `json:"location_items"`
+	LocationItems             []getmatchLocation `json:"location_items"`
+	Seniority                 string             `json:"seniority"`
+	Specializations           []string           `json:"specializations"`
+	SkillsObjects             []getmatchSkill    `json:"skills_objects"`
+	RequiredYearsOfExperience *int               `json:"required_years_of_experience"`
+}
+
+// getmatchSkill is one entry of an offer's skills_objects; only the display Name is used,
+// canonicalized through the skilltag dictionary (see getmatchSkills).
+type getmatchSkill struct {
+	Name string `json:"name"`
 }
 
 // getmatchLocation is one of an offer's locations: a display Label and a Format that is either
@@ -97,33 +113,129 @@ func (g getmatch) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 
 // toJob maps an offer to a Job. The company is the offer's own employer, not the configured
 // entry; the work mode is structured only when the offer's locations agree on one (see
-// getmatchWorkMode).
+// getmatchWorkMode). The per-offer detail is fetched once and supplies both the full HTML body
+// and the structured facets (grade/specialization/skills/experience), which the list page omits.
 func (g getmatch) toJob(ctx context.Context, o getmatchOffer) Job {
 	mode := getmatchWorkMode(o.LocationItems)
+	detail, _ := g.detail(ctx, o.ID)
+	// The full detail body wins over the list summary, falling back when the detail is
+	// empty (event cards) or its request failed (a zero detail) — so an offer is never
+	// dropped over a missing description.
+	desc := o.OfferDescription
+	if strings.TrimSpace(detail.Description) != "" {
+		desc = detail.Description
+	}
 	return Job{
-		ExternalID:  strconv.Itoa(o.ID),
-		URL:         getmatchBaseURL + o.URL,
-		Title:       o.Position,
-		Company:     o.Company.Name,
-		Description: sanitizeHTML(g.description(ctx, o)),
-		Location:    getmatchLocationString(o.LocationItems),
-		Remote:      mode == "remote",
-		WorkMode:    mode,
-		PostedAt:    parseLayout(getmatchDateLayout, o.PublishedAt),
+		ExternalID:         strconv.Itoa(o.ID),
+		URL:                getmatchBaseURL + o.URL,
+		Title:              o.Position,
+		Company:            o.Company.Name,
+		Description:        sanitizeHTML(desc),
+		Location:           getmatchLocationString(o.LocationItems),
+		Remote:             mode == "remote",
+		WorkMode:           mode,
+		PostedAt:           parseLayout(getmatchDateLayout, o.PublishedAt),
+		Seniority:          getmatchSeniority(detail.Seniority),
+		Category:           getmatchCategory(detail.Specializations),
+		Skills:             getmatchSkills(detail.SkillsObjects),
+		ExperienceYearsMin: detail.RequiredYearsOfExperience,
 	}
 }
 
-// description returns the offer's full HTML body from the detail endpoint, falling back to the
-// list summary when the detail body is empty (e.g. event cards) or its request fails, so an
-// offer is never dropped over a missing description.
-func (g getmatch) description(ctx context.Context, o getmatchOffer) string {
+// detail fetches the per-offer detail endpoint, returning a zero offer and false on a failed
+// request so the caller falls back to the list summary and leaves the structured facets empty —
+// an offer is never dropped over a missing detail.
+func (g getmatch) detail(ctx context.Context, id int) (getmatchOffer, bool) {
 	var detail getmatchOffer
-	if err := g.http.GetJSON(ctx, fmt.Sprintf(getmatchDetailURL, o.ID), &detail); err == nil {
-		if strings.TrimSpace(detail.Description) != "" {
-			return detail.Description
+	if err := g.http.GetJSON(ctx, fmt.Sprintf(getmatchDetailURL, id), &detail); err != nil {
+		return getmatchOffer{}, false
+	}
+	return detail, true
+}
+
+// getmatchSeniority maps a getmatch grade to freehire's seniority vocabulary. getmatch's grades
+// (junior/middle/senior/lead/c_level) are a subset of enrich.SeniorityValues with identical
+// spelling, so vocabulary membership IS the map: a recognized grade passes through, anything
+// else is dropped (never guessed).
+func getmatchSeniority(grade string) string {
+	g := strings.ToLower(strings.TrimSpace(grade))
+	if slices.Contains(enrich.SeniorityValues, g) {
+		return g
+	}
+	return ""
+}
+
+// getmatchSpecializationCategory maps getmatch specialization codes to freehire's category
+// vocabulary. The keys are the real codes getmatch emits (sampled from the live API); only
+// high-confidence, unambiguous codes are mapped. Codes with no clean single equivalent —
+// analyst roles (business_analyst, system_analyst, product_analyst), architect, generic C/C++
+// (c_cpp/c_language), dba, recruitment/writer roles — are intentionally absent and resolve to no
+// category, so the title dictionary decides rather than the map guessing.
+var getmatchSpecializationCategory = map[string]string{
+	"python":                              "backend",
+	"golang":                              "backend",
+	"java_scala":                          "backend",
+	"c_sharp":                             "backend",
+	"php":                                 "backend",
+	"ruby":                                "backend",
+	"js_backend":                          "backend",
+	"js_frontend":                         "frontend",
+	"fullstack":                           "fullstack",
+	"android":                             "mobile",
+	"ios":                                 "mobile",
+	"cross_platform_flutter_react_native": "mobile",
+	"dev_ops":                             "devops",
+	"system_administrator":                "devops",
+	"sre":                                 "sre",
+	"data_engineering":                    "data_engineering",
+	"dwh_data_warehouse":                  "data_engineering",
+	"data_science":                        "data_science",
+	"data_analyst_bi":                     "data_analytics",
+	"qa_auto":                             "qa",
+	"qa_manual":                           "qa",
+	"information_security":                "security",
+	"embedded":                            "embedded",
+	"blockchain_crypto":                   "blockchain",
+	"product_design":                      "design",
+	"product_management":                  "product",
+	"project_management":                  "project_management",
+	"engineering_management":              "management",
+	"sales":                               "sales",
+	"marketing":                           "marketing",
+	"support_engineer":                    "support",
+}
+
+// getmatchCategory resolves an offer's specializations to a single category, mirroring
+// getmatchWorkMode: each mapped code contributes its category, and the result is that category
+// only when all mapped codes agree; a conflict (more than one distinct category) or no mapped
+// code yields "" so the title dictionary decides. Unmappable codes are ignored, not treated as
+// a conflict.
+func getmatchCategory(specs []string) string {
+	var category string
+	for _, code := range specs {
+		c, ok := getmatchSpecializationCategory[strings.ToLower(strings.TrimSpace(code))]
+		if !ok {
+			continue
+		}
+		if category == "" {
+			category = c
+		} else if category != c {
+			return ""
 		}
 	}
-	return o.OfferDescription
+	return category
+}
+
+// getmatchSkills canonicalizes an offer's skills_objects through the skilltag dictionary,
+// keeping only resolved technologies (so marketplace noise like "Kiss" or "152-ФЗ" is dropped).
+// The names are joined into one text blob so skilltag.Parse applies the same matching it uses on
+// a description.
+func getmatchSkills(objs []getmatchSkill) []string {
+	names := make([]string, 0, len(objs))
+	for _, o := range objs {
+		names = append(names, o.Name)
+	}
+	return skilltag.Parse(strings.Join(names, " "))
 }
 
 // getmatchWorkMode derives the structured work mode from the offer's location formats, mapping

--- a/internal/sources/getmatch_test.go
+++ b/internal/sources/getmatch_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/strelov1/freehire/internal/enrich"
 )
 
 // getmatchHTTP is a route-aware test JSONGetter. getmatch has two endpoints: a paged list
@@ -227,6 +229,119 @@ func TestGetmatchLaterPageErrorEndsEnumeration(t *testing.T) {
 	}
 	if len(jobs) != 1 {
 		t.Fatalf("got %d jobs, want 1 (gathered before the failing page)", len(jobs))
+	}
+}
+
+func TestGetmatchSeniority(t *testing.T) {
+	tests := []struct {
+		grade string
+		want  string
+	}{
+		{"senior", "senior"},
+		{"middle", "middle"},
+		{"lead", "lead"},
+		{"c_level", "c_level"},
+		{"Senior", "senior"}, // case/space tolerant
+		{"trainee", ""},      // not in freehire's vocabulary → dropped
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := getmatchSeniority(tc.grade); got != tc.want {
+			t.Errorf("getmatchSeniority(%q) = %q, want %q", tc.grade, got, tc.want)
+		}
+	}
+}
+
+func TestGetmatchCategory(t *testing.T) {
+	tests := []struct {
+		name  string
+		specs []string
+		want  string
+	}{
+		{"single mapped", []string{"python"}, "backend"},
+		{"android to mobile", []string{"android"}, "mobile"},
+		{"data engineering passthrough", []string{"data_engineering"}, "data_engineering"},
+		{"duplicate same category", []string{"python", "golang"}, "backend"},
+		{"conflict drops", []string{"python", "android"}, ""},
+		{"unmappable drops", []string{"business_analyst"}, ""},
+		{"unmappable mixed with mapped keeps mapped", []string{"business_analyst", "python"}, "backend"},
+		{"none", nil, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := getmatchCategory(tc.specs); got != tc.want {
+				t.Errorf("getmatchCategory(%v) = %q, want %q", tc.specs, got, tc.want)
+			}
+		})
+	}
+}
+
+// Every category the specialization map targets must be a real CategoryValues member,
+// so the map cannot drift out of the controlled vocabulary.
+func TestGetmatchCategoryMapTargetsAreValid(t *testing.T) {
+	for code, cat := range getmatchSpecializationCategory {
+		if !slices.Contains(enrich.CategoryValues, cat) {
+			t.Errorf("specialization %q maps to %q, not in enrich.CategoryValues", code, cat)
+		}
+	}
+}
+
+func TestGetmatchSkills(t *testing.T) {
+	// Known technologies are canonicalized through skilltag; noise tokens are dropped.
+	got := getmatchSkills([]getmatchSkill{{Name: "Golang"}, {Name: "Kiss"}, {Name: "Docker"}})
+	if !slices.Equal(got, []string{"docker", "go"}) {
+		t.Errorf("getmatchSkills = %v, want [docker go] (canonical, noise dropped)", got)
+	}
+	if got := getmatchSkills(nil); len(got) != 0 {
+		t.Errorf("getmatchSkills(nil) = %v, want empty", got)
+	}
+}
+
+func TestGetmatchFetchSetsStructuredFacets(t *testing.T) {
+	fake := &getmatchHTTP{
+		pages: map[int]string{0: `{"meta":{"total":1,"offset":0,"limit":100},"offers":[
+			{"id":700,"position":"Разработчик","url":"/vacancies/700-x","company":{"name":"C"},
+			 "offer_description":"s","location_items":[{"label":"Москва","format":"remote"}]}
+		]}`},
+		details: map[int]string{700: `{"id":700,"description":"<p>body</p>",
+			"seniority":"senior","specializations":["python"],
+			"skills_objects":[{"name":"Golang"},{"name":"Kiss"}],
+			"required_years_of_experience":4}`},
+	}
+	jobs, err := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	j := jobs[0]
+	if j.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior", j.Seniority)
+	}
+	if j.Category != "backend" {
+		t.Errorf("Category = %q, want backend (python)", j.Category)
+	}
+	if !slices.Equal(j.Skills, []string{"go"}) {
+		t.Errorf("Skills = %v, want [go] (Golang canonical, Kiss dropped)", j.Skills)
+	}
+	if j.ExperienceYearsMin == nil || *j.ExperienceYearsMin != 4 {
+		t.Errorf("ExperienceYearsMin = %v, want 4", j.ExperienceYearsMin)
+	}
+}
+
+// A detail that fails (or omits the structured fields) leaves the facets empty/nil —
+// the adapter never guesses.
+func TestGetmatchFetchStructuredFacetsAbsentOnDetailError(t *testing.T) {
+	fake := &getmatchHTTP{
+		pages: map[int]string{0: `{"meta":{"total":1,"offset":0,"limit":100},"offers":[
+			{"id":701,"position":"Backend Developer","url":"/vacancies/701-x","company":{"name":"C"},
+			 "offer_description":"s","location_items":[{"label":"L","format":"remote"}]}
+		]}`},
+		detailErr: map[int]bool{701: true},
+	}
+	jobs, _ := NewGetmatch(fake).Fetch(context.Background(), CompanyEntry{})
+	j := jobs[0]
+	if j.Seniority != "" || j.Category != "" || len(j.Skills) != 0 || j.ExperienceYearsMin != nil {
+		t.Errorf("structured facets should be empty on detail error, got sen=%q cat=%q skills=%v exp=%v",
+			j.Seniority, j.Category, j.Skills, j.ExperienceYearsMin)
 	}
 }
 

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -47,6 +47,17 @@ type Job struct {
 	// location string. Provenance stays clean: this carries structured signal only,
 	// never the location heuristic.
 	WorkMode string
+	// Seniority, Category, Skills, and ExperienceYearsMin are the platform's
+	// STRUCTURED facet signals, already mapped into freehire's controlled
+	// vocabularies (enrich.SeniorityValues / enrich.CategoryValues / canonical skill
+	// names). They mirror WorkMode: an adapter sets them only when the platform states
+	// the value in a structured field, never a heuristic inferred from free text, and
+	// leaves them empty/nil otherwise so the pipeline's dictionaries decide. The
+	// pipeline gives a set value precedence over the dictionary (Skills are unioned).
+	Seniority          string
+	Category           string
+	Skills             []string
+	ExperienceYearsMin *int
 	// Removed marks a posting the source reports as taken down (e.g. an item flagged
 	// removed in JobStream's incremental feed). A streaming, self-closing source emits
 	// these so the pipeline closes the job by identity instead of upserting it; all other

--- a/openspec/changes/getmatch-structured-facets/.openspec.yaml
+++ b/openspec/changes/getmatch-structured-facets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/getmatch-structured-facets/design.md
+++ b/openspec/changes/getmatch-structured-facets/design.md
@@ -1,0 +1,96 @@
+## Context
+
+getmatch.ru is a boardless marketplace adapter (`internal/sources/getmatch.go`).
+Its per-offer detail endpoint (`/api/offers/{id}`, already fetched for the HTML
+description) exposes structured fields the adapter currently ignores: `seniority`
+(scalar) / `seniorities` (array), `specializations` (code array), `skills_objects`,
+and `required_years_of_experience`.
+
+freehire derives `seniority`/`category`/`skills`/`experience_years_min` only from
+the title/description dictionaries via `jobderive.Derive`. `jobderive.Input`
+already carries one structured signal — `WorkMode` — whose precedence is
+"structured → location → description". The pipeline builds `jobderive.Input` from
+the normalized `sources.Job` (`internal/pipeline/pipeline.go`, where
+`WorkMode: j.WorkMode` is passed). This change extends that exact seam to the
+other facets.
+
+Measured impact: getmatch.ru returns ~204 jobs for `remote + senior/lead/c_level`;
+freehire returns 73, because ~60% of getmatch jobs carry no seniority facet.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let adapters emit structured `Seniority`, `Category`, `Skills`,
+  `ExperienceYearsMin` on `sources.Job`, mirroring `WorkMode`'s contract.
+- Give a structured source signal precedence over the dictionary in `jobderive`.
+- Map getmatch's detail fields into freehire's vocabularies, dropping unmappable values.
+
+**Non-Goals:**
+- Salary (`salary_min/max/currency`): no `jobs` columns exist and it crosses the
+  LLM-owned `enrichment` JSONB boundary — a separate change.
+- Read-model changes: `jobview.FromRow` still serves the facets from `jobs`
+  columns only; the LLM's enrichment values stay raw and unserved.
+- Multi-valued seniority: getmatch's `seniorities` array is collapsed to the scalar
+  `seniority` (see Risks).
+
+## Decisions
+
+### General seam over getmatch-local override
+Extend `sources.Job` and `jobderive.Input` with the new fields and keep all
+derivation in `jobderive.Derive`. Rationale: one derivation path stays testable and
+reusable by future structured sources; it copies the working `WorkMode` pattern.
+Alternative (writing derived values directly in the adapter, bypassing `jobderive`)
+was rejected — it forks the derivation logic and does not generalize.
+
+### Per-facet precedence
+- `seniority`: source → title dict → description (extends the existing two tiers).
+- `category`: source → title dict.
+- `experience_years_min`: source → `jobfacts` text parse.
+- `skills`: UNION of source skills and dictionary skills (skills is a set; both are
+  facts, so neither replaces the other — unlike the scalar facets where source replaces).
+
+### getmatch mapping is gatekept by freehire's vocabularies
+- Grade: use the scalar `seniority`; pass through an explicit map to
+  `SeniorityValues`; drop unknown grades.
+- `required_years_of_experience` → `*int` (nil when absent).
+- `skills_objects`: collect names, run them through `skilltag.Parse` (joining the
+  names as text), keep only canonical resolutions — reusing the curated dictionary
+  as the noise filter rather than adding new filtering logic.
+- `specializations`: an explicit getmatch-code → `CategoryValues` map (e.g.
+  `python`/`golang`/`java_scala`→`backend`, `android`→`mobile`, `dev_ops`→`devops`,
+  `sre`→`sre`, `data_engineering`→`data_engineering`, `data_science`→`data_science`,
+  `data_analyst_bi`→`data_analytics`, `information_security`→`security`,
+  `project_management`→`project_management`, `engineering_management`→`management`).
+  Unmappable codes (`business_analyst`, `system_analyst`, `architect`, …) are
+  dropped. If the array resolves to more than one distinct category, emit empty —
+  mirroring `getmatchWorkMode`'s "single distinct or empty" rule.
+
+## Risks / Trade-offs
+
+- **getmatch multi-grade collapses to one column** → `jobs.seniority` is scalar;
+  taking the primary scalar `seniority` means a "middle/senior" offer shows only
+  under its primary grade, unlike getmatch.ru which lists it under both. Accepted;
+  the primary grade is the most useful single value.
+- **`backfill-derive` cannot recover the signal** → it re-derives from stored
+  columns, which lack the source's structured data. Mitigation: getmatch is
+  boardless, so its next full crawl re-upserts every offer with the structured
+  fields; no backfill is needed for getmatch specifically.
+- **specialization map drift** → getmatch may add specialization codes over time;
+  unmapped ones silently yield empty `category`. Mitigation: the map is explicit and
+  unit-tested; new codes degrade to dictionary-derived category, never to a wrong one.
+- **Vocabulary divergence** → getmatch grade strings must match `SeniorityValues`.
+  Mitigation: an explicit map (not a raw passthrough), so a renamed/unknown grade is
+  dropped rather than persisted out-of-vocabulary.
+
+## Migration Plan
+
+1. Ship the code (no schema/migration — columns already exist).
+2. getmatch's next scheduled crawl re-ingests all offers with the structured fields.
+3. Run `make reindex` so the refreshed `seniority`/`category`/`skills`/
+   `experience_years_min` facets reach Meilisearch.
+4. Rollback: revert the code; the columns remain valid (dictionary-derived values),
+   so no data cleanup is required.
+
+## Open Questions
+
+None.

--- a/openspec/changes/getmatch-structured-facets/proposal.md
+++ b/openspec/changes/getmatch-structured-facets/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+getmatch.ru exposes a posting's grade, required experience, skills, and specialization as **structured** fields in its detail API, but our adapter ignores them — it only reads the HTML description. freehire then derives `seniority`/`category`/`skills`/`experience_years_min` purely from the title/description dictionaries, which stay silent on getmatch's marketing/Russian titles (e.g. "Приглашаем бизнес-аналитиков", "AI Engineer (AI-агенты)"). Result: ~60% of getmatch jobs carry no seniority facet, so a user filtering `remote + senior/lead/c_level` sees only 73 of the ~204 jobs getmatch.ru itself returns for the same filter.
+
+## What Changes
+
+- Adapters can emit **structured facet signals** (`Seniority`, `Category`, `Skills`, `ExperienceYearsMin`) on `sources.Job`, mirroring the existing `WorkMode` field's "structured signal only, never a heuristic" contract.
+- Derivation precedence per facet becomes **structured source signal → dictionary → description**, generalizing the rule `work_mode` already follows. The dictionary remains the fallback when the source is silent; a source value never invents an out-of-vocabulary facet.
+- The getmatch adapter populates these fields from the detail response it already fetches, mapping getmatch's values into freehire's controlled vocabularies and **dropping anything unmappable** (never guessing): grade → `SeniorityValues`; `skills_objects` canonicalized through the existing `skilltag` dictionary; `required_years_of_experience` → `experience_years_min`; `specializations` → `CategoryValues` via an explicit subset map (a mixed-category offer resolves to empty, like WorkMode on conflict).
+- Salary is explicitly out of scope (needs schema work and crosses the LLM-owned enrichment boundary) — noted as a follow-up seam.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `source-ingest`: source adapters gain optional structured facet fields on the normalized `Job`, and the getmatch adapter maps its detail data into them under freehire's vocabularies.
+- `deterministic-facets`: the `seniority`, `category`, `skills`, and `experience_years_min` facets accept a structured source signal that takes precedence over the deterministic dictionary, extending the precedence rule already in force for `work_mode`.
+
+## Impact
+
+- `internal/sources/source.go` (`Job` struct gains structured facet fields), `internal/sources/getmatch.go` (decode + map detail fields).
+- `internal/jobderive/jobderive.go` (per-facet precedence: source → dictionary → description) and `internal/pipeline/pipeline.go` (pass the new `Job` fields into `jobderive.Input`).
+- No schema/migration changes (columns `seniority`, `category`, `skills`, `experience_years_min` already exist).
+- Data refresh: getmatch is boardless, so its next full crawl re-upserts every offer with the structured fields; `backfill-derive` cannot recover them (the structured signal exists only at ingest from the live API). A `reindex` surfaces the refreshed facets to search.

--- a/openspec/changes/getmatch-structured-facets/specs/deterministic-facets/spec.md
+++ b/openspec/changes/getmatch-structured-facets/specs/deterministic-facets/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: A structured source facet signal takes precedence over the dictionaries
+
+The `seniority`, `category`, `skills`, and `experience_years_min` facets SHALL
+accept a structured signal supplied by the source adapter, taking precedence over
+the deterministic dictionary, generalizing the rule `work_mode` already follows.
+For the scalar facets (`seniority`, `category`, `experience_years_min`), the
+source signal SHALL be used when present and the dictionary/description SHALL fill
+the facet only when the source is silent. For the multi-valued `skills` facet, the
+source signal SHALL be UNIONED with the dictionary-derived skills (both are facts;
+neither replaces the other). The structured signal feeds the `jobs` columns at
+ingest through `jobderive`; the public read model is unchanged — `jobview.FromRow`
+still serves these facets from the `jobs` columns only and never from the LLM.
+
+#### Scenario: A source grade beats the title dictionary
+
+- **WHEN** a job carries a structured `seniority=senior` from the source and its
+  title dictionary resolves nothing (or a different grade)
+- **THEN** the derived `seniority` is `senior`
+
+#### Scenario: The dictionary fills a facet the source left empty
+
+- **WHEN** a job carries no structured `category` from the source and its title
+  dictionary resolves `backend`
+- **THEN** the derived `category` is `backend`
+
+#### Scenario: Source skills union with dictionary skills
+
+- **WHEN** a job carries structured `skills=[go]` from the source and the
+  description dictionary resolves `skills=[kubernetes]`
+- **THEN** the derived `skills` are `[go, kubernetes]`
+
+## MODIFIED Requirements
+
+### Requirement: Seniority is derived from the description when the title is silent
+
+The seniority facet SHALL be derived at ingest from three sources, most
+authoritative first: (1) a structured grade supplied by the source adapter, (2)
+the title dictionary (`classify.Parse`), and (3) a conservative, intent-anchored
+phrase match in the job **description**. Each lower source SHALL fill `seniority`
+only when the higher ones resolved nothing. The description detector SHALL use
+anchored phrases (not the bare title aliases) so incidental prose does not match,
+and SHALL emit nothing when there is no clear grade statement (it never guesses,
+and it does not infer a grade from a years-of-experience figure). The category
+facet is unaffected by this requirement.
+
+#### Scenario: The source grade beats the title and description
+
+- **WHEN** a job carries a structured `seniority=senior` from the source while its
+  title resolves `lead`
+- **THEN** the derived `seniority` is `senior` (the structured source signal wins)
+
+#### Scenario: The description fills seniority when the title is silent
+
+- **WHEN** a job carries no structured grade, its title states no grade, and its
+  description says "we are looking for a senior engineer"
+- **THEN** the derived `seniority` is `senior`
+
+#### Scenario: The title grade beats the description
+
+- **WHEN** a job carries no structured grade, its title resolves to `lead`, and its
+  description mentions a senior engineer
+- **THEN** the derived `seniority` is `lead` (the title wins; description only fills)
+
+#### Scenario: Incidental prose does not set seniority
+
+- **WHEN** a job's title states no grade and its description contains incidental
+  phrases like "senior management", "lead the team", "junior colleagues", or
+  "report to the head of product" — but no anchored grade statement
+- **THEN** the derived `seniority` is empty
+
+#### Scenario: A years-of-experience figure does not set seniority
+
+- **WHEN** a job's title states no grade and its description only says "5+ years of
+  experience required"
+- **THEN** the derived `seniority` is empty (no band is inferred)

--- a/openspec/changes/getmatch-structured-facets/specs/source-ingest/spec.md
+++ b/openspec/changes/getmatch-structured-facets/specs/source-ingest/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Source adapters may emit structured facet signals
+
+The normalized `Job` a source adapter returns SHALL carry optional structured
+facet fields — `Seniority`, `Category`, `Skills`, and `ExperienceYearsMin` —
+alongside the existing `WorkMode`. Each field carries a STRUCTURED signal the
+source states explicitly (an enum, tag list, or numeric field), never a value an
+adapter inferred from free text. An adapter that has no structured signal for a
+field SHALL leave it empty/nil, so the downstream derivation falls back to the
+dictionaries. An adapter SHALL map a source value into freehire's controlled
+vocabulary and SHALL emit nothing for a value it cannot map (it never guesses or
+forwards an out-of-vocabulary value).
+
+#### Scenario: An adapter with no structured signal leaves the fields empty
+
+- **WHEN** an adapter normalizes a posting whose platform exposes no grade, skills,
+  category, or experience field
+- **THEN** the returned `Job` has empty `Seniority`/`Category`/`Skills` and a nil
+  `ExperienceYearsMin`
+
+#### Scenario: An unmappable source value is dropped, not forwarded
+
+- **WHEN** an adapter reads a source facet value with no equivalent in freehire's
+  controlled vocabulary
+- **THEN** the corresponding `Job` field is left empty rather than carrying the raw value
+
+### Requirement: getmatch maps its detail data into structured facets
+
+The getmatch adapter SHALL populate the `Job`'s structured facet fields from the
+per-offer detail response it already fetches, under freehire's vocabularies:
+the scalar `seniority` grade SHALL map into `SeniorityValues` (unknown grades
+dropped); `required_years_of_experience` SHALL set `ExperienceYearsMin` (nil when
+absent); `skills_objects` names SHALL be canonicalized through the `skilltag`
+dictionary, keeping only resolved skills; and `specializations` SHALL map into
+`CategoryValues` via an explicit subset map, resolving to a single category or, if
+the offer's specializations map to more than one distinct category, to empty.
+
+#### Scenario: A getmatch grade becomes a structured seniority
+
+- **WHEN** a getmatch offer's detail has `seniority` set to a grade in freehire's
+  vocabulary (e.g. `senior`)
+- **THEN** the normalized `Job` carries `Seniority="senior"`
+
+#### Scenario: getmatch skills are canonicalized and noise is dropped
+
+- **WHEN** a getmatch offer's `skills_objects` contain both a known technology
+  (e.g. "Golang") and an unrecognized token (e.g. "Kiss")
+- **THEN** the normalized `Job`'s `Skills` contain the canonical skill and exclude the noise
+
+#### Scenario: Conflicting specializations resolve to empty
+
+- **WHEN** a getmatch offer's `specializations` map to two different categories
+- **THEN** the normalized `Job`'s `Category` is empty

--- a/openspec/changes/getmatch-structured-facets/tasks.md
+++ b/openspec/changes/getmatch-structured-facets/tasks.md
@@ -1,0 +1,23 @@
+## 1. Structured facet seam
+
+- [ ] 1.1 Add `Seniority`, `Category`, `Skills`, `ExperienceYearsMin` fields to `sources.Job` (`internal/sources/source.go`) with a docstring matching `WorkMode`'s "structured signal only, never a heuristic" contract.
+- [ ] 1.2 Add the same fields to `jobderive.Input` (`internal/jobderive/jobderive.go`).
+- [ ] 1.3 In `jobderive.Derive`, apply precedence: `seniority` source→title→description; `category` source→title; `experience_years_min` source→`jobfacts`; `skills` = union(source, dictionary).
+- [ ] 1.4 In `internal/pipeline/pipeline.go`, pass the new `Job` fields into `jobderive.Input` (beside `WorkMode: j.WorkMode`).
+- [ ] 1.5 Unit-test `jobderive`: source beats dict (seniority/category/experience), dict fills when source silent, skills union, multi-tier seniority order.
+
+## 2. getmatch mapping
+
+- [ ] 2.1 Extend `getmatchOffer` to decode `seniority`, `specializations`, `skills_objects`, `required_years_of_experience` from the detail response.
+- [ ] 2.2 Map the scalar grade to `enrich.SeniorityValues` (explicit map; unknown dropped).
+- [ ] 2.3 Canonicalize `skills_objects` names via `skilltag.Parse` (drop noise).
+- [ ] 2.4 Map `specializations` codes to `enrich.CategoryValues` via an explicit subset map; resolve to a single category or empty on conflict (mirror `getmatchWorkMode`).
+- [ ] 2.5 Set `required_years_of_experience` into `ExperienceYearsMin` (nil when absent).
+- [ ] 2.6 Populate the structured `Job` fields in `toJob` from the detail response (reuse the already-fetched detail; avoid a second request).
+- [ ] 2.7 Unit-test the getmatch mapping with detail fixtures: grade→seniority, skills canonicalized + noise dropped, specialization map (mapped/unmappable/conflict), experience set/absent.
+
+## 3. Verification & rollout
+
+- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green.
+- [ ] 3.2 Live-smoke the getmatch adapter against the real API; confirm a sample of offers now carry structured seniority/skills/category/experience.
+- [ ] 3.3 Document the rollout note (next getmatch crawl re-ingests; run `make reindex` to surface facets) in the change/PR description.

--- a/openspec/changes/getmatch-structured-facets/tasks.md
+++ b/openspec/changes/getmatch-structured-facets/tasks.md
@@ -1,23 +1,23 @@
 ## 1. Structured facet seam
 
-- [ ] 1.1 Add `Seniority`, `Category`, `Skills`, `ExperienceYearsMin` fields to `sources.Job` (`internal/sources/source.go`) with a docstring matching `WorkMode`'s "structured signal only, never a heuristic" contract.
-- [ ] 1.2 Add the same fields to `jobderive.Input` (`internal/jobderive/jobderive.go`).
-- [ ] 1.3 In `jobderive.Derive`, apply precedence: `seniority` source→title→description; `category` source→title; `experience_years_min` source→`jobfacts`; `skills` = union(source, dictionary).
-- [ ] 1.4 In `internal/pipeline/pipeline.go`, pass the new `Job` fields into `jobderive.Input` (beside `WorkMode: j.WorkMode`).
-- [ ] 1.5 Unit-test `jobderive`: source beats dict (seniority/category/experience), dict fills when source silent, skills union, multi-tier seniority order.
+- [x] 1.1 Add `Seniority`, `Category`, `Skills`, `ExperienceYearsMin` fields to `sources.Job` (`internal/sources/source.go`) with a docstring matching `WorkMode`'s "structured signal only, never a heuristic" contract.
+- [x] 1.2 Add the same fields to `jobderive.Input` (`internal/jobderive/jobderive.go`).
+- [x] 1.3 In `jobderive.Derive`, apply precedence: `seniority` source→title→description; `category` source→title; `experience_years_min` source→`jobfacts`; `skills` = union(source, dictionary).
+- [x] 1.4 In `internal/pipeline/pipeline.go`, pass the new `Job` fields into `jobderive.Input` (beside `WorkMode: j.WorkMode`).
+- [x] 1.5 Unit-test `jobderive`: source beats dict (seniority/category/experience), dict fills when source silent, skills union, multi-tier seniority order.
 
 ## 2. getmatch mapping
 
-- [ ] 2.1 Extend `getmatchOffer` to decode `seniority`, `specializations`, `skills_objects`, `required_years_of_experience` from the detail response.
-- [ ] 2.2 Map the scalar grade to `enrich.SeniorityValues` (explicit map; unknown dropped).
-- [ ] 2.3 Canonicalize `skills_objects` names via `skilltag.Parse` (drop noise).
-- [ ] 2.4 Map `specializations` codes to `enrich.CategoryValues` via an explicit subset map; resolve to a single category or empty on conflict (mirror `getmatchWorkMode`).
-- [ ] 2.5 Set `required_years_of_experience` into `ExperienceYearsMin` (nil when absent).
-- [ ] 2.6 Populate the structured `Job` fields in `toJob` from the detail response (reuse the already-fetched detail; avoid a second request).
-- [ ] 2.7 Unit-test the getmatch mapping with detail fixtures: grade→seniority, skills canonicalized + noise dropped, specialization map (mapped/unmappable/conflict), experience set/absent.
+- [x] 2.1 Extend `getmatchOffer` to decode `seniority`, `specializations`, `skills_objects`, `required_years_of_experience` from the detail response.
+- [x] 2.2 Map the scalar grade to `enrich.SeniorityValues` (explicit map; unknown dropped).
+- [x] 2.3 Canonicalize `skills_objects` names via `skilltag.Parse` (drop noise).
+- [x] 2.4 Map `specializations` codes to `enrich.CategoryValues` via an explicit subset map; resolve to a single category or empty on conflict (mirror `getmatchWorkMode`).
+- [x] 2.5 Set `required_years_of_experience` into `ExperienceYearsMin` (nil when absent).
+- [x] 2.6 Populate the structured `Job` fields in `toJob` from the detail response (reuse the already-fetched detail; avoid a second request).
+- [x] 2.7 Unit-test the getmatch mapping with detail fixtures: grade→seniority, skills canonicalized + noise dropped, specialization map (mapped/unmappable/conflict), experience set/absent.
 
 ## 3. Verification & rollout
 
-- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green.
-- [ ] 3.2 Live-smoke the getmatch adapter against the real API; confirm a sample of offers now carry structured seniority/skills/category/experience.
-- [ ] 3.3 Document the rollout note (next getmatch crawl re-ingests; run `make reindex` to surface facets) in the change/PR description.
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 3.2 Live-smoke the getmatch adapter against the real API; confirm a sample of offers now carry structured seniority/skills/category/experience.
+- [x] 3.3 Document the rollout note (next getmatch crawl re-ingests; run `make reindex` to surface facets) in the change/PR description.


### PR DESCRIPTION
## Summary

getmatch.ru exposes a posting's grade, specialization, skills, and required experience as **structured** fields in its detail API, but the adapter ignored them — freehire derived `seniority`/`category`/`skills`/`experience_years_min` only from the title/description dictionaries, which stay silent on getmatch's marketing/Russian titles. Result: ~60% of getmatch jobs carried no seniority facet, so filtering `remote + senior/lead/c_level` showed **73** jobs vs the **~204** getmatch.ru returns for the same filter.

This adds a general "structured source facet" seam (mirroring the existing `WorkMode` field) and wires the getmatch adapter into it.

- `sources.Job` gains optional `Seniority`/`Category`/`Skills`/`ExperienceYearsMin` — structured signal only, never a heuristic.
- `jobderive.Derive` gives a structured source signal precedence over the dictionary (scalars: source → dict → description; **Skills** = union(source, dictionary)).
- getmatch reads its per-offer detail (already fetched for the HTML body) once and maps: grade → `enrich.SeniorityValues` (membership check, unknown dropped); `specializations` → `enrich.CategoryValues` via an explicit **grounded** subset map (sampled from the live API; conflict/unmappable → empty); `skills_objects` → canonicalized via `skilltag.Parse` (noise dropped); `required_years_of_experience` → `ExperienceYearsMin`.
- No schema change (columns already exist). `backfill-derive` docstring updated: it does **not** preserve structured-source facets (re-derives from description, restored on getmatch's next full crawl).

Live-smoke against the real API: 15/15 grades mapped, conflict/unmappable specializations correctly dropped.

## Test Plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (unit, no external deps)
- [x] New `jobderive` tests: source-beats-dict per facet, dict-fills-when-silent, skills union
- [x] New getmatch tests: grade→seniority, skills canonicalized + noise dropped, specialization mapped/unmappable/conflict, experience set/absent, structured facets empty on detail error
- [x] Live-smoke against getmatch.ru (removed before commit — network-dependent)
- [ ] Post-merge: getmatch's next full crawl re-ingests with structured facets; run `make reindex` to surface them to search

OpenSpec change: `openspec/changes/getmatch-structured-facets/`