### PR TITLE
feat(search): freshness-scoped semantic rebuild + posted_ts ranking tie-breaker

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -97,6 +97,20 @@ func run() int {
 		return 1
 	}
 
+	postedWithin, scoped, err := postedWithinFrom(os.Args[1:])
+	if err != nil {
+		log.Printf("reindex: %v", err)
+		return 1
+	}
+	// --posted-within scopes the fresh window the semantic swap rebuild embeds; it is
+	// meaningless for the facet index (which holds the whole catalogue) and for the
+	// in-place --since delta (which cannot be swapped in). Reject those combos loudly
+	// rather than silently ignoring the flag.
+	if scoped && (!semantic || incremental) {
+		log.Print("reindex: --posted-within applies only to a full --semantic rebuild")
+		return 1
+	}
+
 	// --since is a delta into the LIVE index in place: a partial set cannot be
 	// swapped in wholesale (it would drop everything else). A full pass instead
 	// builds a fresh index and atomically swaps it over the live one, which keeps
@@ -122,8 +136,17 @@ func run() int {
 	if semantic {
 		b = client.NewSemanticRebuild()
 	}
-	log.Printf("reindex: target=%s scope=full mode=swap", target)
-	indexed, skipped, err := reindexFull(ctx, worker.NewFullScanReader(q), b)
+	// The semantic rebuild optionally scopes to a fresh posting window (--posted-within);
+	// every other full pass scans the whole table. A scoped reader returns open jobs only,
+	// which the swap rebuild wants anyway (closed jobs are simply absent).
+	reader := worker.NewFullScanReader(q)
+	scope := "full"
+	if scoped {
+		reader = worker.NewPostedSinceReader(q, time.Now().Add(-postedWithin))
+		scope = "posted-within " + postedWithin.String()
+	}
+	log.Printf("reindex: target=%s scope=%s mode=swap", target, scope)
+	indexed, skipped, err := reindexFull(ctx, reader, b)
 	if err != nil {
 		log.Printf("reindex: %v", err)
 		return 1
@@ -155,6 +178,37 @@ func sinceFrom(args []string) (time.Duration, bool, error) {
 		}
 		if d <= 0 {
 			return 0, false, fmt.Errorf("--since must be positive, got %q", raw)
+		}
+		return d, true, nil
+	}
+	return 0, false, nil
+}
+
+// postedWithinFrom parses an optional --posted-within <duration> / --posted-within=<duration>
+// flag (e.g. "168h" for 7 days). It scopes a full --semantic rebuild to jobs posted
+// within that window, since the in-engine embedder cannot embed the whole catalogue in
+// reasonable time. Reports (duration, true, nil) when present, (0, false, nil) when
+// absent, and an error for a missing or unparseable value. Mirrors sinceFrom.
+func postedWithinFrom(args []string) (time.Duration, bool, error) {
+	for i, a := range args {
+		var raw string
+		switch {
+		case a == "--posted-within":
+			if i+1 >= len(args) {
+				return 0, false, fmt.Errorf("--posted-within needs a duration (e.g. 168h)")
+			}
+			raw = args[i+1]
+		case strings.HasPrefix(a, "--posted-within="):
+			raw = strings.TrimPrefix(a, "--posted-within=")
+		default:
+			continue
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			return 0, false, fmt.Errorf("--posted-within %q: %w", raw, err)
+		}
+		if d <= 0 {
+			return 0, false, fmt.Errorf("--posted-within must be positive, got %q", raw)
 		}
 		return d, true, nil
 	}

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -41,6 +41,34 @@ func TestSinceFrom(t *testing.T) {
 	}
 }
 
