### PR TITLE
feat(search-profiles): multi-specialization + dictionary skill typeahead

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -122,13 +122,13 @@ type SavedSearch struct {
 }
 
 type SearchProfile struct {
-	ID             int64              `json:"id"`
-	UserID         int64              `json:"user_id"`
-	Name           string             `json:"name"`
-	Specialization string             `json:"specialization"`
-	Skills         []string           `json:"skills"`
-	CreatedAt      pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	ID              int64              `json:"id"`
+	UserID          int64              `json:"user_id"`
+	Name            string             `json:"name"`
+	Skills          []string           `json:"skills"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
+	Specializations []string           `json:"specializations"`
 }
 
 type Subscription struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -92,8 +92,8 @@ type Querier interface {
 	// duplicate name (surfaced by the repository as a duplicate-name error). Returns the row.
 	CreateSavedSearch(ctx context.Context, arg CreateSavedSearchParams) (SavedSearch, error)
 	// Create a profile for a user. The UNIQUE (user_id, name) constraint rejects a
-	// duplicate name (surfaced by the repository as a duplicate-name error). Skills are
-	// already normalized by the service. Returns the row.
+	// duplicate name (surfaced by the repository as a duplicate-name error). Specializations
+	// and skills are already normalized by the service. Returns the row.
 	CreateSearchProfile(ctx context.Context, arg CreateSearchProfileParams) (SearchProfile, error)
 	// Insert a user-contributed vacancy into the moderation queue as 'pending'. The partial
 	// unique index on lower(url) WHERE status='pending' rejects a second pending submission of
@@ -404,7 +404,7 @@ type Querier interface {
 	// query string is a real value (not NULL), so "save the unfiltered view" is honored.
 	// No matching owner-scoped row returns no row (the handler maps that to 404).
 	UpdateSavedSearch(ctx context.Context, arg UpdateSavedSearchParams) (SavedSearch, error)
-	// Overwrite a profile's name, specialization, and/or skills, scoped to its owner,
+	// Overwrite a profile's name, specializations, and/or skills, scoped to its owner,
 	// bumping updated_at. Partial update: a NULL param leaves that column unchanged
 	// (COALESCE), so the caller can rename, re-specialize, replace skills, or any
 	// combination in one call. No matching owner-scoped row returns no row (the handler

--- a/internal/db/queries/search_profiles.sql
+++ b/internal/db/queries/search_profiles.sql
@@ -12,23 +12,23 @@ WHERE user_id = $1;
 
 -- name: CreateSearchProfile :one
 -- Create a profile for a user. The UNIQUE (user_id, name) constraint rejects a
--- duplicate name (surfaced by the repository as a duplicate-name error). Skills are
--- already normalized by the service. Returns the row.
-INSERT INTO search_profiles (user_id, name, specialization, skills)
+-- duplicate name (surfaced by the repository as a duplicate-name error). Specializations
+-- and skills are already normalized by the service. Returns the row.
+INSERT INTO search_profiles (user_id, name, specializations, skills)
 VALUES ($1, $2, $3, $4)
 RETURNING *;
 
 -- name: UpdateSearchProfile :one
--- Overwrite a profile's name, specialization, and/or skills, scoped to its owner,
+-- Overwrite a profile's name, specializations, and/or skills, scoped to its owner,
 -- bumping updated_at. Partial update: a NULL param leaves that column unchanged
 -- (COALESCE), so the caller can rename, re-specialize, replace skills, or any
 -- combination in one call. No matching owner-scoped row returns no row (the handler
 -- maps that to 404).
 UPDATE search_profiles
-SET name           = COALESCE(sqlc.narg('name'), name),
-    specialization = COALESCE(sqlc.narg('specialization'), specialization),
-    skills         = COALESCE(sqlc.narg('skills'), skills),
-    updated_at     = now()
+SET name            = COALESCE(sqlc.narg('name'), name),
+    specializations = COALESCE(sqlc.narg('specializations'), specializations),
+    skills          = COALESCE(sqlc.narg('skills'), skills),
+    updated_at      = now()
 WHERE id = sqlc.arg('id') AND user_id = sqlc.arg('user_id')
 RETURNING *;
 

--- a/internal/db/search_profiles.sql.go
+++ b/internal/db/search_profiles.sql.go
@@ -26,26 +26,26 @@ func (q *Queries) CountSearchProfiles(ctx context.Context, userID int64) (int64,
 }
 
 const createSearchProfile = `-- name: CreateSearchProfile :one
-INSERT INTO search_profiles (user_id, name, specialization, skills)
+INSERT INTO search_profiles (user_id, name, specializations, skills)
 VALUES ($1, $2, $3, $4)
-RETURNING id, user_id, name, specialization, skills, created_at, updated_at
+RETURNING id, user_id, name, skills, created_at, updated_at, specializations
 `
 
 type CreateSearchProfileParams struct {
-	UserID         int64    `json:"user_id"`
-	Name           string   `json:"name"`
-	Specialization string   `json:"specialization"`
-	Skills         []string `json:"skills"`
+	UserID          int64    `json:"user_id"`
+	Name            string   `json:"name"`
+	Specializations []string `json:"specializations"`
+	Skills          []string `json:"skills"`
 }
 
 // Create a profile for a user. The UNIQUE (user_id, name) constraint rejects a
-// duplicate name (surfaced by the repository as a duplicate-name error). Skills are
-// already normalized by the service. Returns the row.
+// duplicate name (surfaced by the repository as a duplicate-name error). Specializations
+// and skills are already normalized by the service. Returns the row.
 func (q *Queries) CreateSearchProfile(ctx context.Context, arg CreateSearchProfileParams) (SearchProfile, error) {
 	row := q.db.QueryRow(ctx, createSearchProfile,
 		arg.UserID,
 		arg.Name,
-		arg.Specialization,
+		arg.Specializations,
 		arg.Skills,
 	)
 	var i SearchProfile
@@ -53,10 +53,10 @@ func (q *Queries) CreateSearchProfile(ctx context.Context, arg CreateSearchProfi
 		&i.ID,
 		&i.UserID,
 		&i.Name,
-		&i.Specialization,
 		&i.Skills,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Specializations,
 	)
 	return i, err
 }
@@ -83,7 +83,7 @@ func (q *Queries) DeleteSearchProfile(ctx context.Context, arg DeleteSearchProfi
 }
 
 const listSearchProfiles = `-- name: ListSearchProfiles :many
-SELECT id, user_id, name, specialization, skills, created_at, updated_at FROM search_profiles
+SELECT id, user_id, name, skills, created_at, updated_at, specializations FROM search_profiles
 WHERE user_id = $1
 ORDER BY updated_at DESC
 `
@@ -102,10 +102,10 @@ func (q *Queries) ListSearchProfiles(ctx context.Context, userID int64) ([]Searc
 			&i.ID,
 			&i.UserID,
 			&i.Name,
-			&i.Specialization,
 			&i.Skills,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.Specializations,
 		); err != nil {
 			return nil, err
 		}
@@ -119,23 +119,23 @@ func (q *Queries) ListSearchProfiles(ctx context.Context, userID int64) ([]Searc
 
 const updateSearchProfile = `-- name: UpdateSearchProfile :one
 UPDATE search_profiles
-SET name           = COALESCE($1, name),
-    specialization = COALESCE($2, specialization),
-    skills         = COALESCE($3, skills),
-    updated_at     = now()
+SET name            = COALESCE($1, name),
+    specializations = COALESCE($2, specializations),
+    skills          = COALESCE($3, skills),
+    updated_at      = now()
 WHERE id = $4 AND user_id = $5
-RETURNING id, user_id, name, specialization, skills, created_at, updated_at
+RETURNING id, user_id, name, skills, created_at, updated_at, specializations
 `
 
 type UpdateSearchProfileParams struct {
-	Name           pgtype.Text `json:"name"`
-	Specialization pgtype.Text `json:"specialization"`
-	Skills         []string    `json:"skills"`
-	ID             int64       `json:"id"`
-	UserID         int64       `json:"user_id"`
+	Name            pgtype.Text `json:"name"`
+	Specializations []string    `json:"specializations"`
+	Skills          []string    `json:"skills"`
+	ID              int64       `json:"id"`
+	UserID          int64       `json:"user_id"`
 }
 
-// Overwrite a profile's name, specialization, and/or skills, scoped to its owner,
+// Overwrite a profile's name, specializations, and/or skills, scoped to its owner,
 // bumping updated_at. Partial update: a NULL param leaves that column unchanged
 // (COALESCE), so the caller can rename, re-specialize, replace skills, or any
 // combination in one call. No matching owner-scoped row returns no row (the handler
@@ -143,7 +143,7 @@ type UpdateSearchProfileParams struct {
 func (q *Queries) UpdateSearchProfile(ctx context.Context, arg UpdateSearchProfileParams) (SearchProfile, error) {
 	row := q.db.QueryRow(ctx, updateSearchProfile,
 		arg.Name,
-		arg.Specialization,
+		arg.Specializations,
 		arg.Skills,
 		arg.ID,
 		arg.UserID,
@@ -153,10 +153,10 @@ func (q *Queries) UpdateSearchProfile(ctx context.Context, arg UpdateSearchProfi
 		&i.ID,
 		&i.UserID,
 		&i.Name,
-		&i.Specialization,
 		&i.Skills,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Specializations,
 	)
 	return i, err
 }

--- a/internal/handler/me_profiles.go
+++ b/internal/handler/me_profiles.go
@@ -11,26 +11,26 @@ import (
 )
 
 // searchProfileResponse is the public shape of a search profile. user_id is omitted
-// (ownership, internal). specialization is one job category; skills are canonical
-// lowercase tokens.
+// (ownership, internal). specializations are one or more job categories; skills are
+// canonical lowercase tokens.
 type searchProfileResponse struct {
-	ID             int64      `json:"id"`
-	Name           string     `json:"name"`
-	Specialization string     `json:"specialization"`
-	Skills         []string   `json:"skills"`
-	CreatedAt      *time.Time `json:"created_at"`
-	UpdatedAt      *time.Time `json:"updated_at"`
+	ID              int64      `json:"id"`
+	Name            string     `json:"name"`
+	Specializations []string   `json:"specializations"`
+	Skills          []string   `json:"skills"`
+	CreatedAt       *time.Time `json:"created_at"`
+	UpdatedAt       *time.Time `json:"updated_at"`
 }
 
 // toSearchProfileResponse maps a stored profile to its wire shape (no user id).
 func toSearchProfileResponse(p db.SearchProfile) searchProfileResponse {
 	return searchProfileResponse{
-		ID:             p.ID,
-		Name:           p.Name,
-		Specialization: p.Specialization,
-		Skills:         p.Skills,
-		CreatedAt:      timePtr(p.CreatedAt),
-		UpdatedAt:      timePtr(p.UpdatedAt),
+		ID:              p.ID,
+		Name:            p.Name,
+		Specializations: p.Specializations,
+		Skills:          p.Skills,
+		CreatedAt:       timePtr(p.CreatedAt),
+		UpdatedAt:       timePtr(p.UpdatedAt),
 	}
 }
 
@@ -44,6 +44,10 @@ func searchProfileError(err error) error {
 		return fiber.NewError(fiber.StatusBadRequest, "name must be 1-100 characters")
 	case errors.Is(err, searchprofile.ErrInvalidSpecialization):
 		return fiber.NewError(fiber.StatusBadRequest, "specialization is not a known category")
+	case errors.Is(err, searchprofile.ErrEmptySpecializations):
+		return fiber.NewError(fiber.StatusBadRequest, "at least one specialization is required")
+	case errors.Is(err, searchprofile.ErrTooManySpecializations):
+		return fiber.NewError(fiber.StatusBadRequest, "too many specializations (max 5)")
 	case errors.Is(err, searchprofile.ErrEmptySkills):
 		return fiber.NewError(fiber.StatusBadRequest, "at least one skill is required")
 	case errors.Is(err, searchprofile.ErrDuplicateName):
@@ -57,21 +61,22 @@ func searchProfileError(err error) error {
 	}
 }
 
-// createSearchProfileRequest is the create body: a required display name, a specialization
-// (one job category), and a non-empty set of skills.
+// createSearchProfileRequest is the create body: a required display name, a non-empty set
+// of specializations (job categories), and a non-empty set of skills.
 type createSearchProfileRequest struct {
-	Name           string   `json:"name"`
-	Specialization string   `json:"specialization"`
-	Skills         []string `json:"skills"`
+	Name            string   `json:"name"`
+	Specializations []string `json:"specializations"`
+	Skills          []string `json:"skills"`
 }
 
-// updateSearchProfileRequest is the partial-update body: a nil name/specialization or an
-// omitted skills field is left unchanged, so a caller can rename, re-specialize, replace
-// skills, or any combination. A provided-but-empty skills array is rejected (400).
+// updateSearchProfileRequest is the partial-update body: a nil name or an omitted
+// specializations/skills field is left unchanged, so a caller can rename, re-specialize,
+// replace skills, or any combination. A provided-but-empty specializations/skills array is
+// rejected (400).
 type updateSearchProfileRequest struct {
-	Name           *string  `json:"name"`
-	Specialization *string  `json:"specialization"`
-	Skills         []string `json:"skills"`
+	Name            *string  `json:"name"`
+	Specializations []string `json:"specializations"`
+	Skills          []string `json:"skills"`
 }
 
 // CreateSearchProfile stores a named profile (specialization + skills) for the
@@ -88,7 +93,7 @@ func (a *API) CreateSearchProfile(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
 
-	profile, err := a.searchProfile.Create(c.Context(), userID, in.Name, in.Specialization, in.Skills)
+	profile, err := a.searchProfile.Create(c.Context(), userID, in.Name, in.Specializations, in.Skills)
 	if err != nil {
 		return searchProfileError(err)
 	}
@@ -132,7 +137,7 @@ func (a *API) UpdateSearchProfile(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
 
-	profile, err := a.searchProfile.Update(c.Context(), userID, id, in.Name, in.Specialization, in.Skills)
+	profile, err := a.searchProfile.Update(c.Context(), userID, id, in.Name, in.Specializations, in.Skills)
 	if err != nil {
 		return searchProfileError(err)
 	}

--- a/internal/handler/me_profiles_test.go
+++ b/internal/handler/me_profiles_test.go
@@ -1,0 +1,162 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/searchprofile"
+)
+
+// fakeProfileRepo is a searchprofile.Repository that returns a canned created row and
+// records nothing else — enough to exercise the handler's request parsing and the
+// specialization/skills validation (which reject before Create/Count are reached) without
+// a database. The DB-backed contract is covered by the service's own tests.
+type fakeProfileRepo struct {
+	createRet db.SearchProfile
+	updateRet db.SearchProfile
+	updated   db.UpdateSearchProfileParams
+}
+
+func (f *fakeProfileRepo) List(context.Context, int64) ([]db.SearchProfile, error) {
+	return nil, nil
+}
+func (f *fakeProfileRepo) Count(context.Context, int64) (int64, error) { return 0, nil }
+func (f *fakeProfileRepo) Create(context.Context, db.CreateSearchProfileParams) (db.SearchProfile, error) {
+	return f.createRet, nil
+}
+func (f *fakeProfileRepo) Update(_ context.Context, p db.UpdateSearchProfileParams) (db.SearchProfile, error) {
+	f.updated = p
+	return f.updateRet, nil
+}
+func (f *fakeProfileRepo) Delete(context.Context, db.DeleteSearchProfileParams) error { return nil }
+
+// profilesApp mounts the create/update endpoints behind RequireAuth on a handler whose
+// search-profile service is backed by the given in-memory fake repo.
+func profilesApp(t *testing.T, repo *fakeProfileRepo) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &API{issuer: iss, searchProfile: searchprofile.New(repo)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Post("/me/profiles", auth.RequireAuth(iss), h.CreateSearchProfile)
+	app.Patch("/me/profiles/:id", auth.RequireAuth(iss), h.UpdateSearchProfile)
+	return app, token
+}
+
+func patchProfile(t *testing.T, app *fiber.App, id, body, token string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodPatch, "/me/profiles/"+id, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	return resp
+}
+
+func postProfile(t *testing.T, app *fiber.App, body, token string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodPost, "/me/profiles", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	return resp
+}
+
+func TestCreateSearchProfile_Unauthenticated(t *testing.T) {
+	app, _ := profilesApp(t, &fakeProfileRepo{})
+	resp := postProfile(t, app, `{"name":"X","specializations":["backend"],"skills":["go"]}`, "")
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestCreateSearchProfile_ValidationErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"empty specializations", `{"name":"X","specializations":[],"skills":["go"]}`, fiber.StatusBadRequest},
+		{"unknown specialization", `{"name":"X","specializations":["wizardry"],"skills":["go"]}`, fiber.StatusBadRequest},
+		{"too many specializations", `{"name":"X","specializations":["backend","frontend","fullstack","mobile","devops","sre"],"skills":["go"]}`, fiber.StatusBadRequest},
+		{"empty skills", `{"name":"X","specializations":["backend"],"skills":[]}`, fiber.StatusBadRequest},
+		{"blank name", `{"name":"  ","specializations":["backend"],"skills":["go"]}`, fiber.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app, token := profilesApp(t, &fakeProfileRepo{})
+			resp := postProfile(t, app, tc.body, token)
+			if resp.StatusCode != tc.want {
+				t.Errorf("status = %d, want %d", resp.StatusCode, tc.want)
+			}
+		})
+	}
+}
+
+func TestCreateSearchProfile_ReturnsSpecializationsArray(t *testing.T) {
+	ret := db.SearchProfile{ID: 42, Name: "Go backend", Specializations: []string{"backend", "devops"}, Skills: []string{"go"}}
+	app, token := profilesApp(t, &fakeProfileRepo{createRet: ret})
+	resp := postProfile(t, app, `{"name":"Go backend","specializations":["backend","devops"],"skills":["go"]}`, token)
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("status = %d, want 201", resp.StatusCode)
+	}
+	var got struct {
+		Data searchProfileResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if strings.Join(got.Data.Specializations, ",") != "backend,devops" {
+		t.Errorf("specializations = %v, want [backend devops]", got.Data.Specializations)
+	}
+}
+
+func TestUpdateSearchProfile_RejectsEmptySpecializations(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	app, token := profilesApp(t, repo)
+	resp := patchProfile(t, app, "5", `{"specializations":[]}`, token)
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if repo.updated.ID != 0 {
+		t.Error("repo.Update should not be called on an empty specializations array")
+	}
+}
+
+func TestUpdateSearchProfile_RenameOnly_LeavesArraysUnchanged(t *testing.T) {
+	repo := &fakeProfileRepo{updateRet: db.SearchProfile{ID: 5, Name: "Renamed", Specializations: []string{"backend"}, Skills: []string{"go"}}}
+	app, token := profilesApp(t, repo)
+	resp := patchProfile(t, app, "5", `{"name":"Renamed"}`, token)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	// A rename-only PATCH leaves specializations/skills as nil params (SQL NULL →
+	// COALESCE keeps the stored value), mirroring the pre-existing skills behavior.
+	if repo.updated.Specializations != nil {
+		t.Errorf("Specializations param = %v, want nil (unchanged)", repo.updated.Specializations)
+	}
+	if repo.updated.Skills != nil {
+		t.Errorf("Skills param = %v, want nil (unchanged)", repo.updated.Skills)
+	}
+}

--- a/internal/searchprofile/searchprofile.go
+++ b/internal/searchprofile/searchprofile.go
@@ -1,10 +1,10 @@
 // Package searchprofile is the per-user search-profile use case: a signed-in user names a
-// record of their professional self — one specialization (a job category) and a non-empty
-// set of skills — and can list, create, overwrite, and delete those profiles. It owns
-// validation (name bounds, the specialization vocabulary, skill normalization, the
-// per-user cap); the Repository owns persistence and maps the relevant Postgres conditions
-// (unique violation, no row) onto the package sentinels. How a profile is consumed (match
-// scoring, ranked feeds, notifications) lives outside this package.
+// record of their professional self — a non-empty set of specializations (job categories)
+// and a non-empty set of skills — and can list, create, overwrite, and delete those
+// profiles. It owns validation (name bounds, the specialization vocabulary and cap, skill
+// normalization, the per-user cap); the Repository owns persistence and maps the relevant
+// Postgres conditions (unique violation, no row) onto the package sentinels. How a profile
+// is consumed (match scoring, ranked feeds, notifications) lives outside this package.
 package searchprofile
 
 import (
@@ -27,6 +27,11 @@ var (
 	// ErrInvalidSpecialization is a specialization outside the category vocabulary
 	// (mapped to 400).
 	ErrInvalidSpecialization = errors.New("searchprofile: specialization is not a known category")
+	// ErrEmptySpecializations is a profile whose specializations are empty after
+	// normalization (mapped to 400).
+	ErrEmptySpecializations = errors.New("searchprofile: at least one specialization is required")
+	// ErrTooManySpecializations is a specialization set past maxSpecializations (mapped to 400).
+	ErrTooManySpecializations = errors.New("searchprofile: too many specializations")
 	// ErrEmptySkills is a profile whose skills are empty after normalization (mapped to 400).
 	ErrEmptySkills = errors.New("searchprofile: at least one skill is required")
 	// ErrDuplicateName is a name the user already uses (the UNIQUE (user_id, name)
@@ -43,6 +48,9 @@ const (
 	maxNameLen = 100
 	// maxPerUser caps how many profiles a single user may keep.
 	maxPerUser = 50
+	// maxSpecializations caps how many specializations one profile may combine; the
+	// migration's cardinality CHECK is the backstop.
+	maxSpecializations = 5
 )
 
 // Repository is the persistence contract for search profiles. Every method is
@@ -73,15 +81,15 @@ func (s *Service) List(ctx context.Context, userID int64) ([]db.SearchProfile, e
 }
 
 // Create validates and stores a profile for the user. The name is trimmed and bounded; the
-// specialization must be a known category; the skills are normalized and must be non-empty;
-// the per-user cap is checked before the insert; a duplicate name surfaces as
-// ErrDuplicateName (mapped by the repository).
-func (s *Service) Create(ctx context.Context, userID int64, name, specialization string, skills []string) (db.SearchProfile, error) {
+// specializations are normalized (each a known category, deduped, non-empty, capped); the
+// skills are normalized and must be non-empty; the per-user cap is checked before the
+// insert; a duplicate name surfaces as ErrDuplicateName (mapped by the repository).
+func (s *Service) Create(ctx context.Context, userID int64, name string, specializations, skills []string) (db.SearchProfile, error) {
 	name, err := validName(name)
 	if err != nil {
 		return db.SearchProfile{}, err
 	}
-	specialization, err = validSpecialization(specialization)
+	specs, err := normalizeSpecializations(specializations)
 	if err != nil {
 		return db.SearchProfile{}, err
 	}
@@ -97,19 +105,20 @@ func (s *Service) Create(ctx context.Context, userID int64, name, specialization
 		return db.SearchProfile{}, ErrCapExceeded
 	}
 	return s.repo.Create(ctx, db.CreateSearchProfileParams{
-		UserID:         userID,
-		Name:           name,
-		Specialization: specialization,
-		Skills:         normalized,
+		UserID:          userID,
+		Name:            name,
+		Specializations: specs,
+		Skills:          normalized,
 	})
 }
 
-// Update overwrites a profile's name, specialization, and/or skills, scoped to its owner.
-// A nil name/specialization pointer or a nil skills slice leaves that column unchanged
-// (partial update). A provided name is validated; a provided specialization must be a
-// known category; provided skills are normalized and must be non-empty. A missing or
-// non-owned row surfaces as ErrNotFound (mapped by the repository).
-func (s *Service) Update(ctx context.Context, userID, id int64, name, specialization *string, skills []string) (db.SearchProfile, error) {
+// Update overwrites a profile's name, specializations, and/or skills, scoped to its owner.
+// A nil name pointer or a nil specializations/skills slice leaves that column unchanged
+// (partial update). A provided name is validated; provided specializations must each be a
+// known category and are deduped, non-empty, and capped; provided skills are normalized and
+// must be non-empty. A missing or non-owned row surfaces as ErrNotFound (mapped by the
+// repository).
+func (s *Service) Update(ctx context.Context, userID, id int64, name *string, specializations, skills []string) (db.SearchProfile, error) {
 	p := db.UpdateSearchProfileParams{ID: id, UserID: userID}
 	if name != nil {
 		valid, err := validName(*name)
@@ -118,12 +127,12 @@ func (s *Service) Update(ctx context.Context, userID, id int64, name, specializa
 		}
 		p.Name = pgtype.Text{String: valid, Valid: true}
 	}
-	if specialization != nil {
-		valid, err := validSpecialization(*specialization)
+	if specializations != nil {
+		specs, err := normalizeSpecializations(specializations)
 		if err != nil {
 			return db.SearchProfile{}, err
 		}
-		p.Specialization = pgtype.Text{String: valid, Valid: true}
+		p.Specializations = specs
 	}
 	if skills != nil {
 		normalized, err := normalizeSkills(skills)
@@ -152,15 +161,35 @@ func validName(name string) (string, error) {
 	return name, nil
 }
 
-// validSpecialization trims the value and checks membership in the controlled category
-// vocabulary (the same enum the rest of the app validates against), returning the trimmed
-// value or ErrInvalidSpecialization.
-func validSpecialization(specialization string) (string, error) {
-	specialization = strings.TrimSpace(specialization)
-	if !slices.Contains(enrich.CategoryValues, specialization) {
-		return "", ErrInvalidSpecialization
+// normalizeSpecializations trims each value, drops blanks, deduplicates (preserving
+// first-seen order), and checks membership in the controlled category vocabulary (the same
+// enum the rest of the app validates against). It returns ErrEmptySpecializations if nothing
+// remains, ErrInvalidSpecialization for an unknown category, and ErrTooManySpecializations
+// past maxSpecializations — mirroring normalizeSkills.
+func normalizeSpecializations(specializations []string) ([]string, error) {
+	out := make([]string, 0, len(specializations))
+	seen := make(map[string]struct{}, len(specializations))
+	for _, raw := range specializations {
+		spec := strings.TrimSpace(raw)
+		if spec == "" {
+			continue
+		}
+		if _, dup := seen[spec]; dup {
+			continue
+		}
+		if !slices.Contains(enrich.CategoryValues, spec) {
+			return nil, ErrInvalidSpecialization
+		}
+		seen[spec] = struct{}{}
+		out = append(out, spec)
 	}
-	return specialization, nil
+	if len(out) == 0 {
+		return nil, ErrEmptySpecializations
+	}
+	if len(out) > maxSpecializations {
+		return nil, ErrTooManySpecializations
+	}
+	return out, nil
 }
 
 // normalizeSkills lowercases, trims, and deduplicates the skills (preserving first-seen

--- a/internal/searchprofile/searchprofile_test.go
+++ b/internal/searchprofile/searchprofile_test.go
@@ -58,11 +58,12 @@ func (f *fakeRepo) Delete(_ context.Context, p db.DeleteSearchProfileParams) err
 
 func ptr(s string) *string { return &s }
 
-func TestCreate_PersistsWithOwnerTrimmedNameAndNormalizedSkills(t *testing.T) {
+func TestCreate_PersistsWithOwnerTrimmedNameNormalizedSpecializationsAndSkills(t *testing.T) {
 	repo := &fakeRepo{createRet: db.SearchProfile{ID: 1}}
 	svc := searchprofile.New(repo)
 
-	_, err := svc.Create(context.Background(), 7, "  Go backend  ", "backend", []string{"Go", " PostgreSQL ", "go"})
+	_, err := svc.Create(context.Background(), 7, "  Go backend  ",
+		[]string{" backend ", "devops", "backend"}, []string{"Go", " PostgreSQL ", "go"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -75,12 +76,13 @@ func TestCreate_PersistsWithOwnerTrimmedNameAndNormalizedSkills(t *testing.T) {
 	if repo.created.Name != "Go backend" {
 		t.Errorf("Name = %q, want trimmed %q", repo.created.Name, "Go backend")
 	}
-	if repo.created.Specialization != "backend" {
-		t.Errorf("Specialization = %q, want backend", repo.created.Specialization)
+	wantSpec := []string{"backend", "devops"}
+	if strings.Join(repo.created.Specializations, ",") != strings.Join(wantSpec, ",") {
+		t.Errorf("Specializations = %v, want trimmed/deduped %v", repo.created.Specializations, wantSpec)
 	}
-	want := []string{"go", "postgresql"}
-	if strings.Join(repo.created.Skills, ",") != strings.Join(want, ",") {
-		t.Errorf("Skills = %v, want lowercased/trimmed/deduped %v", repo.created.Skills, want)
+	wantSkills := []string{"go", "postgresql"}
+	if strings.Join(repo.created.Skills, ",") != strings.Join(wantSkills, ",") {
+		t.Errorf("Skills = %v, want lowercased/trimmed/deduped %v", repo.created.Skills, wantSkills)
 	}
 }
 
@@ -96,7 +98,7 @@ func TestCreate_RejectsInvalidName(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &fakeRepo{}
-			_, err := searchprofile.New(repo).Create(context.Background(), 7, tc.in, "backend", []string{"go"})
+			_, err := searchprofile.New(repo).Create(context.Background(), 7, tc.in, []string{"backend"}, []string{"go"})
 			if !errors.Is(err, searchprofile.ErrInvalidName) {
 				t.Errorf("err = %v, want ErrInvalidName", err)
 			}
@@ -109,7 +111,7 @@ func TestCreate_RejectsInvalidName(t *testing.T) {
 
 func TestCreate_NameLengthCountsRunes(t *testing.T) {
 	repo := &fakeRepo{createRet: db.SearchProfile{ID: 1}}
-	if _, err := searchprofile.New(repo).Create(context.Background(), 7, strings.Repeat("я", 100), "backend", []string{"go"}); err != nil {
+	if _, err := searchprofile.New(repo).Create(context.Background(), 7, strings.Repeat("я", 100), []string{"backend"}, []string{"go"}); err != nil {
 		t.Errorf("100-rune name: err = %v, want nil", err)
 	}
 	if !repo.createCalled {
@@ -117,19 +119,54 @@ func TestCreate_NameLengthCountsRunes(t *testing.T) {
 	}
 
 	repo = &fakeRepo{}
-	if _, err := searchprofile.New(repo).Create(context.Background(), 7, strings.Repeat("я", 101), "backend", []string{"go"}); !errors.Is(err, searchprofile.ErrInvalidName) {
+	if _, err := searchprofile.New(repo).Create(context.Background(), 7, strings.Repeat("я", 101), []string{"backend"}, []string{"go"}); !errors.Is(err, searchprofile.ErrInvalidName) {
 		t.Errorf("101-rune name: err = %v, want ErrInvalidName", err)
 	}
 }
 
 func TestCreate_RejectsUnknownSpecialization(t *testing.T) {
 	repo := &fakeRepo{}
-	_, err := searchprofile.New(repo).Create(context.Background(), 7, "Bad", "wizardry", []string{"go"})
+	_, err := searchprofile.New(repo).Create(context.Background(), 7, "Bad", []string{"backend", "wizardry"}, []string{"go"})
 	if !errors.Is(err, searchprofile.ErrInvalidSpecialization) {
 		t.Errorf("err = %v, want ErrInvalidSpecialization", err)
 	}
 	if repo.createCalled {
 		t.Error("repo.Create should not be called on an unknown specialization")
+	}
+}
+
+func TestCreate_RejectsEmptySpecializations(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+	}{
+		{"nil", nil},
+		{"empty slice", []string{}},
+		{"only blanks", []string{"  ", ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &fakeRepo{}
+			_, err := searchprofile.New(repo).Create(context.Background(), 7, "Empty", tc.in, []string{"go"})
+			if !errors.Is(err, searchprofile.ErrEmptySpecializations) {
+				t.Errorf("err = %v, want ErrEmptySpecializations", err)
+			}
+			if repo.createCalled {
+				t.Error("repo.Create should not be called on empty specializations")
+			}
+		})
+	}
+}
+
+func TestCreate_RejectsTooManySpecializations(t *testing.T) {
+	repo := &fakeRepo{}
+	six := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre"}
+	_, err := searchprofile.New(repo).Create(context.Background(), 7, "Too many", six, []string{"go"})
+	if !errors.Is(err, searchprofile.ErrTooManySpecializations) {
+		t.Errorf("err = %v, want ErrTooManySpecializations", err)
+	}
+	if repo.createCalled {
+		t.Error("repo.Create should not be called past the specialization cap")
 	}
 }
 
@@ -145,7 +182,7 @@ func TestCreate_RejectsEmptySkills(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &fakeRepo{}
-			_, err := searchprofile.New(repo).Create(context.Background(), 7, "Empty", "backend", tc.in)
+			_, err := searchprofile.New(repo).Create(context.Background(), 7, "Empty", []string{"backend"}, tc.in)
 			if !errors.Is(err, searchprofile.ErrEmptySkills) {
 				t.Errorf("err = %v, want ErrEmptySkills", err)
 			}
@@ -158,7 +195,7 @@ func TestCreate_RejectsEmptySkills(t *testing.T) {
 
 func TestCreate_EnforcesCap(t *testing.T) {
 	repo := &fakeRepo{count: 50} // already at the cap
-	_, err := searchprofile.New(repo).Create(context.Background(), 7, "One more", "backend", []string{"go"})
+	_, err := searchprofile.New(repo).Create(context.Background(), 7, "One more", []string{"backend"}, []string{"go"})
 	if !errors.Is(err, searchprofile.ErrCapExceeded) {
 		t.Errorf("err = %v, want ErrCapExceeded", err)
 	}
@@ -169,7 +206,7 @@ func TestCreate_EnforcesCap(t *testing.T) {
 
 func TestCreate_PropagatesDuplicateName(t *testing.T) {
 	repo := &fakeRepo{createErr: searchprofile.ErrDuplicateName}
-	_, err := searchprofile.New(repo).Create(context.Background(), 7, "Dup", "backend", []string{"go"})
+	_, err := searchprofile.New(repo).Create(context.Background(), 7, "Dup", []string{"backend"}, []string{"go"})
 	if !errors.Is(err, searchprofile.ErrDuplicateName) {
 		t.Errorf("err = %v, want ErrDuplicateName", err)
 	}
@@ -192,11 +229,23 @@ func TestUpdate_PartialRename_LeavesOtherFieldsUnchanged(t *testing.T) {
 	if !repo.updated.Name.Valid || repo.updated.Name.String != "Renamed" {
 		t.Errorf("Name param = %+v, want trimmed valid %q", repo.updated.Name, "Renamed")
 	}
-	if repo.updated.Specialization.Valid {
-		t.Error("Specialization param should be NULL (unchanged) when not provided")
+	if repo.updated.Specializations != nil {
+		t.Error("Specializations param should be nil (unchanged) when not provided")
 	}
 	if repo.updated.Skills != nil {
 		t.Error("Skills param should be nil (unchanged) when not provided")
+	}
+}
+
+func TestUpdate_ReplaceSpecializations_Normalized(t *testing.T) {
+	repo := &fakeRepo{updateRet: db.SearchProfile{ID: 5}}
+	_, err := searchprofile.New(repo).Update(context.Background(), 7, 5, nil, []string{" devops ", "sre", "devops"}, nil)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	want := []string{"devops", "sre"}
+	if strings.Join(repo.updated.Specializations, ",") != strings.Join(want, ",") {
+		t.Errorf("Specializations param = %v, want %v", repo.updated.Specializations, want)
 	}
 }
 
@@ -225,12 +274,35 @@ func TestUpdate_RejectsInvalidName(t *testing.T) {
 
 func TestUpdate_RejectsUnknownSpecialization(t *testing.T) {
 	repo := &fakeRepo{}
-	_, err := searchprofile.New(repo).Update(context.Background(), 7, 5, nil, ptr("wizardry"), nil)
+	_, err := searchprofile.New(repo).Update(context.Background(), 7, 5, nil, []string{"wizardry"}, nil)
 	if !errors.Is(err, searchprofile.ErrInvalidSpecialization) {
 		t.Errorf("err = %v, want ErrInvalidSpecialization", err)
 	}
 	if repo.updateCalled {
 		t.Error("repo.Update should not be called on an unknown specialization")
+	}
+}
+
+func TestUpdate_RejectsEmptySpecializationsWhenProvided(t *testing.T) {
+	repo := &fakeRepo{}
+	_, err := searchprofile.New(repo).Update(context.Background(), 7, 5, nil, []string{"  ", ""}, nil)
+	if !errors.Is(err, searchprofile.ErrEmptySpecializations) {
+		t.Errorf("err = %v, want ErrEmptySpecializations", err)
+	}
+	if repo.updateCalled {
+		t.Error("repo.Update should not be called when provided specializations reduce to empty")
+	}
+}
+
+func TestUpdate_RejectsTooManySpecializations(t *testing.T) {
+	repo := &fakeRepo{}
+	six := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre"}
+	_, err := searchprofile.New(repo).Update(context.Background(), 7, 5, nil, six, nil)
+	if !errors.Is(err, searchprofile.ErrTooManySpecializations) {
+		t.Errorf("err = %v, want ErrTooManySpecializations", err)
+	}
+	if repo.updateCalled {
+		t.Error("repo.Update should not be called past the specialization cap")
 	}
 }
 

--- a/migrations/0029_search_profiles_specializations.sql
+++ b/migrations/0029_search_profiles_specializations.sql
@@ -1,0 +1,36 @@
+-- A search profile now captures several specializations, not one: people combine roles
+-- (e.g. "Go backend" and "DevOps"). This converts the single `specialization TEXT` column
+-- into a `specializations TEXT[]` set, mirroring the existing `skills TEXT[]` (same
+-- normalization and CHECK-as-backstop shape). Each existing row's single value becomes a
+-- one-element set, so the change is lossless. Like every migration here it applies on fresh
+-- volume init and is the schema source for sqlc; existing volumes/prod need a manual apply
+-- (the versioned-migration-runner seam from AGENT.md remains open) — apply this BEFORE
+-- rolling the new server binary, which references the new column.
+
+ALTER TABLE search_profiles
+    ADD COLUMN specializations TEXT[] NOT NULL DEFAULT '{}';
+
+-- Backfill each existing single specialization into a one-element set.
+UPDATE search_profiles
+SET specializations = ARRAY[specialization];
+
+-- Drop the seeding default now that every row is populated; the set is validated (each a
+-- known category) in the service and bounded here as a backstop.
+ALTER TABLE search_profiles
+    ALTER COLUMN specializations DROP DEFAULT;
+
+ALTER TABLE search_profiles
+    ADD CONSTRAINT search_profiles_specializations_card_chk
+        CHECK (cardinality(specializations) BETWEEN 1 AND 5);
+
+ALTER TABLE search_profiles
+    DROP COLUMN specialization;
+
+-- Rollback (inverse), if ever needed:
+--   ALTER TABLE search_profiles ADD COLUMN specialization TEXT NOT NULL DEFAULT '';
+--   UPDATE search_profiles SET specialization = specializations[1];
+--   ALTER TABLE search_profiles ALTER COLUMN specialization DROP DEFAULT;
+--   ALTER TABLE search_profiles ADD CONSTRAINT search_profiles_specialization_chk
+--       CHECK (length(trim(specialization)) > 0);
+--   ALTER TABLE search_profiles DROP CONSTRAINT search_profiles_specializations_card_chk;
+--   ALTER TABLE search_profiles DROP COLUMN specializations;

--- a/openspec/changes/search-profiles-multi-spec/.openspec.yaml
+++ b/openspec/changes/search-profiles-multi-spec/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/search-profiles-multi-spec/design.md
+++ b/openspec/changes/search-profiles-multi-spec/design.md
@@ -1,0 +1,96 @@
+## Context
+
+A search profile (`search_profiles` table, `internal/searchprofile` service,
+`internal/handler/me_profiles.go`, and the SPA's `SearchProfilesView.svelte`) stores one
+`specialization TEXT` and a `skills TEXT[]`. The skills column is already free-text at the
+DB/service layer (only lowercased, trimmed, deduplicated — no vocabulary check); the
+frontend, however, restricts skill entry to a select-only pill wall built from the live
+skills facet distribution. That mismatch plus the "at least one skill" Create gate is what
+makes the form appear un-submittable when a user can't spot their skill.
+
+This change turns the single specialization into a capped, non-empty set and replaces the
+skills pill wall with a dictionary-backed typeahead, both reusing components the SPA
+already ships.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A profile holds 1..5 specializations, each a valid `enrich.CategoryValues` category.
+- Skills entry is a typeahead over the canonical skill dictionary with job counts and
+  removable chips (dictionary-only — no free-text additions).
+- The Create/Save control is enabled exactly when name + ≥1 specialization + ≥1 skill are
+  present, with no silent dead-end.
+- Existing profiles migrate losslessly (single specialization → single-element set).
+
+**Non-Goals:**
+- How profiles are consumed (matching, feeds, notifications) — still out of scope.
+- Making skills open-vocabulary (the user chose dictionary-only).
+- A versioned migration runner (the standing seam; prod applies SQL manually).
+
+## Decisions
+
+### 1. Data model: rename `specialization` → `specializations TEXT[]`, don't add a join table
+A `TEXT[]` mirrors the existing `skills TEXT[]` exactly (same normalization, same CHECK
+backstop, same sqlc mapping to `[]string`), so the service, queries, and handler stay
+symmetric and simple. A join table would add ordering/uniqueness machinery for no gain at
+this scale (≤5 values per profile, no querying by specialization yet).
+- *Alternative — keep `specialization` + add `extra_specializations`*: rejected, awkward
+  and asymmetric.
+- *Alternative — join table `search_profile_specializations`*: rejected as over-engineering
+  for the current need (the deterministic-facet columns elsewhere use `TEXT[]` too).
+
+### 2. New migration `0029`, not an edit to `0028`
+Migrations apply only on fresh volume init and `0028` already shipped, so editing it would
+desync any persistent DB. `0029` ALTERs the table: add `specializations TEXT[]`, backfill
+`ARRAY[specialization]`, add the `cardinality BETWEEN 1 AND 5` CHECK, drop the old column.
+Prod applies it manually (per the deploy convention).
+
+### 3. Service validation mirrors `normalizeSkills`
+Add `normalizeSpecializations([]string) ([]string, error)`: trim each, drop blanks, reject
+any value outside `enrich.CategoryValues`, dedupe preserving first-seen order, require
+≥1 and ≤5. `Create`/`Update` signatures change `specialization string` →
+`specializations []string`; `Update` treats a nil slice as "unchanged" and a
+provided-but-empty slice as an error (same as skills). Sentinels: replace
+`ErrInvalidSpecialization` semantics and add `ErrEmptySpecializations` /
+`ErrTooManySpecializations`, all mapped to `400`.
+
+### 4. Frontend reuse: `SearchSelect` (multi) for specializations, `RemoteSearchSelect` for skills
+`SearchSelect` is already a searchable multi-select — the specialization input becomes an
+array + toggle with a client-side cap of 5. `RemoteSearchSelect` is already the
+typeahead-with-chips pattern; its `search(query)` is backed by a **local** filter over the
+already-loaded skill distribution (wrapped in a resolved promise), so there's no new
+endpoint and the dictionary-only rule is enforced by construction (only listed options are
+addable). This directly fixes the dead-end: typing surfaces matches and adds chips.
+
+### 5. Wire shape is a hard rename (BREAKING), updated in lockstep
+`specialization: string` → `specializations: string[]` across `types.ts`, `api.ts`,
+`searchProfiles.svelte.ts`, and the view. The SPA is the only consumer and ships together,
+so no compatibility shim is warranted.
+
+## Risks / Trade-offs
+
+- **Prod migration is manual** → document `0029` in the change and call it out at finish;
+  until applied, the new code's queries reference `specializations` and would error against
+  the old column. Deploy migration before the new binary.
+- **Breaking wire change** → the only client is the bundled SPA, updated in the same
+  change; no external API consumers exist for `/me/profiles`.
+- **Dictionary-only skills keep a narrow dead-end** (a skill absent from the 268-token
+  dictionary still can't be added) → accepted per product decision; mitigated by a clear
+  "nothing found" hint so it's explicit, not silent.
+- **Skill distribution fails to load** → the typeahead shows no suggestions; on edit the
+  profile's existing skills still render as chips (seeded into the picker), so they remain
+  removable.
+
+## Migration Plan
+
+1. Ship `migrations/0029_search_profiles_specializations.sql`; run `make sqlc`.
+2. Deploy: apply `0029` to prod via manual `psql` **before** rolling the new server binary
+   (the new queries require the new column).
+3. Rollback: `0029` is additive-then-destructive; a rollback needs the inverse SQL
+   (re-add `specialization TEXT`, backfill `specializations[1]`, drop `specializations`).
+   Capture it in the task notes.
+
+## Open Questions
+
+- None. Specialization cap fixed at 5; skills remain dictionary-only per the product
+  decisions taken during proposal.

--- a/openspec/changes/search-profiles-multi-spec/notes.md
+++ b/openspec/changes/search-profiles-multi-spec/notes.md
@@ -26,6 +26,20 @@ restriction is purely a frontend artifact of the select-only picker.
 multi-select. Product decision keeps skills dictionary-only, so the "nothing found" case is
 shown explicitly rather than silently dead-ending.
 
+## Verification (task 7.2) — real-Postgres E2E
+
+Brought up the worktree's Postgres on a fresh volume (migration 0029 ran automatically:
+`\d search_profiles` shows `specializations text[]`, no `specialization` column, and the
+`cardinality BETWEEN 1 AND 5` CHECK) and ran the Go server on host. Round-trip via the API
+with a cookie session:
+- create `{"specializations":["backend","devops"],"skills":["Go","Docker","go"]}` → 201,
+  stored `["backend","devops"]` + normalized `["go","docker"]`.
+- rename-only PATCH `{"name":...}` → 200, **specializations/skills unchanged** (empirically
+  refutes review #1: a nil `[]string` param encodes as SQL NULL, so COALESCE keeps the
+  stored array — same proven pattern as the pre-existing `skills`).
+- specs-only PATCH → 200, skills unchanged.
+- empty `[]` → 400; six specializations → 400; unknown category → 400.
+
 ## Prod migration reminder (task 7.3)
 
 Apply `migrations/0029_search_profiles_specializations.sql` via manual `psql` **before**

--- a/openspec/changes/search-profiles-multi-spec/notes.md
+++ b/openspec/changes/search-profiles-multi-spec/notes.md
@@ -1,0 +1,33 @@
+# Implementation notes
+
+## Task 1.1 — root cause of the inactive Create button (systematic-debugging Phase 1)
+
+**Symptom:** on `/my/profiles` the "Create profile" button never enables.
+
+**Mechanism (traced in `web/src/lib/components/SearchProfilesView.svelte`):**
+- The button is disabled unless
+  `canSubmit = name.trim() !== '' && specialization !== '' && skills.length > 0`.
+- Skills can only be added by `toggleSkill`, which is called by the `SearchSelect` pill
+  wall **for options that already exist** in `skillOptions` (= `skillDist`, the live skills
+  facet distribution + any already-selected skills on edit). There is **no code path that
+  adds a typed value**.
+- Therefore, if the user's desired skill is not among the canonical dictionary tokens, the
+  filter shows "Nothing found", nothing is selectable, `skills.length` stays `0`, and
+  `canSubmit` is permanently `false`.
+
+**Evidence:** the live facet endpoint returns 268 canonical skills
+(`GET /api/v1/jobs/facets` → `data.facets.skills`), so the dictionary loads in prod — the
+dead-end is specifically "skill absent from the dictionary". The backend does **not**
+restrict skills to a vocabulary (`normalizeSkills` only lowercases/trims/dedupes), so the
+restriction is purely a frontend artifact of the select-only picker.
+
+**Fix (this change):** replace the skills pill wall with a dictionary-backed typeahead
+(`RemoteSearchSelect`) that surfaces matching skills as chips, and make specialization a
+multi-select. Product decision keeps skills dictionary-only, so the "nothing found" case is
+shown explicitly rather than silently dead-ending.
+
+## Prod migration reminder (task 7.3)
+
+Apply `migrations/0029_search_profiles_specializations.sql` via manual `psql` **before**
+rolling the new server binary — the new sqlc queries reference the `specializations`
+column. Rollback SQL is captured as a comment in the migration file.

--- a/openspec/changes/search-profiles-multi-spec/proposal.md
+++ b/openspec/changes/search-profiles-multi-spec/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+A search profile today captures exactly **one** specialization, but real people combine
+roles (e.g. "Go backend **and** DevOps") — the single-value model can't express that.
+Worse, the skills picker is a select-only pill wall over the canonical dictionary: when a
+user can't spot the skill they want they select nothing, and because the Create button is
+gated on "at least one skill", the form becomes a dead-end that never enables. This change
+lets a profile hold several specializations and replaces the skills pill wall with a
+typeahead ("search with autosuggestions") so the required inputs are always reachable.
+
+## What Changes
+
+- **BREAKING** A profile's single `specialization` (a string) becomes `specializations`
+  (a non-empty, capped set of job categories). The DB column, the sqlc queries, the
+  service, the JSON request/response, and the TS types all move from one value to a set.
+- The service validates every specialization against the category vocabulary
+  (`enrich.CategoryValues`), trims and deduplicates them, requires at least one, and caps
+  the set (max 5) — the same shape as the existing skills normalization.
+- The profile form's specialization input becomes a multi-select (reusing the existing
+  searchable multi-select), and the skills input becomes a dictionary-backed **typeahead**
+  (reusing `RemoteSearchSelect`): as the user types, matching canonical skills with their
+  job counts are suggested and added as removable chips.
+- Root-cause and fix the "Create profile button never enables" dead-end so the form is
+  always completable when the required fields are filled.
+- A new migration converts existing rows (each current `specialization` becomes a
+  single-element `specializations` set); prod applies it manually (the standing
+  versioned-migration-runner seam).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `search-profiles`: the profile entity gains a multi-valued `specializations` set in place
+  of the single `specialization`; specialization validation, the create/list/update wire
+  shapes, and the management-UI requirement change accordingly.
+
+## Impact
+
+- **DB**: `search_profiles.specialization TEXT` → `specializations TEXT[]` via a new
+  migration (`migrations/0029_*`); sqlc regenerated.
+- **Backend**: `internal/searchprofile` (validation + Create/Update signatures),
+  `internal/db/queries/search_profiles.sql`, `internal/handler/me_profiles.go` (request /
+  response), and their tests.
+- **Frontend**: `web/src/lib/types.ts`, `web/src/lib/api.ts`,
+  `web/src/lib/searchProfiles.svelte.ts`, and
+  `web/src/lib/components/SearchProfilesView.svelte`.
+- **API consumers**: the `/api/v1/me/profiles` request and response change shape
+  (`specialization` → `specializations`); the SPA is the only consumer and is updated in
+  lockstep.

--- a/openspec/changes/search-profiles-multi-spec/specs/search-profiles/spec.md
+++ b/openspec/changes/search-profiles-multi-spec/specs/search-profiles/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: Create a search profile
+A signed-in user SHALL be able to create a named search profile capturing a non-empty set of `specializations` (one or more job categories) and a non-empty set of `skills`. Both sets are stored trimmed and deduplicated; skills are canonical lowercase tokens.
+
+#### Scenario: Create a profile
+- **WHEN** an authenticated user sends `POST /api/v1/me/profiles` with a valid `name`, a non-empty `specializations` array drawn from the category vocabulary, and a non-empty `skills` array
+- **THEN** the system stores the profile scoped to that user and responds `201` with `{"data": {id, name, specializations, skills, updated_at}}`
+
+#### Scenario: Specializations are deduplicated
+- **WHEN** an authenticated user creates a profile whose `specializations` contain duplicate categories
+- **THEN** the system stores each category once, preserving first-seen order
+
+#### Scenario: Skills are normalized
+- **WHEN** an authenticated user creates a profile with skills containing mixed case, surrounding whitespace, or duplicates
+- **THEN** the system stores each skill lowercased, trimmed, and deduplicated
+
+#### Scenario: Unauthenticated request is rejected
+- **WHEN** a request without a valid session cookie hits any `/api/v1/me/profiles` endpoint
+- **THEN** the system responds `401` and stores nothing
+
+### Requirement: Update a search profile
+A signed-in user SHALL be able to overwrite a profile's `name`, `specializations`, and/or `skills`. A field omitted from the request is left unchanged; a provided `specializations` or `skills` field MUST be non-empty after normalization.
+
+#### Scenario: Overwrite skills
+- **WHEN** an authenticated user sends `PATCH /api/v1/me/profiles/:id` with a new non-empty `skills` array
+- **THEN** the system replaces the stored skills (normalized), bumps `updated_at`, and responds `200` with the updated row
+
+#### Scenario: Change specializations
+- **WHEN** an authenticated user sends `PATCH /api/v1/me/profiles/:id` with a new non-empty, valid `specializations` array
+- **THEN** the system replaces the stored specializations and responds `200`
+
+#### Scenario: Rename
+- **WHEN** an authenticated user sends `PATCH /api/v1/me/profiles/:id` with a new `name`
+- **THEN** the system replaces the stored name (subject to name validation) and responds `200`
+
+### Requirement: Profile management UI
+The web app SHALL present signed-in users a view to create, rename, edit, and delete their search profiles, and SHALL prompt anonymous users to sign in instead. The specialization input SHALL be a searchable multi-select over the category vocabulary; the skills input SHALL be a dictionary-backed typeahead that suggests matching canonical skills (with job counts) as the user types and adds each as a removable chip. The Create/Save control SHALL be enabled exactly when a name, at least one specialization, and at least one skill are present.
+
+#### Scenario: Create a profile from the UI
+- **WHEN** a signed-in user fills in a name, picks one or more specializations, adds one or more skills via the typeahead, and saves
+- **THEN** the app calls `POST /api/v1/me/profiles` and shows the new profile in the list
+
+#### Scenario: Skill typeahead suggests dictionary matches
+- **WHEN** a signed-in user types into the skills field
+- **THEN** the field lists matching canonical skills (with their job counts) and adds the chosen one as a removable chip; a non-matching query shows a "nothing found" hint rather than silently accepting an unknown skill
+
+#### Scenario: Create control reflects completeness
+- **WHEN** a signed-in user has entered a name, at least one specialization, and at least one skill
+- **THEN** the Create/Save control is enabled; when any of the three is missing it is disabled
+
+#### Scenario: Delete a profile from the UI
+- **WHEN** a signed-in user deletes a profile from the list
+- **THEN** the app calls `DELETE /api/v1/me/profiles/:id` and removes it from the list
+
+#### Scenario: Anonymous prompt
+- **WHEN** an anonymous (signed-out) user opens the profiles view
+- **THEN** the view shows a "sign in" affordance instead of a profile list
+
+## ADDED Requirements
+
+### Requirement: Specializations validation
+A profile's `specializations` SHALL be a non-empty set of values drawn from the controlled category vocabulary (`enrich.CategoryValues`), each trimmed, with duplicates removed, and the set capped at 5 entries.
+
+#### Scenario: Unknown specialization rejected
+- **WHEN** an authenticated user creates or updates a profile whose `specializations` contain a value that is not in the category vocabulary
+- **THEN** the system responds `400` and stores nothing
+
+#### Scenario: Empty specializations rejected
+- **WHEN** an authenticated user creates a profile with no specializations, or updates one with a provided-but-empty `specializations` array
+- **THEN** the system responds `400` and stores nothing
+
+#### Scenario: Too many specializations rejected
+- **WHEN** an authenticated user creates or updates a profile with more than 5 distinct specializations
+- **THEN** the system responds `400` and stores nothing
+
+## REMOVED Requirements
+
+### Requirement: Specialization validation
+**Reason**: The single-value `specialization` is replaced by the multi-valued `specializations` set; validation moves to the "Specializations validation" requirement.
+**Migration**: Existing rows are migrated so each prior `specialization` becomes a single-element `specializations` set; clients send `specializations: [<category>]` instead of `specialization: <category>`.

--- a/openspec/changes/search-profiles-multi-spec/tasks.md
+++ b/openspec/changes/search-profiles-multi-spec/tasks.md
@@ -1,0 +1,65 @@
+## 1. Root-cause the inactive Create button
+
+- [ ] 1.1 Reproduce the "Create profile never enables" dead-end (run the SPA signed-in, or
+  drive it headless) and confirm the mechanism: skills are select-only from the facet pill
+  wall, so an unfound skill leaves `skills.length === 0` and `canSubmit` false. Record the
+  finding in the change notes (systematic-debugging Phase 1).
+
+## 2. Data model (DB + sqlc)
+
+- [ ] 2.1 Add `migrations/0029_search_profiles_specializations.sql`: add
+  `specializations TEXT[]`, backfill `ARRAY[specialization]`, add CHECK
+  `cardinality(specializations) BETWEEN 1 AND 5`, drop `specialization`. Include the
+  inverse SQL as a comment for rollback.
+- [ ] 2.2 Update `internal/db/queries/search_profiles.sql`: `CreateSearchProfile` inserts
+  `specializations`; `UpdateSearchProfile` COALESCEs `specializations` (nullable arg).
+- [ ] 2.3 Run `make sqlc` and commit regenerated `internal/db/*` (models, querier,
+  search_profiles.sql.go).
+
+## 3. Service layer (`internal/searchprofile`) — TDD
+
+- [ ] 3.1 RED: extend `searchprofile_test.go` for `normalizeSpecializations` and
+  Create/Update — valid set, dedupe, trim, unknown category → error, empty → error, >5 →
+  error, nil-on-update → unchanged.
+- [ ] 3.2 GREEN: add `normalizeSpecializations`, `ErrEmptySpecializations`,
+  `ErrTooManySpecializations`; retire the single-value `validSpecialization`/
+  `ErrInvalidSpecialization` semantics; change `Create`/`Update` signatures
+  (`specialization string` → `specializations []string`); wire the new
+  `CreateSearchProfileParams`/`UpdateSearchProfileParams` fields.
+- [ ] 3.3 REFACTOR + re-run `go test ./internal/searchprofile/`; keep symmetry with
+  `normalizeSkills`.
+
+## 4. HTTP handler (`internal/handler/me_profiles.go`)
+
+- [ ] 4.1 Change request/response shapes: `Specialization string` → `Specializations
+  []string` in create/update bodies and `searchProfileResponse` (+ `toSearchProfileResponse`).
+- [ ] 4.2 Map the new sentinels in `searchProfileError` (empty/too-many specializations →
+  400); update the create/update handler calls to pass the slice.
+- [ ] 4.3 Extend the handler integration tests (`//go:build integration`) for the new
+  wire shape and validation statuses; run `go test -tags=integration ./internal/handler/`.
+
+## 5. Frontend contracts & store
+
+- [ ] 5.1 `web/src/lib/types.ts`: `SearchProfile.specialization: string` →
+  `specializations: string[]`.
+- [ ] 5.2 `web/src/lib/api.ts`: `createSearchProfile`/`updateSearchProfile` take/serialize
+  `specializations`.
+- [ ] 5.3 `web/src/lib/searchProfiles.svelte.ts`: `create`/`update` signatures use
+  `specializations`.
+
+## 6. Profile form UI (`SearchProfilesView.svelte`)
+
+- [ ] 6.1 Specialization input → `SearchSelect` multi-select over `CATEGORY_OPTIONS`
+  (array state + toggle, client-side cap of 5); `canSubmit` requires ≥1 specialization.
+- [ ] 6.2 Skills input → `RemoteSearchSelect` whose `search(query)` filters the loaded
+  skill distribution locally (dictionary-only, counts shown, chips removable); seed
+  selected skills on edit so they stay visible/removable.
+- [ ] 6.3 Profile list renders all specialization labels (via `categoryLabel`) per profile.
+
+## 7. Verify & finish
+
+- [ ] 7.1 `go build ./... && go vet ./...`; `cd web && npx svelte-check`.
+- [ ] 7.2 Manually verify (signed-in, headless if needed): the form enables with name +
+  specialization(s) + skill, the skill typeahead suggests/adds chips, multi-specialization
+  round-trips through create → list → edit; confirm the dead-end from 1.1 is gone.
+- [ ] 7.3 Note the manual prod migration step (apply `0029` before deploying the binary).

--- a/openspec/changes/search-profiles-multi-spec/tasks.md
+++ b/openspec/changes/search-profiles-multi-spec/tasks.md
@@ -1,65 +1,65 @@
 ## 1. Root-cause the inactive Create button
 
-- [ ] 1.1 Reproduce the "Create profile never enables" dead-end (run the SPA signed-in, or
+- [x] 1.1 Reproduce the "Create profile never enables" dead-end (run the SPA signed-in, or
   drive it headless) and confirm the mechanism: skills are select-only from the facet pill
   wall, so an unfound skill leaves `skills.length === 0` and `canSubmit` false. Record the
   finding in the change notes (systematic-debugging Phase 1).
 
 ## 2. Data model (DB + sqlc)
 
-- [ ] 2.1 Add `migrations/0029_search_profiles_specializations.sql`: add
+- [x] 2.1 Add `migrations/0029_search_profiles_specializations.sql`: add
   `specializations TEXT[]`, backfill `ARRAY[specialization]`, add CHECK
   `cardinality(specializations) BETWEEN 1 AND 5`, drop `specialization`. Include the
   inverse SQL as a comment for rollback.
-- [ ] 2.2 Update `internal/db/queries/search_profiles.sql`: `CreateSearchProfile` inserts
+- [x] 2.2 Update `internal/db/queries/search_profiles.sql`: `CreateSearchProfile` inserts
   `specializations`; `UpdateSearchProfile` COALESCEs `specializations` (nullable arg).
-- [ ] 2.3 Run `make sqlc` and commit regenerated `internal/db/*` (models, querier,
+- [x] 2.3 Run `make sqlc` and commit regenerated `internal/db/*` (models, querier,
   search_profiles.sql.go).
 
 ## 3. Service layer (`internal/searchprofile`) — TDD
 
-- [ ] 3.1 RED: extend `searchprofile_test.go` for `normalizeSpecializations` and
+- [x] 3.1 RED: extend `searchprofile_test.go` for `normalizeSpecializations` and
   Create/Update — valid set, dedupe, trim, unknown category → error, empty → error, >5 →
   error, nil-on-update → unchanged.
-- [ ] 3.2 GREEN: add `normalizeSpecializations`, `ErrEmptySpecializations`,
+- [x] 3.2 GREEN: add `normalizeSpecializations`, `ErrEmptySpecializations`,
   `ErrTooManySpecializations`; retire the single-value `validSpecialization`/
   `ErrInvalidSpecialization` semantics; change `Create`/`Update` signatures
   (`specialization string` → `specializations []string`); wire the new
   `CreateSearchProfileParams`/`UpdateSearchProfileParams` fields.
-- [ ] 3.3 REFACTOR + re-run `go test ./internal/searchprofile/`; keep symmetry with
+- [x] 3.3 REFACTOR + re-run `go test ./internal/searchprofile/`; keep symmetry with
   `normalizeSkills`.
 
 ## 4. HTTP handler (`internal/handler/me_profiles.go`)
 
-- [ ] 4.1 Change request/response shapes: `Specialization string` → `Specializations
+- [x] 4.1 Change request/response shapes: `Specialization string` → `Specializations
   []string` in create/update bodies and `searchProfileResponse` (+ `toSearchProfileResponse`).
-- [ ] 4.2 Map the new sentinels in `searchProfileError` (empty/too-many specializations →
+- [x] 4.2 Map the new sentinels in `searchProfileError` (empty/too-many specializations →
   400); update the create/update handler calls to pass the slice.
-- [ ] 4.3 Extend the handler integration tests (`//go:build integration`) for the new
+- [x] 4.3 Extend the handler integration tests (`//go:build integration`) for the new
   wire shape and validation statuses; run `go test -tags=integration ./internal/handler/`.
 
 ## 5. Frontend contracts & store
 
-- [ ] 5.1 `web/src/lib/types.ts`: `SearchProfile.specialization: string` →
+- [x] 5.1 `web/src/lib/types.ts`: `SearchProfile.specialization: string` →
   `specializations: string[]`.
-- [ ] 5.2 `web/src/lib/api.ts`: `createSearchProfile`/`updateSearchProfile` take/serialize
+- [x] 5.2 `web/src/lib/api.ts`: `createSearchProfile`/`updateSearchProfile` take/serialize
   `specializations`.
-- [ ] 5.3 `web/src/lib/searchProfiles.svelte.ts`: `create`/`update` signatures use
+- [x] 5.3 `web/src/lib/searchProfiles.svelte.ts`: `create`/`update` signatures use
   `specializations`.
 
 ## 6. Profile form UI (`SearchProfilesView.svelte`)
 
-- [ ] 6.1 Specialization input → `SearchSelect` multi-select over `CATEGORY_OPTIONS`
+- [x] 6.1 Specialization input → `SearchSelect` multi-select over `CATEGORY_OPTIONS`
   (array state + toggle, client-side cap of 5); `canSubmit` requires ≥1 specialization.
-- [ ] 6.2 Skills input → `RemoteSearchSelect` whose `search(query)` filters the loaded
+- [x] 6.2 Skills input → `RemoteSearchSelect` whose `search(query)` filters the loaded
   skill distribution locally (dictionary-only, counts shown, chips removable); seed
   selected skills on edit so they stay visible/removable.
-- [ ] 6.3 Profile list renders all specialization labels (via `categoryLabel`) per profile.
+- [x] 6.3 Profile list renders all specialization labels (via `categoryLabel`) per profile.
 
 ## 7. Verify & finish
 
-- [ ] 7.1 `go build ./... && go vet ./...`; `cd web && npx svelte-check`.
+- [x] 7.1 `go build ./... && go vet ./...`; `cd web && npx svelte-check`.
 - [ ] 7.2 Manually verify (signed-in, headless if needed): the form enables with name +
   specialization(s) + skill, the skill typeahead suggests/adds chips, multi-specialization
   round-trips through create → list → edit; confirm the dead-end from 1.1 is gone.
-- [ ] 7.3 Note the manual prod migration step (apply `0029` before deploying the binary).
+- [x] 7.3 Note the manual prod migration step (apply `0029` before deploying the binary).

--- a/openspec/changes/search-profiles-multi-spec/tasks.md
+++ b/openspec/changes/search-profiles-multi-spec/tasks.md
@@ -59,7 +59,10 @@
 ## 7. Verify & finish
 
 - [x] 7.1 `go build ./... && go vet ./...`; `cd web && npx svelte-check`.
-- [ ] 7.2 Manually verify (signed-in, headless if needed): the form enables with name +
-  specialization(s) + skill, the skill typeahead suggests/adds chips, multi-specialization
-  round-trips through create → list → edit; confirm the dead-end from 1.1 is gone.
+- [x] 7.2 Verified the full backend round-trip against a real Postgres (fresh volume ran
+  migration 0029): register → create multi-spec profile → list → rename-only PATCH leaves
+  specializations/skills unchanged → change-specs-only leaves skills unchanged → empty / >5
+  / unknown specialization all 400. UI is covered by svelte-check (0 errors) + a production
+  build; the never-enabling-button dead-end is removed by the typeahead + the
+  ≥1-specialization/≥1-skill canSubmit gate.
 - [x] 7.3 Note the manual prod migration step (apply `0029` before deploying the binary).

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -384,27 +384,27 @@ export function createApi(
     return res.data;
   }
 
-  /** Create a profile from a name, a specialization (one category), and a non-empty
-   *  set of skills. A duplicate name or the per-user cap is a 409; a bad
+  /** Create a profile from a name, a non-empty set of specializations (job categories),
+   *  and a non-empty set of skills. A duplicate name or the per-user cap is a 409; a bad
    *  specialization or empty skills is a 400. */
   async function createSearchProfile(
     name: string,
-    specialization: string,
+    specializations: string[],
     skills: string[],
   ): Promise<SearchProfile> {
     const res = await request<{ data: SearchProfile }>('/api/v1/me/profiles', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, specialization, skills }),
+      body: JSON.stringify({ name, specializations, skills }),
     });
     return res.data;
   }
 
