### PR TITLE
feat(web): contextual header search on the company page, drop the inline box

### DIFF
--- a/openspec/changes/reusable-filter-modal/.openspec.yaml
+++ b/openspec/changes/reusable-filter-modal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/reusable-filter-modal/design.md
+++ b/openspec/changes/reusable-filter-modal/design.md
@@ -1,0 +1,115 @@
+## Context
+
+`FilterModal.svelte` is hardwired to job search: it `new`s a `StagedFilters`,
+hardcodes the job `RAIL` (`filterSections.ts`), and resolves facet defs from the job
+`FACETS` registry. `SavedSearches.svelte` ("My filters") is embedded in
+`FilterSummary.svelte`, which renders only in the desktop sidebar (`hidden md:block`)
+— so on mobile, where only the modal opens (via `FilterEdgeTab`), saved searches are
+unreachable. `SavedSearches` also carries board share/unshare/copy-link controls.
+`/companies` ships its own always-open `CompanyFiltersPanel` + a bespoke mobile
+drawer over `CompanyFilterStore` / `COMPANY_FACETS`. `/my/profile` renders the filter
+sidebar/edge-tab/modal on every tab.
+
+Key facts that shape the design:
+
+- `FilterStore`, `StagedFilters`, and `CompanyFilterStore` all implement the shared
+  `FacetStore` interface, and `FacetSection` already renders any `FacetStore`.
+- The modal's `kind === 'facet'` pane renders `FacetSection`; company facets are all
+  plain `facet`-kind, so company panes need **no new pane code**.
+- Companies apply immediately (`setNow`); the modal is deferred (staged copy, commit
+  on footer). Companies therefore need a deferred `StagedCompanyFilters`.
+- `entryCount` currently reads `staged.value.facets[param].values` directly; the
+  company value shape differs (`Record<string,string[]>`), so rail counts must be read
+  through the uniform `staged.facet(param)` method.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One reusable modal shell + summary shell, reused by both the job and company
+  catalogs, keeping the deferred-apply (staged) contract identical.
+- "My filters" reachable wherever the modal opens (incl. mobile) as a deferred rail
+  tab operating on the staged copy.
+- Remove board share/unshare/copy-link from the in-context "My filters" control.
+- `/companies` on the jobs pattern (summary sidebar + modal); `/my/profile` filters
+  only on the Market coverage tab.
+
+**Non-Goals:**
+
+- No backend/API/DB or filter-serialization changes.
+- No change to `/my/searches` or the board endpoints.
+- No new facets or filter semantics; no change to job-modal panes' behavior.
+
+## Decisions
+
+### Shell + thin domain wrappers (over one parameterized file)
+
+- **`FilterModalShell.svelte`** — reusable chrome only: backdrop, header, left rail
+  (from a `rail: RailEntry[]` prop grouped by `sections`), footer (Clear all / Apply /
+  preview "Show N"), error handling, seed-on-open. Depends on a minimal **staging
+  contract** — `active: number`, `seed(): void`, `params(): URLSearchParams`,
+  `commit(): void`, `clear(): void` — plus `entryCount(entry): number` and a
+  `pane: Snippet<[RailEntry]>` for the active pane body. The seed source and commit
+  target are closed over by the wrapper, so the shell stays domain-agnostic.
+- **`FilterModal.svelte`** (job wrapper) — creates `StagedFilters`, passes job `RAIL`
+  + job `entryCount` + the current if/else as the `pane` snippet. Keeps its public
+  props (`store/seed/counts/exclude/railKeys/plain/extra/applyLabel/onApply/canApply/
+  previewCount`) so `JobsView` and the profile change minimally. Adds the "My filters"
+  rail entry (first, `SAVED` section) unless `railKeys` restricts the rail or no
+  saved-search context applies.
+- **`CompanyFilterModal.svelte`** (new) — creates `StagedCompanyFilters`, builds a
+  rail from `COMPANY_FACETS` (single section, all `facet`-kind), `pane` renders
+  `<FacetSection def store={staged} />`, `entryCount = staged.facet(param).values.length`.
+
+Rationale: the job vs company `value` shapes diverge, so a single generic file would
+either lose types or need casts; separate wrappers keep each typed to its own staged
+store and pane set. Matches the "small, well-bounded units" guidance.
+
+### Staging for companies
+
+`StagedCompanyFilters` (`lib/stagedCompanyFilters.svelte.ts`) — a deferred copy of
+`CompanyFilters` implementing `FacetStore` + `seed/params/commit/clear/active/value`,
+mirroring `StagedFilters`. Pure logic → unit-tested with vitest (seed → mutate →
+params/commit round-trips, `active`).
+
+### My filters operates on the staged copy
+
+Inside the modal the "My filters" tab drives the **staged** store, not the live one:
+selecting a set seeds staged; "Save as new" persists staged; the footer applies. This
+keeps the whole modal deferred and consistent. Requires `StagedFilters.apply(query)`
+and a canonical-current getter off `staged.params()`. `SavedSearches.svelte`'s only
+remaining mount is this tab (the sidebar no longer mounts it), so its `store` prop
+becomes the staged store; `SavedSearchesView` on `/my/searches` is untouched.
+
+### Summary shell
+
+**`FilterSummaryShell.svelte`** (new) — shared summary chrome: heading + Reset all,
+the All-filters button (active badge), empty state, chip-group rendering; takes
+`groups: Group[]`, `active`, `onReset`, `onOpen`. `FilterSummary.svelte` (job) drops
+`<SavedSearches>` and renders the shell; **`CompanyFilterSummary.svelte`** (new)
+computes flat per-facet chip groups from `COMPANY_FACETS` and renders the shell.
+
+### Consumers
+
+- `CompaniesView` — desktop `CompanyFilterSummary` (chips + All-filters) + `FilterEdgeTab`
+  (mobile) opening `CompanyFilterModal`. Delete `CompanyFiltersPanel.svelte` and the
+  bespoke drawer.
+- `my/profile` — render the filters sidebar + `FilterEdgeTab` + `FilterModal` only when
+  `tab === 'coverage'`; the wrapper is used without a saved-search context (no My
+  filters tab). CV readiness scores against the profile's default role.
+
+## Risks / Trade-offs
+
+- **Board sharing removed from the panel is a visible UI change.** Mitigated: the full
+  share/unshare/copy management stays on `/my/searches`; the spec delta records the
+  migration.
+- **Staged "My filters" changes selection semantics** (select no longer commits
+  immediately; it stages and applies on Show results). This is intentional for
+  consistency but differs from today's behavior; captured in the saved-searches spec
+  delta.
+- **Refactor breadth** touches several components at once. Mitigated by TDD on the
+  pure `StagedCompanyFilters` and `svelte-check` + visual verification for the wired
+  UI; behavior of the job panes is preserved (the pane snippet is the existing if/else
+  moved verbatim).
+- **Two summaries could drift.** Mitigated by the shared `FilterSummaryShell` owning
+  the chrome; only the group computation differs per catalog.

