### PR TITLE
feat(jobs): show view/apply counts on the job detail page

### DIFF
--- a/internal/db/job_engagement_counts_integration_test.go
+++ b/internal/db/job_engagement_counts_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+// Integration tests for the materialized engagement counters (jobs.view_count /
+// jobs.applied_count). The counters are bumped inside the RecordJobView /
+// MarkJobApplied upserts on a first-time transition only, which can only be
+// verified against a real Postgres. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func jobCounts(t *testing.T, pool *pgxpool.Pool, jobID int64) (view, applied int32) {
+	t.Helper()
+	if err := pool.QueryRow(context.Background(),
+		"SELECT view_count, applied_count FROM jobs WHERE id = $1", jobID).Scan(&view, &applied); err != nil {
+		t.Fatalf("read counts: %v", err)
+	}
+	return view, applied
+}
+
+func TestJobEngagementCounts(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	reset := func(t *testing.T) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, "TRUNCATE user_jobs, users, jobs RESTART IDENTITY CASCADE"); err != nil {
+			t.Fatalf("truncate: %v", err)
+		}
+	}
+
+	t.Run("view_count counts distinct viewers, once each", func(t *testing.T) {
+		reset(t)
+		u1 := insertUser(t, pool, "v1@example.test")
+		u2 := insertUser(t, pool, "v2@example.test")
+		jid := insertJob(t, pool, "view-count-job")
+
+		if v, _ := jobCounts(t, pool, jid); v != 0 {
+			t.Fatalf("initial view_count = %d, want 0", v)
+		}
+
+		if _, err := q.RecordJobView(ctx, RecordJobViewParams{UserID: u1, JobID: jid}); err != nil {
+			t.Fatalf("u1 first view: %v", err)
+		}
+		if v, _ := jobCounts(t, pool, jid); v != 1 {
+			t.Fatalf("after u1 first view: view_count = %d, want 1", v)
+		}
+
+		// A repeat view by the same user must not increment again.
+		if _, err := q.RecordJobView(ctx, RecordJobViewParams{UserID: u1, JobID: jid}); err != nil {
+			t.Fatalf("u1 repeat view: %v", err)
+		}
+		if v, _ := jobCounts(t, pool, jid); v != 1 {
+			t.Fatalf("after u1 repeat view: view_count = %d, want 1", v)
+		}
+
+		// A different user is a new distinct viewer.
+		if _, err := q.RecordJobView(ctx, RecordJobViewParams{UserID: u2, JobID: jid}); err != nil {
+			t.Fatalf("u2 view: %v", err)
+		}
+		if v, _ := jobCounts(t, pool, jid); v != 2 {
+			t.Fatalf("after u2 view: view_count = %d, want 2", v)
+		}
+	})
+
+	t.Run("applied_count bumps only on the NULL->set transition", func(t *testing.T) {
+		reset(t)
+		u1 := insertUser(t, pool, "a1@example.test")
+		u2 := insertUser(t, pool, "a2@example.test")
+		jid := insertJob(t, pool, "apply-count-job")
+
+		// A prior view alone does not touch applied_count.
+		if _, err := q.RecordJobView(ctx, RecordJobViewParams{UserID: u1, JobID: jid}); err != nil {
+			t.Fatalf("u1 view: %v", err)
+		}
+		if _, a := jobCounts(t, pool, jid); a != 0 {
+			t.Fatalf("after view-only: applied_count = %d, want 0", a)
+		}
+
+		if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: u1, JobID: jid}); err != nil {
+			t.Fatalf("u1 apply: %v", err)
+		}
+		if _, a := jobCounts(t, pool, jid); a != 1 {
+			t.Fatalf("after u1 apply: applied_count = %d, want 1", a)
+		}
+
+		// Re-applying is idempotent and must not increment again.
+		if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: u1, JobID: jid}); err != nil {
+			t.Fatalf("u1 re-apply: %v", err)
+		}
+		if _, a := jobCounts(t, pool, jid); a != 1 {
+			t.Fatalf("after u1 re-apply: applied_count = %d, want 1", a)
+		}
+
+		// A second user applying (insert path, applied_at set directly) bumps it.
+		if _, err := q.MarkJobApplied(ctx, MarkJobAppliedParams{UserID: u2, JobID: jid}); err != nil {
+			t.Fatalf("u2 apply: %v", err)
+		}
+		if _, a := jobCounts(t, pool, jid); a != 2 {
+			t.Fatalf("after u2 apply: applied_count = %d, want 2", a)
+		}
+	})
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -131,7 +131,7 @@ func (q *Queries) EstimateOpenJobs(ctx context.Context) (int64, error) {
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 FROM jobs
 WHERE id = $1
 `
@@ -176,12 +176,14 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.ContentHash,
 		&i.EnglishLevel,
 		&i.Cities,
+		&i.ViewCount,
+		&i.AppliedCount,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 FROM jobs
 WHERE public_slug = $1
 `
@@ -226,6 +228,8 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.ContentHash,
 		&i.EnglishLevel,
 		&i.Cities,
+		&i.ViewCount,
+		&i.AppliedCount,
 	)
 	return i, err
 }
@@ -361,7 +365,7 @@ func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 FROM jobs
 WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -422,6 +426,8 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.ContentHash,
 			&i.EnglishLevel,
 			&i.Cities,
+			&i.ViewCount,
+			&i.AppliedCount,
 		); err != nil {
 			return nil, err
 		}
@@ -434,7 +440,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -493,6 +499,8 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.ContentHash,
 			&i.EnglishLevel,
 			&i.Cities,
+			&i.ViewCount,
+			&i.AppliedCount,
 		); err != nil {
 			return nil, err
 		}
@@ -505,7 +513,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -566,6 +574,8 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.ContentHash,
 			&i.EnglishLevel,
 			&i.Cities,
+			&i.ViewCount,
+			&i.AppliedCount,
 		); err != nil {
 			return nil, err
 		}
@@ -578,7 +588,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -643,6 +653,8 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.ContentHash,
 			&i.EnglishLevel,
 			&i.Cities,
+			&i.ViewCount,
+			&i.AppliedCount,
 		); err != nil {
 			return nil, err
 		}
@@ -916,7 +928,7 @@ SET title        = $1,
     updated_by   = $20::bigint,
     updated_at   = now()
 WHERE public_slug = $21 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 `
 
 type UpdateManualJobParams struct {
@@ -1017,6 +1029,8 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.ContentHash,
 		&i.EnglishLevel,
 		&i.Cities,
+		&i.ViewCount,
+		&i.AppliedCount,
 	)
 	return i, err
 }
@@ -1086,7 +1100,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
     ((SELECT old_hash FROM existing) IS DISTINCT FROM $24) AS changed
 `
