### PR TITLE
feat(sources): add keyless BR ATS adapters quickin, mindsight, enlizt

### DIFF
--- a/internal/sources/enlizt.go
+++ b/internal/sources/enlizt.go
@@ -1,0 +1,124 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// enlizt adapts Enlizt career sites (<board>.enlizt.me), a Brazilian ATS. The board is the
+// tenant subdomain; its root page server-renders a list of /vagas/<slug> postings, and each
+// detail page carries a schema.org JobPosting ld+json with the full body and a stable UUID
+// identifier. Description and structured fields come from a per-posting detail fetch,
+// bounded-concurrency, like the other JSON-LD detail adapters (careerspage/icims).
+type enlizt struct {
+	http HTMLGetter
+}
+
+// NewEnlizt builds the Enlizt adapter over the given HTML client.
+func NewEnlizt(c HTMLGetter) Source { return enlizt{http: c} }
+
+func (enlizt) Provider() string { return "enlizt" }
+
+func (s enlizt) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://%s.enlizt.me/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("enlizt: board %q: %w", e.Board, err)
+	}
+	root, err := s.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("enlizt: listing %s: %w", e.Board, err)
+	}
+
+	// Each posting's fields come from its own detail fetch, fanned out under a bounded pool.
+	locs := jobLinks(base, root, enliztIsVaga)
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one posting's detail page and maps its JobPosting ld+json to a Job,
+// returning ok=false when the fetch fails, the page carries no JobPosting, or no stable id
+// can be derived (which would collide on the dedup key), so the caller skips just that one.
+func (s enlizt) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p enliztPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	id := firstNonEmpty(p.Identifier.Value, enliztSlug(loc))
+	if id == "" {
+		return Job{}, false
+	}
+
+	location := joinNonEmpty(
+		p.JobLocation.Address.AddressLocality,
+		p.JobLocation.Address.AddressRegion,
+		p.JobLocation.Address.AddressCountry,
+	)
+	mode := ""
+	if strings.EqualFold(p.JobLocationType, "TELECOMMUTE") {
+		mode = "remote" // schema.org's structured remote signal
+	}
+
+	return Job{
+		ExternalID:  id,
+		URL:         loc,
+		Title:       strings.TrimSpace(p.Title),
+		Company:     firstNonEmpty(p.HiringOrganization.Name, e.Company),
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:      mode == "remote" || isRemote(location),
+		WorkMode:    mode,
+		PostedAt:    parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// enliztPosting is the schema.org JobPosting decoded from an Enlizt detail page's ld+json.
+// identifier is a PropertyValue whose value is the stable posting UUID; jobLocation is a
+// single Place (not an array).
+type enliztPosting struct {
+	Title           string `json:"title"`
+	Description     string `json:"description"`
+	DatePosted      string `json:"datePosted"`
+	JobLocationType string `json:"jobLocationType"`
+	Identifier      struct {
+		Value string `json:"value"`
+	} `json:"identifier"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+			AddressRegion   string `json:"addressRegion"`
+			AddressCountry  string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+}
+
+// enliztVagaPattern matches a /vagas/<slug> posting path: a leading path boundary, one
+// non-empty slug segment, then end-of-string or a query/fragment. Anchoring the end (like
+// careerspage's id pattern) excludes /vagas/<slug>/<action> sub-links (apply/refer) so they
+// are not crawled as duplicate postings; tolerating a missing leading slash accepts a
+// root-relative href. The listing predicate uses it to collect detail links only.
+var enliztVagaPattern = regexp.MustCompile(`(?:^|/)vagas/[^/?#]+(?:$|[?#])`)
+
+// enliztIsVaga reports whether a listing href points at a /vagas/<slug> posting.
+func enliztIsVaga(href string) bool { return enliztVagaPattern.MatchString(href) }
+
+// enliztSlug extracts the <slug> from a /vagas/<slug> URL, the fallback dedup id when the
+// JobPosting carries no identifier. It strips the /vagas/ prefix and any trailing query/
+// fragment the end-anchored pattern may have captured.
+func enliztSlug(loc string) string {
+	m := enliztVagaPattern.FindString(loc)
+	m = strings.TrimPrefix(strings.TrimPrefix(m, "/"), "vagas/")
+	return strings.TrimRight(m, "?#")
+}

--- a/internal/sources/enlizt_test.go
+++ b/internal/sources/enlizt_test.go
@@ -1,0 +1,144 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// enliztFake serves a canned HTML body per URL substring for the listing + detail fetches.
+type enliztFake struct {
+	routes []struct{ match, body string }
+}
+
+func (f *enliztFake) route(match, body string) *enliztFake {
+	f.routes = append(f.routes, struct{ match, body string }{match, body})
+	return f
+}
+
+func (f *enliztFake) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	for _, r := range f.routes {
+		if strings.Contains(url, r.match) {
+			return html.Parse(strings.NewReader(r.body))
+		}
+	}
+	return html.Parse(strings.NewReader("<html></html>"))
+}
+
+func TestEnliztProvider(t *testing.T) {
+	if got := NewEnlizt(nil).Provider(); got != "enlizt" {
+		t.Errorf("Provider() = %q, want %q", got, "enlizt")
+	}
+}
+
+func TestEnliztFetchListsAndMapsDetail(t *testing.T) {
+	listing := `<html><body>
+		<a href="/vagas/full-stack-280426">Full-Stack</a>
+		<a href="/vagas/analista-090426">Analista</a>
+		<a href="/sobre">Sobre</a>
+	</body></html>`
+
+	full := `<html><head><script type="application/ld+json">{
+		"@context":"https://schema.org","@type":"JobPosting","title":"Desenvolvedor(a) Full-Stack",
+		"description":"&lt;p&gt;Build things&lt;/p&gt;","datePosted":"2026-04-28T17:52:33.490Z",
+		"employmentType":"FULL_TIME",
+		"identifier":{"@type":"PropertyValue","name":"Tributo Devido","value":"07f9c460-432b-11f1-aa90-89630f1e6003"},
+		"hiringOrganization":{"@type":"Organization","name":"Tributo Devido"},
+		"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Florianópolis","addressRegion":"SC","addressCountry":"BR"}}
+	}</script></head><body></body></html>`
+
+	analista := `<html><head><script type="application/ld+json">{
+		"@context":"https://schema.org","@type":"JobPosting","title":"Analista Tributário",
+		"description":"<p>Tax</p>","datePosted":"2026-04-09T00:00:00.000Z",
+		"identifier":{"@type":"PropertyValue","value":"11111111-1111-1111-1111-111111111111"},
+		"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"Remote","addressRegion":"","addressCountry":"BR"}}
+	}</script></head></html>`
+
+	fake := (&enliztFake{}).
+		route("/vagas/full-stack-280426", full).
+		route("/vagas/analista-090426", analista).
+		route("tributodevido.enlizt.me/", listing)
+
+	jobs, err := NewEnlizt(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Tributo Devido", Provider: "enlizt", Board: "tributodevido",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (non-vaga link ignored)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	fs, ok := byID["07f9c460-432b-11f1-aa90-89630f1e6003"]
+	if !ok {
+		t.Fatalf("full-stack job missing; got ids %v", byID)
+	}
+	if fs.Title != "Desenvolvedor(a) Full-Stack" {
+		t.Errorf("Title = %q", fs.Title)
+	}
+	if fs.Company != "Tributo Devido" {
+		t.Errorf("Company = %q", fs.Company)
+	}
+	if !strings.Contains(fs.URL, "tributodevido.enlizt.me/vagas/full-stack-280426") {
+		t.Errorf("URL = %q", fs.URL)
+	}
+	if fs.Location != "Florianópolis, SC, BR" {
+		t.Errorf("Location = %q, want %q", fs.Location, "Florianópolis, SC, BR")
+	}
+	if !strings.Contains(fs.Description, "Build things") || strings.Contains(fs.Description, "&lt;") {
+		t.Errorf("Description not unescaped+sanitized: %q", fs.Description)
+	}
+	if fs.PostedAt == nil || fs.PostedAt.Year() != 2026 {
+		t.Errorf("PostedAt = %v", fs.PostedAt)
+	}
+
+	// The Remote-location posting flags remote via the shared heuristic.
+	an := byID["11111111-1111-1111-1111-111111111111"]
+	if !an.Remote {
+		t.Errorf("analista Remote = false, want true (location 'Remote')")
+	}
+}
+
+func TestEnliztDropsPagesWithoutJobPostingAndSubActionLinks(t *testing.T) {
+	// The listing carries a canonical posting, an /apply sub-action of it, and a page with
+	// no JobPosting ld+json. Only the canonical posting yields a Job: the sub-action link is
+	// excluded by the end-anchored pattern, and the bodyless page is dropped (ok=false).
+	listing := `<html><body>
+		<a href="/vagas/real-role-42">Real</a>
+		<a href="/vagas/real-role-42/candidatar">Apply</a>
+		<a href="/vagas/empty-99">Empty</a>
+	</body></html>`
+	real := `<html><head><script type="application/ld+json">{
+		"@type":"JobPosting","title":"Real Role","description":"<p>x</p>","datePosted":"2026-05-01T00:00:00Z",
+		"identifier":{"value":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
+		"jobLocation":{"address":{"addressLocality":"SP","addressCountry":"BR"}}
+	}</script></head></html>`
+	empty := `<html><body><p>No structured data here</p></body></html>`
+
+	fake := (&enliztFake{}).
+		route("/vagas/real-role-42/candidatar", real). // would double-count if the pattern matched sub-actions
+		route("/vagas/real-role-42", real).
+		route("/vagas/empty-99", empty).
+		route("acme.enlizt.me/", listing)
+
+	jobs, err := NewEnlizt(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Provider: "enlizt", Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (sub-action excluded, bodyless page dropped)", len(jobs))
+	}
+	if jobs[0].ExternalID != "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" {
+		t.Errorf("ExternalID = %q", jobs[0].ExternalID)
+	}
+	if !strings.HasSuffix(jobs[0].URL, "/vagas/real-role-42") {
+		t.Errorf("URL = %q, want canonical posting (not the sub-action)", jobs[0].URL)
+	}
+}

--- a/internal/sources/mindsight.go
+++ b/internal/sources/mindsight.go
@@ -1,0 +1,138 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// mindsightBase is the single host Mindsight serves every tenant's public career page
+// from; a board is the tenant's path segment (oportunidades.mindsight.com.br/<slug>).
+const mindsightBase = "https://oportunidades.mindsight.com.br"
+
+// mindsightOpen is the status marking a live posting; the listing only returns published
+// postings, but the guard keeps a non-open one out should the shape ever widen.
+const mindsightOpen = "IN_PROGRESS"
+
+// mindsight adapts Mindsight's public career pages (oportunidades.mindsight.com.br), a
+// Brazilian ATS. Each page is a Next.js app embedding its data in __NEXT_DATA__: the
+// board listing carries every posting's structured fields (id/title/location/work model/
+// dates) but not the body, so each posting's description comes from its own detail page,
+// fanned out like the other detail-fetching adapters.
+type mindsight struct {
+	http TextGetter
+}
+
+// NewMindsight builds the Mindsight adapter over the given HTTP client.
+func NewMindsight(c TextGetter) Source { return mindsight{http: c} }
+
+func (mindsight) Provider() string { return "mindsight" }
+
+// mindsightPost is one posting from the listing's publicJobPostings array. work_model is a
+// structured IN_PERSON/REMOTE/HYBRID enum; country is an ISO alpha-2 code, state an ISO
+// subdivision code; the description is absent here and fetched per posting.
+type mindsightPost struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	WorkModel string `json:"work_model"`
+	Country   string `json:"country"`
+	State     string `json:"state"`
+	City      string `json:"city"`
+	StartAt   string `json:"external_publication_start_at"`
+	CreatedAt string `json:"created_at"`
+}
+
+func (m mindsight) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	body, err := m.http.GetText(ctx, fmt.Sprintf("%s/%s", mindsightBase, e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("mindsight: listing %q: %w", e.Board, err)
+	}
+	raw, ok := bracketSlice(body, "__NEXT_DATA__", '{', '}')
+	if !ok {
+		return nil, fmt.Errorf("mindsight: board %q: no __NEXT_DATA__ in listing", e.Board)
+	}
+	var data struct {
+		Props struct {
+			PageProps struct {
+				PublicJobPostings []mindsightPost `json:"publicJobPostings"`
+			} `json:"pageProps"`
+		} `json:"props"`
+	}
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return nil, fmt.Errorf("mindsight: board %q: decode listing: %w", e.Board, err)
+	}
+
+	posts := data.Props.PageProps.PublicJobPostings
+	return fetchDetails(posts, defaultDetailWorkers, func(p mindsightPost) (Job, bool) {
+		return m.detail(ctx, e, p)
+	}), nil
+}
+
+// detail builds a Job from a listing post, enriching it with the description from the
+// posting's own detail page. The listing post is authoritative for the posting's existence
+// and structured fields, so a failed detail fetch only costs the description. A non-open
+// post (or one with no id, which would collide on the dedup key) is dropped.
+func (m mindsight) detail(ctx context.Context, e CompanyEntry, p mindsightPost) (Job, bool) {
+	if p.ID == 0 || (p.Status != "" && p.Status != mindsightOpen) {
+		return Job{}, false
+	}
+	url := fmt.Sprintf("%s/%s/%d", mindsightBase, e.Board, p.ID)
+
+	description := ""
+	if body, err := m.http.GetText(ctx, url); err == nil {
+		if raw, ok := bracketSlice(body, "__NEXT_DATA__", '{', '}'); ok {
+			var d struct {
+				Props struct {
+					PageProps struct {
+						JobPosting struct {
+							Description string `json:"description"`
+						} `json:"jobPosting"`
+					} `json:"pageProps"`
+				} `json:"props"`
+			}
+			if json.Unmarshal([]byte(raw), &d) == nil {
+				description = sanitizeHTML(d.Props.PageProps.JobPosting.Description)
+			}
+		}
+	}
+
+	// Prefer the publication date, falling back to created_at — but only when the
+	// former yields no usable date. firstNonEmpty on the raw strings would let a
+	// present-but-unparseable/future StartAt (which parseRFC3339/NotFuture drops to nil)
+	// shadow a valid CreatedAt, leaving the job undated; parse both and keep the first hit.
+	posted := parseRFC3339(p.StartAt)
+	if posted == nil {
+		posted = parseRFC3339(p.CreatedAt)
+	}
+
+	mode := mindsightWorkMode(p.WorkModel)
+	return Job{
+		ExternalID:  strconv.Itoa(p.ID),
+		URL:         url,
+		Title:       strings.TrimSpace(p.Name),
+		Company:     e.Company,
+		Location:    joinNonEmpty(p.City, p.State, p.Country),
+		Description: description,
+		Remote:      mode == "remote",
+		WorkMode:    mode,
+		PostedAt:    posted,
+	}, true
+}
+
+// mindsightWorkMode maps Mindsight's work_model enum to our work-mode vocabulary; an
+// empty or unrecognized value yields "".
+func mindsightWorkMode(model string) string {
+	switch strings.ToUpper(strings.TrimSpace(model)) {
+	case "REMOTE":
+		return "remote"
+	case "HYBRID":
+		return "hybrid"
+	case "IN_PERSON":
+		return "onsite"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/mindsight_test.go
+++ b/internal/sources/mindsight_test.go
@@ -1,0 +1,97 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestMindsightPostedDateFallsBackWhenStartAtUnusable(t *testing.T) {
+	// external_publication_start_at is a future instant (a scheduled publication), which
+	// NotFuture drops to nil; the posted date must fall back to created_at rather than
+	// leaving the job undated.
+	listing := `<html><script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"publicJobPostings":[
+		{"id":7,"name":"Scheduled Role","status":"IN_PROGRESS","work_model":"REMOTE",
+		 "country":"BR","state":"SP","city":"São Paulo",
+		 "external_publication_start_at":"2099-01-01T00:00:00Z","created_at":"2026-06-10T00:00:00Z"}
+	]}}}</script></html>`
+	detail := `<html><script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"jobPosting":{"id":7,"description":"<p>x</p>"}}}}</script></html>`
+
+	fake := (&routedHTTP{}).route("/acme/7", detail).route("/acme", listing)
+	jobs, err := NewMindsight(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Provider: "mindsight", Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	if jobs[0].PostedAt == nil || jobs[0].PostedAt.Year() != 2026 || jobs[0].PostedAt.Month() != 6 {
+		t.Errorf("PostedAt = %v, want created_at 2026-06 (future start_at dropped)", jobs[0].PostedAt)
+	}
+}
+
+func TestMindsightProvider(t *testing.T) {
+	if got := NewMindsight(nil).Provider(); got != "mindsight" {
+		t.Errorf("Provider() = %q, want %q", got, "mindsight")
+	}
+}
+
+func TestMindsightFetchListsAndEnrichesDetail(t *testing.T) {
+	// The listing embeds publicJobPostings in __NEXT_DATA__ (structured fields, no body);
+	// each posting's detail page embeds jobPosting.description. Job 16 is open and enriched;
+	// job 99 is not IN_PROGRESS and is dropped.
+	listing := `<html><body><script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"publicJobPostings":[
+		{"id":16,"name":"  Backend Engineer  ","status":"IN_PROGRESS","work_model":"REMOTE",
+		 "country":"BR","state":"SP","city":"Rio Claro",
+		 "external_publication_start_at":"2026-06-16T00:00:00Z","created_at":"2026-06-10T00:00:00Z"},
+		{"id":99,"name":"Closed Role","status":"FINISHED","work_model":"IN_PERSON",
+		 "country":"BR","state":"SP","city":"São Paulo","created_at":"2026-06-01T00:00:00Z"}
+	]}}}</script></body></html>`
+
+	detail16 := `<html><body><script id="__NEXT_DATA__" type="application/json">{"props":{"pageProps":{"jobPosting":{"id":16,
+		"description":"<p>Build APIs</p><script>evil()</script>"}}}}</script></body></html>`
+
+	fake := (&routedHTTP{}).
+		route("/grupomngt/16", detail16).
+		route("/grupomngt", listing)
+
+	jobs, err := NewMindsight(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Grupo MNGT", Provider: "mindsight", Board: "grupomngt",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (closed job dropped)", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "16" {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, "16")
+	}
+	if j.Title != "Backend Engineer" {
+		t.Errorf("Title = %q, want trimmed", j.Title)
+	}
+	if j.Company != "Grupo MNGT" {
+		t.Errorf("Company = %q, want %q", j.Company, "Grupo MNGT")
+	}
+	if j.URL != "https://oportunidades.mindsight.com.br/grupomngt/16" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Location != "Rio Claro, SP, BR" {
+		t.Errorf("Location = %q, want %q", j.Location, "Rio Claro, SP, BR")
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote", j.Remote, j.WorkMode)
+	}
+	if !strings.Contains(j.Description, "Build APIs") {
+		t.Errorf("Description missing detail body: %q", j.Description)
+	}
+	if strings.Contains(j.Description, "evil") || strings.Contains(j.Description, "<script") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	// external_publication_start_at is preferred over created_at for the posted date.
+	if j.PostedAt == nil || j.PostedAt.Month() != 6 || j.PostedAt.Day() != 16 {
+		t.Errorf("PostedAt = %v, want 2026-06-16 (start_at, not created_at)", j.PostedAt)
+	}
+}

--- a/internal/sources/quickin.go
+++ b/internal/sources/quickin.go
@@ -1,0 +1,134 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	quickinBaseURL  = "https://api.quickin.io"
+	quickinPageSize = 100
+	// quickinMaxPages bounds the page walk; the stop signal is the response's pages
+	// count, but this caps a misbehaving API well above any single tenant's postings.
+	quickinMaxPages = 200
+	// quickinPublished is the publicate value marking a live posting; any other value
+	// (draft/paused/closed) is skipped.
+	quickinPublished = "published"
+)
+
+// quickin adapts Quickin's public careers API (api.quickin.io), a Brazilian ATS whose
+// company career sites live at jobs.quickin.io/<slug>. A board is that account slug; it is
+// first resolved to the account's opaque id, which keys the paginated jobs listing. The
+// listing carries the full posting inline (title, description, requirements, location,
+// workplace type), so no per-posting detail request is needed.
+type quickin struct {
+	http JSONGetter
+}
+
+// NewQuickin builds the Quickin adapter over the given HTTP client.
+func NewQuickin(c JSONGetter) Source { return quickin{http: c} }
+
+func (quickin) Provider() string { return "quickin" }
+
+// quickinJob is one posting from the listing. publicate gates visibility; description and
+// requirements are separate HTML blocks; city/region/country are free-text location parts
+// (country is an ISO alpha-2 code); workplace_type is a structured remote/hybrid/onsite enum.
+type quickinJob struct {
+	ID            string `json:"_id"`
+	Publicate     string `json:"publicate"`
+	Title         string `json:"title"`
+	Description   string `json:"description"`
+	Requirements  string `json:"requirements"`
+	City          string `json:"city"`
+	Region        string `json:"region"`
+	Country       string `json:"country"`
+	WorkplaceType string `json:"workplace_type"`
+	CareerURL     string `json:"career_url"`
+	CreatedAt     string `json:"created_at"`
+}
+
+func (q quickin) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	accountID, err := q.accountID(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+	postings, err := q.list(ctx, e.Board, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		if p.Publicate != quickinPublished {
+			continue
+		}
+		mode := workplaceTypeMode(p.WorkplaceType)
+		jobs = append(jobs, Job{
+			ExternalID:  p.ID,
+			URL:         firstNonEmpty(p.CareerURL, fmt.Sprintf("https://jobs.quickin.io/%s/jobs/%s", e.Board, p.ID)),
+			Title:       strings.TrimSpace(p.Title),
+			Company:     e.Company,
+			Location:    joinNonEmpty(p.City, p.Region, p.Country),
+			Description: quickinBody(p.Description, p.Requirements),
+			Remote:      mode == "remote",
+			WorkMode:    mode,
+			PostedAt:    parseRFC3339(p.CreatedAt),
+		})
+	}
+	return jobs, nil
+}
+
+// accountID resolves a board (account slug) to the opaque account id that keys the jobs
+// listing.
+func (q quickin) accountID(ctx context.Context, board string) (string, error) {
+	var acc struct {
+		ID string `json:"_id"`
+	}
+	url := fmt.Sprintf("%s/public/accounts/%s", quickinBaseURL, board)
+	if err := q.http.GetJSON(ctx, url, &acc); err != nil {
+		return "", fmt.Errorf("quickin: account %s: %w", board, err)
+	}
+	if acc.ID == "" {
+		return "", fmt.Errorf("quickin: account %s: empty id", board)
+	}
+	return acc.ID, nil
+}
+
+// list pages through an account's postings, stopping at the response's pages count. A
+// first-page failure aborts (the board yields nothing); a later-page failure after at least
+// one page succeeded stops the walk and keeps what was gathered.
+func (q quickin) list(ctx context.Context, board, accountID string) ([]quickinJob, error) {
+	var postings []quickinJob
+	for page := 1; page <= quickinMaxPages; page++ {
+		url := fmt.Sprintf("%s/public/%s/jobs?page=%d&limit=%d", quickinBaseURL, accountID, page, quickinPageSize)
+		var resp struct {
+			Docs  []quickinJob `json:"docs"`
+			Pages int          `json:"pages"`
+		}
+		if err := q.http.GetJSON(ctx, url, &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("quickin: list %s: %w", board, err)
+			}
+			break // partial: keep what earlier pages yielded
+		}
+		postings = append(postings, resp.Docs...)
+		// Stop at the server's reported last page when it gives one; otherwise (pages
+		// absent or 0) fall back to a short page, so a missing pages field can't
+		// truncate a full board to its first page.
+		if resp.Pages > 0 {
+			if page >= resp.Pages {
+				break
+			}
+		} else if len(resp.Docs) < quickinPageSize {
+			break
+		}
+	}
+	return postings, nil
+}
+
+// quickinBody sanitizes and joins the posting's two HTML blocks (description and
+// requirements) into one plain-text body, dropping whichever is empty.
+func quickinBody(description, requirements string) string {
+	return strings.TrimSpace(sanitizeHTML(description) + "\n\n" + sanitizeHTML(requirements))
+}

--- a/internal/sources/quickin_test.go
+++ b/internal/sources/quickin_test.go
@@ -1,0 +1,136 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestQuickinPaginatesWhenPagesFieldMissing(t *testing.T) {
+	// A response that omits (or zeroes) `pages` must not truncate a full board to its
+	// first page: a full page (len == limit) means "there may be more", so the walk
+	// continues until a short page. Page 1 is full (100 docs, pages:0); page 2 is short.
+	var b strings.Builder
+	b.WriteString(`{"page":1,"pages":0,"docs":[`)
+	for i := 0; i < quickinPageSize; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"_id":"p1-%d","publicate":"published","title":"Role %d","workplace_type":"remote"}`, i, i)
+	}
+	b.WriteString(`]}`)
+	page1 := b.String()
+	page2 := `{"page":2,"pages":0,"docs":[{"_id":"p2-0","publicate":"published","title":"Last","workplace_type":"remote"}]}`
+
+	fake := (&routedHTTP{}).
+		route("/public/accounts/acme", `{"_id":"acc","name":"Acme"}`).
+		route("page=1", page1).
+		route("page=2", page2)
+
+	jobs, err := NewQuickin(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Provider: "quickin", Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// 100 from the full page 1 + 1 from page 2 = 101; a pages:0 early-stop would yield 100.
+	if len(jobs) != quickinPageSize+1 {
+		t.Fatalf("len(jobs) = %d, want %d (missing pages field must not truncate)", len(jobs), quickinPageSize+1)
+	}
+}
+
+func TestQuickinProvider(t *testing.T) {
+	if got := NewQuickin(nil).Provider(); got != "quickin" {
+		t.Errorf("Provider() = %q, want %q", got, "quickin")
+	}
+}
+
+func TestQuickinFetchResolvesAccountMapsFieldsAndPaginates(t *testing.T) {
+	// The board slug "botcity" resolves to an opaque account id, which keys the paginated
+	// jobs listing. Page 1 declares pages=2, so the walk continues to page 2. The first job
+	// exercises every mapping; the unpublished job (publicate != "published") is dropped.
+	account := `{"_id":"acc123","name":"BotCity","slug":"botcity"}`
+
+	page1 := `{"total":3,"page":1,"pages":2,"limit":100,"docs":[
+		{"_id":"job1","publicate":"published","title":"  Python Developer  ",
+		 "description":"<p>Build bots</p><script>evil()</script>","requirements":"<p>Python, 3y</p>",
+		 "city":"Global","region":"SP","country":"BR","workplace_type":"remote",
+		 "career_url":"https://jobs.quickin.io/botcity/jobs/job1","created_at":"2026-07-03T21:54:21.543Z"},
+		{"_id":"job2","publicate":"draft","title":"Hidden Role","description":"<p>secret</p>",
+		 "city":"São Paulo","region":"SP","country":"BR","workplace_type":"remote",
+		 "created_at":"2026-07-02T10:00:00.000Z"}
+	]}`
+
+	page2 := `{"total":3,"page":2,"pages":2,"limit":100,"docs":[
+		{"_id":"job3","publicate":"published","title":"Backend Engineer","description":"<p>APIs</p>",
+		 "requirements":"","city":"","region":"São Paulo","country":"BR","workplace_type":"hybrid",
+		 "career_url":"","created_at":"2026-06-30T12:10:41.833Z"}
+	]}`
+
+	fake := (&routedHTTP{}).
+		route("/public/accounts/botcity", account).
+		route("page=1", page1).
+		route("page=2", page2)
+
+	jobs, err := NewQuickin(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "BotCity", Provider: "quickin", Board: "botcity",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	// 1 published from page 1 (draft dropped) + 1 published from page 2 = 2.
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (one unpublished job dropped across two pages)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	py, ok := byID["job1"]
+	if !ok {
+		t.Fatalf("job1 missing; got %v", byID)
+	}
+	if py.Title != "Python Developer" {
+		t.Errorf("Title = %q, want trimmed %q", py.Title, "Python Developer")
+	}
+	if py.Company != "BotCity" {
+		t.Errorf("Company = %q, want %q", py.Company, "BotCity")
+	}
+	if py.URL != "https://jobs.quickin.io/botcity/jobs/job1" {
+		t.Errorf("URL = %q, want the career_url", py.URL)
+	}
+	if py.Location != "Global, SP, BR" {
+		t.Errorf("Location = %q, want %q", py.Location, "Global, SP, BR")
+	}
+	if !py.Remote || py.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote", py.Remote, py.WorkMode)
+	}
+	// sanitizeHTML keeps safe structural HTML but strips active content (script).
+	if strings.Contains(py.Description, "evil") || strings.Contains(py.Description, "<script") {
+		t.Errorf("Description not sanitized: %q", py.Description)
+	}
+	if !strings.Contains(py.Description, "Build bots") || !strings.Contains(py.Description, "Python, 3y") {
+		t.Errorf("Description missing description+requirements: %q", py.Description)
+	}
+	if py.PostedAt == nil || py.PostedAt.Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed 2026 date", py.PostedAt)
+	}
+
+	be, ok := byID["job3"]
+	if !ok {
+		t.Fatalf("job3 missing")
+	}
+	if be.WorkMode != "hybrid" || be.Remote {
+		t.Errorf("job3 WorkMode=%q Remote=%v, want hybrid/false", be.WorkMode, be.Remote)
+	}
+	// Empty career_url falls back to the constructed jobs URL.
+	if be.URL != "https://jobs.quickin.io/botcity/jobs/job3" {
+		t.Errorf("job3 URL = %q, want constructed fallback", be.URL)
+	}
+	// region-only location (city empty) skips the blank.
+	if be.Location != "São Paulo, BR" {
+		t.Errorf("job3 Location = %q, want %q", be.Location, "São Paulo, BR")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -203,6 +203,9 @@ func All(c HTTPClient) map[string]Source {
 		NewZoho(c),
 		NewTraffit(c),
 		NewErecruiter(c),
+		NewQuickin(c),
+		NewMindsight(c),
+		NewEnlizt(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/openspec/changes/backend-br-ats-adapters/.openspec.yaml
+++ b/openspec/changes/backend-br-ats-adapters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/backend-br-ats-adapters/proposal.md
+++ b/openspec/changes/backend-br-ats-adapters/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`backend-br/vagas` is a high-traffic Brazilian GitHub-issues job board (~50 open
+vacancies at any time). Unpacking its open issues shows the "apply" links resolve to a
+handful of Brazilian ATS platforms — most of which we do **not** ingest today, so those
+vacancies are invisible to freehire. Of the platforms referenced, only InHire (DB1) is
+already covered. The rest are keyless, multi-tenant Brazilian ATS platforms that clear
+the same bar as our existing adapters (structured public data, one company per board),
+so each is worth a dedicated `Source` adapter. Adding them both closes the coverage gap
+for this repo's companies and unlocks the broader BR customer roster each platform hosts.
+
+## What Changes
+
+- Add board-based `Source` adapters for the Brazilian ATS platforms surfaced by
+  `backend-br/vagas`, each keyless and multi-tenant, each registered in `sources.All`
+  and seeded with the live-validated companies from the repo:
+  - **quickin** (`api.quickin.io`) — account-slug board; list endpoint carries the full
+    posting inline (no per-job detail request).
+  - **mindsight** (`oportunidades.mindsight.com.br`) — Next.js `__NEXT_DATA__` career
+    pages; listing is structured, description comes from each posting's detail page.
+  - **enlizt** (`<tenant>.enlizt.me`) — schema.org `JobPosting` JSON-LD.
+- Each adapter is board-based and multi-tenant (not boardless), so it lists in the source
+  facet with no extra wiring — like greenhouse/personio/inhire.
+- Regenerate `web/src/lib/generated/contracts.ts` so the new provider keys appear in
+  `SOURCE_VALUES` (the frontend source filter is generated from `FilterableProviders()`).
+
+## Capabilities
+
+### New Capabilities
+- `backend-br-ats-adapters`: crawl the keyless Brazilian ATS platforms referenced by
+  `backend-br/vagas` (quickin, mindsight, enlizt) — one company per board — and normalize
+  their open vacancies into the job catalogue, so those postings become searchable
+  alongside the rest.
+
+### Modified Capabilities
+<!-- None: additive adapters behind the existing Source interface and registry; no existing spec's requirements change. -->
+
+## Impact
+
+- **New code:** one `internal/sources/<provider>.go` (+ `_test.go`) per platform, one
+  registration line each in `internal/sources/source.go`, one `sources/<provider>.yml`
+  board file each.
+- **No schema/API changes:** every adapter emits the same `sources.Job` shape; ingest,
+  dedup, enrichment, and search are unchanged.
+- **Generated contracts:** `web/src/lib/generated/contracts.ts` regenerated to include
+  the new provider keys in `SOURCE_VALUES` (via `make gen-contracts`).
+- **Ops:** each new board file is a new `cmd/ingest sources/<provider>.yml` cron entry,
+  added the same way as every other provider file.
+- **Reuses existing transport/helpers:** `JSONGetter` / `TextGetter` / `HTMLGetter`,
+  `sanitizeHTML`, `bracketSlice`, `ldJobPosting`, `fetchDetails`, `workplaceTypeMode`.
+- **Descoped (not keyless):** `workfully` (`hiring.workfully.com`, API 403s without a
+  session token; RSC-rendered) and `strider` (`app.onstrider.com`, a Clerk-authenticated
+  SPA whose API 401s) both sit behind authentication, failing the read-only-public-API bar
+  every other adapter clears. Each covers only one company from the repo (Stefanini; one
+  US-marketplace recruiter). Recorded as a seam rather than built with a fragile
+  anonymous-token workaround.
+- **Known seam (out of scope):** bulk harvest of each platform's full BR customer roster
+  (this change seeds only the live-validated companies from `backend-br/vagas`), and the
+  ~20 `sylision.com` aggregator postings + LinkedIn/one-off links in the repo that map to
+  no ATS board (a free-text extraction source, not an adapter, would be needed).

--- a/openspec/changes/backend-br-ats-adapters/specs/backend-br-ats-adapters/spec.md
+++ b/openspec/changes/backend-br-ats-adapters/specs/backend-br-ats-adapters/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Quickin per-company crawl
+
+The system SHALL provide a `quickin` source adapter that crawls a single Quickin account
+into the catalogue. The adapter is board-based and single-company: each configured entry's
+board is the Quickin account slug (as in `jobs.quickin.io/<slug>`). The adapter resolves
+the slug to the account's opaque id via `GET https://api.quickin.io/public/accounts/<slug>`,
+then pages `GET https://api.quickin.io/public/<accountId>/jobs`. The listing carries the
+full posting inline, so no per-posting detail request is required. The crawl is keyless.
+
+#### Scenario: Board yields published postings
+
+- **WHEN** the adapter fetches a configured board
+- **THEN** it resolves the account id, pages the jobs listing, and returns one `Job` per
+  `published` posting, populated with title, career URL, external id, location
+  (city/region/country), work mode (from `workplace_type`), posted-at, and a sanitized
+  HTML body (description + requirements)
+
+#### Scenario: Unpublished postings are dropped
+
+- **WHEN** a listing posting's `publicate` is not `published`
+- **THEN** the adapter omits it
+
+### Requirement: Mindsight per-company crawl
+
+The system SHALL provide a `mindsight` source adapter that crawls a single Mindsight
+career page into the catalogue. The adapter is board-based and single-company: each entry's
+board is the tenant path segment served from `oportunidades.mindsight.com.br/<slug>`. The
+adapter reads the page's Next.js `__NEXT_DATA__` `publicJobPostings` array for the
+structured fields and fetches each posting's detail page for its description body. The
+crawl is keyless.
+
+#### Scenario: Listing drives the crawl, detail supplies the body
+
+- **WHEN** the adapter fetches a configured board
+- **THEN** it returns one `Job` per open (`IN_PROGRESS`) posting with title, detail URL,
+  external id, location (city/state/country), work mode (from `work_model`), posted-at,
+  and a description sanitized from that posting's detail-page `jobPosting.description`
+
+#### Scenario: Closed postings are dropped
+
+- **WHEN** a listing posting's status is not `IN_PROGRESS`
+- **THEN** the adapter omits it, and a failed detail fetch is non-fatal (the posting is
+  still returned, with an empty description)
+
+### Requirement: Enlizt per-company crawl
+
+The system SHALL provide an `enlizt` source adapter that crawls a single Enlizt tenant
+(`<tenant>.enlizt.me`) into the catalogue, board-based and single-company, taking each
+posting's structured fields and body from the tenant's keyless public listing and its
+schema.org `JobPosting` data.
+
+#### Scenario: Board yields tenant postings
+
+- **WHEN** the adapter fetches a configured board
+- **THEN** it returns one `Job` per open posting with title, posting URL, external id,
+  location, posted-at, and a sanitized HTML body
+
+### Requirement: Registered board-based providers
+
+Each new adapter MUST be registered in `sources.All` under its provider key and be
+board-based (not boardless), so `cmd/ingest` and config validation recognise it, board
+files require a board id, and it appears in the source facet (`FilterableProviders()` /
+the generated `SOURCE_VALUES`) like the other ATS adapters.
+
+#### Scenario: Provider is recognised by config validation
+
+- **WHEN** a board file names one of the new providers with a board id
+- **THEN** config validation accepts it, and an entry that omits its board is rejected
+
+#### Scenario: Provider appears in the source facet
+
+- **WHEN** `FilterableProviders()` is enumerated
+- **THEN** each new provider key is present, and `web/src/lib/generated/contracts.ts`
+  `SOURCE_VALUES` includes it after regeneration

