### PR TITLE
feat(search): pluggable embed backend (GPU-ready) + summary passage

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -91,6 +91,10 @@ type Client struct {
 	// embedKey is the optional bearer token for embedURL (EMBED_API_KEY). Empty for
 	// the authless host2 TEI; set when pointing at an authenticated endpoint (HF, etc.).
 	embedKey string
+	// embedConcurrency is how many embed calls a batch runs in flight (EMBED_CONCURRENCY,
+	// default 1). The CPU-bound host2 TEI gains nothing from concurrency, but a remote
+	// GPU endpoint does (it hides per-call latency) — a bulk reindex sets it high.
+	embedConcurrency int
 }
 
 // NewClient connects to Meilisearch at url authenticated by key. It does no I/O
@@ -103,14 +107,19 @@ func NewClient(url, key string) *Client {
 	if v := os.Getenv("EMBED_URL"); v != "" {
 		embedURL = v
 	}
+	concurrency := 1
+	if v, err := strconv.Atoi(os.Getenv("EMBED_CONCURRENCY")); err == nil && v > 0 {
+		concurrency = v
+	}
 	return &Client{
-		manager:  m,
-		facet:    m.Index(facetIndexUID),
-		semantic: m.Index(semanticIndexUID),
-		url:      url,
-		key:      key,
-		embedURL: embedURL,
-		embedKey: os.Getenv("EMBED_API_KEY"),
+		manager:          m,
+		facet:            m.Index(facetIndexUID),
+		semantic:         m.Index(semanticIndexUID),
+		url:              url,
+		key:              key,
+		embedURL:         embedURL,
+		embedKey:         os.Getenv("EMBED_API_KEY"),
+		embedConcurrency: concurrency,
 	}
 }
 

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"time"
 
@@ -42,10 +43,11 @@ const (
 	// e5 gives far sharper skill matching than the old in-engine MiniLM, and offloading
 	// the compute keeps it off Meilisearch's single task queue.
 	embedderModel = "intfloat/multilingual-e5-base"
-	// embedderURL is the TEI OpenAI-compatible embeddings endpoint. A const (like
-	// embedderModel) — both prod and dev run TEI on localhost:8090; promote to config
-	// if a deployment needs to point elsewhere.
-	embedderURL = "http://127.0.0.1:8090/v1/embeddings"
+	// embedderURL is the default embedding backend: the host2 TEI's native /embed route
+	// (see embedChunk). A worker can override it with EMBED_URL to point at a faster
+	// backend serving the same e5 model — e.g. an HF Inference Endpoint for a bulk
+	// reindex — without changing the vector space.
+	embedderURL = "http://127.0.0.1:8090/embed"
 	// embedderDimensions is the e5-base output width; declared so Meilisearch validates
 	// vectors and the userProvided CV vector matches.
 	embedderDimensions = 768
@@ -82,15 +84,34 @@ type Client struct {
 	url      string
 	key      string
 	// embedURL is the TEI /v1/embeddings endpoint this client embeds against (jobs
-	// and CVs alike). It defaults to embedderURL; tests point it at a stub server.
+	// and CVs alike). It defaults to embedderURL (the host2 TEI) but EMBED_URL can
+	// point a worker at a faster backend — e.g. a GPU endpoint for a bulk reindex —
+	// as long as it serves the SAME e5 model (same vector space). Tests set it directly.
 	embedURL string
+	// embedKey is the optional bearer token for embedURL (EMBED_API_KEY). Empty for
+	// the authless host2 TEI; set when pointing at an authenticated endpoint (HF, etc.).
+	embedKey string
 }
 
 // NewClient connects to Meilisearch at url authenticated by key. It does no I/O
-// — the connection is exercised lazily by the first request (or EnsureIndex).
+// — the connection is exercised lazily by the first request (or EnsureIndex). The
+// embedding backend defaults to the host2 TEI but is overridable via EMBED_URL /
+// EMBED_API_KEY (see the embedURL field).
 func NewClient(url, key string) *Client {
 	m := meilisearch.New(url, meilisearch.WithAPIKey(key))
-	return &Client{manager: m, facet: m.Index(facetIndexUID), semantic: m.Index(semanticIndexUID), url: url, key: key, embedURL: embedderURL}
+	embedURL := embedderURL
+	if v := os.Getenv("EMBED_URL"); v != "" {
+		embedURL = v
+	}
+	return &Client{
+		manager:  m,
+		facet:    m.Index(facetIndexUID),
+		semantic: m.Index(semanticIndexUID),
+		url:      url,
+		key:      key,
+		embedURL: embedURL,
+		embedKey: os.Getenv("EMBED_API_KEY"),
+	}
 }
 
 // EnsureIndex creates the facet/keyword jobs index (no embedder) and applies its

--- a/internal/search/embed.go
+++ b/internal/search/embed.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 )
 
 // teiMaxBatch caps how many inputs go in one TEI /v1/embeddings call. TEI rejects a
