### PR TITLE
feat(verdict): per-profile résumé verdict — deterministic market gap + optional LLM coherence

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -61,6 +61,7 @@ func genStructs() (string, error) {
 
 	enrichTS := filepath.Join(tmp, "enrich.ts")
 	jobviewTS := filepath.Join(tmp, "jobview.ts")
+	verdictTS := filepath.Join(tmp, "verdict.ts")
 
 	cfg := &tygo.Config{
 		Packages: []*tygo.PackageConfig{
@@ -74,6 +75,13 @@ func genStructs() (string, error) {
 				OutputPath:   jobviewTS,
 				IncludeFiles: []string{"jobview.go"},
 				TypeMappings: map[string]string{"enrich.Enrichment": "Enrichment"},
+			},
+			{
+				// The résumé-verdict wire shape (Verdict + Skill). Self-contained —
+				// only primitives and []Skill, no cross-package references.
+				Path:         "github.com/strelov1/freehire/internal/verdict",
+				OutputPath:   verdictTS,
+				IncludeFiles: []string{"verdict.go"},
 			},
 		},
 	}
@@ -89,7 +97,11 @@ func genStructs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return enrichBody + "\n" + jobviewBody, nil
+	verdictBody, err := readBody(verdictTS)
+	if err != nil {
+		return "", err
+	}
+	return enrichBody + "\n" + jobviewBody + "\n" + verdictBody, nil
 }
 
 // readBody returns a tygo output file's body with its leading preamble removed, so

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/handler"
+	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/search"
 )
 
@@ -70,6 +71,18 @@ func main() {
 		searchClient = search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
 	}
 
+	// The LLM is optional: only when all three settings are present do we build a
+	// client for the résumé-verdict coherence analysis. Absent it, the client stays
+	// nil and the verdict serves its deterministic core (no coherence). A build error
+	// on a configured endpoint is fatal — a misconfigured gateway should not boot silently.
+	var llmClient *llm.Client
+	if cfg.LLMBaseURL != "" && cfg.LLMAPIKey != "" && cfg.LLMModel != "" {
+		llmClient, err = llm.New(cfg.LLMBaseURL, cfg.LLMAPIKey, cfg.LLMModel)
+		if err != nil {
+			log.Fatalf("llm: %v", err)
+		}
+	}
+
 	// OAuth sign-in is optional: only providers with full credentials are
 	// enabled; the registry may be empty and the server still serves password
 	// auth. Redirect URLs derive from the same-origin frontend origin.
