### PR TITLE
feat(cv-ats): deterministic CV ATS-readiness score (Phase 1)

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -62,6 +62,7 @@ func genStructs() (string, error) {
 	enrichTS := filepath.Join(tmp, "enrich.ts")
 	jobviewTS := filepath.Join(tmp, "jobview.ts")
 	verdictTS := filepath.Join(tmp, "verdict.ts")
+	atscheckTS := filepath.Join(tmp, "atscheck.ts")
 
 	cfg := &tygo.Config{
 		Packages: []*tygo.PackageConfig{
@@ -83,6 +84,13 @@ func genStructs() (string, error) {
 				OutputPath:   verdictTS,
 				IncludeFiles: []string{"verdict.go"},
 			},
+			{
+				// The CV ATS-readiness report wire shape (Report + Check + Status).
+				// Self-contained — only primitives and []Check.
+				Path:         "github.com/strelov1/freehire/internal/atscheck",
+				OutputPath:   atscheckTS,
+				IncludeFiles: []string{"atscheck.go"},
+			},
 		},
 	}
 	if err := tygo.New(cfg).Generate(); err != nil {
@@ -101,7 +109,11 @@ func genStructs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return enrichBody + "\n" + jobviewBody + "\n" + verdictBody, nil
+	atscheckBody, err := readBody(atscheckTS)
+	if err != nil {
+		return "", err
+	}
+	return enrichBody + "\n" + jobviewBody + "\n" + verdictBody + "\n" + atscheckBody, nil
 }
 
 // readBody returns a tygo output file's body with its leading preamble removed, so

--- a/internal/atscheck/atscheck.go
+++ b/internal/atscheck/atscheck.go
@@ -1,0 +1,253 @@
+// Package atscheck computes a deterministic ATS-readiness score for a CV from its
+// plain text: structural checks (machine-readable, contact, sections, dates,
+// length, bullets) plus a role keyword-match. It is pure and I/O-free (mirrors
+// internal/verdict) — the handler supplies the CV text, the CV's parsed skills,
+// and the role's top in-demand skills; an optional LLM layer (see analyzer.go)
+// blends a content-quality score on top.
+//
+// The CV text comes from a plain-text PDF extractor, so layout facts
+// (multi-column, tables, images) are NOT detectable here — only what text allows.
+// The strongest signal we can read is emptiness: a scanned/image CV yields almost
+// no text and fails machine_readable, the single biggest ATS killer.
+package atscheck
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+)
+
+// Status is a check outcome.
+type Status string
+
+const (
+	StatusPass Status = "pass"
+	StatusWarn Status = "warn"
+	StatusFail Status = "fail"
+)
+
+// Check is one line of the readiness checklist.
+type Check struct {
+	ID     string `json:"id"`
+	Status Status `json:"status"`
+	Label  string `json:"label"`
+	Fix    string `json:"fix,omitempty"`
+}
+
+// Report is the full ATS-readiness result. JSON is the wire contract shared with
+// the frontend (an optional LLM layer sets content-quality on top; see analyzer.go).
+type Report struct {
+	Overall      int     `json:"overall"`       // 0-100 blended
+	Readability  int     `json:"readability"`   // 0-100 structural pass-rate
+	KeywordMatch int     `json:"keyword_match"` // 0-100 role skills present in the CV text
+	Checks       []Check `json:"checks"`
+}
+
+// Tunable scoring constants (calibrate against real CVs).
+const (
+	minReadableWords = 30   // below this the CV is treated as a scan/parse failure
+	lengthMin        = 150  // healthy CV word band
+	lengthMax        = 1200 //
+	keywordPassPct   = 70   // keyword-match ≥ this → pass
+	keywordWarnPct   = 40   // ≥ this → warn, else fail
+
+	weightReadability = 0.6 // Overall = round(wR·Readability + wK·KeywordMatch)
+	weightKeyword     = 0.4
+)
+
+var (
+	emailRE  = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+	phoneRE  = regexp.MustCompile(`(?:\+\d[\d\s().\-]{7,}\d)|(?:\(\d{3}\)\s?\d{3}[\s.\-]?\d{4})|(?:\b\d{3}[\s.\-]\d{3}[\s.\-]\d{4}\b)`)
+	dateRE   = regexp.MustCompile(`\b(?:19|20)\d{2}\b|\b\d{1,2}[/.\-]\d{4}\b`)
+	bulletRE = regexp.MustCompile(`(?m)^[ \t]*[-*•‣●·][ \t]+\S`)
+)
+
+var sectionKeywords = map[string][]string{
+	"experience": {"experience", "employment", "work history", "опыт работы", "опыт"},
+	"skills":     {"skills", "навыки", "технолог"},
+}
+
+// Score builds the deterministic report. cvSkills are the CV's parsed skill slugs
+// (the caller runs skilltag.Parse); roleTopSkills are the role's top in-demand
+// skills. Pure and I/O-free.
+func Score(cvText string, cvSkills, roleTopSkills []string) Report {
+	words := len(strings.Fields(cvText))
+	lower := strings.ToLower(cvText)
+
+	structural := []Check{
+		machineReadable(words),
+		contact(cvText),
+		sections(lower),
+		dates(cvText),
+		length(words),
+		bullets(cvText),
+	}
+
+	sum := 0.0
+	for _, c := range structural {
+		sum += statusScore(c.Status)
+	}
+	readability := int(math.Round(sum / float64(len(structural)) * 100))
+
+	kwCheck, keyword := keywordMatch(cvSkills, roleTopSkills)
+
+	overall := int(math.Round(weightReadability*float64(readability) + weightKeyword*float64(keyword)))
+	return Report{
+		Overall:      clamp(overall),
+		Readability:  clamp(readability),
+		KeywordMatch: clamp(keyword),
+		Checks:       append(structural, kwCheck),
+	}
+}
+
+func statusScore(s Status) float64 {
+	switch s {
+	case StatusPass:
+		return 1
+	case StatusWarn:
+		return 0.5
+	default:
+		return 0
+	}
+}
+
+func machineReadable(words int) Check {
+	if words < minReadableWords {
+		return Check{ID: "machine_readable", Status: StatusFail, Label: "Text is machine-readable",
+			Fix: "Export a text-based PDF (not a scan or image) so an ATS can read it."}
+	}
+	return Check{ID: "machine_readable", Status: StatusPass, Label: "Text is machine-readable"}
+}
+
+func contact(cv string) Check {
+	c := Check{ID: "contact", Label: "Contact info (email and phone)"}
+	hasEmail := emailRE.MatchString(cv)
+	hasPhone := phoneRE.MatchString(cv)
+	switch {
+	case hasEmail && hasPhone:
+		c.Status = StatusPass
+	case hasEmail || hasPhone:
+		c.Status = StatusWarn
+		c.Fix = "Add both an email and a phone number near the top."
+	default:
+		c.Status = StatusFail
+		c.Fix = "Add an email and a phone number so recruiters can reach you."
+	}
+	return c
+}
+
+func sections(lower string) Check {
+	c := Check{ID: "sections", Label: "Standard sections (Experience, Skills)"}
+	var missing []string
+	for _, name := range []string{"experience", "skills"} {
+		if !hasAny(lower, sectionKeywords[name]) {
+			missing = append(missing, name)
+		}
+	}
+	switch len(missing) {
+	case 0:
+		c.Status = StatusPass
+	case 1:
+		c.Status = StatusWarn
+		c.Fix = fmt.Sprintf("Add a clearly labelled %s section.", missing[0])
+	default:
+		c.Status = StatusFail
+		c.Fix = "Add clearly labelled Experience and Skills sections."
+	}
+	return c
+}
+
+func dates(cv string) Check {
+	if dateRE.MatchString(cv) {
+		return Check{ID: "dates", Status: StatusPass, Label: "Dated work history"}
+	}
+	return Check{ID: "dates", Status: StatusWarn, Label: "Dated work history",
+		Fix: "Add start/end dates (years) to each role so tenure is parseable."}
+}
+
+func length(words int) Check {
+	c := Check{ID: "length", Label: "Reasonable length"}
+	switch {
+	case words < lengthMin:
+		c.Status = StatusWarn
+		c.Fix = "The CV looks short — expand your experience with concrete detail."
+	case words > lengthMax:
+		c.Status = StatusWarn
+		c.Fix = "The CV looks long — trim to the most relevant one to two pages."
+	default:
+		c.Status = StatusPass
+	}
+	return c
+}
+
+func bullets(cv string) Check {
+	if len(bulletRE.FindAllString(cv, -1)) >= 2 {
+		return Check{ID: "bullets", Status: StatusPass, Label: "Bulleted achievements"}
+	}
+	return Check{ID: "bullets", Status: StatusWarn, Label: "Bulleted achievements",
+		Fix: "Use bullet points for your achievements instead of dense paragraphs."}
+}
+
+// keywordMatch scores how many of the role's top skills appear in the CV's parsed
+// skills, and names the top missing ones.
+func keywordMatch(cvSkills, roleTopSkills []string) (Check, int) {
+	c := Check{ID: "keyword_match", Label: "Role keywords present in the CV"}
+	if len(roleTopSkills) == 0 {
+		c.Status = StatusWarn
+		c.Fix = "Select a target role to score keyword match."
+		return c, 0
+	}
+	owned := make(map[string]bool, len(cvSkills))
+	for _, s := range cvSkills {
+		owned[s] = true
+	}
+	matched := 0
+	var missing []string
+	for _, s := range roleTopSkills {
+		if owned[s] {
+			matched++
+		} else {
+			missing = append(missing, s)
+		}
+	}
+	pct := int(math.Round(float64(matched) / float64(len(roleTopSkills)) * 100))
+	switch {
+	case pct >= keywordPassPct:
+		c.Status = StatusPass
+	case pct >= keywordWarnPct:
+		c.Status = StatusWarn
+	default:
+		c.Status = StatusFail
+	}
+	if len(missing) > 0 {
+		c.Fix = "Spell out these in-demand skills where you've used them: " + strings.Join(topN(missing, 5), ", ") + "."
+	}
+	return c, pct
+}
+
+func hasAny(lower string, keywords []string) bool {
+	for _, k := range keywords {
+		if strings.Contains(lower, k) {
+			return true
+		}
+	}
+	return false
+}
+
+func topN(in []string, n int) []string {
+	if len(in) > n {
+		return in[:n]
+	}
+	return in
+}
+
+func clamp(n int) int {
+	if n < 0 {
+		return 0
+	}
+	if n > 100 {
+		return 100
+	}
+	return n
+}

