### PR TITLE
feat(web): restore Seniority + Specialization alongside Role in one pane

### DIFF
--- a/web/src/lib/components/filters/CategoryPane.svelte
+++ b/web/src/lib/components/filters/CategoryPane.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { ChevronDown, Search } from '@lucide/svelte';
+  import { SvelteSet } from 'svelte/reactivity';
+  import type { FacetStore } from '$lib/facets';
+  import { CATEGORY_GROUPS } from '$lib/filterSections';
+  import FacetHeader from './FacetHeader.svelte';
+  import { pillClass, pillTitle } from '../facets/pill';
+
+  // Specialization pane: category chips grouped into collapsible sections, with a
+  // facet-local search filtering the visible options. In the job filter it toggles
+  // the excludable `category` facet (each chip cycles off → include → exclude → off);
+  // `plain` makes it an include-only choice (e.g. a profile category is not a filter
+  // to exclude).
+  let { store, plain = false }: { store: FacetStore; plain?: boolean } = $props();
+
+  const excludable = $derived(!plain);
+  let query = $state('');
+  const collapsed = new SvelteSet<string>();
+  const st = $derived(store.facet('category'));
+  const onToggle = (v: string) => (excludable ? store.cycle('category', v) : store.pick('category', v));
+
+  const groups = $derived.by(() => {
+    const q = query.trim().toLowerCase();
+    return CATEGORY_GROUPS.map((g) => ({
+      ...g,
+      options: q ? g.options.filter((o) => o.label.toLowerCase().includes(q)) : g.options,
+    })).filter((g) => g.options.length > 0);
+  });
+</script>
+
+<FacetHeader {store} param="category" label="Specialization" />
+
+<div class="mb-4 flex items-center gap-2 rounded-lg border border-input px-3">
+  <Search class="size-4 shrink-0 text-muted-foreground" />
+  <input
+    bind:value={query}
+    placeholder="Search specializations…"
+    class="h-9 w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+  />
+</div>
+
+{#each groups as g (g.name)}
+  {@const isCollapsed = collapsed.has(g.name) && !query}
+  <div class="border-t border-border first:border-t-0">
+    <button
+      type="button"
+      class="flex w-full items-center gap-2 py-3"
+      onclick={() => (collapsed.has(g.name) ? collapsed.delete(g.name) : collapsed.add(g.name))}
+    >
+      <ChevronDown class={['size-4 text-muted-foreground transition-transform', isCollapsed && '-rotate-90']} />
+      <h3 class="text-sm font-semibold tracking-tight">{g.name}</h3>
+    </button>
+    {#if !isCollapsed}
+      <div class="flex flex-wrap gap-2 pb-3">
+        {#each g.options as o (o.value)}
+          {@const excluded = st.exclude.includes(o.value)}
+          {@const included = st.include.includes(o.value)}
+          <button
+            type="button"
+            onclick={() => onToggle(o.value)}
+            title={pillTitle(included, excluded, excludable)}
+            class={pillClass(included || excluded, excluded, 'px-3 py-1.5 text-sm')}
+          >
+            {o.label}
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/each}

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -11,6 +11,7 @@
   import { FRESHNESS_PRESETS, SALARY_MAX, SALARY_STEP, freshnessLabel } from '$lib/filterControls';
   import FacetSection from '../facets/FacetSection.svelte';
   import ChipFacet from './ChipFacet.svelte';
+  import CategoryPane from './CategoryPane.svelte';
   import LocationPane from './LocationPane.svelte';
   import FilterModalShell from './FilterModalShell.svelte';
   import SavedSearches from '../SavedSearches.svelte';
@@ -104,6 +105,7 @@
 
   function entryCount(e: RailEntry): number {
     const f = staged.value;
+    if (e.kind === 'category') return selCount(f, 'role') + selCount(f, 'category') + selCount(f, 'seniority');
     if (e.kind === 'location') return selCount(f, 'regions') + selCount(f, 'countries') + selCount(f, 'cities');
     if (e.kind === 'salary') return selCount(f, 'salary_currency') + (f.salaryMin != null ? 1 : 0);
     if (e.kind === 'work') return selCount(f, 'work_mode') + selCount(f, 'employment_type');
@@ -189,6 +191,17 @@
 {#snippet pane(entry: RailEntry)}
   {#if entry.kind === 'saved'}
     <SavedSearches store={staged} />
+  {:else if entry.kind === 'category'}
+    {@const roleDef = facetDefFor('role')}
+    {#if roleDef && !exclude.includes('role')}
+      <div class="mb-6"><FacetSection def={roleDef} store={staged} {counts} expand /></div>
+    {/if}
+    {#if !exclude.includes('seniority')}
+      <ChipFacet store={staged} param="seniority" label="Seniority" />
+      <div class="mt-6"><CategoryPane store={staged} {plain} /></div>
+    {:else}
+      <CategoryPane store={staged} {plain} />
+    {/if}
   {:else if entry.kind === 'location'}
     <LocationPane store={staged} {counts} />
   {:else if entry.kind === 'facet'}

--- a/web/src/lib/filterSections.ts
+++ b/web/src/lib/filterSections.ts
@@ -113,12 +113,12 @@ export interface RailEntry {
 }
 
 export const RAIL: RailEntry[] = [
-  // The role picker replaces the standalone Seniority and Specialization controls:
-  // its values are seniority-only, bare-category (= specialization), composite
-  // (seniority × specialization), and named roles — one control for "what role".
-  // The seniority/category facets still exist for backward-compatible URLs/saved
-  // searches; they just have no dedicated pane anymore.
-  { key: 'role', label: 'Role', section: 'ROLE', kind: 'facet', facetParam: 'role' },
+  // One "Role" pane holds the whole "what role" concept: the role picker
+  // (natural/named/composite roles), the seniority pills, and the specialization
+  // chips — three controls, one tab. They overlap by design (role=senior is also
+  // reachable via the seniority pill); the picker is the natural-language entry,
+  // the pills/chips the browse-by-axis entry.
+  { key: 'category', label: 'Role', section: 'ROLE', kind: 'category' },
   { key: 'location', label: 'Location', section: 'ROLE', kind: 'location' },
   { key: 'work', label: 'Work & employment', section: 'ROLE', kind: 'work' },
   { key: 'skills', label: 'Skills', section: 'ROLE', kind: 'facet', facetParam: 'skills' },


### PR DESCRIPTION
Reverses the role-only replacement (#480) per feedback: grade × function are orthogonal axes that read better as dedicated **Seniority pills** + grouped **Specialization chips** than buried among the role picker's hundreds of graded variants.

The single **"Role" rail tab** now holds all three controls in one pane:
1. **Role** picker on top — natural-language / named / composite roles (typeahead, top-24 + "type to search" cap, typo-tolerant fuzzy).
2. **Seniority** pills (Intern … C-Level).
3. **Specialization** chips (grouped by department).

They overlap by design (`role=senior` is also reachable via the Seniority pill) — accepted for flexibility. Restores `CategoryPane` (deleted in the role-only pass).

Verified: svelte-check 0, vitest 45/45, combined pane confirmed via screenshot.
Frontend-only; deploys via `release.sh`.