### PR TITLE
feat(trends): x-axis dates, y-max & hover readout on the activity chart

### DIFF
--- a/web/src/lib/activityChart.test.ts
+++ b/web/src/lib/activityChart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildActivityChart, type ActivityBar } from './activityChart';
+import { buildActivityChart, formatCount, pickTickIndices, type ActivityBar } from './activityChart';
 import type { ActivityPoint } from './types';
 
 const pt = (period: string, added: number, removed: number): ActivityPoint => ({
@@ -54,5 +54,48 @@ describe('buildActivityChart', () => {
     const m = buildActivityChart([pt('2026-01-01', 4, 4)]);
     const bar = requireBar(m.bars, 0);
     expect(bar.removedX).toBeGreaterThanOrEqual(bar.addedX + m.barW);
+  });
+
+  it('centres each bar-pair at the seam between its two bars', () => {
+    const m = buildActivityChart([pt('2026-01-01', 4, 4)]);
+    const bar = requireBar(m.bars, 0);
+    // The slot centre is where the added bar ends and the removed bar begins.
+    expect(bar.centerX).toBeCloseTo(bar.addedX + m.barW);
+    expect(bar.centerX).toBeCloseTo(bar.removedX);
+  });
+});
+
+describe('formatCount', () => {
+  it('leaves small numbers as-is', () => {
+    expect(formatCount(0)).toBe('0');
+    expect(formatCount(842)).toBe('842');
+  });
+  it('abbreviates thousands and millions', () => {
+    expect(formatCount(697191)).toBe('697K');
+    expect(formatCount(3354251)).toBe('3.4M');
+    expect(formatCount(3400)).toBe('3.4K');
+  });
+});
+
+describe('pickTickIndices', () => {
+  it('labels every index when there are few', () => {
+    expect(pickTickIndices(3)).toEqual([0, 1, 2]);
+  });
+  it('always includes the first and last index', () => {
+    const ticks = pickTickIndices(90);
+    expect(ticks[0]).toBe(0);
+    expect(ticks[ticks.length - 1]).toBe(89);
+  });
+  it('thins a long series to a readable number of ticks', () => {
+    const ticks = pickTickIndices(90);
+    expect(ticks.length).toBeLessThanOrEqual(12);
+    // strictly increasing, in range
+    for (let i = 1; i < ticks.length; i++) {
+      expect(ticks[i]!).toBeGreaterThan(ticks[i - 1]!);
+      expect(ticks[i]!).toBeLessThan(90);
+    }
+  });
+  it('returns nothing for an empty series', () => {
+    expect(pickTickIndices(0)).toEqual([]);
   });
 });

--- a/web/src/lib/activityChart.ts
+++ b/web/src/lib/activityChart.ts
@@ -18,6 +18,9 @@ export interface ActivityBar {
   removedX: number;
   removedY: number;
   removedH: number;
+  /** Centre x of the period slot (the seam between the two bars) — anchors the
+   *  x-axis date tick and the hover highlight. */
+  centerX: number;
 }
 
 /** The full chart model: the positioned bars plus the viewBox and baseline the
@@ -28,9 +31,11 @@ export interface ActivityChartModel {
   height: number;
   baselineY: number;
   /** The count the tallest bar represents (always ≥ 1 so scaling never divides by
-   *  zero); handy for a y-axis max label. */
+   *  zero); labels the y-axis max. */
   max: number;
   barW: number;
+  /** Width of one period slot — the hover highlight spans it. */
+  slot: number;
 }
 
 const WIDTH = 960;
@@ -51,6 +56,7 @@ export function buildActivityChart(points: ActivityPoint[]): ActivityChartModel 
     baselineY,
     max: 1,
     barW: 0,
