### PR TITLE
fix(jobfit): retry transient stage failures + clean SSE error

### DIFF
--- a/internal/handler/job_fit_stream.go
+++ b/internal/handler/job_fit_stream.go
@@ -68,11 +68,11 @@ func (a *API) StreamJobFit(c *fiber.Ctx) error {
 		})
 		if err != nil {
 			log.Printf("jobfit: stream analyze failed for user %d job %d: %v", userID, job.ID, err)
-			writeSSE(w, "error", map[string]string{"message": "analysis failed"})
+			writeSSE(w, "stream_error", map[string]string{"message": "analysis failed"})
 			return
 		}
 		if analysis == nil {
-			writeSSE(w, "error", map[string]string{"message": "analysis unavailable"})
+			writeSSE(w, "stream_error", map[string]string{"message": "analysis unavailable"})
 			return
 		}
 		a.cacheAnalysis(ctx, userID, job, cvUploadedAt, analysis)

--- a/internal/jobfit/analyzer.go
+++ b/internal/jobfit/analyzer.go
@@ -141,19 +141,34 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 	return &analysis, nil
 }
 
+// stageAttempts is how many times a stage's LLM call is tried before giving up. The
+// gateway occasionally returns a transient HTML error page (a 502/504 under the slow
+// reasoning model's load) that fails JSON parsing; a single retry recovers it, mirroring
+// the enrichment worker's retry-once policy.
+const stageAttempts = 2
+
 // streamStage runs one streaming JSON call, forwarding reasoning deltas as thinking
-// events for the given stage, and unmarshals the accumulated JSON into out.
+// events for the given stage, and unmarshals the accumulated JSON into out. A transport
+// or parse failure is retried once (stageAttempts) before it is returned — the retry's
+// thinking deltas stream too, so the panel simply continues.
 func (a *Analyzer) streamStage(ctx context.Context, stage int, system, user string, emit func(Event), out any) error {
-	raw, err := a.client.GenerateJSONStream(ctx, system, user, func(t string) {
-		emit(Event{Kind: EventThinking, Stage: stage, Thinking: t})
-	})
-	if err != nil {
-		return err
+	var err error
+	for attempt := 1; attempt <= stageAttempts; attempt++ {
+		var raw string
+		raw, err = a.client.GenerateJSONStream(ctx, system, user, func(t string) {
+			emit(Event{Kind: EventThinking, Stage: stage, Thinking: t})
+		})
+		if err == nil {
+			if err = json.Unmarshal([]byte(strings.TrimSpace(raw)), out); err == nil {
+				return nil
+			}
+			err = fmt.Errorf("parse: %w", err)
+		}
+		if attempt < stageAttempts {
+			log.Printf("jobfit: stage %d attempt %d failed, retrying: %v", stage, attempt, err)
+		}
 	}
-	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), out); err != nil {
-		return fmt.Errorf("parse: %w", err)
-	}
-	return nil
+	return err
 }
 
 // stage1SystemPrompt pins the ATS extract-and-match contract.

--- a/internal/jobfit/analyzer_test.go
+++ b/internal/jobfit/analyzer_test.go
@@ -85,7 +85,8 @@ func TestAnalyze_ThreeStageChainUsesAuditedVerdict(t *testing.T) {
 }
 
 func TestAnalyze_Stage3FailFallsBackToStage2(t *testing.T) {
-	m := &queuedModel{resp: []string{stage1JSON, stage2JSON, "not json"}}
+	// Stage 3 fails on both attempts (the retry also gets junk), then falls back.
+	m := &queuedModel{resp: []string{stage1JSON, stage2JSON, "not json", "still not json"}}
 	got, err := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput())
 	if err != nil {
 		t.Fatalf("Analyze should degrade, not error: %v", err)
@@ -115,6 +116,22 @@ func TestAnalyze_Stage3PartialMergesOntoStage2(t *testing.T) {
 	}
 	if len(got.Gaps) != 1 || got.Gaps[0] != "Thin on scale" {
 		t.Errorf("gaps = %v, want the audit's override", got.Gaps)
+	}
+}
+
+func TestAnalyzeStream_RetriesATransientStageFailure(t *testing.T) {
+	// Stage 1 first returns an HTML error page (a transient gateway 502), then valid JSON
+	// on the retry; the chain must recover and produce the final analysis.
+	m := &queuedModel{resp: []string{`<html>502 Bad Gateway</html>`, stage1JSON, stage2JSON, stage3JSON}}
+	got, err := NewAnalyzer(llm.NewWithModel(m)).Analyze(context.Background(), sampleInput())
+	if err != nil {
+		t.Fatalf("Analyze should recover on retry: %v", err)
+	}
+	if got == nil || got.OverallScore != 58 {
+		t.Errorf("recovered final = %+v, want overall 58", got)
+	}
+	if m.n != 4 {
+		t.Errorf("model calls = %d, want 4 (1 failed stage-1 + retry + stages 2,3)", m.n)
 	}
 }
 

