### PR TITLE
feat(auth): 30-day sessions + guard /my/jobs behind sign-in

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,7 +66,7 @@ func Load() Settings {
 		DatabaseURL:    env("DATABASE_URL", "postgres://hire:hire@localhost:5432/hire?sslmode=disable"),
 		FrontendOrigin: env("FRONTEND_ORIGIN", "http://localhost:5173"),
 		JWTSecret:      os.Getenv("JWT_SECRET"),
-		JWTTTL:         envDuration("JWT_TTL", 24*time.Hour),
+		JWTTTL:         envDuration("JWT_TTL", 30*24*time.Hour),
 		CookieSecure:   envBool("COOKIE_SECURE", false),
 		OAuth:          loadOAuth(),
 		MeiliURL:       env("MEILI_URL", "http://localhost:7700"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -16,8 +16,8 @@ func TestLoad_JWTSecretFromEnv(t *testing.T) {
 func TestLoad_JWTTTLDefaultsWhenUnset(t *testing.T) {
 	t.Setenv("JWT_TTL", "")
 
-	if got := Load().JWTTTL; got != 24*time.Hour {
-		t.Errorf("JWTTTL = %v, want 24h", got)
+	if got := Load().JWTTTL; got != 30*24*time.Hour {
+		t.Errorf("JWTTTL = %v, want 30d", got)
 	}
 }
 
@@ -32,8 +32,8 @@ func TestLoad_JWTTTLParsesDuration(t *testing.T) {
 func TestLoad_JWTTTLFallsBackOnGarbage(t *testing.T) {
 	t.Setenv("JWT_TTL", "not-a-duration")
 
-	if got := Load().JWTTTL; got != 24*time.Hour {
-		t.Errorf("JWTTTL = %v, want 24h fallback", got)
+	if got := Load().JWTTTL; got != 30*24*time.Hour {
+		t.Errorf("JWTTTL = %v, want 30d fallback", got)
 	}
 }
 

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -37,14 +37,23 @@
   // singleton (see auth-dialog.svelte), so deep components — like a job's Save
   // button — can prompt sign-in through the same dialog this header renders.
 
-  // Surface a failed OAuth callback (?auth_error) once on the client, then clean
-  // the URL. In onMount so it never runs during SSR.
+  // Surface auth prompts carried in the URL once on the client, then clean it.
+  // ?auth_error: a failed OAuth callback. ?auth=required: a guarded page (e.g.
+  // /my/jobs) bounced a signed-out visitor here to sign in. In onMount so it
+  // never runs during SSR.
   onMount(() => {
-    if (page.url.searchParams.has('auth_error')) {
+    const params = page.url.searchParams;
+    if (params.has('auth_error')) {
+      // A real failure: seed the dialog's error banner.
       openAuthDialog('login', 'Sign-in failed. Please try again.');
-      // eslint-disable-next-line svelte/no-navigation-without-resolve -- shallow same-page URL clean-up to the current pathname; nothing to resolve
-      replaceState(page.url.pathname, {});
+    } else if (params.get('auth') === 'required') {
+      // Just a sign-in gate, not an error — open the dialog with no error banner.
+      openAuthDialog('login');
+    } else {
+      return;
     }
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- shallow same-page URL clean-up to the current pathname; nothing to resolve
+    replaceState(page.url.pathname, {});
   });
 </script>
 

--- a/web/src/routes/my/jobs/+page.server.ts
+++ b/web/src/routes/my/jobs/+page.server.ts
@@ -1,0 +1,12 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+// /my/jobs is personal: a signed-out visitor has nothing to show, so guard it
+// server-side rather than render an empty "sign in" state. The user is resolved
+// once in the root layout load; reuse it via parent(). Auth is a layout-level
+// dialog (no /login route), so we bounce home with ?auth=required and the TopBar
+// pops the sign-in dialog (same pattern as the ?auth_error OAuth callback).
+export const load: PageServerLoad = async ({ parent }) => {
+  const { user } = await parent();
+  if (!user) redirect(302, '/?auth=required');
+};


### PR DESCRIPTION
## What

Two small, related auth changes.

### 1. Sessions last 30 days
Default `JWT_TTL` is now **30 days** (was 24h) — `internal/config/config.go`. Both the JWT `exp` and the session cookie `Expires` derive from this single `JWTTTL`, so the change covers token and cookie together. Tests updated.

> **Ops note:** prod must have `JWT_TTL` unset (or set to `720h`) — an explicit env value overrides the default.

### 2. `/my/jobs` is guarded behind sign-in
A signed-out visitor to `/my/jobs` is now redirected server-side instead of seeing an empty "sign in" state. Auth in the SPA is a layout-level modal dialog (no `/login` route), so:
- `web/src/routes/my/jobs/+page.server.ts` (new) — `redirect(302, '/?auth=required')` when `parent()` resolves no user. Server-side, so no protected-content flash.
- `TopBar.svelte` — opens the sign-in dialog on `?auth=required` (no error styling — it's a gate, not a failure — distinct from the existing `?auth_error` OAuth path).

## Verification
- `go build ./...` — exit 0
- `go test ./internal/config/ ./internal/auth/... ./internal/handler/` — all pass
- `svelte-check` — 0 errors / 0 warnings
- Runtime: `curl -i /my/jobs` (no session) → `302 Found`, `location: /?auth=required`