### PR TITLE
fix(location): rescue Global from description-only geo restrictions

### DIFF
--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -72,6 +72,17 @@ type Derived struct {
 // and skills (structured ∪ dictionary).
 func Derive(in Input) Derived {
 	geo := location.Parse(in.Location)
+	// Geography precedence: the location dictionary → a US-only description signal.
+	// When the location left the geography unpinned (no country, and either no region
+	// or only the bare-"Remote" global bucket) but the description states a hard
+	// US-only eligibility requirement, the job is US-restricted, not open-anywhere —
+	// pin it to the US so it leaves Global/Worldwide. Like the work-mode fallback
+	// below, prose is the lowest-priority source and only fills what the location
+	// dictionary left blank; a resolved place is never overridden.
+	countries, regions := geo.Countries, geo.Regions
+	if usOnly(countries, regions, in.Description) {
+		countries, regions = []string{"us"}, []string{"north_america"}
+	}
 	// Work-mode precedence: structured (ATS) → location marker → description phrase.
 	// Each lower source only fills a value the higher ones left empty.
 	workMode := in.WorkMode
@@ -110,8 +121,8 @@ func Derive(in Input) Derived {
 	return Derived{
 		CompanySlug: normalize.Slug(in.Company),
 		PublicSlug:  normalize.JobSlug(in.Title, in.Company, in.Source, in.ExternalID),
-		Countries:   geo.Countries,
-		Regions:     geo.Regions,
+		Countries:   countries,
+		Regions:     regions,
 		Cities:      geo.Cities,
 		WorkMode:    workMode,
 		// Skills is a set: the structured source skills are unioned with the
@@ -125,6 +136,22 @@ func Derive(in Input) Derived {
 		EnglishLevel:       jobfacts.EnglishLevel(in.Description),
 		ExperienceYearsMin: experience,
 	}
+}
+
+// usOnly reports whether a job's geography is unpinned by the location dictionary —
+// no country resolved, and either no region or only the bare-"Remote" global bucket —
+// while its description carries a hard US-only eligibility signal. It is the gate for
+// the US geography override in Derive: a resolved country or a specific region (e.g.
+// "eu" from "Europe") is left untouched, so the override only rescues the exact case a
+// bare-"Remote" posting with a US-citizenship/clearance requirement falls into.
+func usOnly(countries, regions []string, desc string) bool {
+	if len(countries) != 0 {
+		return false
+	}
+	if len(regions) > 1 || (len(regions) == 1 && regions[0] != "global") {
+		return false
+	}
+	return location.USOnlyFromDescription(desc)
 }
 
 // unionSkills merges the structured source skills with the dictionary skills into a

--- a/internal/jobderive/jobderive_test.go
+++ b/internal/jobderive/jobderive_test.go
@@ -364,3 +364,63 @@ func TestDerive_SourceSkillsUnionWithDictionary(t *testing.T) {
 		t.Errorf("Skills = %v, want [go kubernetes] (source ∪ dictionary, deduped+sorted)", got.Skills)
 	}
 }
+
+// A bare-"Remote" location resolves to the global bucket, but a hard US-only
+// eligibility statement in the description pins the job to the US instead of leaving
+// it Global/Worldwide (the reported bug: a US-citizen/clearance role labeled global).
+func TestDerive_USOnlyDescriptionPinsBareRemoteToUS(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Senior Full-Stack Engineer",
+		Company:     "Redhorse",
+		Source:      "lever",
+		ExternalID:  "1",
+		Location:    "Remote", // → global bucket, no country
+		Description: "Must be a U.S. Citizen and eligible for a U.S. SECRET clearance.",
+	})
+	if !reflect.DeepEqual(got.Countries, []string{"us"}) {
+		t.Errorf("Countries = %v, want [us]", got.Countries)
+	}
+	if !reflect.DeepEqual(got.Regions, []string{"north_america"}) {
+		t.Errorf("Regions = %v, want [north_america] (not global)", got.Regions)
+	}
+	// The override touches only geography — remoteness stays on the work-mode facet.
+	if got.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (unchanged)", got.WorkMode)
+	}
+}
+
+// The US-only override fires ONLY when the location left the geography unpinned. A
+// location that resolved a specific place ("Remote - Germany" → de/eu) is never
+// overridden, even if the description mentions a US eligibility phrase.
+func TestDerive_USOnlyDoesNotOverrideResolvedPlace(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Engineer",
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Location:    "Remote - Germany", // resolves de/eu
+		Description: "US citizenship preferred but we hire across the EU.",
+	})
+	if !reflect.DeepEqual(got.Countries, []string{"de"}) {
+		t.Errorf("Countries = %v, want [de] (resolved place not overridden)", got.Countries)
+	}
+}
+
+// A bare-"Remote" job whose description carries no US-only phrase stays global — the
+// override never guesses, so genuinely open-anywhere remote jobs are unaffected.
+func TestDerive_BareRemoteWithoutUSOnlyStaysGlobal(t *testing.T) {
+	got := Derive(Input{
+		Title:       "Engineer",
+		Company:     "Acme",
+		Source:      "greenhouse",
+		ExternalID:  "board:1",
+		Location:    "Remote",
+		Description: "We are a fully distributed team hiring worldwide.",
+	})
+	if len(got.Countries) != 0 {
+		t.Errorf("Countries = %v, want [] (no US-only signal)", got.Countries)
+	}
+	if !reflect.DeepEqual(got.Regions, []string{"global"}) {
+		t.Errorf("Regions = %v, want [global] (unchanged)", got.Regions)
+	}
+}

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -90,15 +90,20 @@ func FromRow(j db.Job) (Job, error) {
 		}
 	}
 
