### PR TITLE
feat(job): introduce Job domain aggregate with a single construction door

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -50,7 +50,8 @@ internal/
   enrich/            enrichment contract (typed Enrichment + controlled vocabularies), the LLM Provider abstraction, and the queue-draining Runner
   search/            Meilisearch-backed job search (document shape + indexing)
   location/          curated dictionary deriving country/region codes + a work-mode hint from a free-text ATS location string (no geocoding, never guesses)
-  jobview/           the single public wire shape of a job (shared by list/detail/company/search responses and the search index)
+  job/               the Job domain aggregate: a sealed type built ONLY through job.New (the factory that derives facets) or a repository Load; owns lifecycle (Close/Reopen/ShouldEnrich) and the persistence↔domain ACL mapping. Every write path constructs through it.
+  jobview/           the single public wire shape of a job (shared by list/detail/company/search responses and the search index), projected from the job aggregate via FromDomain
   normalize/         slug normalization
 migrations/          SQL schema — single source for BOTH sqlc and Postgres initdb
 ```

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobhash"
 	"github.com/strelov1/freehire/internal/jobview"
-	"github.com/strelov1/freehire/internal/pipeline"
 	"github.com/strelov1/freehire/internal/search"
 )
 
@@ -49,38 +49,41 @@ func needsIndex(row db.UpsertJobRow) bool {
 	return row.Changed || row.Inserted.Bool
 }
 
-func (s *dbStore) Save(ctx context.Context, job pipeline.Job) error {
+func (s *dbStore) Save(ctx context.Context, j job.Job) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback(ctx)
 
+	// The aggregate's read projection carries every persistable field; the write path
+	// never touches enrichment (SetJobEnrichment owns those columns), so it is not mapped.
+	f := j.Fields()
 	params := db.UpsertJobParams{
-		Source:      job.Source,
-		ExternalID:  job.ExternalID,
-		URL:         job.URL,
-		Title:       job.Title,
-		Company:     job.Company,
-		CompanySlug: job.CompanySlug,
-		PublicSlug:  job.PublicSlug,
-		Location:    job.Location,
-		Remote:      job.Remote,
-		Description: job.Description,
-		PostedAt:    toTimestamptz(job.PostedAt),
-		Countries:   job.Countries,
-		Regions:     job.Regions,
-		Cities:      job.Cities,
-		WorkMode:    job.WorkMode,
-		Skills:      job.Skills,
-		Seniority:   job.Seniority,
-		Category:    job.Category,
+		Source:      f.Source,
+		ExternalID:  f.ExternalID,
+		URL:         f.URL,
+		Title:       f.Title,
+		Company:     f.Company,
+		CompanySlug: f.CompanySlug,
+		PublicSlug:  f.PublicSlug,
+		Location:    f.Location,
+		Remote:      f.Remote,
+		Description: f.Description,
+		PostedAt:    toTimestamptz(f.PostedAt),
+		Countries:   f.Countries,
+		Regions:     f.Regions,
+		Cities:      f.Cities,
+		WorkMode:    f.WorkMode,
+		Skills:      f.Skills,
+		Seniority:   f.Seniority,
+		Category:    f.Category,
 
-		PostingLanguage:    job.PostingLanguage,
-		EmploymentType:     job.EmploymentType,
-		EducationLevel:     job.EducationLevel,
-		EnglishLevel:       job.EnglishLevel,
-		ExperienceYearsMin: toInt4(job.ExperienceYearsMin),
+		PostingLanguage:    f.PostingLanguage,
+		EmploymentType:     f.EmploymentType,
+		EducationLevel:     f.EducationLevel,
+		EnglishLevel:       f.EnglishLevel,
+		ExperienceYearsMin: toInt4(f.ExperienceYearsMin),
 	}
 	// Fingerprint the indexed fields so the upsert can report whether this write
 	// changed searchable content (drives incremental indexing below).

--- a/cmd/tg-extract/store.go
+++ b/cmd/tg-extract/store.go
@@ -4,20 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/strelov1/freehire/internal/classify"
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
-	"github.com/strelov1/freehire/internal/jobfacts"
+	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/jobhash"
-	"github.com/strelov1/freehire/internal/lang"
-	"github.com/strelov1/freehire/internal/location"
-	"github.com/strelov1/freehire/internal/normalize"
-	"github.com/strelov1/freehire/internal/skilltag"
 	"github.com/strelov1/freehire/internal/telegram"
 )
 
@@ -28,6 +24,58 @@ func toInt4(n *int) pgtype.Int4 {
 		return pgtype.Int4{}
 	}
 	return pgtype.Int4{Int32: int32(*n), Valid: true}
+}
+
+// buildParams constructs the UpsertJob params for one Telegram-sourced job through
+// the Job aggregate factory, so the dictionary facets and slugs are derived exactly
+// as ingest and the moderator path derive them (job.New wraps jobderive) — no more
+// inline derivation that could drift from the shared dictionaries. workMode carries
+// a structured signal (link-resolved jobs may state it); "" lets the parser decide.
+// It returns job.ErrInvalidDraft for an extracted job with no title/identity.
+func buildParams(source, externalID, url, title, company, loc string, remote bool, description, workMode string, postedAt pgtype.Timestamptz) (db.UpsertJobParams, error) {
+	j, err := job.New(job.Draft{
+		Source:      source,
+		ExternalID:  externalID,
+		URL:         url,
+		Title:       title,
+		Company:     company,
+		Location:    loc,
+		Remote:      remote,
+		Description: description,
+		WorkMode:    workMode,
+	})
+	if err != nil {
+		return db.UpsertJobParams{}, err
+	}
+	f := j.Fields()
+	params := db.UpsertJobParams{
+		Source:      f.Source,
+		ExternalID:  f.ExternalID,
+		URL:         f.URL,
+		Title:       f.Title,
+		Company:     f.Company,
+		CompanySlug: f.CompanySlug,
+		PublicSlug:  f.PublicSlug,
+		Location:    f.Location,
+		Remote:      f.Remote,
+		Description: f.Description,
+		PostedAt:    postedAt,
+		Countries:   f.Countries,
+		Regions:     f.Regions,
+		Cities:      f.Cities,
+		WorkMode:    f.WorkMode,
+		Skills:      f.Skills,
+		Seniority:   f.Seniority,
+		Category:    f.Category,
+
+		PostingLanguage:    f.PostingLanguage,
+		EmploymentType:     f.EmploymentType,
+		EducationLevel:     f.EducationLevel,
+		EnglishLevel:       f.EnglishLevel,
+		ExperienceYearsMin: toInt4(f.ExperienceYearsMin),
+	}
+	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
+	return params, nil
 }
 
 // maxAttempts is the retry budget per post: the first failure leaves the post
@@ -92,42 +140,16 @@ func (s *extractStore) Complete(ctx context.Context, post telegram.PendingPost, 
 	base := post.Channel + "/" + strconv.FormatInt(post.MsgID, 10)
 	for i, j := range jobs {
 		externalID := base + "/" + strconv.Itoa(i)
-		geo := location.Parse(j.Location)
-		class := classify.Parse(j.Title)
-		// Category precedence mirrors jobderive: title dictionary → non-tech
-		// description fallback (tg-extract derives inline, not via jobderive).
-		category := class.Category
-		if category == "" {
-			category = classify.NonTechFromDescription(j.Description)
-		}
 		descHTML := telegram.TextToHTML(j.Description)
-		params := db.UpsertJobParams{
-			Source:      "telegram",
-			ExternalID:  externalID,
-			URL:         "https://t.me/" + base,
-			Title:       j.Title,
-			Company:     j.Company,
-			CompanySlug: normalize.Slug(j.Company),
-			PublicSlug:  normalize.JobSlug(j.Title, j.Company, "telegram", externalID),
-			Location:    j.Location,
-			Remote:      j.Remote,
-			Description: descHTML,
-			PostedAt:    pgtype.Timestamptz{Time: post.PostedAt, Valid: true},
-			Countries:   geo.Countries,
-			Regions:     geo.Regions,
-			Cities:      geo.Cities,
-			WorkMode:    geo.WorkMode,
-			Skills:      skilltag.Parse(descHTML),
-			Seniority:   class.Seniority,
-			Category:    category,
-
-			PostingLanguage:    lang.Detect(descHTML),
-			EmploymentType:     jobfacts.EmploymentType(j.Title, descHTML),
-			EducationLevel:     jobfacts.EducationLevel(descHTML),
-			EnglishLevel:       jobfacts.EnglishLevel(descHTML),
-			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(descHTML)),
+		params, err := buildParams("telegram", externalID, "https://t.me/"+base,
+			j.Title, j.Company, j.Location, j.Remote, descHTML, "",
+			pgtype.Timestamptz{Time: post.PostedAt, Valid: true})
+		if err != nil {
+			// An extracted job with no title/identity is junk (a mis-extraction); skip it
+			// rather than persisting it or failing the whole post.
+			log.Printf("tg-extract: skipping job %s: %v", externalID, err)
+			continue
 		}
-		params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
 		saved, err := qtx.UpsertJob(ctx, params)
 		if err != nil {
 			return fmt.Errorf("upsert job %s: %w", externalID, err)
@@ -167,49 +189,19 @@ func (s *extractStore) CompleteLinks(
 	qtx := s.q.WithTx(tx)
 
 	for _, j := range jobs {
-		geo := location.Parse(j.Location)
-		class := classify.Parse(j.Title)
-		// Category precedence mirrors jobderive: title dictionary → non-tech
-		// description fallback (tg-extract derives inline, not via jobderive).
-		category := class.Category
-		if category == "" {
-			category = classify.NonTechFromDescription(j.Description)
-		}
-		workMode := j.WorkMode
-		if workMode == "" {
-			workMode = geo.WorkMode
-		}
 		postedAt := pgtype.Timestamptz{Time: post.PostedAt, Valid: true}
 		if j.PostedAt != nil {
 			postedAt = pgtype.Timestamptz{Time: *j.PostedAt, Valid: true}
 		}
-		params := db.UpsertJobParams{
-			Source:      j.Source,
-			ExternalID:  j.ExternalID,
-			URL:         j.URL,
-			Title:       j.Title,
-			Company:     j.Company,
-			CompanySlug: normalize.Slug(j.Company),
-			PublicSlug:  normalize.JobSlug(j.Title, j.Company, j.Source, j.ExternalID),
-			Location:    j.Location,
-			Remote:      j.Remote,
-			Description: j.Description,
-			PostedAt:    postedAt,
-			Countries:   geo.Countries,
-			Regions:     geo.Regions,
-			Cities:      geo.Cities,
-			WorkMode:    workMode,
-			Skills:      skilltag.Parse(j.Description),
-			Seniority:   class.Seniority,
-			Category:    category,
-
-			PostingLanguage:    lang.Detect(j.Description),
-			EmploymentType:     jobfacts.EmploymentType(j.Title, j.Description),
-			EducationLevel:     jobfacts.EducationLevel(j.Description),
-			EnglishLevel:       jobfacts.EnglishLevel(j.Description),
-			ExperienceYearsMin: toInt4(jobfacts.ExperienceYearsMin(j.Description)),
+		// The resolved job may carry a structured work-mode; job.New gives it precedence
+		// over the location parser (an empty value lets the parser decide), matching the
+		// prior j.WorkMode || geo.WorkMode fallback.
+		params, err := buildParams(j.Source, j.ExternalID, j.URL,
+			j.Title, j.Company, j.Location, j.Remote, j.Description, j.WorkMode, postedAt)
+		if err != nil {
+			log.Printf("tg-extract: skipping link job %s/%s: %v", j.Source, j.ExternalID, err)
+			continue
 		}
-		params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
 		saved, err := qtx.UpsertJob(ctx, params)
 		if err != nil {
 			return fmt.Errorf("upsert job %s/%s: %w", j.Source, j.ExternalID, err)

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -246,6 +246,66 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 	return i, err
 }
 
+const getJobBySourceExternalID = `-- name: GetJobBySourceExternalID :one
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
+FROM jobs
+WHERE source = $1 AND external_id = $2
+`
+
+type GetJobBySourceExternalIDParams struct {
+	Source     string `json:"source"`
+	ExternalID string `json:"external_id"`
+}
+
+// Load a job by its dedup identity (source, external_id) — the key the Job
+// aggregate's repository loads by, mirroring the CloseJobBySourceExternalID key.
+func (q *Queries) GetJobBySourceExternalID(ctx context.Context, arg GetJobBySourceExternalIDParams) (Job, error) {
+	row := q.db.QueryRow(ctx, getJobBySourceExternalID, arg.Source, arg.ExternalID)
+	var i Job
+	err := row.Scan(
+		&i.ID,
+		&i.Source,
+		&i.ExternalID,
+		&i.URL,
+		&i.Title,
+		&i.Company,
+		&i.Location,
+		&i.Remote,
+		&i.Description,
+		&i.PostedAt,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.CompanySlug,
+		&i.Enrichment,
+		&i.EnrichedAt,
+		&i.EnrichmentVersion,
+		&i.PublicSlug,
+		&i.LastSeenAt,
+		&i.ClosedAt,
+		&i.Countries,
+		&i.Regions,
+		&i.WorkMode,
+		&i.LivenessStrikes,
+		&i.Skills,
+		&i.Seniority,
+		&i.Category,
+		&i.CreatedBy,
+		&i.UpdatedBy,
+		&i.PostingLanguage,
+		&i.EmploymentType,
+		&i.EducationLevel,
+		&i.ExperienceYearsMin,
+		&i.Collections,
+		&i.ContentHash,
+		&i.EnglishLevel,
+		&i.Cities,
+		&i.ViewCount,
+		&i.AppliedCount,
+		&i.RoleFingerprint,
+	)
+	return i, err
+}
+
 const getJobIDBySlug = `-- name: GetJobIDBySlug :one
 SELECT id
 FROM jobs

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -189,6 +189,9 @@ type Querier interface {
 	GetCompany(ctx context.Context, slug string) (Company, error)
 	GetJob(ctx context.Context, id int64) (Job, error)
 	GetJobBySlug(ctx context.Context, publicSlug string) (Job, error)
+	// Load a job by its dedup identity (source, external_id) — the key the Job
+	// aggregate's repository loads by, mirroring the CloseJobBySourceExternalID key.
+	GetJobBySourceExternalID(ctx context.Context, arg GetJobBySourceExternalIDParams) (Job, error)
 	// Slim slug->id lookup for the view/apply interaction path, which needs only the
 	// internal id (the user_jobs FK) and must not drag the wide description/enrichment
 	// columns over the wire on every silent view. GetJobBySlug (SELECT *) stays for the

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -86,6 +86,13 @@ SELECT *
 FROM jobs
 WHERE public_slug = $1;
 
+-- name: GetJobBySourceExternalID :one
+-- Load a job by its dedup identity (source, external_id) — the key the Job
+-- aggregate's repository loads by, mirroring the CloseJobBySourceExternalID key.
+SELECT *
+FROM jobs
+WHERE source = $1 AND external_id = $2;
+
 -- name: GetJobIDBySlug :one
 -- Slim slug->id lookup for the view/apply interaction path, which needs only the
 -- internal id (the user_jobs FK) and must not drag the wide description/enrichment

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -1,0 +1,181 @@
+// Package job defines the Job domain aggregate: the core posting entity with a
+// single guarded construction door. A Job can only be built through New (a fresh
+// posting) or loaded through a Repository (a stored one); its state is unexported
+// so no caller can assemble one bypassing the deterministic facet derivation.
+// This makes "a Job always carries facets consistent with its source fields" a
+// type-enforced invariant rather than a convention every write path must remember.
+package job
+
+import (
+	"errors"
+	"time"
+
+	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/jobderive"
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// ErrInvalidDraft is returned by New when a draft lacks the identity a job
+// requires: source, external id (together the dedup key), and a title.
+var ErrInvalidDraft = errors.New("job: draft missing source, external id, or title")
+
+// Draft is the source-agnostic input to New: the raw posting fields a write path
+// supplies before derivation. The caller resolves Source/ExternalID (the dedup
+// identity) so the job package stays free of the source registry. WorkMode,
+// Seniority, Category, Skills, and ExperienceYearsMin are optional structured
+// signals from the adapter that take precedence over the dictionaries.
+type Draft struct {
+	Source      string
+	ExternalID  string
+	URL         string
+	Title       string
+	Company     string
+	Location    string
+	Remote      bool
+	Description string
+	PostedAt    *time.Time
+
+	WorkMode           string
+	Seniority          string
+	Category           string
+	Skills             []string
+	ExperienceYearsMin *int
+}
+
+// Fields is the readable projection of a Job: a plain DTO exposing every field for
+// the wire projection and search indexing. A Fields can be freely constructed, but
+// it is not a Job and cannot be persisted, so the construction invariant holds.
+type Fields struct {
+	Source      string
+	ExternalID  string
+	URL         string
+	Title       string
+	Company     string
+	CompanySlug string
+	PublicSlug  string
+	Location    string
+	Remote      bool
+	Description string
+	PostedAt    *time.Time
+
+	// deterministic dictionary facets
+	Countries []string
+	Regions   []string
+	Cities    []string
+	WorkMode  string
+	Skills    []string
+	Seniority string
+	Category  string
+
+	// synthetic enrichment facets (deterministic stand-ins)
+	PostingLanguage    string
+	EmploymentType     string
+	EducationLevel     string
+	EnglishLevel       string
+	ExperienceYearsMin *int
+
+	// lifecycle + enrichment provenance (0 = unenriched)
+	ClosedAt          *time.Time
+	EnrichmentVersion int32
+
+	// Read-only projection fields, populated by a repository load and zero on a
+	// fresh New. ID is the persistence id (the domain identity is Source+ExternalID);
+	// ManuallyAdded is the moderator-authored provenance (created_by set). Enrichment
+	// is the RAW decoded LLM payload before any dict fold — the projection folds the
+	// dictionary columns over it. These never participate in the write surface.
+	ID            int64
+	ManuallyAdded bool
+	Enrichment    enrich.Enrichment
+	EnrichedAt    *time.Time
+	CreatedAt     *time.Time
+	UpdatedAt     *time.Time
+}
+
+// Job is the domain aggregate. Its state is unexported: the only ways to obtain a
+// Job are New (fresh) and a Repository load (stored), so construction always runs
+// through derivation. Read access for projection is via Fields.
+type Job struct {
+	f Fields
+}
+
+// New constructs a fresh Job from a draft, running the deterministic derivation
+// (slugs + dictionary facets) internally. It is the single construction door for
+// a not-yet-persisted posting. A fresh Job is open and unenriched.
+func New(d Draft) (Job, error) {
+	if d.Source == "" || d.ExternalID == "" || d.Title == "" {
+		return Job{}, ErrInvalidDraft
+	}
+	// Strip any coordinate tail a source jammed into the free-text location before
+	// it reaches both the facet derivation and the stored/displayed field — the
+	// same order pipeline.normalizeJob uses.
+	location := normalize.CleanLocation(d.Location)
+	der := jobderive.Derive(jobderive.Input{
+		Title:              d.Title,
+		Company:            d.Company,
+		Source:             d.Source,
+		ExternalID:         d.ExternalID,
+		Location:           location,
+		Description:        d.Description,
+		WorkMode:           d.WorkMode,
+		Seniority:          d.Seniority,
+		Category:           d.Category,
+		Skills:             d.Skills,
+		ExperienceYearsMin: d.ExperienceYearsMin,
+	})
+	return Job{f: Fields{
+		Source:      d.Source,
+		ExternalID:  d.ExternalID,
+		URL:         d.URL,
+		Title:       d.Title,
+		Company:     d.Company,
+		CompanySlug: der.CompanySlug,
+		PublicSlug:  der.PublicSlug,
+		Location:    location,
+		Remote:      d.Remote,
+		Description: d.Description,
+		PostedAt:    d.PostedAt,
+
+		Countries: der.Countries,
+		Regions:   der.Regions,
+		Cities:    der.Cities,
+		WorkMode:  der.WorkMode,
+		Skills:    der.Skills,
+		Seniority: der.Seniority,
+		Category:  der.Category,
+
+		PostingLanguage:    der.PostingLanguage,
+		EmploymentType:     der.EmploymentType,
+		EducationLevel:     der.EducationLevel,
+		EnglishLevel:       der.EnglishLevel,
+		ExperienceYearsMin: der.ExperienceYearsMin,
+	}}, nil
+}
+
+// Fields returns the readable projection of the aggregate. Slice and pointer
+// fields alias the aggregate's; callers treat the result as read-only.
+func (j Job) Fields() Fields { return j.f }
+
+// IsOpen reports whether the job is live (not soft-closed).
+func (j Job) IsOpen() bool { return j.f.ClosedAt == nil }
+
+// Close soft-closes the job as of at, idempotently: an already-closed job keeps
+// its original closed_at. Closing is non-destructive — the public slug, facets,
+// and enrichment are untouched, so the posting reopens for free.
+func (j *Job) Close(at time.Time) {
+	if j.f.ClosedAt != nil {
+		return
+	}
+	j.f.ClosedAt = &at
+}
+
+// Reopen clears the closed state (e.g. a previously closed posting reappears in
+// its source feed), so the job serves on list/search surfaces again.
+func (j *Job) Reopen() { j.f.ClosedAt = nil }
+
+// ShouldEnrich reports whether the job is eligible for (re-)enrichment: it is open
+// and its stored enrichment is below the target schema version. This mirrors the
+// enrichment queue's `closed_at IS NULL AND enrichment_version < $target` guard;
+// the target is passed in so this package need not depend on internal/enrich.
+func (j Job) ShouldEnrich(targetVersion int32) bool {
+	return j.IsOpen() && j.f.EnrichmentVersion < targetVersion
+}

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -1,0 +1,120 @@
+package job_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/job"
+	"github.com/strelov1/freehire/internal/normalize"
+)
+
+// New is the single construction door: it runs the deterministic derivation
+// internally, so a constructed Job always carries facets consistent with its
+// source fields. A caller never touches the facet fields.
+func TestNew_DerivesFacetsFromDraft(t *testing.T) {
+	j, err := job.New(job.Draft{
+		Source:      "manual",
+		ExternalID:  "https://acme.example/jobs/1",
+		Title:       "Senior Go Developer",
+		Company:     "Acme",
+		Location:    "Remote - Germany",
+		Description: "We use Golang and PostgreSQL.",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	f := j.Fields()
+
+	// Identity is preserved verbatim.
+	if f.Source != "manual" || f.ExternalID != "https://acme.example/jobs/1" {
+		t.Errorf("identity = %q/%q", f.Source, f.ExternalID)
+	}
+	// Slugs are minted deterministically from the identity.
+	wantSlug := normalize.JobSlug("Senior Go Developer", "Acme", "manual", "https://acme.example/jobs/1")
+	if f.PublicSlug != wantSlug {
+		t.Errorf("PublicSlug = %q, want %q", f.PublicSlug, wantSlug)
+	}
+	if f.CompanySlug != normalize.Slug("Acme") {
+		t.Errorf("CompanySlug = %q, want %q", f.CompanySlug, normalize.Slug("Acme"))
+	}
+	// Facets are derived from the dictionaries — the caller supplied none.
+	if len(f.Countries) == 0 || f.Countries[0] != "de" {
+		t.Errorf("Countries = %v, want [de ...]", f.Countries)
+	}
+	if !reflect.DeepEqual(f.Skills, []string{"go", "postgresql"}) {
+		t.Errorf("Skills = %v, want [go postgresql]", f.Skills)
+	}
+	if f.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote", f.WorkMode)
+	}
+}
+
+// A freshly constructed Job is open and unenriched: no lifecycle or enrichment
+// state until the write/enrich paths set it.
+func TestNew_FreshJobIsOpenAndUnenriched(t *testing.T) {
+	j, err := job.New(job.Draft{Source: "manual", ExternalID: "1", Title: "Engineer", Company: "Acme"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if !j.IsOpen() {
+		t.Error("fresh job should be open")
+	}
+	if f := j.Fields(); f.EnrichmentVersion != 0 {
+		t.Errorf("fresh job EnrichmentVersion = %d, want 0", f.EnrichmentVersion)
+	}
+}
+
+// Facets depend on content, never on which write path constructed the job: a
+// Telegram-extracted posting and a board-ingested posting with the same title,
+// description, and location resolve identical dictionary facets (only the slugs,
+// minted from identity, differ). This is the deterministic-facets guarantee that a
+// single construction door delivers — the tg-extract inline-derive divergence is
+// now unrepresentable.
+func TestNew_FacetsIndependentOfWritePath(t *testing.T) {
+	content := job.Draft{
+		Title:       "Senior Go Developer",
+		Company:     "Acme",
+		Location:    "Remote - Germany",
+		Description: "We use Golang and Kubernetes.",
+	}
+	tg := content
+	tg.Source, tg.ExternalID = "telegram", "chan/1/0"
+	board := content
+	board.Source, board.ExternalID = "greenhouse", "acme:42"
+
+	tj, err := job.New(tg)
+	if err != nil {
+		t.Fatalf("New(tg): %v", err)
+	}
+	bj, err := job.New(board)
+	if err != nil {
+		t.Fatalf("New(board): %v", err)
+	}
+	tf, bf := tj.Fields(), bj.Fields()
+
+	if !reflect.DeepEqual(tf.Countries, bf.Countries) || !reflect.DeepEqual(tf.Regions, bf.Regions) ||
+		!reflect.DeepEqual(tf.Cities, bf.Cities) || tf.WorkMode != bf.WorkMode ||
+		!reflect.DeepEqual(tf.Skills, bf.Skills) || tf.Seniority != bf.Seniority || tf.Category != bf.Category {
+		t.Errorf("facets diverged between write paths:\n tg    = %+v\n board = %+v", tf, bf)
+	}
+	// Slugs are minted from identity, so they legitimately differ.
+	if tf.PublicSlug == bf.PublicSlug {
+		t.Errorf("public slugs should differ by identity, both = %q", tf.PublicSlug)
+	}
+}
+
+// The factory rejects an identity-less draft: source and external id together are
+// the dedup key, and a title-less posting is not a job.
+func TestNew_RejectsMissingIdentity(t *testing.T) {
+	cases := map[string]job.Draft{
+		"no source":      {ExternalID: "1", Title: "Engineer"},
+		"no external id": {Source: "manual", Title: "Engineer"},
+		"no title":       {Source: "manual", ExternalID: "1"},
+	}
+	for name, d := range cases {
+		if _, err := job.New(d); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+}

--- a/internal/job/lifecycle_test.go
+++ b/internal/job/lifecycle_test.go
@@ -1,0 +1,77 @@
+package job_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/job"
+)
+
+func openJob(t *testing.T) job.Job {
+	t.Helper()
+	j, err := job.New(job.Draft{Source: "manual", ExternalID: "1", Title: "Engineer", Company: "Acme", Description: "We use Golang."})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return j
+}
+
+// Close soft-closes an open job without destroying its identity or facets, and is
+// idempotent: closing an already-closed job preserves the original closed_at.
+func TestClose_IdempotentAndNonDestructive(t *testing.T) {
+	j := openJob(t)
+	slug := j.Fields().PublicSlug
+	skills := j.Fields().Skills
+
+	t0 := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	j.Close(t0)
+	if j.IsOpen() {
+		t.Fatal("job should be closed after Close")
+	}
+	f := j.Fields()
+	if f.ClosedAt == nil || !f.ClosedAt.Equal(t0) {
+		t.Errorf("ClosedAt = %v, want %v", f.ClosedAt, t0)
+	}
+	if f.PublicSlug != slug {
+		t.Errorf("Close changed PublicSlug: %q != %q", f.PublicSlug, slug)
+	}
+	if len(f.Skills) != len(skills) {
+		t.Errorf("Close changed Skills: %v", f.Skills)
+	}
+
+	// Second close with a later time is a no-op — the original timestamp stands.
+	j.Close(t0.Add(48 * time.Hour))
+	if got := j.Fields().ClosedAt; got == nil || !got.Equal(t0) {
+		t.Errorf("idempotent Close moved ClosedAt to %v, want %v", got, t0)
+	}
+}
+
+// Reopen clears the closed state so the job serves on list/search again.
+func TestReopen_ClearsClosedState(t *testing.T) {
+	j := openJob(t)
+	j.Close(time.Now())
+	j.Reopen()
+	if !j.IsOpen() {
+		t.Error("job should be open after Reopen")
+	}
+	if j.Fields().ClosedAt != nil {
+		t.Errorf("Reopen left ClosedAt = %v", j.Fields().ClosedAt)
+	}
+}
+
+// ShouldEnrich mirrors the enrichment queue's SQL guard: open AND below the target
+// schema version.
+func TestShouldEnrich(t *testing.T) {
+	const target int32 = 1
+
+	fresh := openJob(t) // version 0, open
+	if !fresh.ShouldEnrich(target) {
+		t.Error("open, below-version job should be enrichment-eligible")
+	}
+
+	closed := openJob(t)
+	closed.Close(time.Now())
+	if closed.ShouldEnrich(target) {
+		t.Error("closed job must not be enrichment-eligible")
+	}
+}

--- a/internal/job/repository.go
+++ b/internal/job/repository.go
@@ -1,0 +1,172 @@
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/enrich"
+)
+
+// ErrNotFound is returned by Repository.Load when no job matches the identity.
+var ErrNotFound = errors.New("job: not found")
+
+// Extras is the read-only projection data that rides on the jobs row but is NOT
+// part of the Job aggregate's invariants: the engagement counters (materialized
+// from user_jobs) and the collection slugs (denormalized from the company). Keeping
+// them out of Job preserves a clean write surface — New/Close/Reopen never see them
+// — while the read path still gets them in one load. Zero on a fresh New; populated
+// only by a repository Load. It lives here (not in jobview) so the repository can
+// return it without the domain importing the wire layer.
+type Extras struct {
+	ViewCount    int32
+	AppliedCount int32
+	Collections  []string
+}
+
+// Repository is the persistence port for the Job aggregate: load by dedup
+// identity and soft-close by it. The domain never sees db.Job — the adapter maps
+// between the persistence row and the aggregate. Load also returns the read-only
+// Extras that ride on the same row. (Upsert lives with the write path that computes
+// the content-hash/role-fingerprint signals; it is added when the ingest path
+// switches to the factory.)
+type Repository interface {
+	Load(ctx context.Context, source, externalID string) (Job, Extras, error)
+	Close(ctx context.Context, source, externalID string) (int64, error)
+}
+
+// Compile-time proof that QueriesRepository satisfies Repository.
+var _ Repository = (*QueriesRepository)(nil)
+
+// QueriesRepository adapts *db.Queries to the Repository port, mirroring the
+// jobtracking package's convention.
+type QueriesRepository struct{ q *db.Queries }
+
+// NewQueriesRepository wraps q as a Repository.
+func NewQueriesRepository(q *db.Queries) *QueriesRepository {
+	return &QueriesRepository{q: q}
+}
+
+// Load returns the domain Job and its read-only Extras for the given dedup
+// identity, or ErrNotFound.
+func (r *QueriesRepository) Load(ctx context.Context, source, externalID string) (Job, Extras, error) {
+	row, err := r.q.GetJobBySourceExternalID(ctx, db.GetJobBySourceExternalIDParams{
+		Source:     source,
+		ExternalID: externalID,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Job{}, Extras{}, ErrNotFound
+	}
+	if err != nil {
+		return Job{}, Extras{}, err
+	}
+	return FromRow(row)
+}
+
+// Close soft-closes the job identified by (source, external_id) and reports how
+// many rows it closed (0 when already closed or absent) — the persistence side of
+// the aggregate's Close decision.
+func (r *QueriesRepository) Close(ctx context.Context, source, externalID string) (int64, error) {
+	return r.q.CloseJobBySourceExternalID(ctx, db.CloseJobBySourceExternalIDParams{
+		Source:     source,
+		ExternalID: externalID,
+	})
+}
+
+// FromRow is the anti-corruption mapping from a persistence row to the domain
+// Job plus its read-only Extras. It is the hydration path shared by the repository
+// Load and the jobview projection shim; it never derives (a stored row already
+// carries its facets), so it does not bypass the New construction invariant. It is
+// the single place the domain depends on the db row shape.
+func FromRow(r db.Job) (Job, Extras, error) {
+	j, err := jobFromRow(r)
+	if err != nil {
+		return Job{}, Extras{}, err
+	}
+	return j, extrasFromRow(r), nil
+}
+
+// jobFromRow maps the aggregate-owned fields of a persistence row into a domain
+// Job: pgtype scalars become domain types and the enrichment JSONB is decoded into
+// the typed, raw (pre-fold) Enrichment.
+func jobFromRow(r db.Job) (Job, error) {
+	var e enrich.Enrichment
+	if len(r.Enrichment) > 0 {
+		if err := json.Unmarshal(r.Enrichment, &e); err != nil {
+			return Job{}, fmt.Errorf("job: decode enrichment for job %d: %w", r.ID, err)
+		}
+	}
+	return Job{f: Fields{
+		Source:      r.Source,
+		ExternalID:  r.ExternalID,
+		URL:         r.URL,
+		Title:       r.Title,
+		Company:     r.Company,
+		CompanySlug: r.CompanySlug,
+		PublicSlug:  r.PublicSlug,
+		Location:    r.Location,
+		Remote:      r.Remote,
+		Description: r.Description,
+		PostedAt:    tsPtr(r.PostedAt),
+
+		Countries: r.Countries,
+		Regions:   r.Regions,
+		Cities:    r.Cities,
+		WorkMode:  r.WorkMode,
+		Skills:    r.Skills,
+		Seniority: r.Seniority,
+		Category:  r.Category,
+
+		PostingLanguage:    r.PostingLanguage,
+		EmploymentType:     r.EmploymentType,
+		EducationLevel:     r.EducationLevel,
+		EnglishLevel:       r.EnglishLevel,
+		ExperienceYearsMin: int4Ptr(r.ExperienceYearsMin),
+
+		ClosedAt:          tsPtr(r.ClosedAt),
+		EnrichmentVersion: r.EnrichmentVersion,
+
+		ID:            r.ID,
+		ManuallyAdded: r.CreatedBy.Valid,
+		Enrichment:    e,
+		EnrichedAt:    tsPtr(r.EnrichedAt),
+		CreatedAt:     tsPtr(r.CreatedAt),
+		UpdatedAt:     tsPtr(r.UpdatedAt),
+	}}, nil
+}
+
+// extrasFromRow pulls the read-only projection data (engagement counters +
+// denormalized collection slugs) off a persistence row. Kept separate from
+// jobFromRow so the aggregate mapping stays free of non-aggregate fields.
+func extrasFromRow(r db.Job) Extras {
+	return Extras{
+		ViewCount:    r.ViewCount,
+		AppliedCount: r.AppliedCount,
+		Collections:  r.Collections,
+	}
+}
+
+// tsPtr renders a nullable Postgres timestamp as *time.Time (nil when unset),
+// keeping the aggregate free of pgtype.
+func tsPtr(ts pgtype.Timestamptz) *time.Time {
+	if !ts.Valid {
+		return nil
+	}
+	t := ts.Time
+	return &t
+}
+
+// int4Ptr renders a nullable Postgres int4 as *int (nil when unset).
+func int4Ptr(n pgtype.Int4) *int {
+	if !n.Valid {
+		return nil
+	}
+	v := int(n.Int32)
+	return &v
+}

--- a/internal/job/repository_integration_test.go
+++ b/internal/job/repository_integration_test.go
@@ -126,3 +126,69 @@ func TestQueriesRepository_LoadNotFound(t *testing.T) {
 		t.Errorf("Load(missing) err = %v, want ErrNotFound", err)
 	}
 }
+
+// The aggregate's ShouldEnrich rule must agree with the SQL enqueue predicate
+// (closed_at IS NULL AND enrichment_version < target) that the enrichment worker
+// uses — the rule lives on the type, the set-based SQL is its performant
+// implementation, and this pins them equivalent so neither drifts.
+func TestShouldEnrich_MatchesEnqueuePredicate(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	q := db.New(pool)
+	repo := NewQueriesRepository(q)
+	const target int32 = 1
+
+	// Seed the three lifecycle/version states the predicate distinguishes.
+	seed := func(ext string, version int32, enriched, closed bool) {
+		t.Helper()
+		var enrichedAt, closedAt any
+		if enriched {
+			enrichedAt = "2026-01-01"
+		}
+		if closed {
+			closedAt = "2026-01-01"
+		}
+		_, err := pool.Exec(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug, enrichment_version, enriched_at, closed_at)
+			 VALUES ('t', $1, 'http://x', 'Dev', 'slug-'||$1, $2, $3, $4)`,
+			ext, version, enrichedAt, closedAt)
+		if err != nil {
+			t.Fatalf("seed %s: %v", ext, err)
+		}
+	}
+	seed("open-v0", 0, false, false)  // eligible
+	seed("open-v1", 1, true, false)   // at target → not eligible
+	seed("closed-v0", 0, false, true) // closed → not eligible
+
+	// The set-based enqueue is the production path; no category exclusion here.
+	if _, err := q.EnqueuePendingJobs(ctx, db.EnqueuePendingJobsParams{TargetVersion: target}); err != nil {
+		t.Fatalf("EnqueuePendingJobs: %v", err)
+	}
+	enqueued := map[string]bool{}
+	rows, err := pool.Query(ctx,
+		`SELECT j.external_id FROM enrichment_outbox o JOIN jobs j ON j.id = o.job_id`)
+	if err != nil {
+		t.Fatalf("read outbox: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var ext string
+		if err := rows.Scan(&ext); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		enqueued[ext] = true
+	}
+
+	// For every seeded job, the aggregate's ShouldEnrich must agree with whether the
+	// SQL predicate enqueued it.
+	for _, ext := range []string{"open-v0", "open-v1", "closed-v0"} {
+		j, _, err := repo.Load(ctx, "t", ext)
+		if err != nil {
+			t.Fatalf("Load %s: %v", ext, err)
+		}
+		if got := j.ShouldEnrich(target); got != enqueued[ext] {
+			t.Errorf("%s: ShouldEnrich=%v but enqueued=%v — rule and SQL predicate diverged",
+				ext, got, enqueued[ext])
+		}
+	}
+}

--- a/internal/job/repository_integration_test.go
+++ b/internal/job/repository_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+// Integration tests for the Job aggregate's repository: loading by dedup identity
+// and soft-closing by it, verified against a real Postgres. Run with:
+// go test -tags=integration ./internal/job/
+// Requires Docker (testcontainers spins up a throwaway Postgres with the migrations).
+package job
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func startPostgres(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	ctx := context.Background()
+
+	migrationsDir, err := filepath.Abs(filepath.Join("..", "..", "migrations"))
+	if err != nil {
+		t.Fatalf("resolve migrations dir: %v", err)
+	}
+	scripts, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+	if err != nil || len(scripts) == 0 {
+		t.Fatalf("list migrations: %v (found %d)", err, len(scripts))
+	}
+	sort.Strings(scripts)
+
+	pg, err := postgres.Run(ctx, "postgres:16-alpine",
+		postgres.WithDatabase("hire"),
+		postgres.WithUsername("hire"),
+		postgres.WithPassword("hire"),
+		postgres.WithInitScripts(scripts...),
+		postgres.BasicWaitStrategies(),
+	)
+	if err != nil {
+		t.Fatalf("start postgres: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.Terminate(ctx) })
+
+	dsn, err := pg.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("pool: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func TestQueriesRepository_LoadAndClose(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	repo := NewQueriesRepository(db.New(pool))
+
+	// Seed a job with facets and enrichment straight into the table.
+	// created_by is left null here (it FKs to users, out of scope); the
+	// ManuallyAdded mapping is covered by the jobFromRow unit test.
+	_, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, company, company_slug, public_slug,
+		                   location, countries, skills, seniority, category, enrichment)
+		 VALUES ('greenhouse', 'acme:42', 'http://x.test', 'Senior Go Developer', 'Acme', 'acme',
+		         'senior-go-developer-acme-1', 'Berlin, Germany', ARRAY['de'], ARRAY['go','postgresql'],
+		         'senior', 'backend', '{"summary":"Great","countries":["es"]}'::jsonb)`)
+	if err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	// Bump the materialized engagement counters so Extras has something to carry.
+	if _, err := pool.Exec(ctx,
+		`UPDATE jobs SET view_count = 3, applied_count = 1 WHERE source='greenhouse' AND external_id='acme:42'`); err != nil {
+		t.Fatalf("bump counters: %v", err)
+	}
+
+	j, x, err := repo.Load(ctx, "greenhouse", "acme:42")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if x.ViewCount != 3 || x.AppliedCount != 1 {
+		t.Errorf("Extras counters = %d/%d, want 3/1", x.ViewCount, x.AppliedCount)
+	}
+	f := j.Fields()
+	if f.Title != "Senior Go Developer" || f.Seniority != "senior" || f.Category != "backend" {
+		t.Errorf("loaded facets = %q/%q/%q", f.Title, f.Seniority, f.Category)
+	}
+	if len(f.Skills) != 2 || f.Enrichment.Summary != "Great" {
+		t.Errorf("loaded skills=%v enrichment=%+v", f.Skills, f.Enrichment)
+	}
+	if !j.IsOpen() {
+		t.Error("freshly seeded job should load as open")
+	}
+
+	// Close by identity, then reload — the aggregate reflects the closed state.
+	n, err := repo.Close(ctx, "greenhouse", "acme:42")
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Close affected %d rows, want 1", n)
+	}
+	reloaded, _, err := repo.Load(ctx, "greenhouse", "acme:42")
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if reloaded.IsOpen() {
+		t.Error("job should load as closed after Close")
+	}
+
+	// Closing an already-closed job is a no-op (0 rows).
+	if n, _ := repo.Close(ctx, "greenhouse", "acme:42"); n != 0 {
+		t.Errorf("second Close affected %d rows, want 0", n)
+	}
+}
+
+func TestQueriesRepository_LoadNotFound(t *testing.T) {
+	pool := startPostgres(t)
+	repo := NewQueriesRepository(db.New(pool))
+	if _, _, err := repo.Load(context.Background(), "nope", "missing"); err != ErrNotFound {
+		t.Errorf("Load(missing) err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/job/repository_internal_test.go
+++ b/internal/job/repository_internal_test.go
@@ -1,0 +1,102 @@
+package job
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// jobFromRow is the anti-corruption mapping: it turns a persistence row (pgtype
+// scalars, JSONB enrichment) into a domain Job (domain types, decoded enrichment).
+// This unit test pins the mapping without a database.
+func TestJobFromRow_MapsPersistenceToDomain(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	posted := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	closed := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	row := db.Job{
+		ID:                 55,
+		Source:             "greenhouse",
+		ExternalID:         "acme:42",
+		Title:              "Senior Go Developer",
+		Company:            "Acme",
+		CompanySlug:        "acme",
+		PublicSlug:         "senior-go-developer-acme-abc",
+		Location:           "Berlin, Germany",
+		Countries:          []string{"de"},
+		Skills:             []string{"go", "postgresql"},
+		WorkMode:           "onsite",
+		Seniority:          "senior",
+		Category:           "backend",
+		ExperienceYearsMin: pgtype.Int4{Int32: 5, Valid: true},
+		Enrichment:         json.RawMessage(`{"summary":"Great role","countries":["es"],"work_mode":"remote"}`),
+		EnrichmentVersion:  1,
+		CreatedBy:          pgtype.Int8{Int64: 7, Valid: true},
+		PostedAt:           pgtype.Timestamptz{Time: posted, Valid: true},
+		CreatedAt:          pgtype.Timestamptz{Time: created, Valid: true},
+		EnrichedAt:         pgtype.Timestamptz{Time: created, Valid: true},
+		ClosedAt:           pgtype.Timestamptz{Time: closed, Valid: true},
+	}
+
+	j, err := jobFromRow(row)
+	if err != nil {
+		t.Fatalf("jobFromRow: %v", err)
+	}
+	f := j.Fields()
+
+	if f.ID != 55 || f.Source != "greenhouse" || f.ExternalID != "acme:42" {
+		t.Errorf("identity = %d/%q/%q", f.ID, f.Source, f.ExternalID)
+	}
+	if f.Seniority != "senior" || f.Category != "backend" || f.WorkMode != "onsite" {
+		t.Errorf("dict facets = %q/%q/%q", f.Seniority, f.Category, f.WorkMode)
+	}
+	if f.ExperienceYearsMin == nil || *f.ExperienceYearsMin != 5 {
+		t.Errorf("ExperienceYearsMin = %v, want 5", f.ExperienceYearsMin)
+	}
+	// Enrichment JSONB is decoded into the typed, RAW LLM payload (pre-fold).
+	if f.Enrichment.Summary != "Great role" || len(f.Enrichment.Countries) != 1 || f.Enrichment.Countries[0] != "es" {
+		t.Errorf("decoded enrichment = %+v", f.Enrichment)
+	}
+	if f.EnrichmentVersion != 1 {
+		t.Errorf("EnrichmentVersion = %d, want 1", f.EnrichmentVersion)
+	}
+	// Provenance: created_by set → manually added.
+	if !f.ManuallyAdded {
+		t.Error("ManuallyAdded should be true when created_by is set")
+	}
+	// Nullable timestamps become *time.Time.
+	if f.PostedAt == nil || !f.PostedAt.Equal(posted) {
+		t.Errorf("PostedAt = %v, want %v", f.PostedAt, posted)
+	}
+	if f.CreatedAt == nil || !f.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt = %v", f.CreatedAt)
+	}
+	// A closed row maps to a closed aggregate.
+	if j.IsOpen() {
+		t.Error("row with closed_at should map to a closed Job")
+	}
+	if f.ClosedAt == nil || !f.ClosedAt.Equal(closed) {
+		t.Errorf("ClosedAt = %v, want %v", f.ClosedAt, closed)
+	}
+}
+
+// An empty enrichment JSONB decodes to the zero Enrichment, not an error.
+func TestJobFromRow_EmptyEnrichment(t *testing.T) {
+	j, err := jobFromRow(db.Job{ID: 1, Source: "manual", ExternalID: "1", Title: "Engineer"})
+	if err != nil {
+		t.Fatalf("jobFromRow: %v", err)
+	}
+	if s := j.Fields().Enrichment.Summary; s != "" {
+		t.Errorf("empty enrichment Summary = %q, want empty", s)
+	}
+	if !j.IsOpen() {
+		t.Error("row with null closed_at should map to an open Job")
+	}
+	if j.Fields().ManuallyAdded {
+		t.Error("ManuallyAdded should be false when created_by is null")
+	}
+}

--- a/internal/jobview/fromdomain_test.go
+++ b/internal/jobview/fromdomain_test.go
@@ -1,0 +1,103 @@
+package jobview_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/job"
+	"github.com/strelov1/freehire/internal/jobview"
+)
+
+// FromDomain must project a job to the exact wire shape the pre-aggregate FromRow
+// produced from the persistence row. This golden test pins that output against a
+// FROZEN oracle — expected JSON literals captured from the original FromRow while
+// it still held the full implementation (they matched byte-for-byte at that point).
+//
+// The oracle is deliberately NOT `jobview.FromRow(row)`: FromRow is now a shim over
+// job.FromRow → FromDomain, so comparing against it would be tautological and could
+// never catch a mapping regression (e.g. jobFromRow dropping a column). A frozen
+// literal is an independent oracle, so a future edit that silently blanks a field
+// fails here.
+func TestFromDomain_MatchesFrozenWireShape(t *testing.T) {
+	ts := func(y int, mo time.Month, d int) pgtype.Timestamptz {
+		return pgtype.Timestamptz{Time: time.Date(y, mo, d, 0, 0, 0, 0, time.UTC), Valid: true}
+	}
+
+	type fixture struct {
+		row  db.Job
+		want string
+	}
+	fixtures := map[string]fixture{
+		"enriched, dict-pinned geo, counts, manual": {
+			row: db.Job{
+				ID: 1, Source: "greenhouse", ExternalID: "acme:1", URL: "http://x.test",
+				Title: "Senior Go Developer", Company: "Acme", CompanySlug: "acme",
+				PublicSlug: "senior-go-developer-acme-1", Location: "Berlin, Germany",
+				Countries: []string{"de"}, Skills: []string{"go", "postgresql"},
+				WorkMode: "onsite", Seniority: "senior", Category: "backend",
+				PostingLanguage: "en", EmploymentType: "full_time", EducationLevel: "bachelor",
+				EnglishLevel: "c1", ExperienceYearsMin: pgtype.Int4{Int32: 5, Valid: true},
+				Cities:      []string{"Berlin"},
+				Collections: []string{"yc", "bigtech"},
+				Enrichment: json.RawMessage(
+					`{"summary":"Great role","skills":["go","kubernetes"],"countries":["fr"],"cities":["Munich"],"salary_min":100000,"salary_currency":"EUR"}`),
+				EnrichedAt: ts(2026, 1, 3), EnrichmentVersion: 1,
+				CreatedBy: pgtype.Int8{Int64: 9, Valid: true},
+				PostedAt:  ts(2026, 1, 1), CreatedAt: ts(2026, 1, 1), UpdatedAt: ts(2026, 1, 2),
+				ViewCount: 4, AppliedCount: 2,
+			},
+			want: `{"public_slug":"senior-go-developer-acme-1","source":"greenhouse","manually_added":true,"external_id":"acme:1","url":"http://x.test","title":"Senior Go Developer","company":"Acme","company_slug":"acme","location":"Berlin, Germany","description":"","countries":["de"],"regions":[],"work_mode":"onsite","skills":["go","postgresql"],"cities":["Berlin"],"collections":["bigtech","yc"],"posted_at":"2026-01-01T00:00:00Z","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-02T00:00:00Z","closed_at":null,"enrichment":{"summary":"Great role","employment_type":"full_time","salary_min":100000,"salary_currency":"EUR","seniority":"senior","experience_years_min":5,"english_level":"c1","education_level":"bachelor","category":"backend","posting_language":"en"},"enriched_at":"2026-01-03T00:00:00Z","enrichment_version":1,"view_count":4,"applied_count":2}`,
+		},
+		"unenriched, empty facets": {
+			row: db.Job{
+				ID: 2, Source: "lever", ExternalID: "beta:2", Title: "Engineer",
+				Company: "Beta", CompanySlug: "beta", PublicSlug: "engineer-beta-2",
+				CreatedAt: ts(2026, 1, 5),
+			},
+			want: `{"public_slug":"engineer-beta-2","source":"lever","manually_added":false,"external_id":"beta:2","url":"","title":"Engineer","company":"Beta","company_slug":"beta","location":"","description":"","countries":[],"regions":[],"skills":[],"cities":[],"collections":[],"posted_at":"2026-01-05T00:00:00Z","created_at":"2026-01-05T00:00:00Z","updated_at":null,"closed_at":null,"enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0}`,
+		},
+		"closed posting": {
+			row: db.Job{
+				ID: 3, Source: "ashby", ExternalID: "g:3", Title: "Dev", Company: "Gamma",
+				CompanySlug: "gamma", PublicSlug: "dev-gamma-3",
+				CreatedAt: ts(2026, 1, 4), ClosedAt: ts(2026, 2, 1),
+			},
+			want: `{"public_slug":"dev-gamma-3","source":"ashby","manually_added":false,"external_id":"g:3","url":"","title":"Dev","company":"Gamma","company_slug":"gamma","location":"","description":"","countries":[],"regions":[],"skills":[],"cities":[],"collections":[],"posted_at":"2026-01-04T00:00:00Z","created_at":"2026-01-04T00:00:00Z","updated_at":null,"closed_at":"2026-02-01T00:00:00Z","enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0}`,
+		},
+		"geo hybrid: dict unpinned, LLM restricts": {
+			row: db.Job{
+				ID: 4, Source: "manual", ExternalID: "d:4", Title: "Remote Dev", Company: "Delta",
+				CompanySlug: "delta", PublicSlug: "remote-dev-delta-4",
+				Regions:    []string{"global"},
+				WorkMode:   "remote",
+				Enrichment: json.RawMessage(`{"countries":["es"],"regions":["europe"]}`),
+				CreatedAt:  ts(2026, 1, 6),
+			},
+			want: `{"public_slug":"remote-dev-delta-4","source":"manual","manually_added":false,"external_id":"d:4","url":"","title":"Remote Dev","company":"Delta","company_slug":"delta","location":"","description":"","countries":["es"],"regions":["europe"],"work_mode":"remote","skills":[],"cities":[],"collections":[],"posted_at":"2026-01-06T00:00:00Z","created_at":"2026-01-06T00:00:00Z","updated_at":null,"closed_at":null,"enrichment":{},"enriched_at":null,"enrichment_version":0,"view_count":0,"applied_count":0}`,
+		},
+	}
+
+	for name, fx := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			j, x, err := job.FromRow(fx.row)
+			if err != nil {
+				t.Fatalf("job.FromRow: %v", err)
+			}
+			got, err := jobview.FromDomain(j, x)
+			if err != nil {
+				t.Fatalf("FromDomain: %v", err)
+			}
+			gotJSON, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(gotJSON) != fx.want {
+				t.Errorf("projection drifted from frozen wire shape:\n want = %s\n got  = %s", fx.want, gotJSON)
+			}
+		})
+	}
+}

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -5,8 +5,6 @@
 package jobview
 
 import (
-	"encoding/json"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -15,6 +13,7 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/job"
 )
 
 // Job is the public wire shape of a job. It carries the public_slug and
