### PR TITLE
feat(filters): location-flexible remote facet + map International to global

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -114,7 +114,8 @@ func backfillAll(ctx context.Context, store facetStore) (scanned, updated int, e
 				d.PostingLanguage == j.PostingLanguage &&
 				d.EmploymentType == j.EmploymentType &&
 				d.EducationLevel == j.EducationLevel &&
-				experience == j.ExperienceYearsMin
+				experience == j.ExperienceYearsMin &&
+				d.RemoteUnspecified == j.RemoteUnspecified
 			if unchanged {
 				continue
 			}
@@ -131,6 +132,7 @@ func backfillAll(ctx context.Context, store facetStore) (scanned, updated int, e
 				EmploymentType:     d.EmploymentType,
 				EducationLevel:     d.EducationLevel,
 				ExperienceYearsMin: experience,
+				RemoteUnspecified:  d.RemoteUnspecified,
 			}); err != nil {
 				return scanned, updated, err
 			}

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -76,6 +76,7 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 		EmploymentType:     job.EmploymentType,
 		EducationLevel:     job.EducationLevel,
 		ExperienceYearsMin: toInt4(job.ExperienceYearsMin),
+		RemoteUnspecified:  job.RemoteUnspecified,
 	}
 	// Fingerprint the indexed fields so the upsert can report whether this write
 	// changed searchable content (drives incremental indexing below).

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -117,6 +117,7 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 			EmploymentType:     jobfacts.EmploymentType(j.Title, descHTML),
 			EducationLevel:     jobfacts.EducationLevel(descHTML),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(descHTML)),
+			RemoteUnspecified:  location.IsRemoteUnspecified(geo.WorkMode, geo),
 		})
 		if err != nil {
 			return fmt.Errorf("upsert job %s: %w", externalID, err)
@@ -188,6 +189,7 @@ func (s *extractStore) CompleteLinks(
 			EmploymentType:     jobfacts.EmploymentType(j.Title, j.Description),
 			EducationLevel:     jobfacts.EducationLevel(j.Description),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(j.Description)),
+			RemoteUnspecified:  location.IsRemoteUnspecified(workMode, geo),
 		})
 		if err != nil {
 			return fmt.Errorf("upsert job %s/%s: %w", j.Source, j.ExternalID, err)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -129,7 +129,7 @@ func (q *Queries) EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrich
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 FROM jobs
 WHERE id = $1
 `
@@ -172,12 +172,13 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.RemoteUnspecified,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 FROM jobs
 WHERE public_slug = $1
 `
@@ -220,6 +221,7 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.RemoteUnspecified,
 	)
 	return i, err
 }
@@ -242,7 +244,7 @@ func (q *Queries) GetJobIDBySlug(ctx context.Context, publicSlug string) (int64,
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 FROM jobs
 WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -301,6 +303,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -313,7 +316,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -370,6 +373,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -382,7 +386,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -441,6 +445,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -453,7 +458,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -516,6 +521,7 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -683,8 +689,9 @@ SET countries = COALESCE($1::text[], '{}'),
     posting_language     = $7,
     employment_type      = $8,
     education_level      = $9,
-    experience_years_min = $10
-WHERE id = $11
+    experience_years_min = $10,
+    remote_unspecified   = $11
+WHERE id = $12
 `
 
 type UpdateJobFacetsParams struct {
@@ -698,13 +705,15 @@ type UpdateJobFacetsParams struct {
 	EmploymentType     string      `json:"employment_type"`
 	EducationLevel     string      `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4 `json:"experience_years_min"`
+	RemoteUnspecified  bool        `json:"remote_unspecified"`
 	ID                 int64       `json:"id"`
 }
 
 // One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 // facet column — countries, regions, work_mode, skills, seniority, category, plus the
 // synthetic enrichment facets posting_language, employment_type, education_level,
-// experience_years_min — from the row's raw content (title/location/description) in one
+// experience_years_min, and remote_unspecified — from the row's raw content
+// (title/location/description) in one
 // pass, replacing the
 // three separate per-facet backfill writes. The facets are a pure function of the
 // raw fields, so this is idempotent. updated_at is deliberately left untouched
@@ -724,6 +733,7 @@ func (q *Queries) UpdateJobFacets(ctx context.Context, arg UpdateJobFacetsParams
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
+		arg.RemoteUnspecified,
 		arg.ID,
 	)
 	return err
@@ -777,10 +787,11 @@ SET title        = $1,
     employment_type      = $15,
     education_level      = $16,
     experience_years_min = $17,
-    updated_by   = $18::bigint,
+    remote_unspecified   = $18,
+    updated_by   = $19::bigint,
     updated_at   = now()
-WHERE public_slug = $19 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+WHERE public_slug = $20 AND created_by IS NOT NULL
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 `
 
 type UpdateManualJobParams struct {
@@ -801,6 +812,7 @@ type UpdateManualJobParams struct {
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
+	RemoteUnspecified  bool               `json:"remote_unspecified"`
 	UpdatedBy          int64              `json:"updated_by"`
 	PublicSlug         string             `json:"public_slug"`
 }
@@ -836,6 +848,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
+		arg.RemoteUnspecified,
 		arg.UpdatedBy,
 		arg.PublicSlug,
 	)
@@ -875,6 +888,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.RemoteUnspecified,
 	)
 	return i, err
 }
@@ -895,7 +909,8 @@ company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min, content_hash
+    posting_language, employment_type, education_level, experience_years_min,
+    remote_unspecified, content_hash
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7, $8,
@@ -904,7 +919,7 @@ INSERT INTO jobs (
     COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'),
     $14, COALESCE($15::text[], '{}'), $16, $17,
     $18, $19, $20, $21,
-    $22
+    $22, $23
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -925,14 +940,15 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
+    remote_unspecified   = EXCLUDED.remote_unspecified,
     content_hash = EXCLUDED.content_hash,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed.
     last_seen_at = now(),
     closed_at    = NULL,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.remote_unspecified,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
-    ((SELECT old_hash FROM existing) IS DISTINCT FROM $22) AS changed
+    ((SELECT old_hash FROM existing) IS DISTINCT FROM $23) AS changed
 `
 
 type UpsertJobParams struct {
@@ -957,6 +973,7 @@ type UpsertJobParams struct {
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
+	RemoteUnspecified  bool               `json:"remote_unspecified"`
 	ContentHash        pgtype.Text        `json:"content_hash"`
 }
 
@@ -1009,6 +1026,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
+		arg.RemoteUnspecified,
 		arg.ContentHash,
 	)
 	var i UpsertJobRow
