### PR TITLE
feat(web): mixed include/exclude per facet filter

### DIFF
--- a/openspec/changes/facet-mixed-include-exclude/.openspec.yaml
+++ b/openspec/changes/facet-mixed-include-exclude/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/facet-mixed-include-exclude/design.md
+++ b/openspec/changes/facet-mixed-include-exclude/design.md
@@ -1,0 +1,90 @@
+## Context
+
+Job-search filters live in the web client as a per-facet `FacetState { values[],
+exclude, matchAll }` (`web/src/lib/filters.ts`). The single `exclude` boolean makes a
+facet all-include or all-exclude, so "include nodejs and exclude php/.net" is
+unrepresentable in one facet. The backend already accepts `?skills=nodejs` and
+`?skills_exclude=php` in the same request (`internal/search/query_filter.go` ANDs the
+excludes with the include group), so this is purely a web-client limitation.
+
+The same `FacetState` and control components (`FacetSection`, `PillGroup`,
+`SearchSelect`, `RemoteSearchSelect`) drive both the sidebar and the deferred-edit
+`FilterModal` (via `StagedFilters`), and the company filter store satisfies the same
+`FacetStore` interface. The web project has no test runner today (verify is
+`svelte-check` + visual). A prototype of the target interaction was built and approved.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let one facet hold included and excluded values simultaneously.
+- Keep the URL/API contract unchanged (`?param` / `?param_exclude` / `?param_mode=and`)
+  so shared links and saved searches keep working.
+- One consistent mental model across control types (a value is off / included /
+  excluded everywhere).
+- Unit-test the pure filter logic (model transitions + URL round-trip).
+
+**Non-Goals:**
+- No backend, Meilisearch, or search-API change; `query_filter.go` and its tests stay
+  untouched.
+- No component-level test harness (Svelte controls stay visually verified).
+- No change to which facets are excludable, nor to the company filter's include-only
+  behavior.
+
+## Decisions
+
+**1. Two arrays over a per-value tag.** `FacetState` becomes `{ include: string[],
+exclude: string[], matchAll: boolean }`. This maps 1:1 to the existing URL params and
+to the backend's group structure, and keeps `matchAll` naturally scoped to the include
+set. Alternative — a single `values: {value, sign}[]` — was rejected: it complicates
+serialization and every chip render keys on a plain string today.
+
+**2. A `setSign` primitive with semantic wrappers in the store.** The store exposes
+`setSign(param, value, 'off'|'include'|'exclude')` plus intent-named wrappers so
+components stay dumb and the transitions stay unit-testable:
+- `cycle` (pills): off → include → exclude → off
+- `pick` (select dropdown): off → include, else → off
+- `toggleSign` (select chip control): include ↔ exclude
+- `add` (token input): → include; `remove`: → off
+`setExclude` (whole-facet) is removed. `FacetStore` (the shared interface) and
+`StagedFilters` mirror this surface; the company store implements them as include-only
+(cycle/toggleSign never fire on non-excludable facets).
+
+**3. Control rendering keys off each value's sign, not a facet-wide flag.**
+`PillGroup` renders three states; `SearchSelect`/`RemoteSearchSelect` render an
+include chip group and a destructive exclude group with a per-chip include↔exclude
+toggle. `FacetSection`/`FacetHeader` drop the whole-facet Exclude toggle but keep the
+Clear and the match-all (Any/All) toggle (still gated on `include.length > 1`).
+`FilterSummary` renders included and excluded values distinctly.
+
+**4. Backward-compatible parse.** `filtersFromParams` reads `param` → include,
+`param_exclude` → exclude. If a value appears in both (malformed/legacy URL), exclude
+wins and it is dropped from include, preserving the "one sign per value" invariant.
+
+**5. Add vitest for the pure logic only.** Vite is already the web toolchain, so a
+`vitest` dev-dependency + `test` script is a minimal addition. Tests cover
+`setSign`/`cycle`/`pick`/`toggleSign`, `filtersToParams`, `filtersFromParams`, the
+round-trip (`canonicalQuery`), and `activeFilterCount`. Components remain
+visually verified (headless-Chrome on the live skills facet).
+
+## Risks / Trade-offs
+
+- **Three-state pills are less discoverable** (second click = exclude) → mitigate with
+  the destructive style + a `title` tooltip naming the next state; the prototype
+  confirmed the interaction reads clearly.
+- **Broad mechanical churn across ~11 files** touching a shared type → mitigate by
+  landing the model + store + tests first (RED/GREEN on pure logic), then updating
+  controls under `svelte-check`, which flags every `FacetState` shape mismatch.
+- **Company filter store shares the interface** → adding no-op-ish include-only
+  wrappers keeps it compiling; excludable is already false there, so behavior is
+  unchanged.
+
+## Migration Plan
+
+Pure client change; ships with the normal web deploy. No data migration. Old shared
+URLs and saved searches parse unchanged. Rollback is reverting the web bundle — the
+URL contract is identical, so a rolled-back client still reads today's links.
+
+## Open Questions
+
+None — model, store API, and both control interactions were settled in brainstorming
+and validated with the approved prototype.

--- a/openspec/changes/facet-mixed-include-exclude/proposal.md
+++ b/openspec/changes/facet-mixed-include-exclude/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Today a facet is either all-include or all-exclude: the filter model carries a
+single `exclude` flag for the whole facet, so a user cannot say "include nodejs
+**and** exclude php/.net" in one facet. The backend already accepts both
+`?skills=nodejs` and `?skills_exclude=php` in the same request — the limitation is
+purely in the web client's filter model and controls.
+
+## What Changes
+
+- **BREAKING (internal model):** Replace the per-facet `FacetState { values,
+  exclude, matchAll }` with `FacetState { include[], exclude[], matchAll }`, so a
+  single facet can hold included and excluded values at the same time. `matchAll`
+  applies to the include set only (exclude values are always ANDed).
+- Filter store gains per-value sign operations (`setSign`, `cycle`, `pick`,
+  `toggleSign`) and drops the whole-facet `setExclude` toggle.
+- **Select facets** (skills, countries, cities, domains, category, company,
+  source, language): the dropdown pick adds to include; selected values render as
+  chips, each with an include↔exclude toggle; excluded values group below in the
+  destructive (red) style.
+- **Pills facets** (regions, work format, seniority, employment, …): each pill is
+  three-state — off → include → exclude → off — replacing the section-wide Exclude
+  toggle.
+- The `FilterSummary` and staged-filter surfaces render include and exclude
+  values distinctly.
+- URL serialization is unchanged in shape (`?param` / `?param_exclude` /
+  `?param_mode=and`), so existing shared links and saved searches keep working.
+- Add **vitest** to the web project to unit-test the pure filter logic (model
+  transitions + URL round-trip); Svelte controls are verified visually.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none: this modifies existing filter behavior -->
+
+### Modified Capabilities
+
+- `filter-modal`: the "per-facet Exclude and Clear" requirement changes from a
+  whole-facet Exclude toggle to per-value include/exclude — three-state pills and a
+  per-chip include↔exclude toggle — so include and exclude values coexist within one
+  facet.
+
+## Impact
+
+- **Web only.** No backend, Meilisearch, or search-API change (the API already
+  accepts simultaneous `param` / `param_exclude`; `query_filter.go` and its tests
+  are untouched).
+- Touched web files: `filters.ts` (model, store, serialization),
+  `stagedFilters.svelte.ts`, `facets.ts` (`FacetSelection`/`FacetStore`
+  interfaces), the facet controls (`PillGroup`, `SearchSelect`,
+  `RemoteSearchSelect`, `FacetSection`, `TokenInput`), and the modal surfaces
+  (`FacetHeader`, `ChipFacet`, `FilterSummary`).
+- New dev dependency: `vitest` + a `test` script in `web/package.json`.
+- Old URLs / saved searches remain valid (parse path is backward-compatible).

--- a/openspec/changes/facet-mixed-include-exclude/specs/filter-modal/spec.md
+++ b/openspec/changes/facet-mixed-include-exclude/specs/filter-modal/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Filter options are selected as chips with per-facet Exclude and Clear
+
+Every multi-value facet control in the modal SHALL render its options as chips (the
+shared pill primitive), not checkboxes or radio buttons, and SHALL let a single facet
+hold included and excluded values at the same time. Each facet value carries one of
+three states — unselected, included, or excluded — held in the facet's separate
+`include` and `exclude` sets. A pills facet SHALL cycle a value through
+unselected → included → excluded → unselected on successive activations, showing the
+active (filled) style when included and the destructive (red) style when excluded. A
+select (searchable) facet SHALL add a picked value to the include set, render each
+selected value as a chip carrying a control that toggles it between include and
+exclude, and group excluded chips under the destructive style. Included values within
+a facet SHALL be ORed by default, with an optional match-all (AND) toggle shown once
+more than one value is included; excluded values SHALL always be ANDed (a job matches
+only if it has none of them). Each facet with a selection SHALL offer a Clear control
+that resets both sets. These per-value controls SHALL match the sidebar's facet
+controls, and the whole-facet Exclude toggle SHALL be removed.
+
+#### Scenario: Options render as chips
+
+- **WHEN** a facet with a fixed option set is shown in the modal
+- **THEN** its options render as chips, and an included option shows the active chip
+  style while an excluded option shows the destructive (red) style
+
+#### Scenario: A pills value cycles through include and exclude
+
+- **WHEN** the user activates the same pills-facet value three times in a row
+- **THEN** the value moves unselected → included → excluded → unselected, and the chip
+  style tracks each state
+
+#### Scenario: A select value toggles between include and exclude
+
+- **WHEN** a select facet has a value staged in its include set and the user activates
+  that chip's include/exclude toggle
+- **THEN** the value moves from the include set to the exclude set (and renders under
+  the destructive style), without being removed from the facet
+
+#### Scenario: Include and exclude coexist in one facet
+
+- **WHEN** the user includes one value and excludes another in the same facet (e.g.
+  include `nodejs`, exclude `php`)
+- **THEN** both selections are retained and serialize to `?<param>=nodejs` and
+  `?<param>_exclude=php` in the same request
+
+#### Scenario: Match-all toggle applies to included values only
+
+- **WHEN** a facet has two or more included values
+- **THEN** a match-all (AND) toggle is shown for the include set, and excluded values
+  are unaffected by it (always ANDed)
+
+#### Scenario: Clear resets both sets
+
+- **WHEN** a facet has both included and excluded values and the user activates Clear
+- **THEN** the facet's include and exclude sets are both emptied