--- a/openspec/changes/reusable-filter-modal/proposal.md
+++ b/openspec/changes/reusable-filter-modal/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The two-pane "All filters" modal is hardwired to job search (it constructs a job
+`StagedFilters`, hardcodes the job rail, and looks facets up in the job registry),
+so it cannot be reused for the companies catalog, and "My filters" (saved searches)
+lives only in the desktop sidebar — invisible on mobile, where only the modal opens.
+The filters panel also carries board share/unshare controls that belong on the
+dedicated `/my/searches` page, and the `/my/profile` page shows the filters on every
+tab though they only apply to Market coverage.
+
+## What Changes
+
+- Refactor the modal into a reusable **shell** (`FilterModalShell`: backdrop,
+  header, rail, footer, deferred apply/preview) plus thin domain wrappers — the job
+  `FilterModal` and a new `CompanyFilterModal` — so both catalogs share one chrome.
+- Extract a **`FilterSummaryShell`** for the sidebar (heading, Reset all, All-filters
+  button, chip groups, empty state); the job `FilterSummary` and a new
+  `CompanyFilterSummary` render over it.
+- Add **"My filters" as a rail tab** inside the modal (first entry), operating on the
+  staged copy — so saved searches are reachable on mobile and stay consistent with
+  the deferred model.
+- **Remove** the board share/unshare/copy-link affordance from the "My filters"
+  panel (`SavedSearches.svelte`). **BREAKING (UI)**: board management now happens only
+  on `/my/searches`.
+- Move `/companies` to the jobs pattern: a summary sidebar + the reused two-pane
+  modal (desktop button + mobile edge tab), replacing the always-present
+  `CompanyFiltersPanel` and its bespoke drawer.
+- On `/my/profile`, render the filters sidebar / edge tab / modal **only on the
+  Market coverage tab**.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this change refactors and relocates existing filter UI; no new user-facing
+capability._
+
+### Modified Capabilities
+
+- `filter-modal`: the modal + summary sidebar are generalized so a non-job catalog
+  reuses them; "My filters" becomes a deferred rail tab; the summary sidebar no
+  longer carries the saved-search controls.
+- `saved-searches`: the "My filters" control relocates into the modal as a deferred
+  tab (staged, applied on Show results); the board share/unshare affordance in the
+  filters panel is removed (it remains on `/my/searches`).
+- `web-frontend`: the companies list switches from an always-present filter-control
+  sidebar to the jobs-style summary sidebar + two-pane "All filters" modal; the
+  `/my/profile` page shows its filters only on the Market coverage tab.
+
+## Impact
+
+- Web only. Affected: `web/src/lib/components/filters/*` (new `FilterModalShell`,
+  `FilterSummaryShell`; refactored `FilterModal`, `FilterSummary`; new
+  `CompanyFilterModal`, `CompanyFilterSummary`), `SavedSearches.svelte`, new
+  `lib/stagedCompanyFilters.svelte.ts`, `CompaniesView.svelte` (delete
+  `CompanyFiltersPanel.svelte`), and `routes/my/profile/+page.svelte`.
+- No backend, API, DB, or filter-serialization changes. `/my/searches` and the board
+  endpoints are untouched.

