### PR TITLE
chore(dev): bump dev Meilisearch v1.13 → v1.49.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   # huggingFace embedder downloads and runs its model inside this container, so
   # the model is cached in the meilisearch_data volume across restarts.
   meilisearch:
-    image: getmeili/meilisearch:v1.13
+    image: getmeili/meilisearch:v1.49.0
     environment:
       MEILI_MASTER_KEY: "${MEILI_MASTER_KEY:-dev-insecure-meili-key}"
       MEILI_ENV: development

--- a/openspec/changes/filter-apply-my-profile/.openspec.yaml
+++ b/openspec/changes/filter-apply-my-profile/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/filter-apply-my-profile/design.md
+++ b/openspec/changes/filter-apply-my-profile/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The jobs filter modal (`FilterModal.svelte`) is a thin, job-specific wrapper over the
+domain-agnostic `FilterModalShell.svelte`. The shell owns the chrome (header with
+title/close, sectioned rail, deferred-apply footer); the wrapper supplies the job rail,
+the `StagedFilters` edit store, and the pane controls. Selections are staged in memory
+and only reach the live URL-synced list on **Show results** (`staged.commit(store)`).
+
+Two pieces already exist and are reused wholesale:
+- `profileStore` (`profile.svelte.ts`) — loads the signed-in user's `UserProfile`
+  (`{ specializations, skills }`) once via `GET /api/v1/me/profile`, SSR-safe, null when
+  signed-out or no profile. `save` enforces a non-empty skills set, so a loaded profile is
+  never empty.
+- The `specializations → category` / `skills → skills` mapping is already the convention:
+  `/my/profile/+page.svelte` seeds a comparison filter with `append('category', spec)` and
+  `append('skills', skill)`.
+
+So this change is purely a new front-end affordance wiring those two together into the
+staged store. No backend, API, or generated-contract work.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One-click application of the user's profile to the jobs filter modal, previewed before
+  commit via the existing deferred-apply flow.
+- Reset-then-seed semantics: applying the profile clears all staged filters, then stages
+  `category` from specializations and `skills` from skills.
+- Graceful states: create-profile link when signed-in without a profile; nothing when
+  signed-out.
+- Keep `FilterModalShell` domain-agnostic (no profile concept leaks into it).
+
+**Non-Goals:**
+- No backend/API/schema changes; no new profile fields.
+- No merge/append mode — this change is reset-and-seed only (chosen deliberately below).
+- No profile editing from the modal (that stays on `/my/profile`).
+- No change to `CompanyFilterModal` or to profile-comparison reuses of `FilterModal`.
+
+## Decisions
+
+### Reset-then-seed, not merge
+Applying the profile calls `staged.clear()` then stages the two facets, so the result is
+exactly "the profile" regardless of prior staged state. Rationale: the profile expresses a
+complete "what I'm looking for"; merging into arbitrary prior selections produces a
+muddled, hard-to-reason-about result. The user still previews via **Show results** and can
+hand-tweak before committing, so nothing is lost by resetting first.
+_Alternative considered:_ merge/append — rejected as ambiguous and harder to undo.
+
+### The action lives in the header, injected by the wrapper via a new shell snippet slot
+`FilterModalShell` gains one optional `headerAction` snippet rendered in the header row.
+`FilterModal` passes the profile button/link into it. Rationale: the profile concept is
+job-specific and must not enter the shell; a single optional snippet is the minimal,
+already-established extension pattern (the shell already takes `extra`/`footerNote`
+snippets). `CompanyFilterModal` omits the slot and is unaffected.
+_Alternatives considered:_ (a) a rail tab like "My filters" — heavier, and the header is
+where a global "seed everything" action reads more naturally than a per-facet pane; (b) a
+chip on the `/jobs` page outside the modal — bypasses the preview step the deferred-apply
+contract is built around.
+
+### Visibility gating in the wrapper
+The action is shown only when `hasSavedTab`-style scope holds (full job modal:
+`savedSearches && !railKeys`) AND the user is signed in. Within that: profile present →
+**Apply my profile** button; signed-in but no profile → a `/my/profile` create link;
+signed-out → render nothing. `profileStore.ensureLoaded()` is called when the modal opens
+for a signed-in user (mirrors the existing Telegram-flag warm-up effect).
+
+### Seeding mechanism
+Add a small method to `StagedFilters`, e.g. `applyProfile(specializations, skills)`, that
+does `clear()` then stages each value through the existing `facetAdd`/`add` path for
+`category` and `skills`. Keeping it on the staged store (rather than inline in the
+component) keeps the component declarative and makes the reset+seed unit-testable without a
+DOM — consistent with how `apply(query)`/`clear()` already live there.
+
+## Risks / Trade-offs
+
+- **Stale profile in a long-lived tab** → `profileStore` caches after first load; if the
+  user edits their profile elsewhere the modal could seed stale values. Mitigation:
+  acceptable for MVP — the profile editor and the modal are the same SPA session and
+  `profileStore` updates in place on save; a full staleness story is out of scope.
+- **A specialization value no longer in the category vocabulary** → it would stage as an
+  unmatched `category` value. Mitigation: profiles are saved from the same category
+  vocabulary the facet uses, so this is not expected; the facet control simply shows the
+  value as selected, and Show-results counts reflect reality.
+- **Header real-estate on narrow screens** → one extra control next to the title.
+  Mitigation: it's a compact button/link; follow existing header responsive styling.

