### PR TITLE
chore: bump Go to 1.25.12 (fix GO-2026-5856)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
           cache: true
 
       - name: Build

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.x'
+          go-version-file: go.mod
           cache: true
 
       - name: Install govulncheck

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strelov1/freehire
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/abadojack/whatlanggo v1.0.1


### PR DESCRIPTION
Bumps the `go` directive to 1.25.12 to pick up the fixed `crypto/tls` standard library.

`govulncheck` on main flags **GO-2026-5856** (Encrypted Client Hello privacy leak in `crypto/tls`, *Fixed in go1.25.12*), reachable via `sources/http.go`, `resume.go`, etc. — a stdlib advisory, not our code. go1.25.12 is released; CI's setup-go `1.25.x` installs it.

Verified locally: `go build ./...` clean on 1.25.12, `govulncheck ./...` → **No vulnerabilities found**.