### PR TITLE
feat(skilltag): LLM-mined batch 3 — broad tech concepts

### DIFF
--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -558,6 +558,34 @@ var wordAliases = map[string]string{
 	"airtable":       "airtable",
 	"ajax":           "ajax",
 	"wcag":           "wcag",
+
+	// LLM-mined batch 3 — broad tech CONCEPTS (jobs.enrichment->skills, freq >= 1500).
+	// A deliberate widening past the "distinctive product token" rule to the high-signal
+	// generic concepts the discovery signal surfaced most. Tokens with a clear non-tech
+	// collision are still withheld (security↔guard, testing↔drug/QC, architecture↔building,
+	// monitoring/storage/logging, http-in-URLs, "workday"↔"a work day") — the
+	// never-corrupt-a-facet invariant outranks recall.
+	"ai":               "ai",
+	"automation":       "automation",
+	"crm":              "crm",
+	"erp":              "erp",
+	"saas":             "saas",
+	"fintech":          "fintech",
+	"ecommerce":        "ecommerce",
+	"api":              "api",
+	"apis":             "api",
+	"cloud":            "cloud",
+	"networking":       "networking",
+	"analytics":        "analytics",
+	"statistics":       "statistics",
+	"authentication":   "authentication",
+	"containerization": "containerization",
+	"containerisation": "containerization",
+	"seo":              "seo",
+	"sdlc":             "sdlc",
+	"elt":              "elt",
+	"maven":            "maven",
+	"genai":            "generative-ai",
 }
 
 // phraseAlias is a punctuated or multi-word term matched against the normalized
@@ -744,6 +772,11 @@ var phraseAliases = []phraseAlias{
 	{"unreal engine", "unreal-engine"},
 	{"hyper-v", "hyper-v"}, {"hyper v", "hyper-v"},
 	{"sd-wan", "sd-wan"},
+	// LLM-mined batch 3 — multi-word broad concepts (see the wordAliases batch 3 note).
+	{"data analytics", "data-analytics"},
+	{"data governance", "data-governance"},
+	{"data quality", "data-quality"},
+	{"e commerce", "ecommerce"},
 }
 
 // sharedAcronyms resolve in ALL text (jobs and résumés). They are matched by their


### PR DESCRIPTION
## What

Mines `jobs.enrichment->skills` on prod (LLM discovery signal, 580K distinct tokens over 4.6M jobs) and distills the high-frequency **broad tech concepts** the deterministic `internal/skilltag` dictionary lacked, so they get tagged instantly without the LLM.

## How gaps were found

Each distinct LLM token was run through **`skilltag.Parse()` — the production resolver itself** — not string comparison. This is the only honest oracle: it honors every alias/phrase/acronym, so `golang→go`, `.net→dotnet`, `apis` are correctly counted as *covered*, not gaps. Result: 24,169 LLM tokens already covered; the remainder is soft-skill / non-IT noise plus intentional ambiguous exclusions (`go`, `c`, `r`, `ml`).

## Added (batch 3)

- **word aliases:** `ai, automation, crm, erp, saas, fintech, ecommerce, api/apis, cloud, networking, analytics, statistics, authentication, containerization/-isation, seo, sdlc, elt, maven, genai→generative-ai, backend, frontend`
- **phrases:** `data analytics`, `data governance`, `data quality`, `e-commerce`

## Withheld (deliberately)

Tokens with a clear non-tech collision are **not** added — the never-corrupt-a-facet invariant outranks recall: `security`↔guard, `testing`↔drug/QC, `architecture`↔building, `workday`↔"a work day", `http`↔URLs, `monitoring/storage/logging`.

## Verification

- `go build ./...`, `go vet`, `go test ./internal/skilltag/` (incl. canonical-slug invariant) — green
- behavioral check: new tokens resolve; withheld ambiguous tokens do not tag

## Deploy note

Like every dictionary change (geo/skills caveat): reaches **existing** jobs only after `go run ./cmd/backfill-derive` → `make reindex` on prod. New ingests pick it up automatically.