### PR TITLE
feat(sources): add 85 ATS boards for untracked companies

### DIFF
--- a/sources/bamboohr.yml
+++ b/sources/bamboohr.yml
@@ -18647,3 +18647,7 @@
   board: surgeonslab
 - company: "Accel Club"
   board: accelclub
+- company: Letterboxd
+  board: letterboxd
+- company: Essensys
+  board: essensys

--- a/sources/careerplug.yml
+++ b/sources/careerplug.yml
@@ -464,3 +464,73 @@
   board: www-precisionscans-net
 - company: Diffraqtion
   board: diffraqtion
+- company: Alphabet
+  board: alphabets-llc
+- company: Behavioral Health Business
+  board: new-beginnings-behavioral-health-in
+- company: The Zephyr Project
+  board: zephyronesecurity-net
+- company: Therapists in Tech
+  board: center-for-wellness
+- company: Connectivity Standards Alliance
+  board: zigbee-alliance-inc
+- company: RK Management Consultants
+  board: rknt-management-inc
+- company: F45 Training
+  board: f45-training-cp008330
+- company: Layanan Pengadaan Secara Elektronik
+  board: lpse
+- company: Signworld Business Partners
+  board: corpus-christi-sign-company
+- company: READY Robotics
+  board: snowbot-philly-east-llc
+- company: Smart Polymers and Composites Laboratory
+  board: adaptive-composites-llc
+- company: Hot Rod Institute
+  board: custom-cars-unlimited-inc
+- company: SKIMS
+  board: msm14-inc
+- company: JLR
+  board: cars-now-usa-llc
+- company: Nothing Bundt Cakes
+  board: nothing-bundt-cakes-269
+- company: Social Worker
+  board: wavelengths-psychology-pc
+- company: Quality Home Care Michigan
+  board: firstlight-home-care-of-oak-park
+- company: Open Evidence
+  board: workcompvidence-pia-llc
+- company: American HealthCare Academy
+  board: american-care-academy
+- company: Dental Advisor
+  board: estheticare-dental-consultant-pc
+- company: Women in Global Health
+  board: woman-to-woman-gynecology-llc
+- company: Right at Home Canada
+  board: right-at-home-canada-fraser-valley
+- company: Sciometrix
+  board: sciometrix-inc
+- company: HomeWell Senior Care
+  board: homewell-care-services-mi251
+- company: QC Kinetix Franchise Group
+  board: qc-kinetix-dallas-houston
+- company: Boost Home Healthcare
+  board: boost-home-healthcare-fairfax-west
+- company: John A. Moran Eye Center
+  board: perlman-center-for-eye-eyelids-surgery
+- company: National Eye Institute
+  board: visionary-eye-institute-inc
+- company: Executive Home Care
+  board: executive-home-care-of-omaha
+- company: Steri-Clean
+  board: steri-clean-careers
+- company: Alabama Department of Rehabilitation Services
+  board: alabama-autism-assistance-program
+- company: LearningRx
+  board: learningrx-careers
+- company: Hometown Pharmacy
+  board: kratzer-s-hometown-pharmacy-mount-orab
+- company: Golden Heart Senior Care
+  board: golden-heart-bloomington
+- company: UTMB Faculty Group Practice
+  board: gulf-coast-kidney-treatment-centers

--- a/sources/gem.yml
+++ b/sources/gem.yml
@@ -428,3 +428,5 @@
   board: vectorworks
 - company: WhatConverts
   board: whatconverts
+- company: BU Consultants
+  board: buconsultants-co

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14065,3 +14065,9 @@
   board: informal
 - company: "Numab Therapeutics AG"
   board: numab
+- company: Tech4Germany
+  board: digitalservice
+- company: PetSmart Veterinary Services
+  board: manchesterveterinaryservices
+- company: Cleveland School of Cannabis
+  board: steamacademyofwarrensvilleheights

--- a/sources/icims.yml
+++ b/sources/icims.yml
@@ -3731,3 +3731,25 @@
   board: realalloy
 - company: The Stronghold Companies
   board: strongholdspecialtyltd
+- company: Vet Jobs
+  board: careers-vet.icims.com
+- company: ZemiTek
+  board: careers-zemitek.icims.com
+- company: Princeton Plasma Physics Laboratory
+  board: pppl-princeton.icims.com
+- company: Shepley Wood Products
+  board: careers-shepleywoodproducts.icims.com
+- company: Southern Pipe & Supply
+  board: careers-southernairms.icims.com
+- company: PRI
+  board: contractwork-eauditstaff.icims.com
+- company: Hawaiʻi Gas
+  board: careers-hawaiigas.icims.com
+- company: PRIDE Industries
+  board: careers-prideindustries.icims.com
+- company: Cooper University Hospital
+  board: careers-cooperhealth.icims.com
+- company: American Career College
+  board: careers-americancareercollege.icims.com
+- company: Akahi Associates, LLC
+  board: careers-akahillc.icims.com

