### PR TITLE
fix(ingest): never wipe a stored job description with an empty re-ingest

### DIFF
--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1056,7 +1056,15 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     company_slug = EXCLUDED.company_slug,
     location     = EXCLUDED.location,
     remote       = EXCLUDED.remote,
-    description  = EXCLUDED.description,
+    -- description comes from a separate, best-effort detail fetch (some adapters,
+    -- e.g. habr_career, load it from a per-vacancy page that an anti-bot layer can
+    -- intermittently fail). A failed fetch yields an empty description but still
+    -- upserts the job, so writing EXCLUDED unconditionally would let a transient
+    -- failure wipe a good description. Keep the stored value when the incoming one is
+    -- empty; a non-empty description still overwrites, so real edits propagate.
+    -- (content_hash below stays the incoming fingerprint; the incremental indexer
+    -- rebuilds its doc from the RETURNING row, which carries this preserved value.)
+    description  = COALESCE(NULLIF(EXCLUDED.description, ''), jobs.description),
     posted_at    = EXCLUDED.posted_at,
     countries    = EXCLUDED.countries,
     regions      = EXCLUDED.regions,

--- a/internal/db/jobs_integration_test.go
+++ b/internal/db/jobs_integration_test.go
@@ -156,6 +156,51 @@ func TestEnqueueJobEnrichmentGating(t *testing.T) {
 	})
 }
 
+// A failed detail fetch makes an adapter yield a job with an empty description while
+// still upserting it (the vacancy must not be dropped). UpsertJob must treat an empty
+// incoming description as "no new value" and keep the stored one, so a transient
+// detail-fetch failure (e.g. an anti-bot challenge on a Habr detail page) cannot wipe a
+// good description. A non-empty description still overwrites, so real edits propagate.
+func TestUpsertJobPreservesDescriptionWhenReingestEmpty(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	first, err := ingestUpsert(ctx, q, ingestParams("acme:desc", "Job"))
+	if err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	if first.Description != "Build things." {
+		t.Fatalf("precondition: description = %q, want the seeded value", first.Description)
+	}
+
+	// Re-crawl whose detail fetch failed: empty description, same identity.
+	empty := ingestParams("acme:desc", "Job")
+	empty.Description = ""
+	second, err := ingestUpsert(ctx, q, empty)
+	if err != nil {
+		t.Fatalf("re-ingest with empty description: %v", err)
+	}
+	if second.ID != first.ID {
+		t.Fatalf("re-ingest created a new row — dedup broken")
+	}
+	if second.Description != "Build things." {
+		t.Errorf("Description = %q, want preserved %q (empty re-ingest wiped it)", second.Description, "Build things.")
+	}
+
+	// A non-empty re-ingest still overwrites, so a genuine content edit propagates.
+	updated := ingestParams("acme:desc", "Job")
+	updated.Description = "Updated description."
+	third, err := ingestUpsert(ctx, q, updated)
+	if err != nil {
+		t.Fatalf("re-ingest with new description: %v", err)
+	}
+	if third.Description != "Updated description." {
+		t.Errorf("Description = %q, want overwritten with the new value", third.Description)
+	}
+}
+
 func TestUpsertJobWritesAndRefreshesGeography(t *testing.T) {
 	pool := startPostgres(t)
 	q := New(pool)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -153,7 +153,15 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     company_slug = EXCLUDED.company_slug,
     location     = EXCLUDED.location,
     remote       = EXCLUDED.remote,
-    description  = EXCLUDED.description,
+    -- description comes from a separate, best-effort detail fetch (some adapters,
+    -- e.g. habr_career, load it from a per-vacancy page that an anti-bot layer can
+    -- intermittently fail). A failed fetch yields an empty description but still
+    -- upserts the job, so writing EXCLUDED unconditionally would let a transient
+    -- failure wipe a good description. Keep the stored value when the incoming one is
+    -- empty; a non-empty description still overwrites, so real edits propagate.
+    -- (content_hash below stays the incoming fingerprint; the incremental indexer
+    -- rebuilds its doc from the RETURNING row, which carries this preserved value.)
+    description  = COALESCE(NULLIF(EXCLUDED.description, ''), jobs.description),
     posted_at    = EXCLUDED.posted_at,
     countries    = EXCLUDED.countries,
     regions      = EXCLUDED.regions,


### PR DESCRIPTION
## Problem

Some habr_career vacancies show **no description** on the site (e.g. [this Alfa-Bank QA role](https://freehire.dev/jobs/qa-engineer-mobile-fullstack-java-al-fa-bank-dqgwkces)) even though their Habr detail page carries a full `JobPosting` description.

Root cause: `career.habr.com` sits behind **Qrator** anti-DDoS. The listing JSON API sails through, but the per-vacancy detail HTML page (where the description lives) gets intermittently challenged/403'd from a datacenter IP under the ~748-page crawl. The `habr_career` adapter treats a failed detail fetch as an **empty** description but still upserts the job — and `UpsertJob`'s `ON CONFLICT` wrote `description = EXCLUDED.description` **unconditionally**, so a single transient failure **wiped a previously-good description**. Descriptions "flicker": a good crawl fills them, the next failed crawl blanks them.

This is a general split-fetch hazard, not habr-specific: any adapter whose description comes from a separate best-effort detail request can wipe good data on a transient failure.

## Fix

```sql
description = COALESCE(NULLIF(EXCLUDED.description, ''), jobs.description)
```

Invariant: **a source never blanks an existing description.** Empty incoming = "no new value" (keep stored); non-empty still overwrites, so real edits propagate.

- `content_hash` stays the incoming fingerprint — the incremental indexer rebuilds its doc from the `RETURNING` row (which carries the preserved value), so the index never sees the transient empty. Worst case is one harmless redundant re-push on the empty→kept transition.
- `UpsertManualJob` is deliberately **unchanged** (moderator path; empty may be intentional, and the service already does partial-merge).
- Existing empty descriptions **self-heal** on the next successful crawl; no backfill needed.

## Tests

Adds `TestUpsertJobPreservesDescriptionWhenReingestEmpty` covering both halves of the invariant (empty preserves, non-empty overwrites). Full `go test -tags=integration ./internal/db/` + unit suite + `go vet` + `gofmt` all green.

## Follow-up (not in this PR)

Optional secondary hardening for the habr detail client — browser UA + cookie-jar + concurrency < 8 — would reduce the *frequency* of empty fetches. Left as a seam; the non-destructive write makes it non-urgent (prod sample showed ~0% empty descriptions across habr jobs, i.e. detail fetches usually succeed).