### PR TITLE
feat(web): persist /jobs filters in localStorage, restore on return to a bare /jobs

### DIFF
--- a/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/design.md
+++ b/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Job filters are stored in the URL query string as the single source of truth. `FilterStore` (jobs-specific, `web/src/lib/filters.ts`) wraps the generic `UrlSyncedState` primitive (`web/src/lib/urlSynced.svelte.ts`), which owns the state↔URL transport: explicit edits go through `setNow`/`setSoon` → `#write` → synchronous `replaceState`; browser back/forward re-seeds via `syncFromUrl` (wired by `syncOnNavigation`). The primitive was deliberately built around synchronous URL writes to fix a dropped-character race, so it must not be reshaped casually.
+
+There are many entry points to `/jobs` (`TopBar`, `HeaderMenu`, `Footer`, home CTAs, error page, swipe exit). Each lands on a bare `/jobs` with an empty URL, which currently clears the user's filters. Making individual links filter-aware would scatter inconsistent behavior; the page itself is the natural single choke-point for restoration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Filters on the standalone `/jobs` survive navigation to a bare `/jobs`, restored regardless of which entry point was used.
+- Filters are cleared only by an explicit user change or reset — never lost to an ordinary navigation.
+- Keep the URL as the source of truth; keep the `UrlSyncedState` primitive generic and its synchronous-write contract intact.
+
+**Non-Goals:**
+- Persistence for the company-embedded jobs list, analytics, or swipe (out of scope).
+- Expiry / TTL for stored filters.
+- Cross-tab synchronization (`storage` event).
+- Server-side or account-level filter persistence (saved searches already cover intentional saves).
+
+## Decisions
+
+### Persist on `#write` only, via an optional `onWrite` callback on the primitive
+`#write` is invoked by every explicit user mutation (`setNow`/`setSoon`) and by nothing else — `syncFromUrl` sets `value`/`applied` directly. That makes `#write` the exact "user changed the filters" signal. `UrlSyncedState` gains an optional `onWrite?(value)` callback fired inside `#write`; the primitive stays generic (it knows nothing about storage). `FilterStore` gains an opt-in `persist` flag that wires `onWrite` to save `filtersToParams(value).toString()` (empty string → remove the key).
+
+- Why this over persisting on `applied` changes: `applied` also settles empty when navigation re-seeds to a bare URL, so it can't distinguish "user cleared" from "navigated to empty" — the whole crux. `#write` fires for the former only.
+- Why store the serialized query string over a bespoke JSON shape: reuse the already unit-tested `filtersToParams`/`filtersFromParams`, so storage and URL share one codec with zero schema drift.
+
+### The `/jobs` page is the single restore choke-point
+Restoration happens in `JobsView` (standalone only), not per nav link. It is wired via **`afterNavigate`** (not a URL-tracking `$effect`): on a navigation that lands on a bare `/jobs` (empty `location.search`) with a non-empty stored set, `filters.apply(stored)` restores it; otherwise `filters.syncFromUrl()` runs (unchanged). For the company-embedded list the branch is gated off and the original `syncOnNavigation(filters)` is used, so it behaves exactly as today.
+
+`apply(stored)` runs through `setNow` → `#write` → `replaceState`, rewriting the URL and re-persisting the same string (idempotent); shallow `replaceState` does not re-fire `afterNavigate`, so there is no loop.
+
+Two constraints, both surfaced by end-to-end verification, shaped this:
+- **`afterNavigate`, not `$effect`.** A restore `$effect` runs during hydration, *before* SvelteKit's client router is initialized, so `apply`'s `replaceState` throws "Cannot call replaceState before router is initialized". `afterNavigate` runs only after the router is ready and after the mount effects, so `replaceState` is safe and the restore's `applied` change lands after the reload effect's first pass (this also removes the effect-ordering fragility a `$effect` would carry).
+- **Skip the initial `enter`.** Even in `afterNavigate`, the very first (cold) load — `nav.type === 'enter'` — is still too early for `replaceState`, and the SSR already rendered that exact URL. So restore is skipped on `enter` (the URL as loaded is served) and applies only on client-side navigations — which is every restore-worthy case: the "Jobs" nav link, cross-route entry, and back/forward. `location.search` (not `page.url.search`) is the address-bar truth, since `page.url` can lag after shallow routing.
+
+### Scope gating via a `persist` flag
+`FilterStore` persistence is opt-in; `JobsView` enables it only when `standalone` (no `scope`). The company-embedded list keeps `persist=false` so it never reads or writes the shared `hire.jobFilters` key.
+
+### New `filterStorage.ts` module
+A small, pure, SSR-guarded module (`loadJobFilters()`, `saveJobFilters(qs)`). It **feature-detects `localStorage` (`typeof`)** rather than importing `browser` from `$app/environment`, so it is importable by the plain-Node vitest env (which has no SvelteKit runtime) — that is what makes it the unit-testable core. Access is wrapped in try/catch and failures are swallowed, like `theme.svelte.ts`/`github.svelte.ts`. This keeps the storage concern out of the runes-bound files.
+
+## Risks / Trade-offs
+
+- **Clicking "Jobs" while on a filtered `/jobs` no longer clears the list** → intended per the approved design; "Clear all" is the explicit reset. Confirmed with the user.
+- **Brief unfiltered flash on client-side entry to a bare `/jobs`** (the list shows the just-loaded unfiltered page for a beat, then the restore reloads it filtered) → acceptable and confined to client-side navigations; a cold load skips restore, so it never flashes there.
+- **A cold hard-load / bookmark of a bare `/jobs` does not restore** → deliberate (the `enter` skip that avoids the router-not-ready error). It's the nice-to-have edge, not the user's scenario, and storage is preserved so the next client-side return restores.
+- **Runes/`$app`-bound code (`urlSynced`, `JobsView`) is not unit-tested** → per project norms, verified via `svelte-check` + a Playwright end-to-end pass (persist, restore-on-nav, clear, URL-precedence, company isolation, and the cold-load no-error edge); the pure `filterStorage.ts` carries the automated coverage.
+- **Frequent `localStorage` writes while typing** (one per keystroke via `setSoon`) → negligible; matches the existing per-keystroke URL write. Not debounced (YAGNI).

