### PR TITLE
feat(companies): filter sidebar (collections/region/country/industry/type/size)

### DIFF
--- a/cmd/recount-companies/main.go
+++ b/cmd/recount-companies/main.go
@@ -1,11 +1,12 @@
-// Command recount-companies recomputes the denormalized companies.job_count for
-// every company in one set-based pass and exits. The list endpoint and the
-// sidebar company typeahead read that column and order by it (most active first),
-// instead of joining and counting jobs on every request. The count changes both
-// when jobs are ingested and when they are closed (closed_at set by the ingest
-// sweep / liveness worker), so it is maintained by this periodic recompute rather
-// than a write-path trigger — eventually consistent within the cron interval.
-// Idempotent: re-running rewrites only the rows whose count actually changed.
+// Command recount-companies recomputes each company's denormalized state — the
+// open-job count and the facet arrays (regions/countries/domains/company_types/
+// company_sizes) derived from its open jobs — in one set-based pass and exits. The
+// list endpoint reads and filters on these columns (and orders by job_count, most
+// active first) instead of joining jobs on every request. They change both when
+// jobs are ingested and when they are closed (closed_at set by the ingest sweep /
+// liveness worker), so they are maintained by this periodic recompute rather than a
+// write-path trigger — eventually consistent within the cron interval. Idempotent:
+// re-running rewrites only the rows whose state actually changed.
 package main
 
 import (
@@ -29,7 +30,7 @@ func run() int {
 	}
 	defer cleanup()
 
-	updated, err := db.New(pool).RecountCompanyJobCounts(ctx)
+	updated, err := db.New(pool).RefreshCompanyFacets(ctx)
 	if err != nil {
 		log.Printf("recount-companies: %v", err)
 		return 1

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -13,12 +13,12 @@ const countCompanies = `-- name: CountCompanies :one
 SELECT count(*)
 FROM companies
 WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%')
-  AND (cardinality($2::text[]) = 0 OR collections && $2::text[])
-  AND (cardinality($3::text[]) = 0 OR regions && $3::text[])
-  AND (cardinality($4::text[]) = 0 OR countries && $4::text[])
-  AND (cardinality($5::text[]) = 0 OR domains && $5::text[])
-  AND (cardinality($6::text[]) = 0 OR company_types && $6::text[])
-  AND (cardinality($7::text[]) = 0 OR company_sizes && $7::text[])
+  AND (coalesce(cardinality($2::text[]), 0) = 0 OR collections && $2::text[])
+  AND (coalesce(cardinality($3::text[]), 0) = 0 OR regions && $3::text[])
+  AND (coalesce(cardinality($4::text[]), 0) = 0 OR countries && $4::text[])
+  AND (coalesce(cardinality($5::text[]), 0) = 0 OR domains && $5::text[])
+  AND (coalesce(cardinality($6::text[]), 0) = 0 OR company_types && $6::text[])
+  AND (coalesce(cardinality($7::text[]), 0) = 0 OR company_sizes && $7::text[])
 `
 
 type CountCompaniesParams struct {
@@ -96,12 +96,12 @@ const listCompanies = `-- name: ListCompanies :many
 SELECT slug, name, job_count
 FROM companies
 WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%')
-  AND (cardinality($2::text[]) = 0 OR collections && $2::text[])
-  AND (cardinality($3::text[]) = 0 OR regions && $3::text[])
-  AND (cardinality($4::text[]) = 0 OR countries && $4::text[])
-  AND (cardinality($5::text[]) = 0 OR domains && $5::text[])
-  AND (cardinality($6::text[]) = 0 OR company_types && $6::text[])
-  AND (cardinality($7::text[]) = 0 OR company_sizes && $7::text[])
+  AND (coalesce(cardinality($2::text[]), 0) = 0 OR collections && $2::text[])
+  AND (coalesce(cardinality($3::text[]), 0) = 0 OR regions && $3::text[])
+  AND (coalesce(cardinality($4::text[]), 0) = 0 OR countries && $4::text[])
+  AND (coalesce(cardinality($5::text[]), 0) = 0 OR domains && $5::text[])
+  AND (coalesce(cardinality($6::text[]), 0) = 0 OR company_types && $6::text[])
+  AND (coalesce(cardinality($7::text[]), 0) = 0 OR company_sizes && $7::text[])
 ORDER BY job_count DESC, name
 LIMIT $9 OFFSET $8
 `

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -12,13 +12,38 @@ import (
 const countCompanies = `-- name: CountCompanies :one
 SELECT count(*)
 FROM companies
-WHERE $1::text = '' OR name ILIKE '%' || $1 || '%'
+WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%')
+  AND (cardinality($2::text[]) = 0 OR collections && $2::text[])
+  AND (cardinality($3::text[]) = 0 OR regions && $3::text[])
+  AND (cardinality($4::text[]) = 0 OR countries && $4::text[])
+  AND (cardinality($5::text[]) = 0 OR domains && $5::text[])
+  AND (cardinality($6::text[]) = 0 OR company_types && $6::text[])
+  AND (cardinality($7::text[]) = 0 OR company_sizes && $7::text[])
 `
 
-// Total companies matching the same optional name filter as ListCompanies, so
-// search pagination reports the filtered total.
-func (q *Queries) CountCompanies(ctx context.Context, search string) (int64, error) {
-	row := q.db.QueryRow(ctx, countCompanies, search)
+type CountCompaniesParams struct {
+	Search       string   `json:"search"`
+	Collections  []string `json:"collections"`
+	Regions      []string `json:"regions"`
+	Countries    []string `json:"countries"`
+	Domains      []string `json:"domains"`
+	CompanyTypes []string `json:"company_types"`
+	CompanySizes []string `json:"company_sizes"`
+}
+
+// Total companies matching the same optional name + facet filters as ListCompanies,
+// so search/filter pagination reports the filtered total. Keep this WHERE identical
+// to ListCompanies.
+func (q *Queries) CountCompanies(ctx context.Context, arg CountCompaniesParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countCompanies,
+		arg.Search,
+		arg.Collections,
+		arg.Regions,
+		arg.Countries,
+		arg.Domains,
+		arg.CompanyTypes,
+		arg.CompanySizes,
+	)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -40,7 +65,7 @@ func (q *Queries) DeleteOrphanCompanies(ctx context.Context) (int64, error) {
 }
 
 const getCompany = `-- name: GetCompany :one
-SELECT slug, name, created_at, updated_at, collections, job_count
+SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes
 FROM companies
 WHERE slug = $1
 `
@@ -58,6 +83,11 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 		&i.UpdatedAt,
 		&i.Collections,
 		&i.JobCount,
+		&i.Regions,
+		&i.Countries,
+		&i.Domains,
+		&i.CompanyTypes,
+		&i.CompanySizes,
 	)
 	return i, err
 }
@@ -65,15 +95,27 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 const listCompanies = `-- name: ListCompanies :many
 SELECT slug, name, job_count
 FROM companies
-WHERE $1::text = '' OR name ILIKE '%' || $1 || '%'
+WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%')
+  AND (cardinality($2::text[]) = 0 OR collections && $2::text[])
+  AND (cardinality($3::text[]) = 0 OR regions && $3::text[])
+  AND (cardinality($4::text[]) = 0 OR countries && $4::text[])
+  AND (cardinality($5::text[]) = 0 OR domains && $5::text[])
+  AND (cardinality($6::text[]) = 0 OR company_types && $6::text[])
+  AND (cardinality($7::text[]) = 0 OR company_sizes && $7::text[])
 ORDER BY job_count DESC, name
-LIMIT $3 OFFSET $2
+LIMIT $9 OFFSET $8
 `
 
 type ListCompaniesParams struct {
-	Search string `json:"search"`
-	Offset int32  `json:"offset"`
-	Limit  int32  `json:"limit"`
+	Search       string   `json:"search"`
+	Collections  []string `json:"collections"`
+	Regions      []string `json:"regions"`
+	Countries    []string `json:"countries"`
+	Domains      []string `json:"domains"`
+	CompanyTypes []string `json:"company_types"`
+	CompanySizes []string `json:"company_sizes"`
+	Offset       int32    `json:"offset"`
+	Limit        int32    `json:"limit"`
 }
 
 type ListCompaniesRow struct {
@@ -88,9 +130,22 @@ type ListCompaniesRow struct {
 // DESC, name — the same ordering the sidebar company typeahead consumes. An empty
 // `search` short-circuits the ILIKE, so the same prepared statement serves both
 // the full list and a name search (`search` is a case-insensitive substring of the
-// name).
+// name). Each facet param is a text[] filtered by array overlap (&&): an empty
+// array short-circuits to no constraint, non-empty values are OR-ed within the
+// facet, and the facets AND together (and with the name search). CountCompanies
+// MUST keep an identical WHERE so the filtered total matches the page.
 func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error) {
-	rows, err := q.db.Query(ctx, listCompanies, arg.Search, arg.Offset, arg.Limit)
+	rows, err := q.db.Query(ctx, listCompanies,
+		arg.Search,
+		arg.Collections,
+		arg.Regions,
+		arg.Countries,
+		arg.Domains,
+		arg.CompanyTypes,
+		arg.CompanySizes,
+		arg.Offset,
+		arg.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -144,28 +199,82 @@ func (q *Queries) ListCompanyCollections(ctx context.Context) ([]ListCompanyColl
 	return items, nil
 }
 
-const recountCompanyJobCounts = `-- name: RecountCompanyJobCounts :execrows
-UPDATE companies c
-SET job_count = COALESCE(o.cnt, 0)
-FROM companies c2
-LEFT JOIN (
-    SELECT company_slug, count(*) AS cnt
+const refreshCompanyFacets = `-- name: RefreshCompanyFacets :execrows
+WITH oj AS (
+    SELECT company_slug, regions, countries, enrichment
     FROM jobs
     WHERE closed_at IS NULL AND company_slug <> ''
+),
+counts AS (
+    SELECT company_slug, count(*) AS cnt FROM oj GROUP BY company_slug
+),
+reg AS (
+    SELECT company_slug, array_agg(DISTINCT r ORDER BY r) AS arr
+    FROM oj CROSS JOIN LATERAL unnest(oj.regions) AS r
     GROUP BY company_slug
-) o ON o.company_slug = c2.slug
+),
+cty AS (
+    SELECT company_slug, array_agg(DISTINCT c ORDER BY c) AS arr
+    FROM oj CROSS JOIN LATERAL unnest(oj.countries) AS c
+    GROUP BY company_slug
+),
+dom AS (
+    SELECT company_slug, array_agg(DISTINCT d ORDER BY d) AS arr
+    FROM oj CROSS JOIN LATERAL jsonb_array_elements_text(
+        CASE WHEN jsonb_typeof(oj.enrichment->'domains') = 'array'
+             THEN oj.enrichment->'domains' ELSE '[]'::jsonb END) AS d
+    GROUP BY company_slug
+),
+ctype AS (
+    SELECT company_slug,
+           array_agg(DISTINCT (enrichment->>'company_type') ORDER BY (enrichment->>'company_type')) AS arr
+    FROM oj
+    WHERE COALESCE(enrichment->>'company_type', '') <> ''
+    GROUP BY company_slug
+),
+csize AS (
+    SELECT company_slug,
+           array_agg(DISTINCT (enrichment->>'company_size') ORDER BY (enrichment->>'company_size')) AS arr
+    FROM oj
+    WHERE COALESCE(enrichment->>'company_size', '') <> ''
+    GROUP BY company_slug
+)
+UPDATE companies c
+SET job_count     = COALESCE(counts.cnt, 0),
+    regions       = COALESCE(reg.arr, '{}'),
+    countries     = COALESCE(cty.arr, '{}'),
+    domains       = COALESCE(dom.arr, '{}'),
+    company_types = COALESCE(ctype.arr, '{}'),
+    company_sizes = COALESCE(csize.arr, '{}')
+FROM companies c2
+LEFT JOIN counts ON counts.company_slug = c2.slug
+LEFT JOIN reg    ON reg.company_slug    = c2.slug
+LEFT JOIN cty    ON cty.company_slug    = c2.slug
+LEFT JOIN dom    ON dom.company_slug    = c2.slug
+LEFT JOIN ctype  ON ctype.company_slug  = c2.slug
+LEFT JOIN csize  ON csize.company_slug  = c2.slug
 WHERE c.slug = c2.slug
-  AND c.job_count IS DISTINCT FROM COALESCE(o.cnt, 0)
+  AND (c.job_count     IS DISTINCT FROM COALESCE(counts.cnt, 0)
+    OR c.regions       IS DISTINCT FROM COALESCE(reg.arr, '{}')
+    OR c.countries     IS DISTINCT FROM COALESCE(cty.arr, '{}')
+    OR c.domains       IS DISTINCT FROM COALESCE(dom.arr, '{}')
+    OR c.company_types IS DISTINCT FROM COALESCE(ctype.arr, '{}')
+    OR c.company_sizes IS DISTINCT FROM COALESCE(csize.arr, '{}'))
 `
 
-// Recompute every company's denormalized open-job count in one set-based pass:
-// aggregate open jobs (closed_at IS NULL) once by company_slug, LEFT JOIN it onto
-// companies so a company with no open jobs is zeroed (COALESCE), and write the
-// result. The `IS DISTINCT FROM` guard skips rows whose count is already correct,
-// so re-running rewrites nothing and the affected-rows count reports real churn.
-// This is cmd/recount-companies' whole job; run periodically (eventual consistency).
-func (q *Queries) RecountCompanyJobCounts(ctx context.Context) (int64, error) {
-	result, err := q.db.Exec(ctx, recountCompanyJobCounts)
+// Recompute every company's denormalized state in one set-based pass: the open-job
+// count plus the facet arrays derived from those open jobs — regions/countries from
+// the jobs geography columns, and domains/company_types/company_sizes from the
+// jobs.enrichment JSONB. Each array is the distinct union across the company's open
+// jobs (closed_at IS NULL), aggregated with a stable ORDER BY so the guard below
+// compares deterministically. A company with no open jobs (or no enriched jobs) is
+// zeroed/emptied via COALESCE. The per-column `IS DISTINCT FROM` guard skips rows
+// already current, so re-running rewrites nothing and the affected-rows count reports
+// real churn. This is cmd/recount-companies' whole job; run periodically (eventual
+// consistency). The facet aggregates are each their own non-correlated GROUP BY so
+// the row-multiplying unnest of one array never distorts another's count.
+func (q *Queries) RefreshCompanyFacets(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, refreshCompanyFacets)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/companies_integration_test.go
+++ b/internal/db/companies_integration_test.go
@@ -61,14 +61,14 @@ func TestListCompaniesSearch(t *testing.T) {
 	})
 
 	t.Run("count reflects the filter", func(t *testing.T) {
-		got, err := q.CountCompanies(ctx, "acme")
+		got, err := q.CountCompanies(ctx, CountCompaniesParams{Search: "acme"})
 		if err != nil {
 			t.Fatalf("count: %v", err)
 		}
 		if got != 2 {
 			t.Errorf("count(acme) = %d, want 2", got)
 		}
-		all, err := q.CountCompanies(ctx, "")
+		all, err := q.CountCompanies(ctx, CountCompaniesParams{Search: ""})
 		if err != nil {
 			t.Fatalf("count all: %v", err)
 		}

--- a/internal/db/companies_job_count_integration_test.go
+++ b/internal/db/companies_job_count_integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-// Integration tests for the denormalized companies.job_count: RecountCompanyJobCounts
+// Integration tests for the denormalized companies.job_count: RefreshCompanyFacets
 // recomputes each company's OPEN-job count (closed_at IS NULL) in one set-based pass
 // and zeroes a company whose jobs all closed, and ListCompanies orders by that count
 // descending (tie-broken by name) while still honoring the name filter. This is SQL
@@ -35,7 +35,7 @@ func companyJobCount(t *testing.T, pool *pgxpool.Pool, slug string) int {
 	return n
 }
 
-func TestRecountCompanyJobCounts(t *testing.T) {
+func TestRefreshCompanyFacetsJobCount(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
 	ctx := context.Background()
@@ -58,7 +58,7 @@ func TestRecountCompanyJobCounts(t *testing.T) {
 	insertJobForCompany(t, pool, "globex:1", "globex")
 
 	t.Run("counts only open jobs", func(t *testing.T) {
-		if _, err := q.RecountCompanyJobCounts(ctx); err != nil {
+		if _, err := q.RefreshCompanyFacets(ctx); err != nil {
 			t.Fatalf("recount: %v", err)
 		}
 		if got := companyJobCount(t, pool, "acme"); got != 3 {
@@ -76,7 +76,7 @@ func TestRecountCompanyJobCounts(t *testing.T) {
 		closeJobByExtID(t, pool, "acme:1")
 		closeJobByExtID(t, pool, "acme:2")
 		closeJobByExtID(t, pool, "acme:3")
-		if _, err := q.RecountCompanyJobCounts(ctx); err != nil {
+		if _, err := q.RefreshCompanyFacets(ctx); err != nil {
 			t.Fatalf("recount: %v", err)
 		}
 		if got := companyJobCount(t, pool, "acme"); got != 0 {
@@ -85,7 +85,7 @@ func TestRecountCompanyJobCounts(t *testing.T) {
 	})
 
 	t.Run("re-running rewrites nothing", func(t *testing.T) {
-		rows, err := q.RecountCompanyJobCounts(ctx)
+		rows, err := q.RefreshCompanyFacets(ctx)
 		if err != nil {
 			t.Fatalf("recount: %v", err)
 		}
@@ -116,7 +116,7 @@ func TestListCompaniesOrdersByJobCount(t *testing.T) {
 		insertJobForCompany(t, pool, ext, "gamma")
 	}
 	insertJobForCompany(t, pool, "alpha:1", "alpha")
-	if _, err := q.RecountCompanyJobCounts(ctx); err != nil {
+	if _, err := q.RefreshCompanyFacets(ctx); err != nil {
 		t.Fatalf("recount: %v", err)
 	}
 

--- a/internal/db/company_facets_integration_test.go
+++ b/internal/db/company_facets_integration_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+// Integration tests for the denormalized company facet arrays: RefreshCompanyFacets
+// aggregates each company's regions/countries (from the jobs geography columns) and
+// domains/company_types/company_sizes (from the jobs.enrichment JSONB) as the
+// distinct union over its OPEN jobs (closed_at IS NULL), in the same set-based pass
+// that maintains job_count. This is SQL behavior (array_agg over unnest /
+// jsonb_array_elements_text + the IS DISTINCT FROM guard), so it runs against a real
+// Postgres. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// insertJobWithFacets seeds a job carrying geography columns and an enrichment blob,
+// so the recompute has something to aggregate. An empty enrichment ("{}") models an
+// unenriched job.
+func insertJobWithFacets(t *testing.T, pool *pgxpool.Pool, externalID, companySlug string, regions, countries []string, enrichment string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, public_slug, company_slug, regions, countries, enrichment)
+		 VALUES ('test', $1, 'http://example.test', 'A job', 'job-' || $1, $2, $3, $4, $5)`,
+		externalID, companySlug, regions, countries, enrichment); err != nil {
+		t.Fatalf("insert job %q: %v", externalID, err)
+	}
+}
+
+// companyTextArray reads one denormalized facet array off the company row, sorted so
+// assertions are order-independent.
+func companyTextArray(t *testing.T, pool *pgxpool.Pool, slug, column string) []string {
+	t.Helper()
+	var got []string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT `+column+` FROM companies WHERE slug = $1`, slug).Scan(&got); err != nil {
+		t.Fatalf("read %s %q: %v", column, slug, err)
+	}
+	sort.Strings(got)
+	return got
+}
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRefreshCompanyFacets(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, "TRUNCATE companies, jobs RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	insertCompany(t, pool, "acme", "Acme Corp")
+	insertCompany(t, pool, "plain", "Plain Co")
+
+	// Acme: two open enriched jobs with overlapping facets + one closed job whose
+	// facets must be excluded.
+	insertJobWithFacets(t, pool, "acme:1", "acme",
+		[]string{"europe"}, []string{"de"},
+		`{"domains":["fintech"],"company_type":"startup","company_size":"11-50"}`)
+	insertJobWithFacets(t, pool, "acme:2", "acme",
+		[]string{"europe", "asia"}, []string{"de", "sg"},
+		`{"domains":["fintech","ecommerce"],"company_type":"product","company_size":"11-50"}`)
+	insertJobWithFacets(t, pool, "acme:closed", "acme",
+		[]string{"africa"}, []string{"ng"},
+		`{"domains":["gaming"],"company_type":"agency","company_size":"1000+"}`)
+	closeJobByExtID(t, pool, "acme:closed")
+
+	// Plain Co: one open, never-enriched job — geography present, enrichment empty.
+	insertJobWithFacets(t, pool, "plain:1", "plain",
+		[]string{"north_america"}, []string{"us"}, `{}`)
+
+	t.Run("unions derived from open jobs only", func(t *testing.T) {
+		if _, err := q.RefreshCompanyFacets(ctx); err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+		if got := companyTextArray(t, pool, "acme", "regions"); !eqStrings(got, []string{"asia", "europe"}) {
+			t.Errorf("acme regions = %v, want [asia europe] (closed africa excluded)", got)
+		}
+		if got := companyTextArray(t, pool, "acme", "countries"); !eqStrings(got, []string{"de", "sg"}) {
+			t.Errorf("acme countries = %v, want [de sg] (closed ng excluded)", got)
+		}
+		if got := companyTextArray(t, pool, "acme", "domains"); !eqStrings(got, []string{"ecommerce", "fintech"}) {
+			t.Errorf("acme domains = %v, want [ecommerce fintech] (closed gaming excluded)", got)
+		}
+		if got := companyTextArray(t, pool, "acme", "company_types"); !eqStrings(got, []string{"product", "startup"}) {
+			t.Errorf("acme company_types = %v, want [product startup]", got)
+		}
+		if got := companyTextArray(t, pool, "acme", "company_sizes"); !eqStrings(got, []string{"11-50"}) {
+			t.Errorf("acme company_sizes = %v, want [11-50]", got)
+		}
+	})
+
+	t.Run("unenriched job contributes no enrichment facets", func(t *testing.T) {
+		if got := companyTextArray(t, pool, "plain", "regions"); !eqStrings(got, []string{"north_america"}) {
+			t.Errorf("plain regions = %v, want [north_america]", got)
+		}
+		if got := companyTextArray(t, pool, "plain", "domains"); len(got) != 0 {
+			t.Errorf("plain domains = %v, want empty", got)
+		}
+		if got := companyTextArray(t, pool, "plain", "company_types"); len(got) != 0 {
+			t.Errorf("plain company_types = %v, want empty", got)
+		}
+	})
+
+	t.Run("re-running rewrites nothing", func(t *testing.T) {
+		rows, err := q.RefreshCompanyFacets(ctx)
+		if err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+		if rows != 0 {
+			t.Errorf("idempotent refresh affected %d rows, want 0", rows)
+		}
+	})
+
+	t.Run("closing all jobs empties the facet arrays", func(t *testing.T) {
+		closeJobByExtID(t, pool, "acme:1")
+		closeJobByExtID(t, pool, "acme:2")
+		if _, err := q.RefreshCompanyFacets(ctx); err != nil {
+			t.Fatalf("refresh: %v", err)
+		}
+		for _, col := range []string{"regions", "countries", "domains", "company_types", "company_sizes"} {
+			if got := companyTextArray(t, pool, "acme", col); len(got) != 0 {
+				t.Errorf("acme %s = %v after all jobs closed, want empty", col, got)
+			}
+		}
+	})
+}

--- a/internal/db/company_facets_integration_test.go
+++ b/internal/db/company_facets_integration_test.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"testing"
 
@@ -41,18 +42,6 @@ func companyTextArray(t *testing.T, pool *pgxpool.Pool, slug, column string) []s
 	}
 	sort.Strings(got)
 	return got
-}
-
-func eqStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 func TestRefreshCompanyFacets(t *testing.T) {
@@ -87,25 +76,25 @@ func TestRefreshCompanyFacets(t *testing.T) {
 		if _, err := q.RefreshCompanyFacets(ctx); err != nil {
 			t.Fatalf("refresh: %v", err)
 		}
-		if got := companyTextArray(t, pool, "acme", "regions"); !eqStrings(got, []string{"asia", "europe"}) {
+		if got := companyTextArray(t, pool, "acme", "regions"); !slices.Equal(got, []string{"asia", "europe"}) {
 			t.Errorf("acme regions = %v, want [asia europe] (closed africa excluded)", got)
 		}
-		if got := companyTextArray(t, pool, "acme", "countries"); !eqStrings(got, []string{"de", "sg"}) {
+		if got := companyTextArray(t, pool, "acme", "countries"); !slices.Equal(got, []string{"de", "sg"}) {
 			t.Errorf("acme countries = %v, want [de sg] (closed ng excluded)", got)
 		}
-		if got := companyTextArray(t, pool, "acme", "domains"); !eqStrings(got, []string{"ecommerce", "fintech"}) {
+		if got := companyTextArray(t, pool, "acme", "domains"); !slices.Equal(got, []string{"ecommerce", "fintech"}) {
 			t.Errorf("acme domains = %v, want [ecommerce fintech] (closed gaming excluded)", got)
 		}
-		if got := companyTextArray(t, pool, "acme", "company_types"); !eqStrings(got, []string{"product", "startup"}) {
+		if got := companyTextArray(t, pool, "acme", "company_types"); !slices.Equal(got, []string{"product", "startup"}) {
 			t.Errorf("acme company_types = %v, want [product startup]", got)
 		}
-		if got := companyTextArray(t, pool, "acme", "company_sizes"); !eqStrings(got, []string{"11-50"}) {
+		if got := companyTextArray(t, pool, "acme", "company_sizes"); !slices.Equal(got, []string{"11-50"}) {
 			t.Errorf("acme company_sizes = %v, want [11-50]", got)
 		}
 	})
 
 	t.Run("unenriched job contributes no enrichment facets", func(t *testing.T) {
-		if got := companyTextArray(t, pool, "plain", "regions"); !eqStrings(got, []string{"north_america"}) {
+		if got := companyTextArray(t, pool, "plain", "regions"); !slices.Equal(got, []string{"north_america"}) {
 			t.Errorf("plain regions = %v, want [north_america]", got)
 		}
 		if got := companyTextArray(t, pool, "plain", "domains"); len(got) != 0 {

--- a/internal/db/job_lifecycle_integration_test.go
+++ b/internal/db/job_lifecycle_integration_test.go
@@ -166,7 +166,7 @@ func TestClosedJobsLeaveListSurfacesButResolveOnDetail(t *testing.T) {
 
 	// companies.job_count is denormalized: UpsertJob does not maintain it,
 	// cmd/recount-companies does. Recompute before asserting on the column.
-	if _, err := q.RecountCompanyJobCounts(ctx); err != nil {
+	if _, err := q.RefreshCompanyFacets(ctx); err != nil {
 		t.Fatalf("recount company job counts: %v", err)
 	}
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -22,12 +22,17 @@ type ApiKey struct {
 }
 
 type Company struct {
-	Slug        string             `json:"slug"`
-	Name        string             `json:"name"`
-	CreatedAt   pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
-	Collections []string           `json:"collections"`
-	JobCount    int32              `json:"job_count"`
+	Slug         string             `json:"slug"`
+	Name         string             `json:"name"`
+	CreatedAt    pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
+	Collections  []string           `json:"collections"`
+	JobCount     int32              `json:"job_count"`
+	Regions      []string           `json:"regions"`
+	Countries    []string           `json:"countries"`
+	Domains      []string           `json:"domains"`
+	CompanyTypes []string           `json:"company_types"`
+	CompanySizes []string           `json:"company_sizes"`
 }
 
 type EnrichmentOutbox struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -59,9 +59,10 @@ type Querier interface {
 	// caller owns the grace window (cutoff = now() - window) and the "run ingested
 	// something" guard, so a failed crawl never mass-closes that source's catalogue.
 	CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams) (int64, error)
-	// Total companies matching the same optional name filter as ListCompanies, so
-	// search pagination reports the filtered total.
-	CountCompanies(ctx context.Context, search string) (int64, error)
+	// Total companies matching the same optional name + facet filters as ListCompanies,
+	// so search/filter pagination reports the filtered total. Keep this WHERE identical
+	// to ListCompanies.
+	CountCompanies(ctx context.Context, arg CountCompaniesParams) (int64, error)
 	CountJobs(ctx context.Context) (int64, error)
 	// Per-stage application counts for the Pipeline snapshot. An application is any
 	// row the user applied to or staged (saved-only rows are excluded); a row with
@@ -204,7 +205,10 @@ type Querier interface {
 	// DESC, name — the same ordering the sidebar company typeahead consumes. An empty
 	// `search` short-circuits the ILIKE, so the same prepared statement serves both
 	// the full list and a name search (`search` is a case-insensitive substring of the
-	// name).
+	// name). Each facet param is a text[] filtered by array overlap (&&): an empty
+	// array short-circuits to no constraint, non-empty values are OR-ed within the
+	// facet, and the facets AND together (and with the name search). CountCompanies
+	// MUST keep an identical WHERE so the filtered total matches the page.
 	ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error)
 	// All companies with their current collection membership. cmd/import-collections
 	// reads this to know the existing company slugs (the match target) and each
@@ -316,13 +320,18 @@ type Querier interface {
 	// left in place — its expiry gates the retry to a later run and doubles as the
 	// crash reaper, so a failed post is never reprocessed within the same run.
 	RecordTelegramPostFailure(ctx context.Context, arg RecordTelegramPostFailureParams) (RecordTelegramPostFailureRow, error)
-	// Recompute every company's denormalized open-job count in one set-based pass:
-	// aggregate open jobs (closed_at IS NULL) once by company_slug, LEFT JOIN it onto
-	// companies so a company with no open jobs is zeroed (COALESCE), and write the
-	// result. The `IS DISTINCT FROM` guard skips rows whose count is already correct,
-	// so re-running rewrites nothing and the affected-rows count reports real churn.
-	// This is cmd/recount-companies' whole job; run periodically (eventual consistency).
-	RecountCompanyJobCounts(ctx context.Context) (int64, error)
+	// Recompute every company's denormalized state in one set-based pass: the open-job
+	// count plus the facet arrays derived from those open jobs — regions/countries from
+	// the jobs geography columns, and domains/company_types/company_sizes from the
+	// jobs.enrichment JSONB. Each array is the distinct union across the company's open
+	// jobs (closed_at IS NULL), aggregated with a stable ORDER BY so the guard below
+	// compares deterministically. A company with no open jobs (or no enriched jobs) is
+	// zeroed/emptied via COALESCE. The per-column `IS DISTINCT FROM` guard skips rows
+	// already current, so re-running rewrites nothing and the affected-rows count reports
+	// real churn. This is cmd/recount-companies' whole job; run periodically (eventual
+	// consistency). The facet aggregates are each their own non-correlated GROUP BY so
+	// the row-multiplying unnest of one array never distorts another's count.
+	RefreshCompanyFacets(ctx context.Context) (int64, error)
 	// Release the lease on a subscription's claimed jobs without counting an attempt,
 	// so a soft-skipped delivery (e.g. Telegram not yet linked) is retried promptly on
 	// a later pass instead of waiting out the lease.

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -12,12 +12,12 @@
 SELECT slug, name, job_count
 FROM companies
 WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%')
-  AND (cardinality(sqlc.arg('collections')::text[]) = 0 OR collections && sqlc.arg('collections')::text[])
-  AND (cardinality(sqlc.arg('regions')::text[]) = 0 OR regions && sqlc.arg('regions')::text[])
-  AND (cardinality(sqlc.arg('countries')::text[]) = 0 OR countries && sqlc.arg('countries')::text[])
-  AND (cardinality(sqlc.arg('domains')::text[]) = 0 OR domains && sqlc.arg('domains')::text[])
-  AND (cardinality(sqlc.arg('company_types')::text[]) = 0 OR company_types && sqlc.arg('company_types')::text[])
-  AND (cardinality(sqlc.arg('company_sizes')::text[]) = 0 OR company_sizes && sqlc.arg('company_sizes')::text[])
+  AND (coalesce(cardinality(sqlc.arg('collections')::text[]), 0) = 0 OR collections && sqlc.arg('collections')::text[])
+  AND (coalesce(cardinality(sqlc.arg('regions')::text[]), 0) = 0 OR regions && sqlc.arg('regions')::text[])
+  AND (coalesce(cardinality(sqlc.arg('countries')::text[]), 0) = 0 OR countries && sqlc.arg('countries')::text[])
+  AND (coalesce(cardinality(sqlc.arg('domains')::text[]), 0) = 0 OR domains && sqlc.arg('domains')::text[])
+  AND (coalesce(cardinality(sqlc.arg('company_types')::text[]), 0) = 0 OR company_types && sqlc.arg('company_types')::text[])
+  AND (coalesce(cardinality(sqlc.arg('company_sizes')::text[]), 0) = 0 OR company_sizes && sqlc.arg('company_sizes')::text[])
 ORDER BY job_count DESC, name
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
@@ -28,12 +28,12 @@ LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 SELECT count(*)
 FROM companies
 WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%')
-  AND (cardinality(sqlc.arg('collections')::text[]) = 0 OR collections && sqlc.arg('collections')::text[])
-  AND (cardinality(sqlc.arg('regions')::text[]) = 0 OR regions && sqlc.arg('regions')::text[])
-  AND (cardinality(sqlc.arg('countries')::text[]) = 0 OR countries && sqlc.arg('countries')::text[])
-  AND (cardinality(sqlc.arg('domains')::text[]) = 0 OR domains && sqlc.arg('domains')::text[])
-  AND (cardinality(sqlc.arg('company_types')::text[]) = 0 OR company_types && sqlc.arg('company_types')::text[])
-  AND (cardinality(sqlc.arg('company_sizes')::text[]) = 0 OR company_sizes && sqlc.arg('company_sizes')::text[]);
+  AND (coalesce(cardinality(sqlc.arg('collections')::text[]), 0) = 0 OR collections && sqlc.arg('collections')::text[])
+  AND (coalesce(cardinality(sqlc.arg('regions')::text[]), 0) = 0 OR regions && sqlc.arg('regions')::text[])
+  AND (coalesce(cardinality(sqlc.arg('countries')::text[]), 0) = 0 OR countries && sqlc.arg('countries')::text[])
+  AND (coalesce(cardinality(sqlc.arg('domains')::text[]), 0) = 0 OR domains && sqlc.arg('domains')::text[])
+  AND (coalesce(cardinality(sqlc.arg('company_types')::text[]), 0) = 0 OR company_types && sqlc.arg('company_types')::text[])
+  AND (coalesce(cardinality(sqlc.arg('company_sizes')::text[]), 0) = 0 OR company_sizes && sqlc.arg('company_sizes')::text[]);
 
 -- name: GetCompany :one
 -- SELECT * (not an explicit column list) so the generated row stays db.Company as

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -5,19 +5,35 @@
 -- DESC, name — the same ordering the sidebar company typeahead consumes. An empty
 -- `search` short-circuits the ILIKE, so the same prepared statement serves both
 -- the full list and a name search (`search` is a case-insensitive substring of the
--- name).
+-- name). Each facet param is a text[] filtered by array overlap (&&): an empty
+-- array short-circuits to no constraint, non-empty values are OR-ed within the
+-- facet, and the facets AND together (and with the name search). CountCompanies
+-- MUST keep an identical WHERE so the filtered total matches the page.
 SELECT slug, name, job_count
 FROM companies
-WHERE sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%'
+WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%')
+  AND (cardinality(sqlc.arg('collections')::text[]) = 0 OR collections && sqlc.arg('collections')::text[])
+  AND (cardinality(sqlc.arg('regions')::text[]) = 0 OR regions && sqlc.arg('regions')::text[])
+  AND (cardinality(sqlc.arg('countries')::text[]) = 0 OR countries && sqlc.arg('countries')::text[])
+  AND (cardinality(sqlc.arg('domains')::text[]) = 0 OR domains && sqlc.arg('domains')::text[])
+  AND (cardinality(sqlc.arg('company_types')::text[]) = 0 OR company_types && sqlc.arg('company_types')::text[])
+  AND (cardinality(sqlc.arg('company_sizes')::text[]) = 0 OR company_sizes && sqlc.arg('company_sizes')::text[])
 ORDER BY job_count DESC, name
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
 -- name: CountCompanies :one
--- Total companies matching the same optional name filter as ListCompanies, so
--- search pagination reports the filtered total.
+-- Total companies matching the same optional name + facet filters as ListCompanies,
+-- so search/filter pagination reports the filtered total. Keep this WHERE identical
+-- to ListCompanies.
 SELECT count(*)
 FROM companies
-WHERE sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%';
+WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%')
+  AND (cardinality(sqlc.arg('collections')::text[]) = 0 OR collections && sqlc.arg('collections')::text[])
+  AND (cardinality(sqlc.arg('regions')::text[]) = 0 OR regions && sqlc.arg('regions')::text[])
+  AND (cardinality(sqlc.arg('countries')::text[]) = 0 OR countries && sqlc.arg('countries')::text[])
+  AND (cardinality(sqlc.arg('domains')::text[]) = 0 OR domains && sqlc.arg('domains')::text[])
+  AND (cardinality(sqlc.arg('company_types')::text[]) = 0 OR company_types && sqlc.arg('company_types')::text[])
+  AND (cardinality(sqlc.arg('company_sizes')::text[]) = 0 OR company_sizes && sqlc.arg('company_sizes')::text[]);
 
 -- name: GetCompany :one
 -- SELECT * (not an explicit column list) so the generated row stays db.Company as
@@ -65,21 +81,75 @@ ON CONFLICT (slug) DO UPDATE SET
 DELETE FROM companies c
 WHERE NOT EXISTS (SELECT 1 FROM jobs j WHERE j.company_slug = c.slug);
 
--- name: RecountCompanyJobCounts :execrows
--- Recompute every company's denormalized open-job count in one set-based pass:
--- aggregate open jobs (closed_at IS NULL) once by company_slug, LEFT JOIN it onto
--- companies so a company with no open jobs is zeroed (COALESCE), and write the
--- result. The `IS DISTINCT FROM` guard skips rows whose count is already correct,
--- so re-running rewrites nothing and the affected-rows count reports real churn.
--- This is cmd/recount-companies' whole job; run periodically (eventual consistency).
-UPDATE companies c
-SET job_count = COALESCE(o.cnt, 0)
-FROM companies c2
-LEFT JOIN (
-    SELECT company_slug, count(*) AS cnt
+-- name: RefreshCompanyFacets :execrows
+-- Recompute every company's denormalized state in one set-based pass: the open-job
+-- count plus the facet arrays derived from those open jobs — regions/countries from
+-- the jobs geography columns, and domains/company_types/company_sizes from the
+-- jobs.enrichment JSONB. Each array is the distinct union across the company's open
+-- jobs (closed_at IS NULL), aggregated with a stable ORDER BY so the guard below
+-- compares deterministically. A company with no open jobs (or no enriched jobs) is
+-- zeroed/emptied via COALESCE. The per-column `IS DISTINCT FROM` guard skips rows
+-- already current, so re-running rewrites nothing and the affected-rows count reports
+-- real churn. This is cmd/recount-companies' whole job; run periodically (eventual
+-- consistency). The facet aggregates are each their own non-correlated GROUP BY so
+-- the row-multiplying unnest of one array never distorts another's count.
+WITH oj AS (
+    SELECT company_slug, regions, countries, enrichment
     FROM jobs
     WHERE closed_at IS NULL AND company_slug <> ''
+),
+counts AS (
+    SELECT company_slug, count(*) AS cnt FROM oj GROUP BY company_slug
+),
+reg AS (
+    SELECT company_slug, array_agg(DISTINCT r ORDER BY r) AS arr
+    FROM oj CROSS JOIN LATERAL unnest(oj.regions) AS r
     GROUP BY company_slug
-) o ON o.company_slug = c2.slug
+),
+cty AS (
+    SELECT company_slug, array_agg(DISTINCT c ORDER BY c) AS arr
+    FROM oj CROSS JOIN LATERAL unnest(oj.countries) AS c
+    GROUP BY company_slug
+),
+dom AS (
+    SELECT company_slug, array_agg(DISTINCT d ORDER BY d) AS arr
+    FROM oj CROSS JOIN LATERAL jsonb_array_elements_text(
+        CASE WHEN jsonb_typeof(oj.enrichment->'domains') = 'array'
+             THEN oj.enrichment->'domains' ELSE '[]'::jsonb END) AS d
+    GROUP BY company_slug
+),
+ctype AS (
+    SELECT company_slug,
+           array_agg(DISTINCT (enrichment->>'company_type') ORDER BY (enrichment->>'company_type')) AS arr
+    FROM oj
+    WHERE COALESCE(enrichment->>'company_type', '') <> ''
+    GROUP BY company_slug
+),
+csize AS (
+    SELECT company_slug,
+           array_agg(DISTINCT (enrichment->>'company_size') ORDER BY (enrichment->>'company_size')) AS arr
+    FROM oj
+    WHERE COALESCE(enrichment->>'company_size', '') <> ''
+    GROUP BY company_slug
+)
+UPDATE companies c
+SET job_count     = COALESCE(counts.cnt, 0),
+    regions       = COALESCE(reg.arr, '{}'),
+    countries     = COALESCE(cty.arr, '{}'),
+    domains       = COALESCE(dom.arr, '{}'),
+    company_types = COALESCE(ctype.arr, '{}'),
+    company_sizes = COALESCE(csize.arr, '{}')
+FROM companies c2
+LEFT JOIN counts ON counts.company_slug = c2.slug
+LEFT JOIN reg    ON reg.company_slug    = c2.slug
+LEFT JOIN cty    ON cty.company_slug    = c2.slug
+LEFT JOIN dom    ON dom.company_slug    = c2.slug
+LEFT JOIN ctype  ON ctype.company_slug  = c2.slug
+LEFT JOIN csize  ON csize.company_slug  = c2.slug
 WHERE c.slug = c2.slug
-  AND c.job_count IS DISTINCT FROM COALESCE(o.cnt, 0);
+  AND (c.job_count     IS DISTINCT FROM COALESCE(counts.cnt, 0)
+    OR c.regions       IS DISTINCT FROM COALESCE(reg.arr, '{}')
+    OR c.countries     IS DISTINCT FROM COALESCE(cty.arr, '{}')
+    OR c.domains       IS DISTINCT FROM COALESCE(dom.arr, '{}')
+    OR c.company_types IS DISTINCT FROM COALESCE(ctype.arr, '{}')
+    OR c.company_sizes IS DISTINCT FROM COALESCE(csize.arr, '{}'));

--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"net/url"
+
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -15,30 +17,71 @@ type companyDetailResponse struct {
 	Jobs    []jobview.Job `json:"jobs"`
 }
 
-// ListCompanies returns a page of companies with their job counts. Counts are
-// computed at query time; there is no denormalized counter yet. An optional `q`
-// query param filters companies by a case-insensitive name substring; an empty
-// or absent `q` returns the full list. meta.total reports the count matching the
-// filter so pagination over a search is correct.
+// ListCompanies returns a page of companies with their denormalized job counts,
+// most active first. An optional `q` query param filters by a case-insensitive
+// name substring, and repeatable facet params — collections/regions/countries/
+// domains/company_type/company_size — filter against the company's denormalized
+// facet arrays by array overlap (OR within a facet, AND across facets), composably
+// with `q`. meta.total reports the count matching the full filter so pagination is
+// correct.
 func (a *API) ListCompanies(c *fiber.Ctx) error {
 	limit, offset := pageParams(c)
 	search := c.Query("q")
+	vals, _ := url.ParseQuery(string(c.Request().URI().QueryString()))
+
+	// Parse each facet once and feed both queries, so their WHERE clauses can't
+	// drift. The query param names (company_type/company_size singular) differ from
+	// the plural db columns; every facet is a non-nil slice so pgx sends '{}', not
+	// NULL — NULL would defeat the cardinality() short-circuit.
+	collections := facetValues(vals, "collections")
+	regions := facetValues(vals, "regions")
+	countries := facetValues(vals, "countries")
+	domains := facetValues(vals, "domains")
+	companyTypes := facetValues(vals, "company_type")
+	companySizes := facetValues(vals, "company_size")
 
 	companies, err := a.queries.ListCompanies(c.Context(), db.ListCompaniesParams{
-		Search: search,
-		Limit:  int32(limit),
-		Offset: int32(offset),
+		Search:       search,
+		Collections:  collections,
+		Regions:      regions,
+		Countries:    countries,
+		Domains:      domains,
+		CompanyTypes: companyTypes,
+		CompanySizes: companySizes,
+		Limit:        int32(limit),
+		Offset:       int32(offset),
 	})
 	if err != nil {
 		return err
 	}
 
-	total, err := a.queries.CountCompanies(c.Context(), search)
+	total, err := a.queries.CountCompanies(c.Context(), db.CountCompaniesParams{
+		Search:       search,
+		Collections:  collections,
+		Regions:      regions,
+		Countries:    countries,
+		Domains:      domains,
+		CompanyTypes: companyTypes,
+		CompanySizes: companySizes,
+	})
 	if err != nil {
 		return err
 	}
 
 	return listResponse(c, companies, total, limit, offset)
+}
+
+// facetValues reads the repeatable values of one facet query param, dropping empty
+// entries and always returning a non-nil slice (so pgx encodes '{}' rather than
+// NULL for an absent facet, keeping the SQL cardinality() short-circuit true).
+func facetValues(vals url.Values, key string) []string {
+	out := make([]string, 0, len(vals[key]))
+	for _, v := range vals[key] {
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // GetCompany returns a single company together with a page of its jobs. The

--- a/internal/handler/companies_integration_test.go
+++ b/internal/handler/companies_integration_test.go
@@ -131,3 +131,93 @@ func TestListCompaniesSearchEndpoint(t *testing.T) {
 		}
 	})
 }
+
+func TestListCompaniesFacetFilterEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	// Seed the denormalized facet arrays directly — this exercises the endpoint's
+	// array-overlap filter independently of how the arrays get derived.
+	seed := func(slug, name string, collections, regions, companyTypes []string) {
+		t.Helper()
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO companies (slug, name, collections, regions, company_types)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			slug, name, collections, regions, companyTypes); err != nil {
+			t.Fatalf("seed %q: %v", slug, err)
+		}
+	}
+	seed("euro-lab", "Euro Lab", []string{"yc"}, []string{"europe"}, []string{"startup"})
+	seed("asia-co", "Asia Co", []string{}, []string{"asia"}, []string{"product"})
+	seed("euro-corp", "Euro Corp", []string{"bigtech"}, []string{"europe"}, []string{"enterprise"})
+	seed("global-lab", "Global Lab", []string{"yc"}, []string{"north_america"}, []string{"enterprise"})
+
+	h := &API{pool: pool, queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/companies", h.ListCompanies)
+
+	doList := func(t *testing.T, url string) (slugs []string, total float64) {
+		t.Helper()
+		resp, err := app.Test(httptest.NewRequest("GET", url, nil))
+		if err != nil {
+			t.Fatalf("request %q: %v", url, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+		var body struct {
+			Data []struct {
+				Slug string `json:"slug"`
+			} `json:"data"`
+			Meta struct {
+				Total float64 `json:"total"`
+			} `json:"meta"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		for _, c := range body.Data {
+			slugs = append(slugs, c.Slug)
+		}
+		sort.Strings(slugs)
+		return slugs, body.Meta.Total
+	}
+
+	assertSlugs := func(t *testing.T, url string, want []string) {
+		t.Helper()
+		got, total := doList(t, url)
+		sort.Strings(want)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("%s → slugs %v, want %v", url, got, want)
+		}
+		if int(total) != len(want) {
+			t.Errorf("%s → meta.total %v, want %d", url, total, len(want))
+		}
+	}
+
+	t.Run("single facet filters by array membership", func(t *testing.T) {
+		assertSlugs(t, "/api/v1/companies?regions=europe", []string{"euro-corp", "euro-lab"})
+	})
+
+	t.Run("multiple values within a facet are OR-ed", func(t *testing.T) {
+		assertSlugs(t, "/api/v1/companies?regions=europe&regions=asia",
+			[]string{"asia-co", "euro-corp", "euro-lab"})
+	})
+
+	t.Run("different facets are AND-ed", func(t *testing.T) {
+		assertSlugs(t, "/api/v1/companies?collections=yc&company_type=startup",
+			[]string{"euro-lab"})
+	})
+
+	t.Run("facets compose with the name search", func(t *testing.T) {
+		assertSlugs(t, "/api/v1/companies?collections=yc&q=lab",
+			[]string{"euro-lab", "global-lab"})
+	})
+
+	t.Run("no facet params returns the full list", func(t *testing.T) {
+		assertSlugs(t, "/api/v1/companies",
+			[]string{"asia-co", "euro-corp", "euro-lab", "global-lab"})
+	})
+}

--- a/migrations/0030_company_facets.sql
+++ b/migrations/0030_company_facets.sql
@@ -1,0 +1,25 @@
+-- Denormalized facet arrays per company, derived from the company's open jobs so
+-- the /companies catalog can be filtered by collection/region/country/industry/
+-- type/size without joining jobs on the hot read path. Like companies.job_count
+-- (0025), these are maintained by the periodic recompute (cmd/recount-companies),
+-- not a write-path trigger, so they are eventually consistent with jobs.
+--
+-- regions/countries come from the top-level jobs.regions/jobs.countries columns
+-- (dense from ingest); domains/company_types/company_sizes come from the
+-- jobs.enrichment JSONB (sparse until a job is LLM-enriched). Each is the distinct
+-- union across the company's open jobs. Default '{}' so a company with no open
+-- jobs (or no enriched jobs) reads as empty between recomputes.
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS regions        TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS countries      TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS domains        TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS company_types  TEXT[] NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS company_sizes  TEXT[] NOT NULL DEFAULT '{}';
+
+-- GIN indexes back the array-overlap (&&) filters the list endpoint uses; without
+-- them a facet filter would sequentially scan companies.
+CREATE INDEX IF NOT EXISTS companies_regions_idx       ON companies USING GIN (regions);
+CREATE INDEX IF NOT EXISTS companies_countries_idx     ON companies USING GIN (countries);
+CREATE INDEX IF NOT EXISTS companies_domains_idx       ON companies USING GIN (domains);
+CREATE INDEX IF NOT EXISTS companies_company_types_idx ON companies USING GIN (company_types);
+CREATE INDEX IF NOT EXISTS companies_company_sizes_idx ON companies USING GIN (company_sizes);

--- a/openspec/changes/company-filter-sidebar/.openspec.yaml
+++ b/openspec/changes/company-filter-sidebar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/company-filter-sidebar/design.md
+++ b/openspec/changes/company-filter-sidebar/design.md
@@ -1,0 +1,134 @@
+## Context
+
+The `/companies` catalog is a search-only list. A company row has `slug`, `name`,
+`collections TEXT[]`, and a denormalized `job_count` (maintained by the periodic
+`cmd/recount-companies` worker via `RecountCompanyJobCounts`). All richer facts —
+geography, industry, type, size — live on the company's **jobs**, not the company:
+
+- `jobs.regions` / `jobs.countries` are top-level `TEXT[]` columns, populated
+  deterministically at ingest by `internal/location`.
+- `enrichment.domains` (array), `enrichment.company_type`, `enrichment.company_size`
+  live only inside the `jobs.enrichment` JSONB, populated asynchronously by the
+  LLM enrichment worker.
+
+The jobs page already has a mature filter sidebar: a URL-synced `FilterStore`
+(`web/src/lib/filters.ts`), a data-driven `FACETS` registry (`web/src/lib/facets.ts`),
+and reusable per-facet controls (`FacetSection`, `PillGroup`, `SearchSelect`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the companies catalog browsable by collection, region, country, industry,
+  company type, and company size.
+- Derive those facets onto the company from its open jobs and filter with plain
+  SQL, staying consistent with the existing `job_count` denormalization pattern.
+- Reuse the existing frontend filter machinery rather than inventing a parallel one.
+
+**Non-Goals:**
+- Live facet counts next to company options (jobs-style distribution). Options come
+  from static vocabularies; counts are a later, separable addition.
+- A Meilisearch index for companies. The list stays plain SQL.
+- Real (external) company headcount. `company_size` is the LLM's per-job estimate,
+  used as-is.
+- Synchronous, per-write facet maintenance. Eventual consistency via the recompute
+  is sufficient (same guarantee `job_count` already has).
+
+## Decisions
+
+### D1: Denormalize facet arrays onto `companies`, filter by array overlap
+
+Add five `TEXT[]` columns to `companies` — `regions`, `countries`, `domains`,
+`company_types`, `company_sizes` — each the distinct union of the value across the
+company's open jobs. Filter the list with the Postgres array-overlap operator
+`&&`: OR within a facet, AND across facets. `collections` (already an array) joins
+the same filtering path.
+
+*Why over alternatives:* query-time aggregation (JOIN to `jobs` on every list
+request) is heavier and yields no clean per-company facet value set; a Meili
+companies index is a whole new index + reindex worker — overkill for a
+closed-vocabulary browse filter. Denormalize-and-recompute mirrors `job_count` and
+the project's established "derive a fact next to the row, refresh periodically"
+pattern.
+
+### D2: Extend the existing recompute pass, don't add a worker
+
+Fold the facet aggregation into `RecountCompanyJobCounts` (renamed to reflect its
+wider job, e.g. `RefreshCompanyFacets`) so one set-based `UPDATE … FROM` computes
+`job_count` **and** all five arrays in a single pass, guarded by `IS DISTINCT FROM`
+so unchanged rows aren't rewritten. `cmd/recount-companies` keeps its shape (load
+pool → one query call → log affected rows).
+
+The aggregation subquery groups open jobs by `company_slug`:
+- `regions` / `countries`: `array_agg(DISTINCT r ORDER BY r)` over
+  `unnest(jobs.regions|countries)`.
+- `domains`: `array_agg(DISTINCT d ORDER BY d)` over
+  `jsonb_array_elements_text(enrichment->'domains')`.
+- `company_types` / `company_sizes`: `array_agg(DISTINCT enrichment->>'company_type'|'company_size')`
+  filtered to non-null, non-empty.
+
+Arrays are aggregated with a stable `ORDER BY` so the `IS DISTINCT FROM` guard
+compares deterministically (element order is significant to array equality).
+
+*Why:* a second worker/cron would duplicate the load-pool + schedule scaffolding
+and split a single logical "refresh the company's derived state" into two passes
+that can disagree between runs. One pass, one guard, one cron entry.
+
+### D3: Reuse `FilterStore` + `FacetSection`; add a `COMPANY_FACETS` subset
+
+Introduce a `COMPANY_FACETS` registry (a subset of the jobs `FacetDef` shape:
+`collections`, `regions`, `countries`, `domains`, `company_type`, `company_size`,
+reusing the existing `COLLECTION` / `REGION` / `DOMAIN` / company-type / -size
+option lists) and a thin `CompanyFiltersPanel` that iterates it and renders each
+via the existing `FacetSection`. `CompaniesView.svelte` gains the sidebar next to
+the list; `FilterStore` provides URL sync + the debounced `applied` snapshot the
+list reload subscribes to. `country` uses the searchable-select control over the
+static ISO country list (no live counts).
+
+*Why over a bespoke panel:* `FacetSection` already renders pills/selects, handles
+clear, and is closed-vocabulary-aware; `FilterStore` already solves URL sync and
+back/forward restoration (the exact bug class fixed in PR#309). Building a second
+implementation would re-introduce those hazards. We deliberately do **not** reuse
+the jobs `FiltersPanel` wholesale because it hard-codes job-only controls (salary
+slider, freshness, remote/visa checkboxes).
+
+### D4: SSR forwards facet params
+
+`/companies/+page.server.ts` reads the facet params from the request URL and passes
+them to `listCompanies` so the first render is already filtered (matching how `?q`
+is handled today), preserving shareable/deep-linkable filtered URLs.
+
+## Risks / Trade-offs
+
+- **Sparse enrichment facets** (`domains`/`company_types`/`company_sizes` empty
+  until jobs are enriched) → acceptable: geography facets are dense from ingest, and
+  enrichment backfills over time. Document it; don't block on full enrichment.
+- **`company_size` is an LLM estimate**, and a company's jobs may disagree (so a
+  company can appear under multiple size buckets) → acceptable for a browse filter;
+  overlap semantics already tolerate multiple values.
+- **No live counts** → a user can pick a facet combination that yields zero
+  companies with no forewarning. Mitigation: the existing empty-state handles it;
+  live counts are a noted future addition.
+- **Array-equality churn in the guard** if aggregation order isn't stable → mitigated
+  by `ORDER BY` inside every `array_agg`, so equal sets compare equal.
+- **Migration on a live prod volume**: initdb-only migrations don't re-apply, so the
+  new columns must be added manually via psql on prod (established ops), then one
+  `cmd/recount-companies` run backfills. Rollback: the columns are additive and
+  unread by old code paths; dropping them (or leaving them) is safe.
+
+## Migration Plan
+
+1. Ship additive migration adding the five `TEXT[]` columns (`DEFAULT '{}'`).
+2. On prod, apply the migration manually via psql (initdb migrations don't
+   re-apply to an existing volume).
+3. Deploy backend (recompute now refreshes facets; list endpoint accepts facet
+   params) and frontend (sidebar).
+4. Run `cmd/recount-companies` once to backfill the arrays; thereafter the existing
+   cron keeps them fresh. No reindex (companies list is not Meili-backed).
+
+Rollback: revert app to the prior build; the extra columns are inert. No data
+migration to undo.
+
+## Open Questions
+
+None — scope (facets, storage, counts-later, country in v1, company_size included)
+was settled during brainstorming.

--- a/openspec/changes/company-filter-sidebar/design.md
+++ b/openspec/changes/company-filter-sidebar/design.md
@@ -73,23 +73,32 @@ compares deterministically (element order is significant to array equality).
 and split a single logical "refresh the company's derived state" into two passes
 that can disagree between runs. One pass, one guard, one cron entry.
 
-### D3: Reuse `FilterStore` + `FacetSection`; add a `COMPANY_FACETS` subset
+### D3: Extract a `FacetStore` interface; add `COMPANY_FACETS` + a thin store & panel
 
 Introduce a `COMPANY_FACETS` registry (a subset of the jobs `FacetDef` shape:
 `collections`, `regions`, `countries`, `domains`, `company_type`, `company_size`,
-reusing the existing `COLLECTION` / `REGION` / `DOMAIN` / company-type / -size
-option lists) and a thin `CompanyFiltersPanel` that iterates it and renders each
-via the existing `FacetSection`. `CompaniesView.svelte` gains the sidebar next to
-the list; `FilterStore` provides URL sync + the debounced `applied` snapshot the
-list reload subscribes to. `country` uses the searchable-select control over the
-static ISO country list (no live counts).
+reusing the existing `COLLECTION` / `REGION` / `DOMAIN` / company-type option lists,
+plus a static `COMPANY_SIZE` list and a static ISO `COUNTRY` list) and a thin
+`CompanyFiltersPanel` that iterates it and renders each via the existing
+`FacetSection`. `CompaniesView.svelte` gains the sidebar next to the list.
 
