### PR TITLE
fix(sources): fetch all Work at a Startup jobs past Algolia's distinct + 1000 cap

### DIFF
--- a/internal/sources/workatastartup.go
+++ b/internal/sources/workatastartup.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	neturl "net/url"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -18,20 +19,27 @@ import (
 // With the key, the index is queried directly — every hit carries the full posting (company,
 // title, markdown description, location, remote, date), so there is no per-job detail call.
 //
-// Coverage caveat: Algolia caps offset pagination at 1000 hits per query (paginationLimitedTo),
-// while the index holds somewhat more; a single sweep therefore returns the first 1000 and
-// logs how many it left behind rather than silently truncating.
+// Two Algolia quirks shape the crawl. (1) The index defaults to distinct-by-company, collapsing
+// its ~5k postings to one-per-company (~1.3k); every query therefore sets distinct=false so all
+// postings are visible. (2) Offset pagination is capped at 1000 hits (paginationLimitedTo), well
+// under the full count, so a single sweep would silently truncate. Instead the crawl bisects the
+// id space: each query filters a half-open [lo, hi) id window and, whenever a window still fills
+// a page, splits it in half and recurses. Because id is unique per posting, a width-1 window
+// holds at most one hit, so the recursion always terminates and reaches every posting — the
+// standard workaround for the offset cap, with id (unique, numeric, filterable) as the key.
 type workatastartup struct {
 	http HeaderJSONPoster
 }
 
 const (
-	waasKeyEnv      = "WAAS_ALGOLIA_KEY"
-	waasAlgoliaApp  = "45BWZJ1SGC"
-	waasAlgoliaIdx  = "WaaSPublicCompanyJob_production"
+	waasKeyEnv     = "WAAS_ALGOLIA_KEY"
+	waasAlgoliaApp = "45BWZJ1SGC"
+	waasAlgoliaIdx = "WaaSPublicCompanyJob_production"
+	// waasHitsPerPage is Algolia's max page size and its offset-pagination cap (paginationLimitedTo):
+	// a window returning a full page is assumed to hold more and gets bisected.
 	waasHitsPerPage = 1000
-	// waasMaxPages bounds pagination; Algolia's 1000-hit cap means this is rarely > 1.
-	waasMaxPages = 5
+	// waasIDProbeBase seeds the exponential search for the id upper bound; current ids are ~1e5.
+	waasIDProbeBase = 1 << 16
 )
 
 // NewWorkAtAStartup builds the Work at a Startup adapter over the given HTTP client.
@@ -44,16 +52,19 @@ func (workatastartup) boardless() {}
 func (workatastartup) aggregator() {}
 
 // waasHit is one job from the Algolia index, body inline (no detail call). remote is
-// "no" | "yes" | "only"; search_path is the canonical job URL.
+// "no" | "yes" | "only"; search_path is the canonical job URL. locations_for_search is
+// heterogeneous — usually []string, but some records carry nested-array garbage (e.g.
+// [[[["Remote"]]], "Remote"]) — so it decodes as raw elements and firstLocation picks the
+// first scalar (see toJob).
 type waasHit struct {
-	ID               json.Number `json:"id"`
-	Title            string      `json:"title"`
-	Description      string      `json:"description"`
-	Remote           string      `json:"remote"`
-	CreatedAt        string      `json:"created_at"`
-	CompanyName      string      `json:"company_name"`
-	LocationsForSrch []string    `json:"locations_for_search"`
-	SearchPath       string      `json:"search_path"`
+	ID               json.Number       `json:"id"`
+	Title            string            `json:"title"`
+	Description      string            `json:"description"`
+	Remote           string            `json:"remote"`
+	CreatedAt        string            `json:"created_at"`
+	CompanyName      string            `json:"company_name"`
+	LocationsForSrch []json.RawMessage `json:"locations_for_search"`
+	SearchPath       string            `json:"search_path"`
 }
 
 func (s workatastartup) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
@@ -67,32 +78,72 @@ func (s workatastartup) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error
 	}
 	url := fmt.Sprintf("https://%s-dsn.algolia.net/1/indexes/%s/query", waasAlgoliaApp, waasAlgoliaIdx)
 
