### PR TITLE
feat(sources): add teamex + top.co adapters, workable open-252

### DIFF
--- a/internal/sources/helpers_test.go
+++ b/internal/sources/helpers_test.go
@@ -68,3 +68,12 @@ func (f *fakeHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
 	}
 	return html.Parse(strings.NewReader(f.body))
 }
+
+func (f *fakeHTTP) GetTextWithHeaders(_ context.Context, url string, headers map[string]string) (string, error) {
+	f.gotURL = url
+	f.gotHeaders = headers
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.body, nil
+}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -56,6 +56,14 @@ type TextGetter interface {
 	GetText(ctx context.Context, url string) (string, error)
 }
 
+// HeaderTextGetter behaves like TextGetter but attaches extra request headers, for a raw-body
+// endpoint gated behind a non-secret header (e.g. a Next.js App Router RSC data endpoint, which
+// returns its flight payload only when the request carries the "RSC: 1" header). The custom
+// headers never override the standard User-Agent/Accept.
+type HeaderTextGetter interface {
+	GetTextWithHeaders(ctx context.Context, url string, headers map[string]string) (string, error)
+}
+
 // JSONPoster sends a JSON request body and decodes the JSON response (platforms whose
 // listing API is POST-only, e.g. Workday).
 type JSONPoster interface {
@@ -82,6 +90,7 @@ type HTTPClient interface {
 	XMLGetter
 	HTMLGetter
 	TextGetter
+	HeaderTextGetter
 	JSONPoster
 	HeaderJSONGetter
 	HeaderJSONPoster
@@ -209,11 +218,19 @@ const maxTextBody = 2 << 20 // 2 MiB
 // maxTextBody). Used by the domain-following harvest, which regex-scans a careers
 // page's HTML for an embedded ATS link rather than parsing a DOM.
 func (c *Client) GetText(ctx context.Context, url string) (string, error) {
+	return c.GetTextWithHeaders(ctx, url, nil)
+}
+
+// GetTextWithHeaders behaves like GetText but attaches extra request headers, for a raw-body
+// endpoint gated behind a non-secret header (e.g. a Next.js RSC data endpoint reached with
+// "RSC: 1").
+func (c *Client) GetTextWithHeaders(ctx context.Context, url string, headers map[string]string) (string, error) {
 	var body string
 	err := c.do(ctx, request{
-		method: http.MethodGet,
-		url:    url,
-		accept: "text/html",
+		method:  http.MethodGet,
+		url:     url,
+		accept:  "text/html",
+		headers: headers,
 		decode: func(resp *http.Response) error {
 			b, err := io.ReadAll(io.LimitReader(resp.Body, maxTextBody))
 			if err != nil {

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -206,6 +206,8 @@ func All(c HTTPClient) map[string]Source {
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.
 		NewTecla(c),
+		NewTeamex(c),
+		NewTopco(c),
 		NewGetmatch(c),
 		NewHabrCareer(c),
 		NewWorkAtAStartup(c),

--- a/internal/sources/teamex.go
+++ b/internal/sources/teamex.go
@@ -1,0 +1,179 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// teamex adapts teamex.io, a global talent marketplace. Its keyless API exposes one paged
+// POST list endpoint (/api/jts/global/filter) whose items already carry the full posting —
+// title, HTML descriptions, countries, required skills — so one paged crawl assembles every
+// Job with no per-posting detail request. The marketplace lists many employers but usually
+// anonymizes them (isAnonymous), so a posting's company falls back to the marketplace label;
+// its boardless config entry's company is only a validation placeholder.
+type teamex struct {
+	http JSONPoster
+}
+
+const (
+	teamexListURL = "https://api.teamex.io/api/jts/global/filter?pageSize=%d&pageIndex=%d"
+	// teamexJobURL is the public posting page, addressed by the job's sequenceId.
+	teamexJobURL   = "https://teamex.io/job/%d"
+	teamexPageSize = 50
+	// teamexMaxPages bounds pagination so a wrong or missing paging.totalCount cannot loop.
+	teamexMaxPages = 100
+	// teamexAnonymousCompany labels a posting whose employer the marketplace hides.
+	teamexAnonymousCompany = "TeamEx"
+)
+
+// NewTeamex builds the teamex adapter over the given HTTP client.
+func NewTeamex(c JSONPoster) Source { return teamex{http: c} }
+
+func (teamex) Provider() string { return "teamex" }
+
+// teamex is a marketplace with one global feed, so its config entries carry no board.
+func (teamex) boardless() {}
+
+// teamex aggregates postings from many employers, so it stays in the source facet.
+func (teamex) aggregator() {}
+
+// teamexListResponse is one page of the filter endpoint: Data.Paging.TotalCount is the
+// catalogue size used to stop pagination; Data.Data is the page of postings.
+type teamexListResponse struct {
+	Data struct {
+		Paging struct {
+			TotalCount int `json:"totalCount"`
+		} `json:"paging"`
+		Data []teamexJob `json:"data"`
+	} `json:"data"`
+}
+
+// teamexJob is one posting. The list item is fully populated (descriptions, countries,
+// skills), so the detail endpoint is never called. Company nests the employer's own name
+// when the posting is not anonymous; IsActive gates closed postings out of the crawl.
+type teamexJob struct {
+	SequenceID           int                   `json:"sequenceId"`
+	Title                string                `json:"title"`
+	IsActive             bool                  `json:"isActive"`
+	IsAnonymous          bool                  `json:"isAnonymous"`
+	PublishedDate        string                `json:"publishedDate"`
+	YearsOfExperienceMin *int                  `json:"yearsOfExperienceMin"`
+	Descriptions         []teamexDescription   `json:"descriptions"`
+	Countries            []teamexCountry       `json:"countries"`
+	RequiredSkills       []teamexRequiredSkill `json:"requiredSkills"`
+	Company              struct {
+		Name string `json:"name"`
+	} `json:"company"`
+}
+
+// teamexDescription is one titled HTML section of a posting's body.
+type teamexDescription struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+// teamexCountry is one of a posting's countries; only the display Name is used for the
+// location string (the pipeline's location dictionary derives codes/regions from it).
+type teamexCountry struct {
+	Name string `json:"name"`
+}
+
+// teamexRequiredSkill wraps a required skill; only the display name is used, canonicalized
+// through the skilltag dictionary.
+type teamexRequiredSkill struct {
+	Skill struct {
+		DisplayName string `json:"displayName"`
+	} `json:"skill"`
+}
+
+func (s teamex) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; page <= teamexMaxPages; page++ {
+		var resp teamexListResponse
+		url := fmt.Sprintf(teamexListURL, teamexPageSize, page)
+		if err := s.http.PostJSON(ctx, url, struct{}{}, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("teamex: list page %d: %w", page, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		if len(resp.Data.Data) == 0 {
+			break
+		}
+		for _, it := range resp.Data.Data {
+			if !it.IsActive {
+				continue // closed postings are not crawled
+			}
+			jobs = append(jobs, teamexToJob(it))
+		}
+		if resp.Data.Paging.TotalCount > 0 && page*teamexPageSize >= resp.Data.Paging.TotalCount {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// teamexToJob maps a posting to a Job. The employer is the posting's own company, but an
+// anonymized posting (isAnonymous) hides it behind the marketplace label even when the payload
+// still carries the name — the name must not leak; an unnamed posting also falls back. The
+// location is the joined country names; skills are canonicalized through skilltag.
+func teamexToJob(it teamexJob) Job {
+	company := teamexAnonymousCompany
+	if !it.IsAnonymous {
+		company = firstNonEmpty(it.Company.Name, teamexAnonymousCompany)
+	}
+	return Job{
+		ExternalID:         strconv.Itoa(it.SequenceID),
+		URL:                fmt.Sprintf(teamexJobURL, it.SequenceID),
+		Title:              it.Title,
+		Company:            company,
+		Location:           teamexLocation(it.Countries),
+		Description:        sanitizeHTML(teamexDescriptionHTML(it.Descriptions)),
+		PostedAt:           parseRFC3339(it.PublishedDate),
+		Skills:             teamexSkills(it.RequiredSkills),
+		ExperienceYearsMin: it.YearsOfExperienceMin,
+	}
+}
+
+// teamexDescriptionHTML composes the posting body from its titled sections, wrapping each
+// plain-text title as a heading before its HTML content (the title is prose, so a bare "<"
+// would otherwise make the sanitizer drop the tail).
+func teamexDescriptionHTML(sections []teamexDescription) string {
+	var b strings.Builder
+	for _, s := range sections {
+		if strings.TrimSpace(s.Title) != "" {
+			b.WriteString("<h3>")
+			b.WriteString(html.EscapeString(s.Title))
+			b.WriteString("</h3>")
+		}
+		b.WriteString(s.Content)
+	}
+	return b.String()
+}
+
+// teamexLocation joins the posting's country names in order, skipping blanks via the shared
+// joinNonEmpty helper.
+func teamexLocation(countries []teamexCountry) string {
+	names := make([]string, 0, len(countries))
+	for _, c := range countries {
+		names = append(names, c.Name)
+	}
+	return joinNonEmpty(names...)
+}
+
+// teamexSkills canonicalizes the posting's required skills through the skilltag dictionary,
+// keeping only resolved technologies. The names are joined into one blob so skilltag.Parse
+// applies the same matching it uses on a description.
+func teamexSkills(skills []teamexRequiredSkill) []string {
+	names := make([]string, 0, len(skills))
+	for _, s := range skills {
+		names = append(names, s.Skill.DisplayName)
+	}
+	return skilltag.Parse(strings.Join(names, " "))
+}

--- a/internal/sources/teamex_test.go
+++ b/internal/sources/teamex_test.go
@@ -1,0 +1,183 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// teamexHTTP is a route-aware test JSONPoster. teamex has a single POST list endpoint
+// (/api/jts/global/filter?pageIndex=), so this fake routes each request by the pageIndex
+// query parameter and records the pages fetched, letting a test assert pagination stops at
+// paging.totalCount.
+type teamexHTTP struct {
+	pages     map[int]string // list body keyed by requested pageIndex
+	failFirst bool           // pageIndex 1 fails
+	failPage  map[int]bool   // a specific pageIndex fails
+	gotPages  []int
+}
+
+var teamexPageRE = regexp.MustCompile(`pageIndex=(\d+)`)
+
+func (f *teamexHTTP) PostJSON(_ context.Context, url string, _, v any) error {
+	page := 1
+	if m := teamexPageRE.FindStringSubmatch(url); m != nil {
+		page, _ = strconv.Atoi(m[1])
+	}
+	f.gotPages = append(f.gotPages, page)
+	if (page == 1 && f.failFirst) || f.failPage[page] {
+		return errors.New("teamexHTTP: list boom")
+	}
+	raw, ok := f.pages[page]
+	if !ok {
+		raw = `{"data":{"paging":{"totalCount":0},"data":[]}}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestTeamexProvider(t *testing.T) {
+	if got := NewTeamex(nil).Provider(); got != "teamex" {
+		t.Errorf("Provider() = %q, want %q", got, "teamex")
+	}
+}
+
+func TestTeamexRegisteredInAllBoardlessAggregator(t *testing.T) {
+	s, ok := All(nil)["teamex"]
+	if !ok {
+		t.Fatal(`All(nil)["teamex"] missing`)
+	}
+	if _, isBoardless := s.(boardless); !isBoardless {
+		t.Error("teamex should be boardless (one global feed, no board id)")
+	}
+	if _, isAggregator := s.(aggregator); !isAggregator {
+		t.Error("teamex should be an aggregator (many employers behind one marketplace)")
+	}
+	if !slices.Contains(FilterableProviders(), "teamex") {
+		t.Error("FilterableProviders() should include the teamex aggregator")
+	}
+}
+
+func TestTeamexFetchMapsJob(t *testing.T) {
+	fake := &teamexHTTP{pages: map[int]string{1: `{"data":{"paging":{"totalCount":1},"data":[
+		{"sequenceId":1506,"title":"Senior Full-Stack Engineer","isActive":true,"isAnonymous":false,
+		 "publishedDate":"2026-07-06T13:52:49.765Z","yearsOfExperienceMin":6,
+		 "descriptions":[{"title":"Overview","content":"<p>Build systems.</p><script>x()</script>"}],
+		 "countries":[{"name":"Argentina","code":"AR"},{"name":"Costa Rica","code":"CR"}],
+		 "requiredSkills":[{"skill":{"displayName":"Docker"}},{"skill":{"displayName":"React"}}],
+		 "company":{"name":"Acme Health"}}
+	]}}`}}
+
+	jobs, err := NewTeamex(fake).Fetch(context.Background(), CompanyEntry{Company: "teamex", Provider: "teamex"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "1506" {
+		t.Errorf("ExternalID = %q, want 1506", j.ExternalID)
+	}
+	if want := "https://teamex.io/job/1506"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.Title != "Senior Full-Stack Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Acme Health" {
+		t.Errorf("Company = %q, want the posting's own employer", j.Company)
+	}
+	if want := "Argentina, Costa Rica"; j.Location != want {
+		t.Errorf("Location = %q, want %q (country names joined)", j.Location, want)
+	}
+	if !strings.Contains(j.Description, "Build systems") || strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not composed+sanitized: %q", j.Description)
+	}
+	if !slices.Equal(j.Skills, []string{"docker", "react"}) {
+		t.Errorf("Skills = %v, want [docker react] (canonical, sorted)", j.Skills)
+	}
+	if j.ExperienceYearsMin == nil || *j.ExperienceYearsMin != 6 {
+		t.Errorf("ExperienceYearsMin = %v, want 6", j.ExperienceYearsMin)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 6, 13, 52, 49, 765000000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-07-06T13:52:49.765Z", j.PostedAt)
+	}
+}
+
+func TestTeamexSkipsInactive(t *testing.T) {
+	fake := &teamexHTTP{pages: map[int]string{1: `{"data":{"paging":{"totalCount":2},"data":[
+		{"sequenceId":1,"title":"Open","isActive":true,"company":{"name":"A"},"countries":[]},
+		{"sequenceId":2,"title":"Closed","isActive":false,"company":{"name":"B"},"countries":[]}
+	]}}`}}
+	jobs, err := NewTeamex(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "1" {
+		t.Fatalf("got %v, want only the active job (isActive:false excluded)", jobs)
+	}
+}
+
+func TestTeamexAnonymousCompanyFallback(t *testing.T) {
+	// An anonymous posting hides its employer (no company.name), so it falls back to the
+	// marketplace label rather than an empty company.
+	fake := &teamexHTTP{pages: map[int]string{1: `{"data":{"paging":{"totalCount":1},"data":[
+		{"sequenceId":9,"title":"Hidden Employer","isActive":true,"isAnonymous":true,
+		 "company":{},"countries":[]}
+	]}}`}}
+	jobs, err := NewTeamex(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Company != "TeamEx" {
+		t.Fatalf("anonymous posting Company = %q, want TeamEx fallback", jobs[0].Company)
+	}
+}
+
+func TestTeamexAnonymousHidesNamedEmployer(t *testing.T) {
+	// When the API flags a posting anonymous but STILL carries the employer name, the flag
+	// wins — the marketplace anonymized it on purpose, so the name must not leak.
+	fake := &teamexHTTP{pages: map[int]string{1: `{"data":{"paging":{"totalCount":1},"data":[
+		{"sequenceId":9,"title":"Hidden Employer","isActive":true,"isAnonymous":true,
+		 "company":{"name":"Acme Corp"},"countries":[]}
+	]}}`}}
+	jobs, err := NewTeamex(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Company != "TeamEx" {
+		t.Fatalf("anonymous posting Company = %q, want TeamEx (name must not leak)", jobs[0].Company)
+	}
+}
+
+func TestTeamexPaginatesAndStopsAtTotal(t *testing.T) {
+	// totalCount=51 with a 50 page size: pages 1 and 2 are fetched, then 2*50>=51 stops.
+	page := func(id int) string {
+		return `{"data":{"paging":{"totalCount":51},"data":[
+			{"sequenceId":` + strconv.Itoa(id) + `,"title":"P","isActive":true,"company":{"name":"C"},"countries":[]}]}}`
+	}
+	fake := &teamexHTTP{pages: map[int]string{1: page(1), 2: page(2)}}
+	jobs, err := NewTeamex(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (two pages)", len(jobs))
+	}
+	if !slices.Equal(fake.gotPages, []int{1, 2}) {
+		t.Errorf("fetched pages = %v, want [1 2] (stop at totalCount)", fake.gotPages)
+	}
+}
+
+func TestTeamexFirstPageErrorFailsBoard(t *testing.T) {
+	fake := &teamexHTTP{failFirst: true}
+	if _, err := NewTeamex(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("Fetch: want first-page error, got nil")
+	}
+}

--- a/internal/sources/topco.go
+++ b/internal/sources/topco.go
@@ -1,0 +1,145 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// topco adapts top.co, the careers board of the TOP (TON/Open Platform) ecosystem. The
+// board lists many portfolio companies (Mira, Wallet, Tribute, …), each posting carrying its
+// own employer, so it is a boardless aggregator. top.co is a Next.js App Router app: the
+// careers page inlines every posting into its RSC flight as a "vacancies":[…] array (id,
+// position, company), but the posting body is lazy — the array's body/requirements/conditions
+// are "$undefined" placeholders. The full HTML body lives on the per-posting RSC data endpoint
+// (/careers/{id} reached with the "RSC: 1" header), so each posting takes one detail fetch.
+type topco struct {
+	http topcoClient
+}
+
+// topcoClient is the transport surface topco needs: the careers page (HTML) plus the
+// per-posting RSC data endpoint (raw text gated behind the RSC header).
+type topcoClient interface {
+	HTMLGetter
+	HeaderTextGetter
+}
+
+const (
+	topcoCareersURL = "https://top.co/careers"
+	// topcoJobURL is both the public posting page and, with the RSC header, its data endpoint.
+	topcoJobURL = "https://top.co/careers/%s"
+)
+
+// NewTopco builds the top.co adapter over the given HTTP client.
+func NewTopco(c topcoClient) Source { return topco{http: c} }
+
+func (topco) Provider() string { return "topco" }
+
+// topco is one careers page with no per-tenant board id.
+func (topco) boardless() {}
+
+// topco aggregates postings from many portfolio companies, so it stays in the source facet.
+func (topco) aggregator() {}
+
+// topcoVacancy is the subset of a careers-flight vacancies entry the adapter maps. Location is
+// always null in the flight (the ecosystem's roles are global/remote); the body fields are the
+// "$undefined" placeholder here and fetched from the detail endpoint instead.
+type topcoVacancy struct {
+	ID       string `json:"id"`
+	Position string `json:"position"`
+	Company  struct {
+		Name string `json:"name"`
+	} `json:"company"`
+}
+
+func (s topco) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	root, err := s.http.GetHTML(ctx, topcoCareersURL)
+	if err != nil {
+		return nil, fmt.Errorf("topco: careers page: %w", err)
+	}
+	flight, err := decodeNextFlight(root)
+	if err != nil {
+		return nil, fmt.Errorf("topco: %w", err)
+	}
+	// The postings are the flight's "vacancies":[…] array. A missing array is an error (a
+	// markup change must surface loudly rather than silently empty the catalogue); an empty
+	// array is valid and yields no jobs.
+	raw, ok := bracketSlice(flight, `"vacancies":`, '[', ']')
+	if !ok {
+		return nil, fmt.Errorf("topco: vacancies payload not found")
+	}
+	var vacancies []topcoVacancy
+	if err := json.Unmarshal([]byte(raw), &vacancies); err != nil {
+		return nil, fmt.Errorf("topco: decode vacancies: %w", err)
+	}
+
+	// Each posting takes one RSC detail fetch for its body; a failed fetch keeps the posting
+	// with an empty description rather than dropping it (fetch never returns ok=false for a
+	// detail error — only an empty id is dropped, as it would collide on the dedup key).
+	return fetchDetails(vacancies, defaultDetailWorkers, func(v topcoVacancy) (Job, bool) {
+		if v.ID == "" {
+			return Job{}, false
+		}
+		return Job{
+			ExternalID:  v.ID,
+			URL:         fmt.Sprintf(topcoJobURL, v.ID),
+			Title:       v.Position,
+			Company:     firstNonEmpty(v.Company.Name, e.Company),
+			Description: sanitizeHTML(s.detailBody(ctx, v.ID)),
+		}, true
+	}), nil
+}
+
+// detailBody fetches a posting's RSC data endpoint (with the "RSC: 1" header that makes top.co
+// return the flight rather than HTML) and composes the body from its body/requirements/
+// conditions HTML sections. A failed request or a still-lazy "$undefined" placeholder yields an
+// empty body, so a posting is never dropped over a missing description.
+func (s topco) detailBody(ctx context.Context, id string) string {
+	flight, err := s.http.GetTextWithHeaders(ctx, fmt.Sprintf(topcoJobURL, id), map[string]string{"RSC": "1"})
+	if err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, marker := range []string{`"body":`, `"requirements":`, `"conditions":`} {
+		v, ok := jsonStringField(flight, marker)
+		// A "$…" value is an unresolved RSC reference/placeholder ("$undefined"), not content.
+		if ok && !strings.HasPrefix(v, "$") {
+			b.WriteString(v)
+		}
+	}
+	return b.String()
+}
+
+// jsonStringField returns the JSON string value that immediately follows the first occurrence
+// of marker (a `"key":` prefix) in s, JSON-decoding its escapes. ok is false when the marker is
+// absent or is not followed by a JSON string literal. It scans the literal honoring backslash
+// escapes, so an embedded escaped quote does not end it early. Used to pull individual fields
+// out of a raw RSC flight stream, which is not wrapped as a decodable document.
+func jsonStringField(s, marker string) (string, bool) {
+	at := strings.Index(s, marker)
+	if at < 0 {
+		return "", false
+	}
+	i := at + len(marker)
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' || s[i] == '\r') {
+		i++
+	}
+	if i >= len(s) || s[i] != '"' {
+		return "", false
+	}
+	start := i
+	for i++; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			i++ // skip the escaped byte
+		case '"':
+			var out string
+			if err := json.Unmarshal([]byte(s[start:i+1]), &out); err != nil {
+				return "", false
+			}
+			return out, true
+		}
+	}
+	return "", false
+}

--- a/internal/sources/topco_test.go
+++ b/internal/sources/topco_test.go
@@ -1,0 +1,203 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// topcoHTTP is a route-aware test client. top.co has two request shapes: the careers listing
+// (GetHTML, a Next.js page whose flight embeds the vacancies array) and a per-posting RSC data
+// endpoint (GetTextWithHeaders, whose raw flight carries the body/requirements/conditions). The
+// fake routes detail requests by the id in the /careers/{id} path and records the RSC header so
+// a test can assert it was sent.
+type topcoHTTP struct {
+	listBody   string            // careers page HTML (with __next_f flight)
+	details    map[string]string // detail flight text keyed by posting id
+	listErr    bool
+	detailErr  map[string]bool
+	gotHeaders map[string]string
+	gotDetails []string
+}
+
+var topcoDetailRE = regexp.MustCompile(`/careers/(\w+)`)
+
+func (f *topcoHTTP) GetHTML(_ context.Context, _ string) (*html.Node, error) {
+	if f.listErr {
+		return nil, errors.New("topcoHTTP: list boom")
+	}
+	return html.Parse(strings.NewReader(f.listBody))
+}
+
+func (f *topcoHTTP) GetTextWithHeaders(_ context.Context, url string, headers map[string]string) (string, error) {
+	f.gotHeaders = headers
+	id := ""
+	if m := topcoDetailRE.FindStringSubmatch(url); m != nil {
+		id = m[1]
+	}
+	f.gotDetails = append(f.gotDetails, id)
+	if f.detailErr[id] {
+		return "", errors.New("topcoHTTP: detail boom")
+	}
+	return f.details[id], nil
+}
+
+// topcoPage wraps a flight body into the self.__next_f.push([1,"…"]) <script> shape a top.co
+// page server-renders, JSON-string-escaped exactly as Next.js emits it.
+func topcoPage(flightBody string) string {
+	esc, _ := json.Marshal(flightBody)
+	return `<html><body><script>self.__next_f.push([1,` + string(esc) + `])</script></body></html>`
+}
+
+// topcoFlight embeds a vacancies JSON array inside a plausible flight body (surrounded by other
+// RSC content, so bracketSlice must isolate the array).
+func topcoFlight(vacanciesJSON string) string {
+	return `["$","div",null,{"products":[{"name":"Wallet"}],"vacancies":` + vacanciesJSON + `}],"footer":1`
+}
+
+func TestTopcoProvider(t *testing.T) {
+	if got := NewTopco(nil).Provider(); got != "topco" {
+		t.Errorf("Provider() = %q, want %q", got, "topco")
+	}
+}
+
+func TestTopcoRegisteredInAllBoardlessAggregator(t *testing.T) {
+	s, ok := All(nil)["topco"]
+	if !ok {
+		t.Fatal(`All(nil)["topco"] missing`)
+	}
+	if _, isBoardless := s.(boardless); !isBoardless {
+		t.Error("topco should be boardless (one careers page, no board id)")
+	}
+	if _, isAggregator := s.(aggregator); !isAggregator {
+		t.Error("topco should be an aggregator (many portfolio companies)")
+	}
+	if !slices.Contains(FilterableProviders(), "topco") {
+		t.Error("FilterableProviders() should include the topco aggregator")
+	}
+}
+
+func TestTopcoNoFlightIsError(t *testing.T) {
+	fake := &topcoHTTP{listBody: `<html><body>no flight</body></html>`}
+	if _, err := NewTopco(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("want error when the page carries no flight payload")
+	}
+}
+
+func TestTopcoNoVacanciesIsError(t *testing.T) {
+	fake := &topcoHTTP{listBody: topcoPage(`["$","div",null,{"children":"nothing"}]`)}
+	if _, err := NewTopco(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("want error when the flight has no vacancies array")
+	}
+}
+
+func TestTopcoMapsVacancy(t *testing.T) {
+	vacancies := `[{"id":"45804","position":"Chief Technology Officer / CTO","location":null,
+		"level":"Head","jobFunction":"Software Engineering","company":{"name":"Mira"},
+		"body":"$undefined","requirements":"$undefined","conditions":"$undefined"}]`
+	fake := &topcoHTTP{
+		listBody: topcoPage(topcoFlight(vacancies)),
+		details: map[string]string{
+			"45804": `2:["$","main",null,{"position":"Chief Technology Officer / CTO",` +
+				`"body":"<p>Lead the team.</p><script>x()</script>",` +
+				`"requirements":"<ul><li>5+ years.</li></ul>",` +
+				`"conditions":"<ul><li>Equity.</li></ul>"}]`,
+		},
+	}
+
+	jobs, err := NewTopco(fake).Fetch(context.Background(), CompanyEntry{Company: "Fallback"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "45804" {
+		t.Errorf("ExternalID = %q, want 45804", j.ExternalID)
+	}
+	if want := "https://top.co/careers/45804"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.Title != "Chief Technology Officer / CTO" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	// The board lists many portfolio companies, so the employer comes from the posting.
+	if j.Company != "Mira" {
+		t.Errorf("Company = %q, want Mira (per-posting, not the entry fallback)", j.Company)
+	}
+	// The full body is fetched from the RSC detail endpoint and sanitized (script stripped).
+	for _, want := range []string{"Lead the team", "5+ years", "Equity"} {
+		if !strings.Contains(j.Description, want) {
+			t.Errorf("Description missing %q: %q", want, j.Description)
+		}
+	}
+	if strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	// The detail endpoint must be reached with the RSC header, else it returns HTML not flight.
+	if f := fake; f.gotHeaders["RSC"] != "1" {
+		t.Errorf("detail RSC header = %q, want 1", f.gotHeaders["RSC"])
+	}
+}
+
+func TestTopcoSkipsEmptyID(t *testing.T) {
+	vacancies := `[
+		{"id":"1","position":"Real","company":{"name":"Co"}},
+		{"id":"","position":"No ID","company":{"name":"Co"}}
+	]`
+	fake := &topcoHTTP{
+		listBody: topcoPage(topcoFlight(vacancies)),
+		details:  map[string]string{"1": `{"body":"<p>b</p>"}`},
+	}
+	jobs, err := NewTopco(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "1" {
+		t.Fatalf("got %v, want only the id-bearing vacancy", jobs)
+	}
+}
+
+func TestTopcoKeepsJobWhenDetailFails(t *testing.T) {
+	// A failed detail fetch must not drop the posting — it is kept with an empty description
+	// rather than lost.
+	vacancies := `[{"id":"7","position":"Backend Engineer","company":{"name":"Tribute"}}]`
+	fake := &topcoHTTP{
+		listBody:  topcoPage(topcoFlight(vacancies)),
+		detailErr: map[string]bool{"7": true},
+	}
+	jobs, err := NewTopco(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "7" {
+		t.Fatalf("got %v, want the posting kept despite detail failure", jobs)
+	}
+	if jobs[0].Description != "" {
+		t.Errorf("Description = %q, want empty on detail failure", jobs[0].Description)
+	}
+}
+
+func TestTopcoIgnoresUndefinedBody(t *testing.T) {
+	// A detail whose fields are still the RSC "$undefined" placeholder yields no description
+	// rather than the literal placeholder text.
+	vacancies := `[{"id":"3","position":"Role","company":{"name":"Co"}}]`
+	fake := &topcoHTTP{
+		listBody: topcoPage(topcoFlight(vacancies)),
+		details:  map[string]string{"3": `{"body":"$undefined","requirements":"$undefined"}`},
+	}
+	jobs, err := NewTopco(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if jobs[0].Description != "" {
+		t.Errorf("Description = %q, want empty (placeholder ignored)", jobs[0].Description)
+	}
+}

--- a/sources/teamex.yml
+++ b/sources/teamex.yml
@@ -1,0 +1,5 @@
+# teamex.io global talent marketplace. Boardless: one global public feed
+# (api.teamex.io/api/jts/global/filter), so the entry carries no board, and each job's
+# company comes from the posting (or a marketplace fallback when anonymized), not this placeholder.
+- company: TeamEx
+  provider: teamex

--- a/sources/topco.yml
+++ b/sources/topco.yml
@@ -1,0 +1,5 @@
+# top.co careers board (TOP / TON / Open Platform ecosystem). Boardless: one careers page
+# (top.co/careers) lists many portfolio companies, so the entry carries no board, and each
+# job's company comes from the posting, not this placeholder.
+- company: TOP
+  provider: topco

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1086,3 +1086,5 @@
   board: kommo
 - company: Emerging Travel Group
   board: emerging-travel-group
+- company: Open
+  board: open-252


### PR DESCRIPTION
## What

Two new boardless multi-company aggregator source adapters plus a workable board entry — all verified live end-to-end against the real APIs.

### teamex (`teamex.io` global talent marketplace)
- Keyless paged **POST** list `/api/jts/global/filter?pageSize=50&pageIndex=N` (body `{}`); list items already carry the full posting (descriptions, countries, skills), so **no per-detail fetch**.
- Anonymized postings (`isAnonymous`) fall back to the marketplace label **so the employer never leaks** even if the payload still carries the name.
- Skills canonicalized via `skilltag`; `isActive:false` skipped. URL `teamex.io/job/{sequenceId}`.

### topco (`top.co`, TON / Open Platform ecosystem board)
- Next.js App Router. Careers page RSC flight lists vacancies (`id`/`position`/`company`); ~10 postings across portfolio companies (Mira, Wallet, Tribute).
- Full body lives on the per-posting **RSC data endpoint** reached with the `RSC: 1` header — added a small `GetTextWithHeaders` transport primitive (mirrors the existing `GetJSONWithHeaders`). New `jsonStringField` helper extracts the body/requirements/conditions out of the raw flight; `$`-prefixed RSC placeholders are ignored.
- A failed detail fetch keeps the posting (empty description) rather than dropping it.

### workable
- Added board entry `open-252` (company **Open**) — its widget API is live.

`apptechmobile.com` was intentionally **not** added — it is an agency "hire our developers" landing page, not a vacancy source.

## Testing
- TDD: RED→GREEN per adapter; unit tests with captured JSON/RSC fixtures (incl. anonymized-employer leak guard, pagination stop, empty-id skip, detail-failure fallback, `$undefined` placeholder guard).
- Live end-to-end run: teamex 7 jobs, topco 10 jobs (full bodies via RSC), workable/open-252 7 jobs — all mapped correctly.
- `go build ./...` · `go vet` · `gofmt` · full `internal/sources` suite green.
- High-effort code review pass applied (honor `isAnonymous`; reuse `joinNonEmpty`).

## Notes / seams
- topco `jsonStringField` uses first-occurrence matching on the single-vacancy detail flight — live-verified correct; documented low-risk seam.
- Follow-up (not in scope): scheduling cron entries for the two new board files.