### PR TITLE
refactor(web): "CV" wording + move CV upload to Edit profile

### DIFF
--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -157,7 +157,7 @@
   <section class="py-16 sm:py-20">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// mission</p>
     <p class="mt-6 max-w-3xl text-2xl font-medium leading-snug tracking-tight sm:text-3xl">
-      A job board that works for you, not for recruiters. No paywalls, no sponsored listings, no résumé
+      A job board that works for you, not for recruiters. No paywalls, no sponsored listings, no CV
       harvesting. Free to use, and free to fork.
     </p>
   </section>

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -85,7 +85,7 @@
     try {
       const extracted = await extractResumeSkills(file);
       if (extracted.length === 0) {
-        resumeNote = 'No known skills found in the résumé.';
+        resumeNote = 'No known skills found in the CV.';
         return;
       }
       const before = skills.length;
@@ -93,11 +93,11 @@
       const added = skills.length - before;
       resumeNote =
         added > 0
-          ? `Added ${added} skill${added === 1 ? '' : 's'} from your résumé.`
-          : 'All résumé skills were already listed.';
+          ? `Added ${added} skill${added === 1 ? '' : 's'} from your CV.`
+          : 'All CV skills were already listed.';
     } catch (err) {
       resumeError =
-        err instanceof ApiError ? err.message : 'Could not read the résumé. Please try again.';
+        err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';
     } finally {
       resumeBusy = false;
     }
@@ -254,7 +254,7 @@
       />
 
       <div class="flex flex-col gap-1.5">
-        <span class="text-sm font-medium">Add skills from your résumé</span>
+        <span class="text-sm font-medium">Add skills from your CV</span>
         <input
           type="file"
           accept="application/pdf,.pdf"

--- a/web/src/routes/my/profiles/[id]/verdict/+page.svelte
+++ b/web/src/routes/my/profiles/[id]/verdict/+page.svelte
@@ -1,15 +1,8 @@
 <script lang="ts">
-  import { ArrowLeft, ArrowUp, FileText, Sparkles } from '@lucide/svelte';
+  import { ArrowLeft, Pencil, Sparkles } from '@lucide/svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import {
-    ApiError,
-    extractResumeSkills,
-    facetCounts,
-    getATSReport,
-    getProfileVerdict,
-    runATSReview,
-  } from '$lib/api';
+  import { facetCounts, getATSReport, getProfileVerdict, runATSReview } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { categoryLabel } from '$lib/facets';
@@ -37,11 +30,8 @@
   let loadError = $state(false);
   let tab = $state<'coverage' | 'cv'>('coverage');
 
-  // CV upload state (the ATS report needs a stored CV).
-  let cvBusy = $state(false);
-  let cvError = $state<string | null>(null);
-  let fileInput = $state<HTMLInputElement | null>(null);
-  let dragActive = $state(false);
+  // CV upload/replace lives on the profile edit form; the report links there.
+  const editHref = $derived(resolve('/my/profiles/[id]/edit', { id: String(id) }));
 
   // AI review state.
   let reviewBusy = $state(false);
@@ -114,44 +104,6 @@
     } catch {
       loadError = true;
     }
-  }
-
-  function isPdf(file: File): boolean {
-    return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
-  }
-
-  // Store the CV (via the skill-extract path, which also stores it when storage is on),
-  // then reload so the ATS report scores it.
-  async function uploadCV(file: File) {
-    cvBusy = true;
-    cvError = null;
-    try {
-      await extractResumeSkills(file);
-      await reload();
-    } catch (err) {
-      cvError = err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';
-    } finally {
-      cvBusy = false;
-    }
-  }
-
-  function onCVFile(e: Event) {
-    const target = e.currentTarget as HTMLInputElement;
-    const file = target.files?.[0];
-    target.value = '';
-    if (file) void uploadCV(file);
-  }
-
-  function onDrop(e: DragEvent) {
-    e.preventDefault();
-    dragActive = false;
-    const file = e.dataTransfer?.files?.[0];
-    if (!file) return;
-    if (!isPdf(file)) {
-      cvError = 'Please drop a PDF file.';
-      return;
-    }
-    void uploadCV(file);
   }
 
   // Humanized role label: the selected categories, falling back to the profile's own
@@ -241,90 +193,46 @@
           <States state="loading" />
         {:else if tab === 'coverage'}
           <VerdictView {verdict} {gapHref} />
-        {:else}
+        {:else if ats?.has_cv && ats.report}
           <!-- CV readiness -->
