### PR TITLE
feat(web): shareable swipe filter links (preserve deep link through sign-in)

### DIFF
--- a/web/src/lib/auth-dialog.svelte.ts
+++ b/web/src/lib/auth-dialog.svelte.ts
@@ -12,6 +12,10 @@ type Mode = 'login' | 'register';
 let open = $state(false);
 let mode = $state<Mode>('login');
 let error = $state<string | null>(null);
+// Where to send the user after a successful sign-in. Set when a guarded page
+// bounced them here to sign in (see TopBar), so both password and OAuth login
+// return to the shared deep link instead of the home page. null = stay put.
+let redirectTo = $state<string | null>(null);
 
 // Getters keep the state read-only from outside; `mode` also gets a setter so
 // the dialog's own sign-in/register toggle can two-way bind to it.
@@ -28,15 +32,25 @@ export const authDialog = {
   get error() {
     return error;
   },
+  get redirectTo() {
+    return redirectTo;
+  },
 };
 
-/** Open the dialog (defaults to sign-in), optionally seeding an inline error. */
-export function openAuthDialog(initialMode: Mode = 'login', initialError: string | null = null) {
+/** Open the dialog (defaults to sign-in), optionally seeding an inline error and
+ *  a post-login redirect target (a validated same-origin path). */
+export function openAuthDialog(
+  initialMode: Mode = 'login',
+  initialError: string | null = null,
+  redirect: string | null = null,
+) {
   mode = initialMode;
   error = initialError;
+  redirectTo = redirect;
   open = true;
 }
 
 export function closeAuthDialog() {
   open = false;
+  redirectTo = null;
 }

--- a/web/src/lib/components/AuthDialog.svelte
+++ b/web/src/lib/components/AuthDialog.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import { goto } from '$app/navigation';
   import { login, register } from '$lib/auth.svelte';
+  import { authDialog } from '$lib/auth-dialog.svelte';
   import { ApiError, oauthProviders } from '$lib/api';
   import { Button } from '$lib/ui';
   import ProviderIcon from './ProviderIcon.svelte';
@@ -39,10 +41,12 @@
 
   const title = $derived(mode === 'login' ? 'Sign in' : 'Create account');
 
-  // OAuth leaves the SPA entirely, so the page to return to after sign-in is
-  // passed to the backend (which echoes it back, sanitized, on the callback).
-  // Password login stays in this dialog, so it needs no redirect.
-  const returnTo = $derived(page.url.pathname + page.url.search);
+  // Where to go after sign-in. When a guarded page bounced the user here to sign
+  // in (e.g. a shared /jobs/swipe?filter link), `redirectTo` is that deep link;
+  // otherwise stay on the current page (in-place prompts like a job's Save
+  // button). OAuth passes this to the backend, which echoes it back sanitized;
+  // password login navigates to it here after success.
+  const returnTo = $derived(authDialog.redirectTo ?? page.url.pathname + page.url.search);
 
   function messageFor(e: unknown): string {
     if (e instanceof ApiError) {
@@ -57,9 +61,15 @@
     e.preventDefault();
     error = null;
     submitting = true;
+    // Capture before onClose(), which clears the dialog's redirectTo.
+    const target = returnTo;
     try {
       await (mode === 'login' ? login : register)(email, password);
       onClose();
+      if (target !== page.url.pathname + page.url.search) {
+        // eslint-disable-next-line svelte/no-navigation-without-resolve -- a validated same-origin path from the guard, not a typed route
+        await goto(target);
+      }
     } catch (err) {
       error = messageFor(err);
     } finally {

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -41,6 +41,14 @@
   // ?auth_error: a failed OAuth callback. ?auth=required: a guarded page (e.g.
   // /my/jobs) bounced a signed-out visitor here to sign in. In onMount so it
   // never runs during SSR.
+  // Only accept a same-origin rooted path as the post-login redirect — never a
+  // scheme-relative "//host" or absolute URL — mirroring the backend's
+  // SafeReturnPath, so a crafted link can't bounce the user off-site.
+  function safeRedirect(raw: string | null): string | null {
+    if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return null;
+    return raw;
+  }
+
   onMount(() => {
     const params = page.url.searchParams;
     if (params.has('auth_error')) {
@@ -48,7 +56,9 @@
       openAuthDialog('login', 'Sign-in failed. Please try again.');
     } else if (params.get('auth') === 'required') {
       // Just a sign-in gate, not an error — open the dialog with no error banner.
-      openAuthDialog('login');
+      // ?redirect (set by a guarded page) is the deep link to return to after
+      // sign-in; stash it before the URL is cleaned below.
+      openAuthDialog('login', null, safeRedirect(params.get('redirect')));
     } else {
       return;
     }

--- a/web/src/routes/jobs/swipe/+page.server.ts
+++ b/web/src/routes/jobs/swipe/+page.server.ts
@@ -4,9 +4,13 @@ import type { PageServerLoad } from './$types';
 // Swipe mode is personal: both actions (save and dismiss) are per-user, and the
 // deck endpoint is authenticated. A signed-out visitor has no deck to show, so
 // guard server-side and bounce home with ?auth=required — the TopBar pops the
-// sign-in dialog (same pattern as /my/jobs). After signing in the visitor
-// re-enters swipe mode from /jobs.
-export const load: PageServerLoad = async ({ parent }) => {
+// sign-in dialog (same pattern as /my/jobs). We also carry the intended
+// destination (path + query) as ?redirect, so a shared link like
+// /jobs/swipe?seniority=senior survives sign-in and reopens the filtered deck.
+export const load: PageServerLoad = async ({ parent, url }) => {
   const { user } = await parent();
-  if (!user) redirect(302, '/?auth=required');
+  if (!user) {
+    const target = url.pathname + url.search;
+    redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
+  }
 };

--- a/web/src/routes/my/jobs/+page.server.ts
+++ b/web/src/routes/my/jobs/+page.server.ts
@@ -5,8 +5,12 @@ import type { PageServerLoad } from './$types';
 // server-side rather than render an empty "sign in" state. The user is resolved
 // once in the root layout load; reuse it via parent(). Auth is a layout-level
 // dialog (no /login route), so we bounce home with ?auth=required and the TopBar
-// pops the sign-in dialog (same pattern as the ?auth_error OAuth callback).
-export const load: PageServerLoad = async ({ parent }) => {
+// pops the sign-in dialog (same pattern as the ?auth_error OAuth callback). The
+// ?redirect carries the destination so sign-in returns here, not the home page.
+export const load: PageServerLoad = async ({ parent, url }) => {
   const { user } = await parent();
-  if (!user) redirect(302, '/?auth=required');
+  if (!user) {
+    const target = url.pathname + url.search;
+    redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
+  }
 };


### PR DESCRIPTION
## What
A shared link like `/jobs/swipe?seniority=senior` now opens the filtered deck for **any** recipient.

- **Signed-in:** already worked — the deck reads `page.url.search` and the backend forwards facets (`TestSwipeDeck_ExcludesJudgedJobsAndForwardsFilters`).
- **Signed-out:** was broken — the server guard bounced to `/?auth=required`, dropping path + query, so after login you landed on the home page.

## Fix (frontend only — Go backend untouched)
Carry the destination through sign-in for **both** password and OAuth:
- Guards (`jobs/swipe`, `my/jobs`) append `?redirect=<pathname+search>`.
- `auth-dialog` singleton gains `redirectTo`; `TopBar` stashes the validated `?redirect` before cleaning the URL.
- `AuthDialog` uses it as the return target — OAuth already threads `returnTo` through the backend (`OAuthStart`/`OAuthCallback` + `SafeReturnPath`); password login `goto`s there after `invalidateAll`.
- `safeRedirect` (client) mirrors the backend `SafeReturnPath`: same-origin rooted paths only — no open redirect.

## Verification
- `npm run check` (svelte-check): 0 errors. No frontend test runner in this repo.
- In-place prompts (e.g. a job's Save button) unchanged: `redirectTo` is null there, so login stays on the page.