### PR TITLE
feat: Loxo careers-board adapter + harvest-loxo prober

### DIFF
--- a/cmd/harvest-loxo/main.go
+++ b/cmd/harvest-loxo/main.go
@@ -116,7 +116,7 @@ func extractCandidates(lines []string) []candidate {
 // segment; a /job/<base64> URL has two segments and carries no slug.
 func candidateFromURL(raw string) (candidate, bool) {
 	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || u.Host == "" || !strings.HasSuffix(u.Host, "app.loxo.co") {
+	if err != nil || u.Host == "" || !isLoxoHost(u.Host) {
 		return candidate{}, false
 	}
 	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
@@ -128,6 +128,12 @@ func candidateFromURL(raw string) (candidate, bool) {
 		return candidate{}, false
 	}
 	return candidate{host: u.Host, slug: parts[0]}, true
+}
+
+// isLoxoHost reports whether host is app.loxo.co or one of its subdomains (agency or pod),
+// without matching a lookalike like "notapp.loxo.co".
+func isLoxoHost(host string) bool {
+	return host == "app.loxo.co" || strings.HasSuffix(host, ".app.loxo.co")
 }
 
 // probeAll validates each candidate concurrently, keeping the boards that yield open jobs.

--- a/cmd/harvest-loxo/main.go
+++ b/cmd/harvest-loxo/main.go
@@ -1,0 +1,223 @@
+// Command harvest-loxo curates Loxo agency boards from an operator-supplied footprint.
+// Loxo exposes no public directory of agencies, so the operator gathers footprint URLs
+// (careers pages and /job/<base64> links, e.g. from a `site:app.loxo.co` search) and pipes
+// them in; this tool extracts each board's (host, slug), live-validates it via the loxo
+// adapter, counts how many postings classify as tech, and emits draft sources/loxo.yml
+// entries (all hub: true) for human review — it never edits the board file itself.
+//
+//	go run ./cmd/harvest-loxo < footprint-urls.txt > candidates.yml
+//	go run ./cmd/harvest-loxo footprint-urls.txt
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/strelov1/freehire/internal/classify"
+	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// boardPath is the board file the emitted entries are de-duplicated against.
+const boardPath = "sources/loxo.yml"
+
+// probeWorkers bounds the concurrent board probes. The shared client handles 429 backoff.
+const probeWorkers = 8
+
+type candidate struct{ host, slug string }
+
+type result struct {
+	cand        candidate
+	company     string
+	total, tech int
+}
+
+func main() { os.Exit(run()) }
+
+func run() int {
+	lines, err := readLines()
+	if err != nil {
+		log.Printf("harvest-loxo: %v", err)
+		return 1
+	}
+	cands := extractCandidates(lines)
+	existing := loadExistingBoards(boardPath)
+	var todo []candidate
+	for _, c := range cands {
+		if !existing[c.host+"/"+c.slug] {
+			todo = append(todo, c)
+		}
+	}
+	log.Printf("harvest-loxo: %d candidates, %d new (after de-dup vs %s)", len(cands), len(todo), boardPath)
+
+	client := sources.NewClient()
+	adapter := sources.NewLoxo(client)
+	kept := probeAll(context.Background(), client, adapter, todo)
+	sort.Slice(kept, func(i, j int) bool { return kept[i].cand.slug < kept[j].cand.slug })
+
+	for _, r := range kept {
+		fmt.Printf("# %s/%s — %d jobs, %d tech\n", r.cand.host, r.cand.slug, r.total, r.tech)
+		fmt.Printf("- company: %s\n  board: %s/%s\n  hub: true\n", r.company, r.cand.host, r.cand.slug)
+	}
+	log.Printf("harvest-loxo: %d/%d boards validated with open jobs", len(kept), len(todo))
+	return 0
+}
+
+// readLines reads footprint URLs from a seed-file arg or stdin.
+func readLines() ([]string, error) {
+	src := os.Stdin
+	if len(os.Args) == 2 {
+		f, err := os.Open(os.Args[1])
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		src = f
+	}
+	var lines []string
+	sc := bufio.NewScanner(src)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		lines = append(lines, sc.Text())
+	}
+	return lines, sc.Err()
+}
+
+// extractCandidates parses footprint URLs into a distinct, order-preserving careers-board
+// candidate set.
+func extractCandidates(lines []string) []candidate {
+	var out []candidate
+	seen := map[string]bool{}
+	for _, l := range lines {
+		c, ok := candidateFromURL(l)
+		if !ok {
+			continue
+		}
+		key := c.host + "/" + c.slug
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, c)
+	}
+	return out
+}
+
+// candidateFromURL turns a Loxo footprint URL into a careers-board (host, slug), ok=false
+// for job-detail, auth, and non-Loxo URLs. A careers page is a single non-reserved path
+// segment; a /job/<base64> URL has two segments and carries no slug.
+func candidateFromURL(raw string) (candidate, bool) {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" || !strings.HasSuffix(u.Host, "app.loxo.co") {
+		return candidate{}, false
+	}
+	parts := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(parts) != 1 || parts[0] == "" {
+		return candidate{}, false
+	}
+	switch parts[0] {
+	case "job", "jobs", "login", "logout", "api", "signup", "password", "users":
+		return candidate{}, false
+	}
+	return candidate{host: u.Host, slug: parts[0]}, true
+}
+
+// probeAll validates each candidate concurrently, keeping the boards that yield open jobs.
+func probeAll(ctx context.Context, client sources.HTTPClient, adapter sources.Source, cands []candidate) []result {
+	var (
+		mu   sync.Mutex
+		kept []result
+		wg   sync.WaitGroup
+	)
+	sem := make(chan struct{}, probeWorkers)
+	for _, c := range cands {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(c candidate) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			if r, ok := probe(ctx, client, adapter, c); ok {
+				mu.Lock()
+				kept = append(kept, r)
+				mu.Unlock()
+			}
+		}(c)
+	}
+	wg.Wait()
+	return kept
+}
+
+// probe live-validates one board: the loxo adapter must return at least one posting. It
+// counts tech postings by title and reads the agency's display name from the listing title.
+func probe(ctx context.Context, client sources.HTTPClient, adapter sources.Source, c candidate) (result, bool) {
+	jobs, err := adapter.Fetch(ctx, sources.CompanyEntry{
+		Board: c.host + "/" + c.slug, Company: c.slug, Hub: true, Provider: "loxo",
+	})
+	if err != nil {
+		log.Printf("harvest-loxo: %s/%s: %v", c.host, c.slug, err)
+		return result{}, false
+	}
+	if len(jobs) == 0 {
+		return result{}, false
+	}
+	tech := 0
+	for _, j := range jobs {
+		if isTechCategory(classify.Parse(j.Title).Category) {
+			tech++
+		}
+	}
+	company := c.slug
+	if txt, err := client.GetText(ctx, "https://"+c.host+"/"+c.slug); err == nil {
+		if n := agencyName(txt); n != "" {
+			company = n
+		}
+	}
+	return result{cand: c, company: company, total: len(jobs), tech: tech}, true
+}
+
+// loxoTitlePattern captures the agency name from a Loxo listing "<title>Job Listing | Agency</title>".
+var loxoTitlePattern = regexp.MustCompile(`(?s)<title>\s*Job Listing\s*\|\s*(.+?)\s*</title>`)
+
+// agencyName returns the agency display name from a listing page's title, or "".
+func agencyName(listingHTML string) string {
+	if m := loxoTitlePattern.FindStringSubmatch(listingHTML); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+// isTechCategory reports whether a classified title category counts as tech: a resolved
+// category that is not one of the confidently non-tech ones.
+func isTechCategory(category string) bool {
+	if category == "" {
+		return false
+	}
+	for _, nt := range enrich.NonTechCategories {
+		if category == nt {
+			return false
+		}
+	}
+	return true
+}
+
+// loadExistingBoards returns the set of "host/slug" boards already in the board file, so
+// the emitter never re-proposes a known board. A missing file yields an empty set.
+func loadExistingBoards(path string) map[string]bool {
+	m := map[string]bool{}
+	cfg, err := sources.LoadConfig(path)
+	if err != nil {
+		return m
+	}
+	for _, e := range cfg.Sources {
+		m[e.Board] = true
+	}
+	return m
+}

--- a/cmd/harvest-loxo/main_test.go
+++ b/cmd/harvest-loxo/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestExtractCandidates(t *testing.T) {
+	in := []string{
+		"https://fitnext.app.loxo.co/fitnext",                     // agency subdomain
+		"https://app.loxo.co/agile-recruiter?location_sort=asc",   // bare host + query
+		"https://pod4.app.loxo.co/la-tech",                        // regional pod
+		"https://app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==", // job detail — no slug, skip
+		"https://fitnext.app.loxo.co/login",                       // non-careers, skip
+		"https://app.loxo.co/agile-recruiter",                     // dup of #2 (query stripped)
+		"https://example.com/careers",                             // not loxo, skip
+		"  ",                                                      // blank, skip
+	}
+	got := extractCandidates(in)
+	want := []candidate{
+		{"fitnext.app.loxo.co", "fitnext"},
+		{"app.loxo.co", "agile-recruiter"},
+		{"pod4.app.loxo.co", "la-tech"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %+v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("candidate[%d] = %+v, want %+v", i, got[i], w)
+		}
+	}
+}
+
+func TestAgencyName(t *testing.T) {
+	cases := map[string]string{
+		`<title>Job Listing | FitNext Co.</title>`: "FitNext Co.",
+		`<title>Job Listing | LA-Tech</title>`:     "LA-Tech",
+		`<title>Something else</title>`:            "", // no agency → caller falls back to slug
+	}
+	for html, want := range cases {
+		if got := agencyName(html); got != want {
+			t.Errorf("agencyName(%q) = %q, want %q", html, got, want)
+		}
+	}
+}
+
+func TestIsTechCategory(t *testing.T) {
+	if !isTechCategory("backend") {
+		t.Error("backend should be tech")
+	}
+	for _, nonTech := range []string{"marketing", "sales", "support", "management", ""} {
+		if isTechCategory(nonTech) {
+			t.Errorf("%q should not count as tech", nonTech)
+		}
+	}
+}

--- a/cmd/harvest-loxo/main_test.go
+++ b/cmd/harvest-loxo/main_test.go
@@ -11,6 +11,7 @@ func TestExtractCandidates(t *testing.T) {
 		"https://fitnext.app.loxo.co/login",                       // non-careers, skip
 		"https://app.loxo.co/agile-recruiter",                     // dup of #2 (query stripped)
 		"https://example.com/careers",                             // not loxo, skip
+		"https://notapp.loxo.co/evil",                             // lookalike host, skip
 		"  ",                                                      // blank, skip
 	}
 	got := extractCandidates(in)

--- a/internal/sources/loxo.go
+++ b/internal/sources/loxo.go
@@ -1,0 +1,206 @@
+package sources
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// loxo adapts Loxo recruiting-agency careers boards. Loxo hosts each agency's public
+// board at "<host>/<slug>" where host is an agency subdomain (fitnext.app.loxo.co), the
+// bare app.loxo.co, or a regional pod (pod4.app.loxo.co); the board id carries the full
+// "<host>/<slug>" so one adapter covers every variant. The server-rendered careers page
+// links each posting as /job/<base64>; the base64 decodes to a stable <agency_id>-<slug>
+// dedup id. A detail page carries the role in og:title, the location in the og:description
+// "Location: … Salary:" run, and the HTML body in an embedded application/json blob (there
+// is no schema.org JobPosting). Boards are agencies hosting many clients' vacancies, so a
+// hub board resolves the client from the posting and falls back to the agency name.
+
+type loxo struct {
+	http HTMLGetter
+}
+
+// NewLoxo builds the Loxo careers-board adapter over the given HTML client.
+func NewLoxo(c HTMLGetter) Source { return loxo{http: c} }
+
+func (loxo) Provider() string { return "loxo" }
+
+func (s loxo) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse("https://" + e.Board)
+	if err != nil {
+		return nil, fmt.Errorf("loxo: board %q: %w", e.Board, err)
+	}
+	root, err := s.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("loxo: listing %s: %w", e.Board, err)
+	}
+	locs := loxoJobLinks(base, root)
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one posting's detail page and maps it to a Job, returning ok=false when
+// the fetch fails so the caller skips just that posting.
+func (s loxo) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	return mapLoxoDetail(root, e, loc)
+}
+
+// mapLoxoDetail maps an already-parsed Loxo detail page to a Job. It is split from detail so
+// it can be unit-tested on a saved fixture without an HTTP fake.
+func mapLoxoDetail(root *html.Node, e CompanyEntry, loc string) (Job, bool) {
+	id := loxoExternalID(loc)
+	if id == "" {
+		return Job{}, false
+	}
+	title := metaProperty(root, "og:title")
+	if title == "" {
+		title = loxoStripAgencySuffix(titleText(root))
+	}
+	desc := loxoDescription(root)
+	if title == "" && desc == "" {
+		return Job{}, false // not a rendered job page
+	}
+
+	company, title := loxoCompany(title, e)
+	location := loxoLocation(metaProperty(root, "og:description"))
+
+	return Job{
+		ExternalID:  id,
+		URL:         loc,
+		Title:       title,
+		Company:     company,
+		Location:    location,
+		Description: sanitizeHTML(desc),
+		Remote:      isRemote(location),
+	}, true
+}
+
+// loxoJobIDPattern captures the base64 job token from a /job/<base64> URL, stopping at a
+// ?/# so the ?t=… cache-buster and any sub-action suffix are excluded.
+var loxoJobIDPattern = regexp.MustCompile(`/job/([A-Za-z0-9=_-]+)(?:$|[/?#])`)
+
+// loxoExternalID returns the posting's stable dedup id: the base64 token decoded to Loxo's
+// <agency_id>-<slug> pair, or the raw token when it does not decode cleanly, or "" when the
+// URL is not a job posting.
+func loxoExternalID(loc string) string {
+	m := loxoJobIDPattern.FindStringSubmatch(loc)
+	if m == nil {
+		return ""
+	}
+	tok := m[1]
+	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.RawURLEncoding} {
+		if dec, err := enc.DecodeString(tok); err == nil {
+			if s := string(dec); strings.ContainsRune(s, '-') && isPrintable(s) {
+				return s
+			}
+		}
+	}
+	return tok
+}
+
+// loxoJobLinks returns the absolute, deduplicated /job/<base64> detail URL of every posting
+// linked on a listing page, resolved against base.
+func loxoJobLinks(base *url.URL, root *html.Node) []string {
+	return jobLinks(base, root, func(href string) bool { return loxoJobIDPattern.MatchString(href) })
+}
+
+// loxoDescription returns the HTML description from the first embedded
+// <script type="application/json"> block that carries one.
+func loxoDescription(root *html.Node) string {
+	var desc string
+	walk(root, func(n *html.Node) bool {
+		if desc != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "script" && attr(n, "type") == "application/json" {
+			var p struct {
+				Description string `json:"description"`
+			}
+			if json.Unmarshal([]byte(textContent(n)), &p) == nil && p.Description != "" {
+				desc = p.Description
+			}
+		}
+		return true
+	})
+	return html.UnescapeString(desc)
+}
+
+// loxoLocation extracts the free-text location from the og:description, whose format is
+// "<role>Location: <loc>Salary: <pay>…". Returns "" when no "Location:" run is present —
+// geography is never guessed.
+func loxoLocation(ogDesc string) string {
+	i := strings.Index(ogDesc, "Location:")
+	if i < 0 {
+		return ""
+	}
+	rest := ogDesc[i+len("Location:"):]
+	if j := strings.Index(rest, "Salary:"); j >= 0 {
+		rest = rest[:j]
+	}
+	return strings.TrimSpace(rest)
+}
+
+// loxoCompany resolves the employer for a posting. On a hub board (an agency hosting many
+// clients) it splits the client off an explicit em-dash / " @ " delimiter in the title,
+// returning (client, roleTitle); otherwise it returns the configured agency name and the
+// title unchanged. The ASCII " - " is deliberately not a delimiter: it collides with
+// compound roles ("Full-Stack") and location suffixes, so treating it as a client marker
+// would guess wrong — never guess.
+func loxoCompany(title string, e CompanyEntry) (company, roleTitle string) {
+	if e.Hub {
+		for _, sep := range []string{" — ", " @ "} {
+			if i := strings.LastIndex(title, sep); i >= 0 {
+				client := strings.TrimSpace(title[i+len(sep):])
+				role := strings.TrimSpace(title[:i])
+				if client != "" && role != "" {
+					return client, role
+				}
+			}
+		}
+	}
+	return e.Company, title
+}
+
+// titleText returns the document <title> text, or "".
+func titleText(root *html.Node) string {
+	var t string
+	walk(root, func(n *html.Node) bool {
+		if t != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "title" {
+			t = textContent(n)
+			return false
+		}
+		return true
+	})
+	return t
+}
+
+// loxoStripAgencySuffix drops a trailing " | <agency>" from a document title.
+func loxoStripAgencySuffix(title string) string {
+	if i := strings.LastIndex(title, " | "); i >= 0 {
+		return strings.TrimSpace(title[:i])
+	}
+	return title
+}
+
+func isPrintable(s string) bool {
+	for _, r := range s {
+		if r < 0x20 && r != '\t' && r != '\n' && r != '\r' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sources/loxo.go
+++ b/internal/sources/loxo.go
@@ -133,7 +133,10 @@ func loxoDescription(root *html.Node) string {
 		}
 		return true
 	})
