### PR TITLE
fix(gupy): restore job description structure via rich detail endpoint

### DIFF
--- a/internal/sources/gupy.go
+++ b/internal/sources/gupy.go
@@ -3,8 +3,12 @@ package sources
 import (
 	"context"
 	"fmt"
+	"html"
 	"strconv"
 	"strings"
+	"unicode"
+
+	"github.com/microcosm-cc/bluemonday"
 )
 
 // gupyBaseURL is the Gupy public portal jobs API. Gupy is the dominant Brazilian
@@ -21,6 +25,13 @@ const gupyPageLimit = 100
 // misbehaving API that always returned a full page would otherwise loop forever, so
 // this caps the walk at 5000 postings — well above any single company's openings.
 const gupyMaxPages = 50
+
+// gupyDetailURL is Gupy's richer public job endpoint, keyed by the same numeric job id as
+// the listing. The portal listing (gupyBaseURL) flattens a posting's sections into one
+// tag-less description blob — headings glued to sentences, list items separated only by
+// ";" — so its description renders as an unstructured wall of text. This endpoint returns
+// the original per-section HTML instead; it is what the public career page itself consumes.
+const gupyDetailURL = "https://private-api.gupy.io/job-publication/public/jobs"
 
 // gupy adapts the Gupy portal API. Its list endpoint carries the description inline,
 // so — like Greenhouse — it needs no per-posting detail request. The board id is the
@@ -66,7 +77,7 @@ func (g gupy) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Title:       strings.TrimSpace(p.Name),
 			Company:     e.Company,
 			Location:    joinNonEmpty(p.City, p.State, p.Country),
-			Description: sanitizeHTML(p.Description),
+			Description: g.description(ctx, p.ID, p.Description),
 			Remote:      p.IsRemoteWork,
 			WorkMode:    workplaceTypeMode(p.WorkplaceType),
 			PostedAt:    parseRFC3339(p.PublishedDate),
@@ -100,4 +111,56 @@ func (g gupy) list(ctx context.Context, board string) ([]gupyJob, error) {
 		offset += len(resp.Data)
 	}
 	return postings, nil
