### PR TITLE
feat(sources): add Taleo Enterprise adapter

### DIFF
--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"strconv"
 	"strings"
 	"time"
@@ -124,6 +125,17 @@ func NewClient() *Client {
 		maxRetries:   2,
 		retryDelay:   500 * time.Millisecond,
 	}
+}
+
+// newCookieClient builds an HTTP client that persists cookies across calls, for the one
+// adapter (Taleo) whose session-bound API needs the JSESSIONID a careersection GET sets to
+// carry into the searchjobs POST. The jar is host-scoped, so a single client segregates
+// cookies across tenants without per-tenant sessions. cookiejar.New(nil) never errors.
+func newCookieClient() *Client {
+	c := NewClient()
+	jar, _ := cookiejar.New(nil)
+	c.httpClient.Jar = jar
+	return c
 }
 
 // streamTimeout bounds a GetStream read. Generous because the throttled bulk feeds it

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -250,6 +250,15 @@ func All(c HTTPClient) map[string]Source {
 	if key := os.Getenv("REED_API_KEY"); key != "" {
 		registry["reed"] = NewReed(c, key)
 	}
+	// taleo needs a cookie-persisting client (its searchjobs POST requires the session cookie
+	// a careersection GET sets), so it cannot use the shared jar-less client. Build a dedicated
+	// one for a real crawl; on the transport-free listing path (c == nil) register a bare adapter
+	// — Provider()/marker assertions never touch the transport.
+	if c == nil {
+		registry["taleo"] = NewTaleo(nil)
+	} else {
+		registry["taleo"] = NewTaleo(newCookieClient())
+	}
 	// meta is the one adapter NOT served by the shared client: Meta's edge 400s the default Go
 	// TLS+HTTP/2 fingerprint, so it needs a Chrome-fingerprint transport (metaHTTP). Build it
 	// only when there is a real client to serve (the c == nil marker/listing path — e.g.

--- a/internal/sources/taleo.go
+++ b/internal/sources/taleo.go
@@ -1,0 +1,289 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// taleo adapts Oracle Taleo Enterprise career sites. The board id is the tenant host and
+// public careersection number, e.g. "valero.taleo.net/2". Taleo's job feed is keyless but
+// session-bound: a GET on the careersection sets a JSESSIONID cookie and embeds the
+// careersection's portal code, which the searchjobs POST needs to authorize. The list
+// carries no description, so each requisition's detail page is fetched and its description
+// decoded from the hidden initialHistory field.
+//
+// Known seam: some tenants front Taleo behind their own domain (no guessable careersection
+// path), and some return "An Error Occurred in TEE" to the searchjobs POST even with a valid
+// portal — those are onboarded per-tenant only when the recipe verifies live (see sources/taleo.yml).
+type taleo struct {
+	http taleoHTTP
+	// hosts serializes crawls of the same host. The client's cookie jar is host-scoped, so
+	// the JSESSIONID a careersection GET sets is shared by every board on that host; two
+	// careersections of one tenant (the host/section board id explicitly allows this) crawled
+	// concurrently would clobber each other's session in the jar. Locking per host keeps each
+	// board's GET→searchjobs→detail sequence on its own session; distinct hosts still run
+	// concurrently and never share a cookie.
+	hosts *keyedMutex
+}
+
+// taleoHTTP is the transport Taleo needs: a cookie-aware GET (careersection + detail HTML)
+// and a header-carrying POST (searchjobs needs the tz headers and the session cookie the GET
+// established). The real client must persist cookies across calls; a Go cookiejar is
+// host-scoped, so one client segregates cookies across tenants without per-tenant sessions.
+type taleoHTTP interface {
+	TextGetter
+	HeaderJSONPoster
+}
+
+// NewTaleo builds the Taleo adapter. In production it is wired with a cookie-persisting
+// client (see newCookieClient) so the session cookie carries from the careersection GET
+// into the searchjobs POST.
+func NewTaleo(c taleoHTTP) Source { return taleo{http: c, hosts: newKeyedMutex()} }
+
+func (taleo) Provider() string { return "taleo" }
+
+// taleoBoard is a configured board split into the tenant host and careersection number.
+type taleoBoard struct {
+	host, section string
+}
+
+// parseTaleoBoard splits "host/section" (e.g. "valero.taleo.net/2").
+func parseTaleoBoard(board string) (taleoBoard, error) {
+	host, section, ok := strings.Cut(board, "/")
+	if !ok || host == "" || section == "" {
+		return taleoBoard{}, fmt.Errorf("taleo: board %q must be \"host/section\"", board)
+	}
+	return taleoBoard{host: host, section: section}, nil
+}
+
+// taleoPortalRe extracts the careersection's portal code, embedded in the page as
+// portalNo: '101430233'. The portal authorizes the searchjobs POST.
+var taleoPortalRe = regexp.MustCompile(`portalNo:\s*'(\d+)'`)
+
+// taleoRequisition is one item from the searchjobs list. column is a positional array whose
+// layout is set per careersection: column[0] is always the title, but which cells hold the
+// location and posted date varies by tenant (some list neither). locationsColumns is the API's
+// own index of the location cell(s), so location is read from it rather than a fixed position.
+type taleoRequisition struct {
+	JobID            string   `json:"jobId"`
+	ContestNo        string   `json:"contestNo"`
+	Column           []string `json:"column"`
+	LocationsColumns []int    `json:"locationsColumns"`
+}
+
+type taleoListResponse struct {
+	RequisitionList []taleoRequisition `json:"requisitionList"`
+	PagingData      struct {
+		TotalCount int `json:"totalCount"`
+	} `json:"pagingData"`
+}
+
+func (s taleo) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	b, err := parseTaleoBoard(e.Board)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hold the host lock across the whole session (careersection GET → searchjobs → detail
+	// fan-out) so a same-host sibling board cannot overwrite our JSESSIONID mid-crawl.
+	defer s.hosts.lock(b.host)()
+
+	portal, err := s.openSection(ctx, b)
+	if err != nil {
+		return nil, err
+	}
+
+	reqs, err := s.listRequisitions(ctx, b, portal)
+	if err != nil {
+		return nil, err
+	}
+
+	// Description is best-effort: the listing already yields a valid job (title, location,
+	// date), so a failed detail fetch leaves the job with an empty description rather than
+	// dropping it.
+	return fetchDetails(reqs, defaultDetailWorkers, func(r taleoRequisition) (Job, bool) {
+		return s.toJob(ctx, e, b, r), true
+	}), nil
+}
+
+// openSection GETs the careersection to establish the session cookie and returns the portal
+// code scraped from the page. Both are required by the searchjobs POST.
+func (s taleo) openSection(ctx context.Context, b taleoBoard) (string, error) {
+	sectionURL := fmt.Sprintf("https://%s/careersection/%s/jobsearch.ftl?lang=en", b.host, b.section)
+	page, err := s.http.GetText(ctx, sectionURL)
+	if err != nil {
+		return "", fmt.Errorf("taleo: open careersection %s/%s: %w", b.host, b.section, err)
+	}
+	m := taleoPortalRe.FindStringSubmatch(page)
+	if m == nil {
+		return "", fmt.Errorf("taleo: no portalNo on careersection %s/%s (not a public section?)", b.host, b.section)
+	}
+	return m[1], nil
+}
+
+// listRequisitions pages through the board's requisitions via searchjobs, stopping when a
+// page is empty or the collected count reaches totalCount.
+func (s taleo) listRequisitions(ctx context.Context, b taleoBoard, portal string) ([]taleoRequisition, error) {
+	url := fmt.Sprintf("https://%s/careersection/rest/jobboard/searchjobs?lang=en&portal=%s", b.host, portal)
+	headers := map[string]string{"tz": "GMT+00:00", "tzname": "UTC"}
+
+	var reqs []taleoRequisition
+	// taleoMaxPages caps the pagination loop so a bogus totalCount can never spin the crawl
+	// indefinitely (cf. the yandex runaway-cursor incident). 200 pages ≈ 5k jobs covers every
+	// board we onboard; the loop normally stops far earlier on totalCount or an empty page.
+	const taleoMaxPages = 200
+	for page := 1; page <= taleoMaxPages; page++ {
+		body := taleoSearchBody(page)
+		var resp taleoListResponse
+		if err := s.http.PostJSONWithHeaders(ctx, url, headers, body, &resp); err != nil {
+			return nil, fmt.Errorf("taleo: searchjobs %s page %d: %w", b.host, page, err)
+		}
+		if len(resp.RequisitionList) == 0 {
+			break
+		}
+		reqs = append(reqs, resp.RequisitionList...)
+		if len(reqs) >= resp.PagingData.TotalCount {
+			break
+		}
+	}
+	return reqs, nil
+}
+
+// taleoSearchBody is the searchjobs request payload for one page: the default (unfiltered)
+// search sorted by posting date, at the given 1-based page.
+func taleoSearchBody(page int) map[string]any {
+	return map[string]any{
+		"multilineEnabled": false,
+		"sortingSelection": map[string]any{
+			"sortBySelectionParam":  "3",
+			"ascendingSortingOrder": false,
+		},
+		"fieldData":                           map[string]any{},
+		"filterSelectionParam":                map[string]any{"searchFilterSelections": []any{}},
+		"advancedSearchFiltersSelectionParam": map[string]any{"searchFilterSelections": []any{}},
+		"pageNo":                              page,
+	}
+}
+
+// toJob maps one requisition to a Job, fetching its detail page for the description
+// (best-effort — a failed or empty detail leaves the description blank).
+func (s taleo) toJob(ctx context.Context, e CompanyEntry, b taleoBoard, r taleoRequisition) Job {
+	title, location, posted := taleoFields(r)
+	detailURL := fmt.Sprintf("https://%s/careersection/%s/jobdetail.ftl?job=%s&lang=en", b.host, b.section, r.ContestNo)
+
+	var description string
+	if page, err := s.http.GetText(ctx, detailURL); err == nil {
+		description = taleoDescription(page)
+	}
+
+	return Job{
+		ExternalID:  r.ContestNo,
+		URL:         detailURL,
+		Title:       title,
+		Company:     e.Company,
+		Location:    location,
+		Description: description,
+		Remote:      isRemote(location),
+		PostedAt:    posted,
+	}
+}
+
+// taleoFields reads a requisition's title, location, and posted date from its variable column
+// layout. Title is always column[0]. Location is read from the cells the API names in
+// locationsColumns (never a guessed position), each a JSON string-array or a plain value. The
+// posted date is the first cell that parses as Taleo's "Jan 2, 2006" listing format, so an
+// id/other cell is never misread as a date; a tenant listing no date yields nil.
+func taleoFields(r taleoRequisition) (title, location string, posted *time.Time) {
+	if len(r.Column) > 0 {
+		title = r.Column[0]
+	}
+	var parts []string
+	for _, idx := range r.LocationsColumns {
+		if idx >= 0 && idx < len(r.Column) {
+			parts = append(parts, taleoLocation(r.Column[idx]))
+		}
+	}
+	location = joinNonEmpty(parts...)
+	for _, cell := range r.Column {
+		if t := parseLayout("Jan 2, 2006", cell); t != nil {
+			posted = t
+			break
+		}
+	}
+	return title, location, posted
+}
+
+// taleoLocation flattens the JSON string-array location cell into a comma-joined string,
+// falling back to the raw cell when it is not a JSON array.
+func taleoLocation(cell string) string {
+	var locs []string
+	if err := json.Unmarshal([]byte(cell), &locs); err != nil {
+		return cell
+	}
+	return joinNonEmpty(locs...)
+}
+
+// taleoDescription decodes a jobdetail.ftl page's description. Taleo embeds it in the hidden
+// initialHistory input: state fields are "!|!"-delimited and the URL-encoded description HTML
+// follows the "!*!" marker. We take the segment after "!*!" up to the next "!|!", percent-decode
+// it (PathUnescape leaves "+" intact so tokens like "C++" survive), and sanitize.
+func taleoDescription(page string) string {
+	value := taleoInitialHistory(page)
+	if value == "" {
+		return ""
+	}
+	_, after, ok := strings.Cut(value, "!*!")
+	if !ok {
+		return ""
+	}
+	if i := strings.Index(after, "!|!"); i >= 0 {
+		after = after[:i]
+	}
+	decoded, err := url.PathUnescape(after)
+	if err != nil {
+		decoded = after // keep the encoded form rather than dropping the description
+	}
+	return sanitizeHTML(decoded)
+}
+
+// keyedMutex hands out one mutex per string key, created on demand, so callers serialize work
+// sharing a key while distinct keys proceed concurrently.
+type keyedMutex struct{ m sync.Map }
+
+func newKeyedMutex() *keyedMutex { return &keyedMutex{} }
+
+// lock acquires the mutex for key and returns its unlock func.
+func (k *keyedMutex) lock(key string) func() {
+	mu, _ := k.m.LoadOrStore(key, &sync.Mutex{})
+	l := mu.(*sync.Mutex)
+	l.Lock()
+	return l.Unlock
+}
+
+// taleoInitialHistory returns the value of the hidden <input name="initialHistory">, or "".
+func taleoInitialHistory(page string) string {
+	root, err := html.Parse(strings.NewReader(page))
+	if err != nil {
+		return ""
+	}
+	var value string
+	walk(root, func(n *html.Node) bool {
+		if value != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "input" && attr(n, "name") == "initialHistory" {
+			value = attr(n, "value")
+			return false
+		}
+		return true
+	})
+	return value
+}

--- a/internal/sources/taleo_test.go
+++ b/internal/sources/taleo_test.go
@@ -1,0 +1,281 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTaleoProvider(t *testing.T) {
+	if got := NewTaleo(nil).Provider(); got != "taleo" {
+		t.Errorf("Provider() = %q, want %q", got, "taleo")
+	}
+}
+
+func TestTaleoInRegistry(t *testing.T) {
+	if s, ok := All(nil)["taleo"]; !ok || s.Provider() != "taleo" {
+		t.Fatal("All() missing provider taleo")
+	}
+}
+
+func TestTaleoBoardValidation(t *testing.T) {
+	for _, board := range []string{"", "valero.taleo.net", "/2", "valero.taleo.net/"} {
+		if _, err := NewTaleo(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Company: "Valero", Board: board}); err == nil {
+			t.Errorf("board %q: want error, got nil", board)
+		}
+	}
+}
+
+// taleoCareersection is a minimal careersection HTML carrying the portalNo the adapter
+// scrapes to authorize the searchjobs POST.
+const taleoCareersection = `<html><head><script>
+	var config = { portalNo: '101430233', portalCode: 2 };
+</script></head><body>Job Search</body></html>`
+
+// taleoJobDetail builds a jobdetail.ftl page whose description lives in the hidden
+// initialHistory input: URL-encoded HTML after the "!*!" marker, then more "!|!"-delimited
+// state. This mirrors the live Taleo shape the adapter must decode.
+func taleoJobDetail(encodedDescHTML string) string {
+	return fmt.Sprintf(`<html><body>
+		<input type="hidden" name="focusOnField" id="focusOnField" value="" />
+		<input type="hidden" name="initialHistory" id="initialHistory"
+			value="ftlx0!|!x!%%24!requisitionDescriptionInterface!|!descRequisition!|!!*!%s!|!false!|!true" />
+		</body></html>`, encodedDescHTML)
+}
+
+// TestTaleoFetch covers the core path: scrape the portal from the careersection, POST
+// searchjobs to page the requisition list, then decode each job's description from its
+// detail page. external_id is contestNo; location is the JSON-array column; the description
+// is URL-decoded and sanitized.
+func TestTaleoFetch(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("careersection/2/jobsearch.ftl", taleoCareersection).
+		route("searchjobs", `{
+			"requisitionList": [
+				{"jobId": "311673", "contestNo": "2600197", "locationsColumns": [1],
+				 "column": ["Occupational Health Professional", "[\"US-OK-Ardmore\"]", "Jul 2, 2026"]},
+				{"jobId": "311680", "contestNo": "2600205", "locationsColumns": [1],
+				 "column": ["Backend Engineer", "[\"US-TX-San Antonio\"]", "Jun 30, 2026"]}
+			],
+			"pagingData": {"totalCount": 2}
+		}`).
+		// Description HTML url-encoded: "<p>Provide care.</p><script>alert(1)</script>"
+		route("job=2600197", taleoJobDetail("%3Cp%3EProvide%20care.%3C%2Fp%3E%3Cscript%3Ealert(1)%3C%2Fscript%3E")).
+		route("job=2600205", taleoJobDetail("%3Cp%3EWrite%20Go.%3C%2Fp%3E"))
+
+	jobs, err := NewTaleo(fake).Fetch(context.Background(), CompanyEntry{Company: "Valero", Board: "valero.taleo.net/2"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j, ok := byID["2600197"]
+	if !ok {
+		t.Fatalf("missing job with external_id=contestNo 2600197; got %v", byID)
+	}
+	if j.Title != "Occupational Health Professional" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Valero" {
+		t.Errorf("Company = %q, want Valero", j.Company)
+	}
+	if j.Location != "US-OK-Ardmore" {
+		t.Errorf("Location = %q, want US-OK-Ardmore", j.Location)
+	}
+	if !strings.Contains(j.URL, "valero.taleo.net/careersection/2/jobdetail.ftl?job=2600197") {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-02" {
+		t.Errorf("PostedAt = %v, want 2026-07-02", j.PostedAt)
+	}
+	if !strings.Contains(j.Description, "Provide care") {
+		t.Errorf("Description missing text: %q", j.Description)
+	}
+	if strings.Contains(j.Description, "script") || strings.Contains(j.Description, "alert") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+}
+
+// TestTaleoFields locks the varying column layout across tenants: location is read from the
+// API's locationsColumns index (never guessed), and the posted date only from a column that
+// parses as "Jan 2, 2006". A tenant whose listing omits location/date (schneider/baesystems
+// shapes) yields empty location and a nil date rather than misreading an id column.
+func TestTaleoFields(t *testing.T) {
+	cases := []struct {
+		name         string
+		req          taleoRequisition
+		wantTitle    string
+		wantLocation string
+		wantPosted   string // "" means nil
+	}{
+		{
+			name:         "valero: title, location, date",
+			req:          taleoRequisition{Column: []string{"Occupational Health Professional", `["US-OK-Ardmore"]`, "Jul 2, 2026"}, LocationsColumns: []int{1}},
+			wantTitle:    "Occupational Health Professional",
+			wantLocation: "US-OK-Ardmore",
+			wantPosted:   "2026-07-02",
+		},
+		{
+			name:         "schneider: title + id column, no location index",
+			req:          taleoRequisition{Column: []string{"Dedicated truck driver", "261143"}, LocationsColumns: []int{}},
+			wantTitle:    "Dedicated truck driver",
+			wantLocation: "",
+			wantPosted:   "",
+		},
+		{
+			name:         "baesystems: title only",
+			req:          taleoRequisition{Column: []string{"Principal Commercial Officer"}},
+			wantTitle:    "Principal Commercial Officer",
+			wantLocation: "",
+			wantPosted:   "",
+		},
+		{
+			name:         "multi-location index joins",
+			req:          taleoRequisition{Column: []string{"Role", `["US-TX-Austin","US-CA-SF"]`}, LocationsColumns: []int{1}},
+			wantTitle:    "Role",
+			wantLocation: "US-TX-Austin, US-CA-SF",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			title, location, posted := taleoFields(tc.req)
+			if title != tc.wantTitle {
+				t.Errorf("title = %q, want %q", title, tc.wantTitle)
+			}
+			if location != tc.wantLocation {
+				t.Errorf("location = %q, want %q", location, tc.wantLocation)
+			}
+			got := ""
+			if posted != nil {
+				got = posted.Format("2006-01-02")
+			}
+			if got != tc.wantPosted {
+				t.Errorf("posted = %q, want %q", got, tc.wantPosted)
+			}
+		})
+	}
+}
+
+// TestKeyedMutexSerializesPerKey asserts the same key is mutually exclusive (a second lock
+// blocks until the first unlocks) while distinct keys are independent.
+func TestKeyedMutexSerializesPerKey(t *testing.T) {
+	k := newKeyedMutex()
+
+	// Distinct keys must not block each other: acquire both without releasing.
+	unlockA := k.lock("a")
+	unlockB := k.lock("b")
+	unlockB()
+
+	// Same key must be exclusive: a second lock on "a" cannot proceed until unlockA runs.
+	acquired := make(chan struct{})
+	go func() {
+		release := k.lock("a")
+		close(acquired)
+		release()
+	}()
+	select {
+	case <-acquired:
+		t.Fatal("second lock on key \"a\" acquired while first still held")
+	case <-time.After(20 * time.Millisecond):
+	}
+	unlockA()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("second lock on key \"a\" never acquired after release")
+	}
+}
+
+// TestTaleoConcurrentSameHostFetch runs two crawls of the same host concurrently through the
+// (concurrency-safe) fake; with -race this guards the per-host locking added for session
+// isolation against data races and deadlocks.
+func TestTaleoConcurrentSameHostFetch(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("jobsearch.ftl", taleoCareersection).
+		route("searchjobs", `{"requisitionList":[{"jobId":"1","contestNo":"c1","locationsColumns":[1],"column":["Role","[\"US\"]","Jul 1, 2026"]}],"pagingData":{"totalCount":1}}`).
+		route("jobdetail.ftl", taleoJobDetail("%3Cp%3Ex%3C%2Fp%3E"))
+	s := NewTaleo(fake)
+
+	var wg sync.WaitGroup
+	for _, board := range []string{"acme.taleo.net/1", "acme.taleo.net/2"} {
+		wg.Add(1)
+		go func(b string) {
+			defer wg.Done()
+			jobs, err := s.Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: b})
+			if err != nil {
+				t.Errorf("board %s: %v", b, err)
+			}
+			if len(jobs) != 1 {
+				t.Errorf("board %s: got %d jobs, want 1", b, len(jobs))
+			}
+		}(board)
+	}
+	wg.Wait()
+}
+
+// taleoPagingFake serves the careersection + detail via URL routes but returns searchjobs
+// pages from a queue, so pagination (pageNo in the POST body, not the URL) can be exercised.
+type taleoPagingFake struct {
+	routes []struct{ match, body string }
+	mu     sync.Mutex
+	pages  []string
+	posts  int
+}
+
+func (f *taleoPagingFake) route(match, body string) *taleoPagingFake {
+	f.routes = append(f.routes, struct{ match, body string }{match, body})
+	return f
+}
+
+func (f *taleoPagingFake) GetText(_ context.Context, url string) (string, error) {
+	for _, r := range f.routes {
+		if strings.Contains(url, r.match) {
+			return r.body, nil
+		}
+	}
+	return "", fmt.Errorf("taleoPagingFake: no route for %s", url)
+}
+
+func (f *taleoPagingFake) PostJSONWithHeaders(_ context.Context, _ string, _ map[string]string, _, v any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.posts >= len(f.pages) {
+		return fmt.Errorf("taleoPagingFake: unexpected extra searchjobs POST #%d", f.posts+1)
+	}
+	body := f.pages[f.posts]
+	f.posts++
+	return json.Unmarshal([]byte(body), v)
+}
+
+func TestTaleoPaginates(t *testing.T) {
+	page := func(contest string) string {
+		return fmt.Sprintf(`{"requisitionList":[{"jobId":"%s","contestNo":"%s","column":["Role %s","[\"US\"]","Jul 1, 2026"]}],"pagingData":{"totalCount":3}}`, contest, contest, contest)
+	}
+	fake := (&taleoPagingFake{
+		pages: []string{page("1"), page("2"), page("3")},
+	}).
+		route("jobsearch.ftl", taleoCareersection).
+		route("jobdetail.ftl", taleoJobDetail("%3Cp%3Ex%3C%2Fp%3E"))
+
+	jobs, err := NewTaleo(fake).Fetch(context.Background(), CompanyEntry{Company: "Valero", Board: "valero.taleo.net/2"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (paged)", len(jobs))
+	}
+	if fake.posts != 3 {
+		t.Errorf("made %d searchjobs POSTs, want 3", fake.posts)
+	}
+}

--- a/sources/taleo.yml
+++ b/sources/taleo.yml
@@ -1,0 +1,21 @@
+# taleo (Oracle Taleo Enterprise) boards. Provider is the filename; board =
+# "<host>/<careersection>" (see internal/sources/taleo.go), e.g. valero.taleo.net/2.
+# Taleo is session-bound: the adapter GETs the careersection to set the JSESSIONID and
+# scrape its portal code, then POSTs searchjobs. Each board was validated live (searchjobs
+# returned >0 jobs and descriptions decoded) before adding.
+#
+# Onboarding a tenant is manual: find its public careersection host + number (the section
+# that renders a real Job Search page, not the recruiter login) — the number is not
+# guessable and varies per tenant. Known seams (do not re-add blindly): tenants that front
+# Taleo behind their own domain (no *.taleo.net careersection — uhg/hilton/textron/jacobs),
+# tenants whose searchjobs returns "An Error Occurred in TEE", and very large boards whose
+# per-job detail fan-out is slow (hyatt.taleo.net/1 lists ~3k jobs).
+
+- company: Valero
+  board: valero.taleo.net/2
+- company: BAE Systems
+  board: baesystems.taleo.net/1
+- company: Schneider National
+  board: schneider.taleo.net/1
+- company: D.R. Horton
+  board: drhorton.taleo.net/2

--- a/sources/taleo.yml
+++ b/sources/taleo.yml
@@ -4,12 +4,14 @@
 # scrape its portal code, then POSTs searchjobs. Each board was validated live (searchjobs
 # returned >0 jobs and descriptions decoded) before adding.
 #
-# Onboarding a tenant is manual: find its public careersection host + number (the section
-# that renders a real Job Search page, not the recruiter login) — the number is not
-# guessable and varies per tenant. Known seams (do not re-add blindly): tenants that front
-# Taleo behind their own domain (no *.taleo.net careersection — uhg/hilton/textron/jacobs),
-# tenants whose searchjobs returns "An Error Occurred in TEE", and very large boards whose
-# per-job detail fan-out is slow (hyatt.taleo.net/1 lists ~3k jobs).
+# Onboarding a tenant is manual: find its public careersection host + section (the one that
+# renders a real Job Search page, not the recruiter login) — the section (a number like "2"
+# or a name like "ex") is not guessable and varies per tenant. Known seams (do not re-add
+# blindly): tenants whose *.taleo.net host is up but expose no public careersection under a
+# guessable path — they front the candidate portal on their own domain (uhg/hilton/textron/
+# cognizant/praxair/rossstores/kearney); tenants whose searchjobs returns "An Error Occurred
+# in TEE"; and very large boards whose per-job detail fan-out is slow (hyatt.taleo.net/1 lists
+# ~3k jobs — excluded; hdr below at ~1.8k takes ~100s and is the practical size ceiling).
 
 - company: Valero
   board: valero.taleo.net/2
@@ -19,3 +21,9 @@
   board: schneider.taleo.net/1
 - company: D.R. Horton
   board: drhorton.taleo.net/2
+- company: Mercedes-Benz
+  board: daimler.taleo.net/ex
+- company: Jacobs
+  board: jacobs.taleo.net/ex
+- company: HDR
+  board: hdr.taleo.net/ex


### PR DESCRIPTION
Supersedes #392 (that branch was overwritten by an unrelated force-push and no longer contains this work).

## What
Keyless source adapter for **Oracle Taleo Enterprise** career sites — the biggest missing ATS vendor in the [state-of-ats-2026](https://github.com/Kayvan-Zahiri/state-of-ats-2026) audit (39 Taleo companies).

## How
Taleo's feed is keyless but **session-bound**, per board:
1. `GET /careersection/<section>/jobsearch.ftl` → sets `JSESSIONID` + embeds `portalNo` (scraped).
2. `POST /careersection/rest/jobboard/searchjobs?portal=<code>` in-session (**`tz`/`tzname` headers required** — else 500 "An Error Occurred in TEE") → pages the requisition list.
3. `GET /careersection/<section>/jobdetail.ftl?job=<contestNo>` → description decoded from the hidden `initialHistory` input (URL-encoded HTML after `!*!`).

Board id = `host/section` (mirrors Oracle's `host/site`); `external_id = contestNo`.

### Notable points
- **`newCookieClient`**: cookie-persisting client so the session carries GET→POST (jar is host-scoped → segregates tenants).
- **Per-host `keyedMutex`**: serializes same-host crawls so two careersections of one tenant can't clobber each other's session (found in review).
- **Variable column layout**: title is `column[0]`; location read from the API's `locationsColumns` index; posted date only from a column parsing as `Jan 2, 2006` — never fixed positions.
- Description is best-effort (a failed detail leaves it blank, job still ships).

## Scope (spike verdict: PARTIAL)
Onboarding is per-tenant (careersection path not guessable; some tenants front Taleo on their own domain or return "Error in TEE"). Ships **7 live-verified boards**: Valero, BAE Systems, Schneider National, D.R. Horton, Mercedes-Benz, Jacobs, HDR. Excluded `hyatt` (~3k jobs, scale). Seams documented in `sources/taleo.yml`.

## Testing
Unit tests (provider, board validation, fetch+detail+sanitize, varying column layouts, pagination, keyedMutex, concurrent same-host under `-race`); all 7 boards live-verified end-to-end; `go build`/`vet`/`test ./...` green on current `main`.

## Deploy note
Needs its own cron `go run ./cmd/ingest sources/taleo.yml` in freehire-ops + a reindex.