### PR TITLE
fix(web): hide header search on /jobs and /companies

### DIFF
--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto, afterNavigate } from '$app/navigation';
+  import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { Search, X } from '@lucide/svelte';
   import { api } from '$lib/api';
@@ -11,6 +12,12 @@
   // A launcher, not a filter: the header search jumps straight to a job/company
   // or hands a free-text query to /jobs. It does NOT own the catalogue's query
   // state — /jobs keeps its own URL-synced `q` input.
+
+  // On the list pages that already have their own text search (/jobs, /companies)
+  // the header input would duplicate it, so hide it there and leave an empty
+  // flex spacer that keeps the menu right-aligned. Detail pages (/jobs/:slug,
+  // /companies/:slug) and everywhere else keep the launcher.
+  const hidden = $derived(page.url.pathname === '/jobs' || page.url.pathname === '/companies');
 
   const JOBS_LIMIT = 6;
   const COMPANIES_LIMIT = 4;
@@ -175,7 +182,8 @@
 <svelte:window onkeydown={onWindowKeydown} onclick={onWindowClick} />
 
 <div bind:this={wrapEl} class="relative flex-1">
-  <!-- Search box -->
+  {#if !hidden}
+    <!-- Search box -->
   <div
     class="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"
   >
@@ -288,5 +296,6 @@
         </button>
       {/if}
     </div>
+  {/if}
   {/if}
 </div>


### PR DESCRIPTION
## Summary

`/jobs` and `/companies` each have their own text-search input, so the global header search sat right above it — two identical search boxes stacked (see the reported "nodejs" screenshot).

Hide the header search **only** on `/jobs` and `/companies` (their own filter is the canonical search there). It stays on detail pages (`/jobs/:slug`, `/companies/:slug`), the homepage, and everywhere else. An empty `flex-1` spacer keeps the hamburger right-aligned.

## Test Plan

- [x] `svelte-check` 0/0, eslint clean (fresh origin/main base)
- [x] Local (headless): on `/jobs` the header has 0 search inputs and the page filter "Search jobs…" remains; homepage still shows the header search