@@ -33,24 +34,70 @@ func jobPassage(d JobDocument) string {
 	return "passage: " + d.Title + " at " + d.Company + ". " + body
 }
 
-// embedBatch turns texts into vectors by calling TEI's OpenAI-compatible
-// /v1/embeddings directly, in input order. We embed here and store the result as a
-// userProvided Meilisearch embedder (see jobEmbedder) rather than letting Meili's rest
-// embedder reach TEI itself: the engine rejects the loopback TEI URI, and embedding in
-// one place keeps the job corpus and the CV query on an identical path (one model, one
-// server → one vector space). Inputs are chunked to TEI's per-call batch limit.
+// embedBatch turns texts into vectors, in input order, by calling the embedding backend
+// (see embedChunk). We embed here and store the result as a userProvided Meilisearch
+// embedder (see jobEmbedder) rather than letting Meili's rest embedder reach the server
+// itself: the engine rejects the loopback TEI URI, and embedding in one place keeps the
+// job corpus and the CV query on an identical path (one model, one server → one vector
+// space). Inputs are chunked to the backend's per-call batch limit, and up to
+// embedConcurrency chunks run in flight — a remote GPU endpoint needs the concurrency to
+// hide per-call latency (the CPU-bound host2 TEI runs it at 1).
 func (c *Client) embedBatch(ctx context.Context, inputs []string) ([][]float64, error) {
-	out := make([][]float64, 0, len(inputs))
+	type span struct{ start, end int }
+	var chunks []span
 	for start := 0; start < len(inputs); start += teiMaxBatch {
 		end := start + teiMaxBatch
 		if end > len(inputs) {
 			end = len(inputs)
 		}
-		vecs, err := c.embedChunk(ctx, inputs[start:end])
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, vecs...)
+		chunks = append(chunks, span{start, end})
+	}
+
+	conc := c.embedConcurrency
+	if conc < 1 {
+		conc = 1
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Each chunk writes its vectors into its own slot, so the flattened result stays in
+	// input order regardless of completion order.
+	results := make([][][]float64, len(chunks))
+	sem := make(chan struct{}, conc)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+	for i, ch := range chunks {
+		wg.Add(1)
+		go func(i int, ch span) {
+			defer wg.Done()
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-sem }()
+			vecs, err := c.embedChunk(ctx, inputs[ch.start:ch.end])
+			if err != nil {
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+					cancel() // stop the remaining chunks on the first failure
+				}
+				mu.Unlock()
+				return
+			}
+			results[i] = vecs
+		}(i, ch)
+	}
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	out := make([][]float64, 0, len(inputs))
+	for _, r := range results {
+		out = append(out, r...)
 	}
 	return out, nil
 }

--- a/internal/search/embed.go
+++ b/internal/search/embed.go
@@ -17,11 +17,20 @@ const teiMaxBatch = 32
 // jobPassage renders a job document into the text embedded for semantic retrieval.
 // e5 is asymmetric: the corpus side carries the "passage:" prefix and the query side
 // carries "query:" (see EmbedText), so they must be embedded the same way to be
