### PR TITLE
docs(web): clarify UrlSyncedState placeholder-seed comment

### DIFF
--- a/web/src/lib/urlSynced.svelte.ts
+++ b/web/src/lib/urlSynced.svelte.ts
@@ -51,7 +51,8 @@ export class UrlSyncedState<T> {
   constructor(initial: URLSearchParams, codec: UrlCodec<T>, debounceMs = 300) {
     this.#codec = codec;
     this.#debounceMs = debounceMs;
-    // Fields above are placeholders; the real seed lands before any consumer reads.
+    // The field initializers above are typed placeholders; both are seeded here
+    // from the URL params, which only arrive as a constructor argument.
     const seeded = codec.parse(initial);
     this.value = seeded;
     this.applied = seeded;


### PR DESCRIPTION
Reword the `UrlSyncedState` constructor comment: the field initializers are typed placeholders that are seeded in the constructor from the URL params (which only arrive as an argument). Comment-only change, no behavior difference.

Salvaged from a stale local branch whose other work (funnel #302, JWT 30d default, /my/jobs auth guard, moderation tabs #304, remote-location-flexible filter #298) had all already landed on `main`.