--- a/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/proposal.md
+++ b/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Job filters live only in the URL query string. When a user navigates back to a bare `/jobs` — most commonly by clicking the "Jobs" nav link (`TopBar`, `HeaderMenu`, `Footer`, home-page CTAs all point at `/jobs`) — the URL is empty and their carefully built filter set is silently dropped. Users expect their filters to persist until *they* change or reset them, not to vanish on an ordinary navigation.
+
+## What Changes
+
+- Job filters are mirrored into `localStorage` (key `hire.jobFilters`) as the serialized filter query string, so the last explicit filter set survives navigation to a bare `/jobs`.
+- The standalone `/jobs` page becomes the single restore choke-point: landing on `/jobs` with an empty URL restores filters from storage — on first mount and on same-route navigation to an empty URL.
+- Persistence is written **only on explicit user changes** (facet toggles, text/slider input, applying a saved search, and "Clear all"), never on back/forward/navigation re-seeding. This is what makes "Clear all" wipe the stored filters while a navigation to an empty URL restores them.
+- Scope is the standalone `/jobs` list only. The company-embedded jobs list (`/companies/:slug`) does not persist, to avoid clobbering the shared key.
+- No expiry and no cross-tab syncing (out of scope — YAGNI).
+
+## Capabilities
+
+### New Capabilities
+- `filter-persistence`: Remembering the standalone `/jobs` filter set in browser storage and restoring it when the user returns to a bare `/jobs`, cleared only by an explicit filter change or reset.
+
+### Modified Capabilities
+<!-- None: this adds a new restore behavior on top of the existing URL-as-source-of-truth filter model; it changes no existing spec's requirements. -->
+
+## Impact
+
+- `web/src/lib/filterStorage.ts` (new): pure, SSR-guarded load/save of the stored filter query string.
+- `web/src/lib/urlSynced.svelte.ts`: `UrlSyncedState` gains an optional `onWrite` callback fired inside `#write` (explicit-change signal only; never on `syncFromUrl`).
+- `web/src/lib/filters.ts`: `FilterStore` gains an opt-in `persist` flag wiring `onWrite` to storage.
+- `web/src/lib/components/JobsView.svelte`: constructs the store with `persist` only when standalone; restores on empty-URL mount; replaces `syncOnNavigation` with a jobs-aware restore-or-sync effect.
+- No backend, API, or database changes. No changes to the company/analytics/swipe filter stacks.

