### PR TITLE
feat(sources): add DataArt careers adapter (sitemap + JobPosting ld+json)

### DIFF
--- a/internal/sources/dataart.go
+++ b/internal/sources/dataart.go
@@ -1,0 +1,168 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// dataart adapts DataArt's careers site (www.dataart.team), a single-company source with no
+// per-tenant board id (boardless). DataArt runs a custom careers SPA fronting no supported ATS,
+// but its sitemap enumerates every vacancy and each vacancy page server-renders a schema.org
+// JobPosting ld+json block, so this adapter is the EPAM/SuccessFactors shape — sitemap to
+// enumerate, per-vacancy detail fetch for the posting — over the shared ld+json helper.
+type dataart struct {
+	http dataartHTTP
+}
+
+// dataartHTTP is the transport dataart needs: the XML sitemap plus HTML detail pages.
+type dataartHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+const dataartSitemapURL = "https://www.dataart.team/sitemap.xml"
+
+// NewDataArt builds the DataArt adapter over the given HTTP client.
+func NewDataArt(c dataartHTTP) Source { return dataart{http: c} }
+
+func (dataart) Provider() string { return "dataart" }
+
+// dataart is single-company, so its config entries carry no board.
+func (dataart) boardless() {}
+
+func (d dataart) Fetch(ctx context.Context, ce CompanyEntry) ([]Job, error) {
+	var sitemap struct {
+		URLs []struct {
+			Loc string `xml:"loc"`
+		} `xml:"url"`
+	}
+	if err := d.http.GetXML(ctx, dataartSitemapURL, &sitemap); err != nil {
+		return nil, fmt.Errorf("dataart: sitemap: %w", err)
+	}
+
+	// Keep only canonical English vacancy pages: the listing root, unrelated pages, and the
+	// /xx/vacancies/… localisations yield no code, so each vacancy is ingested once.
+	var urls []string
+	for _, u := range sitemap.URLs {
+		if dataartVacancyCode(u.Loc) != "" {
+			urls = append(urls, u.Loc)
+		}
+	}
+
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return d.detail(ctx, ce, u)
+	}), nil
+}
+
+// detail fetches one vacancy page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the URL has no code, the fetch fails, or the page carries no JobPosting, so the caller
+// skips just that posting.
+func (d dataart) detail(ctx context.Context, ce CompanyEntry, jobURL string) (Job, bool) {
+	id := dataartVacancyCode(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := d.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p dataartPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	location := p.location()
+	// A "Remote.*" tag is DataArt's structured remote-option signal, so it sets WorkMode
+	// (clean provenance); other jobs leave WorkMode empty and the pipeline parses the location.
+	remote := p.remote()
+	workMode := ""
+	if remote {
+		workMode = "remote"
+	}
+	return Job{
+		ExternalID:  id,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     ce.Company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      remote || isRemote(location),
+		WorkMode:    workMode,
+		PostedAt:    parseDate(p.DatePosted),
+	}, true
+}
+
+// dataartVacancyCodePattern captures the vacancy code from a canonical English vacancy URL
+// (https://www.dataart.team/vacancies/<code>). Anchoring the host directly before /vacancies/
+// excludes the /xx/vacancies/… localisations; requiring a code segment excludes the listing root.
+var dataartVacancyCodePattern = regexp.MustCompile(`^https?://www\.dataart\.team/vacancies/([a-z0-9]+)/?$`)
+
+// dataartVacancyCode extracts the vacancy code from a canonical English vacancy URL, returning
+// "" for the listing root, localisations, and unrelated pages.
+func dataartVacancyCode(u string) string {
+	if m := dataartVacancyCodePattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// dataartPosting is the schema.org JobPosting decoded from a DataArt vacancy page's ld+json.
+type dataartPosting struct {
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	DatePosted  string         `json:"datePosted"`
+	JobLocation []dataartPlace `json:"jobLocation"`
+}
+
+type dataartPlace struct {
+	Address dataartAddress `json:"address"`
+}
+
+type dataartAddress struct {
+	Country  string `json:"addressCountry"`
+	Locality string `json:"addressLocality"`
+}
+
+// location joins each jobLocation place as "City, Country" (falling back to whichever part is
+// present), deduped and separated by "; ", so a job open in several cities lists them all. It
+// drops DataArt's internal "Remote.*" region codes (see dataartRealPlace) so they don't leak
+// into the user-visible location; a place left with no real part is skipped.
+func (p dataartPosting) location() string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, pl := range p.JobLocation {
+		s := joinNonEmpty(dataartRealPlace(pl.Address.Locality), dataartRealPlace(pl.Address.Country))
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return strings.Join(out, "; ")
+}
+
+// remote reports whether any jobLocation carries DataArt's "Remote.*" tag — its explicit
+// remote-option marker, which location() strips from the visible text.
+func (p dataartPosting) remote() bool {
+	for _, pl := range p.JobLocation {
+		if strings.HasPrefix(pl.Address.Country, "Remote.") || strings.HasPrefix(pl.Address.Locality, "Remote.") {
+			return true
+		}
+	}
+	return false
+}
+
+// dataartRealPlace returns a place-name component unless it is one of DataArt's internal
+// "Remote.*" region codes (e.g. "Remote.LATAM-country", "Remote.AR"), which are not real places.
+func dataartRealPlace(s string) string {
+	if strings.HasPrefix(s, "Remote.") {
+		return ""
+	}
+	return s
+}

--- a/internal/sources/dataart_test.go
+++ b/internal/sources/dataart_test.go
@@ -1,0 +1,188 @@
+package sources
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDataartVacancyCode(t *testing.T) {
+	cases := map[string]string{
+		"https://www.dataart.team/vacancies/sla116":       "sla116",
+		"https://www.dataart.team/vacancies/jav1526":      "jav1526",
+		"https://www.dataart.team/vacancies/ml00057":      "ml00057",
+		"https://www.dataart.team/vacancies/go00040/":     "go00040",
+		"https://www.dataart.team/es/vacancies/sla116":    "", // localisation → skipped
+		"https://www.dataart.team/ua/vacancies/sla116":    "",
+		"https://www.dataart.team/vacancies":              "", // listing root
+		"https://www.dataart.team/events/archive":         "",
+		"https://www.dataart.team/vacancies/sla116/apply": "", // deeper path, not a vacancy
+	}
+	for u, want := range cases {
+		if got := dataartVacancyCode(u); got != want {
+			t.Errorf("dataartVacancyCode(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func TestDataartPostingLocation(t *testing.T) {
+	p := dataartPosting{JobLocation: []dataartPlace{
+		{Address: dataartAddress{Locality: "Almaty", Country: "Kazakhstan"}},
+		{Address: dataartAddress{Locality: "Warsaw", Country: "Poland"}},
+	}}
+	if got, want := p.location(), "Almaty, Kazakhstan; Warsaw, Poland"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	// Country-only place falls back to the country.
+	if got, want := (dataartPosting{JobLocation: []dataartPlace{
+		{Address: dataartAddress{Country: "Germany"}},
+	}}).location(), "Germany"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	// Duplicate places collapse.
+	if got, want := (dataartPosting{JobLocation: []dataartPlace{
+		{Address: dataartAddress{Locality: "Kyiv", Country: "Ukraine"}},
+		{Address: dataartAddress{Locality: "Kyiv", Country: "Ukraine"}},
+	}}).location(), "Kyiv, Ukraine"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	if got := (dataartPosting{}).location(); got != "" {
+		t.Errorf("location() = %q, want empty", got)
+	}
+}
+
+func TestDataartPostingStripsRemoteCodes(t *testing.T) {
+	// DataArt leaks internal "Remote.*" region codes into the address; location() drops them
+	// (keeping a real city), skips a fully-coded place, and remote() flags the posting remote.
+	p := dataartPosting{JobLocation: []dataartPlace{
+		{Address: dataartAddress{Locality: "Buenos Aires", Country: "Remote.LATAM-country"}},
+		{Address: dataartAddress{Locality: "Remote.AR", Country: "Remote.LATAM-country"}},
+		{Address: dataartAddress{Locality: "Kyiv", Country: "Ukraine"}},
+	}}
+	if got, want := p.location(), "Buenos Aires; Kyiv, Ukraine"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	if !p.remote() {
+		t.Error("remote() = false, want true (a Remote.* tag is present)")
+	}
+	if (dataartPosting{JobLocation: []dataartPlace{
+		{Address: dataartAddress{Locality: "Kyiv", Country: "Ukraine"}},
+	}}).remote() {
+		t.Error("remote() = true, want false (no Remote.* tag)")
+	}
+}
+
+// dataartDetailHTML builds a DataArt vacancy page carrying a JobPosting ld+json block with a
+// jobLocation array of Place (address country + locality).
+func dataartDetailHTML(title, description, datePosted string, places ...[2]string) string {
+	var jl string
+	for i, p := range places {
+		if i > 0 {
+			jl += ","
+		}
+		jl += `{"@type":"Place","address":{"@type":"PostalAddress","addressCountry":"` +
+			p[1] + `","addressLocality":"` + p[0] + `"}}`
+	}
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + description + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"employmentType":"FULL_TIME",` +
+		`"jobLocation":[` + jl + `]}` +
+		`</script></head><body></body></html>`
+}
+
+func dataartSitemapXML(locs ...string) string {
+	s := `<?xml version="1.0" encoding="UTF-8"?><urlset>`
+	for _, l := range locs {
+		s += `<url><loc>` + l + `</loc></url>`
+	}
+	return s + `</urlset>`
+}
+
+func TestDataartFetchSitemapThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://www.dataart.team/vacancies/sla116"
+	detail := dataartDetailHTML(
+		"Shopify Solutions Architect",
+		"&lt;p&gt;Lead &lt;b&gt;Shopify&lt;/b&gt;.&lt;/p&gt;&lt;script&gt;x&lt;/script&gt;",
+		"2025-05-07",
+		[2]string{"Almaty", "Kazakhstan"}, [2]string{"Warsaw", "Poland"})
+
+	fake := (&routedHTTP{}).
+		route("sitemap.xml", dataartSitemapXML(
+			jobURL,
+			"https://www.dataart.team/es/vacancies/sla116", // localisation, skipped
+			"https://www.dataart.team/vacancies",           // listing root, skipped
+			"https://www.dataart.team/events/archive",      // unrelated, skipped
+		)).
+		route("/vacancies/sla116", detail)
+
+	jobs, err := NewDataArt(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "DataArt", Provider: "dataart",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (localised + listing URLs must be excluded)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "sla116" {
+		t.Errorf("ExternalID = %q, want sla116", j.ExternalID)
+	}
+	if j.Title != "Shopify Solutions Architect" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "DataArt" {
+		t.Errorf("Company = %q, want DataArt", j.Company)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Location != "Almaty, Kazakhstan; Warsaw, Poland" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	// sanitizeHTML keeps safe formatting tags and strips only dangerous ones (e.g. <script>).
+	if want := "<p>Lead <b>Shopify</b>.</p>"; j.Description != want {
+		t.Errorf("Description = %q, want %q (HTML unescaped + sanitized)", j.Description, want)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2025-05-07" {
+		t.Errorf("PostedAt = %v, want 2025-05-07", j.PostedAt)
+	}
+	// No Remote.* tag among these places → no structured work-mode.
+	if j.WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty (no structured remote signal)", j.WorkMode)
+	}
+}
+
+func TestDataartDetailRemoteWorkMode(t *testing.T) {
+	jobURL := "https://www.dataart.team/vacancies/rem001"
+	detail := dataartDetailHTML("Remote Engineer", "d", "2026-01-02",
+		[2]string{"Buenos Aires", "Remote.LATAM-country"})
+	fake := (&routedHTTP{}).route("/vacancies/rem001", detail)
+
+	j, ok := dataart{http: fake}.detail(context.Background(),
+		CompanyEntry{Company: "DataArt", Provider: "dataart"}, jobURL)
+	if !ok {
+		t.Fatal("detail returned ok=false")
+	}
+	if j.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (structured Remote.* tag)", j.WorkMode)
+	}
+	if !j.Remote {
+		t.Error("Remote = false, want true")
+	}
+	if j.Location != "Buenos Aires" {
+		t.Errorf("Location = %q, want %q (Remote.* code stripped)", j.Location, "Buenos Aires")
+	}
+}
+
+func TestDataartProviderAndBoardless(t *testing.T) {
+	var s Source = NewDataArt(nil)
+	if s.Provider() != "dataart" {
+		t.Errorf("Provider() = %q, want dataart", s.Provider())
+	}
+	if _, ok := s.(boardless); !ok {
+		t.Error("dataart must be boardless (single-company, no board id)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -230,6 +230,7 @@ func All(c HTTPClient) map[string]Source {
 		NewGoogle(c),
 		NewApple(c),
 		NewLumenalta(c),
+		NewDataArt(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/openspec/changes/dataart-source/design.md
+++ b/openspec/changes/dataart-source/design.md
@@ -1,0 +1,30 @@
+# Design
+
+## Approach
+
+Mirror the `epam` adapter (sitemap → per-vacancy ld+json detail), differing only
+where DataArt differs:
+
+- **Host is fixed**, not a board. DataArt is one company at `www.dataart.team`,
+  so the adapter is **boardless** (`func (dataart) boardless() {}`) and hardcodes
+  the host — no board id in the config entry (like `lumenalta`).
+- **Plain sitemap.** `https://www.dataart.team/sitemap.xml` (not gzip); decode
+  with `GetXML`.
+- **Canonical-URL filter = dedup id.** Keep only
+  `https://www.dataart.team/vacancies/{code}` where `{code}` is alphanumeric and
+  there is no language prefix. `dataartVacancyCode(url)` returns the code (the
+  `ExternalID`) or `""` for the listing root and `/es|ua|pl|bg/vacancies/...`
+  localisations, so each vacancy is ingested once — the same trick as epam's
+  `_en` filter.
+- **Location from `jobLocation`.** Unlike EPAM, DataArt's `JobPosting` carries a
+  `jobLocation` array of `Place`; `location()` joins each `"City, Country"`
+  (falling back to whichever part is present), deduped, comma-separated.
+
+Everything else reuses the shared helpers: `ldJobPosting`, `fetchDetails` +
+`defaultDetailWorkers`, `sanitizeHTML`, `parseDate`, `isRemote`, `joinNonEmpty`.
+
+## Why not the private JSON API
+
+`/dataart-team/api/vacancy/{code}` returns richer structured data, but it is an
+undocumented private endpoint; the standard schema.org ld+json is stable, public,
+and already has every field we normalize — no reason to couple to the private API.

--- a/openspec/changes/dataart-source/proposal.md
+++ b/openspec/changes/dataart-source/proposal.md
@@ -1,0 +1,40 @@
+# DataArt source adapter
+
+## Why
+
+DataArt (dataart.team) is one of the Eastern-roots companies our idagent audit
+flagged as uncovered: it runs a custom careers SPA, not a supported ATS, so we
+ingest none of its ~136 open vacancies. A feasibility spike found a clean,
+keyless enumeration path — `sitemap.xml` lists every vacancy as
+`/vacancies/{code}`, and each vacancy page server-renders a standard schema.org
+`JobPosting` ld+json block (title, description, `jobLocation` country+city,
+`datePosted`, `employmentType`). This is exactly the sitemap-plus-ld+json shape
+our EPAM and SuccessFactors adapters already use, so a small adapter closes the
+gap. The company slug `dataart` is already in `eastern_roots.txt`, so ingesting
+it also lands the `eastern-roots` collection tag automatically.
+
+## What Changes
+
+- Add a `dataart` source adapter: enumerate `https://www.dataart.team/sitemap.xml`,
+  keep the canonical English vacancy URLs (`/vacancies/{code}`, excluding the
+  listing root and `/xx/vacancies/...` localisations), fetch each page, and map
+  its `JobPosting` ld+json to a `Job` with the vacancy `code` as the stable
+  `ExternalID`.
+- It is a **boardless single-company** adapter (fixed host, one company), like
+  `lumenalta` — registered in `sources.All`, excluded from the source facet.
+- Add `sources/dataart.yml` (one boardless entry: `DataArt`, `provider: dataart`).
+
+## Non-goals
+
+- No use of DataArt's richer private JSON API (`/dataart-team/api/vacancy/{code}`);
+  the standard ld+json is sufficient and matches the existing adapter pattern.
+- No new anti-bot/fingerprint transport — the site serves the shared client fine.
+- Other uncovered eastern-roots companies remain separate changes.
+
+## Impact
+
+- New: `internal/sources/dataart.go` (+ test), `sources/dataart.yml`,
+  `specs/dataart-source`. One line in `sources.All`.
+- Ops to land: a cron slot for `cmd/ingest sources/dataart.yml`; the company
+  slug `dataart` already sits in `eastern_roots.txt`, so `cmd/import-collections`
+  tags it once ingested.

--- a/openspec/changes/dataart-source/specs/dataart-source/spec.md
+++ b/openspec/changes/dataart-source/specs/dataart-source/spec.md
@@ -1,0 +1,40 @@
+# dataart-source Specification
+
+## ADDED Requirements
+
+### Requirement: DataArt careers crawl
+
+The system SHALL provide a `dataart` source adapter that crawls DataArt's careers
+site (`www.dataart.team`) into the catalogue. It is a **boardless single-company**
+adapter: config entries carry no board, the host is fixed, and it is excluded from
+the source facet. The crawl is keyless. It enumerates
+`https://www.dataart.team/sitemap.xml`, keeps the canonical English vacancy URLs,
+fetches each vacancy page, and maps its schema.org `JobPosting` ld+json to a `Job`.
+
+#### Scenario: Sitemap enumerates, each vacancy maps to a Job
+
+- **WHEN** the adapter fetches its configured company entry
+- **THEN** it returns one `Job` per canonical English vacancy URL in the sitemap,
+  with the posting's title, sanitized HTML description, joined `jobLocation`
+  city/country text, apply/detail URL, and posted-at date read from the vacancy
+  page's `JobPosting` ld+json
+
+#### Scenario: Stable dedup identity from the vacancy code
+
+- **WHEN** the adapter maps a vacancy URL `https://www.dataart.team/vacancies/{code}`
+- **THEN** the `Job.ExternalID` is `{code}`, so re-crawling dedups to the same
+  catalogue row
+
+#### Scenario: Each vacancy ingested once across localisations
+
+- **WHEN** the sitemap contains both the canonical `/vacancies/{code}` URL and its
+  localised variants (`/es/vacancies/{code}`, `/ua/...`, `/pl/...`, `/bg/...`) and
+  the listing root `/vacancies`
+- **THEN** only the canonical English URL is crawled; the localised variants and
+  the listing root are skipped, so a vacancy is not ingested multiple times
+
+#### Scenario: A vacancy page without a JobPosting is skipped
+
+- **WHEN** a vacancy page fetch fails or the page carries no `JobPosting` ld+json
+- **THEN** that vacancy is skipped and the rest of the crawl still returns their
+  Jobs

--- a/openspec/changes/dataart-source/tasks.md
+++ b/openspec/changes/dataart-source/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## 1. Adapter helpers (pure)
+
+- [x] 1.1 `dataartVacancyCode(url)` — returns the `{code}` for a canonical English
+  `https://www.dataart.team/vacancies/{code}` URL, `""` for the listing root and
+  `/xx/vacancies/...` localisations. Table test.
+- [x] 1.2 `dataartPosting.location()` — joins `jobLocation` places as
+  `"City, Country"` (fallback to whichever part is present), deduped, and strips
+  DataArt's internal `Remote.*` region codes. Test.
+
+## 2. Fetch + mapping + registration
+
+- [x] 2.1 `dataart.Fetch` — sitemap enumerate → filter → per-vacancy ld+json
+  detail → `Job`, boardless marker, `Provider() == "dataart"`. Routed-HTTP
+  fixture test asserting the full mapping (id, title, location, description,
+  posted-at, structured `WorkMode`) and that localised/listing URLs are excluded.
+- [x] 2.2 Register `NewDataArt(c)` in `sources.All` (boardless single-company
+  section).
+
+## 3. Config + verify
+
+- [x] 3.1 Add `sources/dataart.yml` (one boardless `DataArt` entry).
+- [x] 3.2 `go build ./...`, `go vet ./...`, `go test ./internal/sources/` green.
+- [x] 3.3 Live smoke: the real adapter fetched 136 DataArt jobs mapping correctly
+  (title/location/posted-at/remote).

--- a/sources/dataart.yml
+++ b/sources/dataart.yml
@@ -1,0 +1,5 @@
+# DataArt careers (www.dataart.team). Boardless single-company source: one fixed host with no
+# per-tenant board id, so the entry carries no board. Unlike the aggregators, the job's company
+# is this entry's `company` (DataArt), not read per posting. See internal/sources/dataart.go.
+- company: DataArt
+  provider: dataart


### PR DESCRIPTION
## Why

DataArt (dataart.team) is one of the Eastern-roots companies our [idagent audit](https://www.idagent.pro/companies) flagged as uncovered — it runs a custom careers SPA on no supported ATS, so we ingested none of its ~136 vacancies. A feasibility **spike** (VALIDATED) found a clean, keyless path: `sitemap.xml` enumerates every vacancy as `/vacancies/{code}`, and each vacancy page server-renders a standard schema.org `JobPosting` ld+json — exactly the sitemap-plus-ld+json shape of our existing EPAM/SuccessFactors adapters.

## What

- New **boardless single-company** `dataart` adapter (`internal/sources/dataart.go`): sitemap enumerate → filter to canonical English `/vacancies/{code}` (excludes the listing root and `/xx/vacancies/...` localisations, so each vacancy is ingested once) → per-vacancy `JobPosting` ld+json → `Job`. The vacancy `code` is the stable `ExternalID`.
- `location()` strips DataArt's internal `Remote.*` region codes that leak into the address (they'd otherwise show as junk like `Buenos Aires, Remote.LATAM-country`); that structured remote tag instead sets `Job.WorkMode = "remote"` / `Remote`.
- Registered `NewDataArt` in `sources.All`; added `sources/dataart.yml`.

Reuses the shared `ldJobPosting` / `fetchDetails` / `sanitizeHTML` / `parseDate` / `isRemote` / `joinNonEmpty` helpers — no new transport (the site serves the shared client fine; no anti-bot).

## Verification

- `go build ./...`, `go vet ./...`, `go test ./internal/sources/` green — **6 unit tests** (URL-code extraction incl. localisation/listing/deeper-path exclusion, location join + `Remote.*` stripping, full sitemap→detail mapping, structured `WorkMode`, `Provider`/boardless marker).
- **Live smoke** against real DataArt: the adapter fetched **136 jobs** mapping correctly (title / location / posted-at / remote).
- Independent code review: no correctness or dedup-identity issues.

OpenSpec change `dataart-source` (proposal + design + tasks + `dataart-source` spec delta).

## Ops to land (after merge)

- Add a cron slot for `cmd/ingest sources/dataart.yml`.
- The company slug `dataart` is already in `eastern_roots.txt`, so `cmd/import-collections` tags it `eastern-roots` once ingested; then `make reindex`.