-// comparable. This mirrors the document template Meilisearch used to render, now that
-// embedding runs in Go (see embedBatch). doc.Description is already capped at index
-// time (maxIndexedDescriptionRunes), so this stays within e5's token window.
+// comparable.
+//
+// It prefers the enrichment summary over the raw description: the summary is a short,
+// model-written synopsis (capped well under e5's 512-token window) that captures the
+// whole role — including requirements a long description buries past the truncation
+// point — so it embeds the job more faithfully than the head-truncated description, and
+// its distilled form is closer to a CV query. Unenriched jobs fall back to the
+// description (already capped at maxIndexedDescriptionRunes).
 func jobPassage(d JobDocument) string {
-	return "passage: " + d.Title + " at " + d.Company + ". " + d.Description
+	body := d.Description
+	if s := d.Enrichment.Summary; s != "" {
+		body = s
+	}
+	return "passage: " + d.Title + " at " + d.Company + ". " + body
 }
 
 // embedBatch turns texts into vectors by calling TEI's OpenAI-compatible

--- a/internal/search/embed.go
+++ b/internal/search/embed.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -45,9 +46,14 @@ func (c *Client) embedBatch(ctx context.Context, inputs []string) ([][]float64, 
 	return out, nil
 }
 
-// embedChunk embeds one TEI-sized batch and returns the vectors in input order.
+// embedChunk embeds one TEI-sized batch and returns the vectors in input order. It
+// speaks TEI's native `/embed` shape — `{"inputs": [...]}` in, an array of vectors out
+// — which every backend we target accepts: the host2 TEI (/embed, bare array) and an
+// HF Inference Endpoint (root, `{"embeddings": [...]}`). Over-long inputs (e5 caps at
+// 512 tokens) are truncated server-side (host2 TEI's --auto-truncate; HF truncates by
+// default), so no per-input length handling is needed here.
 func (c *Client) embedChunk(ctx context.Context, inputs []string) ([][]float64, error) {
-	body, err := json.Marshal(map[string]any{"input": inputs, "model": embedderModel})
+	body, err := json.Marshal(map[string]any{"inputs": inputs})
 	if err != nil {
 		return nil, fmt.Errorf("search: embed marshal: %w", err)
 	}
@@ -56,6 +62,9 @@ func (c *Client) embedChunk(ctx context.Context, inputs []string) ([][]float64, 
 		return nil, fmt.Errorf("search: embed request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if c.embedKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.embedKey)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("search: embed call: %w", err)
@@ -64,25 +73,35 @@ func (c *Client) embedChunk(ctx context.Context, inputs []string) ([][]float64, 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("search: embed: unexpected status %d", resp.StatusCode)
 	}
-	var out struct {
-		Data []struct {
-			Embedding []float64 `json:"embedding"`
-		} `json:"data"`
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("search: embed read: %w", err)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, fmt.Errorf("search: embed decode: %w", err)
+	vecs, err := parseEmbeddings(raw)
+	if err != nil {
+		return nil, err
 	}
-	if len(out.Data) != len(inputs) {
-		return nil, fmt.Errorf("search: embed: got %d vectors for %d inputs", len(out.Data), len(inputs))
-	}
-	vecs := make([][]float64, len(out.Data))
-	for i, d := range out.Data {
-		if len(d.Embedding) == 0 {
-			return nil, fmt.Errorf("search: embed: empty vector at %d", i)
-		}
-		vecs[i] = d.Embedding
+	if len(vecs) != len(inputs) {
+		return nil, fmt.Errorf("search: embed: got %d vectors for %d inputs", len(vecs), len(inputs))
 	}
 	return vecs, nil
+}
+
+// parseEmbeddings decodes a TEI-style embeddings response, tolerating both the bare
+// array of vectors (`[[...], ...]`, TEI /embed) and the object form
+// (`{"embeddings": [[...], ...]}`, HF Inference Endpoints).
+func parseEmbeddings(raw []byte) ([][]float64, error) {
+	var bare [][]float64
+	if err := json.Unmarshal(raw, &bare); err == nil && len(bare) > 0 {
+		return bare, nil
+	}
+	var wrapped struct {
+		Embeddings [][]float64 `json:"embeddings"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && len(wrapped.Embeddings) > 0 {
+		return wrapped.Embeddings, nil
+	}
+	return nil, fmt.Errorf("search: embed: unrecognized response shape")
 }
 
 // semanticDocument is a JobDocument carrying its precomputed embedding for the

--- a/internal/search/embed_test.go
+++ b/internal/search/embed_test.go
@@ -11,16 +11,21 @@ import (
 )
 
 // jobPassage must prefix the corpus side with e5's "passage:" marker and weave in the
-// title/company/description, so it stays comparable to the "query:"-prefixed CV.
+// title/company/body, so it stays comparable to the "query:"-prefixed CV. It embeds the
+// description by default but prefers the enrichment summary when present.
 func TestJobPassage(t *testing.T) {
 	var d JobDocument
 	d.Title = "Backend Engineer"
 	d.Company = "Acme"
 	d.Description = "Go and Postgres"
-	got := jobPassage(d)
-	want := "passage: Backend Engineer at Acme. Go and Postgres"
-	if got != want {
-		t.Fatalf("jobPassage = %q, want %q", got, want)
+
+	if got, want := jobPassage(d), "passage: Backend Engineer at Acme. Go and Postgres"; got != want {
+		t.Fatalf("jobPassage (description) = %q, want %q", got, want)
+	}
+
+	d.Enrichment.Summary = "Senior Go role building payment APIs"
+	if got, want := jobPassage(d), "passage: Backend Engineer at Acme. Senior Go role building payment APIs"; got != want {
+		t.Fatalf("jobPassage (summary preferred) = %q, want %q", got, want)
 	}
 }
 

--- a/internal/search/embed_test.go
+++ b/internal/search/embed_test.go
@@ -24,28 +24,24 @@ func TestJobPassage(t *testing.T) {
 	}
 }
 
-// teiEcho is a stub TEI /v1/embeddings that returns, for each input, a one-element
-// vector holding the integer the input text parses to — so a test can assert both that
-// every input got its own vector and that order is preserved across chunk boundaries.
+// teiEcho is a stub TEI /embed that returns, for each input, a one-element vector
+// holding the integer the input text parses to — so a test can assert both that every
+// input got its own vector and that order is preserved across chunk boundaries. It
+// replies with the bare-array shape (as the host2 TEI /embed does).
 func teiEcho(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var in struct {
-			Input []string `json:"input"`
+			Inputs []string `json:"inputs"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		type item struct {
-			Embedding []float64 `json:"embedding"`
-		}
-		out := struct {
-			Data []item `json:"data"`
-		}{}
-		for _, s := range in.Input {
+		out := make([][]float64, 0, len(in.Inputs))
+		for _, s := range in.Inputs {
 			n, _ := strconv.Atoi(strings.TrimSpace(s))
-			out.Data = append(out.Data, item{Embedding: []float64{float64(n)}})
+			out = append(out, []float64{float64(n)})
 		}
 		_ = json.NewEncoder(w).Encode(out)
 	}))
@@ -82,9 +78,9 @@ func TestEmbedBatchChunksAndPreservesOrder(t *testing.T) {
 // not silently misalign vectors to jobs.
 func TestEmbedBatchRejectsCountMismatch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"data": []map[string]any{{"embedding": []float64{1}}}, // one vector regardless of input count
-		})
+		// One vector regardless of input count (wrapped/HF shape), to exercise the
+		// count-mismatch guard.
+		_ = json.NewEncoder(w).Encode(map[string]any{"embeddings": [][]float64{{1}}})
 	}))
 	defer srv.Close()
 	c := &Client{embedURL: srv.URL}

