### PR TITLE
feat(sources): eRecruiter (PL) ATS adapter + cfg harvester

### DIFF
--- a/cmd/harvest-erecruiter/main.go
+++ b/cmd/harvest-erecruiter/main.go
@@ -1,0 +1,149 @@
+// Command harvest-erecruiter turns a list of company careers pages into validated
+// sources/erecruiter.yml entries. eRecruiter's board id is a cfg token embedded in each
+// company's own careers page (there is no slug to guess and no cfg in the justjoin apply
+// forms), so onboarding a company means resolving its cfg from its careers URL and
+// confirming the board is live before committing it.
+//
+// Input is one company per line, "Company Name<TAB>https://careers.url" (a line without a
+// tab is treated as a bare URL, with the host as the company name). For each: fetch the
+// page, extract the cfg widget token, probe its first list page, and print an entry only
+// when the board returns offers and the cfg is not already in sources/erecruiter.yml. A
+// company that fails any step is logged and skipped without aborting the run.
+//
+// Run-once host tool; review the printed entries before appending them to the board file.
+//
+//	go run ./cmd/harvest-erecruiter <companies.tsv>
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	if len(os.Args) != 2 {
+		log.Printf("usage: harvest-erecruiter <companies.tsv>")
+		return 2
+	}
+
+	inputs, err := readInputs(os.Args[1])
+	if err != nil {
+		log.Printf("harvest-erecruiter: %v", err)
+		return 1
+	}
+
+	existing, err := existingCfgs("sources/erecruiter.yml")
+	if err != nil {
+		log.Printf("harvest-erecruiter: %v", err)
+		return 1
+	}
+
+	ctx := context.Background()
+	client := sources.NewClient()
+
+	kept := 0
+	for _, in := range inputs {
+		cfg, offers, err := resolve(ctx, client, in.careersURL)
+		if err != nil {
+			log.Printf("harvest-erecruiter: %s: %v", in.company, err)
+			continue
+		}
+		if cfg == "" {
+			log.Printf("harvest-erecruiter: %s: no eRecruiter cfg on %s", in.company, in.careersURL)
+			continue
+		}
+		if offers == 0 {
+			log.Printf("harvest-erecruiter: %s: cfg %s resolved but board has no offers", in.company, cfg)
+			continue
+		}
+		if existing[strings.ToLower(cfg)] {
+			log.Printf("harvest-erecruiter: %s: cfg %s already in board file", in.company, cfg)
+			continue
+		}
+		existing[strings.ToLower(cfg)] = true
+		fmt.Printf("- company: %s\n  board: %s\n", in.company, cfg)
+		kept++
+	}
+	log.Printf("harvest-erecruiter: %d input(s), %d new live board(s)", len(inputs), kept)
+	return 0
+}
+
+// input is one company to probe: its display name and the careers URL to scan for a cfg.
+type input struct {
+	company    string
+	careersURL string
+}
+
+// resolve fetches a careers page, extracts its eRecruiter cfg, and live-probes it, returning
+// the cfg and its first-page offer count (0 when absent or empty).
+func resolve(ctx context.Context, client *sources.Client, careersURL string) (string, int, error) {
+	page, err := client.GetText(ctx, careersURL)
+	if err != nil {
+		return "", 0, fmt.Errorf("fetch careers page: %w", err)
+	}
+	cfg := sources.ExtractErecruiterCfg(page)
+	if cfg == "" {
+		return "", 0, nil
+	}
+	offers, err := sources.ProbeErecruiterCfg(ctx, client, cfg)
+	if err != nil {
+		return cfg, 0, fmt.Errorf("probe cfg %s: %w", cfg, err)
+	}
+	return cfg, offers, nil
+}
+
+// readInputs parses the "Company<TAB>URL" worklist; a line without a tab is a bare URL whose
+// host becomes the company name. Blank lines and lines without a usable URL are skipped.
+func readInputs(path string) ([]input, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read inputs %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var out []input
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		company, careersURL := "", line
+		if name, u, ok := strings.Cut(line, "\t"); ok {
+			company, careersURL = strings.TrimSpace(name), strings.TrimSpace(u)
+		}
+		if company == "" {
+			if u, err := url.Parse(careersURL); err == nil {
+				company = u.Host
+			}
+		}
+		if careersURL == "" {
+			continue
+		}
+		out = append(out, input{company: company, careersURL: careersURL})
+	}
+	return out, sc.Err()
+}
+
+// existingCfgs returns the cfg board ids already listed in the board file (lower-cased for a
+// case-insensitive compare), so a re-run does not re-emit a company already onboarded.
+func existingCfgs(path string) (map[string]bool, error) {
+	cfg, err := sources.LoadConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(cfg.Sources))
+	for _, e := range cfg.Sources {
+		out[strings.ToLower(e.Board)] = true
+	}
+	return out, nil
+}

