### PR TITLE
feat(companies): one-time company-info backfill

### DIFF
--- a/cmd/backfill-company-info/main.go
+++ b/cmd/backfill-company-info/main.go
@@ -1,0 +1,234 @@
+// Command backfill-company-info is a one-time host worker that loads company-info
+// records from a local JSONL dataset into the companies table. Each record is matched
+// to a company by its normalized-name slug: an existing company (job-backed or a prior
+// reference) has only its company-info columns refreshed, and an unmatched record is
+// inserted as a reference row (is_reference = true) with no jobs, which a later job for
+// the same slug adopts. The loader is source-agnostic — the dataset's origin is named
+// nowhere — and idempotent: re-running the same file rewrites the same values.
+//
+//	backfill-company-info <path/to/records.jsonl>   # needs DATABASE_URL
+//
+// Company-info columns are independent of the job-derived facet columns; this worker
+// never touches job_count, collections, or those facets. Unknown source values are
+// stored as NULL (or omitted from the company_info JSONB) so "unknown" stays distinct
+// from a real value.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/normalize"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// record is one line of the dataset. Only these fields are consumed; unknown fields
+// are ignored. Numeric fields that are absent/null decode to their zero value, which
+// the mapping treats as "unknown".
+type record struct {
+	Name             string   `json:"name"`
+	HomepageURI      string   `json:"homepage_uri"`
+	HQCountry        string   `json:"hq_country"`
+	ParentCompany    string   `json:"parent_company"`
+	Subsidiaries     []string `json:"subsidiaries"`
+	Industries       []string `json:"industries"`
+	Activities       []string `json:"activities"`
+	NbEmployees      int      `json:"nb_employees"`
+	YearFounded      int      `json:"year_founded"`
+	Tagline          string   `json:"tagline"`
+	OrganizationType string   `json:"organization_type"`
+	FundingInvestors []string `json:"latest_funding_investors"`
+	FundingType      string   `json:"latest_funding_type"`
+	FundingYear      int      `json:"latest_funding_year"`
+	FundingAmount    int64    `json:"latest_funding_amount"`
+	StockExchange    string   `json:"stock_exchange"`
+	StockSymbol      string   `json:"stock_symbol"`
+}
+
+// store is the slice of the data layer the loader needs; *db.Queries satisfies it and
+// tests use a fake.
+type store interface {
+	CompanyExists(ctx context.Context, slug string) (bool, error)
+	UpsertCompanyInfo(ctx context.Context, arg db.UpsertCompanyInfoParams) error
+}
+
+func main() { worker.Main(run) }
+
+func run() int {
+	if len(os.Args) < 2 {
+		log.Printf("usage: backfill-company-info <path/to/records.jsonl>")
+		return 2
+	}
+	path := os.Args[1]
+
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	f, err := os.Open(path)
+	if err != nil {
+		log.Printf("open %s: %v", path, err)
+		return 1
+	}
+	defer f.Close()
+
+	stats, err := load(ctx, db.New(pool), f)
+	if err != nil {
+		log.Printf("backfill-company-info: %v", err)
+		return 1
+	}
+	log.Printf("backfill-company-info done: applied=%d matched-existing=%d inserted-reference=%d skipped=%d",
+		stats.applied, stats.matched, stats.inserted, stats.skipped)
+	return 0
+}
+
+type loadStats struct{ applied, matched, inserted, skipped int }
+
+// load streams the JSONL dataset, upserting each valid record's company-info by slug and
+// tallying matched-existing vs inserted-reference for the report. A blank-name/blank-slug
+// or unparseable line is skipped, not fatal.
+func load(ctx context.Context, s store, r io.Reader) (loadStats, error) {
+	var stats loadStats
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024) // records run a few KB
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var rec record
+		if err := json.Unmarshal(line, &rec); err != nil {
+			stats.skipped++
+			continue
+		}
+		params, ok := recordToParams(rec)
+		if !ok {
+			stats.skipped++
+			continue
+		}
+		exists, err := s.CompanyExists(ctx, params.Slug)
+		if err != nil {
+			return stats, err
+		}
+		if err := s.UpsertCompanyInfo(ctx, params); err != nil {
+			return stats, err
+		}
+		stats.applied++
+		if exists {
+			stats.matched++
+		} else {
+			stats.inserted++
+		}
+		if stats.applied%5000 == 0 {
+			log.Printf("backfill-company-info: applied=%d matched=%d inserted=%d",
+				stats.applied, stats.matched, stats.inserted)
+		}
+	}
+	return stats, sc.Err()
+}
+
+// recordToParams maps a dataset record to upsert params, returning ok=false for a
+// record with no usable name (empty slug). Empty/zero source values become NULL, and
+// the low-coverage extras are assembled into the company_info JSONB.
+func recordToParams(r record) (db.UpsertCompanyInfoParams, bool) {
+	name := strings.TrimSpace(r.Name)
+	slug := normalize.Slug(name)
+	if slug == "" {
+		return db.UpsertCompanyInfoParams{}, false
+	}
+	industries := r.Industries
+	if industries == nil {
+		industries = []string{} // NOT NULL column: send '{}', not NULL
+	}
+	return db.UpsertCompanyInfoParams{
+		Slug:             slug,
+		Name:             name,
+		Industries:       industries,
+		YearFounded:      int4(r.YearFounded),
+		EmployeeCount:    int4(r.NbEmployees),
+		HqCountry:        text(r.HQCountry),
+		OrganizationType: text(r.OrganizationType),
+		Tagline:          text(r.Tagline),
+		CompanyInfo:      companyInfoJSON(r),
+	}, true
+}
+
+// companyInfoJSON assembles the low-coverage extras into the company_info JSONB,
+// omitting empty values so absent facts stay absent rather than empty sentinels. An
+// all-empty record yields "{}".
+func companyInfoJSON(r record) json.RawMessage {
+	m := map[string]any{}
+	if v := strings.TrimSpace(r.HomepageURI); v != "" {
+		m["homepage"] = v
+	}
+	if v := strings.TrimSpace(r.ParentCompany); v != "" {
+		m["parent_company"] = v
+	}
+	if len(r.Subsidiaries) > 0 {
+		m["subsidiaries"] = r.Subsidiaries
+	}
+	if len(r.Activities) > 0 {
+		m["activities"] = r.Activities
+	}
+	funding := map[string]any{}
+	if v := strings.TrimSpace(r.FundingType); v != "" {
+		funding["type"] = v
+	}
+	if r.FundingAmount > 0 {
+		funding["amount"] = r.FundingAmount
+	}
+	if r.FundingYear > 0 {
+		funding["year"] = r.FundingYear
+	}
+	if len(r.FundingInvestors) > 0 {
+		funding["investors"] = r.FundingInvestors
+	}
+	if len(funding) > 0 {
+		m["funding"] = funding
+	}
+	if v := strings.TrimSpace(r.StockSymbol); v != "" {
+		stock := map[string]any{"symbol": v}
+		if e := strings.TrimSpace(r.StockExchange); e != "" {
+			stock["exchange"] = e
+		}
+		m["stock"] = stock
+	}
+	if len(m) == 0 {
+		return json.RawMessage("{}")
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return json.RawMessage("{}")
+	}
+	return b
+}
+
+// text maps an optional string to a nullable pgtype.Text; blank becomes SQL NULL.
+func text(s string) pgtype.Text {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: s, Valid: true}
+}
+
+// int4 maps an optional positive int to a nullable pgtype.Int4; a non-positive value
+// (absent headcount / founding year) becomes SQL NULL.
+func int4(n int) pgtype.Int4 {
+	if n <= 0 {
+		return pgtype.Int4{}
+	}
+	return pgtype.Int4{Int32: int32(n), Valid: true}
+}

