### PR TITLE
perf(embed): batch the semantic-embedding drain to one Meili task per wave

### DIFF
--- a/cmd/embed/embed_integration_test.go
+++ b/cmd/embed/embed_integration_test.go
@@ -179,7 +179,7 @@ func TestIntegration_EmbedWorkerDrainsQueue(t *testing.T) {
 
 	runner := embed.Runner{Store: newDBStore(pool), Indexer: searchIndexer{client: client}}
 	stats, err := runner.Run(ctx, embed.RunOptions{
-		TargetModel: search.CurrentEmbedderModel(), Concurrency: 2, LeaseSeconds: 300, MaxAttempts: 3,
+		TargetModel: search.CurrentEmbedderModel(), BatchSize: 500, LeaseSeconds: 300, MaxAttempts: 3,
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -241,11 +241,11 @@ func preIndexClosed(t *testing.T, ctx context.Context, client *search.Client, po
 	// The job was seeded already-closed; temporarily treat it as open for the pre-index
 	// by loading and indexing its document directly.
 	ix := searchIndexer{client: client}
-	job, err := newDBStore(pool).Job(ctx, id)
-	if err != nil {
-		t.Fatalf("load closed job: %v", err)
+	jobs, err := newDBStore(pool).Jobs(ctx, []int64{id})
+	if err != nil || len(jobs) != 1 {
+		t.Fatalf("load closed job: rows=%d err=%v", len(jobs), err)
 	}
-	if err := ix.IndexOpen(ctx, job); err != nil {
+	if err := ix.IndexOpen(ctx, jobs); err != nil {
 		t.Fatalf("pre-index closed job: %v", err)
 	}
 	if _, err := pool.Exec(ctx,

--- a/cmd/embed/indexer.go
+++ b/cmd/embed/indexer.go
@@ -8,22 +8,28 @@ import (
 	"github.com/strelov1/freehire/internal/search"
 )
 
-// searchIndexer adapts the search client to embed.Indexer: embed+upsert an open job's
-// vector in place (no swap), or remove a closed job's document. It builds the document
-// from the persisted row (search.FromJob) so a re-embedded job keeps its enrichment
-// facets — the same path the incremental ingest indexer uses.
+// searchIndexer adapts the search client to embed.Indexer: embed+upsert a batch of open
+// jobs' vectors in place (no swap), or remove a batch of closed jobs' documents. It
+// builds each document from the persisted row (search.FromJob) so a re-embedded job
+// keeps its enrichment facets — the same path the incremental ingest indexer uses.
 type searchIndexer struct {
 	client *search.Client
 }
 
-func (ix searchIndexer) IndexOpen(ctx context.Context, job db.Job) error {
-	doc, err := search.FromJob(job)
-	if err != nil {
-		return fmt.Errorf("build document: %w", err)
+func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) error {
+	docs := make([]search.JobDocument, 0, len(jobs))
+	for _, job := range jobs {
+		doc, err := search.FromJob(job)
+		if err != nil {
+			return fmt.Errorf("build document (job %d): %w", job.ID, err)
+		}
+		docs = append(docs, doc)
 	}
-	return ix.client.IndexSemanticJobs(ctx, []search.JobDocument{doc})
+	// IndexSemanticJobs embeds the whole batch (chunked to the backend's limit) and
+	// upserts it as ONE Meilisearch task, so a large backfill isn't per-doc bound.
+	return ix.client.IndexSemanticJobs(ctx, docs)
 }
 
-func (ix searchIndexer) RemoveClosed(ctx context.Context, jobID int64) error {
-	return ix.client.DeleteSemanticJobs(ctx, []int64{jobID})
+func (ix searchIndexer) RemoveClosed(ctx context.Context, ids []int64) error {
+	return ix.client.DeleteSemanticJobs(ctx, ids)
 }

--- a/cmd/embed/main.go
+++ b/cmd/embed/main.go
@@ -58,7 +58,7 @@ func run() int {
 
 	stats, err := runner.Run(ctx, embed.RunOptions{
 		TargetModel:  search.CurrentEmbedderModel(),
-		Concurrency:  ecfg.Concurrency,
+		BatchSize:    ecfg.BatchSize,
 		LeaseSeconds: ecfg.LeaseSeconds,
 		MaxAttempts:  ecfg.MaxAttempts,
 		CallTimeout:  ecfg.CallTimeout,

--- a/cmd/embed/store.go
+++ b/cmd/embed/store.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -14,7 +13,7 @@ import (
 
 // dbStore adapts the generated queries + pool to embed.Store. It is the only place the
 // runner's domain operations meet the DB layer; each success path (stamp/clear + delete
-// outbox) runs in one transaction here.
+// outbox for a whole batch) runs in one transaction here.
 type dbStore struct {
 	pool *pgxpool.Pool
 	q    *db.Queries
@@ -48,27 +47,29 @@ func (s *dbStore) Claim(ctx context.Context, batch, leaseSeconds int) ([]embed.C
 	return out, nil
 }
 
-func (s *dbStore) Job(ctx context.Context, id int64) (db.Job, error) {
-	return s.q.GetJob(ctx, id)
+func (s *dbStore) Jobs(ctx context.Context, ids []int64) ([]db.Job, error) {
+	return s.q.GetJobsByIDs(ctx, ids)
 }
 
-func (s *dbStore) CompleteOpen(ctx context.Context, entry embed.Claimed, model string, hash pgtype.Text) error {
+func (s *dbStore) CompleteOpen(ctx context.Context, entries []embed.Claimed, model string) error {
+	jobIDs, outboxIDs := splitIDs(entries)
 	return s.tx(ctx, func(qtx *db.Queries) error {
-		if err := qtx.StampSemanticEmbedded(ctx, db.StampSemanticEmbeddedParams{
-			Model: model, Hash: hash, ID: entry.JobID,
+		if err := qtx.StampSemanticEmbeddedBatch(ctx, db.StampSemanticEmbeddedBatchParams{
+			Model: model, Ids: jobIDs,
 		}); err != nil {
 			return fmt.Errorf("stamp: %w", err)
 		}
-		return qtx.DeleteSemanticEntry(ctx, entry.OutboxID)
+		return qtx.DeleteSemanticEntriesBatch(ctx, outboxIDs)
 	})
 }
 
-func (s *dbStore) CompleteClosed(ctx context.Context, entry embed.Claimed) error {
+func (s *dbStore) CompleteClosed(ctx context.Context, entries []embed.Claimed) error {
+	jobIDs, outboxIDs := splitIDs(entries)
 	return s.tx(ctx, func(qtx *db.Queries) error {
-		if err := qtx.ClearSemanticEmbedded(ctx, entry.JobID); err != nil {
+		if err := qtx.ClearSemanticEmbeddedBatch(ctx, jobIDs); err != nil {
 			return fmt.Errorf("clear: %w", err)
 		}
-		return qtx.DeleteSemanticEntry(ctx, entry.OutboxID)
+		return qtx.DeleteSemanticEntriesBatch(ctx, outboxIDs)
 	})
 }
 
@@ -82,6 +83,17 @@ func (s *dbStore) Fail(ctx context.Context, outboxID int64, errMsg string, maxAt
 		return false, err
 	}
 	return row.FailedAt.Valid, nil
+}
+
+// splitIDs pulls the parallel job-id and outbox-id slices a batch completion needs.
+func splitIDs(entries []embed.Claimed) (jobIDs, outboxIDs []int64) {
+	jobIDs = make([]int64, len(entries))
+	outboxIDs = make([]int64, len(entries))
+	for i, e := range entries {
+		jobIDs[i] = e.JobID
+		outboxIDs[i] = e.OutboxID
+	}
+	return jobIDs, outboxIDs
 }
 
 // tx runs fn against a transaction, committing on success and rolling back otherwise.

--- a/internal/config/embed.go
+++ b/internal/config/embed.go
@@ -8,34 +8,33 @@ import "time"
 // EMBED_API_KEY/EMBED_CONCURRENCY inside search.NewClient — so this holds only the
 // queue-drain knobs, mirroring the tuning half of config.Enrich.
 type Embed struct {
-	Concurrency  int           // embeds in flight; also the claim wave size (keeps each wave's lease window short)
+	BatchSize    int           // claim wave + embed/upsert batch size (one Meili task per wave)
 	LeaseSeconds int           // how long a claim is held before it can be reclaimed
 	MaxAttempts  int           // failed attempts before an entry is dead-lettered
-	CallTimeout  time.Duration // bounds a single job's embed/index or remove operation
+	CallTimeout  time.Duration // bounds a single batch's embed/index or remove operation
 }
 
-// LoadEmbed reads the worker's tuning from the environment, all optional with
-// defaults. EMBED_CONCURRENCY doubles as search.NewClient's embed-batch concurrency,
-// so one knob controls "how many embeds are in flight". There is no required field —
-// the MEILI_MASTER_KEY requirement is enforced at the cmd/embed call site (like
-// cmd/reindex), so this never fails.
+// LoadEmbed reads the worker's tuning from the environment, all optional with defaults.
+// EMBED_BATCH_SIZE is the wave/batch size (bigger = fewer Meili tasks for a bulk
+// backfill); EMBED_CONCURRENCY (read separately by search.NewClient) chunks the embed
+// calls inside each batch. There is no required field — the MEILI_MASTER_KEY requirement
+// is enforced at the cmd/embed call site (like cmd/reindex), so this never fails.
 func LoadEmbed() Embed {
 	e := Embed{
-		Concurrency:  envInt("EMBED_CONCURRENCY", 8),
+		BatchSize:    envInt("EMBED_BATCH_SIZE", 500),
 		LeaseSeconds: envInt("EMBED_LEASE_SECONDS", 300),
 		MaxAttempts:  envInt("EMBED_MAX_ATTEMPTS", 3),
-		CallTimeout:  time.Duration(envInt("EMBED_CALL_TIMEOUT_SECONDS", 120)) * time.Second,
+		CallTimeout:  time.Duration(envInt("EMBED_CALL_TIMEOUT_SECONDS", 300)) * time.Second,
 	}
-	// A non-positive concurrency would make the claim's LIMIT 0 (silently no-op) or
-	// feed a negative LIMIT to Postgres; floor it so the worker always makes progress
-	// (mirrors LoadEnrich).
-	if e.Concurrency < 1 {
-		e.Concurrency = 1
+	// A non-positive batch size would make the claim's LIMIT 0 (silently no-op) or feed a
+	// negative LIMIT to Postgres; floor it so the worker always makes progress.
+	if e.BatchSize < 1 {
+		e.BatchSize = 1
 	}
-	// The lease must outlast a single entry's processing, or an in-flight entry becomes
+	// The lease must outlast a single batch's processing, or an in-flight batch becomes
 	// re-claimable mid-embed (double work) and a lease of 0 re-claims a just-failed entry
 	// in a tight loop, burning its whole retry budget in one run. Floor it to the per-call
-	// timeout — the longest one entry can hold the lease.
+	// timeout — the longest one batch can hold the lease.
 	if floor := int(e.CallTimeout.Seconds()); e.LeaseSeconds < floor {
 		e.LeaseSeconds = floor
 	}

--- a/internal/config/embed_test.go
+++ b/internal/config/embed_test.go
@@ -3,29 +3,29 @@ package config
 import "testing"
 
 func TestLoadEmbed_defaultsAndOverrides(t *testing.T) {
-	for _, k := range []string{"EMBED_CONCURRENCY", "EMBED_LEASE_SECONDS", "EMBED_MAX_ATTEMPTS", "EMBED_CALL_TIMEOUT_SECONDS"} {
+	for _, k := range []string{"EMBED_BATCH_SIZE", "EMBED_LEASE_SECONDS", "EMBED_MAX_ATTEMPTS", "EMBED_CALL_TIMEOUT_SECONDS"} {
 		t.Setenv(k, "")
 	}
 	got := LoadEmbed()
-	if got.Concurrency != 8 || got.LeaseSeconds != 300 || got.MaxAttempts != 3 || got.CallTimeout.Seconds() != 120 {
+	if got.BatchSize != 500 || got.LeaseSeconds != 300 || got.MaxAttempts != 3 || got.CallTimeout.Seconds() != 300 {
 		t.Errorf("defaults wrong: %+v", got)
 	}
 
-	t.Setenv("EMBED_CONCURRENCY", "24")
-	if got := LoadEmbed(); got.Concurrency != 24 {
-		t.Errorf("concurrency override = %d, want 24", got.Concurrency)
+	t.Setenv("EMBED_BATCH_SIZE", "1000")
+	if got := LoadEmbed(); got.BatchSize != 1000 {
+		t.Errorf("batch-size override = %d, want 1000", got.BatchSize)
 	}
 
-	// A non-positive concurrency is floored to 1 so the claim always makes progress.
+	// A non-positive batch size is floored to 1 so the claim always makes progress.
 	for _, bad := range []string{"0", "-3"} {
-		t.Setenv("EMBED_CONCURRENCY", bad)
-		if got := LoadEmbed(); got.Concurrency != 1 {
-			t.Errorf("EMBED_CONCURRENCY=%s clamped to %d, want 1", bad, got.Concurrency)
+		t.Setenv("EMBED_BATCH_SIZE", bad)
+		if got := LoadEmbed(); got.BatchSize != 1 {
+			t.Errorf("EMBED_BATCH_SIZE=%s clamped to %d, want 1", bad, got.BatchSize)
 		}
 	}
-	t.Setenv("EMBED_CONCURRENCY", "")
+	t.Setenv("EMBED_BATCH_SIZE", "")
 
-	// The lease is floored to the per-call timeout: a lease shorter than one entry's
+	// The lease is floored to the per-call timeout: a lease shorter than one batch's
 	// processing (0 in the extreme) would re-claim it mid-flight and burn the retry budget.
 	t.Setenv("EMBED_LEASE_SECONDS", "0")
 	t.Setenv("EMBED_CALL_TIMEOUT_SECONDS", "90")

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -251,7 +251,7 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 }
 
 const getJobBySourceExternalID = `-- name: GetJobBySourceExternalID :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
 FROM jobs
 WHERE source = $1 AND external_id = $2
 `
@@ -306,6 +306,8 @@ func (q *Queries) GetJobBySourceExternalID(ctx context.Context, arg GetJobBySour
 		&i.ViewCount,
 		&i.AppliedCount,
 		&i.RoleFingerprint,
+		&i.SemanticEmbeddedModel,
+		&i.SemanticEmbeddedHash,
 	)
 	return i, err
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -58,9 +58,9 @@ type Querier interface {
 	// affected row count: 1 for an owned row (whether or not it was shared — unshare is an
 	// idempotent no-op when already private), 0 when missing or not the caller's (→ 404).
 	ClearSavedSearchPublicSlug(ctx context.Context, arg ClearSavedSearchPublicSlugParams) (int64, error)
-	// Clear a job's embed provenance after its document is removed from jobs_semantic
-	// (closed-job path). Run in the same transaction as DeleteSemanticEntry.
-	ClearSemanticEmbedded(ctx context.Context, id int64) error
+	// Clear a batch of jobs' embed provenance after their documents are removed from
+	// jobs_semantic (closed-job path). Run in the same transaction as DeleteSemanticEntriesBatch.
+	ClearSemanticEmbeddedBatch(ctx context.Context, ids []int64) error
 	// Clear the user's résumé pointer (after deleting the object from storage), any
 	// cached ATS review, and the derived CV embedding (no CV → no recommendations).
 	ClearUserResume(ctx context.Context, id int64) error
@@ -155,7 +155,7 @@ type Querier interface {
 	// Returns the affected row count: 0 means it does not exist or is not the caller's
 	// (the handler maps that to 404).
 	DeleteSavedSearch(ctx context.Context, arg DeleteSavedSearchParams) (int64, error)
-	DeleteSemanticEntry(ctx context.Context, id int64) error
+	DeleteSemanticEntriesBatch(ctx context.Context, ids []int64) error
 	// Unsubscribe, scoped to its owner. Returns the affected row count: 0 means it
 	// does not exist or is not the caller's (the handler maps that to 404). The match
 	// ledger cascades away with the subscription.
@@ -227,6 +227,10 @@ type Querier interface {
 	// columns over the wire on every silent view. GetJobBySlug (SELECT *) stays for the
 	// public detail handler that renders the whole row.
 	GetJobIDBySlug(ctx context.Context, publicSlug string) (int64, error)
+	// Batch-load the persisted rows the embed worker builds documents from. A corrupted
+	// row (SQLSTATE XX001) aborts the whole scan; the worker then retries the batch one id
+	// at a time to isolate and dead-letter the bad row.
+	GetJobsByIDs(ctx context.Context, ids []int64) ([]Job, error)
 	// The display fields for the jobs in a digest, freshest first.
 	GetJobsForDigest(ctx context.Context, jobIds []int64) ([]GetJobsForDigestRow, error)
 	// Public read of a shared board by its slug — no auth, no owner-scoping. Exposes only
@@ -520,15 +524,19 @@ type Querier interface {
 	// Persist the user's derived CV embedding vector plus the identity of the embedder
 	// that produced it (so a model change can mark the vector stale). Never the raw CV text.
 	SetUserResumeEmbedding(ctx context.Context, arg SetUserResumeEmbeddingParams) error
-	// Record that a job's content is embedded under the given model. Run in the same
-	// transaction as DeleteSemanticEntry on the success path, so a crash between the index
-	// write and this stamp is safely retried (idempotent re-embed). hash is the job's
-	// content_hash AS IT WAS EMBEDDED (passed through, nullable): stamping the exact
-	// embedded hash — not the row's current one — keeps the staleness check honest, so a
-	// content change concurrent with the embed re-enqueues on the next run instead of being
-	// silently marked current, and a NULL content_hash stamps NULL (NULL IS DISTINCT FROM
-	// NULL is false, so it does not re-enqueue forever).
-	StampSemanticEmbedded(ctx context.Context, arg StampSemanticEmbeddedParams) error
+	// Record that a batch of jobs' content is embedded under the given model. Run in the
+	// same transaction as DeleteSemanticEntriesBatch on the success path, so a crash between
+	// the index write and this stamp is safely retried (idempotent re-embed). The stamp
+	// copies each job's CURRENT content_hash (nullable-safe: a NULL content_hash stamps NULL
+	// so NULL IS DISTINCT FROM NULL stays false and the job is not re-enqueued forever).
+	// Caveat: if an ingest commits a new content_hash in the tiny window between the embed
+	// (which read the old content) and this stamp, the stamp records the NEW hash while the
+	// vector reflects the old one — so the enqueue predicate sees a match and does NOT
+	// re-enqueue it next run; that job carries a one-revision-stale vector until its content
+	// changes AGAIN (which re-enqueues it). The window is one embed-duration and the drift
+	// self-corrects on the next real change, so this is accepted over threading the exact
+	// embedded hash through a nullable text[] per batch.
+	StampSemanticEmbeddedBatch(ctx context.Context, arg StampSemanticEmbeddedBatchParams) error
 	// Rebuild the companies catalogue from jobs. The companies table is derivable
 	// from jobs (slug = company_slug, name = company), so after a slug-builder change
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's

--- a/internal/db/queries/semantic.sql
+++ b/internal/db/queries/semantic.sql
@@ -54,31 +54,43 @@ JOIN jobs j ON j.id = c.job_id
 WHERE o.id = c.id
 RETURNING o.id, o.job_id, (j.closed_at IS NOT NULL)::boolean AS closed;
 
--- name: StampSemanticEmbedded :exec
--- Record that a job's content is embedded under the given model. Run in the same
--- transaction as DeleteSemanticEntry on the success path, so a crash between the index
--- write and this stamp is safely retried (idempotent re-embed). hash is the job's
--- content_hash AS IT WAS EMBEDDED (passed through, nullable): stamping the exact
--- embedded hash — not the row's current one — keeps the staleness check honest, so a
--- content change concurrent with the embed re-enqueues on the next run instead of being
--- silently marked current, and a NULL content_hash stamps NULL (NULL IS DISTINCT FROM
--- NULL is false, so it does not re-enqueue forever).
+-- name: GetJobsByIDs :many
+-- Batch-load the persisted rows the embed worker builds documents from. A corrupted
+-- row (SQLSTATE XX001) aborts the whole scan; the worker then retries the batch one id
+-- at a time to isolate and dead-letter the bad row.
+SELECT *
+FROM jobs
+WHERE id = ANY(sqlc.arg(ids)::bigint[]);
+
+-- name: StampSemanticEmbeddedBatch :exec
+-- Record that a batch of jobs' content is embedded under the given model. Run in the
+-- same transaction as DeleteSemanticEntriesBatch on the success path, so a crash between
+-- the index write and this stamp is safely retried (idempotent re-embed). The stamp
+-- copies each job's CURRENT content_hash (nullable-safe: a NULL content_hash stamps NULL
+-- so NULL IS DISTINCT FROM NULL stays false and the job is not re-enqueued forever).
+-- Caveat: if an ingest commits a new content_hash in the tiny window between the embed
+-- (which read the old content) and this stamp, the stamp records the NEW hash while the
+-- vector reflects the old one — so the enqueue predicate sees a match and does NOT
+-- re-enqueue it next run; that job carries a one-revision-stale vector until its content
+-- changes AGAIN (which re-enqueues it). The window is one embed-duration and the drift
+-- self-corrects on the next real change, so this is accepted over threading the exact
+-- embedded hash through a nullable text[] per batch.
 UPDATE jobs
 SET semantic_embedded_model = sqlc.arg(model)::text,
-    semantic_embedded_hash  = sqlc.narg(hash)
-WHERE id = sqlc.arg(id);
+    semantic_embedded_hash  = content_hash
+WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 
--- name: ClearSemanticEmbedded :exec
--- Clear a job's embed provenance after its document is removed from jobs_semantic
--- (closed-job path). Run in the same transaction as DeleteSemanticEntry.
+-- name: ClearSemanticEmbeddedBatch :exec
+-- Clear a batch of jobs' embed provenance after their documents are removed from
+-- jobs_semantic (closed-job path). Run in the same transaction as DeleteSemanticEntriesBatch.
 UPDATE jobs
 SET semantic_embedded_model = NULL,
     semantic_embedded_hash  = NULL
-WHERE id = sqlc.arg(id);
+WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 
--- name: DeleteSemanticEntry :exec
+-- name: DeleteSemanticEntriesBatch :exec
 DELETE FROM semantic_outbox
-WHERE id = $1;
+WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 
 -- name: RecordSemanticFailure :one
 -- Count a failed attempt: bump attempts, record the error, and dead-letter (set

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -74,27 +74,27 @@ func (q *Queries) ClaimSemanticBatch(ctx context.Context, arg ClaimSemanticBatch
 	return items, nil
 }
 
-const clearSemanticEmbedded = `-- name: ClearSemanticEmbedded :exec
+const clearSemanticEmbeddedBatch = `-- name: ClearSemanticEmbeddedBatch :exec
 UPDATE jobs
 SET semantic_embedded_model = NULL,
     semantic_embedded_hash  = NULL
-WHERE id = $1
+WHERE id = ANY($1::bigint[])
 `
 
-// Clear a job's embed provenance after its document is removed from jobs_semantic
-// (closed-job path). Run in the same transaction as DeleteSemanticEntry.
-func (q *Queries) ClearSemanticEmbedded(ctx context.Context, id int64) error {
-	_, err := q.db.Exec(ctx, clearSemanticEmbedded, id)
+// Clear a batch of jobs' embed provenance after their documents are removed from
+// jobs_semantic (closed-job path). Run in the same transaction as DeleteSemanticEntriesBatch.
+func (q *Queries) ClearSemanticEmbeddedBatch(ctx context.Context, ids []int64) error {
+	_, err := q.db.Exec(ctx, clearSemanticEmbeddedBatch, ids)
 	return err
 }
 
-const deleteSemanticEntry = `-- name: DeleteSemanticEntry :exec
+const deleteSemanticEntriesBatch = `-- name: DeleteSemanticEntriesBatch :exec
 DELETE FROM semantic_outbox
-WHERE id = $1
+WHERE id = ANY($1::bigint[])
 `
 
-func (q *Queries) DeleteSemanticEntry(ctx context.Context, id int64) error {
-	_, err := q.db.Exec(ctx, deleteSemanticEntry, id)
+func (q *Queries) DeleteSemanticEntriesBatch(ctx context.Context, ids []int64) error {
+	_, err := q.db.Exec(ctx, deleteSemanticEntriesBatch, ids)
 	return err
 }
 
@@ -138,6 +138,77 @@ func (q *Queries) EnqueuePendingSemanticJobs(ctx context.Context, arg EnqueuePen
 	return result.RowsAffected(), nil
 }
 
+const getJobsByIDs = `-- name: GetJobsByIDs :many
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+FROM jobs
+WHERE id = ANY($1::bigint[])
+`
+
+// Batch-load the persisted rows the embed worker builds documents from. A corrupted
+// row (SQLSTATE XX001) aborts the whole scan; the worker then retries the batch one id
+// at a time to isolate and dead-letter the bad row.
+func (q *Queries) GetJobsByIDs(ctx context.Context, ids []int64) ([]Job, error) {
+	rows, err := q.db.Query(ctx, getJobsByIDs, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Job{}
+	for rows.Next() {
+		var i Job
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.ExternalID,
+			&i.URL,
+			&i.Title,
+			&i.Company,
+			&i.Location,
+			&i.Remote,
+			&i.Description,
+			&i.PostedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.CompanySlug,
+			&i.Enrichment,
+			&i.EnrichedAt,
+			&i.EnrichmentVersion,
+			&i.PublicSlug,
+			&i.LastSeenAt,
+			&i.ClosedAt,
+			&i.Countries,
+			&i.Regions,
+			&i.WorkMode,
+			&i.LivenessStrikes,
+			&i.Skills,
+			&i.Seniority,
+			&i.Category,
+			&i.CreatedBy,
+			&i.UpdatedBy,
+			&i.PostingLanguage,
+			&i.EmploymentType,
+			&i.EducationLevel,
+			&i.ExperienceYearsMin,
+			&i.Collections,
+			&i.ContentHash,
+			&i.EnglishLevel,
+			&i.Cities,
+			&i.ViewCount,
+			&i.AppliedCount,
+			&i.RoleFingerprint,
+			&i.SemanticEmbeddedModel,
+			&i.SemanticEmbeddedHash,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const recordSemanticFailure = `-- name: RecordSemanticFailure :one
 UPDATE semantic_outbox
 SET attempts   = attempts + 1,
@@ -173,28 +244,31 @@ func (q *Queries) RecordSemanticFailure(ctx context.Context, arg RecordSemanticF
 	return i, err
 }
 
-const stampSemanticEmbedded = `-- name: StampSemanticEmbedded :exec
+const stampSemanticEmbeddedBatch = `-- name: StampSemanticEmbeddedBatch :exec
 UPDATE jobs
 SET semantic_embedded_model = $1::text,
-    semantic_embedded_hash  = $2
-WHERE id = $3
+    semantic_embedded_hash  = content_hash
+WHERE id = ANY($2::bigint[])
 `
 
-type StampSemanticEmbeddedParams struct {
-	Model string      `json:"model"`
-	Hash  pgtype.Text `json:"hash"`
-	ID    int64       `json:"id"`
+type StampSemanticEmbeddedBatchParams struct {
+	Model string  `json:"model"`
+	Ids   []int64 `json:"ids"`
 }
 
-// Record that a job's content is embedded under the given model. Run in the same
-// transaction as DeleteSemanticEntry on the success path, so a crash between the index
-// write and this stamp is safely retried (idempotent re-embed). hash is the job's
-// content_hash AS IT WAS EMBEDDED (passed through, nullable): stamping the exact
-// embedded hash — not the row's current one — keeps the staleness check honest, so a
-// content change concurrent with the embed re-enqueues on the next run instead of being
-// silently marked current, and a NULL content_hash stamps NULL (NULL IS DISTINCT FROM
-// NULL is false, so it does not re-enqueue forever).
-func (q *Queries) StampSemanticEmbedded(ctx context.Context, arg StampSemanticEmbeddedParams) error {
-	_, err := q.db.Exec(ctx, stampSemanticEmbedded, arg.Model, arg.Hash, arg.ID)
+// Record that a batch of jobs' content is embedded under the given model. Run in the
+// same transaction as DeleteSemanticEntriesBatch on the success path, so a crash between
+// the index write and this stamp is safely retried (idempotent re-embed). The stamp
+// copies each job's CURRENT content_hash (nullable-safe: a NULL content_hash stamps NULL
+// so NULL IS DISTINCT FROM NULL stays false and the job is not re-enqueued forever).
+// Caveat: if an ingest commits a new content_hash in the tiny window between the embed
+// (which read the old content) and this stamp, the stamp records the NEW hash while the
+// vector reflects the old one — so the enqueue predicate sees a match and does NOT
+// re-enqueue it next run; that job carries a one-revision-stale vector until its content
+// changes AGAIN (which re-enqueues it). The window is one embed-duration and the drift
+// self-corrects on the next real change, so this is accepted over threading the exact
+// embedded hash through a nullable text[] per batch.
+func (q *Queries) StampSemanticEmbeddedBatch(ctx context.Context, arg StampSemanticEmbeddedBatchParams) error {
+	_, err := q.db.Exec(ctx, stampSemanticEmbeddedBatch, arg.Model, arg.Ids)
 	return err
 }

--- a/internal/db/semantic_integration_test.go
+++ b/internal/db/semantic_integration_test.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -302,14 +301,15 @@ func TestSemanticStampClearFailure(t *testing.T) {
 	t.Run("stamp then clear provenance", func(t *testing.T) {
 		truncate(t, pool)
 		j := insertJob(t, pool, "stampme")
-		if err := q.StampSemanticEmbedded(ctx, StampSemanticEmbeddedParams{Model: targetModel, Hash: pgtype.Text{String: "h1", Valid: true}, ID: j}); err != nil {
+		setContentHash(t, pool, j, "h1") // the batch stamp copies content_hash
+		if err := q.StampSemanticEmbeddedBatch(ctx, StampSemanticEmbeddedBatchParams{Model: targetModel, Ids: []int64{j}}); err != nil {
 			t.Fatal(err)
 		}
 		model, hash := semanticStamp(t, pool, j)
 		if model == nil || *model != targetModel || hash == nil || *hash != "h1" {
 			t.Errorf("after stamp: model=%v hash=%v, want %q/%q", model, hash, targetModel, "h1")
 		}
-		if err := q.ClearSemanticEmbedded(ctx, j); err != nil {
+		if err := q.ClearSemanticEmbeddedBatch(ctx, []int64{j}); err != nil {
 			t.Fatal(err)
 		}
 		if model, hash := semanticStamp(t, pool, j); model != nil || hash != nil {
@@ -319,14 +319,12 @@ func TestSemanticStampClearFailure(t *testing.T) {
 
 	t.Run("NULL-content_hash job stamped NULL is not re-enqueued", func(t *testing.T) {
 		// A job whose content_hash is NULL (never re-ingested since the content_hash
-		// migration) embeds fine; the stamp must record NULL, not "", so the enqueue's
-		// `semantic_embedded_hash IS DISTINCT FROM content_hash` (NULL vs NULL → false)
-		// does not re-queue it forever.
+		// migration) embeds fine; the stamp copies content_hash, so it records NULL — the
+		// enqueue's `semantic_embedded_hash IS DISTINCT FROM content_hash` (NULL vs NULL →
+		// false) then does not re-queue it forever.
 		truncate(t, pool)
 		j := insertJob(t, pool, "nullhash") // content_hash stays NULL
-		if err := q.StampSemanticEmbedded(ctx, StampSemanticEmbeddedParams{
-			Model: targetModel, Hash: pgtype.Text{Valid: false}, ID: j,
-		}); err != nil {
+		if err := q.StampSemanticEmbeddedBatch(ctx, StampSemanticEmbeddedBatchParams{Model: targetModel, Ids: []int64{j}}); err != nil {
 			t.Fatal(err)
 		}
 		if _, hash := semanticStamp(t, pool, j); hash != nil {
@@ -350,7 +348,7 @@ func TestSemanticStampClearFailure(t *testing.T) {
 		if err != nil || len(claimed) != 1 {
 			t.Fatalf("claim: rows=%d err=%v, want 1", len(claimed), err)
 		}
-		if err := q.DeleteSemanticEntry(ctx, claimed[0].ID); err != nil {
+		if err := q.DeleteSemanticEntriesBatch(ctx, []int64{claimed[0].ID}); err != nil {
 			t.Fatal(err)
 		}
 		if got := semanticOutboxJobIDs(t, pool); len(got) != 0 {

--- a/internal/embed/runner.go
+++ b/internal/embed/runner.go
@@ -1,19 +1,18 @@
 // Package embed drives incremental semantic embedding: enqueue open jobs whose vector
 // is missing/stale (and closed jobs whose vector must be removed), then drain the
-// semantic_outbox queue wave by wave, embedding+upserting open jobs and removing closed
-// ones in place. It mirrors internal/enrich: the Runner is independent of the DB and
-// search layers (Store + Indexer ports), so the branch/fail logic is unit-tested with
-// fakes; cmd/embed wires the real adapters.
+// semantic_outbox queue wave by wave. Each wave is embedded and upserted as ONE batch
+// (one Meilisearch task per wave, not per job) so a bulk backfill isn't bottlenecked on
+// Meili's serial task queue; on a batch failure it falls back to per-item processing so
+// a single poison/corrupted row can't sink the whole batch. It mirrors internal/enrich:
+// the Runner is independent of the DB and search layers (Store + Indexer ports), so the
+// batch/fallback logic is unit-tested with fakes; cmd/embed wires the real adapters.
 package embed
 
 import (
 	"context"
 	"fmt"
 	"log"
-	"sync"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/worker"
@@ -35,24 +34,26 @@ type Store interface {
 	Enqueue(ctx context.Context, targetModel string) (int64, error)
 	// Claim leases up to batch live, unleased entries (closed jobs included).
 	Claim(ctx context.Context, batch, leaseSeconds int) ([]Claimed, error)
-	// Job returns the persisted row a document is built from.
-	Job(ctx context.Context, id int64) (db.Job, error)
-	// CompleteOpen stamps the job's embed provenance (model + the exact embedded
-	// content hash) and deletes the outbox entry, atomically.
-	CompleteOpen(ctx context.Context, entry Claimed, model string, hash pgtype.Text) error
-	// CompleteClosed clears the job's embed provenance and deletes the outbox entry,
-	// atomically (its document was just removed from the index).
-	CompleteClosed(ctx context.Context, entry Claimed) error
-	// Fail records a failed attempt; it returns whether the entry was dead-lettered.
+	// Jobs returns the persisted rows the documents are built from. A corrupted row
+	// aborts the whole load, so the runner retries such a batch per item to isolate it.
+	Jobs(ctx context.Context, ids []int64) ([]db.Job, error)
+	// CompleteOpen stamps each entry's job embed provenance (model + its current
+	// content_hash) and deletes the outbox entries, atomically.
+	CompleteOpen(ctx context.Context, entries []Claimed, model string) error
+	// CompleteClosed clears each entry's job embed provenance and deletes the outbox
+	// entries, atomically (their documents were just removed from the index).
+	CompleteClosed(ctx context.Context, entries []Claimed) error
+	// Fail records a failed attempt for one entry; it reports whether it dead-lettered.
 	Fail(ctx context.Context, outboxID int64, errMsg string, maxAttempts int) (deadLettered bool, err error)
 }
 
-// Indexer is the semantic-index side: embed+upsert an open job, or remove a closed one.
+// Indexer is the semantic-index side: embed+upsert open jobs, or remove closed ones.
 type Indexer interface {
-	// IndexOpen embeds the job's document and upserts its vector into the semantic index.
-	IndexOpen(ctx context.Context, job db.Job) error
-	// RemoveClosed deletes the job's document from the semantic index.
-	RemoveClosed(ctx context.Context, jobID int64) error
+	// IndexOpen embeds the jobs' documents and upserts their vectors into the semantic
+	// index in one batch.
+	IndexOpen(ctx context.Context, jobs []db.Job) error
+	// RemoveClosed deletes the jobs' documents from the semantic index in one batch.
+	RemoveClosed(ctx context.Context, ids []int64) error
 }
 
 // RunOptions are the per-run knobs.
@@ -60,13 +61,14 @@ type RunOptions struct {
 	// TargetModel is the embedder identity: the enqueue staleness key and the value
 	// stamped on a successful embed (search.CurrentEmbedderModel()).
 	TargetModel string
-	// Concurrency is both the number of embeds in flight and the claim wave size, so
-	// each claimed entry's lease window stays ≈ one embed call.
-	Concurrency  int
+	// BatchSize is the claim wave size and the embed/upsert batch size — the lever that
+	// collapses per-doc Meili tasks into one task per wave. The embed backend chunks the
+	// batch internally (EMBED_CONCURRENCY), so this can be large (hundreds).
+	BatchSize    int
 	LeaseSeconds int
 	MaxAttempts  int
-	// CallTimeout bounds a single job's index/remove operation; 0 means no per-call
-	// timeout (the embed backend has its own per-attempt timeout regardless).
+	// CallTimeout bounds a single batch's (or fallback item's) index/remove operation;
+	// 0 means no per-call timeout (the embed backend has its own per-attempt timeout).
 	CallTimeout time.Duration
 }
 
@@ -91,103 +93,148 @@ func (r Runner) Run(ctx context.Context, opt RunOptions) (Stats, error) {
 	if err != nil {
 		return Stats{}, fmt.Errorf("enqueue: %w", err)
 	}
-	log.Printf("embed: enqueued %d pending, draining (concurrency=%d)", enqueued, opt.Concurrency)
+	log.Printf("embed: enqueued %d pending, draining (batch=%d)", enqueued, opt.BatchSize)
 
 	rn := &run{store: r.Store, indexer: r.Indexer, opt: opt}
 	for {
-		// A wave the size of the concurrency, drained in parallel so each entry's lease
-		// window stays ≈ one embed call.
-		batch, err := r.Store.Claim(ctx, opt.Concurrency, opt.LeaseSeconds)
+		batch, err := r.Store.Claim(ctx, opt.BatchSize, opt.LeaseSeconds)
 		if err != nil {
 			return rn.stats, fmt.Errorf("claim: %w", err)
 		}
 		if len(batch) == 0 {
 			return rn.stats, nil
 		}
-		var wg sync.WaitGroup
-		for _, entry := range batch {
-			wg.Add(1)
-			go func(e Claimed) {
-				defer wg.Done()
-				rn.process(ctx, e)
-			}(entry)
+		var open, closed []Claimed
+		for _, e := range batch {
+			if e.Closed {
+				closed = append(closed, e)
+			} else {
+				open = append(open, e)
+			}
 		}
-		wg.Wait()
+		rn.processOpenBatch(ctx, open)
+		rn.processClosedBatch(ctx, closed)
 		log.Printf("embed: progress indexed=%d removed=%d failed=%d dead=%d",
 			rn.stats.Indexed, rn.stats.Removed, rn.stats.Failed, rn.stats.DeadLettered)
 	}
 }
 
-// run accumulates one Run's options and tallies; a wave's workers process entries
-// concurrently, so the tallies are guarded by mu.
+// run accumulates one Run's options and tallies. Waves are processed sequentially (the
+// embed concurrency lives inside the Indexer), so the tallies need no lock.
 type run struct {
 	store   Store
 	indexer Indexer
 	opt     RunOptions
-
-	mu    sync.Mutex
-	stats Stats
+	stats   Stats
 }
 
-// process handles one claimed entry, branching on whether the job is open (embed) or
-// closed (remove). Any failure routes to fail so the run continues with the rest.
-func (rn *run) process(ctx context.Context, entry Claimed) {
+// processOpenBatch embeds+upserts a whole wave of open jobs in one batch and completes
+// them in one transaction. Any batch-level failure (a corrupted-row load, a batch embed
+// error, a partial load) falls back to per-item processing so one bad entry can't sink
+// the wave.
+func (rn *run) processOpenBatch(ctx context.Context, entries []Claimed) {
+	if len(entries) == 0 {
+		return
+	}
 	start := time.Now()
 	callCtx, cancel := rn.callContext(ctx)
 	defer cancel()
 
-	if entry.Closed {
-		rn.processClosed(callCtx, entry, start)
+	jobs, err := rn.store.Jobs(callCtx, jobIDs(entries))
+	if err != nil || len(jobs) != len(entries) {
+		rn.fallbackOpen(ctx, entries)
 		return
 	}
-	rn.processOpen(callCtx, entry, start)
+	if err := rn.indexer.IndexOpen(callCtx, jobs); err != nil {
+		rn.fallbackOpen(ctx, entries)
+		return
+	}
+	if err := rn.store.CompleteOpen(callCtx, entries, rn.opt.TargetModel); err != nil {
+		rn.fallbackOpen(ctx, entries)
+		return
+	}
+	rn.stats.Indexed += len(entries)
+	log.Printf("embed: indexed batch of %d in %s", len(entries), since(start))
 }
 
-func (rn *run) processOpen(ctx context.Context, entry Claimed, start time.Time) {
-	job, err := rn.store.Job(ctx, entry.JobID)
+func (rn *run) fallbackOpen(ctx context.Context, entries []Claimed) {
+	for _, e := range entries {
+		rn.processOpenOne(ctx, e)
+	}
+}
+
+func (rn *run) processOpenOne(ctx context.Context, entry Claimed) {
+	callCtx, cancel := rn.callContext(ctx)
+	defer cancel()
+
+	jobs, err := rn.store.Jobs(callCtx, []int64{entry.JobID})
 	if err != nil {
 		// A corrupted row (XX001) can never load — dead-letter it immediately rather
 		// than burning the attempt budget across cron runs (mirrors enrich).
 		if worker.IsCorruptedRow(err) {
 			rn.failN(entry, fmt.Errorf("load job: %w", err), 1)
-			log.Printf("embed: job=%d dead-lettered (corrupted row) in %s: %v", entry.JobID, since(start), err)
 			return
 		}
 		rn.fail(entry, fmt.Errorf("load job: %w", err))
-		log.Printf("embed: job=%d load failed in %s: %v", entry.JobID, since(start), err)
 		return
 	}
-
-	if err := rn.indexer.IndexOpen(ctx, job); err != nil {
+	if len(jobs) == 0 {
+		rn.fail(entry, fmt.Errorf("job %d not found", entry.JobID))
+		return
+	}
+	if err := rn.indexer.IndexOpen(callCtx, jobs); err != nil {
 		rn.fail(entry, fmt.Errorf("embed/index: %w", err))
-		log.Printf("embed: job=%d index FAILED in %s: %v", entry.JobID, since(start), err)
 		return
 	}
-	if err := rn.store.CompleteOpen(ctx, entry, rn.opt.TargetModel, job.ContentHash); err != nil {
+	if err := rn.store.CompleteOpen(callCtx, []Claimed{entry}, rn.opt.TargetModel); err != nil {
 		rn.fail(entry, fmt.Errorf("complete open: %w", err))
-		log.Printf("embed: job=%d complete failed in %s: %v", entry.JobID, since(start), err)
 		return
 	}
-	rn.tally(func(s *Stats) { s.Indexed++ })
-	log.Printf("embed: job=%d indexed in %s", entry.JobID, since(start))
+	rn.stats.Indexed++
 }
 
-func (rn *run) processClosed(ctx context.Context, entry Claimed, start time.Time) {
-	if err := rn.indexer.RemoveClosed(ctx, entry.JobID); err != nil {
+// processClosedBatch removes a whole wave of closed jobs' documents in one batch, with
+// the same per-item fallback on failure.
+func (rn *run) processClosedBatch(ctx context.Context, entries []Claimed) {
+	if len(entries) == 0 {
+		return
+	}
+	callCtx, cancel := rn.callContext(ctx)
+	defer cancel()
+
+	if err := rn.indexer.RemoveClosed(callCtx, jobIDs(entries)); err != nil {
+		rn.fallbackClosed(ctx, entries)
+		return
+	}
+	if err := rn.store.CompleteClosed(callCtx, entries); err != nil {
+		rn.fallbackClosed(ctx, entries)
+		return
+	}
+	rn.stats.Removed += len(entries)
+}
+
+func (rn *run) fallbackClosed(ctx context.Context, entries []Claimed) {
+	for _, e := range entries {
+		rn.processClosedOne(ctx, e)
+	}
+}
+
+func (rn *run) processClosedOne(ctx context.Context, entry Claimed) {
+	callCtx, cancel := rn.callContext(ctx)
+	defer cancel()
+
+	if err := rn.indexer.RemoveClosed(callCtx, []int64{entry.JobID}); err != nil {
 		rn.fail(entry, fmt.Errorf("remove closed: %w", err))
-		log.Printf("embed: job=%d remove FAILED in %s: %v", entry.JobID, since(start), err)
 		return
 	}
-	if err := rn.store.CompleteClosed(ctx, entry); err != nil {
+	if err := rn.store.CompleteClosed(callCtx, []Claimed{entry}); err != nil {
 		rn.fail(entry, fmt.Errorf("complete closed: %w", err))
-		log.Printf("embed: job=%d complete-closed failed in %s: %v", entry.JobID, since(start), err)
 		return
 	}
-	rn.tally(func(s *Stats) { s.Removed++ })
-	log.Printf("embed: job=%d removed (closed) in %s", entry.JobID, since(start))
+	rn.stats.Removed++
 }
 
-// callContext derives the per-entry timeout context (no-op when CallTimeout is 0).
+// callContext derives the per-batch timeout context (no-op when CallTimeout is 0).
 func (rn *run) callContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if rn.opt.CallTimeout <= 0 {
 		return context.WithCancel(ctx)
@@ -208,19 +255,19 @@ func (rn *run) failN(entry Claimed, cause error, maxAttempts int) {
 	if err != nil {
 		log.Printf("embed: outbox=%d fail-bookkeeping error: %v", entry.OutboxID, err)
 	}
-	rn.tally(func(s *Stats) {
-		if err == nil && dead {
-			s.DeadLettered++
-			return
-		}
-		s.Failed++
-	})
+	if err == nil && dead {
+		rn.stats.DeadLettered++
+		return
+	}
+	rn.stats.Failed++
 }
 
-func (rn *run) tally(f func(*Stats)) {
-	rn.mu.Lock()
-	defer rn.mu.Unlock()
-	f(&rn.stats)
+func jobIDs(entries []Claimed) []int64 {
+	ids := make([]int64, len(entries))
+	for i, e := range entries {
+		ids[i] = e.JobID
+	}
+	return ids
 }
 
 func since(t time.Time) time.Duration { return time.Since(t).Round(time.Millisecond) }

--- a/internal/embed/runner_test.go
+++ b/internal/embed/runner_test.go
@@ -7,31 +7,27 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 )
 
-// fakeStore is an in-memory Store: a queue of claimable entries drained one wave at a
-// time, plus call recorders. Guarded by mu because a wave processes entries concurrently.
+// fakeStore is an in-memory Store. It records batch vs. per-item calls so tests can
+// assert the happy path takes one batch call and a failure falls back to per-item.
 type fakeStore struct {
 	mu sync.Mutex
 
-	pending  []Claimed        // claimed in FIFO order, one wave per Claim call up to batch
-	jobs     map[int64]db.Job // rows returned by Job
-	jobErr   map[int64]error  // load error for a job id (e.g. corrupted row)
-	failWith map[int64]error  // CompleteOpen/CompleteClosed error for a job id
+	pending []Claimed        // claimed FIFO, one wave per Claim up to batch
+	jobs    map[int64]db.Job // rows returned by Jobs
+	jobErr  map[int64]error  // load error for a job id (e.g. corrupted row)
 
-	openDone   []int64             // job ids CompleteOpen'd
-	openStamps map[int64]stampArgs // model+hash stamped per job
-	closedDone []int64             // job ids CompleteClosed'd
-	failCalls  []failCall          // recorded Fail calls
-	attempts   map[int64]int       // outbox id -> attempts so far (dead-letters at maxAttempts)
-}
+	indexErr map[int64]error // CompleteOpen error for a job id (single-item path)
 
-type stampArgs struct {
-	model string
-	hash  pgtype.Text
+	openBatches   [][]int64 // job ids per CompleteOpen call (len>1 = a real batch)
+	closedBatches [][]int64 // job ids per CompleteClosed call
+	openDone      []int64   // all job ids CompleteOpen'd
+	closedDone    []int64   // all job ids CompleteClosed'd
+	failCalls     []failCall
+	attempts      map[int64]int // outbox id -> attempts so far
 }
 
 type failCall struct {
@@ -42,8 +38,8 @@ type failCall struct {
 
 func newFakeStore() *fakeStore {
 	return &fakeStore{
-		jobs: map[int64]db.Job{}, jobErr: map[int64]error{}, failWith: map[int64]error{},
-		openStamps: map[int64]stampArgs{}, attempts: map[int64]int{},
+		jobs: map[int64]db.Job{}, jobErr: map[int64]error{}, indexErr: map[int64]error{},
+		attempts: map[int64]int{},
 	}
 }
 
@@ -63,33 +59,49 @@ func (s *fakeStore) Claim(_ context.Context, batch, _ int) ([]Claimed, error) {
 	return wave, nil
 }
 
-func (s *fakeStore) Job(_ context.Context, id int64) (db.Job, error) {
+func (s *fakeStore) Jobs(_ context.Context, ids []int64) ([]db.Job, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.jobErr[id]; err != nil {
-		return db.Job{}, err
+	// A corrupted row aborts a whole multi-id load (a seq scan hits it); a single-id
+	// load surfaces the row's own error so the runner can isolate it.
+	for _, id := range ids {
+		if err := s.jobErr[id]; err != nil {
+			return nil, err
+		}
 	}
-	return s.jobs[id], nil
+	out := make([]db.Job, 0, len(ids))
+	for _, id := range ids {
+		if j, ok := s.jobs[id]; ok {
+			out = append(out, j)
+		}
+	}
+	return out, nil
 }
 
-func (s *fakeStore) CompleteOpen(_ context.Context, entry Claimed, model string, hash pgtype.Text) error {
+func (s *fakeStore) CompleteOpen(_ context.Context, entries []Claimed, _ string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.failWith[entry.JobID]; err != nil {
-		return err
+	var ids []int64
+	for _, e := range entries {
+		if err := s.indexErr[e.JobID]; err != nil {
+			return err
+		}
+		ids = append(ids, e.JobID)
 	}
-	s.openDone = append(s.openDone, entry.JobID)
-	s.openStamps[entry.JobID] = stampArgs{model, hash}
+	s.openBatches = append(s.openBatches, ids)
+	s.openDone = append(s.openDone, ids...)
 	return nil
 }
 
-func (s *fakeStore) CompleteClosed(_ context.Context, entry Claimed) error {
+func (s *fakeStore) CompleteClosed(_ context.Context, entries []Claimed) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if err := s.failWith[entry.JobID]; err != nil {
-		return err
+	var ids []int64
+	for _, e := range entries {
+		ids = append(ids, e.JobID)
 	}
-	s.closedDone = append(s.closedDone, entry.JobID)
+	s.closedBatches = append(s.closedBatches, ids)
+	s.closedDone = append(s.closedDone, ids...)
 	return nil
 }
 
@@ -101,41 +113,50 @@ func (s *fakeStore) Fail(_ context.Context, outboxID int64, msg string, maxAttem
 	return s.attempts[outboxID] >= maxAttempts, nil
 }
 
-// fakeIndexer records which jobs were embedded vs removed, and can fail specific ids.
+// fakeIndexer records IndexOpen/RemoveClosed calls. batchFails makes any multi-job
+// IndexOpen fail (to exercise the per-item fallback); indexErr fails a specific job.
 type fakeIndexer struct {
-	mu        sync.Mutex
-	indexed   []int64
-	removed   []int64
-	indexErr  map[int64]error
-	removeErr map[int64]error
+	mu         sync.Mutex
+	indexCalls [][]int64 // job ids per IndexOpen call
+	removeCall [][]int64 // ids per RemoveClosed call
+	indexed    []int64
+	removed    []int64
+	batchFails bool
+	indexErr   map[int64]error
 }
 
-func newFakeIndexer() *fakeIndexer {
-	return &fakeIndexer{indexErr: map[int64]error{}, removeErr: map[int64]error{}}
-}
+func newFakeIndexer() *fakeIndexer { return &fakeIndexer{indexErr: map[int64]error{}} }
 
-func (ix *fakeIndexer) IndexOpen(_ context.Context, job db.Job) error {
+func (ix *fakeIndexer) IndexOpen(_ context.Context, jobs []db.Job) error {
 	ix.mu.Lock()
 	defer ix.mu.Unlock()
-	if err := ix.indexErr[job.ID]; err != nil {
-		return err
+	ids := make([]int64, len(jobs))
+	for i, j := range jobs {
+		ids[i] = j.ID
 	}
-	ix.indexed = append(ix.indexed, job.ID)
+	ix.indexCalls = append(ix.indexCalls, ids)
+	if ix.batchFails && len(jobs) > 1 {
+		return errors.New("batch embed failed")
+	}
+	for _, j := range jobs {
+		if err := ix.indexErr[j.ID]; err != nil {
+			return err
+		}
+	}
+	ix.indexed = append(ix.indexed, ids...)
 	return nil
 }
 
-func (ix *fakeIndexer) RemoveClosed(_ context.Context, jobID int64) error {
+func (ix *fakeIndexer) RemoveClosed(_ context.Context, ids []int64) error {
 	ix.mu.Lock()
 	defer ix.mu.Unlock()
-	if err := ix.removeErr[jobID]; err != nil {
-		return err
-	}
-	ix.removed = append(ix.removed, jobID)
+	ix.removeCall = append(ix.removeCall, ids)
+	ix.removed = append(ix.removed, ids...)
 	return nil
 }
 
 func opt() RunOptions {
-	return RunOptions{TargetModel: "e5-test", Concurrency: 2, LeaseSeconds: 300, MaxAttempts: 3}
+	return RunOptions{TargetModel: "e5-test", BatchSize: 500, LeaseSeconds: 300, MaxAttempts: 3}
 }
 
 func has(ids []int64, id int64) bool {
@@ -147,86 +168,93 @@ func has(ids []int64, id int64) bool {
 	return false
 }
 
-func TestRunnerBranchesOnClosed(t *testing.T) {
+func TestRunnerBatchesOpenAndClosed(t *testing.T) {
 	store := newFakeStore()
 	ix := newFakeIndexer()
-	// Two open jobs (embed + stamp) and one closed job (remove + clear).
-	store.jobs[1] = db.Job{ID: 1, ContentHash: pgtype.Text{String: "h1", Valid: true}}
-	store.jobs[2] = db.Job{ID: 2} // NULL content_hash → stamp NULL
+	for _, id := range []int64{1, 2, 3} {
+		store.jobs[id] = db.Job{ID: id}
+	}
 	store.pending = []Claimed{
 		{OutboxID: 10, JobID: 1, Closed: false},
 		{OutboxID: 20, JobID: 2, Closed: false},
-		{OutboxID: 30, JobID: 3, Closed: true},
+		{OutboxID: 30, JobID: 3, Closed: false},
+		{OutboxID: 40, JobID: 4, Closed: true},
+		{OutboxID: 50, JobID: 5, Closed: true},
 	}
 
 	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opt())
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if stats.Indexed != 2 || stats.Removed != 1 || stats.Failed != 0 || stats.DeadLettered != 0 {
-		t.Fatalf("stats = %+v, want indexed=2 removed=1 failed=0 dead=0", stats)
+	if stats.Indexed != 3 || stats.Removed != 2 || stats.Failed != 0 {
+		t.Fatalf("stats = %+v, want indexed=3 removed=2 failed=0", stats)
 	}
-	if !has(ix.indexed, 1) || !has(ix.indexed, 2) {
-		t.Errorf("indexed = %v, want jobs 1 and 2 embedded", ix.indexed)
+	// The whole wave of open jobs must be embedded in ONE IndexOpen call and completed
+	// in ONE CompleteOpen call — that is the batching (one Meili task per wave).
+	if len(ix.indexCalls) != 1 || len(ix.indexCalls[0]) != 3 {
+		t.Errorf("IndexOpen calls = %v, want a single 3-job batch", ix.indexCalls)
 	}
-	if !has(ix.removed, 3) {
-		t.Errorf("removed = %v, want job 3 removed", ix.removed)
+	if len(store.openBatches) != 1 || len(store.openBatches[0]) != 3 {
+		t.Errorf("CompleteOpen batches = %v, want a single 3-entry batch", store.openBatches)
 	}
-	if !has(store.openDone, 1) || !has(store.openDone, 2) {
-		t.Errorf("openDone = %v, want 1 and 2", store.openDone)
+	if len(ix.removeCall) != 1 || len(ix.removeCall[0]) != 2 {
+		t.Errorf("RemoveClosed calls = %v, want a single 2-id batch", ix.removeCall)
 	}
-	if !has(store.closedDone, 3) {
-		t.Errorf("closedDone = %v, want 3", store.closedDone)
-	}
-	// The open path must stamp the model and the exact embedded content_hash (NULL stays NULL).
-	if s := store.openStamps[1]; s.model != "e5-test" || !s.hash.Valid || s.hash.String != "h1" {
-		t.Errorf("job 1 stamp = %+v, want model e5-test / hash h1", s)
-	}
-	if s := store.openStamps[2]; s.model != "e5-test" || s.hash.Valid {
-		t.Errorf("job 2 stamp = %+v, want model e5-test / NULL hash", s)
+	if len(store.closedBatches) != 1 || len(store.closedBatches[0]) != 2 {
+		t.Errorf("CompleteClosed batches = %v, want a single 2-entry batch", store.closedBatches)
 	}
 }
 
-func TestRunnerFailureDoesNotAbort(t *testing.T) {
+func TestRunnerFallsBackToPerItemOnBatchFailure(t *testing.T) {
 	store := newFakeStore()
 	ix := newFakeIndexer()
+	ix.batchFails = true                           // the multi-job batch embed fails
+	ix.indexErr[2] = errors.New("job 2 is poison") // and job 2 fails individually too
+	for _, id := range []int64{1, 2, 3} {
+		store.jobs[id] = db.Job{ID: id}
+	}
+	store.pending = []Claimed{
+		{OutboxID: 10, JobID: 1, Closed: false},
+		{OutboxID: 20, JobID: 2, Closed: false},
+		{OutboxID: 30, JobID: 3, Closed: false},
+	}
+
+	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opt())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Batch failed → per-item retry: jobs 1 and 3 succeed, job 2 fails in isolation.
+	if stats.Indexed != 2 || stats.Failed != 1 {
+		t.Fatalf("stats = %+v, want indexed=2 failed=1 (only the poison job fails)", stats)
+	}
+	if !has(ix.indexed, 1) || !has(ix.indexed, 3) {
+		t.Errorf("indexed = %v, want jobs 1 and 3 to survive the poison job", ix.indexed)
+	}
+	if len(store.failCalls) != 1 || store.failCalls[0].outboxID != 20 {
+		t.Errorf("failCalls = %+v, want one for outbox 20 (job 2)", store.failCalls)
+	}
+}
+
+func TestRunnerCorruptedRowDeadLettersInFallback(t *testing.T) {
+	store := newFakeStore()
+	ix := newFakeIndexer()
+	// A corrupted row aborts the batch load; the per-item fallback isolates it and
+	// dead-letters it immediately (maxAttempts=1), while the rest embed.
+	store.jobErr[2] = &pgconn.PgError{Code: "XX001"}
 	store.jobs[1] = db.Job{ID: 1}
-	store.jobs[2] = db.Job{ID: 2}
-	ix.indexErr[1] = errors.New("embed backend down") // job 1's embed fails
+	store.jobs[3] = db.Job{ID: 3}
 	store.pending = []Claimed{
 		{OutboxID: 10, JobID: 1, Closed: false},
 		{OutboxID: 20, JobID: 2, Closed: false},
+		{OutboxID: 30, JobID: 3, Closed: false},
 	}
 
 	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opt())
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if stats.Indexed != 1 || stats.Failed != 1 {
-		t.Fatalf("stats = %+v, want indexed=1 failed=1 (job 2 still done despite job 1 failing)", stats)
-	}
-	if !has(ix.indexed, 2) {
-		t.Errorf("job 2 not indexed — a sibling failure aborted the wave")
-	}
-	if len(store.failCalls) != 1 || store.failCalls[0].outboxID != 10 || store.failCalls[0].maxAttempts != opt().MaxAttempts {
-		t.Errorf("failCalls = %+v, want one for outbox 10 at maxAttempts=%d", store.failCalls, opt().MaxAttempts)
-	}
-}
-
-func TestRunnerCorruptedRowDeadLettersImmediately(t *testing.T) {
-	store := newFakeStore()
-	ix := newFakeIndexer()
-	// A corrupted row can never load — it must dead-letter on the first attempt
-	// (maxAttempts=1), not burn the whole attempt budget across cron runs.
-	store.jobErr[1] = &pgconn.PgError{Code: "XX001"} // data_corrupted
-	store.pending = []Claimed{{OutboxID: 10, JobID: 1, Closed: false}}
-
-	stats, err := Runner{Store: store, Indexer: ix}.Run(context.Background(), opt())
-	if err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-	if stats.DeadLettered != 1 || stats.Indexed != 0 {
-		t.Fatalf("stats = %+v, want dead=1 indexed=0", stats)
+	if stats.Indexed != 2 || stats.DeadLettered != 1 {
+		t.Fatalf("stats = %+v, want indexed=2 dead=1", stats)
 	}
 	if len(store.failCalls) != 1 || store.failCalls[0].maxAttempts != 1 {
 		t.Errorf("failCalls = %+v, want one with maxAttempts=1 (immediate dead-letter)", store.failCalls)


### PR DESCRIPTION
## Summary

`cmd/embed` processed one job per outbox entry, each doing an **awaited single-doc** Meilisearch upsert. On a busy prod Meili (shared serial task queue, ingest facet tasks, contended host) each semantic task ran ~34s, so a ~2M backfill crawled at ~0.2 docs/s — impractical. The GPU embedder was idle (~0.6s/doc); the bottleneck was Meili task overhead, not embedding.

This reworks the runner to embed+upsert a **whole claimed wave as ONE batch** (one Meili task per wave), collapsing ~2M tasks into a few thousand. On a batch failure it falls back to per-item processing so a poison/corrupted row can't sink the wave. The incremental worker is otherwise unchanged; `reindex --semantic` stays the reconciler.

- **`internal/embed`** — Store/Indexer ports go batch (`Jobs`, `IndexOpen([]Job)`, `CompleteOpen([]entries)`, `RemoveClosed([]ids)`); `processOpenBatch`/`processClosedBatch` with per-item `fallback*`/`process*One`. Preserves corrupted-row → immediate dead-letter and fail-never-aborts. Waves run sequentially now (embed concurrency lives inside the batch), so the tally mutex is gone.
- **queries** — `GetJobsByIDs` + `StampSemanticEmbeddedBatch`/`ClearSemanticEmbeddedBatch`/`DeleteSemanticEntriesBatch`; single-row variants removed. The batch stamp copies `content_hash` in SQL (nullable-safe); a documented one-revision-stale caveat replaces the per-item narg pass-through.
- **config** — `EMBED_BATCH_SIZE` (default 500) replaces the old wave-concurrency knob; `EMBED_CONCURRENCY` still chunks embeds inside a batch.

Follow-up to #522 (the incremental semantic-embedding worker).

## Test Plan
- [x] `go build ./...`, `go vet ./...` (+ `-tags=integration`) clean; gofmt clean
- [x] Unit: `internal/embed` (batch happy path asserts a single IndexOpen+CompleteOpen call; fallback-on-batch-failure isolates a poison job; corrupted-row → immediate dead-letter), `internal/config`
- [x] Integration (Docker): `internal/db` `TestSemantic*` (batch stamp/clear/delete, NULL-hash), `cmd/embed` `TestIntegration_EmbedWorkerDrainsQueue` (batched enqueue→drain→open embedded/closed removed/provenance/outbox drained)
- [x] Code review clean (0 Critical/Important)