--- a/internal/atscheck/atscheck_test.go
+++ b/internal/atscheck/atscheck_test.go
@@ -1,0 +1,105 @@
+package atscheck
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// cleanCV is a realistic plain-text CV that should pass every structural check
+// (kept > the length floor so the length check passes honestly).
+const cleanCV = `Ilya Ivanov
+ilya@example.com  +1 415 555 0134  San Francisco, CA
+
+Summary
+Senior backend engineer with eight years building high-throughput distributed
+systems and data platforms. Comfortable owning services end to end, from design
+and implementation through on-call and cost optimization.
+
+Experience
+Senior Backend Engineer, Acme (2021 - 2026)
+- Built distributed services in Go handling 20,000 requests per second
+- Led the migration to Kubernetes across 40 services, cutting infra cost 30%
+- Designed a Kafka-based event pipeline processing 2 billion events per day
+- Mentored four engineers and ran the backend on-call rotation
+
+Backend Engineer, Globex (2018 - 2021)
+- Shipped a PostgreSQL-backed billing service used by 3 million customers
+- Introduced Terraform and CI/CD, reducing deploy time from hours to minutes
+- Cut p99 latency 45% by adding Redis caching and query tuning
+
+Education
+BSc Computer Science, MIT (2014 - 2018)
+
+Skills
+Go, Kafka, PostgreSQL, Docker, Kubernetes, AWS, Terraform, Redis, gRPC, Python`
+
+func check(t *testing.T, r Report, id string) Check {
+	t.Helper()
+	for _, c := range r.Checks {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("no check %q in %+v", id, r.Checks)
+	return Check{}
+}
+
+func TestScore_ScannedCVFailsMachineReadable(t *testing.T) {
+	r := Score("   ", nil, nil)
+	if got := check(t, r, "machine_readable"); got.Status != StatusFail {
+		t.Errorf("machine_readable = %s, want fail", got.Status)
+	}
+	if r.Readability > 30 {
+		t.Errorf("readability = %d, want low for a scan", r.Readability)
+	}
+}
+
+func TestScore_CleanCVPassesStructure(t *testing.T) {
+	r := Score(cleanCV, nil, nil)
+	for _, id := range []string{"machine_readable", "contact", "sections", "dates", "length", "bullets"} {
+		if got := check(t, r, id); got.Status != StatusPass {
+			t.Errorf("%s = %s, want pass", id, got.Status)
+		}
+	}
+	if r.Readability < 80 {
+		t.Errorf("readability = %d, want high for a clean CV", r.Readability)
+	}
+}
+
+func TestScore_KeywordMatchFromRoleSkills(t *testing.T) {
+	// CV has go + kafka; role wants go, kubernetes, kafka → 2/3 = 67, kubernetes missing.
+	r := Score(cleanCV, []string{"go", "kafka"}, []string{"go", "kubernetes", "kafka"})
+	if r.KeywordMatch != 67 {
+		t.Errorf("KeywordMatch = %d, want 67", r.KeywordMatch)
+	}
+	if fix := check(t, r, "keyword_match").Fix; !strings.Contains(fix, "kubernetes") {
+		t.Errorf("keyword_match fix = %q, want it to name kubernetes", fix)
+	}
+}
+
+func TestScore_KeywordMatchZeroRoleSkills(t *testing.T) {
+	r := Score(cleanCV, []string{"go"}, nil)
+	if r.KeywordMatch != 0 {
+		t.Errorf("KeywordMatch = %d, want 0 when no role skills", r.KeywordMatch)
+	}
+}
+
+func TestScore_OverallBlendsAndClamps(t *testing.T) {
+	r := Score(cleanCV, []string{"go", "kafka"}, []string{"go", "kubernetes", "kafka"})
+	if r.Overall < 0 || r.Overall > 100 {
+		t.Errorf("Overall = %d, want in [0,100]", r.Overall)
+	}
+	// A clean CV with partial keyword match should land between the two sub-scores' extremes.
+	if r.Overall == 0 {
+		t.Errorf("Overall = 0, want a blended non-zero score")
+	}
+}
+
+func TestScore_Deterministic(t *testing.T) {
+	a := Score(cleanCV, []string{"go"}, []string{"go", "kafka"})
+	b := Score(cleanCV, []string{"go"}, []string{"go", "kafka"})
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Score not deterministic:\n%+v\n%+v", a, b)
+	}
+}

