### PR TITLE
feat(cv-autofill): pre-fill onboarding wizard + profile from a résumé

### DIFF
--- a/cmd/harvest-loxo/main_test.go
+++ b/cmd/harvest-loxo/main_test.go
@@ -4,15 +4,15 @@ import "testing"
 
 func TestExtractCandidates(t *testing.T) {
 	in := []string{
-		"https://fitnext.app.loxo.co/fitnext",                     // agency subdomain
-		"https://app.loxo.co/agile-recruiter?location_sort=asc",   // bare host + query
-		"https://pod4.app.loxo.co/la-tech",                        // regional pod
+		"https://fitnext.app.loxo.co/fitnext",                      // agency subdomain
+		"https://app.loxo.co/agile-recruiter?location_sort=asc",    // bare host + query
+		"https://pod4.app.loxo.co/la-tech",                         // regional pod
 		"https://app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==", // job detail — no slug, skip
-		"https://fitnext.app.loxo.co/login",                       // non-careers, skip
-		"https://app.loxo.co/agile-recruiter",                     // dup of #2 (query stripped)
-		"https://example.com/careers",                             // not loxo, skip
-		"https://notapp.loxo.co/evil",                             // lookalike host, skip
-		"  ",                                                      // blank, skip
+		"https://fitnext.app.loxo.co/login",                        // non-careers, skip
+		"https://app.loxo.co/agile-recruiter",                      // dup of #2 (query stripped)
+		"https://example.com/careers",                              // not loxo, skip
+		"https://notapp.loxo.co/evil",                              // lookalike host, skip
+		"  ",                                                       // blank, skip
 	}
 	got := extractCandidates(in)
 	want := []candidate{

--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -30,6 +30,32 @@ func Parse(title string) Classification {
 	}
 }
 
+// Categories resolves every category the text mentions — each alias that occurs as a
+// whole word — distinct and in precedence order (the primary category first). Unlike
+// Parse, which keeps only the single strongest category, this surfaces the full set a
+// résumé spans (a backend engineer who also does ML). Empty when nothing resolves; it
+// never guesses.
+func Categories(text string) []string {
+	return matchAllOrdered(strings.ToLower(text), categoryOrder, categoryAliases)
+}
+
+// matchAllOrdered returns the distinct canonical values of every alias (in priority
+// order) that occurs as a whole word in title. Several aliases can share a canonical
+// ("backend"/"back-end"), so results are deduplicated while preserving first-seen order.
+func matchAllOrdered(title string, order []string, aliases map[string]string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, alias := range order {
+		if wordmatch.Contains(title, alias, wordmatch.UnicodeBoundary) {
+			if slug := aliases[alias]; !seen[slug] {
+				seen[slug] = true
+				out = append(out, slug)
+			}
+		}
+	}
+	return out
+}
+
 // CategoryAliases maps each category canonical to the title aliases that resolve
 // to it (the inverse of the internal alias table); SeniorityAliases does the same
 // for grades. Exposed so the web role picker can search roles by shorthand — the

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -87,6 +87,27 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestCategories(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{"single category", "Senior Backend Engineer", []string{"backend"}},
+		{"several distinct categories, precedence order", "Backend Engineer and Data Engineer doing machine learning", []string{"data_engineering", "ml_ai", "backend"}},
+		{"duplicate aliases collapse to one", "backend and back-end developer", []string{"backend"}},
+		{"generic title resolves nothing", "Software Engineer", nil},
+		{"empty", "", nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Categories(tc.text); !slices.Equal(got, tc.want) {
+				t.Errorf("Categories(%q) = %v, want %v", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCanonicalValuesAreInVocabulary(t *testing.T) {
 	for alias, canon := range seniorityAliases {
 		if !slices.Contains(enrich.SeniorityValues, canon) {

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -327,7 +327,7 @@ func Register(app *fiber.App, cfg Config) {
 	// modal (extracted skills merge into the profile). When S3 storage is configured it
 	// also stores the résumé once (the single upload point); when not, it stays stateless
 	// (parsed and discarded, only canonical slugs returned).
-	api.Post("/me/resume/extract", saved, a.ExtractResumeSkills)
+	api.Post("/me/resume/extract", saved, a.ExtractResumeProfile)
 
 	// Résumé storage (cookie-only): store the résumé once so the verdict's coherence can
 	// reuse it without a second upload. PUT stores/replaces, GET reports status (enabled +

--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -8,10 +8,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/ledongthuc/pdf"
 
+	classifydict "github.com/strelov1/freehire/internal/classify"
 	"github.com/strelov1/freehire/internal/resume"
 	"github.com/strelov1/freehire/internal/skilltag"
 )
@@ -29,16 +31,98 @@ type resumeUpload struct {
 	Text        string
 }
 
-// ExtractResumeSkills turns an uploaded resume into canonical skill slugs via the
-// deterministic skilltag dictionary. It accepts a PDF (multipart/form-data field
+// cvProfile is the profile a résumé yields through the deterministic dictionaries:
+// canonical skills, the seniority grade, and every category the résumé spans (a person
+// can be several — backend + ML). Each dictionary "never guesses", so an unresolved field
+// is empty.
+type cvProfile struct {
+	Skills     []string
+	Seniority  string
+	Categories []string
+}
+
+// headlineRunes bounds the résumé "headline" fed to the title dictionaries: wide enough to
+// clear the name + contact preamble and reach the title (and a few summary words), tight
+// enough that the career-history section below can't reach in and over-promote the grade.
+const headlineRunes = 120
+
+// resumeHeadline returns the top of a résumé as a single flowing string — the name, title,
+// and the start of the summary — with contact/metadata tokens (email, phone, profile URL,
+// bare numbers, punctuation) dropped. The title dictionary (classify) runs over this, not
+// the whole CV, so a grade or role word buried in the career history
+// ("reported to the Head of Eng", a past Director role) can't over-promote the current
+// role. It collapses all whitespace first because PDF text extraction is unreliable about
+// line breaks — a two-column or table header often comes out one token per line — so a
+// line-based scan would stall on the name and never reach the title.
+func resumeHeadline(text string) string {
+	var kept []string
+	runes := 0
+	for _, tok := range strings.Fields(text) {
+		if looksLikeContactToken(tok) {
+			continue
+		}
+		kept = append(kept, tok)
+		if runes += len([]rune(tok)) + 1; runes >= headlineRunes {
+			break
+		}
+	}
+	return strings.Join(kept, " ")
+}
+
+// looksLikeContactToken reports whether a whitespace-delimited résumé token is
+// contact/metadata noise rather than a title word: an email, a profile URL, or a token
+// with no letters at all (a "|" separator, a phone fragment, a bare number). Dropping these
+// keeps the headline landing on the actual role, not the candidate's inbox.
+func looksLikeContactToken(tok string) bool {
+	lower := strings.ToLower(tok)
+	if strings.Contains(lower, "@") {
+		return true
+	}
+	for _, s := range []string{"http", "www.", "linkedin.com", "github.com", ".com/"} {
+		if strings.Contains(lower, s) {
+			return true
+		}
+	}
+	for _, r := range tok {
+		if unicode.IsLetter(r) {
+			return false
+		}
+	}
+	return true // no letters → punctuation / phone digits / bare number
+}
+
+// resumeProfile derives a cvProfile from résumé text using only the existing
+// dictionaries — skilltag for skills over the whole text (skills appear anywhere), and
+// classify over the headline (the current title + summary top) for the seniority grade
+// and the categories the résumé spans. No LLM.
+func resumeProfile(text string) cvProfile {
+	skills := skilltag.Parse(text, skilltag.WithResumeAcronyms())
+	if skills == nil {
+		skills = []string{}
+	}
+	head := resumeHeadline(text)
+	categories := classifydict.Categories(head)
+	if categories == nil {
+		categories = []string{}
+	}
+	return cvProfile{
+		Skills:     skills,
+		Seniority:  classifydict.Parse(head).Seniority,
+		Categories: categories,
+	}
+}
+
+// ExtractResumeProfile turns an uploaded résumé into a structured profile — canonical
+// skill slugs plus the dictionary-resolved seniority grade and the categories it spans —
+// all via the deterministic dictionaries (no LLM). It accepts a PDF (multipart/form-data field
 // "file") or plain text (application/json {text}), dispatched by Content-Type. When S3
 // storage is configured it also stores the résumé once — the single upload point, so the
 // verdict's coherence can reuse it without a second upload; storing is best-effort here
-// (a hiccup must not fail skill extraction, this endpoint's contract). When storage is
-// unconfigured the résumé is parsed and discarded (only the slugs are returned). Behind
-// RequireAuth (cookie-only). Oversize bodies are rejected by the server's global
+// (a hiccup must not fail extraction, this endpoint's contract). When storage is
+// unconfigured the résumé is parsed and discarded (only the derived fields are returned).
+// Behind RequireAuth (cookie-only). Oversize bodies are rejected by the server's global
 // BodyLimit (413) before this handler runs.
-func (a *API) ExtractResumeSkills(c *fiber.Ctx) error {
+func (a *API) ExtractResumeProfile(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
 		return err
@@ -52,16 +136,11 @@ func (a *API) ExtractResumeSkills(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "resume is empty")
 	}
 
-	// Résumé path: enable the résumé-scoped acronym tier (e.g. RAG), which stays off
-	// for job parsing so it never tags job facets ("RAG status").
-	skills := skilltag.Parse(up.Text, skilltag.WithResumeAcronyms())
-	if skills == nil {
-		skills = []string{}
-	}
+	prof := resumeProfile(up.Text)
 
 	if a.resume.Enabled() {
 		if _, err := a.resume.Put(c.Context(), userID, up.ContentType, up.Data); err != nil {
-			// Best-effort: log (never the résumé bytes) and still return the skills.
+			// Best-effort: log (never the résumé bytes) and still return the profile.
 			log.Printf("resume: store on extract failed for user %d: %v", userID, err)
 		} else {
 			// This is the résumé-upload path the app actually uses, so it is where the CV
@@ -69,7 +148,14 @@ func (a *API) ExtractResumeSkills(c *fiber.Ctx) error {
 			go a.embedResume(userID, up.Text)
 		}
 	}
-	return c.JSON(fiber.Map{"data": fiber.Map{"skills": skills}})
+
+	// skills and categories are always arrays (possibly empty) so the client can treat
+	// them uniformly; seniority is omitted when unresolved so a client never sees a guess.
+	data := fiber.Map{"skills": prof.Skills, "categories": prof.Categories}
+	if prof.Seniority != "" {
+		data["seniority"] = prof.Seniority
+	}
+	return c.JSON(fiber.Map{"data": data})
 }
 
 // resumeMetaResponse is the wire shape for résumé status: whether storage is enabled at

--- a/internal/handler/resume_profile_test.go
+++ b/internal/handler/resume_profile_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"slices"
+	"testing"
+)
+
+// resumeProfile composes the deterministic dictionaries (skilltag/classify); these cases
+// pin the fields it resolves from sample résumé text, that unresolved fields come back
+// empty, and that it surfaces every category the résumé spans (not just one).
+func TestResumeProfile(t *testing.T) {
+	tests := []struct {
+		name           string
+		text           string
+		wantSeniority  string
+		wantCategories []string // exact set the headline resolves (order-independent)
+		wantSkills     []string // subset that must be present (order-independent)
+		wantNoSkills   bool     // skills must be empty
+	}{
+		{
+			name:           "full résumé resolves seniority, category and skills",
+			text:           "Senior Backend Engineer\nBuilt payment services in Go and PostgreSQL, deployed on Kubernetes.",
+			wantSeniority:  "senior",
+			wantCategories: []string{"backend"},
+			wantSkills:     []string{"postgresql", "kubernetes"},
+		},
+		{
+			name:           "category without a grade leaves seniority empty (never guessed)",
+			text:           "Frontend Developer with React and TypeScript.",
+			wantCategories: []string{"frontend"},
+			wantSkills:     []string{"react", "typescript"},
+		},
+		{
+			// A résumé that spans several functions surfaces every category, primary first.
+			name:           "multiple categories in the headline are all surfaced",
+			text:           "Senior Backend Engineer & Data Engineer\nGo, PostgreSQL, Airflow.",
+			wantSeniority:  "senior",
+			wantCategories: []string{"data_engineering", "backend"}, // categoryOrder precedence
+			wantSkills:     []string{"postgresql"},
+		},
+		{
+			// Real résumés lead with name + contact lines and put the title below them;
+			// the headline must skip that noise so the title still resolves.
+			name:           "title below the contact block still resolves (contact lines skipped)",
+			text:           "John Doe\njohn.doe@gmail.com | +1 555 123 4567\nSan Francisco, CA · linkedin.com/in/johndoe\n\nSenior Backend Engineer\n\nBuilds payment systems in Go, PostgreSQL, Kubernetes and AWS.",
+			wantSeniority:  "senior",
+			wantCategories: []string{"backend"},
+			wantSkills:     []string{"aws", "kubernetes", "postgresql"},
+		},
+		{
+			// The headline (title + summary top) is what classify sees; grade words buried
+			// in the career history below must not over-promote the current grade.
+			name:           "grade words deep in the CV history don't override the headline",
+			text:           "Senior Backend Engineer\nBuilt payment platforms in Go.\nSkills: Kubernetes, PostgreSQL.\n\nExperience:\n2014 — reported to the Head of Product and the CTO.",
+			wantSeniority:  "senior",
+			wantCategories: []string{"backend"},
+			wantSkills:     []string{"kubernetes", "postgresql"},
+		},
+		{
+			name:       "skills-only text resolves no category/seniority",
+			text:       "Proficient in Python.",
+			wantSkills: []string{"python"},
+		},
+		{
+			name:         "empty text resolves nothing",
+			text:         "",
+			wantNoSkills: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := resumeProfile(tc.text)
+			if p.Seniority != tc.wantSeniority {
+				t.Errorf("seniority = %q, want %q", p.Seniority, tc.wantSeniority)
+			}
+			if !slices.Equal(p.Categories, tc.wantCategories) {
+				t.Errorf("categories = %v, want %v", p.Categories, tc.wantCategories)
+			}
+			if tc.wantNoSkills && len(p.Skills) != 0 {
+				t.Errorf("skills = %v, want empty", p.Skills)
+			}
+			for _, s := range tc.wantSkills {
+				if !slices.Contains(p.Skills, s) {
+					t.Errorf("skills = %v, missing %q", p.Skills, s)
+				}
+			}
+		})
+	}
+}
+
+// Skills and Categories are always non-nil so they serialize as [] not null (the response
+// contract the frontend relies on), even when nothing resolves.
+func TestResumeProfileSlicesNeverNil(t *testing.T) {
+	p := resumeProfile("")
+	if p.Skills == nil {
+		t.Error("Skills is nil; want non-nil empty slice")
+	}
+	if p.Categories == nil {
+		t.Error("Categories is nil; want non-nil empty slice")
+	}
+}

--- a/internal/handler/resume_test.go
+++ b/internal/handler/resume_test.go
@@ -29,7 +29,7 @@ func resumeApp(t *testing.T) (*fiber.App, string) {
 	}
 	h := &API{issuer: iss}
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
-	app.Post("/me/resume/extract", auth.RequireAuth(iss), h.ExtractResumeSkills)
+	app.Post("/me/resume/extract", auth.RequireAuth(iss), h.ExtractResumeProfile)
 	return app, token
 }
 
@@ -85,7 +85,7 @@ func decodeSkills(t *testing.T, resp *http.Response) []string {
 	return got.Data.Skills
 }
 
-func TestExtractResumeSkills_Unauthenticated(t *testing.T) {
+func TestExtractResumeProfile_Unauthenticated(t *testing.T) {
 	app, _ := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"Go and PostgreSQL"}`, "")
 	if resp.StatusCode != fiber.StatusUnauthorized {
@@ -93,7 +93,7 @@ func TestExtractResumeSkills_Unauthenticated(t *testing.T) {
 	}
 }
 
-func TestExtractResumeSkills_Text(t *testing.T) {
+func TestExtractResumeProfile_Text(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"Experienced with PostgreSQL, Kubernetes and Docker."}`, token)
 	if resp.StatusCode != fiber.StatusOK {
@@ -105,7 +105,7 @@ func TestExtractResumeSkills_Text(t *testing.T) {
 	}
 }
 
-func TestExtractResumeSkills_TextNoSkills(t *testing.T) {
+func TestExtractResumeProfile_TextNoSkills(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"I like long walks on the beach."}`, token)
 	if resp.StatusCode != fiber.StatusOK {
@@ -118,7 +118,7 @@ func TestExtractResumeSkills_TextNoSkills(t *testing.T) {
 	}
 }
 
-func TestExtractResumeSkills_EmptyText(t *testing.T) {
+func TestExtractResumeProfile_EmptyText(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeJSON(t, app, `{"text":"   "}`, token)
 	if resp.StatusCode != fiber.StatusBadRequest {
@@ -126,7 +126,7 @@ func TestExtractResumeSkills_EmptyText(t *testing.T) {
 	}
 }
 
-func TestExtractResumeSkills_PDF(t *testing.T) {
+func TestExtractResumeProfile_PDF(t *testing.T) {
 	pdf, err := os.ReadFile("testdata/resume_sample.pdf")
 	if err != nil {
 		t.Fatalf("read fixture: %v", err)
@@ -142,7 +142,7 @@ func TestExtractResumeSkills_PDF(t *testing.T) {
 	}
 }
 
-func TestExtractResumeSkills_MalformedPDF(t *testing.T) {
+func TestExtractResumeProfile_MalformedPDF(t *testing.T) {
 	app, token := resumeApp(t)
 	resp := postResumeFile(t, app, "resume.pdf", []byte("this is not a pdf"), token)
 	if resp.StatusCode != fiber.StatusBadRequest {

--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -124,7 +124,7 @@ type options struct {
 
 // WithResumeAcronyms enables the résumé-scoped acronym tier (resumeAcronyms, e.g.
 // RAG) for a Parse call. Job callers omit it so those acronyms never tag job
-// facets; the résumé path (handler.ExtractResumeSkills) sets it.
+// facets; the résumé path (handler.ExtractResumeProfile) sets it.
 func WithResumeAcronyms() Option {
 	return func(o *options) { o.resumeAcronyms = true }
 }

--- a/internal/sources/loxo_test.go
+++ b/internal/sources/loxo_test.go
@@ -127,10 +127,10 @@ func TestLoxoCompany(t *testing.T) {
 func TestLoxoExternalID(t *testing.T) {
 	cases := map[string]string{
 		"https://fitnext.app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==": "42474-7tse3ikc642yzj0v",
-		"https://app.loxo.co/job/YWJjLTE=":                                "abc-1",
+		"https://app.loxo.co/job/YWJjLTE=":                                 "abc-1",
 		"https://app.loxo.co/job/NDI0NzQtN3RzZTNpa2M2NDJ5emowdg==?t=99":    "42474-7tse3ikc642yzj0v",
-		"https://app.loxo.co/careers-in-nonprofits":                       "",
-		"https://app.loxo.co/job/":                                        "",
+		"https://app.loxo.co/careers-in-nonprofits":                        "",
+		"https://app.loxo.co/job/":                                         "",
 	}
 	for u, want := range cases {
 		if got := loxoExternalID(u); got != want {

--- a/openspec/changes/cv-autofill-onboarding/.openspec.yaml
+++ b/openspec/changes/cv-autofill-onboarding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/cv-autofill-onboarding/design.md
+++ b/openspec/changes/cv-autofill-onboarding/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`POST /api/v1/me/resume/extract` (`internal/handler/resume.go` `ExtractResumeSkills`, cookie-auth) reads a PDF or `{text}` and returns `{skills}` via `skilltag.Parse` — a deterministic dictionary, no LLM. It also stores the résumé and background-embeds it (feeding `/me/recommendations`). Three sibling dictionaries already exist and speak the same controlled vocabularies (`enrich.SeniorityValues`/`CategoryValues`): `classify.Parse(title) → {Seniority, Category}` (ordered aliases → deterministic pick, whole-word via `wordmatch`), and `roletag.Derive(seniority, category, title) → []roleSlug`. The onboarding wizard (`OnboardingWizard.svelte`) captures `sel.{specialization(category), seniority, workMode, region, stack(skills)}` from pill/typeahead pickers and has no CV path. `ProfileForm.svelte` already calls `extractResumeSkills` and merges the returned skills into its `skills` field (but never touches `specializations`).
+
+This change widens `extract` to return the dictionary-derived seniority + categories alongside skills, and consumes it in the wizard (a new CV path, with Focus and Seniority made multi-select) and the profile form (specialization pre-fill). `roletag` is not used — the wizard maps to the category/seniority facets, and roles remain the full FilterModal's job.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Pre-fill the wizard's focus/seniority/stack from a résumé, deterministically, reusing the existing dictionaries — no LLM, no new endpoint, no DB change.
+- Keep it best-effort and non-blocking: unresolved fields stay empty, failures fall back to manual.
+- One refactor improves two surfaces (wizard + profile form).
+
+**Non-Goals:**
+- No LLM CV parser (deliberately — the deterministic dictionaries are the project's doctrine and stay instant/free).
+- No work-mode/region from résumés (not stated on a CV). No `user_profiles` auto-write beyond the profile form's existing merge. No new résumé formats (PDF/text only, as today). No change to résumé storage/embedding or auth.
+
+## Decisions
+
+**D1 — Dictionaries, not an LLM.**
+`skilltag` (skills, whole text) and `classify` (seniority + categories) — deterministic, vocabulary-aligned, "never guess." Skills scan the whole CV; seniority/categories scan a `resumeHeadline` slice, not the full text, so a grade word buried in the career history can't over-promote the current grade (and a generic title simply yields no category rather than a guess). *Alternative:* an LLM CV parser (more robust on messy CVs). Rejected — it adds cost, latency (~2s), a prompt/contract/sanitize layer, and contradicts the dict-only facet doctrine; emitting nothing on an unresolved field is the on-brand behavior.
+
+**D1a — Headline extraction, robust to PDF quirks.**
+`resumeHeadline` collapses all whitespace (PDF text extraction often emits one token per line, so a line-based scan stalls on the name), drops contact/metadata tokens (email, phone, profile URL, bare numbers, `|`/punctuation), and keeps a bounded leading window (`headlineRunes`). Wide enough to clear the name/contact preamble and reach the title + a few summary words; tight enough to exclude the experience section below.
+
+**D1b — Multi-category, not a single primary.**
+A résumé can span several functions (backend + ML), so `classify.Categories` returns *every* category the headline names (distinct, precedence order), not just the strongest. `classify.Parse` still supplies the single seniority grade.
+
+**D2 — Widen `extract` additively, don't add an endpoint.**
+`ExtractResumeProfile` (renamed from `ExtractResumeSkills`) runs `classify` over the headline and returns `{skills, categories, seniority?}` (`skills`/`categories` always arrays, `seniority` omitted when unresolved). Existing `{skills}` consumers keep working (the extra fields are additive). One endpoint stays the single résumé-derivation path. *Alternative:* a parallel `/me/resume/parse`. Rejected as redundant — same input, same side effects.
+
+**D3 — CV path is auth-gated, reusing the existing endpoint.**
+The résumé endpoint is cookie-only (it stores + embeds to the account). The wizard's CV button therefore prompts sign-in first (`openAuthDialog`), then opens the file picker — so the file is chosen already-authenticated and no file-across-redirect handoff is needed (an OAuth redirect just reopens the wizard). *Alternative:* an anonymous parse-only endpoint. Rejected — chosen for the persistence bonus (résumé feeds recommendations) and to avoid an unauthenticated upload surface.
+
+**D4 — Pre-fill in place, multi-select, only the resolved fields.**
+On a successful extraction the wizard merges `categories`/`seniority`/`stack` into `sel` (dedup, keeping any manual picks) and **stays on the current step** with a note — so the user reviews and corrects the pre-filled pills rather than being advanced past the "What do you do?" step. Focus and Seniority are **multi-select** (a person can be several specializations; a search can span a grade range), so the extraction's several categories all light up. A generation counter drops a parse that resolves after the wizard was reset. *Earlier alternative:* advancing to step 2 on success — rejected, it skips review of the fields just filled.
+
+**D5 — Component boundaries.**
+- Backend: `resumeHeadline` + `looksLikeContactToken` + `resumeProfile(text) → {skills, seniority, categories}` in `internal/handler` composing `skilltag` + `classify` (incl. the new `classify.Categories`); `ExtractResumeProfile` calls it and serializes. Unit-tested against sample text (contact-first, one-token-per-line, multi-category, buried-grade).
+- Frontend: `api.ts` `extractResumeProfile` returns the widened type; `OnboardingWizard.svelte` owns the CV affordance + `parsing`/`error`/note state, the multi-select Focus/Seniority (`toggleIn`/`multiPills` over `specializations[]`/`seniorities[]`), and the result→`sel` merge; `ProfileForm.svelte` merges `categories` into specializations. The wizard's manual flow is otherwise untouched.
+
+## Risks / Trade-offs
+
+- **[Dictionary picks the wrong role from a multi-role CV]** → It's a reviewable pre-fill on a step the user confirms; `classify`'s ordered aliases give a stable, explainable pick, and the user can change any field before applying.
+- **[Résumé names no recognizable role/skills]** → Best-effort nulls; the wizard simply pre-fills less and the user continues manually — no failure.
+- **[Widening a shared endpoint breaks a caller]** → Additive only; `ProfileForm` (the sole caller) reads `skills` and now also `category`; a round-trip/shape check covers it.
+- **[Auth friction on the CV path]** → Deliberate (D3); the manual wizard path stays fully anonymous, so only the opt-in CV shortcut asks for sign-in.
+- **[Non-PDF résumé / large file]** → Unchanged from today: PDF/text only, bounded by the server `BodyLimit`; a bad upload returns an error the wizard surfaces as its fallback.
+
+## Migration Plan
+
+Additive backend refactor + frontend feature — no schema, no new endpoint, no data migration. If the extract response type is generated into `web/src/lib/generated/contracts`, regenerate it; otherwise the widened shape is a hand-written TS type. Rollback is reverting the handler + web changes; the extra response fields are ignored by any client that doesn't read them.
+
+## Open Questions
+
+_Resolved during implementation:_
+- Full text vs. a leading slice for the title dictionaries → a `resumeHeadline` slice (D1a), after full-text scanning over-promoted the grade from career-history mentions.
+- One category vs. several → several (D1b); the wizard's Focus (and Seniority) became multi-select (D4).
+- Advance after pre-fill vs. stay for review → stay on the step (D4).
+- CV affordance placement → a step-1 "Upload CV — autofill" button above the manual pickers.

--- a/openspec/changes/cv-autofill-onboarding/proposal.md
+++ b/openspec/changes/cv-autofill-onboarding/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The onboarding wizard turns a fresh `/jobs` visit into a personalized feed, but it still makes the visitor pick their focus, seniority, and stack by hand. Most of that is already written on their résumé. We can pre-fill it: upload a CV once and the wizard's focus/seniority/stack come out filled, ready to review. And we can do it the way every other freehire facet is derived — with our existing deterministic dictionaries, not an LLM.
+
+## What Changes
+
+- Refactor `POST /api/v1/me/resume/extract` to return `{skills, categories, seniority?}` instead of just `{skills}`, deriving the new fields from **existing deterministic dictionaries only**:
+  - `skills` — `skilltag.Parse` over the whole résumé (unchanged).
+  - `seniority` + `categories` — `classify` over the résumé *headline* (leading title + summary, with contact/number/punctuation tokens dropped and whitespace collapsed, so a one-token-per-line PDF still reaches the title and the career history below can't over-promote the grade). A new `classify.Categories` returns **every** category the headline names (distinct, precedence order) — a person can be several.
+  - Best-effort: `skills`/`categories` are always arrays (empty when unresolved), `seniority` is omitted when unresolved (never guessed). No LLM, so the endpoint stays instant and unconditional on `LLM_*`. The existing résumé store + background embed side effects and cookie-auth are unchanged.
+- Add a **CV-upload path to the onboarding wizard** (`/jobs`): a signed-in user uploads a résumé and the wizard's focus (categories) and seniority — both now **multi-select** — plus stack (skills) are pre-filled, and the wizard **stays on the current step** so the user reviews the pills (a short note reports what filled). Anonymous visitors are prompted to sign in first (the résumé endpoint is cookie-only); on error the wizard falls back to manual entry.
+- **Bonus:** `ProfileForm` on `/my/profile` pre-fills `specializations` from the returned `categories` (it already merges the returned `skills`), respecting the specialization cap, so a CV upload there populates the whole profile.
+
+## Capabilities
+
+### New Capabilities
+- `cv-autofill`: Derive a résumé's seniority, categories, and skills via the existing deterministic dictionaries and pre-fill them into the onboarding wizard (and the profile form), so a signed-in visitor can configure their feed from a CV upload instead of by hand.
+
+### Modified Capabilities
+<!-- None: this refactors the resume-extract response additively and reuses resume-storage / deterministic-facets without changing their requirements. -->
+
+## Impact
+
+- **Backend** (`internal/`): refactor `internal/handler/resume.go` `ExtractResumeProfile` (renamed from `ExtractResumeSkills`) to run `classify` over a `resumeHeadline` helper and return the extra fields; add `classify.Categories` for the multi-category set. Reuses `internal/skilltag`, `internal/classify`, `enrich` vocabularies, and the existing résumé store + embed.
+- **Frontend** (`web/`): `OnboardingWizard.svelte` gains the CV-upload affordance + parsing/error states, makes Focus and Seniority multi-select, and applies the result to `sel`; `web/src/lib/api.ts` `extractResumeProfile` (renamed) returns the widened shape; `ProfileForm.svelte` merges `categories` into specializations; auth gate via `openAuthDialog`.
+- **No DB migration, no new endpoint, no LLM dependency.** The `extract` response is widened additively (existing `skills` consumers unaffected).

--- a/openspec/changes/cv-autofill-onboarding/specs/cv-autofill/spec.md
+++ b/openspec/changes/cv-autofill-onboarding/specs/cv-autofill/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Résumé extraction returns a structured profile from dictionaries
+
+The system SHALL derive a résumé's skills, seniority, and the categories it spans from the uploaded résumé using only the existing deterministic dictionaries, and MUST NOT guess — a grade it cannot resolve is omitted and the category set is empty when nothing resolves.
+
+Skills come from the skilltag dictionary over the whole résumé (skills appear anywhere). Seniority and categories come from the classify dictionary over the résumé's *headline* — the leading title and summary words, with contact/metadata tokens (email, phone, profile URL, bare numbers, punctuation) dropped and whitespace collapsed so a PDF that extracts one token per line still reaches the title, while the career-history section below cannot reach in and over-promote the grade. Categories are every category the headline mentions (a person can be several — backend and ML), distinct and in precedence order. The extraction uses no LLM, so it stays instant and does not depend on the LLM configuration. `skills` and `categories` are always arrays (empty when nothing resolves); `seniority` is omitted when unresolved. The résumé is stored and embedded as before, and the endpoint remains authenticated.
+
+#### Scenario: A résumé yields the fields the dictionaries resolve
+
+- **WHEN** a signed-in user submits a résumé that names a recognizable role and known skills
+- **THEN** the response includes the canonical skills, the resolved seniority, and every category the headline resolves
+
+#### Scenario: A résumé spanning several functions returns every category
+
+- **WHEN** the résumé's headline names more than one specialization (e.g. backend and data engineering)
+- **THEN** the response's categories include all of them, in precedence order
+
+#### Scenario: Unresolved fields are omitted or empty, never guessed
+
+- **WHEN** the dictionaries cannot resolve a field from the résumé (e.g. no recognizable seniority)
+- **THEN** seniority is omitted and categories is empty, while the fields that did resolve are returned
+
+#### Scenario: Extraction does not require the LLM
+
+- **WHEN** the LLM integration is not configured
+- **THEN** résumé extraction still returns skills and any dictionary-resolved seniority/categories
+
+#### Scenario: Existing skills callers are unaffected
+
+- **WHEN** a client that reads only the skills field submits a résumé
+- **THEN** the skills are returned exactly as before, regardless of the added fields
+
+### Requirement: The onboarding wizard can pre-fill from a résumé
+
+The system SHALL offer a résumé-upload path in the onboarding wizard that pre-fills the wizard's focus (categories) and seniority — both multi-select — and stack (skills) from the extraction, and SHALL stay on the current step so the user reviews the pre-filled pills rather than being advanced past them. Work mode and region are left to the user, since a résumé does not state them.
+
+Because résumé extraction is authenticated, an unauthenticated visitor is prompted to sign in before uploading. A failed or empty extraction never blocks the wizard: the visitor continues with manual entry and a short note reports what was (or was not) filled. Only the fields the extraction resolved are pre-filled, merged into any manual selection without dropping it; the rest stay empty for the user to pick.
+
+#### Scenario: Upload pre-fills in place for review
+
+- **WHEN** a signed-in visitor uploads a résumé in the wizard
+- **THEN** the wizard pre-fills the resolved focus (possibly several), seniority, and stack, and stays on the current step so the visitor can review and correct them
+
+#### Scenario: Anonymous visitor is asked to sign in first
+
+- **WHEN** an unauthenticated visitor chooses the résumé-upload path
+- **THEN** they are prompted to sign in before the résumé is uploaded
+
+#### Scenario: A failed extraction falls back to manual
+
+- **WHEN** the résumé cannot be read or resolves nothing
+- **THEN** a note or error is shown and the visitor can continue configuring the feed manually
+
+### Requirement: The profile form pre-fills its specializations from a résumé
+
+The system SHALL, on the profile page, pre-fill the profile's specializations from the résumé's resolved categories — reusing the same extraction that already fills the profile's skills, respecting the specialization cap — so a single upload populates the whole profile.
+
+#### Scenario: Résumé upload fills specializations and skills
+
+- **WHEN** a user uploads a résumé on the profile page
+- **THEN** the résumé's resolved categories are merged into the profile's specializations (up to the cap) and its skills into the profile's skills

--- a/openspec/changes/cv-autofill-onboarding/tasks.md
+++ b/openspec/changes/cv-autofill-onboarding/tasks.md
@@ -1,0 +1,28 @@
+## 1. Backend — widen résumé extraction (dictionaries)
+
+- [x] 1.1 Add a `resumeHeadline(text)` helper that collapses whitespace, drops contact/metadata tokens (email/phone/URL/bare-number/punctuation), and returns a bounded leading window (title + summary top) so the title dictionaries reach the title but not the career history.
+- [x] 1.2 Add `classify.Categories(text) → []string` (every category the text names, distinct, precedence order) alongside `Parse`.
+- [x] 1.3 Add a `resumeProfile(text) → {skills, seniority, categories}` helper composing `skilltag.Parse` (skills, whole text) and `classify` over the headline (seniority + categories). No LLM; `skills`/`categories` never nil.
+- [x] 1.4 Refactor the handler (renamed `ExtractResumeSkills` → `ExtractResumeProfile`, `internal/handler/resume.go`) to call the helper and return `{"data": {skills, categories, seniority?}}` (omit empty seniority); keep the résumé store + `embedResume` side effects and cookie-auth unchanged.
+- [x] 1.5 Unit tests (Go): `resumeProfile` resolves seniority/categories/skills from sample text incl. a contact-first layout and a one-token-per-line PDF shape; grade words in the career history don't over-promote; multiple categories are all surfaced; `classify.Categories` dedup + precedence; handler still 401s without auth and 400s on empty input.
+
+## 2. Frontend API + types
+
+- [x] 2.1 `web/src/lib/api.ts`: rename `extractResumeSkills` → `extractResumeProfile` returning `ResumeProfile { skills: string[]; categories: string[]; seniority?: string }`; add the type in `types.ts`.
+
+## 3. Onboarding wizard — CV path (`OnboardingWizard.svelte`)
+
+- [x] 3.1 Add a "Upload CV — autofill" affordance (step 1) alongside the manual pickers, plus `idle`/`parsing`/`error` state and a result note.
+- [x] 3.2 On choose: if `!isAuthenticated()` → `openAuthDialog()` (upload only once signed in — no file-across-redirect handoff); else open the file picker.
+- [x] 3.3 Make Focus and Seniority multi-select (`specializations[]`/`seniorities[]` on `OnboardingSelection`; shared `toggleIn`/`multiPills`); `selectionsToQuery` maps the arrays to the category/seniority facets.
+- [x] 3.4 On file: call `extractResumeProfile`, merge `categories`/`seniority`/`skills` into `sel` (dedup, keep manual picks), stay on the current step for review, and set a note; a generation guard drops a stale parse; error/empty → retryable note, manual path intact.
+
+## 4. Profile-form bonus (`ProfileForm.svelte`)
+
+- [x] 4.1 Merge the returned `categories` into `specializations` (respecting the cap), mirroring the existing skills merge, with an accurate added/capped/nothing note.
+
+## 5. Verify
+
+- [x] 5.1 `go build ./... && go vet ./...` and `go test ./...` green; svelte-check and vitest green; lint clean on changed files.
+- [x] 5.2 Visual verification (throwaway route + headless Chrome): the wizard CV affordance; the parsing/error/note states; a signed-in upload pre-fills multiple focus + seniority + stack and stays on step 1 for review; the manual path unaffected.
+- [x] 5.3 Confirm the profile page still fills skills and now fills specializations from a résumé; confirm existing `{skills}` behavior is unchanged (additive response).

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   Verdict,
   ATSResponse,
   JobMatch,
+  ResumeProfile,
 } from './types';
 
 /** A page of list items, optionally the total matching the query (endpoints that
@@ -536,14 +537,16 @@ export function createApi(
     return { method, body: form };
   }
 
-  /** Extract canonical skill slugs from a resume — a PDF `File` (sent as multipart) or
-   *  pasted text (sent as JSON). Skills come back ready to merge into a profile. */
-  async function extractResumeSkills(input: File | string): Promise<string[]> {
-    const res = await request<{ data: { skills: string[] } }>(
+  /** Derive a résumé's profile — a PDF `File` (sent as multipart) or pasted text (sent
+   *  as JSON) — via the deterministic dictionaries: canonical skills plus the
+   *  specializations and seniority resolved, ready to pre-fill a profile or the onboarding
+   *  wizard. */
+  async function extractResumeProfile(input: File | string): Promise<ResumeProfile> {
+    const res = await request<{ data: ResumeProfile }>(
       '/api/v1/me/resume/extract',
       resumeInit('POST', input),
     );
-    return res.data.skills;
+    return res.data;
   }
 
   /** The market-coverage verdict for the caller's profile: how many open vacancies the
@@ -751,7 +754,7 @@ export function createApi(
     getProfile,
     saveProfile,
     deleteProfile,
-    extractResumeSkills,
+    extractResumeProfile,
     getProfileVerdict,
     getATSReport,
     runATSReview,
@@ -824,7 +827,7 @@ export const {
   getProfile,
   saveProfile,
   deleteProfile,
-  extractResumeSkills,
+  extractResumeProfile,
   getProfileVerdict,
   getATSReport,
   runATSReview,

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ArrowUp, Check, X } from '@lucide/svelte';
-  import { ApiError, extractResumeSkills, facetCounts } from '$lib/api';
+  import { ApiError, extractResumeProfile, facetCounts } from '$lib/api';
   import { CATEGORY_OPTIONS, categoryLabel, type FacetOption } from '$lib/facets';
   import { profileStore } from '$lib/profile.svelte';
   import type { UserProfile } from '$lib/types';
@@ -78,27 +78,44 @@
     void loadSkills();
   });
 
-  // Extract skills from a résumé PDF and merge them into the skills field as a
-  // deduplicated union, preserving anything already entered. The upload also stores the
-  // CV server-side, so notify the parent to refresh the CV-readiness state.
+  // Derive skills + specialization from a résumé PDF and merge them into the fields as a
+  // deduplicated union, preserving anything already entered (the specialization respects
+  // the cap). The upload also stores the CV server-side, so notify the parent to refresh
+  // the CV-readiness state.
   async function analyzeResume(file: File) {
     resumeBusy = true;
     resumeError = null;
     resumeNote = null;
     try {
-      const extracted = await extractResumeSkills(file);
+      const cv = await extractResumeProfile(file);
       onCvUploaded?.();
-      if (extracted.length === 0) {
-        resumeNote = 'No known skills found in the CV.';
-        return;
+
+      const beforeSkills = skills.length;
+      skills = [...new Set([...skills, ...cv.skills])];
+      const addedSkills = skills.length - beforeSkills;
+
+      // Merge every specialization the CV resolved, respecting the cap; track how many
+      // were added vs. left out by the cap so the note is accurate.
+      let addedSpecs = 0;
+      let cappedSpecs = 0; // resolved but the cap left no room
+      for (const cat of cv.categories) {
+        if (specializations.includes(cat)) continue;
+        if (specializations.length < MAX_SPECIALIZATIONS) {
+          specializations = [...specializations, cat];
+          addedSpecs++;
+        } else {
+          cappedSpecs++;
+        }
       }
-      const before = skills.length;
-      skills = [...new Set([...skills, ...extracted])];
-      const added = skills.length - before;
-      resumeNote =
-        added > 0
-          ? `Added ${added} skill${added === 1 ? '' : 's'} from your CV.`
-          : 'All CV skills were already listed.';
+
+      const parts: string[] = [];
+      if (addedSkills > 0) parts.push(`${addedSkills} skill${addedSkills === 1 ? '' : 's'}`);
+      if (addedSpecs > 0) parts.push(`${addedSpecs} specialization${addedSpecs === 1 ? '' : 's'}`);
+      if (parts.length) resumeNote = `Added ${parts.join(' and ')} from your CV.`;
+      else if (cappedSpecs > 0)
+        resumeNote = `Reached the ${MAX_SPECIALIZATIONS}-specialization limit — nothing more added.`;
+      else if (cv.skills.length === 0 && cv.categories.length === 0) resumeNote = 'No known skills found in the CV.';
+      else resumeNote = 'Everything from your CV was already listed.';
     } catch (err) {
       resumeError = err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';
     } finally {

--- a/web/src/lib/components/onboarding/OnboardingWizard.svelte
+++ b/web/src/lib/components/onboarding/OnboardingWizard.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { ArrowLeft, ArrowRight, Sparkles, X } from '@lucide/svelte';
+  import { ArrowLeft, ArrowRight, FileUp, LoaderCircle, Sparkles, X } from '@lucide/svelte';
+  import { ApiError, extractResumeProfile } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import {
     FACETS,
     CATEGORY_OPTIONS,
@@ -49,28 +52,92 @@
   let step = $state(1);
   let sel = $state<OnboardingSelection>(emptySelection());
 
+  // CV auto-fill: a résumé pre-fills focus/seniority/stack (the fields our dictionaries
+  // resolve) in place, so the user reviews them on step 1 rather than being advanced past
+  // it. The extract endpoint is authenticated, so an anonymous visitor signs in first; the
+  // file is chosen only once signed in.
+  let cvState = $state<'idle' | 'parsing' | 'error'>('idle');
+  let cvError = $state<string | null>(null);
+  let cvNote = $state<string | null>(null);
+  let cvInput = $state<HTMLInputElement>();
+  // Bumped on each pick and on wizard re-open, so a parse that resolves late (or after
+  // the wizard was closed and reopened) can't clobber a fresh selection.
+  let cvGen = 0;
+
+  function pickCv() {
+    if (!isAuthenticated()) {
+      openAuthDialog();
+      return;
+    }
+    cvInput?.click();
+  }
+
+  async function onCvFile(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = ''; // allow re-picking the same file after an error
+    if (!file) return;
+    const gen = ++cvGen;
+    cvState = 'parsing';
+    cvError = null;
+    cvNote = null;
+    try {
+      const cv = await extractResumeProfile(file);
+      if (gen !== cvGen) return; // superseded by another pick or a wizard reset
+      const resolved = cv.categories.length > 0 || !!cv.seniority || cv.skills.length > 0;
+      // Pre-fill the fields the dictionaries resolved and stay on step 1, so the user
+      // reviews (and can correct) the focus/seniority the pills now show — we never skip
+      // that review by jumping ahead. Focus and stack merge (a CV can add several) without
+      // dropping anything already picked.
+      sel = {
+        ...sel,
+        specializations: cv.categories.length
+          ? [...new Set([...sel.specializations, ...cv.categories])]
+          : sel.specializations,
+        seniorities: cv.seniority ? [...new Set([...sel.seniorities, cv.seniority])] : sel.seniorities,
+        stack: cv.skills.length ? [...new Set([...sel.stack, ...cv.skills])] : sel.stack,
+      };
+      cvState = 'idle';
+      cvNote = resolved ? 'Filled in what we found — review below.' : 'Couldn’t read details from that CV — pick below.';
+    } catch (err) {
+      if (gen !== cvGen) return;
+      cvState = 'error';
+      cvError = err instanceof ApiError ? err.message : 'Could not read the CV. Please try again.';
+    }
+  }
+
   // Reset staged state each time the wizard opens, so a re-open starts fresh.
   let wasOpen = false;
   $effect(() => {
     if (open && !wasOpen) {
       step = 1;
       sel = emptySelection();
+      cvState = 'idle';
+      cvError = null;
+      cvNote = null;
+      cvGen++; // invalidate any parse still in flight from a previous open
     }
     wasOpen = open;
   });
 
-  // Coarse facets are single-select in the wizard (the full FilterModal covers
+  // Work-mode/region stay single-select in the wizard (the full FilterModal covers
   // multi-select afterward): clicking the active value clears it.
-  function pickOne(field: 'specialization' | 'seniority' | 'workMode' | 'region', value: string) {
+  function pickOne(field: 'workMode' | 'region', value: string) {
     sel = { ...sel, [field]: sel[field] === value ? undefined : value };
   }
 
-  // Stack is multi-select from the skills suggestions: toggle a skill in/out.
-  function toggleStack(value: string) {
-    sel = sel.stack.includes(value)
-      ? { ...sel, stack: sel.stack.filter((s) => s !== value) }
-      : { ...sel, stack: [...sel.stack, value] };
+  // toggleIn adds/removes a value from one of the selection's array fields — the shared
+  // primitive behind the multi-select pill groups (Focus, Seniority, Stack).
+  function toggleIn(field: 'specializations' | 'seniorities' | 'stack', value: string) {
+    const cur = sel[field];
+    sel = { ...sel, [field]: cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value] };
   }
+
+  // Focus is multi-select — a person can be several specializations (a CV can pre-fill
+  // more than one). Seniority is multi-select too — a search can span a grade range.
+  const toggleSpecialization = (value: string) => toggleIn('specializations', value);
+  const toggleSeniority = (value: string) => toggleIn('seniorities', value);
+  const toggleStack = (value: string) => toggleIn('stack', value);
 
   function complete() {
     onComplete(selectionsToQuery(sel));
@@ -84,7 +151,7 @@
 <svelte:window onkeydown={open ? onKeydown : undefined} />
 
 <!-- One single-select pill group; the active value clears on re-click (see pickOne). -->
-{#snippet pills(field: 'specialization' | 'seniority' | 'workMode' | 'region', options: FacetOption[])}
+{#snippet pills(field: 'workMode' | 'region', options: FacetOption[])}
   <div class="flex flex-wrap gap-2">
     {#each options as o (o.value)}
       <button
@@ -94,6 +161,25 @@
         class={[
           'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
           sel[field] === o.value ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-card hover:bg-accent',
+        ]}
+      >
+        {o.label}
+      </button>
+    {/each}
+  </div>
+{/snippet}
+
+<!-- A multi-select pill group: each pill toggles independently (Focus, Seniority). -->
+{#snippet multiPills(selected: string[], options: FacetOption[], toggle: (value: string) => void)}
+  <div class="flex flex-wrap gap-2">
+    {#each options as o (o.value)}
+      <button
+        type="button"
+        onclick={() => toggle(o.value)}
+        aria-pressed={selected.includes(o.value)}
+        class={[
+          'rounded-full border px-3 py-1.5 text-sm font-medium transition-colors',
+          selected.includes(o.value) ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-card hover:bg-accent',
         ]}
       >
         {o.label}
@@ -145,11 +231,40 @@
           <h2 class="text-xl font-semibold tracking-tight">What do you do?</h2>
           <p class="mt-1 text-sm text-muted-foreground">Pick your focus and level — everything's optional.</p>
 
-          <p class="mb-2 mt-5 text-sm font-medium">Focus</p>
-          {@render pills('specialization', specializationOptions)}
+          <!-- CV auto-fill: pre-fills focus/seniority/stack, then jumps to review. -->
+          <input
+            type="file"
+            accept=".pdf,application/pdf"
+            bind:this={cvInput}
+            onchange={onCvFile}
+            class="hidden"
+          />
+          <button
+            type="button"
+            onclick={pickCv}
+            disabled={cvState === 'parsing'}
+            class="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border bg-card px-4 py-3 text-sm font-medium transition-colors hover:border-primary hover:bg-accent disabled:opacity-60"
+          >
+            {#if cvState === 'parsing'}
+              <LoaderCircle class="size-4 animate-spin" aria-hidden="true" /> Reading your CV…
+            {:else}
+              <FileUp class="size-4" aria-hidden="true" /> Upload CV — autofill
+            {/if}
+          </button>
+          {#if cvState === 'error'}
+            <p class="mt-2 text-xs text-destructive">{cvError} Or fill it in below.</p>
+          {:else if cvNote}
+            <p class="mt-2 text-xs text-muted-foreground">{cvNote}</p>
+          {/if}
+          <div class="my-4 flex items-center gap-3 text-xs text-muted-foreground">
+            <span class="h-px flex-1 bg-border"></span> or answer 2 questions <span class="h-px flex-1 bg-border"></span>
+          </div>
 
-          <p class="mb-2 mt-6 text-sm font-medium">Seniority</p>
-          {@render pills('seniority', seniorityOptions)}
+          <p class="mb-2 text-sm font-medium">Focus <span class="font-normal text-muted-foreground">— pick any</span></p>
+          {@render multiPills(sel.specializations, specializationOptions, toggleSpecialization)}
+
+          <p class="mb-2 mt-6 text-sm font-medium">Seniority <span class="font-normal text-muted-foreground">— pick any</span></p>
+          {@render multiPills(sel.seniorities, seniorityOptions, toggleSeniority)}
         {:else}
           <h2 class="text-xl font-semibold tracking-tight">Where and how?</h2>
           <p class="mt-1 text-sm text-muted-foreground">Work format, region, and stack.</p>

--- a/web/src/lib/onboarding.test.ts
+++ b/web/src/lib/onboarding.test.ts
@@ -37,14 +37,24 @@ describe('selectionsToQuery', () => {
   });
 
   it('maps a role-only selection to the category facet', () => {
-    const f = facetsOf({ ...emptySelection(), specialization: 'backend' });
+    const f = facetsOf({ ...emptySelection(), specializations: ['backend'] });
     expect(f.category?.include).toEqual(['backend']);
     expect(f.seniority?.include).toEqual([]);
     expect(f.skills?.include).toEqual([]);
   });
 
+  it('maps several specializations to the category facet', () => {
+    const f = facetsOf({ ...emptySelection(), specializations: ['backend', 'ai_engineering'] });
+    expect(f.category?.include).toEqual(['backend', 'ai_engineering']);
+  });
+
+  it('maps several seniorities to the seniority facet (grade range)', () => {
+    const f = facetsOf({ ...emptySelection(), seniorities: ['middle', 'senior'] });
+    expect(f.seniority?.include).toEqual(['middle', 'senior']);
+  });
+
   it('round-trips a role + stack selection', () => {
-    const sel: OnboardingSelection = { ...emptySelection(), specialization: 'backend', stack: ['Go', 'Kubernetes'] };
+    const sel: OnboardingSelection = { ...emptySelection(), specializations: ['backend'], stack: ['Go', 'Kubernetes'] };
     const f = facetsOf(sel);
     expect(f.category?.include).toEqual(['backend']);
     expect(f.skills?.include).toEqual(['Go', 'Kubernetes']);
@@ -52,8 +62,8 @@ describe('selectionsToQuery', () => {
 
   it('round-trips a full selection across all five facets', () => {
     const sel: OnboardingSelection = {
-      specialization: 'frontend',
-      seniority: 'senior',
+      specializations: ['frontend'],
+      seniorities: ['senior'],
       workMode: 'remote',
       region: 'eu',
       stack: ['TypeScript'],
@@ -74,7 +84,7 @@ describe('selectionsToQuery', () => {
 
 describe('narrowestFacet', () => {
   it('returns null when no relaxable facet is set', () => {
-    const f = filtersFromParams(new URLSearchParams(selectionsToQuery({ ...emptySelection(), specialization: 'backend' })));
+    const f = filtersFromParams(new URLSearchParams(selectionsToQuery({ ...emptySelection(), specializations: ['backend'] })));
     // only category (never relaxed) is set
     expect(narrowestFacet(f)).toBeNull();
   });
@@ -82,18 +92,18 @@ describe('narrowestFacet', () => {
   it('peels stack first, then region, then seniority — never the role', () => {
     const full = filtersFromParams(
       new URLSearchParams(
-        selectionsToQuery({ specialization: 'backend', seniority: 'senior', workMode: undefined, region: 'eu', stack: ['Go'] }),
+        selectionsToQuery({ specializations: ['backend'], seniorities: ['senior'], workMode: undefined, region: 'eu', stack: ['Go'] }),
       ),
     );
     expect(narrowestFacet(full)).toBe('skills');
 
     const noStack = filtersFromParams(
-      new URLSearchParams(selectionsToQuery({ ...emptySelection(), specialization: 'backend', seniority: 'senior', region: 'eu' })),
+      new URLSearchParams(selectionsToQuery({ ...emptySelection(), specializations: ['backend'], seniorities: ['senior'], region: 'eu' })),
     );
     expect(narrowestFacet(noStack)).toBe('regions');
 
     const seniorityOnly = filtersFromParams(
-      new URLSearchParams(selectionsToQuery({ ...emptySelection(), specialization: 'backend', seniority: 'senior' })),
+      new URLSearchParams(selectionsToQuery({ ...emptySelection(), specializations: ['backend'], seniorities: ['senior'] })),
     );
     expect(narrowestFacet(seniorityOnly)).toBe('seniority');
   });

--- a/web/src/lib/onboarding.ts
+++ b/web/src/lib/onboarding.ts
@@ -12,10 +12,12 @@ import { emptyFilters, filtersToParams, type JobFilters } from './facetModel';
 // skippable per field, and an empty field contributes no filter constraint.
 // Each maps to one existing job facet param (see selectionsToQuery).
 export interface OnboardingSelection {
-  /** Coarse specialization → the `category` facet (Backend, Frontend, ML/AI, …). */
-  specialization?: string;
-  /** → the `seniority` facet. */
-  seniority?: string;
+  /** Specializations → the `category` facet (Backend, Frontend, ML/AI, …). Multi-select:
+   *  a person can be several (a CV upload can pre-fill more than one). */
+  specializations: string[];
+  /** Seniorities → the `seniority` facet. Multi-select: a search can span a grade range
+   *  (Middle + Senior), though a CV pre-fills the single current grade. */
+  seniorities: string[];
   /** → the `work_mode` facet. */
   workMode?: string;
   /** → the `regions` facet (macro region code). */
@@ -25,7 +27,7 @@ export interface OnboardingSelection {
 }
 
 export function emptySelection(): OnboardingSelection {
-  return { stack: [] };
+  return { specializations: [], seniorities: [], stack: [] };
 }
 
 /** Map the wizard's selection onto the existing filter query string, via the same
@@ -34,8 +36,8 @@ export function emptySelection(): OnboardingSelection {
  *  No hand-written param strings: the facet-param contract stays in facetModel. */
 export function selectionsToQuery(sel: OnboardingSelection): string {
   const f = emptyFilters();
-  if (sel.specialization) f.facets.category!.include = [sel.specialization];
-  if (sel.seniority) f.facets.seniority!.include = [sel.seniority];
+  if (sel.specializations.length) f.facets.category!.include = [...sel.specializations];
+  if (sel.seniorities.length) f.facets.seniority!.include = [...sel.seniorities];
   if (sel.workMode) f.facets.work_mode!.include = [sel.workMode];
   if (sel.region) f.facets.regions!.include = [sel.region];
   const stack = sel.stack.map((s) => s.trim()).filter(Boolean);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -295,3 +295,13 @@ export interface TelegramStatus {
   linked: boolean;
   chat_id?: number;
 }
+
+/** What a résumé yields through the deterministic dictionaries: canonical skills and
+ *  every specialization the résumé spans, plus the seniority grade. `skills` and
+ *  `categories` are always arrays (empty when nothing resolved); `seniority` is omitted
+ *  when unresolved (never guessed). */
+export interface ResumeProfile {
+  skills: string[];
+  categories: string[];
+  seniority?: string;
+}


### PR DESCRIPTION
## What

Widen `POST /me/resume/extract` to return `{skills, categories, seniority?}` (renamed `ExtractResumeSkills` → `ExtractResumeProfile`), all from the existing deterministic dictionaries — **no LLM**. The onboarding wizard gains a **"Upload CV — autofill"** path, and `ProfileForm` pre-fills specializations too.

## Backend
- `resumeHeadline` collapses whitespace (robust to one-token-per-line PDF extraction), drops contact/number/punctuation tokens, and bounds a leading window so `classify` reaches the title but not the career history (no grade over-promotion from "reported to the Head of Eng").
- `classify.Categories` returns **every** category the headline spans (distinct, precedence order); `classify.Parse` still supplies the single grade.
- `skills`/`categories` always arrays; `seniority` omitted when unresolved (never guessed). Résumé store + embed side-effects and cookie-auth unchanged.

## Frontend
- Wizard: signed-in upload pre-fills **Focus (now multi-select)** + **Seniority (now multi-select)** + Stack and **stays on step 1** for review (with a note); anonymous → sign-in; failure → manual fallback. Shared `toggleIn`/`multiPills`; generation guard drops a stale parse.
- `OnboardingSelection`: `specialization` → `specializations[]`, `seniority` → `seniorities[]`; `selectionsToQuery` maps arrays to the category/seniority facets.
- `ProfileForm` merges returned `categories` into specializations (respecting the cap).

## Tests
- Go: `classify.Categories` (dedup/precedence), `resumeProfile` (contact-first layout, one-token-per-line PDF shape, buried-grade non-promotion, multi-category). All `go test ./...` green.
- Web: `onboarding.test.ts` updated for arrays + multi cases; svelte-check 0/0, vitest 112/112.

No DB migration, no new endpoint, no LLM dependency. OpenSpec change `cv-autofill-onboarding` included.