-	// The six dictionary-derived facets are sourced from the jobs columns ONLY (the
+	// The dictionary-derived facets are sourced from the jobs columns ONLY (the
 	// deterministic dictionaries are the production source); the LLM's values for
 	// them are excluded from the served object so the LLM can later run free as a
 	// discovery signal without corrupting production data. The LLM values stay in
 	// the stored enrichment JSONB (untouched) but are folded out of the served copy
 	// here. normalizeSet lowercases/sorts/dedups each column and guarantees a
 	// non-nil slice so the facet serializes as [] not null.
-	countries := normalizeSet(j.Countries)
-	regions := normalizeSet(j.Regions)
+	//
+	// Countries/regions are the exception (like cities): a hybrid dict-then-LLM facet.
+	// The dictionary wins whenever it pinned a place, but when it left geography
+	// unpinned — no country and at most the bare-"Remote" "global" bucket — the LLM's
+	// enrichment.countries/regions fill in, catching a restriction stated only in the
+	// prose ("Remote (SPAIN only)") that the location string never carried.
+	countries, regions := geoFacet(j.Countries, j.Regions, e.Countries, e.Regions)
 	workMode := j.WorkMode
 	// Seniority/category are the dictionary column value, always — never the LLM's,
 	// and never a dict-silent fill. They stay nested under enrichment, so the
@@ -182,6 +187,42 @@ var nonCityFallback = map[string]struct{}{
 	"remote": {}, "remote-first": {}, "fully remote": {}, "worldwide": {},
 	"anywhere": {}, "global": {}, "distributed": {}, "hybrid": {},
 	"onsite": {}, "on-site": {}, "work from home": {}, "wfh": {},
+}
+
+// geoFacet builds the served country/region facets. The deterministic dictionary
+// columns win whenever they pinned a place — a country, or a region more specific
+// than the open-anywhere "global" bucket. Only when the dictionary left geography
+// unpinned (no country, and at most the bare-"Remote" "global" region) does it fall
+// back wholesale to the LLM's enrichment.countries/regions, which read a restriction
+// stated only in the prose ("Remote (SPAIN only)") that the location string never
+// carried. This mirrors cityFacet's dict-then-LLM hybrid; a pinned dictionary place
+// is never overridden, so the LLM can only fill the global/unspecified bucket — never
+// corrupt a resolved facet. Both outputs are lowercased/sorted/deduped (non-nil).
+func geoFacet(dictCountries, dictRegions, llmCountries, llmRegions []string) (countries, regions []string) {
+	countries = normalizeSet(dictCountries)
+	regions = normalizeSet(dictRegions)
+	if geoPinned(countries, regions) {
+		return countries, regions
+	}
+	llmC, llmR := normalizeSet(llmCountries), normalizeSet(llmRegions)
+	if len(llmC) == 0 && len(llmR) == 0 {
+		return countries, regions // the LLM knows no more than the dict — keep it
+	}
+	return llmC, llmR
+}
+
+// geoPinned reports whether the dictionary resolved a concrete place: a country, or a
+// region more specific than the open-anywhere "global" bucket.
+func geoPinned(countries, regions []string) bool {
+	if len(countries) > 0 {
+		return true
+	}
+	for _, r := range regions {
+		if r != "global" {
+			return true
+		}
+	}
+	return false
 }
 
 // cityFacet builds the served city facet: the deterministic dictionary cities when

