### PR TITLE
feat(swipe): skip every already-seen job and record a view per card

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -175,10 +175,13 @@ type Querier interface {
 	// planner's estimate (see estimate_open_jobs(), migration 0033) is O(1) and
 	// tracks the closed_at IS NULL filter. The total is approximate by design.
 	EstimateOpenJobs(ctx context.Context) (int64, error)
-	// Job ids the user has already judged (saved or dismissed) — the swipe deck's
-	// exclusion set. Ordered most-recently-judged first and capped ($2) so the deck's
-	// `id NOT IN (...)` search filter stays bounded; the overflow risk is only an
-	// occasional re-shown long-ago-judged job, never a correctness problem.
+	// Job ids the user has already interacted with (viewed, saved, applied, or
+	// dismissed) — the swipe deck's exclusion set, so a card is shown at most once
+	// across sessions. viewed_at is set on every interaction row, so any row for the
+	// user counts (the deck records a view the moment a card is shown). Ordered
+	// most-recently-touched first and capped ($2) so the deck's `id NOT IN (...)`
+	// search filter stays bounded; the overflow risk is only an occasional re-shown
+	// long-ago-seen job, never a correctness problem.
 	ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) ([]int64, error)
 	// SELECT * (not an explicit column list) so the generated row stays db.Company as
 	// the table grows columns (e.g. collections); an explicit subset makes sqlc emit a

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -77,15 +77,17 @@ WHERE user_id = $1 AND job_id = $2
 RETURNING *;
 
 -- name: ExcludedJobIDs :many
--- Job ids the user has already judged (saved or dismissed) — the swipe deck's
--- exclusion set. Ordered most-recently-judged first and capped ($2) so the deck's
--- `id NOT IN (...)` search filter stays bounded; the overflow risk is only an
--- occasional re-shown long-ago-judged job, never a correctness problem.
+-- Job ids the user has already interacted with (viewed, saved, applied, or
+-- dismissed) — the swipe deck's exclusion set, so a card is shown at most once
+-- across sessions. viewed_at is set on every interaction row, so any row for the
+-- user counts (the deck records a view the moment a card is shown). Ordered
+-- most-recently-touched first and capped ($2) so the deck's `id NOT IN (...)`
+-- search filter stays bounded; the overflow risk is only an occasional re-shown
+-- long-ago-seen job, never a correctness problem.
 SELECT job_id
 FROM user_jobs
 WHERE user_id = $1
-  AND (saved_at IS NOT NULL OR dismissed_at IS NOT NULL)
-ORDER BY GREATEST(saved_at, dismissed_at) DESC
+ORDER BY GREATEST(viewed_at, saved_at, applied_at, dismissed_at) DESC
 LIMIT $2;
 
 -- name: TrackJob :one

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -150,8 +150,7 @@ const excludedJobIDs = `-- name: ExcludedJobIDs :many
 SELECT job_id
 FROM user_jobs
 WHERE user_id = $1
-  AND (saved_at IS NOT NULL OR dismissed_at IS NOT NULL)
-ORDER BY GREATEST(saved_at, dismissed_at) DESC
+ORDER BY GREATEST(viewed_at, saved_at, applied_at, dismissed_at) DESC
 LIMIT $2
 `
 
@@ -160,10 +159,13 @@ type ExcludedJobIDsParams struct {
 	Limit  int32 `json:"limit"`
 }
 
-// Job ids the user has already judged (saved or dismissed) — the swipe deck's
-// exclusion set. Ordered most-recently-judged first and capped ($2) so the deck's
-// `id NOT IN (...)` search filter stays bounded; the overflow risk is only an
-// occasional re-shown long-ago-judged job, never a correctness problem.
+// Job ids the user has already interacted with (viewed, saved, applied, or
+// dismissed) — the swipe deck's exclusion set, so a card is shown at most once
+// across sessions. viewed_at is set on every interaction row, so any row for the
+// user counts (the deck records a view the moment a card is shown). Ordered
+// most-recently-touched first and capped ($2) so the deck's `id NOT IN (...)`
+// search filter stays bounded; the overflow risk is only an occasional re-shown
+// long-ago-seen job, never a correctness problem.
 func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) ([]int64, error) {
 	rows, err := q.db.Query(ctx, excludedJobIDs, arg.UserID, arg.Limit)
 	if err != nil {

--- a/internal/handler/dismiss_integration_test.go
+++ b/internal/handler/dismiss_integration_test.go
@@ -170,9 +170,10 @@ func TestDismissUndismissEndpoints(t *testing.T) {
 	})
 }
 
