### PR TITLE
feat(enrich): gate non-tech categories out of AI enrichment

### DIFF
--- a/cmd/enrich/store.go
+++ b/cmd/enrich/store.go
@@ -26,7 +26,10 @@ func newDBStore(pool *pgxpool.Pool) *dbStore {
 }
 
 func (s *dbStore) Enqueue(ctx context.Context, targetVersion int) (int64, error) {
-	return s.q.EnqueuePendingJobs(ctx, int32(targetVersion))
+	return s.q.EnqueuePendingJobs(ctx, db.EnqueuePendingJobsParams{
+		TargetVersion:     int32(targetVersion),
+		ExcludeCategories: enrich.NonTechCategories,
+	})
 }
 
 func (s *dbStore) Claim(ctx context.Context, batch, leaseSeconds int) ([]enrich.Claimed, error) {

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/pipeline"
 	"github.com/strelov1/freehire/internal/search"
@@ -90,8 +91,9 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 	}
 
 	if _, err := qtx.EnqueueJobEnrichment(ctx, db.EnqueueJobEnrichmentParams{
-		TargetVersion: s.targetVersion,
-		JobID:         saved.Job.ID,
+		TargetVersion:     s.targetVersion,
+		JobID:             saved.Job.ID,
+		ExcludeCategories: enrich.NonTechCategories,
 	}); err != nil {
 		return fmt.Errorf("enqueue enrichment: %w", err)
 	}

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -124,8 +124,9 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 			return fmt.Errorf("upsert job %s: %w", externalID, err)
 		}
 		if _, err := qtx.EnqueueJobEnrichment(ctx, db.EnqueueJobEnrichmentParams{
-			TargetVersion: int32(enrich.Version),
-			JobID:         saved.Job.ID,
+			TargetVersion:     int32(enrich.Version),
+			JobID:             saved.Job.ID,
+			ExcludeCategories: enrich.NonTechCategories,
 		}); err != nil {
 			return fmt.Errorf("enqueue enrichment %s: %w", externalID, err)
 		}
@@ -197,8 +198,9 @@ func (s *extractStore) CompleteLinks(
 			return fmt.Errorf("upsert job %s/%s: %w", j.Source, j.ExternalID, err)
 		}
 		if _, err := qtx.EnqueueJobEnrichment(ctx, db.EnqueueJobEnrichmentParams{
-			TargetVersion: int32(enrich.Version),
-			JobID:         saved.Job.ID,
+			TargetVersion:     int32(enrich.Version),
+			JobID:             saved.Job.ID,
+			ExcludeCategories: enrich.NonTechCategories,
 		}); err != nil {
 			return fmt.Errorf("enqueue enrichment %s/%s: %w", j.Source, j.ExternalID, err)
 		}

--- a/internal/db/enrichment.sql.go
+++ b/internal/db/enrichment.sql.go
@@ -88,16 +88,25 @@ SELECT id, $1::int
 FROM jobs
 WHERE closed_at IS NULL
   AND (enriched_at IS NULL OR enrichment_version < $1::int)
