### PR TITLE
fix(web): auth dialog opens above the filter modal (z-index)

### DIFF
--- a/web/src/lib/components/AuthDialog.svelte
+++ b/web/src/lib/components/AuthDialog.svelte
@@ -85,7 +85,9 @@
 
 <svelte:window onkeydown={(e) => e.key === 'Escape' && onClose()} />
 
-<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+<!-- z-60 so the auth dialog sits ABOVE other z-50 modals (it can be opened from
+     within the filter modal's "Sign in to save filters"). -->
+<div class="fixed inset-0 z-[60] flex items-center justify-center p-4">
   <!-- Backdrop is a real button so closing on click is keyboard-accessible. -->
   <button type="button" aria-label="Close dialog" class="absolute inset-0 bg-black/50" onclick={onClose}
   ></button>


### PR DESCRIPTION
The "Sign in to save filters" button in the filter modal opens the global AuthDialog, but both used `z-50` — so the later-rendered filter modal covered the dialog and it looked like nothing happened. Bump AuthDialog to `z-[60]` so it stacks above other modals (it's triggerable from within them). Frontend-only, svelte-check 0.