### PR TITLE
feat: live disjunctive facet counts in the filter modal

### DIFF
--- a/internal/handler/facets.go
+++ b/internal/handler/facets.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"net/url"
+	"slices"
 	"sort"
 
 	"github.com/gofiber/fiber/v2"
@@ -69,28 +70,45 @@ func facetAttributes() []string {
 	return attrs
 }
 
+// locationFacetParams are the geography facets that share ONE OR-group in
+// FilterFromValues (their included values widen the results together, not
+// intersect). Disjunctive counting of any one of them must drop the whole group's
+// contribution, not just that param — otherwise selecting a country would zero
+// every sibling region (the reverse of what disjunctive mode is for).
+var locationFacetParams = []string{"regions", "countries", "cities"}
+
 // facetReqs builds one disjunctive request per distribution attribute: each
 // counted under the filter with its own facet's params removed, so a facet's
-// selection doesn't hide its alternatives.
+// selection doesn't hide its alternatives. For a location facet, the whole
+// location OR-group is removed (see locationFacetParams).
 func facetReqs(vals url.Values) []search.FacetReq {
 	param := facetParamByAttr()
 	attrs := facetAttributes()
 	reqs := make([]search.FacetReq, 0, len(attrs))
 	for _, attr := range attrs {
+		drop := []string{param[attr]}
+		if slices.Contains(locationFacetParams, param[attr]) {
+			drop = locationFacetParams
+		}
 		reqs = append(reqs, search.FacetReq{
 			Attr:   attr,
-			Filter: search.FilterFromValues(withoutParam(vals, param[attr])),
+			Filter: search.FilterFromValues(withoutParams(vals, drop)),
 		})
 	}
 	return reqs
 }
 
