### PR TITLE
feat(reality): deterministic ghost-job / posting-reality signal

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -79,7 +79,7 @@ func genStructs() (string, error) {
 			{
 				Path:         "github.com/strelov1/freehire/internal/jobview",
 				OutputPath:   jobviewTS,
-				IncludeFiles: []string{"jobview.go"},
+				IncludeFiles: []string{"jobview.go", "reality.go"},
 				TypeMappings: map[string]string{"enrich.Enrichment": "Enrichment"},
 			},
 			{

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/pipeline"
 	"github.com/strelov1/freehire/internal/search"
 )
@@ -84,6 +85,9 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 	// Fingerprint the indexed fields so the upsert can report whether this write
 	// changed searchable content (drives incremental indexing below).
 	params.ContentHash = pgtype.Text{String: jobhash.Of(params), Valid: true}
+	// role_fingerprint is the repost IDENTITY (excludes posted_at/url/slug), so a
+	// reposted role clusters for the job-reality signal — distinct from content_hash.
+	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
 
 	qtx := s.q.WithTx(tx)
 	saved, err := qtx.UpsertJob(ctx, params)
@@ -120,10 +124,23 @@ func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
 	// paths (enrichment via SetJobEnrichment, collections via
 	// PropagateCollectionsToJobs) reconcile on the next batch reindex, not here.
 	if s.indexer != nil && needsIndex(saved) {
+		// The job-reality signal needs this role's cluster counts; a lookup failure
+		// degrades to a unique role (counts 1) rather than failing the index push.
+		repost, mass := int64(1), int64(1)
+		if c, err := s.q.RoleClusterCount(ctx, db.RoleClusterCountParams{
+			CompanySlug:     saved.Job.CompanySlug,
+			RoleFingerprint: saved.Job.RoleFingerprint,
+		}); err != nil {
+			log.Printf("ingest: role-cluster count for job %d: %v", saved.Job.ID, err)
+		} else {
+			repost, mass = c.RepostCount, c.MassCount
+		}
 		doc, err := search.FromJob(saved.Job)
 		if err != nil {
 			log.Printf("ingest: build index doc for job %d: %v", saved.Job.ID, err)
 		} else {
+			reality := jobview.ClassifyReality(saved.Job, time.Now(), int(repost), int(mass))
+			doc.Reality = &reality
 			s.indexer.Add(ctx, doc)
 		}
 	}

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/search"
 	"github.com/strelov1/freehire/internal/worker"
 )
@@ -123,7 +124,12 @@ func run() int {
 		}
 		scope := "since " + since.String()
 		log.Printf("reindex: target=%s scope=%s mode=in-place", target, scope)
