### PR TITLE
fix(telegramnotify): cap digest to Telegram's 4096-char sendMessage limit

### DIFF
--- a/internal/telegramnotify/notifier.go
+++ b/internal/telegramnotify/notifier.go
@@ -6,9 +6,13 @@ import (
 	"html"
 	"strconv"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/strelov1/freehire/internal/notify"
 )
+
+// telegramMaxLen is Telegram's sendMessage text limit, measured in UTF-16 code units.
+const telegramMaxLen = 4096
 
 // Compile-time guarantee that Notifier satisfies the channel abstraction.
 var _ notify.Notifier = (*Notifier)(nil)
@@ -42,21 +46,62 @@ func (n *Notifier) Send(ctx context.Context, _ string, dest string, d notify.Dig
 // render builds the HTML message body. Job titles, company names, and the saved
 // search name are HTML-escaped (they are user/source data); the freehire URL is
 // our own and safe.
+//
+// The body is capped to Telegram's telegramMaxLen: job lines are added until the
+// next one (plus the largest possible "+ N more" tail) would overflow, then the
+// tail absorbs the remainder. Without the cap a digest of many long-title jobs
+// exceeds the limit, Telegram rejects the send deterministically, every retry
+// re-fails, and the whole batch is dead-lettered — silently dropping the user's
+// notifications.
 func (n *Notifier) render(d notify.Digest) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "🔔 <b>%d</b> new job%s for %q\n\n", d.Total, plural(d.Total), html.EscapeString(d.SavedSearchName))
+
+	// Reserve room for the widest possible tail up front (d.Total is its worst-case
+	// count), so appending the actual tail after the loop can never push past the limit.
+	tailReserve := utf16Len(moreLine(d.Total))
+	used := utf16Len(b.String())
+	shown := 0
 	for _, j := range d.Jobs {
-		link := n.jobBaseURL + "/jobs/" + j.Slug
-		fmt.Fprintf(&b, "• <a href=%q>%s</a>", link, html.EscapeString(j.Title))
-		if j.Company != "" {
-			fmt.Fprintf(&b, " — %s", html.EscapeString(j.Company))
+		line := n.jobLine(j)
+		lineLen := utf16Len(line)
+		if used+lineLen+tailReserve > telegramMaxLen {
+			break
 		}
-		b.WriteByte('\n')
+		b.WriteString(line)
+		used += lineLen
+		shown++
 	}
-	if more := d.Total - len(d.Jobs); more > 0 {
-		fmt.Fprintf(&b, "\n+ %d more", more)
+	if more := d.Total - shown; more > 0 {
+		b.WriteString(moreLine(more))
 	}
 	return b.String()
+}
+
+// jobLine renders one digest job: a bullet linking to the freehire job page, with
+// an optional " — Company" suffix. Title and company are HTML-escaped.
+func (n *Notifier) jobLine(j notify.DigestJob) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "• <a href=%q>%s</a>", n.jobBaseURL+"/jobs/"+j.Slug, html.EscapeString(j.Title))
+	if j.Company != "" {
+		fmt.Fprintf(&b, " — %s", html.EscapeString(j.Company))
+	}
+	b.WriteByte('\n')
+	return b.String()
+}
+
+// moreLine is the "+ N more" overflow tail, or "" when nothing is omitted.
+func moreLine(more int) string {
+	if more <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("\n+ %d more", more)
+}
+
+// utf16Len counts s in UTF-16 code units — the unit Telegram measures a message
+// against — so a supplementary-plane rune (e.g. the 🔔 emoji) correctly counts as two.
+func utf16Len(s string) int {
+	return len(utf16.Encode([]rune(s)))
 }
 
 func plural(n int) string {

--- a/internal/telegramnotify/notifier_test.go
+++ b/internal/telegramnotify/notifier_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/strelov1/freehire/internal/notify"
 )
@@ -50,6 +51,36 @@ func TestNotifier_RenderSingularNoOverflow(t *testing.T) {
 	got := n.render(notify.Digest{SavedSearchName: "x", Total: 1, Jobs: []notify.DigestJob{{Title: "A", Slug: "a"}}})
 	if !strings.Contains(got, "<b>1</b> new job for") || strings.Contains(got, "more") {
 		t.Errorf("singular render wrong: %q", got)
+	}
+}
+
+// A digest of many long-title jobs must stay within Telegram's 4096-code-unit
+// sendMessage limit — otherwise the send fails deterministically, every retry
+// re-fails, and the whole batch is dead-lettered (the user loses all of it). The
+// jobs that don't fit fall into the "+ N more" tail, and none are lost.
+func TestNotifier_RenderCapsAtTelegramLimit(t *testing.T) {
+	n := NewNotifier(NewClient("t"), "https://freehire.dev")
+	const total = 20                                                              // DigestCap
+	longTitle := strings.Repeat("Senior Staff Platform Reliability Engineer ", 6) // ~258 chars
+	jobs := make([]notify.DigestJob, total)
+	for i := range jobs {
+		jobs[i] = notify.DigestJob{
+			Title:   longTitle,
+			Company: "A Rather Long Company Name Incorporated",
+			Slug:    strings.Repeat("some-long-job-slug-", 5),
+		}
+	}
+	got := n.render(notify.Digest{SavedSearchName: "big search", Total: total, Jobs: jobs})
+
+	if n16 := len(utf16.Encode([]rune(got))); n16 > 4096 {
+		t.Errorf("rendered %d UTF-16 units, want <= 4096 (Telegram sendMessage limit)", n16)
+	}
+	shown := strings.Count(got, "• ")
+	if shown == 0 || shown >= total {
+		t.Errorf("shown = %d, want some-but-not-all of %d jobs listed", shown, total)
+	}
+	if !strings.Contains(got, "more") {
+		t.Errorf("dropped jobs must be summarized by a '+ N more' tail: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Problem (MEDIUM — from the repo review)

`render()` built the digest from up to `DigestCap=20` job lines with **no length bound**. A digest of many long-title jobs exceeds Telegram's **4096-code-unit** `sendMessage` limit. Telegram then rejects the send deterministically → every retry re-renders the identical over-length message and re-fails → after `MaxAttempts` the whole batch of matches is dead-lettered (`failed_at`). The user **silently loses all of those notifications**, having re-failed on every cron pass in between.

## Fix

Cap the body to `telegramMaxLen` (4096): add job lines until the next one **plus the widest possible `"+ N more"` tail** would overflow, then let the tail absorb the remainder. No job is lost — every omitted one is counted in `"+ N more"`.

Length is measured in **UTF-16 code units** (`utf16Len` via `utf16.Encode`), the unit Telegram counts, so the `🔔` emoji and any non-BMP text are accounted correctly rather than under-counted as Go bytes/runes.

`render`'s per-job formatting is extracted to `jobLine`, and the tail to `moreLine`.

## Verification — TDD (RED → GREEN)

- New `TestNotifier_RenderCapsAtTelegramLimit`: a 20×(~258-char title) digest rendered **8820** units before the fix (RED); now `<= 4096` with `0 < shown < 20` and a non-empty `"+ N more"` tail (GREEN, no job lost).
- Existing render tests (heading, HTML-escaping, company-less line, `+ 1 more`, singular no-overflow) still pass — small digests are unchanged.
- `gofmt`/`go build`/`go vet`, `telegramnotify` + `notify` suites green.

Generated with assistance from Claude Code.