### PR TITLE
fix(ingest): scope stale-job sweep to companies crawled this run

### DIFF
--- a/cmd/ingest/crawled.go
+++ b/cmd/ingest/crawled.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"sort"
+	"sync"
+)
+
+// crawledSet records, per provider, the distinct company slugs a run actually wrote.
+// The post-run stale sweep scopes its closes to these slugs so a partial or targeted
+// run (a subset of a provider's boards) only closes jobs of the companies it crawled,
+// never the provider's whole catalogue. Safe for concurrent Save calls (boards run in
+// parallel goroutines).
+type crawledSet struct {
+	mu sync.Mutex
+	m  map[string]map[string]struct{} // provider -> set of company slugs
+}
+
+func newCrawledSet() *crawledSet {
+	return &crawledSet{m: make(map[string]map[string]struct{})}
+}
+
+// record notes that this run wrote a job for (provider, slug). An empty slug is ignored:
+// a job with no company can't be safely scope-closed, so it never joins the crawled set.
+func (c *crawledSet) record(provider, slug string) {
+	if slug == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	set, ok := c.m[provider]
+	if !ok {
+		set = make(map[string]struct{})
+		c.m[provider] = set
+	}
+	set[slug] = struct{}{}
+}
+
+// slugs returns the provider's crawled company slugs, sorted for a deterministic sweep.
+func (c *crawledSet) slugs(provider string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	set := c.m[provider]
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/ingest/crawled_test.go
+++ b/cmd/ingest/crawled_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"slices"
+	"sync"
+	"testing"
+)
+
+func TestCrawledSetRecordsDistinctSlugsPerProvider(t *testing.T) {
+	c := newCrawledSet()
+	c.record("workable", "jalasoft")
+	c.record("workable", "gigabrands")
+	c.record("workable", "jalasoft") // duplicate collapses
+	c.record("workable", "")         // empty slug is ignored (can't scope to it)
+	c.record("greenhouse", "arena-im")
+
+	if got, want := c.slugs("workable"), []string{"gigabrands", "jalasoft"}; !slices.Equal(got, want) {
+		t.Errorf("slugs(workable) = %v, want %v (sorted, deduped, no empty)", got, want)
+	}
+	if got, want := c.slugs("greenhouse"), []string{"arena-im"}; !slices.Equal(got, want) {
+		t.Errorf("slugs(greenhouse) = %v, want %v", got, want)
+	}
+	if got := c.slugs("lever"); len(got) != 0 {
+		t.Errorf("slugs(untouched provider) = %v, want empty", got)
+	}
+}
+
+func TestCrawledSetConcurrentRecord(t *testing.T) {
+	c := newCrawledSet()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.record("workable", "acme")
+		}()
+	}
+	wg.Wait()
+	if got, want := c.slugs("workable"), []string{"acme"}; !slices.Equal(got, want) {
+		t.Errorf("slugs after concurrent record = %v, want %v", got, want)
+	}
+}

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -85,9 +85,12 @@ func run() int {
 		storeIndexer = indexer
 	}
 
+	// crawled records the company slugs each provider actually wrote this run, so the
+	// post-run sweep scopes its closes to them (see the sweep below and crawledSet).
+	crawled := newCrawledSet()
 	runner := pipeline.Runner{
 		Registry: registry,
-		Store:    newDBStore(pool, enrich.Version, storeIndexer),
+		Store:    newDBStore(pool, enrich.Version, storeIndexer, crawled),
 	}
 
 	runStats, err := runner.Run(ctx, sourceCfg.Sources)
