### PR TITLE
feat(notify): rich Telegram digest cards with salary + UTM

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -250,7 +250,9 @@ type Querier interface {
 	// row (SQLSTATE XX001) aborts the whole scan; the worker then retries the batch one id
 	// at a time to isolate and dead-letter the bad row.
 	GetJobsByIDs(ctx context.Context, ids []int64) ([]Job, error)
-	// The display fields for the jobs in a digest, freshest first.
+	// The display fields for the jobs in a digest, freshest first. Salary fields are
+	// projected out of the enrichment JSONB (absent keys → NULL) so a card can render
+	// a compensation line only when one is known.
 	GetJobsForDigest(ctx context.Context, jobIds []int64) ([]GetJobsForDigestRow, error)
 	// Public read of a shared board by its slug — no auth, no owner-scoping. Exposes only
 	// the board's display fields; owner columns (user_id) are never selected. A NULL slug

--- a/internal/db/queries/subscriptions.sql
+++ b/internal/db/queries/subscriptions.sql
@@ -97,8 +97,14 @@ LEFT JOIN telegram_links tl ON tl.user_id = s.user_id
 WHERE s.id = $1;
 
 -- name: GetJobsForDigest :many
--- The display fields for the jobs in a digest, freshest first.
-SELECT id, title, company, public_slug, url, posted_at
+-- The display fields for the jobs in a digest, freshest first. Salary fields are
+-- projected out of the enrichment JSONB (absent keys → NULL) so a card can render
+-- a compensation line only when one is known.
+SELECT id, title, company, public_slug, url, posted_at,
+       COALESCE((enrichment->>'salary_min')::int, 0)::int AS salary_min,
+       COALESCE((enrichment->>'salary_max')::int, 0)::int AS salary_max,
+       COALESCE(enrichment->>'salary_currency', '')::text AS salary_currency,
+       COALESCE(enrichment->>'salary_period', '')::text   AS salary_period
 FROM jobs
 WHERE id = ANY(sqlc.arg(job_ids)::bigint[])
 ORDER BY COALESCE(posted_at, created_at) DESC;

--- a/internal/db/subscriptions.sql.go
+++ b/internal/db/subscriptions.sql.go
@@ -136,22 +136,32 @@ func (q *Queries) DeleteSubscription(ctx context.Context, arg DeleteSubscription
 }
 
 const getJobsForDigest = `-- name: GetJobsForDigest :many
-SELECT id, title, company, public_slug, url, posted_at
+SELECT id, title, company, public_slug, url, posted_at,
+       COALESCE((enrichment->>'salary_min')::int, 0)::int AS salary_min,
+       COALESCE((enrichment->>'salary_max')::int, 0)::int AS salary_max,
+       COALESCE(enrichment->>'salary_currency', '')::text AS salary_currency,
+       COALESCE(enrichment->>'salary_period', '')::text   AS salary_period
 FROM jobs
 WHERE id = ANY($1::bigint[])
 ORDER BY COALESCE(posted_at, created_at) DESC
 `
 
 type GetJobsForDigestRow struct {
-	ID         int64              `json:"id"`
-	Title      string             `json:"title"`
-	Company    string             `json:"company"`
-	PublicSlug string             `json:"public_slug"`
-	URL        string             `json:"url"`
-	PostedAt   pgtype.Timestamptz `json:"posted_at"`
+	ID             int64              `json:"id"`
+	Title          string             `json:"title"`
+	Company        string             `json:"company"`
+	PublicSlug     string             `json:"public_slug"`
+	URL            string             `json:"url"`
+	PostedAt       pgtype.Timestamptz `json:"posted_at"`
+	SalaryMin      int32              `json:"salary_min"`
+	SalaryMax      int32              `json:"salary_max"`
+	SalaryCurrency string             `json:"salary_currency"`
+	SalaryPeriod   string             `json:"salary_period"`
 }
 
-// The display fields for the jobs in a digest, freshest first.
+// The display fields for the jobs in a digest, freshest first. Salary fields are
+// projected out of the enrichment JSONB (absent keys → NULL) so a card can render
+// a compensation line only when one is known.
 func (q *Queries) GetJobsForDigest(ctx context.Context, jobIds []int64) ([]GetJobsForDigestRow, error) {
 	rows, err := q.db.Query(ctx, getJobsForDigest, jobIds)
 	if err != nil {
@@ -168,6 +178,10 @@ func (q *Queries) GetJobsForDigest(ctx context.Context, jobIds []int64) ([]GetJo
 			&i.PublicSlug,
 			&i.URL,
 			&i.PostedAt,
+			&i.SalaryMin,
+			&i.SalaryMax,
+			&i.SalaryCurrency,
+			&i.SalaryPeriod,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/notify/deliver.go
+++ b/internal/notify/deliver.go
@@ -108,10 +108,14 @@ func buildDigest(name string, jobs []db.GetJobsForDigestRow, limit int) Digest {
 			break
 		}
 		d.Jobs = append(d.Jobs, DigestJob{
-			Title:   j.Title,
-			Company: j.Company,
-			Slug:    j.PublicSlug,
-			URL:     j.URL,
+			Title:          j.Title,
+			Company:        j.Company,
+			Slug:           j.PublicSlug,
+			URL:            j.URL,
+			SalaryMin:      int(j.SalaryMin),
+			SalaryMax:      int(j.SalaryMax),
+			SalaryCurrency: j.SalaryCurrency,
+			SalaryPeriod:   j.SalaryPeriod,
 		})
 	}
 	return d

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -34,12 +34,18 @@ type Digest struct {
 	Jobs            []DigestJob
 }
 
-// DigestJob is the display shape of one matched job (no internal id).
+// DigestJob is the display shape of one matched job (no internal id). The salary
+// fields are projected from the job's enrichment; a zero SalaryMin/SalaryMax (or
+// empty Currency) means the compensation is unknown and the renderer omits it.
 type DigestJob struct {
-	Title   string
-	Company string
-	Slug    string
-	URL     string
+	Title          string
+	Company        string
+	Slug           string
+	URL            string
+	SalaryMin      int
+	SalaryMax      int
+	SalaryCurrency string
+	SalaryPeriod   string
 }
 
 // Notifier delivers a digest over a channel to a destination. The matching engine

--- a/internal/telegramnotify/notifier.go
+++ b/internal/telegramnotify/notifier.go
@@ -43,16 +43,15 @@ func (n *Notifier) Send(ctx context.Context, _ string, dest string, d notify.Dig
 	return n.client.SendMessage(ctx, chatID, n.render(d))
 }
 
-// render builds the HTML message body. Job titles, company names, and the saved
-// search name are HTML-escaped (they are user/source data); the freehire URL is
-// our own and safe.
+// render builds the HTML message body. Job titles, company names, the salary
+// string, and the saved search name are HTML-escaped (they are user/source data);
+// the freehire URL is our own and safe.
 //
-// The body is capped to Telegram's telegramMaxLen: job lines are added until the
+// The body is capped to Telegram's telegramMaxLen: job cards are added until the
 // next one (plus the largest possible "+ N more" tail) would overflow, then the
-// tail absorbs the remainder. Without the cap a digest of many long-title jobs
-// exceeds the limit, Telegram rejects the send deterministically, every retry
-// re-fails, and the whole batch is dead-lettered — silently dropping the user's
-// notifications.
+// tail absorbs the remainder. Without the cap a digest of many jobs exceeds the
+// limit, Telegram rejects the send deterministically, every retry re-fails, and
+// the whole batch is dead-lettered — silently dropping the user's notifications.
 func (n *Notifier) render(d notify.Digest) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "🔔 <b>%d</b> new job%s for %q\n\n", d.Total, plural(d.Total), html.EscapeString(d.SavedSearchName))
@@ -63,31 +62,87 @@ func (n *Notifier) render(d notify.Digest) string {
 	used := utf16Len(b.String())
 	shown := 0
 	for _, j := range d.Jobs {
-		line := n.jobLine(j)
-		lineLen := utf16Len(line)
-		if used+lineLen+tailReserve > telegramMaxLen {
+		card := n.jobCard(j)
+		cardLen := utf16Len(card)
+		if used+cardLen+tailReserve > telegramMaxLen {
 			break
 		}
-		b.WriteString(line)
-		used += lineLen
+		b.WriteString(card)
+		used += cardLen
 		shown++
 	}
 	if more := d.Total - shown; more > 0 {
 		b.WriteString(moreLine(more))
 	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// jobCard renders one digest job as a multi-line card: a title, an optional
+// company line, an optional salary line, and an Apply link to the freehire job
+// page. Title, company, and salary are HTML-escaped; cards are separated by a
+// trailing blank line.
+func (n *Notifier) jobCard(j notify.DigestJob) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "💼 <b>%s</b>\n", html.EscapeString(j.Title))
+	if j.Company != "" {
+		fmt.Fprintf(&b, "🏛️ at %s\n", html.EscapeString(j.Company))
+	}
+	if s := formatSalary(j.SalaryMin, j.SalaryMax, j.SalaryCurrency, j.SalaryPeriod); s != "" {
+		fmt.Fprintf(&b, "💰 %s\n", html.EscapeString(s))
+	}
+	fmt.Fprintf(&b, "✅ <a href=%q>Apply →</a>\n\n", n.applyURL(j))
 	return b.String()
 }
 
-// jobLine renders one digest job: a bullet linking to the freehire job page, with
-// an optional " — Company" suffix. Title and company are HTML-escaped.
-func (n *Notifier) jobLine(j notify.DigestJob) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "• <a href=%q>%s</a>", n.jobBaseURL+"/jobs/"+j.Slug, html.EscapeString(j.Title))
-	if j.Company != "" {
-		fmt.Fprintf(&b, " — %s", html.EscapeString(j.Company))
+// applyURL is the on-platform freehire job page for a digest job, tagged with a
+// telegram UTM source so the bot's traffic is attributable. Slugs are our own
+// normalized values, so the URL needs no escaping.
+func (n *Notifier) applyURL(j notify.DigestJob) string {
+	return n.jobBaseURL + "/jobs/" + j.Slug + "?utm_source=telegram-bot"
+}
+
+// currencySymbols maps the common ISO 4217 codes to a glyph; any other code is
+// used as a prefix verbatim (e.g. "PLN 20K").
+var currencySymbols = map[string]string{"USD": "$", "EUR": "€", "GBP": "£"}
+
+// formatSalary renders a compensation string like "$130K—$170K / year" from the
+// enrichment salary fields, or "" when no figure is known. A zero bound counts as
+// absent (matching enrichment's positive-or-nil convention), so a one-sided range
+// renders alone. Amounts of 1000+ are abbreviated with a K suffix; smaller figures
+// (e.g. hourly rates) are shown in full.
+func formatSalary(min, max int, currency, period string) string {
+	if min <= 0 && max <= 0 {
+		return ""
 	}
-	b.WriteByte('\n')
-	return b.String()
+	sym := currencySymbols[strings.ToUpper(currency)]
+	if sym == "" && currency != "" {
+		sym = currency + " "
+	}
+	var amount string
+	switch {
+	case min > 0 && max > 0 && min != max:
+		amount = sym + shortMoney(min) + "—" + sym + shortMoney(max)
+	case min > 0:
+		amount = sym + shortMoney(min)
+	default: // only max is known
+		amount = sym + shortMoney(max)
+	}
+	if period != "" {
+		amount += " / " + period
+	}
+	return amount
+}
+
+// shortMoney abbreviates 12000→"12K", 4500→"4.5K", and leaves sub-thousand
+// figures (e.g. hourly rates) in full: 950→"950".
+func shortMoney(v int) string {
+	if v < 1000 {
+		return strconv.Itoa(v)
+	}
+	if v%1000 == 0 {
+		return strconv.Itoa(v/1000) + "K"
+	}
+	return strconv.FormatFloat(float64(v)/1000, 'f', 1, 64) + "K"
 }
 
 // moreLine is the "+ N more" overflow tail, or "" when nothing is omitted.

--- a/internal/telegramnotify/notifier_test.go
+++ b/internal/telegramnotify/notifier_test.go
@@ -19,7 +19,8 @@ func TestNotifier_Render(t *testing.T) {
 		SavedSearchName: "Go & <remote>",
 		Total:           3,
 		Jobs: []notify.DigestJob{
-			{Title: "Go Dev <x>", Company: "Acme", Slug: "go-dev-acme"},
+			{Title: "Go Dev <x>", Company: "Acme", Slug: "go-dev-acme",
+				SalaryMin: 130000, SalaryMax: 170000, SalaryCurrency: "USD", SalaryPeriod: "year"},
 			{Title: "Rustacean", Company: "", Slug: "rustacean-foo"},
 		},
 	}
@@ -32,17 +33,52 @@ func TestNotifier_Render(t *testing.T) {
 	if !strings.Contains(got, "Go &amp; &lt;remote&gt;") {
 		t.Errorf("saved-search name not HTML-escaped: %q", got)
 	}
-	// Job title escaped; link points at the freehire job page (trailing slash trimmed).
-	if !strings.Contains(got, `<a href="https://freehire.dev/jobs/go-dev-acme">Go Dev &lt;x&gt;</a> — Acme`) {
-		t.Errorf("job line wrong: %q", got)
+	// Card: escaped bold title, "at Company" line, salary line, and an Apply link
+	// to the freehire job page (trailing slash trimmed) tagged with the telegram UTM.
+	for _, want := range []string{
+		"💼 <b>Go Dev &lt;x&gt;</b>",
+		"🏛️ at Acme",
+		"💰 $130K—$170K / year",
+		`✅ <a href="https://freehire.dev/jobs/go-dev-acme?utm_source=telegram-bot">Apply →</a>`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("card missing %q in: %q", want, got)
+		}
 	}
-	// A job with no company omits the dash suffix.
-	if !strings.Contains(got, `<a href="https://freehire.dev/jobs/rustacean-foo">Rustacean</a>`) {
-		t.Errorf("company-less job line wrong: %q", got)
+	// A job with no company/salary omits those lines but still renders title + Apply.
+	if !strings.Contains(got, "💼 <b>Rustacean</b>") ||
+		!strings.Contains(got, `href="https://freehire.dev/jobs/rustacean-foo?utm_source=telegram-bot"`) {
+		t.Errorf("company/salary-less card wrong: %q", got)
+	}
+	if strings.Contains(got, "🏛️ at \n") || strings.Count(got, "💰") != 1 {
+		t.Errorf("empty company/salary lines should be omitted: %q", got)
 	}
 	// Total 3 but only 2 listed → "+ 1 more".
 	if !strings.Contains(got, "+ 1 more") {
 		t.Errorf("missing overflow summary: %q", got)
+	}
+}
+
+func TestFormatSalary(t *testing.T) {
+	cases := []struct {
+		name             string
+		min, max         int
+		currency, period string
+		want             string
+	}{
+		{"range", 130000, 170000, "USD", "year", "$130K—$170K / year"},
+		{"min only", 90000, 0, "EUR", "year", "€90K / year"},
+		{"max only", 0, 50000, "GBP", "month", "£50K / month"},
+		{"equal bounds collapse", 100000, 100000, "USD", "year", "$100K / year"},
+		{"unknown currency is a prefix", 20000, 30000, "PLN", "month", "PLN 20K—PLN 30K / month"},
+		{"hourly rate not abbreviated", 50, 80, "USD", "hour", "$50—$80 / hour"},
+		{"fractional thousands", 4500, 0, "USD", "", "$4.5K"},
+		{"no figure", 0, 0, "USD", "year", ""},
+	}
+	for _, tc := range cases {
+		if got := formatSalary(tc.min, tc.max, tc.currency, tc.period); got != tc.want {
+			t.Errorf("%s: formatSalary(%d,%d,%q,%q) = %q, want %q", tc.name, tc.min, tc.max, tc.currency, tc.period, got, tc.want)
+		}
 	}
 }
 
@@ -75,7 +111,7 @@ func TestNotifier_RenderCapsAtTelegramLimit(t *testing.T) {
 	if n16 := len(utf16.Encode([]rune(got))); n16 > 4096 {
 		t.Errorf("rendered %d UTF-16 units, want <= 4096 (Telegram sendMessage limit)", n16)
 	}
-	shown := strings.Count(got, "• ")
+	shown := strings.Count(got, "💼 ")
 	if shown == 0 || shown >= total {
 		t.Errorf("shown = %d, want some-but-not-all of %d jobs listed", shown, total)
 	}


### PR DESCRIPTION
## What

Reshape the saved-search Telegram digest from one bullet per job into a rich per-job **card**, matching a requested reference format:

```
💼 Solution Architect
🏛️ at Sitetracker
💰 $130K—$170K / year
✅ Apply →   (links to freehire.dev/jobs/<slug>?utm_source=telegram-bot)
```

## Changes

- **`GetJobsForDigest`** now projects `salary_min/max/currency/period` out of the `enrichment` JSONB. `COALESCE((enrichment->>'x')::int, 0)::int` / `::text` gives sqlc strict non-null types; `0`/`""` encodes "unknown" (same positive-or-nil semantics as enrichment).
- **`notify.DigestJob`** carries the salary fields; `buildDigest` threads them through. The `notify` package stays channel-agnostic — no formatting there.
- **`telegramnotify`**: `jobLine` → `jobCard` (multi-line, optional company/salary lines, Apply link with `?utm_source=telegram-bot`). New `formatSalary`/`shortMoney` helpers: currency glyph (`$`/`€`/`£`, ISO-code fallback), `K` abbreviation for ≥1000, full figure for sub-thousand (hourly) rates, one-sided ranges rendered alone. The 4096-UTF-16 cap + `+ N more` tail logic is unchanged.

## Notes

- **No migration** — reads an existing column; safe to deploy without a schema step.
- Salary only appears on enriched jobs (LLM-filled, often sparse); cards without it simply omit the 💰 line.
- Link stays on-platform (source URLs may be login-gated), consistent with the existing renderer.

## Tests

`go build`, `go vet`, `go test ./...` green. Updated `notifier_test.go` for the card format + UTM; added `TestFormatSalary` (range / one-sided / equal-bounds / unknown-currency / hourly / fractional-thousands / empty).