### PR TITLE
Add 38 Swiss startup ATS boards from startupvalleys.com

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7399,3 +7399,7 @@
   board: eneba
 - company: Lightspeed
   board: lightspeed
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "Loki Robotics"
+  board: loki

--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18637,3 +18637,11 @@
   board: thetradingpit
 - company: YouHodler
   board: youhodler
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "GUURU Solutions AG"
+  board: guuru
+- company: "Kuros Biosciences"
+  board: kurosbio
+- company: "SurgeonsLab AG"
+  board: surgeonslab

--- a/sources/breezy.yml
+++ b/sources/breezy.yml
@@ -3569,3 +3569,7 @@
   board: chatfuel
 - company: Quantori
   board: quantori
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "Drone Harmony AG"
+  board: drone-harmony

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14059,3 +14059,9 @@
   board: fxpro
 - company: N26
   board: n26
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "Informal Systems"
+  board: informal
+- company: "Numab Therapeutics AG"
+  board: numab

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -4312,3 +4312,10 @@
   board: zerion
 - company: Packmatic
   board: Packmatic
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "Altoida AG"
+  board: Altoida
+- company: "grape insurance AG"
+  board: grape-health
+  region: eu

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -7977,3 +7977,31 @@
   board: urbansportsclub
 - company: Workflex
   board: workflex
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "Impact Hub Zürich"
+  board: impact-hub-zuerich-ag
+- company: "QUMEA"
+  board: qumea-ag
+- company: "Avantama AG"
+  board: avantama
+- company: "Crypto Finance AG"
+  board: crypto-finance
+- company: "derma2go AG"
+  board: derma2go
+- company: "Kaiko AI"
+  board: kaiko
+- company: "nexoya AG"
+  board: nexoya
+- company: "Nexxiot AG"
+  board: nexxiot
+- company: "Previse Systems GmbH"
+  board: previsesystems
+- company: "Scalera (RA Scale AG)"
+  board: scalera
+- company: "Scanvio Medical AG"
+  board: scanvio
+- company: "Speedgoat GmbH"
+  board: speedgoat
+- company: "ZuriQ AG"
+  board: zuriq

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3505,3 +3505,21 @@
   board: betterme
 - company: TTeam
   board: tteam
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "Bloom"
+  board: bloom
+- company: "Exa"
+  board: exa
+- company: "Goodwall SA"
+  board: goodwall
+- company: "Imnoo – AI-commerce for the manufacturing industry"
+  board: imnoo
+- company: "Ipex AG"
+  board: ipex
+- company: "NIKIN AG"
+  board: nikin
+- company: "TWINT"
+  board: twint
+- company: "Xeltis AG"
+  board: xeltis

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1124,3 +1124,21 @@
   board: wati-dot-i-o
 - company: YouTrip
   board: youtrip
+
+# --- startupvalleys.com import (companies + discovered career pages) ---
+- company: "Backbone Art SA"
+  board: bkbn
+- company: "Frontiers Media SA"
+  board: frontiersmedia
+- company: "Matternet"
+  board: matternet
+- company: "SkyCell AG"
+  board: skycell-ag
+- company: "The Faction Collective SA"
+  board: full-stack-supply-co
+- company: "Unit8 SA"
+  board: unit8
+- company: "Vanguard Internet SA"
+  board: batgroup
+- company: "ZYTLYN TECHNOLOGIES AG"
+  board: vorsee


### PR DESCRIPTION
Discovered via the startupvalleys.com directory (2030 Swiss startups): 3 boards from its job feed + 35 from probing company career pages. Each board live-validated (>0 open jobs).

By provider: personio 13, workable 8, recruitee 8, bamboohr 3, lever 2, ashby/breezy/greenhouse 1.

Also imported the 2030 companies into the companies table on prod (1834 new reference rows + 202 enriched) — done directly, not part of this PR.