### PR TITLE
feat(filters): "region not specified" filter, drop remote_unspecified

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -114,8 +114,7 @@ func backfillAll(ctx context.Context, store facetStore) (scanned, updated int, e
 				d.PostingLanguage == j.PostingLanguage &&
 				d.EmploymentType == j.EmploymentType &&
 				d.EducationLevel == j.EducationLevel &&
-				experience == j.ExperienceYearsMin &&
-				d.RemoteUnspecified == j.RemoteUnspecified
+				experience == j.ExperienceYearsMin
 			if unchanged {
 				continue
 			}
@@ -132,7 +131,6 @@ func backfillAll(ctx context.Context, store facetStore) (scanned, updated int, e
 				EmploymentType:     d.EmploymentType,
 				EducationLevel:     d.EducationLevel,
 				ExperienceYearsMin: experience,
-				RemoteUnspecified:  d.RemoteUnspecified,
 			}); err != nil {
 				return scanned, updated, err
 			}

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -76,7 +76,6 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 		EmploymentType:     job.EmploymentType,
 		EducationLevel:     job.EducationLevel,
 		ExperienceYearsMin: toInt4(job.ExperienceYearsMin),
-		RemoteUnspecified:  job.RemoteUnspecified,
 	}
 	// Fingerprint the indexed fields so the upsert can report whether this write
 	// changed searchable content (drives incremental indexing below).

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -117,7 +117,6 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 			EmploymentType:     jobfacts.EmploymentType(j.Title, descHTML),
 			EducationLevel:     jobfacts.EducationLevel(descHTML),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(descHTML)),
-			RemoteUnspecified:  location.IsRemoteUnspecified(geo.WorkMode, geo),
 		})
 		if err != nil {
 			return fmt.Errorf("upsert job %s: %w", externalID, err)
@@ -189,7 +188,6 @@ func (s *extractStore) CompleteLinks(
 			EmploymentType:     jobfacts.EmploymentType(j.Title, j.Description),
 			EducationLevel:     jobfacts.EducationLevel(j.Description),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(j.Description)),
-			RemoteUnspecified:  location.IsRemoteUnspecified(workMode, geo),
 		})
 		if err != nil {
 			return fmt.Errorf("upsert job %s/%s: %w", j.Source, j.ExternalID, err)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -131,7 +131,7 @@ func (q *Queries) EstimateOpenJobs(ctx context.Context) (int64, error) {
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 FROM jobs
 WHERE id = $1
 `
@@ -174,13 +174,12 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
-		&i.RemoteUnspecified,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 FROM jobs
 WHERE public_slug = $1
 `
@@ -223,7 +222,6 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
-		&i.RemoteUnspecified,
 	)
 	return i, err
 }
@@ -323,7 +321,7 @@ func (q *Queries) ListJobSitemap(ctx context.Context, arg ListJobSitemapParams) 
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 FROM jobs
 WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -382,7 +380,6 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
-			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -395,7 +392,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -452,7 +449,6 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
-			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -465,7 +461,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -524,7 +520,6 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
-			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -537,7 +532,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -600,7 +595,6 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
-			&i.RemoteUnspecified,
 		); err != nil {
 			return nil, err
 		}
@@ -768,9 +762,8 @@ SET countries = COALESCE($1::text[], '{}'),
     posting_language     = $7,
     employment_type      = $8,
     education_level      = $9,
-    experience_years_min = $10,
-    remote_unspecified   = $11
-WHERE id = $12
+    experience_years_min = $10
+WHERE id = $11
 `
 
 type UpdateJobFacetsParams struct {
@@ -784,14 +777,13 @@ type UpdateJobFacetsParams struct {
 	EmploymentType     string      `json:"employment_type"`
 	EducationLevel     string      `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4 `json:"experience_years_min"`
-	RemoteUnspecified  bool        `json:"remote_unspecified"`
 	ID                 int64       `json:"id"`
 }
 
 // One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 // facet column — countries, regions, work_mode, skills, seniority, category, plus the
 // synthetic enrichment facets posting_language, employment_type, education_level,
-// experience_years_min, and remote_unspecified — from the row's raw content
+// and experience_years_min — from the row's raw content
 // (title/location/description) in one
 // pass, replacing the
 // three separate per-facet backfill writes. The facets are a pure function of the
@@ -812,7 +804,6 @@ func (q *Queries) UpdateJobFacets(ctx context.Context, arg UpdateJobFacetsParams
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
-		arg.RemoteUnspecified,
 		arg.ID,
 	)
 	return err
@@ -866,11 +857,10 @@ SET title        = $1,
     employment_type      = $15,
     education_level      = $16,
     experience_years_min = $17,
-    remote_unspecified   = $18,
-    updated_by   = $19::bigint,
+    updated_by   = $18::bigint,
     updated_at   = now()
