### PR TITLE
feat(cv-ats): optional LLM qualitative review (Phase 2)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/database"
 	"github.com/strelov1/freehire/internal/handler"
+	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/observability"
 	"github.com/strelov1/freehire/internal/search"
 )
@@ -110,6 +111,25 @@ func main() {
 		log.Fatalf("blobstore: %v", err)
 	}
 
+	// The LLM is optional and built through the shared construction path
+	// (llm.NewClient): it powers the CV ATS qualitative review, wires Langfuse
+	// tracing (source "cv-ats") when LANGFUSE_* are set, and returns a flush func for
+	// shutdown. Nil client when unconfigured — the ATS score stays deterministic. A
+	// build error on a configured endpoint is fatal (a misconfigured gateway must not
+	// boot silently).
+	llmClient, llmFlush, err := llm.NewClient(llm.Settings{
+		BaseURL:           cfg.LLMBaseURL,
+		APIKey:            cfg.LLMAPIKey,
+		Model:             cfg.LLMModel,
+		LangfuseBaseURL:   cfg.LangfuseBaseURL,
+		LangfusePublicKey: cfg.LangfusePublicKey,
+		LangfuseSecretKey: cfg.LangfuseSecretKey,
+	}, "cv-ats")
+	if err != nil {
+		log.Fatalf("llm: %v", err)
+	}
+	defer llmFlush()
+
 	// OAuth sign-in is optional: only providers with full credentials are
 	// enabled; the registry may be empty and the server still serves password
 	// auth. Redirect URLs derive from the same-origin frontend origin.
@@ -124,6 +144,7 @@ func main() {
 		OAuthProviders: oauthProviders,
 		Search:         searchClient,
 		Blob:           blobStore,
+		LLM:            llmClient,
 
 		TelegramBotToken:      cfg.TelegramBotToken,
 		TelegramBotUsername:   cfg.TelegramBotUsername,

--- a/internal/atscheck/analyzer.go
+++ b/internal/atscheck/analyzer.go
@@ -1,0 +1,96 @@
+package atscheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/llm"
+)
+
+const (
+	// maxCVRunes bounds the CV text sent to the model (user-supplied → cap token cost).
+	maxCVRunes = 24000
+	// maxFindingRunes / maxFindings bound the model's advice so a verbose answer can't
+	// blow up the stored/served payload.
+	maxFindingRunes = 240
+	maxFindings     = 5
+)
+
+// Analyzer runs the optional LLM qualitative review of a CV. A nil client (LLM
+// unconfigured) makes Analyze a no-op so the caller degrades to the deterministic
+// score.
+type Analyzer struct {
+	client *llm.Client
+}
+
+// NewAnalyzer wraps an llm.Client. client may be nil (LLM unconfigured).
+func NewAnalyzer(client *llm.Client) *Analyzer {
+	return &Analyzer{client: client}
+}
+
+// Review is the LLM's qualitative answer: a content-quality score and short,
+// actionable findings. JSON is the wire contract (generated to TS + persisted).
+type Review struct {
+	ContentQuality int      `json:"content_quality"`
+	Findings       []string `json:"findings"`
+}
+
+// Analyze asks the model, over the CV text, for a content-quality score (0-100)
+// and a few concrete improvement findings. Returns (nil, nil) when unconfigured so
+// callers degrade. The model is untrusted output — the score is clamped and
+// findings are trimmed, length-bounded, and capped.
+func (a *Analyzer) Analyze(ctx context.Context, cvText string) (*Review, error) {
+	if a == nil || a.client == nil {
+		return nil, nil
+	}
+	raw, err := a.client.GenerateJSON(ctx, reviewSystemPrompt(), reviewUserPrompt(cvText))
+	if err != nil {
+		return nil, fmt.Errorf("atscheck: analyze: %w", err)
+	}
+	var out Review
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &out); err != nil {
+		return nil, fmt.Errorf("atscheck: parse review: %w", err)
+	}
+	out.sanitize()
+	return &out, nil
+}
+
+// sanitize clamps the score and trims/bounds/caps the findings.
+func (r *Review) sanitize() {
+	r.ContentQuality = clamp(r.ContentQuality)
+	cleaned := make([]string, 0, len(r.Findings))
+	for _, f := range r.Findings {
+		if f = strings.TrimSpace(f); f == "" {
+			continue
+		}
+		cleaned = append(cleaned, llm.TruncateRunes(f, maxFindingRunes))
+		if len(cleaned) >= maxFindings {
+			break
+		}
+	}
+	r.Findings = cleaned
+}
+
+// reviewSystemPrompt pins the JSON contract. Kept as a function (mirrors enrich's
+// testable buildSystemPrompt).
+func reviewSystemPrompt() string {
+	var b strings.Builder
+	b.WriteString("You are a senior technical recruiter reviewing the plain text of a candidate's CV. ")
+	b.WriteString("Return ONLY a JSON object.\n\n")
+	b.WriteString("Return exactly these keys:\n")
+	b.WriteString("- \"content_quality\": integer 0-100. How strong the writing is for a human recruiter: ")
+	b.WriteString("action verbs over passive phrasing, quantified achievements over responsibility lists, ")
+	b.WriteString("and clean readable structure. Penalise garbled/interleaved text (a sign of a multi-column ")
+	b.WriteString("or table layout an ATS may scramble). 100 = excellent; low = weak/garbled.\n")
+	b.WriteString("- \"findings\": an array of 2 to 4 short, concrete, actionable improvement sentences ")
+	b.WriteString("(e.g. replace a weak verb, quantify a bullet, fix a section that reads as garbled). ")
+	b.WriteString("Each ≤ 200 characters. Base every judgement only on the CV text provided; do not invent facts.\n")
+	return b.String()
+}
+
+// reviewUserPrompt carries the (bounded) CV text.
+func reviewUserPrompt(cvText string) string {
+	return "CV:\n" + llm.TruncateRunes(cvText, maxCVRunes) + "\n"
+}

