### PR TITLE
feat(sources): eastern-roots coverage — 6 boards, 3 slug de-merges, 10 collection slugs

### DIFF
--- a/internal/collections/eastern_roots.txt
+++ b/internal/collections/eastern_roots.txt
@@ -4,6 +4,7 @@
 # Matched to our catalogue via normalize.Slug at import (cmd/import-collections);
 # unmatched slugs are simply logged. Lines starting with # are comments.
 10web
+1inch
 1password
 3commas
 abbyy
@@ -56,6 +57,7 @@ cattle-care
 centro-ortnec
 chainlink-labs
 chainstack
+chatfuel
 chattermill
 ciklum
 cindicator
@@ -113,6 +115,7 @@ fundraise-up
 fxpro
 g5-games
 garage-it
+genesis-tech
 gismart
 gitlab
 glam-ai
@@ -125,6 +128,7 @@ grammarly
 grid-dynamics
 group-ib
 haut-ai
+headway-inc
 helio-games
 hexens
 higgsfield-ai
@@ -145,16 +149,20 @@ instories
 intellias
 investengine
 inworld-ai
+itechart
 jet-admin
 jetbrains
+jooble
 joom
 kadmos
 kaspersky
 kaspersky-lab
 kevin
 kodland
+kommo
 krisp
 legionfarm
+let-s-enhance
 lifemost
 lokalise
 luminai
@@ -164,6 +172,7 @@ manychat
 mapbox
 medvidi
 mellow
+mercuryo
 mgid
 mirantis
 miratech
@@ -227,6 +236,7 @@ readymag
 recraft
 red
 redtrack
+reface
 remofirst
 replika
 restream

--- a/openspec/changes/eastern-roots-coverage/proposal.md
+++ b/openspec/changes/eastern-roots-coverage/proposal.md
@@ -1,0 +1,47 @@
+# Eastern-roots coverage
+
+## Why
+
+idagent.pro/companies curates 82 international tech companies with Eastern
+European / Russian-speaking roots. An audit of that list against our catalogue
+found two gaps:
+
+- Several companies are ingestable via an ATS we already support but were not
+  yet in a board file.
+- Several ingested (or newly-addable) companies were missing from the
+  `eastern-roots` collection membership, so they never receive the tag.
+
+It also surfaced a latent data bug: three eastern-roots companies were merging
+into a shared catalogue company row under a generic slug (`ajax`, `vivid`,
+`genesis`) alongside unrelated companies, because `company` was a bare generic
+name.
+
+## What Changes
+
+- **Add 6 live-validated ATS boards** to existing board files: Chatfuel
+  (breezy), Kommo (workable), Jooble (teamtailor), Emerging Travel Group
+  (workable), Let's Enhance (teamtailor), Headway Inc (teamtailor).
+- **Disambiguate 3 generic-slug merges** by renaming the eastern-roots company
+  to a unique name (board unchanged): `lever` `ajax` → **Ajax Systems**,
+  `personio` `vivid` → **Vivid Money**, `breezy` `gen-tech` → **Genesis Tech**.
+  This both fixes the merge and yields a slug that matches the membership list.
+- **Add 10 membership slugs** to `internal/collections/eastern_roots.txt`:
+  `1inch`, `chatfuel`, `genesis-tech`, `headway-inc`, `itechart`, `jooble`,
+  `kommo`, `let-s-enhance`, `mercuryo`, `reface`.
+
+## Non-goals
+
+- Building new ATS adapters for companies that only expose custom or
+  LinkedIn-only careers sites (Kaspersky, Revolut, Grammarly, DataArt,
+  SoftServe, Nexters, G5, Fibery, YouHodler, Bitrix24, StarWind, Bitfury,
+  Grid Dynamics, Plesk/UKG, Zerion, Ecwid). Each is a separate change.
+- No behavior/requirement change to the `source-ingest` or `job-collections`
+  capabilities — this is data/content only, so the change carries **no spec
+  delta** (archive with `--skip-specs`).
+
+## Impact
+
+- Data files only: `sources/{breezy,lever,personio,teamtailor,workable}.yml`,
+  `internal/collections/eastern_roots.txt`.
+- Ops to land after merge: ingest the changed board files, run `cmd/reslug`
+  (for the 3 renames), run `cmd/import-collections`, then `make reindex`.

