### PR TITLE
fix(sources): add 3 Taleo board entries missing from #398

### DIFF
--- a/sources/taleo.yml
+++ b/sources/taleo.yml
@@ -28,3 +28,9 @@
   board: jacobs.taleo.net/ex
 - company: HDR
   board: hdr.taleo.net/ex
+- company: Textron
+  board: textron.taleo.net/textron
+- company: Cognizant
+  board: cognizant.taleo.net/naukri
+- company: Ross Stores
+  board: rossstores.taleo.net/rstrcs1.1


### PR DESCRIPTION
#398's edit updated the taleo.yml seam comment to cite Textron / Cognizant / Ross Stores as found, but the three board entries were accidentally dropped from that edit (only the comment landed). This adds them so the file matches its comment. All three were live-verified through the real adapter (Textron 501, Cognizant 397, Ross Stores 505).