### PR TITLE
fix(icims): accept single-object jobLocation (unblocks most iCIMS jobs incl DocuSign)

### DIFF
--- a/internal/sources/icims.go
+++ b/internal/sources/icims.go
@@ -1,7 +1,9 @@
 package sources
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -152,23 +154,47 @@ func (s icims) detail(ctx context.Context, e CompanyEntry, host string, vanity b
 // icimsPosting is the schema.org JobPosting decoded from an iCIMS job fragment's
 // application/ld+json block.
 type icimsPosting struct {
-	Title              string       `json:"title"`
-	Description        string       `json:"description"`
-	DatePosted         string       `json:"datePosted"`
-	JobLocationType    string       `json:"jobLocationType"`
-	JobLocation        []icimsPlace `json:"jobLocation"`
+	Title              string      `json:"title"`
+	Description        string      `json:"description"`
+	DatePosted         string      `json:"datePosted"`
+	JobLocationType    string      `json:"jobLocationType"`
+	JobLocation        icimsPlaces `json:"jobLocation"`
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
 }
 
-// icimsPlace is one entry of JobPosting.jobLocation (iCIMS emits an array).
+// icimsPlace is one entry of JobPosting.jobLocation.
 type icimsPlace struct {
 	Address struct {
 		AddressLocality string `json:"addressLocality"`
 		AddressRegion   string `json:"addressRegion"`
 		AddressCountry  string `json:"addressCountry"`
 	} `json:"address"`
+}
+
+// icimsPlaces decodes JobPosting.jobLocation, which iCIMS emits as EITHER a single Place
+// object (single-location jobs, the common careers-home shape) OR an array of them
+// (multi-location) — normalizing both to a slice. Without this, a single-object jobLocation
+// fails to unmarshal into a []icimsPlace and the whole posting is silently dropped.
+type icimsPlaces []icimsPlace
+
+func (p *icimsPlaces) UnmarshalJSON(b []byte) error {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var arr []icimsPlace
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return err
+		}
+		*p = arr
+		return nil
+	}
+	var one icimsPlace
+	if err := json.Unmarshal(trimmed, &one); err != nil {
+		return err
+	}
+	*p = []icimsPlace{one}
+	return nil
 }
 
 // icimsJobIDPattern captures the numeric posting id from a job URL's /jobs/<id> segment,

--- a/internal/sources/icims_test.go
+++ b/internal/sources/icims_test.go
@@ -26,6 +26,21 @@ const icimsDetailHTML = `<html><head></head><body>
 </script>
 </body></html>`
 
+// icimsDetailSingleLocationHTML is a JobPosting whose jobLocation is a single Place OBJECT
+// (not an array). iCIMS emits this for single-location jobs (e.g. most DocuSign careers-home
+// postings); the adapter must accept it as well as the array form.
+const icimsDetailSingleLocationHTML = `<html><head></head><body>
+<script type="application/ld+json">
+{"@context":"http://schema.org","@type":"JobPosting",
+"title":"Solo Role",
+"description":"<p>One place.</p>",
+"datePosted":"2026-05-01T00:00:00.000Z",
+"hiringOrganization":{"@type":"Organization","name":"Acme"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"Seattle","addressRegion":"Washington","addressCountry":"US"}}}
+</script>
+</body></html>`
+
 // icimsSitemapXML builds an iCIMS sitemap urlset from the given job locs.
 func icimsSitemapXML(locs ...string) string {
 	var b strings.Builder
@@ -88,6 +103,27 @@ func TestICIMSVanityDomainSitemapIndexAndCareersHomeDetail(t *testing.T) {
 	}
 	if jobs[0].Title != "Mobile Medical Assistant" {
 		t.Errorf("Title = %q — detail fragment not fetched via careers-home path", jobs[0].Title)
+	}
+}
+
+// A JobPosting whose jobLocation is a single object (not an array) must still parse and
+// yield the location — iCIMS single-location jobs use the object form, and dropping them
+// silently loses most of a careers-home board.
+func TestICIMSJobLocationAsSingleObject(t *testing.T) {
+	loc := "https://careers-acme.icims.com/jobs/555/solo-role/job"
+	fake := (&routedHTTP{}).
+		route("/sitemap.xml", icimsSitemapXML(loc)).
+		route("/jobs/555/solo-role/job?in_iframe=1", icimsDetailSingleLocationHTML)
+
+	jobs, err := NewICIMS(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 — a single-object jobLocation must parse, not drop", len(jobs))
+	}
+	if jobs[0].Location != "Seattle, Washington, US" {
+		t.Errorf("Location = %q, want %q", jobs[0].Location, "Seattle, Washington, US")
 	}
 }
 


### PR DESCRIPTION
## Summary
iCIMS emits `JobPosting.jobLocation` as a single Place **object** for single-location jobs (the common careers-home shape) and as an **array** for multi-location ones. The struct typed it `[]icimsPlace`, so a single-object jobLocation failed to unmarshal → `ldJobPosting` silently dropped the whole posting.

Impact: DocuSign yielded only **73 of ~300** jobs (the multi-location ones); the target job 27897 was dropped. This also silently dropped single-location jobs on the **1861 classic iCIMS boards**.

Fix: an `icimsPlaces` type whose `UnmarshalJSON` accepts either shape into a slice.

## Test Plan
- [x] `go build/vet/test ./...` — pass; new `TestICIMSJobLocationAsSingleObject`; all existing iCIMS tests green
- [x] **Live**: careers.docusign.com now returns **298 jobs incl. 27897** ("Software Engineer", Seattle), up from 73