### PR TITLE
feat(jobderive): derive english_level deterministically (dict-only facet)

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -114,6 +114,7 @@ func backfillAll(ctx context.Context, store facetStore) (scanned, updated int, e
 				d.PostingLanguage == j.PostingLanguage &&
 				d.EmploymentType == j.EmploymentType &&
 				d.EducationLevel == j.EducationLevel &&
+				d.EnglishLevel == j.EnglishLevel &&
 				experience == j.ExperienceYearsMin
 			if unchanged {
 				continue
@@ -130,6 +131,7 @@ func backfillAll(ctx context.Context, store facetStore) (scanned, updated int, e
 				PostingLanguage:    d.PostingLanguage,
 				EmploymentType:     d.EmploymentType,
 				EducationLevel:     d.EducationLevel,
+				EnglishLevel:       d.EnglishLevel,
 				ExperienceYearsMin: experience,
 			}); err != nil {
 				return scanned, updated, err

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -75,6 +75,7 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 		PostingLanguage:    job.PostingLanguage,
 		EmploymentType:     job.EmploymentType,
 		EducationLevel:     job.EducationLevel,
+		EnglishLevel:       job.EnglishLevel,
 		ExperienceYearsMin: toInt4(job.ExperienceYearsMin),
 	}
 	// Fingerprint the indexed fields so the upsert can report whether this write

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -116,6 +116,7 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 			PostingLanguage:    lang.Detect(descHTML),
 			EmploymentType:     jobfacts.EmploymentType(j.Title, descHTML),
 			EducationLevel:     jobfacts.EducationLevel(descHTML),
+			EnglishLevel:       jobfacts.EnglishLevel(descHTML),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(descHTML)),
 		})
 		if err != nil {
@@ -187,6 +188,7 @@ func (s *extractStore) CompleteLinks(
 			PostingLanguage:    lang.Detect(j.Description),
 			EmploymentType:     jobfacts.EmploymentType(j.Title, j.Description),
 			EducationLevel:     jobfacts.EducationLevel(j.Description),
+			EnglishLevel:       jobfacts.EnglishLevel(j.Description),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(j.Description)),
 		})
 		if err != nil {

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -131,7 +131,7 @@ func (q *Queries) EstimateOpenJobs(ctx context.Context) (int64, error) {
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 FROM jobs
 WHERE id = $1
 `
@@ -174,12 +174,13 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.EnglishLevel,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 FROM jobs
 WHERE public_slug = $1
 `
@@ -222,6 +223,7 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.EnglishLevel,
 	)
 	return i, err
 }
@@ -283,7 +285,7 @@ func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 FROM jobs
 WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -342,6 +344,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.EnglishLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -354,7 +357,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -411,6 +414,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.EnglishLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -423,7 +427,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -482,6 +486,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.EnglishLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -494,7 +499,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -557,6 +562,7 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.ExperienceYearsMin,
 			&i.Collections,
 			&i.ContentHash,
+			&i.EnglishLevel,
 		); err != nil {
 			return nil, err
 		}
@@ -724,8 +730,9 @@ SET countries = COALESCE($1::text[], '{}'),
     posting_language     = $7,
     employment_type      = $8,
     education_level      = $9,