--- a/web/src/lib/jobFit.test.ts
+++ b/web/src/lib/jobFit.test.ts
@@ -56,7 +56,7 @@ describe('reduceFitEvent', () => {
   });
 
   it('captures an error event as terminal', () => {
-    const s = reduceFitEvent(initFitStream(), 'error', { message: 'boom' });
+    const s = reduceFitEvent(initFitStream(), 'stream_error', { message: 'boom' });
     expect(s.error).toBe('boom');
     expect(s.done).toBe(true);
   });

--- a/web/src/lib/jobFit.ts
+++ b/web/src/lib/jobFit.ts
@@ -107,7 +107,7 @@ export function reduceFitEvent(prev: FitStreamState, name: string, data: unknown
       s.done = true;
       s.stages = s.stages.map((x) => ({ ...x, state: 'done' as StageState }));
       return s;
-    case 'error':
+    case 'stream_error':
       s.error = String(d.message ?? 'Analysis failed');
       s.done = true;
       return s;

--- a/web/src/routes/jobs/[slug]/fit/+page.svelte
+++ b/web/src/routes/jobs/[slug]/fit/+page.svelte
@@ -48,10 +48,12 @@
     showThinking = true;
     const source = new EventSource(api.jobFitStreamUrl(data.job.public_slug), { withCredentials: true });
     es = source;
-    for (const name of ['meta', 'stage_start', 'stage_done', 'thinking', 'requirements', 'dimensions', 'final', 'error']) {
+    // NB: our server error event is `stream_error`, never `error` — `error` is
+    // EventSource's own reserved connection-error event (handled by onerror below).
+    for (const name of ['meta', 'stage_start', 'stage_done', 'thinking', 'requirements', 'dimensions', 'final', 'stream_error']) {
       source.addEventListener(name, (e) => {
         stream = reduceFitEvent(stream, name, JSON.parse((e as MessageEvent).data));
-        if (name === 'final' || name === 'error') stop();
+        if (name === 'final' || name === 'stream_error') stop();
       });
     }
     // A connection drop before the final event is a real failure (not the normal close,


### PR DESCRIPTION
## Summary

Prod diagnosis of the streaming fit page failing with "Connection lost":
- The model (`privateclaw/mid`) is a **slow reasoning model** whose gateway occasionally returns a transient **HTML error page** (502/504) that fails JSON parsing (`invalid character '<'`). The chain had **no retry**.
- The SSE server event was named `error`, which **collides with EventSource's reserved connection-error event** — so every failure surfaced as the opaque "Connection lost" instead of a real message.

Fixes:
- **Retry once per stage** on transport/parse failure (`stageAttempts=2`), mirroring the enrichment worker — a transient 502 recovers on the retry.
- **Rename the SSE error event `error` → `stream_error`** so the client distinguishes a genuine analysis failure (clean message) from a native connection drop. Page + reducer updated.

(Confirmed the gateway itself is healthy and returns reasoning tokens — so the thinking panel will populate.)

## Test Plan
- [x] `go test ./...` — 65 pkgs (new: retry recovers a transient HTML failure; Stage-3 fallback now needs both attempts to fail)
- [x] stream integration green; `svelte-check` 0, `eslint` clean, `vitest` 7