### PR TITLE
feat: location & work-mode preferences in user profile

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -245,9 +245,10 @@ type UserJob struct {
 }
 
 type UserProfile struct {
-	UserID          int64              `json:"user_id"`
-	Skills          []string           `json:"skills"`
-	CreatedAt       pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt       pgtype.Timestamptz `json:"updated_at"`
-	Specializations []string           `json:"specializations"`
+	UserID              int64              `json:"user_id"`
+	Skills              []string           `json:"skills"`
+	CreatedAt           pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+	Specializations     []string           `json:"specializations"`
+	LocationPreferences json.RawMessage    `json:"location_preferences"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -686,8 +686,9 @@ type Querier interface {
 	// row per user; relinking from a different chat overwrites the chat_id.
 	UpsertTelegramLink(ctx context.Context, arg UpsertTelegramLinkParams) error
 	// Create-or-replace the user's one profile. The PRIMARY KEY (user_id) makes this an
-	// idempotent upsert: first save inserts, later saves overwrite specializations/skills and
-	// bump updated_at. Specializations and skills are already normalized by the service.
+	// idempotent upsert: first save inserts, later saves overwrite specializations/skills/
+	// location_preferences and bump updated_at. All fields are already normalized by the
+	// service; location_preferences is a validated JSONB block or NULL (no preferences).
 	UpsertUserProfile(ctx context.Context, arg UpsertUserProfileParams) (UserProfile, error)
 	// Apply one yc-oss directory entry, matched by slug. A new slug is inserted as a
 	// reference row (is_reference = true) with no jobs; an existing slug (job-backed or a

--- a/internal/db/queries/user_profiles.sql
+++ b/internal/db/queries/user_profiles.sql
@@ -6,14 +6,16 @@ WHERE user_id = $1;
 
 -- name: UpsertUserProfile :one
 -- Create-or-replace the user's one profile. The PRIMARY KEY (user_id) makes this an
--- idempotent upsert: first save inserts, later saves overwrite specializations/skills and
--- bump updated_at. Specializations and skills are already normalized by the service.
-INSERT INTO user_profiles (user_id, specializations, skills)
-VALUES ($1, $2, $3)
+-- idempotent upsert: first save inserts, later saves overwrite specializations/skills/
+-- location_preferences and bump updated_at. All fields are already normalized by the
+-- service; location_preferences is a validated JSONB block or NULL (no preferences).
+INSERT INTO user_profiles (user_id, specializations, skills, location_preferences)
+VALUES ($1, $2, $3, $4)
 ON CONFLICT (user_id) DO UPDATE
-SET specializations = EXCLUDED.specializations,
-    skills          = EXCLUDED.skills,
-    updated_at      = now()
+SET specializations      = EXCLUDED.specializations,
+    skills               = EXCLUDED.skills,
+    location_preferences = EXCLUDED.location_preferences,
+    updated_at           = now()
 RETURNING *;
 
 -- name: DeleteUserProfile :execrows

--- a/internal/db/user_profiles.sql.go
+++ b/internal/db/user_profiles.sql.go
@@ -7,6 +7,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 )
 
 const deleteUserProfile = `-- name: DeleteUserProfile :execrows
@@ -25,7 +26,7 @@ func (q *Queries) DeleteUserProfile(ctx context.Context, userID int64) (int64, e
 }
 
 const getUserProfile = `-- name: GetUserProfile :one
-SELECT user_id, skills, created_at, updated_at, specializations FROM user_profiles
+SELECT user_id, skills, created_at, updated_at, specializations, location_preferences FROM user_profiles
 WHERE user_id = $1
 `
 
@@ -40,31 +41,40 @@ func (q *Queries) GetUserProfile(ctx context.Context, userID int64) (UserProfile
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Specializations,
+		&i.LocationPreferences,
 	)
 	return i, err
 }
 
 const upsertUserProfile = `-- name: UpsertUserProfile :one
-INSERT INTO user_profiles (user_id, specializations, skills)
-VALUES ($1, $2, $3)
+INSERT INTO user_profiles (user_id, specializations, skills, location_preferences)
+VALUES ($1, $2, $3, $4)
 ON CONFLICT (user_id) DO UPDATE
-SET specializations = EXCLUDED.specializations,
-    skills          = EXCLUDED.skills,
-    updated_at      = now()
-RETURNING user_id, skills, created_at, updated_at, specializations
+SET specializations      = EXCLUDED.specializations,
+    skills               = EXCLUDED.skills,
+    location_preferences = EXCLUDED.location_preferences,
+    updated_at           = now()
+RETURNING user_id, skills, created_at, updated_at, specializations, location_preferences
 `
 
 type UpsertUserProfileParams struct {
-	UserID          int64    `json:"user_id"`
-	Specializations []string `json:"specializations"`
-	Skills          []string `json:"skills"`
+	UserID              int64           `json:"user_id"`
+	Specializations     []string        `json:"specializations"`
+	Skills              []string        `json:"skills"`
+	LocationPreferences json.RawMessage `json:"location_preferences"`
 }
 
 // Create-or-replace the user's one profile. The PRIMARY KEY (user_id) makes this an