--- a/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/specs/filter-persistence/spec.md
+++ b/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/specs/filter-persistence/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Persist the standalone job filter set on explicit change
+The system SHALL persist the standalone `/jobs` filter set to browser storage (key `hire.jobFilters`, as the serialized filter query string) whenever the user explicitly changes it, and SHALL NOT write storage in response to navigation-driven re-seeding (back/forward or landing on a URL).
+
+#### Scenario: User adjusts a filter
+- **WHEN** a signed-in or anonymous user toggles a facet, edits the search text, moves a slider, or applies a saved search on the standalone `/jobs` list
+- **THEN** the serialized filter query string is written to `hire.jobFilters`
+
+#### Scenario: User clears all filters
+- **WHEN** the user resets the filters (Clear all) so the applied filter set is empty
+- **THEN** the `hire.jobFilters` key is removed, so no filters are restored later
+
+#### Scenario: Navigation does not overwrite storage
+- **WHEN** the filter state is re-seeded by a browser back/forward or an incoming navigation rather than a user edit
+- **THEN** `hire.jobFilters` is left unchanged
+
+### Requirement: Restore stored filters when returning to a bare /jobs
+The system SHALL restore the stored filter set when a client-side navigation lands on the standalone `/jobs` with no filter params in the URL and a non-empty value exists in storage; it SHALL rewrite the URL to reflect the restored filters and reload the list. A cold first load of the page (a hard load, refresh, or direct URL — the router's initial `enter`) SHALL NOT restore and SHALL NOT error; the URL as loaded is served.
+
+#### Scenario: Clicking the Jobs nav from another page
+- **WHEN** the user has stored filters and navigates to a bare `/jobs` (e.g. the "Jobs" nav link) from another route
+- **THEN** the stored filters are applied, the URL is rewritten to reflect them, and the list reloads filtered
+
+#### Scenario: Clicking Jobs while already on a filtered /jobs
+- **WHEN** the user is on `/jobs?…` with active filters and triggers a navigation to a bare `/jobs`
+- **THEN** the stored filters are restored rather than the list being cleared
+
+#### Scenario: Cold load of a bare /jobs
+- **WHEN** the user hard-loads or directly opens a bare `/jobs` (the initial `enter`) while `hire.jobFilters` holds a value
+- **THEN** the unfiltered list is served without a restore and without any error, and the stored value is preserved for a later client-side return
+
+#### Scenario: No stored filters
+- **WHEN** the user lands on a bare `/jobs` and `hire.jobFilters` is absent or empty
+- **THEN** the unfiltered list is shown and nothing is restored
+
+### Requirement: URL filter params take precedence over storage
+The system SHALL apply the URL's filter params when they are present on `/jobs`, ignoring any stored value. A pure link/refresh load SHALL leave storage untouched (storage mirrors only explicit user changes); once the user interacts with the URL-seeded filters, that explicit change updates storage as usual.
+
+#### Scenario: Opening a shared filtered link
+- **WHEN** the user opens `/jobs?regions=US` while `hire.jobFilters` holds a different set
+- **THEN** the URL's filters (`regions=US`) are applied and displayed, and `hire.jobFilters` is left unchanged until the user next edits a filter
+
+### Requirement: Persistence is limited to the standalone jobs list
+The system SHALL NOT persist or restore filters for the company-embedded jobs list, so the shared storage key reflects only the standalone `/jobs` filters.
+
+#### Scenario: Filtering a company's postings
+- **WHEN** the user filters the embedded jobs list on `/companies/:slug`
+- **THEN** `hire.jobFilters` is neither written nor read for that list
+
+### Requirement: Storage failures must not break the page
+The system SHALL degrade gracefully when browser storage is unavailable or throws, keeping the URL as the working source of filter state.
+
+#### Scenario: Storage access throws
+- **WHEN** reading or writing `localStorage` fails (private mode, quota, or disabled storage)
+- **THEN** filtering continues to work from the URL and no error is surfaced to the user

--- a/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/tasks.md
+++ b/openspec/changes/archive/2026-07-06-persist-job-filters-localstorage/tasks.md
@@ -1,0 +1,23 @@
+## 1. Storage module (pure, unit-tested core)
+
+- [x] 1.1 Add a failing vitest for `web/src/lib/filterStorage.ts`: `saveJobFilters` writes a non-empty query string to `hire.jobFilters`; `loadJobFilters` round-trips it; `saveJobFilters('')` removes the key; SSR/no-storage and throwing storage are swallowed (return `''` / no throw).
+- [x] 1.2 Implement `filterStorage.ts` (`loadJobFilters()`, `saveJobFilters(qs)`) self-contained (feature-detects `localStorage`, so the pure-Node vitest resolves it) with try/catch swallowing failures; make the test pass.
+
+## 2. Primitive: explicit-change hook
+
+- [x] 2.1 Add an optional `onWrite?: (value: T, serialized: string) => void` to `UrlSyncedState` and invoke it inside `#write` (only there — not in `syncFromUrl`), passing the already-serialized query string. Keep the primitive storage-agnostic.
+
+## 3. FilterStore opt-in persistence
+
+- [x] 3.1 Give `FilterStore` an opt-in `persist` flag; when set, wire `onWrite` to `saveJobFilters(serialized)` (the URL's own query string) so explicit changes (incl. `clear`/`apply`) mirror to storage and clear removes the key.
+
+## 4. JobsView restore choke-point (standalone only)
+
+- [x] 4.1 Construct the store with `persist` enabled only when standalone (no `scope`); the initial `standalone` is captured via `untrack`.
+- [x] 4.2 Restore on empty-URL landing (client-only) — folded into the 4.3 `afterNavigate` handler (fires on every real navigation including cross-route entry), so no separate `onMount` is needed.
+- [x] 4.3 For the standalone list, wire restore via `afterNavigate` (not a `$effect` — a hydration-time effect throws "replaceState before router initialized"): skip the initial `enter`; on empty `location.search` + stored → `filters.apply(stored)`, else `filters.syncFromUrl()`. Company-embedded list keeps the original `syncOnNavigation(filters)` — unchanged.
+
+## 5. Verification
+
+- [x] 5.1 Run the vitest suite (`filterStorage` green — 38/38) and `svelte-check` (0 errors, 0 warnings). oxlint clean; the 4 eslint errors are pre-existing `origin/main` constructs, not introduced here.
+- [x] 5.2 Playwright end-to-end (dev server against prod API) — 10/10: explicit change writes `hire.jobFilters`; clicking "Jobs" nav restores it (URL rewritten); "Clear all" removes the key and stays unfiltered on return; a shared `/jobs?q=…` wins and leaves storage untouched; company page typing writes nothing; cold hard-load of a bare `/jobs` restores nothing and throws no router error.

--- a/openspec/specs/filter-persistence/spec.md
+++ b/openspec/specs/filter-persistence/spec.md
@@ -1,0 +1,60 @@
+# filter-persistence Specification
+
+## Purpose
+TBD - created by archiving change persist-job-filters-localstorage. Update Purpose after archive.
+## Requirements
+### Requirement: Persist the standalone job filter set on explicit change
+The system SHALL persist the standalone `/jobs` filter set to browser storage (key `hire.jobFilters`, as the serialized filter query string) whenever the user explicitly changes it, and SHALL NOT write storage in response to navigation-driven re-seeding (back/forward or landing on a URL).
+
+#### Scenario: User adjusts a filter
+- **WHEN** a signed-in or anonymous user toggles a facet, edits the search text, moves a slider, or applies a saved search on the standalone `/jobs` list
+- **THEN** the serialized filter query string is written to `hire.jobFilters`
+
+#### Scenario: User clears all filters
+- **WHEN** the user resets the filters (Clear all) so the applied filter set is empty
+- **THEN** the `hire.jobFilters` key is removed, so no filters are restored later
+
+#### Scenario: Navigation does not overwrite storage
+- **WHEN** the filter state is re-seeded by a browser back/forward or an incoming navigation rather than a user edit
+- **THEN** `hire.jobFilters` is left unchanged
+
+### Requirement: Restore stored filters when returning to a bare /jobs
+The system SHALL restore the stored filter set when a client-side navigation lands on the standalone `/jobs` with no filter params in the URL and a non-empty value exists in storage; it SHALL rewrite the URL to reflect the restored filters and reload the list. A cold first load of the page (a hard load, refresh, or direct URL — the router's initial `enter`) SHALL NOT restore and SHALL NOT error; the URL as loaded is served.
+
+#### Scenario: Clicking the Jobs nav from another page
+- **WHEN** the user has stored filters and navigates to a bare `/jobs` (e.g. the "Jobs" nav link) from another route
+- **THEN** the stored filters are applied, the URL is rewritten to reflect them, and the list reloads filtered
+
+#### Scenario: Clicking Jobs while already on a filtered /jobs
+- **WHEN** the user is on `/jobs?…` with active filters and triggers a navigation to a bare `/jobs`
+- **THEN** the stored filters are restored rather than the list being cleared
+
+#### Scenario: Cold load of a bare /jobs
+- **WHEN** the user hard-loads or directly opens a bare `/jobs` (the initial `enter`) while `hire.jobFilters` holds a value
+- **THEN** the unfiltered list is served without a restore and without any error, and the stored value is preserved for a later client-side return
+
+#### Scenario: No stored filters
+- **WHEN** the user lands on a bare `/jobs` and `hire.jobFilters` is absent or empty
+- **THEN** the unfiltered list is shown and nothing is restored
+
+### Requirement: URL filter params take precedence over storage
+The system SHALL apply the URL's filter params when they are present on `/jobs`, ignoring any stored value. A pure link/refresh load SHALL leave storage untouched (storage mirrors only explicit user changes); once the user interacts with the URL-seeded filters, that explicit change updates storage as usual.
+
+#### Scenario: Opening a shared filtered link
+- **WHEN** the user opens `/jobs?regions=US` while `hire.jobFilters` holds a different set
+- **THEN** the URL's filters (`regions=US`) are applied and displayed, and `hire.jobFilters` is left unchanged until the user next edits a filter
+
+### Requirement: Persistence is limited to the standalone jobs list
+The system SHALL NOT persist or restore filters for the company-embedded jobs list, so the shared storage key reflects only the standalone `/jobs` filters.
+
+#### Scenario: Filtering a company's postings
+- **WHEN** the user filters the embedded jobs list on `/companies/:slug`
+- **THEN** `hire.jobFilters` is neither written nor read for that list
+
+### Requirement: Storage failures must not break the page
+The system SHALL degrade gracefully when browser storage is unavailable or throws, keeping the URL as the working source of filter state.
+
+#### Scenario: Storage access throws
+- **WHEN** reading or writing `localStorage` fails (private mode, quota, or disabled storage)
+- **THEN** filtering continues to work from the URL and no error is surfaced to the user
+

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -2,7 +2,7 @@
   import { onMount, untrack, type Snippet } from 'svelte';
   import { Layers } from '@lucide/svelte';
   import { browser } from '$app/environment';
-  import { goto } from '$app/navigation';
+  import { afterNavigate, goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
   import { api, type Slice } from '$lib/api';
@@ -10,6 +10,7 @@
   import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams } from '$lib/filters';
+  import { loadJobFilters } from '$lib/filterStorage';
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
   import { setListSearchTarget } from '$lib/listSearch.svelte';
   import type { Job, FacetCounts } from '$lib/types';
@@ -46,13 +47,15 @@
     sidebarTop?: Snippet;
   } = $props();
 
-  // Seed filters from the current URL so the server and the hydrated client
-  // render the same filtered view.
-  const filters = new FilterStore(page.url.searchParams);
-
   // Standalone /jobs (no fixed scope) hands its text search to the header; an
   // embedded, scoped instance (e.g. a company page) keeps its own inline input.
   const standalone = $derived(Object.keys(scope).length === 0);
+
+  // Seed filters from the current URL so the server and the hydrated client
+  // render the same filtered view. Only the standalone list persists to storage;
+  // the embedded company list must not clobber the shared key. Persistence is
+  // fixed for the store's life, so the initial `standalone` is captured once.
+  const filters = new FilterStore(page.url.searchParams, untrack(() => standalone));
 
   // The user's (debounced) facet filters plus the fixed `scope` params
   // (company_slug, …). Reads `applied` so typing doesn't fetch per keystroke.
@@ -155,9 +158,32 @@
     });
   });
 
