### PR TITLE
Add Rapyd adapter + payment-company boards

### DIFF
--- a/internal/sources/rapyd.go
+++ b/internal/sources/rapyd.go
@@ -1,0 +1,163 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// rapyd adapts the Rapyd careers site (www.rapyd.net), a self-hosted WordPress/WPBakery
+// section rather than a third-party ATS: the /company/careers-search/ listing enumerates
+// postings as /company/careers/positions/<slug>/ links, and each position page is
+// server-rendered HTML (no schema.org JobPosting block). The board is the career-site host;
+// the title, location and description come from a per-job detail fetch (bounded
+// concurrency), like the other HTML-detail adapters (globalpayments, successfactors).
+type rapyd struct {
+	http HTMLGetter
+}
+
+// NewRapyd builds the Rapyd adapter over the given HTTP client.
+func NewRapyd(c HTMLGetter) Source { return rapyd{http: c} }
+
+func (rapyd) Provider() string { return "rapyd" }
+
+func (r rapyd) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://%s/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("rapyd: board %q: %w", e.Board, err)
+	}
+
+	listURL := fmt.Sprintf("https://%s/company/careers-search/", e.Board)
+	root, err := r.http.GetHTML(ctx, listURL)
+	if err != nil {
+		return nil, fmt.Errorf("rapyd: listing %s: %w", e.Board, err)
+	}
+
+	// Each position's content comes from its own page fetch, fanned out under a bounded pool.
+	return fetchDetails(rapydPositionLinks(base, root), defaultDetailWorkers, func(u string) (Job, bool) {
+		return r.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one position page and maps it to a Job, returning ok=false when the page
+// fetch fails, the URL carries no slug, or the page has no title, so the caller skips just
+// that posting.
+func (r rapyd) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := rapydPositionID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := r.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+
+	h1 := firstByTag(root, "h1")
+	if h1 == nil {
+		return Job{}, false // a page without a heading is a layout/error page, not a posting
+	}
+	title := textContent(h1)
+	if title == "" {
+		return Job{}, false
+	}
+
+	var location string
+	if loc := firstByClass(root, "country-term"); loc != nil {
+		location = textContent(loc)
+	}
+
+	// The job body lives in the single-career-position__main column; scoping to it keeps the
+	// surrounding nav/footer out of the description.
+	var description string
+	if main := firstByClass(root, "single-career-position__main"); main != nil {
+		description = sanitizeHTML(innerHTML(main))
+	}
+
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       title,
+		Company:     e.Company,
+		Location:    location,
+		Description: description,
+		// No structured workplace field is exposed, so the location text is the only remote
+		// signal (never the title, which false-positives on "Remote …" role names).
+		Remote: isRemote(location),
+	}, true
+}
+
+// rapydPositionLinks returns the absolute hrefs of all anchors linking a
+// /company/careers/positions/<slug>/ page, resolved against base (the listing URL) so
+// relative hrefs still yield fetchable URLs, de-duplicated in first-seen order (a card
+// links the same position from its title and other controls).
+func rapydPositionLinks(base *url.URL, root *html.Node) []string {
+	var out []string
+	seen := make(map[string]bool)
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			href := attr(n, "href")
+			if rapydPositionID(href) == "" {
+				return true
+			}
+			ref, err := url.Parse(href)
+			if err != nil {
+				return true // unparseable href → not a usable position link
+			}
+			abs := base.ResolveReference(ref).String()
+			if !seen[abs] {
+				seen[abs] = true
+				out = append(out, abs)
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// rapydPositionIDPattern captures the slug from a /company/careers/positions/<slug>/ path.
+// The slug is the posting's stable native id (the site exposes no numeric id).
+var rapydPositionIDPattern = regexp.MustCompile(`/company/careers/positions/([^/?#]+)`)
+
+// rapydPositionID extracts the slug id (e.g. "sales-manager-bogota-colombia") from a
+// position page URL, or "" when the URL is not a position page.
+func rapydPositionID(u string) string {
+	if m := rapydPositionIDPattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// firstByTag returns the first element node with the given tag name, or nil.
+func firstByTag(root *html.Node, tag string) *html.Node {
+	var found *html.Node
+	walk(root, func(n *html.Node) bool {
+		if found != nil {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == tag {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// firstByClass returns the first element node carrying the given class, or nil.
+func firstByClass(root *html.Node, class string) *html.Node {
+	var found *html.Node
+	walk(root, func(n *html.Node) bool {
+		if found != nil {
+			return false
+		}
+		if n.Type == html.ElementNode && hasClass(n, class) {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/internal/sources/rapyd_test.go
+++ b/internal/sources/rapyd_test.go
@@ -1,0 +1,147 @@
+package sources
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// rapydListingHTML builds a careers-search listing page linking each position URL, plus
+// non-position links (nav/footer) that must be ignored.
+func rapydListingHTML(positionURLs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="careers-grid">`)
+	for _, u := range positionURLs {
+		b.WriteString(`<a href="` + u + `">A role</a>`)
+	}
+	b.WriteString(`<a href="/company/careers/">All openings</a>`)
+	b.WriteString(`<a href="/company/about/">About</a>`)
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// rapydDetailHTML mirrors the WPBakery career page: an h1 title, a .country-term location,
+// the single-career-position__main content column, and a footer link outside that column.
+func rapydDetailHTML(title, location, bodyHTML string) string {
+	return `<html><head>` +
+		`<meta property="og:title" content="` + title + ` - ` + location + ` - Rapyd"/>` +
+		`</head><body>` +
+		`<div class="country-term"><h4 class="vcex-terms-grid-entry-title entry-title">` + location + `</h4></div>` +
+		`<h1 class="vcex-heading"><span class="vcex-heading-inner">` + title + `</span></h1>` +
+		`<div class="vc_section single-career-position__content">` +
+		`<div class="wpb_column single-career-position__main">` +
+		`<div class="job-details">` + bodyHTML + `</div>` +
+		`</div></div>` +
+		`<div class="footer"><a href="/company/partners">Partners</a></div>` +
+		`</body></html>`
+}
+
+func TestRapydPositionID(t *testing.T) {
+	cases := map[string]string{
+		"https://www.rapyd.net/company/careers/positions/finance-data-developer-bogota-colombia/": "finance-data-developer-bogota-colombia",
+		"/company/careers/positions/sales-manager-bogota-colombia/":                               "sales-manager-bogota-colombia",
+		"https://www.rapyd.net/company/careers-search/":                                           "", // listing
+		"https://www.rapyd.net/company/careers/":                                                  "", // nav
+		"https://www.rapyd.net/company/about/":                                                    "",
+	}
+	for u, want := range cases {
+		if got := rapydPositionID(u); got != want {
+			t.Errorf("rapydPositionID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestRapydPositionLinksResolvesRelativeAndFiltersNonPositions(t *testing.T) {
+	h := `<html><body>
+		<a href="/company/careers/positions/sales-manager-bogota-colombia/">Sales</a>
+		<a href="/company/careers/positions/sales-manager-bogota-colombia/">Apply</a>
+		<a href="https://www.rapyd.net/company/careers/positions/noc-manager-tel-aviv-israel/">NOC</a>
+		<a href="/company/careers/">All</a>
+		<a href="/company/about/">About</a>
+	</body></html>`
+	base := mustURL(t, "https://www.rapyd.net/company/careers-search/")
+	got := rapydPositionLinks(base, parseHTML(t, h))
+	want := []string{
+		"https://www.rapyd.net/company/careers/positions/sales-manager-bogota-colombia/",
+		"https://www.rapyd.net/company/careers/positions/noc-manager-tel-aviv-israel/",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("rapydPositionLinks() = %v, want %v", got, want)
+	}
+}
+
+func TestRapydFetchListingThenDetailAndMaps(t *testing.T) {
+	posURL := "https://www.rapyd.net/company/careers/positions/finance-data-developer-bogota-colombia/"
+	detail := rapydDetailHTML("Finance Data Analyst", "Bogota, Colombia",
+		`<h3>Description</h3><p>Build <b>pipelines</b>.</p><h3>Requirements</h3><ul><li>Python</li></ul>`)
+	fake := (&routedHTTP{}).
+		route("careers-search", rapydListingHTML(posURL)).
+		route("finance-data-developer", detail)
+
+	jobs, err := NewRapyd(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Rapyd", Provider: "rapyd", Board: "www.rapyd.net",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "finance-data-developer-bogota-colombia" {
+		t.Errorf("ExternalID = %q", j.ExternalID)
+	}
+	if j.URL != posURL {
+		t.Errorf("URL = %q, want %q", j.URL, posURL)
+	}
+	if j.Title != "Finance Data Analyst" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Rapyd" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Bogota, Colombia" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if !strings.Contains(j.Description, "<b>pipelines</b>") || !strings.Contains(j.Description, "Python") {
+		t.Errorf("Description missing job body: %q", j.Description)
+	}
+	if strings.Contains(j.Description, "Partners") {
+		t.Errorf("Description leaked footer content: %q", j.Description)
+	}
+}
+
+func TestRapydFailedDetailDropsOnlyThatPosting(t *testing.T) {
+	kept := "https://www.rapyd.net/company/careers/positions/kept-role-london/"
+	dropped := "https://www.rapyd.net/company/careers/positions/dropped-role-paris/"
+	detail := rapydDetailHTML("Kept Role", "London, UK", `<h3>Description</h3><p>x</p>`)
+	// No route for the dropped position → GetHTML errors → only that posting drops.
+	fake := (&routedHTTP{}).
+		route("careers-search", rapydListingHTML(kept, dropped)).
+		route("kept-role-london", detail)
+
+	jobs, err := NewRapyd(fake).Fetch(context.Background(), CompanyEntry{Company: "Rapyd", Board: "www.rapyd.net"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "kept-role-london" {
+		t.Fatalf("got %v, want only the kept posting", jobs)
+	}
+}
+
+func TestRapydProvider(t *testing.T) {
+	if got := NewRapyd(nil).Provider(); got != "rapyd" {
+		t.Errorf("Provider() = %q, want %q", got, "rapyd")
+	}
+}
+
+func TestRapydRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["rapyd"]
+	if !ok {
+		t.Fatal("All() missing provider rapyd")
+	}
+	if s.Provider() != "rapyd" {
+		t.Errorf("All()[rapyd].Provider() = %q", s.Provider())
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -174,6 +174,7 @@ func All(c HTTPClient) map[string]Source {
 		NewBreezy(c),
 		NewJoin(c),
 		NewGlobalPayments(c),
+		NewRapyd(c),
 		NewCareerPlug(c),
 		NewPaycom(c),
 		NewLuxoft(c),

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -1091,6 +1091,8 @@
   board: sola
 - company: Solace
   board: solace
+- company: solidgate
+  board: solidgate
 - company: Solink
   board: solink
 - company: Solva

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -1569,6 +1569,8 @@
   board: dulcedo
 - company: dutch
   board: dutch
+- company: dwolla
+  board: dwolla
 - company: dynamiccatholic
   board: dynamiccatholic
 - company: dzen

--- a/sources/rapyd.yml
+++ b/sources/rapyd.yml
@@ -1,0 +1,7 @@
+# rapyd board. Provider is the filename; the single entry is company + board.
+# board = the Rapyd careers-site host (see internal/sources/rapyd.go); the adapter reads
+# https://<board>/company/careers-search/ and follows each /company/careers/positions/<slug>/.
+# Validated live (>0 positions in the listing) before adding.
+
+- company: Rapyd
+  board: www.rapyd.net

--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -7,3 +7,7 @@
   board: jobs.tetrapak.com
 - company: Ryanair
   board: jobs.ryanair.com
+- company: Paysafe
+  board: jobs.paysafe.com
+- company: Worldline
+  board: jobs.worldline.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -107,6 +107,8 @@
   board: newrich-network
 - company: nextgen-clearing
   board: nextgen-clearing
+- company: Nuvei
+  board: nuvei
 - company: PikPok
   board: pikpok
 - company: powtoon


### PR DESCRIPTION
Cut fresh from `origin/main` (the prior PR #299 was based on a 96-commit-stale main and is closed).

### Rapyd careers adapter
Rapyd self-hosts careers on WordPress/WPBakery — no third-party ATS, wp-json locked. Listing `/company/careers-search/` enumerates `/company/careers/positions/<slug>/`; each detail page is server-rendered HTML (title=`h1`, location=`.country-term`, description scoped to `.single-career-position__main`, ExternalID=slug, board=host). TDD (6 tests). **Verified live: 14 postings parsed off www.rapyd.net.**

### Payment-company boards (existing adapters)
Validated live against each ATS feed:
- **Solidgate** → ashby
- **Dwolla** → lever
- **Paysafe** & **Worldline** → successfactors (SAP SF career sites)
- **Nuvei** → workable

`go build ./...`, `go vet`, `go test ./internal/sources/...` all green; gofmt clean.