### PR TITLE
feat(sources): add 79 harvested boards across ATS providers

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -6669,3 +6669,39 @@
   board: taxfix.com
 - company: Superhuman
   board: Superhuman Platform Inc
+- company: Clearly AI
+  board: clearly-ai
+- company: Synthpop
+  board: synthpop
+- company: splose
+  board: splose
+- company: Chronosphere
+  board: chronospherejobs
+- company: Grotto AI
+  board: grotto
+- company: Reson8
+  board: reson8
+- company: HammerheadAI
+  board: hammerhead-ai
+- company: Mastra
+  board: Mastra
+- company: Genspark
+  board: genspark
+- company: Monk
+  board: monk
+- company: Sequen
+  board: sequen-ai
+- company: SolveAI
+  board: solve.ai
+- company: Lithosquare
+  board: lithosquare
+- company: Augustus
+  board: augustus
+- company: Judgment Labs
+  board: judgmentlabs
+- company: GRAI
+  board: grai
+- company: WisdomAI
+  board: wisdom-ai
+- company: Orderful
+  board: orderful

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -14739,3 +14739,5 @@
   board: ccem
 - company: ludia
   board: ludia
+- company: Kohort
+  board: kohort

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -1685,3 +1685,5 @@
   board: zifty
 - company: zinier
   board: zinier
+- company: OneDome
+  board: onedome

--- a/sources/careerplug.yml
+++ b/sources/careerplug.yml
@@ -462,3 +462,5 @@
   board: woodhousecareers
 - company: Precision Scans Inc.
   board: www-precisionscans-net
+- company: Diffraqtion
+  board: diffraqtion

--- a/sources/comeet.yml
+++ b/sources/comeet.yml
@@ -14,3 +14,25 @@
   board: moonactive/A2.00C
 - company: Jazz
   board: jazz/6A.009
+- company: Backslash Security
+  board: backslash/98.004
+- company: Adaptive6
+  board: adaptive6/AA.000
+- company: SENAI
+  board: senai/CA.004
+- company: Cyera
+  board: cyera/17.008
+- company: Sett
+  board: sett/4A.00B
+- company: Notch
+  board: notch/CA.003
+- company: Aidoc
+  board: Aidoc/B4.007
+- company: Tenzai
+  board: tenzai/1B.002
+- company: OX Security
+  board: ox_security/f8.006
+- company: WINN.AI
+  board: winn_ai/4A.00F
+- company: DealHub.ai
+  board: dealhub/86.005

--- a/sources/freshteam.yml
+++ b/sources/freshteam.yml
@@ -138,3 +138,7 @@
   board: vantage-talent
 - company: woodmontcabinetry
   board: woodmontcabinetry
+- company: Apeiron Labs
+  board: apeironlabs
+- company: KreditBee
+  board: krazybee

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -252,3 +252,9 @@
   board: wyzecam-com
 - company: zensors-com
   board: zensors-com
+- company: Littlebird
+  board: littlebird
+- company: Inception
+  board: inception
+- company: Afori
+  board: afori

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -12223,3 +12223,9 @@
   board: ravenwakegames
 - company: Nscale
   board: nscaleoperationsukltd
+- company: Guidde
+  board: guidde
+- company: Graphon AI
+  board: graphonai
+- company: OmenAI
+  board: omenai

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -535,3 +535,9 @@
   board: ymcaofhonolulu
 - company: ZALORA Group
   board: zalora
+- company: equipifi
+  board: equipifi
+- company: A&K Robotics
+  board: aandkrobotics
+- company: eMed
+  board: emed

--- a/sources/join.yml
+++ b/sources/join.yml
@@ -8223,3 +8223,5 @@
   board: "99703"
 - company: "99734"
   board: "99734"
+- company: Elephant Company
+  board: 119183

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4054,3 +4054,11 @@
   board: articulate
 - company: SmartBug Media
   board: SmartBugOperatingLLC
+- company: BreezeBio
+  board: BreezeBio
+- company: CopilotKit
+  board: copilotkit
+- company: Living Carbon
+  board: livingcarbon
+- company: Zanskar
+  board: Zanskar

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -4133,3 +4133,7 @@
   board: zeinpharma
 - company: zfb
   board: zfb
