### PR TITLE
feat(classify): expand role dictionary (non-tech titles + tech synonyms)

### DIFF
--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -99,3 +99,40 @@ func TestCanonicalValuesAreInVocabulary(t *testing.T) {
 		}
 	}
 }
+
+// TestParse_RoleExpansionBatch covers the categoryAliases expansion: non-tech role
+// titles that feed the enrichment gate (higher-precision than the description tier)
+// plus a few tech-role synonyms. Precision cases confirm the bare-"manager" fallback
+// and unrelated roles are unaffected.
+func TestParse_RoleExpansionBatch(t *testing.T) {
+	cases := []struct{ title, wantCategory string }{
+		// non-tech titles (feed the gate) — new forms not previously matched
+		{"SDR", "sales"},
+		{"Business Development Manager", "sales"},
+		{"Account Manager", "sales"},
+		{"Customer Success Manager", "support"},
+		{"Help Desk Technician", "support"},
+		{"Customer Service Specialist", "support"},
+		{"Copywriter", "marketing"},
+		{"Content Writer", "marketing"},
+		{"Brand Manager", "marketing"},
+		// tech-role synonyms (facet quality)
+		{"Platform Engineer", "devops"},
+		{"Cloud Engineer", "devops"},
+		{"Infrastructure Engineer", "devops"},
+		{"System Administrator", "devops"},
+		{"SDET", "qa"},
+		{"Test Automation Engineer", "qa"},
+
+		// precision — existing behavior must be unchanged
+		{"Cloud Architect", "architecture"},  // not devops
+		{"Operations Manager", "management"}, // bare-manager fallback intact
+		{"Sales Manager", "sales"},           // functional prefix still wins
+		{"Growth Engineer", ""},              // "growth" deliberately not added (ambiguous)
+	}
+	for _, c := range cases {
+		if got := Parse(c.title).Category; got != c.wantCategory {
+			t.Errorf("Parse(%q).Category = %q, want %q", c.title, got, c.wantCategory)
+		}
+	}
+}

--- a/internal/classify/dictionaries.go
+++ b/internal/classify/dictionaries.go
@@ -46,13 +46,13 @@ var categoryOrder = []string{
 	"machine learning", "deep learning", "ml engineer", "ml/ai", "ai/ml",
 	// AI-application terms (RAG/agents/LLM/prompt/applied AI) → ai_engineering.
 	"generative ai", "genai", "llm engineer", "prompt engineer", "applied ai", "rag engineer", "ai engineer", "llm",
-	"devops", "девопс",
+	"devops", "девопс", "platform engineer", "infrastructure engineer", "cloud engineer", "system administrator", "sysadmin",
 	"sre", "site reliability",
 	"network engineer", "network engineering", "network administrator", "сетевой инженер", "сетевой администратор",
 	"backend", "back-end", "back end", "бэкенд", "бекенд",
 	"frontend", "front-end", "front end", "фронтенд", "фронт",
 	"mobile", "android", "ios", "мобильный", "мобильная", "мобильных",
-	"qa", "quality assurance", "tester", "test engineer", "тестировщик", "тестирование",
+	"qa", "quality assurance", "tester", "test engineer", "test automation", "sdet", "тестировщик", "тестирование",
 	"security", "infosec", "appsec", "cybersecurity", "cyber security", "безопасность", "безопасности", "кибербезопасность",
 	"embedded", "firmware", "встраиваемые", "встраиваемых",
 	"blockchain", "блокчейн",
@@ -63,9 +63,9 @@ var categoryOrder = []string{
 	"project manager", "delivery manager", "program manager", "programme manager", "scrum master", "scrum-master", "проджект", "проект-менеджер", "скрам-мастер", "скрам мастер",
 	"engineering manager", "team manager",
 	"marketing", "smm", "маркетолог", "маркетинг",
-	"seo", "search engine optimization", "social media", "контент-маркетолог",
-	"sales", "account executive", "продажи", "продаж", "продажам",
-	"support", "поддержка", "поддержки", "техподдержка", "техподдержки",
+	"seo", "search engine optimization", "social media", "контент-маркетолог", "copywriter", "content writer", "brand manager", "public relations",
+	"sales", "account executive", "business development", "account manager", "sdr", "bdr", "продажи", "продаж", "продажам",
+	"support", "customer success", "customer service", "help desk", "поддержка", "поддержки", "техподдержка", "техподдержки",
 	// Bare "manager" resolves last so a functional prefix wins ("Sales Manager"
 	// → sales, "Support Manager" → support); a manager title with no function
 	// ("Operations Manager") falls through to management.
@@ -128,4 +128,13 @@ var categoryAliases = map[string]string{
 	"support": "support", "поддержка": "support", "поддержки": "support",
 	"техподдержка": "support", "техподдержки": "support",
 	"analyst": "data_analytics", "аналитик": "data_analytics",
+	// role-alias expansion (Lightcast/title diff). Non-tech titles feed the enrichment
+	// gate from the title (higher-precision than the description tier); the multi-word
+	// "* manager" forms are ordered before bare "manager" so they win their function.
+	"business development": "sales", "account manager": "sales", "sdr": "sales", "bdr": "sales",
+	"customer success": "support", "customer service": "support", "help desk": "support",
+	"copywriter": "marketing", "content writer": "marketing", "brand manager": "marketing", "public relations": "marketing",
+	"platform engineer": "devops", "infrastructure engineer": "devops", "cloud engineer": "devops",
+	"system administrator": "devops", "sysadmin": "devops",
+	"sdet": "qa", "test automation": "qa",
 }


### PR DESCRIPTION
The title-only category dictionary (`internal/classify`) had just **54 aliases** — the direct cause of the large empty-`category` bucket that lets non-tech jobs fall through the enrichment gate. This expands `categoryAliases` within the existing `CategoryValues`.

## What

**Non-tech titles (feed the gate from the TITLE — higher-precision than the description tier added earlier):**
- sales: `sdr`, `bdr`, `business development`, `account manager`
- support: `customer success`, `customer service`, `help desk`
- marketing: `copywriter`, `content writer`, `brand manager`, `public relations`

**Tech-role synonyms (facet quality):**
- devops: `platform engineer`, `infrastructure engineer`, `cloud engineer`, `system administrator`, `sysadmin`
- qa: `sdet`, `test automation`

## Precision

Multi-word `* manager` forms are placed **before** the bare `manager` fallback in `categoryOrder`, so they win their function:
- `Account Manager` → sales, `Brand Manager` → marketing, `Business Development Manager` → sales
- `Operations Manager` → management (bare-manager fallback **unchanged**)
- `Cloud Architect` → architecture (not devops), `Sales Manager` → sales (functional prefix still wins)
- `Growth Engineer` → empty (`growth` deliberately omitted — ambiguous)

Bare ambiguous words were avoided; single-token adds are unambiguous acronyms/coined names (`sdr`, `sdet`, `sysadmin`).

## Why this matters

This is the title-level complement to #416 (`NonTechFromDescription`): a non-tech job whose title states the role now classifies from the title (more precise, catches it earlier), moving it out of the empty bucket and into the gate.

## Test plan

- `go build ./... && go vet ./... && go test ./...` green, incl. the alias→`CategoryValues` invariant and the new `TestParse_RoleExpansionBatch` (positives + precision).

## Ops

Dictionary-facet change → `cmd/backfill-derive` + `make reindex` to reach existing jobs (deferred to a quiet window).