### PR TITLE
chore(web): rename 'AI fit analysis' → 'Analyze match'

### DIFF
--- a/web/src/lib/components/JobFitAnalysis.svelte
+++ b/web/src/lib/components/JobFitAnalysis.svelte
@@ -43,8 +43,8 @@
   };
 </script>
 
-<section class="flex flex-col gap-3 border-t border-border pt-4" aria-label="AI fit analysis">
-  <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">AI fit analysis</p>
+<section class="flex flex-col gap-3 border-t border-border pt-4" aria-label="Analyze match">
+  <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Analyze match</p>
 
   {#if data && !data.has_cv}
     <div class="flex items-center justify-between gap-2">

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -68,7 +68,7 @@
           href={resolve('/my/tracking/analyses')}
           class={tabClass(analysesActive)}
         >
-          AI fit
+          Matches
         </a>
       </div>
 


### PR DESCRIPTION
Renames the AI-fit surfaces to the clearer **Analyze match** wording:
- Job-detail sidebar block heading + aria-label: *AI fit analysis* → **Analyze match**.
- Tracking tab: *AI fit* → **Matches** (noun form, reads cleanly beside Board · Pipeline · History).

Copy-only; no behavior change.