### PR TITLE
feat(sources): make Taleo a StreamingSource; re-enable large boards (+Hyatt)

### DIFF
--- a/internal/sources/taleo.go
+++ b/internal/sources/taleo.go
@@ -86,10 +86,31 @@ type taleoListResponse struct {
 	} `json:"pagingData"`
 }
 
+// Fetch buffers the whole board by collecting the streamed jobs. The pipeline prefers
+// FetchStream (incremental save); Fetch stays for non-streaming callers and tests.
 func (s taleo) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var (
+		mu   sync.Mutex
+		jobs []Job
+	)
+	err := s.FetchStream(ctx, e, func(j Job) {
+		mu.Lock()
+		jobs = append(jobs, j)
+		mu.Unlock()
+	})
+	return jobs, err
+}
+
+// FetchStream opens the careersection, pages the requisition list, then fetches each
+// requisition's detail concurrently and emits the assembled Job the moment its detail
+// completes — so the pipeline persists a long, detail-heavy crawl incrementally rather than
+// buffering the whole board (large tenants run to thousands of requisitions). Only a listing
+// failure is returned as a board-level error; a per-requisition detail miss still emits the
+// job with an empty description (best-effort — the listing already yields a valid job).
+func (s taleo) FetchStream(ctx context.Context, e CompanyEntry, emit func(Job)) error {
 	b, err := parseTaleoBoard(e.Board)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Hold the host lock across the whole session (careersection GET → searchjobs → detail
@@ -98,20 +119,17 @@ func (s taleo) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 
 	portal, err := s.openSection(ctx, b)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	reqs, err := s.listRequisitions(ctx, b, portal)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	// Description is best-effort: the listing already yields a valid job (title, location,
-	// date), so a failed detail fetch leaves the job with an empty description rather than
-	// dropping it.
-	return fetchDetails(reqs, defaultDetailWorkers, func(r taleoRequisition) (Job, bool) {
-		return s.toJob(ctx, e, b, r), true
-	}), nil
+	fetchDetailsStream(reqs, defaultDetailWorkers,
+		func(r taleoRequisition) (Job, bool) { return s.toJob(ctx, e, b, r), true }, emit)
+	return nil
 }
 
 // openSection GETs the careersection to establish the session cookie and returns the portal

--- a/internal/sources/taleo_test.go
+++ b/internal/sources/taleo_test.go
@@ -107,6 +107,48 @@ func TestTaleoFetch(t *testing.T) {
 	}
 }
 
+// TestTaleoImplementsStreaming pins the compile-time contract: taleo is a StreamingSource so
+// the pipeline persists a long crawl incrementally instead of buffering the whole board.
+func TestTaleoImplementsStreaming(t *testing.T) {
+	var _ StreamingSource = taleo{}
+}
+
+// TestTaleoFetchStreamEmitsAll checks FetchStream emits every job (order-independent), the
+// same set Fetch returns.
+func TestTaleoFetchStreamEmitsAll(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("careersection/2/jobsearch.ftl", taleoCareersection).
+		route("searchjobs", `{
+			"requisitionList": [
+				{"jobId": "1", "contestNo": "c1", "locationsColumns": [1],
+				 "column": ["Role A", "[\"US\"]", "Jul 2, 2026"]},
+				{"jobId": "2", "contestNo": "c2", "locationsColumns": [1],
+				 "column": ["Role B", "[\"US\"]", "Jul 1, 2026"]}
+			],
+			"pagingData": {"totalCount": 2}
+		}`).
+		route("jobdetail.ftl", taleoJobDetail("%3Cp%3Ex%3C%2Fp%3E"))
+
+	s := NewTaleo(fake).(StreamingSource)
+	var mu sync.Mutex
+	var got []Job
+	err := s.FetchStream(context.Background(), CompanyEntry{Company: "Valero", Board: "valero.taleo.net/2"}, func(j Job) {
+		mu.Lock()
+		got = append(got, j)
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("FetchStream: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, j := range got {
+		ids[j.ExternalID] = true
+	}
+	if len(got) != 2 || !ids["c1"] || !ids["c2"] {
+		t.Fatalf("emitted %d jobs %v, want c1+c2", len(got), ids)
+	}
+}
+
 // TestTaleoFields locks the varying column layout across tenants: location is read from the
 // API's locationsColumns index (never guessed), and the posted date only from a column that
 // parses as "Jan 2, 2006". A tenant whose listing omits location/date (schneider/baesystems

--- a/sources/taleo.yml
+++ b/sources/taleo.yml
@@ -10,9 +10,9 @@
 # appears in the careersection link on the company's own careers page. Known dead ends (host
 # is up but no keyless REST feed, do not re-try blindly): UnitedHealth (careersection now
 # 302s to their Phenom site), Hilton (searchjobs returns totalCount=0 — feed walled), Praxair
-# and A.T. Kearney (legacy joblist.ftl/moresearch.ftl skin with no inline portalNo). Also
-# excluded: very large boards whose per-job detail fan-out is slow (hyatt.taleo.net/1 lists
-# ~3k jobs; hdr below at ~1.8k takes ~100s and is the practical size ceiling).
+# and A.T. Kearney (legacy joblist.ftl/moresearch.ftl skin with no inline portalNo). Large
+# boards are fine: the adapter is a StreamingSource, so a slow detail fan-out (hyatt ~3.2k
+# jobs, ~3.7min) persists incrementally rather than buffering — no per-board size ceiling.
 
 - company: Valero
   board: valero.taleo.net/2
@@ -34,3 +34,5 @@
   board: cognizant.taleo.net/naukri
 - company: Ross Stores
   board: rossstores.taleo.net/rstrcs1.1
+- company: Hyatt
+  board: hyatt.taleo.net/1


### PR DESCRIPTION
Point 5 of the Taleo follow-up plan.

## What
Taleo's per-job detail fan-out is heavy (each job = a full `jobdetail.ftl` page), so large tenants were excluded to avoid buffering the whole board in memory. This implements `StreamingSource`:
- `Fetch` now delegates to `FetchStream` (collects the emitted jobs) — same shape as the eightfold adapter.
- `FetchStream` opens the careersection, pages the requisition list, then fetches each detail concurrently and **emits each Job the moment its detail completes** — so the pipeline persists a long crawl incrementally. Partial work survives an interrupted/rate-limited run.
- The per-host session lock moves into `FetchStream` (held across the whole GET → searchjobs → detail sequence), behaviour unchanged.

## Re-enable large boards
With no size ceiling, **Hyatt** (`hyatt.taleo.net/1`) is added back — live-verified through the streaming path: **3182 jobs, 3168 with descriptions, ~3.7 min**. The seam comment now documents that large boards are fine (streaming, no per-board ceiling).

## Testing
- New: `TestTaleoImplementsStreaming` (compile-time `StreamingSource` contract), `TestTaleoFetchStreamEmitsAll`.
- Existing Taleo suite + `-race` green (incl. concurrent same-host fetch).
- taleo.yml validates (11 boards).

## Deploy
Backend code change → needs an image rebuild (Go binary) + `rsync sources/`. Board additions crawl on the existing `taleo.yml` cron.