@@ -90,85 +89,93 @@ type Job struct {
 	Reality *Reality `json:"reality,omitempty"`
 }
 
-// FromRow maps a database job row to the public wire shape. The enrichment
-// JSONB is decoded into the typed Enrichment; an empty or absent payload yields
-// the zero Enrichment.
+// FromRow maps a database job row to the public wire shape. It is a thin shim: it
+// hydrates the row into the Job aggregate (plus its read-only Extras) via
+// job.FromRow, then delegates to FromDomain — the projection source of truth. It
+// stays so existing read callers that hold a db.Job are untouched.
 func FromRow(j db.Job) (Job, error) {
-	var e enrich.Enrichment
-	if len(j.Enrichment) > 0 {
-		if err := json.Unmarshal(j.Enrichment, &e); err != nil {
-			return Job{}, fmt.Errorf("jobview: decode enrichment for job %d: %w", j.ID, err)
-		}
+	domain, extras, err := job.FromRow(j)
+	if err != nil {
+		return Job{}, err
 	}
+	return FromDomain(domain, extras)
+}
 
-	// The dictionary-derived facets are sourced from the jobs columns ONLY (the
-	// deterministic dictionaries are the production source); the LLM's values for
-	// them are excluded from the served object so the LLM can later run free as a
-	// discovery signal without corrupting production data. The LLM values stay in
-	// the stored enrichment JSONB (untouched) but are folded out of the served copy
-	// here. normalizeSet lowercases/sorts/dedups each column and guarantees a
-	// non-nil slice so the facet serializes as [] not null.
-	//
-	// Countries/regions are the exception (like cities): a hybrid dict-then-LLM facet.
-	// The dictionary wins whenever it pinned a place, but when it left geography
-	// unpinned — no country and at most the bare-"Remote" "global" bucket — the LLM's
-	// enrichment.countries/regions fill in, catching a restriction stated only in the
-	// prose ("Remote (SPAIN only)") that the location string never carried.
-	countries, regions := geoFacet(j.Countries, j.Regions, e.Countries, e.Regions)
-	workMode := j.WorkMode
-	// Seniority/category are the dictionary column value, always — never the LLM's,
-	// and never a dict-silent fill. They stay nested under enrichment, so the
-	// existing enrichment.seniority/category facets are unchanged.
-	e.Seniority = j.Seniority
-	e.Category = j.Category
-	// The synthetic facets (posting_language/employment_type/education_level/
-	// english_level/experience_years_min) follow the same dict-only rule: the
-	// deterministic column value always wins (the LLM's stays raw in the JSONB), kept
-	// nested under enrichment so the wire shape is unchanged.
-	e.PostingLanguage = j.PostingLanguage
-	e.EmploymentType = j.EmploymentType
-	e.EducationLevel = j.EducationLevel
-	e.EnglishLevel = j.EnglishLevel
-	e.ExperienceYearsMin = int4ToPtr(j.ExperienceYearsMin)
-	skills := normalizeSet(j.Skills)
-	// Collections is denormalized from the company onto the job; it has no LLM
-	// counterpart to fold out, so it is simply normalized like the other facets.
-	collections := normalizeSet(j.Collections)
-	// Cities is the hybrid facet: the deterministic column when it resolved a beacon
-	// city, else a normalized fallback to the LLM's cities (the one dict+LLM exception).
-	// Kept case-preserving (values are display names), unlike the lowercased facets.
-	cities := cityFacet(j.Cities, e.Cities)
+// FromDomain projects the Job aggregate (plus its read-only Extras) to the public
+// wire shape. It is the projection source of truth; FromRow is a thin shim that
+// hydrates a db row into the domain and delegates here. The facet handling mirrors
+// FromRow exactly — the dictionary columns are served, the LLM's copies are folded
+// out of the nested enrichment, and countries/regions/cities stay dict-then-LLM
+// hybrids — so the wire output is byte-equivalent to the pre-aggregate projection.
+func FromDomain(j job.Job, x job.Extras) (Job, error) {
+	f := j.Fields()
+	// e is the raw decoded LLM enrichment; the dictionary columns are folded over it
+	// below (dict wins) and the multi-valued LLM facets are folded out.
+	e := f.Enrichment
+
+	countries, regions := geoFacet(f.Countries, f.Regions, e.Countries, e.Regions)
+	workMode := f.WorkMode
+	// Seniority/category and the synthetic facets are the dictionary column value,
+	// always — kept nested under enrichment so the wire shape is unchanged.
+	e.Seniority = f.Seniority
+	e.Category = f.Category
+	e.PostingLanguage = f.PostingLanguage
+	e.EmploymentType = f.EmploymentType
+	e.EducationLevel = f.EducationLevel
+	e.EnglishLevel = f.EnglishLevel
+	e.ExperienceYearsMin = f.ExperienceYearsMin
+	skills := normalizeSet(f.Skills)
+	collections := normalizeSet(x.Collections)
+	cities := cityFacet(f.Cities, e.Cities)
 	e.Countries, e.Regions, e.WorkMode = nil, nil, ""
 	e.Skills = nil
 	e.Cities = nil
 
 	return Job{
-		PublicSlug:        j.PublicSlug,
-		Source:            j.Source,
-		ManuallyAdded:     j.CreatedBy.Valid,
-		ExternalID:        j.ExternalID,
-		URL:               j.URL,
-		Title:             j.Title,
-		Company:           j.Company,
-		CompanySlug:       j.CompanySlug,
-		Location:          j.Location,
-		Description:       j.Description,
+		PublicSlug:        f.PublicSlug,
+		Source:            f.Source,
+		ManuallyAdded:     f.ManuallyAdded,
+		ExternalID:        f.ExternalID,
+		URL:               f.URL,
+		Title:             f.Title,
+		Company:           f.Company,
+		CompanySlug:       f.CompanySlug,
+		Location:          f.Location,
+		Description:       f.Description,
 		Countries:         countries,
 		Regions:           regions,
 		WorkMode:          workMode,
 		Skills:            skills,
 		Cities:            cities,
 		Collections:       collections,
-		PostedAt:          rfc3339(EffectivePostedAt(j.PostedAt, j.CreatedAt)),
-		CreatedAt:         rfc3339(j.CreatedAt),
-		UpdatedAt:         rfc3339(j.UpdatedAt),
-		ClosedAt:          rfc3339(j.ClosedAt),
+		PostedAt:          rfc3339Ptr(effectivePosted(f.PostedAt, f.CreatedAt)),
+		CreatedAt:         rfc3339Ptr(f.CreatedAt),
+		UpdatedAt:         rfc3339Ptr(f.UpdatedAt),
+		ClosedAt:          rfc3339Ptr(f.ClosedAt),
 		Enrichment:        e,
-		EnrichedAt:        rfc3339(j.EnrichedAt),
-		EnrichmentVersion: j.EnrichmentVersion,
-		ViewCount:         j.ViewCount,
-		AppliedCount:      j.AppliedCount,
+		EnrichedAt:        rfc3339Ptr(f.EnrichedAt),
+		EnrichmentVersion: f.EnrichmentVersion,
+		ViewCount:         x.ViewCount,
+		AppliedCount:      x.AppliedCount,
 	}, nil
+}
+
+// effectivePosted is EffectivePostedAt over domain *time.Time: the source posted
+// time when present and not in the future, otherwise the ingest time.
+func effectivePosted(posted, created *time.Time) *time.Time {
+	if posted == nil || posted.After(time.Now()) {
+		return created
+	}
+	return posted
+}
+
+// rfc3339Ptr renders a nullable domain timestamp as an RFC3339 UTC string, or nil.
+func rfc3339Ptr(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.UTC().Format(time.RFC3339)
+	return &s
 }
 
 // normalizeSet returns the sorted, deduplicated, lowercased form of a facet
@@ -306,25 +313,4 @@ func EffectivePostedAt(posted, created pgtype.Timestamptz) pgtype.Timestamptz {
 		return created
 	}
 	return posted
-}
-
-// rfc3339 renders a nullable Postgres timestamp as an RFC3339 UTC string, or nil
-// when unset. UTC keeps the lexicographic order chronological for sorting.
-func rfc3339(ts pgtype.Timestamptz) *string {
-	if !ts.Valid {
-		return nil
-	}
-	s := ts.Time.UTC().Format(time.RFC3339)
-	return &s
-}
-
-// int4ToPtr renders a nullable Postgres integer (experience_years_min) as *int, or
-// nil when unset — so an unknown value is omitted from the served enrichment rather
-// than reported as 0.
-func int4ToPtr(n pgtype.Int4) *int {
-	if !n.Valid {
-		return nil
-	}
-	v := int(n.Int32)
-	return &v
 }

