### PR TITLE
fix(web): guard swipe undo against the fly-off window to stop duplicate cards

### DIFF
--- a/web/src/lib/components/SwipeDeck.svelte
+++ b/web/src/lib/components/SwipeDeck.svelte
@@ -95,8 +95,13 @@
 
     const send = kind === 'save' ? api.saveJob(job.public_slug) : api.dismissJob(job.public_slug);
     send.catch(() => {
-      queue = [job, ...queue];
-      if (last?.job.public_slug === job.public_slug) last = null;
+      // Restore the card only if it hasn't since been undone (undo() clears `last`)
+      // or superseded by a later judge() — re-queuing unconditionally would put back
+      // a card the user already restored, leaving a permanent duplicate in the deck.
+      if (last?.job.public_slug === job.public_slug) {
+        queue = [job, ...queue];
+        last = null;
+      }
     });
 
     // After the fly-off, drop the card. The next one is a fresh DOM node (keyed by
@@ -112,7 +117,11 @@
 
   // Undo the last decision: clear its server mark and put the card back on top.
   function undo() {
-    if (!last) return;
+    // Bail during the fly-off: `last` is set for the whole FLY_MS animation window,
+    // so without the `exiting` gate an undo mid-flight would re-queue the card while
+    // judge()'s deferred slice and failed-send restore are still pending — leaving a
+    // duplicate. Undo is available once the card has settled (exiting=false).
+    if (!last || exiting) return;
     const { job, kind } = last;
     last = null;
     queue = [job, ...queue];


### PR DESCRIPTION
## Problem (LOW — from the repo review; last open finding)

`undo()` had no `exiting` guard, and `judge()`'s `send.catch` re-queued the card **unconditionally**. Two ways this duplicated a card:

1. **Undo mid-fly-off:** `judge()` sets `last`, `exiting=true`, fires `saveJob`, and defers `queue.slice(1)` to a 300ms `setTimeout`. Pressing undo within that window re-queued the card (`queue = [job, ...queue]`) while the slice was still pending → `[A, A, …]`.
2. **Slow request rejects after undo:** even after the fly-off, if the in-flight `saveJob` rejects *after* the user undid the card, the `catch` re-queued it again (the `last`-null check only nulled `last`, it didn't gate the re-insertion).

Either way the user saw a card they'd already judged reappear permanently in the deck, and `saveJob`/`unsaveJob` raced on the server.

## Fix (both guards the review recommended)

- `undo()` bails while `exiting` is true — it runs only once the card has settled (`last` is set for the whole animation window, so the bare `!last` gate wasn't enough).
- `send.catch` restores the card **only when `last` still references it** — i.e. it hasn't been undone (`undo()` clears `last`) or superseded by a later `judge()` — instead of re-queuing unconditionally.

## Verification

`web/` has no runtime test runner, so verified by:
- `svelte-check` — 0 errors, 0 warnings.
- `npm run build` (adapter-node) — succeeds.
- Traced both interleavings (undo-in-window, slow-reject-after-undo) against the new guards; no path re-queues a card twice.

(The one `eslint` error in this file — `new Set` on line 30 — is a pre-existing baseline issue on a line this change doesn't touch.)

Known limitation, left as-is: an undo fired while the original save is still in flight still races unsave vs save on the server (optimistic-UI ordering); fixing that needs request sequencing/cancellation, out of scope for this card-duplication fix.

This closes the last of the 15 repo-review findings.

Generated with assistance from Claude Code.