+    slot: 0,
   };
   if (points.length === 0) {
     return { ...frame, bars: [] };
@@ -62,8 +68,9 @@ export function buildActivityChart(points: ActivityPoint[]): ActivityChartModel 
 
   const bars = points.map((p, i): ActivityBar => {
     const slotX = PAD + i * slot;
-    const addedX = slotX + slot / 2 - barW; // left of centre
-    const removedX = slotX + slot / 2; // right of centre
+    const centerX = slotX + slot / 2;
+    const addedX = centerX - barW; // left of centre
+    const removedX = centerX; // right of centre
     const addedH = (p.added / max) * PLOT_H;
     const removedH = (p.removed / max) * PLOT_H;
     return {
@@ -76,8 +83,35 @@ export function buildActivityChart(points: ActivityPoint[]): ActivityChartModel 
       removedX,
       removedY: baselineY - removedH,
       removedH,
+      centerX,
     };
   });
 
-  return { ...frame, bars, max, barW };
+  return { ...frame, bars, max, barW, slot };
+}
+
+/** Compact count formatting for axis/summary labels: 3354251 → "3.4M",
+ *  697191 → "697K", 842 → "842". Full precision is left to the tooltip. */
+export function formatCount(n: number): string {
+  const abs = Math.abs(n);
+  if (abs >= 1e6) return trimZero((n / 1e6).toFixed(1)) + 'M';
+  if (abs >= 1e3) return trimZero((n / 1e3).toFixed(abs >= 1e5 ? 0 : 1)) + 'K';
+  return String(n);
+}
+
+function trimZero(s: string): string {
+  return s.replace(/\.0$/, '');
+}
+
+/** Choose which period indices get an x-axis date label. Few periods → label all;
+ *  a long series is thinned to at most MAX_TICKS evenly-spaced labels, always
+ *  including the first and last so the time span reads correctly. */
+export function pickTickIndices(count: number): number[] {
+  const MAX_TICKS = 12;
+  if (count <= 0) return [];
+  if (count <= MAX_TICKS) return Array.from({ length: count }, (_, i) => i);
+  const step = (count - 1) / (MAX_TICKS - 1);
+  const seen = new Set<number>();
+  for (let i = 0; i < MAX_TICKS; i++) seen.add(Math.round(i * step));
+  return [...seen].sort((a, b) => a - b);
 }

--- a/web/src/lib/components/ActivityBars.svelte
+++ b/web/src/lib/components/ActivityBars.svelte
@@ -1,56 +1,158 @@
 <script lang="ts">
-  import { buildActivityChart } from '$lib/activityChart';
+  import { buildActivityChart, formatCount, pickTickIndices } from '$lib/activityChart';
   import type { ActivityPoint } from '$lib/types';
 
   // A grouped bar chart of catalogue flow: per period, a green "added" bar and a
   // red "removed" bar. Hand-built SVG scaled to its container width — no charting
-  // dependency, matching PipelineFunnel/RateDonut. All geometry comes from the
-  // pure buildActivityChart model; this component only draws it.
+  // dependency, matching PipelineFunnel/RateDonut. Geometry comes from the pure
+  // buildActivityChart model; this component draws it and layers on the x-axis
+  // date labels, a y-axis max, and a hover readout of exact per-period counts.
   let { points }: { points: ActivityPoint[] } = $props();
 
   const model = $derived(buildActivityChart(points));