-// idempotent upsert: first save inserts, later saves overwrite specializations/skills and
-// bump updated_at. Specializations and skills are already normalized by the service.
+// idempotent upsert: first save inserts, later saves overwrite specializations/skills/
+// location_preferences and bump updated_at. All fields are already normalized by the
+// service; location_preferences is a validated JSONB block or NULL (no preferences).
 func (q *Queries) UpsertUserProfile(ctx context.Context, arg UpsertUserProfileParams) (UserProfile, error) {
-	row := q.db.QueryRow(ctx, upsertUserProfile, arg.UserID, arg.Specializations, arg.Skills)
+	row := q.db.QueryRow(ctx, upsertUserProfile,
+		arg.UserID,
+		arg.Specializations,
+		arg.Skills,
+		arg.LocationPreferences,
+	)
 	var i UserProfile
 	err := row.Scan(
 		&i.UserID,
@@ -72,6 +82,7 @@ func (q *Queries) UpsertUserProfile(ctx context.Context, arg UpsertUserProfilePa
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Specializations,
+		&i.LocationPreferences,
 	)
 	return i, err
 }

--- a/internal/handler/me_profile.go
+++ b/internal/handler/me_profile.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -12,21 +13,26 @@ import (
 
 // profileResponse is the public shape of the user's single profile. user_id is omitted
 // (ownership, internal); there is no id or name. specializations are one or more job
-// categories; skills are canonical lowercase tokens.
+// categories; skills are canonical lowercase tokens; location_preferences is the stored
+// location block echoed verbatim, or null when the user set none.
 type profileResponse struct {
-	Specializations []string   `json:"specializations"`
-	Skills          []string   `json:"skills"`
-	CreatedAt       *time.Time `json:"created_at"`
-	UpdatedAt       *time.Time `json:"updated_at"`
+	Specializations     []string        `json:"specializations"`
+	Skills              []string        `json:"skills"`
+	LocationPreferences json.RawMessage `json:"location_preferences"`
+	CreatedAt           *time.Time      `json:"created_at"`
+	UpdatedAt           *time.Time      `json:"updated_at"`
 }
 
-// toProfileResponse maps a stored profile to its wire shape (no user id).
+// toProfileResponse maps a stored profile to its wire shape (no user id). The location
+// block is the raw JSONB (json.RawMessage), which marshals through unchanged — a NULL
+// column stays null.
 func toProfileResponse(p db.UserProfile) profileResponse {
 	return profileResponse{
-		Specializations: p.Specializations,
-		Skills:          p.Skills,
-		CreatedAt:       timePtr(p.CreatedAt),
-		UpdatedAt:       timePtr(p.UpdatedAt),
+		Specializations:     p.Specializations,
+		Skills:              p.Skills,
+		LocationPreferences: p.LocationPreferences,
+		CreatedAt:           timePtr(p.CreatedAt),
+		UpdatedAt:           timePtr(p.UpdatedAt),
 	}
 }
 
@@ -44,6 +50,16 @@ func profileError(err error) error {
 		return fiber.NewError(fiber.StatusBadRequest, "too many specializations (max 5)")
 	case errors.Is(err, userprofile.ErrEmptySkills):
 		return fiber.NewError(fiber.StatusBadRequest, "at least one skill is required")
+	case errors.Is(err, userprofile.ErrInvalidWorkMode):
+		return fiber.NewError(fiber.StatusBadRequest, "work mode is not a known value")
+	case errors.Is(err, userprofile.ErrInvalidRegion):
+		return fiber.NewError(fiber.StatusBadRequest, "region is not a known value")
+	case errors.Is(err, userprofile.ErrInvalidCountry):
+		return fiber.NewError(fiber.StatusBadRequest, "country is not a valid two-letter code")
+	case errors.Is(err, userprofile.ErrTooManyCountries):
+		return fiber.NewError(fiber.StatusBadRequest, "too many countries")
+	case errors.Is(err, userprofile.ErrTooManyCities):
+		return fiber.NewError(fiber.StatusBadRequest, "too many cities")
 	case errors.Is(err, userprofile.ErrNotFound):
 		return fiber.NewError(fiber.StatusNotFound, "profile not found")
 	default:
@@ -52,10 +68,12 @@ func profileError(err error) error {
 }
 
 // saveProfileRequest is the upsert body: a non-empty set of specializations (job
-// categories) and a non-empty set of skills. The whole profile is replaced on each save.
+// categories), a non-empty set of skills, and an optional location_preferences block. The
+// whole profile is replaced on each save; an omitted/null location block clears it.
 type saveProfileRequest struct {
-	Specializations []string `json:"specializations"`
-	Skills          []string `json:"skills"`
+	Specializations     []string                         `json:"specializations"`
+	Skills              []string                         `json:"skills"`
+	LocationPreferences *userprofile.LocationPreferences `json:"location_preferences"`
 }
 
 // GetProfile returns the authenticated user's single profile, or {"data": null} when they
@@ -77,7 +95,8 @@ func (a *API) GetProfile(c *fiber.Ctx) error {
 }
 
 // PutProfile creates-or-replaces the authenticated user's profile (specializations +
-// skills). A bad/empty specialization set or empty skills is a 400. Cookie-only.
+// skills + optional location preferences). A bad/empty specialization set, empty skills,
+// or an out-of-vocabulary location value is a 400. Cookie-only.
 func (a *API) PutProfile(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
@@ -89,7 +108,7 @@ func (a *API) PutProfile(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
 
-	profile, err := a.userProfile.Save(c.Context(), userID, in.Specializations, in.Skills)
+	profile, err := a.userProfile.Save(c.Context(), userID, in.Specializations, in.Skills, in.LocationPreferences)
 	if err != nil {
 		return profileError(err)
 	}

--- a/internal/handler/me_profile_test.go
+++ b/internal/handler/me_profile_test.go
@@ -127,6 +127,68 @@ func TestPutProfile_ReturnsSpecializationsArray(t *testing.T) {
 	}
 }
 
+func TestPutProfile_ParsesAndEchoesLocationPreferences(t *testing.T) {
+	loc := `{"work_modes":["remote","onsite"],"remote":{"regions":["latam"]},"base":{"country":"BR","city":"Florianópolis"},"relocation":{"open":true,"cities":["Berlin"]}}`
+	repo := &fakeProfileRepo{}
+	// Echo back whatever the service upserts, so the response reflects the stored block.
+	app, token := profileApp(t, repo)
+	resp := doProfile(t, app, fiber.MethodPut,
+		`{"specializations":["backend"],"skills":["go"],"location_preferences":`+loc+`}`, token)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	// The nested block reached the service and was normalized into the upsert params.
+	if repo.upserted.LocationPreferences == nil {
+		t.Fatal("location_preferences did not reach the upsert")
+	}
+	var stored userprofile.LocationPreferences
+	if err := json.Unmarshal(repo.upserted.LocationPreferences, &stored); err != nil {
+		t.Fatalf("unmarshal upserted location: %v", err)
+	}
+	if stored.Base.Country != "br" || stored.Base.City != "Florianópolis" {
+		t.Errorf("base = %+v, want {br Florianópolis}", stored.Base)
+	}
+	if !stored.Relocation.Open || len(stored.Relocation.Cities) != 1 {
+		t.Errorf("relocation = %+v", stored.Relocation)
+	}
+}
+
+func TestPutProfile_RejectsInvalidLocationBlock(t *testing.T) {
+	repo := &fakeProfileRepo{}
+	app, token := profileApp(t, repo)
+	resp := doProfile(t, app, fiber.MethodPut,
+		`{"specializations":["backend"],"skills":["go"],"location_preferences":{"work_modes":["freelance"]}}`, token)
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if repo.upserted.UserID != 0 {
+		t.Error("repo.Upsert should not be called on an invalid location block")
+	}
+}
+
+func TestGetProfile_EchoesStoredLocationPreferences(t *testing.T) {
+	stored := json.RawMessage(`{"work_modes":["remote"],"remote":{"regions":["latam"]}}`)
+	ret := db.UserProfile{UserID: 1, Specializations: []string{"backend"}, Skills: []string{"go"}, LocationPreferences: stored}
+	app, token := profileApp(t, &fakeProfileRepo{getRet: ret})
+	resp := doProfile(t, app, fiber.MethodGet, "", token)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got struct {
+		Data profileResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var loc userprofile.LocationPreferences
+	if err := json.Unmarshal(got.Data.LocationPreferences, &loc); err != nil {
+		t.Fatalf("unmarshal response location: %v", err)
+	}
+	if len(loc.WorkModes) != 1 || loc.WorkModes[0] != "remote" {
+		t.Errorf("work_modes = %v, want [remote]", loc.WorkModes)
+	}
+}
+
 func TestGetProfile_NullWhenNone(t *testing.T) {
 	app, token := profileApp(t, &fakeProfileRepo{getErr: userprofile.ErrNotFound})
 	resp := doProfile(t, app, fiber.MethodGet, "", token)

--- a/internal/userprofile/location.go
+++ b/internal/userprofile/location.go
@@ -1,0 +1,234 @@
+package userprofile
+
+import (
+	"encoding/json"
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/enrich"
+)
+
+// Location-preference sentinel errors, mapped to 400 by the handler.
+var (
+	// ErrInvalidWorkMode is a work mode outside enrich.WorkModeValues.
+	ErrInvalidWorkMode = errors.New("userprofile: work mode is not a known value")
+	// ErrInvalidRegion is a region outside enrich.RegionValues.
+	ErrInvalidRegion = errors.New("userprofile: region is not a known value")
+	// ErrInvalidCountry is a country code that is not a well-formed ISO 3166-1 alpha-2 shape.
+	ErrInvalidCountry = errors.New("userprofile: country is not a valid two-letter code")
+	// ErrTooManyCountries is a country list past maxCountries.
+	ErrTooManyCountries = errors.New("userprofile: too many countries")
+	// ErrTooManyCities is a city list past maxCities.
+	ErrTooManyCities = errors.New("userprofile: too many cities")
+)
+
+// Caps on the free-ish list fields — sanity limits, not domain rules (mirroring
+// maxSpecializations). Countries are bounded by the ISO set; cities are free text.
+const (
+	maxCountries = 20
+	maxCities    = 10
+)
+
+// LocationPreferences is the optional, structured "where & how I want to work" block on a
+// profile: the accepted work arrangements plus three independent, freely-combinable
+// geographic parts — the remote reach, the current base, and the relocation willingness.
+// Every field is optional; an entirely-empty block is treated as "no preferences" (stored
+// NULL). Stored whole as JSONB and echoed back verbatim.
+type LocationPreferences struct {
+	WorkModes  []string     `json:"work_modes,omitempty"`
+	Remote     GeoSet       `json:"remote"`
+	Base       BaseLocation `json:"base"`
+	Relocation Relocation   `json:"relocation"`
+}
+
+// GeoSet is a geographic reach: controlled regions and/or ISO country codes. Empty means
+// "anywhere" (worldwide) in the remote context.
+type GeoSet struct {
+	Regions   []string `json:"regions,omitempty"`
+	Countries []string `json:"countries,omitempty"`
+}
+
+// BaseLocation is the user's current single place: an ISO country code and a free-text city.
+type BaseLocation struct {
+	Country string `json:"country,omitempty"`
+	City    string `json:"city,omitempty"`
+}
+
+// Relocation is the willingness to move: an open flag plus the acceptable destinations.
+// Open with empty targets means "anywhere".
+type Relocation struct {
+	Open      bool     `json:"open"`
+	Regions   []string `json:"regions,omitempty"`
+	Countries []string `json:"countries,omitempty"`
+	Cities    []string `json:"cities,omitempty"`
+}
+
+// isEmpty reports whether the block carries no preference at all, so the service can store
+// NULL instead of a meaningless empty object.
+func (l LocationPreferences) isEmpty() bool {
+	return len(l.WorkModes) == 0 &&
+		len(l.Remote.Regions) == 0 && len(l.Remote.Countries) == 0 &&
+		l.Base.Country == "" && l.Base.City == "" &&
+		!l.Relocation.Open &&
+		len(l.Relocation.Regions) == 0 && len(l.Relocation.Countries) == 0 && len(l.Relocation.Cities) == 0
+}
+
+// normalizeLocationPreferences validates and normalizes the optional location block, then
+// marshals it to JSONB. A nil input, or a block that is empty after normalization, yields a
+// nil payload (stored as NULL — "no preferences"). Any out-of-vocabulary value rejects the
+// whole save.
+func normalizeLocationPreferences(loc *LocationPreferences) (json.RawMessage, error) {
+	if loc == nil {
+		return nil, nil
+	}
+
+	workModes, err := normalizeEnum(loc.WorkModes, enrich.WorkModeValues, ErrInvalidWorkMode)
+	if err != nil {
+		return nil, err
+	}
+	remote, err := normalizeGeoSet(loc.Remote)
+	if err != nil {
+		return nil, err
+	}
+	relocationRegions, err := normalizeEnum(loc.Relocation.Regions, enrich.RegionValues, ErrInvalidRegion)
+	if err != nil {
+		return nil, err
+	}
+	relocationCountries, err := normalizeCountries(loc.Relocation.Countries)
+	if err != nil {
+		return nil, err
+	}
+	relocationCities, err := normalizeCities(loc.Relocation.Cities)
+	if err != nil {
+		return nil, err
+	}
+	baseCountry, err := cleanCountryCode(loc.Base.Country)
+	if err != nil {
+		return nil, err
+	}
+
+	out := LocationPreferences{
+		WorkModes: workModes,
+		Remote:    remote,
+		Base:      BaseLocation{Country: baseCountry, City: strings.TrimSpace(loc.Base.City)},
+		Relocation: Relocation{
+			Open:      loc.Relocation.Open,
+			Regions:   relocationRegions,
+			Countries: relocationCountries,
+			Cities:    relocationCities,
+		},
+	}
+	if out.isEmpty() {
+		return nil, nil
+	}
+	return json.Marshal(out)
+}
+
+// normalizeGeoSet normalizes a reach's regions (controlled vocabulary) and countries (ISO).
+func normalizeGeoSet(g GeoSet) (GeoSet, error) {
+	regions, err := normalizeEnum(g.Regions, enrich.RegionValues, ErrInvalidRegion)
+	if err != nil {
+		return GeoSet{}, err
+	}
+	countries, err := normalizeCountries(g.Countries)
+	if err != nil {
+		return GeoSet{}, err
+	}
+	return GeoSet{Regions: regions, Countries: countries}, nil
+}
+
+// normalizeEnum lowercases, trims, and deduplicates values (first-seen order), rejecting any
+// not in the controlled vocabulary (all lowercase) with invalidErr. Lowercasing keeps the
+// dedup and membership check case-insensitive. Blanks are dropped; an empty result is valid.
+func normalizeEnum(values, vocab []string, invalidErr error) ([]string, error) {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		v := strings.ToLower(strings.TrimSpace(raw))
+		if v == "" {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		if !slices.Contains(vocab, v) {
+			return nil, invalidErr
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// normalizeCountries cleans, deduplicates, and caps a country-code list. Blanks are dropped.
+func normalizeCountries(values []string) ([]string, error) {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		code, err := cleanCountryCode(raw)
+		if err != nil {
+			return nil, err
+		}
+		if code == "" {
+			continue
+		}
+		if _, dup := seen[code]; dup {
+			continue
+		}
+		seen[code] = struct{}{}
+		out = append(out, code)
+	}
+	if len(out) > maxCountries {
+		return nil, ErrTooManyCountries
+	}
+	return out, nil
+}
+
+// cleanCountryCode lowercases and trims a country code, returning "" for blank. A non-blank
+// value that is not a well-formed ISO 3166-1 alpha-2 shape is rejected. We validate shape,
+// not assignment: jobs derive their country facet from the curated location dictionary
+// (a subset that omits real countries like jm/cu), so a membership check would reject
+// countries a user legitimately picks — and a well-formed but unused code is harmless (it
+// simply matches no jobs, like an unknown city or skill).
+func cleanCountryCode(raw string) (string, error) {
+	code := strings.ToLower(strings.TrimSpace(raw))
+	if code == "" {
+		return "", nil
+	}
+	if !isCountryCode(code) {
+		return "", ErrInvalidCountry
+	}
+	return code, nil
+}
+
+// isCountryCode reports whether s is exactly two ASCII letters (an ISO 3166-1 alpha-2 shape).
+func isCountryCode(s string) bool {
+	if len(s) != 2 {
+		return false
+	}
+	return s[0] >= 'a' && s[0] <= 'z' && s[1] >= 'a' && s[1] <= 'z'
+}
+
+// normalizeCities trims cities, drops blanks, and deduplicates case-insensitively (keeping
+// the first-seen surface form), capping the list. Cities are free text (no dictionary).
+func normalizeCities(values []string) ([]string, error) {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, raw := range values {
+		city := strings.TrimSpace(raw)
+		if city == "" {
+			continue
+		}
+		key := strings.ToLower(city)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, city)
+	}
+	if len(out) > maxCities {
+		return nil, ErrTooManyCities
+	}
+	return out, nil
+}

--- a/internal/userprofile/userprofile.go
+++ b/internal/userprofile/userprofile.go
@@ -65,9 +65,10 @@ func (s *Service) Get(ctx context.Context, userID int64) (db.UserProfile, error)
 
 // Save validates and upserts the user's single profile. The specializations are
 // normalized (each a known category, deduped, non-empty, capped); the skills are
-// normalized and must be non-empty. It is a create-or-replace: the first save inserts,
-// later saves overwrite.
-func (s *Service) Save(ctx context.Context, userID int64, specializations, skills []string) (db.UserProfile, error) {
+// normalized and must be non-empty; the optional location block is validated and
+// normalized (or stored NULL when nil/empty). It is a create-or-replace: the first save
+// inserts, later saves overwrite.
+func (s *Service) Save(ctx context.Context, userID int64, specializations, skills []string, loc *LocationPreferences) (db.UserProfile, error) {
 	specs, err := normalizeSpecializations(specializations)
 	if err != nil {
 		return db.UserProfile{}, err
@@ -76,10 +77,15 @@ func (s *Service) Save(ctx context.Context, userID int64, specializations, skill
 	if err != nil {
 		return db.UserProfile{}, err
 	}
+	locJSON, err := normalizeLocationPreferences(loc)
+	if err != nil {
+		return db.UserProfile{}, err
+	}
 	return s.repo.Upsert(ctx, db.UpsertUserProfileParams{
-		UserID:          userID,
-		Specializations: specs,
-		Skills:          normalized,
+		UserID:              userID,
+		Specializations:     specs,
+		Skills:              normalized,
+		LocationPreferences: locJSON,
 	})
 }
 

--- a/internal/userprofile/userprofile_location_test.go
+++ b/internal/userprofile/userprofile_location_test.go
@@ -1,0 +1,149 @@
+package userprofile_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/userprofile"
+)
+
+// decodeLoc unmarshals the location block the fake repo captured.
+func decodeLoc(t *testing.T, raw json.RawMessage) userprofile.LocationPreferences {
+	t.Helper()
+	var got userprofile.LocationPreferences
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal location_preferences: %v", err)
+	}
+	return got
+}
+
+// The Florianópolis case: remote for LATAM, on-site at home in BR, willing to relocate to
+// Berlin — all at once. The block round-trips normalized and whole.
+func TestSave_StoresCombinedLocationPreferences(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := userprofile.New(repo)
+
+	loc := &userprofile.LocationPreferences{
+		WorkModes:  []string{"remote", "onsite"},
+		Remote:     userprofile.GeoSet{Regions: []string{"latam"}},
+		Base:       userprofile.BaseLocation{Country: "BR", City: " Florianópolis "},
+		Relocation: userprofile.Relocation{Open: true, Cities: []string{"Berlin"}},
+	}
+	if _, err := svc.Save(context.Background(), 7, []string{"backend"}, []string{"go"}, loc); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !repo.upsertCalled {
+		t.Fatal("repo.Upsert was not called")
+	}
+	got := decodeLoc(t, repo.upserted.LocationPreferences)
+	if len(got.WorkModes) != 2 || got.WorkModes[0] != "remote" || got.WorkModes[1] != "onsite" {
+		t.Errorf("WorkModes = %v", got.WorkModes)
+	}
+	if len(got.Remote.Regions) != 1 || got.Remote.Regions[0] != "latam" {
+		t.Errorf("Remote.Regions = %v", got.Remote.Regions)
+	}
+	if got.Base.Country != "br" { // lowercased
+		t.Errorf("Base.Country = %q, want br", got.Base.Country)
+	}
+	if got.Base.City != "Florianópolis" { // trimmed, case preserved
+		t.Errorf("Base.City = %q", got.Base.City)
+	}
+	if !got.Relocation.Open || len(got.Relocation.Cities) != 1 || got.Relocation.Cities[0] != "Berlin" {
+		t.Errorf("Relocation = %+v", got.Relocation)
+	}
+}
+
+// No location block → NULL stored (never-set semantics), profile still saved.
+func TestSave_NilLocationStoresNull(t *testing.T) {
+	repo := &fakeRepo{}
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, nil); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if repo.upserted.LocationPreferences != nil {
+		t.Errorf("LocationPreferences = %s, want nil", repo.upserted.LocationPreferences)
+	}
+}
+
+// An entirely-empty block collapses to NULL — no meaningless {} row.
+func TestSave_EmptyLocationCollapsesToNull(t *testing.T) {
+	repo := &fakeRepo{}
+	empty := &userprofile.LocationPreferences{}
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, empty); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if repo.upserted.LocationPreferences != nil {
+		t.Errorf("LocationPreferences = %s, want nil", repo.upserted.LocationPreferences)
+	}
+}
+
+// Out-of-vocabulary values reject the whole save; nothing is persisted.
+func TestSave_RejectsInvalidLocationValues(t *testing.T) {
+	cases := []struct {
+		name string
+		loc  *userprofile.LocationPreferences
+		want error
+	}{
+		{"bad work mode", &userprofile.LocationPreferences{WorkModes: []string{"freelance"}}, userprofile.ErrInvalidWorkMode},
+		{"bad region", &userprofile.LocationPreferences{Remote: userprofile.GeoSet{Regions: []string{"antarctica"}}}, userprofile.ErrInvalidRegion},
+		{"malformed remote country", &userprofile.LocationPreferences{Remote: userprofile.GeoSet{Countries: []string{"usa"}}}, userprofile.ErrInvalidCountry},
+		{"malformed base country", &userprofile.LocationPreferences{Base: userprofile.BaseLocation{Country: "usa"}}, userprofile.ErrInvalidCountry},
+		{"bad relocation region", &userprofile.LocationPreferences{Relocation: userprofile.Relocation{Regions: []string{"mars"}}}, userprofile.ErrInvalidRegion},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &fakeRepo{}
+			_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, tc.loc)
+			if !errors.Is(err, tc.want) {
+				t.Errorf("Save err = %v, want %v", err, tc.want)
+			}
+			if repo.upsertCalled {
+				t.Error("repo.Upsert should not be called on invalid input")
+			}
+		})
+	}
+}
+
+// Work modes and regions are matched case-insensitively (lowercased) and deduped, so a
+// non-lowercase or mixed-case API client is accepted, not rejected.
+func TestSave_NormalizesLocationEnumCase(t *testing.T) {
+	repo := &fakeRepo{}
+	loc := &userprofile.LocationPreferences{
+		WorkModes: []string{"Remote", "remote"},
+		Remote:    userprofile.GeoSet{Regions: []string{"LATAM", "latam"}},
+	}
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, loc); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got := decodeLoc(t, repo.upserted.LocationPreferences)
+	if len(got.WorkModes) != 1 || got.WorkModes[0] != "remote" {
+		t.Errorf("WorkModes = %v, want [remote]", got.WorkModes)
+	}
+	if len(got.Remote.Regions) != 1 || got.Remote.Regions[0] != "latam" {
+		t.Errorf("Remote.Regions = %v, want [latam]", got.Remote.Regions)
+	}
+}
+
+// Countries lowercased + deduped; cities trimmed, blanks dropped, deduped.
+func TestSave_NormalizesLocationCountriesAndCities(t *testing.T) {
+	repo := &fakeRepo{}
+	loc := &userprofile.LocationPreferences{
+		Remote: userprofile.GeoSet{Countries: []string{"BR", "br", "US"}},
+		Relocation: userprofile.Relocation{
+			Open:   true,
+			Cities: []string{" Berlin ", "berlin ", "", "Lisbon"},
+		},
+	}
+	if _, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, []string{"go"}, loc); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got := decodeLoc(t, repo.upserted.LocationPreferences)
+	if len(got.Remote.Countries) != 2 || got.Remote.Countries[0] != "br" || got.Remote.Countries[1] != "us" {
+		t.Errorf("Remote.Countries = %v, want [br us]", got.Remote.Countries)
+	}
+	// "Berlin" and "berlin" differ only by case/space → deduped to one; blank dropped.
+	if len(got.Relocation.Cities) != 2 || got.Relocation.Cities[0] != "Berlin" || got.Relocation.Cities[1] != "Lisbon" {
+		t.Errorf("Relocation.Cities = %v, want [Berlin Lisbon]", got.Relocation.Cities)
+	}
+}

--- a/internal/userprofile/userprofile_test.go
+++ b/internal/userprofile/userprofile_test.go
@@ -47,7 +47,7 @@ func TestSave_UpsertsWithOwnerNormalizedSpecializationsAndSkills(t *testing.T) {
 	svc := userprofile.New(repo)
 
 	_, err := svc.Save(context.Background(), 7,
-		[]string{" backend ", "devops", "backend"}, []string{"Go", " PostgreSQL ", "go"})
+		[]string{" backend ", "devops", "backend"}, []string{"Go", " PostgreSQL ", "go"}, nil)
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestSave_UpsertsWithOwnerNormalizedSpecializationsAndSkills(t *testing.T) {
 
 func TestSave_RejectsUnknownSpecialization(t *testing.T) {
 	repo := &fakeRepo{}
-	_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend", "wizardry"}, []string{"go"})
+	_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend", "wizardry"}, []string{"go"}, nil)
 	if !errors.Is(err, userprofile.ErrInvalidSpecialization) {
 		t.Errorf("err = %v, want ErrInvalidSpecialization", err)
 	}
@@ -90,7 +90,7 @@ func TestSave_RejectsEmptySpecializations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &fakeRepo{}
-			_, err := userprofile.New(repo).Save(context.Background(), 7, tc.in, []string{"go"})
+			_, err := userprofile.New(repo).Save(context.Background(), 7, tc.in, []string{"go"}, nil)
 			if !errors.Is(err, userprofile.ErrEmptySpecializations) {
 				t.Errorf("err = %v, want ErrEmptySpecializations", err)
 			}
@@ -104,7 +104,7 @@ func TestSave_RejectsEmptySpecializations(t *testing.T) {
 func TestSave_RejectsTooManySpecializations(t *testing.T) {
 	repo := &fakeRepo{}
 	six := []string{"backend", "frontend", "fullstack", "mobile", "devops", "sre"}
-	_, err := userprofile.New(repo).Save(context.Background(), 7, six, []string{"go"})
+	_, err := userprofile.New(repo).Save(context.Background(), 7, six, []string{"go"}, nil)
 	if !errors.Is(err, userprofile.ErrTooManySpecializations) {
 		t.Errorf("err = %v, want ErrTooManySpecializations", err)
 	}
@@ -125,7 +125,7 @@ func TestSave_RejectsEmptySkills(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &fakeRepo{}
-			_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, tc.in)
+			_, err := userprofile.New(repo).Save(context.Background(), 7, []string{"backend"}, tc.in, nil)
 			if !errors.Is(err, userprofile.ErrEmptySkills) {
 				t.Errorf("err = %v, want ErrEmptySkills", err)
 			}

--- a/migrations/0009_user_profile_location.sql
+++ b/migrations/0009_user_profile_location.sql
@@ -1,0 +1,13 @@
+-- Add an optional, structured location & work-mode preferences block to the single
+-- user profile. One nullable JSONB value holds the whole block (work_modes, remote
+-- reach, base location, relocation targets); NULL means the user set no preferences.
+-- Read/written whole by internal/userprofile; not filtered in SQL yet (denormalize to
+-- typed columns only when matching needs an index).
+--
+-- APPLY TO PROD MANUALLY BEFORE DEPLOY: initdb runs migrations only on first volume
+-- init, so on a persistent volume this ALTER does not auto-apply. The new binary's
+-- GetUserProfile/UpsertUserProfile SELECT/RETURN location_preferences, so deploying
+-- before running this ALTER makes every profile read and write fail with 42703
+-- (undefined column) → 500. Run it first (same as 0005-0008).
+ALTER TABLE public.user_profiles
+    ADD COLUMN location_preferences jsonb;

--- a/openspec/changes/add-profile-location-preferences/.openspec.yaml
+++ b/openspec/changes/add-profile-location-preferences/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/add-profile-location-preferences/design.md
+++ b/openspec/changes/add-profile-location-preferences/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The singleton `user_profiles` table today holds only `specializations text[]` and `skills text[]` (one row per user, keyed by `user_id`). The domain lives in `internal/userprofile` (Service + Repository + validation), served over `GET/PUT/DELETE /api/v1/me/profile` (`internal/handler/me_profile.go`), and consumed on the frontend by `ProfileForm.svelte`, the `profileStore`, and the jobs filter modal's **Apply my profile** action (`filtersFromProfile` in `web/src/lib/facetModel.ts` → `stagedFilters.applyProfile`).
+
+The controlled vocabularies already exist and are reused, not reinvented: `enrich.WorkModeValues` (`remote`/`hybrid`/`onsite`), `enrich.RegionValues` (9 macro-regions incl. `global`/`latam`), and the ISO alpha-2 country dictionary in `internal/location`. The jobs filter already exposes `work_mode`, `regions`, `countries`, `cities`, and `relocation` facets, so the profile stores facet-compatible values.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let a user record compound, directional location/work preferences ("remote for LATAM" + "on-site in Florianópolis" + "willing to relocate to Berlin") in one profile.
+- Reuse existing vocabularies so the same values flow into the jobs filter with no new taxonomy.
+- Make "Apply my profile" seed the location facets in addition to category/skills.
+
+**Non-Goals:**
+- Matching / recommendations / notifications consuming these preferences (future; the shape already supports them).
+- Multi-base support, per-mode reach modelling beyond the three blocks, or a separate "worldwide" toggle.
+- Geocoding or validating cities against a dictionary (cities stay free-text, mirroring the jobs `cities` facet).
+
+## Decisions
+
+**1. One nullable `location_preferences` JSONB column, not typed columns.**
+The preference is a single nested value read and written whole (form → API → form) and is not filtered in SQL anywhere yet. Typed columns (≈9 arrays/scalars) would be premature normalization with unwieldy CHECK constraints. JSONB + a typed Go struct (`userprofile.LocationPreferences`) gives type safety at the boundary — the same pattern as the `jobs.enrichment` blob — and lets the shape evolve during MVP without a migration per tweak. *Alternative considered:* typed columns, better for a future SQL `WHERE`. *Seam:* when matching needs to index a field (e.g. `remote.regions`), denormalize that one field to a column then.
+
+**2. Three willingness blocks with relocation as a modifier of the physical block.**
+`work_modes` is the arrangement axis; `remote{regions,countries}` is remote reach; `base{country,city}` is the current single location; `relocation{open,regions,countries,cities}` is a directional modifier (destinations distinct from base). This captures the Florianópolis example directly. *Alternative considered:* a flat facet mirror (one set of regions/countries/cities) — rejected because it collapses "where I am now" and "where I'd move", which is the whole point.
+
+**3. `relocation.open` boolean + empty targets = anywhere.**
+No separate "worldwide" checkbox. `open=false` → not willing; `open=true` with empty targets → anywhere; `open=true` with targets → only those. One field, no redundant state.
+
+**4. Apply-to-filter is a lossy flatten, done frontend-side in `filtersFromProfile`.**
+`work_mode ← work_modes`; `regions ← remote.regions ∪ relocation.regions`; `countries ← remote.countries ∪ base.country ∪ relocation.countries`; `cities ← base.city ∪ relocation.cities`; `relocation ← [supported, required]` iff `relocation.open`. The existing `seed()`/`facetAdd` reducer already trims and dedupes, so unions are free. The flatten intentionally loses the base-vs-relocation distinction (the filter is an AND-narrowing of "places relevant to me"); the structured block is retained for future matching.
+
+**5. Validation in `userprofile.Service.Save`, mirroring the existing pattern.**
+New `LocationPreferences` (with nested `GeoSet`, `BaseLocation`, `Relocation`) validated: work modes ⊆ `enrich.WorkModeValues` and regions ⊆ `enrich.RegionValues`, both matched case-insensitively (lowercased); countries lowercased + shape-checked (two ASCII letters — see the Risks note on why not membership); cities trimmed/deduped/capped; everything optional. New sentinels `ErrInvalidWorkMode`, `ErrInvalidRegion`, `ErrInvalidCountry`, `ErrTooManyCountries`, `ErrTooManyCities` alongside the existing `ErrInvalidSpecialization` family. An invalid block rejects the whole save.
+
+## Risks / Trade-offs
+
+- **JSONB is opaque to SQL queries** → acceptable now (nothing queries it); denormalize per the seam in Decision 1 when matching arrives.
+- **Lossy apply-to-filter** (base vs relocation merged, relocation → job-relocation facet) → the filter is a convenience narrowing, not an exact encoding; the structured profile remains the source of truth for future consumers.
+- **Cities are free-text** → the profile form must reuse the jobs city search UX (raw strings) rather than a curated list, so a user can only usefully type cities that exist in the catalogue's distribution; acceptable and consistent with the jobs filter.
+- **Country codes are shape-validated, not membership-validated** → the `internal/location` dictionary is a curated subset (it omits real countries like `jm`/`cu`) built to *derive* job geography, so validating a user's picked country against it would reject legitimate countries the frontend offers. Instead the country is validated for shape (two ASCII letters) and lowercased. A well-formed but job-less code is harmless — it simply matches nothing, like an unknown city or skill. No coupling to `location` for validation.
+
+## Migration Plan
+
+1. Add `migrations/0009_user_profile_location.sql`: `ALTER TABLE public.user_profiles ADD COLUMN location_preferences jsonb;` (nullable, no default; existing rows read as `NULL` = no preferences).
+2. Apply it to prod **manually before deploy** — the repo has no versioned migration runner and initdb migrations only run on first volume init (per the migrations gotcha; an unapplied column would 500 all profile reads).
+3. Regenerate `internal/db` via `make sqlc` after updating `internal/db/queries/user_profiles.sql`.
+4. Rollback: the column is additive and nullable; a rollback binary ignores it, and dropping the column loses only the new preferences.
+
+## Open Questions
+
+- Cap for cities count and for country-code list length — pick sane constants during implementation (e.g. cities ≤ 10, countries ≤ 20) and encode as validation, matching the `maxSpecializations = 5` precedent.

--- a/openspec/changes/add-profile-location-preferences/proposal.md
+++ b/openspec/changes/add-profile-location-preferences/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The user profile today captures *what* work a person wants (specializations + skills) but nothing about *where* and *how* they want to work. Real preferences are compound and directional — "I'll work remote for LATAM, on-site where I live in Florianópolis, and I'm willing to relocate to Berlin" — and users have no way to record them. Without this, "Apply my profile" can only seed category/skill filters, and future matching/notifications have no geography signal.
+
+## What Changes
+
+- Extend the singleton user profile with an optional, structured **location & work-mode preferences** block, expressive enough to combine many willingness statements at once.
+- Model it as three independent blocks stored in one nullable `location_preferences` JSONB column on `user_profiles`:
+  - `work_modes[]` — which arrangements the user accepts (subset of `enrich.WorkModeValues`).
+  - `remote{regions[], countries[]}` — remote reach (legal/timezone); empty = worldwide.
+  - `base{country, city}` — where the user is now (a single place).
+  - `relocation{open, regions[], countries[], cities[]}` — willingness to move and the targets; `open` + empty targets = anywhere.
+- Validate on save: regions ⊆ `enrich.RegionValues`, countries = ISO 3166-1 alpha-2 (lowercase) validated against the `internal/location` dictionary, work modes ⊆ `enrich.WorkModeValues`, cities trimmed/deduped/capped. Every field optional; a NULL column means "never set".
+- Extend the profile wire shape (`GET`/`PUT /api/v1/me/profile`) to carry `location_preferences`.
+- Add a **"Where & how you want to work"** section to the profile edit form, reusing the existing facet option vocabularies.
+- Extend the **Apply my profile** action so it flattens the three blocks into the jobs-filter facets: `regions ← remote.regions ∪ relocation.regions`; `countries ← remote.countries ∪ base.country ∪ relocation.countries`; `cities ← base.city ∪ relocation.cities`; `work_mode ← work_modes`; `relocation ← [supported, required]` when `open`.
+
+Not breaking: the block is additive and optional; existing profiles (specializations + skills only) stay valid, and a NULL block applies no location filters.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `search-profiles`: the profile entity gains an optional `location_preferences` block; save-validation and the fetch/save wire shape extend to cover it.
+- `filter-modal`: the **Apply my profile** action additionally seeds the jobs-filter location facets (work_mode, regions, countries, cities, relocation) from the profile's location preferences.
+
+## Impact
+
+- **DB**: new migration `0009_user_profile_location.sql` — `ALTER TABLE user_profiles ADD COLUMN location_preferences jsonb`. Must be applied to prod manually before deploy (repo has no versioned migration runner).
+- **sqlc**: `internal/db/queries/user_profiles.sql` (`UpsertUserProfile`/`GetUserProfile`) + regenerate `internal/db`.
+- **Go**: `internal/userprofile` (new `LocationPreferences` types + validation + `ErrInvalid*` sentinels), `internal/handler/me_profile.go` (wire shape). Reuses `enrich.WorkModeValues`/`RegionValues` and the `internal/location` country dictionary.
+- **Frontend**: `web/src/lib/types.ts` (`UserProfile`), `web/src/lib/api.ts` + `web/src/lib/profile.svelte.ts` (`save`), `web/src/lib/components/ProfileForm.svelte` (new section), `web/src/lib/facets.ts` (export the `WORK_MODE`/`REGION`/`RELOCATION` option builders), `web/src/lib/facetModel.ts` + `web/src/lib/stagedFilters.svelte.ts` (`filtersFromProfile`/`applyProfile`).
+- **Out of scope (future)**: matching, recommendations, and notifications consuming these preferences — the JSONB shape already supports them; denormalize to typed columns only when a concrete SQL query needs an index.

--- a/openspec/changes/add-profile-location-preferences/specs/filter-modal/spec.md
+++ b/openspec/changes/add-profile-location-preferences/specs/filter-modal/spec.md
@@ -1,0 +1,67 @@
+# filter-modal Specification (delta)
+
+## MODIFIED Requirements
+
+### Requirement: The filter modal can apply the signed-in user's profile
+
+The jobs filter modal SHALL offer, in its header, an **Apply my profile** action for a
+signed-in user who has a saved profile. Activating it SHALL reset the staged filters and
+then seed them from the user's profile: each profile specialization SHALL be staged as a
+`category` value and each profile skill SHALL be staged as a `skills` value. When the
+profile carries a `location_preferences` block, the action SHALL additionally seed the
+location facets by flattening the three blocks: `work_mode` from `work_modes`; `regions`
+from the union of `remote.regions` and `relocation.regions`; `countries` from the union of
+`remote.countries`, `base.country`, and `relocation.countries`; `cities` from the union of
+`base.city` and `relocation.cities`; and `relocation` staged as `supported` and `required`
+when `relocation.open` is true. Empty or absent parts contribute nothing. The action
+SHALL only stage — it SHALL NOT change the live job list; the seeded selection is applied
+through the existing **Show results** commit, so the user previews (and MAY adjust) the
+profile-derived filters before applying.
+
+The action SHALL appear only on the full jobs filter modal (not on reuses that restrict
+the rail to a facet subset, such as the profile-comparison modal). When the signed-in
+user has no saved profile, the header SHALL instead present a link to create one at
+`/my/profile`. When no user is signed in, neither the action nor the link SHALL appear.
+
+#### Scenario: Applying the profile resets and seeds the staged filters
+
+- **WHEN** a signed-in user with a saved profile (specializations `A`, `B`; skills `x`,
+  `y`) has some unrelated staged filters and activates **Apply my profile**
+- **THEN** the previously staged filters are cleared, the `category` facet is staged with
+  `A` and `B`, the `skills` facet is staged with `x` and `y`, and the job list is
+  unchanged until **Show results** is activated
+
+#### Scenario: Applying a profile with location preferences seeds the location facets
+
+- **WHEN** a signed-in user whose profile has `work_modes` `[remote, onsite]`,
+  `remote.regions` `[latam]`, `base` `{country: br, city: "Florianópolis"}`, and
+  `relocation` `{open: true, cities: ["Berlin"]}` activates **Apply my profile**
+- **THEN** the staged filters include `work_mode` `[remote, onsite]`, `regions` `[latam]`,
+  `countries` `[br]`, `cities` `["Florianópolis", "Berlin"]`, and `relocation`
+  `[supported, required]`, and the job list is unchanged until **Show results** is activated
+
+#### Scenario: Applying a profile without location preferences seeds no location facets
+
+- **WHEN** a signed-in user whose profile has no `location_preferences` block activates
+  **Apply my profile**
+- **THEN** only the `category` and `skills` facets are staged and the location facets
+  (`work_mode`, `regions`, `countries`, `cities`, `relocation`) remain empty
+
+#### Scenario: Show results commits the profile-derived filters
+
+- **WHEN** the user has applied their profile in the modal and then activates **Show
+  results**
+- **THEN** the staged selections become the live (URL-synced) filter state and the modal
+  closes
+
+#### Scenario: No profile shows a create-profile link instead
+
+- **WHEN** a signed-in user who has no saved profile opens the jobs filter modal
+- **THEN** the header shows a link to create a profile at `/my/profile` and no
+  **Apply my profile** action
+
+#### Scenario: Signed-out users see neither action nor link
+
+- **WHEN** a signed-out user opens the jobs filter modal
+- **THEN** the header shows neither the **Apply my profile** action nor the
+  create-profile link

--- a/openspec/changes/add-profile-location-preferences/specs/search-profiles/spec.md
+++ b/openspec/changes/add-profile-location-preferences/specs/search-profiles/spec.md
@@ -1,0 +1,80 @@
+# search-profiles Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Location & work-mode preferences
+
+A profile MAY carry an optional `location_preferences` block describing *where* and *how* the user wants to work. The block is composed of three independent, freely combinable parts and is stored whole (as one value); every part and every field within it is optional, and a profile with no location preferences SHALL be represented by the block being absent (`null`). The block SHALL be:
+
+- `work_modes`: a set of accepted work arrangements, each drawn from the controlled work-mode vocabulary (`enrich.WorkModeValues`: `remote`/`hybrid`/`onsite`), deduplicated.
+- `remote`: the remote reach — `{ regions, countries }` — where `regions` is drawn from the controlled region vocabulary (`enrich.RegionValues`) and `countries` is a set of ISO 3166-1 alpha-2 codes; an empty reach means "worldwide".
+- `base`: the user's current single location — `{ country, city }` — where `country` is an ISO 3166-1 alpha-2 code and `city` is free text.
+- `relocation`: willingness to move — `{ open, regions, countries, cities }` — where `open` is a boolean and the target `regions`/`countries`/`cities` are the acceptable destinations; `open` with empty targets means "anywhere".
+
+On save the system SHALL validate and normalize the block: work modes and regions matched case-insensitively and rejected if outside their controlled vocabularies; countries lowercased and rejected if not a well-formed ISO 3166-1 alpha-2 shape (exactly two ASCII letters — shape, not assignment, so the full range of codes a user may pick is accepted); every code/token trimmed and deduplicated; cities trimmed, empty entries dropped, deduplicated, and capped. An invalid value SHALL reject the whole save (the profile is unchanged); nothing out-of-vocabulary is ever stored.
+
+#### Scenario: Save a profile with combined location preferences
+- **WHEN** an authenticated user saves a profile with `location_preferences` of `work_modes` `[remote, onsite]`, `remote.regions` `[latam]`, `base` `{country: br, city: "Florianópolis"}`, and `relocation` `{open: true, cities: ["Berlin"]}`
+- **THEN** the system stores the block whole and a subsequent fetch returns exactly those preferences
+
+#### Scenario: Location preferences are optional
+- **WHEN** an authenticated user saves a profile with valid `specializations` and `skills` and no `location_preferences`
+- **THEN** the system stores the profile with an absent (`null`) location block and the save succeeds
+
+#### Scenario: Out-of-vocabulary work mode or region is rejected
+- **WHEN** an authenticated user saves `location_preferences` whose `work_modes` or any `regions` entry is not in the controlled vocabulary
+- **THEN** the system responds `400`, stores nothing, and leaves any existing profile unchanged
+
+#### Scenario: Malformed country code is rejected
+- **WHEN** an authenticated user saves `location_preferences` with a `countries` or `base.country` value that is not a two-letter code (e.g. an alpha-3 code like `usa`)
+- **THEN** the system responds `400` and stores nothing
+
+#### Scenario: Countries and cities are normalized
+- **WHEN** an authenticated user saves `location_preferences` with country codes in mixed case and cities with surrounding whitespace or duplicates
+- **THEN** the system stores country codes lowercased and deduplicated, and cities trimmed, non-empty, and deduplicated
+
+## MODIFIED Requirements
+
+### Requirement: Retrieve the profile
+
+A signed-in user SHALL be able to fetch their single profile via
+`GET /api/v1/me/profile`. When the user has saved a profile the system responds
+`200` with `{"data": {specializations, skills, location_preferences, created_at, updated_at}}`,
+where `location_preferences` is the saved block or `null` when the user set none; when
+the user has no profile yet it responds `200` with `{"data": null}`.
+
+#### Scenario: Fetch an existing profile
+- **WHEN** an authenticated user who has a saved profile sends `GET /api/v1/me/profile`
+- **THEN** the system responds `200` with `{"data": {...}}` containing that user's `specializations`, `skills`, `location_preferences` (the saved block or `null`), and timestamps
+
+#### Scenario: Fetch when no profile exists
+- **WHEN** an authenticated user who has never saved a profile sends `GET /api/v1/me/profile`
+- **THEN** the system responds `200` with `{"data": null}`
+
+### Requirement: Save the profile
+
+A signed-in user SHALL be able to create-or-replace their single profile via
+`PUT /api/v1/me/profile` with a non-empty set of `specializations` (job
+categories), a non-empty set of `skills`, and an optional `location_preferences`
+block. The write is an upsert keyed by the calling user: it creates the profile
+if none exists and overwrites it otherwise. Both sets are stored trimmed and
+deduplicated; skills are canonical lowercase tokens; the location block is
+validated and normalized per the Location & work-mode preferences requirement, or
+stored as absent when omitted. The system does NOT create an empty profile — a
+profile exists only once saved with valid content.
+
+#### Scenario: Create the profile on first save
+- **WHEN** an authenticated user with no profile sends `PUT /api/v1/me/profile` with a non-empty `specializations` array drawn from the category vocabulary and a non-empty `skills` array
+- **THEN** the system stores the profile for that user and responds `200` with `{"data": {specializations, skills, location_preferences, updated_at}}`
+
+#### Scenario: Overwrite an existing profile
+- **WHEN** an authenticated user who already has a profile sends `PUT /api/v1/me/profile` with new valid `specializations`, `skills`, and `location_preferences`
+- **THEN** the system replaces the stored values (including the location block), bumps `updated_at`, and responds `200`
+
+#### Scenario: Specializations are deduplicated
+- **WHEN** an authenticated user saves a profile whose `specializations` contain duplicate categories
+- **THEN** the system stores each category once, preserving first-seen order
+
+#### Scenario: Skills are normalized
+- **WHEN** an authenticated user saves a profile with skills containing mixed case, surrounding whitespace, or duplicates
+- **THEN** the system stores each skill lowercased, trimmed, and deduplicated

--- a/openspec/changes/add-profile-location-preferences/tasks.md
+++ b/openspec/changes/add-profile-location-preferences/tasks.md
@@ -1,0 +1,32 @@
+## 1. Schema & data access
+
+- [x] 1.1 Add `migrations/0009_user_profile_location.sql` — `ALTER TABLE public.user_profiles ADD COLUMN location_preferences jsonb;` (nullable, no default). (sqlc reads incremental ALTERs cumulatively, so no edit to `0001_init.sql` — that would double-define the column.)
+- [x] 1.2 Update `internal/db/queries/user_profiles.sql`: `UpsertUserProfile` sets `location_preferences` (new param) and `GetUserProfile` returns it; add `user_profiles.location_preferences → json.RawMessage` override in `sqlc.yaml`; run `make sqlc` and commit regenerated `internal/db`.
+
+## 2. Domain types & validation (`internal/userprofile`)
+
+- [x] 2.1 Country validation: shape-check (two ASCII letters, lowercased) inside `internal/userprofile`, NOT membership in `internal/location` — the location dictionary is a curated subset that omits real countries (jm/cu), so a membership check would reject countries the frontend legitimately offers (found in review; see design Risks).
+- [x] 2.2 Define `LocationPreferences` (+ nested `GeoSet`, `BaseLocation`, `Relocation`) in `internal/userprofile`, and add `ErrInvalidWorkMode`, `ErrInvalidRegion`, `ErrInvalidCountry`, `ErrTooManyCountries`, `ErrTooManyCities` sentinels.
+- [x] 2.3 Implement validation + normalization in `Service.Save` (work_modes ⊆ `enrich.WorkModeValues`; regions ⊆ `enrich.RegionValues`, both case-insensitive; countries shape-checked; cities trimmed/deduped/capped; base.country validated; whole block optional, empty→NULL, invalid → reject the save). Unit-test the Florianópolis combined case, the optional/absent case, enum-case normalization, and each rejection.
+- [x] 2.4 Thread `location_preferences` (marshal to/from JSONB) through the `Repository`: satisfied by the sqlc-generated `UpsertUserProfileParams`/`UserProfile` carrying `json.RawMessage` — the interface uses `db` types, so it flows through unchanged; round-trip covered by the combined-case test capturing the upsert param.
+
+## 3. HTTP wire shape (`internal/handler/me_profile.go`)
+
+- [x] 3.1 Extend `saveProfileRequest` (`*LocationPreferences`) and `profileResponse` (`json.RawMessage`, echoed verbatim) with the optional `location_preferences` block; map request→service and stored→response; map the new sentinels to 400 in `profileError`. Added unit handler tests (fake repo, no DB) for parse-and-reach-upsert, `400` on invalid block, and GET echo.
+
+## 4. Frontend model & API
+
+- [x] 4.1 Extend the `UserProfile` TS type (`web/src/lib/types.ts`) with `location_preferences` + `LocationGeoSet`/`LocationBase`/`LocationRelocation`; update `api.saveProfile` and `profileStore.save` to carry it.
+- [x] 4.2 Export `WORK_MODE_OPTIONS`, `REGION_OPTIONS`, `COUNTRY_OPTIONS` from `web/src/lib/facets.ts` (matching `CATEGORY_OPTIONS`). RELOCATION not exported — the form uses a boolean toggle, not the job vocabulary (YAGNI).
+
+## 5. Apply-my-profile flatten
+
+- [x] 5.1 `filtersFromProfile(profile)` now flattens `location_preferences` into facets (work_mode; regions = remote ∪ relocation; countries = remote ∪ base ∪ relocation; cities = base ∪ relocation; relocation = [supported,required] if open — `open` gates the whole relocation contribution); `stagedFilters.applyProfile(profile)` + FilterModal call widened. Tests extended (combined Florianópolis case, not-open case, no-location case) — 7/7 green.
+
+## 6. Profile edit form
+
+- [x] 6.1 Added "Where & how you want to work" section to `ProfileForm.svelte`: work_mode pills, remote-reach region pills + country SearchSelect, base country `<select>` + city Input, relocation toggle + target region/country/city controls; two-way bound; `buildLocation()` gates relocation targets on the toggle and collapses an all-empty block to null. aria-labels on the select/city inputs (review). svelte-check + eslint clean.
+
+## 7. Verification
+
+- [x] 7.1 Verified: `go build/vet/test ./...` green; `make sqlc` no-diff; web `svelte-check` 0/0, `vitest` 122/122, changed-file `eslint` clean (only a pre-existing `URLSearchParams` lint in stagedFilters remains, unrelated); web prod build succeeds. Live DB JSONB round-trip not run standalone — covered by handler marshaling tests + the identical `companies.company_info`/`jobs.enrichment` `json.RawMessage` precedent. Reviewed by finder agents (backend + frontend); all confirmed findings fixed.

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -24,3 +24,8 @@ sql:
           # straight through to the company-detail response ({} stays {}), not base64.
           - column: "companies.company_info"
             go_type: "encoding/json.RawMessage"
+          # The profile location block: raw JSON round-trips whole. The service
+          # marshals a validated, normalized block (or NULL for none), and the stored
+          # bytes marshal straight through to the profile response (null stays null).
+          - column: "user_profiles.location_preferences"
+            go_type: "encoding/json.RawMessage"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -36,6 +36,7 @@ import type {
   ATSResponse,
   JobMatch,
   ResumeProfile,
+  LocationPreferences,
 } from './types';
 
 /** A page of list items, optionally the total matching the query (endpoints that
@@ -472,10 +473,18 @@ export function createApi(
   }
 
   /** Create-or-replace the user's profile from a non-empty set of specializations (job
-   *  categories) and a non-empty set of skills. A bad specialization or empty skills is a
-   *  400. */
-  async function saveProfile(specializations: string[], skills: string[]): Promise<UserProfile> {
-    return requestData<UserProfile>('/api/v1/me/profile', jsonBody('PUT', { specializations, skills }));
+   *  categories), a non-empty set of skills, and an optional location-preferences block
+   *  (null clears it). A bad specialization, empty skills, or an out-of-vocabulary location
+   *  value is a 400. */
+  async function saveProfile(
+    specializations: string[],
+    skills: string[],
+    location: LocationPreferences | null,
+  ): Promise<UserProfile> {
+    return requestData<UserProfile>(
+      '/api/v1/me/profile',
+      jsonBody('PUT', { specializations, skills, location_preferences: location }),
+    );
   }
 
   /** Clear the user's profile. Idempotent. */

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -1,10 +1,17 @@
 <script lang="ts">
   import { ArrowUp, Check, X } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
-  import { CATEGORY_OPTIONS, categoryLabel, type FacetOption } from '$lib/facets';
+  import {
+    CATEGORY_OPTIONS,
+    categoryLabel,
+    COUNTRY_OPTIONS,
+    REGION_OPTIONS,
+    WORK_MODE_OPTIONS,
+    type FacetOption,
+  } from '$lib/facets';
   import { profileStore } from '$lib/profile.svelte';
-  import type { UserProfile } from '$lib/types';
-  import { Button } from '$lib/ui';
+  import type { LocationPreferences, UserProfile } from '$lib/types';
+  import { Button, Input } from '$lib/ui';
   import RemoteSearchSelect from './facets/RemoteSearchSelect.svelte';
   import SearchSelect from './facets/SearchSelect.svelte';
 
@@ -38,6 +45,33 @@
   let skills = $state.raw<string[]>(profile ? [...profile.skills] : []);
   let formError = $state<string | null>(null);
   let busy = $state(false);
+  // Which form section is shown — the profile is long, so split it into two tabs sharing
+  // one Save (both tabs feed the same PUT).
+  let formTab = $state<'main' | 'location'>('main');
+
+  // Location & work preferences — the optional "where & how I want to work" block. Seeded
+  // once from the profile (the parent keys this component on profile identity, so a switch
+  // remounts and re-seeds). Held as flat fields; buildLocation() reassembles the block on
+  // save and the server collapses an all-empty block to "no preferences".
+  // svelte-ignore state_referenced_locally
+  const loc0 = profile?.location_preferences ?? null;
+  let workModes = $state.raw<string[]>(loc0?.work_modes ?? []);
+  let remoteRegions = $state.raw<string[]>(loc0?.remote.regions ?? []);
+  let remoteCountries = $state.raw<string[]>(loc0?.remote.countries ?? []);
+  let baseCountry = $state<string>(loc0?.base.country ?? '');
+  let baseCity = $state<string>(loc0?.base.city ?? '');
+  let relocOpen = $state<boolean>(loc0?.relocation.open ?? false);
+  let relocRegions = $state.raw<string[]>(loc0?.relocation.regions ?? []);
+  let relocCountries = $state.raw<string[]>(loc0?.relocation.countries ?? []);
+  let relocCities = $state.raw<string[]>(loc0?.relocation.cities ?? []);
+  let cityDraft = $state('');
+
+  // Work format gates the geo sub-forms (progressive disclosure): remote reach shows only
+  // when Remote is accepted; the physical base + relocation show only for On-site/Hybrid.
+  // Hidden fields linger in state (re-selecting the format restores the draft) but are not
+  // saved — buildLocation() reads the same gates.
+  const wantsRemote = $derived(workModes.includes('remote'));
+  const wantsPhysical = $derived(workModes.includes('onsite') || workModes.includes('hybrid'));
 
   // Résumé upload → skill extraction. The server also stores the CV (used by the CV
   // readiness tab); the returned slugs merge (union) into the skills field without
@@ -55,11 +89,12 @@
   const canSubmit = $derived(specializations.length > 0 && skills.length > 0);
 
   // The skills typeahead: filter the loaded distribution locally (dictionary-only, so
-  // only known skills are addable) and cap the visible matches.
+  // only known skills are addable). With no query, show just the popular top few; typing
+  // widens to the full match list — so the field is not a wall of skills on open.
   function searchSkills(query: string): Promise<FacetOption[]> {
     const q = query.trim().toLowerCase();
     const matches = q ? skillDist.filter((o) => o.label.toLowerCase().includes(q)) : skillDist;
-    return Promise.resolve(matches.slice(0, 50));
+    return Promise.resolve(matches.slice(0, q ? 50 : 8));
   }
 
   async function loadSkills() {
@@ -168,13 +203,54 @@
     skills = skills.includes(value) ? skills.filter((s) => s !== value) : [...skills, value];
   }
 
+  // Toggle a value in a multi-select list (work modes, regions, countries), returning a new
+  // array so $state.raw readers re-run.
+  function toggleIn(list: string[], value: string): string[] {
+    return list.includes(value) ? list.filter((v) => v !== value) : [...list, value];
+  }
+
+  // Two-state toggle-pill styling for the small fixed sets (work format, regions).
+  function pillCls(active: boolean): string {
+    return active
+      ? 'rounded-full bg-primary px-3 py-1 text-sm font-medium text-primary-foreground'
+      : 'rounded-full border border-border px-3 py-1 text-sm transition-colors hover:border-primary/60';
+  }
+
+  // Add the drafted city (trimmed, case-insensitive dedup) to the relocation targets.
+  function addCity() {
+    const city = cityDraft.trim();
+    cityDraft = '';
+    if (!city || relocCities.some((c) => c.toLowerCase() === city.toLowerCase())) return;
+    relocCities = [...relocCities, city];
+  }
+
+  // Reassemble the flat fields into the location block, or null when the user picked nothing
+  // (the server also collapses an all-empty block, but sending null keeps intent explicit).
+  // Relocation targets are gated on `relocOpen`: withdrawing "Open to relocation" drops them
+  // from the saved block (they linger in local state so toggling back on restores the draft),
+  // matching how the filter seed ignores targets when the user is not open to relocating.
+  function buildLocation(): LocationPreferences | null {
+    // Only persist fields the current work format reveals — a hidden sub-form's lingering
+    // draft is not saved (mirrors how the UI gates them).
+    const loc: LocationPreferences = {
+      work_modes: workModes,
+      remote: wantsRemote ? { regions: remoteRegions, countries: remoteCountries } : {},
+      base: wantsPhysical ? { country: baseCountry || undefined, city: baseCity.trim() || undefined } : {},
+      relocation:
+        wantsPhysical && relocOpen
+          ? { open: true, regions: relocRegions, countries: relocCountries, cities: relocCities }
+          : { open: false },
+    };
+    return workModes.length === 0 ? null : loc;
+  }
+
   async function submit(e: SubmitEvent) {
     e.preventDefault();
     if (!canSubmit || busy) return;
     busy = true;
     formError = null;
     try {
-      await profileStore.save(specializations, skills);
+      await profileStore.save(specializations, skills, buildLocation());
       onSaved?.();
     } catch (err) {
       formError =
@@ -186,6 +262,61 @@
 </script>
 
 <form onsubmit={submit} class="flex flex-col gap-6 rounded-xl border border-border bg-card p-5 sm:p-6">
+  <!-- Sub-tabs: the professional self vs. where/how you want to work. One Save below covers
+       both (a single PUT). -->
+  <div class="flex gap-5 border-b border-border">
+    <button
+      type="button"
+      onclick={() => (formTab = 'main')}
+      class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {formTab === 'main'
+        ? 'border-primary text-foreground'
+        : 'border-transparent text-muted-foreground hover:text-foreground'}"
+    >
+      Skills &amp; role
+    </button>
+    <button
+      type="button"
+      onclick={() => (formTab = 'location')}
+      class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {formTab === 'location'
+        ? 'border-primary text-foreground'
+        : 'border-transparent text-muted-foreground hover:text-foreground'}"
+    >
+      Location &amp; work
+    </button>
+  </div>
+
+  <!-- Region-pill group, reused by remote reach and relocation targets. Declared at the form
+       top level so it is available inside either tab. -->
+  {#snippet regionPills(selected: string[], onToggle: (v: string) => void)}
+    <div class="flex flex-wrap gap-1.5">
+      {#each REGION_OPTIONS as opt (opt.value)}
+        <button type="button" onclick={() => onToggle(opt.value)} class={pillCls(selected.includes(opt.value))}>
+          {opt.label}
+        </button>
+      {/each}
+    </div>
+  {/snippet}
+
+  <!-- A geographic reach: region pills + a top-N country search. Shared by remote reach and
+       relocation targets so the two stay identical. -->
+  {#snippet geoReach(
+    regions: string[],
+    onRegion: (v: string) => void,
+    countries: string[],
+    onCountry: (v: string) => void,
+  )}
+    {@render regionPills(regions, onRegion)}
+    <SearchSelect
+      options={COUNTRY_OPTIONS}
+      include={countries}
+      placeholder="Add specific countries"
+      onToggle={onCountry}
+      cap={8}
+      clearOnSelect
+    />
+  {/snippet}
+
+  {#if formTab === 'main'}
   <!-- Your CV: uploaded state or an empty drop-zone. Uploading extracts skills into the
        field below and stores the CV for the readiness tab. -->
   <div class="flex flex-col gap-1.5">
@@ -293,13 +424,119 @@
     />
   </div>
 
+  {:else}
+  <!-- Location & work: optional preferences. Every part is optional; leaving it all empty
+       stores "no preferences". -->
+  <div class="flex flex-col gap-4">
+    <span class="text-xs text-muted-foreground">All optional — used to tailor your job filters.</span>
+
+    <!-- Work format -->
+    <div class="flex flex-col gap-1.5">
+      <span class="text-xs font-medium text-muted-foreground">Work format</span>
+      <div class="flex flex-wrap gap-1.5">
+        {#each WORK_MODE_OPTIONS as opt (opt.value)}
+          <button type="button" onclick={() => (workModes = toggleIn(workModes, opt.value))} class={pillCls(workModes.includes(opt.value))}>
+            {opt.label}
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    {#if workModes.length === 0}
+      <span class="text-xs text-muted-foreground">Pick a work format above to set where you can work.</span>
+    {/if}
+
+    <!-- Remote reach — only relevant once Remote is accepted. -->
+    {#if wantsRemote}
+      <div class="flex flex-col gap-1.5">
+        <span class="text-xs font-medium text-muted-foreground">Remote — regions you can work for (empty = worldwide)</span>
+        {@render geoReach(
+          remoteRegions,
+          (v) => (remoteRegions = toggleIn(remoteRegions, v)),
+          remoteCountries,
+          (v) => (remoteCountries = toggleIn(remoteCountries, v)),
+        )}
+      </div>
+    {/if}
+
+    <!-- Physical presence (base + relocation) — only for On-site / Hybrid. -->
+    {#if wantsPhysical}
+      <!-- Base location -->
+      <div class="flex flex-col gap-1.5">
+        <span class="text-xs font-medium text-muted-foreground">Where you're based</span>
+        <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <select
+            bind:value={baseCountry}
+            aria-label="Base country"
+            class="h-9 rounded-lg border border-input bg-transparent px-3 text-sm transition-colors focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 dark:bg-input/30"
+          >
+            <option value="">Country…</option>
+            {#each COUNTRY_OPTIONS as opt (opt.value)}
+              <option value={opt.value}>{opt.label}</option>
+            {/each}
+          </select>
+          <Input bind:value={baseCity} aria-label="Base city" placeholder="City" class="w-full" />
+        </div>
+      </div>
+
+      <!-- Relocation -->
+      <div class="flex flex-col gap-2">
+        <label class="flex items-center gap-2 text-sm">
+          <input type="checkbox" bind:checked={relocOpen} class="size-4 rounded border-input" />
+          Open to relocation
+        </label>
+        {#if relocOpen}
+          <span class="text-xs font-medium text-muted-foreground">Where you'd relocate (empty = anywhere)</span>
+          {@render geoReach(
+            relocRegions,
+            (v) => (relocRegions = toggleIn(relocRegions, v)),
+            relocCountries,
+            (v) => (relocCountries = toggleIn(relocCountries, v)),
+          )}
+          {#if relocCities.length > 0}
+            <div class="flex flex-wrap gap-1.5">
+              {#each relocCities as city (city)}
+                <button
+                  type="button"
+                  onclick={() => (relocCities = relocCities.filter((c) => c !== city))}
+                  class="inline-flex items-center gap-1 rounded-full bg-primary px-2.5 py-1 text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
+                >
+                  {city}
+                  <X class="size-3" />
+                </button>
+              {/each}
+            </div>
+          {/if}
+          <Input
+            bind:value={cityDraft}
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addCity();
+              }
+            }}
+            aria-label="Add a relocation city"
+            placeholder="Add a city, press Enter"
+            class="w-full"
+          />
+        {/if}
+      </div>
+    {/if}
+  </div>
+  {/if}
+
   {#if formError}
     <p class="text-sm text-destructive">{formError}</p>
   {/if}
 
-  <div class="flex items-center gap-2 border-t border-border pt-4">
+  <div class="flex items-center gap-3 border-t border-border pt-4">
     <Button variant="primary" type="submit" disabled={!canSubmit || busy}>
       {busy ? 'Saving…' : editing ? 'Save changes' : 'Create profile'}
     </Button>
+    {#if !canSubmit}
+      <span class="text-xs text-muted-foreground">
+        Add a role and at least one skill in the “Skills &amp; role” tab to save.
+      </span>
+    {/if}
   </div>
 </form>

--- a/web/src/lib/components/filters/FilterModal.svelte
+++ b/web/src/lib/components/filters/FilterModal.svelte
@@ -190,7 +190,7 @@
   {#if profile}
     <button
       type="button"
-      onclick={() => staged.applyProfile(profile.specializations, profile.skills)}
+      onclick={() => staged.applyProfile(profile)}
       class="flex h-9 items-center gap-1.5 rounded-lg border border-border px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent"
     >
       <UserRound class="size-4 shrink-0" aria-hidden="true" />

--- a/web/src/lib/facetModel.ts
+++ b/web/src/lib/facetModel.ts
@@ -6,6 +6,7 @@
 // `<param>_exclude` and `<param>_mode=and` conventions.
 
 import { FACETS, type FacetSelection } from './facets';
+import type { UserProfile } from './types';
 
 /** The three states a facet value can hold. */
 export type Sign = 'off' | 'include' | 'exclude';
@@ -176,13 +177,37 @@ export function facetRemove(st: FacetState, v: string): FacetState {
   return facetSetSign(st, v, 'off');
 }
 
-/** Build a fresh filter set seeded from a user profile: specializations become
- *  `category` values and skills become `skills` values, everything else empty. The
- *  reset-and-seed behind "Apply my profile" — trimming/dedup come free from facetAdd. */
-export function filtersFromProfile(specializations: string[], skills: string[]): JobFilters {
+/** Build a fresh filter set seeded from a user profile — the reset-and-seed behind
+ *  "Apply my profile". Specializations become `category` values and skills become `skills`.
+ *  The optional location block flattens into the location facets: work_modes → `work_mode`;
+ *  regions from the remote reach ∪ relocation targets; countries from the remote reach ∪
+ *  base ∪ relocation targets; cities from the base ∪ relocation targets; and `relocation`
+ *  staged as supported+required when the user is open to relocating. The flatten is lossy
+ *  (base vs relocation merge) — the filter is a convenience narrowing of "places relevant to
+ *  me". Trimming/dedup come free from facetAdd, so unions of overlapping lists are safe. */
+export function filtersFromProfile(profile: UserProfile): JobFilters {
   const seed = (values: string[]) => values.reduce(facetAdd, emptyFacet());
   const f = emptyFilters();
-  f.facets.category = seed(specializations);
-  f.facets.skills = seed(skills);
+  f.facets.category = seed(profile.specializations);
+  f.facets.skills = seed(profile.skills);
+
+  const loc = profile.location_preferences;
+  if (loc) {
+    // Relocation targets only count when the user is actually open to relocating — `open`
+    // gates the whole relocation contribution (targets and the relocation facet alike).
+    const reloc = loc.relocation.open ? loc.relocation : { regions: [], countries: [], cities: [] };
+    f.facets.work_mode = seed(loc.work_modes ?? []);
+    f.facets.regions = seed([...(loc.remote.regions ?? []), ...(reloc.regions ?? [])]);
+    f.facets.countries = seed([
+      ...(loc.remote.countries ?? []),
+      ...(loc.base.country ? [loc.base.country] : []),
+      ...(reloc.countries ?? []),
+    ]);
+    f.facets.cities = seed([
+      ...(loc.base.city ? [loc.base.city] : []),
+      ...(reloc.cities ?? []),
+    ]);
+    if (loc.relocation.open) f.facets.relocation = seed(['supported', 'required']);
+  }
   return f;
 }

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -334,6 +334,11 @@ const CATEGORY: FacetOption[] = options(CATEGORY_VALUES, CATEGORY_LABELS);
 // profile's specialization picker) so the same labels/order are shared, not duplicated.
 export const CATEGORY_OPTIONS: FacetOption[] = CATEGORY;
 
+// Work-mode and region options, exported for the profile's location preferences editor so
+// it shares the filter panel's vocabulary/order instead of duplicating it.
+export const WORK_MODE_OPTIONS: FacetOption[] = WORK_MODE;
+export const REGION_OPTIONS: FacetOption[] = REGION;
+
 /** Display label for a category code (e.g. ml_ai → "ML / AI"), shared by the profile
  *  view; falls back to the humanized code. */
 export function categoryLabel(value: string): string {
@@ -395,6 +400,10 @@ const COUNTRY: FacetOption[] = ISO_COUNTRY_CODES.map((value) => ({
   value,
   label: countryLabel(value),
 })).toSorted((a, b) => a.label.localeCompare(b.label));
+
+// The full ISO country select, exported for the profile's location editor (base +
+// remote/relocation countries) so it reuses the same list/labels as the company facet.
+export const COUNTRY_OPTIONS: FacetOption[] = COUNTRY;
 
 // The company catalog's filter facets: mostly a subset of the job facets whose
 // values are mostly derived from a company's open jobs and denormalized onto the

--- a/web/src/lib/profile.svelte.ts
+++ b/web/src/lib/profile.svelte.ts
@@ -8,7 +8,7 @@
 
 import { api } from '$lib/api';
 import { UserResource } from '$lib/userResource.svelte';
-import type { UserProfile } from '$lib/types';
+import type { LocationPreferences, UserProfile } from '$lib/types';
 
 class ProfileStore extends UserResource<UserProfile | null> {
   // Reassigned (never mutated in place) on every change, so $state.raw is enough and
@@ -33,10 +33,15 @@ class ProfileStore extends UserResource<UserProfile | null> {
     this.#profile = null;
   }
 
-  /** Create-or-replace the profile. Throws on a bad specialization or empty skills (the
-   *  caller shows the error). */
-  async save(specializations: string[], skills: string[]): Promise<UserProfile> {
-    const row = await api.saveProfile(specializations, skills);
+  /** Create-or-replace the profile. `location` is the optional location-preferences block
+   *  (null clears it). Throws on a bad specialization, empty skills, or an out-of-vocabulary
+   *  location value (the caller shows the error). */
+  async save(
+    specializations: string[],
+    skills: string[],
+    location: LocationPreferences | null,
+  ): Promise<UserProfile> {
+    const row = await api.saveProfile(specializations, skills, location);
     this.#profile = row;
     this.markLoaded();
     return row;

--- a/web/src/lib/profileFilters.test.ts
+++ b/web/src/lib/profileFilters.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import { filtersFromProfile, filtersToParams, emptyFilters } from './facetModel';
+import type { LocationPreferences, UserProfile } from './types';
+
+// Build a UserProfile with just the fields the seeder reads.
+function mkProfile(
+  specializations: string[],
+  skills: string[],
+  location: LocationPreferences | null = null,
+): UserProfile {
+  return { specializations, skills, location_preferences: location, created_at: null, updated_at: null };
+}
 
 // filtersFromProfile is the pure reset-and-seed used by "Apply my profile": from a
-// clean slate it stages the user's profile specializations as `category` values and
-// skills as `skills` values, and nothing else. StagedFilters.applyProfile is a thin
-// wrapper over it.
+// clean slate it stages the user's profile specializations as `category` values, skills
+// as `skills` values, and (when present) the location block as the location facets.
+// StagedFilters.applyProfile is a thin wrapper over it.
 describe('filtersFromProfile', () => {
   it('seeds category from specializations and skills from skills, and nothing else', () => {
-    const f = filtersFromProfile(['backend', 'devops'], ['go', 'kubernetes']);
+    const f = filtersFromProfile(mkProfile(['backend', 'devops'], ['go', 'kubernetes']));
     const p = filtersToParams(f);
     expect(p.getAll('category')).toEqual(['backend', 'devops']);
     expect(p.getAll('skills')).toEqual(['go', 'kubernetes']);
@@ -16,7 +26,7 @@ describe('filtersFromProfile', () => {
   });
 
   it('starts from a clean slate (independent of any prior state)', () => {
-    const f = filtersFromProfile(['frontend'], ['react']);
+    const f = filtersFromProfile(mkProfile(['frontend'], ['react']));
     // Everything outside the two seeded facets matches an empty filter set.
     const empty = emptyFilters();
     expect(f.q).toEqual(empty.q);
@@ -27,14 +37,55 @@ describe('filtersFromProfile', () => {
   });
 
   it('trims and dedupes seeded values, and drops empties', () => {
-    const f = filtersFromProfile([' backend ', 'backend', ''], ['go', 'go', '  ']);
+    const f = filtersFromProfile(mkProfile([' backend ', 'backend', ''], ['go', 'go', '  ']));
     const p = filtersToParams(f);
     expect(p.getAll('category')).toEqual(['backend']);
     expect(p.getAll('skills')).toEqual(['go']);
   });
 
   it('empty inputs yield an empty filter set', () => {
-    const p = filtersToParams(filtersFromProfile([], []));
+    const p = filtersToParams(filtersFromProfile(mkProfile([], [])));
     expect([...p.keys()]).toEqual([]);
+  });
+
+  it('flattens the location block: the Florianópolis case', () => {
+    const location: LocationPreferences = {
+      work_modes: ['remote', 'onsite'],
+      remote: { regions: ['latam'], countries: ['br'] },
+      base: { country: 'br', city: 'Florianópolis' },
+      relocation: { open: true, regions: ['eu'], cities: ['Berlin'] },
+    };
+    const p = filtersToParams(filtersFromProfile(mkProfile(['backend'], ['go'], location)));
+    expect(p.getAll('work_mode')).toEqual(['remote', 'onsite']);
+    // regions = remote ∪ relocation targets.
+    expect(p.getAll('regions')).toEqual(['latam', 'eu']);
+    // countries = remote ∪ base ∪ relocation; base 'br' dedupes against remote 'br'.
+    expect(p.getAll('countries')).toEqual(['br']);
+    // cities = base ∪ relocation targets.
+    expect(p.getAll('cities')).toEqual(['Florianópolis', 'Berlin']);
+    // open to relocation → both relocation-supporting values.
+    expect(p.getAll('relocation')).toEqual(['supported', 'required']);
+  });
+
+  it('seeds no relocation facet when the user is not open to relocating', () => {
+    const location: LocationPreferences = {
+      remote: { regions: ['latam'] },
+      base: {},
+      relocation: { open: false, cities: ['Berlin'] },
+    };
+    const p = filtersToParams(filtersFromProfile(mkProfile(['backend'], ['go'], location)));
+    expect(p.getAll('relocation')).toEqual([]);
+    // Relocation targets are ignored when not open (open is the gate for the whole block).
+    expect(p.getAll('regions')).toEqual(['latam']);
+    expect(p.getAll('cities')).toEqual([]);
+  });
+
+  it('a profile with no location block seeds only category and skills', () => {
+    const p = filtersToParams(filtersFromProfile(mkProfile(['backend'], ['go'], null)));
+    expect(p.getAll('category')).toEqual(['backend']);
+    expect(p.getAll('skills')).toEqual(['go']);
+    for (const param of ['work_mode', 'regions', 'countries', 'cities', 'relocation']) {
+      expect(p.getAll(param)).toEqual([]);
+    }
   });
 });

--- a/web/src/lib/stagedFilters.svelte.ts
+++ b/web/src/lib/stagedFilters.svelte.ts
@@ -7,6 +7,7 @@
 // same facet controls render against staged or live state without change.
 
 import type { FacetStore } from './facets';
+import type { UserProfile } from './types';
 import {
   activeFilterCount,
   emptyFacet,
@@ -92,10 +93,11 @@ export class StagedFilters implements FacetStore {
     this.#f = emptyFilters();
   }
 
-  /** Reset every staged filter and seed from a user profile: specializations →
-   *  `category`, skills → `skills`. Backs the modal's "Apply my profile" action. */
-  applyProfile(specializations: string[], skills: string[]): void {
-    this.#f = filtersFromProfile(specializations, skills);
+  /** Reset every staged filter and seed from a user profile: specializations → `category`,
+   *  skills → `skills`, and the location block → the location facets (see filtersFromProfile).
+   *  Backs the modal's "Apply my profile" action. */
+  applyProfile(profile: UserProfile): void {
+    this.#f = filtersFromProfile(profile);
   }
 
   /** Replace the staged filters from a saved query string — the "My filters" tab

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -270,9 +270,41 @@ export interface Board {
  *  `specializations` (job categories) and a non-empty set of canonical skill tokens. One
  *  per user (no id, no name); the foundation for finding relevant work. Timestamps are
  *  RFC3339 strings or null. */
+/** A geographic reach: controlled regions and/or ISO country codes. Empty = anywhere. */
+export interface LocationGeoSet {
+  regions?: string[];
+  countries?: string[];
+}
+
+/** The user's current single base: an ISO country code and a free-text city. */
+export interface LocationBase {
+  country?: string;
+  city?: string;
+}
+
+/** Willingness to relocate: an open flag plus acceptable destinations (open + empty
+ *  targets = anywhere). */
+export interface LocationRelocation {
+  open: boolean;
+  regions?: string[];
+  countries?: string[];
+  cities?: string[];
+}
+
+/** Optional "where & how I want to work" block: accepted work arrangements plus three
+ *  geographic parts (remote reach, current base, relocation), freely combined. Mirrors the
+ *  backend userprofile.LocationPreferences; null on a profile means the user set none. */
+export interface LocationPreferences {
+  work_modes?: string[];
+  remote: LocationGeoSet;
+  base: LocationBase;
+  relocation: LocationRelocation;
+}
+
 export interface UserProfile {
   specializations: string[];
   skills: string[];
+  location_preferences: LocationPreferences | null;
   created_at: string | null;
   updated_at: string | null;
 }


### PR DESCRIPTION
## Summary
Adds an optional, structured **location & work-mode preferences** block to the singleton user profile, so a user can record compound, directional preferences at once — e.g. *remote for LATAM* + *on-site in Florianópolis* + *willing to relocate to Berlin*.

**Model** — three freely-combined blocks in one nullable `location_preferences` jsonb column:
- `work_modes[]` (remote/hybrid/onsite)
- `remote{regions,countries}` — remote reach (empty = worldwide)
- `base{country,city}` — where you're based
- `relocation{open,regions,countries,cities}` — open + empty targets = anywhere

All fields optional; an all-empty block collapses to `NULL`. Reuses the existing work-mode/region vocabularies + ISO country shape. Validation in `internal/userprofile` (regions/work_modes case-insensitive; country **shape-checked** — the location dictionary is a curated subset that would over-reject valid countries).

**Apply my profile** now flattens the block into the jobs-filter facets (work_mode; regions/countries/cities as unions; relocation → supported+required when open — `open` gates the whole relocation contribution).

**Frontend** — tabbed `ProfileForm` (*Skills & role* / *Location & work*) with progressive disclosure: geo sub-forms reveal by work format, and country/skill lists show a top-N with type-to-search.

Matching/recommendations consuming these preferences are **out of scope** (schema already supports them). OpenSpec change: `add-profile-location-preferences`.

## ⚠️ Deploy note
Migration `0009_user_profile_location.sql` must be **applied to prod manually before deploying** the new binary (initdb only runs on first volume init; an unapplied column 500s all profile reads/writes — the known 42703 incident).

## Test plan
- [x] `go build/vet/test ./...` green; `make sqlc` no-diff
- [x] web `svelte-check` 0/0, `vitest` 122/122, changed-file `eslint` clean, prod build ok
- [x] Live e2e through the full stack (nginx→SSR→Go→Postgres): login → PUT profile with location → GET round-trips; normalization verified (`BR`→`br`, trim, case-insensitive city dedup)
- [x] Reviewed by finder agents (backend + frontend); all confirmed findings fixed (country over-rejection, enum case, relocation-target gating, a11y labels)