-*Why over a bespoke panel:* `FacetSection` already renders pills/selects, handles
-clear, and is closed-vocabulary-aware; `FilterStore` already solves URL sync and
-back/forward restoration (the exact bug class fixed in PR#309). Building a second
-implementation would re-introduce those hazards. We deliberately do **not** reuse
-the jobs `FiltersPanel` wholesale because it hard-codes job-only controls (salary
-slider, freshness, remote/visa checkboxes).
+The job `FilterStore` is **not** reused directly — it is coupled to the global jobs
+`FACETS` registry and the job-only shape (`visa`/`salary`/`sort`), and it serializes
+the `_exclude`/`_mode` conventions the companies endpoint doesn't understand.
+Instead, extract the narrow `FacetStore` interface `FacetSection` actually depends on
+(`facet`/`toggle`/`add`/`remove`/`clearFacet`/`setExclude`/`setMatchAll`), retype
+`FacetSection` to it, and add a dedicated `CompanyFilterStore` — a thin wrapper over
+the same shared `UrlSyncedState` primitive with plain repeated-param
+(de)serialization (no exclude/mode). Both stores satisfy `FacetStore`, so the same
+section/control components render either.
+
+*Why:* `FacetSection` already renders pills/selects, handles clear, and is
+closed-vocabulary-aware; the `UrlSyncedState` primitive already solves URL sync and
+back/forward restoration (the exact bug class fixed in PR#309). Reusing them via a
+shared interface keeps one implementation of those hazards. We deliberately do **not**
+reuse the jobs `FiltersPanel` wholesale because it hard-codes job-only controls
+(salary slider, freshness, remote/visa checkboxes). `country` uses the
+searchable-select control over the static ISO country list (no live counts).
 
 ### D4: SSR forwards facet params
 

--- a/openspec/changes/company-filter-sidebar/proposal.md
+++ b/openspec/changes/company-filter-sidebar/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+The `/companies` catalog page is a flat, search-only list — the only way to narrow
+it is a name substring. Users who want to browse *kinds* of companies ("YC fintech
+startups hiring in Europe") have no way to filter. Jobs already have a rich facet
+sidebar; companies should get a parallel one so the catalog is browsable, not just
+searchable.
+
+The obstacle is data: a company row today carries only `slug`, `name`,
+`collections`, and `job_count`. It has no geography, industry, type, or size of its
+own — those facts live on its jobs. So this change is primarily about deriving and
+denormalizing those facets onto the company from its open jobs, then filtering on
+them.
+
+## What Changes
+
+- Add derived facet arrays to the `companies` table: `regions`, `countries`,
+  `domains`, `company_types`, `company_sizes` (all `TEXT[]`), each the distinct
+  union of the corresponding value across the company's **open** jobs.
+- Extend the periodic company recompute (`cmd/recount-companies`) to refresh these
+  arrays in the same set-based pass that maintains `job_count`, so they stay
+  eventually consistent with `jobs`.
+- Extend `GET /api/v1/companies` to accept repeatable facet query parameters
+  (`collections`, `regions`, `countries`, `domains`, `company_type`,
+  `company_size`), filtering by array overlap: OR within a facet, AND across
+  facets, composable with the existing `q` name search.
+- Add a filter sidebar to the `/companies` web page, reusing the jobs filter
+  machinery (URL-synced filter state + reusable facet controls), with facets for
+  collection, region, country, industry, company type, and company size.
+
+No breaking changes: the new query parameters and columns are additive; an
+unfiltered request behaves exactly as before.
+
+## Capabilities
+
+### New Capabilities
+<!-- none: this extends existing capabilities -->
+
+### Modified Capabilities
+- `companies`: the `companies` table gains derived facet arrays (`regions`,
+  `countries`, `domains`, `company_types`, `company_sizes`) maintained by the
+  periodic recompute; `GET /api/v1/companies` gains facet-filter query parameters
+  with array-overlap semantics.
+- `web-frontend`: the companies catalog page gains a filter sidebar (collection /
+  region / country / industry / company type / company size), URL-synced like the
+  jobs filters.
+
+## Impact
+
+- **Schema**: new additive migration adding five `TEXT[]` columns to `companies`
+  (default `'{}'`). Applied on prod manually via psql (per project ops); after
+  deploy, one `cmd/recount-companies` run backfills the arrays. No reindex — the
+  companies list is plain SQL, not Meilisearch.
+- **DB/queries**: `internal/db/queries/companies.sql` — the recompute query is
+  extended to aggregate the facet arrays; `ListCompanies`/`CountCompanies` gain
+  optional array-overlap filters.
+- **Backend**: `internal/handler/companies.go` parses the new facet params;
+  `cmd/recount-companies` unchanged in shape (still one query call).
+- **Frontend**: `web/src/lib/components/CompaniesView.svelte` gains a sidebar; new
+  `COMPANY_FACETS` registry and a `CompanyFiltersPanel`, reusing `FilterStore` and
+  `FacetSection`; `web/src/lib/api.ts` `listCompanies` passes facet params;
+  `/companies/+page.server.ts` forwards them for SSR.
+- **Data quality note**: `regions`/`countries` are dense from ingest; `domains`/
+  `company_types`/`company_sizes` are sparse until a job is LLM-enriched, and
+  `company_size` is an LLM estimate — acceptable for a browse filter.

--- a/openspec/changes/company-filter-sidebar/specs/companies/spec.md
+++ b/openspec/changes/company-filter-sidebar/specs/companies/spec.md
@@ -1,0 +1,153 @@
+## ADDED Requirements
+
+### Requirement: Companies carry derived facet arrays aggregated from their open jobs
+
+The system SHALL store, on each `companies` row, a set of denormalized facet
+arrays derived from the company's **open** jobs (`closed_at IS NULL`):
+`regions`, `countries`, `domains`, `company_types`, and `company_sizes` (each a
+`TEXT[]`). Each array SHALL be the **distinct union** of the corresponding value
+across the company's open jobs:
+
+- `regions` and `countries` from the top-level `jobs.regions` / `jobs.countries`
+  columns.
+- `domains`, `company_types`, `company_sizes` from the job's `enrichment` payload
+  (`domains` array, `company_type` scalar, `company_size` scalar); an unenriched
+  or value-less job contributes nothing, so these arrays are sparse until jobs are
+  enriched.
+
+A company with no open jobs SHALL have every facet array empty (`'{}'`). The
+arrays SHALL be maintained by the same periodic recompute that maintains
+`job_count` (see the recompute requirement), not by a synchronous write on the
+ingest/close paths, so they are eventually consistent with `jobs`.
+
+#### Scenario: Region and country unions are derived from open jobs
+
+- **WHEN** the recompute runs for a company whose open jobs have regions
+  `{europe}`, `{europe, asia}` and countries `{de}`, `{de, sg}`
+- **THEN** that company's `regions` is `{asia, europe}` and `countries` is
+  `{de, sg}` (distinct union, closed jobs excluded)
+
+#### Scenario: Enrichment facets are derived from the enrichment payload
+
+- **WHEN** the recompute runs for a company whose open, enriched jobs carry
+  `enrichment.domains` `{fintech}` and `{fintech, ecommerce}`,
+  `enrichment.company_type` `startup` and `product`, and `enrichment.company_size`
+  `11-50`
+- **THEN** that company's `domains` is `{ecommerce, fintech}`, `company_types` is
+  `{product, startup}`, and `company_sizes` is `{11-50}`
+
+#### Scenario: Unenriched jobs contribute no enrichment facets
+
+- **WHEN** a company's only open job has never been enriched (empty `enrichment`)
+- **THEN** that company's `domains`, `company_types`, and `company_sizes` are all
+  empty, while `regions`/`countries` still reflect the job's geography columns
+
+#### Scenario: Closing all jobs empties the facet arrays
+
+- **WHEN** every open job of a company is closed and the recompute runs again
+- **THEN** that company's facet arrays are all set to empty (`'{}'`)
+
+## MODIFIED Requirements
+
+### Requirement: Company list is served without joining jobs
+
+The system SHALL expose `GET /api/v1/companies` returning companies read from the
+`companies` table. Each company's job count SHALL be read from the denormalized
+`companies.job_count` column (open jobs only), not computed at query time, so the
+read path performs no join to the `jobs` table. The list SHALL be ordered by
+`job_count` descending, then `name` ascending, so the most active companies
+surface first.
+
+The endpoint SHALL accept an optional `q` query parameter that filters companies
+by a case-insensitive substring match on the company `name`. An absent or empty
+`q` SHALL return the unfiltered list.
+
+The endpoint SHALL additionally accept repeatable facet query parameters —
+`collections`, `regions`, `countries`, `domains`, `company_type`, and
+`company_size` — each filtering against the company's corresponding denormalized
+array (`collections` and the derived facet arrays) by **array overlap**: a company
+matches a facet when its array shares at least one value with the requested values
+(OR within a facet), and a company must match every provided facet (AND across
+facets). Facet filters SHALL compose with the `q` name search. An absent facet
+parameter SHALL not constrain the list.
+
+When any filter (`q` or a facet) is applied, the list `meta.total` SHALL report
+the count of companies matching the full filter combination, so pagination over
+the filtered results is correct.
+
+#### Scenario: Listing companies most-active first
+
+- **WHEN** a client requests `GET /api/v1/companies`
+- **THEN** the response contains companies under `data` with list `meta`,
+  ordered by `job_count` descending (ties broken by `name`), each carrying its
+  denormalized `job_count`
+
+#### Scenario: Searching companies by name
+
+- **WHEN** a client requests `GET /api/v1/companies?q=acme`
+- **THEN** the response contains only companies whose name matches `acme`
+  case-insensitively, ordered by `job_count` descending, and `meta.total` is the
+  count of matching companies
+
+#### Scenario: Empty query returns the full list
+
+- **WHEN** a client requests `GET /api/v1/companies?q=` (empty or absent)
+- **THEN** the response is the unfiltered company list, identical to omitting the
+  parameter
+
+#### Scenario: Filtering by a single facet
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe`
+- **THEN** the response contains only companies whose `regions` array contains
+  `europe`, and `meta.total` is the count of such companies
+
+#### Scenario: Multiple values within one facet are OR-ed
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe&regions=asia`
+- **THEN** the response contains companies whose `regions` overlap
+  `{europe, asia}` (in Europe **or** Asia)
+
+#### Scenario: Different facets are AND-ed and compose with search
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?collections=yc&company_type=startup&q=lab`
+- **THEN** the response contains only companies that are in the `yc` collection
+  **and** have `startup` among their `company_types` **and** whose name matches
+  `lab`
+
+### Requirement: Company job counts are denormalized and periodically recomputed
+
+The system SHALL store each company's count of open jobs (`closed_at IS NULL`) in
+a denormalized `companies.job_count` column, and its derived facet arrays
+(`regions`, `countries`, `domains`, `company_types`, `company_sizes`) in
+denormalized columns. Both SHALL be maintained by the same periodic recompute (a
+scheduled worker), not by a synchronous write on the job ingest/close paths, so
+they are eventually consistent with the `jobs` table within the recompute
+interval. A company with no open jobs SHALL have `job_count = 0` and empty facet
+arrays.
+
+#### Scenario: Recompute reflects only open jobs
+
+- **WHEN** the recompute runs and a company has 3 open jobs and 2 closed jobs
+  (`closed_at` set)
+- **THEN** that company's `job_count` is set to 3 and its facet arrays reflect
+  only the 3 open jobs
+
+#### Scenario: Recompute zeroes a company whose jobs all closed
+
+- **WHEN** every job of a company has been closed since the last recompute and the
+  recompute runs again
+- **THEN** that company's `job_count` is set to 0 and its facet arrays are emptied
+
+#### Scenario: Counts are eventually consistent
+
+- **WHEN** a new job is ingested for a company between recompute runs
+- **THEN** the company's `job_count` and facet arrays do not change until the next
+  recompute, which then includes the new job
+
+#### Scenario: Recompute rewrites nothing when already current
+
+- **WHEN** the recompute runs and a company's `job_count` and every facet array
+  already equal the freshly computed values
+- **THEN** that company's row is not rewritten (the recompute reports it as
+  unchanged)

--- a/openspec/changes/company-filter-sidebar/specs/web-frontend/spec.md
+++ b/openspec/changes/company-filter-sidebar/specs/web-frontend/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Companies list
+
+The frontend SHALL present companies from `GET /api/v1/companies`, showing each
+company's name and its job count, with each row linking to the company detail.
+
+The page SHALL provide a name-search input. Typing SHALL filter the list against
+the API's `q` parameter (debounced), and the current query SHALL be mirrored into
+the URL query string (`?q=`) so a search survives reload, sharing, and
+back/forward navigation. The page SHALL show the count of matching companies and
+a distinct empty state when a search matches nothing.
+
+The page SHALL present a filter sidebar alongside the list with facets for
+**collection**, **region**, **country**, **industry** (domains), **company type**,
+and **company size**, reusing the jobs filter controls and closed-vocabulary
+option registries (country is a searchable select over the country list; the
+others are pill/select controls over their fixed vocabularies). Selecting facet
+values SHALL refetch the list against the corresponding repeatable API facet
+parameters and mirror the active facets into the URL query string, so a filtered
+view survives reload, sharing, and back/forward navigation, composably with the
+`q` search. The sidebar SHALL offer a way to clear all active filters. On narrow
+viewports the sidebar SHALL collapse into a toggle-opened panel rather than
+occupying the list column.
+
+#### Scenario: Companies are listed
+
+- **WHEN** a user opens `/companies`
+- **THEN** a page of companies is fetched and rendered with job counts
+
+#### Scenario: User searches companies by name
+
+- **WHEN** a user types a query into the companies search input
+- **THEN** the list is refetched filtered by that query and the URL query string
+  is updated to `?q=<query>`
+
+#### Scenario: Search restored from the URL
+
+- **WHEN** a user opens `/companies?q=acme` directly or via back/forward
+- **THEN** the search input is prefilled with `acme` and the filtered list is
+  shown
+
+#### Scenario: Search matches nothing
+
+- **WHEN** a search returns no companies
+- **THEN** an empty state ("No matching companies.") is shown instead of an empty
+  list
+
+#### Scenario: User filters companies by a facet
+
+- **WHEN** a user selects a region in the sidebar
+- **THEN** the list is refetched against `?regions=<value>` and the URL query
+  string reflects the active facet
+
+#### Scenario: Filters restored from the URL
+
+- **WHEN** a user opens `/companies?collections=yc&regions=europe` directly or via
+  back/forward
+- **THEN** the sidebar shows those facets active and the list is filtered to match
+
+#### Scenario: Clearing filters
+
+- **WHEN** a user clears all filters
+- **THEN** the facet parameters are removed from the URL and the full list (for the
+  current `q`, if any) is shown

--- a/openspec/changes/company-filter-sidebar/tasks.md
+++ b/openspec/changes/company-filter-sidebar/tasks.md
@@ -61,6 +61,6 @@
 
 - [x] 5.1 `go build ./... && go vet ./... && go test ./...` and the integration
   tests green.
-- [ ] 5.2 Document the prod rollout in the change/PR: apply the migration manually
+- [x] 5.2 Document the prod rollout in the change/PR: apply the migration manually
   via psql, then run `cmd/recount-companies` once to backfill the arrays (no
   reindex needed).

--- a/openspec/changes/company-filter-sidebar/tasks.md
+++ b/openspec/changes/company-filter-sidebar/tasks.md
@@ -41,25 +41,25 @@
 
 ## 4. Frontend: companies filter sidebar
 
-- [ ] 4.1 Add a `COMPANY_FACETS` registry (subset of the `FacetDef` shape in
+- [x] 4.1 Add a `COMPANY_FACETS` registry (subset of the `FacetDef` shape in
   `web/src/lib/facets.ts`) covering collection/region/country/industry/company
   type/company size, reusing the existing option vocabularies; country as a
   searchable select.
-- [ ] 4.2 Add `CompanyFiltersPanel.svelte` that iterates `COMPANY_FACETS` and
+- [x] 4.2 Add `CompanyFiltersPanel.svelte` that iterates `COMPANY_FACETS` and
   renders each via the existing `FacetSection`, with a clear-all action.
-- [ ] 4.3 Wire a `FilterStore` into `CompaniesView.svelte`: render the sidebar
+- [x] 4.3 Wire a `FilterStore` into `CompaniesView.svelte`: render the sidebar
   next to the list (mobile = toggle-opened panel), subscribe the list reload to the
   debounced `applied` snapshot, and keep the existing `?q` search composed with the
   facets.
-- [ ] 4.4 Extend `listCompanies` in `web/src/lib/api.ts` to pass facet params, and
+- [x] 4.4 Extend `listCompanies` in `web/src/lib/api.ts` to pass facet params, and
   forward them from `/companies/+page.server.ts` for SSR/deep-linking.
-- [ ] 4.5 Verify the web changes with `svelte-check` (no test runner in `web/`) and
+- [x] 4.5 Verify the web changes with `svelte-check` (no test runner in `web/`) and
   a manual browse: filter by region/collection, reload a filtered URL, back/forward,
   clear-all.
 
 ## 5. Verify & ops
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` and the integration
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` and the integration
   tests green.
 - [ ] 5.2 Document the prod rollout in the change/PR: apply the migration manually
   via psql, then run `cmd/recount-companies` once to backfill the arrays (no

--- a/openspec/changes/company-filter-sidebar/tasks.md
+++ b/openspec/changes/company-filter-sidebar/tasks.md
@@ -1,0 +1,66 @@
+## 1. Schema: derived facet columns on companies
+
+- [ ] 1.1 Add an additive migration under `migrations/` adding `regions`,
+  `countries`, `domains`, `company_types`, `company_sizes` as `TEXT[] NOT NULL
+  DEFAULT '{}'` to `companies` (follow the existing migration numbering/style).
+- [ ] 1.2 Run `make sqlc` and confirm `db.Company` gains the five `[]string`
+  fields; `go build ./...` stays green.
+
+## 2. Recompute: aggregate facet arrays alongside job_count
+
+- [ ] 2.1 RED — extend the queue/DB integration test (`internal/db`,
+  `//go:build integration`) to seed a company with open + closed jobs carrying
+  regions/countries and enrichment (`domains`/`company_type`/`company_size`), run
+  the recompute, and assert the five arrays are the distinct union over **open**
+  jobs only (closed excluded; unenriched contributes no enrichment facets; all-closed
+  empties the arrays).
+- [ ] 2.2 GREEN — extend `RecountCompanyJobCounts` in
+  `internal/db/queries/companies.sql` (rename to reflect its wider job, e.g.
+  `RefreshCompanyFacets`) to compute the arrays in the same set-based `UPDATE … FROM`
+  pass: `array_agg(DISTINCT … ORDER BY …)` over `unnest(regions|countries)` and over
+  `jsonb_array_elements_text(enrichment->'domains')`; `array_agg(DISTINCT
+  enrichment->>'company_type'|'company_size')` filtered to non-null/non-empty. Keep
+  the `IS DISTINCT FROM` guard across job_count **and** every array. `make sqlc`.
+- [ ] 2.3 Update `cmd/recount-companies` to call the renamed query; confirm its
+  shape is otherwise unchanged. Re-run the integration test — green.
+
+## 3. API: facet-filtered company list
+
+- [ ] 3.1 RED — handler integration test (`internal/handler`, `//go:build
+  integration`) asserting `GET /api/v1/companies` with `regions`, multiple
+  `regions`, `collections`, `company_type`, and a `q`+facet combination filters by
+  array overlap (OR within a facet, AND across facets, composed with `q`), and that
+  `meta.total` reflects the filtered count.
+- [ ] 3.2 GREEN — extend `ListCompanies`/`CountCompanies` in
+  `internal/db/queries/companies.sql` to take optional array params and filter with
+  the `&&` overlap operator (empty param ⇒ no constraint), preserving the existing
+  `q` short-circuit and ordering. `make sqlc`.
+- [ ] 3.3 GREEN — parse the repeatable facet params in
+  `internal/handler/companies.go` `ListCompanies` and pass them through; unfiltered
+  requests behave exactly as before. Re-run tests — green.
+
+## 4. Frontend: companies filter sidebar
+
+- [ ] 4.1 Add a `COMPANY_FACETS` registry (subset of the `FacetDef` shape in
+  `web/src/lib/facets.ts`) covering collection/region/country/industry/company
+  type/company size, reusing the existing option vocabularies; country as a
+  searchable select.
+- [ ] 4.2 Add `CompanyFiltersPanel.svelte` that iterates `COMPANY_FACETS` and
+  renders each via the existing `FacetSection`, with a clear-all action.
+- [ ] 4.3 Wire a `FilterStore` into `CompaniesView.svelte`: render the sidebar
+  next to the list (mobile = toggle-opened panel), subscribe the list reload to the
+  debounced `applied` snapshot, and keep the existing `?q` search composed with the
+  facets.
+- [ ] 4.4 Extend `listCompanies` in `web/src/lib/api.ts` to pass facet params, and
+  forward them from `/companies/+page.server.ts` for SSR/deep-linking.
+- [ ] 4.5 Verify the web changes with `svelte-check` (no test runner in `web/`) and
+  a manual browse: filter by region/collection, reload a filtered URL, back/forward,
+  clear-all.
+
+## 5. Verify & ops
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` and the integration
+  tests green.
+- [ ] 5.2 Document the prod rollout in the change/PR: apply the migration manually
+  via psql, then run `cmd/recount-companies` once to backfill the arrays (no
+  reindex needed).

--- a/openspec/changes/company-filter-sidebar/tasks.md
+++ b/openspec/changes/company-filter-sidebar/tasks.md
@@ -1,41 +1,41 @@
 ## 1. Schema: derived facet columns on companies
 
-- [ ] 1.1 Add an additive migration under `migrations/` adding `regions`,
+- [x] 1.1 Add an additive migration under `migrations/` adding `regions`,
   `countries`, `domains`, `company_types`, `company_sizes` as `TEXT[] NOT NULL
   DEFAULT '{}'` to `companies` (follow the existing migration numbering/style).
-- [ ] 1.2 Run `make sqlc` and confirm `db.Company` gains the five `[]string`
+- [x] 1.2 Run `make sqlc` and confirm `db.Company` gains the five `[]string`
   fields; `go build ./...` stays green.
 
 ## 2. Recompute: aggregate facet arrays alongside job_count
 
-- [ ] 2.1 RED — extend the queue/DB integration test (`internal/db`,
+- [x] 2.1 RED — extend the queue/DB integration test (`internal/db`,
   `//go:build integration`) to seed a company with open + closed jobs carrying
   regions/countries and enrichment (`domains`/`company_type`/`company_size`), run
   the recompute, and assert the five arrays are the distinct union over **open**
   jobs only (closed excluded; unenriched contributes no enrichment facets; all-closed
   empties the arrays).
-- [ ] 2.2 GREEN — extend `RecountCompanyJobCounts` in
+- [x] 2.2 GREEN — extend `RecountCompanyJobCounts` in
   `internal/db/queries/companies.sql` (rename to reflect its wider job, e.g.
   `RefreshCompanyFacets`) to compute the arrays in the same set-based `UPDATE … FROM`
   pass: `array_agg(DISTINCT … ORDER BY …)` over `unnest(regions|countries)` and over
   `jsonb_array_elements_text(enrichment->'domains')`; `array_agg(DISTINCT
   enrichment->>'company_type'|'company_size')` filtered to non-null/non-empty. Keep
   the `IS DISTINCT FROM` guard across job_count **and** every array. `make sqlc`.
-- [ ] 2.3 Update `cmd/recount-companies` to call the renamed query; confirm its
+- [x] 2.3 Update `cmd/recount-companies` to call the renamed query; confirm its
   shape is otherwise unchanged. Re-run the integration test — green.
 
 ## 3. API: facet-filtered company list
 
-- [ ] 3.1 RED — handler integration test (`internal/handler`, `//go:build
+- [x] 3.1 RED — handler integration test (`internal/handler`, `//go:build
   integration`) asserting `GET /api/v1/companies` with `regions`, multiple
   `regions`, `collections`, `company_type`, and a `q`+facet combination filters by
   array overlap (OR within a facet, AND across facets, composed with `q`), and that
   `meta.total` reflects the filtered count.
-- [ ] 3.2 GREEN — extend `ListCompanies`/`CountCompanies` in
+- [x] 3.2 GREEN — extend `ListCompanies`/`CountCompanies` in
   `internal/db/queries/companies.sql` to take optional array params and filter with
   the `&&` overlap operator (empty param ⇒ no constraint), preserving the existing
   `q` short-circuit and ordering. `make sqlc`.
-- [ ] 3.3 GREEN — parse the repeatable facet params in
+- [x] 3.3 GREEN — parse the repeatable facet params in
   `internal/handler/companies.go` `ListCompanies` and pass them through; unfiltered
   requests behave exactly as before. Re-run tests — green.
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -162,8 +162,16 @@ export function createApi(
   /** List companies, optionally filtered by a name query `q` (a case-insensitive
    *  substring match; an empty `q` lists everything). `meta.total` reflects the
    *  filtered count, so the Paginator pages over the matches. */
-  async function listCompanies(q: string, limit: number, offset: number): Promise<Slice<CompanyListItem>> {
-    const params = new URLSearchParams();
+  // `facets` carries the sidebar's filter params (regions/collections/…, and `q`
+  // when it lives in the filter model); the count-ordered typeahead just passes a
+  // bare `q`. Both funnel through here so the endpoint stays one call site.
+  async function listCompanies(
+    q: string,
+    limit: number,
+    offset: number,
+    facets?: URLSearchParams,
+  ): Promise<Slice<CompanyListItem>> {
+    const params = new URLSearchParams(facets);
     if (q) params.set('q', q);
     params.set('limit', String(limit));
     params.set('offset', String(offset));

--- a/web/src/lib/companyFilters.ts
+++ b/web/src/lib/companyFilters.ts
@@ -1,0 +1,136 @@
+// Company-catalog filters: the model, its URL <-> state (de)serialization, and a
+// reactive store mirrored into the URL query so a filtered view survives reloads,
+// sharing, and back/forward. Param names match GET /api/v1/companies (`q` plus one
+// repeatable param per facet). Unlike the job FilterStore there are no
+// `_exclude`/`_mode` conventions — the companies endpoint filters by plain array
+// overlap (OR within a facet, AND across facets), so a facet is just a value set.
+
+import { COMPANY_FACETS, type FacetSelection, type FacetStore } from './facets';
+import { UrlSyncedState } from './urlSynced.svelte';
+
+export interface CompanyFilters {
+  q: string;
+  /** Selected values keyed by facet param (see COMPANY_FACETS). */
+  facets: Record<string, string[]>;
+}
+
+function emptyFacets(): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const f of COMPANY_FACETS) out[f.param] = [];
+  return out;
+}
+
+export function emptyCompanyFilters(): CompanyFilters {
+  return { q: '', facets: emptyFacets() };
+}
+
+/** Serialize to the query shape GET /api/v1/companies reads. */
+export function companyFiltersToParams(f: CompanyFilters): URLSearchParams {
+  const p = new URLSearchParams();
+  if (f.q) p.set('q', f.q);
+  for (const def of COMPANY_FACETS) {
+    for (const v of f.facets[def.param] ?? []) p.append(def.param, v);
+  }
+  return p;
+}
+
+/** Parse back from URL params. Facet values are a set, so duplicates from a
+ *  shared/edited link are collapsed (the keyed {#each} in the controls throws on a
+ *  repeat), mirroring the job filters' guard. */
+export function companyFiltersFromParams(p: URLSearchParams): CompanyFilters {
+  const f = emptyCompanyFilters();
+  f.q = p.get('q') ?? '';
+  for (const def of COMPANY_FACETS) {
+    const values = [...new Set(p.getAll(def.param))];
+    if (values.length > 0) f.facets[def.param] = values;
+  }
+  return f;
+}
+
+/** Total selected facet values — drives the mobile "Filters (N)" badge. */
+export function activeCompanyFilterCount(f: CompanyFilters): number {
+  let n = 0;
+  for (const def of COMPANY_FACETS) n += f.facets[def.param]?.length ?? 0;
+  return n;
+}
+
+/** Reactive company filters mirrored into the URL — a thin wrapper over the shared
+ *  UrlSyncedState primitive, satisfying the FacetStore contract so the same
+ *  FacetSection/controls render it. Read `value` to drive inputs and `applied` (the
+ *  debounced snapshot) to drive the list reload. */
+export class CompanyFilterStore implements FacetStore {
+  #url: UrlSyncedState<CompanyFilters>;
+
+  constructor(initial?: URLSearchParams) {
+    this.#url = new UrlSyncedState<CompanyFilters>(initial ?? new URLSearchParams(), {
+      parse: companyFiltersFromParams,
+      serialize: companyFiltersToParams,
+    });
+  }
+
+  /** Live filters — bind inputs to this. */
+  get value(): CompanyFilters {
+    return this.#url.value;
+  }
+
+  /** Debounced filters — drive the list reload off this. */
+  get applied(): CompanyFilters {
+    return this.#url.applied;
+  }
+
+  get active(): number {
+    return activeCompanyFilterCount(this.#url.value);
+  }
+
+  facet(param: string): FacetSelection {
+    return { values: this.#url.value.facets[param] ?? [], exclude: false, matchAll: false };
+  }
+
+  // Free text debounces the reload (setSoon); the URL still updates synchronously.
+  setQuery(q: string) {
+    this.#url.setSoon({ ...this.#url.value, q });
+  }
+
+  /** Add the value to a facet if absent, remove it if present (pills/select). */
+  toggle(param: string, v: string) {
+    const values = this.facet(param).values;
+    const next = values.includes(v) ? values.filter((x) => x !== v) : [...values, v];
+    this.#setFacet(param, next);
+  }
+
+  add(param: string, raw: string) {
+    const v = raw.trim();
+    const values = this.facet(param).values;
+    if (!v || values.includes(v)) return;
+    this.#setFacet(param, [...values, v]);
+  }
+
+  remove(param: string, v: string) {
+    this.#setFacet(param, this.facet(param).values.filter((x) => x !== v));
+  }
+
+  clearFacet(param: string) {
+    this.#setFacet(param, []);
+  }
+
+  // The companies endpoint has no exclude/AND-OR modes and no company facet opts
+  // into them, so these are inert — present only to satisfy the FacetStore contract.
+  setExclude() {}
+  setMatchAll() {}
+
+  clear() {
+    this.#url.setNow(emptyCompanyFilters());
+  }
+
+  syncFromUrl() {
+    this.#url.syncFromUrl();
+  }
+
+  dispose() {
+    this.#url.dispose();
+  }
+
+  #setFacet(param: string, values: string[]) {
+    this.#url.setNow({ ...this.#url.value, facets: { ...this.#url.value.facets, [param]: values } });
+  }
+}

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -5,56 +5,55 @@
   import { resolve } from '$app/paths';
   import { api, type Slice } from '$lib/api';
   import { Paginator } from '$lib/paginated.svelte';
-  import { UrlSyncedState, syncOnNavigation } from '$lib/urlSynced.svelte';
-  import { SvelteURLSearchParams } from 'svelte/reactivity';
+  import { syncOnNavigation } from '$lib/urlSynced.svelte';
+  import { CompanyFilterStore, companyFiltersToParams } from '$lib/companyFilters';
   import type { CompanyListItem } from '$lib/types';
   import { Badge, Input } from '$lib/ui';
   import States from './States.svelte';
   import LoadMore from './LoadMore.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CompanyFiltersPanel from './CompanyFiltersPanel.svelte';
 
-  // The first page is server-rendered (route `load`) for the current ?q, so the
-  // rows are in the initial HTML.
+  // The first page is server-rendered (route `load`) for the current filters, so
+  // the rows are in the initial HTML.
   let { initial }: { initial: Slice<CompanyListItem> } = $props();
 
-  // Search lives in the URL (?q=) so it survives reload, sharing, and
-  // back/forward. The shared primitive owns the state<->URL transport and the
-  // reload debounce; here it's a single string (no FilterStore, which models
-  // job-only facets). `value` drives the input, `applied` drives the fetch.
-  const search = new UrlSyncedState<string>(page.url.searchParams, {
-    parse: (p) => p.get('q') ?? '',
-    serialize: (q) => {
-      const p = new SvelteURLSearchParams();
-      if (q) p.set('q', q);
-      return p;
-    },
-  });
+  // The search query and sidebar facets live in the URL so a filtered view survives
+  // reload, sharing, and back/forward. The store owns the state<->URL transport and
+  // the reload debounce; `value` drives inputs, `applied` (debounced) drives the
+  // fetch.
+  const filters = new CompanyFilterStore(page.url.searchParams);
 
-  // Fetch against the debounced query so typing doesn't issue a request per key.
+  // Fetch against the debounced filters so typing/toggling doesn't issue a request
+  // per change. `q` lives inside the serialized params, so it's passed as ''.
   const makePaginator = () =>
-    new Paginator<CompanyListItem>((limit, offset) => api.listCompanies(search.applied, limit, offset));
+    new Paginator<CompanyListItem>((limit, offset) =>
+      api.listCompanies('', limit, offset, companyFiltersToParams(filters.applied)),
+    );
 
   const seeded = makePaginator();
   seeded.seed(untrack(() => initial));
   let companies = $state.raw(seeded);
   let started = false;
+  let drawerOpen = $state(false);
 
-  // `initial` was searched for page.url; if a shallow-routing back/forward left
+  // `initial` was fetched for page.url; if a shallow-routing back/forward left
   // page.url lagging the address bar, it's stale — reload on the first run instead.
   const initialStale = browser && page.url.search !== location.search;
 
-  onMount(() => () => search.dispose());
+  onMount(() => () => filters.dispose());
 
   function reload() {
     companies = makePaginator();
     companies.start();
   }
 
-  // Reload whenever the debounced query changes (typing settled, or back/forward
-  // re-seeded it). Skip the first run: the SSR `initial` already rendered page one.
+  // Reload whenever the debounced filters change (typing settled, a facet toggled,
+  // or back/forward re-seeded them). Skip the first run: the SSR `initial` already
+  // rendered page one.
   $effect(() => {
-    void search.applied; // track the debounced query
+    void filters.applied; // track the debounced filters
     untrack(() => {
       if (!started) {
         started = true;
@@ -64,57 +63,90 @@
     });
   });
 
-  // Browser back/forward re-seeds the query from the URL.
-  syncOnNavigation(search);
+  // Browser back/forward re-seeds the filters from the URL.
+  syncOnNavigation(filters);
 </script>
 
-<div class="mb-4">
-  <Input
-    type="search"
-    value={search.value}
-    oninput={(e) => search.setSoon(e.currentTarget.value)}
-    placeholder="Search companies…"
-    aria-label="Search companies"
-    class="w-full"
-  />
+<div class="flex gap-6">
+  <aside class="hidden w-72 shrink-0 md:block">
+    <div class="sticky top-6 max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
+      <CompanyFiltersPanel store={filters} />
+    </div>
+  </aside>
+
+  <div class="min-w-0 flex-1">
+    <div class="mb-4 flex items-center gap-2">
+      <Input
+        type="search"
+        value={filters.value.q}
+        oninput={(e) => filters.setQuery(e.currentTarget.value)}
+        placeholder="Search companies…"
+        aria-label="Search companies"
+        class="min-w-0 flex-1"
+      />
+      <button
+        type="button"
+        class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent md:hidden"
+        onclick={() => (drawerOpen = true)}
+      >
+        Filters{#if filters.active > 0}&nbsp;({filters.active}){/if}
+      </button>
+    </div>
+
+    {#if companies.status === 'loading'}
+      <States state="loading" />
+    {:else if companies.status === 'error'}
+      <States state="error" message="Failed to load companies." />
+    {:else if companies.items.length === 0}
+      <States
+        state="empty"
+        message={filters.value.q || filters.active > 0 ? 'No matching companies.' : 'No companies yet.'}
+      />
+    {:else}
+      <p class="mb-3 text-sm text-muted-foreground" aria-live="polite">
+        {companies.total.toLocaleString()} {companies.total === 1 ? 'company' : 'companies'}
+      </p>
+      <div class="flex flex-col gap-3">
+        {#each companies.items as company (company.slug)}
+          <a
+            href={resolve('/companies/[slug]', { slug: company.slug })}
+            class="flex items-center justify-between rounded-lg border border-border px-4 py-3 transition-colors hover:bg-accent"
+          >
+            <span class="flex min-w-0 items-center gap-2.5">
+              <CompanyLogo name={company.name} size="size-6" />
+              <span class="truncate font-medium">{company.name}</span>
+            </span>
+            <Badge variant="outline">{company.job_count} jobs</Badge>
+          </a>
+        {/each}
+      </div>
+
+      {#if companies.hasMore}
+        <!-- Scroll-to-bottom auto-load; the button below stays as the accessible
+             fallback (keyboard/screen-reader, and retry on a failed load). -->
+        <InfiniteScroll
+          onLoad={() => companies.loadMore()}
+          enabled={!companies.loadingMore && !companies.loadMoreError}
+        />
+        <LoadMore
+          loading={companies.loadingMore}
+          error={companies.loadMoreError}
+          onclick={() => companies.loadMore()}
+        />
+      {/if}
+    {/if}
+  </div>
 </div>
 
-{#if companies.status === 'loading'}
-  <States state="loading" />
-{:else if companies.status === 'error'}
-  <States state="error" message="Failed to load companies." />
-{:else if companies.items.length === 0}
-  <States state="empty" message={search.value ? 'No matching companies.' : 'No companies yet.'} />
-{:else}
-  <p class="mb-3 text-sm text-muted-foreground" aria-live="polite">
-    {companies.total.toLocaleString()} {companies.total === 1 ? 'company' : 'companies'}
-  </p>
-  <div class="flex flex-col gap-3">
-    {#each companies.items as company (company.slug)}
-      <a
-        href={resolve('/companies/[slug]', { slug: company.slug })}
-        class="flex items-center justify-between rounded-lg border border-border px-4 py-3 transition-colors hover:bg-accent"
-      >
-        <span class="flex min-w-0 items-center gap-2.5">
-          <CompanyLogo name={company.name} size="size-6" />
-          <span class="truncate font-medium">{company.name}</span>
-        </span>
-        <Badge variant="outline">{company.job_count} jobs</Badge>
-      </a>
-    {/each}
+{#if drawerOpen}
+  <div class="fixed inset-0 z-40 md:hidden">
+    <button class="absolute inset-0 bg-black/40" aria-label="Close filters" onclick={() => (drawerOpen = false)}></button>
+    <div class="absolute left-0 top-0 flex h-full w-80 max-w-[85%] flex-col overflow-y-auto bg-background p-4 shadow-xl">
+      <div class="mb-3 flex items-center justify-between">
+        <span class="text-sm font-semibold tracking-tight">Filters</span>
+        <button type="button" class="text-sm text-muted-foreground hover:text-foreground" onclick={() => (drawerOpen = false)}>Done</button>
+      </div>
+      <CompanyFiltersPanel store={filters} />
+    </div>
   </div>
-
-  {#if companies.hasMore}
-    <!-- Scroll-to-bottom auto-load; the button below stays as the accessible
-         fallback (keyboard/screen-reader, and retry on a failed load). -->
-    <InfiniteScroll
-      onLoad={() => companies.loadMore()}
-      enabled={!companies.loadingMore && !companies.loadMoreError}
-    />
-    <LoadMore
-      loading={companies.loadingMore}
-      error={companies.loadMoreError}
-      onclick={() => companies.loadMore()}
-    />
-  {/if}
 {/if}

--- a/web/src/lib/components/CompanyFiltersPanel.svelte
+++ b/web/src/lib/components/CompanyFiltersPanel.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { COMPANY_FACETS, type FacetDef } from '$lib/facets';
+  import type { CompanyFilterStore } from '$lib/companyFilters';
+  import FacetSection from './facets/FacetSection.svelte';
+
+  // Pure presentation over the company filter store: iterate the company facet
+  // registry and render each section. No live counts (the companies list is plain
+  // SQL, not a faceted search) and no special controls — companies filter purely by
+  // their denormalized facet arrays.
+  let { store }: { store: CompanyFilterStore } = $props();
+
+  const isActive = (param: string) => store.facet(param).values.length > 0;
+
+  // Facets with a current selection float to the top; the rest keep registry order.
+  // Keyed by param so Svelte moves the node rather than re-creating it (an open
+  // select survives the reorder).
+  const orderedFacets = $derived.by((): FacetDef[] => [
+    ...COMPANY_FACETS.filter((d) => isActive(d.param)),
+    ...COMPANY_FACETS.filter((d) => !isActive(d.param)),
+  ]);
+</script>
+
+<div class="flex flex-col gap-4">
+  <div class="flex items-center justify-between">
+    <h2 class="text-base font-semibold tracking-tight">Filters</h2>
+    {#if store.active > 0}
+      <button type="button" class="text-xs text-muted-foreground transition-colors hover:text-foreground" onclick={() => store.clear()}>
+        Reset all
+      </button>
+    {/if}
+  </div>
+
+  {#each orderedFacets as def (def.param)}
+    <FacetSection {def} {store} />
+  {/each}
+</div>

--- a/web/src/lib/components/facets/FacetSection.svelte
+++ b/web/src/lib/components/facets/FacetSection.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { X } from '@lucide/svelte';
-  import { dynamicLabel, type FacetDef, type FacetOption } from '$lib/facets';
-  import type { FilterStore } from '$lib/filters';
+  import { dynamicLabel, type FacetDef, type FacetOption, type FacetStore } from '$lib/facets';
   import type { FacetCounts } from '$lib/types';
   import { cn } from '$lib/utils';
   import PillGroup from './PillGroup.svelte';
@@ -13,7 +12,7 @@
   // exclude toggle) plus the control the facet declares. All state lives in the
   // store, keyed by the facet's param. `counts` carries the live facet
   // distribution that drives dynamic (open-vocabulary) selects.
-  let { def, store, counts }: { def: FacetDef; store: FilterStore; counts?: FacetCounts | null } = $props();
+  let { def, store, counts }: { def: FacetDef; store: FacetStore; counts?: FacetCounts | null } = $props();
 
   const st = $derived(store.facet(def.param));
 

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -33,6 +33,28 @@ export interface FacetOption {
 
 export type FacetControl = 'pills' | 'select' | 'tokens' | 'remote';
 
+/** One facet's live selection, as FacetSection reads it. */
+export interface FacetSelection {
+  values: string[];
+  exclude: boolean;
+  matchAll: boolean;
+}
+
+/** The narrow store contract FacetSection drives — the subset of FilterStore's
+ *  surface a facet control touches. Both the job FilterStore and the company
+ *  filter store satisfy it, so the same section/control components render either.
+ *  (setExclude/setMatchAll are only invoked for excludable/hasAndOr facets, which
+ *  the company registry doesn't use.) */
+export interface FacetStore {
+  facet(param: string): FacetSelection;
+  toggle(param: string, v: string): void;
+  add(param: string, raw: string): void;
+  remove(param: string, v: string): void;
+  clearFacet(param: string): void;
+  setExclude(param: string, exclude: boolean): void;
+  setMatchAll(param: string, on: boolean): void;
+}
+
 export interface FacetDef {
   param: string;
   label: string;
@@ -198,6 +220,55 @@ const CURRENCY: FacetOption[] = [
 // Curated collections (yc, bigtech, …) as pill options, sourced from the same
 // registry the /collections hub renders so the label/slug pairs never drift.
 const COLLECTION: FacetOption[] = COLLECTIONS.map((c) => ({ value: c.slug, label: c.title }));
+
+// Company-size buckets — the enrich.CompanySizeValues vocabulary. Not exported as
+// a generated values array (it's a scalar enrichment field, not a search facet on
+// jobs), so the closed set is spelled out here like CURRENCY; the values are
+// already display-ready.
+const COMPANY_SIZE: FacetOption[] = ['1-10', '11-50', '51-200', '201-500', '501-1000', '1000+'].map(
+  (value) => ({ value, label: value }),
+);
+
+// The ISO 3166-1 alpha-2 code set — the country vocabulary the location dictionary
+// draws from. The company country facet is a static searchable select over this
+// (labelled via countryLabel), not a live distribution: the companies list is plain
+// SQL with no facet-count endpoint yet, so options carry no counts.
+const ISO_COUNTRY_CODES = [
+  'ad', 'ae', 'af', 'ag', 'ai', 'al', 'am', 'ao', 'aq', 'ar', 'as', 'at', 'au', 'aw', 'ax', 'az',
+  'ba', 'bb', 'bd', 'be', 'bf', 'bg', 'bh', 'bi', 'bj', 'bl', 'bm', 'bn', 'bo', 'bq', 'br', 'bs',
+  'bt', 'bv', 'bw', 'by', 'bz', 'ca', 'cc', 'cd', 'cf', 'cg', 'ch', 'ci', 'ck', 'cl', 'cm', 'cn',
+  'co', 'cr', 'cu', 'cv', 'cw', 'cx', 'cy', 'cz', 'de', 'dj', 'dk', 'dm', 'do', 'dz', 'ec', 'ee',
+  'eg', 'eh', 'er', 'es', 'et', 'fi', 'fj', 'fk', 'fm', 'fo', 'fr', 'ga', 'gb', 'gd', 'ge', 'gf',
+  'gg', 'gh', 'gi', 'gl', 'gm', 'gn', 'gp', 'gq', 'gr', 'gs', 'gt', 'gu', 'gw', 'gy', 'hk', 'hm',
+  'hn', 'hr', 'ht', 'hu', 'id', 'ie', 'il', 'im', 'in', 'io', 'iq', 'ir', 'is', 'it', 'je', 'jm',
+  'jo', 'jp', 'ke', 'kg', 'kh', 'ki', 'km', 'kn', 'kp', 'kr', 'kw', 'ky', 'kz', 'la', 'lb', 'lc',
+  'li', 'lk', 'lr', 'ls', 'lt', 'lu', 'lv', 'ly', 'ma', 'mc', 'md', 'me', 'mf', 'mg', 'mh', 'mk',
+  'ml', 'mm', 'mn', 'mo', 'mp', 'mq', 'mr', 'ms', 'mt', 'mu', 'mv', 'mw', 'mx', 'my', 'mz', 'na',
+  'nc', 'ne', 'nf', 'ng', 'ni', 'nl', 'no', 'np', 'nr', 'nu', 'nz', 'om', 'pa', 'pe', 'pf', 'pg',
+  'ph', 'pk', 'pl', 'pm', 'pn', 'pr', 'ps', 'pt', 'pw', 'py', 'qa', 're', 'ro', 'rs', 'ru', 'rw',
+  'sa', 'sb', 'sc', 'sd', 'se', 'sg', 'sh', 'si', 'sj', 'sk', 'sl', 'sm', 'sn', 'so', 'sr', 'ss',
+  'st', 'sv', 'sx', 'sy', 'sz', 'tc', 'td', 'tf', 'tg', 'th', 'tj', 'tk', 'tl', 'tm', 'tn', 'to',
+  'tr', 'tt', 'tv', 'tw', 'tz', 'ua', 'ug', 'um', 'us', 'uy', 'uz', 'va', 'vc', 've', 'vg', 'vi',
+  'vn', 'vu', 'wf', 'ws', 'ye', 'yt', 'za', 'zm', 'zw',
+];
+const COUNTRY: FacetOption[] = ISO_COUNTRY_CODES.map((value) => ({
+  value,
+  label: countryLabel(value),
+})).toSorted((a, b) => a.label.localeCompare(b.label));
+
+// The company catalog's filter facets: a subset of the job facets whose values are
+// derivable from a company's open jobs and denormalized onto the companies row
+// (collections + the RefreshCompanyFacets arrays). No exclude/AND-OR modes — the
+// companies list endpoint filters by plain array overlap. Reuses the same option
+// vocabularies as the job facets so labels never drift.
+export const COMPANY_FACETS: FacetDef[] = [
+  { param: 'collections', label: 'Collection', control: 'pills', options: COLLECTION, excludable: false },
+  { param: 'regions', label: 'Region', control: 'pills', options: REGION, excludable: false },
+  { param: 'countries', label: 'Country', control: 'select', options: COUNTRY, excludable: false, placeholder: 'Search countries' },
+  { param: 'domains', label: 'Industry', control: 'select', options: DOMAINS, excludable: false, placeholder: 'Search industries' },
+  { param: 'company_type', label: 'Company type', control: 'pills', options: COMPANY_TYPE, excludable: false },
+  { param: 'company_size', label: 'Company size', control: 'pills', options: COMPANY_SIZE, excludable: false },
+];
 
 export const FACETS: FacetDef[] = [
   { param: 'collections', label: 'Collection', control: 'pills', options: COLLECTION, excludable: false },

--- a/web/src/routes/companies/+page.server.ts
+++ b/web/src/routes/companies/+page.server.ts
@@ -1,12 +1,15 @@
 import { serverApi } from '$lib/server/api';
+import { companyFiltersFromParams, companyFiltersToParams } from '$lib/companyFilters';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
 
-// Server-render the first page of companies for the current ?q, so the rows are
-// in the initial HTML. The debounced search and "load more" then run client-side.
+// Server-render the first page of companies for the current filters (the ?q search
+// plus the sidebar facets), so a shared/deep-linked filtered URL renders filtered
+// in the initial HTML. Round-tripping through companyFilters whitelists the params
+// to the known facets. The debounced search and "load more" then run client-side.
 export const load: PageServerLoad = async ({ url, fetch }) => {
-  const q = url.searchParams.get('q') ?? '';
-  const initial = await serverApi(fetch).listCompanies(q, LIMIT, 0);
+  const facets = companyFiltersToParams(companyFiltersFromParams(url.searchParams));
+  const initial = await serverApi(fetch).listCompanies('', LIMIT, 0, facets);
   return { initial };
 };


### PR DESCRIPTION
## Summary

Adds a filter sidebar to the `/companies` catalog. Companies had no filterable facts of their own (only `collections` + `job_count`), so the core of this change is **deriving facets from a company's open jobs and denormalizing them onto the company row**, then filtering with plain SQL.

- **Schema** (`migrations/0030_company_facets.sql`): five additive `TEXT[]` columns on `companies` — `regions`, `countries`, `domains`, `company_types`, `company_sizes` — with GIN indexes for array-overlap filtering.
- **Derivation**: the periodic recompute `RecountCompanyJobCounts` → **`RefreshCompanyFacets`** now aggregates those arrays (distinct union over the company's OPEN jobs) in the same set-based `UPDATE` pass that maintains `job_count`, guarded per-column by `IS DISTINCT FROM`. `regions`/`countries` from the `jobs` geography columns; `domains`/`company_type`/`company_size` from `jobs.enrichment` JSONB. `cmd/recount-companies` calls the renamed query.
- **API**: `GET /api/v1/companies` accepts repeatable facet params (`collections`/`regions`/`countries`/`domains`/`company_type`/`company_size`), filtered by array overlap — **OR within a facet, AND across facets**, composed with the existing `q` name search. `meta.total` reflects the filtered count.
- **Web**: a filter sidebar on `/companies` (collection/region/country/industry/company type/company size), URL-synced like the jobs filters, desktop-sticky + mobile drawer. Reuses `FacetSection` via a new narrow `FacetStore` interface + a thin `CompanyFilterStore` over the shared `UrlSyncedState` primitive (no `_exclude`/`_mode` — the endpoint doesn't use them).

Planned in OpenSpec change `company-filter-sidebar` (proposal/design/specs/tasks under `openspec/changes/`).

### Data-quality notes
- `regions`/`countries` are dense from ingest; `domains`/`company_types`/`company_sizes` are sparse until jobs are LLM-enriched, and `company_size` is an LLM estimate — acceptable for a browse filter.
- No live facet counts in v1 (companies list is plain SQL, not Meilisearch); options render from static vocabularies. Noted as a future seam.

## Prod rollout
1. Apply `migrations/0030_company_facets.sql` **manually via psql** (initdb migrations don't re-apply to an existing volume).
2. Deploy backend + web.
3. Run `cmd/recount-companies` once to backfill the arrays; the existing cron keeps them fresh. **No reindex** (companies list is not Meili-backed).
Rollback is safe: the columns are additive and inert to old code paths.

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` (unit) green
- [x] `go test -tags=integration ./internal/db/ ./internal/handler/` green — new `RefreshCompanyFacets` aggregation (open-only, closed-excluded, unenriched-contributes-nothing, all-closed-empties, idempotent no-op) and facet-filter endpoint (OR-within/AND-across/compose-with-q, filtered total)
- [x] `web` `svelte-check` 0 errors / 0 warnings; production build OK
- [x] Sidebar rendered + verified live (SSR + screenshot): active pills, float-to-top, URL round-trip
- [ ] Post-deploy: filter by region/collection returns the narrowed catalogue against the new backend