### PR TITLE
feat(web): full-screen mobile drawer for the header menu

### DIFF
--- a/openspec/changes/mobile-header-menu-drawer/.openspec.yaml
+++ b/openspec/changes/mobile-header-menu-drawer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/mobile-header-menu-drawer/design.md
+++ b/openspec/changes/mobile-header-menu-drawer/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`HeaderMenu.svelte` renders one panel that adapts by breakpoint: `max-sm` → a
+full-width, `max-h-[80vh]` overlay dropping from `top-14` with a backdrop; `sm` → an
+anchored `w-64` dropdown. The item list (email, nav links, account links, moderation,
+theme toggle, auth) is a flat sequence of `px-3 py-2 text-sm` rows split by `h-px`
+dividers. Body scroll is locked on mobile via `lockScroll`/`unlockScroll`; the menu
+closes on `afterNavigate`, `Escape`, outside click, and item select. The design system
+is flat-neutral (semantic tokens, system fonts); no web test runner.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Mobile menu reads as a proper full-screen drawer: brand/close top bar, sectioned
+  scrollable links with ≥44px tap targets, theme+auth pinned to a bottom bar.
+- Desktop dropdown unchanged in look and behavior.
+- No change to menu items, gating, or close/scroll-lock behavior.
+
+**Non-Goals:**
+- No new deps, animation library, colors, or fonts.
+- No change to the search field/dropdown, the header layout, or account routes.
+
+## Decisions
+
+- **Single component, two layouts via responsive classes** (not a second component).
+  The container is `max-sm:fixed max-sm:inset-0 max-sm:flex max-sm:flex-col` (full-screen
+  column) and `sm:absolute sm:right-0 sm:top-full sm:w-64 sm:rounded-md` (dropdown).
+  Alternative — split mobile/desktop components — rejected: it would duplicate the item
+  list and its gating logic.
+- **Three flex regions on mobide, collapsing to a plain list on desktop.** Mobile top
+  bar and pinned bottom bar are `sm:hidden`; the middle link region is `max-sm:flex-1
+  max-sm:overflow-y-auto`. On desktop the middle region is the whole dropdown
+  (`sm:max-h-[80vh] sm:overflow-y-auto`) and theme/auth render inline at its end.
+- **Theme + auth defined once via a Svelte `{#snippet}`**, rendered in the mobile
+  bottom bar (`sm:hidden`) and again inline for desktop (`max-sm:hidden`). This satisfies
+  the spec's "defined once, no duplicated logic" without forcing one visual placement on
+  both breakpoints. Chosen over duplicating the two buttons.
+- **Tap targets** use `min-h-11` (44px) + `text-base` on drawer rows; section labels are
+  `text-xs uppercase tracking-wider text-muted-foreground`. Chosen to meet the 44px
+  guideline while staying within existing tokens.
+- **Full-screen `inset-0` (covers the header) with its own top bar** rather than
+  `top-14`. Removes the leftover-backdrop strip and the double-header look; the drawer's
+  own brand+close replaces the covered header controls. No separate backdrop needed on
+  mobile since the sheet is opaque and full-screen (desktop keeps outside-click close).
+
+## Risks / Trade-offs
+
+- [No web test runner → scenarios can't be unit-tested] → verify with `svelte-check`,
+  eslint, and visual checks (mobile open drawer signed-in/out, desktop dropdown), both
+  themes.
+- [Responsive-class divergence is easy to get subtly wrong] → verify BOTH breakpoints
+  visually, not just mobile.
+- [Full-screen inset-0 removes the mobile backdrop] → acceptable: the opaque sheet is the
+  backdrop; scroll-lock still applies; close via the top-bar control / `Escape` /
+  item-select.
+
+## Migration Plan
+
+Pure frontend edit to one component. No data/flags. Rollback = revert the commit.

--- a/openspec/changes/mobile-header-menu-drawer/proposal.md
+++ b/openspec/changes/mobile-header-menu-drawer/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+On mobile the header menu (the hamburger panel) is a desktop dropdown stretched to
+full width: cramped `py-2` rows (tap targets ~32–36px, below the 44px guideline), a
+flat undifferentiated list of nav + account + theme + auth items separated only by
+hair-lines, and a `max-h-[80vh]` overlay that leaves a strip of backdrop at the
+bottom. It reads as unpolished. The menu's *contents* are fine; its mobile
+*presentation* is the problem.
+
+## What Changes
+
+- Redesign the menu's **mobile** presentation into a full-screen **drawer**:
+  - Its own top bar (brand wordmark + a close button) so it reads as a screen, not a
+    dropdown.
+  - A scrollable middle region with the links grouped into labelled sections
+    (Navigate / Account) and **larger tap targets** (≥48px rows, `text-base`).
+  - The theme toggle and the auth action **pinned to a bottom bar** (thumb-reachable),
+    separated by a top border.
+- Keep the existing **desktop** anchored dropdown unchanged.
+- Preserve all current behavior: same menu items and gating (nav, account, moderator,
+  sign in/out), close on item-select / `Escape` / close-control, and body-scroll lock
+  while open on mobile.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `header-navigation`: the menu's mobile overlay becomes a full-screen drawer with a
+  top bar, sectioned larger-tap-target links, and a pinned bottom action bar (the menu
+  *contents* and desktop dropdown are unchanged).
+
+## Impact
+
+- `web/src/lib/components/HeaderMenu.svelte` — the only file changed (markup + Tailwind
+  classes; a Svelte snippet to avoid duplicating the theme/auth actions across the
+  mobile bottom bar and desktop inline list).
+- No backend, API, or DB impact. No new dependencies. Verified via `svelte-check` +
+  eslint + visual check (no web test runner).

--- a/openspec/changes/mobile-header-menu-drawer/specs/header-navigation/spec.md
+++ b/openspec/changes/mobile-header-menu-drawer/specs/header-navigation/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Mobile overlay behavior
+
+On a narrow viewport the open search dropdown SHALL render as a full-width overlay
+with a backdrop, and the open menu SHALL render as a full-screen **drawer** covering
+the viewport. While either overlay is open, body scroll SHALL be locked so background
+content does not scroll behind it. The desktop (wide-viewport) menu SHALL remain an
+anchored dropdown.
+
+#### Scenario: Menu opens as a full-screen drawer on mobile
+
+- **WHEN** a user opens the menu on a narrow viewport
+- **THEN** the menu covers the viewport as a full-screen drawer (not a partial-height
+  dropdown) and the page body behind it does not scroll
+
+#### Scenario: Menu stays a dropdown on desktop
+
+- **WHEN** a user opens the menu on a wide viewport
+- **THEN** the menu renders as an anchored dropdown near the trigger, not a full-screen
+  drawer
+
+#### Scenario: Search dropdown locks background scroll on mobile
+
+- **WHEN** the search dropdown is open on a narrow viewport
+- **THEN** a backdrop appears and the page body behind it does not scroll
+
+## ADDED Requirements
+
+### Requirement: Mobile menu drawer structure
+
+The mobile menu drawer SHALL present three regions: a top bar with the brand wordmark
+and an explicit close control; a scrollable middle region listing the menu items
+grouped into labelled sections (a navigation section and, for a signed-in user, an
+account section); and a bottom bar, pinned to the bottom of the drawer, holding the
+theme toggle and the auth action (Sign in, or Log out for a signed-in user). Menu item
+rows in the drawer SHALL have a touch target of at least 44px in height. The theme
+toggle and auth action SHALL be defined once and reused across the mobile bottom bar
+and the desktop dropdown (no duplicated logic).
+
+#### Scenario: Drawer regions and sections
+
+- **WHEN** a signed-in user opens the menu on a narrow viewport
+- **THEN** the drawer shows a top bar with the brand and a close control, a scrollable
+  list with a Navigate section and an Account section, and a pinned bottom bar with the
+  theme toggle and Log out
+
+#### Scenario: Larger tap targets
+
+- **WHEN** the mobile drawer is open
+- **THEN** each menu item row is at least 44px tall
+
+#### Scenario: Close control dismisses the drawer
+
+- **WHEN** the mobile drawer is open and the user taps its close control
+- **THEN** the drawer closes
+
+#### Scenario: Signed-out bottom bar
+
+- **WHEN** a signed-out user opens the menu on a narrow viewport
+- **THEN** the pinned bottom bar shows the theme toggle and a Sign in action, and the
+  drawer shows no account section

--- a/openspec/changes/mobile-header-menu-drawer/tasks.md
+++ b/openspec/changes/mobile-header-menu-drawer/tasks.md
@@ -1,0 +1,27 @@
+## 1. Restructure the menu panel
+
+- [x] 1.1 Extract the theme toggle + auth action (Sign in / Log out) into a Svelte
+  `{#snippet}` so they can be rendered in two places without duplicating logic
+- [x] 1.2 Convert the panel container to two layouts via responsive classes: mobile
+  `fixed inset-0 flex flex-col` full-screen drawer; desktop the existing anchored
+  `w-64` dropdown (unchanged look)
+
+## 2. Mobile drawer regions
+
+- [x] 2.1 Add the mobile-only top bar (`sm:hidden`): brand wordmark + close control
+  that sets `open = false`
+- [x] 2.2 Make the link list the scrollable middle region (`max-sm:flex-1
+  max-sm:overflow-y-auto`) with labelled sections (Navigate / Account) and ≥44px
+  (`min-h-11`, `text-base`) tap targets; keep item gating (account, moderator) intact
+- [x] 2.3 Add the mobile-only pinned bottom bar (`sm:hidden`) rendering the theme/auth
+  snippet, separated by a top border; render the same snippet inline for desktop
+  (`max-sm:hidden`)
+
+## 3. Behavior + verify
+
+- [x] 3.1 Preserve scroll-lock and close-on-select/`Escape`; adjust the mobile backdrop
+  handling for the full-screen sheet (opaque sheet; close via top-bar control / Escape /
+  outside-click on desktop)
+- [x] 3.2 `svelte-check` and eslint pass for `HeaderMenu.svelte`
+- [x] 3.3 Visual check: mobile drawer (signed-in and signed-out) and desktop dropdown
+  render correctly in light and dark themes; tap targets look ≥44px; no overflow

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -11,6 +11,11 @@
 
   // The single menu absorbs the site nav, the signed-in account items, the theme
   // toggle, and the auth action — the header's only control besides search.
+  //
+  // Two layouts from one markup: on mobile the panel is a full-screen drawer
+  // (own top bar · scrollable sectioned links · pinned bottom action bar); on
+  // desktop it stays the small anchored dropdown. The theme+auth actions live in
+  // one snippet, rendered in the mobile bottom bar and inline for desktop.
 
   let open = $state(false);
   let root = $state<HTMLElement | null>(null);
@@ -18,12 +23,15 @@
   const path = $derived(page.url.pathname);
   const isActive = (href: string) => path === href || path.startsWith(`${href}/`);
 
-  // Shared classes for every menu link; the active section is emphasised.
+  // Shared row classes: a ≥44px tap target with base text on mobile, collapsing
+  // to the compact dropdown row on desktop. Active section is emphasised.
+  const rowBase =
+    'flex items-center gap-2 rounded-md px-4 min-h-11 text-base transition-colors hover:bg-accent hover:text-accent-foreground sm:min-h-0 sm:rounded-none sm:px-3 sm:py-2 sm:text-sm';
   const linkClass = (href: string) =>
-    cn(
-      'block px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground',
-      isActive(href) ? 'font-medium text-foreground' : 'text-muted-foreground',
-    );
+    cn(rowBase, isActive(href) ? 'font-medium text-foreground' : 'text-muted-foreground');
+  const sectionLabel =
+    'px-4 pt-3 pb-1 text-xs font-medium uppercase tracking-wider text-muted-foreground sm:hidden';
+
   // The theme button only renders inside the open panel (client-only), so no
   // SSR mounted-guard is needed — read the store directly.
   const isDark = $derived(themeStore.isDark);
@@ -52,7 +60,7 @@
     { href: '/my/submissions', label: 'My submissions' },
   ] as const;
 
