### PR TITLE
feat(sources): add vouch adapter for vouch.careers

### DIFF
--- a/internal/sources/deel.go
+++ b/internal/sources/deel.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"golang.org/x/net/html"
 )
 
 // deel adapts Deel's multi-tenant ATS (jobs.deel.com/<orgSlug>), a board-based source
@@ -30,11 +28,6 @@ const (
 	deelJobURL = "https://jobs.deel.com/%s/job-details/%s/overview"
 )
 
-// deelPush captures the JS-string body of one self.__next_f.push([1,"…"]) flight chunk
-// (the init push, push([0]), carries no [1,"…"] payload and is ignored). The capture
-// keeps the surrounding quotes so it decodes as a JSON string.
-var deelPush = regexp.MustCompile(`self\.__next_f\.push\(\[1,("(?:[^"\\]|\\.)*")\]\)`)
-
 // NewDeel builds the Deel ATS adapter over the given HTML client.
 func NewDeel(c HTMLGetter) Source { return deel{http: c} }
 
@@ -45,7 +38,7 @@ func (d deel) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	if err != nil {
 		return nil, fmt.Errorf("deel: board %q: %w", e.Board, err)
 	}
-	flight, err := decodeDeelFlight(root)
+	flight, err := decodeNextFlight(root)
 	if err != nil {
 		return nil, fmt.Errorf("deel: board %q: %w", e.Board, err)
 	}
@@ -77,37 +70,6 @@ func (d deel) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, fmt.Errorf("deel: board %q: %d description references but none resolved", e.Board, refs)
 	}
 	return jobs, nil
-}
-
-// decodeDeelFlight concatenates and JS-string-decodes every flight chunk embedded in the
-// page's <script> tags into one stream. Decoding each chunk as a JSON string yields
-// correct UTF-8 (the flight escaping — \", \\, \n, \uXXXX, \/ — is JSON string escaping),
-// so multibyte characters survive intact.
-func decodeDeelFlight(root *html.Node) (string, error) {
-	var scripts strings.Builder
-	walk(root, func(n *html.Node) bool {
-		if n.Type == html.ElementNode && n.Data == "script" {
-			for c := n.FirstChild; c != nil; c = c.NextSibling {
-				if c.Type == html.TextNode {
-					scripts.WriteString(c.Data)
-				}
-			}
-		}
-		return true
-	})
-	matches := deelPush.FindAllStringSubmatch(scripts.String(), -1)
-	if len(matches) == 0 {
-		return "", fmt.Errorf("no flight payload found")
-	}
-	var flight strings.Builder
-	for _, m := range matches {
-		var chunk string
-		if err := json.Unmarshal([]byte(m[1]), &chunk); err != nil {
-			return "", fmt.Errorf("decode flight chunk: %w", err)
-		}
-		flight.WriteString(chunk)
-	}
-	return flight.String(), nil
 }
 
 // deelTextRowMarker matches the start of an RSC text row, "<id>:T<hexlen>,". RSC numbers
@@ -186,47 +148,6 @@ func extractDeelOrgName(flight string) string {
 		return ""
 	}
 	return settings.PreferredOrganizationName
-}
-
-// bracketSlice returns the balanced open..close run that follows the first occurrence of
-// key in s (e.g. the `[ … ]` array or `{ … }` object after a JSON field name), or ok=false
-// when key is absent. It counts depth only outside JSON string literals, so a bracket inside
-// a value — a tenant-controlled title like "[EMEA] Engineer" — does not unbalance the scan.
-func bracketSlice(s, key string, open, closing byte) (string, bool) {
-	at := strings.Index(s, key)
-	if at < 0 {
-		return "", false
-	}
-	start := strings.IndexByte(s[at:], open)
-	if start < 0 {
-		return "", false
-	}
-	start += at
-	depth, inString := 0, false
-	for i := start; i < len(s); i++ {
-		c := s[i]
-		if inString {
-			switch c {
-			case '\\':
-				i++ // skip the escaped byte
-			case '"':
-				inString = false
-			}
-			continue
-		}
-		switch c {
-		case '"':
-			inString = true
-		case open:
-			depth++
-		case closing:
-			depth--
-			if depth == 0 {
-				return s[start : i+1], true
-			}
-		}
-	}
-	return "", false
 }
 
 // toJob maps one posting to a Job. ok is false when the posting carries no id, which would