-WHERE public_slug = $20 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+WHERE public_slug = $19 AND created_by IS NOT NULL
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 `
 
 type UpdateManualJobParams struct {
@@ -891,7 +881,6 @@ type UpdateManualJobParams struct {
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
-	RemoteUnspecified  bool               `json:"remote_unspecified"`
 	UpdatedBy          int64              `json:"updated_by"`
 	PublicSlug         string             `json:"public_slug"`
 }
@@ -927,7 +916,6 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
-		arg.RemoteUnspecified,
 		arg.UpdatedBy,
 		arg.PublicSlug,
 	)
@@ -967,7 +955,6 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
-		&i.RemoteUnspecified,
 	)
 	return i, err
 }
@@ -989,7 +976,7 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
     posting_language, employment_type, education_level, experience_years_min,
-    remote_unspecified, content_hash
+    content_hash
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7, $8,
@@ -998,7 +985,7 @@ INSERT INTO jobs (
     COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'),
     $14, COALESCE($15::text[], '{}'), $16, $17,
     $18, $19, $20, $21,
-    $22, $23
+    $22
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -1019,7 +1006,6 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
-    remote_unspecified   = EXCLUDED.remote_unspecified,
     content_hash = EXCLUDED.content_hash,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
     -- reopen (the row was closed) resets the strike count so a single later expired
@@ -1028,9 +1014,9 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.remote_unspecified,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
-    ((SELECT old_hash FROM existing) IS DISTINCT FROM $23) AS changed
+    ((SELECT old_hash FROM existing) IS DISTINCT FROM $22) AS changed
 `
 
 type UpsertJobParams struct {
@@ -1055,7 +1041,6 @@ type UpsertJobParams struct {
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
-	RemoteUnspecified  bool               `json:"remote_unspecified"`
 	ContentHash        pgtype.Text        `json:"content_hash"`
 }
 
@@ -1108,7 +1093,6 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
-		arg.RemoteUnspecified,
 		arg.ContentHash,
 	)
 	var i UpsertJobRow
@@ -1147,7 +1131,6 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.ExperienceYearsMin,
 		&i.Job.Collections,
 		&i.Job.ContentHash,
-		&i.Job.RemoteUnspecified,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -1167,7 +1150,7 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
     posting_language, employment_type, education_level, experience_years_min,