@@ -1209,6 +1223,8 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.ContentHash,
 		&i.Job.EnglishLevel,
 		&i.Job.Cities,
+		&i.Job.ViewCount,
+		&i.Job.AppliedCount,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -1267,7 +1283,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
 `
 
 type UpsertManualJobParams struct {
@@ -1374,6 +1390,8 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.ContentHash,
 		&i.EnglishLevel,
 		&i.Cities,
+		&i.ViewCount,
+		&i.AppliedCount,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -83,6 +83,8 @@ type Job struct {
 	ContentHash        pgtype.Text        `json:"content_hash"`
 	EnglishLevel       string             `json:"english_level"`
 	Cities             []string           `json:"cities"`
+	ViewCount          int32              `json:"view_count"`
+	AppliedCount       int32              `json:"applied_count"`
 }
 
 type JobReport struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -322,8 +322,10 @@ type Querier interface {
 	// Mark a job as applied for a user. Idempotent and independent of a prior view:
 	// it inserts the row (viewed_at defaults) or updates applied_at in place, and
 	// seeds stage='applied' only when the stage is unset (an advanced stage survives
-	// a re-apply, via COALESCE).
-	MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) (UserJob, error)
+	// a re-apply, via COALESCE). When (and only when) applied_at transitions from
+	// unset to set, bump the job's materialized applied_count in the same statement;
+	// `prior` sees the pre-upsert applied_at, so a re-apply never re-bumps.
+	MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) (MarkJobAppliedRow, error)
 	// Record one expired probe: increment the strike counter and, in the same write,
 	// close the job (closed_at) once it reaches the threshold the caller owns — the
 	// two-strike grace that absorbs a transient death signal. Returns the new strike
@@ -363,7 +365,11 @@ type Querier interface {
 	// Record (or refresh) a user's view of a job. Idempotent on (user_id, job_id):
 	// the first view creates the row, a repeat view touches viewed_at. Returns the
 	// row so the caller learns the current applied_at in the same round-trip.
-	RecordJobView(ctx context.Context, arg RecordJobViewParams) (UserJob, error)
+	// When (and only when) the row is created for the first time — no prior
+	// interaction existed — bump the job's materialized view_count in the same
+	// statement. All WITH sub-statements see one snapshot, so `prior` reflects the
+	// pre-upsert state regardless of execution order; a repeat view never re-bumps.
+	RecordJobView(ctx context.Context, arg RecordJobViewParams) (RecordJobViewRow, error)
 	// Count a failed delivery for a subscription's claimed jobs: bump attempts, record
 	// the error, and dead-letter (set failed_at) once attempts reach the max. claimed_at
 	// is left in place — its expiry gates the retry to a later pass and doubles as the

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -2,21 +2,43 @@
 -- Record (or refresh) a user's view of a job. Idempotent on (user_id, job_id):
 -- the first view creates the row, a repeat view touches viewed_at. Returns the
 -- row so the caller learns the current applied_at in the same round-trip.
-INSERT INTO user_jobs (user_id, job_id)
-VALUES ($1, $2)
-ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
-RETURNING *;
+-- When (and only when) the row is created for the first time — no prior
+-- interaction existed — bump the job's materialized view_count in the same
+-- statement. All WITH sub-statements see one snapshot, so `prior` reflects the
+-- pre-upsert state regardless of execution order; a repeat view never re-bumps.
+WITH prior AS (
+    SELECT 1 AS existed FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
+), upsert AS (
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES ($1, $2)
+    ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
+    RETURNING *
+), bump AS (
+    UPDATE jobs SET view_count = view_count + 1
+    WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior)
+)
+SELECT * FROM upsert;
 
 -- name: MarkJobApplied :one
 -- Mark a job as applied for a user. Idempotent and independent of a prior view:
 -- it inserts the row (viewed_at defaults) or updates applied_at in place, and
 -- seeds stage='applied' only when the stage is unset (an advanced stage survives
--- a re-apply, via COALESCE).
-INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
-VALUES ($1, $2, now(), 'applied')
-ON CONFLICT (user_id, job_id) DO UPDATE
-  SET applied_at = now(), stage = COALESCE(user_jobs.stage, 'applied')
-RETURNING *;
+-- a re-apply, via COALESCE). When (and only when) applied_at transitions from
+-- unset to set, bump the job's materialized applied_count in the same statement;
+-- `prior` sees the pre-upsert applied_at, so a re-apply never re-bumps.
+WITH prior AS (
+    SELECT uj.applied_at FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
+), upsert AS (
+    INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
+    VALUES ($1, $2, now(), 'applied')
+    ON CONFLICT (user_id, job_id) DO UPDATE
+      SET applied_at = now(), stage = COALESCE(user_jobs.stage, 'applied')
+    RETURNING *
+), bump AS (
+    UPDATE jobs SET applied_count = applied_count + 1
+    WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
+)
+SELECT * FROM upsert;
 
 -- name: SaveJob :one
 -- Save (bookmark) a job for a user. Idempotent and independent of a prior view:

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -185,7 +185,7 @@ func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) 
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -271,6 +271,8 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.ContentHash,
 			&i.Job.EnglishLevel,
 			&i.Job.Cities,
+			&i.Job.ViewCount,
+			&i.Job.AppliedCount,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,
@@ -320,11 +322,19 @@ func (q *Queries) ListViewedJobSlugs(ctx context.Context, userID int64) ([]strin
 }
 
 const markJobApplied = `-- name: MarkJobApplied :one
-INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
-VALUES ($1, $2, now(), 'applied')
-ON CONFLICT (user_id, job_id) DO UPDATE
-  SET applied_at = now(), stage = COALESCE(user_jobs.stage, 'applied')
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at
+WITH prior AS (
+    SELECT uj.applied_at FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
+), upsert AS (
+    INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
+    VALUES ($1, $2, now(), 'applied')
+    ON CONFLICT (user_id, job_id) DO UPDATE
+      SET applied_at = now(), stage = COALESCE(user_jobs.stage, 'applied')
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at
+), bump AS (
+    UPDATE jobs SET applied_count = applied_count + 1
+    WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior WHERE prior.applied_at IS NOT NULL)
+)
+SELECT user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at FROM upsert
 `
 
 type MarkJobAppliedParams struct {
@@ -332,13 +342,26 @@ type MarkJobAppliedParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type MarkJobAppliedRow struct {
+	UserID      int64              `json:"user_id"`
+	JobID       int64              `json:"job_id"`
+	ViewedAt    pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt   pgtype.Timestamptz `json:"applied_at"`
+	SavedAt     pgtype.Timestamptz `json:"saved_at"`
+	Stage       pgtype.Text        `json:"stage"`
+	Notes       pgtype.Text        `json:"notes"`
+	DismissedAt pgtype.Timestamptz `json:"dismissed_at"`
+}
+
 // Mark a job as applied for a user. Idempotent and independent of a prior view:
 // it inserts the row (viewed_at defaults) or updates applied_at in place, and
 // seeds stage='applied' only when the stage is unset (an advanced stage survives
-// a re-apply, via COALESCE).
-func (q *Queries) MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) (UserJob, error) {
+// a re-apply, via COALESCE). When (and only when) applied_at transitions from
+// unset to set, bump the job's materialized applied_count in the same statement;
+// `prior` sees the pre-upsert applied_at, so a re-apply never re-bumps.
+func (q *Queries) MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) (MarkJobAppliedRow, error) {
 	row := q.db.QueryRow(ctx, markJobApplied, arg.UserID, arg.JobID)
-	var i UserJob
+	var i MarkJobAppliedRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,
@@ -353,10 +376,18 @@ func (q *Queries) MarkJobApplied(ctx context.Context, arg MarkJobAppliedParams) 
 }
 
 const recordJobView = `-- name: RecordJobView :one
