### PR TITLE
fix(jobfit): make the slow reasoning model complete (timeout + smaller prompts + retry)

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -36,6 +36,10 @@ const (
 	// telegramLinkTTL bounds how long a deep-link token is valid — long enough to
 	// open Telegram and tap Start, short enough to limit a leaked link's window.
 	telegramLinkTTL = 10 * time.Minute
+	// jobfitLLMTimeout is the per-stage LLM timeout for the fit analysis: its reasoning
+	// model spends tens of seconds thinking before answering, so a stage needs more than
+	// the shared client's default.
+	jobfitLLMTimeout = 180 * time.Second
 )
 
 // API holds dependencies shared across HTTP handlers.
@@ -197,9 +201,10 @@ func Register(app *fiber.App, cfg Config) {
 	// or not the LLM is configured.
 	a.atsAnalyzer = atscheck.NewAnalyzer(cfg.LLM)
 	a.atsCache = queries
-	// The fit analysis shares the same LLM client (nil-safe: a nil client makes
-	// Analyze a no-op, so the endpoint degrades to no analysis).
-	a.jobFit = jobfit.NewAnalyzer(cfg.LLM)
+	// The fit analysis shares the same LLM client but with a longer per-call timeout:
+	// its reasoning model is slow (tens of seconds per stage), so the default would time
+	// out mid-stage. Nil-safe (a nil client stays nil → Analyze is a no-op).
+	a.jobFit = jobfit.NewAnalyzer(cfg.LLM.WithTimeout(jobfitLLMTimeout))
 	a.jobFitCache = queries
 	// Telegram notifications are enabled only with both a bot token and a JWT
 	// secret (the link token reuses it). Absent either, the linking endpoints

--- a/internal/jobfit/analyzer.go
+++ b/internal/jobfit/analyzer.go
@@ -11,11 +11,14 @@ import (
 	"github.com/strelov1/freehire/internal/llm"
 )
 
-// Input bounds for untrusted, user/ingest-supplied text sent to the model.
+// Input bounds for untrusted, user/ingest-supplied text sent to the model. Kept modest
+// on purpose: the fit model reasons over every input token, so a large CV/description
+// balloons its thinking time (tens of seconds per stage). These caps keep each stage
+// responsive while still covering the substance of a CV and a posting.
 const (
-	maxCVRunes          = 24000
-	maxDescriptionRunes = 16000
-	maxCompanyRunes     = 4000
+	maxCVRunes          = 10000
+	maxDescriptionRunes = 6000
+	maxCompanyRunes     = 2000
 )
 
 // Analyzer runs the fixed three-stage fit prompt-chain over an llm.Client. A nil
@@ -141,34 +144,34 @@ func (a *Analyzer) AnalyzeStream(ctx context.Context, in Input, emit func(Event)
 	return &analysis, nil
 }
 
-// stageAttempts is how many times a stage's LLM call is tried before giving up. The
-// gateway occasionally returns a transient HTML error page (a 502/504 under the slow
-// reasoning model's load) that fails JSON parsing; a single retry recovers it, mirroring
-// the enrichment worker's retry-once policy.
+// stageAttempts is how many times a stage's LLM call is tried on a PARSE failure. The
+// gateway occasionally returns a transient HTML error page (a 502/504) that fails JSON
+// parsing; a single re-try recovers it, mirroring the enrichment worker. A transport
+// error (timeout, connection) is NOT retried — the model is slow, so a retry with the
+// same timeout would only double the wait — it is returned immediately.
 const stageAttempts = 2
 
 // streamStage runs one streaming JSON call, forwarding reasoning deltas as thinking
 // events for the given stage, and unmarshals the accumulated JSON into out. A transport
-// or parse failure is retried once (stageAttempts) before it is returned — the retry's
-// thinking deltas stream too, so the panel simply continues.
+// failure returns at once; a parse failure (non-JSON gateway error page) is retried once.
 func (a *Analyzer) streamStage(ctx context.Context, stage int, system, user string, emit func(Event), out any) error {
-	var err error
+	var parseErr error
 	for attempt := 1; attempt <= stageAttempts; attempt++ {
-		var raw string
-		raw, err = a.client.GenerateJSONStream(ctx, system, user, func(t string) {
+		raw, err := a.client.GenerateJSONStream(ctx, system, user, func(t string) {
 			emit(Event{Kind: EventThinking, Stage: stage, Thinking: t})
 		})
-		if err == nil {
-			if err = json.Unmarshal([]byte(strings.TrimSpace(raw)), out); err == nil {
-				return nil
-			}
-			err = fmt.Errorf("parse: %w", err)
+		if err != nil {
+			return err // transport/timeout — retrying wouldn't help, fail fast
 		}
+		if parseErr = json.Unmarshal([]byte(strings.TrimSpace(raw)), out); parseErr == nil {
+			return nil
+		}
+		parseErr = fmt.Errorf("parse: %w", parseErr)
 		if attempt < stageAttempts {
-			log.Printf("jobfit: stage %d attempt %d failed, retrying: %v", stage, attempt, err)
+			log.Printf("jobfit: stage %d parse failed, retrying: %v", stage, parseErr)
 		}
 	}
-	return err
+	return parseErr
 }
 
 // stage1SystemPrompt pins the ATS extract-and-match contract.

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -45,6 +45,18 @@ func (c *Client) ModelID() string {
 	return c.modelID
 }
 
+// WithTimeout returns a shallow copy of the client with a different per-call timeout,
+// so a slow use case (a reasoning-heavy multi-stage analysis) can allow longer calls
+// without raising the shared client's default for everyone. Nil-safe.
+func (c *Client) WithTimeout(d time.Duration) *Client {
+	if c == nil {
+		return nil
+	}
+	clone := *c
+	clone.timeout = d
+	return &clone
+}
+
 // Option configures a Client at construction. Options keep tracing opt-in without
 // changing the constructors' required parameters, so existing call sites compile
 // unchanged.


### PR DESCRIPTION
The fit model reasons for tens of seconds/stage; full prompts exceeded the 90s timeout → the stream hung. jobfit now uses a 180s per-call timeout (llm.Client.WithTimeout), trims inputs (CV 10k / desc 6k / company 2k runes), and retries only on parse failures (not timeouts). Paired with an nginx SSE location (proxy_buffering off, read_timeout 300s) applied on prod. Verified: build/test.