### PR TITLE
feat(web): add values section to the About page

### DIFF
--- a/web/src/lib/components/AboutValues.svelte
+++ b/web/src/lib/components/AboutValues.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  // The About page's values block — the promises behind the mission, shown only
+  // on /about (HomeView carries the mission and renders on / too, so these live
+  // in a standalone component to keep them off the landing page).
+  const values = [
+    {
+      n: '01',
+      title: 'For candidates, not recruiters.',
+      body: "When interests collide, the candidate wins — every time. No sponsored listings, no pay-to-rank, no selling your data to whoever pays. If a choice is good for us but bad for the person job-hunting, we don't make it.",
+    },
+    {
+      n: '02',
+      title: 'The whole market, not a slice.',
+      body: "We pull from as many sources as we can — company boards, ATS platforms, niche feeds — so you see the full set of options, not a hand-picked subset. Nothing is hidden because it didn't pay to be shown.",
+    },
+    {
+      n: '03',
+      title: 'From board to you, in minutes.',
+      body: "Fast everywhere it touches you — a site that responds instantly, and new postings that land in your feed while they're still fresh. We measure speed from the company's board all the way to the notification in your pocket.",
+    },
+    {
+      n: '04',
+      title: 'Open, so you can check.',
+      body: "freehire is open source and free to fork. You don't have to take our word that there's no catch — the code is right there. Transparency is how we keep the other promises honest.",
+    },
+    {
+      n: '05',
+      title: 'Built to last, not to flip.',
+      body: "We're not chasing an exit or a data sale. freehire is built to keep serving candidates for years — each improvement compounds instead of being a one-off, so it gets better the longer it runs.",
+    },
+  ];
+</script>
+
+<section class="border-t border-border py-16 sm:py-20">
+  <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// values</p>
+  <dl class="mt-10 divide-y divide-border border-y border-border">
+    {#each values as v (v.n)}
+      <div class="grid gap-2 py-6 sm:grid-cols-[auto_1fr] sm:gap-8">
+        <span class="font-mono text-sm text-muted-foreground">{v.n}</span>
+        <div>
+          <dt class="text-lg font-semibold tracking-tight">{v.title}</dt>
+          <dd class="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">{v.body}</dd>
+        </div>
+      </div>
+    {/each}
+  </dl>
+</section>

--- a/web/src/routes/about/+page.svelte
+++ b/web/src/routes/about/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import AboutValues from '$lib/components/AboutValues.svelte';
   import HomeView from '$lib/components/HomeView.svelte';
   import Seo from '$lib/components/Seo.svelte';
   import { HOME_FAQ } from '$lib/homeFaq';
@@ -30,4 +31,5 @@
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <HomeView stats={data.stats} />
+  <AboutValues />
 </div>


### PR DESCRIPTION
## What

Adds a `// values` section to **/about**, below the existing mission statement, spelling out the five promises behind it.

| # | Value | Meaning |
|---|-------|---------|
| 01 | **For candidates, not recruiters.** | The candidate wins any conflict of interest — no sponsored listings, pay-to-rank, or data selling. |
| 02 | **The whole market, not a slice.** | Pull from as many sources as possible so the full option set is visible; nothing hidden behind payment. |
| 03 | **From board to you, in minutes.** | Speed end to end — from the company's board to the notification. |
| 04 | **Open, so you can check.** | Open source and forkable; the code backs the other promises. |
| 05 | **Built to last, not to flip.** | No exit or data sale; tooling built to compound over years. |

## How

- New standalone `AboutValues.svelte` component holding the copy + markup.
- Rendered from `about/+page.svelte` only — **not** added to `HomeView`, so it appears on `/about` and never on the landing page `/`.
- Styled in the existing `// mission` / `// straight from the source` idiom (mono label, design tokens, no hardcoded colors).

## Verification

- `svelte-check` — 0 errors / 0 warnings
- `eslint` (changed files) — clean

Not yet rendered in a browser.