--- a/internal/jobview/jobview_test.go
+++ b/internal/jobview/jobview_test.go
@@ -184,9 +184,11 @@ func TestFromRow_GeographyAndWorkModeAreDictOnly(t *testing.T) {
 	}
 }
 
-// A dictionary-silent facet is served empty, never filled from the LLM — the
-// load-bearing case that lets the LLM later run free without leaking into
-// production facets.
+// A dictionary-silent facet is served empty for the STRICT dict-only facets
+// (skills/work_mode/seniority/category), never filled from the LLM — the load-bearing
+// case that lets the LLM run free without leaking into those production facets.
+// Geography is the documented exception (geoFacet): a dict-silent country/region DOES
+// fall back to the LLM, asserted separately below.
 func TestFromRow_DictSilentFacetsAreEmptyNotLLM(t *testing.T) {
 	raw, err := json.Marshal(enrich.Enrichment{
 		Countries: []string{"fr"},
@@ -204,8 +206,9 @@ func TestFromRow_DictSilentFacetsAreEmptyNotLLM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FromRow: %v", err)
 	}
-	if len(view.Countries) != 0 || len(view.Regions) != 0 || len(view.Skills) != 0 {
-		t.Errorf("multi-valued facets should be empty, got countries=%v regions=%v skills=%v", view.Countries, view.Regions, view.Skills)
+	// Strict dict-only facets stay empty when the dictionary is silent.
+	if len(view.Skills) != 0 {
+		t.Errorf("skills should be empty (dict silent), got %v", view.Skills)
 	}
 	if view.WorkMode != "" {
 		t.Errorf("WorkMode = %q, want empty (dict silent, LLM ignored)", view.WorkMode)
@@ -213,6 +216,64 @@ func TestFromRow_DictSilentFacetsAreEmptyNotLLM(t *testing.T) {
 	if view.Enrichment.Seniority != "" || view.Enrichment.Category != "" {
 		t.Errorf("seniority/category should be empty, got {%q, %q}", view.Enrichment.Seniority, view.Enrichment.Category)
 	}
+	// Geography is the hybrid exception: dict silent → LLM countries/regions fill in.
+	if len(view.Countries) != 1 || view.Countries[0] != "fr" {
+		t.Errorf("Countries = %v, want [fr] (LLM fallback when dict silent)", view.Countries)
+	}
+	if len(view.Regions) != 1 || view.Regions[0] != "eu" {
+		t.Errorf("Regions = %v, want [eu] (LLM fallback when dict silent)", view.Regions)
+	}
+}
+
+// Geography is a dict-then-LLM hybrid. The LLM fills in only when the dictionary left
+// the geography unpinned — empty, or the bare-"Remote" "global" bucket (the reported
+// bug: "Remote (SPAIN only)" where the ATS location string was just "Remote" and only
+// the description named Spain, which the LLM read into enrichment.countries=[es]).
+func TestFromRow_GeoHybridFallback(t *testing.T) {
+	llm, err := json.Marshal(enrich.Enrichment{Countries: []string{"ES"}, Regions: []string{"eu"}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Bare-remote global bucket → LLM's Spain fills in, replacing global.
+	t.Run("global bucket falls back to LLM", func(t *testing.T) {
+		view, err := FromRow(db.Job{ID: 1, PublicSlug: "x-1", Regions: []string{"global"}, Enrichment: llm})
+		if err != nil {
+			t.Fatalf("FromRow: %v", err)
+		}
+		if len(view.Countries) != 1 || view.Countries[0] != "es" {
+			t.Errorf("Countries = %v, want [es]", view.Countries)
+		}
+		if len(view.Regions) != 1 || view.Regions[0] != "eu" {
+			t.Errorf("Regions = %v, want [eu] (global replaced)", view.Regions)
+		}
+	})
+
+	// A dictionary-pinned place (a resolved country) is NEVER overridden by the LLM.
+	t.Run("pinned dict wins over LLM", func(t *testing.T) {
+		view, err := FromRow(db.Job{ID: 2, PublicSlug: "x-2", Countries: []string{"de"}, Regions: []string{"eu"}, Enrichment: llm})
+		if err != nil {
+			t.Fatalf("FromRow: %v", err)
+		}
+		if len(view.Countries) != 1 || view.Countries[0] != "de" {
+			t.Errorf("Countries = %v, want [de] (pinned dict, LLM ignored)", view.Countries)
+		}
+	})
+
+	// Genuinely open-anywhere: dict global and the LLM knows no place either → stays global.
+	t.Run("global with no LLM geo stays global", func(t *testing.T) {
+		bare, err := json.Marshal(enrich.Enrichment{WorkMode: "remote"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		view, err := FromRow(db.Job{ID: 3, PublicSlug: "x-3", Regions: []string{"global"}, Enrichment: bare})
+		if err != nil {
+			t.Fatalf("FromRow: %v", err)
+		}
+		if len(view.Regions) != 1 || view.Regions[0] != "global" {
+			t.Errorf("Regions = %v, want [global] (open-anywhere unchanged)", view.Regions)
+		}
+	})
 }
 
 func TestFromRow_WorkModeIsTheDictValue(t *testing.T) {

--- a/internal/location/eligibility.go
+++ b/internal/location/eligibility.go
@@ -1,0 +1,34 @@
+package location
+
+import "strings"
+
+// usOnlyPhrases are anchored, US-specific eligibility statements that mark a role
+// as restricted to the United States. Like descriptionWorkModePhrases, they are
+// tuned for PRECISION over recall in long prose: only phrases that essentially
+// never appear outside a genuinely US-restricted posting are listed, so a bare
+// "citizen", "secret", or "security" token cannot misfire. Citizenship phrases are
+// unambiguous; the clearance phrases are US-specific terms of art ("Secret
+// clearance", "TS/SCI") that other countries' vetting schemes do not use (the UK
+// says "SC"/"DV", not "Secret clearance"), so generic "security clearance" is
+// deliberately excluded to avoid mislabeling a UK/AU role as US.
+var usOnlyPhrases = []string{
+	"u.s. citizen", "us citizen", "united states citizen", "citizen of the united states",
+	"u.s. citizenship", "us citizenship",
+	"secret clearance", "ts/sci",
+}
+
+// USOnlyFromDescription reports whether a job description carries a hard US-only
+// eligibility signal (US citizenship or a US security clearance). It reads prose,
+// so it is a lowest-priority geography hint used only to rescue a job the location
+// dictionary could not pin to a country (see jobderive): a bare-"Remote" posting
+// that resolved to the global bucket but requires US citizenship is US-restricted,
+// not open-anywhere. It never guesses — an absent phrase yields false.
+func USOnlyFromDescription(desc string) bool {
+	lower := strings.ToLower(desc)
+	for _, p := range usOnlyPhrases {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/location/eligibility_test.go
+++ b/internal/location/eligibility_test.go
@@ -1,0 +1,38 @@
+package location
+
+import "testing"
+
+func TestUSOnlyFromDescription(t *testing.T) {
+	tests := []struct {
+		name string
+		desc string
+		want bool
+	}{
+		// Positives — hard, US-specific eligibility statements.
+		{"citizen and clearance", "Must be a U.S. Citizen and eligible for a U.S. SECRET clearance.", true},
+		{"us citizen", "This role requires a US Citizen.", true},
+		{"united states citizen", "Applicants must be United States citizens.", true},
+		{"us citizenship", "US citizenship is required for this position.", true},
+		{"us citizenship dotted", "U.S. citizenship required.", true},
+		{"secret clearance", "Candidates must hold an active Secret clearance.", true},
+		{"top secret via substring", "An active Top Secret clearance is mandatory.", true},
+		{"ts sci", "Requires a current TS/SCI with polygraph.", true},
+
+		// Trap negatives — incidental tokens that must NOT trigger a match.
+		{"join us", "Join us! We are hiring engineers worldwide.", false},
+		{"corporate citizen", "We strive to be a good corporate citizen.", false},
+		{"global citizen", "We welcome every global citizen to apply.", false},
+		{"trade secret", "You will help protect our trade secrets.", false},
+		{"security engineer", "We are hiring an Application Security Engineer.", false},
+		{"generic security clearance", "A UK SC security clearance is a plus.", false},
+		{"worldwide", "Open to candidates anywhere in the world.", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := USOnlyFromDescription(tt.desc); got != tt.want {
+				t.Errorf("USOnlyFromDescription(%q) = %v, want %v", tt.desc, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A bare-\`Remote\` ATS \`location\` resolves to the **\`global\`** (Global/Worldwide) bucket, but many postings state their real geographic restriction only in the **prose**, which the deterministic location dictionary never reads:

- [Redhorse](https://freehire.dev/jobs/senior-full-stack-software-engineer-backend-redhorse-corp-bxaqi5qm) — \`location: "Remote"\`, description: *"Must be a U.S. Citizen and eligible for a U.S. SECRET clearance"* → served **global**.
- [Vic-AI](https://freehire.dev/jobs/senior-backend-engineer-vic-ai-sfffsttv) — \`location: "Remote"\`, description: *"Location: Remote (SPAIN only)"* → served **global** (even though the LLM already extracted \`enrichment.countries=["ES"]\`).

Prod scan: **678** open \`global\` jobs carry a US-only signal (citizenship/clearance); Spain-style \`COUNTRY only\` prose restrictions add more.

## Fix — two composable layers

**1. Ingest — deterministic US-only override (works pre-enrichment).**
\`location.USOnlyFromDescription\` matches anchored, US-specific eligibility phrases (US citizenship, \`Secret\`/\`TS/SCI\` clearance — precision-first, never guesses). \`jobderive\` pins an otherwise-unpinned job to \`us\`/\`north_america\`. Catches **542 / 678** existing cases.

**2. Serve/index — LLM geo fallback (general long tail).**
\`jobview.geoFacet\` makes \`countries\`/\`regions\` a **dict-then-LLM hybrid**, mirroring the existing \`cityFacet\`: the dictionary wins whenever it pinned a place, but an **unpinned** geography (empty, or the bare-\`Remote\` \`global\` bucket) falls back to \`enrichment.countries/regions\`. This uses the signal the LLM already computed correctly (Vic-AI → \`["ES"]\`/\`["eu"]\`) instead of discarding it. Propagates to the Meili facet via \`search.FromJob\`. A **pinned** dictionary place is never overridden — risk is confined to the global/unspecified bucket.

## Tests

- \`internal/location\`: \`USOnlyFromDescription\` positives + trap negatives (join us / corporate citizen / trade secret / generic security clearance).
- \`internal/jobderive\`: bare-Remote+US-only → \`us\`; resolved place not overridden; noisy prose stays global.
- \`internal/jobview\`: geo hybrid — global bucket falls back to LLM; pinned dict wins; open-anywhere with no LLM geo stays global.

\`go build ./...\`, \`go test ./...\`, \`gofmt\` all clean.

## Rollout for existing rows

1. Deploy binary (detail reads pick up \`geoFacet\` immediately).
2. \`go run ./cmd/backfill-derive\` — re-derives columns (layer 1).
3. \`make reindex\` — rebuilds docs with new columns + LLM fallback (layer 2).

## Follow-up (not in this PR)

Some \`global\` jobs carry the US signal in the \`location\` **string** itself (\`USA_Remote\`, \`Remote-AZ\`, \`Eastern US - Remote\`, \`Remote (Any State)\`) — a separate \`location.Parse\` dictionary improvement.