### PR TITLE
feat(sources): +3 boards from LinkedIn hiring-list audit

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -12233,3 +12233,5 @@
   board: medium
 - company: GoPro
   board: goprocareers
+- company: Workera
+  board: workera

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4062,3 +4062,5 @@
   board: livingcarbon
 - company: Zanskar
   board: Zanskar
+- company: MissionWired
+  board: MissionWired

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1056,3 +1056,5 @@
   board: clayglobal
 - company: ZeroAvia
   board: zeroavia
+- company: Raptee.HV
+  board: raptee-energy


### PR DESCRIPTION
## Why

Audited a 59-company LinkedIn "companies hiring" list against catalogue coverage. The key finding: **most were already boarded** — the fuzzy `/companies?q=` name search gave false negatives (hims & hers, Contra, Xapo Bank, VGS, Awesome Motive, `constructortech`, `fivetran` are all already in the board files; their jobs just aren't crawled into prod yet). So this is a small, high-signal set of genuine net-adds.

## What

Live-validated against each ATS API before adding:

| Company | ATS | Board | Live jobs |
|---|---|---|---|
| MissionWired | lever | `MissionWired` | **13** ✅ |
| Workera | greenhouse | `workera` | 0 (valid slug, future-proof) |
| Raptee.HV | workable | `raptee-energy` | 0 (valid slug, future-proof) |

Adapter-level smoke: `lever/MissionWired` returns 13 real postings (Account Manager Direct Mail, Associate Content Strategist, …).

## Skipped (with reason)

- **Beekeeper** — merged into LumApps, self-hosted portal (old Greenhouse board dead)
- **Jenius Bank** — shared SMBC SuccessFactors instance, no per-tenant board to isolate
- **Shopify** — real company uses Ashby but fronts it with a custom careers page; no public Ashby board (public API 404s)
- **iVisa** — `ivisa.breezy.hr/json` 302-redirects (tenant not reachable via the adapter)
- **Quantum Corp** — UKG/UltiPro board returns 0 opportunities
- **Intrado** — iCIMS sitemap WAF-blocked (403) from here
- **Rec Room** — greenhouse `recroom` 404s
- **Census** — acquired by Fivetran; already covered via greenhouse `fivetran` (131 jobs)
- **Quest Software** — iCIMS `careers-quest` has 1 job and the company already shows in prod; skipped as marginal/dup
- Custom / no-ATS sites: Kemecon (is itself an aggregator), Goinstacare, AngelOne, Doist, Arkency, Affordmate, Mentorsity, Expert Thinking (Candidly)
- **Bold** — could not disambiguate which "Bold"; greenhouse `bold` is a stale 1-job decoy

## Verification

- All three board files load and `Validate` against the source registry (`go build ./...` clean).
- `lever/MissionWired` live smoke via the actual adapter: 13 postings.

Data-only change (board config), no code. Cron picks the boards up on the next crawl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)