--- a/openspec/changes/filter-apply-my-profile/proposal.md
+++ b/openspec/changes/filter-apply-my-profile/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+A signed-in user who has filled in their profile (specializations + skills) still has
+to re-pick those same values by hand every time they open the job filters. The profile
+already encodes "the work I'm looking for" — the filter modal should be able to apply it
+in one action instead of making the user reconstruct it facet by facet.
+
+## What Changes
+
+- Add an **Apply my profile** action to the header of the jobs filter modal that, in one
+  click, resets the staged filters and seeds them from the signed-in user's profile:
+  `specializations → category` facet and `skills → skills` facet.
+- The action stages only — nothing reaches the job list until the existing **Show
+  results** commit, so the user previews the profile-derived filters (and can adjust
+  them) before applying, consistent with the modal's deferred-apply contract.
+- The action is shown only on the full jobs filter modal for a signed-in user who has a
+  saved profile. When the signed-in user has **no** profile, the header instead offers a
+  link to create one (`/my/profile`); for signed-out users nothing is shown.
+- Frontend-only. Reuses the existing `profileStore`, the `StagedFilters` store, and the
+  established `specializations → category` / `skills → skills` mapping. No backend, API,
+  or schema changes.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `filter-modal`: adds a requirement for a header action that resets and seeds the staged
+  filters from the signed-in user's profile, with a create-profile fallback.
+
+## Impact
+
+- `web/src/lib/components/filters/FilterModal.svelte` — owns the profile-apply logic
+  (job-specific).
+- `web/src/lib/components/filters/FilterModalShell.svelte` — gains one optional header
+  snippet slot so the domain wrapper can inject the action; stays domain-agnostic
+  (unchanged for `CompanyFilterModal`).
+- Reuses `web/src/lib/profile.svelte.ts` (`profileStore`) and
+  `web/src/lib/stagedFilters.svelte.ts` (`StagedFilters.clear` + facet seeding).
+- No backend, database, or generated-contract changes.