-	return html.UnescapeString(desc)
+	// The blob carries raw HTML markup (not entity-escaped), so it goes straight to
+	// sanitizeHTML in the caller — no UnescapeString, which would corrupt literal
+	// entities in text nodes.
+	return desc
 }
 
 // loxoLocation extracts the free-text location from the og:description, whose format is

--- a/internal/sources/loxo_test.go
+++ b/internal/sources/loxo_test.go
@@ -1,0 +1,152 @@
+package sources
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+func TestLoxoProvider(t *testing.T) {
+	if got := NewLoxo(nil).Provider(); got != "loxo" {
+		t.Errorf("Provider() = %q, want %q", got, "loxo")
+	}
+}
+
+// TestLoxoMapDetailFixture parses a real Loxo detail page (fitnext) and asserts the
+// mapping: title from og:title (no " | Agency" suffix), description from the embedded
+// JSON blob, canonical /job/<base64> URL, decoded <agency_id>-<slug> external id, and the
+// location parsed from the og:description "Location: … Salary:" run.
+func TestLoxoMapDetailFixture(t *testing.T) {
+	root := parseFixture(t, "testdata/loxo/detail_fitnext.html")
+	loc := "https://fitnext.app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg=="
+
+	j, ok := mapLoxoDetail(root, CompanyEntry{Company: "FitNext Co."}, loc)
+	if !ok {
+		t.Fatal("mapLoxoDetail returned ok=false on a real detail page")
+	}
+	if j.Title != "Frontend Engineer (React + TypeScript)" {
+		t.Errorf("Title = %q, want the role without the agency suffix", j.Title)
+	}
+	if j.ExternalID != "42474-7tse3ikc642yzj0v" {
+		t.Errorf("ExternalID = %q, want decoded <agency_id>-<slug>", j.ExternalID)
+	}
+	if j.URL != loc {
+		t.Errorf("URL = %q, want canonical detail URL %q", j.URL, loc)
+	}
+	if !strings.Contains(j.Description, "Frontend Engineer") || j.Description == "" {
+		t.Errorf("Description missing/empty: %.80q", j.Description)
+	}
+	if !strings.Contains(j.Location, "LATAM") {
+		t.Errorf("Location = %q, want the Remote (LATAM) parsed from og:description", j.Location)
+	}
+	if !j.Remote {
+		t.Errorf("Remote = false, want true for a Remote (LATAM) posting")
+	}
+}
+
+// TestLoxoJobLinksHostResolution asserts the listing yields one link per posting and that
+// each is resolved against the board host, so pods and agency subdomains all work.
+func TestLoxoJobLinksHostResolution(t *testing.T) {
+	root := parseFixture(t, "testdata/loxo/listing_fitnext.html")
+	for _, host := range []string{"fitnext.app.loxo.co", "pod4.app.loxo.co", "app.loxo.co"} {
+		base := mustURL(t, "https://"+host+"/fitnext")
+		links := loxoJobLinks(base, root)
+		if len(links) != 22 {
+			t.Errorf("%s: got %d job links, want 22", host, len(links))
+		}
+		for _, l := range links {
+			if !strings.HasPrefix(l, "https://"+host+"/job/") {
+				t.Errorf("%s: link %q not resolved against the board host", host, l)
+				break
+			}
+		}
+	}
+}
+
+// TestLoxoFetchMapsAndIsolatesFailures drives Fetch over an inline listing: the routed
+// posting maps to a Job; the unrouted posting's detail fetch fails and is dropped, not fatal.
+func TestLoxoFetchMapsAndIsolatesFailures(t *testing.T) {
+	const listing = `<html><body>
+<a href="/job/YWJjLTE=">Role A</a>
+<a href="/job/YWJjLTI=">Role B</a>
+</body></html>`
+	const detailA = `<html><head>
+<meta property="og:title" content="Role A">
+<meta property="og:description" content="Role ALocation: RemoteSalary: x">
+<script type="application/json">{"description":"<p>Do A</p>"}</script>
+</head></html>`
+
+	fake := (&routedHTTP{}).
+		route("/job/YWJjLTE=", detailA).
+		route("acme", listing)
+
+	jobs, err := NewLoxo(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "app.loxo.co/acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (the unrouted posting must drop, not fail the crawl)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "abc-1" || j.Company != "Acme" || j.Title != "Role A" {
+		t.Errorf("job = {id:%q company:%q title:%q}, want {abc-1 Acme Role A}", j.ExternalID, j.Company, j.Title)
+	}
+	if j.URL != "https://app.loxo.co/job/YWJjLTE=" {
+		t.Errorf("URL = %q, want relative /job link resolved against board host", j.URL)
+	}
+}
+
+func TestLoxoCompany(t *testing.T) {
+	hub := CompanyEntry{Company: "FitNext Co.", Hub: true}
+	plain := CompanyEntry{Company: "FitNext Co."}
+	cases := []struct {
+		name, title       string
+		e                 CompanyEntry
+		wantCo, wantTitle string
+	}{
+		{"hub em-dash client", "Senior SWE — Acme Corp", hub, "Acme Corp", "Senior SWE"},
+		{"hub at client", "Backend Engineer @ Globex", hub, "Globex", "Backend Engineer"},
+		{"hub no delimiter falls back", "Frontend Engineer", hub, "FitNext Co.", "Frontend Engineer"},
+		{"hub ascii hyphen not a delimiter", "Full-Stack Developer - Nashville", hub, "FitNext Co.", "Full-Stack Developer - Nashville"},
+		{"non-hub always agency", "Senior SWE — Acme Corp", plain, "FitNext Co.", "Senior SWE — Acme Corp"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			co, title := loxoCompany(c.title, c.e)
+			if co != c.wantCo || title != c.wantTitle {
+				t.Errorf("loxoCompany(%q) = (%q, %q), want (%q, %q)", c.title, co, title, c.wantCo, c.wantTitle)
+			}
+		})
+	}
+}
+
+func TestLoxoExternalID(t *testing.T) {
+	cases := map[string]string{
+		"https://fitnext.app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==": "42474-7tse3ikc642yzj0v",
+		"https://app.loxo.co/job/YWJjLTE=":                                "abc-1",
+		"https://app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==?t=99":    "42474-7tse3ikc642yzj0v",
+		"https://app.loxo.co/careers-in-nonprofits":                       "",
+		"https://app.loxo.co/job/":                                        "",
+	}
+	for u, want := range cases {
+		if got := loxoExternalID(u); got != want {
+			t.Errorf("loxoExternalID(%q) = %q, want %q", u, got, want)
+		}
+	}
+}
+
+func parseFixture(t *testing.T, path string) *html.Node {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	root, err := html.Parse(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("parse fixture %s: %v", path, err)
+	}
+	return root
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -164,6 +164,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTeamtailor(c),
 		NewICIMS(c),
 		NewCareerPage(c),
+		NewLoxo(c),
 		NewHireology(c),
 		NewIsolvedHire(c),
 		NewApplicantPro(c),

--- a/internal/sources/testdata/loxo/detail_fitnext.html
+++ b/internal/sources/testdata/loxo/detail_fitnext.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<meta charset="utf-8">
+<title>Frontend Engineer (React + TypeScript) | FitNext Co.</title>
+<meta content="Loxo, ATS, Applicant Tracking System, Applicant Tracking Systems, Applicant Tracking software, Top Applicant Tracking Systems, Top ATS, Best ATS, Best Applicant Tracking Systems, List of Applicant Tracking Systems, Free ATS, Affordable ATS, recruitment tools, resume parser, recruiting, talent pipeline, talent intelligence, applicant tracking system reviews, bigbiller, CATS ATS, booleanblackbelt, glen cathey, talentbin, smartrecruiters, bullhorn, entelo, recruiterbox, Executive Search Firm ATS, ATS for Headhunter, ATS for independent recruiter, sourcing tools, sourcer, talent, candidate, passive sourcing, talent warehouse, staffing, agency, SourceCon, Talent Acquisition, hiring, jobs, resumes, LinkedIn, Irina Shamaeva, Boolean strings, People Sourcing Certification Program, Technical Recruiting, Executive Search, employment agencies, Denver agencies, Colorado headhunters, Colorado headhunters" name="keywords">
+<meta content="Loxo is the best executive recruiting software, ATS and CRM for recruiting firms. Get a single system for applicant tracking, CRM, AI sourcing, email marketing and more.
+" name="description">
+<meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+<meta content="Frontend Engineer (React + TypeScript)" property="og:title">
+<meta content="article" property="og:type">
+<meta content="https://fitnext.app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==?t=1783700180" property="og:url">
+<meta content="Loxo" property="og:site_name">
+<meta content="Frontend Engineer (React + TypeScript)Location: Remote (LATAM)Salary: USD $4,500 -..." property="og:description">
+<meta content="https://s3.eu-central-1.amazonaws.com/loxo-images-production-eu-central-1/42474/agencies/logos/000/042/474/impactful/Fitnext.co__logotype_signature__Main_Signature_c%C3%B3pia_17.png?1774028983" property="og:image">
+<meta content="Frontend Engineer (React + TypeScript)" property="twitter:title">
+<meta content="@loxo_recruiting" property="twitter:site">
+<meta content="@loxo_recruiting" property="twitter:creator">
+<meta content="https://fitnext.app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==?t=1783700180" property="twitter:url">
+<meta content="Frontend Engineer (React + TypeScript)Location: Remote (LATAM)Salary: USD $4,500 -..." property="twitter:description">
+<meta content="https://s3.eu-central-1.amazonaws.com/loxo-images-production-eu-central-1/42474/agencies/logos/000/042/474/impactful/Fitnext.co__logotype_signature__Main_Signature_c%C3%B3pia_17.png?1774028983" property="twitter:image">
+<link href="https://d33yba6thzipq8.cloudfront.net/favicon.ico" rel="icon">
+<link href="https://d33yba6thzipq8.cloudfront.net/apple-touch-icon.png" rel="apple-touch-icon">
+<link href="https://d33yba6thzipq8.cloudfront.net/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72">
+<link href="https://d33yba6thzipq8.cloudfront.net/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114">
+<link crossorigin="true" href="https://fonts.gstatic.com" rel="preconnect">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/roboto@5.2.6/400.css" integrity="sha384-oGzj4lD+HPSXRliMbtdEEHeeYeZC14GciyYHui5wMkjoqIzow3KuvUAppSmkoz+w" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/roboto@5.2.6/500.css" integrity="sha384-FLz+KdyjHvAr8le6TxAieOPBHkUbh9ULE54hgIw69YFH2vYgefYe1spBa34gAmB0" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/roboto@5.2.6/700.css" integrity="sha384-QNO2ey9BT43EcVymHnhkhN+cmFphSbWNJYidFLNusXkoGgn4apHTLF8lNHo0Splv" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw==" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/material-icons@5.2.5/400.css" integrity="sha384-9M86YFF7EvOFAk6GyDs3bM449BEGTwPOvtgSzeNqLnyK6/LSTBN0v0TtLu6UaU4c" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&amp;display=swap" rel="stylesheet">
+<style>
+  .material-icons {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+  }
+</style>
+<link rel="stylesheet" href="https://d33yba6thzipq8.cloudfront.net/legacy_application-22d10f4727ddcd3b998cea16c1dde931.css" media="screen" />
+<link rel="stylesheet" href="https://d33yba6thzipq8.cloudfront.net/legacy_job_listing-22d10f4727ddcd3b998cea16c1dde931.css" media="screen" />
+<link rel="stylesheet" href="https://d33yba6thzipq8.cloudfront.net/legacy_print-22d10f4727ddcd3b998cea16c1dde931.css" media="print" />
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="wX7tjiaadK4a0SOmKmWTLCbzzQ_7jDC27ILLxXuu6bfuaeaQcK2f7qUZKU4B9evS4wc-gHC02YACpQ2R7LXWTg" />
+
+</head>
+<body class="body-container">
+<section style='min-height: 100vh; background-color: #f5f5f5; overflow: auto; display: flex; flex-direction: column;'>
+  <div style="margin-left:0px;">
+
+  <a href="https://fitnextconsulting.com" target="_blank" style="text-decoration:none;">
+    <img src="https://i.postimg.cc/sxcP7jkJ/fitnext-co-(Main-Signature)-Main-Signature-copia-9.png" style="height:65px;width:auto;border:0;"></a>
+
+  <div style="width:100%;justify-content:left;padding:px 0;margin:0 auto;">
+      
+      <img src="https://i.postimg.cc/bNBc4Www/Hero-desktop-800x400px.png" style="display:block;width:100%;max-width:1000px;height:auto;border-radius:20px;margin:0 auto;">
+    
+
+  </div>
+</div>
+
+  <div
+    style='background-color: #f5f5f5; padding-top: 70px; padding-bottom: 70px; font-family: Lato;'
+    class='job-apply-wrapper'
+  >
+    
+    <script src="https://d33yba6thzipq8.cloudfront.net/public_rollbar-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+  <div class="a2a_kit a2a_kit_size_32 a2a_floating_style a2a_vertical_style" style="left:0px; top:150px;">
+      <a class="a2a_button_x"></a>
+      <a class="a2a_button_facebook"></a>
+      <a class="a2a_button_pinterest"></a>
+      <a class="a2a_button_copy_link"></a>
+      <a class="a2a_button_whatsapp"></a>
+      <a class="a2a_button_email"></a>
+      <a class="a2a_dd" href="https://www.addtoany.com/share"></a>
+  </div>
+
+  <script>
+    function addToAnyLoadFailure() {
+      console.error('Failed to load AddToAny script');
+
+      if (window.rollbar) {
+        window.rollbar.error('Failed to load AddToAny script',{
+          timestamp: new Date().toISOString(),
+        });
+        console.log('Environment from script:', window.rollbar.options.payload.environment);
+      }
+    }
+  </script>
+  <script async src="https://static.addtoany.com/menu/page.js" integrity="sha384-RY2YUBTi/fD57ZFsRLhevpDSq6di7JkwGAbWhalq+bUH063ppP/bJEfbKDRo2WmK" crossorigin="anonymous" onerror="addToAnyLoadFailure()"></script>
+
+<div style='display: flex; justify-content: flex-end; align-items: center; flex-wrap: wrap; gap: 0.5rem;'>
+    <div style='display: flex; align-items: center; gap: 1.125rem;'>
+      <div style='color: #555555; font-weight: 500;'>Share this job</div>
+      <div class="a2a_kit a2a_kit_size_32 a2a_default_style">
+        <a class="a2a_button_facebook"></a>
+        <a class="a2a_button_x"></a>
+        <a class="a2a_button_linkedin"></a>
+        <a class="a2a_button_email"></a>
+      </div>
+    </div>
+</div>
+
+    <div
+  style='background-color: #ffffff; border-radius: 2rem;'
+  class='job-apply-card'
+>
+  <div class='job-apply-card-header'>
+    <div>
+      <div style='font-weight: 500; font-size: 2rem; color: #555555;'>
+        Frontend Engineer (React + TypeScript)
+      </div>
+      <div style='font-weight: 400; font-size: 1.5rem; color: #555555; opacity: 0.7;'>
+        
+      </div>
+    </div>
+    <div>
+  <a
+    style='color: #ffffff; background-color: #555555; border-radius: 2rem;'
+    class='job-apply-link'
+    href="/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==/form?source_type=app"
+  >
+    Apply for this job
+  </a>
+</div>
+  </div>
+      <div
+        class='cleanslate'
+        style='--job-description-text-color: #555555; --job-description-font-family: Lato;'
+      >
+        <p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Frontend Engineer (React + TypeScript)</strong></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Location:</strong> Remote (LATAM)</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Salary:</strong> USD $4,500 - $6,000/month</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Employment Type:</strong> Full-Time</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Stage:</strong> Seed (Early-stage AI Startup)</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Exclusive Opportunity:</strong> No</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Company Overview</strong></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">We are building an AI-powered platform that helps businesses automate complex operational workflows through intelligent software agents.</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Our product combines artificial intelligence with intuitive user experiences, allowing customers to streamline repetitive tasks while improving efficiency and service quality.</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Backed by leading startup investors, the team is small, highly collaborative, and focused on shipping exceptional products with speed and attention to detail.</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>The Challenge</strong></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">We are looking for a <strong>Frontend Engineer</strong> who is passionate about building polished, high-quality product experiences.</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">This is not a feature factory role. You'll work closely with product and design to transform ideas and Figma designs into production-ready interfaces that feel fast, intuitive, and delightful to use.</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">You'll own the frontend experience from implementation to refinement, paying close attention to animations, interactions, accessibility, responsiveness, and every detail that contributes to an outstanding user experience.</p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Key Responsibilities</strong></p><ul style="margin:0px;padding-left:40px;">
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Build modern web applications using React and TypeScript.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Transform Figma designs into production-ready interfaces with high visual fidelity.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Create fast, responsive, and intuitive user experiences.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Implement motion design and polished UI animations using modern frontend technologies.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Build reusable components and scalable frontend architecture.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Collaborate closely with Product Designers to refine and improve user experiences.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Ensure excellent handling of loading states, empty states, error states, accessibility, and edge cases.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Continuously improve frontend performance, maintainability, and code quality.</li>
+</ul><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Must Have</strong></p><ul style="margin:0px;padding-left:40px;">
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">5+ years of professional frontend engineering experience.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Strong production experience with React and TypeScript.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Experience with web animation libraries such as Framer Motion, GSAP, or similar.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Strong ability to convert Figma designs into production-quality applications.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Excellent attention to UI/UX details, including spacing, alignment, typography, and interactions.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Experience building reusable React components and scalable frontend architectures.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Conversational English with confidence participating in daily meetings.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Comfortable working in a fast-paced startup environment.</li>
+</ul><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Desired Skills</strong></p><ul style="margin:0px;padding-left:40px;">
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Experience building or maintaining a Design System or component library.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Experience refactoring or modernizing large React applications.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Strong knowledge of frontend performance optimization techniques.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Experience with frontend security and application reliability.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Previous experience working at a US-based startup.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Strong opinions about component architecture, scalability, and code reusability.</li>
+</ul><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Soft Skills</strong></p><ul style="margin:0px;padding-left:40px;">
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Strong product mindset.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">High attention to detail.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Ownership and accountability.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Ability to collaborate effectively with designers and engineers.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Excellent problem-solving skills.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Comfortable working with ambiguity and rapidly evolving product requirements.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Ability to execute quickly without compromising quality.</li>
+</ul><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Benefits</strong></p><ul style="margin:0px;padding-left:40px;">
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Fully remote (LATAM).</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Competitive salary paid in USD.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Opportunity to build AI-powered products used by global customers.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Small, highly collaborative engineering team.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">High ownership and direct impact on the product.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Fast-growing early-stage startup environment.</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Opportunity to influence product direction and frontend architecture from an early stage.</li>
+</ul><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><strong>Hiring Process</strong></p><ul style="margin:0px;padding-left:40px;">
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">AI Technical Assessment</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Interview with the CTO</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Paid Work Trial</li>
+<li style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;">Offer</li>
+</ul><p style="line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;"><br></p>
+      </div>
+    <div>
+  <a
+    style='color: #ffffff; background-color: #555555; border-radius: 2rem;'
+    class='job-apply-link'
+    href="/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==/form?source_type=app"
+  >
+    Apply for this job
+  </a>
+</div>
+</div>
+<script type="application/json" id="public-job-description-json">
+  {"description":"\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eFrontend Engineer (React + TypeScript)\u003c/strong\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eLocation:\u003c/strong\u003e Remote (LATAM)\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eSalary:\u003c/strong\u003e USD $4,500 - $6,000/month\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eEmployment Type:\u003c/strong\u003e Full-Time\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eStage:\u003c/strong\u003e Seed (Early-stage AI Startup)\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eExclusive Opportunity:\u003c/strong\u003e No\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eCompany Overview\u003c/strong\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eWe are building an AI-powered platform that helps businesses automate complex operational workflows through intelligent software agents.\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eOur product combines artificial intelligence with intuitive user experiences, allowing customers to streamline repetitive tasks while improving efficiency and service quality.\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eBacked by leading startup investors, the team is small, highly collaborative, and focused on shipping exceptional products with speed and attention to detail.\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eThe Challenge\u003c/strong\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eWe are looking for a \u003cstrong\u003eFrontend Engineer\u003c/strong\u003e who is passionate about building polished, high-quality product experiences.\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eThis is not a feature factory role. You'll work closely with product and design to transform ideas and Figma designs into production-ready interfaces that feel fast, intuitive, and delightful to use.\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eYou'll own the frontend experience from implementation to refinement, paying close attention to animations, interactions, accessibility, responsiveness, and every detail that contributes to an outstanding user experience.\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eKey Responsibilities\u003c/strong\u003e\u003c/p\u003e\u003cul style=\"margin:0px;padding-left:40px;\"\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eBuild modern web applications using React and TypeScript.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eTransform Figma designs into production-ready interfaces with high visual fidelity.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eCreate fast, responsive, and intuitive user experiences.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eImplement motion design and polished UI animations using modern frontend technologies.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eBuild reusable components and scalable frontend architecture.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eCollaborate closely with Product Designers to refine and improve user experiences.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eEnsure excellent handling of loading states, empty states, error states, accessibility, and edge cases.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eContinuously improve frontend performance, maintainability, and code quality.\u003c/li\u003e\n\u003c/ul\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eMust Have\u003c/strong\u003e\u003c/p\u003e\u003cul style=\"margin:0px;padding-left:40px;\"\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e5+ years of professional frontend engineering experience.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eStrong production experience with React and TypeScript.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eExperience with web animation libraries such as Framer Motion, GSAP, or similar.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eStrong ability to convert Figma designs into production-quality applications.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eExcellent attention to UI/UX details, including spacing, alignment, typography, and interactions.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eExperience building reusable React components and scalable frontend architectures.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eConversational English with confidence participating in daily meetings.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eComfortable working in a fast-paced startup environment.\u003c/li\u003e\n\u003c/ul\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eDesired Skills\u003c/strong\u003e\u003c/p\u003e\u003cul style=\"margin:0px;padding-left:40px;\"\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eExperience building or maintaining a Design System or component library.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eExperience refactoring or modernizing large React applications.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eStrong knowledge of frontend performance optimization techniques.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eExperience with frontend security and application reliability.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003ePrevious experience working at a US-based startup.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eStrong opinions about component architecture, scalability, and code reusability.\u003c/li\u003e\n\u003c/ul\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eSoft Skills\u003c/strong\u003e\u003c/p\u003e\u003cul style=\"margin:0px;padding-left:40px;\"\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eStrong product mindset.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eHigh attention to detail.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eOwnership and accountability.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eAbility to collaborate effectively with designers and engineers.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eExcellent problem-solving skills.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eComfortable working with ambiguity and rapidly evolving product requirements.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eAbility to execute quickly without compromising quality.\u003c/li\u003e\n\u003c/ul\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eBenefits\u003c/strong\u003e\u003c/p\u003e\u003cul style=\"margin:0px;padding-left:40px;\"\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eFully remote (LATAM).\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eCompetitive salary paid in USD.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eOpportunity to build AI-powered products used by global customers.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eSmall, highly collaborative engineering team.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eHigh ownership and direct impact on the product.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eFast-growing early-stage startup environment.\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eOpportunity to influence product direction and frontend architecture from an early stage.\u003c/li\u003e\n\u003c/ul\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cstrong\u003eHiring Process\u003c/strong\u003e\u003c/p\u003e\u003cul style=\"margin:0px;padding-left:40px;\"\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eAI Technical Assessment\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eInterview with the CTO\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003ePaid Work Trial\u003c/li\u003e\n\u003cli style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003eOffer\u003c/li\u003e\n\u003c/ul\u003e\u003cp style=\"line-height:1.5;font-family:Arial;font-size:16px;color:rgb(0, 0, 0);margin:0px;\"\u003e\u003cbr\u003e\u003c/p\u003e"}
+</script>
+
+    
+  </div>
+  <div style="max-width:1200px;margin:0 auto;padding:0 20px;">
+    
+    <div style="margin-bottom:30px;display:flex;justify-content:center;">
+      <a href="https://fitnextconsulting.com" target="_blank" style="text-decoration:none;">
+        <img src="https://i.postimg.cc/vHKDT3GT/fitnext-co-(Main-Signature)-Main-Signature-copia-12.png" style="height:65px;width:auto;display:block;border:0;">
+      </a>
+    </div>
+
+    <div style="flex-direction:column;align-items:left;">
+      <a href="https://fitnextconsulting.com/" style="color:#555555;text-decoration:none;font-size:13px;font-weight:bold;padding:10px 40px;border:1px solid #eeeeee;border-radius:50px;display:inline-block;">
+         Website
+      </a>
+      
+      <a href="mailto:michele.marques@fitnextconsulting.com" style="color:#555555;text-decoration:none;font-size:13px;font-weight:bold;padding:10px 40px;border:1px solid #eeeeee;border-radius:50px;display:inline-block;">
+         Contact Us
+      </a>
+
+       <a href="https://www.linkedin.com/company/fitnext-consulting/" style="color:#555555;text-decoration:none;font-size:13px;font-weight:bold;padding:10px 40px;border:1px solid #eeeeee;border-radius:50px;display:inline-block;">
+         Linkedin
+      </a>
+
+    </div>
+
+    <div style="margin-top:25px;padding-top:25px;border-top:1px solid #f5f5f5;color:#bbbbbb;font-size:12px;">
+      © 2026 FitNext Consulting. All rights reserved.
+    </div>
+
+  </div>
+</section>
+
+<script src="https://d33yba6thzipq8.cloudfront.net/legacy-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+<script src="https://d33yba6thzipq8.cloudfront.net/gdpr_form-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+<script src="https://d33yba6thzipq8.cloudfront.net/privacy_rights-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+<script src="https://d33yba6thzipq8.cloudfront.net/public_job_description-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+
+<script>
+  (function() {
+    var gs = document.createElement('script');
+    gs.src = 'https://snippet.growsumo.com/growsumo.min.js';
+    gs.type = 'text/javascript';
+    gs.async = 'true';
+    gs.onload = gs.onreadystatechange = function() {
+      var rs = this.readyState;
+      if (rs && rs != 'complete' && rs != 'loaded') return;
+      try {
+        growsumo._initialize('pk_WoRYsuukqV021CkrvPBGRb5MxLOwDGQr');
+        if (typeof(growsumoInit) === 'function') {
+          growsumoInit();
+          }
+      } catch (e) {
+  
+      }
+    };
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gs, s);
+  })();
+</script>
+</body>
+</html>

