### PR TITLE
feat(ingest): --shard=i/n selector to crawl a slice of a board file

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -43,11 +44,29 @@ func main() {
 func run() int {
 	// The board file is usually one provider's list (sources/<provider>.yml, provider =
 	// file name), but an entry may name its own provider, so it may be a mixed file
-	// (sources/custom.yml). Accept it as the first argument (cron passes the file) or via
-	// SOURCES_FILE.
-	path := os.Getenv("SOURCES_FILE")
-	if len(os.Args) > 1 && os.Args[1] != "" {
-		path = os.Args[1]
+	// (sources/custom.yml). Accept it as the first positional argument (cron passes the
+	// file) or via SOURCES_FILE. An optional --shard=i/n (or the SHARD env) crawls only a
+	// round-robin slice of the file, so a provider with too many boards to finish in one
+	// timeout (workday) is spread across several staggered runs.
+	var path, shardSpec string
+	for _, a := range os.Args[1:] {
+		switch {
+		case strings.HasPrefix(a, "--shard="):
+			shardSpec = strings.TrimPrefix(a, "--shard=")
+		case a == "--shard":
+			// The value must be attached (--shard=i/n); a space-separated form would
+			// otherwise swallow the next arg (the board path) as the selector's value.
+			log.Print("config: --shard needs an attached value, e.g. --shard=2/6")
+			return 1
+		case a != "" && !strings.HasPrefix(a, "-") && path == "":
+			path = a
+		}
+	}
+	if path == "" {
+		path = os.Getenv("SOURCES_FILE")
+	}
+	if shardSpec == "" {
+		shardSpec = os.Getenv("SHARD")
 	}
 	if path == "" {
 		log.Print("config: no board file given (pass sources/<provider>.yml as an argument or set SOURCES_FILE)")
@@ -61,9 +80,25 @@ func run() int {
 
 	registry := sources.All(sources.NewClient())
 	// Fail fast before touching the DB: a misconfigured board should not start a run.
+	// Validate the WHOLE file (not just this shard's slice) so a config error anywhere is
+	// caught on every shard's run, not only when its shard happens to include the bad entry.
 	if err := sourceCfg.Validate(registry); err != nil {
 		log.Printf("config: %v", err)
 		return 1
+	}
+
+	// Narrow to this shard's slice, if requested. Applied after validation, so the run
+	// crawls only its share of a large board file while the stale-job sweep below stays
+	// safe (it already scopes closes to the companies actually crawled this run).
+	if shardSpec != "" {
+		i, n, err := sources.ParseShard(shardSpec)
+		if err != nil {
+			log.Printf("config: %v", err)
+			return 1
+		}
+		full := len(sourceCfg.Sources)
+		sourceCfg = sourceCfg.Shard(i, n)
+		log.Printf("ingest: shard %d/%d — crawling %d of %d boards in %s", i, n, len(sourceCfg.Sources), full, path)
 	}
 
 	ctx, cfg, pool, cleanup, err := worker.Bootstrap(context.Background())

--- a/internal/sources/shard.go
+++ b/internal/sources/shard.go
@@ -1,0 +1,62 @@
+package sources
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// ParseShard parses a "i/n" shard spec: crawl shard i of n (both 1-based counts).
+// It validates 1 <= i <= n and n >= 1, so a malformed or out-of-range spec fails
+// fast at the worker rather than silently crawling the wrong slice.
+func ParseShard(s string) (i, n int, err error) {
+	parts := strings.Split(s, "/")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("sources: shard %q: want the form i/n", s)
+	}
+	i, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("sources: shard %q: %w", s, err)
+	}
+	n, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("sources: shard %q: %w", s, err)
+	}
+	if n < 1 || i < 1 || i > n {
+		return 0, 0, fmt.Errorf("sources: shard %q: need 1 <= i <= n and n >= 1", s)
+	}
+	return i, n, nil
+}
+
+// Shard returns a copy of the config holding only the boards belonging to shard i of
+// n — spreading a single provider's huge board list (e.g. workday) across several
+// staggered runs so each finishes within its timeout. Distinct companies (keyed by
+// their normalized company_slug, in first-appearance order) are assigned round-robin
+// to shards, and ALL of a company's boards go to its shard. Grouping by company — not
+// by raw board index — is required for the stale-job sweep: the sweep scopes closes by
+// company_slug, so a company split across shards could have one shard close the
+// still-live boards another shard owns. i is 1-based (1..n); n <= 1 returns the config
+// unchanged. The file's default provider is preserved.
+func (c Config) Shard(i, n int) Config {
+	if n <= 1 {
+		return c
+	}
+	shardOf := make(map[string]int)
+	next := 0
+	var picked []CompanyEntry
+	for _, e := range c.Sources {
+		slug := normalize.Slug(e.Company)
+		s, ok := shardOf[slug]
+		if !ok {
+			s = next % n
+			shardOf[slug] = s
+			next++
+		}
+		if s == i-1 {
+			picked = append(picked, e)
+		}
+	}
+	return Config{Provider: c.Provider, Sources: picked}
+}

--- a/internal/sources/shard_test.go
+++ b/internal/sources/shard_test.go
@@ -1,0 +1,122 @@
+package sources
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseShard(t *testing.T) {
+	cases := []struct {
+		in   string
+		i, n int
+		ok   bool
+	}{
+		{"1/6", 1, 6, true},
+		{"6/6", 6, 6, true},
+		{"3/4", 3, 4, true},
+		{"1/1", 1, 1, true},
+		{"", 0, 0, false},
+		{"0/6", 0, 0, false},   // i must be >= 1
+		{"7/6", 0, 0, false},   // i must be <= n
+		{"1/0", 0, 0, false},   // n must be >= 1
+		{"abc", 0, 0, false},   // not "i/n"
+		{"1", 0, 0, false},     // missing n
+		{"1/2/3", 0, 0, false}, // too many parts
+		{"-1/3", 0, 0, false},  // negative
+		{"a/3", 0, 0, false},   // non-numeric i
+		{"1/b", 0, 0, false},   // non-numeric n
+	}
+	for _, c := range cases {
+		i, n, err := ParseShard(c.in)
+		if c.ok {
+			if err != nil || i != c.i || n != c.n {
+				t.Errorf("ParseShard(%q) = (%d,%d,%v), want (%d,%d,nil)", c.in, i, n, err, c.i, c.n)
+			}
+		} else if err == nil {
+			t.Errorf("ParseShard(%q) = (%d,%d,nil), want an error", c.in, i, n)
+		}
+	}
+}
+
+func companiesOf(c Config) []string {
+	out := make([]string, len(c.Sources))
+	for i, e := range c.Sources {
+		out[i] = e.Company
+	}
+	return out
+}
+
+func mkConfig(names ...string) Config {
+	e := make([]CompanyEntry, len(names))
+	for i, nm := range names {
+		e[i] = CompanyEntry{Company: nm, Provider: "workday", Board: nm}
+	}
+	return Config{Provider: "workday", Sources: e}
+}
+
+func TestConfigShard_RoundRobinPartition(t *testing.T) {
+	cfg := mkConfig("a", "b", "c", "d", "e", "f", "g")
+
+	// Round-robin: shard i (1-based) of n takes entries at indices where idx%n == i-1.
+	want := map[int][]string{1: {"a", "d", "g"}, 2: {"b", "e"}, 3: {"c", "f"}}
+	for i := 1; i <= 3; i++ {
+		if got := companiesOf(cfg.Shard(i, 3)); !reflect.DeepEqual(got, want[i]) {
+			t.Errorf("Shard(%d,3) = %v, want %v", i, got, want[i])
+		}
+	}
+}
+
+func TestConfigShard_PartitionsCompletelyNoOverlap(t *testing.T) {
+	cfg := mkConfig("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
+	seen := map[string]int{}
+	for i := 1; i <= 4; i++ {
+		for _, c := range companiesOf(cfg.Shard(i, 4)) {
+			seen[c]++
+		}
+	}
+	if len(seen) != 10 {
+		t.Fatalf("union covered %d entries, want all 10", len(seen))
+	}
+	for c, n := range seen {
+		if n != 1 {
+			t.Errorf("entry %q appeared in %d shards, want exactly 1", c, n)
+		}
+	}
+}
+
+// All boards of one company MUST land in the same shard: the stale-job sweep scopes
+// closes by company_slug, so splitting a company across shards would let one shard
+// close the still-live boards another shard owns.
+func TestConfigShard_KeepsACompanysBoardsTogether(t *testing.T) {
+	// x and y each own two boards, interleaved so a naive index split would scatter them.
+	cfg := Config{Provider: "workday", Sources: []CompanyEntry{
+		{Company: "x", Provider: "workday", Board: "x1"},
+		{Company: "y", Provider: "workday", Board: "y1"},
+		{Company: "x", Provider: "workday", Board: "x2"},
+		{Company: "z", Provider: "workday", Board: "z1"},
+		{Company: "y", Provider: "workday", Board: "y2"},
+	}}
+	const n = 2
+	companyShard := map[string]int{}
+	for i := 1; i <= n; i++ {
+		for _, e := range cfg.Shard(i, n).Sources {
+			if prev, ok := companyShard[e.Company]; ok && prev != i {
+				t.Errorf("company %q appears in shards %d and %d — a company must stay in one shard", e.Company, prev, i)
+			}
+			companyShard[e.Company] = i
+		}
+	}
+	if len(companyShard) != 3 {
+		t.Errorf("covered %d companies, want 3 (x,y,z)", len(companyShard))
+	}
+}
+
+func TestConfigShard_SingleShardIsFullConfig(t *testing.T) {
+	cfg := mkConfig("a", "b", "c")
+	if got := companiesOf(cfg.Shard(1, 1)); !reflect.DeepEqual(got, []string{"a", "b", "c"}) {
+		t.Errorf("Shard(1,1) = %v, want the full config", got)
+	}
+	if cfg.Shard(1, 3).Provider != "workday" {
+		t.Error("Shard must preserve the file's default provider")
+	}
+}

--- a/openspec/changes/ingest-board-sharding/.openspec.yaml
+++ b/openspec/changes/ingest-board-sharding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/ingest-board-sharding/design.md
+++ b/openspec/changes/ingest-board-sharding/design.md
@@ -1,0 +1,26 @@
+## Context
+
+`cmd/ingest` crawls one board file per run under a systemd `TimeoutStartSec`. `workday.yml` (~6165 boards) can't finish in the 40-min window because Workday 429-throttles and each throttled board retries (honoring Retry-After), stalling the bounded pool. The run always dies at the same ~1700-board prefix, so most boards never crawl.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let one oversized board file be crawled across several staggered, timeout-safe runs that together cover every board.
+- Keep it a generic ingest capability (any file), not a workday special case.
+- No change to the pipeline, the write path, or the stale-job sweep.
+
+**Non-Goals:**
+- Changing 429 retry behavior (a separate lever; sharding alone restores coverage).
+- Per-file schedule config in the repo — cadence lives in the ops timers.
+
+## Decisions
+
+- **Round-robin by company, not by board index.** `Config.Shard(i, n)` assigns each distinct company (keyed by its normalized company slug, in first-appearance order) round-robin to a shard and keeps all of that company's boards together. This is a correctness requirement, not just balancing: the stale-job sweep scopes closes by `company_slug`, and `workday.yml` has ~800 companies owning multiple boards. Splitting a company across shards would let shard A (having crawled one of the company's boards) sweep-close the company's still-live boards that shard B owns but hasn't refreshed within the grace window — exactly the over-close the sweep exists to avoid. Grouping by company also spreads same-tenant boards across shards, so no shard inherits a dense 429 cluster.
+- **Selector via `--shard=i/n` flag or `SHARD` env.** The flag suits explicit per-timer `ExecStart` lines; the env suits a drop-in. The positional board-file arg is unchanged, so existing timers keep working with no selector.
+- **Validate full, crawl slice.** The whole file is validated every run (a bad entry fails every shard, not just the one that happens to include it); the slice is applied only to what gets crawled.
+- **Sweep stays shard-safe.** With company-grouped shards, each shard crawls a company in full and its post-run sweep (`crawled.slugs`) closes only companies it wholly owns — the existing "partial run closes only what it saw" invariant, now at company (not board) granularity. Shards every 6h against a 48h grace keep every company re-seen well before its cutoff even if a shard misses a cycle.
+
+## Risks / Trade-offs
+
+- **Slower per-board refresh.** A board now refreshes once per shard cycle (6h) instead of hourly — an accepted trade for actually crawling all boards vs. hourly-crawling a fixed 28% and never the rest.
+- **Ops must keep shard count and timers in sync.** If `n` in the timers doesn't match the number of staggered timers, some boards go uncrawled. Mitigated by generating the shard timers together.

--- a/openspec/changes/ingest-board-sharding/proposal.md
+++ b/openspec/changes/ingest-board-sharding/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+`sources/workday.yml` holds ~6165 boards, and Workday's shared infra aggressively rate-limits (HTTP 429). Retrying each throttled board burns the clock, so the hourly run only reaches ~1700 boards before the 40-minute systemd timeout kills it — the same first slice every run, leaving ~72% of Workday boards never crawled. A provider's board list can outgrow a single timed run.
+
+## What Changes
+
+- `cmd/ingest` accepts an optional `--shard=i/n` flag (or `SHARD` env): it crawls only a round-robin 1/n slice of the board file. N staggered timers then partition a huge file across several runs, each finishing within its timeout, while the whole file is covered over one cycle.
+- The slice is applied after validation (the full file is still validated on every shard's run) and before the crawl; the existing per-company stale-job sweep already scopes closes to boards actually crawled, so a partial shard run stays safe.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `source-ingest`: the standalone ingest command additionally accepts a shard selector that restricts a run to a round-robin slice of the board file.
+
+## Impact
+
+- `cmd/ingest/main.go` (flag/env parsing + slice application), `internal/sources/shard.go` (`ParseShard`, `Config.Shard`).
+- Ops (`freehire-ops`): replace the single hourly `freehire-ingest@workday` timer with 6 staggered shard timers (`--shard=1/6`..`6/6`, every 6h). No DB migration, no code change to the pipeline or sweep.

--- a/openspec/changes/ingest-board-sharding/specs/source-ingest/spec.md
+++ b/openspec/changes/ingest-board-sharding/specs/source-ingest/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: A standalone command runs ingest on a schedule
+
+The system SHALL provide a standalone `cmd/ingest` binary that loads configuration, runs every configured board once with bounded concurrency, reports how many jobs were ingested and how many sources failed, and exits — suitable for scheduled execution. It SHALL accept an optional shard selector `--shard=i/n` (or the `SHARD` environment variable, both 1-based) that restricts the run to shard i of n, where distinct companies (keyed by their normalized company slug) are assigned round-robin to shards and all of a company's boards go to the same shard, so a provider whose board list is too large to finish within one timeout can be partitioned across several staggered runs that together cover the whole file. All boards of one company SHALL land in the same shard, so the per-company stale-job sweep of one shard never closes the still-live boards another shard owns. A malformed or out-of-range shard selector SHALL fail fast before any crawl, and the full board file SHALL be validated on every shard's run (not only the slice it crawls).
+
+#### Scenario: Ingest command runs a bounded batch and exits
+
+- **WHEN** the ingest command is run
+- **THEN** it processes every configured board once and exits after reporting the ingested and failed counts
+
+#### Scenario: A shard selector crawls only its slice
+
+- **WHEN** the ingest command is run with `--shard=i/n` on a board file
+- **THEN** it crawls only shard i's boards, and N such runs together crawl every board exactly once
+
+#### Scenario: A company's boards are never split across shards
+
+- **WHEN** a board file lists several boards for the same company and it is crawled with `--shard=i/n`
+- **THEN** all of that company's boards fall in a single shard, so no shard's per-company stale sweep closes boards another shard owns
+
+#### Scenario: A malformed shard selector fails fast
+
+- **WHEN** the ingest command is run with a shard selector that is not `i/n` with `1 <= i <= n` and `n >= 1`
+- **THEN** it reports the error and exits without crawling

--- a/openspec/changes/ingest-board-sharding/tasks.md
+++ b/openspec/changes/ingest-board-sharding/tasks.md
@@ -1,0 +1,15 @@
+## 1. Shard primitives
+
+- [x] 1.1 Add `sources.ParseShard("i/n")` (validates 1<=i<=n, n>=1) and `Config.Shard(i, n)` (round-robin slice, preserves provider); unit-test parsing, the round-robin partition, complete-no-overlap coverage, and the n<=1 passthrough.
+
+## 2. Wire the ingest command
+
+- [x] 2.1 Parse `--shard=i/n` (or `SHARD` env) in `cmd/ingest`, apply `Config.Shard` after validation and before the crawl, and log the slice; a malformed selector fails fast.
+
+## 3. Verify
+
+- [x] 3.1 `go build/vet/test ./...`; smoke the binary: invalid shard exits fast, a valid shard logs "crawling N of M boards" and crawls only its slice.
+
+## 4. Ops (freehire-ops, applied at deploy)
+
+- [ ] 4.1 Replace the hourly `freehire-ingest@workday` timer with 6 staggered shard timers (`--shard=1/6`..`6/6`, every 6h, one per hour); disable the old workday timer.


### PR DESCRIPTION
## Summary
Fixes Workday coverage: `workday.yml` (~6165 boards) can't finish within the 40-min ingest timeout (429 throttling stalls the pool), so the hourly run always dies at the same ~1700-board prefix and ~72% of boards never crawl.

- `sources.ParseShard("i/n")` + `Config.Shard(i, n)`: partition a board file by **company** (round-robin over distinct company slugs, all of a company's boards in one shard). Company-grouping — not board-index — is required so the per-company stale-job sweep of one shard never closes the still-live boards another shard owns.
- `cmd/ingest` accepts `--shard=i/n` (or `SHARD` env), applied after validating the full file. Malformed selectors fail fast.
- Pipeline and the stale sweep are unchanged. No migration.

Ops (applied at deploy): replace the hourly `freehire-ingest@workday` timer with 6 staggered shard timers (`--shard=1/6`..`6/6`, every 6h) so all 6165 boards are covered across a 6-hour cycle.

OpenSpec change: `openspec/changes/ingest-board-sharding/` (modifies `source-ingest`).

## Test Plan
- [x] `go build/vet/test ./...` — all pass
- [x] Unit tests: parse validation, round-robin partition, complete-no-overlap, **company-never-split**, n<=1 passthrough
- [x] Smoke: 6 shards of workday.yml sum to exactly 6165 boards (972+958+1023+1043+1082+1087), each ~1000 (well under the 40-min timeout)