+  const ticks = $derived(pickTickIndices(model.bars.length));
+  // Top of the plot area (where a full-height bar reaches) = the model's top pad.
+  const topY = $derived(model.height - model.baselineY);
+  // Left/right padding the model reserves around the plot (mirrors its PAD), needed
+  // to map a pointer x back to a bar index.
+  const pad = $derived((model.width - model.slot * model.bars.length) / 2);
+
+  // Hover state: the focused bar index plus the pointer pixel position for the
+  // floating tooltip. Null until the pointer enters (so SSR renders no tooltip).
+  let hovered = $state<number | null>(null);
+  let tipX = $state(0);
+  let tipY = $state(0);
+
+  const hoveredBar = $derived(hovered === null ? null : (model.bars[hovered] ?? null));
+
+  function onMove(e: PointerEvent) {
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    if (rect.width === 0 || model.bars.length === 0) return;
+    const vbX = ((e.clientX - rect.left) / rect.width) * model.width;
+    const i = Math.floor((vbX - pad) / model.slot);
+    hovered = Math.min(Math.max(i, 0), model.bars.length - 1);
+    tipX = e.clientX - rect.left;
+    tipY = e.clientY - rect.top;
+  }
+
+  /** Short axis label, e.g. "Jun 1". */
+  function shortDate(period: string): string {
+    return new Date(period + 'T00:00:00Z').toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    });
+  }
+
+  /** Full tooltip date, e.g. "1 Jun 2026". */
+  function fullDate(period: string): string {
+    return new Date(period + 'T00:00:00Z').toLocaleDateString(undefined, {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+  }
 </script>
 
 {#if model.bars.length === 0}
   <p class="py-16 text-center text-sm text-muted-foreground">No activity in this range yet.</p>
 {:else}
   <figure class="flex flex-col gap-3">
-    <svg
-      viewBox="0 0 {model.width} {model.height}"
-      class="w-full"
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="relative"
       role="img"
       aria-label="Vacancies added versus removed per period"
+      onpointermove={onMove}
+      onpointerleave={() => (hovered = null)}
     >
-      {#each model.bars as bar (bar.period)}
-        <rect
-          x={bar.addedX}
-          y={bar.addedY}
-          width={model.barW}
-          height={bar.addedH}
-          class="fill-emerald-500"
+      <svg viewBox="0 0 {model.width} {model.height + 22}" class="w-full">
+        <!-- y-axis max reference line + label -->
+        <line
+          x1={pad}
+          y1={topY}
+          x2={model.width - pad}
+          y2={topY}
+          class="stroke-border"
+          stroke-dasharray="2 3"
+        />
+        <text x={pad} y={topY - 4} class="fill-muted-foreground" font-size="11">
+          {formatCount(model.max)}
+        </text>
+
+        {#if hovered !== null && hoveredBar}
+          <!-- highlight the focused slot -->
+          <rect
+            x={pad + hovered * model.slot}
+            y={topY}
+            width={model.slot}
+            height={model.baselineY - topY}
+            class="fill-muted/50"
+          />
+        {/if}
+
+        {#each model.bars as bar (bar.period)}
+          <rect
+            x={bar.addedX}
+            y={bar.addedY}
+            width={model.barW}
+            height={bar.addedH}
+            class="fill-emerald-500"
+          />
+          <rect
+            x={bar.removedX}
+            y={bar.removedY}
+            width={model.barW}
+            height={bar.removedH}
+            class="fill-rose-500"
+          />
+        {/each}
+
+        <!-- baseline -->
+        <line
+          x1="0"
+          y1={model.baselineY}
+          x2={model.width}
+          y2={model.baselineY}
+          class="stroke-border"
+          stroke-width="1"
+        />
+
+        <!-- x-axis date labels (thinned for long series) -->
+        {#each ticks as i (i)}
+          {@const bar = model.bars[i]}
+          {#if bar}
+            <text
+              x={bar.centerX}
+              y={model.baselineY + 16}
+              text-anchor="middle"
+              class="fill-muted-foreground"
+              font-size="11"
+            >
+              {shortDate(bar.period)}
+            </text>
+          {/if}
+        {/each}
+      </svg>
+
+      {#if hoveredBar}
+        <div
+          class="pointer-events-none absolute z-10 -translate-x-1/2 -translate-y-full rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs shadow-md"
+          style="left: {tipX}px; top: {tipY - 8}px;"
         >
-          <title>{bar.period}: +{bar.added} added</title>
-        </rect>
-        <rect
-          x={bar.removedX}
-          y={bar.removedY}
-          width={model.barW}
-          height={bar.removedH}
-          class="fill-rose-500"
-        >
-          <title>{bar.period}: −{bar.removed} removed</title>
-        </rect>
-      {/each}
-      <!-- Baseline the bars sit on. -->
-      <line
-        x1="0"
-        y1={model.baselineY}
-        x2={model.width}
-        y2={model.baselineY}
-        class="stroke-border"
-        stroke-width="1"
-      />
-    </svg>
+          <div class="mb-1 font-medium text-foreground">{fullDate(hoveredBar.period)}</div>
+          <div class="flex items-center gap-1.5 text-muted-foreground">
+            <span class="inline-block h-2 w-2 rounded-sm bg-emerald-500"></span>
+            Added <span class="ml-auto font-medium text-foreground">{hoveredBar.added.toLocaleString()}</span>
+          </div>
+          <div class="flex items-center gap-1.5 text-muted-foreground">
+            <span class="inline-block h-2 w-2 rounded-sm bg-rose-500"></span>
+            Removed <span class="ml-auto font-medium text-foreground">{hoveredBar.removed.toLocaleString()}</span>
+          </div>
+        </div>
+      {/if}
+    </div>
 
     <figcaption class="flex items-center justify-center gap-6 text-xs text-muted-foreground">
       <span class="flex items-center gap-1.5">


### PR DESCRIPTION
Follow-up polish on the `/trends` chart (the bars alone showed no numbers/dates).

- **X-axis date labels**, thinned to ~12 evenly-spaced ticks so a 90-day series stays readable (`pickTickIndices`).
- **Y-axis max** reference line + compact label (`formatCount`, e.g. `3.4M`, `697K`).
- **Hover readout**: a visible tooltip with the full date and exact added/removed counts (thousands-separated), plus a slot highlight — scales to any density where per-bar labels wouldn't.

Pure helpers `formatCount` / `pickTickIndices` are unit-tested; the component maps pointer x → focused bar. Verified visually (sparse monthly + dense daily). `check` 0/0, vitest + lint green.