### PR TITLE
feat(filters): flatten Global in Location, map bare-remote to global, nudge saving for TG alerts

### DIFF
--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -172,6 +172,18 @@ func normalizeSet(a []string) []string {
 	return out
 }
 
+// nonCityFallback are LLM-emitted "city" values that are really work-mode or
+// open-anywhere markers, not places. The deterministic dictionary never produces
+// these (it emits only real beacon cities); they leak in only through the
+// enrichment.cities fallback, so they are dropped there. A bare-remote job's
+// geography is carried by regions=global instead (see location.Parse), and its
+// remoteness by the work_mode facet.
+var nonCityFallback = map[string]struct{}{
+	"remote": {}, "remote-first": {}, "fully remote": {}, "worldwide": {},
+	"anywhere": {}, "global": {}, "distributed": {}, "hybrid": {},
+	"onsite": {}, "on-site": {}, "work from home": {}, "wfh": {},
+}
+
 // cityFacet builds the served city facet: the deterministic dictionary cities when
 // present (canonical display names), otherwise a normalized fallback to the LLM's
 // enrichment.cities. Case is preserved (the value is its own display label); the
@@ -186,9 +198,13 @@ func cityFacet(dict, llm []string) []string {
 		if i := strings.IndexByte(c, ','); i >= 0 {
 			c = strings.TrimSpace(c[:i])
 		}
-		if c != "" {
-			cleaned = append(cleaned, c)
+		if c == "" {
+			continue
 		}
+		if _, bad := nonCityFallback[strings.ToLower(c)]; bad {
+			continue
+		}
+		cleaned = append(cleaned, c)
 	}
 	return dedupeSortedPreserveCase(cleaned)
 }

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -509,6 +509,16 @@ func TestFromRow_CitiesHybrid(t *testing.T) {
 			t.Errorf("Cities = %v, want %v (LLM fallback normalized)", view.Cities, want)
 		}
 	})
