### PR TITLE
feat(sources): add careerspage adapter for careers-page.com

### DIFF
--- a/internal/sources/careerspage.go
+++ b/internal/sources/careerspage.go
@@ -1,0 +1,147 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// careerspage adapts careers-page.com career sites. The board is the tenant subdomain
+// (e.g. "davidjoseph-co"), forming the host "<board>.careers-page.com". The tenant's
+// listing is server-rendered HTML paginated via ?page=N, each job card linking to a
+// canonical /jobs/<uuid> detail page whose schema.org JobPosting ld+json carries the
+// posting. Description and structured fields come from a per-job detail fetch
+// (bounded-concurrency), like the other JSON-LD detail adapters (icims/freshteam).
+
+type careerspage struct {
+	http HTMLGetter
+}
+
+// NewCareerPage builds the careers-page.com adapter over the given HTML client.
+func NewCareerPage(c HTMLGetter) Source { return careerspage{http: c} }
+
+func (careerspage) Provider() string { return "careerspage" }
+
+// careerspageMaxPages caps the ?page=N walk so a listing that never yields an empty/repeat
+// page cannot loop forever (the boards seen are ~10 pages; this is ample headroom).
+const careerspageMaxPages = 100
+
+func (s careerspage) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://%s.careers-page.com/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("careerspage: board %q: %w", e.Board, err)
+	}
+
+	// Page through the listing, collecting canonical job-detail URLs until a page yields
+	// no new links (the tail/empty page) or the safety cap is hit. A first-page failure is
+	// a board-level error; a later-page failure just stops the walk with what we have.
+	seen := map[string]struct{}{}
+	var locs []string
+	for page := 1; page <= careerspageMaxPages; page++ {
+		listURL := fmt.Sprintf("%s?page=%d", base, page)
+		root, err := s.http.GetHTML(ctx, listURL)
+		if err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("careerspage: listing %s: %w", e.Board, err)
+			}
+			break
+		}
+		added := 0
+		for _, l := range careerspageJobLinks(base, root) {
+			if _, ok := seen[l]; !ok {
+				seen[l] = struct{}{}
+				locs = append(locs, l)
+				added++
+			}
+		}
+		if added == 0 {
+			break
+		}
+	}
+
+	// Each posting's fields come from its own detail fetch, fanned out under a bounded pool.
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one job's detail page and maps its JobPosting ld+json to a Job, returning
+// ok=false when the fetch fails or the page carries no JobPosting, so the caller skips just
+// that posting.
+func (s careerspage) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p careerspagePosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+
+	// No native id → the posting would collide on the (source, external_id) dedup key; drop
+	// it. The listing predicate already collects only URLs with an id, so this only fires if
+	// the detail URL diverges from that shape.
+	id := careerspageJobID(loc)
+	if id == "" {
+		return Job{}, false
+	}
+
+	location := joinNonEmpty(
+		p.JobLocation.Address.AddressLocality,
+		p.JobLocation.Address.AddressRegion,
+		p.JobLocation.Address.AddressCountry,
+	)
+
+	return Job{
+		ExternalID:  id,
+		URL:         loc,
+		Title:       p.Title,
+		Company:     firstNonEmpty(p.HiringOrganization.Name, e.Company),
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      isRemote(location),
+		PostedAt:    parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// careerspagePosting is the schema.org JobPosting decoded from a careers-page.com detail
+// page's application/ld+json block. jobLocation is a single Place (unlike iCIMS's array).
+type careerspagePosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+			AddressRegion   string `json:"addressRegion"`
+			AddressCountry  string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+}
+
+// careerspageJobIDPattern captures the job UUID from a canonical /jobs/<uuid> URL. The
+// match must end at the UUID (end-of-string or a ?/# query/fragment), so the per-card
+// /jobs/<uuid>/refer and /apply sub-action links yield no match.
+var careerspageJobIDPattern = regexp.MustCompile(`/jobs/([0-9a-fA-F-]{36})(?:$|[?#])`)
+
+// careerspageJobID extracts the native job UUID from a detail URL, or "" when the URL is
+// not a canonical job posting.
+func careerspageJobID(loc string) string {
+	if m := careerspageJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// careerspageJobLinks returns the absolute, deduplicated canonical detail URL of every job
+// card on a listing page, resolved against base. The sub-action (/refer, /apply) and
+// pagination anchors are excluded by the job-id predicate.
+func careerspageJobLinks(base *url.URL, root *html.Node) []string {
+	return jobLinks(base, root, func(href string) bool { return careerspageJobID(href) != "" })
+}

--- a/internal/sources/careerspage_test.go
+++ b/internal/sources/careerspage_test.go
@@ -1,0 +1,175 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// careerspageDetailHTML is a careers-page.com job detail page: a server-rendered page whose
+// payload we read is the schema.org JobPosting ld+json. addressCountry is the full country
+// name ("United States"), which we keep as free-text location (the location dictionary resolves
+// it). The description embeds a <script> (escaped as <\/script>) that sanitizeHTML must strip.
+func careerspageDetailHTML(title string) string {
+	return `<html><head></head><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `",
+"description":"<h2>About</h2><p>Build things.</p><script>alert(1)<\/script>",
+"datePosted":"2026-06-29T19:22:10.912789+00:00",
+"validThrough":"2026-08-01T21:12:47.666565+00:00",
+"employmentType":"FULL_TIME",
+"hiringOrganization":{"@type":"Organization","name":"David Joseph & Company"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"New York","addressCountry":"United States"}}}
+</script>
+</body></html>`
+}
+
+// careerspageListingHTML is a careers-page.com listing page carrying the given canonical job
+// UUIDs. Each card also renders /refer and /apply sub-action anchors (no leading slash) that
+// must NOT be treated as postings, plus a pagination anchor — exercising the job-link predicate.
+func careerspageListingHTML(uuids ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jobs-col">`)
+	for _, u := range uuids {
+		b.WriteString(`<div class="job-card" data-job-id="` + u + `">`)
+		b.WriteString(`<a class="job-title-link" href="/jobs/` + u + `">A Role</a>`)
+		b.WriteString(`<a href="jobs/` + u + `/refer">Refer</a>`)
+		b.WriteString(`<a href="jobs/` + u + `/apply">Apply</a>`)
+		b.WriteString(`</div>`)
+	}
+	b.WriteString(`<div class="pagination-wrapper"><a href="?page=2">Next</a></div>`)
+	b.WriteString(`</body></html>`)
+	return b.String()
+}
+
+// emptyListingHTML is a listing page past the last real page: it carries no job cards, so the
+// pagination loop must stop when it yields no new job links.
+const emptyListingHTML = `<html><body><div class="jobs-col"></div></body></html>`
+
+func TestCareerPageProvider(t *testing.T) {
+	if got := NewCareerPage(nil).Provider(); got != "careerspage" {
+		t.Errorf("Provider() = %q, want %q", got, "careerspage")
+	}
+}
+
+func TestCareerPageJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://acme.careers-page.com/jobs/f2222f51-835a-4d0a-9435-291cd2bdaa06":       "f2222f51-835a-4d0a-9435-291cd2bdaa06",
+		"/jobs/a593c5a5-855d-4660-ad73-f68ababc77fd":                                    "a593c5a5-855d-4660-ad73-f68ababc77fd",
+		"https://acme.careers-page.com/jobs/f2222f51-835a-4d0a-9435-291cd2bdaa06?x=1":   "f2222f51-835a-4d0a-9435-291cd2bdaa06",
+		"jobs/f2222f51-835a-4d0a-9435-291cd2bdaa06/refer":                               "", // sub-action, not a posting
+		"https://acme.careers-page.com/jobs/f2222f51-835a-4d0a-9435-291cd2bdaa06/apply": "", // sub-action, not a posting
+		"https://acme.careers-page.com/":                                                "",
+	}
+	for loc, want := range cases {
+		if got := careerspageJobID(loc); got != want {
+			t.Errorf("careerspageJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestCareerPageFetchListingThenDetailAndMaps(t *testing.T) {
+	u := "f2222f51-835a-4d0a-9435-291cd2bdaa06"
+	fake := (&routedHTTP{}).
+		route("?page=1", careerspageListingHTML(u)).
+		route("?page=2", emptyListingHTML).
+		route("/jobs/"+u, careerspageDetailHTML("Founding Software Engineer"))
+
+	jobs, err := NewCareerPage(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Fallback Co", Provider: "careerspage", Board: "davidjoseph-co",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != u {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, u)
+	}
+	if j.URL != "https://davidjoseph-co.careers-page.com/jobs/"+u {
+		t.Errorf("URL = %q, want canonical detail URL", j.URL)
+	}
+	if j.Title != "Founding Software Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "David Joseph & Company" {
+		t.Errorf("Company = %q, want hiringOrganization name", j.Company)
+	}
+	if j.Location != "New York, United States" {
+		t.Errorf("Location = %q, want %q", j.Location, "New York, United States")
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "<h2>About</h2>") || !strings.Contains(j.Description, "Build things") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 29, 19, 22, 10, 912789000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-29T19:22:10Z", j.PostedAt)
+	}
+}
+
+func TestCareerPagePaginatesAcrossPages(t *testing.T) {
+	u1 := "f2222f51-835a-4d0a-9435-291cd2bdaa06"
+	u2 := "a593c5a5-855d-4660-ad73-f68ababc77fd"
+	u3 := "b1763eee-15ef-4dc5-963d-d783ff466124"
+	fake := (&routedHTTP{}).
+		route("?page=1", careerspageListingHTML(u1, u2)).
+		route("?page=2", careerspageListingHTML(u3)).
+		route("?page=3", emptyListingHTML).
+		route("/jobs/"+u1, careerspageDetailHTML("Role 1")).
+		route("/jobs/"+u2, careerspageDetailHTML("Role 2")).
+		route("/jobs/"+u3, careerspageDetailHTML("Role 3"))
+
+	jobs, err := NewCareerPage(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (across two listing pages)", len(jobs))
+	}
+	ids := []string{jobs[0].ExternalID, jobs[1].ExternalID, jobs[2].ExternalID}
+	for _, want := range []string{u1, u2, u3} {
+		if !slices.Contains(ids, want) {
+			t.Errorf("missing job %q in %v", want, ids)
+		}
+	}
+}
+
+func TestCareerPageDropsDetailWithoutJobPosting(t *testing.T) {
+	u1 := "f2222f51-835a-4d0a-9435-291cd2bdaa06"
+	u2 := "a593c5a5-855d-4660-ad73-f68ababc77fd"
+	fake := (&routedHTTP{}).
+		route("?page=1", careerspageListingHTML(u1, u2)).
+		route("?page=2", emptyListingHTML).
+		route("/jobs/"+u1, careerspageDetailHTML("Good Role")).
+		route("/jobs/"+u2, `<html><body>no ld+json here</body></html>`)
+
+	jobs, err := NewCareerPage(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != u1 {
+		t.Fatalf("got %v, want only the posting with a JobPosting block", jobs)
+	}
+}
+
+func TestCareerPageRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["careerspage"]
+	if !ok {
+		t.Fatal("All() missing provider careerspage")
+	}
+	if s.Provider() != "careerspage" {
+		t.Errorf("All()[careerspage].Provider() = %q", s.Provider())
+	}
+	// Board-based (not boardless): it appears in the source facet.
+	if !slices.Contains(FilterableProviders(), "careerspage") {
+		t.Error("FilterableProviders() should include careerspage")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -163,6 +163,7 @@ func All(c HTTPClient) map[string]Source {
 		NewSuccessFactors(c),
 		NewTeamtailor(c),
 		NewICIMS(c),
+		NewCareerPage(c),
 		NewJibe(c),
 		NewPhenom(c),
 		NewAvature(c),

--- a/openspec/changes/add-careerspage-source/.openspec.yaml
+++ b/openspec/changes/add-careerspage-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-careerspage-source/design.md
+++ b/openspec/changes/add-careerspage-source/design.md
@@ -1,0 +1,94 @@
+## Context
+
+careers-page.com hosts each client's career site on a `<tenant>.careers-page.com`
+subdomain. A spike established:
+
+- **Listing** (`https://<board>.careers-page.com/?page=N`) is server-rendered HTML.
+  Each job card is an `a.job-title-link` anchor to `/jobs/<uuid>`, with
+  `data-job-id` / `data-job-city` / `data-job-country` attributes. Pagination uses
+  `?page=1,2,3…`.
+- **Detail** (`https://<board>.careers-page.com/jobs/<uuid>`) server-renders a clean
+  `application/ld+json` `JobPosting`: `title`, `datePosted`, `validThrough`,
+  `employmentType` (`FULL_TIME` etc.), `jobLocation` (`address.addressLocality`,
+  `address.addressCountry`), `hiringOrganization.name`, `baseSalary`, and a
+  `description` HTML string (~4.5 KB observed).
+- Everything is keyless. The platform rate-limits aggressive bursts (429), so the
+  crawl must stay within the shared client's pacing.
+
+This matches the existing JSON-LD detail adapters (`icims`, `freshteam`,
+`successfactors`), which the codebase already supports via `jsonld.go`
+(`ldJobPosting`) and `html.go` (`jobLinks`, DOM helpers).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A board-based `careerspage` adapter that returns every live posting for one
+  tenant, keyless, reusing existing helpers.
+- Stable dedup identity from the job UUID.
+- Robust pagination and per-detail isolation (one bad page never fails the board).
+
+**Non-Goals:**
+- A harvest prober / tenant auto-discovery (`cmd/harvest-boards`). Only one board
+  is known today; a prober is a later seam if the board list grows.
+- Streaming ingest (`StreamingSource`) — the boards are small; the buffered
+  `Fetch` path is sufficient (matches icims/freshteam).
+- Parsing `baseSalary` / `validThrough` into structured facets — out of scope; the
+  pipeline's dictionaries and the LLM own enrichment.
+
+## Decisions
+
+- **Enumerate from the listing HTML, not a sitemap.** Unlike icims (sitemap.xml),
+  careers-page.com exposes the postings directly in the paginated listing. Use the
+  shared `jobLinks(base, root, isJob)` helper with `isJob` = href contains
+  `/jobs/` and a UUID segment. This reuses the deduping/absolutizing already in
+  `html.go`.
+  - *Alternative considered:* parse the `data-job-id` attributes off the cards.
+    Rejected — the anchor href already carries the UUID and canonical detail URL,
+    and `jobLinks` is the established enumeration helper.
+
+- **Stop pagination when a page yields no new job links.** Fetch `?page=N` for
+  `N = 1,2,…`, accumulating links; stop when a page contributes zero new links, or
+  at a safety cap (e.g. 100 pages) to guard a misbehaving listing — mirrors the
+  traffit adapter's never-ending-feed guard.
+
+- **ExternalID = job UUID** extracted from the `/jobs/<uuid>` path via a compiled
+  regexp, exactly as icims extracts its numeric id. Stable across crawls → dedups.
+
+- **Map JSON-LD like icims.** Decode a `careerspagePosting` struct with just the
+  fields we need through `ldJobPosting`; build the location from
+  `jobLocation[0].address` via `joinNonEmpty`; company via
+  `firstNonEmpty(hiringOrganization.name, e.Company)`; description via
+  `sanitizeHTML(html.UnescapeString(...))`; `PostedAt` via `parseRFC3339`.
+
+- **Work mode:** the JSON-LD `employmentType` is `FULL_TIME`/`PART_TIME`, not a
+  workplace-type enum, and no `jobLocationType` was observed, so there is no
+  STRUCTURED remote signal. Leave `WorkMode` empty and set `Remote` only from the
+  free-text location heuristic (`isRemote`), keeping provenance clean (structured
+  fields carry structured signal only).
+
+- **Transport interface = `HTMLGetter` only** (both listing and detail are HTML),
+  narrower than icims's `XMLGetter + HTMLGetter`.
+
+## Risks / Trade-offs
+
+- **429 rate limiting** → the bounded `fetchDetails` pool (`defaultDetailWorkers`)
+  plus the shared client's pacing keeps bursts modest; a dropped detail is skipped,
+  not fatal. If 429s persist in production, lower the worker bound at the call site
+  (the codebase's documented escape hatch).
+- **Listing markup drift** (class names / pagination scheme change) → the adapter
+  breaks for this platform only; covered by a table-driven test over a captured
+  `testdata` fixture, the same safety net every HTML adapter has.
+- **Pagination that never empties** → bounded page cap prevents an infinite loop
+  (the yandex runaway-cursor lesson).
+
+## Migration Plan
+
+Additive and read-only: new adapter file, one registry line, one board file. No
+schema/API/migration changes. Deploy is a normal binary roll; a cron schedule for
+`sources/careerspage.yml` is an ops follow-up (like every other board file).
+Rollback = remove the registry line / board file.
+
+## Open Questions
+
+- None blocking. Tenant auto-discovery (a prober) is deferred until the board list
+  justifies it.

--- a/openspec/changes/add-careerspage-source/proposal.md
+++ b/openspec/changes/add-careerspage-source/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+careers-page.com is a hosted ATS that puts each client's career page on a
+`<tenant>.careers-page.com` subdomain. Every tenant server-renders its job
+listing as HTML and exposes a clean schema.org `JobPosting` `ld+json` block on
+each job detail page — all keyless. We do not ingest it today, so live vacancies
+on these boards (e.g. David Joseph & Company's founding-engineer roles) are
+missing from the catalogue. A spike VALIDATED that the listing and detail pages
+are keyless and machine-readable.
+
+## What Changes
+
+- Add a `careerspage` source adapter (`internal/sources/careerspage.go`) over the
+  keyless `https://<board>.careers-page.com` career site. The board id is the
+  tenant subdomain; the adapter is board-based (not boardless) and stays in the
+  source facet.
+- The adapter enumerates postings from the **server-rendered listing HTML**
+  (`?page=N`), following pagination until a page yields no new job links, then
+  fetches each job's detail page and maps its `application/ld+json` `JobPosting`
+  (title, description, `datePosted`, `employmentType`, `jobLocation`,
+  `hiringOrganization`) to a `Job` — reusing the existing `jsonld.go`/`html.go`
+  helpers, the same shape as the icims/freshteam/successfactors adapters.
+- The detail fan-out runs under the shared bounded worker pool (`fetchDetails`),
+  so one failed detail request drops only that posting.
+- Register the adapter in `sources.All` (one line).
+- Add `sources/careerspage.yml` seeded with the validated David Joseph & Company
+  board (`davidjoseph-co`).
+
+## Capabilities
+
+### New Capabilities
+- `careerspage-source`: crawling one careers-page.com tenant's server-rendered
+  job listing into the catalogue, mapping each posting's schema.org `JobPosting`
+  detail into a normalized `Job`.
+
+### Modified Capabilities
+<!-- none: no existing spec's requirements change -->
+
+## Impact
+
+- New file `internal/sources/careerspage.go` (+ test) and one line in
+  `internal/sources/source.go` (`All`).
+- New board file `sources/careerspage.yml`; a cron schedule for it is an ops
+  follow-up (mirrors every other per-provider board file).
+- No schema, API, or migration changes; read-only over public HTTP.

--- a/openspec/changes/add-careerspage-source/specs/careerspage-source/spec.md
+++ b/openspec/changes/add-careerspage-source/specs/careerspage-source/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: careers-page.com tenant crawl
+
+The system SHALL provide a `careerspage` source adapter that crawls one
+careers-page.com tenant's public job listing into the catalogue. The board id is
+the tenant subdomain, and the adapter fetches the tenant's server-rendered
+listing at `https://<board>.careers-page.com` and each posting's detail page. The
+crawl is keyless. The adapter is board-based (it requires a board id) and appears
+in the source facet.
+
+#### Scenario: Board yields all live postings
+
+- **WHEN** the adapter fetches a configured tenant board
+- **THEN** it returns one `Job` per posting linked from the tenant's listing, with
+  the posting's title, HTML description (sanitized), free-text location, apply/detail
+  URL, and posted-at timestamp taken from the detail page's schema.org `JobPosting`
+
+#### Scenario: Stable dedup identity
+
+- **WHEN** the adapter maps a posting to a `Job`
+- **THEN** the `ExternalID` is the posting's stable careers-page.com job UUID (from
+  its `/jobs/<uuid>` URL), so re-crawling the same tenant dedups to the same
+  catalogue row
+
+#### Scenario: Company falls back to the configured entry
+
+- **WHEN** a posting's `hiringOrganization.name` is present in the JSON-LD
+- **THEN** it is used as the job's company, otherwise the configured board company
+  is used
+
+### Requirement: Paginated listing collection
+
+The listing is paginated via `?page=N`, so the adapter SHALL page through the
+tenant's listing until a page yields no new job links, collecting every posting —
+a single-page fetch would silently truncate boards larger than one page.
+
+#### Scenario: Board larger than one page
+
+- **WHEN** a tenant has more postings than fit on the first listing page
+- **THEN** the adapter returns every live posting, not just the first page
+
+#### Scenario: Guard against a never-ending listing
+
+- **WHEN** paging never reaches an empty/repeat page
+- **THEN** the adapter stops after a bounded number of pages rather than looping
+  forever
+
+### Requirement: Per-posting detail isolation
+
+The description and structured fields live on each posting's detail page, so the
+adapter SHALL fetch details under a bounded concurrent worker pool and drop only
+the postings whose detail fetch fails or carries no `JobPosting`, without aborting
+the board.
+
+#### Scenario: One bad detail page does not fail the board
+
+- **WHEN** a single posting's detail page fails to fetch or lacks a `JobPosting`
+  `ld+json` block
+- **THEN** that posting is skipped and the rest of the board's postings are still
+  returned

--- a/openspec/changes/add-careerspage-source/tasks.md
+++ b/openspec/changes/add-careerspage-source/tasks.md
@@ -1,0 +1,37 @@
+## 1. Fixtures
+
+- [x] 1.1 Fixtures for the adapter test. (Followed the codebase convention: inline
+  HTML constants in `careerspage_test.go` — `careerspageListingHTML`,
+  `careerspageDetailHTML`, `emptyListingHTML` — plus the shared `routedHTTP` fake,
+  mirroring `icims_test.go`/`freshteam_test.go`; no separate `testdata/` files.)
+
+## 2. Adapter (TDD, one behavior at a time)
+
+- [x] 2.1 `careerspageJobID` extracts the job UUID from a `/jobs/<uuid>` URL and
+  returns "" for sub-action/non-job URLs (compiled regexp).
+- [x] 2.2 Listing parse — the adapter collects every canonical `/jobs/<uuid>` detail
+  URL via `jobLinks`, excluding `/refer` and `/apply` sub-actions.
+- [x] 2.3 Detail parse — `detail` maps the `JobPosting` `ld+json` to a `Job` (title,
+  sanitized HTML description, location from `jobLocation.address`, company via
+  `firstNonEmpty(hiringOrganization.name, e.Company)`, `PostedAt` via `parseRFC3339`,
+  `ExternalID` = UUID with an empty-id drop-guard, `URL` = detail URL); a page with
+  no `JobPosting` yields ok=false.
+- [x] 2.4 Pagination — `Fetch` pages `?page=N` until a page yields no new job links,
+  then fans out details via `fetchDetails`; `careerspageMaxPages` guards a
+  never-ending listing.
+- [x] 2.5 `Provider()` returns `"careerspage"`; the adapter is board-based and appears
+  in `All()` / `FilterableProviders()` (registration test).
+
+## 3. Registry + board file
+
+- [x] 3.1 Added `NewCareerPage(c)` to `sources.All` in `internal/sources/source.go`.
+- [x] 3.2 Created `sources/careerspage.yml` with the validated David Joseph & Company
+  entry (`davidjoseph-co`); passes config validation.
+
+## 4. Verify
+
+- [x] 4.1 `go build ./...` / `go vet ./internal/sources/` / `gofmt -l` clean;
+  `go test ./internal/sources/` green.
+- [x] 4.2 Live smoke against `davidjoseph-co`: returned 9 real open postings with
+  populated title/description/location/URL/posted-at in ~10s; throwaway harness
+  discarded.

--- a/sources/careerspage.yml
+++ b/sources/careerspage.yml
@@ -1,0 +1,8 @@
+# careers-page.com career sites. Provider is the filename; each entry is company + board.
+# board = the tenant subdomain (<board>.careers-page.com); see internal/sources/careerspage.go.
+# The listing is server-rendered HTML paged via ?page=N; each job's canonical /jobs/<uuid>
+# detail page carries a schema.org JobPosting ld+json the adapter maps into a posting.
+# Each board validated live (listing lists >0 job postings) before adding.
+
+- company: David Joseph & Company
+  board: davidjoseph-co


### PR DESCRIPTION
## Why

careers-page.com is a hosted ATS that puts each client's career page on a `<tenant>.careers-page.com` subdomain. We didn't ingest it, so live vacancies on these boards (e.g. David Joseph & Company's founding-engineer roles) were missing. A spike VALIDATED that the listing and detail pages are keyless and machine-readable.

## What

- New board-based `careerspage` adapter (`internal/sources/careerspage.go`) over the keyless `https://<board>.careers-page.com` site. Board id = tenant subdomain.
- Enumerates postings from the **server-rendered listing HTML** (`?page=N`), following pagination until a page yields no new job links (`careerspageMaxPages` cap guards a never-ending listing), then fetches each canonical `/jobs/<uuid>` detail page and maps its `application/ld+json` `JobPosting` to a `Job` — reusing `jsonld.go`/`html.go`, mirroring the icims/freshteam adapters.
- Detail fan-out under the shared bounded pool (`fetchDetails`); one failed/JobPosting-less detail drops only that posting. Empty-id drop-guard on the dedup key.
- Registered in `sources.All` (one line). Seeded `sources/careerspage.yml` with the validated `davidjoseph-co` board.

## Verification

- `go build ./... && go vet ./... && gofmt -l` clean; full `go test ./...` green.
- Table-driven adapter tests (provider, job-id extraction incl. `/refer` `/apply` exclusion, listing→detail mapping, multi-page pagination, bad-detail isolation, registration).
- **Live smoke** against `davidjoseph-co`: returned 9 real open postings with populated title/description/location/URL/posted-at in ~10s.

Planned via OpenSpec (`openspec/changes/add-careerspage-source/`). Read-only over public HTTP; no schema/API/migration changes. A cron schedule for the new board file is an ops follow-up (mirrors every other per-provider board file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)