### PR TITLE
feat(cv-ats): copy-suggestions button + review btn on tabs row + clearer content-quality copy

### DIFF
--- a/internal/atscheck/atscheck.go
+++ b/internal/atscheck/atscheck.go
@@ -298,14 +298,15 @@ func (r *Report) ApplyReview(rv *Review) {
 	if rv == nil {
 		return
 	}
-	score := int(math.Round(float64(clamp(rv.ContentQuality)) / 100 * contentMax))
+	cq := clamp(rv.ContentQuality)
+	score := int(math.Round(float64(cq) / 100 * contentMax))
 	for i := range r.Categories {
 		if r.Categories[i].ID != categoryContent {
 			continue
 		}
-		items := []LineItem{{Points: score, Text: "AI-assessed content quality", Status: StatusPass}}
+		items := []LineItem{{Points: score, Text: fmt.Sprintf("AI-assessed content quality: %d/100", cq), Status: StatusPass}}
 		if score < contentMax {
-			items = append(items, LineItem{Points: contentMax - score, Text: "Apply the suggestions below to raise content quality", Status: StatusWarn})
+			items = append(items, LineItem{Points: contentMax - score, Text: "Apply the numbered Suggestions below to close the gap", Status: StatusWarn})
 		}
 		r.Categories[i].Items = items
 	}

--- a/web/src/lib/components/ATSReportView.svelte
+++ b/web/src/lib/components/ATSReportView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Check, TriangleAlert, X } from '@lucide/svelte';
+  import { Check, Copy, TriangleAlert, X } from '@lucide/svelte';
   import type { ATSReport } from '$lib/types';
 
   // The CV ATS-readiness report from the backend: an overall score out of 100 built
@@ -16,6 +16,22 @@
     if (score >= 75) return 'text-primary';
     if (score >= 50) return 'text-amber-500';
     return 'text-destructive';
+  }
+
+  // Copy the suggestions as an LLM-ready prompt so the user can paste them into a
+  // chat and have the model apply them to the CV.
+  let copied = $state(false);
+  async function copySuggestions() {
+    const text =
+      'Please improve my CV by applying these suggestions:\n\n' +
+      suggestions.map((s, i) => `${i + 1}. ${s}`).join('\n');
+    try {
+      await navigator.clipboard.writeText(text);
+      copied = true;
+      setTimeout(() => (copied = false), 1500);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — silently skip.
+    }
   }
 </script>
 
@@ -118,7 +134,20 @@
   <!-- AI suggestions (only after a review) -->
   {#if suggestions.length > 0}
     <div class="flex flex-col gap-2">
-      <h3 class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Suggestions</h3>
+      <div class="flex items-center justify-between gap-3">
+        <h3 class="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Suggestions</h3>
+        <button
+          type="button"
+          onclick={copySuggestions}
+          class="inline-flex items-center gap-1.5 rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        >
+          {#if copied}
+            <Check class="size-3.5 text-primary" /> Copied
+          {:else}
+            <Copy class="size-3.5" /> Copy for AI chat
+          {/if}
+        </button>
+      </div>
       <ol class="flex flex-col gap-1.5">
         {#each suggestions as s, i (i)}
           <li class="flex items-start gap-2 text-sm text-muted-foreground">

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -219,34 +219,51 @@
 
         <main class="flex min-w-0 flex-1 flex-col gap-6">
           <!-- Tabs -->
-          <div class="flex gap-5 border-b border-border">
-            <button
-              type="button"
-              onclick={() => (tab = 'profile')}
-              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'profile'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'}"
-            >
-              Your CV
-            </button>
-            <button
-              type="button"
-              onclick={() => (tab = 'coverage')}
-              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'}"
-            >
-              Market coverage
-            </button>
-            <button
-              type="button"
-              onclick={() => (tab = 'readiness')}
-              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'readiness'
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'}"
-            >
-              CV readiness
-            </button>
+          <div class="flex items-center justify-between gap-3 border-b border-border">
+            <div class="flex gap-5">
+              <button
+                type="button"
+                onclick={() => (tab = 'profile')}
+                class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'profile'
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'}"
+              >
+                Your CV
+              </button>
+              <button
+                type="button"
+                onclick={() => (tab = 'coverage')}
+                class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'}"
+              >
+                Market coverage
+              </button>
+              <button
+                type="button"
+                onclick={() => (tab = 'readiness')}
+                class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'readiness'
+                  ? 'border-primary text-foreground'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'}"
+              >
+                CV readiness
+              </button>
+            </div>
+            {#if tab === 'readiness' && ats?.has_cv && ats.report}
+              <div class="pb-1.5">
+                {#if !ats.report.reviewed && !reviewUnavailable}
+                  <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
+                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                    {reviewBusy ? 'Reviewing…' : 'Run AI review'}
+                  </Button>
+                {:else if ats.report.reviewed}
+                  <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
+                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+                    {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
+                  </Button>
+                {/if}
+              </div>
+            {/if}
           </div>
 
           <!-- Body -->
@@ -263,20 +280,6 @@
           {:else if ats?.has_cv && ats.report}
             <!-- CV readiness -->
             <div class="flex flex-col gap-5">
-              <div class="flex flex-wrap items-center justify-between gap-3">
-                <p class="text-sm text-muted-foreground">How ATS-ready your CV is for this role.</p>
-                {#if !ats.report.reviewed && !reviewUnavailable}
-                  <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
-                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                    {reviewBusy ? 'Reviewing…' : 'Run AI review'}
-                  </Button>
-                {:else if ats.report.reviewed}
-                  <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
-                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                    {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
-                  </Button>
-                {/if}
-              </div>
               {#if reviewUnavailable}
                 <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
               {/if}


### PR DESCRIPTION
Small UX polish on the CV-readiness view:
- **Copy for AI chat** button on the Suggestions block — copies the suggestions as an LLM-ready prompt so the user can paste them into a chat and have the model apply them to the CV.
- **Run/Re-run AI review** button moved up to the tabs row, right-aligned (was in the tab body).
- Removed the redundant "How ATS-ready your CV is for this role." subtitle.
- Clearer Content Quality copy after an AI review: the pass line now shows the score ("AI-assessed content quality: N/100") and the remainder line reads "Apply the numbered Suggestions below to close the gap" (was the ambiguous "Apply the suggestions below").

svelte-check 0/0 · vite build ok · go test ./internal/atscheck green.