### PR TITLE
feat(web): jobs onboarding wizard on /jobs

### DIFF
--- a/openspec/changes/jobs-onboarding-wizard/.openspec.yaml
+++ b/openspec/changes/jobs-onboarding-wizard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/jobs-onboarding-wizard/design.md
+++ b/openspec/changes/jobs-onboarding-wizard/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`/jobs` is a SvelteKit route whose filter state is URL-first: `JobsView.svelte` builds a `FilterStore` from `page.url.searchParams`, and a `$effect` reloads the list and facet counts (no navigation) whenever the debounced `filters.applied` snapshot changes. Filters serialize to a query string via `facetModel.ts` (`filtersToParams`/`filtersFromParams`) and persist to `localStorage` under `hire.jobFilters` (`filterStorage.ts`); on a soft `/jobs` navigation, `JobsView`'s `afterNavigate` restores them. Facet vocabularies and labels are already exported from `facets.ts`/`labels.ts` and the generated contracts (`CATEGORY_OPTIONS`, `roleLabel`/`ROLE_LABELS`, `WORK_MODE_VALUES`, `SENIORITY_VALUES`, region options). `FilterStore.apply(query)` already seeds the whole store from a query string (used by saved searches).
+
+The onboarding wizard therefore has a clean insertion surface: it can produce a filter query and hand it to the existing store, and the feed reconfigures with zero new plumbing. This slice is deliberately frontend-only and anonymous — no backend, DB, or auth changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reconfigure the existing feed from a captured preference set in one confirm, reusing the existing filter store, persistence, and facet counts.
+- Keep the wizard a thin front-door: its output is a standard filter query, fully editable/clearable through the existing FilterModal.
+- Surface onboarding non-intrusively (banner + persistent entry point) and make it skippable.
+- Handle the narrow-feed case honestly (count + relax action), since this slice has no semantic fallback.
+
+**Non-Goals:**
+- CV-upload auto-fill, semantic "similar-by-meaning" expansion, Telegram saved-search alert, account/DB persistence, cross-device sync. Each is a later change; their seams are already identified (`/me/resume/extract`, `semantic_ratio`, `/me/searches` + `/me/subscriptions`, `user_profiles`).
+- Any change to filter, search, or persistence *requirements*. The wizard consumes them unchanged.
+
+## Decisions
+
+**D1 — Output is a filter query, applied via `FilterStore.apply`, not a new preference model.**
+The wizard collects selections in its own staged local state (mirroring how `StagedFilters` isolates edits) and on confirm maps them to a query string through the existing `filtersToParams`, then calls `FilterStore.apply(query)`. *Alternative considered:* a dedicated onboarding preference object threaded into `JobsView`. Rejected — it would duplicate the filter representation and break "editable through the standard filter UI." Reusing the query keeps one source of truth and makes the persistence and FilterModal integration free.
+
+**D2 — Persistence reuses `hire.jobFilters`; onboarding lifecycle is a separate small flag.**
+Applying the query naturally flows into the existing `saveJobFilters` path, so the configured feed survives a return visit with no new persistence code. A separate `hire.onboarding` key (`{ state: 'unseen' | 'seen' | 'done' }`) governs only banner visibility, keeping feed state and UI-nudge state decoupled. *Alternative:* overload `hire.jobFilters` presence as the "done" signal. Rejected — a user who clears filters would wrongly re-trigger the banner.
+
+**D3 — A single one-time banner as the only trigger.**
+Per product decision, the entry is one unobtrusive banner above the feed (not an auto-opening modal). The banner renders only when: standalone feed **and** `hire.onboarding` ≠ `done`/`seen`-dismissed **and** no active filters in the store. It is the sole entry point — once dismissed or completed it retires; there is no persistent re-open control (deliberately: keep the surface calm, the wizard is a first-run nudge, not a recurring tool). This isolates "should we nudge?" logic in one place.
+
+**D4 — Relax-filter order is fixed by specificity (stack → region → seniority).**
+With no semantic fallback in this slice, a narrow selection can empty the feed. The relax action removes the single narrowest applied preference and re-applies, surfacing the change in both feed and filter state. Fixed order beats "remove last-added" (unpredictable) and beats auto-broadening (violates "never silently broaden"). Role is intentionally never auto-dropped — it's the user's primary intent.
+
+**D5 — Component boundaries.**
+- `OnboardingWizard.svelte` — owns staged selection + steps; emits `onComplete(query)` / `onSkip()`. Ignorant of URL/localStorage. Pickers built from `facets.ts` vocabularies.
+- `OnboardingBanner.svelte` — presentational; knows only shown/hidden and emits open/dismiss.
+- `onboarding.ts` — the only impure unit: `selectionsToQuery(selection)` (over `filtersToParams`), the narrowest-facet resolver for relax, and `hire.onboarding` state read/write.
+- `JobsView.svelte` — hosts the banner, wires `onComplete` → `filters.apply(query)`, and decides banner visibility. This is the only edit to existing code.
+
+## Risks / Trade-offs
+
+- **[Wizard vocabularies drift from search params]** → Build every picker from the exported `facets.ts`/contracts vocabularies and map exclusively through `filtersToParams`; a unit test asserts `filtersFromParams(selectionsToQuery(s))` round-trips the selection. No hand-written param strings.
+- **[Stack values / rendering]** → The stack picker reuses the filter panel's `SearchSelect` fed by the live skills facet distribution, so stack values are drawn from the controlled skills vocabulary (only skills that exist in the catalogue) rather than arbitrary free text — and render as escaped text via Svelte's default `{value}` binding, never raw HTML.
+- **[Banner nags users who already filtered or already onboarded]** → Visibility guard keys on both the `hire.onboarding` flag and "no active filters"; dismissing sets `seen` so it will not reappear.
+- **[Narrow feed feels dead]** → Honest count + relax action in the existing empty-state; the richer "similar-by-meaning" experience is explicitly deferred, not faked.
+- **[localStorage unavailable / private mode]** → Treat storage read/write as best-effort; on failure the wizard still works for the session (feed reconfigures in-memory) and the banner simply falls back to its default (may reappear). No hard failure.
+
+## Migration Plan
+
+Pure additive frontend change — no schema, no API, no data migration. Ships with the web build. Rollback is reverting the `JobsView.svelte` edit and removing the new files; no persisted server state is created. The new `hire.onboarding` localStorage key is inert if the feature is removed.
+
+## Open Questions
+
+- Banner dismissal scope: does "×" suppress for the session or permanently (`seen` persisted)? Leaning permanent-until-cleared for calm UX; final call during implementation, low-risk to flip.
+- Exact placement of the persistent "configure feed" control (header vs. filter toolbar) — a UI detail to settle against the current `/jobs` layout during implementation.

