### PR TITLE
feat(web): mobile list toolbar for jobs + companies feeds

### DIFF
--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -17,7 +17,7 @@
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyFilterSummary from './filters/CompanyFilterSummary.svelte';
   import CompanyFilterModal from './filters/CompanyFilterModal.svelte';
-  import FilterEdgeTab from './FilterEdgeTab.svelte';
+  import ListToolbar from './ListToolbar.svelte';
 
   // The first page is server-rendered (route `load`) for the current filters, so
   // the rows are in the initial HTML.
@@ -87,6 +87,12 @@
   </aside>
 
   <div class="min-w-0 flex-1">
+    <ListToolbar
+      total={companies.status === 'ready' && companies.items.length > 0 ? companies.total : null}
+      unit={companies.total === 1 ? 'company' : 'companies'}
+      active={filters.active}
+      onOpenFilters={() => (modalOpen = true)}
+    />
     {#if companies.status === 'loading'}
       <States state="loading" />
     {:else if companies.status === 'error'}
@@ -97,10 +103,6 @@
         message={filters.value.q || filters.active > 0 ? 'No matching companies.' : 'No companies yet.'}
       />
     {:else}
-      <!-- Clear the left-edge filters tab on mobile (see FilterEdgeTab below). -->
-      <p class="mb-3 pl-12 text-sm text-muted-foreground md:pl-0" aria-live="polite">
-        {companies.total.toLocaleString()} {companies.total === 1 ? 'company' : 'companies'}
-      </p>
       <div class="flex flex-col gap-3">
         {#each companies.items as company (company.slug)}
           {@const industry = company.industries?.[0]}
@@ -145,8 +147,5 @@
     {/if}
   </div>
 </div>
-
-<!-- Mobile filters entry (the desktop aside hosts the summary + All-filters button). -->
-<FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
 
 <CompanyFilterModal store={filters} open={modalOpen} onClose={() => (modalOpen = false)} />

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -40,31 +40,44 @@
 
 <a
   href={resolve('/jobs/[slug]', { slug: job.public_slug })}
-  class="block rounded-xl border border-border bg-card p-4 transition hover:bg-accent hover:opacity-100"
+  class="block rounded-xl border border-border bg-card p-4 transition hover:border-foreground/15 hover:bg-accent hover:opacity-100"
   class:opacity-60={isViewed}
 >
-  <div class="flex items-start justify-between gap-3">
-    <div class="flex min-w-0 flex-wrap items-center gap-2">
-      <span class="inline-flex items-center gap-1.5 font-semibold">
-        <CompanyLogo name={job.company} size="size-8" />
+  <!-- Company + timestamp rail: a quiet eyebrow that yields the stage to the title.
+       The name truncates to a single line, so a long company (e.g. "Veterinary
+       Emergency Group (VEG)") keeps the logo centred and the card rhythm even
+       instead of wrapping into a ragged multi-line header. -->
+  <div class="flex items-center justify-between gap-3">
+    <div class="flex min-w-0 items-center gap-2">
+      <CompanyLogo name={job.company} size="size-7" />
+      <span class="truncate text-sm font-medium text-muted-foreground">
         {job.company || 'Unknown company'}
       </span>
-      {#each tags as tag (tag)}
-        <Badge variant="secondary">{tag}</Badge>
-      {/each}
     </div>
-    <div class="flex shrink-0 items-center gap-2">
-      <RealityBadge reality={job.reality} />
-      {#if posted}
-        <span class="text-xs text-muted-foreground">{posted}</span>
-      {/if}
-    </div>
+    {#if posted}
+      <span class="shrink-0 text-xs tabular-nums text-muted-foreground">{posted}</span>
+    {/if}
   </div>
 
-  <h3 class="mt-2 line-clamp-2 text-lg font-semibold tracking-tight">{job.title}</h3>
+  <!-- The title is the card's hero — a size up from the body with tight leading, so
+       the eye lands on the role first. -->
+  <h3 class="mt-2.5 line-clamp-2 text-lg font-semibold leading-snug tracking-tight sm:text-[1.35rem]">
+    {job.title}
+  </h3>
+
+  <!-- Signal row: reality chip + the region/employment facets, grouped under the
+       title as quiet outline chips so they read as metadata, not decoration. -->
+  {#if job.reality || tags.length > 0}
+    <div class="mt-2 flex flex-wrap items-center gap-1.5">
+      <RealityBadge reality={job.reality} />
+      {#each tags as tag (tag)}
+        <Badge variant="outline">{tag}</Badge>
+      {/each}
+    </div>
+  {/if}
 
   {#if blurb}
-    <p class="mt-1.5 line-clamp-2 text-sm text-muted-foreground">{blurb}</p>
+    <p class="mt-2 line-clamp-2 text-sm text-muted-foreground">{blurb}</p>
   {/if}
 
   <div class="mt-3 flex items-end justify-between gap-3">
@@ -77,7 +90,7 @@
       {/if}
     </div>
     {#if salary}
-      <span class="shrink-0 text-base font-bold tracking-tight">{salary}</span>
+      <span class="shrink-0 text-base font-bold tabular-nums tracking-tight">{salary}</span>
     {/if}
   </div>
 </a>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -29,7 +29,7 @@
   import type { Job, FacetCounts } from '$lib/types';
   import FilterSummary from './filters/FilterSummary.svelte';
   import FilterModal from './filters/FilterModal.svelte';
-  import FilterEdgeTab from './FilterEdgeTab.svelte';
+  import ListToolbar from './ListToolbar.svelte';
   import States from './States.svelte';
   import JobRow from './JobRow.svelte';
   import LoadMore from './LoadMore.svelte';
@@ -275,22 +275,29 @@
 
   <div class="min-w-0 flex-1">
     {#if showBanner}
-      <!-- pl-12 md:pl-0 clears the mobile filters edge tab, matching the count row.
-           The banner is the only onboarding entry: it shows once (until dismissed or
-           completed), then retires — no persistent re-open control. -->
-      <div class="pl-12 md:pl-0">
-        <OnboardingBanner onOpen={() => (wizardOpen = true)} onDismiss={dismissBanner} />
-      </div>
+      <!-- Full-bleed within the content column — the Filters/Swipe controls live in the
+           toolbar below (and reappear as scroll-revealed edge tabs), so nothing up here
+           has to indent to clear them. The banner is the only onboarding entry: it shows
+           once (until dismissed or completed), then retires — no persistent re-open control. -->
+      <OnboardingBanner onOpen={() => (wizardOpen = true)} onDismiss={dismissBanner} />
     {/if}
     {#if alertBanner}
-      <div class="pl-12 md:pl-0">
-        <OnboardingAlertBanner
-          query={alertBanner.query}
-          autostart={alertBanner.autostart}
-          onDismiss={() => (alertBanner = null)}
-        />
-      </div>
+      <OnboardingAlertBanner
+        query={alertBanner.query}
+        autostart={alertBanner.autostart}
+        onDismiss={() => (alertBanner = null)}
+      />
     {/if}
+
+    <ListToolbar
+      total={jobs.status === 'ready' && jobs.items.length > 0 ? jobs.total : null}
+      unit={jobs.total === 1 ? 'job' : 'jobs'}
+      active={filters.active}
+      onOpenFilters={() => (modalOpen = true)}
+      onSwipe={standalone ? openSwipe : undefined}
+      showDesktopTotal={standalone}
+    />
+
     {#if jobs.status === 'loading'}
       <States state="loading" />
     {:else if jobs.status === 'error'}
@@ -311,19 +318,6 @@
         </div>
       {/if}
     {:else}
-      <!-- Standalone: the count is the topmost element, level with the fixed edge
-           tab, so pl-12 clears it (reset at md). Company embed: the count sits well
-           below the header/facts, clear of the tab, so it aligns with the cards; it
-           also moves to the sidebar on desktop, hence mobile-only and a touch bolder. -->
-      <p
-        class={[
-          'mb-3 text-sm',
-          standalone ? 'pl-12 text-muted-foreground md:pl-0' : 'font-medium text-foreground md:hidden',
-        ]}
-        aria-live="polite"
-      >
-        {jobs.total.toLocaleString()} {jobs.total === 1 ? 'job' : 'jobs'}
-      </p>
       <div class="flex flex-col gap-3">
         {#each jobs.items as job (job.public_slug)}
           <JobRow {job} />
@@ -340,22 +334,17 @@
   </div>
 </div>
 
-<!-- Mobile left-edge Filters tab, for both the standalone list and the embedded
-     company view (parity with /jobs) — it floats over the left edge of the content
-     the same way on either page. -->
-<FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
-
 {#if standalone}
-  <!-- Swipe-mode entry: an icon-only button pinned to the right viewport edge,
-       level with the left filters tab (top-16). Fixed, so it only exists while the
-       standalone jobs list is mounted (never on the embedded company view) and
-       stays reachable while scrolling; kept below the z-40 mobile overlays. -->
+  <!-- Desktop swipe-mode entry: an icon-only button pinned to the right viewport edge
+       (mobile uses the inline toolbar / scroll-revealed tab, so this is md-only). Fixed,
+       so it exists only while the standalone list is mounted and stays reachable while
+       scrolling; kept below the z-40 mobile overlays. -->
   <button
     type="button"
     onclick={openSwipe}
     aria-label="Swipe mode"
     title="Swipe mode"
-    class="fixed right-0 top-16 z-30 flex items-center rounded-l-lg border border-r-0 border-border bg-secondary py-2.5 pl-2 pr-1.5 text-secondary-foreground shadow-sm transition-colors hover:bg-accent"
+    class="fixed right-0 top-16 z-30 hidden items-center rounded-l-xl border border-r-0 border-border bg-secondary py-2.5 pl-2.5 pr-2 text-secondary-foreground shadow-md transition-colors hover:bg-accent md:flex"
   >
     <Layers class="size-4 shrink-0" />
   </button>

--- a/web/src/lib/components/ListToolbar.svelte
+++ b/web/src/lib/components/ListToolbar.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { fade } from 'svelte/transition';
+  import { Layers, SlidersHorizontal } from '@lucide/svelte';
+
+  // The mobile controls for a list page (jobs, companies, …): an inline toolbar at the
+  // top of the list — the results total on the left, the Filters entry (and, on the jobs
+  // list, a Swipe entry) on the right. Once that toolbar scrolls out of view, the entries
+  // re-reveal as floating edge tabs so they stay reachable deep in the list. Mobile-only;
+  // the desktop sidebar aside carries filters there, so this shows only the total (right-
+  // aligned) at md+. Render it at the top of the list column, outside the view's status
+  // branches, so filters stay reachable while the list is loading/empty/errored.
+  //
+  // `total` is null until the list is ready (then the count appears); `unit` is the
+  // already-pluralised noun ("jobs" / "companies"). `onSwipe` is optional — pass it only
+  // where a swipe deck exists (the standalone jobs list). `showDesktopTotal` is false when
+  // the desktop layout already surfaces the total elsewhere (the company page's sidebar
+  // stat), so the above-list line isn't shown twice; the mobile toolbar total is unaffected.
+  let {
+    total,
+    unit,
+    active = 0,
+    onOpenFilters,
+    onSwipe,
+    showDesktopTotal = true,
+  }: {
+    total: number | null;
+    unit: string;
+    active?: number;
+    onOpenFilters: () => void;
+    onSwipe?: () => void;
+    showDesktopTotal?: boolean;
+  } = $props();
+
+  // Reveal the floating edge tabs once the inline toolbar leaves the viewport. The
+  // toolbar is `md:hidden`, so on desktop it never intersects and this stays true — but
+  // the revealed tabs are `md:hidden` too, so nothing shows there.
+  let toolbarEl = $state<HTMLElement>();
+  let pinned = $state(false);
+  $effect(() => {
+    const el = toolbarEl;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry) pinned = !entry.isIntersecting;
+      },
+      { threshold: 0 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  });
+</script>
+
+<!-- Mobile inline toolbar: total on the left, controls on the right. -->
+<div bind:this={toolbarEl} class="mb-3 flex items-center gap-2 md:hidden">
+  {#if total !== null}
+    <span class="text-sm text-muted-foreground" aria-live="polite">
+      <span class="font-semibold tabular-nums text-foreground">{total.toLocaleString()}</span>
+      {unit}
+    </span>
+  {/if}
+  <div class="ml-auto flex items-center gap-2">
+    <button
+      type="button"
+      onclick={onOpenFilters}
+      class="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium transition-colors hover:bg-accent"
+    >
+      <SlidersHorizontal class="size-4 shrink-0" />
+      Filters
+      {#if active > 0}
+        <span
+          class="flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1 text-[11px] font-semibold leading-none text-primary-foreground"
+        >
+          {active}
+        </span>
+      {/if}
+    </button>
+    {#if onSwipe}
+      <button
+        type="button"
+        onclick={onSwipe}
+        class="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium transition-colors hover:bg-accent"
+      >
+        <Layers class="size-4 shrink-0" />
+        Swipe
+      </button>
+    {/if}
+  </div>
+</div>
+
+<!-- Desktop: the total sits top-right above the list (filters live in the sidebar). -->
+{#if total !== null && showDesktopTotal}
+  <p class="mb-3 hidden text-right text-sm text-muted-foreground md:block" aria-live="polite">
+    <span class="font-semibold tabular-nums text-foreground">{total.toLocaleString()}</span>
+    {unit}
+  </p>
+{/if}
+
+<!-- Scroll-revealed floating controls: Filters (left) and, where present, Swipe (right). -->
+{#if pinned}
+  <button
+    type="button"
+    onclick={onOpenFilters}
+    aria-label="Filters"
+    title="Filters"
+    transition:fade={{ duration: 150 }}
+    class="fixed left-0 top-12 z-30 flex items-center rounded-r-xl border border-l-0 border-border bg-secondary py-2.5 pl-2 pr-2.5 text-secondary-foreground shadow-md transition-colors hover:bg-accent md:hidden"
+  >
+    <SlidersHorizontal class="size-4 shrink-0" />
+    {#if active > 0}
+      <span
+        class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-semibold leading-none text-primary-foreground"
+      >
+        {active}
+      </span>
+    {/if}
+  </button>
+  {#if onSwipe}
+    <button
+      type="button"
+      onclick={onSwipe}
+      aria-label="Swipe mode"
+      title="Swipe mode"
+      transition:fade={{ duration: 150 }}
+      class="fixed right-0 top-12 z-30 flex items-center rounded-l-xl border border-r-0 border-border bg-secondary py-2.5 pl-2.5 pr-2 text-secondary-foreground shadow-md transition-colors hover:bg-accent md:hidden"
+    >
+      <Layers class="size-4 shrink-0" />
+    </button>
+  {/if}
+{/if}


### PR DESCRIPTION
## What

Reworks the mobile controls on the **jobs** (`/`) and **companies** (`/companies`) lists.

- **Inline mobile toolbar** at the top of each list: results total on the left, **Filters** (and **Swipe** on the jobs list) on the right.
- Once the toolbar scrolls out of view, the controls **re-reveal as floating edge tabs** (left = Filters, right = Swipe) via an `IntersectionObserver` + fade, so they stay reachable deep in the list.
- Shared behaviour extracted into a new **`ListToolbar`** component → `/jobs` and `/companies` stay consistent.
- Desktop is unchanged: filters live in the sidebar aside; the desktop total sits top-right above the list (suppressed on the company page, which already shows it in the sidebar stat).
- The onboarding banner and the count are now **full-bleed** — the old `pl-12` gutter that cleared the top-anchored edge tab is gone.

### JobRow polish
- Company name is a single-line **eyebrow** (a long name like "Veterinary Emergency Group (VEG)" no longer wraps into a ragged multi-line header; the logo stays centred).
- The **title leads** as the card's hero.
- Reality + region/employment facets group into a quiet **signal row** under the title.

## Scope / safety
- `FilterEdgeTab` is unchanged and still serves the recommendations / analytics / profile lists.
- No API, schema, or backend changes. No new dependencies.

## Verification
- `npm run check` — 0 errors; `npm run build` — ✓.
- Lint: only the 18 pre-existing repo errors (none in the touched files).
- Visually verified against the live prod API (mobile 390px + desktop 1280px, light & dark): jobs list (top + scrolled), companies list (top + scrolled), company detail page (no duplicate total on desktop).