### PR TITLE
fix(my-jobs): per-column scroll fixes drag-drop in long columns

### DIFF
--- a/web/src/lib/components/BoardColumn.svelte
+++ b/web/src/lib/components/BoardColumn.svelte
@@ -32,8 +32,14 @@
     <span>{label}</span>
     <span class="text-xs tabular-nums text-muted-foreground">{items.length}</span>
   </header>
+  <!-- Each column's card list is its own bounded scroll container. svelte-dnd-action
+       auto-scrolls a scrollable *container* correctly during a drag, but mis-places
+       the drop once the *window* auto-scrolls (a card dropped low in a long column
+       would snap back near the top). Capping the height and scrolling here keeps the
+       drag inside a container the library handles, so a card lands where it's
+       dropped — and the column header/count stay put. -->
   <div
-    class="flex min-h-24 flex-col gap-2"
+    class="flex max-h-[calc(100dvh-14rem)] min-h-24 flex-col gap-2 overflow-y-auto"
     use:dndzone={{ items, flipDurationMs: 150, type: 'board', dropTargetStyle }}
     onconsider={(e) => onconsider(id, e.detail.items as BoardItem[])}
     onfinalize={(e) => onfinalize(id, e.detail.items as BoardItem[])}

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -178,11 +178,7 @@
 {:else if status === 'error'}
   <States state="error" message="Couldn't load your board." />
 {:else}
-  <!-- Bounded-height scroll container (not just overflow-x): so a long column
-       scrolls inside the board and svelte-dnd-action auto-scrolls it while
-       dragging, letting a card drop anywhere in the column — not only near the
-       top. The max-height leaves room for the header + tabs above. -->
-  <div class="flex max-h-[calc(100dvh-12rem)] gap-3 overflow-auto pb-2">
+  <div class="flex gap-3 overflow-x-auto pb-2">
     {#each BOARD_COLUMNS as col (col.id)}
       <BoardColumn
         id={col.id}


### PR DESCRIPTION
## Root cause (reproduced)
Built a pointer-driven reproduction (playwright + system Chrome, throwaway route): on a tall column the **window** auto-scrolls during the drag (≈1600px), but svelte-dnd-action then mis-computes the drop index — the card snaps back near the **top**. That matches the report: "a card only drops near the top of a long column / the highlight is only at the top". The library auto-scrolls a bounded scroll **container** correctly, just not the window.

## Fix
Cap each column's card list and scroll it internally (`overflow-y-auto` + `max-h-[calc(100dvh-14rem)]`) so the drag stays inside a container svelte-dnd-action handles — a card lands where it's dropped, and the column header/count stay put. Reverts the earlier board-level `max-height` (PR #295) that didn't fix it and made headers scroll away.

## Earlier wrong turns (discarded)
- Board-level scroll container (#295) — didn't help.
- `.snapshot` to de-proxy items — a documented svelte-dnd-action+Svelte5 issue, but **not** this bug (reproduction still failed with it).

## Verification
svelte-check + eslint clean. Reproduction confirmed the window-autoscroll failure; per-column scroll resolved it in testing, though the synthetic drag is timing-sensitive — **please confirm live** by dragging a card to the bottom of a long column. The `14rem` height offset is tunable.