### PR TITLE
fix(jobfit-web): forward session cookie in fit page SSR (cache never read → always re-streamed)

### DIFF
--- a/web/src/routes/jobs/[slug]/fit/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/fit/+page.server.ts
@@ -7,8 +7,11 @@ import type { PageServerLoad } from './$types';
 // cached analysis, so a fresh cached result paints in the initial HTML. The cached fit
 // needs auth and may not exist — a 401/404/no-cache degrades to null, and the page then
 // opens the SSE stream client-side. A missing job is a real 404.
-export const load: PageServerLoad = async ({ params, fetch }) => {
-  const api = serverApi(fetch);
+export const load: PageServerLoad = async ({ params, fetch, request }) => {
+  // getJobFit is authenticated, so the session cookie must be forwarded to the internal
+  // API — without it the SSR read is a 401, the cached analysis reads as absent, and the
+  // page needlessly re-streams a fresh compute every visit.
+  const api = serverApi(fetch, request.headers.get('cookie'));
   const job = await api.getJob(params.slug).catch((e) => {
     if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
     throw e;


### PR DESCRIPTION
The fit page SSR called serverApi(fetch) without the cookie → getJobFit 401 → cached analysis read as absent → page re-streamed every visit (spins even when cached). Now forwards the cookie. One-line correctness fix.