### PR TITLE
feat(web): Profiles page (list + create/edit routes) & slimmer jobs edge tabs

### DIFF
--- a/web/src/lib/components/FilterEdgeTab.svelte
+++ b/web/src/lib/components/FilterEdgeTab.svelte
@@ -15,9 +15,9 @@
   {onclick}
   aria-label="Filters"
   title="Filters"
-  class="fixed left-0 top-16 z-30 flex items-center rounded-r-lg border border-l-0 border-border bg-secondary p-3 text-secondary-foreground shadow-sm transition-colors hover:bg-accent md:hidden"
+  class="fixed left-0 top-16 z-30 flex items-center rounded-r-lg border border-l-0 border-border bg-secondary py-2.5 pl-1.5 pr-2 text-secondary-foreground shadow-sm transition-colors hover:bg-accent md:hidden"
 >
-  <SlidersHorizontal class="h-5 w-5 shrink-0" />
+  <SlidersHorizontal class="size-4 shrink-0" />
   {#if active > 0}
     <span
       class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -44,7 +44,7 @@
 
   const accountLinks = [
     { href: '/my/jobs', label: 'My jobs' },
-    { href: '/my/profiles', label: 'Search profiles' },
+    { href: '/my/profiles', label: 'Profiles' },
     { href: '/my/searches', label: 'Saved searches' },
     { href: '/my/notifications', label: 'Notifications' },
     { href: '/my/api-keys', label: 'API keys' },

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -217,9 +217,9 @@
     onclick={openSwipe}
     aria-label="Swipe mode"
     title="Swipe mode"
-    class="fixed right-0 top-16 z-30 flex items-center rounded-l-lg border border-r-0 border-border bg-secondary p-3 text-secondary-foreground shadow-sm transition-colors hover:bg-accent"
+    class="fixed right-0 top-16 z-30 flex items-center rounded-l-lg border border-r-0 border-border bg-secondary py-2.5 pl-2 pr-1.5 text-secondary-foreground shadow-sm transition-colors hover:bg-accent"
   >
-    <Layers class="h-5 w-5 shrink-0" />
+    <Layers class="size-4 shrink-0" />
   </button>
 {/if}
 

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { ArrowLeft, X } from '@lucide/svelte';
+  import { goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
+  import { ApiError, extractResumeSkills, facetCounts } from '$lib/api';
+  import { CATEGORY_OPTIONS, categoryLabel, type FacetOption } from '$lib/facets';
+  import { searchProfiles } from '$lib/searchProfiles.svelte';
+  import type { SearchProfile } from '$lib/types';
+  import { Button, Input } from '$lib/ui';
+  import RemoteSearchSelect from './facets/RemoteSearchSelect.svelte';
+  import SearchSelect from './facets/SearchSelect.svelte';
+
+  // Mirror of the server's specialization cap (searchprofile.maxSpecializations).
+  const MAX_SPECIALIZATIONS = 5;
+
+  // Undefined = create; a profile = edit (its fields seed the form). The wrapping
+  // route resolves the profile (or redirects) before rendering, so here it is a fact.
+  let { profile }: { profile?: SearchProfile } = $props();
+
+  const editing = $derived(profile !== undefined);
+
+  // Seed the form once from the profile prop. The edit route keys on `profile.id`, so
+  // a different profile remounts this component — the initial-value capture is intended.
+  // svelte-ignore state_referenced_locally
+  let name = $state(profile?.name ?? '');
+  // svelte-ignore state_referenced_locally
+  let specializations = $state.raw<string[]>(profile ? [...profile.specializations] : []);
+  // svelte-ignore state_referenced_locally
+  let skills = $state.raw<string[]>(profile ? [...profile.skills] : []);
+  let formError = $state<string | null>(null);
+  let busy = $state(false);
+
+  // Résumé upload → skill extraction. The file/text is parsed server-side and discarded;
+  // the returned slugs merge (union) into the skills field without wiping manual entries.
+  let resumeBusy = $state(false);
+  let resumeText = $state('');
+  let resumeError = $state<string | null>(null);
+  let resumeNote = $state<string | null>(null);
+  let fileInput = $state<HTMLInputElement | null>(null);
+
+  // The universe of skills (canonical tokens with job counts) for the typeahead, from
+  // the facet-distribution endpoint — the same source the filter panel uses. Empty
+  // params = the whole catalogue's skill distribution.
+  let skillDist = $state.raw<FacetOption[]>([]);
+
+  const canSubmit = $derived(
+    name.trim() !== '' && specializations.length > 0 && skills.length > 0,
+  );
+
+  const backHref = resolve('/my/profiles');
+
+  // The skills typeahead: filter the loaded distribution locally (dictionary-only, so
+  // only known skills are addable) and cap the visible matches.
+  function searchSkills(query: string): Promise<FacetOption[]> {
+    const q = query.trim().toLowerCase();
+    const matches = q ? skillDist.filter((o) => o.label.toLowerCase().includes(q)) : skillDist;
+    return Promise.resolve(matches.slice(0, 50));
+  }
+
+  async function loadSkills() {
+    try {
+      const counts = await facetCounts(new URLSearchParams());
+      const dist = counts.facets?.skills ?? {};
+      skillDist = Object.entries(dist)
+        .map(([value, count]) => ({ value, label: value, count }))
+        .toSorted((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+    } catch {
+      // best-effort: an edited profile's skills still render as chips (seeded via
+      // fallbackLabel); the typeahead just has nothing to suggest.
+    }
+  }
+
+  $effect(() => {
+    void loadSkills();
+  });
+
+  // Extract skills from a résumé (a PDF File or pasted text) and merge them into the
+  // skills field as a deduplicated union, preserving anything already entered.
+  async function analyzeResume(input: File | string) {
+    resumeBusy = true;
+    resumeError = null;
+    resumeNote = null;
+    try {
+      const extracted = await extractResumeSkills(input);
+      if (extracted.length === 0) {
+        resumeNote = 'No known skills found in the résumé.';
+        return;
+      }
+      const before = skills.length;
+      skills = [...new Set([...skills, ...extracted])];
+      const added = skills.length - before;
+      resumeNote =
+        added > 0
+          ? `Added ${added} skill${added === 1 ? '' : 's'} from your résumé.`
+          : 'All résumé skills were already listed.';
+    } catch (err) {
+      resumeError =
+        err instanceof ApiError ? err.message : 'Could not read the résumé. Please try again.';
+    } finally {
+      resumeBusy = false;
+    }
+  }
+
+  function onResumeFile(e: Event) {
+    const target = e.currentTarget as HTMLInputElement;
+    const file = target.files?.[0];
+    target.value = ''; // clear so re-selecting the same file fires change again
+    if (file) void analyzeResume(file);
+  }
+
+  // Multi-select with a cap: toggling off is always allowed; toggling on is refused
+  // past MAX_SPECIALIZATIONS (with a hint) so the form matches the server's limit.
+  function toggleSpecialization(value: string) {
+    if (specializations.includes(value)) {
+      specializations = specializations.filter((s) => s !== value);
+      formError = null;
+      return;
+    }
+    if (specializations.length >= MAX_SPECIALIZATIONS) {
+      formError = `You can pick at most ${MAX_SPECIALIZATIONS} specializations.`;
+      return;
+    }
+    specializations = [...specializations, value];
+    formError = null;
+  }
+
+  function toggleSkill(value: string) {
+    skills = skills.includes(value) ? skills.filter((s) => s !== value) : [...skills, value];
+  }
+
+  async function submit(e: SubmitEvent) {
+    e.preventDefault();
+    if (!canSubmit || busy) return;
+    busy = true;
+    formError = null;
+    try {
+      if (profile === undefined) {
+        await searchProfiles.create(name.trim(), specializations, skills);
+      } else {
+        await searchProfiles.update(profile.id, {
+          name: name.trim(),
+          specializations,
+          skills,
+        });
+      }
+      await goto(backHref);
+    } catch (err) {
+      formError =
+        err instanceof ApiError ? err.message : 'Could not save the profile. Please try again.';
+      busy = false;
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-6">
+  <div class="flex flex-col gap-3">
+    <a
+      href={backHref}
+      class="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <ArrowLeft class="size-4" />
+      Profiles
+    </a>
+    <div class="flex flex-col gap-1">
+      <h1 class="text-2xl font-semibold tracking-tight">
+        {editing ? 'Edit profile' : 'New profile'}
+      </h1>
+      <p class="text-sm text-muted-foreground">
+        Describe what you do — one or more specializations and your skills — and reuse it to
+        find relevant work.
+      </p>
+    </div>
+  </div>
+
+  <form onsubmit={submit} class="flex flex-col gap-6 rounded-xl border border-border bg-card p-5 sm:p-6">
+    <label class="flex flex-col gap-1.5">
+      <span class="text-sm font-medium">Name</span>
+      <Input bind:value={name} placeholder="e.g. Go backend" maxlength={100} class="w-full" />
+      <span class="text-xs text-muted-foreground">A short label to recognise this profile.</span>
+    </label>
+
+    <div class="flex flex-col gap-2">
+      <div class="flex items-baseline justify-between">
+        <span class="text-sm font-medium">Specializations</span>
+        <span class="text-xs tabular-nums text-muted-foreground">
+          {specializations.length}/{MAX_SPECIALIZATIONS}
+        </span>
+      </div>
+      {#if specializations.length > 0}
+        <div class="flex flex-wrap gap-1.5">
+          {#each specializations as value (value)}
+            <button
+              type="button"
+              onclick={() => toggleSpecialization(value)}
+              class="inline-flex items-center gap-1 rounded-full bg-primary px-2.5 py-1 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+            >
+              {categoryLabel(value)}
+              <X class="size-3" />
+            </button>
+          {/each}
+        </div>
+      {/if}
+      <SearchSelect
+        options={CATEGORY_OPTIONS}
+        selected={specializations}
+        placeholder="Search specializations"
+        onToggle={toggleSpecialization}
+        clearOnSelect
+      />
+    </div>
+
+    <div class="flex flex-col gap-2">
+      <div class="flex items-baseline justify-between">
+        <span class="text-sm font-medium">Skills</span>
+        <span class="text-xs tabular-nums text-muted-foreground">{skills.length}</span>
+      </div>
+      <RemoteSearchSelect
+        search={searchSkills}
+        selected={skills}
+        placeholder="Search skills"
+        onToggle={toggleSkill}
+        fallbackLabel={(v) => v}
+        clearOnSelect
+      />
+
+      <div class="flex flex-col gap-1.5 rounded-lg border border-dashed border-border p-3">
+        <span class="text-sm font-medium">Add skills from your résumé</span>
+        <div class="flex flex-wrap items-center gap-2">
+          <input
+            type="file"
+            accept="application/pdf,.pdf"
+            class="hidden"
+            bind:this={fileInput}
+            onchange={onResumeFile}
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            type="button"
+            onclick={() => fileInput?.click()}
+            disabled={resumeBusy}
+          >
+            {resumeBusy ? 'Analyzing…' : 'Upload résumé (PDF)'}
+          </Button>
+          <span class="text-xs text-muted-foreground">extracts your skills into the field above</span>
+        </div>
+        <details class="text-xs">
+          <summary class="cursor-pointer text-muted-foreground">or paste résumé text</summary>
+          <div class="mt-2 flex flex-col gap-2">
+            <textarea
+              bind:value={resumeText}
+              rows="4"
+              placeholder="Paste your résumé here…"
+              class="w-full rounded-md border border-border bg-background p-2 text-sm"
+            ></textarea>
+            <div>
+              <Button
+                variant="secondary"
+                size="sm"
+                type="button"
+                onclick={() => analyzeResume(resumeText)}
+                disabled={resumeBusy || resumeText.trim() === ''}
+              >
+                Extract skills
+              </Button>
+            </div>
+          </div>
+        </details>
+        {#if resumeError}
+          <p class="text-sm text-destructive">{resumeError}</p>
+        {:else if resumeNote}
+          <p class="text-xs text-muted-foreground">{resumeNote}</p>
+        {/if}
+      </div>
+    </div>
+
+    {#if formError}
+      <p class="text-sm text-destructive">{formError}</p>
+    {/if}
+
+    <div class="flex items-center gap-2 border-t border-border pt-4">
+      <Button variant="primary" type="submit" disabled={!canSubmit || busy}>
+        {busy ? 'Saving…' : editing ? 'Save changes' : 'Create profile'}
+      </Button>
+      <Button variant="ghost" href={backHref}>Cancel</Button>
+    </div>
+  </form>
+</div>

--- a/web/src/lib/components/SearchProfilesView.svelte
+++ b/web/src/lib/components/SearchProfilesView.svelte
@@ -1,44 +1,22 @@
 <script lang="ts">
-  import { ApiError, extractResumeSkills, facetCounts } from '$lib/api';
+  import { Pencil, Plus, Trash2 } from '@lucide/svelte';
+  import { resolve } from '$app/paths';
+  import { facetCounts } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
-  import { CATEGORY_OPTIONS, categoryLabel, type FacetOption } from '$lib/facets';
+  import { categoryLabel } from '$lib/facets';
   import { searchProfiles } from '$lib/searchProfiles.svelte';
   import { categoryParams, computeGap, sortSkillsByCount, type SkillGap } from '$lib/skillGap';
   import type { SearchProfile } from '$lib/types';
-  import { Button, Input } from '$lib/ui';
-  import RemoteSearchSelect from './facets/RemoteSearchSelect.svelte';
-  import SearchSelect from './facets/SearchSelect.svelte';
+  import { Button } from '$lib/ui';
   import States from './States.svelte';
 
-  // Mirror of the server's specialization cap (searchprofile.maxSpecializations).
-  const MAX_SPECIALIZATIONS = 5;
-
   let status = $state<'loading' | 'error' | 'ready'>('loading');
+  let listError = $state<string | null>(null);
   const profiles = $derived(searchProfiles.items);
 
-  // The universe of skills (canonical tokens with job counts) for the typeahead, fetched
-  // from the facet-distribution endpoint — the same source the filter panel's dynamic
-  // skills facet uses. Empty params = the whole catalogue's skill distribution.
-  let skillDist = $state.raw<FacetOption[]>([]);
-
-  // Form doubles as create (editingId null) and edit (editingId set). A profile needs a
-  // name, at least one specialization, and at least one skill — the same invariants the
-  // server enforces.
-  let editingId = $state<number | null>(null);
-  let name = $state('');
-  let specializations = $state.raw<string[]>([]);
-  let skills = $state.raw<string[]>([]);
-  let formError = $state<string | null>(null);
-  let busy = $state(false);
-
-  // Résumé upload → skill extraction. The file/text is parsed server-side and discarded;
-  // the returned slugs merge (union) into the skills field without wiping manual entries.
-  let resumeBusy = $state(false);
-  let resumeText = $state('');
-  let resumeError = $state<string | null>(null);
-  let resumeNote = $state<string | null>(null);
-  let fileInput = $state<HTMLInputElement | null>(null);
+  const newHref = resolve('/my/profiles/new');
+  const editHref = (id: number) => resolve('/my/profiles/[id]/edit', { id: String(id) });
 
   // Per-profile market skill-gap, keyed by profile id. Market skills are cached by the
   // sorted specialization set, so profiles sharing specializations reuse one facet fetch.
@@ -46,19 +24,6 @@
   let gaps = $state.raw<Record<number, SkillGap>>({});
   const marketCache = new Map<string, string[]>();
   let gapGeneration = 0;
-
-  const canSubmit = $derived(
-    name.trim() !== '' && specializations.length > 0 && skills.length > 0,
-  );
-
-  // The skills typeahead: filter the loaded distribution locally (dictionary-only, so only
-  // known skills are addable) and cap the visible matches. Reads the current distribution
-  // at call time, so a slightly-late load is reflected on the next keystroke.
-  function searchSkills(query: string): Promise<FacetOption[]> {
-    const q = query.trim().toLowerCase();
-    const matches = q ? skillDist.filter((o) => o.label.toLowerCase().includes(q)) : skillDist;
-    return Promise.resolve(matches.slice(0, 50));
-  }
 
   async function loadProfiles() {
     status = 'loading';
@@ -68,53 +33,6 @@
     } catch {
       status = 'error';
     }
-  }
-
-  async function loadSkills() {
-    try {
-      const counts = await facetCounts(new URLSearchParams());
-      const dist = counts.facets?.skills ?? {};
-      skillDist = Object.entries(dist)
-        .map(([value, count]) => ({ value, label: value, count }))
-        .toSorted((a, b) => b.count - a.count || a.label.localeCompare(b.label));
-    } catch {
-      // best-effort: an empty distribution still lets an edited profile's skills show as
-      // chips (seeded via fallbackLabel); the typeahead just has nothing to suggest.
-    }
-  }
-
-  // Extract skills from a résumé (a PDF File or pasted text) and merge them into the
-  // skills field as a deduplicated union, preserving anything already entered.
-  async function analyzeResume(input: File | string) {
-    resumeBusy = true;
-    resumeError = null;
-    resumeNote = null;
-    try {
-      const extracted = await extractResumeSkills(input);
-      if (extracted.length === 0) {
-        resumeNote = 'No known skills found in the résumé.';
-        return;
-      }
-      const before = skills.length;
-      skills = [...new Set([...skills, ...extracted])];
-      const added = skills.length - before;
-      resumeNote =
-        added > 0
-          ? `Added ${added} skill${added === 1 ? '' : 's'} from your résumé.`
-          : 'All résumé skills were already listed.';
-    } catch (err) {
-      resumeError =
-        err instanceof ApiError ? err.message : 'Could not read the résumé. Please try again.';
-    } finally {
-      resumeBusy = false;
-    }
-  }
-
-  function onResumeFile(e: Event) {
-    const target = e.currentTarget as HTMLInputElement;
-    const file = target.files?.[0];
-    target.value = ''; // clear so re-selecting the same file fires change again
-    if (file) void analyzeResume(file);
   }
 
   // For each profile with a specialization, fetch its market skills (cached by spec set)
@@ -155,7 +73,6 @@
   $effect(() => {
     if (isAuthenticated()) {
       void loadProfiles();
-      void loadSkills();
     } else {
       searchProfiles.reset();
     }
@@ -168,200 +85,80 @@
     else gaps = {};
   });
 
-  function resetForm() {
-    editingId = null;
-    name = '';
-    specializations = [];
-    skills = [];
-    formError = null;
-  }
-
-  function startEdit(p: SearchProfile) {
-    editingId = p.id;
-    name = p.name;
-    specializations = [...p.specializations];
-    skills = [...p.skills];
-    formError = null;
-  }
-
-  // Multi-select with a cap: toggling off is always allowed; toggling on is refused past
-  // MAX_SPECIALIZATIONS (with a hint) so the form matches the server's limit.
-  function toggleSpecialization(value: string) {
-    if (specializations.includes(value)) {
-      specializations = specializations.filter((s) => s !== value);
-      return;
-    }
-    if (specializations.length >= MAX_SPECIALIZATIONS) {
-      formError = `You can pick at most ${MAX_SPECIALIZATIONS} specializations.`;
-      return;
-    }
-    specializations = [...specializations, value];
-    formError = null;
-  }
-
-  function toggleSkill(value: string) {
-    skills = skills.includes(value) ? skills.filter((s) => s !== value) : [...skills, value];
-  }
-
-  async function submit(e: SubmitEvent) {
-    e.preventDefault();
-    if (!canSubmit || busy) return;
-    busy = true;
-    formError = null;
-    try {
-      if (editingId === null) {
-        await searchProfiles.create(name.trim(), specializations, skills);
-      } else {
-        await searchProfiles.update(editingId, { name: name.trim(), specializations, skills });
-      }
-      resetForm();
-    } catch (err) {
-      formError = err instanceof ApiError ? err.message : 'Could not save the profile. Please try again.';
-    } finally {
-      busy = false;
-    }
-  }
-
   async function remove(p: SearchProfile) {
     if (!window.confirm(`Delete profile “${p.name}”?`)) return;
+    listError = null;
     try {
       await searchProfiles.remove(p.id);
-      if (editingId === p.id) resetForm();
     } catch {
-      formError = 'Could not delete the profile. Please try again.';
+      listError = 'Could not delete the profile. Please try again.';
     }
   }
 </script>
 
 {#if !isAuthenticated()}
   <div class="flex flex-col items-center gap-3 py-12 text-center">
-    <p class="text-sm text-muted-foreground">Sign in to create search profiles.</p>
+    <p class="text-sm text-muted-foreground">Sign in to create profiles.</p>
     <Button variant="primary" onclick={() => openAuthDialog()}>Sign in</Button>
   </div>
 {:else}
   <div class="flex flex-col gap-6">
-    <div class="flex flex-col gap-1">
-      <h1 class="text-2xl font-semibold tracking-tight">Search profiles</h1>
-      <p class="text-sm text-muted-foreground">
-        Describe what you do — one or more specializations and your skills — and reuse it to
-        find relevant work.
-      </p>
+    <div class="flex flex-wrap items-start justify-between gap-3">
+      <div class="flex flex-col gap-1">
+        <h1 class="text-2xl font-semibold tracking-tight">Profiles</h1>
+        <p class="text-sm text-muted-foreground">
+          Named sets of specializations and skills you can reuse to find relevant work.
+        </p>
+      </div>
+      <Button variant="primary" href={newHref}>
+        <Plus class="size-4" />
+        New profile
+      </Button>
     </div>
 
-    <form onsubmit={submit} class="flex flex-col gap-4 rounded-lg border border-border p-4">
-      <p class="text-sm font-medium">{editingId === null ? 'New profile' : 'Edit profile'}</p>
-
-      <label class="flex flex-col gap-1">
-        <span class="text-sm font-medium">Name</span>
-        <Input bind:value={name} placeholder="e.g. Go backend" maxlength={100} class="w-full" />
-      </label>
-
-      <div class="flex flex-col gap-1.5">
-        <span class="text-sm font-medium">Specializations</span>
-        <SearchSelect
-          options={CATEGORY_OPTIONS}
-          selected={specializations}
-          placeholder="Search specializations"
-          onToggle={toggleSpecialization}
-          clearOnSelect
-        />
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <span class="text-sm font-medium">Skills</span>
-        <RemoteSearchSelect
-          search={searchSkills}
-          selected={skills}
-          placeholder="Search skills"
-          onToggle={toggleSkill}
-          fallbackLabel={(v) => v}
-          clearOnSelect
-        />
-      </div>
-
-      <div class="flex flex-col gap-1.5">
-        <span class="text-sm font-medium">Add skills from your résumé</span>
-        <div class="flex flex-wrap items-center gap-2">
-          <input
-            type="file"
-            accept="application/pdf,.pdf"
-            class="hidden"
-            bind:this={fileInput}
-            onchange={onResumeFile}
-          />
-          <Button
-            variant="secondary"
-            size="sm"
-            type="button"
-            onclick={() => fileInput?.click()}
-            disabled={resumeBusy}
-          >
-            {resumeBusy ? 'Analyzing…' : 'Upload résumé (PDF)'}
-          </Button>
-          <span class="text-xs text-muted-foreground">extracts your skills into the field above</span>
-        </div>
-        <details class="text-xs">
-          <summary class="cursor-pointer text-muted-foreground">or paste résumé text</summary>
-          <div class="mt-2 flex flex-col gap-2">
-            <textarea
-              bind:value={resumeText}
-              rows="4"
-              placeholder="Paste your résumé here…"
-              class="w-full rounded-md border border-border bg-background p-2 text-sm"
-            ></textarea>
-            <div>
-              <Button
-                variant="secondary"
-                size="sm"
-                type="button"
-                onclick={() => analyzeResume(resumeText)}
-                disabled={resumeBusy || resumeText.trim() === ''}
-              >
-                Extract skills
-              </Button>
-            </div>
-          </div>
-        </details>
-        {#if resumeError}
-          <p class="text-sm text-destructive">{resumeError}</p>
-        {:else if resumeNote}
-          <p class="text-xs text-muted-foreground">{resumeNote}</p>
-        {/if}
-      </div>
-
-      {#if formError}
-        <p class="text-sm text-destructive">{formError}</p>
-      {/if}
-
-      <div class="flex items-center gap-2">
-        <Button variant="primary" type="submit" disabled={!canSubmit || busy}>
-          {busy ? 'Saving…' : editingId === null ? 'Create profile' : 'Save changes'}
-        </Button>
-        {#if editingId !== null}
-          <Button variant="ghost" type="button" onclick={resetForm}>Cancel</Button>
-        {/if}
-      </div>
-    </form>
+    {#if listError}
+      <p class="text-sm text-destructive">{listError}</p>
+    {/if}
 
     {#if status === 'loading'}
       <States state="loading" />
     {:else if status === 'error'}
       <States state="error" message="Couldn't load your profiles." />
     {:else if profiles.length === 0}
-      <States state="empty" message="No profiles yet. Create one above." />
+      <div
+        class="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border py-14 text-center"
+      >
+        <p class="text-sm text-muted-foreground">No profiles yet.</p>
+        <Button variant="primary" href={newHref}>
+          <Plus class="size-4" />
+          Create your first profile
+        </Button>
+      </div>
     {:else}
-      <ul class="flex flex-col divide-y divide-border rounded-lg border border-border">
+      <ul class="flex flex-col gap-3">
         {#each profiles as profile (profile.id)}
           {@const gap = gaps[profile.id]}
-          <li class="flex items-start justify-between gap-3 px-4 py-3">
-            <div class="flex min-w-0 flex-col gap-1">
-              <span class="truncate text-sm font-medium">{profile.name}</span>
-              <span class="text-xs text-muted-foreground">
-                {profile.specializations.map(categoryLabel).join(', ')}
-              </span>
+          <li
+            class="flex items-start justify-between gap-3 rounded-xl border border-border bg-card p-4 transition-colors hover:border-foreground/20"
+          >
+            <div class="flex min-w-0 flex-col gap-2">
+              <span class="truncate text-sm font-semibold">{profile.name}</span>
+              <div class="flex flex-wrap gap-1">
+                {#each profile.specializations as spec (spec)}
+                  <span
+                    class="rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground"
+                  >
+                    {categoryLabel(spec)}
+                  </span>
+                {/each}
+              </div>
               <div class="flex flex-wrap gap-1">
                 {#each profile.skills as skill (skill)}
-                  <span class="rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground">{skill}</span>
+                  <span
+                    class="rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground"
+                  >
+                    {skill}
+                  </span>
                 {/each}
               </div>
               {#if gap && gap.total > 0}
@@ -389,8 +186,17 @@
               {/if}
             </div>
             <div class="flex shrink-0 items-center gap-1">
-              <Button variant="ghost" size="sm" onclick={() => startEdit(profile)}>Edit</Button>
-              <Button variant="ghost" size="sm" onclick={() => remove(profile)}>Delete</Button>
+              <Button variant="ghost" size="icon" href={editHref(profile.id)} aria-label="Edit profile">
+                <Pencil class="size-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onclick={() => remove(profile)}
+                aria-label="Delete profile"
+              >
+                <Trash2 class="size-4" />
+              </Button>
             </div>
           </li>
         {/each}

--- a/web/src/routes/my/profiles/+page.svelte
+++ b/web/src/routes/my/profiles/+page.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <svelte:head>
-  <title>Search profiles — freehire</title>
+  <title>Profiles — freehire</title>
   <!-- Personal page: keep it out of search results. -->
   <meta name="robots" content="noindex" />
 </svelte:head>

--- a/web/src/routes/my/profiles/[id]/edit/+page.svelte
+++ b/web/src/routes/my/profiles/[id]/edit/+page.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
+  import ProfileForm from '$lib/components/ProfileForm.svelte';
+  import States from '$lib/components/States.svelte';
+  import { searchProfiles } from '$lib/searchProfiles.svelte';
+  import { Button } from '$lib/ui';
+
+  const id = $derived(Number(page.params.id));
+
+  let status = $state<'loading' | 'error' | 'ready'>('loading');
+  // Resolve the edited profile from the (cached) list — the form needs its current
+  // fields to seed itself. Load once the session is confirmed, then look it up.
+  const profile = $derived(searchProfiles.items.find((p) => p.id === id));
+
+  async function loadProfiles() {
+    status = 'loading';
+    try {
+      await searchProfiles.ensureLoaded();
+      status = 'ready';
+    } catch {
+      status = 'error';
+    }
+  }
+
+  $effect(() => {
+    if (isAuthenticated()) void loadProfiles();
+  });
+</script>
+
+<svelte:head>
+  <title>Edit profile — freehire</title>
+  <!-- Personal page: keep it out of search results. -->
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
+  {#if !isAuthenticated()}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">Sign in to edit profiles.</p>
+      <Button variant="primary" onclick={() => openAuthDialog()}>Sign in</Button>
+    </div>
+  {:else if status === 'loading'}
+    <States state="loading" />
+  {:else if status === 'error'}
+    <States state="error" message="Couldn't load your profiles." />
+  {:else if profile === undefined}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">This profile no longer exists.</p>
+      <Button variant="primary" href={resolve('/my/profiles')}>Back to profiles</Button>
+    </div>
+  {:else}
+    {#key profile.id}
+      <ProfileForm {profile} />
+    {/key}
+  {/if}
+</div>

--- a/web/src/routes/my/profiles/new/+page.svelte
+++ b/web/src/routes/my/profiles/new/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
+  import ProfileForm from '$lib/components/ProfileForm.svelte';
+  import { Button } from '$lib/ui';
+</script>
+
+<svelte:head>
+  <title>New profile — freehire</title>
+  <!-- Personal page: keep it out of search results. -->
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
+  {#if !isAuthenticated()}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">Sign in to create profiles.</p>
+      <Button variant="primary" onclick={() => openAuthDialog()}>Sign in</Button>
+    </div>
+  {:else}
+    <ProfileForm />
+  {/if}
+</div>


### PR DESCRIPTION
## What

Two related web-UI polish changes on the account area and the jobs list.

### Profiles (`/my/profiles`)
- Rename the **"Search profiles"** surface to **"Profiles"** (page title, heading, header menu).
- Split the single mixed page into dedicated routes:
  - `/my/profiles` — **list only**, with a **New profile** button.
  - `/my/profiles/new` — the **create** form.
  - `/my/profiles/[id]/edit` — the **edit** form.
- Extract a shared **`ProfileForm.svelte`** used by both create and edit (seeded from the profile prop; the edit route keys on `profile.id` so a different profile remounts with fresh state).
- UI polish:
  - **List** — cards with hover, outline specialization badges, skill chips, icon Edit/Delete actions, and a dashed empty-state with CTA.
  - **Form** — back link, subtitle, selected-specialization chips (removable), counters (`n/5`, skills count), grouped fields with helper text, and a footer action bar.

### Jobs edge controls (`/jobs`)
- Slim the right-edge **swipe tab** — protrudes ~**30px instead of 44px** (`p-3` → `py-2.5 pl-2 pr-1.5`, icon `size-4`).
- Shrink the mobile **Filters** button to match (`h-8`, `px-2.5`, `text-xs`).

## Notes
- Follows the existing per-route pattern already used by `/my/jobs` (board/pipeline/history).
- The `search_profiles` domain concept (server/API `/me/profiles`) is unchanged — only the user-facing label is "Profiles".

## Verification
- `svelte-check`: 0 errors, 0 warnings.
- `eslint` on changed files: clean.