### PR TITLE
feat(sources): add Unpack Holdings Limited workable board

### DIFF
--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1080,3 +1080,5 @@
   board: jalasoft
 - company: Gigabrands
   board: gigabrands
+- company: Unpack Holdings Limited
+  board: unpack-holdings-limited


### PR DESCRIPTION
Follow-up to #449. Unpack Holdings Limited **is** reachable via the workable widget API under board `unpack-holdings-limited` (66 jobs) — the earlier probe only missed the full-name slug. Adds it so its Sr. Backend Engineer (Golang) and other roles keep ingesting.

Validated: `apply.workable.com/api/v1/widget/accounts/unpack-holdings-limited?details=true` → 66 jobs; targeted ingest on host-2 collected 66 (closed 0 stale). `yaml.safe_load` parses.