--- a/internal/handler/ats_report.go
+++ b/internal/handler/ats_report.go
@@ -1,0 +1,112 @@
+package handler
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/atscheck"
+	"github.com/strelov1/freehire/internal/resume"
+	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// atsRoleTopN is how many of the role's most in-demand skills the CV keyword-match
+// is scored against.
+const atsRoleTopN = 20
+
+// atsResponse is the wire shape for the CV ATS report. HasCV is false when the
+// caller has no stored CV (storage off or none uploaded) — the SPA then prompts an
+// upload instead of showing an empty report; Report is nil in that case.
+type atsResponse struct {
+	HasCV  bool             `json:"has_cv"`
+	Report *atscheck.Report `json:"report"`
+}
+
+// GetATSReport serves the deterministic CV ATS-readiness report for one of the
+// caller's profiles: structural checks over the stored CV text plus a keyword-match
+// against the selected role's top skills. The role is the request's facet params
+// (same as the verdict). Cookie-only, owner-scoped (missing/non-owned → 404); 503
+// when search is unconfigured; 200 with has_cv=false when no CV is stored.
+func (a *API) GetATSReport(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := pathID(c)
+	if err != nil {
+		return err
+	}
+
+	profile, err := a.searchProfile.Get(c.Context(), userID, id)
+	if err != nil {
+		return searchProfileError(err)
+	}
+	if a.facets == nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
+	}
+
+	cvText, ok, err := a.storedCVText(c, userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return c.JSON(fiber.Map{"data": atsResponse{HasCV: false}})
+	}
+
+	roleFilter := search.FilterFromValues(roleValues(c, profile))
+	res, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
+		Filter: roleFilter,
+		Facets: []string{"skills"},
+	})
+	if err != nil {
+		return err
+	}
+	cvSkills := skilltag.Parse(cvText, skilltag.WithResumeAcronyms())
+	report := atscheck.Score(cvText, cvSkills, topRoleSkills(res.Facets["skills"], atsRoleTopN))
+	return c.JSON(fiber.Map{"data": atsResponse{HasCV: true, Report: &report}})
+}
+
+// storedCVText returns the caller's stored CV text; ok=false (no error) when CV
+// storage is disabled or the caller has none stored.
+func (a *API) storedCVText(c *fiber.Ctx, userID int64) (string, bool, error) {
+	if !a.resume.Enabled() {
+		return "", false, nil
+	}
+	text, err := a.resume.Text(c.Context(), userID)
+	if errors.Is(err, resume.ErrNotStored) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return text, true, nil
+}
+
+// topRoleSkills ranks a skills facet distribution by demand (count desc, slug asc)
+// and returns the top n slugs — the role's most in-demand skills.
+func topRoleSkills(facet map[string]int64, n int) []string {
+	type skillCount struct {
+		slug  string
+		count int64
+	}
+	ranked := make([]skillCount, 0, len(facet))
+	for slug, count := range facet {
+		ranked = append(ranked, skillCount{slug, count})
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].count != ranked[j].count {
+			return ranked[i].count > ranked[j].count
+		}
+		return ranked[i].slug < ranked[j].slug
+	})
+	if len(ranked) > n {
+		ranked = ranked[:n]
+	}
+	out := make([]string, len(ranked))
+	for i, r := range ranked {
+		out[i] = r.slug
+	}
+	return out
+}

