### PR TITLE
feat(sources): add 37 ATS boards harvested from wantapply

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7391,3 +7391,11 @@
   board: mistral.ai
 - company: Neura Robotics
   board: neura-robotics-gmbh
+- company: Codeway
+  board: codeway
+- company: CyberStaff
+  board: cyberstaff
+- company: Eneba
+  board: eneba
+- company: Lightspeed
+  board: lightspeed

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18611,3 +18611,29 @@
   board: zerova
 - company: Zoom Fibre
   board: zoomfibre
+- company: EWA
+  board: appewa
+- company: CoreStar
+  board: corestar
+- company: CRITICAL REFLEX
+  board: criticalreflex
+- company: Eqvilent
+  board: eqvilent
+- company: FinDev
+  board: findev
+- company: Horizons
+  board: horizons
+- company: Krisp
+  board: krisp
+- company: On The Spot Development
+  board: onthespotdev
+- company: Pasul
+  board: pasul
+- company: PayDepot
+  board: paydepot
+- company: RoboMarkets
+  board: robomarkets
+- company: The Trading Pit
+  board: thetradingpit
+- company: YouHodler
+  board: youhodler

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3567,3 +3567,5 @@
   board: step-up-team
 - company: Chatfuel
   board: chatfuel
+- company: Quantori
+  board: quantori

--- a/sources/freshteam.yml
+++ b/sources/freshteam.yml
@@ -298,3 +298,9 @@
   board: xsensio
 - company: Yudrio
   board: yudrio-team
+- company: Chattermill
+  board: chattermill
+- company: Pyypl
+  board: pyypl
+- company: TourScanner
+  board: tourscanner

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14055,3 +14055,7 @@
   board: ziro
 - company: Indicium AI
   board: indiciumai
+- company: FxPro
+  board: fxpro
+- company: N26
+  board: n26

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -7969,3 +7969,11 @@
   board: zurheide-feine-kost-kg
 - company: zvoove
   board: zvoove
+- company: bsport
+  board: bsport
+- company: Personio
+  board: personio
+- company: Urban Sports Club
+  board: urbansportsclub
+- company: Workflex
+  board: workflex

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3499,3 +3499,9 @@
   board: zorgmed
 - company: Z-Catering Mitte
   board: zteam
+- company: AI Digital
+  board: aidigital
+- company: BetterMe
+  board: betterme
+- company: TTeam
+  board: tteam

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -5657,3 +5657,17 @@
   board: Endava
 - company: SOSi
   board: SOSi1
+- company: Apifonica
+  board: apifonica
+- company: BGaming
+  board: bgaming
+- company: Joom
+  board: joom
+- company: Olinio
+  board: olinio
+- company: Paralect
+  board: paralect
+- company: Social Quantum
+  board: socialquantum
+- company: Talentgrator
+  board: talentgrator


### PR DESCRIPTION
Harvested 802 companies from wantapply.com (directApply aggregator, no external ATS links) and probed each against public ATS APIs via `cmd/harvest-boards`. Kept only boards returning live jobs:

- bamboohr 13, smartrecruiters 7, ashby 4, personio 4, freshteam 3, recruitee 3, greenhouse 2, breezy 1 = **37**

Poison candidates (generic/short slugs, linkedin-domain fallbacks) dropped; mis-attributed matches (workable/1inch, recruitee/pay) removed on review. Seed list preserved in `spike/wantapply-companies/` (untracked).