### PR TITLE
feat(justjoin): hydrate description from per-offer detail (detail-only-for-new)

### DIFF
--- a/cmd/backfill-justjoin/main.go
+++ b/cmd/backfill-justjoin/main.go
@@ -1,0 +1,139 @@
+// Command backfill-justjoin fills the description of justjoin jobs ingested before per-offer
+// detail hydration existed. The justjoin adapter originally read only the list endpoint, which
+// omits the posting body, so those rows were stored with an empty description (a blank, broken
+// job page). This one-off worker pages every source='justjoin' row, re-fetches the posting's
+// detail (GET /v1/offers/{slug}) via the shared HTTP client, and rewrites the description plus a
+// refreshed content_hash so the row re-indexes. Follow it with `make reindex` (and
+// cmd/backfill-derive to re-derive skills/facets from the new descriptions).
+//
+// It pages by keyset and exits. Idempotent: a row whose stored description already equals the
+// fetched one is skipped, so a second run (e.g. after a rate-limit interruption) rewrites only
+// what a prior run missed. A single posting whose detail fetch fails is counted and skipped,
+// never aborting the run.
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// backfillBatchSize bounds how many rows are read per keyset page.
+const backfillBatchSize = 500
+
+// jobStore is the slice of the data layer the backfill needs: page one provider's rows by keyset
+// and rewrite a row's description + content_hash. *db.Queries satisfies it; the test uses a fake.
+type jobStore interface {
+	ListJobsBySourceAfter(ctx context.Context, arg db.ListJobsBySourceAfterParams) ([]db.Job, error)
+	UpdateJobDescription(ctx context.Context, arg db.UpdateJobDescriptionParams) (int64, error)
+}
+
+// descriptionFetcher fetches the sanitized description for a stored job URL, returning ok=false
+// when the detail is unavailable (bad URL, failed request, or empty body).
+type descriptionFetcher func(ctx context.Context, jobURL string) (string, bool)
+
+func main() {
+	worker.Main(run)
+}
+
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	client := sources.NewClient()
+	fetch := func(ctx context.Context, jobURL string) (string, bool) {
+		return sources.JustJoinDescription(ctx, client, jobURL)
+	}
+
+	scanned, updated, failed, err := backfillAll(ctx, db.New(pool), fetch)
+	if err != nil {
+		log.Printf("backfill-justjoin: %v", err)
+		return 1
+	}
+	log.Printf("backfill-justjoin done: scanned=%d updated=%d failed=%d", scanned, updated, failed)
+	return 0
+}
+
+// backfillAll pages every justjoin row and rewrites the description of rows whose fetched detail
+// body differs from what is stored. It pages by keyset (id > last seen) so concurrent writes
+// cannot skip or repeat rows. A row whose detail fetch fails is counted (failed) and skipped.
+func backfillAll(ctx context.Context, store jobStore, fetch descriptionFetcher) (scanned, updated, failed int, err error) {
+	var afterID int64
+	for {
+		jobs, err := store.ListJobsBySourceAfter(ctx, db.ListJobsBySourceAfterParams{
+			Source:    "justjoin",
+			AfterID:   afterID,
+			BatchSize: backfillBatchSize,
+		})
+		if err != nil {
+			return scanned, updated, failed, err
+		}
+		if len(jobs) == 0 {
+			break
+		}
+		afterID = jobs[len(jobs)-1].ID
+
+		for _, j := range jobs {
+			scanned++
+			desc, ok := fetch(ctx, j.URL)
+			if !ok {
+				failed++
+				continue
+			}
+			if desc == j.Description {
+				continue // already current — idempotent skip
+			}
+			hash := jobhash.Of(hashParams(j, desc))
+			if _, err := store.UpdateJobDescription(ctx, db.UpdateJobDescriptionParams{
+				ID:          j.ID,
+				Description: desc,
+				ContentHash: pgtype.Text{String: hash, Valid: true},
+			}); err != nil {
+				return scanned, updated, failed, err
+			}
+			updated++
+		}
+
+		if len(jobs) < backfillBatchSize {
+			break
+		}
+	}
+	return scanned, updated, failed, nil
+}
+
+// hashParams builds the content_hash inputs for a row with a replaced description — the exact
+// indexed fields jobhash.Of fingerprints (see internal/jobhash), so the recomputed hash matches
+// what the ingest write path would produce for the same row.
+func hashParams(j db.Job, description string) db.UpsertJobParams {
+	return db.UpsertJobParams{
+		URL:                j.URL,
+		Title:              j.Title,
+		Company:            j.Company,
+		CompanySlug:        j.CompanySlug,
+		Location:           j.Location,
+		Remote:             j.Remote,
+		Description:        description,
+		PostedAt:           j.PostedAt,
+		PublicSlug:         j.PublicSlug,
+		Countries:          j.Countries,
+		Regions:            j.Regions,
+		WorkMode:           j.WorkMode,
+		Skills:             j.Skills,
+		Seniority:          j.Seniority,
+		Category:           j.Category,
+		PostingLanguage:    j.PostingLanguage,
+		EmploymentType:     j.EmploymentType,
+		EducationLevel:     j.EducationLevel,
+		ExperienceYearsMin: j.ExperienceYearsMin,
+	}
+}

--- a/cmd/backfill-justjoin/main_test.go
+++ b/cmd/backfill-justjoin/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobhash"
+)
+
+// fakeStore serves one keyset page of justjoin rows and records every description update.
+type fakeStore struct {
+	jobs    []db.Job
+	updates []db.UpdateJobDescriptionParams
+	served  bool
+}
+
+func (f *fakeStore) ListJobsBySourceAfter(_ context.Context, _ db.ListJobsBySourceAfterParams) ([]db.Job, error) {
+	if f.served {
+		return nil, nil
+	}
+	f.served = true
+	return f.jobs, nil
+}
+
+func (f *fakeStore) UpdateJobDescription(_ context.Context, arg db.UpdateJobDescriptionParams) (int64, error) {
+	f.updates = append(f.updates, arg)
+	return 1, nil
+}
+
+func TestBackfillUpdatesOnlyChangedDescriptions(t *testing.T) {
+	store := &fakeStore{jobs: []db.Job{
+		{ID: 1, Source: "justjoin", URL: "https://justjoin.it/job-offer/a", Title: "A", Description: ""},
+		{ID: 2, Source: "justjoin", URL: "https://justjoin.it/job-offer/b", Title: "B", Description: "same"},
+		{ID: 3, Source: "justjoin", URL: "https://justjoin.it/job-offer/c", Title: "C", Description: ""},
+	}}
+	fetch := func(_ context.Context, jobURL string) (string, bool) {
+		switch jobURL {
+		case "https://justjoin.it/job-offer/a":
+			return "New body A", true // empty → gets filled
+		case "https://justjoin.it/job-offer/b":
+			return "same", true // unchanged → skipped
+		default:
+			return "", false // detail failed → counted, skipped
+		}
+	}
+
+	scanned, updated, failed, err := backfillAll(context.Background(), store, fetch)
+	if err != nil {
+		t.Fatalf("backfillAll: %v", err)
+	}
+	if scanned != 3 || updated != 1 || failed != 1 {
+		t.Fatalf("scanned=%d updated=%d failed=%d, want 3/1/1", scanned, updated, failed)
+	}
+	if len(store.updates) != 1 || store.updates[0].ID != 1 {
+		t.Fatalf("updates = %+v, want one update of job 1", store.updates)
+	}
+	u := store.updates[0]
+	if u.Description != "New body A" {
+		t.Errorf("Description = %q, want %q", u.Description, "New body A")
+	}
+	// The content_hash must be the fingerprint of the row's indexed fields WITH the new
+	// description, so the row re-indexes (and is stable on a re-run).
+	want := jobhash.Of(hashParams(store.jobs[0], "New body A"))
+	if !u.ContentHash.Valid || u.ContentHash.String != want {
+		t.Errorf("ContentHash = %+v, want %q", u.ContentHash, want)
+	}
+}

--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -165,6 +165,42 @@ func (s *dbStore) Close(ctx context.Context, source, externalID string) error {
 	return nil
 }
 
