### PR TITLE
fix(search): order facet values by count (cities filter drops busy cities)

### DIFF
--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -669,11 +669,20 @@ func facetSettings() *meilisearch.Settings {
 		// server and SDK fields align.
 		Pagination: &meilisearch.Pagination{MaxTotalHits: maxTotalHits},
 		// Raise the per-facet value cap above Meili's default of 100 so the
-		// analytics facet distribution is not truncated for high-cardinality
-		// facets. Value ordering is done client-side by count; SortFacetValuesBy is
-		// left unset (see the TypoTolerance note above on the SDK over-serializing
-		// newer fields). Requires a reindex to take effect on an existing index.
-		Faceting: &meilisearch.Faceting{MaxValuesPerFacet: maxValuesPerFacet},
+		// distribution is not truncated for high-cardinality facets. And keep the
+		// TOP values BY COUNT, not alphabetically: cities has far more than
+		// maxValuesPerFacet distinct values, so with the default alpha ordering Meili
+		// drops the busiest cities that sort late (e.g. "Florianópolis", 1000+ jobs)
+		// from the distribution even though filtering by them works — client-side
+		// count sorting can't recover a value the engine never returned. `count`
+		// ordering makes the cap keep the most-common values and also sheds the
+		// long-tail noise (zip fragments, one-off strings). sortFacetValuesBy is a
+		// query-time setting supported since Meili v0.28, so unlike the TypoTolerance
+		// note above it is safe on the pinned server.
+		Faceting: &meilisearch.Faceting{
+			MaxValuesPerFacet: maxValuesPerFacet,
+			SortFacetValuesBy: map[string]meilisearch.SortFacetType{"*": meilisearch.SortFacetTypeCount},
+		},
 	}
 }
 

--- a/internal/search/facets_test.go
+++ b/internal/search/facets_test.go
@@ -124,6 +124,11 @@ func TestIndexSettings_FacetingRaisesValueCap(t *testing.T) {
 	if f.MaxValuesPerFacet <= 100 {
 		t.Errorf("MaxValuesPerFacet = %d, want > 100", f.MaxValuesPerFacet)
 	}
+	// The cap must keep the busiest values, not the alphabetically-first ones, or a
+	// high-cardinality facet (cities) drops popular values that sort late.
+	if got := f.SortFacetValuesBy["*"]; got != meilisearch.SortFacetTypeCount {
+		t.Errorf(`SortFacetValuesBy["*"] = %q, want %q`, got, meilisearch.SortFacetTypeCount)
+	}
 }
 
 func TestDecodeFacetDistribution(t *testing.T) {


### PR DESCRIPTION
The `cities` facet has >1200 distinct values; with `sortFacetValuesBy` unset Meili truncates the distribution **alphabetically** at `maxValuesPerFacet`, dropping high-volume cities that sort late — e.g. **Florianópolis** (1000+ jobs) never appears in the filter although `cities=Florianópolis` filtering returns 1034. Client-side count sorting runs on the already-truncated set, so it can't recover them.

Fix: `sortFacetValuesBy: {"*": count}` so the cap keeps the busiest values (and sheds long-tail zip/one-off noise). Query-time setting (Meili ≥0.28, prod v1.13) — applies via a faceting settings update, **no document reindex**.