--- a/internal/handler/ats_report_test.go
+++ b/internal/handler/ats_report_test.go
@@ -1,0 +1,124 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/resume"
+	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/searchprofile"
+)
+
+// atsFacets returns a role skills distribution for the keyword-match.
+func atsFacets() *fakeFacetCounter {
+	return &fakeFacetCounter{res: search.FacetResult{
+		Total:  1000,
+		Facets: map[string]map[string]int64{"skills": {"go": 600, "kubernetes": 400, "kafka": 300}},
+	}}
+}
+
+func atsApp(t *testing.T, repo *fakeProfileRepo, fc facetCounter, store *resume.Store) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &API{issuer: iss, searchProfile: searchprofile.New(repo), facets: fc, resume: store}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/me/profiles/:id/ats-report", auth.RequireAuth(iss), h.GetATSReport)
+	return app, token
+}
+
+func getATS(t *testing.T, app *fiber.App, target, token string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodGet, target, nil)
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
+}
+
+func storeWithCV(t *testing.T, text string) *resume.Store {
+	t.Helper()
+	store := resume.New(newFakeResumeBlobs(), &fakeResumeRepo{})
+	if _, err := store.Put(context.Background(), 1, "text/plain", []byte(text)); err != nil {
+		t.Fatalf("seed CV: %v", err)
+	}
+	return store
+}
+
+func TestGetATS_FacetsUnconfigured503(t *testing.T) {
+	app, token := atsApp(t, ownedProfile(), nil, storeWithCV(t, "x"))
+	if status, _ := getATS(t, app, "/me/profiles/5/ats-report", token); status != fiber.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", status)
+	}
+}
+
+func TestGetATS_NotOwned404(t *testing.T) {
+	repo := &fakeProfileRepo{getErr: searchprofile.ErrNotFound}
+	app, token := atsApp(t, repo, atsFacets(), storeWithCV(t, "x"))
+	if status, _ := getATS(t, app, "/me/profiles/9/ats-report", token); status != fiber.StatusNotFound {
+		t.Fatalf("status = %d, want 404", status)
+	}
+}
+
+func TestGetATS_NoCVStored(t *testing.T) {
+	// Storage enabled but nothing stored → 200 with has_cv=false.
+	store := resume.New(newFakeResumeBlobs(), &fakeResumeRepo{})
+	app, token := atsApp(t, ownedProfile(), atsFacets(), store)
+	status, body := getATS(t, app, "/me/profiles/5/ats-report", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	d := body["data"].(map[string]any)
+	if d["has_cv"] != false {
+		t.Errorf("has_cv = %v, want false", d["has_cv"])
+	}
+}
+
+func TestGetATS_HappyPathScoresStoredCV(t *testing.T) {
+	// "Golang" (not bare "Go") so skilltag unambiguously extracts "go" — bare "go" is
+	// deliberately not tagged, which is the matcher's precision guard.
+	cv := `Ilya Ivanov
+ilya@example.com  +1 415 555 0134
+
+Experience
+Senior Backend Engineer (2021 - 2026)
+- Built distributed systems in Golang and Kafka
+- Ran services on Kubernetes
+
+Skills
+Golang, Kafka, Kubernetes, PostgreSQL`
+	app, token := atsApp(t, ownedProfile(), atsFacets(), storeWithCV(t, cv))
+	status, body := getATS(t, app, "/me/profiles/5/ats-report", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	d := body["data"].(map[string]any)
+	if d["has_cv"] != true {
+		t.Fatalf("has_cv = %v, want true", d["has_cv"])
+	}
+	report := d["report"].(map[string]any)
+	// CV has go+kafka+kubernetes; role top skills are the same three → keyword_match 100.
+	if report["keyword_match"].(float64) != 100 {
+		t.Errorf("keyword_match = %v, want 100", report["keyword_match"])
+	}
+	if report["overall"].(float64) <= 0 {
+		t.Errorf("overall = %v, want > 0", report["overall"])
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -290,6 +290,9 @@ func Register(app *fiber.App, cfg Config) {
 	// market-coverage verdict from the profile's skills against the selected role.
 	// Cookie-only and owner-scoped, like the profile routes it hangs off.
 	api.Get("/me/profiles/:id/verdict", saved, a.GetResumeVerdict)
+	// The CV ATS-readiness report is a sibling per-profile sub-resource: GET scores
+	// the caller's stored CV (structure + role keyword-match). Owner-scoped, cookie-only.
+	api.Get("/me/profiles/:id/ats-report", saved, a.GetATSReport)
 
 	// Resume skill extraction is cookie-only (RequireAuth): it feeds the profile
 	// picker (extracted skills merge into a profile). When S3 storage is configured it

--- a/openspec/changes/cv-ats-score/.openspec.yaml
+++ b/openspec/changes/cv-ats-score/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/cv-ats-score/design.md
+++ b/openspec/changes/cv-ats-score/design.md
@@ -1,0 +1,132 @@
+## Context
+
+The verdict page already computes market-coverage from the profile's skills
+against a role's live Meili facets (`internal/verdict`, `resume_verdict.go`). CVs
+are stored per-user (S3 pointer on `users`, migration 0039) and parsed to skills
+via `skilltag.Parse` (now separator/acronym-fixed). The old LLM "coherence" and
+its server LLM client were removed. This change adds a CV ATS-readiness score —
+deterministic structural + keyword checks plus an optional nil-safe LLM layer —
+as a second section on the verdict page.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A concrete ATS score (0-100) + a fix checklist, computed from the CV text.
+- Deterministic spine (reproducible, free); LLM layer strictly optional/nil-safe.
+- Reuse the verdict's facet machinery and the fixed `skilltag` matcher.
+- Keep `internal/atscheck` pure and unit-tested, like `internal/verdict`.
+
+**Non-Goals:**
+- Layout-aware PDF parsing (multi-column/table hard-detection) — the extractor is
+  plain-text; we detect what text allows and let the LLM flag garbled text.
+- Re-scoring market-coverage (unchanged).
+- Per-job tailoring beyond the selected role.
+
+## Decisions
+
+### D1 — `internal/atscheck` pure scorer
+
+`Score(cv CVText, role RoleSkills) Report` — no I/O. `Report{ Overall int;
+Readability int; KeywordMatch int; Checks []Check }`, `Check{ ID string; Status
+(pass|warn|fail); Label string; Fix string }`. Deterministic checks:
+
+| id | rule | status |
+|----|------|--------|
+| `machine_readable` | extracted text length ≥ threshold | fail if near-empty (scan) |
+| `contact` | email regex AND phone regex present | warn if one missing, fail if both |
+| `sections` | curated heading dict (experience/education/skills, EN+RU) | warn per missing core section |
+| `dates` | year or mm-yyyy pattern present | warn if none |
+| `length` | word count in band (e.g. 150–1000) | warn if out of band |
+| `bullets` | bullet markers present | warn if none |
+| `keyword_match` | role top-N skills present as literal `skilltag` matches | scored (see D2) |
+
+`Readability` = weighted pass-rate of the structural checks; `KeywordMatch` = D2;
+`Overall` = `round(wR·Readability + wK·KeywordMatch)` (+ `wQ·contentQuality` when
+the LLM ran). Weights are named constants (calibrate later, like
+`verdict.MustHaveShare`).
+
+### D2 — Keyword-match, distinct from market-coverage
+
+`roleTopSkills` = the top-N of the role's `skills` facet (same `FacetCounts` the
+verdict uses). `cvSkills` = `skilltag.Parse(cvText, WithResumeAcronyms())`.
+`matched = cvSkills ∩ roleTopSkills`; `KeywordMatch = round(len(matched)/N·100)`.
+The `keyword_match` check's `fix` names the top missing role skills.
+
+*Why distinct:* market-coverage measures the profile's skill SET vs the whole
+market (breadth); keyword-match measures whether the CV TEXT literally surfaces
+this role's terms (what a keyword-filtering ATS scans). A CV can cover the role
+yet fail the keyword scan if the terms aren't written out.
+
+### D3 — Optional LLM layer, nil-safe (re-added server client)
+
+`atscheck.Analyzer` (mirrors the deleted `coherence.go`): `Analyze(ctx, cvText)
+→ *Review` over `llm.Client` (nil ⇒ `(nil,nil)`). `Review{ ContentQuality int;
+Findings []Finding }` — weak/passive verbs, achievement-vs-responsibility,
+garbled-text flag, 2-3 fixes. `GenerateJSON` + Sanitize/Validate (clamp, bound
+strings). Re-add `config.Config` LLM/Langfuse fields + `cmd/server`
+`llm.NewClient` construction (nil-safe; gated on `LLM_*`), passed to the handler.
+No LLM ⇒ deterministic-only report (200), no `content_quality`.
+
+### D4 — Cache the LLM review per-user, on the CV pointer
+
+The LLM review is CV-only (role-independent) and metered/non-deterministic, so
+cache it once per stored CV: add `users.resume_ats_analysis JSONB` next to the
+existing `resume_object_key`. `GET` merges it in; `POST` computes + writes it.
+**Invalidate on CV change:** `resume.Put`/`Delete` clear the column so a new CV
+isn't scored with a stale review. Raw CV text is never stored — only the derived
+review (same invariant as the old coherence blob).
+
+*Alternative considered:* per-profile cache (a `search_profiles` column, like the
+dropped `resume_analysis`). Rejected: the review is role-independent, so a
+per-profile cache re-runs the LLM and yields inconsistent scores for one CV across
+profiles. Per-user keyed to the CV is correct and cheaper.
+
+### D5 — Endpoint, reuses verdict machinery
+
+`GET /me/profiles/:id/ats-report` (owner-scoped 404; 503 when `facets == nil`):
+1. resolve profile; read stored CV text (`resume.Text(userID)`).
+   - No CV stored (storage on, none present) ⇒ 200 with `{ has_cv: false }` so the
+     SPA shows the upload control (not an error).
+2. build the role filter from the request facet params (same `roleValues` as
+   verdict) → `FacetCounts(skills)` → `roleTopSkills`.
+3. `atscheck.Score(cvText, roleTopSkills)`, merge cached review, return.
+`POST` runs `Analyzer.Analyze` over the stored CV, caches, returns merged (best-
+effort: LLM error ⇒ 200 deterministic, like the old verdict POST). CV upload is
+the existing `ExtractResumeSkills`/résumé-storage path; the page gets an
+upload/replace control.
+
+### D6 — Delivery phased in one change
+
+Tasks are ordered so **Phase 1 (deterministic)** is complete and shippable with
+no LLM and no migration: `internal/atscheck` core, `GET` endpoint, verdict-page
+section + CV upload, contracts. **Phase 2 (LLM)** adds the analyzer, the re-added
+server LLM client, the `users` cache migration, the `POST` endpoint, and the
+"Run AI review" UI. If we ship Phase 1 alone, the score is deterministic-only —
+which is exactly the nil-LLM degradation, so no throwaway work.
+
+## Risks / Trade-offs
+
+- **Plain-text extraction is imperfect** (spacing, multi-column) → readability
+  checks are heuristic; `machine_readable` catches the worst case (scans), and the
+  LLM garbled-text flag covers soft multi-column. Copy states the limitation
+  honestly; we never claim a full ATS simulation.
+- **Weights uncalibrated** → named constants, documented as tunable; ship
+  reasonable defaults and revisit with real CVs.
+- **Re-adding the server LLM client** re-introduces config the verdict refactor
+  removed → keep it nil-safe and isolated; enrich workers keep their own
+  `config.Enrich` (unchanged).
+- **Cache staleness on CV replace** → invalidate in `resume.Put`/`Delete`; a
+  missed invalidation only serves an old review, never wrong CV text.
+
+## Migration Plan
+
+1. Phase 1 ships with no schema change.
+2. Phase 2: migration adds `users.resume_ats_analysis JSONB` (nullable);
+   manual-apply on prod before the Phase-2 binary (dictionary/`SELECT *` caveat —
+   the users query is `SELECT *`, so apply the ADD COLUMN BEFORE rolling the
+   binary, per the add-column convention). Regen sqlc. No reindex (no Meili attr).
+
+## Open Questions
+
+- Exact `roleTopSkills` N and the score weights — start with N=20 and equal-ish
+  weights; calibrate against real CVs (the user's CV is a ready test input).

--- a/openspec/changes/cv-ats-score/proposal.md
+++ b/openspec/changes/cv-ats-score/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+The verdict page tells a user how their skills cover the market (market-coverage)
+but says nothing about whether an ATS can even read their CV or whether it carries
+the role's keywords — the two things that actually gate an application. Users want
+a concrete, actionable "how ATS-ready is my CV?" answer. This adds that as a CV
+readiness score + fix checklist next to market-coverage, built on the CV the
+profile already stores and the now-fixed skill matcher.
+
+Wording note: new user-facing copy and API paths use **"CV"**, not "résumé"
+(existing shipped résumé-storage code is left as-is).
+
+## What Changes
+
+- **New `internal/atscheck` package (pure, deterministic).** `Score(cvText,
+  roleTopSkills)` → `{overall, readability, keyword_match, checks[]}`, each check
+  `{id, status: pass|warn|fail, label, fix}`. Deterministic checks over the plain
+  CV text:
+  1. **Machine-readable** — near-empty extracted text ⇒ scanned/image PDF ⇒ hard
+     fail (the one ATS-killer we can reliably detect).
+  2. **Contact info** — email + phone present.
+  3. **Standard sections** — curated heading dictionary (Experience/Education/
+     Skills, EN+RU).
+  4. **Dates** — year / mm-yyyy patterns present.
+  5. **Length** — word-count band (flag very short/long).
+  6. **Bullets** — structured vs wall-of-text.
+  7. **Keyword-match** — of the role's top-N in-demand skills (same Meili facets
+     the verdict uses), how many appear as literal `skilltag` matches in the CV
+     text (ATS keyword-scan simulation). Distinct from market-coverage, which
+     scores the profile's skill SET vs the market.
+  `overall` = weighted blend of readability + keyword_match (+ content_quality
+  when the LLM layer ran); weights are tunable constants.
+- **Optional LLM qualitative layer (nil-safe).** Over the CV text: weak/passive
+  vs strong action verbs, achievement/quantified vs responsibility-only bullets,
+  a garbled-text flag (soft multi-column signal — the extractor is plain-text, so
+  multi-column/tables are NOT hard-detectable; stated honestly), and 2-3 concrete
+  fixes. JSON-forced via `GenerateJSON` + Sanitize/Validate (mirrors the old
+  `coherence.go`). No LLM configured/failed ⇒ deterministic-only score (200).
+- **Re-add a nil-safe server LLM client** (the `config.Config` LLM/Langfuse fields
+  and `cmd/server` construction removed in the verdict refactor), gated on `LLM_*`.
+- **Endpoint** `GET/POST /me/profiles/:id/ats-report` (owner-scoped; 404/503 like
+  verdict). GET = live deterministic report merged with any cached LLM review;
+  POST = run the LLM review over the stored CV and cache it.
+- **Cache the LLM review per-USER** keyed to the stored CV (role-independent, so
+  computed once per CV and reused across profiles/roles), on the users CV pointer;
+  invalidated when the CV is replaced. Raw CV text is never stored (existing
+  invariant).
+- **Web:** a "CV readiness" section on `/my/profiles/[id]/verdict` (score,
+  sub-scores, checklist with fixes, "Run AI review" when LLM is on) plus a CV
+  upload/replace control (the page has none today); `$lib/api`/`$lib/types` +
+  regenerated contracts.
+
+## Capabilities
+
+### New Capabilities
+- `cv-ats-score`: the CV ATS-readiness score — deterministic structural + keyword
+  checks producing a score and fix checklist, plus an optional nil-safe LLM
+  qualitative layer, served per profile against the caller's stored CV.
+
+### Modified Capabilities
+<!-- none at the requirement level: market-coverage (resume-verdict) is unchanged;
+     this adds a new, separate report on the same page. -->
+
+## Impact
+
+- **Backend:** new `internal/atscheck` (pure) + its LLM analyzer; new
+  `internal/handler/ats_report.go` (GET/POST) reusing the verdict's facet fetch;
+  `config.Config` + `cmd/server` re-add the nil-safe LLM client; `internal/resume`
+  or a repo method to read+cache the per-user CV analysis.
+- **Database:** migration adding a per-user CV-analysis cache column (JSONB) to
+  `users`; regen sqlc. No new Meili attribute ⇒ **no reindex**.
+- **Frontend:** verdict page section + CV upload control, `$lib/api`,
+  `$lib/types`, generated contracts.
+- **Delivery:** large change — tasks are phased so the deterministic score (no
+  LLM, no migration) is complete and shippable first, then the LLM layer (server
+  client + cache migration + POST + AI-review UI) lands on top.

--- a/openspec/changes/cv-ats-score/specs/cv-ats-score/spec.md
+++ b/openspec/changes/cv-ats-score/specs/cv-ats-score/spec.md
@@ -1,0 +1,88 @@
+# cv-ats-score Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Deterministic CV ATS-readiness score
+
+The system SHALL compute an ATS-readiness score for a profile's CV from the CV's
+plain text, using deterministic structural checks: machine-readability (near-empty
+extracted text ⇒ the CV is a scan/image ⇒ hard fail), presence of contact info
+(email and phone), standard sections (Experience/Education/Skills headings, EN and
+RU), dates, a sane length band, and bullet usage. Each check SHALL carry a status
+(pass/warn/fail), a human label, and a concrete fix. The score SHALL be
+reproducible (same CV text ⇒ same score) and require no LLM.
+
+#### Scenario: A scanned/image CV fails machine-readability
+- **WHEN** the extracted CV text is near-empty (a scanned or image-only PDF)
+- **THEN** the `machine_readable` check is `fail` and the overall readability is low
+
+#### Scenario: A clean text CV scores its structural checks
+- **WHEN** a CV has an email, phone, Experience/Skills sections, dates, bullets, and a normal length
+- **THEN** those checks are `pass` and readability is high
+
+#### Scenario: Deterministic
+- **WHEN** the same CV text is scored twice
+- **THEN** the score and checklist are identical
+
+### Requirement: Role keyword-match distinct from market-coverage
+
+The system SHALL report a keyword-match: of the selected role's top in-demand
+skills (the role's `skills` facet), how many appear as literal skill-tag matches
+in the CV text. This SHALL be computed from the CV TEXT (not the profile's stored
+skill set) and SHALL name the top missing role skills in the check's fix. The role
+SHALL come from the request's facet params (the verdict page's filter).
+
+#### Scenario: Keyword-match counts role skills present in the CV text
+- **WHEN** a role's top skills are {go, kubernetes, kafka} and the CV text contains "go" and "kafka" but not "kubernetes"
+- **THEN** keyword-match reflects 2 of 3 and the fix names "kubernetes" as missing
+
+#### Scenario: Role comes from the request filter
+- **WHEN** the caller requests the report with `?category=data`
+- **THEN** keyword-match uses the data role's top skills, independent of the profile's stored specializations
+
+### Requirement: Optional LLM qualitative review, nil-safe and cached per user
+
+When an LLM is configured, the system SHALL, on request, review the CV text for
+qualitative issues (weak vs strong action verbs, achievement-vs-responsibility
+bullets, a garbled-text flag, and concrete fixes) and blend a content-quality
+score into the overall. When no LLM is configured or the call fails, the endpoint
+SHALL return the deterministic score only (HTTP 200, no content-quality). The
+derived review SHALL be cached per user keyed to the stored CV and reused across
+profiles/roles; it SHALL be invalidated when the CV is replaced or deleted. The
+raw CV text SHALL NOT be persisted — only the derived review.
+
+#### Scenario: No LLM configured degrades cleanly
+- **WHEN** the server has no LLM configured and a report is requested
+- **THEN** the response is 200 with the deterministic score and no content-quality
+
+#### Scenario: LLM review is cached and reused
+- **WHEN** the LLM review has run for a user's stored CV and the report is opened again (any profile/role)
+- **THEN** the cached review is served without re-calling the LLM
+
+#### Scenario: Replacing the CV invalidates the cached review
+- **WHEN** the user uploads a new CV
+- **THEN** the previously cached review is cleared and not shown for the new CV
+
+#### Scenario: Only the derived review is stored
+- **WHEN** a CV is reviewed
+- **THEN** the stored analysis contains the content-quality and findings but no CV text
+
+### Requirement: ATS report endpoint authentication, ownership, and no-CV state
+
+The ATS report endpoint SHALL require an authenticated session (cookie-only) and
+operate only on a profile owned by the caller (missing/non-owned ⇒ 404). It SHALL
+respond 503 when the search backend is unconfigured. When CV storage is enabled
+but the caller has no CV stored, it SHALL respond 200 with a "no CV" state (so the
+SPA prompts an upload) rather than an error.
+
+#### Scenario: Owner reads their report
+- **WHEN** a signed-in user requests the ATS report for a profile they own, with a CV stored
+- **THEN** the response is 200 with the score and checklist
+
+#### Scenario: Non-owner is refused
+- **WHEN** a signed-in user requests the ATS report for another user's profile
+- **THEN** the response is 404
+
+#### Scenario: No CV stored
+- **WHEN** the caller has CV storage enabled but no CV uploaded
+- **THEN** the response is 200 with a "no CV" state, not an error

--- a/openspec/changes/cv-ats-score/tasks.md
+++ b/openspec/changes/cv-ats-score/tasks.md
@@ -1,0 +1,43 @@
+# Phase 1 — deterministic ATS score (no LLM, no migration; independently shippable)
+
+## 1. Core scorer (pure)
+
+- [x] 1.1 RED: `internal/atscheck` tests — `Score(cvText, roleTopSkills)` returns `{Overall, Readability, KeywordMatch, Checks[]}`; scanned/near-empty text ⇒ `machine_readable` fail + low readability; a clean CV ⇒ structural checks pass + high readability; determinism (same input → same output).
+- [x] 1.2 GREEN: implement the deterministic checks (machine_readable, contact email+phone, sections via a curated EN+RU heading dict, dates, length band, bullets) with per-check `{id,status,label,fix}`; Readability = weighted pass-rate; weights/thresholds as named constants. Pure, no I/O.
+- [x] 1.3 RED+GREEN: keyword-match — `cvSkills = skilltag.Parse(cvText, WithResumeAcronyms())`, `matched = cvSkills ∩ roleTopSkills`, `KeywordMatch = round(len(matched)/N·100)`; the `keyword_match` check's fix names top missing role skills. Test: 2-of-3 role skills present → correct score + missing named; distinct from market-coverage (uses CV text, not profile skills).
+- [x] 1.4 GREEN: `Overall = round(wR·Readability + wK·KeywordMatch)` (content-quality term absent in Phase 1); named weight constants. Tests for the blend + clamping to [0,100].
+
+## 2. HTTP endpoint (GET, deterministic)
+
+- [x] 2.1 RED: handler tests (fake facets + fake résumé store) — owner-scoped 404; 503 when facets nil; "no CV" 200 state when storage enabled but none stored; role from `?category=` param (reuse `roleValues`); happy path returns score + checks.
+- [x] 2.2 GREEN: `internal/handler/ats_report.go` `GetATSReport` — resolve profile (owner-scoped), read stored CV text (`resume.Text`), build role filter + `FacetCounts(skills)` → top-N role skills, call `atscheck.Score`, return `{data: report}`. Wire `GET /me/profiles/:id/ats-report` in `handler.go`.
+
+## 3. Contracts + frontend (deterministic section)
+
+- [x] 3.1 Regen Go→TS contracts (`cmd/gen-contracts`) for the atscheck report shape; add to `$lib/types`; add `getATSReport(id, params)` to `$lib/api`.
+- [x] 3.2 Web: a "CV readiness" section on `/my/profiles/[id]/verdict` — overall score, readability + keyword-match sub-scores, checklist (pass/warn/fail + fix), recomputed on filter change alongside coverage. Use "CV" wording.
+- [x] 3.3 Web: re-introduce a CV upload/replace control on the verdict page (existing `extractResumeSkills`/résumé-storage path); after upload, the report recomputes. "CV" wording.
+
+## 4. Verify Phase 1
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...`; `svelte-check` clean; confirm the deterministic report renders and recomputes on filter/CV change. Deterministic phase ships with NO LLM and NO migration (nil-LLM path = the same degraded score).
+
+# Phase 2 — optional LLM qualitative layer
+
+## 5. Server LLM client (re-added, nil-safe)
+
+- [ ] 5.1 Re-add `config.Config` LLM/Langfuse fields + `config.Load`; re-add `cmd/server` `llm.NewClient` construction (nil-safe, gated on `LLM_*`) + Langfuse flush on shutdown; pass the client into `handler.Config`. Tests: config load; nil when unset.
+
+## 6. LLM analyzer + cache
+
+- [ ] 6.1 RED+GREEN: `atscheck.Analyzer` (mirrors old `coherence.go`) — `Analyze(ctx, cvText) → *Review{ContentQuality, Findings[]}` via `llm.Client` (nil ⇒ (nil,nil)); `GenerateJSON` + Sanitize (clamp 0-100, bound strings). Unit tests with a fake model.
+- [ ] 6.2 Migration `migrations/00NN_users_resume_ats_analysis.sql` — `ALTER TABLE users ADD COLUMN resume_ats_analysis JSONB;` (manual-apply BEFORE the Phase-2 binary; `SELECT *` users query). Add queries to set/clear/read it; `make sqlc`. Invalidate (clear) in `resume.Put`/`Delete`.
+- [ ] 6.3 GREEN: `POST /me/profiles/:id/ats-report` — read stored CV, `Analyze`, cache to `users.resume_ats_analysis`, return merged report (best-effort: LLM error ⇒ 200 deterministic). `GET` merges the cached review + folds `content_quality` into `Overall`.
+
+## 7. Frontend (AI review)
+
+- [ ] 7.1 Web: "Run AI review" button (POST) when LLM is enabled; render content-quality + findings/fixes; hide cleanly when no LLM. Update contracts/types.
+
+## 8. Verify + ops
+
+- [ ] 8.1 `go build ./... && go vet ./... && go test ./...`; `svelte-check`; validate the LLM path with a fake + (locally) a real CV. Ops: apply the `users` migration before deploy; ensure `LLM_*` present in the app env to enable the AI layer (else deterministic-only). No reindex.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -33,6 +33,7 @@ import type {
   Report,
   ReportInput,
   Verdict,
+  ATSResponse,
 } from './types';
 
 /** A page of list items, optionally the total matching the query (endpoints that
@@ -546,6 +547,18 @@ export function createApi(
     return res.data;
   }
 
+  /** The CV ATS-readiness report for a profile: structural checks over the caller's
+   *  stored CV plus a keyword-match against the selected role's top skills. `params`
+   *  carries the same facet filters as the verdict. `has_cv` is false (report null)
+   *  when no CV is stored — the page then prompts an upload. Owner-scoped. */
+  async function getATSReport(id: number, params?: URLSearchParams): Promise<ATSResponse> {
+    const qs = params?.toString();
+    const res = await request<{ data: ATSResponse }>(
+      `/api/v1/me/profiles/${id}/ats-report${qs ? `?${qs}` : ''}`,
+    );
+    return res.data;
+  }
+
   /** The caller's notification subscriptions (one per saved search + channel). */
   async function listSubscriptions(): Promise<Subscription[]> {
     const res = await request<{ data: Subscription[] }>('/api/v1/me/subscriptions');
@@ -715,6 +728,7 @@ export function createApi(
     deleteSearchProfile,
     extractResumeSkills,
     getProfileVerdict,
+    getATSReport,
     listSubscriptions,
     createSubscription,
     setSubscriptionActive,
@@ -786,6 +800,7 @@ export const {
   deleteSearchProfile,
   extractResumeSkills,
   getProfileVerdict,
+  getATSReport,
   listSubscriptions,
   createSubscription,
   setSubscriptionActive,

--- a/web/src/lib/components/ATSReportView.svelte
+++ b/web/src/lib/components/ATSReportView.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { Check, TriangleAlert, X } from '@lucide/svelte';
+  import type { ATSReport } from '$lib/types';
+
+  // The deterministic CV ATS-readiness report from the backend: an overall score,
+  // readability + keyword-match sub-scores, and a checklist of pass/warn/fail items
+  // each with a concrete fix.
+  let { report }: { report: ATSReport } = $props();
+
+  const checks = $derived(report.checks ?? []);
+
+  function tone(score: number): string {
+    if (score >= 75) return 'text-primary';
+    if (score >= 50) return 'text-amber-500';
+    return 'text-destructive';
+  }
+</script>
+
+<div class="flex flex-col gap-6">
+  <div class="flex flex-col gap-1">
+    <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">CV readiness</h2>
+    <p class="text-sm text-muted-foreground">
+      How well an ATS can read your CV and whether it carries this role's keywords.
+    </p>
+  </div>
+
+  <!-- Scoreboard -->
+  <div class="grid gap-3 sm:grid-cols-[1.4fr_1fr]">
+    <div class="flex flex-col justify-center gap-1 rounded-xl border border-border bg-card p-5">
+      <div class="flex items-baseline gap-1">
+        <span class="text-6xl font-semibold tabular-nums leading-none {tone(report.overall)}">{report.overall}</span>
+        <span class="text-2xl font-medium text-muted-foreground">/100</span>
+      </div>
+      <p class="text-sm font-medium">Overall ATS score</p>
+    </div>
+    <div class="grid gap-3">
+      {#each [{ label: 'Readability', value: report.readability }, { label: 'Keyword match', value: report.keyword_match }] as s (s.label)}
+        <div class="flex flex-col gap-2 rounded-xl border border-border bg-card p-4">
+          <div class="flex items-baseline justify-between">
+            <span class="text-3xl font-semibold tabular-nums leading-none">{s.value}%</span>
+            <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">{s.label}</span>
+          </div>
+          <div class="h-1.5 overflow-hidden rounded bg-secondary">
+            <div class="h-full rounded bg-primary" style="width: {s.value}%"></div>
+          </div>
+        </div>
+      {/each}
+    </div>
+  </div>
+
+  <!-- Checklist -->
+  <ul class="flex flex-col gap-2">
+    {#each checks as c (c.id)}
+      <li class="flex items-start gap-3 rounded-lg border border-border bg-card p-3 sm:p-4">
+        <span class="mt-0.5 shrink-0">
+          {#if c.status === 'pass'}
+            <Check class="size-4 text-primary" />
+          {:else if c.status === 'warn'}
+            <TriangleAlert class="size-4 text-amber-500" />
+          {:else}
+            <X class="size-4 text-destructive" />
+          {/if}
+        </span>
+        <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span class="text-sm font-medium">{c.label}</span>
+          {#if c.fix && c.status !== 'pass'}
+            <span class="text-xs leading-relaxed text-muted-foreground">{c.fix}</span>
+          {/if}
+        </div>
+      </li>
+    {/each}
+  </ul>
+</div>

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -152,7 +152,34 @@ export interface Gap {
   unlock_percent: number /* int */; // round(new_vacancies / total × 100)
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'breezy', 'careerplug', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'habr_career', 'himalayas', 'huntflow', 'icims', 'inhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'teamtailor', 'tecla', 'thehub', 'traffit', 'trakstar', 'ukg', 'vention', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+/**
+ * Status is a check outcome.
+ */
+export type Status = string;
+export const StatusPass: Status = "pass";
+export const StatusWarn: Status = "warn";
+export const StatusFail: Status = "fail";
+/**
+ * Check is one line of the readiness checklist.
+ */
+export interface Check {
+  id: string;
+  status: Status;
+  label: string;
+  fix?: string;
+}
+/**
+ * Report is the full ATS-readiness result. JSON is the wire contract shared with
+ * the frontend (an optional LLM layer sets content-quality on top; see analyzer.go).
+ */
+export interface Report {
+  overall: number /* int */; // 0-100 blended
+  readability: number /* int */; // 0-100 structural pass-rate
+  keyword_match: number /* int */; // 0-100 role skills present in the CV text
+  checks: Check[];
+}
+
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'breezy', 'careerplug', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'habr_career', 'himalayas', 'huntflow', 'icims', 'inhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamtailor', 'tecla', 'thehub', 'traffit', 'trakstar', 'ukg', 'vention', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,8 +1,17 @@
 // Wire types mirroring the backend JSON (internal/db models and query rows).
 // Timestamps marshal as RFC3339 strings when present, or null.
 
-import type { Job } from './generated/contracts';
+import type { Job, Report as ATSReportContract } from './generated/contracts';
 export type { Job, Enrichment, Verdict, Gap } from './generated/contracts';
+// atscheck's Report/Check are aliased (a local Report — job reports — already exists).
+export type { Report as ATSReport, Check as ATSCheck } from './generated/contracts';
+
+/** The CV ATS report response: `has_cv` is false when the caller has no stored CV
+ *  (the page prompts an upload); `report` is present only when `has_cv` is true. */
+export interface ATSResponse {
+  has_cv: boolean;
+  report: ATSReportContract | null;
+}
 
 export interface Company {
   slug: string;

--- a/web/src/routes/my/profiles/[id]/verdict/+page.svelte
+++ b/web/src/routes/my/profiles/[id]/verdict/+page.svelte
@@ -1,16 +1,18 @@
 <script lang="ts">
+  import { ArrowUp, FileText, RefreshCw } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { facetCounts, getProfileVerdict } from '$lib/api';
+  import { ApiError, extractResumeSkills, facetCounts, getATSReport, getProfileVerdict } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { categoryLabel } from '$lib/facets';
   import { FilterStore, filtersToParams } from '$lib/filters';
+  import ATSReportView from '$lib/components/ATSReportView.svelte';
   import FiltersPanel from '$lib/components/FiltersPanel.svelte';
   import States from '$lib/components/States.svelte';
   import VerdictView from '$lib/components/VerdictView.svelte';
   import { searchProfiles } from '$lib/searchProfiles.svelte';
-  import type { FacetCounts, Verdict } from '$lib/types';
+  import type { ATSResponse, FacetCounts, Verdict } from '$lib/types';
   import { Button } from '$lib/ui';
 
   const id = $derived(Number(page.params.id));
@@ -24,7 +26,14 @@
   let filters = $state<FilterStore | null>(null);
   let verdict = $state<Verdict | null>(null);
   let counts = $state<FacetCounts | null>(null);
+  let ats = $state<ATSResponse | null>(null);
   let loadError = $state(false);
+
+  // CV upload state (the ATS report needs a stored CV).
+  let cvBusy = $state(false);
+  let cvError = $state<string | null>(null);
+  let fileInput = $state<HTMLInputElement | null>(null);
+  let dragActive = $state(false);
 
   // Build the filter store once the profile is known, seeding its role from the
   // profile's specializations when the URL carries no category — so the panel opens on
@@ -64,11 +73,53 @@
     if (!filters) return;
     const params = filtersToParams(filters.applied);
     try {
-      [verdict, counts] = await Promise.all([getProfileVerdict(id, params), facetCounts(params)]);
+      [verdict, counts, ats] = await Promise.all([
+        getProfileVerdict(id, params),
+        facetCounts(params),
+        getATSReport(id, params),
+      ]);
       loadError = false;
     } catch {
       loadError = true;
     }
+  }
+
+  function isPdf(file: File): boolean {
+    return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+  }
+
+  // Store the CV (via the skill-extract path, which also stores it when storage is on),
+  // then reload so the ATS report scores it.
+  async function uploadCV(file: File) {
+    cvBusy = true;
+    cvError = null;
+    try {
+      await extractResumeSkills(file);
+      await reload();
+    } catch (err) {
+      cvError = err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';
+    } finally {
+      cvBusy = false;
+    }
+  }
+
+  function onCVFile(e: Event) {
+    const target = e.currentTarget as HTMLInputElement;
+    const file = target.files?.[0];
+    target.value = '';
+    if (file) void uploadCV(file);
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    dragActive = false;
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    if (!isPdf(file)) {
+      cvError = 'Please drop a PDF file.';
+      return;
+    }
+    void uploadCV(file);
   }
 
   // Humanized role label: the selected categories, falling back to the profile's own
@@ -119,7 +170,77 @@
         {:else if verdict === null}
           <States state="loading" />
         {:else}
-          <VerdictView {verdict} name={profile.name} {role} {gapHref} />
+          <div class="flex flex-col gap-10">
+            <VerdictView {verdict} name={profile.name} {role} {gapHref} />
+
+            <!-- CV readiness (ATS report). Needs a stored CV; prompt an upload when absent. -->
+            <div class="border-t border-border pt-8">
+              <input
+                type="file"
+                accept="application/pdf,.pdf"
+                class="hidden"
+                bind:this={fileInput}
+                onchange={onCVFile}
+              />
+              {#if ats?.has_cv && ats.report}
+                <div class="flex flex-col gap-4">
+                  <ATSReportView report={ats.report} />
+                  <Button variant="ghost" onclick={() => fileInput?.click()} disabled={cvBusy}>
+                    <RefreshCw class="size-4 {cvBusy ? 'animate-spin' : ''}" />
+                    {cvBusy ? 'Uploading…' : 'Replace CV'}
+                  </Button>
+                </div>
+              {:else}
+                <div class="flex flex-col gap-2">
+                  <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                    CV readiness
+                  </h2>
+                  <button
+                    type="button"
+                    onclick={() => fileInput?.click()}
+                    ondragover={(e) => {
+                      e.preventDefault();
+                      dragActive = true;
+                    }}
+                    ondragleave={(e) => {
+                      e.preventDefault();
+                      dragActive = false;
+                    }}
+                    ondrop={onDrop}
+                    disabled={cvBusy}
+                    class="flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-8 text-center transition-colors disabled:opacity-70 {dragActive
+                      ? 'border-primary bg-primary/5'
+                      : 'border-border hover:border-primary/60'}"
+                  >
+                    <span class="flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                      {#if cvBusy}
+                        <FileText class="size-5" />
+                      {:else}
+                        <ArrowUp class="size-5" />
+                      {/if}
+                    </span>
+                    <span class="flex flex-col gap-0.5">
+                      <span class="text-sm font-semibold">
+                        {cvBusy ? 'Reading your CV…' : 'Upload your CV to score it'}
+                      </span>
+                      {#if !cvBusy}
+                        <span class="text-xs text-muted-foreground">
+                          Drop a PDF here, or <span class="text-primary underline">choose from disk</span>
+                        </span>
+                      {/if}
+                    </span>
+                  </button>
+                  <span class="text-xs text-muted-foreground">
+                    Checks ATS readability + this role's keywords. Parsed on the server; CV text is
+                    not stored.
+                  </span>
+                </div>
+              {/if}
+              {#if cvError}
+                <p class="mt-2 text-sm text-destructive">{cvError}</p>
+              {/if}
+            </div>
+          </div>
         {/if}
       </main>
     </div>


### PR DESCRIPTION
## Summary
Adds a **CV readiness** section to the profile verdict page — a deterministic ATS-readiness score + fix checklist next to market-coverage. Phase 1 of `cv-ats-score` (deterministic core; the optional nil-safe LLM layer is Phase 2).

- **`internal/atscheck`** (pure, unit-tested, mirrors `internal/verdict`): `Score(cvText, cvSkills, roleTopSkills)` → `{overall, readability, keyword_match, checks[]}`, each check `{id, status: pass|warn|fail, label, fix}`.
  - Structural checks over plain text: **machine-readable** (near-empty ⇒ scan ⇒ hard fail — the #1 ATS killer we can detect), contact (email+phone), sections (Experience/Skills, EN+RU), dates, length band, bullets.
  - **Keyword-match** — of the role's top-N skills (same Meili facets the verdict uses), how many appear as literal `skilltag` matches in the CV text. Distinct from market-coverage: it measures whether the CV *text* surfaces the role's terms (what a keyword-scanning ATS reads), not the profile's skill *set*.
- **`GET /me/profiles/:id/ats-report`** — owner-scoped (404), 503 when search is off, `200 {has_cv:false}` when no CV is stored (SPA prompts an upload). Reuses the verdict's `roleValues` + `FacetCounts`.
- **Web:** CV readiness section + a CV upload/replace control (via the existing extract/store path); contracts regenerated; **"CV"** wording (not "résumé") per preference.

## Honest limitation
The PDF extractor is plain-text, so multi-column/table layout is **not** hard-detectable; we detect the strongest signal (empty text = scan) and Phase 2's LLM flags garbled text. Keyword-match also under-credits ambiguous-word skills (`go`, `c`, `r`) that `skilltag` won't tag from a bare mention — the matcher's precision guard.

## Not in this PR (Phase 2)
Nil-safe server LLM client + `atscheck.Analyzer` (content-quality + findings), per-user cache migration (`users.resume_ats_analysis`), `POST` + "Run AI review" UI. Phase 1's nil-LLM path is exactly that degraded state, so no throwaway work.

## Ops
No migration, **no reindex** (reuses the skills facet).

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` — 50 pkg ok, 0 fail (atscheck scorer + handler: 503 / not-owned 404 / no-CV state / happy path)
- [x] `svelte-check` — 0 errors / 0 warnings
- [ ] Live: open a profile verdict, upload a CV → score + checklist render and recompute on filter change