### PR TITLE
feat(web): merge verdict into /my/profile with inline ProfileForm

### DIFF
--- a/openspec/changes/verdict-redesign/proposal.md
+++ b/openspec/changes/verdict-redesign/proposal.md
@@ -32,6 +32,13 @@ LLM — so the report is both more useful and still honest and testable.
 - **Frontend:** rewrite `VerdictView.svelte` and `ATSReportView.svelte` against the
   new contracts using existing design-system tokens (status colours
   green/amber/red, no bespoke theme); regenerate the TS contracts.
+- **Profile-page merge (IA):** fold `/my/profile/verdict` into `/my/profile` as one
+  page on the `/jobs` layout (left filter sidebar + main column). Bring profile
+  editing back inline as a `ProfileForm` (CV drop-zone with a "already uploaded ·
+  update" state, skills + specializations selectors, one Save) — replacing the
+  edit modal. The filter scopes the market comparison by role/facets, seeded from
+  the profile's specializations but independent of it. Delete the `verdict` route
+  and `ProfileEditModal`; drop the edit + sparkles header buttons (keep delete).
 - **Deferred (out of scope):** a `(stack)/(methodology)` per-skill tag; a purple
   page theme.
 
@@ -45,7 +52,9 @@ LLM — so the report is both more useful and still honest and testable.
 ### Modified Capabilities
 - `resume-verdict`: add a market-anchored top-20 skill breakdown (per-skill
   status, must-have flag, advice) plus must-have-covered, stack-match, and
-  coherence headline stats to the verdict.
+  coherence headline stats to the verdict; surface the whole feature on a single
+  `/my/profile` page with inline editing and a role/facet comparison filter,
+  removing the separate `/my/profile/verdict` route.
 - `cv-ats-score`: replace the flat structural checklist score with five weighted
   categories carrying per-item point attribution, an additive `overall`, a
   `potential` score, and explicit strong/recommended keyword lists; the LLM
@@ -60,7 +69,8 @@ LLM — so the report is both more useful and still honest and testable.
   (extra role-skills facet query, CV-section wiring).
 - **Contracts:** `cmd/gen-contracts` → `web/src/lib/generated/contracts.ts`
   (breaking shape change).
-- **Frontend:** `VerdictView.svelte`, `ATSReportView.svelte`, and the verdict
-  `+page.svelte` glue.
+- **Frontend:** `VerdictView.svelte`, `ATSReportView.svelte`; new
+  `ProfileForm.svelte`; rewritten `my/profile/+page.svelte`; deleted
+  `my/profile/verdict/+page.svelte` and `ProfileEditModal.svelte`.
 - **No DB migration:** reuses the stored CV text and the existing
   `users.resume_ats_analysis` cache column.

--- a/openspec/changes/verdict-redesign/specs/resume-verdict/spec.md
+++ b/openspec/changes/verdict-redesign/specs/resume-verdict/spec.md
@@ -57,3 +57,27 @@ role facets and the CV's parsed skill sets.
 #### Scenario: Coherence with no declared skills
 - **WHEN** the CV has no Skills section (`declared` is empty)
 - **THEN** `coherence_percent` = 0
+
+### Requirement: Unified profile and coverage page
+
+The signed-in profile SHALL live on a single `/my/profile` page that combines inline profile editing, market coverage, and CV readiness; the separate `/my/profile/verdict` route SHALL be removed and its content folded into this page. The page SHALL edit the profile inline (no modal): a CV drop-zone, a skills selector, and a specializations selector, saved together by an explicit Save action. A left filter sidebar (the same `/jobs` filter surface, with the `skills` facet excluded) SHALL scope the market comparison by role and other facets; its role selection SHALL be seeded from the profile's specializations but SHALL be independent of the saved profile, so refining the comparison role never mutates the profile.
+
+#### Scenario: Setup shows only the form
+- **WHEN** a signed-in user with no saved profile opens `/my/profile`
+- **THEN** the page shows the inline editing form (with the CV upload) and no coverage or CV-readiness tabs
+
+#### Scenario: Editing is inline, not a modal
+- **WHEN** a user with a saved profile changes their skills or specializations
+- **THEN** they edit the fields directly on the page and persist them with a single Save action — no separate edit modal is opened
+
+#### Scenario: Filter refines comparison without touching the profile
+- **WHEN** the user changes the sidebar role/facet filter
+- **THEN** the coverage and CV-readiness numbers recompute for the filtered market while the saved profile's specializations are unchanged
+
+#### Scenario: CV already uploaded is indicated
+- **WHEN** the user has a stored CV (`has_cv` is true)
+- **THEN** the CV drop-zone shows an "uploaded" state offering to update it, rather than an empty upload prompt
+
+#### Scenario: Results are tabbed
+- **WHEN** a user with a saved profile views the page
+- **THEN** market coverage and CV readiness are presented as two tabs under the editing form

--- a/openspec/changes/verdict-redesign/tasks.md
+++ b/openspec/changes/verdict-redesign/tasks.md
@@ -32,8 +32,8 @@
 
 ## 6. Unified profile page (IA + inline editing)
 
-- [ ] 6.1 New `ProfileForm.svelte`: inline single-profile editor — specializations via `SearchSelect` (≤5), skills via `RemoteSearchSelect`, CV drop-zone that shows an "uploaded · update" state when `has_cv`; Save via `profileStore.save`; `canSubmit` = ≥1 specialization & ≥1 skill
-- [ ] 6.2 Rewrite `my/profile/+page.svelte` to the `/jobs` layout: filter sidebar (`FilterStore`/`FilterSummary`/`FilterModal`/`FilterEdgeTab`, `skills` excluded) + main column = `ProfileForm` + Market-coverage/CV-readiness tabs; fold in the verdict page's init/reload/runReview; keep the delete button, drop the edit + sparkles buttons
-- [ ] 6.3 Filter drives the comparison role independently of the saved profile (category seeded from specializations; changing it never mutates the profile); re-fetch verdict + ATS after a save/upload so the numbers track edits, and drive `ProfileForm`'s CV state from `has_cv`
-- [ ] 6.4 Delete `my/profile/verdict/+page.svelte` and `ProfileEditModal.svelte`; drop the `verdictHref` route reference
-- [ ] 6.5 Verify: `svelte-check` clean + `vite build` green
+- [x] 6.1 New `ProfileForm.svelte`: inline single-profile editor — specializations via `SearchSelect` (≤5), skills via `RemoteSearchSelect`, CV drop-zone that shows an "uploaded · update" state when `has_cv`; Save via `profileStore.save`; `canSubmit` = ≥1 specialization & ≥1 skill
+- [x] 6.2 Rewrite `my/profile/+page.svelte` to the `/jobs` layout: filter sidebar (`FilterStore`/`FilterSummary`/`FilterModal`/`FilterEdgeTab`, `skills` excluded) + main column = `ProfileForm` + Market-coverage/CV-readiness tabs; fold in the verdict page's init/reload/runReview; keep the delete button, drop the edit + sparkles buttons
+- [x] 6.3 Filter drives the comparison role independently of the saved profile (category seeded from specializations; changing it never mutates the profile); re-fetch verdict + ATS after a save/upload so the numbers track edits, and drive `ProfileForm`'s CV state from `has_cv`
+- [x] 6.4 Delete `my/profile/verdict/+page.svelte` and `ProfileEditModal.svelte`; drop the `verdictHref` route reference
+- [x] 6.5 Verify: `svelte-check` clean + `vite build` green

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -1,0 +1,288 @@
+<script lang="ts">
+  import { ArrowUp, Check, X } from '@lucide/svelte';
+  import { ApiError, extractResumeSkills, facetCounts } from '$lib/api';
+  import { CATEGORY_OPTIONS, categoryLabel, type FacetOption } from '$lib/facets';
+  import { profileStore } from '$lib/profile.svelte';
+  import type { UserProfile } from '$lib/types';
+  import { Button } from '$lib/ui';
+  import RemoteSearchSelect from './facets/RemoteSearchSelect.svelte';
+  import SearchSelect from './facets/SearchSelect.svelte';
+
+  // Mirror of the server's specialization cap (searchprofile.maxSpecializations).
+  const MAX_SPECIALIZATIONS = 5;
+
+  // Inline editor for the single profile. `profile` seeds the fields (null = first-time
+  // set-up); `hasCv` drives the CV block's uploaded/empty state. `onSaved` fires after a
+  // successful save (the page re-fetches coverage); `onCvUploaded` fires after a résumé
+  // upload stores a new CV server-side (the page re-fetches the ATS report / has_cv).
+  let {
+    profile,
+    hasCv,
+    onSaved,
+    onCvUploaded,
+  }: {
+    profile: UserProfile | null;
+    hasCv: boolean;
+    onSaved?: () => void;
+    onCvUploaded?: () => void;
+  } = $props();
+
+  const editing = $derived(profile !== null);
+
+  // Seed the fields once from the profile prop. The parent keys this component on the
+  // profile identity, so a different profile remounts it — capturing the initial value
+  // is intended.
+  // svelte-ignore state_referenced_locally
+  let specializations = $state.raw<string[]>(profile ? [...profile.specializations] : []);
+  // svelte-ignore state_referenced_locally
+  let skills = $state.raw<string[]>(profile ? [...profile.skills] : []);
+  let formError = $state<string | null>(null);
+  let busy = $state(false);
+
+  // Résumé upload → skill extraction. The server also stores the CV (used by the CV
+  // readiness tab); the returned slugs merge (union) into the skills field without
+  // wiping manual entries. They persist to the profile only on Save.
+  let resumeBusy = $state(false);
+  let resumeError = $state<string | null>(null);
+  let resumeNote = $state<string | null>(null);
+  let fileInput = $state<HTMLInputElement | null>(null);
+  let dragActive = $state(false);
+
+  // The universe of skills (canonical tokens with job counts) for the typeahead, from
+  // the facet-distribution endpoint — the same source the filter panel uses.
+  let skillDist = $state.raw<FacetOption[]>([]);
+
+  const canSubmit = $derived(specializations.length > 0 && skills.length > 0);
+
+  // The skills typeahead: filter the loaded distribution locally (dictionary-only, so
+  // only known skills are addable) and cap the visible matches.
+  function searchSkills(query: string): Promise<FacetOption[]> {
+    const q = query.trim().toLowerCase();
+    const matches = q ? skillDist.filter((o) => o.label.toLowerCase().includes(q)) : skillDist;
+    return Promise.resolve(matches.slice(0, 50));
+  }
+
+  async function loadSkills() {
+    try {
+      const counts = await facetCounts(new URLSearchParams());
+      const dist = counts.facets?.skills ?? {};
+      skillDist = Object.entries(dist)
+        .map(([value, count]) => ({ value, label: value, count }))
+        .toSorted((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+    } catch {
+      // best-effort: the typeahead just has nothing to suggest.
+    }
+  }
+
+  $effect(() => {
+    void loadSkills();
+  });
+
+  // Extract skills from a résumé PDF and merge them into the skills field as a
+  // deduplicated union, preserving anything already entered. The upload also stores the
+  // CV server-side, so notify the parent to refresh the CV-readiness state.
+  async function analyzeResume(file: File) {
+    resumeBusy = true;
+    resumeError = null;
+    resumeNote = null;
+    try {
+      const extracted = await extractResumeSkills(file);
+      onCvUploaded?.();
+      if (extracted.length === 0) {
+        resumeNote = 'No known skills found in the CV.';
+        return;
+      }
+      const before = skills.length;
+      skills = [...new Set([...skills, ...extracted])];
+      const added = skills.length - before;
+      resumeNote =
+        added > 0
+          ? `Added ${added} skill${added === 1 ? '' : 's'} from your CV.`
+          : 'All CV skills were already listed.';
+    } catch (err) {
+      resumeError = err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';
+    } finally {
+      resumeBusy = false;
+    }
+  }
+
+  function onResumeFile(e: Event) {
+    const target = e.currentTarget as HTMLInputElement;
+    const file = target.files?.[0];
+    target.value = ''; // clear so re-selecting the same file fires change again
+    if (file) void analyzeResume(file);
+  }
+
+  function isPdf(file: File): boolean {
+    return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+  }
+
+  // The file input's `accept` filters the picker, but a drop bypasses it — so the drop
+  // path validates the type itself before touching the extractor.
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    dragActive = false;
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    if (!isPdf(file)) {
+      resumeError = 'Please drop a PDF file.';
+      return;
+    }
+    void analyzeResume(file);
+  }
+
+  // Multi-select with a cap: toggling off is always allowed; toggling on is refused past
+  // MAX_SPECIALIZATIONS (with a hint) so the form matches the server's limit.
+  function toggleSpecialization(value: string) {
+    if (specializations.includes(value)) {
+      specializations = specializations.filter((s) => s !== value);
+      formError = null;
+      return;
+    }
+    if (specializations.length >= MAX_SPECIALIZATIONS) {
+      formError = `You can pick at most ${MAX_SPECIALIZATIONS} specializations.`;
+      return;
+    }
+    specializations = [...specializations, value];
+    formError = null;
+  }
+
+  function toggleSkill(value: string) {
+    skills = skills.includes(value) ? skills.filter((s) => s !== value) : [...skills, value];
+  }
+
+  async function submit(e: SubmitEvent) {
+    e.preventDefault();
+    if (!canSubmit || busy) return;
+    busy = true;
+    formError = null;
+    try {
+      await profileStore.save(specializations, skills);
+      onSaved?.();
+    } catch (err) {
+      formError =
+        err instanceof ApiError ? err.message : 'Could not save the profile. Please try again.';
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<form onsubmit={submit} class="flex flex-col gap-6 rounded-xl border border-border bg-card p-5 sm:p-6">
+  <!-- Your CV: uploaded state or an empty drop-zone. Uploading extracts skills into the
+       field below and stores the CV for the readiness tab. -->
+  <div class="flex flex-col gap-1.5">
+    <span class="text-sm font-medium">Your CV</span>
+    <input
+      type="file"
+      accept="application/pdf,.pdf"
+      class="hidden"
+      bind:this={fileInput}
+      onchange={onResumeFile}
+    />
+    <button
+      type="button"
+      onclick={() => fileInput?.click()}
+      ondragover={(e) => {
+        e.preventDefault();
+        dragActive = true;
+      }}
+      ondragleave={(e) => {
+        e.preventDefault();
+        dragActive = false;
+      }}
+      ondrop={onDrop}
+      disabled={resumeBusy}
+      class="flex items-center justify-center gap-3 rounded-xl border-2 border-dashed text-center transition-colors disabled:opacity-70 {hasCv
+        ? 'px-4 py-3'
+        : 'px-6 py-8'} {dragActive ? 'border-primary bg-primary/5' : 'border-border hover:border-primary/60'}"
+    >
+      {#if hasCv}
+        <Check class="size-4 shrink-0 text-primary" />
+        <span class="text-sm">
+          <span class="font-medium">{resumeBusy ? 'Analyzing…' : 'CV uploaded'}</span>
+          {#if !resumeBusy}
+            <span class="text-muted-foreground">· drop a new PDF to update</span>
+          {/if}
+        </span>
+      {:else}
+        <span class="flex size-11 items-center justify-center rounded-full bg-primary text-primary-foreground">
+          <ArrowUp class="size-5" />
+        </span>
+        <span class="flex flex-col gap-0.5 text-left">
+          <span class="text-sm font-semibold">{resumeBusy ? 'Analyzing…' : 'Drop PDF here'}</span>
+          {#if !resumeBusy}
+            <span class="text-xs text-muted-foreground">
+              or <span class="text-primary underline">choose from disk</span>
+            </span>
+          {/if}
+        </span>
+      {/if}
+    </button>
+    <span class="text-xs text-muted-foreground">
+      Extracts your skills below · parsed on the server; the file is stored to score its readiness.
+    </span>
+    {#if resumeError}
+      <p class="text-sm text-destructive">{resumeError}</p>
+    {:else if resumeNote}
+      <p class="text-xs text-muted-foreground">{resumeNote}</p>
+    {/if}
+  </div>
+
+  <!-- Skills -->
+  <div class="flex flex-col gap-2">
+    <div class="flex items-baseline justify-between">
+      <span class="text-sm font-medium">Skills</span>
+      <span class="text-xs tabular-nums text-muted-foreground">{skills.length}</span>
+    </div>
+    <RemoteSearchSelect
+      search={searchSkills}
+      selected={skills}
+      placeholder="Search skills"
+      onToggle={toggleSkill}
+      fallbackLabel={(v) => v}
+      clearOnSelect
+    />
+  </div>
+
+  <!-- Role / specializations -->
+  <div class="flex flex-col gap-2">
+    <div class="flex items-baseline justify-between">
+      <span class="text-sm font-medium">Role</span>
+      <span class="text-xs tabular-nums text-muted-foreground">
+        {specializations.length}/{MAX_SPECIALIZATIONS}
+      </span>
+    </div>
+    {#if specializations.length > 0}
+      <div class="flex flex-wrap gap-1.5">
+        {#each specializations as value (value)}
+          <button
+            type="button"
+            onclick={() => toggleSpecialization(value)}
+            class="inline-flex items-center gap-1 rounded-full bg-primary px-2.5 py-1 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+          >
+            {categoryLabel(value)}
+            <X class="size-3" />
+          </button>
+        {/each}
+      </div>
+    {/if}
+    <SearchSelect
+      options={CATEGORY_OPTIONS}
+      selected={specializations}
+      placeholder="Search specializations"
+      onToggle={toggleSpecialization}
+      clearOnSelect
+    />
+  </div>
+
+  {#if formError}
+    <p class="text-sm text-destructive">{formError}</p>
+  {/if}
+
+  <div class="flex items-center gap-2 border-t border-border pt-4">
+    <Button variant="primary" type="submit" disabled={!canSubmit || busy}>
+      {busy ? 'Saving…' : editing ? 'Save changes' : 'Create profile'}
+    </Button>
+  </div>
+</form>

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -1,28 +1,80 @@
 <script lang="ts">
-  import { Pencil, Sparkles, Trash2 } from '@lucide/svelte';
-  import { resolve } from '$app/paths';
-  import { getProfileVerdict } from '$lib/api';
+  import { untrack } from 'svelte';
+  import { Sparkles, Trash2 } from '@lucide/svelte';
+  import { page } from '$app/state';
+  import { facetCounts, getATSReport, getProfileVerdict, runATSReview } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
-  import { categoryLabel } from '$lib/facets';
-  import { profileStore } from '$lib/profile.svelte';
-  import { categoryParams } from '$lib/skillGap';
-  import type { Verdict } from '$lib/types';
-  import { Button } from '$lib/ui';
-  import ProfileEditModal from '$lib/components/ProfileEditModal.svelte';
+  import { FilterStore, filtersToParams } from '$lib/filters';
+  import ATSReportView from '$lib/components/ATSReportView.svelte';
+  import FilterSummary from '$lib/components/filters/FilterSummary.svelte';
+  import FilterModal from '$lib/components/filters/FilterModal.svelte';
+  import FilterEdgeTab from '$lib/components/FilterEdgeTab.svelte';
+  import ProfileForm from '$lib/components/ProfileForm.svelte';
   import States from '$lib/components/States.svelte';
-
-  let status = $state<'loading' | 'error' | 'ready'>('loading');
-  let editing = $state(false);
-  let actionError = $state<string | null>(null);
+  import VerdictView from '$lib/components/VerdictView.svelte';
+  import { profileStore } from '$lib/profile.svelte';
+  import type { ATSResponse, FacetCounts, Verdict } from '$lib/types';
+  import { Button } from '$lib/ui';
 
   const profile = $derived(profileStore.profile);
-  const verdictHref = resolve('/my/profile/verdict');
 
-  // Market-coverage headline over the profile's own role. Best-effort: a failed fetch
-  // (or a profile with no specialization) simply omits the coverage block.
-  let coverage = $state.raw<Verdict | null>(null);
-  let coverageGeneration = 0;
+  // Skills are the measured set (from the profile), never a market filter — hide the
+  // skills facet so the sidebar can't turn them into one.
+  const excludeFacets = ['skills'];
+
+  let status = $state<'loading' | 'error' | 'ready'>('loading');
+  let filters = $state<FilterStore | null>(null);
+  let verdict = $state<Verdict | null>(null);
+  let counts = $state<FacetCounts | null>(null);
+  let ats = $state<ATSResponse | null>(null);
+  let loadError = $state(false);
+  let tab = $state<'coverage' | 'cv'>('coverage');
+  let modalOpen = $state(false);
+  let actionError = $state<string | null>(null);
+
+  // Optimistic CV flag: a résumé upload stores the CV server-side before the next ATS
+  // fetch resolves (and before any profile exists during set-up), so reflect it at once.
+  let cvUploaded = $state(false);
+  const hasCv = $derived((ats?.has_cv ?? false) || cvUploaded);
+
+  // Job-count preview for the modal's staged filters — the same facet call, total only.
+  const previewCount = (params: URLSearchParams) => facetCounts(params).then((c) => c.total);
+
+  // AI review state.
+  let reviewBusy = $state(false);
+  let reviewUnavailable = $state(false);
+
+  // Run the optional LLM review over the stored CV; folds content-quality + suggestions
+  // into the report. When the server has no LLM the report comes back unreviewed — flag
+  // that so the UI stops offering the button.
+  async function runReview() {
+    reviewBusy = true;
+    reviewUnavailable = false;
+    try {
+      const params = filters ? filtersToParams(filters.applied) : undefined;
+      const next = await runATSReview(params);
+      ats = next;
+      if (next.has_cv && next.report && !next.report.reviewed) {
+        reviewUnavailable = true;
+      }
+    } catch {
+      reviewUnavailable = true;
+    } finally {
+      reviewBusy = false;
+    }
+  }
+
+  // Seed the comparison filter from the profile's specializations (unless the URL already
+  // carries a category) — so it opens on the profile's own role, which the user can then
+  // change to compare against another position without touching the saved profile.
+  function buildFilters(specializations: string[]): FilterStore {
+    const seed = new URLSearchParams(page.url.searchParams);
+    if (!seed.getAll('category').some((c) => c !== '')) {
+      for (const spec of specializations) seed.append('category', spec);
+    }
+    return new FilterStore(seed);
+  }
 
   async function load() {
     status = 'loading';
@@ -34,36 +86,59 @@
     }
   }
 
-  async function loadCoverage() {
-    const gen = ++coverageGeneration;
-    if (!profile || profile.specializations.length === 0) {
-      coverage = null;
-      return;
-    }
-    try {
-      const v = await getProfileVerdict();
-      if (gen === coverageGeneration) coverage = v;
-    } catch {
-      if (gen === coverageGeneration) coverage = null;
-    }
-  }
-
-  // Load once the session is confirmed (the boot-time /me resolution may still be in
-  // flight when the page is opened directly). Sign-out reset is handled centrally in the
-  // root layout, so this only needs to (re)load when authenticated.
+  // (Re)load once the session resolves.
   $effect(() => {
     if (isAuthenticated()) void load();
   });
 
-  // Recompute coverage whenever the profile changes (save/clear reassigns it).
+  // Build the filter only on the profile null↔exists transition, never on a plain edit —
+  // so refining the comparison role survives a skills/role save. Delete drops it back to
+  // the set-up form.
   $effect(() => {
-    void profile;
-    void loadCoverage();
+    const p = profile;
+    untrack(() => {
+      if (p && !filters) {
+        filters = buildFilters(p.specializations);
+      } else if (!p && filters) {
+        filters.dispose();
+        filters = null;
+      }
+    });
   });
 
-  // Link a missing skill to the job search under the profile's role plus that skill.
-  function jobsHref(specializations: string[], skill: string): string {
-    const params = categoryParams(specializations);
+  // Reload the verdict + facet counts + ATS report whenever the applied (debounced)
+  // filters change. No filter (no profile) → nothing to compute.
+  $effect(() => {
+    const f = filters;
+    if (!f) return;
+    void f.applied;
+    void reload();
+  });
+
+  // reloadGeneration guards against out-of-order responses: fast filter changes can have
+  // an older request resolve after a newer one, so only the latest reload commits.
+  let reloadGeneration = 0;
+  async function reload() {
+    if (!filters) return;
+    const gen = ++reloadGeneration;
+    const params = filtersToParams(filters.applied);
+    try {
+      const [v, c, a] = await Promise.all([
+        getProfileVerdict(params),
+        facetCounts(params),
+        getATSReport(params),
+      ]);
+      if (gen !== reloadGeneration) return; // a newer reload started — discard stale results.
+      [verdict, counts, ats] = [v, c, a];
+      loadError = false;
+    } catch {
+      if (gen === reloadGeneration) loadError = true;
+    }
+  }
+
+  // Link a gap skill to the job search under the current comparison role plus that skill.
+  function gapHref(skill: string): string {
+    const params = filters ? filtersToParams(filters.applied) : new URLSearchParams();
     params.append('skills', skill);
     return `/jobs?${params}`;
   }
@@ -73,6 +148,7 @@
     actionError = null;
     try {
       await profileStore.clear();
+      cvUploaded = false;
     } catch {
       actionError = 'Could not delete the profile. Please try again.';
     }
@@ -96,92 +172,134 @@
   {:else if status === 'error'}
     <States state="error" message="Couldn't load your profile." />
   {:else}
-    <div class="flex flex-col gap-6">
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div class="flex flex-col gap-1">
-          <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
-          <p class="text-sm text-muted-foreground">
-            Your specializations and skills — reuse them to find relevant work.
-          </p>
-        </div>
-        {#if profile}
-          <div class="flex items-center gap-1">
-            <Button variant="ghost" size="icon" href={verdictHref} aria-label="Market coverage">
-              <Sparkles class="size-4" />
-            </Button>
-            <Button variant="ghost" size="icon" onclick={() => (editing = true)} aria-label="Edit profile">
-              <Pencil class="size-4" />
-            </Button>
-            <Button variant="ghost" size="icon" onclick={remove} aria-label="Delete profile">
-              <Trash2 class="size-4" />
-            </Button>
-          </div>
-        {/if}
+    <!-- Header -->
+    <div class="mb-6 flex flex-wrap items-start justify-between gap-3">
+      <div class="flex flex-col gap-1">
+        <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
+        <p class="text-sm text-muted-foreground">
+          Your CV, skills and role — measured against live market demand.
+        </p>
       </div>
-
-      {#if actionError}
-        <p class="text-sm text-destructive">{actionError}</p>
-      {/if}
-
-      {#if !profile}
-        <div
-          class="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border py-14 text-center"
-        >
-          <p class="text-sm text-muted-foreground">You haven't set up your profile yet.</p>
-          <Button variant="primary" onclick={() => (editing = true)}>Set up your profile</Button>
-        </div>
-      {:else}
-        <div class="flex flex-col gap-4 rounded-xl border border-border bg-card p-5">
-          <div class="flex flex-col gap-2">
-            <span class="text-sm font-medium">Specializations</span>
-            <div class="flex flex-wrap gap-1.5">
-              {#each profile.specializations as spec (spec)}
-                <span class="rounded-full border border-border px-2.5 py-1 text-sm text-muted-foreground">
-                  {categoryLabel(spec)}
-                </span>
-              {/each}
-            </div>
-          </div>
-          <div class="flex flex-col gap-2">
-            <span class="text-sm font-medium">Skills</span>
-            <div class="flex flex-wrap gap-1.5">
-              {#each profile.skills as skill (skill)}
-                <span class="rounded bg-secondary px-1.5 py-0.5 text-xs text-secondary-foreground">{skill}</span>
-              {/each}
-            </div>
-          </div>
-
-          {#if coverage && coverage.total > 0}
-            <div class="mt-1 flex flex-col gap-2 border-t border-border pt-4">
-              <div class="flex flex-col gap-1">
-                <span class="text-xs text-muted-foreground">
-                  <span class="font-semibold text-foreground">{coverage.coverage_percent}% coverage</span>
-                  · {coverage.covered.toLocaleString('en-US')} of {coverage.total.toLocaleString('en-US')} open vacancies
-                </span>
-                <div class="h-1.5 overflow-hidden rounded bg-secondary">
-                  <div class="h-full rounded bg-primary" style="width: {coverage.coverage_percent}%"></div>
-                </div>
-              </div>
-              {#if coverage.gaps.length > 0}
-                <div class="flex flex-wrap items-center gap-1">
-                  <span class="text-xs text-muted-foreground">Add to reach more:</span>
-                  {#each coverage.gaps.slice(0, 5) as gap (gap.name)}
-                    <a
-                      href={jobsHref(profile.specializations, gap.name)}
-                      class="rounded border border-dashed border-border px-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground"
-                      title="+{gap.new_vacancies.toLocaleString('en-US')} vacancies"
-                    >{gap.name}</a>
-                  {/each}
-                </div>
-              {/if}
-            </div>
-          {/if}
-        </div>
+      {#if profile}
+        <Button variant="ghost" size="icon" onclick={remove} aria-label="Delete profile">
+          <Trash2 class="size-4" />
+        </Button>
       {/if}
     </div>
+
+    {#if actionError}
+      <p class="mb-4 text-sm text-destructive">{actionError}</p>
+    {/if}
+
+    {#if profile === null}
+      <!-- Set-up: the inline form only; coverage appears once a profile exists. -->
+      <div class="mx-auto w-full max-w-2xl">
+        <ProfileForm
+          profile={null}
+          {hasCv}
+          onSaved={() => void reload()}
+          onCvUploaded={() => (cvUploaded = true)}
+        />
+      </div>
+    {:else}
+      <div class="flex gap-6">
+        <aside class="hidden w-72 shrink-0 md:block">
+          <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
+            {#if filters}
+              <div class="rounded-xl border border-border bg-card p-4">
+                <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} />
+              </div>
+            {/if}
+          </div>
+        </aside>
+
+        <main class="flex min-w-0 flex-1 flex-col gap-6">
+          {#key profile.updated_at}
+            <ProfileForm
+              {profile}
+              {hasCv}
+              onSaved={() => void reload()}
+              onCvUploaded={() => {
+                cvUploaded = true;
+                void reload();
+              }}
+            />
+          {/key}
+
+          <!-- Tabs -->
+          <div class="flex gap-5 border-b border-border">
+            <button
+              type="button"
+              onclick={() => (tab = 'coverage')}
+              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            >
+              Market coverage
+            </button>
+            <button
+              type="button"
+              onclick={() => (tab = 'cv')}
+              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'cv'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            >
+              CV readiness
+            </button>
+          </div>
+
+          <!-- Body -->
+          {#if loadError}
+            <States state="error" message="Couldn't load the report." />
+          {:else if verdict === null}
+            <States state="loading" />
+          {:else if tab === 'coverage'}
+            <VerdictView {verdict} {gapHref} />
+          {:else if ats?.has_cv && ats.report}
+            <!-- CV readiness -->
+            <div class="flex flex-col gap-5">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <p class="text-sm text-muted-foreground">How ATS-ready your CV is for this role.</p>
+                {#if !ats.report.reviewed && !reviewUnavailable}
+                  <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
+                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                    {reviewBusy ? 'Reviewing…' : 'Run AI review'}
+                  </Button>
+                {:else if ats.report.reviewed}
+                  <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
+                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                    {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
+                  </Button>
+                {/if}
+              </div>
+              {#if reviewUnavailable}
+                <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
+              {/if}
+              <ATSReportView report={ats.report} />
+            </div>
+          {:else}
+            <!-- No CV yet: uploaded via the form above. -->
+            <div class="flex flex-col items-start gap-2 rounded-xl border border-dashed border-border p-6">
+              <p class="text-sm font-medium">Add your CV to score its ATS readiness</p>
+              <p class="text-sm text-muted-foreground">
+                Upload your CV in the form above to check ATS readability and this role's keywords.
+              </p>
+            </div>
+          {/if}
+        </main>
+      </div>
+
+      <FilterEdgeTab active={filters?.active ?? 0} onclick={() => (modalOpen = true)} />
+      {#if filters}
+        <FilterModal
+          store={filters}
+          {counts}
+          exclude={excludeFacets}
+          open={modalOpen}
+          onClose={() => (modalOpen = false)}
+          {previewCount}
+        />
+      {/if}
+    {/if}
   {/if}
 </div>
-
-{#if editing}
-  <ProfileEditModal {profile} onClose={() => (editing = false)} />
-{/if}


### PR DESCRIPTION
Folds `/my/profile/verdict` into `/my/profile` on the /jobs two-column layout: a sticky `w-72` filter sidebar (skills excluded) that scopes the market comparison, and a main column with an inline `ProfileForm` + the Market-coverage/CV-readiness tabs.

`ProfileForm` resurrects the pre-#425 inline editor (minus name) for the single profile: a CV drop-zone with a `has_cv` "uploaded · update" state, skills (RemoteSearchSelect) and specializations (SearchSelect), saved together via `profileStore.save`. The comparison filter is an independent lens, built only on the profile null<->exists transition so editing the profile never resets the chosen compare-role.

Deletes the verdict route and ProfileEditModal; drops the edit + sparkles header buttons (keeps delete). Verified locally: svelte-check clean + vite build green + headless-Chrome screenshot (layout matches /jobs, both CV states render). Folded IA scope of the verdict-redesign OpenSpec change (group 6).

NOTE: verdict-redesign backend/content already shipped via #433, so the net change here should be the profile-page IA only.