--- a/openspec/changes/reusable-filter-modal/specs/filter-modal/spec.md
+++ b/openspec/changes/reusable-filter-modal/specs/filter-modal/spec.md
@@ -1,0 +1,87 @@
+## MODIFIED Requirements
+
+### Requirement: The sidebar is a summary of the selected filters
+
+The filter sidebar SHALL display only the currently applied filters, as chips grouped
+by facet, alongside the **All filters** button (carrying a badge with the total number
+of active filter values) and a **Reset all** control. Removing a chip SHALL apply
+immediately to the live filter state (the sidebar edits live state directly; only the
+modal defers). With no filters applied, the sidebar SHALL show an empty state rather
+than facet controls. The saved-search ("My filters") controls SHALL NOT live in the
+sidebar; they are presented as a tab inside the modal (see the saved-searches
+capability).
+
+#### Scenario: Applied filters render as grouped chips
+
+- **WHEN** filters are applied across several facets
+- **THEN** the sidebar shows a chip per applied value, grouped under its facet label
+
+#### Scenario: Removing a chip applies immediately
+
+- **WHEN** the user removes a chip from the sidebar
+- **THEN** that value is dropped from the live filter state and the job list refreshes
+  without opening the modal
+
+#### Scenario: The All-filters badge counts active values
+
+- **WHEN** five filter values are applied
+- **THEN** the **All filters** badge shows `5`
+
+#### Scenario: The sidebar no longer hosts saved searches
+
+- **WHEN** the filters sidebar renders
+- **THEN** it shows only the applied-filter chips, the **All filters** button, and
+  **Reset all** — the "My filters" control is not in the sidebar
+
+## ADDED Requirements
+
+### Requirement: My filters is a deferred tab inside the modal
+
+The modal SHALL present the saved-search ("My filters") control as a rail entry (the
+first entry, under a `SAVED` section) so it is reachable wherever the modal opens,
+including on mobile viewports where the sidebar is hidden. Selecting the entry SHALL
+render the saved-search control in the right pane. Because the modal is deferred,
+the control SHALL operate on the **staged** filters: selecting a saved set seeds the
+staged filters (previewed, not yet applied) and saving persists the staged filters;
+nothing commits to the live filter state until the footer **Show results** action.
+The "My filters" tab SHALL be omitted when the modal is opened for a restricted facet
+subset that has no saved-search context (e.g. the profile comparison modal).
+
+#### Scenario: My filters is reachable on mobile
+
+- **WHEN** a user opens the modal on a sub-`md` viewport and selects the **My filters**
+  rail entry
+- **THEN** the saved-search control renders in the pane, without a desktop sidebar
+
+#### Scenario: Selecting a saved set stages its filters
+
+- **WHEN** a signed-in user selects a saved set from the **My filters** tab
+- **THEN** the staged filters and the Show-results count update to that set, and the
+  live job list is unchanged until **Show results** is activated
+
+#### Scenario: Saving persists the staged filters
+
+- **WHEN** a signed-in user saves the current edits as a new set from the **My filters**
+  tab
+- **THEN** the saved set captures the staged (currently-edited) filters
+
+### Requirement: The filter modal and summary are reusable across catalogs
+
+The two-pane modal chrome and the summary sidebar SHALL be factored into reusable
+shells (a modal shell and a summary shell) driven by a rail definition, a deferred
+(staged) facet store, and a pane renderer, so a non-job catalog can present the same
+deferred two-pane "All filters" modal and chip-summary sidebar. The shell SHALL keep
+the deferred-apply contract identical for every catalog: edits mutate a staged copy
+and commit only on **Show results**.
+
+#### Scenario: The companies catalog reuses the modal
+
+- **WHEN** the companies catalog opens its **All filters** modal
+- **THEN** it renders the same two-pane shell (rail + pane + deferred **Show results**
+  footer) as the jobs modal, over the company facet set
+
+#### Scenario: The staged contract holds for a reused modal
+
+- **WHEN** a user stages a facet change in a reused modal and dismisses it without
+  Show results
+- **THEN** the underlying list is unchanged

