### PR TITLE
feat(sources): neogov fetches full detail description

### DIFF
--- a/internal/sources/html.go
+++ b/internal/sources/html.go
@@ -118,6 +118,22 @@ func elementAttr(root *html.Node, tag, class, name string) string {
 	return found
 }
 
+// firstByID returns the first element whose id attribute equals id, or nil when none matches.
+func firstByID(root *html.Node, id string) *html.Node {
+	var found *html.Node
+	walk(root, func(n *html.Node) bool {
+		if found != nil {
+			return false
+		}
+		if n.Type == html.ElementNode && attr(n, "id") == id {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // hasClass reports whether n's space-separated class attribute contains class; an empty
 // class matches any element.
 func hasClass(n *html.Node, class string) bool {

--- a/internal/sources/neogov.go
+++ b/internal/sources/neogov.go
@@ -89,7 +89,19 @@ func (s neogov) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			break
 		}
 	}
-	return jobs, nil
+
+	// The listing carries only a teaser snippet; fetch each card's detail page for the full
+	// body. The detail page is server-rendered, so it needs no XHR header (unlike the
+	// listing). A failed or bodyless detail keeps the listing snippet rather than dropping
+	// the job, so a transient detail failure never yields a blank description.
+	return fetchDetails(jobs, defaultDetailWorkers, func(j Job) (Job, bool) {
+		if page, err := s.http.GetTextWithHeaders(ctx, j.URL, nil); err == nil {
+			if full := neogovDetailDescription(page); full != "" {
+				j.Description = full
+			}
+		}
+		return j, true
+	}), nil
 }
 
 // neogovTotal reads the open-postings count from the listing header, or 0 when absent (an
@@ -139,6 +151,24 @@ func neogovParseListing(fragment, domain, agency string) ([]Job, error) {
 		return true
 	})
 	return jobs, nil
+}
+
+// neogovDetailDescription extracts the full posting body from a detail page: the
+// #details-info container (Froala's .fr-view) holding the Definition, Minimum
+// Qualifications, and Supplemental Information sections. It returns the sanitized inner
+// HTML, or "" when the container is absent or empty (the caller then keeps the listing
+// snippet). The sibling #details-benefits/#details-questions tabs are deliberately not
+// captured — only the job description belongs in the description.
+func neogovDetailDescription(page string) string {
+	root, err := html.Parse(strings.NewReader(page))
+	if err != nil {
+		return ""
+	}
+	info := firstByID(root, "details-info")
+	if info == nil {
+		return ""
+	}
+	return sanitizeHTML(innerHTML(info))
 }
 
 // neogovFirstMeta returns the text of the first <li> inside the card's list-meta list (the

--- a/internal/sources/neogov_test.go
+++ b/internal/sources/neogov_test.go
@@ -1,6 +1,14 @@
 package sources
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
 
 // Fixture mirrors the real NEOGOV listing fragment (schooljobs/governmentjobs share it):
 // li.list-item[data-job-id] cards, each with an item-details-link, a list-meta whose first