-INSERT INTO user_jobs (user_id, job_id)
-VALUES ($1, $2)
-ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
-RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at
+WITH prior AS (
+    SELECT 1 AS existed FROM user_jobs uj WHERE uj.user_id = $1 AND uj.job_id = $2
+), upsert AS (
+    INSERT INTO user_jobs (user_id, job_id)
+    VALUES ($1, $2)
+    ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
+    RETURNING user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at
+), bump AS (
+    UPDATE jobs SET view_count = view_count + 1
+    WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior)
+)
+SELECT user_id, job_id, viewed_at, applied_at, saved_at, stage, notes, dismissed_at FROM upsert
 `
 
 type RecordJobViewParams struct {
@@ -364,12 +395,27 @@ type RecordJobViewParams struct {
 	JobID  int64 `json:"job_id"`
 }
 
+type RecordJobViewRow struct {
+	UserID      int64              `json:"user_id"`
+	JobID       int64              `json:"job_id"`
+	ViewedAt    pgtype.Timestamptz `json:"viewed_at"`
+	AppliedAt   pgtype.Timestamptz `json:"applied_at"`
+	SavedAt     pgtype.Timestamptz `json:"saved_at"`
+	Stage       pgtype.Text        `json:"stage"`
+	Notes       pgtype.Text        `json:"notes"`
+	DismissedAt pgtype.Timestamptz `json:"dismissed_at"`
+}
+
 // Record (or refresh) a user's view of a job. Idempotent on (user_id, job_id):
 // the first view creates the row, a repeat view touches viewed_at. Returns the
 // row so the caller learns the current applied_at in the same round-trip.
-func (q *Queries) RecordJobView(ctx context.Context, arg RecordJobViewParams) (UserJob, error) {
+// When (and only when) the row is created for the first time — no prior
+// interaction existed — bump the job's materialized view_count in the same
+// statement. All WITH sub-statements see one snapshot, so `prior` reflects the
+// pre-upsert state regardless of execution order; a repeat view never re-bumps.
+func (q *Queries) RecordJobView(ctx context.Context, arg RecordJobViewParams) (RecordJobViewRow, error) {
 	row := q.db.QueryRow(ctx, recordJobView, arg.UserID, arg.JobID)
-	var i UserJob
+	var i RecordJobViewRow
 	err := row.Scan(
 		&i.UserID,
 		&i.JobID,

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -42,7 +42,9 @@ func (r *QueriesRepository) RecordView(ctx context.Context, userID, jobID int64)
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	// The CTE that bumps view_count makes sqlc emit a bespoke row type with the
+	// same shape as db.UserJob; convert so the interaction mapping stays shared.
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // MarkApplied marks a job as applied for a user.
@@ -51,7 +53,8 @@ func (r *QueriesRepository) MarkApplied(ctx context.Context, userID, jobID int64
 	if err != nil {
 		return Interaction{}, err
 	}
-	return toInteraction(row), nil
+	// See RecordView: the applied_count CTE yields a bespoke row of db.UserJob shape.
+	return toInteraction(db.UserJob(row)), nil
 }
 
 // SaveJob saves (bookmarks) a job for a user.

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -72,6 +72,11 @@ type Job struct {
 	Enrichment        enrich.Enrichment `json:"enrichment"`
 	EnrichedAt        *string           `json:"enriched_at"`
 	EnrichmentVersion int32             `json:"enrichment_version"`
+	// ViewCount/AppliedCount are the job's materialized engagement counters —
+	// distinct signed-in users who viewed and who marked applied — served straight
+	// from the jobs columns (no read-time counting). Displayed on the detail page.
+	ViewCount    int32 `json:"view_count"`
+	AppliedCount int32 `json:"applied_count"`
 }
 
 // FromRow maps a database job row to the public wire shape. The enrichment
@@ -145,6 +150,8 @@ func FromRow(j db.Job) (Job, error) {
 		Enrichment:        e,
 		EnrichedAt:        rfc3339(j.EnrichedAt),
 		EnrichmentVersion: j.EnrichmentVersion,
+		ViewCount:         j.ViewCount,
+		AppliedCount:      j.AppliedCount,
 	}, nil
 }
 

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -225,6 +225,19 @@ func TestFromRow_WorkModeIsTheDictValue(t *testing.T) {
 	}
 }
 
+func TestFromRow_CopiesEngagementCounts(t *testing.T) {
+	view, err := FromRow(db.Job{ID: 1, Title: "x", PublicSlug: "x-1", ViewCount: 42, AppliedCount: 7})
+	if err != nil {
+		t.Fatalf("FromRow: %v", err)
+	}
+	if view.ViewCount != 42 {
+		t.Errorf("ViewCount = %d, want 42", view.ViewCount)
+	}
+	if view.AppliedCount != 7 {
+		t.Errorf("AppliedCount = %d, want 7", view.AppliedCount)
+	}
+}
+
 func TestFromRow_EmptyEnrichmentIsZero(t *testing.T) {
 	// An unenriched job's column arrives as "{}" (the table default) or, in
 	// edge cases, a nil byte slice. Both must decode to the zero Enrichment,
@@ -258,6 +271,19 @@ func TestJobJSON_HidesIDExposesSlug(t *testing.T) {
 	}
 	if got := string(fields["public_slug"]); got != `"go-developer-acme-t35nijto"` {
 		t.Errorf("public_slug: want the slug, got %s", got)
+	}
+}
+
+// The engagement counters are part of the public wire contract (served on every
+// job read, displayed on the detail page) and serialize as plain integers.
+func TestJobJSON_ExposesEngagementCounts(t *testing.T) {
+	fields := marshalToFields(t, db.Job{ID: 1, Title: "x", PublicSlug: "x-1", ViewCount: 12, AppliedCount: 3})
+
+	if got := string(fields["view_count"]); got != "12" {
+		t.Errorf("view_count: want 12, got %s", got)
+	}
+	if got := string(fields["applied_count"]); got != "3" {
+		t.Errorf("applied_count: want 3, got %s", got)
 	}
 }
 

--- a/migrations/0040_job_engagement_counts.sql
+++ b/migrations/0040_job_engagement_counts.sql
@@ -1,0 +1,22 @@
+-- Materialized engagement counters on jobs: the number of distinct signed-in
+-- users who have viewed a job and who have marked it applied. Incremented in the
+-- tracking write path (RecordJobView / MarkJobApplied) on the first-time
+-- transition only, so refreshes and repeat actions never inflate them; served
+-- straight off the row by jobview.FromRow with no read-time COUNT.
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS view_count    INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS applied_count INTEGER NOT NULL DEFAULT 0;
+
+-- Backfill from existing interactions. Every user_jobs row has viewed_at set
+-- (NOT NULL DEFAULT now()), so its row count is the distinct-viewer count;
+-- applied_count filters on applied_at.
+UPDATE jobs j SET
+    view_count    = sub.views,
+    applied_count = sub.applied
+FROM (
+    SELECT job_id,
+           count(*)                                       AS views,
+           count(*) FILTER (WHERE applied_at IS NOT NULL) AS applied
+    FROM user_jobs
+    GROUP BY job_id
+) sub
+WHERE sub.job_id = j.id;

--- a/openspec/changes/job-view-apply-counts/.openspec.yaml
+++ b/openspec/changes/job-view-apply-counts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/job-view-apply-counts/design.md
+++ b/openspec/changes/job-view-apply-counts/design.md
@@ -1,0 +1,123 @@
+## Context
+
+`user_jobs (user_id, job_id, viewed_at, applied_at, …)` already records every
+signed-in user's interaction with a job — one row per pair, `viewed_at` always
+set. Views are recorded only for authenticated users (`RecordJobView`), and
+`applied_at` is set by `MarkJobApplied`. Nothing today surfaces aggregate
+interest on a posting. The job wire shape (`jobview.Job`, built by
+`FromRow(db.Job)`) is shared by the list, detail, search-index, and company
+surfaces.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show "N views · M applied" on the job **detail** page.
+- Keep it lightweight: zero read-time counting; reads serve stored values.
+- Never inflate counters on refresh or repeat actions.
+- Backfill existing jobs so the feature isn't all-zeros on release.
+
+**Non-Goals:**
+- Counting anonymous opens (kept as a future seam — would need an anonymous
+  write path plus bot/dedup defense).
+- Displaying the counts on job cards, search results, or company pages.
+- Total-view-event semantics (we count distinct users, not raw opens).
+
+## Decisions
+
+### Materialized counters on `jobs`, not read-time `COUNT`
+
+Add `jobs.view_count` and `jobs.applied_count` (`INT NOT NULL DEFAULT 0`).
+`FromRow` reads them straight off the row, so all read paths carry them for free
+and the detail page needs no extra query.
+
+*Alternative — read-time `COUNT(*) FROM user_jobs WHERE job_id = $1`:* rejected.
+It would need a new `user_jobs(job_id)` index (the PK is `(user_id, job_id)`, no
+help for a job-keyed scan) and a bespoke detail-only response shape or a second
+query, while the counter approach reuses the existing shared shape and is O(1) at
+read. The user explicitly asked to materialize on write.
+
+### Increment inside the existing write query via a snapshot CTE
+
+`RecordJobView` and `MarkJobApplied` become single-statement CTEs that upsert the
+interaction and conditionally bump the job counter, detecting the transition by
+reading the row's **prior** state before the upsert:
+
+```sql
+-- RecordJobView
+WITH prior AS (
+  SELECT 1 FROM user_jobs WHERE user_id = $1 AND job_id = $2
+), upsert AS (
+  INSERT INTO user_jobs (user_id, job_id) VALUES ($1, $2)
+  ON CONFLICT (user_id, job_id) DO UPDATE SET viewed_at = now()
+  RETURNING *
+), bump AS (
+  UPDATE jobs SET view_count = view_count + 1
+  WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior)
+)
+SELECT * FROM upsert;
+```
+
+```sql
+-- MarkJobApplied
+WITH prior AS (
+  SELECT applied_at FROM user_jobs WHERE user_id = $1 AND job_id = $2
+), upsert AS (
+  INSERT INTO user_jobs (user_id, job_id, applied_at, stage)
+  VALUES ($1, $2, now(), 'applied')
+  ON CONFLICT (user_id, job_id) DO UPDATE
+    SET applied_at = now(), stage = COALESCE(user_jobs.stage, 'applied')
+  RETURNING *
+), bump AS (
+  UPDATE jobs SET applied_count = applied_count + 1
+  WHERE id = $2 AND NOT EXISTS (SELECT 1 FROM prior WHERE applied_at IS NOT NULL)
+)
+SELECT * FROM upsert;
+```
+
+All CTEs see one MVCC snapshot, so `prior` reflects the OLD row: the `bump`
+fires only on first-ever view / first `applied_at` transition, and `upsert`'s
+`RETURNING` still returns the row every time (idempotency preserved). Chosen over
+the `xmax = 0` insert-detection trick because the snapshot CTE also handles the
+"row already existed but `applied_at` was NULL" case, which `xmax` cannot.
+
+*Alternative — two statements in the Go repository (read then upsert):* rejected;
+a single statement is atomic and avoids a race between the read and the bump.
+
+### Backfill in the migration
+
+`view_count` ← count of the job's `user_jobs` rows (every row has `viewed_at`
+set); `applied_count` ← count filtered on `applied_at IS NOT NULL`.
+
+### Display: omit zero counters
+
+Render each count only when `> 0`, so a fresh posting never shows "0 views".
+Shown to all visitors, muted, near the title/metadata on the detail page.
+
+## Risks / Trade-offs
+
+- **Signed-in-only undercount** → accepted and documented; the numbers are
+  labelled as engagement among users, and it avoids anonymous bot inflation. The
+  anonymous path is a clean future extension (a separate increment), not a
+  refactor.
+- **Backfill vs. incremental drift** → the backfill counts any interacting user
+  as a viewer (all rows have `viewed_at`), whereas the incremental `view_count`
+  bumps only on the `RecordJobView` insert. A user whose first interaction is a
+  save-without-open would be counted by the backfill but not by a later view.
+  This drift is at most ±1 per such user and immaterial for a social-proof
+  number; not worth extra write-path touch points.
+- **Counter can't go negative / no decrement** → applies/views are monotonic
+  here (no "un-apply" decrements the count). `applied_count` is not decremented
+  by `ClearJobProgress`/`UntrackJob`; accepted — the counter is cumulative
+  interest, not current-state. Documented so it isn't mistaken for a bug.
+- **Migration is manual in prod** → no versioned runner; apply the migration by
+  hand before deploying the new binary (existing project convention).
+
+## Migration Plan
+
+1. Add migration `00NN_job_engagement_counts.sql`: two columns + backfill.
+2. `make sqlc` after editing `user_jobs.sql`; commit generated code.
+3. Deploy order (prod): apply the migration by hand
+   (`docker exec -i freehire-db psql -U hire -d hire < …`) **before** rolling the
+   new app/web images, so the columns exist when the new queries run.
+4. Rollback: the columns are additive and defaulted; an old binary ignores them.
+   Reverting code needs no schema change.

--- a/openspec/changes/job-view-apply-counts/design.md
+++ b/openspec/changes/job-view-apply-counts/design.md
@@ -105,6 +105,17 @@ Shown to all visitors, muted, near the title/metadata on the detail page.
   save-without-open would be counted by the backfill but not by a later view.
   This drift is at most ±1 per such user and immaterial for a social-proof
   number; not worth extra write-path touch points.
+- **Concurrent first-interaction over-count** → the `prior` snapshot CTE detects
+  the transition per-transaction, not across concurrent ones: two simultaneous
+  first-views (or first-applies) of the *same* `(user, job)` both read an empty
+  `prior` from their pre-write snapshots and both bump, yielding +2 for one
+  distinct user. Requires the same user hitting the same job in two overlapping
+  requests (double tab / double-click) inside the commit window — rare, and the
+  effect is a cosmetic +1 on a metric already framed as approximate social proof.
+  Accepted, not serialized: row locks / `xmax` insert-detection would harden it
+  but add complexity disproportionate to a ±1 drift on an approximate count, and
+  would not fully cover the apply case anyway. Documented so it isn't mistaken
+  for an oversight.
 - **Counter can't go negative / no decrement** → applies/views are monotonic
   here (no "un-apply" decrements the count). `applied_count` is not decremented
   by `ClearJobProgress`/`UntrackJob`; accepted — the counter is cumulative

--- a/openspec/changes/job-view-apply-counts/proposal.md
+++ b/openspec/changes/job-view-apply-counts/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+A job's detail page shows no signal of how much interest a posting has drawn. Surfacing how many people have viewed a job and how many have applied gives visitors lightweight social proof and helps them gauge competition — using data the platform already records in `user_jobs`, at effectively zero read cost.
+
+## What Changes
+
+- Materialize two counters on the `jobs` row — `view_count` and `applied_count` — so every read path (list/detail/search) already carries them with no extra query or join.
+- Increment the counters in the existing tracking write path, each only on a first-time transition, so refreshes and repeat actions never inflate them:
+  - `view_count` +1 when a signed-in user's first view row is created (first time they open the detail page).
+  - `applied_count` +1 when a user's `applied_at` goes from unset to set.
+- Backfill both counters from existing `user_jobs` rows in the same migration, so live jobs are not all zero on release.
+- Expose both counters on the public job wire shape (`jobview.Job`) and display them on the job **detail** page only (`JobView.svelte`).
+
+Semantics (accepted, signed-in-only): counts reflect **distinct signed-in users**. Anonymous opens are not counted — noted as a future seam, not built now.
+
+## Capabilities
+
+### New Capabilities
+- `job-engagement-counts`: a job carries and publicly exposes materialized `view_count`/`applied_count`, displayed on the job detail page.
+
+### Modified Capabilities
+- `user-job-tracking`: recording a view and marking applied now also increment the job's materialized counter, each on a first-time transition only.
+
+## Impact
+
+- **Schema**: new migration — `jobs.view_count`/`jobs.applied_count` (`INT NOT NULL DEFAULT 0`) + one-pass backfill.
+- **DB queries** (`internal/db/queries/user_jobs.sql`): `RecordJobView` and `MarkJobApplied` become single-statement CTEs that upsert the interaction and conditionally bump the job counter; `make sqlc` regen.
+- **Wire shape** (`internal/jobview/jobview.go`): two new fields on `Job`, populated by `FromRow`.
+- **Frontend** (`web/src/lib/components/JobView.svelte`, `web/src/lib/types.ts`): render the counts on the detail page.
+- No new endpoints, no read-time counting, no write-path added for anonymous traffic.

--- a/openspec/changes/job-view-apply-counts/specs/job-engagement-counts/spec.md
+++ b/openspec/changes/job-view-apply-counts/specs/job-engagement-counts/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Job carries materialized engagement counters
+
+Each job SHALL carry two non-negative integer counters, `view_count` and
+`applied_count`, materialized on the `jobs` row (default `0`). The counters count
+**distinct signed-in users**: `view_count` is the number of distinct signed-in
+users who have opened the job's detail page; `applied_count` is the number of
+distinct users who have marked the job applied. Read paths SHALL serve these
+values directly from the `jobs` row without any per-request counting or join.
+
+#### Scenario: Counters default to zero
+
+- **WHEN** a job has no recorded interactions
+- **THEN** its `view_count` and `applied_count` are both `0`
+
+#### Scenario: Existing interactions are backfilled on release
+
+- **WHEN** the migration that introduces the counters runs against a database
+  that already holds `user_jobs` rows
+- **THEN** each job's `view_count` is set to its count of interacting users and
+  `applied_count` to its count of users whose `applied_at` is set
+
+### Requirement: Job wire shape exposes the counters
+
+The public job wire shape SHALL expose `view_count` and `applied_count` as
+integer fields, populated from the `jobs` row on every job read (list, detail,
+search).
+
+#### Scenario: Detail response includes the counters
+
+- **WHEN** a client requests `GET /api/v1/jobs/:slug`
+- **THEN** the `data` object includes integer `view_count` and `applied_count`
+  fields reflecting the stored counters
+
+### Requirement: SPA displays the counters on the job detail page
+
+The job detail page SHALL display the job's view and apply counts. A counter that
+is `0` SHALL be omitted so the display never reads as a dead "0 views". The counts
+are shown to every visitor, signed in or not.
+
+#### Scenario: Counts shown on a job with engagement
+
+- **WHEN** a visitor opens a job whose `view_count` is 5 and `applied_count` is 2
+- **THEN** the detail page shows both the view count and the apply count
+
+#### Scenario: Zero counters are omitted
+
+- **WHEN** a visitor opens a job whose `applied_count` is 0
+- **THEN** the apply count is not rendered

--- a/openspec/changes/job-view-apply-counts/specs/user-job-tracking/spec.md
+++ b/openspec/changes/job-view-apply-counts/specs/user-job-tracking/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: Recording a job view
+
+The system SHALL let an authenticated user record that they viewed a job, keyed
+by `(user, job)`, idempotently. The first view creates the interaction; a repeat
+view refreshes its timestamp without creating a duplicate. The endpoint SHALL
+return the interaction record, including whether the job has been saved and
+applied to. When — and only when — the first view row is created for a
+`(user, job)` pair, the system SHALL increment that job's materialized
+`view_count` by one, in the same statement, so repeat views never inflate it.
+
+#### Scenario: First view by a signed-in user
+
+- **WHEN** an authenticated user sends `POST /api/v1/jobs/:id/view` for a job
+  they have not interacted with before
+- **THEN** the system creates a `user_jobs` row with `viewed_at` set,
+  `saved_at` null, and `applied_at` null
+- **AND** responds `200` with
+  `{"data": {job_id, viewed_at, saved_at: null, applied_at: null}}`
+- **AND** the job's `view_count` is incremented by one
+
+#### Scenario: Repeat view does not duplicate
+
+- **WHEN** an authenticated user views the same job a second time
+- **THEN** the existing row's `viewed_at` is refreshed
+- **AND** no second row is created
+- **AND** the response carries the existing `saved_at` and `applied_at` values
+  unchanged
+- **AND** the job's `view_count` is not incremented again
+
+#### Scenario: View requires authentication
+
+- **WHEN** a request to `POST /api/v1/jobs/:id/view` carries no valid auth cookie
+- **THEN** the system responds `401` and records nothing
+
+#### Scenario: View with a non-numeric id
+
+- **WHEN** an authenticated user sends `POST /api/v1/jobs/:id/view` with an `:id`
+  that is not a valid job id
+- **THEN** the system responds with a client error (`400`) and records nothing
+
+### Requirement: Marking a job applied
+
+The system SHALL let an authenticated user mark a job as applied, idempotently,
+and SHALL seed `stage = 'applied'` when the stage is currently unset (an
+already-set stage is left untouched). Authentication MAY be by session cookie or
+by API key; either identifies the acting user identically. Marking applied sets
+`applied_at`; it works whether or not a view was recorded first, and repeating it
+does not create a duplicate or error. The endpoint SHALL return the updated
+interaction record. When — and only when — `applied_at` transitions from unset to
+set for a `(user, job)` pair, the system SHALL increment that job's materialized
+`applied_count` by one, in the same statement, so repeat applies never inflate it.
+
+#### Scenario: Mark applied after viewing
+
+- **WHEN** an authenticated user who has viewed a job sends
+  `POST /api/v1/jobs/:id/apply`
+- **THEN** the job's `applied_at` is set
+- **AND** the response is `200` with `{"data": {job_id, viewed_at, applied_at}}`
+  where `applied_at` is non-null
+- **AND** the job's `applied_count` is incremented by one
+
+#### Scenario: Mark applied is idempotent
+
+- **WHEN** an authenticated user marks the same job applied twice
+- **THEN** the row is updated in place each time
+- **AND** no duplicate row is created and no error is returned
+- **AND** the job's `applied_count` is incremented only on the first apply, not
+  the second
+
+#### Scenario: Applying seeds the initial stage
+
+- **WHEN** an authenticated user applies to a job whose `stage` is unset
+- **THEN** the interaction's `stage` becomes `applied`
+- **AND** applying again, or after the stage has been advanced, leaves the
+  existing stage unchanged
+
+#### Scenario: Apply requires authentication
+
+- **WHEN** a request to `POST /api/v1/jobs/:id/apply` carries neither a valid auth
+  cookie nor a valid API key
+- **THEN** the system responds `401` and records nothing
+
+#### Scenario: Apply authenticated by an API key
+
+- **WHEN** a request to `POST /api/v1/jobs/:id/apply` carries a valid
+  `Authorization: Bearer <key>` and no cookie
+- **THEN** the system marks the job applied for the key's owning user exactly as a
+  cookie session would and responds `200` with the updated interaction record
+
+#### Scenario: Apply to a non-existent job
+
+- **WHEN** an authenticated user sends `POST /api/v1/jobs/:id/apply` with a
+  numeric `:id` that has no corresponding job row
+- **THEN** the foreign-key violation surfaces as `404`, not `500`

--- a/openspec/changes/job-view-apply-counts/tasks.md
+++ b/openspec/changes/job-view-apply-counts/tasks.md
@@ -1,29 +1,29 @@
 ## 1. Schema + backfill
 
-- [ ] 1.1 Add migration `migrations/00NN_job_engagement_counts.sql`: `ALTER TABLE jobs ADD COLUMN view_count INT NOT NULL DEFAULT 0` and `applied_count INT NOT NULL DEFAULT 0`.
-- [ ] 1.2 In the same migration, backfill both from `user_jobs`: `view_count` = count of the job's rows, `applied_count` = count filtered on `applied_at IS NOT NULL`.
+- [x] 1.1 Add migration `migrations/0040_job_engagement_counts.sql`: `ALTER TABLE jobs ADD COLUMN view_count INT NOT NULL DEFAULT 0` and `applied_count INT NOT NULL DEFAULT 0`.
+- [x] 1.2 In the same migration, backfill both from `user_jobs`: `view_count` = count of the job's rows, `applied_count` = count filtered on `applied_at IS NOT NULL`.
 
 ## 2. Write path — increment counters (RED→GREEN per query)
 
-- [ ] 2.1 Integration test (`internal/db`, `//go:build integration`): first `RecordJobView` sets `jobs.view_count` to 1; a repeat view by the same user leaves it at 1; a view by a second user makes it 2.
-- [ ] 2.2 Rewrite `RecordJobView` in `internal/db/queries/user_jobs.sql` as the snapshot-CTE from design.md (prior → upsert → conditional `view_count` bump → `SELECT * FROM upsert`); keep the returned row shape identical.
-- [ ] 2.3 Integration test: first `MarkJobApplied` sets `jobs.applied_count` to 1; marking applied again by the same user leaves it at 1; a second user makes it 2.
-- [ ] 2.4 Rewrite `MarkJobApplied` as the snapshot-CTE (prior.applied_at → upsert → conditional `applied_count` bump on the NULL→set transition → `SELECT * FROM upsert`); preserve the stage-seeding and idempotency behavior.
-- [ ] 2.5 `make sqlc`; commit regenerated `internal/db`. Confirm `go build ./...` and existing tracking tests still pass.
+- [x] 2.1 Integration test (`internal/db`, `//go:build integration`): first `RecordJobView` sets `jobs.view_count` to 1; a repeat view by the same user leaves it at 1; a view by a second user makes it 2.
+- [x] 2.2 Rewrite `RecordJobView` in `internal/db/queries/user_jobs.sql` as the snapshot-CTE from design.md (prior → upsert → conditional `view_count` bump → `SELECT * FROM upsert`); keep the returned row shape identical.
+- [x] 2.3 Integration test: first `MarkJobApplied` sets `jobs.applied_count` to 1; marking applied again by the same user leaves it at 1; a second user makes it 2.
+- [x] 2.4 Rewrite `MarkJobApplied` as the snapshot-CTE (prior.applied_at → upsert → conditional `applied_count` bump on the NULL→set transition → `SELECT * FROM upsert`); preserve the stage-seeding and idempotency behavior.
+- [x] 2.5 `make sqlc`; commit regenerated `internal/db`. Confirm `go build ./...` and existing tracking tests still pass. (sqlc emits bespoke `RecordJobViewRow`/`MarkJobAppliedRow`; repository converts via `db.UserJob(row)`.)
 
 ## 3. Wire shape
 