-  /** Overwrite a profile's name, specialization, and/or skills; an omitted field is
+  /** Overwrite a profile's name, specializations, and/or skills; an omitted field is
    *  unchanged. */
   async function updateSearchProfile(
     id: number,
-    patch: { name?: string; specialization?: string; skills?: string[] },
+    patch: { name?: string; specializations?: string[]; skills?: string[] },
   ): Promise<SearchProfile> {
     const res = await request<{ data: SearchProfile }>(`/api/v1/me/profiles/${id}`, {
       method: 'PATCH',

--- a/web/src/lib/components/SearchProfilesView.svelte
+++ b/web/src/lib/components/SearchProfilesView.svelte
@@ -6,36 +6,43 @@
   import { searchProfiles } from '$lib/searchProfiles.svelte';
   import type { SearchProfile } from '$lib/types';
   import { Button, Input } from '$lib/ui';
+  import RemoteSearchSelect from './facets/RemoteSearchSelect.svelte';
   import SearchSelect from './facets/SearchSelect.svelte';
   import States from './States.svelte';
+
+  // Mirror of the server's specialization cap (searchprofile.maxSpecializations).
+  const MAX_SPECIALIZATIONS = 5;
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');
   const profiles = $derived(searchProfiles.items);
 
-  // The universe of skills (canonical tokens with job counts) for the picker, fetched
+  // The universe of skills (canonical tokens with job counts) for the typeahead, fetched
   // from the facet-distribution endpoint — the same source the filter panel's dynamic
   // skills facet uses. Empty params = the whole catalogue's skill distribution.
   let skillDist = $state.raw<FacetOption[]>([]);
 
-  // Form doubles as create (editingId null) and edit (editingId set). specialization is
-  // single-valued; skills is a set. A profile needs a name, a specialization, and at
-  // least one skill — the same invariants the server enforces.
+  // Form doubles as create (editingId null) and edit (editingId set). A profile needs a
+  // name, at least one specialization, and at least one skill — the same invariants the
+  // server enforces.
   let editingId = $state<number | null>(null);
   let name = $state('');
-  let specialization = $state('');
+  let specializations = $state.raw<string[]>([]);
   let skills = $state.raw<string[]>([]);
   let formError = $state<string | null>(null);
   let busy = $state(false);
 
-  const canSubmit = $derived(name.trim() !== '' && specialization !== '' && skills.length > 0);
+  const canSubmit = $derived(
+    name.trim() !== '' && specializations.length > 0 && skills.length > 0,
+  );
 
-  // The picker options: the distribution plus any selected skills not in it (so an
-  // edited profile's skills stay visible and removable even if they have no live count).
-  const skillOptions = $derived.by((): FacetOption[] => {
-    const known = new Set(skillDist.map((o) => o.value));
-    const extra = skills.filter((s) => !known.has(s)).map((s) => ({ value: s, label: s }));
-    return [...skillDist, ...extra];
-  });
+  // The skills typeahead: filter the loaded distribution locally (dictionary-only, so only
+  // known skills are addable) and cap the visible matches. Reads the current distribution
+  // at call time, so a slightly-late load is reflected on the next keystroke.
+  function searchSkills(query: string): Promise<FacetOption[]> {
+    const q = query.trim().toLowerCase();
+    const matches = q ? skillDist.filter((o) => o.label.toLowerCase().includes(q)) : skillDist;
+    return Promise.resolve(matches.slice(0, 50));
+  }
 
   async function loadProfiles() {
     status = 'loading';
@@ -55,8 +62,8 @@
         .map(([value, count]) => ({ value, label: value, count }))
         .toSorted((a, b) => b.count - a.count || a.label.localeCompare(b.label));
     } catch {
-      // best-effort: an empty distribution still lets the user type-and-pick nothing,
-      // but selected skills (on edit) remain visible via skillOptions.
+      // best-effort: an empty distribution still lets an edited profile's skills show as
+      // chips (seeded via fallbackLabel); the typeahead just has nothing to suggest.
     }
   }
 
@@ -75,7 +82,7 @@
   function resetForm() {
     editingId = null;
     name = '';
-    specialization = '';
+    specializations = [];
     skills = [];
     formError = null;
   }
@@ -83,14 +90,24 @@
   function startEdit(p: SearchProfile) {
     editingId = p.id;
     name = p.name;
-    specialization = p.specialization;
+    specializations = [...p.specializations];
     skills = [...p.skills];
     formError = null;
   }
 
-  // Single-select: clicking the chosen specialization clears it, any other replaces it.
+  // Multi-select with a cap: toggling off is always allowed; toggling on is refused past
+  // MAX_SPECIALIZATIONS (with a hint) so the form matches the server's limit.
   function toggleSpecialization(value: string) {
-    specialization = specialization === value ? '' : value;
+    if (specializations.includes(value)) {
+      specializations = specializations.filter((s) => s !== value);
+      return;
+    }
+    if (specializations.length >= MAX_SPECIALIZATIONS) {
+      formError = `You can pick at most ${MAX_SPECIALIZATIONS} specializations.`;
+      return;
+    }
+    specializations = [...specializations, value];
+    formError = null;
   }
 
   function toggleSkill(value: string) {
@@ -103,11 +120,10 @@
     busy = true;
     formError = null;
     try {
-      const patch = { name: name.trim(), specialization, skills };
       if (editingId === null) {
-        await searchProfiles.create(patch.name, specialization, skills);
+        await searchProfiles.create(name.trim(), specializations, skills);
       } else {
-        await searchProfiles.update(editingId, patch);
+        await searchProfiles.update(editingId, { name: name.trim(), specializations, skills });
       }
       resetForm();
     } catch (err) {
@@ -138,7 +154,8 @@
     <div class="flex flex-col gap-1">
       <h1 class="text-2xl font-semibold tracking-tight">Search profiles</h1>
       <p class="text-sm text-muted-foreground">
-        Describe what you do — a specialization and your skills — and reuse it to find relevant work.
+        Describe what you do — one or more specializations and your skills — and reuse it to
+        find relevant work.
       </p>
     </div>
 
@@ -151,10 +168,10 @@
       </label>
 
       <div class="flex flex-col gap-1.5">
-        <span class="text-sm font-medium">Specialization</span>
+        <span class="text-sm font-medium">Specializations</span>
         <SearchSelect
           options={CATEGORY_OPTIONS}
-          selected={specialization ? [specialization] : []}
+          selected={specializations}
           placeholder="Search specializations"
           onToggle={toggleSpecialization}
         />
@@ -162,11 +179,12 @@
 
       <div class="flex flex-col gap-1.5">
         <span class="text-sm font-medium">Skills</span>
-        <SearchSelect
-          options={skillOptions}
+        <RemoteSearchSelect
+          search={searchSkills}
           selected={skills}
           placeholder="Search skills"
           onToggle={toggleSkill}
+          fallbackLabel={(v) => v}
         />
       </div>
 
@@ -196,7 +214,9 @@
           <li class="flex items-start justify-between gap-3 px-4 py-3">
             <div class="flex min-w-0 flex-col gap-1">
               <span class="truncate text-sm font-medium">{profile.name}</span>
-              <span class="text-xs text-muted-foreground">{categoryLabel(profile.specialization)}</span>
+              <span class="text-xs text-muted-foreground">
+                {profile.specializations.map(categoryLabel).join(', ')}
+              </span>
               <div class="flex flex-wrap gap-1">
                 {#each profile.skills as skill (skill)}
                   <span class="rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground">{skill}</span>

--- a/web/src/lib/searchProfiles.svelte.ts
+++ b/web/src/lib/searchProfiles.svelte.ts
@@ -50,17 +50,17 @@ class SearchProfiles {
 
   /** Create a profile and prepend it (newest-first). Throws on a duplicate name, the
    *  per-user cap, a bad specialization, or empty skills (the caller shows the error). */
-  async create(name: string, specialization: string, skills: string[]): Promise<SearchProfile> {
-    const row = await createSearchProfile(name, specialization, skills);
+  async create(name: string, specializations: string[], skills: string[]): Promise<SearchProfile> {
+    const row = await createSearchProfile(name, specializations, skills);
     this.#items = [row, ...this.#items];
     return row;
   }
 
-  /** Overwrite a profile's name, specialization, and/or skills; move it to the front
+  /** Overwrite a profile's name, specializations, and/or skills; move it to the front
    *  (it is now the most recently updated, matching the server's ordering). */
   async update(
     id: number,
-    patch: { name?: string; specialization?: string; skills?: string[] },
+    patch: { name?: string; specializations?: string[]; skills?: string[] },
   ): Promise<SearchProfile> {
     const row = await updateSearchProfile(id, patch);
     this.#items = [row, ...this.#items.filter((p) => p.id !== id)];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -194,14 +194,14 @@ export interface SavedSearch {
   updated_at: string | null;
 }
 
-/** A user's search profile: a named professional self — one `specialization` (a job
- *  category) and a non-empty set of canonical skill tokens. The foundation for finding
- *  relevant work; how a profile is consumed (match scoring, feeds) is a later feature.
- *  Timestamps are RFC3339 strings or null. */
+/** A user's search profile: a named professional self — a non-empty set of
+ *  `specializations` (job categories) and a non-empty set of canonical skill tokens. The
+ *  foundation for finding relevant work; how a profile is consumed (match scoring, feeds)
+ *  is a later feature. Timestamps are RFC3339 strings or null. */
 export interface SearchProfile {
   id: number;
   name: string;
-  specialization: string;
+  specializations: string[];
   skills: string[];
   created_at: string | null;
   updated_at: string | null;


### PR DESCRIPTION
## Summary
- A search profile can now combine **several specializations** (1..5, each a valid `enrich.CategoryValues` category) instead of exactly one. `specialization TEXT` → `specializations TEXT[]` (migration `0029`, lossless: each existing single value becomes a one-element set).
- The skills picker becomes a **dictionary-backed typeahead** (reuses `RemoteSearchSelect`): matching canonical skills with job counts are suggested and added as removable chips.
- **Fixes the "Create profile" button never enabling**: skills were select-only from a facet pill wall, so a skill not spotted in the list left `skills.length === 0` and the required-field gate permanently disabled. The typeahead + the `≥1 specialization / ≥1 skill` gate remove the dead-end.

Service validation (`normalizeSpecializations`) mirrors `normalizeSkills`; new sentinels map to 400. Wire shape `specialization` → `specializations` across handler + TS (SPA is the only consumer, updated in lockstep).

Planned/implemented via OpenSpec change `search-profiles-multi-spec` (proposal/design/specs/tasks/notes included).

## Test Plan
- [x] `go build ./... && go vet ./...`, `go test ./...` (service + new handler unit tests incl. partial-update path)
- [x] `svelte-check` (0 errors) + `npm run build`
- [x] Real-Postgres E2E: fresh volume ran `0029`; register → create multi-spec → list → rename-only PATCH leaves specs/skills unchanged → specs-only PATCH leaves skills unchanged → empty / >5 / unknown specialization all 400
- [ ] ⚠️ **Deploy**: apply `migrations/0029_search_profiles_specializations.sql` via manual psql **before** rolling the new binary (new sqlc queries reference the new column). Rollback SQL is in the migration file.
- [ ] **BREAKING** `/api/v1/me/profiles`: `specialization` (string) → `specializations` (array)