### PR TITLE
fix(sources): drop broken URL-encoded superhuman ashby board

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -6523,8 +6523,6 @@
   board: subtotal
 - company: summer-robotics
   board: summer-robotics
-- company: superhuman%20platform%20inc
-  board: superhuman%20platform%20inc
 - company: swaprail
   board: swaprail
 - company: swarmaero


### PR DESCRIPTION
The clean `Superhuman Platform Inc` entry from #314 duplicates a pre-existing broken entry `superhuman%20platform%20inc` (URL-encoded slug leaked in as company+board, producing 89 jobs with company `superhuman%20platform%20inc` / slug `superhuman-20platform-20inc`). Both point at the same Ashby org. Remove the broken one; its stale jobs close via the 48h sweep, leaving the clean company=Superhuman ingest.