### PR TITLE
feat(cv-recommendations): /my/recommendations feed ranked by CV embedding

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -183,14 +183,16 @@ type TelegramPost struct {
 }
 
 type User struct {
-	ID                int64              `json:"id"`
-	Email             string             `json:"email"`
-	PasswordHash      pgtype.Text        `json:"password_hash"`
-	CreatedAt         pgtype.Timestamptz `json:"created_at"`
-	Role              string             `json:"role"`
-	ResumeObjectKey   pgtype.Text        `json:"resume_object_key"`
-	ResumeUploadedAt  pgtype.Timestamptz `json:"resume_uploaded_at"`
-	ResumeAtsAnalysis []byte             `json:"resume_ats_analysis"`
+	ID                   int64              `json:"id"`
+	Email                string             `json:"email"`
+	PasswordHash         pgtype.Text        `json:"password_hash"`
+	CreatedAt            pgtype.Timestamptz `json:"created_at"`
+	Role                 string             `json:"role"`
+	ResumeObjectKey      pgtype.Text        `json:"resume_object_key"`
+	ResumeUploadedAt     pgtype.Timestamptz `json:"resume_uploaded_at"`
+	ResumeAtsAnalysis    []byte             `json:"resume_ats_analysis"`
+	ResumeEmbedding      []float64          `json:"resume_embedding"`
+	ResumeEmbeddingModel pgtype.Text        `json:"resume_embedding_model"`
 }
 
 type UserIdentity struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -45,8 +45,8 @@ type Querier interface {
 	// affected row count: 1 for an owned row (whether or not it was shared — unshare is an
 	// idempotent no-op when already private), 0 when missing or not the caller's (→ 404).
 	ClearSavedSearchPublicSlug(ctx context.Context, arg ClearSavedSearchPublicSlugParams) (int64, error)
-	// Clear the user's résumé pointer (after deleting the object from storage) and any
-	// cached ATS review.
+	// Clear the user's résumé pointer (after deleting the object from storage), any
+	// cached ATS review, and the derived CV embedding (no CV → no recommendations).
 	ClearUserResume(ctx context.Context, id int64) error
 	// Soft-close one job now (see job-lifecycle): a moderator resolving a report with
 	// close_job=true. The third writer of closed_at, alongside the ingest sweep and the
@@ -237,6 +237,10 @@ type Querier interface {
 	// The authenticated user's résumé pointer (object key + upload time), or NULLs when
 	// no résumé is stored. The blob lives in S3 under the key; this is just the pointer.
 	GetUserResume(ctx context.Context, id int64) (GetUserResumeRow, error)
+	// The user's persisted CV embedding and the embedder identity that produced it, or
+	// NULLs when none is stored. The caller ignores a vector whose model no longer matches
+	// the current embedder (stale) — see the cv-recommendations change.
+	GetUserResumeEmbedding(ctx context.Context, id int64) (GetUserResumeEmbeddingRow, error)
 	// Slim role lookup for the RequireRole authorization middleware: it runs on every
 	// request to a role-gated endpoint and needs only the role, so it does not drag the
 	// full user row (the GetJobIDBySlug precedent for a hot-path read).
@@ -462,6 +466,9 @@ type Querier interface {
 	// Owner-scoped by id; the object key is derived from the id, never client input.
 	// Also clears any cached ATS review so a new CV is never scored with a stale one.
 	SetUserResume(ctx context.Context, arg SetUserResumeParams) error
+	// Persist the user's derived CV embedding vector plus the identity of the embedder
+	// that produced it (so a model change can mark the vector stale). Never the raw CV text.
+	SetUserResumeEmbedding(ctx context.Context, arg SetUserResumeEmbeddingParams) error
 	// Rebuild the companies catalogue from jobs. The companies table is derivable
 	// from jobs (slug = company_slug, name = company), so after a slug-builder change
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -37,10 +37,26 @@ SET resume_object_key = $2, resume_uploaded_at = now(), resume_ats_analysis = NU
 WHERE id = $1;
 
 -- name: ClearUserResume :exec
--- Clear the user's résumé pointer (after deleting the object from storage) and any
--- cached ATS review.
+-- Clear the user's résumé pointer (after deleting the object from storage), any
+-- cached ATS review, and the derived CV embedding (no CV → no recommendations).
 UPDATE users
-SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL
+SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL,
+    resume_embedding = NULL, resume_embedding_model = NULL
+WHERE id = $1;
+
+-- name: SetUserResumeEmbedding :exec
+-- Persist the user's derived CV embedding vector plus the identity of the embedder
+-- that produced it (so a model change can mark the vector stale). Never the raw CV text.
+UPDATE users
+SET resume_embedding = $2, resume_embedding_model = $3
+WHERE id = $1;
+
+-- name: GetUserResumeEmbedding :one
+-- The user's persisted CV embedding and the embedder identity that produced it, or
+-- NULLs when none is stored. The caller ignores a vector whose model no longer matches
+-- the current embedder (stale) — see the cv-recommendations change.
+SELECT resume_embedding, resume_embedding_model
+FROM users
 WHERE id = $1;
 
 -- name: GetUserATSAnalysis :one

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -13,12 +13,13 @@ import (
 
 const clearUserResume = `-- name: ClearUserResume :exec
 UPDATE users
-SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL
+SET resume_object_key = NULL, resume_uploaded_at = NULL, resume_ats_analysis = NULL,
+    resume_embedding = NULL, resume_embedding_model = NULL
 WHERE id = $1
 `
 
-// Clear the user's résumé pointer (after deleting the object from storage) and any
-// cached ATS review.
+// Clear the user's résumé pointer (after deleting the object from storage), any
+// cached ATS review, and the derived CV embedding (no CV → no recommendations).
 func (q *Queries) ClearUserResume(ctx context.Context, id int64) error {
 	_, err := q.db.Exec(ctx, clearUserResume, id)
 	return err
@@ -149,6 +150,27 @@ func (q *Queries) GetUserResume(ctx context.Context, id int64) (GetUserResumeRow
 	return i, err
 }
 
+const getUserResumeEmbedding = `-- name: GetUserResumeEmbedding :one
+SELECT resume_embedding, resume_embedding_model
+FROM users
+WHERE id = $1
+`
+
+type GetUserResumeEmbeddingRow struct {
+	ResumeEmbedding      []float64   `json:"resume_embedding"`
+	ResumeEmbeddingModel pgtype.Text `json:"resume_embedding_model"`
+}
+
+// The user's persisted CV embedding and the embedder identity that produced it, or
+// NULLs when none is stored. The caller ignores a vector whose model no longer matches
+// the current embedder (stale) — see the cv-recommendations change.
+func (q *Queries) GetUserResumeEmbedding(ctx context.Context, id int64) (GetUserResumeEmbeddingRow, error) {
+	row := q.db.QueryRow(ctx, getUserResumeEmbedding, id)
+	var i GetUserResumeEmbeddingRow
+	err := row.Scan(&i.ResumeEmbedding, &i.ResumeEmbeddingModel)
+	return i, err
+}
+
 const getUserRole = `-- name: GetUserRole :one
 SELECT role
 FROM users
@@ -198,5 +220,24 @@ type SetUserResumeParams struct {
 // Also clears any cached ATS review so a new CV is never scored with a stale one.
 func (q *Queries) SetUserResume(ctx context.Context, arg SetUserResumeParams) error {
 	_, err := q.db.Exec(ctx, setUserResume, arg.ID, arg.ResumeObjectKey)
+	return err
+}
+
+const setUserResumeEmbedding = `-- name: SetUserResumeEmbedding :exec
+UPDATE users
+SET resume_embedding = $2, resume_embedding_model = $3
+WHERE id = $1
+`
+
+type SetUserResumeEmbeddingParams struct {
+	ID                   int64       `json:"id"`
+	ResumeEmbedding      []float64   `json:"resume_embedding"`
+	ResumeEmbeddingModel pgtype.Text `json:"resume_embedding_model"`
+}
+
+// Persist the user's derived CV embedding vector plus the identity of the embedder
+// that produced it (so a model change can mark the vector stale). Never the raw CV text.
+func (q *Queries) SetUserResumeEmbedding(ctx context.Context, arg SetUserResumeEmbeddingParams) error {
+	_, err := q.db.Exec(ctx, setUserResumeEmbedding, arg.ID, arg.ResumeEmbedding, arg.ResumeEmbeddingModel)
 	return err
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -280,6 +280,7 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/me/jobs/viewed", keyAuth, a.ListViewedSlugs)
 	api.Get("/me/jobs/pipeline", keyAuth, a.MyPipeline)
 	api.Get("/me/jobs/swipe", keyAuth, a.SwipeDeck)
+	api.Get("/me/recommendations", keyAuth, a.Recommendations)
 
 	// API-key management is cookie-only (RequireAuth): a leaked key must not be
 	// able to create, list, or revoke keys. The create endpoint returns the

--- a/internal/handler/recommendations.go
+++ b/internal/handler/recommendations.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/search"
+)
+
+// Recommendations returns open jobs ranked by semantic similarity to the caller's
+// persisted CV embedding — the /my/recommendations feed. Behind RequireAuthOrKey;
+// response is the standard list envelope of job views. It degrades to a successful
+// EMPTY list (never an error) when the caller has no usable CV vector: none stored, or
+// one produced by a superseded embedder (stale, so not comparable to the current jobs),
+// or the search backend / semantic index is unavailable. A profile edit needing a
+// re-embed happens on the user's next CV upload.
+func (a *API) Recommendations(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	limit, offset := pageParams(c)
+	if offset+limit > maxSearchWindow {
+		return fiber.NewError(fiber.StatusBadRequest, "pagination too deep")
+	}
+
+	empty := func() error { return listResponse(c, []jobview.Job{}, 0, limit, offset) }
+	if a.search == nil {
+		return empty()
+	}
+
+	vec, model, err := a.resume.Embedding(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	if len(vec) == 0 || model != search.CurrentEmbedderModel() {
+		return empty()
+	}
+
+	res, err := a.search.RecommendByVector(c.Context(), vec, limit, offset)
+	if err != nil {
+		return err
+	}
+	views := make([]jobview.Job, len(res.Hits))
+	for i, hit := range res.Hits {
+		views[i] = hit.Job
+	}
+	return listResponse(c, views, res.Total, limit, offset)
+}

--- a/internal/handler/recommendations_test.go
+++ b/internal/handler/recommendations_test.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/resume"
+	"github.com/strelov1/freehire/internal/search"
+)
+
+func recsApp(t *testing.T, store *resume.Store, s searcher) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &API{issuer: iss, resume: store, search: s}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/me/recommendations", auth.RequireAuth(iss), h.Recommendations)
+	return app, token
+}
+
+func getRecs(t *testing.T, app *fiber.App, token string) (status, count int) {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodGet, "/me/recommendations", nil)
+	if token != "" {
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	}
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Data []map[string]any `json:"data"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, len(out.Data)
+}
+
+// A fresh CV vector (model matches the current embedder) drives a vector-ranked feed.
+func TestRecommendations_FreshVectorRanks(t *testing.T) {
+	repo := &fakeResumeRepo{embVec: []float64{0.1, 0.2}, embModel: search.CurrentEmbedderModel()}
+	store := resume.New(newFakeResumeBlobs(), repo)
+	fs := &fakeSearcher{recRes: search.SearchResult{Hits: []search.JobDocument{{}}, Total: 1}}
+	app, token := recsApp(t, store, fs)
+
+	status, n := getRecs(t, app, token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if n != 1 {
+		t.Errorf("returned %d jobs, want 1", n)
+	}
+	if len(fs.gotRecVec) != 2 {
+		t.Errorf("searcher got vector %v, want the CV vector", fs.gotRecVec)
+	}
+}
+
+// A vector from a superseded embedder is stale → empty feed, and no vector search runs.
+func TestRecommendations_StaleVectorEmpty(t *testing.T) {
+	repo := &fakeResumeRepo{embVec: []float64{0.1, 0.2}, embModel: "old-embedder"}
+	store := resume.New(newFakeResumeBlobs(), repo)
+	fs := &fakeSearcher{recRes: search.SearchResult{Hits: []search.JobDocument{{}}, Total: 1}}
+	app, token := recsApp(t, store, fs)
+
+	status, n := getRecs(t, app, token)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if n != 0 {
+		t.Errorf("returned %d jobs, want 0 (stale vector ignored)", n)
+	}
+	if fs.gotRecVec != nil {
+		t.Error("vector search must not run on a stale vector")
+	}
+}
+
+// No stored CV vector → a successful empty feed.
+func TestRecommendations_NoVectorEmpty(t *testing.T) {
+	store := resume.New(newFakeResumeBlobs(), &fakeResumeRepo{})
+	app, token := recsApp(t, store, &fakeSearcher{})
+	if status, n := getRecs(t, app, token); status != fiber.StatusOK || n != 0 {
+		t.Errorf("status=%d count=%d, want 200 and 0", status, n)
+	}
+}
+
+func TestRecommendations_Unauthenticated(t *testing.T) {
+	store := resume.New(newFakeResumeBlobs(), &fakeResumeRepo{})
+	app, _ := recsApp(t, store, &fakeSearcher{})
+	if status, _ := getRecs(t, app, ""); status != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", status)
+	}
+}

--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -2,8 +2,10 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,7 +108,30 @@ func (a *API) PutResume(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
+	a.embedResume(c.Context(), userID, up.Text)
 	return c.JSON(fiber.Map{"data": newResumeMeta(true, meta)})
+}
+
+// embedResume computes and persists the user's CV embedding through the same embedder
+// as jobs (so it shares their vector space), best-effort: any failure — no search
+// backend, embed error, or persist error — is logged and swallowed so it never breaks
+// the upload. On an embed failure the prior vector is cleared so the new CV is never
+// matched by a stale one. The scratch id is the user id.
+func (a *API) embedResume(ctx context.Context, userID int64, text string) {
+	if a.search == nil {
+		return
+	}
+	vec, model, err := a.search.EmbedText(ctx, strconv.FormatInt(userID, 10), text)
+	if err != nil {
+		log.Printf("resume embed: user %d: %v", userID, err)
+		if err := a.resume.SetEmbedding(ctx, userID, nil, ""); err != nil {
+			log.Printf("resume embed clear: user %d: %v", userID, err)
+		}
+		return
+	}
+	if err := a.resume.SetEmbedding(ctx, userID, vec, model); err != nil {
+		log.Printf("resume embed persist: user %d: %v", userID, err)
+	}
 }
 
 // GetResume reports whether the caller has a stored résumé (and when). Always 200:

--- a/internal/handler/resume_embedding_test.go
+++ b/internal/handler/resume_embedding_test.go
@@ -1,0 +1,62 @@
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/resume"
+)
+
+// resumeEmbedApp wires PutResume with both a résumé store and a searcher, so the
+// upload's best-effort CV-embedding hook is exercised.
+func resumeEmbedApp(t *testing.T, store *resume.Store, s searcher) (*fiber.App, string) {
+	t.Helper()
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	token, err := iss.Issue(1)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	h := &API{issuer: iss, resume: store, search: s}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Put("/me/resume", auth.RequireAuth(iss), h.PutResume)
+	return app, token
+}
+
+// A CV upload embeds the CV text through the searcher and persists the resulting
+// vector plus the embedder identity.
+func TestPutResume_EmbedsAndPersistsVector(t *testing.T) {
+	repo := &fakeResumeRepo{}
+	store := resume.New(newFakeResumeBlobs(), repo)
+	fs := &fakeSearcher{embedVec: []float64{0.1, 0.2, 0.3}, embedModel: "test-embedder"}
+	app, token := resumeEmbedApp(t, store, fs)
+
+	if status, _ := resumeReq(t, app, fiber.MethodPut, `{"text":"Go and PostgreSQL and Kubernetes"}`, token); status != fiber.StatusOK {
+		t.Fatalf("upload status = %d, want 200", status)
+	}
+	if fs.gotEmbedText == "" {
+		t.Error("CV text was not sent to the embedder")
+	}
+	if repo.embModel != "test-embedder" || len(repo.embVec) != 3 {
+		t.Errorf("persisted embedding = (%v, %q), want the fake vector + model", repo.embVec, repo.embModel)
+	}
+}
+
+// An embedder failure must not fail the upload, and it clears any prior vector so the
+// new CV is never matched by a stale one.
+func TestPutResume_EmbedFailureClearsVector(t *testing.T) {
+	repo := &fakeResumeRepo{embVec: []float64{9, 9}, embModel: "stale-model"}
+	store := resume.New(newFakeResumeBlobs(), repo)
+	fs := &fakeSearcher{embedErr: errors.New("embedder down")}
+	app, token := resumeEmbedApp(t, store, fs)
+
+	if status, _ := resumeReq(t, app, fiber.MethodPut, `{"text":"resume text"}`, token); status != fiber.StatusOK {
+		t.Fatalf("upload status = %d, want 200 despite embed failure", status)
+	}
+	if repo.embVec != nil || repo.embModel != "" {
+		t.Errorf("stale vector not cleared: (%v, %q)", repo.embVec, repo.embModel)
+	}
+}

--- a/internal/handler/resume_storage_test.go
+++ b/internal/handler/resume_storage_test.go
@@ -50,8 +50,10 @@ func (f *fakeResumeBlobs) Delete(_ context.Context, key string) error {
 // fakeResumeRepo is an in-memory résumé-pointer Repository. Set stamps a timestamp,
 // mirroring the SQL now().
 type fakeResumeRepo struct {
-	key string
-	set bool
+	key      string
+	set      bool
+	embVec   []float64
+	embModel string
 }
 
 func (r *fakeResumeRepo) Get(_ context.Context, _ int64) (db.GetUserResumeRow, error) {
@@ -72,6 +74,18 @@ func (r *fakeResumeRepo) Set(_ context.Context, _ int64, key string) error {
 func (r *fakeResumeRepo) Clear(_ context.Context, _ int64) error {
 	r.key, r.set = "", false
 	return nil
+}
+
+func (r *fakeResumeRepo) SetEmbedding(_ context.Context, _ int64, vec []float64, model string) error {
+	r.embVec, r.embModel = vec, model
+	return nil
+}
+
+func (r *fakeResumeRepo) GetEmbedding(_ context.Context, _ int64) (db.GetUserResumeEmbeddingRow, error) {
+	return db.GetUserResumeEmbeddingRow{
+		ResumeEmbedding:      r.embVec,
+		ResumeEmbeddingModel: pgtype.Text{String: r.embModel, Valid: r.embModel != ""},
+	}, nil
 }
 
 func resumeStorageApp(t *testing.T, store *resume.Store) (*fiber.App, string) {

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -16,6 +16,11 @@ import (
 type searcher interface {
 	Search(ctx context.Context, p search.SearchParams) (search.SearchResult, error)
 	SimilarJobs(ctx context.Context, id int64, limit int) ([]search.JobDocument, error)
+	// EmbedText returns a vector for text in the jobs' embedding space plus the
+	// embedder identity that produced it (used to embed a CV on upload).
+	EmbedText(ctx context.Context, key, text string) ([]float64, string, error)
+	// RecommendByVector ranks open jobs by similarity to a raw vector (the CV feed).
+	RecommendByVector(ctx context.Context, vector []float64, limit, offset int) (search.SearchResult, error)
 }
 
 // defaultSemanticRatio is 0 — pure keyword search against the always-fresh facet

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -20,6 +20,15 @@ type fakeSearcher struct {
 	similarLimit int
 	similarHits  []search.JobDocument
 	similarErr   error
+	// embed-text call recording + canned result
+	gotEmbedText string
+	embedVec     []float64
+	embedModel   string
+	embedErr     error
+	// recommend-by-vector call recording + canned result
+	gotRecVec []float64
+	recRes    search.SearchResult
+	recErr    error
 }
 
 func (f *fakeSearcher) Search(_ context.Context, p search.SearchParams) (search.SearchResult, error) {
@@ -30,6 +39,16 @@ func (f *fakeSearcher) Search(_ context.Context, p search.SearchParams) (search.
 func (f *fakeSearcher) SimilarJobs(_ context.Context, _ int64, limit int) ([]search.JobDocument, error) {
 	f.similarLimit = limit
 	return f.similarHits, f.similarErr
+}
+
+func (f *fakeSearcher) EmbedText(_ context.Context, _, text string) ([]float64, string, error) {
+	f.gotEmbedText = text
+	return f.embedVec, f.embedModel, f.embedErr
+}
+
+func (f *fakeSearcher) RecommendByVector(_ context.Context, v []float64, _, _ int) (search.SearchResult, error) {
+	f.gotRecVec = v
+	return f.recRes, f.recErr
 }
 
 func searchApp(s searcher) *fiber.App {

--- a/internal/resume/resume.go
+++ b/internal/resume/resume.go
@@ -44,6 +44,11 @@ type Repository interface {
 	Get(ctx context.Context, userID int64) (db.GetUserResumeRow, error)
 	Set(ctx context.Context, userID int64, key string) error
 	Clear(ctx context.Context, userID int64) error
+	// SetEmbedding persists the derived CV vector + the embedder identity that produced
+	// it (a nil vector clears it — e.g. when re-embedding a new CV failed, so the new
+	// CV is never matched by the old vector). GetEmbedding reads them back.
+	SetEmbedding(ctx context.Context, userID int64, vec []float64, model string) error
+	GetEmbedding(ctx context.Context, userID int64) (db.GetUserResumeEmbeddingRow, error)
 }
 
 // Store owns the résumé's object storage plus its pointer. blobs is nil when storage is
@@ -79,6 +84,24 @@ func (s *Store) Put(ctx context.Context, userID int64, contentType string, data 
 		return Meta{}, err
 	}
 	return s.Status(ctx, userID)
+}
+
+// SetEmbedding persists (or clears, with a nil vector) the user's derived CV embedding
+// and the embedder identity that produced it. Independent of object storage — it only
+// touches the pointer row — so it works whenever a CV was uploadable.
+func (s *Store) SetEmbedding(ctx context.Context, userID int64, vec []float64, model string) error {
+	return s.repo.SetEmbedding(ctx, userID, vec, model)
+}
+
+// Embedding returns the user's persisted CV vector and the embedder identity that
+// produced it (both zero when none is stored). The caller ignores a vector whose model
+// no longer matches the current embedder (stale).
+func (s *Store) Embedding(ctx context.Context, userID int64) (vec []float64, model string, err error) {
+	row, err := s.repo.GetEmbedding(ctx, userID)
+	if err != nil {
+		return nil, "", err
+	}
+	return row.ResumeEmbedding, row.ResumeEmbeddingModel.String, nil
 }
 
 // Status reports whether the user has a stored résumé and when it was uploaded.
@@ -197,4 +220,16 @@ func (r *QueriesRepository) Set(ctx context.Context, userID int64, key string) e
 
 func (r *QueriesRepository) Clear(ctx context.Context, userID int64) error {
 	return r.q.ClearUserResume(ctx, userID)
+}
+
+func (r *QueriesRepository) SetEmbedding(ctx context.Context, userID int64, vec []float64, model string) error {
+	return r.q.SetUserResumeEmbedding(ctx, db.SetUserResumeEmbeddingParams{
+		ID:                   userID,
+		ResumeEmbedding:      vec,
+		ResumeEmbeddingModel: pgtype.Text{String: model, Valid: model != ""},
+	})
+}
+
+func (r *QueriesRepository) GetEmbedding(ctx context.Context, userID int64) (db.GetUserResumeEmbeddingRow, error) {
+	return r.q.GetUserResumeEmbedding(ctx, userID)
 }

--- a/internal/resume/resume_test.go
+++ b/internal/resume/resume_test.go
@@ -41,9 +41,27 @@ func (f *fakeBlobs) Delete(_ context.Context, key string) error {
 }
 
 // fakeRepo is an in-memory Repository (one pointer per user).
-type fakeRepo struct{ ptr map[int64]string }
+type fakeRepo struct {
+	ptr      map[int64]string
+	embVec   map[int64][]float64
+	embModel map[int64]string
+}
 
-func newFakeRepo() *fakeRepo { return &fakeRepo{ptr: map[int64]string{}} }
+func newFakeRepo() *fakeRepo {
+	return &fakeRepo{ptr: map[int64]string{}, embVec: map[int64][]float64{}, embModel: map[int64]string{}}
+}
+
+func (r *fakeRepo) SetEmbedding(_ context.Context, userID int64, vec []float64, model string) error {
+	r.embVec[userID], r.embModel[userID] = vec, model
+	return nil
+}
+
+func (r *fakeRepo) GetEmbedding(_ context.Context, userID int64) (db.GetUserResumeEmbeddingRow, error) {
+	return db.GetUserResumeEmbeddingRow{
+		ResumeEmbedding:      r.embVec[userID],
+		ResumeEmbeddingModel: pgtype.Text{String: r.embModel[userID], Valid: r.embModel[userID] != ""},
+	}, nil
+}
 
 func (r *fakeRepo) Get(_ context.Context, userID int64) (db.GetUserResumeRow, error) {
 	key, ok := r.ptr[userID]

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -39,6 +39,13 @@ const (
 	// search needs no external API key. Multilingual + CPU-friendly.
 	embedderModel = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 
+	// resumeVectorIndexUID is the scratch index EmbedText round-trips a CV through to
+	// obtain a vector in the jobs' space: the in-engine embedder exposes no direct
+	// "embed this text" call, so the text is indexed here (with the SAME embedder as
+	// the semantic index), its vector read back, and the doc deleted. Never a
+	// persistent store of CV text — see EmbedText.
+	resumeVectorIndexUID = "resume_vectors"
+
 	// maxTotalHits caps how high a search counts its results: below it,
 	// estimatedTotalHits is the true filtered total, so it is set well above the
 	// index size to keep the reported count honest. It is NOT the pagination guard
@@ -453,6 +460,129 @@ func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDoc
 	return out, nil
 }
 
+// EmbedText embeds text through the SAME embedder that embeds jobs and returns the
+// vector plus the embedder identity that produced it. Meilisearch's in-engine embedder
+// has no "embed this text" endpoint, so the vector is obtained by round-tripping: the
+// text is indexed as one scratch document (in resumeVectorIndexUID, which carries an
+// identical embedder), its vector is read back, and the document is deleted so no
+// source text lingers in the engine. key is a caller-unique scratch id (e.g. the user
+// id) so concurrent callers do not collide. The text goes in the same field the jobs
+// document template reads, so the embedding pipeline — and thus the vector space — is
+// identical to the jobs'.
+func (c *Client) EmbedText(ctx context.Context, key, text string) ([]float64, string, error) {
+	idx := c.manager.Index(resumeVectorIndexUID)
+	if err := c.ensure(ctx, idx, resumeVectorIndexUID, resumeVectorSettings()); err != nil {
+		return nil, "", err
+	}
+	pk := primaryKey
+	doc := map[string]any{primaryKey: key, "description": text}
+	task, err := idx.UpdateDocumentsWithContext(ctx, []map[string]any{doc}, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+	if err != nil {
+		return nil, "", fmt.Errorf("search: embed upsert: %w", err)
+	}
+	if err := c.awaitTask(ctx, idx, task.TaskUID); err != nil {
+		return nil, "", err
+	}
+
+	vec, readErr := c.readDocumentVector(ctx, resumeVectorIndexUID, key)
+	// Always delete the scratch doc, even on read failure, so no CV text persists.
+	if delTask, err := idx.DeleteDocumentWithContext(ctx, key, nil); err == nil {
+		_ = c.awaitTask(ctx, idx, delTask.TaskUID)
+	}
+	if readErr != nil {
+		return nil, "", readErr
+	}
+	return vec, embedderModel, nil
+}
+
+// readDocumentVector fetches one document's embedding via retrieveVectors, using a raw
+// request (the pinned SDK's typed document fetch does not surface _vectors).
+func (c *Client) readDocumentVector(ctx context.Context, uid, key string) ([]float64, error) {
+	u := fmt.Sprintf("%s/indexes/%s/documents/%s?retrieveVectors=true", c.url, uid, key)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("search: vector request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.key)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search: read vector: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search: read vector: unexpected status %d", resp.StatusCode)
+	}
+	var doc struct {
+		Vectors map[string]json.RawMessage `json:"_vectors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("search: decode vector: %w", err)
+	}
+	raw, ok := doc.Vectors[embedderName]
+	if !ok {
+		return nil, fmt.Errorf("search: document has no %q embedding", embedderName)
+	}
+	return decodeEmbedding(raw)
+}
+
+// decodeEmbedding pulls a single vector out of a Meili _vectors.<name> payload,
+// tolerating both the object form ({"embeddings": ..., "regenerate": ...}) and a bare
+// array, and both an array-of-vectors and a single vector.
+func decodeEmbedding(raw json.RawMessage) ([]float64, error) {
+	payload := raw
+	var obj struct {
+		Embeddings json.RawMessage `json:"embeddings"`
+	}
+	if err := json.Unmarshal(raw, &obj); err == nil && len(obj.Embeddings) > 0 {
+		payload = obj.Embeddings
+	}
+	var multi [][]float64
+	if err := json.Unmarshal(payload, &multi); err == nil && len(multi) > 0 {
+		return multi[0], nil
+	}
+	var single []float64
+	if err := json.Unmarshal(payload, &single); err == nil && len(single) > 0 {
+		return single, nil
+	}
+	return nil, fmt.Errorf("search: empty embedding")
+}
+
+// RecommendByVector ranks open jobs in the semantic index by similarity to a raw
+// vector (the caller's persisted CV embedding), the shared ranking rules breaking
+// ties toward fresher jobs. An empty vector or an absent semantic index yields no
+// results — the caller treats "no usable CV vector" as an empty feed, not an error.
+func (c *Client) RecommendByVector(ctx context.Context, vector []float64, limit, offset int) (SearchResult, error) {
+	if len(vector) == 0 {
+		return SearchResult{}, nil
+	}
+	vf := make([]float32, len(vector))
+	for i, v := range vector {
+		vf[i] = float32(v)
+	}
+	resp, err := c.semantic.SearchWithContext(ctx, "", &meilisearch.SearchRequest{
+		Limit:  int64(limit),
+		Offset: int64(offset),
+		Vector: vf,
+		Hybrid: &meilisearch.SearchRequestHybrid{Embedder: embedderName, SemanticRatio: 1},
+	})
+	if err != nil {
+		var meiliErr *meilisearch.Error
+		if errors.As(err, &meiliErr) && meiliErr.MeilisearchApiError.Code == semanticIndexMissingCode {
+			return SearchResult{}, nil
+		}
+		return SearchResult{}, fmt.Errorf("search: recommend: %w", err)
+	}
+	var hits []JobDocument
+	if err := resp.Hits.DecodeInto(&hits); err != nil {
+		return SearchResult{}, fmt.Errorf("search: decode recommend hits: %w", err)
+	}
+	return SearchResult{Hits: hits, Total: resp.EstimatedTotalHits}, nil
+}
+
+// CurrentEmbedderModel is the identity of the embedder currently embedding jobs.
+// Persisted alongside a CV vector so a model change marks the vector stale.
+func CurrentEmbedderModel() string { return embedderModel }
+
 // awaitTask blocks until a Meilisearch task settles and reports a failed task as
 // an error.
 func (c *Client) awaitTask(ctx context.Context, idx meilisearch.IndexManager, taskUID int64) error {
@@ -549,4 +679,12 @@ func semanticSettings() *meilisearch.Settings {
 		},
 	}
 	return s
+}
+
+// resumeVectorSettings configures the EmbedText scratch index with ONLY the semantic
+// index's embedder — same source, model, and document template — so a CV embedded
+// here lands in the exact same vector space as the jobs. No facets/filters: the
+// index holds one transient document at a time and is never searched.
+func resumeVectorSettings() *meilisearch.Settings {
+	return &meilisearch.Settings{Embedders: semanticSettings().Embedders}
 }

--- a/internal/search/embed_test.go
+++ b/internal/search/embed_test.go
@@ -1,0 +1,44 @@
+package search
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// decodeEmbedding must pull one vector out of every shape Meilisearch's
+// _vectors.<name> payload takes across versions: the object form with an
+// array-of-vectors, the object form with a single vector, and a bare array — so the
+// CV read-back does not break on a Meili upgrade.
+func TestDecodeEmbedding(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    []float64
+		wantErr bool
+	}{
+		{"object array-of-vectors", `{"embeddings": [[1, 2, 3]], "regenerate": true}`, []float64{1, 2, 3}, false},
+		{"object single vector", `{"embeddings": [1, 2, 3]}`, []float64{1, 2, 3}, false},
+		{"bare array-of-vectors", `[[0.5, -0.5]]`, []float64{0.5, -0.5}, false},
+		{"object empty embeddings", `{"embeddings": []}`, nil, true},
+		{"empty object", `{}`, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := decodeEmbedding(json.RawMessage(tt.raw))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/migrations/0002_cv_embedding.sql
+++ b/migrations/0002_cv_embedding.sql
@@ -1,0 +1,12 @@
+-- Persisted CV embedding for the /my/recommendations feed. Computed through the
+-- SAME Meilisearch embedder as jobs, so the vector shares the jobs' space (see the
+-- cv-recommendations change). resume_embedding_model records the embedder identity
+-- that produced the vector: a model change marks the vector stale (ignored for
+-- ranking, recomputed on next upload) so a CV vector is never compared against jobs
+-- embedded by a different model. Only the derived vector is stored — never raw CV text.
+--
+-- Applied to a fresh volume by initdb after 0001; on an existing prod volume this
+-- ALTER must be run manually BEFORE deploying code that reads the columns.
+ALTER TABLE public.users
+    ADD COLUMN resume_embedding double precision[],
+    ADD COLUMN resume_embedding_model text;

--- a/openspec/changes/cv-recommendations/.openspec.yaml
+++ b/openspec/changes/cv-recommendations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/cv-recommendations/design.md
+++ b/openspec/changes/cv-recommendations/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Jobs are embedded by an in-engine Meilisearch embedder (huggingFace MiniLM,
+symmetric — CV-as-text and job-as-document land in one space). The résumé
+subsystem already stores the CV file in S3 (`users.resume_object_key`) and can
+extract text (`pdfText` in `internal/handler/resume.go`), but deliberately does
+not persist raw CV text. `PutResume` is the upload entry point. `search.Client`
+owns all Meili access; `SearchParams` supports semantic queries.
+
+The hard constraint (user-stated): the CV embedding MUST live in the same vector
+space as the jobs — otherwise similarity is meaningless. Meili's in-engine
+embedder does not expose a "give me the vector for this text" call, so the only
+way to obtain a same-space CV vector is to have Meili embed it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `/my/recommendations` feed of jobs ranked by semantic similarity to the
+  user's CV.
+- A **persisted** CV embedding that is guaranteed same-space with the jobs.
+- Reuse résumé storage + text extraction; no raw CV text persisted.
+- Graceful degradation (no CV / no vector / no storage / no semantic index).
+
+**Non-Goals:**
+- Changing the swipe deck (`job-swipe`).
+- Skill-based ranking (already cheap via facet filters).
+- Behavior/taste vectors; CV-summary embedding to beat input truncation.
+
+## Decisions
+
+- **Same-space by construction (Meili read-back).** On CV upload, embed the CV
+  text through Meili's *same* embedder and read the vector back: upsert a
+  single-doc into a dedicated `resume_vectors` index whose embedder settings are
+  identical to `jobs_semantic`, fetch it with `retrieveVectors:true`, then
+  **delete the scratch doc** so no CV text persists in Meili. The returned vector
+  is, by construction, in the jobs' space. (No separate model, no drift — this is
+  the whole point.)
+- **Persist the vector, not the text.** Store the vector on the user
+  (`users.resume_embedding float8[]`) plus an **embedder identity**
+  (`users.resume_embedding_model text`, e.g. the model name) so a model change
+  marks the vector stale. A stale vector is ignored for ranking and recomputed on
+  the next upload. This directly enforces "CV vector never compared against jobs
+  from a different model."
+- **Recommendations = Meili vector search.** `GET /me/recommendations` reads the
+  fresh CV vector from Postgres and issues a `jobs_semantic` search with that
+  raw `vector` (open jobs only), returning the standard job-view envelope. No
+  per-request CV fetch/parse/embed — the persisted vector is the whole input.
+- **Compute at upload time.** The embedding step hooks into `PutResume` after the
+  blob is stored and text extracted; it is best-effort (a Meili/embedder failure
+  leaves no vector and does not fail the upload — matches résumé-storage's
+  degrade-not-error stance).
+- **Degradation.** Missing CV vector, stale vector, unconfigured storage, or
+  absent semantic index → the endpoint returns an empty list (not an error) and
+  the page shows an upload prompt / empty state.
+
+## Risks / Trade-offs
+
+- **Read-back is slightly indirect.** Indexing-then-reading-a-vector is less
+  obvious than a direct "embed" API, but it is the only way to get a same-space
+  vector from the in-engine embedder, which is the non-negotiable requirement.
+  Encapsulated behind one `search.Client` helper.
+- **Input truncation.** MiniLM truncates to its max input length, so a long CV is
+  embedded from its leading section only. Accepted for MVP; CV-summary embedding
+  is a noted seam.
+- **Coverage-dependent quality.** Ranks only against embedded jobs; improves as
+  the `jobs_semantic` full build completes. Fallback keeps the feed non-erroring.
+- **Migration on prod.** Adds columns to `users`; must be applied on prod before
+  the deploy that reads them (per the migration convention — unapplied migration
+  → read errors).
+- **Model-swap recompute.** If the jobs embedder is ever switched (e.g. to the
+  proxy), every stored CV vector goes stale and must be recomputed; the embedder-
+  identity guard makes this safe (stale vectors are simply ignored until refreshed
+  on next upload) but users must re-upload or be re-embedded to regain the feed.

--- a/openspec/changes/cv-recommendations/proposal.md
+++ b/openspec/changes/cv-recommendations/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Skill-level matching is already cheap and exact via facet filters, so it is not
+where embeddings add value. A user's CV carries **unstructured semantic signal**
+(experience context, phrasing, domains) that a skill filter cannot capture. With
+the `jobs_semantic` index in place, we can recommend jobs by semantic similarity
+to the user's CV — a genuinely more capable feature than skill matching.
+
+## What Changes
+
+- Add a dedicated **`/my/recommendations`** page (its own tab/nav entry) showing
+  jobs ranked by semantic similarity to the signed-in user's CV. The swipe deck
+  is **not** changed.
+- Add `GET /api/v1/me/recommendations`: rank `jobs_semantic` by the caller's
+  **persisted CV embedding** (a vector search), returning the standard list
+  envelope of job views.
+- **Persist the CV embedding** on the user, computed **through Meili's own
+  embedder** so it lives in the exact same vector space as the job embeddings
+  (see design: the CV text is embedded by the same in-engine model and the vector
+  is read back and stored). Store the embedder identity alongside it so a model
+  change marks the vector stale for recompute — the CV vector is never compared
+  against jobs embedded by a different model.
+- Compute/refresh the CV embedding when a user **uploads or replaces** their CV
+  (hook into the existing résumé upload). No raw CV text is persisted (only the
+  derived vector + the S3 blob that résumé-storage already keeps).
+- **Graceful degradation:** no CV, no persisted vector yet, unconfigured object
+  storage, or unavailable semantic index → the page shows an appropriate empty/
+  prompt state and the endpoint returns an empty (not error) result.
+
+## Capabilities
+
+### New Capabilities
+
+- `cv-recommendations`: a signed-in user gets a `/my/recommendations` feed of
+  jobs ranked by semantic similarity between their CV and the job catalogue,
+  backed by a persisted CV embedding kept in the same vector space as the jobs.
+
+### Modified Capabilities
+
+<!-- none: the swipe deck (job-swipe) is intentionally left unchanged -->
+
+## Impact
+
+- Schema: a persisted CV embedding on `users` (vector + embedder identity) —
+  needs a migration (apply on prod before deploy per the migration convention).
+- Code: new recommendations handler + route; a CV-embedding step wired into the
+  existing résumé upload (`PutResume`), reusing `pdfText` and the object store;
+  a Meili "embed-and-read-back" helper in `internal/search` that guarantees the
+  CV vector matches the jobs' embedder; a vector search over `jobs_semantic`.
+- Frontend: a new `/my/recommendations` SvelteKit page + nav entry + API client
+  method.
+- Depends on: `jobs_semantic` (full build in progress), résumé storage (S3,
+  configured in prod), and the shared embedder settings.
+- Out of scope (seams): behavior-based taste vectors, profile-skill semantic
+  ranking of the swipe deck, CV-section/summary embedding to beat the model's
+  input-length truncation.

--- a/openspec/changes/cv-recommendations/specs/cv-recommendations/spec.md
+++ b/openspec/changes/cv-recommendations/specs/cv-recommendations/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: CV embedding is persisted in the jobs' vector space
+
+The system SHALL compute and persist a per-user CV embedding that lives in the exact same vector space as the job embeddings, by embedding the CV text through the same Meilisearch embedder that embeds jobs and reading the resulting vector back. The persisted vector SHALL be stored with the identity of the embedder that produced it, so that a change of embedder model marks the stored vector stale and it is never compared against jobs embedded by a different model. The raw CV text SHALL NOT be persisted (only the derived vector, alongside the S3 blob résumé-storage already keeps).
+
+#### Scenario: Upload computes and stores the CV vector
+
+- **WHEN** a signed-in user uploads or replaces their CV and both object storage and the semantic embedder are available
+- **THEN** the CV text is embedded through the same embedder as jobs, the resulting vector and the embedder identity are stored on the user, and no raw CV text is persisted
+
+#### Scenario: A stale-model vector is not used
+
+- **WHEN** a user's persisted CV vector was produced by a different embedder identity than the current one
+- **THEN** the system treats the vector as stale (recompute on next upload) and does not rank recommendations with it
+
+#### Scenario: Embedding unavailable degrades the upload
+
+- **WHEN** a CV is uploaded but object storage or the embedder is unavailable
+- **THEN** the CV upload/skill-extraction still succeeds and simply leaves no CV vector stored
+
+### Requirement: Recommendations endpoint ranks jobs by the CV vector
+
+The system SHALL expose an authenticated endpoint `GET /api/v1/me/recommendations` that returns open jobs ranked by vector similarity between the caller's persisted CV embedding and the `jobs_semantic` index. It SHALL use the standard list envelope (`{"data": [...], "meta": {...}}`) with each item in the shared `jobview` shape and SHALL support `limit`/`offset`. When the caller has no usable CV vector (none stored, stale, no CV) or the semantic index is unavailable, it SHALL return an empty result rather than an error.
+
+#### Scenario: Ranked recommendations for a user with a CV vector
+
+- **WHEN** a signed-in user with a fresh persisted CV vector requests `GET /api/v1/me/recommendations`
+- **THEN** the response is a list of open jobs ordered by semantic similarity to the CV vector
+
+#### Scenario: No CV vector returns an empty feed
+
+- **WHEN** a signed-in user with no usable CV vector requests recommendations
+- **THEN** the response is a successful empty list (no error)
+
+#### Scenario: Requires authentication
+
+- **WHEN** a request to `GET /api/v1/me/recommendations` carries neither a valid auth cookie nor a valid API key
+- **THEN** the system responds `401`
+
+### Requirement: The recommendations page presents the feed with empty states
+
+The web app SHALL provide a `/my/recommendations` page, reachable from the signed-in navigation, that renders the recommendations feed for the authenticated user. When there are no recommendations because the user has not uploaded a CV, the page SHALL prompt them to upload one; when recommendations are simply empty or unavailable, it SHALL show a non-error empty state.
+
+#### Scenario: Feed renders for a user with recommendations
+
+- **WHEN** a signed-in user with a CV vector opens `/my/recommendations`
+- **THEN** the page lists the recommended jobs
+
+#### Scenario: No CV prompts upload
+
+- **WHEN** a signed-in user who has not uploaded a CV opens `/my/recommendations`
+- **THEN** the page shows a prompt to upload a CV instead of an empty error

--- a/openspec/changes/cv-recommendations/tasks.md
+++ b/openspec/changes/cv-recommendations/tasks.md
@@ -21,9 +21,9 @@
 
 ## 5. Frontend `/my/recommendations` page
 
-- [ ] 5.1 Add an API client method `getRecommendations(limit, offset)`.
-- [ ] 5.2 Add the `/my/recommendations` SvelteKit route rendering the feed of job views, with a non-error empty state and an "upload your CV" prompt when the user has no CV vector.
-- [ ] 5.3 Add a signed-in navigation entry to the page.
+- [x] 5.1 Add an API client method `getRecommendations(limit, offset)`. — `api.recommendations(limit, offset)` (Slice<Job>).
+- [x] 5.2 Add the `/my/recommendations` SvelteKit route rendering the feed of job views, with a non-error empty state and an "upload your CV" prompt when the user has no CV vector. — `RecommendationsView.svelte` (Paginator + JobRow) + thin page; empty state links to `/my/profile`.
+- [x] 5.3 Add a signed-in navigation entry to the page. — `HeaderMenu.svelte` account links.
 
 ## 6. Verification
 

--- a/openspec/changes/cv-recommendations/tasks.md
+++ b/openspec/changes/cv-recommendations/tasks.md
@@ -10,14 +10,14 @@
 
 ## 3. Compute the CV vector on upload
 
-- [ ] 3.1 Write a failing handler test: `PutResume` with a CV → the persisted vector + model are set via a fake embedder; on embedder/storage failure the upload still succeeds and leaves no vector (best-effort, degrade-not-error).
-- [ ] 3.2 Implement the hook in `PutResume`: after the blob is stored and text extracted (reuse `pdfText`), call `EmbedText` and persist via `SetUserResumeEmbedding`; swallow+log errors so the upload never fails on the embedding step.
+- [x] 3.1 Write a failing handler test: `PutResume` with a CV → the persisted vector + model are set via a fake embedder; on embedder/storage failure the upload still succeeds and leaves no vector (best-effort, degrade-not-error).
+- [x] 3.2 Implement the hook in `PutResume`: after the blob is stored and text extracted (reuse `pdfText`), call `EmbedText` and persist via `SetUserResumeEmbedding`; swallow+log errors so the upload never fails on the embedding step. — routed persistence through `resume.Store.SetEmbedding` (repo interface) so the hook is unit-testable; clears the vector on embed failure.
 
 ## 4. Recommendations endpoint
 
-- [ ] 4.1 Write a failing handler test (fake searcher): `GET /me/recommendations` with a fresh vector → the searcher is asked to vector-rank `jobs_semantic` and job views are returned; no/stale vector (model mismatch) → successful empty list; unauthenticated → 401.
-- [ ] 4.2 Implement a `search.Client` vector search over `jobs_semantic` (rank open jobs by a raw provided vector, `limit`/`offset`).
-- [ ] 4.3 Implement the `Recommendations` handler: read the CV vector + model, ignore it when the model does not match the current embedder identity (stale) or is absent → empty list; otherwise vector-search and return the standard envelope. Wire `GET /api/v1/me/recommendations` behind `RequireAuthOrKey`.
+- [x] 4.1 Write a failing handler test (fake searcher): `GET /me/recommendations` with a fresh vector → the searcher is asked to vector-rank `jobs_semantic` and job views are returned; no/stale vector (model mismatch) → successful empty list; unauthenticated → 401.
+- [x] 4.2 Implement a `search.Client` vector search over `jobs_semantic` (rank open jobs by a raw provided vector, `limit`/`offset`). — `RecommendByVector` (added in group 2), absent-index degrades to empty.
+- [x] 4.3 Implement the `Recommendations` handler: read the CV vector + model, ignore it when the model does not match the current embedder identity (stale) or is absent → empty list; otherwise vector-search and return the standard envelope. Wire `GET /api/v1/me/recommendations` behind `RequireAuthOrKey`.
 
 ## 5. Frontend `/my/recommendations` page
 

--- a/openspec/changes/cv-recommendations/tasks.md
+++ b/openspec/changes/cv-recommendations/tasks.md
@@ -27,4 +27,4 @@
 
 ## 6. Verification
 
-- [ ] 6.1 `go test ./...` + `go vet ./...` green; web `svelte-check` clean; confirm no raw CV text is persisted (only the vector + S3 blob), the migration is recorded for prod-apply-before-deploy, and the swipe deck is unchanged.
+- [x] 6.1 `go test ./...` + `go vet ./...` green; web `svelte-check` clean; confirm no raw CV text is persisted (only the vector + S3 blob), the migration is recorded for prod-apply-before-deploy, and the swipe deck is unchanged. — go suite + vet green; svelte-check clean for the feature files (4 pre-existing vitest-module errors are environmental, unrelated); only the derived vector persists; migration 0002 documents prod-apply-before-deploy; swipe.go/facets.go untouched.

--- a/openspec/changes/cv-recommendations/tasks.md
+++ b/openspec/changes/cv-recommendations/tasks.md
@@ -1,0 +1,30 @@
+## 1. Schema & queries
+
+- [x] 1.1 Add a migration: `users.resume_embedding float8[]` (nullable) and `users.resume_embedding_model text` (nullable, the embedder identity that produced the vector). Note in the change that it must be applied on prod before deploy.
+- [x] 1.2 Add sqlc queries: set the CV embedding (`SetUserResumeEmbedding` — vector + model), read it (`GetUserResumeEmbedding`), and clear it (extend `ClearUserResume` or add). Run `make sqlc`.
+
+## 2. Same-space CV embedding helper (search client)
+
+- [x] 2.1 Write a failing test for a `search.Client` `EmbedText(ctx, text) → (vector, model, error)` helper that obtains a vector in the jobs' space via Meili read-back (integration test against Meili where available; unit-cover the ensure/upsert/retrieve/delete sequencing). — unit-covered the version-fragile `decodeEmbedding` parsing (`embed_test.go`); the full Meili round-trip is exercised under `-tags=integration`.
+- [x] 2.2 Implement `EmbedText`: ensure a `resume_vectors` index with embedder settings identical to `jobs_semantic`, upsert the CV text as one scratch doc, fetch it with `retrieveVectors:true`, delete the scratch doc (no CV text persisted), return the vector + the current embedder model id. — plus `RecommendByVector` (vector search over `jobs_semantic`) and `CurrentEmbedderModel` for the staleness guard.
+
+## 3. Compute the CV vector on upload
+
+- [ ] 3.1 Write a failing handler test: `PutResume` with a CV → the persisted vector + model are set via a fake embedder; on embedder/storage failure the upload still succeeds and leaves no vector (best-effort, degrade-not-error).
+- [ ] 3.2 Implement the hook in `PutResume`: after the blob is stored and text extracted (reuse `pdfText`), call `EmbedText` and persist via `SetUserResumeEmbedding`; swallow+log errors so the upload never fails on the embedding step.
+
+## 4. Recommendations endpoint
+
+- [ ] 4.1 Write a failing handler test (fake searcher): `GET /me/recommendations` with a fresh vector → the searcher is asked to vector-rank `jobs_semantic` and job views are returned; no/stale vector (model mismatch) → successful empty list; unauthenticated → 401.
+- [ ] 4.2 Implement a `search.Client` vector search over `jobs_semantic` (rank open jobs by a raw provided vector, `limit`/`offset`).
+- [ ] 4.3 Implement the `Recommendations` handler: read the CV vector + model, ignore it when the model does not match the current embedder identity (stale) or is absent → empty list; otherwise vector-search and return the standard envelope. Wire `GET /api/v1/me/recommendations` behind `RequireAuthOrKey`.
+
+## 5. Frontend `/my/recommendations` page
+
+- [ ] 5.1 Add an API client method `getRecommendations(limit, offset)`.
+- [ ] 5.2 Add the `/my/recommendations` SvelteKit route rendering the feed of job views, with a non-error empty state and an "upload your CV" prompt when the user has no CV vector.
+- [ ] 5.3 Add a signed-in navigation entry to the page.
+
+## 6. Verification
+
+- [ ] 6.1 `go test ./...` + `go vet ./...` green; web `svelte-check` clean; confirm no raw CV text is persisted (only the vector + S3 blob), the migration is recorded for prod-apply-before-deploy, and the swipe deck is unchanged.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -183,6 +183,15 @@ export function createApi(
     return toSlice(await request<Page<Job>>(`/api/v1/me/jobs/swipe?${params}`), 0);
   }
 
+  /** Personalized job recommendations for the signed-in user: open jobs ranked by
+   *  semantic similarity to their uploaded CV. An empty slice means no usable CV
+   *  vector yet (no CV uploaded, or the embedder was superseded) — the page then
+   *  prompts the user to add their CV. Authenticated. */
+  async function recommendations(limit: number, offset: number): Promise<Slice<Job>> {
+    const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+    return toSlice(await request<Page<Job>>(`/api/v1/me/recommendations?${params}`), offset);
+  }
+
   /** Facet-distribution counts for the analytics page. `params` carries the same
    *  query text and facet filters as `searchJobs` (built by the caller, e.g. via
    *  `filtersToParams`); the endpoint returns counts instead of a page of jobs.
@@ -697,6 +706,7 @@ export function createApi(
     getJobMatch,
     searchJobs,
     swipeDeck,
+    recommendations,
     facetCounts,
     listCompanies,
     getCompany,

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -57,6 +57,7 @@
 
   const accountLinks = [
     { href: '/my/jobs', label: 'My jobs' },
+    { href: '/my/recommendations', label: 'Recommendations' },
     { href: '/my/searches', label: 'Saved searches' },
     { href: '/my/notifications', label: 'Notifications' },
     { href: '/my/api-keys', label: 'API keys' },

--- a/web/src/lib/components/RecommendationsView.svelte
+++ b/web/src/lib/components/RecommendationsView.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { api } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { Paginator } from '$lib/paginated.svelte';
+  import JobRow from './JobRow.svelte';
+  import LoadMore from './LoadMore.svelte';
+  import States from './States.svelte';
+
+  // Open jobs ranked by semantic similarity to the caller's uploaded CV. An empty
+  // page means no usable CV vector yet (no CV uploaded, or the embedder was
+  // superseded), so the empty state points the user at their profile to add a CV
+  // rather than showing a dead end.
+  const page = new Paginator((limit, offset) => api.recommendations(limit, offset));
+
+  $effect(() => {
+    if (isAuthenticated()) void page.start();
+  });
+</script>
+
+{#if page.status === 'loading'}
+  <States state="loading" />
+{:else if page.status === 'error'}
+  <States state="error" message="Couldn't load your recommendations." />
+{:else if page.items.length === 0}
+  <div class="rounded-xl border border-border bg-card p-6 text-center">
+    <p class="text-sm font-medium text-foreground">No recommendations yet</p>
+    <p class="mt-1 text-sm text-muted-foreground">
+      Add or update your CV on your
+      <a
+        href={resolve('/my/profile')}
+        class="font-medium text-foreground underline underline-offset-4 hover:no-underline">profile</a
+      >
+      to get jobs matched to your experience.
+    </p>
+  </div>
+{:else}
+  <ul class="flex flex-col gap-3">
+    {#each page.items as job (job.public_slug)}
+      <li><JobRow {job} /></li>
+    {/each}
+  </ul>
+  {#if page.hasMore}
+    <LoadMore loading={page.loadingMore} error={page.loadMoreError} onclick={() => page.loadMore()} />
+  {/if}
+{/if}

--- a/web/src/routes/my/recommendations/+page.svelte
+++ b/web/src/routes/my/recommendations/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import RecommendationsView from '$lib/components/RecommendationsView.svelte';
+</script>
+
+<svelte:head>
+  <title>Recommendations — freehire</title>
+  <!-- Personal, per-user feed: keep it out of search results. -->
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
+  <h1 class="text-2xl font-semibold tracking-tight">Recommended for you</h1>
+  <p class="mt-1 text-sm text-muted-foreground">Jobs matched to your CV by meaning, not just keywords.</p>
+  <div class="mt-6">
+    <RecommendationsView />
+  </div>
+</div>


### PR DESCRIPTION
## What

A new **`/my/recommendations`** feed: open jobs ranked by semantic similarity to the signed-in user's **CV**. Skill matching is already cheap/exact via facet filters — the value of embeddings is the unstructured semantic signal in a CV (experience context, domains, phrasing) that a filter can't capture. The swipe deck is **not** touched.

Implements OpenSpec change `cv-recommendations` (proposal/design/spec/tasks in `openspec/changes/cv-recommendations/`).

## How

- **Same vector space as jobs, by construction.** Meili's in-engine embedder has no "embed this text" call, so `search.Client.EmbedText` round-trips the CV through the **same embedder** that embeds jobs: index it as one scratch doc in a `resume_vectors` index (identical embedder settings), read the vector back via `retrieveVectors`, delete the scratch doc (no CV text persisted). The CV goes in the same `description` field the jobs' document template reads, so the pipeline — and thus the space — is identical.
- **Persisted vector + staleness guard.** Migration `0002` adds `users.resume_embedding float8[]` + `users.resume_embedding_model`. The model identity is stored so a future embedder change marks the vector stale — a CV vector is never compared against jobs embedded by a different model.
- **Computed on CV upload** (`PutResume` hook), best-effort: an embedder/storage failure never fails the upload and clears any prior vector so a new CV is never matched by a stale one. Only the derived vector is persisted (never raw CV text).
- **Endpoint** `GET /api/v1/me/recommendations` vector-ranks `jobs_semantic` by the persisted CV vector, degrading to an empty feed (no CV / stale / no search) rather than erroring.
- **Frontend** `/my/recommendations` page (Paginator + JobRow) + account-menu nav; empty state points the user at their profile to add a CV.

## Deploy notes

- ⚠️ Apply migration `migrations/0002_cv_embedding.sql` on prod **before** deploying (unapplied migration → read errors).
- Quality scales with `jobs_semantic` coverage (full-catalogue build in progress); degrades gracefully below full.

## Test plan

- `go test ./...` + `go vet ./...` green (added `decodeEmbedding`, `PutResume` embed-hook, and `/me/recommendations` handler tests).
- `EmbedText`/`RecommendByVector` full Meili round-trip is exercised under `-tags=integration`.
- `svelte-check` clean for the feature files.
- [ ] Manual: after the semantic build completes, upload a CV → open `/my/recommendations` → verify a ranked feed; delete CV → verify empty-state prompt.