--- a/openspec/changes/jobs-onboarding-wizard/proposal.md
+++ b/openspec/changes/jobs-onboarding-wizard/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `/jobs` page greets every visitor with a reverse-chronological wall of the whole catalogue — postings in mixed languages, C-level next to junior, no relevance. The landing page promises *"every tech job in one clean feed"*, but the feed a user actually lands on is neither clean nor theirs. Nothing prompts a first-time visitor to narrow it, so the product's normalization and facets (role/seniority/geo/skills) go unfelt. A short, skippable onboarding turns the wall into "your feed" in ~15 seconds, using filters that already exist.
+
+## What Changes
+
+- Add a 3-step onboarding wizard to `/jobs` (frontend-only): **step 1** role + seniority, **step 2** work-mode + region + stack, **step 3** payoff (feed reconfigures, wizard closes).
+- The wizard's selections map to the **existing facet filter query** and are applied through the existing `FilterStore` — the wizard is a friendly front-door to current filters, not a parallel system. Re-editing or clearing via the existing FilterModal keeps working unchanged.
+- Trigger: an **unobtrusive banner above the feed** ("Собрать твою ленту →") that expands the wizard, plus a **persistent "Настроить ленту" entry point**. The banner shows only on a fresh `/jobs` (no active filters, onboarding not yet completed).
+- Persist the resulting filter set to `localStorage` via the existing `hire.jobFilters` mechanism, plus a small `hire.onboarding` flag (seen/done) that controls banner visibility. No account required.
+- Empty/narrow feed: when the chosen filters yield few or zero jobs, show the honest count and an **"ослабить фильтр"** action that drops the narrowest facet (stack → region → seniority).
+- **Out of scope for this slice** (each a later change): CV-upload auto-fill, semantic "similar-by-meaning" expansion, Telegram saved-search alert, persisting preferences to the account/DB, cross-device sync.
+
+## Capabilities
+
+### New Capabilities
+- `jobs-onboarding`: A skippable, anonymous onboarding wizard on `/jobs` that captures role/seniority/work-mode/region/stack (or is dismissed), reconfigures the existing job feed through the existing facet filters, persists the result to `localStorage`, and is surfaced by a banner plus a persistent entry point. Includes the narrow-feed "relax filter" affordance.
+
+### Modified Capabilities
+<!-- None. The wizard reuses filter-persistence, filter-modal, and job-search behavior without changing their requirements. -->
+
+## Impact
+
+- **Frontend only** (`web/`): new `web/src/lib/components/onboarding/OnboardingWizard.svelte`, `OnboardingBanner.svelte`, and a `web/src/lib/onboarding.ts` helper (selection→query mapping + localStorage state); a small edit to `web/src/lib/components/JobsView.svelte` to host the banner and apply the wizard's query.
+- **Reuses, does not change:** `web/src/lib/facets.ts` vocabularies (`CATEGORY_OPTIONS`, `roleLabel`, `WORK_MODE_VALUES`, `SENIORITY_VALUES`, region options), `web/src/lib/facetModel.ts` (`filtersToParams`/`filtersFromParams`), `web/src/lib/filters.ts` (`FilterStore.apply`), `web/src/lib/filterStorage.ts` (`hire.jobFilters`).
+- **No backend, no DB migration, no new API endpoints, no new dependencies.**
+- New `localStorage` key `hire.onboarding`; the existing `hire.jobFilters` key is written through its existing helper.

