### PR TITLE
feat(search-profiles): clear search field after adding a skill/specialization

### DIFF
--- a/web/src/lib/components/SearchProfilesView.svelte
+++ b/web/src/lib/components/SearchProfilesView.svelte
@@ -174,6 +174,7 @@
           selected={specializations}
           placeholder="Search specializations"
           onToggle={toggleSpecialization}
+          clearOnSelect
         />
       </div>
 
@@ -185,6 +186,7 @@
           placeholder="Search skills"
           onToggle={toggleSkill}
           fallbackLabel={(v) => v}
+          clearOnSelect
         />
       </div>
 

--- a/web/src/lib/components/facets/RemoteSearchSelect.svelte
+++ b/web/src/lib/components/facets/RemoteSearchSelect.svelte
@@ -18,6 +18,7 @@
     placeholder,
     onToggle,
     fallbackLabel,
+    clearOnSelect = false,
   }: {
     search: (query: string) => Promise<FacetOption[]>;
     selected: string[];
@@ -25,6 +26,9 @@
     placeholder?: string;
     onToggle: (value: string) => void;
     fallbackLabel: (value: string) => string;
+    // When set, the search field is cleared after picking an option (search →
+    // pick a chip → search the next), suited to a build-a-set form.
+    clearOnSelect?: boolean;
   } = $props();
 
   let query = $state('');
@@ -61,6 +65,13 @@
     return () => clearTimeout(t);
   });
 
+  // Pick an option from the results; optionally reset the search so the field is
+  // ready for the next one (chip removal keeps the query, so it is not routed here).
+  function pick(value: string) {
+    onToggle(value);
+    if (clearOnSelect) query = '';
+  }
+
   const labelOf = (value: string) => seen.get(value) ?? fallbackLabel(value);
   // Don't list an already-selected option in the picker — it's shown as a chip.
   const pickable = $derived(results.filter((o) => !selected.includes(o.value)));
@@ -89,7 +100,7 @@
     {#each pickable as opt (opt.value)}
       <button
         type="button"
-        onclick={() => onToggle(opt.value)}
+        onclick={() => pick(opt.value)}
         class="flex items-center justify-between gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-accent"
       >
         <span class="truncate">{opt.label}</span>

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -12,15 +12,25 @@
     exclude = false,
     placeholder,
     onToggle,
+    clearOnSelect = false,
   }: {
     options: FacetOption[];
     selected: string[];
     exclude?: boolean;
     placeholder?: string;
     onToggle: (value: string) => void;
+    // When set, the filter field is cleared after each toggle — suited to a
+    // build-a-set form (search → pick → search the next), not the filter panel
+    // where you toggle several visible pills after one search.
+    clearOnSelect?: boolean;
   } = $props();
 
   let filter = $state('');
+
+  function toggle(value: string) {
+    onToggle(value);
+    if (clearOnSelect) filter = '';
+  }
 
   const shown = $derived(
     uniqueByValue(options)
@@ -36,7 +46,7 @@
       {@const active = selected.includes(opt.value)}
       <button
         type="button"
-        onclick={() => onToggle(opt.value)}
+        onclick={() => toggle(opt.value)}
         class={pillClass(active, exclude, 'px-2.5 py-1 text-sm')}
       >
         {opt.label}{#if opt.count !== undefined}<span class="ml-1 opacity-60 tabular-nums">{opt.count.toLocaleString()}</span>{/if}


### PR DESCRIPTION
## Summary
On `/my/profiles`, after picking a skill (typeahead) or a specialization the search field now clears so you can search for the next one — instead of leaving the previous query in place.

Implemented as an **opt-in** `clearOnSelect` prop (default `false`) on the shared `SearchSelect` and `RemoteSearchSelect`, enabled only on the profile form. The filter panel (`FacetSection`) is unchanged. Chip removal keeps the query.

## Test Plan
- [x] `svelte-check` (0 errors) + `npm run build`
- [ ] On the profile form: add a skill → skills search clears; add a specialization → specialization search clears; removing a chip leaves the query intact