--- a/openspec/changes/backend-br-ats-adapters/tasks.md
+++ b/openspec/changes/backend-br-ats-adapters/tasks.md
@@ -1,0 +1,44 @@
+## 1. Quickin adapter (account-slug, inline listing)
+
+- [x] 1.1 Add `internal/sources/quickin.go`: `NewQuickin(JSONGetter)`, `Provider() "quickin"`, resolve board slug → account id via `GET /public/accounts/<slug>`, then page `GET /public/<accountId>/jobs`.
+- [x] 1.2 Map each `published` posting inline (title, description+requirements, city/region/country, `workplace_type` → work mode, `career_url`, `created_at`); drop non-`published`.
+- [x] 1.3 `internal/sources/quickin_test.go`: offline `routedHTTP` test covering account resolve, pagination, publish filter, sanitization, work mode, URL fallback.
+- [x] 1.4 Register `NewQuickin(c)` in `sources.All`; add `sources/quickin.yml` (BotCity, Igma — live-validated); regenerate contracts.
+- [x] 1.5 Live end-to-end fetch of BotCity + Igma returns postings with mapped fields.
+
+## 2. Mindsight adapter (Next.js `__NEXT_DATA__`, detail body)
+
+- [x] 2.1 Add `internal/sources/mindsight.go`: `NewMindsight(TextGetter)`, `Provider() "mindsight"`, fetch `oportunidades.mindsight.com.br/<slug>`, `bracketSlice` `__NEXT_DATA__`, decode `publicJobPostings`.
+- [x] 2.2 Enrich each `IN_PROGRESS` posting with the description from its detail page's `jobPosting.description`; map `work_model` → work mode, country/state/city → location, `external_publication_start_at`|`created_at` → posted.
+- [x] 2.3 `internal/sources/mindsight_test.go`: offline test covering listing decode, closed-post drop, detail body enrichment, sanitization, posted-date preference.
+- [x] 2.4 Register `NewMindsight(c)` in `sources.All`; add `sources/mindsight.yml` (Grupo MNGT — live-validated); regenerate contracts.
+- [x] 2.5 Live end-to-end fetch of the seeded board returns postings with mapped fields.
+
+## 3. Enlizt adapter (JSON-LD)
+
+- [x] 3.1 Reverse-engineer enlizt's public listing + detail (`<tenant>.enlizt.me`): confirm keyless list endpoint and `JobPosting` JSON-LD shape.
+- [x] 3.2 Add `internal/sources/enlizt.go` implementing `Source` over the resolved transport; map to `Job` (title, URL, external id, location, work mode, posted, sanitized body).
+- [x] 3.3 `internal/sources/enlizt_test.go`: offline fixture test of the mapping and any drop/fallback paths.
+- [x] 3.4 Register in `sources.All`; add `sources/enlizt.yml` (live-validated tenant); regenerate contracts.
+- [x] 3.5 Live end-to-end fetch returns postings with mapped fields.
+
+## 4. Descoped — Workfully & Strider (not keyless)
+
+Both platforms referenced by `backend-br/vagas` were reverse-engineered and found to sit
+behind authentication, failing the adapter bar (`AGENT.md`: adapters are read-only over
+**public** ATS APIs). Descoped by decision; recorded as a known seam in the proposal.
+
+- **Workfully** (`hiring.workfully.com`): the SPA calls `api.hiring.workfully.com`; every
+  job endpoint (`/jobs/{id}`, `/jobs/{id}/public`, `/recruiters/{id}/jobs`) returns
+  `403 ForbiddenError "You don't have rights"` without a session token, and the page is
+  RSC-rendered (no ld+json / `__NEXT_DATA__`). Covers 1 company (Stefanini).
+- **Strider** (`app.onstrider.com`): a Clerk-authenticated CRA SPA; `.../api/*` returns
+  `401 "User not authenticated"`. A US talent marketplace (not a company ATS), 1 recruiter.
+
+- [x] 4.1 Confirm neither exposes a keyless public jobs API; document the block and descope.
+
+## 5. Cross-cutting verification
+
+- [x] 5.1 `go build ./... && go vet ./... && go test ./internal/sources/` clean with the three adapters registered.
+- [x] 5.2 Each new provider (quickin/mindsight/enlizt) appears in `FilterableProviders()` / `SOURCE_VALUES`; config validation requires a board for each (none boardless).
+- [x] 5.3 A dry `cmd/ingest sources/<provider>.yml` config-validation pass loads each board file without error.

