### PR TITLE
feat(sources): harvest 22 missing ATS boards from speedyapply/2027-SWE-College-Jobs

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7385,3 +7385,9 @@
   board: zip%20security
 - company: Zowie
   board: zowie
+- company: Cohort AI
+  board: cohort
+- company: Mistral AI
+  board: mistral.ai
+- company: Neura Robotics
+  board: neura-robotics-gmbh

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14051,3 +14051,5 @@
   board: zerotothree
 - company: ZIRO
   board: ziro
+- company: Indicium AI
+  board: indiciumai

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4308,3 +4308,5 @@
 # nothing until they post; the eastern-roots `zerion` slug tags it once it has jobs.
 - company: Zerion
   board: zerion
+- company: Packmatic
+  board: Packmatic

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -5653,3 +5653,7 @@
   board: zwieselfortessaamericasllc
 - company: Zzenzen Logistics
   board: zzenzenlogisticscanadaincorporated
+- company: Endava
+  board: Endava
+- company: SOSi
+  board: SOSi1

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1094,3 +1094,31 @@
   board: emerging-travel-group
 - company: Open
   board: open-252
+- company: Arondite
+  board: arondite
+- company: CATHEXIS
+  board: cathexis
+- company: ChainGPT
+  board: chaingpt
+- company: Clearstory
+  board: clearstory
+- company: CVector - Industrial AI
+  board: cvector
+- company: Informed Solutions
+  board: informed-solutions
+- company: MealSuite
+  board: mealsuite
+- company: OptiTrack
+  board: optitrack
+- company: Opus 2
+  board: opus2
+- company: Orion Health
+  board: orion-health
+- company: Saalex
+  board: saalex
+- company: Texas Sports Academy Main
+  board: texas-sports-academy-main
+- company: WATI.io
+  board: wati-dot-i-o
+- company: YouTrip
+  board: youtrip

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12329,3 +12329,5 @@
   board: wkcda.wd3.myworkdayjobs.com/external
 - company: Palo Alto Networks
   board: paloaltonetworks.wd5.myworkdayjobs.com/panwexternalcareers
+- company: MBDA
+  board: mbda.wd3.myworkdayjobs.com/mbda-italy


### PR DESCRIPTION
## What

Harvested the missing ATS boards from [speedyapply/2027-SWE-College-Jobs](https://github.com/speedyapply/2027-SWE-College-Jobs) into our source board files.

## How

The repo's data lives as apply-URLs in four markdown job tables; each URL encodes the ATS platform and board slug. Parsed them: **1017 unique links → 442 candidate boards** across 7 providers we support (greenhouse/lever/ashby/smartrecruiters/workable/icims/workday). Big-tech links (amazon.jobs, google, tiktok, apple) are served by dedicated boardless adapters and need no board entry.

Ran every new candidate through `cmd/harvest-boards`, which dedups against the existing files (with per-provider case rules), **live-probes** each slug, and appends only live boards with employer names from the ATS API.

## Result

Our catalogue already covered nearly everything — of the 442 candidates only 26 were new, and 22 passed the liveness probe:

| Provider | Added |
|---|---|
| workable | 14 |
| ashby | 3 |
| smartrecruiters | 2 |
| greenhouse | 1 |
| lever | 1 |
| workday | 1 |

Correctly dropped: `icims/sig` (no live host), `workday/netflix` (already present), `workday/chegg` (probe failed), `greenhouse/embed` (parse artifact — the real slug comes from `?for=`, which resolved to the already-present `gemini`).

## Verification

`go build ./...` and `go vet` clean; `internal/sources` tests green. Jobs land in the DB on the next ingest crawl of these providers (host-2 cron).