-// TestExcludedJobIDs covers the swipe deck's exclusion query: it returns the
-// user's saved and dismissed job ids (not merely-viewed ones), and respects the
-// cap. The deck feeds these into an `id NOT IN [...]` search filter.
+// TestExcludedJobIDs covers the swipe deck's exclusion query: it returns every
+// job the user has interacted with — saved, dismissed, AND merely-viewed — so a
+// card is shown at most once, and respects the cap. The deck feeds these into an
+// `id NOT IN [...]` search filter.
 func TestExcludedJobIDs(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()
@@ -212,13 +213,11 @@ func TestExcludedJobIDs(t *testing.T) {
 	for _, id := range ids {
 		got[id] = true
 	}
-	if !got[savedID] || !got[dismissedID] {
-		t.Errorf("excluded = %v, want it to contain saved (%d) and dismissed (%d)", ids, savedID, dismissedID)
+	if !got[savedID] || !got[dismissedID] || !got[viewedID] {
+		t.Errorf("excluded = %v, want it to contain saved (%d), dismissed (%d), and viewed (%d)",
+			ids, savedID, dismissedID, viewedID)
 	}
-	if got[viewedID] {
-		t.Errorf("excluded = %v, must NOT contain the merely-viewed job (%d)", ids, viewedID)
-	}
-	if len(ids) != 2 {
-		t.Errorf("len(excluded) = %d, want 2", len(ids))
+	if len(ids) != 3 {
+		t.Errorf("len(excluded) = %d, want 3", len(ids))
 	}
 }

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -158,14 +158,14 @@ type Repository interface {
 	// ViewedSlugs returns every public job slug the caller has interacted with.
 	ViewedSlugs(ctx context.Context, userID int64) ([]string, error)
 
-	// ExcludedJobIDs returns up to limit job ids the caller has already judged
-	// (saved or dismissed), most-recently-judged first.
+	// ExcludedJobIDs returns up to limit job ids the caller has already interacted
+	// with (viewed, saved, applied, or dismissed), most-recently-touched first.
 	ExcludedJobIDs(ctx context.Context, userID int64, limit int32) ([]int64, error)
 }
 
 // excludedJobsCap bounds the swipe deck's exclusion set so the search
 // `id NOT IN (...)` filter stays small; a heavy triager past this cap may
-// occasionally re-see a long-ago-judged job, which is acceptable.
+// occasionally re-see a long-ago-seen job, which is acceptable.
 const excludedJobsCap int32 = 1000
 
 // Service implements the per-user job-tracking use cases.
@@ -203,8 +203,9 @@ func (s *Service) ViewedSlugs(ctx context.Context, userID int64) ([]string, erro
 	return s.repo.ViewedSlugs(ctx, userID)
 }
 
-// ExcludedJobIDs returns the job ids the caller has already judged (saved or
-// dismissed) — the swipe deck's exclusion set, capped at excludedJobsCap.
+// ExcludedJobIDs returns the job ids the caller has already interacted with
+// (viewed, saved, applied, or dismissed) — the swipe deck's exclusion set, so a
+// card is shown at most once across sessions, capped at excludedJobsCap.
 func (s *Service) ExcludedJobIDs(ctx context.Context, userID int64) ([]int64, error) {
 	return s.repo.ExcludedJobIDs(ctx, userID, excludedJobsCap)
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -171,13 +171,16 @@ export function createApi(
   }
 
   /** The swipe-deck batch: open jobs matching the same facets/query as
-   *  `searchJobs`, minus the caller's already-judged (saved or dismissed) jobs,
-   *  excluded server-side. Authenticated; batched via limit/offset for prefetch. */
-  async function swipeDeck(facets: URLSearchParams, limit: number, offset: number): Promise<Slice<Job>> {
+   *  `searchJobs`, minus every job the caller has already interacted with
+   *  (viewed/saved/applied/dismissed), excluded server-side. The deck records a
+   *  view the moment a card is shown, so exclusion drives pagination: each fetch
+   *  returns the head of the un-seen deck (offset 0) and the caller dedups held
+   *  cards client-side. Authenticated. */
+  async function swipeDeck(facets: URLSearchParams, limit: number): Promise<Slice<Job>> {
     const params = new URLSearchParams(facets);
     params.set('limit', String(limit));
-    params.set('offset', String(offset));
-    return toSlice(await request<Page<Job>>(`/api/v1/me/jobs/swipe?${params}`), offset);
+    params.set('offset', '0');
+    return toSlice(await request<Page<Job>>(`/api/v1/me/jobs/swipe?${params}`), 0);
   }
 
   /** Facet-distribution counts for the analytics page. `params` carries the same

--- a/web/src/lib/components/SwipeDeck.svelte
+++ b/web/src/lib/components/SwipeDeck.svelte
@@ -5,10 +5,12 @@
   import { resolve } from '$app/paths';
   import { Heart, RotateCcw, SlidersHorizontal, X } from '@lucide/svelte';
   import { api } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
   import { cardTags, formatSalary } from '$lib/enrichment';
   import { FilterStore, filtersToParams } from '$lib/filters';
   import type { Job, FacetCounts } from '$lib/types';
   import { Badge } from '$lib/ui';
+  import { markViewed } from '$lib/viewedJobs.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import FilterModal from './filters/FilterModal.svelte';
   import JobMatch from './JobMatch.svelte';
@@ -91,14 +93,16 @@
     error = false;
     const myGen = gen;
     try {
-      // offset = held-unjudged count: judged cards are already excluded
-      // server-side, so this returns the page right after what we hold.
-      const slice = await api.swipeDeck(deckParams(), LIMIT, queue.length);
+      // Exclusion-driven pagination: every shown card is recorded as viewed and
+      // thus excluded server-side, so each fetch returns the head of the un-seen
+      // deck (offset 0). Held-but-unshown cards aren't excluded yet, so they can
+      // reappear in the page — `seen` dedups them client-side.
+      const slice = await api.swipeDeck(deckParams(), LIMIT);
       if (myGen !== gen) return; // filters changed mid-flight — discard this page
       const fresh = slice.items.filter((j) => !seen.has(j.public_slug));
       for (const j of fresh) seen.add(j.public_slug);
       queue = [...queue, ...fresh];
-      // A page with no rows at all means the undecided set is drained.
+      // A page with no rows at all means the un-seen set is drained.
       if (slice.items.length === 0) exhausted = true;
     } catch {
       if (myGen === gen) error = true;
@@ -289,6 +293,20 @@
 
   // Cancel the store's pending debounce when the deck unmounts.
   onMount(() => () => filters.dispose());
+
+  // Record a view the moment a card becomes the active one — silent, best-effort
+  // history (a failed write must never break the deck). This marks the card viewed
+  // for the browse-list dimming and, with the server-side deck exclusion, keeps a
+  // card from re-appearing across sessions. Re-firing on undo (which restores a
+  // judged card to the front) just touches viewed_at again — idempotent.
+  $effect(() => {
+    const slug = current?.public_slug;
+    if (!slug || !isAuthenticated()) return;
+    api
+      .recordJobView(slug)
+      .then(() => markViewed(slug))
+      .catch(() => {});
+  });
 
   const salary = $derived(current?.enrichment ? formatSalary(current.enrichment) : null);
   const tags = $derived(current ? cardTags(current) : []);


### PR DESCRIPTION
## What

In swipe mode, skip **every** job the user has already interacted with — not just judged (saved/dismissed) ones, but viewed and applied too — and record a view for each card as it's shown, so a card appears at most once across sessions.

### Backend
- `ExcludedJobIDs` now selects **any** `user_jobs` row for the caller (`viewed_at` is set on every interaction row), ordered most-recently-touched first, still capped at `excludedJobsCap`. Previously it was saved/dismissed only.
- Integration test `TestExcludedJobIDs` inverted: a merely-viewed job is now expected in the exclusion set.

### Frontend
- The deck records a view (`recordJobView` + local `markViewed`) the moment a card becomes active — silent, best-effort, mirroring the detail page. Feeds browse-list dimming and, with the broadened exclusion, guarantees no re-show.
- Pagination switches from offset-based to **exclusion-driven**: since a shown card is immediately excluded server-side, each fetch returns the head of the un-seen deck (offset 0); held-but-unshown cards are deduped client-side via `seen`. `swipeDeck` drops its now-meaningless `offset` param.

### Back button
Undo is unaffected — it restores a judged card from the client queue, so the back button still shows the (now-viewed) card. Re-recording its view is idempotent (`viewed_at` touched, `view_count` not re-bumped).

## Verification
- `go test ./...` — green (incl. `-tags=integration -run TestExcludedJobIDs` against a real Postgres).
- `svelte-check` — 0 errors in `SwipeDeck.svelte` / `api.ts` (pre-existing unrelated errors remain).
- Not exercised live: the end-to-end swipe UX needs an authed account with history; backend + types verified.