### PR TITLE
feat(sources): add Jalasoft, Gigabrands, Bydrec, Step Up Team boards

### DIFF
--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3563,3 +3563,5 @@
   board: zoe-financial
 - company: ZwitterCo
   board: zwitterco
+- company: Step Up Team
+  board: step-up-team

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -7689,3 +7689,5 @@
   board: zulaykitchen
 - company: ZymoChem
   board: zymochem
+- company: Bydrec
+  board: bydrec

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1076,3 +1076,7 @@
   board: foodics
 - company: Salla
   board: salla
+- company: Jalasoft
+  board: jalasoft
+- company: Gigabrands
+  board: gigabrands


### PR DESCRIPTION
Adds four validated ATS boards that surface remote LATAM engineering roles requested for coverage.

## Boards added
| Provider | Company | Board id | Validation |
|---|---|---|---|
| workable | Jalasoft | `jalasoft` | widget API → 80 jobs (incl. *AI/ML Engineer: Agentic Workflows*) |
| workable | Gigabrands | `gigabrands` | widget API → 50 jobs (incl. *Automation AI Engineer*) |
| jazzhr | Bydrec | `bydrec` | bydrec.applytojob.com/apply → 6 jobs (incl. *Senior Full Stack Engineer - Remote LATAM*) |
| breezy | Step Up Team | `step-up-team` | step-up-team.breezy.hr/json → live |

Each board id was validated live against its adapter's endpoint before adding.

## Not included
- **Unpack Holdings Limited** — posts only on the jobs.workable.com *marketplace* (no `linkoutUrl`, no widget account, placeholder website). Our workable adapter crawls widget accounts only, so it's unreachable without a new marketplace adapter.
- **Visa (Brazil, REF080651W)** — company already crawled via workday, but the Brazil posting isn't in the ingested slice (we get PL via justjoin + IN via workday). Separate adapter/config investigation, not a board add.

## Verification
- `python3 yaml.safe_load` parses all three files (539 / 1782 / 3846 entries)
- `go build ./...` ok
- `go test ./internal/sources/` ok