--- a/openspec/changes/reusable-filter-modal/specs/saved-searches/spec.md
+++ b/openspec/changes/reusable-filter-modal/specs/saved-searches/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Saved-search UI in the filters panel
+
+The web filter modal SHALL present a "My filters" tab to signed-in users for
+selecting, saving, updating, and deleting saved searches, and SHALL prompt anonymous
+users to sign in instead of showing the list. Because the modal defers, the tab
+SHALL operate on the staged filters: selecting a set seeds the staged state and
+saving captures the staged filters; the changes reach the live filter state (and the
+URL) only when the modal's **Show results** action is activated.
+
+#### Scenario: Apply a saved search
+
+- **WHEN** a signed-in user selects a saved set from the "My filters" tab and activates
+  **Show results**
+- **THEN** the modal parses the stored query string into the staged filters and, on
+  **Show results**, commits it to the URL, and the results re-search accordingly
+
+#### Scenario: Active set is marked
+
+- **WHEN** the staged filter state's canonical query string equals a saved set's query
+- **THEN** that set is marked active (checkmark) in the control
+
+#### Scenario: Anonymous prompt
+
+- **WHEN** an anonymous (signed-out) user opens the "My filters" tab
+- **THEN** the control shows a "sign in to save" affordance that opens the auth dialog
+  instead of a list of sets
+
+## REMOVED Requirements
+
+### Requirement: Share affordance in the filters panel
+
+**Reason**: Board sharing clutters the in-context filters control and duplicates the
+dedicated management surface. Share, unshare, and copy-link are removed from the
+"My filters" control so it focuses on selecting/saving/updating/deleting.
+
+**Migration**: Users share and unshare a saved search from the account section at
+`/my/searches` (the "Saved searches section in the account area" requirement), which
+retains the full share/unshare/copy-link management unchanged.

