### PR TITLE
feat(collections): add ai-native collection

### DIFF
--- a/internal/collections/collections.go
+++ b/internal/collections/collections.go
@@ -100,6 +100,12 @@ var All = []Collection{
 		Description: "Open roles at globally distributed companies founded by Eastern European (incl. Russian-speaking) founders or with Eastern European engineering roots.",
 		Dataset:     &Dataset{Data: easternRootsData, Parse: ParseSlugList},
 	},
+	{
+		Slug:        "ai-native",
+		Title:       "AI-Native",
+		Description: "Open roles at AI-native companies building AI-first products and infrastructure — model and inference APIs, vector databases, and agent/dev tooling.",
+		Slugs:       AINativeSlugs,
+	},
 }
 
 // Default dataset URLs (overridable per collection via <SLUG>_DATASET_URL in the
@@ -135,6 +141,25 @@ var AICompanySlugs = []string{
 	"runway-ml", "elevenlabs", "eleven-labs", "synthesia", "jasper",
 	"glean", "harvey", "harvey-ai", "suno", "descript", "cresta",
 	"anysphere", "cursor",
+}
+
+// AINativeSlugs is the curated AI-native cohort sourced from the remotepilot.dev
+// directory — model/inference APIs, vector databases, and agent/dev tooling built
+// around AI. Entries are canonical company slugs (normalize.Slug) matched against
+// our ingested companies; the forms below were verified against the names our
+// adapters ingest (e.g. "openrouter.ai" → openrouter-ai, "trmlabs" → trmlabs), with
+// a brand variant listed alongside the few that could be ingested either way. It
+// overlaps AICompanySlugs by design — a company may belong to both collections.
+var AINativeSlugs = []string{
+	// Model & inference APIs.
+	"deepgram", "cohere", "together-ai", "fireworks-ai", "openrouter-ai", "openrouter",
+	// Vector databases & data infrastructure.
+	"pinecone", "qdrant-tech", "qdrant", "weaviate", "supabase", "planetscale", "tensorwave",
+	// Agent & developer tooling.
+	"langchain", "composio", "livekit", "linear", "resend",
+	// Other AI-native companies.
+	"trmlabs", "trm-labs", "jasper", "concentrate-ai", "andromeda",
+	"infinity-constellation", "vclusterlabs", "vcluster-labs", "urun", "tollbit",
 }
 
 // Mag7Slugs is the Magnificent Seven — the 2025 canonical mega-cap tech cohort.

--- a/internal/collections/collections_test.go
+++ b/internal/collections/collections_test.go
@@ -176,6 +176,28 @@ func TestRegistry_HasUnicorn(t *testing.T) {
 	}
 }
 
+func TestRegistry_HasAINative(t *testing.T) {
+	c, ok := Lookup("ai-native")
+	if !ok || len(c.Slugs) == 0 {
+		t.Fatalf("ai-native collection missing or has no member slugs: %+v ok=%v", c, ok)
+	}
+	if c.Title == "" || c.Description == "" {
+		t.Errorf("ai-native collection missing display copy: %+v", c)
+	}
+	// Members are the canonical slugs of our ingested companies (matched by
+	// normalize.Slug), so the forms that differ from the brand name must be present.
+	want := []string{"deepgram", "openrouter-ai", "trmlabs", "qdrant-tech"}
+	set := make(map[string]struct{}, len(c.Slugs))
+	for _, s := range c.Slugs {
+		set[s] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			t.Errorf("ai-native slugs missing %q", w)
+		}
+	}
+}
+
 func TestRetiredSlugs_AreNotLiveCollections(t *testing.T) {
 	// A retired slug must be absent from All (else it is a live collection, not
 	// retired) — the invariant that lets import-collections manage-then-strip it.

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -2119,6 +2119,8 @@
   board: complete
 - company: composio
   board: composio
+- company: Concentrate AI
+  board: concentrate%20ai
 - company: composite
   board: composite
 - company: compound

--- a/web/src/lib/collections.ts
+++ b/web/src/lib/collections.ts
@@ -504,6 +504,12 @@ export const COLLECTIONS: Collection[] = [
     description:
       'Open roles at globally distributed companies founded by Eastern European (incl. Russian-speaking) founders or with Eastern European engineering roots.',
   },
+  {
+    slug: 'ai-native',
+    title: 'AI-Native',
+    description:
+      'Open roles at AI-native companies building AI-first products and infrastructure — model and inference APIs, vector databases, and agent/dev tooling.',
+  },
 ];
 
 // A resolved collection: the display copy plus the fixed job-search facet params


### PR DESCRIPTION
## What

Adds an **`ai-native`** curated company collection, sourced (offline, once) from the
remotepilot.dev directory of AI-native companies (24 companies).

- New code-owned registry entry in `internal/collections` (`AINativeSlugs` + a
  `Collection`), mirrored in the web collections copy — so it gets the
  `/collections/ai-native` landing page and the companies/jobs `collections` facet
  for free, like the existing `ai`/`mag7`/`bigtech` collections.
- Member slugs are canonical to our **ingested** company names (verified against the
  board-file company each ATS adapter uses — e.g. `openrouter.ai → openrouter-ai`,
  `trmlabs → trmlabs`, `qdrant.tech → qdrant-tech`).
- **Concentrate AI** — the only member not already crawled — added to
  `sources/ashby.yml`.

23/24 companies are already in the catalogue; this change is a curated grouping, not
new ingest.

## Deploy

Membership is applied at deploy time: run `cmd/import-collections` (+ a facet
`reindex`) on host-2 after release. Concentrate AI's jobs arrive on the next Ashby
ingest.

## Tests

`go build/vet/test` green (incl. the canonical-slug guard + a new
`TestRegistry_HasAINative`); web `svelte-check` clean, `vitest` 148/148, `eslint`
clean.
