### PR TITLE
feat(sources): add Lionhires greenhouse board

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -6149,6 +6149,8 @@
   board: linksquaresinc
 - company: Linqia
   board: linqia
+- company: Lionhires
+  board: lionhires
 - company: LionTree
   board: liontree
 - company: ' Liquibase'


### PR DESCRIPTION
Adds the `lionhires` greenhouse board (`job-boards.eu.greenhouse.io/lionhires`).

- Validated live against `boards-api.greenhouse.io/v1/boards/lionhires/jobs` — 111 open roles across Europe.
- Includes the requested Team Lead Backend Developer (Node.js), Lisbon (id 4917512101).
- EU-hosted boards are served from the same API host, so no per-region handling needed (see internal/sources/greenhouse.go).

Sources-only change; reaches prod via the sources sync + next ingest cron.