--- a/internal/sources/testdata/loxo/listing_fitnext.html
+++ b/internal/sources/testdata/loxo/listing_fitnext.html
@@ -1,0 +1,1110 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<meta charset="utf-8">
+<title>Job Listing | FitNext Co.</title>
+<meta content="Loxo, ATS, Applicant Tracking System, Applicant Tracking Systems, Applicant Tracking software, Top Applicant Tracking Systems, Top ATS, Best ATS, Best Applicant Tracking Systems, List of Applicant Tracking Systems, Free ATS, Affordable ATS, recruitment tools, resume parser, recruiting, talent pipeline, talent intelligence, applicant tracking system reviews, bigbiller, CATS ATS, booleanblackbelt, glen cathey, talentbin, smartrecruiters, bullhorn, entelo, recruiterbox, Executive Search Firm ATS, ATS for Headhunter, ATS for independent recruiter, sourcing tools, sourcer, talent, candidate, passive sourcing, talent warehouse, staffing, agency, SourceCon, Talent Acquisition, hiring, jobs, resumes, LinkedIn, Irina Shamaeva, Boolean strings, People Sourcing Certification Program, Technical Recruiting, Executive Search, employment agencies, Denver agencies, Colorado headhunters, Colorado headhunters" name="keywords">
+<meta content="Loxo is the best executive recruiting software, ATS and CRM for recruiting firms. Get a single system for applicant tracking, CRM, AI sourcing, email marketing and more.
+" name="description">
+<meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+<meta content="FitNext Co. Job Listing" property="og:title">
+<meta content="article" property="og:type">
+<meta content="https://fitnext.app.loxo.co/fitnext?t=1783700179" property="og:url">
+<meta content="Loxo" property="og:site_name">
+<meta content="FitNext Co. Job Listing" property="og:description">
+<meta content="https://s3.eu-central-1.amazonaws.com/loxo-images-production-eu-central-1/42474/agencies/logos/000/042/474/impactful/Fitnext.co__logotype_signature__Main_Signature_c%C3%B3pia_17.png?1774028983" property="og:image">
+<meta content="FitNext Co. Job Listing" property="twitter:title">
+<meta content="@loxo_recruiting" property="twitter:site">
+<meta content="@loxo_recruiting" property="twitter:creator">
+<meta content="https://fitnext.app.loxo.co/fitnext?t=1783700179" property="twitter:url">
+<meta content="FitNext Co. Job Listing" property="twitter:description">
+<meta content="https://s3.eu-central-1.amazonaws.com/loxo-images-production-eu-central-1/42474/agencies/logos/000/042/474/impactful/Fitnext.co__logotype_signature__Main_Signature_c%C3%B3pia_17.png?1774028983" property="twitter:image">
+<link href="https://d33yba6thzipq8.cloudfront.net/favicon.ico" rel="icon">
+<link href="https://d33yba6thzipq8.cloudfront.net/apple-touch-icon.png" rel="apple-touch-icon">
+<link href="https://d33yba6thzipq8.cloudfront.net/apple-touch-icon-72x72.png" rel="apple-touch-icon" sizes="72x72">
+<link href="https://d33yba6thzipq8.cloudfront.net/apple-touch-icon-114x114.png" rel="apple-touch-icon" sizes="114x114">
+<link crossorigin="true" href="https://fonts.gstatic.com" rel="preconnect">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/roboto@5.2.6/400.css" integrity="sha384-oGzj4lD+HPSXRliMbtdEEHeeYeZC14GciyYHui5wMkjoqIzow3KuvUAppSmkoz+w" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/roboto@5.2.6/500.css" integrity="sha384-FLz+KdyjHvAr8le6TxAieOPBHkUbh9ULE54hgIw69YFH2vYgefYe1spBa34gAmB0" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/roboto@5.2.6/700.css" integrity="sha384-QNO2ey9BT43EcVymHnhkhN+cmFphSbWNJYidFLNusXkoGgn4apHTLF8lNHo0Splv" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha512-SfTiTlX6kk+qitfevl/7LibUOeJWlt9rbyDn92a1DqWOw9vWG2MFoays0sgObmWazO5BQPiFucnnEAjpAB+/Sw==" rel="stylesheet">
+<link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/@fontsource/material-icons@5.2.5/400.css" integrity="sha384-9M86YFF7EvOFAk6GyDs3bM449BEGTwPOvtgSzeNqLnyK6/LSTBN0v0TtLu6UaU4c" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&amp;display=swap" rel="stylesheet">
+<style>
+  .material-icons {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    font-size: 24px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+  }
+</style>
+<link rel="stylesheet" href="https://d33yba6thzipq8.cloudfront.net/legacy_application-22d10f4727ddcd3b998cea16c1dde931.css" media="screen" />
+<link rel="stylesheet" href="https://d33yba6thzipq8.cloudfront.net/legacy_job_listing-22d10f4727ddcd3b998cea16c1dde931.css" media="screen" />
+<link rel="stylesheet" href="https://d33yba6thzipq8.cloudfront.net/legacy_print-22d10f4727ddcd3b998cea16c1dde931.css" media="print" />
+<meta name="csrf-param" content="authenticity_token" />
+<meta name="csrf-token" content="Zhh6k_EB3PP8ounzxfhjnd8n5CrHNxAuNW8MCwF2yb1I3j9iFL0k4k41Sf-M1pQQ23-6Y2HK5F_WqDMzqrj7yA" />
+
+</head>
+<body class="body-container">
+<script src="https://d33yba6thzipq8.cloudfront.net/public_rollbar-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+  <div class="a2a_kit a2a_kit_size_32 a2a_floating_style a2a_vertical_style" style="left:0px; top:150px;">
+      <a class="a2a_button_x"></a>
+      <a class="a2a_button_facebook"></a>
+      <a class="a2a_button_pinterest"></a>
+      <a class="a2a_button_copy_link"></a>
+      <a class="a2a_button_whatsapp"></a>
+      <a class="a2a_button_email"></a>
+      <a class="a2a_dd" href="https://www.addtoany.com/share"></a>
+  </div>
+
+  <script>
+    function addToAnyLoadFailure() {
+      console.error('Failed to load AddToAny script');
+
+      if (window.rollbar) {
+        window.rollbar.error('Failed to load AddToAny script',{
+          timestamp: new Date().toISOString(),
+        });
+        console.log('Environment from script:', window.rollbar.options.payload.environment);
+      }
+    }
+  </script>
+  <script async src="https://static.addtoany.com/menu/page.js" integrity="sha384-RY2YUBTi/fD57ZFsRLhevpDSq6di7JkwGAbWhalq+bUH063ppP/bJEfbKDRo2WmK" crossorigin="anonymous" onerror="addToAnyLoadFailure()"></script>
+
+<section style='min-height: 100vh; background-color: #f5f5f5; overflow: auto; display: flex; flex-direction: column;'>
+  <div style="margin-left:0px;">
+
+  <a href="https://fitnextconsulting.com" target="_blank" style="text-decoration:none;">
+    <img src="https://i.postimg.cc/sxcP7jkJ/fitnext-co-(Main-Signature)-Main-Signature-copia-9.png" style="height:65px;width:auto;border:0;"></a>
+
+  <div style="width:100%;justify-content:left;padding:px 0;margin:0 auto;">
+      
+      <img src="https://i.postimg.cc/bNBc4Www/Hero-desktop-800x400px.png" style="display:block;width:100%;max-width:1000px;height:auto;border-radius:20px;margin:0 auto;">
+    
+
+  </div>
+</div>
+
+  <div
+    style='background-color: #f5f5f5; padding-top: 70px; padding-bottom: 70px; font-family: Lato;'
+    class='job-listings-wrapper'
+  >
+      
+
+
+    <div class='job-listings-search-and-sort'>
+  <div style='display: flex; align-items: center; gap: 0.5rem 1.5rem; flex-wrap: wrap;'>
+      <div style='font-weight: 500; font-size: 2rem; color: #555555;'>
+        Job Openings
+      </div>
+    <form>
+      <div class='jobs-listing-search' style='color: #555555; background-color: #ffffff; border-radius: 2rem;'>
+        <i class='material-icons' style='opacity: 0.5;'>search</i>
+        <input
+          name='query'
+          type='text'
+          value=""
+          style='--job-listing-config-text-color: #555555;'
+          placeholder='Search...'
+        />
+      </div>
+    </form>
+  </div>
+  <div style='display: flex; gap: 0.5rem; align-items: center;'>
+      <a
+        href="?type_sort=asc"
+        style='background-color: #36a9e1; color: #ffffff; border-radius: 2rem;'
+        class='jobs-listing-sort'
+      >
+        Type
+        <i class='material-icons' style='font-size: 1.125rem;'>
+          unfold_more
+        </i>
+      </a>
+    <a
+      href="?location_sort=asc"
+      style='background-color: #36a9e1; color: #ffffff; border-radius: 2rem;'
+      class='jobs-listing-sort'
+    >
+      Location
+      <i class='material-icons' style='font-size: 1.125rem;'>
+        unfold_more
+      </i>
+    </a>
+  </div>
+</div>
+
+      <div style='display: table; border-spacing: 0 0.25rem;'>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtZWloemhlZHR5ZzFlaWp4Zg=="
+      >
+        Forward Deployed Engineer
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 1 month ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtZWloemhlZHR5ZzFlaWp4Zg=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtdDd3a3Z1Y3R6cGdyNHFyZA=="
+      >
+        Creative Designer
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtdDd3a3Z1Y3R6cGdyNHFyZA=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtN2hrMHRwa3lzdHBmNmJyZA=="
+      >
+        Digital Product Manager
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          4 days ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtN2hrMHRwa3lzdHBmNmJyZA=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtN3MwdzJkZDl0dWc5dnN6ZQ=="
+      >
+        Forward Deployed Engineer (AI / Python / Client-Facing)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>location_on</i>
+        San Francisco, California, United States
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtN3MwdzJkZDl0dWc5dnN6ZQ=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg=="
+      >
+        Frontend Engineer (React + TypeScript)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          1 day ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtbnB1ZXNneDVlM3hyYTB4aQ=="
+      >
+        Senior Full-Stack SWE - YC Company
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          1 day ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtbnB1ZXNneDVlM3hyYTB4aQ=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtN3hwY3E1bW9nc3h4NTZqdA=="
+      >
+        Full Stack Developer - Design Studio
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 1 month ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtN3hwY3E1bW9nc3h4NTZqdA=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtOGo5aGhoZmg2N2wwYTlsNw=="
+      >
+        Full-Stack Developer (AI-Native)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 1 month ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtOGo5aGhoZmg2N2wwYTlsNw=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtYTNpbXVxbXp3dTBrNnZmNA=="
+      >
+        Full-Stack Engineer (Front-End Leaning)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>location_on</i>
+        San Francisco, California, United States
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtYTNpbXVxbXp3dTBrNnZmNA=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtYnZ3eHR0NnRpZXNieGhoMg=="
+      >
+        iOS Engineer SDK
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          10 days ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Contract
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtYnZ3eHR0NnRpZXNieGhoMg=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtdDlnNzd4MDRwdWxhMnBvNw=="
+      >
+        Partnerships Lead
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtdDlnNzd4MDRwdWxhMnBvNw=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtbXdrcjRnNXdiMHh3b2Jpaw=="
+      >
+        LATAM Platform Engineer
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtbXdrcjRnNXdiMHh3b2Jpaw=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtZDNxbHhqYTNmY3BjYjk2bg=="
+      >
+        REMOTE - RL Engineer
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          21 days ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtZDNxbHhqYTNmY3BjYjk2bg=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtcWcyZWlwYms1aXQ2dG9jZQ=="
+      >
+        Senior Backend Software Engineer (Core Engineering) – Clojure Focus
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          28 days ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtcWcyZWlwYms1aXQ2dG9jZQ=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtaHlkenk4dDc4dDVpZGljZA=="
+      >
+        Senior Full Stack Engineer (Backend-Leaning)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 1 month ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtaHlkenk4dDc4dDVpZGljZA=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtdHVkZ2twMGlwNnU3MGp3dA=="
+      >
+        Senior Mechatronics Engineer
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 1 month ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>location_on</i>
+        Sydney, New South Wales, Australia
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtdHVkZ2twMGlwNnU3MGp3dA=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtcXFkemc5dWx3dXQ1NnBzdg=="
+      >
+        Senior QA Automation Engineer (Mobile &amp; Backend)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtcXFkemc5dWx3dXQ1NnBzdg=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtOXh4aHB6ZDd5eTIxdHBubg=="
+      >
+        Senior Software Engineer (AI / Distributed Systems)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          3 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>location_on</i>
+        Brazil
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtOXh4aHB6ZDd5eTIxdHBubg=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtdWJ4eWx0ZzZocTZicWdhMw=="
+      >
+        Senior Staff Engineer/ Fintech
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtdWJ4eWx0ZzZocTZicWdhMw=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtejNlZm51bnFod2pydzZmZQ=="
+      >
+        Software Engineer (Browser Agents &amp; Automation)
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          17 days ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtejNlZm51bnFod2pydzZmZQ=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtajBsMXFzYzZ6anI4bWVhcA=="
+      >
+        Sr. Product Designer
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          2 months ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>wifi</i>
+        Remote
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtajBsMXFzYzZ6anI4bWVhcA=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+      <div class='jobs-listing-card'>
+  <div class='data-cell' style='background-color: #ffffff; width: 100%; border-radius: 2rem 0 0 2rem;'>
+    <div style='display: flex; gap: 0.25rem; flex-direction: column;'>
+      <a
+        class='job-title'
+        style='color: #36a9e1;'
+        href="/job/NDI0NzQtMGdnbGYwaWhjZGR1N3UwZw=="
+      >
+        Talent Operations
+      </a>
+        <div class='job-date' style='color: #555555;'>
+          about 1 month ago
+        </div>
+    </div>
+  </div>
+    <div class='data-cell' style='background-color: #ffffff;'>
+      <div class='job-type' style='color: #555555;'>
+        Full Time
+      </div>
+    </div>
+  <div class='data-cell' style='background-color: #ffffff;'>
+    <div class='job-location' style='color: #555555;'>
+        <i class='material-icons' style='font-size: 1.25rem;'>location_on</i>
+        San Francisco, California, United States
+    </div>
+  </div>
+  <div class='data-cell' style='background-color: #ffffff; position: relative; border-radius: 0 2rem 2rem 0;'>
+    <a
+      class='go-to-job overlay'
+      style='background-color: #555555; border-radius: 2rem;'
+      href="/job/NDI0NzQtMGdnbGYwaWhjZGR1N3UwZw=="
+    >
+    </a>
+    <a
+      class='go-to-job'
+      style='color: #555555; border-radius: 2rem;'
+    >
+      <i class='material-icons' style='font-size: 1.25rem;'>chevron_right</i>
+    </a>
+  </div>
+</div>
+  </div>
+
+
+    
+  </div>
+
+  <div style="max-width:1200px;margin:0 auto;padding:0 20px;">
+    
+    <div style="margin-bottom:30px;display:flex;justify-content:center;">
+      <a href="https://fitnextconsulting.com" target="_blank" style="text-decoration:none;">
+        <img src="https://i.postimg.cc/vHKDT3GT/fitnext-co-(Main-Signature)-Main-Signature-copia-12.png" style="height:65px;width:auto;display:block;border:0;">
+      </a>
+    </div>
+
+    <div style="flex-direction:column;align-items:left;">
+      <a href="https://fitnextconsulting.com/" style="color:#555555;text-decoration:none;font-size:13px;font-weight:bold;padding:10px 40px;border:1px solid #eeeeee;border-radius:50px;display:inline-block;">
+         Website
+      </a>
+      
+      <a href="mailto:michele.marques@fitnextconsulting.com" style="color:#555555;text-decoration:none;font-size:13px;font-weight:bold;padding:10px 40px;border:1px solid #eeeeee;border-radius:50px;display:inline-block;">
+         Contact Us
+      </a>
+
+       <a href="https://www.linkedin.com/company/fitnext-consulting/" style="color:#555555;text-decoration:none;font-size:13px;font-weight:bold;padding:10px 40px;border:1px solid #eeeeee;border-radius:50px;display:inline-block;">
+         Linkedin
+      </a>
+
+    </div>
+
+    <div style="margin-top:25px;padding-top:25px;border-top:1px solid #f5f5f5;color:#bbbbbb;font-size:12px;">
+      © 2026 FitNext Consulting. All rights reserved.
+    </div>
+
+  </div>
+</section>
+
+<script src="https://d33yba6thzipq8.cloudfront.net/legacy-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+<script src="https://d33yba6thzipq8.cloudfront.net/gdpr_form-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+<script src="https://d33yba6thzipq8.cloudfront.net/privacy_rights-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+<script src="https://d33yba6thzipq8.cloudfront.net/public_job_description-22d10f4727ddcd3b998cea16c1dde931.js"></script>
+
+<script>
+  (function() {
+    var gs = document.createElement('script');
+    gs.src = 'https://snippet.growsumo.com/growsumo.min.js';
+    gs.type = 'text/javascript';
+    gs.async = 'true';
+    gs.onload = gs.onreadystatechange = function() {
+      var rs = this.readyState;
+      if (rs && rs != 'complete' && rs != 'loaded') return;
+      try {
+        growsumo._initialize('pk_WoRYsuukqV021CkrvPBGRb5MxLOwDGQr');
+        if (typeof(growsumoInit) === 'function') {
+          growsumoInit();
+          }
+      } catch (e) {
+  
+      }
+    };
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gs, s);
+  })();
+</script>
+</body>
+</html>

