### PR TITLE
feat(auth): scope session cookie via COOKIE_DOMAIN for cross-subdomain SSO

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -141,6 +141,7 @@ func main() {
 		JWTSecret:      cfg.JWTSecret,
 		JWTTTL:         cfg.JWTTTL,
 		CookieSecure:   cfg.CookieSecure,
+		CookieDomain:   cfg.CookieDomain,
 		OAuthProviders: oauthProviders,
 		Search:         searchClient,
 		Blob:           blobStore,

--- a/internal/auth/cookie.go
+++ b/internal/auth/cookie.go
@@ -14,24 +14,29 @@ const CookieName = "hire_token"
 // SetTokenCookie writes the auth cookie. SameSite=Lax (with a same-origin
 // deployment) sends it on the app's own requests while blocking it on
 // cross-site ones, which covers CSRF for the current endpoints. secure comes
-// from config so dev (http://localhost) and HTTPS deployments both work.
-func SetTokenCookie(c *fiber.Ctx, token string, ttl time.Duration, secure bool) {
-	writeTokenCookie(c, token, time.Now().Add(ttl), secure)
+// from config so dev (http://localhost) and HTTPS deployments both work. domain
+// scopes the cookie: empty in dev (host-only cookie); ".freehire.dev" in prod so
+// freehire.dev and apply.freehire.dev send the same cookie (unified SSO).
+func SetTokenCookie(c *fiber.Ctx, token string, ttl time.Duration, secure bool, domain string) {
+	writeTokenCookie(c, token, time.Now().Add(ttl), secure, domain)
 }
 
-// ClearTokenCookie expires the auth cookie (logout).
-func ClearTokenCookie(c *fiber.Ctx, secure bool) {
-	writeTokenCookie(c, "", time.Now().Add(-time.Hour), secure)
+// ClearTokenCookie expires the auth cookie (logout). It MUST pass the same
+// secure/domain attributes used at set time — the browser only overwrites a
+// cookie whose attributes match.
+func ClearTokenCookie(c *fiber.Ctx, secure bool, domain string) {
+	writeTokenCookie(c, "", time.Now().Add(-time.Hour), secure, domain)
 }
 
 // writeTokenCookie is the single place the cookie's attributes are set, so set
 // and clear can't drift apart (the browser only overwrites a cookie whose
-// attributes match).
-func writeTokenCookie(c *fiber.Ctx, value string, expires time.Time, secure bool) {
+// attributes match). A blank Domain omits the attribute entirely (host-only).
+func writeTokenCookie(c *fiber.Ctx, value string, expires time.Time, secure bool, domain string) {
 	c.Cookie(&fiber.Cookie{
 		Name:     CookieName,
 		Value:    value,
 		Path:     "/",
+		Domain:   domain,
 		Expires:  expires,
 		HTTPOnly: true,
 		Secure:   secure,

--- a/internal/auth/cookie_test.go
+++ b/internal/auth/cookie_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// setCookieHeader runs a handler that writes the auth cookie with the given
+// domain and returns the resulting Set-Cookie header.
+func setCookieHeader(t *testing.T, domain string) string {
+	t.Helper()
+	app := fiber.New()
+	app.Get("/", func(c *fiber.Ctx) error {
+		SetTokenCookie(c, "tok", time.Hour, true, domain)
+		return c.SendStatus(fiber.StatusOK)
+	})
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	if err != nil {
+		t.Fatalf("test request failed: %v", err)
+	}
+	return resp.Header.Get("Set-Cookie")
+}
+
+// A non-empty domain must appear as the cookie's Domain attribute so the session
+// is shared across freehire.dev and apply.freehire.dev (unified SSO).
+func TestSetTokenCookieSetsDomain(t *testing.T) {
+	sc := setCookieHeader(t, ".freehire.dev")
+	if !strings.Contains(sc, CookieName+"=tok") {
+		t.Fatalf("cookie value missing in %q", sc)
+	}
+	if !strings.Contains(strings.ToLower(sc), "domain=.freehire.dev") {
+		t.Fatalf("expected domain attribute, got %q", sc)
+	}
+}
+
+// An empty domain must omit the Domain attribute entirely (host-only), which is
+// what dev on localhost relies on.
+func TestSetTokenCookieEmptyDomainOmitsAttribute(t *testing.T) {
+	sc := setCookieHeader(t, "")
+	if strings.Contains(strings.ToLower(sc), "domain=") {
+		t.Fatalf("expected no domain attribute, got %q", sc)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,11 @@ type Settings struct {
 	// any HTTPS deployment.
 	CookieSecure bool
 
+	// CookieDomain scopes the session cookie via its Domain attribute. Empty in
+	// dev (host-only). In prod set COOKIE_DOMAIN=.freehire.dev so a session minted
+	// on freehire.dev is also sent to apply.freehire.dev (unified SSO).
+	CookieDomain string
+
 	// OAuth holds per-provider client credentials keyed by provider name
 	// (google, github, linkedin). OAuth sign-in is optional: a provider with
 	// incomplete credentials is simply disabled (enforced where the provider
@@ -98,6 +103,7 @@ func Load() Settings {
 		JWTSecret:      os.Getenv("JWT_SECRET"),
 		JWTTTL:         envDuration("JWT_TTL", 30*24*time.Hour),
 		CookieSecure:   envBool("COOKIE_SECURE", false),
+		CookieDomain:   os.Getenv("COOKIE_DOMAIN"),
 		OAuth:          loadOAuth(),
 		MeiliURL:       env("MEILI_URL", "http://localhost:7700"),
 		MeiliKey:       os.Getenv("MEILI_MASTER_KEY"),

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -90,7 +90,7 @@ func (a *API) Login(c *fiber.Ctx) error {
 // Logout clears the auth cookie. It is public and idempotent: clearing an
 // absent or already-expired cookie is a no-op.
 func (a *API) Logout(c *fiber.Ctx) error {
-	auth.ClearTokenCookie(c, a.cookieSecure)
+	auth.ClearTokenCookie(c, a.cookieSecure, a.cookieDomain)
 	return c.SendStatus(fiber.StatusNoContent)
 }
 
@@ -100,7 +100,7 @@ func (a *API) setSession(c *fiber.Ctx, userID int64) error {
 	if err != nil {
 		return fiber.NewError(fiber.StatusInternalServerError, "failed to start session")
 	}
-	auth.SetTokenCookie(c, token, a.issuer.TTL(), a.cookieSecure)
+	auth.SetTokenCookie(c, token, a.issuer.TTL(), a.cookieSecure, a.cookieDomain)
 	return nil
 }
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -43,6 +43,9 @@ type API struct {
 	queries      *db.Queries
 	issuer       *auth.Issuer
 	cookieSecure bool
+	// cookieDomain scopes the session cookie so freehire.dev and apply.freehire.dev
+	// share it (empty = host-only, for dev).
+	cookieDomain string
 	// oauth maps enabled OAuth provider names to their implementations; empty
 	// when no provider is configured (the routes then 404 / list empty).
 	oauth map[string]oauth.Provider
@@ -134,6 +137,7 @@ type Config struct {
 	JWTSecret      string
 	JWTTTL         time.Duration
 	CookieSecure   bool
+	CookieDomain   string
 	OAuthProviders map[string]oauth.Provider
 	Search         *search.Client
 	// Blob backs résumé storage (internal/blobstore). Nil disables storage: résumé
@@ -163,6 +167,7 @@ func Register(app *fiber.App, cfg Config) {
 		queries:        queries,
 		issuer:         auth.NewIssuer(cfg.JWTSecret, cfg.JWTTTL),
 		cookieSecure:   cfg.CookieSecure,
+		cookieDomain:   cfg.CookieDomain,
 		oauth:          cfg.OAuthProviders,
 		frontendOrigin: cfg.FrontendOrigin,
 		tracking:       jobtracking.New(jobtracking.NewQueriesRepository(queries)),


### PR DESCRIPTION
## What
Thread an optional `COOKIE_DOMAIN` through the auth cookie writer so a session minted on **freehire.dev** is also sent to **apply.freehire.dev** (unified SSO). Mirrors the knob `freehire-apply` already has.

- `SetTokenCookie`/`ClearTokenCookie` take a `domain` arg; blank ⇒ host-only (unchanged for dev / single-host).
- `config` reads `COOKIE_DOMAIN`; the handler threads it from `Config`.
- Added cookie tests: `Domain` attribute is set when configured, omitted when empty.

## Why
Today hire sets a host-only `hire_token` cookie on `freehire.dev`, so a freehire.dev login is **not** carried to `apply.freehire.dev`. apply already validates hire-issued tokens with the shared `JWT_SECRET` and scopes its own cookie to `.freehire.dev`; this closes the hire→apply direction. **No change on the apply side.**

## Deploy note (ops)
Set `COOKIE_DOMAIN=.freehire.dev` on the hire `app` service in `freehire-ops` and redeploy `hire-app`. Empty in dev keeps host-only behavior.

## Caveat
Existing freehire.dev sessions hold a host-only cookie; the shared `.freehire.dev` cookie is minted on their **next** login (or after logout→login). No breakage — SSO activates from the next session, not retroactively.

## Testing
`go build ./cmd/server/...` + `go test ./internal/auth/... ./internal/config/... ./internal/handler/...` all pass. Cookie-writer change is additive and orthogonal to any in-flight work.