-	var jobs []Job
-	for page := 0; page < waasMaxPages; page++ {
-		body := map[string]any{"params": fmt.Sprintf("hitsPerPage=%d&page=%d&query=", waasHitsPerPage, page)}
-		var resp struct {
-			Hits    []waasHit `json:"hits"`
-			NbHits  int       `json:"nbHits"`
-			NbPages int       `json:"nbPages"`
+	// Find an id upper bound: the smallest power-of-two past every posting's id. Exponential so it
+	// self-adjusts as ids grow, with no hard-coded ceiling that could one day silently truncate.
+	hi := int64(waasIDProbeBase)
+	for {
+		hits, err := s.query(ctx, headers, url, hi, -1, 1)
+		if err != nil {
+			return nil, err
 		}
-		if err := s.http.PostJSONWithHeaders(ctx, url, headers, body, &resp); err != nil {
-			return nil, fmt.Errorf("workatastartup: page %d: %w", page, err)
-		}
-		for _, h := range resp.Hits {
-			if job, ok := h.toJob(); ok {
-				jobs = append(jobs, job)
-			}
-		}
-		if page == 0 && resp.NbHits > len(resp.Hits) {
-			// Algolia's 1000-hit pagination cap: report what the sweep cannot reach.
-			log.Printf("workatastartup: index has %d jobs, retrievable cap is %d — %d not fetched this run",
-				resp.NbHits, len(resp.Hits)*max(resp.NbPages, 1), resp.NbHits-len(resp.Hits)*max(resp.NbPages, 1))
-		}
-		if page+1 >= resp.NbPages || len(resp.Hits) == 0 {
+		if len(hits) == 0 {
 			break
 		}
+		hi *= 2
+	}
+
+	var jobs []Job
+	if err := s.collect(ctx, headers, url, 0, hi, &jobs); err != nil {
+		return nil, err
 	}
 	return jobs, nil
+}
+
+// collect gathers every posting whose id is in the half-open window [lo, hi), recursively
+// bisecting a window that still fills a page (so more remain past the offset cap). id uniqueness
+// guarantees termination: a width-1 window holds at most one hit.
+func (s workatastartup) collect(ctx context.Context, headers map[string]string, url string, lo, hi int64, out *[]Job) error {
+	hits, err := s.query(ctx, headers, url, lo, hi, waasHitsPerPage)
+	if err != nil {
+		return err
+	}
+	if len(hits) < waasHitsPerPage || hi-lo <= 1 {
+		for _, h := range hits {
+			if job, ok := h.toJob(); ok {
+				*out = append(*out, job)
+			}
+		}
+		return nil
+	}
+	mid := lo + (hi-lo)/2
+	if err := s.collect(ctx, headers, url, lo, mid, out); err != nil {
+		return err
+	}
+	return s.collect(ctx, headers, url, mid, hi, out)
+}
+
+// query runs one Algolia search over the id window with distinct off (the index defaults to
+// distinct-by-company, which would hide most postings). hi < 0 means an open upper bound (used to
+// probe for postings at or above lo); otherwise the window is half-open [lo, hi).
+func (s workatastartup) query(ctx context.Context, headers map[string]string, url string, lo, hi int64, hitsPerPage int) ([]waasHit, error) {
+	filters := fmt.Sprintf(`["id>=%d","id<%d"]`, lo, hi)
+	if hi < 0 {
+		filters = fmt.Sprintf(`["id>=%d"]`, lo)
+	}
+	p := neturl.Values{}
+	p.Set("query", "")
+	p.Set("distinct", "false")
+	p.Set("hitsPerPage", strconv.Itoa(hitsPerPage))
+	p.Set("numericFilters", filters)
+
+	body := map[string]any{"params": p.Encode()}
+	var resp struct {
+		Hits []waasHit `json:"hits"`
+	}
+	if err := s.http.PostJSONWithHeaders(ctx, url, headers, body, &resp); err != nil {
+		return nil, fmt.Errorf("workatastartup: id window [%d,%d): %w", lo, hi, err)
+	}
+	return resp.Hits, nil
 }
 
 // toJob maps an Algolia hit to a Job, returning ok=false for an unusable hit (no id, which
@@ -103,10 +154,7 @@ func (h waasHit) toJob() (Job, bool) {
 	if id == "" || id == "0" || h.CompanyName == "" {
 		return Job{}, false
 	}
-	location := ""
-	if len(h.LocationsForSrch) > 0 {
-		location = h.LocationsForSrch[0]
-	}
+	location := firstLocation(h.LocationsForSrch)
 	url := h.SearchPath
 	if url == "" {
 		url = fmt.Sprintf("https://www.workatastartup.com/jobs/%s", id)
@@ -123,6 +171,18 @@ func (h waasHit) toJob() (Job, bool) {
 		WorkMode:    workMode,
 		PostedAt:    parseRFC3339(h.CreatedAt),
 	}, true
+}
+
+// firstLocation returns the first locations_for_search element that is a plain JSON string,
+// skipping the nested-array garbage some records carry there. Empty when none is a scalar.
+func firstLocation(raw []json.RawMessage) string {
+	for _, e := range raw {
+		var s string
+		if json.Unmarshal(e, &s) == nil {
+			return s
+		}
+	}
+	return ""
 }
 
 // waasWorkMode maps WaaS's remote flag to the controlled work-mode vocabulary:

--- a/internal/sources/workatastartup_test.go
+++ b/internal/sources/workatastartup_test.go
@@ -2,7 +2,12 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	neturl "net/url"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -62,12 +67,11 @@ func TestWorkAtAStartupWorkMode(t *testing.T) {
 
 func TestWorkAtAStartupFetchMapsHits(t *testing.T) {
 	t.Setenv(waasKeyEnv, "test-key")
-	resp := `{"hits":[
-{"id":96853,"title":"Founding Account Executive","description":"## About\n\nSell **stuff**.","remote":"only","created_at":"2026-06-17T17:44:11.932Z","company_name":"Ergo","locations_for_search":["San Francisco, CA, US","San Francisco","CA","US"],"search_path":"https://www.ycombinator.com/companies/ergo/jobs/VDySCKB-founding-account-executive"},
-{"id":0,"title":"NoID","company_name":"x"},
-{"id":12,"title":"NoCompany","company_name":"","remote":"no"}
-],"nbHits":2,"nbPages":1}`
-	fake := (&routedHTTP{}).route("algolia.net", resp)
+	fake := newWaasIndexFake(
+		`{"id":96853,"title":"Founding Account Executive","description":"## About\n\nSell **stuff**.","remote":"only","created_at":"2026-06-17T17:44:11.932Z","company_name":"Ergo","locations_for_search":["San Francisco, CA, US","San Francisco","CA","US"],"search_path":"https://www.ycombinator.com/companies/ergo/jobs/VDySCKB-founding-account-executive"}`,
+		`{"id":0,"title":"NoID","company_name":"x"}`,
+		`{"id":12,"title":"NoCompany","company_name":"","remote":"no"}`,
+	)
 
 	jobs, err := NewWorkAtAStartup(fake).Fetch(context.Background(), CompanyEntry{})
 	if err != nil {
@@ -99,10 +103,157 @@ func TestWorkAtAStartupFetchMapsHits(t *testing.T) {
 
 func TestWorkAtAStartupURLFallsBackToId(t *testing.T) {
 	t.Setenv(waasKeyEnv, "test-key")
-	resp := `{"hits":[{"id":555,"title":"Role","company_name":"Acme","remote":"no"}],"nbHits":1,"nbPages":1}`
-	fake := (&routedHTTP{}).route("algolia.net", resp)
+	fake := newWaasIndexFake(`{"id":555,"title":"Role","company_name":"Acme","remote":"no"}`)
 	jobs, _ := NewWorkAtAStartup(fake).Fetch(context.Background(), CompanyEntry{})
 	if len(jobs) != 1 || jobs[0].URL != "https://www.workatastartup.com/jobs/555" {
 		t.Fatalf("URL = %q, want id-built fallback", jobs[0].URL)
 	}
+}
+
+// TestWorkAtAStartupToleratesNestedLocations locks in a real-index quirk: some records store
+// nested-array garbage in locations_for_search (e.g. [[[["Remote"]]], "Remote"]) instead of a
+// flat []string. The adapter must skip the nested elements and take the first scalar.
+func TestWorkAtAStartupToleratesNestedLocations(t *testing.T) {
+	t.Setenv(waasKeyEnv, "test-key")
+	fake := newWaasIndexFake(`{"id":64767,"title":"Eng","company_name":"Acme","remote":"only","locations_for_search":[[[[[["Remote"]]]]],"Remote"]}`)
+	jobs, err := NewWorkAtAStartup(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].Location != "Remote" {
+		t.Errorf("Location = %q, want %q (first scalar past the nested garbage)", jobs[0].Location, "Remote")
+	}
+}
+
+// TestWorkAtAStartupBisectsPastPaginationCap is the core coverage test: the index holds far
+// more than one page (waasHitsPerPage), so a single sweep would silently truncate at the cap.
+// The adapter must bisect the id space and return every posting, including high-id ones that a
+// plain first-page query never reaches.
+func TestWorkAtAStartupBisectsPastPaginationCap(t *testing.T) {
+	t.Setenv(waasKeyEnv, "test-key")
+
+	// 2500 postings (ids 1..2500) spread across the id space, > 2 pages at the 1000 cap.
+	var hitJSONs []string
+	for id := 1; id <= 2500; id++ {
+		hitJSONs = append(hitJSONs, fmt.Sprintf(`{"id":%d,"company_name":"Co%d","title":"Role","remote":"no"}`, id, id))
+	}
+	// One deliberately high id, well past any single page, standing in for the posting the
+	// old single-sweep adapter dropped past the cap.
+	const highID = 999001
+	hitJSONs = append(hitJSONs, fmt.Sprintf(`{"id":%d,"company_name":"GoGoGrandparent","title":"Backend Engineer","remote":"only"}`, highID))
+	fake := newWaasIndexFake(hitJSONs...)
+
+	jobs, err := NewWorkAtAStartup(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2501 {
+		t.Fatalf("got %d jobs, want 2501 — bisection must reach every posting past the cap", len(jobs))
+	}
+	ids := make(map[string]bool, len(jobs))
+	for _, j := range jobs {
+		ids[j.ExternalID] = true
+	}
+	if !ids[strconv.Itoa(highID)] {
+		t.Errorf("high-id posting %d was not fetched — bisection failed to reach it", highID)
+	}
+	// No leaf window ever exceeded the retrieval cap.
+	if fake.maxPageReturned > waasHitsPerPage {
+		t.Errorf("a query returned %d hits, above the %d cap", fake.maxPageReturned, waasHitsPerPage)
+	}
+}
+
+// waasIndexFake models the Algolia index for tests: it filters its dataset by the half-open id
+// window carried in numericFilters and caps each response at the requested hitsPerPage, mirroring
+// Algolia's page limit. Bodies are the exact JSON hit strings, so the adapter's real decode path
+// (markdown, locations, search_path) is exercised.
+type waasIndexFake struct {
+	hits []struct { // parsed id + raw JSON, in ascending id order
+		id  int64
+		raw string
+	}
+	maxPageReturned int
+}
+
+func newWaasIndexFake(hitJSONs ...string) *waasIndexFake {
+	f := &waasIndexFake{}
+	for _, raw := range hitJSONs {
+		var h struct {
+			ID json.Number `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(raw), &h); err != nil {
+			panic("waasIndexFake: bad hit JSON: " + err.Error())
+		}
+		id, _ := h.ID.Int64()
+		f.hits = append(f.hits, struct {
+			id  int64
+			raw string
+		}{id, raw})
+	}
+	slices.SortFunc(f.hits, func(a, b struct {
+		id  int64
+		raw string
+	}) int {
+		return int(a.id - b.id)
+	})
+	return f
+}
+
+func (f *waasIndexFake) PostJSONWithHeaders(_ context.Context, _ string, _ map[string]string, body, v any) error {
+	m, _ := body.(map[string]any)
+	params, _ := m["params"].(string)
+	q, err := parseWaasParams(params)
+	if err != nil {
+		return err
+	}
+	var matched []string
+	for _, h := range f.hits {
+		if h.id >= q.lo && h.id < q.hi {
+			matched = append(matched, h.raw)
+		}
+	}
+	if q.hitsPerPage < len(matched) {
+		matched = matched[:q.hitsPerPage]
+	}
+	if len(matched) > f.maxPageReturned {
+		f.maxPageReturned = len(matched)
+	}
+	resp := fmt.Sprintf(`{"hits":[%s]}`, strings.Join(matched, ","))
+	return json.Unmarshal([]byte(resp), v)
+}
+
+type waasQuery struct {
+	lo, hi      int64
+	hitsPerPage int
+}
+
+func parseWaasParams(params string) (waasQuery, error) {
+	q := waasQuery{lo: math.MinInt64, hi: math.MaxInt64}
+	for _, kv := range strings.Split(params, "&") {
+		key, val, _ := strings.Cut(kv, "=")
+		val, err := neturl.QueryUnescape(val)
+		if err != nil {
+			return q, err
+		}
+		switch key {
+		case "hitsPerPage":
+			q.hitsPerPage, _ = strconv.Atoi(val)
+		case "numericFilters":
+			var clauses []string
+			if err := json.Unmarshal([]byte(val), &clauses); err != nil {
+				return q, fmt.Errorf("bad numericFilters %q: %w", val, err)
+			}
+			for _, c := range clauses {
+				if v, ok := strings.CutPrefix(c, "id>="); ok {
+					q.lo, _ = strconv.ParseInt(v, 10, 64)
+				} else if v, ok := strings.CutPrefix(c, "id<"); ok {
+					q.hi, _ = strconv.ParseInt(v, 10, 64)
+				}
+			}
+		}
+	}
+	return q, nil
 }


### PR DESCRIPTION
## Problem

The `workatastartup` (Work at a Startup / YC) crawl surfaced only **~1357 of the ~5009** open postings, so whole companies (e.g. [GoGoGrandparent](https://www.ycombinator.com/companies/gogograndparent/jobs/2vbzAw8-backend-engineer)) never entered the catalogue. The adapter was registered, scheduled, and keyed correctly — the gap was two Algolia index quirks it didn't account for:

1. **distinct-by-company (index default)** collapses ~5009 postings to one-per-company (~1357). Empty-query sweep returned those 1357; the rest were invisible.
2. **Offset pagination capped at 1000** (`paginationLimitedTo`), so even without distinct a single sweep silently truncates.

## Fix

- Set `distinct=false` on every query (all postings visible).
- Replace the single offset sweep with **recursive bisection over the unique, numeric, filterable `id`**: each query filters a half-open `[lo, hi)` id window; a window that still fills a page splits in half and recurses. `id` uniqueness guarantees termination (width-1 window ≤ 1 hit). The id upper bound is found by exponential probe — no hard-coded ceiling that could truncate as ids grow. (`browse` was ruled out: the session search key lacks that ACL — 403.)
- **Data-quirk fix found on live data:** some records store nested-array garbage in `locations_for_search` (e.g. `[[[["Remote"]]], "Remote"]`) instead of a flat `[]string`. Decode as raw elements, take the first scalar.

## Verification

- Unit tests (TDD): bisection reaches all 2501 records past the cap; nested-locations → `"Remote"`; existing mapping/URL/workmode preserved. `go build/vet/test ./...` clean.
- **Live end-to-end** against the real Algolia index with the prod key: `fetched 5009 jobs; GoGoGrandparent(78968) present=true`.

## Rollout note

After deploy, ingest will persist ~5009 (was ~1357) → roughly **+3600 postings** flow into the enrichment queue (one-time LLM budget bump; expected).