### PR TITLE
feat(skilltag): add LLM-mined high-frequency skill gaps

### DIFF
--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -298,6 +298,42 @@ var wordAliases = map[string]string{
 	"salesforce": "salesforce",
 	"sap":        "sap",
 	"oracle":     "oracle",
+
+	// LLM-mined gaps: high-frequency tokens the enrichment discovery signal emitted
+	// (jobs.enrichment->skills) that the seed list lacked. Only distinctive tokens are
+	// bare aliases here; ambiguous ones (plc↔"… plc", temporal↔the adjective,
+	// embedded↔"embedded in", dax↔the index) are deliberately omitted, and R stays a
+	// phrase-only route (see below).
+	"github":        "github",
+	"servicenow":    "servicenow",
+	"sharepoint":    "sharepoint",
+	"hubspot":       "hubspot",
+	"nosql":         "nosql",
+	"etl":           "etl",
+	"itil":          "itil",
+	"cybersecurity": "cybersecurity",
+	"opensearch":    "opensearch",
+	"solr":          "solr",
+	// BI / analytics / statistics tooling
+	"qlik":       "qlik",
+	"sas":        "sas",
+	"spss":       "spss",
+	"stata":      "stata",
+	"vba":        "vba",
+	"xgboost":    "xgboost",
+	"matplotlib": "matplotlib",
+	"seaborn":    "seaborn",
+	"plotly":     "plotly",
+	"jupyter":    "jupyter",
+	// hardware / CAD
+	"autocad": "autocad",
+	"revit":   "revit",
+	"cad":     "cad",
+	"fpga":    "fpga",
+	"verilog": "verilog",
+	// web3
+	"web3":     "web3",
+	"ethereum": "ethereum",
 }
 
 // phraseAlias is a punctuated or multi-word term matched against the normalized
@@ -347,4 +383,17 @@ var phraseAliases = []phraseAlias{
 	{"aws bedrock", "aws-bedrock"}, {"amazon bedrock", "aws-bedrock"},
 	{"sentence transformers", "sentence-transformers"}, {"sentence-transformers", "sentence-transformers"},
 	{"retrieval augmented generation", "rag"}, {"retrieval-augmented generation", "rag"},
+	// LLM-mined multi-word gaps (jobs.enrichment->skills). Multi-word or ambiguous
+	// terms routed as phrases so the bare token can't misfire on non-tech jobs.
+	// ("spring boot" needs no entry — the "spring" word alias already tags it.)
+	{"azure devops", "azure-devops"},
+	{"power apps", "powerapps"}, {"powerapps", "powerapps"},
+	{"power automate", "power-automate"},
+	{"distributed systems", "distributed-systems"},
+	{"data modeling", "data-modeling"}, {"data modelling", "data-modeling"},
+	{"data visualization", "data-visualization"}, {"data visualisation", "data-visualization"},
+	{"prompt engineering", "prompt-engineering"},
+	{"generative ai", "generative-ai"}, {"gen ai", "generative-ai"},
+	{"deep learning", "deep-learning"},
+	{"six sigma", "six-sigma"},
 }

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -96,6 +96,66 @@ func TestParse_NewTechVocab(t *testing.T) {
 	}
 }
 