--- a/openspec/changes/add-loxo-adapter/.openspec.yaml
+++ b/openspec/changes/add-loxo-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/add-loxo-adapter/design.md
+++ b/openspec/changes/add-loxo-adapter/design.md
@@ -1,0 +1,90 @@
+## Context
+
+Loxo is an ATS/CRM for recruiting agencies; each agency gets a public careers
+board at `<host>/<slug>` where `host` is one of an agency subdomain
+(`fitnext.app.loxo.co`), the bare `app.loxo.co`, or a regional pod
+(`pod4.app.loxo.co`). A spike over 6 agencies across all three host types
+VALIDATED the shape: the careers page is server-rendered HTML listing every
+posting as `/job/<base64>`; each detail page carries the role name in `<title>`
+(`Role | Agency`) and the HTML description in an embedded
+`<script type="application/json">{"description": …}` blob; the base64 job id
+decodes to a stable `<agency_id>-<slug>` pair. The real employer is never exposed
+— boards show only the agency name.
+
+freehire already has the seams this needs: the careerspage adapter (listing →
+detail fan-out over an `HTMLGetter`), the `CompanyEntry.Hub` flag honored by
+huntflow for agency/hub boards, and the `harvest-boards` live-validation pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One `loxo` adapter that crawls any Loxo agency board regardless of host variant.
+- Employer attribution that uses the real client when the posting reveals it and
+  falls back to the agency otherwise — never guessed.
+- A discovery prober that turns Loxo's search-engine footprint into curated
+  `sources/loxo.yml` entries.
+
+**Non-Goals:**
+- The paid Loxo Open API (bearer-token gated) — the keyless careers page is the
+  source of truth here.
+- Cross-source deduplication of agency reposts vs. clients' own ATS postings
+  (accepted trade-off; see Risks).
+- A `linksource` for one-off Loxo links (out of scope; the seam is a one-liner
+  later if TG links need it).
+- Automatic committing of discovered boards — the harvester proposes, a human
+  curates.
+
+## Decisions
+
+- **Board id = careers URL without scheme (`<host>/<slug>`).** Alternatives: store
+  slug alone (breaks on pods/subdomains — the host is not derivable from the slug)
+  or a per-entry `Region` host hint (overloads a field meant for API data
+  residency). Carrying the full host+slug keeps one code path across all variants;
+  the adapter splits on the first `/` to get origin and slug.
+- **Detail parse = title + embedded JSON, not schema.org.** Loxo detail pages have
+  no `JobPosting` ld+json (verified), so unlike careerspage we read the `<title>`
+  (strip ` | <agency>`) and the embedded `application/json` blob's `description`.
+  Location/remote are best-effort DOM reads; absent → empty (the location
+  dictionary decides downstream, never a guess).
+- **ExternalID = decoded `<agency_id>-<slug>`.** Stable and human-legible; the
+  agency-id prefix keeps ids unique across boards even before the pipeline
+  namespaces by board.
+- **Employer via `Hub` (reuse, not new).** `hub: true` boards resolve the client
+  only on an explicit title delimiter (`— Client` / `@ Client`); else the agency
+  name. Mirrors huntflow's division-breadcrumb resolution. In practice fallback is
+  the common case, which is honest (the agency is who posts).
+- **Discovery = search footprint, not subdomain brute force.** Loxo has no public
+  agency directory and blind-guessing `*.app.loxo.co` is a huge, low-yield space.
+  One `site:app.loxo.co` query already surfaced ~10 valid agencies; the prober
+  paginates the footprint, extracts `(host, slug)`, and live-validates.
+- **Harvester proposes, human curates.** Same philosophy as `harvest-boards`: emit
+  draft entries with tech-job counts so the operator seeds only live, tech-bearing
+  boards; the committed `sources/loxo.yml` stays the project's validated fact set.
+
+## Risks / Trade-offs
+
+- **Cross-source duplicates** → accepted, no mitigation now. An agency repost and
+  the client's own ATS posting are separate rows (freehire dedups only within a
+  `source`). Treated as a legitimately distinct listing; a future cross-source
+  fuzzy dedup on title+company is a noted seam.
+- **Mostly non-tech agencies** → the harvester's tech-count lets the operator skip
+  boards with no tech vacancies; the per-job non-tech gate filters the rest
+  downstream, so no adapter-level gate is needed.
+- **HTML shape drift** (title suffix / JSON blob format could change) → covered by
+  fixture-based unit tests that fail loudly if the parse breaks; the spike shows
+  the shape is uniform across agencies today.
+- **Employer under-attribution** → by design we accept agency-as-company rather
+  than risk a wrong client guess (consistent with freehire's "never guess" bias).
+
+## Migration Plan
+
+- Pure additive: new adapter file + one `sources.All` line + new board file + new
+  `cmd/harvest-loxo`. No schema or migration.
+- Deploy: ship the binary, add a staggered `freehire-ingest@loxo` timer (as for
+  other board files); seed `sources/loxo.yml` from the spike agencies, expand via
+  `harvest-loxo` output.
+
+## Open Questions
+
+- None blocking. The employer-delimiter heuristic set (`—`, `@`) can be tuned as
+  real titles are observed, without changing the design.

--- a/openspec/changes/add-loxo-adapter/proposal.md
+++ b/openspec/changes/add-loxo-adapter/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Loxo hosts the public careers boards of many recruiting agencies (e.g. FitNext
+Consulting, Agile Recruiter, LA-Tech), each carrying tech vacancies that
+freehire does not yet aggregate. A spike VALIDATED that these boards are cleanly
+scrapeable and that the pattern generalizes across agencies and host variants, so
+a single Loxo adapter unlocks a whole class of sources at once.
+
+## What Changes
+
+- Add a `loxo` ATS adapter (`internal/sources/loxo.go`) in the careerspage style:
+  crawl a board's SSR careers page, extract `/job/<base64>` links, fan out to each
+  detail page, and map it to a `Job`. One line in `sources.All`.
+- Honor the existing `CompanyEntry.Hub` flag for employer attribution (Loxo boards
+  are agencies whose vacancies belong to different clients): resolve the client from
+  the posting when explicitly present, else fall back to the agency name — never guess.
+- Add `cmd/harvest-loxo`, a discovery prober that enumerates Loxo agency boards from
+  the search-engine footprint, live-validates each, and emits draft
+  `sources/loxo.yml` entries for human curation (mirrors `cmd/harvest-boards`).
+- Add the `sources/loxo.yml` board file (all entries `hub: true`), seeded with
+  the validated agencies from the spike.
+- No new tech-gating or lifecycle mechanism: Loxo is a registered board source, so
+  it reuses the per-provider unseen sweep and the existing per-job non-tech gate.
+
+## Capabilities
+
+### New Capabilities
+- `loxo-source`: the Loxo careers-board adapter — listing crawl, detail parse
+  (title, embedded-JSON description, stable `<agency_id>-<slug>` external id,
+  best-effort location/remote), and Hub-based employer attribution.
+- `loxo-harvest`: the `cmd/harvest-loxo` discovery prober — footprint enumeration,
+  live validation, tech-relevance counting, and draft board-file emission.
+
+### Modified Capabilities
+<!-- None: Hub is an existing field already honored by huntflow; the unseen-sweep
+     and non-tech gate are reused unchanged, so no spec-level behavior changes there. -->
+
+## Impact
+
+- New code: `internal/sources/loxo.go` (+ test + fixtures), `cmd/harvest-loxo/main.go`,
+  `sources/loxo.yml`; one registration line in `internal/sources/source.go` (`All`).
+- Reuses: careerspage-style `HTMLGetter`, `CompanyEntry.Hub` (huntflow precedent),
+  `internal/classify` (harvester tech count), the ingest unseen sweep.
+- Accepted trade-off (seam, no mitigation now): cross-source duplicates — an agency
+  repost of a job the client also posts directly to its own ATS yields a second row,
+  since freehire dedups only within a `source`. Treated as a legitimately distinct
+  listing.

--- a/openspec/changes/add-loxo-adapter/specs/loxo-harvest/spec.md
+++ b/openspec/changes/add-loxo-adapter/specs/loxo-harvest/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Loxo board discovery from the search footprint
+
+The system SHALL provide a `harvest-loxo` host tool that enumerates candidate Loxo
+agency boards from the search-engine footprint (paginating `site:app.loxo.co` and
+`*.app.loxo.co`), extracting the `(host, slug)` pair from each careers-page and
+`/job/<base64>` URL. Because Loxo exposes no public directory of agencies, this
+footprint enumeration is the discovery source.
+
+#### Scenario: Candidates extracted from footprint URLs
+
+- **WHEN** the tool reads indexed Loxo URLs for careers pages and job details
+- **THEN** it derives one candidate `(host, slug)` per distinct agency board
+
+### Requirement: Live validation of candidate boards
+
+The tool SHALL keep a candidate board only if its careers page live-validates —
+returns HTTP 200 and contains at least one `/job/<base64>` link. A candidate that
+is absent, empty, or unreachable SHALL be skipped and never abort the run.
+
+#### Scenario: A live board with postings is kept
+
+- **WHEN** a candidate careers page returns 200 with one or more job links
+- **THEN** the board is kept as a validated candidate
+
+#### Scenario: A dead or empty candidate is skipped
+
+- **WHEN** a candidate careers page is unreachable, non-200, or has no job links
+- **THEN** it is skipped and the run continues with the other candidates
+
+### Requirement: Tech-relevance counting
+
+For each validated board the tool SHALL count how many of its postings classify as
+tech (via `internal/classify`) and report that count, so an operator can avoid
+seeding boards that carry no tech vacancies.
+
+#### Scenario: Tech count reported per board
+
+- **WHEN** a validated board's postings are sampled
+- **THEN** the tool reports the board's total and tech-classified job counts
+
+### Requirement: Draft board-file emission for curation
+
+The tool SHALL emit each kept board as a draft `sources/loxo.yml` entry — `company`
+from the board title, `board` as `<host>/<slug>`, and `hub: true` — de-duplicated
+against boards already in the file. The tool proposes entries for human curation
+and does not itself decide the committed board set.
+
+#### Scenario: Kept board emitted as a hub entry
+
+- **WHEN** a board is validated and kept
+- **THEN** it is emitted as a `sources/loxo.yml` entry with `hub: true` and its
+  `<host>/<slug>` board id
+
+#### Scenario: An already-known board is not duplicated
+
+- **WHEN** a candidate board id already appears in `sources/loxo.yml`
+- **THEN** it is filtered out and not emitted again

--- a/openspec/changes/add-loxo-adapter/specs/loxo-harvest/spec.md
+++ b/openspec/changes/add-loxo-adapter/specs/loxo-harvest/spec.md
@@ -2,15 +2,17 @@
 
 ### Requirement: Loxo board discovery from the search footprint
 
-The system SHALL provide a `harvest-loxo` host tool that enumerates candidate Loxo
-agency boards from the search-engine footprint (paginating `site:app.loxo.co` and
-`*.app.loxo.co`), extracting the `(host, slug)` pair from each careers-page and
-`/job/<base64>` URL. Because Loxo exposes no public directory of agencies, this
-footprint enumeration is the discovery source.
+The system SHALL provide a `harvest-loxo` host tool that consumes operator-supplied
+Loxo footprint URLs (careers-page and `/job/<base64>` URLs, read from stdin or a
+seed file) and extracts the `(host, slug)` pair from each into a distinct candidate
+board set. Because Loxo exposes no public directory of agencies, the operator gathers
+the footprint (e.g. via a `site:app.loxo.co` search) and the tool validates and
+curates it — mirroring `harvest-boards`, which validates a supplied seed set rather
+than scraping a search engine itself.
 
 #### Scenario: Candidates extracted from footprint URLs
 
-- **WHEN** the tool reads indexed Loxo URLs for careers pages and job details
+- **WHEN** the tool reads Loxo careers-page and job-detail URLs across host variants
 - **THEN** it derives one candidate `(host, slug)` per distinct agency board
 
 ### Requirement: Live validation of candidate boards

--- a/openspec/changes/add-loxo-adapter/specs/loxo-source/spec.md
+++ b/openspec/changes/add-loxo-adapter/specs/loxo-source/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Loxo careers-board crawl
+
+The system SHALL provide a `loxo` source adapter that crawls one Loxo agency's
+public careers board into the catalogue. The board id is the careers URL without
+scheme (e.g. `fitnext.app.loxo.co/fitnext` or `app.loxo.co/agile-recruiter`), so
+one adapter uniformly covers Loxo's host variants (agency subdomain, bare
+`app.loxo.co`, and regional pods); the adapter derives the origin from the board
+host. The crawl is keyless and board-based, and appears in the source facet.
+
+#### Scenario: Board yields all live postings
+
+- **WHEN** the adapter fetches a configured Loxo board
+- **THEN** it returns one `Job` per posting linked as `/job/<base64>` from the
+  board's server-rendered listing page
+
+#### Scenario: Host variant is honored
+
+- **WHEN** a board id names an agency subdomain, the bare `app.loxo.co` host, or a
+  regional pod host
+- **THEN** the adapter fetches the listing and resolves each posting URL against
+  that same host
+
+### Requirement: Loxo detail mapping
+
+The adapter SHALL map each posting's detail page to a `Job` using the page title
+for the role name (stripped of the trailing ` | <agency>` suffix), the embedded
+`<script type="application/json">` blob for the HTML description, and the
+canonical `<host>/job/<base64>` as the apply/detail URL. Location and remote are
+best-effort from the detail DOM and left empty when absent — the adapter never
+guesses geography.
+
+#### Scenario: Description comes from the embedded JSON
+
+- **WHEN** the detail page carries the embedded JSON blob with a `description`
+- **THEN** the `Job` description is that HTML, and the title is the page title
+  with the ` | <agency>` suffix removed
+
+#### Scenario: Missing structured location resolves to nothing
+
+- **WHEN** a posting exposes no parseable location on the detail page
+- **THEN** the `Job` location/remote are left empty rather than inferred
+
+### Requirement: Stable Loxo dedup identity
+
+The adapter SHALL set each `Job`'s `ExternalID` to the decoded base64 job id,
+which is the platform's stable `<agency_id>-<slug>` pair, so re-crawling the same
+board dedups to the same catalogue row.
+
+#### Scenario: Re-crawl dedups to one row
+
+- **WHEN** the same posting is crawled on two runs
+- **THEN** both map to the same `ExternalID` (`<agency_id>-<slug>`) and upsert to a
+  single catalogue row
+
+### Requirement: Hub-based employer attribution
+
+The adapter SHALL honor the `CompanyEntry.Hub` flag for employer attribution,
+because a Loxo board is an agency hosting many clients' vacancies. When `Hub` is
+set it resolves the client employer from the posting only on an explicit delimiter
+in the title (e.g. `— Client` / `@ Client`), and otherwise falls back to the
+configured agency name. It never guesses an employer.
+
+#### Scenario: Client resolved from an explicit delimiter
+
+- **WHEN** `Hub` is set and a posting title carries an explicit `— <Client>` suffix
+- **THEN** the `Job` company is `<Client>`
+
+#### Scenario: Fallback to the agency name
+
+- **WHEN** `Hub` is set and a posting title exposes no explicit client
+- **THEN** the `Job` company is the configured agency name
+
+### Requirement: Per-posting detail isolation
+
+The adapter SHALL fetch posting detail pages under a bounded concurrent worker
+pool and drop only the postings whose fetch or parse fails, so one bad posting
+never aborts the whole board crawl.
+
+#### Scenario: A failing posting is skipped, not fatal
+
+- **WHEN** one posting's detail page fails to fetch or parse
+- **THEN** that posting is dropped and the rest of the board's postings are still
+  returned

