### PR TITLE
fix(enrich): treat employment_type/education_level as dict-only discovery facets

### DIFF
--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -113,15 +113,14 @@ type scalarEnum struct {
 // servedScalarEnums lists the served single-value enum fields, in declaration
 // order. It is the ONE place the served-scalar set is defined; Validate reads it,
 // Sanitize blanks through it. The dictionary-covered facets (work_mode, seniority,
-// category, regions) are deliberately absent — they are unserved discovery
-// material under dict-only.
+// category, regions, employment_type, education_level) are deliberately absent —
+// jobview serves them from the deterministic dictionaries, so the LLM's values are
+// unserved discovery material under dict-only.
 func (e *Enrichment) servedScalarEnums() []scalarEnum {
 	return []scalarEnum{
-		{"employment_type", &e.EmploymentType, EmploymentTypeValues},
 		{"relocation", &e.Relocation, RelocationValues},
 		{"salary_period", &e.SalaryPeriod, SalaryPeriodValues},
 		{"english_level", &e.EnglishLevel, EnglishLevelValues},
-		{"education_level", &e.EducationLevel, EducationLevelValues},
 		{"company_type", &e.CompanyType, CompanyTypeValues},
 		{"company_size", &e.CompanySize, CompanySizeValues},
 	}
@@ -130,11 +129,12 @@ func (e *Enrichment) servedScalarEnums() []scalarEnum {
 // Validate checks every SERVED enum field against its controlled vocabulary and
 // returns an error identifying the first offending field. Empty (absent) fields
 // pass — every field is optional. Non-enum fields (ISO codes, free text, numbers,
-// skills) are unconstrained here. The six dictionary-covered facets (work_mode,
-// seniority, category, regions, plus the non-enum countries/skills) are
-// deliberately NOT validated: they are served from the deterministic dictionaries
-// (dict-only), so the LLM's values for them are unserved discovery material and an
-// out-of-vocabulary value is captured raw rather than rejected.
+// skills) are unconstrained here. The dictionary-covered facets (work_mode,
+// seniority, category, regions, employment_type, education_level, plus the
+// non-enum countries/skills) are deliberately NOT validated: they are served from
+// the deterministic dictionaries (dict-only), so the LLM's values for them are
+// unserved discovery material and an out-of-vocabulary value is captured raw
+// rather than rejected.
 func (e Enrichment) Validate() error {
 	// Single-value SERVED enum fields. Value receiver, so take the address of the
 	// local copy to reuse the shared field set.
@@ -166,12 +166,12 @@ func (e Enrichment) Validate() error {
 
 // Sanitize drops out-of-vocabulary values from the SERVED enum fields (a scalar is
 // blanked, a multi-value field keeps only known members) so no stray value reaches
-// the served wire shape. The six dictionary-covered facets (work_mode, seniority,
-// category, regions) are deliberately left untouched: they are unserved discovery
-// material under dict-only, so the LLM's raw values — including novel,
-// out-of-vocabulary labels — are kept for later mining. The invariant "never serve
-// an out-of-vocabulary value" still holds for the served fields, and Validate passes
-// afterwards.
+// the served wire shape. The dictionary-covered facets (work_mode, seniority,
+// category, regions, employment_type, education_level) are deliberately left
+// untouched: they are unserved discovery material under dict-only, so the LLM's raw
+// values — including novel, out-of-vocabulary labels — are kept for later mining.
+// The invariant "never serve an out-of-vocabulary value" still holds for the served
+// fields, and Validate passes afterwards.
 func (e *Enrichment) Sanitize() {
 	for _, s := range e.servedScalarEnums() {
 		if *s.ptr != "" && !slices.Contains(s.vocab, *s.ptr) {

--- a/internal/enrich/enrichment_test.go
+++ b/internal/enrich/enrichment_test.go
@@ -115,40 +115,43 @@ func TestValidateAccepts(t *testing.T) {
 }
 
 func TestValidateRejectsScalarEnum(t *testing.T) {
-	// A SERVED enum field is still validated (employment_type reaches the wire shape).
-	err := Enrichment{EmploymentType: "seasonal"}.Validate()
+	// A SERVED enum field is still validated (relocation reaches the wire shape).
+	err := Enrichment{Relocation: "seasonal"}.Validate()
 	if err == nil {
-		t.Fatal("expected error for employment_type \"seasonal\"")
+		t.Fatal("expected error for relocation \"seasonal\"")
 	}
-	if !strings.Contains(err.Error(), "employment_type") {
+	if !strings.Contains(err.Error(), "relocation") {
 		t.Errorf("error must identify the offending field, got: %v", err)
 	}
 }
 
 // When several SERVED enum fields are invalid, Validate reports the first one in
-// declaration order (employment_type is checked before english_level).
+// declaration order (relocation is checked before english_level).
 func TestValidateReportsFirstOffender(t *testing.T) {
-	err := Enrichment{EmploymentType: "telepathic", EnglishLevel: "sr"}.Validate()
+	err := Enrichment{Relocation: "telepathic", EnglishLevel: "sr"}.Validate()
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "employment_type") {
-		t.Errorf("want first offender employment_type, got: %v", err)
+	if !strings.Contains(err.Error(), "relocation") {
+		t.Errorf("want first offender relocation, got: %v", err)
 	}
 	if strings.Contains(err.Error(), "english_level") {
 		t.Errorf("should report only the first offender, got: %v", err)
 	}
 }
 
-// Relax: the six dict-covered discovery facets are captured raw — an out-of-vocab
-// work_mode/seniority/category and a non-vocab regions element pass Validate (they
-// are unserved, so they cannot corrupt production data).
+// Relax: the dict-covered discovery facets are captured raw — an out-of-vocab
+// work_mode/seniority/category/employment_type/education_level and a non-vocab
+// regions element pass Validate (they are unserved, so they cannot corrupt
+// production data).
 func TestValidateAcceptsOutOfVocabDiscoveryFacets(t *testing.T) {
 	discovery := []Enrichment{
 		{Seniority: "staff_plus"},
 		{Category: "ml_platform"},
 		{WorkMode: "remote_first"},
 		{Regions: []string{"eu", "europe"}},
+		{EmploymentType: "freelance"},
+		{EducationLevel: "associate"},
 	}
 	for i, e := range discovery {
 		if err := e.Validate(); err != nil {
@@ -202,18 +205,20 @@ func TestGlobalReachDistinctFromUnknown(t *testing.T) {
 
 func TestSanitizeDropsOutOfVocabValues(t *testing.T) {
 	e := Enrichment{
-		EmploymentType: "seasonal",                   // SERVED invalid scalar -> blanked
-		EnglishLevel:   "b2",                         // SERVED valid -> kept
-		Domains:        []string{"fintech", "bogus"}, // SERVED multi -> keep only known
+		Relocation:   "seasonal",                   // SERVED invalid scalar -> blanked
+		EnglishLevel: "b2",                         // SERVED valid -> kept
+		Domains:      []string{"fintech", "bogus"}, // SERVED multi -> keep only known
 		// Discovery facets are captured raw (unserved):
-		Category:  "astrology",      // kept
-		Seniority: "staff_plus",     // kept
-		Regions:   []string{"nope"}, // kept
+		Category:       "astrology",      // kept
+		Seniority:      "staff_plus",     // kept
+		Regions:        []string{"nope"}, // kept
+		EmploymentType: "freelance",      // kept
+		EducationLevel: "associate",      // kept
 	}
 	e.Sanitize()
 
-	if e.EmploymentType != "" {
-		t.Errorf("EmploymentType = %q, want blanked (served field)", e.EmploymentType)
+	if e.Relocation != "" {
+		t.Errorf("Relocation = %q, want blanked (served field)", e.Relocation)
 	}
 	if e.EnglishLevel != "b2" {
 		t.Errorf("EnglishLevel = %q, want kept", e.EnglishLevel)
@@ -230,6 +235,12 @@ func TestSanitizeDropsOutOfVocabValues(t *testing.T) {
 	}
 	if len(e.Regions) != 1 || e.Regions[0] != "nope" {
 		t.Errorf("Regions = %v, want kept raw (discovery)", e.Regions)
+	}
+	if e.EmploymentType != "freelance" {
+		t.Errorf("EmploymentType = %q, want kept raw (discovery)", e.EmploymentType)
+	}
+	if e.EducationLevel != "associate" {
+		t.Errorf("EducationLevel = %q, want kept raw (discovery)", e.EducationLevel)
 	}
 	if err := e.Validate(); err != nil {
 		t.Errorf("Validate after Sanitize = %v, want nil", err)

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -59,10 +59,10 @@ func parseEnrichment(raw string) (Enrichment, error) {
 
 // systemPrompt instructs the model to emit only stated fields and to draw the
 // SERVED enum values from the controlled vocabularies — the same lists Validate
-// enforces. The six dictionary-covered discovery facets (work_mode, regions,
-// seniority, category) are deliberately relaxed: the prompt invites a novel label
-// when none fits, and Validate does not reject it (it is unserved discovery
-// material), so prompt and validator diverge there on purpose.
+// enforces. The dictionary-covered discovery facets (work_mode, regions,
+// seniority, category, employment_type, education_level) are deliberately relaxed:
+// the prompt invites a novel label when none fits, and Validate does not reject it
+// (it is unserved discovery material), so prompt and validator diverge there on purpose.
 var systemPrompt = buildSystemPrompt()
 
 func buildSystemPrompt() string {
@@ -88,13 +88,14 @@ func buildSystemPrompt() string {
 	enum("company_type", CompanyTypeValues)
 	enum("company_size", CompanySizeValues)
 
-	// Discovery facets: these four (plus the open countries/skills) are served from
+	// Discovery facets: these six (plus the open countries/skills) are served from
 	// our own dictionaries, not from your value, so they are a discovery signal.
 	// Prefer an allowed value, but emit your own label when none fits — this surfaces
 	// vocabulary we are missing. The other enum fields above stay strict.
-	b.WriteString("\nException for work_mode, regions, seniority, category: prefer an allowed ")
-	b.WriteString("value above, but if none accurately fits, you MAY return a concise lowercase ")
-	b.WriteString("label of your own (e.g. seniority \"staff_plus\", category \"ml_platform\"). ")
+	b.WriteString("\nException for work_mode, regions, seniority, category, employment_type, ")
+	b.WriteString("education_level: prefer an allowed value above, but if none accurately fits, ")
+	b.WriteString("you MAY return a concise lowercase label of your own (e.g. seniority ")
+	b.WriteString("\"staff_plus\", category \"ml_platform\"). ")
 	b.WriteString("Still omit the key when the posting does not state it.\n")
 
 	b.WriteString("\nOther keys (omit when unstated): ")

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -47,7 +47,7 @@ func TestSystemPromptRelaxesDiscoveryFacets(t *testing.T) {
 	if !strings.Contains(p, "concise lowercase label of your own") {
 		t.Errorf("discovery facets must permit a novel own label")
 	}
-	for _, f := range []string{"work_mode", "regions", "seniority", "category"} {
+	for _, f := range []string{"work_mode", "regions", "seniority", "category", "employment_type", "education_level"} {
 		if !strings.Contains(p, f) {
 			t.Errorf("discovery instruction should name the facet %q", f)
 		}


### PR DESCRIPTION
## Problem

`jobview.FromRow` overwrites `enrichment.employment_type` / `enrichment.education_level` with the deterministic `jobs`-column value (the synthetic facets added in migration `0023`), and `search.FromJob` builds its index document through that same `jobview` shape. So **the LLM's values for these two fields were never served** — not via the API, not in the search facet; the dictionary always wins in both surfaces, and the LLM value only lives raw in the enrichment JSONB.

Yet the two fields were still:
- in `servedScalarEnums()` → strictly `Validate`d / `Sanitize`d as if served, and
- in the prompt's strict enum list, **not** the discovery-exception.

This is an oversight from when the synthetic facets dict-ified them: they became de-facto dict-only but weren't moved off the served path. Net effect — `servedScalarEnums` misleadingly named (contains non-served fields), the LLM over-constrained on fields whose value is discarded, and prompt/validator asymmetric with the other dict-covered facets.

## Change

Align `employment_type` / `education_level` with the existing dict-covered discovery facets (`work_mode` / `regions` / `seniority` / `category`):
- **`enrichment.go`**: drop both from `servedScalarEnums()` so their out-of-vocabulary values are captured **raw** (discovery material for later mining) instead of blanked; update the `Validate`/`Sanitize` doc comments.
- **`langchain.go`**: move both into the prompt's discovery-exception (they stay in the `enum(...)` list so the model still sees the preferred vocab, exactly like the other four); update comments.

The **served wire shape is unchanged** — `jobview` still serves the deterministic dict value. This only stops validating/sanitizing fields that are never served and relaxes the prompt to match.

## Tests

- `go build ./... && go vet ./internal/enrich/...` clean, `gofmt` clean.
- `go test ./internal/enrich/... ./internal/jobview/... ./internal/jobderive/...` green.
- Updated the served-enum reject/first-offender/sanitize tests to use a genuinely-served field (`relocation`), and added `employment_type`/`education_level` to the discovery-accept and prompt-relaxation tests.