### PR TITLE
feat(sources): reed hydrates detail only for new postings

### DIFF
--- a/internal/sources/reed.go
+++ b/internal/sources/reed.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
-	"sync"
 )
 
 // reed adapts the Reed Jobseeker API (reed.co.uk), the UK's largest job board. Like the
@@ -23,9 +22,15 @@ import (
 // The API has no sector filter, only free-text keywords, and freehire is an IT board — so
 // the adapter enumerates a topical IT slice by searching a curated keyword set, unioning the
 // hits and deduping by Reed job id. The search list omits the employer's real apply URL and
-// truncates the description, so each unique job is fetched in detail (FetchStream +
-// fetchDetailsStream, like eightfold): the detail carries the full body and the employer's
-// externalUrl, with the Reed listing URL (jobUrl) as the fallback.
+// truncates the description, so a job is fetched in detail for the full body and the employer's
+// externalUrl (with the Reed listing URL, jobUrl, as the fallback).
+//
+// Because the Reed API enforces a per-hour request quota, reed is a HydratingSource: it fetches
+// detail ONLY for jobs the catalogue does not already have (FetchNew, driven by the pipeline's
+// seen-set), emitting an already-ingested job as a liveness refresh with no detail request. This
+// bounds a run's request volume to the day's new postings instead of re-hydrating every live
+// posting each crawl, which would exhaust the quota (a 403 "exceeded your per-hour request
+// limit"). Fetch is the list-only fallback used when the pipeline cannot supply a seen-set.
 type reed struct {
 	http   HeaderJSONGetter
 	apiKey string
@@ -110,36 +115,35 @@ func (r reed) authHeaders() map[string]string {
 	return map[string]string{"Authorization": "Basic " + token}
 }
 
-// Fetch buffers the whole crawl by collecting the streamed postings. The pipeline prefers
-// FetchStream (incremental save); Fetch stays for non-streaming callers and tests.
+// Fetch is the list-only fallback used when the pipeline cannot supply a seen-set (a non-DB
+// caller or a test): it hydrates every unique job's detail. The pipeline prefers FetchNew.
 func (r reed) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var (
-		mu   sync.Mutex
-		jobs []Job
-	)
-	err := r.FetchStream(ctx, e, func(j Job) {
-		mu.Lock()
-		jobs = append(jobs, j)
-		mu.Unlock()
-	})
-	return jobs, err
+	return r.FetchNew(ctx, e, func(string) bool { return false })
 }
 
-// FetchStream enumerates the IT slice across the curated keywords (deduping by job id), then
-// fetches each unique job's detail concurrently and emits the assembled Job the moment its
-// detail completes — so the pipeline persists this long, rate-limited crawl incrementally. A
-// failed detail is dropped; only a search (listing) failure is returned as a board-level error.
-func (r reed) FetchStream(ctx context.Context, e CompanyEntry, emit func(Job)) error {
+// FetchNew enumerates the IT slice across the curated keywords (deduping by job id), then fetches
+// detail ONLY for jobs not already ingested — an already-ingested job (seen) is emitted as a
+// liveness refresh (SeenRefresh) carrying just its identity, with no detail request — so a run's
+// request volume stays under the Reed API's per-hour quota. Detail fetches run concurrently; a
+// failed detail is dropped; only a total search (listing) failure is a board-level error.
+func (r reed) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
 	if r.apiKey == "" {
-		return errors.New("reed: missing API key (set REED_API_KEY)")
+		return nil, errors.New("reed: missing API key (set REED_API_KEY)")
 	}
 	ids, err := r.searchIDs(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	fetchDetailsStream(ids, reedDetailWorkers,
-		func(id int64) (Job, bool) { return r.detail(ctx, id) }, emit)
-	return nil
+	return fetchDetails(ids, reedDetailWorkers, func(id int64) (Job, bool) {
+		extID := strconv.FormatInt(id, 10)
+		if seen(extID) {
+			// Already ingested: refresh liveness only, no detail request. Carry just the
+			// identity — a content-less re-upsert would wipe the description/facets hydrated
+			// when this job was new (an empty description re-derives to empty facets).
+			return Job{ExternalID: extID, SeenRefresh: true}, true
+		}
+		return r.detail(ctx, id)
+	}), nil
 }
 
 // searchIDs pages every curated keyword and returns the union of unique job ids, deduped so a

--- a/internal/sources/reed_test.go
+++ b/internal/sources/reed_test.go
@@ -44,6 +44,18 @@ func TestReedRegisteredOnlyWhenKeySet(t *testing.T) {
 	}
 }
 
+// reed opts into the hydrating capability (detail only for new postings) and must NOT be a
+// StreamingSource: the pipeline checks streaming first, which would bypass hydration entirely.
+func TestReedIsHydratingNotStreaming(t *testing.T) {
+	s := NewReed(nil, "k")
+	if _, ok := s.(HydratingSource); !ok {
+		t.Error("reed should implement the HydratingSource marker (FetchNew)")
+	}
+	if _, ok := s.(StreamingSource); ok {
+		t.Error("reed must NOT implement StreamingSource — streaming is dispatched first and would bypass hydration")
+	}
+}
+
 func TestReedBoardFileValidates(t *testing.T) {
 	t.Setenv("REED_API_KEY", "test-key")
 	cfg, err := LoadConfig("../../sources/reed.yml")
@@ -117,6 +129,9 @@ func TestReedFetchDedupAuthAndDetailURL(t *testing.T) {
 	byID := map[string]Job{}
 	for _, j := range jobs {
 		byID[j.ExternalID] = j
+		if j.SeenRefresh {
+			t.Errorf("Fetch fallback (no seen-set) must hydrate every job, but %s is marked SeenRefresh", j.ExternalID)
+		}
 	}
 	j1, ok := byID["1001"]
 	if !ok {
@@ -138,6 +153,71 @@ func TestReedFetchDedupAuthAndDetailURL(t *testing.T) {
 	j2 := byID["1002"]
 	if j2.URL != "https://www.reed.co.uk/jobs/be/1002" {
 		t.Errorf("1002 URL = %q, want the Reed jobUrl fallback (no externalUrl)", j2.URL)
+	}
+}
+
+// countingReed serves the fixed two-result search for every keyword and records how many
+// detail requests each job id received, so a test can assert a seen job's detail is skipped.
+type countingReed struct {
+	mu         sync.Mutex
+	detailHits map[string]int
+}
+
+func (f *countingReed) GetJSONWithHeaders(ctx context.Context, url string, headers map[string]string, v any) error {
+	if strings.Contains(url, "/search") {
+		return json.Unmarshal([]byte(reedSearchTwo), v)
+	}
+	f.mu.Lock()
+	for _, id := range []string{"1001", "1002"} {
+		if strings.HasSuffix(url, "/"+id) {
+			f.detailHits[id]++
+		}
+	}
+	f.mu.Unlock()
+	switch {
+	case strings.HasSuffix(url, "/1001"):
+		return json.Unmarshal([]byte(reedDetail1001), v)
+	default:
+		return json.Unmarshal([]byte(reedDetail1002), v)
+	}
+}
+
+// FetchNew hydrates detail only for job ids not already ingested; an already-ingested id is
+// emitted as a liveness refresh (SeenRefresh) with no detail request.
+func TestReedFetchNewHydratesOnlyUnseen(t *testing.T) {
+	f := &countingReed{detailHits: map[string]int{}}
+	seen := func(externalID string) bool { return externalID == "1001" }
+
+	hs, ok := NewReed(f, "k").(HydratingSource)
+	if !ok {
+		t.Fatal("reed must implement HydratingSource")
+	}
+	jobs, err := hs.FetchNew(context.Background(), CompanyEntry{Provider: "reed"}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (deduped across keywords)", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	// 1001 is seen → a content-less liveness refresh, and its detail must NOT be fetched.
+	if got := byID["1001"]; !got.SeenRefresh || got.Description != "" {
+		t.Errorf("seen job 1001 should be a liveness refresh with no content, got SeenRefresh=%v description=%q", got.SeenRefresh, got.Description)
+	}
+	if f.detailHits["1001"] != 0 {
+		t.Errorf("seen job 1001 detail must NOT be fetched, got %d detail requests", f.detailHits["1001"])
+	}
+
+	// 1002 is new → hydrated from its detail, not marked SeenRefresh.
+	if got := byID["1002"]; got.SeenRefresh || !strings.Contains(got.Description, "Full description for 1002") {
+		t.Errorf("new job 1002 should be hydrated, got SeenRefresh=%v description=%q", got.SeenRefresh, got.Description)
+	}
+	if f.detailHits["1002"] == 0 {
+		t.Error("new job 1002 detail must be fetched")
 	}
 }
 

--- a/openspec/changes/reed-incremental-hydration/.openspec.yaml
+++ b/openspec/changes/reed-incremental-hydration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/reed-incremental-hydration/design.md
+++ b/openspec/changes/reed-incremental-hydration/design.md
@@ -1,0 +1,85 @@
+## Context
+
+The `reed` adapter (`internal/sources/reed.go`) is a boardless, keyed aggregator over
+the Reed Jobseeker API. It enumerates a curated IT keyword slice, unions the job ids,
+and fetches each unique job's **detail** for the full description and employer URL. It
+currently implements `StreamingSource` (`FetchStream`), so the pipeline persists postings
+incrementally as they resolve.
+
+Two facts collide:
+- The Reed API enforces a **per-hour request quota**, signalled with HTTP 403
+  (`"exceeded your per-hour request limit"`) — verified live against the prod key.
+- The crawl re-fetches detail for all ~1700 live postings every run, and the ingest
+  timer runs hourly. This dominant, repeated cost exhausts the quota; when it runs out on
+  the first keyword search (before the first emit), the streaming path records
+  `"streaming board failed with no progress"` and `board_health` intermittently backs the
+  board off.
+
+The pipeline already has the exact seam to fix this. `HydratingSource.FetchNew(ctx, e,
+seen)` lets an adapter fetch detail only for postings not in the catalogue; the pipeline
+supplies the provider's seen-set (`seenLookup.ExistingExternalIDs`) and, for postings the
+adapter re-lists but marks `SeenRefresh`, refreshes liveness by identity via `touch`
+(no content rewrite). `justjoin` (~20k live offers) already runs on this path in prod.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Bound reed's per-run request volume so it stays under the Reed per-hour quota.
+- Eliminate the intermittent "no progress" board_health failures for reed.
+- Reuse the existing hydrating seam with zero pipeline changes.
+
+**Non-Goals:**
+- Reducing the keyword-search (listing) request count — the search still pages all
+  curated keywords each run. That is the irreducible listing cost; only detail is cut.
+- A generic per-source rate limiter or 403-retry (a per-hour quota can't be ridden out
+  with in-run backoff; wrong tool). Noted as a future lever only.
+- Changing usajobs (a healthy sibling with a more generous quota).
+
+## Decisions
+
+**Decision: Convert reed from `StreamingSource` to `HydratingSource`.**
+The pipeline dispatch checks `StreamingSource` **first** (`pipeline.go:195`) and returns
+before it ever consults `HydratingSource`. So an adapter cannot be effectively both:
+reed must drop `FetchStream` for `FetchNew` to run.
+
+- `FetchNew(ctx, e, seen)`: `ids := searchIDs(ctx)` (unchanged union-by-keyword, deduped
+  by job id), then `fetchDetails(ids, reedDetailWorkers, fn)` where `fn(id)`:
+  - if `seen(strconv(id))` → return a minimal `Job{ExternalID: strconv(id), SeenRefresh:
+    true}` (the pipeline refreshes `last_seen_at`/reopen by identity; no detail request,
+    no content rewrite);
+  - else → `detail(ctx, id)` as today.
+- `seen` receives the **raw** numeric id; the pipeline namespaces it via
+  `NamespaceExternalID(e.Board, id)` — for boardless reed that is `":<id>"`, matching the
+  stored `external_id`.
+- `Fetch` (the required `Source` fallback, used when the Store can't supply a seen-set —
+  tests / non-DB) reduces to `FetchNew(ctx, e, func(string) bool { return false })`,
+  hydrating everything as before.
+
+*Alternatives considered:* (a) a new `StreamingHydratingSource` interface + pipeline
+branch — a new abstraction for one adapter, rejected as overkill; (b) making
+`FetchStream` seen-aware — changes the `StreamingSource` interface, blast radius across
+eightfold/jobtech, rejected as non-surgical.
+
+**Decision: A minimal `SeenRefresh` job carries only `ExternalID`.**
+`touch` refreshes by `jobIdentity(e, j)` (source + namespaced external_id) only — it never
+reads content — so a SeenRefresh reed job needs no title/company/url. This also honors the
+`SeenRefresh` contract: it must NOT carry content that could be re-upserted and wipe the
+hydrated description.
+
+## Risks / Trade-offs
+
+- **Loss of streaming incremental-save for reed** → Acceptable: the hydrating crawl only
+  fetches detail for new postings, so it is small and rarely reaches the quota mid-run;
+  the 48h unseen-sweep already guards a short/interrupted crawl from mass-closing the tail.
+- **Listing (search) alone could theoretically still approach the quota** → Mitigated by
+  the paired 6h cadence; if it ever surfaces, the noted future lever (trim `reedKeywords`
+  or throttle search) applies. Not built now (YAGNI).
+- **A first-run against a fresh/empty catalogue hydrates everything** → Same as today's
+  behavior and bounded by the 6h cadence; converges after the first run.
+
+## Migration Plan
+
+Pure code change to one adapter; no DB migration, no config. Deploy with the normal
+blue/green release. Rollback = revert the adapter change (the pipeline seam is unchanged
+and reed simply reverts to streaming). The ops cadence change (hourly→6h) is already
+applied and is independent.

--- a/openspec/changes/reed-incremental-hydration/proposal.md
+++ b/openspec/changes/reed-incremental-hydration/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+The `reed` aggregator re-fetches per-posting detail for **every** live posting on
+every crawl (~1700 detail requests plus keyword-search pages), and its ingest timer
+runs hourly. The Reed Jobseeker API enforces a **per-hour request quota** and signals
+exhaustion with HTTP 403 (`"You have exceeded your per-hour request limit"`). When the
+quota runs out on the first keyword search — before any posting is emitted — the
+streaming crawl records a board-level `"streaming board failed with no progress"`
+failure, intermittently backing the board off in `board_health`. The catalogue already
+holds these postings; re-hydrating unchanged ones each hour is the wasteful multiplier
+that blows the quota.
+
+## What Changes
+
+- Convert the `reed` adapter from a `StreamingSource` to a `HydratingSource`: it
+  fetches per-posting detail **only for postings the catalogue does not already have**
+  (mirroring the existing `justjoin` adapter), and marks already-ingested postings for a
+  liveness refresh instead of re-fetching their detail.
+- **BREAKING (internal contract only):** `reed` no longer implements `FetchStream`
+  (drops incremental streaming save). Its `Fetch` remains as the list-only fallback used
+  when the pipeline cannot supply a seen-set (tests / non-DB callers), hydrating every
+  posting.
+- Pairs with an already-applied ops-side cadence change (not part of this repo): the
+  `reed` ingest timer moved from hourly to every 6h in `freehire-ops`
+  (`gen-ingest-timers.sh`).
+
+Net effect: steady-state detail requests drop from ~1700/run to just the run's new
+postings (dozens), keeping `reed` under the per-hour quota and eliminating the
+"no progress" failures.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `source-ingest`: The "Reed is a registered keyed, keyword-scoped aggregator provider"
+  requirement changes from "fetch each unique job's detail" (all postings) to hydrating
+  detail only for postings not already ingested, refreshing liveness for the rest — reed
+  now conforms to the existing "Adapters may hydrate only postings the catalogue lacks"
+  capability.
+
+## Impact
+
+- `internal/sources/reed.go` — remove `FetchStream`; add `FetchNew`; reshape `Fetch` to
+  a list-only fallback.
+- `internal/sources/reed_test.go` — add a seen-set test mirroring `justjoin_test.go`
+  (seen id → liveness-refresh, no detail request; new id → hydrated).
+- No pipeline changes: the `HydratingSource` seam, seen-set lookup, and liveness `touch`
+  path already exist and are exercised by `justjoin`.
+- No new dependencies, no DB migration, no config changes.
+- Behavioral trade-off: loss of streaming incremental-save for reed; acceptable because
+  the hydrating crawl only fetches detail for new postings and is small.

--- a/openspec/changes/reed-incremental-hydration/specs/source-ingest/spec.md
+++ b/openspec/changes/reed-incremental-hydration/specs/source-ingest/spec.md
@@ -1,0 +1,59 @@
+## MODIFIED Requirements
+
+### Requirement: Reed is a registered keyed, keyword-scoped aggregator provider
+
+The ingest registry SHALL include a `reed` adapter over the Reed Jobseeker API
+(reed.co.uk), and it SHALL be registered only when the `REED_API_KEY` environment
+variable is set — like `usajobs`, the key is a secret read from the environment and
+never stored in a board file. The adapter SHALL be boardless (one API, no per-tenant
+board id) and SHALL declare itself an `aggregator`, taking each posting's employer
+from the API payload and remaining a value in the source facet.
+
+Because the Reed API filters only by free-text keywords (it exposes no sector
+filter) and freehire is an IT job board, the adapter SHALL enumerate a topical IT
+slice by searching a curated set of IT/technology keywords, unioning the results and
+**deduping by the Reed job id** so a posting matched by several keywords is crawled
+once. Because the search list omits the employer's real apply URL and truncates the
+description, the adapter SHALL fetch each unique job's detail and take the full
+description and the employer's `externalUrl` from it, falling back to the Reed
+listing URL (`jobUrl`) when no `externalUrl` is present. Authentication SHALL use the
+API key as HTTP Basic credentials.
+
+Because the Reed API enforces a per-hour request quota, the adapter SHALL be a
+hydrating adapter (per the "Adapters may hydrate only postings the catalogue lacks"
+requirement): it SHALL fetch a posting's detail only when that posting is not already
+ingested, and SHALL mark an already-ingested posting for a liveness refresh instead of
+re-fetching its detail. When the pipeline cannot supply a seen-set, the adapter SHALL
+fall back to fetching every unique job's detail.
+
+#### Scenario: Registered only when the key is configured
+
+- **WHEN** `REED_API_KEY` is unset
+- **THEN** `All()` does NOT register `reed`
+- **AND WHEN** `REED_API_KEY` is set
+- **THEN** `All()` registers `reed` and it appears in the source facet
+
+#### Scenario: Keyword matches are deduped by job id
+
+- **WHEN** the same Reed job id is returned by more than one of the curated
+  keyword searches
+- **THEN** the adapter emits that posting once, not once per matching keyword
+
+#### Scenario: The employer apply URL comes from the job detail
+
+- **WHEN** a job's detail carries an `externalUrl` (the employer's own posting)
+- **THEN** the emitted job's URL is that `externalUrl`, not the Reed listing URL
+- **AND WHEN** the detail has no `externalUrl`
+- **THEN** the emitted job's URL falls back to the Reed listing URL
+
+#### Scenario: Detail is fetched only for postings not already ingested
+
+- **WHEN** the pipeline supplies a seen-set and a unioned Reed job id is already ingested
+- **THEN** the adapter marks that posting for a liveness refresh and issues NO detail request
+- **AND WHEN** a unioned Reed job id is not in the seen-set
+- **THEN** the adapter fetches that job's detail and emits the hydrated posting
+
+#### Scenario: Falls back to hydrating every posting without a seen-set
+
+- **WHEN** the pipeline cannot supply a seen-set (e.g. a non-DB caller)
+- **THEN** the adapter fetches every unique job's detail, as before

--- a/openspec/changes/reed-incremental-hydration/tasks.md
+++ b/openspec/changes/reed-incremental-hydration/tasks.md
@@ -1,0 +1,31 @@
+## 1. Tests (TDD — write first, red)
+
+- [x] 1.1 In `internal/sources/reed_test.go`, add a test asserting `reed` implements
+  `HydratingSource` and no longer implements `StreamingSource`.
+- [x] 1.2 Add a `FetchNew` seen-set test (mirroring `justjoin_test.go`) over a fake HTTP
+  client: given a search that unions ids where some are "seen" and some are new, assert
+  seen ids yield a `SeenRefresh` job with NO detail request issued, and new ids are
+  hydrated from their detail (description + employer `externalUrl`).
+- [x] 1.3 Add a `Fetch` fallback test: with an always-false seen predicate (list-only
+  path), every unique job's detail is fetched and no job is marked `SeenRefresh`.
+
+## 2. Adapter change
+
+- [x] 2.1 Remove `FetchStream` from `reed` (drop the `StreamingSource` marker); keep the
+  `boardless()` and `aggregator()` markers.
+- [x] 2.2 Add `FetchNew(ctx, e, seen)`: `searchIDs` then `fetchDetails(ids,
+  reedDetailWorkers, fn)`, where `fn(id)` returns a minimal `Job{ExternalID:
+  strconv(id), SeenRefresh: true}` when `seen(strconv(id))`, else `detail(ctx, id)`.
+- [x] 2.3 Reshape `Fetch` to the list-only fallback: `FetchNew(ctx, e, func(string) bool
+  { return false })`.
+- [x] 2.4 Update the reed doc comment to describe the hydrating (detail-only-for-new)
+  behavior and the per-hour-quota rationale; remove stale streaming references.
+
+## 3. Verify
+
+- [x] 3.1 `go build ./... && go vet ./...` and `go test ./internal/sources/...` pass.
+- [x] 3.2 Confirm the pipeline path is unchanged (no edits under `internal/pipeline/`),
+  and that `reed` is exercised via the existing `HydratingSource`/`seenLookup`/`touch`
+  seam.
+- [ ] 3.3 Sync the spec delta into `openspec/specs/source-ingest/spec.md` and archive the
+  change per the project OpenSpec workflow.


### PR DESCRIPTION
## Why

The `reed` aggregator re-fetches per-posting detail for **every** live posting on every crawl (~1700 detail requests + keyword-search pages), and its ingest timer runs hourly. The Reed Jobseeker API enforces a **per-hour request quota**, signalled with HTTP 403 (`"exceeded your per-hour request limit"` — verified live against the prod key). When the quota runs out on the first keyword search (before any posting is emitted), the streaming crawl records `"streaming board failed with no progress"`, intermittently backing the board off in `board_health`.

## What

Convert `reed` from a `StreamingSource` to a `HydratingSource` (mirroring `justjoin`): fetch per-posting detail **only for postings not already ingested**, emitting an already-ingested posting as a liveness refresh (`SeenRefresh`) with no detail request. Steady-state detail requests drop from ~1700/run to just the run's new postings.

- Removes `FetchStream`; adds `FetchNew(ctx, e, seen)`; `Fetch` becomes the list-only fallback.
- **No pipeline changes** — the `HydratingSource` seen-set + liveness-`touch` seam already exists and is exercised by `justjoin`.
- Pairs with an ops-side cadence change (freehire-ops, already applied on prod): reed timer moved from hourly to every 6h.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test ./internal/sources/ ./internal/pipeline/` pass, incl. new seen-set tests (seen id → `SeenRefresh`, no detail request; new id → hydrated).

OpenSpec: `reed-incremental-hydration`.