-- [ ] 3.1 Test (`internal/jobview`): `FromRow` copies `view_count`/`applied_count` from the `db.Job` into the wire `Job`.
-- [ ] 3.2 Add `ViewCount int32 \`json:"view_count"\`` and `AppliedCount int32 \`json:"applied_count"\`` to `jobview.Job` and populate them in `FromRow` (and `FromRows` inherits it).
-- [ ] 3.3 Verify the fields appear on `GET /api/v1/jobs/:slug` (existing handler test or a quick integration assertion).
+- [x] 3.1 Test (`internal/jobview`): `FromRow` copies `view_count`/`applied_count` from the `db.Job` into the wire `Job`.
+- [x] 3.2 Add `ViewCount int32 \`json:"view_count"\`` and `AppliedCount int32 \`json:"applied_count"\`` to `jobview.Job` and populate them in `FromRow` (and `FromRows` inherits it).
+- [x] 3.3 Verify the fields appear on `GET /api/v1/jobs/:slug` (JSON contract test `TestJobJSON_ExposesEngagementCounts`).
 
 ## 4. Frontend (detail page)
 
-- [ ] 4.1 Add `view_count`/`applied_count` to the `Job` type in `web/src/lib/types.ts`.
-- [ ] 4.2 In `web/src/lib/components/JobView.svelte`, render a muted "N views · M applied" line on the detail page; omit each metric when its count is 0, and render nothing when both are 0. Verify with `npx svelte-check`.
+- [x] 4.1 Add `view_count`/`applied_count` to the `Job` type — the type is generated (`make gen-contracts`) from `jobview.Job`, so regenerated `web/src/lib/generated/contracts.ts` rather than hand-editing `types.ts`.
+- [x] 4.2 In `web/src/lib/components/JobView.svelte`, render a muted views/applied line in the sidebar metadata; omit each metric when its count is 0. Verified with `npx svelte-check` (0 errors).
 
 ## 5. Verify
 
