### PR TITLE
fix(sources): build Sber apply URL from internalId, not requisitionId

### DIFF
--- a/internal/sources/sber.go
+++ b/internal/sources/sber.go
@@ -16,7 +16,7 @@ type sber struct {
 
 const (
 	sberListURL  = "https://rabota.sber.ru/public/app-candidate-public-api-gateway/api/v1/publications?skip=%d&take=%d"
-	sberVacURL   = "https://rabota.sber.ru/search/%s"
+	sberVacURL   = "https://rabota.sber.ru/search/%d"
 	sberPageSize = 200
 )
 
@@ -31,6 +31,7 @@ func (sber) boardless() {}
 // sberVac is one publication with its body inline (no detail call).
 type sberVac struct {
 	RequisitionID   string `json:"requisitionId"`
+	InternalID      int64  `json:"internalId"`
 	Title           string `json:"title"`
 	Company         string `json:"company"`
 	City            string `json:"city"`
@@ -79,13 +80,16 @@ func (s sber) list(ctx context.Context) ([]sberVac, error) {
 
 // toJob maps an inline vacancy to a Job. The body is assembled from the four text fields
 // (any may be empty); the employer company falls back to the configured entry when blank.
+// The two ids play distinct roles: the public vacancy page resolves the numeric internalId
+// (the requisitionId GUID route 404s), so the URL uses internalId, while the stable
+// requisitionId stays the dedup ExternalID.
 func (s sber) toJob(e CompanyEntry, v sberVac) Job {
 	company := firstNonEmpty(v.Company, e.Company)
 	body := v.Introduction + v.Duties + v.Requirements + v.Conditions
 
 	return Job{
 		ExternalID:  v.RequisitionID,
-		URL:         fmt.Sprintf(sberVacURL, v.RequisitionID),
+		URL:         fmt.Sprintf(sberVacURL, v.InternalID),
 		Title:       v.Title,
 		Company:     company,
 		Location:    v.City,

--- a/internal/sources/sber_test.go
+++ b/internal/sources/sber_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 // sberVacancy builds one inline vacancy fragment (body fields included — no detail call).
-func sberVacancy(reqID, title, company, city, pubDate, intro, duties, requirements, conditions string) string {
-	return `{"requisitionId":"` + reqID + `","title":"` + title + `","company":"` + company +
+func sberVacancy(reqID string, internalID int, title, company, city, pubDate, intro, duties, requirements, conditions string) string {
+	return `{"requisitionId":"` + reqID + `","internalId":` + itoa(internalID) +
+		`,"title":"` + title + `","company":"` + company +
 		`","city":"` + city + `","publicationDate":"` + pubDate +
 		`","introduction":"` + intro + `","duties":"` + duties +
 		`","requirements":"` + requirements + `","conditions":"` + conditions + `"}`
@@ -37,12 +38,12 @@ func TestSberSkipTakePaginatesAndMapsInline(t *testing.T) {
 	// skip+200=400 >= 300, so the loop stops. Bodies are inline — no detail call.
 	fake := (&routedHTTP{}).
 		route("skip=0", sberListPage(300,
-			sberVacancy("uuid-111", "Senior C++", `АО \"СберТех\"`, "г Москва",
+			sberVacancy("uuid-111", 4522762, "Senior C++", `АО \"СберТех\"`, "г Москва",
 				"2026-06-11T16:17:34.000Z",
 				"intro text", "### Duties", "### Requirements", "### Conditions"),
 		)).
 		route("skip=200", sberListPage(300,
-			sberVacancy("uuid-222", "Backend", "", "г Санкт-Петербург",
+			sberVacancy("uuid-222", 555, "Backend", "", "г Санкт-Петербург",
 				"2026-04-01T09:00:00.000Z", "i2", "d2", "r2", "c2"),
 		))
 
@@ -69,8 +70,13 @@ func TestSberSkipTakePaginatesAndMapsInline(t *testing.T) {
 	if j.Company != `АО "СберТех"` {
 		t.Errorf("Company = %q, want vacancy company", j.Company)
 	}
-	if want := "https://rabota.sber.ru/search/uuid-111"; j.URL != want {
+	// URL is built from the numeric internalId (the id the public page resolves), not the
+	// requisitionId GUID (which 404s); the requisitionId stays the dedup ExternalID.
+	if want := "https://rabota.sber.ru/search/4522762"; j.URL != want {
 		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.ExternalID != "uuid-111" {
+		t.Errorf("ExternalID = %q, want requisitionId uuid-111", j.ExternalID)
 	}
 	if j.Location != "г Москва" {
 		t.Errorf("Location = %q, want city", j.Location)

--- a/openspec/changes/fix-sber-apply-url/.openspec.yaml
+++ b/openspec/changes/fix-sber-apply-url/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/fix-sber-apply-url/design.md
+++ b/openspec/changes/fix-sber-apply-url/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`internal/sources/sber.go` maps each feed publication to a `Job`. It sets both the dedup
+`ExternalID` and the apply `URL` from `sberVac.RequisitionID`:
+
+```go
+sberVacURL = "https://rabota.sber.ru/search/%s"   // formatted with v.RequisitionID
+```
+
+A spike against live Sber data showed the `requisitionId` GUID route 404s for every
+vacancy, while `https://rabota.sber.ru/search/<internalId>` returns 200 and 302-redirects
+to the SEO-slug page. The feed record already carries the numeric `internalId` (confirmed
+in the raw payload); the adapter's `sberVac` struct simply does not parse it today.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Emit a working apply URL for every Sber vacancy, built from `internalId`.
+- Preserve the dedup key (`ExternalID` = `requisitionId`) so no rows re-key or duplicate.
+
+**Non-Goals:**
+- No liveness/closure changes — a corrected URL merely unblocks a future liveness probe;
+  that is out of scope here.
+- No SEO-slug reconstruction. Bare `search/<internalId>` 302s to the slug page, which is
+  sufficient; storing the slug form is not worth reimplementing Sber's slugging.
+
+## Decisions
+
+- **Add `InternalID int64` to `sberVac`** and format the URL from it. The feed field is
+  `internalId` (a JSON number), so parse it as an integer, not a string.
+  - Alternative: reuse `publicationId` (also a GUID) — rejected, it 404s like
+    `requisitionId`. Only `internalId` resolves.
+- **Keep `ExternalID` on `requisitionId`.** It is the existing dedup identity for all Sber
+  rows; switching it would orphan every current row and re-ingest duplicates.
+
+## Risks / Trade-offs
+
+- [Existing prod rows keep the stale 404 URL until re-crawled] → `UpsertJob` overwrites
+  `url` on the next Sber crawl; no backfill needed, the fix self-heals within one cycle.
+- [Sber could change its URL scheme again] → covered by the new spec scenario and a unit
+  test asserting the `internalId` URL shape, so a regression is caught.
+
+## Migration Plan
+
+None. Ship the adapter change; the next scheduled Sber crawl overwrites `url` for every
+posting via the normal upsert path. Rollback is reverting the adapter.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-sber-apply-url/proposal.md
+++ b/openspec/changes/fix-sber-apply-url/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The `sber` adapter builds every vacancy's apply URL from the vacancy's `requisitionId`
+GUID (`https://rabota.sber.ru/search/<requisitionId>`), but that route returns HTTP 404
+for **every** Sber posting — alive or not. Sber's public vacancy page is addressed only by
+the numeric `internalId`. As a result every Sber apply link on freehire is broken, which
+also makes live vacancies look permanently removed.
+
+## What Changes
+
+- The `sber` adapter builds the job `URL` from the posting's numeric `internalId`
+  (`https://rabota.sber.ru/search/<internalId>`, which 302-redirects to the SEO-slug page)
+  instead of the `requisitionId`.
+- `sberVac` gains an `internalId` field (already present in the feed payload) to carry it.
+- The dedup key is unchanged: `ExternalID` stays the `requisitionId`, so no re-keying or
+  duplicate rows.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `source-ingest`: the `sber` inline-body scenario is refined to require the apply URL be
+  built from the numeric `internalId`, not the `requisitionId`.
+
+## Impact
+
+- `internal/sources/sber.go` (URL construction + `sberVac` struct), `internal/sources/sber_test.go`.
+- Existing Sber rows in prod keep their stale `url`; a re-ingest overwrites `url` via
+  `UpsertJob` on the next Sber crawl. No migration needed.

--- a/openspec/changes/fix-sber-apply-url/specs/source-ingest/spec.md
+++ b/openspec/changes/fix-sber-apply-url/specs/source-ingest/spec.md
@@ -1,0 +1,61 @@
+## MODIFIED Requirements
+
+### Requirement: Russian bigtech single-company providers are registered
+
+The system SHALL register adapters for the single-company Russian career APIs `yandex`,
+`ozon`, `rwb`, `sber`, `alfabank`, `lamoda`, `kuper`, `aviasales`, `dodo`, `domclick`,
+`mtslink`, `tbank`, `mts`, and `vk`, so each can be listed in the boards configuration.
+Each adapter SHALL yield the normalized job shape (at least title, url, location, remote
+flag, description, and the platform's native posting id) with the `description` as
+sanitized HTML (or sanitized text for an API that publishes plain text) assembled from the
+platform's authoritative field(s). An adapter whose list endpoint omits the description
+SHALL fetch each posting's detail with bounded concurrency rather than yield an empty body,
+and a single failed detail SHALL drop only that posting rather than abort the board. All
+providers except `yandex` SHALL be `boardless`; `yandex` SHALL select host and language
+(`ru`/`com`) from its `board`.
+
+Where a provider's public vacancy page is addressed by a different identifier than its
+dedup key, the adapter SHALL build the job `url` from the page identifier while keeping the
+dedup `external_id` on the provider's stable posting id.
+
+#### Scenario: Cursor-paginated board is fully crawled
+
+- **WHEN** a `yandex` board is crawled and its list endpoint paginates by cursor
+- **THEN** the adapter follows the cursor until exhausted, skips postings that redirect out
+  or are hiring events, fetches each remaining posting's detail for the description, and
+  yields each as the normalized job shape with `external_id` set to the posting's native id
+
+#### Scenario: Page-paginated board is fully crawled
+
+- **WHEN** an `ozon` board is crawled and its list endpoint paginates by page number
+- **THEN** the adapter walks every page to the reported total, keeps only externally-listed
+  vacancies, fetches each posting's detail for the description, and yields each as the
+  normalized job shape
+
+#### Scenario: Offset-paginated board with inline body needs no detail call
+
+- **WHEN** a `sber` or `alfabank` board is crawled and the list endpoint carries the full
+  body inline
+- **THEN** the adapter walks the offset window to the reported total and yields each posting
+  directly with a sanitized description, issuing no per-posting detail request
+
+#### Scenario: Sber posting URL is built from the numeric internalId
+
+- **WHEN** a `sber` posting is normalized and its feed record carries both a `requisitionId`
+  GUID and a numeric `internalId`
+- **THEN** the job `url` is `https://rabota.sber.ru/search/<internalId>` (the identifier the
+  public vacancy page resolves — the `requisitionId` GUID route returns 404)
+- **AND** the job `external_id` remains the `requisitionId`, so the dedup key is unchanged
+
+#### Scenario: Header-gated board is crawled
+
+- **WHEN** an `mts` board is crawled and its API requires a non-secret `x-api-key` header
+- **THEN** the adapter obtains the public key, sends it on each request, walks the offset
+  window to the reported total, fetches each posting's detail, and yields each as the
+  normalized job shape
+
+#### Scenario: A board with no open postings yields no jobs without error
+
+- **WHEN** any of these providers' endpoints returns an empty posting list for a configured
+  board
+- **THEN** the adapter yields zero jobs and returns no error, so the board is simply skipped

--- a/openspec/changes/fix-sber-apply-url/tasks.md
+++ b/openspec/changes/fix-sber-apply-url/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Fix the Sber apply URL
 
-- [ ] 1.1 Add a failing test in `internal/sources/sber_test.go` asserting that a `sber`
+- [x] 1.1 Add a failing test in `internal/sources/sber_test.go` asserting that a `sber`
   posting whose feed record has `requisitionId` GUID and numeric `internalId` yields a job
   with `URL == "https://rabota.sber.ru/search/<internalId>"` and `ExternalID == <requisitionId>`.
-- [ ] 1.2 Add `InternalID int64` (json `internalId`) to `sberVac` and build the job `URL`
+- [x] 1.2 Add `InternalID int64` (json `internalId`) to `sberVac` and build the job `URL`
   from it (`sberVacURL` formatted with `%d`); keep `ExternalID` on `RequisitionID`.
-- [ ] 1.3 Run `go test ./internal/sources/` and `go vet ./...` — green.
+- [x] 1.3 Run `go test ./internal/sources/` and `go vet ./...` — green.

--- a/openspec/changes/fix-sber-apply-url/tasks.md
+++ b/openspec/changes/fix-sber-apply-url/tasks.md
@@ -1,0 +1,8 @@
+## 1. Fix the Sber apply URL
+
+- [ ] 1.1 Add a failing test in `internal/sources/sber_test.go` asserting that a `sber`
+  posting whose feed record has `requisitionId` GUID and numeric `internalId` yields a job
+  with `URL == "https://rabota.sber.ru/search/<internalId>"` and `ExternalID == <requisitionId>`.
+- [ ] 1.2 Add `InternalID int64` (json `internalId`) to `sberVac` and build the job `URL`
+  from it (`sberVacURL` formatted with `%d`); keep `ExternalID` on `RequisitionID`.
+- [ ] 1.3 Run `go test ./internal/sources/` and `go vet ./...` — green.


### PR DESCRIPTION
## Summary

The `sber` adapter built every vacancy's apply URL from the `requisitionId` GUID (`https://rabota.sber.ru/search/<requisitionId>`) — a route that returns **HTTP 404 for every Sber posting**, alive or not. Sber's public vacancy page is addressed only by the numeric `internalId`. So every Sber apply link on freehire was broken, which also made live vacancies look permanently removed.

- Add `InternalID int64` (json `internalId`, already in the feed payload) to `sberVac`.
- Build the job `URL` from `internalId` (`sberVacURL` `%s`→`%d`); `search/<internalId>` 302-redirects to the SEO-slug page.
- Keep `ExternalID` on `requisitionId` — dedup key unchanged, no re-key/duplicates, no migration (`UpsertJob` overwrites `url` on the next crawl).

Discovered while investigating a report that a live "Linux-инженер (SberOS)" vacancy looked gone: the requisitionId URL 404'd, but the vacancy was still in Sber's feed and its `internalId` page returned 200.

### Verified against live Sber data
- `search/<requisitionId>` GUID → 404 for all vacancies
- `search/<internalId>` → 200, redirects to canonical slug page
- Sber keys only on `internalId` (even a wrong slug redirects to the canonical page)

Planned/tracked via OpenSpec change `fix-sber-apply-url` (proposal/design/specs/tasks included).

## Test Plan
- [x] `go test ./internal/sources/ -count=1` — green (updated `TestSberSkipTakePaginatesAndMapsInline` asserts URL uses internalId and ExternalID stays requisitionId)
- [x] `go build ./...` / `go vet ./...` — clean
- [x] `go test ./...` — 0 failures
- [ ] After merge+deploy: next Sber crawl overwrites `url` for existing rows; spot-check an apply link on freehire resolves to a live page