### PR TITLE
fix(search): retry transient embedding failures during semantic reindex

### DIFF
--- a/internal/search/embed.go
+++ b/internal/search/embed.go
@@ -8,12 +8,29 @@ import (
 	"io"
 	"net/http"
 	"sync"
+	"time"
 )
 
 // teiMaxBatch caps how many inputs go in one TEI /v1/embeddings call. TEI rejects a
 // batch above its --max-client-batch-size (default 32); embedBatch chunks larger
 // inputs into sequential calls so callers can hand it a whole reindex batch.
 const teiMaxBatch = 32
+
+// embedMaxAttempts bounds how many times embedChunk retries a transient embedding-backend
+// failure (a transport error, 429, or 5xx) before giving up. A bulk semantic reindex makes
+// hundreds of thousands of cross-network calls to a remote embedding endpoint over many
+// hours, so a single blip (a dropped connection, a brief endpoint restart) must not abort
+// the whole run — but a persistent outage, or a deterministic 4xx from a malformed batch,
+// still surfaces after the bounded retries rather than looping forever.
+const embedMaxAttempts = 5
+
+// embedAttemptTimeout caps a single embedding HTTP call so a hung connection is retried
+// rather than stalling the run indefinitely — http.DefaultClient has no timeout of its own.
+const embedAttemptTimeout = 60 * time.Second
+
+// embedRetryBase is the backoff before the first retry; it doubles each attempt (1s, 2s,
+// 4s, …). A package var, not a const, so tests can shrink it to keep them fast.
+var embedRetryBase = time.Second
 
 // jobPassage renders a job document into the text embedded for semantic retrieval.
 // e5 is asymmetric: the corpus side carries the "passage:" prefix and the query side
@@ -102,20 +119,55 @@ func (c *Client) embedBatch(ctx context.Context, inputs []string) ([][]float64, 
 	return out, nil
 }
 
