### PR TITLE
fix(skilltag): separator-insensitive phrases + case-preserving acronym pass

### DIFF
--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -50,7 +50,9 @@ func (a *API) ExtractResumeSkills(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "resume is empty")
 	}
 
-	skills := skilltag.Parse(up.Text)
+	// Résumé path: enable the résumé-scoped acronym tier (e.g. RAG), which stays off
+	// for job parsing so it never tags job facets ("RAG status").
+	skills := skilltag.Parse(up.Text, skilltag.WithResumeAcronyms())
 	if skills == nil {
 		skills = []string{}
 	}

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -381,8 +381,11 @@ var phraseAliases = []phraseAlias{
 	{"semantic kernel", "semantic-kernel"},
 	{"vertex ai", "vertex-ai"},
 	{"aws bedrock", "aws-bedrock"}, {"amazon bedrock", "aws-bedrock"},
-	{"sentence transformers", "sentence-transformers"}, {"sentence-transformers", "sentence-transformers"},
-	{"retrieval augmented generation", "rag"}, {"retrieval-augmented generation", "rag"},
+	// Hyphen/space variants collapse to one matcher (see phraseMatchers), so only the
+	// space form is listed — "sentence-transformers"/"retrieval-augmented generation"
+	// resolve via the separator-insensitive phrase match.
+	{"sentence transformers", "sentence-transformers"},
+	{"retrieval augmented generation", "rag"},
 	// LLM-mined multi-word gaps (jobs.enrichment->skills). Multi-word or ambiguous
 	// terms routed as phrases so the bare token can't misfire on non-tech jobs.
 	// ("spring boot" needs no entry — the "spring" word alias already tags it.)
@@ -396,4 +399,22 @@ var phraseAliases = []phraseAlias{
 	{"generative ai", "generative-ai"}, {"gen ai", "generative-ai"},
 	{"deep learning", "deep-learning"},
 	{"six sigma", "six-sigma"},
+}
+
+// sharedAcronyms resolve in ALL text (jobs and résumés). They are matched by their
+// exact UPPERCASE surface form as a whole word (case-preserved pass), because their
+// lowercase form is deliberately excluded as ambiguous (`ml` = millilitre). The
+// uppercase form is unambiguous even in job descriptions. Each value is a canonical
+// that already exists in the vocabulary — an acronym is another alias, never a new
+// facet value.
+var sharedAcronyms = map[string]string{
+	"ML": "machine-learning",
+}
+
+// resumeAcronyms resolve ONLY when parsing résumés (Parse with WithResumeAcronyms).
+// Their uppercase form collides with a non-tech meaning in JOB text — "RAG status"
+// (red/amber/green project health) — so tagging them on jobs would corrupt facets;
+// in résumés that collision is near-absent. Each value is an existing canonical.
+var resumeAcronyms = map[string]string{
+	"RAG": "rag",
 }

--- a/internal/skilltag/dictionaries_test.go
+++ b/internal/skilltag/dictionaries_test.go
@@ -22,6 +22,24 @@ func TestDictionaryInvariants(t *testing.T) {
 			t.Errorf("ambiguous word %q must not be a wordAliases key", w)
 		}
 	}