@@ -1047,6 +1065,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.ExperienceYearsMin,
 		&i.Job.Collections,
 		&i.Job.ContentHash,
+		&i.Job.RemoteUnspecified,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -1065,7 +1084,8 @@ WITH company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min, created_by
+    posting_language, employment_type, education_level, experience_years_min,
+    remote_unspecified, created_by
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7, $8,
@@ -1075,7 +1095,7 @@ INSERT INTO jobs (
     $14, COALESCE($15::text[], '{}'),
     $16, $17,
     $18, $19, $20, $21,
-    $22::bigint
+    $22, $23::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -1096,10 +1116,11 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
-    updated_by   = $23::bigint,
+    remote_unspecified   = EXCLUDED.remote_unspecified,
+    updated_by   = $24::bigint,
     closed_at    = NULL,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 `
 
 type UpsertManualJobParams struct {
@@ -1124,6 +1145,7 @@ type UpsertManualJobParams struct {
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
+	RemoteUnspecified  bool               `json:"remote_unspecified"`
 	CreatedBy          int64              `json:"created_by"`
 	UpdatedBy          int64              `json:"updated_by"`
 }
@@ -1161,6 +1183,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
+		arg.RemoteUnspecified,
 		arg.CreatedBy,
 		arg.UpdatedBy,
 	)
@@ -1200,6 +1223,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.RemoteUnspecified,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -76,6 +76,7 @@ type Job struct {
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
 	Collections        []string           `json:"collections"`
 	ContentHash        pgtype.Text        `json:"content_hash"`
+	RemoteUnspecified  bool               `json:"remote_unspecified"`
 }
 
 type JobReport struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -358,7 +358,8 @@ type Querier interface {
 	// One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 	// facet column — countries, regions, work_mode, skills, seniority, category, plus the
 	// synthetic enrichment facets posting_language, employment_type, education_level,
-	// experience_years_min — from the row's raw content (title/location/description) in one
+	// experience_years_min, and remote_unspecified — from the row's raw content
+	// (title/location/description) in one
 	// pass, replacing the
 	// three separate per-facet backfill writes. The facets are a pure function of the
 	// raw fields, so this is idempotent. updated_at is deliberately left untouched

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -94,7 +94,8 @@ company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min, content_hash
+    posting_language, employment_type, education_level, experience_years_min,
+    remote_unspecified, content_hash
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
     sqlc.arg(company), sqlc.arg(company_slug), sqlc.arg(location), sqlc.arg(remote),
@@ -103,7 +104,7 @@ INSERT INTO jobs (
     COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'),
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'), sqlc.arg(seniority), sqlc.arg(category),
     sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(experience_years_min),
-    sqlc.arg(content_hash)
+    sqlc.arg(remote_unspecified), sqlc.arg(content_hash)
 )
 -- public_slug is deliberately NOT in the DO UPDATE SET: the slug is minted once
 -- at insert and is the row's stable public identity. Re-ingest of the same
@@ -128,6 +129,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
+    remote_unspecified   = EXCLUDED.remote_unspecified,
     content_hash = EXCLUDED.content_hash,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed.
     last_seen_at = now(),
@@ -172,7 +174,8 @@ WITH company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min, created_by
+    posting_language, employment_type, education_level, experience_years_min,
+    remote_unspecified, created_by
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
     sqlc.arg(company), sqlc.arg(company_slug), sqlc.arg(location), sqlc.arg(remote),
@@ -182,7 +185,7 @@ INSERT INTO jobs (
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'),
     sqlc.arg(seniority), sqlc.arg(category),
     sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(experience_years_min),
-    sqlc.arg(created_by)::bigint
+    sqlc.arg(remote_unspecified), sqlc.arg(created_by)::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -203,6 +206,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
+    remote_unspecified   = EXCLUDED.remote_unspecified,
     updated_by   = sqlc.arg(updated_by)::bigint,
     closed_at    = NULL,
     updated_at   = now()
@@ -247,6 +251,7 @@ SET title        = sqlc.arg(title),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),
     experience_years_min = sqlc.arg(experience_years_min),
+    remote_unspecified   = sqlc.arg(remote_unspecified),
     updated_by   = sqlc.arg(updated_by)::bigint,
     updated_at   = now()
 WHERE public_slug = sqlc.arg(public_slug) AND created_by IS NOT NULL
@@ -362,7 +367,8 @@ WHERE id = sqlc.arg(id);
 -- One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 -- facet column — countries, regions, work_mode, skills, seniority, category, plus the
 -- synthetic enrichment facets posting_language, employment_type, education_level,
--- experience_years_min — from the row's raw content (title/location/description) in one
+-- experience_years_min, and remote_unspecified — from the row's raw content
+-- (title/location/description) in one
 -- pass, replacing the
 -- three separate per-facet backfill writes. The facets are a pure function of the
 -- raw fields, so this is idempotent. updated_at is deliberately left untouched
@@ -380,5 +386,6 @@ SET countries = COALESCE(sqlc.arg(countries)::text[], '{}'),
     posting_language     = sqlc.arg(posting_language),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),
-    experience_years_min = sqlc.arg(experience_years_min)
+    experience_years_min = sqlc.arg(experience_years_min),
+    remote_unspecified   = sqlc.arg(remote_unspecified)
 WHERE id = sqlc.arg(id);

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -115,7 +115,7 @@ func (q *Queries) CountUserJobs(ctx context.Context, userID int64) (CountUserJob
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.remote_unspecified, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -199,6 +199,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.ExperienceYearsMin,
 			&i.Job.Collections,
 			&i.Job.ContentHash,
+			&i.Job.RemoteUnspecified,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -59,6 +59,9 @@ type Derived struct {
 	EmploymentType     string
 	EducationLevel     string
 	ExperienceYearsMin *int
+	// RemoteUnspecified is true when the job is remote but its geography did not
+	// resolve to any country or region — the "remote, region not specified" facet.
+	RemoteUnspecified bool
 }
 
 // Derive computes the slugs and dictionary facets for a job. Geography, skills, and the
@@ -115,6 +118,7 @@ func Derive(in Input) Derived {
 		EmploymentType:     jobfacts.EmploymentType(in.Title, in.Description),
 		EducationLevel:     jobfacts.EducationLevel(in.Description),
 		ExperienceYearsMin: experience,
+		RemoteUnspecified:  location.IsRemoteUnspecified(workMode, geo),
 	}
 }
 

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -36,6 +36,50 @@ func TestDerive_SlugsAndFacets(t *testing.T) {
 	}
 }
 
+// RemoteUnspecified flags a remote job whose geography did not resolve to any
+// country or region — the "remote, region not specified" bucket. It is true only
+// when work_mode is remote AND both countries and regions are empty.
+func TestDerive_RemoteUnspecified(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Input
+		want bool
+	}{
+		{
+			name: "bare remote with no geography is flagged",
+			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "1", Location: "Remote"},
+			want: true,
+		},
+		{
+			name: "remote with a resolved region is not flagged",
+			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "2", Location: "Remote - Europe"},
+			want: false,
+		},
+		{
+			name: "remote anywhere (global) is not flagged",
+			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "3", Location: "Remote - Anywhere"},
+			want: false,
+		},
+		{
+			name: "onsite with no geography is not flagged",
+			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "4", Location: "On-site"},
+			want: false,
+		},
+		{
+			name: "no location at all is not flagged",
+			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "5"},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Derive(tt.in).RemoteUnspecified; got != tt.want {
+				t.Errorf("RemoteUnspecified = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // A structured work-mode signal from the caller (e.g. an ATS workplace-type enum)
 // beats the free-text parser hint.
 //

--- a/internal/jobhash/jobhash.go
+++ b/internal/jobhash/jobhash.go
@@ -47,6 +47,7 @@ func Of(p db.UpsertJobParams) string {
 	write(p.EmploymentType)
 	write(p.EducationLevel)
 	write(nullableInt(p.ExperienceYearsMin))
+	write(strconv.FormatBool(p.RemoteUnspecified))
 
 	sum := sha256.Sum256([]byte(b.String()))
 	return hex.EncodeToString(sum[:])

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -50,6 +50,11 @@ type Job struct {
 	Regions   []string `json:"regions"`
 	WorkMode  string   `json:"work_mode,omitempty"`
 	Skills    []string `json:"skills"`
+	// RemoteUnspecified is a deterministic source fact served straight from the jobs
+	// column: true when the job is remote but its geography resolved to no country
+	// and no region — the "remote, region not specified" facet. Served top-level like
+	// the other dictionary facets; indexed as a Meilisearch filterable attribute.
+	RemoteUnspecified bool `json:"remote_unspecified"`
 	// Collections is the set of curated-collection slugs (e.g. yc, bigtech) the
 	// job's company belongs to, denormalized from the company onto the job. It is a
 	// deterministic source fact (no LLM counterpart) served straight from the jobs
@@ -123,6 +128,7 @@ func FromRow(j db.Job) (Job, error) {
 		Regions:           regions,
 		WorkMode:          workMode,
 		Skills:            skills,
+		RemoteUnspecified: j.RemoteUnspecified,
 		Collections:       collections,
 		PostedAt:          rfc3339(EffectivePostedAt(j.PostedAt, j.CreatedAt)),
 		CreatedAt:         rfc3339(j.CreatedAt),

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -396,6 +396,25 @@ func TestFromRow_CollectionsEmptyIsNonNil(t *testing.T) {
 	}
 }
 
+// remote_unspecified is served straight from the jobs column (a deterministic
+// source fact), like the other dictionary facets.
+func TestFromRow_RemoteUnspecifiedFromColumn(t *testing.T) {
+	on, err := FromRow(db.Job{ID: 1, RemoteUnspecified: true})
+	if err != nil {
+		t.Fatalf("FromRow: %v", err)
+	}
+	if !on.RemoteUnspecified {
+		t.Fatalf("RemoteUnspecified = false, want true (from column)")
+	}
+	off, err := FromRow(db.Job{ID: 2})
+	if err != nil {
+		t.Fatalf("FromRow: %v", err)
+	}
+	if off.RemoteUnspecified {
+		t.Fatalf("RemoteUnspecified = true, want false (default)")
+	}
+}
+
 // Seniority/category are the dictionary column value, always — the LLM never wins
 // and never fills a dict-silent field. They stay nested under enrichment so the
 // existing facet path is unchanged.

--- a/internal/location/dictionaries.go
+++ b/internal/location/dictionaries.go
@@ -322,6 +322,7 @@ var nameToRegion = map[string]string{
 	// Open-anywhere markers, multilingual. A bare "remote" stays geography-less
 	// (work mode only); these are explicit "the whole world" phrasings.
 	"anywhere": "global", "worldwide": "global", "global": "global",
+	"international": "global", "international remote": "global", "globally": "global",
 	"remote anywhere": "global", "world wide": "global", "world-wide": "global",
 	"everywhere": "global", "fully distributed": "global",
 	"по всему миру": "global", "весь мир": "global",

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -27,6 +27,16 @@ type Geo struct {
 	WorkMode  string // "", "remote", "hybrid", or "onsite" — only on an explicit marker
 }
 
+// IsRemoteUnspecified reports whether a job is remote but its geography resolved to
+// no country and no region — the "remote, region not specified" facet. The work mode
+// is passed in (rather than read from geo) because callers resolve it through their
+// own precedence (structured signal → location hint → description); geo carries only
+// the parsed country/region sets. It is the single definition of the rule, shared by
+// jobderive and the Telegram extract path.
+func IsRemoteUnspecified(workMode string, geo Geo) bool {
+	return workMode == "remote" && len(geo.Countries) == 0 && len(geo.Regions) == 0
+}
+
 // separatorReplacer normalizes every token separator to a comma in one pass so a
 // single Split yields the geography tokens. The multi-character forms (" - ",
 // " or ") and parentheses are included, so "Berlin (On-site)" -> "berlin",

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -57,6 +57,11 @@ func TestParse(t *testing.T) {
 			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
 		},
 		{
+			name:     "international marker yields global and remote",
+			location: "Remote - International",
+			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
+		},
+		{
 			name:     "hybrid marker with city",
 			location: "Hybrid - London",
 			want:     Geo{Countries: []string{"gb"}, Regions: []string{"uk"}, WorkMode: "hybrid"},

--- a/internal/moderation/moderation.go
+++ b/internal/moderation/moderation.go
@@ -163,6 +163,7 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
 		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
+		RemoteUnspecified:  d.RemoteUnspecified,
 
 		CreatedBy: actorID,
 		UpdatedBy: actorID,
@@ -229,6 +230,7 @@ func (s *Service) Update(ctx context.Context, actorID int64, slug string, p Upda
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
 		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
+		RemoteUnspecified:  d.RemoteUnspecified,
 
 		UpdatedBy: actorID,
 	})

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -60,6 +60,9 @@ type Job struct {
 	EmploymentType     string
 	EducationLevel     string
 	ExperienceYearsMin *int
+	// RemoteUnspecified is true when the job is remote but its geography resolved to
+	// no country and no region — the "remote, region not specified" facet.
+	RemoteUnspecified bool
 }
 
 // Store persists one normalized job and enqueues it for enrichment when needed,
@@ -325,5 +328,6 @@ func normalizeJob(e sources.CompanyEntry, j sources.Job) Job {
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
 		ExperienceYearsMin: d.ExperienceYearsMin,
+		RemoteUnspecified:  d.RemoteUnspecified,
 	}
 }

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -493,7 +493,7 @@ func facetSettings() *meilisearch.Settings {
 		// dot path.
 		FilterableAttributes: []string{
 			"source", "company_slug",
-			"work_mode", "regions", "countries", "skills", "collections",
+			"work_mode", "regions", "countries", "skills", "collections", "remote_unspecified",
 			"enrichment.employment_type", "enrichment.education_level", "enrichment.seniority",
 			"enrichment.category", "enrichment.domains",
 			"enrichment.company_type", "enrichment.company_size", "enrichment.visa_sponsorship",

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -79,6 +79,13 @@ func filterFromValues(v url.Values, now time.Time) any {
 		groups = append(groups, []string{EqBool("enrichment.visa_sponsorship", raw == "true")})
 	}
 
+	// remote_unspecified is a one-way toggle: setting it true restricts to remote
+	// jobs whose geography did not resolve. It adds only a positive constraint, so a
+	// false/empty value emits nothing (filtering OUT that bucket is not a use case).
+	if v.Get("remote_unspecified") == "true" {
+		groups = append(groups, []string{EqBool("remote_unspecified", true)})
+	}
+
 	if n, ok := atoiOK(v.Get("salary_min")); ok {
 		groups = append(groups, []string{Gte("enrichment.salary_min", n)})
 	}

--- a/internal/search/query_filter_test.go
+++ b/internal/search/query_filter_test.go
@@ -111,6 +111,25 @@ func TestFilterFromValues_VisaBoolAndNumeric(t *testing.T) {
 	}
 }
 
+func TestFilterFromValues_RemoteUnspecified(t *testing.T) {
+	// remote_unspecified=true restricts to the facet; it ANDs as its own group.
+	got := normalizeGroups(t, FilterFromValues(vals("remote_unspecified=true&seniority=senior")))
+	want := [][]string{
+		{`enrichment.seniority = "senior"`},
+		{`remote_unspecified = true`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// The toggle only adds a positive constraint: unset, empty, or false emit nothing.
+	for _, q := range []string{"", "remote_unspecified=", "remote_unspecified=false"} {
+		if got := FilterFromValues(vals(q)); got != nil {
+			t.Errorf("FilterFromValues(%q) = %v, want nil", q, got)
+		}
+	}
+}
+
 func TestFilterFromValues_PostedWithinDays(t *testing.T) {
 	// now is injected so the cutoff is deterministic. posted_within_days=N restricts
 	// to posted_ts >= now - N*86400 (posted within the last N days).

--- a/migrations/0027_job_remote_unspecified.sql
+++ b/migrations/0027_job_remote_unspecified.sql
@@ -1,0 +1,10 @@
+-- remote_unspecified facet (see openspec change add-remote-region-filters): a
+-- deterministic boolean, derived at ingest by internal/jobderive, true when a job
+-- is remote (work_mode='remote') but its geography resolved to no country and no
+-- region — the "remote, region not specified" bucket. Like the other dictionary
+-- facets it is a SOURCE fact stored beside (not inside) the `enrichment` JSONB, so
+-- the LLM enrichment worker never clobbers it; jobview serves it dict-only and the
+-- search index registers it as a filterable attribute. Defaults false so existing
+-- rows are inert until re-derived (cmd/backfill-derive) and reindexed.
+ALTER TABLE jobs
+    ADD COLUMN IF NOT EXISTS remote_unspecified BOOLEAN NOT NULL DEFAULT false;

--- a/openspec/changes/add-remote-region-filters/.openspec.yaml
+++ b/openspec/changes/add-remote-region-filters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-30

--- a/openspec/changes/add-remote-region-filters/design.md
+++ b/openspec/changes/add-remote-region-filters/design.md
@@ -1,0 +1,95 @@
+## Context
+
+Geography is a deterministic dictionary (`internal/location`) feeding Meilisearch
+facets (`regions`/`countries`/`work_mode`); it never guesses and emits nothing it
+cannot resolve. The `global` region already exists and several open-anywhere
+markers (`Anywhere`, `Worldwide`, `Global`, …) already map to it, but
+`International` does not. Separately, a bare `Remote` deliberately yields no
+region — correct (such a posting is often silently region-restricted), but it
+leaves a large set of remote jobs unreachable from the Region filter. The
+employment-type matcher already resolves `Contractor`/`freelance`/etc. to
+`employment_type=contract` with an existing filter and UI pill, so `Contractor`
+needs only a data backfill.
+
+All facets follow one pattern: derive at ingest via `jobderive`, store a `jobs`
+column beside (not inside) the `enrichment` JSONB, serve dict-only via `jobview`,
+index as a Meilisearch facet. A dictionary/derivation change reaches existing rows
+only via `cmd/backfill-derive` + `make reindex`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Recognize `International` (and close worldwide synonyms) as `global`.
+- Add a `remote_unspecified` facet (remote + no resolved geography), filterable in
+  the API and selectable in the SPA, with a facet count like other Region pills.
+- Reach existing rows through the existing re-derive + reindex path.
+
+**Non-Goals:**
+- Mapping a bare `Remote` to `global` (explicitly rejected — keeps `global` clean).
+- `EMEA` handling (deferred).
+- Any `Contractor` code change (already implemented; backfill-only).
+- Any LLM/enrichment change.
+
+## Decisions
+
+**1. `International` → `global` as a dictionary entry.** Add `international` (and
+close synonyms: e.g. `international remote`, `globally`) to `location.nameToRegion`
+→ `global`. *Alternative considered:* a new region value — rejected; `International`
+means "the whole world", which is exactly what `global` already encodes. The
+existing `RegionValues`-membership invariant test covers it for free.
+
+**2. `remote_unspecified` as a stored boolean column, not a computed query
+predicate.** Add `Derived.RemoteUnspecified` computed in `jobderive.Derive` as
+`work_mode == "remote" && len(countries) == 0 && len(regions) == 0`, persisted to
+a new `jobs.remote_unspecified BOOLEAN NOT NULL DEFAULT false` column, served by
+`jobview`, and registered as a Meilisearch filterable attribute. *Alternative
+considered:* a compute-only compound filter (`work_mode="remote" AND regions IS
+EMPTY AND countries IS EMPTY`) with no column — rejected: it cannot produce a
+facet-distribution count for the pill, and it scatters a magic predicate in the
+filter builder. A stored, named facet matches the codebase's facet pattern and
+gives the SPA a count badge consistent with the other Region pills.
+
+**3. Filter param mirrors `visa_sponsorship`.** Boolean facets in this codebase
+are not in the `StringFacets` map; they are handled explicitly in
+`FilterFromValues` via `EqBool` (see `visa_sponsorship`). `remote_unspecified`
+follows the same shape: `if v.Get("remote_unspecified") == "true" { … EqBool(...) }`.
+This keeps the pure filter builder shared by the HTTP handler and the saved-search
+matcher.
+
+**4. SPA pill in the Region group, distinct from Global.** Render a control in the
+Region facet group bound to the `remote_unspecified` param, labelled to read as
+"remote, region not specified". It is a boolean, not a member of the `regions`
+array, so it stays a separate control rather than polluting `REGION` /
+`RegionValues`.
+
+## Risks / Trade-offs
+
+- [New filterable attribute 500s `/jobs` until reindex] → Deploy ordering: add the
+  attribute and run a full fresh-index + swap reindex BEFORE the API/UI exposes the
+  param. This recurred before; treat reindex as a precondition, not a follow-up.
+- [Stored boolean is redundant with `work_mode`/`regions`/`countries`] → Accepted:
+  it is always derived from those three by `jobderive` (never hand-set), so it
+  cannot drift; the redundancy buys a clean named facet + count.
+- [`remote_unspecified` over-broad] → It is intentionally narrow (requires
+  `work_mode=remote`); a region-tagged remote job (incl. `global`) is excluded, so
+  it captures only the truly unspecified bucket.
+- [Backfill scope] → `cmd/backfill-derive` already re-derives all dictionary facets
+  in one pass; it must also write the new column (and picks up the `International`
+  mapping and the pre-existing `Contractor` matcher in the same run).
+
+## Migration Plan
+
+1. Add the column migration; recreate the volume in dev (`down -v && make up`) per
+   the initdb-only migration convention, or apply manually in prod.
+2. `make sqlc` after editing queries; commit generated code.
+3. Ship the derivation + storage + reindex config; run `cmd/backfill-derive` then a
+   full `make reindex` (fresh index + swap) so the new attribute exists before the
+   API/UI references it.
+4. Then enable the API param and SPA pill.
+
+Rollback: drop the SPA pill / API param first; the column and attribute are inert
+if unfiltered. The column can remain (defaults false) without effect.
+
+## Open Questions
+
+None — scope and approach confirmed during brainstorming.

--- a/openspec/changes/add-remote-region-filters/proposal.md
+++ b/openspec/changes/add-remote-region-filters/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Remote, location-agnostic vacancies are under-discoverable in the filters. Two
+gaps: (1) common worldwide markers like `International` are not recognized, so
+those roles fall out of the `global` region facet; (2) a bare `Remote` with no
+resolvable country/region deliberately gets no geography, so there is no way to
+filter for "remote, region not specified" — these jobs are invisible to anyone
+browsing by region. Closing both gaps surfaces more remote roles with purely
+deterministic dictionary code (no LLM), applied to existing rows via the existing
+re-derive + reindex path.
+
+## What Changes
+
+- Map the worldwide marker `International` (and close synonyms) to the existing
+  `global` region in the location dictionary.
+- Add a new deterministic facet `remote_unspecified`: true when a job is
+  `work_mode=remote` AND has no resolved countries AND no resolved regions.
+  Stored as a `jobs` column, derived at ingest by `jobderive`, served dict-only,
+  indexed as a Meilisearch filterable attribute, filterable via a new
+  `remote_unspecified` search param, and shown as a filter pill in the SPA Region
+  group (distinct from `Global`).
+- Re-derive existing jobs (`cmd/backfill-derive`) and rebuild the search index so
+  the new mapping, the new facet, and the already-implemented `Contractor`
+  employment-type matcher reach the existing catalogue. **Operational ordering:**
+  the new filterable attribute must be added and a full reindex completed before
+  the API/UI exposes the filter, or `/jobs` returns 500 on the unknown attribute.
+
+Note: `Contractor` requires no code — `jobfacts.EmploymentType` already resolves
+`contractor`/`freelance`/etc. to `employment_type=contract`, with an existing
+search filter and UI pill. It is covered by the backfill only.
+
+## Capabilities
+
+### New Capabilities
+- `remote-region-filters`: the `remote_unspecified` derived facet — its
+  derivation rule, deterministic storage, dict-only serving, search filterability,
+  and SPA filter surface.
+
+### Modified Capabilities
+- `job-geography`: the location parser additionally resolves `International` (and
+  close worldwide synonyms) to the `global` region.
+
+## Impact
+
+- Code: `internal/location/dictionaries.go` (International→global),
+  `migrations/` (new `remote_unspecified` column + a new filterable attribute),
+  `internal/db/queries/*.sql` + `make sqlc` (write the column on upsert/derive),
+  `internal/jobderive` (compute the facet), `internal/jobview` (serve it),
+  `internal/search` (filterable attribute + `query_filter` param),
+  `web/src/lib/facets.ts` (filter pill).
+- Ops: `cmd/backfill-derive` then `make reindex` (reindex BEFORE exposing the new
+  filterable attribute to avoid `/jobs` 500s).
+- No LLM, no new dependencies.

--- a/openspec/changes/add-remote-region-filters/specs/job-geography/spec.md
+++ b/openspec/changes/add-remote-region-filters/specs/job-geography/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Job geography is derived deterministically from the location string
+
+The system SHALL provide a deterministic parser that maps a job's free-text
+`location` string to a set of ISO 3166-1 alpha-2 country codes and a set of
+region codes. The parser SHALL tokenize the location on the separators `,`, `;`,
+`/`, `|`, ` - `, and ` or `, and resolve each token against curated dictionaries:
+country/city/shorthand names to country codes, macro-region names to region
+codes, and country codes to their region. It SHALL emit only values present in
+the controlled vocabularies (see below), deduplicated, and SHALL emit nothing for
+tokens it cannot resolve (it never guesses). A bare remote marker (e.g. `Remote`)
+with no geographic token SHALL yield empty geography; the `global` region SHALL be
+emitted only from an explicit open-anywhere marker (e.g. `Anywhere`, `Worldwide`,
+`Global`, `International`), never inferred from a bare `Remote`. The open-anywhere
+marker set SHALL include `International` and its close worldwide synonyms.
+
+The parser SHALL also derive a `work_mode` hint from an explicit marker in the
+location string — `remote`, `hybrid`, or `onsite` — checked in priority order
+hybrid > remote > onsite (the most specific arrangement wins when several markers
+co-occur). A location with no work-mode marker SHALL yield an empty work_mode (a
+bare city is never assumed to be onsite). The marker scan is independent of the
+geography tokens, so a bare `Remote` yields `work_mode=remote` with empty geography.
+
+#### Scenario: A named country yields its code and region
+
+- **WHEN** the location `Remote - Germany` is parsed
+- **THEN** the countries are `[de]` and the regions include `eu`
+
+#### Scenario: A bare remote marker yields a work mode but no geography
+
+- **WHEN** the location `Remote` is parsed
+- **THEN** the work_mode is `remote` and both countries and regions are empty
+
+#### Scenario: Work mode marker priority
+
+- **WHEN** a location names both a hybrid and a remote marker (e.g.
+  `Hybrid / Remote - London`)
+- **THEN** the work_mode is `hybrid`
+
+#### Scenario: A macro region name yields a region without a country
+
+- **WHEN** the location `Remote - Europe` is parsed
+- **THEN** the regions are `[eu]` and the countries are empty
+
+#### Scenario: Multiple locations union into the result
+
+- **WHEN** the location `Remote - UK or Europe` is parsed
+- **THEN** the countries are `[gb]` and the regions include both `uk` and `eu`
+
+#### Scenario: A bare remote marker yields no geography
+
+- **WHEN** the location `Remote` is parsed
+- **THEN** both countries and regions are empty
+
+#### Scenario: An explicit open-anywhere marker yields global
+
+- **WHEN** the location `Remote - Anywhere` is parsed
+- **THEN** the regions are `[global]`
+
+#### Scenario: The International marker yields global
+
+- **WHEN** the location `Remote - International` (or a close worldwide synonym) is
+  parsed
+- **THEN** the regions are `[global]` and the work_mode is `remote`
+
+#### Scenario: An unresolvable location yields no geography
+
+- **WHEN** the location is a token absent from every dictionary
+- **THEN** both countries and regions are empty rather than a guessed value

--- a/openspec/changes/add-remote-region-filters/specs/remote-region-filters/spec.md
+++ b/openspec/changes/add-remote-region-filters/specs/remote-region-filters/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: The remote_unspecified facet is derived deterministically
+
+The system SHALL derive a boolean facet `remote_unspecified` for each job from
+its already-derived geography facets, with no LLM involvement. The facet SHALL be
+`true` when, and only when, the derived `work_mode` is `remote` AND the derived
+`countries` set is empty AND the derived `regions` set is empty; otherwise it
+SHALL be `false`. The facet SHALL be computed by `jobderive.Derive` from the same
+inputs that produce the geography facets, so the ingest pipeline and the moderator
+write path produce identical results, and a re-derive is idempotent.
+
+#### Scenario: A bare remote job is flagged
+
+- **WHEN** a job's geography derives to `work_mode=remote`, empty countries, and
+  empty regions (e.g. location `Remote`)
+- **THEN** `remote_unspecified` is `true`
+
+#### Scenario: A remote job with a resolved region is not flagged
+
+- **WHEN** a job derives to `work_mode=remote` with a non-empty region (e.g.
+  location `Remote - Europe` → `[eu]`, or `Remote - Anywhere` → `[global]`)
+- **THEN** `remote_unspecified` is `false`
+
+#### Scenario: A non-remote job with no geography is not flagged
+
+- **WHEN** a job derives to an empty `work_mode` (or `hybrid`/`onsite`) with empty
+  countries and regions
+- **THEN** `remote_unspecified` is `false`
+
+### Requirement: The remote_unspecified facet is stored, served, and indexed
+
+The system SHALL persist `remote_unspecified` as a `jobs` table column written on
+every upsert and re-derive, alongside the other deterministic facets and NOT
+inside the `enrichment` JSONB. The public read model (`jobview`) SHALL serve the
+column value. The search index SHALL register `remote_unspecified` as a
+filterable attribute, sourced from the served read model, so existing rows reflect
+the facet only after a re-derive and reindex.
+
+#### Scenario: The facet is served from the jobs column
+
+- **WHEN** a job with `remote_unspecified=true` is read through the public model
+- **THEN** the served object reports the facet as `true`
+
+#### Scenario: The facet is a filterable search attribute
+
+- **WHEN** the search index is configured
+- **THEN** `remote_unspecified` is among the index's filterable attributes
+
+### Requirement: Jobs can be filtered by remote_unspecified
+
+The search API SHALL accept a `remote_unspecified` boolean filter param that,
+when set to `true`, restricts results to jobs whose `remote_unspecified` facet is
+`true`. The param SHALL be built by the same pure filter builder shared by the
+HTTP search handler and the saved-search/notification matcher, so both produce an
+identical filter. An unset or empty param SHALL emit no filter fragment.
+
+#### Scenario: Filtering by remote_unspecified narrows results
+
+- **WHEN** a search request sets `remote_unspecified=true`
+- **THEN** only jobs whose `remote_unspecified` facet is `true` are returned
+
+#### Scenario: An unset param emits no filter
+
+- **WHEN** a search request omits `remote_unspecified` (or passes it empty)
+- **THEN** no `remote_unspecified` fragment is added to the search filter
+
+### Requirement: The SPA exposes remote_unspecified as a sidebar toggle
+
+The web frontend SHALL present `remote_unspecified` as a boolean toggle control in
+the jobs filter sidebar (mirroring the existing boolean filters such as visa
+sponsorship), labelled to convey location-flexible remote work (no specific country
+or region) and kept distinct from the `Global` region option. Enabling it SHALL
+drive the `remote_unspecified` search param; the filter model SHALL serialize the
+enabled state to `remote_unspecified=true`, parse it back from the URL, and count it
+as one active filter.
+
+#### Scenario: The toggle is shown and drives the param
+
+- **WHEN** the user opens the jobs filter sidebar
+- **THEN** a location-flexible remote toggle appears, distinct from the `Global`
+  region option, and enabling it sets the `remote_unspecified` search param to
+  `true`

--- a/openspec/changes/add-remote-region-filters/tasks.md
+++ b/openspec/changes/add-remote-region-filters/tasks.md
@@ -1,0 +1,35 @@
+## 1. International → global (job-geography)
+
+- [x] 1.1 Add a failing test in `internal/location` asserting `Parse("Remote - International")` yields `regions=[global]`, `work_mode=remote`, empty countries (plus a synonym case).
+- [x] 1.2 Add `"international"` (+ close worldwide synonyms) → `global` to `nameToRegion` in `internal/location/dictionaries.go`; confirm the `RegionValues`-membership invariant test still passes.
+
+## 2. remote_unspecified derivation (jobderive)
+
+- [x] 2.1 Add a failing test in `internal/jobderive` covering the three cases from the spec: bare remote → true; remote+region (incl. `global`) → false; non-remote/empty-geo → false.
+- [x] 2.2 Add `RemoteUnspecified bool` to `jobderive.Derived` and compute it in `Derive` as `work_mode == "remote" && len(Countries) == 0 && len(Regions) == 0`.
+
+## 3. Storage (migration + sqlc)
+
+- [x] 3.1 Add migration `migrations/00XX_remote_unspecified.sql` adding `jobs.remote_unspecified BOOLEAN NOT NULL DEFAULT false`.
+- [x] 3.2 Update the relevant queries in `internal/db/queries/*.sql` (UpsertJob and the derive/backfill write path) to set `remote_unspecified`; run `make sqlc` and commit generated code.
+- [x] 3.3 Wire the derived value into the pipeline and moderator write paths and `cmd/backfill-derive` so the column is written on ingest and on re-derive.
+
+## 4. Serving (jobview)
+
+- [x] 4.1 Add a failing `internal/jobview` test asserting the served object reports `remote_unspecified` from the column.
+- [x] 4.2 Serve `remote_unspecified` from the `jobs` column in `jobview` (dict-only, beside the other facets).
+
+## 5. Search (Meili attribute + filter param)
+
+- [x] 5.1 Add a failing `internal/search` test asserting `FilterFromValues` emits an `EqBool` fragment for `remote_unspecified=true` and nothing when unset.
+- [x] 5.2 Register `remote_unspecified` as a filterable attribute in `internal/search/client.go`; populate it in the search document from the read model.
+- [x] 5.3 Handle the `remote_unspecified=true` param in `FilterFromValues` via `EqBool` (mirroring `visa_sponsorship`).
+
+## 6. SPA filter pill (web-frontend)
+
+- [x] 6.1 Add a `remote_unspecified` filter control to the Region group in `web/src/lib/facets.ts`, labelled "remote, region not specified" and distinct from `Global`; verify via `svelte-check`.
+
+## 7. Rollout
+
+- [x] 7.1 `go build ./... && go vet ./... && go test ./...` green; `svelte-check` clean.
+- [x] 7.2 Document the deploy ordering in the change: run `cmd/backfill-derive` then a full `make reindex` (fresh index + swap) BEFORE the API/UI exposes the new param, to avoid `/jobs` 500s on the unknown filterable attribute.

--- a/web/src/lib/components/FiltersPanel.svelte
+++ b/web/src/lib/components/FiltersPanel.svelte
@@ -127,6 +127,19 @@
     </div>
   </div>
 
+  <div class="border-b border-border pb-4">
+    <h3 class="mb-2 text-sm font-semibold tracking-tight">Remote</h3>
+    <label class="flex cursor-pointer items-center gap-2 text-sm">
+      <input
+        type="checkbox"
+        class="size-4 rounded border-border"
+        checked={store.value.remoteUnspecified}
+        onchange={(e) => store.setRemoteUnspecified(e.currentTarget.checked)}
+      />
+      <span>Remote · location-flexible</span>
+    </label>
+  </div>
+
   <div>
     <h3 class="mb-2 text-sm font-semibold tracking-tight">Visa</h3>
     <label class="flex cursor-pointer items-center gap-2 text-sm">

--- a/web/src/lib/docs/filters.ts
+++ b/web/src/lib/docs/filters.ts
@@ -51,6 +51,11 @@ export const FILTER_FACETS: FilterRow[] = [
 export const FILTER_EXTRAS: FilterRow[] = [
   { param: 'visa_sponsorship', label: 'Visa sponsorship', values: 'true, false' },
   {
+    param: 'remote_unspecified',
+    label: 'Remote, location-flexible',
+    values: 'true — remote jobs whose geography resolved to no country or region',
+  },
+  {
     param: 'salary_min',
     label: 'Minimum salary',
     values: 'integer — jobs whose minimum salary is at least this (pair with salary_currency)',

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -31,6 +31,10 @@ export interface JobFilters {
   /** Facet state keyed by the facet's query param (see FACETS). */
   facets: Record<string, FacetState>;
   visa: boolean;
+  /** Remote jobs whose geography did not resolve to any country or region — the
+   *  "remote, region not specified" bucket. Serialized as `remote_unspecified=true`;
+   *  a one-way toggle (false is never serialized), distinct from the `global` region. */
+  remoteUnspecified: boolean;
   salaryMin: number | null;
   /** Freshness: keep only jobs posted within the last N days (null = any age).
    *  Serialized as `posted_within_days`; the backend turns it into a posted_ts
@@ -50,7 +54,7 @@ function emptyFacets(): Record<string, FacetState> {
 }
 
 export function emptyFilters(): JobFilters {
-  return { q: '', facets: emptyFacets(), visa: false, salaryMin: null, postedWithinDays: null, sort: DEFAULT_SORT };
+  return { q: '', facets: emptyFacets(), visa: false, remoteUnspecified: false, salaryMin: null, postedWithinDays: null, sort: DEFAULT_SORT };
 }
 
 /** Serialize filters to URL query params (the shape the search API reads). */
@@ -68,6 +72,7 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
     }
   }
   if (f.visa) p.set('visa_sponsorship', 'true');
