### PR TITLE
feat(web): single context-aware header search

### DIFF
--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -7,8 +7,9 @@
   import { Paginator } from '$lib/paginated.svelte';
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
   import { CompanyFilterStore, companyFiltersToParams } from '$lib/companyFilters';
+  import { setListSearchTarget } from '$lib/listSearch.svelte';
   import type { CompanyListItem } from '$lib/types';
-  import { Badge, Input } from '$lib/ui';
+  import { Badge } from '$lib/ui';
   import States from './States.svelte';
   import LoadMore from './LoadMore.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
@@ -42,7 +43,15 @@
   // page.url lagging the address bar, it's stale — reload on the first run instead.
   const initialStale = browser && page.url.search !== location.search;
 
-  onMount(() => () => filters.dispose());
+  // Register this page's store so the header search drives it (the header hosts
+  // the text field here — see HeaderListSearch).
+  onMount(() => {
+    setListSearchTarget(filters);
+    return () => {
+      setListSearchTarget(null);
+      filters.dispose();
+    };
+  });
 
   function reload() {
     companies = makePaginator();
@@ -76,14 +85,9 @@
 
   <div class="min-w-0 flex-1">
     <div class="mb-4 flex items-center gap-2">
-      <Input
-        type="search"
-        value={filters.value.q}
-        oninput={(e) => filters.setQuery(e.currentTarget.value)}
-        placeholder="Search companies…"
-        aria-label="Search companies"
-        class="min-w-0 flex-1"
-      />
+      <!-- The header search is this page's text filter (see HeaderListSearch);
+           the spacer keeps the mobile Filters button right-aligned. -->
+      <div class="flex-1"></div>
       <button
         type="button"
         class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent md:hidden"

--- a/web/src/lib/components/HeaderListSearch.svelte
+++ b/web/src/lib/components/HeaderListSearch.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { Search, X } from '@lucide/svelte';
+  import { listSearchTarget } from '$lib/listSearch.svelte';
+
+  // The header's list-mode input: on /jobs and /companies it IS the page's text
+  // search, proxying straight into the active list store (registered by the view).
+  // No dropdown — the page's own list is the live result. Reuses the store's URL
+  // sync + debounce, so this stays a thin remote control.
+  let { placeholder }: { placeholder: string } = $props();
+
+  let inputEl = $state<HTMLInputElement | null>(null);
+
+  const target = $derived(listSearchTarget());
+  // Fall back to the URL's `q` before the view registers (SSR + first paint), so a
+  // shared /jobs?q=… link shows its query immediately.
+  const q = $derived(target?.value.q ?? page.url.searchParams.get('q') ?? '');
+
+  // Same global hotkeys as the launcher: Cmd/Ctrl+K always, `/` unless typing.
+  function onWindowKeydown(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+      e.preventDefault();
+      inputEl?.focus();
+      return;
+    }
+    if (e.key === '/' && !e.metaKey && !e.ctrlKey) {
+      const tag = (document.activeElement as HTMLElement | null)?.tagName;
+      if (tag !== 'INPUT' && tag !== 'TEXTAREA') {
+        e.preventDefault();
+        inputEl?.focus();
+      }
+    }
+  }
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} />
+
+<div class="relative flex-1">
+  <div
+    class="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"
+  >
+    <Search class="size-4 shrink-0 text-muted-foreground" />
+    <input
+      bind:this={inputEl}
+      value={q}
+      oninput={(e) => target?.setQuery(e.currentTarget.value)}
+      type="text"
+      {placeholder}
+      aria-label={placeholder}
+      autocomplete="off"
+      spellcheck="false"
+      class="min-w-0 flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
+    />
+    {#if q}
+      <button
+        type="button"
+        onclick={() => target?.setQuery('')}
+        aria-label="Clear search"
+        class="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <X class="size-4" />
+      </button>
+    {:else}
+      <kbd
+        class="hidden shrink-0 rounded border border-border px-1.5 text-xs text-muted-foreground sm:inline"
+        >/</kbd
+      >
+    {/if}
+  </div>
+</div>

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { goto, afterNavigate } from '$app/navigation';
-  import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { Search, X } from '@lucide/svelte';
   import { api } from '$lib/api';
@@ -9,15 +8,10 @@
   import { cn } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
 
-  // A launcher, not a filter: the header search jumps straight to a job/company
-  // or hands a free-text query to /jobs. It does NOT own the catalogue's query
-  // state — /jobs keeps its own URL-synced `q` input.
-
-  // On the list pages that already have their own text search (/jobs, /companies)
-  // the header input would duplicate it, so hide it there and leave an empty
-  // flex spacer that keeps the menu right-aligned. Detail pages (/jobs/:slug,
-  // /companies/:slug) and everywhere else keep the launcher.
-  const hidden = $derived(page.url.pathname === '/jobs' || page.url.pathname === '/companies');
+  // The global launcher: jumps straight to a job/company or hands a free-text
+  // query to /jobs. TopBar renders it on every page EXCEPT the list pages
+  // (/jobs, /companies), which swap in HeaderListSearch — a thin proxy that
+  // filters that page's list instead.
 
   const JOBS_LIMIT = 6;
   const COMPANIES_LIMIT = 4;
@@ -182,8 +176,7 @@
 <svelte:window onkeydown={onWindowKeydown} onclick={onWindowClick} />
 
 <div bind:this={wrapEl} class="relative flex-1">
-  {#if !hidden}
-    <!-- Search box -->
+  <!-- Search box -->
   <div
     class="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"
   >
@@ -296,6 +289,5 @@
         </button>
       {/if}
     </div>
-  {/if}
   {/if}
 </div>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -10,6 +10,7 @@
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams } from '$lib/filters';
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
+  import { setListSearchTarget } from '$lib/listSearch.svelte';
   import type { Job, FacetCounts } from '$lib/types';
   import { Input } from '$lib/ui';
   import FiltersPanel from './FiltersPanel.svelte';
@@ -38,6 +39,10 @@
   // Seed filters from the current URL so the server and the hydrated client
   // render the same filtered view.
   const filters = new FilterStore(page.url.searchParams);
+
+  // Standalone /jobs (no fixed scope) hands its text search to the header; an
+  // embedded, scoped instance (e.g. a company page) keeps its own inline input.
+  const standalone = $derived(Object.keys(scope).length === 0);
 
   // The user's (debounced) facet filters plus the fixed `scope` params
   // (company_slug, …). Reads `applied` so typing doesn't fetch per keystroke.
@@ -88,7 +93,12 @@
   // pending debounced reload so it can't fire after this view is gone.
   onMount(() => {
     if (isAuthenticated()) ensureViewedLoaded();
-    return () => filters.dispose();
+    // Register this page's store so the header search drives it (standalone only).
+    if (standalone) setListSearchTarget(filters);
+    return () => {
+      if (standalone) setListSearchTarget(null);
+      filters.dispose();
+    };
   });
 
   function reloadList() {
@@ -138,14 +148,20 @@
 
   <div class="min-w-0 flex-1">
     <div class="mb-4 flex items-center gap-2">
-      <Input
-        type="search"
-        value={filters.value.q}
-        oninput={(e) => filters.setQuery(e.currentTarget.value)}
-        placeholder="Search jobs…"
-        aria-label="Search jobs"
-        class="min-w-0 flex-1"
-      />
+      {#if standalone}
+        <!-- The header search is this page's text filter (see HeaderListSearch);
+             the spacer keeps Swipe/Filters right-aligned. -->
+        <div class="flex-1"></div>
+      {:else}
+        <Input
+          type="search"
+          value={filters.value.q}
+          oninput={(e) => filters.setQuery(e.currentTarget.value)}
+          placeholder="Search jobs…"
+          aria-label="Search jobs"
+          class="min-w-0 flex-1"
+        />
+      {/if}
       <button
         type="button"
         class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent"

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -6,11 +6,20 @@
   import { authDialog, openAuthDialog, closeAuthDialog } from '$lib/auth-dialog.svelte';
   import AuthDialog from './AuthDialog.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
+  import HeaderListSearch from './HeaderListSearch.svelte';
   import HeaderMenu from './HeaderMenu.svelte';
 
   // The header is three slots — logo | search | menu — identical on every
   // viewport. Nav links, the account items, the theme toggle, and the auth
-  // action all live in HeaderMenu; instant search lives in HeaderSearch.
+  // action all live in HeaderMenu.
+  //
+  // The middle slot is one text field that adapts to context: on the list pages
+  // (/jobs, /companies) it IS that page's filter (HeaderListSearch drives the
+  // list, so there's no duplicate box); everywhere else it's the global launcher
+  // with the instant dropdown (HeaderSearch).
+  const listKind = $derived(
+    page.url.pathname === '/jobs' ? 'jobs' : page.url.pathname === '/companies' ? 'companies' : null,
+  );
 
   // The auth dialog lives at the layout level but its open state is a shared
   // singleton (see auth-dialog.svelte), so deep components — like a job's Save
@@ -61,7 +70,13 @@
       <span class="hidden sm:inline">FreeHire</span>
     </a>
 
-    <HeaderSearch />
+    {#if listKind === 'jobs'}
+      <HeaderListSearch placeholder="Search jobs…" />
+    {:else if listKind === 'companies'}
+      <HeaderListSearch placeholder="Search companies…" />
+    {:else}
+      <HeaderSearch />
+    {/if}
 
     <HeaderMenu />
   </div>

--- a/web/src/lib/listSearch.svelte.ts
+++ b/web/src/lib/listSearch.svelte.ts
@@ -1,0 +1,26 @@
+// Bridge that lets the header act as the single text-search on the list pages
+// (/jobs, /companies) which already own a URL-synced filter store. The active
+// list view registers its store here on mount; the header's list-mode input
+// proxies through it — reusing that store's synchronous URL write, debounced
+// reload, and back/forward handling instead of re-implementing (and re-breaking)
+// that logic in the header.
+
+/** The slice of a page filter store the header drives. Both FilterStore and
+ *  CompanyFilterStore satisfy it (`value.q` + `setQuery`). */
+export interface ListSearchTarget {
+  readonly value: { q: string };
+  setQuery(q: string): void;
+}
+
+let active = $state<ListSearchTarget | null>(null);
+
+/** The current list page's search target, or null off the list pages. Reactive —
+ *  read it in the header to bind the input. */
+export function listSearchTarget(): ListSearchTarget | null {
+  return active;
+}
+
+/** A list view registers its store on mount and clears it (null) on destroy. */
+export function setListSearchTarget(target: ListSearchTarget | null): void {
+  active = target;
+}


### PR DESCRIPTION
## Summary

Replaces the earlier "hide the header search on list pages" approach (#319) with **one adaptive search field**, per feedback that the header search should stay everywhere.

- On **/jobs** and **/companies** the header field *is* that page's text filter (`HeaderListSearch`) — typing live-filters the list and **preserves the active facets** in the URL. No second box.
- **Everywhere else** it's the global launcher with the instant JOBS+COMPANIES dropdown (`HeaderSearch`).
- `TopBar` picks which to render by route.

### How it stays correct
The list views (`JobsView`, `CompaniesView`) register their existing URL-synced filter store via a tiny `listSearch` bridge; the header proxies input straight into it. This **reuses** the store's synchronous URL write + debounced reload + back/forward handling (`UrlSyncedState`), so facets are preserved and there's no dropped-character race — no DIY URL logic in the header. An embedded, scoped `JobsView` (the company page) keeps its own inline input.

## Test Plan

- [x] `svelte-check` 0/0 (the one eslint `no-navigation-without-resolve` on `openSwipe` is a pre-existing baseline, unchanged)
- [x] Local (headless): `/jobs?countries=US` + type "node" → URL `?q=node&countries=US` (**facet preserved**), list 3→1; `/companies` type "gra" → `?q=gra`, 1 company; home → launcher dropdown with JOBS section; no duplicate input on either list page