--- a/internal/atscheck/analyzer_test.go
+++ b/internal/atscheck/analyzer_test.go
@@ -1,0 +1,56 @@
+package atscheck
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tmc/langchaingo/llms"
+
+	"github.com/strelov1/freehire/internal/llm"
+)
+
+type fakeModel struct {
+	resp string
+	err  error
+}
+
+func (f fakeModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: f.resp}}}, nil
+}
+func (fakeModel) Call(context.Context, string, ...llms.CallOption) (string, error) { return "", nil }
+
+func TestAnalyze_NilClientIsNoOp(t *testing.T) {
+	got, err := NewAnalyzer(nil).Analyze(context.Background(), "some cv")
+	if err != nil || got != nil {
+		t.Fatalf("nil analyzer = (%v,%v), want (nil,nil)", got, err)
+	}
+}
+
+func TestAnalyze_ParsesAndSanitizes(t *testing.T) {
+	model := fakeModel{resp: `{"content_quality":150,"findings":["  Use stronger action verbs.  ","",  "Quantify your impact."]}`}
+	a := NewAnalyzer(llm.NewWithModel(model))
+	got, err := a.Analyze(context.Background(), "cv text")
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if got.ContentQuality != 100 {
+		t.Errorf("ContentQuality = %d, want clamped to 100", got.ContentQuality)
+	}
+	if len(got.Findings) != 2 {
+		t.Errorf("Findings = %v, want 2 (empty dropped)", got.Findings)
+	}
+	if got.Findings[0] != "Use stronger action verbs." {
+		t.Errorf("Findings[0] = %q, want trimmed", got.Findings[0])
+	}
+}
+
+func TestAnalyze_ModelErrorPropagates(t *testing.T) {
+	a := NewAnalyzer(llm.NewWithModel(fakeModel{err: errors.New("boom")}))
+	if _, err := a.Analyze(context.Background(), "cv"); err == nil {
+		t.Fatal("want error when the model fails")
+	}
+}

--- a/internal/atscheck/atscheck.go
+++ b/internal/atscheck/atscheck.go
@@ -42,6 +42,34 @@ type Report struct {
 	Readability  int     `json:"readability"`   // 0-100 structural pass-rate
 	KeywordMatch int     `json:"keyword_match"` // 0-100 role skills present in the CV text
 	Checks       []Check `json:"checks"`
+	// ContentQuality/Findings are set only when the optional LLM review ran (see
+	// ApplyReview); nil/empty renders no AI section.
+	ContentQuality *int     `json:"content_quality,omitempty"`
+	Findings       []string `json:"findings,omitempty"`
+}
+
+// Three-way Overall weights when the LLM content-quality is present (sum to 1).
+const (
+	weightReadabilityQ = 0.45
+	weightKeywordQ     = 0.30
+	weightQualityQ     = 0.25
+)
+
+// ApplyReview folds an optional LLM review into the report: it attaches the
+// content-quality + findings and re-blends Overall to include content-quality. A
+// nil review leaves the deterministic report untouched.
+func (r *Report) ApplyReview(rv *Review) {
+	if rv == nil {
+		return
+	}
+	cq := rv.ContentQuality
+	r.ContentQuality = &cq
+	r.Findings = rv.Findings
+	r.Overall = clamp(int(math.Round(
+		weightReadabilityQ*float64(r.Readability) +
+			weightKeywordQ*float64(r.KeywordMatch) +
+			weightQualityQ*float64(cq),
+	)))
 }
 
 // Tunable scoring constants (calibrate against real CVs).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,19 @@ type Settings struct {
 	MeiliURL string
 	MeiliKey string
 
+	// LLM backs the optional CV ATS qualitative review on the HTTP server (the enrich
+	// worker reads its own LLM settings via config.Enrich). Optional and provider-
+	// agnostic: any empty field disables the AI layer — the server builds no LLM client
+	// and the ATS score stays deterministic (enforced at the cmd/server call site, not
+	// here). Langfuse tracing is optional observability, wired only when all three set.
+	LLMBaseURL string
+	LLMAPIKey  string
+	LLMModel   string
+
+	LangfuseBaseURL   string
+	LangfusePublicKey string
+	LangfuseSecretKey string
+
 	// S3 backs résumé storage (internal/blobstore). Optional and provider-agnostic:
 	// any S3-compatible endpoint works, and no bucket/host/provider is baked into code —
 	// freehire-ops owns those. All four must be set to enable storage; any empty field