-		indexed, deleted, skipped, err := reindexAll(ctx, worker.NewIncrementalReader(q, time.Now().Add(-since)), ops)
+		lookup, err := buildRealityLookup(ctx, q)
+		if err != nil {
+			log.Printf("reindex: build reality lookup: %v", err)
+			return 1
+		}
+		indexed, deleted, skipped, err := reindexAll(ctx, worker.NewIncrementalReader(q, time.Now().Add(-since)), ops, lookup, time.Now())
 		if err != nil {
 			log.Printf("reindex: %v", err)
 			return 1
@@ -146,7 +152,12 @@ func run() int {
 		scope = "posted-within " + postedWithin.String()
 	}
 	log.Printf("reindex: target=%s scope=%s mode=swap", target, scope)
-	indexed, skipped, err := reindexFull(ctx, reader, b)
+	lookup, err := buildRealityLookup(ctx, q)
+	if err != nil {
+		log.Printf("reindex: build reality lookup: %v", err)
+		return 1
+	}
+	indexed, skipped, err := reindexFull(ctx, reader, b, lookup, time.Now())
 	if err != nil {
 		log.Printf("reindex: %v", err)
 		return 1
@@ -229,7 +240,7 @@ func semanticRequested(args []string) bool {
 // how many documents were indexed (open jobs) and deleted (closed jobs). fetch
 // pages by keyset (id > last seen) — full or incremental (--since) — so rows
 // inserted or re-ordered during the run cannot be skipped or repeated.
-func reindexAll(ctx context.Context, reader worker.PageReader, ops indexOps) (int, int, int, error) {
+func reindexAll(ctx context.Context, reader worker.PageReader, ops indexOps, lookup realityLookup, now time.Time) (int, int, int, error) {
 	if err := ops.ensure(ctx); err != nil {
 		return 0, 0, 0, err
 	}
@@ -253,7 +264,7 @@ func reindexAll(ctx context.Context, reader worker.PageReader, ops indexOps) (in
 		skipped += len(corrupted)
 
 		if len(jobs) > 0 {
-			docs, deleteIDs, err := splitJobs(jobs)
+			docs, deleteIDs, err := splitJobs(jobs, lookup, now)
 			if err != nil {
 				return int(indexed.Load()), int(deleted.Load()), skipped, err
 			}
@@ -297,7 +308,7 @@ type rebuilder interface {
 // fetch pages by keyset (id > last seen) so rows inserted or re-ordered during the
 // run cannot be skipped or repeated. Used for full passes; --since stays in place
 // (reindexAll) since a partial index cannot be swapped in wholesale.
-func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder) (int, int, error) {
+func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder, lookup realityLookup, now time.Time) (int, int, error) {
 	if err := b.Prepare(ctx); err != nil {
 		return 0, 0, err
 	}
@@ -318,7 +329,7 @@ func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder) (in
 		skipped += len(corrupted)
 
 		if len(jobs) > 0 {
-			docs, _, err := splitJobs(jobs) // closed jobs (deleteIDs) are dropped, not indexed
+			docs, _, err := splitJobs(jobs, lookup, now) // closed jobs (deleteIDs) are dropped, not indexed
 			if err != nil {
 				return int(indexed.Load()), skipped, err
 			}
@@ -343,10 +354,36 @@ func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder) (in
 	return int(indexed.Load()), skipped, nil
 }
 
+// realityLookup returns a role cluster's repost and concurrent-open counts for the
+// job-reality signal. A miss (a role not in the precomputed map, i.e. a singleton)
+// yields (1, 1) — a unique, non-reposted role. A nil lookup means the counts default
+// to (1, 1) everywhere (used by tests that do not exercise clustering).
+type realityLookup func(companySlug, fingerprint string) (repost, mass int)
+
+// buildRealityLookup precomputes the whole-catalogue role-cluster counts once, so the
+// per-job classification during the rebuild is a map read, not N queries.
+func buildRealityLookup(ctx context.Context, q *db.Queries) (realityLookup, error) {
+	rows, err := q.RoleClusterCountsAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string][2]int, len(rows))
+	for _, r := range rows {
+		m[r.CompanySlug+"\x00"+r.RoleFingerprint.String] = [2]int{int(r.RepostCount), int(r.MassCount)}
+	}
+	return func(cs, fp string) (int, int) {
+		if v, ok := m[cs+"\x00"+fp]; ok {
+			return v[0], v[1]
+		}
+		return 1, 1
+	}, nil
+}
+
 // splitJobs partitions a batch from the (deliberately unfiltered) reindex feed:
-// open jobs become index documents, closed jobs become deletions so they leave
+// open jobs become index documents (each carrying its reality signal, classified
+// against `now` and its cluster counts), closed jobs become deletions so they leave
 // the index (the index contains only open jobs — see the job-search spec).
-func splitJobs(jobs []db.Job) ([]search.JobDocument, []int64, error) {
+func splitJobs(jobs []db.Job, lookup realityLookup, now time.Time) ([]search.JobDocument, []int64, error) {
 	docs := make([]search.JobDocument, 0, len(jobs))
 	deleteIDs := make([]int64, 0, len(jobs))
 	for _, j := range jobs {
@@ -354,10 +391,16 @@ func splitJobs(jobs []db.Job) ([]search.JobDocument, []int64, error) {
 			deleteIDs = append(deleteIDs, j.ID)
 			continue
 		}
+		repost, mass := 1, 1
+		if lookup != nil {
+			repost, mass = lookup(j.CompanySlug, j.RoleFingerprint.String)
+		}
 		doc, err := search.FromJob(j)
 		if err != nil {
 			return nil, nil, err
 		}
+		reality := jobview.ClassifyReality(j, now, repost, mass)
+		doc.Reality = &reality
 		docs = append(docs, doc)
 	}
 	return docs, deleteIDs, nil

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -86,7 +86,7 @@ func TestSplitJobs_OpenBecomeDocsClosedBecomeDeletions(t *testing.T) {
 	closed := db.Job{ID: 2, Title: "Closed", PublicSlug: "closed-x",
 		ClosedAt: pgtype.Timestamptz{Time: open.CreatedAt.Time, Valid: true}}
 
-	docs, deleteIDs, err := splitJobs([]db.Job{open, closed})
+	docs, deleteIDs, err := splitJobs([]db.Job{open, closed}, nil, time.Now())
 	if err != nil {
 		t.Fatalf("splitJobs: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestReindexFull_PushesOpenDocsThenPromotes(t *testing.T) {
 	reader := &fakePageReader{pages: map[int64][]db.Job{0: page}}
 
 	f := &fakeRebuilder{}
-	indexed, skipped, err := reindexFull(context.Background(), reader, f)
+	indexed, skipped, err := reindexFull(context.Background(), reader, f, nil, time.Now())
 	if err != nil {
 		t.Fatalf("reindexFull: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestReindexFull_SkipsCorruptedRowAndPromotes(t *testing.T) {
 	}
 
 	f := &fakeRebuilder{}
-	indexed, skipped, err := reindexFull(context.Background(), reader, f)
+	indexed, skipped, err := reindexFull(context.Background(), reader, f, nil, time.Now())
 	if err != nil {
 		t.Fatalf("reindexFull: %v", err)
 	}

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobfacts"
+	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/lang"
 	"github.com/strelov1/freehire/internal/location"
 	"github.com/strelov1/freehire/internal/normalize"
@@ -100,7 +101,7 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 			category = classify.NonTechFromDescription(j.Description)
 		}
 		descHTML := telegram.TextToHTML(j.Description)
-		saved, err := qtx.UpsertJob(ctx, db.UpsertJobParams{
+		params := db.UpsertJobParams{
 			Source:      "telegram",
 			ExternalID:  externalID,
 			URL:         "https://t.me/" + base,
@@ -125,7 +126,9 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 			EducationLevel:     jobfacts.EducationLevel(descHTML),
 			EnglishLevel:       jobfacts.EnglishLevel(descHTML),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(descHTML)),
-		})
+		}
+		params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
+		saved, err := qtx.UpsertJob(ctx, params)
 		if err != nil {
 			return fmt.Errorf("upsert job %s: %w", externalID, err)
 		}
@@ -180,7 +183,7 @@ func (s *extractStore) CompleteLinks(
 		if j.PostedAt != nil {
 			postedAt = pgtype.Timestamptz{Time: *j.PostedAt, Valid: true}
 		}
-		saved, err := qtx.UpsertJob(ctx, db.UpsertJobParams{
+		params := db.UpsertJobParams{
 			Source:      j.Source,
 			ExternalID:  j.ExternalID,
 			URL:         j.URL,
@@ -205,7 +208,9 @@ func (s *extractStore) CompleteLinks(
 			EducationLevel:     jobfacts.EducationLevel(j.Description),
 			EnglishLevel:       jobfacts.EnglishLevel(j.Description),
 			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(j.Description)),
-		})
+		}
+		params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
+		saved, err := qtx.UpsertJob(ctx, params)
 		if err != nil {
 			return fmt.Errorf("upsert job %s/%s: %w", j.Source, j.ExternalID, err)
 		}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -141,7 +141,7 @@ func (q *Queries) EstimateOpenJobs(ctx context.Context) (int64, error) {
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 FROM jobs
 WHERE id = $1
 `
@@ -188,12 +188,13 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.Cities,
 		&i.ViewCount,
 		&i.AppliedCount,
+		&i.RoleFingerprint,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 FROM jobs
 WHERE public_slug = $1
 `
@@ -240,6 +241,7 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.Cities,
 		&i.ViewCount,
 		&i.AppliedCount,
+		&i.RoleFingerprint,
 	)
 	return i, err
 }
@@ -375,7 +377,7 @@ func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 FROM jobs
 WHERE closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -438,6 +440,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.Cities,
 			&i.ViewCount,
 			&i.AppliedCount,
+			&i.RoleFingerprint,
 		); err != nil {
 			return nil, err
 		}
@@ -450,7 +453,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -511,6 +514,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.Cities,
 			&i.ViewCount,
 			&i.AppliedCount,
+			&i.RoleFingerprint,
 		); err != nil {
 			return nil, err
 		}
@@ -523,7 +527,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -586,6 +590,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.Cities,
 			&i.ViewCount,
 			&i.AppliedCount,
+			&i.RoleFingerprint,
 		); err != nil {
 			return nil, err
 		}
@@ -598,7 +603,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -665,6 +670,7 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.Cities,
 			&i.ViewCount,
 			&i.AppliedCount,
+			&i.RoleFingerprint,
 		); err != nil {
 			return nil, err
 		}
@@ -713,7 +719,7 @@ func (q *Queries) ListOpenJobIDsPostedAfter(ctx context.Context, arg ListOpenJob
 }
 
 const listOpenJobsPostedAfter = `-- name: ListOpenJobsPostedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 FROM jobs
 WHERE id > $1 AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= $2
 ORDER BY id
@@ -782,6 +788,7 @@ func (q *Queries) ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsP
 			&i.Cities,
 			&i.ViewCount,
 			&i.AppliedCount,
+			&i.RoleFingerprint,
 		); err != nil {
 			return nil, err
 		}
@@ -861,6 +868,87 @@ WHERE id = $1 AND liveness_strikes <> 0
 func (q *Queries) ResetLivenessStrikes(ctx context.Context, id int64) error {
 	_, err := q.db.Exec(ctx, resetLivenessStrikes, id)
 	return err
+}
+
+const roleClusterCount = `-- name: RoleClusterCount :one
+SELECT
+    COUNT(*)::bigint AS repost_count,
+    COUNT(*) FILTER (WHERE closed_at IS NULL)::bigint AS mass_count
+FROM jobs
+WHERE company_slug = $1
+  AND role_fingerprint = $2
+  AND role_fingerprint <> ''
+`
+
+type RoleClusterCountParams struct {
+	CompanySlug     string      `json:"company_slug"`
+	RoleFingerprint pgtype.Text `json:"role_fingerprint"`
+}
+
+type RoleClusterCountRow struct {
+	RepostCount int64 `json:"repost_count"`
+	MassCount   int64 `json:"mass_count"`
+}
+
+// The job-reality repost/mass-posting counts for one role cluster: how many postings
+// of the same role (by role_fingerprint within a company) exist of any status
+// (repost_count = repost history) and how many are still open (mass_count = concurrent
+// mass-posting). A NULL/empty fingerprint is excluded so unfingerprinted rows never
+// cluster together; a lookup miss means a unique role (count 1). Used by the
+// incremental index push and the single-job detail read.
+func (q *Queries) RoleClusterCount(ctx context.Context, arg RoleClusterCountParams) (RoleClusterCountRow, error) {
+	row := q.db.QueryRow(ctx, roleClusterCount, arg.CompanySlug, arg.RoleFingerprint)
+	var i RoleClusterCountRow
+	err := row.Scan(&i.RepostCount, &i.MassCount)
+	return i, err
+}
+
+const roleClusterCountsAll = `-- name: RoleClusterCountsAll :many
+SELECT
+    company_slug,
+    role_fingerprint,
+    COUNT(*)::bigint AS repost_count,
+    COUNT(*) FILTER (WHERE closed_at IS NULL)::bigint AS mass_count
+FROM jobs
+WHERE role_fingerprint IS NOT NULL AND role_fingerprint <> ''
+GROUP BY company_slug, role_fingerprint
+HAVING COUNT(*) > 1
+`
+
+type RoleClusterCountsAllRow struct {
+	CompanySlug     string      `json:"company_slug"`
+	RoleFingerprint pgtype.Text `json:"role_fingerprint"`
+	RepostCount     int64       `json:"repost_count"`
+	MassCount       int64       `json:"mass_count"`
+}
+
+// The whole-catalogue role-cluster counts in one aggregate pass, for the reindex to
+// build its (company_slug, role_fingerprint) -> counts lookup once. Only clusters with
+// more than one posting are returned (singletons are the count-1 default a lookup miss
+// already implies), keeping the map small. NULL/empty fingerprints are excluded.
+func (q *Queries) RoleClusterCountsAll(ctx context.Context) ([]RoleClusterCountsAllRow, error) {
+	rows, err := q.db.Query(ctx, roleClusterCountsAll)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []RoleClusterCountsAllRow{}
+	for rows.Next() {
+		var i RoleClusterCountsAllRow
+		if err := rows.Scan(
+			&i.CompanySlug,
+			&i.RoleFingerprint,
+			&i.RepostCount,
+			&i.MassCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const selectOrphanLivenessCandidates = `-- name: SelectOrphanLivenessCandidates :many
@@ -1055,7 +1143,7 @@ SET title        = $1,
     updated_by   = $20::bigint,
     updated_at   = now()
 WHERE public_slug = $21 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 `
 
 type UpdateManualJobParams struct {
@@ -1158,6 +1246,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.Cities,
 		&i.ViewCount,
 		&i.AppliedCount,
+		&i.RoleFingerprint,
 	)
 	return i, err
 }
@@ -1179,7 +1268,7 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, cities, work_mode, skills, seniority, category,
     posting_language, employment_type, education_level, english_level, experience_years_min,
-    content_hash
+    content_hash, role_fingerprint
 ) VALUES (
     $1, $2, $3, $4,
     $5, $6, $7, $8,
@@ -1188,7 +1277,7 @@ INSERT INTO jobs (
     COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'), COALESCE($14::text[], '{}'),
     $15, COALESCE($16::text[], '{}'), $17, $18,
     $19, $20, $21, $22, $23,
-    $24
+    $24, $25
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -1220,6 +1309,9 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     english_level        = EXCLUDED.english_level,
     experience_years_min = EXCLUDED.experience_years_min,
     content_hash = EXCLUDED.content_hash,
+    -- role_fingerprint is the repost-identity (internal/jobhash.RoleFingerprint):
+    -- refreshed on re-ingest so a title/description edit re-clusters the role.
+    role_fingerprint = EXCLUDED.role_fingerprint,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
     -- reopen (the row was closed) resets the strike count so a single later expired
     -- probe can't immediately re-close it — the two-strike grace survives a reopen.
@@ -1227,7 +1319,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
     ((SELECT old_hash FROM existing) IS DISTINCT FROM $24) AS changed
 `
@@ -1257,6 +1349,7 @@ type UpsertJobParams struct {
 	EnglishLevel       string             `json:"english_level"`
 	ExperienceYearsMin pgtype.Int4        `json:"experience_years_min"`
 	ContentHash        pgtype.Text        `json:"content_hash"`
+	RoleFingerprint    pgtype.Text        `json:"role_fingerprint"`
 }
 
 type UpsertJobRow struct {
@@ -1311,6 +1404,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		arg.EnglishLevel,
 		arg.ExperienceYearsMin,
 		arg.ContentHash,
+		arg.RoleFingerprint,
 	)
 	var i UpsertJobRow
 	err := row.Scan(
@@ -1352,6 +1446,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.Cities,
 		&i.Job.ViewCount,
 		&i.Job.AppliedCount,
+		&i.Job.RoleFingerprint,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -1410,7 +1505,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
 `
 
 type UpsertManualJobParams struct {
@@ -1519,6 +1614,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.Cities,
 		&i.ViewCount,
 		&i.AppliedCount,
+		&i.RoleFingerprint,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -94,6 +94,7 @@ type Job struct {
 	Cities             []string           `json:"cities"`
 	ViewCount          int32              `json:"view_count"`
 	AppliedCount       int32              `json:"applied_count"`
+	RoleFingerprint    pgtype.Text        `json:"role_fingerprint"`
 }
 
 type JobReport struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -433,6 +433,18 @@ type Querier interface {
 	// expired probes can close a job. Guarded to the non-zero case so probing an
 	// already-clean job does not churn the row.
 	ResetLivenessStrikes(ctx context.Context, id int64) error
+	// The job-reality repost/mass-posting counts for one role cluster: how many postings
+	// of the same role (by role_fingerprint within a company) exist of any status
+	// (repost_count = repost history) and how many are still open (mass_count = concurrent
+	// mass-posting). A NULL/empty fingerprint is excluded so unfingerprinted rows never
+	// cluster together; a lookup miss means a unique role (count 1). Used by the
+	// incremental index push and the single-job detail read.
+	RoleClusterCount(ctx context.Context, arg RoleClusterCountParams) (RoleClusterCountRow, error)
+	// The whole-catalogue role-cluster counts in one aggregate pass, for the reindex to
+	// build its (company_slug, role_fingerprint) -> counts lookup once. Only clusters with
+	// more than one posting are returned (singletons are the count-1 default a lookup miss
+	// already implies), keeping the map small. NULL/empty fingerprints are excluded.
+	RoleClusterCountsAll(ctx context.Context) ([]RoleClusterCountsAllRow, error)
 	// Save (bookmark) a job for a user. Idempotent and independent of a prior view:
 	// it inserts the row (viewed_at defaults) or refreshes saved_at in place.
 	SaveJob(ctx context.Context, arg SaveJobParams) (UserJob, error)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -155,7 +155,7 @@ INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
     public_slug, countries, regions, cities, work_mode, skills, seniority, category,
     posting_language, employment_type, education_level, english_level, experience_years_min,
-    content_hash
+    content_hash, role_fingerprint
 ) VALUES (
     sqlc.arg(source), sqlc.arg(external_id), sqlc.arg(url), sqlc.arg(title),
     sqlc.arg(company), sqlc.arg(company_slug), sqlc.arg(location), sqlc.arg(remote),
@@ -164,7 +164,7 @@ INSERT INTO jobs (
     COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'), COALESCE(sqlc.arg(cities)::text[], '{}'),
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'), sqlc.arg(seniority), sqlc.arg(category),
     sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(english_level), sqlc.arg(experience_years_min),
-    sqlc.arg(content_hash)
+    sqlc.arg(content_hash), sqlc.arg(role_fingerprint)
 )
 -- public_slug is deliberately NOT in the DO UPDATE SET: the slug is minted once
 -- at insert and is the row's stable public identity. Re-ingest of the same
@@ -200,6 +200,9 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     english_level        = EXCLUDED.english_level,
     experience_years_min = EXCLUDED.experience_years_min,
     content_hash = EXCLUDED.content_hash,
+    -- role_fingerprint is the repost-identity (internal/jobhash.RoleFingerprint):
+    -- refreshed on re-ingest so a title/description edit re-clusters the role.
+    role_fingerprint = EXCLUDED.role_fingerprint,
     -- The crawl saw the posting: refresh liveness and reopen if it was closed. A
     -- reopen (the row was closed) resets the strike count so a single later expired
     -- probe can't immediately re-close it — the two-strike grace survives a reopen.
@@ -210,6 +213,36 @@ ON CONFLICT (source, external_id) DO UPDATE SET
 RETURNING sqlc.embed(jobs),
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
     ((SELECT old_hash FROM existing) IS DISTINCT FROM sqlc.arg(content_hash)) AS changed;
+
+-- name: RoleClusterCount :one
+-- The job-reality repost/mass-posting counts for one role cluster: how many postings
+-- of the same role (by role_fingerprint within a company) exist of any status
+-- (repost_count = repost history) and how many are still open (mass_count = concurrent
+-- mass-posting). A NULL/empty fingerprint is excluded so unfingerprinted rows never
+-- cluster together; a lookup miss means a unique role (count 1). Used by the
+-- incremental index push and the single-job detail read.
+SELECT
+    COUNT(*)::bigint AS repost_count,
+    COUNT(*) FILTER (WHERE closed_at IS NULL)::bigint AS mass_count
+FROM jobs
+WHERE company_slug = sqlc.arg(company_slug)
+  AND role_fingerprint = sqlc.arg(role_fingerprint)
+  AND role_fingerprint <> '';
+
+-- name: RoleClusterCountsAll :many
+-- The whole-catalogue role-cluster counts in one aggregate pass, for the reindex to
+-- build its (company_slug, role_fingerprint) -> counts lookup once. Only clusters with
+-- more than one posting are returned (singletons are the count-1 default a lookup miss
+-- already implies), keeping the map small. NULL/empty fingerprints are excluded.
+SELECT
+    company_slug,
+    role_fingerprint,
+    COUNT(*)::bigint AS repost_count,
+    COUNT(*) FILTER (WHERE closed_at IS NULL)::bigint AS mass_count
+FROM jobs
+WHERE role_fingerprint IS NOT NULL AND role_fingerprint <> ''
+GROUP BY company_slug, role_fingerprint
+HAVING COUNT(*) > 1;
 
 -- name: PropagateCollectionsToJobs :execrows
 -- Denormalize each company's curated-collection set onto its jobs, so the search

--- a/internal/db/role_fingerprint_integration_test.go
+++ b/internal/db/role_fingerprint_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+// Integration tests for the job-reality repost-clustering: UpsertJob persists
+// role_fingerprint, and RoleClusterCount / RoleClusterCountsAll group postings of the
+// same role (by company_slug + role_fingerprint) into repost-history and concurrent
+// open counts. Grouping and the NULL/empty-fingerprint exclusion are SQL behaviors
+// verifiable only against a real Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func withFingerprint(externalID, title, fingerprint string) UpsertJobParams {
+	p := ingestParams(externalID, title)
+	if fingerprint != "" {
+		p.RoleFingerprint = pgtype.Text{String: fingerprint, Valid: true}
+	}
+	return p
+}
+
+func TestRoleClusterCount_ClustersRepostsAndCountsOpen(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// Three postings of ONE role under distinct external_ids (reposts over time),
+	// plus an unrelated role and an unfingerprinted row that must not interfere.
+	const fp = "role-abc"
+	for _, ext := range []string{"acme:1", "acme:2", "acme:3"} {
+		if _, err := q.UpsertJob(ctx, withFingerprint(ext, "Staff Engineer", fp)); err != nil {
+			t.Fatalf("upsert %s: %v", ext, err)
+		}
+	}
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:other", "Designer", "role-xyz")); err != nil {
+		t.Fatalf("upsert other role: %v", err)
+	}
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:nofp", "Untagged", "")); err != nil {
+		t.Fatalf("upsert unfingerprinted: %v", err)
+	}
+
+	// The role persisted its fingerprint and clusters all three postings.
+	c, err := q.RoleClusterCount(ctx, RoleClusterCountParams{CompanySlug: "acme", RoleFingerprint: pgtype.Text{String: fp, Valid: true}})
+	if err != nil {
+		t.Fatalf("RoleClusterCount: %v", err)
+	}
+	if c.RepostCount != 3 {
+		t.Errorf("repost_count = %d, want 3", c.RepostCount)
+	}
+	if c.MassCount != 3 {
+		t.Errorf("mass_count = %d, want 3 (all open)", c.MassCount)
+	}
+
+	// Closing one posting drops the concurrent (open) count but keeps repost history.
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = now() WHERE external_id = $1", "acme:3"); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	c2, err := q.RoleClusterCount(ctx, RoleClusterCountParams{CompanySlug: "acme", RoleFingerprint: pgtype.Text{String: fp, Valid: true}})
+	if err != nil {
+		t.Fatalf("RoleClusterCount after close: %v", err)
+	}
+	if c2.RepostCount != 3 {
+		t.Errorf("repost_count after close = %d, want 3 (history keeps closed)", c2.RepostCount)
+	}
+	if c2.MassCount != 2 {
+		t.Errorf("mass_count after close = %d, want 2 (one closed)", c2.MassCount)
+	}
+}
+
+// An empty/NULL fingerprint must never cluster: unfingerprinted rows would otherwise
+// all group under one bucket and falsely read as a mass-posted ghost.
+func TestRoleClusterCountsAll_ExcludesUnfingerprintedAndSingletons(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// Two unfingerprinted rows (empty) — must not form a cluster.
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:a", "Role A", "")); err != nil {
+		t.Fatalf("upsert a: %v", err)
+	}
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:b", "Role B", "")); err != nil {
+		t.Fatalf("upsert b: %v", err)
+	}
+	// A singleton fingerprinted role — excluded (HAVING COUNT(*) > 1).
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:solo", "Solo", "role-solo")); err != nil {
+		t.Fatalf("upsert solo: %v", err)
+	}
+	// A real cluster of two.
+	for _, ext := range []string{"acme:c1", "acme:c2"} {
+		if _, err := q.UpsertJob(ctx, withFingerprint(ext, "Cluster", "role-cluster")); err != nil {
+			t.Fatalf("upsert %s: %v", ext, err)
+		}
+	}
+
+	rows, err := q.RoleClusterCountsAll(ctx)
+	if err != nil {
+		t.Fatalf("RoleClusterCountsAll: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("clusters = %d, want 1 (only the real cluster)", len(rows))
+	}
+	if rows[0].RoleFingerprint.String != "role-cluster" || rows[0].RepostCount != 2 {
+		t.Errorf("cluster = %+v, want role-cluster repost_count 2", rows[0])
+	}
+}

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -187,7 +187,7 @@ func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) 
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -275,6 +275,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.Cities,
 			&i.Job.ViewCount,
 			&i.Job.AppliedCount,
+			&i.Job.RoleFingerprint,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,

--- a/internal/handler/job_reality_integration_test.go
+++ b/internal/handler/job_reality_integration_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+// End-to-end HTTP verification of the job-reality signal on the detail endpoint:
+// GET /api/v1/jobs/:slug drives the real path — GetJobBySlug → RoleClusterCount →
+// jobview.ClassifyReality → JSON serialization — so the served `reality` object and
+// its evidence are what a client actually receives.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func seedRealityJob(t *testing.T, pool *pgxpool.Pool, q *db.Queries, extID, slug, desc string) {
+	t.Helper()
+	p := db.UpsertJobParams{
+		Source: "greenhouse", ExternalID: extID, URL: "https://ex.test/" + extID,
+		Title: "Staff Engineer", Company: "Acme", CompanySlug: "acme",
+		PublicSlug: slug, Location: "Remote", Remote: true, Description: desc,
+	}
+	p.RoleFingerprint = pgtype.Text{String: "fp-" + extID, Valid: true}
+	if _, err := q.UpsertJob(context.Background(), p); err != nil {
+		t.Fatalf("seed %s: %v", extID, err)
+	}
+}
+
+func TestGetJob_ServesRealitySignal(t *testing.T) {
+	pool := startPostgres(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, "TRUNCATE jobs, companies RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	h := &API{pool: pool, queries: q}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/jobs/:slug", h.GetJob)
+
+	getReality := func(t *testing.T, slug string) map[string]any {
+		t.Helper()
+		resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/jobs/"+slug, nil))
+		if err != nil {
+			t.Fatalf("request: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status %d: %s", resp.StatusCode, body)
+		}
+		var out struct {
+			Data struct {
+				Reality map[string]any `json:"reality"`
+			} `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if out.Data.Reality == nil {
+			t.Fatal("response has no reality object")
+		}
+		return out.Data.Reality
+	}
+
+	t.Run("old + evergreen text converges to likely-evergreen", func(t *testing.T) {
+		seedRealityJob(t, pool, q, "acme:ever", "ever-slug", "We are always hiring for this role.")
+		if _, err := pool.Exec(ctx,
+			"UPDATE jobs SET created_at = now() - interval '240 days', posted_at = now() - interval '240 days' WHERE public_slug = $1",
+			"ever-slug"); err != nil {
+			t.Fatalf("age job: %v", err)
+		}
+		r := getReality(t, "ever-slug")
+		if r["class"] != "likely-evergreen" {
+			t.Errorf("class = %v, want likely-evergreen", r["class"])
+		}
+		if age, _ := r["age_days"].(float64); age < 239 {
+			t.Errorf("age_days = %v, want ~240", r["age_days"])
+		}
+	})
+
+	t.Run("a brand-new plain posting is fresh", func(t *testing.T) {
+		seedRealityJob(t, pool, q, "acme:new", "new-slug", "Own the checkout service.")
+		r := getReality(t, "new-slug")
+		if r["class"] != "fresh" {
+			t.Errorf("class = %v, want fresh", r["class"])
+		}
+	})
+}

--- a/internal/handler/jobs.go
+++ b/internal/handler/jobs.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"time"
+
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -49,6 +51,19 @@ func (a *API) GetJob(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
+
+	// Attach the job-reality signal (see internal/jobreality): the badge on the detail
+	// page. A count-query failure degrades to a unique role (counts 1) rather than
+	// dropping the whole response.
+	repost, mass := int64(1), int64(1)
+	if cnt, err := a.queries.RoleClusterCount(c.Context(), db.RoleClusterCountParams{
+		CompanySlug:     job.CompanySlug,
+		RoleFingerprint: job.RoleFingerprint,
+	}); err == nil {
+		repost, mass = cnt.RepostCount, cnt.MassCount
+	}
+	reality := jobview.ClassifyReality(job, time.Now(), int(repost), int(mass))
+	view.Reality = &reality
 
 	return c.JSON(fiber.Map{"data": view})
 }

--- a/internal/jobhash/rolefingerprint.go
+++ b/internal/jobhash/rolefingerprint.go
@@ -1,0 +1,39 @@
+package jobhash
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// RoleFingerprint returns a deterministic hex fingerprint of a job's ROLE IDENTITY —
+// company, normalized title, and normalized description — deliberately excluding
+// every volatile field (posted_at, url, public_slug, source, external_id, location).
+// A role reposted under a new external_id with a refreshed posted date therefore
+// resolves to the same fingerprint, so the reality signal can cluster reposts.
+//
+// This is the opposite of Of: Of is the CHANGE signal (it includes posted_at, so a
+// repost with a bumped date is "changed" and re-indexed); RoleFingerprint is the
+// IDENTITY signal (it ignores posted_at, so reposts collapse to one role). Never use
+// content_hash to cluster reposts.
+func RoleFingerprint(p db.UpsertJobParams) string {
+	const rs = "\x1e"
+	var b strings.Builder
+	b.WriteString(p.CompanySlug)
+	b.WriteString(rs)
+	b.WriteString(normalizeRoleText(p.Title))
+	b.WriteString(rs)
+	b.WriteString(normalizeRoleText(p.Description))
+
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// normalizeRoleText lower-cases and collapses runs of whitespace so cosmetic case or
+// spacing differences in a re-post do not split one role. The normalization stays
+// narrow (no stemming/punctuation stripping) to avoid over-merging distinct roles.
+func normalizeRoleText(s string) string {
+	return strings.Join(strings.Fields(strings.ToLower(s)), " ")
+}

--- a/internal/jobhash/rolefingerprint_test.go
+++ b/internal/jobhash/rolefingerprint_test.go
@@ -1,0 +1,99 @@
+package jobhash
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestRoleFingerprint_StableForEqualContent(t *testing.T) {
+	h := RoleFingerprint(sample())
+	if h == "" {
+		t.Fatal("fingerprint is empty")
+	}
+	if again := RoleFingerprint(sample()); again != h {
+		t.Fatalf("fingerprint not stable: %q != %q", h, again)
+	}
+}
+
+// The fingerprint is the repost IDENTITY: a role reposted under a new external_id
+// with a refreshed posted date (and new url/slug) must resolve to one fingerprint,
+// so it deliberately ignores every volatile field.
+func TestRoleFingerprint_IgnoresVolatileFields(t *testing.T) {
+	base := RoleFingerprint(sample())
+	cases := map[string]func(*db.UpsertJobParams){
+		"posted_at": func(p *db.UpsertJobParams) {
+			p.PostedAt = pgtype.Timestamptz{Time: time.Unix(1_800_000_000, 0).UTC(), Valid: true}
+		},
+		"posted_at_null": func(p *db.UpsertJobParams) { p.PostedAt = pgtype.Timestamptz{} },
+		"url":            func(p *db.UpsertJobParams) { p.URL = "https://example.com/jobs/999" },
+		"public_slug":    func(p *db.UpsertJobParams) { p.PublicSlug = "staff-full-stack-engineer-cookunity-zzzz" },
+		"external_id":    func(p *db.UpsertJobParams) { p.ExternalID = "cookunity:9999999999" },
+		"source":         func(p *db.UpsertJobParams) { p.Source = "lever" },
+		"location":       func(p *db.UpsertJobParams) { p.Location = "Remote - EU" },
+		"remote":         func(p *db.UpsertJobParams) { p.Remote = false },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := sample()
+			mutate(&p)
+			if got := RoleFingerprint(p); got != base {
+				t.Errorf("fingerprint changed after mutating volatile field %s (should cluster)", name)
+			}
+		})
+	}
+}
+
+func TestRoleFingerprint_ChangesWhenRoleChanges(t *testing.T) {
+	base := RoleFingerprint(sample())
+	cases := map[string]func(*db.UpsertJobParams){
+		"company_slug": func(p *db.UpsertJobParams) { p.CompanySlug = "acme" },
+		"title":        func(p *db.UpsertJobParams) { p.Title = "Senior Backend Engineer" },
+		"description":  func(p *db.UpsertJobParams) { p.Description = "A completely different role." },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := sample()
+			mutate(&p)
+			if got := RoleFingerprint(p); got == base {
+				t.Errorf("fingerprint unchanged after mutating role field %s (collision)", name)
+			}
+		})
+	}
+}
+
+// Normalization is narrow: case and surrounding/collapsing whitespace do not split a
+// role, so a re-post with cosmetic title/description whitespace still clusters.
+func TestRoleFingerprint_NormalizesCaseAndWhitespace(t *testing.T) {
+	base := RoleFingerprint(sample())
+	cases := map[string]func(*db.UpsertJobParams){
+		"title_case":       func(p *db.UpsertJobParams) { p.Title = "STAFF FULL STACK ENGINEER" },
+		"title_whitespace": func(p *db.UpsertJobParams) { p.Title = "  Staff   Full  Stack   Engineer " },
+		"desc_case":        func(p *db.UpsertJobParams) { p.Description = "BUILD SMART FRIDGES." },
+		"desc_whitespace":  func(p *db.UpsertJobParams) { p.Description = "Build   smart fridges.  " },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := sample()
+			mutate(&p)
+			if got := RoleFingerprint(p); got != base {
+				t.Errorf("fingerprint changed after cosmetic %s (should normalize)", name)
+			}
+		})
+	}
+}
+
+// Field-boundary guard: title/description content must not shift across the boundary
+// and collide.
+func TestRoleFingerprint_FieldsAreDelimited(t *testing.T) {
+	a := sample()
+	a.Title, a.Description = "ab", "c"
+	b := sample()
+	b.Title, b.Description = "a", "bc"
+	if RoleFingerprint(a) == RoleFingerprint(b) {
+		t.Error("field boundary not delimited: content shifted across fields collides")
+	}
+}

