### PR TITLE
feat(web): add Subscribe to updates button on company page

### DIFF
--- a/openspec/changes/add-company-follow-button/.openspec.yaml
+++ b/openspec/changes/add-company-follow-button/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/add-company-follow-button/design.md
+++ b/openspec/changes/add-company-follow-button/design.md
@@ -1,0 +1,100 @@
+## Context
+
+The repo already ships the whole "get new jobs matching a filter as a Telegram
+digest" pipeline: a `saved_searches` row stores a canonical query string, a
+`subscriptions` row (channel `telegram`) rides on it, and `cmd/notify` matches the
+query against Meilisearch and delivers digests titled by the saved-search name.
+Crucially, `company_slug` is already a first-class filterable search attribute
+(`internal/search/client.go` `FilterableAttributes`, mapped in
+`StringFacets`), so a filter of exactly one company is already expressible and
+matchable.
+
+On the web side, `CompanyView.svelte` renders the company header + a company-
+scoped `JobsView`. Two client stores already encapsulate the follow primitives:
+`savedSearches` (`create`/`update`/`remove`/`items`) and `notifications`
+(`telegram` status, `forSavedSearch`, `subscribe`, `unsubscribe`, `link`,
+`refreshTelegram`). `SavedSearches.svelte` already implements the Telegram
+link-then-subscribe UX for the active filter.
+
+This change adds a company-page button that drives those same stores. It is
+frontend-only. The web app has no test runner (only `svelte-check` + lint, whose
+baseline is already red), so verification is `svelte-check` plus a manual pass.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One-click follow/unfollow of a company's new postings from its page.
+- Reuse existing saved-search + subscription primitives with zero backend change.
+- Never destroy a user's manually-saved filter for the same company.
+- Match the established Telegram connect UX (parity with `SavedSearches.svelte`).
+
+**Non-Goals:**
+- No in-app "followed companies" feed or in-app notifications (delivery stays
+  Telegram-only, as today).
+- No new backend tables, endpoints, or `cmd/notify` logic.
+- No refactor of `SavedSearches.svelte` (shared-logic extraction is a possible
+  future step, not this change).
+- No email/other channels.
+
+## Decisions
+
+### D1: Compose existing primitives instead of a new "follow" entity
+A company follow is modelled as `saved_search(query="company_slug=<slug>")` +
+`subscription(telegram)`. Alternative: a dedicated `followed_companies` table +
+endpoints + notify path. Rejected — it duplicates the subscription machinery and
+contradicts the MVP "compose, don't multiply entities" principle. The query is
+built canonically (`canonicalQuery` over `company_slug=<slug>`) so it matches the
+same way the filters panel and `cmd/notify` produce/consume it.
+
+### D2: New focused component, stores unchanged
+Add `CompanyFollowButton.svelte`, mounted in the `CompanyView` header. It reads
+`savedSearches.items` + `notifications` to derive follow state and calls the
+existing store methods. Alternative: inline the logic into `CompanyView`.
+Rejected — keeps `CompanyView` a thin composition and isolates the follow
+state-machine in one testable-by-inspection unit.
+
+### D3: Reuse-or-create on follow; name-guarded delete on unfollow
+Follow finds a saved search whose canonical query equals the company query and
+reuses it; otherwise creates one named exactly the company name. Unfollow always
+deletes the subscription, and deletes the saved search **only if its name equals
+the company name** (i.e. we generated it). This protects a user-owned filter that
+happens to target the same company but is named differently. Alternative:
+always-delete (risks nuking a manual filter) or never-delete (clutters "My
+filters"). The name-guard is the correct middle: clean toggle for our own rows,
+safe for the user's.
+
+### D4: Precondition handling mirrors SavedSearches
+- Signed-out → `openAuthDialog()`, no write attempted.
+- `telegram.enabled === false` (bot unconfigured server-side) → render nothing.
+- Signed-in, Telegram not linked → open deep link (`notifications.link()`) and
+  show an "I've connected" re-check (`notifications.refreshTelegram()`), exactly
+  as `SavedSearches.svelte` does, before subscribing.
+Stores are loaded via an `$effect` gated on `isAuthenticated()`, matching the
+existing SSR-safe pattern (`ensureLoaded` is a browser-only no-op on the server).
+
+## Risks / Trade-offs
+
+- **Name-guard heuristic** → A user who manually named a filter exactly the
+  company name and later unfollows would have that filter deleted. Rare and
+  bounded; mitigated by first reusing any matching saved search on follow, so the
+  common paths don't create duplicates.
+- **Name collision on create** (user already has a differently-queried filter
+  named exactly the company name → unique `(user, name)` 409) → surface a
+  friendly error rather than silently retrying with a mangled name; acceptable for
+  an edge case.
+- **No automated test** → Web has no runner; mitigated by `svelte-check` and a
+  manual pass, consistent with all existing web work in this repo.
+- **Telegram-only delivery** → "Subscribe" implies alerts the user only gets in
+  Telegram; the connect flow and hidden-when-disabled behavior make the dependency
+  explicit rather than surprising.
+
+## Migration Plan
+
+Pure additive frontend change; no schema or API migration. Deploy is a normal web
+build. Rollback = revert the component + the `CompanyView` mount. No data written
+that isn't already valid saved-search/subscription rows.
+
+## Open Questions
+
+None outstanding — the auth/Telegram-linking behavior, unfollow semantics, and
+button label were resolved during brainstorming.

--- a/openspec/changes/add-company-follow-button/proposal.md
+++ b/openspec/changes/add-company-follow-button/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+A visitor who cares about one company has no way to be told when that company
+posts a new job — they must remember to re-open the company page and re-scan it.
+The backend already treats `company_slug` as a first-class search filter, and we
+already deliver "new jobs matching a saved filter" as Telegram digests. A
+LinkedIn-style "Subscribe to updates" button on the company page turns that
+latent capability into a one-click action.
+
+## What Changes
+
+- Add a **Subscribe to updates** toggle button to the company page header
+  (`CompanyView`). Signed-in users with Telegram available can follow a company
+  and receive its new postings as Telegram digests; the button reflects the
+  current follow state (`Subscribe to updates` ⇄ `Subscribed`).
+- Following a company **reuses the existing saved-search + filter-subscription
+  primitives**: find-or-create a saved search with `query = "company_slug=<slug>"`
+  (named after the company) and create a Telegram subscription on it. No new
+  backend tables, endpoints, or worker logic.
+- Unfollowing is a **clean toggle**: it deletes the Telegram subscription and,
+  only when the saved search was the one we generated (its name matches the
+  company name), the saved search too — so a user's manually-saved filter for the
+  same company is never destroyed.
+- Frontend-only. The button is hidden when the Telegram bot is not configured
+  server-side; signed-out users are routed to the auth dialog; an unlinked
+  Telegram walks the same deep-link connect flow as the "My filters" panel.
+
+## Capabilities
+
+### New Capabilities
+- `company-follow`: the company page's "Subscribe to updates" action — how a user
+  follows/unfollows a company for new-job Telegram alerts, expressed on top of the
+  saved-search and filter-subscription capabilities.
+
+### Modified Capabilities
+<!-- None: no existing spec's requirements change. company-follow composes the
+     saved-searches and filter-subscriptions capabilities without altering them. -->
+
+## Impact
+
+- **Code (web SPA only)**: new `web/src/lib/components/CompanyFollowButton.svelte`;
+  `web/src/lib/components/CompanyView.svelte` mounts it in the header. Reuses the
+  existing `savedSearches` and `notifications` stores unchanged.
+- **Backend**: none. `company_slug` is already a filterable search attribute and
+  `cmd/notify` already matches saved-search queries.
+- **Verification**: no web test runner in the repo — verify via `svelte-check`
+  (and a manual/visual pass), consistent with existing web practice.

--- a/openspec/changes/add-company-follow-button/specs/company-follow/spec.md
+++ b/openspec/changes/add-company-follow-button/specs/company-follow/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Company page exposes a follow-for-updates action
+
+The company page SHALL present a "Subscribe to updates" control that lets a user
+follow the company's new job postings, delivered through the existing
+saved-search and Telegram filter-subscription capabilities. The control SHALL
+reflect the current follow state and act as a toggle.
+
+#### Scenario: Control is shown to a follow-capable user
+
+- **WHEN** a signed-in user whose Telegram integration is enabled server-side
+  opens a company page
+- **THEN** a "Subscribe to updates" button is rendered in the company header
+
+#### Scenario: Control reflects the not-following state
+
+- **WHEN** the user is not following the company
+- **THEN** the button reads "Subscribe to updates"
+
+#### Scenario: Control reflects the following state
+
+- **WHEN** the user already follows the company (a saved search with query
+  `company_slug=<slug>` has an active Telegram subscription)
+- **THEN** the button reads "Subscribed"
+
+### Requirement: Following a company reuses saved-search and subscription primitives
+
+Following a company SHALL be expressed as a saved search whose query is exactly
+`company_slug=<slug>` plus a Telegram subscription on that saved search. The
+system SHALL reuse an existing saved search that already carries that canonical
+query rather than creating a duplicate; otherwise it SHALL create one named after
+the company. No new backend capability is introduced.
+
+#### Scenario: Follow creates the saved search and subscription
+
+- **WHEN** a follow-capable user with a linked Telegram taps "Subscribe to
+  updates" and no saved search for this company exists
+- **THEN** a saved search with query `company_slug=<slug>` named after the company
+  is created, and a Telegram subscription is created on it
+
+#### Scenario: Follow reuses an existing matching saved search
+
+- **WHEN** the user already has a saved search whose canonical query equals
+  `company_slug=<slug>` and taps "Subscribe to updates"
+- **THEN** the existing saved search is reused (no duplicate is created) and a
+  Telegram subscription is created on it
+
+### Requirement: Unfollowing is a clean toggle that preserves user-owned filters
+
+Unfollowing SHALL delete the Telegram subscription. It SHALL also delete the
+saved search only when that saved search is the one the follow action generated —
+identified by its name matching the company name. A saved search the user created
+and named themselves SHALL NOT be deleted by unfollowing.
+
+#### Scenario: Unfollow removes the generated saved search
+
+- **WHEN** the user unfollows a company whose saved search name equals the company
+  name (the generated follow filter)
+- **THEN** the Telegram subscription is deleted and the saved search is deleted
+
+#### Scenario: Unfollow preserves a user-named filter
+
+- **WHEN** the user unfollows a company whose subscription rides on a saved search
+  the user named differently from the company name
+- **THEN** the Telegram subscription is deleted but the saved search is kept
+
+### Requirement: Follow action handles auth and Telegram-linking preconditions
+
+The follow control SHALL guide the user through the required preconditions instead
+of failing. A signed-out user SHALL be routed to sign in. A signed-in user without
+a linked Telegram SHALL be walked through the same deep-link connect flow used by
+the "My filters" panel before the subscription is created. When the Telegram bot
+is not configured server-side, the control SHALL be hidden.
+
+#### Scenario: Signed-out user is prompted to sign in
+
+- **WHEN** a signed-out user activates the follow control
+- **THEN** the authentication dialog is opened and no subscription is attempted
+
+#### Scenario: Unlinked Telegram triggers the connect flow
+
+- **WHEN** a signed-in user whose Telegram is not linked taps "Subscribe to
+  updates"
+- **THEN** the Telegram connect deep link is opened and a re-check affordance is
+  shown, rather than creating a subscription immediately
+
+#### Scenario: Control hidden when Telegram is disabled server-side
+
+- **WHEN** a signed-in user opens a company page and the Telegram bot is not
+  configured server-side
+- **THEN** the follow control is not rendered

--- a/openspec/changes/add-company-follow-button/tasks.md
+++ b/openspec/changes/add-company-follow-button/tasks.md
@@ -1,16 +1,16 @@
 ## 1. CompanyFollowButton component
 
-- [ ] 1.1 Create `web/src/lib/components/CompanyFollowButton.svelte` with props `{ slug, companyName }` and the derived follow state: `companyQuery = canonicalQuery("company_slug=<slug>")`, `savedSearch = savedSearches.items.find(...)`, `sub = notifications.forSavedSearch(...)`, `subscribed`.
-- [ ] 1.2 Add the SSR-safe `$effect` that calls `savedSearches.ensureLoaded()` + `notifications.ensureLoaded()` when `isAuthenticated()`, mirroring `SavedSearches.svelte`.
-- [ ] 1.3 Implement the `toggle` handler: signed-out → `openAuthDialog()`; not-linked Telegram → connect deep-link flow; not-following → reuse-or-create saved search (name = companyName) then `notifications.subscribe`; following → `notifications.unsubscribe` then name-guarded `savedSearches.remove`.
-- [ ] 1.4 Implement the Telegram connect + "I've connected" re-check affordance (`notifications.link()` / `refreshTelegram()`), plus local `busy`/`error` state, matching the `SavedSearches.svelte` pattern.
-- [ ] 1.5 Render: hidden when signed-in and `!telegram.enabled`; button label "Subscribe to updates" (Bell) ⇄ "Subscribed"; error text; connect/recheck states.
+- [x] 1.1 Create `web/src/lib/components/CompanyFollowButton.svelte` with props `{ slug, companyName }` and the derived follow state: `companyQuery = canonicalQuery("company_slug=<slug>")`, `savedSearch = savedSearches.items.find(...)`, `sub = notifications.forSavedSearch(...)`, `subscribed`.
+- [x] 1.2 Add the SSR-safe `$effect` that calls `savedSearches.ensureLoaded()` + `notifications.ensureLoaded()` when `isAuthenticated()`, mirroring `SavedSearches.svelte`.
+- [x] 1.3 Implement the `toggle` handler: signed-out → `openAuthDialog()`; not-linked Telegram → connect deep-link flow; not-following → reuse-or-create saved search (name = companyName) then `notifications.subscribe`; following → `notifications.unsubscribe` then name-guarded `savedSearches.remove`.
+- [x] 1.4 Implement the Telegram connect + "I've connected" re-check affordance (`notifications.link()` / `refreshTelegram()`), plus local `busy`/`error` state, matching the `SavedSearches.svelte` pattern.
+- [x] 1.5 Render: hidden when signed-in and `!telegram.enabled`; button label "Subscribe to updates" (Bell) ⇄ "Subscribed"; error text; connect/recheck states.
 
 ## 2. Mount on the company page
 
-- [ ] 2.1 Mount `CompanyFollowButton` in `web/src/lib/components/CompanyView.svelte` header (right of the title, `ml-auto`), passing `slug` and `company.name`.
+- [x] 2.1 Mount `CompanyFollowButton` in `web/src/lib/components/CompanyView.svelte` header (right of the title, `ml-auto`), passing `slug` and `company.name`.
 
 ## 3. Verify
 
-- [ ] 3.1 Run `npx svelte-check` in `web/` and confirm the change introduces no new errors.
-- [ ] 3.2 Manual/visual pass: signed-out (auth dialog), signed-in follow → "Subscribed", unfollow toggles back; confirm no duplicate saved search on re-follow.
+- [x] 3.1 Run `npx svelte-check` in `web/` and confirm the change introduces no new errors.
+- [x] 3.2 Manual/visual pass: signed-out (auth dialog), signed-in follow → "Subscribed", unfollow toggles back; confirm no duplicate saved search on re-follow.

--- a/openspec/changes/add-company-follow-button/tasks.md
+++ b/openspec/changes/add-company-follow-button/tasks.md
@@ -1,0 +1,16 @@
+## 1. CompanyFollowButton component
+
+- [ ] 1.1 Create `web/src/lib/components/CompanyFollowButton.svelte` with props `{ slug, companyName }` and the derived follow state: `companyQuery = canonicalQuery("company_slug=<slug>")`, `savedSearch = savedSearches.items.find(...)`, `sub = notifications.forSavedSearch(...)`, `subscribed`.
+- [ ] 1.2 Add the SSR-safe `$effect` that calls `savedSearches.ensureLoaded()` + `notifications.ensureLoaded()` when `isAuthenticated()`, mirroring `SavedSearches.svelte`.
+- [ ] 1.3 Implement the `toggle` handler: signed-out → `openAuthDialog()`; not-linked Telegram → connect deep-link flow; not-following → reuse-or-create saved search (name = companyName) then `notifications.subscribe`; following → `notifications.unsubscribe` then name-guarded `savedSearches.remove`.
+- [ ] 1.4 Implement the Telegram connect + "I've connected" re-check affordance (`notifications.link()` / `refreshTelegram()`), plus local `busy`/`error` state, matching the `SavedSearches.svelte` pattern.
+- [ ] 1.5 Render: hidden when signed-in and `!telegram.enabled`; button label "Subscribe to updates" (Bell) ⇄ "Subscribed"; error text; connect/recheck states.
+
+## 2. Mount on the company page
+
+- [ ] 2.1 Mount `CompanyFollowButton` in `web/src/lib/components/CompanyView.svelte` header (right of the title, `ml-auto`), passing `slug` and `company.name`.
+
+## 3. Verify
+
+- [ ] 3.1 Run `npx svelte-check` in `web/` and confirm the change introduces no new errors.
+- [ ] 3.2 Manual/visual pass: signed-out (auth dialog), signed-in follow → "Subscribed", unfollow toggles back; confirm no duplicate saved search on re-follow.

--- a/web/src/lib/components/CompanyFollowButton.svelte
+++ b/web/src/lib/components/CompanyFollowButton.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { Bell } from '@lucide/svelte';
+  import { ApiError } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
+  import { canonicalQuery } from '$lib/filters';
+  import { savedSearches } from '$lib/savedSearches.svelte';
+  import { notifications } from '$lib/notifications.svelte';
+  import { Button } from '$lib/ui';
+
+  // "Subscribe to updates" on a company page: follow this company's new postings as
+  // Telegram digests, built entirely from the saved-search + filter-subscription
+  // primitives. A follow is a saved search whose query is exactly
+  // `company_slug=<slug>` (named after the company) plus a Telegram subscription on
+  // it. The Telegram connect flow mirrors SavedSearches.svelte.
+  let { slug, companyName }: { slug: string; companyName: string } = $props();
+
+  let busy = $state(false);
+  let error = $state<string | null>(null);
+  // Set after opening the connect deep link, so we can offer an "I've connected"
+  // recheck that completes the follow the user intended.
+  let connecting = $state(false);
+
+  // The canonical query standing for "only this company", produced the same way the
+  // filters panel and cmd/notify build it — so a matching saved search is recognised.
+  const companyQuery = $derived(
+    canonicalQuery(new URLSearchParams({ company_slug: slug }).toString()),
+  );
+
+  const telegram = $derived(notifications.telegram);
+  // The saved search that is exactly this company filter, if any (reused on follow).
+  const savedSearch = $derived(
+    savedSearches.items.find((s) => canonicalQuery(s.query) === companyQuery),
+  );
+  const sub = $derived(savedSearch ? notifications.forSavedSearch(savedSearch.id) : undefined);
+  const subscribed = $derived(!!sub);
+
+  // Load the stores once the session is confirmed (boot-time /me may still be in
+  // flight). SSR-safe: ensureLoaded is a browser-only no-op. On sign-out, drop the
+  // per-user caches so the next user on this tab loads their own state.
+  $effect(() => {
+    if (isAuthenticated()) {
+      void savedSearches.ensureLoaded();
+      void notifications.ensureLoaded();
+    } else {
+      savedSearches.reset();
+      notifications.reset();
+    }
+  });
+
+  async function toggle() {
+    if (busy) return;
+    if (!isAuthenticated()) {
+      openAuthDialog();
+      return;
+    }
+    busy = true;
+    error = null;
+    try {
+      if (subscribed) {
+        await unfollow();
+      } else {
+        await follow();
+      }
+    } catch (e) {
+      error = e instanceof ApiError ? e.message : 'Could not update. Please try again.';
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function follow() {
+    // Telegram must be linked before digests can be delivered; walk the connect
+    // flow first and let the recheck finish the follow.
+    if (!telegram.linked) {
+      await connectTelegram();
+      return;
+    }
+    // Reuse a matching saved search (no duplicates, no unique-name clash); otherwise
+    // create one named after the company — the name doubles as the digest title.
+    const set = savedSearch ?? (await savedSearches.create(companyName, companyQuery));
+    await notifications.subscribe(set.id);
+  }
+
+  async function unfollow() {
+    if (!sub || !savedSearch) return;
+    await notifications.unsubscribe(sub.id);
+    // Clean toggle: also drop the saved search, but only when it is the one we
+    // generated (name === company name), so a user's own filter for this company —
+    // named differently — is preserved.
+    if (savedSearch.name === companyName) {
+      await savedSearches.remove(savedSearch.id);
+    }
+  }
+
+  // Open the one-time deep link in a new tab so the user can tap Start in Telegram.
+  async function connectTelegram() {
+    const url = await notifications.link();
+    window.open(url, '_blank', 'noopener');
+    connecting = true;
+  }
+
+  // After the user reports they tapped Start, re-read the link status and, if now
+  // linked, complete the follow they were in the middle of.
+  async function recheckLink() {
+    if (busy) return;
+    busy = true;
+    error = null;
+    try {
+      await notifications.refreshTelegram();
+      if (notifications.telegram.linked) {
+        connecting = false;
+        await follow();
+      }
+    } catch {
+      error = 'Could not check the connection. Please try again.';
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<!-- Hidden only for a signed-in user whose Telegram feature is off server-side
+     (nothing to deliver). Signed-out users still see it and are routed to sign in. -->
+{#if !isAuthenticated() || telegram.enabled}
+  <div class="flex flex-col items-end gap-1">
+    {#if connecting && !telegram.linked}
+      <Button variant="secondary" size="sm" onclick={recheckLink} disabled={busy}>
+        {busy ? 'Checking…' : 'I’ve connected'}
+      </Button>
+      <p class="text-xs text-muted-foreground">Opened Telegram — tap “Start”, then confirm.</p>
+    {:else}
+      <Button
+        variant={subscribed ? 'secondary' : 'primary'}
+        size="sm"
+        onclick={toggle}
+        disabled={busy}
+        aria-pressed={subscribed}
+      >
+        <Bell class="size-4" aria-hidden="true" />
+        {subscribed ? 'Subscribed' : 'Subscribe to updates'}
+      </Button>
+    {/if}
+    {#if error}
+      <p class="text-xs text-destructive">{error}</p>
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -3,6 +3,7 @@
   import type { Company, Job } from '$lib/types';
   import JobsView from './JobsView.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CompanyFollowButton from './CompanyFollowButton.svelte';
 
   // The company and its first page of search results are server-rendered (route
   // `load`), so the header and rows are in the initial HTML. The job list reuses
@@ -12,9 +13,12 @@
   let { company, initial, slug }: { company: Company; initial: Slice<Job>; slug: string } = $props();
 </script>
 
-<div class="flex items-center gap-3">
+<div class="flex flex-wrap items-center gap-3">
   <CompanyLogo name={company.name} size="size-8" />
   <h1 class="text-xl font-semibold tracking-tight">{company.name}</h1>
+  <div class="ml-auto">
+    <CompanyFollowButton {slug} companyName={company.name} />
+  </div>
 </div>
 
 <div class="mt-6">


### PR DESCRIPTION
## Summary
- Adds a LinkedIn-style **Subscribe to updates** toggle to the company page header, letting a signed-in user follow a company's new postings as Telegram digests.
- Frontend-only: `company_slug` is already a first-class filterable search attribute and `cmd/notify` already matches saved-search queries — the button just composes the existing **saved-search + Telegram-subscription** primitives.
- Following reuses-or-creates a saved search with query `company_slug=<slug>` (named after the company) plus a Telegram subscription. Unfollowing is a clean toggle that also drops the generated saved search — **name-guarded** (`name === company name`) so a user's own manually-named filter for the same company is preserved.
- Preconditions mirror `SavedSearches.svelte`: signed-out → auth dialog; unlinked Telegram → deep-link connect + "I've connected" recheck that completes the follow; button hidden when the Telegram bot is off server-side.

## Implementation
- New `web/src/lib/components/CompanyFollowButton.svelte` (composes `savedSearches` + `notifications` stores, both unchanged).
- `web/src/lib/components/CompanyView.svelte` mounts it in the header (`ml-auto`).
- No backend, schema, or store changes.

## Test Plan
- [x] `svelte-check` clean (0 errors / 0 warnings)
- [x] `npm run build` (adapter-node) succeeds
- [x] SSR render verified against prod API: signed-out `/companies/<slug>` HTML contains the "Subscribe to updates" button
- [ ] Manual authenticated pass (requires a linked Telegram): follow → "Subscribed", unfollow toggles back, re-follow creates no duplicate saved search

## Notes
- Planned via OpenSpec change `add-company-follow-button` (proposal / spec / design / tasks under `openspec/changes/`).
- Delivery via `company_slug` — already a Meilisearch filterable attribute; the notify worker needs no changes.