--- a/sources/enlizt.yml
+++ b/sources/enlizt.yml
@@ -1,0 +1,4 @@
+# Enlizt boards. Provider is the filename; each entry is company + board.
+# board = the tenant subdomain in <board>.enlizt.me (see internal/sources/enlizt.go).
+- company: Tributo Devido
+  board: tributodevido

--- a/sources/mindsight.yml
+++ b/sources/mindsight.yml
@@ -1,0 +1,5 @@
+# Mindsight boards. Provider is the filename; each entry is company + board.
+# board = the tenant path segment served from oportunidades.mindsight.com.br/<slug>
+# (see internal/sources/mindsight.go).
+- company: Grupo MNGT
+  board: grupomngt

--- a/sources/quickin.yml
+++ b/sources/quickin.yml
@@ -1,0 +1,8 @@
+# Quickin boards. Provider is the filename; each entry is company + board.
+# board = the Quickin account slug in jobs.quickin.io/<slug> (resolved to the account's
+# opaque id via api.quickin.io, which keys the paginated jobs listing — see
+# internal/sources/quickin.go).
+- company: BotCity
+  board: botcity
+- company: Igma
+  board: igma

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -87,12 +87,17 @@ export interface Job {
   location: string;
   description: string;
   /**
-   * Countries/Regions/WorkMode/Skills are served from the jobs dictionary columns
-   * ONLY — the deterministic dictionaries are the sole production source for these
-   * facets. The LLM's enrichment values for them are deliberately excluded from
-   * the served object (they remain raw in the stored enrichment JSONB), so the LLM
-   * can later run free as a discovery signal without corrupting production data.
-   * They are served top-level and once; the same fields are folded out of the
+   * WorkMode/Skills are served from the jobs dictionary columns ONLY — the
+   * deterministic dictionaries are the sole production source for these facets. The
+   * LLM's enrichment values for them are deliberately excluded from the served object
+   * (they remain raw in the stored enrichment JSONB), so the LLM can later run free as
+   * a discovery signal without corrupting production data.
+   * Countries/Regions are a HYBRID facet, like Cities (see geoFacet): the dictionary
+   * columns win whenever they pinned a place, but an unpinned geography (no country,
+   * and at most the bare-"Remote" "global" bucket) falls back to the LLM's
+   * enrichment.countries/regions — catching a restriction stated only in the prose
+   * ("Remote (SPAIN only)") that the location string never carried.
+   * All four are served top-level and once; the same fields are folded out of the
    * nested Enrichment to avoid duplication.
    */
   countries: string[];
@@ -318,7 +323,7 @@ export interface JobMatch {
   missing: string[];
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'eightfold', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'icims', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobicy', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mycareersfuture', 'oracle', 'paycom', 'paylocity', 'personio', 'phenom', 'pinpoint', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'ukg', 'vention', 'vouch', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'icims', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'luxoft', 'mindsight', 'mycareersfuture', 'oracle', 'paycom', 'paylocity', 'personio', 'phenom', 'pinpoint', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'ukg', 'vention', 'vouch', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];


### PR DESCRIPTION
## Why

Unpacking [`backend-br/vagas`](https://github.com/backend-br/vagas) (a high-traffic Brazilian GitHub-issues job board, ~50 open vacancies) showed its "apply" links resolve to a handful of Brazilian ATS platforms — most of which we did not ingest, so those vacancies were invisible to freehire. Only InHire (DB1) was already covered.

## What

Board-based, keyless `Source` adapters for the three platforms that expose public data, each seeded with the repo's live-validated companies:

- **quickin** (`api.quickin.io`) — account-slug board; the jobs listing carries the full posting inline (no per-job detail fetch). Boards: BotCity, Igma (14 live postings).
- **mindsight** (`oportunidades.mindsight.com.br`) — Next.js `__NEXT_DATA__` listing + per-posting detail body. Board: Grupo MNGT (11 live).
- **enlizt** (`<tenant>.enlizt.me`) — root listing of `/vagas/<slug>` links + schema.org `JobPosting` ld+json detail. Board: Tributo Devido (3 live).

Each is registered in `sources.All`, is board-based (not boardless), and appears in the generated `SOURCE_VALUES`. No schema/API changes — every adapter emits the same `sources.Job` shape.

## Descoped (not keyless)

`workfully` (`hiring.workfully.com`, API `403`s without a session token; RSC-rendered) and `strider` (`app.onstrider.com`, a Clerk-authenticated SPA whose API `401`s) both sit behind authentication, failing the read-only-public-API bar every other adapter clears. Each covers only one company from the repo. Recorded as a seam in the OpenSpec change rather than built with a fragile anonymous-token workaround.

## Verification

- `go build ./... && go vet ./... && go test ./internal/sources/` clean; gofmt clean.
- Each adapter: offline `routedHTTP`/fixture test (TDD) → live end-to-end fetch → adversarial multi-agent review → fixes. Review caught and fixed 3 real bugs: quickin pagination truncating on a missing `pages` field, mindsight `PostedAt` fallback shadowed by a future/date-only `StartAt`, enlizt's unanchored `/vagas/` regex over-matching apply/refer sub-links.
- All three `sources/*.yml` board files pass config validation against the registry.

## Ops follow-up

Three new board files → three new `cmd/ingest sources/<provider>.yml` cron entries in `freehire-ops`.

OpenSpec: `backend-br-ats-adapters`.