--- a/openspec/changes/add-loxo-adapter/tasks.md
+++ b/openspec/changes/add-loxo-adapter/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Fixtures
 
-- [ ] 1.1 Save real Loxo HTML fixtures under `internal/sources/testdata/loxo/`: a
+- [x] 1.1 Save real Loxo HTML fixtures under `internal/sources/testdata/loxo/`: a
   listing page and 1-2 detail pages (from the spike agencies, incl. one with a
   title-delimiter client and one plain agency title)
 
 ## 2. Loxo adapter — detail parse
 
-- [ ] 2.1 RED: test that `loxo` maps a detail fixture to a `Job` — title stripped
+- [x] 2.1 RED: test that `loxo` maps a detail fixture to a `Job` — title stripped
   of ` | <agency>`, description from the embedded JSON blob, URL canonical
   `<host>/job/<base64>`, `ExternalID` = decoded `<agency_id>-<slug>`
-- [ ] 2.2 GREEN: implement the detail parse in `internal/sources/loxo.go`
-- [ ] 2.3 RED+GREEN: best-effort location/remote from the detail DOM; empty when
+- [x] 2.2 GREEN: implement the detail parse in `internal/sources/loxo.go`
+- [x] 2.3 RED+GREEN: best-effort location/remote from the detail DOM; empty when
   absent (no guessing)
 
 ## 3. Loxo adapter — listing crawl
 
