### PR TITLE
feat(web): surface Jobs/Companies as inline header links

### DIFF
--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -4,6 +4,7 @@
   import { resolve } from '$app/paths';
   import { replaceState } from '$app/navigation';
   import { authDialog, openAuthDialog, closeAuthDialog } from '$lib/auth-dialog.svelte';
+  import { cn } from '$lib/utils';
   import AuthDialog from './AuthDialog.svelte';
   import HeaderSearch from './HeaderSearch.svelte';
   import HeaderListSearch from './HeaderListSearch.svelte';
@@ -20,6 +21,17 @@
   const listKind = $derived(
     page.url.pathname === '/jobs' ? 'jobs' : page.url.pathname === '/companies' ? 'companies' : null,
   );
+
+  // Jobs/Companies are also surfaced as inline links here — left-aligned beside
+  // the logo, shown only from sm up (mobile keeps them in HeaderMenu, which is
+  // unchanged). The active section is emphasised, matching HeaderMenu's links.
+  const path = $derived(page.url.pathname);
+  const isActive = (href: string) => path === href || path.startsWith(`${href}/`);
+  const navLinkClass = (href: string) =>
+    cn(
+      'rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
+      isActive(href) ? 'font-medium text-foreground' : 'text-muted-foreground',
+    );
 
   // The auth dialog lives at the layout level but its open state is a shared
   // singleton (see auth-dialog.svelte), so deep components — like a job's Save
@@ -69,6 +81,11 @@
       </svg>
       <span class="hidden sm:inline">FreeHire</span>
     </a>
+
+    <nav class="hidden shrink-0 items-center gap-1 sm:flex">
+      <a href={resolve('/jobs')} class={navLinkClass('/jobs')}>Jobs</a>
+      <a href={resolve('/companies')} class={navLinkClass('/companies')}>Companies</a>
+    </nav>
 
     {#if listKind === 'jobs'}
       <HeaderListSearch placeholder="Search jobs…" />


### PR DESCRIPTION
Move Jobs and Companies out of the hamburger menu into the top bar as left-aligned inline links beside the logo (shown from `sm` up). Active-section styling mirrors `HeaderMenu`. The hamburger menu keeps the same links for mobile — unchanged.

Verified with `svelte-check` (0 errors).