### PR TITLE
feat(sources): add eArcu ATS source adapter

### DIFF
--- a/internal/sources/earcu.go
+++ b/internal/sources/earcu.go
@@ -1,0 +1,145 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// earcu adapts an eArcu career site. eArcu is a multi-tenant UK ATS whose clients each run
+// on their own careers host and publish a keyless RSS feed at /jobs/rss. Each feed item
+// carries the full posting body inline (a "Key: value, …" metadata prefix followed by a
+// <div id="rssjobdesc"> body), so no per-posting request is needed in the common case; when
+// an item has no inline body the adapter falls back to the detail page's schema.org
+// JobPosting JSON-LD. Unlike Personio the board is the full careers host, not a subdomain.
+//
+// earcuHTTP is the transport earcu needs: an RSS feed plus HTML detail pages.
+type earcuHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+type earcu struct {
+	http earcuHTTP
+}
+
+// NewEarcu builds the eArcu adapter over the given HTTP client.
+func NewEarcu(c earcuHTTP) Source { return earcu{http: c} }
+
+func (earcu) Provider() string { return "earcu" }
+
+// earcuRSS is a board's /jobs/rss document. Only the fields the adapter maps are decoded.
+type earcuRSS struct {
+	Items []earcuItem `xml:"channel>item"`
+}
+
+type earcuItem struct {
+	Link        string `xml:"link"`
+	Title       string `xml:"title"`
+	Description string `xml:"description"`
+	PubDate     string `xml:"pubDate"`
+}
+
+// earcuIDRe extracts the stable posting id from a vacancy detail URL of the form
+// /jobs/vacancy/<slug>/<id>/description/. Anchored on the final /description so an
+// earlier numeric path segment can't be mistaken for the id.
+var earcuIDRe = regexp.MustCompile(`/(\d+)/description/?$`)
+
+// earcuRefRe matches the trailing " (<ref>)" eArcu reference suffix in a feed title.
+var earcuRefRe = regexp.MustCompile(`\s*\(\d+\)\s*$`)
+
+// earcuLocationRe pulls the Location value out of the metadata prefix; the prefix always
+// ends the Location field with ", eArcu Vacancy Reference:", so this tolerates commas inside
+// earlier fields (e.g. a thousands-separated salary).
+var earcuLocationRe = regexp.MustCompile(`Location:\s*(.+?),\s*eArcu Vacancy Reference:`)
+
+// earcuCountryRe is the fallback when a feed carries no Location field.
+var earcuCountryRe = regexp.MustCompile(`Country:\s*([^,]+)`)
+
+func (a earcu) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	url := fmt.Sprintf("https://%s/jobs/rss", e.Board)
+
+	var feed earcuRSS
+	if err := a.http.GetXML(ctx, url, &feed); err != nil {
+		return nil, fmt.Errorf("earcu: fetch board %s: %w", e.Board, err)
+	}
+
+	jobs := make([]Job, 0, len(feed.Items))
+	for _, it := range feed.Items {
+		m := earcuIDRe.FindStringSubmatch(it.Link)
+		if m == nil {
+			continue // no stable posting id — skip rather than emit an empty key
+		}
+		prefix, body := earcuSplit(it.Description)
+		location := earcuLocation(prefix)
+		description := sanitizeHTML(body)
+		if description == "" {
+			description = a.detailDescription(ctx, it.Link)
+		}
+		jobs = append(jobs, Job{
+			ExternalID:  m[1],
+			URL:         it.Link,
+			Title:       strings.TrimSpace(earcuRefRe.ReplaceAllString(it.Title, "")),
+			Company:     e.Company,
+			Location:    location,
+			Description: description,
+			Remote:      isRemote(location), // the feed has no structured remote flag
+			PostedAt:    earcuPubDate(it.PubDate),
+		})
+	}
+	return jobs, nil
+}
+
+// earcuLocation returns the posting's location from the feed item's metadata prefix,
+// preferring the Location field and falling back to Country; empty when neither is present.
+func earcuLocation(desc string) string {
+	if m := earcuLocationRe.FindStringSubmatch(desc); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	if m := earcuCountryRe.FindStringSubmatch(desc); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+// earcuSplit divides a feed item's description into the metadata prefix (the leading
+// "Key: value, …" text) and the inline body (the rssjobdesc block, "" when absent).
+// Splitting once keeps location parsing off the HTML body, where a stray "Country:"/
+// "Location:" in the posting text would otherwise be mistaken for metadata.
+func earcuSplit(desc string) (prefix, body string) {
+	if i := strings.Index(desc, `<div id="rssjobdesc"`); i >= 0 {
+		return desc[:i], desc[i:]
+	}
+	return desc, ""
+}
+
+// detailDescription fetches a posting's detail page and returns its schema.org JobPosting
+// body, sanitized; "" when the page fetch fails or carries no such block.
+func (a earcu) detailDescription(ctx context.Context, url string) string {
+	root, err := a.http.GetHTML(ctx, url)
+	if err != nil {
+		return ""
+	}
+	var ld struct {
+		Description string `json:"description"`
+	}
+	if !ldJobPosting(root, &ld) || ld.Description == "" {
+		return ""
+	}
+	return sanitizeHTML(html.UnescapeString(ld.Description))
+}
+
+// earcuPubDate parses an eArcu feed pubDate. eArcu emits an RFC822 date whose zone is a
+// literal "Z" (UTC), sometimes with an unpadded day, so the primary layout uses a
+// numeric-offset zone (which also accepts an explicit +hhmm) and an unpadded day; a feed
+// using a named zone (GMT/MST) falls back to the standard RFC1123 forms.
+func earcuPubDate(s string) *time.Time {
+	if t := parseLayout("Mon, 2 Jan 2006 15:04:05 Z0700", s); t != nil {
+		return t
+	}
+	return parsePubDate(s)
+}

--- a/internal/sources/earcu_test.go
+++ b/internal/sources/earcu_test.go
@@ -1,0 +1,220 @@
+package sources
+
+import (
+	"context"
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+func TestEarcuProvider(t *testing.T) {
+	if got := NewEarcu(nil).Provider(); got != "earcu" {
+		t.Errorf("Provider() = %q, want %q", got, "earcu")
+	}
+}
+
+// earcuFeed is a minimal two-item eArcu RSS document plus one item whose link carries no
+// posting id (must be dropped). The description mirrors the live feed: a "Key: value, …"
+// metadata prefix followed by the escaped rssjobdesc body.
+const earcuFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <title>Jobs at Cambridge</title>
+  <link>https://careers.cambridge.org/jobs/</link>
+  <item>
+    <guid isPermaLink="true">https://careers.cambridge.org/jobs/vacancy/transfer-pricing-manager-cambridge/7384/description/</guid>
+    <link>https://careers.cambridge.org/jobs/vacancy/transfer-pricing-manager-cambridge/7384/description/</link>
+    <title>Transfer Pricing Manager (7367)</title>
+    <description>Country: UK, Business Unit: Finance, Salary: &#163;75,300-&#163;90,000, Location: Cambridge, eArcu Vacancy Reference: 7367&lt;div id="rssjobdesc"&gt;Job Title: Transfer Pricing Manager&lt;br /&gt;Build the finance pipeline.&lt;/div&gt;</description>
+    <pubDate>Tue, 07 Jul 2026 15:53:15 Z</pubDate>
+  </item>
+  <item>
+    <guid isPermaLink="true">https://careers.cambridge.org/jobs/vacancy/senior-go-engineer-remote/7375/description/</guid>
+    <link>https://careers.cambridge.org/jobs/vacancy/senior-go-engineer-remote/7375/description/</link>
+    <title>Senior Go Engineer (7358)</title>
+    <description>Country: UK, Location: Remote, eArcu Vacancy Reference: 7358&lt;div id="rssjobdesc"&gt;Work from anywhere.&lt;/div&gt;</description>
+    <pubDate>Mon, 06 Jul 2026 09:00:00 Z</pubDate>
+  </item>
+  <item>
+    <guid isPermaLink="true">https://careers.cambridge.org/jobs/</guid>
+    <link>https://careers.cambridge.org/jobs/</link>
+    <title>No id here</title>
+    <description>Location: Cambridge, eArcu Vacancy Reference: 0&lt;div id="rssjobdesc"&gt;x&lt;/div&gt;</description>
+    <pubDate>Mon, 06 Jul 2026 09:00:00 Z</pubDate>
+  </item>
+</channel></rss>`
+
+func TestEarcuFetch(t *testing.T) {
+	fake := &fakeHTTP{body: earcuFeed}
+
+	jobs, err := NewEarcu(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Cambridge University Press & Assessment", Provider: "earcu", Board: "careers.cambridge.org",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fake.gotURL, "careers.cambridge.org/jobs/rss") {
+		t.Errorf("requested URL %q should target the board rss feed", fake.gotURL)
+	}
+	// The third item has no posting id in its link and must be dropped.
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (id-less item dropped)", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "7384" {
+		t.Errorf("ExternalID = %q, want the id from the URL path", j.ExternalID)
+	}
+	if j.Title != "Transfer Pricing Manager" {
+		t.Errorf("Title = %q, want the reference suffix stripped", j.Title)
+	}
+	if j.Company != "Cambridge University Press & Assessment" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.URL != "https://careers.cambridge.org/jobs/vacancy/transfer-pricing-manager-cambridge/7384/description/" {
+		t.Errorf("URL = %q, want the item link", j.URL)
+	}
+	if j.Location != "Cambridge" {
+		t.Errorf("Location = %q, want the metadata Location value", j.Location)
+	}
+	if !strings.Contains(j.Description, "Build the finance pipeline.") {
+		t.Errorf("Description missing the inline body, got %q", j.Description)
+	}
+	if strings.Contains(j.Description, "Country:") {
+		t.Errorf("Description should be the rssjobdesc body only, not the metadata prefix: %q", j.Description)
+	}
+	if j.Remote {
+		t.Error("Remote = true for a Cambridge location, want false")
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want the parsed pubDate (2026)", j.PostedAt)
+	}
+	if !jobs[1].Remote {
+		t.Error("second job Location=Remote should set Remote=true")
+	}
+}
+
+// earcuRouted is a fake that returns the RSS feed for GetXML and a separate detail HTML
+// body (or error) for GetHTML, so the JSON-LD body fallback and its failure path can be
+// exercised.
+type earcuRouted struct {
+	feed      string
+	detail    string
+	detailErr error
+}
+
+func (f *earcuRouted) GetXML(_ context.Context, _ string, v any) error {
+	return xml.Unmarshal([]byte(f.feed), v)
+}
+
+func (f *earcuRouted) GetHTML(_ context.Context, _ string) (*html.Node, error) {
+	if f.detailErr != nil {
+		return nil, f.detailErr
+	}
+	return html.Parse(strings.NewReader(f.detail))
+}
+
+func TestEarcuDetailFallback(t *testing.T) {
+	// Feed item with no rssjobdesc body → adapter must fetch the detail page's JobPosting.
+	feed := `<?xml version="1.0"?><rss version="2.0"><channel>
+  <item>
+    <link>https://careers.cambridge.org/jobs/vacancy/no-body-role/7400/description/</link>
+    <title>No Body Role (7399)</title>
+    <description>Country: UK, Location: London, eArcu Vacancy Reference: 7399</description>
+    <pubDate>Tue, 07 Jul 2026 15:53:15 Z</pubDate>
+  </item>
+</channel></rss>`
+	detail := `<html><head>
+    <script type="application/ld+json">{"@type":"JobPosting","description":"<p>Detail body from JSON-LD.</p>"}</script>
+    </head><body></body></html>`
+
+	jobs, err := NewEarcu(&earcuRouted{feed: feed, detail: detail}).Fetch(context.Background(), CompanyEntry{
+		Company: "Cambridge", Provider: "earcu", Board: "careers.cambridge.org",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if !strings.Contains(jobs[0].Description, "Detail body from JSON-LD.") {
+		t.Errorf("Description = %q, want the JSON-LD fallback body", jobs[0].Description)
+	}
+}
+
+// TestEarcuLocation covers the metadata-prefix parsing: a comma-bearing Location value,
+// the Country fallback when Location is absent, and that a stray "Country:" in the HTML
+// body never leaks into the location (parsing is scoped to the prefix).
+func TestEarcuLocation(t *testing.T) {
+	feed := `<?xml version="1.0"?><rss version="2.0"><channel>
+  <item>
+    <link>https://careers.cambridge.org/jobs/vacancy/multi-part/201/description/</link>
+    <title>Multi Part (200)</title>
+    <description>Country: UK, Location: London, UK, eArcu Vacancy Reference: 200&lt;div id="rssjobdesc"&gt;Body.&lt;/div&gt;</description>
+    <pubDate>Tue, 07 Jul 2026 15:53:15 Z</pubDate>
+  </item>
+  <item>
+    <link>https://careers.cambridge.org/jobs/vacancy/country-only/203/description/</link>
+    <title>Country Only (202)</title>
+    <description>Country: UK, eArcu Vacancy Reference: 202&lt;div id="rssjobdesc"&gt;Country: Ireland is mentioned in the body.&lt;/div&gt;</description>
+    <pubDate>Tue, 07 Jul 2026 15:53:15 Z</pubDate>
+  </item>
+</channel></rss>`
+
+	jobs, err := NewEarcu(&earcuRouted{feed: feed}).Fetch(context.Background(), CompanyEntry{
+		Company: "Cambridge", Provider: "earcu", Board: "careers.cambridge.org",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2", len(jobs))
+	}
+	if jobs[0].Location != "London, UK" {
+		t.Errorf("Location = %q, want the full comma-bearing value %q", jobs[0].Location, "London, UK")
+	}
+	if jobs[1].Location != "UK" {
+		t.Errorf("Location = %q, want the Country fallback %q (body 'Country: Ireland' must not leak)", jobs[1].Location, "UK")
+	}
+}
+
+// TestEarcuDetailFetchFailureNonFatal asserts a body-less item whose detail fetch fails is
+// still emitted (empty description), not dropped and not aborting the board.
+func TestEarcuDetailFetchFailureNonFatal(t *testing.T) {
+	feed := `<?xml version="1.0"?><rss version="2.0"><channel>
+  <item>
+    <link>https://careers.cambridge.org/jobs/vacancy/no-body/300/description/</link>
+    <title>No Body (299)</title>
+    <description>Location: London, eArcu Vacancy Reference: 299</description>
+    <pubDate>Tue, 07 Jul 2026 15:53:15 Z</pubDate>
+  </item>
+</channel></rss>`
+
+	jobs, err := NewEarcu(&earcuRouted{feed: feed, detailErr: context.DeadlineExceeded}).Fetch(context.Background(), CompanyEntry{
+		Company: "Cambridge", Provider: "earcu", Board: "careers.cambridge.org",
+	})
+	if err != nil {
+		t.Fatalf("Fetch should not fail when a detail fetch errors: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (item kept despite detail-fetch failure)", len(jobs))
+	}
+	if jobs[0].Description != "" {
+		t.Errorf("Description = %q, want empty after a failed detail fetch", jobs[0].Description)
+	}
+}
+
+// TestEarcuPubDateUnpadded covers an unpadded RFC822 day, which the padded RFC1123 layouts
+// reject; the adapter's primary layout must still parse it.
+func TestEarcuPubDateUnpadded(t *testing.T) {
+	if got := earcuPubDate("Fri, 3 Jul 2026 09:00:00 Z"); got == nil || got.UTC().Day() != 3 {
+		t.Errorf("earcuPubDate(unpadded day) = %v, want a parsed 2026-07-03", got)
+	}
+}
+
+func TestEarcuRegisteredInAll(t *testing.T) {
+	if _, ok := All(nil)["earcu"]; !ok {
+		t.Error("earcu adapter not registered in All")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -192,6 +192,7 @@ func All(c HTTPClient) map[string]Source {
 		NewOracle(c),
 		NewEightfold(c),
 		NewFreshteam(c),
+		NewEarcu(c),
 		NewDeel(c),
 		NewVouch(c),
 		NewRecruitingSolutions(c),

--- a/openspec/changes/earcu-source-adapter/.openspec.yaml
+++ b/openspec/changes/earcu-source-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/earcu-source-adapter/design.md
+++ b/openspec/changes/earcu-source-adapter/design.md
@@ -1,0 +1,74 @@
+## Context
+
+eArcu is a UK multi-tenant ATS whose clients each run on a custom careers host
+(`careers.<company>.com`) and expose a keyless RSS feed at `/jobs/rss`. A live probe of
+`careers.cambridge.org/jobs/rss` returns a valid RSS 2.0 document (38 `<item>`s) where each
+item carries:
+
+- `<title>` — e.g. `Transfer Pricing Manager (7367)` (trailing `(ref)` is the eArcu reference)
+- `<link>` / `<guid>` — the detail URL `https://<host>/jobs/vacancy/<slug>/<id>/description/`
+- `<pubDate>` — RFC1123-style timestamp (`Tue, 07 Jul 2026 15:53:15 Z`)
+- `<description>` — a `Key: value, …` prefix (`Country: UK, … Salary: £…, Location: Cambridge,
+  eArcu Vacancy Reference: 7367`) **followed by the full posting body** inside a
+  `<div id="rssjobdesc">…</div>` (HTML-escaped in the feed)
+
+Detail pages additionally embed a schema.org `JobPosting` JSON-LD block, so the existing
+`ldJobPosting`/`sanitizeHTML` helpers give a clean fallback body. This maps almost exactly
+onto the existing **Personio** adapter (XML feed with inline body + JSON-LD detail fallback);
+eArcu differs only in that the board is the full host rather than a subdomain slug.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One keyless feed request per board yields all open postings with inline bodies.
+- Reuse existing transport (`XMLGetter` + `HTMLGetter`) and helpers (`sanitizeHTML`,
+  `ldJobPosting`, `parseRFC…`, `isRemote`) — no new HTTP-client capability.
+- Stable dedup identity from the posting id in the detail URL.
+- Ship a `sources/earcu.yml` seeded only with **live-validated** hosts.
+
+**Non-Goals:**
+- Bulk harvest of the full eArcu customer roster (follow-up discovery; this change seeds
+  what validates live, starting from `careers.cambridge.org`).
+- Structured facet extraction (WorkMode/Seniority/Category/Skills) from the feed's
+  `Key: value` prefix — left empty so the pipeline's dictionaries decide, matching Personio.
+- Applicant-side flows; the adapter is read-only over the public feed.
+
+## Decisions
+
+- **Provider key `earcu`, board = full careers host.** `Fetch` builds `https://<board>/jobs/rss`.
+  The board is the host verbatim (e.g. `careers.cambridge.org`), so the adapter is
+  board-based (not boardless) and multi-tenant — it lists in the source facet with no extra
+  wiring. Config validation already requires a board for non-boardless providers.
+- **RSS parse via `GetXML`.** Decode `<rss><channel><item>` with a struct mirroring the
+  fields above. `pubDate` → `PostedAt` (parse RFC1123 with a `Z`-zone tolerance; nil on
+  failure, never fatal).
+- **ExternalID from the URL path.** Regex the `/vacancy/<slug>/<id>/description/` id out of
+  `<link>`. Drop items with no extractable id (spec: never emit an empty key). Prefer the URL
+  id over the `eArcu Vacancy Reference` in the description, because the URL id is what
+  identifies the posting page.
+- **Location from the description prefix.** Parse `Location: …` (and fall back to `Country: …`)
+  out of the `Key: value` prefix that precedes `rssjobdesc`. Feed `Remote`/`WorkMode` stays
+  heuristic-free: leave `WorkMode` empty and set `Remote` only via the shared `isRemote`
+  location heuristic, so provenance stays clean (matches Personio).
+- **Body: feed-first, detail JSON-LD fallback.** Extract the `<div id="rssjobdesc">` inner
+  HTML from the (unescaped) description and `sanitizeHTML` it. If empty, GET the detail URL
+  and use its `JobPosting` JSON-LD `description`; a failed detail fetch is non-fatal.
+- **Title cleanup.** Strip a trailing ` (\d+)` reference suffix so titles read cleanly; keep
+  the rest verbatim.
+- **Transport interface.** Define `earcuHTTP interface { XMLGetter; HTMLGetter }` and
+  `NewEarcu(c earcuHTTP) Source`, mirroring `personioHTTP`/`NewPersonio`. Tests use the
+  existing `fakeHTTP` (which already implements both).
+
+## Risks / Trade-offs
+
+- **Single confirmed host at ship time.** Only `careers.cambridge.org` is verified so far;
+  the seed file's value scales with host discovery. Accepted: the adapter is correct and
+  reusable now, and the roster grows as follow-up harvest validates more hosts (same path
+  every other adapter took). Each host is validated live before it enters `earcu.yml`.
+- **Feed markup drift.** The inline body lives in a `rssjobdesc` div and the metadata in a
+  `Key: value` prefix — both eArcu conventions that could change. The JSON-LD detail fallback
+  hedges the body; location parsing degrades gracefully (empty location, never a crash).
+- **Custom-domain edge protection.** eArcu hosts sit behind Cloudflare; the default Go
+  fingerprint reached `careers.cambridge.org` fine, so we start on the standard shared client
+  and only escalate to the Chrome-fingerprint transport (as bayt/EPAM do) if a probed host
+  returns 403. Recorded as a per-host validation step, not pre-emptive complexity.

--- a/openspec/changes/earcu-source-adapter/proposal.md
+++ b/openspec/changes/earcu-source-adapter/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+eArcu is a multi-tenant UK ATS behind the career sites of large employers (Cambridge University Press & Assessment, plus a documented roster including BP, Asda, British Airways, FirstGroup, Flutter, the Football Association, Virgin Active, CVS Group, Cromwell Tools). We currently ingest none of them: eArcu clients run on their own custom domains (`careers.<company>.com`), so their vacancies are invisible to every existing adapter. Each eArcu site publishes a keyless `/jobs/rss` feed with the full posting body inline, so the platform is cleanly crawlable and worth a dedicated adapter (multi-tenant + keyless + structured — the same bar the other ATS adapters clear).
+
+## What Changes
+
+- Add an `earcu` source adapter (`internal/sources/earcu.go`) implementing the `Source` interface: fetch a board's keyless `/jobs/rss` feed, parse each `<item>` into a `Job` (title, posting URL, external id, location, posting date, description body), and fall back to the detail page's schema.org `JobPosting` JSON-LD when a feed item's body is empty.
+- Register it in `sources.All` (one line) so `cmd/ingest` and config validation recognise the `earcu` provider.
+- Seed `sources/earcu.yml` with verified eArcu career hosts (board = the full careers host, e.g. `careers.cambridge.org`), each validated live before inclusion.
+- eArcu is board-based and multi-tenant (not boardless), so it lists in the source facet with no extra wiring — like greenhouse/personio.
+
+## Capabilities
+
+### New Capabilities
+- `earcu-source`: crawl a per-company eArcu career site via its keyless `/jobs/rss` feed (board = careers host) and normalize its open vacancies into the job catalogue, with detail-page JSON-LD as a body fallback.
+
+### Modified Capabilities
+<!-- None: this is an additive adapter behind the existing Source interface and registry; no existing spec's requirements change. -->
+
+## Impact
+
+- **New code:** `internal/sources/earcu.go` (+ `earcu_test.go`), one registration line in `internal/sources/source.go`, new board file `sources/earcu.yml`.
+- **No schema/API changes:** the adapter emits the same `sources.Job` shape every other adapter does; ingest, dedup, enrichment, and search are unchanged.
+- **Ops:** a new board file means a new `cmd/ingest sources/earcu.yml` cron entry (added the same way as every other provider file).
+- **Reuses existing transport:** `XMLGetter` (RSS) + `HTMLGetter` (JSON-LD detail fallback) and the shared `sanitizeHTML` / `ldJobPosting` helpers — no new HTTP-client capability.
+- **Known seam (out of scope):** bulk harvest of the full eArcu customer roster. This change seeds only live-validated hosts; expanding the roster is follow-up discovery work, mirroring how other adapters shipped with a seed and grew later.

--- a/openspec/changes/earcu-source-adapter/specs/earcu-source/spec.md
+++ b/openspec/changes/earcu-source-adapter/specs/earcu-source/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: eArcu per-company RSS crawl
+
+The system SHALL provide an `earcu` source adapter that crawls a single eArcu career
+site into the catalogue. The adapter is **board-based and single-company**: each
+configured entry's board is the full careers host (e.g. `careers.cambridge.org`), and
+the company is the configured `company`. For each configured board the adapter fetches
+the keyless RSS feed at `https://<board>/jobs/rss` and returns one `Job` per feed
+`<item>`. The crawl is keyless (no API key) and issues one feed request per board — the
+full posting body is inline in the feed, so no per-posting request is required in the
+common case.
+
+#### Scenario: Board yields all feed items
+
+- **WHEN** the adapter fetches a configured board
+- **THEN** it returns one `Job` per `<item>` in that board's `/jobs/rss` feed, each
+  populated with title, posting/detail URL, external id, free-text location, posted-at,
+  and an HTML description
+
+#### Scenario: Board host is used verbatim
+
+- **WHEN** an entry's board is a careers host such as `careers.cambridge.org`
+- **THEN** the adapter requests `https://careers.cambridge.org/jobs/rss` (the board is
+  the host, not a subdomain slug), and the configured `company` is the job's company
+
+### Requirement: Description body with detail-page fallback
+
+The adapter SHALL take each job's description from the feed item — eArcu embeds the full
+posting body as HTML inside the item's `<description>` (the `rssjobdesc` block) — and
+sanitize it. WHEN a feed item carries no usable body, the adapter MUST fall back to the
+posting detail page's schema.org `JobPosting` JSON-LD `description`, reusing the shared
+`ldJobPosting`/`sanitizeHTML` helpers. A posting that yields no body from either source
+is still returned (title/URL/location are sufficient), not dropped.
+
+#### Scenario: Body comes from the feed
+
+- **WHEN** a feed item's `<description>` contains the inline posting body
+- **THEN** that body is sanitized into the job's description without any detail-page
+  request
+
+#### Scenario: Empty feed body falls back to detail JSON-LD
+
+- **WHEN** a feed item has no inline body
+- **THEN** the adapter fetches the item's detail URL and uses its `JobPosting` JSON-LD
+  `description`; a failed detail fetch is non-fatal and leaves the description empty
+
+### Requirement: Stable dedup identity
+
+The adapter SHALL derive each job's `ExternalID` from the stable eArcu posting id — the
+numeric id in the detail URL path (`/jobs/vacancy/<slug>/<id>/description/`) — so
+re-crawling the same board dedups to the same catalogue row. A feed item whose link has
+no extractable posting id is dropped rather than persisted with an empty key.
+
+#### Scenario: Re-crawl dedups
+
+- **WHEN** the same posting appears on a later crawl
+- **THEN** it maps to the same `ExternalID` and updates the existing row rather than
+  creating a duplicate
+
+#### Scenario: Item without an id is dropped
+
+- **WHEN** a feed item's link has no extractable posting id
+- **THEN** the adapter omits that item rather than emitting a job with an empty
+  `ExternalID`
+
+### Requirement: Registered board-based provider
+
+The adapter MUST be registered in `sources.All` under the provider key `earcu` and be
+board-based (not boardless), so `cmd/ingest` and config validation recognise it, board
+files require a board id, and it appears in the source facet like the other ATS adapters.
+
+#### Scenario: Provider is recognised by config validation
+
+- **WHEN** a board file names provider `earcu` with a board host
+- **THEN** config validation accepts it, and an `earcu` entry that omits its board is
+  rejected

--- a/openspec/changes/earcu-source-adapter/tasks.md
+++ b/openspec/changes/earcu-source-adapter/tasks.md
@@ -1,0 +1,28 @@
+## 1. Adapter core (RSS crawl)
+
+- [x] 1.1 Add `internal/sources/earcu.go`: `earcuHTTP interface { XMLGetter; HTMLGetter }`, `earcu` struct, `NewEarcu`, and `Provider() string { return "earcu" }` (mirror `personio.go`).
+- [x] 1.2 Define the RSS decode structs (`<rss><channel><item>` with title/link/guid/pubDate/description) and `Fetch` building `https://<board>/jobs/rss` via `GetXML`, returning one `Job` per item.
+- [x] 1.3 Parse `ExternalID` from the `/jobs/vacancy/<slug>/<id>/description/` link path; drop items with no extractable id.
+- [x] 1.4 Parse posted-at from `<pubDate>` (RFC1123 with `Z`-zone tolerance; nil on failure) and clean the title by stripping a trailing ` (\d+)` reference suffix.
+
+## 2. Description + location
+
+- [x] 2.1 Extract the inline body from the `rssjobdesc` block in the (unescaped) `<description>` and `sanitizeHTML` it; parse `Location:`/`Country:` out of the `Key: value` prefix for `Job.Location`.
+- [x] 2.2 When the feed body is empty, fall back to the detail page's `JobPosting` JSON-LD `description` via `GetHTML` + `ldJobPosting` (non-fatal on fetch failure); set `Remote` via the shared `isRemote(location)` heuristic, leave `WorkMode` empty.
+
+## 3. Registration + config
+
+- [x] 3.1 Register `NewEarcu(c)` in `sources.All` (`internal/sources/source.go`) among the board-based ATS adapters.
+- [x] 3.2 Confirm config validation requires a board for `earcu` (it is not boardless) and that `earcu` appears in `FilterableProviders()`.
+
+## 4. Tests
+
+- [x] 4.1 `internal/sources/earcu_test.go`: table-driven `Fetch` test over a fixture RSS document (via `fakeHTTP`) asserting title cleanup, URL, ExternalID, location, posted-at, and inline body.
+- [x] 4.2 Test the detail-page JSON-LD body fallback (empty feed body → JSON-LD description) and the drop-on-missing-id and non-fatal-detail-failure paths.
+- [x] 4.3 `TestEarcuRegisteredInAll` asserting the provider key resolves in `sources.All` (mirror the other `*RegisteredInAll` tests).
+
+## 5. Board file + live validation
+
+- [x] 5.1 Add `sources/earcu.yml` with the header comment and the verified `careers.cambridge.org` entry (company: Cambridge University Press & Assessment).
+- [x] 5.2 Probe candidate eArcu hosts from the documented roster live (`/jobs/rss` returns items + carries the `eArcu` marker) and add every host that validates; log any dropped for not validating.
+- [x] 5.3 Run `go build ./... && go vet ./... && go test ./internal/sources/` and a dry `cmd/ingest sources/earcu.yml` config-validation pass to confirm the board file loads.

--- a/sources/earcu.yml
+++ b/sources/earcu.yml
@@ -1,0 +1,11 @@
+# earcu boards. Provider is the filename; each entry is company + board.
+# board = the full eArcu careers host (feed is https://<board>/jobs/rss;
+# see internal/sources/earcu.go). eArcu clients run on custom domains, so the
+# board is the host itself, not a subdomain slug.
+#
+# Add a host only after validating it live: https://<host>/jobs/rss must return
+# 200 with items carrying the "eArcu Vacancy Reference" marker. Harvesting the
+# wider eArcu customer roster is follow-up discovery work.
+
+- company: Cambridge University Press & Assessment
+  board: careers.cambridge.org


### PR DESCRIPTION
## Summary
- Adds an **eArcu** source adapter — eArcu is a multi-tenant UK ATS (Cambridge University Press & Assessment, plus a documented roster of BP/Asda/British Airways/FirstGroup/Flutter/FA/…) whose clients run on their own careers host and publish a **keyless `/jobs/rss`** feed with the full posting body inline. We ingested none of them before.
- `internal/sources/earcu.go`: `Source` over `https://<board>/jobs/rss` (board = the full careers host). Parses each RSS item → `Job`: title (eArcu ref suffix stripped), detail URL, id from the URL path, location from the metadata prefix (scoped to the prefix so body text can't leak), pubDate (RFC822 with a literal `Z` zone + unpadded-day tolerance), and the inline `rssjobdesc` body — with a schema.org `JobPosting` JSON-LD fallback when an item has no inline body.
- Registers `NewEarcu` in `sources.All` (board-based, non-boardless → appears in the source facet, requires a board).
- `sources/earcu.yml` seeded with the **live-validated** `careers.cambridge.org`.

Mirrors the Personio adapter (XML feed + JSON-LD detail fallback), reusing `sanitizeHTML` / `ldJobPosting` / `parseLayout` / `isRemote`. Wider eArcu-roster host harvest is follow-up discovery work (noted in `sources/earcu.yml` + the OpenSpec design).

## Test Plan
- [x] `go test ./...` — all 55 packages pass; 7 new `Earcu*` unit tests cover field mapping, ref-suffix stripping, id extraction + drop-on-missing-id, location scoping (body `Country:` must not leak) + Country fallback + multi-part location, inline body vs JSON-LD fallback, non-fatal detail-fetch failure, unpadded pubDate, and registry membership.
- [x] `go build ./... && go vet ./internal/sources/ && gofmt -l` clean.
- [x] **Live end-to-end:** `cmd/ingest sources/earcu.yml` crawled `careers.cambridge.org` and ingested **38 postings, 0 failed** — 0 with a leftover ref suffix, 0 empty locations, 0 thin bodies, 0 empty external ids.