### PR TITLE
fix(inhire): correct outbound vacancy URL host to .inhire.app

### DIFF
--- a/internal/sources/inhire.go
+++ b/internal/sources/inhire.go
@@ -19,7 +19,7 @@ type inhire struct {
 const (
 	inhireListURL    = "https://api.inhire.app/job-posts/public/pages"
 	inhireDetailURL  = "https://api.inhire.app/job-posts/public/pages/%s"
-	inhireVacancyURL = "https://%s.inhire.com.br/vagas/%s"
+	inhireVacancyURL = "https://%s.inhire.app/vagas/%s"
 )
 
 // NewInhire builds the InHire adapter over the given HTTP client.

--- a/internal/sources/inhire_test.go
+++ b/internal/sources/inhire_test.go
@@ -56,7 +56,7 @@ func TestInhireFetchMapsListAndDetail(t *testing.T) {
 	if j.Location != "São Paulo, BR" {
 		t.Errorf("Location = %q", j.Location)
 	}
-	if j.URL != "https://contaazul.inhire.com.br/vagas/"+jobID {
+	if j.URL != "https://contaazul.inhire.app/vagas/"+jobID {
 		t.Errorf("URL = %q", j.URL)
 	}
 	if j.WorkMode != "remote" {


### PR DESCRIPTION
## Problem
Reported broken link: `freehire.dev/jobs/tech-lead-...-grupo-taking-3wdwcj5r` opened fine (200), but its outbound apply URL pointed at `https://grupotaking.inhire.com.br/vagas/<id>` — that domain is **NXDOMAIN** (doesn't resolve). Every inhire job had a dead apply link.

## Cause
`inhireVacancyURL` in `internal/sources/inhire.go` hardcoded `.inhire.com.br`. InHire's tenant careers sites actually live on `<tenant>.inhire.app` (Cloudflare) — the same host family as the `api.inhire.app` the adapter already calls.

## Fix
- Point `inhireVacancyURL` at `https://%s.inhire.app/vagas/%s`; update the test.
- Verified `.inhire.app` returns 200 for multiple tenants (grupotaking, contaazul); `.inhire.com.br` fails to resolve for all.

## Prod
Existing 10,380 inhire rows already backfilled directly (`UPDATE jobs SET url = replace(url, '.inhire.com.br/', '.inhire.app/')`). URL isn't in the search doc, so no reindex needed. Re-crawl would self-heal anyway via `UpsertJob` (`url = EXCLUDED.url`).