### PR TITLE
chore(config): drop unused Settings.LangfuseEnabled (simplify)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,8 +49,8 @@ type Settings struct {
 
 	// Langfuse traces the server's LLM calls (the résumé-verdict coherence analysis),
 	// mirroring the enrich/tg-extract workers (config.Enrich). Optional observability:
-	// tracing is wired only when all three are set (LangfuseEnabled) — otherwise the LLM
-	// client runs untraced. Enforced at the cmd/server call site, not here.
+	// llm.NewClient wires tracing only when all three are set — otherwise the client
+	// runs untraced. Handled at the cmd/server call site, not here.
 	LangfuseBaseURL   string
 	LangfusePublicKey string
 	LangfuseSecretKey string
@@ -80,13 +80,6 @@ type Settings struct {
 type OAuthCredentials struct {
 	ClientID     string
 	ClientSecret string
-}
-
-// LangfuseEnabled reports whether the server should trace its LLM calls: true only
-// when all three Langfuse settings are present (a partial config is treated as off),
-// mirroring config.Enrich.LangfuseEnabled.
-func (s Settings) LangfuseEnabled() bool {
-	return s.LangfuseBaseURL != "" && s.LangfusePublicKey != "" && s.LangfuseSecretKey != ""
 }
 
 // oauthProviders are the providers whose credentials Load reads from the

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -64,18 +64,17 @@ func TestLoad_LangfuseFromEnv(t *testing.T) {
 		t.Errorf("Langfuse settings = %q/%q/%q, want the env values",
 			s.LangfuseBaseURL, s.LangfusePublicKey, s.LangfuseSecretKey)
 	}
-	if !s.LangfuseEnabled() {
-		t.Error("LangfuseEnabled should be true when all three are set")
-	}
 }
 
-func TestLoad_LangfuseDisabledWhenPartial(t *testing.T) {
-	t.Setenv("LANGFUSE_BASE_URL", "https://us.cloud.langfuse.com")
-	t.Setenv("LANGFUSE_PUBLIC_KEY", "pk-1")
-	t.Setenv("LANGFUSE_SECRET_KEY", "") // missing → disabled
+func TestLoad_LangfuseEmptyWhenUnset(t *testing.T) {
+	t.Setenv("LANGFUSE_BASE_URL", "")
+	t.Setenv("LANGFUSE_PUBLIC_KEY", "")
+	t.Setenv("LANGFUSE_SECRET_KEY", "")
 
-	if Load().LangfuseEnabled() {
-		t.Error("LangfuseEnabled should be false when a setting is missing")
+	s := Load()
+	if s.LangfuseBaseURL != "" || s.LangfusePublicKey != "" || s.LangfuseSecretKey != "" {
+		t.Errorf("Langfuse settings should be empty when unset, got %q/%q/%q",
+			s.LangfuseBaseURL, s.LangfusePublicKey, s.LangfuseSecretKey)
 	}
 }
 


### PR DESCRIPTION
Quality pass on the unified-LLM change (#386). `Settings.LangfuseEnabled()` was added for symmetry with `config.Enrich` but is never called in production — `cmd/server` hands the Langfuse fields to `llm.NewClient`, which does its own enabled-check via `NewTracer`. Remove the dead predicate + its predicate-only test; keep field-load coverage (mirrors the S3 settings tests). No behavior change; build/vet/gofmt/test green.