-// withoutParam returns a copy of vals with a facet's own params dropped (the bare
-// param plus its `_exclude` / `_mode` variants), leaving every other facet intact.
-func withoutParam(vals url.Values, param string) url.Values {
+// withoutParams returns a copy of vals with each named facet's params dropped (the
+// bare param plus its `_exclude` / `_mode` variants), leaving every other facet
+// intact.
+func withoutParams(vals url.Values, params []string) url.Values {
+	drop := make(map[string]bool, len(params)*3)
+	for _, p := range params {
+		drop[p], drop[p+"_exclude"], drop[p+"_mode"] = true, true, true
+	}
 	out := make(url.Values, len(vals))
 	for k, v := range vals {
-		if k == param || k == param+"_exclude" || k == param+"_mode" {
+		if drop[k] {
 			continue
 		}
 		out[k] = v

--- a/internal/handler/facets.go
+++ b/internal/handler/facets.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"net/url"
 	"sort"
 
 	"github.com/gofiber/fiber/v2"
@@ -16,6 +17,9 @@ import (
 // means search is unconfigured and the endpoint reports 503.
 type facetCounter interface {
 	FacetCounts(ctx context.Context, p search.FacetParams) (search.FacetResult, error)
+	// DisjunctiveFacetCounts counts each facet under its own reduced filter (see
+	// the disjunctive mode of JobFacets) plus the total under the full filter.
+	DisjunctiveFacetCounts(ctx context.Context, query string, reqs []search.FacetReq, totalFilter any) (search.FacetResult, error)
 }
 
 // facetExtra describes a facetable attribute that is not a string-equality facet
@@ -65,6 +69,35 @@ func facetAttributes() []string {
 	return attrs
 }
 
+// facetReqs builds one disjunctive request per distribution attribute: each
+// counted under the filter with its own facet's params removed, so a facet's
+// selection doesn't hide its alternatives.
+func facetReqs(vals url.Values) []search.FacetReq {
+	param := facetParamByAttr()
+	attrs := facetAttributes()
+	reqs := make([]search.FacetReq, 0, len(attrs))
+	for _, attr := range attrs {
+		reqs = append(reqs, search.FacetReq{
+			Attr:   attr,
+			Filter: search.FilterFromValues(withoutParam(vals, param[attr])),
+		})
+	}
+	return reqs
+}
+
+// withoutParam returns a copy of vals with a facet's own params dropped (the bare
+// param plus its `_exclude` / `_mode` variants), leaving every other facet intact.
+func withoutParam(vals url.Values, param string) url.Values {
+	out := make(url.Values, len(vals))
+	for k, v := range vals {
+		if k == param || k == param+"_exclude" || k == param+"_mode" {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 // facetParamByAttr inverts the facet vocabulary (index attribute → public query
 // param) so the response is keyed the way clients filter: "enrichment.seniority"
 // is exposed as "seniority", hiding the index's internal dot-path structure.
@@ -88,11 +121,22 @@ func (a *API) JobFacets(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
 	}
 
-	res, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
-		Query:  c.Query("q"),
-		Filter: buildSearchFilter(c),
-		Facets: facetAttributes(),
-	})
+	q := c.Query("q")
+	var res search.FacetResult
+	var err error
+	if c.QueryBool("disjunctive") {
+		// Disjunctive: each facet counted under the full filter minus its own
+		// selection, so a selected facet still shows its siblings (the live-modal
+		// experience). The total stays the full-filter count.
+		vals, _ := url.ParseQuery(string(c.Request().URI().QueryString()))
+		res, err = a.facets.DisjunctiveFacetCounts(c.Context(), q, facetReqs(vals), search.FilterFromValues(vals))
+	} else {
+		res, err = a.facets.FacetCounts(c.Context(), search.FacetParams{
+			Query:  q,
+			Filter: buildSearchFilter(c),
+			Facets: facetAttributes(),
+		})
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/handler/facets_test.go
+++ b/internal/handler/facets_test.go
@@ -91,6 +91,38 @@ func TestJobFacets_DisjunctiveReducesEachFacetsOwnFilter(t *testing.T) {
 	}
 }
 
+func TestJobFacets_DisjunctiveDropsWholeLocationGroup(t *testing.T) {
+	// regions/countries/cities share one OR group, so a location facet's reduced
+	// filter must drop the WHOLE group — else selecting a country zeroes sibling
+	// regions.
+	fake := &fakeFacetCounter{}
+	app := facetsApp(fake)
+
+	status, _ := doGet(t, app, "/jobs/facets?disjunctive=1&countries=BR&seniority=senior")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	// The regions facet is counted with the entire location group removed (no BR),
+	// but keeps the non-location seniority selection.
+	regGroups, ok := fake.reqFilter("regions").([][]string)
+	if !ok {
+		t.Fatalf("no reduced filter for regions: %#v", fake.gotReqs)
+	}
+	if filterHas(regGroups, `countries = "BR"`) {
+		t.Errorf("regions facet should drop the whole location group, got %#v", regGroups)
+	}
+	if !filterHas(regGroups, `enrichment.seniority = "senior"`) {
+		t.Errorf("regions facet should keep seniority, got %#v", regGroups)
+	}
+
+	// A non-location facet keeps the country selection.
+	senGroups, _ := fake.reqFilter("enrichment.seniority").([][]string)
+	if !filterHas(senGroups, `countries = "BR"`) {
+		t.Errorf("seniority facet should keep the country selection, got %#v", senGroups)
+	}
+}
+
 func TestJobFacets_PassesFiltersAndRequestsFacets(t *testing.T) {
 	fake := &fakeFacetCounter{}
 	app := facetsApp(fake)

--- a/internal/handler/facets_test.go
+++ b/internal/handler/facets_test.go
@@ -10,14 +10,33 @@ import (
 )
 
 type fakeFacetCounter struct {
-	got search.FacetParams
-	res search.FacetResult
-	err error
+	got      search.FacetParams
+	gotReqs  []search.FacetReq
+	gotTotal any
+	res      search.FacetResult
+	err      error
 }
 
 func (f *fakeFacetCounter) FacetCounts(_ context.Context, p search.FacetParams) (search.FacetResult, error) {
 	f.got = p
 	return f.res, f.err
+}
+
+func (f *fakeFacetCounter) DisjunctiveFacetCounts(_ context.Context, _ string, reqs []search.FacetReq, totalFilter any) (search.FacetResult, error) {
+	f.gotReqs = reqs
+	f.gotTotal = totalFilter
+	return f.res, f.err
+}
+
+// reqFilter returns the reduced filter the disjunctive path built for one index
+// attribute (nil if absent).
+func (f *fakeFacetCounter) reqFilter(attr string) any {
+	for _, r := range f.gotReqs {
+		if r.Attr == attr {
+			return r.Filter
+		}
+	}
+	return nil
 }
 
 func facetsApp(fc facetCounter) *fiber.App {
@@ -32,6 +51,43 @@ func TestJobFacets_DisabledReturns503(t *testing.T) {
 	status, _ := doGet(t, app, "/jobs/facets")
 	if status != fiber.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", status)
+	}
+}
+
+func TestJobFacets_DisjunctiveReducesEachFacetsOwnFilter(t *testing.T) {
+	fake := &fakeFacetCounter{}
+	app := facetsApp(fake)
+
+	status, _ := doGet(t, app, "/jobs/facets?disjunctive=1&seniority=senior&regions=eu")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	// The seniority facet is counted WITHOUT its own selection, but WITH the others.
+	senGroups, ok := fake.reqFilter("enrichment.seniority").([][]string)
+	if !ok {
+		t.Fatalf("no reduced filter for enrichment.seniority: %#v", fake.gotReqs)
+	}
+	if filterHas(senGroups, `enrichment.seniority = "senior"`) {
+		t.Errorf("seniority facet should drop its own selection, got %#v", senGroups)
+	}
+	if !filterHas(senGroups, `regions = "eu"`) {
+		t.Errorf("seniority facet should keep other facets (regions), got %#v", senGroups)
+	}
+
+	// A different facet keeps seniority in its own reduced filter.
+	regGroups, _ := fake.reqFilter("regions").([][]string)
+	if !filterHas(regGroups, `enrichment.seniority = "senior"`) {
+		t.Errorf("regions facet should keep seniority, got %#v", regGroups)
+	}
+	if filterHas(regGroups, `regions = "eu"`) {
+		t.Errorf("regions facet should drop its own selection, got %#v", regGroups)
+	}
+
+	// The grand total uses the full filter (both facets).
+	totalGroups, _ := fake.gotTotal.([][]string)
+	if !filterHas(totalGroups, `enrichment.seniority = "senior"`) || !filterHas(totalGroups, `regions = "eu"`) {
+		t.Errorf("total filter should include all facets, got %#v", totalGroups)
 	}
 }
 

--- a/internal/handler/resume_verdict_test.go
+++ b/internal/handler/resume_verdict_test.go
@@ -38,6 +38,11 @@ func (f *twoQueryFacets) FacetCounts(_ context.Context, p search.FacetParams) (s
 	return search.FacetResult{}, nil
 }
 
+// The verdict path never uses disjunctive counts; satisfy the interface.
+func (f *twoQueryFacets) DisjunctiveFacetCounts(context.Context, string, []search.FacetReq, any) (search.FacetResult, error) {
+	return search.FacetResult{}, nil
+}
+
 // coverageFacets: role has 1000 open vacancies (query A), 370 uncovered (query B)
 // with kubernetes the biggest gap.
 func coverageFacets() *twoQueryFacets {

--- a/internal/search/facets.go
+++ b/internal/search/facets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/meilisearch/meilisearch-go"
 )
@@ -47,6 +48,91 @@ func (c *Client) FacetCounts(ctx context.Context, p FacetParams) (FacetResult, e
 		return FacetResult{}, fmt.Errorf("search: facet query: %w", err)
 	}
 	return buildFacetResult(resp)
+}
+
+// FacetReq is one facet's disjunctive request: the attribute to distribute and
+// the filter to count it under — the full filter with that facet's own selection
+// removed, so its own selection does not zero out its sibling values.
+type FacetReq struct {
+	Attr   string
+	Filter any
+}
+
+// facetSearcher runs one Limit:0 facet query. It is injected so
+// disjunctiveFacetCounts is unit-testable without a live engine.
+type facetSearcher func(ctx context.Context, query string, filter any, facets []string) (*meilisearch.SearchResponse, error)
+
+// DisjunctiveFacetCounts computes each facet's distribution under its own reduced
+// filter (so a selected facet still shows its siblings' counts) plus the grand
+// total under the full filter. All queries run concurrently, so the latency is
+// that of the slowest single facet query, not their sum.
+func (c *Client) DisjunctiveFacetCounts(ctx context.Context, query string, reqs []FacetReq, totalFilter any) (FacetResult, error) {
+	return disjunctiveFacetCounts(ctx, query, reqs, totalFilter, func(ctx context.Context, q string, filter any, facets []string) (*meilisearch.SearchResponse, error) {
+		return c.facet.SearchWithContext(ctx, q, &meilisearch.SearchRequest{Filter: filter, Facets: facets, Limit: 0})
+	})
+}
+
+func disjunctiveFacetCounts(ctx context.Context, query string, reqs []FacetReq, totalFilter any, search facetSearcher) (FacetResult, error) {
+	res := FacetResult{Facets: map[string]map[string]int64{}, Stats: map[string]FacetStat{}}
+	var (
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+		firstErr error
+	)
+	run := func(fn func() error) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := fn(); err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+
+	// The grand total under the full filter — the number "Show N results" reflects.
+	run(func() error {
+		resp, err := search(ctx, query, totalFilter, nil)
+		if err != nil {
+			return fmt.Errorf("search: disjunctive total: %w", err)
+		}
+		mu.Lock()
+		res.Total = resp.EstimatedTotalHits
+		mu.Unlock()
+		return nil
+	})
+	// Each facet under its own reduced filter, keeping only its own distribution.
+	for _, r := range reqs {
+		r := r
+		run(func() error {
+			resp, err := search(ctx, query, r.Filter, []string{r.Attr})
+			if err != nil {
+				return fmt.Errorf("search: disjunctive facet %s: %w", r.Attr, err)
+			}
+			fr, err := buildFacetResult(resp)
+			if err != nil {
+				return err
+			}
+			mu.Lock()
+			if d, ok := fr.Facets[r.Attr]; ok {
+				res.Facets[r.Attr] = d
+			}
+			for k, v := range fr.Stats {
+				res.Stats[k] = v
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	wg.Wait()
+	if firstErr != nil {
+		return FacetResult{}, firstErr
+	}
+	return res, nil
 }
 
 // buildFacetResult assembles a FacetResult from a Meilisearch response, decoding

--- a/internal/search/facets_test.go
+++ b/internal/search/facets_test.go
@@ -1,12 +1,77 @@
 package search
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/meilisearch/meilisearch-go"
 )
+
+func TestDisjunctiveFacetCounts(t *testing.T) {
+	type call struct {
+		filter any
+		facets []string
+	}
+	var mu sync.Mutex
+	var calls []call
+	searcher := func(_ context.Context, _ string, filter any, facets []string) (*meilisearch.SearchResponse, error) {
+		mu.Lock()
+		calls = append(calls, call{filter, facets})
+		mu.Unlock()
+		if len(facets) == 0 { // total-only query under the full filter
+			return &meilisearch.SearchResponse{EstimatedTotalHits: 1234}, nil
+		}
+		attr := facets[0]
+		dist, _ := json.Marshal(map[string]map[string]int64{attr: {"x": 10, "y": 5}})
+		return &meilisearch.SearchResponse{FacetDistribution: dist, EstimatedTotalHits: 99}, nil
+	}
+
+	reqs := []FacetReq{{Attr: "seniority", Filter: "F_sen"}, {Attr: "category", Filter: "F_cat"}}
+	got, err := disjunctiveFacetCounts(context.Background(), "go", reqs, "FULL", searcher)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	// Total comes from the total-only query (the full filter), not any facet subtotal.
+	if got.Total != 1234 {
+		t.Errorf("Total = %d, want 1234", got.Total)
+	}
+	// Each facet carries its own disjunctive distribution.
+	if got.Facets["seniority"]["x"] != 10 || got.Facets["category"]["y"] != 5 {
+		t.Errorf("Facets = %v", got.Facets)
+	}
+	// One query per facet (facets=[attr], reduced filter) + one total-only (full filter).
+	if len(calls) != 3 {
+		t.Fatalf("calls = %d, want 3", len(calls))
+	}
+	var total, sen *call
+	for i := range calls {
+		switch {
+		case len(calls[i].facets) == 0:
+			total = &calls[i]
+		case calls[i].facets[0] == "seniority":
+			sen = &calls[i]
+		}
+	}
+	if total == nil || total.filter != "FULL" {
+		t.Errorf("total query filter = %v, want FULL with no facets", total)
+	}
+	if sen == nil || sen.filter != "F_sen" {
+		t.Errorf("seniority query filter = %v, want F_sen", sen)
+	}
+}
+
+func TestDisjunctiveFacetCounts_ErrorPropagates(t *testing.T) {
+	searcher := func(context.Context, string, any, []string) (*meilisearch.SearchResponse, error) {
+		return nil, errors.New("boom")
+	}
+	if _, err := disjunctiveFacetCounts(context.Background(), "", []FacetReq{{Attr: "a", Filter: "f"}}, "full", searcher); err == nil {
+		t.Fatal("expected error to propagate")
+	}
+}
 
 func TestBuildFacetResult(t *testing.T) {
 	t.Run("assembles total, facets and stats", func(t *testing.T) {

--- a/openspec/changes/live-faceting/.openspec.yaml
+++ b/openspec/changes/live-faceting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/live-faceting/design.md
+++ b/openspec/changes/live-faceting/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The modal is deferred-apply: panes edit a `staged` store; nothing hits the live
+list until Apply. Facet option counts today come from `JobsView.counts` — the
+`/jobs/facets` distribution of the **applied** filters — passed down as a static
+`counts` prop. `FilterModalShell` already fetches a **staged** total via a
+debounced `previewCount(stagedParams)` for the "Show N" button. A prior change
+(#487) gave `ChipFacet`/`CategoryPane`/`PillGroup` optional count props, so the
+rendering side is ready; what's missing is (a) counts on every control, (b) the
+counts following the staged selection disjunctively, and (c) a loading state.
+
+Meilisearch computes a facet distribution **after** the query filter
+(conjunctive), so a single call can't produce disjunctive counts — selecting a
+value zeroes its siblings. Disjunctive faceting needs one query per facet, each
+excluding that facet's own filter.
+
+## Goals / Non-Goals
+
+**Goals:** live, disjunctive counts on every modal facet control; a loading state
+on recompute; keep deferred-apply; no new dependency; endpoint latency ≈ one facet
+query (concurrent).
+
+**Non-Goals:** changing the applied-list behaviour; per-facet caching; disjunctive
+counts outside the modal (the sidebar/applied path keeps conjunctive counts).
+
+## Decisions
+
+**Disjunctive via concurrent per-facet queries (`search.DisjunctiveFacetCounts`).**
+Given the query, a total filter, and a list of `{attr, filter}` (each filter is
+the full filter minus that facet's own selection), run all queries + one
+total-only query **concurrently** (`errgroup`, already vendored) against the facet
+index with `Limit:0`. Merge each facet's own distribution and the grand total.
+Wall time ≈ the slowest single query, not the sum. ~18 cheap `Limit:0` searches
+per debounced recompute is acceptable (and covered by the loading state).
+
+**Filter reduction stays in the handler.** The handler owns `url.Values` and
+`search.StringFacets` (param→attr). For each facet param it clones the values,
+deletes `param`, `param_exclude`, `param_mode`, and rebuilds via
+`search.FilterFromValues` — the reduced filter for that facet. The total uses the
+full values. This keeps all filter-string construction in one place; `search`
+only runs the queries. The disjunctive path is gated on a `disjunctive` query flag
+so the existing conjunctive endpoint (sidebar, ATS) is untouched.
+`facetCounter` gains a `DisjunctiveFacetCounts` method (fake updated for tests).
+
+**Frontend: the shell owns staged counts + loading.** `FilterModalShell` already
+debounces on `staged.params()`. Generalize its `previewCount` into a
+`stagedCounts(params) => Promise<FacetCounts>` (disjunctive) supplied by
+`JobsView`; the shell keeps a `stagedCounts` + `loading` `$state`, and passes the
+distribution down to the panes (replacing the applied `counts` prop within the
+modal) and the total+loading to the Show button. `JobsView` still computes the
+applied `counts` for the sidebar. The pane wiring passes counts to **every**
+`ChipFacet` and the `LocationPane`.
+
+**Loading state.** The Show button renders a spinner while `loading`; option
+counts read from the last resolved `stagedCounts` (so they don't flicker to empty
+mid-fetch) and may dim. A monotonic gen id drops stale responses (as `previewCount`
+already does).
+
+## Risks / Trade-offs
+
+- **Meili query volume**: ~18 facet queries per debounced recompute. Cheap
+  (`Limit:0`), concurrent, modal-only, debounced — acceptable; the loading state
+  hides the latency. If it ever bites, batch via Meili multi-search.
+- **Debounce feel**: 200ms debounce means counts trail the click slightly; the
+  spinner makes that legible rather than janky.
+- **Disjunctive is modal-only**: the applied/sidebar counts stay conjunctive
+  (they reflect the applied filter, where conjunctive is correct). No divergence
+  risk since they answer different questions.

--- a/openspec/changes/live-faceting/proposal.md
+++ b/openspec/changes/live-faceting/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The filter modal shows a job count only on the role picker and the dynamic
+selects, and those counts reflect the **already-applied** filters, not what the
+user is picking right now. So while building a filter you can't see how many jobs
+each option would add, and the seniority/specialization/other controls show no
+counts at all. Users expect the Amazon/Booking experience: every option shows a
+live count that updates as you pick, with the count staying meaningful for the
+facet you're editing.
+
+## What Changes
+
+- **Counts on every facet control** in the modal — the Seniority pills, the
+  Specialization chips, and every other `ChipFacet`/location control show their
+  live match count, like the role picker already does.
+- **Live recompute from the staged (in-progress) selection** — as the user
+  toggles options, the counts recompute (debounced) from the staged filter, not
+  the applied one. The **deferred-apply contract is unchanged**: nothing reaches
+  the live list until Apply.
+- **Disjunctive faceting** — each facet's own selection is excluded from its own
+  distribution, so siblings stay visible (selecting "Senior" still shows
+  "Junior 54k"). This needs a backend capability: for each requested facet, count
+  under the full filter **minus that facet's own selection**, plus a grand total
+  under the full filter. Implemented as concurrent Meilisearch facet queries in
+  `internal/search` and exposed via `GET /api/v1/jobs/facets` behind a flag.
+- **Loading state** — while a recompute is in flight, the modal's "Show N
+  results" button shows a spinner (and the counts dim) instead of a stale number;
+  the number returns when the fetch resolves.
+
+## Capabilities
+
+### Modified Capabilities
+- `job-analytics`: the facet-distribution endpoint gains an opt-in **disjunctive**
+  mode — each facet counted under the filter minus its own selection, plus the
+  full-filter total — backed by a new concurrent `search` capability.
+- `filter-modal`: all facet controls show live counts sourced from the staged
+  selection (disjunctive), and the footer preview shows a loading state while a
+  recompute is in flight.
+
+## Impact
+
+- **Backend**: `internal/search` (new `DisjunctiveFacetCounts` — concurrent
+  per-facet queries + total), `internal/handler/facets.go` (build per-facet
+  reduced filters, wire the disjunctive path + `facetCounter` interface).
+- **Frontend**: `FilterModalShell` (debounced staged facet-counts fetch + loading
+  state, spinner on the Show button), `ChipFacet`/`CategoryPane`/`PillGroup`
+  (count props), `FilterModal` (pass staged counts to every pane), `api.ts`
+  (`disjunctive` param), `JobsView` (provide the staged-counts fetcher).
+- No index/schema change; no new dependency (`golang.org/x/sync` already vendored).

--- a/openspec/changes/live-faceting/specs/filter-modal/spec.md
+++ b/openspec/changes/live-faceting/specs/filter-modal/spec.md
@@ -36,8 +36,8 @@ apply the filter to the live list; only the footer Apply action does.
 
 ### Requirement: The preview shows a loading state during recompute
 
-While a staged-count recompute is in flight, the modal's "Show N results" footer
-SHALL show a loading indicator instead of a stale number, and the option counts
+The modal's "Show N results" footer SHALL show a loading indicator instead of a
+stale number while a staged-count recompute is in flight, and the option counts
 MAY be dimmed; when the recompute resolves, the number (and counts) SHALL appear.
 
 #### Scenario: Spinner while recomputing

--- a/openspec/changes/live-faceting/specs/filter-modal/spec.md
+++ b/openspec/changes/live-faceting/specs/filter-modal/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Every facet control shows a live match count
+
+Every facet control in the filter modal SHALL display a match count per option —
+the seniority pills, the specialization chips, and every other chip/pill and
+location control — the same way the role picker and the dynamic selects already
+do. A count SHALL be omitted only when the distribution has no entry for that
+control (e.g. the endpoint is unavailable), never breaking the control.
+
+#### Scenario: Seniority and specialization show counts
+
+- **WHEN** the modal's Role pane is open with facet counts available
+- **THEN** each Seniority pill and each Specialization chip shows its job count
+  beside its label
+
+### Requirement: Counts recompute live from the staged selection
+
+The modal's option counts SHALL be sourced from the **staged** (in-progress)
+selection, recomputed (debounced) as the user toggles options, using the
+**disjunctive** distribution — so a facet keeps showing its sibling counts while
+selected. The deferred-apply contract is unchanged: recomputing counts SHALL NOT
+apply the filter to the live list; only the footer Apply action does.
+
+#### Scenario: Toggling an option updates the other facets' counts
+
+- **WHEN** the user toggles a facet option in the modal
+- **THEN** the counts on the other facets recompute from the new staged selection
+  (after a short debounce), while the live job list stays unchanged until Apply
+
+#### Scenario: The edited facet still shows its alternatives
+
+- **WHEN** the user selects one value of a facet
+- **THEN** that facet's other values still show their (disjunctive) counts, so the
+  user can see and switch to alternatives
+
+### Requirement: The preview shows a loading state during recompute
+
+While a staged-count recompute is in flight, the modal's "Show N results" footer
+SHALL show a loading indicator instead of a stale number, and the option counts
+MAY be dimmed; when the recompute resolves, the number (and counts) SHALL appear.
+
+#### Scenario: Spinner while recomputing
+
+- **WHEN** the user toggles an option and the staged-count fetch is in flight
+- **THEN** the "Show N results" button shows a spinner rather than the previous
+  number
+- **AND** once the fetch resolves, the button shows the updated job count

--- a/openspec/changes/live-faceting/specs/job-analytics/spec.md
+++ b/openspec/changes/live-faceting/specs/job-analytics/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Disjunctive facet distribution
+
+The facet-distribution endpoint SHALL support a **disjunctive** mode (opt-in via a
+`disjunctive` query flag). In this mode, each requested facet's distribution SHALL
+be computed under the full filter **with that facet's own selection removed**
+(its `<param>`, `<param>_exclude`, and `<param>_mode` values excluded), so a
+facet's own selection does not zero out its sibling values. The reported `total`
+SHALL still be the estimated count under the **full** filter (all facets applied)
+— the number the "Show N results" action reflects. Non-disjunctive requests keep
+the existing conjunctive behaviour (every facet counted under the full filter).
+
+The disjunctive distributions SHALL be produced by running the per-facet queries
+**concurrently** (a `search` capability), so the endpoint's latency is that of a
+single facet query rather than the sum of all of them.
+
+#### Scenario: A facet's own selection does not hide its siblings
+
+- **WHEN** a client requests the disjunctive facet distribution with
+  `seniority=senior` selected
+- **THEN** the `seniority` distribution still reports counts for the other
+  seniorities (e.g. `junior`, `middle`) — each counted under the rest of the
+  filter, ignoring the `senior` selection
+- **AND** a different facet (e.g. `category`) is counted under a filter that
+  **does** include `seniority=senior`
+
+#### Scenario: The total reflects the full filter
+
+- **WHEN** a client requests the disjunctive distribution with several facets
+  selected
+- **THEN** the response `total` is the estimated job count under all selected
+  facets combined (not any single facet's disjunctive subtotal)
+
+#### Scenario: Non-disjunctive requests are unchanged
+
+- **WHEN** a client requests the facet distribution without the disjunctive flag
+- **THEN** every facet is counted under the full filter (conjunctive), exactly as
+  before

--- a/openspec/changes/live-faceting/tasks.md
+++ b/openspec/changes/live-faceting/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Backend — disjunctive facet counts (`internal/search`)
 
-- [ ] 1.1 Add `search.DisjunctiveFacetCounts(ctx, query, reqs []FacetReq,
+- [x] 1.1 Add `search.DisjunctiveFacetCounts(ctx, query, reqs []FacetReq,
   totalFilter any) (FacetResult, error)` where `FacetReq{Attr, Filter}` — runs one
   `Limit:0` facet query per req (facets=[attr]) plus one total-only query, all
   concurrent (`errgroup`), and merges each facet's own distribution + the grand
@@ -9,49 +9,49 @@
 
 ## 2. Backend — endpoint wiring (`internal/handler/facets.go`)
 
-- [ ] 2.1 Add `DisjunctiveFacetCounts` to the `facetCounter` interface (update the
+- [x] 2.1 Add `DisjunctiveFacetCounts` to the `facetCounter` interface (update the
   fake in `facets_test.go`).
-- [ ] 2.2 In `JobFacets`, when `disjunctive` is set, build per-facet reduced
+- [x] 2.2 In `JobFacets`, when `disjunctive` is set, build per-facet reduced
   filters (clone values, delete `param`/`param_exclude`/`param_mode`,
   `FilterFromValues`) for each distribution facet, plus the full filter for the
   total, and call `DisjunctiveFacetCounts`; re-key to public params as today.
   Non-disjunctive requests keep the existing `FacetCounts` path.
-- [ ] 2.3 Handler test: `disjunctive=1` passes per-facet reduced filters (the
+- [x] 2.3 Handler test: `disjunctive=1` passes per-facet reduced filters (the
   seniority query's filter omits `seniority=`) and the total uses the full filter.
 
 ## 3. Frontend — API
 
-- [ ] 3.1 `api.facetCounts(params, { disjunctive })` — forward the flag as a query
+- [x] 3.1 `api.facetCounts(params, { disjunctive })` — forward the flag as a query
   param; return the full `FacetCounts` (already does).
 
 ## 4. Frontend — live staged counts + loading (`FilterModalShell`)
 
-- [ ] 4.1 Replace the `previewCount` total-only fetch with a `stagedCounts(params)
+- [x] 4.1 Replace the `previewCount` total-only fetch with a `stagedCounts(params)
   => Promise<FacetCounts>` (disjunctive) supplied by the wrapper; keep a
   `stagedCounts` + `loading` `$state`, gen-guarded and debounced on
   `staged.params()`.
-- [ ] 4.2 Show button: spinner while `loading`, else `Show {stagedCounts.total}`.
-- [ ] 4.3 Expose the staged distribution to the `pane` snippet (so panes read it
+- [x] 4.2 Show button: spinner while `loading`, else `Show {stagedCounts.total}`.
+- [x] 4.3 Expose the staged distribution to the `pane` snippet (so panes read it
   instead of the applied `counts`).
 
 ## 5. Frontend — counts on every control (`FilterModal` + panes)
 
-- [ ] 5.1 Pass the staged distribution to **every** `ChipFacet` (work_mode,
+- [x] 5.1 Pass the staged distribution to **every** `ChipFacet` (work_mode,
   employment_type, domains, company_type, collections, relocation,
   salary_currency, english_level) and to `LocationPane`, in addition to the
   role/seniority/specialization pane.
-- [ ] 5.2 Confirm `PillGroup`/`ChipFacet`/`CategoryPane` render `opt.count` (from
+- [x] 5.2 Confirm `PillGroup`/`ChipFacet`/`CategoryPane` render `opt.count` (from
   #487); extend `LocationPane` region/country/city rows with counts.
 
 ## 6. Frontend — JobsView wiring
 
-- [ ] 6.1 Provide `stagedCounts` fetcher to the modal (disjunctive facetCounts over
+- [x] 6.1 Provide `stagedCounts` fetcher to the modal (disjunctive facetCounts over
   staged+scope params); keep the applied `counts` for the sidebar.
 
 ## 7. Verify
 
-- [ ] 7.1 `go build ./... && go vet ./... && go test ./...`; web `svelte-check` +
+- [x] 7.1 `go build ./... && go vet ./... && go test ./...`; web `svelte-check` +
   vitest green.
-- [ ] 7.2 Visual: modal shows counts on all controls; toggling an option keeps the
+- [x] 7.2 Visual: modal shows counts on all controls; toggling an option keeps the
   edited facet's siblings visible and recomputes others; Show button spins then
   shows the number.

--- a/openspec/changes/live-faceting/tasks.md
+++ b/openspec/changes/live-faceting/tasks.md
@@ -1,0 +1,57 @@
+## 1. Backend — disjunctive facet counts (`internal/search`)
+
+- [ ] 1.1 Add `search.DisjunctiveFacetCounts(ctx, query, reqs []FacetReq,
+  totalFilter any) (FacetResult, error)` where `FacetReq{Attr, Filter}` — runs one
+  `Limit:0` facet query per req (facets=[attr]) plus one total-only query, all
+  concurrent (`errgroup`), and merges each facet's own distribution + the grand
+  total. Table/behaviour tests for the merge (fake responses) and that a query
+  error propagates.
+
+## 2. Backend — endpoint wiring (`internal/handler/facets.go`)
+
+- [ ] 2.1 Add `DisjunctiveFacetCounts` to the `facetCounter` interface (update the
+  fake in `facets_test.go`).
+- [ ] 2.2 In `JobFacets`, when `disjunctive` is set, build per-facet reduced
+  filters (clone values, delete `param`/`param_exclude`/`param_mode`,
+  `FilterFromValues`) for each distribution facet, plus the full filter for the
+  total, and call `DisjunctiveFacetCounts`; re-key to public params as today.
+  Non-disjunctive requests keep the existing `FacetCounts` path.
+- [ ] 2.3 Handler test: `disjunctive=1` passes per-facet reduced filters (the
+  seniority query's filter omits `seniority=`) and the total uses the full filter.
+
+## 3. Frontend — API
+
+- [ ] 3.1 `api.facetCounts(params, { disjunctive })` — forward the flag as a query
+  param; return the full `FacetCounts` (already does).
+
+## 4. Frontend — live staged counts + loading (`FilterModalShell`)
+
+- [ ] 4.1 Replace the `previewCount` total-only fetch with a `stagedCounts(params)
+  => Promise<FacetCounts>` (disjunctive) supplied by the wrapper; keep a
+  `stagedCounts` + `loading` `$state`, gen-guarded and debounced on
+  `staged.params()`.
+- [ ] 4.2 Show button: spinner while `loading`, else `Show {stagedCounts.total}`.
+- [ ] 4.3 Expose the staged distribution to the `pane` snippet (so panes read it
+  instead of the applied `counts`).
+
+## 5. Frontend — counts on every control (`FilterModal` + panes)
+
+- [ ] 5.1 Pass the staged distribution to **every** `ChipFacet` (work_mode,
+  employment_type, domains, company_type, collections, relocation,
+  salary_currency, english_level) and to `LocationPane`, in addition to the
+  role/seniority/specialization pane.
+- [ ] 5.2 Confirm `PillGroup`/`ChipFacet`/`CategoryPane` render `opt.count` (from
+  #487); extend `LocationPane` region/country/city rows with counts.
+
+## 6. Frontend — JobsView wiring
+
+- [ ] 6.1 Provide `stagedCounts` fetcher to the modal (disjunctive facetCounts over
+  staged+scope params); keep the applied `counts` for the sidebar.
+
+## 7. Verify
+
+- [ ] 7.1 `go build ./... && go vet ./... && go test ./...`; web `svelte-check` +
+  vitest green.
+- [ ] 7.2 Visual: modal shows counts on all controls; toggling an option keeps the
+  edited facet's siblings visible and recomputes others; Show button spins then
+  shows the number.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -196,8 +196,12 @@ export function createApi(
    *  query text and facet filters as `searchJobs` (built by the caller, e.g. via
    *  `filtersToParams`); the endpoint returns counts instead of a page of jobs.
    *  Empty `facets`/`stats` are normalized to `{}` so callers never see null. */
-  async function facetCounts(params: URLSearchParams): Promise<FacetCounts> {
-    const res = await request<{ data: FacetCounts }>(`/api/v1/jobs/facets?${params}`);
+  // `disjunctive` asks the endpoint to count each facet under the filter minus its
+  // own selection (so a selected facet still shows its siblings) — the live-modal mode.
+  async function facetCounts(params: URLSearchParams, opts?: { disjunctive?: boolean }): Promise<FacetCounts> {
+    const p = new URLSearchParams(params);
+    if (opts?.disjunctive) p.set('disjunctive', '1');
+    const res = await request<{ data: FacetCounts }>(`/api/v1/jobs/facets?${p}`);
     return { total: res.data.total, facets: res.data.facets ?? {}, stats: res.data.stats ?? {} };
   }
 

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -95,12 +95,14 @@
   let modalOpen = $state(false);
   let started = false;
 
-  // The job count for a staged filter set (built by the modal), merged with the fixed
-  // scope params (e.g. company_slug) so the "Show N jobs" preview matches the list.
-  const previewCount = (params: URLSearchParams) => {
+  // Live disjunctive facet counts for the staged filter set (built by the modal),
+  // merged with the fixed scope params (e.g. company_slug) so every control's counts —
+  // and the "Show N jobs" total — match the list. Disjunctive so a selected facet
+  // still shows its siblings' counts.
+  const stagedCounts = (params: URLSearchParams) => {
     const p = new URLSearchParams(params);
     for (const [k, v] of Object.entries(scope)) p.set(k, v);
-    return api.facetCounts(p).then((c) => c.total);
+    return api.facetCounts(p, { disjunctive: true });
   };
 
   // The server-rendered `initial` was searched for `page.url`. After a back/forward
@@ -274,5 +276,5 @@
   savedSearches={standalone}
   open={modalOpen}
   onClose={() => (modalOpen = false)}
-  {previewCount}
+  {stagedCounts}
 />

--- a/web/src/lib/components/filters/CompanyFilterModal.svelte
+++ b/web/src/lib/components/filters/CompanyFilterModal.svelte
@@ -3,6 +3,7 @@
   import type { CompanyFilterStore } from '$lib/companyFilters';
   import { StagedCompanyFilters } from '$lib/stagedCompanyFilters.svelte';
   import type { RailEntry, RailSection } from '$lib/filterSections';
+  import type { FacetCounts } from '$lib/types';
   import FacetSection from '../facets/FacetSection.svelte';
   import FilterModalShell from './FilterModalShell.svelte';
 
@@ -51,7 +52,7 @@
   {pane}
 />
 
-{#snippet pane(entry: RailEntry)}
+{#snippet pane(entry: RailEntry, _live: FacetCounts | null)}
   {@const def = COMPANY_FACETS.find((d) => d.param === entry.facetParam)}
   {#if def}<FacetSection {def} store={staged} expand />{/if}
 {/snippet}

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -38,6 +38,7 @@
     open = false,
     onClose,
     previewCount,
+    stagedCounts,
     extra,
   }: {
     store?: FilterStore;
@@ -58,6 +59,10 @@
     open?: boolean;
     onClose: () => void;
     previewCount?: (params: URLSearchParams) => Promise<number>;
+    // Live disjunctive facet counts for the staged selection — when supplied, every
+    // control shows counts that recompute as you pick (the job list). Absent for the
+    // analytics/swipe reuse, which keep the applied `counts` + total-only preview.
+    stagedCounts?: (params: URLSearchParams) => Promise<FacetCounts>;
     // Extra content rendered above the pane, handed the staged store so it can edit it
     // (e.g. the profile editor's "import skills from CV").
     extra?: Snippet<[StagedFilters]>;
@@ -161,6 +166,7 @@
   {applyDisabled}
   {applyLabel}
   {previewCount}
+  countsFetch={stagedCounts}
   {pane}
   extra={extra ? extraStaged : undefined}
   {footerNote}
@@ -188,27 +194,28 @@
   {/if}
 {/snippet}
 
-{#snippet pane(entry: RailEntry)}
+{#snippet pane(entry: RailEntry, live: FacetCounts | null)}
+  {@const c = live ?? counts}
   {#if entry.kind === 'saved'}
     <SavedSearches store={staged} />
   {:else if entry.kind === 'category'}
     {@const roleDef = facetDefFor('role')}
     {#if roleDef && !exclude.includes('role')}
-      <div class="mb-6"><FacetSection def={roleDef} store={staged} {counts} expand /></div>
+      <div class="mb-6"><FacetSection def={roleDef} store={staged} counts={c} expand /></div>
     {/if}
     {#if !exclude.includes('seniority')}
-      <ChipFacet store={staged} param="seniority" label="Seniority" {counts} />
-      <div class="mt-6"><CategoryPane store={staged} {plain} {counts} /></div>
+      <ChipFacet store={staged} param="seniority" label="Seniority" counts={c} />
+      <div class="mt-6"><CategoryPane store={staged} {plain} counts={c} /></div>
     {:else}
-      <CategoryPane store={staged} {plain} {counts} />
+      <CategoryPane store={staged} {plain} counts={c} />
     {/if}
   {:else if entry.kind === 'location'}
-    <LocationPane store={staged} {counts} />
+    <LocationPane store={staged} counts={c} />
   {:else if entry.kind === 'facet'}
     {@const def = facetDefFor(entry.facetParam)}
-    {#if def}<FacetSection {def} store={staged} {counts} expand />{/if}
+    {#if def}<FacetSection {def} store={staged} counts={c} expand />{/if}
   {:else if entry.kind === 'salary'}
-    <ChipFacet store={staged} param="salary_currency" label="Currency" />
+    <ChipFacet store={staged} param="salary_currency" label="Currency" counts={c} />
     <div class="mb-2 mt-6 flex items-center justify-between">
       <h3 class="text-sm font-semibold tracking-tight">Minimum salary</h3>
       <span class="text-xs font-medium text-muted-foreground"
@@ -226,17 +233,17 @@
       class="w-full accent-primary"
     />
   {:else if entry.kind === 'work'}
-    <ChipFacet store={staged} param="work_mode" label="Work format" />
-    <div class="mt-6"><ChipFacet store={staged} param="employment_type" label="Employment type" /></div>
+    <ChipFacet store={staged} param="work_mode" label="Work format" counts={c} />
+    <div class="mt-6"><ChipFacet store={staged} param="employment_type" label="Employment type" counts={c} /></div>
   {:else if entry.kind === 'industry'}
-    <ChipFacet store={staged} param="domains" label="Industry" />
-    <div class="mt-6"><ChipFacet store={staged} param="company_type" label="Company type" /></div>
-    <div class="mt-6"><ChipFacet store={staged} param="collections" label="Collection" /></div>
+    <ChipFacet store={staged} param="domains" label="Industry" counts={c} />
+    <div class="mt-6"><ChipFacet store={staged} param="company_type" label="Company type" counts={c} /></div>
+    <div class="mt-6"><ChipFacet store={staged} param="collections" label="Collection" counts={c} /></div>
   {:else if entry.kind === 'language'}
-    {#if englishDef}<FacetSection def={englishDef} store={staged} {counts} expand />{/if}
-    <div class="mt-4">{#if postingDef}<FacetSection def={postingDef} store={staged} {counts} expand />{/if}</div>
+    {#if englishDef}<FacetSection def={englishDef} store={staged} counts={c} expand />{/if}
+    <div class="mt-4">{#if postingDef}<FacetSection def={postingDef} store={staged} counts={c} expand />{/if}</div>
   {:else if entry.kind === 'relocation'}
-    <ChipFacet store={staged} param="relocation" label="Relocation" />
+    <ChipFacet store={staged} param="relocation" label="Relocation" counts={c} />
     <h3 class="mb-2 mt-6 text-sm font-semibold tracking-tight">Visa</h3>
     <label class="flex cursor-pointer items-center gap-2 text-sm">
       <input

--- a/web/src/lib/components/filters/FilterModalShell.svelte
+++ b/web/src/lib/components/filters/FilterModalShell.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { X } from '@lucide/svelte';
+  import { LoaderCircle, X } from '@lucide/svelte';
   import type { RailEntry, RailSection } from '$lib/filterSections';
+  import type { FacetCounts } from '$lib/types';
 
   // The reusable two-pane filter-modal chrome: backdrop, header, the sectioned left
   // rail, and the deferred footer (Clear all / Apply / live preview). It knows nothing
@@ -34,6 +35,7 @@
     applyDisabled = false,
     applyLabel,
     previewCount,
+    countsFetch,
     initialKey,
     pane,
     extra,
@@ -53,12 +55,18 @@
     applyDisabled?: boolean;
     /** Custom footer label (e.g. "Save"); when absent the button shows the live preview. */
     applyLabel?: string;
+    /** Legacy total-only preview: the footer count. Used when `countsFetch` is absent. */
     previewCount?: (params: URLSearchParams) => Promise<number>;
+    /** Live disjunctive facet counts for the staged selection. When set, the shell fetches
+     *  the full distribution (debounced), drives the footer total + a loading spinner, and
+     *  hands the distribution to the `pane` snippet — so every control shows live counts. */
+    countsFetch?: (params: URLSearchParams) => Promise<FacetCounts>;
     /** Rail entry to land on when the modal opens (defaults to the first entry) — lets a
      *  caller keep a lead tab (e.g. "My filters") in the rail without opening on it. */
     initialKey?: string;
-    /** Renders the active entry's controls into the right pane. */
-    pane: Snippet<[RailEntry]>;
+    /** Renders the active entry's controls into the right pane, given the live staged
+     *  facet counts (null until the first fetch resolves or when `countsFetch` is absent). */
+    pane: Snippet<[RailEntry, FacetCounts | null]>;
     /** Optional content above the pane (e.g. the profile editor's "import from CV"). */
     extra?: Snippet;
     /** Optional footer nudge above the action row, handed a `jumpTo` to switch panes and
@@ -87,23 +95,49 @@
   const activeEntry = $derived(rail.find((e) => e.key === active) ?? rail[0]);
 
   // Debounced live preview for the staged filters, keyed by a monotonic gen so a slow
-  // response can't overwrite a newer one.
+  // response can't overwrite a newer one. With `countsFetch` the shell holds the full
+  // distribution (`liveCounts`) + a `loading` flag driving the footer spinner; otherwise
+  // it falls back to the total-only `previewCount`.
   let showCount = $state<number | null>(null);
+  let liveCounts = $state<FacetCounts | null>(null);
+  let loading = $state(false);
   let countGen = 0;
   $effect(() => {
-    if (!open || !previewCount) return;
+    if (!open) return;
     const params = staged.params(); // tracks the staged edits
     const gen = ++countGen;
-    const pc = previewCount;
-    const t = setTimeout(() => {
-      pc(params)
-        .then((n) => {
-          if (gen === countGen) showCount = n;
-        })
-        .catch(() => {});
-    }, 200);
+    let t: ReturnType<typeof setTimeout> | undefined;
+    if (countsFetch) {
+      const cf = countsFetch;
+      loading = true;
+      t = setTimeout(() => {
+        cf(params)
+          .then((c) => {
+            if (gen === countGen) {
+              liveCounts = c;
+              loading = false;
+            }
+          })
+          .catch(() => {
+            if (gen === countGen) loading = false;
+          });
+      }, 200);
+    } else if (previewCount) {
+      const pc = previewCount;
+      t = setTimeout(() => {
+        pc(params)
+          .then((n) => {
+            if (gen === countGen) showCount = n;
+          })
+          .catch(() => {});
+      }, 200);
+    }
     return () => clearTimeout(t);
   });
+
+  // The footer total: the live distribution's total when count-fetching, else the
+  // legacy preview number.
+  const total = $derived(countsFetch ? liveCounts?.total ?? null : showCount);
 
   let applyBusy = $state(false);
   let applyError = $state<string | null>(null);
@@ -190,7 +224,7 @@
         <!-- pane -->
         <section class="min-w-0 flex-1 overflow-y-auto p-4 sm:p-6">
           {#if extra}<div class="mb-6">{@render extra()}</div>{/if}
-          {#if activeEntry}{@render pane(activeEntry)}{/if}
+          {#if activeEntry}{@render pane(activeEntry, liveCounts)}{/if}
         </section>
       </div>
 
@@ -214,9 +248,11 @@
           >
             {#if applyLabel}
               {applyBusy ? 'Saving…' : applyLabel}
+            {:else if loading}
+              Show <LoaderCircle class="size-4 animate-spin" /> jobs
             {:else}
-              Show {showCount != null ? showCount.toLocaleString('en-US') : ''}
-              {showCount === 1 ? 'job' : 'jobs'}
+              Show {total != null ? total.toLocaleString('en-US') : ''}
+              {total === 1 ? 'job' : 'jobs'}
             {/if}
           </button>
         </div>


### PR DESCRIPTION
Live faceting in the job filter modal — the Amazon/Booking experience. Planned via OpenSpec (`live-faceting`).

## What
- **Counts on every control** — seniority pills, specialization chips, and all other ChipFacets/location rows now show a match count, like the role picker did.
- **Live recompute from the staged selection** — counts recompute (debounced) as you pick, not from the applied filter. Deferred-apply unchanged (nothing hits the list until Apply).
- **Disjunctive** — each facet's own selection is excluded from its own distribution, so siblings stay visible (selecting "Senior" still shows "Junior 54k"). Location facets (regions/countries/cities) drop the whole OR-group.
- **Loading state** — the "Show N results" footer shows a spinner while a recompute is in flight, then the number.

## How
- **Backend** (`internal/search`): `DisjunctiveFacetCounts` runs one `Limit:0` facet query per facet (each under the full filter minus its own selection) + one total-only query, **concurrently** (wall time ≈ one query), and merges. `/jobs/facets` gains a `disjunctive` flag; the handler builds the per-facet reduced filters. Conjunctive path (sidebar, ATS) unchanged.
- **Frontend**: `FilterModalShell` fetches the full staged distribution (disjunctive, debounced, gen-guarded) via a `countsFetch` prop, holds `liveCounts` + `loading`, drives the footer + spinner, and hands the distribution to the pane snippet. `FilterModal` panes use `live ?? counts`.

## Verification
- `go build/vet/test` green; svelte-check 0; vitest 45/45.
- Unit-tested: disjunctive merge (race-clean), reduced-filter construction, and the location-group reduction.
- Adversarial review found + fixed the location OR-group bug.
- Live e2e (spinner + disjunctive siblings) confirms on the deploy preview (needs the disjunctive backend live).

No index/schema change; no new dependency.