-  // Browser back/forward re-seeds the filters from the URL; the resulting
-  // `applied` change drives the reload effect above.
-  syncOnNavigation(filters);
+  // Re-seed the filters from the URL on every real navigation (initial load, the
+  // "Jobs" nav link, back/forward). On the standalone list a navigation that lands
+  // on a bare /jobs (empty URL) instead restores the last persisted filters, so an
+  // ordinary navigation never drops them ("Clear all" persisted an empty set, so it
+  // stays cleared).
+  //
+  // afterNavigate (not a URL-tracking $effect) because it runs only after the router
+  // is initialized: apply()'s replaceState is safe on a client-side navigation (a
+  // hydration-time $effect would throw "before router is initialized"), its `applied`
+  // change lands after the reload effect's first pass, and our own shallow replaceState
+  // writes don't re-fire it — so there's no restore loop. Restore is skipped on the
+  // initial `enter` navigation (a hard load / refresh): the router isn't ready for
+  // replaceState yet, and the SSR already rendered that exact URL, so we just re-seed
+  // from it. Every restore-worthy case — the "Jobs" nav link, cross-route entry,
+  // back/forward — is a client-side navigation, where it works. location.search is the
+  // address-bar truth (page.url can lag after shallow routing). The company-embedded
+  // list (persist off) keeps the plain re-seed — unchanged.
+  if (untrack(() => standalone)) {
+    afterNavigate((nav) => {
+      const stored = nav.type !== 'enter' && location.search === '' ? loadJobFilters() : '';
+      if (stored) filters.apply(stored);
+      else filters.syncFromUrl();
+    });
+  } else {
+    syncOnNavigation(filters);
+  }
 </script>
 
 <div class="flex gap-6">

