### PR TITLE
feat(web): clear a whole filter group from its summary heading

### DIFF
--- a/web/src/lib/components/filters/FilterSummaryShell.svelte
+++ b/web/src/lib/components/filters/FilterSummaryShell.svelte
@@ -66,7 +66,17 @@
   {:else}
     {#each groups as g (g.label)}
       <div class="flex flex-col gap-2">
-        <span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{g.label}</span>
+        <div class="flex items-center gap-1">
+          <span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">{g.label}</span>
+          <button
+            type="button"
+            aria-label="Clear {g.label}"
+            onclick={() => g.chips.forEach((c) => c.remove())}
+            class="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <X class="size-3" />
+          </button>
+        </div>
         <div class="flex flex-wrap gap-1.5">
           {#each g.chips as c (c.text)}
             <span


### PR DESCRIPTION
## What

Adds an **X next to each group heading** in the filters summary sidebar (e.g. **SPECIALIZATION**, **SKILLS**, Location, Salary…) so a user can clear an entire facet group in one click, instead of removing chips one by one.

## How

`FilterSummaryShell` already owns each chip's `remove` handler, so "clear group" is just composing them — the heading X runs `g.chips.forEach((c) => c.remove())`. No new props or store methods:

- Reload is driven by the debounced `applied` snapshot, so removing N chips in a loop still collapses into a single list reload.
- Works for composite groups too (Location = regions+countries+cities, Salary = currency+min) since it clears whatever chips the group rendered.
- Shared shell → the behavior applies to both the jobs (`FilterSummary`) and companies (`CompanyFilterSummary`) sidebars for free.

## Verify

- `svelte-check` clean.