### PR TITLE
feat(verdict): market-signal upgrades — skill bundles, adjacent status, richer advice, summary density

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -62,6 +62,7 @@ func genStructs() (string, error) {
 
 	enrichTS := filepath.Join(tmp, "enrich.ts")
 	jobviewTS := filepath.Join(tmp, "jobview.ts")
+	bundleTS := filepath.Join(tmp, "bundle.ts")
 	verdictTS := filepath.Join(tmp, "verdict.ts")
 	atscheckTS := filepath.Join(tmp, "atscheck.ts")
 
@@ -79,11 +80,18 @@ func genStructs() (string, error) {
 				TypeMappings: map[string]string{"enrich.Enrichment": "Enrichment"},
 			},
 			{
-				// The market-coverage verdict wire shape (Verdict + Gap). Self-contained —
-				// only primitives and []Gap, no cross-package references.
+				// The curated skill bundles the verdict reports coverage of.
+				Path:         "github.com/strelov1/freehire/internal/skillbundle",
+				OutputPath:   bundleTS,
+				IncludeFiles: []string{"skillbundle.go"},
+			},
+			{
+				// The market-coverage verdict wire shape (Verdict + Gap + SkillRow +
+				// []skillbundle.Bundle → Bundle).
 				Path:         "github.com/strelov1/freehire/internal/verdict",
 				OutputPath:   verdictTS,
 				IncludeFiles: []string{"verdict.go"},
+				TypeMappings: map[string]string{"skillbundle.Bundle": "Bundle"},
 			},
 			{
 				// The CV ATS-readiness report wire shape (Report + Check + Status).
@@ -106,6 +114,10 @@ func genStructs() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	bundleBody, err := readBody(bundleTS)
+	if err != nil {
+		return "", err
+	}
 	verdictBody, err := readBody(verdictTS)
 	if err != nil {
 		return "", err
@@ -114,7 +126,7 @@ func genStructs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return enrichBody + "\n" + jobviewBody + "\n" + verdictBody + "\n" + atscheckBody, nil
+	return enrichBody + "\n" + jobviewBody + "\n" + bundleBody + "\n" + verdictBody + "\n" + atscheckBody, nil
 }
 
 // readBody returns a tygo output file's body with its leading preamble removed, so

--- a/internal/atscheck/atscheck.go
+++ b/internal/atscheck/atscheck.go
@@ -18,6 +18,8 @@ import (
 	"math"
 	"regexp"
 	"strings"
+
+	"github.com/strelov1/freehire/internal/skilltag"
 )
 
 // Status is a check outcome.
@@ -91,6 +93,7 @@ const (
 	minActionVerbs   = 3    // bullet lines starting with a strong verb → Content passes
 	minQuantified    = 2    // quantified results → Content passes
 	minDensitySkills = 3    // distinct parsed skills → Density passes
+	minSummarySkills = 2    // skill tags in the summary section → Summary keyword-density passes
 )
 
 var (
@@ -129,7 +132,7 @@ func Score(cvText string, cvSkills, roleTopSkills []string) Report {
 		Categories: []ScoreCategory{
 			keyword,
 			formatCategory(cvText, words),
-			sectionsCategory(lower),
+			sectionsCategory(lower, cvText),
 			contentCategory(cvText),
 			lengthCategory(words, cvSkills),
 		},
@@ -210,17 +213,62 @@ func formatCategory(cv string, words int) ScoreCategory {
 	}}
 }
 
-func sectionsCategory(lower string) ScoreCategory {
+func sectionsCategory(lower, cvText string) ScoreCategory {
+	// Weights re-balanced to fit the summary keyword-density item while keeping the
+	// category maximum at 15 (and the five-category total at 100).
 	return ScoreCategory{ID: categorySections, Label: "Section Completeness", Items: []LineItem{
-		item(hasAny(lower, sectionKeywords["experience"]), 5, "Experience section",
+		item(hasAny(lower, sectionKeywords["experience"]), 4, "Experience section",
 			"Add a clearly labelled Experience section", StatusWarn),
 		item(hasAny(lower, sectionKeywords["skills"]), 4, "Skills section",
 			"Add a clearly labelled Skills section", StatusWarn),
 		item(hasAny(lower, sectionKeywords["education"]), 3, "Education section",
 			"Add an Education section", StatusWarn),
-		item(hasAny(lower, sectionKeywords["summary"]), 3, "Professional summary",
+		item(hasAny(lower, sectionKeywords["summary"]), 2, "Professional summary",
 			"Add a short professional summary at the top", StatusWarn),
+		summaryDensityItem(cvText, 2),
 	}}
+}
+
+// summaryDensityItem rewards a keyword-dense professional summary — recruiters scan
+// it in ~6 seconds, so it should carry the CV's concrete skills.
+func summaryDensityItem(cvText string, weight int) LineItem {
+	n := len(skilltag.Parse(summaryText(cvText), skilltag.WithResumeAcronyms()))
+	return item(n >= minSummarySkills, weight, "Summary carries role keywords",
+		"Add a few role keywords to your professional summary", StatusWarn)
+}
+
+// summaryText returns the text under the CV's summary heading, up to the next section
+// heading (or "" when there is no summary section).
+func summaryText(cvText string) string {
+	var out []string
+	in := false
+	for _, line := range strings.Split(cvText, "\n") {
+		if section, ok := headingSection(line); ok {
+			in = section == "summary"
+			continue
+		}
+		if in {
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+// headingSection reports which section a line heads, matching a heading line whose
+// normalized text equals one of a section's keywords.
+func headingSection(line string) (string, bool) {
+	norm := strings.TrimSpace(strings.TrimRight(strings.TrimSpace(strings.ToLower(line)), ":"))
+	if norm == "" {
+		return "", false
+	}
+	for section, kws := range sectionKeywords {
+		for _, k := range kws {
+			if norm == k {
+				return section, true
+			}
+		}
+	}
+	return "", false
 }
 
 // contentCategory is the deterministic Content Quality proxy used when no LLM review

--- a/internal/atscheck/atscheck_test.go
+++ b/internal/atscheck/atscheck_test.go
@@ -2,8 +2,54 @@ package atscheck
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func sectionItem(t *testing.T, r Report, substr string) (LineItem, bool) {
+	t.Helper()
+	for _, it := range catByID(t, r, "section_completeness").Items {
+		if strings.Contains(strings.ToLower(it.Text), substr) {
+			return it, true
+		}
+	}
+	return LineItem{}, false
+}
+
+func TestScore_SummaryKeywordDensity_Dense(t *testing.T) {
+	cv := "Jane Roe\njane@example.com  +1 415 555 0134\n\nSummary\nBackend engineer. Core stack: Golang, Kafka, Kubernetes, PostgreSQL.\n\nExperience\n- Built services\n\nSkills\nGolang, Kafka"
+	r := Score(cv, []string{"go", "kafka"}, nil)
+	it, ok := sectionItem(t, r, "keyword")
+	if !ok {
+		t.Fatalf("no summary keyword-density item in %+v", catByID(t, r, "section_completeness").Items)
+	}
+	if it.Status != StatusPass {
+		t.Errorf("density = %s, want pass for a keyword-dense summary", it.Status)
+	}
+}
+
+func TestScore_SummaryKeywordDensity_Generic(t *testing.T) {
+	cv := "Jane Roe\njane@example.com  +1 415 555 0134\n\nSummary\nExperienced engineer passionate about building great products.\n\nExperience\n- Built services\n\nSkills\nGolang"
+	r := Score(cv, []string{"go"}, nil)
+	it, ok := sectionItem(t, r, "keyword")
+	if !ok {
+		t.Fatal("no summary keyword-density item")
+	}
+	if it.Status == StatusPass {
+		t.Errorf("density = pass, want recoverable for a generic summary")
+	}
+}
+
+func TestScore_CategoryMaximaSumTo100(t *testing.T) {
+	r := Score(cleanCV, cleanSkills, []string{"go", "kafka"})
+	sum := 0
+	for _, c := range r.Categories {
+		sum += c.Max
+	}
+	if sum != 100 {
+		t.Errorf("Σ category max = %d, want 100", sum)
+	}
+}
 
 // cleanCV is a realistic plain-text CV that should pass every deterministic check
 // (kept > the length floor so the length check passes honestly).

--- a/internal/handler/resume_verdict.go
+++ b/internal/handler/resume_verdict.go
@@ -62,7 +62,7 @@ func (a *API) computeCoverage(c *fiber.Ctx, userID int64, profile db.UserProfile
 	if err != nil {
 		return verdict.Verdict{}, err
 	}
-	declared, body := a.cvSkillSets(c, userID)
+	declared, body, all := a.cvSkillSets(c, userID)
 	return verdict.Compute(verdict.Input{
 		Total:           role.Total,
 		UncoveredTotal:  uncovered.Total,
@@ -70,20 +70,20 @@ func (a *API) computeCoverage(c *fiber.Ctx, userID int64, profile db.UserProfile
 		RoleSkills:      role.Facets["skills"],
 		Declared:        declared,
 		Body:            body,
+		All:             all,
 	}), nil
 }
 
-// cvSkillSets parses the caller's stored CV into its declared (Skills-section) and
-// body skill sets for the role breakdown. Best-effort: with no CV stored (or a read
-// error) it returns empty sets so the breakdown degrades to all-missing rather than
-// failing the verdict.
-func (a *API) cvSkillSets(c *fiber.Ctx, userID int64) (declared, body []string) {
+// cvSkillSets parses the caller's stored CV into its declared (Skills-section), body,
+// and union skill sets for the role breakdown and bundle coverage. Best-effort: with
+// no CV stored (or a read error) it returns empty sets so the breakdown degrades to
+// all-missing rather than failing the verdict.
+func (a *API) cvSkillSets(c *fiber.Ctx, userID int64) (declared, body, all []string) {
 	text, ok, err := a.storedCVText(c, userID)
 	if err != nil || !ok {
-		return nil, nil
+		return nil, nil, nil
 	}
-	declared, body, _ = cvsection.Parse(text)
-	return declared, body
+	return cvsection.Parse(text)
 }
 
 // roleValues builds the facet query for the coverage role from the request. It

--- a/internal/skillbundle/skillbundle.go
+++ b/internal/skillbundle/skillbundle.go
@@ -1,0 +1,63 @@
+// Package skillbundle groups skills into a curated set of market-recognised bundles
+// (a candidate is expected to hold combinations, not isolated skills — e.g. GenAI+Ops
+// appears in most AI-engineering roles) and reports a CV's coverage of each. It is a
+// curated dictionary, not a derived co-occurrence graph (mirrors internal/skilltag):
+// pure, deterministic, no LLM.
+package skillbundle
+
+// BundleCoveredPct is the share of a bundle's member skills a CV must hold for the
+// bundle to count as covered. Tunable.
+const BundleCoveredPct = 50
+
+// Bundle is one market skill combination and a CV's coverage of it.
+type Bundle struct {
+	Name    string `json:"name"`
+	Label   string `json:"label"`
+	Covered int    `json:"covered"` // member skills the CV holds
+	Total   int    `json:"total"`   // bundle size
+	Has     bool   `json:"has"`     // Covered/Total ≥ BundleCoveredPct
+}
+
+// bundle is a curated definition: a stable name/label and its member skill slugs
+// (canonical skilltag slugs).
+type bundle struct {
+	name    string
+	label   string
+	members []string
+}
+
+// bundles is the curated dictionary, AI/backend-focused first (expand as needed).
+var bundles = []bundle{
+	{"genai-core", "GenAI core", []string{"llm", "rag", "langchain", "generative-ai", "prompt-engineering"}},
+	{"cloud-ops", "Cloud & Ops", []string{"docker", "kubernetes", "ci-cd", "terraform", "aws"}},
+	{"web-stack", "Web stack", []string{"react", "typescript", "javascript", "nextjs", "nodejs"}},
+	{"data", "Data", []string{"sql", "postgresql", "mongodb", "kafka", "redis"}},
+	{"ml", "Machine learning", []string{"pytorch", "tensorflow", "scikit-learn"}},
+}
+
+// Coverage returns each bundle's coverage by the CV's parsed skill set. Pure and
+// deterministic (bundles keep their declared order).
+func Coverage(cvSkills []string) []Bundle {
+	owned := make(map[string]bool, len(cvSkills))
+	for _, s := range cvSkills {
+		owned[s] = true
+	}
+	out := make([]Bundle, 0, len(bundles))
+	for _, b := range bundles {
+		covered := 0
+		for _, m := range b.members {
+			if owned[m] {
+				covered++
+			}
+		}
+		total := len(b.members)
+		out = append(out, Bundle{
+			Name:    b.name,
+			Label:   b.label,
+			Covered: covered,
+			Total:   total,
+			Has:     total > 0 && covered*100 >= BundleCoveredPct*total,
+		})
+	}
+	return out
+}

--- a/internal/skillbundle/skillbundle_test.go
+++ b/internal/skillbundle/skillbundle_test.go
@@ -1,0 +1,52 @@
+package skillbundle
+
+import (
+	"reflect"
+	"testing"
+)
+
+func find(bs []Bundle, name string) (Bundle, bool) {
+	for _, b := range bs {
+		if b.Name == name {
+			return b, true
+		}
+	}
+	return Bundle{}, false
+}
+
+func TestCoverage_FullyCovered(t *testing.T) {
+	bs := Coverage([]string{"docker", "kubernetes", "ci-cd", "terraform", "aws"})
+	b, ok := find(bs, "cloud-ops")
+	if !ok {
+		t.Fatalf("no cloud-ops bundle in %+v", bs)
+	}
+	if b.Covered != 5 || b.Total != 5 || !b.Has {
+		t.Errorf("cloud-ops = %+v, want covered 5/5 and Has", b)
+	}
+}
+
+func TestCoverage_AtThresholdCovered(t *testing.T) {
+	// 3 of 5 = 60% ≥ 50% → Has.
+	bs := Coverage([]string{"docker", "kubernetes", "ci-cd"})
+	b, _ := find(bs, "cloud-ops")
+	if b.Covered != 3 || !b.Has {
+		t.Errorf("cloud-ops = %+v, want covered 3 and Has", b)
+	}
+}
+
+func TestCoverage_BelowThresholdNotCovered(t *testing.T) {
+	// 2 of 5 = 40% < 50% → not Has.
+	bs := Coverage([]string{"docker", "kubernetes"})
+	b, _ := find(bs, "cloud-ops")
+	if b.Covered != 2 || b.Has {
+		t.Errorf("cloud-ops = %+v, want covered 2 and NOT Has", b)
+	}
+}
+
+func TestCoverage_Deterministic(t *testing.T) {
+	a := Coverage([]string{"go", "sql", "postgresql", "react"})
+	b := Coverage([]string{"go", "sql", "postgresql", "react"})
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("Coverage not deterministic:\n%+v\n%+v", a, b)
+	}
+}

--- a/internal/verdict/adjacent.go
+++ b/internal/verdict/adjacent.go
@@ -1,0 +1,44 @@
+package verdict
+
+// adjacentTo maps a role skill to the candidate skills that are genuinely
+// substitutable/transferable for it — a curated, conservative dictionary (only real
+// swaps, so `adjacent` never over-triggers). A role skill the CV lacks but for which
+// it holds a listed neighbour reads as `adjacent` (close, reframe-able) rather than a
+// hard `missing`. Keys and values are canonical skilltag slugs.
+var adjacentTo = map[string][]string{
+	// ML frameworks
+	"pytorch":    {"tensorflow"},
+	"tensorflow": {"pytorch"},
+	// Relational databases
+	"postgresql": {"mysql", "mariadb"},
+	"mysql":      {"postgresql", "mariadb"},
+	"mariadb":    {"postgresql", "mysql"},
+	// Cloud providers
+	"aws":   {"gcp", "azure"},
+	"gcp":   {"aws", "azure"},
+	"azure": {"aws", "gcp"},
+	// Frontend frameworks
+	"react":   {"vue", "angular"},
+	"vue":     {"react", "angular"},
+	"angular": {"react", "vue"},
+	// Message queues
+	"kafka":    {"rabbitmq", "sqs"},
+	"rabbitmq": {"kafka", "sqs"},
+	// Backend web frameworks
+	"fastapi": {"flask", "django", "express", "nestjs"},
+	"flask":   {"fastapi", "django"},
+	"django":  {"flask", "fastapi"},
+	"express": {"nestjs", "fastify"},
+	"nestjs":  {"express", "fastify"},
+}
+
+// adjacentHeld returns the first neighbour of `roleSkill` that the CV holds (in
+// declared or body), or "" when none — i.e. the close skill to reframe around.
+func adjacentHeld(roleSkill string, declared, body map[string]bool) string {
+	for _, adj := range adjacentTo[roleSkill] {
+		if declared[adj] || body[adj] {
+			return adj
+		}
+	}
+	return ""
+}

--- a/internal/verdict/adjacent_test.go
+++ b/internal/verdict/adjacent_test.go
@@ -1,0 +1,87 @@
+package verdict
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompute_AdjacentStatusWhenCloseSkillHeld(t *testing.T) {
+	// Role wants tensorflow; the CV lacks it but lists pytorch (adjacent).
+	v := Compute(Input{
+		Total:      100,
+		RoleSkills: map[string]int64{"tensorflow": 60},
+		Body:       []string{"pytorch"},
+		All:        []string{"pytorch"},
+	})
+	r, ok := rowByName(v.Skills, "tensorflow")
+	if !ok {
+		t.Fatal("no tensorflow row")
+	}
+	if r.Status != StatusAdjacent {
+		t.Errorf("status = %q, want adjacent", r.Status)
+	}
+	if r.Adjacent != "pytorch" {
+		t.Errorf("adjacent = %q, want pytorch", r.Adjacent)
+	}
+}
+
+func TestCompute_MissingWhenNoAdjacentHeld(t *testing.T) {
+	v := Compute(Input{
+		Total:      100,
+		RoleSkills: map[string]int64{"rust": 60},
+		Body:       []string{"pytorch"},
+		All:        []string{"pytorch"},
+	})
+	r, _ := rowByName(v.Skills, "rust")
+	if r.Status != StatusMissing {
+		t.Errorf("status = %q, want missing", r.Status)
+	}
+}
+
+func TestCompute_AdjacentDoesNotInflateCoverage(t *testing.T) {
+	// tensorflow is must-have (60% ≥ 50%) but only adjacent → not covered.
+	v := Compute(Input{
+		Total:      100,
+		RoleSkills: map[string]int64{"tensorflow": 60},
+		Body:       []string{"pytorch"},
+		All:        []string{"pytorch"},
+	})
+	if v.MustHaveTotal != 1 {
+		t.Errorf("MustHaveTotal = %d, want 1", v.MustHaveTotal)
+	}
+	if v.MustHaveCovered != 0 {
+		t.Errorf("MustHaveCovered = %d, want 0 (adjacent isn't covered)", v.MustHaveCovered)
+	}
+	if v.StackMatchPercent != 0 {
+		t.Errorf("StackMatchPercent = %d, want 0", v.StackMatchPercent)
+	}
+}
+
+func TestCompute_AdjacentAdviceNamesCloseSkill(t *testing.T) {
+	v := Compute(Input{
+		Total:      100,
+		RoleSkills: map[string]int64{"tensorflow": 60},
+		Body:       []string{"pytorch"},
+		All:        []string{"pytorch"},
+	})
+	r, _ := rowByName(v.Skills, "tensorflow")
+	if !strings.Contains(r.Advice, "pytorch") {
+		t.Errorf("advice = %q, want it to name pytorch", r.Advice)
+	}
+}
+
+func TestCompute_BundleRowsFromCVSkills(t *testing.T) {
+	v := Compute(Input{
+		Total: 100,
+		All:   []string{"docker", "kubernetes", "ci-cd", "terraform", "aws"},
+	})
+	var cloudOps bool
+	for _, b := range v.Bundles {
+		if b.Name == "cloud-ops" && b.Has {
+			cloudOps = true
+		}
+	}
+	if !cloudOps {
+		t.Errorf("bundles = %+v, want cloud-ops covered", v.Bundles)
+	}
+}

--- a/internal/verdict/input.go
+++ b/internal/verdict/input.go
@@ -15,4 +15,5 @@ type Input struct {
 	RoleSkills      map[string]int64
 	Declared        []string
 	Body            []string
+	All             []string // declared ∪ body — the CV's full parsed skill set (for bundles)
 }

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -12,6 +12,8 @@ package verdict
 import (
 	"math"
 	"sort"
+
+	"github.com/strelov1/freehire/internal/skillbundle"
 )
 
 // MaxGaps caps how many gap skills the verdict carries — the biggest wins, not an
@@ -28,9 +30,10 @@ const MustHavePct = 50
 
 // Skill statuses relative to the CV's parsed skill sets.
 const (
-	StatusStrong  = "strong"  // declared in the CV's Skills section
-	StatusHidden  = "hidden"  // used in the body but not declared
-	StatusMissing = "missing" // absent from the CV
+	StatusStrong   = "strong"   // declared in the CV's Skills section
+	StatusHidden   = "hidden"   // used in the body but not declared
+	StatusAdjacent = "adjacent" // not held, but a substitutable/transferable skill is
+	StatusMissing  = "missing"  // absent from the CV, no close skill held
 )
 
 // Verdict is the coverage result. JSON is the wire contract shared with the
@@ -42,11 +45,12 @@ type Verdict struct {
 	Gaps            []Gap `json:"gaps"`             // missing skills, biggest win first
 
 	// Market-anchored role-skill breakdown (all deterministic).
-	Skills            []SkillRow `json:"skills"`
-	MustHaveTotal     int        `json:"must_have_total"`
-	MustHaveCovered   int        `json:"must_have_covered"`
-	StackMatchPercent int        `json:"stack_match_percent"`
-	CoherencePercent  int        `json:"coherence_percent"`
+	Skills            []SkillRow           `json:"skills"`
+	MustHaveTotal     int                  `json:"must_have_total"`
+	MustHaveCovered   int                  `json:"must_have_covered"`
+	StackMatchPercent int                  `json:"stack_match_percent"`
+	CoherencePercent  int                  `json:"coherence_percent"`
+	Bundles           []skillbundle.Bundle `json:"bundles"` // market skill-combination coverage
 }
 
 // Gap is one missing in-demand skill and the new vacancies it would unlock.
@@ -61,8 +65,9 @@ type SkillRow struct {
 	Name            string `json:"name"`
 	MarketFrequency int    `json:"market_frequency"` // round(vacancies listing it / total × 100)
 	MustHave        bool   `json:"must_have"`
-	Status          string `json:"status"` // strong | hidden | missing
-	Advice          string `json:"advice"` // empty for strong
+	Status          string `json:"status"`             // strong | hidden | adjacent | missing
+	Adjacent        string `json:"adjacent,omitempty"` // the close skill held, when status is adjacent
+	Advice          string `json:"advice"`             // empty for strong
 }
 
 // Compute builds the coverage verdict and the role-skill breakdown. Pure and
@@ -88,17 +93,18 @@ func addBreakdown(v *Verdict, in Input) {
 	declared := toSet(in.Declared)
 	body := toSet(in.Body)
 
-	held := 0 // top skills the CV holds (strong or hidden)
+	held := 0 // top skills the CV holds (strong or hidden — adjacent does NOT count)
 	for _, name := range topRoleSkills(in.RoleSkills) {
 		freq := percent(in.RoleSkills[name], in.Total)
 		mustHave := freq >= MustHavePct
-		status := classify(name, declared, body)
+		status, closeSkill := classify(name, declared, body)
 		v.Skills = append(v.Skills, SkillRow{
 			Name:            name,
 			MarketFrequency: freq,
 			MustHave:        mustHave,
 			Status:          status,
-			Advice:          advice(name, status),
+			Adjacent:        closeSkill,
+			Advice:          advice(name, status, closeSkill),
 		})
 
 		covered := status == StatusStrong || status == StatusHidden
@@ -116,26 +122,33 @@ func addBreakdown(v *Verdict, in Input) {
 		v.StackMatchPercent = int(math.Round(float64(held) / float64(n) * 100))
 	}
 	v.CoherencePercent = coherence(declared, body)
+	v.Bundles = skillbundle.Coverage(in.All)
 }
 
-// classify returns a skill's status relative to the CV: strong when declared in the
-// Skills section, hidden when only used in the body, missing when absent.
-func classify(name string, declared, body map[string]bool) string {
+// classify returns a skill's status relative to the CV and, for adjacent, the close
+// skill held: strong when declared, hidden when only in the body, adjacent when a
+// substitutable skill is held, missing otherwise.
+func classify(name string, declared, body map[string]bool) (status, closeSkill string) {
 	switch {
 	case declared[name]:
-		return StatusStrong
+		return StatusStrong, ""
 	case body[name]:
-		return StatusHidden
-	default:
-		return StatusMissing
+		return StatusHidden, ""
 	}
+	if adj := adjacentHeld(name, declared, body); adj != "" {
+		return StatusAdjacent, adj
+	}
+	return StatusMissing, ""
 }
 
-// advice is a deterministic status-keyed guidance line (empty for strong).
-func advice(name, status string) string {
+// advice is a deterministic status-keyed guidance line (empty for strong). For
+// adjacent it names the close skill to reframe around.
+func advice(name, status, closeSkill string) string {
 	switch status {
 	case StatusHidden:
 		return name + " shows up in your experience but not your Skills section — list it explicitly so a reviewer spots it fast."
+	case StatusAdjacent:
+		return "You already have " + closeSkill + ", which is close to " + name + " — reframe the overlap, or ramp up the difference."
 	case StatusMissing:
 		return "You haven't shown " + name + " — learn it hands-on, add it to your Skills section, and back it with a project in Experience."
 	default:

--- a/openspec/changes/verdict-market-signals/.openspec.yaml
+++ b/openspec/changes/verdict-market-signals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/verdict-market-signals/design.md
+++ b/openspec/changes/verdict-market-signals/design.md
@@ -1,0 +1,63 @@
+## Context
+
+Builds on the merged verdict redesign (#433): `internal/verdict` computes a top-20
+role-skill breakdown with `strong`/`hidden`/`missing` status + must-have/stack/
+coherence stats; `internal/atscheck` scores five weighted categories. Both are pure
+and dictionary-first. `internal/cvsection` already yields the CV's `declared`/`body`/
+`all` skill sets. These four additions are all deterministic, mirroring
+`internal/skilltag`/`location`/`classify`.
+
+## Goals / Non-Goals
+
+**Goals:** market-combination signal (bundles); soften binary gaps with an `adjacent`
+band; typed actionable advice; a summary keyword-density ATS check. All deterministic.
+
+**Non-Goals:** archetype detection, ghost-job/legitimacy scoring, conversion
+pre-filtering, interview story-bank (career-ops features unrelated to CV-vs-market
+scoring); LLM-derived adjacency; auto-generating a reworded CV.
+
+## Decisions
+
+**1. Curated bundle dictionary (`internal/skillbundle`), not derived co-occurrence.**
+A handful of market-recognised bundles → member skill slugs. Coverage of a bundle by
+a CV = |members ∩ cvAll| / |members|; a bundle is "covered" at ≥ `BundleCoveredPct`
+(start 50%). *Why:* matches the repo's dict-first convention (precision over a noisy
+derived graph); a fixed, legible set beats live co-occurrence mining for a first cut.
+Seed bundles: `genai-core`, `cloud-ops`, `web-stack`, `data`, `ml`.
+
+**2. `adjacent` as a fourth skill status, from a curated adjacency dictionary.**
+`adjacentTo[roleSkill] = {close candidate skills}`. Classification precedence:
+`strong` (declared) → `hidden` (body) → `adjacent` (an adjacent skill is in the CV) →
+`missing`. `adjacent` counts toward neither must-have coverage nor stack-match (the
+candidate lacks the exact skill) but is surfaced as "close, reframe-able" rather than
+a hard miss. *Why:* a curated, symmetric-ish adjacency map is deterministic and
+auditable; a 4th enum value is additive on the wire (status is a free string).
+
+**3. Advice is status-keyed and names the concrete lever.** `adjacent` → "you have
+<close>, reframe the overlap or ramp up"; `hidden` → surface in Skills; `missing` →
+learn + evidence. Pure templates.
+
+**4. Summary keyword-density line item in `atscheck`.** Reuse `cvsection`-style
+heading detection to isolate the summary section; award points when it carries ≥ N of
+the CV's skill tags. Slots into the existing Content or Section category (keep the
+100-point total by re-balancing item weights within that category, not adding a 6th
+category).
+
+## Risks / Trade-offs
+
+- **Curated dicts need seeding + upkeep** → keep them small and AI/backend-focused
+  first; note the seam for expansion (mirrors skilltag). A dict change needs no
+  migration (verdict/atscheck recompute live).
+- **`adjacent` could over-trigger** if the adjacency map is too loose → seed
+  conservatively (only genuinely substitutable pairs) and treat `adjacent` as
+  not-covered so it never inflates must-have/stack numbers.
+- **Bundle overlap with stack-match** (both read the CV's skills) → bundles group by
+  market combination (a different lens: "you have the ops bundle"), stack-match is
+  flat top-20 breadth; label them distinctly.
+- **Summary-density re-balancing** must keep category maxima summing to 100 →
+  covered by an `atscheck` test asserting Σmax = 100.
+
+## Open Questions
+
+- Final `BundleCoveredPct` and the exact bundle/adjacency seed contents (calibrate
+  against real CVs, e.g. the one used to validate must-have=50%).

--- a/openspec/changes/verdict-market-signals/proposal.md
+++ b/openspec/changes/verdict-market-signals/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+The verdict now scores a CV against live market demand, but treats every skill in
+isolation and every gap as a hard binary miss. Mining the `career-ops` toolkit (a
+MIT job-search project that analysed 895 real AI-engineering vacancies and
+independently derived the same ≥50% must-have threshold we use) surfaced four
+higher-signal, market-grounded ideas that make the verdict more actionable while
+staying deterministic and dictionary-first.
+
+## What Changes
+
+- **Skill-bundle coverage:** the market expects skill *combinations*, not isolated
+  skills (career-ops: GenAI+Ops appears in 72% of AI roles, pure-GenAI in 1.4%).
+  Add a small **curated bundle dictionary** (genai-core, cloud-ops, web-stack,
+  data, ml) and report, from the CV's parsed skills, which core bundles the
+  candidate covers vs partially covers.
+- **Transferable / adjacent skill status:** a missing role skill is often *adjacent*
+  to one the candidate has (FastAPI ≈ REST APIs, PyTorch ≈ TensorFlow). Add a
+  **curated adjacency dictionary** and a fourth skill status, `adjacent`, between
+  `hidden` and `missing`: the candidate lacks the exact skill but holds a close one.
+- **Actionable, typed gap advice:** enrich the per-skill advice so each status
+  carries a concrete next step — `adjacent` names the close skill to reframe around;
+  `hidden` says surface it; `missing` says learn + evidence.
+- **ATS summary keyword-density check:** recruiters scan the summary in ~6 seconds,
+  so a keyword-dense professional summary matters. Add a deterministic line item to
+  the ATS Content/Section scoring that rewards a summary section carrying the CV's
+  concrete skills.
+
+All four are deterministic and dictionary-first (no LLM, no guessing), consistent
+with `internal/location`/`skilltag`/`classify`.
+
+## Capabilities
+
+### New Capabilities
+- `skill-bundles`: a curated dictionary grouping skills into market-recognised
+  bundles, and the coverage of each bundle by a CV's parsed skills.
+
+### Modified Capabilities
+- `resume-verdict`: add per-skill `adjacent` status (curated adjacency), typed
+  status advice, and the skill-bundle coverage rows to the verdict.
+- `cv-ats-score`: add a deterministic summary keyword-density line item.
+
+## Impact
+
+- **Backend:** new `internal/skillbundle` (+ adjacency data — likely in `skilltag`
+  or a small `internal/skilladjacent`); `internal/verdict` (`SkillRow.status` gains
+  `adjacent`, new `Bundle` rows, advice); `internal/atscheck` (summary-density
+  line item); handler `resume_verdict.go` (thread the CV `all` skill set for bundle
+  coverage).
+- **Contracts:** `cmd/gen-contracts` → `contracts.ts` (adds `Bundle`, extends the
+  status vocabulary — additive).
+- **Frontend:** `VerdictView.svelte` (adjacent badge colour + a compact bundle
+  section), `ATSReportView.svelte` (unchanged shape; the new line item just appears).
+- **No DB migration.**

--- a/openspec/changes/verdict-market-signals/specs/cv-ats-score/spec.md
+++ b/openspec/changes/verdict-market-signals/specs/cv-ats-score/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Summary keyword-density line item
+
+The ATS score SHALL include a deterministic line item that rewards a keyword-dense
+professional summary: it SHALL isolate the CV's summary section (by heading) and
+award the item when the summary carries at least a configured number of the CV's
+concrete skill tags, otherwise mark it recoverable with a fix to add role keywords
+to the summary. The item SHALL slot into an existing category without changing the
+five categories' total maximum of 100 (item weights re-balanced within the
+category). It SHALL require no LLM.
+
+#### Scenario: Keyword-dense summary is rewarded
+- **WHEN** the CV's summary section mentions several of the CV's skills (e.g. "Go, Kafka, Kubernetes")
+- **THEN** the summary keyword-density item passes and awards its points
+
+#### Scenario: Empty or generic summary is flagged
+- **WHEN** the CV's summary carries none of the CV's concrete skills
+- **THEN** the item is recoverable with a fix to add role keywords to the summary
+
+#### Scenario: Category maxima still sum to 100
+- **WHEN** the report is scored
+- **THEN** the five categories' maxima still sum to 100

--- a/openspec/changes/verdict-market-signals/specs/resume-verdict/spec.md
+++ b/openspec/changes/verdict-market-signals/specs/resume-verdict/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Transferable/adjacent skill status
+
+The verdict SHALL classify a top-20 role skill the CV does not hold exactly (neither
+`strong` nor `hidden`) as `adjacent` when the CV holds a skill listed as adjacent to
+it in a curated adjacency dictionary; otherwise it remains `missing`. Classification
+precedence SHALL be `strong` → `hidden` → `adjacent` → `missing`. An `adjacent`
+skill SHALL NOT count toward must-have coverage or stack-match (the exact skill is
+absent) — it is surfaced as a close, reframe-able gap rather than a hard miss. The
+classification SHALL be deterministic and require no LLM.
+
+#### Scenario: Adjacent when a close skill is held
+- **WHEN** the role wants "rest-apis", the CV lacks it but lists "fastapi", and the adjacency dictionary maps rest-apis → {fastapi}
+- **THEN** the skill's status is `adjacent`
+
+#### Scenario: Missing when no close skill is held
+- **WHEN** the role wants "rust", the CV holds no skill adjacent to rust
+- **THEN** the skill's status is `missing`
+
+#### Scenario: Adjacent does not inflate coverage
+- **WHEN** a must-have role skill is `adjacent` (not strong or hidden)
+- **THEN** it does not count toward `must_have_covered` or `stack_match_percent`
+
+### Requirement: Typed, actionable per-skill advice
+
+Each non-`strong` skill status SHALL carry a concrete, status-specific advice line:
+`adjacent` SHALL name the close skill the candidate holds and prompt reframing or
+ramp-up; `hidden` SHALL prompt surfacing the skill in the Skills section; `missing`
+SHALL prompt learning it and evidencing it. `strong` SHALL carry no advice. Advice
+SHALL be deterministic templates.
+
+#### Scenario: Adjacent advice names the held skill
+- **WHEN** "rest-apis" is `adjacent` because the CV lists "fastapi"
+- **THEN** its advice references "fastapi" as the close skill to reframe around
+
+### Requirement: Skill-bundle rows on the verdict
+
+The verdict SHALL include the CV's coverage of the curated skill bundles (see the
+skill-bundles capability) so the candidate sees which market skill *combinations*
+they cover, not only isolated skills.
+
+#### Scenario: Bundle coverage carried on the verdict
+- **WHEN** the CV covers the `genai-core` and `cloud-ops` bundles but not `web-stack`
+- **THEN** the verdict's bundle rows report genai-core and cloud-ops as covered and web-stack as not covered

--- a/openspec/changes/verdict-market-signals/specs/skill-bundles/spec.md
+++ b/openspec/changes/verdict-market-signals/specs/skill-bundles/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Curated skill-bundle coverage
+
+The system SHALL define a curated dictionary of market-recognised skill bundles
+(each a bundle name → a set of member skill slugs) and compute a CV's coverage of
+each bundle from the CV's parsed skill set: `covered` = the count of member skills
+present, `total` = the bundle size. A bundle SHALL be reported as covered when
+`covered / total` ≥ a configured threshold (`BundleCoveredPct`). The computation
+SHALL be pure, deterministic, and require no LLM (mirroring the other dictionaries).
+
+#### Scenario: Bundle fully covered
+- **WHEN** the `cloud-ops` bundle is {docker, kubernetes, ci-cd, terraform} and the CV lists all four
+- **THEN** its coverage is `covered` = 4, `total` = 4, and it is reported as covered
+
+#### Scenario: Bundle partially covered below threshold
+- **WHEN** the `web-stack` bundle has 5 members, the CV lists 1 of them, and the threshold is 50%
+- **THEN** its coverage is `covered` = 1 and it is NOT reported as covered
+
+#### Scenario: Deterministic
+- **WHEN** the same CV skill set is scored against the bundles twice
+- **THEN** the bundle coverage is identical

--- a/openspec/changes/verdict-market-signals/tasks.md
+++ b/openspec/changes/verdict-market-signals/tasks.md
@@ -5,11 +5,11 @@
 
 ## 2. Adjacent status + advice (verdict)
 
-- [ ] 2.1 Curated adjacency dictionary (roleSkill → close candidate skills), conservative AI/backend seed
-- [ ] 2.2 Add `StatusAdjacent`; extend `classify` precedence strong→hidden→adjacent→missing; adjacent excluded from must-have/stack counts; carry the matched close skill
-- [ ] 2.3 Typed advice: adjacent names the close skill (reframe/ramp), hidden=surface, missing=learn+evidence
-- [ ] 2.4 Add `Bundle` rows to `Verdict` (thread CV `all` skills through `Compute`)
-- [ ] 2.5 Table-driven `verdict` tests: adjacent classification, adjacent not inflating coverage, advice text, bundle rows
+- [x] 2.1 Curated adjacency dictionary (roleSkill → close candidate skills), conservative AI/backend seed
+- [x] 2.2 Add `StatusAdjacent`; extend `classify` precedence strong→hidden→adjacent→missing; adjacent excluded from must-have/stack counts; carry the matched close skill
+- [x] 2.3 Typed advice: adjacent names the close skill (reframe/ramp), hidden=surface, missing=learn+evidence
+- [x] 2.4 Add `Bundle` rows to `Verdict` (thread CV `all` skills through `Compute`)
+- [x] 2.5 Table-driven `verdict` tests: adjacent classification, adjacent not inflating coverage, advice text, bundle rows
 
 ## 3. ATS summary keyword-density (atscheck)
 

--- a/openspec/changes/verdict-market-signals/tasks.md
+++ b/openspec/changes/verdict-market-signals/tasks.md
@@ -1,0 +1,28 @@
+## 1. Skill bundles (new pure package)
+
+- [ ] 1.1 Add `internal/skillbundle` — curated bundle dict (genai-core, cloud-ops, web-stack, data, ml) + `Coverage(cvSkills) []Bundle{name,label,covered,total,covered_bool}`; `BundleCoveredPct` const
+- [ ] 1.2 Table-driven tests: full/partial/threshold coverage, determinism
+
+## 2. Adjacent status + advice (verdict)
+
+- [ ] 2.1 Curated adjacency dictionary (roleSkill → close candidate skills), conservative AI/backend seed
+- [ ] 2.2 Add `StatusAdjacent`; extend `classify` precedence strong→hidden→adjacent→missing; adjacent excluded from must-have/stack counts; carry the matched close skill
+- [ ] 2.3 Typed advice: adjacent names the close skill (reframe/ramp), hidden=surface, missing=learn+evidence
+- [ ] 2.4 Add `Bundle` rows to `Verdict` (thread CV `all` skills through `Compute`)
+- [ ] 2.5 Table-driven `verdict` tests: adjacent classification, adjacent not inflating coverage, advice text, bundle rows
+
+## 3. ATS summary keyword-density (atscheck)
+
+- [ ] 3.1 Summary-section extractor + a keyword-density line item; re-balance the host category's item weights so Σmax stays 100
+- [ ] 3.2 `atscheck` tests: dense summary passes, generic summary recoverable, Σmax == 100
+
+## 4. Contracts + frontend
+
+- [ ] 4.1 Regenerate TS contracts (`Bundle`; status vocab additive)
+- [ ] 4.2 `VerdictView.svelte`: `adjacent` badge colour + advice; compact "Skill bundles" section (covered vs partial)
+- [ ] 4.3 `svelte-check` clean + `vite build` green
+
+## 5. Verify
+
+- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green
+- [ ] 5.2 Calibrate bundle/adjacency seeds against the real CV (throwaway harness); confirm sane output

--- a/openspec/changes/verdict-market-signals/tasks.md
+++ b/openspec/changes/verdict-market-signals/tasks.md
@@ -13,8 +13,8 @@
 
 ## 3. ATS summary keyword-density (atscheck)
 
-- [ ] 3.1 Summary-section extractor + a keyword-density line item; re-balance the host category's item weights so Σmax stays 100
-- [ ] 3.2 `atscheck` tests: dense summary passes, generic summary recoverable, Σmax == 100
+- [x] 3.1 Summary-section extractor + a keyword-density line item; re-balance the host category's item weights so Σmax stays 100
+- [x] 3.2 `atscheck` tests: dense summary passes, generic summary recoverable, Σmax == 100
 
 ## 4. Contracts + frontend
 

--- a/openspec/changes/verdict-market-signals/tasks.md
+++ b/openspec/changes/verdict-market-signals/tasks.md
@@ -18,11 +18,11 @@
 
 ## 4. Contracts + frontend
 
-- [ ] 4.1 Regenerate TS contracts (`Bundle`; status vocab additive)
-- [ ] 4.2 `VerdictView.svelte`: `adjacent` badge colour + advice; compact "Skill bundles" section (covered vs partial)
-- [ ] 4.3 `svelte-check` clean + `vite build` green
+- [x] 4.1 Regenerate TS contracts (`Bundle`; status vocab additive)
+- [x] 4.2 `VerdictView.svelte`: `adjacent` badge colour + advice; compact "Skill bundles" section (covered vs partial)
+- [x] 4.3 `svelte-check` clean + `vite build` green
 
 ## 5. Verify
 
-- [ ] 5.1 `go build ./... && go vet ./... && go test ./...` green
-- [ ] 5.2 Calibrate bundle/adjacency seeds against the real CV (throwaway harness); confirm sane output
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` green
+- [x] 5.2 Calibrate bundle/adjacency seeds against the real CV (throwaway harness); confirm sane output

--- a/openspec/changes/verdict-market-signals/tasks.md
+++ b/openspec/changes/verdict-market-signals/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Skill bundles (new pure package)
 
-- [ ] 1.1 Add `internal/skillbundle` — curated bundle dict (genai-core, cloud-ops, web-stack, data, ml) + `Coverage(cvSkills) []Bundle{name,label,covered,total,covered_bool}`; `BundleCoveredPct` const
-- [ ] 1.2 Table-driven tests: full/partial/threshold coverage, determinism
+- [x] 1.1 Add `internal/skillbundle` — curated bundle dict (genai-core, cloud-ops, web-stack, data, ml) + `Coverage(cvSkills) []Bundle{name,label,covered,total,covered_bool}`; `BundleCoveredPct` const
+- [x] 1.2 Table-driven tests: full/partial/threshold coverage, determinism
 
 ## 2. Adjacent status + advice (verdict)
 

--- a/web/src/lib/components/VerdictView.svelte
+++ b/web/src/lib/components/VerdictView.svelte
@@ -18,12 +18,14 @@
 
   const gaps = $derived(verdict.gaps ?? []);
   const skills = $derived(verdict.skills ?? []);
+  const bundles = $derived(verdict.bundles ?? []);
   const uncovered = $derived(Math.max(verdict.total - verdict.covered, 0));
 
-  // Status → badge styling (STRONG green / HIDDEN amber / MISSING red).
+  // Status → badge styling (STRONG green / HIDDEN amber / ADJACENT blue / MISSING red).
   const statusStyle: Record<string, string> = {
     strong: 'bg-primary/10 text-primary',
     hidden: 'bg-amber-500/10 text-amber-600 dark:text-amber-500',
+    adjacent: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
     missing: 'bg-destructive/10 text-destructive',
   };
 </script>
@@ -68,6 +70,26 @@
       <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Coherence</span>
     </div>
   </div>
+
+  <!-- Skill bundles: the market expects combinations, not isolated skills -->
+  {#if bundles.length > 0}
+    <div class="flex flex-col gap-2">
+      <h2 class="text-base font-semibold tracking-tight">Skill bundles the market expects</h2>
+      <div class="flex flex-wrap gap-2">
+        {#each bundles as b (b.name)}
+          <span
+            class="inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-sm {b.has
+              ? 'bg-primary/5 text-foreground'
+              : 'bg-card text-muted-foreground'}"
+          >
+            {#if b.has}<Check class="size-3.5 text-primary" />{/if}
+            <span class="font-medium">{b.label}</span>
+            <span class="tabular-nums text-xs text-muted-foreground">{b.covered}/{b.total}</span>
+          </span>
+        {/each}
+      </div>
+    </div>
+  {/if}
 
   <!-- Biggest wins -->
   {#if gaps.length > 0}

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -137,6 +137,22 @@ export interface Job {
 }
 
 /**
+ * BundleCoveredPct is the share of a bundle's member skills a CV must hold for the
+ * bundle to count as covered. Tunable.
+ */
+export const BundleCoveredPct = 50;
+/**
+ * Bundle is one market skill combination and a CV's coverage of it.
+ */
+export interface Bundle {
+  name: string;
+  label: string;
+  covered: number /* int */; // member skills the CV holds
+  total: number /* int */; // bundle size
+  has: boolean; // Covered/Total ≥ BundleCoveredPct
+}
+
+/**
  * MaxGaps caps how many gap skills the verdict carries — the biggest wins, not an
  * exhaustive list. TopSkills caps the role-skill breakdown at the most in-demand.
  */
@@ -163,7 +179,11 @@ export const StatusHidden = "hidden"; // used in the body but not declared
 /**
  * Skill statuses relative to the CV's parsed skill sets.
  */
-export const StatusMissing = "missing"; // absent from the CV
+export const StatusAdjacent = "adjacent"; // not held, but a substitutable/transferable skill is
+/**
+ * Skill statuses relative to the CV's parsed skill sets.
+ */
+export const StatusMissing = "missing"; // absent from the CV, no close skill held
 /**
  * Verdict is the coverage result. JSON is the wire contract shared with the
  * frontend (generated to TS via cmd/gen-contracts).
@@ -181,6 +201,7 @@ export interface Verdict {
   must_have_covered: number /* int */;
   stack_match_percent: number /* int */;
   coherence_percent: number /* int */;
+  bundles: Bundle[]; // market skill-combination coverage
 }
 /**
  * Gap is one missing in-demand skill and the new vacancies it would unlock.
@@ -197,7 +218,8 @@ export interface SkillRow {
   name: string;
   market_frequency: number /* int */; // round(vacancies listing it / total × 100)
   must_have: boolean;
-  status: string; // strong | hidden | missing
+  status: string; // strong | hidden | adjacent | missing
+  adjacent?: string; // the close skill held, when status is adjacent
   advice: string; // empty for strong
 }
 


### PR DESCRIPTION
Four market-grounded upgrades to the verdict/CV-readiness feature, mined from the `career-ops` toolkit (a MIT job-search project that analysed 895 real AI vacancies and independently derived the same ≥50% must-have threshold we use). All deterministic and dictionary-first — no LLM, no guessing.

## 1. Skill bundles (`internal/skillbundle`)
The market expects skill *combinations*, not isolated skills (career-ops: GenAI+Ops in 72% of AI roles, pure-GenAI in 1.4%). A curated bundle dictionary (genai-core, cloud-ops, web-stack, data, ml) → the verdict reports which bundles the CV covers. `Verdict.bundles`.

## 2. Transferable / adjacent skill status (`internal/verdict`)
A missing role skill is often *adjacent* to one the candidate holds. A curated adjacency dictionary (FastAPI≈Flask/Express, PyTorch≈TensorFlow, AWS≈GCP/Azure, React≈Vue…) adds a 4th status `adjacent` between `hidden` and `missing`. Adjacent does **not** count toward must-have coverage or stack-match (the exact skill is absent) — it's surfaced as a close, reframe-able gap. New `SkillRow.adjacent` names the close skill.

## 3. Typed, actionable advice
Each status carries a concrete next step: `adjacent` names the close skill to reframe around, `hidden` says surface it, `missing` says learn + evidence.

## 4. ATS summary keyword-density (`internal/atscheck`)
Recruiters scan the summary in ~6 seconds. A deterministic line item rewards a keyword-dense professional summary. Slots into Section Completeness with weights re-balanced so the five categories still sum to 100.

## Notes
- Additive wire changes: new `Bundle` type, `Verdict.bundles`, `SkillRow.adjacent`, `status` gains `adjacent`. Contracts regenerated (gen-contracts now emits `skillbundle.Bundle`).
- Frontend: `VerdictView` gets an adjacent (blue) badge + a "Skill bundles the market expects" section.
- No DB migration.
- Builds on #433 (verdict redesign) and #434 (profile-page merge), both merged.

## Verification
`go build/vet/test ./...` green · `svelte-check` 0/0 · `vite build` ok. **Calibrated on a real CV** (throwaway harness): bundles = GenAI✓/Cloud✓/Web✓/Data✓/ML·; adjacency correctly flagged fastapi←express, gcp/azure←aws, vue←react; adjacent skills correctly excluded from must-have/stack (5/7, 60%).