### PR TITLE
fix(web): restore URL filters on back/forward from shallow-routing entries

### DIFF
--- a/web/src/lib/components/AnalyticsView.svelte
+++ b/web/src/lib/components/AnalyticsView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
+  import { browser } from '$app/environment';
   import { page } from '$app/state';
   import { api } from '$lib/api';
   import { FilterStore, filtersToParams } from '$lib/filters';
@@ -25,6 +26,9 @@
   let status = $state<'ready' | 'loading' | 'error'>('ready');
   let drawerOpen = $state(false);
   let started = false;
+  // `initial` counts were fetched for page.url; if a shallow-routing back/forward
+  // left page.url lagging the address bar, they're stale — re-fetch on the first run.
+  const initialStale = browser && page.url.search !== location.search;
   // Monotonic fetch id: a response only commits if it is still the latest, so a
   // slow fetch that resolves after a newer one can't overwrite fresh counts with
   // stale data. The reload debounce now lives in FilterStore (value -> applied),
@@ -47,7 +51,7 @@
     untrack(() => {
       if (!started) {
         started = true;
-        return;
+        if (!initialStale) return;
       }
       status = 'loading';
       const params = filtersToParams(filters.applied);

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
+  import { browser } from '$app/environment';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { api, type Slice } from '$lib/api';
@@ -39,6 +40,10 @@
   let companies = $state.raw(seeded);
   let started = false;
 
+  // `initial` was searched for page.url; if a shallow-routing back/forward left
+  // page.url lagging the address bar, it's stale — reload on the first run instead.
+  const initialStale = browser && page.url.search !== location.search;
+
   onMount(() => () => search.dispose());
 
   function reload() {
@@ -53,7 +58,7 @@
     untrack(() => {
       if (!started) {
         started = true;
-        return;
+        if (!initialStale) return;
       }
       reload();
     });

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
+  import { browser } from '$app/environment';
   import { page } from '$app/state';
   import { api, type Slice } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -74,6 +75,12 @@
   let drawerOpen = $state(false);
   let started = false;
 
+  // The server-rendered `initial` was searched for `page.url`. After a back/forward
+  // onto a shallow-routing entry that lags page.url behind the address bar, `initial`
+  // is stale (it holds the pre-filter page) while the filters seed from the real URL.
+  // Detect that mismatch so the first effect run reloads instead of keeping `initial`.
+  const initialStale = browser && page.url.search !== location.search;
+
   // For a signed-in user, load the set of already-viewed slugs so JobRow can dim
   // seen cards (no-op when signed out — the set stays empty). Cleanup: cancel any
   // pending debounced reload so it can't fire after this view is gone.
@@ -98,7 +105,9 @@
       refreshCounts();
       if (!started) {
         started = true;
-        return;
+        // Keep the SSR `initial` page unless it was loaded for a different URL than
+        // the address bar (stale shallow-routing restore) — then reload to match.
+        if (!initialStale) return;
       }
       reloadList();
     });

--- a/web/src/lib/urlSynced.svelte.ts
+++ b/web/src/lib/urlSynced.svelte.ts
@@ -12,6 +12,7 @@
 // structural fix for the dropped-character race the goto+debounce design had.
 
 import { untrack } from 'svelte';
+import { browser } from '$app/environment';
 import { page } from '$app/state';
 import { replaceState } from '$app/navigation';
 
@@ -52,8 +53,15 @@ export class UrlSyncedState<T> {
     this.#codec = codec;
     this.#debounceMs = debounceMs;
     // The field initializers above are typed placeholders; both are seeded here
-    // from the URL params, which only arrive as a constructor argument.
-    const seeded = codec.parse(initial);
+    // from the URL params. On the client the browser's address bar
+    // (location.search) is the authoritative filter state: after a back/forward
+    // onto a shallow-routing (replaceState) entry, SvelteKit's page.url — which the
+    // view reads to pass `initial` — can lag to the pre-filter URL while the address
+    // bar still shows the filter. Seeding from location makes a restored view mirror
+    // the real URL. On the server location is unavailable; the passed page.url params
+    // are correct there and match the client for every non-shallow navigation.
+    const params = browser ? new URLSearchParams(location.search) : initial;
+    const seeded = codec.parse(params);
     this.value = seeded;
     this.applied = seeded;
   }
@@ -84,7 +92,10 @@ export class UrlSyncedState<T> {
    *  writes are synchronous, a mismatch here is a genuine external navigation — never
    *  a stale-our-own-commit, so reseeding can't eat in-flight typing. */
   syncFromUrl() {
-    const current = page.url.searchParams;
+    // Read the browser's address bar, not page.url: after a shallow-routing (replaceState)
+    // back/forward, page.url lags to the pre-filter URL while location.search is correct.
+    // Reading page.url here would revert the constructor's location-seeded value to empty.
+    const current = browser ? new URLSearchParams(location.search) : page.url.searchParams;
     if (current.toString() === this.#codec.serialize(this.value).toString()) return;
     clearTimeout(this.#timer);
     this.#timer = undefined;


### PR DESCRIPTION
## Problem

Applying a `/jobs` filter — a collection pill (`?collections=yc`) or a typed `q`/salary — then opening a job and pressing **Back** showed the sidebar and count as if no filter were applied, even though the address bar still read `?collections=yc`. A hard refresh (F5) worked, which masked the bug.

## Root cause

`UrlSyncedState.#write` writes the URL via SvelteKit **shallow routing** (`replaceState` from `$app/navigation`) — a deliberate choice for a synchronous, no-lag URL update while typing. After a back/forward onto that entry, SvelteKit's reactive `page.url` **lags to the pre-filter base URL** while the browser's `location.search` stays correct. The views seed their `FilterStore`/`UrlSyncedState` from `page.url.searchParams` → empty seed → sidebar/counts unfiltered. `data.initial` (the SSR page) is also the stale base load, so the list shows the whole catalogue.

A second, non-obvious half: `syncFromUrl()` (run by `syncOnNavigation`'s mount effect) also read the stale `page.url` and **reverted** a correct constructor seed back to empty.

## Fix (keeps the client-driven `replaceState` model — no `goto`, anti-lag intact)

- `urlSynced.svelte.ts`: seed the constructor **and** `syncFromUrl()` from `location.search` (the authoritative client URL) instead of `page.url`.
- `JobsView` / `CompaniesView` / `AnalyticsView`: `initialStale = browser && page.url.search !== location.search` — when the SSR `initial` was loaded for a different URL than the address bar, the first reload-effect run reloads instead of keeping the stale payload.

## Verification

No web test runner — verified via playwright-core + system Chrome against a local dev build pointed at the prod API. After **Back**, URL ↔ sidebar badge (`Filters (N)`) ↔ count now all agree:

| Scenario | Before | After |
|---|---|---|
| yc pill → job → back | 2.5M, `Filters` | 21,998, `Filters (1)` ✅ |
| typed `python` → job → back | empty, 2.5M | `python`, 13,370 ✅ |
| direct URL + F5 on a filter | ✅ | ✅ (unchanged) |
| rapid typing (anti-lag) | — | no dropped chars ✅ |
| companies search → back | lost | preserved ✅ |

`svelte-check` — 0 errors.