### PR TITLE
feat(companies): surface website/LinkedIn/description; match slug in search

### DIFF
--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -77,7 +77,7 @@ func (q *Queries) CompanySitemapBoundaries(ctx context.Context, chunkSize int64)
 const countCompanies = `-- name: CountCompanies :one
 SELECT count(*)
 FROM companies
-WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%')
+WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '%')
   AND (coalesce(cardinality($2::text[]), 0) = 0 OR collections && $2::text[])
   AND (coalesce(cardinality($3::text[]), 0) = 0 OR regions && $3::text[])
   AND (coalesce(cardinality($4::text[]), 0) = 0 OR countries && $4::text[])
@@ -192,7 +192,7 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 const listCompanies = `-- name: ListCompanies :many
 SELECT slug, name, job_count, tagline, industries, hq_country
 FROM companies
-WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%')
+WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '%')
   AND (coalesce(cardinality($2::text[]), 0) = 0 OR collections && $2::text[])
   AND (coalesce(cardinality($3::text[]), 0) = 0 OR regions && $3::text[])
   AND (coalesce(cardinality($4::text[]), 0) = 0 OR countries && $4::text[])
@@ -244,8 +244,10 @@ type ListCompaniesRow struct {
 // array short-circuits to no constraint, non-empty values are OR-ed within the
 // facet, and the facets AND together (and with the name search). `remote_regions`
 // is the job-derived facet scoped to remote jobs (see RefreshCompanyFacets), a
-// subset of `regions`. CountCompanies MUST keep an identical WHERE so the filtered
-// total matches the page.
+// subset of `regions`. The name search also matches the slug, so a hyphenated slug
+// query ("ge-vernova") finds the company even though its name has a space ("GE
+// Vernova"). CountCompanies MUST keep an identical WHERE so the filtered total
+// matches the page.
 func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error) {
 	rows, err := q.db.Query(ctx, listCompanies,
 		arg.Search,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -318,8 +318,10 @@ type Querier interface {
 	// array short-circuits to no constraint, non-empty values are OR-ed within the
 	// facet, and the facets AND together (and with the name search). `remote_regions`
 	// is the job-derived facet scoped to remote jobs (see RefreshCompanyFacets), a
-	// subset of `regions`. CountCompanies MUST keep an identical WHERE so the filtered
-	// total matches the page.
+	// subset of `regions`. The name search also matches the slug, so a hyphenated slug
+	// query ("ge-vernova") finds the company even though its name has a space ("GE
+	// Vernova"). CountCompanies MUST keep an identical WHERE so the filtered total
+	// matches the page.
 	ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error)
 	// All companies with their current collection membership. cmd/import-collections
 	// reads this to know the existing company slugs (the match target) and each

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -9,11 +9,13 @@
 -- array short-circuits to no constraint, non-empty values are OR-ed within the
 -- facet, and the facets AND together (and with the name search). `remote_regions`
 -- is the job-derived facet scoped to remote jobs (see RefreshCompanyFacets), a
--- subset of `regions`. CountCompanies MUST keep an identical WHERE so the filtered
--- total matches the page.
+-- subset of `regions`. The name search also matches the slug, so a hyphenated slug
+-- query ("ge-vernova") finds the company even though its name has a space ("GE
+-- Vernova"). CountCompanies MUST keep an identical WHERE so the filtered total
+-- matches the page.
 SELECT slug, name, job_count, tagline, industries, hq_country
 FROM companies
-WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%')
+WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%' OR slug ILIKE '%' || sqlc.arg('search') || '%')
   AND (coalesce(cardinality(sqlc.arg('collections')::text[]), 0) = 0 OR collections && sqlc.arg('collections')::text[])
   AND (coalesce(cardinality(sqlc.arg('regions')::text[]), 0) = 0 OR regions && sqlc.arg('regions')::text[])
   AND (coalesce(cardinality(sqlc.arg('countries')::text[]), 0) = 0 OR countries && sqlc.arg('countries')::text[])
@@ -34,7 +36,7 @@ LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 -- to ListCompanies.
 SELECT count(*)
 FROM companies
-WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%')
+WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%' OR slug ILIKE '%' || sqlc.arg('search') || '%')
   AND (coalesce(cardinality(sqlc.arg('collections')::text[]), 0) = 0 OR collections && sqlc.arg('collections')::text[])
   AND (coalesce(cardinality(sqlc.arg('regions')::text[]), 0) = 0 OR regions && sqlc.arg('regions')::text[])
   AND (coalesce(cardinality(sqlc.arg('countries')::text[]), 0) = 0 OR countries && sqlc.arg('countries')::text[])

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -12331,3 +12331,17 @@
   board: paloaltonetworks.wd5.myworkdayjobs.com/panwexternalcareers
 - company: MBDA
   board: mbda.wd3.myworkdayjobs.com/mbda-italy
+- company: Ryt Bank
+  board: rytbank.wd3.myworkdayjobs.com/External_Career
+- company: pennant
+  board: pennant.wd1.myworkdayjobs.com/CMICareerSite
+- company: ochsner
+  board: ochsner.wd1.myworkdayjobs.com/OchsnerACQ
+- company: Bank of America
+  board: ghr.wd1.myworkdayjobs.com/lateral-ous
+- company: Rakuten
+  board: rakuten.wd1.myworkdayjobs.com/RakutenSymphony
+- company: db
+  board: db.wd3.myworkdayjobs.com/PBWebsite
+- company: galileo
+  board: galileo.wd3.myworkdayjobs.com/regents_university_london_careersite

--- a/web/src/lib/components/CompanyAbout.svelte
+++ b/web/src/lib/components/CompanyAbout.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import type { Company } from '$lib/types';
+
+  // The company's full description as a standalone "About" card, mirroring how a job
+  // renders its description as its own block. The header only shows the derived
+  // tagline (first sentence); this is the whole summary. Present-only: renders nothing
+  // when the company has no description, so the page never leaves an empty box.
+  let { company }: { company: Company } = $props();
+
+  const description = $derived(company.company_info?.description?.trim() ?? '');
+
+  // Collapsed to a few lines, expandable — a long summary shouldn't dominate the page
+  // above the jobs. The toggle appears only when the text actually overflows the clamp,
+  // measured once the paragraph is in the DOM (scrollHeight vs the clamped clientHeight).
+  let expanded = $state(false);
+  let clampable = $state(false);
+  let para = $state<HTMLParagraphElement>();
+
+  $effect(() => {
+    if (para && !expanded) clampable = para.scrollHeight > para.clientHeight + 1;
+  });
+</script>
+
+{#if description}
+  <section class="rounded-2xl border border-border bg-card p-5">
+    <p class="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">About</p>
+    <p
+      bind:this={para}
+      class={[
+        'whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground',
+        !expanded && 'line-clamp-4',
+      ]}
+    >
+      {description}
+    </p>
+    {#if clampable || expanded}
+      <button
+        type="button"
+        class="mt-2 text-sm font-medium text-primary hover:underline"
+        onclick={() => (expanded = !expanded)}
+      >
+        {expanded ? 'Show less' : 'Show more'}
+      </button>
+    {/if}
+  </section>
+{/if}

--- a/web/src/lib/components/CompanyHeader.svelte
+++ b/web/src/lib/components/CompanyHeader.svelte
@@ -4,18 +4,21 @@
   import CompanyFollowButton from './CompanyFollowButton.svelte';
 
   // The company's header card: identity (logo + name + tagline + follow CTA) with the
-  // industries and website link below a divider. The scalar company facts live in a
-  // separate CompanyFacts card (jobs sidebar on desktop, under the header on mobile),
-  // so this stays compact. The card is always shown, even for an unenriched company
-  // (just the identity row) — the tagline and the meta divider are present-only.
+  // industries and the website/LinkedIn links below a divider. The scalar company facts
+  // live in a separate CompanyFacts card (jobs sidebar on desktop, under the header on
+  // mobile), so this stays compact. The card is always shown, even for an unenriched
+  // company (just the identity row) — the tagline and the meta divider are present-only.
   let { company, slug }: { company: Company; slug: string } = $props();
 
   const info = $derived(company.company_info ?? {});
   const industries = $derived(company.industries ?? []);
-  const website = $derived(info.homepage);
+  // The homepage lives under `website` (hirebase) or `homepage` (older records) — read
+  // whichever is present so the link renders regardless of which importer filled it.
+  const website = $derived(info.website ?? info.homepage);
   const websiteHref = $derived(website ? (website.startsWith('http') ? website : `https://${website}`) : '');
+  const linkedin = $derived(info.linkedin);
 
-  const hasMeta = $derived(industries.length > 0 || !!website);
+  const hasMeta = $derived(industries.length > 0 || !!website || !!linkedin);
 </script>
 
 <section class="rounded-2xl border border-border bg-card p-5">
@@ -44,6 +47,14 @@
           href={websiteHref}
           target="_blank"
           rel="noopener noreferrer">{website} ↗</a
+        >
+      {/if}
+      {#if linkedin}
+        <a
+          class="text-sm font-medium text-primary hover:underline"
+          href={linkedin}
+          target="_blank"
+          rel="noopener noreferrer">LinkedIn ↗</a
         >
       {/if}
     </div>

--- a/web/src/lib/components/CompanyView.svelte
+++ b/web/src/lib/components/CompanyView.svelte
@@ -4,6 +4,7 @@
   import JobsView from './JobsView.svelte';
   import States from './States.svelte';
   import CompanyHeader from './CompanyHeader.svelte';
+  import CompanyAbout from './CompanyAbout.svelte';
   import CompanyFacts from './CompanyFacts.svelte';
 
   // The company entity is server-rendered (route `load`), so the header is in the
@@ -18,6 +19,12 @@
 </script>
 
 <CompanyHeader {company} {slug} />
+
+<!-- Full company description, full-width under the header (CompanyHeader shows only the
+     derived tagline). Renders nothing when there's no description. -->
+<div class="mt-4">
+  <CompanyAbout {company} />
+</div>
 
 <!-- Company facts sit atop the jobs sidebar on desktop (passed into JobsView as
      `sidebarTop`); the sidebar is hidden on mobile, so mirror them here as a card

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -37,9 +37,12 @@ export interface CompanyInfo {
     symbol?: string;
     exchange?: string;
   };
-  // YC-directory extras (populated by cmd/import-yc; absent on non-YC companies).
+  // Directory extras (populated by cmd/import-yc and cmd/import-hirebase; absent on
+  // companies neither importer touched). `website`/`linkedin` are the hirebase
+  // outbound links; `description` is the full company summary.
   description?: string;
   website?: string;
+  linkedin?: string;
   stage?: string;
   top_company?: boolean;
   is_hiring?: boolean;


### PR DESCRIPTION
## Why
Investigating https://freehire.dev/companies/ge-vernova surfaced two gaps: the company had `website`, `linkedin`, and a full `description` stored in `company_info`, but none rendered — and searching the slug form `ge-vernova` returned nothing.

## Changes
**UI — render stored-but-hidden company info** (`web/`)
- `CompanyHeader`: website link read `info.homepage`, but the data lands under `info.website` → now reads `info.website ?? info.homepage`. Added a **LinkedIn** link alongside it.
- New `CompanyAbout` card: the full `description` (header only showed the derived tagline), clamped to ~4 lines with a **Show more** toggle that appears only on real overflow. Same card tokens as the header — no new visual language.
- `CompanyInfo` type gains `linkedin`.

**Search — match the slug** (`internal/db`)
- Company `?q=` was `name ILIKE '%q%'` (case-insensitive, but name-only). A slug query `ge-vernova` couldn't match the name `GE Vernova`. `ListCompanies`/`CountCompanies` now also `OR slug ILIKE '%q%'`.

**Sources**
- +7 Workday boards (separate commit).

## Verification
- `go build ./...`, `go vet`, `go test ./internal/handler/` — green.
- `npm run check` (0 errors) + `npm run build` (SSR) — green.
- Rendered `/companies/ge-vernova` via node server pointed at prod API: website `linktree.com ↗`, `LinkedIn ↗`, About card with description + Show more all render.

_Note: search change is query-only — no migration._