+// LLM-mined vocabulary (skilltag-llm-mined): high-frequency gaps found by mining
+// the enrichment discovery signal (jobs.enrichment->skills). Each resolves from
+// realistic text; the ambiguity guards confirm the tokens we deliberately did NOT
+// add (plc, temporal, embedded, nomad) never tag on their common non-tech uses.
+func TestParse_LLMMinedVocab(t *testing.T) {
+	contains := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+	cases := []struct {
+		name   string
+		in     string
+		want   []string
+		absent []string
+	}{
+		{"data tooling", "ETL into NoSQL stores; dashboards in Qlik with SAS and SPSS.",
+			[]string{"etl", "nosql", "qlik", "sas", "spss"}, nil},
+		{"saas platforms", "Administer ServiceNow, SharePoint, HubSpot and GitHub.",
+			[]string{"servicenow", "sharepoint", "hubspot", "github"}, nil},
+		{"search engines", "Full-text search over OpenSearch and Solr.", []string{"opensearch", "solr"}, nil},
+		{"cad + hardware", "AutoCAD and Revit for CAD; FPGA design in Verilog.",
+			[]string{"autocad", "revit", "cad", "fpga", "verilog"}, nil},
+		{"python viz/ml", "Plotting with Matplotlib, Seaborn and Plotly in Jupyter; XGBoost models; VBA macros.",
+			[]string{"matplotlib", "seaborn", "plotly", "jupyter", "xgboost", "vba"}, nil},
+		{"web3", "Smart contracts on Ethereum with a modern Web3 stack.", []string{"ethereum", "web3"}, nil},
+		{"phrases", "Azure DevOps pipelines, distributed systems, deep learning and prompt engineering.",
+			[]string{"azure-devops", "distributed-systems", "deep-learning", "prompt-engineering"}, nil},
+		{"spring boot via word", "Spring Boot microservices.", []string{"spring"}, nil},
+		{"ms low-code", "Automate with Power Apps and Power Automate.", []string{"powerapps", "power-automate"}, nil},
+		{"data phrases", "Strong data modeling and data visualization skills.", []string{"data-modeling", "data-visualization"}, nil},
+		{"generative ai", "Experience with Generative AI tooling.", []string{"generative-ai"}, nil},
+		{"itil + six sigma", "ITIL service management and Six Sigma.", []string{"itil", "six-sigma"}, nil},
+		{"security", "Cybersecurity and incident response.", []string{"cybersecurity"}, nil},
+		// ambiguity guards: deliberately-omitted tokens must not tag on common non-tech uses.
+		{"plc company suffix trap", "Join Barclays PLC, a FTSE-100 firm.", nil, []string{"plc"}},
+		{"temporal adjective trap", "Analyze temporal trends in the data.", nil, []string{"temporal"}},
+		{"embedded phrase trap", "You will be embedded in a cross-functional team.", nil, []string{"embedded"}},
+		{"nomad trap", "A remote-first company hiring digital nomads.", nil, []string{"nomad"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Parse(c.in)
+			for _, w := range c.want {
+				if !contains(got, w) {
+					t.Errorf("Parse(%q) = %v, missing %q", c.in, got, w)
+				}
+			}
+			for _, a := range c.absent {
+				if contains(got, a) {
+					t.Errorf("Parse(%q) = %v, must NOT contain %q", c.in, got, a)
+				}
+			}
+		})
+	}
+}
+
 // AI/LLM engineering vocabulary (ai-skills-gaps): vector DBs, LLM frameworks,
 // model providers, and serving/inference tools resolve from realistic text.
 // Ambiguous bare words are deliberately NOT tagged (RAG project status, the word


### PR DESCRIPTION
## What & why

Data-driven expansion of the `skilltag` dictionary. I mined the **enrichment discovery signal** — the LLM's raw `jobs.enrichment->skills` over ~1.2M enriched jobs — for tokens the model emits frequently that our seed dictionary didn't cover. This is exactly what the raw LLM values are kept for (dict-only serving folds them out but stores them for mining).

Method: ranked LLM skill tokens by frequency, subtracted everything the dictionary already knows, dropped the soft/business/non-IT majority (the corpus isn't purely IT — `customer_service`, `nursing`, `excel`… dominate the head), and kept the tech tokens, confirming each against its true prod frequency.

## Added

**Word aliases** (distinctive single tokens): `github` (5.3k), `servicenow`, `sharepoint`, `hubspot`, `nosql`, `etl` (8.9k), `itil`, `cybersecurity` (9.2k), `opensearch`, `solr`, `qlik`, `sas`, `spss`, `stata`, `vba`, `xgboost`, `matplotlib`, `seaborn`, `plotly`, `jupyter`, `autocad` (14k), `revit`, `cad`, `fpga`, `verilog`, `web3`, `ethereum`.

**Phrase aliases** (multi-word/ambiguous → routed as phrases): `azure devops`, `power apps`, `power automate`, `distributed systems`, `data modeling`/`modelling`, `data visualization`/`visualisation`, `prompt engineering`, `generative ai`/`gen ai`, `deep learning`, `six sigma`.

## Deliberately omitted (precision-first)

High LLM frequency but the bare token collides with common non-tech prose (skilltag runs on **all** jobs, IT and not):
- `plc` (5.9k) — "… PLC" company suffix (e.g. *Barclays PLC*)
- `temporal` — the adjective ("temporal data")
- `embedded` — "embedded in a team"
- `dax` — the stock index
- `R` stays a **phrase-only** route (`r language`), like `go`/`c` — bare `r` is unsafe.

Already in the dictionary (appeared in the mine, no-op): `snowflake`, `databricks`, `looker`, `powerbi`.

## Tests

`TestParse_LLMMinedVocab` covers the new aliases resolving from realistic text **and** ambiguity guards proving the omitted tokens (`plc`/`temporal`/`embedded`/`nomad`) never tag. `go build`, `go vet`, `gofmt`, `go test ./...` all pass.

## Deploy notes

Dictionary change — run `cmd/backfill-derive` + reindex to re-tag existing rows.