### PR TITLE
feat(workers): survive corrupted (XX001) rows in full-scan workers

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -26,8 +26,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgtype"
-
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/worker"
@@ -56,26 +54,6 @@ func facetOps(c *search.Client) indexOps {
 
 func semanticOps(c *search.Client) indexOps {
 	return indexOps{"semantic", c.EnsureSemanticIndex, c.IndexSemanticJobs, c.DeleteSemanticJobs}
-}
-
-// pageFetcher returns the next keyset page of jobs after the given id (empty when
-// the scan is exhausted). The full scan returns every job; the incremental scan
-// (reindex --since) returns only those changed at or after a cutoff.
-type pageFetcher func(ctx context.Context, afterID int64) ([]db.Job, error)
-
-func fullScan(q *db.Queries) pageFetcher {
-	return func(ctx context.Context, afterID int64) ([]db.Job, error) {
-		return q.ListJobsByIDAfter(ctx, db.ListJobsByIDAfterParams{AfterID: afterID, BatchSize: reindexBatchSize})
-	}
-}
-
-func incrementalScan(q *db.Queries, since time.Time) pageFetcher {
-	cutoff := pgtype.Timestamptz{Time: since, Valid: true}
-	return func(ctx context.Context, afterID int64) ([]db.Job, error) {
-		return q.ListJobsUpdatedAfter(ctx, db.ListJobsUpdatedAfterParams{
-			AfterID: afterID, Since: cutoff, BatchSize: reindexBatchSize,
-		})
-	}
 }
 
 // progressInterval is how often reindex emits a heartbeat with its running totals.
@@ -131,12 +109,12 @@ func run() int {
 		}
 		scope := "since " + since.String()
 		log.Printf("reindex: target=%s scope=%s mode=in-place", target, scope)
-		indexed, deleted, err := reindexAll(ctx, incrementalScan(q, time.Now().Add(-since)), ops)
+		indexed, deleted, skipped, err := reindexAll(ctx, worker.NewIncrementalReader(q, time.Now().Add(-since)), ops)
 		if err != nil {
 			log.Printf("reindex: %v", err)
 			return 1
 		}
-		log.Printf("reindex done: target=%s scope=%s indexed=%d deleted=%d", target, scope, indexed, deleted)
+		log.Printf("reindex done: target=%s scope=%s indexed=%d deleted=%d skipped=%d", target, scope, indexed, deleted, skipped)
 		return 0
 	}
 
@@ -145,12 +123,12 @@ func run() int {
 		b = client.NewSemanticRebuild()
 	}
 	log.Printf("reindex: target=%s scope=full mode=swap", target)
-	indexed, err := reindexFull(ctx, fullScan(q), b)
+	indexed, skipped, err := reindexFull(ctx, worker.NewFullScanReader(q), b)
 	if err != nil {
 		log.Printf("reindex: %v", err)
 		return 1
 	}
-	log.Printf("reindex done: target=%s scope=full indexed=%d", target, indexed)
+	log.Printf("reindex done: target=%s scope=full indexed=%d skipped=%d", target, indexed, skipped)
 	return 0
 }
 