@@ -113,10 +116,13 @@ func run() int {
 	failed := total.Failed
 
 	// Post-run sweep (job-lifecycle spec): per provider, close that provider's open jobs
-	// unseen for the whole grace window. Scoped per provider so one provider's run never
-	// closes another's jobs, and guarded per provider (only those that ingested at least
-	// one job) so a total crawl outage for one provider cannot mass-close its catalogue —
-	// even when several providers share one run (e.g. custom.yml).
+	// unseen for the whole grace window — but only for the companies this run actually
+	// crawled (crawled.slugs). Scoped per provider so one provider's run never closes
+	// another's jobs; guarded per provider (only those that ingested at least one job) so
+	// a total crawl outage cannot mass-close a catalogue; and scoped per company so a
+	// PARTIAL run (a subset of a provider's boards — a targeted run, or a full crawl of a
+	// huge provider that timed out mid-way) closes only what it saw, never the boards it
+	// never reached.
 	queries := db.New(pool)
 	cutoff := pgtype.Timestamptz{Time: time.Now().Add(-staleAfter), Valid: true}
 	// A self-closing source (e.g. jobtech) manages its own closes from its stream, so the
@@ -131,8 +137,9 @@ func run() int {
 			continue
 		}
 		closed, err := queries.CloseUnseenJobs(ctx, db.CloseUnseenJobsParams{
-			Source: provider,
-			Cutoff: cutoff,
+			Source:       provider,
+			Cutoff:       cutoff,
+			CompanySlugs: crawled.slugs(provider),
 		})
 		if err != nil {
 			// Count and continue: one provider's sweep failure must not skip the rest,

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -123,6 +123,13 @@ func run() int {
 	// PARTIAL run (a subset of a provider's boards — a targeted run, or a full crawl of a
 	// huge provider that timed out mid-way) closes only what it saw, never the boards it
 	// never reached.
+	//
+	// Trade-off (deliberate under-close): a company is swept only when the run wrote a job
+	// for it, so a board that fetched but returned zero postings, or a company removed from
+	// the board file, is NOT retired here — its open jobs leak until a later crawl reopens
+	// or closes them. Board sources have no liveness backstop (the liveness probe skips
+	// registered providers), so this is accepted to avoid the far worse over-close: closing
+	// live jobs of boards a partial/timed-out run never reached.
 	queries := db.New(pool)
 	cutoff := pgtype.Timestamptz{Time: time.Now().Add(-staleAfter), Valid: true}
 	// A self-closing source (e.g. jobtech) manages its own closes from its stream, so the

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -32,10 +32,11 @@ type dbStore struct {
 	q             *db.Queries
 	targetVersion int32
 	indexer       jobIndexer
+	crawled       *crawledSet
 }
 
-func newDBStore(pool *pgxpool.Pool, targetVersion int, indexer jobIndexer) *dbStore {
-	return &dbStore{pool: pool, q: db.New(pool), targetVersion: int32(targetVersion), indexer: indexer}
+func newDBStore(pool *pgxpool.Pool, targetVersion int, indexer jobIndexer, crawled *crawledSet) *dbStore {
+	return &dbStore{pool: pool, q: db.New(pool), targetVersion: int32(targetVersion), indexer: indexer, crawled: crawled}
 }
 
 // needsIndex reports whether a persisted write changed what search would show: a
@@ -100,6 +101,14 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 
 	if err := tx.Commit(ctx); err != nil {
 		return err
+	}
+
+	// Record this (provider, company) as crawled so the post-run stale sweep only
+	// closes jobs of companies this run actually wrote — never a provider's whole
+	// catalogue when a run crawled only some of its boards. Uses the persisted row so
+	// aggregator sources (one board, per-job companies) scope by their real companies.
+	if s.crawled != nil {
+		s.crawled.record(saved.Job.Source, saved.Job.CompanySlug)
 	}
 
 	// Best-effort incremental indexing of the now-committed row: only when the

--- a/internal/db/job_lifecycle_integration_test.go
+++ b/internal/db/job_lifecycle_integration_test.go
@@ -87,7 +87,7 @@ func TestCloseUnseenJobsClosesOnlyStaleJobs(t *testing.T) {
 	ageJob(t, pool, stale.ID, 49*time.Hour)
 	ageJob(t, pool, fresh.ID, 6*time.Hour)
 
-	closed, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{Source: "greenhouse", Cutoff: pgTimestamptz(time.Now().Add(-48 * time.Hour))})
+	closed, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{Source: "greenhouse", Cutoff: pgTimestamptz(time.Now().Add(-48 * time.Hour)), CompanySlugs: []string{"acme"}})
 	if err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
@@ -111,12 +111,80 @@ func TestCloseUnseenJobsClosesOnlyStaleJobs(t *testing.T) {
 	}
 
 	// Idempotent: a second sweep with the same cutoff closes nothing.
-	again, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{Source: "greenhouse", Cutoff: pgTimestamptz(time.Now().Add(-48 * time.Hour))})
+	again, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{Source: "greenhouse", Cutoff: pgTimestamptz(time.Now().Add(-48 * time.Hour)), CompanySlugs: []string{"acme"}})
 	if err != nil {
 		t.Fatalf("second sweep: %v", err)
 	}
 	if again != 0 {
 		t.Fatalf("second sweep closed %d jobs, want 0", again)
+	}
+}
+
+// TestCloseUnseenJobsScopedToCrawledCompanies pins the sweep-scoping contract: a run
+// closes stale jobs only for the company slugs it actually crawled, never a provider's
+// whole catalogue. This is the guard against a partial/targeted run mass-closing a
+// provider whose full crawl times out (see cmd/ingest crawledSet).
+func TestCloseUnseenJobsScopedToCrawledCompanies(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	acmeP := ingestParams("acme:1", "Acme Eng")
+	acmeP.CompanySlug = "acme"
+	globexP := ingestParams("globex:1", "Globex Eng")
+	globexP.CompanySlug = "globex"
+	acme, err := ingestUpsert(ctx, q, acmeP)
+	if err != nil {
+		t.Fatalf("upsert acme: %v", err)
+	}
+	globex, err := ingestUpsert(ctx, q, globexP)
+	if err != nil {
+		t.Fatalf("upsert globex: %v", err)
+	}
+	// Both jobs are stale, but this run crawled only acme's board.
+	ageJob(t, pool, acme.ID, 49*time.Hour)
+	ageJob(t, pool, globex.ID, 49*time.Hour)
+
+	closed, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{
+		Source:       "greenhouse",
+		Cutoff:       pgTimestamptz(time.Now().Add(-48 * time.Hour)),
+		CompanySlugs: []string{"acme"},
+	})
+	if err != nil {
+		t.Fatalf("scoped sweep: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("scoped sweep closed %d jobs, want 1 (only acme)", closed)
+	}
+
+	acmeAfter, err := q.GetJob(ctx, acme.ID)
+	if err != nil {
+		t.Fatalf("get acme: %v", err)
+	}
+	if !acmeAfter.ClosedAt.Valid {
+		t.Fatal("acme (crawled this run, stale) must be closed")
+	}
+	globexAfter, err := q.GetJob(ctx, globex.ID)
+	if err != nil {
+		t.Fatalf("get globex: %v", err)
+	}
+	if globexAfter.ClosedAt.Valid {
+		t.Fatal("globex (not crawled this run) must stay open despite being stale")
+	}
+
+	// A run that recorded no companies (empty scope) closes nothing — the guard against
+	// a zero-company run mass-closing a provider.
+	none, err := q.CloseUnseenJobs(ctx, CloseUnseenJobsParams{
+		Source:       "greenhouse",
+		Cutoff:       pgTimestamptz(time.Now().Add(-48 * time.Hour)),
+		CompanySlugs: nil,
+	})
+	if err != nil {
+		t.Fatalf("empty-scope sweep: %v", err)
+	}
+	if none != 0 {
+		t.Fatalf("empty-scope sweep closed %d jobs, want 0", none)
 	}
 }
 

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -68,20 +68,25 @@ SET closed_at  = now(),
 WHERE closed_at IS NULL
   AND source = $1
   AND last_seen_at < $2
