### PR TITLE
feat(web): move company facts into the jobs sidebar

### DIFF
--- a/web/src/lib/components/CompanyFacts.svelte
+++ b/web/src/lib/components/CompanyFacts.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import type { Company } from '$lib/types';
+  import { countryLabel } from '$lib/facets';
+
+  // The company's scalar facts as a self-contained card, shown in the jobs sidebar
+  // (desktop) and as a fallback card under the header (mobile, where the sidebar is
+  // hidden). Present-only: renders nothing when the company has no facts, so the
+  // wrapper never leaves an empty box.
+  let { company }: { company: Company } = $props();
+
+  const info = $derived(company.company_info ?? {});
+
+  // Compact money label: $250M, $1.2B, $500K.
+  function formatAmount(n: number): string {
+    if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(n % 1_000_000_000 ? 1 : 0)}B`;
+    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(n % 1_000_000 ? 1 : 0)}M`;
+    if (n >= 1_000) return `$${Math.round(n / 1_000)}K`;
+    return `$${n}`;
+  }
+
+  const fundingLine = $derived(
+    info.funding
+      ? [info.funding.type, info.funding.amount ? formatAmount(info.funding.amount) : null, info.funding.year]
+          .filter(Boolean)
+          .join(' · ')
+      : ''
+  );
+  // "NASDAQ: ACME", or just "ACME" when the exchange is unknown.
+  const stockLine = $derived(
+    info.stock?.symbol ? [info.stock.exchange, info.stock.symbol].filter(Boolean).join(': ') : ''
+  );
+
+  // Ordered {term, value} pairs — present-only, so an absent field drops out of the
+  // definition list rather than showing a blank row.
+  const facts = $derived(
+    [
+      company.year_founded ? { term: 'Founded', value: String(company.year_founded) } : null,
+      company.employee_count
+        ? { term: 'Employees', value: company.employee_count.toLocaleString() }
+        : null,
+      company.hq_country ? { term: 'Headquarters', value: countryLabel(company.hq_country) } : null,
+      company.organization_type ? { term: 'Type', value: company.organization_type } : null,
+      stockLine ? { term: 'Listed', value: stockLine } : null,
+      fundingLine ? { term: 'Funding', value: fundingLine } : null,
+      info.parent ? { term: 'Parent', value: info.parent } : null,
+      info.subsidiaries?.length ? { term: 'Subsidiaries', value: info.subsidiaries.join(', ') } : null,
+    ].filter((f): f is { term: string; value: string } => !!f)
+  );
+</script>
+
+{#if facts.length}
+  <div class="rounded-xl border border-border bg-card p-4">
+    <p class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Company facts</p>
+    <dl class="grid grid-cols-[auto_1fr] items-baseline gap-x-3 gap-y-2 text-sm">
+      {#each facts as fact (fact.term)}
+        <dt class="text-muted-foreground">{fact.term}</dt>
+        <dd class="text-right font-medium">{fact.value}</dd>
+      {/each}
+    </dl>
+  </div>
+{/if}

--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -1,65 +1,23 @@
 <script lang="ts">
   import type { Company } from '$lib/types';
-  import { countryLabel } from '$lib/facets';
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyFollowButton from './CompanyFollowButton.svelte';
 
-  // The company's header: identity (logo + name + tagline + follow CTA) fused with
-  // the authoritative company-info facts into one cohesive card. Every info field is
-  // optional (populated by the backfill), so the card renders "present-only": the
-  // facts panel and industries block appear only when they have content, and a company
-  // with no info at all falls back to a plain, borderless identity row (unchanged).
+  // The company's header card: identity (logo + name + tagline + follow CTA) with the
+  // industries and website link below a divider. The scalar company facts live in a
+  // separate CompanyFacts card (jobs sidebar on desktop, under the header on mobile),
+  // so this stays compact. Present-only: with no tagline/industries/website the card
+  // is dropped and only the plain, borderless identity row remains (unenriched
+  // companies unchanged).
   let { company, slug }: { company: Company; slug: string } = $props();
 
   const info = $derived(company.company_info ?? {});
-
-  // Compact money label: $250M, $1.2B, $500K.
-  function formatAmount(n: number): string {
-    if (n >= 1_000_000_000) return `$${(n / 1_000_000_000).toFixed(n % 1_000_000_000 ? 1 : 0)}B`;
-    if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(n % 1_000_000 ? 1 : 0)}M`;
-    if (n >= 1_000) return `$${Math.round(n / 1_000)}K`;
-    return `$${n}`;
-  }
-
-  const fundingLine = $derived(
-    info.funding
-      ? [info.funding.type, info.funding.amount ? formatAmount(info.funding.amount) : null, info.funding.year]
-          .filter(Boolean)
-          .join(' · ')
-      : ''
-  );
-  // "NASDAQ: ACME", or just "ACME" when the exchange is unknown.
-  const stockLine = $derived(
-    info.stock?.symbol ? [info.stock.exchange, info.stock.symbol].filter(Boolean).join(': ') : ''
-  );
-
-  // The scalar facts, as ordered {term, value} pairs — present-only, so an absent
-  // field drops out of the definition list rather than showing a blank row.
-  const facts = $derived(
-    [
-      company.year_founded ? { term: 'Founded', value: String(company.year_founded) } : null,
-      company.employee_count
-        ? { term: 'Employees', value: company.employee_count.toLocaleString() }
-        : null,
-      company.hq_country ? { term: 'Headquarters', value: countryLabel(company.hq_country) } : null,
-      company.organization_type ? { term: 'Type', value: company.organization_type } : null,
-      stockLine ? { term: 'Listed', value: stockLine } : null,
-      fundingLine ? { term: 'Funding', value: fundingLine } : null,
-      info.parent ? { term: 'Parent', value: info.parent } : null,
-      info.subsidiaries?.length ? { term: 'Subsidiaries', value: info.subsidiaries.join(', ') } : null,
-    ].filter((f): f is { term: string; value: string } => !!f)
-  );
-
   const industries = $derived(company.industries ?? []);
   const website = $derived(info.homepage);
   const websiteHref = $derived(website ? (website.startsWith('http') ? website : `https://${website}`) : '');
 
-  // Which sides of the split have content — drives the layout and the graceful
-  // collapse to a single column (or, with no info at all, a bare identity row).
-  const leftHasContent = $derived(industries.length > 0 || !!website);
-  const rightHasContent = $derived(facts.length > 0);
-  const hasBody = $derived(leftHasContent || rightHasContent);
-  const hasInfo = $derived(!!company.tagline || hasBody);
+  const hasMeta = $derived(industries.length > 0 || !!website);
+  const hasInfo = $derived(!!company.tagline || hasMeta);
 </script>
 
 {#snippet identity()}
@@ -77,52 +35,23 @@
   </div>
 {/snippet}
 
-{#snippet industriesBlock()}
-  {#if industries.length}
-    <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Industries</p>
-    <div class="mt-2.5 flex flex-wrap gap-1.5">
-      {#each industries as industry (industry)}
-        <span class="rounded-full bg-secondary px-2 py-0.5 text-xs text-secondary-foreground">{industry}</span>
-      {/each}
-    </div>
-  {/if}
-  {#if website}
-    <a
-      class="inline-block text-sm font-medium text-primary hover:underline {industries.length ? 'mt-3' : ''}"
-      href={websiteHref}
-      target="_blank"
-      rel="noopener noreferrer">{website} ↗</a
-    >
-  {/if}
-{/snippet}
-
-{#snippet factsBlock()}
-  <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Company facts</p>
-  <dl class="mt-2.5 grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-2 text-sm">
-    {#each facts as fact (fact.term)}
-      <dt class="text-muted-foreground">{fact.term}</dt>
-      <dd class="text-right font-semibold">{fact.value}</dd>
-    {/each}
-  </dl>
-{/snippet}
-
 {#if hasInfo}
-  <section class="overflow-hidden rounded-2xl border border-border bg-card">
-    <div class="p-5">{@render identity()}</div>
-
-    {#if hasBody}
-      {#if leftHasContent && rightHasContent}
-        <div class="grid border-t border-border sm:grid-cols-[1fr_0.82fr]">
-          <div class="p-5">{@render industriesBlock()}</div>
-          <div class="border-t border-border bg-muted p-5 sm:border-l sm:border-t-0">
-            {@render factsBlock()}
-          </div>
-        </div>
-      {:else}
-        <div class="border-t border-border p-5">
-          {#if rightHasContent}{@render factsBlock()}{:else}{@render industriesBlock()}{/if}
-        </div>
-      {/if}
+  <section class="rounded-2xl border border-border bg-card p-5">
+    {@render identity()}
+    {#if hasMeta}
+      <div class="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-4">
+        {#each industries as industry (industry)}
+          <span class="rounded-full bg-secondary px-2.5 py-0.5 text-xs text-secondary-foreground">{industry}</span>
+        {/each}
+        {#if website}
+          <a
+            class="text-sm font-medium text-primary hover:underline"
+            href={websiteHref}
+            target="_blank"
+            rel="noopener noreferrer">{website} ↗</a
+          >
+        {/if}
+      </div>
     {/if}
   </section>
 {:else}

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -4,6 +4,7 @@
   import JobsView from './JobsView.svelte';
   import States from './States.svelte';
   import CompanyHeader from './CompanyHeader.svelte';
+  import CompanyFacts from './CompanyFacts.svelte';
 
   // The company entity is server-rendered (route `load`), so the header is in the
   // initial HTML. The job list is *streamed*: `initial` is a promise the route
@@ -18,11 +19,22 @@
 
 <CompanyHeader {company} {slug} />
 
+<!-- Company facts sit atop the jobs sidebar on desktop (passed into JobsView as
+     `sidebarTop`); the sidebar is hidden on mobile, so mirror them here as a card
+     under the header. CompanyFacts renders nothing when there are no facts. -->
+<div class="mt-4 md:hidden">
+  <CompanyFacts {company} />
+</div>
+
 <div class="mt-6">
   {#await initial}
     <States state="loading" />
   {:then slice}
-    <JobsView initial={slice} scope={{ company_slug: slug }} excludeFacets={['source']} />
+    <JobsView initial={slice} scope={{ company_slug: slug }} excludeFacets={['source']}>
+      {#snippet sidebarTop()}
+        <CompanyFacts {company} />
+      {/snippet}
+    </JobsView>
   {:catch}
     <States state="error" message="Couldn't load jobs for this company." />
   {/await}

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, untrack } from 'svelte';
+  import { onMount, untrack, type Snippet } from 'svelte';
   import { Layers } from '@lucide/svelte';
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
@@ -33,11 +33,19 @@
   // page passes `{ company_slug }`): they're merged into every search but kept out
   // of `filters`/the URL, so they're not user-selectable facets. `excludeFacets`
   // hides facets that are redundant under that scope (e.g. Source on a company).
+  // `sidebarTop` renders above the filter summary in the desktop sidebar (e.g. the
+  // company page's facts card); the standalone /jobs list omits it.
   let {
     initial,
     scope = {},
     excludeFacets = [],
-  }: { initial: Slice<Job>; scope?: Record<string, string>; excludeFacets?: string[] } = $props();
+    sidebarTop,
+  }: {
+    initial: Slice<Job>;
+    scope?: Record<string, string>;
+    excludeFacets?: string[];
+    sidebarTop?: Snippet;
+  } = $props();
 
   // Seed filters from the current URL so the server and the hydrated client
   // render the same filtered view.
@@ -152,8 +160,11 @@
 
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
-    <div class="sticky top-6 max-h-[calc(100vh-5rem)] overflow-y-auto rounded-xl border border-border bg-card p-4">
-      <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} />
+    <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
+      {@render sidebarTop?.()}
+      <div class="rounded-xl border border-border bg-card p-4">
+        <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} />
+      </div>
     </div>
   </aside>
 


### PR DESCRIPTION
## Что

Итерация после [#429](https://github.com/strelov1/freehire/pull/429): единая карточка хедера получилась массивной — левая половина пустовала рядом с высокой панелью фактов. Переношу «Company facts» в сайдбар к фильтрам, хедер делаю компактным.

## Изменения

- **`CompanyFacts.svelte`** (новый) — самодостаточная карточка фактов (definition-list), рендерит `null` при отсутствии фактов.
- **`CompanyHeader.svelte`** — компактная карточка: айдентичность + tagline, ниже под divider — чипы индустрий + ссылка на сайт. Панель фактов убрана.
- **`JobsView.svelte`** — новый опциональный `sidebarTop?: Snippet`, рендерится над карточкой фильтров в десктопном сайдбаре. Standalone `/jobs` его не передаёт → не меняется.
- **`CompanyView.svelte`** — передаёт `<CompanyFacts>` в `sidebarTop` (десктоп) и дублирует карточкой под хедером на мобилке (`md:hidden`), где сайдбара нет.

## Инвариант present-only сохранён
`CompanyFacts` ничего не рендерит без фактов; компания без company-info по-прежнему деградирует в чистую безрамочную строку айдентичности.

## Проверка
- `svelte-check` — 0 ошибок / 0 предупреждений (4909 файлов).
- Визуально проверено на прод-данных (truelogic) через headless Chrome: десктоп (факты в сайдбаре) + мобилка (факты карточкой под хедером).