### PR TITLE
feat(sources): add Zerion via existing Lever adapter

### DIFF
--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4304,3 +4304,7 @@
   board: world-view-enterprises-inc.
 - company: Worldscape
   board: worldscape-technology
+# Zerion (web3 wallet, zerion.io). Live Lever board, currently 0 open postings — ingests
+# nothing until they post; the eastern-roots `zerion` slug tags it once it has jobs.
+- company: Zerion
+  board: zerion


### PR DESCRIPTION
Zerion (zerion.io, web3 wallet) hosts jobs on **Lever** (`jobs.lever.co/zerion`). The public JSON API is **live** (`api.lever.co/v0/postings/zerion?mode=json` → 200) — it returns `[]` only because Zerion has **0 open roles right now** (an earlier read mistook the empty board for a disabled API). One board line, no new code; the eastern-roots `zerion` slug already in `eastern_roots.txt` tags it once it posts.

Found via a deeper search of the 6 remaining no-source idagent companies — Zerion was the only addable one. The other 5 (Grammarly=dead GH board post-Superhuman-merge, StarWind=Cloudflare-gated own site, Fibery=hires inside own workspace, Bitfury/Bitrix24=LinkedIn-only) have no ingestable feed.