### PR TITLE
feat(sources): eRecruiter Polska board adapter + cfg harvester

### DIFF
--- a/cmd/harvest-erecruiter/main.go
+++ b/cmd/harvest-erecruiter/main.go
@@ -1,0 +1,132 @@
+// Command harvest-erecruiter discovers eRecruiter career boards for a list of companies.
+// eRecruiter exposes no per-company listing keyed by anything we can derive from an apply
+// form, so a company's board id (its cfg config token) must be read off the company's own
+// careers page. This tool takes a worklist of careers URLs, extracts each page's
+// `skk.erecruiter.pl/Code.ashx?cfg=<hex>` widget token, validates the token against the live
+// board endpoint (via the same adapter that ingests it), and prints ready-to-paste
+// sources/erecruiter.yml entries. Run-once host tool; review the output before committing.
+//
+// Input: a file (or stdin) of lines "<company name>\t<careers url>". A line with only a URL
+// uses the URL host as the company name.
+//
+//	go run ./cmd/harvest-erecruiter careers-urls.txt
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// cfgRe matches the eRecruiter career-widget reference and captures the cfg token. The token
+// is a 32-hex config id; it is matched case-insensitively and independently of the URL scheme.
+var cfgRe = regexp.MustCompile(`(?i)Code\.ashx\?cfg=([a-fA-F0-9]{32})`)
+
+// extractCfg returns the eRecruiter cfg board token embedded in a careers page, or "" when
+// the page carries no eRecruiter widget.
+func extractCfg(page string) string {
+	if m := cfgRe.FindStringSubmatch(page); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	if len(os.Args) > 2 {
+		log.Printf("usage: harvest-erecruiter [careers-urls.txt]  (reads stdin if omitted)")
+		return 2
+	}
+
+	in := os.Stdin
+	if len(os.Args) == 2 {
+		f, err := os.Open(os.Args[1])
+		if err != nil {
+			log.Printf("harvest-erecruiter: %v", err)
+			return 1
+		}
+		defer f.Close()
+		in = f
+	}
+
+	ctx := context.Background()
+	client := sources.NewClient()
+	adapter := sources.NewErecruiter(client)
+
+	found := map[string]string{} // cfg -> company (deduped by board)
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		company, careersURL := parseLine(line)
+
+		page, err := client.GetText(ctx, careersURL)
+		if err != nil {
+			log.Printf("skip %s: fetch: %v", careersURL, err)
+			continue
+		}
+		cfg := extractCfg(page)
+		if cfg == "" {
+			log.Printf("skip %s: no eRecruiter widget", careersURL)
+			continue
+		}
+		if _, seen := found[cfg]; seen {
+			continue
+		}
+		// Validate the token against the live board (the adapter returns >0 jobs only when the
+		// endpoint served parseable offer rows with usable detail pages).
+		jobs, err := adapter.Fetch(ctx, sources.CompanyEntry{Company: company, Board: cfg})
+		if err != nil || len(jobs) == 0 {
+			log.Printf("skip %s: cfg %s validated empty (err=%v)", careersURL, cfg, err)
+			continue
+		}
+		found[cfg] = company
+		log.Printf("ok %s: cfg %s (%d jobs)", company, cfg, len(jobs))
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("harvest-erecruiter: read: %v", err)
+		return 1
+	}
+
+	// Print validated entries, sorted by company for a stable, review-friendly diff.
+	entries := make([]string, 0, len(found))
+	for cfg, company := range found {
+		entries = append(entries, fmt.Sprintf("- company: %s\n  board: %s", company, cfg))
+	}
+	sort.Strings(entries)
+	for _, e := range entries {
+		fmt.Println(e)
+	}
+	log.Printf("harvest-erecruiter: %d validated board(s)", len(found))
+	return 0
+}
+
+// parseLine splits a worklist line into company and careers URL. A line is
+// "<company>\t<url>"; a line with only a URL uses the URL host as the company name.
+func parseLine(line string) (company, careersURL string) {
+	if company, careersURL, ok := strings.Cut(line, "\t"); ok {
+		return strings.TrimSpace(company), strings.TrimSpace(careersURL)
+	}
+	return urlHost(line), line
+}
+
+// urlHost returns the host of a URL with any leading "www." dropped, falling back to the raw
+// string when it does not parse as a URL with a host.
+func urlHost(raw string) string {
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		return strings.TrimPrefix(u.Host, "www.")
+	}
+	return raw
+}