+}
+
+// gupyDetail is a posting's structured detail. Gupy splits a job into fixed sections;
+// concatenating them in board order reproduces the full description with its original
+// markup (paragraphs, lists, emphasis) that the flat listing description discards.
+type gupyDetail struct {
+	Description         string `json:"description"`         // intro / "about the role"
+	Responsibilities    string `json:"responsibilities"`    // Responsabilidades e atribuições
+	Prerequisites       string `json:"prerequisites"`       // Requisitos e qualificações
+	RelevantExperiences string `json:"relevantExperiences"` // Informações adicionais / benefits
+}
+
+// description fetches the posting's structured detail and assembles its sections into one
+// sanitized HTML document. The flat listing description is the fallback when the detail
+// endpoint is unreachable or yields nothing usable, so a detail hiccup degrades to the old
+// behaviour rather than dropping the body.
+func (g gupy) description(ctx context.Context, id int64, flat string) string {
+	var d gupyDetail
+	if err := g.http.GetJSON(ctx, fmt.Sprintf("%s/%d", gupyDetailURL, id), &d); err == nil {
+		if assembled := gupySections(d); assembled != "" {
+			return sanitizeHTML(assembled)
+		}
+	}
+	return sanitizeHTML(flat)
+}
+
+// gupySections concatenates the detail's section fragments in display order, skipping any
+// that carry no real text (Gupy commonly emits a "<p>.</p>" placeholder intro). It returns
+// "" when every section is empty, signalling the caller to fall back to the flat listing.
+func gupySections(d gupyDetail) string {
+	var b strings.Builder
+	for _, section := range []string{d.Description, d.Responsibilities, d.Prerequisites, d.RelevantExperiences} {
+		if gupyHasText(section) {
+			b.WriteString(section)
+		}
+	}
+	return b.String()
+}
+
+// gupyTextPolicy strips all markup, leaving only text — used to tell a real section from a
+// placeholder like "<p>.</p>" or "<p>&nbsp;</p>". Compiled once, safe for concurrent use.
+var gupyTextPolicy = bluemonday.StrictPolicy()
+
+// gupyHasText reports whether an HTML fragment contains any letter or digit once tags and
+// entities are stripped, so whitespace/punctuation-only sections are treated as empty.
+func gupyHasText(fragment string) bool {
+	for _, r := range html.UnescapeString(gupyTextPolicy.Sanitize(fragment)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/sources/gupy_test.go
+++ b/internal/sources/gupy_test.go
@@ -110,6 +110,72 @@ func TestGupyFetchMapsFieldsAndPaginates(t *testing.T) {
 
 // itoa is provided by ozon_test.go in this package.
 
+func TestGupyFetchAssemblesRichDescription(t *testing.T) {
+	// The portal listing flattens a posting's sections into one tag-less blob; the richer
+	// public detail endpoint returns them as separate HTML fields. Fetch must pull the
+	// detail and assemble the sections into structured HTML, not serve the flat listing text.
+	fake := (&routedHTTP{}).
+		route("offset=0", `{"data":[
+			{"id":500,"name":"Backend Engineer","jobUrl":"https://acme.gupy.io/job/500",
+			 "description":"Do stuff;Ship it;Be a Go expert","workplaceType":"remote"}
+		]}`).
+		route("job-publication/public/jobs/500", `{
+			"description":"<p>.</p>",
+			"responsibilities":"<p>O profissional:</p><ul><li>Ship it;</li></ul>",
+			"prerequisites":"<ul><li>Be a Go expert</li></ul>",
+			"relevantExperiences":"<p>Free lunch</p>"
+		}`)
+
+	jobs, err := NewGupy(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "gupy", Board: "42",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	desc := jobs[0].Description
+
+	// Structure from the detail is preserved: list markup survives sanitization.
+	if !strings.Contains(desc, "<li>") || !strings.Contains(desc, "<ul>") {
+		t.Errorf("Description dropped list structure, got %q", desc)
+	}
+	// Every section's body is present.
+	for _, want := range []string{"Ship it", "Go expert", "Free lunch"} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("Description missing %q section body, got %q", want, desc)
+		}
+	}
+	// The empty "<p>.</p>" intro placeholder must not leak a stray leading dot.
+	if strings.HasPrefix(strings.TrimSpace(desc), ".") {
+		t.Errorf("Description leaked the placeholder intro, got %q", desc)
+	}
+}
+
+func TestGupyFetchFallsBackToFlatDescription(t *testing.T) {
+	// When the detail endpoint is unreachable (no route → GetJSON error), Fetch degrades to
+	// the listing's own description rather than dropping the body.
+	fake := (&routedHTTP{}).
+		route("offset=0", `{"data":[
+			{"id":600,"name":"Role","jobUrl":"https://acme.gupy.io/job/600",
+			 "description":"<p>flat body</p>","workplaceType":"remote"}
+		]}`)
+
+	jobs, err := NewGupy(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "gupy", Board: "42",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "flat body") {
+		t.Errorf("Description = %q, want fallback to flat listing body", jobs[0].Description)
+	}
+}
+
 func TestGupyFetchStopsOnEmptyPage(t *testing.T) {
 	// A short first page ends the walk immediately — no offset=100 request is made.
 	fake := (&routedHTTP{}).
@@ -126,8 +192,10 @@ func TestGupyFetchStopsOnEmptyPage(t *testing.T) {
 	if len(jobs) != 1 {
 		t.Fatalf("len(jobs) = %d, want 1 from the single short page", len(jobs))
 	}
-	if fake.calls != 1 {
-		t.Errorf("made %d HTTP calls, want 1 (short page must stop the walk)", fake.calls)
+	// One listing call (the short page stops the walk — no offset=100 request) plus one
+	// per-posting detail call for the single posting.
+	if fake.calls != 2 {
+		t.Errorf("made %d HTTP calls, want 2 (one listing that stops the walk + one detail)", fake.calls)
 	}
 }
 


### PR DESCRIPTION
## Problem

Gupy job descriptions render as an unstructured wall of text on freehire (e.g. [this job](https://freehire.dev/jobs/java-back-end-developer-senior-remote-compass-uol-zfyrzsha)). Root cause: the Gupy **portal listing API** (`employability-portal.gupy.io/api/v1/jobs`, both list and `/jobs/{id}`) returns `description` as a **flat, tag-less blob** — section headers glued to sentences, list items separated only by `;`, no `<li>`/`<br>`/newlines. `sanitizeHTML` was innocent: there was no markup to preserve.

## Fix

Switch the adapter to **list + detail**. The richer public endpoint the career SPA itself uses — `https://private-api.gupy.io/job-publication/public/jobs/{id}`, keyed by the same numeric portal id, keyless — returns the sections as separate HTML fields (`description`, `responsibilities`, `prerequisites`, `relevantExperiences`). We assemble them in order (skipping text-empty placeholders like `<p>.</p>`) and sanitize. Verified against a posting with all sections incl. Benefícios — no content lost.

Resilience: **falls back to the flat listing description** on any detail error, so an outage degrades rather than drops the body.

## Trade-off

gupy goes from list-only to +1 request per posting — the accepted cost of real structured data. Existing rows self-heal on the next ingest crawl (content_hash → UpsertJob refresh); no backfill needed.

## Tests

- `TestGupyFetchAssemblesRichDescription` — detail sections assembled into structured HTML, placeholder intro dropped.
- `TestGupyFetchFallsBackToFlatDescription` — degrades to flat listing body when detail is unreachable.
- Updated `TestGupyFetchStopsOnEmptyPage` for the list+detail call count.

`go build ./...`, `go vet`, `go test ./internal/sources` green.