-- [ ] 5.1 `go test ./...` (unit) green; `go test -tags=integration ./internal/db/` green (Docker).
-- [ ] 5.2 `go build ./... && go vet ./...` and `npx svelte-check` clean.
-- [ ] 5.3 Recreate the DB volume locally (`docker compose down -v && make up`) or apply the migration, then manually confirm: open a job while signed in → `view_count` increments once; apply → `applied_count` increments once; refresh → neither moves.
+- [x] 5.1 `go test ./...` (unit) green; `go test -tags=integration ./internal/db/` green (Docker, 245s, all pass).
+- [x] 5.2 `go build ./... && go vet ./...` and `npx svelte-check` clean.
+- [x] 5.3 Increment/idempotency behavior (first view→1, repeat→no change, second user→2; apply likewise) is proven against a real Postgres by `TestJobEngagementCounts` in the integration suite — stronger than a manual click. UI rendering verified by `svelte-check`. Live in-browser visual check deferred to deploy.

--- a/openspec/changes/job-view-apply-counts/tasks.md
+++ b/openspec/changes/job-view-apply-counts/tasks.md
@@ -1,0 +1,29 @@
+## 1. Schema + backfill
+
+- [ ] 1.1 Add migration `migrations/00NN_job_engagement_counts.sql`: `ALTER TABLE jobs ADD COLUMN view_count INT NOT NULL DEFAULT 0` and `applied_count INT NOT NULL DEFAULT 0`.
+- [ ] 1.2 In the same migration, backfill both from `user_jobs`: `view_count` = count of the job's rows, `applied_count` = count filtered on `applied_at IS NOT NULL`.
+
+## 2. Write path — increment counters (RED→GREEN per query)
+
+- [ ] 2.1 Integration test (`internal/db`, `//go:build integration`): first `RecordJobView` sets `jobs.view_count` to 1; a repeat view by the same user leaves it at 1; a view by a second user makes it 2.
+- [ ] 2.2 Rewrite `RecordJobView` in `internal/db/queries/user_jobs.sql` as the snapshot-CTE from design.md (prior → upsert → conditional `view_count` bump → `SELECT * FROM upsert`); keep the returned row shape identical.
+- [ ] 2.3 Integration test: first `MarkJobApplied` sets `jobs.applied_count` to 1; marking applied again by the same user leaves it at 1; a second user makes it 2.
+- [ ] 2.4 Rewrite `MarkJobApplied` as the snapshot-CTE (prior.applied_at → upsert → conditional `applied_count` bump on the NULL→set transition → `SELECT * FROM upsert`); preserve the stage-seeding and idempotency behavior.
+- [ ] 2.5 `make sqlc`; commit regenerated `internal/db`. Confirm `go build ./...` and existing tracking tests still pass.
+
+## 3. Wire shape
+
+- [ ] 3.1 Test (`internal/jobview`): `FromRow` copies `view_count`/`applied_count` from the `db.Job` into the wire `Job`.
+- [ ] 3.2 Add `ViewCount int32 \`json:"view_count"\`` and `AppliedCount int32 \`json:"applied_count"\`` to `jobview.Job` and populate them in `FromRow` (and `FromRows` inherits it).
+- [ ] 3.3 Verify the fields appear on `GET /api/v1/jobs/:slug` (existing handler test or a quick integration assertion).
+
+## 4. Frontend (detail page)
+
+- [ ] 4.1 Add `view_count`/`applied_count` to the `Job` type in `web/src/lib/types.ts`.
+- [ ] 4.2 In `web/src/lib/components/JobView.svelte`, render a muted "N views · M applied" line on the detail page; omit each metric when its count is 0, and render nothing when both are 0. Verify with `npx svelte-check`.
+
+## 5. Verify
+
+- [ ] 5.1 `go test ./...` (unit) green; `go test -tags=integration ./internal/db/` green (Docker).
+- [ ] 5.2 `go build ./... && go vet ./...` and `npx svelte-check` clean.
+- [ ] 5.3 Recreate the DB volume locally (`docker compose down -v && make up`) or apply the migration, then manually confirm: open a job while signed in → `view_count` increments once; apply → `applied_count` increments once; refresh → neither moves.

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import { resolve } from '$app/paths';
-  import { ArrowRight, Bookmark, Check, Flag } from '@lucide/svelte';
+  import { ArrowRight, Bookmark, Check, Eye, Flag } from '@lucide/svelte';
   import { markJobApplied, recordJobView, saveJob, unsaveJob } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
