### PR TITLE
feat(web): related-role suggestions in the role picker

### DIFF
--- a/web/src/lib/components/facets/FacetSection.svelte
+++ b/web/src/lib/components/facets/FacetSection.svelte
@@ -82,6 +82,7 @@
       excludable={def.excludable}
       placeholder={def.placeholder}
       cap={def.cap}
+      related={def.related}
       {onToggle}
       {expand}
     />

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { uniqueByValue, type FacetOption } from '$lib/facets';
+  import { Plus } from '@lucide/svelte';
+  import { relatedOptions, uniqueByValue, type FacetOption } from '$lib/facets';
   import { fuzzyMatch } from '$lib/fuzzy';
   import { Input } from '$lib/ui';
   import { pillClass, pillTitle } from './pill';
@@ -20,6 +21,7 @@
     clearOnSelect = false,
     expand = false,
     cap,
+    related,
   }: {
     options: FacetOption[];
     include: string[];
@@ -38,6 +40,10 @@
     // distribution (role: hundreds of values) stays readable — the rest surface
     // as you type. Selected options always show. Unset = no cap.
     cap?: number;
+    // Curated base-slug → related-slug map. When set (role facet), a "Related"
+    // chip row appears under the list once a search narrows it, suggesting
+    // siblings the text search can't name (type "mobile" → iOS/Android chips).
+    related?: Record<string, string[]>;
   } = $props();
 
   let filter = $state('');
@@ -65,6 +71,21 @@
     capped ? matched.filter((o, i) => i < cap! || isSelected(o.value)) : matched,
   );
   const hiddenCount = $derived(capped ? matched.length - shown.length : 0);
+
+  // "Related" suggestions: only once a search narrows the list (an unfiltered
+  // picker would suggest everything). Sourced from what the search surfaced
+  // (`shown`), excluding anything already shown or selected — so the chips are
+  // specifically the siblings the text search couldn't reach.
+  const suggestions = $derived(
+    related && filter.trim()
+      ? relatedOptions(
+          uniqueByValue(options),
+          shown.map((o) => o.value),
+          [...include, ...exclude],
+          related,
+        )
+      : [],
+  );
 </script>
 
 <div class="flex flex-col gap-2">
