### PR TITLE
feat(sources): add Tellent (recruitee) board

### DIFF
--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -69,6 +69,8 @@
   board: spocket
 - company: Squeeze Studio
   board: squeezestudio
+- company: Tellent
+  board: tellent
 - company: ten square games
   board: tensquaregames
 - company: Terra


### PR DESCRIPTION
Tellent runs its careers page on Recruitee (`careers.tellent.com` → `tellent.recruitee.com`), which it owns. The Recruitee adapter is already supported, so this is just the board entry.

Board currently has 0 open offers, but the entry lets ingest pick up postings automatically once published.