### PR TITLE
fix(web): raise nginx proxy_buffer_size (company page 502)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/hire ./cmd/server
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/liveness ./cmd/liveness \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/notify ./cmd/notify \
  && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/import-collections ./cmd/import-collections \
- && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/recount-companies ./cmd/recount-companies
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/recount-companies ./cmd/recount-companies \
+ && CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/backfill-company-info ./cmd/backfill-company-info
 
 # --- runtime stage ---
 FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /app
-COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-derive /out/liveness /out/notify /out/import-collections /out/recount-companies /app/
+COPY --from=build /out/hire /out/ingest /out/enrich /out/reindex /out/tg-ingest /out/tg-extract /out/reslug /out/backfill-derive /out/liveness /out/notify /out/import-collections /out/recount-companies /out/backfill-company-info /app/
 EXPOSE 8080
 USER nonroot:nonroot
 ENTRYPOINT ["/app/hire"]

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -55,5 +55,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # SvelteKit emits a large `Link: rel=modulepreload` response header that grows
+        # with a page's module graph; some pages (e.g. company detail) exceed nginx's
+        # default 4k proxy_buffer_size, which otherwise fails with 502 "upstream sent
+        # too big header". Give the response-header buffer generous headroom.
+        proxy_buffer_size 16k;
+        proxy_buffers 8 16k;
+        proxy_busy_buffers_size 16k;
     }
 }


### PR DESCRIPTION
The company-detail page's SvelteKit modulepreload Link header (4097 bytes) exceeds nginx's default 4k proxy_buffer_size → 502 'upstream sent too big header'. Raise to 16k. Also ships the backfill-company-info binary in the image (earlier commit).