### PR TITLE
refactor(search): reuse toFloat32 in RecommendByVector

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -531,14 +531,10 @@ func (c *Client) RecommendByVector(ctx context.Context, vector []float64, limit,
 	if len(vector) == 0 {
 		return SearchResult{}, nil
 	}
-	vf := make([]float32, len(vector))
-	for i, v := range vector {
-		vf[i] = float32(v)
-	}
 	resp, err := c.semantic.SearchWithContext(ctx, "", &meilisearch.SearchRequest{
 		Limit:  int64(limit),
 		Offset: int64(offset),
-		Vector: vf,
+		Vector: toFloat32(vector),
 		Hybrid: &meilisearch.SearchRequestHybrid{Embedder: embedderName, SemanticRatio: 1},
 	})
 	if err != nil {


### PR DESCRIPTION
Small follow-up to #489: drop the inline float64→float32 loop in `RecommendByVector` for the shared `toFloat32` helper. Behavior-identical (same conversion), no redeploy needed. `go test ./internal/search/` + the `RecommendByVector` integration test stay green.