### PR TITLE
feat(web): site-level structured data (WebSite, Organization, FAQ, breadcrumbs)

### DIFF
--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -2,6 +2,7 @@
   import { resolve } from '$app/paths';
   import { Button } from '$lib/ui';
   import HomeFunnel from '$lib/components/HomeFunnel.svelte';
+  import { HOME_FAQ } from '$lib/homeFaq';
 
   const GITHUB = 'https://github.com/strelov1/freehire';
   const CLI = 'https://github.com/strelov1/freehire-cli';
@@ -355,6 +356,23 @@ freehire save <span class="text-foreground">&lt;slug&gt;</span></pre>
         </Button>
       </div>
     </div>
+  </section>
+
+  <!-- FAQ. Visible answers mirror the FAQPage JSON-LD (see homeFaq.ts) so the
+       structured data always matches what's on the page. -->
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// faq</p>
+    <h2 class="mt-6 max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+      Frequently asked questions.
+    </h2>
+    <dl class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each HOME_FAQ as item (item.question)}
+        <div class="bg-background p-6 sm:p-7">
+          <dt class="text-lg font-semibold tracking-tight">{item.question}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{item.answer}</dd>
+        </div>
+      {/each}
+    </dl>
   </section>
 </div>
 

--- a/web/src/lib/homeFaq.ts
+++ b/web/src/lib/homeFaq.ts
@@ -1,0 +1,39 @@
+// Homepage FAQ content — the single source for both the visible section
+// (HomeView.svelte) and the FAQPage JSON-LD (routes/+page.svelte). Google
+// requires the schema's answers to match the on-page text, so they share this.
+// Answers are written answer-first and stay honest to what the product does.
+
+import type { FaqItem } from './seo';
+
+export const HOME_FAQ: FaqItem[] = [
+  {
+    question: 'What is freehire?',
+    answer:
+      'freehire is a free, open-source IT job aggregator. It pulls tech job postings straight from company career boards — Greenhouse, Lever, Ashby, Teamtailor and more — removes duplicates, and tags each role with its stack, seniority, salary and location, so you search jobs, not job boards.',
+  },
+  {
+    question: 'Is freehire free to use?',
+    answer:
+      'Yes. freehire is completely free and open source under the MIT license. There are no paywalls, no sponsored listings, and no résumé harvesting — it works for job seekers, not recruiters.',
+  },
+  {
+    question: 'Where do the job listings come from?',
+    answer:
+      'Listings come directly from companies’ public applicant tracking systems (ATS), such as Greenhouse, Lever, Ashby, Teamtailor and SuccessFactors. Every posting is normalized to one schema and deduplicated, so the same role never appears twice across boards.',
+  },
+  {
+    question: 'How is freehire different from other job boards?',
+    answer:
+      'Unlike traditional job boards, freehire sources jobs directly from company career pages instead of paid listings. There are no sponsored posts and no paywalls, and because it is open source, anyone can add a new company or ATS source.',
+  },
+  {
+    question: 'Can I use freehire from the command line or with AI agents?',
+    answer:
+      'Yes. freehire offers a CLI and an HTTP API, so a script or an AI agent can search, open and track jobs over the same interface — no browser needed. Create an API key and add --json for machine-readable output.',
+  },
+  {
+    question: 'How do I get notified about new jobs?',
+    answer:
+      'Save a search — your stack, seniority, region and salary — and subscribe to it. When a matching job is added, freehire sends it to you on Telegram as a tidy digest, so the openings come to you.',
+  },
+];

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -5,6 +5,13 @@
 import type { Company, Enrichment, Job } from './types';
 
 const SITE = 'freehire';
+// Site-level facts reused across the homepage WebSite/Organization schema.
+const SITE_DESCRIPTION =
+  'FreeHire aggregates tech jobs straight from company career boards, deduplicates them, and tags each with stack, seniority and location. Free and open source.';
+const SITE_GITHUB = 'https://github.com/strelov1/freehire';
+
+/** One question/answer pair; the shape shared by the visible FAQ and its schema. */
+export type FaqItem = { question: string; answer: string };
 
 /** Plain-text, length-capped description for `<meta name="description">` and OG,
  *  derived from the job's sanitized HTML body. */
@@ -133,6 +140,69 @@ export function organizationJsonLd(company: Company, origin: string): Record<str
     '@type': 'Organization',
     name: company.name,
     url: `${origin}/companies/${company.slug}`,
+  };
+}
+
+/** schema.org WebSite for the homepage. The SearchAction advertises the job
+ *  search so engines can offer a sitelinks search box straight into /jobs?q=. */
+export function websiteJsonLd(origin: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: SITE,
+    url: `${origin}/`,
+    description: SITE_DESCRIPTION,
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: `${origin}/jobs?q={search_term_string}`,
+      },
+      'query-input': 'required name=search_term_string',
+    },
+  };
+}
+
+/** schema.org Organization for freehire itself (the publisher) — names the entity
+ *  for search/AI engines. Distinct from `organizationJsonLd`, which describes a
+ *  hiring company on its own page. */
+export function siteOrganizationJsonLd(origin: string): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: SITE,
+    url: `${origin}/`,
+    logo: `${origin}/apple-touch-icon.png`,
+    description: SITE_DESCRIPTION,
+    sameAs: [SITE_GITHUB],
+  };
+}
+
+/** schema.org BreadcrumbList from an ordered list of trail steps. */
+export function breadcrumbJsonLd(items: { name: string; url: string }[]): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+/** schema.org FAQPage. The questions must also appear as visible text on the page
+ *  (Google's requirement), so it is built from the same source as the rendered FAQ. */
+export function faqPageJsonLd(faqs: FaqItem[]): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((f) => ({
+      '@type': 'Question',
+      name: f.question,
+      acceptedAnswer: { '@type': 'Answer', text: f.answer },
+    })),
   };
 }
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -2,8 +2,16 @@
   import { page } from '$app/state';
   import HomeView from '$lib/components/HomeView.svelte';
   import Seo from '$lib/components/Seo.svelte';
