### PR TITLE
fix(cv-recommendations): server-side auth guard on /my/recommendations

### DIFF
--- a/web/src/routes/my/recommendations/+page.server.ts
+++ b/web/src/routes/my/recommendations/+page.server.ts
@@ -1,0 +1,16 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+// /my/recommendations is personal (a per-user CV-ranked feed), so a signed-out
+// visitor has nothing to show — guard it server-side rather than render an empty
+// state, matching /my/jobs. The user is resolved once in the root layout load;
+// reuse it via parent(). Auth is a layout-level dialog (no /login route), so we
+// bounce home with ?auth=required and the TopBar pops the sign-in dialog; ?redirect
+// carries the destination so sign-in returns here.
+export const load: PageServerLoad = async ({ parent, url }) => {
+  const { user } = await parent();
+  if (!user) {
+    const target = url.pathname + url.search;
+    redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
+  }
+};


### PR DESCRIPTION
A signed-out visitor to `/my/recommendations` saw an empty client-rendered page instead of the sign-in bounce every other `/my/*` page does. Adds the same `+page.server.ts` guard as `/my/jobs` (redirect to `/?auth=required&redirect=...` → TopBar pops the sign-in dialog). Follow-up to #474.