### PR TITLE
fix(web): widen /companies to max-w-6xl for the filter sidebar

### DIFF
--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -15,6 +15,6 @@
   {canonical}
 />
 
-<div class="mx-auto w-full max-w-3xl px-4 py-6">
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
   <CompaniesView initial={data.initial} />
 </div>


### PR DESCRIPTION
The company filter sidebar (#318) was added inside the old single-column `max-w-3xl` wrapper, cramping the sidebar + list. Match `/jobs` (`max-w-6xl`) so the two-column layout has room.