### PR TITLE
fix(web): counts on own line, mute LinkedIn, tidy mobile footer

### DIFF
--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -32,8 +32,7 @@
   ];
 
   // External profiles: open in a new tab, each rendered with its ProviderIcon brand
-  // mark. github/telegram follow the text colour (so hover works); linkedin keeps
-  // its brand blue by design.
+  // mark. All three follow the muted text colour (so they match and hover works).
   const socials = [
     { provider: 'github', label: 'GitHub', href: 'https://github.com/strelov1/freehire' },
     { provider: 'linkedin', label: 'LinkedIn', href: 'https://linkedin.com/company/freehire-dev/' },
@@ -44,8 +43,8 @@
 </script>
 
 <footer class="border-t border-border">
-  <div class="mx-auto max-w-6xl px-4 py-10 sm:py-12">
-    <div class="grid grid-cols-2 gap-8 sm:grid-cols-4 sm:gap-6">
+  <div class="mx-auto max-w-6xl px-4 py-8 sm:py-12">
+    <div class="grid grid-cols-2 gap-x-6 gap-y-7 sm:grid-cols-4 sm:gap-6">
       <!-- Brand block: full width on mobile, one column on wide viewports. -->
       <div class="col-span-2 sm:col-span-1 sm:pr-4">
         <a

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -244,29 +244,28 @@
         </ul>
       {/if}
 
-      <div
-        class="flex flex-wrap items-center gap-2 border-t border-border pt-4 first:border-t-0 first:pt-0"
-      >
+      <div class="flex flex-col gap-2 border-t border-border pt-4 first:border-t-0 first:pt-0">
+        <div class="flex flex-wrap items-center gap-2">
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link from filterHref; query-only, no route to resolve -->
-        <a href={filterHref('source', job.source)}>
-          <Badge variant="outline" class="transition-colors hover:bg-accent hover:text-foreground">
-            {job.source}
-          </Badge>
-        </a>
-        {#if job.manually_added}
-          <Badge variant="secondary">Manually added</Badge>
-        {/if}
-        {#if posted}<span class="text-xs text-muted-foreground">Posted {posted}</span>{/if}
-        {#if views > 0}
-          <span class="flex items-center gap-1 text-xs text-muted-foreground">
-            <Eye class="size-3.5" />{views}
-            {views === 1 ? 'view' : 'views'}
-          </span>
-        {/if}
-        {#if applies > 0}
-          <span class="flex items-center gap-1 text-xs text-muted-foreground">
-            <Check class="size-3.5" />{applies} applied
-          </span>
+          <a href={filterHref('source', job.source)}>
+            <Badge variant="outline" class="transition-colors hover:bg-accent hover:text-foreground">
+              {job.source}
+            </Badge>
+          </a>
+          {#if job.manually_added}
+            <Badge variant="secondary">Manually added</Badge>
+          {/if}
+          {#if posted}<span class="text-xs text-muted-foreground">Posted {posted}</span>{/if}
+        </div>
+        {#if views > 0 || applies > 0}
+          <div class="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            {#if views > 0}
+              <span class="flex items-center gap-1"><Eye class="size-3.5" />{views} {views === 1 ? 'view' : 'views'}</span>
+            {/if}
+            {#if applies > 0}
+              <span class="flex items-center gap-1"><Check class="size-3.5" />{applies} applied</span>
+            {/if}
+          </div>
         {/if}
       </div>
 

--- a/web/src/lib/components/ProviderIcon.svelte
+++ b/web/src/lib/components/ProviderIcon.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   // Brand marks (OAuth sign-in buttons, footer links), inlined because icon
   // libraries (lucide) do not ship brand logos. Google keeps its official
-  // colors; GitHub and Telegram follow the current text color so they adapt to
-  // the theme; LinkedIn uses its brand blue.
+  // colors; GitHub, Telegram, and LinkedIn follow the current text color so they
+  // adapt to the theme (and match the muted footer treatment).
   let { provider }: { provider: string } = $props();
 </script>
 
@@ -38,7 +38,7 @@
     />
   </svg>
 {:else if provider === 'linkedin'}
-  <svg viewBox="0 0 24 24" class="size-4" fill="#0A66C2" aria-hidden="true">
+  <svg viewBox="0 0 24 24" class="size-4" fill="currentColor" aria-hidden="true">
     <path
       d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"
     />


### PR DESCRIPTION
Small UI polish (frontend-only, no API/schema changes):

- **Job detail:** the view/apply counts moved to a dedicated row under the source/"Posted" line, so they no longer ragged-wrap beside the source badge.
- **Social icons:** LinkedIn now follows the muted text colour like GitHub/Telegram (dropped the hard-coded brand blue), so the footer social row is uniform and adapts to theme.
- **Footer mobile:** tighter vertical padding and grid gaps.

Verified: `svelte-check` 0 errors; headless mobile-width screenshots confirm counts-on-own-line, gray LinkedIn, and the tighter footer.