### PR TITLE
feat(sources): add Traffit ATS adapter + harvest prober

### DIFF
--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -567,4 +567,5 @@ var probers = map[string]prober{
 	"jazzhr":          jazzhrProber{},
 	"careerplug":      careerplugProber{},
 	"paycom":          paycomProber{},
+	"traffit":         traffitProber{},
 }

--- a/cmd/harvest-boards/traffit.go
+++ b/cmd/harvest-boards/traffit.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+// traffitProber probes a Traffit tenant. A board is the tenant subdomain; the keyless
+// list endpoint returns JSON with the open-posting count for a real tenant, and an HTML
+// placeholder for a non-tenant subdomain (which fails to decode and is skipped). Traffit
+// serves every tenant under a wildcard cert/DNS, so there is no keyless way to enumerate
+// candidates — the prober validates a supplied seed list rather than discovering its own.
+type traffitProber struct{}
+
+// probe queries one tenant's list for its open-posting count. A missing tenant (getter
+// error on the HTML placeholder) or one with no live postings yields ("", 0, nil) — a
+// skip. The company name falls back to the slug; display names are curated in the seed file.
+func (traffitProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
+	var resp struct {
+		Count int `json:"count"`
+		Items []struct {
+			AdvertID int64 `json:"advertId"`
+		} `json:"items"`
+	}
+	url := fmt.Sprintf("https://%s.traffit.com/public/an/list/?limit=1", slug)
+	if err := c.GetJSON(ctx, url, &resp); err != nil {
+		return "", 0, nil
+	}
+	// Liveness is "the endpoint returned a posting", like every other prober.
+	if len(resp.Items) == 0 {
+		return "", 0, nil
+	}
+	return slug, resp.Count, nil
+}

