### PR TITLE
fix(cv-recommendations): CV embedding failed (template needs title/company) + background embed

### DIFF
--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -108,7 +108,10 @@ func (a *API) PutResume(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	a.embedResume(c.Context(), userID, up.Text)
+	// Embed in the background: it must not block the upload response. Embedding is a
+	// Meilisearch round-trip that is seconds normally but MINUTES while a full semantic
+	// rebuild is monopolizing the engine — long enough to time out the proxy/upload.
+	go a.embedResume(userID, up.Text)
 	return c.JSON(fiber.Map{"data": newResumeMeta(true, meta)})
 }
 
@@ -116,11 +119,14 @@ func (a *API) PutResume(c *fiber.Ctx) error {
 // as jobs (so it shares their vector space), best-effort: any failure — no search
 // backend, embed error, or persist error — is logged and swallowed so it never breaks
 // the upload. On an embed failure the prior vector is cleared so the new CV is never
-// matched by a stale one. The scratch id is the user id.
-func (a *API) embedResume(ctx context.Context, userID int64, text string) {
+// matched by a stale one. The scratch id is the user id. It runs on its own timeout
+// context (not the request's, which is already gone once the upload responded).
+func (a *API) embedResume(userID int64, text string) {
 	if a.search == nil {
 		return
 	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 	vec, model, err := a.search.EmbedText(ctx, strconv.FormatInt(userID, 10), text)
 	if err != nil {
 		log.Printf("resume embed: user %d: %v", userID, err)

--- a/internal/handler/resume_embedding_test.go
+++ b/internal/handler/resume_embedding_test.go
@@ -3,40 +3,20 @@ package handler
 import (
 	"errors"
 	"testing"
-	"time"
 
-	"github.com/gofiber/fiber/v2"
-
-	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/resume"
 )
 
-// resumeEmbedApp wires PutResume with both a résumé store and a searcher, so the
-// upload's best-effort CV-embedding hook is exercised.
-func resumeEmbedApp(t *testing.T, store *resume.Store, s searcher) (*fiber.App, string) {
-	t.Helper()
-	iss := auth.NewIssuer("test-secret", time.Hour)
-	token, err := iss.Issue(1)
-	if err != nil {
-		t.Fatalf("issue token: %v", err)
-	}
-	h := &API{issuer: iss, resume: store, search: s}
-	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	app.Put("/me/resume", auth.RequireAuth(iss), h.PutResume)
-	return app, token
-}
-
-// A CV upload embeds the CV text through the searcher and persists the resulting
-// vector plus the embedder identity.
-func TestPutResume_EmbedsAndPersistsVector(t *testing.T) {
+// embedResume is called (backgrounded) from PutResume; tested directly so the
+// assertion is synchronous. A successful embed persists the vector + embedder model.
+func TestEmbedResume_PersistsVector(t *testing.T) {
 	repo := &fakeResumeRepo{}
 	store := resume.New(newFakeResumeBlobs(), repo)
 	fs := &fakeSearcher{embedVec: []float64{0.1, 0.2, 0.3}, embedModel: "test-embedder"}
-	app, token := resumeEmbedApp(t, store, fs)
+	h := &API{resume: store, search: fs}
 
-	if status, _ := resumeReq(t, app, fiber.MethodPut, `{"text":"Go and PostgreSQL and Kubernetes"}`, token); status != fiber.StatusOK {
-		t.Fatalf("upload status = %d, want 200", status)
-	}
+	h.embedResume(1, "Go and PostgreSQL and Kubernetes")
+
 	if fs.gotEmbedText == "" {
 		t.Error("CV text was not sent to the embedder")
 	}
@@ -45,18 +25,27 @@ func TestPutResume_EmbedsAndPersistsVector(t *testing.T) {
 	}
 }
 
-// An embedder failure must not fail the upload, and it clears any prior vector so the
-// new CV is never matched by a stale one.
-func TestPutResume_EmbedFailureClearsVector(t *testing.T) {
+// An embedder failure clears any prior vector so the new CV is never matched by a stale
+// one (and never surfaces to the user — it is best-effort, logged).
+func TestEmbedResume_FailureClearsVector(t *testing.T) {
 	repo := &fakeResumeRepo{embVec: []float64{9, 9}, embModel: "stale-model"}
 	store := resume.New(newFakeResumeBlobs(), repo)
 	fs := &fakeSearcher{embedErr: errors.New("embedder down")}
-	app, token := resumeEmbedApp(t, store, fs)
+	h := &API{resume: store, search: fs}
 
-	if status, _ := resumeReq(t, app, fiber.MethodPut, `{"text":"resume text"}`, token); status != fiber.StatusOK {
-		t.Fatalf("upload status = %d, want 200 despite embed failure", status)
-	}
+	h.embedResume(1, "resume text")
+
 	if repo.embVec != nil || repo.embModel != "" {
 		t.Errorf("stale vector not cleared: (%v, %q)", repo.embVec, repo.embModel)
+	}
+}
+
+// No search backend → embedResume is a no-op (never panics, persists nothing).
+func TestEmbedResume_NoSearchBackend(t *testing.T) {
+	repo := &fakeResumeRepo{}
+	h := &API{resume: resume.New(newFakeResumeBlobs(), repo), search: nil}
+	h.embedResume(1, "text") // must not panic
+	if repo.embModel != "" || repo.embVec != nil {
+		t.Error("no-op embedResume must not persist anything")
 	}
 }

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -475,7 +475,13 @@ func (c *Client) EmbedText(ctx context.Context, key, text string) ([]float64, st
 		return nil, "", err
 	}
 	pk := primaryKey
-	doc := map[string]any{primaryKey: key, "description": text}
+	// The CV goes in the same `description` field the jobs document template reads, so
+	// the embedding pipeline — and thus the vector space — is identical to the jobs'.
+	// title/company must be present too: the shared template references them and
+	// Meilisearch's Liquid is STRICT — a missing referenced field fails the document
+	// (`invalid_document_fields`), not renders empty. Empty strings render as a job with
+	// no title/company would, keeping the space identical.
+	doc := map[string]any{primaryKey: key, "title": "", "company": "", "description": text}
 	task, err := idx.UpdateDocumentsWithContext(ctx, []map[string]any{doc}, &meilisearch.DocumentOptions{PrimaryKey: &pk})
 	if err != nil {
 		return nil, "", fmt.Errorf("search: embed upsert: %w", err)


### PR DESCRIPTION
## Root cause (reproduced on prod Meili)

`/my/recommendations` was always empty because **every CV embedding failed**. `EmbedText`'s scratch doc was \`{id, description}\`, but the shared jobs embedder \`documentTemplate\` is \`{{ doc.title }} at {{ doc.company }}. {{ doc.description }}\` — and Meilisearch's Liquid is **strict**: a referenced-but-missing field fails the document with \`invalid_document_fields\` ("Unknown index: title"), it does NOT render empty (my original assumption). So no vector was ever produced → `resume_embedding` stayed NULL → empty feed.

Reproduced directly against prod Meili: \`{id, description}\` → task fails; \`{id, title:"", company:"", description}\` → task succeeds, **384-dim vector**.

## Fix

- Include empty \`title\`/\`company\` in the scratch doc — renders exactly as a title/company-less job would, so the CV stays in the **same vector space** as jobs.
- Run the embed in a **background goroutine** with its own timeout context (not the request's). Embedding is a Meili round-trip that is seconds normally but **minutes while a full semantic rebuild monopolizes the engine** — long enough to time out the upload/proxy. The upload now returns immediately.

## Test plan

- `go test ./...` green (embedResume tested directly now that it's backgrounded; `decodeEmbedding` unchanged).
- Verified the embedding round-trip on prod Meili (see above).
- [ ] After deploy: re-upload a CV → `resume_embedding` populates → `/my/recommendations` returns a ranked feed.

Follow-up to #474.