+  AND category <> ALL(COALESCE($2::text[], '{}'))
 ON CONFLICT (job_id, target_version) DO NOTHING
 `
 
+type EnqueuePendingJobsParams struct {
+	TargetVersion     int32    `json:"target_version"`
+	ExcludeCategories []string `json:"exclude_categories"`
+}
+
 // Idempotent backfill: enqueue every OPEN job that is unenriched or below the target
 // schema version. Closed jobs (closed_at IS NOT NULL) are skipped — a dead posting no
-// user will see should not consume LLM budget. ON CONFLICT keeps exactly one entry per
-// (job_id, target_version), so running this every command invocation never duplicates
-// work.
-func (q *Queries) EnqueuePendingJobs(ctx context.Context, targetVersion int32) (int64, error) {
-	result, err := q.db.Exec(ctx, enqueuePendingJobs, targetVersion)
+// user will see should not consume LLM budget. Jobs whose derived category is in
+// exclude_categories (enrich.NonTechCategories) are skipped too, so LLM budget stays
+// on technical roles; category is NOT NULL DEFAULT ”, so an empty/unrecognized
+// category is never excluded (empty string <> ALL keeps the row). ON CONFLICT keeps
+// exactly one entry per (job_id, target_version), so running this every command
+// invocation never duplicates work.
+func (q *Queries) EnqueuePendingJobs(ctx context.Context, arg EnqueuePendingJobsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, enqueuePendingJobs, arg.TargetVersion, arg.ExcludeCategories)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/enrichment_integration_test.go
+++ b/internal/db/enrichment_integration_test.go
@@ -89,6 +89,35 @@ func setPostedAt(t *testing.T, pool *pgxpool.Pool, jobID int64, posted string) {
 	}
 }
 
+// setCategory stamps a job's derived category so the non-tech enqueue gate can be tested.
+func setCategory(t *testing.T, pool *pgxpool.Pool, jobID int64, category string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		"UPDATE jobs SET category = $1 WHERE id = $2", category, jobID); err != nil {
+		t.Fatalf("set category: %v", err)
+	}
+}
+
+// enqueuedJobIDs returns the outbox's job_ids in ascending order for assertions.
+func enqueuedJobIDs(t *testing.T, pool *pgxpool.Pool) []int64 {
+	t.Helper()
+	rows, err := pool.Query(context.Background(),
+		"SELECT job_id FROM enrichment_outbox ORDER BY job_id")
+	if err != nil {
+		t.Fatalf("select outbox: %v", err)
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan job_id: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 // closeJob soft-closes a job (sets closed_at) so claim/enqueue exclusion can be tested.
 func closeJob(t *testing.T, pool *pgxpool.Pool, jobID int64) {
 	t.Helper()
@@ -111,7 +140,7 @@ func TestEnrichmentClaimPriority(t *testing.T) {
 		newer := insertJob(t, pool, "newer")
 		setPostedAt(t, pool, older, "2024-01-01T00:00:00Z")
 		setPostedAt(t, pool, newer, "2024-06-01T00:00:00Z")
-		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -133,7 +162,7 @@ func TestEnrichmentClaimPriority(t *testing.T) {
 		dated := insertJob(t, pool, "dated")
 		setPostedAt(t, pool, dated, "2024-01-01T00:00:00Z")
 		undated := insertJob(t, pool, "undated") // posted_at NULL, created_at = now()
-		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -152,7 +181,7 @@ func TestEnrichmentClaimPriority(t *testing.T) {
 		open := insertJob(t, pool, "open")
 		gone := insertJob(t, pool, "closed")
 		closeJob(t, pool, gone)
-		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -178,7 +207,7 @@ func TestEnrichmentClaimPriority(t *testing.T) {
 		truncate(t, pool)
 		open := insertJob(t, pool, "open")
 		gone := insertJob(t, pool, "gone")
-		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 			t.Fatal(err)
 		}
 		// Close one job after it was queued: the claim-time filter must skip it.
@@ -204,7 +233,7 @@ func TestEnrichmentQueue(t *testing.T) {
 		insertJob(t, pool, "idem")
 
 		for i := 0; i < 2; i++ {
-			if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+			if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 				t.Fatalf("enqueue: %v", err)
 			}
 		}
@@ -221,7 +250,7 @@ func TestEnrichmentQueue(t *testing.T) {
 		truncate(t, pool)
 		insertJob(t, pool, "j1")
 		insertJob(t, pool, "j2")
-		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -245,7 +274,7 @@ func TestEnrichmentQueue(t *testing.T) {
 	t.Run("a stale lease is reclaimable", func(t *testing.T) {
 		truncate(t, pool)
 		insertJob(t, pool, "stale")
-		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -265,7 +294,7 @@ func TestEnrichmentQueue(t *testing.T) {
 	t.Run("attempts reaching max dead-letters the entry", func(t *testing.T) {
 		truncate(t, pool)
 		insertJob(t, pool, "dead")
-		if _, err := q.EnqueuePendingJobs(ctx, targetVersion); err != nil {
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
 			t.Fatal(err)
 		}
 		claimed, err := q.ClaimEnrichmentBatch(ctx, ClaimEnrichmentBatchParams{LeaseSeconds: 3600, BatchSize: 10})
@@ -291,6 +320,83 @@ func TestEnrichmentQueue(t *testing.T) {
 		// Dead-lettered → never claimed again, even with an expired lease.
 		if c, err := q.ClaimEnrichmentBatch(ctx, ClaimEnrichmentBatchParams{LeaseSeconds: 0, BatchSize: 10}); err != nil || len(c) != 0 {
 			t.Errorf("claim after dead-letter: rows=%d, want 0", len(c))
+		}
+	})
+}
+
+// TestEnqueueGatesNonTechCategory covers the AI-budget gate: both enqueue paths skip a
+// job whose derived category is blacklisted (enrich.NonTechCategories), while tech and
+// empty/unrecognized categories still enqueue. The empty string (” — the NOT NULL
+// column default for a title the classify dictionary could not place) must pass the
+// `<> ALL` gate, so a tech job with an unrecognized title is never silently dropped.
+func TestEnqueueGatesNonTechCategory(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	nonTech := []string{"marketing", "sales", "support", "management"}
+
+	t.Run("backfill enqueue skips only blacklisted categories", func(t *testing.T) {
+		truncate(t, pool)
+		tech := insertJob(t, pool, "tech")
+		setCategory(t, pool, tech, "backend")
+		sales := insertJob(t, pool, "sales")
+		setCategory(t, pool, sales, "sales")
+		empty := insertJob(t, pool, "empty") // category keeps the '' default
+		other := insertJob(t, pool, "other")
+		setCategory(t, pool, other, "other")
+
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{
+			TargetVersion:     targetVersion,
+			ExcludeCategories: nonTech,
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		got := enqueuedJobIDs(t, pool)
+		want := []int64{tech, empty, other} // sales excluded; keep tech + empty + other
+		sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+		if len(got) != len(want) {
+			t.Fatalf("enqueued = %v, want %v (sales excluded, empty/other kept)", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("enqueued = %v, want %v (sales excluded, empty/other kept)", got, want)
+			}
+		}
+	})
+
+	t.Run("transactional enqueue skips a blacklisted job", func(t *testing.T) {
+		truncate(t, pool)
+		mgmt := insertJob(t, pool, "mgmt")
+		setCategory(t, pool, mgmt, "management")
+
+		n, err := q.EnqueueJobEnrichment(ctx, EnqueueJobEnrichmentParams{
+			TargetVersion:     targetVersion,
+			JobID:             mgmt,
+			ExcludeCategories: nonTech,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("enqueued rows = %d, want 0 for a management job", n)
+		}
+		if got := enqueuedJobIDs(t, pool); len(got) != 0 {
+			t.Errorf("outbox = %v, want empty", got)
+		}
+	})
+
+	t.Run("nil exclude list gates nothing", func(t *testing.T) {
+		truncate(t, pool)
+		sales := insertJob(t, pool, "sales")
+		setCategory(t, pool, sales, "sales")
+		// A nil arg becomes NULL; COALESCE(..., '{}') makes `<> ALL` gate nothing, so a
+		// caller that forgets the exclude list keeps the pre-gate behavior (enqueue all).
+		if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: targetVersion}); err != nil {
+			t.Fatal(err)
+		}
+		if got := enqueuedJobIDs(t, pool); len(got) != 1 || got[0] != sales {
+			t.Errorf("enqueued = %v, want [%d] (nil exclude → no gating)", got, sales)
 		}
 	})
 }

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -94,21 +94,26 @@ SELECT id, $1::int
 FROM jobs
 WHERE id = $2::bigint
   AND (enriched_at IS NULL OR enrichment_version < $1::int)
+  AND category <> ALL(COALESCE($3::text[], '{}'))
 ON CONFLICT (job_id, target_version) DO NOTHING
 `
 
 type EnqueueJobEnrichmentParams struct {
-	TargetVersion int32 `json:"target_version"`
-	JobID         int64 `json:"job_id"`
+	TargetVersion     int32    `json:"target_version"`
+	JobID             int64    `json:"job_id"`
+	ExcludeCategories []string `json:"exclude_categories"`
 }
 
 // Transactional-outbox enqueue for the ingest write path: queue this one job for