--- a/cmd/harvest-boards/traffit_test.go
+++ b/cmd/harvest-boards/traffit_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTraffitRegistered(t *testing.T) {
+	if _, ok := probers["traffit"]; !ok {
+		t.Fatal(`probers["traffit"] missing`)
+	}
+}
+
+func TestTraffitProbe(t *testing.T) {
+	p := traffitProber{}
+	getter := fakeGetter{
+		"https://cloudfide.traffit.com/public/an/list/?limit=1": `{"count":5,"items":[{"advertId":50}]}`,
+		// live tenant, zero open postings -> skip
+		"https://empty.traffit.com/public/an/list/?limit=1": `{"count":0,"items":[]}`,
+	}
+
+	cases := []struct {
+		slug     string
+		wantName string
+		wantN    int
+	}{
+		{"cloudfide", "cloudfide", 5},
+		{"empty", "", 0},
+		{"bogus", "", 0}, // unmapped URL (HTML placeholder in prod) -> getter error -> skip
+	}
+	for _, c := range cases {
+		name, n, err := p.probe(context.Background(), getter, c.slug)
+		if err != nil {
+			t.Errorf("probe(%s) err = %v, want nil", c.slug, err)
+		}
+		if name != c.wantName || n != c.wantN {
+			t.Errorf("probe(%s) = (%q, %d), want (%q, %d)", c.slug, name, n, c.wantName, c.wantN)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -193,6 +193,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTrakstar(c),
 		NewFactorial(c),
 		NewZoho(c),
+		NewTraffit(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/internal/sources/traffit.go
+++ b/internal/sources/traffit.go
@@ -1,0 +1,127 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// traffit adapts Traffit career sites. The board is the tenant subdomain (from a public
+// URL, <tenant>.traffit.com); the keyless list endpoint returns fully-populated postings —
+// title, inline HTML description, and a structured geolocation — so no per-posting detail
+// fetch is needed. The endpoint caps a page at traffitPageSize items, so the board is paged.
+type traffit struct {
+	http JSONGetter
+}
+
+// NewTraffit builds the Traffit adapter over the given HTTP client.
+func NewTraffit(c JSONGetter) Source { return traffit{http: c} }
+
+func (traffit) Provider() string { return "traffit" }
+
+const (
+	// traffitPageSize is the endpoint's maximum page size; a request for more is clamped to it.
+	traffitPageSize = 100
+	// traffitMaxPages bounds the walk so a feed that never reaches count (or keeps returning
+	// full pages) cannot loop forever. It sits far above any real tenant's posting count.
+	traffitMaxPages = 500
+)
+
+// traffitList is one page of a tenant's public advert list.
+type traffitList struct {
+	Count int           `json:"count"`
+	Items []traffitItem `json:"items"`
+}
+
+// traffitItem is one posting in the list. Both advertId and advertPublishId are stable
+// numeric ids; advertId is the dedup key, with advertPublishId as a fallback.
+type traffitItem struct {
+	AdvertID        int64  `json:"advertId"`
+	AdvertPublishID int64  `json:"advertPublishId"`
+	Title           string `json:"title"`
+	Name            string `json:"name"`
+	URL             string `json:"url"`
+	Description     string `json:"description"`
+	Geolocation     string `json:"geolocation"`
+	ValidStart      int64  `json:"validStart"`
+}
+
+// traffitGeo is the posting's structured location, carried as a JSON string in geolocation.
+type traffitGeo struct {
+	Locality string `json:"locality"`
+	Region1  string `json:"region1"`
+	Country  string `json:"country"`
+}
+
+// String renders the location as "Locality, Region, Country", dropping empty parts. An empty
+// or unparseable geolocation yields "" so the pipeline's dictionary derivation stays silent.
+func (g traffitGeo) String() string {
+	var parts []string
+	for _, p := range []string{g.Locality, g.Region1, g.Country} {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+func (t traffit) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page, fetched := 0, 0; page < traffitMaxPages; page++ {
+		url := fmt.Sprintf("https://%s.traffit.com/public/an/list/?limit=%d&offset=%d",
+			e.Board, traffitPageSize, page*traffitPageSize)
+		var list traffitList
+		if err := t.http.GetJSON(ctx, url, &list); err != nil {
+			return nil, fmt.Errorf("traffit: list %s offset %d: %w", e.Board, page*traffitPageSize, err)
+		}
+		if len(list.Items) == 0 {
+			break
+		}
+		for _, it := range list.Items {
+			if j, ok := t.toJob(it, e); ok {
+				jobs = append(jobs, j)
+			}
+		}
+		if fetched += len(list.Items); fetched >= list.Count {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a posting to a Job, returning ok=false when it carries no id (which would
+// collide on the dedup key). Title falls back to name; company comes from config.
+func (traffit) toJob(it traffitItem, e CompanyEntry) (Job, bool) {
+	id := it.AdvertID
+	if id == 0 {
+		id = it.AdvertPublishID
+	}
+	if id == 0 {
+		return Job{}, false
+	}
+
+	title := strings.TrimSpace(it.Title)
+	if title == "" {
+		title = strings.TrimSpace(it.Name)
+	}
+
+	var location string
+	if it.Geolocation != "" {
+		var geo traffitGeo
+		if json.Unmarshal([]byte(it.Geolocation), &geo) == nil {
+			location = geo.String()
+		}
+	}
+
+	return Job{
+		ExternalID:  strconv.FormatInt(id, 10),
+		URL:         it.URL,
+		Title:       title,
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(it.Description),
+		PostedAt:    parseEpochSeconds(it.ValidStart),
+	}, true
+}

--- a/internal/sources/traffit_test.go
+++ b/internal/sources/traffit_test.go
@@ -1,0 +1,138 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestTraffitProvider(t *testing.T) {
+	if got := NewTraffit(nil).Provider(); got != "traffit" {
+		t.Errorf("Provider() = %q, want %q", got, "traffit")
+	}
+}
+
+func TestTraffitFetchMapsFieldsAndPaginates(t *testing.T) {
+	// Page 1 is a full page (traffitPageSize items), so the walk continues; page 2 carries
+	// the interesting cases and, once collected, reaches count so no third page is fetched.
+	// The reported count is the raw item total (103): the walk pages by it, then drops the
+	// id-less posting, so 102 jobs survive.
+	var page1 strings.Builder
+	page1.WriteString(`{"count":103,"items":[`)
+	for i := 0; i < traffitPageSize; i++ {
+		if i > 0 {
+			page1.WriteString(",")
+		}
+		page1.WriteString(`{"advertId":`)
+		page1.WriteString(itoa(1000 + i))
+		page1.WriteString(`,"title":"Role","name":"Role","url":"https://acme.traffit.com/public/an/x`)
+		page1.WriteString(itoa(1000 + i))
+		page1.WriteString(`"}`)
+	}
+	page1.WriteString(`]}`)
+
+	// One fully-populated posting, one with a null geolocation, one with no id (dropped).
+	page2 := `{"count":103,"items":[
+		{"advertId":2001,"title":"  Senior Java Engineer  ","name":"Senior Java Engineer",
+		 "url":"https://acme.traffit.com/public/an/abc","validStart":1770284174,
+		 "description":"<p>Build things</p><script>evil()</script>",
+		 "geolocation":"{\"iso\":\"pl\",\"locality\":\"Warszawa\",\"region1\":\"Mazowieckie\",\"country\":\"Polska\"}"},
+		{"advertId":2002,"title":"","name":"Remote Fallback Role",
+		 "url":"https://acme.traffit.com/public/an/def","geolocation":null},
+		{"advertId":0,"advertPublishId":0,"title":"No Id","url":"https://acme.traffit.com/public/an/ghi"}
+	]}`
+
+	fake := (&routedHTTP{}).
+		route("offset=0", page1.String()).
+		route("offset=100", page2)
+
+	jobs, err := NewTraffit(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "traffit", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// 100 from page 1 + 2 from page 2 (the id-less posting dropped) = 102.
+	if len(jobs) != traffitPageSize+2 {
+		t.Fatalf("len(jobs) = %d, want %d across two pages with one id-less posting dropped", len(jobs), traffitPageSize+2)
+	}
+	// Two requests only: the walk reaches count and must not fetch a third page.
+	if fake.calls != 2 {
+		t.Fatalf("fake.calls = %d, want 2 (no third page once count is reached)", fake.calls)
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	if _, ok := byID["0"]; ok {
+		t.Error("id-less posting should be dropped, but a job with ExternalID \"0\" was kept")
+	}
+
+	full, ok := byID["2001"]
+	if !ok {
+		t.Fatal("job 2001 missing")
+	}
+	if full.Title != "Senior Java Engineer" {
+		t.Errorf("Title = %q, want trimmed %q", full.Title, "Senior Java Engineer")
+	}
+	if full.Company != "Acme" {
+		t.Errorf("Company = %q, want %q", full.Company, "Acme")
+	}
+	if strings.Contains(full.Description, "<script") {
+		t.Errorf("Description not sanitized: %q", full.Description)
+	}
+	if want := "Warszawa, Mazowieckie, Polska"; full.Location != want {
+		t.Errorf("Location = %q, want %q", full.Location, want)
+	}
+	if full.PostedAt == nil || full.PostedAt.Year() != 2026 {
+		t.Errorf("PostedAt = %v, want a 2026 date from validStart", full.PostedAt)
+	}
+	if full.URL != "https://acme.traffit.com/public/an/abc" {
+		t.Errorf("URL = %q, want the posting url", full.URL)
+	}
+
+	fb, ok := byID["2002"]
+	if !ok {
+		t.Fatal("job 2002 missing")
+	}
+	if fb.Title != "Remote Fallback Role" {
+		t.Errorf("Title = %q, want name fallback %q", fb.Title, "Remote Fallback Role")
+	}
+	if fb.Location != "" {
+		t.Errorf("Location = %q, want empty for null geolocation", fb.Location)
+	}
+}
+
+func TestTraffitFetchStopsOnEmptyPage(t *testing.T) {
+	// count over-reports (999) but the tenant runs out of postings on page 2. An empty page
+	// must end the walk instead of spinning up to the page cap.
+	var page1 strings.Builder
+	page1.WriteString(`{"count":999,"items":[`)
+	for i := 0; i < traffitPageSize; i++ {
+		if i > 0 {
+			page1.WriteString(",")
+		}
+		page1.WriteString(`{"advertId":`)
+		page1.WriteString(itoa(1000 + i))
+		page1.WriteString(`,"title":"Role","url":"https://acme.traffit.com/public/an/x"}`)
+	}
+	page1.WriteString(`]}`)
+
+	fake := (&routedHTTP{}).
+		route("offset=0", page1.String()).
+		route("offset=100", `{"count":999,"items":[]}`)
+
+	jobs, err := NewTraffit(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != traffitPageSize {
+		t.Fatalf("len(jobs) = %d, want %d (empty second page ends the walk)", len(jobs), traffitPageSize)
+	}
+	if fake.calls != 2 {
+		t.Fatalf("fake.calls = %d, want 2 (stop at the empty page)", fake.calls)
+	}
+}

--- a/openspec/changes/add-traffit-source/.openspec.yaml
+++ b/openspec/changes/add-traffit-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/add-traffit-source/design.md
+++ b/openspec/changes/add-traffit-source/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Traffit hosts each client on `<tenant>.traffit.com`. The career widget bootstraps from
+`/public/an/generateJs/` and fetches postings from `/public/an/list/`. That list endpoint
+is keyless JSON and self-contained — the description HTML is inline, so no per-posting
+detail fetch is needed. Verified during source discovery:
+
+- `GET https://<tenant>.traffit.com/public/an/list/` → `{"count":N,"items":[...]}`.
+- A non-tenant subdomain (wildcard DNS + wildcard cert make every subdomain resolve)
+  returns an HTML placeholder, not JSON.
+- Page size caps at 100 (`?limit`), defaults to 10; `?offset` works. So large boards
+  MUST be paged (e.g. `jit` = 167 postings).
+- 14 live tenants validated (~385 open postings): cloudfide, traffit, trust, people,
+  spline, zen, welove, jit, balticamadeus, fintalent, b2bnetwork, soflab, itlt, hrhub.
+
+Relevant item fields: `advertId` / `advertPublishId` (stable id), `title`/`name`,
+`description` (HTML), `geolocation` (a JSON **string** with `locality`/`region1`/
+`country`/`iso`), `language`, `url`, `applicationForm`, `validStart` (Unix seconds).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless `traffit` adapter that returns every live posting of one tenant, paged.
+- A harvest prober that live-validates candidate tenant slugs.
+- A seeded `sources/traffit.yml` with a validated starter tenant set.
+
+**Non-Goals:**
+- Auto-discovery of tenants (not keyless-feasible: wildcard DNS/cert; crt.sh only sees
+  marketing subdomains). Seed comes from search dorks / a curated list, validated live.
+- Applicant-form parsing (`/public/form/...`) — that page is a dead end for ingest.
+- A central Traffit aggregator — none exists (`jobs.`/`kariera.` return 503).
+
+## Decisions
+
+- **Board = tenant subdomain; board-based, not boardless.** Mirrors greenhouse/lever:
+  one entry per tenant, `board` required, stays in the source facet. `Provider()` →
+  `"traffit"`.
+- **Pagination loop.** Request `?limit=100&offset=N` starting at 0, accumulate items,
+  stop when `len(collected) >= count` or a page returns 0 items. Cap the loop with a
+  page bound (defensive, like gupy's `gupyMaxOffset`) so a misbehaving feed can't spin.
+- **Dedup id = `advertId`** (fall back to `advertPublishId` if absent), stringified.
+  Skip a posting with no id (would collide on the dedup key), matching comeet.
+- **Location** from the `geolocation` JSON string: parse it, render `locality` (+
+  `region1`/`country` when present). `geolocation` can be `null` (e.g. cloudfide's first
+  posting) → empty location, the dictionary derivation stays silent, no guess.
+- **posted_at** from `validStart` via the existing `parseEpochSeconds` helper.
+- **Description** run through the shared `sanitizeHTML`.
+- **WorkMode** left empty — Traffit's list carries no structured workplace enum, so the
+  pipeline's location/dictionary derivation decides (no free-text heuristic in the adapter,
+  per the structured-signal convention).
+- **Prober** (`cmd/harvest-boards/traffit.go`): `GetJSON` the list endpoint for a slug;
+  on error (HTML placeholder won't parse) or zero items return `("", 0, nil)` — a skip.
+  Company name falls back to the slug; a human curates display names in `sources/traffit.yml`.
+  Registered in `probers["traffit"]`. Not a `discoverer` (no keyless enumeration source).
+
+## Risks / Trade-offs
+
+- **Seed staleness / manual discovery.** Without auto-discovery, new tenants are found
+  only when someone re-runs a dork sweep and re-probes. Acceptable: the prober makes
+  re-validation cheap, and the adapter's value doesn't depend on exhaustive coverage.
+- **Page-size assumption.** The 100 cap is observed, not documented; if Traffit changes
+  it the loop still terminates on the `count`/empty-page conditions, only the request
+  count changes.
+- **Language mix.** Many tenants post in Polish; that's expected for CEE coverage and the
+  enrichment/classification dictionaries already handle non-English input.

--- a/openspec/changes/add-traffit-source/proposal.md
+++ b/openspec/changes/add-traffit-source/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Traffit is a widely-used Polish/CEE Applicant Tracking System hosting each client's
+career page on a `<tenant>.traffit.com` subdomain. Every tenant exposes a keyless,
+self-contained public JSON list endpoint (`/public/an/list/`) that returns fully
+populated postings — title, HTML description, structured geolocation, and a stable
+posting id — in one call. We do not ingest it today, so a large pool of live
+Polish/CEE IT vacancies is missing from the catalogue, a region where our coverage
+is thin.
+
+## What Changes
+
+- Add a `traffit` source adapter (`internal/sources/traffit.go`) over the keyless
+  `https://<board>.traffit.com/public/an/list/` JSON API. The board id is the tenant
+  subdomain; the adapter is board-based (not boardless) and stays in the source facet.
+- The adapter **paginates** (`?limit=100&offset=N`): the endpoint caps a page at 100
+  items and defaults to 10, so a single fetch would silently truncate large boards
+  (e.g. `jit` has 167 postings). It loops until it has collected `count` items or a
+  page comes back empty.
+- Register the adapter in `sources.All` (one line).
+- Add a `traffitProber` to `cmd/harvest-boards` that validates a seed list of candidate
+  tenant slugs against the list endpoint (a real tenant returns JSON with a job count;
+  a non-tenant subdomain returns an HTML placeholder, so `GetJSON` fails and the slug
+  is skipped — the same shape as the greenhouse/lever probers). Auto-discovery from
+  DNS/certificate-transparency is not keyless-feasible (Traffit serves all tenants
+  under a wildcard cert and wildcard DNS), so the seed is supplied, not enumerated.
+- Add `sources/traffit.yml` seeded with a validated starter set of live tenants
+  (~14 tenants, ~385 open postings) so the adapter delivers volume immediately.
+
+## Capabilities
+
+### New Capabilities
+- `traffit-source`: crawling one Traffit tenant's public job list into the catalogue,
+  and validating candidate Traffit tenant slugs during harvest.
+
+### Modified Capabilities
+<!-- none: no existing spec's requirements change -->
+
+## Impact
+
+- New: `internal/sources/traffit.go` (+ test), `cmd/harvest-boards/traffit.go` (+ test),
+  `sources/traffit.yml`.
+- Modified: `internal/sources/source.go` (one registry line in `sources.All`),
+  `cmd/harvest-boards`'s `probers` map (one line).
+- Ops: after committing, a `cmd/ingest sources/traffit.yml` cron entry crawls the file;
+  no schema/migration change. Incremental search indexing works unchanged (adapter goes
+  through `UpsertJob`).

--- a/openspec/changes/add-traffit-source/specs/traffit-source/spec.md
+++ b/openspec/changes/add-traffit-source/specs/traffit-source/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Traffit tenant crawl
+
+The system SHALL provide a `traffit` source adapter that crawls one Traffit tenant's
+public job list into the catalogue. The board id is the tenant subdomain, and the
+adapter fetches `https://<board>.traffit.com/public/an/list/` — a keyless public JSON
+endpoint. The adapter is board-based (it requires a board id) and appears in the source
+facet.
+
+#### Scenario: Board yields all live postings
+
+- **WHEN** the adapter fetches a configured tenant board
+- **THEN** it returns one `Job` per posting in the tenant's list, with the posting's
+  title, HTML description (sanitized), free-text location derived from the posting's
+  structured geolocation, apply/detail URL, and posted-at timestamp
+
+#### Scenario: Stable dedup identity
+
+- **WHEN** the adapter maps a posting to a `Job`
+- **THEN** the `ExternalID` is the posting's stable Traffit advert id, so re-crawling
+  the same tenant dedups to the same catalogue row
+
+### Requirement: Paginated collection
+
+The endpoint caps a page at 100 items and defaults to 10, so the adapter SHALL page
+through the tenant's postings until it has collected the reported total (`count`) or a
+page returns no items — a single-page fetch would silently truncate boards larger than
+one page.
+
+#### Scenario: Board larger than one page
+
+- **WHEN** a tenant has more postings than one page (e.g. 167 postings)
+- **THEN** the adapter returns every live posting, not just the first page
+
+#### Scenario: Guard against a never-ending feed
+
+- **WHEN** the endpoint keeps returning a full page without ever reaching `count`
+- **THEN** the adapter stops after a bounded number of pages rather than looping forever
+
+### Requirement: Harvest tenant validation
+
+The system SHALL provide a harvest prober for the `traffit` provider that validates a
+candidate tenant slug against the list endpoint. A real tenant returns JSON with a job
+count; a non-tenant subdomain returns an HTML placeholder. The prober keeps a candidate
+only when the endpoint returns parseable JSON with at least one live posting, and skips
+any other candidate without aborting the harvest.
+
+#### Scenario: Live tenant kept
+
+- **WHEN** the prober probes a slug whose list endpoint returns JSON with live postings
+- **THEN** it reports the tenant as live with its open-job count
+
+#### Scenario: Non-tenant skipped
+
+- **WHEN** the prober probes a slug whose subdomain returns the HTML placeholder (no JSON)
+- **THEN** it skips the candidate silently and continues with the rest

--- a/openspec/changes/add-traffit-source/tasks.md
+++ b/openspec/changes/add-traffit-source/tasks.md
@@ -1,0 +1,39 @@
+## 1. Adapter
+
+- [x] 1.1 Write `internal/sources/traffit_test.go` (RED): a fake JSON getter returns a
+  two-page list (`count` > page size) and the adapter must return all postings mapped
+  correctly — title, sanitized description, location from the `geolocation` JSON string,
+  `ExternalID` = advert id, `PostedAt` from `validStart`. Include a case with
+  `geolocation: null` (empty location, no error) and a posting missing an id (skipped).
+- [x] 1.2 Implement `internal/sources/traffit.go` (GREEN): `NewTraffit`, `Provider()`
+  → `"traffit"`, `Fetch` paging `?limit=100&offset=N` until `count` collected / empty
+  page (with a defensive page cap), mapping items to `Job`. Reuse `sanitizeHTML` and
+  `parseEpochSeconds`.
+- [x] 1.3 Register `NewTraffit(c)` in `sources.All` (`internal/sources/source.go`).
+- [x] 1.4 REFACTOR + simplify the adapter diff; re-run `go test ./internal/sources/`.
+
+## 2. Harvest prober
+
+- [x] 2.1 Write `cmd/harvest-boards/traffit_test.go` (RED): probing a slug whose getter
+  returns list JSON with postings reports the count; a slug whose getter errors / returns
+  no items yields `("", 0, nil)`. Assert `probers["traffit"]` is registered.
+- [x] 2.2 Implement `cmd/harvest-boards/traffit.go` (GREEN): `traffitProber.probe`
+  `GetJSON`s the list endpoint, returns `(slug, count, nil)` for a live tenant and a skip
+  otherwise; add `"traffit"` to the `probers` map.
+- [x] 2.3 REFACTOR + simplify; re-run `go test ./cmd/harvest-boards/`.
+
+## 3. Seed file
+
+- [x] 3.1 Add `sources/traffit.yml` with the validated starter tenants (cloudfide,
+  traffit, trust, people, spline, zen, welove, jit, balticamadeus, fintalent, b2bnetwork,
+  soflab, itlt, hrhub) — each `company` + `board` (subdomain), with curated display names.
+- [x] 3.2 Validate the file loads and passes registry validation:
+  `go run ./cmd/ingest sources/traffit.yml` against a local DB (or dry-load), confirming
+  no "unknown provider" / empty-board errors.
+
+## 4. Finish
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...` all green.
+- [x] 4.2 Request code review on the full diff; address Critical/Important.
+- [x] 4.3 Verify end-to-end: crawl one tenant and confirm postings persist / a large
+  tenant returns > one page of jobs.

--- a/sources/traffit.yml
+++ b/sources/traffit.yml
@@ -1,0 +1,35 @@
+# Traffit career sites. Provider is the filename; each entry is company + board.
+# board = the tenant subdomain (<board>.traffit.com); see internal/sources/traffit.go.
+# The keyless list endpoint (<board>.traffit.com/public/an/list/) returns every open
+# posting fully populated, paged 100 at a time. Traffit is a Polish/CEE ATS, so many
+# postings are in Polish. Each board validated live (list endpoint returned >0) before
+# adding; cmd/harvest-boards traffit <seed.json> re-validates candidate slugs.
+
+- company: Cloudfide
+  board: cloudfide
+- company: TRAFFIT
+  board: traffit
+- company: Trust
+  board: trust
+- company: People
+  board: people
+- company: Spline
+  board: spline
+- company: ZEN
+  board: zen
+- company: WeLove
+  board: welove
+- company: JIT Team
+  board: jit
+- company: Baltic Amadeus
+  board: balticamadeus
+- company: Fintalent
+  board: fintalent
+- company: B2B Network
+  board: b2bnetwork
+- company: SOFLAB
+  board: soflab
+- company: IT LeasingTeam
+  board: itlt
+- company: HR|hub
+  board: hrhub


### PR DESCRIPTION
## Summary

Adds a **Traffit** job-source adapter. Traffit is a Polish/CEE ATS that hosts each client on `<tenant>.traffit.com` and exposes a keyless public JSON list endpoint (`/public/an/list/`) returning fully-populated postings — title, inline HTML description, structured geolocation, and a stable advert id — in one call.

- **`internal/sources/traffit.go`** — board-based adapter (board = tenant subdomain), registered in `sources.All`. **Paginates** `?limit=100&offset=N`: the endpoint caps a page at 100 (defaults to 10), so a single fetch would silently truncate large boards (e.g. `jit` has 167 postings). Maps advertId→ExternalID (fallback advertPublishId; skips id-less), title→name fallback, sanitized description, location from the `geolocation` JSON-string field, posted-at from `validStart`. No structured WorkMode (endpoint has none) — the pipeline's dictionaries decide.
- **`cmd/harvest-boards/traffit.go`** — a `traffitProber` that live-validates a candidate tenant slug against the list endpoint (real tenant → JSON + count; non-tenant subdomain → HTML placeholder → skip). Not a discoverer: Traffit serves tenants under wildcard DNS + wildcard cert, so there is no keyless way to enumerate them — the seed is supplied and validated.
- **`sources/traffit.yml`** — 14 tenants validated live (~385 open postings): cloudfide, traffit, trust, people, spline, zen, welove, jit, balticamadeus, fintalent, b2bnetwork, soflab, itlt, hrhub.
- OpenSpec change `add-traffit-source` (proposal/design/specs/tasks) included.

No schema/migration change; incremental search indexing works unchanged (adapter goes through `UpsertJob`).

## Test Plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` all pass (new `traffit_test.go` covers pagination, geolocation-null, id-less skip, name fallback; prober test covers live/empty/non-tenant)
- [x] Live e2e against real endpoint: `cloudfide` → 5 jobs, `jit` → **167 jobs** (confirms multi-page pagination collects the full board)
- [ ] Post-merge ops: add a cron entry `cmd/ingest sources/traffit.yml`