### PR TITLE
perf(db): index job-list and enrichment-claim ORDER BYs (migration 0033)

### DIFF
--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -21,7 +21,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     UNIQUE (source, external_id)
 );
 
--- Composite index matches the ListJobs ORDER BY (posted_at DESC NULLS LAST, id DESC)
--- and still serves queries that filter/sort on posted_at alone (leading column).
+-- Composite index for posted_at-ordered access and queries that filter/sort on posted_at
+-- alone (leading column). NOTE: ListJobs now orders by created_at, served by the partial
+-- jobs_open_created_at_id_idx in migration 0033 — not this index.
 CREATE INDEX IF NOT EXISTS jobs_posted_at_id_idx ON jobs (posted_at DESC NULLS LAST, id DESC);
 CREATE INDEX IF NOT EXISTS jobs_source_idx ON jobs (source);

--- a/migrations/0033_job_list_indexes.sql
+++ b/migrations/0033_job_list_indexes.sql
@@ -1,0 +1,33 @@
+-- Indexes for the newest-first list surfaces and the enrichment claim, whose ORDER BYs no
+-- existing index served. jobs_posted_at_id_idx (0001) is keyed on posted_at, but ListJobs /
+-- ListJobsByCompany sort by created_at and ClaimEnrichmentBatch by COALESCE(posted_at,
+-- created_at). Without these, the public /api/v1/jobs list and CountJobs full-scan open jobs
+-- and top-N sort on every request, and a version-bump enrichment backfill re-sorts the whole
+-- claimable set on every wave. All three are partial on the open-jobs predicate every list
+-- surface shares (closed_at IS NULL), so they stay small and the filter is free.
+--
+-- Prod note: these run on first initdb here, but on the live table apply them with
+-- CREATE INDEX CONCURRENTLY (outside a transaction) so the build does not lock writes:
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS jobs_open_created_at_id_idx          ON jobs (created_at DESC, id DESC)                        WHERE closed_at IS NULL;
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS jobs_open_company_created_at_id_idx  ON jobs (company_slug, created_at DESC, id DESC)          WHERE closed_at IS NULL;
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS jobs_open_enrich_freshness_idx       ON jobs ((COALESCE(posted_at, created_at)) DESC, id DESC) WHERE closed_at IS NULL;
+
+-- Serves ListJobs (WHERE closed_at IS NULL ORDER BY created_at DESC, id DESC) and CountJobs
+-- (a count of the partial index's entries).
+CREATE INDEX IF NOT EXISTS jobs_open_created_at_id_idx
+    ON jobs (created_at DESC, id DESC)
+    WHERE closed_at IS NULL;
+
+-- Serves ListJobsByCompany (WHERE company_slug = $1 AND closed_at IS NULL ORDER BY
+-- created_at DESC, id DESC): company_slug leads so the equality seeks, then the index yields
+-- the newest-first order directly.
+CREATE INDEX IF NOT EXISTS jobs_open_company_created_at_id_idx
+    ON jobs (company_slug, created_at DESC, id DESC)
+    WHERE closed_at IS NULL;
+
+-- Serves ClaimEnrichmentBatch's ORDER BY COALESCE(posted_at, created_at) DESC, id DESC over
+-- open jobs, so a claim wave is an ordered index scan + LIMIT instead of a full sort of the
+-- whole claimable set. The expression mirrors the query's freshness key exactly.
+CREATE INDEX IF NOT EXISTS jobs_open_enrich_freshness_idx
+    ON jobs ((COALESCE(posted_at, created_at)) DESC, id DESC)
+    WHERE closed_at IS NULL;


### PR DESCRIPTION
## Problem (MEDIUM ×2 — from the repo review, rec #2)

Hot queries sort/filter open jobs by columns **no index serves**:

| Query | ORDER BY / filter | Served by an index? |
|-------|-------------------|---------------------|
| `ListJobs` (public `/api/v1/jobs`) | `closed_at IS NULL ORDER BY created_at DESC, id DESC` | ❌ (only `posted_at` index exists) |
| `ListJobsByCompany` | `company_slug = $1 AND closed_at IS NULL ORDER BY created_at DESC, id DESC` | ❌ (company index is keyed on `posted_at`) |
| `CountJobs` | `closed_at IS NULL` | ❌ (seq scan) |
| `ClaimEnrichmentBatch` | `ORDER BY COALESCE(posted_at, created_at) DESC, id DESC` | ❌ (no expression index) |

Result: every list request full-scans open jobs + top-N sorts; a deep `OFFSET` spills the whole open set to an **on-disk** sort; `CountJobs` seq-scans; each enrichment-claim wave of a version-bump backfill **hash-joins the whole outbox to jobs and full-sorts it**.

## Fix — migration `0033`

Three **partial** (`WHERE closed_at IS NULL`, the predicate every list surface shares) indexes matching the exact ORDER BYs:

- `jobs_open_created_at_id_idx (created_at DESC, id DESC)` → `ListJobs` + `CountJobs`
- `jobs_open_company_created_at_id_idx (company_slug, created_at DESC, id DESC)` → `ListJobsByCompany`
- `jobs_open_enrich_freshness_idx ((COALESCE(posted_at, created_at)) DESC, id DESC)` → `ClaimEnrichmentBatch`

Also corrects the stale `0001` comment that claimed `jobs_posted_at_id_idx` serves the `ListJobs` ORDER BY (it moved to `created_at`) — so nobody "fixes" `ListJobs` back to `posted_at` and regresses freshness.

## Verification — EXPLAIN ANALYZE on a seeded 60k-row Postgres (before → after)

| Query | Before | After |
|-------|--------|-------|
| `ListJobs` (offset 0) | Parallel Seq Scan + top-N sort, 1858 buf | **Index Scan, no sort**, ~102 buf, 0.36ms |
| `ListJobs` (deep offset) | **external merge sort, 5.7 MB on disk** | Index Scan, **no disk spill** |
| `CountJobs` | Seq Scan 51k, 10.5ms | **Index Only Scan**, 3.5ms |
| `ListJobsByCompany` (large co.) | Sort over `posted_at` index | **ordered Index Scan, no sort** |
| `ClaimEnrichmentBatch` | Hash Join 51k + top-N sort, 2245 buf | **Nested Loop Index Scan**, 18 buf, 0.18ms |

(`make sqlc` re-runs clean — partial-index DDL parses, no codegen drift. `go build`/`vet`/full unit suite green.)

## Deploy note

Migrations apply via initdb on a fresh volume, but this repo hand-applies migrations to the live DB. On the ~1.5M-row `jobs` table, apply with **`CREATE INDEX CONCURRENTLY`** (outside a transaction) so the build does not lock writes — the exact statements are in the migration file header.

Out of scope (noted in the review): switching the public list to **keyset** pagination would also remove the inherent deep-`OFFSET` walk; this PR only removes the unindexed sort.

Generated with assistance from Claude Code.