-- [ ] 3.1 RED: test that a listing fixture yields one `/job/<base64>` link per
+- [x] 3.1 RED: test that a listing fixture yields one `/job/<base64>` link per
   posting and resolves each against the board host (subdomain / bare / pod)
-- [ ] 3.2 GREEN: implement listing fetch + link extraction + bounded-concurrency
+- [x] 3.2 GREEN: implement listing fetch + link extraction + bounded-concurrency
   detail fan-out (drop only failing postings)
-- [ ] 3.3 RED+GREEN: `Provider()` returns `"loxo"`; board id `<host>/<slug>` splits
+- [x] 3.3 RED+GREEN: `Provider()` returns `"loxo"`; board id `<host>/<slug>` splits
   to origin + slug
 
 ## 4. Hub employer attribution
 
-- [ ] 4.1 RED: test `hub: true` resolves the client on an explicit title delimiter
+- [x] 4.1 RED: test `hub: true` resolves the client on an explicit title delimiter
   (`— Client` / `@ Client`) and falls back to the agency name otherwise
-- [ ] 4.2 GREEN: implement Hub-aware company resolution
+- [x] 4.2 GREEN: implement Hub-aware company resolution
 
 ## 5. Registry + board file
 
-- [ ] 5.1 Register `loxo` in `internal/sources/source.go` `All`
-- [ ] 5.2 Add `sources/loxo.yml` seeded with the validated spike agencies, all
+- [x] 5.1 Register `loxo` in `internal/sources/source.go` `All`
+- [x] 5.2 Add `sources/loxo.yml` seeded with the validated spike agencies, all
   `hub: true`; `go run ./cmd/ingest sources/loxo.yml` validates against the registry
 
 ## 6. harvest-loxo prober

