### PR TITLE
feat(sources): add 4 more ATS boards from wantapply (2nd pass)

### DIFF
--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -3731,3 +3731,5 @@
   board: realalloy
 - company: The Stronghold Companies
   board: strongholdspecialtyltd
+- company: Prequel
+  board: prequel

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -7691,3 +7691,9 @@
   board: zymochem
 - company: Bydrec
   board: bydrec
+- company: Americor
+  board: americor
+- company: INDEX
+  board: index
+- company: Smartcat
+  board: smartcat


### PR DESCRIPTION
Second harvest pass over the remaining ATS providers with the wantapply seed. Kept 4 live boards: icims/Prequel, jazzhr/Americor, jazzhr/Smartcat, jazzhr/INDEX. apploi excluded (permissive prober matched all 847 candidates).