### PR TITLE
feat(web): company-info card on the company page

### DIFF
--- a/openspec/changes/company-info-display/.openspec.yaml
+++ b/openspec/changes/company-info-display/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/company-info-display/design.md
+++ b/openspec/changes/company-info-display/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The company page (`web/src/routes/companies/[slug]/+page.svelte` → `CompanyView.svelte`)
+renders a header (logo, name, follow) then a streamed jobs list. The company-detail API
+returns `db.Company`, which now carries the company-info columns (`industries`,
+`year_founded`, `employee_count`, `hq_country`, `organization_type`, `tagline`) and the
+`company_info` JSONB. The hand-written web `Company` type (`web/src/lib/types.ts`) does not
+expose them yet. `facets.ts` already has `countryLabel(code)` (ISO alpha-2 → English name).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show the company's authoritative facts on its page, degrading gracefully as fields are
+  missing.
+
+**Non-Goals:**
+- No backend/API/schema change (data already served).
+- No `industries` search facet or company-list changes (a separate change).
+- No JSON-LD enrichment (foundingDate/numberOfEmployees) — noted as a later refinement.
+
+## Decisions
+
+**A single stacked card, not a sidebar.** The card sits between the header and the jobs
+list, full width. *Alternative — a two-column sidebar* — was rejected during design as a
+larger layout change for little gain; the card reads well stacked and keeps the jobs list
+full width.
+
+**Render-only-what-exists, hide-when-empty.** Every field is conditional; the whole card
+returns nothing when no company-info field is set. This keeps unenriched (job-only)
+companies visually unchanged and avoids empty scaffolding — the same "dict-silent stays
+silent" spirit as the backend facets.
+
+**Type the `company_info` JSONB explicitly.** Add a `CompanyInfo` interface
+(`{ homepage?, parent?, subsidiaries?[], activities?[], funding?{type?,amount?,year?,investors?[]}, stock?{symbol?,exchange?} }`)
+rather than `unknown`, so the template reads typed fields. The company-info columns are added
+to the `Company` interface as optional (older API responses / unenriched rows omit them).
+
+**Reuse existing helpers.** HQ uses `countryLabel`; chips reuse the app's rounded-full badge
+styling; employee count is formatted with `toLocaleString`; a small local helper formats a
+funding amount (e.g. `$250M`).
+
+## Risks / Trade-offs
+
+- **Type drift between hand-written `Company` and the API** → fields are optional and
+  defensively read, so a missing field just hides its line; no runtime break.
+- **`company_info` shape depends on the backfill's JSONB assembly** → the `CompanyInfo` type
+  mirrors exactly what the loader writes (`funding`/`stock`/`homepage`/`parent`/
+  `subsidiaries`/`activities`); documented in both places.
+
+## Migration Plan
+
+Frontend-only; ships with the normal web deploy. No data migration. Depends on the
+`company-info-backfill` change being merged and run so the fields are populated (before that,
+the card simply never renders).
+
+## Open Questions
+
+- Whether to later feed `year_founded`/`employee_count` into the company `organizationJsonLd`
+  for richer structured data — deferred.

--- a/openspec/changes/company-info-display/proposal.md
+++ b/openspec/changes/company-info-display/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The company-info backfill (previous change) lands authoritative company facts — size,
+founding year, HQ, organization type, industries, tagline, website, and occasional
+funding/stock/parent data — on the `companies` row, and the company-detail API already
+returns them. Nothing surfaces them yet: the company page shows only a name header and the
+jobs list. This change renders those facts so a visitor sees who the company is, not just
+its openings.
+
+## What Changes
+
+- Add a `CompanyInfoCard` component to the company page (`CompanyView`), a single-column
+  card between the header and the jobs list.
+- The card renders **only the fields that are present**, and renders nothing at all when the
+  company has no company-info (so unenriched companies show no empty box).
+- Card content: tagline; an inline facts line (founded · employees · HQ country · org type);
+  industry chips; a website link; and — when present — funding, stock listing, parent
+  company, and subsidiaries.
+- Extend the hand-written web `Company` type with the company-info fields and a `CompanyInfo`
+  shape for the `company_info` JSONB.
+
+## Capabilities
+
+### New Capabilities
+- `company-info-display`: rendering the company's authoritative firmographic facts on the
+  company detail page, conditional on availability.
+
+### Modified Capabilities
+<!-- none: purely additive frontend rendering of data the API already returns -->
+
+## Impact
+
+- **Frontend only.** New `web/src/lib/components/CompanyInfoCard.svelte`; wired into
+  `CompanyView.svelte`. `web/src/lib/types.ts` gains optional company-info fields +
+  `CompanyInfo`. Reuses `countryLabel` (facets.ts) for HQ.
+- No backend/API/schema change (the company-detail response already carries the fields).
+- Depends on the `company-info-backfill` change being merged so the data exists.

