### PR TITLE
fix(db): drop the duplicate open-jobs created_at index (dedup #333 vs #345)

### DIFF
--- a/migrations/0035_dedup_open_created_index.sql
+++ b/migrations/0035_dedup_open_created_index.sql
@@ -1,0 +1,13 @@
+-- Deduplicate the open-jobs "newest-first" index. Two migrations landed independently
+-- creating an IDENTICAL btree on (created_at DESC, id DESC) WHERE closed_at IS NULL:
+--   jobs_open_created_at_id_idx   — 0033_job_list_indexes.sql        (#333)
+--   jobs_open_created_idx         — 0033_jobs_open_created_index.sql (#345, the canonical
+--                                    GET /api/v1/jobs fix)
+-- Keep #345's and drop the #333 duplicate so the catalogue doesn't carry two identical
+-- indexes (double write cost + disk on ~2.5M rows) for one query. The other two indexes
+-- from 0033_job_list_indexes are NOT duplicated and stay: jobs_open_company_created_at_id_idx
+-- (ListJobsByCompany) and jobs_open_enrich_freshness_idx (ClaimEnrichmentBatch).
+--
+-- Prod note: on the live table drop it without blocking writes with
+--   DROP INDEX CONCURRENTLY IF EXISTS jobs_open_created_at_id_idx;
+DROP INDEX IF EXISTS jobs_open_created_at_id_idx;


### PR DESCRIPTION
## Problem

#333 (`0033_job_list_indexes`) and #345 (`0033_jobs_open_created_index`) landed independently — each fixing the slow `GET /api/v1/jobs` by creating an **identical** btree on `(created_at DESC, id DESC) WHERE closed_at IS NULL`:

- `jobs_open_created_at_id_idx` (#333)
- `jobs_open_created_idx` (#345 — the canonical jobs-list fix)

Carrying both means two identical indexes for one query — double write cost + disk on ~2.5M rows. (There are also duplicate migration *numbers* — `0033_*` ×2 and `0034_*` ×2 — cosmetic, since all are `IF NOT EXISTS` and apply on initdb; left as-is.)

## Fix

`migrations/0035_dedup_open_created_index.sql`: `DROP INDEX IF EXISTS jobs_open_created_at_id_idx;` — drop the #333 duplicate, keep #345's canonical `jobs_open_created_idx`.

**Not touched (not duplicated — the only index for their query):**
- `jobs_open_company_created_at_id_idx` → `ListJobsByCompany` (`ORDER BY created_at DESC`)
- `jobs_open_enrich_freshness_idx` → `ClaimEnrichmentBatch` (`ORDER BY COALESCE(posted_at, created_at) DESC`)

## Verification

Applied **all** origin/main migrations + `0035` on a throwaway Postgres:
- all apply cleanly;
- final `jobs_open*` set = `company_created_at_id`, `created` (#345), `enrich_freshness`, `id` (#345) — the duplicate `created_at_id` is **gone**, the rest intact (asserted `true`).
- `make sqlc` → no codegen drift.

Prod note: `DROP INDEX IF EXISTS` is safe regardless of whether the index was applied; on the live table use `DROP INDEX CONCURRENTLY IF EXISTS` to avoid the lock.

Generated with assistance from Claude Code.