### PR TITLE
chore(web): visually hide the companies page h1 (mirror /jobs)

### DIFF
--- a/web/src/routes/companies/+page.svelte
+++ b/web/src/routes/companies/+page.svelte
@@ -16,8 +16,9 @@
 />
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
-  <!-- Primary heading for search engines and assistive tech. pl-12 clears the
-       mobile filters edge tab (reset at md), matching the list's top row. -->
-  <h1 class="mb-4 pl-12 text-2xl font-semibold tracking-tight md:pl-0">Companies hiring in tech</h1>
+  <!-- Primary heading kept for search engines and assistive tech, but visually
+       hidden: the list and filters make the page's purpose clear, so the on-screen
+       title was redundant. sr-only takes no layout space. Mirrors /jobs. -->
+  <h1 class="sr-only">Companies hiring in tech</h1>
   <CompaniesView initial={data.initial} />
 </div>


### PR DESCRIPTION
Removes the visible **"Companies hiring in tech"** heading and the large top gap its heading block created. The h1 becomes `sr-only` — still in the DOM for SEO and assistive tech, but taking no layout space — exactly the treatment `/jobs` already uses, so both list pages now start identically. `svelte-check` clean.