### PR TITLE
feat(sources): harvest 5 boards from hiring-without-whiteboards

### DIFF
--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -73,6 +73,8 @@
   board: tensquaregames
 - company: Terra
   board: terra
+- company: Tiugo Technologies
+  board: tiugotech
 - company: Trackman
   board: trackman
 - company: TransPerfect

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3,6 +3,8 @@
 # reads https://<board>/jobs and follows pagination, then each job page's JobPosting ld+json.
 # Each board validated live (>0 jobs in its listing, full normalized sample) before adding.
 
+- company: BRYTER
+  board: bryter.teamtailor.com
 - company: Tibber
   board: jobs.tibber.com
 

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -31,6 +31,8 @@
   board: coolgames
 - company: DataVisor
   board: datavisor-jobs
+- company: Detroit Labs
+  board: detroitlabs
 - company: Devoted Studios
   board: devoted-studios-1
 - company: Double Eleven
@@ -109,6 +111,10 @@
   board: nextgen-clearing
 - company: Nuvei
   board: nuvei
+- company: Peaksware
+  board: peaksware
+- company: Persado
+  board: persado
 - company: PikPok
   board: pikpok
 - company: powtoon


### PR DESCRIPTION
## Summary
Cross-referenced [poteto/hiring-without-whiteboards](https://github.com/poteto/hiring-without-whiteboards) (**764 company links**) against our adapters to find ATS boards we don't yet ingest.

**Headline finding: no new ATS platform.** Every ATS detected on the list is one we already have an adapter for — coverage against this well-known list is ~95% (greenhouse 27/30 already present, **ashby 25/25**, etc.). The one non-covered vendor (Homerun) appears only as its own company entry, not as a board in use.

Adds the handful of companies that sit on **our** ATS but were missing from the board files, each **live-validated (>0 open jobs)** before inclusion:

| File | Company | board | jobs |
|---|---|---|--:|
| workable | Detroit Labs | detroitlabs | 1 |
| workable | Peaksware | peaksware | 13 |
| workable | Persado | persado | 3 |
| recruitee | Tiugo Technologies | tiugotech | 5 |
| teamtailor | BRYTER | bryter.teamtailor.com | 4 |

Slugs that resolved to empty/dead boards (lever `beam`/`meetalbert`, most greenhouse candidates) were dropped, and pre-existing boards hidden behind quoted YAML values (`caravelo`, `resourcify`, `busuu`) were caught and excluded.

## Test Plan
- [x] All added slugs live-validated against their ATS API/listing (job count > 0).
- [x] YAML parses for all three files; added boards appear exactly once (no duplicates); alphabetical order preserved.
- [x] `cmd/ingest` config-validation (`LoadConfig` + `Validate`) passes for each changed board file.