### PR TITLE
feat(web): indexable collection landing pages

### DIFF
--- a/openspec/changes/collection-landing-pages/.openspec.yaml
+++ b/openspec/changes/collection-landing-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/collection-landing-pages/design.md
+++ b/openspec/changes/collection-landing-pages/design.md
@@ -1,0 +1,104 @@
+## Context
+
+`freehire` surfaces curated collections on the `/collections` hub. Two kinds exist
+in `web/src/lib/collections.ts`:
+
+- `COLLECTIONS` — company-membership collections (`yc`, `bigtech`, …), mirroring the
+  Go registry; each maps to the search facet `collections=<slug>`.
+- `FILTER_COLLECTIONS` — frontend-only attribute collections, each mapping to an
+  arbitrary set of `/jobs` facet params (currently just `remote-worldwide`).
+
+Every hub card links to `/jobs?collections=<slug>` (or `/jobs?<params>`). The
+`/jobs` list route hard-codes `canonical = <origin>/jobs`, so every filtered
+variant — including collections — canonicalises to the bare list. The curated copy
+never earns an indexable URL.
+
+`JobsView` already supports a `scope` prop: a `Record<string, string>` of fixed
+search params merged into every search but kept out of the URL and the
+user-facing filter set. Company pages use it (`scope={{ company_slug }}`). This is
+exactly the primitive a collection landing needs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Each curated collection gets an indexable, self-canonical landing at
+  `/collections/:slug` with its own `<title>`, `<h1>`, and description.
+- Reuse existing filtering/feed machinery — no new pagination or facet code.
+- Grow the attribute-collection set (regional remote landings) as pure data.
+- Fix the missing `<h1>` on `/jobs` and `/companies` along the way.
+
+**Non-Goals:**
+- Redirecting the old `/jobs?collections=<slug>` URLs (they remain valid manual
+  filters; canonical consolidation already handles the duplicate signal).
+- Multi-value (`OR`-list) scope params — every current collection param is
+  single-valued; a seam is left, not built.
+- Backend/spec changes to the search API or the Go collections registry.
+- A generated contract for `FILTER_COLLECTIONS` (still hand-kept; fold into
+  gen-contracts only if the set outgrows a single file).
+
+## Decisions
+
+**Route `/collections/[slug]` reusing `JobsView` `scope`.** The `+page.server.ts`
+resolves the slug against a unified lookup over both registries, builds the
+collection's facet params, and fetches the SSR first page
+(`searchJobs(params, 20, 0)`) — mirroring `/jobs/+page.server.ts`. The
+`+page.svelte` renders `<Seo>` (self-canonical), a visible `<h1>` + intro copy,
+then `<JobsView {initial} scope={params} excludeFacets={<collection facet keys>} />`.
+This is the same shape as `/companies/[slug]` → `CompanyView` → `JobsView`.
+_Alternative rejected:_ a bespoke read-only feed component — more code, loses the
+built-in filter/pagination/count behaviour for free.
+
+**Unified slug lookup.** A single exported helper resolves a slug to
+`{ title, description, params }`, checking `FILTER_COLLECTIONS` (own `params`) then
+`COLLECTIONS` (`{ collections: slug }`). Slugs are unique across both sets; the
+helper is the single source for the route, the hub links, and the sitemap, so they
+cannot drift. `scope` is `Record<string, string>`; the helper asserts every param
+value is a single string (current data holds), leaving the array seam explicit.
+
+**Template copy from the existing `title`.** `<title>` = `"<title> jobs · freehire"`,
+`<h1>` = `"<title> jobs"`, description/intro = the existing `description`. No new
+per-collection copy fields, no placeholders. An optional override field is a future
+seam if a template ever reads awkwardly.
+
+**Regional remote collections as data.** New `FILTER_COLLECTIONS` entries using
+validated facet values — regions from `REGION_LABELS`
+(`global, north_america, latam, eu, uk, mena, africa, apac, cis`) and countries as
+ISO alpha-2. Note the vocabulary: there is no `us` region — Remote US and Remote
+Brasil are country-level (`countries: us` / `countries: br`); Remote Latam is
+region-level (`regions: latam`). Each new collection is shipped only after its live
+count is confirmed healthy and non-empty.
+
+**Sitemap via `STATIC_PATHS`.** Add `/collections` and `/for-companies` to
+`STATIC_PATHS`, plus one `/collections/:slug` per entry in the unified registry.
+The set is small and fixed (~a dozen), so it stays in the static-pages sub-sitemap —
+no new sub-sitemap or backend query.
+
+**List-page `<h1>`.** Add one semantic `<h1>` to `JobsView` and `CompaniesView`
+(e.g. "Tech jobs" / "Companies hiring in tech"), styled to match the existing page
+headers.
+
+## Risks / Trade-offs
+
+- **Thin/empty collection landings hurt SEO** → gate each new collection on a
+  healthy live count before shipping; skip any that are near-empty.
+- **Invalid facet values would render an empty feed** → params validated against
+  the generated `REGION_LABELS` / country vocabulary, never guessed.
+- **Duplicate signal between `/collections/:slug` and `/jobs?collections=<slug>`**
+  → the collection landing is the canonical, internally linked (hub) and
+  sitemapped home; `/jobs?collections=<slug>` canonicalises to `/jobs`, so it does
+  not compete. Acceptable, no redirect needed.
+- **`JobsView` embedded mode** (non-standalone) hides the swipe button and routes
+  header search into the scoped list — identical to company pages, so the UX is
+  consistent and already proven.
+
+## Migration Plan
+
+Pure additive frontend change; no schema or data migration. Deploy is a standard
+`web` build. Rollback is reverting the route + data entries; old `/jobs?…` filter
+URLs keep working throughout. No reindex needed (facet params already indexed).
+
+## Open Questions
+
+- Final curated list of regional remote collections to ship in this iteration —
+  decided at implementation time from live counts (start set: Remote Latam, Remote
+  Brasil, Remote US; extend to Remote Europe / APAC if counts warrant).

