### PR TITLE
feat(sources): add Treasury Prime greenhouse board

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -2021,6 +2021,8 @@
   board: transcarent
 - company: TransMarket Group
   board: transmarketgroup
+- company: Treasury Prime
+  board: treasuryprime
 - company: TribalScale
   board: tribalscale
 - company: TripAdvisor


### PR DESCRIPTION
## Summary
- Adds **Treasury Prime** to `sources/greenhouse.yml` (board token `treasuryprime`). Surfaced via clojurejobboard.com, which links its Clojure role to `job-boards.greenhouse.io/treasuryprime`.
- The board token is valid but currently **empty** (0 open jobs — the company is between hiring waves, the linked role is filled). The entry ingests nothing today and picks up future Treasury Prime postings on the next crawl, giving their whole Greenhouse board, not just the Clojure role.

## Test Plan
- [x] YAML parses (7022 entries); `treasuryprime` present, alphabetical order preserved (between `TransMarket Group` and `TribalScale`).
- [x] `go build ./cmd/ingest` clean.
- [x] Greenhouse board token verified live: `boards-api.greenhouse.io/v1/boards/treasuryprime/jobs` → HTTP 200 (`total: 0` — empty, valid).