### PR TITLE
feat(web): fold company filters into grouped panes

### DIFF
--- a/web/src/lib/components/filters/CompanyFilterModal.svelte
+++ b/web/src/lib/components/filters/CompanyFilterModal.svelte
@@ -9,24 +9,44 @@
 
   // The companies-catalog filter modal: a thin wrapper over FilterModalShell, the
   // company counterpart of FilterModal. All company facets are plain include-only
-  // controls, so the rail is a single `FILTERS` section of FacetSection panes and the
-  // footer just applies (no per-facet count endpoint to preview against).
+  // controls, so the rail is a single `FILTERS` section and the footer just applies
+  // (no per-facet count endpoint to preview against).
+  //
+  // The rail is a presentation grouping over COMPANY_FACETS, not 1:1 with it (mirroring
+  // the job modal's RAIL): related facets fold into one pane that stacks their
+  // FacetSections, so the closely-linked geography, company-shape, and YC-directory
+  // facets read as three panes instead of scattering across seven rail rows. Each param
+  // stays a distinct query param — only the presentation is grouped.
   let { store, open = false, onClose }: { store: CompanyFilterStore; open?: boolean; onClose: () => void } = $props();
 
   const staged = new StagedCompanyFilters();
 
-  const rail: RailEntry[] = COMPANY_FACETS.map((def) => ({
-    key: def.param,
-    label: def.label,
+  // Rail groups: each pane renders the FacetSections for its `params`, in order. A
+  // single-facet group is just its own pane (Collection/Country/Industry). Every
+  // COMPANY_FACETS param appears in exactly one group.
+  const GROUPS: { key: string; label: string; params: string[] }[] = [
+    { key: 'collections', label: 'Collection', params: ['collections'] },
+    { key: 'region', label: 'Region', params: ['regions', 'remote_regions'] },
+    { key: 'countries', label: 'Country', params: ['countries'] },
+    { key: 'domains', label: 'Industry', params: ['domains'] },
+    { key: 'company', label: 'Company', params: ['company_type', 'company_size'] },
+    { key: 'yc', label: 'Y Combinator', params: ['yc_status', 'yc_stage', 'yc_flags', 'yc_batch'] },
+  ];
+
+  const rail: RailEntry[] = GROUPS.map((g) => ({
+    key: g.key,
+    label: g.label,
     section: 'FILTERS',
     kind: 'facet',
-    facetParam: def.param,
   }));
   const sections: RailSection[] = ['FILTERS'];
 
-  // Company facets are include-only, so the badge is just the selected count.
+  const paramsOf = (key: string) => GROUPS.find((g) => g.key === key)?.params ?? [];
+
+  // Company facets are include-only, so the badge is the total selected across the
+  // group's params.
   function entryCount(e: RailEntry): number {
-    return staged.facet(e.facetParam ?? e.key).include.length;
+    return paramsOf(e.key).reduce((n, p) => n + staged.facet(p).include.length, 0);
   }
 
   function seed() {
@@ -53,6 +73,11 @@
 />
 
 {#snippet pane(entry: RailEntry, _live: FacetCounts | null)}
-  {@const def = COMPANY_FACETS.find((d) => d.param === entry.facetParam)}
-  {#if def}<FacetSection {def} store={staged} expand />{/if}
+  {@const params = paramsOf(entry.key)}
+  <div class="space-y-4">
+    {#each params as param (param)}
+      {@const def = COMPANY_FACETS.find((d) => d.param === param)}
+      {#if def}<FacetSection {def} store={staged} expand />{/if}
+    {/each}
+  </div>
 {/snippet}

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -425,7 +425,7 @@ export const COMPANY_FACETS: FacetDef[] = [
   { param: 'company_size', label: 'Company size', control: 'pills', options: COMPANY_SIZE, excludable: false },
   { param: 'yc_status', label: 'YC status', control: 'pills', options: YC_STATUS, excludable: false },
   { param: 'yc_stage', label: 'YC stage', control: 'pills', options: YC_STAGE, excludable: false },
-  { param: 'yc_flags', label: 'YC', control: 'pills', options: YC_FLAGS, excludable: false },
+  { param: 'yc_flags', label: 'YC highlights', control: 'pills', options: YC_FLAGS, excludable: false },
   { param: 'yc_batch', label: 'YC batch', control: 'select', options: YC_BATCH, excludable: false, placeholder: 'Search YC batches' },
 ];
 


### PR DESCRIPTION
## What

The companies filter modal rail was built 1:1 with `COMPANY_FACETS` (11 rows). This folds related facets into composite panes, mirroring the job modal's `RAIL`:

| Pane | Folds |
|------|-------|
| Collection | `collections` |
| **Region** | `regions` + `remote_regions` |
| Country | `countries` |
| Industry | `domains` |
| **Company** | `company_type` + `company_size` |
| **Y Combinator** | `yc_status` + `yc_stage` + `yc_flags` + `yc_batch` |

11 rail rows → 6. Also relabels `yc_flags` `"YC"` → `"YC highlights"` (a subsection titled "YC" under a "Y Combinator" pane read oddly).

## Why

Presentation-only. Each `param` stays a distinct query param — the model (`companyFacetModel`), URL serialization, and summary chips (`CompanyFilterSummary`) iterate `COMPANY_FACETS` flatly and are unchanged. Small diff (2 files).

## Verification

- Browsed the companies filter modal against prod data: rail groups render, composite panes stack their sub-sections, rail badge sums selections across a group's params.
- `svelte-check`: 0 errors / 0 warnings
- `vitest`: 18/18 (companyFacetModel, filterStorage)