+  if (f.remoteUnspecified) p.set('remote_unspecified', 'true');
   if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
   if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
   // Omit the default sort: a clean URL leans on the backend's empty-query default.
@@ -92,6 +97,7 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
     else if (include.length > 0) f.facets[def.param] = { values: include, exclude: false, matchAll };
   }
   f.visa = p.get('visa_sponsorship') === 'true';
+  f.remoteUnspecified = p.get('remote_unspecified') === 'true';
   const salary = Number(p.get('salary_min'));
   f.salaryMin = p.get('salary_min') && !Number.isNaN(salary) ? salary : null;
   // Freshness is a positive whole number of days; anything else (absent, zero,
@@ -108,6 +114,7 @@ export function activeFilterCount(f: JobFilters): number {
   let n = 0;
   for (const def of FACETS) n += f.facets[def.param]?.values.length ?? 0;
   if (f.visa) n += 1;
+  if (f.remoteUnspecified) n += 1;
   if (f.salaryMin != null) n += 1;
   if (f.postedWithinDays != null) n += 1;
   return n;
@@ -173,6 +180,10 @@ export class FilterStore {
   // Discrete inputs (clicked/toggled): apply immediately via setNow.
   setVisa(on: boolean) {
     this.#url.setNow({ ...this.#url.value, visa: on });
+  }
+
+  setRemoteUnspecified(on: boolean) {
+    this.#url.setNow({ ...this.#url.value, remoteUnspecified: on });
   }
 
   setSort(sort: SortField) {


### PR DESCRIPTION
## What & why

More remote roles are discoverable, with purely deterministic dictionary code (no LLM). Two gaps closed:

1. **`International` → `global`.** The worldwide marker `International` (+ `international remote`, `globally`) now resolves to the existing `global` region, so those postings join the Global facet.
2. **New `remote_unspecified` facet** — remote jobs not pinned to any country/region (the *location-flexible* slice, distinct from region-locked remote like "Remote — US"). Rule defined once in `location.IsRemoteUnspecified`.

`Contractor` needed no code — `jobfacts.EmploymentType` already matches it; it's covered by the backfill.

## How

- `internal/location`: dictionary entry + shared `IsRemoteUnspecified` predicate.
- `internal/jobderive`: computes `RemoteUnspecified`.
- `migrations/0027` + sqlc: `jobs.remote_unspecified` column, wired into **every** write path (ingest, moderator create/update, tg-extract ×2, backfill-derive incl. its idempotency check).
- `jobhash` (change-detection), `jobview` (dict-only serving), `internal/search` (Meili filterable attr + `remote_unspecified=true` query param, one-way toggle).
- SPA: `Remote · location-flexible` sidebar toggle + URL state + API docs row.

## Deploy ordering ⚠️

New Meili filterable attribute 500s `/jobs` until reindexed. On prod: apply migration → full **fresh-index + swap** reindex → `cmd/backfill-derive` → then expose the UI filter.

## Verification

`gofmt` clean · `go build`/`go vet` OK · full `go test ./...` green · `svelte-check` 0 errors · independent code review: wiring 100%, no bugs.

Implements OpenSpec change `add-remote-region-filters`.