--- a/openspec/changes/filter-apply-my-profile/specs/filter-modal/spec.md
+++ b/openspec/changes/filter-apply-my-profile/specs/filter-modal/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: The filter modal can apply the signed-in user's profile
+
+The jobs filter modal SHALL offer, in its header, an **Apply my profile** action for a
+signed-in user who has a saved profile. Activating it SHALL reset the staged filters and
+then seed them from the user's profile: each profile specialization SHALL be staged as a
+`category` value and each profile skill SHALL be staged as a `skills` value. The action
+SHALL only stage — it SHALL NOT change the live job list; the seeded selection is applied
+through the existing **Show results** commit, so the user previews (and MAY adjust) the
+profile-derived filters before applying.
+
+The action SHALL appear only on the full jobs filter modal (not on reuses that restrict
+the rail to a facet subset, such as the profile-comparison modal). When the signed-in
+user has no saved profile, the header SHALL instead present a link to create one at
+`/my/profile`. When no user is signed in, neither the action nor the link SHALL appear.
+
+#### Scenario: Applying the profile resets and seeds the staged filters
+
+- **WHEN** a signed-in user with a saved profile (specializations `A`, `B`; skills `x`,
+  `y`) has some unrelated staged filters and activates **Apply my profile**
+- **THEN** the previously staged filters are cleared, the `category` facet is staged with
+  `A` and `B`, the `skills` facet is staged with `x` and `y`, and the job list is
+  unchanged until **Show results** is activated
+
+#### Scenario: Show results commits the profile-derived filters
+
+- **WHEN** the user has applied their profile in the modal and then activates **Show
+  results**
+- **THEN** the staged `category` and `skills` selections become the live (URL-synced)
+  filter state and the modal closes
+
+#### Scenario: No profile shows a create-profile link instead
+
+- **WHEN** a signed-in user who has no saved profile opens the jobs filter modal
+- **THEN** the header shows a link to create a profile at `/my/profile` and no
+  **Apply my profile** action
+
+#### Scenario: Signed-out users see neither action nor link
+
+- **WHEN** a signed-out user opens the jobs filter modal
+- **THEN** the header shows neither the **Apply my profile** action nor the
+  create-profile link

--- a/openspec/changes/filter-apply-my-profile/tasks.md
+++ b/openspec/changes/filter-apply-my-profile/tasks.md
@@ -1,0 +1,19 @@
+## 1. Staged store: reset-and-seed from a profile
+
+- [ ] 1.1 Add a unit test (vitest) for `StagedFilters.applyProfile(specializations, skills)`: given non-empty prior staged filters, it clears everything, then stages each specialization as a `category` value and each skill as a `skills` value (assert via `params()`); empty inputs leave the store cleared.
+- [ ] 1.2 Implement `applyProfile` on `StagedFilters` (`web/src/lib/stagedFilters.svelte.ts`): `clear()` then seed `category`/`skills` through the existing facet-add path. Tests green.
+
+## 2. Shell header slot
+
+- [ ] 2.1 Add an optional `headerAction` snippet prop to `FilterModalShell.svelte` and render it in the header row (next to title/close). Absent slot renders nothing; `CompanyFilterModal` unaffected.
+
+## 3. Wrapper wiring and gating
+
+- [ ] 3.1 In `FilterModal.svelte`, warm `profileStore.ensureLoaded()` when the modal opens for a signed-in user in full-job scope (mirror the existing Telegram-flag warm-up effect).
+- [ ] 3.2 Pass a `headerAction` snippet to the shell that, in full-job scope only: signed-in with a saved profile → renders an **Apply my profile** button calling `staged.applyProfile(profile.specializations, profile.skills)`; signed-in without a profile → renders a link to `/my/profile`; signed-out → renders nothing.
+- [ ] 3.3 Confirm the reuse paths (profile-comparison modal with `railKeys`, `CompanyFilterModal`) show no profile action.
+
+## 4. Verification
+
+- [ ] 4.1 Run `svelte-check` and the vitest suite; both clean.
+- [ ] 4.2 Visual verify in the running web app: open the jobs filter modal signed-in with a profile → **Apply my profile** resets and seeds `category`/`skills`, preview count updates, **Show results** commits to the URL; signed-in without a profile shows the create-profile link; signed-out shows neither.


### PR DESCRIPTION
Aligns the dev docker-compose Meili to the prod version line (prod: 1.48.3 → upgrading to 1.49.0). Dev was stale at v1.13 and couldn't open a current-version dump, blocking local upgrade dry-runs.