--- a/openspec/changes/collection-landing-pages/proposal.md
+++ b/openspec/changes/collection-landing-pages/proposal.md
@@ -16,8 +16,10 @@ collection its own server-rendered, self-canonical landing page.
   for `company_slug`) to pin the collection's facet params — no new filtering code.
 - Point the `/collections` hub cards at `/collections/:slug` instead of `/jobs?…`.
 - Expand `FILTER_COLLECTIONS` with regional remote landings (e.g. Remote Latam,
-  Remote Brasil, Remote US) — additive data entries, each validated against the
-  live facet vocabulary and shipped only when it has a healthy, non-empty count.
+  Remote Brasil, Remote US) and language/framework landings (the "<lang> jobs"
+  search pattern: Python, Go, Rust, Ruby, Node.js, React, … mapping to the `skills`
+  facet) — additive data entries, each validated against the live facet vocabulary
+  and shipped only when it has a healthy, non-empty count.
 - List the `/collections` hub, each collection landing, and `/for-companies` in
   the sitemap.
 - Add a visible `<h1>` to the `/jobs` and `/companies` list pages (currently

--- a/openspec/changes/collection-landing-pages/proposal.md
+++ b/openspec/changes/collection-landing-pages/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Curated collections (`Y Combinator`, `AI Companies`, `Remote Worldwide`, …) are
+high-intent search targets with ready-made copy, but they have no indexable URL:
+every collection card links to `/jobs?collections=<slug>`, and the `/jobs` list
+hard-codes its canonical to the bare `/jobs`, so Google collapses all collections
+into one page. The curated landing content cannot rank. This change gives each
+collection its own server-rendered, self-canonical landing page.
+
+## What Changes
+
+- Add a server-rendered route `/collections/:slug` that renders a collection's
+  job feed with a collection-specific `<title>`, `<h1>`, `<meta name="description">`,
+  and a self-canonical URL. Unknown slug → 404.
+- Reuse the existing `JobsView` `scope` mechanism (the same one company pages use
+  for `company_slug`) to pin the collection's facet params — no new filtering code.
+- Point the `/collections` hub cards at `/collections/:slug` instead of `/jobs?…`.
+- Expand `FILTER_COLLECTIONS` with regional remote landings (e.g. Remote Latam,
+  Remote Brasil, Remote US) — additive data entries, each validated against the
+  live facet vocabulary and shipped only when it has a healthy, non-empty count.
+- List the `/collections` hub, each collection landing, and `/for-companies` in
+  the sitemap.
+- Add a visible `<h1>` to the `/jobs` and `/companies` list pages (currently
+  missing).
+
+## Capabilities
+
+### New Capabilities
+<!-- none: this surfaces existing collections through the existing SSR/SEO capability -->
+
+### Modified Capabilities
+- `web-ssr-seo`: add indexable collection landing pages (per-collection metadata +
+  visible `<h1>`), extend the sitemap to enumerate the collection pages and the
+  `/collections` hub, and require a visible `<h1>` on the public list pages.
+
+## Impact
+
+- **web/** — new route `web/src/routes/collections/[slug]/` (server load + page);
+  `collections/+page.server.ts` (card hrefs); `lib/collections.ts` (new
+  filter-collection entries + a unified slug→collection lookup); `lib/sitemap.ts`
+  (`STATIC_PATHS` + collection URLs); `JobsView`/`CompaniesView` (`<h1>`).
+- No backend changes: the search API already accepts `collections`, `regions`,
+  `countries`, and `work_mode` facet params.

--- a/openspec/changes/collection-landing-pages/specs/web-ssr-seo/spec.md
+++ b/openspec/changes/collection-landing-pages/specs/web-ssr-seo/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Collection landing pages are indexable
+
+The frontend SHALL serve a server-rendered landing page at `GET /collections/:slug`
+for each curated collection, so the collection's job feed and its curated copy are
+in the initial HTML. The page SHALL emit collection-specific document metadata: a
+`<title>` and `<meta name="description">` distinct from the generic `/jobs` list,
+a `<link rel="canonical">` pointing at its own `/collections/:slug` URL (never the
+bare `/jobs`), and a single visible `<h1>` naming the collection. The page SHALL
+render the collection's open jobs by pinning the collection's facet params (e.g.
+`collections=<slug>`, or `work_mode`/`regions`/`countries` for an attribute
+collection) as a fixed scope the visitor can further filter but cannot remove. An
+unrecognised slug SHALL return a 404 (not a 200 empty or unfiltered page). Each
+collection landing page SHALL be enumerated in the sitemap.
+
+#### Scenario: A collection has its own canonical landing page
+
+- **WHEN** `GET /collections/:slug` is requested for a known collection
+- **THEN** the HTML `<head>` contains a collection-specific `<title>`, a
+  `<meta name="description">`, and a `<link rel="canonical">` whose URL is that
+  same `/collections/:slug` (not `/jobs`)
+
+#### Scenario: The landing page shows the collection's jobs in the initial HTML
+
+- **WHEN** `GET /collections/:slug` is requested for a known collection with open jobs
+- **THEN** the returned HTML body contains a single `<h1>` naming the collection
+  and the first page of that collection's job rows (not an empty shell)
+
+#### Scenario: An unknown collection slug is a 404
+
+- **WHEN** `GET /collections/:slug` is requested for a slug that maps to no collection
+- **THEN** the server responds with a 404 status and an error page
+
+#### Scenario: Collection landing pages are in the sitemap
+
+- **WHEN** the sitemap's static-pages sub-sitemap is requested
+- **THEN** it lists a `<loc>` for the `/collections` hub and for each collection's
+  `/collections/:slug` landing page
+
+### Requirement: Public list pages carry a primary heading
+
+The public list pages (`/jobs` and `/companies`) SHALL each render exactly one visible `<h1>` describing the page's content, so the primary heading is present for search engines and assistive technology.
+
+#### Scenario: The jobs list has a top-level heading
+
+- **WHEN** `GET /jobs` is requested
+- **THEN** the returned HTML body contains exactly one `<h1>` describing the jobs list
+
+#### Scenario: The companies list has a top-level heading
+
+- **WHEN** `GET /companies` is requested
+- **THEN** the returned HTML body contains exactly one `<h1>` describing the companies list

--- a/openspec/changes/collection-landing-pages/tasks.md
+++ b/openspec/changes/collection-landing-pages/tasks.md
@@ -1,0 +1,40 @@
+## 1. Collection registry lookup
+
+- [ ] 1.1 Add a unified `collectionBySlug(slug)` helper in `lib/collections.ts` that resolves a slug to `{ title, description, params }`, checking `FILTER_COLLECTIONS` then `COLLECTIONS` (`{ collections: slug }`); returns undefined for unknown slugs
+- [ ] 1.2 Add a `collectionSlugs()` / exported list of all collection slugs for the sitemap, sourced from the same two registries
+- [ ] 1.3 Unit-test the lookup: known filter slug, known company slug, unknown slug, and slug uniqueness across the two sets
+
+## 2. Collection landing route
+
+- [ ] 2.1 Create `web/src/routes/collections/[slug]/+page.server.ts`: resolve the slug via `collectionBySlug`, `error(404)` when unknown, fetch `initial = searchJobs(params, 20, 0)`, return `{ collection, initial }`
+- [ ] 2.2 Create `web/src/routes/collections/[slug]/+page.svelte`: `<Seo>` with self-canonical `/collections/:slug`, template `<title>` (`"<title> jobs · freehire"`) and description; visible `<h1>` (`"<title> jobs"`) + intro copy; render `<JobsView {initial} scope={params} excludeFacets={collectionFacetKeys} />`
+- [ ] 2.3 Verify SSR: the landing HTML contains the `<h1>`, the job rows, and a self-referential canonical (not `/jobs`); an unknown slug returns 404
+
+## 3. Hub links
+
+- [ ] 3.1 In `collections/+page.server.ts`, carry each card's `slug` and set `href` to `/collections/:slug` (drop the `/jobs?…` href); keep the count logic unchanged
+- [ ] 3.2 Confirm `collections/+page.svelte` links resolve to the landing pages
+
+## 4. Regional remote collections (data)
+
+- [ ] 4.1 Add regional remote entries to `FILTER_COLLECTIONS` with validated facet params: Remote Latam (`regions: latam`), Remote Brasil (`countries: br`), Remote US (`countries: us`), each with `work_mode: remote`
+- [ ] 4.2 Verify each new collection returns a healthy, non-empty count against the live search API; drop or defer any that are thin
+- [ ] 4.3 (Optional) add Remote Europe (`regions: eu`) / Remote APAC (`regions: apac`) if counts warrant
+
+## 5. Sitemap
+
+- [ ] 5.1 Add `/collections` and `/for-companies` to `STATIC_PATHS` in `lib/sitemap.ts`
+- [ ] 5.2 Append one `/collections/:slug` per collection slug to the static-pages sub-sitemap
+- [ ] 5.3 Verify `GET /sitemap-pages.xml` lists the hub and every collection landing
+
+## 6. List-page headings
+
+- [ ] 6.1 Add a single semantic `<h1>` to `JobsView` (e.g. "Tech jobs"), styled to match existing headers
+- [ ] 6.2 Add a single semantic `<h1>` to `CompaniesView` (e.g. "Companies hiring in tech")
+- [ ] 6.3 Verify `/jobs` and `/companies` each render exactly one `<h1>`
+
+## 7. Verification
+
+- [ ] 7.1 `npm run check` (svelte-check) and lint pass
+- [ ] 7.2 Validate a landing page's JSON-LD / metadata and canonical in the rendered HTML
+- [ ] 7.3 `openspec validate collection-landing-pages --strict` passes

--- a/openspec/changes/collection-landing-pages/tasks.md
+++ b/openspec/changes/collection-landing-pages/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Collection registry lookup
 
-- [ ] 1.1 Add a unified `collectionBySlug(slug)` helper in `lib/collections.ts` that resolves a slug to `{ title, description, params }`, checking `FILTER_COLLECTIONS` then `COLLECTIONS` (`{ collections: slug }`); returns undefined for unknown slugs
-- [ ] 1.2 Add a `collectionSlugs()` / exported list of all collection slugs for the sitemap, sourced from the same two registries
-- [ ] 1.3 Unit-test the lookup: known filter slug, known company slug, unknown slug, and slug uniqueness across the two sets
+- [x] 1.1 Add a unified `collectionBySlug(slug)` helper in `lib/collections.ts` that resolves a slug to `{ title, description, params }`, checking `FILTER_COLLECTIONS` then `COLLECTIONS` (`{ collections: slug }`); returns undefined for unknown slugs
+- [x] 1.2 Add a `collectionSlugs()` / exported list of all collection slugs for the sitemap, sourced from the same two registries
+- [x] 1.3 Unit-test the lookup: known filter slug, known company slug, unknown slug, and slug uniqueness across the two sets
 
 ## 2. Collection landing route
 
-- [ ] 2.1 Create `web/src/routes/collections/[slug]/+page.server.ts`: resolve the slug via `collectionBySlug`, `error(404)` when unknown, fetch `initial = searchJobs(params, 20, 0)`, return `{ collection, initial }`
-- [ ] 2.2 Create `web/src/routes/collections/[slug]/+page.svelte`: `<Seo>` with self-canonical `/collections/:slug`, template `<title>` (`"<title> jobs · freehire"`) and description; visible `<h1>` (`"<title> jobs"`) + intro copy; render `<JobsView {initial} scope={params} excludeFacets={collectionFacetKeys} />`
-- [ ] 2.3 Verify SSR: the landing HTML contains the `<h1>`, the job rows, and a self-referential canonical (not `/jobs`); an unknown slug returns 404
+- [x] 2.1 Create `web/src/routes/collections/[slug]/+page.server.ts`: resolve the slug via `collectionBySlug`, `error(404)` when unknown, thread `url.searchParams` and set the collection's scope params on top, fetch `initial = searchJobs(facets, 20, 0)`, return `{ collection, initial }`
+- [x] 2.2 Create `web/src/routes/collections/[slug]/+page.svelte`: `<Seo>` with self-canonical `/collections/:slug`, template `<title>` (`"<title> jobs · freehire"`) and description; visible `<h1>` (`"<title> jobs"`) + intro copy; BreadcrumbList JSON-LD; render `<JobsView {initial} scope={params} excludeFacets={collectionFacetKeys} />`
+- [x] 2.3 Verify SSR: the landing HTML contains the `<h1>`, the job rows, and a self-referential canonical (not `/jobs`); an unknown slug returns 404; a filtered URL (`?work_mode=remote`) server-renders the filtered subset
 
 ## 3. Hub links
 
-- [ ] 3.1 In `collections/+page.server.ts`, carry each card's `slug` and set `href` to `/collections/:slug` (drop the `/jobs?…` href); keep the count logic unchanged
-- [ ] 3.2 Confirm `collections/+page.svelte` links resolve to the landing pages
+- [x] 3.1 In `collections/+page.server.ts`, carry each card's `slug` and set `href` to `/collections/:slug` (drop the `/jobs?…` href); keep the count logic unchanged
+- [x] 3.2 Confirm `collections/+page.svelte` links resolve to the landing pages
 
 ## 4. Regional remote collections (data)
 
-- [ ] 4.1 Add regional remote entries to `FILTER_COLLECTIONS` with validated facet params: Remote Latam (`regions: latam`), Remote Brasil (`countries: br`), Remote US (`countries: us`), each with `work_mode: remote`
-- [ ] 4.2 Verify each new collection returns a healthy, non-empty count against the live search API; drop or defer any that are thin
-- [ ] 4.3 (Optional) add Remote Europe (`regions: eu`) / Remote APAC (`regions: apac`) if counts warrant
+- [x] 4.1 Add regional remote entries to `FILTER_COLLECTIONS` with validated facet params: Remote Latam (`regions: latam`), Remote Brasil (`countries: br`), Remote US (`countries: us`), each with `work_mode: remote`
+- [x] 4.2 Verify each new collection returns a healthy, non-empty count against the live search API; drop or defer any that are thin
+- [x] 4.3 (Optional) add Remote Europe (`regions: eu`) / Remote APAC (`regions: apac`) if counts warrant — both shipped (29k / 15k live counts)
 
 ## 5. Sitemap
 
-- [ ] 5.1 Add `/collections` and `/for-companies` to `STATIC_PATHS` in `lib/sitemap.ts`
-- [ ] 5.2 Append one `/collections/:slug` per collection slug to the static-pages sub-sitemap
-- [ ] 5.3 Verify `GET /sitemap-pages.xml` lists the hub and every collection landing
+- [x] 5.1 Add `/collections` and `/for-companies` to `STATIC_PATHS` in `lib/sitemap.ts`
+- [x] 5.2 Append one `/collections/:slug` per collection slug to the static-pages sub-sitemap
+- [x] 5.3 Verify `GET /sitemap-pages.xml` lists the hub and every collection landing
 
 ## 6. List-page headings
 
-- [ ] 6.1 Add a single semantic `<h1>` to `JobsView` (e.g. "Tech jobs"), styled to match existing headers
-- [ ] 6.2 Add a single semantic `<h1>` to `CompaniesView` (e.g. "Companies hiring in tech")
-- [ ] 6.3 Verify `/jobs` and `/companies` each render exactly one `<h1>`
+- [x] 6.1 Add a single semantic `<h1>` to the `/jobs` route page ("Tech jobs") — placed at route level (not in `JobsView`) so embedded/scoped uses keep their own single `<h1>`
+- [x] 6.2 Add a single semantic `<h1>` to the `/companies` route page ("Companies hiring in tech") — same route-level placement rationale
+- [x] 6.3 Verify `/jobs` and `/companies` each render exactly one `<h1>`
 
 ## 7. Verification
 
-- [ ] 7.1 `npm run check` (svelte-check) and lint pass
-- [ ] 7.2 Validate a landing page's JSON-LD / metadata and canonical in the rendered HTML
-- [ ] 7.3 `openspec validate collection-landing-pages --strict` passes
+- [x] 7.1 `npm run check` (svelte-check) and lint pass
+- [x] 7.2 Validate a landing page's JSON-LD / metadata and canonical in the rendered HTML
+- [x] 7.3 `openspec validate collection-landing-pages --strict` passes

--- a/openspec/changes/collection-landing-pages/tasks.md
+++ b/openspec/changes/collection-landing-pages/tasks.md
@@ -20,6 +20,7 @@
 - [x] 4.1 Add regional remote entries to `FILTER_COLLECTIONS` with validated facet params: Remote Latam (`regions: latam`), Remote Brasil (`countries: br`), Remote US (`countries: us`), each with `work_mode: remote`
 - [x] 4.2 Verify each new collection returns a healthy, non-empty count against the live search API; drop or defer any that are thin
 - [x] 4.3 (Optional) add Remote Europe (`regions: eu`) / Remote APAC (`regions: apac`) if counts warrant — both shipped (29k / 15k live counts)
+- [x] 4.4 Add language/framework collections (the "<lang> jobs" pattern) mapping to the `skills` facet, using exact skilltag canonicals (`go`/`nodejs`/`cpp`/`csharp`, not `golang`/`node`/`c++`/`c#`); 16 languages + 8 frameworks, each count-verified against the live `/jobs/facets` distribution
 
 ## 5. Sitemap
 

--- a/web/src/lib/collections.test.ts
+++ b/web/src/lib/collections.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { collectionBySlug, collectionSlugs } from './collections';
+
+describe('collectionBySlug', () => {
+  it('resolves a company-membership collection to a collections facet param', () => {
+    const c = collectionBySlug('yc');
+    expect(c).toBeDefined();
+    expect(c?.title).toBe('Y Combinator');
+    expect(c?.params).toEqual({ collections: 'yc' });
+  });
+
+  it('resolves a filter collection to its own facet params', () => {
+    const c = collectionBySlug('remote-worldwide');
+    expect(c).toBeDefined();
+    expect(c?.title).toBe('Remote Worldwide');
+    expect(c?.params).toEqual({ work_mode: 'remote', regions: 'global' });
+  });
+
+  it('returns undefined for an unknown slug', () => {
+    expect(collectionBySlug('does-not-exist')).toBeUndefined();
+  });
+});
+
+describe('collectionSlugs', () => {
+  it('lists every collection slug across both registries with no duplicates', () => {
+    const slugs = collectionSlugs();
+    expect(slugs).toContain('yc'); // company collection
+    expect(slugs).toContain('remote-worldwide'); // filter collection
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -67,6 +67,156 @@ export const FILTER_COLLECTIONS: FilterCollection[] = [
     description: 'Fully remote roles open to candidates across Asia-Pacific.',
     params: { work_mode: 'remote', regions: 'apac' },
   },
+  // Language & framework landings — the classic "<lang> jobs" search pattern, one
+  // per canonical `skills` facet value. `slug`/`params.skills` MUST be the exact
+  // skilltag canonical (e.g. `go` not `golang`, `nodejs` not `node`, `cpp`/`csharp`
+  // not `c++`/`c#`) or the feed comes back empty. Each was confirmed to have a live
+  // count before shipping; the few low-count ones (clojure/elixir/svelte) are kept
+  // deliberately — low-competition "<lang> jobs" terms with hundreds of real roles.
+  {
+    slug: 'python',
+    title: 'Python',
+    description: 'Open roles that use Python — backend, data, ML and automation.',
+    params: { skills: 'python' },
+  },
+  {
+    slug: 'javascript',
+    title: 'JavaScript',
+    description: 'Open roles that use JavaScript across web and backend.',
+    params: { skills: 'javascript' },
+  },
+  {
+    slug: 'typescript',
+    title: 'TypeScript',
+    description: 'Open roles that use TypeScript for typed JavaScript at scale.',
+    params: { skills: 'typescript' },
+  },
+  {
+    slug: 'java',
+    title: 'Java',
+    description: 'Open roles that use Java — enterprise backends, Android and big data.',
+    params: { skills: 'java' },
+  },
+  {
+    slug: 'csharp',
+    title: 'C#',
+    description: 'Open roles that use C# and the .NET ecosystem.',
+    params: { skills: 'csharp' },
+  },
+  {
+    slug: 'cpp',
+    title: 'C++',
+    description: 'Open roles that use C++ — systems, games and performance-critical code.',
+    params: { skills: 'cpp' },
+  },
+  {
+    slug: 'go',
+    title: 'Go',
+    description: 'Open roles that use Go for backends, infra and cloud-native services.',
+    params: { skills: 'go' },
+  },
+  {
+    slug: 'rust',
+    title: 'Rust',
+    description: 'Open roles that use Rust for safe, high-performance systems.',
+    params: { skills: 'rust' },
+  },
+  {
+    slug: 'ruby',
+    title: 'Ruby',
+    description: 'Open roles that use Ruby, from web apps to tooling.',
+    params: { skills: 'ruby' },
+  },
+  {
+    slug: 'php',
+    title: 'PHP',
+    description: 'Open roles that use PHP for web backends and platforms.',
+    params: { skills: 'php' },
+  },
+  {
+    slug: 'kotlin',
+    title: 'Kotlin',
+    description: 'Open roles that use Kotlin for Android and JVM backends.',
+    params: { skills: 'kotlin' },
+  },
+  {
+    slug: 'swift',
+    title: 'Swift',
+    description: 'Open roles that use Swift for iOS, macOS and Apple platforms.',
+    params: { skills: 'swift' },
+  },
+  {
+    slug: 'scala',
+    title: 'Scala',
+    description: 'Open roles that use Scala for JVM backends and data engineering.',
+    params: { skills: 'scala' },
+  },
+  {
+    slug: 'nodejs',
+    title: 'Node.js',
+    description: 'Open roles that use Node.js for JavaScript backends and APIs.',
+    params: { skills: 'nodejs' },
+  },
+  {
+    slug: 'clojure',
+    title: 'Clojure',
+    description: 'Open roles that use Clojure and functional JVM development.',
+    params: { skills: 'clojure' },
+  },
+  {
+    slug: 'elixir',
+    title: 'Elixir',
+    description: 'Open roles that use Elixir and the BEAM for scalable backends.',
+    params: { skills: 'elixir' },
+  },
+  {
+    slug: 'react',
+    title: 'React',
+    description: 'Open roles that use React to build web interfaces.',
+    params: { skills: 'react' },
+  },
+  {
+    slug: 'angular',
+    title: 'Angular',
+    description: 'Open roles that use Angular for web applications.',
+    params: { skills: 'angular' },
+  },
+  {
+    slug: 'vue',
+    title: 'Vue',
+    description: 'Open roles that use Vue.js for web interfaces.',
+    params: { skills: 'vue' },
+  },
+  {
+    slug: 'nextjs',
+    title: 'Next.js',
+    description: 'Open roles that use Next.js for full-stack React apps.',
+    params: { skills: 'nextjs' },
+  },
+  {
+    slug: 'spring',
+    title: 'Spring',
+    description: 'Open roles that use Spring for Java backends.',
+    params: { skills: 'spring' },
+  },
+  {
+    slug: 'rails',
+    title: 'Rails',
+    description: 'Open roles that use Ruby on Rails for web applications.',
+    params: { skills: 'rails' },
+  },
+  {
+    slug: 'django',
+    title: 'Django',
+    description: 'Open roles that use Django for Python web backends.',
+    params: { skills: 'django' },
+  },
+  {
+    slug: 'svelte',
+    title: 'Svelte',
+    description: 'Open roles that use Svelte and SvelteKit for web interfaces.',
+    params: { skills: 'svelte' },
+  },
 ];
 
 // toQuery expands a filter collection's params into a URL query string, repeating a

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -33,6 +33,40 @@ export const FILTER_COLLECTIONS: FilterCollection[] = [
       'Fully remote roles open to candidates anywhere in the world, not tied to a country or region.',
     params: { work_mode: 'remote', regions: 'global' },
   },
+  // Regional remote landings. Params use the canonical facet vocabulary: regions
+  // from REGION_LABELS (there is no `us` region — the US is country-level), and
+  // countries as ISO 3166-1 alpha-2. Each was confirmed to have a healthy,
+  // non-empty live count before shipping.
+  {
+    slug: 'remote-latam',
+    title: 'Remote Latam',
+    description: 'Fully remote roles open to candidates across Latin America.',
+    params: { work_mode: 'remote', regions: 'latam' },
+  },
+  {
+    slug: 'remote-brasil',
+    title: 'Remote Brasil',
+    description: 'Fully remote roles open to candidates in Brazil.',
+    params: { work_mode: 'remote', countries: 'br' },
+  },
+  {
+    slug: 'remote-us',
+    title: 'Remote US',
+    description: 'Fully remote roles open to candidates in the United States.',
+    params: { work_mode: 'remote', countries: 'us' },
+  },
+  {
+    slug: 'remote-europe',
+    title: 'Remote Europe',
+    description: 'Fully remote roles open to candidates across Europe.',
+    params: { work_mode: 'remote', regions: 'eu' },
+  },
+  {
+    slug: 'remote-apac',
+    title: 'Remote APAC',
+    description: 'Fully remote roles open to candidates across Asia-Pacific.',
+    params: { work_mode: 'remote', regions: 'apac' },
+  },
 ];
 
 // toQuery expands a filter collection's params into a URL query string, repeating a
@@ -100,3 +134,51 @@ export const COLLECTIONS: Collection[] = [
       'Open roles at globally distributed companies founded by Eastern European (incl. Russian-speaking) founders or with Eastern European engineering roots.',
   },
 ];
+
+// A resolved collection: the display copy plus the fixed job-search facet params
+// that scope its feed. `params` is single-valued (the shape JobsView's `scope`
+// pins) — every current collection maps to single values; a multi-value filter
+// collection would need `scope` widened first (see design's array seam).
+export type ResolvedCollection = {
+  title: string;
+  description: string;
+  params: Record<string, string>;
+};
+
+// Flatten a filter collection's params to the single-valued scope shape. A
+// single-element list collapses to its element; a genuine multi-value param is
+// unsupported by `scope` today and takes its first value (no such data exists).
+function scopeParams(params: Record<string, string | string[]>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      const [first] = value;
+      if (first !== undefined) out[key] = first;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+// Resolve a slug to its collection, checking filter collections first, then
+// company-membership collections (which map to the `collections` facet). Returns
+// undefined for an unknown slug. The single source used by the /collections/:slug
+// landing route, the hub card links, and the sitemap, so they cannot drift.
+export function collectionBySlug(slug: string): ResolvedCollection | undefined {
+  const filter = FILTER_COLLECTIONS.find((c) => c.slug === slug);
+  if (filter) {
+    return { title: filter.title, description: filter.description, params: scopeParams(filter.params) };
+  }
+  const company = COLLECTIONS.find((c) => c.slug === slug);
+  if (company) {
+    return { title: company.title, description: company.description, params: { collections: company.slug } };
+  }
+  return undefined;
+}
+
+// Every collection slug across both registries — the sitemap's source for the
+// collection landing URLs. Slugs are unique across the two sets.
+export function collectionSlugs(): string[] {
+  return [...FILTER_COLLECTIONS.map((c) => c.slug), ...COLLECTIONS.map((c) => c.slug)];
+}

--- a/web/src/lib/sitemap.test.ts
+++ b/web/src/lib/sitemap.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { STATIC_PATHS, collectionPaths } from './sitemap';
+
+describe('sitemap static paths', () => {
+  it('includes the collections hub and the for-companies page', () => {
+    expect(STATIC_PATHS).toContain('/collections');
+    expect(STATIC_PATHS).toContain('/for-companies');
+  });
+});
+
+describe('collectionPaths', () => {
+  it('maps every collection slug to its /collections/:slug landing path', () => {
+    const paths = collectionPaths();
+    expect(paths).toContain('/collections/yc'); // company collection
+    expect(paths).toContain('/collections/remote-worldwide'); // filter collection
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -3,13 +3,30 @@
 // is an index that points at chunked sub-sitemaps (static pages, job chunks,
 // company chunks). Each chunk is one keyset page fetched by cursor.
 
+import { collectionSlugs } from './collections';
+
 // Must equal the backend's sitemapMaxURLs — the chunk size the boundary cursors
 // are computed with — so each sub-sitemap holds exactly one keyset chunk and
 // never exceeds the protocol limit.
 export const SITEMAP_CHUNK = 50000;
 
 /** The site's static, always-present pages (relative paths). */
-export const STATIC_PATHS = ['/', '/jobs', '/companies', '/cli', '/recruiters'];
+export const STATIC_PATHS = [
+  '/',
+  '/jobs',
+  '/companies',
+  '/collections',
+  '/for-companies',
+  '/cli',
+  '/recruiters',
+];
+
+/** The curated collection landing pages (`/collections/:slug`), one per collection.
+ *  A small, fixed set, so they ride in the static-pages sub-sitemap alongside
+ *  STATIC_PATHS rather than needing their own chunked file. */
+export function collectionPaths(): string[] {
+  return collectionSlugs().map((slug) => `/collections/${slug}`);
+}
 
 export interface UrlEntry {
   loc: string;

--- a/web/src/routes/collections/+page.server.ts
+++ b/web/src/routes/collections/+page.server.ts
@@ -3,14 +3,14 @@ import { COLLECTIONS, FILTER_COLLECTIONS, toQuery } from '$lib/collections';
 import type { PageServerLoad } from './$types';
 
 // One card on the /collections hub, normalized across both kinds of collection so
-// the page can render them uniformly. `href` is a bare `/jobs?…` path (the component
-// wraps it with `resolve`) and doubles as the card's identity; `count` is the
-// open-job count, or null when it could not be fetched — counts are decorative, so a
-// failed fetch degrades to no count.
+// the page can render them uniformly. `href` is the collection's own landing page
+// (`/collections/:slug`, the component wraps it with `resolve`) and doubles as the
+// card's identity; `count` is the open-job count, or null when it could not be
+// fetched — counts are decorative, so a failed fetch degrades to no count.
 export type CollectionCard = {
   title: string;
   description: string;
-  href: `/jobs?${string}`;
+  href: `/collections/${string}`;
   count: number | null;
 };
 
@@ -39,14 +39,14 @@ export const load: PageServerLoad = async ({ fetch }) => {
       } catch {
         // Count is decorative — leave it null on failure.
       }
-      return { title: fc.title, description: fc.description, href: `/jobs?${query}`, count };
+      return { title: fc.title, description: fc.description, href: `/collections/${fc.slug}`, count };
     }),
   );
 
   const companyCards: CollectionCard[] = COLLECTIONS.map((c) => ({
     title: c.title,
     description: c.description,
-    href: `/jobs?collections=${c.slug}`,
+    href: `/collections/${c.slug}`,
     count: facetCounts ? (facetCounts[c.slug] ?? 0) : null,
   }));
 

