### PR TITLE
fix(db): reset liveness_strikes when an upsert reopens a closed job

### DIFF
--- a/internal/db/job_liveness_integration_test.go
+++ b/internal/db/job_liveness_integration_test.go
@@ -85,6 +85,54 @@ func TestLivenessHealthyProbeResetsStrikes(t *testing.T) {
 	}
 }
 
+// A reopened orphan job must start its liveness strike count fresh. After two
+// strikes close it, re-ingesting the same posting sets closed_at = NULL and must
+// also reset liveness_strikes, so a single later expired probe records strike 1 and
+// leaves it open instead of immediately re-closing it — the two-strike grace
+// survives a reopen.
+func TestLivenessReopenResetsStrikes(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	job, err := ingestUpsert(ctx, q, orphanParams("tg:1", "Orphan"))
+	if err != nil {
+		t.Fatalf("upsert orphan: %v", err)
+	}
+	if _, err := q.MarkLivenessExpired(ctx, MarkLivenessExpiredParams{ID: job.ID, Threshold: 2}); err != nil {
+		t.Fatalf("first expired: %v", err)
+	}
+	closed, err := q.MarkLivenessExpired(ctx, MarkLivenessExpiredParams{ID: job.ID, Threshold: 2})
+	if err != nil {
+		t.Fatalf("second expired: %v", err)
+	}
+	if !closed.ClosedAt.Valid || closed.LivenessStrikes != 2 {
+		t.Fatalf("setup: want closed with 2 strikes, got closed=%v strikes=%d", closed.ClosedAt.Valid, closed.LivenessStrikes)
+	}
+
+	// Re-ingest the same posting: it reopens (closed_at = NULL) and strikes reset.
+	reopened, err := ingestUpsert(ctx, q, orphanParams("tg:1", "Orphan"))
+	if err != nil {
+		t.Fatalf("re-ingest: %v", err)
+	}
+	if reopened.ClosedAt.Valid {
+		t.Fatal("re-ingest must reopen the job")
+	}
+	if reopened.LivenessStrikes != 0 {
+		t.Fatalf("reopen must reset liveness_strikes, got %d", reopened.LivenessStrikes)
+	}
+
+	// One expired probe now only records strike 1 and leaves the job open.
+	after, err := q.MarkLivenessExpired(ctx, MarkLivenessExpiredParams{ID: job.ID, Threshold: 2})
+	if err != nil {
+		t.Fatalf("post-reopen expired: %v", err)
+	}
+	if after.LivenessStrikes != 1 || after.ClosedAt.Valid {
+		t.Fatalf("after reopen, one probe must not re-close: strikes=%d closed=%v", after.LivenessStrikes, after.ClosedAt.Valid)
+	}
+}
+
 func TestSelectOrphanLivenessCandidatesExcludesBoardAndClosed(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1019,9 +1019,12 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     experience_years_min = EXCLUDED.experience_years_min,
     remote_unspecified   = EXCLUDED.remote_unspecified,
     content_hash = EXCLUDED.content_hash,
-    -- The crawl saw the posting: refresh liveness and reopen if it was closed.
+    -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
+    -- reopen (the row was closed) resets the strike count so a single later expired
+    -- probe can't immediately re-close it — the two-strike grace survives a reopen.
     last_seen_at = now(),
     closed_at    = NULL,
+    liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
 RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.remote_unspecified,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
@@ -1195,7 +1198,10 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     experience_years_min = EXCLUDED.experience_years_min,
     remote_unspecified   = EXCLUDED.remote_unspecified,
     updated_by   = $24::bigint,
+    -- A moderator re-create reopens the job; reset the strike count too so the
+    -- two-strike liveness grace survives a reopen (see UpsertJob).
     closed_at    = NULL,
+    liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
 RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
 `

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -155,9 +155,12 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     experience_years_min = EXCLUDED.experience_years_min,
     remote_unspecified   = EXCLUDED.remote_unspecified,
     content_hash = EXCLUDED.content_hash,
-    -- The crawl saw the posting: refresh liveness and reopen if it was closed.
+    -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
+    -- reopen (the row was closed) resets the strike count so a single later expired
+    -- probe can't immediately re-close it — the two-strike grace survives a reopen.
     last_seen_at = now(),
     closed_at    = NULL,
+    liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
 RETURNING sqlc.embed(jobs),
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
@@ -232,7 +235,10 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     experience_years_min = EXCLUDED.experience_years_min,
     remote_unspecified   = EXCLUDED.remote_unspecified,
     updated_by   = sqlc.arg(updated_by)::bigint,
+    -- A moderator re-create reopens the job; reset the strike count too so the
+    -- two-strike liveness grace survives a reopen (see UpsertJob).
     closed_at    = NULL,
+    liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
 RETURNING *;
 


### PR DESCRIPTION
## Problem (LOW — from the repo review)

`UpsertJob` and `UpsertManualJob` reopen a closed job (`closed_at = NULL`) but left `liveness_strikes` untouched. So a reopened **orphan-source** job (moderator re-create via `UpsertManualJob`, or `geekjob`) carried its old strike count. On the next `cmd/liveness` run, a single `Expired` verdict computed `strikes+1 >= threshold(2)` and **immediately re-closed** it — bypassing the two-consecutive-strikes grace that exists to absorb one transient death signal (a momentary JS-shell read as `insufficient_content`, or a 404 during a redeploy).

## Fix

Reset `liveness_strikes` in both `DO UPDATE SET`s, gated on an **actual reopen**:

```sql
liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END
```

So a reopened job starts fresh, while an in-progress strike on a still-open job re-upserted mid-cycle is preserved (not erased). Regenerated sqlc.

## Verification — TDD (RED → GREEN), integration

New `TestLivenessReopenResetsStrikes` (`//go:build integration`, testcontainers): an orphan closed by two strikes, then re-ingested —
- **RED** (before): `reopen must reset liveness_strikes, got 2`.
- **GREEN** (after): reopen → `strikes = 0`, still open; one later expired probe records strike 1 and leaves it open (grace restored).

Full `go test -tags=integration ./internal/db/` suite green (all other UpsertJob-based tests unaffected); `go vet`, `gofmt` clean.

Generated with assistance from Claude Code.