### PR TITLE
fix(verdict): measure skill frequency against skill-bearing vacancies

### DIFF
--- a/internal/handler/resume_verdict.go
+++ b/internal/handler/resume_verdict.go
@@ -62,9 +62,19 @@ func (a *API) computeCoverage(c *fiber.Ctx, userID int64, profile db.UserProfile
 	if err != nil {
 		return verdict.Verdict{}, err
 	}
+	// Skill-bearing total: the role's vacancies that list at least one tagged skill.
+	// Skill frequency (and the must-have flag) is measured against this, not the raw
+	// role total, so postings the tagger left skill-less don't deflate frequencies.
+	skilled, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
+		Filter: search.AndSkillsPresent(roleFilter),
+	})
+	if err != nil {
+		return verdict.Verdict{}, err
+	}
 	declared, body, all := a.cvSkillSets(c, userID)
 	return verdict.Compute(verdict.Input{
 		Total:           role.Total,
+		SkilledTotal:    skilled.Total,
 		UncoveredTotal:  uncovered.Total,
 		UncoveredSkills: uncovered.Facets["skills"],
 		RoleSkills:      role.Facets["skills"],

--- a/internal/search/filter.go
+++ b/internal/search/filter.go
@@ -105,6 +105,17 @@ func AndNotSkills(base any, skills []string) any {
 	return Filter(groups...)
 }
 
+// AndSkillsPresent narrows a base filter (as built by FilterFromValues) to
+// documents whose `skills` array is non-empty. It backs the verdict's
+// skill-bearing count: skill frequency is measured against vacancies that list
+// at least one tagged skill, not the whole role, so postings the tagger left
+// skill-less don't deflate every frequency.
+func AndSkillsPresent(base any) any {
+	groups, _ := base.([][]string)
+	groups = append(groups, []string{IsNotEmpty("skills")})
+	return Filter(groups...)
+}
+
 // quote wraps a value in a Meilisearch string literal, backslash-escaping the
 // double-quote and backslash characters.
 func quote(value string) string {

--- a/internal/verdict/breakdown_test.go
+++ b/internal/verdict/breakdown_test.go
@@ -73,6 +73,47 @@ func TestCompute_MustHaveCoverage(t *testing.T) {
 	}
 }
 
+func TestCompute_FrequencyUsesSkilledTotalWhenSet(t *testing.T) {
+	// Frequency is measured against skill-bearing vacancies, not all vacancies:
+	// react is tagged in 350 of 1000 role vacancies but 350 of the 500 that list
+	// any skill → 70%, clearing the must-have threshold that a raw 35% would miss.
+	// This removes the deflation caused by postings the tagger left skill-less.
+	v := Compute(Input{
+		Total:        1000,
+		SkilledTotal: 500,
+		RoleSkills:   map[string]int64{"react": 350},
+	})
+	r, ok := rowByName(v.Skills, "react")
+	if !ok {
+		t.Fatal("no skill row for react")
+	}
+	if r.MarketFrequency != 70 {
+		t.Errorf("react market_frequency = %d, want 70 (350/500)", r.MarketFrequency)
+	}
+	if !r.MustHave {
+		t.Error("react must_have = false, want true (70% ≥ threshold)")
+	}
+	if v.MustHaveTotal != 1 {
+		t.Errorf("MustHaveTotal = %d, want 1", v.MustHaveTotal)
+	}
+}
+
+func TestCompute_FrequencyFallsBackToTotalWithoutSkilledTotal(t *testing.T) {
+	// No SkilledTotal (0) → frequency falls back to the all-vacancy Total, so
+	// behaviour is unchanged for callers that don't supply it.
+	v := Compute(Input{
+		Total:      1000,
+		RoleSkills: map[string]int64{"react": 350},
+	})
+	r, _ := rowByName(v.Skills, "react")
+	if r.MarketFrequency != 35 {
+		t.Errorf("react market_frequency = %d, want 35 (350/1000 fallback)", r.MarketFrequency)
+	}
+	if r.MustHave {
+		t.Error("react must_have = true, want false (35% < threshold under fallback)")
+	}
+}
+
 func TestCompute_StackMatchBreadth(t *testing.T) {
 	// a strong, b hidden, c & d missing → 2 of 4 held → 50%.
 	v := Compute(Input{

--- a/internal/verdict/input.go
+++ b/internal/verdict/input.go
@@ -13,7 +13,13 @@ type Input struct {
 	UncoveredTotal  int64
 	UncoveredSkills map[string]int64
 	RoleSkills      map[string]int64
-	Declared        []string
-	Body            []string
-	All             []string // declared ∪ body — the CV's full parsed skill set (for bundles)
+	// SkilledTotal is the role's open vacancies that list at least one tagged skill.
+	// Skill frequency (and the must-have flag it drives) is measured against it, not
+	// Total: a posting the tagger left skill-less is missing data, not evidence a
+	// skill is absent, so counting it in the denominator deflates every frequency.
+	// Zero means "not supplied" and frequency falls back to Total (see addBreakdown).
+	SkilledTotal int64
+	Declared     []string
+	Body         []string
+	All          []string // declared ∪ body — the CV's full parsed skill set (for bundles)
 }

--- a/internal/verdict/verdict.go
+++ b/internal/verdict/verdict.go
@@ -93,9 +93,16 @@ func addBreakdown(v *Verdict, in Input) {
 	declared := toSet(in.Declared)
 	body := toSet(in.Body)
 
+	// Measure skill frequency against skill-bearing vacancies, falling back to the
+	// all-vacancy Total when the caller doesn't supply SkilledTotal (see Input).
+	freqTotal := in.SkilledTotal
+	if freqTotal <= 0 {
+		freqTotal = in.Total
+	}
+
 	held := 0 // top skills the CV holds (strong or hidden — adjacent does NOT count)
 	for _, name := range topRoleSkills(in.RoleSkills) {
-		freq := percent(in.RoleSkills[name], in.Total)
+		freq := percent(in.RoleSkills[name], freqTotal)
 		mustHave := freq >= MustHavePct
 		status, closeSkill := classify(name, declared, body)
 		v.Skills = append(v.Skills, SkillRow{

--- a/web/src/lib/components/VerdictView.svelte
+++ b/web/src/lib/components/VerdictView.svelte
@@ -60,9 +60,20 @@
   <!-- Market-anchored stats -->
   <div class="grid gap-3 sm:grid-cols-3">
     <div class="flex flex-col gap-1 rounded-xl border border-border bg-card p-4">
-      <span class="text-3xl font-semibold tabular-nums leading-none">
-        {verdict.must_have_covered}<span class="text-lg text-muted-foreground">/{verdict.must_have_total}</span>
-      </span>
+      {#if verdict.must_have_total > 0}
+        <span class="text-3xl font-semibold tabular-nums leading-none">
+          {verdict.must_have_covered}<span class="text-lg text-muted-foreground">/{verdict.must_have_total}</span>
+        </span>
+      {:else}
+        <!-- No skill clears the must-have frequency threshold for this role, so the
+             covered/total ratio is undefined — show a dash instead of a broken "0/0". -->
+        <span
+          class="text-3xl font-semibold leading-none text-muted-foreground"
+          title="No single skill appears in the majority of this role's vacancies, so there's no must-have to measure."
+        >
+          —
+        </span>
+      {/if}
       <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Must-have skills covered</span>
     </div>
     <div class="flex flex-col gap-1 rounded-xl border border-border bg-card p-4">


### PR DESCRIPTION
## Problem
The coverage view showed **"0/0 Must-have skills covered"** for common dev roles — it read as broken.

Root cause: must-have frequency was `skill_count / all_role_vacancies`. The deterministic `skilltag` dictionary never guesses, so many postings carry no tagged skills, yet they still counted in the denominator — deflating every frequency. Measured on prod:

| Role | tag coverage | top skill old% → **new%** | must-have old → **new** |
|------|:---:|---|:---:|
| frontend | 53% | react 38 → **71**, ts 32 → **60**, js 28 → **53** | 0 → **3** |
| fullstack | ~93% | react 58 → **62**, ts 48 → **51** | 1 → **2** |
| backend | 91% | aws 43 → 47, java 36 → 40 | 0 → **0** (honest — no universal skill) |

## Fix
A posting with no tagged skills is *missing data*, not evidence a skill is absent, so it doesn't belong in the denominator.
- Add `search.AndSkillsPresent` (`skills IS NOT EMPTY`) and query the role's **skill-bearing total**.
- `verdict.Compute` divides skill frequency by `SkilledTotal`, falling back to the raw `Total` when unset (callers/tests unchanged).
- `VerdictView` renders a legitimate empty must-have set (e.g. backend) as **"—"** instead of "0/0".

## Verification
- Unit tests: freq uses `SkilledTotal` when set; falls back to `Total` when not. Full `go test ./...` green.
- Filter verified against **prod Meilisearch**: `category=frontend AND skills IS NOT EMPTY` → 3603, matching Postgres ground truth (3592) within index staleness. backend → 7309 (PG 7310).
- `gofmt`/`go vet` clean; `svelte-check` clean on VerdictView.

No wire-contract change (`Input` is handler-side; `Verdict` fields unchanged).