### PR TITLE
fix(sitemap): ship freshest jobs instead of a full-catalogue scan

### DIFF
--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -243,73 +243,35 @@ func (q *Queries) GetJobIDBySlug(ctx context.Context, publicSlug string) (int64,
 	return id, err
 }
 
-const jobSitemapBoundaries = `-- name: JobSitemapBoundaries :many
-SELECT id FROM (
-  SELECT id,
-         row_number() OVER (ORDER BY id) AS rn,
-         count(*) OVER () AS total
-  FROM jobs
-  WHERE closed_at IS NULL
-) t
-WHERE rn % $1::bigint = 0 AND rn < total
-ORDER BY id
-`
-
-// The id ending every full chunk of `chunk_size` open jobs (ordered by id),
-// excluding the final row, so the sitemap index can list each sub-sitemap's keyset
-// cursor without the client walking the whole catalogue.
-func (q *Queries) JobSitemapBoundaries(ctx context.Context, chunkSize int64) ([]int64, error) {
-	rows, err := q.db.Query(ctx, jobSitemapBoundaries, chunkSize)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []int64{}
-	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		items = append(items, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listJobSitemap = `-- name: ListJobSitemap :many
-SELECT id, public_slug, updated_at
+const listJobSitemapFreshest = `-- name: ListJobSitemapFreshest :many
+SELECT public_slug, updated_at
 FROM jobs
-WHERE closed_at IS NULL AND id > $1
-ORDER BY id
-LIMIT $2
+WHERE closed_at IS NULL
+ORDER BY id DESC
+LIMIT $1
 `
 
-type ListJobSitemapParams struct {
-	AfterID   int64 `json:"after_id"`
-	BatchSize int32 `json:"batch_size"`
-}
-
-type ListJobSitemapRow struct {
-	ID         int64              `json:"id"`
+type ListJobSitemapFreshestRow struct {
 	PublicSlug string             `json:"public_slug"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
-// Slim keyset page for the sitemap: only the fields a sitemap URL needs, open jobs
-// only, cursored by the immutable primary key so a chunk is a bounded index scan
-// (never a deep OFFSET over millions of rows).
-func (q *Queries) ListJobSitemap(ctx context.Context, arg ListJobSitemapParams) ([]ListJobSitemapRow, error) {
-	rows, err := q.db.Query(ctx, listJobSitemap, arg.AfterID, arg.BatchSize)
+// The freshest open jobs for the sitemap: only the fields a URL needs, newest id
+// first. Ordering by id DESC (served by jobs_open_id_idx) reads the most recently
+// inserted rows, which sit at the physical end of the heap — a sequential, cache-warm
+// scan. Enumerating the whole 2.5M-row catalogue per request is heap-bound and far
+// too slow (and pollutes the buffer cache), so the sitemap ships the freshest slice;
+// fuller coverage needs a precomputed narrow table, not a live scan.
+func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([]ListJobSitemapFreshestRow, error) {
+	rows, err := q.db.Query(ctx, listJobSitemapFreshest, rowLimit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListJobSitemapRow{}
+	items := []ListJobSitemapFreshestRow{}
 	for rows.Next() {
-		var i ListJobSitemapRow
-		if err := rows.Scan(&i.ID, &i.PublicSlug, &i.UpdatedAt); err != nil {
+		var i ListJobSitemapFreshestRow
+		if err := rows.Scan(&i.PublicSlug, &i.UpdatedAt); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -220,10 +220,6 @@ type Querier interface {
 	// never reset. extracted_at is non-NULL when the ingest prefilter already
 	// decided the post holds no vacancy, so it is recorded but never queued.
 	InsertTelegramPost(ctx context.Context, arg InsertTelegramPostParams) (int64, error)
-	// The id ending every full chunk of `chunk_size` open jobs (ordered by id),
-	// excluding the final row, so the sitemap index can list each sub-sitemap's keyset
-	// cursor without the client walking the whole catalogue.
-	JobSitemapBoundaries(ctx context.Context, chunkSize int64) ([]int64, error)
 	// A user's API keys, newest first. Metadata only — never the token_hash.
 	ListAPIKeysByUser(ctx context.Context, userID int64) ([]ListAPIKeysByUserRow, error)
 	// Every active subscription with the data the matching worker needs: the saved
@@ -250,10 +246,13 @@ type Querier interface {
 	// Slim keyset page of companies for the sitemap, cursored by the slug primary key
 	// (first chunk keyed by the empty string, which sorts before every slug).
 	ListCompanySitemap(ctx context.Context, arg ListCompanySitemapParams) ([]ListCompanySitemapRow, error)
-	// Slim keyset page for the sitemap: only the fields a sitemap URL needs, open jobs
-	// only, cursored by the immutable primary key so a chunk is a bounded index scan
-	// (never a deep OFFSET over millions of rows).
-	ListJobSitemap(ctx context.Context, arg ListJobSitemapParams) ([]ListJobSitemapRow, error)
+	// The freshest open jobs for the sitemap: only the fields a URL needs, newest id
+	// first. Ordering by id DESC (served by jobs_open_id_idx) reads the most recently
+	// inserted rows, which sit at the physical end of the heap — a sequential, cache-warm
+	// scan. Enumerating the whole 2.5M-row catalogue per request is heap-bound and far
+	// too slow (and pollutes the buffer cache), so the sitemap ships the freshest slice;
+	// fuller coverage needs a precomputed narrow table, not a live scan.
+	ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([]ListJobSitemapFreshestRow, error)
 	// Newest-added first: created_at is when the job entered the catalogue (stable
 	// across re-ingests), so fresh ingests surface on top regardless of how old the
 	// platform's posted_at is. id breaks ties within one ingest batch.

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -55,29 +55,18 @@ SELECT count(*)
 FROM jobs
 WHERE closed_at IS NULL;
 
--- name: ListJobSitemap :many
--- Slim keyset page for the sitemap: only the fields a sitemap URL needs, open jobs
--- only, cursored by the immutable primary key so a chunk is a bounded index scan
--- (never a deep OFFSET over millions of rows).
-SELECT id, public_slug, updated_at
+-- name: ListJobSitemapFreshest :many
+-- The freshest open jobs for the sitemap: only the fields a URL needs, newest id
+-- first. Ordering by id DESC (served by jobs_open_id_idx) reads the most recently
+-- inserted rows, which sit at the physical end of the heap — a sequential, cache-warm
+-- scan. Enumerating the whole 2.5M-row catalogue per request is heap-bound and far
+-- too slow (and pollutes the buffer cache), so the sitemap ships the freshest slice;
+-- fuller coverage needs a precomputed narrow table, not a live scan.
+SELECT public_slug, updated_at
 FROM jobs
-WHERE closed_at IS NULL AND id > sqlc.arg(after_id)
-ORDER BY id
-LIMIT sqlc.arg(batch_size);
-
--- name: JobSitemapBoundaries :many
--- The id ending every full chunk of `chunk_size` open jobs (ordered by id),
--- excluding the final row, so the sitemap index can list each sub-sitemap's keyset
--- cursor without the client walking the whole catalogue.
-SELECT id FROM (
-  SELECT id,
-         row_number() OVER (ORDER BY id) AS rn,
-         count(*) OVER () AS total
-  FROM jobs
-  WHERE closed_at IS NULL
-) t
-WHERE rn % sqlc.arg(chunk_size)::bigint = 0 AND rn < total
-ORDER BY id;
+WHERE closed_at IS NULL
+ORDER BY id DESC
+LIMIT sqlc.arg(row_limit);
 
 -- name: ListJobsByCompany :many
 SELECT *

--- a/internal/db/sitemap_integration_test.go
+++ b/internal/db/sitemap_integration_test.go
@@ -1,10 +1,10 @@
 //go:build integration
 
-// Integration tests for the sitemap keyset read path: the slim slice queries page
-// by an id/slug cursor (never OFFSET) and skip closed jobs, and the boundary
-// queries return the cursor at each Nth row so the sitemap index can enumerate
-// chunks without walking the catalogue. SQL behaviors, verifiable only against a
-// real Postgres. Run with: go test -tags=integration ./internal/db/
+// Integration tests for the sitemap read path: the job feed returns the freshest
+// open jobs (newest id first, closed excluded); the company slice pages by a slug
+// cursor and the boundary query returns the cursor at each Nth row so the company
+// sitemap index can enumerate chunks without walking the table. SQL behaviors,
+// verifiable only against a real Postgres. Run with: go test -tags=integration ./internal/db/
 package db
 
 import (
@@ -27,7 +27,7 @@ func seedOpenJob(ctx context.Context, t *testing.T, q *Queries, n int) Job {
 	return j
 }
 
-func TestJobSitemapKeyset(t *testing.T) {
+func TestJobSitemapFreshest(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)
 	ctx := context.Background()
@@ -35,72 +35,37 @@ func TestJobSitemapKeyset(t *testing.T) {
 
 	var jobs []Job
 	for i := 1; i <= 5; i++ {
-		jobs = append(jobs, seedOpenJob(ctx, t, q, i))
+		jobs = append(jobs, seedOpenJob(ctx, t, q, i)) // ascending ids
 	}
-	// A closed job must never appear in the sitemap slice nor shift the cursor math.
+	// A closed job must never appear in the sitemap.
 	closed := seedOpenJob(ctx, t, q, 6)
 	if _, err := pool.Exec(ctx, `UPDATE jobs SET closed_at = now() WHERE id = $1`, closed.ID); err != nil {
 		t.Fatalf("close job: %v", err)
 	}
 
-	t.Run("slice pages by id cursor and skips closed jobs", func(t *testing.T) {
-		first, err := q.ListJobSitemap(ctx, ListJobSitemapParams{AfterID: 0, BatchSize: 2})
+	t.Run("returns the freshest open jobs, newest id first", func(t *testing.T) {
+		got, err := q.ListJobSitemapFreshest(ctx, 3)
 		if err != nil {
-			t.Fatalf("ListJobSitemap: %v", err)
+			t.Fatalf("ListJobSitemapFreshest: %v", err)
 		}
-		if len(first) != 2 || first[0].ID != jobs[0].ID || first[1].ID != jobs[1].ID {
-			t.Fatalf("first page = %v, want [%d %d]", jobSitemapIDs(first), jobs[0].ID, jobs[1].ID)
-		}
-		if first[0].PublicSlug != jobs[0].PublicSlug {
-			t.Fatalf("public_slug = %q, want %q", first[0].PublicSlug, jobs[0].PublicSlug)
-		}
-
-		// Drain the rest via the keyset cursor: it must stop at the 5 open jobs and
-		// never surface the closed one.
-		var seen []int64
-		cursor := int64(0)
-		for {
-			page, err := q.ListJobSitemap(ctx, ListJobSitemapParams{AfterID: cursor, BatchSize: 2})
-			if err != nil {
-				t.Fatalf("ListJobSitemap page: %v", err)
-			}
-			if len(page) == 0 {
-				break
-			}
-			for _, r := range page {
-				seen = append(seen, r.ID)
-			}
-			cursor = page[len(page)-1].ID
-		}
-		if len(seen) != 5 {
-			t.Fatalf("drained %d open jobs, want 5 (ids %v)", len(seen), seen)
-		}
-		for _, id := range seen {
-			if id == closed.ID {
-				t.Fatalf("closed job %d leaked into sitemap slice", closed.ID)
-			}
+		want := []string{jobs[4].PublicSlug, jobs[3].PublicSlug, jobs[2].PublicSlug}
+		if fmt.Sprint(freshestSlugs(got)) != fmt.Sprint(want) {
+			t.Fatalf("freshest 3 = %v, want %v", freshestSlugs(got), want)
 		}
 	})
 
-	t.Run("boundaries return the id at each Nth open job, excluding the last", func(t *testing.T) {
-		// 5 open jobs, chunk size 2 -> cursors after rows 2 and 4 (row 6=EOF excluded).
-		got, err := q.JobSitemapBoundaries(ctx, 2)
+	t.Run("caps at the limit and excludes closed jobs", func(t *testing.T) {
+		got, err := q.ListJobSitemapFreshest(ctx, 100)
 		if err != nil {
-			t.Fatalf("JobSitemapBoundaries: %v", err)
+			t.Fatalf("ListJobSitemapFreshest: %v", err)
 		}
-		want := []int64{jobs[1].ID, jobs[3].ID}
-		if fmt.Sprint(got) != fmt.Sprint(want) {
-			t.Fatalf("boundaries = %v, want %v", got, want)
+		if len(got) != 5 {
+			t.Fatalf("got %d open jobs, want 5 (%v)", len(got), freshestSlugs(got))
 		}
-	})
-
-	t.Run("boundaries empty when a single chunk covers everything", func(t *testing.T) {
-		got, err := q.JobSitemapBoundaries(ctx, 50)
-		if err != nil {
-			t.Fatalf("JobSitemapBoundaries: %v", err)
-		}
-		if len(got) != 0 {
-			t.Fatalf("boundaries = %v, want none", got)
+		for _, r := range got {
+			if r.PublicSlug == closed.PublicSlug {
+				t.Fatalf("closed job %q leaked into sitemap", closed.PublicSlug)
+			}
 		}
 	})
 }
@@ -144,10 +109,10 @@ func TestCompanySitemapKeyset(t *testing.T) {
 	})
 }
 
-func jobSitemapIDs(rows []ListJobSitemapRow) []int64 {
-	out := make([]int64, len(rows))
+func freshestSlugs(rows []ListJobSitemapFreshestRow) []string {
+	out := make([]string, len(rows))
 	for i, r := range rows {
-		out[i] = r.ID
+		out[i] = r.PublicSlug
 	}
 	return out
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -186,7 +186,6 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/jobs/search", a.SearchJobs)
 	api.Get("/jobs/facets", a.JobFacets)
 	api.Get("/jobs/sitemap", a.JobSitemap)
-	api.Get("/jobs/sitemap/boundaries", a.JobSitemapBoundaries)
 	api.Get("/jobs/:slug", a.GetJob)
 	api.Get("/jobs/:slug/similar", a.SimilarJobs)
 	api.Get("/companies", a.ListCompanies)

--- a/internal/handler/sitemap.go
+++ b/internal/handler/sitemap.go
@@ -8,10 +8,19 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 )
 
-// sitemapMaxURLs is the sitemap-protocol per-file cap. It doubles as the default
-// and hard limit for a slice request and the chunk size the index uses to compute
-// keyset boundaries, so a served chunk can never exceed the protocol limit.
+// sitemapMaxURLs is the sitemap-protocol per-file cap. It bounds the company slice
+// and the chunk size the company index uses for keyset boundaries, so a served
+// chunk can never exceed the protocol limit. It is also the ceiling for the job
+// feed, which ships only its freshest slice (see jobSitemapFreshest).
 const sitemapMaxURLs = 50000
+
+// jobSitemapFreshest is how many of the newest open jobs the sitemap ships. The
+// jobs table is far too large (millions of rows) to enumerate per request without
+// a heap-bound scan that also evicts the buffer cache, so the sitemap covers the
+// freshest slice (ordered by id DESC, a cache-warm scan); fuller coverage would
+// need a precomputed narrow table. Kept at the protocol per-file cap so it fits one
+// sub-sitemap with no chunking.
+const jobSitemapFreshest = sitemapMaxURLs
 
 // sitemapEntry is the slim wire shape a sitemap URL needs — the public slug and a
 // lastmod. Nothing wider (no full job row, no search engine) crosses the wire.
@@ -31,12 +40,9 @@ func sitemapChunk(c *fiber.Ctx) int64 {
 	return int64(min(max(c.QueryInt("chunk", sitemapMaxURLs), 1), sitemapMaxURLs))
 }
 
-// JobSitemap serves one keyset page of open-job sitemap entries after ?after=<id>.
+// JobSitemap serves the freshest open-job sitemap entries (newest id first).
 func (a *API) JobSitemap(c *fiber.Ctx) error {
-	rows, err := a.queries.ListJobSitemap(c.Context(), db.ListJobSitemapParams{
-		AfterID:   int64(c.QueryInt("after", 0)),
-		BatchSize: sitemapLimit(c),
-	})
+	rows, err := a.queries.ListJobSitemapFreshest(c.Context(), jobSitemapFreshest)
 	if err != nil {
 		return err
 	}
@@ -45,16 +51,6 @@ func (a *API) JobSitemap(c *fiber.Ctx) error {
 		entries[i] = sitemapEntry{Slug: r.PublicSlug, UpdatedAt: r.UpdatedAt.Time}
 	}
 	return c.JSON(fiber.Map{"data": entries})
-}
-
-// JobSitemapBoundaries returns the keyset cursor (job id) ending each ?chunk=<n> of
-// open jobs, for building the sitemap index.
-func (a *API) JobSitemapBoundaries(c *fiber.Ctx) error {
-	cursors, err := a.queries.JobSitemapBoundaries(c.Context(), sitemapChunk(c))
-	if err != nil {
-		return err
-	}
-	return c.JSON(fiber.Map{"data": cursors})
 }
 
 // CompanySitemap serves one keyset page of company sitemap entries after ?after=<slug>.

--- a/internal/handler/sitemap_integration_test.go
+++ b/internal/handler/sitemap_integration_test.go
@@ -49,7 +49,6 @@ func TestSitemapEndpoints(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	// Sitemap routes are registered BEFORE the :slug catch-alls, mirroring wiring.
 	app.Get("/api/v1/jobs/sitemap", h.JobSitemap)
-	app.Get("/api/v1/jobs/sitemap/boundaries", h.JobSitemapBoundaries)
 	app.Get("/api/v1/companies/sitemap", h.CompanySitemap)
 	app.Get("/api/v1/companies/sitemap/boundaries", h.CompanySitemapBoundaries)
 	app.Get("/api/v1/jobs/:slug", h.GetJob)
@@ -84,25 +83,14 @@ func TestSitemapEndpoints(t *testing.T) {
 		return d.Data
 	}
 
-	t.Run("job slice is slim, keyset-paged, and not captured by :slug", func(t *testing.T) {
-		got := decodeEntries(t, get(t, "/api/v1/jobs/sitemap?after=0&limit=2"))
-		if len(got) != 2 || got[0].Slug != "job-01" || got[1].Slug != "job-02" {
-			t.Fatalf("page = %+v, want [job-01 job-02]", got)
+	t.Run("job sitemap is slim, freshest-first, and not captured by :slug", func(t *testing.T) {
+		got := decodeEntries(t, get(t, "/api/v1/jobs/sitemap"))
+		// Seeded job-01..job-05 with ascending ids -> newest id first.
+		if len(got) != 5 || got[0].Slug != "job-05" || got[4].Slug != "job-01" {
+			t.Fatalf("page = %+v, want job-05..job-01", got)
 		}
 		if got[0].UpdatedAt == "" {
 			t.Fatalf("entry missing updated_at: %+v", got[0])
-		}
-	})
-
-	t.Run("job boundaries drive the index cursors", func(t *testing.T) {
-		var d struct {
-			Data []int64 `json:"data"`
-		}
-		if err := json.Unmarshal(get(t, "/api/v1/jobs/sitemap/boundaries?chunk=2"), &d); err != nil {
-			t.Fatalf("decode boundaries: %v", err)
-		}
-		if len(d.Data) != 2 {
-			t.Fatalf("boundaries = %v, want 2 cursors for 5 jobs at chunk 2", d.Data)
 		}
 	})
 

--- a/migrations/0034_jobs_open_id_idx.sql
+++ b/migrations/0034_jobs_open_id_idx.sql
@@ -1,0 +1,14 @@
+-- Serves the sitemap's freshest-jobs feed (ListJobSitemapFreshest:
+-- WHERE closed_at IS NULL ORDER BY id DESC LIMIT n). Ordering by id DESC over the
+-- open-jobs partial index reads the newest rows in physical heap order — a
+-- sequential, cache-warm scan (~0.5s for 50k) — where a created_at-ordered index
+-- scatters heap access (~17s) and a full-catalogue enumeration is heap-bound and
+-- pollutes the buffer cache. Partial on the open predicate every list surface
+-- shares (closed_at IS NULL), so it stays small.
+--
+-- Prod note: this runs on first initdb here, but on the live table apply it with
+-- CREATE INDEX CONCURRENTLY (outside a transaction) so the build does not lock writes:
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS jobs_open_id_idx ON jobs (id) WHERE closed_at IS NULL;
+CREATE INDEX IF NOT EXISTS jobs_open_id_idx
+    ON jobs (id)
+    WHERE closed_at IS NULL;

--- a/openspec/specs/web-ssr-seo/spec.md
+++ b/openspec/specs/web-ssr-seo/spec.md
@@ -93,15 +93,16 @@ SHALL include `Organization` JSON-LD.
 
 The site SHALL serve a real `GET /robots.txt` (a valid robots file that allows
 crawling of public pages and references the sitemap) and a `GET /sitemap.xml`
-that is a valid **sitemap index** (`<sitemapindex>`) referencing sub-sitemaps.
-The sub-sitemaps together SHALL enumerate every indexable public URL — the
-static pages, all open job (`/jobs/:slug`) pages, and all company
-(`/companies/:slug`) pages — with no artificial cap, each sub-sitemap holding at
-most 50,000 URLs (the sitemap-protocol limit). Neither the index nor any
+that is a valid **sitemap index** (`<sitemapindex>`) referencing sub-sitemaps for
+the static pages, the jobs, and the companies. Neither the index nor any
 sub-sitemap SHALL return the HTML application shell, and each SHALL be valid XML.
-The job and company sub-sitemaps SHALL be paginated by a keyset cursor (the last
-id / slug of the previous chunk) rather than an offset, so serving a chunk is a
-bounded scan independent of catalogue size.
+Every sub-sitemap SHALL hold at most 50,000 URLs (the sitemap-protocol limit).
+All companies (`/companies/:slug`) SHALL be enumerated across keyset-cursor-paged
+company sub-sitemaps. The job sub-sitemap SHALL list the **freshest** open jobs
+(`/jobs/:slug`, newest first) up to the per-file limit, rather than the full
+catalogue: the jobs table is too large to enumerate per request without a
+heap-bound scan that also evicts the buffer cache, so full job coverage is a
+deliberate follow-up (a precomputed narrow table), not a live scan.
 
 #### Scenario: robots.txt is a valid robots file
 
@@ -113,20 +114,18 @@ bounded scan independent of catalogue size.
 
 - **WHEN** `GET /sitemap.xml` is requested
 - **THEN** the response is valid XML with a `<sitemapindex>` root listing
-  sub-sitemap `<loc>` URLs for the static pages, every job chunk, and every
-  company chunk, and it does not contain job or company page `<url>` entries
-  directly
+  sub-sitemap `<loc>` URLs for the static pages, the jobs, and every company
+  chunk, and it does not contain job or company page `<url>` entries directly
 
-#### Scenario: a job sub-sitemap lists a bounded chunk of open jobs
+#### Scenario: the job sub-sitemap lists the freshest open jobs
 
-- **WHEN** a job sub-sitemap URL from the index is requested
+- **WHEN** the job sub-sitemap URL from the index is requested
 - **THEN** the response is a valid `<urlset>` of at most 50,000 open-job
-  (`/jobs/:slug`) URLs derived from current data, each with a `<lastmod>`
+  (`/jobs/:slug`) URLs, newest first, each with a `<lastmod>`, and no closed job
 
-#### Scenario: sub-sitemaps together cover the full open catalogue
+#### Scenario: company sub-sitemaps cover all companies
 
-- **WHEN** the index's job and company sub-sitemaps are followed in sequence by
-  their keyset cursors
-- **THEN** every open job and every company in the catalogue appears in exactly
-  one sub-sitemap, with no 5,000-row (or other artificial) cap
+- **WHEN** the index's company sub-sitemaps are followed in sequence by their
+  slug cursors
+- **THEN** every company appears in exactly one sub-sitemap, with no artificial cap
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -209,20 +209,13 @@ export function createApi(
 
   // --- Sitemap --------------------------------------------------------------
   //
-  // Slim, keyset-paginated feeds behind the sitemap index (server routes only).
-  // The slice endpoints return one chunk after a cursor; the boundary endpoints
-  // return the cursor ending each chunk, so the index can enumerate sub-sitemaps
-  // without walking the catalogue.
+  // Feeds behind the sitemap index (server routes only). Jobs ship their freshest
+  // slice (one file); companies are keyset-paginated across chunks, with a boundary
+  // endpoint returning the cursor ending each chunk so the index can enumerate them.
 
-  /** One chunk of open-job sitemap entries with id > `after` (0 for the first). */
-  async function sitemapJobs(after: number, limit: number): Promise<SitemapEntry[]> {
-    const res = await request<{ data: SitemapEntry[] }>(`/api/v1/jobs/sitemap?after=${after}&limit=${limit}`);
-    return res.data;
-  }
-
-  /** The job-id cursor ending each `chunk`-sized page of open jobs. */
-  async function sitemapJobBoundaries(chunk: number): Promise<number[]> {
-    const res = await request<{ data: number[] }>(`/api/v1/jobs/sitemap/boundaries?chunk=${chunk}`);
+  /** The freshest open-job sitemap entries (newest first), one file. */
+  async function sitemapJobs(): Promise<SitemapEntry[]> {
+    const res = await request<{ data: SitemapEntry[] }>('/api/v1/jobs/sitemap');
     return res.data;
   }
 
@@ -648,7 +641,6 @@ export function createApi(
     listCompanies,
     getCompany,
     sitemapJobs,
-    sitemapJobBoundaries,
     sitemapCompanies,
     sitemapCompanyBoundaries,
     register,

--- a/web/src/routes/sitemap-jobs.xml/+server.ts
+++ b/web/src/routes/sitemap-jobs.xml/+server.ts
@@ -1,12 +1,12 @@
 import { serverApi } from '$lib/server/api';
-import { SITEMAP_CHUNK, urlsetXml, xmlResponse } from '$lib/sitemap';
+import { urlsetXml, xmlResponse } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
 
-// One keyset chunk of open-job URLs, addressed by ?after=<job id> (0 for the
-// first chunk). The sitemap index lists these; each fetches exactly one chunk.
+// The freshest open-job URLs (newest first), one file. The jobs table is too large
+// to enumerate per request without a heap-bound scan that evicts the buffer cache,
+// so the sitemap ships the freshest slice; the backend caps the count.
 export const GET: RequestHandler = async ({ url, fetch }) => {
-  const after = Number(url.searchParams.get('after') ?? '0') || 0;
-  const jobs = await serverApi(fetch).sitemapJobs(after, SITEMAP_CHUNK);
+  const jobs = await serverApi(fetch).sitemapJobs();
   const entries = jobs.map((j) => ({ loc: `${url.origin}/jobs/${j.slug}`, lastmod: j.updated_at }));
   return xmlResponse(urlsetXml(entries));
 };

--- a/web/src/routes/sitemap.xml/+server.ts
+++ b/web/src/routes/sitemap.xml/+server.ts
@@ -2,27 +2,18 @@ import { serverApi } from '$lib/server/api';
 import { SITEMAP_CHUNK, sitemapIndexXml, xmlResponse } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
 
-// The sitemap index. It lists one sub-sitemap for the static pages plus one per
-// keyset chunk of jobs and companies, so the whole open catalogue is covered
-// within the 50k-URL protocol limit. The chunk cursors come from the backend's
-// boundary endpoints (the id/slug ending each chunk), so building the index is a
-// couple of small queries — never a walk of the catalogue. Cached; a chunk is
-// fetched only when a crawler follows its URL.
+// The sitemap index: the static pages, the freshest-jobs sub-sitemap (one file),
+// and one company sub-sitemap per keyset chunk. Company chunk cursors come from the
+// backend's boundary endpoint (the slug ending each chunk), so building the index
+// is a couple of small queries — never a walk of the catalogue. Cached; a
+// sub-sitemap is fetched only when a crawler follows its URL.
 export const GET: RequestHandler = async ({ url, fetch }) => {
   const origin = url.origin;
-  const api = serverApi(fetch);
+  const companyCursors = await serverApi(fetch).sitemapCompanyBoundaries(SITEMAP_CHUNK);
 
-  const [jobCursors, companyCursors] = await Promise.all([
-    api.sitemapJobBoundaries(SITEMAP_CHUNK),
-    api.sitemapCompanyBoundaries(SITEMAP_CHUNK),
-  ]);
-
-  const locs = [`${origin}/sitemap-pages.xml`];
-  // The first chunk starts before every row (job id 0 / empty slug); each
-  // boundary cursor starts the next chunk.
-  for (const after of [0, ...jobCursors]) {
-    locs.push(`${origin}/sitemap-jobs.xml?after=${after}`);
-  }
+  const locs = [`${origin}/sitemap-pages.xml`, `${origin}/sitemap-jobs.xml`];
+  // The first company chunk starts before every slug (empty string); each boundary
+  // cursor starts the next chunk.
   for (const after of ['', ...companyCursors]) {
     locs.push(`${origin}/sitemap-companies.xml?after=${encodeURIComponent(after)}`);
   }


### PR DESCRIPTION
## Why

The job sitemap shipped in #338 enumerated **all ~2.5M open jobs** per crawl via keyset chunks. On prod that's a heap-bound scan (measured **40–113s**) that **504s** behind nginx's 60s timeout and **evicts the buffer cache**, degrading the whole DB (job list, counts) and piling up connections. `/sitemap.xml` regressed from the old bounded file to a timeout.

## What

Companies (small, narrow table) stay fully paginated. Jobs now ship their **freshest slice**, one file:

- `/sitemap.xml` → index: static pages + one jobs sub-sitemap + company chunks
- `/sitemap-jobs.xml` → the freshest 50k open jobs (`ORDER BY id DESC`), one `<urlset>`

`ORDER BY id DESC` over the new partial index `jobs_open_id_idx` reads the newest rows in **physical heap order** — a cache-warm **~0.5s** scan — versus ~17s for `created_at` order (scattered heap) or minutes for the full catalogue. Drops the job keyset/boundary queries, their endpoint, and now-unused helpers.

Migration `0034_jobs_open_id_idx.sql` adds the index (apply `CONCURRENTLY` on the live volume — done on prod during this incident).

## Coverage note

The freshest 50k is what this DB can serve per request without a heap-bound scan. **Full job coverage** is a deliberate follow-up needing a precomputed narrow table (`job_sitemap(slug, updated_at)`) or static generation — not a live scan. Spec `web-ssr-seo` updated to reflect the freshest-slice behaviour.

## Verification

- db + handler integration tests (freshest-first, closed excluded, companies paginated).
- `svelte-check` clean; `npm run build` OK; `go build/vet`, unit tests pass.
- Local end-to-end (Postgres + Go + node SSR): index lists pages+jobs+companies; `/sitemap-jobs.xml` returns newest-first with the closed job excluded.
- On prod: `jobs_open_id_idx` build makes the freshest-50k query **578ms**; also applied the merged-but-unapplied `jobs_open_created_at_id_idx` (0033), cutting `/api/v1/jobs` from 26s.

Follow-up to #338.