### PR TITLE
feat(sources): add BreakwaterTech, Woba, Sequoia Connect boards

### DIFF
--- a/sources/comeet.yml
+++ b/sources/comeet.yml
@@ -36,3 +36,5 @@
   board: winn_ai/4A.00F
 - company: DealHub.ai
   board: dealhub/86.005
+- company: Sequoia Connect
+  board: sequoiaconnect/45.004

--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -708,3 +708,7 @@
   board: rpo-xpinc
 - company: "Spun"
   board: spun
+
+# --- added from a LinkedIn-sourced vacancy, validated live 2026-07-08 ---
+- company: "Woba"
+  board: woba

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -135,6 +135,8 @@
   board: bounteous
 - company: Branch
   board: branch.gg
+- company: Breakwater Technology
+  board: BreakwaterTech
 - company: Bright Edge
   board: brightedge
 - company: Bright Machines


### PR DESCRIPTION
## What

Adds three missing boards so vacancies surfaced from LinkedIn get ingested:

| Company | Provider | Board | Target posting |
|---------|----------|-------|----------------|
| Breakwater Technology | `lever` | `BreakwaterTech` | `2800389a-…` |
| Woba | `inhire` | `woba` | `b91e94ac-…` |
| Sequoia Connect | `comeet` | `sequoiaconnect/45.004` | `B2.964` — Full Stack Engineer (Node.js + React), México |

## Why

Each of these postings was checked against `(source, external_id)` in prod and was **absent** — not because of an ingest bug, but because the board was never in `sources/`. The Lever/Inhire/Comeet fronts (`jobs.lever.co`, `*.inhire.app`, the `sequoia-connect.com` co-branded Comeet site) map to boards our adapters already support.

## Validation

Each board was validated **live against the adapter's own public API** before adding, and the target `external_id` was confirmed present in the feed:

- Lever `BreakwaterTech` (US host) → 3 postings, target present
- Inhire `woba` (X-Tenant) → 7 posts, target present
- Comeet `sequoiaconnect/45.004` → 119 positions, `B2.964` = *Full Stack Engineer (Node.js + React)* present

All three files pass `sources.LoadConfig` + registry validation (`cmd/ingest` gets past config to the DB step). `go build ./...` is clean.

## Not included

**Ashby TRM Labs** — the fourth requested vacancy (`ecc944…`, *Senior Software Engineer, Backend*). Its board `trm-labs` is **already configured**; the posting is live in the Ashby feed and will arrive on the next ashby crawl. No change needed.