--- a/openspec/changes/reusable-filter-modal/specs/web-frontend/spec.md
+++ b/openspec/changes/reusable-filter-modal/specs/web-frontend/spec.md
@@ -1,0 +1,96 @@
+## MODIFIED Requirements
+
+### Requirement: Companies list
+
+The frontend SHALL present companies from `GET /api/v1/companies`, showing each
+company's name and its job count, with each row linking to the company detail.
+
+The page SHALL provide a name-search input. Typing SHALL filter the list against
+the API's `q` parameter (debounced), and the current query SHALL be mirrored into
+the URL query string (`?q=`) so a search survives reload, sharing, and
+back/forward navigation. The page SHALL show the count of matching companies and
+a distinct empty state when a search matches nothing.
+
+The page SHALL present filters through the same two-pane "All filters" modal and
+chip-summary sidebar the jobs list uses (the reusable filter shells), over the
+company facet set: **collection**, **region**, **country**, **industry** (domains),
+**company type**, and **company size**, reusing the jobs filter controls and
+closed-vocabulary option registries (country is a searchable select over the country
+list; the others are pill/select controls over their fixed vocabularies). On desktop
+the sidebar SHALL show the applied-facet chips plus an **All filters** button opening
+the modal; on narrow viewports the modal SHALL open from a pinned left-edge tab. As
+in the jobs modal, facet edits SHALL be staged and applied on **Show results**;
+applying SHALL refetch the list against the corresponding repeatable API facet
+parameters and mirror the active facets into the URL query string, so a filtered view
+survives reload, sharing, and back/forward navigation, composably with the `q` search.
+The summary sidebar SHALL offer a **Reset all** control.
+
+#### Scenario: Companies are listed
+
+- **WHEN** a user opens `/companies`
+- **THEN** a page of companies is fetched and rendered with job counts
+
+#### Scenario: User searches companies by name
+
+- **WHEN** a user types a query into the companies search input
+- **THEN** the list is refetched filtered by that query and the URL query string
+  is updated to `?q=<query>`
+
+#### Scenario: Search restored from the URL
+
+- **WHEN** a user opens `/companies?q=acme` directly or via back/forward
+- **THEN** the search input is prefilled with `acme` and the filtered list is
+  shown
+
+#### Scenario: Search matches nothing
+
+- **WHEN** a search returns no companies
+- **THEN** an empty state ("No matching companies.") is shown instead of an empty
+  list
+
+#### Scenario: User filters companies by a facet
+
+- **WHEN** a user opens the **All filters** modal, selects a region, and activates
+  **Show results**
+- **THEN** the list is refetched against `?regions=<value>` and the URL query
+  string reflects the active facet
+
+#### Scenario: Filters restored from the URL
+
+- **WHEN** a user opens `/companies?collections=yc&regions=europe` directly or via
+  back/forward
+- **THEN** the summary sidebar shows those facets active and the list is filtered to
+  match
+
+#### Scenario: Clearing filters
+
+- **WHEN** a user activates **Reset all**
+- **THEN** the facet parameters are removed from the URL and the full list (for the
+  current `q`, if any) is shown
+
+## ADDED Requirements
+
+### Requirement: Profile filters appear only on the Market coverage tab
+
+The `/my/profile` page SHALL expose its role/filter controls (the summary sidebar,
+the mobile left-edge tab, and the two-pane modal) only while the **Market coverage**
+tab is active, since coverage is the only view computed against ad-hoc filters. On the
+**Your CV** and **CV readiness** tabs the filter controls SHALL NOT be shown, and CV
+readiness SHALL be scored against the profile's default role. The profile page SHALL
+NOT present the "My filters" (saved-search) tab.
+
+#### Scenario: Filters shown on Market coverage
+
+- **WHEN** a signed-in user with a profile opens the **Market coverage** tab
+- **THEN** the filter summary, the mobile filters tab, and the **All filters** modal
+  are available to refine the comparison role
+
+#### Scenario: Filters hidden on other tabs
+
+- **WHEN** the user switches to the **Your CV** or **CV readiness** tab
+- **THEN** no filter summary, mobile tab, or modal is shown
+
+#### Scenario: No My filters on the profile
+
+- **WHEN** the profile's **All filters** modal is opened
+- **THEN** it presents the facet rail without a "My filters" (saved-search) tab

