### PR TITLE
chore(web): clear two lint errors (unused import, reactive-track expr)

### DIFF
--- a/web/src/lib/companyFilters.ts
+++ b/web/src/lib/companyFilters.ts
@@ -3,7 +3,7 @@
 // this module owns only the reactive UrlSyncedState wrapper. Re-exports the model's
 // public surface so existing `$lib/companyFilters` importers are unchanged.
 
-import { COMPANY_FACETS, type FacetSelection, type FacetStore } from './facets';
+import { type FacetSelection, type FacetStore } from './facets';
 import {
   activeCompanyFilterCount,
   addCompanyFacet,

--- a/web/src/routes/jobs/[slug]/fit/+page.svelte
+++ b/web/src/routes/jobs/[slug]/fit/+page.svelte
@@ -25,7 +25,7 @@
   // The thinking panel tails the model's reasoning: keep it pinned to the newest tokens.
   let thinkingEl = $state<HTMLElement | null>(null);
   $effect(() => {
-    stream.thinking; // track new reasoning
+    void stream.thinking; // track new reasoning
     if (thinkingEl) thinkingEl.scrollTop = thinkingEl.scrollHeight;
   });
 


### PR DESCRIPTION
Two zero-runtime lint fixes:

- `companyFilters.ts` — drop the **unused `COMPANY_FACETS`** import (the `FacetSelection`/`FacetStore` types on the same line stay; both are used).
- `jobs/[slug]/fit/+page.svelte` — prefix the `$effect` dependency-tracking read with **`void`** (`void stream.thinking;`), matching the repo's existing `void filters.applied;` convention, so `no-unused-expressions` stops flagging the intentional reactive read.

No behavior change; no deploy needed.

_Note: the frontend still has ~18 pre-existing `svelte/*` lint errors (`no-navigation-without-resolve`, `prefer-svelte-reactivity`, `no-unused-svelte-ignore`) across unrelated routes — lint isn't CI-gated. Left untouched; cleaning them is a separate pass._