--- a/web/src/lib/filterStorage.test.ts
+++ b/web/src/lib/filterStorage.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { loadJobFilters, saveJobFilters, JOB_FILTERS_KEY } from './filterStorage';
+
+// A minimal in-memory localStorage stand-in for the Node test environment (where
+// there is no browser storage). Individual tests swap in throwing/undefined
+// variants to exercise the SSR / disabled-storage guards.
+class MemoryStorage {
+  #map = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.#map.has(k) ? (this.#map.get(k) as string) : null;
+  }
+  setItem(k: string, v: string): void {
+    this.#map.set(k, v);
+  }
+  removeItem(k: string): void {
+    this.#map.delete(k);
+  }
+}
+
+describe('filterStorage', () => {
+  afterEach(() => {
+    // @ts-expect-error - clean up the global we install per test
+    delete globalThis.localStorage;
+  });
+
+  it('round-trips a non-empty query string through hire.jobFilters', () => {
+    const store = new MemoryStorage();
+    // @ts-expect-error - install the stand-in
+    globalThis.localStorage = store;
+
+    saveJobFilters('regions=EU&seniority=senior');
+
+    expect(store.getItem(JOB_FILTERS_KEY)).toBe('regions=EU&seniority=senior');
+    expect(loadJobFilters()).toBe('regions=EU&seniority=senior');
+  });
+
+  it('removes the key when saving an empty string', () => {
+    const store = new MemoryStorage();
+    store.setItem(JOB_FILTERS_KEY, 'regions=EU');
+    // @ts-expect-error - install the stand-in
+    globalThis.localStorage = store;
+
+    saveJobFilters('');
+
+    expect(store.getItem(JOB_FILTERS_KEY)).toBeNull();
+    expect(loadJobFilters()).toBe('');
+  });
+
+  it('returns empty and no-ops when storage is unavailable (SSR)', () => {
+    // No globalThis.localStorage installed.
+    expect(loadJobFilters()).toBe('');
+    expect(() => saveJobFilters('regions=EU')).not.toThrow();
+  });
+
+  it('swallows storage access errors (private mode / quota)', () => {
+    // @ts-expect-error - install a throwing stand-in
+    globalThis.localStorage = {
+      getItem() {
+        throw new Error('denied');
+      },
+      setItem() {
+        throw new Error('quota');
+      },
+      removeItem() {
+        throw new Error('denied');
+      },
+    };
+
+    expect(loadJobFilters()).toBe('');
+    expect(() => saveJobFilters('regions=EU')).not.toThrow();
+    expect(() => saveJobFilters('')).not.toThrow();
+  });
+});