--- a/openspec/changes/reusable-filter-modal/tasks.md
+++ b/openspec/changes/reusable-filter-modal/tasks.md
@@ -1,0 +1,37 @@
+## 1. Company staging primitive (pure logic, TDD)
+
+- [ ] 1.1 Add `web/src/lib/stagedCompanyFilters.svelte.ts`: `StagedCompanyFilters` implementing `FacetStore` + `value`/`active`/`seed`/`params`/`commit`/`clear`, mirroring `StagedFilters` over the `CompanyFilters` shape.
+- [ ] 1.2 Unit test (vitest): seed from `CompanyFilters` → toggle/add/remove → `params()` matches `companyFiltersToParams`; `commit(store)` applies to a `CompanyFilterStore`; `active` counts selected values; `clear()` empties.
+
+## 2. Reusable modal shell
+
+- [ ] 2.1 Add `FilterModalShell.svelte`: backdrop/header/rail (from `rail` + `sections` props)/footer (Clear all / Apply / preview) / seed-on-open / Escape+backdrop close / error handling, depending on the minimal staging contract (`active`/`seed`/`params`/`commit`/`clear`), `entryCount(entry)`, and a `pane` snippet.
+- [ ] 2.2 Refactor `FilterModal.svelte` (job) into a thin wrapper over the shell: create `StagedFilters`, pass job `RAIL` + job `entryCount` + the existing pane if/else as the `pane` snippet; preserve all current public props and behavior.
+- [ ] 2.3 Verify `JobsView`, `AnalyticsView`, and `my/profile` still open/apply the job modal unchanged (`svelte-check`).
+
+## 3. My filters as a deferred modal tab
+
+- [ ] 3.1 Add `StagedFilters.apply(query)` and a canonical-current getter (from `params()`), so `SavedSearches` can read/seed the staged state.
+- [ ] 3.2 Remove board sharing from `SavedSearches.svelte`: delete `shareActive`/`unshareActive`/`copyBoardLink` + their UI; keep select/save/update/delete + Telegram notify.
+- [ ] 3.3 Point `SavedSearches` at the staged store (prop), so select seeds staged and save persists staged.
+- [ ] 3.4 Add the "My filters" rail entry (first, `SAVED` section) in the job `FilterModal`, rendering `SavedSearches` in the pane; omit it when `railKeys` restricts the rail (profile).
+
+## 4. Summary shell + job summary
+
+- [ ] 4.1 Add `FilterSummaryShell.svelte`: heading + Reset all, All-filters button (active badge), empty state, chip-group rendering; props `groups`/`active`/`onReset`/`onOpen`.
+- [ ] 4.2 Refactor `FilterSummary.svelte` (job) to compute its chip groups and render the shell; remove the embedded `<SavedSearches>`.
+
+## 5. Companies on the jobs pattern
+
+- [ ] 5.1 Add `CompanyFilterModal.svelte`: wraps the shell with `StagedCompanyFilters`, a `COMPANY_FACETS`-derived rail (single section, `facet`-kind), a `FacetSection` pane, and `staged.facet(param).values.length` counts.
+- [ ] 5.2 Add `CompanyFilterSummary.svelte`: compute flat per-facet chip groups from `COMPANY_FACETS`, render `FilterSummaryShell`, open `CompanyFilterModal`.
+- [ ] 5.3 Rewire `CompaniesView.svelte`: desktop `CompanyFilterSummary` + `FilterEdgeTab` (mobile) opening `CompanyFilterModal`; remove the bespoke mobile drawer. Delete `CompanyFiltersPanel.svelte`.
+
+## 6. Profile filter gating
+
+- [ ] 6.1 In `routes/my/profile/+page.svelte`, render the filter summary sidebar, `FilterEdgeTab`, and `FilterModal` only when `tab === 'coverage'`; ensure no "My filters" tab appears (railKeys-restricted).
+
+## 7. Verification
+
+- [ ] 7.1 `pnpm --dir web svelte-check` and vitest green.
+- [ ] 7.2 Visual verify (headless Chrome): mobile "My filters" tab reachable; `/companies` modal parity; profile filters only on Market coverage; board sharing absent from the panel but present on `/my/searches`.

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -13,7 +13,6 @@
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
   import { setListSearchTarget } from '$lib/listSearch.svelte';
   import type { Job, FacetCounts } from '$lib/types';
-  import { Input } from '$lib/ui';
   import FilterSummary from './filters/FilterSummary.svelte';
   import FilterModal from './filters/FilterModal.svelte';
   import FilterEdgeTab from './FilterEdgeTab.svelte';
@@ -112,10 +111,13 @@
   // pending debounced reload so it can't fire after this view is gone.
   onMount(() => {
     if (isAuthenticated()) ensureViewedLoaded();
-    // Register this page's store so the header search drives it (standalone only).
-    if (standalone) setListSearchTarget(filters);
+    // Register this page's store so the header search drives it. This holds for the
+    // standalone /jobs list AND the company page's embedded, scoped list — on
+    // /companies/:slug the header search filters that company's postings (there's
+    // no inline box), so both modes route their text search through the header.
+    setListSearchTarget(filters);
     return () => {
-      if (standalone) setListSearchTarget(null);
+      setListSearchTarget(null);
       filters.dispose();
     };
   });