--- a/internal/jobreality/classify.go
+++ b/internal/jobreality/classify.go
@@ -1,0 +1,98 @@
+// Package jobreality derives a deterministic "reality" classification of a job —
+// whether it looks like a real, active opening or a perpetual ghost/evergreen
+// listing — from ingest history and text facts. It is the same "never guesses"
+// doctrine as internal/location / classify / skilltag, but computed from history
+// (first-seen age, repost/mass-posting counts) rather than content alone, so it is
+// TIME-DEPENDENT and computed at index/read time, never stored.
+package jobreality
+
+import "time"
+
+// Reality classes.
+const (
+	ClassFresh           = "fresh"
+	ClassStale           = "stale"
+	ClassLikelyEvergreen = "likely-evergreen"
+)
+
+// Thresholds. One signal is weak; the verdict requires convergence.
+const (
+	freshWindowDays = 14 // age at or under which a job with no evergreen signal is fresh
+	oldAgeDays      = 90 // age at or over which the "old" signal fires
+	repostThreshold = 3  // distinct postings of one role (any status) that count as reposting
+	massThreshold   = 5  // concurrent open postings of one role that count as mass-posting
+	convergence     = 2  // number of independent signals required for likely-evergreen
+)
+
+// Input is the history + text facts a classification reads. RepostCount is the number
+// of distinct external_ids of any status sharing the role fingerprint (repost
+// history); MassPostingCount is the same restricted to open jobs (concurrent
+// mass-posting). Both are at least 1 (the job itself). EvergreenText is the dictionary
+// result (see HasEvergreenMarker). PostedAt is honored only when HasPostedAt is set.
+type Input struct {
+	Now              time.Time
+	CreatedAt        time.Time
+	PostedAt         time.Time
+	HasPostedAt      bool
+	RepostCount      int
+	MassPostingCount int
+	EvergreenText    bool
+}
+
+// Evidence is the observable facts behind a classification — surfaced so the UI states
+// facts, not a bare accusation.
+type Evidence struct {
+	AgeDays          int
+	RepostCount      int
+	MassPostingCount int
+	FakeFreshness    bool
+}
+
+// Result is a classification and the evidence that produced it.
+type Result struct {
+	Class    string
+	Evidence Evidence
+}
+
+// Classify assigns a reality class from the input. likely-evergreen requires at least
+// `convergence` independent signals to fire — never age alone; otherwise a new job
+// with no evergreen signal is fresh and everything else is stale.
+func Classify(in Input) Result {
+	ageDays := int(in.Now.Sub(in.CreatedAt).Hours() / 24)
+
+	old := ageDays >= oldAgeDays
+	// Reposting and mass-posting must be INDEPENDENT signals: MassPostingCount (open)
+	// is a subset of RepostCount (any status), so counting both raw would let one
+	// concurrent spray fire two signals and reach the verdict alone. The repost signal
+	// therefore counts only the HISTORICAL churn — reposts beyond the concurrent open
+	// ones (roles closed and re-posted under new ids over time).
+	massPosted := in.MassPostingCount >= massThreshold
+	reposted := in.RepostCount-in.MassPostingCount >= repostThreshold
+
+	signals := 0
+	for _, on := range []bool{old, reposted, massPosted, in.EvergreenText} {
+		if on {
+			signals++
+		}
+	}
+
+	fakeFreshness := old && in.HasPostedAt && int(in.Now.Sub(in.PostedAt).Hours()/24) <= freshWindowDays
+
+	class := ClassStale
+	switch {
+	case signals >= convergence:
+		class = ClassLikelyEvergreen
+	case ageDays <= freshWindowDays && !in.EvergreenText:
+		class = ClassFresh
+	}
+
+	return Result{
+		Class: class,
+		Evidence: Evidence{
+			AgeDays:          ageDays,
+			RepostCount:      in.RepostCount,
+			MassPostingCount: in.MassPostingCount,
+			FakeFreshness:    fakeFreshness,
+		},
+	}
+}

