### PR TITLE
fix(config): bump default JWT_SECRET to >=32 bytes so `make up` boots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,9 @@ DATABASE_URL=postgres://hire:hire@localhost:5432/hire?sslmode=disable
 # per-provider callback URL: <origin>/api/v1/auth/oauth/<provider>/callback
 FRONTEND_ORIGIN=http://localhost:5173
 
-# Auth: JWT signing secret (required — the server fails fast if empty) and
-# session TTL. Set a strong random JWT_SECRET in any non-local deployment.
-JWT_SECRET=dev-insecure-secret-change-me
+# Auth: JWT signing secret (required — the server fails fast if unset or under
+# 32 bytes) and session TTL. Set a strong random JWT_SECRET in any non-local deployment.
+JWT_SECRET=dev-insecure-secret-change-me-0123456789
 # JWT_TTL=24h
 # Mark the session cookie Secure (set true on any HTTPS deployment)
 # COOKIE_SECURE=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,9 +35,9 @@ services:
     environment:
       PORT: "8080"
       DATABASE_URL: "postgres://hire:hire@db:5432/hire?sslmode=disable"
-      # Required by the auth surface (server fails fast if empty). Dev default —
-      # set a real JWT_SECRET in any non-local deployment.
-      JWT_SECRET: "${JWT_SECRET:-dev-insecure-secret-change-me}"
+      # Required by the auth surface (server fails fast if unset or under 32 bytes).
+      # Dev default — set a real, random JWT_SECRET in any non-local deployment.
+      JWT_SECRET: "${JWT_SECRET:-dev-insecure-secret-change-me-0123456789}"
       # OAuth callbacks redirect the browser back to this origin; it also
       # derives the per-provider callback URL registered at each provider.
       FRONTEND_ORIGIN: "${FRONTEND_ORIGIN:-http://localhost:5173}"


### PR DESCRIPTION
## Problem (MEDIUM — from the repo review)

`cmd/server/main.go` fails fast when `JWT_SECRET` is under 32 bytes:

```go
if len(cfg.JWTSecret) < 32 { log.Fatal("config: JWT_SECRET is required and must be at least 32 bytes") }
```

But the `docker-compose.yml` default and the identical `.env.example` value were `dev-insecure-secret-change-me` — **29 bytes**. The length gate was added after the compose default was set, and the default was never bumped. So the documented `make up` bootstrap (no `.env`) resolves `JWT_SECRET` to a 29-byte value, the app container `log.Fatal`s on startup, and the web container serves 502s on `/api`. The out-of-the-box dev path never yields a running backend.

## Fix

Pad both defaults to a 40-byte placeholder (`dev-insecure-secret-change-me-0123456789`), keeping the two in sync. Real deployments still override it (the comment already says so, now noting the ≥32-byte requirement).

## Verification

- `printf` confirms the new default is 40 bytes (≥ 32).
- `docker compose config` with **no** `.env` present resolves `JWT_SECRET` to the 40-byte default (the `${JWT_SECRET:-…}` fallback), clearing the boot gate — i.e. the exact failing `make up` scenario now passes.
- `docker compose config -q` — YAML valid.

Generated with assistance from Claude Code.