### PR TITLE
fix(search): OR location facets together instead of ANDing

### DIFF
--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -36,6 +36,16 @@ var StringFacets = map[string]string{
 	"posting_language": "enrichment.posting_language",
 }
 
+// locationFacets are the geography params that describe one user-facing concept
+// ("where"), so their included values OR into a single group rather than ANDing
+// across facets — selecting the "Global" region and "Brazil" widens the results
+// (Global OR Brazil) instead of intersecting them to zero. They share the SPA's
+// one Location pane. Excludes stay per-value AND groups like every other facet,
+// and a non-location facet (e.g. work_mode) still ANDs with the whole group, so
+// "remote AND (Europe OR Brazil)" holds. Geographic AND is nonsensical ("in
+// Europe AND in LATAM" is empty), so the `_mode=and` override does not apply here.
+var locationFacets = map[string]bool{"regions": true, "countries": true, "cities": true}
+
 // RegionUnspecified is the reserved value of the `regions` facet that selects
 // jobs with no resolved geography (an empty regions array) rather than a real
 // region code. The SPA's "Not specified" region chip serializes to it. It maps to
@@ -65,7 +75,9 @@ func facetNeq(param, attr, val string) string {
 // FilterFromValues turns the facet params of a parsed search query into a
 // Meilisearch filter. Within a facet, included values are ORed by default (or
 // ANDed when `<param>_mode=and`); excluded values (`<param>_exclude=...`) become
-// NOT fragments. Facets are ANDed. Returns nil when no facet is set.
+// NOT fragments. Facets are ANDed, except the location facets (regions/countries/
+// cities), whose includes OR into one shared group (see locationFacets). Returns
+// nil when no facet is set.
 //
 // It is pure (no *fiber.Ctx), so the HTTP handler and the notification matcher
 // build identical filters from the same canonical query string — the handler
@@ -80,26 +92,36 @@ func FilterFromValues(v url.Values) any {
 // branch.
 func filterFromValues(v url.Values, now time.Time) any {
 	var groups [][]string
+	// Included geography fragments across regions/countries/cities collect here and
+	// are appended as one OR group (see locationFacets).
+	var locationGroup []string
 
 	for param, attr := range StringFacets {
-		if included := nonEmpty(v[param]); len(included) > 0 {
-			if v.Get(param+"_mode") == "and" {
-				// Each value its own AND group: a job must match all of them.
-				for _, val := range included {
-					groups = append(groups, []string{facetEq(param, attr, val)})
-				}
-			} else {
-				group := make([]string, len(included))
-				for i, val := range included {
-					group[i] = facetEq(param, attr, val)
-				}
-				groups = append(groups, group)
+		included := nonEmpty(v[param])
+		switch {
+		case locationFacets[param]:
+			for _, val := range included {
+				locationGroup = append(locationGroup, facetEq(param, attr, val))
 			}
+		case len(included) > 0 && v.Get(param+"_mode") == "and":
+			// Each value its own AND group: a job must match all of them.
+			for _, val := range included {
+				groups = append(groups, []string{facetEq(param, attr, val)})
+			}
+		case len(included) > 0:
+			group := make([]string, len(included))
+			for i, val := range included {
+				group[i] = facetEq(param, attr, val)
+			}
+			groups = append(groups, group)
 		}
 		// Excluded values: each is its own AND group so all are filtered out.
 		for _, val := range nonEmpty(v[param+"_exclude"]) {
 			groups = append(groups, []string{facetNeq(param, attr, val)})
 		}
+	}
+	if len(locationGroup) > 0 {
+		groups = append(groups, locationGroup)
 	}
 
 	if raw := v.Get("visa_sponsorship"); raw != "" {

--- a/internal/search/query_filter_test.go
+++ b/internal/search/query_filter_test.go
@@ -144,6 +144,54 @@ func TestFilterFromValues_RegionUnspecifiedSentinel(t *testing.T) {
 	}
 }
 
+func TestFilterFromValues_LocationFacetsORTogether(t *testing.T) {
+	// regions, countries and cities describe one user concept ("where"), so their
+	// included values OR into a single group instead of ANDing across facets:
+	// selecting the "Global" region and "Brazil" must widen the results
+	// (Global OR Brazil), not intersect them to zero.
+	got := normalizeGroups(t, FilterFromValues(vals("regions=global&countries=BR")))
+	want := [][]string{{`countries = "BR"`, `regions = "global"`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("regions+countries: got %v, want %v", got, want)
+	}
+
+	// Cities join the same OR group.
+	got = normalizeGroups(t, FilterFromValues(vals("regions=eu&countries=BR&cities=Berlin")))
+	want = [][]string{{`cities = "Berlin"`, `countries = "BR"`, `regions = "eu"`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("regions+countries+cities: got %v, want %v", got, want)
+	}
+
+	// A non-location facet still ANDs with the location group as its own group:
+	// "remote AND (Europe OR Brazil)".
+	got = normalizeGroups(t, FilterFromValues(vals("regions=eu&countries=BR&work_mode=remote")))
+	want = [][]string{
+		{`countries = "BR"`, `regions = "eu"`},
+		{`work_mode = "remote"`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("location OR, work_mode AND: got %v, want %v", got, want)
+	}
+
+	// The regions-unspecified sentinel also joins the location OR group.
+	got = normalizeGroups(t, FilterFromValues(vals("regions=none&countries=BR")))
+	want = [][]string{{`countries = "BR"`, `regions IS EMPTY`}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sentinel + country: got %v, want %v", got, want)
+	}
+
+	// Location excludes stay their own AND groups, independent of the include OR:
+	// "(Europe OR Brazil) AND never Russia".
+	got = normalizeGroups(t, FilterFromValues(vals("regions=eu&countries=BR&countries_exclude=RU")))
+	want = [][]string{
+		{`countries != "RU"`},
+		{`countries = "BR"`, `regions = "eu"`},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("location OR with exclude: got %v, want %v", got, want)
+	}
+}
+
 func TestFilterFromValues_PostedWithinDays(t *testing.T) {
 	// now is injected so the cutoff is deterministic. posted_within_days=N restricts
 	// to posted_ts >= now - N*86400 (posted within the last N days).


### PR DESCRIPTION
## Проблема

Выбор региона + страны в панели Location (например, Global + Brazil) давал **0 вакансий**: `regions`/`countries`/`cities` были каждый своей AND-группой, а их пересечение пусто (бразильская вакансия — это `region=latam, country=BR`, не `region=global`).

## Решение

Гео-facet'ы описывают одно понятие — «где», поэтому их included-значения теперь объединяются в **одну OR-группу**:

```
Global + Brazil + Europe  →  (regions="global" OR countries="BR" OR regions="eu")
```

Не-гео facet'ы (work_mode и т.д.) остаются отдельными AND-группами:

```
Remote + (Brazil, Europe)  →  (work_mode="remote") AND (countries="BR" OR regions="eu")
```

= удалённые вакансии в Бразилии/Европе — ровно ожидаемое поведение.

## Детали
- Исключения (`countries_exclude=RU`) остаются per-value AND: «(Europe OR Brazil) AND never Russia».
- Sentinel «Not specified» (`regions=none` → `IS EMPTY`) входит в ту же гео-OR-группу.
- `_mode=and` к географии не применяется (гео-AND бессмыслен).
- Фикс в единой `FilterFromValues` → консистентно для поиска, счётчика «Show N jobs» и матчера сохранённых подписок.

## Проверка
- Новый тест `TestFilterFromValues_LocationFacetsORTogether` покрывает все ветки.
- `go test ./internal/search/`, `go build ./...`, `gofmt` — зелёные.

Никакой миграции/reindex — это query-time логика фильтра.