### PR TITLE
feat: shareable public saved-search boards

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -118,12 +118,14 @@ type JobSubmission struct {
 }
 
 type SavedSearch struct {
-	ID        int64              `json:"id"`
-	UserID    int64              `json:"user_id"`
-	Name      string             `json:"name"`
-	Query     string             `json:"query"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	ID          int64              `json:"id"`
+	UserID      int64              `json:"user_id"`
+	Name        string             `json:"name"`
+	Query       string             `json:"query"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+	PublicSlug  pgtype.Text        `json:"public_slug"`
+	AuthorLabel pgtype.Text        `json:"author_label"`
 }
 
 type SearchProfile struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -6,6 +6,8 @@ package db
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type Querier interface {
@@ -39,6 +41,10 @@ type Querier interface {
 	ClaimTelegramPosts(ctx context.Context, arg ClaimTelegramPostsParams) ([]ClaimTelegramPostsRow, error)
 	// Reset a tracked job to the wishlist: drop stage and applied state, keep saved/viewed/notes.
 	ClearJobProgress(ctx context.Context, arg ClearJobProgressParams) (UserJob, error)
+	// Unpublish a board: clear the slug and author label, owner-scoped. Returns the
+	// affected row count: 1 for an owned row (whether or not it was shared — unshare is an
+	// idempotent no-op when already private), 0 when missing or not the caller's (→ 404).
+	ClearSavedSearchPublicSlug(ctx context.Context, arg ClearSavedSearchPublicSlugParams) (int64, error)
 	// Soft-close one job now (see job-lifecycle): a moderator resolving a report with
 	// close_job=true. The third writer of closed_at, alongside the ingest sweep and the
 	// liveness probe. WHERE closed_at IS NULL keeps it idempotent — a second close on an
@@ -169,10 +175,19 @@ type Querier interface {
 	GetJobIDBySlug(ctx context.Context, publicSlug string) (int64, error)
 	// The display fields for the jobs in a digest, freshest first.
 	GetJobsForDigest(ctx context.Context, jobIds []int64) ([]GetJobsForDigestRow, error)
+	// Public read of a shared board by its slug — no auth, no owner-scoping. Exposes only
+	// the board's display fields; owner columns (user_id) are never selected. A NULL slug
+	// never equals the param, so private sets are unreachable. No row → 404.
+	GetPublicBoardBySlug(ctx context.Context, publicSlug pgtype.Text) (GetPublicBoardBySlugRow, error)
 	// Load a single report by id for the review path. The resolve/dismiss flow guards the
 	// status in the service; the Mark* queries are additionally scoped to status='pending' as
 	// defense-in-depth against a concurrent second decision.
 	GetReport(ctx context.Context, id int64) (JobReport, error)
+	// Fetch one of a user's saved searches, owner-scoped. Used by the share use case to
+	// read the current name/public_slug before deciding whether to keep an existing slug
+	// or mint a new one. No matching row (wrong id or another user's) returns no row (the
+	// service maps that to ErrNotFound).
+	GetSavedSearch(ctx context.Context, arg GetSavedSearchParams) (SavedSearch, error)
 	// Load a single submission by id for the review path. The approve/reject flow guards the
 	// status in the service; the Mark* queries are additionally scoped to status='pending' as
 	// defense-in-depth against a concurrent second decision.
@@ -366,6 +381,13 @@ type Querier interface {
 	// and the provenance stamp, touching no raw source field. Kept separate from
 	// UpsertJob (the ingest full-upsert path) so ingest and enrichment stay decoupled.
 	SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentParams) error
+	// Publish a saved search as a board: set its public slug and (optional) author label,
+	// owner-scoped, bumping updated_at. The service decides the slug (keeping an existing
+	// one on re-share, minting a fresh one otherwise), so this sets it verbatim; a
+	// collision with another board's slug raises a UNIQUE violation the service retries.
+	// author_label is set verbatim (NULL clears it → anonymous). No matching owner-scoped
+	// row returns no row (→ ErrNotFound).
+	SetSavedSearchPublicSlug(ctx context.Context, arg SetSavedSearchPublicSlugParams) (SavedSearch, error)
 	// Pause/resume a subscription, scoped to its owner. No matching owner-scoped row
 	// returns no row (the handler maps that to 404).
 	SetSubscriptionActive(ctx context.Context, arg SetSubscriptionActiveParams) (Subscription, error)

--- a/internal/db/queries/saved_searches.sql
+++ b/internal/db/queries/saved_searches.sql
@@ -36,3 +36,41 @@ RETURNING *;
 -- (the handler maps that to 404).
 DELETE FROM saved_searches
 WHERE id = $1 AND user_id = $2;
+
+-- name: GetSavedSearch :one
+-- Fetch one of a user's saved searches, owner-scoped. Used by the share use case to
+-- read the current name/public_slug before deciding whether to keep an existing slug
+-- or mint a new one. No matching row (wrong id or another user's) returns no row (the
+-- service maps that to ErrNotFound).
+SELECT * FROM saved_searches
+WHERE id = $1 AND user_id = $2;
+
+-- name: SetSavedSearchPublicSlug :one
+-- Publish a saved search as a board: set its public slug and (optional) author label,
+-- owner-scoped, bumping updated_at. The service decides the slug (keeping an existing
+-- one on re-share, minting a fresh one otherwise), so this sets it verbatim; a
+-- collision with another board's slug raises a UNIQUE violation the service retries.
+-- author_label is set verbatim (NULL clears it → anonymous). No matching owner-scoped
+-- row returns no row (→ ErrNotFound).
+UPDATE saved_searches
+SET public_slug  = sqlc.arg('public_slug'),
+    author_label = sqlc.narg('author_label'),
+    updated_at   = now()
+WHERE id = sqlc.arg('id') AND user_id = sqlc.arg('user_id')
+RETURNING *;
+
+-- name: ClearSavedSearchPublicSlug :execrows
+-- Unpublish a board: clear the slug and author label, owner-scoped. Returns the
+-- affected row count: 1 for an owned row (whether or not it was shared — unshare is an
+-- idempotent no-op when already private), 0 when missing or not the caller's (→ 404).
+UPDATE saved_searches
+SET public_slug = NULL, author_label = NULL, updated_at = now()
+WHERE id = $1 AND user_id = $2;
+
+-- name: GetPublicBoardBySlug :one
+-- Public read of a shared board by its slug — no auth, no owner-scoping. Exposes only
+-- the board's display fields; owner columns (user_id) are never selected. A NULL slug
+-- never equals the param, so private sets are unreachable. No row → 404.
+SELECT name, query, author_label
+FROM saved_searches
+WHERE public_slug = $1;

--- a/internal/db/saved_searches.sql.go
+++ b/internal/db/saved_searches.sql.go
@@ -11,6 +11,28 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const clearSavedSearchPublicSlug = `-- name: ClearSavedSearchPublicSlug :execrows
+UPDATE saved_searches
+SET public_slug = NULL, author_label = NULL, updated_at = now()
+WHERE id = $1 AND user_id = $2
+`
+
+type ClearSavedSearchPublicSlugParams struct {
+	ID     int64 `json:"id"`
+	UserID int64 `json:"user_id"`
+}
+
+// Unpublish a board: clear the slug and author label, owner-scoped. Returns the
+// affected row count: 1 for an owned row (whether or not it was shared — unshare is an
+// idempotent no-op when already private), 0 when missing or not the caller's (→ 404).
+func (q *Queries) ClearSavedSearchPublicSlug(ctx context.Context, arg ClearSavedSearchPublicSlugParams) (int64, error) {
+	result, err := q.db.Exec(ctx, clearSavedSearchPublicSlug, arg.ID, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countSavedSearches = `-- name: CountSavedSearches :one
 SELECT count(*) FROM saved_searches
 WHERE user_id = $1
@@ -28,7 +50,7 @@ func (q *Queries) CountSavedSearches(ctx context.Context, userID int64) (int64, 
 const createSavedSearch = `-- name: CreateSavedSearch :one
 INSERT INTO saved_searches (user_id, name, query)
 VALUES ($1, $2, $3)
-RETURNING id, user_id, name, query, created_at, updated_at
+RETURNING id, user_id, name, query, created_at, updated_at, public_slug, author_label
 `
 
 type CreateSavedSearchParams struct {
@@ -49,6 +71,8 @@ func (q *Queries) CreateSavedSearch(ctx context.Context, arg CreateSavedSearchPa
 		&i.Query,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PublicSlug,
+		&i.AuthorLabel,
 	)
 	return i, err
 }
@@ -74,8 +98,60 @@ func (q *Queries) DeleteSavedSearch(ctx context.Context, arg DeleteSavedSearchPa
 	return result.RowsAffected(), nil
 }
 
+const getPublicBoardBySlug = `-- name: GetPublicBoardBySlug :one
+SELECT name, query, author_label
+FROM saved_searches
+WHERE public_slug = $1
+`
+
+type GetPublicBoardBySlugRow struct {
+	Name        string      `json:"name"`
+	Query       string      `json:"query"`
+	AuthorLabel pgtype.Text `json:"author_label"`
+}
+
+// Public read of a shared board by its slug — no auth, no owner-scoping. Exposes only
+// the board's display fields; owner columns (user_id) are never selected. A NULL slug
+// never equals the param, so private sets are unreachable. No row → 404.
+func (q *Queries) GetPublicBoardBySlug(ctx context.Context, publicSlug pgtype.Text) (GetPublicBoardBySlugRow, error) {
+	row := q.db.QueryRow(ctx, getPublicBoardBySlug, publicSlug)
+	var i GetPublicBoardBySlugRow
+	err := row.Scan(&i.Name, &i.Query, &i.AuthorLabel)
+	return i, err
+}
+
+const getSavedSearch = `-- name: GetSavedSearch :one
+SELECT id, user_id, name, query, created_at, updated_at, public_slug, author_label FROM saved_searches
+WHERE id = $1 AND user_id = $2
+`
+
+type GetSavedSearchParams struct {
+	ID     int64 `json:"id"`
+	UserID int64 `json:"user_id"`
+}
+
+// Fetch one of a user's saved searches, owner-scoped. Used by the share use case to
+// read the current name/public_slug before deciding whether to keep an existing slug
+// or mint a new one. No matching row (wrong id or another user's) returns no row (the
+// service maps that to ErrNotFound).
+func (q *Queries) GetSavedSearch(ctx context.Context, arg GetSavedSearchParams) (SavedSearch, error) {
+	row := q.db.QueryRow(ctx, getSavedSearch, arg.ID, arg.UserID)
+	var i SavedSearch
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.Query,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PublicSlug,
+		&i.AuthorLabel,
+	)
+	return i, err
+}
+
 const listSavedSearches = `-- name: ListSavedSearches :many
-SELECT id, user_id, name, query, created_at, updated_at FROM saved_searches
+SELECT id, user_id, name, query, created_at, updated_at, public_slug, author_label FROM saved_searches
 WHERE user_id = $1
 ORDER BY updated_at DESC
 `
@@ -97,6 +173,8 @@ func (q *Queries) ListSavedSearches(ctx context.Context, userID int64) ([]SavedS
 			&i.Query,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.PublicSlug,
+			&i.AuthorLabel,
 		); err != nil {
 			return nil, err
 		}
@@ -108,13 +186,56 @@ func (q *Queries) ListSavedSearches(ctx context.Context, userID int64) ([]SavedS
 	return items, nil
 }
 
+const setSavedSearchPublicSlug = `-- name: SetSavedSearchPublicSlug :one
+UPDATE saved_searches
+SET public_slug  = $1,
+    author_label = $2,
+    updated_at   = now()
+WHERE id = $3 AND user_id = $4
+RETURNING id, user_id, name, query, created_at, updated_at, public_slug, author_label
+`
+
+type SetSavedSearchPublicSlugParams struct {
+	PublicSlug  pgtype.Text `json:"public_slug"`
+	AuthorLabel pgtype.Text `json:"author_label"`
+	ID          int64       `json:"id"`
+	UserID      int64       `json:"user_id"`
+}
+
+// Publish a saved search as a board: set its public slug and (optional) author label,
+// owner-scoped, bumping updated_at. The service decides the slug (keeping an existing
+// one on re-share, minting a fresh one otherwise), so this sets it verbatim; a
+// collision with another board's slug raises a UNIQUE violation the service retries.
+// author_label is set verbatim (NULL clears it → anonymous). No matching owner-scoped
+// row returns no row (→ ErrNotFound).
+func (q *Queries) SetSavedSearchPublicSlug(ctx context.Context, arg SetSavedSearchPublicSlugParams) (SavedSearch, error) {
+	row := q.db.QueryRow(ctx, setSavedSearchPublicSlug,
+		arg.PublicSlug,
+		arg.AuthorLabel,
+		arg.ID,
+		arg.UserID,
+	)
+	var i SavedSearch
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.Query,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.PublicSlug,
+		&i.AuthorLabel,
+	)
+	return i, err
+}
+
 const updateSavedSearch = `-- name: UpdateSavedSearch :one
 UPDATE saved_searches
 SET name       = COALESCE($1, name),
     query      = COALESCE($2, query),
     updated_at = now()
 WHERE id = $3 AND user_id = $4
-RETURNING id, user_id, name, query, created_at, updated_at
+RETURNING id, user_id, name, query, created_at, updated_at, public_slug, author_label
 `
 
 type UpdateSavedSearchParams struct {
@@ -144,6 +265,8 @@ func (q *Queries) UpdateSavedSearch(ctx context.Context, arg UpdateSavedSearchPa
 		&i.Query,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.PublicSlug,
+		&i.AuthorLabel,
 	)
 	return i, err
 }

--- a/internal/handler/boards.go
+++ b/internal/handler/boards.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// boardResponse is the public wire shape of a shared board: only its display fields. It
+// deliberately omits every owner-identifying column (user id, email) so publishing a board
+// exposes no account PII. author_label is empty when the board is anonymous.
+type boardResponse struct {
+	Name        string `json:"name"`
+	Query       string `json:"query"`
+	AuthorLabel string `json:"author_label"`
+}
+
+// toBoardResponse maps a public-board row to its wire shape.
+func toBoardResponse(b db.GetPublicBoardBySlugRow) boardResponse {
+	return boardResponse{
+		Name:        b.Name,
+		Query:       b.Query,
+		AuthorLabel: b.AuthorLabel.String,
+	}
+}
+
+// GetBoard serves a shared board by its public slug — unauthenticated, no owner-scoping.
+// An unknown or unshared slug is a 404 (mapped from the saved-search not-found sentinel).
+func (a *API) GetBoard(c *fiber.Ctx) error {
+	board, err := a.savedSearch.GetPublicBoard(c.Context(), c.Params("slug"))
+	if err != nil {
+		return savedSearchError(err)
+	}
+	return c.JSON(fiber.Map{"data": toBoardResponse(board)})
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -190,6 +190,10 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/companies", a.ListCompanies)
 	api.Get("/companies/:slug", a.GetCompany)
 
+	// Public read of a shared saved-search "board" by its slug — unauthenticated, like
+	// the job/company reads above. Owner identity is never exposed (see boardResponse).
+	api.Get("/boards/:slug", a.GetBoard)
+
 	// Per-user job interactions and the user-scoped reads accept either the
 	// session cookie or an API key (RequireAuthOrKey), so a script holding a key
 	// can drive the same flow as the browser. The public job reads above stay
@@ -256,6 +260,10 @@ func Register(app *fiber.App, cfg Config) {
 	api.Post("/me/searches", saved, a.CreateSavedSearch)
 	api.Patch("/me/searches/:id", saved, a.UpdateSavedSearch)
 	api.Delete("/me/searches/:id", saved, a.DeleteSavedSearch)
+	// Publish/unpublish a saved search as a public board. Cookie-only (same as the rest
+	// of /me/searches); the public read is GET /boards/:slug above.
+	api.Post("/me/searches/:id/share", saved, a.ShareSavedSearch)
+	api.Delete("/me/searches/:id/share", saved, a.UnshareSavedSearch)
 
 	// Search profiles are cookie-only (RequireAuth) like saved searches: a browser
 	// feature (the profile picker), owner-scoped (a non-owned id is a 404).

--- a/internal/handler/me_searches.go
+++ b/internal/handler/me_searches.go
@@ -14,21 +14,27 @@ import (
 // (ownership, internal); query is the canonical search query string the SPA replays
 // into the filter URL.
 type savedSearchResponse struct {
-	ID        int64      `json:"id"`
-	Name      string     `json:"name"`
-	Query     string     `json:"query"`
-	CreatedAt *time.Time `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at"`
+	ID          int64      `json:"id"`
+	Name        string     `json:"name"`
+	Query       string     `json:"query"`
+	PublicSlug  string     `json:"public_slug"`  // empty when the set is private (not shared)
+	AuthorLabel string     `json:"author_label"` // empty when the board is anonymous
+	CreatedAt   *time.Time `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at"`
 }
 
 // toSavedSearchResponse maps a stored saved search to its wire shape (no user id).
+// PublicSlug/AuthorLabel are empty strings when their columns are NULL (private /
+// anonymous), since pgtype.Text zero-values its String to "".
 func toSavedSearchResponse(s db.SavedSearch) savedSearchResponse {
 	return savedSearchResponse{
-		ID:        s.ID,
-		Name:      s.Name,
-		Query:     s.Query,
-		CreatedAt: timePtr(s.CreatedAt),
-		UpdatedAt: timePtr(s.UpdatedAt),
+		ID:          s.ID,
+		Name:        s.Name,
+		Query:       s.Query,
+		PublicSlug:  s.PublicSlug.String,
+		AuthorLabel: s.AuthorLabel.String,
+		CreatedAt:   timePtr(s.CreatedAt),
+		UpdatedAt:   timePtr(s.UpdatedAt),
 	}
 }
 
@@ -45,6 +51,8 @@ func savedSearchError(err error) error {
 		return fiber.NewError(fiber.StatusConflict, "saved-search limit reached")
 	case errors.Is(err, savedsearch.ErrNotFound):
 		return fiber.NewError(fiber.StatusNotFound, "saved search not found")
+	case errors.Is(err, savedsearch.ErrInvalidAuthorLabel):
+		return fiber.NewError(fiber.StatusBadRequest, "author label must be at most 60 characters")
 	default:
 		return err
 	}
@@ -142,6 +150,57 @@ func (a *API) DeleteSavedSearch(c *fiber.Ctx) error {
 	}
 
 	if err := a.savedSearch.Delete(c.Context(), userID, id); err != nil {
+		return savedSearchError(err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+// shareSavedSearchRequest is the share body: an optional author label shown on the public
+// board (blank/omitted renders the board anonymously).
+type shareSavedSearchRequest struct {
+	AuthorLabel string `json:"author_label"`
+}
+
+// ShareSavedSearch publishes one of the authenticated user's saved searches as a public
+// board, minting (or keeping) its slug and setting the optional author label. Owner-scoped
+// and cookie-only: a missing/non-owned id is a 404, an over-long label is a 400. Returns the
+// updated saved search (now carrying public_slug).
+func (a *API) ShareSavedSearch(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := pathID(c)
+	if err != nil {
+		return err
+	}
+
+	var in shareSavedSearchRequest
+	if err := c.BodyParser(&in); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	}
+
+	saved, err := a.savedSearch.Share(c.Context(), userID, id, in.AuthorLabel)
+	if err != nil {
+		return savedSearchError(err)
+	}
+	return c.JSON(fiber.Map{"data": toSavedSearchResponse(saved)})
+}
+
+// UnshareSavedSearch makes one of the authenticated user's shared boards private again.
+// Owner-scoped and cookie-only; idempotent (already-private is a no-op), a missing/non-owned
+// id is a 404.
+func (a *API) UnshareSavedSearch(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := pathID(c)
+	if err != nil {
+		return err
+	}
+
+	if err := a.savedSearch.Unshare(c.Context(), userID, id); err != nil {
 		return savedSearchError(err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)

--- a/internal/handler/me_searches_integration_test.go
+++ b/internal/handler/me_searches_integration_test.go
@@ -151,6 +151,132 @@ func TestSavedSearchesEndToEnd(t *testing.T) {
 	}
 }
 
+func TestSavedSearchBoardsEndToEnd(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var ownerID, otherID int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('boards@example.test') RETURNING id`).Scan(&ownerID); err != nil {
+		t.Fatalf("seed owner: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('other-boards@example.test') RETURNING id`).Scan(&otherID); err != nil {
+		t.Fatalf("seed other user: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	ownerCookie, _ := iss.Issue(ownerID)
+	otherCookie, _ := iss.Issue(otherID)
+	queries := db.New(pool)
+	h := &API{pool: pool, queries: queries, issuer: iss, savedSearch: savedsearch.New(savedsearch.NewQueriesRepository(queries))}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	guard := auth.RequireAuth(iss)
+	app.Post("/api/v1/me/searches", guard, h.CreateSavedSearch)
+	app.Post("/api/v1/me/searches/:id/share", guard, h.ShareSavedSearch)
+	app.Delete("/api/v1/me/searches/:id/share", guard, h.UnshareSavedSearch)
+	app.Get("/api/v1/boards/:slug", h.GetBoard) // public, no guard
+
+	req := func(method, p, cookie, body string) *http.Request {
+		var r io.Reader
+		if body != "" {
+			r = bytes.NewBufferString(body)
+		}
+		rq := httptest.NewRequest(method, p, r)
+		if body != "" {
+			rq.Header.Set("Content-Type", "application/json")
+		}
+		if cookie != "" {
+			rq.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+		}
+		return rq
+	}
+	do := func(rq *http.Request) (*http.Response, map[string]any) {
+		res, err := app.Test(rq, -1)
+		if err != nil {
+			t.Fatalf("app.Test: %v", err)
+		}
+		var env map[string]any
+		b, _ := io.ReadAll(res.Body)
+		if len(b) > 0 {
+			_ = json.Unmarshal(b, &env)
+		}
+		return res, env
+	}
+
+	// Create a saved search to publish.
+	_, env := do(req(http.MethodPost, "/api/v1/me/searches", ownerCookie, `{"name":"Remote Go","query":"q=go&work_mode=remote"}`))
+	id := int64(env["data"].(map[string]any)["id"].(float64))
+	sharePath := fmt.Sprintf("/api/v1/me/searches/%d/share", id)
+
+	// Unauthenticated share → 401.
+	if res, _ := do(req(http.MethodPost, sharePath, "", "")); res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated share status = %d, want 401", res.StatusCode)
+	}
+
+	// Over-long author label → 400, nothing published.
+	longLabel := strings.Repeat("x", 61)
+	if res, _ := do(req(http.MethodPost, sharePath, ownerCookie, fmt.Sprintf(`{"author_label":%q}`, longLabel))); res.StatusCode != http.StatusBadRequest {
+		t.Errorf("over-long-label share status = %d, want 400", res.StatusCode)
+	}
+
+	// Cross-user share → 404.
+	if res, _ := do(req(http.MethodPost, sharePath, otherCookie, `{}`)); res.StatusCode != http.StatusNotFound {
+		t.Errorf("cross-user share status = %d, want 404", res.StatusCode)
+	}
+
+	// Owner shares with an author label → 200, gets a public slug.
+	res, env := do(req(http.MethodPost, sharePath, ownerCookie, `{"author_label":"strelov"}`))
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("share status = %d, want 200", res.StatusCode)
+	}
+	shared := env["data"].(map[string]any)
+	slug, _ := shared["public_slug"].(string)
+	if slug == "" || !strings.HasPrefix(slug, "remote-go-") {
+		t.Fatalf("public_slug = %q, want readable non-empty slug", slug)
+	}
+	if shared["author_label"] != "strelov" {
+		t.Errorf("author_label = %v, want %q", shared["author_label"], "strelov")
+	}
+
+	// Re-share keeps the same slug.
+	_, env = do(req(http.MethodPost, sharePath, ownerCookie, `{"author_label":"strelov"}`))
+	if env["data"].(map[string]any)["public_slug"] != slug {
+		t.Errorf("re-share slug = %v, want kept %q", env["data"].(map[string]any)["public_slug"], slug)
+	}
+
+	// Public read of the board → 200, only display fields, no owner identity.
+	boardPath := "/api/v1/boards/" + slug
+	res, env = do(req(http.MethodGet, boardPath, "", ""))
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("board read status = %d, want 200", res.StatusCode)
+	}
+	board := env["data"].(map[string]any)
+	if board["name"] != "Remote Go" || board["query"] != "q=go&work_mode=remote" || board["author_label"] != "strelov" {
+		t.Errorf("board body = %+v, want name/query/author carried", board)
+	}
+	for _, leaked := range []string{"user_id", "id", "email"} {
+		if _, ok := board[leaked]; ok {
+			t.Errorf("board response leaks owner field %q: %+v", leaked, board)
+		}
+	}
+
+	// Unshare → 204, then the board 404s.
+	if res, _ := do(req(http.MethodDelete, sharePath, ownerCookie, "")); res.StatusCode != http.StatusNoContent {
+		t.Errorf("unshare status = %d, want 204", res.StatusCode)
+	}
+	if res, _ := do(req(http.MethodGet, boardPath, "", "")); res.StatusCode != http.StatusNotFound {
+		t.Errorf("board read after unshare status = %d, want 404", res.StatusCode)
+	}
+	// Unshare again (already private) is an idempotent 204.
+	if res, _ := do(req(http.MethodDelete, sharePath, ownerCookie, "")); res.StatusCode != http.StatusNoContent {
+		t.Errorf("idempotent unshare status = %d, want 204", res.StatusCode)
+	}
+	// Unknown slug → 404.
+	if res, _ := do(req(http.MethodGet, "/api/v1/boards/does-not-exist", "", "")); res.StatusCode != http.StatusNotFound {
+		t.Errorf("unknown-slug status = %d, want 404", res.StatusCode)
+	}
+}
+
 func TestSavedSearchesCapEnforced(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()

--- a/internal/savedsearch/repository.go
+++ b/internal/savedsearch/repository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 )
@@ -76,6 +77,62 @@ func (r *QueriesRepository) Delete(ctx context.Context, p db.DeleteSavedSearchPa
 		return ErrNotFound
 	}
 	return nil
+}
+
+// Get reads one of a user's saved searches, owner-scoped, mapping "no row" (missing or
+// another user's) to ErrNotFound.
+func (r *QueriesRepository) Get(ctx context.Context, p db.GetSavedSearchParams) (db.SavedSearch, error) {
+	row, err := r.q.GetSavedSearch(ctx, p)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return db.SavedSearch{}, ErrNotFound
+	}
+	if err != nil {
+		return db.SavedSearch{}, err
+	}
+	return row, nil
+}
+
+// SetPublicSlug publishes a board scoped to its owner, mapping a slug UNIQUE collision to
+// ErrSlugTaken (retried by the service) and "no row" (missing or non-owned) to ErrNotFound.
+func (r *QueriesRepository) SetPublicSlug(ctx context.Context, p db.SetSavedSearchPublicSlugParams) (db.SavedSearch, error) {
+	row, err := r.q.SetSavedSearchPublicSlug(ctx, p)
+	if isUniqueViolation(err) {
+		return db.SavedSearch{}, ErrSlugTaken
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return db.SavedSearch{}, ErrNotFound
+	}
+	if err != nil {
+		return db.SavedSearch{}, err
+	}
+	return row, nil
+}
+
+// ClearPublicSlug unpublishes a board scoped to its owner, mapping "no row affected"
+// (missing or non-owned) to ErrNotFound. Clearing an already-private owned row still
+// matches (row count 1), so unshare is an idempotent no-op.
+func (r *QueriesRepository) ClearPublicSlug(ctx context.Context, p db.ClearSavedSearchPublicSlugParams) error {
+	affected, err := r.q.ClearSavedSearchPublicSlug(ctx, p)
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// GetPublicBoard reads a shared board by slug (no auth, no owner-scoping), mapping "no row"
+// (unknown or unshared slug) to ErrNotFound.
+func (r *QueriesRepository) GetPublicBoard(ctx context.Context, slug string) (db.GetPublicBoardBySlugRow, error) {
+	row, err := r.q.GetPublicBoardBySlug(ctx, pgtype.Text{String: slug, Valid: true})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return db.GetPublicBoardBySlugRow{}, ErrNotFound
+	}
+	if err != nil {
+		return db.GetPublicBoardBySlugRow{}, err
+	}
+	return row, nil
 }
 
 // isUniqueViolation reports whether err is a Postgres unique-constraint violation (23505).

--- a/internal/savedsearch/savedsearch.go
+++ b/internal/savedsearch/savedsearch.go
@@ -27,6 +27,11 @@ var (
 	ErrCapExceeded = errors.New("savedsearch: saved-search limit reached")
 	// ErrNotFound is a missing or non-owned target (mapped to 404).
 	ErrNotFound = errors.New("savedsearch: not found")
+	// ErrInvalidAuthorLabel is an over-long board author label (mapped to 400).
+	ErrInvalidAuthorLabel = errors.New("savedsearch: author label must be at most 60 characters")
+	// ErrSlugTaken is a public-slug UNIQUE collision on share. It is an internal retry
+	// signal (Share regenerates the suffix and tries again), not a client-facing status.
+	ErrSlugTaken = errors.New("savedsearch: public slug already taken")
 )
 
 const (
@@ -34,6 +39,8 @@ const (
 	maxNameLen = 100
 	// maxPerUser caps how many saved searches a single user may keep.
 	maxPerUser = 50
+	// maxAuthorLabelLen bounds a board's optional author label.
+	maxAuthorLabelLen = 60
 )
 
 // Repository is the persistence contract for saved searches. Every method is
@@ -46,6 +53,15 @@ type Repository interface {
 	Create(ctx context.Context, p db.CreateSavedSearchParams) (db.SavedSearch, error)
 	Update(ctx context.Context, p db.UpdateSavedSearchParams) (db.SavedSearch, error)
 	Delete(ctx context.Context, p db.DeleteSavedSearchParams) error
+	// Get reads one of a user's saved searches, owner-scoped; no row → ErrNotFound.
+	Get(ctx context.Context, p db.GetSavedSearchParams) (db.SavedSearch, error)
+	// SetPublicSlug publishes a board (owner-scoped); a slug UNIQUE collision →
+	// ErrSlugTaken (the service retries), no owner-scoped row → ErrNotFound.
+	SetPublicSlug(ctx context.Context, p db.SetSavedSearchPublicSlugParams) (db.SavedSearch, error)
+	// ClearPublicSlug unpublishes a board (owner-scoped); no owner-scoped row → ErrNotFound.
+	ClearPublicSlug(ctx context.Context, p db.ClearSavedSearchPublicSlugParams) error
+	// GetPublicBoard reads a shared board by slug (no auth, no owner-scoping); no row → ErrNotFound.
+	GetPublicBoard(ctx context.Context, slug string) (db.GetPublicBoardBySlugRow, error)
 }
 
 // Service implements the saved-search use cases.

--- a/internal/savedsearch/savedsearch_test.go
+++ b/internal/savedsearch/savedsearch_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/savedsearch"
 )
@@ -31,6 +33,49 @@ type fakeRepo struct {
 	deleteErr    error
 
 	listRet []db.SavedSearch
+
+	getRet    db.SavedSearch
+	getErr    error
+	getParams db.GetSavedSearchParams
+
+	setRet    db.SavedSearch
+	setErrs   []error // consumed one per SetPublicSlug call (nil = success)
+	setCalls  int
+	setParams []db.SetSavedSearchPublicSlugParams
+
+	clearErr    error
+	clearCalled bool
+	clearParams db.ClearSavedSearchPublicSlugParams
+
+	boardRet    db.GetPublicBoardBySlugRow
+	boardErr    error
+	boardSlug   string
+	boardCalled bool
+}
+
+func (f *fakeRepo) Get(_ context.Context, p db.GetSavedSearchParams) (db.SavedSearch, error) {
+	f.getParams = p
+	return f.getRet, f.getErr
+}
+
+func (f *fakeRepo) SetPublicSlug(_ context.Context, p db.SetSavedSearchPublicSlugParams) (db.SavedSearch, error) {
+	f.setParams = append(f.setParams, p)
+	i := f.setCalls
+	f.setCalls++
+	if i < len(f.setErrs) && f.setErrs[i] != nil {
+		return db.SavedSearch{}, f.setErrs[i]
+	}
+	return f.setRet, nil
+}
+
+func (f *fakeRepo) ClearPublicSlug(_ context.Context, p db.ClearSavedSearchPublicSlugParams) error {
+	f.clearParams, f.clearCalled = p, true
+	return f.clearErr
+}
+
+func (f *fakeRepo) GetPublicBoard(_ context.Context, slug string) (db.GetPublicBoardBySlugRow, error) {
+	f.boardSlug, f.boardCalled = slug, true
+	return f.boardRet, f.boardErr
 }
 
 func (f *fakeRepo) List(_ context.Context, _ int64) ([]db.SavedSearch, error) {
@@ -208,6 +253,144 @@ func TestDelete_NotFound(t *testing.T) {
 	repo := &fakeRepo{deleteErr: savedsearch.ErrNotFound}
 	err := savedsearch.New(repo).Delete(context.Background(), 7, 999)
 	if !errors.Is(err, savedsearch.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestShare_MintsReadableSlugFromName(t *testing.T) {
+	repo := &fakeRepo{
+		getRet: db.SavedSearch{ID: 5, UserID: 7, Name: "Remote Go"}, // private (no slug)
+		setRet: db.SavedSearch{ID: 5, PublicSlug: pgtype.Text{String: "remote-go-a3f1", Valid: true}},
+	}
+	svc := savedsearch.New(repo)
+
+	got, err := svc.Share(context.Background(), 7, 5, "strelov")
+	if err != nil {
+		t.Fatalf("Share: %v", err)
+	}
+	if repo.getParams.ID != 5 || repo.getParams.UserID != 7 {
+		t.Errorf("Get scope = id %d user %d, want id 5 user 7", repo.getParams.ID, repo.getParams.UserID)
+	}
+	if repo.setCalls != 1 {
+		t.Fatalf("SetPublicSlug calls = %d, want 1", repo.setCalls)
+	}
+	p := repo.setParams[0]
+	if p.ID != 5 || p.UserID != 7 {
+		t.Errorf("set scope = id %d user %d, want id 5 user 7", p.ID, p.UserID)
+	}
+	if !p.PublicSlug.Valid || !strings.HasPrefix(p.PublicSlug.String, "remote-go-") {
+		t.Errorf("minted slug = %q, want readable prefix %q", p.PublicSlug.String, "remote-go-")
+	}
+	if p.PublicSlug.String == "remote-go-" {
+		t.Error("minted slug has no random suffix")
+	}
+	if !p.AuthorLabel.Valid || p.AuthorLabel.String != "strelov" {
+		t.Errorf("author label param = %+v, want valid %q", p.AuthorLabel, "strelov")
+	}
+	if got.PublicSlug.String != "remote-go-a3f1" {
+		t.Errorf("returned slug = %q, want the persisted row's", got.PublicSlug.String)
+	}
+}
+
+func TestShare_KeepsExistingSlugOnReshare(t *testing.T) {
+	repo := &fakeRepo{
+		getRet: db.SavedSearch{ID: 5, UserID: 7, Name: "Remote Go",
+			PublicSlug: pgtype.Text{String: "remote-go-old1", Valid: true}}, // already shared
+		setRet: db.SavedSearch{ID: 5, PublicSlug: pgtype.Text{String: "remote-go-old1", Valid: true}},
+	}
+	_, err := savedsearch.New(repo).Share(context.Background(), 7, 5, "new label")
+	if err != nil {
+		t.Fatalf("re-share: %v", err)
+	}
+	if repo.setParams[0].PublicSlug.String != "remote-go-old1" {
+		t.Errorf("re-share slug = %q, want existing %q kept", repo.setParams[0].PublicSlug.String, "remote-go-old1")
+	}
+	if repo.setParams[0].AuthorLabel.String != "new label" {
+		t.Errorf("re-share author label = %q, want updated %q", repo.setParams[0].AuthorLabel.String, "new label")
+	}
+}
+
+func TestShare_EmptyLabelIsAnonymous(t *testing.T) {
+	repo := &fakeRepo{getRet: db.SavedSearch{ID: 5, UserID: 7, Name: "X"}, setRet: db.SavedSearch{ID: 5}}
+	if _, err := savedsearch.New(repo).Share(context.Background(), 7, 5, "   "); err != nil {
+		t.Fatalf("Share: %v", err)
+	}
+	if repo.setParams[0].AuthorLabel.Valid {
+		t.Errorf("author label = %+v, want NULL (anonymous) for blank input", repo.setParams[0].AuthorLabel)
+	}
+}
+
+func TestShare_RejectsOverLongLabel(t *testing.T) {
+	repo := &fakeRepo{getRet: db.SavedSearch{ID: 5, UserID: 7, Name: "X"}}
+	_, err := savedsearch.New(repo).Share(context.Background(), 7, 5, strings.Repeat("x", 61))
+	if !errors.Is(err, savedsearch.ErrInvalidAuthorLabel) {
+		t.Errorf("err = %v, want ErrInvalidAuthorLabel", err)
+	}
+	if repo.setCalls != 0 {
+		t.Error("SetPublicSlug should not be called on an invalid label")
+	}
+}
+
+func TestShare_NotOwned(t *testing.T) {
+	repo := &fakeRepo{getErr: savedsearch.ErrNotFound}
+	_, err := savedsearch.New(repo).Share(context.Background(), 7, 999, "")
+	if !errors.Is(err, savedsearch.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+	if repo.setCalls != 0 {
+		t.Error("SetPublicSlug should not be called when the set is not owned")
+	}
+}
+
+func TestShare_RetriesOnSlugCollision(t *testing.T) {
+	repo := &fakeRepo{
+		getRet:  db.SavedSearch{ID: 5, UserID: 7, Name: "Remote Go"},
+		setErrs: []error{savedsearch.ErrSlugTaken}, // first attempt collides, second succeeds
+		setRet:  db.SavedSearch{ID: 5, PublicSlug: pgtype.Text{String: "remote-go-b2c3", Valid: true}},
+	}
+	_, err := savedsearch.New(repo).Share(context.Background(), 7, 5, "")
+	if err != nil {
+		t.Fatalf("Share with one collision: %v", err)
+	}
+	if repo.setCalls != 2 {
+		t.Errorf("SetPublicSlug calls = %d, want 2 (retry after collision)", repo.setCalls)
+	}
+}
+
+func TestUnshare_ScopedToOwner(t *testing.T) {
+	repo := &fakeRepo{}
+	if err := savedsearch.New(repo).Unshare(context.Background(), 7, 5); err != nil {
+		t.Fatalf("Unshare: %v", err)
+	}
+	if !repo.clearCalled || repo.clearParams.ID != 5 || repo.clearParams.UserID != 7 {
+		t.Errorf("clear scope = id %d user %d, want id 5 user 7", repo.clearParams.ID, repo.clearParams.UserID)
+	}
+}
+
+func TestUnshare_NotFound(t *testing.T) {
+	repo := &fakeRepo{clearErr: savedsearch.ErrNotFound}
+	if err := savedsearch.New(repo).Unshare(context.Background(), 7, 999); !errors.Is(err, savedsearch.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGetPublicBoard_ReturnsBoard(t *testing.T) {
+	repo := &fakeRepo{boardRet: db.GetPublicBoardBySlugRow{Name: "Remote Go", Query: "q=go"}}
+	got, err := savedsearch.New(repo).GetPublicBoard(context.Background(), "remote-go-a3f1")
+	if err != nil {
+		t.Fatalf("GetPublicBoard: %v", err)
+	}
+	if repo.boardSlug != "remote-go-a3f1" {
+		t.Errorf("looked up slug = %q, want %q", repo.boardSlug, "remote-go-a3f1")
+	}
+	if got.Name != "Remote Go" || got.Query != "q=go" {
+		t.Errorf("board = %+v, want name/query carried through", got)
+	}
+}
+
+func TestGetPublicBoard_NotFound(t *testing.T) {
+	repo := &fakeRepo{boardErr: savedsearch.ErrNotFound}
+	if _, err := savedsearch.New(repo).GetPublicBoard(context.Background(), "nope"); !errors.Is(err, savedsearch.ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/savedsearch/share.go
+++ b/internal/savedsearch/share.go
@@ -1,0 +1,139 @@
+package savedsearch
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+const (
+	// slugSuffixLen is the length of the random suffix appended to a board slug — enough
+	// to disambiguate boards sharing a name and to make slugs non-trivially guessable,
+	// while keeping the URL short.
+	slugSuffixLen = 4
+	// slugBaseMaxLen caps the readable, name-derived part of a slug so a long name can't
+	// produce an unwieldy URL.
+	slugBaseMaxLen = 60
+	// slugFallbackBase is used when a name transliterates to nothing (e.g. all symbols),
+	// so a board always gets a usable slug.
+	slugFallbackBase = "board"
+	// maxShareAttempts bounds the retry loop when a minted slug collides with an existing
+	// board; each attempt draws a fresh suffix. Collisions are astronomically unlikely, so
+	// this is a safety backstop, not a hot path.
+	maxShareAttempts = 5
+)
+
+// slugAlphabet is the character set for the random suffix: lowercase letters and digits,
+// so the suffix stays URL-safe and visually consistent with the transliterated base.
+const slugAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+
+// Share publishes a saved search as a public board, owner-scoped. It reads the set (a
+// missing or non-owned id → ErrNotFound), keeps an existing public slug on re-share or
+// mints a readable one from the name otherwise, and stores the optional author label
+// (trimmed; blank → anonymous, over-long → ErrInvalidAuthorLabel). A slug collision is
+// retried with a fresh suffix. Returns the updated row (with its public slug).
+func (s *Service) Share(ctx context.Context, userID, id int64, authorLabel string) (db.SavedSearch, error) {
+	label, err := validAuthorLabel(authorLabel)
+	if err != nil {
+		return db.SavedSearch{}, err
+	}
+
+	set, err := s.repo.Get(ctx, db.GetSavedSearchParams{ID: id, UserID: userID})
+	if err != nil {
+		return db.SavedSearch{}, err
+	}
+
+	// Re-share keeps the existing slug so a previously shared link stays valid.
+	if set.PublicSlug.Valid {
+		return s.repo.SetPublicSlug(ctx, db.SetSavedSearchPublicSlugParams{
+			ID:          id,
+			UserID:      userID,
+			PublicSlug:  set.PublicSlug,
+			AuthorLabel: label,
+		})
+	}
+
+	for attempt := 0; attempt < maxShareAttempts; attempt++ {
+		slug, err := boardSlug(set.Name)
+		if err != nil {
+			return db.SavedSearch{}, err
+		}
+		row, err := s.repo.SetPublicSlug(ctx, db.SetSavedSearchPublicSlugParams{
+			ID:          id,
+			UserID:      userID,
+			PublicSlug:  pgtype.Text{String: slug, Valid: true},
+			AuthorLabel: label,
+		})
+		if errors.Is(err, ErrSlugTaken) {
+			continue // fresh suffix on the next attempt
+		}
+		if err != nil {
+			return db.SavedSearch{}, err
+		}
+		return row, nil
+	}
+	return db.SavedSearch{}, ErrSlugTaken
+}
+
+// Unshare makes a shared board private again, owner-scoped. It is an idempotent no-op
+// when the set is already private; a missing or non-owned id → ErrNotFound.
+func (s *Service) Unshare(ctx context.Context, userID, id int64) error {
+	return s.repo.ClearPublicSlug(ctx, db.ClearSavedSearchPublicSlugParams{ID: id, UserID: userID})
+}
+
+// GetPublicBoard reads a shared board by its public slug — no auth, no owner-scoping.
+// An unknown or unshared slug → ErrNotFound.
+func (s *Service) GetPublicBoard(ctx context.Context, slug string) (db.GetPublicBoardBySlugRow, error) {
+	return s.repo.GetPublicBoard(ctx, slug)
+}
+
+// validAuthorLabel trims the label and enforces the length bound (counted in runes, as
+// labels are often Cyrillic). A blank label is valid and stored as NULL (the board renders
+// anonymously); an over-long one → ErrInvalidAuthorLabel.
+func validAuthorLabel(label string) (pgtype.Text, error) {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return pgtype.Text{}, nil
+	}
+	if utf8.RuneCountInString(label) > maxAuthorLabelLen {
+		return pgtype.Text{}, ErrInvalidAuthorLabel
+	}
+	return pgtype.Text{String: label, Valid: true}, nil
+}
+
+// boardSlug builds a readable public slug from a name: the transliterated, hyphenated base
+// (bounded and never empty) plus a random suffix, e.g. "Remote Go" → "remote-go-a3f1".
+func boardSlug(name string) (string, error) {
+	base := normalize.Slug(name)
+	if base == "" {
+		base = slugFallbackBase
+	}
+	if len(base) > slugBaseMaxLen {
+		base = strings.TrimRight(base[:slugBaseMaxLen], "-")
+	}
+	suffix, err := randomSuffix(slugSuffixLen)
+	if err != nil {
+		return "", err
+	}
+	return base + "-" + suffix, nil
+}
+
+// randomSuffix returns n random characters from slugAlphabet, drawn from a CSPRNG so slugs
+// are not enumerable by sequence.
+func randomSuffix(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	for i, b := range buf {
+		buf[i] = slugAlphabet[int(b)%len(slugAlphabet)]
+	}
+	return string(buf), nil
+}

--- a/migrations/0032_saved_searches_public_slug.sql
+++ b/migrations/0032_saved_searches_public_slug.sql
@@ -1,0 +1,20 @@
+-- Public saved-search "boards": a signed-in user can publish one of their saved
+-- searches under a stable, shareable slug. `public_slug IS NULL` means the set is
+-- private (the default, matching every existing row); a non-NULL slug means it is
+-- shared and readable by anyone at GET /api/v1/boards/<slug> and /b/<slug> in the
+-- web app. `author_label` is an optional, self-contained attribution string shown on
+-- the public board (empty/NULL renders anonymously) — deliberately NOT derived from
+-- users.email, so publishing exposes no account PII. Both columns are additive and
+-- nullable, so this is safe to apply to an existing volume/prod manually (the
+-- versioned-migration-runner seam from AGENT.md remains open). Applied automatically
+-- by Postgres on first volume init and also serves as schema source for sqlc.
+
+ALTER TABLE saved_searches
+    ADD COLUMN IF NOT EXISTS public_slug  TEXT,
+    ADD COLUMN IF NOT EXISTS author_label TEXT;
+
+-- One slug ⇒ one board. A plain UNIQUE tolerates many NULLs in Postgres, so private
+-- (unshared) rows are unconstrained; only published slugs must be distinct. This index
+-- also backs the public read GET /api/v1/boards/<slug>.
+CREATE UNIQUE INDEX IF NOT EXISTS saved_searches_public_slug_idx
+    ON saved_searches (public_slug);

--- a/openspec/changes/archive/2026-07-01-add-public-search-boards/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-01-add-public-search-boards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/archive/2026-07-01-add-public-search-boards/design.md
+++ b/openspec/changes/archive/2026-07-01-add-public-search-boards/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Saved searches (`saved_searches` table, `internal/savedsearch` service, `/api/v1/me/searches` under `RequireAuth`) let a signed-in user store named filter snapshots (`query` = the canonical search string the filter URL and `GET /jobs/search` share). They are private and addressed by internal numeric id. Separately, the repo already runs a "public read by slug" pattern: `jobs.public_slug TEXT NOT NULL UNIQUE`, `GetJobBySlug`, and `api.Get("/jobs/:slug", ...)` with no auth middleware. This change grafts that pattern onto saved searches so a user can publish one as a public "board".
+
+Design decisions were settled with the user up front:
+- Slug is readable — `normalize(name)` + short random suffix — over an unguessable token.
+- Author attribution is a self-contained optional `author_label` on the board, not a new `users.display_name` profile subsystem.
+- Sharing is a nullable `public_slug` toggle on the existing row, not a separate `public_boards` entity.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let any user turn one of their saved searches into a link-shareable, publicly readable board and revoke it.
+- Reuse the existing public-read-by-slug pattern and the existing jobs-list rendering (the board page just applies the stored query).
+- Expose zero owner PII on the public surface.
+- Keep all write/management operations cookie-only, exactly like the rest of `/me/searches`.
+
+**Non-Goals:**
+- No user profile / `display_name` subsystem (author is a per-board free-text label).
+- No board discovery/listing/search of others' boards, no unguessable-token privacy guarantee, no view analytics, no board-level access control beyond shared/not-shared.
+- No changes to how private saved searches behave today.
+
+## Decisions
+
+### Slug: `normalize(name)` + short random suffix, minted at share time
+Reuse `internal/normalize` (already used for job/company slugs) on the set's name, append a short random suffix (e.g. 4 lowercase base36 chars) to disambiguate and reduce guessability while keeping a readable URL: `remote-go-jobs-a3f1`. Uniqueness is enforced by the `UNIQUE` index; on the rare insert conflict, regenerate the suffix and retry a bounded number of times. Slug is minted once and kept across re-shares; unshare clears it, and a later share mints a fresh one.
+- *Alternative rejected*: random opaque token (more private, less friendly) — user chose readability. Trade-off recorded under Risks.
+- *Alternative rejected*: slug derived purely from id (stable but ugly and enumerable).
+
+### Model: nullable `public_slug` + `author_label` columns on `saved_searches`
+`ALTER TABLE saved_searches ADD COLUMN public_slug TEXT` with a `UNIQUE` index (partial or plain — a plain UNIQUE tolerates multiple NULLs in Postgres, so a plain `UNIQUE (public_slug)` is sufficient and simplest) and `ADD COLUMN author_label TEXT`. `public_slug IS NULL` ⇔ private. This keeps one entity and one source of truth for `query`; no cross-table sync.
+- *Alternative rejected*: a separate `public_boards(slug, saved_search_id, ...)` table — duplicates `query` or forces a join, and adds a lifecycle to keep in sync, for no gain at this scope.
+
+### Endpoints mirror existing conventions
+- `POST /api/v1/me/searches/:id/share` (RequireAuth) → owner-scoped; body `{author_label?}`; returns the updated `savedSearchResponse` (now including `public_slug`, `author_label`).
+- `DELETE /api/v1/me/searches/:id/share` (RequireAuth) → owner-scoped; `204`.
+- `GET /api/v1/boards/:slug` (no auth) → public read; returns `{data: {name, query, author_label}}` only. Modeled on `GetJob`/`GetJobBySlug`. A missing/unshared slug returns `pgx.ErrNoRows` → the central `ErrorHandler` maps it to 404 (no per-handler remapping, per repo convention).
+
+The service layer (`internal/savedsearch`) gains `Share(ctx, userID, id, authorLabel)`, `Unshare(ctx, userID, id)`, and `GetPublicBySlug(ctx, slug)`, plus slug generation. New sqlc queries: `SetSavedSearchPublicSlug` (owner-scoped update), `ClearSavedSearchPublicSlug` (owner-scoped), `GetPublicBoardBySlug` (reads only where `public_slug = $1`). `ListSavedSearches`/`GetSavedSearch` return the two new columns (regen from `SELECT *`).
+
+### Wire shape and web
+`savedSearchResponse` gains `public_slug` (string, empty when null) and `author_label` (string). A new public board response type carries only `name`, `query`, `author_label`. The SPA adds `web/src/routes/b/[slug]/` that fetches the board and renders the existing jobs list seeded with the board's query (reusing the same query→filter parsing the "apply a saved search" flow already uses).
+
+**Account section placement.** The account area under `/my/*` is a flat set of sibling pages (`/my/jobs`, `/my/profiles`, `/my/notifications`, `/my/api-keys`, `/my/submissions`), each linked from the `menuItems` array in `HeaderMenu.svelte` — there is no shared `/my/+layout`. So "Saved searches" is added the same way: a new `web/src/routes/my/searches/+page.svelte` plus one entry in `HeaderMenu.svelte`. The page reuses the existing `savedSearches` store (`web/src/lib/savedSearches.svelte.ts`) for the list and the new share/unshare API client calls.
+
+**Share/unshare UI reuse.** Both the account section and the filters "My filters" control (`SavedSearches.svelte`) call the same new `api.ts` functions (`shareSavedSearch(id, authorLabel)` → returns the updated set with slug; `unshareSavedSearch(id)`), and the shared/unshared state is read from `public_slug` on the listed set. Creation stays only in the filters control (it owns the current-filters `query`); the account section is management-only. TS contracts regen via `cmd/gen-contracts` where applicable.
+
+## Risks / Trade-offs
+
+- **Readable slug is partially guessable / enumerable** → Accepted per user decision; mitigated by the random suffix (not pure name) and by the invariant that a board is reachable only while explicitly shared. No PII is exposed even on a correct guess (only name/query/author_label, all author-authored).
+- **Unshare breaks existing links** → This is the intended semantics of revocation; documented in the spec. Re-share mints a new slug rather than reviving the old one.
+- **Slug collision on insert** → Bounded retry with a fresh suffix; `UNIQUE` index is the backstop.
+- **Author label is free text (light PII by choice)** → It is optional and author-supplied; empty renders anonymously. We never derive it from `email`.
+- **Migration on a persistent DB** → Repo has no versioned migration runner yet (known seam); the two `ADD COLUMN` statements are additive and nullable, safe to apply manually on prod (per existing deploy convention) before the code ships.
+
+## Migration Plan
+
+1. Add migration `00NN_saved_searches_public_slug.sql` (two nullable columns + `UNIQUE` index on `public_slug`); `make sqlc`.
+2. Ship service + handlers + routes behind the existing conventions; no behavior change for private sets.
+3. Web route + filters-panel controls.
+4. Rollback: unshare is reversible; to fully back out, drop the two columns (no data loss for private saved searches, which never populate them).

--- a/openspec/changes/archive/2026-07-01-add-public-search-boards/proposal.md
+++ b/openspec/changes/archive/2026-07-01-add-public-search-boards/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Saved searches today are private, cookie-scoped, and addressed by an internal numeric id — a user can replay their own filters but cannot hand anyone a link to them. Sharing a curated job view (e.g. "remote Go jobs in the EU") is a common, low-cost ask that turns a personal convenience into a distribution surface. Every ingredient already exists: the canonical `query` string is a ready-made shareable payload, and the repo already runs a public-read-by-slug pattern for jobs. This change removes exactly two locks from saved searches — owner-only addressing and auth-guarded reads — to make any saved search publicly shareable as a "board".
+
+## What Changes
+
+- A signed-in user can **share** one of their own saved searches, minting a stable public **slug** (readable, derived from the name plus a short random suffix, e.g. `remote-go-jobs-a3f1`).
+- Sharing accepts an optional **author label** (free text, e.g. a display handle) stored on the board; empty means the board renders anonymously. `users` is not touched — no profile/display-name subsystem.
+- A user can **unshare**, clearing the slug and returning the saved search to private. Unshare intentionally breaks the old link (that is the point); re-sharing mints a fresh slug.
+- A new **public, unauthenticated read** returns a shared board by slug: its name, canonical query, and author label — never the owner's id or email.
+- The SPA gains a public **`/b/:slug`** route that loads the board and renders its jobs by applying the stored query to the existing jobs list.
+- The account area gains a dedicated **"Saved searches" section** (`/my/searches`, reached from the header account menu like the other `/my/*` sections) that lists the user's saved searches and lets them **share/unshare** each one (add the board criterion), copy its public `/b/:slug` link, rename, and delete. Creating a saved search stays in the "My filters" control (that is where the current filters exist); the filters control also keeps a lightweight share/unshare affordance.
+- Listing one's own saved searches now also reports each set's shared state (slug + author label) so the UI can show what is shared.
+
+## Capabilities
+
+### New Capabilities
+<!-- none; this extends the existing saved-searches capability -->
+
+### Modified Capabilities
+- `saved-searches`: adds share/unshare requirements, a nullable public slug and optional author label on the stored set, a public unauthenticated read-by-slug that never leaks owner identity, and the public board UI. Existing private behavior (create/list/update/delete, owner-scoping, name validation, per-user cap) is unchanged.
+
+## Impact
+
+- **DB / migration**: add `saved_searches.public_slug TEXT UNIQUE` (nullable) and `saved_searches.author_label TEXT` (nullable). New migration; sqlc regen.
+- **API**: new `POST /api/v1/me/searches/:id/share` and `DELETE /api/v1/me/searches/:id/share` (both `RequireAuth`, cookie-only, like the rest of `/me/searches`); new public `GET /api/v1/boards/:slug` (no auth). The `savedSearchResponse` shape gains `public_slug` and `author_label`.
+- **Code**: `internal/savedsearch` service gains Share/Unshare/GetPublicBySlug + slug generation (reuses `internal/normalize`); `internal/handler/me_searches.go` gains the two share handlers; a new public boards handler + route registration in `handler.go`.
+- **Web**: new `web/src/routes/b/[slug]` public route; new account section `web/src/routes/my/searches` + a "Saved searches" entry in `HeaderMenu.svelte`; share/unshare UI in both the account section and the filters panel; new share-board API client calls in `web/src/lib/api.ts`; generated TS contract for the board wire shape.
+- **Privacy note**: the readable slug is partially guessable by design (chosen for URL friendliness over unguessability); a board is public-by-link only when explicitly shared, and no owner PII is ever exposed.

--- a/openspec/changes/archive/2026-07-01-add-public-search-boards/specs/saved-searches/spec.md
+++ b/openspec/changes/archive/2026-07-01-add-public-search-boards/specs/saved-searches/spec.md
@@ -1,91 +1,4 @@
-# saved-searches Specification
-
-## Purpose
-TBD - created by archiving change saved-searches. Update Purpose after archive.
-## Requirements
-### Requirement: Save a filter set
-A signed-in user SHALL be able to save the current job-search filter state under a name. The saved set captures the canonical search query string (the same serialization the filter URL and `GET /api/v1/jobs/search` use), so re-applying it reproduces the exact filters, including an empty query string which represents "show all".
-
-#### Scenario: Create a saved search
-- **WHEN** an authenticated user sends `POST /api/v1/me/searches` with a valid `name` and a `query` string
-- **THEN** the system stores the set scoped to that user and responds `201` with `{"data": {id, name, query, updated_at}}`
-
-#### Scenario: Empty query is valid
-- **WHEN** an authenticated user creates a saved search with `query` equal to an empty string
-- **THEN** the system stores it (it represents the unfiltered "show all" view) and responds `201`
-
-#### Scenario: Unauthenticated request is rejected
-- **WHEN** a request without a valid session cookie hits any `/api/v1/me/searches` endpoint
-- **THEN** the system responds `401` and stores nothing
-
-### Requirement: Name validation
-A saved search name SHALL be trimmed and contain between 1 and 100 characters, and SHALL be unique per user (case-sensitive after trim).
-
-#### Scenario: Blank name rejected
-- **WHEN** an authenticated user creates or renames a saved search with a name that is empty or only whitespace
-- **THEN** the system responds `400` and stores nothing
-
-#### Scenario: Over-long name rejected
-- **WHEN** the trimmed name exceeds 100 characters
-- **THEN** the system responds `400` and stores nothing
-
-#### Scenario: Duplicate name rejected
-- **WHEN** an authenticated user creates or renames a saved search to a name they already use
-- **THEN** the system responds `409` and does not create or modify a row
-
-### Requirement: Per-user cap
-The system SHALL allow at most 50 saved searches per user.
-
-#### Scenario: Cap exceeded on create
-- **WHEN** an authenticated user who already has 50 saved searches sends a create request
-- **THEN** the system responds `409` and stores nothing
-
-### Requirement: List saved searches
-A signed-in user SHALL be able to list their own saved searches, most recently updated first. Each listed set SHALL report its shared state: its public slug (empty when private) and author label.
-
-#### Scenario: List own sets
-- **WHEN** an authenticated user sends `GET /api/v1/me/searches`
-- **THEN** the system responds `200` with `{"data": [...]}` containing only that user's saved searches ordered by `updated_at` descending, each including `public_slug` (empty when not shared) and `author_label`
-
-### Requirement: Update a saved search
-A signed-in user SHALL be able to overwrite a saved search's name and/or query. A field omitted from the request is left unchanged. The "Update" UI action overwrites the selected set's query with the current filters.
-
-#### Scenario: Overwrite query
-- **WHEN** an authenticated user sends `PATCH /api/v1/me/searches/:id` with a new `query`
-- **THEN** the system replaces the stored query, bumps `updated_at`, and responds `200` with the updated row
-
-#### Scenario: Rename
-- **WHEN** an authenticated user sends `PATCH /api/v1/me/searches/:id` with a new `name`
-- **THEN** the system replaces the stored name (subject to name validation) and responds `200`
-
-### Requirement: Delete a saved search
-A signed-in user SHALL be able to delete one of their own saved searches.
-
-#### Scenario: Delete own set
-- **WHEN** an authenticated user sends `DELETE /api/v1/me/searches/:id` for a set they own
-- **THEN** the system removes the row and responds `204`
-
-### Requirement: User-scoped access
-Every saved-search operation SHALL be scoped to the calling user; one user MUST NOT be able to read, modify, or delete another user's saved search.
-
-#### Scenario: Cannot touch another user's set
-- **WHEN** an authenticated user sends `PATCH` or `DELETE` for a saved-search id owned by a different user
-- **THEN** the system responds `404` and the target row is unchanged
-
-### Requirement: Saved-search UI in the filters panel
-The web filters panel SHALL present a "My filters" control to signed-in users for selecting, saving, updating, and deleting saved searches, and SHALL prompt anonymous users to sign in instead of showing the list.
-
-#### Scenario: Apply a saved search
-- **WHEN** a signed-in user selects a saved set from the "My filters" control
-- **THEN** the panel applies its filters by parsing the stored query string into the filter state and committing it to the URL, and the results re-search accordingly
-
-#### Scenario: Active set is marked
-- **WHEN** the current filter state's canonical query string equals a saved set's query
-- **THEN** that set is marked active (checkmark) in the control
-
-#### Scenario: Anonymous prompt
-- **WHEN** an anonymous (signed-out) user opens the filters panel
-- **THEN** the "My filters" control shows a "sign in to save" affordance that opens the auth dialog instead of a list of sets
+## ADDED Requirements
 
 ### Requirement: Share a saved search as a public board
 A signed-in user SHALL be able to make one of their own saved searches public by minting a stable public slug for it. Sharing MAY include an optional author label (free text, 1-60 characters after trim) stored on the board; an omitted or empty label means the board is anonymous. Sharing an already-shared set is idempotent for the slug (the existing slug is kept) but SHALL update the author label to the supplied value.
@@ -185,3 +98,11 @@ The "My filters" control SHALL let a signed-in user share and unshare the select
 - **WHEN** a signed-in user unshares a shared set
 - **THEN** the control shows the set as private again and no longer offers its public link
 
+## MODIFIED Requirements
+
+### Requirement: List saved searches
+A signed-in user SHALL be able to list their own saved searches, most recently updated first. Each listed set SHALL report its shared state: its public slug (empty when private) and author label.
+
+#### Scenario: List own sets
+- **WHEN** an authenticated user sends `GET /api/v1/me/searches`
+- **THEN** the system responds `200` with `{"data": [...]}` containing only that user's saved searches ordered by `updated_at` descending, each including `public_slug` (empty when not shared) and `author_label`

--- a/openspec/changes/archive/2026-07-01-add-public-search-boards/tasks.md
+++ b/openspec/changes/archive/2026-07-01-add-public-search-boards/tasks.md
@@ -1,0 +1,31 @@
+## 1. Schema & generated DB access
+
+- [x] 1.1 Add migration `migrations/00NN_saved_searches_public_slug.sql`: `ALTER TABLE saved_searches ADD COLUMN public_slug TEXT`, `ADD COLUMN author_label TEXT`, and a `UNIQUE` index on `public_slug`.
+- [x] 1.2 Add sqlc queries in `internal/db/queries/saved_searches.sql`: `GetSavedSearch` (owner-scoped read), `SetSavedSearchPublicSlug` (owner-scoped set of slug + author_label), `ClearSavedSearchPublicSlug` (owner-scoped, slug→NULL), `GetPublicBoardBySlug` (read only where `public_slug = $1`); list/get select the new columns.
+- [x] 1.3 Run `make sqlc` and confirm `internal/db` regenerates with the new columns and queries (build passes).
+
+## 2. Service layer (`internal/savedsearch`)
+
+- [x] 2.1 Add slug generation: `normalize(name)` + short random suffix, with bounded retry on unique-collision. Unit-test collision retry and readable-slug shape.
+- [x] 2.2 Add `Share(ctx, userID, id, authorLabel)`: validates/trims author_label (≤60), mints slug when absent (keeps existing on re-share), applies label; owner-scoped (missing/non-owned → ErrNotFound). Unit-test share, re-share-keeps-slug, over-long label, not-owned.
+- [x] 2.3 Add `Unshare(ctx, userID, id)`: clears slug, owner-scoped, idempotent no-op when already private; non-owned → ErrNotFound. Unit-test.
+- [x] 2.4 Add `GetPublicBySlug(ctx, slug)`: returns name/query/author_label for a currently-shared board; unknown/unshared → ErrNotFound (or `pgx.ErrNoRows`). Unit-test found and not-found.
+
+## 3. HTTP handlers & routes
+
+- [x] 3.1 Extend `savedSearchResponse` with `public_slug` (empty when NULL) and `author_label`; update `toSavedSearchResponse`. Adjust list/update/create responses.
+- [x] 3.2 Add `ShareSavedSearch` (`POST /me/searches/:id/share`) and `UnshareSavedSearch` (`DELETE /me/searches/:id/share`) in `internal/handler/me_searches.go`, mapping service sentinels via `savedSearchError`; both under `RequireAuth`. Handler tests (integration build-tag) for share/unshare/not-owned/401/over-long-label.
+- [x] 3.3 Add public boards handler `GetBoard` (`GET /api/v1/boards/:slug`) returning `{data: {name, query, author_label}}` only, no owner fields; unknown/unshared → 404 via central ErrorHandler. Handler test for read + 404.
+- [x] 3.4 Register the three routes in `internal/handler/handler.go` (two under the `/me/searches` auth group, one public alongside `/jobs/:slug`).
+
+## 4. Web (SPA)
+
+- [x] 4.1 Regenerate/extend the TS contract + `SavedSearch` type (public_slug, author_label) and add a board wire type; add `shareSavedSearch(id, authorLabel)` and `unshareSavedSearch(id)` to `web/src/lib/api.ts` following the existing saved-search client pattern.
+- [x] 4.2 Add public route `web/src/routes/b/[slug]/` that fetches `GET /api/v1/boards/:slug`, renders board name + author label, and lists jobs by applying the stored query (reuse the existing query→filter parsing); render a not-found state for an unknown slug.
+- [x] 4.3 Add the account section `web/src/routes/my/searches/+page.svelte` (list via the `savedSearches` store; share/unshare/rename/delete; copy `/b/:slug` link when shared; sign-in prompt for anonymous) and add a "Saved searches" entry to `menuItems` in `HeaderMenu.svelte`.
+- [x] 4.4 Add share/unshare controls to the "My filters" panel (`SavedSearches.svelte`): share (optional author label) surfaces a copyable `/b/:slug` link; unshare reverts to private. Reflect shared state from `public_slug`.
+
+## 5. Verification
+
+- [x] 5.1 `go build ./... && go vet ./...`, `go test ./...`, and the integration-tagged handler/db tests pass; web `svelte-check` clean (0 errors/0 warnings) and production SSR `npm run build` succeeds.
+- [x] 5.2 End-to-end verified at the API level by `TestSavedSearchBoardsEndToEnd` against a real Postgres: create → share → open `/api/v1/boards/:slug` anonymously (no owner PII: user_id/id/email asserted absent) → re-share keeps slug → unshare → slug 404s → unknown slug 404s. Residual (not run here): a browser walkthrough of `/my/searches` and `/b/:slug` against a seeded Docker stack — recommended smoke before deploy.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2006,9 +2006,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2026,9 +2023,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2046,9 +2040,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2066,9 +2057,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -24,6 +24,7 @@ import type {
   ApiKey,
   CreatedApiKey,
   SavedSearch,
+  Board,
   SearchProfile,
   Subscription,
   TelegramStatus,
@@ -406,6 +407,30 @@ export function createApi(
     await call(`/api/v1/me/searches/${id}`, { method: 'DELETE' });
   }
 
+  /** Publish a saved search as a public board (cookie-only). Returns the updated set,
+   *  now carrying `public_slug`. An optional `authorLabel` is shown on the board; blank
+   *  renders it anonymously. Re-sharing keeps the existing slug. */
+  async function shareSavedSearch(id: number, authorLabel = ''): Promise<SavedSearch> {
+    const res = await request<{ data: SavedSearch }>(`/api/v1/me/searches/${id}/share`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ author_label: authorLabel }),
+    });
+    return res.data;
+  }
+
+  /** Make a shared board private again (cookie-only). Idempotent. */
+  async function unshareSavedSearch(id: number): Promise<void> {
+    await call(`/api/v1/me/searches/${id}/share`, { method: 'DELETE' });
+  }
+
+  /** Public read of a shared board by slug — unauthenticated. Returns only display
+   *  fields (name, query, author_label). An unknown/unshared slug throws (404). */
+  async function getBoard(slug: string): Promise<Board> {
+    const res = await request<{ data: Board }>(`/api/v1/boards/${encodeURIComponent(slug)}`);
+    return res.data;
+  }
+
   // Search profiles: named specialization + skills sets (cookie-only on the server).
 
   /** The current user's search profiles, most recently updated first. */
@@ -606,6 +631,9 @@ export function createApi(
     createSavedSearch,
     updateSavedSearch,
     deleteSavedSearch,
+    shareSavedSearch,
+    unshareSavedSearch,
+    getBoard,
     listSearchProfiles,
     createSearchProfile,
     updateSearchProfile,
@@ -672,6 +700,9 @@ export const {
   createSavedSearch,
   updateSavedSearch,
   deleteSavedSearch,
+  shareSavedSearch,
+  unshareSavedSearch,
+  getBoard,
   listSearchProfiles,
   createSearchProfile,
   updateSearchProfile,

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -45,6 +45,7 @@
   const accountLinks = [
     { href: '/my/jobs', label: 'My jobs' },
     { href: '/my/profiles', label: 'Search profiles' },
+    { href: '/my/searches', label: 'Saved searches' },
     { href: '/my/notifications', label: 'Notifications' },
     { href: '/my/api-keys', label: 'API keys' },
     { href: '/submit', label: 'Submit a job' },

--- a/web/src/lib/components/SavedSearches.svelte
+++ b/web/src/lib/components/SavedSearches.svelte
@@ -168,6 +168,50 @@
     }
   }
 
+  // Share/unshare the currently-selected set as a public board. The panel keeps this
+  // lightweight (shares anonymously); the author label is set from the Saved searches
+  // account page (/my/searches).
+  const activeSet = $derived(activeId != null ? (items.find((s) => s.id === activeId) ?? null) : null);
+  let shareBusy = $state(false);
+  let copied = $state(false);
+
+  async function shareActive() {
+    if (!activeSet || shareBusy) return;
+    shareBusy = true;
+    error = null;
+    try {
+      await savedSearches.share(activeSet.id);
+    } catch (e) {
+      error = e instanceof ApiError ? e.message : 'Could not share. Please try again.';
+    } finally {
+      shareBusy = false;
+    }
+  }
+
+  async function unshareActive() {
+    if (!activeSet || shareBusy) return;
+    shareBusy = true;
+    error = null;
+    try {
+      await savedSearches.unshare(activeSet.id);
+    } catch {
+      error = 'Could not unshare. Please try again.';
+    } finally {
+      shareBusy = false;
+    }
+  }
+
+  async function copyBoardLink() {
+    if (!activeSet?.public_slug) return;
+    try {
+      await navigator.clipboard.writeText(`${location.origin}/b/${activeSet.public_slug}`);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      error = 'Could not copy the link.';
+    }
+  }
+
   const selectClass =
     'h-9 w-full rounded-lg border border-input bg-transparent px-3 text-sm transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30';
 </script>
@@ -217,6 +261,30 @@
         <Button variant="secondary" size="sm" onclick={startSave} disabled={busy}>Save as new</Button>
         {#if activeId != null}
           <Button variant="ghost" size="sm" onclick={remove} disabled={busy}>Delete</Button>
+        {/if}
+      </div>
+    {/if}
+
+    <!-- Share the selected set as a public board (link-shareable). -->
+    {#if activeSet && !naming}
+      <div class="flex flex-wrap items-center gap-2">
+        {#if activeSet.public_slug}
+          <a
+            href={`/b/${activeSet.public_slug}`}
+            class="min-w-0 truncate text-xs text-primary underline-offset-4 hover:underline"
+          >
+            /b/{activeSet.public_slug}
+          </a>
+          <Button variant="ghost" size="sm" onclick={copyBoardLink}>
+            {copied ? 'Copied' : 'Copy link'}
+          </Button>
+          <Button variant="ghost" size="sm" onclick={unshareActive} disabled={shareBusy}>
+            Unshare
+          </Button>
+        {:else}
+          <Button variant="secondary" size="sm" onclick={shareActive} disabled={shareBusy}>
+            {shareBusy ? 'Sharing…' : 'Share as board'}
+          </Button>
         {/if}
       </div>
     {/if}

--- a/web/src/lib/components/SavedSearchesView.svelte
+++ b/web/src/lib/components/SavedSearchesView.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+  import { ApiError } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
+  import { savedSearches } from '$lib/savedSearches.svelte';
+  import type { SavedSearch } from '$lib/types';
+  import { Button, Input } from '$lib/ui';
+  import States from './States.svelte';
+
+  let status = $state<'loading' | 'error' | 'ready'>('loading');
+  const items = $derived(savedSearches.items);
+
+  // Share flow: clicking "Share" on a row reveals an optional author-label input for that
+  // row (mirrors the SearchProfilesView editingId pattern); confirming publishes the board.
+  let shareEditId = $state<number | null>(null);
+  let authorLabel = $state('');
+  let busyId = $state<number | null>(null);
+  let error = $state<string | null>(null);
+  // The row whose link was just copied, to flip its button label briefly.
+  let copiedId = $state<number | null>(null);
+
+  async function load() {
+    status = 'loading';
+    try {
+      await savedSearches.ensureLoaded();
+      status = 'ready';
+    } catch {
+      status = 'error';
+    }
+  }
+
+  // Load once the session is confirmed; reset the per-user cache on sign-out so a different
+  // user does not see the previous one's searches (mirrors SearchProfilesView).
+  $effect(() => {
+    if (isAuthenticated()) {
+      void load();
+    } else {
+      savedSearches.reset();
+    }
+  });
+
+  // The public board URL for a shared set. Browser-only (uses location.origin); the list
+  // renders after auth on the client, so origin is always available here.
+  function boardUrl(slug: string): string {
+    return `${location.origin}/b/${slug}`;
+  }
+
+  function startShare(s: SavedSearch) {
+    shareEditId = s.id;
+    authorLabel = s.author_label;
+    error = null;
+  }
+
+  async function confirmShare(id: number) {
+    busyId = id;
+    error = null;
+    try {
+      await savedSearches.share(id, authorLabel.trim());
+      shareEditId = null;
+      authorLabel = '';
+    } catch (err) {
+      error = err instanceof ApiError ? err.message : 'Could not share this search. Please try again.';
+    } finally {
+      busyId = null;
+    }
+  }
+
+  async function unshare(id: number) {
+    busyId = id;
+    error = null;
+    try {
+      await savedSearches.unshare(id);
+    } catch {
+      error = 'Could not unshare this search. Please try again.';
+    } finally {
+      busyId = null;
+    }
+  }
+
+  async function rename(s: SavedSearch) {
+    const next = window.prompt('Rename saved search', s.name)?.trim();
+    if (!next || next === s.name) return;
+    error = null;
+    try {
+      await savedSearches.update(s.id, { name: next });
+    } catch (err) {
+      error = err instanceof ApiError ? err.message : 'Could not rename this search. Please try again.';
+    }
+  }
+
+  async function remove(s: SavedSearch) {
+    if (!window.confirm(`Delete saved search “${s.name}”?`)) return;
+    error = null;
+    try {
+      await savedSearches.remove(s.id);
+    } catch {
+      error = 'Could not delete this search. Please try again.';
+    }
+  }
+
+  async function copyLink(s: SavedSearch) {
+    try {
+      await navigator.clipboard.writeText(boardUrl(s.public_slug));
+      copiedId = s.id;
+      setTimeout(() => {
+        if (copiedId === s.id) copiedId = null;
+      }, 1500);
+    } catch {
+      error = 'Could not copy the link.';
+    }
+  }
+</script>
+
+{#if !isAuthenticated()}
+  <div class="flex flex-col items-center gap-3 py-12 text-center">
+    <p class="text-sm text-muted-foreground">Sign in to manage your saved searches.</p>
+    <Button variant="primary" onclick={() => openAuthDialog()}>Sign in</Button>
+  </div>
+{:else}
+  <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-1">
+      <h1 class="text-2xl font-semibold tracking-tight">Saved searches</h1>
+      <p class="text-sm text-muted-foreground">
+        Reuse a saved filter set, or share it as a public board anyone can open. Create new
+        saved searches from the filters panel on the jobs page.
+      </p>
+    </div>
+
+    {#if error}
+      <p class="text-sm text-destructive">{error}</p>
+    {/if}
+
+    {#if status === 'loading'}
+      <States state="loading" />
+    {:else if status === 'error'}
+      <States state="error" message="Couldn't load your saved searches." />
+    {:else if items.length === 0}
+      <States
+        state="empty"
+        message="No saved searches yet. Save a filter set from the jobs page to see it here."
+      />
+    {:else}
+      <ul class="flex flex-col divide-y divide-border rounded-lg border border-border">
+        {#each items as s (s.id)}
+          <li class="flex flex-col gap-2 px-4 py-3">
+            <div class="flex items-start justify-between gap-3">
+              <div class="flex min-w-0 flex-col gap-0.5">
+                <span class="truncate text-sm font-medium">{s.name}</span>
+                <span class="text-xs text-muted-foreground">
+                  {s.query === '' ? 'All jobs' : 'Custom filters'}
+                  {#if s.public_slug}· <span class="text-primary">Shared</span>{/if}
+                </span>
+              </div>
+              <div class="flex shrink-0 flex-wrap items-center justify-end gap-1">
+                <Button variant="ghost" size="sm" href={`/jobs?${s.query}`}>Open</Button>
+                <Button variant="ghost" size="sm" onclick={() => rename(s)}>Rename</Button>
+                {#if s.public_slug}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={busyId === s.id}
+                    onclick={() => unshare(s.id)}
+                  >
+                    Unshare
+                  </Button>
+                {:else}
+                  <Button variant="ghost" size="sm" onclick={() => startShare(s)}>Share</Button>
+                {/if}
+                <Button variant="ghost" size="sm" onclick={() => remove(s)}>Delete</Button>
+              </div>
+            </div>
+
+            {#if s.public_slug}
+              <!-- Shared: show the public link and (when set) the author label. -->
+              <div class="flex flex-wrap items-center gap-2 rounded bg-secondary/50 px-2 py-1.5">
+                <a
+                  href={`/b/${s.public_slug}`}
+                  class="min-w-0 truncate text-xs text-primary underline-offset-4 hover:underline"
+                >
+                  /b/{s.public_slug}
+                </a>
+                {#if s.author_label}
+                  <span class="text-xs text-muted-foreground">by {s.author_label}</span>
+                {/if}
+                <Button variant="ghost" size="sm" class="ml-auto" onclick={() => copyLink(s)}>
+                  {copiedId === s.id ? 'Copied' : 'Copy link'}
+                </Button>
+              </div>
+            {:else if shareEditId === s.id}
+              <!-- Private + sharing: optional author label, then confirm. -->
+              <div class="flex flex-wrap items-center gap-2">
+                <Input
+                  bind:value={authorLabel}
+                  placeholder="Author label (optional)"
+                  maxlength={60}
+                  class="w-56"
+                />
+                <Button
+                  variant="primary"
+                  size="sm"
+                  disabled={busyId === s.id}
+                  onclick={() => confirmShare(s.id)}
+                >
+                  {busyId === s.id ? 'Sharing…' : 'Create board'}
+                </Button>
+                <Button variant="ghost" size="sm" onclick={() => (shareEditId = null)}>Cancel</Button>
+              </div>
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+{/if}

--- a/web/src/lib/savedSearches.svelte.ts
+++ b/web/src/lib/savedSearches.svelte.ts
@@ -10,7 +10,14 @@
 // caller (a duplicate name or the per-user cap is a 409) so the UI can show them.
 
 import { browser } from '$app/environment';
-import { listSavedSearches, createSavedSearch, updateSavedSearch, deleteSavedSearch } from '$lib/api';
+import {
+  listSavedSearches,
+  createSavedSearch,
+  updateSavedSearch,
+  deleteSavedSearch,
+  shareSavedSearch,
+  unshareSavedSearch,
+} from '$lib/api';
 import type { SavedSearch } from '$lib/types';
 
 class SavedSearches {
@@ -64,6 +71,22 @@ class SavedSearches {
   async remove(id: number): Promise<void> {
     await deleteSavedSearch(id);
     this.#items = this.#items.filter((s) => s.id !== id);
+  }
+
+  /** Publish a set as a public board and replace it in place (keeping its position, so
+   *  toggling share doesn't reorder the list). Returns the updated set with its slug. */
+  async share(id: number, authorLabel = ''): Promise<SavedSearch> {
+    const row = await shareSavedSearch(id, authorLabel);
+    this.#items = this.#items.map((s) => (s.id === id ? row : s));
+    return row;
+  }
+
+  /** Make a shared set private again and clear its board fields in place. */
+  async unshare(id: number): Promise<void> {
+    await unshareSavedSearch(id);
+    this.#items = this.#items.map((s) =>
+      s.id === id ? { ...s, public_slug: '', author_label: '' } : s,
+    );
   }
 
   /** Drop the cached list and the loaded flag. The component calls this when the

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -192,8 +192,22 @@ export interface SavedSearch {
   id: number;
   name: string;
   query: string;
+  /** Public board slug when the set is shared, or "" when private. Shared boards are
+   *  readable by anyone at /b/<public_slug>. */
+  public_slug: string;
+  /** Optional attribution shown on the public board; "" renders the board anonymously. */
+  author_label: string;
   created_at: string | null;
   updated_at: string | null;
+}
+
+/** A public "board": a shared saved search readable by anyone at /b/<slug>. Carries only
+ *  display fields — no owner identity. `query` is the canonical search query string, applied
+ *  to the jobs list to render the board's results. `author_label` is "" when anonymous. */
+export interface Board {
+  name: string;
+  query: string;
+  author_label: string;
 }
 
 /** A user's search profile: a named professional self — a non-empty set of

--- a/web/src/routes/b/[slug]/+page.server.ts
+++ b/web/src/routes/b/[slug]/+page.server.ts
@@ -1,0 +1,25 @@
+import { error } from '@sveltejs/kit';
+import { ApiError } from '$lib/api';
+import { serverApi } from '$lib/server/api';
+import type { PageServerLoad } from './$types';
+
+const LIMIT = 20;
+
+// A public board is a shared saved search: load it by slug, then server-render the first
+// page of the jobs matching its stored query (so the rows are in the initial HTML for
+// sharing/reload). An unknown or unshared slug is a 404 → the app's +error page renders
+// the not-found state. Public read: no cookie forwarded.
+export const load: PageServerLoad = async ({ params, fetch }) => {
+  const client = serverApi(fetch);
+
+  let board;
+  try {
+    board = await client.getBoard(params.slug);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) throw error(404, 'Board not found');
+    throw e;
+  }
+
+  const initial = await client.searchJobs(new URLSearchParams(board.query), LIMIT, 0);
+  return { board, initial };
+};

--- a/web/src/routes/b/[slug]/+page.svelte
+++ b/web/src/routes/b/[slug]/+page.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { api } from '$lib/api';
+  import { Paginator } from '$lib/paginated.svelte';
+  import type { Job } from '$lib/types';
+  import JobRow from '$lib/components/JobRow.svelte';
+  import LoadMore from '$lib/components/LoadMore.svelte';
+  import States from '$lib/components/States.svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+  const board = $derived(data.board);
+
+  // A public board is read-only: page the board's stored query (kept fixed here — there is
+  // no filter panel to change it). The paginator is rebuilt when the loaded board changes
+  // (e.g. client-side navigation between two boards) and seeded with that load's SSR first
+  // page, so rows are in the initial HTML; "load more" fetches client-side. The query can
+  // carry repeated keys (multi-value facets), passed through URLSearchParams verbatim.
+  const jobs = $derived.by(() => {
+    const p = new Paginator<Job>((limit, offset) =>
+      api.searchJobs(new URLSearchParams(data.board.query), limit, offset),
+    );
+    p.seed(data.initial);
+    return p;
+  });
+</script>
+
+<svelte:head>
+  <title>{board.name} — freehire</title>
+  <!-- Share-by-link, not meant for search discovery. -->
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto w-full max-w-4xl px-4 py-6">
+  <div class="mb-4 flex flex-col gap-1">
+    <h1 class="text-2xl font-semibold tracking-tight">{board.name}</h1>
+    <p class="text-sm text-muted-foreground">
+      {jobs.total.toLocaleString()}
+      {jobs.total === 1 ? 'job' : 'jobs'}{#if board.author_label} · shared by {board.author_label}{/if}
+    </p>
+  </div>
+
+  {#if jobs.items.length === 0}
+    <States state="empty" message="No jobs match this board right now." />
+  {:else}
+    <ul class="flex flex-col divide-y divide-border rounded-lg border border-border">
+      {#each jobs.items as job (job.public_slug)}
+        <JobRow {job} />
+      {/each}
+    </ul>
+    {#if jobs.hasMore}
+      <LoadMore
+        loading={jobs.loadingMore}
+        error={jobs.loadMoreError}
+        onclick={() => jobs.loadMore()}
+      />
+    {/if}
+  {/if}
+</div>

--- a/web/src/routes/my/searches/+page.svelte
+++ b/web/src/routes/my/searches/+page.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import SavedSearchesView from '$lib/components/SavedSearchesView.svelte';
+</script>
+
+<svelte:head>
+  <title>Saved searches — freehire</title>
+  <!-- Personal page: keep it out of search results. -->
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
+  <SavedSearchesView />
+</div>


### PR DESCRIPTION
## Summary
- Lets a signed-in user publish a saved search as a public **board** at `/b/<slug>` — a curated job view shareable by link (the hiring.cafe "board" idea, mapped onto our existing saved searches).
- Extends the `saved-searches` capability: `public_slug` (nullable, UNIQUE) + `author_label` on `saved_searches`; `public_slug IS NULL` = private.
- New API: `POST`/`DELETE /api/v1/me/searches/:id/share` (cookie-only) and public `GET /api/v1/boards/:slug` returning only `{name, query, author_label}` — **no owner PII**.
- Web: public `/b/[slug]` route (SSR board + read-only paginated jobs), account section `/my/searches` (+ header menu entry) for manage/share/unshare/copy-link, and a lightweight share/unshare in the "My filters" panel.

## Design notes
- Slug is readable (`normalize.Slug(name)` + random suffix, e.g. `remote-go-jobs-a3f1`) and minted on share; re-share keeps it, unshare clears it (a fresh share mints a new one).
- Author attribution is a self-contained optional `author_label` on the board (blank → anonymous) — `users` is untouched (no display-name subsystem).
- Sharing is a nullable-slug toggle on the existing row, not a separate entity.
- OpenSpec change `add-public-search-boards` archived; `saved-searches` main spec synced (+6 requirements, ~1 modified).

## Test plan
- [x] `go build ./... && go vet ./...`, `go test ./...` (unit) green; `gofmt` clean
- [x] Integration (`-tags=integration ./internal/handler ./internal/db`) green, incl. `TestSavedSearchBoardsEndToEnd`: create → share → anonymous board read (asserts no `user_id`/`id`/`email`) → re-share keeps slug → unshare → 404 → unknown slug 404
- [x] `svelte-check` 0 errors / 0 warnings; production SSR `npm run build` succeeds
- [ ] Residual manual smoke: browser walkthrough of `/my/searches` and `/b/:slug` against a seeded stack before deploy