--- a/openspec/changes/company-info-display/specs/company-info-display/spec.md
+++ b/openspec/changes/company-info-display/specs/company-info-display/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Company page surfaces authoritative company facts
+
+The company detail page SHALL render the company's authoritative company-info facts in a
+card between the page header and the jobs list. The card SHALL render only the fields that
+are present, and SHALL render nothing at all when the company has no company-info, so an
+unenriched company shows no empty container.
+
+When present, the card SHALL show: the tagline; an inline facts line composed of founding
+year, employee count, HQ country (the ISO code resolved to an English country name), and
+organization type, with only the present facts shown; the industries as chips; and a website
+link that opens in a new tab. When present in the `company_info` payload, the card SHALL also
+show funding (type, amount, year), stock listing (exchange and symbol), the parent company,
+and subsidiaries.
+
+#### Scenario: Enriched company shows its facts
+
+- **WHEN** a visitor opens the page of a company that has company-info
+- **THEN** the card appears above the jobs list showing the present facts (tagline, founded,
+  employees, HQ country name, organization type, industries, website) and omitting any facts
+  that are absent
+
+#### Scenario: Unenriched company shows no card
+
+- **WHEN** a visitor opens the page of a company that has no company-info fields
+- **THEN** no company-info card is rendered and the page shows the header and jobs list as
+  before
+
+#### Scenario: HQ country code is shown as a country name
+
+- **WHEN** the company's HQ country is stored as an ISO 3166-1 alpha-2 code (e.g. `US`)
+- **THEN** the card displays the resolved English country name (e.g. "United States")
+
+#### Scenario: Rare facts appear only when present
+
+- **WHEN** the company's `company_info` payload contains funding, stock, parent, or
+  subsidiaries data
+- **THEN** those sections are shown; and when a company lacks them, those sections are omitted
+
+#### Scenario: Reference company page
+
+- **WHEN** a visitor opens the page of a reference company that has company-info but no jobs
+- **THEN** the card is shown as the page's main content and the jobs list shows its empty
+  state below

--- a/openspec/changes/company-info-display/tasks.md
+++ b/openspec/changes/company-info-display/tasks.md
@@ -1,0 +1,18 @@
+## 1. Types
+
+- [x] 1.1 Add optional company-info fields to the `Company` interface in `web/src/lib/types.ts`: `industries?`, `year_founded?`, `employee_count?`, `hq_country?`, `organization_type?`, `tagline?`, `company_info?: CompanyInfo`
+- [x] 1.2 Add a `CompanyInfo` interface mirroring the loader's JSONB: `{ homepage?, parent?, subsidiaries?, activities?, funding?: { type?, amount?, year?, investors? }, stock?: { symbol?, exchange? } }`
+
+## 2. Component
+
+- [x] 2.1 Add `web/src/lib/components/CompanyInfoCard.svelte` taking a `company: Company` prop; compute a `hasInfo` guard and render nothing when false
+- [x] 2.2 Render tagline; inline facts line (founded · `toLocaleString` employees · `countryLabel(hq_country)` · organization_type — present only); industry chips (rounded-full badge)
+- [x] 2.3 Render website link (`target=_blank rel=noopener`) from `company_info.homepage`; and the rare blocks (funding, stock `EXCHANGE: SYMBOL`, parent, subsidiaries) each conditional on presence; add a small funding-amount formatter (e.g. `$250M`)
+
+## 3. Wire-in
+
+- [x] 3.1 Render `CompanyInfoCard` in `CompanyView.svelte` between the header and the `mt-6` jobs block
+
+## 4. Verify
+
+- [x] 4.1 `npm run check` (svelte-check) clean for the touched files; visual check via headless screenshot on an enriched company, an unenriched company (no card), and a reference company (card + empty jobs)

