### PR TITLE
fix(web): reality badge — drop the repeated age, show the posting-date contrast

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -175,7 +175,7 @@
       {/if}
     </div>
 
-    <RealityBadge reality={job.reality} detailed />
+    <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />
 
     {#if showApplyPrompt && !applied}
       <div

--- a/web/src/lib/components/RealityBadge.svelte
+++ b/web/src/lib/components/RealityBadge.svelte
@@ -1,16 +1,28 @@
 <script lang="ts">
-  import { realityBadge } from '$lib/reality';
+  import { realityBadge, postingContrast } from '$lib/reality';
   import type { Reality } from '$lib/generated/contracts';
   import { cn } from '$lib/utils';
 
   // Surfaces the job-reality signal as a facts-backed badge: nothing for a fresh or
   // unclassified job, a muted age chip for a stale one, an amber "Likely evergreen"
-  // for a converged one. It states facts (in the label and the hover title, and
-  // inline when `detailed`), never a bare accusation. `detailed` renders the full
-  // fact string beside the badge on the job detail page.
-  let { reality, detailed = false }: { reality?: Reality | null; detailed?: boolean } = $props();
+  // for a converged one. It states facts (in the chip label and the hover tooltip, and
+  // inline when `detailed`), never a bare accusation. `detailed` renders complementary
+  // facts beside the chip on the job detail page — deliberately NOT the age, which the
+  // chip already carries, so "Open N days" never reads twice in a row.
+  let {
+    reality,
+    postedAt = null,
+    detailed = false,
+  }: { reality?: Reality | null; postedAt?: string | null; detailed?: boolean } = $props();
 
   const badge = $derived(realityBadge(reality));
+  // The posting-date contrast (when the source's date reads fresher than the true age)
+  // followed by the remaining evidence; empty when neither applies (chip shows alone).
+  const detail = $derived(
+    badge && reality
+      ? [postingContrast(reality, postedAt), badge.evidence].filter(Boolean).join(' · ')
+      : '',
+  );
 
   const toneClass: Record<'warn' | 'muted', string> = {
     warn: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400',
@@ -21,7 +33,7 @@
 {#if badge}
   <span class="inline-flex items-center gap-1.5">
     <span
-      title={badge.facts}
+      title={badge.tooltip}
       class={cn(
         'inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium',
         toneClass[badge.tone],
@@ -29,8 +41,8 @@
     >
       {badge.label}
     </span>
-    {#if detailed}
-      <span class="text-xs text-muted-foreground">{badge.facts}</span>
+    {#if detailed && detail}
+      <span class="text-xs text-muted-foreground">{detail}</span>
     {/if}
   </span>
 {/if}

--- a/web/src/lib/reality.test.ts
+++ b/web/src/lib/reality.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { realityBadge } from './reality';
+import { realityBadge, postingContrast } from './reality';
 import type { Reality } from './generated/contracts';
 
 const base = (over: Partial<Reality>): Reality => ({
@@ -11,6 +11,8 @@ const base = (over: Partial<Reality>): Reality => ({
   ...over,
 });
 
+const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000).toISOString();
+
 describe('realityBadge', () => {
   it('returns null for a fresh job (no badge)', () => {
     expect(realityBadge(base({ class: 'fresh' }))).toBeNull();
@@ -21,21 +23,52 @@ describe('realityBadge', () => {
     expect(realityBadge(null)).toBeNull();
   });
 
-  it('marks a likely-evergreen job with a warning tone and fact string', () => {
+  it('marks a likely-evergreen job with a warning tone and full tooltip', () => {
     const b = realityBadge(base({ class: 'likely-evergreen', age_days: 240, repost_count: 6 }));
     expect(b?.tone).toBe('warn');
-    expect(b?.facts).toContain('240');
-    expect(b?.facts).toContain('6'); // reposted 6×
+    expect(b?.tooltip).toContain('240');
+    expect(b?.tooltip).toContain('6'); // reposted 6×
   });
 
-  it('reports fake-freshness in the facts when the posting date was refreshed', () => {
+  it('reports fake-freshness in the tooltip when the posting date was refreshed', () => {
     const b = realityBadge(base({ class: 'likely-evergreen', age_days: 300, fake_freshness: true }));
-    expect(b?.facts.toLowerCase()).toContain('refreshed');
+    expect(b?.tooltip.toLowerCase()).toContain('refreshed');
   });
 
-  it('marks a stale job with a muted tone stating its age', () => {
+  it('marks a stale job with a muted tone stating its age in the chip label', () => {
     const b = realityBadge(base({ class: 'stale', age_days: 120 }));
     expect(b?.tone).toBe('muted');
-    expect(b?.facts).toContain('120');
+    expect(b?.label).toBe('Open 120d');
+    expect(b?.tooltip).toContain('120');
+  });
+
+  it('keeps the age out of the evidence string so it is not shown twice', () => {
+    const b = realityBadge(base({ class: 'stale', age_days: 120, repost_count: 3 }));
+    expect(b?.evidence).toBe('reposted 3×');
+    expect(b?.evidence).not.toContain('120');
+    expect(b?.evidence).not.toContain('Open');
+  });
+
+  it('leaves the evidence empty when a stale job has no evidence beyond its age', () => {
+    const b = realityBadge(base({ class: 'stale', age_days: 30 }));
+    expect(b?.evidence).toBe('');
+  });
+});
+
+describe('postingContrast', () => {
+  it('surfaces the posting date when it reads clearly fresher than the true age', () => {
+    const note = postingContrast(base({ age_days: 30 }), daysAgo(2));
+    expect(note).toContain('posting dated');
+    expect(note.toLowerCase()).toContain('day');
+  });
+
+  it('stays silent when the posting date roughly matches the true age', () => {
+    expect(postingContrast(base({ age_days: 20 }), daysAgo(18))).toBe('');
+  });
+
+  it('stays silent without a posting date or with an unparseable one', () => {
+    expect(postingContrast(base({ age_days: 30 }), null)).toBe('');
+    expect(postingContrast(base({ age_days: 30 }), undefined)).toBe('');
+    expect(postingContrast(base({ age_days: 30 }), 'not-a-date')).toBe('');
   });
 });

--- a/web/src/lib/reality.ts
+++ b/web/src/lib/reality.ts
@@ -1,30 +1,55 @@
 import type { Reality } from './generated/contracts';
+import { timeAgo } from './utils';
 
-/** A rendered job-reality badge: a tone and a compact label, plus the full fact
- *  string that justifies it. `null` means show no badge (a fresh or unclassified
- *  job). We state facts ("Open 240 days · reposted 6×"), never a bare accusation. */
+/** A rendered job-reality badge: a tone and a compact chip label, plus two fuller
+ *  strings. `tooltip` is the complete justification (age + evidence) shown on hover;
+ *  `evidence` is the same minus the age the label already carries, so the detail view
+ *  can show complementary facts without repeating "Open N days". `null` means show no
+ *  badge (a fresh or unclassified job). We state facts, never a bare accusation. */
 export interface RealityBadge {
   tone: 'warn' | 'muted';
   label: string;
-  facts: string;
+  tooltip: string;
+  evidence: string;
 }
 
-/** facts assembles the observable evidence behind a non-fresh classification. */
-function facts(r: Reality): string {
-  const parts = [`Open ${r.age_days} days`];
+/** evidenceParts is the observable evidence behind a non-fresh classification,
+ *  EXCLUDING the age — the badge label already carries it, so restating it here would
+ *  read as "Open 21 days" twice beside an "Open 21d" chip. */
+function evidenceParts(r: Reality): string[] {
+  const parts: string[] = [];
   if (r.repost_count > 1) parts.push(`reposted ${r.repost_count}×`);
   if (r.mass_posting_count > 1) parts.push(`${r.mass_posting_count} open copies`);
   if (r.fake_freshness) parts.push('posting date refreshed');
-  return parts.join(' · ');
+  return parts;
 }
 
 /** realityBadge maps the served reality signal to a badge, or null when there is
  *  nothing to show (fresh or missing). */
 export function realityBadge(reality?: Reality | null): RealityBadge | null {
   if (!reality || reality.class === 'fresh') return null;
+  const parts = evidenceParts(reality);
+  const evidence = parts.join(' · ');
+  const tooltip = [`Open ${reality.age_days} days`, ...parts].join(' · ');
   if (reality.class === 'likely-evergreen') {
-    return { tone: 'warn', label: 'Likely evergreen', facts: facts(reality) };
+    return { tone: 'warn', label: 'Likely evergreen', tooltip, evidence };
   }
   // stale
-  return { tone: 'muted', label: `Open ${reality.age_days}d`, facts: facts(reality) };
+  return { tone: 'muted', label: `Open ${reality.age_days}d`, tooltip, evidence };
+}
+
+/** postingContrast returns a "posting dated N ago" note when the source's posting date
+ *  reads meaningfully fresher than the job's true age — the refreshed-date story the
+ *  age label alone hides ("open 21 days, but posting dated 2 days ago"). '' when there
+ *  is no posting date, it is unparseable, or the gap is too small to be worth stating. */
+export function postingContrast(reality: Reality, postedAt?: string | null): string {
+  if (!postedAt) return '';
+  const d = new Date(postedAt);
+  if (Number.isNaN(d.getTime())) return '';
+  const postedDays = Math.floor((Date.now() - d.getTime()) / 86_400_000);
+  // The badge only shows for non-fresh jobs (age > 14d); a posting reading a clear
+  // week fresher than that true age is the contrast worth surfacing.
+  if (reality.age_days - postedDays < 7) return '';
+  const ago = timeAgo(postedAt);
+  return ago ? `posting dated ${ago}` : '';
 }


### PR DESCRIPTION
## What

On the job **detail** page the reality badge showed its age twice in a row:

```
[Open 21d]  Open 21 days · reposted 2×      ← "Open 21" repeated
```

The chip already states the age, so the inline facts now carry only what it *doesn't*:

```
[Open 21d]  posting dated 2 days ago · reposted 2×
```

`posting dated N ago` appears only when the source's posting date (`posted_at`, the effective/displayed date) reads a clear week fresher than the job's **true age** (`age_days`, derived from `created_at`) — the refreshed-date story the age label alone hides. Otherwise the line is just the remaining evidence, or nothing (chip alone).

## Why

`age_days` comes from `created_at` (first seen); the displayed `posted_at` can be much fresher on a re-listed/refreshed posting. Surfacing both — "open 21 days, but posting dated 2 days ago" — is exactly the reality signal the badge exists for. (`updated_at`/`last_seen_at` were considered and rejected: `UpsertJob` bumps them every crawl, so they always read "just now" for a live board job.)

## Changes

- **`reality.ts`** — `realityBadge` returns `{ tone, label, tooltip, evidence }`: `tooltip` keeps the full justification (age + evidence) for the hover title; `evidence` drops the age so it is never restated beside the chip. New pure `postingContrast()` derives the note.
- **`RealityBadge.svelte`** — optional `postedAt` prop; the `detailed` line is `postingContrast + evidence`, rendered only when non-empty.
- **`JobView.svelte`** — passes `job.posted_at`.
- Card (`JobRow`) unchanged — it already shows the chip plus its own relative posted date.

## Verification

- `vitest` — 75 passed (10 in `reality.test.ts`, incl. new evidence-split + `postingContrast` cases).
- `svelte-check` — 0 errors / 0 warnings.
- Visual — headless-Chrome screenshot of a throwaway route across four scenarios (refreshed-date, reposts-no-contrast, plain-stale chip-only, likely-evergreen); all render as designed. Throwaway route removed.