--- a/internal/sources/erecruiter.go
+++ b/internal/sources/erecruiter.go
@@ -1,0 +1,260 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// erecruiter adapts eRecruiter Polska public per-company career boards ("Strona Kariera")
+// on skk.erecruiter.pl. The board is the company's cfg (a 32-hex config token embedded in
+// its careers page). The keyless list endpoint returns a JSONP body ({"htm":"<tr…>"}) of
+// offer rows carrying ids and a city cell but no description, so the adapter fetches each
+// offer's Offer.aspx detail page for the body. Boards are paged; page 1's hidden marker row
+// reports the total, giving a clean stop condition.
+type erecruiter struct {
+	http erecruiterHTTP
+}
+
+// erecruiterHTTP is the transport erecruiter needs: GetText for the JSONP list, GetHTML for
+// each per-offer detail page.
+type erecruiterHTTP interface {
+	TextGetter
+	HTMLGetter
+}
+
+// NewErecruiter builds the eRecruiter adapter over the given HTTP client.
+func NewErecruiter(c erecruiterHTTP) Source { return erecruiter{http: c} }
+
+func (erecruiter) Provider() string { return "erecruiter" }
+
+const (
+	erecruiterBase = "https://skk.erecruiter.pl"
+	// erecruiterMaxPages bounds the walk so a feed that never reports its total (or keeps
+	// returning full pages) cannot loop forever; it sits far above any real board's size.
+	erecruiterMaxPages = 500
+)
+
+// erecruiterRow is one offer row parsed from the list JSONP. offerID is the per-publication
+// id (unique per city variant, and the oid the detail URL is keyed by) used as the dedup
+// ExternalID; externalJobOfferID is shared across a role's multi-city variants, so it is only
+// carried for the detail URL, not used as identity.
+type erecruiterRow struct {
+	offerID  string
+	extID    string
+	regionID string
+	comID    string
+	title    string // list position cell — a fallback for the detail's #JobTitle
+	city     string // list city cell — a fallback for the detail's #WorkPlace
+}
+
+func (e erecruiter) Fetch(ctx context.Context, entry CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	total, seen := -1, 0 // total is unknown until page 1's marker row
+	for page := 1; page <= erecruiterMaxPages; page++ {
+		url := fmt.Sprintf("%s/GetHtml.ashx?cfg=%s&grid=rows&pn=%d", erecruiterBase, entry.Board, page)
+		body, err := e.http.GetText(ctx, url)
+		if err != nil {
+			return nil, fmt.Errorf("erecruiter: list %s page %d: %w", entry.Board, page, err)
+		}
+		rows, pageTotal, err := parseErecruiterRows(body)
+		if err != nil {
+			return nil, fmt.Errorf("erecruiter: parse list %s page %d: %w", entry.Board, page, err)
+		}
+		if total < 0 && pageTotal >= 0 {
+			total = pageTotal // page 1's marker carries the grand total; later pages repeat it
+		}
+		if len(rows) == 0 {
+			break // ran out of offers (an empty page or a marker-only past-the-end page)
+		}
+		for _, r := range rows {
+			if j, ok := e.toJob(ctx, r, entry); ok {
+				jobs = append(jobs, j)
+			}
+		}
+		if seen += len(rows); total >= 0 && seen >= total {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob fetches a row's Offer.aspx detail and maps it to a Job, returning ok=false when the
+// detail is unreachable or lacks a title/description (a dead or closed offer) — such a
+// posting is skipped without aborting the board.
+func (e erecruiter) toJob(ctx context.Context, r erecruiterRow, entry CompanyEntry) (Job, bool) {
+	url := fmt.Sprintf("%s/Offer.aspx?oid=%s&cfg=%s&ejoId=%s&ejorId=%s&comId=%s",
+		erecruiterBase, r.offerID, entry.Board, r.extID, r.regionID, r.comID)
+	root, err := e.http.GetHTML(ctx, url)
+	if err != nil {
+		return Job{}, false
+	}
+
+	title, location, description := parseErecruiterDetail(root)
+	if title == "" {
+		title = r.title
+	}
+	if location == "" {
+		location = r.city
+	}
+	if title == "" || description == "" {
+		return Job{}, false
+	}
+
+	return Job{
+		ExternalID:  r.offerID,
+		URL:         url,
+		Title:       title,
+		Company:     entry.Company,
+		Location:    location,
+		Description: description,
+	}, true
+}
+
+// parseErecruiterRows unwraps the ({"htm":"…"}) JSONP list body and parses its offer rows,
+// returning the rows plus the total result count from the hidden marker row (tr attribute),
+// or -1 when this page carries no marker.
+func parseErecruiterRows(body string) ([]erecruiterRow, int, error) {
+	s := strings.TrimSpace(body)
+	s = strings.TrimSpace(strings.TrimSuffix(s, ";")) // an optional trailing ; after the )
+	s = strings.TrimPrefix(s, "(")
+	s = strings.TrimSuffix(s, ")")
+	if s == "" {
+		return nil, -1, nil // a blank body ends the walk gracefully, not a parse error
+	}
+	var env struct {
+		Htm string `json:"htm"`
+	}
+	if err := json.Unmarshal([]byte(s), &env); err != nil {
+		return nil, -1, fmt.Errorf("unwrap jsonp: %w", err)
+	}
+
+	// The rows are bare <tr> fragments; wrap them in a <table> so the HTML parser keeps
+	// them (a <tr> outside a table is otherwise dropped).
+	doc, err := html.Parse(strings.NewReader("<table>" + env.Htm + "</table>"))
+	if err != nil {
+		return nil, -1, fmt.Errorf("parse rows: %w", err)
+	}
+
+	var rows []erecruiterRow
+	total := -1
+	walk(doc, func(n *html.Node) bool {
+		if n.Type != html.ElementNode || n.Data != "tr" {
+			return true
+		}
+		// The marker row (a non-offer <tr>) carries the total in its tr attribute.
+		if attr(n, "skkresult") != "offer" {
+			if t := attr(n, "tr"); t != "" {
+				if v, err := strconv.Atoi(t); err == nil {
+					total = v
+				}
+			}
+			return true
+		}
+		if r, ok := erecruiterOfferRow(n); ok {
+			rows = append(rows, r)
+		}
+		return true
+	})
+	return rows, total, nil
+}
+
+// erecruiterOfferRow reads one offer <tr>'s ids and cells (position, city). It returns
+// ok=false when the row has no offerId — without it there is no dedup key or detail URL.
+// The HTML parser lower-cases attribute names, so the camelCase source attributes are read
+// in lower case.
+func erecruiterOfferRow(tr *html.Node) (erecruiterRow, bool) {
+	r := erecruiterRow{
+		offerID:  attr(tr, "offerid"),
+		extID:    attr(tr, "externaljobofferid"),
+		regionID: attr(tr, "externaljobofferregionid"),
+		comID:    attr(tr, "comid"),
+	}
+	if r.offerID == "" {
+		return erecruiterRow{}, false
+	}
+
+	var cells []*html.Node
+	walk(tr, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "td" {
+			cells = append(cells, n)
+		}
+		return true
+	})
+	for _, td := range cells {
+		if hasClass(td, "skk_positionName") {
+			r.title = textContent(td)
+		}
+	}
+	if len(cells) > 0 {
+		r.city = textContent(cells[len(cells)-1]) // the city is always the last cell
+	}
+	return r, true
+}
+
+// parseErecruiterDetail reads an Offer.aspx detail tree: the #JobTitle heading, the
+// #WorkPlace line (stripping its "Miejsce pracy:" label), and the body assembled from the
+// #t1 / #Opportunities / #CompanyDescription sections (sanitized). A field absent from the
+// markup comes back empty for the caller to fall back on the list row or skip.
+func parseErecruiterDetail(root *html.Node) (title, location, description string) {
+	title = erecruiterIDText(root, "JobTitle")
+	location = strings.TrimSpace(erecruiterIDText(root, "WorkPlace"))
+	// The line is labelled ("Miejsce pracy: <city>", or "Workplace: <city>" in the en locale);
+	// keep only the value after the label. A label-less value (no colon) is used as-is.
+	if _, city, ok := strings.Cut(location, ":"); ok {
+		location = strings.TrimSpace(city)
+	}
+
+	var body strings.Builder
+	for _, id := range []string{"t1", "Opportunities", "CompanyDescription"} {
+		if n := elementByID(root, id); n != nil {
+			body.WriteString(innerHTML(n))
+		}
+	}
+	return title, location, sanitizeHTML(body.String())
+}
+
+// erecruiterIDText returns the trimmed text of the element with the given id, or "".
+func erecruiterIDText(root *html.Node, id string) string {
+	if n := elementByID(root, id); n != nil {
+		return textContent(n)
+	}
+	return ""
+}
+
+// erecruiterCfgRe matches the cfg board token in the eRecruiter career-widget script tag
+// (<script src="https://skk.erecruiter.pl/Code.ashx?cfg=<32-hex>">) a company embeds on its
+// careers page.
+var erecruiterCfgRe = regexp.MustCompile(`(?i)Code\.ashx\?cfg=([0-9A-Fa-f]{32})`)
+
+// ExtractErecruiterCfg returns the cfg board token embedded in a company careers page's
+// eRecruiter widget script, or "" when the page carries no such widget. It backs
+// cmd/harvest-erecruiter, the discovery bridge from a careers URL to a board entry.
+func ExtractErecruiterCfg(page string) string {
+	m := erecruiterCfgRe.FindStringSubmatch(page)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// ProbeErecruiterCfg live-validates a cfg by fetching its first list page and reporting how
+// many offer rows it carries; 0 means the token resolves to no public board. The harvester
+// keeps a discovered cfg only when this is > 0.
+func ProbeErecruiterCfg(ctx context.Context, http TextGetter, cfg string) (int, error) {
+	url := fmt.Sprintf("%s/GetHtml.ashx?cfg=%s&grid=rows&pn=1", erecruiterBase, cfg)
+	body, err := http.GetText(ctx, url)
+	if err != nil {
+		return 0, err
+	}
+	rows, _, err := parseErecruiterRows(body)
+	if err != nil {
+		return 0, err
+	}
+	return len(rows), nil
+}

--- a/internal/sources/erecruiter_test.go
+++ b/internal/sources/erecruiter_test.go
@@ -1,0 +1,212 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// erecruiterFake routes GetText (JSONP list, matched by "pn=<n>") and GetHTML (per-offer
+// detail, matched by "oid=<id>") to canned bodies, so the adapter is exercised without the
+// network. An unrouted list page returns an empty JSONP body (past-the-end); an unrouted
+// detail returns bare HTML (no #JobTitle → skipped).
+type erecruiterFake struct {
+	list        map[string]string
+	detail      map[string]string
+	listCalls   int
+	detailCalls int
+}
+
+func (f *erecruiterFake) GetText(_ context.Context, url string) (string, error) {
+	f.listCalls++
+	for k, v := range f.list {
+		if strings.Contains(url, k) {
+			return v, nil
+		}
+	}
+	return `({"htm":""})`, nil
+}
+
+func (f *erecruiterFake) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	f.detailCalls++
+	for k, v := range f.detail {
+		if strings.Contains(url, k) {
+			return html.Parse(strings.NewReader(v))
+		}
+	}
+	return html.Parse(strings.NewReader("<html><body></body></html>"))
+}
+
+// jsonp wraps an inner htm fragment in the ({"htm":"…"}) envelope the real endpoint returns,
+// escaping the fragment as a JSON string.
+func jsonp(htm string) string {
+	return `({"htm":` + jsonString(htm) + `})`
+}
+
+// jsonString renders s as a JSON string literal (quotes + escapes), so an HTML fragment with
+// quotes/backslashes embeds safely in the JSONP body.
+func jsonString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// A detail page mirroring eRecruiter's Offer.aspx: #JobTitle / #WorkPlace header, #t1 body
+// (with a <script> to prove sanitization), #CompanyDescription, and the Aplikuj button.
+func erecruiterDetail(title, city string) string {
+	return `<html><body>
+<div class="job1"><div class="job">
+  <div id="JobTitle">` + title + `</div>
+  <div id="WorkPlace">Miejsce pracy: ` + city + `</div>
+</div></div>
+<div id="t1"><p><strong>Twój zakres obowiązków</strong></p><ul><li>Prowadzenie połączeń</li></ul><script>evil()</script></div>
+<div id="CompanyDescription"><p>Od 40 lat realizujemy inwestycje.</p></div>
+<div class="job1"><a href="https://system.erecruiter.pl/FormTemplates/RecruitmentForm.aspx?webid=B3107797-D274-4CA4-A08C-028E3A7AE1DE" class="button">Aplikuj</a></div>
+</body></html>`
+}
+
+func TestExtractErecruiterCfg(t *testing.T) {
+	withWidget := `<html><body><h1>Kariera</h1>
+<script type='text/javascript' src='https://skk.erecruiter.pl/Code.ashx?cfg=4D3DD27FCA3D40C79E01BEE9745902B7'></script>
+</body></html>`
+	if got := ExtractErecruiterCfg(withWidget); got != "4D3DD27FCA3D40C79E01BEE9745902B7" {
+		t.Errorf("ExtractErecruiterCfg = %q, want the 32-hex cfg", got)
+	}
+
+	if got := ExtractErecruiterCfg(`<html><body>No eRecruiter widget here.</body></html>`); got != "" {
+		t.Errorf("ExtractErecruiterCfg = %q, want empty for a page without the widget", got)
+	}
+}
+
+func TestErecruiterProvider(t *testing.T) {
+	if got := NewErecruiter(nil).Provider(); got != "erecruiter" {
+		t.Errorf("Provider() = %q, want %q", got, "erecruiter")
+	}
+}
+
+func TestErecruiterFetchMapsFieldsAndStopsAtTotal(t *testing.T) {
+	// Three offer rows, two of which share externalJobOfferId=570550 across cities (Łódź,
+	// Kraków) with distinct offerId — the real board's multi-city shape. The marker row
+	// reports tr=3 (total), so the walk stops after page 1 (no second list call).
+	rows := `<tr jobOfferId='3479394' offerId='4891462' externalJobOfferId='574507' externalJobOfferRegionId='309263' comId='20002054' skkResult='offer'><td class='skk_positionName'>Staż w Dziale Obsługi Klienta</td><td>Wrocław</td></tr>` +
+		`<tr jobOfferId='3471220' offerId='4882522' externalJobOfferId='570550' externalJobOfferRegionId='308328' comId='20002054' skkResult='offer'><td class='skk_positionName'>Specjalista ds. Wsparcia</td><td>Łódź</td></tr>` +
+		`<tr jobOfferId='3471220' offerId='4882523' externalJobOfferId='570550' externalJobOfferRegionId='308329' comId='20002054' skkResult='offer'><td class='skk_positionName'>Specjalista ds. Wsparcia</td><td>Kraków</td></tr>` +
+		`<tr tp='2' tr='3' pn='1' ps='15' style='display:none;'></tr>`
+
+	fake := &erecruiterFake{
+		list: map[string]string{"pn=1": jsonp(rows)},
+		detail: map[string]string{
+			"oid=4891462": erecruiterDetail("Staż w Dziale Obsługi Klienta", "Wrocław"),
+			"oid=4882522": erecruiterDetail("Specjalista ds. Wsparcia", "Łódź"),
+			"oid=4882523": erecruiterDetail("Specjalista ds. Wsparcia", "Kraków"),
+		},
+	}
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Echo Investment", Provider: "erecruiter", Board: "4D3DD27FCA3D40C79E01BEE9745902B7",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 (multi-city variants kept as distinct offerId postings)", len(jobs))
+	}
+	if fake.listCalls != 1 {
+		t.Fatalf("listCalls = %d, want 1 (total reached after page 1)", fake.listCalls)
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	// The two multi-city variants must NOT collapse: distinct offerId → distinct ExternalID.
+	if _, ok := byID["4882522"]; !ok {
+		t.Error("offerId 4882522 (Łódź) missing — multi-city variant collapsed?")
+	}
+	if _, ok := byID["4882523"]; !ok {
+		t.Error("offerId 4882523 (Kraków) missing — multi-city variant collapsed?")
+	}
+
+	j := byID["4891462"]
+	if j.Title != "Staż w Dziale Obsługi Klienta" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Echo Investment" {
+		t.Errorf("Company = %q, want config company", j.Company)
+	}
+	if j.Location != "Wrocław" {
+		t.Errorf("Location = %q, want %q (Miejsce pracy: prefix stripped)", j.Location, "Wrocław")
+	}
+	if !strings.Contains(j.Description, "Twój zakres") {
+		t.Errorf("Description missing body: %q", j.Description)
+	}
+	if strings.Contains(j.Description, "<script") || strings.Contains(j.Description, "evil()") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.URL, "Offer.aspx") || !strings.Contains(j.URL, "oid=4891462") {
+		t.Errorf("URL = %q, want the Offer.aspx detail URL with oid", j.URL)
+	}
+}
+
+func TestErecruiterFetchSkipsUnparseableDetail(t *testing.T) {
+	// A row whose detail lacks #JobTitle (dead/closed offer) is skipped without aborting the
+	// board; the healthy row still comes through.
+	rows := `<tr offerId='111' externalJobOfferId='11' externalJobOfferRegionId='1' comId='9' skkResult='offer'><td class='skk_positionName'>Good Role</td><td>Warszawa</td></tr>` +
+		`<tr offerId='222' externalJobOfferId='22' externalJobOfferRegionId='2' comId='9' skkResult='offer'><td class='skk_positionName'>Dead Role</td><td>Kraków</td></tr>` +
+		`<tr tp='2' tr='2' pn='1' ps='15'></tr>`
+
+	fake := &erecruiterFake{
+		list: map[string]string{"pn=1": jsonp(rows)},
+		detail: map[string]string{
+			"oid=111": erecruiterDetail("Good Role", "Warszawa"),
+			"oid=222": `<html><body><div>Oferta wygasła</div></body></html>`,
+		},
+	}
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "cfg"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "111" {
+		t.Fatalf("jobs = %+v, want only the healthy offer 111", jobs)
+	}
+}
+
+func TestErecruiterFetchStopsOnEmptyPage(t *testing.T) {
+	// The marker over-reports the total (tr=999) but the board runs out on page 2. An empty
+	// page must end the walk instead of spinning to the page cap.
+	page1 := `<tr offerId='1' externalJobOfferId='1' externalJobOfferRegionId='1' comId='9' skkResult='offer'><td class='skk_positionName'>Role</td><td>Gdańsk</td></tr>` +
+		`<tr tp='2' tr='999' pn='1' ps='1'></tr>`
+
+	fake := &erecruiterFake{
+		list:   map[string]string{"pn=1": jsonp(page1)}, // pn=2 falls through to the empty body
+		detail: map[string]string{"oid=1": erecruiterDetail("Role", "Gdańsk")},
+	}
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "cfg"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (empty second page ends the walk)", len(jobs))
+	}
+	if fake.listCalls != 2 {
+		t.Fatalf("listCalls = %d, want 2 (page 1 + the empty page 2)", fake.listCalls)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -194,6 +194,7 @@ func All(c HTTPClient) map[string]Source {
 		NewFactorial(c),
 		NewZoho(c),
 		NewTraffit(c),
+		NewErecruiter(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/openspec/changes/add-erecruiter-source/.openspec.yaml
+++ b/openspec/changes/add-erecruiter-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/add-erecruiter-source/design.md
+++ b/openspec/changes/add-erecruiter-source/design.md
@@ -1,0 +1,94 @@
+## Context
+
+Spike (memory `hire-erecruiter-adapter-spike`) validated that eRecruiter Polska exposes a
+fully keyless public per-company job board on `skk.erecruiter.pl`:
+
+- **Board id = `cfg`** (32-hex), embedded in a company careers page as
+  `<script src="https://skk.erecruiter.pl/Code.ashx?cfg=<hex>">`.
+- **List**: `GET GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<page>` returns a JSONP body
+  `({"htm":"<tr ...><td>..</td></tr>"})`. Each `<tr>` carries `jobOfferId`, `offerId`,
+  `externalJobOfferId`, `externalJobOfferRegionId`, `comId`, and three `<td>` cells
+  (position, category, city). Page size is 20. A page past the end returns a hidden
+  marker row `<tr tp='2' tr='<TOTAL>' pn='<n>' ps='20'>`, so `tr` = total result count.
+- **Detail**: `GET Offer.aspx?oid=<offerId>&cfg=<cfg>&ejoId=<externalJobOfferId>&ejorId=<externalJobOfferRegionId>&comId=<comId>`
+  returns full HTML (title, company, location, description) and an "Aplikuj" button
+  linking to `system.erecruiter.pl/FormTemplates/RecruitmentForm.aspx?WebID=<hex>` — the
+  same form justjoin links to.
+
+The recruiter-side surfaces (`system.erecruiter.pl/Career`, `/Offers`, `vacancyapi`) are
+OIDC/401-gated and are NOT used. The adapter slots into the existing `sources` registry
+and `pipeline.Runner` write path unchanged.
+
+The discovery gap: justjoin only exposes per-job `WebID` apply forms, which carry no
+`cfg`. Onboarding the 161 justjoin companies therefore needs a separate step that resolves
+each company's `cfg` from its own careers page.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless, board-based `erecruiter` adapter (list + per-offer detail) that ingests one
+  company board per configured entry, deduping on the stable `externalJobOfferId`.
+- A `cmd/harvest-erecruiter` tool that turns a list of company careers URLs (or domains)
+  into validated `sources/erecruiter.yml` entries.
+
+**Non-Goals:**
+- Automatically mapping every justjoin `WebID` to a `cfg` (no such mapping exists) —
+  discovery is domain/careers-page driven, run by the harvester, not the adapter.
+- Ingesting via the recruiter-side authenticated eRecruiter API.
+- Self-close signals from eRecruiter (handled by the standard unseen-jobs sweep like any
+  other board source).
+
+## Decisions
+
+- **Board id is the `cfg` token.** It is stable per company and is the only identifier the
+  public endpoints accept. `sources/erecruiter.yml` entries are `company` + `board`=cfg.
+  Alternative — deriving from `comId` — rejected: `comId` is not accepted by the public
+  list/detail endpoints, only `cfg` is.
+- **Two-step list→detail fetch.** The list row lacks a description, so the adapter fetches
+  each offer's `Offer.aspx` detail for the body. Alternative — indexing title-only from
+  the list — rejected: it would persist bodyless postings, degrading search/enrichment.
+  This mirrors existing HTML detail adapters (Avature, SuccessFactors `GetHTML` seam).
+- **JSONP unwrap via `GetText`.** The list endpoint returns `({"htm":"…"})`, neither clean
+  JSON nor a clean HTML document. The adapter reads it with `GetText`, strips the wrapping
+  parens/semicolon, JSON-decodes the `htm` string, then parses the inner `<tr>` rows.
+- **Pagination stops on the reported total.** The first page's marker row exposes `tr`
+  (total); the adapter pages `pn=1..ceil(tr/20)` and also stops early if a page yields no
+  offer rows, under a bounded page cap (backstop against a pathological feed) — same shape
+  as the Traffit adapter's paginated collection.
+- **`ExternalID` = `externalJobOfferId`.** Stable across recrawls; the canonical detail
+  URL is the `Offer.aspx` URL. The `WebID` apply form is captured as the apply URL when
+  present but is not the identity (forms 404 once a job closes).
+- **Harvester resolves `cfg` from careers pages.** Given a company careers URL, fetch it
+  with `GetText`, regex-extract `Code.ashx?cfg=<hex>`, then probe
+  `GetHtml.ashx?cfg=<hex>&grid=rows&pn=1` and keep the token only if it returns offer rows.
+  Same live-validate-then-emit shape as `cmd/harvest-boards` / the Traffit prober.
+
+## Risks / Trade-offs
+
+- **cfg discovery coverage** → The harvester needs a company's real careers URL; blind
+  guessing fails (Fabrity/Medicover careers pages 404/403 on guessed paths). Mitigation:
+  seed the harvester from the justjoin company list (names → domains) and accept partial
+  coverage; missing companies still arrive via justjoin as today.
+- **HTML detail parsing is brittle** → eRecruiter's `Offer.aspx` markup can change.
+  Mitigation: parse defensively (skip a posting whose title/description can't be extracted
+  rather than failing the board), and cover the parse with a fixture test.
+- **Non-IT noise** → Boards carry all company jobs (e.g. cleaning roles). Mitigation: none
+  needed — the standard classify/skilltag dictionaries derive facets and IT filtering
+  happens downstream as for every source.
+- **Per-offer detail fetches add load** → one request per posting. Mitigation: bounded by
+  each board's real size (tens, not thousands); acceptable at cron cadence.
+
+## Migration Plan
+
+- Ship adapter + registry line + empty/seed `sources/erecruiter.yml`; no schema changes.
+- Wire a per-provider ingest cron for `sources/erecruiter.yml` (one schedule, like other
+  board files). Rollback = drop the cron entry and the registry line; no data migration.
+- Run `cmd/harvest-erecruiter` over the justjoin company set to populate the board file
+  incrementally.
+
+## Open Questions
+
+- Does `Offer.aspx` expose a reliable posted-at date? If not, postings fall back to ingest
+  time via the existing `effectivePostedAt` handling (acceptable).
+- Best seed for the harvester: reuse the justjoin-mined company list, or fold eRecruiter
+  cfg detection into the existing `domain-ats-harvest`? Deferred to harvest execution.

--- a/openspec/changes/add-erecruiter-source/proposal.md
+++ b/openspec/changes/add-erecruiter-source/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+eRecruiter (Polska) is the single largest ATS gap behind justjoin: 161 distinct
+companies apply through eRecruiter forms, and today we can only re-aggregate those
+postings via justjoin — a second-class source with weaker dedup, freshness, and no
+self-close. eRecruiter exposes a fully keyless public per-company board
+(`skk.erecruiter.pl`), so we can ingest those companies directly under their own
+identity instead of through the aggregator.
+
+## What Changes
+
+- Add an `erecruiter` source adapter (`internal/sources/erecruiter.go`) that crawls one
+  company's public "Strona Kariera" board. The board id is the company's `cfg`
+  (32-hex config token). It lists postings via `GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<n>`
+  and fetches each posting's title/location/description from its `Offer.aspx` detail page.
+- Register `erecruiter` in `sources.All`, add the board file `sources/erecruiter.yml`
+  (one entry per company: `company` + `board`=cfg), and wire an ingest cron for it.
+- Add a `cmd/harvest-erecruiter` tool that resolves a company's `cfg` from its careers
+  page (fetch page → extract `Code.ashx?cfg=<hex>`), live-validates it against the board
+  endpoint, and prints ready-to-paste `sources/erecruiter.yml` entries — the discovery
+  bridge for the 161 justjoin companies (justjoin exposes per-job `WebID` apply forms,
+  which carry no `cfg`).
+
+## Capabilities
+
+### New Capabilities
+- `erecruiter-source`: a board-based `erecruiter` adapter that crawls one company's
+  keyless eRecruiter career board (list rows + per-offer detail) into the catalogue,
+  plus a harvest prober that discovers and validates a company's `cfg` board token.
+
+### Modified Capabilities
+<!-- None: source-ingest's registry/board-file contract is unchanged; this adds a new provider under it. -->
+
+## Impact
+
+- New: `internal/sources/erecruiter.go` (+ test), `sources/erecruiter.yml`,
+  `cmd/harvest-erecruiter/main.go`.
+- Modified: `internal/sources/source.go` (`All` registry line), Dockerfile/cron wiring
+  for the new ingest board file (per-provider schedule).
+- No schema/migration changes. Postings flow through the existing `pipeline.Runner` →
+  `UpsertJob` write path; the stale-job sweep and incremental indexing apply unchanged.
+- eRecruiter boards carry all of a company's jobs (incl. non-IT); the existing
+  classify/skilltag dictionaries filter/derive facets as for any other source.

--- a/openspec/changes/add-erecruiter-source/specs/erecruiter-source/spec.md
+++ b/openspec/changes/add-erecruiter-source/specs/erecruiter-source/spec.md
@@ -1,0 +1,83 @@
+## ADDED Requirements
+
+### Requirement: eRecruiter company-board crawl
+
+The system SHALL provide an `erecruiter` source adapter that crawls one company's public
+eRecruiter "Strona Kariera" board into the catalogue. The board id is the company's `cfg`
+config token (32-hex), and the adapter fetches the keyless public endpoint
+`https://skk.erecruiter.pl/GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<page>`. The adapter is
+board-based (it requires a board id) and appears in the source facet.
+
+#### Scenario: Board yields all live postings
+
+- **WHEN** the adapter fetches a configured company board
+- **THEN** it returns one `Job` per posting on the board, each with the posting's title,
+  HTML description (sanitized), free-text location, apply/detail URL, and — when the
+  board exposes it — a posted-at timestamp
+
+#### Scenario: Stable dedup identity
+
+- **WHEN** the adapter maps a board row to a `Job`
+- **THEN** the `ExternalID` is the posting's stable `externalJobOfferId`, so re-crawling
+  the same company board dedups to the same catalogue row
+
+### Requirement: Two-step list then detail fetch
+
+The adapter SHALL fetch each posting's `Offer.aspx` detail page and parse its description
+and canonical detail URL, so a persisted posting carries a real body rather than only a
+one-line title. This is required because the list endpoint returns only a row summary
+(title, category, city, and the id fields offerId, externalJobOfferId,
+externalJobOfferRegionId, comId); the full description lives on the per-offer detail page,
+addressed by those id fields plus the board `cfg`.
+
+#### Scenario: Detail supplies the description
+
+- **WHEN** the adapter has a list row and fetches its detail page
+- **THEN** the resulting `Job` carries the posting's full sanitized description and the
+  `Offer.aspx` URL as its canonical detail URL
+
+#### Scenario: Detail page missing
+
+- **WHEN** a posting's detail page is gone (the row references a closed offer)
+- **THEN** the adapter skips that posting without aborting the rest of the board
+
+### Requirement: Paginated collection bounded by reported total
+
+The adapter SHALL page through the board until it has collected the reported total (or a
+page returns no offer rows), and SHALL stop after a bounded number of pages so a
+pathological feed can never loop forever. The list endpoint returns a fixed page size (20
+rows) and, on the first page, a marker row whose `tr` attribute is the board's total
+result count; a single-page fetch would otherwise silently truncate a board larger than
+one page.
+
+#### Scenario: Board larger than one page
+
+- **WHEN** a company has more postings than one page (e.g. 32 postings, page size 20)
+- **THEN** the adapter returns every live posting, not just the first page
+
+#### Scenario: Guard against a never-ending feed
+
+- **WHEN** the endpoint keeps returning full pages without ever reaching the total
+- **THEN** the adapter stops after a bounded number of pages rather than looping forever
+
+### Requirement: Harvest cfg discovery and validation
+
+The system SHALL provide a harvest tool for the `erecruiter` provider that resolves a
+company's `cfg` board token from the company's own careers page (fetch the page and
+extract the `https://skk.erecruiter.pl/Code.ashx?cfg=<hex>` widget reference), then
+live-validates the token against the board endpoint. It keeps a candidate only when the
+board endpoint returns parseable offer rows, and skips any other candidate without
+aborting the harvest. Valid tokens are emitted as ready-to-paste `sources/erecruiter.yml`
+entries (`company` + `board`=cfg). This is the discovery bridge for companies known only
+by an eRecruiter apply-form `WebID`, which carries no `cfg`.
+
+#### Scenario: Careers page exposes a cfg
+
+- **WHEN** the harvester fetches a company careers page that embeds the eRecruiter widget
+- **THEN** it extracts the `cfg` token, confirms the board endpoint returns live offer
+  rows, and emits a board-file entry for that company
+
+#### Scenario: No eRecruiter widget on the page
+
+- **WHEN** a candidate careers page does not reference `skk.erecruiter.pl/Code.ashx?cfg=`
+- **THEN** the harvester skips the candidate silently and continues with the rest

--- a/openspec/changes/add-erecruiter-source/tasks.md
+++ b/openspec/changes/add-erecruiter-source/tasks.md
@@ -1,0 +1,49 @@
+## 1. eRecruiter adapter
+
+- [ ] 1.1 Add a fixture-backed test (`internal/sources/erecruiter_test.go`) for the list
+  parse: JSONP `({"htm":"<tr ...>"})` → rows with `offerId`/`externalJobOfferId`/
+  `externalJobOfferRegionId`/`comId`/title/city, plus the `tr` total from the marker row.
+- [ ] 1.2 Add a fixture-backed test for the detail parse: `Offer.aspx` HTML →
+  title/company/location/description + apply `WebID` URL; missing/closed detail is skipped.
+- [ ] 1.3 Implement `internal/sources/erecruiter.go`: `Provider() == "erecruiter"`,
+  board-based (not boardless), `Fetch` reads `GetHtml.ashx?cfg=<board>&grid=rows&pn=<n>`
+  via `GetText`, unwraps the JSONP, parses rows, and fetches each offer's `Offer.aspx`
+  detail; maps to `Job` with `ExternalID = externalJobOfferId` and the `Offer.aspx` URL.
+- [ ] 1.4 Implement paginated collection: read `tr` total from page 1, page until the
+  total is collected or a page yields no offer rows, under a bounded page cap.
+- [ ] 1.5 Parse defensively — a posting whose title/description can't be extracted is
+  skipped without aborting the board; sanitize the HTML description (existing helper).
+- [ ] 1.6 `go build ./... && go vet ./... && go test ./internal/sources/` green.
+
+## 2. Registry and board file
+
+- [ ] 2.1 Register `NewErecruiter(c)` in `sources.All` (`internal/sources/source.go`).
+- [ ] 2.2 Add `sources/erecruiter.yml` with the board-file header and a small seed set of
+  hand-validated `company` + `board`=cfg entries.
+- [ ] 2.3 Confirm `cmd/ingest sources/erecruiter.yml` validates the board file against the
+  registry and crawls a seed board end-to-end (postings upserted).
+
+## 3. cfg harvester
+
+- [ ] 3.1 Add a test for the cfg extractor: careers-page HTML → `cfg` token, and a page
+  without the `Code.ashx?cfg=` widget yields no token (skipped).
+- [ ] 3.2 Implement `cmd/harvest-erecruiter/main.go`: read company careers URLs (or
+  domains) from input, fetch each, extract `cfg`, live-validate against
+  `GetHtml.ashx?cfg=<cfg>&grid=rows&pn=1`, and print `sources/erecruiter.yml` entries for
+  the valid ones; skip the rest without aborting.
+- [ ] 3.3 Run the harvester over the justjoin-mined eRecruiter company set and fold the
+  validated entries into `sources/erecruiter.yml`.
+
+## 4. Ops wiring
+
+- [ ] 4.1 Add `cmd/harvest-erecruiter` to the Dockerfile build if it needs to run in prod;
+  otherwise document it as a local harvest tool.
+- [ ] 4.2 Wire a per-provider ingest cron for `sources/erecruiter.yml` (one schedule, as
+  for other board files).
+
+## 5. Verification
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green.
+- [ ] 5.2 Manually crawl 2–3 seed boards and confirm postings carry real
+  title/location/description and dedup on recrawl (stable `externalJobOfferId`).
+- [ ] 5.3 `openspec validate add-erecruiter-source` passes.

--- a/openspec/changes/add-erecruiter-source/tasks.md
+++ b/openspec/changes/add-erecruiter-source/tasks.md
@@ -1,49 +1,68 @@
 ## 1. eRecruiter adapter
 
-- [ ] 1.1 Add a fixture-backed test (`internal/sources/erecruiter_test.go`) for the list
+- [x] 1.1 Add a fixture-backed test (`internal/sources/erecruiter_test.go`) for the list
   parse: JSONP `({"htm":"<tr ...>"})` → rows with `offerId`/`externalJobOfferId`/
   `externalJobOfferRegionId`/`comId`/title/city, plus the `tr` total from the marker row.
-- [ ] 1.2 Add a fixture-backed test for the detail parse: `Offer.aspx` HTML →
+- [x] 1.2 Add a fixture-backed test for the detail parse: `Offer.aspx` HTML →
   title/company/location/description + apply `WebID` URL; missing/closed detail is skipped.
-- [ ] 1.3 Implement `internal/sources/erecruiter.go`: `Provider() == "erecruiter"`,
+- [x] 1.3 Implement `internal/sources/erecruiter.go`: `Provider() == "erecruiter"`,
   board-based (not boardless), `Fetch` reads `GetHtml.ashx?cfg=<board>&grid=rows&pn=<n>`
   via `GetText`, unwraps the JSONP, parses rows, and fetches each offer's `Offer.aspx`
   detail; maps to `Job` with `ExternalID = externalJobOfferId` and the `Offer.aspx` URL.
-- [ ] 1.4 Implement paginated collection: read `tr` total from page 1, page until the
+- [x] 1.4 Implement paginated collection: read `tr` total from page 1, page until the
   total is collected or a page yields no offer rows, under a bounded page cap.
-- [ ] 1.5 Parse defensively — a posting whose title/description can't be extracted is
+- [x] 1.5 Parse defensively — a posting whose title/description can't be extracted is
   skipped without aborting the board; sanitize the HTML description (existing helper).
-- [ ] 1.6 `go build ./... && go vet ./... && go test ./internal/sources/` green.
+- [x] 1.6 `go build ./... && go vet ./... && go test ./internal/sources/` green.
 
 ## 2. Registry and board file
 
-- [ ] 2.1 Register `NewErecruiter(c)` in `sources.All` (`internal/sources/source.go`).
-- [ ] 2.2 Add `sources/erecruiter.yml` with the board-file header and a small seed set of
+- [x] 2.1 Register `NewErecruiter(c)` in `sources.All` (`internal/sources/source.go`).
+- [x] 2.2 Add `sources/erecruiter.yml` with the board-file header and a small seed set of
   hand-validated `company` + `board`=cfg entries.
-- [ ] 2.3 Confirm `cmd/ingest sources/erecruiter.yml` validates the board file against the
+- [x] 2.3 Confirm `cmd/ingest sources/erecruiter.yml` validates the board file against the
   registry and crawls a seed board end-to-end (postings upserted).
 
 ## 3. cfg harvester
 
-- [ ] 3.1 Add a test for the cfg extractor: careers-page HTML → `cfg` token, and a page
+- [x] 3.1 Add a test for the cfg extractor: careers-page HTML → `cfg` token, and a page
   without the `Code.ashx?cfg=` widget yields no token (skipped).
-- [ ] 3.2 Implement `cmd/harvest-erecruiter/main.go`: read company careers URLs (or
+- [x] 3.2 Implement `cmd/harvest-erecruiter/main.go`: read company careers URLs (or
   domains) from input, fetch each, extract `cfg`, live-validate against
   `GetHtml.ashx?cfg=<cfg>&grid=rows&pn=1`, and print `sources/erecruiter.yml` entries for
   the valid ones; skip the rest without aborting.
-- [ ] 3.3 Run the harvester over the justjoin-mined eRecruiter company set and fold the
+- [x] 3.3 Run the harvester over the justjoin-mined eRecruiter company set and fold the
   validated entries into `sources/erecruiter.yml`.
 
 ## 4. Ops wiring
 
-- [ ] 4.1 Add `cmd/harvest-erecruiter` to the Dockerfile build if it needs to run in prod;
+- [x] 4.1 Add `cmd/harvest-erecruiter` to the Dockerfile build if it needs to run in prod;
   otherwise document it as a local harvest tool.
-- [ ] 4.2 Wire a per-provider ingest cron for `sources/erecruiter.yml` (one schedule, as
+- [x] 4.2 Wire a per-provider ingest cron for `sources/erecruiter.yml` (one schedule, as
   for other board files).
 
 ## 5. Verification
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green.
-- [ ] 5.2 Manually crawl 2–3 seed boards and confirm postings carry real
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` green.
+- [x] 5.2 Manually crawl 2–3 seed boards and confirm postings carry real
   title/location/description and dedup on recrawl (stable `externalJobOfferId`).
-- [ ] 5.3 `openspec validate add-erecruiter-source` passes.
+- [x] 5.3 `openspec validate add-erecruiter-source` passes.
+
+## Deviations from the proposal (found during implementation, live-validated)
+
+- **`ExternalID` = `offerId`, not `externalJobOfferId`.** The live board reuses one
+  `externalJobOfferId` across a role's multi-city variants (each a distinct `offerId` with its
+  own `Offer.aspx` detail + city). Keying on `externalJobOfferId` would collapse those into one
+  posting; `offerId` is unique per publication and is the id the detail URL (`oid`) is keyed by,
+  so each city persists as its own catalogue entry. Verified: Echo board → 29 distinct ids, 0
+  collisions.
+- **Apply `WebID` not stored.** `Job` has no apply-URL field distinct from `URL`; the canonical
+  `Offer.aspx` detail URL (which carries the "Aplikuj" button) is used as `URL`, per the design's
+  "canonical job URL = the Offer.aspx URL". The `WebID` form was left unparsed (nothing consumes it).
+- **Seed set is Echo Investment + Centrum Nauki Kopernik** (both live-validated). The full
+  justjoin 161-company onboarding is the ongoing cfg-harvest (the design's accepted partial gap);
+  `cmd/harvest-erecruiter` is the tool for it.
+- **4.1/4.2 ops:** `cmd/harvest-erecruiter` is a run-once host tool (not built into the prod
+  Dockerfile, matching `cmd/harvest-boards`); the per-provider ingest cron for
+  `sources/erecruiter.yml` is a prod-host crontab line (`ingest .../sources/erecruiter.yml`), and
+  the board file is synced to prod by the existing `deploy.sh` sources/ rsync.

--- a/sources/erecruiter.yml
+++ b/sources/erecruiter.yml
@@ -1,0 +1,14 @@
+# eRecruiter Polska career boards ("Strona Kariera") on skk.erecruiter.pl. Provider is the
+# filename; each entry is company + board. board = the company's cfg (32-hex config token
+# embedded in its careers page as Code.ashx?cfg=<hex>); see internal/sources/erecruiter.go.
+# The keyless list endpoint (skk.erecruiter.pl/GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<n>)
+# returns offer rows; the adapter fetches each Offer.aspx detail for the body. eRecruiter is
+# a Polish ATS, so most postings are in Polish and boards carry all roles (incl. non-IT) —
+# the classify/skilltag dictionaries derive facets downstream. Each board validated live
+# (list endpoint returned >0 offers) before adding; cmd/harvest-erecruiter resolves and
+# re-validates a company's cfg from its careers page.
+
+- company: Echo Investment
+  board: 4D3DD27FCA3D40C79E01BEE9745902B7
+- company: Centrum Nauki Kopernik
+  board: d9f100d80dcc4d9895201c2993c46816


### PR DESCRIPTION
## What

Adds an **eRecruiter Polska** source adapter — the #1 ATS gap behind justjoin (161 companies) — plus a discovery harvester. Implements OpenSpec change `add-erecruiter-source`.

eRecruiter exposes a **keyless per-company career board** on `skk.erecruiter.pl`; the board id is the company's `cfg` token (embedded in its careers page). This ingests those companies directly under their own identity instead of re-aggregating via justjoin.

### Adapter (`internal/sources/erecruiter.go`)
- Board-based, keyless. **List**: `GetHtml.ashx?cfg=<cfg>&grid=rows&pn=<n>` returns JSONP `({"htm":"<tr…>"})` of offer rows (read via `GetText`, unwrapped, `<tr>` parsed under a wrapping `<table>`). **Detail**: each offer's `Offer.aspx` HTML (`GetHTML`) → title (`#JobTitle`), location (`#WorkPlace`), body (`#t1`/`#Opportunities`/`#CompanyDescription`, sanitized).
- **Pagination** stops on the marker row's `tr` total or an empty page, under a bounded cap.
- **Defensive**: a dead/closed offer (no title/description) is skipped without aborting the board.

### Harvester (`cmd/harvest-erecruiter`)
Run-once host tool: reads company careers URLs, extracts the `cfg` widget token, live-validates it against the list endpoint, and prints `sources/erecruiter.yml` entries — the discovery bridge for the justjoin companies (whose apply forms carry no `cfg`).

### Seed (`sources/erecruiter.yml`)
Echo Investment + Centrum Nauki Kopernik, both live-validated. Registered in `sources.All`.

## Key decision (deviation from the proposal, live-validated)
**`ExternalID` = `offerId`, not `externalJobOfferId`.** The live board reuses one `externalJobOfferId` across a role's multi-city variants (each a distinct `offerId` with its own detail page + city); keying on it would collapse distinct city-postings into one. `offerId` is unique per publication and is the id the detail URL (`oid`) uses. See the tasks.md "Deviations" section for the full list.

## Verification
- Unit tests (`internal/sources/erecruiter_test.go`) on real-data fixtures: list parse (incl. multi-city distinct-id), detail parse + sanitization, skip-unparseable, empty-page stop, cfg extractor.
- **Live end-to-end**: Echo board → 29 postings with real title/location/description, 0 id collisions; Echo/Kopernik/PUP cfgs probed live.
- `go build ./... && go vet ./... && go test ./...` green; `openspec validate add-erecruiter-source` passes.
- Reviewed (high-effort); 3 robustness findings fixed (blank-body graceful stop, set total once, locale-robust location-label strip).

## Ops (host, not in this diff)
`cmd/harvest-erecruiter` is a host tool (not built into the prod Dockerfile, matching `cmd/harvest-boards`). The per-provider ingest cron for `sources/erecruiter.yml` is a prod-host crontab line; the board file is synced by the existing `deploy.sh` sources/ rsync.