### PR TITLE
feat(web): nudge filter tabs up, extend to /companies, fix company-hero overlap

### DIFF
--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -15,6 +15,7 @@
   import InfiniteScroll from './InfiniteScroll.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyFiltersPanel from './CompanyFiltersPanel.svelte';
+  import FilterEdgeTab from './FilterEdgeTab.svelte';
 
   // The first page is server-rendered (route `load`) for the current filters, so
   // the rows are in the initial HTML.
@@ -84,19 +85,6 @@
   </aside>
 
   <div class="min-w-0 flex-1">
-    <div class="mb-4 flex items-center gap-2">
-      <!-- The header search is this page's text filter (see HeaderListSearch);
-           the spacer keeps the mobile Filters button right-aligned. -->
-      <div class="flex-1"></div>
-      <button
-        type="button"
-        class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent md:hidden"
-        onclick={() => (drawerOpen = true)}
-      >
-        Filters{#if filters.active > 0}&nbsp;({filters.active}){/if}
-      </button>
-    </div>
-
     {#if companies.status === 'loading'}
       <States state="loading" />
     {:else if companies.status === 'error'}
@@ -107,7 +95,8 @@
         message={filters.value.q || filters.active > 0 ? 'No matching companies.' : 'No companies yet.'}
       />
     {:else}
-      <p class="mb-3 text-sm text-muted-foreground" aria-live="polite">
+      <!-- Clear the left-edge filters tab on mobile (see FilterEdgeTab below). -->
+      <p class="mb-3 pl-12 text-sm text-muted-foreground md:pl-0" aria-live="polite">
         {companies.total.toLocaleString()} {companies.total === 1 ? 'company' : 'companies'}
       </p>
       <div class="flex flex-col gap-3">
@@ -141,6 +130,9 @@
     {/if}
   </div>
 </div>
+
+<!-- Mobile filters entry (the desktop aside is always visible). -->
+<FilterEdgeTab active={filters.active} onclick={() => (drawerOpen = true)} />
 
 {#if drawerOpen}
   <div class="fixed inset-0 z-40 md:hidden">

--- a/web/src/lib/components/FilterEdgeTab.svelte
+++ b/web/src/lib/components/FilterEdgeTab.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { SlidersHorizontal } from '@lucide/svelte';
+
+  // Icon-only tab pinned to the left viewport edge on mobile, opening the filters
+  // drawer — the mobile counterpart to the desktop aside panel, and a mirror of
+  // the jobs list's right-edge swipe tab. Hidden at/above `md` where the aside is
+  // always visible. The active-filter count rides as a corner badge. Used by the
+  // top-level list pages (/jobs, /companies); embedded/scoped lists (a company's
+  // jobs) keep an inline button instead, so the tab never overlaps a page hero.
+  let { active = 0, onclick }: { active?: number; onclick: () => void } = $props();
+</script>
+
+<button
+  type="button"
+  {onclick}
+  aria-label="Filters"
+  title="Filters"
+  class="fixed left-0 top-16 z-30 flex items-center rounded-r-lg border border-l-0 border-border bg-secondary p-3 text-secondary-foreground shadow-sm transition-colors hover:bg-accent md:hidden"
+>
+  <SlidersHorizontal class="h-5 w-5 shrink-0" />
+  {#if active > 0}
+    <span
+      class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"
+    >
+      {active}
+    </span>
+  {/if}
+</button>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
-  import { Layers, SlidersHorizontal } from '@lucide/svelte';
+  import { Layers } from '@lucide/svelte';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
@@ -15,6 +15,7 @@
   import type { Job, FacetCounts } from '$lib/types';
   import { Input } from '$lib/ui';
   import FiltersPanel from './FiltersPanel.svelte';
+  import FilterEdgeTab from './FilterEdgeTab.svelte';
   import States from './States.svelte';
   import JobRow from './JobRow.svelte';
   import LoadMore from './LoadMore.svelte';
@@ -150,15 +151,25 @@
   <div class="min-w-0 flex-1">
     {#if !standalone}
       <!-- Company embed: the text filter lives inline (the header search is the
-           standalone list's filter). Mobile filter access is the left-edge tab below. -->
-      <Input
-        type="search"
-        value={filters.value.q}
-        oninput={(e) => filters.setQuery(e.currentTarget.value)}
-        placeholder="Search jobs…"
-        aria-label="Search jobs"
-        class="mb-4 w-full"
-      />
+           standalone list's filter), with the Filters button beside it. No fixed
+           edge tab here — it would overlap the company hero above this list. -->
+      <div class="mb-4 flex items-center gap-2">
+        <Input
+          type="search"
+          value={filters.value.q}
+          oninput={(e) => filters.setQuery(e.currentTarget.value)}
+          placeholder="Search jobs…"
+          aria-label="Search jobs"
+          class="min-w-0 flex-1"
+        />
+        <button
+          type="button"
+          class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent md:hidden"
+          onclick={() => (drawerOpen = true)}
+        >
+          Filters{#if filters.active > 0}&nbsp;({filters.active}){/if}
+        </button>
+      </div>
     {/if}
 
     {#if jobs.status === 'loading'}
@@ -168,8 +179,11 @@
     {:else if jobs.items.length === 0}
       <States state="empty" message="No matching jobs." />
     {:else}
-      <!-- Clear the left-edge filters tab (top-20, level with this first line) on mobile. -->
-      <p class="mb-3 pl-12 text-sm text-muted-foreground md:pl-0" aria-live="polite">
+      <!-- On the standalone list, clear the left-edge filters tab on mobile. -->
+      <p
+        class={['mb-3 text-sm text-muted-foreground', standalone && 'pl-12 md:pl-0']}
+        aria-live="polite"
+      >
         {jobs.total.toLocaleString()} {jobs.total === 1 ? 'job' : 'jobs'}
       </p>
       <div class="flex flex-col gap-3">
@@ -188,39 +202,22 @@
   </div>
 </div>
 
-<!-- Mobile filters entry: an icon-only tab pinned to the left viewport edge,
-     mirroring the swipe tab on the right (header h-14 + page py-6 = top-20). Fixed
-     so it stays reachable while scrolling; hidden on desktop where the aside panel
-     is always visible. The active-filter count rides as a corner badge. -->
-<button
-  type="button"
-  onclick={() => (drawerOpen = true)}
-  aria-label="Filters"
-  title="Filters"
-  class="fixed left-0 top-20 z-30 flex items-center rounded-r-lg border border-l-0 border-border bg-secondary p-3 text-secondary-foreground shadow-sm transition-colors hover:bg-accent md:hidden"
->
-  <SlidersHorizontal class="h-5 w-5 shrink-0" />
-  {#if filters.active > 0}
-    <span
-      class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"
-    >
-      {filters.active}
-    </span>
-  {/if}
-</button>
-
 {#if standalone}
+  <!-- Standalone list only: the fixed edge tabs sit over the top of the viewport,
+       where this page's content starts. The embedded company view keeps its inline
+       Filters button (above) so nothing overlaps the company hero. -->
+  <FilterEdgeTab active={filters.active} onclick={() => (drawerOpen = true)} />
+
   <!-- Swipe-mode entry: an icon-only button pinned to the right viewport edge,
-       level with the top of the filters panel (header h-14 + page py-6 = top-20).
-       Fixed, so it only exists while the standalone jobs list is mounted (never on
-       the embedded company view) and stays reachable while scrolling; kept below
-       the z-40 mobile overlays. -->
+       level with the left filters tab (top-16). Fixed, so it only exists while the
+       standalone jobs list is mounted (never on the embedded company view) and
+       stays reachable while scrolling; kept below the z-40 mobile overlays. -->
   <button
     type="button"
     onclick={openSwipe}
     aria-label="Swipe mode"
     title="Swipe mode"
-    class="fixed right-0 top-20 z-30 flex items-center rounded-l-lg border border-r-0 border-border bg-secondary p-3 text-secondary-foreground shadow-sm transition-colors hover:bg-accent"
+    class="fixed right-0 top-16 z-30 flex items-center rounded-l-lg border border-r-0 border-border bg-secondary p-3 text-secondary-foreground shadow-sm transition-colors hover:bg-accent"
   >
     <Layers class="h-5 w-5 shrink-0" />
   </button>


### PR DESCRIPTION
Follow-up polish to the mobile filters edge tab (#351), from mobile QA:

## Changes
- **Nudge up**: both edge tabs move `top-20` → `top-16` so they sit above the count line rather than level with it.
- **Companies list**: `/companies` gets the same left-edge filters tab (with active-count badge + count offset), replacing its old inline "Filters" pill.
- **Company hero overlap (regression fix)**: the fixed edge tab now renders **only on the standalone list**. The embedded company-detail job list (`/companies/[slug]`) keeps an inline Filters button beside its search input, so the fixed tab no longer overlaps the company logo/name/subscribe header.
- **Refactor**: extract the shared `FilterEdgeTab.svelte` (two concrete call sites now — jobs + companies).

## Test Plan
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `/jobs` (dev): both tabs at `top-16`, badge on active filters, count cleared
- [x] `/companies` (dev): left-edge tab present (DOM), old pill gone, count cleared
- [x] `/companies/[slug]` (dev): fixed edge tab + swipe tab **absent** (DOM: 0/0) — no hero overlap. (Scoped job list shows only a skeleton in dev — a pre-existing SSR-seed artifact confirmed identical on `origin/main` baseline; verified full render on prod post-deploy.)
- [ ] Prod: confirm all three surfaces after deploy