@@ -34,6 +34,10 @@
   const e = $derived(job.enrichment ?? {});
   const salary = $derived(formatSalary(e));
   const facets = $derived(summaryFacets(job));
+  // Engagement counters (distinct signed-in viewers / applicants), served on the
+  // job. A zero metric is omitted so the line never reads as a dead "0 views".
+  const views = $derived(job.view_count ?? 0);
+  const applies = $derived(job.applied_count ?? 0);
 
   // Record a view for signed-in users once the page hydrates (browser only).
   // Silent history that also tells us whether they
@@ -253,6 +257,17 @@
           <Badge variant="secondary">Manually added</Badge>
         {/if}
         {#if posted}<span class="text-xs text-muted-foreground">Posted {posted}</span>{/if}
+        {#if views > 0}
+          <span class="flex items-center gap-1 text-xs text-muted-foreground">
+            <Eye class="size-3.5" />{views}
+            {views === 1 ? 'view' : 'views'}
+          </span>
+        {/if}
+        {#if applies > 0}
+          <span class="flex items-center gap-1 text-xs text-muted-foreground">
+            <Check class="size-3.5" />{applies} applied
+          </span>
+        {/if}
       </div>
 
       <div class="border-t border-border pt-4 first:border-t-0 first:pt-0">

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -119,6 +119,13 @@ export interface Job {
   enrichment: Enrichment;
   enriched_at?: string;
   enrichment_version: number /* int32 */;
+  /**
+   * ViewCount/AppliedCount are the job's materialized engagement counters —
+   * distinct signed-in users who viewed and who marked applied — served straight
+   * from the jobs columns (no read-time counting). Displayed on the detail page.
+   */
+  view_count: number /* int32 */;
+  applied_count: number /* int32 */;
 }
 
 /**


### PR DESCRIPTION
## What

Show how many people viewed and applied to a job on its **detail** page — using data already in `user_jobs`, at zero read cost.

- Materialized counters `jobs.view_count` / `jobs.applied_count` (migration 0040 + backfill).
- Incremented in the existing `RecordJobView` / `MarkJobApplied` upserts via a snapshot-CTE, each **only on a first-time transition** (first view row created / `applied_at` NULL→set), so refreshes and repeats never inflate them.
- Reads are free: `jobview.FromRow` serves the columns straight off the row (no read-time `COUNT`, no join). Exposed on the public `Job` wire shape (contracts regenerated).
- SPA renders a muted "N views · M applied" line in the detail sidebar, omitting a metric when its count is 0.

Semantics: counts are **distinct signed-in users**. Anonymous opens are a documented future seam, not built.

## How

- `internal/db/queries/user_jobs.sql`: both queries become `WITH prior … , upsert … , bump …` — `prior` reads the pre-upsert row so the counter bumps only on the transition; `upsert`'s `RETURNING` keeps the row shape (idempotency preserved). sqlc emits bespoke row types; the repository converts via `db.UserJob(row)`.
- `migrations/0040_job_engagement_counts.sql`: two `INT NOT NULL DEFAULT 0` columns + one-pass backfill from `user_jobs`.
- `internal/jobview/jobview.go`: `ViewCount`/`AppliedCount` on `Job`, populated in `FromRow`.
- `web/.../JobView.svelte` + regenerated `contracts.ts`.

## Design & spec

`openspec/changes/job-view-apply-counts/` (proposal, design, specs, tasks). Built with the spec-driven-tdd discipline (RED→GREEN per query, simplify, review).

## Known limitation (accepted, documented in design.md)

Under two **concurrent first**-views/applies of the *same* `(user, job)` (double tab / double-click in the commit window), both transactions' snapshot `prior` is empty and both bump → a cosmetic +1 on an approximate metric. Not serialized: locks/`xmax` would add complexity disproportionate to a ±1 drift. Surfaced by the review, kept by design.

## Verification

- `go test ./...` (unit) green; `go test -tags=integration ./internal/db/` green (245s) — `TestJobEngagementCounts` proves first-view→1 / repeat→no-change / second-user→2 and the apply transition against real Postgres.
- `go build ./... && go vet ./...` clean; `npx svelte-check` 0 errors.

## Deploy note

Migration is additive; **apply `0040` by hand before rolling the new images** (no versioned runner — project convention).