### PR TITLE
feat(api): stateless market-coverage endpoint (POST /api/v1/market/coverage)

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -246,6 +246,11 @@ func Register(app *fiber.App, cfg Config) {
 	// Read-only per-job skill match against the caller's profile (no writes).
 	api.Get("/jobs/:slug/match", keyAuth, a.JobMatch)
 
+	// Stateless market-coverage: score a caller-supplied skill list (request body)
+	// against the facet-filtered market. Cookie or API key — the CLI drives it with
+	// a key. No user data is stored; it is the stateless sibling of the CV verdict.
+	api.Post("/market/coverage", keyAuth, a.MarketCoverage)
+
 	// Moderator-authored jobs: create a hand-curated vacancy and edit it. Authenticated
 	// by cookie or API key (the CLI uses a key), then gated on the moderator role. The
 	// public job reads above stay unauthenticated; a non-moderator gets 403.

--- a/internal/handler/market_coverage.go
+++ b/internal/handler/market_coverage.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/search"
+)
+
+// maxCoverageSkills caps the supplied skill list. Each skill becomes its own
+// `skills != "<skill>"` AND group in the uncovered query, so an unbounded list
+// would balloon the Meilisearch filter; a real CV lists well under this many
+// canonical skills.
+const maxCoverageSkills = 100
+
+// coverageRequest is the market-coverage request body: the caller's skill list,
+// measured against the filtered market. One skill or many — a single-element list
+// is a valid probe of that one skill's demand.
+type coverageRequest struct {
+	Skills []string `json:"skills"`
+}
+
+// MarketCoverage scores a caller-supplied skill list against the live open-vacancy
+// market for a facet-filtered role: how many of the role's vacancies list at least
+// one of the skills (the covered count), which missing skill unlocks the most new
+// vacancies, and the role's top in-demand skills scored against the list. It is the
+// stateless, API-key sibling of the CV-based verdict — skills come from the request
+// body, the market filter from the facet query params. 400 on empty skills, 503
+// when search is unconfigured.
+func (a *API) MarketCoverage(c *fiber.Ctx) error {
+	if a.facets == nil {
+		return fiber.NewError(fiber.StatusServiceUnavailable, "search is not available")
+	}
+
+	var req coverageRequest
+	if err := c.BodyParser(&req); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	}
+	skills := nonEmptyStrings(req.Skills)
+	if len(skills) == 0 {
+		return fiber.NewError(fiber.StatusBadRequest, "skills is required")
+	}
+	if len(skills) > maxCoverageSkills {
+		return fiber.NewError(fiber.StatusBadRequest, "too many skills")
+	}
+
+	// A flat list has no CV declared/body sections, so declared and all are the
+	// same list and body is empty (statuses collapse to strong/adjacent/missing).
+	v, err := a.coverageFor(c.Context(), marketFilter(c), skills, skills, nil, skills)
+	if err != nil {
+		return err
+	}
+	// coherence is a CV-section metric (declared ∩ body); a flat skill list has no
+	// sections, so it is meaningless here — zero it rather than advertise a score.
+	v.CoherencePercent = 0
+	return c.JSON(fiber.Map{"data": v})
+}
+
+// marketFilter builds the market filter from the request's facet query params
+// (the full facet vocabulary), with the skills facet stripped (see stripSkillParams).
+func marketFilter(c *fiber.Ctx) any {
+	vals, _ := url.ParseQuery(string(c.Request().URI().QueryString()))
+	stripSkillParams(vals)
+	return search.FilterFromValues(vals)
+}
+
+// nonEmptyStrings trims each value and drops the empties, so a stray "" in the
+// skills list never becomes a filter fragment.
+func nonEmptyStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/handler/market_coverage_integration_test.go
+++ b/internal/handler/market_coverage_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+// Integration test for the stateless market-coverage endpoint against a real
+// Postgres: POST /api/v1/market/coverage is behind RequireAuthOrKey, so an
+// anonymous request is 401 and a request bearing a valid API key is served. The
+// facet backend is stubbed (the coverage math is unit-tested in verdict); this
+// test verifies the route + auth wiring end to end. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/search"
+)
+
+func TestMarketCoverageEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	var userID int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('coverage@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	cookie, _ := iss.Issue(userID)
+	fake := &recordingFacetCounter{res: search.FacetResult{
+		Total:  500,
+		Facets: map[string]map[string]int64{"skills": {"go": 300}},
+	}}
+	h := &API{pool: pool, queries: queries, issuer: iss, facets: fake}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	keyAuth := auth.RequireAuthOrKey(iss, h.queries)
+	app.Post("/api/v1/me/api-keys", auth.RequireAuth(iss), h.CreateAPIKey)
+	app.Post("/api/v1/market/coverage", keyAuth, h.MarketCoverage)
+
+	const path = "/api/v1/market/coverage?category=backend"
+
+	// Anonymous → 401.
+	anon := httptest.NewRequest(fiber.MethodPost, path, bytes.NewBufferString(`{"skills":["go"]}`))
+	anon.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(anon)
+	if err != nil {
+		t.Fatalf("anon request: %v", err)
+	}
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Fatalf("anon status = %d, want 401", resp.StatusCode)
+	}
+
+	// Mint an API key via the cookie session.
+	createReq := httptest.NewRequest(fiber.MethodPost, "/api/v1/me/api-keys", bytes.NewBufferString(`{"name":"ci"}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+	createResp, err := app.Test(createReq)
+	if err != nil || createResp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("create key: err=%v status=%d", err, createResp.StatusCode)
+	}
+	var created struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(createResp.Body).Decode(&created)
+	if created.Data.Token == "" {
+		t.Fatal("create key returned no plaintext token")
+	}
+
+	// Bearer key → 200 with the coverage payload.
+	keyed := httptest.NewRequest(fiber.MethodPost, path, bytes.NewBufferString(`{"skills":["go"]}`))
+	keyed.Header.Set("Content-Type", "application/json")
+	keyed.Header.Set("Authorization", "Bearer "+created.Data.Token)
+	keyedResp, err := app.Test(keyed)
+	if err != nil {
+		t.Fatalf("keyed request: %v", err)
+	}
+	if keyedResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("keyed status = %d, want 200", keyedResp.StatusCode)
+	}
+	var body struct {
+		Data struct {
+			Total           int64 `json:"total"`
+			CoveragePercent int   `json:"coverage_percent"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(keyedResp.Body).Decode(&body)
+	if body.Data.Total != 500 {
+		t.Errorf("total = %d, want 500", body.Data.Total)
+	}
+
+	// The market filter carried the query facet through to the role query.
+	if !filterHas(fake.callFilter(0), `enrichment.category = "backend"`) {
+		t.Errorf("role query missing category facet: %#v", fake.callFilter(0))
+	}
+}

--- a/internal/handler/market_coverage_test.go
+++ b/internal/handler/market_coverage_test.go
@@ -1,0 +1,165 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/search"
+)
+
+// recordingFacetCounter captures every FacetCounts call (coverageFor makes three)
+// so a test can assert the filter of any one of them.
+type recordingFacetCounter struct {
+	calls []search.FacetParams
+	res   search.FacetResult
+	err   error
+}
+
+func (r *recordingFacetCounter) FacetCounts(_ context.Context, p search.FacetParams) (search.FacetResult, error) {
+	r.calls = append(r.calls, p)
+	return r.res, r.err
+}
+
+func (r *recordingFacetCounter) DisjunctiveFacetCounts(_ context.Context, _ string, _ []search.FacetReq, _ any) (search.FacetResult, error) {
+	return r.res, r.err
+}
+
+// callFilter returns the [][]string filter of the Nth captured call.
+func (r *recordingFacetCounter) callFilter(n int) [][]string {
+	if n >= len(r.calls) {
+		return nil
+	}
+	g, _ := r.calls[n].Filter.([][]string)
+	return g
+}
+
+func coverageApp(fc facetCounter) *fiber.App {
+	h := &API{facets: fc}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Post("/market/coverage", h.MarketCoverage)
+	return app
+}
+
+func doPostJSON(t *testing.T, app *fiber.App, target, body string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodPost, target, bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
+}
+
+func TestMarketCoverage_DisabledReturns503(t *testing.T) {
+	app := coverageApp(nil) // search not configured
+	status, _ := doPostJSON(t, app, "/market/coverage", `{"skills":["go"]}`)
+	if status != fiber.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", status)
+	}
+}
+
+func TestMarketCoverage_EmptySkillsReturns400(t *testing.T) {
+	fake := &recordingFacetCounter{}
+	app := coverageApp(fake)
+	status, _ := doPostJSON(t, app, "/market/coverage", `{"skills":[]}`)
+	if status != fiber.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("no facet query should run for empty skills, got %d", len(fake.calls))
+	}
+}
+
+func TestMarketCoverage_TooManySkillsReturns400(t *testing.T) {
+	fake := &recordingFacetCounter{}
+	app := coverageApp(fake)
+
+	// Build a skills list past the cap.
+	big := make([]string, maxCoverageSkills+1)
+	for i := range big {
+		big[i] = "s" + strconv.Itoa(i)
+	}
+	payload, _ := json.Marshal(coverageRequest{Skills: big})
+
+	status, _ := doPostJSON(t, app, "/market/coverage", string(payload))
+	if status != fiber.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", status)
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("no facet query should run past the skills cap, got %d", len(fake.calls))
+	}
+}
+
+func TestMarketCoverage_ComputesAndShapesResponse(t *testing.T) {
+	// role total 500; uncovered (vacancies listing none of the skills) 200 → covered
+	// 300 → 60%. The role skill distribution feeds the breakdown.
+	fake := &recordingFacetCounter{res: search.FacetResult{
+		Total:  500,
+		Facets: map[string]map[string]int64{"skills": {"go": 300, "kubernetes": 250}},
+	}}
+	app := coverageApp(fake)
+
+	status, body := doPostJSON(t, app, "/market/coverage?category=backend", `{"skills":["go"]}`)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+
+	data, ok := body["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data = %#v, want object", body["data"])
+	}
+	if data["total"].(float64) != 500 {
+		t.Errorf("total = %v, want 500", data["total"])
+	}
+	// covered = total - uncovered; both come from the same stubbed Total (500),
+	// so covered floors at 0 here — assert the field is present and numeric.
+	if _, ok := data["coverage_percent"].(float64); !ok {
+		t.Errorf("coverage_percent missing/!number: %#v", data["coverage_percent"])
+	}
+	if _, ok := data["gaps"].([]any); !ok {
+		t.Errorf("gaps should be an array, got %#v", data["gaps"])
+	}
+	// Stateless: no coherence score is advertised.
+	if data["coherence_percent"].(float64) != 0 {
+		t.Errorf("coherence_percent = %v, want 0 (stateless)", data["coherence_percent"])
+	}
+}
+
+func TestMarketCoverage_FilterFromQueryAndSkillsFromBody(t *testing.T) {
+	fake := &recordingFacetCounter{res: search.FacetResult{Total: 10}}
+	app := coverageApp(fake)
+
+	status, _ := doPostJSON(t, app, "/market/coverage?category=backend&countries=BR", `{"skills":["go","docker"]}`)
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if len(fake.calls) < 2 {
+		t.Fatalf("want at least role+uncovered queries, got %d", len(fake.calls))
+	}
+
+	// The role query (call 0) carries the query-param facet filter.
+	role := fake.callFilter(0)
+	if !filterHas(role, `enrichment.category = "backend"`) || !filterHas(role, `countries = "BR"`) {
+		t.Errorf("role filter missing query facets: %#v", role)
+	}
+	// The role filter must NOT filter by the supplied skills (they are the measured
+	// set, not a market filter).
+	if filterHas(role, `skills = "go"`) {
+		t.Errorf("role filter should not include the measured skills: %#v", role)
+	}
+
+	// The uncovered query (call 1) excludes the body skills via AndNotSkills.
+	uncovered := fake.callFilter(1)
+	if !filterHas(uncovered, `skills != "go"`) || !filterHas(uncovered, `skills != "docker"`) {
+		t.Errorf("uncovered filter should exclude body skills: %#v", uncovered)
+	}
+}