@@ -83,6 +96,7 @@ func main() {
 		CookieSecure:   cfg.CookieSecure,
 		OAuthProviders: oauthProviders,
 		Search:         searchClient,
+		LLM:            llmClient,
 
 		TelegramBotToken:      cfg.TelegramBotToken,
 		TelegramBotUsername:   cfg.TelegramBotUsername,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,15 @@ type Settings struct {
 	MeiliURL string
 	MeiliKey string
 
+	// LLM backs the résumé-verdict coherence analysis on the HTTP server (the enrich
+	// worker reads its own LLM settings via config.Enrich). Optional: any empty field
+	// disables the AI layer — the server builds no LLM client and the verdict still
+	// renders deterministically (enforced at the cmd/server call site, not here).
+	// Provider-agnostic: any OpenAI-compatible endpoint.
+	LLMBaseURL string
+	LLMAPIKey  string
+	LLMModel   string
+
 	// Telegram bot for outbound notifications (filter subscriptions). Optional:
 	// an empty TelegramBotToken disables the feature — the linking endpoints and
 	// webhook are inert and the notify worker has nothing to deliver through.
@@ -71,6 +80,10 @@ func Load() Settings {
 		OAuth:          loadOAuth(),
 		MeiliURL:       env("MEILI_URL", "http://localhost:7700"),
 		MeiliKey:       os.Getenv("MEILI_MASTER_KEY"),
+
+		LLMBaseURL: os.Getenv("LLM_BASE_URL"),
+		LLMAPIKey:  os.Getenv("LLM_API_KEY"),
+		LLMModel:   os.Getenv("LLM_MODEL"),
 
 		TelegramBotToken:      os.Getenv("TELEGRAM_BOT_TOKEN"),
 		TelegramBotUsername:   os.Getenv("TELEGRAM_BOT_USERNAME"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,28 @@ import (
 	"time"
 )
 
+func TestLoad_LLMFromEnv(t *testing.T) {
+	t.Setenv("LLM_BASE_URL", "https://gw.example/v1")
+	t.Setenv("LLM_API_KEY", "key-123")
+	t.Setenv("LLM_MODEL", "some-model")
+
+	s := Load()
+	if s.LLMBaseURL != "https://gw.example/v1" || s.LLMAPIKey != "key-123" || s.LLMModel != "some-model" {
+		t.Errorf("LLM settings = %q/%q/%q, want the env values", s.LLMBaseURL, s.LLMAPIKey, s.LLMModel)
+	}
+}
+
+func TestLoad_LLMEmptyWhenUnset(t *testing.T) {
+	t.Setenv("LLM_BASE_URL", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+
+	s := Load()
+	if s.LLMBaseURL != "" || s.LLMAPIKey != "" || s.LLMModel != "" {
+		t.Errorf("LLM settings should be empty when unset, got %q/%q/%q", s.LLMBaseURL, s.LLMAPIKey, s.LLMModel)
+	}
+}
+
 func TestLoad_JWTSecretFromEnv(t *testing.T) {
 	t.Setenv("JWT_SECRET", "s3cret")
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -137,6 +137,7 @@ type SearchProfile struct {
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
 	Specializations []string           `json:"specializations"`
+	ResumeAnalysis  json.RawMessage    `json:"resume_analysis"`
 }
 
 type Subscription struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -196,6 +196,9 @@ type Querier interface {
 	// or mint a new one. No matching row (wrong id or another user's) returns no row (the
 	// service maps that to ErrNotFound).
 	GetSavedSearch(ctx context.Context, arg GetSavedSearchParams) (SavedSearch, error)
+	// One profile scoped to its owner, so a user can only read their own. No matching row
+	// (wrong id or another user's) returns no row (the handler maps that to 404).
+	GetSearchProfile(ctx context.Context, arg GetSearchProfileParams) (SearchProfile, error)
 	// Load a single submission by id for the review path. The approve/reject flow guards the
 	// status in the service; the Mark* queries are additionally scoped to status='pending' as
 	// defense-in-depth against a concurrent second decision.
@@ -406,6 +409,11 @@ type Querier interface {
 	// author_label is set verbatim (NULL clears it → anonymous). No matching owner-scoped
 	// row returns no row (→ ErrNotFound).
 	SetSavedSearchPublicSlug(ctx context.Context, arg SetSavedSearchPublicSlugParams) (SavedSearch, error)
+	// Persist the derived résumé-analysis JSON (coherence + advice + analyzed_at) on a
+	// profile, scoped to its owner. Never stores the résumé text — only this derived blob.
+	// Does not bump updated_at (the profile's own fields are unchanged). Returns the affected
+	// row count: 0 means missing or not the caller's (the handler maps that to 404).
+	SetSearchProfileResumeAnalysis(ctx context.Context, arg SetSearchProfileResumeAnalysisParams) (int64, error)
 	// Pause/resume a subscription, scoped to its owner. No matching owner-scoped row
 	// returns no row (the handler maps that to 404).
 	SetSubscriptionActive(ctx context.Context, arg SetSubscriptionActiveParams) (Subscription, error)

--- a/internal/db/queries/search_profiles.sql
+++ b/internal/db/queries/search_profiles.sql
@@ -32,6 +32,21 @@ SET name            = COALESCE(sqlc.narg('name'), name),
 WHERE id = sqlc.arg('id') AND user_id = sqlc.arg('user_id')
 RETURNING *;
 
+-- name: GetSearchProfile :one
+-- One profile scoped to its owner, so a user can only read their own. No matching row
+-- (wrong id or another user's) returns no row (the handler maps that to 404).
+SELECT * FROM search_profiles
+WHERE id = $1 AND user_id = $2;
+
+-- name: SetSearchProfileResumeAnalysis :execrows
+-- Persist the derived résumé-analysis JSON (coherence + advice + analyzed_at) on a
+-- profile, scoped to its owner. Never stores the résumé text — only this derived blob.
+-- Does not bump updated_at (the profile's own fields are unchanged). Returns the affected
+-- row count: 0 means missing or not the caller's (the handler maps that to 404).
+UPDATE search_profiles
+SET resume_analysis = $3
+WHERE id = $1 AND user_id = $2;
+
 -- name: DeleteSearchProfile :execrows
 -- Delete a profile, scoped to its owner so a user can only delete their own. Returns
 -- the affected row count: 0 means it does not exist or is not the caller's (the

--- a/internal/db/search_profiles.sql.go
+++ b/internal/db/search_profiles.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -28,7 +29,7 @@ func (q *Queries) CountSearchProfiles(ctx context.Context, userID int64) (int64,
 const createSearchProfile = `-- name: CreateSearchProfile :one
 INSERT INTO search_profiles (user_id, name, specializations, skills)
 VALUES ($1, $2, $3, $4)
-RETURNING id, user_id, name, skills, created_at, updated_at, specializations
+RETURNING id, user_id, name, skills, created_at, updated_at, specializations, resume_analysis
 `
 
 type CreateSearchProfileParams struct {
@@ -57,6 +58,7 @@ func (q *Queries) CreateSearchProfile(ctx context.Context, arg CreateSearchProfi
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Specializations,
+		&i.ResumeAnalysis,
 	)
 	return i, err
 }
@@ -82,8 +84,36 @@ func (q *Queries) DeleteSearchProfile(ctx context.Context, arg DeleteSearchProfi
 	return result.RowsAffected(), nil
 }
 
+const getSearchProfile = `-- name: GetSearchProfile :one
+SELECT id, user_id, name, skills, created_at, updated_at, specializations, resume_analysis FROM search_profiles
+WHERE id = $1 AND user_id = $2
+`
+
+type GetSearchProfileParams struct {
+	ID     int64 `json:"id"`
+	UserID int64 `json:"user_id"`
+}
+
+// One profile scoped to its owner, so a user can only read their own. No matching row
+// (wrong id or another user's) returns no row (the handler maps that to 404).
+func (q *Queries) GetSearchProfile(ctx context.Context, arg GetSearchProfileParams) (SearchProfile, error) {
+	row := q.db.QueryRow(ctx, getSearchProfile, arg.ID, arg.UserID)
+	var i SearchProfile
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.Name,
+		&i.Skills,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Specializations,
+		&i.ResumeAnalysis,
+	)
+	return i, err
+}
+
 const listSearchProfiles = `-- name: ListSearchProfiles :many
-SELECT id, user_id, name, skills, created_at, updated_at, specializations FROM search_profiles
+SELECT id, user_id, name, skills, created_at, updated_at, specializations, resume_analysis FROM search_profiles
 WHERE user_id = $1
 ORDER BY updated_at DESC
 `
@@ -106,6 +136,7 @@ func (q *Queries) ListSearchProfiles(ctx context.Context, userID int64) ([]Searc
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.Specializations,
+			&i.ResumeAnalysis,
 		); err != nil {
 			return nil, err
 		}
@@ -117,6 +148,30 @@ func (q *Queries) ListSearchProfiles(ctx context.Context, userID int64) ([]Searc
 	return items, nil
 }
 
+const setSearchProfileResumeAnalysis = `-- name: SetSearchProfileResumeAnalysis :execrows
+UPDATE search_profiles
+SET resume_analysis = $3
+WHERE id = $1 AND user_id = $2
+`
+
+type SetSearchProfileResumeAnalysisParams struct {
+	ID             int64           `json:"id"`
+	UserID         int64           `json:"user_id"`
+	ResumeAnalysis json.RawMessage `json:"resume_analysis"`
+}
+
+// Persist the derived résumé-analysis JSON (coherence + advice + analyzed_at) on a
+// profile, scoped to its owner. Never stores the résumé text — only this derived blob.
+// Does not bump updated_at (the profile's own fields are unchanged). Returns the affected
+// row count: 0 means missing or not the caller's (the handler maps that to 404).
+func (q *Queries) SetSearchProfileResumeAnalysis(ctx context.Context, arg SetSearchProfileResumeAnalysisParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setSearchProfileResumeAnalysis, arg.ID, arg.UserID, arg.ResumeAnalysis)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateSearchProfile = `-- name: UpdateSearchProfile :one
 UPDATE search_profiles
 SET name            = COALESCE($1, name),
@@ -124,7 +179,7 @@ SET name            = COALESCE($1, name),
     skills          = COALESCE($3, skills),
     updated_at      = now()
 WHERE id = $4 AND user_id = $5
-RETURNING id, user_id, name, skills, created_at, updated_at, specializations
+RETURNING id, user_id, name, skills, created_at, updated_at, specializations, resume_analysis
 `
 
 type UpdateSearchProfileParams struct {
@@ -157,6 +212,7 @@ func (q *Queries) UpdateSearchProfile(ctx context.Context, arg UpdateSearchProfi
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Specializations,
+		&i.ResumeAnalysis,
 	)
 	return i, err
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobtracking"
+	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/moderation"
 	"github.com/strelov1/freehire/internal/report"
 	"github.com/strelov1/freehire/internal/savedsearch"
@@ -23,6 +24,7 @@ import (
 	"github.com/strelov1/freehire/internal/submission"
 	"github.com/strelov1/freehire/internal/subscription"
 	"github.com/strelov1/freehire/internal/telegramnotify"
+	"github.com/strelov1/freehire/internal/verdict"
 )
 
 const (
@@ -76,6 +78,10 @@ type API struct {
 	// delete a named specialization + skills); the handlers translate wire ↔ domain
 	// and delegate to it.
 	searchProfile *searchprofile.Service
+	// verdictAnalyzer runs the LLM coherence analysis for the résumé verdict. Its
+	// client is nil when the LLM is unconfigured; Analyze then degrades to a no-op
+	// and the verdict serves its deterministic core only.
+	verdictAnalyzer *verdict.Analyzer
 	// Telegram notification wiring. All nil/empty when the bot is unconfigured —
 	// the linking endpoints then report the feature off and the webhook is inert.
 	// telegramLinks mints/verifies the deep-link token; telegramBot replies to the
@@ -123,6 +129,9 @@ type Config struct {
 	CookieSecure   bool
 	OAuthProviders map[string]oauth.Provider
 	Search         *search.Client
+	// LLM backs the résumé-verdict coherence analysis. Nil disables the AI layer:
+	// the verdict still renders deterministically (the coherence card is hidden).
+	LLM *llm.Client
 	// Telegram bot for notification linking/delivery confirmations. Optional: an
 	// empty TelegramBotToken disables the feature (linking endpoints report off,
 	// webhook inert). TelegramBotUsername builds the deep link; TelegramWebhookSecret
@@ -160,6 +169,9 @@ func Register(app *fiber.App, cfg Config) {
 	a.savedSearch = savedsearch.New(savedsearch.NewQueriesRepository(queries))
 	a.subscription = subscription.New(subscription.NewQueriesRepository(queries))
 	a.searchProfile = searchprofile.New(searchprofile.NewQueriesRepository(queries))
+	// Nil-safe: NewAnalyzer(nil) yields an analyzer whose Analyze is a no-op, so the
+	// verdict endpoint works whether or not the LLM is configured.
+	a.verdictAnalyzer = verdict.NewAnalyzer(cfg.LLM)
 	// Telegram notifications are enabled only with both a bot token and a JWT
 	// secret (the link token reuses it). Absent either, the linking endpoints
 	// report the feature off and the webhook is inert (see telegramEnabled).
@@ -274,6 +286,11 @@ func Register(app *fiber.App, cfg Config) {
 	api.Post("/me/profiles", saved, a.CreateSearchProfile)
 	api.Patch("/me/profiles/:id", saved, a.UpdateSearchProfile)
 	api.Delete("/me/profiles/:id", saved, a.DeleteSearchProfile)
+	// The résumé verdict is a per-profile sub-resource: GET computes it live, POST
+	// analyzes an uploaded résumé and persists only the derived AI layer. Cookie-only
+	// and owner-scoped, like the profile routes it hangs off.
+	api.Get("/me/profiles/:id/verdict", saved, a.GetResumeVerdict)
+	api.Post("/me/profiles/:id/verdict", saved, a.ResumeVerdict)
 
 	// Resume skill extraction is cookie-only (RequireAuth): it feeds the profile
 	// picker (extracted skills merge into a profile). Stateless — the resume is

--- a/internal/handler/me_profiles_test.go
+++ b/internal/handler/me_profiles_test.go
@@ -24,6 +24,12 @@ type fakeProfileRepo struct {
 	createRet db.SearchProfile
 	updateRet db.SearchProfile
 	updated   db.UpdateSearchProfileParams
+
+	getRet db.SearchProfile
+	getErr error
+
+	setAnalysis    db.SetSearchProfileResumeAnalysisParams
+	setAnalysisErr error
 }
 
 func (f *fakeProfileRepo) List(context.Context, int64) ([]db.SearchProfile, error) {
@@ -38,6 +44,13 @@ func (f *fakeProfileRepo) Update(_ context.Context, p db.UpdateSearchProfilePara
 	return f.updateRet, nil
 }
 func (f *fakeProfileRepo) Delete(context.Context, db.DeleteSearchProfileParams) error { return nil }
+func (f *fakeProfileRepo) Get(_ context.Context, _ db.GetSearchProfileParams) (db.SearchProfile, error) {
+	return f.getRet, f.getErr
+}
+func (f *fakeProfileRepo) SetResumeAnalysis(_ context.Context, p db.SetSearchProfileResumeAnalysisParams) error {
+	f.setAnalysis = p
+	return f.setAnalysisErr
+}
 
 // profilesApp mounts the create/update endpoints behind RequireAuth on a handler whose
 // search-profile service is backed by the given in-memory fake repo.

--- a/internal/handler/resume_verdict.go
+++ b/internal/handler/resume_verdict.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"encoding/json"
+	"log"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/verdict"
+)
+
+// storedAnalysis is the derived résumé-analysis blob persisted on a profile
+// (search_profiles.resume_analysis JSONB): the coherence score, per-gap advice, and
+// when it was produced. The raw résumé text is deliberately never part of it.
+type storedAnalysis struct {
+	Coherence  int               `json:"coherence"`
+	Advice     map[string]string `json:"advice"`
+	AnalyzedAt string            `json:"analyzed_at"`
+}
+
+// GetResumeVerdict serves the résumé verdict for one of the caller's profiles: the
+// deterministic market comparison computed live from the profile's skills +
+// specializations, merged with any previously stored coherence/advice. Cookie-only,
+// owner-scoped (missing/non-owned profile → 404); 503 when search is unconfigured.
+func (a *API) GetResumeVerdict(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := pathID(c)
+	if err != nil {
+		return err
+	}
+
+	profile, err := a.searchProfile.Get(c.Context(), userID, id)
+	if err != nil {
+		return searchProfileError(err)
+	}
+
+	v, err := a.computeVerdict(c, profile)
+	if err != nil {
+		return err
+	}
+	applyStoredAnalysis(&v, profile.ResumeAnalysis)
+	return c.JSON(fiber.Map{"data": v})
+}
+
+// ResumeVerdict analyzes an uploaded résumé (PDF multipart "file" or JSON {text})
+// against one of the caller's profiles: it computes the deterministic verdict, asks the
+// LLM for a coherence score + gap advice over the résumé text, persists ONLY that
+// derived analysis (never the text — the privacy invariant from resume.go), and returns
+// the full verdict. Best-effort AI: an unconfigured or failing model degrades to the
+// deterministic verdict (still 200). Cookie-only, owner-scoped.
+func (a *API) ResumeVerdict(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := pathID(c)
+	if err != nil {
+		return err
+	}
+
+	profile, err := a.searchProfile.Get(c.Context(), userID, id)
+	if err != nil {
+		return searchProfileError(err)
+	}
+
+	text, err := resumeText(c)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(text) == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "resume is empty")
+	}
+
+	v, err := a.computeVerdict(c, profile)
+	if err != nil {
+		return err
+	}
+
+	analysis, err := a.verdictAnalyzer.Analyze(c.Context(), text, v.MustHaveGaps())
+	if err != nil {
+		// Best-effort: log the error (never the résumé text) and serve the deterministic
+		// verdict. The AI layer is an enhancement, not a gate.
+		log.Printf("verdict: résumé analysis failed for profile %d: %v", id, err)
+		return c.JSON(fiber.Map{"data": v})
+	}
+	if analysis != nil {
+		blob, err := json.Marshal(storedAnalysis{
+			Coherence:  analysis.Coherence,
+			Advice:     analysis.Advice,
+			AnalyzedAt: time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			return err
+		}
+		if err := a.searchProfile.SetResumeAnalysis(c.Context(), userID, id, blob); err != nil {
+			return searchProfileError(err)
+		}
+		applyStoredAnalysis(&v, blob)
+	}
+	return c.JSON(fiber.Map{"data": v})
+}
+
+// computeVerdict builds the deterministic verdict from a profile's skills against the
+// market facet distribution for its specialization(s). 503 when search is unconfigured
+// — the market data is the verdict's one hard dependency.
+func (a *API) computeVerdict(c *fiber.Ctx, profile db.SearchProfile) (verdict.Verdict, error) {
+	if a.facets == nil {
+		return verdict.Verdict{}, fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
+	}
+	filter := search.FilterFromValues(url.Values{"category": profile.Specializations})
+	res, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
+		Filter: filter,
+		Facets: []string{"skills"},
+	})
+	if err != nil {
+		return verdict.Verdict{}, err
+	}
+	market := verdict.MarketSkills{Counts: res.Facets["skills"], Total: res.Total}
+	return verdict.Compute(market, profile.Skills), nil
+}
+
+// applyStoredAnalysis merges a persisted analysis blob into a verdict: the coherence
+// score, the analysis timestamp, and advice attached to matching skill rows. A nil,
+// empty, or unparseable blob leaves the verdict deterministic-only.
+func applyStoredAnalysis(v *verdict.Verdict, blob json.RawMessage) {
+	if len(blob) == 0 {
+		return
+	}
+	var stored storedAnalysis
+	if err := json.Unmarshal(blob, &stored); err != nil {
+		return
+	}
+	coherence := stored.Coherence
+	v.Coherence = &coherence
+	if stored.AnalyzedAt != "" {
+		at := stored.AnalyzedAt
+		v.AnalyzedAt = &at
+	}
+	for i := range v.Skills {
+		if adv, ok := stored.Advice[v.Skills[i].Name]; ok && adv != "" {
+			text := adv
+			v.Skills[i].Advice = &text
+		}
+	}
+}

--- a/internal/handler/resume_verdict_test.go
+++ b/internal/handler/resume_verdict_test.go
@@ -1,0 +1,228 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/llm"
+	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/searchprofile"
+	"github.com/strelov1/freehire/internal/verdict"
+)
+
+var errBoom = errors.New("boom")
+
+// fakeLLM is a stub llms.Model returning a canned JSON response.
+type fakeLLM struct {
+	resp string
+	err  error
+}
+
+func (f fakeLLM) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: f.resp}}}, nil
+}
+func (fakeLLM) Call(context.Context, string, ...llms.CallOption) (string, error) { return "", nil }
+
+// verdictApp mounts the GET/POST verdict routes on a handler backed by the given
+// fakes. analyzer may wrap a nil client (LLM off) or a fake model.
+func verdictApp(t *testing.T, repo *fakeProfileRepo, fc facetCounter, analyzer *verdict.Analyzer) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &API{issuer: iss, searchProfile: searchprofile.New(repo), facets: fc, verdictAnalyzer: analyzer}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/me/profiles/:id/verdict", auth.RequireAuth(iss), h.GetResumeVerdict)
+	app.Post("/me/profiles/:id/verdict", auth.RequireAuth(iss), h.ResumeVerdict)
+	return app, token
+}
+
+// marketFacets is a canned skills distribution: go 60%, python 50% (both must-have),
+// docker 30% (a non-must-have gap). Total 100.
+func marketFacets() *fakeFacetCounter {
+	return &fakeFacetCounter{res: search.FacetResult{
+		Total:  100,
+		Facets: map[string]map[string]int64{"skills": {"go": 60, "python": 50, "docker": 30}},
+	}}
+}
+
+func ownedProfile() *fakeProfileRepo {
+	return &fakeProfileRepo{getRet: db.SearchProfile{
+		ID: 5, UserID: 1, Specializations: []string{"backend"}, Skills: []string{"go"},
+	}}
+}
+
+func doVerdict(t *testing.T, app *fiber.App, method, target, body, token string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set("Content-Type", fiber.MIMEApplicationJSON)
+	}
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
+}
+
+func dataOf(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	d, ok := body["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("response has no data object: %v", body)
+	}
+	return d
+}
+
+func TestGetVerdict_FacetsUnconfigured503(t *testing.T) {
+	app, token := verdictApp(t, ownedProfile(), nil, verdict.NewAnalyzer(nil))
+	status, _ := doVerdict(t, app, fiber.MethodGet, "/me/profiles/5/verdict", "", token)
+	if status != fiber.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", status)
+	}
+}
+
+func TestGetVerdict_ProfileNotFound404(t *testing.T) {
+	repo := &fakeProfileRepo{getErr: searchprofile.ErrNotFound}
+	app, token := verdictApp(t, repo, marketFacets(), verdict.NewAnalyzer(nil))
+	status, _ := doVerdict(t, app, fiber.MethodGet, "/me/profiles/999/verdict", "", token)
+	if status != fiber.StatusNotFound {
+		t.Fatalf("status = %d, want 404", status)
+	}
+}
+
+func TestGetVerdict_DeterministicNoAnalysis(t *testing.T) {
+	app, token := verdictApp(t, ownedProfile(), marketFacets(), verdict.NewAnalyzer(nil))
+	status, body := doVerdict(t, app, fiber.MethodGet, "/me/profiles/5/verdict", "", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	d := dataOf(t, body)
+	// go covered of {go,python,docker} → 33%.
+	if d["stack_match"].(float64) != 33 {
+		t.Errorf("stack_match = %v, want 33", d["stack_match"])
+	}
+	if len(d["skills"].([]any)) != 3 {
+		t.Errorf("skills len = %d, want 3", len(d["skills"].([]any)))
+	}
+	if _, ok := d["coherence"]; ok {
+		t.Errorf("coherence should be omitted without analysis, got %v", d["coherence"])
+	}
+}
+
+func TestGetVerdict_MergesStoredAnalysis(t *testing.T) {
+	repo := ownedProfile()
+	repo.getRet.ResumeAnalysis = []byte(`{"coherence":88,"advice":{"python":"Show a Python service."},"analyzed_at":"2026-01-01T00:00:00Z"}`)
+	app, token := verdictApp(t, repo, marketFacets(), verdict.NewAnalyzer(nil))
+	status, body := doVerdict(t, app, fiber.MethodGet, "/me/profiles/5/verdict", "", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	d := dataOf(t, body)
+	if d["coherence"].(float64) != 88 {
+		t.Errorf("coherence = %v, want 88", d["coherence"])
+	}
+	// python is a must-have gap → advice attached.
+	for _, s := range d["skills"].([]any) {
+		sk := s.(map[string]any)
+		if sk["name"] == "python" && sk["advice"] == nil {
+			t.Errorf("python gap should carry stored advice")
+		}
+	}
+}
+
+func TestPostVerdict_EmptyText400(t *testing.T) {
+	app, token := verdictApp(t, ownedProfile(), marketFacets(), verdict.NewAnalyzer(nil))
+	status, _ := doVerdict(t, app, fiber.MethodPost, "/me/profiles/5/verdict", `{"text":"   "}`, token)
+	if status != fiber.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+}
+
+func TestPostVerdict_LLMUnconfiguredDegrades(t *testing.T) {
+	repo := ownedProfile()
+	app, token := verdictApp(t, repo, marketFacets(), verdict.NewAnalyzer(nil))
+	status, body := doVerdict(t, app, fiber.MethodPost, "/me/profiles/5/verdict", `{"text":"my resume"}`, token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	d := dataOf(t, body)
+	if _, ok := d["coherence"]; ok {
+		t.Errorf("coherence should be omitted when LLM is off")
+	}
+	if repo.setAnalysis.ResumeAnalysis != nil {
+		t.Errorf("nothing should be persisted when LLM is off")
+	}
+}
+
+func TestPostVerdict_AnalyzesAndPersists(t *testing.T) {
+	repo := ownedProfile()
+	model := fakeLLM{resp: `{"coherence":77,"advice":{"python":"Ship a Python project and quantify impact."}}`}
+	analyzer := verdict.NewAnalyzer(llm.NewWithModel(model))
+	app, token := verdictApp(t, repo, marketFacets(), analyzer)
+
+	status, body := doVerdict(t, app, fiber.MethodPost, "/me/profiles/5/verdict", `{"text":"my resume text"}`, token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	d := dataOf(t, body)
+	if d["coherence"].(float64) != 77 {
+		t.Errorf("coherence = %v, want 77", d["coherence"])
+	}
+	if repo.setAnalysis.ResumeAnalysis == nil {
+		t.Fatalf("derived analysis should be persisted")
+	}
+	if !strings.Contains(string(repo.setAnalysis.ResumeAnalysis), "coherence") {
+		t.Errorf("persisted blob should contain coherence, got %s", repo.setAnalysis.ResumeAnalysis)
+	}
+}
+
+func TestPostVerdict_LLMErrorDegrades(t *testing.T) {
+	repo := ownedProfile()
+	// LLM configured but the call errors: the verdict still renders deterministically
+	// (200, no coherence) and nothing is persisted.
+	analyzer := verdict.NewAnalyzer(llm.NewWithModel(fakeLLM{err: errBoom}))
+	app, token := verdictApp(t, repo, marketFacets(), analyzer)
+
+	status, body := doVerdict(t, app, fiber.MethodPost, "/me/profiles/5/verdict", `{"text":"my resume"}`, token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200 (degraded)", status)
+	}
+	if _, ok := dataOf(t, body)["coherence"]; ok {
+		t.Errorf("coherence should be omitted when the LLM errors")
+	}
+	if repo.setAnalysis.ResumeAnalysis != nil {
+		t.Errorf("nothing should be persisted when the LLM errors")
+	}
+}
+
+func TestPostVerdict_ProfileNotFound404(t *testing.T) {
+	repo := &fakeProfileRepo{getErr: searchprofile.ErrNotFound}
+	app, token := verdictApp(t, repo, marketFacets(), verdict.NewAnalyzer(nil))
+	status, _ := doVerdict(t, app, fiber.MethodPost, "/me/profiles/999/verdict", `{"text":"r"}`, token)
+	if status != fiber.StatusNotFound {
+		t.Fatalf("status = %d, want 404", status)
+	}
+}

--- a/internal/searchprofile/repository.go
+++ b/internal/searchprofile/repository.go
@@ -77,6 +77,32 @@ func (r *QueriesRepository) Delete(ctx context.Context, p db.DeleteSearchProfile
 	return nil
 }
 
+// Get returns a profile scoped to its owner, mapping no matching row (wrong id or another
+// user's) to ErrNotFound.
+func (r *QueriesRepository) Get(ctx context.Context, p db.GetSearchProfileParams) (db.SearchProfile, error) {
+	row, err := r.q.GetSearchProfile(ctx, p)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return db.SearchProfile{}, ErrNotFound
+	}
+	if err != nil {
+		return db.SearchProfile{}, err
+	}
+	return row, nil
+}
+
+// SetResumeAnalysis persists the derived analysis blob scoped to the owner, mapping
+// "no row affected" (missing or non-owned) to ErrNotFound.
+func (r *QueriesRepository) SetResumeAnalysis(ctx context.Context, p db.SetSearchProfileResumeAnalysisParams) error {
+	affected, err := r.q.SetSearchProfileResumeAnalysis(ctx, p)
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // isUniqueViolation reports whether err is a Postgres unique-constraint violation (23505).
 func isUniqueViolation(err error) bool {
 	var pgErr *pgconn.PgError

--- a/internal/searchprofile/searchprofile.go
+++ b/internal/searchprofile/searchprofile.go
@@ -9,6 +9,7 @@ package searchprofile
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"slices"
 	"strings"
@@ -63,6 +64,8 @@ type Repository interface {
 	Create(ctx context.Context, p db.CreateSearchProfileParams) (db.SearchProfile, error)
 	Update(ctx context.Context, p db.UpdateSearchProfileParams) (db.SearchProfile, error)
 	Delete(ctx context.Context, p db.DeleteSearchProfileParams) error
+	Get(ctx context.Context, p db.GetSearchProfileParams) (db.SearchProfile, error)
+	SetResumeAnalysis(ctx context.Context, p db.SetSearchProfileResumeAnalysisParams) error
 }
 
 // Service implements the search-profile use cases.
@@ -148,6 +151,23 @@ func (s *Service) Update(ctx context.Context, userID, id int64, name *string, sp
 // ErrNotFound (mapped by the repository).
 func (s *Service) Delete(ctx context.Context, userID, id int64) error {
 	return s.repo.Delete(ctx, db.DeleteSearchProfileParams{ID: id, UserID: userID})
+}
+
+// Get returns one of the user's profiles by id, scoped to its owner. A missing or
+// non-owned row surfaces as ErrNotFound (mapped by the repository).
+func (s *Service) Get(ctx context.Context, userID, id int64) (db.SearchProfile, error) {
+	return s.repo.Get(ctx, db.GetSearchProfileParams{ID: id, UserID: userID})
+}
+
+// SetResumeAnalysis persists the derived résumé-analysis JSON on one of the user's
+// profiles, scoped to its owner. The blob is the coherence score + advice + timestamp
+// only — never the résumé text. A missing or non-owned row surfaces as ErrNotFound.
+func (s *Service) SetResumeAnalysis(ctx context.Context, userID, id int64, analysis json.RawMessage) error {
+	return s.repo.SetResumeAnalysis(ctx, db.SetSearchProfileResumeAnalysisParams{
+		ID:             id,
+		UserID:         userID,
+		ResumeAnalysis: analysis,
+	})
 }
 
 // validName trims the name and enforces the 1..maxNameLen bound (counted in runes, to

--- a/internal/searchprofile/searchprofile_test.go
+++ b/internal/searchprofile/searchprofile_test.go
@@ -30,7 +30,25 @@ type fakeRepo struct {
 	deleteCalled bool
 	deleteErr    error
 
+	getParams db.GetSearchProfileParams
+	getRet    db.SearchProfile
+	getErr    error
+
+	setAnalysis       db.SetSearchProfileResumeAnalysisParams
+	setAnalysisCalled bool
+	setAnalysisErr    error
+
 	listRet []db.SearchProfile
+}
+
+func (f *fakeRepo) Get(_ context.Context, p db.GetSearchProfileParams) (db.SearchProfile, error) {
+	f.getParams = p
+	return f.getRet, f.getErr
+}
+
+func (f *fakeRepo) SetResumeAnalysis(_ context.Context, p db.SetSearchProfileResumeAnalysisParams) error {
+	f.setAnalysis, f.setAnalysisCalled = p, true
+	return f.setAnalysisErr
 }
 
 func (f *fakeRepo) List(_ context.Context, _ int64) ([]db.SearchProfile, error) {
@@ -339,6 +357,54 @@ func TestDelete_ScopedToOwner(t *testing.T) {
 func TestDelete_NotFound(t *testing.T) {
 	repo := &fakeRepo{deleteErr: searchprofile.ErrNotFound}
 	err := searchprofile.New(repo).Delete(context.Background(), 7, 999)
+	if !errors.Is(err, searchprofile.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestGet_ScopedToOwner(t *testing.T) {
+	repo := &fakeRepo{getRet: db.SearchProfile{ID: 5}}
+	got, err := searchprofile.New(repo).Get(context.Background(), 7, 5)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != 5 {
+		t.Errorf("got profile id %d, want 5", got.ID)
+	}
+	if repo.getParams.ID != 5 || repo.getParams.UserID != 7 {
+		t.Errorf("get scope = id %d user %d, want id 5 user 7", repo.getParams.ID, repo.getParams.UserID)
+	}
+}
+
+func TestGet_NotFound(t *testing.T) {
+	repo := &fakeRepo{getErr: searchprofile.ErrNotFound}
+	_, err := searchprofile.New(repo).Get(context.Background(), 7, 999)
+	if !errors.Is(err, searchprofile.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSetResumeAnalysis_ScopedToOwner(t *testing.T) {
+	repo := &fakeRepo{}
+	blob := []byte(`{"coherence":80}`)
+	err := searchprofile.New(repo).SetResumeAnalysis(context.Background(), 7, 5, blob)
+	if err != nil {
+		t.Fatalf("SetResumeAnalysis: %v", err)
+	}
+	if !repo.setAnalysisCalled {
+		t.Fatal("repo.SetResumeAnalysis not called")
+	}
+	if repo.setAnalysis.ID != 5 || repo.setAnalysis.UserID != 7 {
+		t.Errorf("set scope = id %d user %d, want id 5 user 7", repo.setAnalysis.ID, repo.setAnalysis.UserID)
+	}
+	if string(repo.setAnalysis.ResumeAnalysis) != string(blob) {
+		t.Errorf("stored analysis = %s, want %s", repo.setAnalysis.ResumeAnalysis, blob)
+	}
+}
+
+func TestSetResumeAnalysis_NotFound(t *testing.T) {
+	repo := &fakeRepo{setAnalysisErr: searchprofile.ErrNotFound}
+	err := searchprofile.New(repo).SetResumeAnalysis(context.Background(), 7, 999, []byte(`{}`))
 	if !errors.Is(err, searchprofile.ErrNotFound) {
 		t.Errorf("err = %v, want ErrNotFound", err)
 	}

--- a/internal/verdict/coherence.go
+++ b/internal/verdict/coherence.go
@@ -1,0 +1,121 @@
+package verdict
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/llm"
+)
+
+const (
+	// maxResumeRunes bounds the résumé text sent to the model. The text is
+	// user-supplied, so capping it keeps one huge upload from amplifying token cost
+	// (mirrors enrich's maxDescriptionRunes).
+	maxResumeRunes = 24000
+
+	// maxAdviceRunes bounds each advice string, so a verbose model can't blow up the
+	// stored/served payload.
+	maxAdviceRunes = 280
+)
+
+// Analyzer runs the single LLM call that scores résumé coherence and drafts gap
+// advice. A nil client (LLM unconfigured) makes Analyze a no-op so the caller
+// degrades to the deterministic verdict.
+type Analyzer struct {
+	client *llm.Client
+}
+
+// NewAnalyzer wraps an llm.Client. client may be nil (LLM unconfigured).
+func NewAnalyzer(client *llm.Client) *Analyzer {
+	return &Analyzer{client: client}
+}
+
+// Analysis is the LLM's structured answer: a coherence score and advice keyed by
+// skill slug.
+type Analysis struct {
+	Coherence int               `json:"coherence"`
+	Advice    map[string]string `json:"advice"`
+}
+
+// Analyze asks the model, over the résumé text, for a coherence score (0-100) and
+// short advice for each of the given must-have gap slugs. It clamps the score to
+// 0-100, drops advice for any slug not in gaps, and truncates advice length.
+// Returns (nil, nil) when the analyzer is unconfigured so callers can degrade.
+func (a *Analyzer) Analyze(ctx context.Context, resume string, gaps []string) (*Analysis, error) {
+	if a == nil || a.client == nil {
+		return nil, nil
+	}
+
+	raw, err := a.client.GenerateJSON(ctx, buildCoherencePrompt(), userPrompt(resume, gaps))
+	if err != nil {
+		return nil, fmt.Errorf("verdict: analyze: %w", err)
+	}
+
+	var out Analysis
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &out); err != nil {
+		return nil, fmt.Errorf("verdict: parse analysis: %w", err)
+	}
+
+	out.sanitize(gaps)
+	return &out, nil
+}
+
+// sanitize clamps the coherence score and keeps only advice for the requested
+// gap slugs, each length-bounded. Defensive: the model is untrusted output.
+func (an *Analysis) sanitize(gaps []string) {
+	an.Coherence = clamp(an.Coherence, 0, 100)
+
+	allowed := make(map[string]bool, len(gaps))
+	for _, g := range gaps {
+		allowed[g] = true
+	}
+	cleaned := make(map[string]string, len(an.Advice))
+	for slug, text := range an.Advice {
+		text = strings.TrimSpace(text)
+		if text == "" || !allowed[slug] {
+			continue
+		}
+		cleaned[slug] = llm.TruncateRunes(text, maxAdviceRunes)
+	}
+	an.Advice = cleaned
+}
+
+func clamp(n, lo, hi int) int {
+	if n < lo {
+		return lo
+	}
+	if n > hi {
+		return hi
+	}
+	return n
+}
+
+// buildCoherencePrompt is the system prompt pinning the JSON contract. Kept as a
+// function (not a const) to mirror enrich's testable buildSystemPrompt.
+func buildCoherencePrompt() string {
+	var b strings.Builder
+	b.WriteString("You are a technical résumé reviewer. You receive the plain text of a candidate's ")
+	b.WriteString("résumé and a list of target skill slugs. Return ONLY a JSON object.\n\n")
+	b.WriteString("Return exactly these keys:\n")
+	b.WriteString("- \"coherence\": integer 0-100. How well the skills the candidate CLAIMS (in a ")
+	b.WriteString("Skills/Technologies section) are actually substantiated by concrete evidence in ")
+	b.WriteString("their Experience/Projects (real usage, outcomes, numbers). 100 = every claimed ")
+	b.WriteString("skill is backed by experience; low = buzzword stuffing with no backing.\n")
+	b.WriteString("- \"advice\": an object mapping each target slug (use the EXACT slug given) to ONE ")
+	b.WriteString("short sentence of concrete, actionable advice on how to close that gap and evidence ")
+	b.WriteString("it in Experience. Include a key only for a slug you were given; omit slugs you have ")
+	b.WriteString("no useful advice for.\n\n")
+	b.WriteString("Do not invent skills. Do not include any key other than \"coherence\" and \"advice\". ")
+	b.WriteString("Base every judgement only on the résumé text provided.\n")
+	return b.String()
+}
+
+// userPrompt carries the target gap slugs and the (bounded) résumé text.
+func userPrompt(resume string, gaps []string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Target skills to advise on (use these exact slugs as keys): %s\n\n", strings.Join(gaps, ", "))
+	fmt.Fprintf(&b, "Résumé:\n%s\n", llm.TruncateRunes(resume, maxResumeRunes))
+	return b.String()
+}

--- a/internal/verdict/coherence_test.go
+++ b/internal/verdict/coherence_test.go
@@ -1,0 +1,151 @@
+package verdict
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/llm"
+)
+
+// fakeModel is a stub llms.Model returning a canned response (or error).
+type fakeModel struct {
+	resp string
+	err  error
+}
+
+func (f fakeModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: f.resp}}}, nil
+}
+func (fakeModel) Call(context.Context, string, ...llms.CallOption) (string, error) { return "", nil }
+
+func analyzerFor(resp string, err error) *Analyzer {
+	return NewAnalyzer(llm.NewWithModel(fakeModel{resp: resp, err: err}))
+}
+
+func TestAnalyze_NilClientDegrades(t *testing.T) {
+	a := NewAnalyzer(nil)
+	got, err := a.Analyze(context.Background(), "résumé", []string{"go"})
+	if err != nil || got != nil {
+		t.Fatalf("nil client should degrade to (nil, nil), got (%v, %v)", got, err)
+	}
+}
+
+func TestAnalyze_ValidResponse(t *testing.T) {
+	resp := `{"coherence": 82, "advice": {"go": "Show a Go service in Experience."}}`
+	a := analyzerFor(resp, nil)
+	got, err := a.Analyze(context.Background(), "résumé text", []string{"go"})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if got.Coherence != 82 {
+		t.Errorf("coherence = %d, want 82", got.Coherence)
+	}
+	if got.Advice["go"] == "" {
+		t.Errorf("advice for go should be present")
+	}
+}
+
+func TestAnalyze_ClampsCoherence(t *testing.T) {
+	for _, tc := range []struct {
+		in   int
+		want int
+	}{{150, 100}, {-5, 0}, {100, 100}, {0, 0}} {
+		a := analyzerFor(`{"coherence": `+itoa(tc.in)+`, "advice": {}}`, nil)
+		got, err := a.Analyze(context.Background(), "r", nil)
+		if err != nil {
+			t.Fatalf("Analyze: %v", err)
+		}
+		if got.Coherence != tc.want {
+			t.Errorf("coherence(%d) = %d, want %d", tc.in, got.Coherence, tc.want)
+		}
+	}
+}
+
+func TestAnalyze_DropsAdviceOutsideGaps(t *testing.T) {
+	resp := `{"coherence": 50, "advice": {"go": "keep", "python": "drop — not a gap"}}`
+	a := analyzerFor(resp, nil)
+	got, err := a.Analyze(context.Background(), "r", []string{"go"})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if _, ok := got.Advice["python"]; ok {
+		t.Errorf("advice for a non-gap skill must be dropped: %v", got.Advice)
+	}
+	if got.Advice["go"] == "" {
+		t.Errorf("advice for the requested gap must survive")
+	}
+}
+
+func TestAnalyze_TruncatesAdvice(t *testing.T) {
+	long := strings.Repeat("x", maxAdviceRunes+50)
+	resp := `{"coherence": 50, "advice": {"go": "` + long + `"}}`
+	a := analyzerFor(resp, nil)
+	got, err := a.Analyze(context.Background(), "r", []string{"go"})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if n := len([]rune(got.Advice["go"])); n > maxAdviceRunes {
+		t.Errorf("advice length = %d runes, want <= %d", n, maxAdviceRunes)
+	}
+}
+
+func TestAnalyze_MalformedJSONErrors(t *testing.T) {
+	a := analyzerFor("not json", nil)
+	got, err := a.Analyze(context.Background(), "r", []string{"go"})
+	if err == nil || got != nil {
+		t.Fatalf("malformed response should error, got (%v, %v)", got, err)
+	}
+}
+
+func TestAnalyze_ModelErrorPropagates(t *testing.T) {
+	a := analyzerFor("", errors.New("boom"))
+	if _, err := a.Analyze(context.Background(), "r", []string{"go"}); err == nil {
+		t.Fatal("model error should propagate")
+	}
+}
+
+func TestUserPrompt_IncludesGapsAndTruncatesResume(t *testing.T) {
+	sentinel := "SENTINEL_BEYOND_LIMIT"
+	resume := strings.Repeat("a", maxResumeRunes) + sentinel
+	p := userPrompt(resume, []string{"go", "kubernetes"})
+	if !strings.Contains(p, "go") || !strings.Contains(p, "kubernetes") {
+		t.Errorf("prompt must list the gap slugs, got:\n%s", p)
+	}
+	if strings.Contains(p, sentinel) {
+		t.Errorf("résumé must be truncated at maxResumeRunes; sentinel leaked through")
+	}
+}
+
+func TestSystemPrompt_MentionsCoherenceContract(t *testing.T) {
+	p := buildCoherencePrompt()
+	if !strings.Contains(p, "coherence") || !strings.Contains(p, "advice") {
+		t.Errorf("system prompt must state the coherence/advice JSON contract, got:\n%s", p)
+	}
+}
+
+// itoa avoids importing strconv just for the clamp table.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -1,0 +1,144 @@
+// Package verdict computes a résumé "verdict" for a search profile: how the
+// candidate's skills stack up against the most in-demand skills on the live
+// market for their target role(s).
+//
+// The deterministic core (Compute) is pure — it takes the market facet
+// distribution and the candidate's skills and returns the scored breakdown, with
+// no I/O and no LLM. It mirrors the frontend web/src/lib/skillGap.ts so the two
+// never diverge. The optional coherence score and per-gap advice are layered on
+// by the LLM Analyzer (coherence.go); Compute never depends on them.
+package verdict
+
+import (
+	"math"
+	"sort"
+)
+
+const (
+	// TopN is how many of the market's most in-demand skills define the breakdown
+	// (the "expected" set). Mirrors GAP_TOP_N in skillGap.ts.
+	TopN = 20
+
+	// MustHaveShare is the demand-share cutoff for a "must-have" skill: a skill that
+	// appears in at least this fraction of the role's open postings is treated as a
+	// non-negotiable. Deterministic and self-explanatory in the UI ("asked for by
+	// 40%+ of postings"); tunable in one place. Calibrate against real facet data.
+	MustHaveShare = 0.40
+)
+
+// MarketSkills is the facet distribution for a role: canonical skill slug → count
+// of open postings that list it, plus Total open postings in the role (the
+// denominator for the demand share and the unlock percentage).
+type MarketSkills struct {
+	Counts map[string]int64
+	Total  int64
+}
+
+// Verdict is the full result. Coherence/AnalyzedAt are set only when an LLM
+// analysis is present (see coherence.go); nil renders no coherence card. JSON is
+// the wire contract shared with the frontend (generated to TS via cmd/gen-contracts).
+type Verdict struct {
+	StackMatch      int     `json:"stack_match"`      // 0-100: share of the top-N the candidate has
+	MustHaveCovered int     `json:"must_have_covered"`
+	MustHaveTotal   int     `json:"must_have_total"`
+	Coherence       *int    `json:"coherence,omitempty"`   // 0-100, LLM-derived
+	AnalyzedAt      *string `json:"analyzed_at,omitempty"` // RFC3339, when the résumé was last analyzed
+	Skills          []Skill `json:"skills"`                // exactly the top-N, in demand order
+}
+
+// Skill is one row of the breakdown.
+type Skill struct {
+	Rank     int     `json:"rank"`
+	Name     string  `json:"name"`             // canonical slug; the UI humanizes it
+	MustHave bool    `json:"must_have"`
+	Have     bool    `json:"have"`
+	Unlock   *int    `json:"unlock,omitempty"` // gaps only: % of the role's postings this skill touches
+	Advice   *string `json:"advice,omitempty"` // LLM-derived, attached to must-have gaps when available
+}
+
+// Compute builds the deterministic core of a verdict: the top-N market skills for
+// the role (demand order, count desc then slug asc for a stable tiebreak), which
+// the candidate covers, the stack-match %, the must-have set, and the per-gap
+// unlock %. Pure and I/O-free.
+func Compute(market MarketSkills, candidate []string) Verdict {
+	ranked := rankByDemand(market.Counts)
+	if len(ranked) > TopN {
+		ranked = ranked[:TopN]
+	}
+
+	owned := make(map[string]bool, len(candidate))
+	for _, s := range candidate {
+		owned[s] = true
+	}
+
+	skills := make([]Skill, 0, len(ranked))
+	have, mustTotal, mustCovered := 0, 0, 0
+	for i, e := range ranked {
+		share := 0.0
+		if market.Total > 0 {
+			share = float64(e.count) / float64(market.Total)
+		}
+		mustHave := share >= MustHaveShare
+		has := owned[e.slug]
+
+		row := Skill{Rank: i + 1, Name: e.slug, MustHave: mustHave, Have: has}
+		if has {
+			have++
+		} else {
+			unlock := int(math.Round(share * 100))
+			row.Unlock = &unlock
+		}
+		if mustHave {
+			mustTotal++
+			if has {
+				mustCovered++
+			}
+		}
+		skills = append(skills, row)
+	}
+
+	stack := 0
+	if len(ranked) > 0 {
+		stack = int(math.Round(float64(have) / float64(len(ranked)) * 100))
+	}
+
+	return Verdict{
+		StackMatch:      stack,
+		MustHaveCovered: mustCovered,
+		MustHaveTotal:   mustTotal,
+		Skills:          skills,
+	}
+}
+
+// MustHaveGaps returns the slugs of the must-have skills the candidate lacks, in
+// demand order — the set worth asking the LLM to advise on.
+func (v Verdict) MustHaveGaps() []string {
+	var gaps []string
+	for _, s := range v.Skills {
+		if s.MustHave && !s.Have {
+			gaps = append(gaps, s.Name)
+		}
+	}
+	return gaps
+}
+
+type skillCount struct {
+	slug  string
+	count int64
+}
+
+// rankByDemand orders a facet distribution by count descending, then slug
+// ascending as a stable tiebreak so the top-N is deterministic across loads.
+func rankByDemand(counts map[string]int64) []skillCount {
+	ranked := make([]skillCount, 0, len(counts))
+	for slug, count := range counts {
+		ranked = append(ranked, skillCount{slug: slug, count: count})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].count != ranked[j].count {
+			return ranked[i].count > ranked[j].count
+		}
+		return ranked[i].slug < ranked[j].slug
+	})
+	return ranked
+}

--- a/internal/verdict/verdict_test.go
+++ b/internal/verdict/verdict_test.go
@@ -1,0 +1,176 @@
+package verdict
+
+import (
+	"reflect"
+	"testing"
+)
+
+// intptr is a test helper for the optional *int fields.
+func intptr(n int) *int { return &n }
+
+func TestCompute_RanksByDemandWithSlugTiebreak(t *testing.T) {
+	market := MarketSkills{
+		Counts: map[string]int64{"go": 10, "python": 10, "rust": 5},
+		Total:  100,
+	}
+	v := Compute(market, nil)
+
+	// Equal counts (go, python) break ties by ascending slug → go before python.
+	got := []string{v.Skills[0].Name, v.Skills[1].Name, v.Skills[2].Name}
+	want := []string{"go", "python", "rust"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("rank order = %v, want %v", got, want)
+	}
+	for i, s := range v.Skills {
+		if s.Rank != i+1 {
+			t.Errorf("skill %q rank = %d, want %d", s.Name, s.Rank, i+1)
+		}
+	}
+}
+
+func TestCompute_TruncatesToTopN(t *testing.T) {
+	counts := make(map[string]int64, TopN+5)
+	for i := 0; i < TopN+5; i++ {
+		// Distinct counts so ordering is unambiguous.
+		counts[string(rune('a'+i))] = int64(100 - i)
+	}
+	v := Compute(MarketSkills{Counts: counts, Total: 1000}, nil)
+	if len(v.Skills) != TopN {
+		t.Fatalf("len(skills) = %d, want %d", len(v.Skills), TopN)
+	}
+}
+
+func TestCompute_StackMatchAndCoverage(t *testing.T) {
+	// 4 market skills, candidate has 1 → 25%.
+	market := MarketSkills{
+		Counts: map[string]int64{"go": 40, "python": 30, "sql": 20, "rust": 10},
+		Total:  100,
+	}
+	v := Compute(market, []string{"python"})
+	if v.StackMatch != 25 {
+		t.Errorf("StackMatch = %d, want 25", v.StackMatch)
+	}
+	for _, s := range v.Skills {
+		if s.Name == "python" && !s.Have {
+			t.Errorf("python should be Have")
+		}
+		if s.Name == "go" && s.Have {
+			t.Errorf("go should not be Have")
+		}
+	}
+}
+
+func TestCompute_FewerThanTopNDenominator(t *testing.T) {
+	// Only 8 skills; candidate has 2 → round(2/8*100) = 25.
+	counts := map[string]int64{}
+	for i := 0; i < 8; i++ {
+		counts[string(rune('a'+i))] = int64(100 - i)
+	}
+	v := Compute(MarketSkills{Counts: counts, Total: 1000}, []string{"a", "b"})
+	if len(v.Skills) != 8 {
+		t.Fatalf("len(skills) = %d, want 8", len(v.Skills))
+	}
+	if v.StackMatch != 25 {
+		t.Errorf("StackMatch = %d, want 25 (2/8)", v.StackMatch)
+	}
+}
+
+func TestCompute_UnlockOnGapsOnly(t *testing.T) {
+	// go: 340/1000 = 34%. Candidate lacks go → unlock 34; python owned → no unlock.
+	market := MarketSkills{
+		Counts: map[string]int64{"go": 340, "python": 500},
+		Total:  1000,
+	}
+	v := Compute(market, []string{"python"})
+	byName := map[string]Skill{}
+	for _, s := range v.Skills {
+		byName[s.Name] = s
+	}
+	if got := byName["go"]; got.Have || got.Unlock == nil || *got.Unlock != 34 {
+		t.Errorf("go = %+v, want Have=false Unlock=34", got)
+	}
+	if got := byName["python"]; !got.Have || got.Unlock != nil {
+		t.Errorf("python = %+v, want Have=true Unlock=nil", got)
+	}
+}
+
+func TestCompute_MustHaveShareBoundary(t *testing.T) {
+	// at: exactly 40% → must-have; below: 39% → not.
+	market := MarketSkills{
+		Counts: map[string]int64{"at": 400, "below": 390},
+		Total:  1000,
+	}
+	v := Compute(market, nil)
+	byName := map[string]Skill{}
+	for _, s := range v.Skills {
+		byName[s.Name] = s
+	}
+	if !byName["at"].MustHave {
+		t.Errorf("skill at 40%% share should be a must-have")
+	}
+	if byName["below"].MustHave {
+		t.Errorf("skill at 39%% share should not be a must-have")
+	}
+	if v.MustHaveTotal != 1 {
+		t.Errorf("MustHaveTotal = %d, want 1", v.MustHaveTotal)
+	}
+}
+
+func TestCompute_MustHaveCovered(t *testing.T) {
+	market := MarketSkills{
+		Counts: map[string]int64{"go": 600, "python": 500, "sql": 100},
+		Total:  1000,
+	}
+	// go & python are must-haves (>=40%); candidate has go only.
+	v := Compute(market, []string{"go"})
+	if v.MustHaveTotal != 2 {
+		t.Errorf("MustHaveTotal = %d, want 2", v.MustHaveTotal)
+	}
+	if v.MustHaveCovered != 1 {
+		t.Errorf("MustHaveCovered = %d, want 1", v.MustHaveCovered)
+	}
+}
+
+func TestCompute_EmptyCandidate(t *testing.T) {
+	market := MarketSkills{Counts: map[string]int64{"go": 40, "python": 30}, Total: 100}
+	v := Compute(market, nil)
+	if v.StackMatch != 0 {
+		t.Errorf("StackMatch = %d, want 0", v.StackMatch)
+	}
+	for _, s := range v.Skills {
+		if s.Have {
+			t.Errorf("skill %q should be a gap", s.Name)
+		}
+	}
+}
+
+func TestCompute_ZeroTotalNoPanic(t *testing.T) {
+	// Total 0 must not divide-by-zero; unlock defaults to 0, nothing is a must-have.
+	market := MarketSkills{Counts: map[string]int64{"go": 0, "python": 0}, Total: 0}
+	v := Compute(market, nil)
+	if len(v.Skills) != 2 {
+		t.Fatalf("len(skills) = %d, want 2", len(v.Skills))
+	}
+	for _, s := range v.Skills {
+		if s.MustHave {
+			t.Errorf("no must-haves when total is 0")
+		}
+		if s.Unlock == nil || *s.Unlock != 0 {
+			t.Errorf("unlock = %v, want 0", s.Unlock)
+		}
+	}
+}
+
+func TestVerdict_MustHaveGaps(t *testing.T) {
+	market := MarketSkills{
+		Counts: map[string]int64{"go": 600, "python": 500, "sql": 100},
+		Total:  1000,
+	}
+	// go, python must-haves; candidate has go. Gap = python only.
+	v := Compute(market, []string{"go"})
+	got := v.MustHaveGaps()
+	want := []string{"python"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("MustHaveGaps() = %v, want %v", got, want)
+	}
+}

--- a/migrations/0038_search_profiles_resume_analysis.sql
+++ b/migrations/0038_search_profiles_resume_analysis.sql
@@ -1,0 +1,17 @@
+-- The résumé verdict persists only its derived AI layer on the owning search profile:
+-- a coherence score, per-gap advice, and the analysis timestamp. The raw résumé text is
+-- NEVER stored (the privacy invariant from internal/handler/resume.go) — only this
+-- derived JSON. The deterministic part of the verdict (stack match, gaps, unlock) is
+-- computed live from the profile's skills/specializations, so it is not stored here.
+--
+-- Nullable, no default: a profile with no analysis yet is NULL, backward-compatible with
+-- existing rows. Like every migration here it applies on fresh volume init and is the
+-- schema source for sqlc; existing volumes/prod need a manual apply (the open
+-- versioned-migration-runner seam from AGENT.md) — apply this BEFORE rolling the new
+-- server binary, which references the new column via the profile fetch query.
+
+ALTER TABLE search_profiles
+    ADD COLUMN resume_analysis JSONB;
+
+-- Rollback (inverse), if ever needed:
+--   ALTER TABLE search_profiles DROP COLUMN resume_analysis;

--- a/openspec/changes/resume-verdict/.openspec.yaml
+++ b/openspec/changes/resume-verdict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/resume-verdict/design.md
+++ b/openspec/changes/resume-verdict/design.md
@@ -1,0 +1,60 @@
+## Context
+
+freehire already parses a résumé into canonical skill slugs (`internal/handler/resume.go` → `skilltag.Parse`, text discarded) and shows a per-profile "Market fit" ratio in the web UI (`web/src/lib/skillGap.ts` reading the `/jobs/facets` distribution). The verdict feature promotes that ratio into a full screen and adds an LLM "coherence" read of the résumé. The verdict UI (`web/src/lib/components/VerdictView.svelte`) is already built and styled to the app's flat monochrome theme, currently on mock data.
+
+Key constraints:
+- **Privacy invariant** (from `resume.go`): the raw résumé text is never persisted or logged.
+- **Market facets** are the source of skill demand; the handler already has a `facetCounter` (`FacetCounts(ctx, search.FacetParams)`), the same source `/jobs/facets` uses.
+- **LLM access** is provider-agnostic via `internal/llm` (`New`, `GenerateJSON`, `TruncateRunes`, `NewWithModel` test seam); the HTTP server does not build a client today — only `cmd/enrich` does.
+- **Migrations** apply on fresh volume init only; existing/prod volumes need a manual apply (the open versioned-migration-runner seam).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Serve a per-profile verdict: deterministic market gap (stack match, must-haves, per-gap unlock) computed live from the profile, plus an optional LLM coherence score + gap advice.
+- Persist only the derived AI layer (coherence + advice + `analyzed_at`) so it survives reload, never the résumé text.
+- Degrade gracefully: deterministic verdict always renders; the AI layer is best-effort.
+- One canonical gap computation shared in spirit with `skillGap.ts` (backend `internal/verdict.Compute` is the authority for this feature).
+
+**Non-Goals:**
+- Persisting or re-uploading the résumé text; a refreshed coherence requires a new upload.
+- Classifying skills into stack/methodology (no data source) or humanizing skill slugs beyond what the UI already does.
+- Rate-limiting the LLM endpoint beyond the existing global limiter and input truncation (noted as a follow-up).
+- Changing the existing profile "Market fit" widget or `skillGap.ts`.
+
+## Decisions
+
+**1. Deterministic core in a pure `internal/verdict` package, computed live.**
+`Compute(market MarketSkills, candidate []string) Verdict` is pure (no I/O, no LLM), mirroring `skillGap.ts` (top-20, count-desc/slug-asc sort, coverage, unlock = count/total). It is computed on every read from the profile's saved `skills` + `specializations`, so editing the profile refreshes the verdict without a re-upload. Alternative (persist a full verdict snapshot) rejected: it goes stale when the profile changes and duplicates market data.
+
+**2. Must-have = demand-share threshold.** `MustHave = count/total ≥ MustHaveShare` (constant, start 0.40), self-explanatory in the UI and role-independent. Alternative (top-K by rank) rejected as arbitrary. The constant is calibrated against real facet data during verification.
+
+**3. AI layer is a separate `Analyzer` over `internal/llm`, best-effort, persisted as derived data.** `Analyzer.Analyze(ctx, resumeText, gaps) (*Analysis, error)`; a nil client (LLM unconfigured) returns `(nil, nil)`. One JSON call returns `{coherence:int, advice:{slug:string}}`; the caller clamps coherence to 0-100, drops advice for non-gap slugs, and truncates advice length. On any error the handler swallows it (logs the error, never the text) and serves the deterministic verdict. The derived analysis is stored as `resume_analysis JSONB` on `search_profiles`; the résumé text is used only in-request.
+
+**4. Two endpoints on the profile sub-resource.**
+- `GET /api/v1/me/profiles/:id/verdict` — compute the deterministic verdict live and merge any stored `resume_analysis`.
+- `POST /api/v1/me/profiles/:id/verdict` — parse the uploaded résumé (PDF multipart `file` or JSON `{text}`, reusing `resumeText`/`pdfText` from `resume.go`), run the analyzer, persist the derived analysis, return the full verdict.
+Both `RequireAuth` (cookie-only, matching the other `/me/profiles` routes) and ownership-checked via the `searchprofile` service (missing/other-owner → 404).
+
+**5. Server LLM wiring mirrors the Meili nil-guard.** Add `LLMBaseURL/LLMAPIKey/LLMModel` to the server config; in `cmd/server`, build an `*llm.Client` only when all three are set and pass it into `handler.Config`; `handler.Register` wraps it in `verdict.NewAnalyzer` (nil-safe). No vendor/model hard-coded.
+
+**6. Contract via `cmd/gen-contracts`.** Add `internal/verdict` to the tygo packages so `Verdict`/`Skill` become the TS types the frontend consumes; `VerdictView.svelte` is refactored from mock data to a `verdict` prop of that type.
+
+## Risks / Trade-offs
+
+- **Must-have threshold may yield too few/many must-haves on sparse dictionary tagging** → make it a single tunable constant and calibrate against live facet counts in verification; UI legend states the rule.
+- **LLM latency on an interactive request** (default 90s timeout in `internal/llm`) → frontend shows a busy state; the deterministic verdict is available without the AI call. A shorter analyzer timeout is a possible follow-up (would need an `llm` API addition, out of scope now).
+- **Stored analysis goes stale relative to an edited profile** → acceptable; the coherence is about the résumé, not the market, and re-uploading refreshes it. `analyzed_at` is surfaced so staleness is visible.
+- **User-influenced text amplifying token cost** → input bounded via `TruncateRunes` (mirrors enrich's `maxDescriptionRunes`); advice output bounded by the ≤20 must-have gap slugs and per-entry truncation.
+- **Migration on prod** → the `resume_analysis` column must be applied manually before the new binary rolls (documented seam); the column is nullable with no default, so it is backward-compatible with old rows.
+
+## Migration Plan
+
+1. Add migration `migrations/00NN_search_profiles_resume_analysis.sql`: `ALTER TABLE search_profiles ADD COLUMN resume_analysis JSONB;` (nullable, no default).
+2. `make sqlc` after adding the new queries; commit generated code.
+3. Deploy order: apply the migration manually on the persistent/prod DB **before** rolling the new server binary (which references the column via the profile fetch query).
+4. Rollback: `ALTER TABLE search_profiles DROP COLUMN resume_analysis;` after reverting the binary. No data loss beyond the derived analyses.
+
+## Open Questions
+
+- Exact `MustHaveShare` value — resolve by inspecting live facet distributions for a few categories during verification (start 0.40).

--- a/openspec/changes/resume-verdict/proposal.md
+++ b/openspec/changes/resume-verdict/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+A search profile already tells a user which skills they have and a one-line "Market fit" ratio, but it does not tell them *how they stack up against the live market for their target role* or *what to add first for the biggest gain*. Users want a verdict: a clear read on their coverage of the most in-demand skills, the highest-leverage gaps, and whether their résumé actually backs up the skills it claims.
+
+## What Changes
+
+- **New verdict screen** at `/my/profiles/[id]/verdict`: Stack Match %, must-haves covered X/Y, a top-20 market-skill breakdown (each Covered or a Gap carrying `+N% roles`), "Biggest wins" (top gaps by unlock), and "Your superpowers" chips. Reuses the already-built `VerdictView.svelte` (currently mock data → refactored to a real `Verdict` prop).
+- **Deterministic core computed live** from the profile's saved `skills` + `specializations` against the `/jobs` facet distribution (mirrors `web/src/lib/skillGap.ts`). No résumé needed for this part.
+- **Optional AI layer**: the user uploads a résumé (PDF or text) on the verdict page; the server reads the text *once, in that request* and asks the LLM for a Coherence Score (0-100 — are the claimed skills backed by Experience?) plus short advice for each must-have gap.
+- **Privacy invariant preserved**: the raw résumé text is NEVER persisted (same as `internal/handler/resume.go`). Only the derived AI layer (coherence + advice + `analyzed_at`) is stored, so it survives reload.
+- **Graceful degradation**: the LLM client is built on the HTTP server only when `LLM_BASE_URL`/`LLM_API_KEY`/`LLM_MODEL` are set (mirrors the Meilisearch nil-guard). When absent or on LLM error, the verdict still renders deterministically with the coherence card hidden.
+- **Cleanup**: remove the throwaway preview route `web/src/routes/verdict-preview/+page.svelte`.
+
+## Capabilities
+
+### New Capabilities
+- `resume-verdict`: computing and serving a per-profile résumé verdict — the deterministic market skill-gap scoring (stack match, must-haves, per-gap unlock) plus the optional, privacy-preserving LLM coherence score and gap advice, persisted as a derived analysis on the profile.
+
+### Modified Capabilities
+<!-- None: the verdict is a new capability. The search_profiles table gains a derived
+     resume_analysis column, but the search-profiles capability's own requirements
+     (create/list/update/delete a profile) are unchanged. -->
+
+## Impact
+
+- **New backend package** `internal/verdict` (pure `Compute` + LLM `Analyzer`).
+- **Handler**: `GET`/`POST /api/v1/me/profiles/:id/verdict` in `internal/handler` (RequireAuth, ownership-checked); reuses résumé parsing from `internal/handler/resume.go`.
+- **Config + `cmd/server`**: build an `internal/llm` client when the `LLM_*` env is set; pass into `handler.Config` (nil disables the AI layer).
+- **DB**: migration adds `resume_analysis JSONB` (nullable) to `search_profiles`; new sqlc queries (fetch profile by id+user, set analysis).
+- **Contracts**: `cmd/gen-contracts` emits the `Verdict`/`Skill` TS types.
+- **Frontend**: new route `/my/profiles/[id]/verdict`, `api.ts` calls, `VerdictView.svelte` prop refactor, a "Verdict" link on the profile card. No web test runner — verify via `svelte-check`.
+- **Ops**: the migration needs a manual apply on existing/prod volumes (the open versioned-migration-runner seam), applied before the new server binary rolls.

--- a/openspec/changes/resume-verdict/specs/resume-verdict/spec.md
+++ b/openspec/changes/resume-verdict/specs/resume-verdict/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Deterministic market skill-gap scoring
+
+The system SHALL compute a verdict for a search profile by comparing the profile's saved skills against the most in-demand skills on the live market for the profile's specialization(s). The market is the facet distribution of open jobs filtered to the profile's specialization categories (OR-combined). The "expected" set SHALL be the top 20 skills ordered by descending open-job count, breaking ties by ascending slug for determinism.
+
+#### Scenario: Stack match reflects coverage of the top skills
+- **WHEN** a profile's skills cover 11 of the 20 top market skills for its specializations
+- **THEN** the verdict reports `stack_match` = 55 (round(11/20 × 100)) and marks those 11 rows `have: true`
+
+#### Scenario: Fewer than twenty market skills available
+- **WHEN** the market for the specializations returns only 8 distinct skills
+- **THEN** the breakdown contains 8 rows and `stack_match` is computed against a denominator of 8, not 20
+
+#### Scenario: No market data available
+- **WHEN** the search/facet backend is not configured
+- **THEN** the verdict endpoint responds 503 and no verdict is produced
+
+### Requirement: Per-gap unlock percentage
+
+For each expected skill the candidate lacks (a gap), the system SHALL report an `unlock` percentage equal to the share of the role's open postings that list that skill (round(count / total × 100)). Covered skills SHALL NOT carry an unlock value.
+
+#### Scenario: Gap carries its market reach
+- **WHEN** a gap skill appears in 340 of 1000 open postings for the role
+- **THEN** that skill's row has `have: false` and `unlock: 34`
+
+#### Scenario: Covered skill has no unlock
+- **WHEN** an expected skill is present in the profile
+- **THEN** its row has `have: true` and no `unlock` value
+
+### Requirement: Must-have designation by demand share
+
+The system SHALL mark an expected skill as a must-have when it appears in at least a fixed demand-share fraction of the role's open postings. The verdict SHALL report `must_have_total` (must-haves within the top set) and `must_have_covered` (must-haves the profile has).
+
+#### Scenario: High-demand skill is a must-have
+- **WHEN** a skill appears in 45% of the role's postings and the must-have cutoff is 40%
+- **THEN** its row has `must_have: true` and it counts toward `must_have_total`
+
+#### Scenario: Lower-demand skill is not a must-have
+- **WHEN** a skill appears in 25% of the role's postings and the cutoff is 40%
+- **THEN** its row has `must_have: false`
+
+### Requirement: LLM coherence score and gap advice
+
+When an LLM is configured, the system SHALL let the user upload a résumé (PDF or plain text) on the verdict page and, in that same request, ask the model — over the résumé text — for a coherence score in the range 0-100 (how well the claimed skills are substantiated by the Experience section) and a short piece of advice for each must-have gap. Out-of-range scores SHALL be clamped to 0-100; advice for skills not in the requested gap set SHALL be dropped; advice text SHALL be length-bounded.
+
+#### Scenario: Résumé analyzed with the model configured
+- **WHEN** a signed-in user uploads a résumé on the verdict page and the LLM is configured
+- **THEN** the returned verdict includes `coherence` (0-100) and `advice` attached to must-have gap rows
+
+#### Scenario: Model returns an out-of-range score
+- **WHEN** the model returns a coherence of 150
+- **THEN** the persisted/served coherence is clamped to 100
+
+### Requirement: Résumé text is never persisted
+
+The system SHALL use the raw résumé text only within the analysis request and MUST NOT persist or log it. Only the derived analysis — coherence score, per-gap advice, and the analysis timestamp — SHALL be stored, on the owning search profile.
+
+#### Scenario: Only derived analysis is stored
+- **WHEN** a résumé is analyzed for a profile
+- **THEN** the stored `resume_analysis` contains the coherence, advice, and `analyzed_at` but no résumé text, and reopening the verdict later shows the same coherence and advice
+
+### Requirement: Graceful degradation without the LLM
+
+The verdict SHALL always render its deterministic core. When the LLM is unconfigured or the analysis call fails, the endpoint SHALL still return the deterministic verdict with the coherence score and advice omitted (a 200, not an error).
+
+#### Scenario: LLM unconfigured
+- **WHEN** the server has no LLM configured and a verdict is requested
+- **THEN** the response is 200 with the full deterministic breakdown and no `coherence`
+
+#### Scenario: LLM call fails during analysis
+- **WHEN** a résumé is uploaded but the model errors or returns unparseable output
+- **THEN** the response is 200 with the deterministic verdict and no `coherence`/`advice`, and the raw error is not surfaced to the client
+
+### Requirement: Verdict endpoint authentication and ownership
+
+The verdict endpoints SHALL require an authenticated session (cookie-only) and SHALL operate only on a profile owned by the caller. Requesting or analyzing another user's profile, or a missing profile, SHALL respond 404.
+
+#### Scenario: Owner reads their verdict
+- **WHEN** a signed-in user requests the verdict for a profile they own
+- **THEN** the response is 200 with the verdict
+
+#### Scenario: Non-owner is refused
+- **WHEN** a signed-in user requests the verdict for a profile owned by someone else
+- **THEN** the response is 404

--- a/openspec/changes/resume-verdict/tasks.md
+++ b/openspec/changes/resume-verdict/tasks.md
@@ -1,0 +1,46 @@
+## 1. Backend deterministic core (`internal/verdict`)
+
+- [x] 1.1 Write table tests for `verdict.Compute`: demand sort + slug tiebreak, top-20 truncation, fewer-than-20 denominator, `StackMatch` rounding, `Unlock` = count/total (gaps only, none on covered), must-have share boundary at `MustHaveShare`, empty candidate, `Total == 0` (no divide-by-zero)
+- [x] 1.2 Implement `Verdict`/`Skill`/`MarketSkills` types + `Compute` to pass 1.1
+- [x] 1.3 Add `Verdict.MustHaveGaps()` (must-have gaps in demand order) with tests
+
+## 2. Backend LLM analyzer (`internal/verdict/coherence.go`)
+
+- [x] 2.1 Write tests (using `llm.NewWithModel` with a fake `llms.Model`): valid JSON → clamped coherence + gap-filtered advice; out-of-range coherence clamped to 0-100; advice for non-gap slugs dropped; over-length advice truncated; malformed JSON → error; `NewAnalyzer(nil).Analyze` → `(nil, nil)`; prompt includes gap slugs and truncates résumé at `maxResumeRunes`
+- [x] 2.2 Implement `Analyzer`, `Analysis`, prompt build, parse, clamp/sanitize, and nil-client degradation to pass 2.1
+
+## 3. Persistence (`search_profiles.resume_analysis`)
+
+- [x] 3.1 Add migration `migrations/00NN_search_profiles_resume_analysis.sql`: nullable `resume_analysis JSONB`, with rollback comment
+- [x] 3.2 Add sqlc queries: `GetSearchProfile` (:one, by id + user_id) and `SetSearchProfileResumeAnalysis` (:exec, scoped by user_id); include `resume_analysis` in the profile row projections; run `make sqlc` and commit generated code
+- [x] 3.3 Extend the `searchprofile` service + repository with fetch-one and set-analysis use cases (ownership-scoped) with tests
+
+## 4. Config + server LLM wiring
+
+- [x] 4.1 Add `LLMBaseURL`/`LLMAPIKey`/`LLMModel` to the server config + `Load` (optional; empty disables) with a test
+- [x] 4.2 In `cmd/server`, build an `*llm.Client` only when all three are set; pass into `handler.Config`; in `handler.Register` wrap it via `verdict.NewAnalyzer` (nil-safe)
+
+## 5. Handler endpoints (`/api/v1/me/profiles/:id/verdict`)
+
+- [x] 5.1 Reuse résumé text parsing from `resume.go` (share `resumeText`/`pdfText`) for the POST path
+- [x] 5.2 Implement `GET .../verdict`: load owned profile (404 otherwise), 503 when facets unconfigured, build category filter, `FacetCounts` → `MarketSkills`, `verdict.Compute` from profile skills, merge stored `resume_analysis`; tests with fake `facetCounter` + fake repo
+- [x] 5.3 Implement `POST .../verdict`: parse résumé (400 on empty/invalid), compute deterministic gaps, run analyzer, persist derived analysis, return full verdict; tests for degradation (nil analyzer / LLM error → 200 no coherence), ownership 404, empty text 400
+- [x] 5.4 Wire both routes in `handler.Register` next to the other `/me/profiles` routes (cookie-only `RequireAuth`)
+
+## 6. Contracts
+
+- [x] 6.1 Add `internal/verdict` to `cmd/gen-contracts`; run `make gen-contracts`; confirm `Verdict`/`Skill` appear in the committed `web/src/lib/generated/contracts.ts` and are re-exported for `api.ts`
+
+## 7. Frontend
+
+- [x] 7.1 Refactor `VerdictView.svelte` from mock data to a `verdict: Verdict` prop; hide the coherence card when `coherence == null`; humanize role via `categoryLabel`; drop the mock `kind` field
+- [x] 7.2 Add `api.ts` calls: `getProfileVerdict(id)` and `analyzeProfileResume(id, input: File|string)` (multipart vs JSON dispatch, mirroring `extractResumeSkills`)
+- [x] 7.3 Add route `web/src/routes/my/profiles/[id]/verdict/+page.svelte`: load the verdict, render `VerdictView`, and offer a résumé dropzone (reuse the `ProfileForm` dropzone pattern) that calls `analyzeProfileResume`; `noindex`, auth-gated
+- [x] 7.4 Add a "Verdict" link to each profile card in `SearchProfilesView.svelte`
+- [x] 7.5 Remove the throwaway `web/src/routes/verdict-preview/+page.svelte`
+- [x] 7.6 `svelte-check` clean for the touched files
+
+## 8. Verification
+
+- [x] 8.1 `go build ./... && go vet ./... && go test ./...`; confirm `make sqlc` + `make gen-contracts` output is committed. NOTE: `MustHaveShare` left at the documented default 0.40 — live-facet calibration is an ops follow-up (needs prod facet counts; flagged in design.md Open Questions).
+- [x] 8.2 Degradation/ownership/503 paths covered by `resume_verdict_test.go` (GET deterministic, POST with/without LLM, LLM error, 404, empty-text 400); `npm run check` (0 errors) and `npm run build` pass. Live server smoke (Postgres+Meili+LLM) remains a pre-deploy ops step.

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -20,3 +20,7 @@ sql:
           # response (an empty payload stays {}); a plain []byte would base64-encode.
           - column: "jobs.enrichment"
             go_type: "encoding/json.RawMessage"
+          # Same reasoning for the profile's derived résumé analysis: keep the JSONB
+          # blob as raw bytes that marshal straight through (nil → null), not base64.
+          - column: "search_profiles.resume_analysis"
+            go_type: "encoding/json.RawMessage"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -32,6 +32,7 @@ import type {
   SubmissionInput,
   Report,
   ReportInput,
+  Verdict,
 } from './types';
 
 /** A page of list items, optionally the total matching the query (endpoints that
@@ -527,6 +528,33 @@ export function createApi(
     return res.data.skills;
   }
 
+  /** The résumé verdict for a profile: the deterministic market comparison plus any
+   *  previously stored coherence/advice. Owner-scoped (404 for another user's profile). */
+  async function getProfileVerdict(id: number): Promise<Verdict> {
+    const res = await request<{ data: Verdict }>(`/api/v1/me/profiles/${id}/verdict`);
+    return res.data;
+  }
+
+  /** Analyze a résumé (a PDF `File` sent as multipart, or pasted text sent as JSON)
+   *  against a profile: the server runs the LLM coherence/advice over the text (never
+   *  persisting it) and returns the full verdict with coherence attached. */
+  async function analyzeProfileResume(id: number, input: File | string): Promise<Verdict> {
+    let init: RequestInit;
+    if (typeof input === 'string') {
+      init = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: input }),
+      };
+    } else {
+      const form = new FormData();
+      form.append('file', input);
+      init = { method: 'POST', body: form };
+    }
+    const res = await request<{ data: Verdict }>(`/api/v1/me/profiles/${id}/verdict`, init);
+    return res.data;
+  }
+
   /** The caller's notification subscriptions (one per saved search + channel). */
   async function listSubscriptions(): Promise<Subscription[]> {
     const res = await request<{ data: Subscription[] }>('/api/v1/me/subscriptions');
@@ -695,6 +723,8 @@ export function createApi(
     updateSearchProfile,
     deleteSearchProfile,
     extractResumeSkills,
+    getProfileVerdict,
+    analyzeProfileResume,
     listSubscriptions,
     createSubscription,
     setSubscriptionActive,
@@ -765,6 +795,8 @@ export const {
   updateSearchProfile,
   deleteSearchProfile,
   extractResumeSkills,
+  getProfileVerdict,
+  analyzeProfileResume,
   listSubscriptions,
   createSubscription,
   setSubscriptionActive,

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ArrowLeft, X } from '@lucide/svelte';
+  import { ArrowLeft, ArrowUp, X } from '@lucide/svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { ApiError, extractResumeSkills, facetCounts } from '$lib/api';
@@ -33,10 +33,11 @@
   // Résumé upload → skill extraction. The file/text is parsed server-side and discarded;
   // the returned slugs merge (union) into the skills field without wiping manual entries.
   let resumeBusy = $state(false);
-  let resumeText = $state('');
   let resumeError = $state<string | null>(null);
   let resumeNote = $state<string | null>(null);
   let fileInput = $state<HTMLInputElement | null>(null);
+  let dragActive = $state(false);
+  let fileName = $state<string | null>(null);
 
   // The universe of skills (canonical tokens with job counts) for the typeahead, from
   // the facet-distribution endpoint — the same source the filter panel uses. Empty
@@ -74,14 +75,15 @@
     void loadSkills();
   });
 
-  // Extract skills from a résumé (a PDF File or pasted text) and merge them into the
-  // skills field as a deduplicated union, preserving anything already entered.
-  async function analyzeResume(input: File | string) {
+  // Extract skills from a résumé PDF and merge them into the skills field as a
+  // deduplicated union, preserving anything already entered.
+  async function analyzeResume(file: File) {
     resumeBusy = true;
     resumeError = null;
     resumeNote = null;
+    fileName = file.name;
     try {
-      const extracted = await extractResumeSkills(input);
+      const extracted = await extractResumeSkills(file);
       if (extracted.length === 0) {
         resumeNote = 'No known skills found in the résumé.';
         return;
@@ -106,6 +108,34 @@
     const file = target.files?.[0];
     target.value = ''; // clear so re-selecting the same file fires change again
     if (file) void analyzeResume(file);
+  }
+
+  function isPdf(file: File): boolean {
+    return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+  }
+
+  // The file input's `accept` filters the picker, but a drop bypasses it — so the
+  // drop path validates the type itself before touching the extractor.
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    dragActive = false;
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    if (!isPdf(file)) {
+      resumeError = 'Please drop a PDF file.';
+      return;
+    }
+    void analyzeResume(file);
+  }
+
+  function onDragOver(e: DragEvent) {
+    e.preventDefault();
+    dragActive = true;
+  }
+
+  function onDragLeave(e: DragEvent) {
+    e.preventDefault();
+    dragActive = false;
   }
 
   // Multi-select with a cap: toggling off is always allowed; toggling on is refused
@@ -223,49 +253,46 @@
         clearOnSelect
       />
 
-      <div class="flex flex-col gap-1.5 rounded-lg border border-dashed border-border p-3">
+      <div class="flex flex-col gap-1.5">
         <span class="text-sm font-medium">Add skills from your résumé</span>
-        <div class="flex flex-wrap items-center gap-2">
-          <input
-            type="file"
-            accept="application/pdf,.pdf"
-            class="hidden"
-            bind:this={fileInput}
-            onchange={onResumeFile}
-          />
-          <Button
-            variant="secondary"
-            size="sm"
-            type="button"
-            onclick={() => fileInput?.click()}
-            disabled={resumeBusy}
+        <input
+          type="file"
+          accept="application/pdf,.pdf"
+          class="hidden"
+          bind:this={fileInput}
+          onchange={onResumeFile}
+        />
+        <button
+          type="button"
+          onclick={() => fileInput?.click()}
+          ondragover={onDragOver}
+          ondragleave={onDragLeave}
+          ondrop={onDrop}
+          disabled={resumeBusy}
+          class="flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-8 text-center transition-colors disabled:opacity-70 {dragActive
+            ? 'border-primary bg-primary/5'
+            : 'border-border hover:border-primary/60'}"
+        >
+          <span
+            class="flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground"
           >
-            {resumeBusy ? 'Analyzing…' : 'Upload résumé (PDF)'}
-          </Button>
-          <span class="text-xs text-muted-foreground">extracts your skills into the field above</span>
-        </div>
-        <details class="text-xs">
-          <summary class="cursor-pointer text-muted-foreground">or paste résumé text</summary>
-          <div class="mt-2 flex flex-col gap-2">
-            <textarea
-              bind:value={resumeText}
-              rows="4"
-              placeholder="Paste your résumé here…"
-              class="w-full rounded-md border border-border bg-background p-2 text-sm"
-            ></textarea>
-            <div>
-              <Button
-                variant="secondary"
-                size="sm"
-                type="button"
-                onclick={() => analyzeResume(resumeText)}
-                disabled={resumeBusy || resumeText.trim() === ''}
-              >
-                Extract skills
-              </Button>
-            </div>
-          </div>
-        </details>
+            <ArrowUp class="size-5" />
+          </span>
+          <span class="flex flex-col gap-0.5">
+            <span class="text-sm font-semibold">{resumeBusy ? 'Analyzing…' : 'Drop PDF here'}</span>
+            {#if !resumeBusy}
+              <span class="text-xs text-muted-foreground">
+                or <span class="text-primary underline">choose from disk</span>
+              </span>
+            {/if}
+          </span>
+          {#if fileName}
+            <span class="text-xs text-primary">✓ {fileName}</span>
+          {/if}
+        </button>
+        <span class="text-xs text-muted-foreground">
+          Extracts your skills into the field above · parsed on the server and discarded.
+        </span>
         {#if resumeError}
           <p class="text-sm text-destructive">{resumeError}</p>
         {:else if resumeNote}

--- a/web/src/lib/components/SearchProfilesView.svelte
+++ b/web/src/lib/components/SearchProfilesView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Pencil, Plus, Trash2 } from '@lucide/svelte';
+  import { Pencil, Plus, Sparkles, Trash2 } from '@lucide/svelte';
   import { resolve } from '$app/paths';
   import { facetCounts } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -17,6 +17,7 @@
 
   const newHref = resolve('/my/profiles/new');
   const editHref = (id: number) => resolve('/my/profiles/[id]/edit', { id: String(id) });
+  const verdictHref = (id: number) => resolve('/my/profiles/[id]/verdict', { id: String(id) });
 
   // Per-profile market skill-gap, keyed by profile id. Market skills are cached by the
   // sorted specialization set, so profiles sharing specializations reuse one facet fetch.
@@ -164,8 +165,11 @@
               {#if gap && gap.total > 0}
                 <div class="mt-1 flex flex-col gap-1">
                   <div class="flex items-center gap-2">
-                    <span class="whitespace-nowrap text-xs text-muted-foreground">
-                      Market fit {gap.coverage}/{gap.total}
+                    <span
+                      class="whitespace-nowrap text-xs text-muted-foreground"
+                      title="{gap.coverage} of {gap.total} top market skills"
+                    >
+                      Market fit {Math.round((gap.coverage / gap.total) * 100)}%
                     </span>
                     <div class="h-1.5 flex-1 overflow-hidden rounded bg-secondary">
                       <div class="h-full rounded bg-primary" style="width: {(gap.coverage / gap.total) * 100}%"></div>
@@ -186,6 +190,14 @@
               {/if}
             </div>
             <div class="flex shrink-0 items-center gap-1">
+              <Button
+                variant="ghost"
+                size="icon"
+                href={verdictHref(profile.id)}
+                aria-label="Résumé verdict"
+              >
+                <Sparkles class="size-4" />
+              </Button>
               <Button variant="ghost" size="icon" href={editHref(profile.id)} aria-label="Edit profile">
                 <Pencil class="size-4" />
               </Button>

--- a/web/src/lib/components/VerdictView.svelte
+++ b/web/src/lib/components/VerdictView.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+  import { ArrowLeft, Check, TrendingUp } from '@lucide/svelte';
+  import type { Verdict } from '$lib/types';
+  import { Badge } from '$lib/ui';
+
+  // The verdict is computed by the backend (deterministic market comparison + optional
+  // LLM coherence/advice). name/role are the owning profile's label and a humanized
+  // specialization string for the header and the "of <role> roles" copy.
+  let { verdict, name, role }: { verdict: Verdict; name: string; role: string } = $props();
+
+  const skills = $derived(verdict.skills ?? []);
+  const strong = $derived(skills.filter((s) => s.have));
+  // The gaps that open the most of the market, biggest win first — the whole point:
+  // not "random missing skills" but the ones that unlock the most vacancies.
+  const topGaps = $derived(
+    skills
+      .filter((s) => !s.have && s.unlock != null)
+      .toSorted((a, b) => (b.unlock ?? 0) - (a.unlock ?? 0)),
+  );
+
+  // Stack Match always shows; Coherence only when the résumé has been analyzed.
+  const stats = $derived(
+    [
+      { label: 'Stack Match', value: verdict.stack_match },
+      ...(verdict.coherence != null ? [{ label: 'Coherence Score', value: verdict.coherence }] : []),
+    ].map((s, i) => ({ ...s, delay: 80 + i * 80 })),
+  );
+</script>
+
+<div class="flex flex-col gap-8">
+  <!-- Header -->
+  <div class="flex flex-col gap-3">
+    <a
+      href="/my/profiles"
+      class="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <ArrowLeft class="size-4" />
+      Profiles
+    </a>
+    <div class="flex flex-col gap-1">
+      <h1 class="text-3xl font-semibold tracking-tight">Here's your verdict</h1>
+      <p class="text-sm text-muted-foreground">{name} · {role}</p>
+    </div>
+  </div>
+
+  <!-- Scoreboard -->
+  <div class="grid gap-3 sm:grid-cols-[1.4fr_1fr]">
+    <!-- Must-haves -->
+    <div
+      class="flex flex-col justify-between gap-4 rounded-xl border border-border bg-card p-5 animate-in fade-in slide-in-from-bottom-2 duration-500"
+    >
+      <div class="flex items-center justify-between gap-2">
+        <Badge variant="outline" class="uppercase tracking-[0.14em]">
+          {verdict.must_have_total - verdict.must_have_covered} must-haves away
+        </Badge>
+      </div>
+      <div>
+        <div class="flex items-baseline gap-1">
+          <span class="text-6xl font-semibold tabular-nums leading-none">{verdict.must_have_covered}</span>
+          <span class="text-3xl font-medium tabular-nums text-muted-foreground">/{verdict.must_have_total}</span>
+        </div>
+        <p class="mt-2 text-sm font-medium">Must-have skills covered</p>
+        <p class="text-sm text-muted-foreground">
+          You're close. Closing these gaps puts you past most ATS filters.
+        </p>
+      </div>
+    </div>
+
+    <!-- Stack match (+ coherence when analyzed) -->
+    <div class="grid gap-3">
+      {#each stats as stat (stat.label)}
+        <div
+          class="flex flex-col gap-2 rounded-xl border border-border bg-card p-5 animate-in fade-in slide-in-from-bottom-2 duration-500"
+          style="animation-delay: {stat.delay}ms"
+        >
+          <div class="flex items-baseline justify-between">
+            <span class="text-4xl font-semibold tabular-nums leading-none">{stat.value}%</span>
+            <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">{stat.label}</span>
+          </div>
+          <div class="h-1.5 overflow-hidden rounded bg-secondary">
+            <div class="h-full rounded bg-primary" style="width: {stat.value}%"></div>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </div>
+
+  <!-- Legend -->
+  <p class="rounded-lg border border-border bg-card/50 p-4 text-xs leading-relaxed text-muted-foreground">
+    <span class="font-semibold text-foreground">Must-haves</span> are the non-negotiables for this role —
+    cover them all and you're past the first screen.
+    <span class="font-semibold text-foreground">Stack Match</span> shows your breadth across the top-20 skills.
+    <span class="font-semibold text-foreground">Coherence Score</span> checks that every skill you claim is
+    also backed by your Experience — a low score is buzzword stuffing.
+  </p>
+
+  <!-- Biggest wins -->
+  {#if topGaps.length > 0}
+    <div class="flex flex-col gap-3">
+      <div class="flex items-center gap-2">
+        <TrendingUp class="size-4 text-muted-foreground" />
+        <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          Biggest wins · what unlocks the most roles
+        </h2>
+      </div>
+      <div class="grid gap-2 sm:grid-cols-3">
+        {#each topGaps.slice(0, 3) as gap, i (gap.rank)}
+          <div
+            class="flex flex-col gap-1 rounded-xl border border-border bg-card p-4 animate-in fade-in slide-in-from-bottom-2 duration-500"
+            style="animation-delay: {i * 70}ms"
+          >
+            <span class="text-3xl font-semibold tabular-nums leading-none">+{gap.unlock}%</span>
+            <span class="text-xs text-muted-foreground">of {role} roles</span>
+            <span class="mt-1 line-clamp-2 text-sm font-medium">{gap.name}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  {/if}
+
+  <!-- Full breakdown -->
+  <div class="flex flex-col gap-3">
+    <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+      Full breakdown · top market skills
+    </h2>
+    <ul class="flex flex-col gap-2">
+      {#each skills as skill, i (skill.rank)}
+        <li
+          class="flex items-start gap-3 rounded-lg border border-border bg-card p-3 sm:p-4 animate-in fade-in slide-in-from-bottom-1 duration-300"
+          style="animation-delay: {Math.min(i * 30, 400)}ms"
+        >
+          <span class="w-6 shrink-0 pt-0.5 text-sm tabular-nums {skill.have ? 'text-muted-foreground' : 'text-foreground'}">
+            {skill.rank}
+          </span>
+
+          <div class="flex min-w-0 flex-1 flex-col gap-1">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span class="text-sm font-medium">{skill.name}</span>
+              {#if skill.must_have}
+                <Badge variant="outline" class="uppercase tracking-wide">must-have</Badge>
+              {/if}
+            </div>
+            {#if skill.advice}
+              <p class="text-xs leading-relaxed text-muted-foreground">{skill.advice}</p>
+            {/if}
+          </div>
+
+          <div class="flex shrink-0 flex-col items-end gap-1 pt-0.5">
+            {#if skill.have}
+              <span class="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground">
+                <Check class="size-3.5" />
+                Covered
+              </span>
+            {:else}
+              <span class="rounded-md border border-border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                Gap
+              </span>
+              {#if skill.unlock != null}
+                <span class="inline-flex items-center gap-1 text-xs font-semibold tabular-nums">
+                  <TrendingUp class="size-3" />
+                  +{skill.unlock}% roles
+                </span>
+              {/if}
+            {/if}
+          </div>
+        </li>
+      {/each}
+    </ul>
+  </div>
+
+  <!-- Your superpowers -->
+  {#if strong.length > 0}
+    <div class="flex flex-col gap-3">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+        Your superpowers
+      </h2>
+      <div class="flex flex-wrap gap-1.5">
+        {#each strong as skill (skill.rank)}
+          <Badge>{skill.name}</Badge>
+        {/each}
+      </div>
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -92,6 +92,15 @@ export interface Job {
   work_mode?: string;
   skills: string[];
   /**
+   * Cities is a HYBRID facet (the one deliberate dict+LLM exception): the
+   * deterministic jobs.cities column when it resolved a beacon city, otherwise a
+   * normalized fallback to the LLM's enrichment.cities — cities are high-cardinality
+   * and the dictionary is only a beacon list, so a pure-dict facet would be too
+   * sparse. Values are canonical display names (Title case); the LLM copy is folded
+   * out of the nested Enrichment like the other geography facets.
+   */
+  cities: string[];
+  /**
    * Collections is the set of curated-collection slugs (e.g. yc, bigtech) the
    * job's company belongs to, denormalized from the company onto the job. It is a
    * deterministic source fact (no LLM counterpart) served straight from the jobs
@@ -110,6 +119,52 @@ export interface Job {
   enrichment: Enrichment;
   enriched_at?: string;
   enrichment_version: number /* int32 */;
+}
+
+/**
+ * TopN is how many of the market's most in-demand skills define the breakdown
+ * (the "expected" set). Mirrors GAP_TOP_N in skillGap.ts.
+ */
+export const TopN = 20;
+/**
+ * MustHaveShare is the demand-share cutoff for a "must-have" skill: a skill that
+ * appears in at least this fraction of the role's open postings is treated as a
+ * non-negotiable. Deterministic and self-explanatory in the UI ("asked for by
+ * 40%+ of postings"); tunable in one place. Calibrate against real facet data.
+ */
+export const MustHaveShare = 0.40;
+/**
+ * MarketSkills is the facet distribution for a role: canonical skill slug → count
+ * of open postings that list it, plus Total open postings in the role (the
+ * denominator for the demand share and the unlock percentage).
+ */
+export interface MarketSkills {
+  Counts: { [key: string]: number /* int64 */};
+  Total: number /* int64 */;
+}
+/**
+ * Verdict is the full result. Coherence/AnalyzedAt are set only when an LLM
+ * analysis is present (see coherence.go); nil renders no coherence card. JSON is
+ * the wire contract shared with the frontend (generated to TS via cmd/gen-contracts).
+ */
+export interface Verdict {
+  stack_match: number /* int */; // 0-100: share of the top-N the candidate has
+  must_have_covered: number /* int */;
+  must_have_total: number /* int */;
+  coherence?: number /* int */; // 0-100, LLM-derived
+  analyzed_at?: string; // RFC3339, when the résumé was last analyzed
+  skills: Skill[]; // exactly the top-N, in demand order
+}
+/**
+ * Skill is one row of the breakdown.
+ */
+export interface Skill {
+  rank: number /* int */;
+  name: string; // canonical slug; the UI humanizes it
+  must_have: boolean;
+  have: boolean;
+  unlock?: number /* int */; // gaps only: % of the role's postings this skill touches
+  advice?: string; // LLM-derived, attached to must-have gaps when available
 }
 
 export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'breezy', 'careerplug', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'habr_career', 'himalayas', 'huntflow', 'icims', 'inhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'traffit', 'trakstar', 'ukg', 'vention', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -2,7 +2,7 @@
 // Timestamps marshal as RFC3339 strings when present, or null.
 
 import type { Job } from './generated/contracts';
-export type { Job, Enrichment } from './generated/contracts';
+export type { Job, Enrichment, Verdict, Skill } from './generated/contracts';
 
 export interface Company {
   slug: string;

--- a/web/src/routes/my/profiles/[id]/verdict/+page.svelte
+++ b/web/src/routes/my/profiles/[id]/verdict/+page.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  import { ArrowUp } from '@lucide/svelte';
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import { ApiError, analyzeProfileResume, getProfileVerdict } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
+  import { categoryLabel } from '$lib/facets';
+  import States from '$lib/components/States.svelte';
+  import VerdictView from '$lib/components/VerdictView.svelte';
+  import { searchProfiles } from '$lib/searchProfiles.svelte';
+  import type { Verdict } from '$lib/types';
+  import { Button } from '$lib/ui';
+
+  const id = $derived(Number(page.params.id));
+  const profile = $derived(searchProfiles.items.find((p) => p.id === id));
+  const role = $derived(profile ? profile.specializations.map(categoryLabel).join(', ') : '');
+
+  let status = $state<'loading' | 'error' | 'ready'>('loading');
+  let verdict = $state<Verdict | null>(null);
+
+  // Résumé analysis (the LLM coherence layer) — dropzone state.
+  let resumeBusy = $state(false);
+  let resumeError = $state<string | null>(null);
+  let dragActive = $state(false);
+  let fileName = $state<string | null>(null);
+  let fileInput = $state<HTMLInputElement | null>(null);
+
+  async function load() {
+    status = 'loading';
+    try {
+      await searchProfiles.ensureLoaded();
+      verdict = await getProfileVerdict(id);
+      status = 'ready';
+    } catch {
+      status = 'error';
+    }
+  }
+
+  $effect(() => {
+    if (isAuthenticated()) void load();
+  });
+
+  function isPdf(file: File): boolean {
+    return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+  }
+
+  // Analyze the résumé for coherence + advice. Best-effort like the backend: a failure
+  // shows a message but the deterministic verdict already on screen is untouched.
+  async function analyze(file: File) {
+    resumeBusy = true;
+    resumeError = null;
+    fileName = file.name;
+    try {
+      verdict = await analyzeProfileResume(id, file);
+    } catch (err) {
+      resumeError =
+        err instanceof ApiError ? err.message : 'Could not analyze the résumé. Please try again.';
+    } finally {
+      resumeBusy = false;
+    }
+  }
+
+  function onFile(e: Event) {
+    const target = e.currentTarget as HTMLInputElement;
+    const file = target.files?.[0];
+    target.value = '';
+    if (file) void analyze(file);
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    dragActive = false;
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    if (!isPdf(file)) {
+      resumeError = 'Please drop a PDF file.';
+      return;
+    }
+    void analyze(file);
+  }
+
+  function onDragOver(e: DragEvent) {
+    e.preventDefault();
+    dragActive = true;
+  }
+
+  function onDragLeave(e: DragEvent) {
+    e.preventDefault();
+    dragActive = false;
+  }
+</script>
+
+<svelte:head>
+  <title>Résumé verdict — freehire</title>
+  <!-- Personal page: keep it out of search results. -->
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
+  {#if !isAuthenticated()}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">Sign in to see your verdict.</p>
+      <Button variant="primary" onclick={() => openAuthDialog()}>Sign in</Button>
+    </div>
+  {:else if status === 'loading'}
+    <States state="loading" />
+  {:else if status === 'error'}
+    <States state="error" message="Couldn't load the verdict." />
+  {:else if profile === undefined || verdict === null}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">This profile no longer exists.</p>
+      <Button variant="primary" href={resolve('/my/profiles')}>Back to profiles</Button>
+    </div>
+  {:else}
+    <div class="flex flex-col gap-8">
+      <VerdictView {verdict} name={profile.name} {role} />
+
+      <!-- Résumé coherence: upload once to add the Coherence Score + gap advice. -->
+      <div class="flex flex-col gap-2">
+        <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          {verdict.coherence == null ? 'Add a coherence check' : 'Refresh the coherence check'}
+        </h2>
+        <input
+          type="file"
+          accept="application/pdf,.pdf"
+          class="hidden"
+          bind:this={fileInput}
+          onchange={onFile}
+        />
+        <button
+          type="button"
+          onclick={() => fileInput?.click()}
+          ondragover={onDragOver}
+          ondragleave={onDragLeave}
+          ondrop={onDrop}
+          disabled={resumeBusy}
+          class="flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-8 text-center transition-colors disabled:opacity-70 {dragActive
+            ? 'border-primary bg-primary/5'
+            : 'border-border hover:border-primary/60'}"
+        >
+          <span class="flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground">
+            <ArrowUp class="size-5" />
+          </span>
+          <span class="flex flex-col gap-0.5">
+            <span class="text-sm font-semibold">{resumeBusy ? 'Analyzing…' : 'Drop your résumé PDF here'}</span>
+            {#if !resumeBusy}
+              <span class="text-xs text-muted-foreground">
+                or <span class="text-primary underline">choose from disk</span>
+              </span>
+            {/if}
+          </span>
+          {#if fileName}
+            <span class="text-xs text-primary">✓ {fileName}</span>
+          {/if}
+        </button>
+        <span class="text-xs text-muted-foreground">
+          Checks whether your Experience backs up your skills · parsed on the server and discarded.
+        </span>
+        {#if resumeError}
+          <p class="text-sm text-destructive">{resumeError}</p>
+        {/if}
+      </div>
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary
- New `/my/profiles/[id]/verdict` screen: **Stack Match %**, **must-haves covered**, a **top-20 market-skill breakdown** (each Covered or a Gap carrying **+N% roles** unlock), **Biggest wins**, and **Your superpowers** — computed live from the profile's skills + specializations against the `/jobs` facet distribution (new pure `internal/verdict.Compute`, mirrors `web/src/lib/skillGap.ts`).
- Optional **AI layer**: uploading a résumé (PDF/text) on the page runs one LLM call for a **Coherence Score (0-100)** + short advice per must-have gap. The raw résumé text is analyzed in-request and **never persisted** (same privacy invariant as `internal/handler/resume.go`); only the derived analysis is stored as `search_profiles.resume_analysis JSONB`.
- **Graceful degradation**: the LLM client is built only when `LLM_BASE_URL`/`LLM_API_KEY`/`LLM_MODEL` are set (mirrors the Meili nil-guard). Absent or on error, the verdict still renders deterministically with the coherence card hidden (200, not 500).
- Removes the throwaway `verdict-preview` route; `VerdictView.svelte` refactored from mock data to a real `Verdict` prop; profile card gets a "Verdict" link.
- Planned/tracked in OpenSpec (`openspec/changes/resume-verdict`) under the spec-driven-tdd workflow.

## Notes / ops
- **Migration 0038** (`resume_analysis JSONB`, nullable) must be applied **manually before** rolling the new binary (the open versioned-migration-runner seam).
- `MustHaveShare` left at the documented default **0.40** — live-facet calibration is a follow-up (design.md Open Questions).
- Pre-existing `internal/location` `TestParse` failure is unrelated to this change (fails on `main`).

## Test Plan
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/verdict ./internal/handler ./internal/searchprofile ./internal/config ./cmd/gen-contracts` green (deterministic math, LLM sanitize/clamp/degrade, ownership 404, empty-text 400, 503-no-search, persist)
- [x] `cd web && npm run check` (0 errors) and `npm run build` pass
- [ ] Pre-deploy smoke with Postgres + Meili + `LLM_*`: GET renders deterministically; POST with LLM → coherence + advice; without `LLM_*` → 200 no coherence; without Meili → 503