### PR TITLE
fix(erecruiter): template-agnostic detail body + 28 validated boards

### DIFF
--- a/internal/sources/erecruiter.go
+++ b/internal/sources/erecruiter.go
@@ -198,9 +198,8 @@ func erecruiterOfferRow(tr *html.Node) (erecruiterRow, bool) {
 }
 
 // parseErecruiterDetail reads an Offer.aspx detail tree: the #JobTitle heading, the
-// #WorkPlace line (stripping its "Miejsce pracy:" label), and the body assembled from the
-// #t1 / #Opportunities / #CompanyDescription sections (sanitized). A field absent from the
-// markup comes back empty for the caller to fall back on the list row or skip.
+// #WorkPlace line (stripping its "Miejsce pracy:" label), and the sanitized body. A field
+// absent from the markup comes back empty for the caller to fall back on the list row or skip.
 func parseErecruiterDetail(root *html.Node) (title, location, description string) {
 	title = erecruiterIDText(root, "JobTitle")
 	location = strings.TrimSpace(erecruiterIDText(root, "WorkPlace"))
@@ -209,14 +208,40 @@ func parseErecruiterDetail(root *html.Node) (title, location, description string
 	if _, city, ok := strings.Cut(location, ":"); ok {
 		location = strings.TrimSpace(city)
 	}
+	return title, location, sanitizeHTML(erecruiterBody(root))
+}
 
+// erecruiterBodyExcludeIDs are the offer-container sections that are not the job body: the
+// header (already captured as title/location) and the GDPR consent clause.
+var erecruiterBodyExcludeIDs = map[string]bool{"JobTitle": true, "WorkPlace": true, "Clause": true}
+
+// erecruiterBody returns the offer's HTML body. Company career-page templates render the body
+// under different ids (#t1, or #opis/#description/#Notes/…), so it takes the whole offer
+// container (#offCont) minus the header and consent-clause sections — template-agnostic —
+// rather than a fixed list of section ids. It falls back to the known section ids for a page
+// without the standard container, and returns "" when neither yields anything.
+func erecruiterBody(root *html.Node) string {
+	if cont := elementByID(root, "offCont"); cont != nil {
+		var drop []*html.Node
+		walk(cont, func(n *html.Node) bool {
+			if n.Type == html.ElementNode && erecruiterBodyExcludeIDs[attr(n, "id")] {
+				drop = append(drop, n)
+				return false
+			}
+			return true
+		})
+		for _, n := range drop {
+			n.Parent.RemoveChild(n)
+		}
+		return innerHTML(cont)
+	}
 	var body strings.Builder
 	for _, id := range []string{"t1", "Opportunities", "CompanyDescription"} {
 		if n := elementByID(root, id); n != nil {
 			body.WriteString(innerHTML(n))
 		}
 	}
-	return title, location, sanitizeHTML(body.String())
+	return body.String()
 }
 
 // erecruiterIDText returns the trimmed text of the element with the given id, or "".

--- a/internal/sources/erecruiter_test.go
+++ b/internal/sources/erecruiter_test.go
@@ -188,6 +188,43 @@ func TestErecruiterFetchSkipsUnparseableDetail(t *testing.T) {
 	}
 }
 