--- a/internal/handler/resume_verdict.go
+++ b/internal/handler/resume_verdict.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"net/url"
 
 	"github.com/gofiber/fiber/v2"
@@ -38,25 +39,35 @@ func (a *API) GetResumeVerdict(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": v})
 }
 
-// computeCoverage runs the two facet queries behind the coverage verdict and folds
-// them through the pure verdict.Compute. Query A is the role's open-vacancy total;
-// query B is the "uncovered" set — the same role filtered to vacancies listing
-// none of the profile's skills — whose total and skill distribution give the
-// covered count and the per-skill new-vacancy unlock.
+// computeCoverage builds the coverage verdict for the caller's profile: the role
+// filter is the request facets (defaulting category to the profile), the covered
+// count is measured against the profile's structured skills, and the role-skill
+// breakdown is scored against the CV's parsed declared/body/all sets.
 func (a *API) computeCoverage(c *fiber.Ctx, userID int64, profile db.UserProfile) (verdict.Verdict, error) {
 	roleFilter := search.FilterFromValues(roleValues(c, profile))
+	declared, body, all := a.cvSkillSets(c, userID)
+	return a.coverageFor(c.Context(), roleFilter, profile.Skills, declared, body, all)
+}
 
-	// The role query now also reads the full role skill distribution (Facets:skills)
-	// so the breakdown can rank the role's top in-demand skills and flag must-haves.
-	role, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
+// coverageFor runs the three facet queries behind the coverage verdict for a role
+// filter and folds them through the pure verdict.Compute. Query A is the role's
+// open-vacancy total (plus its full skill distribution, ranked into the
+// breakdown); query B is the "uncovered" set — the same role filtered to vacancies
+// listing none of coverageSkills — whose total and skill distribution give the
+// covered count and the per-skill new-vacancy unlock; query C is the skill-bearing
+// total (see below). coverageSkills drives covered/uncovered; declared/body/all
+// score the role-skill breakdown — the two sets differ for the CV verdict (profile
+// skills vs parsed CV) and coincide for a stateless skill list.
+func (a *API) coverageFor(ctx context.Context, roleFilter any, coverageSkills, declared, body, all []string) (verdict.Verdict, error) {
+	role, err := a.facets.FacetCounts(ctx, search.FacetParams{
 		Filter: roleFilter,
 		Facets: []string{"skills"},
 	})
 	if err != nil {
 		return verdict.Verdict{}, err
 	}
-	uncovered, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
-		Filter: search.AndNotSkills(roleFilter, profile.Skills),
+	uncovered, err := a.facets.FacetCounts(ctx, search.FacetParams{
+		Filter: search.AndNotSkills(roleFilter, coverageSkills),
 		Facets: []string{"skills"},
 	})
 	if err != nil {
@@ -65,13 +76,12 @@ func (a *API) computeCoverage(c *fiber.Ctx, userID int64, profile db.UserProfile
 	// Skill-bearing total: the role's vacancies that list at least one tagged skill.
 	// Skill frequency (and the must-have flag) is measured against this, not the raw
 	// role total, so postings the tagger left skill-less don't deflate frequencies.
-	skilled, err := a.facets.FacetCounts(c.Context(), search.FacetParams{
+	skilled, err := a.facets.FacetCounts(ctx, search.FacetParams{
 		Filter: search.AndSkillsPresent(roleFilter),
 	})
 	if err != nil {
 		return verdict.Verdict{}, err
 	}
-	declared, body, all := a.cvSkillSets(c, userID)
 	return verdict.Compute(verdict.Input{
 		Total:           role.Total,
 		SkilledTotal:    skilled.Total,
@@ -102,13 +112,20 @@ func (a *API) cvSkillSets(c *fiber.Ctx, userID int64) (declared, body, all []str
 // selected no category — so an unfiltered verdict scores the profile's own role.
 func roleValues(c *fiber.Ctx, profile db.UserProfile) url.Values {
 	vals, _ := url.ParseQuery(string(c.Request().URI().QueryString()))
-	delete(vals, "skills")
-	delete(vals, "skills_exclude")
-	delete(vals, "skills_mode")
+	stripSkillParams(vals)
 	if !hasNonEmpty(vals["category"]) {
 		vals["category"] = profile.Specializations
 	}
 	return vals
+}
+
+// stripSkillParams removes the skills facet params (bare + _exclude/_mode) from a
+// query set. In the coverage endpoints the caller's skills are the measured set,
+// never a market filter that would narrow the market to jobs already listing them.
+func stripSkillParams(vals url.Values) {
+	delete(vals, "skills")
+	delete(vals, "skills_exclude")
+	delete(vals, "skills_mode")
 }
 
 // hasNonEmpty reports whether a query-param slice carries at least one non-empty

--- a/openspec/changes/market-coverage-api/.openspec.yaml
+++ b/openspec/changes/market-coverage-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/market-coverage-api/design.md
+++ b/openspec/changes/market-coverage-api/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The market-coverage verdict (`internal/verdict` + `GetResumeVerdict`) already
+scores a candidate's skills against the live market, but it is cookie-only and
+sources its skills from a stored profile + parsed CV, defaulting the role from the
+profile's specializations. `verdict.Compute` itself is pure and I/O-free: it takes
+an `Input` (three facet-query results + declared/body/all skill sets) and returns
+the scored `Verdict`. An agent driving `freehire-cli` has only a flat skill list
+and an API key — it needs a stateless entry into the same computation.
+
+(Full design narrative: `docs/superpowers/specs/2026-07-08-market-coverage-api-design.md`.)
+
+## Goals / Non-Goals
+
+**Goals:**
+- A stateless `POST /api/v1/market/coverage` (API key or cookie) taking skills in
+  the body and a market filter in the query, returning the coverage verdict.
+- Reuse `verdict.Compute` unchanged; extract the shared three-query step so the
+  new endpoint and the CV verdict share one implementation.
+- Full facet-filter vocabulary via the existing `buildSearchFilter`.
+- `freehire-cli`: `market-fit` command + generic `--facet key=value` filtering on
+  `market-fit` and `search`.
+
+**Non-Goals:**
+- No coverage segmentation into per-facet-value buckets.
+- No CV parsing / `coherence` / `hidden` status in this path.
+- No new market data, LLM, DB migration, or reindex.
+
+## Decisions
+
+- **Reuse over re-implement.** `verdict.Compute` stays as-is. Extract
+  `coverageFor(ctx, roleFilter, declared, body, all) (verdict.Verdict, error)` from
+  `resume_verdict.go` — the three facet queries (role total; uncovered via
+  `AndNotSkills`; skill-bearing total via `AndSkillsPresent`) plus `Compute`.
+  `GetResumeVerdict` and the new handler both call it. This keeps the ranking /
+  must-have / gap logic single-source.
+- **Flat-list skill mapping.** New handler calls
+  `coverageFor(ctx, filter, skills, nil, skills)` — `Declared = skills`,
+  `Body = nil`, `All = skills`. Statuses collapse to `strong / adjacent / missing`;
+  `coherence_percent` is meaningless (0) and is omitted from the response.
+- **Transport.** Filter as query params (reuse `buildSearchFilter(c)` — the whole
+  vocabulary for free); skills as a JSON body `{"skills": [...]}`. `POST` because
+  the caller submits a body; the route sits with the other `keyAuth` job routes.
+- **Response shape.** `{"data": verdict}` reusing the existing `verdict.Verdict`
+  contract (already codegen'd to TS), with `coherence_percent` zeroed.
+- **CLI filters.** A generic `--facet key=value` (repeatable) mapped straight into
+  `url.Values` covers the full 22-facet + numeric vocabulary without 22 named
+  flags; keep the existing convenience flags and add high-traffic ones.
+
+## Risks / Trade-offs
+
+- **Cost.** Each call runs three Meili facet queries; API-key gating (not public)
+  bounds anonymous abuse.
+- **Contract coupling.** The response reuses `verdict.Verdict`, so a future verdict
+  field lands here too. Acceptable — both are the same coverage concept; the
+  stateless path just omits the CV-section metric.
+- **Cross-repo.** The CLI lives in the separate `freehire-cli` repo; its tasks run
+  there, not in this repo's worktree.

--- a/openspec/changes/market-coverage-api/proposal.md
+++ b/openspec/changes/market-coverage-api/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+We already compute how well a candidate's skills cover the live market (the
+`resume-verdict` capability), but it is cookie-only and reads its skills from a
+stored profile + parsed CV. An agent driving `freehire-cli` holds only a flat
+list of skills and no browser session, so it cannot use it. We need a stateless,
+API-key endpoint that takes a skill list plus a market filter and returns the
+coverage.
+
+## What Changes
+
+- New `POST /api/v1/market/coverage` endpoint (behind `RequireAuthOrKey`): body
+  carries the caller's `skills`; the market filter is the full facet vocabulary
+  as query params. Returns the market-coverage result (total, covered, coverage
+  percent, ranked skill gaps, and the role's top in-demand skills scored against
+  the passed skills).
+- Refactor: extract the shared "role filter + skill sets → three facet queries →
+  `verdict.Compute`" step so the new endpoint and the existing CV verdict share
+  one implementation. Behavior of the existing verdict is preserved.
+- `coherence_percent` (a CV-section metric) is omitted from the stateless
+  response — a flat skill list has no declared/body sections.
+- `freehire-cli`: new `market-fit` command and full facet-filter support (a
+  generic `--facet key=value` plus high-traffic named flags), extended to the
+  `search` command too. *(Consumer of the API; lives in the separate
+  `freehire-cli` repo.)*
+
+## Capabilities
+
+### New Capabilities
+- `market-coverage`: a stateless, API-key endpoint that scores a supplied skill
+  list against the live open-vacancy market for a facet-filtered role and returns
+  coverage, ranked skill gaps, and the role's top in-demand skills.
+
+### Modified Capabilities
+<!-- None. The resume-verdict refactor is behavior-preserving (implementation
+     detail), so its requirements do not change. -->
+
+## Impact
+
+- **New:** `internal/handler/market_coverage.go`, route in
+  `internal/handler/handler.go`.
+- **Refactored (behavior-preserving):** `internal/handler/resume_verdict.go`
+  (extract shared `coverageFor`).
+- **Reused unchanged:** `internal/verdict`, `internal/search` (filter vocabulary),
+  `buildSearchFilter`.
+- **Client (separate repo):** `freehire-cli` — new `Coverage` client method,
+  `market-fit` command, generic `--facet` flag on `market-fit` + `search`.
+- No DB migration, no reindex — pure read/compute over the live search index.

--- a/openspec/changes/market-coverage-api/specs/market-coverage/spec.md
+++ b/openspec/changes/market-coverage-api/specs/market-coverage/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Stateless market-coverage from a supplied skill list
+
+The system SHALL expose `POST /api/v1/market/coverage` that scores a caller-supplied
+list of skills against the live open-vacancy market for a facet-filtered role, and
+return the coverage result: the role's open-vacancy total, how many of those
+vacancies list at least one of the supplied skills, the coverage percent, the
+ranked missing-skill gaps (each with the new vacancies it would unlock), and the
+role's top in-demand skills scored against the supplied skills.
+
+The endpoint SHALL take the skills from the request body (`{"skills": [...]}`) and
+the market filter from the request's facet query params. It SHALL reuse the same
+coverage computation as the CV-based verdict (no divergent scoring logic).
+
+#### Scenario: Coverage for a filtered role
+- **WHEN** an authenticated caller posts `{"skills": ["go","docker"]}` with a facet
+  filter (e.g. `?category=backend&seniority=senior`)
+- **THEN** the response `data` reports `total`, `covered`, `coverage_percent`, a
+  ranked `gaps` list, and a `skills` breakdown of the role's top in-demand skills
+  with each skill's market frequency, must-have flag, and its status against the
+  supplied skills (`strong` / `adjacent` / `missing`)
+
+#### Scenario: Skills are the measured set, not a filter
+- **WHEN** the caller supplies skills the market rarely lists
+- **THEN** those skills narrow neither `total` nor the role query; they only change
+  `covered` and the gap ranking (the market total reflects the facet filter alone)
+
+### Requirement: Full facet-filter vocabulary
+
+The endpoint SHALL accept the same complete facet vocabulary as the job search and
+facets endpoints (every `search.StringFacets` param plus the numeric facets), so a
+caller can narrow the market by any facet, not a fixed subset.
+
+#### Scenario: Narrowing by an arbitrary facet
+- **WHEN** the caller adds any supported facet param (e.g. `?countries=BR`,
+  `?employment_type=full_time`, `?english_level=b2`, `?salary_min=100000`)
+- **THEN** the coverage is computed against the market narrowed by that facet
+
+### Requirement: Stateless response omits CV-section metrics
+
+Because a flat skill list has no declared/body CV sections, the response SHALL NOT
+report the CV-section metrics (`coherence`, and the `hidden` skill status). Skill
+statuses SHALL be limited to `strong`, `adjacent`, and `missing`.
+
+#### Scenario: No hidden status or coherence
+- **WHEN** the coverage result is returned
+- **THEN** no skill row carries the `hidden` status and the response does not
+  advertise a coherence score
+
+### Requirement: Authentication and precondition failures
+
+The endpoint SHALL require authentication by session cookie or API key. It SHALL
+return 400 when no skills are supplied (nothing to measure), 401 when the caller is
+unauthenticated, and 503 when search is not configured.
+
+#### Scenario: API-key caller
+- **WHEN** a request carries a valid `Authorization: Bearer fhk_…` API key
+- **THEN** the coverage is computed and returned
+
+#### Scenario: Missing skills
+- **WHEN** an authenticated caller posts an empty or absent `skills` list
+- **THEN** the response is 400
+
+#### Scenario: Unauthenticated caller
+- **WHEN** a request carries no cookie and no API key
+- **THEN** the response is 401
+
+#### Scenario: Search unconfigured
+- **WHEN** the search backend is not configured
+- **THEN** the response is 503

--- a/openspec/changes/market-coverage-api/tasks.md
+++ b/openspec/changes/market-coverage-api/tasks.md
@@ -1,13 +1,13 @@
 ## 1. Backend: extract shared coverage step
 
-- [ ] 1.1 Extract `coverageFor(ctx, roleFilter any, declared, body, all []string) (verdict.Verdict, error)` from `computeCoverage` in `internal/handler/resume_verdict.go` (the three facet queries + `verdict.Compute`); rewire `computeCoverage`/`GetResumeVerdict` to call it. Existing verdict tests stay green (behavior-preserving).
+- [x] 1.1 Extract `coverageFor(ctx, roleFilter any, coverageSkills, declared, body, all []string) (verdict.Verdict, error)` from `computeCoverage` in `internal/handler/resume_verdict.go` (the three facet queries + `verdict.Compute`); rewire `computeCoverage`/`GetResumeVerdict` to call it. `coverageSkills` drives covered/uncovered; declared/body/all score the breakdown (the two differ for the CV verdict). Existing verdict tests stay green (behavior-preserving).
 
 ## 2. Backend: stateless market-coverage endpoint
 
-- [ ] 2.1 RED: integration test `internal/handler/market_coverage_integration_test.go` — `POST /api/v1/market/coverage` with skills body + facet query returns coverage `data`; empty skills → 400; no search → 503; API-key auth accepted; anonymous → 401.
-- [ ] 2.2 GREEN: `internal/handler/market_coverage.go` — parse `{"skills":[...]}` from body, build filter via `buildSearchFilter(c)`, call `coverageFor(ctx, filter, skills, nil, skills)`, return `{"data": verdict}` with `coherence_percent` omitted/zeroed.
-- [ ] 2.3 Register `POST /api/v1/market/coverage` behind `keyAuth` in `internal/handler/handler.go` (next to the other `keyAuth` job routes).
-- [ ] 2.4 Confirm the `verdict.Verdict` TS contract still regenerates cleanly (`cmd/gen-contracts`) — no new field, so no web change expected.
+- [x] 2.1 RED: handler unit test `internal/handler/market_coverage_test.go` (fake facetCounter, no Docker) — `POST /market/coverage` with skills body + facet query returns coverage `data`; skills-from-body reach `AndNotSkills`, filter-from-query reaches the role query, supplied skills do NOT filter the market; empty skills → 400; too-many skills → 400; no search → 503. (Route-level 401/API-key acceptance is delivered by the shared `keyAuth` middleware — tested where that middleware is tested — see 2.3.)
+- [x] 2.2 GREEN: `internal/handler/market_coverage.go` — parse `{"skills":[...]}` from body, trim/drop empties + cap at `maxCoverageSkills`, build filter via `marketFilter(c)` (full vocabulary, skills stripped), call `coverageFor(ctx, filter, skills, skills, nil, skills)`, return `{"data": verdict}` with `coherence_percent` zeroed.
+- [x] 2.3 Register `POST /api/v1/market/coverage` behind `keyAuth` in `internal/handler/handler.go` (next to the other `keyAuth` job routes).
+- [x] 2.4 Confirm the `verdict.Verdict` TS contract still regenerates cleanly (`cmd/gen-contracts`) — no new field, no `web/` change.
 
 ## 3. CLI (freehire-cli repo): client + command
 

--- a/openspec/changes/market-coverage-api/tasks.md
+++ b/openspec/changes/market-coverage-api/tasks.md
@@ -11,14 +11,14 @@
 
 ## 3. CLI (freehire-cli repo): client + command
 
-- [ ] 3.1 RED: `internal/client/client_test.go` — `Coverage(skills, facets)` sends `POST /api/v1/market/coverage`, skills JSON body, facets as query; returns raw `data`; error envelopes → `*APIError`.
-- [ ] 3.2 GREEN: add `Coverage` to `internal/client/client.go`.
-- [ ] 3.3 RED: `internal/cli/*_test.go` — `market-fit --skills go,react [--facet k=v]` hits the right path, sends skills + facets, prints coverage + gaps table; `--json` passthrough.
-- [ ] 3.4 GREEN: new `internal/cli/marketfit.go` command wired into root.
-- [ ] 3.5 Add generic `--facet key=value` (repeatable) filtering to `market-fit` and `search`, plus high-traffic named flags (`--country`, `--city`, `--role`, `--employment-type`, `--english-level`, `--salary-min`, `--visa`); fold all into `url.Values`.
-- [ ] 3.6 Update `DESIGN.md` / `README.md` with the `market-fit` command and the fuller filter flags.
+- [x] 3.1 RED: `internal/client/client_test.go` — `Coverage(CoverageParams)` sends `POST /api/v1/market/coverage`, skills JSON body, facets as query; returns raw `data`.
+- [x] 3.2 GREEN: add `Coverage`/`CoverageParams` to `internal/client/client.go`.
+- [x] 3.3 RED: `internal/cli/cli_test.go` — `market-fit --skills go,docker --skills react --category backend --facet source=greenhouse` sends skills in the body (not query), facets in the query, prints `Coverage: N%` + gaps; missing `--skills` errors.
+- [x] 3.4 GREEN: new `internal/cli/marketfit.go` command wired into root.
+- [x] 3.5 Extract shared facet flags (`internal/cli/facets.go`: `addFacetFlags`/`facetsFromFlags`) — named high-traffic facets (`--region/--country/--city/--company/--category/--role/--seniority/--employment-type/--english-level`, `--remote`, `--salary-min`, `--visa`) + generic `--facet key=value`; wired into `market-fit` and refactored `search` onto it. `--skills` stays per-command (filter in search, measured set in market-fit).
+- [x] 3.6 Update `DESIGN.md` / `README.md` with the `market-fit` command and the fuller filter flags.
 
 ## 4. Finish
 
-- [ ] 4.1 `go build ./... && go vet ./... && go test ./...` (both repos); backend queue/integration tests where relevant.
-- [ ] 4.2 Manual verification against a running stack: post a skill list, confirm coverage/gaps; exercise a non-default facet.
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...` green in both repos.
+- [x] 4.2 End-to-end verification: `market_coverage_integration_test.go` (real Postgres via testcontainers) — anonymous POST → 401, API-key POST → 200 with the coverage payload, and the query facet reaches the role query. (Facet backend stubbed; the Meili `FacetCounts` path is unchanged and covered by the verdict/search suites.)

--- a/openspec/changes/market-coverage-api/tasks.md
+++ b/openspec/changes/market-coverage-api/tasks.md
@@ -1,0 +1,24 @@
+## 1. Backend: extract shared coverage step
+
+- [ ] 1.1 Extract `coverageFor(ctx, roleFilter any, declared, body, all []string) (verdict.Verdict, error)` from `computeCoverage` in `internal/handler/resume_verdict.go` (the three facet queries + `verdict.Compute`); rewire `computeCoverage`/`GetResumeVerdict` to call it. Existing verdict tests stay green (behavior-preserving).
+
+## 2. Backend: stateless market-coverage endpoint
+
+- [ ] 2.1 RED: integration test `internal/handler/market_coverage_integration_test.go` — `POST /api/v1/market/coverage` with skills body + facet query returns coverage `data`; empty skills → 400; no search → 503; API-key auth accepted; anonymous → 401.
+- [ ] 2.2 GREEN: `internal/handler/market_coverage.go` — parse `{"skills":[...]}` from body, build filter via `buildSearchFilter(c)`, call `coverageFor(ctx, filter, skills, nil, skills)`, return `{"data": verdict}` with `coherence_percent` omitted/zeroed.
+- [ ] 2.3 Register `POST /api/v1/market/coverage` behind `keyAuth` in `internal/handler/handler.go` (next to the other `keyAuth` job routes).
+- [ ] 2.4 Confirm the `verdict.Verdict` TS contract still regenerates cleanly (`cmd/gen-contracts`) — no new field, so no web change expected.
+
+## 3. CLI (freehire-cli repo): client + command
+
+- [ ] 3.1 RED: `internal/client/client_test.go` — `Coverage(skills, facets)` sends `POST /api/v1/market/coverage`, skills JSON body, facets as query; returns raw `data`; error envelopes → `*APIError`.
+- [ ] 3.2 GREEN: add `Coverage` to `internal/client/client.go`.
+- [ ] 3.3 RED: `internal/cli/*_test.go` — `market-fit --skills go,react [--facet k=v]` hits the right path, sends skills + facets, prints coverage + gaps table; `--json` passthrough.
+- [ ] 3.4 GREEN: new `internal/cli/marketfit.go` command wired into root.
+- [ ] 3.5 Add generic `--facet key=value` (repeatable) filtering to `market-fit` and `search`, plus high-traffic named flags (`--country`, `--city`, `--role`, `--employment-type`, `--english-level`, `--salary-min`, `--visa`); fold all into `url.Values`.
+- [ ] 3.6 Update `DESIGN.md` / `README.md` with the `market-fit` command and the fuller filter flags.
+
+## 4. Finish
+
+- [ ] 4.1 `go build ./... && go vet ./... && go test ./...` (both repos); backend queue/integration tests where relevant.
+- [ ] 4.2 Manual verification against a running stack: post a skill list, confirm coverage/gaps; exercise a non-default facet.


### PR DESCRIPTION
## What

A stateless, API-key sibling of the CV market-coverage verdict: score a
caller-supplied skill list against the live open-vacancy market for a
facet-filtered role.

`POST /api/v1/market/coverage` (behind `RequireAuthOrKey`):
- **skills in the body** `{"skills": ["go","docker"]}` — one skill probes that
  skill's demand, a list scores the whole stack;
- **market filter in the query** — the full `search.StringFacets` vocabulary +
  numeric facets, via the existing `buildSearchFilter`;
- returns the `verdict.Verdict` shape (total, covered, coverage %, ranked gaps,
  role top-skills breakdown) with `coherence_percent` zeroed (a CV-section metric,
  meaningless for a flat list).

## How

- Extract `coverageFor` from `resume_verdict.go` — the three facet queries
  (role total; uncovered via `AndNotSkills`; skill-bearing via `AndSkillsPresent`)
  + `verdict.Compute`. `GetResumeVerdict` and the new handler both call it, so the
  coverage/ranking/must-have logic stays single-source (behavior-preserving).
- New `market_coverage.go`: parse + trim + cap the skills (`maxCoverageSkills`),
  build the market filter with the skills facet stripped (the measured set is
  never a market filter), zero coherence.

## Tests

- Unit (`market_coverage_test.go`, fake facet backend): shape, filter-from-query,
  skills-from-body reach `AndNotSkills`, empty/too-many skills → 400, no search → 503.
- Integration (`market_coverage_integration_test.go`, real Postgres): anonymous → 401,
  API-key → 200 with payload, query facet reaches the role query.
- `verdict.Verdict` TS contract regenerates unchanged (no `web/` diff).

Planned in OpenSpec change `market-coverage-api`.