### PR TITLE
fix(my-jobs): board bounded scroll container fixes drag-drop at column bottom

### DIFF
--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -178,7 +178,11 @@
 {:else if status === 'error'}
   <States state="error" message="Couldn't load your board." />
 {:else}
-  <div class="flex gap-3 overflow-x-auto pb-2">
+  <!-- Bounded-height scroll container (not just overflow-x): so a long column
+       scrolls inside the board and svelte-dnd-action auto-scrolls it while
+       dragging, letting a card drop anywhere in the column — not only near the
+       top. The max-height leaves room for the header + tabs above. -->
+  <div class="flex max-h-[calc(100dvh-12rem)] gap-3 overflow-auto pb-2">
     {#each BOARD_COLUMNS as col (col.id)}
       <BoardColumn
         id={col.id}


### PR DESCRIPTION
Drag-and-drop only registered near the top of a long column. Cause: the board used `overflow-x-auto`, which per the CSS spec forces `overflow-y: auto` too — a vertical scroll container with no actual scroll (height = content). svelte-dnd-action then tried to auto-scroll that immovable container instead of letting you reach the bottom of a long column.

Fix: give the board a viewport-bounded `max-h-[calc(100dvh-12rem)]` with `overflow-auto`, so a long column scrolls inside the board and the library auto-scrolls it during a drag. A card can now be dropped anywhere in a column.

CSS-only; svelte-check + eslint clean. Drag behavior needs interactive verification (the `max-height` offset is tunable).