@@ -88,5 +109,20 @@
   </div>
   {#if hiddenCount > 0}
     <span class="px-1 text-xs text-muted-foreground">+{hiddenCount.toLocaleString()} more — type to search</span>
+  {/if}
+  {#if suggestions.length > 0}
+    <div class="mt-1 flex flex-wrap items-center gap-1.5 border-t border-dashed border-border pt-2">
+      <span class="text-xs font-medium text-muted-foreground">Related</span>
+      {#each suggestions as opt (opt.value)}
+        <button
+          type="button"
+          onclick={() => toggle(opt.value)}
+          title="Add {opt.label}"
+          class="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-1 text-sm text-muted-foreground transition-colors hover:border-solid hover:bg-accent hover:text-foreground"
+        >
+          <Plus class="size-3" />{opt.label}{#if opt.count !== undefined}<span class="opacity-60 tabular-nums">{opt.count.toLocaleString()}</span>{/if}
+        </button>
+      {/each}
+    </div>
   {/if}
 </div>

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -22,6 +22,7 @@ import {
   CATEGORY_LABELS, DOMAIN_LABELS, COMPANY_TYPE_LABELS,
 } from './labels';
 import { COLLECTIONS } from './collections';
+import { ROLE_RELATED } from './roleRelated';
 import { api } from './api';
 
 export interface FacetOption {
@@ -89,6 +90,13 @@ export interface FacetDef {
    * dedicated endpoint instead of the Meili facet counts.
    */
   remote?: (query: string) => Promise<FacetOption[]>;
+  /**
+   * Curated adjacency map (base slug → related base slugs) driving a "Related"
+   * suggestion row under the picker — for surfacing siblings the text search
+   * can't name (typing "mobile" won't match "iOS Developer"). Only the role facet
+   * sets it; see relatedOptions / ROLE_RELATED.
+   */
+  related?: Record<string, string[]>;
 }
 
 // Resolve an ISO 3166-1 alpha-2 code to an English country name via platform Intl
@@ -176,6 +184,53 @@ export function dynamicLabel(param: string, value: string): string {
 export function uniqueByValue(opts: FacetOption[]): FacetOption[] {
   const seen = new Set<string>();
   return opts.filter((o) => (seen.has(o.value) ? false : seen.add(o.value)));
+}
+
+// Role slugs carry an optional seniority grade prefix (senior_backend); the
+// related-role map is keyed by the ungraded base (backend), so one entry serves
+// every grade. Longest prefix first is unnecessary — the grades share no
+// prefix among themselves — but drawing them from SENIORITY_VALUES keeps this in
+// lockstep with the roletag vocabulary.
+const gradePrefixes = SENIORITY_VALUES.map((s) => s + '_');
+
+/** Strip a leading seniority grade from a role slug: senior_mobile → mobile. An
+ *  ungraded slug (mobile, ios_developer, or a bare seniority like c_level) is
+ *  returned unchanged. */
+export function baseRole(slug: string): string {
+  for (const p of gradePrefixes) {
+    if (slug.startsWith(p)) return slug.slice(p.length);
+  }
+  return slug;
+}
+
+/** Suggestions for the role picker's "Related" row: for each currently-surfaced
+ *  role (`matched`), look up its base's curated relatives, keep only those that
+ *  have jobs in the current distribution (present in `options`) and aren't already
+ *  shown or selected, dedupe, and cap at `limit`. Pure so it's unit-testable; the
+ *  point is to surface siblings the text search can't ("mobile" never matches
+ *  "iOS Developer"). */
+export function relatedOptions(
+  options: FacetOption[],
+  matched: string[],
+  selected: string[],
+  related: Record<string, string[]>,
+  limit = 8,
+): FacetOption[] {
+  const byValue = new Map(options.map((o) => [o.value, o]));
+  const skip = new Set([...matched, ...selected]);
+  const seen = new Set<string>();
+  const out: FacetOption[] = [];
+  for (const v of matched) {
+    for (const slug of related[baseRole(v)] ?? []) {
+      if (skip.has(slug) || seen.has(slug)) continue;
+      const o = byValue.get(slug);
+      if (!o) continue;
+      seen.add(slug);
+      out.push(o);
+      if (out.length >= limit) return out;
+    }
+  }
+  return out;
 }
 
 /** A title-cased fallback label for a value with no explicit label. */
@@ -315,7 +370,7 @@ export const FACETS: FacetDef[] = [
   { param: 'collections', label: 'Collection', control: 'pills', options: COLLECTION, excludable: false },
   { param: 'regions', label: 'Region', control: 'pills', options: JOB_REGION, excludable: true },
   { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
-  { param: 'role', label: 'Role', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search roles', cap: 24 },
+  { param: 'role', label: 'Role', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search roles', cap: 24, related: ROLE_RELATED },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
   { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },
   { param: 'skills', label: 'Skills', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search skills' },

--- a/web/src/lib/relatedOptions.test.ts
+++ b/web/src/lib/relatedOptions.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { baseRole, relatedOptions, type FacetOption } from './facets';
+
+const opt = (value: string, count = 1): FacetOption => ({ value, label: value, count });
+
+describe('baseRole', () => {
+  it('strips a leading seniority grade', () => {
+    expect(baseRole('senior_mobile')).toBe('mobile');
+    expect(baseRole('lead_software_engineer')).toBe('software_engineer');
+    expect(baseRole('c_level_backend')).toBe('backend');
+  });
+  it('leaves an ungraded slug untouched', () => {
+    expect(baseRole('mobile')).toBe('mobile');
+    expect(baseRole('ios_developer')).toBe('ios_developer');
+    // c_level as a seniority-only role is not a graded prefix of itself.
+    expect(baseRole('c_level')).toBe('c_level');
+  });
+});
+
+describe('relatedOptions', () => {
+  const related = {
+    mobile: ['ios_developer', 'android_developer', 'react_native_developer'],
+    ios_developer: ['android_developer', 'mobile'],
+  };
+  // A full distribution the picker would have (values that actually have jobs).
+  const options = [
+    opt('mobile', 100),
+    opt('ios_developer', 40),
+    opt('android_developer', 30),
+    opt('react_native_developer', 10),
+  ];
+
+  it('suggests a hub role\'s relatives that the text search did not surface', () => {
+    // Typing "mobile" surfaces only "mobile"; its relatives are the payload.
+    const out = relatedOptions(options, ['mobile'], [], related);
+    expect(out.map((o) => o.value)).toEqual([
+      'ios_developer',
+      'android_developer',
+      'react_native_developer',
+    ]);
+  });
+
+  it('normalises a graded hub value to its base before lookup', () => {
+    const out = relatedOptions(options, ['senior_mobile'], [], related);
+    expect(out.map((o) => o.value)).toContain('ios_developer');
+  });
+
+  it('excludes relatives already shown (matched) or selected', () => {
+    // "ios_developer" is both matched and, say, selected — never re-suggested.
+    const out = relatedOptions(options, ['mobile', 'ios_developer'], ['android_developer'], related);
+    expect(out.map((o) => o.value)).toEqual(['react_native_developer']);
+  });
+
+  it('drops relatives absent from the distribution (no jobs → no label/count)', () => {
+    const sparse = [opt('mobile', 5), opt('ios_developer', 2)];
+    const out = relatedOptions(sparse, ['mobile'], [], related);
+    expect(out.map((o) => o.value)).toEqual(['ios_developer']);
+  });
+
+  it('dedupes when several matched hubs point at the same relative', () => {
+    const out = relatedOptions(options, ['mobile', 'ios_developer'], [], related);
+    // android_developer is a relative of both mobile and ios_developer — once only.
+    expect(out.filter((o) => o.value === 'android_developer')).toHaveLength(1);
+  });
+
+  it('returns nothing when no matched value is a hub', () => {
+    expect(relatedOptions(options, ['android_developer'], [], {})).toEqual([]);
+  });
+
+  it('honours the limit', () => {
+    const out = relatedOptions(options, ['mobile'], [], related, 2);
+    expect(out).toHaveLength(2);
+  });
+});

--- a/web/src/lib/roleRelated.ts
+++ b/web/src/lib/roleRelated.ts
@@ -1,0 +1,54 @@
+// Curated adjacency map for the role picker's "Related" suggestions: a hub role
+// (keyed by its seniority-stripped base slug) → sibling/child roles a searcher
+// probably also wants but whose names the text search would NOT surface (typing
+// "mobile" never matches "iOS Developer"). It's a hand-curated dictionary, not an
+// inferred graph — same "never guess" discipline as the roletag/skilltag
+// dictionaries. Every slug here must exist in the ROLE_LABELS catalog; a
+// suggestion only renders when the role also has jobs in the current distribution
+// (see relatedOptions in facets.ts), so a stale entry is inert, never broken.
+//
+// Keys and values are BASE slugs (no senior_/lead_/… prefix); the picker strips a
+// value's grade before lookup, so one entry serves every seniority of the hub.
+export const ROLE_RELATED: Record<string, string[]> = {
+  // Mobile: the coarse "mobile" bucket rarely surfaces the platform specialisations.
+  mobile: ['ios_developer', 'android_developer', 'react_native_developer', 'flutter_developer'],
+  ios_developer: ['android_developer', 'react_native_developer', 'flutter_developer', 'mobile'],
+  android_developer: ['ios_developer', 'react_native_developer', 'flutter_developer', 'mobile'],
+  react_native_developer: ['ios_developer', 'android_developer', 'flutter_developer', 'mobile'],
+  flutter_developer: ['ios_developer', 'android_developer', 'react_native_developer', 'mobile'],
+
+  // Web engineering: the split a "developer" search flattens.
+  backend: ['fullstack', 'frontend', 'software_engineer'],
+  frontend: ['fullstack', 'backend', 'software_engineer'],
+  fullstack: ['backend', 'frontend', 'software_engineer'],
+  software_engineer: ['backend', 'frontend', 'fullstack'],
+
+  // Data / ML: adjacent-but-distinctly-named specialisations.
+  data_science: ['ml_ai', 'data_engineering', 'data_analytics', 'ai_engineering'],
+  data_analytics: ['data_science', 'data_engineering', 'business_analyst'],
+  data_engineering: ['data_science', 'data_platform_engineer', 'ml_ai'],
+  ml_ai: ['ai_engineering', 'data_science', 'mlops_engineer'],
+  ai_engineering: ['ml_ai', 'prompt_engineer', 'data_science'],
+
+  // Infra: "devops" hides the SRE/platform/cloud family.
+  devops: ['sre', 'platform_engineer', 'cloud_engineer', 'infrastructure_engineer'],
+  sre: ['devops', 'platform_engineer', 'infrastructure_engineer'],
+  platform_engineer: ['devops', 'sre', 'cloud_engineer'],
+  cloud_engineer: ['devops', 'platform_engineer', 'cloud_architect'],
+
+  // Security & architecture: named sub-disciplines a broad term won't match.
+  security: ['cybersecurity_engineer'],
+  architecture: ['solutions_architect', 'software_architect', 'cloud_architect', 'data_architect', 'enterprise_architect'],
+  solutions_architect: ['software_architect', 'cloud_architect', 'enterprise_architect'],
+
+  // Design / product / management: cross-name siblings.
+  design: ['product_designer', 'ux_designer'],
+  product: ['product_designer', 'business_analyst'],
+  management: ['engineering_manager', 'team_lead', 'director', 'scrum_master'],
+  engineering_manager: ['team_lead', 'director', 'management'],
+  team_lead: ['engineering_manager', 'scrum_master'],
+
+  // Go-to-market: sales/marketing sub-roles.
+  sales: ['account_executive', 'account_manager'],
+  marketing: ['growth_marketer', 'seo_specialist'],
+};


### PR DESCRIPTION
## What

When a role search narrows the picker, a curated **"Related"** chip row appears under the list, suggesting sibling roles the text search can't name — typing **"mobile"** surfaces **iOS · Android · React Native · Flutter** chips; clicking a chip adds it (ORs into the include set).

This is the "chips suggest, click to add" UX approved for the role facet: the text search finds what you *name*, related chips surface what you *mean* but a keyword won't match.

## How

- **`ROLE_RELATED`** (`web/src/lib/roleRelated.ts`) — a curated base-slug → related-slug adjacency map (mobile→ios/android/rn/flutter, devops→sre/platform/cloud/infra, data_science→ml_ai/data_eng/analytics, …). Hand-curated, "never guess", same discipline as the roletag/skilltag dictionaries. Every slug verified against `ROLE_LABELS`.
- **`relatedOptions` / `baseRole`** (`facets.ts`) — pure, unit-tested. `baseRole` strips the seniority grade (senior_mobile→mobile) so one map entry serves every grade; `relatedOptions` only suggests roles that (a) exist in the current distribution (have jobs) and (b) aren't already shown or selected — so chips are exactly the siblings the search couldn't reach. Deduped, capped.
- **`SearchSelect`** — renders the row, gated on a non-empty filter (an unfiltered picker would suggest everything). **`FacetSection`** threads `def.related` through. Only the role facet sets `related`.

## Verification

- `relatedOptions.test.ts` — 9 cases (base-slug stripping, hub lookup, exclude shown/selected, drop-if-no-jobs, dedupe, limit).
- `npm run check` — 0 errors / 0 warnings; `vitest run` — 54 passed; `npm run build` — clean.
- Frontend-only, additive, **no reindex**.

Note: CI backend integration `hybrid_search` is red on an unrelated concurrent semantic-embedder migration — this PR touches no backend/search code.