@@ -170,21 +172,14 @@
 
   <div class="min-w-0 flex-1">
     {#if !standalone}
-      <!-- Company embed: the text filter lives inline (the header search is the
-           standalone list's filter), with the Filters button beside it. No fixed
-           edge tab here — it would overlap the company hero above this list. -->
-      <div class="mb-4 flex items-center gap-2">
-        <Input
-          type="search"
-          value={filters.value.q}
-          oninput={(e) => filters.setQuery(e.currentTarget.value)}
-          placeholder="Search jobs…"
-          aria-label="Search jobs"
-          class="min-w-0 flex-1"
-        />
+      <!-- Company embed: the text search now lives in the header (contextual to
+           this company), so there's no inline box here. Keep a mobile-only Filters
+           button — the fixed edge tab is suppressed on this view (it would overlap
+           the company hero) and desktop opens the modal from the sidebar summary. -->
+      <div class="mb-4 md:hidden">
         <button
           type="button"
-          class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent md:hidden"
+          class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent"
           onclick={() => (modalOpen = true)}
         >
           Filters{#if filters.active > 0}&nbsp;({filters.active}){/if}

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -15,11 +15,19 @@
   // action all live in HeaderMenu.
   //
   // The middle slot is one text field that adapts to context: on the list pages
-  // (/jobs, /companies) it IS that page's filter (HeaderListSearch drives the
-  // list, so there's no duplicate box); everywhere else it's the global launcher
-  // with the instant dropdown (HeaderSearch).
+  // (/jobs, /companies, and a company's own /companies/:slug jobs list) it IS that
+  // page's filter (HeaderListSearch drives the list, so there's no duplicate box);
+  // everywhere else it's the global launcher with the instant dropdown
+  // (HeaderSearch). A company detail page is a jobs list scoped to that company, so
+  // the header search filters its postings — hence 'company' shares the jobs proxy.
   const listKind = $derived(
-    page.url.pathname === '/jobs' ? 'jobs' : page.url.pathname === '/companies' ? 'companies' : null,
+    page.url.pathname === '/jobs'
+      ? 'jobs'
+      : page.url.pathname === '/companies'
+        ? 'companies'
+        : /^\/companies\/[^/]+$/.test(page.url.pathname)
+          ? 'company'
+          : null,
   );
 
   // Jobs/Companies are also surfaced as inline links here — left-aligned beside
@@ -97,7 +105,7 @@
       <a href={resolve('/companies')} class={navLinkClass('/companies')}>Companies</a>
     </nav>
 
-    {#if listKind === 'jobs'}
+    {#if listKind === 'jobs' || listKind === 'company'}
       <HeaderListSearch placeholder="Search jobs…" />
     {:else if listKind === 'companies'}
       <HeaderListSearch placeholder="Search companies…" />


### PR DESCRIPTION
## What

On `/companies/:slug` the header search bar now filters **that company's** postings, and the redundant inline search box above the list is removed.

## Why

The company page had two search inputs: the global launcher in the header (which ignored the company scope) and an inline box above the job list. That's confusing — the header search on a company page should just search within that company.

## How

- `TopBar.svelte` — treat a company detail route (`/companies/:slug`) as a list page, so it renders `HeaderListSearch` (the thin proxy) with a `Search jobs…` placeholder instead of the global `HeaderSearch` launcher.
- `JobsView.svelte` — register the filter store with the header bridge unconditionally (not just for the standalone `/jobs` list). The company embed's scoped store (`company_slug` fixed) now drives the header search, so results stay scoped to the company. The inline `Input` box is removed; mobile keeps a Filters button (the fixed edge tab is suppressed on this view to avoid overlapping the company hero).

No new logic for company-scoped filtering — it reuses the existing `scopedParams()` (which already merges `company_slug`) and the `listSearch` header bridge.

## Verification

- `svelte-check`: 0 errors, 0 warnings.
- Visual (headless Chrome against prod data, `/companies/truelogic`):
  - Desktop + mobile: header shows `Search jobs…`, no inline box; mobile keeps the Filters button.
  - `?q=Full-Stack` → 46/250 jobs, all truelogic (scoped positive match).
  - `?q=QA engineer` → "No matching jobs" (would match globally — proves the scope).