### PR TITLE
docs(jobview): describe Countries/Regions as the dict+LLM hybrid

### DIFF
--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -39,12 +39,19 @@ type Job struct {
 	CompanySlug   string `json:"company_slug"`
 	Location      string `json:"location"`
 	Description   string `json:"description"`
-	// Countries/Regions/WorkMode/Skills are served from the jobs dictionary columns
-	// ONLY — the deterministic dictionaries are the sole production source for these
-	// facets. The LLM's enrichment values for them are deliberately excluded from
-	// the served object (they remain raw in the stored enrichment JSONB), so the LLM
-	// can later run free as a discovery signal without corrupting production data.
-	// They are served top-level and once; the same fields are folded out of the
+	// WorkMode/Skills are served from the jobs dictionary columns ONLY — the
+	// deterministic dictionaries are the sole production source for these facets. The
+	// LLM's enrichment values for them are deliberately excluded from the served object
+	// (they remain raw in the stored enrichment JSONB), so the LLM can later run free as
+	// a discovery signal without corrupting production data.
+	//
+	// Countries/Regions are a HYBRID facet, like Cities (see geoFacet): the dictionary
+	// columns win whenever they pinned a place, but an unpinned geography (no country,
+	// and at most the bare-"Remote" "global" bucket) falls back to the LLM's
+	// enrichment.countries/regions — catching a restriction stated only in the prose
+	// ("Remote (SPAIN only)") that the location string never carried.
+	//
+	// All four are served top-level and once; the same fields are folded out of the
 	// nested Enrichment to avoid duplication.
 	Countries []string `json:"countries"`
 	Regions   []string `json:"regions"`


### PR DESCRIPTION
Follow-up to #504. The `Job` struct comment still described `Countries`/`Regions` as served from the dictionary columns **ONLY**, but #504 turned them into a dict-then-LLM hybrid (`geoFacet`). This corrects the doc: `WorkMode`/`Skills` remain strict dict-only; `Countries`/`Regions` now mirror `Cities`' documented exception. Comment-only, no behavior change.