--- a/openspec/changes/add-loxo-adapter/tasks.md
+++ b/openspec/changes/add-loxo-adapter/tasks.md
@@ -1,0 +1,51 @@
+## 1. Fixtures
+
+- [ ] 1.1 Save real Loxo HTML fixtures under `internal/sources/testdata/loxo/`: a
+  listing page and 1-2 detail pages (from the spike agencies, incl. one with a
+  title-delimiter client and one plain agency title)
+
+## 2. Loxo adapter — detail parse
+
+- [ ] 2.1 RED: test that `loxo` maps a detail fixture to a `Job` — title stripped
+  of ` | <agency>`, description from the embedded JSON blob, URL canonical
+  `<host>/job/<base64>`, `ExternalID` = decoded `<agency_id>-<slug>`
+- [ ] 2.2 GREEN: implement the detail parse in `internal/sources/loxo.go`
+- [ ] 2.3 RED+GREEN: best-effort location/remote from the detail DOM; empty when
+  absent (no guessing)
+
+## 3. Loxo adapter — listing crawl
+
+- [ ] 3.1 RED: test that a listing fixture yields one `/job/<base64>` link per
+  posting and resolves each against the board host (subdomain / bare / pod)
+- [ ] 3.2 GREEN: implement listing fetch + link extraction + bounded-concurrency
+  detail fan-out (drop only failing postings)
+- [ ] 3.3 RED+GREEN: `Provider()` returns `"loxo"`; board id `<host>/<slug>` splits
+  to origin + slug
+
+## 4. Hub employer attribution
+
+- [ ] 4.1 RED: test `hub: true` resolves the client on an explicit title delimiter
+  (`— Client` / `@ Client`) and falls back to the agency name otherwise
+- [ ] 4.2 GREEN: implement Hub-aware company resolution
+
+## 5. Registry + board file
+
+- [ ] 5.1 Register `loxo` in `internal/sources/source.go` `All`
+- [ ] 5.2 Add `sources/loxo.yml` seeded with the validated spike agencies, all
+  `hub: true`; `go run ./cmd/ingest sources/loxo.yml` validates against the registry
+
+## 6. harvest-loxo prober
+
+- [ ] 6.1 RED: test slug/host extraction from footprint URLs (careers + `/job/`
+  URLs across host variants) yields distinct `(host, slug)` candidates
+- [ ] 6.2 GREEN: implement footprint enumeration + candidate extraction
+- [ ] 6.3 Implement live validation (200 + `/job/` links; skip dead, never abort)
+  and per-board tech-count via `internal/classify`
+- [ ] 6.4 Emit draft `sources/loxo.yml` entries (`company`, `board: <host>/<slug>`,
+  `hub: true`), de-duplicated against the existing file
+
+## 7. Verify
+
+- [ ] 7.1 `go build ./... && go vet ./... && go test ./...` green
+- [ ] 7.2 Run `harvest-loxo` against the live footprint and confirm it emits
+  validated draft entries; sanity-run `cmd/ingest sources/loxo.yml` end-to-end