+// ExistingExternalIDs returns the set of external_ids already stored for a provider — the
+// pipeline's seen-set for a hydrating source (justjoin), so per-posting detail is fetched only
+// for postings the catalogue lacks. Implements pipeline.seenLookup.
+func (s *dbStore) ExistingExternalIDs(ctx context.Context, source string) (map[string]struct{}, error) {
+	ids, err := s.q.ExistingExternalIDs(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	return set, nil
+}
+
+// Touch refreshes an already-ingested posting's liveness (last_seen_at, reopen if closed) by
+// its (source, external_id) identity, without rewriting content — the path a HydratingSource
+// (justjoin) uses for an offer it re-listed but did not re-fetch, so its hydrated description
+// and facets are preserved. Implements pipeline.toucher.
+func (s *dbStore) Touch(ctx context.Context, source, externalID string) error {
+	companySlug, err := s.q.TouchJob(ctx, db.TouchJobParams{
+		Source:     source,
+		ExternalID: externalID,
+	})
+	if err != nil {
+		return fmt.Errorf("touch job %s/%s: %w", source, externalID, err)
+	}
+	// Record the company as crawled, exactly as Save does, so the post-run stale sweep keeps
+	// this company in scope. Otherwise a company whose offers were all touched (none newly
+	// saved) would fall out of the crawled-set and its removed offers would never close.
+	if s.crawled != nil {
+		s.crawled.record(source, companySlug)
+	}
+	return nil
+}
+
 // toTimestamptz maps an optional posted_at to the pgtype the generated params expect;
 // a nil time becomes SQL NULL.
 func toTimestamptz(t *time.Time) pgtype.Timestamptz {

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -140,6 +140,36 @@ func (q *Queries) EstimateOpenJobs(ctx context.Context) (int64, error) {
 	return column_1, err
 }
 
+const existingExternalIDs = `-- name: ExistingExternalIDs :many
+SELECT external_id FROM jobs WHERE source = $1
+`
+
+// Seen-set for a hydrating source (see source-ingest): all external_ids stored for one
+// provider, so an adapter with expensive per-posting detail (justjoin, ~20k live offers)
+// fetches detail only for postings the catalogue does not already have. Closed rows are
+// included — a closed posting is still "seen" (no need to re-fetch its detail; a reappearance
+// reopens it via the upsert regardless). Keyed by source alone; the caller namespaces the
+// adapter's raw posting id to match the stored external_id.
+func (q *Queries) ExistingExternalIDs(ctx context.Context, source string) ([]string, error) {
+	rows, err := q.db.Query(ctx, existingExternalIDs, source)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var external_id string
+		if err := rows.Scan(&external_id); err != nil {
+			return nil, err
+		}
+		items = append(items, external_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getJob = `-- name: GetJob :one
 SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
 FROM jobs
@@ -674,6 +704,85 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 	return items, nil
 }
 
+const listJobsBySourceAfter = `-- name: ListJobsBySourceAfter :many
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+FROM jobs
+WHERE source = $1 AND id > $2
+ORDER BY id
+LIMIT $3
+`
+
+type ListJobsBySourceAfterParams struct {
+	Source    string `json:"source"`
+	AfterID   int64  `json:"after_id"`
+	BatchSize int32  `json:"batch_size"`
+}
+
+// Keyset scan over one provider's rows, for cmd/backfill-justjoin: pages by the immutable
+// primary key (concurrent writes can't skip or repeat rows) filtered to a single source. Returns
+// closed rows too — a one-time backfill of a missing description fills open and closed alike.
+func (q *Queries) ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourceAfterParams) ([]Job, error) {
+	rows, err := q.db.Query(ctx, listJobsBySourceAfter, arg.Source, arg.AfterID, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Job{}
+	for rows.Next() {
+		var i Job
+		if err := rows.Scan(
+			&i.ID,
+			&i.Source,
+			&i.ExternalID,
+			&i.URL,
+			&i.Title,
+			&i.Company,
+			&i.Location,
+			&i.Remote,
+			&i.Description,
+			&i.PostedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.CompanySlug,
+			&i.Enrichment,
+			&i.EnrichedAt,
+			&i.EnrichmentVersion,
+			&i.PublicSlug,
+			&i.LastSeenAt,
+			&i.ClosedAt,
+			&i.Countries,
+			&i.Regions,
+			&i.WorkMode,
+			&i.LivenessStrikes,
+			&i.Skills,
+			&i.Seniority,
+			&i.Category,
+			&i.CreatedBy,
+			&i.UpdatedBy,
+			&i.PostingLanguage,
+			&i.EmploymentType,
+			&i.EducationLevel,
+			&i.ExperienceYearsMin,
+			&i.Collections,
+			&i.ContentHash,
+			&i.EnglishLevel,
+			&i.Cities,
+			&i.ViewCount,
+			&i.AppliedCount,
+			&i.RoleFingerprint,
+			&i.SemanticEmbeddedModel,
+			&i.SemanticEmbeddedHash,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
 SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
 FROM jobs
@@ -1100,6 +1209,65 @@ func (q *Queries) SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentPara
 		arg.ID,
 	)
 	return err
+}
+
+const touchJob = `-- name: TouchJob :one
+UPDATE jobs
+SET last_seen_at = now(),
+    closed_at    = NULL,
+    -- A reopen resets the strike count so a single later expired probe can't immediately
+    -- re-close it, mirroring UpsertJob.
+    liveness_strikes = CASE WHEN closed_at IS NOT NULL THEN 0 ELSE liveness_strikes END,
+    updated_at   = now()
+WHERE source = $1 AND external_id = $2
+RETURNING company_slug
+`
+
+type TouchJobParams struct {
+	Source     string `json:"source"`
+	ExternalID string `json:"external_id"`
+}
+
+// Liveness refresh for a hydrating source's already-ingested posting (see source-ingest): the
+// crawl re-listed the offer but fetched no fresh content (detail is fetched only for new
+// offers), so refresh last_seen_at and reopen if it had been closed — WITHOUT touching the
+// content columns. A full upsert of the content-less listing would re-derive the deterministic
+// facets from an empty description and wipe the row's hydrated description/skills. This is the
+// reopen half of UpsertJob's ON CONFLICT, minus every content write. RETURNING company_slug so
+// the caller records the company into the crawled-set that scopes the post-run unseen sweep —
+// exactly as UpsertJob's write path does — otherwise a company whose offers were all touched
+// (not newly saved) would drop out of the sweep and its removed offers would never close.
+func (q *Queries) TouchJob(ctx context.Context, arg TouchJobParams) (string, error) {
+	row := q.db.QueryRow(ctx, touchJob, arg.Source, arg.ExternalID)
+	var company_slug string
+	err := row.Scan(&company_slug)
+	return company_slug, err
+}
+
+const updateJobDescription = `-- name: UpdateJobDescription :execrows
+UPDATE jobs
+SET description  = $1,
+    content_hash = $2,
+    updated_at   = now()
+WHERE id = $3
+`
+
+type UpdateJobDescriptionParams struct {
+	Description string      `json:"description"`
+	ContentHash pgtype.Text `json:"content_hash"`
+	ID          int64       `json:"id"`
+}
+
+// Targeted description rewrite for cmd/backfill-justjoin: sets the description and the refreshed
+// content_hash (recomputed in Go from the row's indexed fields with the new description) so the
+// row re-indexes. Stamps updated_at so `reindex --since` also captures it. Only the description
+// and hash move; the deterministic facets are re-derived separately by cmd/backfill-derive.
+func (q *Queries) UpdateJobDescription(ctx context.Context, arg UpdateJobDescriptionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateJobDescription, arg.Description, arg.ContentHash, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateJobFacets = `-- name: UpdateJobFacets :exec

--- a/internal/db/jobs_existing_ids_integration_test.go
+++ b/internal/db/jobs_existing_ids_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration
+
+// Integration test for the hydrating-source seen-set query: ExistingExternalIDs returns the
+// external_ids stored for one provider (and only that provider), so a hydrating adapter fetches
+// per-posting detail only for postings the catalogue lacks. A SQL behavior, verifiable only
+// against a real Postgres. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestExistingExternalIDsScopedToProvider(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// Two greenhouse rows and one lever row.
+	for _, ext := range []string{"acme:1", "acme:2"} {
+		if _, err := ingestUpsert(ctx, q, ingestParams(ext, "Engineer")); err != nil {
+			t.Fatalf("upsert %s: %v", ext, err)
+		}
+	}
+	lever := ingestParams("other:9", "Designer")
+	lever.Source = "lever"
+	if _, err := ingestUpsert(ctx, q, lever); err != nil {
+		t.Fatalf("upsert lever: %v", err)
+	}
+
+	ids, err := q.ExistingExternalIDs(ctx, "greenhouse")
+	if err != nil {
+		t.Fatalf("ExistingExternalIDs: %v", err)
+	}
+	slices.Sort(ids)
+	if !slices.Equal(ids, []string{"acme:1", "acme:2"}) {
+		t.Errorf("ids = %v, want [acme:1 acme:2] (lever row excluded)", ids)
+	}
+}

--- a/internal/db/jobs_touch_integration_test.go
+++ b/internal/db/jobs_touch_integration_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+// Integration test for the hydrating-source liveness refresh: TouchJob refreshes last_seen_at
+// and reopens a closed row WITHOUT rewriting its content, so a re-listed already-ingested
+// posting keeps the description/facets it was hydrated with. Verifiable only against a real
+// Postgres. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestTouchJobRefreshesLivenessAndPreservesContent(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// Ingest a job that carries a description and skills (as a hydrated justjoin row would).
+	p := ingestParams("justjoin:1", "Engineer")
+	p.Source = "justjoin"
+	p.Description = "Rich hydrated body."
+	p.Skills = []string{"go", "typescript"}
+	if _, err := ingestUpsert(ctx, q, p); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Simulate a stale, closed row: last_seen_at far in the past, closed_at set.
+	if _, err := pool.Exec(ctx,
+		`UPDATE jobs SET last_seen_at = now() - interval '10 days', closed_at = now() WHERE source='justjoin' AND external_id='justjoin:1'`,
+	); err != nil {
+		t.Fatalf("stale/close setup: %v", err)
+	}
+
+	companySlug, err := q.TouchJob(ctx, TouchJobParams{Source: "justjoin", ExternalID: "justjoin:1"})
+	if err != nil {
+		t.Fatalf("TouchJob: %v", err)
+	}
+	// The touched row's company is returned so the caller can keep it in the sweep scope.
+	if companySlug != "acme" {
+		t.Errorf("TouchJob company_slug = %q, want acme", companySlug)
+	}
+
+	got, err := q.GetJobBySourceExternalID(ctx, GetJobBySourceExternalIDParams{Source: "justjoin", ExternalID: "justjoin:1"})
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if got.ClosedAt.Valid {
+		t.Error("closed_at still set, want reopened (NULL)")
+	}
+	if time.Since(got.LastSeenAt.Time) > time.Minute {
+		t.Errorf("last_seen_at = %v, want refreshed to ~now", got.LastSeenAt.Time)
+	}
+	// Content must be untouched.
+	if got.Description != "Rich hydrated body." {
+		t.Errorf("Description = %q, want preserved", got.Description)
+	}
+	if len(got.Skills) != 2 {
+		t.Errorf("Skills = %v, want preserved [go typescript]", got.Skills)
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -217,6 +217,13 @@ type Querier interface {
 	// search filter stays bounded; the overflow risk is only an occasional re-shown
 	// long-ago-seen job, never a correctness problem.
 	ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) ([]int64, error)
+	// Seen-set for a hydrating source (see source-ingest): all external_ids stored for one
+	// provider, so an adapter with expensive per-posting detail (justjoin, ~20k live offers)
+	// fetches detail only for postings the catalogue does not already have. Closed rows are
+	// included — a closed posting is still "seen" (no need to re-fetch its detail; a reappearance
+	// reopens it via the upsert regardless). Keyed by source alone; the caller namespaces the
+	// adapter's raw posting id to match the stored external_id.
+	ExistingExternalIDs(ctx context.Context, source string) ([]string, error)
 	// The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
 	// which the caller treats as "never seen, eligible".
 	GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error)
@@ -347,6 +354,10 @@ type Querier interface {
 	// concurrent inserts/updates (which shift posted_at ordering) cannot make the
 	// scan skip or repeat rows the way OFFSET pagination would.
 	ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterParams) ([]Job, error)
+	// Keyset scan over one provider's rows, for cmd/backfill-justjoin: pages by the immutable
+	// primary key (concurrent writes can't skip or repeat rows) filtered to a single source. Returns
+	// closed rows too — a one-time backfill of a missing description fills open and closed alike.
+	ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourceAfterParams) ([]Job, error)
 	// Incremental keyset scan for `reindex --since`: like ListJobsByIDAfter but only
 	// rows changed at or after the cutoff. Every write path (UpsertJob, the close
 	// sweeps, SetJobEnrichment, UpdateJobFacets) stamps updated_at = now(), so this
@@ -565,6 +576,16 @@ type Querier interface {
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's
 	// name variants; ON CONFLICT folds collisions and refreshes existing rows.
 	SyncCompaniesFromJobs(ctx context.Context) error
+	// Liveness refresh for a hydrating source's already-ingested posting (see source-ingest): the
+	// crawl re-listed the offer but fetched no fresh content (detail is fetched only for new
+	// offers), so refresh last_seen_at and reopen if it had been closed — WITHOUT touching the
+	// content columns. A full upsert of the content-less listing would re-derive the deterministic
+	// facets from an empty description and wipe the row's hydrated description/skills. This is the
+	// reopen half of UpsertJob's ON CONFLICT, minus every content write. RETURNING company_slug so
+	// the caller records the company into the crawled-set that scopes the post-run unseen sweep —
+	// exactly as UpsertJob's write path does — otherwise a company whose offers were all touched
+	// (not newly saved) would drop out of the sweep and its removed offers would never close.
+	TouchJob(ctx context.Context, arg TouchJobParams) (string, error)
 	// Set an application's stage and/or notes for a user, idempotently. Upserts the
 	// (user, job) row (viewed_at defaults). Partial update: a NULL param leaves that
 	// column unchanged (COALESCE keeps the existing value), so the caller can set the
@@ -582,6 +603,11 @@ type Querier interface {
 	// Remove a job from the board: drop every pipeline mark, keep viewed_at so the
 	// job remains in the user's view history.
 	UntrackJob(ctx context.Context, arg UntrackJobParams) (UserJob, error)
+	// Targeted description rewrite for cmd/backfill-justjoin: sets the description and the refreshed
+	// content_hash (recomputed in Go from the row's indexed fields with the new description) so the
+	// row re-indexes. Stamps updated_at so `reindex --since` also captures it. Only the description
+	// and hash move; the deterministic facets are re-derived separately by cmd/backfill-derive.
+	UpdateJobDescription(ctx context.Context, arg UpdateJobDescriptionParams) (int64, error)
 	// One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
 	// facet column — countries, regions, work_mode, skills, seniority, category, plus the
 	// synthetic enrichment facets posting_language, employment_type, education_level,

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -18,6 +18,27 @@ WHERE id > sqlc.arg(after_id)
 ORDER BY id
 LIMIT sqlc.arg(batch_size);
 
+-- name: ListJobsBySourceAfter :many
+-- Keyset scan over one provider's rows, for cmd/backfill-justjoin: pages by the immutable
+-- primary key (concurrent writes can't skip or repeat rows) filtered to a single source. Returns
+-- closed rows too — a one-time backfill of a missing description fills open and closed alike.
+SELECT *
+FROM jobs
+WHERE source = sqlc.arg(source) AND id > sqlc.arg(after_id)
+ORDER BY id
+LIMIT sqlc.arg(batch_size);
+
+-- name: UpdateJobDescription :execrows
+-- Targeted description rewrite for cmd/backfill-justjoin: sets the description and the refreshed
+-- content_hash (recomputed in Go from the row's indexed fields with the new description) so the
+-- row re-indexes. Stamps updated_at so `reindex --since` also captures it. Only the description
+-- and hash move; the deterministic facets are re-derived separately by cmd/backfill-derive.
+UPDATE jobs
+SET description  = sqlc.arg(description),
+    content_hash = sqlc.arg(content_hash),
+    updated_at   = now()
+WHERE id = sqlc.arg(id);
+
 -- name: ListJobsUpdatedAfter :many
 -- Incremental keyset scan for `reindex --since`: like ListJobsByIDAfter but only
 -- rows changed at or after the cutoff. Every write path (UpsertJob, the close
@@ -404,6 +425,35 @@ SET closed_at  = now(),
 WHERE closed_at IS NULL
   AND source = sqlc.arg(source)
   AND external_id = sqlc.arg(external_id);
+
+-- name: ExistingExternalIDs :many
+-- Seen-set for a hydrating source (see source-ingest): all external_ids stored for one
+-- provider, so an adapter with expensive per-posting detail (justjoin, ~20k live offers)
+-- fetches detail only for postings the catalogue does not already have. Closed rows are
+-- included — a closed posting is still "seen" (no need to re-fetch its detail; a reappearance
+-- reopens it via the upsert regardless). Keyed by source alone; the caller namespaces the
+-- adapter's raw posting id to match the stored external_id.
+SELECT external_id FROM jobs WHERE source = sqlc.arg(source);
+
+-- name: TouchJob :one
+-- Liveness refresh for a hydrating source's already-ingested posting (see source-ingest): the
+-- crawl re-listed the offer but fetched no fresh content (detail is fetched only for new
+-- offers), so refresh last_seen_at and reopen if it had been closed — WITHOUT touching the
+-- content columns. A full upsert of the content-less listing would re-derive the deterministic
+-- facets from an empty description and wipe the row's hydrated description/skills. This is the
+-- reopen half of UpsertJob's ON CONFLICT, minus every content write. RETURNING company_slug so
+-- the caller records the company into the crawled-set that scopes the post-run unseen sweep —
+-- exactly as UpsertJob's write path does — otherwise a company whose offers were all touched
+-- (not newly saved) would drop out of the sweep and its removed offers would never close.
+UPDATE jobs
+SET last_seen_at = now(),
+    closed_at    = NULL,
+    -- A reopen resets the strike count so a single later expired probe can't immediately
+    -- re-close it, mirroring UpsertJob.
+    liveness_strikes = CASE WHEN closed_at IS NOT NULL THEN 0 ELSE liveness_strikes END,
+    updated_at   = now()
+WHERE source = sqlc.arg(source) AND external_id = sqlc.arg(external_id)
+RETURNING company_slug;
 
 -- name: CloseJobByID :execrows
 -- Soft-close one job now (see job-lifecycle): a moderator resolving a report with

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -40,6 +40,25 @@ type closer interface {
 	Close(ctx context.Context, source, externalID string) error
 }
 
+// toucher is the optional Store capability a HydratingSource needs: refresh a posting's liveness
+// (last_seen_at, reopen if closed) by its (source, external_id) identity, WITHOUT rewriting its
+// content. The pipeline uses it for a posting the adapter re-listed but did not re-fetch (its
+// stored content is already current); a full upsert of the content-less listing would wipe the
+// hydrated description/facets. Only the ingest dbStore implements it; the pipeline type-asserts
+// for it and drops the refresh when a Store lacks it (test fakes), like closer.
+type toucher interface {
+	Touch(ctx context.Context, source, externalID string) error
+}
+
+// seenLookup is the optional Store capability a HydratingSource needs: the set of external_ids
+// already stored for a provider, so the adapter fetches expensive per-posting detail only for
+// postings the catalogue lacks. Only the ingest dbStore implements it; the runner type-asserts
+// for it and falls back to the list-only Fetch when a Store lacks it (test fakes, non-DB
+// callers), so other Store implementations are unaffected.
+type seenLookup interface {
+	ExistingExternalIDs(ctx context.Context, source string) (map[string]struct{}, error)
+}
+
 // BoardHealth is the optional per-board health port: it tells the Runner whether a
 // board is currently cooled down (skip it) and records each crawl's outcome so a
 // repeatedly-failing board backs off. A nil BoardHealth disables the feature entirely
@@ -185,7 +204,7 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 		return ing, fail, skip, 0
 	}
 
-	raw, err := src.Fetch(ctx, e)
+	raw, err := r.fetchBoard(ctx, e, src)
 	if err != nil {
 		// Log the cause so a failed board is diagnosable (the source error carries
 		// the HTTP status / timeout); the run still isolates and continues.
@@ -196,6 +215,20 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 
 	var firstErr error
 	for _, j := range raw {
+		// A HydratingSource marks an already-ingested posting it re-listed but did not
+		// re-fetch: refresh its liveness by identity instead of re-upserting content-less
+		// (which would wipe the description/facets hydrated when it was new).
+		if j.SeenRefresh {
+			if err := r.touch(ctx, e, j); err != nil {
+				skipped++
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			ingested++
+			continue
+		}
 		dj, err := normalizeJob(e, j)
 		if err != nil {
 			skipped++
@@ -224,6 +257,46 @@ func (r Runner) ingestBoard(ctx context.Context, e sources.CompanyEntry) (ingest
 	// save skips — those are stats.Skipped, not a board outage.
 	r.recordSuccess(ctx, e, ingested)
 	return ingested, 0, skipped, 0
+}
+
+// fetchBoard fetches a board's postings, preferring a hydrating adapter's FetchNew — which
+// fetches per-posting detail (e.g. the description the list omits) only for postings not already
+// ingested — when the adapter opts in AND the Store can supply the provider's seen-set. It falls
+// back to the list-only Fetch otherwise. The seen predicate namespaces the adapter's raw posting
+// id the same way the write path does, so it matches the stored external_id. A seen-set lookup
+// error fails OPEN (empty set → every posting treated as new), so a health hiccup never skips the
+// board.
+func (r Runner) fetchBoard(ctx context.Context, e sources.CompanyEntry, src sources.Source) ([]sources.Job, error) {
+	hs, ok := src.(sources.HydratingSource)
+	if !ok {
+		return src.Fetch(ctx, e)
+	}
+	sl, ok := r.Store.(seenLookup)
+	if !ok {
+		return src.Fetch(ctx, e)
+	}
+	set, err := sl.ExistingExternalIDs(ctx, e.Provider)
+	if err != nil {
+		log.Printf("ingest: %s seen-set lookup failed, hydrating every posting as new: %v", e.Provider, err)
+		set = nil
+	}
+	seen := func(externalID string) bool {
+		_, ok := set[sources.NamespaceExternalID(e.Board, externalID)]
+		return ok
+	}
+	return hs.FetchNew(ctx, e, seen)
+}
+
+// touch refreshes an already-ingested posting's liveness (last_seen_at, reopen) by identity,
+// without rewriting its content. It routes through the Store's optional toucher capability; a
+// Store without it (a test fake) drops the refresh, matching how ingestStream handles closer.
+func (r Runner) touch(ctx context.Context, e sources.CompanyEntry, j sources.Job) error {
+	t, ok := r.Store.(toucher)
+	if !ok {
+		return nil
+	}
+	source, externalID := jobIdentity(e, j)
+	return t.Touch(ctx, source, externalID)
 }
 
 // cooledDown reports whether a board is currently backed off. It fails OPEN: a health

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -14,11 +14,23 @@ import (
 
 // fakeStore records every saved job and every (source, external_id) closed. It implements
 // the optional closer capability, so it is safe for the runner's concurrent Save/Close calls.
+// It also implements the optional seenLookup capability (ExistingExternalIDs), so a hydrating
+// source can be driven by a canned seen-set.
 type fakeStore struct {
-	mu     sync.Mutex
-	saved  []job.Job
-	closed [][2]string
-	err    error
+	mu      sync.Mutex
+	saved   []job.Job
+	closed  [][2]string
+	touched [][2]string
+	err     error
+	seenIDs map[string]struct{} // stored (namespaced) external_ids for ExistingExternalIDs
+	seenErr error               // when set, ExistingExternalIDs fails
+}
+
+func (s *fakeStore) ExistingExternalIDs(_ context.Context, _ string) (map[string]struct{}, error) {
+	if s.seenErr != nil {
+		return nil, s.seenErr
+	}
+	return s.seenIDs, nil
 }
 
 func (s *fakeStore) Save(_ context.Context, j job.Job) error {
@@ -38,6 +50,16 @@ func (s *fakeStore) Close(_ context.Context, source, externalID string) error {
 		return s.err
 	}
 	s.closed = append(s.closed, [2]string{source, externalID})
+	return nil
+}
+
+func (s *fakeStore) Touch(_ context.Context, source, externalID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.err != nil {
+		return s.err
+	}
+	s.touched = append(s.touched, [2]string{source, externalID})
 	return nil
 }
 
@@ -79,6 +101,37 @@ func (f fakeStreamingSource) FetchStream(_ context.Context, _ sources.CompanyEnt
 		emit(j)
 	}
 	return nil
+}
+
+// fakeHydratingSource implements sources.HydratingSource: FetchNew records that it was used and
+// captures the seen(externalID) result for each job's raw id, so a test can prove the runner
+// preferred FetchNew and supplied a predicate reflecting the store's seen-set. Its Fetch returns
+// the same jobs, so a test seeing FetchNew's side effects proves the hydrating path was taken.
+type fakeHydratingSource struct {
+	provider       string
+	jobs           []sources.Job
+	fetchNewCalled bool
+	seenResults    map[string]bool
+}
+
+func (f *fakeHydratingSource) Provider() string { return f.provider }
+
+func (f *fakeHydratingSource) Fetch(context.Context, sources.CompanyEntry) ([]sources.Job, error) {
+	return f.jobs, nil
+}
+
+func (f *fakeHydratingSource) FetchNew(_ context.Context, _ sources.CompanyEntry, seen func(string) bool) ([]sources.Job, error) {
+	f.fetchNewCalled = true
+	f.seenResults = map[string]bool{}
+	out := make([]sources.Job, len(f.jobs))
+	for i, j := range f.jobs {
+		s := seen(j.ExternalID)
+		f.seenResults[j.ExternalID] = s
+		// Mirror the real adapter: a seen offer is marked for liveness refresh, not upsert.
+		j.SeenRefresh = s
+		out[i] = j
+	}
+	return out, nil
 }
 
 func registry(srcs ...sources.Source) map[string]sources.Source {
@@ -164,6 +217,68 @@ func TestRunStreamsAllJobs(t *testing.T) {
 	}
 	if len(store.saved) != 2 || stats.Total().Ingested != 2 || stats.Total().Failed != 0 {
 		t.Fatalf("saved=%d stats=%+v, want 2 saved Ingested=2 Failed=0", len(store.saved), stats.Total())
+	}
+}
+
+// TestRunDrivesHydratingSourceWithSeenSet proves the runner prefers FetchNew for a
+// HydratingSource and supplies a seen predicate backed by the store's set of already-ingested
+// (namespaced) external_ids: the boardless offer already stored as ":seen" reads seen=true, a
+// new offer reads seen=false.
+func TestRunDrivesHydratingSourceWithSeenSet(t *testing.T) {
+	src := &fakeHydratingSource{provider: "justjoin", jobs: []sources.Job{
+		{ExternalID: "seen", Title: "A", Company: "C", URL: "u"},
+		{ExternalID: "new", Title: "B", Company: "C", URL: "u"},
+	}}
+	store := &fakeStore{seenIDs: map[string]struct{}{":seen": {}}}
+	r := Runner{Registry: registry(src), Store: store}
+
+	if _, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "C", Provider: "justjoin", Board: ""},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !src.fetchNewCalled {
+		t.Fatal("runner should call FetchNew for a HydratingSource, not Fetch")
+	}
+	if !src.seenResults["seen"] {
+		t.Error("seen(\"seen\") = false, want true (already stored as \":seen\")")
+	}
+	if src.seenResults["new"] {
+		t.Error("seen(\"new\") = true, want false (not yet stored)")
+	}
+	// The new offer is upserted; the seen offer is only touched (liveness refresh), so its
+	// hydrated content is never overwritten by a content-less re-upsert. Boardless → ":<id>".
+	if len(store.saved) != 1 || store.saved[0].Fields().ExternalID != ":new" {
+		t.Errorf("saved = %+v, want only the new offer (\":new\")", store.saved)
+	}
+	if len(store.touched) != 1 || store.touched[0] != [2]string{"justjoin", ":seen"} {
+		t.Errorf("touched = %v, want one touch of (justjoin, :seen)", store.touched)
+	}
+}
+
+// TestRunHydratingSourceFailsOpenOnSeenLookupError proves a seen-set query failure does not skip
+// the board: the runner falls back to an empty seen-set (every offer treated as new) and still
+// crawls via FetchNew.
+func TestRunHydratingSourceFailsOpenOnSeenLookupError(t *testing.T) {
+	src := &fakeHydratingSource{provider: "justjoin", jobs: []sources.Job{
+		{ExternalID: "a", Title: "A", Company: "C", URL: "u"},
+	}}
+	store := &fakeStore{seenErr: errors.New("db down")}
+	r := Runner{Registry: registry(src), Store: store}
+
+	if _, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "C", Provider: "justjoin", Board: ""},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !src.fetchNewCalled {
+		t.Fatal("runner should still crawl via FetchNew despite the seen-lookup error")
+	}
+	if src.seenResults["a"] {
+		t.Error("seen(\"a\") = true, want false (empty set on lookup error)")
+	}
+	if len(store.saved) != 1 {
+		t.Errorf("len(saved) = %d, want 1 (board still crawled)", len(store.saved))
 	}
 }
 

--- a/internal/sources/justjoin.go
+++ b/internal/sources/justjoin.go
@@ -3,6 +3,12 @@ package sources
 import (
 	"context"
 	"fmt"
+	"log"
+	"slices"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/skilltag"
 )
 
 // justjoin adapts justjoin.it, a Polish/CEE IT job marketplace. Boardless (one public API,
@@ -21,6 +27,9 @@ const (
 	justJoinBaseURL  = "https://api.justjoin.it/v2/user-panel/offers/by-cursor"
 	// justJoinOfferURL builds the canonical detail URL the feed omits, from the slug.
 	justJoinOfferURL = "https://justjoin.it/job-offer/%s"
+	// justJoinDetailURL is the per-offer detail endpoint carrying the posting body the list
+	// endpoint omits (a `/v1` route, distinct from the `/v2` list base).
+	justJoinDetailURL = "https://api.justjoin.it/v1/offers/%s"
 )
 
 // NewJustJoin builds the JustJoin adapter over the given HTTP client.
@@ -54,8 +63,59 @@ type justJoinOffer struct {
 	PublishedAt   string `json:"publishedAt"`
 }
 
+// Fetch is the list-only crawl (no description): kept for back-compat and as the fallback for
+// callers that do not drive hydration. FetchNew is the hydrating path used by ingest.
 func (s justjoin) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	offers, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var jobs []Job
+	for _, o := range offers {
+		if job, ok := o.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// FetchNew is the hydrating crawl: it pages the same list, but fetches a posting's detail (the
+// body the list omits) only for an offer the catalogue does not already have — seen reports
+// whether an offer's guid is already ingested. A seen offer yields the list-only job (no detail
+// request); an unseen offer is hydrated with its detail; a single offer's detail failure is
+// isolated (logged, falling back to list-only so the offer is still ingested). Detail fetches
+// run under the shared bounded worker pool.
+func (s justjoin) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	offers, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(offers, defaultDetailWorkers, func(o justJoinOffer) (Job, bool) {
+		base, ok := o.toJob()
+		if !ok {
+			return Job{}, false // unusable offer — dropped, as in Fetch
+		}
+		if seen(o.GUID) {
+			// Already ingested: refresh liveness only, no detail request. The pipeline
+			// must not re-upsert content — that would wipe the description/facets
+			// hydrated when this offer was new (an empty description re-derives to empty
+			// facets). base carries just the identity fields toJob set.
+			base.SeenRefresh = true
+			return base, true
+		}
+		d, ok := s.detail(ctx, o.Slug)
+		if !ok {
+			log.Printf("justjoin: detail %q failed; ingesting list-only", o.Slug)
+			return base, true
+		}
+		return d.apply(base), true
+	}), nil
+}
+
+// crawl pages the cursor feed and returns every raw offer — the shared list walk behind Fetch
+// and FetchNew.
+func (s justjoin) crawl(ctx context.Context) ([]justJoinOffer, error) {
+	var offers []justJoinOffer
 	cursor := 0
 	for page := 0; page < justJoinMaxPages; page++ {
 		url := justJoinBaseURL
@@ -68,11 +128,7 @@ func (s justjoin) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
 			return nil, fmt.Errorf("justjoin: list cursor %d: %w", cursor, err)
 		}
-		for _, o := range resp.Data {
-			if job, ok := o.toJob(); ok {
-				jobs = append(jobs, job)
-			}
-		}
+		offers = append(offers, resp.Data...)
 		// Stop at the end of the feed, or whenever the cursor fails to advance — a
 		// non-increasing cursor means the page param was ignored (refetching page 1) or
 		// the feed looped, so one extra request is the worst case, never an endless loop.
@@ -81,7 +137,91 @@ func (s justjoin) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 		}
 		cursor = resp.Meta.Next.Cursor
 	}
-	return jobs, nil
+	return offers, nil
+}
+
+// justJoinDetail is the per-offer detail payload (GET /v1/offers/{slug}). It carries the
+// posting body the list omits, plus the structured facets justjoin states.
+type justJoinDetail struct {
+	Body            string          `json:"body"`
+	RequiredSkills  []justJoinSkill `json:"requiredSkills"`
+	ExperienceLevel struct {
+		Value string `json:"value"`
+	} `json:"experienceLevel"`
+}
+
+// justJoinSkill is one required-skill entry (only the canonical name is used).
+type justJoinSkill struct {
+	Name string `json:"name"`
+}
+
+// JustJoinDescription fetches the sanitized description for a stored justjoin job URL, deriving
+// the offer slug from the URL. It returns ok=false when the URL is not a justjoin offer URL, the
+// detail request fails, or the offer has no body. It exists for cmd/backfill-justjoin, which
+// fills the description of rows ingested before detail hydration existed; the crawl path uses
+// (justjoin).detail directly.
+func JustJoinDescription(ctx context.Context, c JSONGetter, jobURL string) (string, bool) {
+	slug, ok := strings.CutPrefix(jobURL, "https://justjoin.it/job-offer/")
+	if !ok || slug == "" {
+		return "", false
+	}
+	d, ok := justjoin{http: c}.detail(ctx, slug)
+	if !ok {
+		return "", false
+	}
+	body := sanitizeHTML(d.Body)
+	if body == "" {
+		return "", false
+	}
+	return body, true
+}
+
+// detail fetches an offer's detail, returning ok=false on a failed request so the caller
+// falls back to the list-only job — an offer is never dropped over a missing detail.
+func (s justjoin) detail(ctx context.Context, slug string) (justJoinDetail, bool) {
+	var d justJoinDetail
+	if err := s.http.GetJSON(ctx, fmt.Sprintf(justJoinDetailURL, slug), &d); err != nil {
+		return justJoinDetail{}, false
+	}
+	return d, true
+}
+
+// apply enriches a list-derived job with the detail payload: the sanitized body becomes the
+// description, and the structured facets justjoin states unambiguously are mapped into
+// freehire's vocabularies (empty when unmapped, so the pipeline's dictionaries decide).
+// Category is deliberately not set — justjoin's category is a language/stack tag that does not
+// pin a single freehire role category, so the title dictionary decides it.
+func (d justJoinDetail) apply(base Job) Job {
+	base.Description = sanitizeHTML(d.Body)
+	base.Skills = justJoinSkills(d.RequiredSkills)
+	base.Seniority = justJoinSeniority(d.ExperienceLevel.Value)
+	return base
+}
+
+// justJoinSkills canonicalizes the required skills through the skilltag dictionary, keeping
+// only resolved technologies. The names are joined into one blob so skilltag.Parse applies the
+// same matching it uses on a description.
+func justJoinSkills(skills []justJoinSkill) []string {
+	names := make([]string, 0, len(skills))
+	for _, s := range skills {
+		names = append(names, s.Name)
+	}
+	return skilltag.Parse(strings.Join(names, " "))
+}
+
+// justJoinSeniority maps justjoin's experience level to freehire's seniority vocabulary.
+// justjoin names the middle grade "mid"; the rest (intern/junior/senior/c_level) share
+// spelling, so after that one rename vocabulary membership IS the map — an unrecognized level
+// (e.g. "manager", which is not a freehire seniority) drops rather than being guessed.
+func justJoinSeniority(level string) string {
+	l := strings.ToLower(strings.TrimSpace(level))
+	if l == "mid" {
+		l = "middle"
+	}
+	if slices.Contains(enrich.SeniorityValues, l) {
+		return l
+	}
+	return ""
 }
 
 // toJob maps an offer to a Job, returning ok=false for an unusable offer (no slug to build

--- a/internal/sources/justjoin_test.go
+++ b/internal/sources/justjoin_test.go
@@ -3,8 +3,58 @@ package sources
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 )
+
+// TestJustJoinHydrateMapsDetail verifies the per-offer detail fetch + mapping: the sanitized
+// body becomes the description and the structured facets justjoin states unambiguously
+// (skills, seniority) map into freehire's vocabularies. justjoin's "mid" means "middle".
+func TestJustJoinHydrateMapsDetail(t *testing.T) {
+	detail := `{
+"body":"<p>Build things.</p><script>alert(1)</script>",
+"requiredSkills":[{"name":"TypeScript","level":3},{"name":"Node.js","level":3}],
+"experienceLevel":{"label":"Mid","value":"mid"}
+}`
+	fake := (&routedHTTP{}).route("/v1/offers/acme-go-dev", detail)
+	s := justjoin{http: fake}
+
+	d, ok := s.detail(context.Background(), "acme-go-dev")
+	if !ok {
+		t.Fatal("detail() ok=false, want a successful fetch")
+	}
+	got := d.apply(Job{Title: "Go Developer", Company: "Acme"})
+
+	if !strings.Contains(got.Description, "Build things.") || strings.Contains(got.Description, "<script>") {
+		t.Errorf("Description not sanitized/assembled: %q", got.Description)
+	}
+	if !slices.Contains(got.Skills, "typescript") || !slices.Contains(got.Skills, "nodejs") {
+		t.Errorf("Skills = %v, want canonical typescript+nodejs", got.Skills)
+	}
+	if got.Seniority != "middle" {
+		t.Errorf("Seniority = %q, want middle (justjoin mid)", got.Seniority)
+	}
+}
+
+// TestJustJoinDescription covers the exported backfill helper: it derives the slug from a stored
+// job URL, fetches the detail, and returns the sanitized body — or ok=false when the URL is not a
+// justjoin offer URL, the fetch fails, or the body is empty.
+func TestJustJoinDescription(t *testing.T) {
+	detail := `{"body":"<p>Real body.</p><script>x()</script>"}`
+	fake := (&routedHTTP{}).route("/v1/offers/acme-go-dev--krakow", detail)
+
+	got, ok := JustJoinDescription(context.Background(), fake, "https://justjoin.it/job-offer/acme-go-dev--krakow")
+	if !ok {
+		t.Fatal("ok=false, want a fetched description")
+	}
+	if !strings.Contains(got, "Real body.") || strings.Contains(got, "<script>") {
+		t.Errorf("description not sanitized: %q", got)
+	}
+
+	if _, ok := JustJoinDescription(context.Background(), fake, "https://example.com/not-justjoin"); ok {
+		t.Error("ok=true for a non-justjoin URL, want false")
+	}
+}
 
 func TestJustJoinProvider(t *testing.T) {
 	if got := NewJustJoin(nil).Provider(); got != "justjoin" {
@@ -19,6 +69,12 @@ func TestJustJoinIsBoardlessAggregator(t *testing.T) {
 	}
 	if _, ok := s.(aggregator); !ok {
 		t.Error("justjoin should implement the aggregator marker")
+	}
+}
+
+func TestJustJoinIsHydratingSource(t *testing.T) {
+	if _, ok := NewJustJoin(nil).(HydratingSource); !ok {
+		t.Error("justjoin should implement the HydratingSource marker")
 	}
 }
 
@@ -38,6 +94,61 @@ func TestJustJoinBoardFileValidates(t *testing.T) {
 	}
 	if err := cfg.Validate(All(nil)); err != nil {
 		t.Fatalf("sources/justjoin.yml fails validation: %v", err)
+	}
+}
+
+func TestJustJoinFetchNewHydratesOnlyUnseen(t *testing.T) {
+	list := `{"data":[
+{"guid":"new-1","slug":"acme-go-dev--krakow","title":"Go Developer","companyName":"Acme","city":"Kraków","workplaceType":"remote","publishedAt":"2026-05-18T10:00:00.000Z"},
+{"guid":"seen-1","slug":"coder-security--warszawa","title":"Security Engineer","companyName":"Coder","city":"Warszawa","workplaceType":"office","publishedAt":"2026-05-19T00:41:27.040Z"}
+],"meta":{"next":null}}`
+	detail := `{"body":"<p>Build things.</p>","requiredSkills":[{"name":"Go"}],"experienceLevel":{"value":"senior"}}`
+	fake := (&routedHTTP{}).route("/v1/offers/acme-go-dev--krakow", detail).route("by-cursor", list)
+	seen := func(id string) bool { return id == "seen-1" }
+
+	jobs, err := justjoin{http: fake}.FetchNew(context.Background(), CompanyEntry{}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if got := byID["new-1"]; !strings.Contains(got.Description, "Build things.") || got.Seniority != "senior" {
+		t.Errorf("unseen offer not hydrated: desc=%q seniority=%q", got.Description, got.Seniority)
+	}
+	if got := byID["seen-1"]; got.Description != "" || !got.SeenRefresh {
+		t.Errorf("seen offer should be a liveness-refresh with no content, got description=%q SeenRefresh=%v", got.Description, got.SeenRefresh)
+	}
+	if byID["new-1"].SeenRefresh {
+		t.Error("hydrated new offer must not be marked SeenRefresh")
+	}
+	// One detail request for the single unseen offer (plus the one list page).
+	if fake.calls != 2 {
+		t.Errorf("made %d requests, want 2 (1 list + 1 detail for the unseen offer)", fake.calls)
+	}
+}
+
+func TestJustJoinFetchNewIsolatesDetailFailure(t *testing.T) {
+	list := `{"data":[
+{"guid":"new-1","slug":"acme-go-dev--krakow","title":"Go Developer","companyName":"Acme","city":"Kraków","workplaceType":"remote","publishedAt":"2026-05-18T10:00:00.000Z"}
+],"meta":{"next":null}}`
+	// No detail route → the detail fetch errors; the offer must still be ingested list-only.
+	fake := (&routedHTTP{}).route("by-cursor", list)
+	seen := func(string) bool { return false }
+
+	jobs, err := justjoin{http: fake}.FetchNew(context.Background(), CompanyEntry{}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew must not abort on a single detail failure: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (list-only fallback)", len(jobs))
+	}
+	if jobs[0].Description != "" {
+		t.Errorf("detail failed, want empty description, got %q", jobs[0].Description)
 	}
 }
 

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -63,6 +63,14 @@ type Job struct {
 	// these so the pipeline closes the job by identity instead of upserting it; all other
 	// adapters leave it false and only ever emit live postings.
 	Removed bool
+	// SeenRefresh marks a posting a HydratingSource re-listed but did NOT fetch fresh
+	// content for (it was already ingested, so detail is skipped). The pipeline refreshes
+	// the row's liveness (last_seen_at, reopen) by identity WITHOUT rewriting its content,
+	// so the description and facets hydrated when it was new are preserved — a content-less
+	// re-upsert would re-derive the facets from an empty description and wipe them. Only a
+	// HydratingSource sets it (carrying just Title/Company/URL/ExternalID for the identity);
+	// all other adapters leave it false. Mutually exclusive with Removed.
+	SeenRefresh bool
 }
 
 // Source adapts one job-source platform. Provider is the platform key that selects
@@ -84,6 +92,18 @@ type Source interface {
 type StreamingSource interface {
 	Source
 	FetchStream(ctx context.Context, e CompanyEntry, emit func(Job)) error
+}
+
+// HydratingSource is a Source that fetches expensive per-posting detail (e.g. the description
+// the list omits) only for postings the catalogue does not already have. The pipeline supplies a
+// seen predicate — seen(externalID) reports whether that posting is already ingested for the
+// provider — so a large aggregator (justjoin, ~20k live offers) issues detail requests only for
+// new postings instead of on every crawl. An adapter opts in by implementing this in addition to
+// Fetch (the list-only fallback used when the pipeline cannot supply a seen set); every other
+// adapter is unaffected. The pipeline prefers FetchNew when the adapter implements it.
+type HydratingSource interface {
+	Source
+	FetchNew(ctx context.Context, e CompanyEntry, seen func(externalID string) bool) ([]Job, error)
 }
 
 // boardless marks an adapter whose API has no per-tenant board id, so config

--- a/openspec/changes/justjoin-detail-hydration/.openspec.yaml
+++ b/openspec/changes/justjoin-detail-hydration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/justjoin-detail-hydration/design.md
+++ b/openspec/changes/justjoin-detail-hydration/design.md
@@ -1,0 +1,119 @@
+## Context
+
+`internal/sources/justjoin.go` reads only the `by-cursor` list endpoint, which omits the
+posting body, so every justjoin job is stored with an empty `Description`. The body lives
+only in `GET https://api.justjoin.it/v1/offers/{slug}` (verified live — the list `/v2/...`
+base 404s for a slug; the detail is a separate `/v1` route). `description` is part of
+`jobhash` (the `content_hash` that drives change-detection and search re-indexing) and it
+feeds skilltag/enrichment, so it must be present at upsert time, not backfilled into the
+JSONB later.
+
+The catalogue holds ~20,515 live justjoin offers. The list already carries the structured
+fields (`requiredSkills`, `experienceLevel`, `employmentTypes`, `categoryId`) — only `body`
+is detail-only. Fetching detail for every offer every crawl is ~20k extra requests per run
+(risking rate-limiting), so the design fetches detail only for offers the catalogue does not
+already have.
+
+The pipeline (`internal/pipeline/pipeline.go`) dispatches each board to its adapter via
+`Source.Fetch`, then saves each returned job through `Store.Save`. It already expresses
+optional adapter/store capabilities as interfaces the runner type-asserts (`StreamingSource`,
+`closer`, `BoardHealth`) — the idiom this change follows.
+
+## Goals / Non-Goals
+
+**Goals:**
+- justjoin jobs carry a real (sanitized) description.
+- Detail requests happen only for new offers in steady state; bounded concurrency; a single
+  offer's failure does not abort the crawl.
+- Fill the structured facets justjoin states (skills/seniority/category) mapped to freehire's
+  vocabularies, since detail is fetched anyway.
+- Backfill the ~20k existing empty rows once.
+- No change to `Source.Fetch` or to any other adapter; no N+1 DB queries.
+
+**Non-Goals:**
+- Fetching detail for already-seen offers on every crawl (rejected: cost).
+- Salary parsing from `employmentTypes` (out of scope; separate concern).
+- A general framework for detail hydration across all aggregators — only justjoin opts in
+  now; the seam is reusable but not retrofitted elsewhere.
+
+## Decisions
+
+**1. Optional `HydratingSource` interface, not a param on `Fetch`.**
+Add `HydratingSource { Source; FetchNew(ctx, e, seen func(externalID string) bool) ([]Job, error) }`.
+The runner type-asserts it (exactly like `StreamingSource`); justjoin implements both `Fetch`
+(list-only, kept for back-compat/tests/fallback) and `FetchNew`. Alternative — add a
+`seen`/`knownIDs` parameter to `Source.Fetch` — rejected: it forces a stub arg on every
+adapter and muddies the single-purpose fetch signature.
+
+**2. Provider-scoped seen-set, one query per crawl.**
+Add an optional Store capability `seenLookup { ExistingExternalIDs(ctx, source) (map[string]struct{}, error) }`,
+implemented in `cmd/ingest/store.go` over a new sqlc query `SELECT external_id FROM jobs WHERE source = $1`.
+The runner, when both the adapter is a `HydratingSource` and the Store is a `seenLookup`,
+loads the set once and closes a `seen` predicate over it (O(1) membership per offer).
+Fails open: a lookup error → empty set (every offer treated as new), logged, board still
+crawled. Alternative — per-offer `exists` query — rejected as N+1.
+Note the seen-set uses the namespaced `external_id` as stored; justjoin is boardless so the
+namespace is stable, and the adapter keys on the raw `guid` — the runner adapts between them
+(the predicate it passes already accounts for how identity is namespaced).
+
+**3. Detail fetch: bounded concurrency inside `FetchNew`.**
+`FetchNew` pages the list as today; for each unseen offer it fetches `/v1/offers/{slug}` via
+the shared `JSONGetter`, with a bounded worker pool (small fixed fan-out, in the spirit of
+the enrich concurrency), and maps `body`→`Description` (sanitized), `requiredSkills[].name`→
+`Skills` (via `skilltag.Parse`), and `experienceLevel.value`→`Seniority` (justjoin's `mid`
+means `middle`, then vocab-membership per `enrich.SeniorityValues`; empty when unmapped).
+**Category is intentionally not derived from justjoin's `category`**: it is a language/stack
+tag (JavaScript/Java/Python) that does not pin a single freehire role category, so mapping it
+would guess (JS is frontend or backend). The title dictionary decides category — the current
+behavior. A detail error for one offer is logged and that offer
+falls back to list-only (still ingested, just without a body this run — it will retry next
+crawl because it stays unseen only if never saved; once saved list-only it is seen, so the
+backfill/next-change path covers it — acceptable, logged).
+
+**3a. Seen offers refresh liveness only — they must NOT re-upsert content (review correction).**
+A seen offer is re-listed every crawl but carries no fresh content (detail is skipped). It cannot
+simply be upserted list-only: `jobderive` re-derives the deterministic facets (skills,
+posting_language, …) from the empty description, and `UpsertJob` guards only `description`
+(`COALESCE(NULLIF(...))`) — every other facet column is written unconditionally, so a content-less
+re-upsert would WIPE the description-derived facets hydrated when the offer was new, and churn
+`content_hash`. But the offer still needs its `last_seen_at` refreshed, or the 48h unseen sweep
+would wrongly close a still-live offer once its company gets any new offer (which puts the company
+in the crawled-set). So a seen offer is marked (`sources.Job.SeenRefresh`) and the pipeline routes
+it to a liveness-only `Touch` (bump `last_seen_at`, reopen if closed) by identity, leaving content
+untouched — mirroring the `Removed → Close` routing. `Touch` is an optional Store capability
+(`toucher`), like `closer`. `TouchJob` `RETURNING company_slug` so `dbStore.Touch` records the
+company into the crawled-set that scopes the post-run unseen sweep — exactly as `Save` does —
+otherwise a company whose offers were all touched (none newly saved this crawl) would fall out of
+the sweep and its genuinely-removed offers would never close.
+
+**4. One-time `cmd/backfill-justjoin`.**
+Run-once worker: select `source='justjoin'` rows, derive slug from the stored URL, fetch
+detail, update description via a new query, isolate/count per-row failures. Followed by
+`make reindex`. Separate command (not an `--backfill` flag on `cmd/ingest`) to keep the cron
+ingest path unbranched and match the other run-once maintenance commands.
+
+## Risks / Trade-offs
+
+- **First post-deploy state: 20k rows still empty until backfill runs** → run
+  `cmd/backfill-justjoin` + `make reindex` as the deploy step (documented in tasks); until
+  then only new offers get descriptions.
+- **A new offer whose detail fetch fails is saved list-only (empty body) and then counts as
+  "seen"** → it will not auto-hydrate next crawl. Mitigation: the failure is logged; the
+  periodic backfill (or a future re-hydrate on content change) recovers it. Acceptable given
+  detail failures are rare and the alternative (not saving the offer) hides the job entirely.
+- **justjoin rate-limiting on the backfill's 20k detail requests** → bounded concurrency +
+  isolate-and-continue; the backfill can be re-run (idempotent update) if throttled.
+- **`description` moving `content_hash` re-indexes ~20k docs once** → expected and desired;
+  the incremental index + reindex reconcile it.
+
+## Migration Plan
+
+1. Ship the adapter + pipeline seam (new offers hydrate going forward).
+2. Run `cmd/backfill-justjoin` once against prod, then `make reindex`.
+3. Rollback: the change is additive (new interface/queries/command); reverting the binary
+   restores list-only ingest with no schema rollback needed (no migration is added).
+
+## Open Questions
+
+None — seam shape (optional port + seen-set) and backfill (separate command) confirmed with
+the requester.

--- a/openspec/changes/justjoin-detail-hydration/proposal.md
+++ b/openspec/changes/justjoin-detail-hydration/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+JustJoin.it jobs are ingested with an empty description: the adapter reads only the
+`by-cursor` list endpoint, which omits the posting body. Every justjoin vacancy on
+freehire therefore renders with no description and a broken, empty job page (e.g.
+`/jobs/nodejs-software-engineer-e-mobility-energy-spyrosoft-qlna6pha`). The body lives
+only in a per-offer detail endpoint (`GET /v1/offers/{slug}`), so the fix requires
+detail requests — but justjoin serves ~20k live offers, so fetching detail for every
+offer every crawl is prohibitively expensive.
+
+## What Changes
+
+- **`justjoin` adapter fetches per-offer detail to populate the description.** For an
+  offer the catalogue does not already have, the adapter fetches `GET /v1/offers/{slug}`,
+  puts the sanitized `body` HTML into the job description, and — since the detail is
+  fetched anyway — fills the structured facets the platform states unambiguously
+  (`requiredSkills` → `Skills`, `experienceLevel` → `Seniority`), mapped into freehire's
+  controlled vocabularies (empty when unmapped). Category is left to the title dictionary:
+  justjoin's `category` is a language/stack tag that does not pin a single role category.
+- **Detail is fetched only for offers not already in the catalogue ("detail for new").**
+  The pipeline passes a `seen(externalID)` predicate (backed by the set of already-ingested
+  `external_id`s for the provider, one query per crawl) to a new optional adapter capability;
+  an already-seen offer emits a list-only job (its `last_seen_at` is bumped, description
+  unchanged). Steady-state crawls then hit detail only for the day's new offers.
+- **Detail requests are bounded.** The adapter fetches detail with bounded concurrency and
+  isolates a single offer's detail failure (it does not abort the crawl).
+- **One-time backfill for the existing empty rows.** A run-once `cmd/backfill-justjoin`
+  re-fetches detail for existing `source='justjoin'` rows and updates their description, so
+  the ~20k already-ingested vacancies gain a body and re-index (their `content_hash` moves).
+
+## Capabilities
+
+### New Capabilities
+- `justjoin-source`: the justjoin adapter's list+detail crawl — how it hydrates the
+  description and structured facets from `/v1/offers/{slug}` for unseen offers, and the
+  one-time backfill of existing rows.
+
+### Modified Capabilities
+- `source-ingest`: add an optional adapter capability that hydrates only postings the
+  catalogue does not already have, driven by a provider-scoped seen-set the pipeline
+  supplies — a bounded, opt-in seam that leaves every other adapter and the `Source.Fetch`
+  signature unchanged.
+
+## Impact
+
+- **Code**: `internal/sources/justjoin.go` (new `FetchNew`, detail fetch + mapping),
+  `internal/sources/source.go` (new `HydratingSource` optional interface),
+  `internal/pipeline/pipeline.go` (type-assert the hydrating capability + seen-set port),
+  `cmd/ingest/store.go` + `internal/db/queries/*.sql` (new `ExistingExternalIDs` query and
+  a description-update query), new `cmd/backfill-justjoin/main.go`.
+- **APIs**: none (backend ingest only).
+- **Operations**: `cmd/backfill-justjoin` run once after deploy, followed by `make reindex`;
+  first steady-state crawl is cheap (detail only for new offers).
+- **Dependencies**: none new — reuses the existing shared HTTP JSON client and sqlc.

--- a/openspec/changes/justjoin-detail-hydration/specs/justjoin-source/spec.md
+++ b/openspec/changes/justjoin-detail-hydration/specs/justjoin-source/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: JustJoin list-plus-detail crawl
+
+The system SHALL provide a `justjoin` source adapter that crawls the justjoin.it public
+API. The adapter is boardless and multi-company (it stays in the source facet and takes
+each posting's company from the feed), paging the cursor list endpoint
+`https://api.justjoin.it/v2/user-panel/offers/by-cursor` by the `from` cursor. Because the
+list endpoint omits the posting body, the adapter SHALL obtain the description from the
+per-offer detail endpoint `https://api.justjoin.it/v1/offers/{slug}`, whose `body` field
+carries the description HTML.
+
+#### Scenario: List page maps to jobs
+
+- **WHEN** the adapter reads a cursor page from the list endpoint
+- **THEN** it yields one `Job` per offer carrying the offer's title, company, city
+  location, work mode (from `workplaceType`), posted-at timestamp, and the offer `guid` as
+  the `ExternalID`, synthesizing the canonical detail URL from the offer slug
+
+#### Scenario: Offer without slug, guid, or company is dropped
+
+- **WHEN** an offer in the feed has no slug, no guid, or no company name
+- **THEN** the adapter drops that offer (it cannot build a URL, a dedup key, or a company)
+
+### Requirement: JustJoin hydrates the description for unseen offers only
+
+The adapter SHALL fetch per-offer detail only for an offer the catalogue does not already
+have, so a steady-state crawl issues detail requests only for new offers. The adapter SHALL
+receive a `seen(externalID)` predicate; for an offer whose `guid` is not seen it SHALL fetch
+`/v1/offers/{slug}`, put the sanitized `body` into the job description, and — from the same
+detail payload — set the structured facets the platform states unambiguously: skills from
+`requiredSkills[].name` (canonicalized through the skill dictionary) and seniority from
+`experienceLevel.value` (mapped into freehire's seniority vocabulary, with justjoin's `mid`
+meaning `middle`), each left empty when a value does not map. The adapter SHALL NOT derive a
+category from justjoin's `category`: it is a language/stack tag (JavaScript, Java, Python, …)
+that does not pin a single freehire role category, so the title dictionary decides category.
+For a seen offer the adapter SHALL yield a liveness-refresh job (no detail request): the pipeline
+refreshes the posting's last-seen state (and reopens it if closed) WITHOUT rewriting its content,
+so the description and facets hydrated when it was new are preserved rather than overwritten by a
+content-less re-upsert.
+
+Detail requests SHALL be bounded (a single crawl SHALL NOT issue unbounded concurrent detail
+requests), and a single offer's detail failure SHALL be isolated: the adapter logs and skips
+that offer's hydration rather than aborting the crawl.
+
+#### Scenario: New offer is hydrated with a description
+
+- **WHEN** the crawl encounters an offer whose guid is not in the seen set
+- **THEN** the adapter fetches that offer's detail and yields a `Job` whose description is
+  the sanitized detail `body`, with skills and seniority set from the detail when they map to
+  freehire's vocabularies
+
+#### Scenario: Already-ingested offer skips the detail request and preserves content
+
+- **WHEN** the crawl encounters an offer whose guid is already in the seen set
+- **THEN** the adapter yields a liveness-refresh `Job` (marked, no detail request), and the
+  pipeline only refreshes the row's last-seen/open state — its stored description and facets are
+  not overwritten
+
+#### Scenario: A single offer's detail failure does not abort the crawl
+
+- **WHEN** the detail request for one unseen offer fails
+- **THEN** the adapter logs and skips that offer's hydration and continues crawling the
+  remaining offers
+
+### Requirement: One-time backfill of existing empty JustJoin descriptions
+
+The system SHALL provide a run-once `cmd/backfill-justjoin` worker that, for existing
+catalogue rows with `source = 'justjoin'`, fetches each posting's detail from
+`/v1/offers/{slug}` (slug taken from the stored URL) and updates the row's description, so
+the rows ingested before hydration gain a body and re-index (their `content_hash` moves). A
+single posting's detail failure SHALL be isolated and counted, never aborting the run.
+
+#### Scenario: Existing empty row gains a description
+
+- **WHEN** the backfill worker processes a `justjoin` row whose detail fetch succeeds
+- **THEN** it updates that row's description with the sanitized detail body
+
+#### Scenario: Backfill isolates a failed posting
+
+- **WHEN** the detail fetch for one row fails or the posting is gone
+- **THEN** the worker logs and skips that row and continues with the rest

--- a/openspec/changes/justjoin-detail-hydration/specs/source-ingest/spec.md
+++ b/openspec/changes/justjoin-detail-hydration/specs/source-ingest/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Adapters may hydrate only postings the catalogue lacks
+
+The pipeline SHALL support an optional adapter capability that fetches per-posting detail
+only for postings the catalogue does not already have, so an adapter whose detail requests
+are expensive (a large aggregator) issues them only for new postings rather than on every
+crawl. The capability SHALL be opt-in through a distinct adapter interface (not a change to
+`Source.Fetch`), so every other adapter and the base fetch signature are unchanged — the
+same optional-port shape the pipeline already uses for streaming and self-closing sources.
+
+When a board's adapter implements this capability, the pipeline SHALL supply a
+provider-scoped `seen(externalID)` predicate backed by the set of `external_id`s already
+stored for that provider, obtained with a single query per crawl (not one query per
+posting). An adapter that does not implement the capability SHALL be crawled through the
+normal fetch path, unaffected.
+
+A hydrating adapter re-lists postings it already ingested but fetches no fresh content for them,
+so the pipeline MUST refresh such a posting's liveness (last-seen state, and reopen if closed)
+WITHOUT rewriting its content columns. A content-less re-upsert would re-derive the deterministic
+facets from an empty description and overwrite the row's hydrated description/skills/etc. The
+adapter SHALL mark an already-ingested posting for liveness refresh; the pipeline routes a marked
+posting to the refresh path instead of the content upsert. (This mirrors the removed-posting
+close routing.) A refresh keeps the posting out of the post-run unseen sweep just as a full
+upsert would.
+
+#### Scenario: Already-ingested posting refreshes liveness without a content rewrite
+
+- **WHEN** a hydrating adapter yields a posting marked for liveness refresh (already ingested)
+- **THEN** the pipeline refreshes its last-seen/open state and does NOT overwrite its stored
+  description or facets
+
+#### Scenario: Hydrating adapter is driven by the seen-set
+
+- **WHEN** a board's adapter implements the hydrating capability
+- **THEN** the pipeline loads the set of already-ingested external ids for that provider once
+  and passes a membership predicate to the adapter, which hydrates only postings not in the set
+
+#### Scenario: Non-hydrating adapter is unaffected
+
+- **WHEN** a board's adapter does not implement the hydrating capability
+- **THEN** the pipeline crawls it through the normal fetch path and issues no seen-set query
+
+#### Scenario: Seen-set lookup failure does not abort the crawl
+
+- **WHEN** the seen-set query fails for a hydrating board
+- **THEN** the pipeline logs the failure and crawls the board with an empty seen-set (every
+  offer treated as new) rather than skipping the board

--- a/openspec/changes/justjoin-detail-hydration/tasks.md
+++ b/openspec/changes/justjoin-detail-hydration/tasks.md
@@ -1,0 +1,29 @@
+## 1. JustJoin adapter: detail hydration
+
+- [x] 1.1 Add the detail types (`justJoinDetail` with `body`, `requiredSkills[].name`, `experienceLevel.value`) and a `hydrate` mapper that returns a Job with sanitized `body` → `Description`, skills via `skilltag.Parse(requiredSkills[].name)`, and seniority via `experienceLevel.value` (mid→middle, then `enrich.SeniorityValues` membership; empty when unmapped). Category is NOT set from justjoin (stack tag, title dict decides). Unit-test with a fake JSONGetter (routedHTTP): asserts description is sanitized and skills/seniority map.
+- [x] 1.2 Add `FetchNew(ctx, e, seen func(externalID string) bool)`: page the list as `Fetch` does, hydrate only offers whose `guid` is not `seen` (bounded concurrency), mark seen offers `SeenRefresh` (liveness-only, no content), and isolate a single offer's detail failure (log + fall back to list-only). Unit-test: seen offer marked + no detail, unseen offer hydrates, one detail error does not abort.
+
+## 1b. Seen-offer liveness refresh (must not wipe hydrated content)
+
+- [x] 1b.1 Add `sources.Job.SeenRefresh` (mirroring `Removed`) and route it in the pipeline's buffered loop to a liveness-only `Touch` (via a `toucher` optional Store capability) instead of a content re-upsert. Add the `TouchJob` query (`last_seen_at`+reopen, no content), `make sqlc`, and `dbStore.Touch`. Unit-test the pipeline routing (seen → touch, new → save); integration-test `TouchJob` preserves description/skills while refreshing liveness + reopening.
+
+## 2. HydratingSource optional interface
+
+- [x] 2.1 Add `HydratingSource` interface (`Source` + `FetchNew`) to `internal/sources/source.go` and assert `justjoin` implements it. Unit-test: `NewJustJoin(nil).(HydratingSource)` type-asserts.
+
+## 3. Pipeline seam: seen-set driven hydration
+
+- [x] 3.1 Add the optional `seenLookup { ExistingExternalIDs(ctx, source) (map[string]struct{}, error) }` Store capability and wire `ingestBoard` to prefer `FetchNew` when the adapter is a `HydratingSource` and the Store is a `seenLookup`: load the provider's seen-set once, pass a membership predicate; fail open (empty set + log) on lookup error. Non-hydrating adapters and Stores without the capability use the existing `Fetch` path unchanged. Unit-test with fakes: hydrating adapter is driven by the seen-set; non-hydrating adapter untouched; lookup error → empty set, board still crawled.
+
+## 4. Store: ExistingExternalIDs query
+
+- [x] 4.1 Add the sqlc query `ExistingExternalIDs` (`SELECT external_id FROM jobs WHERE source = $1`), run `make sqlc`, and implement `seenLookup` on `cmd/ingest`'s `dbStore` (returning the set). Integration-test (build-tagged) that it returns the stored external ids for the provider.
+
+## 5. One-time backfill command
+
+- [x] 5.1 Add the sqlc queries the backfill needs (list `source='justjoin'` rows with id/url; update a row's description + refreshed content_hash), run `make sqlc`. Unit/integration-test the update query.
+- [x] 5.2 Add `cmd/backfill-justjoin/main.go` (run-once via `worker.Main`): iterate justjoin rows, derive slug from the stored URL, fetch detail, update description, isolate + count per-row failures, log a summary. Manually smoke-run against a couple of live slugs.
+
+## 6. Verification
+
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...` green; document the deploy step (run `cmd/backfill-justjoin` then `make reindex`) in the change notes.


### PR DESCRIPTION
## Problem

The `justjoin` adapter read only the `by-cursor` list endpoint, which omits the posting body, so **every justjoin job was ingested with an empty description** — a blank, broken job page (e.g. [nodejs-software-engineer-e-mobility-energy-spyrosoft](https://freehire.dev/jobs/nodejs-software-engineer-e-mobility-energy-spyrosoft-qlna6pha)). The body lives only in the per-offer detail endpoint `GET /v1/offers/{slug}` (a `/v1` route, distinct from the `/v2` list base).

Fetching detail for all ~20k live offers every crawl is prohibitive, hence **detail-only-for-new**.

## Change

- **`HydratingSource`** — opt-in adapter capability (`Source` + `FetchNew`) the pipeline type-asserts, mirroring `StreamingSource`/`closer`. `FetchNew` fetches detail only for offers the catalogue lacks, driven by a provider-scoped **seen-set** (`ExistingExternalIDs`, one query per crawl, fails open on error).
- **New offers hydrated:** sanitized `body` → `Description`, `requiredSkills` → `Skills` (skilltag), `experienceLevel` → `Seniority` (`mid`→`middle`). Category is left to the title dictionary — justjoin's `category` is a language/stack tag, ambiguous for a role category.
- **Seen offers → liveness-only `Touch`** (marked `SeenRefresh`, routed like `Removed → Close`): bump `last_seen_at` + reopen, **no content rewrite**. A content-less re-upsert would re-derive facets from the empty description and wipe the hydrated ones (only `description` is COALESCE-guarded in `UpsertJob`). `TouchJob RETURNING company_slug` keeps the company in the post-run unseen-sweep scope, so removed offers still close.
- **`cmd/backfill-justjoin`** — run-once worker filling the description of rows ingested before hydration (keyset paging, refreshed `content_hash`, per-row failures isolated).

## Verification

- `go build ./... && go vet ./... && go test ./...` green.
- Integration tests (`ExistingExternalIDs`, `TouchJob` preserves content while refreshing liveness + reopening) against real Postgres.
- Live end-to-end: the exact reported offer now yields a real **2841-char sanitized description** through the shipped path.
- Reviewed by a multi-agent pass; two real bugs (facet-wipe on re-crawl, crawled-set/sweep gap) found, fixed, and re-verified.

## Deploy

No schema migration. After deploy: run `cmd/backfill-justjoin`, then `make reindex` (optionally `cmd/backfill-derive` so skills re-derive from the new descriptions).

OpenSpec change: `openspec/changes/justjoin-detail-hydration/`.