### PR TITLE
feat(recommendations): facet-filter the CV recommendations feed

### DIFF
--- a/internal/handler/recommendations.go
+++ b/internal/handler/recommendations.go
@@ -37,7 +37,9 @@ func (a *API) Recommendations(c *fiber.Ctx) error {
 		return empty()
 	}
 
-	res, err := a.search.RecommendByVector(c.Context(), vec, limit, offset)
+	// The same facet params the search endpoint accepts constrain the candidate set;
+	// the CV vector then ranks only the jobs that pass the filter.
+	res, err := a.search.RecommendByVector(c.Context(), vec, buildSearchFilter(c), limit, offset)
 	if err != nil {
 		return err
 	}

--- a/internal/handler/recommendations_test.go
+++ b/internal/handler/recommendations_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"reflect"
 	"testing"
 	"time"
 
@@ -89,6 +91,59 @@ func TestRecommendations_NoVectorEmpty(t *testing.T) {
 	app, token := recsApp(t, store, &fakeSearcher{})
 	if status, n := getRecs(t, app, token); status != fiber.StatusOK || n != 0 {
 		t.Errorf("status=%d count=%d, want 200 and 0", status, n)
+	}
+}
+
+// A facet param on the request is translated to a Meilisearch filter and passed to
+// the vector search, so only jobs matching the facet are ranked by the CV vector.
+func TestRecommendations_FacetFilterReachesSearch(t *testing.T) {
+	repo := &fakeResumeRepo{embVec: []float64{0.1, 0.2}, embModel: search.CurrentEmbedderModel()}
+	store := resume.New(newFakeResumeBlobs(), repo)
+	fs := &fakeSearcher{recRes: search.SearchResult{Hits: []search.JobDocument{{}}, Total: 1}}
+	app, token := recsApp(t, store, fs)
+
+	req := httptest.NewRequest(fiber.MethodGet, "/me/recommendations?work_mode=remote", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	resp.Body.Close()
+
+	want := search.FilterFromValues(url.Values{"work_mode": {"remote"}})
+	if !reflect.DeepEqual(fs.gotRecFilter, want) {
+		t.Errorf("searcher filter = %#v, want %#v", fs.gotRecFilter, want)
+	}
+}
+
+// A fresh CV vector whose filtered search matches nothing yields a successful empty
+// feed (not an error) — the filtered-empty case the SPA renders as "no matches".
+func TestRecommendations_FilterNoMatchEmpty(t *testing.T) {
+	repo := &fakeResumeRepo{embVec: []float64{0.1, 0.2}, embModel: search.CurrentEmbedderModel()}
+	store := resume.New(newFakeResumeBlobs(), repo)
+	fs := &fakeSearcher{recRes: search.SearchResult{}} // no hits
+	app, token := recsApp(t, store, fs)
+
+	req := httptest.NewRequest(fiber.MethodGet, "/me/recommendations?work_mode=remote", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var out struct {
+		Data []map[string]any `json:"data"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if len(out.Data) != 0 {
+		t.Errorf("returned %d jobs, want 0 for a filter that matches nothing", len(out.Data))
+	}
+	// The vector search still ran (a fresh vector), just with a filter that excluded all.
+	if len(fs.gotRecVec) == 0 {
+		t.Error("vector search should run for a fresh vector even when the filter matches nothing")
 	}
 }
 

--- a/internal/handler/search.go
+++ b/internal/handler/search.go
@@ -19,8 +19,9 @@ type searcher interface {
 	// EmbedText returns a vector for text in the jobs' embedding space plus the
 	// embedder identity that produced it (used to embed a CV on upload).
 	EmbedText(ctx context.Context, key, text string) ([]float64, string, error)
-	// RecommendByVector ranks open jobs by similarity to a raw vector (the CV feed).
-	RecommendByVector(ctx context.Context, vector []float64, limit, offset int) (search.SearchResult, error)
+	// RecommendByVector ranks open jobs by similarity to a raw vector (the CV feed),
+	// constrained to an optional facet filter (nil for none).
+	RecommendByVector(ctx context.Context, vector []float64, filter any, limit, offset int) (search.SearchResult, error)
 }
 
 // defaultSemanticRatio is 0 — pure keyword search against the always-fresh facet

--- a/internal/handler/search_test.go
+++ b/internal/handler/search_test.go
@@ -26,9 +26,10 @@ type fakeSearcher struct {
 	embedModel   string
 	embedErr     error
 	// recommend-by-vector call recording + canned result
-	gotRecVec []float64
-	recRes    search.SearchResult
-	recErr    error
+	gotRecVec    []float64
+	gotRecFilter any
+	recRes       search.SearchResult
+	recErr       error
 }
 
 func (f *fakeSearcher) Search(_ context.Context, p search.SearchParams) (search.SearchResult, error) {
@@ -46,8 +47,9 @@ func (f *fakeSearcher) EmbedText(_ context.Context, _, text string) ([]float64, 
 	return f.embedVec, f.embedModel, f.embedErr
 }
 
-func (f *fakeSearcher) RecommendByVector(_ context.Context, v []float64, _, _ int) (search.SearchResult, error) {
+func (f *fakeSearcher) RecommendByVector(_ context.Context, v []float64, filter any, _, _ int) (search.SearchResult, error) {
 	f.gotRecVec = v
+	f.gotRecFilter = filter
 	return f.recRes, f.recErr
 }
 

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -555,9 +555,11 @@ func (c *Client) EmbedText(ctx context.Context, _, text string) ([]float64, stri
 
 // RecommendByVector ranks open jobs in the semantic index by similarity to a raw
 // vector (the caller's persisted CV embedding), the shared ranking rules breaking
-// ties toward fresher jobs. An empty vector or an absent semantic index yields no
+// ties toward fresher jobs. An optional filter (a Meilisearch filter expression, nil
+// for none) constrains the candidate set before ranking — the CV ranks only the jobs
+// that pass the facet filter. An empty vector or an absent semantic index yields no
 // results — the caller treats "no usable CV vector" as an empty feed, not an error.
-func (c *Client) RecommendByVector(ctx context.Context, vector []float64, limit, offset int) (SearchResult, error) {
+func (c *Client) RecommendByVector(ctx context.Context, vector []float64, filter any, limit, offset int) (SearchResult, error) {
 	if len(vector) == 0 {
 		return SearchResult{}, nil
 	}
@@ -565,6 +567,7 @@ func (c *Client) RecommendByVector(ctx context.Context, vector []float64, limit,
 		Limit:  int64(limit),
 		Offset: int64(offset),
 		Vector: toFloat32(vector),
+		Filter: filter,
 		Hybrid: &meilisearch.SearchRequestHybrid{Embedder: embedderName, SemanticRatio: 1},
 	})
 	if err != nil {

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -579,7 +579,7 @@ func TestIntegration_EmbedTextAndRecommend(t *testing.T) {
 		t.Errorf("EmbedText model = %q, want %q", model, embedderModel)
 	}
 
-	res, err := c.RecommendByVector(ctx, vec, 10, 0)
+	res, err := c.RecommendByVector(ctx, vec, nil, 10, 0)
 	if err != nil {
 		t.Fatalf("RecommendByVector: %v", err)
 	}
@@ -591,8 +591,21 @@ func TestIntegration_EmbedTextAndRecommend(t *testing.T) {
 		t.Errorf("top recommendation id = %d, want a backend job (1 or 2); hits=%+v", top, ids(res.Hits))
 	}
 
+	t.Run("filter narrows the ranked set to matching jobs", func(t *testing.T) {
+		// A filter passed to the recommend call must constrain the candidates before
+		// the vector ranks them: with `id = 1` only the first job survives, even though
+		// the CV also overlaps job 2. Proves the filter reaches the semantic search.
+		res, err := c.RecommendByVector(ctx, vec, "id = 1", 10, 0)
+		if err != nil {
+			t.Fatalf("RecommendByVector(filter): %v", err)
+		}
+		if got := ids(res.Hits); len(got) != 1 || got[0] != 1 {
+			t.Errorf("filtered recommend ids = %v, want exactly [1]", got)
+		}
+	})
+
 	t.Run("empty vector yields empty feed, not an error", func(t *testing.T) {
-		empty, err := c.RecommendByVector(ctx, nil, 10, 0)
+		empty, err := c.RecommendByVector(ctx, nil, nil, 10, 0)
 		if err != nil {
 			t.Fatalf("RecommendByVector(nil): %v", err)
 		}

--- a/openspec/changes/recommendations-facet-filters/.openspec.yaml
+++ b/openspec/changes/recommendations-facet-filters/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/recommendations-facet-filters/design.md
+++ b/openspec/changes/recommendations-facet-filters/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`/my/recommendations` renders a client-only, auth-gated feed. `RecommendationsView.svelte` pages `api.recommendations(limit, offset)` → `GET /api/v1/me/recommendations` → `handler.Recommendations` → `search.RecommendByVector(vec, limit, offset)`, a pure vector search (`SemanticRatio: 1`) against the `jobs_semantic` index that ranks the whole open catalogue by CV similarity.
+
+`/jobs` already has the full sidebar filter: a URL-driven `FilterStore`, a `FilterModal` (all facets), a `FilterSummary` card, a mobile `FilterEdgeTab`, and live facet counts from `GET /api/v1/jobs/facets`. Its handler turns request facet params into a Meilisearch filter via the shared, pure `search.FilterFromValues`.
+
+Filtering a vector feed must happen server-side: the vector search ranks the entire catalogue and the page only pages a slice, so client-side filtering of a page would be wrong. The `jobs_semantic` index inherits `FilterableAttributes` from `facetSettings()` (`semanticSettings` builds on it), so a filter can be applied to the semantic search with no reindex.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Constrain the recommendations feed by the same facet vocabulary `/jobs` supports, applied before the CV ranking.
+- Reuse the existing filter UI components unchanged (`FilterModal`, `FilterSummary`, `FilterEdgeTab`, `FilterStore`).
+- Reuse the shared, pure filter builder (`search.FilterFromValues`) so recommendations and search cannot drift.
+
+**Non-Goals:**
+- No free-text query on recommendations (the CV is the query); the header search stays bound to `/jobs`.
+- No swipe-mode entry from recommendations.
+- No CV-scoped facet counts: the modal's counts come from the whole-catalogue `/jobs/facets` distribution (a pure-vector feed ranks the whole catalogue, so the facet distribution under the same filters is the natural, honest proxy).
+- No database migration, no Meilisearch reindex.
+
+## Decisions
+
+**Backend — thread a filter through the vector search.**
+- `search.RecommendByVector(ctx, vector, limit, offset)` → `RecommendByVector(ctx, vector, filter any, limit, offset)`, setting `Filter: filter` on the `meilisearch.SearchRequest`. A `nil` filter preserves today's unfiltered behavior.
+- `handler.Recommendations` builds the filter with the existing `buildSearchFilter(c)` (the same helper `SearchJobs` uses) and passes it through.
+- Update the `searcher` interface's `RecommendByVector` signature in `internal/handler/search.go` and the test fakes.
+
+**Frontend — grow `RecommendationsView` its own sidebar, not reuse `JobsView`.**
+`JobsView` is coupled to `searchJobs`, an SSR `initial` prop, header-search registration, swipe entry, and the shared `hire.jobFilters` localStorage key — none of which fit the client-only recommendations feed. Reusing it would mean a heavily-branched "mode" prop. Instead `RecommendationsView` renders its own thin sidebar reusing the *leaf* filter components:
+- A `FilterStore` seeded from the URL with **persistence off** (so it never reads/writes the `/jobs` `hire.jobFilters` key — filters stay per-page). It writes the active filters to the URL synchronously; `syncOnNavigation` re-seeds on back/forward.
+- The paginator source becomes `api.recommendations(filtersToParams(filters.applied), limit, offset)`; a debounced-`applied` `$effect` reloads the feed on filter change (same pattern as `JobsView`, minus the SSR-`initial` skip).
+- Facet counts feed the modal from `api.facetCounts(params)` / `api.facetCounts(params, { disjunctive })` — no `scope` params.
+- `FilterModal` is mounted with `savedSearches={false}` (saved searches belong to the search list).
+
+**API — `recommendations` accepts facet params.**
+`api.recommendations(facets: URLSearchParams, limit, offset)` merges the facet params into the query string alongside `limit`/`offset` (mirrors `searchJobs`). Callers with no filter pass an empty `URLSearchParams`.
+
+**Empty-state disambiguation.**
+The feed already returns an empty slice both for "no CV" and "no matches". The page can't tell them apart from the payload alone. Decision: treat an empty result as **no-CV** only when no facet filter is active; when filters are active, an empty result is the **no-matches** state. This is exact — a filtered empty feed is by construction a filter outcome, and the no-CV case is independent of filters (an unfiltered open first fetch reveals it).
+
+**Layout.** `/my/recommendations/+page.svelte` widens from `max-w-3xl` to `max-w-6xl` to seat the sidebar, matching `/jobs`; the heading/intro move above the two-column row.
+
+## Risks / Trade-offs
+
+- **Counts are whole-catalogue, not CV-scoped.** A count of "120 remote jobs" describes the catalogue, not how many of *your* recommendations are remote. Accepted: CV-scoped counts aren't meaningful for a pure-vector feed (it ranks everything), and the count still correctly answers "does this facet have jobs". Documented in the view.
+- **Deep pagination bound.** The endpoint keeps its `offset+limit > maxSearchWindow` guard; filters don't change that.
+- **Two sidebars now exist** (`JobsView` and `RecommendationsView`). If a third feed needs the same shell, extract a shared `FilteredList` wrapper then — not pre-emptively (YAGNI); the leaf components are already shared, so the duplication is only the ~40-line aside/edge-tab wiring.

--- a/openspec/changes/recommendations-facet-filters/proposal.md
+++ b/openspec/changes/recommendations-facet-filters/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The `/my/recommendations` feed ranks the whole open catalogue by CV similarity but offers no way to narrow it — a user who only wants remote, or senior, or backend roles has to scroll a full ranked list. The `/jobs` list already has a rich sidebar facet filter; recommendations should offer the same narrowing, applied *before* the ranking.
+
+## What Changes
+
+- Add facet filtering to the `GET /api/v1/me/recommendations` endpoint: the same facet query params the search endpoint accepts (regions, work_mode, seniority, category, skills, salary, freshness, …) constrain the candidate set, and the CV vector ranks what survives the filter.
+- Thread an optional Meilisearch filter through `search.RecommendByVector`; the `jobs_semantic` index already carries the shared filterable attributes, so no reindex is needed.
+- Give `/my/recommendations` a sidebar filter that reuses the existing `FilterModal`/`FilterSummary`/`FilterEdgeTab` machinery (identical to `/jobs`), driving the recommendations endpoint instead of search.
+- Keep the feed's existing empty states, distinguishing "no CV uploaded" (prompt to add a CV) from "no jobs match the current filters".
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `cv-recommendations`: the recommendations endpoint additionally accepts facet filter params and constrains the ranked candidate set to them; the recommendations page gains a sidebar facet filter and a filters-empty state.
+
+## Impact
+
+- Backend: `internal/search/client.go` (`RecommendByVector` gains a filter arg), `internal/handler/recommendations.go` (parse + pass the facet filter), the `searcher` interface in `internal/handler/search.go`.
+- Frontend: `web/src/lib/api.ts` (`recommendations` accepts facet params), `web/src/lib/components/RecommendationsView.svelte` (sidebar + filter wiring), `web/src/routes/my/recommendations/+page.svelte` (widen layout for the sidebar).
+- No database migration and no Meilisearch reindex (the semantic index is already filterable).

--- a/openspec/changes/recommendations-facet-filters/specs/cv-recommendations/spec.md
+++ b/openspec/changes/recommendations-facet-filters/specs/cv-recommendations/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: Recommendations endpoint ranks jobs by the CV vector
+
+The system SHALL expose an authenticated endpoint `GET /api/v1/me/recommendations` that returns open jobs ranked by vector similarity between the caller's persisted CV embedding and the `jobs_semantic` index, constrained to any facet filter carried on the request. It SHALL accept the same facet query params as the search endpoint (e.g. `regions`, `work_mode`, `seniority`, `category`, `skills`, salary and freshness ranges, per-facet `_exclude`/`_mode`), translate them through the same shared filter builder, and apply the resulting filter to the vector search so that only jobs matching every facet are ranked. It SHALL use the standard list envelope (`{"data": [...], "meta": {...}}`) with each item in the shared `jobview` shape and SHALL support `limit`/`offset`. When the caller has no usable CV vector (none stored, stale, no CV) or the semantic index is unavailable, it SHALL return an empty result rather than an error.
+
+#### Scenario: Ranked recommendations for a user with a CV vector
+
+- **WHEN** a signed-in user with a fresh persisted CV vector requests `GET /api/v1/me/recommendations`
+- **THEN** the response is a list of open jobs ordered by semantic similarity to the CV vector
+
+#### Scenario: Facet filter constrains the ranked set
+
+- **WHEN** a signed-in user with a fresh CV vector requests recommendations with facet params (e.g. `?work_mode=remote&seniority=senior`)
+- **THEN** the response contains only open jobs that match those facets, ordered by semantic similarity to the CV vector
+
+#### Scenario: A filter that matches nothing returns an empty feed
+
+- **WHEN** the request carries a facet filter that no open job satisfies
+- **THEN** the response is a successful empty list (no error)
+
+#### Scenario: No CV vector returns an empty feed
+
+- **WHEN** a signed-in user with no usable CV vector requests recommendations
+- **THEN** the response is a successful empty list (no error)
+
+#### Scenario: Requires authentication
+
+- **WHEN** a request to `GET /api/v1/me/recommendations` carries neither a valid auth cookie nor a valid API key
+- **THEN** the system responds `401`
+
+### Requirement: The recommendations page presents the feed with empty states
+
+The web app SHALL provide a `/my/recommendations` page, reachable from the signed-in navigation, that renders the recommendations feed for the authenticated user and offers a sidebar facet filter over it. The page SHALL reuse the shared filter UI (the same modal, summary, and mobile edge tab as `/jobs`), reflect the active filters in the URL, and re-fetch the feed from `GET /api/v1/me/recommendations` with the selected facets when they change. When there are no recommendations because the user has not uploaded a CV, the page SHALL prompt them to upload one; when the feed is empty because the current filters match no job, it SHALL show a non-error "no matches" state distinct from the upload prompt; when recommendations are otherwise empty or unavailable, it SHALL show a non-error empty state.
+
+#### Scenario: Feed renders for a user with recommendations
+
+- **WHEN** a signed-in user with a CV vector opens `/my/recommendations`
+- **THEN** the page lists the recommended jobs alongside a sidebar filter
+
+#### Scenario: Applying a filter narrows the feed
+
+- **WHEN** the user selects one or more facets in the recommendations sidebar
+- **THEN** the feed re-fetches and lists only the recommended jobs matching those facets
+
+#### Scenario: A filter matching nothing shows a no-matches state
+
+- **WHEN** the user has a CV vector but the selected filters match no open job
+- **THEN** the page shows a non-error "no matching jobs" state rather than the upload prompt
+
+#### Scenario: No CV prompts upload
+
+- **WHEN** a signed-in user who has not uploaded a CV opens `/my/recommendations`
+- **THEN** the page shows a prompt to upload a CV instead of an empty error

--- a/openspec/changes/recommendations-facet-filters/tasks.md
+++ b/openspec/changes/recommendations-facet-filters/tasks.md
@@ -1,0 +1,20 @@
+## 1. Backend — filter the vector search
+
+- [x] 1.1 Add a `filter any` argument to `search.RecommendByVector`, setting it as `Filter` on the semantic `SearchRequest` (nil preserves unfiltered behavior); update the integration test to cover a filtered vector search returning only matching jobs.
+- [x] 1.2 Update the `searcher` interface's `RecommendByVector` signature in `internal/handler/search.go` and every fake/impl that satisfies it.
+- [x] 1.3 Parse the request's facet params in `handler.Recommendations` via `buildSearchFilter(c)` and pass the filter to `RecommendByVector`; add a handler test asserting the facet filter reaches the search backend and an empty-on-no-match result.
+
+## 2. Frontend — recommendations facet params
+
+- [x] 2.1 Change `api.recommendations` to accept `facets: URLSearchParams` and merge them into the request query string alongside `limit`/`offset`.
+
+## 3. Frontend — recommendations sidebar filter
+
+- [x] 3.1 Rework `RecommendationsView.svelte` to add the shared sidebar: a URL-seeded `FilterStore` (persistence off), `FilterSummary` card + `FilterEdgeTab` + `FilterModal` (savedSearches off), facet counts from `api.facetCounts`, and a debounced-`applied` `$effect` that reloads the feed via `api.recommendations(filtersToParams(filters.applied), …)`.
+- [x] 3.2 Disambiguate the empty states: unfiltered-empty → "add a CV" prompt (unchanged); filtered-empty → a non-error "no matching jobs" state.
+- [x] 3.3 Widen `web/src/routes/my/recommendations/+page.svelte` to `max-w-6xl` and lay out the heading/intro above the sidebar+list row.
+
+## 4. Verify
+
+- [x] 4.1 `go build ./... && go vet ./... && go test ./...`; run the search integration test for the filtered-recommend path. (All exit 0; `TestIntegration_EmbedTextAndRecommend` filter sub-test green.)
+- [x] 4.2 Frontend `svelte-check` clean on the touched files (no pure-logic to unit-test). Interactive visual pass of `/my/recommendations` DEFERRED — it needs the full authed stack (CV vector + semantic index); the sidebar reuses the already-visually-verified `/jobs` FilterModal/FilterSummary/FilterEdgeTab in the same layout, so verify on staging after deploy.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -184,11 +184,15 @@ export function createApi(
   }
 
   /** Personalized job recommendations for the signed-in user: open jobs ranked by
-   *  semantic similarity to their uploaded CV. An empty slice means no usable CV
-   *  vector yet (no CV uploaded, or the embedder was superseded) — the page then
-   *  prompts the user to add their CV. Authenticated. */
-  async function recommendations(limit: number, offset: number): Promise<Slice<Job>> {
-    const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+   *  semantic similarity to their uploaded CV, constrained to `facets` (the same
+   *  facet filter params `searchJobs` accepts, built by the caller). An empty slice
+   *  means either no usable CV vector yet (no CV uploaded, or the embedder was
+   *  superseded) or that the active filter matched nothing — the page tells them
+   *  apart by whether a filter is set. Authenticated. */
+  async function recommendations(facets: URLSearchParams, limit: number, offset: number): Promise<Slice<Job>> {
+    const params = new URLSearchParams(facets);
+    params.set('limit', String(limit));
+    params.set('offset', String(offset));
     return toSlice(await request<Page<Job>>(`/api/v1/me/recommendations?${params}`), offset);
   }
 

--- a/web/src/lib/components/RecommendationsView.svelte
+++ b/web/src/lib/components/RecommendationsView.svelte
@@ -1,46 +1,142 @@
 <script lang="ts">
+  import { onMount, untrack } from 'svelte';
   import { resolve } from '$app/paths';
+  import { page } from '$app/state';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { Paginator } from '$lib/paginated.svelte';
+  import { FilterStore, filtersToParams } from '$lib/filters';
+  import { syncOnNavigation } from '$lib/urlSynced.svelte';
+  import type { Job, FacetCounts } from '$lib/types';
+  import FilterSummary from './filters/FilterSummary.svelte';
+  import FilterModal from './filters/FilterModal.svelte';
+  import FilterEdgeTab from './FilterEdgeTab.svelte';
   import JobRow from './JobRow.svelte';
   import LoadMore from './LoadMore.svelte';
   import States from './States.svelte';
 
-  // Open jobs ranked by semantic similarity to the caller's uploaded CV. An empty
-  // page means no usable CV vector yet (no CV uploaded, or the embedder was
-  // superseded), so the empty state points the user at their profile to add a CV
-  // rather than showing a dead end.
-  const page = new Paginator((limit, offset) => api.recommendations(limit, offset));
+  // The recommendations feed is the open catalogue ranked by CV similarity, narrowed
+  // by an optional facet filter. Filtering happens server-side — the vector search
+  // ranks the whole catalogue while the page shows a slice, so a filter change
+  // re-fetches the feed rather than filtering the current page. Filters live in the
+  // URL but are NOT persisted to the shared /jobs storage key (persistence off), so
+  // they stay per-page and never bleed into the standalone jobs list.
+  const filters = new FilterStore(page.url.searchParams, false);
 
+  const filterParams = () => filtersToParams(filters.applied);
+
+  const makePaginator = () =>
+    new Paginator<Job>((limit, offset) => api.recommendations(filterParams(), limit, offset));
+
+  let feed = $state.raw(makePaginator());
+
+  // Live facet counts feed the modal's controls and its "Show N jobs" total. For a
+  // pure-vector feed the ranking spans the whole catalogue, so the facet distribution
+  // over the same filters (the shared /jobs facets endpoint) is the honest proxy — it
+  // answers "which facet values have open jobs", not "how many of your matches are X".
+  let counts = $state<FacetCounts | null>(null);
+  let countsGen = 0;
+  const refreshCounts = () => {
+    const gen = ++countsGen;
+    return api
+      .facetCounts(filterParams())
+      .then((c) => {
+        if (gen === countsGen) counts = c;
+      })
+      .catch(() => {});
+  };
+
+  // Disjunctive counts for the staged (in-modal) filter set, so a selected facet still
+  // shows its siblings' counts and the total matches what the list would show.
+  const stagedCounts = (params: URLSearchParams) => api.facetCounts(params, { disjunctive: true });
+
+  let modalOpen = $state(false);
+
+  function reloadFeed() {
+    const next = makePaginator();
+    next.start();
+    feed = next;
+  }
+
+  // Load, and reload on every debounced filter change, but only when signed in — the
+  // endpoint is authenticated. Unlike /jobs there is no SSR-seeded first page, so the
+  // first run fetches too. `filters.applied` and `isAuthenticated()` are the tracked
+  // deps; the reload itself is untracked so it reads the params without subscribing.
   $effect(() => {
-    if (isAuthenticated()) void page.start();
+    void filters.applied;
+    if (!isAuthenticated()) return;
+    untrack(() => {
+      refreshCounts();
+      reloadFeed();
+    });
   });
+
+  // Cancel the store's pending debounce when the view unmounts.
+  onMount(() => () => filters.dispose());
+
+  // Re-seed filters from the URL on every real navigation (back/forward, nav link).
+  syncOnNavigation(filters);
+
+  // An empty feed is ambiguous at the API — no-CV and no-match both return [] — so
+  // disambiguate by whether a filter is active: a filtered-empty result is by
+  // construction a filter outcome, and the no-CV case is independent of filters.
+  // Keyed on the *applied* (debounced) params the feed was fetched with — not the
+  // live filter count — so a mid-drag slider can't flash "no matches" before the
+  // feed re-settles.
+  const filtered = $derived([...filterParams()].length > 0);
 </script>
 
-{#if page.status === 'loading'}
-  <States state="loading" />
-{:else if page.status === 'error'}
-  <States state="error" message="Couldn't load your recommendations." />
-{:else if page.items.length === 0}
-  <div class="rounded-xl border border-border bg-card p-6 text-center">
-    <p class="text-sm font-medium text-foreground">No recommendations yet</p>
-    <p class="mt-1 text-sm text-muted-foreground">
-      Add or update your CV on your
-      <a
-        href={resolve('/my/profile')}
-        class="font-medium text-foreground underline underline-offset-4 hover:no-underline">profile</a
-      >
-      to get jobs matched to your experience.
-    </p>
+<div class="flex gap-6">
+  <aside class="hidden w-72 shrink-0 md:block">
+    <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
+      <div class="rounded-xl border border-border bg-card p-4">
+        <FilterSummary store={filters} onOpen={() => (modalOpen = true)} />
+      </div>
+    </div>
+  </aside>
+
+  <div class="min-w-0 flex-1">
+    {#if feed.status === 'loading'}
+      <States state="loading" />
+    {:else if feed.status === 'error'}
+      <States state="error" message="Couldn't load your recommendations." />
+    {:else if feed.items.length === 0}
+      {#if filtered}
+        <States state="empty" message="No recommendations match these filters." />
+      {:else}
+        <div class="rounded-xl border border-border bg-card p-6 text-center">
+          <p class="text-sm font-medium text-foreground">No recommendations yet</p>
+          <p class="mt-1 text-sm text-muted-foreground">
+            Add or update your CV on your
+            <a
+              href={resolve('/my/profile')}
+              class="font-medium text-foreground underline underline-offset-4 hover:no-underline">profile</a
+            >
+            to get jobs matched to your experience.
+          </p>
+        </div>
+      {/if}
+    {:else}
+      <ul class="flex flex-col gap-3">
+        {#each feed.items as job (job.public_slug)}
+          <li><JobRow {job} /></li>
+        {/each}
+      </ul>
+      {#if feed.hasMore}
+        <LoadMore loading={feed.loadingMore} error={feed.loadMoreError} onclick={() => feed.loadMore()} />
+      {/if}
+    {/if}
   </div>
-{:else}
-  <ul class="flex flex-col gap-3">
-    {#each page.items as job (job.public_slug)}
-      <li><JobRow {job} /></li>
-    {/each}
-  </ul>
-  {#if page.hasMore}
-    <LoadMore loading={page.loadingMore} error={page.loadMoreError} onclick={() => page.loadMore()} />
-  {/if}
-{/if}
+</div>
+
+<!-- Mobile left-edge Filters tab (desktop uses the sidebar summary above). -->
+<FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
+
+<FilterModal
+  store={filters}
+  {counts}
+  savedSearches={false}
+  open={modalOpen}
+  onClose={() => (modalOpen = false)}
+  {stagedCounts}
+/>

--- a/web/src/routes/my/recommendations/+page.svelte
+++ b/web/src/routes/my/recommendations/+page.svelte
@@ -8,9 +8,12 @@
   <meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class="mx-auto w-full max-w-3xl px-4 py-6">
-  <h1 class="text-2xl font-semibold tracking-tight">Recommended for you</h1>
-  <p class="mt-1 text-sm text-muted-foreground">Jobs matched to your CV by meaning, not just keywords.</p>
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <!-- pl-12 clears the mobile filters edge tab (reset at md, where the sidebar shows). -->
+  <div class="pl-12 md:pl-0">
+    <h1 class="text-2xl font-semibold tracking-tight">Recommended for you</h1>
+    <p class="mt-1 text-sm text-muted-foreground">Jobs matched to your CV by meaning, not just keywords.</p>
+  </div>
   <div class="mt-6">
     <RecommendationsView />
   </div>


### PR DESCRIPTION
## Summary

Adds sidebar facet filtering to `/my/recommendations`, mirroring `/jobs`. The filter is applied **before** the CV vector ranking, server-side.

- **Backend**: `search.RecommendByVector` gains a `filter any` arg, set as `Filter` on the semantic `SearchRequest` (nil = unchanged). `handler.Recommendations` builds it via the shared `buildSearchFilter(c)` — the same translation `SearchJobs` uses — so the two can't drift. The `jobs_semantic` index already inherits the filterable attributes from `facetSettings()`, so **no reindex and no migration** are needed.
- **Frontend**: `api.recommendations` takes `facets: URLSearchParams`. `RecommendationsView.svelte` grows a sidebar reusing the shared `FilterModal`/`FilterSummary`/`FilterEdgeTab` (its own `FilterStore` with persistence **off**, so filters stay per-page and never touch the `/jobs` storage key). Facet counts come from `/jobs/facets` (whole-catalogue distribution — the honest proxy for a pure-vector feed). Empty states are disambiguated: filtered-empty → "no matches", unfiltered-empty → "add a CV" prompt.

OpenSpec change: `openspec/changes/recommendations-facet-filters/` (modifies the `cv-recommendations` capability).

## Test Plan

- [x] `go build ./... && go vet ./... && go test ./...` — all exit 0
- [x] `go test -tags=integration ./internal/search/` — filtered-recommend sub-test proves `id = 1` narrows a CV-ranked feed to exactly the matching job
- [x] New handler tests: facet param reaches the vector search; a filter matching nothing returns an empty (non-error) feed
- [x] `svelte-check` — 0 errors in touched files
- [ ] Visual pass of `/my/recommendations` with and without an active filter (needs an authed user with a CV vector + semantic index — verify on staging)