### PR TITLE
feat(sources): add Danish jobnet + jobdanmark portal adapters

### DIFF
--- a/internal/sources/jobdanmark.go
+++ b/internal/sources/jobdanmark.go
@@ -1,0 +1,173 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// jobdanmark adapts JobiDanmark (jobdanmark.dk), a Danish job portal. Its keyless search API
+// (POST /api/jobsearch/search/{page}) returns a paginated catalogue where every item carries its
+// own employer, but NOT the job body — so, like the other list-without-description adapters
+// (SmartRecruiters/Rippling), each item is completed from its detail page, whose server-rendered
+// schema.org JobPosting (a JSON-LD block) supplies the full description and a clean datePosted.
+// Like the other national feeds it is boardless (one API, no per-tenant board) and an aggregator
+// (many employers; the company comes from the item). It covers every sector, not just IT — the
+// same as jobtech/jobnet — so the downstream dictionaries and the enrich non-tech gate decide
+// relevance, not the adapter.
+type jobdanmark struct {
+	http jobdanmarkClient
+}
+
+// jobdanmarkClient is the transport role jobdanmark needs: a POST list plus an HTML detail page.
+type jobdanmarkClient interface {
+	JSONPoster
+	HTMLGetter
+}
+
+const (
+	jobdanmarkBaseURL = "https://jobdanmark.dk"
+	// jobdanmarkSearchURL is the POST search, paged in the path. An empty filter body returns
+	// the whole catalogue freshest-first.
+	jobdanmarkSearchURL = "https://jobdanmark.dk/api/jobsearch/search/%d"
+	// jobdanmarkMaxPages bounds pagination so a wrong or missing totalPages cannot loop. At
+	// 30/page it covers ~30k ads, well above the live catalogue (~14k); the empty page the API
+	// returns past the end is the real terminator.
+	jobdanmarkMaxPages = 1000
+)
+
+// NewJobdanmark builds the JobiDanmark adapter over the given POST+HTML client.
+func NewJobdanmark(c jobdanmarkClient) Source { return jobdanmark{http: c} }
+
+func (jobdanmark) Provider() string { return "jobdanmark" }
+
+// jobdanmark is a national portal with one global feed, so its config entry carries no board.
+func (jobdanmark) boardless() {}
+
+// jobdanmark aggregates postings from many employers, so it stays in the source facet.
+func (jobdanmark) aggregator() {}
+
+// jobdanmarkSearchBody is the POST search request. An empty JobTypes/Filters with the Text
+// location mode returns the unfiltered catalogue.
+type jobdanmarkSearchBody struct {
+	JobTypes     []string `json:"jobTypes"`
+	Filters      []any    `json:"filters"`
+	LocationMode string   `json:"locationMode"`
+	Distance     int      `json:"distance"`
+}
+
+// jobdanmarkSearchResponse is one search page: TotalPages bounds pagination; Items is the page.
+type jobdanmarkSearchResponse struct {
+	Items      []jobdanmarkItem `json:"items"`
+	TotalPages int              `json:"totalPages"`
+}
+
+// jobdanmarkItem is one list posting. The list omits the body; CompanyAddress is a free-text
+// address without a country (the portal is Danish, so the country is appended for the geo
+// dictionary); URL is a site-relative "/job/<slug>".
+type jobdanmarkItem struct {
+	Title          string `json:"title"`
+	CompanyName    string `json:"companyName"`
+	CompanyAddress string `json:"companyAddress"`
+	URL            string `json:"url"`
+	PublishedDate  string `json:"publishedDate"`
+}
+
+// Fetch pages the whole catalogue, then fetches each item's detail page concurrently for the
+// description (bounded worker pool). A first-page failure is a board error; a later page failing
+// ends enumeration with the items gathered so far.
+func (s jobdanmark) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	items, err := s.list(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(items, defaultDetailWorkers, func(it jobdanmarkItem) (Job, bool) {
+		return s.toJob(ctx, it)
+	}), nil
+}
+
+// list pages the POST search freshest-first, stopping on an empty page or when the last page is
+// reached.
+func (s jobdanmark) list(ctx context.Context) ([]jobdanmarkItem, error) {
+	body := jobdanmarkSearchBody{JobTypes: []string{}, Filters: []any{}, LocationMode: "Text", Distance: 50}
+	var items []jobdanmarkItem
+	for page := 1; page <= jobdanmarkMaxPages; page++ {
+		var resp jobdanmarkSearchResponse
+		if err := s.http.PostJSON(ctx, fmt.Sprintf(jobdanmarkSearchURL, page), body, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("jobdanmark: search page %d: %w", page, err)
+			}
+			break // a later page failing ends enumeration with the items gathered so far
+		}
+		if len(resp.Items) == 0 {
+			break
+		}
+		items = append(items, resp.Items...)
+		if resp.TotalPages > 0 && page >= resp.TotalPages {
+			break
+		}
+	}
+	return items, nil
+}
+
+// toJob maps a list item plus its detail page to a Job, returning ok=false for an item with no
+// title, employer (which would break the company slug), or url to key on. The detail supplies the
+// body and a clean datePosted; a failed detail leaves the description empty and falls back to the
+// list's date rather than dropping the (otherwise complete) posting.
+func (s jobdanmark) toJob(ctx context.Context, it jobdanmarkItem) (Job, bool) {
+	// Strip any query/fragment for both the slug and the stored URL; trim a trailing slash so a
+	// directory-style path still yields the last segment as the id.
+	path := strings.TrimRight(trimURLSuffix(it.URL), "/")
+	if it.Title == "" || it.CompanyName == "" || path == "" {
+		return Job{}, false
+	}
+	slug := path[strings.LastIndex(path, "/")+1:]
+	if slug == "" {
+		return Job{}, false
+	}
+	jobURL := path
+	if !strings.HasPrefix(jobURL, "http") {
+		jobURL = jobdanmarkBaseURL + jobURL
+	}
+	desc, posted := s.detail(ctx, jobURL)
+	if posted == nil {
+		posted = parseLayout("02-01-2006", it.PublishedDate) // list date is DD-MM-YYYY
+	}
+	return Job{
+		ExternalID:  slug,
+		URL:         jobURL,
+		Title:       it.Title,
+		Company:     it.CompanyName,
+		Description: sanitizeHTML(desc),
+		// The address omits the country; jobdanmark is a Danish portal, so append it for the
+		// geo dictionary (a rare cross-border address still resolves its own country too).
+		Location: joinNonEmpty(it.CompanyAddress, "Danmark"),
+		PostedAt: posted,
+	}, true
+}
+
+// detail fetches the item's detail page and reads the schema.org JobPosting JSON-LD, returning
+// its description and datePosted. A failed request or a page with no JobPosting yields an empty
+// description and a nil date (the caller falls back to the list date) — a posting is never dropped
+// over a missing detail.
+func (s jobdanmark) detail(ctx context.Context, jobURL string) (string, *time.Time) {
+	root, err := s.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return "", nil
+	}
+	var ld struct {
+		Description string `json:"description"`
+		DatePosted  string `json:"datePosted"`
+	}
+	if !ldJobPosting(root, &ld) {
+		return "", nil
+	}
+	// datePosted is date-only ("2026-07-07") on the live page; tolerate a full ISO timestamp
+	// too so the detail date keeps winning if the format ever gains a time component.
+	posted := parseDate(ld.DatePosted)
+	if posted == nil {
+		posted = parseRFC3339(ld.DatePosted)
+	}
+	return ld.Description, posted
+}

