### PR TITLE
feat(sources): add Taleo Enterprise adapter

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -22,6 +22,8 @@
   // yet loaded). `showApplyPrompt` is the post-click "Did you apply?" question.
   let interaction = $state.raw<UserJob | null>(null);
   let showApplyPrompt = $state(false);
+  // Signed-out gate: the "Show" click offers sign-in before opening the posting.
+  let showSignInPrompt = $state(false);
   // The report dialog (a problem-with-this-job complaint) opens over the page.
   let showReport = $state(false);
   const applied = $derived(interaction?.applied_at != null);
@@ -41,6 +43,7 @@
     const slug = job.public_slug; // track the current job
     interaction = null;
     showApplyPrompt = false;
+    showSignInPrompt = false;
     if (!browser || !isAuthenticated()) return;
     recordJobView(slug)
       .then((rec) => {
@@ -53,8 +56,28 @@
 
   // The Apply link opens the external posting; once the user has gone to apply,
   // offer the "Did you apply?" choice (only when signed in and not already applied).
-  function onApplyClick() {
-    if (isAuthenticated() && !applied) showApplyPrompt = true;
+  // Signed-out visitors are gated first: the click is intercepted (the link does
+  // not open) and a sign-in offer is shown instead — the posting opens only via
+  // "View without signing in" below.
+  function onApplyClick(e: MouseEvent) {
+    if (!isAuthenticated()) {
+      e.preventDefault();
+      showSignInPrompt = true;
+      return;
+    }
+    if (!applied) showApplyPrompt = true;
+  }
+
+  // Gate — "Sign up" routes to the register dialog; "View without signing in"
+  // opens the posting in a new tab (the navigation the click was holding back).
+  function signUpFromGate() {
+    showSignInPrompt = false;
+    openAuthDialog('register');
+  }
+
+  function viewWithoutSignIn() {
+    showSignInPrompt = false;
+    window.open(job.url, '_blank', 'noopener,noreferrer');
   }
 
   async function confirmApplied() {
@@ -154,6 +177,18 @@
         <div class="flex items-center gap-2">
           <Button variant="primary" size="sm" onclick={confirmApplied}>Yes, save</Button>
           <Button variant="ghost" size="sm" onclick={dismissApplyPrompt}>No</Button>
+        </div>
+      </div>
+    {/if}
+
+    {#if showSignInPrompt}
+      <div
+        class="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-secondary px-4 py-3"
+      >
+        <span class="text-sm">Sign in to keep track of the jobs you apply to.</span>
+        <div class="flex items-center gap-2">
+          <Button variant="primary" size="sm" onclick={signUpFromGate}>Sign up</Button>
+          <Button variant="ghost" size="sm" onclick={viewWithoutSignIn}>View without signing in</Button>
         </div>
       </div>
     {/if}


### PR DESCRIPTION
## What

Adds a keyless source adapter for **Oracle Taleo Enterprise** career sites — the biggest missing ATS vendor in the [state-of-ats-2026](https://github.com/Kayvan-Zahiri/state-of-ats-2026) audit (39 companies on Taleo, no adapter until now).

## How

Taleo's job feed is keyless but **session-bound**. Per board:
1. `GET /careersection/<section>/jobsearch.ftl` → sets the `JSESSIONID` cookie and embeds `portalNo: '<code>'` (scraped).
2. `POST /careersection/rest/jobboard/searchjobs?portal=<code>` in the same session (the `tz`/`tzname` headers are **required** — without them Taleo returns 500 "An Error Occurred in TEE") → pages the requisition list.
3. `GET /careersection/<section>/jobdetail.ftl?job=<contestNo>` → the description is URL-encoded HTML in the hidden `initialHistory` input, after the `!*!` marker.

Board id is `host/section` (mirrors Oracle's `host/site`). `external_id = contestNo`.

### Notable design points
- **`newCookieClient`** (http.go): a cookie-persisting client so the careersection session carries into the `searchjobs` POST. The jar is host-scoped, so one client segregates tenants.
- **Per-host `keyedMutex`**: serializes crawls sharing a host, so two careersections of one tenant can't clobber each other's `JSESSIONID` in the shared jar (caught in review). Distinct hosts still run concurrently.
- **Variable column layout**: `column[0]` is always the title, but location is read from the API's own `locationsColumns` index (never a guessed position) and the posted date only from a column parsing as `Jan 2, 2006` — so an id column is never misread as location/date.
- Description is **best-effort**: the listing already yields a valid job, so a failed/empty detail leaves the description blank rather than dropping the job.

## Scope (spike verdict: PARTIAL)

Onboarding is per-tenant — the careersection path is not guessable, some tenants front Taleo behind their own domain (uhg/hilton/textron/jacobs), and some return "Error in TEE" even with a valid portal. Ships **four live-verified boards** (valero, BAE Systems, Schneider National, D.R. Horton); `hyatt` (~3162 jobs) excluded for scale. Seams documented in `sources/taleo.yml`.

## Testing
- Unit tests: provider, board validation, fetch+detail+sanitize, varying column layouts, pagination, keyedMutex, concurrent same-host fetch (`-race`).
- Live-verified all four boards end-to-end (descriptions decoded 100%).
- `go build ./...`, `go vet`, full `go test ./...`, and `-race` on the package — all green.

## Deploy note
New source file needs its own cron `go run ./cmd/ingest sources/taleo.yml` in freehire-ops, followed by a reindex.