### PR TITLE
feat(skilltag): expand dictionary with security/qa/data skills

### DIFF
--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -334,6 +334,35 @@ var wordAliases = map[string]string{
 	// web3
 	"web3":     "web3",
 	"ethereum": "ethereum",
+	// security (unambiguous tokens; ambiguous "burp" routes via a phrase below)
+	"nmap":       "nmap",
+	"wireshark":  "wireshark",
+	"metasploit": "metasploit",
+	"owasp":      "owasp",
+	"nessus":     "nessus",
+	"keycloak":   "keycloak",
+	"oauth":      "oauth",
+	"oauth2":     "oauth",
+	"saml":       "saml",
+	"openid":     "openid",
+	"oidc":       "openid",
+	"jwt":        "jwt",
+	// qa / testing
+	"puppeteer": "puppeteer",
+	"appium":    "appium",
+	"k6":        "k6",
+	"gatling":   "gatling",
+	"jmeter":    "jmeter",
+	"testng":    "testng",
+	"soapui":    "soapui",
+	// data — ELT / warehouse (unambiguous; ambiguous engines route via phrases below)
+	"metabase": "metabase",
+	"dagster":  "dagster",
+	"airbyte":  "airbyte",
+	"fivetran": "fivetran",
+	"debezium": "debezium",
+	"hbase":    "hbase",
+	"nifi":     "nifi",
 }
 
 // phraseAlias is a punctuated or multi-word term matched against the normalized
@@ -399,6 +428,17 @@ var phraseAliases = []phraseAlias{
 	{"generative ai", "generative-ai"}, {"gen ai", "generative-ai"},
 	{"deep learning", "deep-learning"},
 	{"six sigma", "six-sigma"},
+	// Lightcast-diffed gaps (security/qa/data). Ambiguous English words (burp, druid,
+	// pinot, presto, iceberg) are emitted ONLY via a qualifying phrase, so a bare
+	// non-tech use ("a druid", "pinot noir", "a loud burp") never tags — same doctrine
+	// as c/r above.
+	{"burp suite", "burp-suite"},
+	{"robot framework", "robot-framework"},
+	{"apache druid", "druid"},
+	{"apache pinot", "pinot"},
+	{"prestodb", "presto"}, {"presto db", "presto"},
+	{"delta lake", "delta-lake"},
+	{"apache iceberg", "iceberg"},
 }
 
 // sharedAcronyms resolve in ALL text (jobs and résumés). They are matched by their

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -281,3 +281,42 @@ func TestParse_AIVocab(t *testing.T) {
 		})
 	}
 }
+
+// TestParse_ExpansionBatch1 covers the security/qa/data skill additions (diffed
+// against the Lightcast ATS taxonomy). Positives assert the new canonicals tag;
+// negatives assert the ambiguous-word skills route ONLY via a qualifying phrase,
+// so a bare English use ("a druid", "a burp") never misfires — the precision-first
+// doctrine the dictionary already applies to c/r/go.
+func TestParse_ExpansionBatch1(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		// security
+		{"scanners", "We run Metasploit, Nmap and Wireshark.", []string{"metasploit", "nmap", "wireshark"}},
+		{"appsec tools", "OWASP guidelines, Nessus scans, Burp Suite pentest.", []string{"burp-suite", "nessus", "owasp"}},
+		{"auth stack", "Auth: OAuth2, SAML, JWT, Keycloak, OpenID Connect.", []string{"jwt", "keycloak", "oauth", "openid", "saml"}},
+		// qa
+		{"load + browser + frameworks", "Load: k6, Gatling, JMeter. Browser: Puppeteer, Appium. Frameworks: TestNG, Robot Framework, SoapUI.",
+			[]string{"appium", "gatling", "jmeter", "k6", "puppeteer", "robot-framework", "soapui", "testng"}},
+		// data — ELT/warehouse
+		{"elt pipeline", "Airbyte, Fivetran, Dagster, Debezium into Metabase; HBase, Apache NiFi.",
+			[]string{"airbyte", "dagster", "debezium", "fivetran", "hbase", "metabase", "nifi"}},
+		// data — query engines routed via phrase (bare token is ambiguous)
+		{"query engines via phrase", "Apache Druid, Apache Pinot, PrestoDB, Delta Lake, Apache Iceberg.",
+			[]string{"delta-lake", "druid", "iceberg", "pinot", "presto"}},
+
+		// precision negatives — ambiguous words must NOT tag without their qualifier
+		{"bare ambiguous words do not tag", "The druid drank pinot noir, said presto, and admired the iceberg.", nil},
+		{"burp is not a skill", "He let out a loud burp.", nil},
+		{"jasmine and karma are not added", "Jasmine watered the plants with good karma.", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Parse(tc.in); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("Parse(%q) = %#v, want %#v", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
First batch of `internal/skilltag` dictionary gaps, found by diffing our canonical set against the **Lightcast (EMSI) Open Skills** ATS taxonomy (34K skills; the taxonomy O*NET itself migrated to in 2022).

## Context

The dict had ~305 canonical tech skills. Diffing against Lightcast surfaced ~100 well-known tech skills we were missing. This PR ships the highest-signal, unambiguous batch — **security, QA, data** — grouped by category.

## What

New `wordAliases` (unambiguous tokens): nmap, wireshark, metasploit, owasp, nessus, keycloak, oauth(2), saml, openid/oidc, jwt · puppeteer, appium, k6, gatling, jmeter, testng, soapui · metabase, dagster, airbyte, fivetran, debezium, hbase, nifi.

New `phraseAliases` (ambiguous English words — emitted **only** via a qualifying phrase so a bare non-tech use never tags): `burp suite`, `robot framework`, `apache druid`→druid, `apache pinot`→pinot, `prestodb`/`presto db`→presto, `delta lake`, `apache iceberg`→iceberg.

## Precision

The ambiguous-word routing mirrors the dict's existing doctrine for `c`/`r`/`go` (never a bare alias). Tests cover both positives (each new canonical tags) and precision-negatives ("The druid drank pinot noir, said presto, admired the iceberg" → nothing; "a loud burp" → nothing).

## Test plan

- `go build ./... && go vet ./... && go test ./...` green, incl. `TestDictionaryInvariants` (slug form, floor, ambiguous-not-bare) and the new `TestParse_ExpansionBatch1`.

## Ops

Dictionary-facet change → needs `cmd/backfill-derive` + `make reindex` to reach existing jobs (deferred to a quiet window; the host is currently disk-constrained).

## Follow-ups

- ~66 more diffed candidates remain (cloud/devops, frontend, ml, erp) + the ambiguous tier that needs phrase-anchoring.
- The stronger signal — mining `jobs.enrichment->skills` for frequency-ranked real gaps — is queued for a quiet window.