### PR TITLE
fix(cv-recommendations): embed in Go via TEI, store userProvided vectors

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -1,9 +1,9 @@
 // Package search provides Meilisearch-backed full-text and hybrid (keyword +
 // semantic) search over jobs. It owns the document shape and two index
 // configurations — a facet/keyword index (no embedder, the fast default) and a
-// semantic index that adds the in-engine huggingFace embedder — plus the
-// read/write helpers, so callers (the search handler and the reindex command)
-// never touch the meilisearch-go SDK directly.
+// semantic index with a userProvided embedder whose vectors this package computes
+// against TEI (see embed.go) — plus the read/write helpers, so callers (the search
+// handler and the reindex command) never touch the meilisearch-go SDK directly.
 package search
 
 import (
@@ -50,13 +50,6 @@ const (
 	// vectors and the userProvided CV vector matches.
 	embedderDimensions = 768
 
-	// resumeVectorIndexUID is the scratch index EmbedText round-trips a CV through to
-	// obtain a vector in the jobs' space: the in-engine embedder exposes no direct
-	// "embed this text" call, so the text is indexed here (with the SAME embedder as
-	// the semantic index), its vector read back, and the doc deleted. Never a
-	// persistent store of CV text — see EmbedText.
-	resumeVectorIndexUID = "resume_vectors"
-
 	// maxTotalHits caps how high a search counts its results: below it,
 	// estimatedTotalHits is the true filtered total, so it is set well above the
 	// index size to keep the reported count honest. It is NOT the pagination guard
@@ -88,13 +81,16 @@ type Client struct {
 	semantic meilisearch.IndexManager
 	url      string
 	key      string
+	// embedURL is the TEI /v1/embeddings endpoint this client embeds against (jobs
+	// and CVs alike). It defaults to embedderURL; tests point it at a stub server.
+	embedURL string
 }
 
 // NewClient connects to Meilisearch at url authenticated by key. It does no I/O
 // — the connection is exercised lazily by the first request (or EnsureIndex).
 func NewClient(url, key string) *Client {
 	m := meilisearch.New(url, meilisearch.WithAPIKey(key))
-	return &Client{manager: m, facet: m.Index(facetIndexUID), semantic: m.Index(semanticIndexUID), url: url, key: key}
+	return &Client{manager: m, facet: m.Index(facetIndexUID), semantic: m.Index(semanticIndexUID), url: url, key: key, embedURL: embedderURL}
 }
 
 // EnsureIndex creates the facet/keyword jobs index (no embedder) and applies its
@@ -116,9 +112,9 @@ func (c *Client) EnsureIndex(ctx context.Context) error {
 	return c.awaitTask(ctx, c.facet, task.TaskUID)
 }
 
-// EnsureSemanticIndex creates the hybrid jobs index (with the in-engine embedder)
-// and applies its settings. It is built by the separate reindex --semantic pass;
-// querying it embeds documents, so it is kept off the default reindex path.
+// EnsureSemanticIndex creates the hybrid jobs index (with the userProvided embedder)
+// and applies its settings. It is built by the separate reindex --semantic pass, which
+// computes the vectors against TEI, so it is kept off the default reindex path.
 func (c *Client) EnsureSemanticIndex(ctx context.Context) error {
 	return c.ensure(ctx, c.semantic, semanticIndexUID, semanticSettings())
 }
@@ -136,8 +132,11 @@ type Rebuild struct {
 	rebuildUID     string
 	settings       *meilisearch.Settings
 	resetEmbedders bool
-	rebuild        meilisearch.IndexManager
-	tasks          []int64
+	// semantic marks this a hybrid-index rebuild: Push embeds each batch (via TEI) and
+	// attaches the vectors, since the semantic index uses a userProvided embedder.
+	semantic bool
+	rebuild  meilisearch.IndexManager
+	tasks    []int64
 }
 
 // NewFacetRebuild starts a full rebuild of the facet/keyword production index.
@@ -147,7 +146,7 @@ func (c *Client) NewFacetRebuild() *Rebuild {
 
 // NewSemanticRebuild starts a full rebuild of the hybrid semantic index.
 func (c *Client) NewSemanticRebuild() *Rebuild {
-	return &Rebuild{c: c, liveUID: semanticIndexUID, rebuildUID: semanticRebuildUID, settings: semanticSettings()}
+	return &Rebuild{c: c, liveUID: semanticIndexUID, rebuildUID: semanticRebuildUID, settings: semanticSettings(), semantic: true}
 }
 
 // Prepare creates a fresh, empty rebuild index with this pass's settings, ready to
@@ -186,8 +185,19 @@ func (r *Rebuild) Push(ctx context.Context, docs []JobDocument) error {
 	if len(docs) == 0 {
 		return nil
 	}
+	// The semantic index stores userProvided vectors, so a semantic rebuild embeds each
+	// batch (via TEI) and pushes documents carrying their vectors; the facet rebuild
+	// pushes the plain documents.
+	var payload any = docs
+	if r.semantic {
+		sdocs, err := r.c.embedDocs(ctx, docs)
+		if err != nil {
+			return err
+		}
+		payload = sdocs
+	}
 	pk := primaryKey
-	task, err := r.rebuild.UpdateDocumentsWithContext(ctx, docs, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+	task, err := r.rebuild.UpdateDocumentsWithContext(ctx, payload, &meilisearch.DocumentOptions{PrimaryKey: &pk})
 	if err != nil {
 		return fmt.Errorf("search: rebuild push: %w", err)
 	}
@@ -300,10 +310,23 @@ func (c *Client) IndexJobs(ctx context.Context, docs []JobDocument) error {
 	return c.indexInto(ctx, c.facet, docs)
 }
 
-// IndexSemanticJobs upserts a batch into the semantic index (which embeds new or
-// changed documents). Used by the reindex --semantic pass.
+// IndexSemanticJobs embeds a batch (via TEI) and upserts it into the semantic index
+// with each document's vector, since that index uses a userProvided embedder. Used by
+// the incremental reindex --semantic pass.
 func (c *Client) IndexSemanticJobs(ctx context.Context, docs []JobDocument) error {
-	return c.indexInto(ctx, c.semantic, docs)
+	if len(docs) == 0 {
+		return nil
+	}
+	sdocs, err := c.embedDocs(ctx, docs)
+	if err != nil {
+		return err
+	}
+	pk := primaryKey
+	task, err := c.semantic.UpdateDocumentsWithContext(ctx, sdocs, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+	if err != nil {
+		return fmt.Errorf("search: index semantic documents: %w", err)
+	}
+	return c.awaitTask(ctx, c.semantic, task.TaskUID)
 }
 
 func (c *Client) indexInto(ctx context.Context, idx meilisearch.IndexManager, docs []JobDocument) error {
@@ -396,6 +419,14 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 	idx := c.facet
 	if p.SemanticRatio > 0 {
 		idx = c.semantic
+		// The semantic index uses a userProvided embedder, so Meilisearch cannot embed
+		// the query text itself — we embed it here (TEI, "query:" prefix for e5's
+		// asymmetric retrieval) and pass the vector for the semantic half of the blend.
+		qv, err := c.embedBatch(ctx, []string{"query: " + p.Query})
+		if err != nil {
+			return SearchResult{}, err
+		}
+		req.Vector = toFloat32(qv[0])
 		req.Hybrid = &meilisearch.SearchRequestHybrid{
 			Embedder:      embedderName,
 			SemanticRatio: p.SemanticRatio,
@@ -475,97 +506,21 @@ func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDoc
 	return out, nil
 }
 
-// EmbedText embeds text through the SAME embedder that embeds jobs and returns the
-// vector plus the embedder identity that produced it. Meilisearch's in-engine embedder
-// has no "embed this text" endpoint, so the vector is obtained by round-tripping: the
-// text is indexed as one scratch document (in resumeVectorIndexUID, which carries an
-// identical embedder), its vector is read back, and the document is deleted so no
-// source text lingers in the engine. key is a caller-unique scratch id (e.g. the user
-// id) so concurrent callers do not collide. The text goes in the same field the jobs
-// document template reads, so the embedding pipeline — and thus the vector space — is
-// identical to the jobs'.
-func (c *Client) EmbedText(ctx context.Context, key, text string) ([]float64, string, error) {
-	idx := c.manager.Index(resumeVectorIndexUID)
-	if err := c.ensure(ctx, idx, resumeVectorIndexUID, resumeVectorSettings()); err != nil {
+// EmbedText embeds text through the SAME path (TEI, same model) that embeds jobs and
+// returns the vector plus the embedder identity that produced it, so a CV vector is
+// directly comparable to the job corpus. The CV is the query side of e5's asymmetric
+// retrieval, so it carries the "query:" prefix (jobs carry "passage:", see jobPassage).
+// The key parameter is unused now that no scratch document is round-tripped through
+// Meilisearch; it is kept for interface compatibility.
+func (c *Client) EmbedText(ctx context.Context, _, text string) ([]float64, string, error) {
+	vecs, err := c.embedBatch(ctx, []string{"query: " + text})
+	if err != nil {
 		return nil, "", err
 	}
-	pk := primaryKey
-	// The CV goes in the same `description` field the jobs document template reads, so
-	// the embedding pipeline — and thus the vector space — is identical to the jobs'.
-	// title/company must be present too: the shared template references them and
-	// Meilisearch's Liquid is STRICT — a missing referenced field fails the document
-	// (`invalid_document_fields`), not renders empty. Empty strings render as a job with
-	// no title/company would, keeping the space identical.
-	doc := map[string]any{primaryKey: key, "title": "", "company": "", "description": text}
-	task, err := idx.UpdateDocumentsWithContext(ctx, []map[string]any{doc}, &meilisearch.DocumentOptions{PrimaryKey: &pk})
-	if err != nil {
-		return nil, "", fmt.Errorf("search: embed upsert: %w", err)
+	if len(vecs) == 0 || len(vecs[0]) == 0 {
+		return nil, "", fmt.Errorf("search: empty embedding")
 	}
-	if err := c.awaitTask(ctx, idx, task.TaskUID); err != nil {
-		return nil, "", err
-	}
-
-	vec, readErr := c.readDocumentVector(ctx, resumeVectorIndexUID, key)
-	// Always delete the scratch doc, even on read failure, so no CV text persists.
-	if delTask, err := idx.DeleteDocumentWithContext(ctx, key, nil); err == nil {
-		_ = c.awaitTask(ctx, idx, delTask.TaskUID)
-	}
-	if readErr != nil {
-		return nil, "", readErr
-	}
-	return vec, embedderModel, nil
-}
-
-// readDocumentVector fetches one document's embedding via retrieveVectors, using a raw
-// request (the pinned SDK's typed document fetch does not surface _vectors).
-func (c *Client) readDocumentVector(ctx context.Context, uid, key string) ([]float64, error) {
-	u := fmt.Sprintf("%s/indexes/%s/documents/%s?retrieveVectors=true", c.url, uid, key)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-	if err != nil {
-		return nil, fmt.Errorf("search: vector request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+c.key)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("search: read vector: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("search: read vector: unexpected status %d", resp.StatusCode)
-	}
-	var doc struct {
-		Vectors map[string]json.RawMessage `json:"_vectors"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
-		return nil, fmt.Errorf("search: decode vector: %w", err)
-	}
-	raw, ok := doc.Vectors[embedderName]
-	if !ok {
-		return nil, fmt.Errorf("search: document has no %q embedding", embedderName)
-	}
-	return decodeEmbedding(raw)
-}
-
-// decodeEmbedding pulls a single vector out of a Meili _vectors.<name> payload,
-// tolerating both the object form ({"embeddings": ..., "regenerate": ...}) and a bare
-// array, and both an array-of-vectors and a single vector.
-func decodeEmbedding(raw json.RawMessage) ([]float64, error) {
-	payload := raw
-	var obj struct {
-		Embeddings json.RawMessage `json:"embeddings"`
-	}
-	if err := json.Unmarshal(raw, &obj); err == nil && len(obj.Embeddings) > 0 {
-		payload = obj.Embeddings
-	}
-	var multi [][]float64
-	if err := json.Unmarshal(payload, &multi); err == nil && len(multi) > 0 {
-		return multi[0], nil
-	}
-	var single []float64
-	if err := json.Unmarshal(payload, &single); err == nil && len(single) > 0 {
-		return single, nil
-	}
-	return nil, fmt.Errorf("search: empty embedding")
+	return vecs[0], embedderModel, nil
 }
 
 // RecommendByVector ranks open jobs in the semantic index by similarity to a raw
@@ -690,42 +645,26 @@ func facetSettings() *meilisearch.Settings {
 }
 
 // semanticSettings is the hybrid index configuration: the facet/keyword settings plus
-// the embedder. Meilisearch embeds each new or changed document at index time (and
-// skips unchanged ones), so this index is built by the separate reindex --semantic
-// pass and never on the default reindex path. Embedding is offloaded to TEI (see
-// jobEmbedder) rather than run in-engine, so it never blocks Meilisearch's task queue.
+// the userProvided embedder (see jobEmbedder). Vectors are computed in Go against TEI
+// and pushed with each document, so this index is built by the separate reindex
+// --semantic pass and never on the default reindex path, and embedding never touches
+// Meilisearch's task queue.
 func semanticSettings() *meilisearch.Settings {
 	s := facetSettings()
 	s.Embedders = map[string]meilisearch.Embedder{embedderName: jobEmbedder()}
 	return s
 }
 
-// jobEmbedder is the shared TEI embedder for jobs, reached over TEI's OpenAI-compatible
-// /v1/embeddings. It is the `rest` source, NOT `openAi`: Meilisearch's openAi source
-// hard-validates the model name against OpenAI's own models and rejects e5, so we drive
-// the same endpoint via rest with explicit request/response templates. The request
-// batches (`{{..}}`) inputs into OpenAI's `input` array; the response pulls each vector
-// from `data[].embedding`. Jobs are the corpus, so their text carries the e5 "passage:"
-// prefix — the CV, the query side, uses "query:" (see resumeVectorSettings). No apiKey:
-// TEI runs without auth.
+// jobEmbedder is the semantic index's embedder. It is `userProvided`: Meilisearch
+// stores and searches the vectors but never computes them. We embed in Go against TEI
+// (see embedBatch/embedDocs) and push each document with its vector, instead of the
+// `rest` source that has Meili call TEI itself — the engine rejects the loopback TEI
+// URI, and owning the embedding keeps jobs and CVs on one identical path (one model,
+// one server → one vector space). Dimensions must match what TEI returns so Meili
+// validates the vectors.
 func jobEmbedder() meilisearch.Embedder {
 	return meilisearch.Embedder{
-		Source:           "rest",
-		URL:              embedderURL,
-		Dimensions:       embedderDimensions,
-		DocumentTemplate: "passage: {{ doc.title }} at {{ doc.company }}. {{ doc.description }}",
-		Request:          map[string]interface{}{"input": []interface{}{"{{text}}", "{{..}}"}, "model": embedderModel},
-		Response:         map[string]interface{}{"data": []interface{}{map[string]interface{}{"embedding": "{{embedding}}"}, "{{..}}"}},
+		Source:     "userProvided",
+		Dimensions: embedderDimensions,
 	}
-}
-
-// resumeVectorSettings configures the EmbedText scratch index with the SAME TEI embedder
-// as jobs — same model + endpoint, so the CV vector lands in the jobs' space — but the
-// CV text carries the e5 "query:" prefix: recommendations search the job corpus
-// (passages) with the CV as the query, e5's asymmetric-retrieval convention. No
-// facets/filters: the index holds one transient document at a time and is never searched.
-func resumeVectorSettings() *meilisearch.Settings {
-	e := jobEmbedder()
-	e.DocumentTemplate = "query: {{ doc.description }}"
-	return &meilisearch.Settings{Embedders: map[string]meilisearch.Embedder{embedderName: e}}
 }

--- a/internal/search/embed.go
+++ b/internal/search/embed.go
@@ -1,0 +1,121 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// teiMaxBatch caps how many inputs go in one TEI /v1/embeddings call. TEI rejects a
+// batch above its --max-client-batch-size (default 32); embedBatch chunks larger
+// inputs into sequential calls so callers can hand it a whole reindex batch.
+const teiMaxBatch = 32
+
+// jobPassage renders a job document into the text embedded for semantic retrieval.
+// e5 is asymmetric: the corpus side carries the "passage:" prefix and the query side
+// carries "query:" (see EmbedText), so they must be embedded the same way to be
+// comparable. This mirrors the document template Meilisearch used to render, now that
+// embedding runs in Go (see embedBatch). doc.Description is already capped at index
+// time (maxIndexedDescriptionRunes), so this stays within e5's token window.
+func jobPassage(d JobDocument) string {
+	return "passage: " + d.Title + " at " + d.Company + ". " + d.Description
+}
+
+// embedBatch turns texts into vectors by calling TEI's OpenAI-compatible
+// /v1/embeddings directly, in input order. We embed here and store the result as a
+// userProvided Meilisearch embedder (see jobEmbedder) rather than letting Meili's rest
+// embedder reach TEI itself: the engine rejects the loopback TEI URI, and embedding in
+// one place keeps the job corpus and the CV query on an identical path (one model, one
+// server → one vector space). Inputs are chunked to TEI's per-call batch limit.
+func (c *Client) embedBatch(ctx context.Context, inputs []string) ([][]float64, error) {
+	out := make([][]float64, 0, len(inputs))
+	for start := 0; start < len(inputs); start += teiMaxBatch {
+		end := start + teiMaxBatch
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		vecs, err := c.embedChunk(ctx, inputs[start:end])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+// embedChunk embeds one TEI-sized batch and returns the vectors in input order.
+func (c *Client) embedChunk(ctx context.Context, inputs []string) ([][]float64, error) {
+	body, err := json.Marshal(map[string]any{"input": inputs, "model": embedderModel})
+	if err != nil {
+		return nil, fmt.Errorf("search: embed marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.embedURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("search: embed request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search: embed call: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search: embed: unexpected status %d", resp.StatusCode)
+	}
+	var out struct {
+		Data []struct {
+			Embedding []float64 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("search: embed decode: %w", err)
+	}
+	if len(out.Data) != len(inputs) {
+		return nil, fmt.Errorf("search: embed: got %d vectors for %d inputs", len(out.Data), len(inputs))
+	}
+	vecs := make([][]float64, len(out.Data))
+	for i, d := range out.Data {
+		if len(d.Embedding) == 0 {
+			return nil, fmt.Errorf("search: embed: empty vector at %d", i)
+		}
+		vecs[i] = d.Embedding
+	}
+	return vecs, nil
+}
+
+// semanticDocument is a JobDocument carrying its precomputed embedding for the
+// userProvided embedder. The embedded JobDocument flattens its own fields into the
+// document; _vectors adds the vector Meilisearch stores and searches by.
+type semanticDocument struct {
+	JobDocument
+	Vectors map[string][]float32 `json:"_vectors"`
+}
+
+// embedDocs embeds each job's passage text and wraps it with its vector, ready to push
+// into the semantic index.
+func (c *Client) embedDocs(ctx context.Context, docs []JobDocument) ([]semanticDocument, error) {
+	inputs := make([]string, len(docs))
+	for i, d := range docs {
+		inputs[i] = jobPassage(d)
+	}
+	vecs, err := c.embedBatch(ctx, inputs)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]semanticDocument, len(docs))
+	for i, d := range docs {
+		out[i] = semanticDocument{JobDocument: d, Vectors: map[string][]float32{embedderName: toFloat32(vecs[i])}}
+	}
+	return out, nil
+}
+
+// toFloat32 narrows a float64 vector to the float32 Meilisearch stores.
+func toFloat32(v []float64) []float32 {
+	f := make([]float32, len(v))
+	for i, x := range v {
+		f[i] = float32(x)
+	}
+	return f
+}

--- a/internal/search/embed_test.go
+++ b/internal/search/embed_test.go
@@ -1,44 +1,95 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 )
 
-// decodeEmbedding must pull one vector out of every shape Meilisearch's
-// _vectors.<name> payload takes across versions: the object form with an
-// array-of-vectors, the object form with a single vector, and a bare array — so the
-// CV read-back does not break on a Meili upgrade.
-func TestDecodeEmbedding(t *testing.T) {
-	tests := []struct {
-		name    string
-		raw     string
-		want    []float64
-		wantErr bool
-	}{
-		{"object array-of-vectors", `{"embeddings": [[1, 2, 3]], "regenerate": true}`, []float64{1, 2, 3}, false},
-		{"object single vector", `{"embeddings": [1, 2, 3]}`, []float64{1, 2, 3}, false},
-		{"bare array-of-vectors", `[[0.5, -0.5]]`, []float64{0.5, -0.5}, false},
-		{"object empty embeddings", `{"embeddings": []}`, nil, true},
-		{"empty object", `{}`, nil, true},
+// jobPassage must prefix the corpus side with e5's "passage:" marker and weave in the
+// title/company/description, so it stays comparable to the "query:"-prefixed CV.
+func TestJobPassage(t *testing.T) {
+	var d JobDocument
+	d.Title = "Backend Engineer"
+	d.Company = "Acme"
+	d.Description = "Go and Postgres"
+	got := jobPassage(d)
+	want := "passage: Backend Engineer at Acme. Go and Postgres"
+	if got != want {
+		t.Fatalf("jobPassage = %q, want %q", got, want)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := decodeEmbedding(json.RawMessage(tt.raw))
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantErr {
-				return
-			}
-			if len(got) != len(tt.want) {
-				t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.want), got)
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("got[%d] = %v, want %v", i, got[i], tt.want[i])
-				}
-			}
+}
+
+// teiEcho is a stub TEI /v1/embeddings that returns, for each input, a one-element
+// vector holding the integer the input text parses to — so a test can assert both that
+// every input got its own vector and that order is preserved across chunk boundaries.
+func teiEcho(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		type item struct {
+			Embedding []float64 `json:"embedding"`
+		}
+		out := struct {
+			Data []item `json:"data"`
+		}{}
+		for _, s := range in.Input {
+			n, _ := strconv.Atoi(strings.TrimSpace(s))
+			out.Data = append(out.Data, item{Embedding: []float64{float64(n)}})
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+}
+
+// embedBatch must chunk inputs past TEI's per-call limit and stitch the vectors back in
+// input order — otherwise a reindex batch (2000) would either be rejected by TEI or
+// scramble which vector belongs to which job.
+func TestEmbedBatchChunksAndPreservesOrder(t *testing.T) {
+	srv := teiEcho(t)
+	defer srv.Close()
+	c := &Client{embedURL: srv.URL}
+
+	n := teiMaxBatch*2 + 3 // spans three chunks
+	inputs := make([]string, n)
+	for i := range inputs {
+		inputs[i] = strconv.Itoa(i)
+	}
+	vecs, err := c.embedBatch(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("embedBatch: %v", err)
+	}
+	if len(vecs) != n {
+		t.Fatalf("got %d vectors, want %d", len(vecs), n)
+	}
+	for i, v := range vecs {
+		if len(v) != 1 || v[0] != float64(i) {
+			t.Fatalf("vecs[%d] = %v, want [%d]", i, v, i)
+		}
+	}
+}
+
+// A TEI reply with a different vector count than inputs is corruption we must reject,
+// not silently misalign vectors to jobs.
+func TestEmbedBatchRejectsCountMismatch(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"embedding": []float64{1}}}, // one vector regardless of input count
 		})
+	}))
+	defer srv.Close()
+	c := &Client{embedURL: srv.URL}
+
+	if _, err := c.embedBatch(context.Background(), []string{"a", "b"}); err == nil {
+		t.Fatal("expected an error on vector/input count mismatch, got nil")
 	}
 }

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -6,15 +6,21 @@
 //
 //	go test -tags=integration ./internal/search/
 //
-// Requires Docker (testcontainers spins up a throwaway Meilisearch). The first
-// run is slow: the huggingFace embedder downloads its model at index time.
+// Requires Docker (testcontainers spins up a throwaway Meilisearch). The semantic
+// index uses a userProvided embedder, so no model download happens in-engine; the
+// vectors come from a stub TEI (fakeTEI) the client is pointed at.
 package search
 
 import (
 	"context"
 	"encoding/json"
+	"hash/fnv"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/meilisearch/meilisearch-go"
@@ -24,6 +30,50 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 )
+
+// fakeTEI stands in for the TEI embedding server: an OpenAI-compatible
+// /v1/embeddings that returns a deterministic bag-of-words vector per input, so texts
+// sharing tokens land near each other under cosine similarity. That is enough for the
+// semantic assertions (a query hits jobs whose text it overlaps) without a real model,
+// and keeps the userProvided vector width at embedderDimensions so Meili accepts it.
+func fakeTEI(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		type item struct {
+			Embedding []float64 `json:"embedding"`
+		}
+		var out struct {
+			Data []item `json:"data"`
+		}
+		for _, s := range in.Input {
+			out.Data = append(out.Data, item{Embedding: bagOfWords(s)})
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// bagOfWords hashes each token into a fixed-width count vector — a crude but
+// deterministic embedding whose cosine similarity tracks token overlap.
+func bagOfWords(s string) []float64 {
+	v := make([]float64, embedderDimensions)
+	for _, tok := range strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(tok))
+		v[h.Sum32()%embedderDimensions]++
+	}
+	return v
+}
 
 func startMeili(t *testing.T) *Client {
 	t.Helper()
@@ -52,7 +102,9 @@ func startMeili(t *testing.T) *Client {
 	if err != nil {
 		t.Fatalf("port: %v", err)
 	}
-	return NewClient("http://"+host+":"+port.Port(), key)
+	c := NewClient("http://"+host+":"+port.Port(), key)
+	c.embedURL = fakeTEI(t)
+	return c
 }
 
 func enrichedJSON(t *testing.T, e enrich.Enrichment) []byte {
@@ -485,6 +537,79 @@ func TestIntegration_SimilarJobs(t *testing.T) {
 			t.Errorf("expected no neighbours when the index is absent, got %d", len(hits))
 		}
 	})
+}
+
+// TestIntegration_EmbedTextAndRecommend covers the whole /my/recommendations path
+// end-to-end against a real engine: a CV is embedded (EmbedText, the query side) into
+// the same space as the indexed jobs (the passage side), and RecommendByVector ranks
+// the corpus by that vector. This is the path a unit test cannot reach — the PR that
+// shipped EmbedText broke on exactly this gap — so it must hit real Meili + the stub
+// embedder. A backend-flavoured CV must surface the backend jobs, not the frontend one.
+func TestIntegration_EmbedTextAndRecommend(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	if err := c.EnsureSemanticIndex(ctx); err != nil {
+		t.Fatalf("EnsureSemanticIndex: %v", err)
+	}
+	jobs := []db.Job{
+		{ID: 1, Title: "Senior Golang Backend Engineer", Company: "Acme", Location: "Berlin",
+			Description: "Build distributed backend services and REST APIs in Go.",
+			PublicSlug:  "senior-golang-backend-engineer-acme-aaa",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
+		{ID: 2, Title: "Backend Software Engineer", Company: "Beta", Location: "Remote",
+			Description: "Design server-side backend microservices and REST APIs.",
+			PublicSlug:  "backend-software-engineer-beta-bbb",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
+		{ID: 3, Title: "Frontend React Developer", Company: "Gamma", Location: "Remote",
+			Description: "Build user interfaces with React and TypeScript.",
+			PublicSlug:  "frontend-react-developer-gamma-ccc",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
+	}
+	if err := c.IndexSemanticJobs(ctx, toDocs(t, jobs)); err != nil {
+		t.Fatalf("IndexSemanticJobs: %v", err)
+	}
+
+	vec, model, err := c.EmbedText(ctx, "user-1", "Backend engineer building Go services and REST APIs.")
+	if err != nil {
+		t.Fatalf("EmbedText: %v", err)
+	}
+	if len(vec) != embedderDimensions {
+		t.Fatalf("EmbedText vector width = %d, want %d", len(vec), embedderDimensions)
+	}
+	if model != embedderModel {
+		t.Errorf("EmbedText model = %q, want %q", model, embedderModel)
+	}
+
+	res, err := c.RecommendByVector(ctx, vec, 10, 0)
+	if err != nil {
+		t.Fatalf("RecommendByVector: %v", err)
+	}
+	if len(res.Hits) == 0 {
+		t.Fatal("RecommendByVector returned no hits for a CV that overlaps indexed jobs")
+	}
+	// The backend CV must rank a backend job first, ahead of the React job.
+	if top := res.Hits[0].ID; top != 1 && top != 2 {
+		t.Errorf("top recommendation id = %d, want a backend job (1 or 2); hits=%+v", top, ids(res.Hits))
+	}
+
+	t.Run("empty vector yields empty feed, not an error", func(t *testing.T) {
+		empty, err := c.RecommendByVector(ctx, nil, 10, 0)
+		if err != nil {
+			t.Fatalf("RecommendByVector(nil): %v", err)
+		}
+		if len(empty.Hits) != 0 {
+			t.Errorf("expected empty feed for an empty vector, got %d hits", len(empty.Hits))
+		}
+	})
+}
+
+func ids(docs []JobDocument) []int64 {
+	out := make([]int64, len(docs))
+	for i, d := range docs {
+		out[i] = d.ID
+	}
+	return out
 }
 
 func toDocs(t *testing.T, jobs []db.Job) []JobDocument {


### PR DESCRIPTION
## Problem

The deployed e5/TEI embedder (#482/#484) never actually embedded anything. Meilisearch's `rest` embedder rejects the loopback TEI URI at embed time — every embed task failed with `could not reach embedding server: bad uri: Rejected URI`, and the request never reached TEI (its logs stayed empty). So jobs were never re-embedded on e5 and `/my/recommendations` kept running on the old coarse in-engine MiniLM vectors (the "Ruby tops a non-Ruby CV" symptom).

Root cause is in Meili's opaque `rest` embedder, not our networking (Meili is native, `curl` from the host to TEI works, no proxy in Meili's env). Rather than keep reverse-engineering it, this removes the entire failure class.

## Fix: `userProvided` embedder

The semantic index now uses a **`userProvided`** embedder — Meili stores and searches vectors but never computes them. We embed in Go against TEI (`internal/search/embed.go`) and push each document with its vector. Meili no longer reaches TEI, so `Rejected URI` is impossible by construction, and the job corpus and the CV query share **one** embedding path (one model, one server → one vector space).

- `jobEmbedder` → `userProvided` (no URL/templates); `embedURL` is a `Client` field (tests point it at a stub)
- semantic `Rebuild.Push` and `IndexSemanticJobs` embed each batch (`passage:` prefix), chunked to TEI's batch limit
- `EmbedText` embeds the CV directly (`query:` prefix), dropping the scratch-index round-trip + Meili `_vectors` read-back
- hybrid text `Search` embeds the query in Go too (`query:` prefix) — works under `userProvided` **and** finally applies e5's asymmetric query prefix on the query side
- new integration test drives `EmbedText → RecommendByVector` end-to-end against real Meili + a stub TEI (the exact path the PR #477 bug slipped through); a backend-flavoured CV ranks the backend jobs first

## Verification

- `go build ./... && go vet ./...` clean
- `go test ./...` green
- `go test -tags=integration ./internal/search/` green (real Meili via testcontainers + stub TEI): hybrid search, SimilarJobs, and the new EmbedText→Recommend flow all pass

## Deploy

Deploy, then run a scoped semantic reindex (`reindex --semantic --posted-within …`) so jobs get e5 vectors, then have a user re-upload their CV to get a fresh e5 CV vector. Needs the TEI container up on host2 :8090 (unchanged).