@@ -88,6 +101,14 @@ func Load() Settings {
 		OAuth:          loadOAuth(),
 		MeiliURL:       env("MEILI_URL", "http://localhost:7700"),
 		MeiliKey:       os.Getenv("MEILI_MASTER_KEY"),
+
+		LLMBaseURL: os.Getenv("LLM_BASE_URL"),
+		LLMAPIKey:  os.Getenv("LLM_API_KEY"),
+		LLMModel:   os.Getenv("LLM_MODEL"),
+
+		LangfuseBaseURL:   os.Getenv("LANGFUSE_BASE_URL"),
+		LangfusePublicKey: os.Getenv("LANGFUSE_PUBLIC_KEY"),
+		LangfuseSecretKey: os.Getenv("LANGFUSE_SECRET_KEY"),
 
 		S3Endpoint:  os.Getenv("S3_ENDPOINT"),
 		S3Bucket:    os.Getenv("S3_BUCKET"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,28 @@ import (
 	"time"
 )
 
+func TestLoad_LLMFromEnv(t *testing.T) {
+	t.Setenv("LLM_BASE_URL", "https://gw.example/v1")
+	t.Setenv("LLM_API_KEY", "key-123")
+	t.Setenv("LLM_MODEL", "some-model")
+
+	s := Load()
+	if s.LLMBaseURL != "https://gw.example/v1" || s.LLMAPIKey != "key-123" || s.LLMModel != "some-model" {
+		t.Errorf("LLM settings = %q/%q/%q, want the env values", s.LLMBaseURL, s.LLMAPIKey, s.LLMModel)
+	}
+}
+
+func TestLoad_LLMEmptyWhenUnset(t *testing.T) {
+	t.Setenv("LLM_BASE_URL", "")
+	t.Setenv("LLM_API_KEY", "")
+	t.Setenv("LLM_MODEL", "")
+
+	s := Load()
+	if s.LLMBaseURL != "" || s.LLMAPIKey != "" || s.LLMModel != "" {
+		t.Errorf("LLM settings should be empty when unset, got %q/%q/%q", s.LLMBaseURL, s.LLMAPIKey, s.LLMModel)
+	}
+}
+
 func TestLoad_S3FromEnv(t *testing.T) {
 	t.Setenv("S3_ENDPOINT", "https://hel1.your-objectstorage.com")
 	t.Setenv("S3_BUCKET", "freehire-resumes")

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -184,13 +184,14 @@ type TelegramPost struct {
 }
 
 type User struct {
-	ID               int64              `json:"id"`
-	Email            string             `json:"email"`
-	PasswordHash     pgtype.Text        `json:"password_hash"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	Role             string             `json:"role"`
-	ResumeObjectKey  pgtype.Text        `json:"resume_object_key"`
-	ResumeUploadedAt pgtype.Timestamptz `json:"resume_uploaded_at"`
+	ID                int64              `json:"id"`
+	Email             string             `json:"email"`
+	PasswordHash      pgtype.Text        `json:"password_hash"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	Role              string             `json:"role"`
+	ResumeObjectKey   pgtype.Text        `json:"resume_object_key"`
+	ResumeUploadedAt  pgtype.Timestamptz `json:"resume_uploaded_at"`
+	ResumeAtsAnalysis []byte             `json:"resume_ats_analysis"`
 }
 
 type UserIdentity struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -45,7 +45,8 @@ type Querier interface {
 	// affected row count: 1 for an owned row (whether or not it was shared — unshare is an
 	// idempotent no-op when already private), 0 when missing or not the caller's (→ 404).
 	ClearSavedSearchPublicSlug(ctx context.Context, arg ClearSavedSearchPublicSlugParams) (int64, error)
-	// Clear the user's résumé pointer (after deleting the object from storage).
+	// Clear the user's résumé pointer (after deleting the object from storage) and any
+	// cached ATS review.
 	ClearUserResume(ctx context.Context, id int64) error
 	// Soft-close one job now (see job-lifecycle): a moderator resolving a report with
 	// close_job=true. The third writer of closed_at, alongside the ingest sweep and the
@@ -211,6 +212,9 @@ type Querier interface {
 	GetSubscriptionForDelivery(ctx context.Context, id int64) (GetSubscriptionForDeliveryRow, error)
 	// The caller's linked Telegram chat (link-status endpoint + delivery resolution).
 	GetTelegramLink(ctx context.Context, userID int64) (TelegramLink, error)
+	// The user's cached CV ATS qualitative review (content-quality + findings), or NULL
+	// when none has been computed. Derived only — never the raw CV text.
+	GetUserATSAnalysis(ctx context.Context, id int64) ([]byte, error)
 	// Login lookup. Case-insensitive on email; returns password_hash so the handler
 	// can verify the password (and reject accounts that have none). role feeds the
 	// post-login wire shape.
@@ -432,8 +436,11 @@ type Querier interface {
 	// Pause/resume a subscription, scoped to its owner. No matching owner-scoped row
 	// returns no row (the handler maps that to 404).
 	SetSubscriptionActive(ctx context.Context, arg SetSubscriptionActiveParams) (Subscription, error)
+	// Cache the derived CV ATS review for the user (keyed to their stored CV).
+	SetUserATSAnalysis(ctx context.Context, arg SetUserATSAnalysisParams) error
 	// Record (or replace) the user's stored-résumé pointer, stamping the upload time.
 	// Owner-scoped by id; the object key is derived from the id, never client input.
+	// Also clears any cached ATS review so a new CV is never scored with a stale one.
 	SetUserResume(ctx context.Context, arg SetUserResumeParams) error
 	// Rebuild the companies catalogue from jobs. The companies table is derivable
 	// from jobs (slug = company_slug, name = company), so after a slug-builder change

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -31,14 +31,29 @@ WHERE id = $1;
 -- name: SetUserResume :exec
 -- Record (or replace) the user's stored-résumé pointer, stamping the upload time.
 -- Owner-scoped by id; the object key is derived from the id, never client input.
+-- Also clears any cached ATS review so a new CV is never scored with a stale one.
 UPDATE users
-SET resume_object_key = $2, resume_uploaded_at = now()
+SET resume_object_key = $2, resume_uploaded_at = now(), resume_ats_analysis = NULL
 WHERE id = $1;
 
 -- name: ClearUserResume :exec
--- Clear the user's résumé pointer (after deleting the object from storage).
+-- Clear the user's résumé pointer (after deleting the object from storage) and any
+-- cached ATS review.
 UPDATE users
-SET resume_object_key = NULL, resume_uploaded_at = NULL
+SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL
+WHERE id = $1;
+
+-- name: GetUserATSAnalysis :one
+-- The user's cached CV ATS qualitative review (content-quality + findings), or NULL
+-- when none has been computed. Derived only — never the raw CV text.
+SELECT resume_ats_analysis
+FROM users
+WHERE id = $1;
+
+-- name: SetUserATSAnalysis :exec
+-- Cache the derived CV ATS review for the user (keyed to their stored CV).
+UPDATE users
+SET resume_ats_analysis = $2
 WHERE id = $1;
 
 -- name: GetUserRole :one

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -13,11 +13,12 @@ import (
 
 const clearUserResume = `-- name: ClearUserResume :exec
 UPDATE users
-SET resume_object_key = NULL, resume_uploaded_at = NULL
+SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL
 WHERE id = $1
 `
 
-// Clear the user's résumé pointer (after deleting the object from storage).
+// Clear the user's résumé pointer (after deleting the object from storage) and any
+// cached ATS review.
 func (q *Queries) ClearUserResume(ctx context.Context, id int64) error {
 	_, err := q.db.Exec(ctx, clearUserResume, id)
 	return err
@@ -54,6 +55,21 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateU
 		&i.CreatedAt,
 	)
 	return i, err
+}
+
+const getUserATSAnalysis = `-- name: GetUserATSAnalysis :one
+SELECT resume_ats_analysis
+FROM users
+WHERE id = $1
+`
+
+// The user's cached CV ATS qualitative review (content-quality + findings), or NULL
+// when none has been computed. Derived only — never the raw CV text.
+func (q *Queries) GetUserATSAnalysis(ctx context.Context, id int64) ([]byte, error) {
+	row := q.db.QueryRow(ctx, getUserATSAnalysis, id)
+	var resume_ats_analysis []byte
+	err := row.Scan(&resume_ats_analysis)
+	return resume_ats_analysis, err
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
@@ -149,9 +165,26 @@ func (q *Queries) GetUserRole(ctx context.Context, id int64) (string, error) {
 	return role, err
 }
 
+const setUserATSAnalysis = `-- name: SetUserATSAnalysis :exec
+UPDATE users
+SET resume_ats_analysis = $2
+WHERE id = $1
+`
+
+type SetUserATSAnalysisParams struct {
+	ID                int64  `json:"id"`
+	ResumeAtsAnalysis []byte `json:"resume_ats_analysis"`
+}
+
+// Cache the derived CV ATS review for the user (keyed to their stored CV).
+func (q *Queries) SetUserATSAnalysis(ctx context.Context, arg SetUserATSAnalysisParams) error {
+	_, err := q.db.Exec(ctx, setUserATSAnalysis, arg.ID, arg.ResumeAtsAnalysis)
+	return err
+}
+
 const setUserResume = `-- name: SetUserResume :exec
 UPDATE users
-SET resume_object_key = $2, resume_uploaded_at = now()
+SET resume_object_key = $2, resume_uploaded_at = now(), resume_ats_analysis = NULL
 WHERE id = $1
 `
 
@@ -162,6 +195,7 @@ type SetUserResumeParams struct {
 
 // Record (or replace) the user's stored-résumé pointer, stamping the upload time.
 // Owner-scoped by id; the object key is derived from the id, never client input.
+// Also clears any cached ATS review so a new CV is never scored with a stale one.
 func (q *Queries) SetUserResume(ctx context.Context, arg SetUserResumeParams) error {
 	_, err := q.db.Exec(ctx, setUserResume, arg.ID, arg.ResumeObjectKey)
 	return err

--- a/internal/handler/ats_report.go
+++ b/internal/handler/ats_report.go
@@ -1,16 +1,27 @@
 package handler
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
+	"log"
 	"sort"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/atscheck"
+	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/skilltag"
 )
+
+// atsReviewStore reads/writes the per-user cached CV ATS review. *db.Queries
+// satisfies it; a fake backs the DB-less handler tests.
+type atsReviewStore interface {
+	GetUserATSAnalysis(ctx context.Context, id int64) ([]byte, error)
+	SetUserATSAnalysis(ctx context.Context, arg db.SetUserATSAnalysisParams) error
+}
 
 // atsRoleTopN is how many of the role's most in-demand skills the CV keyword-match
 // is scored against.
@@ -24,48 +35,118 @@ type atsResponse struct {
 	Report *atscheck.Report `json:"report"`
 }
 
-// GetATSReport serves the deterministic CV ATS-readiness report for one of the
-// caller's profiles: structural checks over the stored CV text plus a keyword-match
-// against the selected role's top skills. The role is the request's facet params
-// (same as the verdict). Cookie-only, owner-scoped (missing/non-owned → 404); 503
-// when search is unconfigured; 200 with has_cv=false when no CV is stored.
+// GetATSReport serves the CV ATS-readiness report for one of the caller's profiles:
+// the deterministic structural + keyword score merged with any cached LLM review.
+// Cookie-only, owner-scoped (404); 503 when search is unconfigured; 200 with
+// has_cv=false when no CV is stored.
 func (a *API) GetATSReport(c *fiber.Ctx) error {
-	userID, err := requireUserID(c)
+	userID, profile, err := a.atsContext(c)
 	if err != nil {
 		return err
 	}
-	id, err := pathID(c)
+	report, _, hasCV, err := a.deterministicReport(c, userID, profile)
 	if err != nil {
 		return err
 	}
+	if !hasCV {
+		return c.JSON(fiber.Map{"data": atsResponse{HasCV: false}})
+	}
+	if review := a.cachedReview(c, userID); review != nil {
+		report.ApplyReview(review)
+	}
+	return c.JSON(fiber.Map{"data": atsResponse{HasCV: true, Report: report}})
+}
 
-	profile, err := a.searchProfile.Get(c.Context(), userID, id)
-	if err != nil {
-		return searchProfileError(err)
-	}
-	if a.facets == nil {
-		return fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
-	}
-
-	cvText, ok, err := a.storedCVText(c, userID)
+// PostATSReport runs the optional LLM qualitative review over the caller's stored
+// CV, caches it per user, and returns the report with it folded in. Best-effort: an
+// unconfigured or failing LLM returns the deterministic report (200). Cookie-only,
+// owner-scoped.
+func (a *API) PostATSReport(c *fiber.Ctx) error {
+	userID, profile, err := a.atsContext(c)
 	if err != nil {
 		return err
 	}
-	if !ok {
+	report, cvText, hasCV, err := a.deterministicReport(c, userID, profile)
+	if err != nil {
+		return err
+	}
+	if !hasCV {
 		return c.JSON(fiber.Map{"data": atsResponse{HasCV: false}})
 	}
 
+	review, err := a.atsAnalyzer.Analyze(c.Context(), cvText)
+	if err != nil {
+		// Best-effort: log (never the CV text) and serve the deterministic report.
+		log.Printf("atscheck: review failed for user %d: %v", userID, err)
+		return c.JSON(fiber.Map{"data": atsResponse{HasCV: true, Report: report}})
+	}
+	if review != nil {
+		if blob, err := json.Marshal(review); err == nil {
+			if err := a.atsCache.SetUserATSAnalysis(c.Context(), db.SetUserATSAnalysisParams{
+				ID:                userID,
+				ResumeAtsAnalysis: blob,
+			}); err != nil {
+				log.Printf("atscheck: cache review for user %d: %v", userID, err)
+			}
+		}
+		report.ApplyReview(review)
+	}
+	return c.JSON(fiber.Map{"data": atsResponse{HasCV: true, Report: report}})
+}
+
+// atsContext resolves the authenticated caller, the owner-scoped profile (404), and
+// enforces that search is configured (503).
+func (a *API) atsContext(c *fiber.Ctx) (int64, db.SearchProfile, error) {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return 0, db.SearchProfile{}, err
+	}
+	id, err := pathID(c)
+	if err != nil {
+		return 0, db.SearchProfile{}, err
+	}
+	profile, err := a.searchProfile.Get(c.Context(), userID, id)
+	if err != nil {
+		return 0, db.SearchProfile{}, searchProfileError(err)
+	}
+	if a.facets == nil {
+		return 0, db.SearchProfile{}, fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
+	}
+	return userID, profile, nil
+}
+
+// deterministicReport builds the live deterministic report from the stored CV and
+// the selected role. hasCV is false (no error) when no CV is stored; cvText is
+// returned for the LLM path.
+func (a *API) deterministicReport(c *fiber.Ctx, userID int64, profile db.SearchProfile) (*atscheck.Report, string, bool, error) {
+	cvText, ok, err := a.storedCVText(c, userID)
+	if err != nil || !ok {
+		return nil, "", ok, err
+	}
 	roleFilter := search.FilterFromValues(roleValues(c, profile))
 	res, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
 		Filter: roleFilter,
 		Facets: []string{"skills"},
 	})
 	if err != nil {
-		return err
+		return nil, "", true, err
 	}
 	cvSkills := skilltag.Parse(cvText, skilltag.WithResumeAcronyms())
 	report := atscheck.Score(cvText, cvSkills, topRoleSkills(res.Facets["skills"], atsRoleTopN))
-	return c.JSON(fiber.Map{"data": atsResponse{HasCV: true, Report: &report}})
+	return &report, cvText, true, nil
+}
+
+// cachedReview reads the caller's cached LLM review, or nil when none/invalid.
+func (a *API) cachedReview(c *fiber.Ctx, userID int64) *atscheck.Review {
+	blob, err := a.atsCache.GetUserATSAnalysis(c.Context(), userID)
+	if err != nil || len(blob) == 0 {
+		return nil
+	}
+	var rv atscheck.Review
+	if err := json.Unmarshal(blob, &rv); err != nil {
+		return nil
+	}
+	return &rv
 }
 
 // storedCVText returns the caller's stored CV text; ok=false (no error) when CV

--- a/internal/handler/ats_report_test.go
+++ b/internal/handler/ats_report_test.go
@@ -9,12 +9,37 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/tmc/langchaingo/llms"
 
+	"github.com/strelov1/freehire/internal/atscheck"
 	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/searchprofile"
 )
+
+// fakeATSCache is an in-memory atsReviewStore for the DB-less handler tests.
+type fakeATSCache struct{ blob map[int64][]byte }
+
+func newFakeATSCache() *fakeATSCache { return &fakeATSCache{blob: map[int64][]byte{}} }
+
+func (f *fakeATSCache) GetUserATSAnalysis(_ context.Context, id int64) ([]byte, error) {
+	return f.blob[id], nil
+}
+func (f *fakeATSCache) SetUserATSAnalysis(_ context.Context, arg db.SetUserATSAnalysisParams) error {
+	f.blob[arg.ID] = arg.ResumeAtsAnalysis
+	return nil
+}
+
+// atsModel is a canned llms.Model for the LLM review path.
+type atsModel struct{ resp string }
+
+func (m atsModel) GenerateContent(context.Context, []llms.MessageContent, ...llms.CallOption) (*llms.ContentResponse, error) {
+	return &llms.ContentResponse{Choices: []*llms.ContentChoice{{Content: m.resp}}}, nil
+}
+func (atsModel) Call(context.Context, string, ...llms.CallOption) (string, error) { return "", nil }
 
 // atsFacets returns a role skills distribution for the keyword-match.
 func atsFacets() *fakeFacetCounter {
@@ -26,15 +51,45 @@ func atsFacets() *fakeFacetCounter {
 
 func atsApp(t *testing.T, repo *fakeProfileRepo, fc facetCounter, store *resume.Store) (*fiber.App, string) {
 	t.Helper()
+	return atsAppWith(t, repo, fc, store, atscheck.NewAnalyzer(nil), newFakeATSCache())
+}
+
+func atsAppWith(t *testing.T, repo *fakeProfileRepo, fc facetCounter, store *resume.Store, analyzer *atscheck.Analyzer, cache atsReviewStore) (*fiber.App, string) {
+	t.Helper()
 	iss := auth.NewIssuer("test-secret", time.Hour)
 	token, err := iss.Issue(1)
 	if err != nil {
 		t.Fatalf("issue token: %v", err)
 	}
-	h := &API{issuer: iss, searchProfile: searchprofile.New(repo), facets: fc, resume: store}
+	h := &API{
+		issuer:        iss,
+		searchProfile: searchprofile.New(repo),
+		facets:        fc,
+		resume:        store,
+		atsAnalyzer:   analyzer,
+		atsCache:      cache,
+	}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	app.Get("/me/profiles/:id/ats-report", auth.RequireAuth(iss), h.GetATSReport)
+	g := auth.RequireAuth(iss)
+	app.Get("/me/profiles/:id/ats-report", g, h.GetATSReport)
+	app.Post("/me/profiles/:id/ats-report", g, h.PostATSReport)
 	return app, token
+}
+
+func postATS(t *testing.T, app *fiber.App, target, token string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodPost, target, nil)
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
 }
 
 func getATS(t *testing.T, app *fiber.App, target, token string) (int, map[string]any) {
@@ -120,5 +175,49 @@ Golang, Kafka, Kubernetes, PostgreSQL`
 	}
 	if report["overall"].(float64) <= 0 {
 		t.Errorf("overall = %v, want > 0", report["overall"])
+	}
+	// Phase 1 (no LLM review): no content-quality field.
+	if _, ok := report["content_quality"]; ok {
+		t.Errorf("content_quality present without an LLM review")
+	}
+}
+
+func TestPostATS_RunsLLMReviewAndCaches(t *testing.T) {
+	cache := newFakeATSCache()
+	analyzer := atscheck.NewAnalyzer(llm.NewWithModel(atsModel{
+		resp: `{"content_quality":80,"findings":["Quantify your impact."]}`,
+	}))
+	app, token := atsAppWith(t, ownedProfile(), atsFacets(), storeWithCV(t, "some cv text here"), analyzer, cache)
+
+	status, body := postATS(t, app, "/me/profiles/5/ats-report", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	report := dataOf(t, body)["report"].(map[string]any)
+	if report["content_quality"].(float64) != 80 {
+		t.Errorf("content_quality = %v, want 80", report["content_quality"])
+	}
+	if len(report["findings"].([]any)) != 1 {
+		t.Errorf("findings = %v, want 1", report["findings"])
+	}
+	if len(cache.blob[1]) == 0 {
+		t.Errorf("review was not cached for the user")
+	}
+}
+
+func TestPostATS_NoLLMDegrades(t *testing.T) {
+	// Nil analyzer (LLM off) → 200 deterministic, no content-quality, nothing cached.
+	cache := newFakeATSCache()
+	app, token := atsAppWith(t, ownedProfile(), atsFacets(), storeWithCV(t, "some cv text here"),
+		atscheck.NewAnalyzer(nil), cache)
+	status, body := postATS(t, app, "/me/profiles/5/ats-report", token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if _, ok := dataOf(t, body)["report"].(map[string]any)["content_quality"]; ok {
+		t.Errorf("content_quality present with LLM off")
+	}
+	if len(cache.blob[1]) != 0 {
+		t.Errorf("nothing should be cached with LLM off")
 	}
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -10,12 +10,14 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/accounts"
+	"github.com/strelov1/freehire/internal/atscheck"
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/auth/oauth"
 	"github.com/strelov1/freehire/internal/blobstore"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobtracking"
+	"github.com/strelov1/freehire/internal/llm"
 	"github.com/strelov1/freehire/internal/moderation"
 	"github.com/strelov1/freehire/internal/report"
 	"github.com/strelov1/freehire/internal/resume"
@@ -82,6 +84,11 @@ type API struct {
 	// text for the verdict). Its blob store is nil when S3 is unconfigured; Enabled()
 	// then reports false and callers degrade to per-request résumé upload.
 	resume *resume.Store
+	// atsAnalyzer runs the optional LLM qualitative review for the CV ATS report.
+	// Its client is nil when the LLM is unconfigured; Analyze then degrades to a no-op.
+	atsAnalyzer *atscheck.Analyzer
+	// atsCache reads/writes the per-user cached CV ATS review (backed by *db.Queries).
+	atsCache atsReviewStore
 	// Telegram notification wiring. All nil/empty when the bot is unconfigured —
 	// the linking endpoints then report the feature off and the webhook is inert.
 	// telegramLinks mints/verifies the deep-link token; telegramBot replies to the
@@ -132,6 +139,9 @@ type Config struct {
 	// Blob backs résumé storage (internal/blobstore). Nil disables storage: résumé
 	// upload only extracts skills in-request (no regression).
 	Blob blobstore.Store
+	// LLM backs the optional CV ATS qualitative review. Nil disables the AI layer:
+	// the ATS score stays deterministic (the report just omits content-quality).
+	LLM *llm.Client
 	// Telegram bot for notification linking/delivery confirmations. Optional: an
 	// empty TelegramBotToken disables the feature (linking endpoints report off,
 	// webhook inert). TelegramBotUsername builds the deep link; TelegramWebhookSecret
@@ -172,6 +182,10 @@ func Register(app *fiber.App, cfg Config) {
 	// Résumé storage is nil-safe: a nil Blob (S3 unconfigured) yields a disabled service
 	// whose Enabled() is false, so the upload/verdict paths degrade to in-request parsing.
 	a.resume = resume.New(cfg.Blob, resume.NewQueriesRepository(queries))
+	// Nil-safe: NewAnalyzer(nil) is a no-op analyzer, so the ATS report works whether
+	// or not the LLM is configured.
+	a.atsAnalyzer = atscheck.NewAnalyzer(cfg.LLM)
+	a.atsCache = queries
 	// Telegram notifications are enabled only with both a bot token and a JWT
 	// secret (the link token reuses it). Absent either, the linking endpoints
 	// report the feature off and the webhook is inert (see telegramEnabled).
@@ -293,6 +307,8 @@ func Register(app *fiber.App, cfg Config) {
 	// The CV ATS-readiness report is a sibling per-profile sub-resource: GET scores
 	// the caller's stored CV (structure + role keyword-match). Owner-scoped, cookie-only.
 	api.Get("/me/profiles/:id/ats-report", saved, a.GetATSReport)
+	// POST runs the optional LLM qualitative review over the stored CV and caches it.
+	api.Post("/me/profiles/:id/ats-report", saved, a.PostATSReport)
 
 	// Resume skill extraction is cookie-only (RequireAuth): it feeds the profile
 	// picker (extracted skills merge into a profile). When S3 storage is configured it

--- a/migrations/0041_users_resume_ats_analysis.sql
+++ b/migrations/0041_users_resume_ats_analysis.sql
@@ -1,0 +1,15 @@
+-- The CV ATS-readiness report caches its optional LLM qualitative review per user,
+-- keyed to the stored CV (the review is role-independent, so it is computed once per
+-- CV and reused across profiles/roles). Only the derived review (content-quality +
+-- findings) is stored here — never the raw CV text (the privacy invariant from
+-- internal/handler/resume.go). Nullable, no default: a user with no review yet is
+-- NULL; it is cleared whenever the CV pointer is set or cleared (SetUserResume /
+-- ClearUserResume), so a new CV is never scored with a stale review.
+--
+-- Like every migration here it applies on fresh volume init and is the schema source
+-- for sqlc; existing volumes/prod need a manual apply (the open versioned-migration
+-- -runner seam from AGENT.md) — apply this BEFORE rolling the new server binary,
+-- which references the new column via the users query (SELECT-based).
+
+ALTER TABLE users
+    ADD COLUMN resume_ats_analysis JSONB;

--- a/openspec/changes/cv-ats-score/tasks.md
+++ b/openspec/changes/cv-ats-score/tasks.md
@@ -26,18 +26,18 @@
 
 ## 5. Server LLM client (re-added, nil-safe)
 
-- [ ] 5.1 Re-add `config.Config` LLM/Langfuse fields + `config.Load`; re-add `cmd/server` `llm.NewClient` construction (nil-safe, gated on `LLM_*`) + Langfuse flush on shutdown; pass the client into `handler.Config`. Tests: config load; nil when unset.
+- [x] 5.1 Re-add `config.Config` LLM/Langfuse fields + `config.Load`; re-add `cmd/server` `llm.NewClient` construction (nil-safe, gated on `LLM_*`) + Langfuse flush on shutdown; pass the client into `handler.Config`. Tests: config load; nil when unset.
 
 ## 6. LLM analyzer + cache
 
-- [ ] 6.1 RED+GREEN: `atscheck.Analyzer` (mirrors old `coherence.go`) — `Analyze(ctx, cvText) → *Review{ContentQuality, Findings[]}` via `llm.Client` (nil ⇒ (nil,nil)); `GenerateJSON` + Sanitize (clamp 0-100, bound strings). Unit tests with a fake model.
-- [ ] 6.2 Migration `migrations/00NN_users_resume_ats_analysis.sql` — `ALTER TABLE users ADD COLUMN resume_ats_analysis JSONB;` (manual-apply BEFORE the Phase-2 binary; `SELECT *` users query). Add queries to set/clear/read it; `make sqlc`. Invalidate (clear) in `resume.Put`/`Delete`.
-- [ ] 6.3 GREEN: `POST /me/profiles/:id/ats-report` — read stored CV, `Analyze`, cache to `users.resume_ats_analysis`, return merged report (best-effort: LLM error ⇒ 200 deterministic). `GET` merges the cached review + folds `content_quality` into `Overall`.
+- [x] 6.1 RED+GREEN: `atscheck.Analyzer` (mirrors old `coherence.go`) — `Analyze(ctx, cvText) → *Review{ContentQuality, Findings[]}` via `llm.Client` (nil ⇒ (nil,nil)); `GenerateJSON` + Sanitize (clamp 0-100, bound strings). Unit tests with a fake model.
+- [x] 6.2 Migration `migrations/00NN_users_resume_ats_analysis.sql` — `ALTER TABLE users ADD COLUMN resume_ats_analysis JSONB;` (manual-apply BEFORE the Phase-2 binary; `SELECT *` users query). Add queries to set/clear/read it; `make sqlc`. Invalidate (clear) in `resume.Put`/`Delete`.
+- [x] 6.3 GREEN: `POST /me/profiles/:id/ats-report` — read stored CV, `Analyze`, cache to `users.resume_ats_analysis`, return merged report (best-effort: LLM error ⇒ 200 deterministic). `GET` merges the cached review + folds `content_quality` into `Overall`.
 
 ## 7. Frontend (AI review)
 
-- [ ] 7.1 Web: "Run AI review" button (POST) when LLM is enabled; render content-quality + findings/fixes; hide cleanly when no LLM. Update contracts/types.
+- [x] 7.1 Web: "Run AI review" button (POST) when LLM is enabled; render content-quality + findings/fixes; hide cleanly when no LLM. Update contracts/types.
 
 ## 8. Verify + ops
 
-- [ ] 8.1 `go build ./... && go vet ./... && go test ./...`; `svelte-check`; validate the LLM path with a fake + (locally) a real CV. Ops: apply the `users` migration before deploy; ensure `LLM_*` present in the app env to enable the AI layer (else deterministic-only). No reindex.
+- [x] 8.1 `go build ./... && go vet ./... && go test ./...`; `svelte-check`; validate the LLM path with a fake + (locally) a real CV. Ops: apply the `users` migration before deploy; ensure `LLM_*` present in the app env to enable the AI layer (else deterministic-only). No reindex.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -559,6 +559,18 @@ export function createApi(
     return res.data;
   }
 
+  /** Run the optional LLM qualitative review over the caller's stored CV; returns the
+   *  ATS report with content-quality + findings folded in (cached server-side). With no
+   *  LLM configured this is just the deterministic report. */
+  async function runATSReview(id: number, params?: URLSearchParams): Promise<ATSResponse> {
+    const qs = params?.toString();
+    const res = await request<{ data: ATSResponse }>(
+      `/api/v1/me/profiles/${id}/ats-report${qs ? `?${qs}` : ''}`,
+      { method: 'POST' },
+    );
+    return res.data;
+  }
+
   /** The caller's notification subscriptions (one per saved search + channel). */
   async function listSubscriptions(): Promise<Subscription[]> {
     const res = await request<{ data: Subscription[] }>('/api/v1/me/subscriptions');
@@ -729,6 +741,7 @@ export function createApi(
     extractResumeSkills,
     getProfileVerdict,
     getATSReport,
+    runATSReview,
     listSubscriptions,
     createSubscription,
     setSubscriptionActive,
@@ -801,6 +814,7 @@ export const {
   extractResumeSkills,
   getProfileVerdict,
   getATSReport,
+  runATSReview,
   listSubscriptions,
   createSubscription,
   setSubscriptionActive,

--- a/web/src/lib/components/ATSReportView.svelte
+++ b/web/src/lib/components/ATSReportView.svelte
@@ -8,6 +8,14 @@
   let { report }: { report: ATSReport } = $props();
 
   const checks = $derived(report.checks ?? []);
+  const findings = $derived(report.findings ?? []);
+
+  // Sub-scores: the AI content-quality bar appears only after an AI review has run.
+  const subScores = $derived([
+    { label: 'Readability', value: report.readability },
+    { label: 'Keyword match', value: report.keyword_match },
+    ...(report.content_quality != null ? [{ label: 'AI content', value: report.content_quality }] : []),
+  ]);
 
   function tone(score: number): string {
     if (score >= 75) return 'text-primary';
@@ -34,7 +42,7 @@
       <p class="text-sm font-medium">Overall ATS score</p>
     </div>
     <div class="grid gap-3">
-      {#each [{ label: 'Readability', value: report.readability }, { label: 'Keyword match', value: report.keyword_match }] as s (s.label)}
+      {#each subScores as s (s.label)}
         <div class="flex flex-col gap-2 rounded-xl border border-border bg-card p-4">
           <div class="flex items-baseline justify-between">
             <span class="text-3xl font-semibold tabular-nums leading-none">{s.value}%</span>
@@ -70,4 +78,19 @@
       </li>
     {/each}
   </ul>
+
+  <!-- AI findings (only after an AI review) -->
+  {#if findings.length > 0}
+    <div class="flex flex-col gap-2">
+      <h3 class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">AI suggestions</h3>
+      <ul class="flex flex-col gap-1.5">
+        {#each findings as f, i (i)}
+          <li class="flex items-start gap-2 text-sm text-muted-foreground">
+            <span class="mt-1 size-1.5 shrink-0 rounded-full bg-primary"></span>
+            <span class="leading-relaxed">{f}</span>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
 </div>

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -177,9 +177,15 @@ export interface Report {
   readability: number /* int */; // 0-100 structural pass-rate
   keyword_match: number /* int */; // 0-100 role skills present in the CV text
   checks: Check[];
+  /**
+   * ContentQuality/Findings are set only when the optional LLM review ran (see
+   * ApplyReview); nil/empty renders no AI section.
+   */
+  content_quality?: number /* int */;
+  findings?: string[];
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'breezy', 'careerplug', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'habr_career', 'himalayas', 'huntflow', 'icims', 'inhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamtailor', 'tecla', 'thehub', 'traffit', 'trakstar', 'ukg', 'vention', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'breezy', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'habr_career', 'himalayas', 'huntflow', 'icims', 'inhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamtailor', 'tecla', 'thehub', 'traffit', 'trakstar', 'ukg', 'vention', 'vouch', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];

--- a/web/src/routes/my/profiles/[id]/verdict/+page.svelte
+++ b/web/src/routes/my/profiles/[id]/verdict/+page.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
-  import { ArrowUp, FileText, RefreshCw } from '@lucide/svelte';
+  import { ArrowUp, FileText, RefreshCw, Sparkles } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { ApiError, extractResumeSkills, facetCounts, getATSReport, getProfileVerdict } from '$lib/api';
+  import {
+    ApiError,
+    extractResumeSkills,
+    facetCounts,
+    getATSReport,
+    getProfileVerdict,
+    runATSReview,
+  } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { categoryLabel } from '$lib/facets';
@@ -34,6 +41,30 @@
   let cvError = $state<string | null>(null);
   let fileInput = $state<HTMLInputElement | null>(null);
   let dragActive = $state(false);
+
+  // AI review state.
+  let reviewBusy = $state(false);
+  let reviewUnavailable = $state(false);
+
+  // Run the optional LLM review over the stored CV; folds content-quality + findings
+  // into the report. When the server has no LLM the report comes back unchanged — flag
+  // that so the UI stops offering the button.
+  async function runReview() {
+    reviewBusy = true;
+    reviewUnavailable = false;
+    try {
+      const params = filters ? filtersToParams(filters.applied) : undefined;
+      const next = await runATSReview(id, params);
+      ats = next;
+      if (next.has_cv && next.report && next.report.content_quality == null) {
+        reviewUnavailable = true;
+      }
+    } catch {
+      reviewUnavailable = true;
+    } finally {
+      reviewBusy = false;
+    }
+  }
 
   // Build the filter store once the profile is known, seeding its role from the
   // profile's specializations when the URL carries no category — so the panel opens on
@@ -185,10 +216,26 @@
               {#if ats?.has_cv && ats.report}
                 <div class="flex flex-col gap-4">
                   <ATSReportView report={ats.report} />
-                  <Button variant="ghost" onclick={() => fileInput?.click()} disabled={cvBusy}>
-                    <RefreshCw class="size-4 {cvBusy ? 'animate-spin' : ''}" />
-                    {cvBusy ? 'Uploading…' : 'Replace CV'}
-                  </Button>
+                  <div class="flex flex-wrap items-center gap-2">
+                    {#if ats.report.content_quality == null && !reviewUnavailable}
+                      <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
+                        <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                        {reviewBusy ? 'Reviewing…' : 'Run AI review'}
+                      </Button>
+                    {:else if ats.report.content_quality != null}
+                      <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
+                        <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                        {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
+                      </Button>
+                    {/if}
+                    <Button variant="ghost" onclick={() => fileInput?.click()} disabled={cvBusy}>
+                      <RefreshCw class="size-4 {cvBusy ? 'animate-spin' : ''}" />
+                      {cvBusy ? 'Uploading…' : 'Replace CV'}
+                    </Button>
+                  </div>
+                  {#if reviewUnavailable}
+                    <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
+                  {/if}
                 </div>
               {:else}
                 <div class="flex flex-col gap-2">


### PR DESCRIPTION
## Summary
Phase 2 of `cv-ats-score`: layers an **optional, nil-safe LLM qualitative review** on the deterministic CV ATS score (Phase 1, #405).

- **Re-adds a nil-safe server LLM client** — `config.Config` LLM/Langfuse fields + `cmd/server` `llm.NewClient` (source `"cv-ats"`, defer flush), gated on `LLM_*`. Unconfigured ⇒ deterministic score only (the exact prior behaviour).
- **`internal/atscheck.Analyzer`** — `Analyze(cvText) → Review{content_quality, findings}` via `GenerateJSON` (weak vs strong verbs, achievement-vs-responsibility bullets, garbled-text/multi-column flag, concrete fixes). Sanitised (clamp 0-100, trim/bound/cap findings). `Report.ApplyReview` folds content-quality into a 3-way `Overall` blend (0.45/0.30/0.25).
- **`POST /me/profiles/:id/ats-report`** — runs the review over the stored CV, caches it **per user** (`users.resume_ats_analysis` JSONB, migration `0041`), reused across profiles/roles. **Invalidated on CV change** (SetUserResume/ClearUserResume now null the column). Best-effort: LLM error ⇒ 200 deterministic. `GET` merges the cached review + folds content-quality.
- **Web:** "Run AI review" button + content-quality bar + AI-suggestions list; degrades cleanly (button hidden / "unavailable" note) when no LLM. Contracts regenerated.

## Migration safety
`users` queries are **column-explicit** (no `SELECT *`), so adding `resume_ats_analysis` is backward-compatible — **no 500 window**. Apply `0041` **before** the new binary (its ATS queries reference the column; the CV-upload path's `SetUserResume` also sets it).

## Ops
- Apply `migrations/0041_users_resume_ats_analysis.sql` before deploy.
- Set `LLM_*` in the **app** container env to enable the AI layer (else deterministic-only). Same creds the enrich worker uses.
- **No reindex** (no Meili change).

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` — 50 pkg ok, 0 fail (analyzer parse/sanitize/nil; POST review+cache; POST no-LLM degrade)
- [x] `svelte-check` — 0 errors / 0 warnings
- [ ] Live: upload a CV → "Run AI review" → content-quality + suggestions render; replace CV → review clears