-    experience_years_min = $10
-WHERE id = $11
+    english_level        = $10,
+    experience_years_min = $11
+WHERE id = $12
 `
 
 type UpdateJobFacetsParams struct {
@@ -738,6 +745,7 @@ type UpdateJobFacetsParams struct {
 	PostingLanguage    string      `json:"posting_language"`
 	EmploymentType     string      `json:"employment_type"`
 	EducationLevel     string      `json:"education_level"`
+	EnglishLevel       string      `json:"english_level"`
 	ExperienceYearsMin pgtype.Int4 `json:"experience_years_min"`
 	ID                 int64       `json:"id"`
 }
@@ -745,7 +753,7 @@ type UpdateJobFacetsParams struct {
 // One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 // facet column — countries, regions, work_mode, skills, seniority, category, plus the
 // synthetic enrichment facets posting_language, employment_type, education_level,
-// and experience_years_min — from the row's raw content
+// english_level, and experience_years_min — from the row's raw content
 // (title/location/description) in one
 // pass, replacing the
 // three separate per-facet backfill writes. The facets are a pure function of the
@@ -765,6 +773,7 @@ func (q *Queries) UpdateJobFacets(ctx context.Context, arg UpdateJobFacetsParams
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
+		arg.EnglishLevel,
 		arg.ExperienceYearsMin,
 		arg.ID,
 	)
@@ -818,11 +827,12 @@ SET title        = $1,
     posting_language     = $14,
     employment_type      = $15,
     education_level      = $16,
-    experience_years_min = $17,
-    updated_by   = $18::bigint,
+    english_level        = $17,
+    experience_years_min = $18,
+    updated_by   = $19::bigint,
     updated_at   = now()
-WHERE public_slug = $19 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+WHERE public_slug = $20 AND created_by IS NOT NULL
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 `
 
 type UpdateManualJobParams struct {
@@ -842,6 +852,7 @@ type UpdateManualJobParams struct {
 	PostingLanguage    string             `json:"posting_language"`
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
+	EnglishLevel       string             `json:"english_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
 	UpdatedBy          int64              `json:"updated_by"`
 	PublicSlug         string             `json:"public_slug"`
@@ -877,6 +888,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
+		arg.EnglishLevel,
 		arg.ExperienceYearsMin,
 		arg.UpdatedBy,
 		arg.PublicSlug,
@@ -917,6 +929,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.EnglishLevel,
 	)
 	return i, err
 }
@@ -937,7 +950,7 @@ company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min,
+    posting_language, employment_type, education_level, english_level, experience_years_min,
     content_hash
 ) VALUES (
     $1, $2, $3, $4,
@@ -946,8 +959,8 @@ INSERT INTO jobs (
     $11,
     COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'),
     $14, COALESCE($15::text[], '{}'), $16, $17,
-    $18, $19, $20, $21,
-    $22
+    $18, $19, $20, $21, $22,
+    $23
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -967,6 +980,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
+    english_level        = EXCLUDED.english_level,
     experience_years_min = EXCLUDED.experience_years_min,
     content_hash = EXCLUDED.content_hash,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
@@ -976,9 +990,9 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
-    ((SELECT old_hash FROM existing) IS DISTINCT FROM $22) AS changed
+    ((SELECT old_hash FROM existing) IS DISTINCT FROM $23) AS changed
 `
 
 type UpsertJobParams struct {
@@ -1002,6 +1016,7 @@ type UpsertJobParams struct {
 	PostingLanguage    string             `json:"posting_language"`
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
+	EnglishLevel       string             `json:"english_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
 	ContentHash        pgtype.Text        `json:"content_hash"`
 }
@@ -1054,6 +1069,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
+		arg.EnglishLevel,
 		arg.ExperienceYearsMin,
 		arg.ContentHash,
 	)
@@ -1093,6 +1109,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.ExperienceYearsMin,
 		&i.Job.Collections,
 		&i.Job.ContentHash,
+		&i.Job.EnglishLevel,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -1111,7 +1128,7 @@ WITH company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min,
+    posting_language, employment_type, education_level, english_level, experience_years_min,
     created_by
 ) VALUES (
     $1, $2, $3, $4,
@@ -1121,8 +1138,8 @@ INSERT INTO jobs (
     COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'),
     $14, COALESCE($15::text[], '{}'),
     $16, $17,
-    $18, $19, $20, $21,
-    $22::bigint
+    $18, $19, $20, $21, $22,
+    $23::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -1142,14 +1159,15 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
+    english_level        = EXCLUDED.english_level,
     experience_years_min = EXCLUDED.experience_years_min,
-    updated_by   = $23::bigint,
+    updated_by   = $24::bigint,
     -- A moderator re-create reopens the job; reset the strike count too so the
     -- two-strike liveness grace survives a reopen (see UpsertJob).
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level
 `
 
 type UpsertManualJobParams struct {
@@ -1173,6 +1191,7 @@ type UpsertManualJobParams struct {
 	PostingLanguage    string             `json:"posting_language"`
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
+	EnglishLevel       string             `json:"english_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
 	CreatedBy          int64              `json:"created_by"`
 	UpdatedBy          int64              `json:"updated_by"`
@@ -1210,6 +1229,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
+		arg.EnglishLevel,
 		arg.ExperienceYearsMin,
 		arg.CreatedBy,
 		arg.UpdatedBy,
@@ -1250,6 +1270,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.ExperienceYearsMin,
 		&i.Collections,
 		&i.ContentHash,
+		&i.EnglishLevel,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -81,6 +81,7 @@ type Job struct {
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
 	Collections        []string           `json:"collections"`
 	ContentHash        pgtype.Text        `json:"content_hash"`
+	EnglishLevel       string             `json:"english_level"`
 }
 
 type JobReport struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -434,7 +434,7 @@ type Querier interface {
 	// One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 	// facet column — countries, regions, work_mode, skills, seniority, category, plus the
 	// synthetic enrichment facets posting_language, employment_type, education_level,
-	// and experience_years_min — from the row's raw content
+	// english_level, and experience_years_min — from the row's raw content
 	// (title/location/description) in one
 	// pass, replacing the
 	// three separate per-facet backfill writes. The facets are a pure function of the

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -109,7 +109,7 @@ company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min,
+    posting_language, employment_type, education_level, english_level, experience_years_min,
     content_hash
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
@@ -118,7 +118,7 @@ INSERT INTO jobs (
     sqlc.arg(public_slug),
     COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'),
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'), sqlc.arg(seniority), sqlc.arg(category),
-    sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(experience_years_min),
+    sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(english_level), sqlc.arg(experience_years_min),
     sqlc.arg(content_hash)
 )
 -- public_slug is deliberately NOT in the DO UPDATE SET: the slug is minted once
@@ -143,6 +143,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
+    english_level        = EXCLUDED.english_level,
     experience_years_min = EXCLUDED.experience_years_min,
     content_hash = EXCLUDED.content_hash,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
@@ -191,7 +192,7 @@ WITH company_upsert AS (
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, work_mode, skills, seniority, category,
-    posting_language, employment_type, education_level, experience_years_min,
+    posting_language, employment_type, education_level, english_level, experience_years_min,
     created_by
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
@@ -201,7 +202,7 @@ INSERT INTO jobs (
     COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'),
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'),
     sqlc.arg(seniority), sqlc.arg(category),
-    sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(experience_years_min),
+    sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(english_level), sqlc.arg(experience_years_min),
     sqlc.arg(created_by)::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
@@ -222,6 +223,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
+    english_level        = EXCLUDED.english_level,
     experience_years_min = EXCLUDED.experience_years_min,
     updated_by   = sqlc.arg(updated_by)::bigint,
     -- A moderator re-create reopens the job; reset the strike count too so the
@@ -269,6 +271,7 @@ SET title        = sqlc.arg(title),
     posting_language     = sqlc.arg(posting_language),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),
+    english_level        = sqlc.arg(english_level),
     experience_years_min = sqlc.arg(experience_years_min),
     updated_by   = sqlc.arg(updated_by)::bigint,
     updated_at   = now()
@@ -385,7 +388,7 @@ WHERE id = sqlc.arg(id);
 -- One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 -- facet column — countries, regions, work_mode, skills, seniority, category, plus the
 -- synthetic enrichment facets posting_language, employment_type, education_level,
--- and experience_years_min — from the row's raw content
+-- english_level, and experience_years_min — from the row's raw content
 -- (title/location/description) in one
 -- pass, replacing the
 -- three separate per-facet backfill writes. The facets are a pure function of the
@@ -404,5 +407,6 @@ SET countries = COALESCE(sqlc.arg(countries)::text[], '{}'),
     posting_language     = sqlc.arg(posting_language),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),
+    english_level        = sqlc.arg(english_level),
     experience_years_min = sqlc.arg(experience_years_min)
 WHERE id = sqlc.arg(id);

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -185,7 +185,7 @@ func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) 
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -269,6 +269,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.ExperienceYearsMin,
 			&i.Job.Collections,
 			&i.Job.ContentHash,
+			&i.Job.EnglishLevel,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,

--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -113,14 +113,13 @@ type scalarEnum struct {
 // servedScalarEnums lists the served single-value enum fields, in declaration
 // order. It is the ONE place the served-scalar set is defined; Validate reads it,
 // Sanitize blanks through it. The dictionary-covered facets (work_mode, seniority,
-// category, regions, employment_type, education_level) are deliberately absent —
-// jobview serves them from the deterministic dictionaries, so the LLM's values are
-// unserved discovery material under dict-only.
+// category, regions, employment_type, education_level, english_level) are
+// deliberately absent — jobview serves them from the deterministic dictionaries, so
+// the LLM's values are unserved discovery material under dict-only.
 func (e *Enrichment) servedScalarEnums() []scalarEnum {
 	return []scalarEnum{
 		{"relocation", &e.Relocation, RelocationValues},
 		{"salary_period", &e.SalaryPeriod, SalaryPeriodValues},
-		{"english_level", &e.EnglishLevel, EnglishLevelValues},
 		{"company_type", &e.CompanyType, CompanyTypeValues},
 		{"company_size", &e.CompanySize, CompanySizeValues},
 	}
@@ -130,8 +129,8 @@ func (e *Enrichment) servedScalarEnums() []scalarEnum {
 // returns an error identifying the first offending field. Empty (absent) fields
 // pass — every field is optional. Non-enum fields (ISO codes, free text, numbers,
 // skills) are unconstrained here. The dictionary-covered facets (work_mode,
-// seniority, category, regions, employment_type, education_level, plus the
-// non-enum countries/skills) are deliberately NOT validated: they are served from
+// seniority, category, regions, employment_type, education_level, english_level,
+// plus the non-enum countries/skills) are deliberately NOT validated: they are served from
 // the deterministic dictionaries (dict-only), so the LLM's values for them are
 // unserved discovery material and an out-of-vocabulary value is captured raw
 // rather than rejected.
@@ -167,8 +166,8 @@ func (e Enrichment) Validate() error {
 // Sanitize drops out-of-vocabulary values from the SERVED enum fields (a scalar is
 // blanked, a multi-value field keeps only known members) so no stray value reaches
 // the served wire shape. The dictionary-covered facets (work_mode, seniority,
-// category, regions, employment_type, education_level) are deliberately left
-// untouched: they are unserved discovery material under dict-only, so the LLM's raw
+// category, regions, employment_type, education_level, english_level) are
+// deliberately left untouched: they are unserved discovery material under dict-only, so the LLM's raw
 // values — including novel, out-of-vocabulary labels — are kept for later mining.
 // The invariant "never serve an out-of-vocabulary value" still holds for the served
 // fields, and Validate passes afterwards.

--- a/internal/enrich/enrichment_test.go
+++ b/internal/enrich/enrichment_test.go
@@ -126,23 +126,23 @@ func TestValidateRejectsScalarEnum(t *testing.T) {
 }
 
 // When several SERVED enum fields are invalid, Validate reports the first one in
-// declaration order (relocation is checked before english_level).
+// declaration order (relocation is checked before company_size).
 func TestValidateReportsFirstOffender(t *testing.T) {
-	err := Enrichment{Relocation: "telepathic", EnglishLevel: "sr"}.Validate()
+	err := Enrichment{Relocation: "telepathic", CompanySize: "huge"}.Validate()
 	if err == nil {
 		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), "relocation") {
 		t.Errorf("want first offender relocation, got: %v", err)
 	}
-	if strings.Contains(err.Error(), "english_level") {
+	if strings.Contains(err.Error(), "company_size") {
 		t.Errorf("should report only the first offender, got: %v", err)
 	}
 }
 
 // Relax: the dict-covered discovery facets are captured raw — an out-of-vocab
-// work_mode/seniority/category/employment_type/education_level and a non-vocab
-// regions element pass Validate (they are unserved, so they cannot corrupt
+// work_mode/seniority/category/employment_type/education_level/english_level and a
+// non-vocab regions element pass Validate (they are unserved, so they cannot corrupt
 // production data).
 func TestValidateAcceptsOutOfVocabDiscoveryFacets(t *testing.T) {
 	discovery := []Enrichment{
@@ -152,6 +152,7 @@ func TestValidateAcceptsOutOfVocabDiscoveryFacets(t *testing.T) {
 		{Regions: []string{"eu", "europe"}},
 		{EmploymentType: "freelance"},
 		{EducationLevel: "associate"},
+		{EnglishLevel: "toefl_110"},
 	}
 	for i, e := range discovery {
 		if err := e.Validate(); err != nil {
@@ -205,23 +206,24 @@ func TestGlobalReachDistinctFromUnknown(t *testing.T) {
 
 func TestSanitizeDropsOutOfVocabValues(t *testing.T) {
 	e := Enrichment{
-		Relocation:   "seasonal",                   // SERVED invalid scalar -> blanked
-		EnglishLevel: "b2",                         // SERVED valid -> kept
-		Domains:      []string{"fintech", "bogus"}, // SERVED multi -> keep only known
+		Relocation:  "seasonal",                   // SERVED invalid scalar -> blanked
+		CompanyType: "product",                    // SERVED valid -> kept
+		Domains:     []string{"fintech", "bogus"}, // SERVED multi -> keep only known
 		// Discovery facets are captured raw (unserved):
 		Category:       "astrology",      // kept
 		Seniority:      "staff_plus",     // kept
 		Regions:        []string{"nope"}, // kept
 		EmploymentType: "freelance",      // kept
 		EducationLevel: "associate",      // kept
+		EnglishLevel:   "toefl_110",      // kept
 	}
 	e.Sanitize()
 
 	if e.Relocation != "" {
 		t.Errorf("Relocation = %q, want blanked (served field)", e.Relocation)
 	}
-	if e.EnglishLevel != "b2" {
-		t.Errorf("EnglishLevel = %q, want kept", e.EnglishLevel)
+	if e.CompanyType != "product" {
+		t.Errorf("CompanyType = %q, want kept", e.CompanyType)
 	}
 	if len(e.Domains) != 1 || e.Domains[0] != "fintech" {
 		t.Errorf("Domains = %v, want [fintech] (served multi filtered)", e.Domains)
@@ -241,6 +243,9 @@ func TestSanitizeDropsOutOfVocabValues(t *testing.T) {
 	}
 	if e.EducationLevel != "associate" {
 		t.Errorf("EducationLevel = %q, want kept raw (discovery)", e.EducationLevel)
+	}
+	if e.EnglishLevel != "toefl_110" {
+		t.Errorf("EnglishLevel = %q, want kept raw (discovery)", e.EnglishLevel)
 	}
 	if err := e.Validate(); err != nil {
 		t.Errorf("Validate after Sanitize = %v, want nil", err)

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -60,9 +60,10 @@ func parseEnrichment(raw string) (Enrichment, error) {
 // systemPrompt instructs the model to emit only stated fields and to draw the
 // SERVED enum values from the controlled vocabularies — the same lists Validate
 // enforces. The dictionary-covered discovery facets (work_mode, regions,
-// seniority, category, employment_type, education_level) are deliberately relaxed:
-// the prompt invites a novel label when none fits, and Validate does not reject it
-// (it is unserved discovery material), so prompt and validator diverge there on purpose.
+// seniority, category, employment_type, education_level, english_level) are
+// deliberately relaxed: the prompt invites a novel label when none fits, and Validate
+// does not reject it (it is unserved discovery material), so prompt and validator
+// diverge there on purpose.
 var systemPrompt = buildSystemPrompt()
 
 func buildSystemPrompt() string {
@@ -88,14 +89,14 @@ func buildSystemPrompt() string {
 	enum("company_type", CompanyTypeValues)
 	enum("company_size", CompanySizeValues)
 
-	// Discovery facets: these six (plus the open countries/skills) are served from
+	// Discovery facets: these seven (plus the open countries/skills) are served from
 	// our own dictionaries, not from your value, so they are a discovery signal.
 	// Prefer an allowed value, but emit your own label when none fits — this surfaces
 	// vocabulary we are missing. The other enum fields above stay strict.
 	b.WriteString("\nException for work_mode, regions, seniority, category, employment_type, ")
-	b.WriteString("education_level: prefer an allowed value above, but if none accurately fits, ")
-	b.WriteString("you MAY return a concise lowercase label of your own (e.g. seniority ")
-	b.WriteString("\"staff_plus\", category \"ml_platform\"). ")
+	b.WriteString("education_level, english_level: prefer an allowed value above, but if none ")
+	b.WriteString("accurately fits, you MAY return a concise lowercase label of your own ")
+	b.WriteString("(e.g. seniority \"staff_plus\", category \"ml_platform\"). ")
 	b.WriteString("Still omit the key when the posting does not state it.\n")
 
 	b.WriteString("\nOther keys (omit when unstated): ")

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -37,7 +37,7 @@ func TestSystemPromptIncludesRegionVocabulary(t *testing.T) {
 	}
 }
 
-// Relax: the prompt permits a novel own-label for the six discovery facets while
+// Relax: the prompt permits a novel own-label for the seven discovery facets while
 // keeping the strict "exactly one allowed value" instruction for the served fields.
 func TestSystemPromptRelaxesDiscoveryFacets(t *testing.T) {
 	p := buildSystemPrompt()
@@ -47,7 +47,7 @@ func TestSystemPromptRelaxesDiscoveryFacets(t *testing.T) {
 	if !strings.Contains(p, "concise lowercase label of your own") {
 		t.Errorf("discovery facets must permit a novel own label")
 	}
-	for _, f := range []string{"work_mode", "regions", "seniority", "category", "employment_type", "education_level"} {
+	for _, f := range []string{"work_mode", "regions", "seniority", "category", "employment_type", "education_level", "english_level"} {
 		if !strings.Contains(p, f) {
 			t.Errorf("discovery instruction should name the facet %q", f)
 		}

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -58,6 +58,7 @@ type Derived struct {
 	PostingLanguage    string
 	EmploymentType     string
 	EducationLevel     string
+	EnglishLevel       string
 	ExperienceYearsMin *int
 }
 
@@ -114,6 +115,7 @@ func Derive(in Input) Derived {
 		PostingLanguage:    lang.Detect(in.Description),
 		EmploymentType:     jobfacts.EmploymentType(in.Title, in.Description),
 		EducationLevel:     jobfacts.EducationLevel(in.Description),
+		EnglishLevel:       jobfacts.EnglishLevel(in.Description),
 		ExperienceYearsMin: experience,
 	}
 }

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -49,7 +49,8 @@ func TestDerive_SyntheticFacets(t *testing.T) {
 		ExternalID: "1",
 		Description: "We are looking for a motivated engineer to join our backend team " +
 			"and build scalable services. A Bachelor's degree in Computer Science is " +
-			"required, along with at least 3 years of hands-on programming experience.",
+			"required, along with at least 3 years of hands-on programming experience. " +
+			"Fluent English is required.",
 	})
 	if got.PostingLanguage != "en" {
 		t.Errorf("PostingLanguage = %q, want en", got.PostingLanguage)
@@ -59,6 +60,9 @@ func TestDerive_SyntheticFacets(t *testing.T) {
 	}
 	if got.EducationLevel != "bachelor" {
 		t.Errorf("EducationLevel = %q, want bachelor", got.EducationLevel)
+	}
+	if got.EnglishLevel != "c1" {
+		t.Errorf("EnglishLevel = %q, want c1", got.EnglishLevel)
 	}
 	if got.ExperienceYearsMin == nil || *got.ExperienceYearsMin != 3 {
 		t.Errorf("ExperienceYearsMin = %v, want 3", got.ExperienceYearsMin)
@@ -75,9 +79,9 @@ func TestDerive_SyntheticFacetsSilent(t *testing.T) {
 		ExternalID:  "2",
 		Description: "Join us.",
 	})
-	if got.EmploymentType != "" || got.EducationLevel != "" || got.ExperienceYearsMin != nil {
-		t.Errorf("expected silent facets, got type=%q edu=%q exp=%v",
-			got.EmploymentType, got.EducationLevel, got.ExperienceYearsMin)
+	if got.EmploymentType != "" || got.EducationLevel != "" || got.EnglishLevel != "" || got.ExperienceYearsMin != nil {
+		t.Errorf("expected silent facets, got type=%q edu=%q eng=%q exp=%v",
+			got.EmploymentType, got.EducationLevel, got.EnglishLevel, got.ExperienceYearsMin)
 	}
 }
 

--- a/internal/jobfacts/jobfacts.go
+++ b/internal/jobfacts/jobfacts.go
@@ -146,11 +146,11 @@ var (
 	// Level phrases (checked for English proximity via near). The intermediate family
 	// carries its prefix so "upper-intermediate"→b2 and "pre-intermediate"→a2 resolve
 	// without a lookbehind (RE2 has none); the Russian "средн" family mirrors it.
-	reNative     = regexp.MustCompile(`\bnative\b|родн\w*`)
+	reNative     = regexp.MustCompile(`\bnative\b|родн\w*|носител\w*`)
 	reFluentAdv  = regexp.MustCompile(`fluen\w*|\badvanced\b|свободн\w*|продвинут\w*`)
 	reInterFam   = regexp.MustCompile(`\b(upper[\s-]?|pre[\s-]?)?intermediate\b`)
 	reRuMidFam   = regexp.MustCompile(`(выше\s+)?средн\w*`)
-	reConversRu  = regexp.MustCompile(`разговорн\w*`)
+	reConvers    = regexp.MustCompile(`\bconversational\b|разговорн\w*`)
 	reElementary = regexp.MustCompile(`\belementary\b|\bbeginner\b|начальн\w*`)
 	reBasic      = regexp.MustCompile(`\bbasic\b|базов\w*`)
 	reNoEnglish  = regexp.MustCompile(`no english|english (?:is )?not required|without english|без английск\w*`)
@@ -187,7 +187,7 @@ func EnglishLevel(description string) string {
 	if near(s, reEnglishKw, reFluentAdv) {
 		levels["c1"] = true
 	}
-	if near(s, reEnglishKw, reConversRu) {
+	if near(s, reEnglishKw, reConvers) {
 		levels["b1"] = true
 	}
 	if near(s, reEnglishKw, reElementary) {

--- a/internal/jobfacts/jobfacts.go
+++ b/internal/jobfacts/jobfacts.go
@@ -128,3 +128,150 @@ func ExperienceYearsMin(description string) *int {
 	}
 	return &best
 }
+
+// English-level detection. Precision-first like the matchers above: it resolves an
+// explicit CEFR code or a well-known level phrase (EN + RU, since the Telegram
+// sources are Russian-heavy) and emits "" when nothing is stated. Every signal must
+// sit near an English keyword, so a bare "B2"/"advanced"/"native" is not misread out
+// of context ("B2B SaaS", "advanced degree", "native macOS app"). Values are members
+// of enrich.EnglishLevelValues.
+var (
+	// reEnglishKw gates the whole parse and anchors every phrase: english_level is
+	// about English, so a description that never names it yields nothing.
+	reEnglishKw = regexp.MustCompile(`english|английск`)
+	// A CEFR code counts only adjacent (either order) to an English keyword.
+	reCEFRForward = regexp.MustCompile(`(?:english|английск\w*)[^.\n]{0,20}\b([abc][12])\b`)
+	reCEFRBack    = regexp.MustCompile(`\b([abc][12])\b[^.\n]{0,20}(?:english|английск\w*)`)
+
+	// Level phrases (checked for English proximity via near). The intermediate family
+	// carries its prefix so "upper-intermediate"→b2 and "pre-intermediate"→a2 resolve
+	// without a lookbehind (RE2 has none); the Russian "средн" family mirrors it.
+	reNative     = regexp.MustCompile(`\bnative\b|родн\w*`)
+	reFluentAdv  = regexp.MustCompile(`fluen\w*|\badvanced\b|свободн\w*|продвинут\w*`)
+	reInterFam   = regexp.MustCompile(`\b(upper[\s-]?|pre[\s-]?)?intermediate\b`)
+	reRuMidFam   = regexp.MustCompile(`(выше\s+)?средн\w*`)
+	reConversRu  = regexp.MustCompile(`разговорн\w*`)
+	reElementary = regexp.MustCompile(`\belementary\b|\bbeginner\b|начальн\w*`)
+	reBasic      = regexp.MustCompile(`\bbasic\b|базов\w*`)
+	reNoEnglish  = regexp.MustCompile(`no english|english (?:is )?not required|without english|без английск\w*`)
+)
+
+// englishRank orders the vocabulary lowest→highest so the minimum named level is
+// returned — the conservative floor, matching "minimum English level required".
+var englishRank = map[string]int{"a1": 1, "a2": 2, "b1": 3, "b2": 4, "c1": 5, "c2": 6, "native": 7}
+
+// englishWindow is the byte gap allowed between an English keyword and a level word
+// for the two to count as one signal. Sized for Russian (2 bytes/rune), so ~15 runes.
+const englishWindow = 30
+
+// EnglishLevel resolves the required English level from the description, returning
+// one of enrich.EnglishLevelValues or "" when nothing is stated. When several levels
+// are named it returns the lowest (the minimum requirement); an explicit "no English"
+// phrase resolves to "none" only when no positive level is present.
+func EnglishLevel(description string) string {
+	s := strings.ToLower(description)
+	if !reEnglishKw.MatchString(s) {
+		return ""
+	}
+
+	levels := map[string]bool{}
+	for _, m := range reCEFRForward.FindAllStringSubmatch(s, -1) {
+		levels[m[1]] = true
+	}
+	for _, m := range reCEFRBack.FindAllStringSubmatch(s, -1) {
+		levels[m[1]] = true
+	}
+	if near(s, reEnglishKw, reNative) {
+		levels["native"] = true
+	}
+	if near(s, reEnglishKw, reFluentAdv) {
+		levels["c1"] = true
+	}
+	if near(s, reEnglishKw, reConversRu) {
+		levels["b1"] = true
+	}
+	if near(s, reEnglishKw, reElementary) {
+		levels["a1"] = true
+	}
+	if near(s, reEnglishKw, reBasic) {
+		levels["a2"] = true
+	}
+	for _, m := range reInterFam.FindAllStringSubmatchIndex(s, -1) {
+		if !spanNearEnglish(s, m[0], m[1]) {
+			continue
+		}
+		switch {
+		case m[2] < 0: // no prefix group — plain "intermediate"
+			levels["b1"] = true
+		case strings.HasPrefix(s[m[2]:m[3]], "upper"):
+			levels["b2"] = true
+		case strings.HasPrefix(s[m[2]:m[3]], "pre"):
+			levels["a2"] = true
+		default:
+			levels["b1"] = true
+		}
+	}
+	for _, m := range reRuMidFam.FindAllStringSubmatchIndex(s, -1) {
+		if !spanNearEnglish(s, m[0], m[1]) {
+			continue
+		}
+		if m[2] >= 0 { // "выше средн..." — above intermediate
+			levels["b2"] = true
+		} else {
+			levels["b1"] = true
+		}
+	}
+
+	if len(levels) == 0 {
+		if reNoEnglish.MatchString(s) {
+			return "none"
+		}
+		return ""
+	}
+	best := ""
+	for lv := range levels {
+		if best == "" || englishRank[lv] < englishRank[best] {
+			best = lv
+		}
+	}
+	return best
+}
+
+// near reports whether any match of kw and any match of phrase in s lie within
+// englishWindow bytes of each other without a sentence boundary between them.
+func near(s string, kw, phrase *regexp.Regexp) bool {
+	kws := kw.FindAllStringIndex(s, -1)
+	for _, p := range phrase.FindAllStringIndex(s, -1) {
+		if spanNear(s, kws, p[0], p[1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// spanNearEnglish reports whether the [start,end) span sits near an English keyword.
+func spanNearEnglish(s string, start, end int) bool {
+	return spanNear(s, reEnglishKw.FindAllStringIndex(s, -1), start, end)
+}
+
+// spanNear reports whether [start,end) is within englishWindow bytes of any span,
+// with no sentence boundary (. or newline) in the gap — so a level word and an
+// English keyword in different sentences ("native iOS apps. English docs") don't
+// bind. An overlap always counts.
+func spanNear(s string, spans [][]int, start, end int) bool {
+	for _, m := range spans {
+		var lo, hi int
+		switch {
+		case start >= m[1]:
+			lo, hi = m[1], start
+		case m[0] >= end:
+			lo, hi = end, m[0]
+		default:
+			return true // overlap
+		}
+		if hi-lo <= englishWindow && !strings.ContainsAny(s[lo:hi], ".\n") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/jobfacts/jobfacts_test.go
+++ b/internal/jobfacts/jobfacts_test.go
@@ -139,6 +139,8 @@ func TestEnglishLevel(t *testing.T) {
 		{"advanced degree is not english", "An advanced degree in CS is required.", ""},
 		{"native app is not native english", "Build native iOS apps. English docs provided.", ""},
 		// Phrase levels (RU).
+		{"english conversational -> b1", "Conversational English is enough.", "b1"},
+		{"russian native speaker -> native", "Требуется носитель английского языка.", "native"},
 		{"russian fluent -> c1", "Свободный английский обязателен.", "c1"},
 		{"russian conversational -> b1", "Нужен разговорный английский.", "b1"},
 		{"russian above-average -> b2", "Английский выше среднего.", "b2"},

--- a/internal/jobfacts/jobfacts_test.go
+++ b/internal/jobfacts/jobfacts_test.go
@@ -110,4 +110,50 @@ func TestValuesAreInVocabulary(t *testing.T) {
 			t.Errorf("education_level %q not in enrich.EducationLevelValues", v)
 		}
 	}
+	for _, v := range []string{"none", "a1", "a2", "b1", "b2", "c1", "native"} {
+		if !slices.Contains(enrich.EnglishLevelValues, v) {
+			t.Errorf("english_level %q not in enrich.EnglishLevelValues", v)
+		}
+	}
+}
+
+func TestEnglishLevel(t *testing.T) {
+	cases := []struct{ name, desc, want string }{
+		{"unstated", "Strong coding skills required.", ""},
+		{"english mentioned, no level", "You will write docs in English.", ""},
+		// CEFR codes, only in English context.
+		{"cefr b2", "English level B2 required.", "b2"},
+		{"cefr c1 code before english", "C1 English is a must.", "c1"},
+		{"cefr russian context", "Английский язык на уровне B2.", "b2"},
+		{"b2b is not b2", "We build B2B SaaS. English is used daily.", ""},
+		{"a1 out of context ignored", "Experience with the Audi A1 platform.", ""},
+		// Phrase levels (EN).
+		{"native", "Native English speaker required.", "native"},
+		{"fluent -> c1", "Fluent English is required.", "c1"},
+		{"advanced -> c1", "Advanced English, written and spoken.", "c1"},
+		{"upper-intermediate -> b2", "Upper-intermediate English or higher.", "b2"},
+		{"intermediate -> b1", "Intermediate English is enough.", "b1"},
+		{"pre-intermediate -> a2", "Pre-intermediate English acceptable.", "a2"},
+		{"elementary -> a1", "Elementary English is fine.", "a1"},
+		{"basic -> a2", "Basic English required.", "a2"},
+		{"advanced degree is not english", "An advanced degree in CS is required.", ""},
+		{"native app is not native english", "Build native iOS apps. English docs provided.", ""},
+		// Phrase levels (RU).
+		{"russian fluent -> c1", "Свободный английский обязателен.", "c1"},
+		{"russian conversational -> b1", "Нужен разговорный английский.", "b1"},
+		{"russian above-average -> b2", "Английский выше среднего.", "b2"},
+		{"russian average -> b1", "Английский на среднем уровне.", "b1"},
+		{"russian basic -> a2", "Базовый английский достаточно.", "a2"},
+		// Minimum-of-several and explicit none.
+		{"range takes the floor", "English from intermediate to advanced.", "b1"},
+		{"explicit no english -> none", "No English required for this role.", "none"},
+		{"positive beats no-english phrase", "B2 English; no advanced English needed.", "b2"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := EnglishLevel(c.desc); got != c.want {
+				t.Errorf("EnglishLevel(%q) = %q, want %q", c.desc, got, c.want)
+			}
+		})
+	}
 }

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -94,12 +94,13 @@ func FromRow(j db.Job) (Job, error) {
 	e.Seniority = j.Seniority
 	e.Category = j.Category
 	// The synthetic facets (posting_language/employment_type/education_level/
-	// experience_years_min) follow the same dict-only rule: the deterministic column
-	// value always wins (the LLM's stays raw in the JSONB), kept nested under
-	// enrichment so the wire shape is unchanged.
+	// english_level/experience_years_min) follow the same dict-only rule: the
+	// deterministic column value always wins (the LLM's stays raw in the JSONB), kept
+	// nested under enrichment so the wire shape is unchanged.
 	e.PostingLanguage = j.PostingLanguage
 	e.EmploymentType = j.EmploymentType
 	e.EducationLevel = j.EducationLevel
+	e.EnglishLevel = j.EnglishLevel
 	e.ExperienceYearsMin = int4ToPtr(j.ExperienceYearsMin)
 	skills := normalizeSet(j.Skills)
 	// Collections is denormalized from the company onto the job; it has no LLM

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -419,8 +419,8 @@ func TestFromRow_ClassificationIsDictOnly(t *testing.T) {
 }
 
 // The synthetic facets (posting_language/employment_type/education_level/
-// experience_years_min) are dict-only too: the column value wins over the LLM's,
-// and a silent column drops the LLM value rather than falling back to it.
+// english_level/experience_years_min) are dict-only too: the column value wins over
+// the LLM's, and a silent column drops the LLM value rather than falling back to it.
 func TestFromRow_SyntheticFacetsAreDictOnly(t *testing.T) {
 	exp := 8
 	// LLM present with different values; the columns must win (and the silent
@@ -429,6 +429,7 @@ func TestFromRow_SyntheticFacetsAreDictOnly(t *testing.T) {
 		PostingLanguage:    "fr",
 		EmploymentType:     "contract",
 		EducationLevel:     "phd",
+		EnglishLevel:       "b1",
 		ExperienceYearsMin: &exp,
 	})
 	if err != nil {
@@ -436,7 +437,7 @@ func TestFromRow_SyntheticFacetsAreDictOnly(t *testing.T) {
 	}
 	view, err := FromRow(db.Job{
 		ID: 1, Title: "x", PublicSlug: "x-1",
-		PostingLanguage: "en", EmploymentType: "internship", EducationLevel: "bachelor",
+		PostingLanguage: "en", EmploymentType: "internship", EducationLevel: "bachelor", EnglishLevel: "c1",
 		ExperienceYearsMin: pgtype.Int4{}, // silent column → served as nil, not the LLM's 8
 		Enrichment:         raw,
 	})
@@ -444,9 +445,9 @@ func TestFromRow_SyntheticFacetsAreDictOnly(t *testing.T) {
 		t.Fatalf("FromRow: %v", err)
 	}
 	if view.Enrichment.PostingLanguage != "en" || view.Enrichment.EmploymentType != "internship" ||
-		view.Enrichment.EducationLevel != "bachelor" {
-		t.Errorf("dict should win: got {%q,%q,%q}", view.Enrichment.PostingLanguage,
-			view.Enrichment.EmploymentType, view.Enrichment.EducationLevel)
+		view.Enrichment.EducationLevel != "bachelor" || view.Enrichment.EnglishLevel != "c1" {
+		t.Errorf("dict should win: got {%q,%q,%q,%q}", view.Enrichment.PostingLanguage,
+			view.Enrichment.EmploymentType, view.Enrichment.EducationLevel, view.Enrichment.EnglishLevel)
 	}
 	if view.Enrichment.ExperienceYearsMin != nil {
 		t.Errorf("silent experience column should drop the LLM value, got %v", *view.Enrichment.ExperienceYearsMin)

--- a/internal/moderation/moderation.go
+++ b/internal/moderation/moderation.go
@@ -162,6 +162,7 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 		PostingLanguage:    d.PostingLanguage,
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
+		EnglishLevel:       d.EnglishLevel,
 		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
 
 		CreatedBy: actorID,
@@ -228,6 +229,7 @@ func (s *Service) Update(ctx context.Context, actorID int64, slug string, p Upda
 		PostingLanguage:    d.PostingLanguage,
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
+		EnglishLevel:       d.EnglishLevel,
 		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
 
 		UpdatedBy: actorID,

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -53,11 +53,12 @@ type Job struct {
 	Category  string
 	// Synthetic enrichment facets derived from Title/Description by jobderive
 	// (internal/lang + internal/jobfacts): the posting language, employment type,
-	// education level, and minimum required experience. Each is empty/nil when
-	// nothing is resolved.
+	// education level, English level, and minimum required experience. Each is
+	// empty/nil when nothing is resolved.
 	PostingLanguage    string
 	EmploymentType     string
 	EducationLevel     string
+	EnglishLevel       string
 	ExperienceYearsMin *int
 }
 
@@ -323,6 +324,7 @@ func normalizeJob(e sources.CompanyEntry, j sources.Job) Job {
 		PostingLanguage:    d.PostingLanguage,
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,
+		EnglishLevel:       d.EnglishLevel,
 		ExperienceYearsMin: d.ExperienceYearsMin,
 	}
 }

--- a/migrations/0036_job_english_level.sql
+++ b/migrations/0036_job_english_level.sql
@@ -1,0 +1,11 @@
+-- english_level dictionary facet: the required English level, derived
+-- deterministically at ingest by internal/jobfacts (via internal/jobderive) from the
+-- description text. Like the other synthetic facets (migration 0023) it is a SOURCE
+-- fact stored beside — not inside — the `enrichment` JSONB, so the LLM enrichment
+-- worker never clobbers it; jobview serves it dict-only (the deterministic value
+-- always wins, the LLM's stays raw in the blob as a discovery signal).
+--
+-- english_level: enum enrich.EnglishLevelValues (none/a1/a2/b1/b2/c1/c2/native),
+--   "" when unstated.
+ALTER TABLE jobs
+    ADD COLUMN IF NOT EXISTS english_level TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## What & why

Moves `english_level` off the LLM onto a deterministic dictionary, following the established synthetic-facet pattern (`posting_language`/`employment_type`/`education_level`, migration 0023). Deterministic facets are reproducible (re-derivable via `backfill-derive` with no LLM spend) and stay stable across model runs — and `english_level` is a closed CEFR vocabulary that reads well from text.

## Changes

- **`internal/jobfacts`**: new `EnglishLevel(description)` — precision-first EN+RU matcher:
  - CEFR codes counted **only in English context** (`English B2`, `уровень B2`), so `B2B SaaS` is never read as B2, and an out-of-context `A1` is ignored.
  - Level phrases: native / fluent / advanced / upper-intermediate / intermediate / pre-intermediate / elementary / basic + Russian (`свободный`/`разговорный`/`выше среднего`/`средний`/`базовый`/`начальный`/`родной`).
  - Every signal must sit near an English keyword **with no sentence boundary between** (so `native iOS apps. English docs` ≠ native English). Emits `""` when nothing is stated (never guesses). Several levels → the **minimum** (the required floor).
- **migration 0036**: `jobs.english_level TEXT NOT NULL DEFAULT ''` — a source fact beside the `enrichment` JSONB; wired through `UpsertJob` / moderator create+update / `UpdateJobFacets` (sqlc regenerated).
- **`jobderive.Derive`** fills it; all write paths (`pipeline`/`ingest`/`moderation`/`tg-extract`) and `cmd/backfill-derive` carry it.
- **`jobview`** serves it dict-only (column wins, LLM value stays raw in JSONB). It is already a Meilisearch filterable facet, so it now facets on the dictionary value.
- **`internal/enrich`**: drop `english_level` from `servedScalarEnums` (no longer validated/sanitized as served) and move it into the prompt's discovery-exception — same treatment as the other dict facets (consistent with #361).

## Tests

- `TestEnglishLevel` covers CEFR-in-context, `B2B`/`A1`/`advanced degree`/`native app` false-positive guards, EN + RU phrases, range→floor, and explicit "no English"→none.
- `jobderive`/`jobview`/`enrich` synthetic-facet tests extended for `english_level` (derive, dict-only serve, discovery accept/sanitize, prompt relaxation).
- `go build ./...`, `go vet`, `gofmt`, and `go test ./...` all pass.

## Deploy notes

No served-shape change. To reach existing rows: apply **migration 0036** (manual — no migration runner), deploy, then run `cmd/backfill-derive` + reindex (standard dictionary-facet change).