-// embedChunk embeds one TEI-sized batch and returns the vectors in input order. It
-// speaks TEI's native `/embed` shape — `{"inputs": [...]}` in, an array of vectors out
-// — which every backend we target accepts: the host2 TEI (/embed, bare array) and an
-// HF Inference Endpoint (root, `{"embeddings": [...]}`). Over-long inputs (e5 caps at
-// 512 tokens) are truncated server-side (host2 TEI's --auto-truncate; HF truncates by
-// default), so no per-input length handling is needed here.
+// embedChunk embeds one TEI-sized batch and returns the vectors in input order,
+// retrying a transient backend failure with exponential backoff (see embedMaxAttempts).
+// A long bulk reindex crosses the network hundreds of thousands of times, so one blip
+// must not abort it — but a deterministic error (a 4xx, a malformed response) or a
+// cancelled parent context fails fast without burning the retry budget.
 func (c *Client) embedChunk(ctx context.Context, inputs []string) ([][]float64, error) {
 	body, err := json.Marshal(map[string]any{"inputs": inputs})
 	if err != nil {
 		return nil, fmt.Errorf("search: embed marshal: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.embedURL, bytes.NewReader(body))
+
+	var lastErr error
+	for attempt := 0; attempt < embedMaxAttempts; attempt++ {
+		if attempt > 0 {
+			// Back off before retrying, but abort promptly if the parent context is done
+			// (e.g. a sibling chunk failed and cancelled the batch).
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(embedRetryBase << (attempt - 1)):
+			}
+		}
+		vecs, retriable, err := c.embedOnce(ctx, body, len(inputs))
+		if err == nil {
+			return vecs, nil
+		}
+		lastErr = err
+		if !retriable {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("search: embed: giving up after %d attempts: %w", embedMaxAttempts, lastErr)
+}
+
+// embedOnce makes a single embedding call and reports whether a failure is worth
+// retrying. It speaks TEI's native `/embed` shape — `{"inputs": [...]}` in, an array of
+// vectors out — which every backend we target accepts: the host2 TEI (/embed, bare array)
+// and an HF Inference Endpoint (root, `{"embeddings": [...]}`). Over-long inputs (e5 caps
+// at 512 tokens) are truncated server-side (host2 TEI's --auto-truncate; HF truncates by
+// default), so no per-input length handling is needed here.
+//
+// Transport errors, 429, and 5xx are transient (retriable); a 4xx or a mismatched vector
+// count is deterministic (not retriable); a cancelled parent context is terminal.
+func (c *Client) embedOnce(ctx context.Context, body []byte, n int) ([][]float64, bool, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, embedAttemptTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.embedURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("search: embed request: %w", err)
+		return nil, false, fmt.Errorf("search: embed request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if c.embedKey != "" {
@@ -123,24 +175,31 @@ func (c *Client) embedChunk(ctx context.Context, inputs []string) ([][]float64, 
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("search: embed call: %w", err)
+		// A cancelled PARENT context is terminal (the whole batch is being torn down);
+		// any other transport failure — including this attempt's own timeout — is transient.
+		if ctx.Err() != nil {
+			return nil, false, ctx.Err()
+		}
+		return nil, true, fmt.Errorf("search: embed call: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("search: embed: unexpected status %d", resp.StatusCode)
+		retriable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500
+		return nil, retriable, fmt.Errorf("search: embed: unexpected status %d", resp.StatusCode)
 	}
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("search: embed read: %w", err)
+		// A body cut short mid-read is a broken connection — transient.
+		return nil, true, fmt.Errorf("search: embed read: %w", err)
 	}
 	vecs, err := parseEmbeddings(raw)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	if len(vecs) != len(inputs) {
-		return nil, fmt.Errorf("search: embed: got %d vectors for %d inputs", len(vecs), len(inputs))
+	if len(vecs) != n {
+		return nil, false, fmt.Errorf("search: embed: got %d vectors for %d inputs", len(vecs), n)
 	}
-	return vecs, nil
+	return vecs, false, nil
 }
 
 // parseEmbeddings decodes a TEI-style embeddings response, tolerating both the bare

--- a/internal/search/embed_test.go
+++ b/internal/search/embed_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // jobPassage must prefix the corpus side with e5's "passage:" marker and weave in the
@@ -77,6 +79,91 @@ func TestEmbedBatchChunksAndPreservesOrder(t *testing.T) {
 		if len(v) != 1 || v[0] != float64(i) {
 			t.Fatalf("vecs[%d] = %v, want [%d]", i, v, i)
 		}
+	}
+}
+
+// shrinkEmbedRetryBase makes retry backoff negligible for the duration of a test, so a
+// test exercising retries does not sleep whole seconds.
+func shrinkEmbedRetryBase(t *testing.T) {
+	t.Helper()
+	prev := embedRetryBase
+	embedRetryBase = time.Microsecond
+	t.Cleanup(func() { embedRetryBase = prev })
+}
+
+// A transient backend failure (a dropped connection, a brief 5xx while the endpoint
+// restarts) must NOT abort a bulk reindex — embedChunk retries it. Without this, a single
+// blip over a multi-hour run kills the whole embed pass (the ghost-JD incident).
+func TestEmbedChunkRetriesTransientThenSucceeds(t *testing.T) {
+	shrinkEmbedRetryBase(t)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) <= 2 { // fail the first two attempts, then serve
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		var in struct {
+			Inputs []string `json:"inputs"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		out := make([][]float64, len(in.Inputs))
+		for i := range in.Inputs {
+			out[i] = []float64{float64(i)}
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	defer srv.Close()
+	c := &Client{embedURL: srv.URL}
+
+	vecs, err := c.embedBatch(context.Background(), []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("embedBatch after transient failures: %v", err)
+	}
+	if len(vecs) != 2 {
+		t.Fatalf("got %d vectors, want 2", len(vecs))
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 calls (2 failed + 1 ok), got %d", got)
+	}
+}
+
+// A persistent backend outage must surface as an error after the bounded retries — not
+// loop forever and not give up on the first try.
+func TestEmbedChunkGivesUpAfterMaxAttempts(t *testing.T) {
+	shrinkEmbedRetryBase(t)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	c := &Client{embedURL: srv.URL}
+
+	if _, err := c.embedBatch(context.Background(), []string{"a"}); err == nil {
+		t.Fatal("expected an error after exhausting retries, got nil")
+	}
+	if got := calls.Load(); got != embedMaxAttempts {
+		t.Fatalf("expected %d attempts, got %d", embedMaxAttempts, got)
+	}
+}
+
+// A 4xx is a deterministic client error (a malformed batch) — retrying it only wastes the
+// budget, so embedChunk must fail fast on the first call.
+func TestEmbedChunkDoesNotRetryClientError(t *testing.T) {
+	shrinkEmbedRetryBase(t)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "bad request", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	c := &Client{embedURL: srv.URL}
+
+	if _, err := c.embedBatch(context.Background(), []string{"a"}); err == nil {
+		t.Fatal("expected an error on a 4xx, got nil")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 call (no retry on 4xx), got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Problem
A full `reindex --semantic` embeds the whole open catalogue (~3.1M jobs) against a remote embedding endpoint (host2 TEI or a GPU HF Inference Endpoint), making hundreds of thousands of cross-network calls over ~20h. `embedChunk` had **no retry** — a single transient blip (dropped connection, brief endpoint restart, host network hiccup) cancelled the whole batch (`embedBatch` cancels siblings on first error) and aborted the entire run with exit 1.

This bit a live full-catalogue embed twice: it died ~1.35M docs in on a host2↔AWS network blip (the same blip that briefly dropped ssh).

## Fix
Bounded retry with exponential backoff + per-attempt timeout, in `internal/search/embed.go`:
- Split the call into `embedOnce` (one attempt, classifies the failure as retriable/terminal) and `embedChunk` (the retry loop).
- **Retriable:** transport errors, 429, 5xx — retried up to `embedMaxAttempts` (5) with backoff 1→8s.
- **Terminal (fail fast):** 4xx, vector/input count mismatch, cancelled parent context.
- `embedAttemptTimeout` (60s) caps a single call so a hung connection is retried, not stalled (http.DefaultClient has no timeout).

## Tests
- `TestEmbedChunkRetriesTransientThenSucceeds` — 2× 503 then 200, absorbed.
- `TestEmbedChunkGivesUpAfterMaxAttempts` — persistent 5xx surfaces after exactly 5 attempts.
- `TestEmbedChunkDoesNotRetryClientError` — a 4xx does not retry (1 call).

No behaviour change on the happy path; only the failure path gains resilience.