### PR TITLE
feat(sources): harvest 10 new ATS boards from remote100k.com

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -6669,3 +6669,19 @@
   board: scorewarrior
 - company: Taxfix
   board: taxfix.com
+- company: Ashby
+  board: Ashby
+- company: ClassDojo
+  board: ClassDojo
+- company: Deepgram
+  board: Deepgram
+- company: Moxie
+  board: Moxie
+- company: Owner.com
+  board: Owner
+- company: SearchStax
+  board: Searchstax
+- company: Superhuman
+  board: Superhuman Platform Inc
+- company: Tremendous
+  board: Tremendous

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4052,3 +4052,5 @@
   board: sunstudio
 - company: Articulate
   board: articulate
+- company: SmartBug Media
+  board: SmartBugOperatingLLC

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -1218,3 +1218,5 @@
   board: iavhqy.fa.ocs.oraclecloud.com/jobsearch
 - company: Anywhere Real Estate Inc.
   board: ibmqjb.fa.ocs.oraclecloud.com/jobsearch
+- company: Argano
+  board: fa-eyau-saasfaprod1.fa.ocs.oraclecloud.com/CX_1


### PR DESCRIPTION
## What

Harvested new ATS boards from [remote100k.com](https://remote100k.com/), a curated \$100k+ remote-job aggregator (~611 jobs).

## How

Each remote100k job page's Apply link is an outbound URL to the real ATS, marked `?ref=remote100k`. Pipeline:

1. `sitemap.xml` enumerates all 611 `/remote-job/` pages
2. Fetched each page, extracted the `?ref=remote100k` apply URL
3. Classified via `internal/atsdetect.FromURL` → 381 matched supported providers (greenhouse 252, ashby 90, workday 24, lever 8, oracle 3, icims 3, pinpoint 1)
4. Fed per-provider seeds to `cmd/harvest-boards`, which **live-probes each slug** against the provider API and keeps only boards returning >0 jobs, deduped against existing entries

The catalogue already covered ~96% of matched boards. Net-new **10 live boards**:

- **ashby (8):** Ashby, ClassDojo, Deepgram, Moxie, Owner, SearchStax, Superhuman, Tremendous
- **lever (1):** SmartBug Media
- **oracle (1):** Argano

## Verification

- All three changed board files pass `sources.Config.Validate(registry)` (same check `cmd/ingest` runs at startup)
- `go build ./...` + `go vet` clean
- Confirmed no case-variant duplicates vs existing entries (Ashby slugs are case-sensitive and may contain spaces, e.g. `Superhuman Platform Inc` — valid live slugs)