--- a/cmd/backfill-company-info/main.go
+++ b/cmd/backfill-company-info/main.go
@@ -36,20 +36,20 @@ import (
 // the mapping treats as "unknown".
 type record struct {
 	Name             string   `json:"name"`
-	HomepageURI      string   `json:"homepage_uri"`
-	HQCountry        string   `json:"hq_country"`
-	ParentCompany    string   `json:"parent_company"`
+	HomepageURI      string   `json:"website"`
+	HQCountry        string   `json:"country"`
+	ParentCompany    string   `json:"parent"`
 	Subsidiaries     []string `json:"subsidiaries"`
 	Industries       []string `json:"industries"`
 	Activities       []string `json:"activities"`
-	NbEmployees      int      `json:"nb_employees"`
-	YearFounded      int      `json:"year_founded"`
+	NbEmployees      int      `json:"employees"`
+	YearFounded      int      `json:"founded"`
 	Tagline          string   `json:"tagline"`
-	OrganizationType string   `json:"organization_type"`
-	FundingInvestors []string `json:"latest_funding_investors"`
-	FundingType      string   `json:"latest_funding_type"`
-	FundingYear      int      `json:"latest_funding_year"`
-	FundingAmount    int64    `json:"latest_funding_amount"`
+	OrganizationType string   `json:"org_type"`
+	FundingInvestors []string `json:"funding_investors"`
+	FundingType      string   `json:"funding_type"`
+	FundingYear      int      `json:"funding_year"`
+	FundingAmount    int64    `json:"funding_amount"`
 	StockExchange    string   `json:"stock_exchange"`
 	StockSymbol      string   `json:"stock_symbol"`
 }

--- a/cmd/backfill-company-info/main_test.go
+++ b/cmd/backfill-company-info/main_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestRecordToParams_Full(t *testing.T) {
+	rec := record{
+		Name:             "Acme Corp",
+		HomepageURI:      "acme.com",
+		HQCountry:        "US",
+		ParentCompany:    "Acme Holdings",
+		Subsidiaries:     []string{"Acme Labs"},
+		Industries:       []string{"Software", "Fintech"},
+		Activities:       []string{"Builds widgets"},
+		NbEmployees:      500,
+		YearFounded:      1999,
+		Tagline:          "We do things",
+		OrganizationType: "Private",
+		FundingType:      "Series B",
+		FundingYear:      2020,
+		FundingAmount:    250000000,
+		FundingInvestors: []string{"VC One"},
+		StockExchange:    "NASDAQ",
+		StockSymbol:      "ACME",
+	}
+	p, ok := recordToParams(rec)
+	if !ok {
+		t.Fatal("ok = false, want true for a named record")
+	}
+	if p.Slug != "acme-corp" {
+		t.Errorf("slug = %q, want normalized \"acme-corp\"", p.Slug)
+	}
+	if p.Name != "Acme Corp" {
+		t.Errorf("name = %q", p.Name)
+	}
+	if !p.YearFounded.Valid || p.YearFounded.Int32 != 1999 {
+		t.Errorf("year_founded = %+v", p.YearFounded)
+	}
+	if !p.EmployeeCount.Valid || p.EmployeeCount.Int32 != 500 {
+		t.Errorf("employee_count = %+v", p.EmployeeCount)
+	}
+	if !p.HqCountry.Valid || p.HqCountry.String != "US" {
+		t.Errorf("hq_country = %+v", p.HqCountry)
+	}
+	if !reflect.DeepEqual(p.Industries, []string{"Software", "Fintech"}) {
+		t.Errorf("industries = %v", p.Industries)
+	}
+
+	var info map[string]any
+	if err := json.Unmarshal(p.CompanyInfo, &info); err != nil {
+		t.Fatalf("company_info not valid JSON: %v", err)
+	}
+	if info["homepage"] != "acme.com" || info["parent_company"] != "Acme Holdings" {
+		t.Errorf("company_info missing homepage/parent: %v", info)
+	}
+	funding, _ := info["funding"].(map[string]any)
+	if funding == nil || funding["type"] != "Series B" {
+		t.Errorf("funding block wrong: %v", info["funding"])
+	}
+	stock, _ := info["stock"].(map[string]any)
+	if stock == nil || stock["symbol"] != "ACME" || stock["exchange"] != "NASDAQ" {
+		t.Errorf("stock block wrong: %v", info["stock"])
+	}
+}
+
+func TestRecordToParams_EmptyValuesBecomeNullAndEmptyJSON(t *testing.T) {
+	rec := record{Name: "Bare Co"} // everything else zero
+	p, ok := recordToParams(rec)
+	if !ok {
+		t.Fatal("ok = false, want true")
+	}
+	if p.YearFounded.Valid || p.EmployeeCount.Valid {
+		t.Error("zero numerics should be NULL, not set")
+	}
+	if p.HqCountry.Valid || p.OrganizationType.Valid || p.Tagline.Valid {
+		t.Error("blank strings should be NULL, not set")
+	}
+	if p.Industries == nil {
+		t.Error("industries must be non-nil ([]string{}) for the NOT NULL column")
+	}
+	if len(p.Industries) != 0 {
+		t.Errorf("industries = %v, want empty", p.Industries)
+	}
+	if string(p.CompanyInfo) != "{}" {
+		t.Errorf("company_info = %s, want {}", p.CompanyInfo)
+	}
+}
+
+func TestRecordToParams_BlankNameSkipped(t *testing.T) {
+	for _, name := range []string{"", "   ", "!!!"} {
+		if _, ok := recordToParams(record{Name: name}); ok {
+			t.Errorf("recordToParams(name=%q) ok = true, want false (empty slug)", name)
+		}
+	}
+}

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -7,9 +7,24 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+const companyExists = `-- name: CompanyExists :one
+SELECT EXISTS(SELECT 1 FROM companies WHERE slug = $1)
+`
+
+// Whether a company row already exists for the slug. The backfill checks this
+// before upserting to log matched-existing vs inserted-reference counts — the
+// upsert itself is blind to which path (insert or update) it took.
+func (q *Queries) CompanyExists(ctx context.Context, slug string) (bool, error) {
+	row := q.db.QueryRow(ctx, companyExists, slug)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
 
 const companySitemapBoundaries = `-- name: CompanySitemapBoundaries :many
 SELECT slug FROM (
@@ -87,11 +102,14 @@ func (q *Queries) CountCompanies(ctx context.Context, arg CountCompaniesParams) 
 
 const deleteOrphanCompanies = `-- name: DeleteOrphanCompanies :execrows
 DELETE FROM companies c
-WHERE NOT EXISTS (SELECT 1 FROM jobs j WHERE j.company_slug = c.slug)
+WHERE NOT c.is_reference
+  AND NOT EXISTS (SELECT 1 FROM jobs j WHERE j.company_slug = c.slug)
 `
 
 // Drop companies no longer referenced by any job — the stale rows left behind
-// when a slug-builder change re-keys jobs onto new slugs.
+// when a slug-builder change re-keys jobs onto new slugs. Reference rows imported
+// by the company-info backfill are preserved: they intentionally have no job, so
+// the NOT is_reference guard keeps the backfill directory from being swept away.
 func (q *Queries) DeleteOrphanCompanies(ctx context.Context) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteOrphanCompanies)
 	if err != nil {
@@ -101,7 +119,7 @@ func (q *Queries) DeleteOrphanCompanies(ctx context.Context) (int64, error) {
 }
 
 const getCompany = `-- name: GetCompany :one
-SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes
+SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes, industries, year_founded, employee_count, hq_country, organization_type, tagline, company_info, is_reference, company_info_at
 FROM companies
 WHERE slug = $1
 `
@@ -124,6 +142,15 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 		&i.Domains,
 		&i.CompanyTypes,
 		&i.CompanySizes,
+		&i.Industries,
+		&i.YearFounded,
+		&i.EmployeeCount,
+		&i.HqCountry,
+		&i.OrganizationType,
+		&i.Tagline,
+		&i.CompanyInfo,
+		&i.IsReference,
+		&i.CompanyInfoAt,
 	)
 	return i, err
 }
@@ -394,5 +421,58 @@ ON CONFLICT (slug) DO UPDATE SET
 // name variants; ON CONFLICT folds collisions and refreshes existing rows.
 func (q *Queries) SyncCompaniesFromJobs(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, syncCompaniesFromJobs)
+	return err
+}
+
+const upsertCompanyInfo = `-- name: UpsertCompanyInfo :exec
+INSERT INTO companies (
+    slug, name, industries, year_founded, employee_count, hq_country,
+    organization_type, tagline, company_info, is_reference, company_info_at
+) VALUES (
+    $1, $2, $3, $4,
+    $5, $6, $7,
+    $8, $9, true, now()
+)
+ON CONFLICT (slug) DO UPDATE SET
+    industries        = EXCLUDED.industries,
+    year_founded      = EXCLUDED.year_founded,
+    employee_count    = EXCLUDED.employee_count,
+    hq_country        = EXCLUDED.hq_country,
+    organization_type = EXCLUDED.organization_type,
+    tagline           = EXCLUDED.tagline,
+    company_info      = EXCLUDED.company_info,
+    company_info_at   = now(),
+    updated_at        = now()
+`
+
+type UpsertCompanyInfoParams struct {
+	Slug             string          `json:"slug"`
+	Name             string          `json:"name"`
+	Industries       []string        `json:"industries"`
+	YearFounded      pgtype.Int4     `json:"year_founded"`
+	EmployeeCount    pgtype.Int4     `json:"employee_count"`
+	HqCountry        pgtype.Text     `json:"hq_country"`
+	OrganizationType pgtype.Text     `json:"organization_type"`
+	Tagline          pgtype.Text     `json:"tagline"`
+	CompanyInfo      json.RawMessage `json:"company_info"`
+}
+
+// Apply one external-dataset company-info record, matched by slug. A new slug is
+// inserted as a reference row (is_reference = true) with no jobs; an existing slug
+// (job-backed or a prior reference) has only its company-info columns refreshed —
+// name, job_count, collections, is_reference, and the job-derived facet arrays are
+// left untouched. Idempotent: re-running the same record rewrites the same values.
+func (q *Queries) UpsertCompanyInfo(ctx context.Context, arg UpsertCompanyInfoParams) error {
+	_, err := q.db.Exec(ctx, upsertCompanyInfo,
+		arg.Slug,
+		arg.Name,
+		arg.Industries,
+		arg.YearFounded,
+		arg.EmployeeCount,
+		arg.HqCountry,
+		arg.OrganizationType,
+		arg.Tagline,
+		arg.CompanyInfo,
+	)
 	return err
 }

--- a/internal/db/company_info_integration_test.go
+++ b/internal/db/company_info_integration_test.go
@@ -1,0 +1,184 @@
+//go:build integration
+
+// Integration tests for the company-info backfill query semantics: UpsertCompanyInfo
+// inserts an unmatched slug as a reference row and refreshes only the company-info
+// columns of an existing one (leaving job_count and the job-derived facets untouched),
+// is idempotent, and DeleteOrphanCompanies preserves reference rows while still
+// sweeping jobless non-reference companies. This is SQL behavior, verified against a
+// real Postgres. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// companyInfoHomepage reads the homepage out of the stored company_info JSONB. It
+// parses rather than string-compares because Postgres re-serializes JSONB (key order
+// and spacing are not preserved).
+func companyInfoHomepage(t *testing.T, raw []byte) string {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("company_info not valid JSON (%s): %v", raw, err)
+	}
+	s, _ := m["homepage"].(string)
+	return s
+}
+
+func sampleCompanyInfo(slug, name string) UpsertCompanyInfoParams {
+	return UpsertCompanyInfoParams{
+		Slug:             slug,
+		Name:             name,
+		Industries:       []string{"Software", "Fintech"},
+		YearFounded:      pgtype.Int4{Int32: 1999, Valid: true},
+		EmployeeCount:    pgtype.Int4{Int32: 500, Valid: true},
+		HqCountry:        pgtype.Text{String: "US", Valid: true},
+		OrganizationType: pgtype.Text{String: "Private", Valid: true},
+		Tagline:          pgtype.Text{String: "We do things", Valid: true},
+		CompanyInfo:      json.RawMessage(`{"homepage":"acme.com"}`),
+	}
+}
+
+func TestUpsertCompanyInfo(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, "TRUNCATE companies RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	t.Run("unmatched slug is inserted as a reference row", func(t *testing.T) {
+		if err := q.UpsertCompanyInfo(ctx, sampleCompanyInfo("acme", "Acme Corp")); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+		c, err := q.GetCompany(ctx, "acme")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if !c.IsReference {
+			t.Error("is_reference = false, want true for an inserted reference row")
+		}
+		if c.JobCount != 0 {
+			t.Errorf("job_count = %d, want 0", c.JobCount)
+		}
+		if len(c.Industries) != 2 || c.YearFounded.Int32 != 1999 || c.EmployeeCount.Int32 != 500 {
+			t.Errorf("company-info columns not set: %+v", c)
+		}
+		if c.HqCountry.String != "US" || c.OrganizationType.String != "Private" {
+			t.Errorf("hq/org not set: %q %q", c.HqCountry.String, c.OrganizationType.String)
+		}
+		if got := companyInfoHomepage(t, c.CompanyInfo); got != "acme.com" {
+			t.Errorf("company_info homepage = %q (raw %s)", got, c.CompanyInfo)
+		}
+		if !c.CompanyInfoAt.Valid {
+			t.Error("company_info_at not stamped")
+		}
+	})
+
+	t.Run("existing company is enriched without disturbing jobs or facets", func(t *testing.T) {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO companies (slug, name, job_count, company_types, company_sizes)
+			 VALUES ('globex', 'Globex', 7, ARRAY['Public'], ARRAY['201-500'])`); err != nil {
+			t.Fatalf("seed globex: %v", err)
+		}
+		p := sampleCompanyInfo("globex", "Globex Renamed")
+		if err := q.UpsertCompanyInfo(ctx, p); err != nil {
+			t.Fatalf("upsert: %v", err)
+		}
+		c, err := q.GetCompany(ctx, "globex")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if c.IsReference {
+			t.Error("is_reference flipped to true on an existing company")
+		}
+		if c.JobCount != 7 {
+			t.Errorf("job_count = %d, want 7 (untouched)", c.JobCount)
+		}
+		if len(c.CompanyTypes) != 1 || c.CompanyTypes[0] != "Public" {
+			t.Errorf("company_types clobbered: %v", c.CompanyTypes)
+		}
+		if len(c.CompanySizes) != 1 || c.CompanySizes[0] != "201-500" {
+			t.Errorf("company_sizes clobbered: %v", c.CompanySizes)
+		}
+		if c.Name != "Globex" {
+			t.Errorf("name = %q, want unchanged \"Globex\" (display name is not overwritten)", c.Name)
+		}
+		if c.EmployeeCount.Int32 != 500 {
+			t.Errorf("company-info not applied: employee_count = %v", c.EmployeeCount)
+		}
+	})
+
+	t.Run("re-running is idempotent", func(t *testing.T) {
+		p := sampleCompanyInfo("acme", "Acme Corp")
+		if err := q.UpsertCompanyInfo(ctx, p); err != nil {
+			t.Fatalf("upsert 2: %v", err)
+		}
+		c, err := q.GetCompany(ctx, "acme")
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		if c.EmployeeCount.Int32 != 500 || companyInfoHomepage(t, c.CompanyInfo) != "acme.com" {
+			t.Errorf("idempotent re-run changed values: %+v", c)
+		}
+		// still exactly one acme row
+		var n int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM companies WHERE slug = 'acme'`).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 1 {
+			t.Errorf("acme row count = %d, want 1", n)
+		}
+	})
+}
+
+func TestCompanyExistsAndOrphanCleanupPreservesReference(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, "TRUNCATE companies RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "TRUNCATE jobs RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate jobs: %v", err)
+	}
+
+	// A job-backed company, a jobless non-reference orphan, and a jobless reference row.
+	insertCompany(t, pool, "withjob", "With Job")
+	insertJobWithFacets(t, pool, "j1", "withjob", []string{}, []string{}, "{}")
+	insertCompany(t, pool, "orphan", "Orphan Co") // is_reference defaults false
+	if err := q.UpsertCompanyInfo(ctx, sampleCompanyInfo("refco", "Ref Co")); err != nil {
+		t.Fatalf("upsert refco: %v", err)
+	}
+
+	t.Run("CompanyExists reflects presence", func(t *testing.T) {
+		for slug, want := range map[string]bool{"withjob": true, "refco": true, "missing": false} {
+			got, err := q.CompanyExists(ctx, slug)
+			if err != nil {
+				t.Fatalf("exists %s: %v", slug, err)
+			}
+			if got != want {
+				t.Errorf("CompanyExists(%q) = %v, want %v", slug, got, want)
+			}
+		}
+	})
+
+	t.Run("orphan cleanup deletes jobless non-reference only", func(t *testing.T) {
+		if _, err := q.DeleteOrphanCompanies(ctx); err != nil {
+			t.Fatalf("delete orphans: %v", err)
+		}
+		for slug, wantExists := range map[string]bool{"withjob": true, "refco": true, "orphan": false} {
+			got, err := q.CompanyExists(ctx, slug)
+			if err != nil {
+				t.Fatalf("exists %s: %v", slug, err)
+			}
+			if got != wantExists {
+				t.Errorf("after cleanup CompanyExists(%q) = %v, want %v", slug, got, wantExists)
+			}
+		}
+	})
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -22,17 +22,26 @@ type ApiKey struct {
 }
 
 type Company struct {
-	Slug         string             `json:"slug"`
-	Name         string             `json:"name"`
-	CreatedAt    pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt    pgtype.Timestamptz `json:"updated_at"`
-	Collections  []string           `json:"collections"`
-	JobCount     int32              `json:"job_count"`
-	Regions      []string           `json:"regions"`
-	Countries    []string           `json:"countries"`
-	Domains      []string           `json:"domains"`
-	CompanyTypes []string           `json:"company_types"`
-	CompanySizes []string           `json:"company_sizes"`
+	Slug             string             `json:"slug"`
+	Name             string             `json:"name"`
+	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	Collections      []string           `json:"collections"`
+	JobCount         int32              `json:"job_count"`
+	Regions          []string           `json:"regions"`
+	Countries        []string           `json:"countries"`
+	Domains          []string           `json:"domains"`
+	CompanyTypes     []string           `json:"company_types"`
+	CompanySizes     []string           `json:"company_sizes"`
+	Industries       []string           `json:"industries"`
+	YearFounded      pgtype.Int4        `json:"year_founded"`
+	EmployeeCount    pgtype.Int4        `json:"employee_count"`
+	HqCountry        pgtype.Text        `json:"hq_country"`
+	OrganizationType pgtype.Text        `json:"organization_type"`
+	Tagline          pgtype.Text        `json:"tagline"`
+	CompanyInfo      json.RawMessage    `json:"company_info"`
+	IsReference      bool               `json:"is_reference"`
+	CompanyInfoAt    pgtype.Timestamptz `json:"company_info_at"`
 }
 
 type EnrichmentOutbox struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -68,6 +68,10 @@ type Querier interface {
 	// caller owns the grace window (cutoff = now() - window) and the "run ingested
 	// something" guard, so a failed crawl never mass-closes that source's catalogue.
 	CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams) (int64, error)
+	// Whether a company row already exists for the slug. The backfill checks this
+	// before upserting to log matched-existing vs inserted-reference counts — the
+	// upsert itself is blind to which path (insert or update) it took.
+	CompanyExists(ctx context.Context, slug string) (bool, error)
 	// The slug ending every full chunk of `chunk_size` companies (ordered by slug),
 	// excluding the final row, so the sitemap index can list each company sub-sitemap's
 	// keyset cursor.
@@ -131,7 +135,9 @@ type Querier interface {
 	DeleteAPIKey(ctx context.Context, arg DeleteAPIKeyParams) (int64, error)
 	DeleteEnrichmentEntry(ctx context.Context, id int64) error
 	// Drop companies no longer referenced by any job — the stale rows left behind
-	// when a slug-builder change re-keys jobs onto new slugs.
+	// when a slug-builder change re-keys jobs onto new slugs. Reference rows imported
+	// by the company-info backfill are preserved: they intentionally have no job, so
+	// the NOT is_reference guard keeps the backfill directory from being swept away.
 	DeleteOrphanCompanies(ctx context.Context) (int64, error)
 	// Delete a saved search, scoped to its owner so a user can only delete their own.
 	// Returns the affected row count: 0 means it does not exist or is not the caller's
@@ -506,6 +512,12 @@ type Querier interface {
 	// combination in one call. No matching owner-scoped row returns no row (the handler
 	// maps that to 404).
 	UpdateSearchProfile(ctx context.Context, arg UpdateSearchProfileParams) (SearchProfile, error)
+	// Apply one external-dataset company-info record, matched by slug. A new slug is
+	// inserted as a reference row (is_reference = true) with no jobs; an existing slug
+	// (job-backed or a prior reference) has only its company-info columns refreshed —
+	// name, job_count, collections, is_reference, and the job-derived facet arrays are
+	// left untouched. Idempotent: re-running the same record rewrites the same values.
+	UpsertCompanyInfo(ctx context.Context, arg UpsertCompanyInfoParams) error
 	// Single atomic write: upsert the company (only when the slug is non-empty,
 	// via the WHERE on the SELECT) and the job together, keeping the "one write =
 	// one job" property of the pipeline's write path.

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -99,9 +99,43 @@ ON CONFLICT (slug) DO UPDATE SET
 
 -- name: DeleteOrphanCompanies :execrows
 -- Drop companies no longer referenced by any job — the stale rows left behind
--- when a slug-builder change re-keys jobs onto new slugs.
+-- when a slug-builder change re-keys jobs onto new slugs. Reference rows imported
+-- by the company-info backfill are preserved: they intentionally have no job, so
+-- the NOT is_reference guard keeps the backfill directory from being swept away.
 DELETE FROM companies c
-WHERE NOT EXISTS (SELECT 1 FROM jobs j WHERE j.company_slug = c.slug);
+WHERE NOT c.is_reference
+  AND NOT EXISTS (SELECT 1 FROM jobs j WHERE j.company_slug = c.slug);
+
+-- name: CompanyExists :one
+-- Whether a company row already exists for the slug. The backfill checks this
+-- before upserting to log matched-existing vs inserted-reference counts — the
+-- upsert itself is blind to which path (insert or update) it took.
+SELECT EXISTS(SELECT 1 FROM companies WHERE slug = $1);
+
+-- name: UpsertCompanyInfo :exec
+-- Apply one external-dataset company-info record, matched by slug. A new slug is
+-- inserted as a reference row (is_reference = true) with no jobs; an existing slug
+-- (job-backed or a prior reference) has only its company-info columns refreshed —
+-- name, job_count, collections, is_reference, and the job-derived facet arrays are
+-- left untouched. Idempotent: re-running the same record rewrites the same values.
+INSERT INTO companies (
+    slug, name, industries, year_founded, employee_count, hq_country,
+    organization_type, tagline, company_info, is_reference, company_info_at
+) VALUES (
+    sqlc.arg(slug), sqlc.arg(name), sqlc.arg(industries), sqlc.arg(year_founded),
+    sqlc.arg(employee_count), sqlc.arg(hq_country), sqlc.arg(organization_type),
+    sqlc.arg(tagline), sqlc.arg(company_info), true, now()
+)
+ON CONFLICT (slug) DO UPDATE SET
+    industries        = EXCLUDED.industries,
+    year_founded      = EXCLUDED.year_founded,
+    employee_count    = EXCLUDED.employee_count,
+    hq_country        = EXCLUDED.hq_country,
+    organization_type = EXCLUDED.organization_type,
+    tagline           = EXCLUDED.tagline,
+    company_info      = EXCLUDED.company_info,
+    company_info_at   = now(),
+    updated_at        = now();
 
 -- name: RefreshCompanyFacets :execrows
 -- Recompute every company's denormalized state in one set-based pass: the open-job

--- a/migrations/0042_company_info.sql
+++ b/migrations/0042_company_info.sql
@@ -1,0 +1,26 @@
+-- Authoritative company-info attributes, loaded by the one-time cmd/backfill-company-info
+-- worker from an external dataset. These are per-company facts (headcount, founding year,
+-- HQ, industry, organization type) that our own jobs can't supply, kept independent of the
+-- job-derived facet columns (company_types/company_sizes/countries/domains/regions): the
+-- periodic RefreshCompanyFacets never touches these, and the backfill never touches those.
+-- Unknown source values stay NULL (or absent from the JSONB) so "unknown" is distinguishable
+-- from a real value.
+ALTER TABLE companies
+    ADD COLUMN IF NOT EXISTS industries        TEXT[]      NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS year_founded      INT,
+    ADD COLUMN IF NOT EXISTS employee_count    INT,
+    ADD COLUMN IF NOT EXISTS hq_country        TEXT,
+    ADD COLUMN IF NOT EXISTS organization_type TEXT,
+    ADD COLUMN IF NOT EXISTS tagline           TEXT,
+    -- Lower-coverage extras (homepage, funding, stock listing, parent, subsidiaries,
+    -- activities); homepage goes here, not the job-derived domains[] that RefreshCompanyFacets
+    -- owns, so it's available without clobbering.
+    ADD COLUMN IF NOT EXISTS company_info      JSONB       NOT NULL DEFAULT '{}',
+    -- A reference row is a company imported by the backfill that no job references (yet).
+    -- The orphan cleanup preserves these; a later job for the same slug adopts the row.
+    ADD COLUMN IF NOT EXISTS is_reference      BOOLEAN     NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS company_info_at   TIMESTAMPTZ;
+
+-- Backs the future industries facet filter (array overlap &&), mirroring the other
+-- companies facet GIN indexes.
+CREATE INDEX IF NOT EXISTS companies_industries_idx ON companies USING GIN (industries);

--- a/openspec/changes/company-info-backfill/.openspec.yaml
+++ b/openspec/changes/company-info-backfill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/company-info-backfill/design.md
+++ b/openspec/changes/company-info-backfill/design.md
@@ -43,13 +43,13 @@ gain, and a provenance string would name the source (disallowed).
 
 **Slug-only matching in v1.** The loader normalizes each record's company name via
 `internal/normalize` (the catalogue's slug rule) and matches on `slug`. *Alternative —
-secondary domain match (`homepage_uri` ↔ `domains[]`)* — deferred until the miss rate is
-measured; the loader logs matched-existing vs inserted-reference counts to inform that.
+secondary domain match (the record's website ↔ `domains[]`)* — deferred until the miss rate
+is measured; the loader logs matched-existing vs inserted-reference counts to inform that.
 
-**Low-fill extras in JSONB.** `parent_company`, `subsidiaries`, `activities`, funding,
-stock, and `homepage_uri` (~10–20%, homepage ~99%) go into a `company_info` JSONB rather
-than sparse columns. `homepage_uri` goes to the JSONB — not the job-derived `domains[]` that
-`RefreshCompanyFacets` owns — so it is available without clobbering.
+**Low-fill extras in JSONB.** parent, subsidiaries, activities, funding, stock, and the
+website (~10–20%, website ~99%) go into a `company_info` JSONB rather than sparse columns.
+The website goes to the JSONB — not the job-derived `domains[]` that `RefreshCompanyFacets`
+owns — so it is available without clobbering.
 
 **Run-once host worker, not the moderator API.** `cmd/backfill-company-info <file.jsonl>`
 follows the `cmd/backfill-derive` shape (needs `DATABASE_URL`), streaming the file and

--- a/openspec/changes/company-info-backfill/design.md
+++ b/openspec/changes/company-info-backfill/design.md
@@ -1,0 +1,86 @@
+## Context
+
+`companies` is slug-keyed (normalized name, no surrogate id) and rows are born from jobs
+(`jobs.company_slug`); `DeleteOrphanCompanies` removes any company no job references. The
+existing facet columns (`company_types`, `company_sizes`, `countries`, `domains`, `regions`)
+are job-derived — `RefreshCompanyFacets` recomputes them as the distinct union across a
+company's open jobs (noisy per-job LLM enrichment + geo dictionaries). `companies.countries`
+means *where the jobs are*, not the company HQ.
+
+An external company info dataset (~158k companies), harvested out-of-band into a local
+JSONL artifact, carries authoritative per-company facts: headcount, founding year, HQ
+country, organization type, industries, tagline, and lower-coverage funding/stock/parent
+data. This change lands the data model, a one-time loader, and company-detail exposure.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Authoritative company-info columns on `companies`, independent of the job-derived facets.
+- Enrich existing companies and import unmatched ones as visible reference rows that
+  auto-upgrade when a job later appears for them.
+- Keep the loader and schema free of any reference to the dataset's origin.
+
+**Non-Goals:**
+- No recurring refresh / cron worker (one-time backfill; re-run manually).
+- No `industries` search facet or frontend beyond company-detail exposure (Phase 2).
+- No domain-based fuzzy matching in v1 (slug-only).
+- No LinkedIn/social URLs (absent from the dataset; no fabricated guesses).
+
+## Decisions
+
+**New columns, not a new table (variant B).** Company info live on `companies` directly,
+with `is_reference` distinguishing imported reference rows. *Alternative — a separate
+`company_company info` table joined at read time* — was rejected: it adds a join to every
+company read for no invariant benefit once `DeleteOrphanCompanies` is guarded. The columns
+are independent of the job-derived facets, so there is no clobber between the backfill and
+`RefreshCompanyFacets`.
+
+**Reference rows via a boolean flag.** `is_reference BOOLEAN DEFAULT false`; the only
+behavioral coupling is `DeleteOrphanCompanies` gaining `AND NOT is_reference`. A reference
+row that later gets a job simply has `job_count > 0`; the flag may stay true (it only gates
+deletion). *Alternative — a `has_jobs` column or provenance enum* — is more surface for no
+gain, and a provenance string would name the source (disallowed).
+
+**Slug-only matching in v1.** The loader normalizes each record's company name via
+`internal/normalize` (the catalogue's slug rule) and matches on `slug`. *Alternative —
+secondary domain match (`homepage_uri` ↔ `domains[]`)* — deferred until the miss rate is
+measured; the loader logs matched-existing vs inserted-reference counts to inform that.
+
+**Low-fill extras in JSONB.** `parent_company`, `subsidiaries`, `activities`, funding,
+stock, and `homepage_uri` (~10–20%, homepage ~99%) go into a `company_info` JSONB rather
+than sparse columns. `homepage_uri` goes to the JSONB — not the job-derived `domains[]` that
+`RefreshCompanyFacets` owns — so it is available without clobbering.
+
+**Run-once host worker, not the moderator API.** `cmd/backfill-company-info <file.jsonl>`
+follows the `cmd/backfill-derive` shape (needs `DATABASE_URL`), streaming the file and
+upserting via one new sqlc query `UpsertCompanyInfo`. A 158k-row import over the
+HTTP moderator API would be needlessly slow for a one-time job with direct DB access.
+
+## Risks / Trade-offs
+
+- **Low slug match rate for existing companies** → the loader logs matched vs inserted
+  counts; if enrichment coverage is poor, add the domain secondary match in a follow-up.
+- **Catalogue grows ~158k rows; deep `OFFSET` pagination on the company list may slow** →
+  the list query is unchanged here (reference rows sort to the tail); keyset pagination is a
+  later fix if needed (the sitemap already uses keyset).
+- **`is_reference` invariant relaxation touches orphan cleanup** → covered by an integration
+  test asserting `DeleteOrphanCompanies` skips reference rows; no other code assumes
+  "every company has a job".
+- **Idempotency / partial reruns** → the upsert is `ON CONFLICT (slug)` writing only
+  company-info columns, so a re-run or resume rewrites the same values without duplicates.
+
+## Migration Plan
+
+1. Ship migration `0041_company_info.sql` (additive columns + GIN index on
+   `industries`); apply to the persistent DB before deploying code that reads the columns
+   (no versioned runner — manual `psql`, per project ops).
+2. Regenerate `internal/db` with `make sqlc`; deploy the binary carrying
+   `cmd/backfill-company-info` and the guarded `DeleteOrphanCompanies`.
+3. Run the backfill once against the local JSONL artifact.
+4. Rollback: the columns are additive and nullable; reverting code leaves them dormant.
+   Reference rows can be removed with `DELETE FROM companies WHERE is_reference` if needed.
+
+## Open Questions
+
+- Slug match rate against the live catalogue — measured on first run, decides whether the
+  domain secondary match is worth adding.

--- a/openspec/changes/company-info-backfill/design.md
+++ b/openspec/changes/company-info-backfill/design.md
@@ -71,7 +71,7 @@ HTTP moderator API would be needlessly slow for a one-time job with direct DB ac
 
 ## Migration Plan
 
-1. Ship migration `0041_company_info.sql` (additive columns + GIN index on
+1. Ship migration `0042_company_info.sql` (additive columns + GIN index on
    `industries`); apply to the persistent DB before deploying code that reads the columns
    (no versioned runner — manual `psql`, per project ops).
 2. Regenerate `internal/db` with `make sqlc`; deploy the binary carrying

--- a/openspec/changes/company-info-backfill/proposal.md
+++ b/openspec/changes/company-info-backfill/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Our `companies` rows only carry data derived from our own job postings — noisy per-job LLM
+facets and job-location geography — with no authoritative company info (headcount, founding
+year, HQ, industry, organization type). An external company info dataset, harvested
+out-of-band, provides high-coverage authoritative facts for ~158k companies. A one-time
+backfill enriches the companies we already have and imports the rest as a visible reference
+directory.
+
+## What Changes
+
+- Add authoritative company-info columns to `companies`: `industries`, `year_founded`,
+  `employee_count`, `hq_country`, `organization_type`, `tagline`, a `company_info` JSONB for
+  low-fill extras (homepage, funding, stock, parent/subsidiaries, activities), plus
+  `is_reference` and `company_info_at`.
+- Add a run-once host worker `cmd/backfill-company-info` that streams a local JSONL dataset,
+  matches each company by normalized-name slug, updates existing companies, and inserts
+  unmatched ones as reference rows (`is_reference = true`, no jobs).
+- **BREAKING (invariant):** companies may now exist without any job. `DeleteOrphanCompanies`
+  no longer removes `is_reference` rows.
+- The new columns are independent of the job-derived facets; `RefreshCompanyFacets` does not
+  touch them.
+- Source anonymity: nothing in the repo names the dataset's origin — no source adapter, no
+  `sources/*.yml`, no provenance string. The loader reads a generic file path.
+- LinkedIn/social URLs are out of scope (absent from the dataset; no fabricated guesses).
+- Surfacing new company info as search facets and in the frontend is a **separate later
+  change** (Phase 2); this change lands the data model, loader, and company-detail exposure.
+
+## Capabilities
+
+### New Capabilities
+- `company-info`: authoritative company-info attributes on a company and the
+  one-time backfill that imports them from an external dataset, matching by slug and
+  inserting unmatched companies as reference rows.
+
+### Modified Capabilities
+- `companies`: companies may exist as reference rows with no jobs; the orphan cleanup
+  preserves reference rows instead of deleting them.
+
+## Impact
+
+- **Schema:** new migration `0041_company_info.sql` (columns + GIN index on
+  `industries`).
+- **DB queries:** new `UpsertCompanyInfo`; `DeleteOrphanCompanies` gains an
+  `AND NOT is_reference` guard. `make sqlc` regen.
+- **New command:** `cmd/backfill-company-info` (+ Dockerfile/ops entry if run in prod).
+- **Company detail:** the detail view shape maps the new columns into the response
+  (`GetCompany` already `SELECT *`).
+- **Catalogue size:** company count grows by up to ~158k reference rows.

--- a/openspec/changes/company-info-backfill/specs/companies/spec.md
+++ b/openspec/changes/company-info-backfill/specs/companies/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Companies are stored as a slug-keyed entity
+
+The system SHALL store companies in a `companies` table identified by a natural
+`slug` key derived by normalizing the company name. The table SHALL NOT use a
+surrogate id. Each company SHALL have a display `name`.
+
+A company row is normally created from a job's company name. A company MAY also
+exist as a **reference row** created by the company info backfill without any
+job referencing it; such a row SHALL be marked `is_reference = true`. Any orphan
+cleanup that deletes companies no job references SHALL preserve reference rows.
+When a job is later ingested whose normalized name matches a reference row's
+`slug`, the existing row SHALL be reused (not duplicated), gaining jobs while
+keeping its company-info data.
+
+#### Scenario: Company is created from a job's company name
+
+- **WHEN** a job is ingested with a non-empty company name that has no matching
+  company row
+- **THEN** the system inserts a `companies` row whose `slug` is the normalized
+  name and whose `name` is the display name
+
+#### Scenario: Existing company is reused, not duplicated
+
+- **WHEN** a job is ingested whose normalized company name matches an existing
+  `companies.slug`
+- **THEN** no duplicate company row is created and the existing row is reused
+
+#### Scenario: Reference company survives orphan cleanup
+
+- **WHEN** the orphan cleanup runs and a company row has no job referencing it
+  but is marked `is_reference = true`
+- **THEN** the row is not deleted
+
+#### Scenario: A job adopts a reference company
+
+- **WHEN** a job is ingested whose normalized company name matches the `slug` of
+  a reference row
+- **THEN** the existing row is reused, its job count reflects the new job, and
+  its company-info fields are unchanged

--- a/openspec/changes/company-info-backfill/specs/company-info/spec.md
+++ b/openspec/changes/company-info-backfill/specs/company-info/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Companies carry authoritative company-info attributes
+
+The system SHALL store authoritative company-info attributes on the `companies`
+entity, independent of the job-derived facet arrays: `industries` (text array),
+`year_founded` (integer, nullable), `employee_count` (integer, nullable),
+`hq_country` (ISO 3166-1 alpha-2, nullable), `organization_type` (nullable),
+`tagline` (nullable), and a `company_info` JSONB holding lower-coverage extras
+(homepage, funding, stock listing, parent company, subsidiaries, activities). A
+`company_info_at` timestamp SHALL record when the attributes were last written.
+
+These attributes SHALL be independent of the job-derived facet columns
+(`company_types`, `company_sizes`, `countries`, `domains`, `regions`): the
+periodic facet recompute SHALL NOT read or write the company-info attributes, and
+the company info backfill SHALL NOT read or write the job-derived facets or
+`job_count`.
+
+An attribute that is unknown in the source SHALL be stored as NULL (or omitted
+from the JSONB), so "unknown" stays distinguishable from a real value.
+
+#### Scenario: Company-info attributes persist on the company
+
+- **WHEN** a company is enriched with company-info attributes
+- **THEN** its `industries`, `year_founded`, `employee_count`, `hq_country`,
+  `organization_type`, `tagline`, and `company_info` JSONB are stored and
+  `company_info_at` is set
+
+#### Scenario: Facet recompute does not disturb company info
+
+- **WHEN** the periodic company facet recompute runs over a company that has
+  company-info attributes
+- **THEN** the company-info attributes are unchanged
+
+### Requirement: Company info are loaded by a one-time backfill matched by slug
+
+The system SHALL provide a run-once host worker that streams a local dataset file
+(a path passed as an argument) of company company info and applies each record to
+the `companies` table, matching by the normalized-name `slug`. For a record whose
+slug matches an existing company, the worker SHALL update only that company's
+company-info attributes, leaving `job_count`, `collections`, and the job-derived
+facets untouched. For a record whose slug matches no company, the worker SHALL
+insert a new company row as a reference row (`is_reference = true`) with the
+company-info attributes and no jobs. The worker SHALL be idempotent: re-running the
+same dataset SHALL produce the same company-info values. The worker and schema
+SHALL NOT reference the dataset's origin.
+
+#### Scenario: Existing company is enriched
+
+- **WHEN** the backfill processes a record whose slug matches an existing company
+- **THEN** the company's company-info attributes are updated and its `job_count`,
+  `collections`, and job-derived facets are unchanged
+
+#### Scenario: Unmatched company is imported as a reference row
+
+- **WHEN** the backfill processes a record whose slug matches no existing company
+- **THEN** a new `companies` row is inserted with `is_reference = true`,
+  `job_count = 0`, the display name, and the company-info attributes
+
+#### Scenario: Re-running the backfill is idempotent
+
+- **WHEN** the backfill is run twice over the same dataset file
+- **THEN** the second run produces the same company-info values with no duplicate
+  rows
+
+#### Scenario: Origin is not recorded
+
+- **WHEN** the backfill writes a company's company info
+- **THEN** no field, column, or log names the dataset's source

--- a/openspec/changes/company-info-backfill/tasks.md
+++ b/openspec/changes/company-info-backfill/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Schema
 
-- [ ] 1.1 Add migration `migrations/0041_company_info.sql`: columns `industries TEXT[] NOT NULL DEFAULT '{}'`, `year_founded INT`, `employee_count INT`, `hq_country TEXT`, `organization_type TEXT`, `tagline TEXT`, `company_info JSONB NOT NULL DEFAULT '{}'`, `is_reference BOOLEAN NOT NULL DEFAULT false`, `company_info_at TIMESTAMPTZ`
-- [ ] 1.2 Add `CREATE INDEX IF NOT EXISTS companies_industries_idx ON companies USING GIN (industries)` in the same migration
+- [x] 1.1 Add migration `migrations/0042_company_info.sql`: columns `industries TEXT[] NOT NULL DEFAULT '{}'`, `year_founded INT`, `employee_count INT`, `hq_country TEXT`, `organization_type TEXT`, `tagline TEXT`, `company_info JSONB NOT NULL DEFAULT '{}'`, `is_reference BOOLEAN NOT NULL DEFAULT false`, `company_info_at TIMESTAMPTZ`
+- [x] 1.2 Add `CREATE INDEX IF NOT EXISTS companies_industries_idx ON companies USING GIN (industries)` in the same migration
 
 ## 2. DB access (sqlc)
 
-- [ ] 2.1 Add `UpsertCompanyInfo` in `internal/db/queries/companies.sql`: `INSERT ... ON CONFLICT (slug)` writing ONLY the company-info columns + `company_info_at = now()` + `name`; on insert set `is_reference = true`; on conflict update only company-info columns (never `job_count`/`collections`/job-derived facets/`is_reference` of an existing row)
-- [ ] 2.2 Guard `DeleteOrphanCompanies` with `AND NOT c.is_reference`
-- [ ] 2.3 Run `make sqlc` and commit the regenerated `internal/db`
+- [x] 2.1 Add `UpsertCompanyInfo` in `internal/db/queries/companies.sql`: `INSERT ... ON CONFLICT (slug)` writing ONLY the company-info columns + `company_info_at = now()` + `name`; on insert set `is_reference = true`; on conflict update only company-info columns (never `job_count`/`collections`/job-derived facets/`is_reference` of an existing row)
+- [x] 2.2 Guard `DeleteOrphanCompanies` with `AND NOT c.is_reference`
+- [x] 2.3 Run `make sqlc` and commit the regenerated `internal/db`
 
 ## 3. Backfill worker
 
-- [ ] 3.1 Add `cmd/backfill-company-info/main.go` (run-once, needs `DATABASE_URL`; file path as arg): stream the JSONL, map name→slug via `internal/normalize`, call `UpsertCompanyInfo` per record
-- [ ] 3.2 Map record fields → params: empty/zero source values → NULL; assemble `company_info` JSONB from homepage + funding/stock/parent/subsidiaries/activities; keep the loader source-agnostic (no origin named in code, comments, or logs)
-- [ ] 3.3 Log matched-existing vs inserted-reference counts (and skipped/blank-name rows) for the match-rate measurement
+- [x] 3.1 Add `cmd/backfill-company-info/main.go` (run-once, needs `DATABASE_URL`; file path as arg): stream the JSONL, map name→slug via `internal/normalize`, call `UpsertCompanyInfo` per record
+- [x] 3.2 Map record fields → params: empty/zero source values → NULL; assemble `company_info` JSONB from homepage + funding/stock/parent/subsidiaries/activities; keep the loader source-agnostic (no origin named in code, comments, or logs)
+- [x] 3.3 Log matched-existing vs inserted-reference counts (and skipped/blank-name rows) for the match-rate measurement
 
 ## 4. Company detail exposure
 
-- [ ] 4.1 Map the new columns into the company-detail response shape (jobview/company detail), rendering company info on the company row; leave list/search/facets unchanged (Phase 2)
+- [x] 4.1 Map the new columns into the company-detail response shape (jobview/company detail), rendering company info on the company row; leave list/search/facets unchanged (Phase 2)
 
 ## 5. Tests
 
-- [ ] 5.1 `internal/db` integration test (build-tagged `integration`): insert-new-as-reference, update-existing-preserves-`job_count`/facets, idempotent re-run
-- [ ] 5.2 Integration test: `DeleteOrphanCompanies` deletes a jobless non-reference company but skips an `is_reference` one
-- [ ] 5.3 Unit test for the loader's record→params mapping (empty/zero → NULL, JSONB extras assembled) over fixture JSONL lines
+- [x] 5.1 `internal/db` integration test (build-tagged `integration`): insert-new-as-reference, update-existing-preserves-`job_count`/facets, idempotent re-run
+- [x] 5.2 Integration test: `DeleteOrphanCompanies` deletes a jobless non-reference company but skips an `is_reference` one
+- [x] 5.3 Unit test for the loader's record→params mapping (empty/zero → NULL, JSONB extras assembled) over fixture JSONL lines
 
 ## 6. Verify
 
-- [ ] 6.1 `go build ./... && go vet ./... && go test ./...`; run the backfill against the dump, confirm matched/inserted counts and spot-check enriched + reference rows
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...`; run the backfill against the dump, confirm matched/inserted counts and spot-check enriched + reference rows

--- a/openspec/changes/company-info-backfill/tasks.md
+++ b/openspec/changes/company-info-backfill/tasks.md
@@ -1,0 +1,30 @@
+## 1. Schema
+
+- [ ] 1.1 Add migration `migrations/0041_company_info.sql`: columns `industries TEXT[] NOT NULL DEFAULT '{}'`, `year_founded INT`, `employee_count INT`, `hq_country TEXT`, `organization_type TEXT`, `tagline TEXT`, `company_info JSONB NOT NULL DEFAULT '{}'`, `is_reference BOOLEAN NOT NULL DEFAULT false`, `company_info_at TIMESTAMPTZ`
+- [ ] 1.2 Add `CREATE INDEX IF NOT EXISTS companies_industries_idx ON companies USING GIN (industries)` in the same migration
+
+## 2. DB access (sqlc)
+
+- [ ] 2.1 Add `UpsertCompanyInfo` in `internal/db/queries/companies.sql`: `INSERT ... ON CONFLICT (slug)` writing ONLY the company-info columns + `company_info_at = now()` + `name`; on insert set `is_reference = true`; on conflict update only company-info columns (never `job_count`/`collections`/job-derived facets/`is_reference` of an existing row)
+- [ ] 2.2 Guard `DeleteOrphanCompanies` with `AND NOT c.is_reference`
+- [ ] 2.3 Run `make sqlc` and commit the regenerated `internal/db`
+
+## 3. Backfill worker
+
+- [ ] 3.1 Add `cmd/backfill-company-info/main.go` (run-once, needs `DATABASE_URL`; file path as arg): stream the JSONL, map name→slug via `internal/normalize`, call `UpsertCompanyInfo` per record
+- [ ] 3.2 Map record fields → params: empty/zero source values → NULL; assemble `company_info` JSONB from homepage + funding/stock/parent/subsidiaries/activities; keep the loader source-agnostic (no origin named in code, comments, or logs)
+- [ ] 3.3 Log matched-existing vs inserted-reference counts (and skipped/blank-name rows) for the match-rate measurement
+
+## 4. Company detail exposure
+
+- [ ] 4.1 Map the new columns into the company-detail response shape (jobview/company detail), rendering company info on the company row; leave list/search/facets unchanged (Phase 2)
+
+## 5. Tests
+
+- [ ] 5.1 `internal/db` integration test (build-tagged `integration`): insert-new-as-reference, update-existing-preserves-`job_count`/facets, idempotent re-run
+- [ ] 5.2 Integration test: `DeleteOrphanCompanies` deletes a jobless non-reference company but skips an `is_reference` one
+- [ ] 5.3 Unit test for the loader's record→params mapping (empty/zero → NULL, JSONB extras assembled) over fixture JSONL lines
+
+## 6. Verify
+
+- [ ] 6.1 `go build ./... && go vet ./... && go test ./...`; run the backfill against the dump, confirm matched/inserted counts and spot-check enriched + reference rows

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -24,3 +24,7 @@ sql:
           # blob as raw bytes that marshal straight through (nil → null), not base64.
           - column: "search_profiles.resume_analysis"
             go_type: "encoding/json.RawMessage"
+          # Same reasoning for the company-info extras JSONB: raw bytes marshal
+          # straight through to the company-detail response ({} stays {}), not base64.
+          - column: "companies.company_info"
+            go_type: "encoding/json.RawMessage"


### PR DESCRIPTION
## What

Enrich the `companies` table with authoritative company-info from an **external company-info dataset** (harvested out-of-band, source-agnostic loader). One-time backfill: enriches existing companies and imports unmatched ones as visible reference rows.

## Changes

- **Migration 0042**: adds `industries`, `year_founded`, `employee_count`, `hq_country`, `organization_type`, `tagline`, `company_info` JSONB, `is_reference`, `company_info_at` to `companies` (+ GIN index on `industries`). Independent of the job-derived facet columns.
- **sqlc**: `UpsertCompanyInfo` (writes only company-info columns), `CompanyExists`; `DeleteOrphanCompanies` now preserves `is_reference` rows. `company_info` typed `json.RawMessage`.
- **`cmd/backfill-company-info <file.jsonl>`**: run-once host worker; streams a local JSONL dataset, matches by normalized-name slug, updates existing / inserts unmatched as reference rows. Idempotent, source-agnostic.
- Company detail exposes the new fields automatically (`GetCompany` is `SELECT *`).

## Invariant change

Companies may now exist as reference rows with no jobs; the orphan cleanup no longer sweeps them.

## Verification

`go build/vet ./...` + `gofmt` clean; unit + integration tests pass; verified end-to-end over a 5k real-data sample (insert + idempotent re-run, no dups).

## Deploy note

Apply migration 0042 **together with** the new binary — `GetCompany` uses `SELECT *`, so adding columns to the table while an old binary runs would break the company-detail scan. Phase 2 (industries facet + frontend) is a separate change.