--- a/internal/sources/jobdanmark_test.go
+++ b/internal/sources/jobdanmark_test.go
@@ -1,0 +1,228 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// jobdanmarkHTTP is a route-aware test fake for the jobdanmarkClient roles. The list is a POST
+// that paginates on the page in the URL (/api/jobsearch/search/{page}); the detail is a GetHTML
+// keyed by the slug at the end of the job URL. It records the pages and detail slugs requested so
+// a test can assert pagination stops at totalPages and a detail is fetched per item.
+type jobdanmarkHTTP struct {
+	pages      map[int]string    // POST list body keyed by page
+	details    map[string]string // detail HTML keyed by slug
+	failPage   map[int]bool      // a specific page's POST fails
+	failDetail map[string]bool   // a specific slug's detail GET fails
+	gotPages   []int
+	gotDetails []string
+}
+
+var jobdanmarkPageRE = regexp.MustCompile(`/search/(\d+)`)
+
+func (f *jobdanmarkHTTP) PostJSON(_ context.Context, url string, _ any, v any) error {
+	page := 1
+	if m := jobdanmarkPageRE.FindStringSubmatch(url); m != nil {
+		page, _ = strconv.Atoi(m[1])
+	}
+	f.gotPages = append(f.gotPages, page)
+	if f.failPage[page] {
+		return errors.New("jobdanmarkHTTP: list boom")
+	}
+	raw, ok := f.pages[page]
+	if !ok {
+		raw = `{"items":[],"totalPages":0}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func (f *jobdanmarkHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	slug := url[strings.LastIndex(url, "/")+1:]
+	f.gotDetails = append(f.gotDetails, slug)
+	if f.failDetail[slug] {
+		return nil, errors.New("jobdanmarkHTTP: detail boom")
+	}
+	raw, ok := f.details[slug]
+	if !ok {
+		raw = "<html></html>"
+	}
+	return html.Parse(strings.NewReader(raw))
+}
+
+// jobdanmarkDetailHTML wraps a JSON-LD JobPosting exactly as the live page serves it — the
+// script type is HTML-entity-encoded ("application/ld&#x2B;json"), which the html parser decodes
+// back to "application/ld+json" so ldJobPosting matches.
+func jobdanmarkDetailHTML(datePosted, description string) string {
+	ld := `{"@type":"JobPosting","datePosted":"` + datePosted + `","description":` + strconv.Quote(description) + `}`
+	return `<html><head><script type="application/ld&#x2B;json">` + ld + `</script></head><body></body></html>`
+}
+
+func TestJobdanmarkProvider(t *testing.T) {
+	if got := NewJobdanmark(nil).Provider(); got != "jobdanmark" {
+		t.Errorf("Provider() = %q, want %q", got, "jobdanmark")
+	}
+}
+
+func TestJobdanmarkFetchMapsJob(t *testing.T) {
+	fake := &jobdanmarkHTTP{
+		pages: map[int]string{1: `{"totalPages":1,"items":[
+			{"title":"Backend Developer","companyName":"Acme A/S",
+			 "companyAddress":"Storegade 25, 6261 Bredebro","url":"/job/acme-dev","publishedDate":"05-07-2026"}
+		]}`},
+		details: map[string]string{"acme-dev": jobdanmarkDetailHTML("2026-07-07", `<p onclick="x()">Full body here</p>`)},
+	}
+
+	jobs, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "acme-dev" {
+		t.Errorf("ExternalID = %q, want acme-dev", j.ExternalID)
+	}
+	if j.URL != "https://jobdanmark.dk/job/acme-dev" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Backend Developer" || j.Company != "Acme A/S" {
+		t.Errorf("Title/Company = %q / %q", j.Title, j.Company)
+	}
+	// Description comes from the detail JSON-LD as HTML (safe tags kept), run through
+	// sanitizeHTML which drops the dangerous on* handler but preserves the text/markup.
+	if !strings.Contains(j.Description, "Full body here") || strings.Contains(j.Description, "onclick") {
+		t.Errorf("Description not extracted/sanitized: %q", j.Description)
+	}
+	// The portal omits the country from the address; the adapter appends it so the geo
+	// dictionary resolves Denmark.
+	if j.Location != "Storegade 25, 6261 Bredebro, Danmark" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	// The detail JSON-LD datePosted (ISO) is preferred over the list's DD-MM-YYYY.
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-07" {
+		t.Errorf("PostedAt = %v, want 2026-07-07 from detail", j.PostedAt)
+	}
+	if len(fake.gotDetails) != 1 || fake.gotDetails[0] != "acme-dev" {
+		t.Errorf("detail fetches = %v, want [acme-dev]", fake.gotDetails)
+	}
+}
+
+// When the detail fetch fails or carries no JobPosting, the job is still emitted (the list
+// already has title/company/url/date) with an empty description and the list's date.
+func TestJobdanmarkFetchKeepsJobWhenDetailMissing(t *testing.T) {
+	fake := &jobdanmarkHTTP{
+		pages: map[int]string{1: `{"totalPages":1,"items":[
+			{"title":"Dev","companyName":"Acme","companyAddress":"København","url":"/job/nodetail","publishedDate":"05-07-2026"}
+		]}`},
+		failDetail: map[string]bool{"nodetail": true},
+	}
+	jobs, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].Description != "" {
+		t.Errorf("Description = %q, want empty on missing detail", jobs[0].Description)
+	}
+	// Falls back to the list publishedDate (DD-MM-YYYY -> 2026-07-05).
+	if jobs[0].PostedAt == nil || jobs[0].PostedAt.Format("2006-01-02") != "2026-07-05" {
+		t.Errorf("PostedAt = %v, want 2026-07-05 fallback", jobs[0].PostedAt)
+	}
+}
+
+// An item with no title, employer, or url to key on is dropped rather than emitted.
+func TestJobdanmarkFetchDropsIncompleteItems(t *testing.T) {
+	fake := &jobdanmarkHTTP{pages: map[int]string{1: `{"totalPages":1,"items":[
+		{"title":"","companyName":"Acme","url":"/job/a"},
+		{"title":"No company","companyName":"","url":"/job/b"},
+		{"title":"No url","companyName":"Acme","url":""},
+		{"title":"Good","companyName":"Acme","url":"/job/ok"}
+	]}`}}
+	jobs, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "ok" {
+		t.Fatalf("got %v, want only the complete item", jobs)
+	}
+}
+
+// A trailing slash or tracking query on the item URL must not defeat the id or leak into the
+// stored URL: the slug is the last real path segment and the URL is stripped of query/fragment.
+func TestJobdanmarkFetchNormalizesURL(t *testing.T) {
+	fake := &jobdanmarkHTTP{pages: map[int]string{1: `{"totalPages":1,"items":[
+		{"title":"A","companyName":"Acme","url":"/job/acme-dev/"},
+		{"title":"B","companyName":"Acme","url":"/job/other-role?utm=x#frag"}
+	]}`}}
+	jobs, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	byID := map[string]string{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j.URL
+	}
+	if got := byID["acme-dev"]; got != "https://jobdanmark.dk/job/acme-dev" {
+		t.Errorf("trailing-slash URL: id=acme-dev URL=%q", got)
+	}
+	if got := byID["other-role"]; got != "https://jobdanmark.dk/job/other-role" {
+		t.Errorf("query URL: id=other-role URL=%q (query/fragment must be stripped)", got)
+	}
+}
+
+func TestJobdanmarkFetchPaginates(t *testing.T) {
+	fake := &jobdanmarkHTTP{pages: map[int]string{
+		1: `{"totalPages":9999,"items":[{"title":"A","companyName":"Acme","url":"/job/a"}]}`,
+	}}
+	if _, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(fake.gotPages) != 2 || fake.gotPages[0] != 1 || fake.gotPages[1] != 2 {
+		t.Errorf("requested pages = %v, want [1 2] (page 2 empty terminates)", fake.gotPages)
+	}
+}
+
+func TestJobdanmarkFetchStopsAtTotalPages(t *testing.T) {
+	fake := &jobdanmarkHTTP{pages: map[int]string{
+		1: `{"totalPages":1,"items":[{"title":"A","companyName":"Acme","url":"/job/a"}]}`,
+	}}
+	if _, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(fake.gotPages) != 1 {
+		t.Errorf("requested pages = %v, want only [1]", fake.gotPages)
+	}
+}
+
+func TestJobdanmarkFetchFirstPageErrorFails(t *testing.T) {
+	fake := &jobdanmarkHTTP{failPage: map[int]bool{1: true}}
+	if _, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"}); err == nil {
+		t.Fatal("Fetch: want error when the first page fails")
+	}
+}
+
+func TestJobdanmarkFetchLaterPageErrorKeepsJobs(t *testing.T) {
+	fake := &jobdanmarkHTTP{
+		pages:    map[int]string{1: `{"totalPages":9999,"items":[{"title":"A","companyName":"Acme","url":"/job/a"}]}`},
+		failPage: map[int]bool{2: true},
+	}
+	jobs, err := NewJobdanmark(fake).Fetch(context.Background(), CompanyEntry{Company: "JobiDanmark", Provider: "jobdanmark"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Errorf("got %d jobs, want the 1 gathered before the failing page", len(jobs))
+	}
+}
+
+var _ jobdanmarkClient = (*jobdanmarkHTTP)(nil)

--- a/internal/sources/jobnet.go
+++ b/internal/sources/jobnet.go
@@ -1,0 +1,128 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+)
+
+// jobnet adapts Jobnet.dk — Denmark's official public job portal, operated by STAR
+// (Styrelsen for Arbejdsmarked og Rekruttering). Its BFF search API (/bff/FindJob/Search,
+// gated behind a non-secret "x-csrf: 1" header) returns a paginated catalogue where every
+// ad carries its own employer and the full HTML description inline, so one paged crawl
+// assembles every Job with no per-ad detail fetch. Like the other national feeds it is
+// boardless (one national API, no per-tenant board) and an aggregator (many employers; the
+// company comes from the ad, not the placeholder entry). It covers every sector, not just IT
+// — the same as jobtech — so the downstream dictionaries and the enrich non-tech gate decide
+// relevance, not the adapter.
+type jobnet struct {
+	http HeaderJSONGetter
+}
+
+const (
+	// jobnetSearchURL pages the BFF search freshest-first. Keyless; the only gate is the
+	// x-csrf header (see jobnetHeaders). An empty SearchString returns the whole catalogue.
+	jobnetSearchURL = "https://jobnet.dk/bff/FindJob/Search?PageNumber=%d&ResultsPerPage=%d&OrderType=PublicationDate"
+	// jobnetJobURL is the canonical posting page, built from the ad id when the ad carries no
+	// destination URL of its own. The page sits behind the STAR login, but it is the ad's
+	// stable public location; an ad with its own jobAdUrl (external postings) prefers that.
+	jobnetJobURL = "https://job.jobnet.dk/CV/FindWork/Details/%s"
+	// jobnetPageSize is the ResultsPerPage the API honours (100 confirmed against the live API).
+	jobnetPageSize = 100
+	// jobnetMaxPages bounds pagination so a wrong or missing totalJobAdCount cannot loop.
+	// The empty page the API returns past the end is the real terminator; this is only the
+	// runaway backstop, sized well above the live catalogue (~20k) so catalogue growth does
+	// not silently truncate the crawl (a freshest-first crawl truncated at the tail would let
+	// the unseen sweep close the oldest still-open ads).
+	jobnetMaxPages = 600
+)
+
+// jobnetHeaders is the non-secret header the BFF requires; without it the API 400s.
+var jobnetHeaders = map[string]string{"x-csrf": "1"}
+
+// NewJobnet builds the Jobnet.dk adapter over the given header-capable JSON client.
+func NewJobnet(c HeaderJSONGetter) Source { return jobnet{http: c} }
+
+func (jobnet) Provider() string { return "jobnet" }
+
+// jobnet is a national portal with one global feed, so its config entry carries no board.
+func (jobnet) boardless() {}
+
+// jobnet aggregates postings from many employers, so it stays in the source facet.
+func (jobnet) aggregator() {}
+
+// jobnetSearchResponse is one BFF search page: TotalJobAdCount is the catalogue size used to
+// stop pagination; JobAds is the page. Only the fields the catalogue needs are decoded.
+type jobnetSearchResponse struct {
+	TotalJobAdCount int        `json:"totalJobAdCount"`
+	JobAds          []jobnetAd `json:"jobAds"`
+}
+
+// jobnetAd is one posting. HiringOrgName is the employer (the portal lists many); Description
+// is the full HTML body served inline on the list; JobAdURL is set only for external postings
+// and, when present, is the real destination link.
+type jobnetAd struct {
+	JobAdID            string `json:"jobAdId"`
+	Title              string `json:"title"`
+	HiringOrgName      string `json:"hiringOrgName"`
+	Description        string `json:"description"`
+	PostalDistrictName string `json:"postalDistrictName"`
+	Country            string `json:"country"`
+	PublicationDate    string `json:"publicationDate"`
+	JobAdURL           string `json:"jobAdUrl"`
+}
+
+// Fetch pages the BFF search freshest-first, stopping when the catalogue is exhausted (an
+// empty page or the running count reaching totalJobAdCount). The first page failing is a
+// board error; a later page failing ends enumeration with the jobs gathered so far.
+func (s jobnet) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	seen := 0
+	for page := 1; page <= jobnetMaxPages; page++ {
+		var resp jobnetSearchResponse
+		url := fmt.Sprintf(jobnetSearchURL, page, jobnetPageSize)
+		if err := s.http.GetJSONWithHeaders(ctx, url, jobnetHeaders, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("jobnet: search page %d: %w", page, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+		if len(resp.JobAds) == 0 {
+			break
+		}
+		seen += len(resp.JobAds)
+		for _, a := range resp.JobAds {
+			if j, ok := a.toJob(); ok {
+				jobs = append(jobs, j)
+			}
+		}
+		// Stop once the ads actually returned reach the reported catalogue size. Counting
+		// returned ads (not page*pageSize) stays correct even if the API caps a page below
+		// ResultsPerPage; the empty-page break above is the primary terminator, this only
+		// saves the trailing empty request.
+		if resp.TotalJobAdCount > 0 && seen >= resp.TotalJobAdCount {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an ad to a Job, returning ok=false for an ad with no id to key on or no employer
+// name (which would break the company slug). Remote/WorkMode are left unset: the search
+// response states no structured work arrangement, so the deterministic location dictionary
+// derives it downstream from the location string rather than the adapter guessing.
+func (a jobnetAd) toJob() (Job, bool) {
+	if a.JobAdID == "" || a.HiringOrgName == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID: a.JobAdID,
+		// External postings carry their own destination; jobnet-hosted ones fall back to the
+		// canonical id-based posting page.
+		URL:         firstNonEmpty(a.JobAdURL, fmt.Sprintf(jobnetJobURL, a.JobAdID)),
+		Title:       a.Title,
+		Company:     a.HiringOrgName,
+		Description: sanitizeHTML(a.Description),
+		Location:    joinNonEmpty(a.PostalDistrictName, a.Country),
+		PostedAt:    parseRFC3339(a.PublicationDate),
+	}, true
+}

--- a/internal/sources/jobnet_test.go
+++ b/internal/sources/jobnet_test.go
@@ -1,0 +1,181 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// jobnetHTTP is a page-aware test HeaderJSONGetter. Jobnet has one endpoint — the paged BFF
+// search (/bff/FindJob/Search?PageNumber=) — so this fake routes by the PageNumber query
+// parameter and records both the pages requested (to assert pagination stops at
+// totalJobAdCount / the first empty page) and the x-csrf header seen (to assert it is sent).
+type jobnetHTTP struct {
+	pages    map[int]string // search body keyed by requested PageNumber
+	failPage map[int]bool   // a specific page's request fails
+	gotPages []int
+	gotCSRF  string
+}
+
+var jobnetPageRE = regexp.MustCompile(`PageNumber=(\d+)`)
+
+func (f *jobnetHTTP) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
+	f.gotCSRF = headers["x-csrf"]
+	page := 1
+	if m := jobnetPageRE.FindStringSubmatch(url); m != nil {
+		page, _ = strconv.Atoi(m[1])
+	}
+	f.gotPages = append(f.gotPages, page)
+	if f.failPage[page] {
+		return errors.New("jobnetHTTP: boom")
+	}
+	raw, ok := f.pages[page]
+	if !ok {
+		raw = `{"jobAds":[],"totalJobAdCount":0}`
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestJobnetProvider(t *testing.T) {
+	if got := NewJobnet(nil).Provider(); got != "jobnet" {
+		t.Errorf("Provider() = %q, want %q", got, "jobnet")
+	}
+}
+
+func TestJobnetFetchMapsAd(t *testing.T) {
+	fake := &jobnetHTTP{pages: map[int]string{1: `{"totalJobAdCount":1,"jobAds":[
+		{"jobAdId":"c1dc33fa-9c57-4592-a050-36ecda5bdfc1","title":"IT-supportelev",
+		 "hiringOrgName":"ipnordic A/S","postalDistrictName":"Gråsten","country":"Danmark",
+		 "publicationDate":"2026-07-07T00:00:00+02:00","jobAdUrl":"",
+		 "description":"<p>Er du nysgerrig</p><script>x()</script>"}
+	]}`}}
+
+	jobs, err := NewJobnet(fake).Fetch(context.Background(), CompanyEntry{Company: "Jobnet", Provider: "jobnet"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "c1dc33fa-9c57-4592-a050-36ecda5bdfc1" {
+		t.Errorf("ExternalID = %q", j.ExternalID)
+	}
+	if j.Title != "IT-supportelev" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "ipnordic A/S" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	// jobAdUrl empty → the canonical id-based posting page is the link.
+	if want := "https://job.jobnet.dk/CV/FindWork/Details/c1dc33fa-9c57-4592-a050-36ecda5bdfc1"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.Location != "Gråsten, Danmark" {
+		t.Errorf("Location = %q, want %q", j.Location, "Gråsten, Danmark")
+	}
+	// HTML is sanitized: the <script> is stripped, the text kept.
+	if got := j.Description; got == "" || regexp.MustCompile(`(?i)<script`).MatchString(got) {
+		t.Errorf("Description not sanitized: %q", got)
+	}
+	if j.PostedAt == nil {
+		t.Fatal("PostedAt = nil, want parsed date")
+	}
+	if fake.gotCSRF != "1" {
+		t.Errorf("x-csrf header = %q, want %q", fake.gotCSRF, "1")
+	}
+}
+
+// An external ad carries its own destination URL; the adapter must prefer it over the
+// synthesized jobnet page so the link points at the real posting.
+func TestJobnetFetchPrefersAdURL(t *testing.T) {
+	fake := &jobnetHTTP{pages: map[int]string{1: `{"totalJobAdCount":1,"jobAds":[
+		{"jobAdId":"abc","title":"Dev","hiringOrgName":"Acme","country":"Danmark",
+		 "jobAdUrl":"https://acme.example/jobs/1","description":"<p>x</p>"}
+	]}`}}
+	jobs, err := NewJobnet(fake).Fetch(context.Background(), CompanyEntry{Company: "Jobnet", Provider: "jobnet"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].URL != "https://acme.example/jobs/1" {
+		t.Fatalf("URL = %v, want the ad's own jobAdUrl", jobs)
+	}
+}
+
+// An ad with no id to key on or no employer name (which would break the company slug) is
+// dropped rather than emitted, mirroring the other aggregator adapters.
+func TestJobnetFetchDropsIncompleteAds(t *testing.T) {
+	fake := &jobnetHTTP{pages: map[int]string{1: `{"totalJobAdCount":3,"jobAds":[
+		{"jobAdId":"","title":"No id","hiringOrgName":"Acme","description":"x"},
+		{"jobAdId":"has-id","title":"No company","hiringOrgName":"","description":"x"},
+		{"jobAdId":"ok","title":"Good","hiringOrgName":"Acme","description":"x"}
+	]}`}}
+	jobs, err := NewJobnet(fake).Fetch(context.Background(), CompanyEntry{Company: "Jobnet", Provider: "jobnet"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "ok" {
+		t.Fatalf("got %v, want only the complete ad", jobs)
+	}
+}
+
+func TestJobnetFetchPaginates(t *testing.T) {
+	// Page 1 reports a total far above one page, so the crawl requests page 2; page 2 is
+	// empty (the unknown-page default), which terminates enumeration.
+	fake := &jobnetHTTP{pages: map[int]string{
+		1: `{"totalJobAdCount":9999,"jobAds":[{"jobAdId":"a","title":"A","hiringOrgName":"Acme","description":"x"}]}`,
+	}}
+	jobs, err := NewJobnet(fake).Fetch(context.Background(), CompanyEntry{Company: "Jobnet", Provider: "jobnet"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Errorf("got %d jobs, want 1", len(jobs))
+	}
+	if len(fake.gotPages) != 2 || fake.gotPages[0] != 1 || fake.gotPages[1] != 2 {
+		t.Errorf("requested pages = %v, want [1 2]", fake.gotPages)
+	}
+}
+
+// totalJobAdCount stops pagination without a wasted trailing request: page 1 already covers
+// the whole (tiny) catalogue, so page 2 is never requested.
+func TestJobnetFetchStopsAtTotal(t *testing.T) {
+	fake := &jobnetHTTP{pages: map[int]string{
+		1: `{"totalJobAdCount":1,"jobAds":[{"jobAdId":"a","title":"A","hiringOrgName":"Acme","description":"x"}]}`,
+	}}
+	if _, err := NewJobnet(fake).Fetch(context.Background(), CompanyEntry{Company: "Jobnet", Provider: "jobnet"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(fake.gotPages) != 1 {
+		t.Errorf("requested pages = %v, want only [1]", fake.gotPages)
+	}
+}
+
+func TestJobnetFetchFirstPageErrorFails(t *testing.T) {
+	fake := &jobnetHTTP{failPage: map[int]bool{1: true}}
+	if _, err := NewJobnet(fake).Fetch(context.Background(), CompanyEntry{Company: "Jobnet", Provider: "jobnet"}); err == nil {
+		t.Fatal("Fetch: want error when the first page fails")
+	}
+}
+
+// A later page failing ends enumeration with the jobs gathered so far, rather than failing
+// the whole board.
+func TestJobnetFetchLaterPageErrorKeepsJobs(t *testing.T) {
+	fake := &jobnetHTTP{
+		pages:    map[int]string{1: `{"totalJobAdCount":9999,"jobAds":[{"jobAdId":"a","title":"A","hiringOrgName":"Acme","description":"x"}]}`},
+		failPage: map[int]bool{2: true},
+	}
+	jobs, err := NewJobnet(fake).Fetch(context.Background(), CompanyEntry{Company: "Jobnet", Provider: "jobnet"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Errorf("got %d jobs, want the 1 gathered before the failing page", len(jobs))
+	}
+}
+
+// compile-time guard that the fake satisfies the role the adapter depends on.
+var _ HeaderJSONGetter = (*jobnetHTTP)(nil)

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -226,6 +226,8 @@ func All(c HTTPClient) map[string]Source {
 		NewRemotive(c),
 		NewJustJoin(c),
 		NewJobtech(c),
+		NewJobnet(c),
+		NewJobdanmark(c),
 		// International single-company adapters (boardless).
 		NewTelegramCareers(c),
 		NewUber(c),

--- a/sources/jobdanmark.yml
+++ b/sources/jobdanmark.yml
@@ -1,0 +1,6 @@
+# JobiDanmark (jobdanmark.dk), a Danish job portal. Boardless aggregator: one public, keyless
+# search API (jobdanmark.dk/api/jobsearch/search), so the entry carries no board, and each job's
+# employer comes from the item, not this placeholder. The list omits the body, so the crawl fetches
+# a detail page per posting for the description (JSON-LD JobPosting) — like getmatch, its own cron slot.
+- company: JobiDanmark
+  provider: jobdanmark

--- a/sources/jobnet.yml
+++ b/sources/jobnet.yml
@@ -1,0 +1,6 @@
+# Jobnet.dk — Denmark's official public job portal, operated by STAR (Styrelsen for
+# Arbejdsmarked og Rekruttering). Boardless aggregator: one public BFF search API
+# (jobnet.dk/bff/FindJob/Search, gated only by a non-secret "x-csrf: 1" header), so the
+# entry carries no board, and each job's employer comes from the ad, not this placeholder.
+- company: Jobnet
+  provider: jobnet


### PR DESCRIPTION
Two Denmark national job-portal adapters, mined from the `MadsLorentzen/ai-job-search` skills. Both are **boardless aggregators**, cover **every sector** (non-tech filtered downstream by the enrich gate, as with `jobtech`), and are **not self-closing** — they re-crawl the whole catalogue each run and rely on the normal 48h unseen sweep to close stale postings.

## jobnet (jobnet.dk — official STAR government portal)
- Keyless BFF search `jobnet.dk/bff/FindJob/Search`, gated by a non-secret `x-csrf: 1` header (→ `HeaderJSONGetter`).
- ~20.5k ads; `totalJobAdCount` bounds pagination.
- **Description is inline in the search response** → search-only, no per-posting detail fetch (~410 req/crawl).
- URL: the ad's own `jobAdUrl` when external, else the canonical `job.jobnet.dk/CV/FindWork/Details/{id}` page.

## jobdanmark (jobdanmark.dk / JobiDanmark)
- Keyless **POST** `/api/jobsearch/search/{page}`; an empty filter body returns the whole catalogue (~14k, 30/page, `totalPages`).
- **The list omits the body**, so each posting is completed from its detail page's server-rendered schema.org `JobPosting` (JSON-LD) via `fetchDetails` — the getmatch list-then-detail pattern.
- The address carries no country; since it is a `.dk` national portal the country is appended so the geo dictionary resolves Denmark.

## Verification
- Unit tests: jobnet (7) + jobdanmark (9), all green.
- Live smoke against both real APIs (deleted throwaways): field mapping, pagination, JSON-LD extraction, and dates all confirmed end-to-end.
- `go build ./...`, `go vet`, full `go test ./...` clean.

## Follow-up (ops, out of repo)
Prod cron needs an independent schedule slot for `sources/jobnet.yml` and `sources/jobdanmark.yml` (like the other board files).