### PR TITLE
fix(cv-recommendations): embed CV on /me/resume/extract (the path the app uses)

### DIFF
--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -63,6 +63,10 @@ func (a *API) ExtractResumeSkills(c *fiber.Ctx) error {
 		if _, err := a.resume.Put(c.Context(), userID, up.ContentType, up.Data); err != nil {
 			// Best-effort: log (never the résumé bytes) and still return the skills.
 			log.Printf("resume: store on extract failed for user %d: %v", userID, err)
+		} else {
+			// This is the résumé-upload path the app actually uses, so it is where the CV
+			// gets embedded for /my/recommendations (background, best-effort — see embedResume).
+			go a.embedResume(userID, up.Text)
 		}
 	}
 	return c.JSON(fiber.Map{"data": fiber.Map{"skills": skills}})


### PR DESCRIPTION
The web CV upload calls `POST /me/resume/extract`, which stores the blob but had no embed hook — the hook lived only in `PutResume` (`PUT /me/resume`), which the frontend never calls. So the CV was never embedded → empty `/my/recommendations` even after re-upload. Trigger `embedResume` (background, best-effort) after the store on the extract path too. Follow-up to #474/#477.