+func TestPostedWithinFrom(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantDur time.Duration
+		wantOK  bool
+		wantErr bool
+	}{
+		{"absent", []string{"--semantic"}, 0, false, false},
+		{"space form", []string{"--semantic", "--posted-within", "168h"}, 168 * time.Hour, true, false},
+		{"equals form", []string{"--posted-within=720h"}, 720 * time.Hour, true, false},
+		{"missing value", []string{"--posted-within"}, 0, false, true},
+		{"unparseable", []string{"--posted-within", "7d"}, 0, false, true},
+		{"non-positive", []string{"--posted-within", "0h"}, 0, false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dur, ok, err := postedWithinFrom(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if ok != tt.wantOK || dur != tt.wantDur {
+				t.Errorf("got (%v, %v), want (%v, %v)", dur, ok, tt.wantDur, tt.wantOK)
+			}
+		})
+	}
+}
+
 func TestSemanticRequested(t *testing.T) {
 	if !semanticRequested([]string{"--since", "50h", "--semantic"}) {
 		t.Error("--semantic should be detected among other args")

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -676,6 +676,123 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 	return items, nil
 }
 
+const listOpenJobIDsPostedAfter = `-- name: ListOpenJobIDsPostedAfter :many
+SELECT id
+FROM jobs
+WHERE id > $1 AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= $2
+ORDER BY id
+LIMIT $3
+`
+
+type ListOpenJobIDsPostedAfterParams struct {
+	AfterID     int64              `json:"after_id"`
+	PostedSince pgtype.Timestamptz `json:"posted_since"`
+	BatchSize   int32              `json:"batch_size"`
+}
+
+// Id-only projection of ListOpenJobsPostedAfter — the corruption-degrade path for the
+// freshness-scoped semantic scan, mirroring ListJobIDsAfter.
+func (q *Queries) ListOpenJobIDsPostedAfter(ctx context.Context, arg ListOpenJobIDsPostedAfterParams) ([]int64, error) {
+	rows, err := q.db.Query(ctx, listOpenJobIDsPostedAfter, arg.AfterID, arg.PostedSince, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listOpenJobsPostedAfter = `-- name: ListOpenJobsPostedAfter :many
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+FROM jobs
+WHERE id > $1 AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= $2
+ORDER BY id
+LIMIT $3
+`
+
+type ListOpenJobsPostedAfterParams struct {
+	AfterID     int64              `json:"after_id"`
+	PostedSince pgtype.Timestamptz `json:"posted_since"`
+	BatchSize   int32              `json:"batch_size"`
+}
+
+// Freshness-scoped keyset scan for `reindex --semantic --posted-within`: open jobs
+// whose effective posting date (COALESCE(posted_at, created_at) — the same date
+// jobview derives and the search doc's posted_ts encodes) is at or after the cutoff.
+// The in-engine embedder cannot embed the whole open catalogue in reasonable time, so
+// the semantic index covers only this fresh window; being a swap rebuild it also drops
+// jobs that have since aged out. Open-only (closed_at IS NULL): a swap rebuild never
+// holds closed jobs, so unlike ListJobsUpdatedAfter there is nothing to delete. Served
+// by jobs_open_enrich_freshness_idx (COALESCE(posted_at, created_at) DESC WHERE open).
+func (q *Queries) ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsPostedAfterParams) ([]Job, error) {
+	rows, err := q.db.Query(ctx, listOpenJobsPostedAfter, arg.AfterID, arg.PostedSince, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Job{}
+	for rows.Next() {
+		var i Job
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.ExternalID,
+			&i.URL,
+			&i.Title,
+			&i.Company,
+			&i.Location,
+			&i.Remote,
+			&i.Description,
+			&i.PostedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.CompanySlug,
+			&i.Enrichment,
+			&i.EnrichedAt,
+			&i.EnrichmentVersion,
+			&i.PublicSlug,
+			&i.LastSeenAt,
+			&i.ClosedAt,
+			&i.Countries,
+			&i.Regions,
+			&i.WorkMode,
+			&i.LivenessStrikes,
+			&i.Skills,
+			&i.Seniority,
+			&i.Category,
+			&i.CreatedBy,
+			&i.UpdatedBy,
+			&i.PostingLanguage,
+			&i.EmploymentType,
+			&i.EducationLevel,
+			&i.ExperienceYearsMin,
+			&i.Collections,
+			&i.ContentHash,
+			&i.EnglishLevel,
+			&i.Cities,
+			&i.ViewCount,
+			&i.AppliedCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markLivenessExpired = `-- name: MarkLivenessExpired :one
 UPDATE jobs
 SET liveness_strikes = liveness_strikes + 1,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -304,6 +304,18 @@ type Querier interface {
 	// index current without re-pushing the whole table. Returns closed rows too, so
 	// the caller deletes a freshly-closed job from the index.
 	ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedAfterParams) ([]Job, error)
+	// Id-only projection of ListOpenJobsPostedAfter — the corruption-degrade path for the
+	// freshness-scoped semantic scan, mirroring ListJobIDsAfter.
+	ListOpenJobIDsPostedAfter(ctx context.Context, arg ListOpenJobIDsPostedAfterParams) ([]int64, error)
+	// Freshness-scoped keyset scan for `reindex --semantic --posted-within`: open jobs
+	// whose effective posting date (COALESCE(posted_at, created_at) — the same date
+	// jobview derives and the search doc's posted_ts encodes) is at or after the cutoff.
+	// The in-engine embedder cannot embed the whole open catalogue in reasonable time, so
+	// the semantic index covers only this fresh window; being a swap rebuild it also drops
+	// jobs that have since aged out. Open-only (closed_at IS NULL): a swap rebuild never
+	// holds closed jobs, so unlike ListJobsUpdatedAfter there is nothing to delete. Served
+	// by jobs_open_enrich_freshness_idx (COALESCE(posted_at, created_at) DESC WHERE open).
+	ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsPostedAfterParams) ([]Job, error)
 	// The moderator review queue: every pending report, newest first, with the reporter's email
 	// and the reported job's slug and title so the moderator can judge it and link to it.
 	ListPendingReports(ctx context.Context) ([]ListPendingReportsRow, error)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -52,6 +52,30 @@ WHERE id > sqlc.arg(after_id) AND updated_at >= sqlc.arg(since)
 ORDER BY id
 LIMIT sqlc.arg(batch_size);
 
+-- name: ListOpenJobsPostedAfter :many
+-- Freshness-scoped keyset scan for `reindex --semantic --posted-within`: open jobs
+-- whose effective posting date (COALESCE(posted_at, created_at) — the same date
+-- jobview derives and the search doc's posted_ts encodes) is at or after the cutoff.
+-- The in-engine embedder cannot embed the whole open catalogue in reasonable time, so
+-- the semantic index covers only this fresh window; being a swap rebuild it also drops
+-- jobs that have since aged out. Open-only (closed_at IS NULL): a swap rebuild never
+-- holds closed jobs, so unlike ListJobsUpdatedAfter there is nothing to delete. Served
+-- by jobs_open_enrich_freshness_idx (COALESCE(posted_at, created_at) DESC WHERE open).
+SELECT *
+FROM jobs
+WHERE id > sqlc.arg(after_id) AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= sqlc.arg(posted_since)
+ORDER BY id
+LIMIT sqlc.arg(batch_size);
+
+-- name: ListOpenJobIDsPostedAfter :many
+-- Id-only projection of ListOpenJobsPostedAfter — the corruption-degrade path for the
+-- freshness-scoped semantic scan, mirroring ListJobIDsAfter.
+SELECT id
+FROM jobs
+WHERE id > sqlc.arg(after_id) AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= sqlc.arg(posted_since)
+ORDER BY id
+LIMIT sqlc.arg(batch_size);
+
 -- name: GetJob :one
 SELECT *
 FROM jobs

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -511,7 +511,14 @@ func facetSettings() *meilisearch.Settings {
 		},
 		// posted_at / created_at are RFC3339 UTC strings and sort chronologically as text.
 		SortableAttributes: []string{"posted_at", "created_at", "enrichment.salary_min", "enrichment.salary_max"},
-		RankingRules:       []string{"words", "sort", "typo", "proximity", "attribute", "exactness"},
+		// posted_ts:desc is a freshness tie-breaker appended AFTER exactness: relevance
+		// (and any explicit sort) always decides first, and among results otherwise tied
+		// on every relevance rule the fresher posting wins. It uses the numeric
+		// effective-posting field (posted_ts, unix seconds) — the reliable date jobview
+		// derives, not the raw posted_at — and needs no sortable declaration (custom
+		// ranking rules are independent of SortableAttributes). Flows into the semantic
+		// index too, since semanticSettings builds on these rules.
+		RankingRules: []string{"words", "sort", "typo", "proximity", "attribute", "exactness", "posted_ts:desc"},
 		// Typo tolerance is left at Meilisearch's defaults (on, with sensible min
 		// word sizes). We deliberately do not send a TypoTolerance struct: the SDK
 		// always serializes newer fields (e.g. disableOnNumbers) that older

--- a/internal/worker/resilient.go
+++ b/internal/worker/resilient.go
@@ -44,6 +44,8 @@ type jobQueries interface {
 	ListJobIDsAfter(context.Context, db.ListJobIDsAfterParams) ([]int64, error)
 	ListJobsUpdatedAfter(context.Context, db.ListJobsUpdatedAfterParams) ([]db.Job, error)
 	ListJobIDsUpdatedAfter(context.Context, db.ListJobIDsUpdatedAfterParams) ([]int64, error)
+	ListOpenJobsPostedAfter(context.Context, db.ListOpenJobsPostedAfterParams) ([]db.Job, error)
+	ListOpenJobIDsPostedAfter(context.Context, db.ListOpenJobIDsPostedAfterParams) ([]int64, error)
 	GetJob(context.Context, int64) (db.Job, error)
 }
 
@@ -81,6 +83,30 @@ func (r incrementalReader) IDs(ctx context.Context, afterID int64, bs int32) ([]
 	return r.q.ListJobIDsUpdatedAfter(ctx, db.ListJobIDsUpdatedAfterParams{AfterID: afterID, Since: r.since, BatchSize: bs})
 }
 func (r incrementalReader) Row(ctx context.Context, id int64) (db.Job, error) {
+	return r.q.GetJob(ctx, id)
+}
+
+type postedSinceReader struct {
+	q     jobQueries
+	since pgtype.Timestamptz
+}
+
+// NewPostedSinceReader adapts *db.Queries to a PageReader over OPEN jobs whose
+// effective posting date (COALESCE(posted_at, created_at)) is at or after since —
+// the freshness window `reindex --semantic --posted-within` embeds. Keyset by id.
+// Unlike the incremental reader it returns open jobs only, since the semantic swap
+// rebuild it feeds never holds closed jobs (nothing to delete).
+func NewPostedSinceReader(q jobQueries, since time.Time) PageReader {
+	return postedSinceReader{q: q, since: pgtype.Timestamptz{Time: since, Valid: true}}
+}
+
+func (r postedSinceReader) Batch(ctx context.Context, afterID int64, bs int32) ([]db.Job, error) {
+	return r.q.ListOpenJobsPostedAfter(ctx, db.ListOpenJobsPostedAfterParams{AfterID: afterID, PostedSince: r.since, BatchSize: bs})
+}
+func (r postedSinceReader) IDs(ctx context.Context, afterID int64, bs int32) ([]int64, error) {
+	return r.q.ListOpenJobIDsPostedAfter(ctx, db.ListOpenJobIDsPostedAfterParams{AfterID: afterID, PostedSince: r.since, BatchSize: bs})
+}
+func (r postedSinceReader) Row(ctx context.Context, id int64) (db.Job, error) {
 	return r.q.GetJob(ctx, id)
 }
 


### PR DESCRIPTION
## What

Enables the dormant **hybrid / similar-jobs semantic search** end-to-end without melting the box, plus a freshness bias in ranking.

### 1. Freshness-scoped semantic rebuild
The in-engine huggingFace embedder is CPU-bound (**measured ~22 docs/s** on host2), so embedding the whole ~2.9M open-job catalogue takes ~37h and blocks Meili's single task queue (live index goes stale for the duration). `reindex --semantic` gains **`--posted-within <dur>`** to scope the swap rebuild to a fresh posting window:

- `cmd/reindex`: `--posted-within` flag + validation (rejected for the facet pass and the in-place `--since` delta, where it is meaningless).
- `internal/worker`: `postedSinceReader`, mirroring the `--since` `incrementalReader` but open-only (a swap rebuild never holds closed jobs).
- `internal/db`: `ListOpenJobsPostedAfter` / `ListOpenJobIDsPostedAfter` keyset queries filtering `closed_at IS NULL AND COALESCE(posted_at, created_at) >= cutoff`, served by the existing `jobs_open_enrich_freshness_idx`.

Being a swap rebuild it naturally evicts jobs that age out of the window.

### 2. Freshness ranking tie-breaker
`posted_ts:desc` appended as the **last** ranking rule in `facetSettings()`: relevance (and any explicit `sort`) decides first; among otherwise-tied results the fresher posting wins. Uses the numeric effective-posting field, needs no sortable declaration, and flows into the semantic index too.

## Rollout
1. Deploy (rebuilds the `reindex` worker binary).
2. Night run: `reindex --semantic --posted-within=168h` (7 days, ~580k, ~7h). Live facet index untouched until the atomic swap.
3. Verify `/jobs/:slug/similar` + hybrid (`semantic_ratio>0`); widen the window later, weighing each widening against live-index queue-block time.
4. Ranking tie-breaker applies to the live facet index on its next scheduled facet reindex.

## Tests
`go test ./...` green; added `TestPostedWithinFrom`.