### PR TITLE
fix(web): reposition profile delete + AI-review controls for mobile

### DIFF
--- a/web/src/lib/components/ATSReportView.svelte
+++ b/web/src/lib/components/ATSReportView.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import { Check, Copy, TriangleAlert, X } from '@lucide/svelte';
+  import type { Snippet } from 'svelte';
   import type { ATSReport } from '$lib/types';
 
   // The CV ATS-readiness report from the backend: an overall score out of 100 built
   // from five weighted categories, each with per-item point attribution, plus the
   // role's strong/recommended keywords and (after an AI review) numbered suggestions.
-  let { report }: { report: ATSReport } = $props();
+  // `action` is an optional control (the Run/Re-run AI review button) rendered in the
+  // section header so it stays beside the title on every viewport.
+  let { report, action }: { report: ATSReport; action?: Snippet } = $props();
 
   const categories = $derived(report.categories ?? []);
   const strong = $derived(report.strong_keywords ?? []);
@@ -36,11 +39,16 @@
 </script>
 
 <div class="flex flex-col gap-6">
-  <div class="flex flex-col gap-1">
-    <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">CV readiness</h2>
-    <p class="text-sm text-muted-foreground">
-      How well an ATS reads your CV and whether it carries this role's keywords.
-    </p>
+  <div class="flex flex-wrap items-start justify-between gap-3">
+    <div class="flex min-w-0 flex-col gap-1">
+      <h2 class="text-sm font-semibold uppercase tracking-[0.14em] text-muted-foreground">CV readiness</h2>
+      <p class="text-sm text-muted-foreground">
+        How well an ATS reads your CV and whether it carries this role's keywords.
+      </p>
+    </div>
+    {#if action}
+      {@render action()}
+    {/if}
   </div>
 
   <!-- Scoreboard: overall now, potential if you apply the fixes -->

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -182,23 +182,32 @@
     <States state="error" message="Couldn't load your profile." />
   {:else}
     <!-- Header -->
-    <div class="mb-6 flex flex-wrap items-start justify-between gap-3">
-      <div class="flex flex-col gap-1">
-        <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
-        <p class="text-sm text-muted-foreground">
-          Your CV, skills and role — measured against live market demand.
-        </p>
-      </div>
-      {#if profile}
-        <Button variant="ghost" size="icon" onclick={remove} aria-label="Delete profile">
-          <Trash2 class="size-4" />
-        </Button>
-      {/if}
+    <div class="mb-6 flex flex-col gap-1">
+      <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
+      <p class="text-sm text-muted-foreground">
+        Your CV, skills and role — measured against live market demand.
+      </p>
     </div>
 
     {#if actionError}
       <p class="mb-4 text-sm text-destructive">{actionError}</p>
     {/if}
+
+    <!-- Run / Re-run AI review control, rendered inside the CV-readiness section header
+         (via ATSReportView's `action` slot) rather than crammed into the tab row. -->
+    {#snippet reviewAction()}
+      {#if ats?.report && !ats.report.reviewed && !reviewUnavailable}
+        <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
+          <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+          {reviewBusy ? 'Reviewing…' : 'Run AI review'}
+        </Button>
+      {:else if ats?.report?.reviewed}
+        <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
+          <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+          {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
+        </Button>
+      {/if}
+    {/snippet}
 
     {#if profile === null}
       <!-- Set-up: the inline form only; coverage appears once a profile exists. -->
@@ -221,51 +230,34 @@
 
         <main class="flex min-w-0 flex-1 flex-col gap-6">
           <!-- Tabs -->
-          <div class="flex items-center justify-between gap-3 border-b border-border">
-            <div class="flex gap-5">
-              <button
-                type="button"
-                onclick={() => (tab = 'profile')}
-                class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'profile'
-                  ? 'border-primary text-foreground'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'}"
-              >
-                Your CV
-              </button>
-              <button
-                type="button"
-                onclick={() => (tab = 'coverage')}
-                class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
-                  ? 'border-primary text-foreground'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'}"
-              >
-                Market coverage
-              </button>
-              <button
-                type="button"
-                onclick={() => (tab = 'readiness')}
-                class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'readiness'
-                  ? 'border-primary text-foreground'
-                  : 'border-transparent text-muted-foreground hover:text-foreground'}"
-              >
-                CV readiness
-              </button>
-            </div>
-            {#if tab === 'readiness' && ats?.has_cv && ats.report}
-              <div class="pb-1.5">
-                {#if !ats.report.reviewed && !reviewUnavailable}
-                  <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
-                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                    {reviewBusy ? 'Reviewing…' : 'Run AI review'}
-                  </Button>
-                {:else if ats.report.reviewed}
-                  <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
-                    <Sparkles class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-                    {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
-                  </Button>
-                {/if}
-              </div>
-            {/if}
+          <div class="flex gap-5 border-b border-border">
+            <button
+              type="button"
+              onclick={() => (tab = 'profile')}
+              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'profile'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            >
+              Your CV
+            </button>
+            <button
+              type="button"
+              onclick={() => (tab = 'coverage')}
+              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            >
+              Market coverage
+            </button>
+            <button
+              type="button"
+              onclick={() => (tab = 'readiness')}
+              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'readiness'
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'}"
+            >
+              CV readiness
+            </button>
           </div>
 
           <!-- Body -->
@@ -273,6 +265,19 @@
             {#key profile.updated_at}
               <ProfileForm {profile} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
             {/key}
+            <!-- Destructive action lives at the foot of the profile-management tab, out of
+                 the page header (where it crowded the title on narrow viewports). -->
+            <div class="mt-2 flex justify-end border-t border-border pt-4">
+              <Button
+                variant="ghost"
+                size="sm"
+                onclick={remove}
+                class="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 class="size-4" />
+                Delete profile
+              </Button>
+            </div>
           {:else if loadError}
             <States state="error" message="Couldn't load the report." />
           {:else if verdict === null}
@@ -285,7 +290,7 @@
               {#if reviewUnavailable}
                 <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
               {/if}
-              <ATSReportView report={ats.report} />
+              <ATSReportView report={ats.report} action={reviewAction} />
             </div>
           {:else}
             <!-- No CV yet: uploaded via the Your CV tab. -->


### PR DESCRIPTION
## Problem
On mobile the Profile page had two cramped controls:
- **Delete profile** (trash icon) wrapped to a stray line under the header description (`flex-wrap justify-between` in the header).
- **Run AI review** was squeezed into the tab row, breaking the tab labels onto two lines.

## Fix
- **Delete profile** → moved to the foot of the **Your CV** tab, behind a `border-t` divider, as a muted `ghost` button (red on hover). Destructive action lives with profile management, out of the header.
- **Run / Re-run AI review** → moved out of the tab row into the **CV readiness** section header, via a new optional `action` snippet slot on `ATSReportView`. Title left, button right; wraps cleanly under the title on narrow viewports. Behaviour (Run vs Re-run, busy state) unchanged.

## Verification
- `svelte-check` — 0 errors/warnings in both files.
- Visual check at a true 390px content box (headless Chrome): review button sits on its own row under the section title; delete button reads fully at the tab foot; scoreboard unaffected.

No new dependencies or components — reuses the existing `Button` and the project's snippet pattern.