--- a/sources/jazzhr.yml
+++ b/sources/jazzhr.yml
@@ -7697,3 +7697,11 @@
   board: index
 - company: Smartcat
   board: smartcat
+- company: Nationwide IT Services
+  board: nationwideitservices
+- company: Ben Franklin Technology Partners of Central & Northern PA
+  board: benfranklintechnologypartnersofcentralandnorthernpa
+- company: Automotive Art
+  board: automotiveart
+- company: Parkland County
+  board: parklandcounty

--- a/sources/paylocity.yml
+++ b/sources/paylocity.yml
@@ -18867,3 +18867,21 @@
   board: ffeb44e5-c90e-4ebf-8894-f22d75ab990b
 - company: Birch Bay Retirement Village
   board: ffef105a-d66e-4de3-98e7-8dc08e386e57
+- company: Job search
+  board: d15ab4ae-c8a7-4768-b462-868e5dbd35a8
+- company: Binary Defense
+  board: Available-Positions
+- company: CLOOS
+  board: 198572c4-8ebf-49e8-8d96-6c31bfac9704
+- company: UNOX
+  board: 1a350e42-cf0c-4dda-9983-2baa887006c3
+- company: DRUNK ELEPHANT
+  board: 8228c54c-6bf9-4160-9c8c-daa29f88c310
+- company: Elder-Well® Adult Day Program
+  board: fdc5564b-fc5b-498d-99b8-ba1f06fcb18e
+- company: The Medicine Shoppe
+  board: cd1070a3-6e59-42e8-890f-19d097265f2c
+- company: Cancer Center of South Florida
+  board: d4e3a833-7b73-4552-b4a7-1487c4844cf4
+- company: Turning Point Therapeutics
+  board: 97ffcf88-991a-4f30-8dfc-0c117e498bbc

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -8005,3 +8005,9 @@
   board: speedgoat
 - company: "ZuriQ AG"
   board: zuriq
+- company: Aioneers
+  board: aioneers
+- company: Olmatic
+  board: olmatic-gmbh
+- company: Audi F1 Project
+  board: audi-formula-racing-students

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3525,3 +3525,7 @@
   board: xeltis
 - company: "Appercut"
   board: appercut
+- company: See Tickets
+  board: seetickets
+- company: NecstGen
+  board: necstgen

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -35,3 +35,13 @@
   board: gaiias-open-positions
 - company: Mytra
   board: mytra
+- company: Thrive Global
+  board: thriveglobal
+- company: OneOrigin
+  board: oneorigin
+- company: Blue Water Autonomy
+  board: blue-water-autonomy
+- company: Boom Supersonic
+  board: boom-supersonic
+- company: Cancer Research Institute
+  board: cancer-research-institute-inc

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -5671,3 +5671,13 @@
   board: socialquantum
 - company: Talentgrator
   board: talentgrator
+- company: Veracity Software
+  board: veracitytechnologies
+- company: GudangAda
+  board: GudangAda
+- company: Hummingbird Scientific
+  board: HummingbirdScientific
+- company: NMC Royal Medical Center
+  board: nmchealthcare
+- company: Medical College of Wisconsin
+  board: froedtert3

--- a/sources/trakstar.yml
+++ b/sources/trakstar.yml
@@ -1062,3 +1062,13 @@
   board: yeledvyalda
 - company: ZG Subpoena Solutions
   board: zgsubpoenasolution
+- company: eGov Foundation
+  board: egovernments
+- company: myAgro
+  board: myagro
+- company: Instituto de Telecomunicações
+  board: itlisbon
+- company: BHEL
+  board: bhei
+- company: European Society of Cardiology
+  board: escmagazine


### PR DESCRIPTION
Adds 85 previously-untracked ATS boards for companies found via an external job-board catalogue.

**How boards were derived:** each found company's ATS platform was mapped to its freehire provider, and the board id extracted in freehire's exact format. Every entry is **host-validated** — the board id is kept only when the board link host actually belongs to that provider, which auto-filters aggregator reposts and mis-hosted links. Workday and platforms whose board format can't be validated were deliberately excluded.

**Breakdown:** careerplug +35, icims +11, paylocity +9, smartrecruiters +5, trakstar +5, rippling +5, jazzhr +4, personio +3, greenhouse +3, bamboohr +2, recruitee +2, gem +1.

Data-only change (no code); each board is idempotent-safe on the dedup key.