--- a/internal/jobreality/classify_test.go
+++ b/internal/jobreality/classify_test.go
@@ -1,0 +1,121 @@
+package jobreality
+
+import (
+	"testing"
+	"time"
+)
+
+var now = time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+// base is an ordinary fresh, unique, active posting. Tests mutate one axis.
+func base() Input {
+	return Input{
+		Now:              now,
+		CreatedAt:        now.Add(-2 * 24 * time.Hour),
+		PostedAt:         now.Add(-2 * 24 * time.Hour),
+		HasPostedAt:      true,
+		RepostCount:      1,
+		MassPostingCount: 1,
+		EvergreenText:    false,
+	}
+}
+
+func daysAgo(d int) time.Time { return now.Add(-time.Duration(d) * 24 * time.Hour) }
+
+func TestClassify_FreshWhenNewAndNoSignals(t *testing.T) {
+	res := Classify(base())
+	if res.Class != ClassFresh {
+		t.Errorf("class = %q, want %q", res.Class, ClassFresh)
+	}
+	if res.Evidence.AgeDays != 2 {
+		t.Errorf("ageDays = %d, want 2", res.Evidence.AgeDays)
+	}
+}
+
+func TestClassify_StaleWhenLongOpenButNoOtherSignal(t *testing.T) {
+	in := base()
+	in.CreatedAt, in.PostedAt = daysAgo(240), daysAgo(240)
+	res := Classify(in)
+	if res.Class != ClassStale {
+		t.Errorf("class = %q, want %q", res.Class, ClassStale)
+	}
+}
+
+// Age alone must NEVER reach the verdict — a genuinely hard-to-fill senior role open
+// a long time is not evergreen.
+func TestClassify_AgeAloneIsNotEvergreen(t *testing.T) {
+	in := base()
+	in.CreatedAt, in.PostedAt = daysAgo(400), daysAgo(400)
+	if res := Classify(in); res.Class == ClassLikelyEvergreen {
+		t.Errorf("age alone reached %q", ClassLikelyEvergreen)
+	}
+}
+
+func TestClassify_LikelyEvergreenOnConvergence(t *testing.T) {
+	in := base()
+	in.CreatedAt, in.PostedAt = daysAgo(240), daysAgo(240)
+	in.RepostCount = 6
+	in.EvergreenText = true
+	res := Classify(in)
+	if res.Class != ClassLikelyEvergreen {
+		t.Errorf("class = %q, want %q", res.Class, ClassLikelyEvergreen)
+	}
+	if res.Evidence.RepostCount != 6 {
+		t.Errorf("evidence repostCount = %d, want 6", res.Evidence.RepostCount)
+	}
+}
+
+// Two independent signals (old age + mass-posting) are enough — the convergence gate
+// is exactly two. MassPostingCount is a subset of RepostCount (open ⊆ any-status), so
+// a valid all-concurrent spray sets both equal; the repost signal (historical churn)
+// stays silent here, proving mass-posting counts as one signal, not two.
+func TestClassify_TwoSignalsConverge(t *testing.T) {
+	in := base()
+	in.CreatedAt, in.PostedAt = daysAgo(120), daysAgo(120)
+	in.RepostCount, in.MassPostingCount = 8, 8
+	if res := Classify(in); res.Class != ClassLikelyEvergreen {
+		t.Errorf("class = %q, want %q (old age + mass-posting)", res.Class, ClassLikelyEvergreen)
+	}
+}
+
+// A concurrent mass-posting on its own — no age, no history, no text — must NOT reach
+// the verdict: mass-posting is a single signal and the gate needs convergence.
+func TestClassify_MassPostingAloneIsNotEvergreen(t *testing.T) {
+	in := base() // age 2 days, RepostCount default bumped to match mass below
+	in.RepostCount, in.MassPostingCount = 8, 8
+	if res := Classify(in); res.Class == ClassLikelyEvergreen {
+		t.Errorf("mass-posting alone reached %q", ClassLikelyEvergreen)
+	}
+}
+
+// A recent posted date over an old first-seen is recorded as fake-freshness evidence,
+// but on its own (only the old-age signal) it does not brand the job evergreen.
+func TestClassify_FakeFreshnessRecordedNotVerdict(t *testing.T) {
+	in := base()
+	in.CreatedAt = daysAgo(240)
+	in.PostedAt, in.HasPostedAt = daysAgo(1), true
+	res := Classify(in)
+	if !res.Evidence.FakeFreshness {
+		t.Error("expected FakeFreshness evidence when posted recent but first-seen old")
+	}
+	if res.Class == ClassLikelyEvergreen {
+		t.Errorf("fake-freshness alone reached %q", ClassLikelyEvergreen)
+	}
+}
+
+func TestClassify_NoFakeFreshnessWhenPostedMatchesFirstSeen(t *testing.T) {
+	in := base()
+	in.CreatedAt, in.PostedAt = daysAgo(240), daysAgo(240)
+	if res := Classify(in); res.Evidence.FakeFreshness {
+		t.Error("did not expect FakeFreshness when posted date matches first-seen")
+	}
+}
+
+func TestClassify_Deterministic(t *testing.T) {
+	in := base()
+	in.CreatedAt = daysAgo(200)
+	in.RepostCount, in.MassPostingCount, in.EvergreenText = 4, 6, true
+	if Classify(in) != Classify(in) {
+		t.Error("classification not deterministic for identical input")
+	}
+}