--- a/openspec/changes/eastern-roots-coverage/tasks.md
+++ b/openspec/changes/eastern-roots-coverage/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## 1. Source boards
+
+- [x] 1.1 Add live-validated boards: Chatfuel (`breezy.yml`), Kommo + Emerging
+  Travel Group (`workable.yml`), Jooble + Let's Enhance + Headway Inc
+  (`teamtailor.yml`).
+- [x] 1.2 Disambiguate generic-slug merges: rename `lever` `ajax` → Ajax Systems,
+  `personio` `vivid` → Vivid Money, `breezy` `gen-tech` → Genesis Tech.
+
+## 2. Collection membership
+
+- [x] 2.1 Add 10 eastern-roots slugs to `eastern_roots.txt`, alphabetically
+  placed, no duplicates.
+
+## 3. Verify
+
+- [x] 3.1 All five board files parse as YAML; new/renamed entries are unique.
+- [x] 3.2 `go build ./...` and `go test ./internal/collections/` green.

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -2361,7 +2361,7 @@
   board: gci-security-inc
 - company: GCU UK
   board: gcu-uk-ltd
-- company: Genesis
+- company: Genesis Tech
   board: gen-tech
 - company: George F. Young
   board: george-f-young
@@ -3565,3 +3565,5 @@
   board: zwitterco
 - company: Step Up Team
   board: step-up-team
+- company: Chatfuel
+  board: chatfuel

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -967,7 +967,7 @@
   board: airtm
 - company: aizon
   board: aizon
-- company: ajax
+- company: Ajax Systems
   board: ajax
 - company: ajccanada
   board: ajccanada

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -2429,7 +2429,7 @@
   board: virtual-solution-ag
 - company: vital-pms
   board: vital-pms
-- company: vivid
+- company: Vivid Money
   board: vivid
 - company: vivira
   board: vivira

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -2616,3 +2616,9 @@
   board: pit.teamtailor.com
 - company: Summize
   board: summize.teamtailor.com
+- company: Jooble
+  board: jooble.teamtailor.com
+- company: Let's Enhance
+  board: careers.letsenhance.io
+- company: Headway Inc
+  board: headway.teamtailor.com

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1082,3 +1082,7 @@
   board: gigabrands
 - company: Unpack Holdings Limited
   board: unpack-holdings-limited
+- company: Kommo
+  board: kommo
+- company: Emerging Travel Group
+  board: emerging-travel-group


### PR DESCRIPTION
## Why

Audit of [idagent.pro/companies](https://www.idagent.pro/companies) (82 international tech companies with Eastern-European / Russian-speaking roots) against our catalogue found: some companies ingestable via a supported ATS were not in a board file; some ingested/newly-addable companies were missing from `eastern-roots` collection membership; and three eastern-roots companies were **merging into a shared catalogue row** under a generic slug (`ajax`, `vivid`, `genesis`) alongside unrelated companies.

## What

**Add 6 live-validated ATS boards:**
| Company | File | Board |
|---|---|---|
| Chatfuel | `breezy.yml` | `chatfuel` |
| Kommo | `workable.yml` | `kommo` |
| Jooble | `teamtailor.yml` | `jooble.teamtailor.com` |
| Emerging Travel Group | `workable.yml` | `emerging-travel-group` |
| Let's Enhance | `teamtailor.yml` | `careers.letsenhance.io` |
| Headway Inc | `teamtailor.yml` | `headway.teamtailor.com` |

**Disambiguate 3 generic-slug merges** (board unchanged, unique name → unique slug that matches the membership list): `lever` `ajax` → **Ajax Systems**, `personio` `vivid` → **Vivid Money**, `breezy` `gen-tech` → **Genesis Tech**. The colliding `ashby`/`bamboohr`/other generic boards are confirmed *different* companies and left as-is.

**Add 10 membership slugs** to `internal/collections/eastern_roots.txt`: `1inch`, `chatfuel`, `genesis-tech`, `headway-inc`, `itechart`, `jooble`, `kommo`, `let-s-enhance`, `mercuryo`, `reface`.

## Not in scope

New ATS adapters for companies on custom / LinkedIn-only careers sites (Kaspersky, Revolut, Grammarly, DataArt, SoftServe, Nexters, G5, Fibery, YouHodler, Bitrix24, StarWind, Bitfury, Grid Dynamics, Plesk/UKG, Zerion, Ecwid) — each a separate change.

## Verification

- All 5 board files parse as YAML; new/renamed entries unique; no duplicate slugs.
- `go build ./...` and `go test ./internal/collections/` green.

Data/content only — no spec delta (OpenSpec change `eastern-roots-coverage`, archive with `--skip-specs`).

## Ops to land (after merge)

1. Ingest changed board files (`breezy`, `teamtailor`, `workable`, `lever`, `personio`).
2. `cmd/reslug` — re-slug the 3 renamed companies.
3. `cmd/import-collections` — apply `eastern-roots` tags.
4. `make reindex` — refresh the Meili facet.