### PR TITLE
feat(jobfacts): match US contractor shorthands (1099, C2C, corp-to-corp)

### DIFF
--- a/internal/jobfacts/jobfacts.go
+++ b/internal/jobfacts/jobfacts.go
@@ -16,11 +16,14 @@ import (
 // Employment-type matchers, checked in precedence order: a "full-time internship"
 // is an internship, a part-time contract is part-time, etc. "temporary" / "fixed
 // term" map to contract (the closest vocabulary member). Bare \bintern\b is safe —
-// the boundary keeps it out of "internal"/"international".
+// the boundary keeps it out of "internal"/"international". The contract matcher also
+// covers the US-market shorthands for an independent contractor: 1099 (the tax form),
+// C2C and "corp-to-corp". "consultant" is deliberately excluded — it is as often a
+// full-time title as a contract arrangement.
 var (
 	reInternship = regexp.MustCompile(`\b(internship|intern|co-?op|working student|praktikum|werkstudent)\b`)
 	rePartTime   = regexp.MustCompile(`\bpart[\s-]?time\b`)
-	reContract   = regexp.MustCompile(`\b(contractor|contract|freelancer|freelance|fixed[\s-]?term|temporary|b2b)\b`)
+	reContract   = regexp.MustCompile(`\b(contractor|contract|freelancer|freelance|fixed[\s-]?term|temporary|b2b|c2c|1099|corp[\s-]?to[\s-]?corp)\b`)
 	reFullTime   = regexp.MustCompile(`\b(full[\s-]?time|permanent)\b`)
 )
 

--- a/internal/jobfacts/jobfacts_test.go
+++ b/internal/jobfacts/jobfacts_test.go
@@ -19,6 +19,10 @@ func TestEmploymentType(t *testing.T) {
 		{"contractor", "Dev", "We hire a contractor for this.", "contract"},
 		{"freelance", "Designer", "Freelance, remote.", "contract"},
 		{"temporary -> contract", "Picker", "Temporary seasonal position.", "contract"},
+		{"1099 -> contract", "Dev", "This is a 1099 position.", "contract"},
+		{"c2c -> contract", "Dev", "Open to C2C candidates.", "contract"},
+		{"corp-to-corp -> contract", "Dev", "W2 or corp-to-corp accepted.", "contract"},
+		{"corp to corp spaced -> contract", "Dev", "Corp to corp engagement.", "contract"},
 		{"full time", "Engineer", "Full-time, permanent position.", "full_time"},
 		{"internship beats full-time", "Intern", "A full-time internship for students.", "internship"},
 	}


### PR DESCRIPTION
Extends `reContract` to resolve US-market shorthands for an independent contractor — **1099** (the tax form), **C2C**, and **corp-to-corp** / `corp to corp` — to `employment_type=contract`.

`consultant` is deliberately excluded (as often a full-time title as a contract arrangement); `temp` too (`temporary` already matches).

Applies to existing rows on the next `cmd/backfill-derive` + `reindex`.

Verification: `go test ./...` green, gofmt clean. TDD (added 4 failing cases first).