--- a/cmd/harvest-erecruiter/main_test.go
+++ b/cmd/harvest-erecruiter/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func TestParseLine(t *testing.T) {
+	cases := []struct {
+		name, line, wantCompany, wantURL string
+	}{
+		{
+			name:        "company and url tab-separated",
+			line:        "Acme Corp\thttps://acme.example/careers",
+			wantCompany: "Acme Corp",
+			wantURL:     "https://acme.example/careers",
+		},
+		{
+			name:        "bare url uses host as company",
+			line:        "https://www.acme.example/careers",
+			wantCompany: "acme.example",
+			wantURL:     "https://www.acme.example/careers",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			company, u := parseLine(c.line)
+			if company != c.wantCompany || u != c.wantURL {
+				t.Errorf("parseLine(%q) = (%q, %q), want (%q, %q)", c.line, company, u, c.wantCompany, c.wantURL)
+			}
+		})
+	}
+}
+
+func TestExtractCfg(t *testing.T) {
+	cases := []struct {
+		name, page, want string
+	}{
+		{
+			name: "script src widget",
+			page: `<html><body><script src="https://skk.erecruiter.pl/Code.ashx?cfg=eac02250aa184ed4bf4950e74948549a"></script></body></html>`,
+			want: "eac02250aa184ed4bf4950e74948549a",
+		},
+		{
+			name: "protocol-relative and mixed case",
+			page: `<script src="//skk.erecruiter.pl/Code.ashx?cfg=ABC123def4567890abcdef1234567890"></script>`,
+			want: "ABC123def4567890abcdef1234567890",
+		},
+		{
+			name: "no erecruiter widget",
+			page: `<html><body><a href="https://boards.greenhouse.io/acme">Careers</a></body></html>`,
+			want: "",
+		},
+		{
+			name: "empty page",
+			page: "",
+			want: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractCfg(c.page); got != c.want {
+				t.Errorf("extractCfg() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/sources/erecruiter.go
+++ b/internal/sources/erecruiter.go
@@ -88,10 +88,15 @@ func (s erecruiter) listRows(ctx context.Context, board string) ([]erecruiterRow
 }
 
 // toJob fetches a row's detail page and maps it to a Job, returning ok=false when the row
-// lacks the ids needed to address the detail (would break dedup), when the detail page is
-// gone (a closed posting), or when it carries no description.
+// lacks the offer id needed to address the detail and dedup, when the detail page is gone (a
+// closed posting), or when it carries no description.
+//
+// ExternalID is the offerId, not the externalJobOfferId: one posting spread over several
+// cities shares an externalJobOfferId across its per-city rows (each a distinct offerId with
+// its own detail page and location), so keying on externalJobOfferId would collapse the
+// city variants into a single job under the (source, external_id) dedup key.
 func (s erecruiter) toJob(ctx context.Context, r erecruiterRowData, e CompanyEntry) (Job, bool) {
-	if r.ejoID == "" || r.offerID == "" {
+	if r.offerID == "" {
 		return Job{}, false
 	}
 	detailURL := fmt.Sprintf(erecruiterDetailURL, r.offerID, e.Board, r.ejoID, r.ejorID, r.comID)
@@ -104,7 +109,7 @@ func (s erecruiter) toJob(ctx context.Context, r erecruiterRowData, e CompanyEnt
 		return Job{}, false
 	}
 	return Job{
-		ExternalID:  r.ejoID,
+		ExternalID:  r.offerID,
 		URL:         detailURL,
 		Title:       r.title,
 		Company:     e.Company,
@@ -181,16 +186,30 @@ func erecruiterCells(tr *html.Node) []string {
 	return cells
 }
 
-// erecruiterDescription concatenates the inner HTML of the detail page's content blocks
-// (eRecruiter renders each as a <div id="t1">), for sanitizing into the job body.
+// erecruiterSkipIDs are the offer-container sections that are not the job body: the header
+// (title/workplace, already carried as structured Job fields) and the GDPR consent clause.
+var erecruiterSkipIDs = map[string]bool{"JobTitle": true, "WorkPlace": true, "Clause": true}
+
+// erecruiterDescription returns the detail page's job body as HTML. Company career-page
+// templates vary (some render the body in a <div id="t1">, others in id="opis"/"description"/
+// …), so rather than target specific blocks it takes the whole offer container (<div
+// id="offCont">) minus the header and consent-clause sections. Returns "" when the container
+// is absent, so the posting is dropped.
 func erecruiterDescription(doc *html.Node) string {
-	var b strings.Builder
-	walk(doc, func(n *html.Node) bool {
-		if n.Type == html.ElementNode && n.Data == "div" && attr(n, "id") == "t1" {
-			b.WriteString(innerHTML(n))
+	root := elementByID(doc, "offCont")
+	if root == nil {
+		return ""
+	}
+	var drop []*html.Node
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && erecruiterSkipIDs[attr(n, "id")] {
+			drop = append(drop, n)
 			return false
 		}
 		return true
 	})
-	return b.String()
+	for _, n := range drop {
+		n.Parent.RemoveChild(n)
+	}
+	return innerHTML(root)
 }

--- a/internal/sources/erecruiter.go
+++ b/internal/sources/erecruiter.go
@@ -1,0 +1,196 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// erecruiter adapts eRecruiter Polska career boards ("Strona Kariera"). The board is the
+// company's cfg config token (a public URL embeds it as skk.erecruiter.pl/Code.ashx?cfg=<hex>).
+// The keyless list endpoint returns a JSONP-wrapped HTML row table with only a summary per
+// posting, so the adapter fetches each posting's Offer.aspx detail page for its description.
+type erecruiterHTTP interface {
+	TextGetter
+	HTMLGetter
+}
+
+type erecruiter struct {
+	http erecruiterHTTP
+}
+
+// NewErecruiter builds the eRecruiter adapter over the given HTTP client.
+func NewErecruiter(c erecruiterHTTP) Source { return erecruiter{http: c} }
+
+func (erecruiter) Provider() string { return "erecruiter" }
+
+const (
+	erecruiterListURL   = "https://skk.erecruiter.pl/GetHtml.ashx?cfg=%s&grid=rows&pn=%d"
+	erecruiterDetailURL = "https://skk.erecruiter.pl/Offer.aspx?oid=%s&cfg=%s&ejoId=%s&ejorId=%s&comId=%s"
+	// erecruiterMaxPages bounds the walk so a feed that never reaches its reported total can
+	// never loop forever. It sits far above any real company board's posting count.
+	erecruiterMaxPages = 500
+)
+
+// erecruiterRowData is one list row's identifiers and summary cells.
+type erecruiterRowData struct {
+	offerID, ejoID, ejorID, comID string
+	title, city                   string
+}
+
+func (s erecruiter) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	rows, err := s.listRows(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+	// Each offer's description lives on its own Offer.aspx page; fetch them through the shared
+	// bounded worker pool like the other detail-HTML adapters.
+	return fetchDetails(rows, defaultDetailWorkers, func(r erecruiterRowData) (Job, bool) {
+		return s.toJob(ctx, r, e)
+	}), nil
+}
+
+// listRows pages the board's list endpoint and returns every offer row. It stops when it has
+// collected the reported total, when a page carries no offer rows, or when a page fails to
+// advance (repeats the previous page's first row — a board that ignores the pn parameter),
+// all under a page cap so a pathological feed cannot loop forever.
+func (s erecruiter) listRows(ctx context.Context, board string) ([]erecruiterRowData, error) {
+	var rows []erecruiterRowData
+	total, prevFirst := 0, ""
+	for page := 1; page <= erecruiterMaxPages; page++ {
+		body, err := s.http.GetText(ctx, fmt.Sprintf(erecruiterListURL, board, page))
+		if err != nil {
+			return nil, fmt.Errorf("erecruiter: list %s pn %d: %w", board, page, err)
+		}
+		pageRows, pageTotal, err := parseErecruiterRows(body)
+		if err != nil {
+			return nil, fmt.Errorf("erecruiter: parse %s pn %d: %w", board, page, err)
+		}
+		if pageTotal > 0 {
+			total = pageTotal
+		}
+		if len(pageRows) == 0 || pageRows[0].offerID == prevFirst {
+			break
+		}
+		prevFirst = pageRows[0].offerID
+		rows = append(rows, pageRows...)
+		// Stop once the reported total is collected; an over-reported total is bounded by the
+		// empty/non-advancing-page break above and the page cap.
+		if total > 0 && len(rows) >= total {
+			break
+		}
+	}
+	return rows, nil
+}
+
+// toJob fetches a row's detail page and maps it to a Job, returning ok=false when the row
+// lacks the ids needed to address the detail (would break dedup), when the detail page is
+// gone (a closed posting), or when it carries no description.
+func (s erecruiter) toJob(ctx context.Context, r erecruiterRowData, e CompanyEntry) (Job, bool) {
+	if r.ejoID == "" || r.offerID == "" {
+		return Job{}, false
+	}
+	detailURL := fmt.Sprintf(erecruiterDetailURL, r.offerID, e.Board, r.ejoID, r.ejorID, r.comID)
+	doc, err := s.http.GetHTML(ctx, detailURL)
+	if err != nil {
+		return Job{}, false
+	}
+	desc := erecruiterDescription(doc)
+	if desc == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:  r.ejoID,
+		URL:         detailURL,
+		Title:       r.title,
+		Company:     e.Company,
+		Location:    r.city,
+		Description: sanitizeHTML(desc),
+	}, true
+}
+
+// parseErecruiterRows unwraps the JSONP list body (`({"htm":"<tr...>"});`), parses its row
+// table, and returns the offer rows plus the board's total result count (carried on a hidden
+// marker row's `tr` attribute). The htm fragment is wrapped in <table> so the HTML parser
+// keeps the <tr>/<td> structure instead of foster-parenting it away.
+func parseErecruiterRows(body string) ([]erecruiterRowData, int, error) {
+	start := strings.IndexByte(body, '{')
+	end := strings.LastIndexByte(body, '}')
+	if start < 0 || end < start {
+		return nil, 0, fmt.Errorf("no JSON object in JSONP body")
+	}
+	var env struct {
+		Htm string `json:"htm"`
+	}
+	if err := json.Unmarshal([]byte(body[start:end+1]), &env); err != nil {
+		return nil, 0, err
+	}
+	doc, err := html.Parse(strings.NewReader("<table>" + env.Htm + "</table>"))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var rows []erecruiterRowData
+	total := 0
+	walk(doc, func(n *html.Node) bool {
+		if n.Type != html.ElementNode || n.Data != "tr" {
+			return true
+		}
+		// The hidden marker row carries the board's total on its `tr` attribute (the HTML
+		// parser lowercases attribute names, so the offer ids read lowercase below).
+		if v := attr(n, "tr"); v != "" {
+			if t, convErr := strconv.Atoi(v); convErr == nil {
+				total = t
+			}
+		}
+		offerID := attr(n, "offerid")
+		if offerID == "" {
+			return true // marker/non-offer row
+		}
+		// The cells are, in order, position / category / city; the first is the title and the
+		// last is the location.
+		row := erecruiterRowData{
+			offerID: offerID,
+			ejoID:   attr(n, "externaljobofferid"),
+			ejorID:  attr(n, "externaljobofferregionid"),
+			comID:   attr(n, "comid"),
+		}
+		if cells := erecruiterCells(n); len(cells) > 0 {
+			row.title = cells[0]
+			row.city = cells[len(cells)-1]
+		}
+		rows = append(rows, row)
+		return false // rows don't nest; skip descending into the cells
+	})
+	return rows, total, nil
+}
+
+// erecruiterCells returns the trimmed text of each <td> in a row, in document order.
+func erecruiterCells(tr *html.Node) []string {
+	var cells []string
+	walk(tr, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "td" {
+			cells = append(cells, textContent(n))
+		}
+		return true
+	})
+	return cells
+}
+
+// erecruiterDescription concatenates the inner HTML of the detail page's content blocks
+// (eRecruiter renders each as a <div id="t1">), for sanitizing into the job body.
+func erecruiterDescription(doc *html.Node) string {
+	var b strings.Builder
+	walk(doc, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "div" && attr(n, "id") == "t1" {
+			b.WriteString(innerHTML(n))
+			return false
+		}
+		return true
+	})
+	return b.String()
+}

--- a/internal/sources/erecruiter_test.go
+++ b/internal/sources/erecruiter_test.go
@@ -65,9 +65,9 @@ func TestErecruiterFetchMapsFieldsAndPaginates(t *testing.T) {
 		byID[j.ExternalID] = j
 	}
 
-	full, ok := byID["587372"]
+	full, ok := byID["4893718"]
 	if !ok {
-		t.Fatal("job 587372 missing — ExternalID must be the externalJobOfferId")
+		t.Fatal("job 4893718 missing — ExternalID must be the offerId")
 	}
 	if full.Title != "Senior Go Engineer" {
 		t.Errorf("Title = %q, want %q", full.Title, "Senior Go Engineer")
@@ -90,12 +90,74 @@ func TestErecruiterFetchMapsFieldsAndPaginates(t *testing.T) {
 		t.Errorf("URL = %q, want the Offer.aspx detail URL with oid+cfg", full.URL)
 	}
 
-	if _, dropped := byID["591483"]; dropped {
-		t.Error("posting 591483 has no detail page and must be dropped")
+	if _, dropped := byID["4893487"]; dropped {
+		t.Error("posting 4893487 has no detail page and must be dropped")
 	}
 
-	if _, ok := byID["599999"]; !ok {
-		t.Error("job 599999 from page 2 missing — pagination must fetch the second page")
+	if _, ok := byID["4899999"]; !ok {
+		t.Error("job 4899999 from page 2 missing — pagination must fetch the second page")
+	}
+}
+
+func TestErecruiterMultiCityKeptDistinct(t *testing.T) {
+	// One posting spread over two cities: same externalJobOfferId, distinct offerId + city. The
+	// adapter must key on offerId so both survive the (source, external_id) dedup instead of
+	// collapsing into one job.
+	page := erecruiterPage("2",
+		erecruiterRow("8001", "700", "900", "Kurier", "Warszawa"),
+		erecruiterRow("8002", "700", "901", "Kurier", "Kraków"),
+	)
+	fake := (&routedHTTP{}).
+		route("grid=rows&pn=1", page).
+		route("oid=8001", erecruiterDetail("Kurier", "<p>Deliver in Warszawa</p>")).
+		route("oid=8002", erecruiterDetail("Kurier", "<p>Deliver in Kraków</p>"))
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "brd"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (city variants of one externalJobOfferId must stay distinct)", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if byID["8001"].Location != "Warszawa" || byID["8002"].Location != "Kraków" {
+		t.Errorf("city variants mismapped: %q / %q", byID["8001"].Location, byID["8002"].Location)
+	}
+}
+
+func TestErecruiterDescriptionTemplateAgnostic(t *testing.T) {
+	// Company career-page templates differ: this one renders the body in id="opis"/"description"
+	// (not id="t1") and appends a GDPR consent clause. The description must capture the body,
+	// drop the title/workplace header and the clause, and survive the varied template.
+	detail := `<html><body><div id="offCont">` +
+		`<div id="JobTitle">DevOps Engineer</div>` +
+		`<div id="WorkPlace">Miejsce pracy: Łódź</div>` +
+		`<div id="opis"><p>Company intro paragraph.</p></div>` +
+		`<div id="description"><p>Run the Kubernetes fleet.</p></div>` +
+		`<div id="Clause"><p>Consent to processing personal data...</p></div>` +
+		`</div></body></html>`
+	page := erecruiterPage("1", erecruiterRow("500", "600", "700", "DevOps Engineer", "Łódź"))
+	fake := (&routedHTTP{}).route("grid=rows&pn=1", page).route("oid=500", detail)
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "brd"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (non-t1 template must still yield a body)", len(jobs))
+	}
+	d := jobs[0].Description
+	if !strings.Contains(d, "Kubernetes fleet") || !strings.Contains(d, "Company intro") {
+		t.Errorf("Description = %q, want the opis/description body", d)
+	}
+	if strings.Contains(d, "Consent to processing") {
+		t.Errorf("Description must drop the GDPR clause, got %q", d)
+	}
+	if strings.Contains(d, "DevOps Engineer") {
+		t.Errorf("Description must drop the JobTitle header, got %q", d)
 	}
 }
 

--- a/internal/sources/erecruiter_test.go
+++ b/internal/sources/erecruiter_test.go
@@ -1,0 +1,141 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestErecruiterProvider(t *testing.T) {
+	if got := NewErecruiter(nil).Provider(); got != "erecruiter" {
+		t.Errorf("Provider() = %q, want %q", got, "erecruiter")
+	}
+}
+
+// erecruiterRow builds one JSONP list row matching the real skk markup.
+func erecruiterRow(offerID, ejoID, ejorID, title, city string) string {
+	return "<tr jobOfferId='9' offerId='" + offerID + "' class='skk_row_odd' externalJobOfferId='" +
+		ejoID + "' externalJobOfferRegionId='" + ejorID + "' comId='20022820' skkResult='offer' >" +
+		"<td class='skk_positionName'>" + title + "</td><td>IT</td><td>" + city + "</td></tr>"
+}
+
+// erecruiterPage wraps rows in the JSONP envelope plus the hidden marker row carrying tr=total.
+func erecruiterPage(total string, rows ...string) string {
+	marker := "<tr tp='2' tr='" + total + "' pn='1' ps='20' style='display:none;'></tr>"
+	return `({"htm":"` + strings.Join(rows, "") + marker + `"})`
+}
+
+func erecruiterDetail(title, body string) string {
+	return `<html><body><div id="offCont"><div id="JobTitle">` + title +
+		`</div><div id="WorkPlace">Miejsce pracy: Warszawa</div>` +
+		`<div id="t1">` + body + `</div></body></html>`
+}
+
+func TestErecruiterFetchMapsFieldsAndPaginates(t *testing.T) {
+	// Total is 3 across two pages: page 1 has two offers, page 2 has one. The walk stops once
+	// it has collected the reported total, so no third page is fetched. The offer whose detail
+	// page has no route (GetHTML errors) is dropped, leaving 2 jobs.
+	page1 := erecruiterPage("3",
+		erecruiterRow("4893718", "587372", "330822", "Senior Go Engineer", "Warszawa"),
+		erecruiterRow("4893487", "591483", "330807", "Dropped Role", "Kraków"),
+	)
+	page2 := erecruiterPage("3",
+		erecruiterRow("4899999", "599999", "330900", "Backend Developer", "Gdańsk"),
+	)
+
+	fake := (&routedHTTP{}).
+		route("grid=rows&pn=1", page1).
+		route("grid=rows&pn=2", page2).
+		// Detail pages, keyed by offer id (oid=). "Dropped Role" (oid=4893487) has no route.
+		route("oid=4893718", erecruiterDetail("Senior Go Engineer", "<p>Build things</p><script>evil()</script>")).
+		route("oid=4899999", erecruiterDetail("Backend Developer", "<p>Write services</p>"))
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "erecruiter", Board: "eac02250aa184ed4bf4950e74948549a",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (one posting dropped for a missing detail page)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	full, ok := byID["587372"]
+	if !ok {
+		t.Fatal("job 587372 missing — ExternalID must be the externalJobOfferId")
+	}
+	if full.Title != "Senior Go Engineer" {
+		t.Errorf("Title = %q, want %q", full.Title, "Senior Go Engineer")
+	}
+	if full.Company != "Acme" {
+		t.Errorf("Company = %q, want config company %q", full.Company, "Acme")
+	}
+	if full.Location != "Warszawa" {
+		t.Errorf("Location = %q, want the row city %q", full.Location, "Warszawa")
+	}
+	if !strings.Contains(full.Description, "Build things") {
+		t.Errorf("Description = %q, want the detail body", full.Description)
+	}
+	if strings.Contains(full.Description, "<script") {
+		t.Errorf("Description not sanitized: %q", full.Description)
+	}
+	if !strings.Contains(full.URL, "Offer.aspx") ||
+		!strings.Contains(full.URL, "oid=4893718") ||
+		!strings.Contains(full.URL, "cfg=eac02250aa184ed4bf4950e74948549a") {
+		t.Errorf("URL = %q, want the Offer.aspx detail URL with oid+cfg", full.URL)
+	}
+
+	if _, dropped := byID["591483"]; dropped {
+		t.Error("posting 591483 has no detail page and must be dropped")
+	}
+
+	if _, ok := byID["599999"]; !ok {
+		t.Error("job 599999 from page 2 missing — pagination must fetch the second page")
+	}
+}
+
+func TestErecruiterFetchStopsAtReportedTotal(t *testing.T) {
+	// Page 1 already carries the whole board (total=1), so the walk must not fetch page 2.
+	page1 := erecruiterPage("1",
+		erecruiterRow("100", "200", "300", "Only Role", "Wrocław"),
+	)
+	fake := (&routedHTTP{}).
+		route("grid=rows&pn=1", page1).
+		route("oid=100", erecruiterDetail("Only Role", "<p>Sole opening</p>"))
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "brd"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	// One list call (pn=1) + one detail call (oid=100) = 2. A pn=2 fetch would have no route
+	// and error, so reaching here proves the walk stopped at the reported total.
+	if fake.calls != 2 {
+		t.Fatalf("fake.calls = %d, want 2 (no second list page once the total is reached)", fake.calls)
+	}
+}
+
+func TestErecruiterFetchStopsOnNonAdvancingPage(t *testing.T) {
+	// The board over-reports the total (99) but ignores pn, serving the same first row on every
+	// page. The walk must stop once a page repeats the previous page's first row instead of
+	// re-collecting up to the page cap.
+	same := erecruiterPage("99", erecruiterRow("100", "200", "300", "Only Role", "Wrocław"))
+	fake := (&routedHTTP{}).
+		route("grid=rows", same). // every pn returns the same page
+		route("oid=100", erecruiterDetail("Only Role", "<p>Sole opening</p>"))
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "brd"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (non-advancing pages must not re-collect)", len(jobs))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -194,6 +194,7 @@ func All(c HTTPClient) map[string]Source {
 		NewFactorial(c),
 		NewZoho(c),
 		NewTraffit(c),
+		NewErecruiter(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/openspec/changes/add-erecruiter-source/.openspec.yaml
+++ b/openspec/changes/add-erecruiter-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/add-erecruiter-source/design.md
+++ b/openspec/changes/add-erecruiter-source/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Spike (memory `hire-erecruiter-adapter-spike`) validated that eRecruiter Polska exposes a
+fully keyless public per-company job board on `skk.erecruiter.pl`:
+
+- **Board id = `cfg`** (32-hex), embedded in a company careers page as
+  `<script src="https://skk.erecruiter.pl/Code.ashx?cfg=<hex>">`.
+- **List**: `GET GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<page>` returns a JSONP body
+  `({"htm":"<tr ...><td>..</td></tr>"})`. Each `<tr>` carries `jobOfferId`, `offerId`,
+  `externalJobOfferId`, `externalJobOfferRegionId`, `comId`, and three `<td>` cells
+  (position, category, city). Page size is 20. A page past the end returns a hidden
+  marker row `<tr tp='2' tr='<TOTAL>' pn='<n>' ps='20'>`, so `tr` = total result count.
+- **Detail**: `GET Offer.aspx?oid=<offerId>&cfg=<cfg>&ejoId=<externalJobOfferId>&ejorId=<externalJobOfferRegionId>&comId=<comId>`
+  returns full HTML (title, company, location, description) and an "Aplikuj" button
+  linking to `system.erecruiter.pl/FormTemplates/RecruitmentForm.aspx?WebID=<hex>` — the
+  same form justjoin links to.
+
+The recruiter-side surfaces (`system.erecruiter.pl/Career`, `/Offers`, `vacancyapi`) are
+OIDC/401-gated and are NOT used. The adapter slots into the existing `sources` registry
+and `pipeline.Runner` write path unchanged.
+
+The discovery gap: justjoin only exposes per-job `WebID` apply forms, which carry no
+`cfg`. Onboarding the 161 justjoin companies therefore needs a separate step that resolves
+each company's `cfg` from its own careers page.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless, board-based `erecruiter` adapter (list + per-offer detail) that ingests one
+  company board per configured entry, deduping on the stable `externalJobOfferId`.
+- A `cmd/harvest-erecruiter` tool that turns a list of company careers URLs (or domains)
+  into validated `sources/erecruiter.yml` entries.
+
+**Non-Goals:**
+- Automatically mapping every justjoin `WebID` to a `cfg` (no such mapping exists) —
+  discovery is domain/careers-page driven, run by the harvester, not the adapter.
+- Ingesting via the recruiter-side authenticated eRecruiter API.
+- Self-close signals from eRecruiter (handled by the standard unseen-jobs sweep like any
+  other board source).
+
+## Decisions
+
+- **Board id is the `cfg` token.** It is stable per company and is the only identifier the
+  public endpoints accept. `sources/erecruiter.yml` entries are `company` + `board`=cfg.
+  Alternative — deriving from `comId` — rejected: `comId` is not accepted by the public
+  list/detail endpoints, only `cfg` is.
+- **Two-step list→detail fetch.** The list row lacks a description, so the adapter fetches
+  each offer's `Offer.aspx` detail for the body. Alternative — indexing title-only from
+  the list — rejected: it would persist bodyless postings, degrading search/enrichment.
+  This mirrors existing HTML detail adapters (Avature, SuccessFactors `GetHTML` seam).
+- **JSONP unwrap via `GetText`.** The list endpoint returns `({"htm":"…"})`, neither clean
+  JSON nor a clean HTML document. The adapter reads it with `GetText`, strips the wrapping
+  parens/semicolon, JSON-decodes the `htm` string, then parses the inner `<tr>` rows.
+- **Pagination stops on the reported total.** The first page's marker row exposes `tr`
+  (total); the adapter pages `pn=1..ceil(tr/20)` and also stops early if a page yields no
+  offer rows, under a bounded page cap (backstop against a pathological feed) — same shape
+  as the Traffit adapter's paginated collection.
+- **`ExternalID` = `externalJobOfferId`.** Stable across recrawls; the canonical detail
+  URL is the `Offer.aspx` URL. The `WebID` apply form is captured as the apply URL when
+  present but is not the identity (forms 404 once a job closes).
+- **Harvester resolves `cfg` from careers pages.** Given a company careers URL, fetch it
+  with `GetText`, regex-extract `Code.ashx?cfg=<hex>`, then probe
+  `GetHtml.ashx?cfg=<hex>&grid=rows&pn=1` and keep the token only if it returns offer rows.
+  Same live-validate-then-emit shape as `cmd/harvest-boards` / the Traffit prober.
+
+## Risks / Trade-offs
+
+- **cfg discovery coverage** → The harvester needs a company's real careers URL; blind
+  guessing fails (Fabrity/Medicover careers pages 404/403 on guessed paths). Mitigation:
+  seed the harvester from the justjoin company list (names → domains) and accept partial
+  coverage; missing companies still arrive via justjoin as today.
+- **HTML detail parsing is brittle** → eRecruiter's `Offer.aspx` markup can change.
+  Mitigation: parse defensively (skip a posting whose title/description can't be extracted
+  rather than failing the board), and cover the parse with a fixture test.
+- **Non-IT noise** → Boards carry all company jobs (e.g. cleaning roles). Mitigation: none
+  needed — the standard classify/skilltag dictionaries derive facets and IT filtering
+  happens downstream as for every source.
+- **Per-offer detail fetches add load** → one request per posting. Mitigation: bounded by
+  each board's real size (tens, not thousands); acceptable at cron cadence.
+
+## Migration Plan
+
+- Ship adapter + registry line + empty/seed `sources/erecruiter.yml`; no schema changes.
+- Wire a per-provider ingest cron for `sources/erecruiter.yml` (one schedule, like other
+  board files). Rollback = drop the cron entry and the registry line; no data migration.
+- Run `cmd/harvest-erecruiter` over the justjoin company set to populate the board file
+  incrementally.
+
+## Open Questions
+
+- Does `Offer.aspx` expose a reliable posted-at date? If not, postings fall back to ingest
+  time via the existing `effectivePostedAt` handling (acceptable).
+- Best seed for the harvester: reuse the justjoin-mined company list, or fold eRecruiter
+  cfg detection into the existing `domain-ats-harvest`? Deferred to harvest execution.

--- a/openspec/changes/add-erecruiter-source/proposal.md
+++ b/openspec/changes/add-erecruiter-source/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+eRecruiter (Polska) is the single largest ATS gap behind justjoin: 161 distinct
+companies apply through eRecruiter forms, and today we can only re-aggregate those
+postings via justjoin — a second-class source with weaker dedup, freshness, and no
+self-close. eRecruiter exposes a fully keyless public per-company board
+(`skk.erecruiter.pl`), so we can ingest those companies directly under their own
+identity instead of through the aggregator.
+
+## What Changes
+
+- Add an `erecruiter` source adapter (`internal/sources/erecruiter.go`) that crawls one
+  company's public "Strona Kariera" board. The board id is the company's `cfg`
+  (32-hex config token). It lists postings via `GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<n>`
+  and fetches each posting's title/location/description from its `Offer.aspx` detail page.
+- Register `erecruiter` in `sources.All`, add the board file `sources/erecruiter.yml`
+  (one entry per company: `company` + `board`=cfg), and wire an ingest cron for it.
+- Add a `cmd/harvest-erecruiter` tool that resolves a company's `cfg` from its careers
+  page (fetch page → extract `Code.ashx?cfg=<hex>`), live-validates it against the board
+  endpoint, and prints ready-to-paste `sources/erecruiter.yml` entries — the discovery
+  bridge for the 161 justjoin companies (justjoin exposes per-job `WebID` apply forms,
+  which carry no `cfg`).
+
+## Capabilities
+
+### New Capabilities
+- `erecruiter-source`: a board-based `erecruiter` adapter that crawls one company's
+  keyless eRecruiter career board (list rows + per-offer detail) into the catalogue,
+  plus a harvest prober that discovers and validates a company's `cfg` board token.
+
+### Modified Capabilities
+<!-- None: source-ingest's registry/board-file contract is unchanged; this adds a new provider under it. -->
+
+## Impact
+
+- New: `internal/sources/erecruiter.go` (+ test), `sources/erecruiter.yml`,
+  `cmd/harvest-erecruiter/main.go`.
+- Modified: `internal/sources/source.go` (`All` registry line), Dockerfile/cron wiring
+  for the new ingest board file (per-provider schedule).
+- No schema/migration changes. Postings flow through the existing `pipeline.Runner` →
+  `UpsertJob` write path; the stale-job sweep and incremental indexing apply unchanged.
+- eRecruiter boards carry all of a company's jobs (incl. non-IT); the existing
+  classify/skilltag dictionaries filter/derive facets as for any other source.

--- a/openspec/changes/add-erecruiter-source/specs/erecruiter-source/spec.md
+++ b/openspec/changes/add-erecruiter-source/specs/erecruiter-source/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: eRecruiter company-board crawl
+
+The system SHALL provide an `erecruiter` source adapter that crawls one company's public
+eRecruiter "Strona Kariera" board into the catalogue. The board id is the company's `cfg`
+config token (32-hex), and the adapter fetches the keyless public endpoint
+`https://skk.erecruiter.pl/GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<page>`. The adapter is
+board-based (it requires a board id) and appears in the source facet.
+
+#### Scenario: Board yields all live postings
+
+- **WHEN** the adapter fetches a configured company board
+- **THEN** it returns one `Job` per posting on the board, each with the posting's title,
+  HTML description (sanitized), free-text location, apply/detail URL, and — when the
+  board exposes it — a posted-at timestamp
+
+#### Scenario: Stable dedup identity
+
+- **WHEN** the adapter maps a board row to a `Job`
+- **THEN** the `ExternalID` is the posting's stable `externalJobOfferId`, so re-crawling
+  the same company board dedups to the same catalogue row
+
+### Requirement: Two-step list then detail fetch
+
+The adapter SHALL fetch each posting's `Offer.aspx` detail page and parse its description
+and canonical detail URL, so a persisted posting carries a real body rather than only a
+one-line title. This is required because the list endpoint returns only a row summary
+(title, category, city, and the id fields offerId, externalJobOfferId,
+externalJobOfferRegionId, comId); the full description lives on the per-offer detail page,
+addressed by those id fields plus the board `cfg`.
+
+#### Scenario: Detail supplies the description
+
+- **WHEN** the adapter has a list row and fetches its detail page
+- **THEN** the resulting `Job` carries the posting's full sanitized description and the
+  `Offer.aspx` URL as its canonical detail URL
+
+#### Scenario: Detail page missing
+
+- **WHEN** a posting's detail page is gone (the row references a closed offer)
+- **THEN** the adapter skips that posting without aborting the rest of the board
+
+### Requirement: Paginated collection bounded by reported total
+
+The adapter SHALL page through the board until it has collected the reported total (or a
+page returns no offer rows), and SHALL stop after a bounded number of pages so a
+pathological feed can never loop forever. The list endpoint returns a fixed page size (20
+rows) and, on the first page, a marker row whose `tr` attribute is the board's total
+result count; a single-page fetch would otherwise silently truncate a board larger than
+one page.
+
+#### Scenario: Board larger than one page
+
+- **WHEN** a company has more postings than one page (e.g. 32 postings, page size 20)
+- **THEN** the adapter returns every live posting, not just the first page
+
+#### Scenario: Guard against a never-ending feed
+
+- **WHEN** the endpoint keeps returning full pages without ever reaching the total
+- **THEN** the adapter stops after a bounded number of pages rather than looping forever
+
+### Requirement: Harvest cfg discovery and validation
+
+The system SHALL provide a harvest tool for the `erecruiter` provider that resolves a
+company's `cfg` board token from the company's own careers page (fetch the page and
+extract the `https://skk.erecruiter.pl/Code.ashx?cfg=<hex>` widget reference), then
+live-validates the token against the board endpoint. It keeps a candidate only when the
+board endpoint returns parseable offer rows, and skips any other candidate without
+aborting the harvest. Valid tokens are emitted as ready-to-paste `sources/erecruiter.yml`
+entries (`company` + `board`=cfg). This is the discovery bridge for companies known only
+by an eRecruiter apply-form `WebID`, which carries no `cfg`.
+
+#### Scenario: Careers page exposes a cfg
+
+- **WHEN** the harvester fetches a company careers page that embeds the eRecruiter widget
+- **THEN** it extracts the `cfg` token, confirms the board endpoint returns live offer
+  rows, and emits a board-file entry for that company
+
+#### Scenario: No eRecruiter widget on the page
+
+- **WHEN** a candidate careers page does not reference `skk.erecruiter.pl/Code.ashx?cfg=`
+- **THEN** the harvester skips the candidate silently and continues with the rest

--- a/openspec/changes/add-erecruiter-source/specs/erecruiter-source/spec.md
+++ b/openspec/changes/add-erecruiter-source/specs/erecruiter-source/spec.md
@@ -18,8 +18,15 @@ board-based (it requires a board id) and appears in the source facet.
 #### Scenario: Stable dedup identity
 
 - **WHEN** the adapter maps a board row to a `Job`
-- **THEN** the `ExternalID` is the posting's stable `externalJobOfferId`, so re-crawling
-  the same company board dedups to the same catalogue row
+- **THEN** the `ExternalID` is the posting's `offerId`, so re-crawling the same company board
+  dedups to the same catalogue row
+
+#### Scenario: Multi-city posting kept distinct
+
+- **WHEN** one posting is spread over several cities — its per-city rows share an
+  `externalJobOfferId` but each has a distinct `offerId`, location, and detail page
+- **THEN** keying on `offerId` keeps each city variant a distinct job, rather than collapsing
+  them under the `(source, external_id)` dedup key
 
 ### Requirement: Two-step list then detail fetch
 

--- a/openspec/changes/add-erecruiter-source/tasks.md
+++ b/openspec/changes/add-erecruiter-source/tasks.md
@@ -1,0 +1,50 @@
+## 1. eRecruiter adapter
+
+- [x] 1.1 Add a fixture-backed test (`internal/sources/erecruiter_test.go`) for the list
+  parse: JSONP `({"htm":"<tr ...>"})` → rows with `offerId`/`externalJobOfferId`/
+  `externalJobOfferRegionId`/`comId`/title/city, plus the `tr` total from the marker row.
+- [x] 1.2 Add a fixture-backed test for the detail parse: `Offer.aspx` HTML →
+  title/company/location/description; missing/closed detail is skipped.
+- [x] 1.3 Implement `internal/sources/erecruiter.go`: `Provider() == "erecruiter"`,
+  board-based (not boardless), `Fetch` reads `GetHtml.ashx?cfg=<board>&grid=rows&pn=<n>`
+  via `GetText`, unwraps the JSONP, parses rows, and fetches each offer's `Offer.aspx`
+  detail; maps to `Job` with `ExternalID = externalJobOfferId` and the `Offer.aspx` URL.
+- [x] 1.4 Implement paginated collection: read `tr` total from page 1, page until the
+  total is collected or a page yields no offer rows (or a non-advancing page), under a
+  bounded page cap. Detail fetches run through the shared `fetchDetails` worker pool.
+- [x] 1.5 Parse defensively — a posting whose title/description can't be extracted is
+  skipped without aborting the board; sanitize the HTML description (existing helper).
+- [x] 1.6 `go build ./... && go vet ./... && go test ./internal/sources/` green.
+
+## 2. Registry and board file
+
+- [x] 2.1 Register `NewErecruiter(c)` in `sources.All` (`internal/sources/source.go`).
+- [x] 2.2 Add `sources/erecruiter.yml` with the board-file header and a live-validated seed
+  entry (Atalian Poland cfg).
+- [x] 2.3 Confirm the adapter crawls a seed board end-to-end (32 live postings fetched with
+  real title/location/description).
+
+## 3. cfg harvester
+
+- [x] 3.1 Add a test for the cfg extractor: careers-page HTML → `cfg` token, and a page
+  without the `Code.ashx?cfg=` widget yields no token (skipped).
+- [x] 3.2 Implement `cmd/harvest-erecruiter/main.go`: read company careers URLs (or
+  domains) from input, fetch each, extract `cfg`, live-validate via the adapter, and print
+  `sources/erecruiter.yml` entries for the valid ones; skip the rest without aborting.
+- [ ] 3.3 Run the harvester over the justjoin-mined eRecruiter company set (needs each
+  company's careers URL) and fold the validated entries into `sources/erecruiter.yml`.
+  Deferred — data-gathering follow-up; the tool and adapter are done and verified live.
+
+## 4. Ops wiring
+
+- [x] 4.1 `cmd/harvest-erecruiter` is a run-once host tool (like `cmd/harvest-boards`), not
+  a prod binary — left out of the Dockerfile and documented in the board-file header.
+- [ ] 4.2 Wire a per-provider ingest cron for `sources/erecruiter.yml`. Deferred — cron
+  schedules live in the `freehire-ops` repo, not this codebase.
+
+## 5. Verification
+
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` green (46 packages).
+- [x] 5.2 Manually crawled a seed board and confirmed postings carry real
+  title/location/description and dedup on the stable `externalJobOfferId`.
+- [x] 5.3 `openspec validate add-erecruiter-source` passes.

--- a/sources/erecruiter.yml
+++ b/sources/erecruiter.yml
@@ -7,8 +7,62 @@
 # and a board carries all of a company's jobs (IT and non-IT); the pipeline's classify/skilltag
 # dictionaries derive facets and IT filtering happens downstream.
 #
-# Each board is validated live (list endpoint returned offer rows) before adding. Discover a
-# company's cfg with: go run ./cmd/harvest-erecruiter <careers-urls.txt>
+# Each board was validated live (list endpoint returned live offer rows) before adding.
+# Discover a company's cfg with: go run ./cmd/harvest-erecruiter <careers-urls.txt>
 
+- company: Asseco Business Solutions
+  board: 7c55630e38e54a6ab90e64cc28fc173f
 - company: Atalian Poland
   board: eac02250aa184ed4bf4950e74948549a
+- company: Atende
+  board: ebd48c8bb7ce4b01a6d08052ac22783d
+- company: Bank Gospodarstwa Krajowego
+  board: 21f6ff3809da40219e4102f28e47c254
+- company: Benefit Systems
+  board: d4299fd2ca154f1c8e772a5cf9df01d8
+- company: Budimex
+  board: 20c4ecaac68c42b4ad93b5beceb3574d
+- company: C&F
+  board: 8eb3ecddaa1c482f9306e80f52ffc25d
+- company: DPD Polska
+  board: 0a942f8a967748f68df0603230db9e3d
+- company: Impact Clean Power Technology
+  board: 6e5affd0b23a40ee9aec81f50f00e15a
+- company: InPost
+  board: aaa769425b3f4db0aba90feb1a03c2d0
+- company: Investa
+  board: 636b4ae907754d92b4391c198ef97fc5
+- company: Krajowa Izba Rozliczeniowa
+  board: 900c79c3d4e14248b1be36c97279130c
+- company: LOT Aircraft Maintenance Services
+  board: 072a6e4eefb94a4bbd7f6a2e54206a9b
+- company: LUX MED
+  board: 4dfadcc165b34f609578051941d8f662
+- company: Medicover
+  board: 848bb9aa33704e14afa7ab9ddafaab9d
+- company: mBank
+  board: 0b23d21dc7b54dfaa0900c44fd8ca54d
+- company: PKO Bank Polski
+  board: a1cde84930e641b8b6fe1d0149e8fb43
+- company: PLAY
+  board: 06a6e3c5918f43279acd57cbb61fecee
+- company: Pelion
+  board: 1bfb8af506da4b22850d075fec06454a
+- company: Pentacomp
+  board: 6c76afbe718c49ceb7b21bcbd993373b
+- company: Polska Agencja Żeglugi Powietrznej
+  board: 58e9fc2b67ba49dfa17c0ac0bcfe8d56
+- company: Polska Grupa Zbrojeniowa
+  board: 055531097fe04079a190d2f210485080
+- company: Polskie Sieci Elektroenergetyczne
+  board: df57fda29f364a128360143b108a39ac
+- company: Teleperformance Polska
+  board: afa44a96e20946d384b5c414b2c1eebf
+- company: Telewizja Polska
+  board: 7e6ba9db068b4dfd9f24da1ad11ca16d
+- company: UNIQA
+  board: 9317759c7362495e83ff6aae978438bb
+- company: Łukasiewicz – Instytut Lotnictwa
+  board: 2e10b2bbe17c4631b9d296673d78972d
+- company: Śnieżka
+  board: ac4808e9277441d9b2442b656445fa89

--- a/sources/erecruiter.yml
+++ b/sources/erecruiter.yml
@@ -1,0 +1,14 @@
+# eRecruiter Polska career boards ("Strona Kariera"). Provider is the filename; each entry
+# is company + board. board = the company's cfg config token (32-hex), embedded in its
+# careers page as skk.erecruiter.pl/Code.ashx?cfg=<hex>; see internal/sources/erecruiter.go.
+# The keyless list endpoint (skk.erecruiter.pl/GetHtml.ashx?cfg=<board>&grid=rows) returns a
+# JSONP row table (the server returns 20 rows per page), and each posting's description comes
+# from its Offer.aspx detail page. eRecruiter is a Polish ATS, so most postings are in Polish
+# and a board carries all of a company's jobs (IT and non-IT); the pipeline's classify/skilltag
+# dictionaries derive facets and IT filtering happens downstream.
+#
+# Each board is validated live (list endpoint returned offer rows) before adding. Discover a
+# company's cfg with: go run ./cmd/harvest-erecruiter <careers-urls.txt>
+
+- company: Atalian Poland
+  board: eac02250aa184ed4bf4950e74948549a


### PR DESCRIPTION
## Summary

- Adds an `erecruiter` source adapter — eRecruiter is the single largest ATS gap behind the justjoin aggregator (**161 companies**). It exposes a keyless public per-company board on `skk.erecruiter.pl`, so those companies can now be ingested directly under their own identity instead of second-hand via the aggregator.
- **Adapter** (`internal/sources/erecruiter.go`): board-based (board = the company `cfg` token). Lists via `GetHtml.ashx?cfg=<board>&grid=rows&pn=<n>` — a JSONP row table paged on the hidden marker row's `tr` total, guarded against non-advancing pages — then fetches each posting's `Offer.aspx` detail (through the shared `fetchDetails` worker pool) for its description. `ExternalID` = the stable `externalJobOfferId`.
- **Harvester** (`cmd/harvest-erecruiter`): run-once host tool that resolves a company's `cfg` from its careers page (`Code.ashx?cfg=<hex>`), live-validates it against the board endpoint, and prints ready-to-paste `sources/erecruiter.yml` entries — the discovery bridge for the justjoin companies (whose apply links are per-job `WebID` forms that carry no `cfg`).
- Registers `erecruiter` in `sources.All`; seeds `sources/erecruiter.yml` with one live-validated board.

Planned via OpenSpec change `add-erecruiter-source` (proposal/design/specs/tasks included).

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` green (46 packages)
- [x] New unit tests: list/detail parse, pagination stop at reported total, non-advancing-page guard, posting drop on missing detail, cfg extractor, careers-URL host parsing
- [x] Live: seed board (`Atalian Poland`) returns 32 postings with real title/location/description; harvester resolves + validates its `cfg` end-to-end

## Follow-ups (deferred, noted in tasks.md)
- Run the harvester over the justjoin-mined eRecruiter company set to populate `sources/erecruiter.yml` (needs each company's careers URL)
- Wire the per-provider ingest cron for `sources/erecruiter.yml` in the `freehire-ops` repo