+
+	// Acronym canonicals must be valid slugs AND already reachable via an existing
+	// alias — an acronym is another route to a known canonical, never a new facet value.
+	existing := map[string]bool{}
+	for _, c := range wordAliases {
+		existing[c] = true
+	}
+	for _, p := range phraseAliases {
+		existing[p.canonical] = true
+	}
+	for tier, acr := range map[string]map[string]string{"sharedAcronyms": sharedAcronyms, "resumeAcronyms": resumeAcronyms} {
+		for surface, c := range acr {
+			assertSlug(t, tier+"["+surface+"]", c)
+			if !existing[c] {
+				t.Errorf("%s[%q] → %q is not an existing canonical (would create a new facet value)", tier, surface, c)
+			}
+		}
+	}
 }
 
 func assertSlug(t *testing.T, what, s string) {

--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -3,10 +3,21 @@
 //
 // Like internal/location, it is a curated dictionary, not an extractor: it
 // resolves a known vocabulary of languages, frameworks, datastores, and infra by
-// alias, and emits nothing for anything it cannot resolve (it never guesses).
-// Tokens are lowercase slugs (go, postgresql, react, kubernetes), the same shape
-// the enrichment contract's skills field uses, so the parser and the LLM payload
-// speak one vocabulary and union cleanly at read time.
+// alias, and emits nothing for anything it cannot resolve (it never guesses). No
+// fuzzy or semantic matching — recall grows by curating the dictionary, not by
+// similarity. Tokens are lowercase slugs (go, postgresql, react, kubernetes), the
+// same shape the enrichment contract's skills field uses, so the parser and the
+// LLM payload speak one vocabulary and union cleanly at read time.
+//
+// Two resolution rules keep exact matching robust:
+//   - Separator-insensitive phrases: a multi-word alias matches its hyphenated,
+//     underscored, and spaced forms alike ("distributed-systems" ==
+//     "distributed systems"), without collapsing the text — so boundary guards
+//     that keep "objective-c" from leaking a bare "c" are preserved.
+//   - Case-preserving acronyms: an UPPERCASE acronym resolves while its ambiguous
+//     lowercase form does not (ML → machine-learning; ml stays millilitre). A
+//     shared tier applies to all text; a résumé-scoped tier (WithResumeAcronyms,
+//     e.g. RAG) applies only to résumés so it never tags job facets ("RAG status").
 package skilltag
 
 import (
@@ -26,11 +37,77 @@ var htmlTagRE = regexp.MustCompile(`<[^>]*>`)
 // pass. Punctuated terms (c++, node.js) are handled separately by the phrase pass.
 var wordTokenRE = regexp.MustCompile(`[a-z0-9]+`)
 
-// normalize strips HTML tags, lowercases the text, and trims leading/trailing
-// whitespace. Tags are replaced with a space (not empty) to preserve word
-// boundaries so "<b>Go</b>Engineer" cannot fuse.
+// sepRE matches a run of the word-joiners '-'/'_' and whitespace. It is used to
+// split a multi-word alias into its segments; the text itself is NOT rewritten, so
+// the punctuation that is part of a canonical token (., #, +, /) and the boundary
+// guards (a leading '-' is not a word start) are preserved.
+var sepRE = regexp.MustCompile(`[-_\s]+`)
+
+// normalize strips HTML tags, lowercases the text, and trims. Tags are replaced
+// with a space (not empty) to preserve word boundaries so "<b>Go</b>Engineer"
+// cannot fuse. Separators are deliberately left intact — the phrase matcher makes
+// '-'/'_'/space equivalent inside multi-word terms without losing the boundary
+// information that keeps "objective-c" from leaking a bare "c".
 func normalize(text string) string {
 	return strings.TrimSpace(strings.ToLower(htmlTagRE.ReplaceAllString(text, " ")))
+}
+
+// phraseMatcher resolves one phrase alias against normalized text. A multi-word
+// alias compiles to a regex whose inter-segment separators match any run of
+// '-'/'_'/whitespace, so "distributed-systems", "distributed_systems", and
+// "distributed systems" all resolve to one canonical; a single-token alias
+// (c++, node.js, ci/cd) keeps the cheaper substring path.
+type phraseMatcher struct {
+	canonical string
+	re        *regexp.Regexp // multi-segment alias; nil for a single token
+	token     string         // single-token alias (used when re == nil)
+}
+
+// matches reports whether the alias occurs in norm as a standalone term. Regex
+// hits are boundary-checked with the same ASCIIBoundary rule as the substring
+// path, so a leading '-' (e.g. the "c" in "objective-c") is not a word start.
+func (m phraseMatcher) matches(norm string) bool {
+	if m.re == nil {
+		return wordmatch.Contains(norm, m.token, wordmatch.ASCIIBoundary)
+	}
+	for _, loc := range m.re.FindAllStringIndex(norm, -1) {
+		if wordmatch.ASCIIBoundary(norm, loc[0], loc[1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// phraseMatchers compiles phraseAliases once at startup: a multi-word alias (split
+// on '-'/'_'/space) becomes a separator-insensitive regex; a single token stays a
+// substring match. Only the match key is transformed — canonicals are unchanged.
+var phraseMatchers = func() []phraseMatcher {
+	out := make([]phraseMatcher, 0, len(phraseAliases))
+	for _, p := range phraseAliases {
+		segs := nonEmpty(sepRE.Split(strings.ToLower(p.alias), -1))
+		if len(segs) <= 1 {
+			out = append(out, phraseMatcher{canonical: p.canonical, token: strings.ToLower(p.alias)})
+			continue
+		}
+		quoted := make([]string, len(segs))
+		for i, s := range segs {
+			quoted[i] = regexp.QuoteMeta(s)
+		}
+		re := regexp.MustCompile(strings.Join(quoted, `[-_\s]+`))
+		out = append(out, phraseMatcher{canonical: p.canonical, re: re})
+	}
+	return out
+}()
+
+// nonEmpty drops empty segments (a leading/trailing separator splits to "").
+func nonEmpty(in []string) []string {
+	out := in[:0]
+	for _, s := range in {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // wordTokens returns the alphanumeric tokens of already-normalized text, in order.
@@ -38,16 +115,46 @@ func wordTokens(norm string) []string {
 	return wordTokenRE.FindAllString(norm, -1)
 }
 
+// Option configures a Parse call. The zero set is job-safe (default).
+type Option func(*options)
+
+type options struct {
+	resumeAcronyms bool
+}
+
+// WithResumeAcronyms enables the résumé-scoped acronym tier (resumeAcronyms, e.g.
+// RAG) for a Parse call. Job callers omit it so those acronyms never tag job
+// facets; the résumé path (handler.ExtractResumeSkills) sets it.
+func WithResumeAcronyms() Option {
+	return func(o *options) { o.resumeAcronyms = true }
+}
+
 // Parse scans free text and returns the curated canonical skill slugs it contains,
-// sorted and deduplicated. Returns nil when nothing resolves. It strips HTML, runs a
-// phrase pass for punctuated/multi-word terms, then a word pass over the bare tokens.
-func Parse(text string) []string {
-	norm := normalize(text)
+// sorted and deduplicated. Returns nil when nothing resolves. It runs three passes
+// that union into a set: a case-preserving acronym pass over the HTML-stripped
+// original-case text (shared tier always, résumé tier when opted in), then a phrase
+// pass (separator-insensitive) and a word pass over the lowercased, normalized text.
+func Parse(text string, opts ...Option) []string {
+	var o options
+	for _, fn := range opts {
+		fn(&o)
+	}
 	set := map[string]struct{}{}
 
-	for _, p := range phraseAliases {
-		if wordmatch.Contains(norm, p.alias, wordmatch.ASCIIBoundary) {
-			set[p.canonical] = struct{}{}
+	// Acronym pass: case-sensitive whole-word match over case-preserved text, so an
+	// UPPERCASE acronym resolves while its ambiguous lowercase form does not. Uses a
+	// Unicode word boundary because the text is not lowercased here (ASCIIBoundary's
+	// word test is lowercase-only and would misjudge uppercase neighbours).
+	cased := htmlTagRE.ReplaceAllString(text, " ")
+	matchAcronyms(cased, sharedAcronyms, set)
+	if o.resumeAcronyms {
+		matchAcronyms(cased, resumeAcronyms, set)
+	}
+
+	norm := normalize(text)
+	for _, m := range phraseMatchers {
+		if m.matches(norm) {
+			set[m.canonical] = struct{}{}
 		}
 	}
 	for _, tok := range wordTokens(norm) {
@@ -56,4 +163,14 @@ func Parse(text string) []string {
 		}
 	}
 	return stringset.Sorted(set)
+}
+
+// matchAcronyms adds the canonical of each acronym whose exact surface form occurs
+// as a standalone token in cased (case-preserved) text.
+func matchAcronyms(cased string, acronyms map[string]string, set map[string]struct{}) {
+	for surface, canonical := range acronyms {
+		if wordmatch.Contains(cased, surface, wordmatch.UnicodeBoundary) {
+			set[canonical] = struct{}{}
+		}
+	}
 }

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -8,6 +8,7 @@ import (
 func TestNormalizeStripsHTMLAndLowercases(t *testing.T) {
 	got := normalize("<div><p>Senior <b>Go</b> Engineer</p></div>")
 	// Two spaces between words: each surrounding tag is replaced by one space.
+	// Separators are NOT collapsed here — the phrase matcher handles that.
 	want := "senior  go  engineer"
 	if got != want {
 		t.Fatalf("normalize = %q, want %q", got, want)
@@ -50,6 +51,72 @@ func TestParse(t *testing.T) {
 				t.Fatalf("Parse(%q) = %#v, want %#v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// Separator-insensitive matching (skilltag-matching-fixes): '-'/'_' between
+// alphanumerics are equivalent to a space, so hyphenated/underscored multi-word
+// terms resolve like their space form — without touching punctuated canonicals.
+func TestParse_SeparatorInsensitive(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"hyphen multiword", "Experience with distributed-systems at scale.", []string{"distributed-systems"}},
+		{"underscore multiword", "distributed_systems everywhere", []string{"distributed-systems"}},
+		{"space still resolves", "distributed systems everywhere", []string{"distributed-systems"}},
+		{"hyphen and space dedup to one", "distributed-systems and distributed systems", []string{"distributed-systems"}},
+		{"machine-learning hyphen", "machine-learning pipelines", []string{"machine-learning"}},
+		{"ci-cd hyphen", "CI-CD pipeline", []string{"ci-cd"}},
+		{"react-native hyphen", "React-Native apps", []string{"react", "react-native"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Parse(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Parse(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// Case-preserving acronym pass (skilltag-matching-fixes): a curated shared tier
+// (ML) resolves everywhere; a résumé-scoped tier (RAG) resolves only under the
+// résumé option so it never tags job facets ("RAG status").
+func TestParse_Acronyms(t *testing.T) {
+	has := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Shared acronym ML → machine-learning, applied by the default Parse.
+	if got := Parse("Senior ML Engineer with Python"); !has(got, "machine-learning") {
+		t.Errorf("Parse ML = %v, want machine-learning", got)
+	}
+	// Whole-word only: ML embedded in HTML/HTMl must not fire; lowercase ml must not.
+	if got := Parse("We write HTML and CSS"); has(got, "machine-learning") {
+		t.Errorf("Parse HTML = %v, must not emit machine-learning", got)
+	}
+	if got := Parse("Mix 500 ml of solution"); has(got, "machine-learning") {
+		t.Errorf("Parse 'ml' lowercase = %v, must not emit machine-learning", got)
+	}
+
+	// Résumé-scoped acronym RAG → rag, ONLY under WithResumeAcronyms.
+	if got := Parse("Built RAG pipelines over pgvector", WithResumeAcronyms()); !has(got, "rag") {
+		t.Errorf("Parse RAG (resume) = %v, want rag", got)
+	}
+	// Default (job) parsing must NOT tag RAG — this is what protects the existing
+	// "RAG status" job guard and keeps job facets unchanged.
+	if got := Parse("Built RAG pipelines over pgvector"); has(got, "rag") {
+		t.Errorf("Parse RAG (default) = %v, must not emit rag", got)
+	}
+	if got := Parse("We report RAG status weekly"); has(got, "rag") {
+		t.Errorf("Parse 'RAG status' (default) = %v, must not emit rag", got)
 	}
 }
 

--- a/openspec/changes/skilltag-matching-fixes/.openspec.yaml
+++ b/openspec/changes/skilltag-matching-fixes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/skilltag-matching-fixes/design.md
+++ b/openspec/changes/skilltag-matching-fixes/design.md
@@ -1,0 +1,157 @@
+## Context
+
+`internal/skilltag.Parse` resolves a curated technology vocabulary from free
+text in two passes (`skilltag.go`):
+1. **Phrase pass** — for each `phraseAliases` entry (multi-word/punctuated, e.g.
+   `distributed systems`, `c++`, `node.js`), `wordmatch.Contains(norm, alias,
+   ASCIIBoundary)` tests for a whole-token occurrence.
+2. **Word pass** — `wordTokenRE = [a-z0-9]+` splits the normalized text into bare
+   tokens, each looked up in the `wordAliases` map.
+
+`normalize()` strips HTML, lowercases, trims. It does **not** touch `-`/`_`, and
+`wordTokenRE` splits on them. `ASCIIBoundary` additionally guards a leading `.`
+or `-` as an invalid left boundary (so `asp.net`↛`.net`, `objective-c`↛`c`).
+
+This is a curated dictionary that feeds the production `jobs.skills` facet — the
+project's invariant is "resolve known vocabulary, never guess." The fixes must
+preserve that; embeddings/fuzzy matching are explicitly out.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `distributed-systems` / `distributed_systems` resolve exactly like
+  `distributed systems`.
+- Curated uppercase acronyms (`RAG`, `ETL`, `ELT`, `gRPC`, …) resolve while their
+  ambiguous lowercase forms stay unresolved.
+- Zero regressions: punctuated canonicals (`c++`, `node.js`, `asp.net`, `c#`)
+  still match; no new false positives; dedup+sort invariant intact.
+
+**Non-Goals:**
+- Embeddings, semantic similarity, or any fuzzy/probabilistic matching.
+- Growing the general vocabulary (that is the separate LLM-mining track).
+- Changing consumers (`jobderive`, `ExtractResumeSkills`) or the facet schema.
+
+## Decisions
+
+### D1 — Collapse `-`/`_` to space on BOTH text and phrase aliases
+
+**Do NOT collapse the text.** The first attempt — collapse `-`/`_`/whitespace to a
+space in both text and aliases — is clean for matching but breaks the boundary
+guard (see D2), so it was abandoned during implementation. Instead, leave the
+lowercased text with its separators intact and make the **phrase matcher**
+separator-insensitive per alias:
+
+- A multi-word alias (split on `[-_\s]+` into segments) compiles once at init to a
+  regex joining its `regexp.QuoteMeta`'d segments with `[-_\s]+`, e.g. `distributed
+  systems` → `distributed[-_\s]+systems`. It matches `distributed-systems`,
+  `distributed_systems`, `distributed systems`, and mixed forms
+  (`retrieval-augmented generation`) alike.
+- A single-token alias (no `-`/`_`/space: `c++`, `node.js`, `ci/cd`) keeps the
+  cheaper `wordmatch.Contains` substring path unchanged.
+- Each regex hit is boundary-checked with the SAME `wordmatch.ASCIIBoundary` used
+  by the substring path (applied to the match `[start,end)`), so the boundary
+  semantics are identical to before.
+
+*Preserve `.`/`#`/`+`/`/`:* `sepRE = [-_\s]+` excludes them, so `c++`, `node.js`,
+`asp.net`, `c#`, `c/c++`, `ci/cd`, `f#` never split and stay single-token.
+
+*Why per-alias regex over generate-variants:* generating `-`/`_`/space variants per
+alias fails on MIXED separators in one occurrence (`retrieval-augmented generation`
+has both `-` and space); the regex's `[-_\s]+` handles mixed uniformly. The
+redundant hyphen/space alias pairs still collapse to one matcher, so they are
+retired (`retrieval-augmented generation`, `sentence-transformers`).
+
+### D2 — Boundary-guard interaction (why text is NOT collapsed)
+
+`ASCIIBoundary` treats a leading `-` as an invalid left boundary — this is exactly
+what stops `objective-c` from leaking a bare `c` (the `c developer` phrase's `c` is
+preceded by `-`). Collapsing `-`→space in the text destroys that guard: `objective
+c developer` then matches `c developer` and emits `c` (a regression the tests
+caught). Keeping the text un-collapsed and matching separators only *inside* an
+alias's own segments preserves the guard: over `objective-c developer`, the `c
+developer` regex still finds `c developer`, but its match starts at a `c` preceded
+by `-`, so `ASCIIBoundary` rejects it. The `.` guard (`asp.net`↛`.net`) is likewise
+untouched. Regression cases (`objective-c`, `front-end`, `c developer`, all
+punctuated canonicals) are locked down by tests.
+
+### D3 — Case-preserving acronym pass, split into shared vs résumé-scoped tiers
+
+Match a curated set of case-sensitive acronym surface forms (whole-word, over the
+HTML-stripped, **case-preserved** text) → canonical slug. Canonicals must already
+exist in the vocabulary (the acronym is another alias onto the same slug), so no
+new facet values appear. `etl`/`grpc`/`nlp`/`llm` are NOT candidates — they are
+already unambiguous bare lowercase word-aliases and resolve today.
+
+**Uppercase is NOT always a sufficient disambiguator** — the existing guard test
+`rag status trap` proves it: "RAG status" (red/amber/green project health) is
+written uppercase in PM job posts, which is exactly why `rag` is excluded. Since
+`skilltag` runs on ALL jobs, tagging "RAG" there would corrupt production facets.
+Two tiers resolve this:
+
+- **`sharedAcronyms`** — unambiguous even in job text; applied by the default
+  `Parse` (jobs + résumés). Seed: **`ML → machine-learning`** (lower `ml` =
+  millilitre, excluded; upper `ML` in an IT corpus = machine learning;
+  `machine-learning` canonical exists).
+- **`resumeAcronyms`** — collide with a non-tech uppercase meaning in *job* text
+  but are safe in *résumés*; applied only under the résumé option. Seed:
+  **`RAG → rag`** ("RAG status" is a PM-job artefact, near-absent in résumés).
+
+`Parse` gains a variadic option: `Parse(text string, opts ...Option)`. Default
+(no opts) = job-safe: separator-fix + `sharedAcronyms`. The résumé path
+(`handler.ExtractResumeSkills`, the only résumé consumer) calls
+`Parse(text, skilltag.WithResumeAcronyms())`, adding `resumeAcronyms`. Existing
+callers (`jobderive`, …) call `Parse(text)` unchanged and never see `RAG`, so the
+`rag status trap` guard and all job facets stay intact.
+
+*Why not add lowercase `rag`/`ml` to `wordAliases`:* reintroduces the exact
+ambiguity the dictionary avoids (`rag` cloth, `ml` millilitre). Case-sensitivity +
+tiering is the disambiguator.
+
+### D4 — `Parse` structure
+
+```
+func Parse(text string, opts ...Option) []string
+htmlStripped := stripHTML(text)           // case preserved
+acronyms := sharedAcronyms                 // + resumeAcronyms if WithResumeAcronyms()
+for sf, canon := range acronyms {          // case-sensitive whole-word
+    if containsCaseSensitive(htmlStripped, sf) { set[canon] }
+}
+norm := matchNormal(htmlStripped)          // lowercase + collapse [-_\s]+ → " "
+for _, p := range phraseAliases { if Contains(norm, p.normAlias, ASCIIBoundary) { set[p.canonical] } }
+for _, tok := range wordTokens(norm) { if c, ok := wordAliases[tok]; ok { set[c] } }
+return sorted(set)
+```
+
+Passes union into a set (order-independent); acronym-first only so the
+case-preserved text is used before it is lowercased.
+
+## Risks / Trade-offs
+
+- **Lost leading-`-` boundary guard (D2)** → Mitigation: targeted regression
+  tests for `objective-c`, `front-end`, and any hyphenated non-skill compounds;
+  the `c`/ambiguous canonicals are phrase-only, so bare-token leakage is not
+  possible.
+- **Acronym false positives (D3)** → Mitigation: curated, per-entry precision
+  gate; case-sensitivity; document `RAG`'s trade-off; keep the list short and
+  conservative.
+- **Collapsing `_` could merge snake_case identifiers** (e.g. `spring_boot`) →
+  this is desirable here (matches `spring boot`), but tests confirm no unintended
+  merges create false hits.
+- **Stale facets across the catalogue** → Mitigation: the standard
+  dictionary-change ops (`cmd/backfill-derive` + `cmd/reindex`) after deploy;
+  called out in tasks and the finish step. No schema change, so no migration
+  risk.
+
+## Migration Plan
+
+1. Ship the code + tests (no schema/migration).
+2. Deploy the new binary/images.
+3. Run `cmd/backfill-derive` (re-derives all six dictionary facets incl. skills)
+   then `cmd/reindex` on prod to refresh `jobs.skills` for existing jobs.
+4. Rollback = redeploy prior image; the matcher change is additive-recall, so a
+   stale index simply reverts to the old (narrower) matches — no data loss.
+
+## Open Questions
+
+- Final acronym list contents — start conservative (`RAG`, `ETL`, `ELT`, `gRPC`)
+  and grow per-entry with the same precision gate. Not blocking.

--- a/openspec/changes/skilltag-matching-fixes/proposal.md
+++ b/openspec/changes/skilltag-matching-fixes/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+The deterministic skill-tag matcher (`internal/skilltag`) misses two everyday
+classes of real skills, which silently under-counts a candidate's or a job's
+stack. This matters now because the résumé-centric analysis being built next
+derives a user's skills **solely** from their résumé text — so every miss is a
+lost skill in coverage and the ATS score, with no manual entry to compensate.
+
+Two concrete gaps, both from the matcher mechanics (not missing vocabulary):
+- **Hyphen/underscore joins don't match.** `distributed-systems` misses the
+  `distributed systems` phrase alias because `normalize()` only strips HTML and
+  lowercases — the hyphen survives, and the word pass splits on it.
+- **Uppercase acronyms don't match.** `RAG` never resolves to
+  retrieval-augmented-generation because the matcher lowercases everything (so
+  the acronym signal is lost) and the bare `rag` alias is deliberately excluded
+  as ambiguous (`rag` = cloth / RAG-status).
+
+The fix stays **deterministic and precision-first** — no embeddings, no fuzzy
+matching. `skilltag` feeds the production `jobs.skills` facet, so guessing would
+corrupt facet precision; the right lever is better exact-matching rules plus a
+curated acronym list, not semantic similarity.
+
+## What Changes
+
+- **Separator-insensitive multi-word matching.** Treat `-` and `_` between
+  alphanumerics as equivalent to a space, applied consistently to both the input
+  text and the phrase aliases, so `distributed-systems`, `distributed_systems`,
+  and `distributed systems` all resolve to the same canonical. Punctuation that
+  is part of a canonical token (`.`, `#`, `+`, `/` — as in `c++`, `node.js`,
+  `asp.net`, `c#`) is **untouched**.
+- **Case-preserving acronym pass.** A new pass over the original-case
+  (HTML-stripped) text matches a curated, precision-vetted acronym dictionary by
+  exact uppercase surface form (e.g. `RAG`, `ETL`, `ELT`, `gRPC`), so the
+  acronym resolves while its ambiguous lowercase form does not. Each acronym is
+  admitted only when its uppercase form is confidently unambiguous in the
+  IT-jobs/résumé corpus.
+- **`Parse` restructured** to run the acronym pass over case-preserved text
+  before the existing lowercase phrase and word passes; results still union,
+  dedup, and sort (invariant preserved).
+- **No vocabulary redefinition** beyond the new curated acronym list; existing
+  `wordAliases`/`phraseAliases` behavior is preserved (punctuated canonicals
+  still match; no new false positives).
+
+## Capabilities
+
+### New Capabilities
+- `skill-tag-matching`: the resolution rules of the deterministic skill-tag
+  matcher — separator-insensitive multi-word matching, case-preserving acronym
+  matching, and the precision-first "curated only, never guess" invariant.
+
+### Modified Capabilities
+<!-- none: the deterministic-facets invariant (dicts are the sole source of the
+     six facets) is unchanged; only the matcher's resolution rules are new. -->
+
+## Impact
+
+- **Code:** `internal/skilltag/skilltag.go` (`normalize` + `Parse` restructure;
+  new acronym pass), `internal/skilltag/dictionaries.go` (curated acronym list;
+  possibly retire now-redundant duplicate hyphen/space alias pairs),
+  `internal/skilltag/skilltag_test.go` + `dictionaries_test.go` (new cases +
+  invariant). Possibly a small helper in `internal/wordmatch` for
+  case-sensitive whole-word matching if the acronym pass needs it.
+- **Consumers:** `Parse` becomes variadic (`Parse(text, opts...)`), so `jobderive`
+  and the facet pipeline stay on `Parse(text)` unchanged; only the résumé path
+  `handler.ExtractResumeSkills` opts in via `skilltag.WithResumeAcronyms()`.
+- **Ops (dictionary-change convention):** existing jobs carry stale
+  `jobs.skills`; after deploy run `cmd/backfill-derive` then `cmd/reindex` to
+  re-derive the skills facet across the catalogue (same as the geography/skills
+  dictionary-change procedure in AGENT.md). No schema/migration change.

--- a/openspec/changes/skilltag-matching-fixes/specs/skill-tag-matching/spec.md
+++ b/openspec/changes/skilltag-matching-fixes/specs/skill-tag-matching/spec.md
@@ -1,0 +1,90 @@
+# skill-tag-matching Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Separator-insensitive multi-word matching
+
+The skill-tag matcher SHALL treat `-` and `_` between alphanumerics as equivalent
+to a space when resolving multi-word terms, so that hyphenated, underscored, and
+space-separated forms of a term all resolve to the same canonical skill. This
+normalization SHALL apply consistently to both the input text and the phrase
+aliases.
+
+#### Scenario: Hyphenated multi-word term resolves
+- **WHEN** the text contains "distributed-systems"
+- **THEN** the matcher emits the same canonical ("distributed-systems") it emits for "distributed systems"
+
+#### Scenario: Underscored multi-word term resolves
+- **WHEN** the text contains "distributed_systems"
+- **THEN** the matcher emits the same canonical it emits for "distributed systems"
+
+#### Scenario: Space form still resolves
+- **WHEN** the text contains "distributed systems"
+- **THEN** the matcher emits its canonical (no regression from the normalization)
+
+### Requirement: Punctuated canonicals are preserved
+
+The separator normalization SHALL collapse only `-`/`_` (and whitespace); the
+punctuation characters `.`, `#`, `+`, and `/` that are part of a canonical token
+SHALL be left intact, so punctuated skills continue to resolve and do not gain
+false positives.
+
+#### Scenario: Plus/hash/dot canonicals still match
+- **WHEN** the text contains "c++", "c#", "node.js", or "asp.net"
+- **THEN** each resolves to its canonical (cpp, csharp, nodejs, dotnet) exactly as before
+
+#### Scenario: Suffix of a punctuated token is not a false match
+- **WHEN** the text contains "asp.net"
+- **THEN** it does NOT additionally emit a ".net"-only match that the leading-dot boundary guard forbids
+
+#### Scenario: Hyphen compound does not leak an ambiguous single-letter canonical
+- **WHEN** the text contains "objective-c" with no other C signal
+- **THEN** the matcher does NOT emit the "c" canonical
+
+### Requirement: Case-preserving acronym matching
+
+The matcher SHALL resolve a curated set of technology acronyms by their exact
+case-sensitive surface form, matched as whole words over the original-case text,
+while their ambiguous lowercase forms SHALL NOT resolve. Each acronym SHALL map to
+a canonical that already exists in the vocabulary (an acronym is an additional
+alias, never a new facet value).
+
+Acronyms SHALL be split into two tiers: a **shared** set applied to all text
+(jobs and résumés), and a **résumé-scoped** set applied only when the caller opts
+in for résumé parsing. An acronym whose uppercase form is ambiguous in job
+descriptions (e.g. "RAG status") SHALL be résumé-scoped so it never tags jobs.
+
+#### Scenario: Shared acronym resolves everywhere
+- **WHEN** any text contains "ML" as a standalone token
+- **THEN** the matcher emits "machine-learning"
+
+#### Scenario: Résumé-scoped acronym resolves only in résumé mode
+- **WHEN** a résumé is parsed with the résumé option and contains "RAG"
+- **THEN** the matcher emits "rag" (retrieval-augmented generation)
+
+#### Scenario: Résumé-scoped acronym never tags job text
+- **WHEN** default (job) parsing sees "RAG" — including "RAG status"
+- **THEN** the matcher does NOT emit "rag"
+
+#### Scenario: Ambiguous lowercase form does not resolve
+- **WHEN** the text contains the lowercase word "rag" or "ml"
+- **THEN** the matcher does NOT emit the corresponding canonical
+
+#### Scenario: Acronym matched as a whole word only
+- **WHEN** "ML" appears embedded in a larger token (e.g. "HTML")
+- **THEN** it does NOT emit "machine-learning"
+
+### Requirement: Precision-first, curated-only resolution
+
+The matcher SHALL remain a curated dictionary that resolves only known aliases
+(including the new separator and acronym rules) and SHALL emit nothing for terms
+it cannot resolve — it never guesses, and no fuzzy or semantic similarity is
+used. Results SHALL stay deduplicated and sorted.
+
+#### Scenario: Unknown term emits nothing
+- **WHEN** the text contains a term with no curated alias
+- **THEN** the matcher emits no canonical for it
+
+#### Scenario: Deterministic, deduplicated, sorted output
+- **WHEN** the same skill appears multiple times and in mixed separator/case forms
+- **THEN** its canonical appears exactly once and the result is sorted (identical across runs)

--- a/openspec/changes/skilltag-matching-fixes/tasks.md
+++ b/openspec/changes/skilltag-matching-fixes/tasks.md
@@ -1,0 +1,22 @@
+## 1. Separator-insensitive multi-word matching
+
+- [x] 1.1 RED: add `skilltag_test.go` cases — "distributed-systems" and "distributed_systems" resolve to the same canonical as "distributed systems"; mixed forms in one text dedup to one; the space form still resolves.
+- [x] 1.2 RED: add regression cases — punctuated canonicals "c++", "c#", "node.js", "asp.net", "c/c++", "f#" still resolve; "asp.net" does NOT leak ".net"; "objective-c" (no other C signal) does NOT emit "c"; a hyphen compound like "front-end" emits no spurious canonical.
+- [x] 1.3 GREEN: introduce a shared match-normal form in `skilltag.go` — after HTML strip + lowercase, collapse `[-_\s]+` to a single space (leave `.`/`#`/`+`/`/` intact). Apply to the input text; precompute the normalized form of every `phraseAliases` entry once at package init and match against it. Keep `wordAliases` word-pass as is (tokens already split on `-`/`_`).
+- [x] 1.4 REFACTOR: retire any now-redundant duplicate alias pairs whose only difference was hyphen-vs-space (e.g. paired "retrieval augmented generation" / "retrieval-augmented generation") — the normal form makes one entry cover both. Keep tests green.
+
+## 2. Case-preserving acronym pass (shared + résumé-scoped tiers)
+
+- [x] 2.1 RED: shared — "ML" resolves to "machine-learning" in default parsing; "ML" inside "HTML" does NOT; lowercase "ml" does NOT. Résumé-scoped — `Parse(text, WithResumeAcronyms())` on "RAG" resolves "rag"; DEFAULT `Parse` on "RAG"/"RAG status" does NOT emit "rag" (existing `rag status trap` guard stays green).
+- [x] 2.2 GREEN: add `sharedAcronyms` (ML→machine-learning) + `resumeAcronyms` (RAG→rag) to `dictionaries.go` — each value an EXISTING canonical (no new facet value). Add a case-sensitive whole-word matcher (small `internal/wordmatch` helper or case-sensitive boundary). Add `type Option` + `WithResumeAcronyms()`; make `Parse` variadic `Parse(text string, opts ...Option)` (existing `Parse(text)` callers unchanged).
+- [x] 2.3 GREEN: restructure `Parse` — strip HTML (case-preserved) → acronym pass (shared + résumé tier when opted) → match-normal → phrase → word → union/dedup/sort. Confirm sort+dedup, `rag status trap`, and AI-vocab guards stay green.
+- [x] 2.4 GREEN: wire the résumé consumer — `handler.ExtractResumeSkills` calls `skilltag.Parse(up.Text, skilltag.WithResumeAcronyms())`; job callers (`jobderive`, …) stay on `Parse(text)`.
+
+## 3. Dictionary invariant + docs
+
+- [x] 3.1 Extend `dictionaries_test.go` (or the invariant test) so every `sharedAcronyms`/`resumeAcronyms` value is a valid canonical slug reachable via an existing alias — no acronym introduces a brand-new facet value.
+- [x] 3.2 Update the package doc comment in `skilltag.go` to describe the two new resolution rules (separator-insensitivity, case-preserving acronyms) and the precision-first invariant.
+
+## 4. Verify
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./internal/skilltag/ ./...`; confirm no regressions across the suite. Record the required post-deploy ops in the finish step: run `cmd/backfill-derive` then `cmd/reindex` on prod to re-derive `jobs.skills` for existing jobs (dictionary-change convention).


### PR DESCRIPTION
## Summary
Fixes two everyday misses in the deterministic skill-tag matcher (`internal/skilltag`) — no embeddings, precision-first. Motivated by the résumé-centric analysis next, where a user's skills are derived **solely** from their résumé, so every miss is a lost skill.

- **Separator-insensitive multi-word matching.** `distributed-systems`, `distributed_systems`, and `distributed systems` now resolve to one canonical (also mixed forms like `retrieval-augmented generation`). Each multi-word alias compiles once to a regex joining its `QuoteMeta`'d segments with `[-_\s]+`, matched over the **non-collapsed** lowercased text and boundary-checked with `ASCIIBoundary`. The text is deliberately **not** collapsed, so the leading-`-` guard still stops `objective-c` from leaking a bare `c`. Single-token aliases (`c++`, `node.js`, `ci/cd`) keep the substring path; redundant hyphen/space alias pairs retired.
- **Case-preserving acronym pass (two tiers).** `Parse(text, opts ...Option)` matches curated acronym surface forms case-sensitively, whole-word (`UnicodeBoundary`), over the HTML-stripped **original-case** text. `sharedAcronyms` (`ML→machine-learning`) apply everywhere; `resumeAcronyms` (`RAG→rag`) only under `WithResumeAcronyms()` — so **"RAG status" never tags job facets**. `handler.ExtractResumeSkills` opts in; job callers (`jobderive`, `tg-extract`, `getmatch`) stay on `Parse(text)` unchanged.

Why résumé-scoped RAG: the existing `rag status trap` test proves uppercase "RAG status" (red/amber/green) collides in PM **job** posts; it's near-absent in résumés, so RAG is safe there.

## Deploy op (dictionary change)
`skilltag` feeds the `jobs.skills` facet. After deploy, run `cmd/backfill-derive` then `cmd/reindex` to re-derive skills for existing jobs. No schema/migration.

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` — 49 pkg ok, 0 fail
- [x] New tests: hyphen/underscore variants; punctuated canonicals + `objective-c` no-leak regressions; `ML` shared (not inside `HTML`, not lowercase `ml`); `RAG` résumé-only, never on jobs; dict invariant (acronym canonicals must pre-exist)
- [x] Adversarial review: differential old-substring vs new-regex over 11 contexts × every alias → zero divergences beyond the intended behavior