### PR TITLE
fix(facets): stop deterministic-dictionary false-positives in employment-type and location

### DIFF
--- a/internal/jobfacts/jobfacts.go
+++ b/internal/jobfacts/jobfacts.go
@@ -17,14 +17,21 @@ import (
 // is an internship, a part-time contract is part-time, etc. "temporary" / "fixed
 // term" map to contract (the closest vocabulary member). Bare \bintern\b is safe —
 // the boundary keeps it out of "internal"/"international". The contract matcher also
-// covers the US-market shorthands for an independent contractor: 1099 (the tax form),
-// C2C and "corp-to-corp". "consultant" is deliberately excluded — it is as often a
-// full-time title as a contract arrangement.
+// covers the unambiguous US-market shorthands for an independent contractor: 1099
+// (the tax form) and "corp-to-corp". "consultant" is deliberately excluded — it is as
+// often a full-time title as a contract arrangement.
+//
+// b2b/c2c also denote an independent-contractor arrangement in some markets, but the
+// bare tokens collide with ubiquitous business-model prose ("B2B SaaS", "C2C
+// marketplace") — so, like the bare "ms"/"bs" degree abbreviations below, they favour
+// precision: reContractShorthand matches them only when an employment-context word
+// sits right after ("C2C candidates", "B2B contract", "C2C only"), never standalone.
 var (
-	reInternship = regexp.MustCompile(`\b(internship|intern|co-?op|working student|praktikum|werkstudent)\b`)
-	rePartTime   = regexp.MustCompile(`\bpart[\s-]?time\b`)
-	reContract   = regexp.MustCompile(`\b(contractor|contract|freelancer|freelance|fixed[\s-]?term|temporary|b2b|c2c|1099|corp[\s-]?to[\s-]?corp)\b`)
-	reFullTime   = regexp.MustCompile(`\b(full[\s-]?time|permanent)\b`)
+	reInternship        = regexp.MustCompile(`\b(internship|intern|co-?op|working student|praktikum|werkstudent)\b`)
+	rePartTime          = regexp.MustCompile(`\bpart[\s-]?time\b`)
+	reContract          = regexp.MustCompile(`\b(contractor|contract|freelancer|freelance|fixed[\s-]?term|temporary|1099|corp[\s-]?to[\s-]?corp)\b`)
+	reContractShorthand = regexp.MustCompile(`\b(b2b|c2c)\b[\s:/.-]*(only|contract|contractor|candidates?|welcome|accepted|basis|engagement|employment|position|arrangement|w2)\b`)
+	reFullTime          = regexp.MustCompile(`\b(full[\s-]?time|permanent)\b`)
 )
 
 // EmploymentType resolves the work arrangement from the title and description,
@@ -37,7 +44,7 @@ func EmploymentType(title, description string) string {
 		return "internship"
 	case rePartTime.MatchString(s):
 		return "part_time"
-	case reContract.MatchString(s):
+	case reContract.MatchString(s) || reContractShorthand.MatchString(s):
 		return "contract"
 	case reFullTime.MatchString(s):
 		return "full_time"

--- a/internal/jobfacts/jobfacts_test.go
+++ b/internal/jobfacts/jobfacts_test.go
@@ -23,6 +23,11 @@ func TestEmploymentType(t *testing.T) {
 		{"c2c -> contract", "Dev", "Open to C2C candidates.", "contract"},
 		{"corp-to-corp -> contract", "Dev", "W2 or corp-to-corp accepted.", "contract"},
 		{"corp to corp spaced -> contract", "Dev", "Corp to corp engagement.", "contract"},
+		// b2b/c2c are business-model prose far more often than an employment type, so the
+		// bare token must not override an explicit full-time or mislabel an ordinary posting.
+		{"b2b saas business model does not beat full-time", "Backend Engineer", "We build B2B SaaS for enterprises. Full-time, permanent.", "full_time"},
+		{"b2b product prose is not contract", "Engineer", "Join us building a b2b product for enterprises.", ""},
+		{"c2c marketplace is not contract", "Engineer", "We run a C2C marketplace for hobbyists.", ""},
 		{"full time", "Engineer", "Full-time, permanent position.", "full_time"},
 		{"internship beats full-time", "Intern", "A full-time internship for students.", "internship"},
 	}

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -76,17 +76,26 @@ func Parse(location string) Geo {
 			continue
 		}
 		// Dash-delimited exports carry the geography either first ("United
-		// States-Utah-Roy", "TX-Houston") or last ("Nisku-Alberta-Canada"). The
-		// first segment is resolved fully (a leading bare code like "tx" is a real
-		// signal); every other segment is resolved by NAME only, so a 2-letter code
-		// buried in a hyphenated city name ("stoke-on-trent" -> "on") cannot misfire
-		// while a country/region word ("alberta", "canada", "china") still does.
+		// States-Utah-Roy", "TX-Houston") or last ("Nisku-Alberta-Canada"). Every
+		// non-leading segment is resolved by NAME only, so a 2-letter code buried in a
+		// hyphenated city name ("stoke-on-trent" -> "on") cannot misfire while a
+		// country/region word ("alberta", "canada", "china") still does. The leading
+		// segment gets the same name-only treatment first; a bare 2-letter code there
+		// ("tx" in "TX-Houston") is accepted only when a following segment also
+		// resolved — i.e. a real geographic dash-export, not a hyphenated common word
+		// ("in-house", "de-witt") whose first segment merely happens to be a code.
 		// Tried only after the whole token failed, so "cluj-napoca"/"nur-sultan"
 		// (dictionary keys) still win as a unit.
 		if segs := strings.Split(tok, "-"); len(segs) > 1 {
-			resolveGeoToken(strings.TrimSpace(segs[0]), countrySet, regionSet)
+			tailResolved := false
 			for _, seg := range segs[1:] {
-				resolveGeoName(strings.TrimSpace(seg), countrySet, regionSet)
+				if resolveGeoName(strings.TrimSpace(seg), countrySet, regionSet) {
+					tailResolved = true
+				}
+			}
+			lead := strings.TrimSpace(segs[0])
+			if !resolveGeoName(lead, countrySet, regionSet) && tailResolved {
+				resolveGeoToken(lead, countrySet, regionSet)
 			}
 		}
 	}

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -111,6 +111,39 @@ func TestParse(t *testing.T) {
 			location: "Atlantis",
 			want:     Geo{},
 		},
+		{
+			// A hyphenated word whose first segment happens to be a 2-letter code
+			// ("in") must not emit a phantom country: no other segment is geography.
+			name:     "hyphenated word is not a leading bare code",
+			location: "Remote or in-house",
+			want:     Geo{WorkMode: "remote"},
+		},
+		{
+			// "De-Witt" (a place, but not a geo dash-export) must not add a phantom
+			// "de" country; the real "NY" token still resolves.
+			name:     "hyphenated place name keeps only the resolvable token",
+			location: "De-Witt, NY",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
+		},
+		{
+			// A real dash-export with a bare leading code stays resolvable because a
+			// following segment ("houston") is geography that corroborates it.
+			name:     "geographic dash-export with bare leading code preserved",
+			location: "TX-Houston",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
+		},
+		{
+			// Name-leading dash-export is unaffected by the bare-code gate.
+			name:     "geographic dash-export with name leading segment preserved",
+			location: "United States-Utah-Roy",
+			want:     Geo{Countries: []string{"us"}, Regions: []string{"north_america"}},
+		},
+		{
+			// A hyphenated city whose inner segment is a bare code ("on") never misfires.
+			name:     "hyphenated city does not misfire",
+			location: "stoke-on-trent",
+			want:     Geo{},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem (MEDIUM ×2 — from the repo review)

Two deterministic dictionaries violated their own documented "precision over recall / never guess" contract, feeding **wrong values** into served search facets:

1. **`jobfacts.EmploymentType`** — `reContract` matched bare `b2b`/`c2c`, checked *before* full-time. So ordinary IT postings — "We build **B2B** SaaS", "full-time **b2b** product", "**C2C** marketplace" — were labeled `employment_type=contract`, overriding even an explicit full-time signal. B2B/C2C are ubiquitous business-model descriptors, so this corrupted the facet for a large slice of jobs.

2. **`location.Parse`** — on a token that failed to resolve whole, the dash-split resolved the **first** segment via the full `resolveGeoToken`, which accepts a bare 2-letter ISO/subdivision code. A hyphenated word whose first segment happens to be a code misfired: `in-house` → **India/APAC**, `De-Witt, NY` → a phantom **Germany** added to the correct US, `or-*`/`al-*` likewise — silently corrupting the geography facet.

## Fix

**jobfacts** — rather than drop `b2b`/`c2c` (they *do* denote a contractor arrangement in some markets), gate them behind an employment-context anchor (`reContractShorthand`: `C2C candidates`, `B2B contract`, `C2C only`, …) — mirroring the package's existing exclusion of bare `ms`/`bs` degree abbreviations. Unambiguous `1099`/`corp-to-corp` stay in `reContract`.
- `Open to C2C candidates.` → still `contract`
- `B2B SaaS … full-time` → `full_time`; `b2b product` / `C2C marketplace` → unstated

**location** — resolve the leading dash segment by **name only** first; accept a bare code there only when a following segment also resolved (a real geographic dash-export corroborates the code).
- `TX-Houston`, `United States-Utah-Roy` → still `us` / `north_america`
- `in-house`, `De-Witt, NY` (phantom country), `stoke-on-trent` → no misfire

Both stale code comments claiming the old behavior are corrected.

## Verification — TDD (RED → GREEN)

Added failing tests reproducing each false positive, watched them fail, then fixed:
- jobfacts: 3 new cases (b2b-saas / b2b-product / c2c-marketplace) + all 14 existing pass (incl. the preserved `C2C candidates`).
- location: 2 false-positive cases (fail before) + 3 preservation guards (TX-Houston / United States-Utah-Roy / stoke-on-trent) + all pre-existing pass.
- `gofmt` clean, `go build`/`vet`, full unit suite green (45 pkgs, 0 fail).

## Deploy note

These are dictionary changes: **new ingests** get the corrected facet automatically, but existing rows need a re-derive to update — run `cmd/backfill-derive` then `make reindex` (same as any geography/skills dictionary change).

Two commits (one per fix) for independent review.

Generated with assistance from Claude Code.