+func TestErecruiterDetailTemplateAgnostic(t *testing.T) {
+	// A company whose detail renders the body under #opis/#description (not #t1) inside the
+	// standard #offCont container, plus a GDPR #Clause. The body must be captured across the
+	// varied template, and the header (#JobTitle/#WorkPlace) and clause dropped.
+	detail := `<html><body><div id="offCont">` +
+		`<div id="JobTitle">DevOps Engineer</div>` +
+		`<div id="WorkPlace">Miejsce pracy: Łódź</div>` +
+		`<div id="opis"><p>Company intro paragraph.</p></div>` +
+		`<div id="description"><p>Run the Kubernetes fleet.</p></div>` +
+		`<div id="Clause"><p>Zgoda na przetwarzanie danych osobowych.</p></div>` +
+		`</div></body></html>`
+	rows := `<tr offerId='500' externalJobOfferId='60' externalJobOfferRegionId='70' comId='9' skkResult='offer'><td class='skk_positionName'>DevOps Engineer</td><td>Łódź</td></tr>` +
+		`<tr tp='2' tr='1' pn='1' ps='15'></tr>`
+	fake := &erecruiterFake{
+		list:   map[string]string{"pn=1": jsonp(rows)},
+		detail: map[string]string{"oid=500": detail},
+	}
+
+	jobs, err := NewErecruiter(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "cfg"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (a non-#t1 template must still yield a body)", len(jobs))
+	}
+	d := jobs[0].Description
+	if !strings.Contains(d, "Kubernetes fleet") || !strings.Contains(d, "Company intro") {
+		t.Errorf("Description = %q, want the #opis/#description body", d)
+	}
+	if strings.Contains(d, "przetwarzanie danych") {
+		t.Errorf("Description must drop the GDPR #Clause: %q", d)
+	}
+	if strings.Contains(d, "DevOps Engineer") {
+		t.Errorf("Description must drop the #JobTitle header: %q", d)
+	}
+}
+
 func TestErecruiterFetchStopsOnEmptyPage(t *testing.T) {
 	// The marker over-reports the total (tr=999) but the board runs out on page 2. An empty
 	// page must end the walk instead of spinning to the page cap.

--- a/sources/erecruiter.yml
+++ b/sources/erecruiter.yml
@@ -12,3 +12,59 @@
   board: 4D3DD27FCA3D40C79E01BEE9745902B7
 - company: Centrum Nauki Kopernik
   board: d9f100d80dcc4d9895201c2993c46816
+- company: Asseco Business Solutions
+  board: 7c55630e38e54a6ab90e64cc28fc173f
+- company: Atalian Poland
+  board: eac02250aa184ed4bf4950e74948549a
+- company: Atende
+  board: ebd48c8bb7ce4b01a6d08052ac22783d
+- company: Bank Gospodarstwa Krajowego
+  board: 21f6ff3809da40219e4102f28e47c254
+- company: Benefit Systems
+  board: d4299fd2ca154f1c8e772a5cf9df01d8
+- company: Budimex
+  board: 20c4ecaac68c42b4ad93b5beceb3574d
+- company: C&F
+  board: 8eb3ecddaa1c482f9306e80f52ffc25d
+- company: DPD Polska
+  board: 0a942f8a967748f68df0603230db9e3d
+- company: Impact Clean Power Technology
+  board: 6e5affd0b23a40ee9aec81f50f00e15a
+- company: InPost
+  board: aaa769425b3f4db0aba90feb1a03c2d0
+- company: Investa
+  board: 636b4ae907754d92b4391c198ef97fc5
+- company: Krajowa Izba Rozliczeniowa
+  board: 900c79c3d4e14248b1be36c97279130c
+- company: LOT Aircraft Maintenance Services
+  board: 072a6e4eefb94a4bbd7f6a2e54206a9b
+- company: LUX MED
+  board: 4dfadcc165b34f609578051941d8f662
+- company: Medicover
+  board: 848bb9aa33704e14afa7ab9ddafaab9d
+- company: mBank
+  board: 0b23d21dc7b54dfaa0900c44fd8ca54d
+- company: PKO Bank Polski
+  board: a1cde84930e641b8b6fe1d0149e8fb43
+- company: PLAY
+  board: 06a6e3c5918f43279acd57cbb61fecee
+- company: Pelion
+  board: 1bfb8af506da4b22850d075fec06454a
+- company: Pentacomp
+  board: 6c76afbe718c49ceb7b21bcbd993373b
+- company: Polska Agencja Żeglugi Powietrznej
+  board: 58e9fc2b67ba49dfa17c0ac0bcfe8d56
+- company: Polska Grupa Zbrojeniowa
+  board: 055531097fe04079a190d2f210485080
+- company: Polskie Sieci Elektroenergetyczne
+  board: df57fda29f364a128360143b108a39ac
+- company: Teleperformance Polska
+  board: afa44a96e20946d384b5c414b2c1eebf
+- company: Telewizja Polska
+  board: 7e6ba9db068b4dfd9f24da1ad11ca16d
+- company: UNIQA
+  board: 9317759c7362495e83ff6aae978438bb
+- company: Łukasiewicz – Instytut Lotnictwa
+  board: 2e10b2bbe17c4631b9d296673d78972d
+- company: Śnieżka
+  board: ac4808e9277441d9b2442b656445fa89


### PR DESCRIPTION
Follow-up to #364 (merged eRecruiter adapter).

## Summary
- **Bug fix — template-agnostic description.** #364 assembled the detail body from a fixed id list (`#t1`/`#Opportunities`/`#CompanyDescription`). eRecruiter career-page templates vary per company — many render the body under `#opis`/`#description`/`#Notes` — so those boards produced an empty body and, because `toJob` drops empty-description postings, **every posting was silently dropped**. Verified live: Medicover and LUX MED returned **0 jobs** under #364. Now take the whole offer container (`#offCont`) minus the header (`#JobTitle`/`#WorkPlace`, already captured) and the GDPR `#Clause` — template-agnostic — with a fallback to the known section ids so boards that used the old path are unaffected. Medicover → 646, LUX MED → 385 after the fix.
- **Populate the board file.** Adds 28 live-validated company boards to `sources/erecruiter.yml` (each confirmed to return live offer rows through the adapter). Discovered via `site:skk.erecruiter.pl` search — the `cfg` is embedded in Google-indexed `Offer.aspx` URLs — covering the eRecruiter companies that hide behind the justjoin aggregator (Asseco BS, Benefit Systems, C&F, InPost, Pentacomp, Medicover, and more).

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` green (45 packages)
- [x] New unit test `TestErecruiterDetailTemplateAgnostic`: a `#opis`/`#description` body inside `#offCont` is captured; `#Clause` and header dropped
- [x] Live: 28 boards each validated >0 offers through the adapter; Medicover/LUX MED recovered from 0 to 646/385 with the fix