+  import { HOME_FAQ } from '$lib/homeFaq';
+  import { faqPageJsonLd, jsonLdScript, siteOrganizationJsonLd, websiteJsonLd } from '$lib/seo';
 
-  const canonical = $derived(`${page.url.origin}/`);
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/`);
+  // One script carrying the site-level entities: what the site is (WebSite +
+  // its search action), who publishes it (Organization), and the FAQ.
+  const jsonLd = $derived(
+    jsonLdScript([websiteJsonLd(origin), siteOrganizationJsonLd(origin), faqPageJsonLd(HOME_FAQ)])
+  );
 </script>
 
 <Seo
@@ -11,6 +19,11 @@
   description="FreeHire aggregates tech jobs straight from company career boards, deduplicates them, and tags each with stack, seniority and location. Free and open source."
   {canonical}
 />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <HomeView />

--- a/web/src/routes/companies/[slug]/+page.svelte
+++ b/web/src/routes/companies/[slug]/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/state';
   import CompanyView from '$lib/components/CompanyView.svelte';
   import Seo from '$lib/components/Seo.svelte';
-  import { jsonLdScript, organizationJsonLd } from '$lib/seo';
+  import { breadcrumbJsonLd, jsonLdScript, organizationJsonLd } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -10,7 +10,16 @@
   const origin = $derived(page.url.origin);
   const canonical = $derived(`${origin}/companies/${data.slug}`);
   const description = $derived(`Open jobs at ${data.company.name}, aggregated by freehire.`);
-  const jsonLd = $derived(jsonLdScript(organizationJsonLd(data.company, origin)));
+  const jsonLd = $derived(
+    jsonLdScript([
+      organizationJsonLd(data.company, origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Companies', url: `${origin}/companies` },
+        { name: data.company.name, url: canonical },
+      ]),
+    ])
+  );
 </script>
 
 <Seo title={`${data.company.name} · freehire`} {description} {canonical} />

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -3,7 +3,13 @@
   import JobRow from '$lib/components/JobRow.svelte';
   import JobView from '$lib/components/JobView.svelte';
   import Seo from '$lib/components/Seo.svelte';
-  import { jobPageTitle, jobPostingJsonLd, jsonLdScript, metaDescription } from '$lib/seo';
+  import {
+    breadcrumbJsonLd,
+    jobPageTitle,
+    jobPostingJsonLd,
+    jsonLdScript,
+    metaDescription,
+  } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -13,7 +19,16 @@
   // The per-job OG preview lives beside the canonical URL; og:image must be absolute.
   const ogImage = $derived(`${canonical}/og.png`);
   const description = $derived(metaDescription(data.job.description));
-  const jsonLd = $derived(jsonLdScript(jobPostingJsonLd(data.job, origin)));
+  const jsonLd = $derived(
+    jsonLdScript([
+      jobPostingJsonLd(data.job, origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Jobs', url: `${origin}/jobs` },
+        { name: data.job.title, url: canonical },
+      ]),
+    ])
+  );
 </script>
 
 <Seo title={jobPageTitle(data.job)} {description} {canonical} image={ogImage} />


### PR DESCRIPTION
## What & why

The homepage carried **zero** structured data, so Google and AI search engines (ChatGPT, Perplexity, Gemini) had no machine-readable entity describing the site. Job and company detail pages already emit `JobPosting`/`Organization`; this fills the site-level gap and adds breadcrumbs.

## Changes

- **`WebSite` + `SearchAction`** on the homepage — advertises the job search (`/jobs?q={q}`) so engines can offer a sitelinks search box.
- **`Organization`** for freehire itself (the publisher; `sameAs` → GitHub) — names the entity so AI engines cite "freehire" rather than an unnamed source.
- **`FAQPage`** — a new visible FAQ section on the homepage plus matching schema. Both are driven by a single source (`src/lib/homeFaq.ts`) so the on-page answers and the schema can never drift (Google requires FAQ answers to be visible on the page).
- **`BreadcrumbList`** on job and company detail pages, emitted alongside the existing schema as a JSON-LD array in the same `<script>`.

All JSON-LD flows through the existing `jsonLdScript` helper, which escapes `<` → `<` (XSS/breakout-safe).

## Not included

Sitemap coverage is a **separate PR**: `/sitemap.xml` is currently capped at 5,000 jobs / 5,000 companies while the catalogue is 100k+, so ~95% of job pages aren't listed. Fixing that (sitemap-index + a lightweight backend slug endpoint) is tracked separately.

## Verification

- `svelte-check` — 0 errors, 0 warnings
- `npm run build` (SSR) — succeeds