--- a/openspec/changes/facet-mixed-include-exclude/tasks.md
+++ b/openspec/changes/facet-mixed-include-exclude/tasks.md
@@ -1,0 +1,30 @@
+## 1. Test infrastructure
+
+- [x] 1.1 Add `vitest` dev-dependency and a `test` script to `web/package.json`; add a minimal `vitest.config.ts` (jsdom not required — logic is pure) and confirm `npm run test` runs an empty/passing suite.
+
+## 2. Model + URL serialization (TDD on pure logic)
+
+- [x] 2.1 Write failing tests in `web/src/lib/filters.test.ts` for the new `FacetState { include, exclude, matchAll }`: `emptyFacet`, `filtersToParams` (include → `param`, exclude → `param_exclude`, `param_mode=and` only when `include.length > 1`), `filtersFromParams` (round-trip + both-sets-present, and the exclude-wins de-dup when a value appears in both), `canonicalQuery` round-trip, and `activeFilterCount = include + exclude`.
+- [x] 2.2 Change `FacetState` to `{ include: string[]; exclude: string[]; matchAll: boolean }` and update `emptyFacet`, `filtersToParams`, `filtersFromParams`, `activeFilterCount` until 2.1 is green. Keep the URL shape unchanged.
+
+## 3. Store API (TDD where pure)
+
+- [x] 3.1 Write failing tests for the store transitions: `setSign` (off/include/exclude), `cycle` (off→include→exclude→off), `pick` (off→include, else→off), `toggleSign` (include↔exclude), `add` (→include, no-op on blank/dup), `remove` (→off), and `setMatchAll`/`clearFacet`.
+- [x] 3.2 Implement the new methods on `FilterStore`, remove `setExclude` and the old `toggle`, and mirror the same surface on `StagedFilters`; update the `FacetSelection`/`FacetStore` interfaces in `facets.ts`. Make 3.1 green.
+
+## 4. Facet controls (visual)
+
+- [x] 4.1 `PillGroup.svelte`: render three states (off/include/exclude) keyed off the value's sign, call `cycle`, and set a `title` naming the next state. Replace the `exclude` boolean prop with the include/exclude sets.
+- [x] 4.2 `SearchSelect.svelte` and `RemoteSearchSelect.svelte`: dropdown pick → `pick`; render selected values as an include chip group and a destructive exclude chip group, each chip with an include↔exclude toggle (`toggleSign`) and a remove (`remove`).
+- [x] 4.3 `FacetSection.svelte` + `FacetHeader.svelte`: drop the whole-facet Exclude toggle; keep Clear (resets both sets) and the match-all (Any/All) toggle gated on `include.length > 1`. Wire `ChipFacet.svelte` pills to `cycle`.
+- [x] 4.4 `TokenInput.svelte`: confirm it drives `add`/`remove` as include-only (no exclude affordance needed for its facets).
+
+## 5. Summary + company parity
+
+- [x] 5.1 `FilterSummary.svelte`: render included and excluded values distinctly (destructive style for excludes).
+- [x] 5.2 Update the company filter store to implement the new `FacetStore` methods as include-only (all company facets are non-excludable); confirm the company filter page still compiles and filters.
+
+## 6. Verify
+
+- [x] 6.1 `npm run test` green; `npm run check` (svelte-check) clean across the `FacetState` chain; `npm run lint` no new errors.
+- [x] 6.2 Visual verify (headless-Chrome) on the live skills facet: include `nodejs` + exclude `php`/`.net` yields `?skills=nodejs&skills_exclude=php&skills_exclude=.net`; three-state region pills cycle correctly. Remove the throwaway `filter-prototype.html`.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -39,7 +39,8 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.0",
-        "vite": "^6.0.0"
+        "vite": "^6.0.0",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@apm-js-collab/code-transformer": {
@@ -3015,10 +3016,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {
@@ -3294,6 +3313,129 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3361,6 +3503,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -3484,6 +3636,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -4029,6 +4191,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4898,6 +5070,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5061,6 +5247,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5442,6 +5635,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -5487,6 +5687,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",
@@ -5714,6 +5928,23 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5728,6 +5959,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/totalist": {
@@ -5989,6 +6230,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -6018,6 +6349,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "test": "vitest run",
     "og:smoke": "node scripts/og-smoke.mjs",
     "gen:api-docs": "node scripts/gen-api-docs.mjs",
     "gen:api-docs:smoke": "node scripts/gen-api-docs-smoke.mjs",
@@ -38,7 +39,8 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.9"
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",

--- a/web/src/lib/companyFilters.ts
+++ b/web/src/lib/companyFilters.ts
@@ -82,8 +82,10 @@ export class CompanyFilterStore implements FacetStore {
     return activeCompanyFilterCount(this.#url.value);
   }
 
+  // Company facets are include-only (no `_exclude` on the companies endpoint), so the
+  // selection maps its value set to `include` and leaves `exclude` empty.
   facet(param: string): FacetSelection {
-    return { values: this.#url.value.facets[param] ?? [], exclude: false, matchAll: false };
+    return { include: this.#url.value.facets[param] ?? [], exclude: [], matchAll: false };
   }
 
   // Free text debounces the reload (setSoon); the URL still updates synchronously.
@@ -91,22 +93,31 @@ export class CompanyFilterStore implements FacetStore {
     this.#url.setSoon({ ...this.#url.value, q });
   }
 
-  /** Add the value to a facet if absent, remove it if present (pills/select). */
-  toggle(param: string, v: string) {
-    const values = this.facet(param).values;
-    const next = values.includes(v) ? values.filter((x) => x !== v) : [...values, v];
-    this.#setFacet(param, next);
+  // Add the value if absent, remove it if present. Company facets never exclude, so
+  // `cycle` (excludable facets' off → include → exclude) collapses to this plain
+  // include toggle, same as `pick`.
+  #toggleInclude(param: string, v: string) {
+    const values = this.facet(param).include;
+    this.#setFacet(param, values.includes(v) ? values.filter((x) => x !== v) : [...values, v]);
+  }
+
+  cycle(param: string, v: string) {
+    this.#toggleInclude(param, v);
+  }
+
+  pick(param: string, v: string) {
+    this.#toggleInclude(param, v);
   }
 
   add(param: string, raw: string) {
     const v = raw.trim();
-    const values = this.facet(param).values;
+    const values = this.facet(param).include;
     if (!v || values.includes(v)) return;
     this.#setFacet(param, [...values, v]);
   }
 
   remove(param: string, v: string) {
-    this.#setFacet(param, this.facet(param).values.filter((x) => x !== v));
+    this.#setFacet(param, this.facet(param).include.filter((x) => x !== v));
   }
 
   clearFacet(param: string) {
@@ -115,7 +126,7 @@ export class CompanyFilterStore implements FacetStore {
 
   // The companies endpoint has no exclude/AND-OR modes and no company facet opts
   // into them, so these are inert — present only to satisfy the FacetStore contract.
-  setExclude() {}
+  toggleSign() {}
   setMatchAll() {}
 
   clear() {

--- a/web/src/lib/components/AnalyticsView.svelte
+++ b/web/src/lib/components/AnalyticsView.svelte
@@ -76,11 +76,12 @@
 
   // The salary range is only meaningful within a single currency — the stats
   // aggregate across every currency in the matched set, so a cross-currency
-  // min–max would mix e.g. USD and CLP. Show it only when exactly one currency
-  // is selected (include mode), and label it with that currency.
+  // min–max would mix e.g. USD and CLP. Exactly one *included* currency pins the
+  // matched set to it (the include filter ORs to just that currency), so show the
+  // range then, labelled with that currency, regardless of any excluded currencies.
   const salaryCurrency = $derived.by(() => {
     const st = filters.facet('salary_currency');
-    return !st.exclude && st.values.length === 1 ? st.values[0] : null;
+    return st.include.length === 1 ? st.include[0] : null;
   });
   const salary = $derived.by(() => {
     if (!salaryCurrency) return null;

--- a/web/src/lib/components/CompanyFiltersPanel.svelte
+++ b/web/src/lib/components/CompanyFiltersPanel.svelte
@@ -9,7 +9,7 @@
   // their denormalized facet arrays.
   let { store }: { store: CompanyFilterStore } = $props();
 
-  const isActive = (param: string) => store.facet(param).values.length > 0;
+  const isActive = (param: string) => store.facet(param).include.length > 0;
 
   // Facets with a current selection float to the top; the rest keep registry order.
   // Keyed by param so Svelte moves the node rather than re-creating it (an open

--- a/web/src/lib/components/FacetBreakdown.svelte
+++ b/web/src/lib/components/FacetBreakdown.svelte
@@ -25,7 +25,7 @@
   const hidden = $derived(entries.length - shown.length);
   const max = $derived(shown[0]?.[1] ?? 0);
 
-  const selected = $derived(new Set(store.facet(def.param).values));
+  const selected = $derived(new Set(store.facet(def.param).include));
 </script>
 
 <section class="rounded-xl border border-border bg-card p-4">
@@ -38,7 +38,7 @@
         <li>
           <button
             type="button"
-            onclick={() => store.toggle(def.param, value)}
+            onclick={() => store.pick(def.param, value)}
             aria-pressed={selected.has(value)}
             class={[
               'group relative flex w-full items-center justify-between gap-2 overflow-hidden rounded-md px-2 py-1 text-left text-sm transition-colors',

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -237,7 +237,7 @@
     </div>
     <RemoteSearchSelect
       search={searchSkills}
-      selected={skills}
+      include={skills}
       placeholder="Search skills"
       onToggle={toggleSkill}
       fallbackLabel={(v) => v}
@@ -269,7 +269,7 @@
     {/if}
     <SearchSelect
       options={CATEGORY_OPTIONS}
-      selected={specializations}
+      include={specializations}
       placeholder="Search specializations"
       onToggle={toggleSpecialization}
       clearOnSelect

--- a/web/src/lib/components/facets/FacetSection.svelte
+++ b/web/src/lib/components/facets/FacetSection.svelte
@@ -2,19 +2,23 @@
   import { X } from '@lucide/svelte';
   import { dynamicLabel, type FacetDef, type FacetOption, type FacetStore } from '$lib/facets';
   import type { FacetCounts } from '$lib/types';
-  import { cn } from '$lib/utils';
   import PillGroup from './PillGroup.svelte';
   import RemoteSearchSelect from './RemoteSearchSelect.svelte';
   import SearchSelect from './SearchSelect.svelte';
   import TokenInput from './TokenInput.svelte';
 
-  // One facet section: header (label, optional Any/All match toggle, optional
-  // exclude toggle) plus the control the facet declares. All state lives in the
-  // store, keyed by the facet's param. `counts` carries the live facet
-  // distribution that drives dynamic (open-vocabulary) selects.
+  // One facet section: header (label, optional Any/All match toggle, Clear) plus the
+  // control the facet declares. Each value is off / included / excluded; clicking a
+  // control cycles an excludable facet (off → include → exclude → off) or plainly
+  // toggles a non-excludable one (off ↔ include). All state lives in the store, keyed
+  // by the facet's param. `counts` carries the live facet distribution that drives
+  // dynamic (open-vocabulary) selects.
   let { def, store, counts, expand = false }: { def: FacetDef; store: FacetStore; counts?: FacetCounts | null; expand?: boolean } = $props();
 
   const st = $derived(store.facet(def.param));
+  const total = $derived(st.include.length + st.exclude.length);
+  // Excludable facets cycle through the exclude state; the rest only toggle include.
+  const onToggle = (v: string) => (def.excludable ? store.cycle(def.param, v) : store.pick(def.param, v));
 
   // Options for a select facet: static for closed vocabularies, or built from the
   // live distribution (value → count, busiest first) for dynamic ones. Selected
@@ -23,15 +27,15 @@
   const selectOptions = $derived.by((): FacetOption[] => {
     if (!def.dynamic) return def.options ?? [];
     const dist = counts?.facets?.[def.param] ?? {};
-    const keys = new Set<string>([...Object.keys(dist), ...st.values]);
+    const keys = new Set<string>([...Object.keys(dist), ...st.include, ...st.exclude]);
     return [...keys]
       .map((value) => ({ value, label: dynamicLabel(def.param, value), count: dist[value] ?? 0 }))
       .toSorted((a, b) => b.count - a.count || a.label.localeCompare(b.label));
   });
-  // The exclude/clear actions only appear once something is selected — so their
-  // meaning is clear ("you picked these — hide them, or clear them") rather than
-  // abstract controls on an empty section.
-  const showMatch = $derived(def.hasAndOr && !st.exclude && st.values.length > 1);
+  // The match/clear actions only appear once something is selected — so their
+  // meaning is clear ("you picked these — match all, or clear them") rather than
+  // abstract controls on an empty section. Match-all applies to the include set.
+  const showMatch = $derived(def.hasAndOr && st.include.length > 1);
 </script>
 
 <div class="border-b border-border pb-4">
@@ -42,70 +46,57 @@
         <button
           type="button"
           onclick={() => store.setMatchAll(def.param, !st.matchAll)}
-          title="Match any of / all of the selected values"
+          title="Match any of / all of the included values"
           class="rounded-full border border-border px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
         >
           Match: {st.matchAll ? 'All' : 'Any'}
         </button>
       {/if}
     </div>
-    {#if st.values.length > 0}
-      <div class="flex items-center gap-1">
-        {#if def.excludable}
-          <button
-            type="button"
-            onclick={() => store.setExclude(def.param, !st.exclude)}
-            title="Hide jobs that match the selected options"
-            class={cn(
-              'rounded-full px-2 py-0.5 text-xs font-medium transition-colors',
-              st.exclude ? 'bg-destructive/15 text-destructive' : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            {st.exclude ? 'Excluding' : 'Exclude'}
-          </button>
-        {/if}
-        <button
-          type="button"
-          onclick={() => store.clearFacet(def.param)}
-          title="Clear {def.label}"
-          aria-label="Clear {def.label}"
-          class="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-        >
-          <X class="size-3.5" />
-        </button>
-      </div>
+    {#if total > 0}
+      <button
+        type="button"
+        onclick={() => store.clearFacet(def.param)}
+        title="Clear {def.label}"
+        aria-label="Clear {def.label}"
+        class="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <X class="size-3.5" />
+      </button>
     {/if}
   </div>
 
   {#if def.control === 'pills'}
     <PillGroup
       options={def.options ?? []}
-      selected={st.values}
+      include={st.include}
       exclude={st.exclude}
-      onToggle={(v) => store.toggle(def.param, v)}
+      excludable={def.excludable}
+      {onToggle}
     />
   {:else if def.control === 'select'}
     <SearchSelect
       options={selectOptions}
-      selected={st.values}
+      include={st.include}
       exclude={st.exclude}
+      excludable={def.excludable}
       placeholder={def.placeholder}
-      onToggle={(v) => store.toggle(def.param, v)}
+      {onToggle}
       {expand}
     />
   {:else if def.control === 'remote' && def.remote}
     <RemoteSearchSelect
       search={def.remote}
-      selected={st.values}
+      include={st.include}
       exclude={st.exclude}
       placeholder={def.placeholder}
-      onToggle={(v) => store.toggle(def.param, v)}
+      {onToggle}
       fallbackLabel={(v) => dynamicLabel(def.param, v)}
       {expand}
     />
   {:else}
     <TokenInput
-      tokens={st.values}
+      tokens={st.include}
       onAdd={(v) => store.add(def.param, v)}
       onRemove={(v) => store.remove(def.param, v)}
       placeholder={def.placeholder}

--- a/web/src/lib/components/facets/PillGroup.svelte
+++ b/web/src/lib/components/facets/PillGroup.svelte
@@ -1,41 +1,49 @@
 <script lang="ts">
   import { uniqueByValue, type FacetOption } from '$lib/facets';
-  import { pillClass } from './pill';
+  import { pillClass, pillTitle } from './pill';
 
-  // A wrap of toggle pills for one facet. Selected pills fill with the primary
-  // color; in exclude mode they take the muted destructive treatment to signal
-  // "filter these out". Stateless — selection and toggle come from the store.
+  // A wrap of three-state pills for one facet. Each pill is off (idle), included
+  // (primary fill), or excluded (muted destructive, struck through). Clicking calls
+  // `onToggle`, which the parent wires to cycle (excludable facets: off → include →
+  // exclude → off) or to a plain include toggle (non-excludable). Stateless —
+  // selection and the transition come from the store.
   let {
     options,
-    selected,
-    exclude = false,
+    include,
+    exclude = [],
+    excludable = true,
     onToggle,
   }: {
     options: FacetOption[];
-    selected: string[];
-    exclude?: boolean;
+    include: string[];
+    exclude?: string[];
+    excludable?: boolean;
     onToggle: (value: string) => void;
   } = $props();
 
   // A selected value with no matching option — e.g. a vocabulary value removed
-  // since an old bookmark or saved search was created — still renders as an
-  // active pill so it stays removable instead of becoming an invisible, stuck
-  // filter that silently constrains results.
+  // since an old bookmark or saved search was created — still renders as a pill so
+  // it stays removable instead of becoming an invisible, stuck filter that silently
+  // constrains results.
   const shown = $derived(
     uniqueByValue([
       ...options,
-      ...selected.filter((v) => !options.some((o) => o.value === v)).map((v) => ({ value: v, label: v })),
+      ...[...include, ...exclude]
+        .filter((v) => !options.some((o) => o.value === v))
+        .map((v) => ({ value: v, label: v })),
     ]),
   );
 </script>
 
 <div class="flex flex-wrap gap-2">
   {#each shown as opt (opt.value)}
-    {@const active = selected.includes(opt.value)}
+    {@const excluded = exclude.includes(opt.value)}
+    {@const included = include.includes(opt.value)}
     <button
       type="button"
       onclick={() => onToggle(opt.value)}
-      class={pillClass(active, exclude, 'px-3 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50')}
+      title={pillTitle(included, excluded, excludable)}
+      class={pillClass(included || excluded, excluded, 'px-3 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50')}
     >
       {opt.label}
     </button>

--- a/web/src/lib/components/facets/RemoteSearchSelect.svelte
+++ b/web/src/lib/components/facets/RemoteSearchSelect.svelte
@@ -8,13 +8,15 @@
   // A server-backed multi-select: as the user types we query `search` (debounced)
   // and list the matching options with counts; an empty query lists the popular
   // first page. Used for entity facets too large to ship as a distribution
-  // (company). Selected values render as removable chips above the search — they
-  // stay visible even when absent from the current results — labelled from what
-  // we have seen, falling back to `fallbackLabel` for a value restored from the URL.
+  // (company). Selected values render as chips above the search — they stay visible
+  // even when absent from the current results — labelled from what we have seen,
+  // falling back to `fallbackLabel` for a value restored from the URL. A chip is
+  // included or excluded; clicking it calls `onToggle` (cycle for excludable facets,
+  // plain include toggle otherwise).
   let {
     search,
-    selected,
-    exclude = false,
+    include,
+    exclude = [],
     placeholder,
     onToggle,
     fallbackLabel,
@@ -22,8 +24,8 @@
     expand = false,
   }: {
     search: (query: string) => Promise<FacetOption[]>;
-    selected: string[];
-    exclude?: boolean;
+    include: string[];
+    exclude?: string[];
     placeholder?: string;
     onToggle: (value: string) => void;
     fallbackLabel: (value: string) => string;
@@ -75,6 +77,7 @@
     if (clearOnSelect) query = '';
   }
 
+  const selected = $derived([...include, ...exclude]);
   const labelOf = (value: string) => seen.get(value) ?? fallbackLabel(value);
   // Don't list an already-selected option in the picker — it's shown as a chip.
   const pickable = $derived(results.filter((o) => !selected.includes(o.value)));
@@ -84,11 +87,12 @@
   {#if selected.length > 0}
     <div class="flex flex-wrap gap-1.5">
       {#each selected as value (value)}
+        {@const excluded = exclude.includes(value)}
         <button
           type="button"
           onclick={() => onToggle(value)}
           title={labelOf(value)}
-          class={pillClass(true, exclude, 'inline-flex max-w-full items-center px-2.5 py-1 text-sm')}
+          class={pillClass(true, excluded, 'inline-flex max-w-full items-center px-2.5 py-1 text-sm')}
         >
           <span class="min-w-0 truncate">{labelOf(value)}</span>
           <X class="ml-1 size-3 shrink-0" />

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -1,23 +1,28 @@
 <script lang="ts">
   import { uniqueByValue, type FacetOption } from '$lib/facets';
   import { Input } from '$lib/ui';
-  import { pillClass } from './pill';
+  import { pillClass, pillTitle } from './pill';
 
   // A searchable multi-select: a filter field over the options rendered as a
-  // scrollable pill list. Selected options sort to the front. Used for the larger
-  // enum facets (specialization, industry).
+  // scrollable list of three-state pills (off / include / exclude). Selected options
+  // sort to the front. Used for the larger enum facets (specialization, industry,
+  // skills) and, in plain mode (excludable=false), the profile's specialization
+  // picker. Clicking calls `onToggle`, which the parent wires to cycle or to a plain
+  // include toggle.
   let {
     options,
-    selected,
-    exclude = false,
+    include,
+    exclude = [],
+    excludable = false,
     placeholder,
     onToggle,
     clearOnSelect = false,
     expand = false,
   }: {
     options: FacetOption[];
-    selected: string[];
-    exclude?: boolean;
+    include: string[];
+    exclude?: string[];
+    excludable?: boolean;
     placeholder?: string;
     onToggle: (value: string) => void;
     // When set, the filter field is cleared after each toggle — suited to a
@@ -36,10 +41,12 @@
     if (clearOnSelect) filter = '';
   }
 
+  const isSelected = (v: string) => include.includes(v) || exclude.includes(v);
+
   const shown = $derived(
     uniqueByValue(options)
       .filter((o) => o.label.toLowerCase().includes(filter.trim().toLowerCase()))
-      .toSorted((a, b) => Number(selected.includes(b.value)) - Number(selected.includes(a.value))),
+      .toSorted((a, b) => Number(isSelected(b.value)) - Number(isSelected(a.value))),
   );
 </script>
 
@@ -47,11 +54,13 @@
   <Input bind:value={filter} {placeholder} class="w-full" />
   <div class={expand ? 'flex flex-wrap gap-1.5' : 'flex max-h-44 flex-wrap gap-1.5 overflow-y-auto'}>
     {#each shown as opt (opt.value)}
-      {@const active = selected.includes(opt.value)}
+      {@const excluded = exclude.includes(opt.value)}
+      {@const included = include.includes(opt.value)}
       <button
         type="button"
         onclick={() => toggle(opt.value)}
-        class={pillClass(active, exclude, 'px-2.5 py-1 text-sm')}
+        title={pillTitle(included, excluded, excludable)}
+        class={pillClass(included || excluded, excluded, 'px-2.5 py-1 text-sm')}
       >
         {opt.label}{#if opt.count !== undefined}<span class="ml-1 opacity-60 tabular-nums">{opt.count.toLocaleString()}</span>{/if}
       </button>

--- a/web/src/lib/components/facets/pill.ts
+++ b/web/src/lib/components/facets/pill.ts
@@ -12,3 +12,12 @@ export function pillClass(active: boolean, exclude: boolean, extra = ''): string
     extra,
   );
 }
+
+// Tooltip hint for a three-state facet pill, naming the state its next click
+// produces. Excludable facets cycle off → include → exclude → off; non-excludable
+// ones just toggle off ↔ include, so they never advertise an exclude step.
+export function pillTitle(included: boolean, excluded: boolean, excludable: boolean): string | undefined {
+  if (excluded) return 'Click to remove';
+  if (included) return excludable ? 'Click to exclude' : 'Click to remove';
+  return excludable ? 'Click to include' : undefined;
+}

--- a/web/src/lib/components/filters/CategoryPane.svelte
+++ b/web/src/lib/components/filters/CategoryPane.svelte
@@ -4,17 +4,20 @@
   import type { FacetStore } from '$lib/facets';
   import { CATEGORY_GROUPS } from '$lib/filterSections';
   import FacetHeader from './FacetHeader.svelte';
-  import { pillClass } from '../facets/pill';
+  import { pillClass, pillTitle } from '../facets/pill';
 
   // Specialization pane: category chips grouped into collapsible sections, with a
-  // facet-local search filtering the visible options. Toggles the `category` facet.
-  // `plain` hides the search-only Exclude toggle (a profile category is a plain choice).
+  // facet-local search filtering the visible options. In the job filter it toggles
+  // the excludable `category` facet (each chip cycles off → include → exclude → off);
+  // `plain` makes it an include-only choice (e.g. a profile category is not a filter
+  // to exclude).
   let { store, plain = false }: { store: FacetStore; plain?: boolean } = $props();
 
+  const excludable = $derived(!plain);
   let query = $state('');
   const collapsed = new SvelteSet<string>();
   const st = $derived(store.facet('category'));
-  const selected = $derived(st.values);
+  const onToggle = (v: string) => (excludable ? store.cycle('category', v) : store.pick('category', v));
 
   const groups = $derived.by(() => {
     const q = query.trim().toLowerCase();
@@ -25,7 +28,7 @@
   });
 </script>
 
-<FacetHeader {store} param="category" label="Specialization" noExclude={plain} />
+<FacetHeader {store} param="category" label="Specialization" />
 
 <div class="mb-4 flex items-center gap-2 rounded-lg border border-input px-3">
   <Search class="size-4 shrink-0 text-muted-foreground" />
@@ -50,10 +53,13 @@
     {#if !isCollapsed}
       <div class="flex flex-wrap gap-2 pb-3">
         {#each g.options as o (o.value)}
+          {@const excluded = st.exclude.includes(o.value)}
+          {@const included = st.include.includes(o.value)}
           <button
             type="button"
-            onclick={() => store.toggle('category', o.value)}
-            class={pillClass(selected.includes(o.value), st.exclude, 'px-3 py-1.5 text-sm')}
+            onclick={() => onToggle(o.value)}
+            title={pillTitle(included, excluded, excludable)}
+            class={pillClass(included || excluded, excluded, 'px-3 py-1.5 text-sm')}
           >
             {o.label}
           </button>

--- a/web/src/lib/components/filters/ChipFacet.svelte
+++ b/web/src/lib/components/filters/ChipFacet.svelte
@@ -3,16 +3,20 @@
   import FacetHeader from './FacetHeader.svelte';
   import PillGroup from '../facets/PillGroup.svelte';
 
-  // One chip facet inside a modal pane: a FacetHeader (label + Exclude + Clear) over a
-  // PillGroup — the same per-facet controls the sidebar offers. Options come from the
-  // registry (by `param`), so a caller only names the facet.
+  // One chip facet inside a modal pane: a FacetHeader (label + Clear) over a
+  // PillGroup — the same per-facet controls the sidebar offers. Options and the
+  // excludable flag come from the registry (by `param`), so a caller only names the
+  // facet. Excludable facets cycle each pill off → include → exclude → off.
   let { store, param, label }: { store: FacetStore; param: string; label: string } = $props();
 
-  const options = FACETS.find((d) => d.param === param)?.options ?? [];
+  const def = FACETS.find((d) => d.param === param);
+  const options = def?.options ?? [];
+  const excludable = def?.excludable ?? false;
   const st = $derived(store.facet(param));
+  const onToggle = (v: string) => (excludable ? store.cycle(param, v) : store.pick(param, v));
 </script>
 
 <div>
   <FacetHeader {store} {param} {label} />
-  <PillGroup {options} selected={st.values} exclude={st.exclude} onToggle={(v) => store.toggle(param, v)} />
+  <PillGroup {options} include={st.include} exclude={st.exclude} {excludable} {onToggle} />
 </div>

--- a/web/src/lib/components/filters/FacetHeader.svelte
+++ b/web/src/lib/components/filters/FacetHeader.svelte
@@ -1,45 +1,28 @@
 <script lang="ts">
   import { X } from '@lucide/svelte';
-  import { FACETS, type FacetStore } from '$lib/facets';
-  import { cn } from '$lib/utils';
+  import type { FacetStore } from '$lib/facets';
 
-  // A single-param facet header: the label plus the Exclude toggle (when the facet is
-  // excludable and has a selection) and a Clear button. Shared by the chip facets and
-  // the Specialization pane so the per-facet controls read identically everywhere.
-  // `noExclude` forces the Exclude toggle off for a plain-select reuse (e.g. the profile
-  // editor, where a value is a plain choice, not a filter to exclude).
-  let { store, param, label, noExclude = false }: { store: FacetStore; param: string; label: string; noExclude?: boolean } = $props();
+  // A single-param facet header: the label plus a Clear button (shown once the facet
+  // has a selection). Shared by the chip facets and the Specialization pane so the
+  // per-facet header reads identically everywhere. Include/exclude is chosen per
+  // value on the pills themselves, so there is no facet-wide exclude toggle here.
+  let { store, param, label }: { store: FacetStore; param: string; label: string } = $props();
 
-  const excludable = $derived(!noExclude && (FACETS.find((d) => d.param === param)?.excludable ?? false));
   const st = $derived(store.facet(param));
+  const total = $derived(st.include.length + st.exclude.length);
 </script>
 
 <div class="mb-2 flex min-h-6 items-center justify-between gap-2">
   <h3 class="text-sm font-semibold tracking-tight">{label}</h3>
-  {#if st.values.length > 0}
-    <div class="flex items-center gap-1">
-      {#if excludable}
-        <button
-          type="button"
-          onclick={() => store.setExclude(param, !st.exclude)}
-          title="Hide jobs that match the selected options"
-          class={cn(
-            'rounded-full px-2 py-0.5 text-xs font-medium transition-colors',
-            st.exclude ? 'bg-destructive/15 text-destructive' : 'text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {st.exclude ? 'Excluding' : 'Exclude'}
-        </button>
-      {/if}
-      <button
-        type="button"
-        onclick={() => store.clearFacet(param)}
-        title="Clear {label}"
-        aria-label="Clear {label}"
-        class="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-      >
-        <X class="size-3.5" />
-      </button>
-    </div>
+  {#if total > 0}
+    <button
+      type="button"
+      onclick={() => store.clearFacet(param)}
+      title="Clear {label}"
+      aria-label="Clear {label}"
+      class="flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+    >
+      <X class="size-3.5" />
+    </button>
   {/if}
 </div>

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -81,18 +81,23 @@
 
   const activeEntry = $derived(visibleRail.find((e) => e.key === active) ?? visibleRail[0]);
 
+  // Values selected for one facet — included plus excluded — so the rail count
+  // reflects any staged selection regardless of sign.
+  function selCount(f: JobFilters, param: string): number {
+    const st = f.facets[param];
+    return st ? st.include.length + st.exclude.length : 0;
+  }
+
   function entryCount(e: RailEntry, f: JobFilters): number {
-    if (e.kind === 'category') return (f.facets.category?.values.length ?? 0) + (f.facets.seniority?.values.length ?? 0);
-    if (e.kind === 'location')
-      return (f.facets.regions?.values.length ?? 0) + (f.facets.countries?.values.length ?? 0) + (f.facets.cities?.values.length ?? 0);
-    if (e.kind === 'salary') return (f.facets.salary_currency?.values.length ?? 0) + (f.salaryMin != null ? 1 : 0);
-    if (e.kind === 'work') return (f.facets.work_mode?.values.length ?? 0) + (f.facets.employment_type?.values.length ?? 0);
-    if (e.kind === 'industry')
-      return (f.facets.domains?.values.length ?? 0) + (f.facets.company_type?.values.length ?? 0) + (f.facets.collections?.values.length ?? 0);
-    if (e.kind === 'language') return (f.facets.english_level?.values.length ?? 0) + (f.facets.posting_language?.values.length ?? 0);
-    if (e.kind === 'relocation') return (f.facets.relocation?.values.length ?? 0) + (f.visa ? 1 : 0);
+    if (e.kind === 'category') return selCount(f, 'category') + selCount(f, 'seniority');
+    if (e.kind === 'location') return selCount(f, 'regions') + selCount(f, 'countries') + selCount(f, 'cities');
+    if (e.kind === 'salary') return selCount(f, 'salary_currency') + (f.salaryMin != null ? 1 : 0);
+    if (e.kind === 'work') return selCount(f, 'work_mode') + selCount(f, 'employment_type');
+    if (e.kind === 'industry') return selCount(f, 'domains') + selCount(f, 'company_type') + selCount(f, 'collections');
+    if (e.kind === 'language') return selCount(f, 'english_level') + selCount(f, 'posting_language');
+    if (e.kind === 'relocation') return selCount(f, 'relocation') + (f.visa ? 1 : 0);
     if (e.kind === 'posted') return f.postedWithinDays != null ? 1 : 0;
-    return f.facets[e.facetParam ?? e.key]?.values.length ?? 0;
+    return selCount(f, e.facetParam ?? e.key);
   }
 
   // Panes that reuse FacetSection (dynamic controls); ChipFacet resolves its own

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -32,22 +32,23 @@
     const push = (label: string, chips: Chip[]) => {
       if (chips.length) out.push({ label, chips });
     };
+    // Chips for one facet: included values first, then excluded (destructive style).
+    const facetChips = (param: string): Chip[] => {
+      const st = f.facets[param];
+      if (!st) return [];
+      return [
+        ...st.include.map((v) => ({ text: valueLabel(param, v), exclude: false, remove: () => store.remove(param, v) })),
+        ...st.exclude.map((v) => ({ text: valueLabel(param, v), exclude: true, remove: () => store.remove(param, v) })),
+      ];
+    };
     const facetGroup = (param: string, label: string) => {
       if (exclude.includes(param)) return;
-      const st = f.facets[param];
-      if (!st?.values.length) return;
-      push(label, st.values.map((v) => ({ text: valueLabel(param, v), exclude: st.exclude, remove: () => store.remove(param, v) })));
+      push(label, facetChips(param));
     };
 
     facetGroup('category', 'Specialization');
     // Location: regions + countries + cities under one heading.
-    const loc: Chip[] = [];
-    for (const param of ['regions', 'countries', 'cities'] as const) {
-      const geo = f.facets[param];
-      if (!geo) continue;
-      for (const v of geo.values) loc.push({ text: valueLabel(param, v), exclude: geo.exclude, remove: () => store.remove(param, v) });
-    }
-    push('Location', loc);
+    push('Location', [...facetChips('regions'), ...facetChips('countries'), ...facetChips('cities')]);
 
     facetGroup('seniority', 'Seniority');
     facetGroup('work_mode', 'Work format');
@@ -62,8 +63,7 @@
     facetGroup('relocation', 'Relocation');
 
     // Salary: currency + minimum.
-    const salary: Chip[] = [];
-    for (const v of f.facets.salary_currency?.values ?? []) salary.push({ text: v, exclude: f.facets.salary_currency!.exclude, remove: () => store.remove('salary_currency', v) });
+    const salary: Chip[] = facetChips('salary_currency');
     if (f.salaryMin != null) salary.push({ text: `${f.salaryMin.toLocaleString('en-US')}+`, exclude: false, remove: () => store.setSalaryMin(null) });
     push('Salary', salary);
 

--- a/web/src/lib/components/filters/LocationPane.svelte
+++ b/web/src/lib/components/filters/LocationPane.svelte
@@ -5,7 +5,7 @@
   import { REGION_LABELS } from '$lib/labels';
   import { COUNTRY_REGION_MAP } from '$lib/generated/contracts';
   import type { FacetCounts } from '$lib/types';
-  import { pillClass } from '../facets/pill';
+  import { pillClass, pillTitle } from '../facets/pill';
 
   // Location pane: a region → country tree plus a flat, searchable Cities list.
   // The country tree is built from the exported country→region map, scoped to what
@@ -22,9 +22,15 @@
   const countryCounts = $derived(counts?.facets?.countries ?? {});
   const cityCounts = $derived(counts?.facets?.cities ?? {});
 
-  const regionSel = $derived(store.facet('regions').values);
-  const countrySel = $derived(store.facet('countries').values);
-  const citySel = $derived(store.facet('cities').values);
+  // regions/countries/cities are excludable: each pill cycles off → include →
+  // exclude → off. The `*Sel` unions drive the "kept visible / has selection" logic;
+  // the per-facet include/exclude sets drive each pill's state and style.
+  const regionF = $derived(store.facet('regions'));
+  const countryF = $derived(store.facet('countries'));
+  const cityF = $derived(store.facet('cities'));
+  const regionSel = $derived([...regionF.include, ...regionF.exclude]);
+  const countrySel = $derived([...countryF.include, ...countryF.exclude]);
+  const citySel = $derived([...cityF.include, ...cityF.exclude]);
 
   // region code → countries to show, busiest first. Built from the live distribution
   // plus any currently-selected country, so a selected country stays visible (and
@@ -110,19 +116,25 @@
     </button>
 
     {#if isOpen}
+      {@const rExc = regionF.exclude.includes(region)}
+      {@const rInc = regionF.include.includes(region)}
       <div class="flex flex-wrap gap-2 pb-3">
         <button
           type="button"
-          onclick={() => store.toggle('regions', region)}
-          class={pillClass(regionSel.includes(region), false, 'px-3 py-1.5 text-sm')}
+          onclick={() => store.cycle('regions', region)}
+          title={pillTitle(rInc, rExc, true)}
+          class={pillClass(rInc || rExc, rExc, 'px-3 py-1.5 text-sm')}
         >
           All {REGION_LABELS[region] ?? region}
         </button>
         {#each countryCodes as code (code)}
+          {@const cExc = countryF.exclude.includes(code)}
+          {@const cInc = countryF.include.includes(code)}
           <button
             type="button"
-            onclick={() => store.toggle('countries', code)}
-            class={pillClass(countrySel.includes(code), false, 'px-3 py-1.5 text-sm')}
+            onclick={() => store.cycle('countries', code)}
+            title={pillTitle(cInc, cExc, true)}
+            class={pillClass(cInc || cExc, cExc, 'px-3 py-1.5 text-sm')}
           >
             {countryLabel(code)}
           </button>
@@ -137,7 +149,14 @@
     <div class="mb-2 text-sm font-semibold tracking-tight">Cities</div>
     <div class="flex flex-wrap gap-2">
       {#each citiesShown as city (city)}
-        <button type="button" onclick={() => store.toggle('cities', city)} class={pillClass(citySel.includes(city), false, 'px-3 py-1.5 text-sm')}>
+        {@const ctExc = cityF.exclude.includes(city)}
+        {@const ctInc = cityF.include.includes(city)}
+        <button
+          type="button"
+          onclick={() => store.cycle('cities', city)}
+          title={pillTitle(ctInc, ctExc, true)}
+          class={pillClass(ctInc || ctExc, ctExc, 'px-3 py-1.5 text-sm')}
+        >
           {city}
         </button>
       {/each}

--- a/web/src/lib/facetModel.test.ts
+++ b/web/src/lib/facetModel.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptyFacet,
+  emptyFilters,
+  filtersToParams,
+  filtersFromParams,
+  activeFilterCount,
+  canonicalQuery,
+  signOf,
+  facetSetSign,
+  facetCycle,
+  facetPick,
+  facetToggleSign,
+  facetAdd,
+  facetRemove,
+  type FacetState,
+  type JobFilters,
+} from './facetModel';
+
+// A JobFilters seeded with one facet's state, for serialization tests.
+function withSkills(st: Partial<FacetState>): JobFilters {
+  const f = emptyFilters();
+  f.facets.skills = { include: [], exclude: [], matchAll: false, ...st };
+  return f;
+}
+
+// The skills facet is always present (emptyFacets seeds every FACET), so this read
+// is safe; the helper drops the index-signature `| undefined` for terser asserts.
+const sk = (f: JobFilters): FacetState => f.facets.skills!;
+
+describe('emptyFacet', () => {
+  it('is two empty sets and OR mode', () => {
+    expect(emptyFacet()).toEqual({ include: [], exclude: [], matchAll: false });
+  });
+});
+
+describe('filtersToParams', () => {
+  it('serializes include to the bare param and exclude to <param>_exclude', () => {
+    const p = filtersToParams(withSkills({ include: ['nodejs', 'react'], exclude: ['php'] }));
+    expect(p.getAll('skills')).toEqual(['nodejs', 'react']);
+    expect(p.getAll('skills_exclude')).toEqual(['php']);
+  });
+
+  it('emits <param>_mode=and only when matchAll and more than one included value', () => {
+    expect(filtersToParams(withSkills({ include: ['go', 'rust'], matchAll: true })).get('skills_mode')).toBe('and');
+    expect(filtersToParams(withSkills({ include: ['go'], matchAll: true })).get('skills_mode')).toBeNull();
+    expect(filtersToParams(withSkills({ include: ['go', 'rust'], matchAll: false })).get('skills_mode')).toBeNull();
+  });
+
+  it('omits a facet with no values', () => {
+    expect(filtersToParams(emptyFilters()).toString()).toBe('');
+  });
+});
+
+describe('filtersFromParams', () => {
+  it('reads the bare param into include and <param>_exclude into exclude', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=nodejs&skills_exclude=php&skills_exclude=.net'));
+    expect(sk(f).include).toEqual(['nodejs']);
+    expect(sk(f).exclude).toEqual(['php', '.net']);
+  });
+
+  it('reads <param>_mode=and into matchAll', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=go&skills=rust&skills_mode=and'));
+    expect(sk(f).matchAll).toBe(true);
+  });
+
+  it('drops a value from include when it also appears in exclude (exclude wins)', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=php&skills_exclude=php'));
+    expect(sk(f).include).toEqual([]);
+    expect(sk(f).exclude).toEqual(['php']);
+  });
+
+  it('de-duplicates repeated URL values', () => {
+    const f = filtersFromParams(new URLSearchParams('skills=go&skills=go'));
+    expect(sk(f).include).toEqual(['go']);
+  });
+});
+
+describe('canonicalQuery', () => {
+  it('is idempotent for a mixed include/exclude query', () => {
+    const q = 'skills=nodejs&skills_exclude=php';
+    const once = canonicalQuery(q);
+    expect(canonicalQuery(once)).toBe(once);
+    expect(new URLSearchParams(once).getAll('skills')).toEqual(['nodejs']);
+    expect(new URLSearchParams(once).getAll('skills_exclude')).toEqual(['php']);
+  });
+});
+
+describe('activeFilterCount', () => {
+  it('counts included and excluded values plus scalar filters', () => {
+    const f = withSkills({ include: ['a', 'b'], exclude: ['c'] });
+    f.visa = true;
+    f.salaryMin = 100000;
+    expect(activeFilterCount(f)).toBe(5); // 2 include + 1 exclude + visa + salary
+  });
+});
+
+describe('sign transitions (pure)', () => {
+  const inc = (): FacetState => ({ include: ['go'], exclude: [], matchAll: false });
+
+  it('signOf reports the value state', () => {
+    expect(signOf(emptyFacet(), 'go')).toBe('off');
+    expect(signOf({ include: ['go'], exclude: [], matchAll: false }, 'go')).toBe('include');
+    expect(signOf({ include: [], exclude: ['go'], matchAll: false }, 'go')).toBe('exclude');
+  });
+
+  it('facetSetSign moves a value between sets and does not mutate the input', () => {
+    const st = inc();
+    const next = facetSetSign(st, 'go', 'exclude');
+    expect(next).toEqual({ include: [], exclude: ['go'], matchAll: false });
+    expect(st).toEqual({ include: ['go'], exclude: [], matchAll: false }); // unchanged
+    expect(facetSetSign(next, 'go', 'off')).toEqual({ include: [], exclude: [], matchAll: false });
+  });
+
+  it('facetCycle goes off -> include -> exclude -> off', () => {
+    let st = emptyFacet();
+    st = facetCycle(st, 'go');
+    expect(signOf(st, 'go')).toBe('include');
+    st = facetCycle(st, 'go');
+    expect(signOf(st, 'go')).toBe('exclude');
+    st = facetCycle(st, 'go');
+    expect(signOf(st, 'go')).toBe('off');
+  });
+
+  it('facetPick adds to include, and removes when already selected in either set', () => {
+    expect(signOf(facetPick(emptyFacet(), 'go'), 'go')).toBe('include');
+    expect(signOf(facetPick({ include: ['go'], exclude: [], matchAll: false }, 'go'), 'go')).toBe('off');
+    expect(signOf(facetPick({ include: [], exclude: ['go'], matchAll: false }, 'go'), 'go')).toBe('off');
+  });
+
+  it('facetToggleSign flips include and exclude', () => {
+    expect(signOf(facetToggleSign({ include: ['go'], exclude: [], matchAll: false }, 'go'), 'go')).toBe('exclude');
+    expect(signOf(facetToggleSign({ include: [], exclude: ['go'], matchAll: false }, 'go'), 'go')).toBe('include');
+  });
+
+  it('facetAdd adds to include, no-op on blank or existing value', () => {
+    expect(facetAdd(emptyFacet(), '  go ').include).toEqual(['go']);
+    expect(facetAdd(inc(), 'go')).toEqual(inc()); // duplicate
+    expect(facetAdd(emptyFacet(), '   ')).toEqual(emptyFacet()); // blank
+    expect(facetAdd({ include: [], exclude: ['go'], matchAll: false }, 'go').exclude).toEqual(['go']); // already excluded -> no-op
+  });
+
+  it('facetRemove clears the value from both sets', () => {
+    expect(facetRemove({ include: ['go'], exclude: [], matchAll: false }, 'go')).toEqual(emptyFacet());
+    expect(facetRemove({ include: [], exclude: ['go'], matchAll: false }, 'go')).toEqual(emptyFacet());
+  });
+});

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -1,0 +1,178 @@
+// The pure job-filter model: the facet/filter types, their URL <-> state
+// (de)serialization, and the per-value sign transitions. No SvelteKit or Svelte
+// runes here, so this module is unit-testable in plain Node and importable from
+// both the reactive store (filters.ts) and the staged-edit surface. Param names
+// match what the search API (GET /api/v1/jobs/search) expects, including the
+// `<param>_exclude` and `<param>_mode=and` conventions.
+
+import { FACETS } from './facets';
+
+/** The three states a facet value can hold. */
+export type Sign = 'off' | 'include' | 'exclude';
+
+/** One facet's selection: the included values and the excluded values (a value is
+ *  in at most one set), plus whether the *included* values are ANDed (match all)
+ *  instead of ORed (match any). Excluded values are always ANDed — a job matches
+ *  only if it has none of them. Include and exclude coexist in one facet, so a
+ *  user can include some values and exclude others at the same time. */
+export interface FacetState {
+  include: string[];
+  exclude: string[];
+  matchAll: boolean;
+}
+
+/** The fields the browse list can be ordered by. Only `posted_at` (the source's
+ *  posting date, newest-first) is offered today; the type stays a union so a
+ *  future sort (e.g. salary) re-introduces an option without reshaping callers. */
+export type SortField = 'posted_at';
+
+/** Default (and currently only) browse order: freshest by posting date. Kept out
+ *  of the URL (see filtersToParams) so the default reads as a clean, sort-less URL
+ *  and the backend's own empty-query default stays the single source of truth. */
+export const DEFAULT_SORT: SortField = 'posted_at';
+
+export interface JobFilters {
+  q: string;
+  /** Facet state keyed by the facet's query param (see FACETS). */
+  facets: Record<string, FacetState>;
+  visa: boolean;
+  salaryMin: number | null;
+  /** Freshness: keep only jobs posted within the last N days (null = any age).
+   *  Serialized as `posted_within_days`; the backend turns it into a posted_ts
+   *  range filter relative to request time. */
+  postedWithinDays: number | null;
+  sort: SortField;
+}
+
+export function emptyFacet(): FacetState {
+  return { include: [], exclude: [], matchAll: false };
+}
+
+function emptyFacets(): Record<string, FacetState> {
+  const out: Record<string, FacetState> = {};
+  for (const f of FACETS) out[f.param] = emptyFacet();
+  return out;
+}
+
+export function emptyFilters(): JobFilters {
+  return { q: '', facets: emptyFacets(), visa: false, salaryMin: null, postedWithinDays: null, sort: DEFAULT_SORT };
+}
+
+// ---- URL serialization ----
+
+/** Serialize filters to URL query params (the shape the search API reads). */
+export function filtersToParams(f: JobFilters): URLSearchParams {
+  const p = new URLSearchParams();
+  if (f.q) p.set('q', f.q);
+  for (const def of FACETS) {
+    const st = f.facets[def.param];
+    if (!st) continue;
+    for (const v of st.include) p.append(def.param, v);
+    for (const v of st.exclude) p.append(`${def.param}_exclude`, v);
+    // AND-mode is per facet and only meaningful with more than one included value.
+    if (st.matchAll && st.include.length > 1) p.set(`${def.param}_mode`, 'and');
+  }
+  if (f.visa) p.set('visa_sponsorship', 'true');
+  if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
+  if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
+  // Omit the default sort: a clean URL leans on the backend's empty-query default.
+  if (f.sort !== DEFAULT_SORT) p.set('sort', f.sort);
+  return p;
+}
+
+/** Parse filters back from URL query params. Include and exclude are independent
+ *  sets; if a value appears in both (a malformed or legacy link), exclude wins and
+ *  it is dropped from include so a value carries exactly one sign. */
+export function filtersFromParams(p: URLSearchParams): JobFilters {
+  const f = emptyFilters();
+  f.q = p.get('q') ?? '';
+  for (const def of FACETS) {
+    // URL params aren't guaranteed unique (shared/edited links, crawlers), but a
+    // facet's values are a set — the store's transitions enforce that on user
+    // input, so the URL parse must too. A repeated value otherwise reaches a chip
+    // list keyed by value, and Svelte throws `each_key_duplicate` on hydration.
+    const exclude = [...new Set(p.getAll(`${def.param}_exclude`))];
+    const excludeSet = new Set(exclude);
+    const include = [...new Set(p.getAll(def.param))].filter((v) => !excludeSet.has(v));
+    const matchAll = p.get(`${def.param}_mode`) === 'and';
+    f.facets[def.param] = { include, exclude, matchAll };
+  }
+  f.visa = p.get('visa_sponsorship') === 'true';
+  const salary = Number(p.get('salary_min'));
+  f.salaryMin = p.get('salary_min') && !Number.isNaN(salary) ? salary : null;
+  // Freshness is a positive whole number of days; anything else (absent, zero,
+  // negative, non-numeric) reads as "any age", matching the backend's own guard.
+  const days = Number(p.get('posted_within_days'));
+  f.postedWithinDays = Number.isInteger(days) && days > 0 ? days : null;
+  // Sort isn't user-selectable today, so it's never read from the URL — it stays
+  // the default seeded by emptyFilters().
+  return f;
+}
+
+/** Total selected facet values (plus visa/salary/freshness) — drives the mobile badge. */
+export function activeFilterCount(f: JobFilters): number {
+  let n = 0;
+  for (const def of FACETS) {
+    const st = f.facets[def.param];
+    if (st) n += st.include.length + st.exclude.length;
+  }
+  if (f.visa) n += 1;
+  if (f.salaryMin != null) n += 1;
+  if (f.postedWithinDays != null) n += 1;
+  return n;
+}
+
+/** Normalize a search query string to its canonical form (parse → re-serialize),
+ *  so two filter sets that differ only in param order or stale/unknown params
+ *  compare equal. Used to detect which saved search matches the current filters. */
+export function canonicalQuery(query: string): string {
+  return filtersToParams(filtersFromParams(new URLSearchParams(query))).toString();
+}
+
+// ---- per-value sign transitions (pure: FacetState -> FacetState) ----
+
+/** Which set a value currently belongs to. */
+export function signOf(st: FacetState, v: string): Sign {
+  if (st.include.includes(v)) return 'include';
+  if (st.exclude.includes(v)) return 'exclude';
+  return 'off';
+}
+
+/** Force a value into the given state, removing it from the other set first. */
+export function facetSetSign(st: FacetState, v: string, sign: Sign): FacetState {
+  const include = st.include.filter((x) => x !== v);
+  const exclude = st.exclude.filter((x) => x !== v);
+  if (sign === 'include') include.push(v);
+  else if (sign === 'exclude') exclude.push(v);
+  return { ...st, include, exclude };
+}
+
+/** Pills interaction: off → include → exclude → off. */
+export function facetCycle(st: FacetState, v: string): FacetState {
+  const s = signOf(st, v);
+  return facetSetSign(st, v, s === 'off' ? 'include' : s === 'include' ? 'exclude' : 'off');
+}
+
+/** Select-dropdown interaction: pick adds to include; picking a selected value
+ *  (in either set) clears it. */
+export function facetPick(st: FacetState, v: string): FacetState {
+  return facetSetSign(st, v, signOf(st, v) === 'off' ? 'include' : 'off');
+}
+
+/** Per-chip toggle: flip a value between include and exclude. */
+export function facetToggleSign(st: FacetState, v: string): FacetState {
+  return facetSetSign(st, v, signOf(st, v) === 'include' ? 'exclude' : 'include');
+}
+
+/** Token-input add: put a value into include; no-op on blank or a value already
+ *  present in either set. */
+export function facetAdd(st: FacetState, raw: string): FacetState {
+  const v = raw.trim();
+  if (!v || signOf(st, v) !== 'off') return st;
+  return facetSetSign(st, v, 'include');
+}
+
+/** Remove a value from the facet entirely (both sets). */
+export function facetRemove(st: FacetState, v: string): FacetState {
+  return facetSetSign(st, v, 'off');
+}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -33,25 +33,30 @@ export interface FacetOption {
 
 export type FacetControl = 'pills' | 'select' | 'tokens' | 'remote';
 
-/** One facet's live selection, as FacetSection reads it. */
+/** One facet's live selection, as FacetSection reads it: the included and excluded
+ *  values (a value is in at most one set), plus the include-set match mode. */
 export interface FacetSelection {
-  values: string[];
-  exclude: boolean;
+  include: string[];
+  exclude: string[];
   matchAll: boolean;
 }
 
 /** The narrow store contract FacetSection drives — the subset of FilterStore's
  *  surface a facet control touches. Both the job FilterStore and the company
  *  filter store satisfy it, so the same section/control components render either.
- *  (setExclude/setMatchAll are only invoked for excludable/hasAndOr facets, which
- *  the company registry doesn't use.) */
+ *  (cycle/toggleSign move a value between include and exclude; the company registry
+ *  has no excludable facets, so pick/add/remove only ever land values in include.) */
 export interface FacetStore {
   facet(param: string): FacetSelection;
-  toggle(param: string, v: string): void;
+  /** Pills: cycle a value off → include → exclude → off. */
+  cycle(param: string, v: string): void;
+  /** Select dropdown: add a value to include, or clear it if already selected. */
+  pick(param: string, v: string): void;
+  /** Per-chip toggle: flip a value between include and exclude. */
+  toggleSign(param: string, v: string): void;
   add(param: string, raw: string): void;
   remove(param: string, v: string): void;
   clearFacet(param: string): void;
-  setExclude(param: string, exclude: boolean): void;
   setMatchAll(param: string, on: boolean): void;
 }
 

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -1,124 +1,28 @@
-// Job search filters: the model, its URL <-> state (de)serialization, and a
-// reactive store that mirrors the filters into the URL query so they survive
-// reloads, sharing, and back/forward. Param names match what the search API
-// (GET /api/v1/jobs/search) expects, including the `<param>_exclude` and
-// `<param>_mode=and` conventions.
+// The reactive job-filter store, mirrored into the URL. The pure model (types,
+// URL (de)serialization, and per-value sign transitions) lives in ./facetModel and
+// is re-exported here so existing `$lib/filters` imports keep working; this file
+// owns only the SvelteKit-bound FilterStore.
 
-import { FACETS } from './facets';
 import { UrlSyncedState } from './urlSynced.svelte';
+import {
+  type FacetState,
+  type JobFilters,
+  type Sign,
+  type SortField,
+  emptyFacet,
+  emptyFilters,
+  filtersFromParams,
+  filtersToParams,
+  activeFilterCount,
+  facetSetSign,
+  facetCycle,
+  facetPick,
+  facetToggleSign,
+  facetAdd,
+  facetRemove,
+} from './facetModel';
 
-/** One facet's selection: the chosen values, whether it filters by inclusion or
- *  exclusion, and (for facets that allow it) whether selected values are ANDed
- *  (match all) instead of ORed (match any). */
-export interface FacetState {
-  values: string[];
-  exclude: boolean;
-  matchAll: boolean;
-}
-
-/** The fields the browse list can be ordered by. Only `posted_at` (the source's
- *  posting date, newest-first) is offered today; the type stays a union so a
- *  future sort (e.g. salary) re-introduces an option without reshaping callers. */
-export type SortField = 'posted_at';
-
-/** Default (and currently only) browse order: freshest by posting date. Kept out
- *  of the URL (see filtersToParams) so the default reads as a clean, sort-less URL
- *  and the backend's own empty-query default stays the single source of truth. */
-export const DEFAULT_SORT: SortField = 'posted_at';
-
-export interface JobFilters {
-  q: string;
-  /** Facet state keyed by the facet's query param (see FACETS). */
-  facets: Record<string, FacetState>;
-  visa: boolean;
-  salaryMin: number | null;
-  /** Freshness: keep only jobs posted within the last N days (null = any age).
-   *  Serialized as `posted_within_days`; the backend turns it into a posted_ts
-   *  range filter relative to request time. */
-  postedWithinDays: number | null;
-  sort: SortField;
-}
-
-export function emptyFacet(): FacetState {
-  return { values: [], exclude: false, matchAll: false };
-}
-
-function emptyFacets(): Record<string, FacetState> {
-  const out: Record<string, FacetState> = {};
-  for (const f of FACETS) out[f.param] = emptyFacet();
-  return out;
-}
-
-export function emptyFilters(): JobFilters {
-  return { q: '', facets: emptyFacets(), visa: false, salaryMin: null, postedWithinDays: null, sort: DEFAULT_SORT };
-}
-
-/** Serialize filters to URL query params (the shape the search API reads). */
-export function filtersToParams(f: JobFilters): URLSearchParams {
-  const p = new URLSearchParams();
-  if (f.q) p.set('q', f.q);
-  for (const def of FACETS) {
-    const st = f.facets[def.param];
-    if (!st || st.values.length === 0) continue;
-    const key = st.exclude ? `${def.param}_exclude` : def.param;
-    for (const v of st.values) p.append(key, v);
-    // AND-mode is per facet and only meaningful with more than one included value.
-    if (st.matchAll && !st.exclude && st.values.length > 1) {
-      p.set(`${def.param}_mode`, 'and');
-    }
-  }
-  if (f.visa) p.set('visa_sponsorship', 'true');
-  if (f.salaryMin != null) p.set('salary_min', String(f.salaryMin));
-  if (f.postedWithinDays != null) p.set('posted_within_days', String(f.postedWithinDays));
-  // Omit the default sort: a clean URL leans on the backend's empty-query default.
-  if (f.sort !== DEFAULT_SORT) p.set('sort', f.sort);
-  return p;
-}
-
-/** Parse filters back from URL query params. Exclude takes precedence over
- *  include when both appear for the same facet. */
-export function filtersFromParams(p: URLSearchParams): JobFilters {
-  const f = emptyFilters();
-  f.q = p.get('q') ?? '';
-  for (const def of FACETS) {
-    // URL params aren't guaranteed unique (shared/edited links, crawlers), but a
-    // facet's values are a set — `add`/`toggle` enforce that on user input, so the
-    // URL parse must too. A repeated value otherwise reaches TokenInput, which keys
-    // each chip by its value, and Svelte throws `each_key_duplicate` on hydration.
-    const exclude = [...new Set(p.getAll(`${def.param}_exclude`))];
-    const include = [...new Set(p.getAll(def.param))];
-    const matchAll = p.get(`${def.param}_mode`) === 'and';
-    if (exclude.length > 0) f.facets[def.param] = { values: exclude, exclude: true, matchAll };
-    else if (include.length > 0) f.facets[def.param] = { values: include, exclude: false, matchAll };
-  }
-  f.visa = p.get('visa_sponsorship') === 'true';
-  const salary = Number(p.get('salary_min'));
-  f.salaryMin = p.get('salary_min') && !Number.isNaN(salary) ? salary : null;
-  // Freshness is a positive whole number of days; anything else (absent, zero,
-  // negative, non-numeric) reads as "any age", matching the backend's own guard.
-  const days = Number(p.get('posted_within_days'));
-  f.postedWithinDays = Number.isInteger(days) && days > 0 ? days : null;
-  // Sort isn't user-selectable today, so it's never read from the URL — it stays
-  // the default seeded by emptyFilters().
-  return f;
-}
-
-/** Total selected facet values (plus visa/salary) — drives the mobile badge. */
-export function activeFilterCount(f: JobFilters): number {
-  let n = 0;
-  for (const def of FACETS) n += f.facets[def.param]?.values.length ?? 0;
-  if (f.visa) n += 1;
-  if (f.salaryMin != null) n += 1;
-  if (f.postedWithinDays != null) n += 1;
-  return n;
-}
-
-/** Normalize a search query string to its canonical form (parse → re-serialize),
- *  so two filter sets that differ only in param order or stale/unknown params
- *  compare equal. Used to detect which saved search matches the current filters. */
-export function canonicalQuery(query: string): string {
-  return filtersToParams(filtersFromParams(new URLSearchParams(query))).toString();
-}
+export * from './facetModel';
 
 /** Reactive job filters mirrored into the URL. A thin wrapper over the shared
  *  `UrlSyncedState` primitive: it owns the job-specific shape (facets/visa/salary/
@@ -179,39 +83,44 @@ export class FilterStore {
     this.#url.setNow({ ...this.#url.value, sort });
   }
 
-  /** Toggle a facet between match-all (AND) and match-any (OR) of its values. */
+  /** Toggle a facet between match-all (AND) and match-any (OR) of its included values. */
   setMatchAll(param: string, on: boolean) {
     this.#setFacet(param, { ...this.facet(param), matchAll: on });
   }
 
-  /** Add the value to a facet if absent, remove it if present (pills). */
-  toggle(param: string, v: string) {
-    const st = this.facet(param);
-    const has = st.values.includes(v);
-    this.#setFacet(param, { ...st, values: has ? st.values.filter((x) => x !== v) : [...st.values, v] });
+  /** Force a facet value to a specific sign (off/include/exclude). */
+  setSign(param: string, v: string, sign: Sign) {
+    this.#setFacet(param, facetSetSign(this.facet(param), v, sign));
   }
 
-  /** Add a token to a facet (token inputs); no-op on blank or duplicate. */
+  /** Pills interaction: cycle a value off → include → exclude → off. */
+  cycle(param: string, v: string) {
+    this.#setFacet(param, facetCycle(this.facet(param), v));
+  }
+
+  /** Select-dropdown interaction: add a value to include, or clear it if selected. */
+  pick(param: string, v: string) {
+    this.#setFacet(param, facetPick(this.facet(param), v));
+  }
+
+  /** Per-chip toggle: flip a value between include and exclude. */
+  toggleSign(param: string, v: string) {
+    this.#setFacet(param, facetToggleSign(this.facet(param), v));
+  }
+
+  /** Add a token to a facet's include set (token inputs); no-op on blank or duplicate. */
   add(param: string, raw: string) {
-    const v = raw.trim();
-    const st = this.facet(param);
-    if (!v || st.values.includes(v)) return;
-    this.#setFacet(param, { ...st, values: [...st.values, v] });
+    this.#setFacet(param, facetAdd(this.facet(param), raw));
   }
 
+  /** Remove a value from a facet entirely (both sets). */
   remove(param: string, v: string) {
-    const st = this.facet(param);
-    this.#setFacet(param, { ...st, values: st.values.filter((x) => x !== v) });
+    this.#setFacet(param, facetRemove(this.facet(param), v));
   }
 
-  /** Reset a single facet (values + exclude mode) — the per-section clear. */
+  /** Reset a single facet (both sets) — the per-section clear. */
   clearFacet(param: string) {
     this.#setFacet(param, emptyFacet());
-  }
-
-  /** Switch a facet between include and exclude mode (the "Исключить" link). */
-  setExclude(param: string, exclude: boolean) {
-    this.#setFacet(param, { ...this.facet(param), exclude });
   }
 
   clear() {

--- a/web/src/lib/stagedFilters.svelte.ts
+++ b/web/src/lib/stagedFilters.svelte.ts
@@ -13,6 +13,11 @@ import {
   emptyFilters,
   filtersFromParams,
   filtersToParams,
+  facetCycle,
+  facetPick,
+  facetToggleSign,
+  facetAdd,
+  facetRemove,
   type FacetState,
   type FilterStore,
   type JobFilters,
@@ -41,30 +46,28 @@ export class StagedFilters implements FacetStore {
     return this.#f.facets[param] ?? emptyFacet();
   }
 
-  toggle(param: string, v: string): void {
-    const st = this.facet(param);
-    const has = st.values.includes(v);
-    this.#setFacet(param, { ...st, values: has ? st.values.filter((x) => x !== v) : [...st.values, v] });
+  cycle(param: string, v: string): void {
+    this.#setFacet(param, facetCycle(this.facet(param), v));
+  }
+
+  pick(param: string, v: string): void {
+    this.#setFacet(param, facetPick(this.facet(param), v));
+  }
+
+  toggleSign(param: string, v: string): void {
+    this.#setFacet(param, facetToggleSign(this.facet(param), v));
   }
 
   add(param: string, raw: string): void {
-    const v = raw.trim();
-    const st = this.facet(param);
-    if (!v || st.values.includes(v)) return;
-    this.#setFacet(param, { ...st, values: [...st.values, v] });
+    this.#setFacet(param, facetAdd(this.facet(param), raw));
   }
 
   remove(param: string, v: string): void {
-    const st = this.facet(param);
-    this.#setFacet(param, { ...st, values: st.values.filter((x) => x !== v) });
+    this.#setFacet(param, facetRemove(this.facet(param), v));
   }
 
   clearFacet(param: string): void {
     this.#setFacet(param, emptyFacet());
-  }
-
-  setExclude(param: string, exclude: boolean): void {
-    this.#setFacet(param, { ...this.facet(param), exclude });
   }
 
   setMatchAll(param: string, on: boolean): void {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// A standalone vitest config (not the SvelteKit vite.config) so unit tests run in
+// plain Node without loading the SvelteKit plugin or `$app/*` runtime. The filter
+// model lives in a pure module (facetModel.ts) with no runes or SvelteKit imports,
+// so no Svelte compilation is needed here.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## What

Lets one facet include some values **and** exclude others at the same time — e.g. include `nodejs` while excluding `php`/`.net`. Previously a facet was all-include or all-exclude (a single `exclude` boolean per facet).

Frontend-only: the search API already accepts simultaneous `?param` and `?param_exclude`, so **no backend, Meilisearch, or `query_filter` change**.

## How

- Replace `FacetState { values, exclude:boolean, matchAll }` with `{ include[], exclude[], matchAll }`.
- Extract the pure model (types, URL (de)serialization, per-value sign transitions `setSign`/`cycle`/`pick`/`toggleSign`) into `facetModel.ts`; `filters.ts` re-exports it and keeps only the SvelteKit-bound `FilterStore`.
- Facet pills are **three-state everywhere**: excludable facets cycle `off → include → exclude → off`; non-excludable ones toggle `off ↔ include`.
- Drop the whole-facet Exclude toggle; `FilterSummary` renders include and exclude chips distinctly (destructive style for excludes).
- Add **vitest** for the pure model + serialization (17 tests). URL shape unchanged (`?param` / `?param_exclude` / `?param_mode=and`), so old shared links and saved searches still parse.

## Verification

- `npm run test` → 17/17 pass
- `npm run check` (svelte-check) → 0 errors / 0 warnings
- `npm run build` → ok
- Headless-Chrome visual verify: mixed include/exclude renders correctly across skills (select), regions & seniority (pills), and the sidebar summary.

OpenSpec change: `facet-mixed-include-exclude` (modifies `filter-modal` spec).