--- a/internal/jobreality/dictionary.go
+++ b/internal/jobreality/dictionary.go
@@ -1,0 +1,41 @@
+package jobreality
+
+import "strings"
+
+// evergreenPhrases are curated phrases that signal a posting is a perpetual
+// talent-pool / pipeline listing rather than a specific opening. They are kept
+// specific (multi-word) on purpose so a generic word like "pipeline" in "data
+// pipeline" never trips the signal — the dictionary never guesses. EN + RU surface
+// forms, matched case-insensitively as substrings.
+var evergreenPhrases = []string{
+	"always hiring",
+	"always looking for",
+	"we are always",
+	"we're always",
+	"talent community",
+	"talent pool",
+	"talent network",
+	"future opportunities",
+	"future openings",
+	"general application",
+	"open application",
+	"ongoing recruitment",
+	// RU
+	"всегда в поиске",
+	"постоянно ищем",
+	"постоянно в поиске",
+	"кадровый резерв",
+	"будущие вакансии",
+}
+
+// HasEvergreenMarker reports whether the description carries a curated evergreen
+// phrase. It emits nothing (false) for text it cannot match — never inferring.
+func HasEvergreenMarker(description string) bool {
+	lower := strings.ToLower(description)
+	for _, phrase := range evergreenPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/jobreality/dictionary_test.go
+++ b/internal/jobreality/dictionary_test.go
@@ -1,0 +1,38 @@
+package jobreality
+
+import "testing"
+
+func TestHasEvergreenMarker_DetectsKnownPhrases(t *testing.T) {
+	cases := map[string]string{
+		"always hiring":        "We are always hiring talented engineers.",
+		"talent community":     "Join our talent community for future roles.",
+		"talent pool":          "Add yourself to our talent pool.",
+		"future opportunities": "Submit your CV for future opportunities.",
+		"ru always looking":    "Мы всегда в поиске сильных разработчиков.",
+		"ru reserve":           "Резюме попадёт в кадровый резерв компании.",
+	}
+	for name, text := range cases {
+		t.Run(name, func(t *testing.T) {
+			if !HasEvergreenMarker(text) {
+				t.Errorf("expected evergreen marker in %q", text)
+			}
+		})
+	}
+}
+
+// The dictionary never guesses: an ordinary description with no evergreen phrasing
+// (even one mentioning a generic "pipeline") emits no marker.
+func TestHasEvergreenMarker_EmitsNothingForUnmatched(t *testing.T) {
+	cases := map[string]string{
+		"plain role":       "We are hiring a senior Go engineer to build our data pipeline.",
+		"specific opening": "This role owns the checkout service. Apply by Friday.",
+		"empty":            "",
+	}
+	for name, text := range cases {
+		t.Run(name, func(t *testing.T) {
+			if HasEvergreenMarker(text) {
+				t.Errorf("did not expect evergreen marker in %q", text)
+			}
+		})
+	}
+}

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -77,6 +77,10 @@ type Job struct {
 	// from the jobs columns (no read-time counting). Displayed on the detail page.
 	ViewCount    int32 `json:"view_count"`
 	AppliedCount int32 `json:"applied_count"`
+	// Reality is the job-reality signal (fresh/stale/likely-evergreen + evidence),
+	// computed at index/read time and attached by ClassifyReality — never stored, as
+	// it is time-dependent. Nil when not computed (e.g. a plain FromRow without counts).
+	Reality *Reality `json:"reality,omitempty"`
 }
 
 // FromRow maps a database job row to the public wire shape. The enrichment

--- a/internal/jobview/reality.go
+++ b/internal/jobview/reality.go
@@ -1,0 +1,43 @@
+package jobview
+
+import (
+	"time"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobreality"
+)
+
+// Reality is the served job-reality signal: the class plus the observable facts that
+// produced it, so the UI states facts ("open 240 days · reposted 6×") rather than a
+// bare accusation. It is computed at index/read time (never stored — it is
+// time-dependent) and attached via ClassifyReality; a job with no computed signal
+// omits the field.
+type Reality struct {
+	Class            string `json:"class"`
+	AgeDays          int    `json:"age_days"`
+	RepostCount      int    `json:"repost_count"`
+	MassPostingCount int    `json:"mass_posting_count"`
+	FakeFreshness    bool   `json:"fake_freshness"`
+}
+
+// ClassifyReality derives a job's reality signal from its row, the current time, and
+// the repost/mass-posting counts of its role cluster (see internal/db RoleClusterCount).
+// The evergreen-text signal is read from the description via the jobreality dictionary.
+func ClassifyReality(j db.Job, now time.Time, repostCount, massPostingCount int) Reality {
+	res := jobreality.Classify(jobreality.Input{
+		Now:              now,
+		CreatedAt:        j.CreatedAt.Time,
+		PostedAt:         j.PostedAt.Time,
+		HasPostedAt:      j.PostedAt.Valid,
+		RepostCount:      repostCount,
+		MassPostingCount: massPostingCount,
+		EvergreenText:    jobreality.HasEvergreenMarker(j.Description),
+	})
+	return Reality{
+		Class:            res.Class,
+		AgeDays:          res.Evidence.AgeDays,
+		RepostCount:      res.Evidence.RepostCount,
+		MassPostingCount: res.Evidence.MassPostingCount,
+		FakeFreshness:    res.Evidence.FakeFreshness,
+	}
+}

--- a/internal/jobview/reality_test.go
+++ b/internal/jobview/reality_test.go
@@ -1,0 +1,50 @@
+package jobview
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestClassifyReality_MapsConvergentSignalsToVerdict(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	j := db.Job{
+		CreatedAt:   pgtype.Timestamptz{Time: now.Add(-240 * 24 * time.Hour), Valid: true},
+		PostedAt:    pgtype.Timestamptz{Time: now.Add(-1 * 24 * time.Hour), Valid: true},
+		Description: "We are always hiring — join our talent community.",
+	}
+	// Reposted 6× historically; not mass-posted concurrently.
+	r := ClassifyReality(j, now, 6, 1)
+
+	if r.Class != "likely-evergreen" {
+		t.Errorf("class = %q, want likely-evergreen", r.Class)
+	}
+	if r.AgeDays != 240 {
+		t.Errorf("ageDays = %d, want 240", r.AgeDays)
+	}
+	if r.RepostCount != 6 {
+		t.Errorf("repostCount = %d, want 6", r.RepostCount)
+	}
+	if !r.FakeFreshness {
+		t.Error("expected FakeFreshness (posted 1d over first-seen 240d)")
+	}
+}
+
+func TestClassifyReality_FreshJobHasNoEvidence(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	j := db.Job{
+		CreatedAt:   pgtype.Timestamptz{Time: now.Add(-2 * 24 * time.Hour), Valid: true},
+		PostedAt:    pgtype.Timestamptz{Time: now.Add(-2 * 24 * time.Hour), Valid: true},
+		Description: "Own the checkout service. Apply by Friday.",
+	}
+	r := ClassifyReality(j, now, 1, 1)
+	if r.Class != "fresh" {
+		t.Errorf("class = %q, want fresh", r.Class)
+	}
+	if r.FakeFreshness {
+		t.Error("did not expect FakeFreshness on a genuinely new job")
+	}
+}

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -643,6 +643,10 @@ func facetSettings() *meilisearch.Settings {
 			// field the "posted within N days" range filter needs (Meili range operators
 			// require a number; the string posted_at below is sort-only).
 			"posted_ts",
+			// reality.class is the job-reality signal (fresh/stale/likely-evergreen),
+			// nested under the served reality object; the "hide likely-evergreen" filter
+			// matches on this dot path.
+			"reality.class",
 		},
 		// posted_at / created_at are RFC3339 UTC strings and sort chronologically as text.
 		SortableAttributes: []string{"posted_at", "created_at", "enrichment.salary_min", "enrichment.salary_max"},

--- a/internal/search/document.go
+++ b/internal/search/document.go
@@ -47,7 +47,10 @@ type JobDocument struct {
 // enrichment payload yields the zero Enrichment (the job is still fully
 // searchable by its text). Geography (regions/countries) and work_mode ride the
 // document top-level — the resolved union of parsed-location and enrichment
-// values — and are filtered via those bare attributes.
+// values — and are filtered via those bare attributes. The reality signal is NOT
+// set here (it needs the caller's clock and role-cluster counts); the caller
+// attaches it to the returned document via doc.Reality so it backs the
+// `reality.class` facet.
 func FromJob(j db.Job) (JobDocument, error) {
 	view, err := jobview.FromRow(j)
 	if err != nil {

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -31,6 +31,7 @@ var StringFacets = map[string]string{
 	"salary_period":    "enrichment.salary_period",
 	"skills":           "skills",
 	"role":             "roles",
+	"reality":          "reality.class",
 	"collections":      "collections",
 	"relocation":       "enrichment.relocation",
 	"english_level":    "enrichment.english_level",

--- a/migrations/0003_role_fingerprint.sql
+++ b/migrations/0003_role_fingerprint.sql
@@ -1,0 +1,20 @@
+-- role_fingerprint is the repost-identity of a job: a narrow content fingerprint
+-- over company + normalized title + normalized description, DELIBERATELY excluding
+-- volatile fields (posted_at, url, public_slug) so a role reposted under a new
+-- external_id with a refreshed posted date clusters to one fingerprint. It is the
+-- input to the job-reality signal's repost/mass-posting counts (see the
+-- job-reality-signal change). It is distinct from jobs.content_hash, which is the
+-- incremental-index CHANGE signal and INCLUDES posted_at — the two have opposite jobs.
+--
+-- The index backs the two per-(company_slug, role_fingerprint) counts the reality
+-- signal computes: distinct external_ids of any status (repost history) and of open
+-- jobs only (concurrent mass-posting).
+--
+-- Applied to a fresh volume by initdb after 0002; on an existing prod volume this
+-- ALTER must be run manually BEFORE deploying code that writes/reads the column, and
+-- role_fingerprint backfilled for existing rows so the counts are meaningful.
+ALTER TABLE public.jobs
+    ADD COLUMN role_fingerprint text;
+
+CREATE INDEX jobs_company_role_fingerprint_idx
+    ON public.jobs USING btree (company_slug, role_fingerprint);

--- a/openspec/changes/job-reality-signal/.openspec.yaml
+++ b/openspec/changes/job-reality-signal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/job-reality-signal/design.md
+++ b/openspec/changes/job-reality-signal/design.md
@@ -1,0 +1,47 @@
+## Context
+
+freehire already derives several deterministic facets from a job row (`internal/location`, `skilltag`, `classify`, `roletag`) and serves them dict-only through `jobview.FromRow` into a Meilisearch facet. This change adds a *history-derived* signal rather than a text-only one: it reads `jobs.created_at` / `posted_at` / `closed_at`, a repost-cluster count, a mass-posting count, and an evergreen-text dictionary hit, and folds them into a single `reality` class. The distinguishing asset is `created_at` — the moment freehire first saw a `(source, external_id)` — which no consumer of the source's `posted_at` can reconstruct.
+
+Constraints: sqlc-only DB access (edit `internal/db/queries/*.sql` → `make sqlc`); migrations apply via initdb (dev volume recreate; prod manual per deploy convention; no migration-runner yet); deterministic "never guesses" dictionary philosophy; additive and surgical; derived-facet changes reach existing jobs only via `cmd/backfill-derive` + `make reindex`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Classify each job `fresh` / `stale` / `likely-evergreen` deterministically, with `likely-evergreen` gated on signal *convergence*.
+- See through fake freshness using `created_at`, and cluster reposts under new `external_id`s via a narrow `role_fingerprint`.
+- Serve the class as a job-view field + `reality` Meilisearch facet, with facts-backed evidence for the badge.
+- Fit the existing derive/backfill/reindex machinery with no new worker.
+
+**Non-Goals:**
+- No company-level "this employer posts fake jobs" verdict — only per-posting, per convergence.
+- No LLM/ML classifier; enrichment's `enrichment.*` is never a source for this facet.
+- No new liveness/probe mechanism (the existing `liveness_strikes` orphan path is untouched).
+- No default hiding of `likely-evergreen` in the feed (facet is opt-in) — chosen framing is "middle": colored verdict only on convergence.
+
+## Decisions
+
+**1. A dedicated `role_fingerprint`, not `content_hash`.** `jobhash.Of` includes `posted_at` (and url/slug), so `content_hash` changes on a reposted-fresh duplicate and cannot cluster reposts. Add a narrow fingerprint over `company_slug + normalizedTitle + normalizedDescription`. Alternative considered: strip `posted_at` from `content_hash` — rejected because `content_hash` is the *change* signal for incremental indexing and must stay sensitive to `posted_at`; the two fingerprints have opposite jobs.
+
+**2. Persist the fingerprint on the write path; compute the repost *count* at derive/index time.** The fingerprint is a stored column (`jobs.role_fingerprint`) written by `UpsertJob`; the "distinct external_ids per (company_slug, role_fingerprint)" count is a query run during derive, not a stored counter (avoids write-time fan-out and keeps `UpsertJob` a single-row upsert). A partial index on `(company_slug, role_fingerprint) WHERE closed_at IS NULL` backs the count.
+
+**3. The class is computed in a pure `internal/jobreality` package.** Input is a small struct (age from `created_at`, `posted_at`, `closed_at`, repost count, mass-posting count, evergreen-text bool) → output `{Class, Evidence}`. This keeps the thresholds/convergence rule unit-testable in isolation, mirroring how `classify`/`roletag` are pure over their inputs. The scoring rule: `fresh` when age ≤ freshWindow and no evergreen signal; `likely-evergreen` when ≥ N of {old-age, repost≥k, mass-posting≥m, evergreen-text} converge; else `stale`.
+
+**4. Evidence is served, not just the class.** `jobview` carries `reality: {class, ageDays, repostCount, massPostingCount, fakeFreshness}` so the SPA renders facts, not a bare label — this is the legal/UX guard behind the "middle" framing.
+
+**5. Reality is compute-at-index, NOT a stored derived facet — because it is time-dependent.** Unlike geography/skills/seniority (invariant given the content), reality's age term (`now - created_at`) changes with the clock, so a stored class would go stale between derives (a `fresh` job silently becomes `stale`). It is therefore computed at index build in `search.FromJob` and served as a top-level `JobDocument` field, exactly like `Roles` (`roletag.Derive`) and `PostedTS` already are — no column, no `jobderive` entry, no `backfill-derive` participation for the class. What DOES get stored is only `role_fingerprint` (a stable content fingerprint, an input to the counts). The repost/mass counts are precomputed **once per reindex** as a `map[(company_slug, role_fingerprint)] → {repostCount, massPostingCount}` and passed into `FromJob`, so a full rebuild stays one aggregate pass, not N per-row queries. The incremental ingest push computes counts per new/changed job via a bounded single query. The single-row detail read (`jobview`) computes reality from the row plus one small count query. A dictionary/threshold change reaches existing jobs on the next `make reindex` alone (no `backfill-derive` needed for the class); only a `role_fingerprint` normalization change needs a fingerprint re-backfill.
+
+## Risks / Trade-offs
+
+- **False `likely-evergreen` on honest hard-to-fill roles** → convergence gate (never age-only) + facts-backed badge + opt-in facet (no default hide). Tunable thresholds live in one pure package.
+- **Repost count needs history to be meaningful** → on a fresh catalogue the count is 1 for everything; the signal strengthens as reposts accumulate. Acceptable: the other signals (true age, fake-freshness, text) work from day one.
+- **New filterable Meili attribute 500s `/jobs` until the first reindex** (known window) → ship binary, then `backfill-derive` + `reindex` in the documented order.
+- **Fingerprint normalization drift** (title/description cleaning) could split or over-merge reposts → keep normalization narrow and deterministic, cover with tests; a later normalization change is a `role_fingerprint` re-backfill.
+- **Schema change** (`role_fingerprint`) → dev volume recreate; prod migration applied manually *before* the new binary deploys (per the deploy/unapplied-migration convention).
+
+## Migration Plan
+
+1. Migration: `ALTER TABLE jobs ADD COLUMN role_fingerprint text;` + partial index.
+2. `make sqlc` after editing `UpsertJob` to accept/write `role_fingerprint`.
+3. Ship binary; apply migration in prod before deploy.
+4. Backfill `role_fingerprint` for existing rows (one-off derive), then `make reindex` — the reindex computes `reality` at index time (no `backfill-derive` step for the class, since it is not a stored facet).
+5. Rollback: the facet is additive; dropping the column and reverting the binary leaves the catalogue intact (soft, no data loss).

--- a/openspec/changes/job-reality-signal/proposal.md
+++ b/openspec/changes/job-reality-signal/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The most demoralizing part of a tech job search is not finding links — it is not knowing whether a posting is *real*. Evergreen reqs, talent-pool fishing, and reposts that fake a fresh date send applicants to burn effort on vacancies nobody is filling. Every other board trusts the source's posted date and cannot see through the trick. freehire uniquely keeps history (`jobs.created_at` = when *we* first saw a `(source, external_id)`), so it can tell an applicant "this 'posted 2 days ago' role has actually been open 240 days and was reposted 6 times" — a signal no single seeker, LLM, or competitor can compute.
+
+## What Changes
+
+- Add a deterministic **job-reality signal**: a small heuristic engine (`internal/jobreality`) that classifies each job as `fresh` / `stale` / `likely-evergreen` from history and text facts, mirroring the "never guesses" dictionary philosophy of `internal/location` / `skilltag` / `roletag` / `classify`.
+- Signals (all deterministic, combined — one signal is weak, convergence is strong):
+  - **True age** from `created_at` (not the gameable `posted_at`).
+  - **Fake-freshness**: `posted_at` recent while `created_at` is old.
+  - **Continuous-open duration** (`created_at → now`, `closed_at IS NULL`).
+  - **Mass-posting**: count of open jobs for the same `(company_slug, normalized title)`.
+  - **Evergreen text markers** ("always hiring", "talent community", "pipeline", RU equivalents) via a curated dictionary.
+  - **Repost clustering**: how many distinct `external_id`s share one narrow role fingerprint over time → "reposted 6×".
+- Persist a narrow **`role_fingerprint`** on the ingest write path (company + normalized title + description, **excluding** `posted_at`/url/slug) so reposts under new `external_id`s cluster. NOTE: `internal/jobhash` deliberately *includes* `posted_at` in `content_hash`, so `content_hash` cannot serve as the repost-identity key — a separate fingerprint is required.
+- Expose the classification as a Meilisearch facet (`reality`) — filterable, but **not** hidden by default — and surface it in the job view as a **facts-backed badge** ("open 240 days · posted date bumped 6× · company keeps this role permanently"). The colored `likely-evergreen` verdict shows **only when multiple signals converge**, never on age alone — no defamatory single-signal accusation, low false-positive risk on genuinely hard-to-fill senior roles.
+- Served **dict-only** and reconciled via `cmd/backfill-derive` + `make reindex`, exactly like the other derived facets.
+
+## Capabilities
+
+### New Capabilities
+- `job-reality-signal`: deterministic classification of a job's likelihood of being a real, active opening (`fresh`/`stale`/`likely-evergreen`) from ingest history + text, served as a job-view field and a Meilisearch `reality` facet with a facts-backed badge.
+
+### Modified Capabilities
+- `source-ingest`: the `UpsertJob` write path additionally computes and persists a narrow `role_fingerprint` (excluding volatile fields) so reposts of the same role under new `external_id`s are countable.
+
+## Impact
+
+- **Schema** (`migrations/`): `jobs.role_fingerprint text` + a supporting index for the "distinct external_ids per fingerprint per company" count. Schema change → recreate the dev volume (known no-migration-runner seam; prod applied manually per deploy convention).
+- **New package** `internal/jobreality` (+ dictionary, +tests).
+- **`internal/jobhash` / ingest normalize path**: compute `role_fingerprint` alongside `content_hash`; wire into `UpsertJob` params (edit `internal/db/queries/jobs.sql` → `make sqlc`).
+- **`internal/jobderive`** (or the backfill pass): derive `reality` at index build; `cmd/backfill-derive` re-derives on existing jobs.
+- **`internal/search` + `internal/jobview`**: new `reality` served field + filterable facet attribute (NEW attribute → the usual "500 until first reindex" window applies).
+- **`web/`**: reality badge on the job card + detail; optional `reality` filter chip in the filter modal.
+- **Ops**: after ship — apply migration, run `cmd/backfill-derive`, then `make reindex`.

--- a/openspec/changes/job-reality-signal/specs/job-reality-signal/spec.md
+++ b/openspec/changes/job-reality-signal/specs/job-reality-signal/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Each job carries a deterministic reality classification
+The system SHALL classify every job into exactly one reality class — `fresh`, `stale`, or `likely-evergreen` — computed deterministically from ingest history and posting text, with no randomness and no LLM call.
+
+#### Scenario: A newly first-seen posting is fresh
+- **WHEN** a job's `created_at` is recent (within the fresh window) and no evergreen signals apply
+- **THEN** its reality class is `fresh`
+
+#### Scenario: A long-open posting with no other signals is stale
+- **WHEN** a job has been continuously open well beyond the fresh window but no convergence of evergreen signals is present
+- **THEN** its reality class is `stale`, not `likely-evergreen`
+
+#### Scenario: The classification is stable for identical input
+- **WHEN** the same job row and clock are classified twice
+- **THEN** the resulting class and evidence are identical
+
+### Requirement: Likely-evergreen requires convergence, never a single signal
+The system SHALL assign `likely-evergreen` only when multiple independent signals converge, and MUST NOT assign it on age alone, so a genuinely hard-to-fill senior role open a long time is not mislabeled.
+
+#### Scenario: Age alone does not trigger the verdict
+- **WHEN** a job has been open 240 days but has no reposts, no mass-posting, and no evergreen text markers
+- **THEN** its reality class is `stale`, not `likely-evergreen`
+
+#### Scenario: Convergent signals trigger the verdict
+- **WHEN** a job is long-open AND its role has been reposted multiple times AND the description carries evergreen text markers
+- **THEN** its reality class is `likely-evergreen`
+
+### Requirement: True age is measured from first-seen, not the source posted date
+The system SHALL derive a job's age from `created_at` (when freehire first saw the `(source, external_id)`), so a posting whose `posted_at` is refreshed to look new is still measured from when it actually first appeared.
+
+#### Scenario: A reposted-fresh date does not reset perceived age
+- **WHEN** a job's `posted_at` is recent but its `created_at` is far older
+- **THEN** the reality signal treats the job as old and records fake-freshness evidence
+
+### Requirement: Repost clustering counts distinct postings of one role
+The system SHALL count how many distinct `external_id`s share one job's `role_fingerprint` within the same company, and expose that count as repost evidence.
+
+#### Scenario: Repeated reposts under new ids are counted
+- **WHEN** a company has published six distinct `external_id`s that share one role fingerprint
+- **THEN** each such job's evidence reports a repost count of six
+
+#### Scenario: A unique role has no repost signal
+- **WHEN** a job's role fingerprint is shared by no other posting in the company
+- **THEN** its repost count is one and contributes no evergreen signal
+
+### Requirement: Evergreen text markers come from a curated dictionary that never guesses
+The system SHALL detect evergreen phrasing ("always hiring", "talent community", "building a pipeline", and curated RU equivalents) via a deterministic dictionary, and MUST emit no marker for text it cannot match.
+
+#### Scenario: A known evergreen phrase is detected
+- **WHEN** a description contains a curated evergreen phrase
+- **THEN** the evergreen-text signal is set
+
+#### Scenario: Unmatched text yields no marker
+- **WHEN** a description contains no curated phrase
+- **THEN** no evergreen-text signal is emitted (the dictionary never infers)
+
+### Requirement: The reality signal is served dict-only and exposed as a search facet
+The system SHALL serve the reality class as a top-level job-view field and index it as a filterable Meilisearch `reality` facet, computed from the deterministic signal alone and never from LLM enrichment.
+
+#### Scenario: The facet is filterable but not hidden by default
+- **WHEN** a client requests jobs without a reality filter
+- **THEN** all classes are returned, and the client MAY filter by `reality` to include or exclude a class
+
+#### Scenario: Existing jobs are reconciled through reindex
+- **WHEN** the reality dictionary or thresholds change
+- **THEN** `make reindex` recomputes the class at index time on existing jobs (the class is computed at index, not stored, so no `backfill-derive` step is needed for it)
+
+### Requirement: The job view surfaces facts-backed evidence, not a bare verdict
+The system SHALL accompany a non-`fresh` classification with the observable facts that produced it — age in days, repost count, and mass-posting count — so the UI states facts ("open 240 days · reposted 6×") rather than an unsupported accusation.
+
+#### Scenario: Evidence travels with the classification
+- **WHEN** a job is classified `likely-evergreen`
+- **THEN** its served payload includes the age, repost count, and mass-posting count that justify the class

--- a/openspec/changes/job-reality-signal/specs/source-ingest/spec.md
+++ b/openspec/changes/job-reality-signal/specs/source-ingest/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: The write path persists a repost-clustering role fingerprint
+The `UpsertJob` write path SHALL compute and persist a narrow `role_fingerprint` for every job — derived from company, normalized title, and description, and deliberately excluding volatile fields (`posted_at`, url, public slug) — so reposts of the same role under new `external_id`s cluster to one fingerprint.
+
+#### Scenario: The fingerprint ignores a bumped posted date
+- **WHEN** a role is reposted under a new `external_id` with an identical title and description but a refreshed `posted_at`
+- **THEN** both postings resolve to the same `role_fingerprint`
+
+#### Scenario: content_hash is not reused as the fingerprint
+- **WHEN** the write path computes the fingerprint
+- **THEN** it uses a dedicated narrow fingerprint (not `content_hash`, which includes `posted_at` and so changes on repost)
+
+#### Scenario: A distinct role gets a distinct fingerprint
+- **WHEN** two postings differ in normalized title or description
+- **THEN** they resolve to different `role_fingerprint` values

--- a/openspec/changes/job-reality-signal/tasks.md
+++ b/openspec/changes/job-reality-signal/tasks.md
@@ -1,0 +1,30 @@
+## 1. Repost fingerprint (schema + write path)
+
+- [x] 1.1 Add migration: `jobs.role_fingerprint text` + btree index on `(company_slug, role_fingerprint)` (backs both counts — repost history any-status and concurrent open); note dev volume recreate + prod manual-apply-before-deploy in the migration comment.
+- [x] 1.2 Add a narrow fingerprint function (`jobhash.RoleFingerprint` over `company_slug` + normalized title + normalized description, **excluding** `posted_at`/url/slug); unit tests: bumped `posted_at` → same fingerprint, differing title/description → different fingerprint.
+- [x] 1.3 Wire the fingerprint into the write path: added `role_fingerprint` to `UpsertJob` (`jobs.sql` + `make sqlc`), set it beside `content_hash` in `cmd/ingest/store.go` and both `cmd/tg-extract/store.go` sites (NOT `content_hash`).
+- [x] 1.4 Integration test (`//go:build integration`): reposts under distinct `external_id`s cluster to one fingerprint; `RoleClusterCount` reports repost/mass counts; NULL/empty fingerprints excluded. Green on real Postgres.
+
+## 2. Reality classifier (pure `internal/jobreality`)
+
+- [x] 2.1 Curated evergreen-text dictionary (EN + RU surface forms: "always hiring", "talent community", "talent pool", RU "всегда в поиске"/"кадровый резерв", …) + phrase matcher; tests: known phrase matches, unmatched text (incl. generic "pipeline") emits nothing (never guesses).
+- [x] 2.2 Pure classifier: input `{now, createdAt, postedAt, hasPostedAt, repostCount, massPostingCount, evergreenText}` → `{Class, Evidence{ageDays, repostCount, massPostingCount, fakeFreshness}}`. Rule: `fresh` if age ≤ freshWindow and no evergreen signal; `likely-evergreen` only when ≥2 of {old-age, historical-repost≥k, massPosting≥m, evergreenText} converge (repost signal made independent of mass); else `stale`.
+- [x] 2.3 Classifier tests covering every spec scenario: fresh, stale, age-alone-is-not-evergreen, convergence-is-evergreen, mass-posting-alone-is-not-evergreen, fake-freshness recorded when `postedAt` recent but `createdAt` old, determinism.
+
+## 3. Derive, serve, and index
+
+- [x] 3.1 sqlc queries `RoleClusterCount` (single cluster: repost + mass) and `RoleClusterCountsAll` (whole-catalogue GROUP BY, HAVING>1, for the reindex lookup map); both exclude NULL/empty fingerprints. Verified by integration test.
+- [x] 3.2 `reality` computed at index time and attached via promoted `doc.Reality` (FromJob signature unchanged — less churn): `jobview.ClassifyReality(job, now, repost, mass)`. Reindex (`reindexFull` + incremental `reindexAll`) precomputes the count map once (`buildRealityLookup`); ingest incremental push computes the single count. Unit test `jobview.ClassifyReality`.
+- [x] 3.3 `handler.GetJob` (single Postgres row) computes `reality` from the row + one `RoleClusterCount`, attaches `view.Reality`; count-failure degrades to unique role. (List `/jobs` gets the badge via the Meili search path, not per-row PG.)
+- [x] 3.4 `internal/search`: `reality.class` added to `filterableAttributes` + `StringFacets["reality"]→"reality.class"` (query param → facet). New attribute → reindex before it filters (500 window noted).
+
+## 4. Web surface
+
+- [x] 4.1 Regenerated TS contracts (`make gen-contracts`); added `reality.go` to the jobview tygo `IncludeFiles` so the `Reality` interface + `reality?` field emit into `contracts.ts`.
+- [x] 4.2 `RealityBadge.svelte` + pure `realityBadge()` helper (vitest): `fresh`→nothing, `stale`→muted age chip, `likely-evergreen`→amber "Likely evergreen" with facts (title + inline `detailed`). Wired into `JobRow` (card) and `JobView` (detail).
+- [x] 4.3 Added `reality` facet to `FACETS` (pills, `excludable: true` → opt-in "exclude Likely evergreen"; not hidden by default). Values fresh/stale/likely-evergreen.
+
+## 5. Verify and reconcile
+
+- [x] 5.1 `go build ./... && go vet ./... && go test ./...` green (56 pkg); gofmt clean; DB integration tests green on real Postgres; web `vitest` (64) + `svelte-check` (0 errors) green.
+- [x] 5.2 Verification-before-completion: end-to-end HTTP test (`job_reality_integration_test.go`) drives `GET /api/v1/jobs/:slug` on a real Postgres — an old+evergreen-text job serves `reality.class = likely-evergreen` (age_days ~240), a new plain job serves `fresh`. Ship order: apply migration → deploy → backfill `role_fingerprint` → `make reindex` (no `backfill-derive`; reality is index-time).

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -4,6 +4,7 @@
   import { cardTags, formatSalary } from '$lib/enrichment';
   import type { Job } from '$lib/types';
   import { Badge } from '$lib/ui';
+  import RealityBadge from './RealityBadge.svelte';
   import { timeAgo } from '$lib/utils';
   import { hasViewed } from '$lib/viewedJobs.svelte';
 
@@ -43,9 +44,12 @@
         <Badge variant="secondary">{tag}</Badge>
       {/each}
     </div>
-    {#if posted}
-      <span class="shrink-0 text-xs text-muted-foreground">{posted}</span>
-    {/if}
+    <div class="flex shrink-0 items-center gap-2">
+      <RealityBadge reality={job.reality} />
+      {#if posted}
+        <span class="text-xs text-muted-foreground">{posted}</span>
+      {/if}
+    </div>
   </div>
 
   <h3 class="mt-2 line-clamp-2 text-lg font-semibold tracking-tight">{job.title}</h3>

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -12,6 +12,7 @@
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
   import JobMatch from './JobMatch.svelte';
+  import RealityBadge from './RealityBadge.svelte';
   import ReportDialog from './ReportDialog.svelte';
 
   // The job is server-rendered: it arrives as a prop from the route's `load`, so
@@ -173,6 +174,8 @@
         </div>
       {/if}
     </div>
+
+    <RealityBadge reality={job.reality} detailed />
 
     {#if showApplyPrompt && !applied}
       <div

--- a/web/src/lib/components/RealityBadge.svelte
+++ b/web/src/lib/components/RealityBadge.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { realityBadge } from '$lib/reality';
+  import type { Reality } from '$lib/generated/contracts';
+  import { cn } from '$lib/utils';
+
+  // Surfaces the job-reality signal as a facts-backed badge: nothing for a fresh or
+  // unclassified job, a muted age chip for a stale one, an amber "Likely evergreen"
+  // for a converged one. It states facts (in the label and the hover title, and
+  // inline when `detailed`), never a bare accusation. `detailed` renders the full
+  // fact string beside the badge on the job detail page.
+  let { reality, detailed = false }: { reality?: Reality | null; detailed?: boolean } = $props();
+
+  const badge = $derived(realityBadge(reality));
+
+  const toneClass: Record<'warn' | 'muted', string> = {
+    warn: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    muted: 'border-border text-muted-foreground',
+  };
+</script>
+
+{#if badge}
+  <span class="inline-flex items-center gap-1.5">
+    <span
+      title={badge.facts}
+      class={cn(
+        'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium',
+        toneClass[badge.tone],
+      )}
+    >
+      {badge.label}
+    </span>
+    {#if detailed}
+      <span class="text-xs text-muted-foreground">{badge.facts}</span>
+    {/if}
+  </span>
+{/if}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -329,6 +329,15 @@ export function categoryLabel(value: string): string {
 }
 const DOMAINS: FacetOption[] = options(DOMAIN_VALUES, DOMAIN_LABELS);
 
+// The job-reality classes (internal/jobreality) — a small closed set, spelled out
+// like CURRENCY (not a generated values array). Offered excludable so the common use
+// is "exclude Likely evergreen" to hide probable ghost postings; not hidden by default.
+const REALITY: FacetOption[] = [
+  { value: 'fresh', label: 'Fresh' },
+  { value: 'stale', label: 'Stale' },
+  { value: 'likely-evergreen', label: 'Likely evergreen' },
+];
+
 const CURRENCY: FacetOption[] = [
   { value: 'USD', label: 'USD' },
   { value: 'EUR', label: 'EUR' },
@@ -405,6 +414,7 @@ export const FACETS: FacetDef[] = [
   { param: 'employment_type', label: 'Employment', control: 'pills', options: EMPLOYMENT, excludable: true },
   { param: 'english_level', label: 'English', control: 'pills', options: ENGLISH, excludable: true },
   { param: 'posting_language', label: 'Job language', control: 'select', dynamic: true, excludable: true, placeholder: 'Search languages' },
+  { param: 'reality', label: 'Posting reality', control: 'pills', options: REALITY, excludable: true },
   { param: 'salary_currency', label: 'Currency', control: 'pills', options: CURRENCY, excludable: true },
   { param: 'company_slug', label: 'Company', control: 'remote', excludable: true, placeholder: 'Search companies', remote: companySearch },
   { param: 'source', label: 'Source', control: 'select', dynamic: true, excludable: true, placeholder: 'Search sources' },

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -134,6 +134,30 @@ export interface Job {
    */
   view_count: number /* int32 */;
   applied_count: number /* int32 */;
+  /**
+   * Reality is the job-reality signal (fresh/stale/likely-evergreen + evidence),
+   * computed at index/read time and attached by ClassifyReality — never stored, as
+   * it is time-dependent. Nil when not computed (e.g. a plain FromRow without counts).
+   */
+  reality?: Reality;
+}
+
+//////////
+// source: reality.go
+
+/**
+ * Reality is the served job-reality signal: the class plus the observable facts that
+ * produced it, so the UI states facts ("open 240 days · reposted 6×") rather than a
+ * bare accusation. It is computed at index/read time (never stored — it is
+ * time-dependent) and attached via ClassifyReality; a job with no computed signal
+ * omits the field.
+ */
+export interface Reality {
+  class: string;
+  age_days: number /* int */;
+  repost_count: number /* int */;
+  mass_posting_count: number /* int */;
+  fake_freshness: boolean;
 }
 
 /**

--- a/web/src/lib/reality.test.ts
+++ b/web/src/lib/reality.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { realityBadge } from './reality';
+import type { Reality } from './generated/contracts';
+
+const base = (over: Partial<Reality>): Reality => ({
+  class: 'fresh',
+  age_days: 2,
+  repost_count: 1,
+  mass_posting_count: 1,
+  fake_freshness: false,
+  ...over,
+});
+
+describe('realityBadge', () => {
+  it('returns null for a fresh job (no badge)', () => {
+    expect(realityBadge(base({ class: 'fresh' }))).toBeNull();
+  });
+
+  it('returns null when reality is absent', () => {
+    expect(realityBadge(undefined)).toBeNull();
+    expect(realityBadge(null)).toBeNull();
+  });
+
+  it('marks a likely-evergreen job with a warning tone and fact string', () => {
+    const b = realityBadge(base({ class: 'likely-evergreen', age_days: 240, repost_count: 6 }));
+    expect(b?.tone).toBe('warn');
+    expect(b?.facts).toContain('240');
+    expect(b?.facts).toContain('6'); // reposted 6×
+  });
+
+  it('reports fake-freshness in the facts when the posting date was refreshed', () => {
+    const b = realityBadge(base({ class: 'likely-evergreen', age_days: 300, fake_freshness: true }));
+    expect(b?.facts.toLowerCase()).toContain('refreshed');
+  });
+
+  it('marks a stale job with a muted tone stating its age', () => {
+    const b = realityBadge(base({ class: 'stale', age_days: 120 }));
+    expect(b?.tone).toBe('muted');
+    expect(b?.facts).toContain('120');
+  });
+});

--- a/web/src/lib/reality.ts
+++ b/web/src/lib/reality.ts
@@ -1,0 +1,30 @@
+import type { Reality } from './generated/contracts';
+
+/** A rendered job-reality badge: a tone and a compact label, plus the full fact
+ *  string that justifies it. `null` means show no badge (a fresh or unclassified
+ *  job). We state facts ("Open 240 days · reposted 6×"), never a bare accusation. */
+export interface RealityBadge {
+  tone: 'warn' | 'muted';
+  label: string;
+  facts: string;
+}
+
+/** facts assembles the observable evidence behind a non-fresh classification. */
+function facts(r: Reality): string {
+  const parts = [`Open ${r.age_days} days`];
+  if (r.repost_count > 1) parts.push(`reposted ${r.repost_count}×`);
+  if (r.mass_posting_count > 1) parts.push(`${r.mass_posting_count} open copies`);
+  if (r.fake_freshness) parts.push('posting date refreshed');
+  return parts.join(' · ');
+}
+
+/** realityBadge maps the served reality signal to a badge, or null when there is
+ *  nothing to show (fresh or missing). */
+export function realityBadge(reality?: Reality | null): RealityBadge | null {
+  if (!reality || reality.class === 'fresh') return null;
+  if (reality.class === 'likely-evergreen') {
+    return { tone: 'warn', label: 'Likely evergreen', facts: facts(reality) };
+  }
+  // stale
+  return { tone: 'muted', label: `Open ${reality.age_days}d`, facts: facts(reality) };
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic **posting-reality signal** — classifies each job `fresh` / `stale` / `likely-evergreen` from ingest history + text, so a job-seeker can tell a real opening from an evergreen/ghost posting.
- The moat: age is measured from `created_at` (when *we* first saw the posting), so it sees through reposts that fake a fresh `posted_at`. The `likely-evergreen` verdict fires **only on convergence of ≥2 independent signals** (never age alone) and is shown as **facts** ("open 240 days · reposted 6×"), not an accusation.
- Signals: true age, repost clustering (narrow `role_fingerprint` excluding `posted_at`), concurrent mass-posting, curated EN/RU evergreen-text dictionary.
- Reality is **computed at index/read time, not stored** (it is time-dependent, unlike the other dictionary facets) — mirrors `roles`/`posted_ts`. Served as `jobview.Reality`, indexed as the filterable `reality.class` Meili facet, rendered as a badge on card + detail with an opt-in filter chip.

## Key files
- `internal/jobhash/rolefingerprint.go` · `migrations/0003_role_fingerprint.sql` · `UpsertJob` (ingest + tg-extract)
- `internal/jobreality/` (pure classifier + dictionary)
- `RoleClusterCount` / `RoleClusterCountsAll` (counts, NULL-guarded)
- `internal/jobview/reality.go`, reindex/ingest/detail wiring, `internal/search` facet
- `web/`: `RealityBadge.svelte`, `reality.ts`, `facets.ts` chip
- OpenSpec change `job-reality-signal`

## Test Plan
- [x] `go build ./... && go vet ./...` clean; `gofmt` clean
- [x] `go test ./...` — 56 packages, 0 failures
- [x] DB integration on real Postgres — repost clustering + counts (`role_fingerprint_integration_test.go`)
- [x] End-to-end HTTP integration — `GET /api/v1/jobs/:slug` serves `likely-evergreen` for an old+evergreen job, `fresh` for a new one (`job_reality_integration_test.go`)
- [x] web `vitest` (64) + `svelte-check` (0 errors)

## Deploy order (schema + new Meili attribute)
apply migration `0003` → deploy binary → backfill `role_fingerprint` on existing rows → `make reindex` (no `backfill-derive`; reality is computed at index time).