--- a/internal/sources/deel_test.go
+++ b/internal/sources/deel_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // deelPage wraps a raw flight stream into a minimal board page: one
-// self.__next_f.push([1,"<json-quoted flight>"]) script, the shape decodeDeelFlight reads.
+// self.__next_f.push([1,"<json-quoted flight>"]) script, the shape decodeNextFlight reads.
 func deelPage(flight string) string {
 	q, _ := json.Marshal(flight)
 	return `<html><body><script>self.__next_f.push([1,` + string(q) + `])</script></body></html>`
@@ -52,9 +52,9 @@ func TestDeelIsBoardBased(t *testing.T) {
 // decode into one stream carrying the postings payload, with multibyte text decoded as
 // correct UTF-8 (no mojibake).
 func TestDeelDecodeFlight(t *testing.T) {
-	flight, err := decodeDeelFlight(deelParse(t, "deel_klarna.html"))
+	flight, err := decodeNextFlight(deelParse(t, "deel_klarna.html"))
 	if err != nil {
-		t.Fatalf("decodeDeelFlight: %v", err)
+		t.Fatalf("decodeNextFlight: %v", err)
 	}
 	if !strings.Contains(flight, `"jobPostings":`) {
 		t.Error("flight stream missing jobPostings payload")
@@ -67,9 +67,9 @@ func TestDeelDecodeFlight(t *testing.T) {
 // TestDeelTextRows pins reference resolution: a posting's "$N" reference resolves to its
 // length-delimited text row's HTML.
 func TestDeelTextRows(t *testing.T) {
-	flight, err := decodeDeelFlight(deelParse(t, "deel_klarna.html"))
+	flight, err := decodeNextFlight(deelParse(t, "deel_klarna.html"))
 	if err != nil {
-		t.Fatalf("decodeDeelFlight: %v", err)
+		t.Fatalf("decodeNextFlight: %v", err)
 	}
 	rows := deelTextRows(flight)
 	html23, ok := rows["23"]

--- a/internal/sources/nextflight.go
+++ b/internal/sources/nextflight.go
@@ -1,0 +1,91 @@
+package sources
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// Shared Next.js App Router RSC-flight primitives. A Next.js server-rendered page inlines
+// its data as a sequence of self.__next_f.push([1,"…"]) chunks; concatenating and
+// JS-string-decoding the chunks yields one flight string that embeds the page's JSON.
+// The deel and vouch adapters both read their postings out of this stream.
+
+// nextFlightPush captures the JS-string body of one self.__next_f.push([1,"…"]) flight
+// chunk (the init push, push([0]), carries no [1,"…"] payload and is ignored). The capture
+// keeps the surrounding quotes so it decodes as a JSON string.
+var nextFlightPush = regexp.MustCompile(`self\.__next_f\.push\(\[1,("(?:[^"\\]|\\.)*")\]\)`)
+
+// decodeNextFlight concatenates and JS-string-decodes every flight chunk embedded in the
+// page's <script> tags, returning the assembled flight stream (or an error when the page
+// carries no flight payload — a markup change must surface loudly).
+func decodeNextFlight(root *html.Node) (string, error) {
+	var scripts strings.Builder
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "script" {
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				if c.Type == html.TextNode {
+					scripts.WriteString(c.Data)
+				}
+			}
+		}
+		return true
+	})
+	matches := nextFlightPush.FindAllStringSubmatch(scripts.String(), -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("no flight payload found")
+	}
+	var flight strings.Builder
+	for _, m := range matches {
+		var chunk string
+		if err := json.Unmarshal([]byte(m[1]), &chunk); err != nil {
+			return "", fmt.Errorf("decode flight chunk: %w", err)
+		}
+		flight.WriteString(chunk)
+	}
+	return flight.String(), nil
+}
+
+// bracketSlice returns the balanced open..close run that follows the first occurrence of
+// key in s (e.g. the `[ … ]` array or `{ … }` object after a JSON field name), or ok=false
+// when key is absent. It counts depth only outside JSON string literals, so a bracket inside
+// a value — a tenant-controlled title like "[EMEA] Engineer" — does not unbalance the scan.
+func bracketSlice(s, key string, open, closing byte) (string, bool) {
+	at := strings.Index(s, key)
+	if at < 0 {
+		return "", false
+	}
+	start := strings.IndexByte(s[at:], open)
+	if start < 0 {
+		return "", false
+	}
+	start += at
+	depth, inString := 0, false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			switch c {
+			case '\\':
+				i++ // skip the escaped byte
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case open:
+			depth++
+		case closing:
+			depth--
+			if depth == 0 {
+				return s[start : i+1], true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -187,6 +187,7 @@ func All(c HTTPClient) map[string]Source {
 		NewEightfold(c),
 		NewFreshteam(c),
 		NewDeel(c),
+		NewVouch(c),
 		NewRecruitingSolutions(c),
 		NewUKG(c),
 		NewSenior(c),

--- a/internal/sources/vouch.go
+++ b/internal/sources/vouch.go
@@ -1,0 +1,184 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// vouch adapts vouch.careers, a referral-driven careers platform. The board is the URL
+// company cuid (e.g. "cmghojtua00p5et0dvusuxx5o"), and the company page
+// vouch.careers/companies/<board> is a Next.js App Router app that inlines every posting
+// into its RSC flight stream as a "listings":[…] JSON array — each entry fully populated
+// (title, pitch, must/nice HTML, employmentType, company, locations, state flags). One GET
+// per board therefore assembles every Job with no per-posting detail request, the same
+// embedded-payload shape as the deel/google adapters.
+type vouch struct {
+	http HTMLGetter
+}
+
+const vouchBaseURL = "https://vouch.careers"
+
+// NewVouch builds the vouch.careers adapter over the given HTML client.
+func NewVouch(c HTMLGetter) Source { return vouch{http: c} }
+
+func (vouch) Provider() string { return "vouch" }
+
+func (s vouch) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	pageURL := fmt.Sprintf("%s/companies/%s", vouchBaseURL, e.Board)
+	root, err := s.http.GetHTML(ctx, pageURL)
+	if err != nil {
+		return nil, fmt.Errorf("vouch: board %q: %w", e.Board, err)
+	}
+	flight, err := decodeNextFlight(root)
+	if err != nil {
+		return nil, fmt.Errorf("vouch: board %q: %w", e.Board, err)
+	}
+	// The postings are the flight's "listings":[…] array. A missing array is an error (a
+	// markup change must surface loudly rather than silently empty the catalogue); an empty
+	// array is valid and yields no jobs.
+	raw, ok := bracketSlice(flight, `"listings":`, '[', ']')
+	if !ok {
+		return nil, fmt.Errorf("vouch: board %q: listings payload not found", e.Board)
+	}
+	var listings []vouchListing
+	if err := json.Unmarshal([]byte(raw), &listings); err != nil {
+		return nil, fmt.Errorf("vouch: board %q: decode listings: %w", e.Board, err)
+	}
+
+	var jobs []Job
+	for _, l := range listings {
+		if j, ok := s.toJob(e, l); ok {
+			jobs = append(jobs, j)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps one listing to a Job. ok is false for a non-live posting (deactivated, draft,
+// or unlisted — not a real vacancy) or one with no id (which would collide on the
+// (source, external_id) dedup key).
+func (vouch) toJob(e CompanyEntry, l vouchListing) (Job, bool) {
+	if !l.Activated || l.Draft || l.Unlisted || l.ID == "" {
+		return Job{}, false
+	}
+
+	// The detail URL is the listing's own relative url; resolve it against the site base,
+	// falling back to the canonical /companies/<board>/<id> shape if it is absent.
+	detailURL := fmt.Sprintf("%s/companies/%s/%s", vouchBaseURL, e.Board, l.ID)
+	if l.URL != "" {
+		if ref, err := url.Parse(l.URL); err == nil {
+			detailURL = resolveVouchURL(ref)
+		}
+	}
+
+	location := vouchLocationText(l.Locations)
+	workMode := vouchWorkMode(l.EmploymentType)
+
+	return Job{
+		ExternalID:  l.ID,
+		URL:         detailURL,
+		Title:       l.Title,
+		Company:     firstNonEmpty(l.Company.Name, e.Company),
+		Location:    location,
+		Description: sanitizeHTML(vouchDescription(l)),
+		Remote:      workMode == "remote" || isRemote(location),
+		WorkMode:    workMode,
+		PostedAt:    parseRFC3339(l.PublishedAt),
+	}, true
+}
+
+// vouchBase is the parsed site base, resolved once for every listing's relative url.
+var vouchBase, _ = url.Parse(vouchBaseURL)
+
+// resolveVouchURL resolves a listing's (relative) url against the vouch.careers base.
+func resolveVouchURL(ref *url.URL) string {
+	return vouchBase.ResolveReference(ref).String()
+}
+
+// vouchDescription composes the posting body from the listing's parts. `description` is
+// usually empty; the real content is the pitch plus the `must`/`nice` HTML sections. The
+// pitch is plain prose, so it is HTML-escaped before wrapping (an unescaped "<" would make
+// the sanitizer treat the tail as a bogus tag and drop it).
+func vouchDescription(l vouchListing) string {
+	var b strings.Builder
+	if l.Pitch != "" {
+		b.WriteString("<p>")
+		b.WriteString(html.EscapeString(l.Pitch))
+		b.WriteString("</p>")
+	}
+	b.WriteString(l.Description)
+	b.WriteString(l.Must)
+	b.WriteString(l.Nice)
+	return b.String()
+}
+
+// vouchWorkMode maps the employmentType tokens to a work mode via the shared
+// workplaceTypeMode. A posting can carry several tokens (e.g. ["Full-time","Remote","Hybrid"]);
+// remote is the most permissive and wins, then hybrid, then on-site. Contract-type tokens
+// (Full-time/Part-time/Contract) map to "" and are ignored, as is an unrecognized set (the
+// location parser/LLM still resolve).
+func vouchWorkMode(types []string) string {
+	var hasHybrid, hasOnsite bool
+	for _, t := range types {
+		switch workplaceTypeMode(t) {
+		case "remote":
+			return "remote"
+		case "hybrid":
+			hasHybrid = true
+		case "onsite":
+			hasOnsite = true
+		}
+	}
+	if hasHybrid {
+		return "hybrid"
+	}
+	if hasOnsite {
+		return "onsite"
+	}
+	return ""
+}
+
+// vouchLocationText builds a free-text location from the listing's first location, preferring
+// the human-readable address, else the city/area/country parts. Remote roles often carry no
+// location, yielding "".
+func vouchLocationText(locs []vouchLocation) string {
+	if len(locs) == 0 {
+		return ""
+	}
+	l := locs[0]
+	return firstNonEmpty(l.Address, joinNonEmpty(l.City, l.AdministrativeArea, l.Country))
+}
+
+// vouchListing is the subset of a flight `listings` entry the adapter maps.
+type vouchListing struct {
+	ID             string   `json:"id"`
+	URL            string   `json:"url"`
+	Title          string   `json:"title"`
+	Pitch          string   `json:"pitch"`
+	Must           string   `json:"must"`
+	Nice           string   `json:"nice"`
+	Description    string   `json:"description"`
+	EmploymentType []string `json:"employmentType"`
+	PublishedAt    string   `json:"publishedAt"`
+	Activated      bool     `json:"activated"`
+	Draft          bool     `json:"draft"`
+	Unlisted       bool     `json:"unlisted"`
+	Company        struct {
+		Name string `json:"name"`
+	} `json:"company"`
+	Locations []vouchLocation `json:"locations"`
+}
+
+// vouchLocation is one entry of a listing's locations array (vouch emits ISO country codes
+// and a human-readable address).
+type vouchLocation struct {
+	Address            string `json:"address"`
+	City               string `json:"city"`
+	AdministrativeArea string `json:"administrative_area"`
+	Country            string `json:"country"`
+}

--- a/internal/sources/vouch_test.go
+++ b/internal/sources/vouch_test.go
@@ -1,0 +1,177 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// vouchPage wraps a flight body (the concatenated RSC stream content) into the
+// self.__next_f.push([1,"…"]) <script> shape a vouch company page server-renders. The body
+// is JSON-string-escaped, exactly as Next.js emits it, so the adapter's flight decoder
+// round-trips it back.
+func vouchPage(flightBody string) string {
+	esc, _ := json.Marshal(flightBody)
+	return `<html><body><script>self.__next_f.push([1,` + string(esc) + `])</script></body></html>`
+}
+
+// vouchFlight embeds a listings JSON array inside a plausible flight body (surrounded by
+// other RSC content, so bracketSlice must isolate the array).
+func vouchFlight(listingsJSON string) string {
+	return `["$","div",null,{"id":"jobs","children":["$","$L37",null,{"listings":` + listingsJSON + `}]}],"footer":1`
+}
+
+func TestVouchProvider(t *testing.T) {
+	if got := NewVouch(nil).Provider(); got != "vouch" {
+		t.Errorf("Provider() = %q, want %q", got, "vouch")
+	}
+}
+
+func TestVouchRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["vouch"]
+	if !ok {
+		t.Fatal("All() missing provider vouch")
+	}
+	if s.Provider() != "vouch" {
+		t.Errorf("All()[vouch].Provider() = %q", s.Provider())
+	}
+	if !slices.Contains(FilterableProviders(), "vouch") {
+		t.Error("FilterableProviders() should include vouch")
+	}
+}
+
+func TestVouchNoFlightIsError(t *testing.T) {
+	fake := &fakeHTTP{body: `<html><body>no flight here</body></html>`}
+	if _, err := NewVouch(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"}); err == nil {
+		t.Fatal("want error when the page carries no flight payload")
+	}
+}
+
+func TestVouchNoListingsIsError(t *testing.T) {
+	fake := &fakeHTTP{body: vouchPage(`["$","div",null,{"children":"nothing"}]`)}
+	if _, err := NewVouch(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"}); err == nil {
+		t.Fatal("want error when the flight has no listings array")
+	}
+}
+
+func TestVouchMapsLiveListing(t *testing.T) {
+	listing := `[{
+		"id":"cmjob1","url":"/companies/acme/cmjob1","title":"Senior Software Engineer",
+		"pitch":"Shape an AI platform.","must":"<p>Ship production systems.</p>","nice":"<p>NestJS.</p>",
+		"description":"","employmentType":["Full-time","Remote"],
+		"publishedAt":"2025-10-21T07:15:49.762Z","activated":true,"draft":false,"unlisted":false,
+		"company":{"name":"Laine"},"locations":[]
+	}]`
+	fake := &fakeHTTP{body: vouchPage(vouchFlight(listing))}
+
+	jobs, err := NewVouch(fake).Fetch(context.Background(), CompanyEntry{Company: "Fallback", Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "cmjob1" {
+		t.Errorf("ExternalID = %q, want cmjob1", j.ExternalID)
+	}
+	if j.URL != "https://vouch.careers/companies/acme/cmjob1" {
+		t.Errorf("URL = %q, want resolved absolute", j.URL)
+	}
+	if j.Title != "Senior Software Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Laine" {
+		t.Errorf("Company = %q, want company.name", j.Company)
+	}
+	if j.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (employmentType has Remote)", j.WorkMode)
+	}
+	if !j.Remote {
+		t.Error("Remote should be true for a Remote employmentType")
+	}
+	if !strings.Contains(j.Description, "Ship production systems") || !strings.Contains(j.Description, "NestJS") {
+		t.Errorf("Description lost body content: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Shape an AI platform") {
+		t.Errorf("Description lost pitch: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2025, 10, 21, 7, 15, 49, 762000000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2025-10-21T07:15:49Z", j.PostedAt)
+	}
+}
+
+func TestVouchExcludesNonLiveAndEmptyID(t *testing.T) {
+	listings := `[
+		{"id":"live","url":"/companies/acme/live","title":"Live","employmentType":["Full-time"],"publishedAt":"2025-10-21T07:15:49.762Z","activated":true,"draft":false,"unlisted":false,"company":{"name":"Co"},"locations":[]},
+		{"id":"draft","url":"/companies/acme/draft","title":"Draft","activated":true,"draft":true,"unlisted":false,"company":{"name":"Co"}},
+		{"id":"unlisted","url":"/companies/acme/unlisted","title":"Unlisted","activated":true,"draft":false,"unlisted":true,"company":{"name":"Co"}},
+		{"id":"deactivated","url":"/companies/acme/deact","title":"Deactivated","activated":false,"draft":false,"unlisted":false,"company":{"name":"Co"}},
+		{"id":"","url":"/companies/acme/noid","title":"No ID","activated":true,"draft":false,"unlisted":false,"company":{"name":"Co"}}
+	]`
+	fake := &fakeHTTP{body: vouchPage(vouchFlight(listings))}
+
+	jobs, err := NewVouch(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "live" {
+		t.Fatalf("got %v, want only the live listing (draft/unlisted/deactivated/empty-id excluded)", jobs)
+	}
+}
+
+func TestVouchEscapesPlainTextPitch(t *testing.T) {
+	// A pitch is plain prose; a bare "<" must be escaped, else the sanitizer reads the tail
+	// as a bogus tag and drops it.
+	listing := `[{
+		"id":"cmjob1","url":"/companies/acme/cmjob1","title":"Role",
+		"pitch":"Join a <10 person team building the future.","must":"<p>Ship.</p>",
+		"employmentType":["Full-time","Remote"],"publishedAt":"2025-10-21T07:15:49.762Z",
+		"activated":true,"draft":false,"unlisted":false,"company":{"name":"Co"},"locations":[]
+	}]`
+	fake := &fakeHTTP{body: vouchPage(vouchFlight(listing))}
+
+	jobs, err := NewVouch(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "10 person team building the future") {
+		t.Errorf("pitch tail dropped (unescaped '<'): %q", jobs[0].Description)
+	}
+	if !strings.Contains(jobs[0].Description, "Ship") {
+		t.Errorf("must section lost: %q", jobs[0].Description)
+	}
+}
+
+func TestVouchWorkModeAndLocation(t *testing.T) {
+	listings := `[
+		{"id":"h","url":"/companies/acme/h","title":"Hybrid Role","employmentType":["Full-time","Hybrid"],"activated":true,"draft":false,"unlisted":false,"company":{"name":"Co"},
+		 "locations":[{"address":"Geneva, Switzerland","city":"Geneva","administrative_area":"Geneva","country":"CH"}]},
+		{"id":"o","url":"/companies/acme/o","title":"Onsite Role","employmentType":["Full-time","On-site"],"activated":true,"draft":false,"unlisted":false,"company":{"name":"Co"},"locations":[]}
+	]`
+	fake := &fakeHTTP{body: vouchPage(vouchFlight(listings))}
+
+	jobs, err := NewVouch(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if byID["h"].WorkMode != "hybrid" {
+		t.Errorf("hybrid job WorkMode = %q, want hybrid", byID["h"].WorkMode)
+	}
+	if byID["h"].Location != "Geneva, Switzerland" {
+		t.Errorf("hybrid job Location = %q, want %q", byID["h"].Location, "Geneva, Switzerland")
+	}
+	if byID["o"].WorkMode != "onsite" {
+		t.Errorf("onsite job WorkMode = %q, want onsite", byID["o"].WorkMode)
+	}
+}

--- a/openspec/changes/add-vouch-source/.openspec.yaml
+++ b/openspec/changes/add-vouch-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/add-vouch-source/design.md
+++ b/openspec/changes/add-vouch-source/design.md
@@ -1,0 +1,99 @@
+## Context
+
+vouch.careers is a Next.js App Router app. A company's jobs live at
+`vouch.careers/companies/<companyId>` (companyId is a cuid, e.g.
+`cmghojtua00p5et0dvusuxx5o`). A spike established:
+
+- The company page **server-renders every posting into the RSC flight** (a sequence
+  of `self.__next_f.push([1,"…"])` chunks). Concatenating and JSON-unescaping the
+  chunks yields a flight string that contains a clean `"listings":[ {…}, … ]` JSON
+  array — one object per posting.
+- Each listing object is fully populated: `id` (cuid), `url` (relative detail URL),
+  `title`, `pitch`, `must` (requirements HTML), `nice` (nice-to-have HTML),
+  `description` (often empty), `employmentType` (array of tokens like
+  `["Full-time","Remote"]`), `company` (`{name, …}`), `locations` (array, often
+  empty for remote roles), `publishedAt` (RFC3339), and the state flags `activated`
+  / `draft` / `unlisted`.
+- Everything is keyless. No per-job detail fetch is needed — the company page has it
+  all. The observed board (Laine) returned 11 live listings.
+
+The codebase already parses Next.js flight for Deel (`internal/sources/deel.go`),
+including a generic balanced-slice extractor (`bracketSlice`) and a flight decoder
+(`decodeDeelFlight`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A board-based `vouch` adapter that returns every live posting for one company from
+  a single keyless page fetch.
+- Stable dedup identity from the listing cuid; structured work mode from
+  `employmentType`; clean HTML description from the body fields.
+- Reuse the existing flight primitives rather than re-implementing them.
+
+**Non-Goals:**
+- Per-job detail fetches or streaming — one page carries the whole board.
+- A harvest prober / company auto-discovery. Only one board is known today.
+- Parsing `salary`/`reward` into structured facets — enrichment owns that.
+- Resolving the Supabase storage/image URLs or company-level `company-locations`
+  block — a listing's own `locations` (when present) is the location source.
+
+## Decisions
+
+- **Extract everything from the single company page's flight.** Fetch
+  `https://vouch.careers/companies/<board>`, decode the flight, `bracketSlice` the
+  `"listings":` array, and `json.Unmarshal` it into `[]vouchListing`. This mirrors
+  `extractDeelPostings` but without Deel's text-row indirection (vouch inlines the
+  body HTML directly in each listing, so no `$N` reference resolution is needed).
+
+- **Reuse `bracketSlice`; promote the flight decoder to a shared name.**
+  `bracketSlice` is already generic and stays as-is. `decodeDeelFlight` and its
+  `deelPush` regexp are generic Next.js-flight mechanics; rename them to
+  `decodeNextFlight` / `nextFlightPush` (updating Deel's single call site) so a
+  second consumer isn't coupled to the "deel" name. No behavior change; deel's tests
+  cover the rename.
+  - *Alternative considered:* call `decodeDeelFlight` from `vouch.go` unchanged.
+    Rejected — it reads as vouch depending on deel; the neutral name is the honest
+    shape now that the primitive is shared.
+
+- **Only live postings.** Emit a listing only when `activated && !draft &&
+  !unlisted`. The `listings` array can carry hidden/draft rows that are not real
+  vacancies.
+
+- **ExternalID = listing `id`** (cuid), with the standard empty-id drop-guard. **URL**
+  = the listing's `url` resolved against `https://vouch.careers`. **Company** =
+  `firstNonEmpty(listing.company.name, e.Company)`.
+
+- **Description** = the body fields joined as HTML — `pitch` + `must` + `nice` — then
+  `sanitizeHTML`. `description` is usually empty, so the real content is those three.
+
+- **Work mode (structured):** map `employmentType` tokens — "Remote"→remote,
+  "Hybrid"→hybrid, "On-site"→onsite (first match wins) — into `WorkMode`, and set
+  `Remote` when the tokens contain "Remote" (or the location heuristic matches). This
+  is a structured field, so it is authoritative (provenance stays clean).
+
+- **Location** from the listing's own `locations` array (city/country when present),
+  else empty — remote roles legitimately have no location.
+
+- **Transport interface = `HTMLGetter`** (one HTML page).
+
+## Risks / Trade-offs
+
+- **RSC flight is version-sensitive** (a Next.js upgrade can reshape the stream) →
+  the adapter errors loudly when `listings` is absent (never silently empties), and a
+  table-driven test over a captured flight fixture pins the shape. This is the same
+  bargain the Deel adapter already accepts.
+- **`employmentType` token vocabulary drift** → an unrecognized token yields empty
+  work mode (the location parser/LLM still resolve remote), never a wrong value.
+- **A company with a very large flight** (many postings) is one big response → still
+  a single fetch, far cheaper than a per-job fan-out; acceptable.
+
+## Migration Plan
+
+Additive and read-only: new adapter file, one registry line, one board file, plus a
+no-behavior-change rename in deel.go. No schema/API/migration changes. Rollback =
+remove the registry line / board file.
+
+## Open Questions
+
+- None blocking. Company auto-discovery (a prober) is deferred until the board list
+  justifies it.

--- a/openspec/changes/add-vouch-source/proposal.md
+++ b/openspec/changes/add-vouch-source/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+vouch.careers is a hosted careers platform (referral-driven hiring) that puts each
+company's jobs at `vouch.careers/companies/<companyId>`. It is a Next.js App Router
+app that server-renders every posting into the RSC flight stream, keyless. We do not
+ingest it today, so live vacancies on these boards (e.g. Laine's engineering roles)
+are missing from the catalogue. A spike VALIDATED that the company page inlines the
+full, structured job objects in the flight.
+
+## What Changes
+
+- Add a `vouch` source adapter (`internal/sources/vouch.go`) over the keyless
+  `https://vouch.careers/companies/<board>` company page. The board id is the URL
+  company cuid; the adapter is board-based (not boardless) and stays in the source
+  facet.
+- The adapter fetches the **single company page**, decodes the Next.js RSC flight,
+  and extracts the inlined `"listings":[…]` JSON array — no per-job detail fan-out,
+  because each listing object already carries its full body (`title`, `pitch`,
+  `must`/`nice` HTML, `employmentType`, `company.name`, `locations`, `publishedAt`,
+  and the `activated`/`draft`/`unlisted` state). Only **live** postings (activated,
+  not draft, not unlisted) are emitted.
+- Work mode is a STRUCTURED signal: `employmentType` carries "Remote"/"Hybrid"/
+  "On-site" tokens, mapped to the work-mode vocabulary.
+- Reuse the existing Next.js flight primitives from `deel.go` (`bracketSlice` and
+  the flight decoder), extracting the generic flight decoder into a shared,
+  neutrally-named helper now that a second adapter consumes it.
+- Register the adapter in `sources.All` (one line). Add `sources/vouch.yml` seeded
+  with the validated Laine board.
+
+## Capabilities
+
+### New Capabilities
+- `vouch-source`: crawling one vouch.careers company page into the catalogue by
+  decoding the Next.js RSC flight and mapping each inlined live listing to a `Job`.
+
+### Modified Capabilities
+<!-- none: no existing spec's requirements change. The deel flight-decoder rename is an
+     internal refactor with no behavior change (deel's spec/behavior is unchanged). -->
+
+## Impact
+
+- New file `internal/sources/vouch.go` (+ test) and one line in
+  `internal/sources/source.go` (`All`).
+- A small internal refactor in `internal/sources/deel.go`: rename the generic flight
+  decoder to a shared name (`decodeNextFlight`/`nextFlightPush`), no behavior change,
+  covered by the existing deel tests.
+- New board file `sources/vouch.yml`; a cron schedule is an ops follow-up.
+- No schema, API, or migration changes; read-only over public HTTP.

--- a/openspec/changes/add-vouch-source/specs/vouch-source/spec.md
+++ b/openspec/changes/add-vouch-source/specs/vouch-source/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: vouch.careers company crawl
+
+The system SHALL provide a `vouch` source adapter that crawls one vouch.careers
+company page into the catalogue. The board id is the URL company cuid, and the
+adapter fetches `https://vouch.careers/companies/<board>`, decodes the Next.js RSC
+flight, and extracts the inlined `listings` array. The crawl is keyless. The adapter
+is board-based (it requires a board id) and appears in the source facet.
+
+#### Scenario: Company page yields all live postings
+
+- **WHEN** the adapter fetches a configured company board
+- **THEN** it returns one `Job` per **live** listing (activated, not draft, not
+  unlisted) in the page's `listings` array, with the posting's title, HTML
+  description composed from its body fields, free-text location, apply/detail URL,
+  work mode, and posted-at timestamp — all read from the single company page, with
+  no per-posting detail fetch
+
+#### Scenario: Stable dedup identity
+
+- **WHEN** the adapter maps a listing to a `Job`
+- **THEN** the `ExternalID` is the listing's stable vouch id (cuid), so re-crawling
+  the same company dedups to the same catalogue row; a listing without an id is
+  dropped rather than persisted with an empty key
+
+#### Scenario: Company name falls back to the configured entry
+
+- **WHEN** a listing carries a `company.name`
+- **THEN** it is used as the job's company, otherwise the configured board company
+  is used
+
+### Requirement: Excludes non-live listings
+
+The `listings` array can include draft, deactivated, or unlisted postings, so the
+adapter SHALL emit only postings that are `activated` and neither `draft` nor
+`unlisted` — a draft or hidden posting is not a live vacancy.
+
+#### Scenario: Draft or unlisted posting skipped
+
+- **WHEN** a listing is not activated, or is marked draft or unlisted
+- **THEN** the adapter omits it from the returned jobs
+
+### Requirement: Structured work mode from employment type
+
+The listing's `employmentType` is a STRUCTURED set of tokens including
+"Remote"/"Hybrid"/"On-site", so the adapter SHALL map it to the work-mode
+vocabulary rather than inferring the arrangement from free text.
+
+#### Scenario: Remote token maps to remote work mode
+
+- **WHEN** a listing's `employmentType` contains "Remote"
+- **THEN** the job's work mode is "remote"
+
+### Requirement: Resilient flight parsing
+
+The postings live in the Next.js RSC flight, so the adapter SHALL fail with an error
+when the flight or its `listings` array is absent (a markup change must surface
+loudly rather than silently empty the catalogue), while an empty `listings` array is
+valid and yields no jobs.
+
+#### Scenario: Missing flight payload errors
+
+- **WHEN** the company page carries no flight payload or no `listings` array
+- **THEN** `Fetch` returns an error rather than an empty success

--- a/openspec/changes/add-vouch-source/tasks.md
+++ b/openspec/changes/add-vouch-source/tasks.md
@@ -1,0 +1,36 @@
+## 1. Shared flight helper
+
+- [x] 1.1 Extracted the generic Next.js flight primitives into
+  `internal/sources/nextflight.go`: `decodeDeelFlight`→`decodeNextFlight`,
+  `deelPush`→`nextFlightPush`, and `bracketSlice` (moved verbatim). Updated deel's call
+  sites + deel_test.go; deel tests stay green (byte-identical, no behavior change).
+
+## 2. Adapter (TDD, one behavior at a time)
+
+- [x] 2.1 `Provider()` returns `"vouch"`; the adapter is board-based and appears in
+  `All()` / `FilterableProviders()` (registration test).
+- [x] 2.2 Flight parse — extracts the `listings` array via `bracketSlice`/`decodeNextFlight`;
+  a page with no flight / no `listings` returns an error (two tests).
+- [x] 2.3 Mapping — each live listing maps to a `Job` (ExternalID = id with empty-id
+  drop-guard, URL resolved from listing `url`, Title, Company via
+  `firstNonEmpty(company.name, e.Company)`, Description = sanitized pitch+must+nice with
+  the plain-text pitch HTML-escaped, Location from `locations`, PostedAt via `parseRFC3339`).
+- [x] 2.4 Live-filter — draft / deactivated / unlisted / empty-id listings omitted; only
+  `activated && !draft && !unlisted` returned.
+- [x] 2.5 Structured work mode — `employmentType` mapped through the shared
+  `workplaceTypeMode` with remote>hybrid>onsite priority; `Remote` set when work mode is
+  remote or the location heuristic matches.
+
+## 3. Registry + board file
+
+- [x] 3.1 Added `NewVouch(c)` to `sources.All` in `internal/sources/source.go`.
+- [x] 3.2 Created `sources/vouch.yml` with the validated Laine entry (board =
+  `cmghojtua00p5et0dvusuxx5o`); passes config validation.
+
+## 4. Verify
+
+- [x] 4.1 `go build ./...` / `go vet ./...` / `gofmt -l` clean; full `go test ./...` green
+  (including the unchanged deel tests).
+- [x] 4.2 Live smoke against the Laine board: returned 11 real live postings with
+  populated title/description/location/work-mode/URL in ~1.4s (single fetch, no fan-out);
+  throwaway harness discarded.

--- a/sources/vouch.yml
+++ b/sources/vouch.yml
@@ -1,0 +1,8 @@
+# vouch.careers companies. Provider is the filename; each entry is company + board.
+# board = the URL company cuid (vouch.careers/companies/<board>); see internal/sources/vouch.go.
+# The company page is a Next.js app that inlines every live posting in its RSC flight as a
+# "listings" array — one GET assembles the whole board, no per-job fetch.
+# Each board validated live (page listed >0 live postings) before adding.
+
+- company: Laine
+  board: cmghojtua00p5et0dvusuxx5o


### PR DESCRIPTION
## Why

vouch.careers is a hosted, referral-driven careers platform. Each company's jobs live at `vouch.careers/companies/<companyId>`, a Next.js App Router page that server-renders every posting into the RSC flight stream — keyless. We didn't ingest it, so live vacancies on these boards (e.g. Laine's engineering roles) were missing. A spike VALIDATED that the company page inlines the full, structured job objects in the flight.

## What

- New board-based `vouch` adapter (`internal/sources/vouch.go`) over the keyless `https://vouch.careers/companies/<board>` company page. Board id = URL company cuid.
- Fetches the **single company page**, decodes the Next.js RSC flight, and extracts the inlined `"listings":[…]` JSON array — **no per-job detail fan-out**, because each listing already carries its full body (`title`, `pitch`, `must`/`nice` HTML, `employmentType`, `company.name`, `locations`, `publishedAt`, state flags).
- Emits only **live** postings (`activated && !draft && !unlisted`), with an empty-id drop-guard on the `(source, external_id)` dedup key.
- **Structured work mode** from `employmentType` tokens, mapped through the shared `workplaceTypeMode` (remote > hybrid > onsite). Location from the listing's own `locations` (ISO country + human address). Plain-text `pitch` HTML-escaped before composing the description.
- Extracts the generic Next.js flight primitives shared with Deel into `internal/sources/nextflight.go` (`decodeNextFlight`/`nextFlightPush`/`bracketSlice`) — behavior-preserving move; deel tests unchanged (and `ukg.go` already shared `bracketSlice`).
- Registered in `sources.All`; seeded `sources/vouch.yml` with the validated Laine board.

## Verification

- `go build ./... && go vet ./... && gofmt -l` clean; full `go test ./...` green (incl. unchanged deel tests).
- Table-driven tests: provider/registration, flight-missing & listings-missing → error, live mapping, live-filter (draft/unlisted/deactivated/empty-id excluded), work-mode + location, and a pitch-escaping regression.
- **Live smoke** against the Laine board: 11 real live postings with populated title/description/location/work-mode/URL in ~1.4s (single fetch, no fan-out).

Planned via OpenSpec (`openspec/changes/add-vouch-source/`). Read-only over public HTTP; no schema/API/migration changes. Cron schedule for the board file is an ops follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)