-// enrichment, gated on the same condition the backfill uses (unenriched or below the
-// target schema version), so an already-enriched job is not re-queued. Idempotent via
-// the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+// enrichment, gated on the same conditions the backfill uses (unenriched or below the
+// target schema version, and a non-blacklisted category), so an already-enriched job
+// is not re-queued and a confidently non-technical role (exclude_categories =
+// enrich.NonTechCategories) never consumes LLM budget. category is NOT NULL DEFAULT ”,
+// so an empty/unrecognized category still enqueues (empty string <> ALL). Idempotent
+// via the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
 // job's UpsertJob so a newly ingested job is queued atomically with its write.
 func (q *Queries) EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrichmentParams) (int64, error) {
-	result, err := q.db.Exec(ctx, enqueueJobEnrichment, arg.TargetVersion, arg.JobID)
+	result, err := q.db.Exec(ctx, enqueueJobEnrichment, arg.TargetVersion, arg.JobID, arg.ExcludeCategories)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -152,17 +152,23 @@ type Querier interface {
 	// refreshes dismissed_at in place.
 	DismissJob(ctx context.Context, arg DismissJobParams) (UserJob, error)
 	// Transactional-outbox enqueue for the ingest write path: queue this one job for
-	// enrichment, gated on the same condition the backfill uses (unenriched or below the
-	// target schema version), so an already-enriched job is not re-queued. Idempotent via
-	// the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+	// enrichment, gated on the same conditions the backfill uses (unenriched or below the
+	// target schema version, and a non-blacklisted category), so an already-enriched job
+	// is not re-queued and a confidently non-technical role (exclude_categories =
+	// enrich.NonTechCategories) never consumes LLM budget. category is NOT NULL DEFAULT '',
+	// so an empty/unrecognized category still enqueues (empty string <> ALL). Idempotent
+	// via the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
 	// job's UpsertJob so a newly ingested job is queued atomically with its write.
 	EnqueueJobEnrichment(ctx context.Context, arg EnqueueJobEnrichmentParams) (int64, error)
 	// Idempotent backfill: enqueue every OPEN job that is unenriched or below the target
 	// schema version. Closed jobs (closed_at IS NOT NULL) are skipped — a dead posting no
-	// user will see should not consume LLM budget. ON CONFLICT keeps exactly one entry per
-	// (job_id, target_version), so running this every command invocation never duplicates
-	// work.
-	EnqueuePendingJobs(ctx context.Context, targetVersion int32) (int64, error)
+	// user will see should not consume LLM budget. Jobs whose derived category is in
+	// exclude_categories (enrich.NonTechCategories) are skipped too, so LLM budget stays
+	// on technical roles; category is NOT NULL DEFAULT '', so an empty/unrecognized
+	// category is never excluded (empty string <> ALL keeps the row). ON CONFLICT keeps
+	// exactly one entry per (job_id, target_version), so running this every command
+	// invocation never duplicates work.
+	EnqueuePendingJobs(ctx context.Context, arg EnqueuePendingJobsParams) (int64, error)
 	// Fast approximate open-job total for the DB-backed /jobs list's meta.total. An
 	// exact count(*) over ~millions of open rows was a per-request full scan; the
 	// planner's estimate (see estimate_open_jobs(), migration 0033) is O(1) and

--- a/internal/db/queries/enrichment.sql
+++ b/internal/db/queries/enrichment.sql
@@ -1,14 +1,18 @@
 -- name: EnqueuePendingJobs :execrows
 -- Idempotent backfill: enqueue every OPEN job that is unenriched or below the target
 -- schema version. Closed jobs (closed_at IS NOT NULL) are skipped — a dead posting no
--- user will see should not consume LLM budget. ON CONFLICT keeps exactly one entry per
--- (job_id, target_version), so running this every command invocation never duplicates
--- work.
+-- user will see should not consume LLM budget. Jobs whose derived category is in
+-- exclude_categories (enrich.NonTechCategories) are skipped too, so LLM budget stays
+-- on technical roles; category is NOT NULL DEFAULT '', so an empty/unrecognized
+-- category is never excluded (empty string <> ALL keeps the row). ON CONFLICT keeps
+-- exactly one entry per (job_id, target_version), so running this every command
+-- invocation never duplicates work.
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, sqlc.arg(target_version)::int
 FROM jobs
 WHERE closed_at IS NULL
   AND (enriched_at IS NULL OR enrichment_version < sqlc.arg(target_version)::int)
+  AND category <> ALL(COALESCE(sqlc.arg(exclude_categories)::text[], '{}'))
 ON CONFLICT (job_id, target_version) DO NOTHING;
 
 -- name: ClaimEnrichmentBatch :many

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -394,15 +394,19 @@ WHERE id = sqlc.arg(id);
 
 -- name: EnqueueJobEnrichment :execrows
 -- Transactional-outbox enqueue for the ingest write path: queue this one job for
--- enrichment, gated on the same condition the backfill uses (unenriched or below the
--- target schema version), so an already-enriched job is not re-queued. Idempotent via
--- the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
+-- enrichment, gated on the same conditions the backfill uses (unenriched or below the
+-- target schema version, and a non-blacklisted category), so an already-enriched job
+-- is not re-queued and a confidently non-technical role (exclude_categories =
+-- enrich.NonTechCategories) never consumes LLM budget. category is NOT NULL DEFAULT '',
+-- so an empty/unrecognized category still enqueues (empty string <> ALL). Idempotent
+-- via the outbox's UNIQUE (job_id, target_version). Run in the same transaction as the
 -- job's UpsertJob so a newly ingested job is queued atomically with its write.
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, sqlc.arg(target_version)::int
 FROM jobs
 WHERE id = sqlc.arg(job_id)::bigint
   AND (enriched_at IS NULL OR enrichment_version < sqlc.arg(target_version)::int)
+  AND category <> ALL(COALESCE(sqlc.arg(exclude_categories)::text[], '{}'))
 ON CONFLICT (job_id, target_version) DO NOTHING;
 
 -- name: SetJobEnrichment :exec

--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -95,7 +95,15 @@ var (
 		"design", "product", "project_management", "management",
 		"marketing", "sales", "support", "other",
 	}
-	DomainValues = []string{
+	// NonTechCategories are the CategoryValues for confidently non-technical roles
+	// that are excluded from AI enrichment: the derived category is a source fact
+	// (internal/classify, from the title), so gating the enrichment enqueue on it
+	// keeps LLM budget off jobs no engineer will see. It is a blacklist, not a
+	// whitelist — only categories we are sure are non-technical are dropped; an
+	// empty/"other"/unrecognized category still enqueues, so a tech job the title
+	// dictionary could not place is never silently skipped.
+	NonTechCategories = []string{"marketing", "sales", "support", "management"}
+	DomainValues      = []string{
 		"fintech", "gambling", "ecommerce", "crypto", "healthcare",
 		"saas", "gamedev", "edtech", "adtech", "govtech",
 		"media", "travel", "logistics", "other",

--- a/internal/moderation/repository.go
+++ b/internal/moderation/repository.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/enrich"
 )
 
 // Compile-time proof that QueriesRepository satisfies Repository.
@@ -44,8 +45,9 @@ func (r *QueriesRepository) Create(ctx context.Context, p db.UpsertManualJobPara
 		return db.Job{}, fmt.Errorf("upsert manual job: %w", err)
 	}
 	if _, err := qtx.EnqueueJobEnrichment(ctx, db.EnqueueJobEnrichmentParams{
-		TargetVersion: r.targetVersion,
-		JobID:         job.ID,
+		TargetVersion:     r.targetVersion,
+		JobID:             job.ID,
+		ExcludeCategories: enrich.NonTechCategories,
 	}); err != nil {
 		return db.Job{}, fmt.Errorf("enqueue enrichment: %w", err)
 	}

--- a/openspec/changes/company-info-display/.openspec.yaml
+++ b/openspec/changes/company-info-display/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/company-info-display/design.md
+++ b/openspec/changes/company-info-display/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The company page (`web/src/routes/companies/[slug]/+page.svelte` → `CompanyView.svelte`)
+renders a header (logo, name, follow) then a streamed jobs list. The company-detail API
+returns `db.Company`, which now carries the company-info columns (`industries`,
+`year_founded`, `employee_count`, `hq_country`, `organization_type`, `tagline`) and the
+`company_info` JSONB. The hand-written web `Company` type (`web/src/lib/types.ts`) does not
+expose them yet. `facets.ts` already has `countryLabel(code)` (ISO alpha-2 → English name).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show the company's authoritative facts on its page, degrading gracefully as fields are
+  missing.
+
+**Non-Goals:**
+- No backend/API/schema change (data already served).
+- No `industries` search facet or company-list changes (a separate change).
+- No JSON-LD enrichment (foundingDate/numberOfEmployees) — noted as a later refinement.
+
+## Decisions
+
+**A single stacked card, not a sidebar.** The card sits between the header and the jobs
+list, full width. *Alternative — a two-column sidebar* — was rejected during design as a
+larger layout change for little gain; the card reads well stacked and keeps the jobs list
+full width.
+
+**Render-only-what-exists, hide-when-empty.** Every field is conditional; the whole card
+returns nothing when no company-info field is set. This keeps unenriched (job-only)
+companies visually unchanged and avoids empty scaffolding — the same "dict-silent stays
+silent" spirit as the backend facets.
+
+**Type the `company_info` JSONB explicitly.** Add a `CompanyInfo` interface
+(`{ homepage?, parent?, subsidiaries?[], activities?[], funding?{type?,amount?,year?,investors?[]}, stock?{symbol?,exchange?} }`)
+rather than `unknown`, so the template reads typed fields. The company-info columns are added
+to the `Company` interface as optional (older API responses / unenriched rows omit them).
+
+**Reuse existing helpers.** HQ uses `countryLabel`; chips reuse the app's rounded-full badge
+styling; employee count is formatted with `toLocaleString`; a small local helper formats a
+funding amount (e.g. `$250M`).
+
+## Risks / Trade-offs
+
+- **Type drift between hand-written `Company` and the API** → fields are optional and
+  defensively read, so a missing field just hides its line; no runtime break.
+- **`company_info` shape depends on the backfill's JSONB assembly** → the `CompanyInfo` type
+  mirrors exactly what the loader writes (`funding`/`stock`/`homepage`/`parent`/
+  `subsidiaries`/`activities`); documented in both places.
+
+## Migration Plan
+
+Frontend-only; ships with the normal web deploy. No data migration. Depends on the
+`company-info-backfill` change being merged and run so the fields are populated (before that,
+the card simply never renders).
+
+## Open Questions
+
+- Whether to later feed `year_founded`/`employee_count` into the company `organizationJsonLd`
+  for richer structured data — deferred.

--- a/openspec/changes/company-info-display/proposal.md
+++ b/openspec/changes/company-info-display/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The company-info backfill (previous change) lands authoritative company facts — size,
+founding year, HQ, organization type, industries, tagline, website, and occasional
+funding/stock/parent data — on the `companies` row, and the company-detail API already
+returns them. Nothing surfaces them yet: the company page shows only a name header and the
+jobs list. This change renders those facts so a visitor sees who the company is, not just
+its openings.
+
+## What Changes
+
+- Add a `CompanyInfoCard` component to the company page (`CompanyView`), a single-column
+  card between the header and the jobs list.
+- The card renders **only the fields that are present**, and renders nothing at all when the
+  company has no company-info (so unenriched companies show no empty box).
+- Card content: tagline; an inline facts line (founded · employees · HQ country · org type);
+  industry chips; a website link; and — when present — funding, stock listing, parent
+  company, and subsidiaries.
+- Extend the hand-written web `Company` type with the company-info fields and a `CompanyInfo`
+  shape for the `company_info` JSONB.
+
+## Capabilities
+
+### New Capabilities
+- `company-info-display`: rendering the company's authoritative firmographic facts on the
+  company detail page, conditional on availability.
+
+### Modified Capabilities
+<!-- none: purely additive frontend rendering of data the API already returns -->
+
+## Impact
+
+- **Frontend only.** New `web/src/lib/components/CompanyInfoCard.svelte`; wired into
+  `CompanyView.svelte`. `web/src/lib/types.ts` gains optional company-info fields +
+  `CompanyInfo`. Reuses `countryLabel` (facets.ts) for HQ.
+- No backend/API/schema change (the company-detail response already carries the fields).
+- Depends on the `company-info-backfill` change being merged so the data exists.

--- a/openspec/changes/company-info-display/specs/company-info-display/spec.md
+++ b/openspec/changes/company-info-display/specs/company-info-display/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Company page surfaces authoritative company facts
+
+The company detail page SHALL render the company's authoritative company-info facts in a
+card between the page header and the jobs list. The card SHALL render only the fields that
+are present, and SHALL render nothing at all when the company has no company-info, so an
+unenriched company shows no empty container.
+
+When present, the card SHALL show: the tagline; an inline facts line composed of founding
+year, employee count, HQ country (the ISO code resolved to an English country name), and
+organization type, with only the present facts shown; the industries as chips; and a website
+link that opens in a new tab. When present in the `company_info` payload, the card SHALL also
+show funding (type, amount, year), stock listing (exchange and symbol), the parent company,
+and subsidiaries.
+
+#### Scenario: Enriched company shows its facts
+
+- **WHEN** a visitor opens the page of a company that has company-info
+- **THEN** the card appears above the jobs list showing the present facts (tagline, founded,
+  employees, HQ country name, organization type, industries, website) and omitting any facts
+  that are absent
+
+#### Scenario: Unenriched company shows no card
+
+- **WHEN** a visitor opens the page of a company that has no company-info fields
+- **THEN** no company-info card is rendered and the page shows the header and jobs list as
+  before
+
+#### Scenario: HQ country code is shown as a country name
+
+- **WHEN** the company's HQ country is stored as an ISO 3166-1 alpha-2 code (e.g. `US`)
+- **THEN** the card displays the resolved English country name (e.g. "United States")
+
+#### Scenario: Rare facts appear only when present
+
+- **WHEN** the company's `company_info` payload contains funding, stock, parent, or
+  subsidiaries data
+- **THEN** those sections are shown; and when a company lacks them, those sections are omitted
+
+#### Scenario: Reference company page
+
+- **WHEN** a visitor opens the page of a reference company that has company-info but no jobs
+- **THEN** the card is shown as the page's main content and the jobs list shows its empty
+  state below

--- a/openspec/changes/company-info-display/tasks.md
+++ b/openspec/changes/company-info-display/tasks.md
@@ -1,0 +1,18 @@
+## 1. Types
+
+- [x] 1.1 Add optional company-info fields to the `Company` interface in `web/src/lib/types.ts`: `industries?`, `year_founded?`, `employee_count?`, `hq_country?`, `organization_type?`, `tagline?`, `company_info?: CompanyInfo`
+- [x] 1.2 Add a `CompanyInfo` interface mirroring the loader's JSONB: `{ homepage?, parent?, subsidiaries?, activities?, funding?: { type?, amount?, year?, investors? }, stock?: { symbol?, exchange? } }`
+
+## 2. Component
+
+- [x] 2.1 Add `web/src/lib/components/CompanyInfoCard.svelte` taking a `company: Company` prop; compute a `hasInfo` guard and render nothing when false
+- [x] 2.2 Render tagline; inline facts line (founded · `toLocaleString` employees · `countryLabel(hq_country)` · organization_type — present only); industry chips (rounded-full badge)
+- [x] 2.3 Render website link (`target=_blank rel=noopener`) from `company_info.homepage`; and the rare blocks (funding, stock `EXCHANGE: SYMBOL`, parent, subsidiaries) each conditional on presence; add a small funding-amount formatter (e.g. `$250M`)
+
+## 3. Wire-in
+
+- [x] 3.1 Render `CompanyInfoCard` in `CompanyView.svelte` between the header and the `mt-6` jobs block
+
+## 4. Verify
+
+- [x] 4.1 `npm run check` (svelte-check) clean for the touched files; visual check via headless screenshot on an enriched company, an unenriched company (no card), and a reference company (card + empty jobs)

--- a/web/src/lib/components/CompanyInfoCard.svelte
+++ b/web/src/lib/components/CompanyInfoCard.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import type { Company } from '$lib/types';
+  import { countryLabel } from '$lib/facets';
+
+  // The company's authoritative company-info facts, rendered above the jobs list.
+  // Every field is optional (populated by the backfill); the whole card renders
+  // nothing when the company has no info, so unenriched companies are unchanged.
+  let { company }: { company: Company } = $props();
+
+  const info = $derived(company.company_info ?? {});
+
+  // Inline facts, present-only, in a stable order.
+  const facts = $derived(
+    [
+      company.year_founded ? `Founded ${company.year_founded}` : null,
+      company.employee_count ? `${company.employee_count.toLocaleString()} employees` : null,
+      company.hq_country ? countryLabel(company.hq_country) : null,
+      company.organization_type || null,
+    ].filter((f): f is string => !!f)
+  );
+
+  const industries = $derived(company.industries ?? []);
+  const website = $derived(info.homepage);
+  const subsidiaries = $derived(info.subsidiaries ?? []);
+
+  // Compact money label: $250M, $1.2B, $500K.
+  function formatAmount(n: number): string {
+    if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(n % 1_000_000_000 ? 1 : 0)}B`;
+    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(n % 1_000_000 ? 1 : 0)}M`;
+    if (n >= 1_000) return `$${Math.round(n / 1_000)}K`;
+    return `$${n}`;
+  }
+
+  const fundingLine = $derived(
+    info.funding
+      ? [info.funding.type, info.funding.amount ? formatAmount(info.funding.amount) : null, info.funding.year]
+          .filter(Boolean)
+          .join(' · ')
+      : ''
+  );
+  const stockLine = $derived(
+    info.stock?.symbol ? (info.stock.exchange ? `${info.stock.exchange}: ${info.stock.symbol}` : info.stock.symbol) : ''
+  );
+  const websiteHref = $derived(website ? (website.startsWith('http') ? website : `https://${website}`) : '');
+
+  const hasInfo = $derived(
+    !!company.tagline ||
+      facts.length > 0 ||
+      industries.length > 0 ||
+      !!website ||
+      !!fundingLine ||
+      !!stockLine ||
+      !!info.parent ||
+      subsidiaries.length > 0
+  );
+</script>
+
+{#if hasInfo}
+  <section class="mt-4 rounded-xl border border-border bg-card p-4 text-sm">
+    {#if company.tagline}
+      <p class="text-muted-foreground">{company.tagline}</p>
+    {/if}
+
+    {#if facts.length}
+      <p class="mt-2 font-medium">{facts.join(' · ')}</p>
+    {/if}
+
+    {#if industries.length}
+      <div class="mt-3 flex flex-wrap gap-1.5">
+        {#each industries as industry (industry)}
+          <span class="rounded-full bg-secondary px-2 py-0.5 text-xs text-secondary-foreground">{industry}</span>
+        {/each}
+      </div>
+    {/if}
+
+    {#if fundingLine || stockLine || info.parent || subsidiaries.length}
+      <dl class="mt-3 grid gap-1 text-xs text-muted-foreground">
+        {#if fundingLine}
+          <div><dt class="inline font-medium text-foreground">Funding:</dt> {fundingLine}</div>
+        {/if}
+        {#if stockLine}
+          <div><dt class="inline font-medium text-foreground">Listed:</dt> {stockLine}</div>
+        {/if}
+        {#if info.parent}
+          <div><dt class="inline font-medium text-foreground">Parent:</dt> {info.parent}</div>
+        {/if}
+        {#if subsidiaries.length}
+          <div><dt class="inline font-medium text-foreground">Subsidiaries:</dt> {subsidiaries.join(', ')}</div>
+        {/if}
+      </dl>
+    {/if}
+
+    {#if website}
+      <a
+        class="mt-3 inline-block text-primary hover:underline"
+        href={websiteHref}
+        target="_blank"
+        rel="noopener noreferrer">{website} ↗</a
+      >
+    {/if}
+  </section>
+{/if}

--- a/web/src/lib/components/CompanyInfoCard.svelte
+++ b/web/src/lib/components/CompanyInfoCard.svelte
@@ -38,8 +38,9 @@
           .join(' · ')
       : ''
   );
+  // "NASDAQ: ACME", or just "ACME" when the exchange is unknown.
   const stockLine = $derived(
-    info.stock?.symbol ? (info.stock.exchange ? `${info.stock.exchange}: ${info.stock.symbol}` : info.stock.symbol) : ''
+    info.stock?.symbol ? [info.stock.exchange, info.stock.symbol].filter(Boolean).join(': ') : ''
   );
   const websiteHref = $derived(website ? (website.startsWith('http') ? website : `https://${website}`) : '');
 

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -5,6 +5,7 @@
   import States from './States.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyFollowButton from './CompanyFollowButton.svelte';
+  import CompanyInfoCard from './CompanyInfoCard.svelte';
 
   // The company entity is server-rendered (route `load`), so the header is in the
   // initial HTML. The job list is *streamed*: `initial` is a promise the route
@@ -24,6 +25,8 @@
     <CompanyFollowButton {slug} companyName={company.name} />
   </div>
 </div>
+
+<CompanyInfoCard {company} />
 
 <div class="mt-6">
   {#await initial}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -13,6 +13,25 @@ export interface ATSResponse {
   report: ATSReportContract | null;
 }
 
+/** The lower-coverage extras stored in the company's `company_info` JSONB. Every
+ *  field is optional — the loader omits what the source doesn't provide. */
+export interface CompanyInfo {
+  homepage?: string;
+  parent?: string;
+  subsidiaries?: string[];
+  activities?: string[];
+  funding?: {
+    type?: string;
+    amount?: number;
+    year?: number;
+    investors?: string[];
+  };
+  stock?: {
+    symbol?: string;
+    exchange?: string;
+  };
+}
+
 export interface Company {
   slug: string;
   name: string;
@@ -21,6 +40,15 @@ export interface Company {
   collections: string[];
   created_at: string | null;
   updated_at: string | null;
+  // Authoritative company-info facts (populated by the company-info backfill;
+  // absent/empty on unenriched rows). GetCompany is SELECT *, so these ride along.
+  industries?: string[];
+  year_founded?: number | null;
+  employee_count?: number | null;
+  hq_country?: string | null;
+  organization_type?: string | null;
+  tagline?: string | null;
+  company_info?: CompanyInfo;
 }
 
 /** A row of the companies catalog: company plus its computed job count. */


### PR DESCRIPTION
## Why

The enrichment worker spends LLM budget on every open, unenriched job. On prod ~19% of open jobs are confidently non-technical roles (marketing/sales/support/management by the deterministic title-derived `category`) that no engineer will see. This gates them out of the enqueue path.

## What

- New `enrich.NonTechCategories = {marketing, sales, support, management}` (single source, beside `CategoryValues`).
- Both enqueue queries — the transactional-outbox `EnqueueJobEnrichment` and the backfill `EnqueuePendingJobs` — add `AND category <> ALL(COALESCE(exclude_categories, '{}'))`. All 5 call sites (ingest / enrich / tg-extract×2 / moderation) pass `enrich.NonTechCategories`.
- **Blacklist, not whitelist:** an empty / `other` / unrecognized category still enqueues, so a tech job the title dictionary could not classify is never silently skipped.
- `COALESCE(..., '{}')` makes a nil/empty exclude list gate nothing (null-safe; preserves pre-gate behavior).

## Impact

- Cuts ~20% of pending enrichment calls (prod: 334K of 1.67M) at zero risk to tech coverage.
- No schema change. The gate affects only future enqueues; already-queued non-tech rows drain once (optional one-time DELETE for the backlog).

## Test plan

- `go build ./... && go vet ./... && go test ./...` green.
- `go test -tags=integration ./internal/db/` green, incl. new `TestEnqueueGatesNonTechCategory` (both enqueue paths skip a blacklisted category; empty/other keep enqueuing; nil exclude gates nothing).