### PR TITLE
fix(sources): drop icims/prequel (slug collision → A.C. Coy)

### DIFF
--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -3731,5 +3731,3 @@
   board: realalloy
 - company: The Stronghold Companies
   board: strongholdspecialtyltd
-- company: Prequel
-  board: prequel


### PR DESCRIPTION
The harvested icims board `prequel` resolves to A.C. Coy (already ingested via icims), not the intended company Prequel. Mislabeled + redundant — removed.