### PR TITLE
fix(web): reset per-user stores on sign-out to stop cross-user data leaks

### DIFF
--- a/web/src/lib/notifications.svelte.ts
+++ b/web/src/lib/notifications.svelte.ts
@@ -26,6 +26,9 @@ class Notifications {
   #subs = $state.raw<Subscription[]>([]);
   #loaded = false;
   #loading: Promise<void> | null = null;
+  // Bumped by reset(); a load resolving after a reset (a same-tab user handoff) is
+  // discarded instead of repopulating with the previous user's telegram + subs.
+  #generation = 0;
 
   get telegram(): TelegramStatus {
     return this.#telegram;
@@ -45,15 +48,17 @@ class Notifications {
   async ensureLoaded(): Promise<void> {
     if (!browser || this.#loaded) return;
     if (this.#loading) return this.#loading;
+    const gen = this.#generation;
     this.#loading = Promise.all([telegramStatus(), listSubscriptions()])
       .then(([tg, subs]) => {
+        if (gen !== this.#generation) return; // reset() ran mid-load — discard stale state.
         this.#telegram = tg;
         this.#subs = subs;
         this.#loaded = true;
       })
       .catch(() => {})
       .finally(() => {
-        this.#loading = null;
+        if (gen === this.#generation) this.#loading = null;
       });
     return this.#loading;
   }
@@ -94,6 +99,7 @@ class Notifications {
 
   /** Drop cached state on sign-out so the next user loads their own. */
   reset() {
+    this.#generation++;
     this.#telegram = disabled;
     this.#subs = [];
     this.#loaded = false;

--- a/web/src/lib/savedSearches.svelte.ts
+++ b/web/src/lib/savedSearches.svelte.ts
@@ -27,6 +27,9 @@ class SavedSearches {
   #loaded = false;
   // The in-flight load, shared so concurrent callers issue one request.
   #loading: Promise<void> | null = null;
+  // Bumped by reset(); a load resolving after a reset (a same-tab user handoff) is
+  // discarded instead of repopulating the list with the previous user's searches.
+  #generation = 0;
 
   get items(): SavedSearch[] {
     return this.#items;
@@ -37,8 +40,10 @@ class SavedSearches {
   async ensureLoaded(): Promise<void> {
     if (!browser || this.#loaded) return;
     if (this.#loading) return this.#loading;
+    const gen = this.#generation;
     this.#loading = listSavedSearches()
       .then((rows) => {
+        if (gen !== this.#generation) return; // reset() ran mid-load — discard stale rows.
         this.#items = rows;
         this.#loaded = true;
       })
@@ -46,7 +51,7 @@ class SavedSearches {
         // best-effort: a failed load just means the picker is empty.
       })
       .finally(() => {
-        this.#loading = null;
+        if (gen === this.#generation) this.#loading = null;
       });
     return this.#loading;
   }
@@ -93,6 +98,7 @@ class SavedSearches {
    *  session ends, so a different user signing in on the same tab loads their own
    *  searches instead of seeing the previous user's (the list is per-user). */
   reset() {
+    this.#generation++;
     this.#items = [];
     this.#loaded = false;
     this.#loading = null;

--- a/web/src/lib/searchProfiles.svelte.ts
+++ b/web/src/lib/searchProfiles.svelte.ts
@@ -24,6 +24,9 @@ class SearchProfiles {
   #loaded = false;
   // The in-flight load, shared so concurrent callers issue one request.
   #loading: Promise<void> | null = null;
+  // Bumped by reset(); a load resolving after a reset (a same-tab user handoff) is
+  // discarded instead of repopulating the list with the previous user's profiles.
+  #generation = 0;
 
   get items(): SearchProfile[] {
     return this.#items;
@@ -34,8 +37,10 @@ class SearchProfiles {
   async ensureLoaded(): Promise<void> {
     if (!browser || this.#loaded) return;
     if (this.#loading) return this.#loading;
+    const gen = this.#generation;
     this.#loading = listSearchProfiles()
       .then((rows) => {
+        if (gen !== this.#generation) return; // reset() ran mid-load — discard stale rows.
         this.#items = rows;
         this.#loaded = true;
       })
@@ -43,7 +48,7 @@ class SearchProfiles {
         // best-effort: a failed load just means the list is empty.
       })
       .finally(() => {
-        this.#loading = null;
+        if (gen === this.#generation) this.#loading = null;
       });
     return this.#loading;
   }
@@ -76,6 +81,7 @@ class SearchProfiles {
   /** Drop the cached list and the loaded flag. The view calls this when the session
    *  ends, so a different user signing in on the same tab loads their own profiles. */
   reset() {
+    this.#generation++;
     this.#items = [];
     this.#loaded = false;
     this.#loading = null;

--- a/web/src/lib/viewedJobs.svelte.ts
+++ b/web/src/lib/viewedJobs.svelte.ts
@@ -22,6 +22,9 @@ class ViewedJobs {
   #loaded = false;
   // The in-flight load, shared so concurrent callers issue one request.
   #loading: Promise<void> | null = null;
+  // Bumped by reset(); a load that resolves after a reset (a same-tab user handoff)
+  // is discarded instead of repopulating the fresh set.
+  #generation = 0;
 
   has(slug: string): boolean {
     return this.#slugs.has(slug);
@@ -38,8 +41,10 @@ class ViewedJobs {
   async ensureLoaded(): Promise<void> {
     if (!browser || this.#loaded) return;
     if (this.#loading) return this.#loading;
+    const gen = this.#generation;
     this.#loading = listViewedSlugs()
       .then((slugs) => {
+        if (gen !== this.#generation) return; // reset() ran mid-load — discard stale slugs.
         this.#slugs = new SvelteSet(slugs);
         this.#loaded = true;
       })
@@ -47,9 +52,19 @@ class ViewedJobs {
         // best-effort: an unreachable/failed load just means nothing dims.
       })
       .finally(() => {
-        this.#loading = null;
+        if (gen === this.#generation) this.#loading = null;
       });
     return this.#loading;
+  }
+
+  /** Drop the viewed set on sign-out so a different user signing in on the same tab
+   *  can't see the previous user's viewed jobs dimmed — the store is a per-user module
+   *  singleton that survives the soft invalidateAll() on logout. */
+  reset() {
+    this.#generation++;
+    this.#slugs = new SvelteSet();
+    this.#loaded = false;
+    this.#loading = null;
   }
 }
 
@@ -65,4 +80,8 @@ export function markViewed(slug: string) {
 
 export function ensureViewedLoaded(): Promise<void> {
   return viewedJobs.ensureLoaded();
+}
+
+export function resetViewedJobs() {
+  viewedJobs.reset();
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -2,6 +2,11 @@
   import { resolve } from '$app/paths';
   import { onMount } from 'svelte';
   import { initTheme } from '$lib/theme.svelte';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { resetViewedJobs } from '$lib/viewedJobs.svelte';
+  import { savedSearches } from '$lib/savedSearches.svelte';
+  import { searchProfiles } from '$lib/searchProfiles.svelte';
+  import { notifications } from '$lib/notifications.svelte';
   import TopBar from '$lib/components/TopBar.svelte';
   import ProviderIcon from '$lib/components/ProviderIcon.svelte';
   import '../app.css';
@@ -11,6 +16,22 @@
   // Apply the persisted theme and start tracking the OS preference once mounted.
   // A no-FOUC inline script in app.html already set the class before paint.
   onMount(() => initTheme());
+
+  // Drop every per-user store the moment the session ends. logout() re-resolves via
+  // invalidateAll() — a soft client navigation, so these module-singleton stores
+  // survive it and would otherwise show the previous user's data to whoever signs in
+  // next on the same tab. Centralized in the always-mounted root layout so it fires
+  // regardless of route (the per-component load effects only cover their own store
+  // while mounted; viewedJobs, used on /jobs, had no reset at all). Idempotent — a
+  // reset of already-empty stores while signed out is a no-op.
+  $effect(() => {
+    if (!isAuthenticated()) {
+      resetViewedJobs();
+      savedSearches.reset();
+      searchProfiles.reset();
+      notifications.reset();
+    }
+  });
 </script>
 
 <!-- Column layout with min-h-svh (small-viewport height, so the mobile address


### PR DESCRIPTION
## Problem (MEDIUM + 3 LOW — from the repo review, rec #5)

The per-user module-singleton stores — `viewedJobs`, `savedSearches`, `searchProfiles`, `notifications` — survive `logout()` because it re-resolves via `invalidateAll()`, a **soft client navigation, not a full reload**. So after user A signs out and user B signs in on the same tab, B can see A's data.

- **MEDIUM — `viewedJobs` has no `reset()` at all.** It loads the viewed-slug set once (`#loaded` stays `true`) and dims `JobRow` cards by A's slugs for B — a browsing-history leak on `/jobs`, precisely where the sibling stores' components aren't even mounted (so no reset could fire).
- **LOW ×3 — the coupled repopulation bug.** `savedSearches`/`searchProfiles`/`notifications` have `reset()`, but their `ensureLoaded().then` writes `#items`/`#loaded` **unconditionally**. A load still in flight when `reset()` runs repopulates the store with the previous user's data and re-marks it loaded — defeating the reset.

These are causally linked: a sign-out reset is worthless if an in-flight `.then` immediately repopulates.

## Fix (root cause)

- **Centralize teardown** in the always-mounted root layout (`+layout.svelte`): one `$effect` resets all four stores whenever the session is not authenticated, so it fires on **every** sign-out regardless of route (idempotent while signed out). This is the single source of truth the review recommended; the scattered per-component resets only covered their own store while mounted.
- **Add `reset()` + generation guard to `viewedJobs`.**
- **Generation guard on every store**: `ensureLoaded()` captures the generation before the request; the `.then`/`.finally` bail if `reset()` bumped it — a load resolving after a reset is discarded instead of writing into the fresh state.

The existing per-component resets are left in place (now redundant but harmless/idempotent) to keep the change surgical.

## Verification

`web/` has no runtime test runner, so verified by:
- `svelte-check` — 0 errors, 0 warnings (baseline also clean).
- `eslint` on the changed files — clean.
- `npm run build` (adapter-node) — succeeds; the new `$effect` and runes compile.
- Reasoning traced against the exact leak paths; the generation-guard mirrors the store lifecycle already proven for the three siblings' `reset()`.

Diff: 5 files, +62/-4.

Generated with assistance from Claude Code.