-  // Mobile only: the open panel is a full-width overlay, so lock the page behind
+  // Mobile only: the open panel is a full-screen overlay, so lock the page behind
   // it. Desktop keeps the small anchored dropdown and stays scrollable.
   $effect(() => {
     if (!open) return;
@@ -85,6 +93,43 @@
   onkeydown={(e) => e.key === 'Escape' && (open = false)}
 />
 
+<!-- Theme toggle + auth action: defined once, rendered in the mobile bottom bar
+     and inline on desktop. -->
+{#snippet themeAuth()}
+  <button
+    type="button"
+    role="menuitem"
+    onclick={() => themeStore.toggle()}
+    class={cn(rowBase, 'w-full text-left text-muted-foreground')}
+  >
+    {#if isDark}
+      <Moon class="size-4 shrink-0" /> Light theme
+    {:else}
+      <Sun class="size-4 shrink-0" /> Dark theme
+    {/if}
+  </button>
+
+  {#if isAuthenticated()}
+    <button
+      type="button"
+      role="menuitem"
+      onclick={logout}
+      class={cn(rowBase, 'w-full text-left text-muted-foreground')}
+    >
+      Log out
+    </button>
+  {:else}
+    <button
+      type="button"
+      role="menuitem"
+      onclick={signIn}
+      class={cn(rowBase, 'w-full text-left font-medium text-foreground')}
+    >
+      Sign in
+    </button>
+  {/if}
+{/snippet}
+
 <div class="relative" bind:this={root}>
   <button
     type="button"
@@ -110,80 +155,81 @@
   </button>
 
   {#if open}
-    <!-- Mobile backdrop behind the full-width panel. -->
-    <button
-      class="fixed inset-0 z-40 bg-black/40 sm:hidden"
-      aria-label="Close menu"
-      onclick={() => (open = false)}
-    ></button>
-
     <div
       role="menu"
-      class="z-50 max-h-[80vh] overflow-y-auto border border-border bg-background py-1 shadow-lg
-             max-sm:fixed max-sm:inset-x-0 max-sm:top-14 max-sm:mt-0 max-sm:rounded-none max-sm:border-x-0
-             sm:absolute sm:right-0 sm:top-full sm:mt-2 sm:w-64 sm:rounded-md"
+      class="z-50 bg-background
+             max-sm:fixed max-sm:inset-0 max-sm:flex max-sm:flex-col
+             sm:absolute sm:right-0 sm:top-full sm:mt-2 sm:max-h-[80vh] sm:w-64 sm:overflow-y-auto sm:rounded-md sm:border sm:border-border sm:py-1 sm:shadow-lg"
     >
-      {#if isAuthenticated()}
-        <p class="truncate px-3 py-2 text-sm text-muted-foreground" title={email}>{email}</p>
-        <div class="my-1 h-px bg-border"></div>
-      {/if}
+      <!-- Mobile top bar: brand + close (drawer reads as a screen, not a dropdown). -->
+      <div class="flex h-14 shrink-0 items-center justify-between border-b border-border px-4 sm:hidden">
+        <span class="flex items-center gap-2 text-sm font-semibold tracking-tight">
+          <svg viewBox="0 0 512 512" class="size-5 shrink-0" fill="currentColor" aria-hidden="true">
+            <path
+              fill-rule="evenodd"
+              clip-rule="evenodd"
+              d="M256 56C366.457 56 456 145.543 456 256C456 366.457 366.457 456 256 456C145.543 456 56 366.457 56 256C56 145.543 145.543 56 256 56ZM256 166L346 256L256 346L166 256L256 166Z"
+            />
+          </svg>
+          FreeHire
+        </span>
+        <button
+          type="button"
+          aria-label="Close menu"
+          onclick={() => (open = false)}
+          class="inline-flex size-9 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <X class="size-5" />
+        </button>
+      </div>
 
-      <!-- Nav -->
-      {#each navLinks as link (link.href)}
-        <a href={resolve(link.href)} role="menuitem" onclick={() => (open = false)} class={linkClass(link.href)}>
-          {link.label}
-        </a>
-      {/each}
+      <!-- Middle: scrollable, sectioned links. -->
+      <div class="max-sm:flex-1 max-sm:overflow-y-auto max-sm:px-2 max-sm:pb-3">
+        {#if isAuthenticated()}
+          <p class="truncate px-4 py-2 text-sm text-muted-foreground sm:px-3" title={email}>{email}</p>
+          <div class="my-1 hidden h-px bg-border sm:block"></div>
+        {/if}
 
-      <!-- Account -->
-      {#if isAuthenticated()}
-        <div class="my-1 h-px bg-border"></div>
-        {#each accountLinks as link (link.href)}
+        <!-- Nav -->
+        <p class={sectionLabel}>Navigate</p>
+        {#each navLinks as link (link.href)}
           <a href={resolve(link.href)} role="menuitem" onclick={() => (open = false)} class={linkClass(link.href)}>
             {link.label}
           </a>
         {/each}
-        {#if isModerator}
-          <a href={resolve('/moderation')} role="menuitem" onclick={() => (open = false)} class={linkClass('/moderation')}>
-            Moderation
-          </a>
-        {/if}
-      {/if}
 
-      <!-- Theme + auth -->
-      <div class="my-1 h-px bg-border"></div>
-      <button
-        type="button"
-        role="menuitem"
-        onclick={() => themeStore.toggle()}
-        class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-      >
-        {#if isDark}
-          <Moon class="size-4" /> Light theme
-        {:else}
-          <Sun class="size-4" /> Dark theme
+        <!-- Account -->
+        {#if isAuthenticated()}
+          <div class="my-1 hidden h-px bg-border sm:block"></div>
+          <p class={sectionLabel}>Account</p>
+          {#each accountLinks as link (link.href)}
+            <a href={resolve(link.href)} role="menuitem" onclick={() => (open = false)} class={linkClass(link.href)}>
+              {link.label}
+            </a>
+          {/each}
+          {#if isModerator}
+            <a
+              href={resolve('/moderation')}
+              role="menuitem"
+              onclick={() => (open = false)}
+              class={linkClass('/moderation')}
+            >
+              Moderation
+            </a>
+          {/if}
         {/if}
-      </button>
 
-      {#if isAuthenticated()}
-        <button
-          type="button"
-          role="menuitem"
-          onclick={logout}
-          class="block w-full px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-        >
-          Log out
-        </button>
-      {:else}
-        <button
-          type="button"
-          role="menuitem"
-          onclick={signIn}
-          class="block w-full px-3 py-2 text-left text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-        >
-          Sign in
-        </button>
-      {/if}
+        <!-- Desktop-only: theme + auth inline at the end of the dropdown. -->
+        <div class="hidden sm:block">
+          <div class="my-1 h-px bg-border"></div>
+          {@render themeAuth()}
+        </div>
+      </div>
+
+      <!-- Mobile-only: theme + auth pinned to the bottom of the drawer. -->
+      <div class="shrink-0 border-t border-border p-2 sm:hidden">
+        {@render themeAuth()}
+      </div>
     </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary
- Redesign the header hamburger menu's **mobile** presentation as a full-screen **drawer**: own top bar (brand + close), scrollable links grouped into **Navigate** / **Account** sections with **≥44px tap targets**, and the theme toggle + auth action **pinned to a bottom bar**.
- **Desktop** anchored `w-64` dropdown is unchanged (verified).
- One markup → two layouts via `max-sm:`/`sm:` classes; theme+auth extracted into a single Svelte `{#snippet}` reused in the mobile bottom bar and desktop inline list (no duplicated logic).
- Menu items, gating (account/moderator/signed-out), scroll-lock, and close-on-select/`Escape` all preserved.

Planned as OpenSpec change `mobile-header-menu-drawer` (delta on `header-navigation`).

## Test Plan
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] `eslint HeaderMenu.svelte` — clean
- [x] `npm run build` — succeeds
- [x] Visual — mobile drawer (signed-out) shows top bar / Navigate section / pinned theme+Sign in; desktop dropdown unchanged (dark theme)

## Notes
No web test runner; verification is svelte-check + eslint + build + visual. Known deferred seams (all pre-existing / out of scope): brand SVG duplicated across TopBar/Footer/HeaderMenu; no focus-trap on the drawer; loose `role="menu"` semantics.