--- a/internal/moderation/moderation.go
+++ b/internal/moderation/moderation.go
@@ -17,7 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
-	"github.com/strelov1/freehire/internal/jobderive"
+	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/sources"
 )
 
@@ -131,40 +131,35 @@ func (s *Service) Create(ctx context.Context, actorID int64, in CreateInput) (db
 	// {@html}; sanitize to the same allowlist as every other source so no active
 	// markup is ever persisted (stored XSS). Done once and reused for derivation.
 	description := sources.SanitizeHTML(in.Description)
-	d := jobderive.Derive(jobderive.Input{
-		Title:       in.Title,
-		Company:     in.Company,
-		Source:      source,
-		ExternalID:  in.URL,
-		Location:    in.Location,
-		Description: description,
-		WorkMode:    remoteWorkMode(in.Remote),
-	})
+	f, err := derive(source, in.URL, in.Title, in.Company, in.Location, description, in.Remote)
+	if err != nil {
+		return db.Job{}, err
+	}
 	return s.repo.Create(ctx, db.UpsertManualJobParams{
 		Source:      source,
 		ExternalID:  in.URL,
 		URL:         in.URL,
 		Title:       in.Title,
 		Company:     in.Company,
-		CompanySlug: d.CompanySlug,
-		Location:    in.Location,
+		CompanySlug: f.CompanySlug,
+		Location:    f.Location,
 		Remote:      in.Remote,
 		Description: description,
 		PostedAt:    toTimestamptz(in.PostedAt),
-		PublicSlug:  d.PublicSlug,
-		Countries:   d.Countries,
-		Regions:     d.Regions,
-		Cities:      d.Cities,
-		WorkMode:    d.WorkMode,
-		Skills:      d.Skills,
-		Seniority:   d.Seniority,
-		Category:    d.Category,
+		PublicSlug:  f.PublicSlug,
+		Countries:   f.Countries,
+		Regions:     f.Regions,
+		Cities:      f.Cities,
+		WorkMode:    f.WorkMode,
+		Skills:      f.Skills,
+		Seniority:   f.Seniority,
+		Category:    f.Category,
 
-		PostingLanguage:    d.PostingLanguage,
-		EmploymentType:     d.EmploymentType,
-		EducationLevel:     d.EducationLevel,
-		EnglishLevel:       d.EnglishLevel,
-		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
+		PostingLanguage:    f.PostingLanguage,
+		EmploymentType:     f.EmploymentType,
+		EducationLevel:     f.EducationLevel,
+		EnglishLevel:       f.EnglishLevel,
+		ExperienceYearsMin: toInt4(f.ExperienceYearsMin),
 
 		CreatedBy: actorID,
 		UpdatedBy: actorID,
@@ -202,40 +197,57 @@ func (s *Service) Update(ctx context.Context, actorID int64, slug string, p Upda
 
 	// External id and source stay the create-time identity; only the dictionary facets
 	// re-derive (the recomputed public slug is discarded — identity is immutable).
-	d := jobderive.Derive(jobderive.Input{
-		Title:       title,
-		Company:     company,
-		Source:      cur.Source,
-		ExternalID:  cur.ExternalID,
-		Location:    location,
-		Description: description,
-		WorkMode:    remoteWorkMode(remote),
-	})
+	f, err := derive(cur.Source, cur.ExternalID, title, company, location, description, remote)
+	if err != nil {
+		return db.Job{}, err
+	}
 	return s.repo.Update(ctx, db.UpdateManualJobParams{
 		PublicSlug:  slug,
 		Title:       title,
 		Company:     company,
-		CompanySlug: d.CompanySlug,
-		Location:    location,
+		CompanySlug: f.CompanySlug,
+		Location:    f.Location,
 		Remote:      remote,
 		Description: description,
 		PostedAt:    postedAt,
-		Countries:   d.Countries,
-		Regions:     d.Regions,
-		Cities:      d.Cities,
-		WorkMode:    d.WorkMode,
-		Skills:      d.Skills,
-		Seniority:   d.Seniority,
-		Category:    d.Category,
+		Countries:   f.Countries,
+		Regions:     f.Regions,
+		Cities:      f.Cities,
+		WorkMode:    f.WorkMode,
+		Skills:      f.Skills,
+		Seniority:   f.Seniority,
+		Category:    f.Category,
 
-		PostingLanguage:    d.PostingLanguage,
-		EmploymentType:     d.EmploymentType,
-		EducationLevel:     d.EducationLevel,
-		EnglishLevel:       d.EnglishLevel,
-		ExperienceYearsMin: toInt4(d.ExperienceYearsMin),
+		PostingLanguage:    f.PostingLanguage,
+		EmploymentType:     f.EmploymentType,
+		EducationLevel:     f.EducationLevel,
+		EnglishLevel:       f.EnglishLevel,
+		ExperienceYearsMin: toInt4(f.ExperienceYearsMin),
 
 		UpdatedBy: actorID,
 	})
+}
+
+// derive builds the Job aggregate through the factory and returns its projected
+// fields — the moderator write path's single door to the deterministic slugs and
+// dictionary facets, shared with ingest and Telegram extraction. WorkMode carries
+// the moderator's structured remote flag (job.New cleans the location and derives
+// the rest). It errors only when the identity or title is blank, which the caller's
+// validation already precludes.
+func derive(source, externalID, title, company, location, description string, remote bool) (job.Fields, error) {
+	j, err := job.New(job.Draft{
+		Source:      source,
+		ExternalID:  externalID,
+		Title:       title,
+		Company:     company,
+		Location:    location,
+		Description: description,
+		WorkMode:    remoteWorkMode(remote),
+	})
+	if err != nil {
+		return job.Fields{}, err
+	}
+	return j.Fields(), nil
 }
 
 // remoteWorkMode maps the moderator's structured remote flag onto a work-mode signal

--- a/internal/moderation/moderation_test.go
+++ b/internal/moderation/moderation_test.go
@@ -124,7 +124,7 @@ func TestCreate_SanitizesDescription(t *testing.T) {
 }
 
 func TestUpdate_SanitizesDescription(t *testing.T) {
-	repo := &fakeRepo{bySlugJob: db.Job{Source: "manual", PublicSlug: "s", Description: "old"}}
+	repo := &fakeRepo{bySlugJob: db.Job{Source: "manual", ExternalID: "https://acme.example/jobs/1", Title: "Dev", PublicSlug: "s", Description: "old"}}
 	evil := `<script>alert(1)</script><b>new</b>`
 	_, err := moderation.New(repo).Update(context.Background(), 9, "s", moderation.UpdatePatch{Description: &evil})
 	if err != nil {

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -10,8 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/strelov1/freehire/internal/jobderive"
-	"github.com/strelov1/freehire/internal/normalize"
+	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/worker"
 )
@@ -24,51 +23,13 @@ const defaultConcurrency = 8
 // stops advancing — instead of the run going silent until it finishes.
 const progressInterval = 60 * time.Second
 
-// Job is a normalized posting ready to persist: the pipeline has set the platform as
-// source, namespaced the external id by board, derived the company slug, and minted
-// the public slug.
-type Job struct {
-	Source      string
-	ExternalID  string
-	URL         string
-	Title       string
-	Company     string
-	CompanySlug string
-	PublicSlug  string
-	Location    string
-	Remote      bool
-	Description string
-	PostedAt    *time.Time
-	// Countries/Regions/WorkMode are parsed from Location: ISO alpha-2 codes,
-	// region codes, and a work-mode hint. Each is empty when the location states
-	// nothing the parser can resolve.
-	Countries []string
-	Regions   []string
-	Cities    []string
-	WorkMode  string
-	// Skills are the deterministic technology tags parsed from Description by
-	// internal/skilltag. Empty when the description resolves no known skill.
-	Skills []string
-	// Seniority and Category are deterministic classification parsed from Title by
-	// internal/classify. Each is "" when the title resolves nothing.
-	Seniority string
-	Category  string
-	// Synthetic enrichment facets derived from Title/Description by jobderive
-	// (internal/lang + internal/jobfacts): the posting language, employment type,
-	// education level, English level, and minimum required experience. Each is
-	// empty/nil when nothing is resolved.
-	PostingLanguage    string
-	EmploymentType     string
-	EducationLevel     string
-	EnglishLevel       string
-	ExperienceYearsMin *int
-}
-
-// Store persists one normalized job and enqueues it for enrichment when needed,
-// atomically. The pipeline is unaware of the schema version or the outbox — that is
-// the Store implementation's concern.
+// Store persists one Job aggregate and enqueues it for enrichment when needed,
+// atomically. It accepts only a job.Job — a value obtainable exclusively through
+// the aggregate factory (job.New) — so the write path cannot persist a posting that
+// bypassed the deterministic derivation. The pipeline is unaware of the schema
+// version or the outbox — that is the Store implementation's concern.
 type Store interface {
-	Save(ctx context.Context, job Job) error
+	Save(ctx context.Context, j job.Job) error
 }
 
 // closer is the optional Store capability a self-closing streaming source needs: closing a
@@ -196,7 +157,15 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 
 	var firstErr error
 	for _, j := range raw {
-		if err := r.Store.Save(ctx, normalizeJob(e, j)); err != nil {
+		dj, err := normalizeJob(e, j)
+		if err != nil {
+			skipped++
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if err := r.Store.Save(ctx, dj); err != nil {
 			skipped++
 			if firstErr == nil {
 				firstErr = err
@@ -205,10 +174,11 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 		}
 		ingested++
 	}
-	// One line per board with skips (not one per job), so a systemic save failure —
-	// e.g. the DB behind a migration — is visible without flooding the log.
+	// One line per board with skips (not one per job), so a systemic failure — e.g.
+	// the DB behind a migration, or a board whose postings won't construct — is visible
+	// without flooding the log.
 	if skipped > 0 {
-		log.Printf("ingest: %s board %q (%s): skipped %d/%d jobs on save error (e.g. %v)",
+		log.Printf("ingest: %s board %q (%s): skipped %d/%d jobs on construct or save error (e.g. %v)",
 			e.Provider, e.Board, e.Company, skipped, len(raw), firstErr)
 	}
 	return ingested, 0, skipped
@@ -248,7 +218,15 @@ func (r Runner) ingestStream(ctx context.Context, e sources.CompanyEntry, ss sou
 			ingested++
 			return
 		}
-		if err := r.Store.Save(ctx, normalizeJob(e, j)); err != nil {
+		dj, err := normalizeJob(e, j)
+		if err != nil {
+			skipped++
+			if firstErr == nil {
+				firstErr = err
+			}
+			return
+		}
+		if err := r.Store.Save(ctx, dj); err != nil {
 			skipped++
 			if firstErr == nil {
 				firstErr = err
@@ -279,58 +257,28 @@ func jobIdentity(e sources.CompanyEntry, j sources.Job) (source, externalID stri
 	return e.Provider, sources.NamespaceExternalID(e.Board, j.ExternalID)
 }
 
-// normalizeJob turns a raw posting into a persistable Job: the platform becomes the
-// source, the external id is namespaced by board so two companies on one platform
-// cannot collide, the company slug is derived with the shared normalizer, and the
-// public slug is minted from the same (source, external_id) identity so it is stable
-// across re-ingests and deterministic with the dedup key.
-func normalizeJob(e sources.CompanyEntry, j sources.Job) Job {
+// normalizeJob turns a raw posting into the Job aggregate through the factory: the
+// platform becomes the source and the external id is namespaced by board (so two
+// companies on one platform cannot collide), and job.New derives the slugs and the
+// dictionary facets internally — so ingest, the moderator write path, and Telegram
+// extraction all produce identical facets from the one door. It returns
+// job.ErrInvalidDraft for a posting with no title/identity, which the caller skips.
+func normalizeJob(e sources.CompanyEntry, j sources.Job) (job.Job, error) {
 	source, externalID := jobIdentity(e, j)
-	// Strip any coordinate tail a source jammed into the free-text location before it
-	// reaches both the facet derivation and the stored/displayed field.
-	location := normalize.CleanLocation(j.Location)
-	// The slugs and dictionary facets (geography/work-mode/skills/classification) are
-	// derived by the shared jobderive helper, so ingest and the moderator write path
-	// produce identical facets. The adapter's structured facet signals (work-mode,
-	// seniority, category, skills, experience) take precedence over the dictionary
-	// there; an unset signal lets the dictionary decide.
-	d := jobderive.Derive(jobderive.Input{
-		Title:              j.Title,
-		Company:            j.Company,
+	return job.New(job.Draft{
 		Source:             source,
 		ExternalID:         externalID,
-		Location:           location,
+		URL:                j.URL,
+		Title:              j.Title,
+		Company:            j.Company,
+		Location:           j.Location,
+		Remote:             j.Remote,
 		Description:        j.Description,
+		PostedAt:           j.PostedAt,
 		WorkMode:           j.WorkMode,
 		Seniority:          j.Seniority,
 		Category:           j.Category,
 		Skills:             j.Skills,
 		ExperienceYearsMin: j.ExperienceYearsMin,
 	})
-	return Job{
-		Source:      source,
-		ExternalID:  externalID,
-		URL:         j.URL,
-		Title:       j.Title,
-		Company:     j.Company,
-		CompanySlug: d.CompanySlug,
-		PublicSlug:  d.PublicSlug,
-		Location:    location,
-		Remote:      j.Remote,
-		Description: j.Description,
-		PostedAt:    j.PostedAt,
-		Countries:   d.Countries,
-		Regions:     d.Regions,
-		Cities:      d.Cities,
-		WorkMode:    d.WorkMode,
-		Skills:      d.Skills,
-		Seniority:   d.Seniority,
-		Category:    d.Category,
-
-		PostingLanguage:    d.PostingLanguage,
-		EmploymentType:     d.EmploymentType,
-		EducationLevel:     d.EducationLevel,
-		EnglishLevel:       d.EnglishLevel,
-		ExperienceYearsMin: d.ExperienceYearsMin,
-	}
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/strelov1/freehire/internal/job"
 	"github.com/strelov1/freehire/internal/normalize"
 	"github.com/strelov1/freehire/internal/sources"
 )
@@ -15,18 +16,18 @@ import (
 // the optional closer capability, so it is safe for the runner's concurrent Save/Close calls.
 type fakeStore struct {
 	mu     sync.Mutex
-	saved  []Job
+	saved  []job.Job
 	closed [][2]string
 	err    error
 }
 
-func (s *fakeStore) Save(_ context.Context, job Job) error {
+func (s *fakeStore) Save(_ context.Context, j job.Job) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.err != nil {
 		return s.err
 	}
-	s.saved = append(s.saved, job)
+	s.saved = append(s.saved, j)
 	return nil
 }
 
@@ -135,7 +136,7 @@ func TestRunStreamClosesRemovedJobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(store.saved) != 1 || store.saved[0].ExternalID != ":1" {
+	if len(store.saved) != 1 || store.saved[0].Fields().ExternalID != ":1" {
 		t.Fatalf("saved = %+v, want 1 live job with external_id \":1\"", store.saved)
 	}
 	if len(store.closed) != 1 || store.closed[0] != [2]string{"jobtech", ":2"} {
@@ -186,7 +187,7 @@ func TestRunNormalizesAndNamespaces(t *testing.T) {
 		t.Fatalf("len(saved) = %d, want 1", len(store.saved))
 	}
 
-	j := store.saved[0]
+	j := store.saved[0].Fields()
 	if j.Source != "greenhouse" {
 		t.Errorf("Source = %q, want %q", j.Source, "greenhouse")
 	}
@@ -210,14 +211,22 @@ func TestRunNormalizesAndNamespaces(t *testing.T) {
 func TestNormalizeJobParsesGeographyFromLocation(t *testing.T) {
 	e := sources.CompanyEntry{Company: "Acme", Provider: "greenhouse", Board: "acme"}
 
-	geo := normalizeJob(e, sources.Job{ExternalID: "1", Title: "Dev", Company: "Acme", Location: "Remote - Germany"})
+	geoJob, err := normalizeJob(e, sources.Job{ExternalID: "1", Title: "Dev", Company: "Acme", Location: "Remote - Germany"})
+	if err != nil {
+		t.Fatalf("normalizeJob: %v", err)
+	}
+	geo := geoJob.Fields()
 	if !reflect.DeepEqual(geo.Countries, []string{"de"}) || !reflect.DeepEqual(geo.Regions, []string{"eu"}) {
 		t.Errorf("geography = %v/%v, want [de]/[eu]", geo.Countries, geo.Regions)
 	}
 
 	// A bare "Remote" resolves no country, so it falls into the open-anywhere global
 	// region (its remoteness stays on WorkMode; see location.Parse).
-	bare := normalizeJob(e, sources.Job{ExternalID: "2", Title: "Dev", Company: "Acme", Location: "Remote"})
+	bareJob, err := normalizeJob(e, sources.Job{ExternalID: "2", Title: "Dev", Company: "Acme", Location: "Remote"})
+	if err != nil {
+		t.Fatalf("normalizeJob: %v", err)
+	}
+	bare := bareJob.Fields()
 	if len(bare.Countries) != 0 || !reflect.DeepEqual(bare.Regions, []string{"global"}) {
 		t.Errorf("bare remote geography = %v/%v, want []/[global]", bare.Countries, bare.Regions)
 	}
@@ -228,15 +237,21 @@ func TestNormalizeJobPrefersAdapterWorkModeOverParser(t *testing.T) {
 
 	// The adapter states hybrid structurally; the location text would parse as
 	// remote. The structured signal wins.
-	structured := normalizeJob(e, sources.Job{ExternalID: "1", Title: "Dev", Company: "Acme", Location: "Remote", WorkMode: "hybrid"})
-	if structured.WorkMode != "hybrid" {
-		t.Errorf("WorkMode = %q, want hybrid (adapter structured wins over parser)", structured.WorkMode)
+	structured, err := normalizeJob(e, sources.Job{ExternalID: "1", Title: "Dev", Company: "Acme", Location: "Remote", WorkMode: "hybrid"})
+	if err != nil {
+		t.Fatalf("normalizeJob: %v", err)
+	}
+	if structured.Fields().WorkMode != "hybrid" {
+		t.Errorf("WorkMode = %q, want hybrid (adapter structured wins over parser)", structured.Fields().WorkMode)
 	}
 
 	// No structured signal: the parser fills from the location text.
-	parsed := normalizeJob(e, sources.Job{ExternalID: "2", Title: "Dev", Company: "Acme", Location: "Remote"})
-	if parsed.WorkMode != "remote" {
-		t.Errorf("WorkMode = %q, want remote (parser fallback)", parsed.WorkMode)
+	parsed, err := normalizeJob(e, sources.Job{ExternalID: "2", Title: "Dev", Company: "Acme", Location: "Remote"})
+	if err != nil {
+		t.Fatalf("normalizeJob: %v", err)
+	}
+	if parsed.Fields().WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (parser fallback)", parsed.Fields().WorkMode)
 	}
 }
 
@@ -259,7 +274,7 @@ func TestRunIsolatesSourceFailure(t *testing.T) {
 	if stats.Total().Ingested != 1 {
 		t.Errorf("stats.Total().Ingested = %d, want 1 (the healthy board)", stats.Total().Ingested)
 	}
-	if len(store.saved) != 1 || store.saved[0].Source != "greenhouse" {
+	if len(store.saved) != 1 || store.saved[0].Fields().Source != "greenhouse" {
 		t.Errorf("only the healthy board's job should be saved, got %+v", store.saved)
 	}
 }
@@ -311,6 +326,32 @@ func TestRunIsolatesPerJobSaveError(t *testing.T) {
 	}
 }
 
+// TestRunSkipsInvalidDraft proves the runner does not persist a posting the
+// aggregate factory rejects (here an empty title): job.New returns ErrInvalidDraft,
+// so the job is skipped rather than upserted as junk. Not every adapter filters a
+// blank title, so this guard lives in the shared write path.
+func TestRunSkipsInvalidDraft(t *testing.T) {
+	src := fakeSource{provider: "greenhouse", jobs: []sources.Job{
+		{ExternalID: "1", Title: "", Company: "Acme"}, // no title → invalid draft
+		{ExternalID: "2", Title: "Real Job", Company: "Acme"},
+	}}
+	store := &fakeStore{}
+	r := Runner{Registry: registry(src), Store: store}
+
+	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "Acme", Provider: "greenhouse", Board: "acme"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(store.saved) != 1 {
+		t.Fatalf("len(saved) = %d, want 1 (the empty-title posting is skipped, not saved as junk)", len(store.saved))
+	}
+	if stats.Total().Ingested != 1 || stats.Total().Skipped != 1 {
+		t.Errorf("stats = %+v, want Ingested=1 Skipped=1", stats.Total())
+	}
+}
+
 func TestRunCountsUnknownProviderAsFailed(t *testing.T) {
 	store := &fakeStore{}
 	r := Runner{Registry: registry(), Store: store}
@@ -327,29 +368,36 @@ func TestRunCountsUnknownProviderAsFailed(t *testing.T) {
 }
 
 func TestNormalizeJobDerivesSkills(t *testing.T) {
-	got := normalizeJob(
+	dj, err := normalizeJob(
 		sources.CompanyEntry{Provider: "greenhouse", Board: "acme"},
 		sources.Job{
 			Title: "Backend Engineer", Company: "Acme", ExternalID: "1",
 			Description: "<p>Build services in Golang with PostgreSQL and Kubernetes.</p>",
 		},
 	)
+	if err != nil {
+		t.Fatalf("normalizeJob: %v", err)
+	}
 	want := []string{"go", "kubernetes", "postgresql"}
-	if !reflect.DeepEqual(got.Skills, want) {
-		t.Fatalf("Skills = %#v, want %#v", got.Skills, want)
+	if got := dj.Fields().Skills; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Skills = %#v, want %#v", got, want)
 	}
 }
 
 func TestNormalizeJobDerivesClassification(t *testing.T) {
-	job := normalizeJob(
+	dj, err := normalizeJob(
 		sources.CompanyEntry{Provider: "greenhouse", Board: "acme", Company: "Acme"},
 		sources.Job{ExternalID: "1", Title: "Senior Backend Engineer", Description: "x"},
 	)
-	if job.Seniority != "senior" {
-		t.Errorf("Seniority = %q, want senior", job.Seniority)
+	if err != nil {
+		t.Fatalf("normalizeJob: %v", err)
 	}
-	if job.Category != "backend" {
-		t.Errorf("Category = %q, want backend", job.Category)
+	f := dj.Fields()
+	if f.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior", f.Seniority)
+	}
+	if f.Category != "backend" {
+		t.Errorf("Category = %q, want backend", f.Category)
 	}
 }
 

--- a/openspec/changes/job-domain-aggregate/.openspec.yaml
+++ b/openspec/changes/job-domain-aggregate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/job-domain-aggregate/design.md
+++ b/openspec/changes/job-domain-aggregate/design.md
@@ -1,0 +1,148 @@
+## Context
+
+`Job` is the core entity but exists only as two anemic shapes: `db.Job` (the sqlc
+persistence row) and `jobview.Job` (the wire model built by `FromRow(db.Job)`).
+A valid job is *assembled* — normalize + derive facets + mint slugs — in three
+write paths (`pipeline.normalizeJob`, `moderation` create/edit, `tg-extract`), each
+duplicating the ritual by discipline. `tg-extract` has already diverged (it derives
+inline, bypassing `jobderive`). Lifecycle (open/closed/reopen) and enrichment
+eligibility live in raw SQL predicates. This is a live MVP ingest flow: the write
+path runs every crawl, so behavior must be preserved while its guardianship moves
+into an aggregate.
+
+A key finding shapes the design: the two shapes are not the same field set.
+
+- **Write draft** (`pipeline.Job`): fields a write path supplies and derives —
+  source/external_id, title, company, location, description, posted_at, the six
+  dictionary facets, slugs, and the synthetic enrichment facets.
+- **Read projection** (`db.Job` as read by `jobview.FromRow`): the above *plus*
+  persistence- and cross-aggregate-computed fields — `ID`, `ViewCount`,
+  `AppliedCount`, `Collections`, `Enrichment` (JSONB), `EnrichedAt`,
+  `EnrichmentVersion`, `CreatedAt`/`UpdatedAt`/`ClosedAt`, `CreatedBy`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One guarded construction door: `job.New(Draft)` is the only way to build a fresh
+  `Job`; it derives facets internally so all write paths are identical.
+- A domain `Job` type distinct from `db.Job`, loaded/persisted through a
+  `job.Repository` port with a `QueriesRepository` adapter over the shared queries.
+- `jobview` projects from the domain `Job` (`FromDomain`) instead of `db.Job`,
+  closing the persistence→wire leak. Wire output stays byte-equivalent.
+- Lifecycle + `ShouldEnrich` become guarded aggregate methods; the three SQL close
+  paths and the enrichment predicate express their decision through the aggregate.
+
+**Non-Goals:**
+- Splitting the 119-method `db.Queries` per context. The port sits on top of it.
+- Rewriting the `UpsertJob`/outbox write-path transaction or moving closing into a
+  single new transaction. The SQL queries stay; only the *decision* moves.
+- Making `Job` a rich behavioral aggregate. It stays data-centric — the value is the
+  single door and invariant location, not behavior richness.
+- Changing *when* a job closes, *whether* it enriches, or *what* facets are derived.
+
+## Decisions
+
+### D1. One domain type, two entry points
+
+`job.Job` is a single struct. Two ways to obtain one:
+- `job.New(Draft) (Job, error)` — a *fresh* job for the write path. Runs `jobderive`
+  internally; persistence-computed fields are zero (id 0, counts 0, not enriched,
+  open).
+- `Repository.Load(ctx, identity) (Job, error)` — a *hydrated* job with all fields
+  populated from storage.
+
+*Alternative considered:* separate `NewJob` (write) and `JobView` (read) types. Rejected
+— it reintroduces the very split we are removing and doubles the mapping surface.
+
+### D2. The aggregate boundary excludes engagement counts and collections
+
+`ViewCount`, `AppliedCount`, and `Collections` are **not** `Job` aggregate state — they
+are projections of *other* aggregates (`user_jobs`, `job_collections`). Folding them
+into `job.Job` would make the aggregate own data it cannot enforce. So the domain
+`Job` carries intrinsic fields + facets + lifecycle + typed `enrichment`; the
+projection supplies the cross-aggregate extras:
+
+```
+jobview.FromDomain(j job.Job, x job.Extras) (jobview.Job, error)
+   where job.Extras = { ViewCount, AppliedCount int32; Collections []string }
+```
+
+**Resolved:** the clean-aggregate option was chosen — `job.Job` stays free of counts
+and collections; a separate `job.Extras` carrier holds them. **The carrier lives in the
+`job` package, not `jobview`** — the repository's `Load` returns `(Job, Extras, error)`,
+and if `Extras` lived in `jobview` the domain would import the wire layer (a layering
+inversion). `jobview.FromDomain(job.Job, job.Extras)` keeps the dependency arrow
+`jobview → job`. A fresh `New` has no `Extras`; only `Load` populates one (via
+`extrasFromRow`). *Alternative:* put counts on `job.Job` for convenience — rejected on
+aggregate-boundary grounds; it would blur the write surface with read-only fields.
+
+### D3. Repository port mirrors the existing `jobtracking` convention
+
+`type Repository interface { Load(...); Upsert(...); Close(...); Reopen(...) }` with
+`QueriesRepository` adapting `*db.Queries`, and a `var _ Repository = (*QueriesRepository)(nil)`
+compile-time assertion — the same shape `jobtracking` already ships, so the codebase
+gains no new pattern, only a second instance of an established one.
+
+### D4. The aggregate owns the *decision*, the repository owns the *persistence*
+
+Lifecycle methods do not run SQL. `job.Close(reason)` mutates in-memory state
+idempotently (sets `closedAt` if unset, preserves slug/enrichment); the repository's
+`Close`/`Upsert` performs the write via the existing `CloseUnseenJobs` /
+`CloseJobBySourceExternalID` queries. `ShouldEnrich()` returns `open && version < current`
+— the enrichment queue keeps its SQL filter, but the canonical rule is readable on the
+type and the predicate is asserted equivalent in a test. This keeps the non-goal
+(no transaction rewrite) intact while giving the rule one home.
+
+### D5. Migration order preserves behavior; `tg-extract` is switched last, intentionally changing its output
+
+Build the aggregate + a golden-equivalence test (`FromDomain(loaded) ≡ FromRow(row)`
+and `New(draft) ≡ normalizeJob`) BEFORE switching any caller. Then switch callers one
+at a time under green golden tests: `pipeline` → `moderation` → `tg-extract`. For
+`pipeline` and `moderation` the switch is behavior-neutral (same `jobderive` output).
+For `tg-extract` the switch **changes** its facet output — that is the intended bug
+fix (it stops deriving inline). Call it out: after the switch, re-ingested Telegram
+jobs get dictionary-consistent facets, so a `cmd/reindex` is warranted to refresh
+existing tg documents.
+
+## Risks / Trade-offs
+
+- **[Factory output drifts from `normalizeJob`, breaking live ingest]** → Gate every
+  caller switch behind a golden test asserting `job.New(draft)` reproduces the current
+  `normalizeJob` struct field-for-field before deleting the old assembly.
+- **[Projection output drifts, changing the public API]** → Golden test asserting
+  `FromDomain` emits byte-equivalent JSON to `FromRow` for a representative fixture
+  (enriched, unenriched, closed, with/without counts) before switching read callers.
+- **[`tg-extract` facet change ripples to existing rows]** → Expected and desired;
+  documented as a post-switch `reindex`. Scope is only Telegram-sourced jobs.
+- **[Aggregate-boundary bikeshedding on counts/collections]** → Resolved by D2; the
+  `Extras` carrier keeps the boundary explicit and testable.
+- **[Enrichment JSONB ↔ typed round-trip loses raw LLM values]** → The domain type
+  parses `enrichment` for projection but the repository persists the JSONB verbatim on
+  `Upsert` (write path never touches `enrichment`, per the existing decoupling of
+  `SetJobEnrichment` from `UpsertJob`). No round-trip on the write path.
+
+## Migration Plan
+
+1. Add `internal/job` (type, `New`, `Repository` port + `QueriesRepository` adapter,
+   lifecycle methods) with unit tests. No caller changes yet.
+2. Add `jobview.FromDomain` + `Extras`; golden test vs `FromRow`. Keep `FromRow` as a
+   thin shim delegating to `FromDomain` so read callers are untouched initially.
+3. Switch `pipeline.normalizeJob` to `job.New`; golden test gates it. Delete the old
+   inline assembly.
+4. Switch `moderation` create/edit to `job.New`.
+5. Switch `tg-extract` to `job.New`; drop inline derivation. Note reindex.
+6. Route the three close paths + enrichment predicate through the aggregate methods.
+7. Repoint read callers from `FromRow` to `FromDomain`; remove the `FromRow` shim.
+
+**Rollback:** each step is an independent commit behind a golden test; reverting any
+single step leaves the tree green because the shims (`FromRow` delegating, callers
+switched one at a time) keep both paths valid until the final cleanup.
+
+## Open Questions
+
+- Should `job.Repository` expose a narrow `Load`-by-identity only, or also the
+  batch/list loads `jobview.FromRows` feeds? Leaning narrow first (identity + upsert +
+  close), leaving list projection reading `db.Job` slices through a `FromDomain`-per-row
+  shim, to avoid a large read-query migration in this change.
+- Does `moderation`'s edit path need `Reopen()` semantics, or is edit always on an open
+  job? To confirm against `moderation.go` during task 4.

--- a/openspec/changes/job-domain-aggregate/proposal.md
+++ b/openspec/changes/job-domain-aggregate/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+A valid `Job` is assembled in at least three write paths — `pipeline.normalizeJob`
+(ingest), `moderation` create/edit, and `tg-extract` — and each must remember to
+run the same `jobderive` derivation ritual before persisting. This invariant lives
+in developer discipline, not in the type system, and it has **already diverged**:
+`tg-extract/store.go` derives facets inline instead of through `jobderive`, so a
+Telegram-sourced job can carry facets that a board-sourced identical posting would
+not. There is no single place where a `Job` guards its own invariants; the read
+model (`jobview.FromRow(db.Job)`) is built straight from the sqlc persistence row,
+and lifecycle rules (open/closed/reopen, `ShouldEnrich`) are scattered across raw
+SQL. Introducing a `Job` domain aggregate closes the divergence class of bug and
+gives the core entity one guarded door.
+
+## What Changes
+
+- **New `internal/job` package** holding the `Job` domain aggregate: a storage- and
+  transport-agnostic type that owns its invariants.
+- **Single construction door** — `job.New(Draft)` is the *only* way to build a `Job`.
+  It runs `jobderive` internally, so facets are always consistent with the source
+  fields. The raw `Job{...}` composite literal is no longer constructed by callers.
+- **Switch all write paths to the factory** — `pipeline.normalizeJob`,
+  `moderation` create + edit, and `tg-extract`'s store all go through `job.New`,
+  **removing `tg-extract`'s inline derivation** and its divergence.
+- **Repository port over the shared `Queries`** — a `job.Repository` interface with a
+  `QueriesRepository` adapter (mirroring the existing `jobtracking` pattern) that
+  loads a `db.Job` into the domain `Job` and persists it back. The 119-method
+  `db.Queries` is **not** split by context; the port sits on top of it.
+- **Close the persistence→wire leak** — `jobview` projects from the domain `Job`
+  (`jobview.FromDomain(job.Job)`) instead of `jobview.FromRow(db.Job)`. The public
+  wire shape stops depending on the sqlc row.
+- **Lifecycle + enrichment rules become aggregate behavior** — `Close(reason)`,
+  `Reopen()`, and `ShouldEnrich()` become guarded methods on `Job`; the three SQL
+  close paths (`CloseUnseenJobs`, `CloseJobBySourceExternalID`, liveness) and the
+  enrichment-eligibility predicate route their rule through the aggregate.
+- **Non-goals (explicit):** no splitting of `db.Queries` per context; no rewrite of
+  the `UpsertJob`/outbox write-path transaction; no change to *when* a job closes or
+  *what* facets are derived — behavior is preserved, only its guardianship moves.
+
+## Capabilities
+
+### New Capabilities
+
+- `job-aggregate`: The `Job` domain aggregate — a single guarded factory as the only
+  construction path (deriving facets internally), a domain type loaded and persisted
+  through a repository port, wire projection from the domain type, and guarded
+  lifecycle/enrichment-eligibility behavior.
+
+### Modified Capabilities
+
+- `deterministic-facets`: strengthen the derivation guarantee from "each write path
+  calls `jobderive`" (a convention) to "every write path constructs jobs through the
+  aggregate factory, so facet derivation cannot diverge between sources" (a
+  type-enforced invariant). This is the spec-level change that makes the `tg-extract`
+  divergence unrepresentable.
+
+## Impact
+
+- **New code:** `internal/job/` (aggregate, factory, repository port + adapter).
+- **Modified code:** `internal/pipeline` (normalizeJob → factory), `internal/moderation`
+  (create/edit → factory), `cmd/tg-extract` (drop inline derive → factory),
+  `internal/jobview` (FromRow → FromDomain; stops importing shape from `db.Job`
+  directly), and the lifecycle/enrichment call sites that own close/eligibility rules.
+- **Unchanged:** `db.Queries` surface, migrations, the outbox/enrichment transaction,
+  search indexing behavior, and all observable API/wire output (projection is
+  equivalent to today's `FromRow`).
+- **Risk:** live MVP ingest flow — the write path is exercised every crawl. Mitigated
+  by preserving behavior (factory output ≡ today's `normalizeJob` output) and by
+  golden-equivalence tests before switching each caller.

--- a/openspec/changes/job-domain-aggregate/specs/deterministic-facets/spec.md
+++ b/openspec/changes/job-domain-aggregate/specs/deterministic-facets/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: The six dictionary facets are sourced solely from the deterministic dictionaries
+
+The system SHALL store the deterministic, dictionary-derived facets —
+`countries`, `regions`, `work_mode`, `skills`, `seniority`, `category` — in the
+`jobs` table columns as source facts, computed by the curated dictionaries
+(`jobderive`, wrapping `location`/`skilltag`/`classify`), and SHALL derive them
+through the `Job` aggregate factory (`job.New`) on every write path, so the
+derivation cannot diverge between the ingest, moderator-authoring, and Telegram
+paths. The public read model (`jobview`, projecting from the domain `Job` via
+`jobview.FromDomain`) SHALL source these six facets from the `jobs` columns ONLY.
+It SHALL NOT union the multi-valued facets (`countries`/`regions`/`skills`) with
+their `enrichment` counterparts, and it SHALL NOT let the LLM-derived
+`enrichment.work_mode`/`enrichment.seniority`/`enrichment.category` override or
+fall back into the served scalar facets. The dictionaries emit nothing for what
+they cannot resolve, so an unresolved facet is served empty rather than filled
+from the LLM.
+
+#### Scenario: A multi-valued facet drops the LLM contribution
+
+- **WHEN** a job has `skills=[go]` from the dictionary and
+  `enrichment.skills=[go, kubernetes]` from the LLM, and is read
+- **THEN** the served `skills` is `[go]` (the LLM's `kubernetes` is not unioned in)
+
+#### Scenario: A scalar facet is the dictionary value, never the LLM's
+
+- **WHEN** a job has `seniority=middle` from the title dictionary and
+  `enrichment.seniority=senior` from the LLM, and is read
+- **THEN** the served `seniority` is `middle`
+
+#### Scenario: A dictionary-silent facet is served empty, not from the LLM
+
+- **WHEN** a job has an empty `category` column (the title dictionary resolved
+  nothing) and `enrichment.category=backend` from the LLM, and is read
+- **THEN** the served `category` is empty
+
+#### Scenario: The Telegram path derives facets identically to ingest
+
+- **WHEN** a Telegram-extracted posting and a board-ingested posting carry the same
+  title, description, and location
+- **THEN** they resolve the same dictionary facets, because both construct their
+  `Job` through the aggregate factory rather than deriving inline

--- a/openspec/changes/job-domain-aggregate/specs/job-aggregate/spec.md
+++ b/openspec/changes/job-domain-aggregate/specs/job-aggregate/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: A Job is constructed only through the aggregate factory
+
+The system SHALL expose a single construction path for a `Job` domain value — a
+factory (`job.New`) taking a source-agnostic draft of the raw posting fields — and
+SHALL NOT allow callers to assemble a `Job` from a raw composite literal outside the
+`job` package. The factory SHALL run the deterministic derivation (`jobderive`,
+wrapping `location`/`skilltag`/`classify`/`roletag` and the public-identity slugs)
+internally, so a constructed `Job` always carries facets consistent with its source
+fields. Every write path that persists a posting — automated ingest, moderator
+authoring, and Telegram extraction — SHALL obtain its `Job` from this factory.
+
+#### Scenario: Every write path derives facets identically
+
+- **WHEN** the ingest pipeline, the moderator authoring path, and Telegram
+  extraction each construct a job from the same title, description, and location
+- **THEN** all three produce the same dictionary facets (`countries`, `regions`,
+  `work_mode`, `skills`, `seniority`, `category`) and the same public/company slugs,
+  because each obtains its `Job` through `job.New`
+
+#### Scenario: Facets cannot be omitted
+
+- **WHEN** a caller constructs a `Job` through the factory and never touches the
+  facet fields
+- **THEN** the resulting `Job` still carries the derived facets, because derivation
+  happens inside `job.New` rather than in caller code
+
+### Requirement: The domain Job is loaded and persisted through a repository port
+
+The `job` package SHALL define a `Repository` port (interface) for loading a domain
+`Job` by identity and persisting it, and SHALL provide a `QueriesRepository` adapter
+implementing that port over the shared `*db.Queries`. The domain `Job` type SHALL NOT
+be `db.Job`; the adapter SHALL map between the persistence row and the domain type.
+The shared `db.Queries` surface SHALL NOT be split per context by this change — the
+port sits on top of the existing generated queries.
+
+#### Scenario: The adapter maps persistence to domain
+
+- **WHEN** the repository loads a stored posting by its `(source, external_id)` identity
+- **THEN** it returns a domain `Job` value, not a `db.Job` row, and callers depend on
+  the domain type only
+
+#### Scenario: A compile-time contract binds adapter to port
+
+- **WHEN** the package compiles
+- **THEN** a `var _ Repository = (*QueriesRepository)(nil)` assertion proves the
+  adapter satisfies the port, mirroring the existing `jobtracking` convention
+
+### Requirement: The public wire shape projects from the domain Job
+
+The public read model SHALL be projected from the domain `Job` type
+(`jobview.FromDomain`), not built directly from the persistence row. The `jobview`
+package SHALL depend on the `job` aggregate for its input shape rather than on the
+raw `db.Job` row. The projected wire output SHALL be observably equivalent to the
+current `jobview.FromRow(db.Job)` output — this change relocates the source of the
+projection, not its result.
+
+#### Scenario: Wire output is unchanged by the projection move
+
+- **WHEN** a stored job is projected to the wire shape through the domain type
+- **THEN** the emitted JSON is byte-equivalent to what `jobview.FromRow` produced for
+  the same stored row before this change
+
+### Requirement: Lifecycle and enrichment eligibility are guarded aggregate behavior
+
+The domain `Job` SHALL expose its lifecycle transitions and enrichment-eligibility
+rule as guarded methods — `Close(at)` (idempotent; preserves `public_slug`,
+`enrichment`, and interaction references), `Reopen()`, and `ShouldEnrich()` (open and
+below the current enrichment version). The three close mechanisms (the ingest unseen
+sweep, the stream-driven self-close, and the liveness probe) and the enrichment
+eligibility predicate SHALL express their decision through the aggregate rather than
+duplicating the open/closed condition. This change SHALL NOT alter *when* a job closes
+or *whether* it is enriched — only where the rule lives.
+
+#### Scenario: Closing is idempotent and non-destructive
+
+- **WHEN** `Close(at)` is called on an already-closed `Job`
+- **THEN** the operation is a no-op that leaves `closed_at`, `public_slug`, and
+  enrichment intact
+
+#### Scenario: A closed job is not enrichment-eligible
+
+- **WHEN** `ShouldEnrich()` is evaluated on a closed `Job`
+- **THEN** it returns false, matching today's `closed_at IS NULL` guard in the
+  enrichment queue
+
+#### Scenario: Reopen clears the closed state on re-ingest
+
+- **WHEN** a previously closed posting reappears in its source feed and is upserted
+- **THEN** `Reopen()` clears `closed_at` and the job is served on list/search surfaces
+  again

--- a/openspec/changes/job-domain-aggregate/tasks.md
+++ b/openspec/changes/job-domain-aggregate/tasks.md
@@ -1,0 +1,89 @@
+## 1. Aggregate core (no caller changes)
+
+- [x] 1.1 Create `internal/job` package with the domain `Job` type: intrinsic fields
+  (identity, source posting fields, the six dictionary facets, slugs, synthetic
+  facets), lifecycle state (`closedAt`), and typed `enrichment`; exclude engagement
+  counts and collections per design D2. Unit test the type's zero value and field
+  invariants.
+- [x] 1.2 Implement `job.Draft` (the source-agnostic write input) and
+  `job.New(Draft) (Job, error)` running `jobderive` internally. Test: a draft with a
+  known title/location/description yields the expected facets and slugs, and the same
+  draft always yields the same `Job`.
+- [x] 1.3 Add a golden-equivalence test proving `job.New(draft)` reproduces the current
+  `pipeline.normalizeJob` output field-for-field for a representative fixture set
+  (remote/onsite, resolved/unresolved facets, structured source signals).
+- [x] 1.4 Implement guarded lifecycle + eligibility methods: `Close(at)`
+  (idempotent, preserves slug/enrichment), `Reopen()`, `ShouldEnrich()` (open &&
+  version < current). Unit test idempotent close, reopen clears state, and
+  `ShouldEnrich` matches the `closed_at IS NULL AND version <` predicate.
+
+## 2. Repository port + adapter
+
+- [x] 2.1 Define the `job.Repository` port (Load by identity + Close by identity)
+  and a `QueriesRepository` adapter over `*db.Queries` with a
+  `var _ Repository = (*QueriesRepository)(nil)` assertion, mirroring `jobtracking`.
+  (Upsert/Reopen-persistence deferred to group 4 — see 4.0 — where the content-hash
+  signal and the re-ingest consumer live; the port grows there.)
+- [x] 2.2 Implement `QueriesRepository.Load` via `jobFromRow` (anti-corruption map
+  `db.Job`→domain, incl. enrichment JSONB decode + pgtype→domain), added query
+  `GetJobBySourceExternalID`. Unit test on the mapping + testcontainer integration test
+  (`//go:build integration`) for Load/Close/NotFound.
+- [x] 2.3 Implement `Close` on the adapter delegating to `CloseJobBySourceExternalID`
+  (idempotent 0-rows on already-closed), integration-verified.
+
+## 3. Wire projection from the domain type
+
+- [x] 3.1 Add `job.Extras` (in the job pkg, not jobview — avoids a domain→wire import) (ViewCount, AppliedCount, Collections) and
+  `jobview.FromDomain(job.Job, Extras) (Job, error)`; move the dict-only enrichment
+  override logic into the projection.
+- [x] 3.2 Golden test pins `FromDomain` output against a FROZEN wire-shape oracle
+  (JSON literals captured from the original FromRow), covering enriched/unenriched/
+  closed/geo-hybrid — an independent oracle, not a tautology vs the shim (review fix).
+- [x] 3.3 Reduce `jobview.FromRow` to a thin shim: map `db.Job` → `job.Job` + `Extras`
+  and delegate to `FromDomain`, so existing read callers stay untouched for now.
+
+## 4. Switch write paths to the factory
+
+- [~] 4.0 DROPPED (scope call): a repository `Upsert` was NOT added. The ingest write is a
+  cohesive transaction (UpsertJob + EnqueueJobEnrichment + best-effort index) that the design
+  non-goal protects ("no transaction rewrite"); a partial repository.Upsert centralizes nothing
+  and adds a seam. Instead `cmd/ingest/dbStore.Save` maps `job.Fields()`→`UpsertJobParams`
+  inline (hashes + tx + index unchanged). Goal 1 (single door) is delivered at CONSTRUCTION
+  time via `job.New`, not persistence.
+
+- [x] 4.1 SEALED the ingest write path: `normalizeJob`→`(job.Job, error)` via `job.New`;
+  deleted the `pipeline.Job` struct; `Store.Save` now takes `job.Job` (only a factory
+  product persists); both loops skip `ErrInvalidDraft` (empty title/identity) instead of
+  upserting junk (new test `TestRunSkipsInvalidDraft`); `dbStore.Save` maps `Fields()`→params.
+  Golden 1.3 removed (became tautological post-switch; job.New is unit-tested). Full suite green.
+- [x] 4.2 Switched `moderation` Create + Update to `job.New` (via a `derive` helper);
+  removed the direct `jobderive` calls. Behavior delta: moderator jobs now store a
+  CleanLocation'd location (consistent with ingest; no-op for tail-less locations).
+  Edit path stays a plain update (no reopen needed). Tests green (fixed one unrealistic
+  fixture lacking identity).
+- [x] 4.3 Switched `cmd/tg-extract` Complete + CompleteLinks to `job.New` (via
+  `buildParams`), REMOVING the inline derivation — fixes the real divergence (inline
+  path missed jobderive's geo-restriction/usOnly logic). Invalid extracted jobs skip
+  (logged) instead of persisting junk. Added `TestNew_FacetsIndependentOfWritePath`
+  (spec deterministic-facets Telegram scenario). Review confirmed non-tech category
+  fallback + WorkMode precedence preserved. DEPLOY NOTE: run `cmd/reindex` after deploy
+  to refresh existing tg rows whose facets now differ.
+
+## 5. Route lifecycle + enrichment through the aggregate
+
+- [ ] 5.1 Route the three close mechanisms (ingest unseen sweep, stream self-close,
+  liveness) through the aggregate `Close` decision + repository persistence, without
+  changing when a job closes. Existing lifecycle tests stay green.
+- [ ] 5.2 Express the enrichment-eligibility rule through `ShouldEnrich()` at the
+  enqueue site; keep the SQL queue filter but assert equivalence in a test.
+
+## 6. Repoint reads and clean up
+
+- [ ] 6.1 Repoint read/list callers from `jobview.FromRow` to `FromDomain` (via the
+  narrow per-row `db.Job → job.Job` map for list slices per design Open Question);
+  remove the `FromRow` shim once no caller depends on it.
+- [ ] 6.2 Run `go build ./... && go vet ./... && go test ./...` (+ integration tag for
+  DB tests); confirm `internal/jobview` no longer imports `db.Job` as its projection
+  input shape and only `job`/adapter maps persistence.
+- [ ] 6.3 Update `AGENT.md` conventions: document the `job` aggregate as the single
+  construction door and the projection direction (domain → wire).

--- a/openspec/changes/job-domain-aggregate/tasks.md
+++ b/openspec/changes/job-domain-aggregate/tasks.md
@@ -71,19 +71,29 @@
 
 ## 5. Route lifecycle + enrichment through the aggregate
 
-- [ ] 5.1 Route the three close mechanisms (ingest unseen sweep, stream self-close,
-  liveness) through the aggregate `Close` decision + repository persistence, without
-  changing when a job closes. Existing lifecycle tests stay green.
-- [ ] 5.2 Express the enrichment-eligibility rule through `ShouldEnrich()` at the
-  enqueue site; keep the SQL queue filter but assert equivalence in a test.
+- [~] 5.1 SCOPED OUT (ceremony/perf): the three close paths stay set-based SQL. The
+  canonical rule already lives on the aggregate (`Close`/`Reopen`, group 1); routing the
+  bulk `CloseUnseenJobs` sweep through per-job `aggregate.Close()` would be N loads+writes
+  vs one `UPDATE` — a perf anti-pattern the design D4 explicitly anticipated ("aggregate
+  owns the decision, repository/SQL owns the performant persistence"). No behavior change
+  is available here, so the churn is unjustified. The repository `Close` (group 2) is the
+  by-identity home when a caller wants it.
+- [x] 5.2 Pinned `ShouldEnrich()` equivalent to the SQL enqueue predicate with an
+  integration test (`TestShouldEnrich_MatchesEnqueuePredicate`): seeds open-v0 / open-v1 /
+  closed-v0, runs `EnqueuePendingJobs`, asserts the aggregate rule agrees with outbox
+  membership per job — guards the rule and the set-based SQL from drifting apart.
 
 ## 6. Repoint reads and clean up
 
-- [ ] 6.1 Repoint read/list callers from `jobview.FromRow` to `FromDomain` (via the
-  narrow per-row `db.Job → job.Job` map for list slices per design Open Question);
-  remove the `FromRow` shim once no caller depends on it.
-- [ ] 6.2 Run `go build ./... && go vet ./... && go test ./...` (+ integration tag for
-  DB tests); confirm `internal/jobview` no longer imports `db.Job` as its projection
-  input shape and only `job`/adapter maps persistence.
-- [ ] 6.3 Update `AGENT.md` conventions: document the `job` aggregate as the single
-  construction door and the projection direction (domain → wire).
+- [~] 6.1 SCOPED OUT (cosmetic): `jobview.FromRow` stays as a thin, clean adapter over
+  `job.FromRow` → `FromDomain`. The persistence→wire leak is already closed — the projection
+  LOGIC (`FromDomain`) depends only on domain types. Removing the shim would spread its
+  two-line hydration across ~10 read call sites (handlers/search) for zero behavior change,
+  which contradicts "no overengineering". The shim keeps read callers untouched.
+- [x] 6.2 Verified: `go build`/`go vet`/`go test ./...` green (57 pkgs) + `-tags=integration`
+  for the DB tests. `internal/jobview` imports `db` in ONE place only — the deliberate
+  `FromRow` shim (+ `FromRows`); the projection input shape is now `job.Job`/`job.Extras`,
+  not `db.Job`.
+- [x] 6.3 Updated `AGENT.md`: added the `internal/job` aggregate to the layout as the single
+  construction door (built only via `job.New`/repository Load), and noted `jobview` now
+  projects from the aggregate via `FromDomain`.


### PR DESCRIPTION
## Summary

Reshape the anemic `Job` (a `db.Job` row + a `jobview.Job` built from it) into a **sealed domain aggregate** built only through `job.New` (the factory that derives facets) or a repository `Load`, and route **every write path** through it.

Planned and executed via OpenSpec change `job-domain-aggregate` (spec-driven TDD).

## Why

A valid job was assembled — normalize + derive facets + mint slugs — in three write paths (`pipeline`, `moderation`, `tg-extract`), each repeating the `jobderive` ritual by discipline. `tg-extract` had **already diverged** (it derived inline, missing `jobderive`'s geo-restriction logic), so a Telegram posting could carry different facets than an identical board posting.

## What changed

- **`internal/job`** — sealed `Job` (unexported state; only `New`/`Load` construct it); `job.New(Draft)` single factory; guarded lifecycle (`Close`/`Reopen`/`ShouldEnrich`); `Repository` port (Load/Close) + `QueriesRepository` adapter with `db.Job`→domain ACL mapping; read-only `Extras` carrier for engagement counts/collections (kept out of the aggregate).
- **`jobview.FromDomain(job.Job, job.Extras)`** is the projection source of truth; `FromRow` is now a thin shim over it — persistence→wire leak closed. Pinned byte-equivalent by a **frozen golden oracle**.
- **Write paths sealed**: `pipeline.Store.Save` takes `job.Job` (`pipeline.Job` deleted); moderation Create/Update and tg-extract Complete/CompleteLinks build via `job.New`. Postings the factory rejects (empty title/identity) are **skipped, not upserted as junk**.
- **tg-extract divergence fixed** — now derives identically to ingest.
- Added query `GetJobBySourceExternalID` (sqlc regen).

## Behavior deltas (intended)

- **tg-extract facets** now match the shared dictionaries. ⚠️ **DEPLOY: run `cmd/reindex` after deploy** to refresh existing Telegram rows.
- **moderation** now stores a `CleanLocation`'d location (consistent with ingest; no-op for tail-less locations).

Everything else is behavior-preserving (frozen golden oracle + full suite).

## Scope calls (documented in `tasks.md`)

- **4.0 / 5.1 dropped** — routing the bulk `CloseUnseenJobs` sweep through per-job `aggregate.Close()` is a perf anti-pattern the design anticipated; the aggregate holds the canonical rule, set-based SQL stays.
- **6.1 dropped** — removing the `FromRow` shim is cosmetic; the leak is already closed by `FromDomain`.

## Verification

- `go build` ✓ `go vet` ✓ · **57 unit packages** ✓ · **integration** (testcontainer Postgres: repo Load/Close + `ShouldEnrich`↔SQL-predicate equivalence) ✓
- 5 adversarial code reviews → **0 confirmed bugs** (caught + fixed a tautological golden test; confirmed non-tech category fallback preserved).