### PR TITLE
fix(accounts): recover the OAuth same-email race instead of hard-failing

### DIFF
--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -42,6 +42,14 @@ var (
 	// callback already inserted the same identity row (unique violation).
 	ErrIdentityConflict = errors.New("accounts: identity already exists")
 
+	// ErrEmailRace is returned by the repository when link-or-create lost a race on
+	// the user email index: a concurrent callback created the account under the same
+	// verified email (but a different identity) first, so our identity was never
+	// inserted. Distinct from ErrIdentityConflict because the recovery differs — the
+	// service retries the link to attach our identity to the now-existing account,
+	// rather than looking up an identity that does not exist.
+	ErrEmailRace = errors.New("accounts: email create race")
+
 	// ErrNoVerifiedEmail is returned by the service when the caller does not
 	// supply a verified, non-empty email — a hard requirement before linking or
 	// creating an account (unverified email is an account-takeover vector).
@@ -116,12 +124,27 @@ func (s *Service) ResolveOAuthAccount(
 
 	// 3. link existing account by email or create a new passwordless account.
 	id, err = s.repo.LinkOrCreateByEmail(ctx, provider, providerUserID, normalized)
-	if errors.Is(err, ErrIdentityConflict) {
-		// 4. lost a race with a concurrent callback — the identity now exists;
-		// return whichever goroutine won.
+	switch {
+	case err == nil:
+		return id, nil
+	case errors.Is(err, ErrIdentityConflict):
+		// 4a. lost a race with a concurrent callback for the SAME identity — it now
+		// exists; return whichever goroutine won.
 		return s.repo.UserIDByIdentity(ctx, provider, providerUserID)
+	case errors.Is(err, ErrEmailRace):
+		// 4b. lost a race with a concurrent callback that created the account under
+		// the same verified email but a DIFFERENT identity, so our identity was never
+		// inserted. Retry the link now that the account exists, so our identity
+		// attaches to it (a bare UserIDByIdentity retry would miss — it isn't there).
+		id, err = s.repo.LinkOrCreateByEmail(ctx, provider, providerUserID, normalized)
+		if errors.Is(err, ErrIdentityConflict) {
+			// A further concurrent callback inserted our identity in the meantime.
+			return s.repo.UserIDByIdentity(ctx, provider, providerUserID)
+		}
+		return id, err
+	default:
+		return 0, err
 	}
-	return id, err
 }
 
 // Register creates a new account with the given email and password.

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -267,6 +267,35 @@ func TestResolveOAuthAccount_Race_RetryFails(t *testing.T) {
 	}
 }
 
+// (g) email race: a concurrent callback for the SAME verified email under a
+// DIFFERENT identity created the account first, so our LinkOrCreateByEmail lost on
+// the user email index (ErrEmailRace) and never inserted our identity. The service
+// retries the link — which now finds the account by email and attaches our identity
+// — instead of failing the callback with ?auth_error=oauth.
+func TestResolveOAuthAccount_EmailRace_LinksToWinner(t *testing.T) {
+	repo := &fakeRepo{
+		identityResults: []idResult{
+			{id: 0, err: ErrIdentityNotFound}, // first identity lookup misses
+		},
+		linkResults: []linkResult{
+			{id: 0, err: ErrEmailRace}, // lost the email-create race
+			{id: 7, err: nil},          // retry links our identity to the winner's account
+		},
+	}
+	svc := New(repo, &fakeHasher{})
+
+	id, err := svc.ResolveOAuthAccount(context.Background(), "github", "ghid-9", "shared@example.com", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != 7 {
+		t.Errorf("want id=7 (identity linked to the winner's account), got %d", id)
+	}
+	if len(repo.linkCalls) != 2 {
+		t.Errorf("want 2 LinkOrCreateByEmail calls (initial + retry), got %d", len(repo.linkCalls))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Register tests
 // ---------------------------------------------------------------------------

--- a/internal/accounts/repository.go
+++ b/internal/accounts/repository.go
@@ -46,8 +46,11 @@ func (r *QueriesRepository) UserIDByIdentity(ctx context.Context, provider, prov
 
 // LinkOrCreateByEmail links the given identity to the account with the
 // supplied (already-lowercased) email, creating a passwordless account when
-// none exists. The operation runs in a single transaction. It returns
-// ErrIdentityConflict on a unique-violation (concurrent callback race).
+// none exists. The operation runs in a single transaction. A concurrent-callback
+// race surfaces as one of two distinct errors: ErrEmailRace when the account was
+// created first under the same email (our CreateUser lost the email index, so our
+// identity was never inserted), or ErrIdentityConflict when our exact identity was
+// inserted first. The service recovers from each differently.
 func (r *QueriesRepository) LinkOrCreateByEmail(
 	ctx context.Context,
 	provider, providerUserID, email string,
@@ -73,7 +76,9 @@ func (r *QueriesRepository) LinkOrCreateByEmail(
 		})
 		if err != nil {
 			if isUniqueViolation(err) {
-				return 0, ErrIdentityConflict
+				// users has a single unique index (lower(email)), so this can only be
+				// a concurrent account creation for the same email — not our identity.
+				return 0, ErrEmailRace
 			}
 			return 0, err
 		}


### PR DESCRIPTION
## Problem (LOW — from the repo review)

In `LinkOrCreateByEmail`, a unique violation from `CreateUser` can only be the `users` `lower(email)` index — i.e. a **concurrent callback created the account for the same verified email first**. But it was mislabeled `ErrIdentityConflict`, so `ResolveOAuthAccount` retried `UserIDByIdentity` — and our identity was **never inserted** (the transaction aborted at `CreateUser`, before `CreateUserIdentity`). The retry returned `ErrIdentityNotFound`, so the OAuth callback failed hard (302 `?auth_error=oauth`).

**Trigger:** two first-time OAuth sign-ins for one verified email via *different* providers (e.g. Google + GitHub), arriving between the loser's empty `GetUserByEmail` and the winner's commit. It self-healed only on a manual retry; the correct outcome is to link the loser's identity to the now-existing account.

## Fix

Distinguish the two races at the source:
- `CreateUser`'s email-index violation → new **`ErrEmailRace`** (our identity was never inserted).
- `CreateUserIdentity` / commit violation → still `ErrIdentityConflict` (our exact identity exists).

`ResolveOAuthAccount` recovers from each differently:
- `ErrIdentityConflict` → retry `UserIDByIdentity` (unchanged).
- `ErrEmailRace` → retry `LinkOrCreateByEmail`, which now finds the account by email and attaches our identity (falling back to `UserIDByIdentity` only if a further concurrent callback inserted our identity meanwhile).

## Verification — TDD (RED → GREEN)

- New `TestResolveOAuthAccount_EmailRace_LinksToWinner`: `LinkOrCreateByEmail` returns `ErrEmailRace` then succeeds on retry → service returns the linked id (RED: `unexpected error: accounts: email create race` before the fix).
- Existing `Race_ReturnsWinner` / `Race_RetryFails` (same-identity paths) unchanged and green.
- Full unit suite green (45 pkgs), `go vet`/`gofmt` clean.

Note: the fix is exercised by the service-level unit test with a fake repository (the true concurrent DB race is non-deterministic); the repository relabel (`CreateUser` 23505 → `ErrEmailRace`) is a one-line change guarded by the single-unique-index invariant.

Generated with assistance from Claude Code.