### PR TITLE
feat(web): professional multi-column site footer + LinkedIn

### DIFF
--- a/openspec/changes/add-site-footer/.openspec.yaml
+++ b/openspec/changes/add-site-footer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-site-footer/design.md
+++ b/openspec/changes/add-site-footer/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The footer today is inline `<footer>` markup in `web/src/routes/+layout.svelte`
+(a single row: tagline + CLI/API/Telegram/GitHub). The layout already wraps the app
+in a `flex min-h-svh flex-col` column, so a bottom-pinned footer works by construction.
+The design system (`web/src/app.css`) is a deliberate flat-neutral palette: oklch
+grayscale, one background fill, separation via spacing + thin borders, system fonts.
+`ProviderIcon.svelte` already renders github/linkedin/telegram brand marks. The web
+app has **no test runner** (memory: `hire web no test runner`) — verification is
+`svelte-check` + lint + visual.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A dedicated, reusable `Footer.svelte` with a restrained multi-column layout.
+- Add the LinkedIn social link; keep GitHub + Telegram.
+- Faithful to the flat-neutral aesthetic; responsive (stacks on mobile); theme-safe.
+
+**Non-Goals:**
+- No new fonts, colors, or dependencies.
+- No newsletter form, language switcher, or extra pages beyond existing routes.
+- No changes to `ProviderIcon`, header, or any backend/API.
+
+## Decisions
+
+- **Extract into `$lib/components/Footer.svelte`, mount once from the layout.**
+  Mirrors the existing `TopBar` component pattern (layout renders `<TopBar />`).
+  Alternative — keep it inline — rejected: a multi-column footer is too much markup
+  to leave in the layout and isn't reusable/testable in isolation.
+- **Link groups map to existing routes only** (Product / Resources / Company). Chosen
+  over inventing new destinations so every link resolves today; `resolve()` from
+  `$app/paths` keeps internal links correct under base-path config, matching the
+  current footer's usage.
+- **Styling with existing Tailwind semantic tokens** (`border`, `muted-foreground`,
+  `foreground`) and a responsive grid (`grid-cols-2 md:grid-cols-4` or similar) that
+  stacks on mobile. No custom CSS beyond what tokens provide. Chosen over a bespoke
+  palette to honor `surgical changes` / `match existing style`.
+- **Social links reuse `ProviderIcon`** with `target="_blank" rel="noopener noreferrer"`,
+  exactly as the current external links do.
+
+## Risks / Trade-offs
+
+- [No web test runner → scenarios can't be unit-tested] → verify via `svelte-check`
+  (types/a11y), lint, and a visual check in both themes and at a mobile width.
+- [Route drift: a linked route is renamed/removed later] → links use existing routes
+  observed in `src/routes`; `resolve()` surfaces bad paths at build/type time.
+- [Over-cluttering the footer] → constrain to the three named groups + brand + bottom
+  bar; the spec forbids links beyond those listed.
+
+## Migration Plan
+
+Pure frontend swap: replace the inline `<footer>` block in `+layout.svelte` with
+`<Footer />`. No data migration, no feature flag. Rollback = revert the commit.

--- a/openspec/changes/add-site-footer/proposal.md
+++ b/openspec/changes/add-site-footer/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The site footer is a thin single-row strip inlined in the root layout: a tagline
+plus four links (CLI, API, Telegram, GitHub). It reads as a placeholder, offers no
+site navigation, and omits the project's LinkedIn presence
+(`linkedin.com/company/freehire-dev/`). A proper footer improves wayfinding and
+makes freehire look professionally maintained.
+
+## What Changes
+
+- Extract the inline footer out of `web/src/routes/+layout.svelte` into a dedicated
+  `Footer.svelte` component.
+- Give it a restrained multi-column layout: a brand block (name + tagline + social
+  icons) and navigation columns grouping existing routes (Product, Resources,
+  Company).
+- Add the **LinkedIn** social link (`https://linkedin.com/company/freehire-dev/`)
+  alongside the existing GitHub and Telegram links, reusing `ProviderIcon`.
+- Add a bottom bar: copyright line + open-source note.
+- Keep it clean and uncluttered, responsive (columns stack on mobile), and faithful
+  to the flat-neutral design system (oklch grayscale, thin borders, system fonts —
+  no new fonts or colors beyond existing brand marks).
+
+## Capabilities
+
+### New Capabilities
+- `site-footer`: the global site footer — its layout, the link groups it exposes,
+  the social links it carries, and its responsive/theming behavior.
+
+### Modified Capabilities
+<!-- None: the footer today has no spec of its own; header-navigation and
+     web-frontend are unaffected. -->
+
+## Impact
+
+- `web/src/routes/+layout.svelte` — remove the inline `<footer>` markup, render
+  `<Footer />` instead.
+- `web/src/lib/components/Footer.svelte` — new component.
+- Reuses `web/src/lib/components/ProviderIcon.svelte` (already supports
+  github/linkedin/telegram); no icon changes needed.
+- No backend, API, or DB impact. No new dependencies. Verified via `svelte-check` +
+  lint + visual check (the web app has no test runner).

--- a/openspec/changes/add-site-footer/specs/site-footer/spec.md
+++ b/openspec/changes/add-site-footer/specs/site-footer/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Global footer component
+
+The web app SHALL render a single global site footer on every route, implemented as
+a dedicated `Footer.svelte` component and mounted once from the root layout (not
+inlined per route). The footer SHALL stay pinned to the bottom of the viewport on
+sparse pages via the existing column layout.
+
+#### Scenario: Footer present on every page
+
+- **WHEN** a user loads any route in the SPA
+- **THEN** the site footer is rendered below the main content
+- **AND** on a short page the footer sits at the bottom of the viewport rather than
+  floating mid-screen
+
+#### Scenario: Footer is a reusable component
+
+- **WHEN** the root layout renders
+- **THEN** it renders `<Footer />` rather than inline `<footer>` markup
+
+### Requirement: Multi-column layout with grouped navigation
+
+The footer SHALL present a restrained multi-column layout: a brand block (project
+name + one-line tagline + social icons) and navigation columns that group existing
+site routes. Link groups SHALL be:
+
+- **Product**: Jobs, Companies, Collections, Recruiters
+- **Resources**: CLI, API docs
+- **Company**: For companies, Submit a job
+
+Internal links SHALL use `$app/paths` `resolve()`. The layout SHALL remain clean and
+uncluttered — no links or sections beyond those listed.
+
+#### Scenario: Navigation groups link to real routes
+
+- **WHEN** a user clicks a footer navigation link
+- **THEN** they are taken to the corresponding in-app route (e.g. Jobs → `/jobs`,
+  API docs → `/docs/api`)
+
+### Requirement: Social links including LinkedIn
+
+The footer SHALL expose social links for GitHub
+(`https://github.com/strelov1/freehire`), LinkedIn
+(`https://linkedin.com/company/freehire-dev/`), and Telegram
+(`https://t.me/freehiredev`), each rendered with its `ProviderIcon` brand mark.
+External links SHALL open in a new tab with `target="_blank"` and
+`rel="noopener noreferrer"`.
+
+#### Scenario: LinkedIn link present and safe
+
+- **WHEN** a user views the footer
+- **THEN** a LinkedIn link pointing at `https://linkedin.com/company/freehire-dev/`
+  is shown with the LinkedIn icon
+- **AND** it opens in a new tab with `rel="noopener noreferrer"`
+
+#### Scenario: GitHub and Telegram links retained
+
+- **WHEN** a user views the footer
+- **THEN** the existing GitHub and Telegram links are still present, each with its
+  brand icon and opening in a new tab
+
+### Requirement: Bottom bar
+
+The footer SHALL include a bottom bar containing a copyright line and an
+open-source note, visually separated from the columns by a thin border.
+
+#### Scenario: Copyright and open-source note shown
+
+- **WHEN** a user views the footer
+- **THEN** a bottom bar shows a copyright line and an open-source note
+
+### Requirement: Responsive and theme-faithful
+
+The footer SHALL be responsive — columns stack vertically on narrow viewports and
+sit side by side on wide ones — and SHALL use only the existing flat-neutral design
+tokens (oklch grayscale, thin borders, system fonts). It SHALL NOT introduce new
+fonts or colors beyond the existing brand icon marks, and SHALL render correctly in
+both light and dark themes.
+
+#### Scenario: Columns stack on mobile
+
+- **WHEN** the footer is viewed on a narrow (mobile) viewport
+- **THEN** the brand block and navigation columns stack vertically without horizontal
+  overflow
+
+#### Scenario: Adapts to theme
+
+- **WHEN** the app is in dark mode
+- **THEN** the footer uses the dark-theme tokens (foreground/muted/border) and remains
+  legible

--- a/openspec/changes/add-site-footer/tasks.md
+++ b/openspec/changes/add-site-footer/tasks.md
@@ -1,0 +1,24 @@
+## 1. Footer component
+
+- [x] 1.1 Create `web/src/lib/components/Footer.svelte` scaffold: `<footer>` with the
+  responsive grid shell and a brand block (project name + one-line tagline)
+- [x] 1.2 Add the social links (GitHub, LinkedIn, Telegram) to the brand block, each
+  via `ProviderIcon` with `target="_blank" rel="noopener noreferrer"`; LinkedIn →
+  `https://linkedin.com/company/freehire-dev/`
+- [x] 1.3 Add the navigation columns — Product (Jobs, Companies, Collections,
+  Recruiters), Resources (CLI, API docs), Company (For companies, Submit) — using
+  `resolve()` for internal links
+- [x] 1.4 Add the bottom bar: copyright line + open-source note, separated by a thin
+  top border; confirm responsive stacking and light/dark tokens
+
+## 2. Integration
+
+- [x] 2.1 Replace the inline `<footer>` block in `web/src/routes/+layout.svelte` with
+  `<Footer />` (import from `$lib/components/Footer.svelte`)
+
+## 3. Verify
+
+- [x] 3.1 `svelte-check` passes for the new component and the layout; lint shows no new
+  errors
+- [x] 3.2 Visual check: footer renders correctly in light and dark themes and at a
+  mobile viewport width (columns stack, no horizontal overflow)

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import ProviderIcon from './ProviderIcon.svelte';
+
+  // Grouped navigation over existing routes only — kept deliberately small so the
+  // footer stays uncluttered. Internal links go through resolve() (base-path safe),
+  // mirroring the header.
+  const groups = [
+    {
+      title: 'Product',
+      links: [
+        { label: 'Jobs', href: resolve('/jobs') },
+        { label: 'Companies', href: resolve('/companies') },
+        { label: 'Collections', href: resolve('/collections') },
+        { label: 'Recruiters', href: resolve('/recruiters') },
+      ],
+    },
+    {
+      title: 'Resources',
+      links: [
+        { label: 'CLI', href: resolve('/cli') },
+        { label: 'API docs', href: resolve('/docs/api') },
+      ],
+    },
+    {
+      title: 'Company',
+      links: [
+        { label: 'For companies', href: resolve('/for-companies') },
+        { label: 'Submit a job', href: resolve('/submit') },
+      ],
+    },
+  ];
+
+  // External profiles: open in a new tab, each rendered with its ProviderIcon brand
+  // mark. github/telegram follow the text colour (so hover works); linkedin keeps
+  // its brand blue by design.
+  const socials = [
+    { provider: 'github', label: 'GitHub', href: 'https://github.com/strelov1/freehire' },
+    { provider: 'linkedin', label: 'LinkedIn', href: 'https://linkedin.com/company/freehire-dev/' },
+    { provider: 'telegram', label: 'Telegram', href: 'https://t.me/freehiredev' },
+  ];
+
+  const year = new Date().getFullYear();
+</script>
+
+<footer class="border-t border-border">
+  <div class="mx-auto max-w-6xl px-4 py-10 sm:py-12">
+    <div class="grid grid-cols-2 gap-8 sm:grid-cols-4 sm:gap-6">
+      <!-- Brand block: full width on mobile, one column on wide viewports. -->
+      <div class="col-span-2 sm:col-span-1 sm:pr-4">
+        <a
+          href={resolve('/')}
+          class="flex items-center gap-2 text-sm font-semibold tracking-tight"
+        >
+          <!-- Same mark as the header; tracks the theme via currentColor. -->
+          <svg
+            viewBox="0 0 512 512"
+            class="size-5 shrink-0"
+            fill="currentColor"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M256 56C366.457 56 456 145.543 456 256C456 366.457 366.457 456 256 456C145.543 456 56 366.457 56 256C56 145.543 145.543 56 256 56ZM256 166L346 256L256 346L166 256L256 166Z"
+            />
+          </svg>
+          <span>FreeHire</span>
+        </a>
+        <p class="mt-3 max-w-xs text-sm text-muted-foreground">
+          Free, open-source IT job aggregator.
+        </p>
+        <div class="mt-4 flex items-center gap-3">
+          {#each socials as social (social.provider)}
+            <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external profile URL opened in a new tab; not an internal route -->
+            <a href={social.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={social.label}
+              class="text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ProviderIcon provider={social.provider} />
+            </a>
+          {/each}
+        </div>
+      </div>
+
+      <!-- Navigation groups. Each is a named landmark (aria-label) so screen readers
+           get a title without adding headings to the page outline. -->
+      {#each groups as group (group.title)}
+        <nav class="flex flex-col gap-3" aria-label={group.title}>
+          <p class="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            {group.title}
+          </p>
+          <ul class="flex flex-col gap-2">
+            {#each group.links as link (link.href)}
+              <li>
+                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal route already passed through resolve() when building `groups`; the linter can't trace it via the variable -->
+                <a href={link.href}
+                  class="text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {link.label}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </nav>
+      {/each}
+    </div>
+  </div>
+
+  <!-- Bottom bar: copyright + open-source note, split off by a thin border. -->
+  <div class="border-t border-border">
+    <div
+      class="mx-auto flex max-w-6xl flex-col gap-1 px-4 py-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between"
+    >
+      <p>© {year} FreeHire</p>
+      <p>
+        Free &amp; open-source.
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external repository URL opened in a new tab; not an internal route -->
+        <a href="https://github.com/strelov1/freehire"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-medium text-foreground transition-colors hover:text-muted-foreground"
+        >
+          View source on GitHub
+        </a>.
+      </p>
+    </div>
+  </div>
+</footer>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { resolve } from '$app/paths';
   import { navigating } from '$app/state';
   import { onMount } from 'svelte';
   import { initTheme } from '$lib/theme.svelte';
@@ -9,7 +8,7 @@
   import { searchProfiles } from '$lib/searchProfiles.svelte';
   import { notifications } from '$lib/notifications.svelte';
   import TopBar from '$lib/components/TopBar.svelte';
-  import ProviderIcon from '$lib/components/ProviderIcon.svelte';
+  import Footer from '$lib/components/Footer.svelte';
   import '../app.css';
 
   let { children } = $props();
@@ -59,43 +58,7 @@
     {@render children()}
   </main>
 
-  <footer class="border-t border-border">
-    <div
-      class="mx-auto flex w-full max-w-6xl items-center justify-between gap-3 px-4 py-3 text-xs text-muted-foreground"
-    >
-      <p>Free, open-source IT job aggregator.</p>
-      <div class="flex shrink-0 items-center gap-4">
-        <a
-          href={resolve('/cli')}
-          class="shrink-0 font-medium text-foreground transition-colors hover:text-muted-foreground"
-        >
-          CLI
-        </a>
-        <a
-          href={resolve('/docs/api')}
-          class="shrink-0 font-medium text-foreground transition-colors hover:text-muted-foreground"
-        >
-          API
-        </a>
-        <a
-          href="https://t.me/freehiredev"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex shrink-0 items-center gap-1.5 font-medium text-foreground transition-colors hover:text-muted-foreground"
-        >
-          <ProviderIcon provider="telegram" /> Ask a question
-        </a>
-        <a
-          href="https://github.com/strelov1/freehire"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="inline-flex shrink-0 items-center gap-1.5 font-medium text-foreground transition-colors hover:text-muted-foreground"
-        >
-          <ProviderIcon provider="github" /> GitHub
-        </a>
-      </div>
-    </div>
-  </footer>
+  <Footer />
 </div>
 
 <style>


### PR DESCRIPTION
## Summary
- Extract the thin single-row inline footer out of the root layout into a dedicated `Footer.svelte` component (mirrors the `TopBar` pattern).
- Restrained, professional **multi-column** layout: brand block (logo + tagline + social icons) · **Product** (Jobs, Companies, Collections, Recruiters) · **Resources** (CLI, API docs) · **Company** (For companies, Submit a job) · bottom bar (copyright + open-source note).
- Adds the **LinkedIn** profile link (`linkedin.com/company/freehire-dev/`) alongside the existing GitHub and Telegram links, reusing `ProviderIcon`.
- Faithful to the flat-neutral design system: semantic tokens only, system fonts, thin borders; responsive (columns stack on mobile); works in light + dark themes.
- Removes the now-unused `resolve`/`ProviderIcon` imports from `+layout.svelte`.

Planned as OpenSpec change `add-site-footer` (proposal/design/specs/tasks included).

## Test Plan
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `eslint` on changed files — clean (external/dynamic hrefs carry justified `eslint-disable` per repo convention)
- [x] `npm run build` — production build succeeds (adapter-node)
- [x] Visual check — footer renders professionally in dark theme (desktop) and stacks cleanly at mobile width, no horizontal overflow
- [ ] Reviewer: confirm light-theme rendering in a browser

## Notes
No web test runner exists; verification is svelte-check + eslint + build + visual (per project convention). After merge: `openspec archive add-site-footer` + sync main specs.