+- company: SpotmyEnergy
+  board: spotmyenergy
+- company: NEURA Robotics
+  board: neura-robotics

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -2375,3 +2375,7 @@
   board: savantzorg
 - company: Snapp!
   board: snapp
+- company: constellr
+  board: constellr
+- company: Hydrosat
+  board: hydrosat

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -11,3 +11,27 @@
   board: kevel-careers
 - company: Klir
   board: klir
+- company: Positron AI
+  board: positron
+- company: GoTu
+  board: gotu-careers
+- company: Scope3
+  board: scope3pbc
+- company: Aalyria
+  board: aalyria-careers
+- company: Expo
+  board: expo
+- company: AppWork
+  board: appwork
+- company: Novella
+  board: novella
+- company: Greenpixie
+  board: work-at-greenpixie
+- company: Enzo Health
+  board: enzo-health
+- company: LighthouseAI
+  board: lighthouseai-careers
+- company: gaiia
+  board: gaiias-open-positions
+- company: Mytra
+  board: mytra

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -4265,3 +4265,5 @@
   board: zooplusse
 - company: Vattenfall AB
   board: Vattenfall
+- company: DNAnexus
+  board: DNAnexus

--- a/sources/solides.yml
+++ b/sources/solides.yml
@@ -2314,3 +2314,5 @@
   board: worldnet
 - company: "LINE UP EVENTOS S/A"
   board: zumbrazil
+- company: BemAgro
+  board: bemagro

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -2602,3 +2602,17 @@
   board: careers.fyul.com
 - company: Qutwo
   board: qutwo.teamtailor.com
+- company: Hublo
+  board: hublo.teamtailor.com
+- company: Cloudsmith
+  board: careers.cloudsmith.com
+- company: EGIDE
+  board: egide.teamtailor.com
+- company: Humand
+  board: careers.humand.co
+- company: belo
+  board: work.belo.app
+- company: Pit
+  board: pit.teamtailor.com
+- company: Summize
+  board: summize.teamtailor.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1040,3 +1040,15 @@
   board: soulbound
 - company: UserWise Services
   board: userwise-services
+- company: Fibr AI
+  board: fibr-dot-a-i
+- company: Circit
+  board: circit-limited
+- company: Equal Parts
+  board: equal-parts
+- company: Code Metal
+  board: code-metal
+- company: Optiwatt
+  board: optiwatt
+- company: NATILUS
+  board: natilus


### PR DESCRIPTION
## What

Adds **79 new board entries** across 18 already-registered ATS providers, harvested from an ATS-coverage audit of ~1159 companies. Each entry is a `company + board` pair on a provider whose adapter already exists — no new adapters, no code, just data.

## How the candidates were found

1. **Grep-triage** every company against `sources/*.yml` (strict normalized name match) → already-tracked vs unknown.
2. **Web-detect** the unknowns' careers page → ATS + exact board slug, bucketed as `tracked / gap_supported / gap_unsupported / no_ats`.
3. This PR = the `gap_supported` bucket (adapter exists, only the board entry was missing).

## Verified live (not just slugs on paper)

Ran every added board through its adapter's `Fetch` (no DB) before committing:

- **66** boards return open jobs right now (e.g. Cyera 102, Hublo 22, OX Security 18, Expo 11, NATILUS 5)
- **13** are valid boards with 0 current openings (will populate when roles open)
- **8** were pruned as bad slugs (404/421/no-token): Meadow Memorials, Ualá, Voltron Data, Patronus AI, The Modern Milkman, Zenskar, Sokin, Sateliot — fixable with a corrected slug in a follow-up.

Breakdown by provider: ashby 18, comeet 11, rippling 12, teamtailor 7, workable 6, gem 3, jazzhr 3, greenhouse 3, lever 4, freshteam/personio/recruitee 2 each, + smartrecruiters/solides/breezy/careerplug/bamboohr/join 1 each.

## Excluded up-front (by design)

- **workatastartup** — boardless aggregator, already crawled wholesale; per-company entries aren't how it works.
- **join** non-numeric ids — the adapter needs a numeric companyId.
- **space-containing slugs** — URL double-encoding risk.

## Checks

- All changed files parse as valid YAML.
- `go vet ./internal/sources/` clean, `go test ./internal/sources/` = ok.
- Every entry format-matched to the provider's existing convention (teamtailor → full domain, comeet → `slug/uid`, join → numeric id).