--- a/openspec/changes/add-loxo-adapter/tasks.md
+++ b/openspec/changes/add-loxo-adapter/tasks.md
@@ -36,16 +36,16 @@
 
 ## 6. harvest-loxo prober
 
-- [ ] 6.1 RED: test slug/host extraction from footprint URLs (careers + `/job/`
+- [x] 6.1 RED: test slug/host extraction from footprint URLs (careers + `/job/`
   URLs across host variants) yields distinct `(host, slug)` candidates
-- [ ] 6.2 GREEN: implement footprint enumeration + candidate extraction
-- [ ] 6.3 Implement live validation (200 + `/job/` links; skip dead, never abort)
+- [x] 6.2 GREEN: implement footprint enumeration + candidate extraction
+- [x] 6.3 Implement live validation (200 + `/job/` links; skip dead, never abort)
   and per-board tech-count via `internal/classify`
-- [ ] 6.4 Emit draft `sources/loxo.yml` entries (`company`, `board: <host>/<slug>`,
+- [x] 6.4 Emit draft `sources/loxo.yml` entries (`company`, `board: <host>/<slug>`,
   `hub: true`), de-duplicated against the existing file
 
 ## 7. Verify
 
-- [ ] 7.1 `go build ./... && go vet ./... && go test ./...` green
-- [ ] 7.2 Run `harvest-loxo` against the live footprint and confirm it emits
+- [x] 7.1 `go build ./... && go vet ./... && go test ./...` green
+- [x] 7.2 Run `harvest-loxo` against the live footprint and confirm it emits
   validated draft entries; sanity-run `cmd/ingest sources/loxo.yml` end-to-end

--- a/sources/loxo.yml
+++ b/sources/loxo.yml
@@ -1,0 +1,17 @@
+# Loxo recruiting-agency careers boards. Provider is the filename; each entry is
+# company + board. board = the careers URL without scheme, "<host>/<slug>", covering
+# Loxo's host variants (agency subdomain, bare app.loxo.co, regional pod); see
+# internal/sources/loxo.go. Boards are agencies hosting many clients' vacancies, so every
+# entry is hub: true — the adapter resolves the client from the posting when the title
+# reveals it and otherwise attributes the vacancy to the agency name.
+# Each board validated live (listing lists >0 /job postings) before adding.
+
+- company: FitNext Co.
+  board: fitnext.app.loxo.co/fitnext
+  hub: true
+- company: Agile Recruiter
+  board: app.loxo.co/agile-recruiter
+  hub: true
+- company: LA-Tech
+  board: pod4.app.loxo.co/la-tech
+  hub: true


### PR DESCRIPTION
## Summary
- Add a `loxo` ATS adapter (`internal/sources/loxo.go`) for Loxo recruiting-agency careers boards. Board id = careers URL without scheme (`<host>/<slug>`), uniformly covering agency-subdomain / bare `app.loxo.co` / regional-pod hosts. Crawls the SSR listing → `/job/<base64>` links → detail parse (og:title, embedded `application/json` description, og:description location, decoded `<agency_id>-<slug>` external id). Honors `CompanyEntry.Hub` for client-vs-agency employer attribution (never guesses).
- Add `cmd/harvest-loxo`: consumes operator-supplied footprint URLs, extracts `(host, slug)`, de-dups vs `sources/loxo.yml`, live-validates via the adapter, counts tech postings (`internal/classify`), and emits draft `hub: true` board entries for curation.
- Add `sources/loxo.yml` seeded with three spike-validated tech agencies; register `loxo` in `sources.All`.
- OpenSpec change `add-loxo-adapter` (proposal/design/specs/tasks) included.

Feasibility spiked across 6 agencies (VALIDATED); design brainstormed (mass-harvest + Hub attribution, cross-source dups accepted as a noted seam).

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` green
- [x] Adapter unit tests on real fitnext fixtures (detail parse, host resolution, Fetch isolation, Hub, external-id)
- [x] `harvest-loxo` live end-to-end: validated new boards (levelociti 384/24 tech, patriot 11/2 tech), de-duped seeded agencies, excluded job/non-loxo URLs