### PR TITLE
fix(linksource): namespace resolved external_id by board so TG-linked jobs dedup

### DIFF
--- a/internal/linksource/ashby.go
+++ b/internal/linksource/ashby.go
@@ -70,7 +70,7 @@ func (a ashby) Resolve(ctx context.Context, raw string) (sources.Job, bool, erro
 			jobURL = "https://jobs.ashbyhq.com/" + board + "/" + id
 		}
 		return sources.Job{
-			ExternalID:  board + ":" + id,
+			ExternalID:  sources.NamespaceExternalID(board, id),
 			URL:         jobURL,
 			Title:       j.Title,
 			Company:     humanizeBoard(board),

--- a/internal/linksource/greenhouse.go
+++ b/internal/linksource/greenhouse.go
@@ -74,7 +74,7 @@ func (g greenhouse) Resolve(ctx context.Context, raw string) (sources.Job, bool,
 	}
 
 	return sources.Job{
-		ExternalID:  board + ":" + id,
+		ExternalID:  sources.NamespaceExternalID(board, id),
 		URL:         j.AbsoluteURL,
 		Title:       j.Title,
 		Company:     j.CompanyName,

--- a/internal/linksource/habrcareer.go
+++ b/internal/linksource/habrcareer.go
@@ -13,7 +13,9 @@ import (
 // habrCareer resolves Habr Career vacancies. Channels link them through the u.habr.com
 // shortener, which 301s to career.habr.com/vacancies/<id>; the canonical id and URL come
 // from the resolved location, so the same vacancy linked from several channels dedups to
-// one row.
+// one row. Habr is a boardless source, so the ingest pipeline namespaces its external_id
+// with an empty board (":<id>"); the adapter produces the same key via
+// sources.NamespaceExternalID so a linked vacancy dedups against the board crawl too.
 type habrCareer struct {
 	http Client
 }
@@ -71,7 +73,7 @@ func (h habrCareer) Resolve(ctx context.Context, raw string) (sources.Job, bool,
 	}
 
 	return sources.Job{
-		ExternalID:  id,
+		ExternalID:  sources.NamespaceExternalID("", id),
 		URL:         "https://career.habr.com/vacancies/" + id,
 		Title:       p.Title,
 		Company:     p.Company,

--- a/internal/linksource/habrcareer_test.go
+++ b/internal/linksource/habrcareer_test.go
@@ -43,8 +43,10 @@ func TestHabrCareerResolvesShortLinkToVacancy(t *testing.T) {
 	if !ok {
 		t.Fatal("ok=false, want the vacancy resolved")
 	}
-	if job.ExternalID != "1000166712" {
-		t.Errorf("ExternalID = %q, want 1000166712", job.ExternalID)
+	// Habr is boardless, so the ingest pipeline namespaces its external_id with an empty board
+	// (":<id>"); the link-source must produce the same key to dedup against the board crawl.
+	if job.ExternalID != ":1000166712" {
+		t.Errorf("ExternalID = %q, want :1000166712 (boardless namespace)", job.ExternalID)
 	}
 	if job.URL != "https://career.habr.com/vacancies/1000166712" {
 		t.Errorf("URL = %q, want canonical vacancy URL without utm", job.URL)
@@ -76,7 +78,7 @@ func TestHabrCareerResolvesDirectVacancyLink(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if !ok || job.ExternalID != "1000166712" {
+	if !ok || job.ExternalID != ":1000166712" {
 		t.Fatalf("direct link not resolved: ok=%v id=%q", ok, job.ExternalID)
 	}
 }

--- a/internal/linksource/lever.go
+++ b/internal/linksource/lever.go
@@ -12,8 +12,9 @@ import (
 
 // lever resolves Lever-hosted vacancies. Lever is multi-tenant, so a TG link points at an
 // arbitrary company's board — many of which sources/lever.yml does not list. The adapter
-// writes the SAME identity the ingest pipeline would (source="lever", external_id=<posting
-// id>), so UpsertJob's ON CONFLICT dedups against an already-crawled company and a
+// writes the SAME identity the ingest pipeline would (source="lever", external_id
+// "<board>:<posting id>" via sources.NamespaceExternalID, the URL's company slug being the
+// board), so UpsertJob's ON CONFLICT dedups against an already-crawled company and a
 // not-yet-crawled one is added under the canonical key rather than a thin telegram dup.
 type lever struct {
 	http Client
@@ -35,8 +36,8 @@ func (lever) Match(u *url.URL) bool {
 }
 
 // Resolve reads the public per-posting API for the linked company+id and maps it exactly as
-// the ingest lever adapter does. The posting id is globally unique, so external_id is the
-// bare id (no board prefix), matching the ingest key.
+// the ingest lever adapter does, namespacing external_id by board (the URL's company slug) to
+// match the pipeline's dedup key.
 func (l lever) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -86,7 +87,7 @@ func (l lever) Resolve(ctx context.Context, raw string) (sources.Job, bool, erro
 	body.WriteString(p.Additional)
 
 	return sources.Job{
-		ExternalID:  p.ID,
+		ExternalID:  sources.NamespaceExternalID(company, p.ID),
 		URL:         p.HostedURL,
 		Title:       p.Text,
 		Company:     humanizeBoard(company), // the per-posting API carries no company name

--- a/internal/linksource/lever_test.go
+++ b/internal/linksource/lever_test.go
@@ -32,11 +32,11 @@ func TestLeverResolvesAlignedIdentity(t *testing.T) {
 	if !ok {
 		t.Fatal("ok=false, want the vacancy resolved")
 	}
-	// Lever posting ids are globally unique, so the ingest adapter keys external_id on the
-	// bare id; the link-source must match that exactly to dedup against an ingested board
-	// rather than write a thin telegram-source duplicate.
-	if job.ExternalID != "52c01c91-582c-42fc-8722-82c3eeb9ed24" {
-		t.Errorf("ExternalID = %q, want the bare posting id", job.ExternalID)
+	// The ingest pipeline namespaces every posting's external_id by board (the URL's company
+	// slug is Lever's board), so the link-source must produce the same "<board>:<id>" key to
+	// dedup against an ingested board rather than write a thin telegram-source duplicate.
+	if job.ExternalID != "offchainlabs:52c01c91-582c-42fc-8722-82c3eeb9ed24" {
+		t.Errorf("ExternalID = %q, want the board-namespaced posting id", job.ExternalID)
 	}
 	if job.URL != "https://jobs.lever.co/offchainlabs/52c01c91-582c-42fc-8722-82c3eeb9ed24" {
 		t.Errorf("URL = %q", job.URL)

--- a/internal/linksource/resolve_test.go
+++ b/internal/linksource/resolve_test.go
@@ -29,8 +29,8 @@ func TestResolveLinksReturnsMatchedVacanciesAndSkipsRest(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("resolved = %d (%+v), want 1", len(got), got)
 	}
-	if got[0].Source != "habr_career" || got[0].Job.ExternalID != "1000166712" {
-		t.Errorf("resolved = %+v, want habr_career/1000166712", got[0])
+	if got[0].Source != "habr_career" || got[0].Job.ExternalID != ":1000166712" {
+		t.Errorf("resolved = %+v, want habr_career/:1000166712", got[0])
 	}
 }
 

--- a/internal/linksource/workable.go
+++ b/internal/linksource/workable.go
@@ -12,8 +12,9 @@ import (
 
 // workable resolves Workable-hosted vacancies. Workable is multi-tenant, so a TG link points
 // at an arbitrary account's board. The adapter writes the SAME identity the ingest pipeline
-// would (source="workable", external_id=<shortcode>), so UpsertJob's ON CONFLICT dedups
-// against an already-crawled account rather than writing a thin telegram duplicate.
+// would (source="workable", external_id "<account>:<shortcode>" via sources.NamespaceExternalID,
+// the URL's account being the board), so UpsertJob's ON CONFLICT dedups against an
+// already-crawled account rather than writing a thin telegram duplicate.
 type workable struct {
 	http Client
 }
@@ -71,7 +72,7 @@ func (w workable) Resolve(ctx context.Context, raw string) (sources.Job, bool, e
 			continue
 		}
 		return sources.Job{
-			ExternalID:  j.Shortcode,
+			ExternalID:  sources.NamespaceExternalID(account, j.Shortcode),
 			URL:         j.URL,
 			Title:       j.Title,
 			Company:     humanizeBoard(account), // the widget API carries no company name

--- a/internal/linksource/workable_test.go
+++ b/internal/linksource/workable_test.go
@@ -27,10 +27,11 @@ func TestWorkableResolvesNamedShortcode(t *testing.T) {
 	if !ok {
 		t.Fatal("ok=false, want the named vacancy resolved")
 	}
-	// external_id is the shortcode, matching what the ingest workable adapter writes, so the
-	// same vacancy crawled directly dedups instead of duplicating.
-	if job.ExternalID != "915C6E469E" {
-		t.Errorf("ExternalID = %q, want 915C6E469E", job.ExternalID)
+	// The ingest pipeline namespaces external_id by board (the URL's account is Workable's
+	// board), so the link-source must produce the same "<account>:<shortcode>" key for the
+	// same vacancy crawled directly to dedup instead of duplicating.
+	if job.ExternalID != "jobhire:915C6E469E" {
+		t.Errorf("ExternalID = %q, want jobhire:915C6E469E", job.ExternalID)
 	}
 	if job.Title != "Lead AI Product Manager" {
 		t.Errorf("Title = %q (picked wrong shortcode?)", job.Title)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -5,7 +5,6 @@ package pipeline
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"sync"
 	"sync/atomic"
@@ -277,7 +276,7 @@ func (r Runner) ingestStream(ctx context.Context, e sources.CompanyEntry, ss sou
 // the upsert (via normalizeJob) and the stream-driven close derive identity here, so a
 // removal closes exactly the row a live emit would have upserted.
 func jobIdentity(e sources.CompanyEntry, j sources.Job) (source, externalID string) {
-	return e.Provider, fmt.Sprintf("%s:%s", e.Board, j.ExternalID)
+	return e.Provider, sources.NamespaceExternalID(e.Board, j.ExternalID)
 }
 
 // normalizeJob turns a raw posting into a persistable Job: the platform becomes the

--- a/internal/sources/identity.go
+++ b/internal/sources/identity.go
@@ -1,0 +1,15 @@
+package sources
+
+import "fmt"
+
+// NamespaceExternalID is the single definition of the dedup-key external_id format shared by
+// the ingest pipeline and the link-source adapters: the platform's native posting id
+// namespaced by board, so two companies on one multi-tenant platform cannot collide. A
+// boardless source passes an empty board, yielding a ":<id>" key. Both write paths to
+// UpsertJob — the ingest pipeline (via jobIdentity) and the link-source adapters (via
+// tg-extract's CompleteLinks) — MUST route their external_id through here, so a job resolved
+// from a Telegram link dedups against the same posting crawled from a board file rather than
+// creating a duplicate row.
+func NamespaceExternalID(board, externalID string) string {
+	return fmt.Sprintf("%s:%s", board, externalID)
+}

--- a/internal/sources/identity_test.go
+++ b/internal/sources/identity_test.go
@@ -1,0 +1,20 @@
+package sources
+
+import "testing"
+
+func TestNamespaceExternalID(t *testing.T) {
+	cases := []struct {
+		name  string
+		board string
+		id    string
+		want  string
+	}{
+		{"boarded platform namespaces by board", "acme", "42", "acme:42"},
+		{"boardless source uses empty board prefix", "", "1000166598", ":1000166598"},
+	}
+	for _, tc := range cases {
+		if got := NamespaceExternalID(tc.board, tc.id); got != tc.want {
+			t.Errorf("%s: NamespaceExternalID(%q, %q) = %q, want %q", tc.name, tc.board, tc.id, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem (HIGH — from the repo review)

Two write paths reach the DB `UpsertJob` (keyed `UNIQUE (source, external_id)`):

1. **Board ingest** (`cmd/ingest` → `internal/pipeline` `jobIdentity`) unconditionally namespaces `external_id` as `"<board>:<id>"` (boardless sources → `":<id>"`).
2. **Telegram link-following** (`cmd/tg-extract` `CompleteLinks`) wrote the linksource adapter's `sources.Job.ExternalID` **verbatim**, bypassing that namespacing.

Three linksource adapters — `habr_career`, `lever`, `workable` — emitted a **bare** id. So a vacancy resolved from a Telegram link and the *same* vacancy crawled from a board file got **different** `external_id`s, the `ON CONFLICT` never fired, and the catalogue held **duplicate rows** (inflated counts, wasted enrichment budget, duplicate search docs, split `user_jobs`).

`greenhouse`/`ashby` were already correct — but they **duplicated the `board+":"+id` format inline**, which is exactly what let the other three drift.

## Fix (root cause, not three patches)

- New `sources.NamespaceExternalID(board, externalID)` — the **single definition** of the dedup-key format.
- Route **both** write paths through it: `pipeline.jobIdentity` and every **board-twinned** linksource adapter (`greenhouse`, `ashby`, `lever`, `workable`, and boardless `habr` via empty board → `":<id>"`).
- `geekjob`/`remoteyeah` are **linksource-only** (no board-ingest twin) and intentionally stay bare — namespacing them would orphan their existing rows.
- Comments/tests that enshrined the wrong bare-id rationale are corrected to assert the namespaced key.

## Verification

- TDD: added `identity_test.go` (boarded + boardless forms); flipped the three adapter tests + `resolve_test.go` to the namespaced key (watched them fail, then pass).
- `go build ./...`, `go vet ./...`, `gofmt` clean, full unit suite green (45 pkgs, 0 fail).
- Adversarial re-review confirmed completeness: no twinned adapter left bare, no single-path adapter wrongly namespaced, `public_slug` stays consistent (first-writer-wins, excluded from `DO UPDATE SET`).

## Out of scope (follow-ups)

- **Existing duplicate rows** in prod (bare-id linksource rows already written) are not migrated by this code change — they need a one-off dedup/cleanup pass.
- **Board-slug case sensitivity**: linksource derives `board` from the URL path (case-preserving) while ingest uses the yml board slug (e.g. `AIFund`, `BestEgg`). A case mismatch still misses dedup. This is **pre-existing** (identical for the already-namespaced greenhouse/ashby) and not worsened here; fixing it properly must normalize case on **both** paths.

Generated with assistance from Claude Code.