### PR TITLE
refactor(web): move header-search visibility to TopBar

### DIFF
--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { goto, afterNavigate } from '$app/navigation';
-  import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { Search, X } from '@lucide/svelte';
   import { api } from '$lib/api';
@@ -11,13 +10,8 @@
 
   // A launcher, not a filter: the header search jumps straight to a job/company
   // or hands a free-text query to /jobs. It does NOT own the catalogue's query
-  // state — /jobs keeps its own URL-synced `q` input.
-
-  // On the list pages that already have their own text search (/jobs, /companies)
-  // the header input would duplicate it, so hide it there and leave an empty
-  // flex spacer that keeps the menu right-aligned. Detail pages (/jobs/:slug,
-  // /companies/:slug) and everywhere else keep the launcher.
-  const hidden = $derived(page.url.pathname === '/jobs' || page.url.pathname === '/companies');
+  // state — /jobs keeps its own URL-synced `q` input. TopBar decides where it
+  // renders (hidden on the list pages that have their own search).
 
   const JOBS_LIMIT = 6;
   const COMPANIES_LIMIT = 4;
@@ -182,8 +176,7 @@
 <svelte:window onkeydown={onWindowKeydown} onclick={onWindowClick} />
 
 <div bind:this={wrapEl} class="relative flex-1">
-  {#if !hidden}
-    <!-- Search box -->
+  <!-- Search box -->
   <div
     class="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"
   >
@@ -296,6 +289,5 @@
         </button>
       {/if}
     </div>
-  {/if}
   {/if}
 </div>

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -12,6 +12,13 @@
   // viewport. Nav links, the account items, the theme toggle, and the auth
   // action all live in HeaderMenu; instant search lives in HeaderSearch.
 
+  // The list pages (/jobs, /companies) already have their own text search, so
+  // hide the header launcher there to avoid two stacked search boxes; an empty
+  // spacer keeps the menu right-aligned. Detail pages and everywhere else keep it.
+  const showSearch = $derived(
+    page.url.pathname !== '/jobs' && page.url.pathname !== '/companies',
+  );
+
   // The auth dialog lives at the layout level but its open state is a shared
   // singleton (see auth-dialog.svelte), so deep components — like a job's Save
   // button — can prompt sign-in through the same dialog this header renders.
@@ -61,7 +68,11 @@
       <span class="hidden sm:inline">FreeHire</span>
     </a>
 
-    <HeaderSearch />
+    {#if showSearch}
+      <HeaderSearch />
+    {:else}
+      <div class="flex-1"></div>
+    {/if}
 
     <HeaderMenu />
   </div>


### PR DESCRIPTION
## Summary

Follow-up cleanup to #319. The "hide header search on /jobs & /companies" logic lived inside `HeaderSearch` as an `{#if !hidden}` wrap, which left the inner markup mis-indented and kept the component (with its window keydown/click listeners) mounted-but-hidden on those pages.

Hoist the route decision to `TopBar` (the layout owner): it renders `<HeaderSearch/>` or an empty `flex-1` spacer. `HeaderSearch` drops the route coupling (`page` import + `hidden` derived + wrap) and its markup returns to natural indentation. Behavior is identical (search hidden on the two list pages, shown everywhere else); on those pages the component now simply isn't mounted (no dead listeners).

## Test Plan

- [x] `svelte-check` 0/0, eslint clean (fresh origin/main base)