### PR TITLE
feat: per-job profile-match block in the job sidebar

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -65,6 +65,7 @@ func genStructs() (string, error) {
 	bundleTS := filepath.Join(tmp, "bundle.ts")
 	verdictTS := filepath.Join(tmp, "verdict.ts")
 	atscheckTS := filepath.Join(tmp, "atscheck.ts")
+	jobmatchTS := filepath.Join(tmp, "jobmatch.ts")
 
 	cfg := &tygo.Config{
 		Packages: []*tygo.PackageConfig{
@@ -100,6 +101,12 @@ func genStructs() (string, error) {
 				OutputPath:   atscheckTS,
 				IncludeFiles: []string{"atscheck.go"},
 			},
+			{
+				// The per-job profile-match wire shape (JobMatch + AdjacentSkill).
+				Path:         "github.com/strelov1/freehire/internal/jobmatch",
+				OutputPath:   jobmatchTS,
+				IncludeFiles: []string{"jobmatch.go"},
+			},
 		},
 	}
 	if err := tygo.New(cfg).Generate(); err != nil {
@@ -126,7 +133,11 @@ func genStructs() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return enrichBody + "\n" + jobviewBody + "\n" + bundleBody + "\n" + verdictBody + "\n" + atscheckBody, nil
+	jobmatchBody, err := readBody(jobmatchTS)
+	if err != nil {
+		return "", err
+	}
+	return enrichBody + "\n" + jobviewBody + "\n" + bundleBody + "\n" + verdictBody + "\n" + atscheckBody + "\n" + jobmatchBody, nil
 }
 
 // readBody returns a tygo output file's body with its leading preamble removed, so

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -243,6 +243,8 @@ func Register(app *fiber.App, cfg Config) {
 	api.Patch("/jobs/:slug/track", keyAuth, a.TrackJob)
 	api.Delete("/jobs/:slug/stage", keyAuth, a.ClearStage)
 	api.Delete("/jobs/:slug/track", keyAuth, a.Untrack)
+	// Read-only per-job skill match against the caller's profile (no writes).
+	api.Get("/jobs/:slug/match", keyAuth, a.JobMatch)
 
 	// Moderator-authored jobs: create a hand-curated vacancy and edit it. Authenticated
 	// by cookie or API key (the CLI uses a key), then gated on the moderator role. The

--- a/internal/handler/job_match.go
+++ b/internal/handler/job_match.go
@@ -1,0 +1,29 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/jobmatch"
+)
+
+// JobMatch serves the per-job profile match: how well the open job's skills are
+// covered by the authenticated caller's profile skills (exact/adjacent/missing +
+// coverage percent). Deterministic, no LLM. Cookie or API key; an unknown slug is
+// a 404 (pgx.ErrNoRows via the central handler) and a caller without a profile is
+// a 404 (profileError). The SPA only calls this once the viewer is signed in with
+// a non-empty profile, so the not-found paths are defensive.
+func (a *API) JobMatch(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	job, err := a.queries.GetJobBySlug(c.Context(), c.Params("slug"))
+	if err != nil {
+		return err
+	}
+	profile, err := a.userProfile.Get(c.Context(), userID)
+	if err != nil {
+		return profileError(err)
+	}
+	return c.JSON(fiber.Map{"data": jobmatch.Compute(job.Skills, profile.Skills)})
+}

--- a/internal/handler/job_match_integration_test.go
+++ b/internal/handler/job_match_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+// Integration test for the per-job profile-match endpoint:
+// GET /api/v1/jobs/:slug/match must classify the job's skills against the
+// caller's profile skills (exact/adjacent/missing) and return the coverage
+// percent. Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/userprofile"
+)
+
+func TestJobMatchEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('matcher@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO user_profiles (user_id, specializations, skills)
+		 VALUES ($1, ARRAY['frontend'], ARRAY['react','typescript','gcp'])`, userID); err != nil {
+		t.Fatalf("seed profile: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, public_slug, skills)
+		 VALUES ('test', 'm1', 'http://example.test', 'Job', 'match-job',
+		         ARRAY['react','typescript','graphql','nodejs','aws'])`); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(userID)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &API{
+		pool: pool, queries: queries, issuer: iss,
+		userProfile: userprofile.New(userprofile.NewQueriesRepository(queries)),
+	}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/jobs/:slug/match", auth.RequireAuth(iss), h.JobMatch)
+
+	type adj struct {
+		Name string `json:"name"`
+		Via  string `json:"via"`
+	}
+	type matchBody struct {
+		Data struct {
+			Total           int      `json:"total"`
+			ExactCount      int      `json:"exact_count"`
+			AdjacentCount   int      `json:"adjacent_count"`
+			CoveragePercent int      `json:"coverage_percent"`
+			Matched         []string `json:"matched"`
+			Adjacent        []adj    `json:"adjacent"`
+			Missing         []string `json:"missing"`
+		} `json:"data"`
+	}
+
+	get := func(t *testing.T, slug string) (*http.Response, matchBody) {
+		t.Helper()
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/jobs/"+slug+"/match", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET match: %v", err)
+		}
+		var body matchBody
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp, body
+	}
+
+	t.Run("classifies job skills against the profile", func(t *testing.T) {
+		resp, body := get(t, "match-job")
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, b)
+		}
+		d := body.Data
+		if d.Total != 5 || d.ExactCount != 2 || d.AdjacentCount != 1 || d.CoveragePercent != 50 {
+			t.Errorf("got total=%d exact=%d adjacent=%d percent=%d, want 5/2/1/50",
+				d.Total, d.ExactCount, d.AdjacentCount, d.CoveragePercent)
+		}
+		if len(d.Adjacent) != 1 || d.Adjacent[0].Name != "aws" || d.Adjacent[0].Via != "gcp" {
+			t.Errorf("adjacent = %+v, want [{aws gcp}]", d.Adjacent)
+		}
+		if len(d.Missing) != 2 {
+			t.Errorf("missing = %v, want 2 entries", d.Missing)
+		}
+	})
+
+	t.Run("unknown slug is 404", func(t *testing.T) {
+		resp, _ := get(t, "no-such-job")
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404", resp.StatusCode)
+		}
+	})
+
+	t.Run("caller without a profile is 404", func(t *testing.T) {
+		var otherID int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (email) VALUES ('noprofile@example.test') RETURNING id`).Scan(&otherID); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+		otherToken, err := iss.Issue(otherID)
+		if err != nil {
+			t.Fatalf("issue token: %v", err)
+		}
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/jobs/match-job/match", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: otherToken})
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET match: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusNotFound {
+			t.Errorf("status = %d, want 404 (no profile)", resp.StatusCode)
+		}
+	})
+}

--- a/internal/jobmatch/jobmatch.go
+++ b/internal/jobmatch/jobmatch.go
@@ -1,0 +1,67 @@
+// Package jobmatch computes how well a single job's skills are covered by a
+// user's profile skills. It is a pure, deterministic set operation over canonical
+// skilltag slugs, plus the curated adjacency dictionary from internal/verdict — no
+// LLM, no market data. Each job skill is exact (held), adjacent (a neighbour is
+// held, naming the via skill), or missing.
+package jobmatch
+
+import (
+	"math"
+
+	"github.com/strelov1/freehire/internal/verdict"
+)
+
+// AdjacentSkill is a job skill the profile does not hold exactly but for which it
+// holds a substitutable neighbour; Via names that held neighbour.
+type AdjacentSkill struct {
+	Name string `json:"name"`
+	Via  string `json:"via"`
+}
+
+// JobMatch is the per-job match. Matched, Adjacent, and Missing preserve the job's
+// skill order within each group; CoveragePercent weighs an exact match as 1 and an
+// adjacent match as one half.
+type JobMatch struct {
+	Total           int             `json:"total"`
+	ExactCount      int             `json:"exact_count"`
+	AdjacentCount   int             `json:"adjacent_count"`
+	CoveragePercent int             `json:"coverage_percent"`
+	Matched         []string        `json:"matched"`
+	Adjacent        []AdjacentSkill `json:"adjacent"`
+	Missing         []string        `json:"missing"`
+}
+
+// Compute classifies each of jobSkills against profileSkills. Both are canonical
+// skilltag slugs. An exact hold takes precedence over an adjacency.
+func Compute(jobSkills, profileSkills []string) JobMatch {
+	held := make(map[string]bool, len(profileSkills))
+	for _, s := range profileSkills {
+		held[s] = true
+	}
+
+	// Non-nil slices so an empty result serialises as [] rather than null.
+	r := JobMatch{
+		Total:    len(jobSkills),
+		Matched:  []string{},
+		Adjacent: []AdjacentSkill{},
+		Missing:  []string{},
+	}
+
+	for _, skill := range jobSkills {
+		if held[skill] {
+			r.Matched = append(r.Matched, skill)
+		} else if via, ok := verdict.AdjacentVia(skill, held); ok {
+			r.Adjacent = append(r.Adjacent, AdjacentSkill{Name: skill, Via: via})
+		} else {
+			r.Missing = append(r.Missing, skill)
+		}
+	}
+
+	r.ExactCount = len(r.Matched)
+	r.AdjacentCount = len(r.Adjacent)
+	if r.Total > 0 {
+		weighted := float64(r.ExactCount) + 0.5*float64(r.AdjacentCount)
+		r.CoveragePercent = int(math.Round(weighted / float64(r.Total) * 100))
+	}
+	return r
+}

--- a/internal/jobmatch/jobmatch_test.go
+++ b/internal/jobmatch/jobmatch_test.go
@@ -1,0 +1,99 @@
+package jobmatch
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCompute_WorkedExample(t *testing.T) {
+	// Job wants 5 skills; profile has react, typescript exactly and gcp
+	// (a neighbour of aws). 2 exact + 1 adjacent of 5 → 50%.
+	got := Compute(
+		[]string{"react", "typescript", "graphql", "nodejs", "aws"},
+		[]string{"react", "typescript", "gcp"},
+	)
+
+	if got.Total != 5 {
+		t.Errorf("Total = %d, want 5", got.Total)
+	}
+	if got.ExactCount != 2 {
+		t.Errorf("ExactCount = %d, want 2", got.ExactCount)
+	}
+	if got.AdjacentCount != 1 {
+		t.Errorf("AdjacentCount = %d, want 1", got.AdjacentCount)
+	}
+	if got.CoveragePercent != 50 {
+		t.Errorf("CoveragePercent = %d, want 50", got.CoveragePercent)
+	}
+	if !reflect.DeepEqual(got.Matched, []string{"react", "typescript"}) {
+		t.Errorf("Matched = %v, want [react typescript]", got.Matched)
+	}
+	if !reflect.DeepEqual(got.Adjacent, []AdjacentSkill{{Name: "aws", Via: "gcp"}}) {
+		t.Errorf("Adjacent = %+v, want [{aws gcp}]", got.Adjacent)
+	}
+	if !reflect.DeepEqual(got.Missing, []string{"graphql", "nodejs"}) {
+		t.Errorf("Missing = %v, want [graphql nodejs]", got.Missing)
+	}
+}
+
+func TestCompute_ExactTakesPrecedenceOverAdjacent(t *testing.T) {
+	// Profile holds react exactly and vue (a neighbour) — react must count exact.
+	got := Compute([]string{"react"}, []string{"react", "vue"})
+	if got.ExactCount != 1 || got.AdjacentCount != 0 {
+		t.Errorf("exact=%d adjacent=%d, want exact=1 adjacent=0", got.ExactCount, got.AdjacentCount)
+	}
+	if got.CoveragePercent != 100 {
+		t.Errorf("CoveragePercent = %d, want 100", got.CoveragePercent)
+	}
+}
+
+func TestCompute_HalfWeightRounding(t *testing.T) {
+	// 0 exact, 1 adjacent (aws via gcp) of 3 → round(0.5/3*100) = round(16.67) = 17.
+	got := Compute([]string{"aws", "kafka", "rust"}, []string{"gcp"})
+	if got.ExactCount != 0 || got.AdjacentCount != 1 {
+		t.Fatalf("exact=%d adjacent=%d, want exact=0 adjacent=1", got.ExactCount, got.AdjacentCount)
+	}
+	if got.CoveragePercent != 17 {
+		t.Errorf("CoveragePercent = %d, want 17", got.CoveragePercent)
+	}
+}
+
+func TestCompute_RoundsHalfPercentAwayFromZero(t *testing.T) {
+	// 1 exact of 8 unrelated skills → 1/8 = 12.5% → round half away from zero = 13.
+	job := []string{"go", "rust", "elixir", "haskell", "scala", "clojure", "erlang", "ocaml"}
+	got := Compute(job, []string{"go"})
+	if got.ExactCount != 1 || got.AdjacentCount != 0 {
+		t.Fatalf("exact=%d adjacent=%d, want 1/0", got.ExactCount, got.AdjacentCount)
+	}
+	if got.CoveragePercent != 13 {
+		t.Errorf("CoveragePercent = %d, want 13 (round(12.5))", got.CoveragePercent)
+	}
+}
+
+func TestCompute_NoRecognisedJobSkills(t *testing.T) {
+	got := Compute(nil, []string{"go"})
+	if got.Total != 0 || got.CoveragePercent != 0 {
+		t.Errorf("Total=%d percent=%d, want 0/0", got.Total, got.CoveragePercent)
+	}
+	if len(got.Matched) != 0 || len(got.Adjacent) != 0 || len(got.Missing) != 0 {
+		t.Errorf("lists not empty: %+v", got)
+	}
+}
+
+func TestCompute_EmptyListsMarshalAsArrays(t *testing.T) {
+	// A missing-only result must serialise matched/adjacent as [] not null.
+	got := Compute([]string{"rust"}, nil)
+	b, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"matched":[]`) || !strings.Contains(s, `"adjacent":[]`) {
+		t.Errorf("json = %s, want matched/adjacent as []", s)
+	}
+	if !strings.Contains(s, `"missing":["rust"]`) {
+		t.Errorf("json = %s, want missing [rust]", s)
+	}
+}

