### PR TITLE
feat(web): company page header/sidebar polish + mobile filters parity

### DIFF
--- a/web/src/lib/components/CompanyFollowButton.svelte
+++ b/web/src/lib/components/CompanyFollowButton.svelte
@@ -136,9 +136,11 @@
         onclick={toggle}
         disabled={busy}
         aria-pressed={subscribed}
+        aria-label={subscribed ? 'Subscribed' : 'Subscribe to updates'}
       >
         <Bell class="size-4" aria-hidden="true" />
-        {subscribed ? 'Subscribed' : 'Subscribe to updates'}
+        <!-- Icon-only on mobile to keep the company header compact; label from sm up. -->
+        <span class="hidden sm:inline">{subscribed ? 'Subscribed' : 'Subscribe to updates'}</span>
       </Button>
     {/if}
     {#if error}

--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -6,9 +6,8 @@
   // The company's header card: identity (logo + name + tagline + follow CTA) with the
   // industries and website link below a divider. The scalar company facts live in a
   // separate CompanyFacts card (jobs sidebar on desktop, under the header on mobile),
-  // so this stays compact. Present-only: with no tagline/industries/website the card
-  // is dropped and only the plain, borderless identity row remains (unenriched
-  // companies unchanged).
+  // so this stays compact. The card is always shown, even for an unenriched company
+  // (just the identity row) — the tagline and the meta divider are present-only.
   let { company, slug }: { company: Company; slug: string } = $props();
 
   const info = $derived(company.company_info ?? {});
@@ -17,43 +16,36 @@
   const websiteHref = $derived(website ? (website.startsWith('http') ? website : `https://${website}`) : '');
 
   const hasMeta = $derived(industries.length > 0 || !!website);
-  const hasInfo = $derived(!!company.tagline || hasMeta);
 </script>
 
-{#snippet identity()}
+<section class="rounded-2xl border border-border bg-card p-5">
   <div class="flex items-start gap-3">
     <CompanyLogo name={company.name} size="size-11" />
-    <div class="min-w-0">
+    <div class="min-w-0 flex-1">
       <h1 class="text-2xl font-semibold tracking-tight">{company.name}</h1>
       {#if company.tagline}
         <p class="mt-1 text-sm text-muted-foreground">{company.tagline}</p>
       {/if}
     </div>
-    <div class="ml-auto">
+    <!-- flex-1 above lets the name/tagline use the full width; the follow CTA stays
+         top-right and never shrinks (it collapses to an icon on mobile itself). -->
+    <div class="shrink-0">
       <CompanyFollowButton {slug} companyName={company.name} />
     </div>
   </div>
-{/snippet}
-
-{#if hasInfo}
-  <section class="rounded-2xl border border-border bg-card p-5">
-    {@render identity()}
-    {#if hasMeta}
-      <div class="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-4">
-        {#each industries as industry (industry)}
-          <span class="rounded-full bg-secondary px-2.5 py-0.5 text-xs text-secondary-foreground">{industry}</span>
-        {/each}
-        {#if website}
-          <a
-            class="text-sm font-medium text-primary hover:underline"
-            href={websiteHref}
-            target="_blank"
-            rel="noopener noreferrer">{website} ↗</a
-          >
-        {/if}
-      </div>
-    {/if}
-  </section>
-{:else}
-  {@render identity()}
-{/if}
+  {#if hasMeta}
+    <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-border pt-3">
+      {#each industries as industry (industry)}
+        <span class="rounded-full bg-secondary px-2.5 py-0.5 text-xs text-secondary-foreground">{industry}</span>
+      {/each}
+      {#if website}
+        <a
+          class="text-sm font-medium text-primary hover:underline"
+          href={websiteHref}
+          target="_blank"
+          rel="noopener noreferrer">{website} ↗</a
+        >
+      {/if}
+    </div>
+  {/if}
+</section>

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -26,7 +26,7 @@
   <CompanyFacts {company} />
 </div>
 
-<div class="mt-6">
+<div class="mt-4">
   {#await initial}
     <States state="loading" />
   {:then slice}

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -163,6 +163,19 @@
 <div class="flex gap-6">
   <aside class="hidden w-72 shrink-0 md:block">
     <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
+      {#if !standalone && jobs.status === 'ready'}
+        <!-- Company view: the (filtered) open-job count as the sidebar's lead stat.
+             The inline count above the list is hidden on desktop (shown only on
+             mobile, where there's no sidebar), so it lives here instead. -->
+        <div class="rounded-xl border border-border bg-card px-4 py-3">
+          <p class="text-3xl font-semibold leading-none tracking-tight tabular-nums">
+            {jobs.total.toLocaleString()}
+          </p>
+          <p class="mt-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {jobs.total === 1 ? 'open job' : 'open jobs'}
+          </p>
+        </div>
+      {/if}
       {@render sidebarTop?.()}
       <div class="rounded-xl border border-border bg-card p-4">
         <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} />
@@ -171,22 +184,6 @@
   </aside>
 
   <div class="min-w-0 flex-1">
-    {#if !standalone}
-      <!-- Company embed: the text search now lives in the header (contextual to
-           this company), so there's no inline box here. Keep a mobile-only Filters
-           button — the fixed edge tab is suppressed on this view (it would overlap
-           the company hero) and desktop opens the modal from the sidebar summary. -->
-      <div class="mb-4 md:hidden">
-        <button
-          type="button"
-          class="h-9 shrink-0 rounded-lg border border-border bg-secondary px-3 text-sm font-medium text-secondary-foreground transition-colors hover:bg-accent"
-          onclick={() => (modalOpen = true)}
-        >
-          Filters{#if filters.active > 0}&nbsp;({filters.active}){/if}
-        </button>
-      </div>
-    {/if}
-
     {#if jobs.status === 'loading'}
       <States state="loading" />
     {:else if jobs.status === 'error'}
@@ -194,9 +191,15 @@
     {:else if jobs.items.length === 0}
       <States state="empty" message="No matching jobs." />
     {:else}
-      <!-- On the standalone list, clear the left-edge filters tab on mobile. -->
+      <!-- Standalone: the count is the topmost element, level with the fixed edge
+           tab, so pl-12 clears it (reset at md). Company embed: the count sits well
+           below the header/facts, clear of the tab, so it aligns with the cards; it
+           also moves to the sidebar on desktop, hence mobile-only and a touch bolder. -->
       <p
-        class={['mb-3 text-sm text-muted-foreground', standalone && 'pl-12 md:pl-0']}
+        class={[
+          'mb-3 text-sm',
+          standalone ? 'pl-12 text-muted-foreground md:pl-0' : 'font-medium text-foreground md:hidden',
+        ]}
         aria-live="polite"
       >
         {jobs.total.toLocaleString()} {jobs.total === 1 ? 'job' : 'jobs'}
@@ -217,12 +220,12 @@
   </div>
 </div>
 
-{#if standalone}
-  <!-- Standalone list only: the fixed edge tabs sit over the top of the viewport,
-       where this page's content starts. The embedded company view keeps its inline
-       Filters button (above) so nothing overlaps the company hero. -->
-  <FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
+<!-- Mobile left-edge Filters tab, for both the standalone list and the embedded
+     company view (parity with /jobs) — it floats over the left edge of the content
+     the same way on either page. -->
+<FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
 
+{#if standalone}
   <!-- Swipe-mode entry: an icon-only button pinned to the right viewport edge,
        level with the left filters tab (top-16). Fixed, so it only exists while the
        standalone jobs list is mounted (never on the embedded company view) and


### PR DESCRIPTION
## What

Polish for the company page (`/companies/[slug]`), driven by mobile review.

### Header (`CompanyHeader`)
- **Always a bordered card**, including unenriched companies (previously the card was dropped and only a borderless identity row remained). The tagline and the industries/website divider stay present-only *inside* the card.
- **Mobile-friendly**: the "Subscribe to updates" CTA collapses to an icon-only bell on mobile (label from `sm` up, `aria-label` retained), and the name/tagline column takes the full width (`flex-1`) instead of being crushed beside a full-text button.

### Sidebar / count (`JobsView`, `CompanyView`)
- The (filtered) **open-job count** is surfaced as a prominent lead stat at the top of the desktop sidebar.
- The inline count above the list is now **mobile-only** on the company view (it lives in the sidebar on desktop).
- Tightened the header→list top spacing (`mt-6`→`mt-4`, header divider `pt-4`→`pt-3`).

### Filters parity (`JobsView`)
- The company view now uses the **same fixed left-edge Filters tab** as `/jobs` on mobile, instead of a bespoke inline Filters button — the two lists behave identically. The swipe-mode button stays standalone-only.

## Verification
- `svelte-check` clean (only pre-existing `vitest` test-file errors).
- Production build passes.
- Visually verified both states (enriched `truelogic` / bare `amazon`) on desktop and mobile via headless Chrome against the prod API.

## Notes
- A **pre-existing** ~40px horizontal overflow exists on very narrow viewports (≤~410px CSS) across the app (reproduces on production, on `/jobs` too) — **out of scope** here, flagged for a separate fix.