--- a/internal/search/embed_test.go
+++ b/internal/search/embed_test.go
@@ -58,9 +58,10 @@ func teiEcho(t *testing.T) *httptest.Server {
 func TestEmbedBatchChunksAndPreservesOrder(t *testing.T) {
 	srv := teiEcho(t)
 	defer srv.Close()
-	c := &Client{embedURL: srv.URL}
+	// Concurrency > 1 so chunks complete out of order — the result must still be ordered.
+	c := &Client{embedURL: srv.URL, embedConcurrency: 8}
 
-	n := teiMaxBatch*2 + 3 // spans three chunks
+	n := teiMaxBatch*5 + 3 // spans several chunks across the worker pool
 	inputs := make([]string, n)
 	for i := range inputs {
 		inputs[i] = strconv.Itoa(i)

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -31,29 +31,27 @@ import (
 	"github.com/strelov1/freehire/internal/enrich"
 )
 
-// fakeTEI stands in for the TEI embedding server: an OpenAI-compatible
-// /v1/embeddings that returns a deterministic bag-of-words vector per input, so texts
-// sharing tokens land near each other under cosine similarity. That is enough for the
-// semantic assertions (a query hits jobs whose text it overlaps) without a real model,
-// and keeps the userProvided vector width at embedderDimensions so Meili accepts it.
+// fakeTEI stands in for the embedding server, replying in the wrapped
+// {"embeddings": [...]} shape an HF Inference Endpoint uses. It returns a deterministic
+// bag-of-words vector per input, so texts sharing tokens land near each other under
+// cosine similarity — enough for the semantic assertions (a query hits jobs whose text
+// it overlaps) without a real model, and it keeps the vector width at
+// embedderDimensions so Meili accepts the userProvided vectors.
 func fakeTEI(t *testing.T) string {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var in struct {
-			Input []string `json:"input"`
+			Inputs []string `json:"inputs"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		type item struct {
-			Embedding []float64 `json:"embedding"`
-		}
-		var out struct {
-			Data []item `json:"data"`
-		}
-		for _, s := range in.Input {
-			out.Data = append(out.Data, item{Embedding: bagOfWords(s)})
+		out := struct {
+			Embeddings [][]float64 `json:"embeddings"`
+		}{}
+		for _, s := range in.Inputs {
+			out.Embeddings = append(out.Embeddings, bagOfWords(s))
 		}
 		_ = json.NewEncoder(w).Encode(out)
 	}))


### PR DESCRIPTION
Follow-up to #489 to make the CV-recommendation embeddings actually populate. Three changes, all on the embedding path:

1. **Configurable backend** — `EMBED_URL`/`EMBED_API_KEY` point a worker at a faster backend serving the same e5 model (default stays the host2 TEI). Switches to TEI's native `/embed` shape (`{"inputs":[...]}`), tolerating both the bare-array response (host2 TEI) and the wrapped `{"embeddings":[...]}` (HF Inference Endpoint). Over-long inputs truncate server-side.
2. **Summary passage** — prefer the model-written enrichment summary over the head-truncated description for the semantic passage (captures the whole role within e5's 512-token window; falls back to the description when unenriched).
3. **Concurrent embed** — `embedBatch` runs up to `EMBED_CONCURRENCY` chunks in flight (default 1). CPU-bound host2 TEI gains nothing, but a remote GPU endpoint does — measured ~20 → ~116 docs/s at concurrency 16. Order preserved, race-tested.

**Why:** host2's shared CPU embeds e5 at ~3 docs/s — a full reindex is impractical (~11 days). A GPU endpoint (same e5 model → same vector space) with concurrency makes it feasible (~hours), while per-request CV/query embedding stays on host2.

**Verify:** `go build/vet`, `go test -race ./internal/search/`, and the integration tests (real Meili + stub backend in the new response shape) all green. Both real backends (host2 TEI `/embed`, HF endpoint) confirmed accepting the exact request shape.