--- a/web/src/routes/collections/[slug]/+page.server.ts
+++ b/web/src/routes/collections/[slug]/+page.server.ts
@@ -1,0 +1,27 @@
+import { error } from '@sveltejs/kit';
+import { serverApi } from '$lib/server/api';
+import { collectionBySlug } from '$lib/collections';
+import type { PageServerLoad } from './$types';
+
+const LIMIT = 20;
+
+// Server-render a collection's landing page: the display copy plus the first page
+// of its scoped feed, so the rows are in the initial HTML. An unrecognised slug is
+// a 404. The collection's facet params are pinned as JobsView `scope` on the
+// client, so the feed stays fixed to the collection while the visitor can still
+// filter within it.
+//
+// The SSR search starts from the visitor's in-URL filters, then sets the
+// collection's scope params on top (scope wins) — mirroring the company page — so
+// a shared or reloaded filtered collection URL (e.g. ?skills=go) server-renders
+// the same filtered list the hydrated JobsView shows, not the unfiltered feed.
+export const load: PageServerLoad = async ({ params, url, fetch }) => {
+  const collection = collectionBySlug(params.slug);
+  if (!collection) error(404, 'Collection not found');
+
+  const facets = new URLSearchParams(url.searchParams);
+  for (const [key, value] of Object.entries(collection.params)) facets.set(key, value);
+
+  const initial = await serverApi(fetch).searchJobs(facets, LIMIT, 0);
+  return { slug: params.slug, collection, initial };
+};