+	t.Run("work-mode markers leaked as LLM cities are dropped", func(t *testing.T) {
+		raw, _ := json.Marshal(enrich.Enrichment{Cities: []string{"Remote", "Berlin", "Worldwide", "Anywhere"}})
+		view, err := FromRow(db.Job{ID: 4, PublicSlug: "x-4", Cities: nil, Enrichment: raw})
+		if err != nil {
+			t.Fatalf("FromRow: %v", err)
+		}
+		if !reflect.DeepEqual(view.Cities, []string{"Berlin"}) {
+			t.Errorf("Cities = %v, want [Berlin] (work-mode markers filtered)", view.Cities)
+		}
+	})
 	t.Run("neither dict nor LLM yields an empty array, not null", func(t *testing.T) {
 		view, err := FromRow(db.Job{ID: 3, PublicSlug: "x-3"})
 		if err != nil {

--- a/internal/location/location.go
+++ b/internal/location/location.go
@@ -38,10 +38,12 @@ var separatorReplacer = strings.NewReplacer(
 
 // Parse maps a location string to its geography. Countries/regions are
 // deduplicated and sorted; nil when nothing resolves. WorkMode is set only from
-// an explicit marker — a bare "Remote" yields WorkMode "remote" with no
-// geography, while a plain city/country yields geography with no WorkMode. The
-// "global" region is emitted only from an explicit open-anywhere marker, never
-// inferred from a bare "Remote".
+// an explicit marker, while a plain city/country yields geography with no
+// WorkMode. A remote job that resolves NO geography (a bare "Remote", "WFH", …)
+// is open-anywhere, so it falls into the "global" region — its remoteness stays
+// on WorkMode (the separate work-type facet), which the global region never
+// displaces. A remote marker alongside a real place ("US Remote") keeps that
+// place and is not globalized.
 func Parse(location string) Geo {
 	lower := strings.ToLower(location)
 
@@ -99,11 +101,23 @@ func Parse(location string) Geo {
 		}
 	}
 
+	countries := stringset.Sorted(countrySet)
+	regions := stringset.Sorted(regionSet)
+	mode := detectWorkMode(lower)
+
+	// A remote job that resolved no country and no region is open-anywhere: treat it
+	// as the global region so it joins the Global/Worldwide bucket instead of the
+	// "geography not specified" one. Only fires when nothing else resolved, so
+	// "US Remote" stays north_america and "Remote - Germany" stays eu.
+	if mode == "remote" && len(countries) == 0 && len(regions) == 0 {
+		regions = []string{"global"}
+	}
+
 	return Geo{
-		Countries: stringset.Sorted(countrySet),
-		Regions:   stringset.Sorted(regionSet),
+		Countries: countries,
+		Regions:   regions,
 		Cities:    stringset.Sorted(citySet),
-		WorkMode:  detectWorkMode(lower),
+		WorkMode:  mode,
 	}
 }
 

--- a/internal/location/location_test.go
+++ b/internal/location/location_test.go
@@ -78,13 +78,23 @@ func TestParse(t *testing.T) {
 			want:     Geo{Countries: []string{"nz"}, Regions: []string{"apac"}, Cities: []string{"Auckland"}},
 		},
 		{
-			name:     "bare remote yields work mode but no geography",
+			// A remote job that resolves no geography at all is open-anywhere: it joins the
+			// global bucket (its remoteness is still carried by WorkMode, which the separate
+			// work-type facet filters on — the global region never displaces it).
+			name:     "bare remote with no geography yields global",
 			location: "Remote",
-			want:     Geo{WorkMode: "remote"},
+			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
 		},
 		{
 			name:     "explicit anywhere yields global and remote",
 			location: "Remote - Anywhere",
+			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
+		},
+		{
+			// The global fallback is driven by the detected work mode, not the literal word
+			// "remote": a WFH marker with no place resolves the same way.
+			name:     "work-from-home marker with no place yields global",
+			location: "Work from home",
 			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
 		},
 		{
@@ -145,9 +155,10 @@ func TestParse(t *testing.T) {
 		{
 			// A hyphenated word whose first segment happens to be a 2-letter code
 			// ("in") must not emit a phantom country: no other segment is geography.
+			// It resolves no country, so the remote fallback puts it in global.
 			name:     "hyphenated word is not a leading bare code",
 			location: "Remote or in-house",
-			want:     Geo{WorkMode: "remote"},
+			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
 		},
 		{
 			// "De-Witt" (a place, but not a geo dash-export) must not add a phantom
@@ -305,9 +316,9 @@ func TestParseCyrillic(t *testing.T) {
 			want:     Geo{Countries: []string{"ru"}, Regions: []string{"cis"}, WorkMode: "remote"},
 		},
 		{
-			name:     "bare Удалённо yields remote mode, no geography",
+			name:     "bare Удалённо yields remote mode and global",
 			location: "Удалённо",
-			want:     Geo{WorkMode: "remote"},
+			want:     Geo{Regions: []string{"global"}, WorkMode: "remote"},
 		},
 		{
 			name:     "Cyrillic hybrid marker with city",

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -215,10 +215,11 @@ func TestNormalizeJobParsesGeographyFromLocation(t *testing.T) {
 		t.Errorf("geography = %v/%v, want [de]/[eu]", geo.Countries, geo.Regions)
 	}
 
-	// A location with no resolvable place leaves geography empty (never guessed).
+	// A bare "Remote" resolves no country, so it falls into the open-anywhere global
+	// region (its remoteness stays on WorkMode; see location.Parse).
 	bare := normalizeJob(e, sources.Job{ExternalID: "2", Title: "Dev", Company: "Acme", Location: "Remote"})
-	if len(bare.Countries) != 0 || len(bare.Regions) != 0 {
-		t.Errorf("bare remote geography = %v/%v, want empty", bare.Countries, bare.Regions)
+	if len(bare.Countries) != 0 || !reflect.DeepEqual(bare.Regions, []string{"global"}) {
+		t.Errorf("bare remote geography = %v/%v, want []/[global]", bare.Countries, bare.Regions)
 	}
 }
 

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { Bell } from '@lucide/svelte';
   import { FACETS } from '$lib/facets';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { notifications } from '$lib/notifications.svelte';
   import { emptyFilters, type FilterStore, type JobFilters } from '$lib/filters';
   import { StagedFilters } from '$lib/stagedFilters.svelte';
   import { RAIL, RAIL_SECTIONS, type RailEntry, type RailSection } from '$lib/filterSections';
@@ -62,6 +65,23 @@
 
   const staged = new StagedFilters();
 
+  // The "My filters" tab is present only on the full job modal — the caller enables saved
+  // searches and doesn't restrict the rail to a facet subset (as the profile modal does).
+  // Gates the tab itself (visibleRail), its data warm-up, and the footer nudge that jumps
+  // to it, so the jump never lands on a missing tab.
+  const hasSavedTab = $derived(savedSearches && !railKeys);
+
+  // Warm the Telegram feature flag when the modal opens for a signed-in user, so the
+  // footer "save for TG alerts" nudge can gate on it before the My-filters tab (which
+  // otherwise triggers the load) is ever opened. No-op off the browser / once loaded.
+  $effect(() => {
+    if (open && hasSavedTab && isAuthenticated()) void notifications.ensureLoaded();
+  });
+
+  // The footer nudge shows only when the My-filters tab exists (so the jump lands
+  // somewhere), Telegram alerts are available, and there's a search worth saving.
+  const showSaveNudge = $derived(hasSavedTab && notifications.telegram.enabled && staged.active > 0);
+
   // The "My filters" (saved searches) tab. It heads the rail on the full job modal, but
   // not when the caller restricts the rail to a facet subset (e.g. the profile modal),
   // which has no saved-search context.
@@ -72,7 +92,7 @@
   // and a 'facet' entry is hidden when its param is excluded (e.g. Company on a company
   // page).
   const visibleRail = $derived([
-    ...(savedSearches && !railKeys ? [SAVED_ENTRY] : []),
+    ...(hasSavedTab ? [SAVED_ENTRY] : []),
     ...RAIL.filter((e) => (!railKeys || railKeys.includes(e.key)) && !(e.facetParam && exclude.includes(e.facetParam))),
   ]);
 
@@ -143,10 +163,29 @@
   {previewCount}
   {pane}
   extra={extra ? extraStaged : undefined}
+  {footerNote}
 />
 
 {#snippet extraStaged()}
   {@render extra?.(staged)}
+{/snippet}
+
+{#snippet footerNote({ jumpTo, activeKey }: { jumpTo: (key: string) => void; activeKey: string })}
+  {#if showSaveNudge && activeKey !== 'saved'}
+    <p class="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Bell class="size-3.5 shrink-0" aria-hidden="true" />
+      <span>
+        Want new jobs for this search in Telegram?
+        <button
+          type="button"
+          onclick={() => jumpTo('saved')}
+          class="font-medium text-foreground underline underline-offset-2 hover:opacity-80"
+        >
+          Save it to My filters
+        </button>.
+      </span>
+    </p>
+  {/if}
 {/snippet}
 
 {#snippet pane(entry: RailEntry)}

--- a/web/src/lib/components/filters/FilterModalShell.svelte
+++ b/web/src/lib/components/filters/FilterModalShell.svelte
@@ -37,6 +37,7 @@
     initialKey,
     pane,
     extra,
+    footerNote,
   }: {
     open?: boolean;
     onClose: () => void;
@@ -60,6 +61,10 @@
     pane: Snippet<[RailEntry]>;
     /** Optional content above the pane (e.g. the profile editor's "import from CV"). */
     extra?: Snippet;
+    /** Optional footer nudge above the action row, handed a `jumpTo` to switch panes and
+     *  the current `activeKey` — lets a domain wrapper add copy (e.g. "save this search")
+     *  that jumps to another tab without the shell knowing what the tabs mean. */
+    footerNote?: Snippet<[{ jumpTo: (key: string) => void; activeKey: string }]>;
   } = $props();
 
   // Set on the first open (see the seed effect); until then activeEntry falls back to
@@ -194,6 +199,7 @@
         {#if applyError}
           <p class="text-sm text-destructive">{applyError}</p>
         {/if}
+        {#if footerNote}{@render footerNote({ jumpTo: (k) => (active = k), activeKey: active })}{/if}
         <div class="flex items-center justify-between">
           <button
             type="button"

--- a/web/src/lib/components/filters/LocationPane.svelte
+++ b/web/src/lib/components/filters/LocationPane.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { ChevronDown, Search, X } from '@lucide/svelte';
   import { SvelteSet } from 'svelte/reactivity';
-  import { countryLabel, type FacetStore } from '$lib/facets';
+  import { countryLabel, REGION_UNSPECIFIED, type FacetStore } from '$lib/facets';
   import { REGION_LABELS } from '$lib/labels';
   import { COUNTRY_REGION_MAP } from '$lib/generated/contracts';
   import type { FacetCounts } from '$lib/types';
@@ -49,8 +49,15 @@
   });
 
   // The macro-regions are always shown (a stable list, like the old region facet), so
-  // the pane is never empty — even before the first facet-count fetch resolves.
-  const regions = Object.keys(REGION_LABELS);
+  // the pane is never empty — even before the first facet-count fetch resolves. `global`
+  // is pulled out: no country maps to it, so it has nothing to drill into and renders as
+  // a flat pill (see flatRegions) rather than an empty accordion.
+  const regions = Object.keys(REGION_LABELS).filter((r) => r !== 'global');
+
+  // Country-less region pills shown flat above the tree: the "anywhere" macro-bucket
+  // (global) and the "no resolved geography" sentinel (REGION_UNSPECIFIED → "Not
+  // specified"). Neither drills into countries, so both stay as one-click pills.
+  const flatRegions = ['global', REGION_UNSPECIFIED];
 
   // Cities to show: the distribution plus any selected city (kept visible at zero
   // count), busiest first.
@@ -61,7 +68,7 @@
   const CITY_LIMIT = 18;
 
   const q = $derived(query.trim().toLowerCase());
-  const regionLabel = (code: string) => REGION_LABELS[code] ?? code;
+  const regionLabel = (code: string) => (code === REGION_UNSPECIFIED ? 'Not specified' : (REGION_LABELS[code] ?? code));
   const matchRegion = (code: string) => !q || regionLabel(code).toLowerCase().includes(q);
   const matchCountry = (code: string) => !q || countryLabel(code).toLowerCase().includes(q);
   const matchCity = (city: string) => !q || city.toLowerCase().includes(q);
@@ -79,6 +86,9 @@
       .map((region) => ({ region, countryCodes: (countriesByRegion[region] ?? []).filter(matchCountry), nameMatch: matchRegion(region) }))
       .filter((r) => r.nameMatch || r.countryCodes.length),
   );
+
+  // Flat pills hide during a search unless their own label matches the query.
+  const visibleFlatRegions = $derived(flatRegions.filter(matchRegion));
 
   // Selected-location chips, shown above the tree: included first, then excluded,
   // across regions → countries → cities. Each chip removes its value outright (not a
@@ -145,6 +155,23 @@
           <X class="size-3" />
         </button>
       </span>
+    {/each}
+  </div>
+{/if}
+
+{#if visibleFlatRegions.length}
+  <div class="mb-1 flex flex-wrap gap-2 border-b border-border pb-3">
+    {#each visibleFlatRegions as code (code)}
+      {@const rExc = regionF.exclude.includes(code)}
+      {@const rInc = regionF.include.includes(code)}
+      <button
+        type="button"
+        onclick={() => store.cycle('regions', code)}
+        title={pillTitle(rInc, rExc, true)}
+        class={pillClass(rInc || rExc, rExc, 'px-3 py-1.5 text-sm')}
+      >
+        {regionLabel(code)}
+      </button>
     {/each}
   </div>
 {/if}

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -7,7 +7,7 @@
 // in sync with the backend vocabulary.
 
 export const REGION_LABELS: Record<string, string> = {
-  global: 'Global',
+  global: 'Global/Worldwide',
   north_america: 'North America',
   latam: 'LATAM',
   eu: 'Europe',


### PR DESCRIPTION
## What

Three related improvements to the job filters.

### Location pane
- **`global` is now a flat pill, not an accordion.** No country maps to `global`, so its accordion only ever showed an empty "All Global" pill. It's pulled out of the region tree and rendered as a one-click flat pill.
- **Relabeled `global` → "Global/Worldwide"** in the shared `REGION_LABELS` (so the filter summary and detail-page facet rows stay consistent).
- **Added a flat "Not specified" pill** — the existing `regions=none` IS-EMPTY sentinel — beside Global, so users can filter jobs with no resolved geography.

### Geography: bare-remote → global
- `location.Parse`: a remote job that resolves **no country and no region** is open-anywhere, so it now lands in the `global` region instead of the "geography not specified" bucket. Only fires when nothing else resolved — `"US Remote"` stays `north_america`, `"Remote - Germany"` stays `eu`. Remoteness is unchanged (still on `WorkMode`, which the separate work-type facet filters on).
- `jobview.cityFacet`: drops work-mode / open-anywhere markers (`Remote`, `Worldwide`, `Anywhere`, `Distributed`, …) that leak into the **LLM cities fallback** — these are not places. The deterministic dictionary never emitted them.

### Filter modal: save-for-TG-alerts nudge
- A footer nudge above the action row: *"Want new jobs for this search in Telegram? **Save it to My filters**."* The link jumps to the **My filters** tab in-modal (verified via CDP click: Location → My filters, nudge hides on the saved tab).
- Gated on: the My-filters tab existing, the Telegram feature enabled, and at least one active filter.
- `FilterModalShell` stays domain-agnostic — the TG copy lives in `FilterModal` and is passed via a `footerNote` snippet that receives a `jumpTo` + `activeKey`.

## Verification
- `go test ./...` green (updated location / jobview / pipeline tests for the new geography behavior).
- `svelte-check` clean.
- Location pane and footer nudge visually verified headless (all pill states; tab-switch via CDP click).

## Deploy note
The `remote → global` mapping writes to the `jobs.regions` column at **ingest time**, so applying it to the existing catalogue needs **`cmd/backfill-derive` → `make reindex`**. The `cityFacet` filter is serve/index-time and applies on the next reindex.