### PR TITLE
feat(sources): track Klir, Qutwo, Nscale, Jazz boards

### DIFF
--- a/sources/comeet.yml
+++ b/sources/comeet.yml
@@ -12,3 +12,5 @@
   board: ludeo/D7.008
 - company: Moon Active
   board: moonactive/A2.00C
+- company: Jazz
+  board: jazz/6A.009

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -12221,3 +12221,5 @@
   board: loonshotgames
 - company: Ravenwake Games
   board: ravenwakegames
+- company: Nscale
+  board: nscaleoperationsukltd

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -9,3 +9,5 @@
   board: 11fs-group-ltd
 - company: Kevel
   board: kevel-careers
+- company: Klir
+  board: klir

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -2600,3 +2600,5 @@
   board: huaweisweden.teamtailor.com
 - company: FYUL
   board: careers.fyul.com
+- company: Qutwo
+  board: qutwo.teamtailor.com


### PR DESCRIPTION
Adds four fast-growing companies (from a hiring-list audit) that expose a **supported keyless ATS**, each **validated live** before adding:

| Company | Provider | board | Live check |
|---|---|---|---|
| Klir | rippling | `klir` | HTTP 200, 4 open roles |
| Qutwo | teamtailor | `qutwo.teamtailor.com` | HTTP 200, listing present |
| Nscale | greenhouse | `nscaleoperationsukltd` | HTTP 200, 216 open roles (EU-hosted board) |
| Jazz | comeet | `jazz/6A.009` | HTTP 200 (jazz.security DLP) |

**No adapter changes needed:** the greenhouse adapter already serves EU boards from the single `boards-api.greenhouse.io` host; the comeet adapter scrapes the public read token itself, so `board=<slug>/<uid>` is enough.

All four board files pass `Config.Validate` against the adapter registry; `go build ./...` and `go vet ./internal/sources` are green.

### Audited but not added
From the same 33-company list, most were **already tracked** (mostly Ashby). Three have **no ingestable ATS** (custom pages / email apply): Outmarket AI, spektr, Tharros. **Fleet AI** also has no public ATS board (applies via `mailto:careers@fleet.so`; no live Ashby/Greenhouse/Lever slug), so it is excluded.