### PR TITLE
fix(search): raise maxValuesPerFacet to 1200 for the ~800 role values

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -67,9 +67,13 @@ const (
 	maxTotalHits = 10000000
 
 	// maxValuesPerFacet raises the per-facet value cap above Meili's default of
-	// 100 so the analytics facet distribution is not truncated for
-	// high-cardinality facets (skills, countries).
-	maxValuesPerFacet = 300
+	// 100 so the analytics facet distribution is not truncated for high-cardinality
+	// facets (skills, countries, and especially roles — ~800 graded/named values).
+	// Meili truncates to this cap ALPHABETICALLY (sortFacetValuesBy defaults to
+	// "alpha") BEFORE the client sorts by count, so a cap below the value count
+	// silently drops the busiest values past the alphabetical cut (e.g. "senior_*"
+	// roles). Keep it comfortably above the role catalogue.
+	maxValuesPerFacet = 1200
 
 	taskPollInterval = 50 * time.Millisecond
 )


### PR DESCRIPTION
The role facet has ~800 graded/named values but Meili capped the facet distribution at 300 and truncates **alphabetically** (before the client sorts by count), so the busiest roles past the alphabetical cut (all `senior_*`, `staff_*`, `software_engineer`, …) vanished from the picker — the filter worked, but they weren't selectable. Bump the cap above the role catalogue.

Verified locally: build/vet/test green. (CI backend is red on an unrelated in-progress semantic-embedder migration in #484 — this diff only touches the facet cap const.)