--- a/internal/verdict/adjacent.go
+++ b/internal/verdict/adjacent.go
@@ -32,6 +32,19 @@ var adjacentTo = map[string][]string{
 	"nestjs":  {"express", "fastify"},
 }
 
+// AdjacentVia returns the first neighbour of `required` present in `held` — the
+// close skill that makes `required` count as adjacent rather than missing — or
+// ("", false) when none. `held` is a canonical skill-slug set (a flat set of the
+// caller's skills), keeping this usable outside the CV declared/body split.
+func AdjacentVia(required string, held map[string]bool) (string, bool) {
+	for _, adj := range adjacentTo[required] {
+		if held[adj] {
+			return adj, true
+		}
+	}
+	return "", false
+}
+
 // adjacentHeld returns the first neighbour of `roleSkill` that the CV holds (in
 // declared or body), or "" when none — i.e. the close skill to reframe around.
 func adjacentHeld(roleSkill string, declared, body map[string]bool) string {

--- a/internal/verdict/adjacent_test.go
+++ b/internal/verdict/adjacent_test.go
@@ -70,6 +70,33 @@ func TestCompute_AdjacentAdviceNamesCloseSkill(t *testing.T) {
 	}
 }
 
+func TestAdjacentVia(t *testing.T) {
+	held := map[string]bool{"gcp": true, "vue": true}
+
+	if via, ok := AdjacentVia("aws", held); !ok || via != "gcp" {
+		t.Errorf("AdjacentVia(aws) = (%q, %v), want (gcp, true)", via, ok)
+	}
+	if via, ok := AdjacentVia("react", held); !ok || via != "vue" {
+		t.Errorf("AdjacentVia(react) = (%q, %v), want (vue, true)", via, ok)
+	}
+	// No neighbour held.
+	if via, ok := AdjacentVia("pytorch", held); ok || via != "" {
+		t.Errorf("AdjacentVia(pytorch) = (%q, %v), want (\"\", false)", via, ok)
+	}
+	// Skill with no adjacency entry at all.
+	if via, ok := AdjacentVia("rust", held); ok || via != "" {
+		t.Errorf("AdjacentVia(rust) = (%q, %v), want (\"\", false)", via, ok)
+	}
+}
+
+func TestAdjacentVia_FirstListedNeighbourWins(t *testing.T) {
+	// aws neighbours are [gcp, azure] in listed order; hold only azure.
+	held := map[string]bool{"azure": true}
+	if via, ok := AdjacentVia("aws", held); !ok || via != "azure" {
+		t.Errorf("AdjacentVia(aws) = (%q, %v), want (azure, true)", via, ok)
+	}
+}
+
 func TestCompute_BundleRowsFromCVSkills(t *testing.T) {
 	v := Compute(Input{
 		Total: 100,

--- a/openspec/changes/job-profile-match/.openspec.yaml
+++ b/openspec/changes/job-profile-match/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/job-profile-match/design.md
+++ b/openspec/changes/job-profile-match/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The SPA already exposes both inputs needed for a per-job match on the job page: `job.skills[]` (canonical skilltag slugs, arriving with the SSR-loaded job) and the user's `profile.skills[]` (loaded once via `profileStore.ensureLoaded()` from `/api/v1/me/profile`). The existing profile "market coverage" (`internal/verdict`, `/me/profile/verdict`) is backend-computed because it needs Meilisearch market distributions — irrelevant here. For a single job the match is a set operation over two skill lists, plus the curated adjacency dictionary in `internal/verdict/adjacent.go` (react↔vue↔angular, postgresql↔mysql, aws↔gcp, pytorch↔tensorflow, …).
+
+Auth and profile state are already first-class in the SPA: `isAuthenticated()` (from `page.data.user`, SSR-safe) and the `profileStore` singleton.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Answer "how much of this job do I cover, and what's missing?" at the top of the job sidebar.
+- Deterministic, no LLM; reuse the canonical adjacency dictionary rather than duplicating it.
+- Four clear UI states (real match / guest teaser / no-profile teaser / not-enough-data) with no redundant network calls.
+
+**Non-Goals:**
+- Caching, match history, or persistence of match results.
+- Any influence on search ranking or facets.
+- LLM-based similarity or "coherence" scoring.
+- Multi-profile matching (profile is a per-user singleton).
+
+## Decisions
+
+**Compute on the backend, not the client.** Although both skill lists are already in the browser, the canonical skill vocabulary and the adjacency dictionary live in Go. Duplicating the adjacency map into TypeScript would create a second source of truth that drifts. A new `GET /api/v1/jobs/:slug/match` keeps the logic in one place and returns a typed, ready-to-render shape. *Alternative considered:* pure client-side intersection — rejected because it can't do adjacency without re-implementing the dictionary, and adjacency is a chosen feature.
+
+**Mirror the `user_jobs.go` per-user endpoint shape.** The endpoint sits behind `RequireAuthOrKey`, is addressed by `public_slug` (resolved to the internal id before the read), and returns `{"data": ...}`. This matches the existing per-user job endpoints exactly, so route wiring, auth, and error handling follow established patterns (`pgx.ErrNoRows` → 404 via the central `ErrorHandler`).
+
+**Add `adjacentVia`, keep `adjacentHeld`.** The current `adjacentHeld(required, held) bool` answers "is any neighbour held?" but not "which one". The UI hint "· у вас GCP" needs the specific neighbour, so add `adjacentVia(required string, held map[string]struct{}) (string, bool)` returning the first held neighbour. `adjacentHeld` can be expressed in terms of it or left as-is; the classification path uses `adjacentVia`. Pure and deterministic. *Alternative:* return all neighbours — rejected as YAGNI; one representative via is enough for the chip.
+
+**Percent weights adjacent at one half.** `round((exact + 0.5×adjacent)/total×100)`. Exact skills are full credit; a transferable-but-not-exact skill is partial. This drives both the headline number and the two-segment progress bar (green = exact width, amber = half-weight adjacent width). *Alternative:* adjacent as full or zero credit — half is the honest middle and matches the validated design.
+
+**Frontend gates the state; the endpoint only computes.** `JobMatch.svelte` decides which of the four states to render from data it already has — `job.skills` (SSR), `isAuthenticated()`, and `profileStore` — and only calls the endpoint in the real-match state. The guest and no-profile teasers use static, non-real figures behind a light blur, so no data leaks and no wasted request. This keeps the endpoint single-purpose (assume an authenticated caller with a profile) and the UI logic co-located.
+
+**Generate the TS type via `cmd/gen-contracts`.** The Go response struct is the source of truth; the SPA consumes the generated `contracts.ts` type, consistent with the rest of the codebase.
+
+## Risks / Trade-offs
+
+- **Adjacency dictionary is curated and incomplete** → the amber "Близкие" group only reflects known neighbour pairs; unknown transferable skills fall to "Не хватает". Acceptable: the same curated-dictionary trade-off as the rest of the skill tooling; it never guesses.
+- **Job skills vs profile skills vocabulary mismatch** → both are canonical skilltag slugs produced by the same `internal/skilltag` dictionary, so they compare directly; no normalization step needed. Guard with a test that compares real slugs.
+- **Guest teaser shows a static 76%** → could be mistaken for a real score. Mitigation: the light blur + lock affordance and CTA make the "sign in to see yours" intent clear; the figure is fixed demo content.
+- **Extra `/me/profile` fetch on the job page** → the match component triggers `profileStore.ensureLoaded()`; this is a one-time cached fetch already used elsewhere, and only for authenticated viewers.
+
+## Migration Plan
+
+Additive only — a new endpoint, a new component, one insertion into `JobView.svelte`, and a regenerated contract. No schema changes, no data migration. Rollback is removing the route wiring and the component insertion. Deploy backend (endpoint) before or with the frontend; the SPA degrades gracefully if the endpoint 404s (the real-match state simply fails to load, other states are unaffected).

--- a/openspec/changes/job-profile-match/proposal.md
+++ b/openspec/changes/job-profile-match/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+A signed-in user browsing a job has no immediate signal of how well it fits their own skills — they must eyeball the job's skill tags against what they know. The profile already has a "market coverage" view, but nothing answers the concrete question on the job page: *"how much of THIS job do I already cover, and what am I missing?"* A per-job match block turns the sidebar into a personal fit signal and a nudge to complete the profile.
+
+## What Changes
+
+- **New backend endpoint** `GET /api/v1/jobs/:slug/match` (behind `RequireAuthOrKey`, slug-addressed, mirroring the per-user endpoints in `user_jobs.go`). It classifies each of the job's skills against the caller's profile skills as **exact**, **adjacent**, or **missing**, and returns a coverage percent. Deterministic — **no LLM**.
+- **Adjacency helper** — add `adjacentVia(required, held) → (via, ok)` to `internal/verdict/adjacent.go` alongside the existing `adjacentHeld`, so the response can name *which* held skill made a job skill count as adjacent (e.g. job wants `aws`, you have `gcp`).
+- **New TS contract type** for the match response, generated via `cmd/gen-contracts`.
+- **New frontend component** `JobMatch.svelte`, placed at the **top of the `JobView.svelte` sidebar**, with four states: not-enough-data, guest teaser (blurred + "Войти"), no-profile teaser (blurred + "Загрузить CV"), and the real match block (percent + two-colour progress bar + three chip groups: Есть / Близкие / Не хватает).
+
+## Capabilities
+
+### New Capabilities
+- `job-profile-match`: The per-job skill-coverage match between an open job and the signed-in user's profile — endpoint, classification rules (exact/adjacent/missing), coverage-percent formula, and the sidebar block with its authed/guest/no-profile/empty states.
+
+### Modified Capabilities
+<!-- None: the adjacency helper and gen-contracts changes are implementation details of the new capability; no existing spec's requirements change. -->
+
+## Impact
+
+- **API**: new `GET /api/v1/jobs/:slug/match`.
+- **Backend code**: new handler (`internal/handler/`), a small addition to `internal/verdict/adjacent.go`, route wiring in `handler.Register`, and a generated contract type.
+- **Frontend**: new `web/src/lib/components/JobMatch.svelte`, one insertion into `JobView.svelte`, a new `api.ts` call, and the regenerated `contracts.ts`. Reuses existing `isAuthenticated()` and `profileStore`.
+- **Out of scope (YAGNI)**: caching, match history, any influence on search/facets, and any LLM involvement.

--- a/openspec/changes/job-profile-match/specs/job-profile-match/spec.md
+++ b/openspec/changes/job-profile-match/specs/job-profile-match/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Per-job match endpoint
+
+The system SHALL expose `GET /api/v1/jobs/:slug/match` behind `RequireAuthOrKey` (session cookie or API key), addressed by a job's public slug. It SHALL classify each skill of the open job against the caller's profile skills and return the classification plus a coverage percent in the standard `{"data": ...}` envelope. The computation SHALL be deterministic and MUST NOT call an LLM.
+
+#### Scenario: Authenticated caller with a profile
+
+- **WHEN** an authenticated caller requests the match for a job whose skills are `[react, typescript, graphql, nodejs, aws]` and their profile skills are `[react, typescript, gcp]`
+- **THEN** the response `data` reports `total: 5`, `exact_count: 2` (`react`, `typescript`), `adjacent_count: 1` (`aws` via `gcp`), the `missing` list `[graphql, nodejs]`, and `coverage_percent: 50`
+
+#### Scenario: Unauthenticated caller
+
+- **WHEN** a caller without a valid session cookie or API key requests the match endpoint
+- **THEN** the system SHALL respond `401` and MUST NOT return any match data
+
+#### Scenario: Unknown job slug
+
+- **WHEN** an authenticated caller requests the match for a slug that resolves to no job
+- **THEN** the system SHALL respond `404`
+
+### Requirement: Skill classification and coverage formula
+
+Each job skill SHALL be classified as **exact** when the profile contains that canonical skill, else **adjacent** when the profile contains a neighbour of it per the curated adjacency dictionary (`internal/verdict/adjacent.go`), else **missing**. An adjacent classification SHALL carry the `via` skill — the specific held neighbour that satisfied it. Coverage percent SHALL be `round((exact_count + 0.5 × adjacent_count) / total × 100)`, where an exact match weighs 1 and an adjacent match weighs one half.
+
+#### Scenario: Exact takes precedence over adjacent
+
+- **WHEN** a job skill is present exactly in the profile and also has a held neighbour
+- **THEN** it SHALL be classified `exact`, not `adjacent`
+
+#### Scenario: Adjacent names its via skill
+
+- **WHEN** a job requires `aws`, the profile lacks `aws` but holds `gcp`, and the dictionary treats them as neighbours
+- **THEN** `aws` SHALL be classified `adjacent` with `via: "gcp"`
+
+#### Scenario: Percent rounds half-weighted adjacents
+
+- **WHEN** a job has 5 skills with 2 exact and 1 adjacent
+- **THEN** `coverage_percent` SHALL be `50` (`round((2 + 0.5) / 5 × 100)`)
+
+#### Scenario: Job with no recognised skills
+
+- **WHEN** the job's skill list is empty
+- **THEN** the endpoint SHALL report `total: 0` with empty `matched`, `adjacent`, and `missing` lists, and the sidebar SHALL render a "not enough data" state rather than a match block
+
+### Requirement: Match response contract
+
+The match response `data` SHALL contain `total`, `exact_count`, `adjacent_count`, `coverage_percent`, `matched` (list of skill names), `adjacent` (list of `{name, via}`), and `missing` (list of skill names). A corresponding TypeScript type SHALL be generated via `cmd/gen-contracts` so the SPA consumes a typed shape.
+
+#### Scenario: Response envelope shape
+
+- **WHEN** the endpoint returns a successful match
+- **THEN** the body SHALL be `{"data": {total, exact_count, adjacent_count, coverage_percent, matched, adjacent, missing}}` with `adjacent` entries carrying both `name` and `via`
+
+### Requirement: Sidebar match block states
+
+The job-detail sidebar SHALL render a match block at its top with exactly four mutually exclusive states, choosing the state without redundant network calls. The guest and no-profile states SHALL show a lightly-blurred teaser (static, non-real figures) with a single footer call-to-action, and MUST NOT call the match endpoint.
+
+#### Scenario: Not-enough-data state
+
+- **WHEN** the open job has no recognised skills
+- **THEN** the block SHALL show a "not enough data" card and SHALL NOT call the match endpoint
+
+#### Scenario: Guest state
+
+- **WHEN** the viewer is not authenticated and the job has skills
+- **THEN** the block SHALL show a lightly-blurred teaser with a static percentage and a footer "Войти" button, and SHALL NOT call the match endpoint
+
+#### Scenario: No-profile state
+
+- **WHEN** the viewer is authenticated but has no profile or an empty profile skill list
+- **THEN** the block SHALL show a lightly-blurred teaser with a footer "Загрузить CV" button, and SHALL NOT call the match endpoint
+
+#### Scenario: Real match state
+
+- **WHEN** the viewer is authenticated with a non-empty profile skill list and the job has skills
+- **THEN** the block SHALL call the match endpoint and render the percentage, a two-colour progress bar (exact segment plus a half-weight adjacent segment), and three chip groups — Есть (exact), Близкие (adjacent, each hinting its `via` skill), and Не хватает (missing)

--- a/openspec/changes/job-profile-match/tasks.md
+++ b/openspec/changes/job-profile-match/tasks.md
@@ -1,0 +1,34 @@
+## 1. Adjacency helper
+
+- [x] 1.1 Add `AdjacentVia(required string, held map[string]bool) (string, bool)` to `internal/verdict/adjacent.go`, returning the first held neighbour of `required` per the curated dictionary; `adjacentHeld` left as-is (neighbour-order semantics differ). Unit tests: known pair returns via, no neighbour returns `("", false)`, no-adjacency-entry case, first-listed-neighbour-wins.
+
+## 2. Match computation (pure)
+
+- [x] 2.1 Add a pure `Compute(jobSkills, profileSkills []string) Result` in a small package (`internal/jobmatch`) that classifies each job skill as exact / adjacent (with `via`) / missing and computes `coverage_percent = round((exact + 0.5×adjacent)/total×100)`. Exact takes precedence over adjacent. Unit tests: the 5-skill worked example (2 exact, 1 adjacent, 50%), precedence, half-weight rounding, `total=0` → zeroed result with empty lists.
+
+## 3. Endpoint
+
+- [x] 3.1 Define the response struct (`total`, `exact_count`, `adjacent_count`, `coverage_percent`, `matched []string`, `adjacent []{name,via}`, `missing []string`) and add a handler `JobMatch` in `internal/handler/` that resolves the job by `public_slug`, loads the caller's profile skills, runs `jobmatch.Compute`, and returns `{"data": ...}`. Unknown slug → `pgx.ErrNoRows` (central handler → 404).
+- [x] 3.2 Wire `GET /api/v1/jobs/:slug/match` behind `RequireAuthOrKey` in `handler.Register`.
+- [x] 3.3 Handler integration test (`//go:build integration`): authed caller gets the expected classification/percent; unknown slug → 404. (Auth-missing → 401 is covered by the middleware.)
+
+## 4. Contract generation
+
+- [x] 4.1 Run `cmd/gen-contracts` and commit the regenerated `web/src/lib/generated/contracts.ts` so the match response type is available to the SPA.
+
+## 5. Frontend data access
+
+- [x] 5.1 Add a `getJobMatch(slug)` call in `web/src/lib/api.ts` returning the generated match type.
+
+## 6. Sidebar component
+
+- [x] 6.1 Create `web/src/lib/components/JobMatch.svelte` implementing the four states: not-enough-data (empty `job.skills`), guest teaser (blurred, static figures, footer "Войти", no API call), no-profile teaser (blurred, footer "Загрузить CV", no API call), and real match (fetch via `getJobMatch`, render percent + two-colour progress bar + three chip groups Есть/Близкие/Не хватает with `via` hint). State chosen from `job.skills`, `isAuthenticated()`, and `profileStore.ensureLoaded()` without redundant calls. Use inline SVG for lock/document icons and the app's colour tokens.
+- [x] 6.2 Extract and unit-test (vitest) any pure formatting/state-selection logic used by the component (e.g. state resolver given auth/profile/skills, progress-bar segment widths).
+
+## 7. Integration into job page
+
+- [x] 7.1 Insert `<JobMatch>` at the top of the `JobView.svelte` sidebar (above salary/metadata), passing `job` (and slug). Verify with `svelte-check` and a visual check across the four states.
+
+## 8. Verify
+
+- [x] 8.1 `go build ./... && go vet ./... && go test ./...`; run the handler integration test; `svelte-check` clean. Confirm the four states render correctly against a running app.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -34,6 +34,7 @@ import type {
   ReportInput,
   Verdict,
   ATSResponse,
+  JobMatch,
 } from './types';
 
 /** A page of list items, optionally the total matching the query (endpoints that
@@ -140,6 +141,15 @@ export function createApi(
    *  renders them; the source job is excluded by the backend. */
   async function getSimilarJobs(slug: string): Promise<Job[]> {
     const body = await request<{ data: Job[] }>(`/api/v1/jobs/${slug}/similar`);
+    return body.data;
+  }
+
+  /** How well the job addressed by `slug` is covered by the caller's profile skills:
+   *  each job skill classified exact/adjacent/missing plus a coverage percent.
+   *  Requires a signed-in caller with a profile (404 otherwise); the sidebar only
+   *  calls it in that state. */
+  async function getJobMatch(slug: string): Promise<JobMatch> {
+    const body = await request<{ data: JobMatch }>(`/api/v1/jobs/${slug}/match`);
     return body.data;
   }
 
@@ -681,6 +691,7 @@ export function createApi(
     listJobs,
     getJob,
     getSimilarJobs,
+    getJobMatch,
     searchJobs,
     swipeDeck,
     facetCounts,
@@ -756,6 +767,7 @@ export const {
   listJobs,
   getJob,
   getSimilarJobs,
+  getJobMatch,
   searchJobs,
   swipeDeck,
   facetCounts,

--- a/web/src/lib/components/JobMatch.svelte
+++ b/web/src/lib/components/JobMatch.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { resolve } from '$app/paths';
+  import { FileText, Lock } from '@lucide/svelte';
+  import { getJobMatch } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
+  import { resolveMatchState, matchBarSegments } from '$lib/jobMatch';
+  import { profileStore } from '$lib/profile.svelte';
+  import type { Job, JobMatch } from '$lib/types';
+  import { Button } from '$lib/ui';
+
+  // The job is server-rendered; only this personal signal hydrates client-side.
+  let { job }: { job: Job } = $props();
+
+  // The fetched match — set only in the `ready` state. Read by the template/segments
+  // but never by `state`, so setting it can't re-trigger the fetch effect below.
+  let match = $state.raw<JobMatch | null>(null);
+
+  // One-time profile load for signed-in viewers (SSR-safe no-op otherwise); the
+  // block resolves to `loading` until it settles so the CTA doesn't flash.
+  $effect(() => {
+    if (browser && isAuthenticated()) profileStore.ensureLoaded();
+  });
+
+  const blockState = $derived(
+    resolveMatchState({
+      jobSkills: job.skills ?? [],
+      authenticated: isAuthenticated(),
+      profileLoaded: profileStore.loaded,
+      profileSkills: profileStore.profile?.skills,
+    }),
+  );
+
+  // Fetch the real match only when ready; re-fetch on navigation to another job.
+  $effect(() => {
+    const slug = job.public_slug; // track the current job
+    match = null;
+    if (!browser || blockState !== 'ready') return;
+    getJobMatch(slug)
+      .then((m) => {
+        if (job.public_slug === slug) match = m;
+      })
+      .catch(() => {});
+  });
+
+  const segments = $derived(match ? matchBarSegments(match) : { exact: 0, adjacent: 0 });
+
+  // Static teaser for the locked states — deliberately not a real score.
+  const teaser = { percent: 76, have: ['React', 'Docker', 'SQL'], missing: ['Kafka'] };
+
+  const chip = 'rounded-full border px-2 py-0.5 text-xs font-medium';
+  const haveChip = `${chip} border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400`;
+  const adjChip = `${chip} border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-500`;
+  const missChip = `${chip} border-destructive/30 bg-destructive/10 text-destructive`;
+
+  const profileHref = resolve('/my/profile');
+</script>
+
+<section
+  class="flex flex-col gap-3 border-t border-border pt-4 first:border-t-0 first:pt-0"
+  aria-label="Profile match"
+>
+  <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Profile match</p>
+
+  {#if blockState === 'no-skills'}
+    <p class="text-sm text-muted-foreground">Not enough data to compare this job to your profile.</p>
+  {:else if blockState === 'guest' || blockState === 'no-profile'}
+    <!-- Locked teaser: lightly-blurred static content (not a real score) + a footer CTA. -->
+    <div class="pointer-events-none select-none space-y-3 opacity-90 blur-[1.5px]" aria-hidden="true">
+      <div class="flex items-baseline justify-between gap-2">
+        <span class="text-2xl font-bold tabular-nums leading-none">{teaser.percent}%</span>
+        <span class="text-xs text-muted-foreground">4 of 5 skills</span>
+      </div>
+      <div class="flex h-2 overflow-hidden rounded bg-secondary">
+        <div class="h-full bg-emerald-500" style="width: {teaser.percent}%"></div>
+      </div>
+      <div class="flex flex-wrap gap-1.5">
+        {#each teaser.have as skill (skill)}<span class={haveChip}>{skill}</span>{/each}
+        {#each teaser.missing as skill (skill)}<span class={missChip}>{skill}</span>{/each}
+      </div>
+    </div>
+    <div class="flex items-center justify-between gap-2 border-t border-dashed border-border pt-3">
+      {#if blockState === 'guest'}
+        <span class="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Lock class="size-3.5 shrink-0" />Sign in to see your match
+        </span>
+        <Button variant="primary" size="sm" onclick={() => openAuthDialog('login')}>Sign in</Button>
+      {:else}
+        <span class="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <FileText class="size-3.5 shrink-0" />Add your skills or upload a CV
+        </span>
+        <Button variant="primary" size="sm" href={profileHref}>Upload CV</Button>
+      {/if}
+    </div>
+  {:else if blockState === 'ready' && match}
+    <!-- Real match: percent + two-colour bar + three skill groups. -->
+    <div class="flex items-baseline justify-between gap-2">
+      <span class="text-2xl font-bold tabular-nums leading-none">{match.coverage_percent}%</span>
+      <span class="text-xs text-muted-foreground">
+        {match.exact_count} of {match.total} skills{#if match.adjacent_count}
+          · {match.adjacent_count} close{/if}
+      </span>
+    </div>
+    <div class="flex h-2 overflow-hidden rounded bg-secondary">
+      <div class="h-full bg-emerald-500 transition-all" style="width: {segments.exact}%"></div>
+      <div class="h-full bg-amber-500 transition-all" style="width: {segments.adjacent}%"></div>
+    </div>
+
+    {#if match.matched.length}
+      <div class="flex flex-col gap-1.5">
+        <span class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <span class="size-1.5 rounded-full bg-emerald-500"></span>You have
+        </span>
+        <div class="flex flex-wrap gap-1.5">
+          {#each match.matched as skill (skill)}<span class={haveChip}>{skill}</span>{/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if match.adjacent.length}
+      <div class="flex flex-col gap-1.5">
+        <span class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <span class="size-1.5 rounded-full bg-amber-500"></span>Close — you have a related skill
+        </span>
+        <div class="flex flex-wrap gap-1.5">
+          {#each match.adjacent as a (a.name)}
+            <span class={adjChip}>{a.name} <span class="opacity-70">· you have {a.via}</span></span>
+          {/each}
+        </div>
+      </div>
+    {/if}
+
+    {#if match.missing.length}
+      <div class="flex flex-col gap-1.5">
+        <span class="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <span class="size-1.5 rounded-full bg-destructive"></span>Missing
+        </span>
+        <div class="flex flex-wrap gap-1.5">
+          {#each match.missing as skill (skill)}<span class={missChip}>{skill}</span>{/each}
+        </div>
+      </div>
+    {/if}
+  {:else}
+    <!-- Skeleton: the profile is still loading, or the match is in flight (ready but
+         not yet fetched). A signed-in profiled viewer never sees the locked teaser. -->
+    <div class="h-2 animate-pulse rounded bg-secondary"></div>
+    <div class="flex gap-1.5">
+      <div class="h-5 w-14 animate-pulse rounded-full bg-secondary"></div>
+      <div class="h-5 w-16 animate-pulse rounded-full bg-secondary"></div>
+    </div>
+  {/if}
+</section>

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -11,6 +11,7 @@
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
+  import JobMatch from './JobMatch.svelte';
   import ReportDialog from './ReportDialog.svelte';
 
   // The job is server-rendered: it arrives as a prop from the route's `load`, so
@@ -200,6 +201,8 @@
 
   <aside class="w-full shrink-0 lg:col-start-1 lg:row-span-3 lg:row-start-1">
     <div class="sticky top-6 flex flex-col gap-4 rounded-xl border border-border bg-card p-4">
+      <JobMatch {job} />
+
       {#if salary}
         <p
           class="border-t border-border pt-4 text-xl font-semibold tabular-nums tracking-tight first:border-t-0 first:pt-0"

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -271,7 +271,30 @@ export interface Report {
   suggestions?: string[];
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'breezy', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'icims', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'paylocity', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamtailor', 'tecla', 'thehub', 'traffit', 'trakstar', 'ukg', 'vention', 'vouch', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+/**
+ * AdjacentSkill is a job skill the profile does not hold exactly but for which it
+ * holds a substitutable neighbour; Via names that held neighbour.
+ */
+export interface AdjacentSkill {
+  name: string;
+  via: string;
+}
+/**
+ * JobMatch is the per-job match. Matched, Adjacent, and Missing preserve the job's
+ * skill order within each group; CoveragePercent weighs an exact match as 1 and an
+ * adjacent match as one half.
+ */
+export interface JobMatch {
+  total: number /* int */;
+  exact_count: number /* int */;
+  adjacent_count: number /* int */;
+  coverage_percent: number /* int */;
+  matched: string[];
+  adjacent: AdjacentSkill[];
+  missing: string[];
+}
+
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'icims', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'paylocity', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamtailor', 'tecla', 'thehub', 'traffit', 'trakstar', 'ukg', 'vention', 'vouch', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];

--- a/web/src/lib/jobMatch.test.ts
+++ b/web/src/lib/jobMatch.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { resolveMatchState, matchBarSegments } from './jobMatch';
+
+describe('resolveMatchState', () => {
+  const base = { jobSkills: ['go'], authenticated: true, profileLoaded: true, profileSkills: ['go'] };
+
+  it('is "no-skills" when the job has no recognised skills (regardless of auth)', () => {
+    expect(resolveMatchState({ ...base, jobSkills: [] })).toBe('no-skills');
+    expect(resolveMatchState({ ...base, jobSkills: [], authenticated: false })).toBe('no-skills');
+  });
+
+  it('is "guest" when not authenticated and the job has skills', () => {
+    expect(resolveMatchState({ ...base, authenticated: false })).toBe('guest');
+  });
+
+  it('is "loading" when authenticated but the profile has not loaded yet', () => {
+    expect(resolveMatchState({ ...base, profileLoaded: false, profileSkills: null })).toBe('loading');
+  });
+
+  it('is "no-profile" when authenticated, loaded, but no profile skills', () => {
+    expect(resolveMatchState({ ...base, profileSkills: null })).toBe('no-profile');
+    expect(resolveMatchState({ ...base, profileSkills: [] })).toBe('no-profile');
+  });
+
+  it('is "ready" when authenticated with a non-empty profile and a skilled job', () => {
+    expect(resolveMatchState(base)).toBe('ready');
+  });
+});
+
+describe('matchBarSegments', () => {
+  it('splits the bar into a full-weight exact segment and a half-weight adjacent segment', () => {
+    // 2 exact + 1 adjacent of 5 → exact 40%, adjacent 10% (0.5*1/5).
+    expect(matchBarSegments({ total: 5, exact_count: 2, adjacent_count: 1 })).toEqual({
+      exact: 40,
+      adjacent: 10,
+    });
+  });
+
+  it('returns zeros when total is 0', () => {
+    expect(matchBarSegments({ total: 0, exact_count: 0, adjacent_count: 0 })).toEqual({
+      exact: 0,
+      adjacent: 0,
+    });
+  });
+});

--- a/web/src/lib/jobMatch.ts
+++ b/web/src/lib/jobMatch.ts
@@ -1,0 +1,38 @@
+// Pure presentation logic for the sidebar job-profile-match block. Kept out of the
+// component so it is unit-testable (vitest) without a DOM: which of the four block
+// states to render, and how to size the two-colour progress bar.
+
+/** Which state the match block renders. `loading` is the brief window while an
+ *  authenticated viewer's profile is still being fetched — shown before we know
+ *  whether it is `no-profile` or `ready`, so the CTA doesn't flash. */
+export type MatchState = 'no-skills' | 'guest' | 'loading' | 'no-profile' | 'ready';
+
+/** Resolve the block state from what the page already knows. `no-skills` wins over
+ *  everything (nothing personal to show), then the auth gate, then the profile gate. */
+export function resolveMatchState(input: {
+  jobSkills: string[];
+  authenticated: boolean;
+  profileLoaded: boolean;
+  profileSkills: string[] | null | undefined;
+}): MatchState {
+  if (input.jobSkills.length === 0) return 'no-skills';
+  if (!input.authenticated) return 'guest';
+  if (!input.profileLoaded) return 'loading';
+  if (!input.profileSkills || input.profileSkills.length === 0) return 'no-profile';
+  return 'ready';
+}
+
+/** The two progress-bar segment widths (in percent of the track): a full-weight
+ *  green segment for exact matches and a half-weight amber segment for adjacent
+ *  ones. Their sum is the (unrounded) coverage percent. */
+export function matchBarSegments(m: {
+  total: number;
+  exact_count: number;
+  adjacent_count: number;
+}): { exact: number; adjacent: number } {
+  if (m.total <= 0) return { exact: 0, adjacent: 0 };
+  return {
+    exact: (m.exact_count / m.total) * 100,
+    adjacent: ((0.5 * m.adjacent_count) / m.total) * 100,
+  };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -3,6 +3,8 @@
 
 import type { Job, Report as ATSReportContract } from './generated/contracts';
 export type { Job, Enrichment, Verdict, Gap, SkillRow } from './generated/contracts';
+// Per-job profile match (how well a job's skills are covered by the caller's profile).
+export type { JobMatch, AdjacentSkill } from './generated/contracts';
 // atscheck's Report is aliased ATSReport (a local Report — job reports — already exists);
 // its category/line-item shapes come along for the report view.
 export type {


### PR DESCRIPTION
## Summary
Adds a per-job **profile match** to the job-detail sidebar: how well an open job's skills are covered by the signed-in user's profile skills.

- **Backend:** new `GET /api/v1/jobs/:slug/match` (behind `RequireAuthOrKey`) classifies each job skill as **exact** / **adjacent** (via a held neighbour) / **missing** and returns a coverage percent (`round((exact + 0.5·adjacent)/total·100)`). Deterministic, **no LLM** — reuses the curated adjacency dictionary via a new `verdict.AdjacentVia` and a pure `internal/jobmatch.Compute`.
- **Contracts:** `JobMatch`/`AdjacentSkill` TS types generated via `cmd/gen-contracts`.
- **Frontend:** `JobMatch.svelte` at the top of the `JobView` sidebar with four states — real match (percent + two-colour bar + Have/Close/Missing chip groups), a lightly-blurred **Sign in** teaser for guests, an **Upload CV** teaser when the profile is empty, and a not-enough-data card when the job has no skills. State resolves from data the page already has; the endpoint is called only in the ready state.

## Design
Validated up front via visual mockups (bar + chips layout, light-blur teaser with footer CTA). App theme is monochrome shadcn: green = exact, amber = adjacent, red/destructive = missing.

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...`
- [x] Handler integration test (`-tags=integration`): happy-path classification/percent, unknown-slug → 404, no-profile → 404
- [x] Unit tests: `verdict.AdjacentVia`, `jobmatch.Compute` (precedence, half-weight rounding, total=0), vitest for the pure state/bar logic (7)
- [x] `svelte-check` clean, eslint/oxlint clean
- [x] Visual check (headless): guest teaser + not-enough-data states render per the mockup

## Follow-up
- OpenSpec change `job-profile-match` is included as active; run `/opsx:archive` + `/opsx:sync` after merge to fold the delta into the canonical specs.