@@ -53,6 +61,129 @@ func TestNeogovParseListing(t *testing.T) {
 	}
 	if jobs[1].ExternalID != "5379875" || jobs[1].Location != "Douglas Campus, AZ" {
 		t.Errorf("job1 = %q/%q", jobs[1].ExternalID, jobs[1].Location)
+	}
+}
+
+// neogovDetailFixture mirrors the real NEOGOV detail page: the full posting body lives in
+// <div id="details-info" class="tab-pane active fr-view"> as a <dl>/<dt>/<dd> structure, with
+// separate benefit/question tabs the adapter must NOT capture.
+const neogovDetailFixture = `<html><body>
+  <div class="container entity-details-content tab-content">
+    <div id="details-info" class="tab-pane active fr-view">
+      <dl>
+        <dt><h2>Definition</h2></dt>
+        <dd><p>Provide advanced clinical services to youth in secure care.</p></dd>
+        <dt><h2>Minimum Qualifications</h2></dt>
+        <dd><p>A master's degree in social work.</p></dd>
+      </dl>
+    </div>
+    <div id="details-benefits" class="tab-pane fr-view"><p>Benefits blurb — must be excluded.</p></div>
+  </div>
+</body></html>`
+
+func TestNeogovDetailDescription(t *testing.T) {
+	desc := neogovDetailDescription(neogovDetailFixture)
+	if !strings.Contains(desc, "Minimum Qualifications") {
+		t.Errorf("description missing full body: %q", desc)
+	}
+	if !strings.Contains(desc, "advanced clinical services") {
+		t.Errorf("description missing definition: %q", desc)
+	}
+	if strings.Contains(desc, "Benefits blurb") {
+		t.Errorf("description leaked the benefits tab: %q", desc)
+	}
+	// Sanitized HTML structure is preserved, not flattened to text.
+	if !strings.Contains(desc, "<h2>") {
+		t.Errorf("description not HTML: %q", desc)
+	}
+}
+
+func TestNeogovDetailDescriptionAbsent(t *testing.T) {
+	if desc := neogovDetailDescription(`<html><body><div>no details-info here</div></body></html>`); desc != "" {
+		t.Errorf("want empty when container absent, got %q", desc)
+	}
+}
+
+func TestFirstByID(t *testing.T) {
+	root, err := html.Parse(strings.NewReader(`<div><p id="target">hit</p><p id="other">miss</p></div>`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n := firstByID(root, "target")
+	if n == nil || textContent(n) != "hit" {
+		t.Errorf("firstByID = %v", n)
+	}
+	if firstByID(root, "missing") != nil {
+		t.Errorf("firstByID(missing) should be nil")
+	}
+}
+
+// neogovFakeHTTP routes by URL: the listing endpoint returns a fragment, each /jobs/<id>/
+// detail URL returns its mapped body (or an error), and records whether the XHR header was
+// sent so the test can assert the detail fetch is a plain GET.
+type neogovFakeHTTP struct {
+	listing    string
+	details    map[string]string
+	detailErr  map[string]bool
+	detailXHR  map[string]bool // id -> whether X-Requested-With was sent on its detail call
+	listingXHR bool
+}
+
+var neogovJobIDRe = regexp.MustCompile(`/jobs/(\d+)/`)
+
+func (f *neogovFakeHTTP) GetTextWithHeaders(_ context.Context, url string, headers map[string]string) (string, error) {
+	_, xhr := headers["X-Requested-With"]
+	if strings.Contains(url, "careers/home/index") {
+		f.listingXHR = xhr
+		return f.listing, nil
+	}
+	m := neogovJobIDRe.FindStringSubmatch(url)
+	id := ""
+	if m != nil {
+		id = m[1]
+	}
+	if f.detailXHR == nil {
+		f.detailXHR = map[string]bool{}
+	}
+	f.detailXHR[id] = xhr
+	if f.detailErr[id] {
+		return "", errors.New("neogovFakeHTTP: detail boom")
+	}
+	return f.details[id], nil
+}
+
+func TestNeogovFetchStoresDetailBody(t *testing.T) {
+	// A count span forces the walk to stop after one listing page.
+	listing := `<span id="job-postings-number">2</span>` + neogovListingFixture
+	f := &neogovFakeHTTP{
+		listing: listing,
+		details: map[string]string{"5371857": neogovDetailFixture},
+		// 5379875 has no detail body → its fetch errors, so the snippet must survive.
+		detailErr: map[string]bool{"5379875": true},
+	}
+	jobs, err := neogov{http: f}.Fetch(context.Background(), CompanyEntry{Company: "Cochise College", Board: "schooljobs.com/cochisecollege"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if got := byID["5371857"].Description; !strings.Contains(got, "Minimum Qualifications") {
+		t.Errorf("job 5371857 description = %q, want full detail body", got)
+	}
+	if got := byID["5379875"].Description; got != "Maintain the college's financial records." {
+		t.Errorf("job 5379875 description = %q, want listing snippet fallback", got)
+	}
+	// The detail fetch must be a plain GET (no XHR header); the listing must carry it.
+	if !f.listingXHR {
+		t.Errorf("listing request missing X-Requested-With header")
+	}
+	if f.detailXHR["5371857"] {
+		t.Errorf("detail request must NOT carry X-Requested-With header")
 	}
 }
 

--- a/openspec/changes/neogov-detail-description/.openspec.yaml
+++ b/openspec/changes/neogov-detail-description/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/neogov-detail-description/design.md
+++ b/openspec/changes/neogov-detail-description/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`internal/sources/neogov.go` is a list-only adapter: it parses the listing fragment's
+`li.list-item` cards and stores the card's `.list-entry` teaser as the description. A
+spike against a live posting (`governmentjobs.com/careers/louisiana/jobs/5382055`)
+confirmed the full body is server-rendered on the detail page inside
+`<div id="details-info" class="tab-pane active fr-view">` as a `<dl>/<dt>/<dd>`
+structure (~4KB text), reachable by a plain GET with **no** `X-Requested-With` header.
+The package already provides `innerHTML(node)`, `sanitizeHTML(s)`, `firstByClass`,
+`walk`, and `attr`; the `neogovHTTP` port already exposes
+`GetTextWithHeaders(ctx, url, headers)`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Store the full NEOGOV posting body as sanitized HTML, replacing the teaser snippet.
+- Keep one board's detail fetches bounded and resilient — a per-card failure degrades
+  to the snippet, never a blank description or a dropped job.
+- Backfill existing rows through the normal ingest path, no new worker.
+
+**Non-Goals:**
+- Parsing the detail page's Benefits/Questions tabs (`#details-benefits`,
+  `#details-questions`) — only `#details-info` is the job description.
+- Extracting the absolute posted date from the detail page (a separate concern the
+  list-only comment already flagged; out of scope here).
+- Any schema, API, migration, or env change.
+
+## Decisions
+
+**Fetch the detail page per card, reuse the existing port.** `Fetch` already builds
+each card's absolute detail URL. After parsing the listing, the adapter fetches each
+card's detail via `GetTextWithHeaders(ctx, url, nil)` — the same port, but with a nil
+header map because the detail page is plain server-rendered HTML. Alternative
+considered: extend the port with a header-less `GetText`. Rejected — passing `nil`
+headers to the existing method is the minimal change and the shared HTTP client
+already tolerates it.
+
+**Extract `#details-info` by its stable class, sanitize its inner HTML.** The
+container carries `class="... fr-view"` (Froala editor view) and `id="details-info"`.
+The parse locates it and yields `sanitizeHTML(innerHTML(node))`, matching the
+sanitized-HTML description contract every other detail adapter follows (tbank,
+dataart, careerspage). The listing snippet is retained as the degrade fallback.
+A small `firstByID` helper (mirroring `firstByClass`) selects the container by id for
+precision; matching `fr-view` by class is the fallback if id proves unstable across
+tenants.
+
+**Bound the detail fetches.** The per-board detail requests run under a bounded
+concurrency (a small worker pool over the parsed cards), satisfying the source-ingest
+"detail requests SHALL be bounded" requirement and matching the N+1 shape of other
+detail adapters. Sequential is acceptable for correctness; bounded-concurrent keeps a
+large agency's crawl within the cron window.
+
+**No backfill script.** `UpsertJob`'s conflict clause is
+`description = COALESCE(NULLIF(EXCLUDED.description, ''), jobs.description)` — a
+non-empty incoming description overwrites the stored one — and `content_hash` includes
+the description (`jobhash.Of`), so a re-crawl reports the row `changed` and re-pushes
+it to the search index. The next `cmd/ingest sources/neogov.yml` run therefore
+corrects every existing NEOGOV row in place. Alternative considered: a one-off
+`cmd/backfill-neogov`. Rejected as redundant with the self-healing re-ingest path
+(the same pattern as job-reality-signal and incremental indexing) — an operator runs
+the normal crawl once post-deploy for an immediate backfill.
+
+## Risks / Trade-offs
+
+- **Detail markup varies across tenants** → extraction keys on `#details-info` /
+  `.fr-view`, both NEOGOV platform chrome (not per-agency content), and degrades to
+  the snippet when absent, so an unexpected layout yields the old behavior, not a
+  blank.
+- **N+1 request volume on large agencies** → bounded concurrency plus the existing
+  `board_health` cooldown backoff keep a slow or failing board from being hammered;
+  detail failures are per-card and non-fatal to the board crawl.
+- **Sanitized HTML now where plain text was** → correct per the source-ingest
+  sanitized-HTML requirement; the frontend already renders adapter descriptions as
+  sanitized HTML, so this aligns NEOGOV with every other detail adapter.

--- a/openspec/changes/neogov-detail-description/proposal.md
+++ b/openspec/changes/neogov-detail-description/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The NEOGOV adapter (governmentjobs.com / schooljobs.com) is list-only: it stores the
+short teaser snippet from the listing card (`li.list-item .list-entry`) as the job
+description. The full posting body — Minimum Qualifications, Examples of Work,
+Supplemental Information — lives on the per-vacancy detail page the adapter never
+fetches, so every NEOGOV job on freehire ships a truncated description
+(e.g. `/jobs/social-worker-5-a-...` shows only the opening paragraph).
+
+## What Changes
+
+- The NEOGOV adapter fetches each listing card's detail page and stores the full
+  job body (the `#details-info` / `.fr-view` container) as sanitized HTML, instead of
+  the listing snippet.
+- The detail fetch is a plain GET (no `X-Requested-With` header — unlike the listing,
+  the detail page is server-rendered) and is bounded so one board cannot issue
+  unbounded concurrent requests, per the existing source-ingest requirement.
+- A failed or empty detail fetch degrades to the listing snippet rather than dropping
+  the job, so a transient detail failure never produces a blank description.
+- **No backfill script.** Existing NEOGOV rows are corrected in place by the next
+  normal `cmd/ingest sources/neogov.yml` crawl: `UpsertJob` overwrites a stored
+  description with the non-empty full body, and the resulting `content_hash` change
+  re-pushes the doc to the search index. Operators may run that crawl once
+  post-deploy to backfill immediately instead of waiting for cron.
+
+## Capabilities
+
+### New Capabilities
+- `neogov-source`: the NEOGOV career-site adapter's ingest contract — board shape,
+  listing pagination, and detail-fetched full description.
+
+### Modified Capabilities
+<!-- none: source-ingest already permits per-posting detail fetch and requires sanitized-HTML descriptions; this change realizes those for NEOGOV without altering the general contract -->
+
+## Impact
+
+- `internal/sources/neogov.go` (+ `neogov_test.go`): add per-card detail fetch and
+  full-body extraction; the `neogovHTTP` port already exposes the needed text GET.
+- No schema, migration, or API change. No new env.
+- Ingest cost: NEOGOV crawls change from one request per board to one per board plus
+  one per posting (bounded), the same N+1 shape as other detail-fetching adapters.

--- a/openspec/changes/neogov-detail-description/specs/neogov-source/spec.md
+++ b/openspec/changes/neogov-detail-description/specs/neogov-source/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: NEOGOV adapter ingests career-site postings
+
+The system SHALL ingest jobs from NEOGOV career sites (governmentjobs.com and its
+education vertical schooljobs.com) through a `neogov` `Source` adapter registered by
+provider key. The board SHALL be `"<domain>/<agency>"` (e.g.
+`schooljobs.com/cochisecollege`), and an invalid board (missing domain or agency)
+SHALL fail fast with an error.
+
+The listing endpoint is a Knockout SPA whose job cards are served only when the
+request carries an `X-Requested-With: XMLHttpRequest` header; without it the endpoint
+returns the empty JS shell. The adapter SHALL send that header for the listing,
+SHALL paginate until a page yields no new cards or the header count is reached, and
+SHALL parse each `li.list-item[data-job-id]` card for its title, detail URL, and
+location.
+
+#### Scenario: Adapter parses listing cards into jobs
+
+- **WHEN** the adapter fetches an agency's listing fragment with the XHR header
+- **THEN** it yields one job per `li.list-item[data-job-id]` card, carrying the card's
+  title, absolute detail URL, location, and the platform's `data-job-id` as the
+  external id
+
+#### Scenario: Invalid board fails fast
+
+- **WHEN** a board string lacks a `<domain>/<agency>` split
+- **THEN** the adapter returns an error and yields no jobs
+
+### Requirement: NEOGOV adapter stores the full detail-page description
+
+The adapter SHALL fetch each listing card's detail page and yield the full posting
+body — the `#details-info` (`.fr-view`) container that holds the job's Definition,
+Minimum Qualifications, and Supplemental Information sections — as the job
+`description`, in place of the listing card's teaser snippet. The detail page is
+server-rendered, so the detail fetch SHALL be a plain GET that does NOT send the
+`X-Requested-With` header the listing requires. The description SHALL be sanitized
+HTML (per the source-ingest sanitized-HTML requirement), assembled from the
+container's inner markup, not the plain-text snippet.
+
+Detail fetches SHALL be bounded so a single board cannot issue unbounded concurrent
+requests. A detail fetch that fails or yields an empty body SHALL degrade to the
+listing card's snippet rather than dropping the job or storing a blank description.
+
+#### Scenario: Full body replaces the listing snippet
+
+- **WHEN** the adapter processes a listing card whose detail page carries the full
+  posting body in `#details-info`
+- **THEN** the yielded job description is the sanitized HTML of that container,
+  containing the full sections rather than only the card's opening paragraph
+
+#### Scenario: Detail fetch failure degrades to the snippet
+
+- **WHEN** a card's detail page fails to fetch or its `#details-info` container is
+  absent or empty
+- **THEN** the adapter yields the job with the listing card's snippet as its
+  description rather than dropping the job or storing a blank description
+
+### Requirement: Existing NEOGOV rows backfill through re-ingest
+
+The change SHALL NOT require a dedicated backfill worker. Because `UpsertJob`
+overwrites a stored description with a non-empty incoming one and the resulting
+`content_hash` change re-pushes the document to the search index, a normal
+`cmd/ingest sources/neogov.yml` crawl SHALL correct every existing NEOGOV row in
+place.
+
+#### Scenario: Re-ingest replaces a stored snippet in place
+
+- **WHEN** an existing NEOGOV job whose stored description is the old listing snippet
+  is re-crawled by the updated adapter
+- **THEN** `UpsertJob` overwrites the description with the full detail body and reports
+  the row as content-changed, so it is re-indexed without a separate backfill script

--- a/openspec/changes/neogov-detail-description/tasks.md
+++ b/openspec/changes/neogov-detail-description/tasks.md
@@ -1,0 +1,31 @@
+## 1. Detail extraction
+
+- [x] 1.1 Add a `firstByID` helper in `internal/sources/html.go` (mirroring
+  `firstByClass`), with a unit test.
+- [x] 1.2 Add `neogovDetailDescription(fragment string) string` in `neogov.go`: parse
+  the detail HTML, locate `#details-info`, and return `sanitizeHTML(innerHTML(node))`;
+  return `""` when the container is absent or empty. Cover with a `neogov_test.go`
+  fixture (full body present, and container missing → empty).
+
+## 2. Wire detail fetch into Fetch
+
+- [x] 2.1 After the listing parse, fetch each card's detail via
+  `GetTextWithHeaders(ctx, url, nil)` under bounded concurrency and set
+  `Job.Description` to the extracted full body; on fetch error or empty result, keep
+  the listing snippet. Update the existing listing test's fake HTTP to serve detail
+  pages and assert the full body is stored, snippet is the fallback.
+- [x] 2.2 Bound the detail fan-out by reusing the shared, already-tested
+  `fetchDetails(_, defaultDetailWorkers, _)` helper (the same bound every other
+  detail adapter uses) rather than re-testing the helper's own concurrency guarantee.
+
+## 3. Verify & document
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./internal/sources/`.
+- [x] 3.2 Ran the adapter live against `governmentjobs.com/louisiana` and
+  `schooljobs.com/cochisecollege`: full `<dl>` HTML bodies (4–8 KB) now flow on both
+  tenants; the `#details-info` selector holds on both. A transient detail-fetch
+  failure under concurrency degrades to the listing snippet (confirmed
+  non-deterministic across two runs — the same posting self-heals to full HTML on
+  re-crawl), never a blank or dropped job. Large boards (louisiana ≈ 644 postings)
+  incur the documented N+1 detail-fetch cost, bounded by `defaultDetailWorkers` +
+  `board_health` cooldown. No backfill script: re-ingest overwrites snippets in place.


### PR DESCRIPTION
## Summary
- The NEOGOV adapter (`governmentjobs.com` / `schooljobs.com`) stored only the listing card's teaser snippet as the job description; the full posting body (Minimum Qualifications, Examples of Work, Supplemental Information) lives on the per-vacancy detail page it never fetched — so every NEOGOV job shipped a truncated description.
- `Fetch` now fetches each card's detail page and stores the **sanitized HTML** of the `#details-info` (`.fr-view`) container, bounded by the shared `fetchDetails` worker pool. The detail fetch is a plain GET (the detail page is server-rendered, unlike the XHR-gated listing).
- A failed or bodyless detail **degrades to the listing snippet** rather than dropping the job or storing a blank description.
- Adds a small `firstByID` DOM helper (mirrors `firstByClass`).

## No backfill script
Existing NEOGOV rows self-heal on the next `cmd/ingest sources/neogov.yml` crawl: `UpsertJob` overwrites the stored snippet with the non-empty full body (`description = COALESCE(NULLIF(EXCLUDED.description,''), jobs.description)`) and the `content_hash` change re-pushes the doc to the search index. Operators may run that crawl once post-deploy to backfill immediately.

## Test Plan
- [x] `go build ./... && go vet ./internal/sources/ && go test ./internal/sources/` green
- [x] Unit: full body replaces snippet; container-absent → empty; detail-fetch error → snippet fallback; detail GET carries no XHR header while listing does; `firstByID`
- [x] Live: ran against `governmentjobs.com/louisiana` + `schooljobs.com/cochisecollege` — full `<dl>` HTML bodies (4–8 KB) flow on both tenants; `#details-info` selector holds; a transient detail failure degrades to the snippet and self-heals to full HTML on re-crawl (confirmed non-deterministic across two runs)

## Notes
- Large boards (e.g. louisiana ≈ 644 postings) incur the documented N+1 detail-fetch cost, bounded by `defaultDetailWorkers` + the `board_health` cooldown.
- OpenSpec change: `openspec/changes/neogov-detail-description/` (new `neogov-source` capability spec).