--- a/openspec/changes/jobs-onboarding-wizard/specs/jobs-onboarding/spec.md
+++ b/openspec/changes/jobs-onboarding-wizard/specs/jobs-onboarding/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Onboarding wizard captures feed preferences
+
+The system SHALL present a skippable multi-step wizard that captures a visitor's job-feed preferences — role, seniority, work mode, region, and stack — without requiring an account.
+
+The wizard presents preferences across steps: step one captures role and seniority; step two captures work mode, region, and stack. All fields are optional, and any field may be left empty. The wizard offers pickers built from the same controlled vocabularies the job search understands (categories, work modes, seniority levels, regions), so a captured preference is always a value the feed can filter on. The stack picker suggests skills from the live skills facet distribution (busiest first, with per-skill job counts) and filters them typo-tolerantly as the user types, so it only offers skills that exist in the catalogue.
+
+#### Scenario: User completes the wizard with a full selection
+
+- **WHEN** a visitor opens the wizard, selects a role, a seniority, a work mode, a region, and one or more stack items, and confirms
+- **THEN** the feed reconfigures to those preferences and the wizard closes
+
+#### Scenario: User confirms with a partial selection
+
+- **WHEN** a visitor selects only a role and confirms without choosing seniority, work mode, region, or stack
+- **THEN** the feed reconfigures using only the role and the wizard closes
+
+#### Scenario: User picks a stack skill from the live suggestions
+
+- **WHEN** a visitor types into the stack picker and selects a suggested skill
+- **THEN** the skill is captured as a stack preference, drawn from the skills facet vocabulary, and rendered safely as text (no markup injection)
+
+### Requirement: Wizard reconfigures the existing job feed through existing filters
+
+The system SHALL translate the wizard's selections into the existing facet filter query and apply them through the existing filter store, so that the resulting feed, its facet counts, and subsequent re-editing behave identically to filters set through the standard filter UI.
+
+The wizard MUST NOT introduce a parallel feed, ranking, or filter representation. Preferences left empty MUST NOT constrain the feed.
+
+#### Scenario: Selections become standard filter query params
+
+- **WHEN** the wizard applies a selection of role and work mode
+- **THEN** the feed shows the same results as if those same facet values had been chosen in the standard filter UI
+
+#### Scenario: Wizard result is editable through the standard filter UI
+
+- **WHEN** a visitor completes the wizard and then opens the standard filter UI
+- **THEN** the wizard's selections appear as the current filter state and can be changed or cleared through the normal controls
+
+### Requirement: Onboarding is surfaced by a one-time banner
+
+The system SHALL surface onboarding through a single unobtrusive banner shown above the feed. The banner is the only entry point to the wizard; once dismissed or completed it retires and is not shown again, and there is no persistent re-open control.
+
+The banner SHALL appear only on the standalone jobs feed when onboarding has not been completed and no filters are already active, so it never interrupts a visitor who arrived via a shared filtered link. The banner does not block viewing the feed.
+
+#### Scenario: Banner shown to a fresh visitor
+
+- **WHEN** a visitor opens the standalone jobs feed with no active filters and has not completed onboarding
+- **THEN** the banner is displayed above the feed and the feed remains browsable
+
+#### Scenario: Banner hidden when arriving with active filters
+
+- **WHEN** a visitor opens the jobs feed via a link that already carries filter params
+- **THEN** the banner is not displayed
+
+#### Scenario: Banner opens the wizard
+
+- **WHEN** a visitor activates the banner's set-up action
+- **THEN** the wizard opens
+
+### Requirement: Onboarding preferences persist locally across visits
+
+The system SHALL persist the wizard's resulting filter set to local browser storage using the existing job-filter persistence mechanism, and SHALL record onboarding completion state locally so the banner is not shown again after completion.
+
+Persistence MUST NOT require authentication and MUST NOT write to any server or account.
+
+#### Scenario: Configured feed survives a return visit
+
+- **WHEN** a visitor completes the wizard and later returns to the standalone jobs feed in the same browser
+- **THEN** the feed is restored to the configured preferences
+
+#### Scenario: Banner does not reappear after completion
+
+- **WHEN** a visitor has completed the wizard
+- **THEN** the banner is not shown on subsequent visits, while the persistent entry point remains available
+
+### Requirement: Onboarding can be skipped
+
+The system SHALL allow a visitor to dismiss the banner or exit the wizard without making a selection, leaving the feed unchanged.
+
+Dismissing the banner SHALL suppress it from reappearing, without altering the current feed.
+
+#### Scenario: Visitor dismisses the banner
+
+- **WHEN** a visitor dismisses the banner without opening the wizard
+- **THEN** the banner is suppressed on subsequent visits and the feed is unchanged
+
+#### Scenario: Visitor exits the wizard without confirming
+
+- **WHEN** a visitor opens the wizard and closes it without confirming a selection
+- **THEN** the feed is unchanged and the wizard closes
+
+### Requirement: Narrow feed offers a relax-filter affordance
+
+The system SHALL, when the configured preferences yield few or no matching jobs, display the honest result count and an action that relaxes the feed by removing the narrowest applied preference.
+
+Relaxing SHALL remove one preference at a time in order of specificity — stack first, then region, then seniority — and reflect the change in the feed and its filter state. The system MUST NOT silently broaden the feed on its own.
+
+#### Scenario: Zero results offers relax action
+
+- **WHEN** the configured preferences match no open jobs
+- **THEN** an empty-state message with the count and a "relax filter" action is shown
+
+#### Scenario: Relaxing removes the narrowest preference first
+
+- **WHEN** a visitor with role, region, and stack preferences activates the relax action
+- **THEN** the stack preference is removed first and the feed and filter state update to reflect the broader query

--- a/openspec/changes/jobs-onboarding-wizard/tasks.md
+++ b/openspec/changes/jobs-onboarding-wizard/tasks.md
@@ -1,0 +1,30 @@
+## 1. Selection→query helper and lifecycle state (`web/src/lib/onboarding.ts`)
+
+- [x] 1.1 Define the wizard `Selection` type (role, seniority, workMode, region, stack[]) and a `selectionsToQuery(selection)` that maps it through the existing `filtersToParams` — no hand-written param strings; empty fields contribute nothing.
+- [x] 1.2 Add `narrowestFacet(filters)` returning the facet to drop for the relax action, in fixed specificity order (skills → regions → seniority; never role), operating on live filter state (`JobFilters`).
+- [x] 1.3 Add `hire.onboarding` state helpers (`loadOnboardingState`/`markSeen`/`markDone`, plus pure `bannerVisible`) over localStorage, best-effort (no throw when storage is unavailable).
+- [x] 1.4 Unit tests (vitest): `filtersFromParams(selectionsToQuery(s))` round-trips for empty / role-only / role+stack / full selections; `narrowestFacet` peels the expected facet first and never the role; lifecycle helpers no-op safely when localStorage throws (11 tests green).
+
+## 2. Wizard component (`web/src/lib/components/onboarding/OnboardingWizard.svelte`)
+
+- [x] 2.1 Build the step flow: step 1 focus + seniority, step 2 work-mode + region + stack, confirm on the last step; back/skip on each step; staged local selection isolated from the live store. (Payoff is the reconfigured feed after close — no separate in-wizard screen.)
+- [x] 2.2 Build pickers from the exported `facets.ts` vocabularies (`CATEGORY_OPTIONS` for focus, `FACETS` options for seniority/work-mode/regions minus the `none` sentinel); all fields optional, single-select coarse facets.
+- [x] 2.3 Stack picker reuses the filter panel's `SearchSelect` fed by the live skills facet distribution (`counts.facets.skills`, busiest-first with counts): type to filter typo-tolerantly, click to add/remove. Values come from the controlled skills vocabulary and render as escaped text.
+- [x] 2.4 Emit `onComplete(query)` (from `selectionsToQuery`) on confirm and `onCancel()` on exit-without-confirm; component stays ignorant of URL/localStorage.
+
+## 3. Banner component (`web/src/lib/components/onboarding/OnboardingBanner.svelte`)
+
+- [x] 3.1 Presentational banner ("Make this your feed") with a Set-up action and a dismiss (×); emits `onOpen`/`onDismiss`, knows only shown/hidden.
+
+## 4. Integrate into the feed (`web/src/lib/components/JobsView.svelte`)
+
+- [x] 4.1 Host the banner above the list; compute visibility = standalone feed AND onboarding not done/dismissed AND no active filters (`bannerVisible`).
+- [x] 4.2 Wire the wizard: `onComplete(query)` → `filters.apply(query)` (feed + facet counts reconfigure via existing `$effect`; persistence flows through existing `saveJobFilters`), then `markDone`; `onCancel`/banner dismiss → `markSeen`.
+- [x] 4.3 (Per product decision, no persistent entry point.) The banner is the sole trigger: once dismissed/completed it retires and there is no re-open control.
+- [x] 4.4 Extend the existing empty-state: when the applied query yields zero results and a relaxable facet is set, show a "Broaden search" action calling `relaxFeed` (drops the narrowest facet via `clearFacet`).
+
+## 5. Verify
+
+- [x] 5.1 `npm run check` (svelte-check: 0 errors) and vitest (92 passed) green; `npm run lint` clean on new files.
+- [x] 5.2 Visual verification via throwaway route + headless Chrome: banner + wizard steps 1 & 2 render in the app theme, step navigation works, region picker excludes the `none` sentinel; screenshots captured (throwaway route removed after).
+- [x] 5.3 Confirmed by construction: `completeWizard` calls `filters.apply(query)`, which seeds the same `FilterStore` the FilterModal's `StagedFilters` reads on open — so the wizard's result is editable/clearable through the standard filter UI with no parallel state (covered by the `selectionsToQuery` round-trip test).

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -11,6 +11,16 @@
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams } from '$lib/filters';
   import { loadJobFilters } from '$lib/filterStorage';