--- a/web/src/lib/components/CompanyInfoCard.svelte
+++ b/web/src/lib/components/CompanyInfoCard.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import type { Company } from '$lib/types';
+  import { countryLabel } from '$lib/facets';
+
+  // The company's authoritative company-info facts, rendered above the jobs list.
+  // Every field is optional (populated by the backfill); the whole card renders
+  // nothing when the company has no info, so unenriched companies are unchanged.
+  let { company }: { company: Company } = $props();
+
+  const info = $derived(company.company_info ?? {});
+
+  // Inline facts, present-only, in a stable order.
+  const facts = $derived(
+    [
+      company.year_founded ? `Founded ${company.year_founded}` : null,
+      company.employee_count ? `${company.employee_count.toLocaleString()} employees` : null,
+      company.hq_country ? countryLabel(company.hq_country) : null,
+      company.organization_type || null,
+    ].filter((f): f is string => !!f)
+  );
+
+  const industries = $derived(company.industries ?? []);
+  const website = $derived(info.homepage);
+  const subsidiaries = $derived(info.subsidiaries ?? []);
+
+  // Compact money label: $250M, $1.2B, $500K.
+  function formatAmount(n: number): string {
+    if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(n % 1_000_000_000 ? 1 : 0)}B`;
+    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(n % 1_000_000 ? 1 : 0)}M`;
+    if (n >= 1_000) return `$${Math.round(n / 1_000)}K`;
+    return `$${n}`;
+  }
+
+  const fundingLine = $derived(
+    info.funding
+      ? [info.funding.type, info.funding.amount ? formatAmount(info.funding.amount) : null, info.funding.year]
+          .filter(Boolean)
+          .join(' · ')
+      : ''
+  );
+  const stockLine = $derived(
+    info.stock?.symbol ? (info.stock.exchange ? `${info.stock.exchange}: ${info.stock.symbol}` : info.stock.symbol) : ''
+  );
+  const websiteHref = $derived(website ? (website.startsWith('http') ? website : `https://${website}`) : '');
+
+  const hasInfo = $derived(
+    !!company.tagline ||
+      facts.length > 0 ||
+      industries.length > 0 ||
+      !!website ||
+      !!fundingLine ||
+      !!stockLine ||
+      !!info.parent ||
+      subsidiaries.length > 0
+  );
+</script>
+
+{#if hasInfo}
+  <section class="mt-4 rounded-xl border border-border bg-card p-4 text-sm">
+    {#if company.tagline}
+      <p class="text-muted-foreground">{company.tagline}</p>
+    {/if}
+
+    {#if facts.length}
+      <p class="mt-2 font-medium">{facts.join(' · ')}</p>
+    {/if}
+
+    {#if industries.length}
+      <div class="mt-3 flex flex-wrap gap-1.5">
+        {#each industries as industry (industry)}
+          <span class="rounded-full bg-secondary px-2 py-0.5 text-xs text-secondary-foreground">{industry}</span>
+        {/each}
+      </div>
+    {/if}
+
+    {#if fundingLine || stockLine || info.parent || subsidiaries.length}
+      <dl class="mt-3 grid gap-1 text-xs text-muted-foreground">
+        {#if fundingLine}
+          <div><dt class="inline font-medium text-foreground">Funding:</dt> {fundingLine}</div>
+        {/if}
+        {#if stockLine}
+          <div><dt class="inline font-medium text-foreground">Listed:</dt> {stockLine}</div>
+        {/if}
+        {#if info.parent}
+          <div><dt class="inline font-medium text-foreground">Parent:</dt> {info.parent}</div>
+        {/if}
+        {#if subsidiaries.length}
+          <div><dt class="inline font-medium text-foreground">Subsidiaries:</dt> {subsidiaries.join(', ')}</div>
+        {/if}
+      </dl>
+    {/if}
+
+    {#if website}
+      <a
+        class="mt-3 inline-block text-primary hover:underline"
+        href={websiteHref}
+        target="_blank"
+        rel="noopener noreferrer">{website} ↗</a
+      >
+    {/if}
+  </section>
+{/if}

--- a/web/src/lib/components/CompanyInfoCard.svelte
+++ b/web/src/lib/components/CompanyInfoCard.svelte
@@ -38,8 +38,9 @@
           .join(' · ')
       : ''
   );
+  // "NASDAQ: ACME", or just "ACME" when the exchange is unknown.
   const stockLine = $derived(
-    info.stock?.symbol ? (info.stock.exchange ? `${info.stock.exchange}: ${info.stock.symbol}` : info.stock.symbol) : ''
+    info.stock?.symbol ? [info.stock.exchange, info.stock.symbol].filter(Boolean).join(': ') : ''
   );
   const websiteHref = $derived(website ? (website.startsWith('http') ? website : `https://${website}`) : '');
 

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -5,6 +5,7 @@
   import States from './States.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyFollowButton from './CompanyFollowButton.svelte';
+  import CompanyInfoCard from './CompanyInfoCard.svelte';
 
   // The company entity is server-rendered (route `load`), so the header is in the
   // initial HTML. The job list is *streamed*: `initial` is a promise the route
@@ -24,6 +25,8 @@
     <CompanyFollowButton {slug} companyName={company.name} />
   </div>
 </div>
+
+<CompanyInfoCard {company} />
 
 <div class="mt-6">
   {#await initial}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -13,6 +13,25 @@ export interface ATSResponse {
   report: ATSReportContract | null;
 }
 
+/** The lower-coverage extras stored in the company's `company_info` JSONB. Every
+ *  field is optional — the loader omits what the source doesn't provide. */
+export interface CompanyInfo {
+  homepage?: string;
+  parent?: string;
+  subsidiaries?: string[];
+  activities?: string[];
+  funding?: {
+    type?: string;
+    amount?: number;
+    year?: number;
+    investors?: string[];
+  };
+  stock?: {
+    symbol?: string;
+    exchange?: string;
+  };
+}
+
 export interface Company {
   slug: string;
   name: string;
@@ -21,6 +40,15 @@ export interface Company {
   collections: string[];
   created_at: string | null;
   updated_at: string | null;
+  // Authoritative company-info facts (populated by the company-info backfill;
+  // absent/empty on unenriched rows). GetCompany is SELECT *, so these ride along.
+  industries?: string[];
+  year_founded?: number | null;
+  employee_count?: number | null;
+  hq_country?: string | null;
+  organization_type?: string | null;
+  tagline?: string | null;
+  company_info?: CompanyInfo;
 }
 
 /** A row of the companies catalog: company plus its computed job count. */


### PR DESCRIPTION
## What

Phase 2 of company-info: surface the authoritative company facts (landed by #408) on the company page.

Adds `CompanyInfoCard` between the header and the jobs list — a single-column card showing tagline, an inline facts line (founded · employees · HQ country · org type), industry chips, a website link, and — when present — funding / stock listing / parent / subsidiaries. Renders **nothing** when the company has no company-info, so unenriched companies are visually unchanged.

Extends the web `Company` type with the optional company-info fields + a `CompanyInfo` shape for the JSONB. Frontend-only; the company-detail API already returns the fields.

## Verification

`svelte-check` clean (0 errors); headless-screenshot check of full (with rare blocks), core-only, and unenriched (card absent) states — country codes resolve to names, counts formatted, `$250M` funding label.

## Depends on

Data appears once #408 (company-info-backfill) is merged, deployed, and the backfill has run. Until then the card simply never renders.