### PR TITLE
Companies catalog cards: tagline + industry/HQ badges

### DIFF
--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -156,7 +156,7 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 }
 
 const listCompanies = `-- name: ListCompanies :many
-SELECT slug, name, job_count
+SELECT slug, name, job_count, tagline, industries, hq_country
 FROM companies
 WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%')
   AND (coalesce(cardinality($2::text[]), 0) = 0 OR collections && $2::text[])
@@ -182,9 +182,12 @@ type ListCompaniesParams struct {
 }
 
 type ListCompaniesRow struct {
-	Slug     string `json:"slug"`
-	Name     string `json:"name"`
-	JobCount int32  `json:"job_count"`
+	Slug       string      `json:"slug"`
+	Name       string      `json:"name"`
+	JobCount   int32       `json:"job_count"`
+	Tagline    pgtype.Text `json:"tagline"`
+	Industries []string    `json:"industries"`
+	HqCountry  pgtype.Text `json:"hq_country"`
 }
 
 // Catalog page: companies with their job counts, most active first. The job count
@@ -216,7 +219,14 @@ func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([
 	items := []ListCompaniesRow{}
 	for rows.Next() {
 		var i ListCompaniesRow
-		if err := rows.Scan(&i.Slug, &i.Name, &i.JobCount); err != nil {
+		if err := rows.Scan(
+			&i.Slug,
+			&i.Name,
+			&i.JobCount,
+			&i.Tagline,
+			&i.Industries,
+			&i.HqCountry,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -9,7 +9,7 @@
 -- array short-circuits to no constraint, non-empty values are OR-ed within the
 -- facet, and the facets AND together (and with the name search). CountCompanies
 -- MUST keep an identical WHERE so the filtered total matches the page.
-SELECT slug, name, job_count
+SELECT slug, name, job_count, tagline, industries, hq_country
 FROM companies
 WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%')
   AND (coalesce(cardinality(sqlc.arg('collections')::text[]), 0) = 0 OR collections && sqlc.arg('collections')::text[])

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -10,6 +10,7 @@
   import { setListSearchTarget } from '$lib/listSearch.svelte';
   import type { CompanyListItem } from '$lib/types';
   import { Badge } from '$lib/ui';
+  import { countryLabel } from '$lib/facets';
   import States from './States.svelte';
   import LoadMore from './LoadMore.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
@@ -101,15 +102,28 @@
       </p>
       <div class="flex flex-col gap-3">
         {#each companies.items as company (company.slug)}
+          {@const industry = company.industries?.[0]}
+          {@const hq = company.hq_country ? countryLabel(company.hq_country) : null}
           <a
             href={resolve('/companies/[slug]', { slug: company.slug })}
-            class="flex items-center justify-between rounded-lg border border-border px-4 py-3 transition-colors hover:bg-accent"
+            class="flex items-start gap-2.5 rounded-lg border border-border px-4 py-3 transition-colors hover:bg-accent"
           >
-            <span class="flex min-w-0 items-center gap-2.5">
-              <CompanyLogo name={company.name} size="size-6" />
-              <span class="truncate font-medium">{company.name}</span>
-            </span>
-            <Badge variant="outline">{company.job_count} jobs</Badge>
+            <span class="mt-0.5"><CompanyLogo name={company.name} size="size-6" /></span>
+            <div class="flex min-w-0 flex-1 flex-col gap-1">
+              <div class="flex items-center justify-between gap-2">
+                <span class="truncate font-medium">{company.name}</span>
+                <Badge variant="outline" class="shrink-0">{company.job_count} jobs</Badge>
+              </div>
+              {#if company.tagline}
+                <p class="line-clamp-1 text-sm text-muted-foreground">{company.tagline}</p>
+              {/if}
+              {#if industry || hq}
+                <div class="flex flex-wrap gap-1.5">
+                  {#if industry}<Badge variant="secondary">{industry}</Badge>{/if}
+                  {#if hq}<Badge variant="secondary">{hq}</Badge>{/if}
+                </div>
+              {/if}
+            </div>
           </a>
         {/each}
       </div>

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -51,11 +51,15 @@ export interface Company {
   company_info?: CompanyInfo;
 }
 
-/** A row of the companies catalog: company plus its computed job count. */
+/** A row of the companies catalog: company plus its computed job count and a few
+ *  company-info facts for the card (present-only — absent on unenriched rows). */
 export interface CompanyListItem {
   slug: string;
   name: string;
   job_count: number;
+  tagline?: string | null;
+  industries?: string[] | null;
+  hq_country?: string | null;
 }
 
 /** Pagination metadata returned alongside list responses. */


### PR DESCRIPTION
Adds a short description and minimal badges to each card on the `/companies` catalog, when the data is available.

## Changes
- **Backend**: `ListCompanies` now also selects `tagline`, `industries`, and `hq_country` (existing company-info columns — no migration). The handler returns them on each list row; `pgtype.Text` marshals as a plain string/null.
- **Frontend**: each catalog card renders — present-only — a one-line **tagline** (truncated) and up to two minimal badges: first **industry** and **headquarters** country (via `countryLabel`), alongside the existing "N jobs" badge. Unenriched rows render exactly as before (logo + name + job count).

## Verification
- `go build/vet/test ./...` pass; `gofmt` clean; `svelte-check` 0/0.
- Visually verified (headless, mock data): tagline + Industry/HQ badges render, long name + tagline truncate cleanly, and a company with no company-info shows just the name + job count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)