### PR TITLE
fix(skilltag): stop "objective-c" leaking a bare "c" skill tag

### DIFF
--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -35,6 +35,8 @@ func TestParse(t *testing.T) {
 		{"multiword", "React Native and CI/CD pipelines", []string{"ci-cd", "react", "react-native"}},
 		{"ambiguous word rejected", "Please go to the careers page in C.", nil},
 		{"ambiguous via qualifier", "5y as a C developer", []string{"c"}},
+		{"objective-c does not leak bare c", "Objective-C developer", []string{"objective-c"}},
+		{"objective-c alongside real C still tags both", "Objective-C and C developer", []string{"c", "objective-c"}},
 		{"word boundary", "a reaction to going rusty", nil},
 		{"html stripped", "<p>Kubernetes</p><a href='k8s'>k8s</a>", []string{"kubernetes"}},
 		{"empty", "", nil},

--- a/internal/wordmatch/wordmatch.go
+++ b/internal/wordmatch/wordmatch.go
@@ -1,7 +1,7 @@
 // Package wordmatch reports whether a term occurs as a standalone token in a
 // string. The scan is shared; the notion of a token boundary is supplied by the
 // caller (Unicode letters/digits for title classification, ASCII alphanumerics —
-// with a leading-dot guard — for skill tags), so the two dictionaries that need
+// with a leading dot/hyphen guard — for skill tags), so the two dictionaries that need
 // whole-word matching no longer hand-roll the same loop.
 package wordmatch
 
@@ -64,11 +64,12 @@ func isWordRune(r rune) bool {
 }
 
 // ASCIIBoundary treats ASCII alphanumerics as word bytes, with one asymmetry: a
-// LEADING '.' is not a valid left boundary (the term is the suffix of a larger
-// dotted token, e.g. "asp.net" must not match ".net"), while a TRAILING '.' is a
-// sentence period and is a valid right boundary ("We use C#.").
+// LEADING '.' or '-' is not a valid left boundary (the term is the suffix of a
+// larger punctuated token — "asp.net" must not match ".net", "objective-c" must not
+// match "c developer"), while a TRAILING '.' is a sentence period and is a valid
+// right boundary ("We use C#.").
 func ASCIIBoundary(s string, start, end int) bool {
-	if alnumAt(s, start-1) || byteAt(s, start-1) == '.' {
+	if alnumAt(s, start-1) || byteAt(s, start-1) == '.' || byteAt(s, start-1) == '-' {
 		return false
 	}
 	return !alnumAt(s, end)


### PR DESCRIPTION
## Problem (LOW — from the repo review)

The ambiguous canonical `c` is deliberately emitted only via unambiguous phrase aliases (`"c developer"`, `"c programming"`, `"ansi c"`). But `wordmatch.ASCIIBoundary` rejected a leading `.` yet **accepted a leading `-`**, so `"c developer"` matched as the suffix of `"objective-c developer"` — tagging an Objective-C posting with both `objective-c` and a spurious `c`. That `c` then wrongly matches a `skills=c` (C language) search filter.

## Fix

Extend the leading-boundary guard — which already rejects `.` so `"asp.net"` doesn't match `".net"` — to also reject `-`: a term that is the tail of a hyphenated compound token is not a standalone occurrence. `ASCIIBoundary` is used **only** by skilltag's phrase pass (word aliases tokenize on `-` before matching), so the blast radius is skill phrases.

## Verification — TDD (RED → GREEN)

- `"Objective-C developer"` → `["c","objective-c"]` before (RED) → `["objective-c"]` after.
- Preservation: `"Objective-C and C developer"` still → `["c","objective-c"]` (the real "C developer" has a space, not a hyphen, on its left).
- Full `skilltag` + `wordmatch` corpora stay green (no other phrase relied on a post-hyphen match); `gofmt`/`build`/`vet` clean.

Generated with assistance from Claude Code.