### PR TITLE
feat(web): show live match counts on Seniority pills and Specialization chips

### DIFF
--- a/web/src/lib/components/facets/PillGroup.svelte
+++ b/web/src/lib/components/facets/PillGroup.svelte
@@ -45,7 +45,7 @@
       title={pillTitle(included, excluded, excludable)}
       class={pillClass(included || excluded, excluded, 'px-3 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50')}
     >
-      {opt.label}
+      {opt.label}{#if opt.count !== undefined}<span class="ml-1 opacity-60 tabular-nums">{opt.count.toLocaleString()}</span>{/if}
     </button>
   {/each}
 </div>

--- a/web/src/lib/components/filters/CategoryPane.svelte
+++ b/web/src/lib/components/filters/CategoryPane.svelte
@@ -2,6 +2,7 @@
   import { ChevronDown, Search } from '@lucide/svelte';
   import { SvelteSet } from 'svelte/reactivity';
   import type { FacetStore } from '$lib/facets';
+  import type { FacetCounts } from '$lib/types';
   import { CATEGORY_GROUPS } from '$lib/filterSections';
   import FacetHeader from './FacetHeader.svelte';
   import { pillClass, pillTitle } from '../facets/pill';
@@ -10,8 +11,10 @@
   // facet-local search filtering the visible options. In the job filter it toggles
   // the excludable `category` facet (each chip cycles off → include → exclude → off);
   // `plain` makes it an include-only choice (e.g. a profile category is not a filter
-  // to exclude).
-  let { store, plain = false }: { store: FacetStore; plain?: boolean } = $props();
+  // to exclude). When `counts` is passed, each chip shows its live match count.
+  let { store, plain = false, counts = null }: { store: FacetStore; plain?: boolean; counts?: FacetCounts | null } = $props();
+
+  const dist = $derived(counts?.facets?.category ?? null);
 
   const excludable = $derived(!plain);
   let query = $state('');
@@ -61,7 +64,7 @@
             title={pillTitle(included, excluded, excludable)}
             class={pillClass(included || excluded, excluded, 'px-3 py-1.5 text-sm')}
           >
-            {o.label}
+            {o.label}{#if dist}<span class="ml-1 opacity-60 tabular-nums">{(dist[o.value] ?? 0).toLocaleString()}</span>{/if}
           </button>
         {/each}
       </div>

--- a/web/src/lib/components/filters/ChipFacet.svelte
+++ b/web/src/lib/components/filters/ChipFacet.svelte
@@ -1,19 +1,27 @@
 <script lang="ts">
   import { FACETS, type FacetStore } from '$lib/facets';
+  import type { FacetCounts } from '$lib/types';
   import FacetHeader from './FacetHeader.svelte';
   import PillGroup from '../facets/PillGroup.svelte';
 
   // One chip facet inside a modal pane: a FacetHeader (label + Clear) over a
   // PillGroup — the same per-facet controls the sidebar offers. Options and the
   // excludable flag come from the registry (by `param`), so a caller only names the
-  // facet. Excludable facets cycle each pill off → include → exclude → off.
-  let { store, param, label }: { store: FacetStore; param: string; label: string } = $props();
+  // facet. Excludable facets cycle each pill off → include → exclude → off. When
+  // `counts` is passed, each pill shows its live match count under the current scope.
+  let { store, param, label, counts = null }: { store: FacetStore; param: string; label: string; counts?: FacetCounts | null } = $props();
 
   const def = FACETS.find((d) => d.param === param);
-  const options = def?.options ?? [];
   const excludable = def?.excludable ?? false;
   const st = $derived(store.facet(param));
   const onToggle = (v: string) => (excludable ? store.cycle(param, v) : store.pick(param, v));
+
+  // Merge the live distribution counts into the static registry options.
+  const options = $derived.by(() => {
+    const dist = counts?.facets?.[param];
+    const base = def?.options ?? [];
+    return dist ? base.map((o) => ({ ...o, count: dist[o.value] ?? 0 })) : base;
+  });
 </script>
 
 <div>

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -197,10 +197,10 @@
       <div class="mb-6"><FacetSection def={roleDef} store={staged} {counts} expand /></div>
     {/if}
     {#if !exclude.includes('seniority')}
-      <ChipFacet store={staged} param="seniority" label="Seniority" />
-      <div class="mt-6"><CategoryPane store={staged} {plain} /></div>
+      <ChipFacet store={staged} param="seniority" label="Seniority" {counts} />
+      <div class="mt-6"><CategoryPane store={staged} {plain} {counts} /></div>
     {:else}
-      <CategoryPane store={staged} {plain} />
+      <CategoryPane store={staged} {plain} {counts} />
     {/if}
   {:else if entry.kind === 'location'}
     <LocationPane store={staged} {counts} />


### PR DESCRIPTION
The role picker already shows a job count per option; this brings the same live facet-distribution counts to the **Seniority** pills and the **Specialization** chips, so all three controls in the Role pane read consistently.

- `PillGroup` renders `opt.count` when present; `ChipFacet` merges `counts.facets[param]` into its options; `CategoryPane` renders `counts.facets.category` per chip.
- Counts respect the current filter scope (recomputed as you filter), same as the role picker.
- Frontend-only; no backend/index change (the seniority/category distributions are already returned by `/jobs/facets`).

Verified: svelte-check 0, vitest 45/45, screenshot (Seniority + Specialization show counts).