### PR TITLE
fix(sources): decode Zoho's double-escaped richtext descriptions

### DIFF
--- a/internal/sources/zoho.go
+++ b/internal/sources/zoho.go
@@ -105,29 +105,88 @@ func (z zoho) description(ctx context.Context, url string) (string, bool) {
 	return body, true
 }
 
-// zohoHexEscape matches a \xNN JS hex escape, which Zoho uses for every non-alphanumeric
-// byte of the embedded record (quotes, angle brackets, …).
-var zohoHexEscape = regexp.MustCompile(`\\x[0-9a-fA-F]{2}`)
-
-// zohoUnescape decodes the JS string escaping of an embedded Zoho value: \xNN hex escapes to
-// their byte first (turning \x22 into a quote, \x3C into '<', …), then the standard
-// backslash escapes. The result is HTML, which the caller sanitizes.
+// zohoUnescape decodes the JS string escaping of an embedded Zoho value into HTML, which the
+// caller sanitizes. The record is serialized into the page as a JS string whose richtext field
+// values are themselves already escaped, so markup arrives escaped twice: a closing tag's slash
+// as \\\/ (an escaped backslash followed by an escaped slash) and a bullet as \\u2022. A single
+// pass would peel only the outer layer, leaving a stray backslash that makes <\/span> an invalid
+// tag the sanitizer emits as visible &lt;\/span&gt; text. We therefore decode one level per pass
+// and repeat until the string stabilizes; this terminates because every changing pass removes at
+// least one (finite) backslash, and leaves single-escaped values (which stabilize after one pass)
+// untouched.
 func zohoUnescape(s string) string {
-	s = zohoHexEscape.ReplaceAllStringFunc(s, func(m string) string {
-		b, err := strconv.ParseUint(m[2:], 16, 8)
-		if err != nil {
-			return m
+	for range zohoMaxUnescapePasses {
+		next := zohoUnescapeOnce(s)
+		if next == s {
+			break
 		}
-		return string(rune(b))
-	})
-	return strings.NewReplacer(
-		`\/`, `/`,
-		`\n`, "\n",
-		`\t`, "\t",
-		`\r`, "",
-		`\"`, `"`,
-		`\\`, `\`,
-	).Replace(s)
+		s = next
+	}
+	return s
+}
+
+// zohoMaxUnescapePasses caps the decode loop as a guard; the observed nesting is two levels, so
+// this is slack, not a functional bound.
+const zohoMaxUnescapePasses = 8
+
+// zohoUnescapeOnce decodes one level of JS string escaping in a single left-to-right pass, so an
+// escaped backslash (\\) is consumed as one unit before the following character is read — the
+// ordering that lets \\\/ collapse to / across two passes. \xNN and \uNNNN decode to their rune;
+// \n\t\r\"\/ are the standard escapes; an unknown \X yields X (matching JS, and folding Zoho's
+// stray \- back to -).
+func zohoUnescapeOnce(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] != '\\' || i+1 >= len(s) {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		switch c := s[i+1]; c {
+		case '\\':
+			b.WriteByte('\\')
+			i += 2
+		case '/':
+			b.WriteByte('/')
+			i += 2
+		case 'n':
+			b.WriteByte('\n')
+			i += 2
+		case 't':
+			b.WriteByte('\t')
+			i += 2
+		case 'r':
+			i += 2
+		case '"':
+			b.WriteByte('"')
+			i += 2
+		case 'x':
+			if i+4 <= len(s) {
+				if v, err := strconv.ParseUint(s[i+2:i+4], 16, 8); err == nil {
+					b.WriteRune(rune(v))
+					i += 4
+					continue
+				}
+			}
+			b.WriteByte(c)
+			i += 2
+		case 'u':
+			if i+6 <= len(s) {
+				if v, err := strconv.ParseUint(s[i+2:i+6], 16, 16); err == nil {
+					b.WriteRune(rune(v))
+					i += 6
+					continue
+				}
+			}
+			b.WriteByte(c)
+			i += 2
+		default:
+			b.WriteByte(c)
+			i += 2
+		}
+	}
+	return b.String()
 }
 
 // elementAttrByID returns the named attribute of the first element with the given tag and id,

--- a/internal/sources/zoho_test.go
+++ b/internal/sources/zoho_test.go
@@ -13,6 +13,13 @@ func TestZohoUnescape(t *testing.T) {
 		`line\nbreak`:              "line\nbreak",  // backslash-n
 		`path\/to`:                 "path/to",      // escaped slash
 		`plain`:                    "plain",        // nothing to do
+		// The richtext field is escaped twice, so markup arrives double-escaped: a
+		// single pass would leave a stray backslash. Decoding to a fixpoint resolves it.
+		`<\\\/span>`:    "</span>",    // double-escaped closing tag
+		`<\\\/p>`:       "</p>",       // double-escaped closing tag
+		`\\u2022`:       "•",          // double-escaped unicode bullet
+		`\\\x22q\\\x22`: `"q"`,        // double-escaped quotes
+		`margin\-top`:   "margin-top", // stray backslash-hyphen folds to hyphen
 	}
 	for in, want := range cases {
 		if got := zohoUnescape(in); got != want {
@@ -36,6 +43,29 @@ func TestZohoElementAttrByID(t *testing.T) {
 func zohoDetailHTML(description string) string {
 	return `<html><body><script>var rec = "{\x22id\x22:\x221\x22,\x22Job_Description\x22:\x22` +
 		description + `\x22,\x22Country\x22:null}";</script></body></html>`
+}
+
+// TestZohoDescriptionDoubleEscaped guards the real-world case where the detail record
+// escapes the richtext value twice: closing tags arrive as <\\\/p> and bullets as \\u2022.
+// Before the fixpoint decode these reached storage as visible &lt;\/p&gt; / • text.
+func TestZohoDescriptionDoubleEscaped(t *testing.T) {
+	desc := `<p style=\\\x22margin\-top:0px\\\x22>Duties\\u2022audit files.<br\/><\\\/p>`
+	http := (&routedHTTP{}).route("/jobs/Careers/1", zohoDetailHTML(desc))
+
+	got, ok := zoho{http: http}.description(context.Background(), "https://acme.zohorecruit.com/jobs/Careers/1")
+	if !ok {
+		t.Fatal("description: not found")
+	}
+	// A leftover backslash (e.g. •, <\/p>) or an entity-escaped tag (&lt;) means the
+	// nested escaping was not fully peeled.
+	if strings.Contains(got, "&lt;") || strings.Contains(got, `\`) {
+		t.Errorf("description leaks escaped markup: %q", got)
+	}
+	for _, want := range []string{"</p>", "•", "Duties", "audit files"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("description = %q, missing %q", got, want)
+		}
+	}
 }
 
 func TestZohoFetch(t *testing.T) {


### PR DESCRIPTION
## Problem

Zoho Recruit job descriptions rendered with literal HTML tags and `•` in the body, e.g. [operations-specialist-elevate-claims-solutions](https://freehire.dev/jobs/operations-specialist-elevate-claims-solutions-dl2pf7no) showed `</span>`/`</p>` as visible text.

## Root cause

Zoho serializes the detail record into the page as a JS string whose richtext `Job_Description` value is **itself already escaped**, so markup arrives escaped **twice**: a closing tag's slash as `\\/` and a bullet as `\u2022`. The single-pass `zohoUnescape` peeled only the outer layer, leaving a stray backslash that turned `<\/span>` into an invalid tag the sanitizer emitted as visible `&lt;\/span&gt;` text. Opening tags, having no slash, still rendered — hence the asymmetry. Bullets leaked as literal `\u2022` because `\uNNNN` was never handled.

## Fix

Rewrite `zohoUnescape` as a single left-to-right scanner (handling `\xNN`, `\uNNNN`, standard escapes, and unknown `\X`→`X`) applied to a **fixpoint**, so nested escaping is fully peeled while single-escaped values are untouched (they stabilize after one pass). Verified against the live posting's captured blob: 0 residual backslashes, tags render, bullets decode. Adds a double-escaping regression test.

No migrations, no new search attributes. Existing broken descriptions self-heal on the next Zoho crawl (content_hash changes → re-upsert + re-index).