### PR TITLE
feat(my-jobs): add application pipeline tab

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -63,6 +63,11 @@ type Querier interface {
 	// search pagination reports the filtered total.
 	CountCompanies(ctx context.Context, search string) (int64, error)
 	CountJobs(ctx context.Context) (int64, error)
+	// Per-stage application counts for the Pipeline snapshot. An application is any
+	// row the user applied to or staged (saved-only rows are excluded); a row with
+	// applied_at set but no stage groups under a NULL stage. The Go layer folds these
+	// rows into the pipeline buckets.
+	CountMyJobsByStage(ctx context.Context, userID int64) ([]CountMyJobsByStageRow, error)
 	// How many saved searches a user has — the per-user cap is enforced against this in
 	// the service before a create.
 	CountSavedSearches(ctx context.Context, userID int64) (int64, error)

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -107,3 +107,14 @@ SELECT count(*)                                        AS "all",
                             OR stage      IS NOT NULL) AS board
 FROM user_jobs
 WHERE user_id = $1;
+
+-- name: CountMyJobsByStage :many
+-- Per-stage application counts for the Pipeline snapshot. An application is any
+-- row the user applied to or staged (saved-only rows are excluded); a row with
+-- applied_at set but no stage groups under a NULL stage. The Go layer folds these
+-- rows into the pipeline buckets.
+SELECT stage, count(*) AS count
+FROM user_jobs
+WHERE user_id = $1
+  AND (applied_at IS NOT NULL OR stage IS NOT NULL)
+GROUP BY stage;

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -39,6 +39,43 @@ func (q *Queries) ClearJobProgress(ctx context.Context, arg ClearJobProgressPara
 	return i, err
 }
 