@@ -197,9 +175,9 @@ func semanticRequested(args []string) bool {
 // how many documents were indexed (open jobs) and deleted (closed jobs). fetch
 // pages by keyset (id > last seen) — full or incremental (--since) — so rows
 // inserted or re-ordered during the run cannot be skipped or repeated.
-func reindexAll(ctx context.Context, fetch pageFetcher, ops indexOps) (int, int, error) {
+func reindexAll(ctx context.Context, reader worker.PageReader, ops indexOps) (int, int, int, error) {
 	if err := ops.ensure(ctx); err != nil {
-		return 0, 0, err
+		return 0, 0, 0, err
 	}
 
 	// Atomic so the heartbeat goroutine can read the running totals while the loop
@@ -212,35 +190,37 @@ func reindexAll(ctx context.Context, fetch pageFetcher, ops indexOps) (int, int,
 	defer stopHeartbeat()
 
 	var afterID int64
+	var skipped int
 	for {
-		jobs, err := fetch(ctx, afterID)
+		jobs, lastID, corrupted, err := worker.ResilientPage(ctx, reader, afterID, reindexBatchSize)
 		if err != nil {
-			return int(indexed.Load()), int(deleted.Load()), err
+			return int(indexed.Load()), int(deleted.Load()), skipped, err
 		}
-		if len(jobs) == 0 {
+		skipped += len(corrupted)
+
+		if len(jobs) > 0 {
+			docs, deleteIDs, err := splitJobs(jobs)
+			if err != nil {
+				return int(indexed.Load()), int(deleted.Load()), skipped, err
+			}
+			if err := ops.index(ctx, docs); err != nil {
+				return int(indexed.Load()), int(deleted.Load()), skipped, err
+			}
+			if err := ops.remove(ctx, deleteIDs); err != nil {
+				return int(indexed.Load()), int(deleted.Load()), skipped, err
+			}
+			indexed.Add(int64(len(docs)))
+			deleted.Add(int64(len(deleteIDs)))
+		}
+
+		// Keyset progress is the exhaustion signal (see reindexFull).
+		if lastID == afterID {
 			break
 		}
-		afterID = jobs[len(jobs)-1].ID
-
-		docs, deleteIDs, err := splitJobs(jobs)
-		if err != nil {
-			return int(indexed.Load()), int(deleted.Load()), err
-		}
-		if err := ops.index(ctx, docs); err != nil {
-			return int(indexed.Load()), int(deleted.Load()), err
-		}
-		if err := ops.remove(ctx, deleteIDs); err != nil {
-			return int(indexed.Load()), int(deleted.Load()), err
-		}
-		indexed.Add(int64(len(docs)))
-		deleted.Add(int64(len(deleteIDs)))
-
-		if len(jobs) < reindexBatchSize {
-			break
-		}
+		afterID = lastID
 	}
 
-	return int(indexed.Load()), int(deleted.Load()), nil
+	return int(indexed.Load()), int(deleted.Load()), skipped, nil
 }
 
 // rebuilder builds a brand-new index out of band and atomically swaps it into
@@ -263,9 +243,9 @@ type rebuilder interface {
 // fetch pages by keyset (id > last seen) so rows inserted or re-ordered during the
 // run cannot be skipped or repeated. Used for full passes; --since stays in place
 // (reindexAll) since a partial index cannot be swapped in wholesale.
-func reindexFull(ctx context.Context, fetch pageFetcher, b rebuilder) (int, error) {
+func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder) (int, int, error) {
 	if err := b.Prepare(ctx); err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
 	var indexed atomic.Int64
@@ -275,34 +255,38 @@ func reindexFull(ctx context.Context, fetch pageFetcher, b rebuilder) (int, erro
 	defer stopHeartbeat()
 
 	var afterID int64
+	var skipped int
 	for {
-		jobs, err := fetch(ctx, afterID)
+		jobs, lastID, corrupted, err := worker.ResilientPage(ctx, reader, afterID, reindexBatchSize)
 		if err != nil {
-			return int(indexed.Load()), err
+			return int(indexed.Load()), skipped, err
 		}
-		if len(jobs) == 0 {
+		skipped += len(corrupted)
+
+		if len(jobs) > 0 {
+			docs, _, err := splitJobs(jobs) // closed jobs (deleteIDs) are dropped, not indexed
+			if err != nil {
+				return int(indexed.Load()), skipped, err
+			}
+			if err := b.Push(ctx, docs); err != nil {
+				return int(indexed.Load()), skipped, err
+			}
+			indexed.Add(int64(len(docs)))
+		}
+
+		// Keyset progress is the exhaustion signal: ResilientPage advances lastID
+		// past a skipped (corrupted) row, so a short page from the degrade path does
+		// not end the scan early the way a "< batchSize" check would.
+		if lastID == afterID {
 			break
 		}
-		afterID = jobs[len(jobs)-1].ID
-
-		docs, _, err := splitJobs(jobs) // closed jobs (deleteIDs) are dropped, not indexed
-		if err != nil {
-			return int(indexed.Load()), err
-		}
-		if err := b.Push(ctx, docs); err != nil {
-			return int(indexed.Load()), err
-		}
-		indexed.Add(int64(len(docs)))
-
-		if len(jobs) < reindexBatchSize {
-			break
-		}
+		afterID = lastID
 	}
 
 	if err := b.Promote(ctx); err != nil {
-		return int(indexed.Load()), err
+		return int(indexed.Load()), skipped, err
 	}
-	return int(indexed.Load()), nil
+	return int(indexed.Load()), skipped, nil
 }
 
 // splitJobs partitions a batch from the (deliberately unfiltered) reindex feed:

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -107,20 +108,18 @@ func TestReindexFull_PushesOpenDocsThenPromotes(t *testing.T) {
 	open3 := db.Job{ID: 3, Title: "C", PublicSlug: "c"}
 	page := []db.Job{open1, closed, open3}
 
-	fetch := func(_ context.Context, afterID int64) ([]db.Job, error) {
-		if afterID == 0 {
-			return page, nil
-		}
-		return nil, nil
-	}
+	reader := &fakePageReader{pages: map[int64][]db.Job{0: page}}
 
 	f := &fakeRebuilder{}
-	indexed, err := reindexFull(context.Background(), fetch, f)
+	indexed, skipped, err := reindexFull(context.Background(), reader, f)
 	if err != nil {
 		t.Fatalf("reindexFull: %v", err)
 	}
 	if indexed != 2 {
 		t.Errorf("indexed = %d, want 2 (open jobs only)", indexed)
+	}
+	if skipped != 0 {
+		t.Errorf("skipped = %d, want 0", skipped)
 	}
 	wantCalls := []string{"prepare", "push", "promote"}
 	if !reflect.DeepEqual(f.calls, wantCalls) {
@@ -129,4 +128,65 @@ func TestReindexFull_PushesOpenDocsThenPromotes(t *testing.T) {
 	if len(f.pushed) != 1 || !reflect.DeepEqual(f.pushed[0], []int64{1, 3}) {
 		t.Errorf("pushed = %v, want [[1 3]] (closed job 2 skipped)", f.pushed)
 	}
+}
+
+// A corrupted row (its Batch read faults with XX001) must not abort the rebuild:
+// ResilientPage degrades to per-row reads, the corrupted row is skipped, the rest
+// are indexed, and the fresh index still promotes.
+func TestReindexFull_SkipsCorruptedRowAndPromotes(t *testing.T) {
+	reader := &fakePageReader{
+		corruptAfter: map[int64]bool{0: true},
+		idPages:      map[int64][]int64{0: {1, 2, 3}},
+		rows: map[int64]db.Job{
+			1: {ID: 1, Title: "A", PublicSlug: "a"},
+			3: {ID: 3, Title: "C", PublicSlug: "c"},
+		},
+		rowCorrupt: map[int64]bool{2: true},
+	}
+
+	f := &fakeRebuilder{}
+	indexed, skipped, err := reindexFull(context.Background(), reader, f)
+	if err != nil {
+		t.Fatalf("reindexFull: %v", err)
+	}
+	if indexed != 2 || skipped != 1 {
+		t.Errorf("indexed=%d skipped=%d, want indexed=2 skipped=1", indexed, skipped)
+	}
+	if len(f.pushed) == 0 || !reflect.DeepEqual(f.pushed[0], []int64{1, 3}) {
+		t.Errorf("pushed = %v, want [[1 3]] (corrupted row 2 skipped)", f.pushed)
+	}
+	if f.calls[len(f.calls)-1] != "promote" {
+		t.Errorf("expected promote at the end, calls = %v", f.calls)
+	}
+}
+
+// fakePageReader implements worker.PageReader. Batch returns pages[afterID], or
+// faults with XX001 when corruptAfter[afterID] is set (driving the degrade path,
+// which then reads idPages[afterID] and rows[id], faulting on rowCorrupt[id]).
+type fakePageReader struct {
+	pages        map[int64][]db.Job
+	corruptAfter map[int64]bool
+	idPages      map[int64][]int64
+	rows         map[int64]db.Job
+	rowCorrupt   map[int64]bool
+}
+
+func xx001() error { return &pgconn.PgError{Code: "XX001"} }
+
+func (f *fakePageReader) Batch(_ context.Context, afterID int64, _ int32) ([]db.Job, error) {
+	if f.corruptAfter[afterID] {
+		return nil, xx001()
+	}
+	return f.pages[afterID], nil
+}
+
+func (f *fakePageReader) IDs(_ context.Context, afterID int64, _ int32) ([]int64, error) {
+	return f.idPages[afterID], nil
+}
+
+func (f *fakePageReader) Row(_ context.Context, id int64) (db.Job, error) {
+	if f.rowCorrupt[id] {
+		return db.Job{}, xx001()
+	}
+	return f.rows[id], nil
 }

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -247,6 +247,80 @@ func (q *Queries) GetJobIDBySlug(ctx context.Context, publicSlug string) (int64,
 	return id, err
 }
 
+const listJobIDsAfter = `-- name: ListJobIDsAfter :many
+SELECT id
+FROM jobs
+WHERE id > $1
+ORDER BY id
+LIMIT $2
+`
+
+type ListJobIDsAfterParams struct {
+	AfterID   int64 `json:"after_id"`
+	BatchSize int32 `json:"batch_size"`
+}
+
+// Id-only projection of ListJobsByIDAfter, used as the corruption-degrade path:
+// when a full SELECT * batch faults on a corrupted TOAST value (SQLSTATE XX001),
+// the scan re-reads the same window as bare ids (id is never toasted, so this
+// never faults) and then fetches each row individually to isolate and skip the
+// unreadable one.
+func (q *Queries) ListJobIDsAfter(ctx context.Context, arg ListJobIDsAfterParams) ([]int64, error) {
+	rows, err := q.db.Query(ctx, listJobIDsAfter, arg.AfterID, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listJobIDsUpdatedAfter = `-- name: ListJobIDsUpdatedAfter :many
+SELECT id
+FROM jobs
+WHERE id > $1 AND updated_at >= $2
+ORDER BY id
+LIMIT $3
+`
+
+type ListJobIDsUpdatedAfterParams struct {
+	AfterID   int64              `json:"after_id"`
+	Since     pgtype.Timestamptz `json:"since"`
+	BatchSize int32              `json:"batch_size"`
+}
+
+// Id-only projection of ListJobsUpdatedAfter — the corruption-degrade path for the
+// incremental (`reindex --since`) scan, mirroring ListJobIDsAfter.
+func (q *Queries) ListJobIDsUpdatedAfter(ctx context.Context, arg ListJobIDsUpdatedAfterParams) ([]int64, error) {
+	rows, err := q.db.Query(ctx, listJobIDsUpdatedAfter, arg.AfterID, arg.Since, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listJobSitemapFreshest = `-- name: ListJobSitemapFreshest :many
 SELECT public_slug, updated_at
 FROM jobs

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -253,6 +253,15 @@ type Querier interface {
 	// Slim keyset page of companies for the sitemap, cursored by the slug primary key
 	// (first chunk keyed by the empty string, which sorts before every slug).
 	ListCompanySitemap(ctx context.Context, arg ListCompanySitemapParams) ([]ListCompanySitemapRow, error)
+	// Id-only projection of ListJobsByIDAfter, used as the corruption-degrade path:
+	// when a full SELECT * batch faults on a corrupted TOAST value (SQLSTATE XX001),
+	// the scan re-reads the same window as bare ids (id is never toasted, so this
+	// never faults) and then fetches each row individually to isolate and skip the
+	// unreadable one.
+	ListJobIDsAfter(ctx context.Context, arg ListJobIDsAfterParams) ([]int64, error)
+	// Id-only projection of ListJobsUpdatedAfter — the corruption-degrade path for the
+	// incremental (`reindex --since`) scan, mirroring ListJobIDsAfter.
+	ListJobIDsUpdatedAfter(ctx context.Context, arg ListJobIDsUpdatedAfterParams) ([]int64, error)
 	// The freshest open jobs for the sitemap: only the fields a URL needs, newest id
 	// first. Ordering by id DESC (served by jobs_open_id_idx) reads the most recently
 	// inserted rows, which sit at the physical end of the heap — a sequential, cache-warm

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -31,6 +31,27 @@ WHERE id > sqlc.arg(after_id) AND updated_at >= sqlc.arg(since)
 ORDER BY id
 LIMIT sqlc.arg(batch_size);
 
+-- name: ListJobIDsAfter :many
+-- Id-only projection of ListJobsByIDAfter, used as the corruption-degrade path:
+-- when a full SELECT * batch faults on a corrupted TOAST value (SQLSTATE XX001),
+-- the scan re-reads the same window as bare ids (id is never toasted, so this
+-- never faults) and then fetches each row individually to isolate and skip the
+-- unreadable one.
+SELECT id
+FROM jobs
+WHERE id > sqlc.arg(after_id)
+ORDER BY id
+LIMIT sqlc.arg(batch_size);
+
+-- name: ListJobIDsUpdatedAfter :many
+-- Id-only projection of ListJobsUpdatedAfter — the corruption-degrade path for the
+-- incremental (`reindex --since`) scan, mirroring ListJobIDsAfter.
+SELECT id
+FROM jobs
+WHERE id > sqlc.arg(after_id) AND updated_at >= sqlc.arg(since)
+ORDER BY id
+LIMIT sqlc.arg(batch_size);
+
 -- name: GetJob :one
 SELECT *
 FROM jobs

--- a/internal/enrich/runner.go
+++ b/internal/enrich/runner.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"sync"
 	"time"
+
+	"github.com/strelov1/freehire/internal/worker"
 )
 
 // Claimed is one outbox entry leased to this run.
@@ -115,6 +117,14 @@ func (rn *run) process(ctx context.Context, entry Claimed) {
 
 	job, err := rn.store.Job(ctx, entry.JobID)
 	if err != nil {
+		// A corrupted row (XX001) is permanently unreadable — retrying across cron
+		// runs would only burn the attempt budget on a job that can never load, so
+		// dead-letter it immediately (maxAttempts=1) instead.
+		if worker.IsCorruptedRow(err) {
+			rn.failN(ctx, entry, fmt.Errorf("load job: %w", err), 1)
+			log.Printf("enrich: job=%d dead-lettered (corrupted row) in %s: %v", entry.JobID, time.Since(start).Round(time.Millisecond), err)
+			return
+		}
 		rn.fail(ctx, entry, fmt.Errorf("load job: %w", err))
 		log.Printf("enrich: job=%d load failed in %s: %v", entry.JobID, time.Since(start).Round(time.Millisecond), err)
 		return
@@ -176,7 +186,14 @@ func (rn *run) enrich(ctx context.Context, job JobInput) (Enrichment, error) {
 }
 
 func (rn *run) fail(ctx context.Context, entry Claimed, cause error) {
-	dead, err := rn.store.Fail(ctx, entry.OutboxID, cause.Error(), rn.opt.MaxAttempts)
+	rn.failN(ctx, entry, cause, rn.opt.MaxAttempts)
+}
+
+// failN records a failure with an explicit attempt ceiling. fail uses the run's
+// configured MaxAttempts; the corrupted-row path passes 1 to force an immediate
+// dead-letter (an unreadable row will never succeed on retry).
+func (rn *run) failN(ctx context.Context, entry Claimed, cause error, maxAttempts int) {
+	dead, err := rn.store.Fail(ctx, entry.OutboxID, cause.Error(), maxAttempts)
 	if err != nil {
 		// The attempt still counts as a failure below, but log the cause: a
 		// bookkeeping outage (e.g. the DB going unreachable mid-drain) would

--- a/internal/enrich/runner_test.go
+++ b/internal/enrich/runner_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // --- fakes ------------------------------------------------------------------
@@ -47,6 +49,7 @@ type fakeStore struct {
 	enqueued  bool
 	completed []int64
 	failed    []int64
+	failMax   []int
 }
 
 func (s *fakeStore) Enqueue(_ context.Context, _ int) (int64, error) {
@@ -74,11 +77,13 @@ func (s *fakeStore) Complete(_ context.Context, entry Claimed, _ json.RawMessage
 	return nil
 }
 
-func (s *fakeStore) Fail(_ context.Context, outboxID int64, _ string, _ int) (bool, error) {
+func (s *fakeStore) Fail(_ context.Context, outboxID int64, _ string, maxAttempts int) (bool, error) {
 	s.mu.Lock()
 	s.failed = append(s.failed, outboxID)
+	s.failMax = append(s.failMax, maxAttempts)
 	s.mu.Unlock()
-	return s.deadFor[outboxID], nil
+	// maxAttempts == 1 forces immediate dead-letter (the corrupted-row path).
+	return s.deadFor[outboxID] || maxAttempts == 1, nil
 }
 
 func opts() RunOptions {
@@ -86,6 +91,33 @@ func opts() RunOptions {
 }
 
 // --- tests ------------------------------------------------------------------
+
+// A job whose row read faults with data corruption (XX001) must be dead-lettered
+// immediately — not retried across cron runs — and the LLM must never be called
+// for an unreadable job.
+func TestRun_corruptedJobDeadLettersImmediately(t *testing.T) {
+	store := &fakeStore{
+		claims: [][]Claimed{{{OutboxID: 7, JobID: 100, TargetVersion: Version}}},
+		jobErr: map[int64]error{100: &pgconn.PgError{Code: "XX001"}},
+	}
+	prov := &funcProvider{fn: func(JobInput) (Enrichment, error) {
+		return Enrichment{Seniority: "senior", WorkMode: "remote"}, nil
+	}}
+
+	stats, err := Runner{Provider: prov, Store: store}.Run(context.Background(), opts())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.callCount() != 0 {
+		t.Errorf("provider called %d times for a corrupted job, want 0", prov.callCount())
+	}
+	if len(store.failMax) != 1 || store.failMax[0] != 1 {
+		t.Errorf("Fail maxAttempts = %v, want [1] (immediate dead-letter)", store.failMax)
+	}
+	if stats.DeadLettered != 1 {
+		t.Errorf("DeadLettered = %d, want 1", stats.DeadLettered)
+	}
+}
 
 func TestRun_validIsWrittenAndDequeued(t *testing.T) {
 	store := &fakeStore{

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -50,32 +50,32 @@ func TestParse(t *testing.T) {
 		{
 			name:     "polish spelling of warsaw resolves to PL",
 			location: "Warszawa",
-			want:     Geo{Countries: []string{"pl"}, Regions: []string{"eu"}},
+			want:     Geo{Countries: []string{"pl"}, Regions: []string{"eu"}, Cities: []string{"Warsaw"}},
 		},
 		{
 			name:     "polish city with diacritics",
 			location: "Łódź, Poland",
-			want:     Geo{Countries: []string{"pl"}, Regions: []string{"eu"}},
+			want:     Geo{Countries: []string{"pl"}, Regions: []string{"eu"}, Cities: []string{"Łódź"}},
 		},
 		{
 			name:     "unambiguous UK city",
 			location: "Manchester",
-			want:     Geo{Countries: []string{"gb"}, Regions: []string{"uk"}},
+			want:     Geo{Countries: []string{"gb"}, Regions: []string{"uk"}, Cities: []string{"Manchester"}},
 		},
 		{
 			name:     "accented montreal resolves to CA",
 			location: "Montréal, QC",
-			want:     Geo{Countries: []string{"ca"}, Regions: []string{"north_america"}},
+			want:     Geo{Countries: []string{"ca"}, Regions: []string{"north_america"}, Cities: []string{"Montreal"}},
 		},
 		{
 			name:     "australian beacon city",
 			location: "Brisbane",
-			want:     Geo{Countries: []string{"au"}, Regions: []string{"apac"}},
+			want:     Geo{Countries: []string{"au"}, Regions: []string{"apac"}, Cities: []string{"Brisbane"}},
 		},
 		{
 			name:     "new zealand beacon city",
 			location: "Auckland",
-			want:     Geo{Countries: []string{"nz"}, Regions: []string{"apac"}},
+			want:     Geo{Countries: []string{"nz"}, Regions: []string{"apac"}, Cities: []string{"Auckland"}},
 		},
 		{
 			name:     "bare remote yields work mode but no geography",

--- a/internal/worker/resilient.go
+++ b/internal/worker/resilient.go
@@ -1,0 +1,138 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// corruptDataSQLState is Postgres SQLSTATE XX001 (data_corrupted), raised when a
+// row cannot be read because its on-disk storage is damaged — most visibly a
+// "missing chunk number N for toast value ..." on a broken TOAST pointer.
+const corruptDataSQLState = "XX001"
+
+// IsCorruptedRow reports whether err is (or wraps) a Postgres data-corruption
+// error. It is deliberately narrow: only XX001 opts a read into the skip path, so
+// every other failure still surfaces to the caller unchanged.
+func IsCorruptedRow(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == corruptDataSQLState
+}
+
+// PageReader is the narrow slice of DB access ResilientPage needs: a wide keyset
+// batch (the fast path), an id-only projection of the same window (the degrade
+// path, which never detoasts so it cannot fault on corruption), and a single-row
+// fetch to isolate the readable rows from the corrupted one. Build one with
+// NewFullScanReader / NewIncrementalReader; tests supply a fake.
+type PageReader interface {
+	Batch(ctx context.Context, afterID int64, batchSize int32) ([]db.Job, error)
+	IDs(ctx context.Context, afterID int64, batchSize int32) ([]int64, error)
+	Row(ctx context.Context, id int64) (db.Job, error)
+}
+
+// jobQueries is the subset of *db.Queries the readers call — narrowed to keep the
+// readers testable and their dependency explicit.
+type jobQueries interface {
+	ListJobsByIDAfter(context.Context, db.ListJobsByIDAfterParams) ([]db.Job, error)
+	ListJobIDsAfter(context.Context, db.ListJobIDsAfterParams) ([]int64, error)
+	ListJobsUpdatedAfter(context.Context, db.ListJobsUpdatedAfterParams) ([]db.Job, error)
+	ListJobIDsUpdatedAfter(context.Context, db.ListJobIDsUpdatedAfterParams) ([]int64, error)
+	GetJob(context.Context, int64) (db.Job, error)
+}
+
+type fullScanReader struct{ q jobQueries }
+
+// NewFullScanReader adapts *db.Queries to a PageReader over the whole jobs table
+// (keyset by id).
+func NewFullScanReader(q jobQueries) PageReader { return fullScanReader{q} }
+
+func (r fullScanReader) Batch(ctx context.Context, afterID int64, bs int32) ([]db.Job, error) {
+	return r.q.ListJobsByIDAfter(ctx, db.ListJobsByIDAfterParams{AfterID: afterID, BatchSize: bs})
+}
+func (r fullScanReader) IDs(ctx context.Context, afterID int64, bs int32) ([]int64, error) {
+	return r.q.ListJobIDsAfter(ctx, db.ListJobIDsAfterParams{AfterID: afterID, BatchSize: bs})
+}
+func (r fullScanReader) Row(ctx context.Context, id int64) (db.Job, error) {
+	return r.q.GetJob(ctx, id)
+}
+
+type incrementalReader struct {
+	q     jobQueries
+	since pgtype.Timestamptz
+}
+
+// NewIncrementalReader adapts *db.Queries to a PageReader over jobs changed at or
+// after since (the `reindex --since` window), keyset by id.
+func NewIncrementalReader(q jobQueries, since time.Time) PageReader {
+	return incrementalReader{q: q, since: pgtype.Timestamptz{Time: since, Valid: true}}
+}
+
+func (r incrementalReader) Batch(ctx context.Context, afterID int64, bs int32) ([]db.Job, error) {
+	return r.q.ListJobsUpdatedAfter(ctx, db.ListJobsUpdatedAfterParams{AfterID: afterID, Since: r.since, BatchSize: bs})
+}
+func (r incrementalReader) IDs(ctx context.Context, afterID int64, bs int32) ([]int64, error) {
+	return r.q.ListJobIDsUpdatedAfter(ctx, db.ListJobIDsUpdatedAfterParams{AfterID: afterID, Since: r.since, BatchSize: bs})
+}
+func (r incrementalReader) Row(ctx context.Context, id int64) (db.Job, error) {
+	return r.q.GetJob(ctx, id)
+}
+
+// ResilientPage reads one keyset page. Normally it returns the batch as-is. If the
+// batch faults with a data-corruption error (XX001) — one row's TOAST is damaged,
+// which fails the whole SELECT * — it degrades: it re-lists the same window as bare
+// ids and fetches each row individually, collecting the readable ones and skipping
+// (with a log line) any that still fault with XX001. Non-corruption errors always
+// propagate unchanged.
+//
+// lastID is the keyset cursor for the next call. On the degrade path it advances to
+// the last listed id — past the skipped row — so the scan never loops on it. When
+// nothing was read (empty batch, or an empty degrade window), lastID equals the
+// input afterID, which the caller reads as "no progress → exhausted".
+func ResilientPage(ctx context.Context, r PageReader, afterID int64, batchSize int32) (rows []db.Job, lastID int64, skipped []int64, err error) {
+	rows, err = r.Batch(ctx, afterID, batchSize)
+	if err == nil {
+		if len(rows) == 0 {
+			return nil, afterID, nil, nil
+		}
+		return rows, rows[len(rows)-1].ID, nil, nil
+	}
+	if !IsCorruptedRow(err) {
+		return nil, 0, nil, err
+	}
+
+	ids, idErr := r.IDs(ctx, afterID, batchSize)
+	if idErr != nil {
+		return nil, 0, nil, idErr
+	}
+	if len(ids) == 0 {
+		return nil, afterID, nil, nil
+	}
+
+	rows = make([]db.Job, 0, len(ids))
+	for _, id := range ids {
+		job, rowErr := r.Row(ctx, id)
+		if rowErr != nil {
+			if IsCorruptedRow(rowErr) {
+				skipped = append(skipped, id)
+				log.Printf("resilient scan: skipping corrupted row id=%d: %v", id, rowErr)
+				continue
+			}
+			// The row vanished between the id-list and this fetch (a concurrent
+			// close/delete). The fast keyset SELECT would simply omit it, so the
+			// degrade path does too — stay symmetric rather than aborting the scan.
+			if errors.Is(rowErr, pgx.ErrNoRows) {
+				continue
+			}
+			return nil, 0, nil, rowErr
+		}
+		rows = append(rows, job)
+	}
+	return rows, ids[len(ids)-1], skipped, nil
+}

--- a/internal/worker/resilient_test.go
+++ b/internal/worker/resilient_test.go
@@ -1,0 +1,165 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// fakeReader is a scripted pageReader for resilientPage tests. batchErr, when set,
+// is returned by batch(); rows map holds per-id results for the degrade path
+// (a nil error with an all-zero Job means "corrupted" only if listed in rowErr).
+type fakeReader struct {
+	batchRows  []db.Job
+	batchErr   error
+	idList     []int64
+	idErr      error
+	rowResults map[int64]db.Job
+	rowErrs    map[int64]error
+	batchCalls int
+	idCalls    int
+}
+
+func (f *fakeReader) Batch(_ context.Context, _ int64, _ int32) ([]db.Job, error) {
+	f.batchCalls++
+	return f.batchRows, f.batchErr
+}
+
+func (f *fakeReader) IDs(_ context.Context, _ int64, _ int32) ([]int64, error) {
+	f.idCalls++
+	return f.idList, f.idErr
+}
+
+func (f *fakeReader) Row(_ context.Context, id int64) (db.Job, error) {
+	if err := f.rowErrs[id]; err != nil {
+		return db.Job{}, err
+	}
+	return f.rowResults[id], nil
+}
+
+func corruptErr() error { return &pgconn.PgError{Code: corruptDataSQLState} }
+
+func TestResilientPage_HealthyBatch(t *testing.T) {
+	r := &fakeReader{batchRows: []db.Job{{ID: 1}, {ID: 2}, {ID: 5}}}
+	rows, lastID, skipped, err := ResilientPage(context.Background(), r, 0, 2000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 3 || lastID != 5 || len(skipped) != 0 {
+		t.Fatalf("rows=%d lastID=%d skipped=%v", len(rows), lastID, skipped)
+	}
+	if r.idCalls != 0 {
+		t.Fatalf("degrade path used on healthy batch: idCalls=%d", r.idCalls)
+	}
+}
+
+func TestResilientPage_EmptyBatchExhausted(t *testing.T) {
+	r := &fakeReader{batchRows: nil}
+	rows, lastID, _, err := ResilientPage(context.Background(), r, 42, 2000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 0 || lastID != 42 {
+		t.Fatalf("expected no rows and lastID unchanged (42), got rows=%d lastID=%d", len(rows), lastID)
+	}
+}
+
+func TestResilientPage_CorruptedRowSkipped(t *testing.T) {
+	r := &fakeReader{
+		batchErr:   corruptErr(),
+		idList:     []int64{10, 11, 12},
+		rowResults: map[int64]db.Job{10: {ID: 10}, 12: {ID: 12}},
+		rowErrs:    map[int64]error{11: corruptErr()},
+	}
+	rows, lastID, skipped, err := ResilientPage(context.Background(), r, 9, 2000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 || rows[0].ID != 10 || rows[1].ID != 12 {
+		t.Fatalf("expected rows 10,12; got %+v", rows)
+	}
+	if len(skipped) != 1 || skipped[0] != 11 {
+		t.Fatalf("expected skipped [11]; got %v", skipped)
+	}
+	if lastID != 12 {
+		t.Fatalf("expected keyset advanced to 12 (past skipped row); got %d", lastID)
+	}
+}
+
+func TestResilientPage_VanishedRowInDegradeSkipped(t *testing.T) {
+	// Row 11 disappears (pgx.ErrNoRows) between the id-list and the fetch — a
+	// concurrent close/delete. The fast SELECT would omit it; the degrade path must
+	// too, without aborting and without counting it as corrupted.
+	r := &fakeReader{
+		batchErr:   corruptErr(),
+		idList:     []int64{10, 11, 12},
+		rowResults: map[int64]db.Job{10: {ID: 10}, 12: {ID: 12}},
+		rowErrs:    map[int64]error{11: pgx.ErrNoRows},
+	}
+	rows, lastID, skipped, err := ResilientPage(context.Background(), r, 9, 2000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 || rows[0].ID != 10 || rows[1].ID != 12 {
+		t.Fatalf("expected rows 10,12; got %+v", rows)
+	}
+	if len(skipped) != 0 {
+		t.Fatalf("a vanished row must not count as corrupted; skipped=%v", skipped)
+	}
+	if lastID != 12 {
+		t.Fatalf("expected keyset advanced to 12; got %d", lastID)
+	}
+}
+
+func TestResilientPage_NonCorruptionBatchErrorPropagates(t *testing.T) {
+	sentinel := errors.New("connection reset")
+	r := &fakeReader{batchErr: sentinel}
+	_, _, _, err := ResilientPage(context.Background(), r, 0, 2000)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error propagated, got %v", err)
+	}
+	if r.idCalls != 0 {
+		t.Fatalf("degrade path must not run for non-XX001 error")
+	}
+}
+
+func TestResilientPage_NonCorruptionRowErrorPropagates(t *testing.T) {
+	sentinel := errors.New("connection reset mid-row")
+	r := &fakeReader{
+		batchErr:   corruptErr(),
+		idList:     []int64{20, 21},
+		rowErrs:    map[int64]error{21: sentinel},
+		rowResults: map[int64]db.Job{20: {ID: 20}},
+	}
+	_, _, _, err := ResilientPage(context.Background(), r, 19, 2000)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel propagated from per-row read, got %v", err)
+	}
+}
+
+func TestIsCorruptedRow(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"data corruption XX001", &pgconn.PgError{Code: "XX001"}, true},
+		{"wrapped XX001", fmt.Errorf("read batch: %w", &pgconn.PgError{Code: "XX001"}), true},
+		{"other pg error", &pgconn.PgError{Code: "23505"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCorruptedRow(tt.err); got != tt.want {
+				t.Errorf("IsCorruptedRow(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/resilient-toast-corruption/.openspec.yaml
+++ b/openspec/changes/resilient-toast-corruption/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/resilient-toast-corruption/design.md
+++ b/openspec/changes/resilient-toast-corruption/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`reindex` reads jobs in keyset batches of 2000 via `db.Queries.ListJobsByIDAfter` (`cmd/reindex/main.go`, `pageFetcher`). The `SELECT` detoasts every column server-side, so one row with a broken TOAST pointer fails the whole batch query with `pgconn.PgError.Code == "XX001"`, aborting the run before the index swap. `enrich` instead reads one job at a time via `db.Queries.GetJob` on each claimed outbox entry (`cmd/enrich/store.go`), and already routes failures to fail→retry→dead-letter — so it is per-row isolated but wastes retries on a permanently unreadable row. `ingest` writes and never full-scans+detoasts, so it is unaffected (`backfill-derive` completed for the same reason — it does not touch the corrupted field). The DB runs as `postgres:16-alpine` in `freehire-ops/docker-compose.prod.yml` with the default docker stop grace (10s), so a slow shutdown under load gets SIGKILLed — a likely origin of the corruption.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One corrupted (`XX001`) row cannot abort a full-scan worker; it is skipped and logged, the scan completes.
+- `reindex` reaches its swap with corrupted rows present (this also closes the live `/facets` 500 once deployed).
+- `enrich` dead-letters a corrupted row immediately instead of burning retries.
+- Postgres shuts down cleanly to stop producing new corruption.
+- Operators can find and repair corrupted rows.
+
+**Non-Goals:**
+- Recovering the corrupted field's data (it is unrecoverable; re-ingest/re-enrich repopulates).
+- Enabling Postgres data checksums (requires a cluster rebuild via dump/restore — tracked separately).
+- Changing the batch/keyset design or any API/schema.
+
+## Decisions
+
+**1. Resilient page helper (shared).** Add `resilientPage(ctx, r ResilientReader, afterID, batchSize) (rows []db.Job, lastID int64, skipped []int64, err error)`:
+1. Fast path: `ListJobsByIDAfter(afterID, batchSize)`.
+2. On error classified as `XX001` (via `errors.As` → `*pgconn.PgError`, `Code == "XX001"`): call a new `ListJobIDsAfter(afterID, batchSize)` (projects `id` only — no toasted columns, so it never faults), then `GetJob(id)` per id; readable rows collected, `XX001` ids appended to `skipped` and logged, keyset advanced to the last listed id.
+3. Any non-`XX001` error returned unchanged.
+Place it where both the query set and Job type are in scope; `internal/worker` (already imported by the workers) with `db.Queries` behind a small interface for testability. One new sqlc query `ListJobIDsAfter`.
+
+**2. `reindex` wires the helper.** `fullScan`/`incrementalScan` return via `resilientPage`; the run accumulates `skipped` into the existing stats/log summary. Incremental scan (`--since`) needs the same id-only fallback keyed on `updated_at`; if that adds too much surface, the fallback can list ids with the same predicate — decided during implementation, but the full-scan path is the one that crashed and is mandatory.
+
+**3. `enrich` classifies corruption.** In the claim/process path, wrap the `GetJob` read; if the error is `XX001`, mark the entry dead-lettered (skip retry) with a clear reason. Reuses the existing dead-letter path, only short-circuiting the retry.
+
+**4. Graceful shutdown (ops).** Set `stop_grace_period: 60s` on the `db` service in `docker-compose.prod.yml`. Postgres receives SIGINT/SIGTERM (fast shutdown) from docker and gets 60s to checkpoint before SIGKILL. Optionally set the container's OOM score so the kernel prefers killing a worker over Postgres — noted, not required.
+
+**5. Diagnostics & repair (ops runbook).** A `DO` scan that reads every row and collects `XX001` ids (already used live to find the current bad rows); `pg_amcheck` for an authoritative heap+TOAST check; repair by `UPDATE jobs SET <corrupted field> = '' WHERE id = <bad>` (rewrites the TOAST pointer, row readable again; value returns on next ingest/enrich). A disk-space alert cron (`df` threshold → log/Telegram), since disk-full is a known prior corruption trigger.
+
+## Risks / Trade-offs
+
+- **Row-by-row fallback is slow for a batch that contains a bad row** (up to `batchSize` single-row fetches). Acceptable: corruption is rare, so the penalty applies only to the few batches that contain a bad row, not the whole scan.
+- **A corrupted row is silently absent from the index** until repaired+re-ingested. Mitigated by logging skipped ids and the repair runbook — silent only in the index, never in the logs.
+- **Repair clears a field**, losing one job's description until refresh. Acceptable — the alternative is an unreadable, unindexable row.
+- **`stop_grace_period` lengthens worst-case deploy stop** by up to 60s if Postgres is slow to checkpoint. Acceptable trade for avoiding corruption.

--- a/openspec/changes/resilient-toast-corruption/proposal.md
+++ b/openspec/changes/resilient-toast-corruption/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+A single row in `jobs` with corrupted TOAST storage (`missing chunk number 0 for toast value ... SQLSTATE XX001`) crashed the entire facet `reindex` mid-run, so a new deploy's search index never swapped in and `/api/v1/jobs/facets` stayed 500. One unreadable row out of ~2.5M open jobs must not be able to take down a full-catalogue worker. The corruption itself most likely came from Postgres being SIGKILLed (OOM / short docker stop grace) mid-write, so we also close that root cause.
+
+## What Changes
+
+- **Resilient full-scan reads**: a shared helper wraps the keyset batch read so that when a batch fails with `XX001` (data corruption), it degrades to id-only listing + per-row fetch, skips and logs the unreadable row(s), and continues — instead of aborting the whole scan.
+- **`reindex` uses the helper**: the facet/semantic reindex completes to the index swap even with corrupted rows present; skipped rows are counted and logged.
+- **`enrich` fast-fails on corruption**: the enrichment worker (already per-row) recognises `XX001` and dead-letters the entry immediately instead of burning its retry budget.
+- **Graceful DB shutdown (ops)**: raise the Postgres container `stop_grace_period` so `docker stop` lets Postgres finish a clean fast-shutdown before SIGKILL — removing the likely corruption trigger.
+- **Diagnostics & repair (ops)**: a corrupted-row scan + `pg_amcheck` procedure to find bad rows, a repair step that clears the corrupted field so the row is readable again (re-populated on next ingest/enrich), and a disk-space alert (disk-full is a known prior trigger).
+
+## Capabilities
+
+### New Capabilities
+- `corruption-resilience`: full-scan workers survive individual corrupted (`XX001`) rows by skipping+logging them rather than aborting; operators can detect and repair corrupted rows; the DB shuts down cleanly to prevent new corruption.
+
+### Modified Capabilities
+<!-- none: worker read behaviour is new resilience, not a change to an existing spec's requirements -->
+
+## Impact
+
+- **Code (`hire`)**: new `internal/db` (or `internal/worker`) resilient-page helper + `ListJobIDsAfter` query; `cmd/reindex` streaming loop; `internal/enrich` failure classification.
+- **Ops (`freehire-ops`)**: `docker-compose.prod.yml` `db` service `stop_grace_period`; diagnostics/repair runbook; disk-space alert cron.
+- **Data**: repairing a corrupted row clears one job's corrupted field (e.g. `description`) until its next ingest/enrich refresh.
+- **No API/schema breaking changes.**

--- a/openspec/changes/resilient-toast-corruption/specs/corruption-resilience/spec.md
+++ b/openspec/changes/resilient-toast-corruption/specs/corruption-resilience/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Full-scan reads survive corrupted rows
+
+A full-catalogue keyset scan SHALL NOT abort when an individual row cannot be read due to Postgres data corruption. When a batch read fails with SQLSTATE `XX001` (data corruption, e.g. a missing TOAST chunk), the scan SHALL degrade to reading the affected batch row-by-row, skip only the rows that still fail with `XX001`, log each skipped row's id, advance the keyset past them, and continue the scan to completion.
+
+Errors other than `XX001` SHALL propagate unchanged (the resilience path is narrow to data corruption only, so unrelated failures still surface).
+
+#### Scenario: healthy batch reads normally
+
+- **WHEN** a batch read succeeds
+- **THEN** the helper returns the batch rows and the last id, with no skipped rows and no extra queries
+
+#### Scenario: batch contains one corrupted row
+
+- **WHEN** a batch read fails with SQLSTATE `XX001`
+- **THEN** the helper lists the batch's ids (a projection that does not detoast), fetches each row individually, returns every readable row, records the corrupted row's id as skipped, logs it, and advances the keyset past the batch
+
+#### Scenario: non-corruption error is not swallowed
+
+- **WHEN** a batch read fails with an error whose SQLSTATE is not `XX001`
+- **THEN** the helper returns that error unchanged and does not enter the row-by-row degrade path
+
+### Requirement: Reindex completes despite corrupted rows
+
+The `reindex` worker SHALL read jobs through the resilient full-scan helper so that a corrupted row does not prevent the index rebuild from reaching the swap. Skipped rows SHALL be counted and reported in the run's log summary; a corrupted row is simply absent from the rebuilt index (it is unreadable) rather than aborting the rebuild.
+
+#### Scenario: reindex with a corrupted row still swaps in
+
+- **WHEN** a full reindex encounters a corrupted row mid-scan
+- **THEN** the corrupted row is skipped and logged, the remaining jobs are indexed, and the fresh index is swapped in
+
+### Requirement: Enrichment fast-fails on corrupted rows
+
+The `enrich` worker SHALL classify a per-job read that fails with SQLSTATE `XX001` as a non-retryable (corrupted) failure and dead-letter the outbox entry immediately, rather than consuming its retry budget on an unreadable row.
+
+#### Scenario: enrich claims a corrupted job
+
+- **WHEN** enrichment reads a claimed job and the read fails with SQLSTATE `XX001`
+- **THEN** the entry is marked dead-lettered without retry and the worker continues draining other entries
+
+### Requirement: Graceful database shutdown
+
+The Postgres container SHALL be given enough shutdown grace for a clean fast-shutdown to complete before the container runtime sends SIGKILL, so the database is not killed mid-write (a corruption trigger).
+
+#### Scenario: stopping the DB container
+
+- **WHEN** the Postgres container is stopped (deploy, restart, or manual `docker stop`)
+- **THEN** Postgres receives its stop signal and completes a clean shutdown within the configured grace period before any SIGKILL
+
+### Requirement: Corruption detection and repair
+
+Operators SHALL be able to detect corrupted rows across the catalogue and repair them. Detection SHALL enumerate the ids of rows that fail to read (`XX001`). Repair SHALL make a corrupted row readable again by clearing the corrupted field, accepting that its value is re-populated on the row's next ingest or enrich refresh.
+
+#### Scenario: scan reports corrupted ids
+
+- **WHEN** the corruption scan runs over the `jobs` table
+- **THEN** it reports the ids of every row that cannot be fully read
+
+#### Scenario: repair restores readability
+
+- **WHEN** a corrupted row is repaired
+- **THEN** the row can be read in full afterwards and is eligible for indexing and enrichment again

--- a/openspec/changes/resilient-toast-corruption/tasks.md
+++ b/openspec/changes/resilient-toast-corruption/tasks.md
@@ -1,0 +1,35 @@
+## 1. Resilient page helper (code, TDD)
+
+- [x] 1.1 Add `ListJobIDsAfter` sqlc query (projects `id` only, keyset by `id`), run `make sqlc`, commit generated code
+- [x] 1.2 Add `XX001` classifier helper (`errors.As` → `*pgconn.PgError`, `Code == "XX001"`) with unit test
+- [x] 1.3 Implement `ResilientPage` in `internal/worker` behind a small reader interface: fast batch path, `XX001` degrade to id-list + per-row `GetJob`, skip+log corrupted ids, advance keyset; unit tests for healthy batch, one corrupted row, non-`XX001` error propagation
+
+## 2. Reindex uses the helper (code, TDD)
+
+- [x] 2.1 Wire full scan (and `--since` incremental scan) through `ResilientPage`; accumulate skipped ids into run stats and log summary
+- [x] 2.2 Test: reindex over a reader that yields a corrupted row skips it, indexes the rest, reaches swap
+
+## 3. Enrich fast-fails on corruption (code, TDD)
+
+- [x] 3.1 Classify `XX001` on the claimed-job read as non-retryable; dead-letter the entry immediately with a clear reason
+- [x] 3.2 Test: a corrupted claimed job is dead-lettered without retry; other entries continue draining
+
+## 3b. Unblock CI (pre-existing, separate concern)
+
+- [x] 3b.1 Fix stale `internal/location` city test expectations left red by #374 (code correct, assertions not updated) — a red `go test ./...` blocks this PR's CI
+
+## 4. Graceful DB shutdown (ops)
+
+- [ ] 4.1 Set `stop_grace_period: 60s` on the `db` service in `freehire-ops/docker-compose.prod.yml`; note optional OOM-score tweak in the ops README
+
+## 5. Diagnostics, repair, prevention (ops)
+
+- [ ] 5.1 Add a corruption-scan + `pg_amcheck` runbook (find `XX001` row ids) to ops docs
+- [ ] 5.2 Add a repair procedure (clear corrupted field so the row is readable; re-populated on next ingest/enrich) to ops docs
+- [ ] 5.3 Add a disk-space alert cron (`df` threshold → log/Telegram) to ops
+
+## 6. Rollout & verification
+
+- [ ] 6.1 Deploy the resilient `reindex` first; run reindex on prod and confirm it passes the corrupted row(s), swaps in, and `/api/v1/jobs/facets` returns 200 with the city facet populated
+- [ ] 6.2 Repair the remaining corrupted row(s) found by the scan; re-run `pg_amcheck` to confirm the catalogue is clean
+- [ ] 6.3 Apply graceful-shutdown + disk-alert ops changes to prod


### PR DESCRIPTION
## Why
A single \`jobs\` row with a broken TOAST pointer (\`missing chunk number 0 for toast value ... SQLSTATE XX001\`) crashed the entire facet \`reindex\` mid-run, so a fresh deploy's index never swapped in and \`/api/v1/jobs/facets\` stayed 500. One unreadable row out of ~2.5M must not take down a full-catalogue worker.

## What
- **\`internal/worker\`**: \`ResilientPage\` — a keyset page reader that, on \`XX001\`, degrades to an id-only list (never detoasts) + per-row \`GetJob\`, skipping and logging the corrupted row and advancing the keyset. \`IsCorruptedRow\` classifier; full + incremental \`PageReader\` adapters; \`ListJobIDsAfter\`/\`ListJobIDsUpdatedAfter\` id-only queries. A vanished row (\`pgx.ErrNoRows\`, concurrent close) is skipped too, matching the fast SELECT.
- **\`cmd/reindex\`**: loops via \`ResilientPage\` with keyset-progress termination (\`lastID == afterID\`); skipped rows counted + logged. Reaches the swap despite corrupted rows.
- **\`internal/enrich\`**: an \`XX001\` job read is dead-lettered immediately (no retry-budget burn).

## Also (separate concern)
- **\`fix(location)\`**: six stale city test expectations left red on \`main\` by #374 (code correct, assertions not updated) — a red \`go test ./...\` blocked CI.

## Test
Unit tests for healthy batch, corrupted-row degrade, vanished-row skip, non-XX001 propagation, keyset exhaustion; reindex skips corrupted + promotes; enrich dead-letters corrupted without retry. Full suite green (46 ok, 0 fail).

OpenSpec: \`resilient-toast-corruption\`. Ops follow-ups (graceful DB shutdown, pg_amcheck runbook, repair, disk alert) tracked in tasks.md.