### PR TITLE
feat(icims): support vanity-domain / careers-home iCIMS sites (+ DocuSign)

### DIFF
--- a/internal/sources/icims.go
+++ b/internal/sources/icims.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"golang.org/x/net/html"
 )
@@ -36,35 +37,82 @@ type icimsSitemapEntry struct {
 }
 
 func (s icims) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []icimsSitemapEntry `xml:"url"`
-	}
-	url := fmt.Sprintf("https://careers-%s.icims.com/sitemap.xml", e.Board)
-	if err := s.http.GetXML(ctx, url, &sitemap); err != nil {
-		return nil, fmt.Errorf("icims: sitemap %s: %w", e.Board, err)
+	host := icimsHost(e.Board)
+	locs, err := s.jobLocs(ctx, host, e.Board)
+	if err != nil {
+		return nil, err
 	}
 
-	// Keep only real job postings: a loc with a parseable /jobs/<id>/ segment. This drops
-	// the non-posting /jobs/search and /jobs/intro entries, which carry no numeric id.
+	// Each job's posting comes from its own iframe-fragment fetch, fanned out under a
+	// bounded pool. vanity boards (careers-home) build the fragment URL differently.
+	vanity := icimsVanity(e.Board)
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, host, vanity, loc)
+	}), nil
+}
+
+// icimsVanity reports whether the board is a full vanity host (contains a dot) rather than a
+// bare iCIMS slug. A vanity site (e.g. careers.docusign.com) runs the newer "careers-home"
+// product: its sitemap is an index and its job detail lives at /careers-home/jobs/<id>.
+func icimsVanity(board string) bool { return strings.Contains(board, ".") }
+
+// icimsHost resolves the board to the host the endpoints use: a vanity board is itself the
+// host; a bare slug forms the classic "careers-<slug>.icims.com".
+func icimsHost(board string) string {
+	if icimsVanity(board) {
+		return board
+	}
+	return "careers-" + board + ".icims.com"
+}
+
+// icimsSitemap decodes either sitemap shape: a flat <urlset> (child <url>) or a
+// <sitemapindex> (child <sitemap>). Both nest a <loc>, so one entry type serves both.
+type icimsSitemap struct {
+	URLs     []icimsSitemapEntry `xml:"url"`
+	Sitemaps []icimsSitemapEntry `xml:"sitemap"`
+}
+
+// jobLocs collects the board's job-posting URLs from its sitemap, following a sitemap index
+// one level deep (vanity/careers-home sites nest their <url> entries under sub-sitemaps) and
+// keeping only locs with a parseable /jobs/<id> segment — dropping the /jobs/search and
+// /jobs/intro entries, which carry no numeric id.
+func (s icims) jobLocs(ctx context.Context, host, board string) ([]string, error) {
+	var root icimsSitemap
+	if err := s.http.GetXML(ctx, fmt.Sprintf("https://%s/sitemap.xml", host), &root); err != nil {
+		return nil, fmt.Errorf("icims: sitemap %s: %w", board, err)
+	}
+	entries := root.URLs
+	for _, sm := range root.Sitemaps {
+		var sub icimsSitemap
+		if err := s.http.GetXML(ctx, sm.Loc, &sub); err != nil {
+			// Skip a flaky sub-sitemap rather than losing the whole board — the same
+			// per-entry isolation the detail fan-out uses; the missed postings reappear
+			// on the next crawl. Only a failed ROOT sitemap fails the board.
+			continue
+		}
+		entries = append(entries, sub.URLs...)
+	}
 	var locs []string
-	for _, u := range sitemap.URLs {
+	for _, u := range entries {
 		if icimsJobID(u.Loc) != "" {
 			locs = append(locs, u.Loc)
 		}
 	}
-
-	// Each job's posting comes from its own iframe-fragment fetch, fanned out under a
-	// bounded pool.
-	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
-		return s.detail(ctx, e, loc)
-	}), nil
+	return locs, nil
 }
 
 // detail fetches one job's "?in_iframe=1" fragment and maps its JobPosting ld+json to a
 // Job, returning ok=false when the fragment fetch fails or carries no JobPosting, so the
 // caller skips just that posting.
