### PR TITLE
feat(web): centralized account sidebar for the my/ section

### DIFF
--- a/openspec/changes/my-account-sidebar/.openspec.yaml
+++ b/openspec/changes/my-account-sidebar/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/my-account-sidebar/design.md
+++ b/openspec/changes/my-account-sidebar/design.md
@@ -1,0 +1,92 @@
+## Context
+
+The `my/*` account pages are standalone SvelteKit routes. Each `+page.svelte`
+opens with its own `<div class="mx-auto w-full max-w-{3xl|6xl} px-4 py-6">`
+wrapper, its own `!isAuthenticated()` sign-in gate, and its own
+`<meta name="robots" content="noindex">`. `my/tracking` additionally has its own
+`+layout.svelte` that repeats the container + gate + noindex and adds a
+Board/Pipeline/History/AI-fit tab row. Navigation into the section exists only in
+the header dropdown (`HeaderMenu.svelte`, "Account" links). There is no `/my`
+index route, so a bare `/my` 404s.
+
+The `tracking/+layout.svelte` already demonstrates the in-repo pattern this
+change generalizes: a route layout that owns the section chrome and derives an
+active tab from `page.url.pathname`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One source of truth for the account area's chrome (container, `noindex`,
+  auth-gate) and its navigation.
+- Persistent in-section navigation across all `my/*` pages including Profile.
+- Responsive: vertical sidebar at `lg`+, horizontal tab strip below `lg`.
+- Preserve Tracking's existing sub-tabs unchanged (two navigation levels).
+- Close the bare-`/my` 404.
+
+**Non-Goals:**
+- No collapsible/icon-only sidebar state or persisted collapse preference.
+- No change to the header dropdown account links (they stay as entry points).
+- No backend/API/DB changes; frontend only.
+- No moving page `<h1>`/headers into the layout — pages keep their own headers
+  (several carry subtitles and action buttons).
+
+## Decisions
+
+**Route layout as the shell (over a shared wrapper component or nav-only
+layout).** A new `my/+layout.svelte` owns the container, `noindex`, auth-gate,
+and navigation; children render only their header + body. SvelteKit nests
+layouts, so `my/+layout` → `tracking/+layout` → page composes naturally, giving
+the two navigation levels (sidebar → tabs) with no special-casing. Alternatives:
+a nav-only layout leaves every page still centering itself and re-declaring its
+gate (double-centering, duplicated gates); an imported `<AccountShell>` component
+pushes boilerplate into every page versus one idiomatic layout.
+
+**Vertical sidebar at `lg`, horizontal strip below `lg` (not `md`).** Profile's
+coverage tab has its own internal `md:block w-72` filter aside; putting the outer
+sidebar at `md` would cramp Profile at mid widths. Gating the vertical sidebar at
+`lg` leaves Profile room while still giving the sidebar on typical desktop
+widths. Below `lg` the navigation is a horizontal `overflow-x-auto` strip above
+the content.
+
+**Centralize the auth-gate (accepted behavior change).** The layout renders the
+shell only when authenticated and shows a single sign-in prompt otherwise,
+replacing the five per-page prompts. This unifies the sign-in copy across the
+section — an intentional, user-approved change — and lets each page assume it
+renders only when signed in. Active-item logic reuses the existing
+`path === href || path.startsWith(href + '/')` idiom from `HeaderMenu`/
+`tracking-layout`.
+
+**`/my` redirect via `+page.ts` load.** A `redirect(308, '/my/tracking')` in a
+route `load` mirrors the existing `my/notifications` and `my/jobs/[...path]`
+redirect-only routes. Redirect-only children short-circuit in `load` before
+rendering, so the shell wrapping them is harmless.
+
+**Width handling.** The shell owns `mx-auto w-full max-w-6xl px-4 py-6`. Pages
+drop their outer wrapper. Narrow reading pages (searches, api-keys, submissions)
+keep an inner `max-w-2xl/3xl` on their body to preserve line length within the
+content column; wide pages (recommendations, tracking, profile) fill the column.
+
+## Risks / Trade-offs
+
+- [Unified auth-gate loses per-page sign-in copy] → Approved by the user; the
+  single prompt covers the whole section and keeps a Sign-in action.
+- [Nested asides on Profile's coverage tab at `lg`] → The outer sidebar is
+  `w-56`; the inner filter aside is itself optional (`hidden md:block`) and only
+  on the coverage tab. Content stays usable at `lg`, comfortable at `xl`.
+- [Refactor touches every leaf page] → Mechanical, per-page edits (remove
+  wrapper/gate/noindex), each verified independently; redirect-only routes
+  untouched.
+- [SSR renders signed-out shell first] → Matches the existing `tracking/+layout`
+  pattern (`isAuthenticated()` is a client store); acceptable on `noindex`
+  personal pages.
+
+## Migration Plan
+
+Pure frontend, no data migration. Ships as a normal `web/` deploy. Rollback is
+reverting the change; no state to unwind.
+
+## Open Questions
+
+None outstanding — scope confirmed during brainstorming (all `my/*` including
+Profile; sidebar = top level with Tracking tabs retained; mobile = horizontal
+strip; auth-gate unified).

--- a/openspec/changes/my-account-sidebar/proposal.md
+++ b/openspec/changes/my-account-sidebar/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The personal `my/*` pages (Profile, Tracking, Recommendations, Saved searches,
+API keys, Submissions) are standalone: each owns its width container and
+auth-gate, and the only way to move between them is the header dropdown menu.
+There is no persistent in-section navigation, so the account area does not read
+as one place, and a bare `/my` URL 404s. A centralized sidebar gives the section
+a single navigational home and a single source of truth for its chrome.
+
+## What Changes
+
+- Add a `my/+layout.svelte` shell that owns the account area's chrome for every
+  `my/*` route: the width container, the `noindex` head tag, a unified auth-gate
+  (one sign-in prompt for the whole section), and the section navigation.
+- The navigation renders as a **vertical sidebar at `lg` and up** and a
+  **horizontal, scrollable tab strip below `lg`** — six items: Profile,
+  Tracking, Recommendations, Saved searches & alerts, API keys, My submissions.
+  The active item is derived from the current path.
+- Tracking keeps its existing Board/Pipeline/History/AI-fit sub-tabs unchanged:
+  the sidebar is the top navigation level, the tabs are the sub-view level.
+- Add a `/my` index redirect to `/my/tracking` (closing the current bare-`/my`
+  404).
+- Refactor `my/tracking/+layout.svelte` and the five leaf pages (`profile`,
+  `recommendations`, `searches`, `api-keys`, `submissions`) to drop their own
+  width container, per-page auth-gate, and per-page `noindex` — now owned by the
+  layout. Each page keeps its `<title>`, its `<h1>` header, and its body.
+- Header dropdown account links are unchanged (they stay as entry points into
+  the section).
+
+## Capabilities
+
+### New Capabilities
+- `account-navigation`: the persistent in-section navigation and shared chrome
+  (width container, auth-gate, `noindex`) for the signed-in `my/*` account area,
+  including its responsive sidebar/tab-strip behavior and the `/my` redirect.
+
+### Modified Capabilities
+<!-- None: header-navigation's account links stay unchanged; this is a new,
+     separate in-section navigation surface. -->
+
+## Impact
+
+- Frontend only (`web/`). No backend, API, or DB changes.
+- New: `web/src/routes/my/+layout.svelte`, `web/src/routes/my/+page.ts`.
+- Modified: `web/src/routes/my/tracking/+layout.svelte` and the `+page.svelte`
+  of `profile`, `recommendations`, `searches`, `api-keys`, `submissions`.
+- Behavior change: the per-page sign-in prompt copy is unified into one gate.
+- `notifications` and `jobs/[...path]` (redirect-only routes) are untouched.

--- a/openspec/changes/my-account-sidebar/specs/account-navigation/spec.md
+++ b/openspec/changes/my-account-sidebar/specs/account-navigation/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Account section shell
+
+The signed-in account area SHALL render every `my/*` route inside a single shared
+shell owning the width container, the `noindex` robots tag, and the section
+navigation. Individual `my/*` pages SHALL NOT set their own outer width
+container, `noindex` tag, or per-page sign-in gate for these concerns; they
+render only their own `<title>`, header, and body inside the shell's content
+column.
+
+#### Scenario: Every account page renders inside the shell
+
+- **WHEN** a signed-in user opens any `my/*` page
+- **THEN** the page content appears in the shell's content column beside the
+  section navigation, within the shared width container
+
+#### Scenario: Account pages are excluded from search indexing
+
+- **WHEN** any `my/*` page is loaded
+- **THEN** the response head carries a `noindex` robots directive set once by the
+  shell
+
+### Requirement: Section navigation items
+
+The shell SHALL present navigation to the six account sections — Profile,
+Tracking, Recommendations, Saved searches & alerts, API keys, and My submissions
+— each linking to its `my/*` route. The item matching the current path SHALL be
+marked active, where a section is active when the path equals its route or is a
+descendant of it. Create actions and non-account links (e.g. Submit a job,
+Moderation) SHALL NOT appear in this navigation.
+
+#### Scenario: Active item reflects the current route
+
+- **WHEN** a user is on `/my/tracking/pipeline`
+- **THEN** the Tracking navigation item is marked active and the others are not
+
+#### Scenario: Navigating between sections
+
+- **WHEN** a user selects a navigation item
+- **THEN** the app navigates to that section's route without unmounting the shell
+  or its navigation
+
+### Requirement: Responsive navigation form
+
+The section navigation SHALL render as a vertical sidebar beside the content on
+wide (`lg` and up) viewports and as a horizontal, scrollable tab strip above the
+content on narrower viewports. Exactly one of the two forms SHALL be visible at
+any viewport width.
+
+#### Scenario: Wide viewport shows the sidebar
+
+- **WHEN** a signed-in user views an account page on a `lg`-or-wider viewport
+- **THEN** the navigation renders as a vertical sidebar and the horizontal strip
+  is hidden
+
+#### Scenario: Narrow viewport shows the tab strip
+
+- **WHEN** a signed-in user views an account page below the `lg` breakpoint
+- **THEN** the navigation renders as a horizontal scrollable strip above the
+  content and the vertical sidebar is hidden
+
+### Requirement: Unified account auth gate
+
+The shell SHALL render the navigation and page content only for a signed-in
+user. For a signed-out visitor it SHALL render a single sign-in prompt for the
+whole section — with an action that opens the sign-in dialog — in place of the
+navigation and content.
+
+#### Scenario: Signed-out visitor sees one sign-in prompt
+
+- **WHEN** a signed-out visitor opens any `my/*` page
+- **THEN** a single sign-in prompt with a sign-in action is shown instead of the
+  navigation and page body
+
+### Requirement: Tracking sub-navigation preserved
+
+The shell navigation SHALL be the top navigation level for Tracking; Tracking's
+existing Board, Pipeline, History, and AI-fit sub-views SHALL remain reachable as
+sub-tabs within the Tracking content, unchanged by the shell.
+
+#### Scenario: Tracking retains its sub-tabs under the shell
+
+- **WHEN** a signed-in user opens `/my/tracking`
+- **THEN** the shell marks Tracking active and the Board/Pipeline/History/AI-fit
+  sub-tabs are shown within the content column
+
+### Requirement: Account index redirect
+
+Requesting the bare `/my` path SHALL redirect to `/my/tracking` rather than
+returning a not-found response.
+
+#### Scenario: Bare /my redirects
+
+- **WHEN** a user navigates to `/my`
+- **THEN** the app redirects to `/my/tracking`

--- a/openspec/changes/my-account-sidebar/tasks.md
+++ b/openspec/changes/my-account-sidebar/tasks.md
@@ -1,0 +1,44 @@
+## 1. Navigation model (pure, unit-tested)
+
+- [x] 1.1 Add `web/src/lib/accountNav.ts` exporting the six-item nav config
+  (`{ href, label }`) and a pure `isSectionActive(path, href)` helper
+  (`path === href || path.startsWith(href + '/')`). Icons are mapped in the
+  layout, keeping this module Svelte-free and unit-testable.
+- [x] 1.2 Add `web/src/lib/accountNav.test.ts` (vitest): exact match active;
+  descendant path active (`/my/tracking/pipeline` → Tracking); non-matching
+  sibling not active; segment-boundary guard; config shape (6 items, `/my/`
+  hrefs, unique).
+
+## 2. Shell layout
+
+- [x] 2.1 Create `web/src/routes/my/+layout.svelte`: `mx-auto w-full max-w-6xl
+  px-4 py-6` container, `noindex` in `<svelte:head>`, unified auth-gate
+  (signed-out → single sign-in prompt + `openAuthDialog` action), signed-in →
+  vertical sidebar (`hidden lg:block w-56 shrink-0`, sticky) + horizontal strip
+  (`lg:hidden overflow-x-auto`) driven by `accountNav`, and `{@render
+  children()}` in a `min-w-0 flex-1` content column.
+- [x] 2.2 Add `web/src/routes/my/+page.ts` → `redirect(308, '/my/tracking')`.
+
+## 3. Refactor pages to fit the shell
+
+- [x] 3.1 `my/tracking/+layout.svelte`: drop the outer container, the
+  `!isAuthenticated()` gate, and the `noindex` (now owned by `my/+layout`); keep
+  the `<title>`, `<h1>Tracking`, the tab row, and `{@render children()}`.
+- [x] 3.2 `my/profile/+page.svelte`: remove the outer `mx-auto max-w-6xl px-4
+  py-6` wrapper, the `!isAuthenticated()` gate, and the per-page `noindex`; keep
+  `<title>`, header, and the internal tabbed layout.
+- [x] 3.3 `my/recommendations/+page.svelte`: remove outer wrapper + gate +
+  noindex; body fills the content column.
+- [x] 3.4 `my/searches/+page.svelte`: remove outer wrapper + gate + noindex;
+  keep an inner `max-w-3xl` on the body for reading width.
+- [x] 3.5 `my/api-keys/+page.svelte`: remove outer wrapper + gate + noindex;
+  keep inner `max-w-3xl` on the body.
+- [x] 3.6 `my/submissions/+page.svelte`: remove outer wrapper + gate + noindex;
+  keep inner `max-w-3xl` on the body.
+
+## 4. Verify
+
+- [x] 4.1 `npm run check` (svelte-check), eslint, and vitest all green.
+- [x] 4.2 Visual verify: signed-in shows the sidebar at `lg`+ and the strip below
+  `lg` with the correct active item per section; signed-out shows the single
+  gate; `/my` redirects to `/my/tracking`; Tracking sub-tabs still work.

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { accountNav, isSectionActive } from './accountNav';
+
+describe('accountNav config', () => {
+  it('lists the five account sections', () => {
+    expect(accountNav).toHaveLength(5);
+  });
+
+  it('every item links under /my/ and has a label', () => {
+    for (const item of accountNav) {
+      expect(item.href.startsWith('/my/')).toBe(true);
+      expect(item.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has unique hrefs', () => {
+    const hrefs = accountNav.map((i) => i.href);
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});
+
+describe('isSectionActive', () => {
+  it('is active on an exact path match', () => {
+    expect(isSectionActive('/my/profile', '/my/profile')).toBe(true);
+  });
+
+  it('is active on a descendant path', () => {
+    expect(isSectionActive('/my/tracking/pipeline', '/my/tracking')).toBe(true);
+  });
+
+  it('is not active on a different section', () => {
+    expect(isSectionActive('/my/profile', '/my/tracking')).toBe(false);
+  });
+
+  it('does not match on a shared prefix that is not a path segment', () => {
+    // '/my/api-keys-extra' shares the '/my/api-keys' prefix but is a different
+    // route — a segment boundary ('/') is required, not a bare string prefix.
+    expect(isSectionActive('/my/api-keys-extra', '/my/api-keys')).toBe(false);
+  });
+});

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -1,0 +1,25 @@
+// The account section's navigation model: the ordered list of `my/*` sections and
+// the active-item rule. Kept free of Svelte/icon imports so it stays pure and
+// unit-testable; the `my/+layout.svelte` shell maps each href to its icon.
+
+// Order = the order shown in the sidebar / tab strip. Identity (Profile) first,
+// then the reading/working sections. Create actions (Submit a job, Moderation)
+// deliberately live in the header menu, not here. `as const` keeps each href a
+// literal route so the layout can pass it to `resolve()` type-safely (mirroring
+// HeaderMenu's navLinks).
+export const accountNav = [
+  { href: '/my/profile', label: 'Profile' },
+  { href: '/my/tracking', label: 'Tracking' },
+  { href: '/my/searches', label: 'Search notifications' },
+  { href: '/my/api-keys', label: 'API keys' },
+  { href: '/my/submissions', label: 'My submissions' },
+] as const;
+
+export type AccountNavItem = (typeof accountNav)[number];
+
+// A section is active when the current path equals its route or is a descendant
+// of it. The trailing-slash guard means a shared string prefix that is not a path
+// segment (e.g. '/my/api-keys-extra' vs '/my/api-keys') is not a match.
+export function isSectionActive(path: string, href: string): boolean {
+  return path === href || path.startsWith(href + '/');
+}

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import { User, LayoutList, Bell, Key, FileText } from '@lucide/svelte';
+  import type { LucideIcon } from '@lucide/svelte';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
+  import { Button } from '$lib/ui';
+  import { accountNav, isSectionActive, type AccountNavItem } from '$lib/accountNav';
+  import { cn } from '$lib/utils';
+
+  // The account shell: one source of truth for the `my/*` chrome — the width
+  // container, the noindex tag, the auth gate, and the section navigation. Child
+  // pages render only their own header + body inside the content column. The nav
+  // is a vertical sidebar at lg+ and a horizontal scrollable strip below lg;
+  // Tracking keeps its own sub-tabs (this is the top navigation level).
+
+  let { children }: { children: Snippet } = $props();
+
+  const path = $derived(page.url.pathname);
+
+  // Icon per section, kept out of the pure accountNav model so that stays
+  // Svelte-free and unit-testable. Keyed by the nav hrefs so a new section
+  // without an icon is a compile error, not a runtime `<undefined />`.
+  const icons: Record<AccountNavItem['href'], LucideIcon> = {
+    '/my/profile': User,
+    '/my/tracking': LayoutList,
+    '/my/searches': Bell,
+    '/my/api-keys': Key,
+    '/my/submissions': FileText,
+  };
+
+  // Shared item treatment for both nav forms; active matches the tracking tabs.
+  const itemClass = (active: boolean) =>
+    cn(
+      'flex items-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
+      active
+        ? 'bg-secondary font-medium text-secondary-foreground'
+        : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+    );
+</script>
+
+<svelte:head>
+  <!-- Personal pages: keep the whole section out of search results, set once here. -->
+  <meta name="robots" content="noindex" />
+</svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  {#if !isAuthenticated()}
+    <div class="flex flex-col items-center gap-3 py-12 text-center">
+      <p class="text-sm text-muted-foreground">Sign in to access your account.</p>
+      <Button variant="primary" onclick={() => openAuthDialog()}>Sign in</Button>
+    </div>
+  {:else}
+    <!-- Same items, two forms; `extra` carries the per-form item tweaks. -->
+    {#snippet navLinks(extra: string)}
+      {#each accountNav as item (item.href)}
+        {@const active = isSectionActive(path, item.href)}
+        {@const Icon = icons[item.href]}
+        <a
+          href={resolve(item.href)}
+          aria-current={active ? 'page' : undefined}
+          class={cn(itemClass(active), extra)}
+        >
+          <Icon class="size-4 shrink-0" />
+          {item.label}
+        </a>
+      {/each}
+    {/snippet}
+
+    <!-- Below lg: a horizontal, scrollable strip above the content. -->
+    <nav aria-label="Account sections" class="mb-4 flex gap-1 overflow-x-auto lg:hidden">
+      {@render navLinks('shrink-0 whitespace-nowrap')}
+    </nav>
+
+    <div class="lg:flex lg:gap-8">
+      <!-- lg and up: a vertical sidebar beside the content. -->
+      <aside aria-label="Account sections" class="hidden shrink-0 lg:block lg:w-56">
+        <nav class="sticky top-6 flex flex-col gap-1">
+          {@render navLinks('')}
+        </nav>
+      </aside>
+
+      <div class="min-w-0 flex-1">
+        {@render children()}
+      </div>
+    </div>
+  {/if}
+</div>

--- a/web/src/routes/my/+page.ts
+++ b/web/src/routes/my/+page.ts
@@ -1,0 +1,7 @@
+import { redirect } from '@sveltejs/kit';
+
+// The account area has no landing page of its own; a bare /my sends the user to
+// Tracking (the first working section). 308 so bookmarks/inbound links are kept.
+export function load() {
+  redirect(308, '/my/tracking');
+}

--- a/web/src/routes/my/api-keys/+page.svelte
+++ b/web/src/routes/my/api-keys/+page.svelte
@@ -4,10 +4,10 @@
 
 <svelte:head>
   <title>API keys — freehire</title>
-  <!-- Personal page: keep it out of search results. -->
-  <meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class="mx-auto w-full max-w-3xl px-4 py-6">
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex;
+     an inner max-width keeps the content readable within the content column. -->
+<div class="max-w-3xl">
   <ApiKeysView />
 </div>

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -4,7 +4,6 @@
   import { page } from '$app/state';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
-  import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { FilterStore, filtersToParams } from '$lib/filters';
   import ATSReportView from '$lib/components/ATSReportView.svelte';
   import FilterSummary from '$lib/components/filters/FilterSummary.svelte';
@@ -185,163 +184,156 @@
 
 <svelte:head>
   <title>Profile — freehire</title>
-  <!-- Personal page: keep it out of search results. -->
-  <meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class="mx-auto w-full max-w-6xl px-4 py-6">
-  {#if !isAuthenticated()}
-    <div class="flex flex-col items-center gap-3 py-12 text-center">
-      <p class="text-sm text-muted-foreground">Sign in to set up your profile.</p>
-      <Button variant="primary" onclick={() => openAuthDialog()}>Sign in</Button>
-    </div>
-  {:else if status === 'loading'}
-    <States state="loading" />
-  {:else if status === 'error'}
-    <States state="error" message="Couldn't load your profile." />
-  {:else}
-    <!-- Header -->
-    <div class="mb-6 flex flex-col gap-1">
-      <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
-      <p class="text-sm text-muted-foreground">
-        Your CV, skills and role — measured against live market demand.
-      </p>
-    </div>
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex. -->
+{#if status === 'loading'}
+  <States state="loading" />
+{:else if status === 'error'}
+  <States state="error" message="Couldn't load your profile." />
+{:else}
+  <!-- Header -->
+  <div class="mb-6 flex flex-col gap-1">
+    <h1 class="text-2xl font-semibold tracking-tight">Profile</h1>
+    <p class="text-sm text-muted-foreground">
+      Your CV, skills and role — measured against live market demand.
+    </p>
+  </div>
 
-    {#if actionError}
-      <p class="mb-4 text-sm text-destructive">{actionError}</p>
+  {#if actionError}
+    <p class="mb-4 text-sm text-destructive">{actionError}</p>
+  {/if}
+
+  <!-- Run / Re-run AI review control, rendered inside the CV-readiness section header
+       (via ATSReportView's `action` slot) rather than crammed into the tab row. -->
+  {#snippet reviewAction()}
+    {#if ats?.report && !ats.report.reviewed && !reviewUnavailable}
+      <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
+        <ScanSearch class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+        {reviewBusy ? 'Reviewing…' : 'Run AI review'}
+      </Button>
+    {:else if ats?.report?.reviewed}
+      <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
+        <ScanSearch class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
+        {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
+      </Button>
     {/if}
+  {/snippet}
 
-    <!-- Run / Re-run AI review control, rendered inside the CV-readiness section header
-         (via ATSReportView's `action` slot) rather than crammed into the tab row. -->
-    {#snippet reviewAction()}
-      {#if ats?.report && !ats.report.reviewed && !reviewUnavailable}
-        <Button variant="primary" onclick={runReview} disabled={reviewBusy}>
-          <ScanSearch class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-          {reviewBusy ? 'Reviewing…' : 'Run AI review'}
-        </Button>
-      {:else if ats?.report?.reviewed}
-        <Button variant="ghost" onclick={runReview} disabled={reviewBusy}>
-          <ScanSearch class="size-4 {reviewBusy ? 'animate-pulse' : ''}" />
-          {reviewBusy ? 'Reviewing…' : 'Re-run AI review'}
-        </Button>
-      {/if}
-    {/snippet}
+  {#if profile === null}
+    <!-- Set-up: the inline form only; coverage appears once a profile exists. -->
+    <div class="mx-auto w-full max-w-2xl">
+      <ProfileForm profile={null} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
+    </div>
+  {:else}
+    <div class="flex gap-6">
+      <main class="flex min-w-0 flex-1 flex-col gap-6">
+        <!-- Tabs -->
+        <div class="flex gap-5 border-b border-border">
+          <button
+            type="button"
+            onclick={() => (tab = 'profile')}
+            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'profile'
+              ? 'border-brand text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            Your CV
+          </button>
+          <button
+            type="button"
+            onclick={() => (tab = 'coverage')}
+            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
+              ? 'border-brand text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            Market coverage
+          </button>
+          <button
+            type="button"
+            onclick={() => (tab = 'readiness')}
+            class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'readiness'
+              ? 'border-brand text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'}"
+          >
+            CV readiness
+          </button>
+        </div>
 
-    {#if profile === null}
-      <!-- Set-up: the inline form only; coverage appears once a profile exists. -->
-      <div class="mx-auto w-full max-w-2xl">
-        <ProfileForm profile={null} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
-      </div>
-    {:else}
-      <div class="flex gap-6">
-        <!-- Filters refine the Market coverage comparison only, so the summary sidebar
-             shows on that tab alone; the other tabs get the full width. -->
-        {#if filters && tab === 'coverage'}
-          <aside class="hidden w-72 shrink-0 md:block">
-            <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
-              <div class="rounded-xl border border-border bg-card p-4">
-                <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} />
-              </div>
-            </div>
-          </aside>
-        {/if}
-
-        <main class="flex min-w-0 flex-1 flex-col gap-6">
-          <!-- Tabs -->
-          <div class="flex gap-5 border-b border-border">
-            <button
-              type="button"
-              onclick={() => (tab = 'profile')}
-              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'profile'
-                ? 'border-brand text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'}"
+        <!-- Body -->
+        {#if tab === 'profile'}
+          {#key profile.updated_at}
+            <ProfileForm {profile} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
+          {/key}
+          <!-- Destructive action lives at the foot of the profile-management tab, out of
+               the page header (where it crowded the title on narrow viewports). -->
+          <div class="mt-2 flex justify-end border-t border-border pt-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={remove}
+              class="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
             >
-              Your CV
-            </button>
-            <button
-              type="button"
-              onclick={() => (tab = 'coverage')}
-              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'coverage'
-                ? 'border-brand text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'}"
-            >
-              Market coverage
-            </button>
-            <button
-              type="button"
-              onclick={() => (tab = 'readiness')}
-              class="-mb-px border-b-2 px-1 pb-2.5 text-sm font-medium transition-colors {tab === 'readiness'
-                ? 'border-brand text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'}"
-            >
-              CV readiness
-            </button>
+              <Trash2 class="size-4" />
+              Delete profile
+            </Button>
           </div>
+        {:else if loadError}
+          <States state="error" message="Couldn't load the report." />
+        {:else if verdict === null}
+          <States state="loading" />
+        {:else if tab === 'coverage'}
+          <VerdictView {verdict} {gapHref} />
+        {:else}
+          <!-- CV readiness: the structured résumé we parsed from the CV (read-only,
+               omitted when none is current) above the ATS-readiness score. -->
+          <div class="flex flex-col gap-6">
+            {#if structured}
+              <ResumeStructuredView resume={structured} />
+            {/if}
+            {#if ats?.has_cv && ats.report}
+              <div class="flex flex-col gap-5">
+                {#if reviewUnavailable}
+                  <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
+                {/if}
+                <ATSReportView report={ats.report} action={reviewAction} />
+              </div>
+            {:else if !structured}
+              <!-- No CV yet: uploaded via the Your CV tab. -->
+              <div class="flex flex-col items-start gap-2 rounded-xl border border-dashed border-border p-6">
+                <p class="text-sm font-medium">Add your CV to score its ATS readiness</p>
+                <p class="text-sm text-muted-foreground">
+                  Upload your CV in the <button type="button" class="font-medium text-foreground underline underline-offset-2" onclick={() => (tab = 'profile')}>Your CV</button> tab to check ATS readability and this role's keywords.
+                </p>
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </main>
 
-          <!-- Body -->
-          {#if tab === 'profile'}
-            {#key profile.updated_at}
-              <ProfileForm {profile} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
-            {/key}
-            <!-- Destructive action lives at the foot of the profile-management tab, out of
-                 the page header (where it crowded the title on narrow viewports). -->
-            <div class="mt-2 flex justify-end border-t border-border pt-4">
-              <Button
-                variant="ghost"
-                size="sm"
-                onclick={remove}
-                class="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-              >
-                <Trash2 class="size-4" />
-                Delete profile
-              </Button>
-            </div>
-          {:else if loadError}
-            <States state="error" message="Couldn't load the report." />
-          {:else if verdict === null}
-            <States state="loading" />
-          {:else if tab === 'coverage'}
-            <VerdictView {verdict} {gapHref} />
-          {:else}
-            <!-- CV readiness: the structured résumé we parsed from the CV (read-only,
-                 omitted when none is current) above the ATS-readiness score. -->
-            <div class="flex flex-col gap-6">
-              {#if structured}
-                <ResumeStructuredView resume={structured} />
-              {/if}
-              {#if ats?.has_cv && ats.report}
-                <div class="flex flex-col gap-5">
-                  {#if reviewUnavailable}
-                    <p class="text-xs text-muted-foreground">AI review is not available right now.</p>
-                  {/if}
-                  <ATSReportView report={ats.report} action={reviewAction} />
-                </div>
-              {:else if !structured}
-                <!-- No CV yet: uploaded via the Your CV tab. -->
-                <div class="flex flex-col items-start gap-2 rounded-xl border border-dashed border-border p-6">
-                  <p class="text-sm font-medium">Add your CV to score its ATS readiness</p>
-                  <p class="text-sm text-muted-foreground">
-                    Upload your CV in the <button type="button" class="font-medium text-foreground underline underline-offset-2" onclick={() => (tab = 'profile')}>Your CV</button> tab to check ATS readability and this role's keywords.
-                  </p>
-                </div>
-              {/if}
-            </div>
-          {/if}
-        </main>
-      </div>
-
+      <!-- Filters refine the Market coverage comparison only, so the summary sidebar
+           shows on that tab alone — to the right of the content, clear of the account
+           nav sidebar. -->
       {#if filters && tab === 'coverage'}
-        <FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
-        <FilterModal
-          store={filters}
-          {counts}
-          exclude={excludeFacets}
-          open={modalOpen}
-          onClose={() => (modalOpen = false)}
-          {previewCount}
-        />
+        <aside class="hidden w-72 shrink-0 md:block">
+          <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
+            <div class="rounded-xl border border-border bg-card p-4">
+              <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} />
+            </div>
+          </div>
+        </aside>
       {/if}
+    </div>
+
+    {#if filters && tab === 'coverage'}
+      <FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
+      <FilterModal
+        store={filters}
+        {counts}
+        exclude={excludeFacets}
+        open={modalOpen}
+        onClose={() => (modalOpen = false)}
+        {previewCount}
+      />
     {/if}
   {/if}
-</div>
+{/if}

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -330,6 +330,7 @@
         store={filters}
         {counts}
         exclude={excludeFacets}
+        savedSearches
         open={modalOpen}
         onClose={() => (modalOpen = false)}
         {previewCount}

--- a/web/src/routes/my/searches/+page.svelte
+++ b/web/src/routes/my/searches/+page.svelte
@@ -4,10 +4,10 @@
 
 <svelte:head>
   <title>Saved searches — freehire</title>
-  <!-- Personal page: keep it out of search results. -->
-  <meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class="mx-auto w-full max-w-3xl px-4 py-6">
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex;
+     an inner max-width keeps the list readable within the content column. -->
+<div class="max-w-3xl">
   <SavedSearchesView />
 </div>

--- a/web/src/routes/my/submissions/+page.svelte
+++ b/web/src/routes/my/submissions/+page.svelte
@@ -4,10 +4,10 @@
 
 <svelte:head>
   <title>My submissions — freehire</title>
-  <!-- Personal page: keep it out of search results. -->
-  <meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class="mx-auto w-full max-w-3xl px-4 py-6">
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex;
+     an inner max-width keeps the list readable within the content column. -->
+<div class="max-w-3xl">
   <MySubmissionsView />
 </div>

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -2,13 +2,14 @@
   import type { Snippet } from 'svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import { isAuthenticated } from '$lib/auth.svelte';
   import { cn } from '$lib/utils';
 
   let { children }: { children: Snippet } = $props();
 
-  // Each view is its own URL so it is linkable, bookmarkable, and survives a
-  // reload. Board is the index route; Pipeline/History/AI fit get their own paths.
+  // The account shell (my/+layout) owns the container, auth gate, and noindex;
+  // this layout adds only Tracking's own sub-navigation. Each view is its own URL
+  // so it is linkable, bookmarkable, and survives a reload. Board is the index
+  // route; Pipeline/History/Matches get their own paths.
   const path = $derived(page.url.pathname);
   // Board (index) matches exactly so it is not also active on the child routes.
   const boardActive = $derived(path === '/my/tracking');
@@ -26,53 +27,42 @@
 </script>
 
 <svelte:head>
-  <!-- Base title (the child pages override it with their view name); set here so
-       it is present even in the signed-out state, where children do not render. -->
+  <!-- Base title; the child pages override it with their view name. -->
   <title>Tracking — freehire</title>
-  <!-- Personal pages: keep them out of search results. -->
-  <meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class="mx-auto w-full max-w-6xl px-4 py-6">
-  {#if !isAuthenticated()}
-    <p class="py-12 text-center text-sm text-muted-foreground">
-      Sign in to see the jobs you saved, applied to, and are tracking.
-    </p>
-  {:else}
-    <div class="flex flex-col gap-4">
-      <h1 class="text-2xl font-semibold tracking-tight">Tracking</h1>
+<div class="flex flex-col gap-4">
+  <h1 class="text-2xl font-semibold tracking-tight">Tracking</h1>
 
-      <div role="tablist" aria-label="Tracking view" class="flex items-center gap-1">
-        <a role="tab" aria-selected={boardActive} href={resolve('/my/tracking')} class={tabClass(boardActive)}>
-          Board
-        </a>
-        <a
-          role="tab"
-          aria-selected={pipelineActive}
-          href={resolve('/my/tracking/pipeline')}
-          class={tabClass(pipelineActive)}
-        >
-          Pipeline
-        </a>
-        <a
-          role="tab"
-          aria-selected={historyActive}
-          href={resolve('/my/tracking/history')}
-          class={tabClass(historyActive)}
-        >
-          History
-        </a>
-        <a
-          role="tab"
-          aria-selected={analysesActive}
-          href={resolve('/my/tracking/analyses')}
-          class={tabClass(analysesActive)}
-        >
-          Matches
-        </a>
-      </div>
+  <div role="tablist" aria-label="Tracking view" class="flex items-center gap-1">
+    <a role="tab" aria-selected={boardActive} href={resolve('/my/tracking')} class={tabClass(boardActive)}>
+      Board
+    </a>
+    <a
+      role="tab"
+      aria-selected={pipelineActive}
+      href={resolve('/my/tracking/pipeline')}
+      class={tabClass(pipelineActive)}
+    >
+      Pipeline
+    </a>
+    <a
+      role="tab"
+      aria-selected={historyActive}
+      href={resolve('/my/tracking/history')}
+      class={tabClass(historyActive)}
+    >
+      History
+    </a>
+    <a
+      role="tab"
+      aria-selected={analysesActive}
+      href={resolve('/my/tracking/analyses')}
+      class={tabClass(analysesActive)}
+    >
+      Matches
+    </a>
+  </div>
 
-      {@render children()}
-    </div>
-  {/if}
+  {@render children()}
 </div>


### PR DESCRIPTION
## Summary
- New `my/+layout.svelte` shell owning the account area's chrome for every `my/*` route: width container, `noindex`, a unified auth-gate, and section navigation.
- Navigation renders as a vertical sidebar at `lg`+ and a horizontal scrollable tab strip below `lg`, driven by a pure, unit-tested `accountNav` model (icons mapped in the layout, keeping the model Svelte-free).
- `/my` now redirects (308) to `/my/tracking`.
- `tracking/+layout` and the five leaf pages (`profile`, `recommendations`, `searches`, `api-keys`, `submissions`) drop their own container, auth-gate, and `noindex` — now owned by the shell. Tracking keeps its Board/Pipeline/History/AI-fit sub-tabs.

Behavior change: the five per-page sign-in prompts are unified into one section gate.

OpenSpec change: `openspec/changes/my-account-sidebar` (archive after merge).

## Test Plan
- [x] `npm run check` (svelte-check): 0 errors / 0 warnings
- [x] `npx vitest run`: 148 passed (7 new for `accountNav`)
- [x] `npm run build`: production build succeeds
- [x] eslint: no new errors vs baseline
- [x] Visual: sidebar at `lg`, scrollable strip below `lg`, active item correct; signed-out shows the unified gate; `/my` → 308 `/my/tracking`
- [ ] Note: branch is based on `main`@707d71b; `main` has since advanced 15 commits — update/rebase if merge conflicts surface