### PR TITLE
fix(sources): parseRFC3339 accepts numeric offset without colon (posted_at for iCIMS careers-home)

### DIFF
--- a/internal/sources/parsetime_test.go
+++ b/internal/sources/parsetime_test.go
@@ -1,0 +1,37 @@
+package sources
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRFC3339(t *testing.T) {
+	utc := func(y int, mo time.Month, d, h, mi int) *time.Time {
+		x := time.Date(y, mo, d, h, mi, 0, 0, time.UTC)
+		return &x
+	}
+	cases := []struct {
+		name string
+		in   string
+		want *time.Time
+	}{
+		{"zulu with fraction", "2026-04-15T00:00:00.000Z", utc(2026, 4, 15, 0, 0)},
+		{"colon offset", "2026-03-01T12:00:00-04:00", utc(2026, 3, 1, 16, 0)},             // → 16:00 UTC
+		{"numeric offset no colon", "2026-06-30T15:42:00+0000", utc(2026, 6, 30, 15, 42)}, // iCIMS careers-home
+		{"numeric offset with fraction", "2026-06-30T15:42:00.000+0000", utc(2026, 6, 30, 15, 42)},
+		{"numeric offset nonzero", "2026-03-01T12:00:00-0400", utc(2026, 3, 1, 16, 0)},
+		{"empty", "", nil},
+		{"garbage", "not-a-date", nil},
+	}
+	for _, c := range cases {
+		got := parseRFC3339(c.in)
+		switch {
+		case c.want == nil && got != nil:
+			t.Errorf("%s: parseRFC3339(%q) = %v, want nil", c.name, c.in, got)
+		case c.want != nil && got == nil:
+			t.Errorf("%s: parseRFC3339(%q) = nil, want %v", c.name, c.in, c.want)
+		case c.want != nil && got != nil && !got.Equal(*c.want):
+			t.Errorf("%s: parseRFC3339(%q) = %v, want %v (UTC)", c.name, c.in, got.UTC(), c.want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -422,8 +422,17 @@ func parseLayout(layout, s string) *time.Time {
 }
 
 // parseRFC3339 parses an RFC3339 timestamp (the common ATS format). RFC3339Nano
-// accepts both fractional and plain-second forms, a strict superset of RFC3339.
-func parseRFC3339(s string) *time.Time { return parseLayout(time.RFC3339Nano, s) }
+// accepts both fractional and plain-second forms (Z and colon offsets), a strict
+// superset of RFC3339. As a fallback it accepts the RFC822-style numeric offset
+// WITHOUT a colon (e.g. iCIMS careers-home's "2026-06-30T15:42:00+0000"), which
+// RFC3339 rejects — the fallback layout only matches numeric offsets, so a Z or
+// colon-offset string that reached here (parse or NotFuture failure) still yields nil.
+func parseRFC3339(s string) *time.Time {
+	if t := parseLayout(time.RFC3339Nano, s); t != nil {
+		return t
+	}
+	return parseLayout("2006-01-02T15:04:05.999999999-0700", s)
+}
 
 // parseDate parses a date-only timestamp ("2006-01-02", as Workable emits).
 func parseDate(s string) *time.Time { return parseLayout("2006-01-02", s) }


### PR DESCRIPTION
## Summary
iCIMS careers-home emits `datePosted` as `2026-06-30T15:42:00+0000` — an RFC822-style numeric offset **without a colon**, which RFC3339 rejects. So DocuSign (and other careers-home) jobs got `posted_at = NULL`. Add a fallback layout for the no-colon numeric-offset form.

- Primary `RFC3339Nano` path (Z / colon offsets) unchanged.
- Fallback layout matches only numeric offsets, so a Z/colon string that reaches it (parse or NotFuture failure) still yields nil — no misparse.
- Shared helper used by ~55 adapters; additive, low-risk.

## Test Plan
- [x] New `TestParseRFC3339` — Z+fraction, colon offset, **no-colon offset (+0000, -0400)**, fractional+no-colon, empty, garbage
- [x] `go build/vet/test ./...` — pass; gofmt clean