-func (s icims) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
-	root, err := s.http.GetHTML(ctx, loc+"?in_iframe=1")
+func (s icims) detail(ctx context.Context, e CompanyEntry, host string, vanity bool, loc string) (Job, bool) {
+	id := icimsJobID(loc)
+	// Classic hosts serve the fragment at <loc>?in_iframe=1. Vanity/careers-home locs are
+	// /jobs/<id>?lang=… (a query already), so their fragment lives at a distinct path.
+	frag := loc + "?in_iframe=1"
+	if vanity {
+		frag = fmt.Sprintf("https://%s/careers-home/jobs/%s?in_iframe=1", host, id)
+	}
+	root, err := s.http.GetHTML(ctx, frag)
 	if err != nil {
 		return Job{}, false
 	}
@@ -89,7 +137,7 @@ func (s icims) detail(ctx context.Context, e CompanyEntry, loc string) (Job, boo
 	remote := p.JobLocationType == "TELECOMMUTE"
 
 	return Job{
-		ExternalID:  icimsJobID(loc),
+		ExternalID:  id,
 		URL:         loc,
 		Title:       p.Title,
 		Company:     firstNonEmpty(p.HiringOrganization.Name, e.Company),
@@ -123,10 +171,11 @@ type icimsPlace struct {
 	} `json:"address"`
 }
 
-// icimsJobIDPattern captures the numeric posting id from a job URL's /jobs/<id>/ segment.
-// The trailing slash is required, so the non-posting /jobs/search and /jobs/intro entries
-// (no id, no trailing-slash digits) yield no match.
-var icimsJobIDPattern = regexp.MustCompile(`/jobs/(\d+)/`)
+// icimsJobIDPattern captures the numeric posting id from a job URL's /jobs/<id> segment,
+// terminated by a slash, query, fragment, or end of string. This matches both the classic
+// host form (/jobs/<id>/<slug>/job) and the vanity/careers-home form (/jobs/<id>?lang=…),
+// while the non-posting /jobs/search and /jobs/intro entries (no digits) yield no match.
+var icimsJobIDPattern = regexp.MustCompile(`/jobs/(\d+)(?:[/?#]|$)`)
 
 // icimsJobID extracts the native numeric posting id from a job page URL, or "" when the
 // URL is not a job posting.

--- a/internal/sources/icims_test.go
+++ b/internal/sources/icims_test.go
@@ -37,6 +37,60 @@ func icimsSitemapXML(locs ...string) string {
 	return b.String()
 }
 
+// icimsSitemapIndexXML builds an iCIMS <sitemapindex> pointing at the given sub-sitemap locs.
+func icimsSitemapIndexXML(subLocs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`)
+	for _, l := range subLocs {
+		b.WriteString(`<sitemap><loc>` + l + `</loc></sitemap>`)
+	}
+	b.WriteString(`</sitemapindex>`)
+	return b.String()
+}
+
+func TestICIMSHost(t *testing.T) {
+	cases := map[string]string{
+		"360care":              "careers-360care.icims.com", // classic slug → icims host
+		"careers.docusign.com": "careers.docusign.com",      // vanity domain passes through
+	}
+	for board, want := range cases {
+		if got := icimsHost(board); got != want {
+			t.Errorf("icimsHost(%q) = %q, want %q", board, got, want)
+		}
+	}
+}
+
+// A vanity-domain board (careers.docusign.com) serves a sitemap INDEX (not a flat urlset)
+// and its job detail lives at /careers-home/jobs/<id>?in_iframe=1 (not <loc>?in_iframe=1).
+// The adapter must follow the index, match the query-form job loc, and fetch the
+// careers-home fragment.
+func TestICIMSVanityDomainSitemapIndexAndCareersHomeDetail(t *testing.T) {
+	loc := "https://careers.docusign.com/jobs/27897?lang=en-us"
+	fake := (&routedHTTP{}).
+		route("/sitemap.xml", icimsSitemapIndexXML("https://careers.docusign.com/sitemap1.xml")).
+		route("/sitemap1.xml", icimsSitemapXML(loc)).
+		route("/careers-home/jobs/27897?in_iframe=1", icimsDetailHTML)
+
+	jobs, err := NewICIMS(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Docusign", Provider: "icims", Board: "careers.docusign.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (index followed, query-form loc matched)", len(jobs))
+	}
+	if jobs[0].ExternalID != "27897" {
+		t.Errorf("ExternalID = %q, want 27897", jobs[0].ExternalID)
+	}
+	if jobs[0].URL != loc {
+		t.Errorf("URL = %q, want the canonical sitemap loc %q", jobs[0].URL, loc)
+	}
+	if jobs[0].Title != "Mobile Medical Assistant" {
+		t.Errorf("Title = %q — detail fragment not fetched via careers-home path", jobs[0].Title)
+	}
+}
+
 func TestICIMSProvider(t *testing.T) {
 	if got := NewICIMS(nil).Provider(); got != "icims" {
 		t.Errorf("Provider() = %q, want %q", got, "icims")
@@ -49,6 +103,9 @@ func TestICIMSJobID(t *testing.T) {
 		"https://careers-acme.icims.com/jobs/12345/some-role/job?in_iframe=1":      "12345",
 		"https://careers-acme.icims.com/jobs/search":                               "",
 		"https://careers-acme.icims.com/jobs/intro":                                "",
+		// Vanity/careers-home sitemap locs: /jobs/<id> with a query and no trailing slash.
+		"https://careers.docusign.com/jobs/27897?lang=en-us": "27897",
+		"https://careers.docusign.com/jobs/29339":            "29339",
 	}
 	for loc, want := range cases {
 		if got := icimsJobID(loc); got != want {

--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -1,9 +1,14 @@
 # iCIMS boards. Provider is the filename; each entry is company + board.
 # board = the iCIMS slug, forming careers-<board>.icims.com (see internal/sources/icims.go);
 # the adapter reads its sitemap.xml and each job's ?in_iframe=1 JobPosting ld+json fragment.
+# A board that is a full host (contains a dot, e.g. careers.docusign.com) is a vanity domain
+# on the newer "careers-home" product: the adapter follows its sitemap index and reads
+# /careers-home/jobs/<id>?in_iframe=1 instead.
 # Each board validated live (sitemap lists >0 job postings) before adding — slugs are
 # harvested from a seed worklist via cmd/harvest-boards, never copied unvalidated.
 
+- company: Docusign
+  board: careers.docusign.com
 - company: 360care
   board: 360care
 - company: 142designgroup


### PR DESCRIPTION
## Summary
`careers.docusign.com` is iCIMS on the newer **careers-home** product, which the classic adapter couldn't crawl. Extend the iCIMS adapter to handle it, and add DocuSign.

Differences handled:
- **host**: vanity domain (`careers.docusign.com`) vs `careers-<slug>.icims.com` — `icimsHost`/`icimsVanity` (a board with a dot is a full host).
- **sitemap**: follow a one-level **sitemap index** (vanity sites nest `<url>` under sub-sitemaps); a flaky sub-sitemap is skipped, not fatal.
- **job URL**: regex now matches `/jobs/<id>?lang=…` (no trailing slash) as well as classic `/jobs/<id>/slug/job`.
- **detail**: vanity fragment is `/careers-home/jobs/<id>?in_iframe=1`.

Classic boards (1861) are byte-for-byte unchanged. `sources/icims.yml` +1 (Docusign).

## Test Plan
- [x] `go build/vet/test ./...` — pass; new unit tests: `TestICIMSHost`, `TestICIMSVanityDomainSitemapIndexAndCareersHomeDetail`, query-form JobID cases; all classic tests still green
- [x] **Live**: the real HTTP client crawled careers.docusign.com — pulled 73+ DocuSign jobs, no 403/blocking; sitemap-index → sub-sitemap → careers-home detail all worked
- [x] Code review (subagent): Ready to proceed; sub-sitemap continue-on-error applied