+const countMyJobsByStage = `-- name: CountMyJobsByStage :many
+SELECT stage, count(*) AS count
+FROM user_jobs
+WHERE user_id = $1
+  AND (applied_at IS NOT NULL OR stage IS NOT NULL)
+GROUP BY stage
+`
+
+type CountMyJobsByStageRow struct {
+	Stage pgtype.Text `json:"stage"`
+	Count int64       `json:"count"`
+}
+
+// Per-stage application counts for the Pipeline snapshot. An application is any
+// row the user applied to or staged (saved-only rows are excluded); a row with
+// applied_at set but no stage groups under a NULL stage. The Go layer folds these
+// rows into the pipeline buckets.
+func (q *Queries) CountMyJobsByStage(ctx context.Context, userID int64) ([]CountMyJobsByStageRow, error) {
+	rows, err := q.db.Query(ctx, countMyJobsByStage, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CountMyJobsByStageRow{}
+	for rows.Next() {
+		var i CountMyJobsByStageRow
+		if err := rows.Scan(&i.Stage, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const countUserJobs = `-- name: CountUserJobs :one
 SELECT count(*)                                        AS "all",
        count(*) FILTER (WHERE saved_at IS NULL

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -230,6 +230,7 @@ func Register(app *fiber.App, cfg Config) {
 	// list without making that list authenticated.
 	api.Get("/me/jobs", keyAuth, a.ListMyJobs)
 	api.Get("/me/jobs/viewed", keyAuth, a.ListViewedSlugs)
+	api.Get("/me/jobs/pipeline", keyAuth, a.MyPipeline)
 
 	// API-key management is cookie-only (RequireAuth): a leaked key must not be
 	// able to create, list, or revoke keys. The create endpoint returns the

--- a/internal/handler/me_jobs.go
+++ b/internal/handler/me_jobs.go
@@ -69,6 +69,24 @@ func (a *API) ListMyJobs(c *fiber.Ctx) error {
 	})
 }
 
+// MyPipeline returns the authenticated caller's application-pipeline snapshot:
+// the total application count and its distribution across the seven status
+// buckets, aggregated server-side over all of the caller's applications. The SPA
+// Pipeline tab renders the Sankey and the interview/offer rate cards from this.
+func (a *API) MyPipeline(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+
+	pipeline, err := a.tracking.Pipeline(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{"data": pipeline})
+}
+
 // ListViewedSlugs returns the set of public job slugs the authenticated caller
 // has interacted with (every user_jobs row counts as viewed). The SPA reads this
 // to dim already-seen cards in the browse list and search results without

--- a/internal/handler/me_pipeline_integration_test.go
+++ b/internal/handler/me_pipeline_integration_test.go
@@ -1,0 +1,154 @@
+//go:build integration
+
+// Integration test for the Pipeline aggregate endpoint: GET /api/v1/me/jobs/pipeline
+// must aggregate the caller's applications into the seven buckets server-side,
+// counting an applied-with-no-stage row as no_answer, excluding saved-only and
+// viewed-only rows, and requiring authentication. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobtracking"
+)
+
+func TestMyPipelineEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('pipeline@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	seedJob := func(t *testing.T, ext string) int64 {
+		t.Helper()
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug)
+			 VALUES ('test', $1, 'http://example.test', 'Job ' || $1, 'pipe-' || $1)
+			 RETURNING id`, ext).Scan(&id); err != nil {
+			t.Fatalf("seed job %q: %v", ext, err)
+		}
+		return id
+	}
+	stage := func(t *testing.T, jobID int64, s string) {
+		t.Helper()
+		if _, err := queries.TrackJob(ctx, db.TrackJobParams{
+			UserID: userID, JobID: jobID, Stage: pgtype.Text{String: s, Valid: true},
+		}); err != nil {
+			t.Fatalf("track stage %q: %v", s, err)
+		}
+	}
+
+	// One application per non-empty bucket, plus a second applied-no-stage row so
+	// no_answer is distinguishable, plus a saved-only and a viewed-only row that
+	// must NOT count as applications.
+	stage(t, seedJob(t, "screening"), "screening")
+	stage(t, seedJob(t, "responded"), "responded") // also in_progress
+	stage(t, seedJob(t, "interview"), "interview")
+	stage(t, seedJob(t, "offer"), "offer")
+	stage(t, seedJob(t, "accepted"), "accepted")
+	stage(t, seedJob(t, "rejected"), "rejected")
+	stage(t, seedJob(t, "withdrawn"), "withdrawn")
+
+	// applied with no explicit stage → no_answer (two of them)
+	if _, err := queries.MarkJobApplied(ctx, db.MarkJobAppliedParams{UserID: userID, JobID: seedJob(t, "applied1")}); err != nil {
+		t.Fatalf("apply1: %v", err)
+	}
+	if _, err := queries.MarkJobApplied(ctx, db.MarkJobAppliedParams{UserID: userID, JobID: seedJob(t, "applied2")}); err != nil {
+		t.Fatalf("apply2: %v", err)
+	}
+	// saved-only and viewed-only — excluded from applications
+	if _, err := queries.SaveJob(ctx, db.SaveJobParams{UserID: userID, JobID: seedJob(t, "saved")}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := queries.RecordJobView(ctx, db.RecordJobViewParams{UserID: userID, JobID: seedJob(t, "viewed")}); err != nil {
+		t.Fatalf("view: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(userID)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &API{pool: pool, queries: queries, issuer: iss, tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries))}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/jobs/pipeline", auth.RequireAuth(iss), h.MyPipeline)
+
+	t.Run("aggregates applications into buckets", func(t *testing.T) {
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/jobs/pipeline", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET pipeline: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+
+		var body struct {
+			Data struct {
+				Applications int64 `json:"applications"`
+				Buckets      struct {
+					NoAnswer     int64 `json:"no_answer"`
+					InProgress   int64 `json:"in_progress"`
+					Interviewing int64 `json:"interviewing"`
+					Offer        int64 `json:"offer"`
+					Accepted     int64 `json:"accepted"`
+					Rejected     int64 `json:"rejected"`
+					Declined     int64 `json:"declined"`
+				} `json:"buckets"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		b := body.Data.Buckets
+		if body.Data.Applications != 9 {
+			t.Errorf("applications = %d, want 9", body.Data.Applications)
+		}
+		if b.NoAnswer != 2 {
+			t.Errorf("no_answer = %d, want 2", b.NoAnswer)
+		}
+		if b.InProgress != 2 {
+			t.Errorf("in_progress = %d, want 2 (screening+responded)", b.InProgress)
+		}
+		if b.Interviewing != 1 || b.Offer != 1 || b.Accepted != 1 || b.Rejected != 1 || b.Declined != 1 {
+			t.Errorf("buckets = %+v, want each of interviewing/offer/accepted/rejected/declined = 1", b)
+		}
+		sum := b.NoAnswer + b.InProgress + b.Interviewing + b.Offer + b.Accepted + b.Rejected + b.Declined
+		if sum != body.Data.Applications {
+			t.Errorf("buckets sum = %d, want applications = %d", sum, body.Data.Applications)
+		}
+	})
+
+	t.Run("unauthenticated is 401", func(t *testing.T) {
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/jobs/pipeline", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET pipeline: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+}

--- a/internal/handler/track_test.go
+++ b/internal/handler/track_test.go
@@ -50,6 +50,9 @@ func (stubTrackingRepo) CountInteractions(context.Context, int64) (jobtracking.C
 	return jobtracking.Counts{}, nil
 }
 func (stubTrackingRepo) ViewedSlugs(context.Context, int64) ([]string, error) { return nil, nil }
+func (stubTrackingRepo) PipelineCounts(context.Context, int64) ([]userjob.StageCount, error) {
+	return nil, nil
+}
 
 // trackApp mounts the track route on a handler whose tracking service is backed
 // by a stub repository (no DB). The auth gate and the service's body validation

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -142,6 +142,10 @@ type Repository interface {
 	// CountInteractions returns the per-filter counts for the caller in one pass.
 	CountInteractions(ctx context.Context, userID int64) (Counts, error)
 
+	// PipelineCounts returns the caller's per-stage application counts (saved-only
+	// rows excluded; an applied row with no stage carries an empty Stage).
+	PipelineCounts(ctx context.Context, userID int64) ([]userjob.StageCount, error)
+
 	// ViewedSlugs returns every public job slug the caller has interacted with.
 	ViewedSlugs(ctx context.Context, userID int64) ([]string, error)
 }
@@ -179,6 +183,17 @@ func (s *Service) ListTracked(ctx context.Context, userID int64, filter string, 
 // ViewedSlugs returns every public job slug the caller has interacted with.
 func (s *Service) ViewedSlugs(ctx context.Context, userID int64) ([]string, error) {
 	return s.repo.ViewedSlugs(ctx, userID)
+}
+
+// Pipeline returns the caller's application-pipeline snapshot: the per-stage
+// counts folded into the buckets and application total. The stage→bucket mapping
+// lives in userjob.Aggregate.
+func (s *Service) Pipeline(ctx context.Context, userID int64) (userjob.Pipeline, error) {
+	counts, err := s.repo.PipelineCounts(ctx, userID)
+	if err != nil {
+		return userjob.Pipeline{}, err
+	}
+	return userjob.Aggregate(counts), nil
 }
 
 // RecordView resolves slug → jobID then delegates to the repository.

--- a/internal/jobtracking/jobtracking_test.go
+++ b/internal/jobtracking/jobtracking_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/strelov1/freehire/internal/jobtracking"
+	"github.com/strelov1/freehire/internal/userjob"
 )
 
 // fakeRepo is an in-memory fake satisfying Repository.
@@ -35,6 +36,8 @@ type fakeRepo struct {
 	countErr            error
 	viewedResult        []string
 	viewedErr           error
+	pipelineResult      []userjob.StageCount
+	pipelineErr         error
 
 	// recorded calls
 	slugCalls  int
@@ -95,6 +98,10 @@ func (f *fakeRepo) CountInteractions(_ context.Context, _ int64) (jobtracking.Co
 
 func (f *fakeRepo) ViewedSlugs(_ context.Context, _ int64) ([]string, error) {
 	return f.viewedResult, f.viewedErr
+}
+
+func (f *fakeRepo) PipelineCounts(_ context.Context, _ int64) ([]userjob.StageCount, error) {
+	return f.pipelineResult, f.pipelineErr
 }
 
 // helpers
@@ -502,5 +509,36 @@ func TestViewedSlugs_Passthrough(t *testing.T) {
 	}
 	if len(slugs) != 2 || slugs[0] != "job-a" {
 		t.Errorf("slugs = %v, want [job-a job-b]", slugs)
+	}
+}
+
+func TestPipelineAggregates(t *testing.T) {
+	repo := &fakeRepo{pipelineResult: []userjob.StageCount{
+		{Stage: "applied", Count: 5},
+		{Stage: "interview", Count: 3},
+		{Stage: "", Count: 2}, // applied with no explicit stage
+	}}
+	svc := jobtracking.New(repo)
+
+	got, err := svc.Pipeline(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Pipeline: %v", err)
+	}
+	if got.Applications != 10 {
+		t.Errorf("Applications = %d, want 10", got.Applications)
+	}
+	if got.Buckets.NoAnswer != 7 { // applied 5 + null-stage 2
+		t.Errorf("NoAnswer = %d, want 7", got.Buckets.NoAnswer)
+	}
+	if got.Buckets.Interviewing != 3 {
+		t.Errorf("Interviewing = %d, want 3", got.Buckets.Interviewing)
+	}
+}
+
+func TestPipelinePropagatesRepoError(t *testing.T) {
+	repo := &fakeRepo{pipelineErr: errors.New("boom")}
+	svc := jobtracking.New(repo)
+	if _, err := svc.Pipeline(context.Background(), 1); err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/userjob"
 )
 
 // Compile-time proof that QueriesRepository satisfies Repository.
@@ -167,6 +168,21 @@ func (r *QueriesRepository) CountInteractions(ctx context.Context, userID int64)
 // ViewedSlugs returns every public job slug the caller has interacted with.
 func (r *QueriesRepository) ViewedSlugs(ctx context.Context, userID int64) ([]string, error) {
 	return r.q.ListViewedJobSlugs(ctx, userID)
+}
+
+// PipelineCounts returns the caller's per-stage application counts. A NULL stage
+// (an applied row with no explicit stage) becomes an empty Stage, which
+// userjob.Aggregate folds into the no_answer bucket.
+func (r *QueriesRepository) PipelineCounts(ctx context.Context, userID int64) ([]userjob.StageCount, error) {
+	rows, err := r.q.CountMyJobsByStage(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	counts := make([]userjob.StageCount, 0, len(rows))
+	for _, row := range rows {
+		counts = append(counts, userjob.StageCount{Stage: row.Stage.String, Count: row.Count})
+	}
+	return counts, nil
 }
 
 // toInteraction converts a db.UserJob row to the domain Interaction type.

--- a/internal/userjob/buckets.go
+++ b/internal/userjob/buckets.go
@@ -1,0 +1,56 @@
+package userjob
+
+// StageCount is one (stage, count) group from the per-user application aggregate.
+// An empty Stage is an applied row carrying no explicit stage.
+type StageCount struct {
+	Stage string
+	Count int64
+}
+
+// BucketCounts is the snapshot distribution of a user's applications across the
+// seven pipeline buckets. Bucket names are derived from the stage vocabulary and
+// are the wire shape returned by the pipeline endpoint.
+type BucketCounts struct {
+	NoAnswer     int64 `json:"no_answer"`
+	InProgress   int64 `json:"in_progress"`
+	Interviewing int64 `json:"interviewing"`
+	Offer        int64 `json:"offer"`
+	Accepted     int64 `json:"accepted"`
+	Rejected     int64 `json:"rejected"`
+	Declined     int64 `json:"declined"`
+}
+
+// Pipeline is the application-pipeline snapshot: the total application count and
+// its distribution across buckets. Buckets always sum to Applications.
+type Pipeline struct {
+	Applications int64        `json:"applications"`
+	Buckets      BucketCounts `json:"buckets"`
+}
+
+// Aggregate folds per-stage counts into the pipeline snapshot. The stage→bucket
+// mapping is the single source of truth: screening/responded collapse into
+// in_progress, withdrawn is declined, and an empty or unrecognized stage falls to
+// no_answer so every counted application lands in exactly one bucket.
+func Aggregate(counts []StageCount) Pipeline {
+	var p Pipeline
+	for _, c := range counts {
+		p.Applications += c.Count
+		switch c.Stage {
+		case "screening", "responded":
+			p.Buckets.InProgress += c.Count
+		case "interview":
+			p.Buckets.Interviewing += c.Count
+		case "offer":
+			p.Buckets.Offer += c.Count
+		case "accepted":
+			p.Buckets.Accepted += c.Count
+		case "rejected":
+			p.Buckets.Rejected += c.Count
+		case "withdrawn":
+			p.Buckets.Declined += c.Count
+		default: // "applied", "", and any unknown stage
+			p.Buckets.NoAnswer += c.Count
+		}
+	}
+	return p
+}

--- a/internal/userjob/buckets_test.go
+++ b/internal/userjob/buckets_test.go
@@ -1,0 +1,77 @@
+package userjob
+
+import "testing"
+
+func sumBuckets(b BucketCounts) int64 {
+	return b.NoAnswer + b.InProgress + b.Interviewing + b.Offer + b.Accepted + b.Rejected + b.Declined
+}
+
+func TestAggregateMapsStagesToBuckets(t *testing.T) {
+	got := Aggregate([]StageCount{
+		{Stage: "applied", Count: 70},
+		{Stage: "screening", Count: 5},
+		{Stage: "responded", Count: 13},
+		{Stage: "interview", Count: 20},
+		{Stage: "offer", Count: 2},
+		{Stage: "accepted", Count: 1},
+		{Stage: "rejected", Count: 8},
+		{Stage: "withdrawn", Count: 1},
+	})
+
+	want := BucketCounts{
+		NoAnswer:     70,
+		InProgress:   18, // screening + responded
+		Interviewing: 20,
+		Offer:        2,
+		Accepted:     1,
+		Rejected:     8,
+		Declined:     1, // withdrawn
+	}
+	if got.Buckets != want {
+		t.Errorf("Buckets = %+v, want %+v", got.Buckets, want)
+	}
+	if got.Applications != 120 {
+		t.Errorf("Applications = %d, want 120", got.Applications)
+	}
+}
+
+func TestAggregateBucketsSumToApplications(t *testing.T) {
+	got := Aggregate([]StageCount{
+		{Stage: "applied", Count: 3},
+		{Stage: "interview", Count: 4},
+		{Stage: "rejected", Count: 5},
+	})
+	if sum := sumBuckets(got.Buckets); sum != got.Applications {
+		t.Errorf("buckets sum = %d, want Applications = %d", sum, got.Applications)
+	}
+}
+
+func TestAggregateNullStageIsNoAnswer(t *testing.T) {
+	// An applied row with no explicit stage arrives as an empty Stage.
+	got := Aggregate([]StageCount{{Stage: "", Count: 6}})
+	if got.Buckets.NoAnswer != 6 {
+		t.Errorf("NoAnswer = %d, want 6", got.Buckets.NoAnswer)
+	}
+	if got.Applications != 6 {
+		t.Errorf("Applications = %d, want 6", got.Applications)
+	}
+}
+
+func TestAggregateEmptyInput(t *testing.T) {
+	got := Aggregate(nil)
+	if got != (Pipeline{}) {
+		t.Errorf("Aggregate(nil) = %+v, want zero Pipeline", got)
+	}
+}
+
+func TestAggregateUnknownStageIsCountedAndDeterministic(t *testing.T) {
+	// An out-of-vocabulary stage must still be counted as an application and land
+	// in a bucket, so the buckets always sum to Applications.
+	got := Aggregate([]StageCount{{Stage: "bogus", Count: 4}})
+	if got.Applications != 4 {
+		t.Errorf("Applications = %d, want 4", got.Applications)
+	}
+	if sum := sumBuckets(got.Buckets); sum != 4 {
+		t.Errorf("buckets sum = %d, want 4", sum)
+	}
+}

--- a/openspec/changes/add-my-jobs-pipeline-tab/.openspec.yaml
+++ b/openspec/changes/add-my-jobs-pipeline-tab/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/add-my-jobs-pipeline-tab/design.md
+++ b/openspec/changes/add-my-jobs-pipeline-tab/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`/my/jobs` (SvelteKit SPA) already has Board and History tabs over the per-user interaction data in `user_jobs` (`internal/handler/me_jobs.go` → `GET /api/v1/me/jobs`). Each `user_jobs` row holds a single **current** `stage` from the controlled vocabulary `applied, screening, responded, interview, offer, accepted, rejected, withdrawn` (`internal/userjob/stages.go`), plus `viewed_at/saved_at/applied_at`. There is **no stage transition history and no per-stage timestamps** — we know where a job is now, not the path it took. The frontend has no charting dependency (hand-built SVG only).
+
+## Goals / Non-Goals
+
+**Goals:**
+- An at-a-glance Pipeline tab: current application distribution as a Sankey snapshot + Interview/Offer rate donuts.
+- Correct aggregates over **all** of the user's applications (not a paginated page).
+- Keep the stage→bucket mapping and rate definitions as a single source of truth in Go.
+- Zero new dependencies; reuse the existing `/me/jobs` auth and response conventions.
+
+**Non-Goals:**
+- Historical funnel / true conversion (would need transition tracking).
+- Import/Export/Template/Columns/Add-job from the reference mockup; Board redesign; date-range filters; codegen for the bucket vocabulary.
+
+## Decisions
+
+**1. Snapshot semantics (each application counted in exactly one current bucket).**
+We only persist the current `stage`, so a true historical funnel is impossible without new data. Alternative (add a transition log) was rejected as out of scope and far larger. Consequence: terminal stages (`rejected`/`withdrawn`) erase how far a job got, so rate cards are an **honest lower bound** ("reached interview/offer now"), not historical conversion. This is acceptable and documented in the UI sub-text.
+
+**2. Stage → 7 buckets (mapping lives in Go).**
+`applied`(no further stage)→`no_answer`; `screening,responded`→`in_progress`; `interview`→`interviewing`; `offer`→`offer`; `accepted`→`accepted`; `rejected`→`rejected`; `withdrawn`→`declined`. Applications denominator = rows where `applied_at IS NOT NULL OR stage IS NOT NULL` (saved-only excluded). Rates: Interview = (interviewing+offer+accepted)/applications; Offer = (offer+accepted)/applications. A pure Go function owns this mapping (unit-testable, no DB), mirroring how the project keeps controlled vocabularies in Go.
+
+**3. Dedicated aggregate endpoint `GET /api/v1/me/jobs/pipeline` (not extending `/me/jobs` meta).**
+The tab needs only aggregates, not the job list, and aggregation must run server-side over **all** applications — the board list is paginated, so client-side grouping over a page would be wrong. A dedicated endpoint keeps the contract small and avoids bloating the list response. A new sqlc query `CountMyJobsByStage` does `SELECT stage, count(*) ... GROUP BY stage` (NULL stage = applied-but-unstaged is its own group); the Go function folds rows into buckets. Response: `{"data": {"applications": N, "buckets": {…7 keys…}}}`. The frontend derives the two rates from bucket counts (trivial arithmetic; the bucket mapping — the real domain logic — stays in Go).
+
+**4. Frontend: container + two presentational SVG components.**
+`PipelineView.svelte` (fetch + loading/error/empty) composes `PipelineFunnel.svelte` (Sankey, props `applications`+`buckets`) and `RateDonut.svelte` (props `percent`+`label`). Bucket labels/colors/order are a static map in the frontend (7 stable buckets). Tab added to `MyJobsView.svelte` (order Board / Pipeline / History; default stays Board); auth gating is inherited from `MyJobsView`.
+
+## Risks / Trade-offs
+
+- **Lower-bound rates may confuse users** → UI sub-text states it's a current-status snapshot; a rejected-after-interview job shows only as rejected.
+- **Bucket vocabulary drift between Go and the frontend static map** → buckets are few and stable; documented as a known seam (codegen deferred, YAGNI). If a stage is added to `stages.go`, the mapping function and frontend map must be updated together — covered by the mapping unit test.
+- **Empty state** (no applications) → component renders a friendly "You haven't applied to any jobs yet" rather than a zero-width Sankey.
+
+## Migration Plan
+
+No schema change. Deploy backend + frontend together. Rollback is removing the tab and route — no data migration. After merge, regenerate sqlc is already committed (`make sqlc` output checked in).
+
+## Open Questions
+
+None — all design decisions were settled during brainstorming.

--- a/openspec/changes/add-my-jobs-pipeline-tab/proposal.md
+++ b/openspec/changes/add-my-jobs-pipeline-tab/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Users tracking many applications on `/my/jobs` can see individual jobs on the Board and History tabs, but have no at-a-glance view of where their applications stand overall or how they convert. A Pipeline view answers "where are my applications right now, and what share reached an interview or an offer?"
+
+## What Changes
+
+- Add a new **Pipeline** tab to the `/my/jobs` page, alongside the existing Board and History tabs (default tab stays Board).
+- The tab renders a **snapshot** of the signed-in user's current application distribution as a single-level Sankey-ribbon diagram (Applications → 7 status buckets), plus two donut cards: **Interview Rate** and **Offer Rate**.
+- Add a dedicated aggregate endpoint `GET /api/v1/me/jobs/pipeline` (auth `RequireAuthOrKey`) that returns per-bucket application counts computed server-side over **all** the user's applications.
+- Visualizations are hand-built SVG — **no new frontend dependencies**.
+- **Snapshot semantics, not historical flow:** because only each job's current `stage` is stored (no transition history), each application is counted in exactly one current bucket; rate cards are an honest lower bound.
+
+## Capabilities
+
+### New Capabilities
+- `application-pipeline`: the user's job-application pipeline snapshot — the server-side per-bucket aggregation of their tracked applications, the stage→bucket mapping and rate definitions, the `GET /me/jobs/pipeline` endpoint contract, and the Pipeline tab visualization (Sankey + rate donuts).
+
+### Modified Capabilities
+<!-- None: the aggregate endpoint and tab are self-contained in the new capability; user-job-tracking's existing endpoints and web-frontend's existing tabs are unchanged in behavior. -->
+
+## Impact
+
+- **Backend:** new sqlc query `CountMyJobsByStage` (`internal/db/queries/`, regenerate via `make sqlc`); a pure stage→bucket aggregation function (the mapping/rate source of truth, in Go); a new handler method near `internal/handler/me_jobs.go`; one new route under the existing `/me/jobs` group.
+- **Frontend (`web/`):** new `PipelineView.svelte` (container) composing `PipelineFunnel.svelte` (Sankey SVG) and `RateDonut.svelte`; `getMyPipeline()` in `web/src/lib/api.ts`; `PipelineStats` type in `web/src/lib/types.ts`; a new tab wired into `MyJobsView.svelte`.
+- **Data/schema:** none — read-only aggregate over the existing `user_jobs` table; no migration.
+- **Dependencies:** none added.

--- a/openspec/changes/add-my-jobs-pipeline-tab/specs/application-pipeline/spec.md
+++ b/openspec/changes/add-my-jobs-pipeline-tab/specs/application-pipeline/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Pipeline aggregate endpoint
+
+The system SHALL expose `GET /api/v1/me/jobs/pipeline`, authenticated with `RequireAuthOrKey` (session cookie or API key), returning the signed-in user's application counts aggregated server-side over **all** of their tracked applications. The response envelope SHALL be `{"data": {"applications": <int>, "buckets": {"no_answer","in_progress","interviewing","offer","accepted","rejected","declined"}}}` where every bucket key is always present (zero when empty).
+
+#### Scenario: Authenticated user with applications
+
+- **WHEN** an authenticated user requests `GET /api/v1/me/jobs/pipeline`
+- **THEN** the response is `200` with `data.applications` equal to the number of their tracked applications and `data.buckets` carrying the per-bucket counts that sum to `data.applications`
+
+#### Scenario: Unauthenticated request
+
+- **WHEN** a request without a valid session or API key hits `GET /api/v1/me/jobs/pipeline`
+- **THEN** the response is `401`
+
+#### Scenario: User with no applications
+
+- **WHEN** an authenticated user who has never applied to or staged any job requests the endpoint
+- **THEN** the response is `200` with `data.applications` equal to `0` and every bucket count `0`
+
+### Requirement: Application counting and stage-to-bucket mapping
+
+The system SHALL count as an application every `user_jobs` row where `applied_at IS NOT NULL OR stage IS NOT NULL`, and SHALL exclude saved-only rows (saved but never applied and with no stage). Each counted application SHALL fall into exactly one bucket determined by its current stage: `applied` (no further stage) → `no_answer`; `screening` and `responded` → `in_progress`; `interview` → `interviewing`; `offer` → `offer`; `accepted` → `accepted`; `rejected` → `rejected`; `withdrawn` → `declined`. An application row whose `applied_at` is set but whose `stage` is null SHALL map to `no_answer`. The mapping SHALL be owned by a single pure function in Go.
+
+#### Scenario: Each application is counted once
+
+- **WHEN** the buckets are computed for a set of applications
+- **THEN** the sum of all seven bucket counts equals `applications`
+
+#### Scenario: Saved-only jobs are excluded
+
+- **WHEN** a user has a job that is saved but never applied to and carries no stage
+- **THEN** that job is not counted in `applications` and contributes to no bucket
+
+#### Scenario: Applied without an explicit stage maps to no_answer
+
+- **WHEN** an application has `applied_at` set and `stage` null
+- **THEN** it is counted in the `no_answer` bucket
+
+### Requirement: Interview and offer rates are an honest snapshot
+
+The Pipeline SHALL present an **Interview Rate** equal to `(interviewing + offer + accepted) / applications` and an **Offer Rate** equal to `(offer + accepted) / applications`, both as a current-status snapshot. Because only each job's current stage is stored, these rates SHALL be treated as a lower bound (an application rejected after interviewing appears only as `rejected`), and the UI SHALL communicate that the view is a current-status snapshot rather than historical conversion.
+
+#### Scenario: Rates derived from buckets
+
+- **WHEN** a user has 100 applications with 20 interviewing, 2 offer, and 1 accepted
+- **THEN** the Interview Rate is `23%` and the Offer Rate is `3%`
+
+#### Scenario: Zero applications yields zero rates without division error
+
+- **WHEN** a user has zero applications
+- **THEN** both rates render as `0%` and no division-by-zero occurs
+
+### Requirement: Pipeline tab on the My Jobs page
+
+The `/my/jobs` page SHALL offer a **Pipeline** tab alongside the existing Board and History tabs, with Board remaining the default tab. The Pipeline tab SHALL render the application distribution as a single-level Sankey diagram (Applications fanning into the seven status buckets, ribbon widths proportional to counts) together with Interview Rate and Offer Rate donut cards, using hand-built SVG with no new frontend dependency. The tab SHALL be available only to signed-in users, inheriting the page's existing authentication gating.
+
+#### Scenario: Signed-in user opens the Pipeline tab
+
+- **WHEN** a signed-in user selects the Pipeline tab
+- **THEN** the Sankey diagram and the two rate donuts render from the aggregate endpoint's data
+
+#### Scenario: Empty state
+
+- **WHEN** a signed-in user with no applications opens the Pipeline tab
+- **THEN** a friendly empty message is shown instead of a zero-width diagram
+
+#### Scenario: Default tab unchanged
+
+- **WHEN** a signed-in user opens `/my/jobs` without selecting a tab
+- **THEN** the Board tab is shown, not the Pipeline tab

--- a/openspec/changes/add-my-jobs-pipeline-tab/tasks.md
+++ b/openspec/changes/add-my-jobs-pipeline-tab/tasks.md
@@ -1,0 +1,32 @@
+## 1. Backend — bucket aggregation (pure domain)
+
+- [x] 1.1 Define the pipeline bucket vocabulary + a pure `Buckets`/`Aggregate` function (in `internal/userjob`, or a new `internal/pipeline` package) that folds `(stage, count)` rows — including a null-stage row — into the seven buckets and an `applications` total, per the stage→bucket mapping in design.md. Source of truth for the mapping lives here.
+- [x] 1.2 Unit-test the function (RED first): each application counted once (buckets sum to applications), `screening`/`responded` → `in_progress`, null-stage → `no_answer`, terminal stages map correctly, empty input → all zeros, unknown/out-of-vocab stage handled deterministically.
+
+## 2. Backend — query + handler
+
+- [x] 2.1 Add sqlc query `CountMyJobsByStage` in `internal/db/queries/` (`SELECT stage, count(*) FROM user_jobs WHERE user_id=$1 AND (applied_at IS NOT NULL OR stage IS NOT NULL) GROUP BY stage`); run `make sqlc` and commit generated output.
+- [x] 2.2 Add a handler method near `internal/handler/me_jobs.go` that runs the query for the current user (`c.Locals`), feeds rows into the bucket function, and returns `{"data": {"applications": N, "buckets": {…}}}`; return errors for the central `ErrorHandler`.
+- [x] 2.3 Wire `GET /me/jobs/pipeline` into the `/me/jobs` route group under `RequireAuthOrKey`.
+- [x] 2.4 Integration test (`//go:build integration`, testcontainers): seed `user_jobs` rows (various stages, applied-no-stage, saved-only) and assert the endpoint returns the correct `applications` total and bucket counts, and `401` when unauthenticated.
+
+## 3. Frontend — data layer
+
+- [x] 3.1 Add `PipelineStats` type to `web/src/lib/types.ts` (applications + the seven bucket counts).
+- [x] 3.2 Add `getMyPipeline()` to `web/src/lib/api.ts` calling `GET /api/v1/me/jobs/pipeline`.
+
+## 4. Frontend — presentational components
+
+- [x] 4.1 `RateDonut.svelte` — props `percent`, `label`, `sublabel`; hand-built SVG donut; zero-safe.
+- [x] 4.2 `PipelineFunnel.svelte` — props `applications`, `buckets`; single-level Sankey SVG with proportional ribbons; static bucket label/color/order map; handles the all-zero case gracefully.
+
+## 5. Frontend — container + tab
+
+- [x] 5.1 `PipelineView.svelte` — fetch via `getMyPipeline()`; loading, error, and empty ("no applications yet") states; compute Interview/Offer rates from buckets; compose `PipelineFunnel` + two `RateDonut`s; include the snapshot sub-text.
+- [x] 5.2 Add the **Pipeline** tab to `MyJobsView.svelte` (order Board / Pipeline / History; default stays Board); inherits the existing auth gating.
+
+## 6. Verification
+
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...` green; integration test green with `-tags=integration`.
+- [x] 6.2 Frontend checks: `npm run check` (svelte-check) clean for the new files; run the app and confirm the Pipeline tab renders the Sankey + rate donuts against real `/me/jobs/pipeline` data, including the empty state.
+- [x] 6.3 Update any generated contracts if touched; confirm no new npm dependency was added.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   ListMeta,
   MyJob,
   MyJobCounts,
+  PipelineStats,
   User,
   UserJob,
   ApiKey,
@@ -294,6 +295,13 @@ export function createApi(
     return { ...toSlice(res, offset), counts: res.meta.counts };
   }
 
+  /** The current user's application-pipeline snapshot: per-bucket application
+   *  counts aggregated server-side, for the Pipeline tab's Sankey and rate cards. */
+  async function getMyPipeline(): Promise<PipelineStats> {
+    const res = await request<{ data: PipelineStats }>('/api/v1/me/jobs/pipeline');
+    return res.data;
+  }
+
   /** The public slugs of every job the current user has interacted with. The
    *  browse UI cross-references this set to dim already-viewed cards without
    *  authenticating the public job list. */
@@ -512,6 +520,7 @@ export function createApi(
     untrackJob,
     trackJob,
     listMyJobs,
+    getMyPipeline,
     listViewedSlugs,
     listApiKeys,
     createApiKey,
@@ -570,6 +579,7 @@ export const {
   untrackJob,
   trackJob,
   listMyJobs,
+  getMyPipeline,
   listViewedSlugs,
   listApiKeys,
   createApiKey,

--- a/web/src/lib/components/MyJobsView.svelte
+++ b/web/src/lib/components/MyJobsView.svelte
@@ -3,10 +3,12 @@
   import { cn } from '$lib/utils';
   import JobBoard from './JobBoard.svelte';
   import JobHistory from './JobHistory.svelte';
+  import PipelineView from './PipelineView.svelte';
 
-  type View = 'board' | 'history';
+  type View = 'board' | 'pipeline' | 'history';
   const tabs: { value: View; label: string }[] = [
     { value: 'board', label: 'Board' },
+    { value: 'pipeline', label: 'Pipeline' },
     { value: 'history', label: 'History' },
   ];
   let view = $state<View>('board');
@@ -41,6 +43,8 @@
 
     {#if view === 'board'}
       <JobBoard />
+    {:else if view === 'pipeline'}
+      <PipelineView />
     {:else}
       <JobHistory />
     {/if}

--- a/web/src/lib/components/PipelineFunnel.svelte
+++ b/web/src/lib/components/PipelineFunnel.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import { PIPELINE_BUCKETS } from '$lib/pipeline';
+  import type { PipelineBuckets } from '$lib/types';
+
+  // A single-level Sankey snapshot: one Applications source fanning into the
+  // status buckets, ribbon and node heights proportional to each count. Hand-built
+  // SVG — no charting dependency. The parent guarantees applications > 0 (the
+  // empty state is handled there); we guard anyway.
+  let { applications, buckets }: { applications: number; buckets: PipelineBuckets } = $props();
+
+  // SVG geometry, in viewBox units (the element scales to its container width).
+  // The left source bar fills HH; the right nodes share the same heights but are
+  // spread with a gap between them, so the ribbons fan out instead of running flat.
+  const W = 460;
+  const PAD = 10;
+  const GAP = 8;
+  const HH = 224;
+  const LX = 6;
+  const LW = 16;
+  const RX = 250;
+  const RW = 14;
+  const MID = (LX + LW + RX) / 2;
+
+  interface Ribbon {
+    key: string;
+    label: string;
+    color: string;
+    count: number;
+    path: string;
+    nodeY: number;
+    nodeH: number;
+    labelY: number;
+  }
+
+  const model = $derived.by(() => {
+    const visible = PIPELINE_BUCKETS.map((b) => ({ ...b, count: buckets[b.key] })).filter(
+      (b) => b.count > 0,
+    );
+    if (applications <= 0 || visible.length === 0) {
+      return { height: HH + PAD * 2, barY: PAD, ribbons: [] as Ribbon[] };
+    }
+
+    const totalGap = GAP * (visible.length - 1);
+    const height = HH + totalGap + PAD * 2;
+    const barY = PAD + totalGap / 2; // source bar centered against the spread nodes
+
+    let left = barY;
+    let right = PAD;
+    const ribbons = visible.map((b): Ribbon => {
+      const h = (b.count / applications) * HH;
+      const ly0 = left;
+      const ly1 = left + h;
+      const ry0 = right;
+      const ry1 = right + h;
+      left = ly1;
+      right = ry1 + GAP;
+      return {
+        key: b.key,
+        label: b.label,
+        color: b.color,
+        count: b.count,
+        path: `M ${LX + LW} ${ly0} C ${MID} ${ly0}, ${MID} ${ry0}, ${RX} ${ry0} L ${RX} ${ry1} C ${MID} ${ry1}, ${MID} ${ly1}, ${LX + LW} ${ly1} Z`,
+        nodeY: ry0,
+        nodeH: h,
+        labelY: ry0 + h / 2,
+      };
+    });
+    return { height, barY, ribbons };
+  });
+</script>
+
+<svg viewBox="0 0 {W} {model.height}" class="w-full" role="img" aria-label="Application pipeline by status">
+  <!-- Source bar: all applications -->
+  <rect x={LX} y={model.barY} width={LW} height={HH} rx="3" class="fill-foreground" />
+
+  {#each model.ribbons as r (r.key)}
+    <path d={r.path} fill={r.color} fill-opacity="0.5" />
+    <rect x={RX} y={r.nodeY} width={RW} height={Math.max(r.nodeH, 1)} rx="2" fill={r.color} />
+    <text x={RX + RW + 8} y={r.labelY} dy="0.32em" class="fill-foreground text-[0.72rem]">
+      {r.label}<tspan class="fill-muted-foreground"> {r.count}</tspan>
+    </text>
+  {/each}
+</svg>

--- a/web/src/lib/components/PipelineView.svelte
+++ b/web/src/lib/components/PipelineView.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { getMyPipeline } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { interviewRate, offerRate } from '$lib/pipeline';
+  import type { PipelineStats } from '$lib/types';
+  import PipelineFunnel from './PipelineFunnel.svelte';
+  import RateDonut from './RateDonut.svelte';
+  import States from './States.svelte';
+
+  // Single aggregate fetch (not paginated): the snapshot of where the caller's
+  // applications stand. Reassigned wholesale, never mutated → $state.raw.
+  let status = $state<'loading' | 'error' | 'ready'>('loading');
+  let stats = $state.raw<PipelineStats | null>(null);
+
+  async function load() {
+    status = 'loading';
+    try {
+      stats = await getMyPipeline();
+      status = 'ready';
+    } catch {
+      status = 'error';
+    }
+  }
+
+  $effect(() => {
+    if (isAuthenticated()) void load();
+  });
+
+  const iv = $derived(stats ? interviewRate(stats) : 0);
+  const offer = $derived(stats ? offerRate(stats) : 0);
+</script>
+
+{#if status === 'loading'}
+  <States state="loading" rows={3} />
+{:else if status === 'error'}
+  <States state="error" message="Couldn't load your pipeline." />
+{:else if !stats || stats.applications === 0}
+  <States state="empty" message="You haven't applied to any jobs yet. Applications you track will show up here." />
+{:else}
+  <div class="flex flex-col gap-3">
+    <div class="flex flex-col items-center gap-6 rounded-lg border bg-card p-5 md:flex-row md:items-center">
+      <div class="min-w-0 flex-1">
+        <p class="mb-2 text-sm text-muted-foreground">
+          {stats.applications} application{stats.applications === 1 ? '' : 's'}
+        </p>
+        <PipelineFunnel applications={stats.applications} buckets={stats.buckets} />
+      </div>
+      <div class="flex shrink-0 gap-4">
+        <RateDonut percent={iv} label="Interview Rate" sublabel="reached interview" />
+        <RateDonut percent={offer} label="Offer Rate" sublabel="reached offer" />
+      </div>
+    </div>
+    <p class="text-xs text-muted-foreground">
+      A snapshot of where your applications stand now. Rates are a lower bound — a job rejected after
+      an interview counts only as rejected.
+    </p>
+  </div>
+{/if}

--- a/web/src/lib/components/RateDonut.svelte
+++ b/web/src/lib/components/RateDonut.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  // A single conversion-rate donut. Presentational: the parent passes an already
+  // computed fraction (0–1). Hand-built SVG, no charting dependency.
+  let {
+    percent,
+    label,
+    sublabel,
+  }: { percent: number; label: string; sublabel?: string } = $props();
+
+  const R = 42;
+  const CIRC = 2 * Math.PI * R;
+
+  // Clamp so a malformed fraction can't draw a negative or overflowing arc.
+  const fraction = $derived(Math.max(0, Math.min(1, percent)));
+  const dash = $derived(`${CIRC * fraction} ${CIRC}`);
+  const display = $derived(
+    fraction === 0 ? '0%' : `${(fraction * 100).toFixed(fraction < 0.1 ? 1 : 0)}%`,
+  );
+</script>
+
+<div class="flex flex-col items-center gap-1">
+  <svg viewBox="0 0 100 100" class="h-28 w-28" role="img" aria-label="{label}: {display}">
+    <circle cx="50" cy="50" r={R} fill="none" stroke-width="9" class="stroke-muted" />
+    <circle
+      cx="50"
+      cy="50"
+      r={R}
+      fill="none"
+      stroke="currentColor"
+      stroke-width="9"
+      stroke-linecap="round"
+      stroke-dasharray={dash}
+      transform="rotate(-90 50 50)"
+      class="text-foreground transition-[stroke-dasharray] duration-500"
+    />
+    <text x="50" y="50" dy="0.34em" text-anchor="middle" class="fill-foreground text-[1.45rem] font-semibold">
+      {display}
+    </text>
+  </svg>
+  <div class="text-center">
+    <p class="text-sm font-medium">{label}</p>
+    {#if sublabel}
+      <p class="text-xs text-muted-foreground">{sublabel}</p>
+    {/if}
+  </div>
+</div>

--- a/web/src/lib/pipeline.ts
+++ b/web/src/lib/pipeline.ts
@@ -1,0 +1,40 @@
+// Presentation layer for the application pipeline. The server owns the
+// stage→bucket mapping and returns the bucket counts; this module is purely how
+// the Pipeline tab renders them — the bucket order, labels, colors, and the two
+// derived rates. The seven buckets are stable, so the vocabulary is a static map
+// here rather than generated (a documented seam: if a bucket is ever added, this
+// list and the Go mapping must change together).
+
+import type { PipelineBuckets, PipelineStats } from './types';
+
+export interface BucketConfig {
+  key: keyof PipelineBuckets;
+  label: string;
+  /** Sankey ribbon/node fill. Status-conventional: greens positive, rose negative. */
+  color: string;
+}
+
+/** Buckets in funnel order, from earliest/most-applications to terminal. */
+export const PIPELINE_BUCKETS: BucketConfig[] = [
+  { key: 'no_answer', label: 'No answer', color: '#cbd5e1' },
+  { key: 'in_progress', label: 'In progress', color: '#fcd34d' },
+  { key: 'interviewing', label: 'Interviewing', color: '#93c5fd' },
+  { key: 'offer', label: 'Offer', color: '#86efac' },
+  { key: 'accepted', label: 'Accepted', color: '#22c55e' },
+  { key: 'rejected', label: 'Rejected', color: '#fb7185' },
+  { key: 'declined', label: 'Declined', color: '#c4b5fd' },
+];
+
+/** Share of applications that reached an interview or beyond. A current-status
+ *  snapshot, so it is a lower bound (a job rejected after interviewing counts
+ *  only as rejected). Zero applications yields 0 without dividing by zero. */
+export function interviewRate(s: PipelineStats): number {
+  if (s.applications === 0) return 0;
+  return (s.buckets.interviewing + s.buckets.offer + s.buckets.accepted) / s.applications;
+}
+
+/** Share of applications that reached an offer or beyond. Same snapshot caveat. */
+export function offerRate(s: PipelineStats): number {
+  if (s.applications === 0) return 0;
+  return (s.buckets.offer + s.buckets.accepted) / s.applications;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -144,6 +144,25 @@ export interface MyJobCounts {
   applied: number;
 }
 
+/** A snapshot of the caller's applications across the seven pipeline buckets.
+ *  Buckets always sum to the application total. */
+export interface PipelineBuckets {
+  no_answer: number;
+  in_progress: number;
+  interviewing: number;
+  offer: number;
+  accepted: number;
+  rejected: number;
+  declined: number;
+}
+
+/** The application-pipeline snapshot for the Pipeline tab: the caller's total
+ *  application count and its distribution across the status buckets. */
+export interface PipelineStats {
+  applications: number;
+  buckets: PipelineBuckets;
+}
+
 /** An API key as returned by the management endpoints — metadata only; the
  *  plaintext token is never part of this shape. `token_prefix` is a short,
  *  non-secret leading slice (e.g. "fhk_Ab12cd") shown so the user can tell keys


### PR DESCRIPTION
## Summary
- Adds a **Pipeline** tab to `/my/jobs` (alongside Board / History; default stays Board) showing a snapshot of where the user's applications stand: a single-level **Sankey** (Applications → seven status buckets) plus **Interview Rate** and **Offer Rate** donut cards. Hand-built SVG, **no new frontend dependency**.
- New aggregate endpoint **`GET /api/v1/me/jobs/pipeline`** (`RequireAuthOrKey`) backed by a `CountMyJobsByStage` sqlc query and a pure `stage→bucket` aggregation in `internal/userjob` (the mapping's source of truth).

## Design notes
- **Snapshot semantics, not historical flow.** Only each job's *current* `stage` is stored (no transition history), so each application is counted in exactly one bucket and the rate cards are an honest **lower bound** (a job rejected after an interview shows only as rejected). The UI states this.
- Applications = rows where `applied_at IS NOT NULL OR stage IS NOT NULL` (saved-only excluded); applied-without-stage → `no_answer`; buckets always sum to applications.
- Stage→bucket: `applied`/null→no_answer; `screening,responded`→in_progress; `interview`→interviewing; `offer`→offer; `accepted`→accepted; `rejected`→rejected; `withdrawn`→declined.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` green
- [x] Integration test over real Postgres (`-tags=integration`): all buckets, saved/viewed exclusions, applied-no-stage→no_answer, buckets sum = applications, 401 when unauthenticated
- [x] Unit tests: bucket mapping (incl. null/unknown stage, empty input) and `Service.Pipeline`
- [x] `npm run check` (svelte-check) clean; `npm run build` succeeds; ESLint clean on new files
- [x] Rendered in browser — Sankey fans out correctly; donuts show 19% / 2.5% for the sample data
- [x] No new npm dependency

## Follow-up
- The OpenSpec change `add-my-jobs-pipeline-tab` rides along active in this PR; it will be archived (move to `archive/` + sync main specs) in a separate housekeeping PR after merge, mirroring the getmatch flow (#285 → #286).