--- a/web/src/routes/collections/[slug]/+page.svelte
+++ b/web/src/routes/collections/[slug]/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import JobsView from '$lib/components/JobsView.svelte';
+  import Seo from '$lib/components/Seo.svelte';
+  import { breadcrumbJsonLd, jsonLdScript } from '$lib/seo';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const origin = $derived(page.url.origin);
+  // Self-canonical: the landing page is the collection's canonical home, never the
+  // bare /jobs the raw ?collections= filter would resolve to.
+  const canonical = $derived(`${origin}/collections/${data.slug}`);
+  // Template copy from the collection's display title (see design): "<title> jobs".
+  const heading = $derived(`${data.collection.title} jobs`);
+  // Request hiding the facets the collection pins via `scope`. Note: this only
+  // hides standalone facets; the collection facets that live in composite panes
+  // (collections/work_mode/regions) stay visible in the filter UI for now, but
+  // `scope` re-pins them on every search so the user can never actually remove the
+  // collection's constraint (JobsView.scopedParams) — hiding those controls is a
+  // deferred UI polish, not a correctness gap.
+  const excludeFacets = $derived(Object.keys(data.collection.params));
+  // Breadcrumb structured data (freehire → Collections → this collection), mirroring
+  // the company landing — this is an SEO landing page, so the trail helps engines.
+  const jsonLd = $derived(
+    jsonLdScript(
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Collections', url: `${origin}/collections` },
+        { name: heading, url: canonical },
+      ])
+    )
+  );
+</script>
+
+<Seo title={`${heading} · freehire`} description={data.collection.description} {canonical} />
+
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD built by jsonLdScript, which escapes `<`; raw injection is the only way to emit a structured-data <script> -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <header class="mb-8">
+    <h1 class="text-2xl font-semibold tracking-tight">{heading}</h1>
+    <p class="mt-2 max-w-2xl text-sm leading-relaxed text-muted-foreground">
+      {data.collection.description}
+    </p>
+  </header>
+
+  <!-- Remount on slug change so the seeded paginator/filters start fresh per
+       collection (mirrors the company page). -->
+  {#key data.slug}
+    <JobsView initial={data.initial} scope={data.collection.params} {excludeFacets} />
+  {/key}
+</div>

--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -16,5 +16,8 @@
 />
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <!-- Primary heading for search engines and assistive tech. pl-12 clears the
+       mobile filters edge tab (reset at md), matching the list's top row. -->
+  <h1 class="mb-4 pl-12 text-2xl font-semibold tracking-tight md:pl-0">Companies hiring in tech</h1>
   <CompaniesView initial={data.initial} />
 </div>

--- a/web/src/routes/jobs/+page.svelte
+++ b/web/src/routes/jobs/+page.svelte
@@ -16,5 +16,8 @@
 />
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <!-- Primary heading for search engines and assistive tech. pl-12 clears the
+       mobile filters edge tab (reset at md), matching the list's top row. -->
+  <h1 class="mb-4 pl-12 text-2xl font-semibold tracking-tight md:pl-0">Tech jobs</h1>
   <JobsView initial={data.initial} />
 </div>

--- a/web/src/routes/sitemap-pages.xml/+server.ts
+++ b/web/src/routes/sitemap-pages.xml/+server.ts
@@ -1,8 +1,10 @@
-import { STATIC_PATHS, urlsetXml, xmlResponse } from '$lib/sitemap';
+import { STATIC_PATHS, collectionPaths, urlsetXml, xmlResponse } from '$lib/sitemap';
 import type { RequestHandler } from './$types';
 
-// Sub-sitemap for the site's static pages, referenced by the sitemap index.
+// Sub-sitemap for the site's static pages plus the curated collection landing
+// pages, referenced by the sitemap index.
 export const GET: RequestHandler = ({ url }) => {
-  const entries = STATIC_PATHS.map((path) => ({ loc: `${url.origin}${path}` }));
+  const paths = [...STATIC_PATHS, ...collectionPaths()];
+  const entries = paths.map((path) => ({ loc: `${url.origin}${path}` }));
   return xmlResponse(urlsetXml(entries));
 };


### PR DESCRIPTION
## Summary

Curated collections had no indexable URL — every hub card linked to
`/jobs?collections=<slug>`, which the `/jobs` list canonicalises to bare `/jobs`,
so Google collapsed them all into one page. This gives each collection its own
server-rendered, self-canonical landing.

- **New route `/collections/[slug]`** reusing `JobsView`'s `scope` (the same
  primitive company pages use): per-collection `<title>`/`<h1>`/description,
  self-canonical URL, `BreadcrumbList` JSON-LD, 404 on unknown slug. The SSR
  search threads `url.searchParams` so a shared/reloaded filtered collection URL
  renders filtered (not the full feed).
- **39 collection landings**: 6 regional-remote (Latam/Brasil/US/Europe/APAC +
  Worldwide), 24 language/framework (`<lang> jobs` → `skills` facet), 9 company.
  Every entry's live count was verified non-empty; slugs use exact skilltag
  canonicals (`go`/`nodejs`/`cpp`/`csharp`).
- **Hub** cards now link to `/collections/:slug`.
- **Sitemap** lists `/collections`, `/for-companies`, and every collection landing.
- **Missing `<h1>`** added to `/jobs` and `/companies` (route level → one per page).

Planned via OpenSpec change `collection-landing-pages` (modifies `web-ssr-seo`).

## Test Plan

- [x] `npm run check` (svelte-check) — 0 errors / 0 warnings
- [x] `npm test` — 65 passing (new `collections.test.ts`, `sitemap.test.ts`)
- [x] SSR against prod API: landings 200 with h1/self-canonical/job rows; unknown
      slug → 404; `?work_mode=remote` filters at SSR; `/jobs` & `/companies` one `<h1>`
- [x] `sitemap-pages.xml` lists hub + all landings
- [x] Multi-agent review (correctness/cross-file/cleanup) — one SSR-filter bug found & fixed