+  AND company_slug = ANY($3::text[])
 `
 
 type CloseUnseenJobsParams struct {
-	Source string             `json:"source"`
-	Cutoff pgtype.Timestamptz `json:"cutoff"`
+	Source       string             `json:"source"`
+	Cutoff       pgtype.Timestamptz `json:"cutoff"`
+	CompanySlugs []string           `json:"company_slugs"`
 }
 
 // Post-ingest sweep (see job-lifecycle spec): close every open job of ONE source not
-// seen since the cutoff. Scoped by source because ingest runs per provider — a
-// greenhouse run must not close jobs another provider owns and didn't crawl. The
-// caller owns the grace window (cutoff = now() - window) and the "run ingested
-// something" guard, so a failed crawl never mass-closes that source's catalogue.
+// seen since the cutoff, scoped to the company slugs the run actually crawled. Scoped
+// by source because ingest runs per provider (a greenhouse run must not close jobs
+// another provider owns), and by company_slug because a run may crawl only a SUBSET of
+// a provider's boards — a partial or targeted run (or a full crawl of a huge provider
+// that times out and only completes some boards) must not close the companies it never
+// touched. The caller passes the crawled slugs and owns the grace window (cutoff =
+// now() - window), so neither a failed nor a partial crawl mass-closes a catalogue.
 func (q *Queries) CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams) (int64, error) {
-	result, err := q.db.Exec(ctx, closeUnseenJobs, arg.Source, arg.Cutoff)
+	result, err := q.db.Exec(ctx, closeUnseenJobs, arg.Source, arg.Cutoff, arg.CompanySlugs)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -63,10 +63,13 @@ type Querier interface {
 	// upsert of the same (source, external_id) reopens it if the posting reappears.
 	CloseJobBySourceExternalID(ctx context.Context, arg CloseJobBySourceExternalIDParams) (int64, error)
 	// Post-ingest sweep (see job-lifecycle spec): close every open job of ONE source not
-	// seen since the cutoff. Scoped by source because ingest runs per provider — a
-	// greenhouse run must not close jobs another provider owns and didn't crawl. The
-	// caller owns the grace window (cutoff = now() - window) and the "run ingested
-	// something" guard, so a failed crawl never mass-closes that source's catalogue.
+	// seen since the cutoff, scoped to the company slugs the run actually crawled. Scoped
+	// by source because ingest runs per provider (a greenhouse run must not close jobs
+	// another provider owns), and by company_slug because a run may crawl only a SUBSET of
+	// a provider's boards — a partial or targeted run (or a full crawl of a huge provider
+	// that times out and only completes some boards) must not close the companies it never
+	// touched. The caller passes the crawled slugs and owns the grace window (cutoff =
+	// now() - window), so neither a failed nor a partial crawl mass-closes a catalogue.
 	CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams) (int64, error)
 	// Whether a company row already exists for the slug. The backfill checks this
 	// before upserting to log matched-existing vs inserted-reference counts — the

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -312,16 +312,20 @@ RETURNING *;
 
 -- name: CloseUnseenJobs :execrows
 -- Post-ingest sweep (see job-lifecycle spec): close every open job of ONE source not
--- seen since the cutoff. Scoped by source because ingest runs per provider — a
--- greenhouse run must not close jobs another provider owns and didn't crawl. The
--- caller owns the grace window (cutoff = now() - window) and the "run ingested
--- something" guard, so a failed crawl never mass-closes that source's catalogue.
+-- seen since the cutoff, scoped to the company slugs the run actually crawled. Scoped
+-- by source because ingest runs per provider (a greenhouse run must not close jobs
+-- another provider owns), and by company_slug because a run may crawl only a SUBSET of
+-- a provider's boards — a partial or targeted run (or a full crawl of a huge provider
+-- that times out and only completes some boards) must not close the companies it never
+-- touched. The caller passes the crawled slugs and owns the grace window (cutoff =
+-- now() - window), so neither a failed nor a partial crawl mass-closes a catalogue.
 UPDATE jobs
 SET closed_at  = now(),
     updated_at = now()
 WHERE closed_at IS NULL
   AND source = sqlc.arg(source)
-  AND last_seen_at < sqlc.arg(cutoff);
+  AND last_seen_at < sqlc.arg(cutoff)
+  AND company_slug = ANY(sqlc.arg(company_slugs)::text[]);
 
 -- name: CloseJobBySourceExternalID :execrows
 -- Stream-driven close (see job-lifecycle): a self-closing feed source (e.g. jobtech)

--- a/openspec/specs/job-lifecycle/spec.md
+++ b/openspec/specs/job-lifecycle/spec.md
@@ -16,19 +16,20 @@ persists the job.
 
 ### Requirement: Jobs unseen beyond a grace window are closed after a run
 
-After an ingest run, the system SHALL run the unseen-job sweep **per provider**: for each
-provider that ingested at least one job during the run, it SHALL stamp `closed_at` on every
-open job of that provider whose `last_seen_at` is older than a 48-hour grace window. A
-provider that ingested nothing in the run SHALL NOT have its jobs swept, so a total crawl
-failure — for one provider in a multi-provider run, or for a whole single-provider run —
-cannot mass-close that provider's catalogue. The sweep of one provider never touches
-another provider's jobs.
+After an ingest run, the system SHALL run the unseen-job sweep **per provider, scoped to the companies that run wrote**: for each provider that ingested at least one job during the run, it SHALL stamp `closed_at` on every open job of that provider whose `last_seen_at` is older than a 48-hour grace window **and whose `company_slug` the run wrote a job for**. A provider that ingested nothing SHALL NOT have its jobs swept, and a company the run did not write (its board was not in this run, returned no postings, or was removed from the board file) SHALL NOT be swept — so a partial or targeted run, or a full crawl of a large provider that times out before completing, cannot mass-close the boards it never reached. The sweep of one provider never touches another provider's jobs. The trade-off is deliberate: a board that empties out or is removed leaks its open jobs (they reopen or close on a later crawl) rather than risk over-closing live jobs the run simply did not reach.
 
 #### Scenario: Stale job is closed
 
 - **WHEN** a sweep runs after a provider ingested at least one job and an open job of that
-  provider was last seen 49 hours ago
+  provider — belonging to a company the run wrote — was last seen 49 hours ago
 - **THEN** that job's `closed_at` is set and the job stops appearing in list surfaces
+
+#### Scenario: A company the run did not crawl is not swept
+
+- **WHEN** a run ingests jobs for company A of a provider but does not write any job for
+  company B of the same provider (B's board was not in this run, or returned no postings)
+  and B has an open job last seen 49 hours ago
+- **THEN** the sweep closes A's stale jobs but leaves B's stale job open
 
 #### Scenario: Recently seen job survives the sweep
 


### PR DESCRIPTION
## Problem
The post-run `CloseUnseenJobs` sweep closed **every** open job of a provider unseen 48h — provider-wide. For a huge provider whose full crawl times out (`workday.yml` = 6164 boards, killed at `TimeoutStartSec` **before** reaching the sweep), the stale pool never gets swept and grows. A later **partial or targeted** run then completes, reaches the sweep, and mass-closes the whole accumulated pool. Discovered live: a targeted `workday` (Visa) ingest soft-closed **50,993** jobs at once (reverted immediately in prod).

## Fix
Scope the sweep to the company slugs the run actually wrote: `dbStore` records `(provider, company_slug)` per persisted upsert into a concurrency-safe `crawledSet`; the sweep passes `crawled.slugs(provider)` to `CloseUnseenJobs`, now `… AND company_slug = ANY(@company_slugs)`. A full crawl still closes across all its companies; a partial/targeted run closes only companies it touched. Aggregators scope correctly (slugs come from persisted rows). **Fail-safe:** empty scope closes 0, never all.

## Trade-off (deliberate under-close)
A company is swept only when the run **wrote a job** for it. So a board that fetched but returned **zero postings**, or a company **removed from the board file**, is not retired here — its open jobs leak until a later crawl reopens/closes them. Board sources have **no liveness backstop** (the liveness probe skips registered providers). This is accepted because the alternative is the far worse over-close (the 51k incident). The old provider-wide sweep was simultaneously the mass-close hazard AND the retire mechanism; scoping fixes the hazard and, inherently, loses cheap retire.

## Tests (TDD)
- `crawledSet` unit tests: dedup, per-provider isolation, concurrent `record` under `-race`.
- Integration: sweep closes only listed companies; a stale non-listed company stays open; empty scope closes nothing. Existing sweep test updated.

## Docs
openspec `job-lifecycle` spec updated (per-provider **and** company-scoped, + not-crawled-company scenario).

## Known follow-up (separate)
Retiring emptied/removed boards needs a dedicated safe reconciler (e.g. extend liveness to board sources, or a full-crawl-complete-aware sweep). Sharding the huge board files so full crawls complete; `arc` crawl is dead (~20 days).