-    remote_unspecified, created_by
+    created_by
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7, $8,
@@ -1177,7 +1160,7 @@ INSERT INTO jobs (
     $14, COALESCE($15::text[], '{}'),
     $16, $17,
     $18, $19, $20, $21,
-    $22, $23::bigint
+    $22::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -1198,14 +1181,13 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
-    remote_unspecified   = EXCLUDED.remote_unspecified,
-    updated_by   = $24::bigint,
+    updated_by   = $23::bigint,
     -- A moderator re-create reopens the job; reset the strike count too so the
     -- two-strike liveness grace survives a reopen (see UpsertJob).
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, remote_unspecified
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
 `
 
 type UpsertManualJobParams struct {
@@ -1230,7 +1212,6 @@ type UpsertManualJobParams struct {
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
-	RemoteUnspecified  bool               `json:"remote_unspecified"`
 	CreatedBy          int64              `json:"created_by"`
 	UpdatedBy          int64              `json:"updated_by"`
 }
@@ -1268,7 +1249,6 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		arg.EmploymentType,
 		arg.EducationLevel,
 		arg.ExperienceYearsMin,
-		arg.RemoteUnspecified,
 		arg.CreatedBy,
 		arg.UpdatedBy,
 	)
@@ -1308,7 +1288,6 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
-		&i.RemoteUnspecified,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -81,7 +81,6 @@ type Job struct {
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
 	Collections        []string           `json:"collections"`
 	ContentHash        pgtype.Text        `json:"content_hash"`
-	RemoteUnspecified  bool               `json:"remote_unspecified"`
 }
 
 type JobReport struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -435,7 +435,7 @@ type Querier interface {
 	// One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 	// facet column — countries, regions, work_mode, skills, seniority, category, plus the
 	// synthetic enrichment facets posting_language, employment_type, education_level,
-	// experience_years_min, and remote_unspecified — from the row's raw content
+	// and experience_years_min — from the row's raw content
 	// (title/location/description) in one
 	// pass, replacing the
 	// three separate per-facet backfill writes. The facets are a pure function of the

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -121,7 +121,7 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
     posting_language, employment_type, education_level, experience_years_min,
-    remote_unspecified, content_hash
+    content_hash
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
     sqlc.arg(company), sqlc.arg(company_slug), sqlc.arg(location), sqlc.arg(remote),
@@ -130,7 +130,7 @@ INSERT INTO jobs (
     COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'),
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'), sqlc.arg(seniority), sqlc.arg(category),
     sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(experience_years_min),
-    sqlc.arg(remote_unspecified), sqlc.arg(content_hash)
+    sqlc.arg(content_hash)
 )
 -- public_slug is deliberately NOT in the DO UPDATE SET: the slug is minted once
 -- at insert and is the row's stable public identity. Re-ingest of the same
@@ -155,7 +155,6 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
-    remote_unspecified   = EXCLUDED.remote_unspecified,
     content_hash = EXCLUDED.content_hash,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
     -- reopen (the row was closed) resets the strike count so a single later expired
@@ -204,7 +203,7 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
     posting_language, employment_type, education_level, experience_years_min,
-    remote_unspecified, created_by
+    created_by
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
     sqlc.arg(company), sqlc.arg(company_slug), sqlc.arg(location), sqlc.arg(remote),
@@ -214,7 +213,7 @@ INSERT INTO jobs (
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'),
     sqlc.arg(seniority), sqlc.arg(category),
     sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(experience_years_min),
-    sqlc.arg(remote_unspecified), sqlc.arg(created_by)::bigint
+    sqlc.arg(created_by)::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -235,7 +234,6 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     experience_years_min = EXCLUDED.experience_years_min,
-    remote_unspecified   = EXCLUDED.remote_unspecified,
     updated_by   = sqlc.arg(updated_by)::bigint,
     -- A moderator re-create reopens the job; reset the strike count too so the
     -- two-strike liveness grace survives a reopen (see UpsertJob).
@@ -283,7 +281,6 @@ SET title        = sqlc.arg(title),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),
     experience_years_min = sqlc.arg(experience_years_min),
-    remote_unspecified   = sqlc.arg(remote_unspecified),
     updated_by   = sqlc.arg(updated_by)::bigint,
     updated_at   = now()
 WHERE public_slug = sqlc.arg(public_slug) AND created_by IS NOT NULL
@@ -399,7 +396,7 @@ WHERE id = sqlc.arg(id);
 -- One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 -- facet column — countries, regions, work_mode, skills, seniority, category, plus the
 -- synthetic enrichment facets posting_language, employment_type, education_level,
--- experience_years_min, and remote_unspecified — from the row's raw content
+-- and experience_years_min — from the row's raw content
 -- (title/location/description) in one
 -- pass, replacing the
 -- three separate per-facet backfill writes. The facets are a pure function of the
@@ -418,6 +415,5 @@ SET countries = COALESCE(sqlc.arg(countries)::text[], '{}'),
     posting_language     = sqlc.arg(posting_language),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),
-    experience_years_min = sqlc.arg(experience_years_min),
-    remote_unspecified   = sqlc.arg(remote_unspecified)
+    experience_years_min = sqlc.arg(experience_years_min)
 WHERE id = sqlc.arg(id);

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -185,7 +185,7 @@ func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) 
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.remote_unspecified, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -269,7 +269,6 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.ExperienceYearsMin,
 			&i.Job.Collections,
 			&i.Job.ContentHash,
-			&i.Job.RemoteUnspecified,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -59,9 +59,6 @@ type Derived struct {
 	EmploymentType     string
 	EducationLevel     string
 	ExperienceYearsMin *int
-	// RemoteUnspecified is true when the job is remote but its geography did not
-	// resolve to any country or region — the "remote, region not specified" facet.
-	RemoteUnspecified bool
 }
 
 // Derive computes the slugs and dictionary facets for a job. Geography, skills, and the
@@ -118,7 +115,6 @@ func Derive(in Input) Derived {
 		EmploymentType:     jobfacts.EmploymentType(in.Title, in.Description),
 		EducationLevel:     jobfacts.EducationLevel(in.Description),
 		ExperienceYearsMin: experience,
-		RemoteUnspecified:  location.IsRemoteUnspecified(workMode, geo),
 	}
 }
 

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -36,50 +36,6 @@ func TestDerive_SlugsAndFacets(t *testing.T) {
 	}
 }
 
-// RemoteUnspecified flags a remote job whose geography did not resolve to any
-// country or region — the "remote, region not specified" bucket. It is true only
-// when work_mode is remote AND both countries and regions are empty.
-func TestDerive_RemoteUnspecified(t *testing.T) {
-	tests := []struct {
-		name string
-		in   Input
-		want bool
-	}{
-		{
-			name: "bare remote with no geography is flagged",
-			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "1", Location: "Remote"},
-			want: true,
-		},
-		{
-			name: "remote with a resolved region is not flagged",
-			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "2", Location: "Remote - Europe"},
-			want: false,
-		},
-		{
-			name: "remote anywhere (global) is not flagged",
-			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "3", Location: "Remote - Anywhere"},
-			want: false,
-		},
-		{
-			name: "onsite with no geography is not flagged",
-			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "4", Location: "On-site"},
-			want: false,
-		},
-		{
-			name: "no location at all is not flagged",
-			in:   Input{Title: "Dev", Company: "Acme", Source: "manual", ExternalID: "5"},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := Derive(tt.in).RemoteUnspecified; got != tt.want {
-				t.Errorf("RemoteUnspecified = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // A structured work-mode signal from the caller (e.g. an ATS workplace-type enum)
 // beats the free-text parser hint.
 //

--- a/internal/jobhash/jobhash.go
+++ b/internal/jobhash/jobhash.go
@@ -47,7 +47,6 @@ func Of(p db.UpsertJobParams) string {
 	write(p.EmploymentType)
 	write(p.EducationLevel)
 	write(nullableInt(p.ExperienceYearsMin))
-	write(strconv.FormatBool(p.RemoteUnspecified))
 
 	sum := sha256.Sum256([]byte(b.String()))
 	return hex.EncodeToString(sum[:])

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -50,11 +50,6 @@ type Job struct {
 	Regions   []string `json:"regions"`
 	WorkMode  string   `json:"work_mode,omitempty"`
 	Skills    []string `json:"skills"`
-	// RemoteUnspecified is a deterministic source fact served straight from the jobs
-	// column: true when the job is remote but its geography resolved to no country
-	// and no region — the "remote, region not specified" facet. Served top-level like
-	// the other dictionary facets; indexed as a Meilisearch filterable attribute.
-	RemoteUnspecified bool `json:"remote_unspecified"`
 	// Collections is the set of curated-collection slugs (e.g. yc, bigtech) the
 	// job's company belongs to, denormalized from the company onto the job. It is a
 	// deterministic source fact (no LLM counterpart) served straight from the jobs
@@ -128,7 +123,6 @@ func FromRow(j db.Job) (Job, error) {
 		Regions:           regions,
 		WorkMode:          workMode,
 		Skills:            skills,
-		RemoteUnspecified: j.RemoteUnspecified,
 		Collections:       collections,
 		PostedAt:          rfc3339(EffectivePostedAt(j.PostedAt, j.CreatedAt)),
 		CreatedAt:         rfc3339(j.CreatedAt),

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -396,25 +396,6 @@ func TestFromRow_CollectionsEmptyIsNonNil(t *testing.T) {
 	}
 }
 
-// remote_unspecified is served straight from the jobs column (a deterministic
-// source fact), like the other dictionary facets.
-func TestFromRow_RemoteUnspecifiedFromColumn(t *testing.T) {
-	on, err := FromRow(db.Job{ID: 1, RemoteUnspecified: true})
-	if err != nil {
-		t.Fatalf("FromRow: %v", err)
-	}
-	if !on.RemoteUnspecified {
-		t.Fatalf("RemoteUnspecified = false, want true (from column)")
-	}
-	off, err := FromRow(db.Job{ID: 2})
-	if err != nil {
-		t.Fatalf("FromRow: %v", err)
-	}
-	if off.RemoteUnspecified {
-		t.Fatalf("RemoteUnspecified = true, want false (default)")
-	}
-}
-
 // Seniority/category are the dictionary column value, always — the LLM never wins
 // and never fills a dict-silent field. They stay nested under enrichment so the
 // existing facet path is unchanged.

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -27,16 +27,6 @@ type Geo struct {
 	WorkMode  string // "", "remote", "hybrid", or "onsite" — only on an explicit marker
 }
 
-// IsRemoteUnspecified reports whether a job is remote but its geography resolved to
-// no country and no region — the "remote, region not specified" facet. The work mode
-// is passed in (rather than read from geo) because callers resolve it through their
-// own precedence (structured signal → location hint → description); geo carries only
-// the parsed country/region sets. It is the single definition of the rule, shared by
-// jobderive and the Telegram extract path.
-func IsRemoteUnspecified(workMode string, geo Geo) bool {
-	return workMode == "remote" && len(geo.Countries) == 0 && len(geo.Regions) == 0
-}
-
 // separatorReplacer normalizes every token separator to a comma in one pass so a
 // single Split yields the geography tokens. The multi-character forms (" - ",
 // " or ") and parentheses are included, so "Berlin (On-site)" -> "berlin",

--- a/internal/moderation/moderation.go
+++ b/internal/moderation/moderation.go
@@ -163,7 +163,6 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
 		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
-		RemoteUnspecified:  d.RemoteUnspecified,
 
 		CreatedBy: actorID,
 		UpdatedBy: actorID,
@@ -230,7 +229,6 @@ func (s *Service) Update(ctx context.Context, actorID int64, slug string, p Upda
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
 		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
-		RemoteUnspecified:  d.RemoteUnspecified,
 
 		UpdatedBy: actorID,
 	})

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -59,9 +59,6 @@ type Job struct {
 	EmploymentType     string
 	EducationLevel     string
 	ExperienceYearsMin *int
-	// RemoteUnspecified is true when the job is remote but its geography resolved to
-	// no country and no region — the "remote, region not specified" facet.
-	RemoteUnspecified bool
 }
 
 // Store persists one normalized job and enqueues it for enrichment when needed,
@@ -327,6 +324,5 @@ func normalizeJob(e sources.CompanyEntry, j sources.Job) Job {
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
 		ExperienceYearsMin: d.ExperienceYearsMin,
-		RemoteUnspecified:  d.RemoteUnspecified,
 	}
 }

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -497,7 +497,7 @@ func facetSettings() *meilisearch.Settings {
 			// reindex first on deploy, or /jobs 500s on the new attribute.
 			"id",
 			"source", "company_slug",
-			"work_mode", "regions", "countries", "skills", "collections", "remote_unspecified",
+			"work_mode", "regions", "countries", "skills", "collections",
 			"enrichment.employment_type", "enrichment.education_level", "enrichment.seniority",
 			"enrichment.category", "enrichment.domains",
 			"enrichment.company_type", "enrichment.company_size", "enrichment.visa_sponsorship",

--- a/internal/search/filter.go
+++ b/internal/search/filter.go
@@ -28,6 +28,19 @@ func EqBool(attr string, v bool) string {
 	return attr + " = " + strconv.FormatBool(v)
 }
 
+// IsEmpty builds an `attr IS EMPTY` fragment, matching documents whose array (or
+// string) attribute is empty. It backs the regions "not specified" sentinel —
+// selecting jobs whose geography did not resolve — without a materialized column.
+func IsEmpty(attr string) string {
+	return attr + " IS EMPTY"
+}
+
+// IsNotEmpty builds `attr IS NOT EMPTY`, the exclude form of IsEmpty (jobs that DO
+// carry a value for the attribute).
+func IsNotEmpty(attr string) string {
+	return attr + " IS NOT EMPTY"
+}
+
 // Gte builds a `attr >= n` numeric fragment.
 func Gte(attr string, n int) string {
 	return attr + " >= " + strconv.Itoa(n)

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -35,6 +35,32 @@ var StringFacets = map[string]string{
 	"posting_language": "enrichment.posting_language",
 }
 
+// RegionUnspecified is the reserved value of the `regions` facet that selects
+// jobs with no resolved geography (an empty regions array) rather than a real
+// region code. The SPA's "Not specified" region chip serializes to it. It maps to
+// Meilisearch's IS EMPTY (IS NOT EMPTY when excluded), so it ORs with real region
+// values in the same facet group and supports exclude like any region — replacing
+// the former materialized `remote_unspecified` boolean with a query-time predicate.
+const RegionUnspecified = "none"
+
+// facetEq builds a facet's include fragment: an equality, except the regions
+// unspecified sentinel, which becomes IS EMPTY.
+func facetEq(param, attr, val string) string {
+	if param == "regions" && val == RegionUnspecified {
+		return IsEmpty(attr)
+	}
+	return Eq(attr, val)
+}
+
+// facetNeq builds a facet's exclude fragment: an inequality, except the regions
+// unspecified sentinel, which becomes IS NOT EMPTY.
+func facetNeq(param, attr, val string) string {
+	if param == "regions" && val == RegionUnspecified {
+		return IsNotEmpty(attr)
+	}
+	return Neq(attr, val)
+}
+
 // FilterFromValues turns the facet params of a parsed search query into a
 // Meilisearch filter. Within a facet, included values are ORed by default (or
 // ANDed when `<param>_mode=and`); excluded values (`<param>_exclude=...`) become
@@ -59,31 +85,24 @@ func filterFromValues(v url.Values, now time.Time) any {
 			if v.Get(param+"_mode") == "and" {
 				// Each value its own AND group: a job must match all of them.
 				for _, val := range included {
-					groups = append(groups, []string{Eq(attr, val)})
+					groups = append(groups, []string{facetEq(param, attr, val)})
 				}
 			} else {
 				group := make([]string, len(included))
 				for i, val := range included {
-					group[i] = Eq(attr, val)
+					group[i] = facetEq(param, attr, val)
 				}
 				groups = append(groups, group)
 			}
 		}
 		// Excluded values: each is its own AND group so all are filtered out.
 		for _, val := range nonEmpty(v[param+"_exclude"]) {
-			groups = append(groups, []string{Neq(attr, val)})
+			groups = append(groups, []string{facetNeq(param, attr, val)})
 		}
 	}
 
 	if raw := v.Get("visa_sponsorship"); raw != "" {
 		groups = append(groups, []string{EqBool("enrichment.visa_sponsorship", raw == "true")})
-	}
-
-	// remote_unspecified is a one-way toggle: setting it true restricts to remote
-	// jobs whose geography did not resolve. It adds only a positive constraint, so a
-	// false/empty value emits nothing (filtering OUT that bucket is not a use case).
-	if v.Get("remote_unspecified") == "true" {
-		groups = append(groups, []string{EqBool("remote_unspecified", true)})
 	}
 
 	if n, ok := atoiOK(v.Get("salary_min")); ok {

--- a/internal/search/query_filter_test.go
+++ b/internal/search/query_filter_test.go
@@ -111,22 +111,36 @@ func TestFilterFromValues_VisaBoolAndNumeric(t *testing.T) {
 	}
 }
 
-func TestFilterFromValues_RemoteUnspecified(t *testing.T) {
-	// remote_unspecified=true restricts to the facet; it ANDs as its own group.
-	got := normalizeGroups(t, FilterFromValues(vals("remote_unspecified=true&seniority=senior")))
-	want := [][]string{
-		{`enrichment.seniority = "senior"`},
-		{`remote_unspecified = true`},
-	}
+func TestFilterFromValues_RegionUnspecifiedSentinel(t *testing.T) {
+	// The reserved `regions=none` value selects jobs with no resolved geography
+	// via Meili's IS EMPTY, not an equality against a literal "none" region.
+	got := normalizeGroups(t, FilterFromValues(vals("regions=none")))
+	want := [][]string{{`regions IS EMPTY`}}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+		t.Errorf("regions=none: got %v, want %v", got, want)
 	}
 
-	// The toggle only adds a positive constraint: unset, empty, or false emit nothing.
-	for _, q := range []string{"", "remote_unspecified=", "remote_unspecified=false"} {
-		if got := FilterFromValues(vals(q)); got != nil {
-			t.Errorf("FilterFromValues(%q) = %v, want nil", q, got)
-		}
+	// It ORs with real region values inside the same facet group, so "Europe or
+	// unspecified" is a single OR of an equality and IS EMPTY.
+	got = normalizeGroups(t, FilterFromValues(vals("regions=none&regions=eu")))
+	want = [][]string{{`regions = "eu"`, `regions IS EMPTY`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("regions=none&eu: got %v, want %v", got, want)
+	}
+
+	// Excluding the sentinel keeps only jobs that DO have a region (IS NOT EMPTY).
+	got = normalizeGroups(t, FilterFromValues(vals("regions_exclude=none")))
+	want = [][]string{{`regions IS NOT EMPTY`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("regions_exclude=none: got %v, want %v", got, want)
+	}
+
+	// The sentinel is scoped to the regions facet — "none" is a real value
+	// everywhere else and stays an equality (never IS EMPTY).
+	got = normalizeGroups(t, FilterFromValues(vals("relocation=none")))
+	want = [][]string{{`enrichment.relocation = "none"`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("relocation=none: got %v, want %v", got, want)
 	}
 }
 

--- a/migrations/0034_drop_remote_unspecified.sql
+++ b/migrations/0034_drop_remote_unspecified.sql
@@ -1,0 +1,13 @@
+-- Drop the remote_unspecified column (added in 0027). The "remote, region not
+-- specified" bucket it materialized is now a query-time predicate: the search
+-- filter selects jobs with no resolved geography via `regions IS EMPTY` (the
+-- reserved `regions=none` facet value), which composes with the existing
+-- work_mode=remote filter instead of duplicating it in a stored boolean. The
+-- column is therefore dead — nothing derives, persists, serves, or filters on it.
+--
+-- This is also the schema source sqlc reads: applied after 0027, it leaves the
+-- column absent from the generated models. On a persistent DB (initdb runs
+-- migrations only on first volume init) this must be applied by hand:
+--   ALTER TABLE jobs DROP COLUMN IF EXISTS remote_unspecified;
+ALTER TABLE jobs
+    DROP COLUMN IF EXISTS remote_unspecified;

--- a/openspec/specs/remote-region-filters/spec.md
+++ b/openspec/specs/remote-region-filters/spec.md
@@ -1,87 +1,74 @@
 # remote-region-filters Specification
 
 ## Purpose
-TBD - created by syncing change add-remote-region-filters. Update Purpose after archive.
+Let users filter jobs to the "geography not specified" bucket — postings whose
+derived region set is empty — without materializing a redundant column. Combined
+with the existing `work_mode=remote` filter it reproduces the former
+"remote, location-flexible" bucket, and on its own it is the orthogonal
+"region unspecified" filter.
 
 ## Requirements
-### Requirement: The remote_unspecified facet is derived deterministically
+### Requirement: The regions facet accepts an "unspecified" sentinel value
 
-The system SHALL derive a boolean facet `remote_unspecified` for each job from
-its already-derived geography facets, with no LLM involvement. The facet SHALL be
-`true` when, and only when, the derived `work_mode` is `remote` AND the derived
-`countries` set is empty AND the derived `regions` set is empty; otherwise it
-SHALL be `false`. The facet SHALL be computed by `jobderive.Derive` from the same
-inputs that produce the geography facets, so the ingest pipeline and the moderator
-write path produce identical results, and a re-derive is idempotent.
+The search API SHALL treat a reserved `regions` facet value (`none`) as a request
+for jobs whose derived `regions` set is empty, rather than an equality against a
+literal region code. The predicate SHALL be expressed as the search engine's
+empty-array test (`regions IS EMPTY`) so it composes with real region values (ORed
+within the facet) and requires no stored per-job column. The sentinel SHALL be
+built by the same pure filter builder shared by the HTTP search handler and the
+saved-search/notification matcher, so both produce an identical filter.
 
-#### Scenario: A bare remote job is flagged
+#### Scenario: The sentinel selects jobs with no resolved region
 
-- **WHEN** a job's geography derives to `work_mode=remote`, empty countries, and
-  empty regions (e.g. location `Remote`)
-- **THEN** `remote_unspecified` is `true`
+- **WHEN** a search request sets `regions=none`
+- **THEN** only jobs whose derived `regions` set is empty are returned (via
+  `regions IS EMPTY`)
 
-#### Scenario: A remote job with a resolved region is not flagged
+#### Scenario: The sentinel ORs with real regions
 
-- **WHEN** a job derives to `work_mode=remote` with a non-empty region (e.g.
-  location `Remote - Europe` → `[eu]`, or `Remote - Anywhere` → `[global]`)
-- **THEN** `remote_unspecified` is `false`
+- **WHEN** a search request sets `regions=none` alongside a real region (e.g.
+  `regions=none&regions=eu`)
+- **THEN** jobs are returned that have region `eu` OR no region at all, as a single
+  ORed facet group
 
-#### Scenario: A non-remote job with no geography is not flagged
+#### Scenario: Excluding the sentinel keeps only located jobs
 
-- **WHEN** a job derives to an empty `work_mode` (or `hybrid`/`onsite`) with empty
-  countries and regions
-- **THEN** `remote_unspecified` is `false`
+- **WHEN** a search request excludes the sentinel (`regions_exclude=none`)
+- **THEN** only jobs whose derived `regions` set is non-empty are returned (via
+  `regions IS NOT EMPTY`)
 
-### Requirement: The remote_unspecified facet is stored, served, and indexed
+#### Scenario: The sentinel is scoped to the regions facet
 
-The system SHALL persist `remote_unspecified` as a `jobs` table column written on
-every upsert and re-derive, alongside the other deterministic facets and NOT
-inside the `enrichment` JSONB. The public read model (`jobview`) SHALL serve the
-column value. The search index SHALL register `remote_unspecified` as a
-filterable attribute, sourced from the served read model, so existing rows reflect
-the facet only after a re-derive and reindex.
+- **WHEN** the reserved value appears on a different facet (e.g. `relocation=none`,
+  where `none` is a real vocabulary value)
+- **THEN** it is treated as an ordinary equality, never as an empty-set test
 
-#### Scenario: The facet is served from the jobs column
+### Requirement: The "region not specified" filter needs no stored facet
 
-- **WHEN** a job with `remote_unspecified=true` is read through the public model
-- **THEN** the served object reports the facet as `true`
+The system SHALL NOT persist a materialized boolean for the "remote, region not
+specified" bucket. The bucket SHALL be derivable at query time from the existing
+`regions` search attribute (empty array) combined with the existing `work_mode`
+filter, so no `jobs` column, read-model field, or dedicated filterable attribute
+is required for it.
 
-#### Scenario: The facet is a filterable search attribute
+#### Scenario: The former bucket is reproduced by composition
 
-- **WHEN** the search index is configured
-- **THEN** `remote_unspecified` is among the index's filterable attributes
+- **WHEN** a search request combines `work_mode=remote` with `regions=none`
+- **THEN** it returns exactly the remote jobs whose geography did not resolve — the
+  bucket formerly served by a stored `remote_unspecified` facet
 
-### Requirement: Jobs can be filtered by remote_unspecified
+### Requirement: The SPA exposes the sentinel as a Region chip
 
-The search API SHALL accept a `remote_unspecified` boolean filter param that,
-when set to `true`, restricts results to jobs whose `remote_unspecified` facet is
-`true`. The param SHALL be built by the same pure filter builder shared by the
-HTTP search handler and the saved-search/notification matcher, so both produce an
-identical filter. An unset or empty param SHALL emit no filter fragment.
+The web frontend SHALL present the "region not specified" option as a pill within
+the jobs filter sidebar's Region facet (labelled `Not specified`), appended after
+the real macro-region pills, so it selects, ORs, and excludes like any region. The
+filter model SHALL serialize the selected chip to `regions=none`, parse it back
+from the URL, and count it toward the active-filter total like any facet value. The
+company filter's Region facet SHALL NOT offer the sentinel (the companies list
+filters by array overlap, which has no empty-set test).
 
-#### Scenario: Filtering by remote_unspecified narrows results
+#### Scenario: The chip is shown inside the Region facet
 
-- **WHEN** a search request sets `remote_unspecified=true`
-- **THEN** only jobs whose `remote_unspecified` facet is `true` are returned
-
-#### Scenario: An unset param emits no filter
-
-- **WHEN** a search request omits `remote_unspecified` (or passes it empty)
-- **THEN** no `remote_unspecified` fragment is added to the search filter
-
-### Requirement: The SPA exposes remote_unspecified as a sidebar toggle
-
-The web frontend SHALL present `remote_unspecified` as a boolean toggle control in
-the jobs filter sidebar (mirroring the existing boolean filters such as visa
-sponsorship), labelled to convey location-flexible remote work (no specific country
-or region) and kept distinct from the `Global` region option. Enabling it SHALL
-drive the `remote_unspecified` search param; the filter model SHALL serialize the
-enabled state to `remote_unspecified=true`, parse it back from the URL, and count it
-as one active filter.
-
-#### Scenario: The toggle is shown and drives the param
-
-- **WHEN** the user opens the jobs filter sidebar
-- **THEN** a location-flexible remote toggle appears, distinct from the `Global`
-  region option, and enabling it sets the `remote_unspecified` search param to
-  `true`
+- **WHEN** the user opens the jobs filter sidebar's Region facet
+- **THEN** a `Not specified` pill appears among the region pills, and selecting it
+  sets the `regions=none` search param

--- a/web/src/lib/components/FiltersPanel.svelte
+++ b/web/src/lib/components/FiltersPanel.svelte
@@ -127,19 +127,6 @@
     </div>
   </div>
 
-  <div class="border-b border-border pb-4">
-    <h3 class="mb-2 text-sm font-semibold tracking-tight">Remote</h3>
-    <label class="flex cursor-pointer items-center gap-2 text-sm">
-      <input
-        type="checkbox"
-        class="size-4 rounded border-border"
-        checked={store.value.remoteUnspecified}
-        onchange={(e) => store.setRemoteUnspecified(e.currentTarget.checked)}
-      />
-      <span>Remote · location-flexible</span>
-    </label>
-  </div>
-
   <div>
     <h3 class="mb-2 text-sm font-semibold tracking-tight">Visa</h3>
     <label class="flex cursor-pointer items-center gap-2 text-sm">

--- a/web/src/lib/docs/filters.ts
+++ b/web/src/lib/docs/filters.ts
@@ -51,11 +51,6 @@ export const FILTER_FACETS: FilterRow[] = [
 export const FILTER_EXTRAS: FilterRow[] = [
   { param: 'visa_sponsorship', label: 'Visa sponsorship', values: 'true, false' },
   {
-    param: 'remote_unspecified',
-    label: 'Remote, location-flexible',
-    values: 'true — remote jobs whose geography resolved to no country or region',
-  },
-  {
     param: 'salary_min',
     label: 'Minimum salary',
     values: 'integer — jobs whose minimum salary is at least this (pair with salary_currency)',

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -187,6 +187,18 @@ const SOURCE: FacetOption[] = options(SOURCE_VALUES, {
 // whose insertion order is the curated display order.
 const REGION: FacetOption[] = options(Object.keys(REGION_LABELS), REGION_LABELS);
 
+// Reserved `regions` value selecting jobs with no resolved geography (an empty
+// regions array) — the "region not specified" bucket — rather than a real region
+// code. The backend maps it to Meilisearch's IS EMPTY (see search.RegionUnspecified),
+// so it ORs with real regions and supports exclude like any region pill. Only the
+// job facet offers it; the company facet omits it (companies filter by SQL array
+// overlap, which has no empty-set sentinel).
+export const REGION_UNSPECIFIED = 'none';
+
+// Job region options: the macro-regions plus the "Not specified" sentinel chip,
+// appended last so it reads after the real regions.
+const JOB_REGION: FacetOption[] = [...REGION, { value: REGION_UNSPECIFIED, label: 'Not specified' }];
+
 const WORK_MODE: FacetOption[] = options(WORK_MODE_VALUES, WORK_MODE_LABELS);
 const SENIORITY: FacetOption[] = options(SENIORITY_VALUES, SENIORITY_LABELS);
 const COMPANY_TYPE: FacetOption[] = options(COMPANY_TYPE_VALUES, COMPANY_TYPE_LABELS);
@@ -272,7 +284,7 @@ export const COMPANY_FACETS: FacetDef[] = [
 
 export const FACETS: FacetDef[] = [
   { param: 'collections', label: 'Collection', control: 'pills', options: COLLECTION, excludable: false },
-  { param: 'regions', label: 'Region', control: 'pills', options: REGION, excludable: true },
+  { param: 'regions', label: 'Region', control: 'pills', options: JOB_REGION, excludable: true },
   { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
   { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -31,10 +31,6 @@ export interface JobFilters {
   /** Facet state keyed by the facet's query param (see FACETS). */
   facets: Record<string, FacetState>;
   visa: boolean;
-  /** Remote jobs whose geography did not resolve to any country or region — the
-   *  "remote, region not specified" bucket. Serialized as `remote_unspecified=true`;
-   *  a one-way toggle (false is never serialized), distinct from the `global` region. */
-  remoteUnspecified: boolean;
   salaryMin: number | null;
   /** Freshness: keep only jobs posted within the last N days (null = any age).
    *  Serialized as `posted_within_days`; the backend turns it into a posted_ts
@@ -54,7 +50,7 @@ function emptyFacets(): Record<string, FacetState> {
 }
 
 export function emptyFilters(): JobFilters {
-  return { q: '', facets: emptyFacets(), visa: false, remoteUnspecified: false, salaryMin: null, postedWithinDays: null, sort: DEFAULT_SORT };
+  return { q: '', facets: emptyFacets(), visa: false, salaryMin: null, postedWithinDays: null, sort: DEFAULT_SORT };
 }
 
 /** Serialize filters to URL query params (the shape the search API reads). */
@@ -72,7 +68,6 @@ export function filtersToParams(f: JobFilters): URLSearchParams {
     }
   }
   if (f.visa) p.set('visa_sponsorship', 'true');
-  if (f.remoteUnspecified) p.set('remote_unspecified', 'true');
   if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
   if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
   // Omit the default sort: a clean URL leans on the backend's empty-query default.
@@ -97,7 +92,6 @@ export function filtersFromParams(p: URLSearchParams): JobFilters {
     else if (include.length > 0) f.facets[def.param] = { values: include, exclude: false, matchAll };
   }
   f.visa = p.get('visa_sponsorship') === 'true';
-  f.remoteUnspecified = p.get('remote_unspecified') === 'true';
   const salary = Number(p.get('salary_min'));
   f.salaryMin = p.get('salary_min') && !Number.isNaN(salary) ? salary : null;
   // Freshness is a positive whole number of days; anything else (absent, zero,
@@ -114,7 +108,6 @@ export function activeFilterCount(f: JobFilters): number {
   let n = 0;
   for (const def of FACETS) n += f.facets[def.param]?.values.length ?? 0;
   if (f.visa) n += 1;
-  if (f.remoteUnspecified) n += 1;
   if (f.salaryMin != null) n += 1;
   if (f.postedWithinDays != null) n += 1;
   return n;
@@ -180,10 +173,6 @@ export class FilterStore {
   // Discrete inputs (clicked/toggled): apply immediately via setNow.
   setVisa(on: boolean) {
     this.#url.setNow({ ...this.#url.value, visa: on });
-  }
-
-  setRemoteUnspecified(on: boolean) {
-    this.#url.setNow({ ...this.#url.value, remoteUnspecified: on });
   }
 
   setSort(sort: SortField) {


### PR DESCRIPTION
Replaces the denormalized `remote_unspecified` facet (a stored `work_mode=remote × regions=∅` product) with a query-time predicate: the reserved `regions=none` value maps to Meilisearch `regions IS EMPTY` / `IS NOT EMPTY`, ORs with real regions, and composes with `work_mode=remote` to reproduce the former bucket.

- **search**: `RegionUnspecified` sentinel + `IsEmpty`/`IsNotEmpty`; drop the `remote_unspecified` branch and filterable attribute.
- **derivation**: remove the facet from jobderive/pipeline/jobhash/jobview/moderation/tg-extract/ingest/backfill + `location.IsRemoteUnspecified`.
- **db**: migration `0034` drops `jobs.remote_unspecified`; queries + sqlc regenerated.
- **web**: "Not specified" pill inside the Region facet (job facet only) replaces the standalone checkbox; `remoteUnspecified` removed from the model + docs.
- **spec**: `remote-region-filters` rewritten.

**Deploy note**: apply the migration by hand on the persistent volume — `ALTER TABLE jobs DROP COLUMN IF EXISTS remote_unspecified;`. Order is safe: the new build never references the column (sqlc expands `SELECT *` to an explicit list without it), so the drop is pure cleanup. `regions IS EMPTY` works on the existing index immediately (regions already filterable); reindex only to clean up the dead attribute.

Verified: `go build/vet`, full unit tests, integration-compile, `gofmt`, `svelte-check` — all clean against `origin/main`.