--- a/web/src/lib/filterStorage.ts
+++ b/web/src/lib/filterStorage.ts
@@ -1,0 +1,34 @@
+// Persists the standalone /jobs filter set in browser storage as the serialized
+// filter query string, so it survives a navigation back to a bare /jobs. The URL
+// stays the source of truth; this is only the "last explicit filter set" mirror,
+// restored by JobsView when the user lands on /jobs with no filter params.
+//
+// Self-contained on purpose: it feature-detects `localStorage` (typeof) rather
+// than importing `browser` from `$app/environment`, so the unit test runs in the
+// plain-Node vitest env (which has no SvelteKit runtime). Every access is wrapped
+// and failures are swallowed — private mode / quota / disabled storage must never
+// break filtering, which still works from the URL.
+
+export const JOB_FILTERS_KEY = 'hire.jobFilters';
+
+/** The stored filter query string, or '' when absent/unavailable. */
+export function loadJobFilters(): string {
+  if (typeof localStorage === 'undefined') return '';
+  try {
+    return localStorage.getItem(JOB_FILTERS_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/** Mirror the applied filters to storage. An empty string removes the key, so a
+ *  cleared filter set leaves nothing to restore. */
+export function saveJobFilters(qs: string): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    if (qs) localStorage.setItem(JOB_FILTERS_KEY, qs);
+    else localStorage.removeItem(JOB_FILTERS_KEY);
+  } catch {
+    // best-effort: private mode / quota / disabled storage
+  }
+}

--- a/web/src/lib/filters.ts
+++ b/web/src/lib/filters.ts
@@ -4,6 +4,7 @@
 // owns only the SvelteKit-bound FilterStore.
 
 import { UrlSyncedState } from './urlSynced.svelte';
+import { saveJobFilters } from './filterStorage';
 import {
   type FacetState,
   type JobFilters,
@@ -33,12 +34,19 @@ export class FilterStore {
   #url: UrlSyncedState<JobFilters>;
 
   /** Seed from the current URL params (passed by the view from `page.url`), so
-   *  the same filters render on the server and hydrate on the client. */
-  constructor(initial?: URLSearchParams) {
-    this.#url = new UrlSyncedState<JobFilters>(initial ?? new URLSearchParams(), {
-      parse: filtersFromParams,
-      serialize: filtersToParams,
-    });
+   *  the same filters render on the server and hydrate on the client. With
+   *  `persist`, every explicit change is mirrored to localStorage (an empty set
+   *  clears the key), so the standalone /jobs list can restore it after a
+   *  navigation back to a bare URL — see JobsView. Navigation re-seeds don't
+   *  trigger it (the primitive's `onWrite` fires only on explicit writes), so a
+   *  bare URL never wipes the stored set. */
+  constructor(initial?: URLSearchParams, persist = false) {
+    this.#url = new UrlSyncedState<JobFilters>(
+      initial ?? new URLSearchParams(),
+      { parse: filtersFromParams, serialize: filtersToParams },
+      undefined,
+      persist ? (_value, serialized) => saveJobFilters(serialized) : undefined,
+    );
   }
 
   /** Live filters — bind inputs to this. */

--- a/web/src/lib/urlSynced.svelte.ts
+++ b/web/src/lib/urlSynced.svelte.ts
@@ -46,12 +46,26 @@ export class UrlSyncedState<T> {
   // reload per keystroke. `undefined` means no reload is queued (back/forward relies
   // on this being truthful — see syncFromUrl).
   #timer: ReturnType<typeof setTimeout> | undefined;
+  // Fired on every explicit user write (setNow/setSoon), never on syncFromUrl. A
+  // generic hook — the primitive stays storage-agnostic; a consumer uses it to
+  // mirror the change (FilterStore persists it to localStorage). Because it skips
+  // the navigation path, an incoming empty URL never overwrites what was persisted.
+  // Receives the same serialized query string written to the URL, so a persisted
+  // mirror is identical to the URL by construction (no second serialization).
+  #onWrite?: (value: T, serialized: string) => void;
 
   /** Seed from the current URL params (passed by the view from `page.url`), so the
-   *  same state renders on the server and hydrates on the client. */
-  constructor(initial: URLSearchParams, codec: UrlCodec<T>, debounceMs = 300) {
+   *  same state renders on the server and hydrates on the client. `onWrite`, if
+   *  given, is called on each explicit change (see the field note). */
+  constructor(
+    initial: URLSearchParams,
+    codec: UrlCodec<T>,
+    debounceMs = 300,
+    onWrite?: (value: T, serialized: string) => void,
+  ) {
     this.#codec = codec;
     this.#debounceMs = debounceMs;
+    this.#onWrite = onWrite;
     // The field initializers above are typed placeholders; both are seeded here
     // from the URL params. On the client the browser's address bar
     // (location.search) is the authoritative filter state: after a back/forward
@@ -118,5 +132,6 @@ export class UrlSyncedState<T> {
     // write is cheap and synchronous. Browser-only (mutations are user events).
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- in-place query write to the current pathname; there is no route to resolve
     replaceState(page.url.pathname + (qs ? `?${qs}` : ''), {});
+    this.#onWrite?.(next, qs);
   }
 }


### PR DESCRIPTION
## Summary
- Job filters live only in the URL, so returning to a bare `/jobs` (usually the "Jobs" nav link) silently dropped the user's filter set. This mirrors the standalone `/jobs` filters to `localStorage` (`hire.jobFilters`, the serialized query string) and restores them when a client-side navigation lands on an empty `/jobs`.
- Cleared only by an explicit filter change or "Clear all"; URL params still win; a pure link/refresh load leaves storage untouched. Company-embedded list keeps persistence off (shared key untouched).
- Restore is wired via `afterNavigate` (a hydration `$effect` would call `replaceState` before the router is initialized) and skips the initial `enter` load.

## Test Plan
- [x] `vitest` — storage core (round-trip, empty→remove key, SSR/no-storage, throwing storage)
- [x] `svelte-check` — 0 errors, 0 warnings
- [x] Playwright end-to-end (dev server → prod API), 10/10: persist on change, nav-restore, clear removes key + stays clean, `/jobs?q=…` URL wins + storage untouched, company page writes nothing, cold hard-load restores nothing and throws no router error