### PR TITLE
refactor(web): tab the verdict page + tidy profile card & headings

### DIFF
--- a/web/src/lib/components/SearchProfilesView.svelte
+++ b/web/src/lib/components/SearchProfilesView.svelte
@@ -143,31 +143,34 @@
                   </span>
                 {/each}
               </div>
-              <div class="flex flex-wrap gap-1">
-                {#each profile.skills as skill (skill)}
+              <div class="flex flex-wrap items-center gap-1">
+                {#each profile.skills.slice(0, 12) as skill (skill)}
                   <span
                     class="rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground"
                   >
                     {skill}
                   </span>
                 {/each}
+                {#if profile.skills.length > 12}
+                  <span class="px-1 text-xs text-muted-foreground">
+                    +{profile.skills.length - 12} more
+                  </span>
+                {/if}
               </div>
               {#if cov && cov.total > 0}
-                <div class="mt-1 flex flex-col gap-1">
-                  <div class="flex items-center gap-2">
-                    <span
-                      class="whitespace-nowrap text-xs text-muted-foreground"
-                      title="{cov.covered} of {cov.total} open vacancies"
-                    >
-                      Coverage {cov.coverage_percent}% · {cov.covered.toLocaleString('en-US')}/{cov.total.toLocaleString('en-US')}
+                <div class="mt-2 flex flex-col gap-2">
+                  <div class="flex flex-col gap-1">
+                    <span class="text-xs text-muted-foreground">
+                      <span class="font-semibold text-foreground">{cov.coverage_percent}% coverage</span>
+                      · {cov.covered.toLocaleString('en-US')} of {cov.total.toLocaleString('en-US')} open vacancies
                     </span>
-                    <div class="h-1.5 flex-1 overflow-hidden rounded bg-secondary">
+                    <div class="h-1.5 overflow-hidden rounded bg-secondary">
                       <div class="h-full rounded bg-primary" style="width: {cov.coverage_percent}%"></div>
                     </div>
                   </div>
                   {#if cov.gaps.length > 0}
                     <div class="flex flex-wrap items-center gap-1">
-                      <span class="text-xs text-muted-foreground">Add:</span>
+                      <span class="text-xs text-muted-foreground">Add to reach more:</span>
                       {#each cov.gaps.slice(0, 5) as gap (gap.name)}
                         <a
                           href={jobsHref(profile.specializations, gap.name)}

--- a/web/src/lib/components/VerdictView.svelte
+++ b/web/src/lib/components/VerdictView.svelte
@@ -1,21 +1,17 @@
 <script lang="ts">
-  import { ArrowLeft, Check, TrendingUp } from '@lucide/svelte';
+  import { Check, TrendingUp } from '@lucide/svelte';
   import type { Verdict } from '$lib/types';
   import { Badge } from '$lib/ui';
 
   // The verdict is the backend's market-coverage computation for the selected role:
   // how many of the role's open vacancies the profile's skills reach, and which missing
-  // skill unlocks the most new vacancies. `role` is a humanized label for the header;
-  // `gapHref`, when given, links a gap skill to the matching job search.
+  // skill unlocks the most new vacancies. `gapHref`, when given, links a gap skill to
+  // the matching job search. The page owns the header/tabs; this renders the body.
   let {
     verdict,
-    name,
-    role,
     gapHref,
   }: {
     verdict: Verdict;
-    name: string;
-    role: string;
     gapHref?: (skill: string) => string;
   } = $props();
 
@@ -24,21 +20,6 @@
 </script>
 
 <div class="flex flex-col gap-8">
-  <!-- Header -->
-  <div class="flex flex-col gap-3">
-    <a
-      href="/my/profiles"
-      class="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-    >
-      <ArrowLeft class="size-4" />
-      Profiles
-    </a>
-    <div class="flex flex-col gap-1">
-      <h1 class="text-3xl font-semibold tracking-tight">Your market coverage</h1>
-      <p class="text-sm text-muted-foreground">{name}{role ? ` · ${role}` : ''}</p>
-    </div>
-  </div>
-
   <!-- Coverage headline -->
   <div class="flex flex-col gap-4 rounded-xl border border-border bg-card p-6 animate-in fade-in slide-in-from-bottom-2 duration-500">
     <div class="flex flex-wrap items-end justify-between gap-2">
@@ -66,9 +47,7 @@
     <div class="flex flex-col gap-3">
       <div class="flex items-center gap-2">
         <TrendingUp class="size-4 text-muted-foreground" />
-        <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-          Add a skill · what unlocks the most vacancies
-        </h2>
+        <h2 class="text-base font-semibold tracking-tight">Add a skill to reach more vacancies</h2>
       </div>
       <ul class="flex flex-col gap-2">
         {#each gaps as gap, i (gap.name)}

--- a/web/src/routes/my/profiles/[id]/verdict/+page.svelte
+++ b/web/src/routes/my/profiles/[id]/verdict/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ArrowUp, FileText, RefreshCw, Sparkles } from '@lucide/svelte';
+  import { ArrowLeft, ArrowUp, FileText, Sparkles } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import {
@@ -35,6 +35,7 @@
   let counts = $state<FacetCounts | null>(null);
   let ats = $state<ATSResponse | null>(null);
   let loadError = $state(false);
+  let tab = $state<'coverage' | 'cv'>('coverage');
 
   // CV upload state (the ATS report needs a stored CV).
   let cvBusy = $state(false);
@@ -195,99 +196,135 @@
       <aside class="md:sticky md:top-6 md:self-start">
         <FiltersPanel store={filters} exclude={excludeFacets} {counts} />
       </aside>
-      <main>
+      <main class="flex flex-col gap-6">
+        <!-- Page header -->
+        <div class="flex flex-col gap-3">
+          <a
+            href="/my/profiles"
+            class="inline-flex w-fit items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft class="size-4" />
+            Profiles
+          </a>
+          <div class="flex flex-col gap-1">
+            <h1 class="text-3xl font-semibold tracking-tight">{profile.name}</h1>
+            {#if role}<p class="text-sm text-muted-foreground">{role}</p>{/if}
+          </div>
+        </div>
+
+        <!-- Tabs -->
+        <div class="flex gap-5 border-b border-border">
+          <button
+            type="button"
+            onclick={() => (tab = 'coverage')}
+            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            Market coverage
+          </button>
+          <button
+            type="button"
+            onclick={() => (tab = 'cv')}
+            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'cv'
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            CV readiness
+          </button>
+        </div>
+
+        <!-- Body -->
         {#if loadError}
-          <States state="error" message="Couldn't load the coverage." />
+          <States state="error" message="Couldn't load the report." />
         {:else if verdict === null}
           <States state="loading" />
+        {:else if tab === 'coverage'}
+          <VerdictView {verdict} {gapHref} />
         {:else}
-          <div class="flex flex-col gap-10">
-            <VerdictView {verdict} name={profile.name} {role} {gapHref} />
-
-            <!-- CV readiness (ATS report). Needs a stored CV; prompt an upload when absent. -->
-            <div class="border-t border-border pt-8">
-              <input
-                type="file"
-                accept="application/pdf,.pdf"
-                class="hidden"
-                bind:this={fileInput}
-                onchange={onCVFile}
-              />
-              {#if ats?.has_cv && ats.report}
-                <div class="flex flex-col gap-4">
-                  <ATSReportView report={ats.report} />
-                  <div class="flex flex-wrap items-center gap-2">
-                    {#if ats.report.content_quality == null && !reviewUnavailable}
-                      <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
-                        <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                        {reviewBusy ? 'Reviewing…' : 'Run AI review'}
-                      </Button>
-                    {:else if ats.report.content_quality != null}
-                      <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
-                        <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                        {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
-                      </Button>
-                    {/if}
-                    <Button variant="ghost" onclick={() => fileInput?.click()} disabled={cvBusy}>
-                      <RefreshCw class="size-4 {cvBusy ? 'animate-spin' : ''}" />
-                      {cvBusy ? 'Uploading…' : 'Replace CV'}
-                    </Button>
-                  </div>
-                  {#if reviewUnavailable}
-                    <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
-                  {/if}
-                </div>
-              {:else}
-                <div class="flex flex-col gap-2">
-                  <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-                    CV readiness
-                  </h2>
-                  <button
-                    type="button"
-                    onclick={() => fileInput?.click()}
-                    ondragover={(e) => {
-                      e.preventDefault();
-                      dragActive = true;
-                    }}
-                    ondragleave={(e) => {
-                      e.preventDefault();
-                      dragActive = false;
-                    }}
-                    ondrop={onDrop}
-                    disabled={cvBusy}
-                    class="flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-8 text-center transition-colors disabled:opacity-70 {dragActive
-                      ? 'border-primary bg-primary/5'
-                      : 'border-border hover:border-primary/60'}"
-                  >
-                    <span class="flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                      {#if cvBusy}
-                        <FileText class="size-5" />
-                      {:else}
-                        <ArrowUp class="size-5" />
-                      {/if}
-                    </span>
-                    <span class="flex flex-col gap-0.5">
-                      <span class="text-sm font-semibold">
-                        {cvBusy ? 'Reading your CV…' : 'Upload your CV to score it'}
-                      </span>
-                      {#if !cvBusy}
-                        <span class="text-xs text-muted-foreground">
-                          Drop a PDF here, or <span class="text-primary underline">choose from disk</span>
-                        </span>
-                      {/if}
-                    </span>
-                  </button>
-                  <span class="text-xs text-muted-foreground">
-                    Checks ATS readability + this role's keywords. Parsed on the server; CV text is
-                    not stored.
-                  </span>
-                </div>
+          <!-- CV readiness -->
+          <input
+            type="file"
+            accept="application/pdf,.pdf"
+            class="hidden"
+            bind:this={fileInput}
+            onchange={onCVFile}
+          />
+          {#if ats?.has_cv && ats.report}
+            <div class="flex flex-col gap-5">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <p class="text-sm text-muted-foreground">How ATS-ready your CV is for this role.</p>
+                {#if ats.report.content_quality == null && !reviewUnavailable}
+                  <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
+                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                    {reviewBusy ? 'Reviewing…' : 'Run AI review'}
+                  </Button>
+                {:else if ats.report.content_quality != null}
+                  <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
+                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                    {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
+                  </Button>
+                {/if}
+              </div>
+              {#if reviewUnavailable}
+                <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
               {/if}
-              {#if cvError}
-                <p class="mt-2 text-sm text-destructive">{cvError}</p>
-              {/if}
+              <ATSReportView report={ats.report} />
+              <button
+                type="button"
+                onclick={() => fileInput?.click()}
+                disabled={cvBusy}
+                class="w-fit text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline disabled:opacity-70"
+              >
+                {cvBusy ? 'Uploading…' : 'Replace CV'}
+              </button>
             </div>
-          </div>
+          {:else}
+            <div class="flex flex-col gap-2">
+              <button
+                type="button"
+                onclick={() => fileInput?.click()}
+                ondragover={(e) => {
+                  e.preventDefault();
+                  dragActive = true;
+                }}
+                ondragleave={(e) => {
+                  e.preventDefault();
+                  dragActive = false;
+                }}
+                ondrop={onDrop}
+                disabled={cvBusy}
+                class="flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-10 text-center transition-colors disabled:opacity-70 {dragActive
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:border-primary/60'}"
+              >
+                <span class="flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                  {#if cvBusy}
+                    <FileText class="size-5" />
+                  {:else}
+                    <ArrowUp class="size-5" />
+                  {/if}
+                </span>
+                <span class="flex flex-col gap-0.5">
+                  <span class="text-sm font-semibold">
+                    {cvBusy ? 'Reading your CV…' : 'Upload your CV to score it'}
+                  </span>
+                  {#if !cvBusy}
+                    <span class="text-xs text-muted-foreground">
+                      Drop a PDF here, or <span class="text-primary underline">choose from disk</span>
+                    </span>
+                  {/if}
+                </span>
+              </button>
+              <span class="text-xs text-muted-foreground">
+                Checks ATS readability + this role's keywords. Parsed on the server; CV text is not
+                stored.
+              </span>
+            </div>
+          {/if}
+          {#if cvError}
+            <p class="mt-2 text-sm text-destructive">{cvError}</p>
+          {/if}
         {/if}
       </main>
     </div>


### PR DESCRIPTION
Frontend-only polish of the just-shipped CV-ATS / coverage screens (no backend changes).

## Verdict page
- **Tabs:** "Market coverage" / "CV readiness" under a shared header (profile name + role) and the role-filter sidebar — the two long stacked sections were weakly structured.
- **CV readiness tab:** "Run AI review" is a prominent action at the **top** of the tab; **"Replace CV"** demoted from a competing button to a quiet text link at the bottom.
- **"Add a skill…" heading:** dropped the shouty uppercase/wide-tracking micro-caps for a normal subheading ("Add a skill to reach more vacancies").
- `VerdictView` is now body-only (the page owns the header).

## Profile card
- Cap the skill wall at **12 chips + "+N more"** (CV-derived skill lists were dozens long and dominated the card).
- Clearer coverage line: **bold percent** + "X of Y open vacancies".

## Test Plan
- [x] `svelte-check` — 0 errors / 0 warnings
- [ ] Live: verdict page tabs switch; Run AI review at top; Replace CV subtle; profile card reads cleanly