+  import {
+    bannerVisible,
+    loadOnboardingState,
+    markDone,
+    markSeen,
+    narrowestFacet,
+    type OnboardingLifecycle,
+  } from '$lib/onboarding';
+  import OnboardingWizard from './onboarding/OnboardingWizard.svelte';
+  import OnboardingBanner from './onboarding/OnboardingBanner.svelte';
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
   import { setListSearchTarget } from '$lib/listSearch.svelte';
   import type { Job, FacetCounts } from '$lib/types';
@@ -94,6 +104,45 @@
 
   let modalOpen = $state(false);
   let started = false;
+
+  // Onboarding: the one-time nudge banner + wizard, standalone-only. The lifecycle
+  // lives in localStorage (client-only); seed it at init on the client so a returning
+  // (dismissed/completed) visitor never flashes a banner before mount. The banner is
+  // the sole entry — once dismissed or completed it retires; there is no persistent
+  // re-open control.
+  let wizardOpen = $state(false);
+  let onboardingState = $state<OnboardingLifecycle>(browser ? loadOnboardingState() : 'unseen');
+  // Show only to an un-nudged visitor with no active facet filters AND no text query,
+  // so a shared search/filter link is never interrupted (activeFilterCount ignores the
+  // query, so check it explicitly). Gated on `browser`: never SSR the banner.
+  const showBanner = $derived(
+    browser && standalone && bannerVisible(onboardingState, filters.active > 0 || filters.value.q.trim() !== ''),
+  );
+
+  function dismissBanner() {
+    markSeen();
+    onboardingState = 'seen';
+  }
+  function cancelWizard() {
+    wizardOpen = false;
+    markSeen();
+    onboardingState = loadOnboardingState(); // markSeen never downgrades a completed run
+  }
+  function completeWizard(query: string) {
+    // Apply through the same store path as a saved search — feed, counts, and
+    // localStorage all reconfigure via the existing effect; then the banner retires.
+    filters.apply(query);
+    markDone();
+    onboardingState = 'done';
+    wizardOpen = false;
+  }
+  // Narrow-feed relief: the single narrowest applied facet to drop (skills → regions →
+  // seniority; never the role), or null if none. Shared by the empty-state guard and
+  // the relax action so they can't disagree. Never broadens on its own.
+  const relaxTarget = $derived(narrowestFacet(filters.value));
+  function relaxFeed() {
+    if (relaxTarget) filters.clearFacet(relaxTarget);
+  }
 
   // Live disjunctive facet counts for the staged filter set (built by the modal),
   // merged with the fixed scope params (e.g. company_slug) so every control's counts —
@@ -212,12 +261,33 @@
   </aside>
 
   <div class="min-w-0 flex-1">