-          <input
-            type="file"
-            accept="application/pdf,.pdf"
-            class="hidden"
-            bind:this={fileInput}
-            onchange={onCVFile}
-          />
-          {#if ats?.has_cv && ats.report}
-            <div class="flex flex-col gap-5">
-              <div class="flex flex-wrap items-center justify-between gap-3">
-                <p class="text-sm text-muted-foreground">How ATS-ready your CV is for this role.</p>
-                {#if ats.report.content_quality == null && !reviewUnavailable}
-                  <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
-                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                    {reviewBusy ? 'Reviewing…' : 'Run AI review'}
-                  </Button>
-                {:else if ats.report.content_quality != null}
-                  <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
-                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                    {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
-                  </Button>
-                {/if}
-              </div>
-              {#if reviewUnavailable}
-                <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
+          <div class="flex flex-col gap-5">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <p class="text-sm text-muted-foreground">How ATS-ready your CV is for this role.</p>
+              {#if ats.report.content_quality == null && !reviewUnavailable}
+                <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
+                  <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                  {reviewBusy ? 'Reviewing…' : 'Run AI review'}
+                </Button>
+              {:else if ats.report.content_quality != null}
+                <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
+                  <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                  {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
+                </Button>
               {/if}
-              <ATSReportView report={ats.report} />
-              <button
-                type="button"
-                onclick={() => fileInput?.click()}
-                disabled={cvBusy}
-                class="w-fit text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline disabled:opacity-70"
-              >
-                {cvBusy ? 'Uploading…' : 'Replace CV'}
-              </button>
             </div>
-          {:else}
-            <div class="flex flex-col gap-2">
-              <button
-                type="button"
-                onclick={() => fileInput?.click()}
-                ondragover={(e) => {
-                  e.preventDefault();
-                  dragActive = true;
-                }}
-                ondragleave={(e) => {
-                  e.preventDefault();
-                  dragActive = false;
-                }}
-                ondrop={onDrop}
-                disabled={cvBusy}
-                class="flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-10 text-center transition-colors disabled:opacity-70 {dragActive
-                  ? 'border-primary bg-primary/5'
-                  : 'border-border hover:border-primary/60'}"
-              >
-                <span class="flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                  {#if cvBusy}
-                    <FileText class="size-5" />
-                  {:else}
-                    <ArrowUp class="size-5" />
-                  {/if}
-                </span>
-                <span class="flex flex-col gap-0.5">
-                  <span class="text-sm font-semibold">
-                    {cvBusy ? 'Reading your CV…' : 'Upload your CV to score it'}
-                  </span>
-                  {#if !cvBusy}
-                    <span class="text-xs text-muted-foreground">
-                      Drop a PDF here, or <span class="text-primary underline">choose from disk</span>
-                    </span>
-                  {/if}
-                </span>
-              </button>
-              <span class="text-xs text-muted-foreground">
-                Checks ATS readability + this role's keywords. Parsed on the server; CV text is not
-                stored.
-              </span>
-            </div>
-          {/if}
-          {#if cvError}
-            <p class="mt-2 text-sm text-destructive">{cvError}</p>
-          {/if}
+            {#if reviewUnavailable}
+              <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
+            {/if}
+            <ATSReportView report={ats.report} />
+            <a
+              href={editHref}
+              class="w-fit text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+            >
+              Update your CV in profile settings
+            </a>
+          </div>
+        {:else}
+          <!-- No CV yet: managed on the profile edit form. -->
+          <div class="flex flex-col items-start gap-3 rounded-xl border border-dashed border-border p-6">
+            <p class="text-sm font-medium">Add your CV to score its ATS readiness</p>
+            <p class="text-sm text-muted-foreground">
+              Upload your CV on the profile to check ATS readability and this role's keywords.
+            </p>
+            <Button variant="primary" href={editHref}>
+              <Pencil class="size-4" />
+              Edit profile
+            </Button>
+          </div>
         {/if}
       </main>
     </div>


### PR DESCRIPTION
Frontend-only polish (no backend).

- **"CV" wording:** rename user-facing "résumé" → "CV" in the profile form (the skill-extract upload) and the homepage mission line. Code identifiers (`extractResumeSkills`, `/me/resume` API) unchanged.
- **CV upload moved to Edit profile:** the verdict page's CV-readiness tab drops the inline upload dropzone and the "Replace CV" button. CV upload/replace lives on the profile **Edit** form (which already stores the CV via the skill-extract path), so the report links there instead:
  - CV present → a quiet "Update your CV in profile settings" link.
  - No CV → an "Add your CV…" prompt with an **Edit profile** button.

## Test Plan
- [x] `svelte-check` — 0 errors / 0 warnings
- [ ] Live: profile form says "CV"; verdict CV tab has no Replace-CV/dropzone; links go to Edit profile