### PR TITLE
fix(sources): drop 7 redundant case-variant ashby boards

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -6669,19 +6669,5 @@
   board: scorewarrior
 - company: Taxfix
   board: taxfix.com
-- company: Ashby
-  board: Ashby
-- company: ClassDojo
-  board: ClassDojo
-- company: Deepgram
-  board: Deepgram
-- company: Moxie
-  board: Moxie
-- company: Owner.com
-  board: Owner
-- company: SearchStax
-  board: Searchstax
 - company: Superhuman
   board: Superhuman Platform Inc
-- company: Tremendous
-  board: Tremendous


### PR DESCRIPTION
Follow-up to #314. Those capitalized ashby boards (Deepgram/ClassDojo/Moxie/Owner/Searchstax/Tremendous/Ashby) already exist lowercase; Ashby's API resolves slugs case-insensitively to identical job ids, so the extras only double-crawl. Keeps the genuinely-new `Superhuman Platform Inc`. lever (SmartBug Media) and oracle (Argano) additions verified genuinely new and untouched.