+    {#if showBanner}
+      <!-- pl-12 md:pl-0 clears the mobile filters edge tab, matching the count row.
+           The banner is the only onboarding entry: it shows once (until dismissed or
+           completed), then retires — no persistent re-open control. -->
+      <div class="pl-12 md:pl-0">
+        <OnboardingBanner onOpen={() => (wizardOpen = true)} onDismiss={dismissBanner} />
+      </div>
+    {/if}
     {#if jobs.status === 'loading'}
       <States state="loading" />
     {:else if jobs.status === 'error'}
       <States state="error" message="Failed to load jobs." />
     {:else if jobs.items.length === 0}
       <States state="empty" message="No matching jobs." />
+      {#if standalone && relaxTarget}
+        <!-- No semantic fallback in this slice: offer an honest one-step broaden
+             instead of silently widening the feed. -->
+        <div class="mt-4 flex justify-center">
+          <button
+            type="button"
+            onclick={relaxFeed}
+            class="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-4 py-2 text-sm font-medium transition-colors hover:bg-accent"
+          >
+            Broaden search
+          </button>
+        </div>
+      {/if}
     {:else}
       <!-- Standalone: the count is the topmost element, level with the fixed edge
            tab, so pl-12 clears it (reset at md). Company embed: the count sits well
@@ -278,3 +348,7 @@
   onClose={() => (modalOpen = false)}
   {stagedCounts}
 />
+
+{#if standalone}
+  <OnboardingWizard open={wizardOpen} {counts} onComplete={completeWizard} onCancel={cancelWizard} />
+{/if}

--- a/web/src/lib/components/facets/FacetSection.svelte
+++ b/web/src/lib/components/facets/FacetSection.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { X } from '@lucide/svelte';
-  import { dynamicLabel, type FacetDef, type FacetOption, type FacetStore } from '$lib/facets';
+  import { dynamicLabel, dynamicOptions, type FacetDef, type FacetOption, type FacetStore } from '$lib/facets';
   import type { FacetCounts } from '$lib/types';
   import PillGroup from './PillGroup.svelte';
   import RemoteSearchSelect from './RemoteSearchSelect.svelte';
@@ -26,11 +26,7 @@
   // removable.
   const selectOptions = $derived.by((): FacetOption[] => {
     if (!def.dynamic) return def.options ?? [];
-    const dist = counts?.facets?.[def.param] ?? {};
-    const keys = new Set<string>([...Object.keys(dist), ...st.include, ...st.exclude]);
-    return [...keys]
-      .map((value) => ({ value, label: dynamicLabel(def.param, value), count: dist[value] ?? 0 }))
-      .toSorted((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+    return dynamicOptions(def.param, counts?.facets?.[def.param] ?? {}, [...st.include, ...st.exclude]);
   });
   // The match/clear actions only appear once something is selected — so their
   // meaning is clear ("you picked these — match all, or clear them") rather than

--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -36,6 +36,10 @@
       push(label, facetChips(param));
     };
 
+    // The text query (from the header search on the standalone list) as a removable
+    // chip, so the sidebar shows what you searched, not just the facet filters.
+    push('Search', f.q.trim() ? [{ text: f.q, exclude: false, remove: () => store.setQuery('') }] : []);
+
     facetGroup('category', 'Specialization');
     // Location: regions + countries + cities under one heading.
     push('Location', [...facetChips('regions'), ...facetChips('countries'), ...facetChips('cities')]);

--- a/web/src/lib/components/onboarding/OnboardingBanner.svelte
+++ b/web/src/lib/components/onboarding/OnboardingBanner.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { Sparkles, X } from '@lucide/svelte';
+
+  // The unobtrusive nudge above the /jobs feed. Presentational only: it knows
+  // whether it's shown and emits open/dismiss — JobsView owns visibility (unseen
+  // AND no active filters) and lifecycle. Never blocks the feed below it.
+  let { onOpen, onDismiss }: { onOpen: () => void; onDismiss: () => void } = $props();
+</script>
+
+<div class="mb-3 flex items-center gap-3 rounded-xl border border-border bg-card p-3 pl-4 sm:pl-4">
+  <div class="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+    <Sparkles class="size-4.5" />
+  </div>
+  <div class="min-w-0 flex-1">
+    <p class="text-sm font-semibold tracking-tight">Make this your feed</p>
+    <p class="truncate text-xs text-muted-foreground">Answer 2 quick questions — see only jobs that fit you.</p>
+  </div>
+  <button
+    type="button"
+    onclick={onOpen}
+    class="inline-flex h-9 shrink-0 items-center rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+  >
+    Set up
+  </button>
+  <button
+    type="button"
+    onclick={onDismiss}
+    aria-label="Dismiss"
+    class="flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+  >
+    <X class="size-4" />
+  </button>
+</div>

--- a/web/src/lib/components/onboarding/OnboardingWizard.svelte
+++ b/web/src/lib/components/onboarding/OnboardingWizard.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  import { ArrowLeft, ArrowRight, Sparkles, X } from '@lucide/svelte';
+  import {
+    FACETS,
+    CATEGORY_OPTIONS,
+    REGION_UNSPECIFIED,
+    dynamicOptions,
+    type FacetOption,
+  } from '$lib/facets';
+  import type { FacetCounts } from '$lib/types';
+  import { emptySelection, selectionsToQuery, type OnboardingSelection } from '$lib/onboarding';
+  import SearchSelect from '../facets/SearchSelect.svelte';
+
+  // The /jobs onboarding wizard: a skippable overlay that captures coarse feed
+  // preferences and emits the equivalent filter query. It owns only its staged
+  // selection and step — it knows nothing about the URL, the filter store, or
+  // localStorage; the parent (JobsView) applies the query and records lifecycle.
+  // Two selection steps; the reconfigured feed after `onComplete` is the payoff.
+  let {
+    open = false,
+    counts = null,
+    onComplete,
+    onCancel,
+  }: {
+    open?: boolean;
+    /** Live facet distribution — feeds the stack picker's skill suggestions. */
+    counts?: FacetCounts | null;
+    /** Confirmed: the equivalent filter query string (empty if nothing was picked). */
+    onComplete: (query: string) => void;
+    /** Dismissed without confirming (Escape / backdrop / skip) — feed unchanged. */
+    onCancel: () => void;
+  } = $props();
+
+  // Option vocabularies drawn from the same registry the search understands, so a
+  // captured preference is always a value the feed can filter on. Regions drop the
+  // "not specified" sentinel — onboarding is about choosing a place, not its absence.
+  const facetOptions = (param: string): FacetOption[] => FACETS.find((f) => f.param === param)?.options ?? [];
+  const specializationOptions = CATEGORY_OPTIONS;
+  const seniorityOptions = facetOptions('seniority');
+  const workModeOptions = facetOptions('work_mode');
+  const regionOptions = facetOptions('regions').filter((o) => o.value !== REGION_UNSPECIFIED);
+
+  // Stack suggestions come from the live skills distribution (the same builder the
+  // filter panel's Skills select uses), so the picker only offers skills that exist in
+  // the catalogue — busiest first, with job counts; already-picked values stay listed.
+  const skillOptions = $derived.by(() => dynamicOptions('skills', counts?.facets?.skills ?? {}, sel.stack));
+
+  const TOTAL_STEPS = 2;
+  let step = $state(1);
+  let sel = $state<OnboardingSelection>(emptySelection());
+
+  // Reset staged state each time the wizard opens, so a re-open starts fresh.
+  let wasOpen = false;
+  $effect(() => {
+    if (open && !wasOpen) {
+      step = 1;
+      sel = emptySelection();
+    }
+    wasOpen = open;
+  });
+
+  // Coarse facets are single-select in the wizard (the full FilterModal covers
+  // multi-select afterward): clicking the active value clears it.
+  function pickOne(field: 'specialization' | 'seniority' | 'workMode' | 'region', value: string) {
+    sel = { ...sel, [field]: sel[field] === value ? undefined : value };
+  }
+
+  // Stack is multi-select from the skills suggestions: toggle a skill in/out.
+  function toggleStack(value: string) {
+    sel = sel.stack.includes(value)
+      ? { ...sel, stack: sel.stack.filter((s) => s !== value) }
+      : { ...sel, stack: [...sel.stack, value] };
+  }
+
+  function complete() {
+    onComplete(selectionsToQuery(sel));
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onCancel();
+  }
+</script>
+
+<svelte:window onkeydown={open ? onKeydown : undefined} />
+
+<!-- One single-select pill group; the active value clears on re-click (see pickOne). -->
+{#snippet pills(field: 'specialization' | 'seniority' | 'workMode' | 'region', options: FacetOption[])}
+  <div class="flex flex-wrap gap-2">
+    {#each options as o (o.value)}
+      <button
+        type="button"
+        onclick={() => pickOne(field, o.value)}
+        aria-pressed={sel[field] === o.value}
+        class={[
+          'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+          sel[field] === o.value ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-card hover:bg-accent',
+        ]}
+      >
+        {o.label}
+      </button>
+    {/each}
+  </div>
+{/snippet}
+
+{#if open}
+  <div class="fixed inset-0 z-50 flex items-stretch justify-center sm:items-center sm:p-6">
+    <button class="absolute inset-0 bg-foreground/35" aria-label="Close" onclick={onCancel}></button>
+
+    <div
+      class="relative flex h-full w-full flex-col overflow-hidden bg-background shadow-2xl sm:h-auto sm:max-h-[calc(100vh-3rem)] sm:max-w-lg sm:rounded-2xl sm:border sm:border-border"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Set up your feed"
+    >
+      <!-- header: step dots + skip -->
+      <div class="flex items-center gap-3 border-b border-border px-5 py-3">
+        <div class="flex flex-1 items-center gap-1.5" aria-hidden="true">
+          {#each { length: TOTAL_STEPS } as _, i (i)}
+            <span class={['h-1 w-7 rounded-full transition-colors', i < step ? 'bg-primary' : 'bg-border']}></span>
+          {/each}
+        </div>
+        <button
+          type="button"
+          onclick={onCancel}
+          class="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Skip
+        </button>
+        <button
+          type="button"
+          onclick={onCancel}
+          aria-label="Close"
+          class="flex size-8 items-center justify-center rounded-lg border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <X class="size-4" />
+        </button>
+      </div>
+
+      <!-- body -->
+      <div class="min-h-0 flex-1 overflow-y-auto px-5 py-5">
+        <div class="mb-1 inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-primary">
+          <Sparkles class="size-3.5" /> Step {step} of {TOTAL_STEPS}
+        </div>
+        {#if step === 1}
+          <h2 class="text-xl font-semibold tracking-tight">What do you do?</h2>
+          <p class="mt-1 text-sm text-muted-foreground">Pick your focus and level — everything's optional.</p>
+
+          <p class="mb-2 mt-5 text-sm font-medium">Focus</p>
+          {@render pills('specialization', specializationOptions)}
+
+          <p class="mb-2 mt-6 text-sm font-medium">Seniority</p>
+          {@render pills('seniority', seniorityOptions)}
+        {:else}
+          <h2 class="text-xl font-semibold tracking-tight">Where and how?</h2>
+          <p class="mt-1 text-sm text-muted-foreground">Work format, region, and stack.</p>
+
+          <p class="mb-2 mt-5 text-sm font-medium">Work format</p>
+          {@render pills('workMode', workModeOptions)}
+
+          <p class="mb-2 mt-6 text-sm font-medium">Region</p>
+          {@render pills('region', regionOptions)}
+
+          <p class="mb-2 mt-6 text-sm font-medium">Stack <span class="font-normal text-muted-foreground">— optional</span></p>
+          <!-- Suggestions come from the live skills facet: type to filter, click to add. -->
+          <SearchSelect
+            options={skillOptions}
+            include={sel.stack}
+            onToggle={toggleStack}
+            clearOnSelect
+            cap={24}
+            placeholder="Search skills…"
+          />
+        {/if}
+      </div>
+
+      <!-- footer: back / next|finish -->
+      <div class="flex items-center gap-3 border-t border-border px-5 py-3">
+        {#if step > 1}
+          <button
+            type="button"
+            onclick={() => (step -= 1)}
+            class="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft class="size-4" /> Back
+          </button>
+        {/if}
+        <div class="flex-1"></div>
+        <button
+          type="button"
+          onclick={step < TOTAL_STEPS ? () => (step += 1) : complete}
+          class="inline-flex h-11 items-center gap-1.5 rounded-lg bg-primary px-6 text-sm font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+        >
+          {step < TOTAL_STEPS ? 'Next' : 'Show jobs'} <ArrowRight class="size-4" />
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -194,6 +194,18 @@ export function uniqueByValue(opts: FacetOption[]): FacetOption[] {
   return opts.filter((o) => (seen.has(o.value) ? false : seen.add(o.value)));
 }
 
+/** Build select options for a dynamic facet from its live distribution (value →
+ *  count) plus any already-selected values (so a selection absent from the current
+ *  distribution stays listed and removable), labelled via dynamicLabel and sorted
+ *  busiest-first. Shared by the filter panel's dynamic selects (FacetSection) and
+ *  the onboarding stack picker. */
+export function dynamicOptions(param: string, dist: Record<string, number>, selected: string[]): FacetOption[] {
+  const keys = new Set<string>([...Object.keys(dist), ...selected]);
+  return [...keys]
+    .map((value) => ({ value, label: dynamicLabel(param, value), count: dist[value] ?? 0 }))
+    .toSorted((a, b) => (b.count ?? 0) - (a.count ?? 0) || a.label.localeCompare(b.label));
+}
+
 // Role slugs carry an optional seniority grade prefix (senior_backend); the
 // related-role map is keyed by the ungraded base (backend), so one entry serves
 // every grade. Longest prefix first is unnecessary — the grades share no
@@ -421,7 +433,7 @@ export const FACETS: FacetDef[] = [
   { param: 'collections', label: 'Collection', control: 'pills', options: COLLECTION, excludable: false },
   { param: 'regions', label: 'Region', control: 'pills', options: JOB_REGION, excludable: true },
   { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
-  { param: 'role', label: 'Role', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search roles', cap: 24, related: ROLE_RELATED, searchAliases: ROLE_ALIASES },
+  { param: 'role', label: 'Role', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search roles', cap: 8, related: ROLE_RELATED, searchAliases: ROLE_ALIASES },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
   { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },
   { param: 'skills', label: 'Skills', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search skills' },

--- a/web/src/lib/onboarding.test.ts
+++ b/web/src/lib/onboarding.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { filtersFromParams } from './facetModel';
+import {
+  emptySelection,
+  selectionsToQuery,
+  narrowestFacet,
+  bannerVisible,
+  loadOnboardingState,
+  markSeen,
+  markDone,
+  ONBOARDING_KEY,
+  type OnboardingSelection,
+} from './onboarding';
+
+// Reuse the same in-memory localStorage stand-in shape as filterStorage.test.ts:
+// the Node test env has no browser storage, so tests install a global per case.
+class MemoryStorage {
+  #map = new Map<string, string>();
+  getItem(k: string): string | null {
+    return this.#map.has(k) ? (this.#map.get(k) as string) : null;
+  }
+  setItem(k: string, v: string): void {
+    this.#map.set(k, v);
+  }
+  removeItem(k: string): void {
+    this.#map.delete(k);
+  }
+}
+
+// Parse a selection's query back into filter facet state, so tests assert the
+// selection survives the round-trip the live store performs (apply → URL → parse).
+const facetsOf = (sel: OnboardingSelection) => filtersFromParams(new URLSearchParams(selectionsToQuery(sel))).facets;
+
+describe('selectionsToQuery', () => {
+  it('is empty for an empty selection', () => {
+    expect(selectionsToQuery(emptySelection())).toBe('');
+  });
+
+  it('maps a role-only selection to the category facet', () => {
+    const f = facetsOf({ ...emptySelection(), specialization: 'backend' });
+    expect(f.category?.include).toEqual(['backend']);
+    expect(f.seniority?.include).toEqual([]);
+    expect(f.skills?.include).toEqual([]);
+  });
+
+  it('round-trips a role + stack selection', () => {
+    const sel: OnboardingSelection = { ...emptySelection(), specialization: 'backend', stack: ['Go', 'Kubernetes'] };
+    const f = facetsOf(sel);
+    expect(f.category?.include).toEqual(['backend']);
+    expect(f.skills?.include).toEqual(['Go', 'Kubernetes']);
+  });
+
+  it('round-trips a full selection across all five facets', () => {
+    const sel: OnboardingSelection = {
+      specialization: 'frontend',
+      seniority: 'senior',
+      workMode: 'remote',
+      region: 'eu',
+      stack: ['TypeScript'],
+    };
+    const f = facetsOf(sel);
+    expect(f.category?.include).toEqual(['frontend']);
+    expect(f.seniority?.include).toEqual(['senior']);
+    expect(f.work_mode?.include).toEqual(['remote']);
+    expect(f.regions?.include).toEqual(['eu']);
+    expect(f.skills?.include).toEqual(['TypeScript']);
+  });
+
+  it('drops blank stack entries', () => {
+    const sel: OnboardingSelection = { ...emptySelection(), stack: ['Go', '  ', ''] };
+    expect(facetsOf(sel).skills?.include).toEqual(['Go']);
+  });
+});
+
+describe('narrowestFacet', () => {
+  it('returns null when no relaxable facet is set', () => {
+    const f = filtersFromParams(new URLSearchParams(selectionsToQuery({ ...emptySelection(), specialization: 'backend' })));
+    // only category (never relaxed) is set
+    expect(narrowestFacet(f)).toBeNull();
+  });
+
+  it('peels stack first, then region, then seniority — never the role', () => {
+    const full = filtersFromParams(
+      new URLSearchParams(
+        selectionsToQuery({ specialization: 'backend', seniority: 'senior', workMode: undefined, region: 'eu', stack: ['Go'] }),
+      ),
+    );
+    expect(narrowestFacet(full)).toBe('skills');
+
+    const noStack = filtersFromParams(
+      new URLSearchParams(selectionsToQuery({ ...emptySelection(), specialization: 'backend', seniority: 'senior', region: 'eu' })),
+    );
+    expect(narrowestFacet(noStack)).toBe('regions');
+
+    const seniorityOnly = filtersFromParams(
+      new URLSearchParams(selectionsToQuery({ ...emptySelection(), specialization: 'backend', seniority: 'senior' })),
+    );
+    expect(narrowestFacet(seniorityOnly)).toBe('seniority');
+  });
+});
+
+describe('bannerVisible', () => {
+  it('shows only for an unseen visitor with no active filters', () => {
+    expect(bannerVisible('unseen', false)).toBe(true);
+    expect(bannerVisible('unseen', true)).toBe(false);
+    expect(bannerVisible('seen', false)).toBe(false);
+    expect(bannerVisible('done', false)).toBe(false);
+  });
+});
+
+describe('onboarding lifecycle state', () => {
+  afterEach(() => {
+    // @ts-expect-error - clean up the global we install per test
+    delete globalThis.localStorage;
+  });
+
+  it('defaults to unseen and records seen / done', () => {
+    const store = new MemoryStorage();
+    // @ts-expect-error - install the stand-in
+    globalThis.localStorage = store;
+
+    expect(loadOnboardingState()).toBe('unseen');
+    markSeen();
+    expect(store.getItem(ONBOARDING_KEY)).toBe('seen');
+    expect(loadOnboardingState()).toBe('seen');
+    markDone();
+    expect(loadOnboardingState()).toBe('done');
+  });
+
+  it('does not downgrade a completed onboarding back to seen', () => {
+    const store = new MemoryStorage();
+    // @ts-expect-error - install the stand-in
+    globalThis.localStorage = store;
+
+    markDone();
+    markSeen();
+    expect(loadOnboardingState()).toBe('done');
+  });
+
+  it('no-ops safely when storage is unavailable or throws', () => {
+    // No storage installed (SSR).
+    expect(loadOnboardingState()).toBe('unseen');
+    expect(() => markSeen()).not.toThrow();
+    expect(() => markDone()).not.toThrow();
+
+    // @ts-expect-error - throwing stand-in (private mode / quota)
+    globalThis.localStorage = {
+      getItem() {
+        throw new Error('denied');
+      },
+      setItem() {
+        throw new Error('quota');
+      },
+      removeItem() {
+        throw new Error('denied');
+      },
+    };
+    expect(loadOnboardingState()).toBe('unseen');
+    expect(() => markSeen()).not.toThrow();
+    expect(() => markDone()).not.toThrow();
+  });
+});

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -1,0 +1,106 @@
+// Onboarding: the pure glue between the /jobs onboarding wizard and the existing
+// job filters, plus the local "have we nudged this visitor yet?" lifecycle. The
+// wizard captures coarse feed preferences; here they map onto the SAME facet
+// filter query the standard filter UI produces, so the wizard is a front-door to
+// existing filters, not a parallel system. No Svelte here (mirrors facetModel.ts /
+// filterStorage.ts), so it's unit-testable in plain Node and every storage access
+// is best-effort — private mode / SSR must never break the feed.
+
+import { emptyFilters, filtersToParams, type JobFilters } from './facetModel';
+
+// The wizard's captured preferences. Every field is optional: the wizard is
+// skippable per field, and an empty field contributes no filter constraint.
+// Each maps to one existing job facet param (see selectionsToQuery).
+export interface OnboardingSelection {
+  /** Coarse specialization → the `category` facet (Backend, Frontend, ML/AI, …). */
+  specialization?: string;
+  /** → the `seniority` facet. */
+  seniority?: string;
+  /** → the `work_mode` facet. */
+  workMode?: string;
+  /** → the `regions` facet (macro region code). */
+  region?: string;
+  /** Free-text stack tokens → the `skills` facet. */
+  stack: string[];
+}
+
+export function emptySelection(): OnboardingSelection {
+  return { stack: [] };
+}
+
+/** Map the wizard's selection onto the existing filter query string, via the same
+ *  `filtersToParams` the standard filter UI uses — so an empty selection yields an
+ *  empty query and a full one yields exactly what the equivalent facet clicks would.
+ *  No hand-written param strings: the facet-param contract stays in facetModel. */
+export function selectionsToQuery(sel: OnboardingSelection): string {
+  const f = emptyFilters();
+  if (sel.specialization) f.facets.category!.include = [sel.specialization];
+  if (sel.seniority) f.facets.seniority!.include = [sel.seniority];
+  if (sel.workMode) f.facets.work_mode!.include = [sel.workMode];
+  if (sel.region) f.facets.regions!.include = [sel.region];
+  const stack = sel.stack.map((s) => s.trim()).filter(Boolean);
+  if (stack.length) f.facets.skills!.include = stack;
+  return filtersToParams(f).toString();
+}
+
+// The facets the narrow-feed "relax" action peels off, narrowest (most specific)
+// first. The role/specialization is deliberately absent — it's the visitor's
+// primary intent and is never auto-dropped. Operates on the live filter state so
+// the affordance works for any narrow feed, not only a wizard-built one.
+export const RELAX_FACET_ORDER = ['skills', 'regions', 'seniority'] as const;
+
+/** The single narrowest relaxable facet currently constraining the feed, or null
+ *  if none is set. The empty-state relax action clears exactly this one. */
+export function narrowestFacet(f: JobFilters): string | null {
+  for (const param of RELAX_FACET_ORDER) {
+    const st = f.facets[param];
+    if (st && (st.include.length > 0 || st.exclude.length > 0)) return param;
+  }
+  return null;
+}
+
+// ---- lifecycle: the local nudge state ----
+
+export const ONBOARDING_KEY = 'hire.onboarding';
+
+/** unseen = never nudged (banner may show); seen = dismissed without completing
+ *  (banner suppressed); done = completed the wizard (banner suppressed for good). */
+export type OnboardingLifecycle = 'unseen' | 'seen' | 'done';
+
+/** The banner shows only to a visitor we've never nudged AND who has no active
+ *  filters (so a shared filtered link is never interrupted). Pure for testability. */
+export function bannerVisible(state: OnboardingLifecycle, hasActiveFilters: boolean): boolean {
+  return state === 'unseen' && !hasActiveFilters;
+}
+
+/** The stored lifecycle, defaulting to 'unseen' when absent/unavailable. */
+export function loadOnboardingState(): OnboardingLifecycle {
+  if (typeof localStorage === 'undefined') return 'unseen';
+  try {
+    const v = localStorage.getItem(ONBOARDING_KEY);
+    return v === 'seen' || v === 'done' ? v : 'unseen';
+  } catch {
+    return 'unseen';
+  }
+}
+
+function save(state: OnboardingLifecycle): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    if (state === 'unseen') localStorage.removeItem(ONBOARDING_KEY);
+    else localStorage.setItem(ONBOARDING_KEY, state);
+  } catch {
+    // best-effort: private mode / quota / disabled storage
+  }
+}
+
+/** Record that the visitor dismissed the nudge without completing it. Never
+ *  downgrades a completed onboarding (done outranks seen). */
+export function markSeen(): void {
+  if (loadOnboardingState() !== 'done') save('seen');
+}
+
+/** Record that the visitor completed the wizard — the banner won't show again. */
+export function markDone(): void {
+  save('done');
+}

--- a/web/src/routes/jobs/+page.svelte
+++ b/web/src/routes/jobs/+page.svelte
@@ -16,8 +16,9 @@
 />
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
-  <!-- Primary heading for search engines and assistive tech. pl-12 clears the
-       mobile filters edge tab (reset at md), matching the list's top row. -->
-  <h1 class="mb-4 pl-12 text-2xl font-semibold tracking-tight md:pl-0">Tech jobs</h1>
+  <!-- Primary heading kept for search engines and assistive tech, but visually
+       hidden: the page's purpose is clear from the feed and onboarding banner, so
+       the on-screen title was redundant. sr-only takes no layout space. -->
+  <h1 class="sr-only">Tech jobs</h1>
   <JobsView initial={data.initial} />
 </div>


### PR DESCRIPTION
## Why
`/jobs` greets every visitor with a reverse-chronological wall of the whole catalogue — mixed languages, C-level next to junior, no relevance. This adds a skippable, anonymous onboarding wizard that turns it into a personalized, relevance-first feed in ~15 seconds. **Frontend-only slice over the existing facet filters — no backend, DB, API, or migration.**

## What
- **3-step wizard** (focus + seniority → work-mode + region + stack). Selections map to the existing filter query via `filtersToParams` and apply through `FilterStore`, so the result is fully editable/clearable via the standard FilterModal — a friendly front-door to existing filters, not a parallel system.
- **Stack picker** reuses the filter panel's `SearchSelect` fed by the live **skills facet distribution** (type-to-filter, busiest-first with job counts).
- **One-time banner** above the feed (localStorage lifecycle), suppressed when any facet filter **or a text query** is active so a shared/filtered link is never interrupted; seeded at init to avoid a returning-visitor flash.
- **Narrow/empty feed** offers an honest "Broaden search" that drops the narrowest facet (skills → regions → seniority; never the role).
- Extracts a shared `facets.dynamicOptions()` helper (deduped from `FacetSection`).

### Bundled UX tweaks (same branch)
- Hide the on-screen **"Tech jobs" h1** (kept `sr-only` for SEO/a11y) — the feed + banner make it redundant.
- Show the active **text query as a removable chip** in the filter sidebar.
- Reduce the **Role facet default cap 24 → 8** to cut clutter (esp. mobile); the rest surface on type.

## Out of scope (future slices — seams identified)
CV auto-fill (`/me/resume/extract`), semantic "similar" (`semantic_ratio`), Telegram saved-search alert (`/me/searches` + `/me/subscriptions`), account/DB persistence (`user_profiles`).

## Testing
- Unit tests for `onboarding.ts` (selection→query round-trip, relax order, lifecycle guards).
- `svelte-check` 0 errors; `vitest` 92 passing; lint clean on changed files.
- Verified live against prod data (banner states, wizard steps, skill suggestions, sidebar query chip, Role cap).

OpenSpec change: `openspec/changes/jobs-onboarding-wizard/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)