### PR TITLE
feat(sources): add 2 missing boards (Accel Club, Appercut)

### DIFF
--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18645,3 +18645,5 @@
   board: kurosbio
 - company: "SurgeonsLab AG"
   board: surgeonslab
+- company: "Accel Club"
+  board: accelclub

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3523,3 +3523,5 @@
   board: twint
 - company: "Xeltis AG"
   board: xeltis
+- company: "Appercut"
+  board: appercut


### PR DESCRIPTION
Two board entries were in local working state but never committed to main. Both verified live (HTTP 200 with real openings): `accelclub.bamboohr.com`, `appercut.recruitee.com`. YAML validates.