### PR TITLE
fix(tbank): crawl all top-level categories (IT was silently missing)

### DIFF
--- a/internal/sources/tbank.go
+++ b/internal/sources/tbank.go
@@ -9,8 +9,10 @@ import (
 
 // tbank adapts T-Bank's public careers API (tbank.ru/pfpjobs/papi), a single-company source
 // with no per-tenant board id (boardless). The list endpoint paginates by publisher offset
-// and carries no body, so each vacancy's description comes from its own POST detail request,
-// fanned out like the other detail-fetching adapters. The "publisher" source covers all roles.
+// and carries only titles, so each vacancy's description comes from its own POST detail
+// request, fanned out like the other detail-fetching adapters. The publisher list source does
+// NOT return all roles by default — the request must name every top-level category (see
+// tbankCategories) or IT and back-office vacancies are silently omitted.
 type tbank struct {
 	http JSONPoster
 }
@@ -21,6 +23,14 @@ const (
 	tbankSource    = "publisher"
 	tbankPageLimit = 20
 )
+
+// tbankCategories is the full set of T-Bank's top-level vacancy categories. The publisher
+// list source treats an empty category filter as tcareer_work_with_clients ONLY (mass-hire
+// client roles), silently excluding IT and back-office; naming every category is what reaches
+// the whole catalogue. The server unions them, so one filtered pagination loop covers all.
+// A curated constant (like the location/skilltag dictionaries) — extend it if T-Bank adds a
+// top-level category. (Discovered from the careers-site filter config, 2026-07.)
+var tbankCategories = []string{"tcareer_it", "tcareer_back_office", "tcareer_work_with_clients"}
 
 // NewTBank builds the T-Bank adapter over the given HTTP client.
 func NewTBank(c JSONPoster) Source { return tbank{http: c} }
@@ -78,7 +88,7 @@ func (b tbank) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 func (b tbank) list(ctx context.Context) ([]tbankVacancyItem, error) {
 	var items []tbankVacancyItem
 	for offset := 0; ; {
-		req := tbankListRequest{Limit: tbankPageLimit, Filters: map[string]any{}}
+		req := tbankListRequest{Limit: tbankPageLimit, Filters: map[string]any{"category": tbankCategories}}
 		req.Pagination.Publisher.Offset = offset
 
 		var resp struct {

--- a/internal/sources/tbank_test.go
+++ b/internal/sources/tbank_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -14,10 +15,11 @@ import (
 // description[] on the request's urlSlug. A urlSlug in failSlugs errors so detail-isolation
 // can be exercised.
 type tbankHTTP struct {
-	pages     map[int]string    // offset -> canned getVacancies payload
-	detail    map[string]string // urlSlug -> canned getVacancyDescription payload
-	failSlugs map[string]bool   // urlSlugs whose detail request errors
-	listCalls int               // number of getVacancies requests served (loop-termination guard)
+	pages       map[int]string    // offset -> canned getVacancies payload
+	detail      map[string]string // urlSlug -> canned getVacancyDescription payload
+	failSlugs   map[string]bool   // urlSlugs whose detail request errors
+	listCalls   int               // number of getVacancies requests served (loop-termination guard)
+	lastListReq tbankListRequest  // the most recent getVacancies request body (filter assertions)
 }
 
 func (f *tbankHTTP) PostJSON(_ context.Context, url string, body, v any) error {
@@ -28,6 +30,7 @@ func (f *tbankHTTP) PostJSON(_ context.Context, url string, body, v any) error {
 			return errors.New("tbankHTTP: list body is not a tbankListRequest")
 		}
 		f.listCalls++
+		f.lastListReq = req
 		if f.listCalls > 8 { // a non-advancing loop would spin forever; bound the test
 			return errors.New("tbankHTTP: too many list calls (pagination did not terminate)")
 		}
@@ -83,6 +86,29 @@ func TestTBankProvider(t *testing.T) {
 func TestTBankIsBoardless(t *testing.T) {
 	if _, ok := NewTBank(nil).(boardless); !ok {
 		t.Error("tbank should implement the boardless marker")
+	}
+}
+
+// The publisher list source treats an empty category filter as work-with-clients only, so
+// the request MUST name every top-level category to reach IT and back-office vacancies.
+func TestTBankListRequestsAllCategories(t *testing.T) {
+	fake := &tbankHTTP{
+		pages:  map[int]string{0: tbankListPage(0, true, tbankVacancy("Eng", "Москва", "tcareer_it", "s1", "eng"))},
+		detail: map[string]string{"s1": `{"resultCode":"OK","payload":{"description":[{"key":"k","content":"<p>x</p>"}]}}`},
+	}
+
+	if _, err := NewTBank(fake).Fetch(context.Background(), CompanyEntry{Company: "T-Bank"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	cats, ok := fake.lastListReq.Filters["category"].([]string)
+	if !ok {
+		t.Fatalf("list filters.category = %#v, want []string of top-level categories", fake.lastListReq.Filters["category"])
+	}
+	for _, want := range []string{"tcareer_it", "tcareer_back_office", "tcareer_work_with_clients"} {
+		if !slices.Contains(cats, want) {
+			t.Errorf("list filters.category %v missing %q", cats, want)
+		}
 	}
 }
 

--- a/openspec/changes/tbank-crawl-all-categories/.openspec.yaml
+++ b/openspec/changes/tbank-crawl-all-categories/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/tbank-crawl-all-categories/design.md
+++ b/openspec/changes/tbank-crawl-all-categories/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`internal/sources/tbank.go` crawls T-Bank's `getVacancies` list endpoint with an
+empty `filters` map. Live probing (2026-07) shows the `publisher` source treats an
+empty `filters.category` as `["tcareer_work_with_clients"]` alone (970 postings),
+silently excluding `tcareer_it` (264) and `tcareer_back_office` (457). The adapter's
+comment asserting the source "covers all roles" is therefore false. Everything else
+in the adapter — offset pagination, per-vacancy detail fan-out, block assembly,
+`urlSlug` identity — is correct and stays.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Crawl all three top-level categories so IT and back-office vacancies are ingested.
+- Keep the change surgical: only the list request's filter and the stale comment.
+
+**Non-Goals:**
+- No prod DB surgery (existing client rows stay; their category is still crawled).
+- No dynamic category discovery, no per-role config, no new endpoint.
+
+## Decisions
+
+**One filtered request with all categories, not a per-category loop.**
+Live verification: passing all three categories in a single `filters.category` array
+returns the full union (1691) under normal `publisher.offset` pagination — the server
+merges them server-side. So the existing single pagination loop is unchanged; only
+the request body gains the filter. Alternative (loop the adapter once per category
+and concatenate) was rejected: it triples the request count and re-implements
+pagination bookkeeping for no benefit, since the server already unions them.
+
+**Curated constant slice, not runtime discovery.**
+The category set is a small, stable, explicit `tbankCategories` constant — the same
+"curated dictionary, never guesses" pattern the project uses for `location`/
+`skilltag`/`classify`. The API exposes no category-enumeration endpoint (probed:
+`getFilters`/`getCategories` → 404; list response carries no facet metadata), and
+the three top-level segments are discoverable only from the careers-site config, so
+hardcoding the vetted set is both necessary and idiomatic. A future category is a
+one-line addition with a documented seam.
+
+## Risks / Trade-offs
+
+- [T-Bank renames or adds a top-level category] → The crawl silently misses it, the
+  same failure mode as today but narrower. Mitigation: the constant is documented as
+  the seam; a coverage drop surfaces via the ingest count. Acceptable for a curated
+  single-source adapter.
+- [Non-IT roles remain in the catalogue] → By explicit product decision (crawl all
+  categories); the enrich non-tech gate already withholds LLM budget from them, so
+  the cost is storage/search noise only, not spend.
+
+## Migration Plan
+
+Pure code change; no schema/config/migration. On merge, the next scheduled
+`cmd/ingest sources/custom.yml` run begins upserting IT and back-office vacancies.
+Rollback is reverting the one-line filter. Existing rows are untouched either way.

--- a/openspec/changes/tbank-crawl-all-categories/proposal.md
+++ b/openspec/changes/tbank-crawl-all-categories/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The `tbank` source adapter ingests **zero IT vacancies**. Its `getVacancies` list
+request sends empty filters, and T-Bank's `publisher` source silently defaults to a
+single category — `tcareer_work_with_clients` (mass-hire client/collection roles) —
+so the entire IT (`tcareer_it`) and back-office (`tcareer_back_office`) catalogues
+are never crawled. For a tech job aggregator this is the opposite of what we want:
+prod holds ~1277 field-sales/collections roles and not one engineering vacancy.
+
+## What Changes
+
+- The `tbank` adapter's list request crawls **all three top-level categories**
+  (`tcareer_it`, `tcareer_back_office`, `tcareer_work_with_clients`) by passing them
+  as a curated constant slice in `filters.category`, instead of the empty filter
+  that defaulted to client roles only. A single offset-paginated loop then returns
+  the full catalogue (verified live: 264 + 457 + 970 = 1691 in one filtered query).
+- The false code comment claiming the `publisher` source "covers all roles" is
+  corrected to document the category-filter requirement.
+- No prod DB surgery: the existing non-IT rows stay (their category is still
+  crawled), so nothing is force-closed by this change.
+
+## Capabilities
+
+### New Capabilities
+- `tbank-source`: the T-Bank careers-API adapter — a boardless single-company
+  source that crawls every top-level vacancy category via the `getVacancies` list
+  filter and fetches each posting's description from the detail endpoint.
+
+### Modified Capabilities
+<!-- none: no existing spec's requirements change -->
+
+## Impact
+
+- `internal/sources/tbank.go` — list request gains the category filter; the
+  `tbankSource`/comment provenance is corrected.
+- `internal/sources/tbank_test.go` — covers the multi-category list request.
+- Runtime: the next `cmd/ingest sources/custom.yml` run begins ingesting IT and
+  back-office vacancies (~721 additional postings beyond the current client roles).
+- No schema, API, or config change.

--- a/openspec/changes/tbank-crawl-all-categories/specs/tbank-source/spec.md
+++ b/openspec/changes/tbank-crawl-all-categories/specs/tbank-source/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: T-Bank careers-API crawl across all categories
+
+The system SHALL provide a `tbank` source adapter that crawls T-Bank's public
+careers API (`www.tbank.ru/pfpjobs/papi`) into the catalogue. It is a **boardless
+single-company** adapter: config entries carry no board, the host is fixed, and it
+is excluded from the source facet. The crawl is keyless and two-phase — a
+`getVacancies` list request enumerates postings, and each posting's description is
+fetched from a per-vacancy `getVacancyDescription` detail request.
+
+The list request MUST filter on the full set of T-Bank's top-level vacancy
+categories (`tcareer_it`, `tcareer_back_office`, `tcareer_work_with_clients`). An
+empty category filter is not equivalent to "all categories" — the `publisher`
+source defaults it to `tcareer_work_with_clients` alone, which excludes every IT
+and back-office vacancy. The categories are a curated constant slice; adding a
+future category is a one-line change.
+
+#### Scenario: List request carries the full category set
+
+- **WHEN** the adapter issues a `getVacancies` list request
+- **THEN** the request body's `filters.category` contains every top-level category
+  (`tcareer_it`, `tcareer_back_office`, `tcareer_work_with_clients`), so IT and
+  back-office vacancies are enumerated alongside client roles
+
+#### Scenario: Offset pagination drains every category in one loop
+
+- **WHEN** the server reports more results via `nextPagination.publisher.offset`
+  with `isFinished=false`
+- **THEN** the adapter follows the offset until `isFinished` (or the offset stops
+  advancing), accumulating vacancies across all filtered categories in a single loop
+
+#### Scenario: Each vacancy maps to a Job with a stable identity
+
+- **WHEN** the adapter fetches a vacancy's detail
+- **THEN** it returns a `Job` whose `ExternalID` is the vacancy `urlSlug`, whose
+  `URL` is the five-segment careers route ending in that `urlSlug`, and whose
+  description is the assembled, sanitized HTML of the detail blocks — so re-crawling
+  dedups to the same catalogue row
+
+#### Scenario: A failed detail request skips only that vacancy
+
+- **WHEN** one vacancy's `getVacancyDescription` request fails
+- **THEN** the adapter omits just that vacancy and still returns the rest of the crawl

--- a/openspec/changes/tbank-crawl-all-categories/tasks.md
+++ b/openspec/changes/tbank-crawl-all-categories/tasks.md
@@ -1,0 +1,9 @@
+## 1. Crawl all top-level categories
+
+- [ ] 1.1 Add a `tbankCategories` curated constant slice (`tcareer_it`,
+  `tcareer_back_office`, `tcareer_work_with_clients`) and set the `getVacancies`
+  list request's `filters.category` to it; correct the false "publisher covers all
+  roles" comment to document the category-filter requirement.
+- [ ] 1.2 Cover the behavior in `tbank_test.go`: assert the list request body sends
+  all three categories in `filters.category` (RED-first), and that pagination still
+  drains vacancies across the filtered set into mapped Jobs.

--- a/openspec/changes/tbank-crawl-all-categories/tasks.md
+++ b/openspec/changes/tbank-crawl-all-categories/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Crawl all top-level categories
 
-- [ ] 1.1 Add a `tbankCategories` curated constant slice (`tcareer_it`,
+- [x] 1.1 Add a `tbankCategories` curated constant slice (`tcareer_it`,
   `tcareer_back_office`, `tcareer_work_with_clients`) and set the `getVacancies`
   list request's `filters.category` to it; correct the false "publisher covers all
   roles" comment to document the category-filter requirement.
-- [ ] 1.2 Cover the behavior in `tbank_test.go`: assert the list request body sends
+- [x] 1.2 Cover the behavior in `tbank_test.go`: assert the list request body sends
   all three categories in `filters.category` (RED-first), and that pagination still
   drains vacancies across the filtered set into mapped Jobs.


### PR DESCRIPTION
## Summary
- The `tbank` adapter's `getVacancies` list request sent an **empty category filter**, which the `publisher` source silently treats as `tcareer_work_with_clients` only (mass-hire client/collection roles). Every IT (`tcareer_it`) and back-office (`tcareer_back_office`) vacancy was missed — prod held ~1277 field/client roles and **zero engineering vacancies**.
- Fix: send all three top-level categories via a curated `tbankCategories` constant in `filters.category`. The server unions them under one offset-paginated loop.
- Corrected the false `// The "publisher" source covers all roles.` comment.
- No schema/config change; no prod DB surgery (existing rows keep being crawled).

## Verification
- Unit: new `TestTBankListRequestsAllCategories` asserts the request body carries all three categories (RED-first); full `internal/sources` suite green, `go vet` clean.
- **Live end-to-end** (real adapter against `tbank.ru/pfpjobs/papi`): `total jobs=1691` (matches API `totalCount`), 199 IT-ish titles, and the previously-missing **SRE Data Platform** posting (`0d59235f-…`) now flows through with the correct URL.

## Test Plan
- [ ] CI green
- [ ] After merge, next scheduled `cmd/ingest sources/custom.yml` begins ingesting ~721 IT + back-office vacancies

OpenSpec change: `tbank-crawl-all-categories`.