### PR TITLE
feat(sources): add 3 harvested boards from backend-br /vagas sibling repos

### DIFF
--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -702,3 +702,9 @@
   board: toroinvestimentos
 - company: "Voltta"
   board: volttaenergy
+
+# --- harvested from the backend-br /vagas sibling repos 2026-07-08 ---
+- company: "XP Inc"
+  board: rpo-xpinc
+- company: "Spun"
+  board: spun

--- a/sources/solides.yml
+++ b/sources/solides.yml
@@ -2316,3 +2316,7 @@
   board: zumbrazil
 - company: BemAgro
   board: bemagro
+
+# --- harvested from the backend-br /vagas sibling repos 2026-07-08 ---
+- company: "Sistemas Tecnologia"
+  board: sistemastecnol


### PR DESCRIPTION
Swept the ~21 sibling GitHub `/vagas` community boards linked from `backend-br/vagas` (frontendbr, phpdevbr, react-brasil, pydevbr, …; ~71 open vacancies). **Coverage is already broad** — nearly every apply link resolves to a platform we ingest.

**Added (live-validated companies on supported platforms):**
- inhire: XP Inc (`rpo-xpinc`), Spun (`spun`)
- solides: Sistemas Tecnologia (`sistemastecnol`)

**Not added** — the four new platforms surfaced (coodesh, recrutei, huntit, pandape) all fail the read-only-public-API bar (auth-gated list APIs or client-rendered listings), same call as workfully/strider. sylision.com is a recruiter aggregator, not an ATS.

Board-file additions only, validated against the registry. No code changes.