### PR TITLE
feat(dedup): collapse role-cluster reposts to one canonical job

### DIFF
--- a/cmd/ingest/store.go
+++ b/cmd/ingest/store.go
@@ -126,7 +126,10 @@ func (s *dbStore) Save(ctx context.Context, j job.Job) error {
 	// facets. The signal only covers fields UpsertJob writes: changes made by other
 	// paths (enrichment via SetJobEnrichment, collections via
 	// PropagateCollectionsToJobs) reconcile on the next batch reindex, not here.
-	if s.indexer != nil && needsIndex(saved) {
+	// A known non-canonical repost (duplicate_of set on a prior recompute) is not
+	// searchable, so it is never pushed to the live index; the reindex reconciles a
+	// freshly-ingested repost whose marker is not yet computed.
+	if s.indexer != nil && needsIndex(saved) && !saved.Job.DuplicateOf.Valid {
 		// The job-reality signal needs this role's cluster counts; a lookup failure
 		// degrades to a unique role (counts 1) rather than failing the index push.
 		repost, mass := int64(1), int64(1)

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -112,6 +112,17 @@ func run() int {
 		return 1
 	}
 
+	// Refresh the role-cluster canonical markers before reading jobs, so the collapse
+	// (splitJobs drops non-canonical reposts) reflects the current catalogue and a
+	// closed canon has failed over. Whole-table but IS DISTINCT FROM-guarded, so steady
+	// state only re-marks changed rows. Best-effort: a hiccup here must not block the
+	// reindex (which also owns settings/compaction), so it degrades to the prior markers.
+	if n, err := q.RecomputeRoleDuplicates(ctx); err != nil {
+		log.Printf("reindex: recompute role duplicates (continuing with prior markers): %v", err)
+	} else if n > 0 {
+		log.Printf("reindex: recomputed role duplicates (%d rows re-marked)", n)
+	}
+
 	// --since is a delta into the LIVE index in place: a partial set cannot be
 	// swapped in wholesale (it would drop everything else). A full pass instead
 	// builds a fresh index and atomically swaps it over the live one, which keeps
@@ -387,7 +398,10 @@ func splitJobs(jobs []db.Job, lookup realityLookup, now time.Time) ([]search.Job
 	docs := make([]search.JobDocument, 0, len(jobs))
 	deleteIDs := make([]int64, 0, len(jobs))
 	for _, j := range jobs {
-		if j.ClosedAt.Valid {
+		// A closed job or a non-canonical repost (duplicate_of set) leaves the index:
+		// only the open canonical row of each role cluster is searchable. Deleting (not
+		// just skipping) removes a row that was indexed before it was closed or demoted.
+		if j.ClosedAt.Valid || j.DuplicateOf.Valid {
 			deleteIDs = append(deleteIDs, j.ID)
 			continue
 		}

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -98,6 +98,25 @@ func TestSplitJobs_OpenBecomeDocsClosedBecomeDeletions(t *testing.T) {
 	}
 }
 
+// A non-canonical repost (duplicate_of set) must not be indexed, and is deleted from
+// the index so a previously-canonical row that got demoted leaves search.
+func TestSplitJobs_RepostsDeletedNotIndexed(t *testing.T) {
+	canon := db.Job{ID: 1, Title: "Canon", PublicSlug: "canon-x"}
+	repost := db.Job{ID: 2, Title: "Repost", PublicSlug: "repost-x",
+		DuplicateOf: pgtype.Int8{Int64: 1, Valid: true}}
+
+	docs, deleteIDs, err := splitJobs([]db.Job{canon, repost}, nil, time.Now())
+	if err != nil {
+		t.Fatalf("splitJobs: %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != 1 {
+		t.Fatalf("docs = %+v, want only the canon", docs)
+	}
+	if len(deleteIDs) != 1 || deleteIDs[0] != 2 {
+		t.Fatalf("deleteIDs = %v, want [2] (repost removed)", deleteIDs)
+	}
+}
+
 // fakeRebuilder records the sequence of rebuilder calls and the ids of every
 // pushed batch, so a unit test can pin the full-rebuild orchestration without a
 // real Meilisearch.

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -367,9 +367,12 @@ func (q *Queries) ListCompanySitemap(ctx context.Context, arg ListCompanySitemap
 
 const refreshCompanyFacets = `-- name: RefreshCompanyFacets :execrows
 WITH oj AS (
+    -- duplicate_of IS NULL counts one canonical job per role cluster, so the company
+    -- job_count matches the collapsed /jobs and company lists (reposts share facets, so
+    -- the DISTINCT region/country aggregates are unaffected — only the count changes).
     SELECT company_slug, regions, countries, enrichment, work_mode
     FROM jobs
-    WHERE closed_at IS NULL AND company_slug <> ''
+    WHERE closed_at IS NULL AND duplicate_of IS NULL AND company_slug <> ''
 ),
 counts AS (
     SELECT company_slug, count(*) AS cnt FROM oj GROUP BY company_slug

--- a/internal/db/enrichment.sql.go
+++ b/internal/db/enrichment.sql.go
@@ -20,6 +20,7 @@ WITH claimable AS (
       AND (o.claimed_at IS NULL
            OR o.claimed_at < now() - make_interval(secs => $1::int))
       AND j.closed_at IS NULL
+      AND j.duplicate_of IS NULL
     ORDER BY COALESCE(j.posted_at, j.created_at) DESC, j.id DESC
     FOR UPDATE OF o SKIP LOCKED
     LIMIT $2
@@ -87,6 +88,7 @@ INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, $1::int
 FROM jobs
 WHERE closed_at IS NULL
+  AND duplicate_of IS NULL
   AND (enriched_at IS NULL OR enrichment_version < $1::int)
   AND category <> ALL(COALESCE($2::text[], '{}'))
 ON CONFLICT (job_id, target_version) DO NOTHING

--- a/internal/db/job_duplicate_of_integration_test.go
+++ b/internal/db/job_duplicate_of_integration_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+// Integration tests for RecomputeRoleDuplicates: it collapses each role cluster
+// (company_slug + role_fingerprint) to one canonical open job (min(id)), pointing the
+// other open reposts at it via duplicate_of, while leaving singletons and
+// unfingerprinted rows canonical. Canon failover on close and the min(id) tie-break are
+// SQL behaviors verifiable only against a real Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// dupOf reads a job's id and duplicate_of by external_id. dup is -1 when NULL (canon).
+func dupOf(t *testing.T, pool *pgxpool.Pool, ext string) (id int64, dup int64) {
+	t.Helper()
+	var d *int64
+	if err := pool.QueryRow(context.Background(),
+		"SELECT id, duplicate_of FROM jobs WHERE external_id = $1", ext).Scan(&id, &d); err != nil {
+		t.Fatalf("read %s: %v", ext, err)
+	}
+	if d == nil {
+		return id, -1
+	}
+	return id, *d
+}
+
+func TestRecomputeRoleDuplicates_CollapsesClusterToMinIDCanon(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// A cluster of three identical-fingerprint open jobs; first inserted has min(id).
+	const fp = "role-dup"
+	for _, ext := range []string{"acme:1", "acme:2", "acme:3"} {
+		if _, err := q.UpsertJob(ctx, withFingerprint(ext, "Staff Engineer", fp)); err != nil {
+			t.Fatalf("upsert %s: %v", ext, err)
+		}
+	}
+	// A singleton fingerprinted role and an unfingerprinted row must stay canonical.
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:solo", "Solo", "role-solo")); err != nil {
+		t.Fatalf("upsert solo: %v", err)
+	}
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:nofp", "Untagged", "")); err != nil {
+		t.Fatalf("upsert nofp: %v", err)
+	}
+
+	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	canonID, canonDup := dupOf(t, pool, "acme:1")
+	if canonDup != -1 {
+		t.Errorf("canon acme:1 duplicate_of = %d, want NULL", canonDup)
+	}
+	for _, ext := range []string{"acme:2", "acme:3"} {
+		if _, dup := dupOf(t, pool, ext); dup != canonID {
+			t.Errorf("%s duplicate_of = %d, want canon %d", ext, dup, canonID)
+		}
+	}
+	if _, dup := dupOf(t, pool, "acme:solo"); dup != -1 {
+		t.Errorf("singleton duplicate_of = %d, want NULL", dup)
+	}
+	if _, dup := dupOf(t, pool, "acme:nofp"); dup != -1 {
+		t.Errorf("unfingerprinted duplicate_of = %d, want NULL", dup)
+	}
+
+	// Idempotent: a second run does not flip the canon.
+	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
+		t.Fatalf("recompute again: %v", err)
+	}
+	if _, dup := dupOf(t, pool, "acme:1"); dup != -1 {
+		t.Errorf("canon changed on re-run: acme:1 duplicate_of = %d, want NULL", dup)
+	}
+
+	// Failover: close the canon; the next min(id) (acme:2) becomes canonical.
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = now() WHERE external_id = $1", "acme:1"); err != nil {
+		t.Fatalf("close canon: %v", err)
+	}
+	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
+		t.Fatalf("recompute after close: %v", err)
+	}
+	newCanonID, newCanonDup := dupOf(t, pool, "acme:2")
+	if newCanonDup != -1 {
+		t.Errorf("failover: acme:2 duplicate_of = %d, want NULL (new canon)", newCanonDup)
+	}
+	if _, dup := dupOf(t, pool, "acme:3"); dup != newCanonID {
+		t.Errorf("failover: acme:3 duplicate_of = %d, want new canon %d", dup, newCanonID)
+	}
+}
+
+func TestDuplicateReposts_HiddenFromListAndEnrichment(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	const fp = "role-dup"
+	for _, ext := range []string{"acme:1", "acme:2"} {
+		if _, err := q.UpsertJob(ctx, withFingerprint(ext, "Staff Engineer", fp)); err != nil {
+			t.Fatalf("upsert %s: %v", ext, err)
+		}
+	}
+	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	canonID, _ := dupOf(t, pool, "acme:1")
+	repostID, _ := dupOf(t, pool, "acme:2")
+
+	// ListJobs returns the canon, not the repost.
+	jobs, err := q.ListJobs(ctx, ListJobsParams{Limit: 100, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	seen := map[int64]bool{}
+	for _, j := range jobs {
+		seen[j.ID] = true
+	}
+	if !seen[canonID] {
+		t.Errorf("ListJobs missing canon %d", canonID)
+	}
+	if seen[repostID] {
+		t.Errorf("ListJobs returned repost %d, want it hidden", repostID)
+	}
+
+	// EnqueuePendingJobs enqueues the canon, not the repost.
+	if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: 1}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if !outboxHas(t, pool, canonID) {
+		t.Errorf("canon %d not enqueued", canonID)
+	}
+	if outboxHas(t, pool, repostID) {
+		t.Errorf("repost %d enqueued, want it skipped", repostID)
+	}
+}
+
+func outboxHas(t *testing.T, pool *pgxpool.Pool, jobID int64) bool {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM enrichment_outbox WHERE job_id = $1", jobID).Scan(&n); err != nil {
+		t.Fatalf("outbox count %d: %v", jobID, err)
+	}
+	return n > 0
+}

--- a/internal/db/job_duplicate_semantic_integration_test.go
+++ b/internal/db/job_duplicate_semantic_integration_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+// The semantic queue must treat a non-canonical repost (duplicate_of set) like a closed
+// job: never embed it, and remove it if it was embedded while canonical — so it stays
+// consistent with the full reindex --semantic, which drops reposts via splitJobs.
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func setDuplicateOf(t *testing.T, pool *pgxpool.Pool, jobID, canonID int64) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		"UPDATE jobs SET duplicate_of = $1 WHERE id = $2", canonID, jobID); err != nil {
+		t.Fatalf("set duplicate_of: %v", err)
+	}
+}
+
+func contains(ids []int64, want int64) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSemanticEnqueue_RepostsExcludedAndRemoved(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	canon := insertJob(t, pool, "canon")
+	setContentHash(t, pool, canon, "h1")
+
+	// A never-embedded repost must NOT be enqueued for embedding.
+	repost := insertJob(t, pool, "repost")
+	setContentHash(t, pool, repost, "h1")
+	setDuplicateOf(t, pool, repost, canon)
+
+	// A repost that WAS embedded while canonical must be enqueued for removal.
+	embeddedRepost := insertJob(t, pool, "embedded-repost")
+	setContentHash(t, pool, embeddedRepost, "h1")
+	setSemanticStamp(t, pool, embeddedRepost, targetModel, "h1")
+	setDuplicateOf(t, pool, embeddedRepost, canon)
+
+	if _, err := q.EnqueuePendingSemanticJobs(ctx, EnqueuePendingSemanticJobsParams{TargetModel: targetModel}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	ids := semanticOutboxJobIDs(t, pool)
+	if !contains(ids, canon) {
+		t.Errorf("canon %d not enqueued for embedding", canon)
+	}
+	if contains(ids, repost) {
+		t.Errorf("never-embedded repost %d enqueued, want excluded", repost)
+	}
+	if !contains(ids, embeddedRepost) {
+		t.Errorf("embedded repost %d not enqueued for removal", embeddedRepost)
+	}
+
+	// The claim flags the embedded repost for removal (closed=true), like a closed job.
+	claimed, err := q.ClaimSemanticBatch(ctx, ClaimSemanticBatchParams{LeaseSeconds: 3600, BatchSize: 10})
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	for _, c := range claimed {
+		if c.JobID == embeddedRepost && !c.Closed {
+			t.Errorf("embedded repost claimed with closed=false, want true (removal)")
+		}
+		if c.JobID == canon && c.Closed {
+			t.Errorf("canon claimed with closed=true, want false (embed)")
+		}
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -439,7 +439,7 @@ func (q *Queries) ListJobIDsUpdatedAfter(ctx context.Context, arg ListJobIDsUpda
 const listJobSitemapFreshest = `-- name: ListJobSitemapFreshest :many
 SELECT public_slug, updated_at
 FROM jobs
-WHERE closed_at IS NULL
+WHERE closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY id DESC
 LIMIT $1
 `
@@ -557,7 +557,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 const listJobsByCompany = `-- name: ListJobsByCompany :many
 SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
-WHERE company_slug = $1 AND closed_at IS NULL
+WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
 LIMIT $2 OFFSET $3
 `
@@ -568,6 +568,8 @@ type ListJobsByCompanyParams struct {
 	Offset      int32  `json:"offset"`
 }
 
+// duplicate_of IS NULL collapses role-cluster reposts to their canonical row, matching
+// the /jobs list so a company page shows one card per role, not every repost.
 func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyParams) ([]Job, error) {
 	rows, err := q.db.Query(ctx, listJobsByCompany, arg.CompanySlug, arg.Limit, arg.Offset)
 	if err != nil {

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -171,7 +171,7 @@ func (q *Queries) ExistingExternalIDs(ctx context.Context, source string) ([]str
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE id = $1
 `
@@ -221,12 +221,13 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.RoleFingerprint,
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
+		&i.DuplicateOf,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE public_slug = $1
 `
@@ -276,12 +277,13 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.RoleFingerprint,
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
+		&i.DuplicateOf,
 	)
 	return i, err
 }
 
 const getJobBySourceExternalID = `-- name: GetJobBySourceExternalID :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE source = $1 AND external_id = $2
 `
@@ -338,6 +340,7 @@ func (q *Queries) GetJobBySourceExternalID(ctx context.Context, arg GetJobBySour
 		&i.RoleFingerprint,
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
+		&i.DuplicateOf,
 	)
 	return i, err
 }
@@ -473,9 +476,9 @@ func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
-WHERE closed_at IS NULL
+WHERE closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
 LIMIT $1 OFFSET $2
 `
@@ -539,6 +542,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.RoleFingerprint,
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
+			&i.DuplicateOf,
 		); err != nil {
 			return nil, err
 		}
@@ -551,7 +555,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL
 ORDER BY created_at DESC, id DESC
@@ -615,6 +619,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.RoleFingerprint,
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
+			&i.DuplicateOf,
 		); err != nil {
 			return nil, err
 		}
@@ -627,7 +632,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -693,6 +698,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.RoleFingerprint,
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
+			&i.DuplicateOf,
 		); err != nil {
 			return nil, err
 		}
@@ -705,7 +711,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsBySourceAfter = `-- name: ListJobsBySourceAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE source = $1 AND id > $2
 ORDER BY id
@@ -772,6 +778,7 @@ func (q *Queries) ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourc
 			&i.RoleFingerprint,
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
+			&i.DuplicateOf,
 		); err != nil {
 			return nil, err
 		}
@@ -784,7 +791,7 @@ func (q *Queries) ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourc
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -854,6 +861,7 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.RoleFingerprint,
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
+			&i.DuplicateOf,
 		); err != nil {
 			return nil, err
 		}
@@ -902,7 +910,7 @@ func (q *Queries) ListOpenJobIDsPostedAfter(ctx context.Context, arg ListOpenJob
 }
 
 const listOpenJobsPostedAfter = `-- name: ListOpenJobsPostedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE id > $1 AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= $2
 ORDER BY id
@@ -974,6 +982,7 @@ func (q *Queries) ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsP
 			&i.RoleFingerprint,
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
+			&i.DuplicateOf,
 		); err != nil {
 			return nil, err
 		}
@@ -1035,6 +1044,44 @@ WHERE jobs.company_slug = c.slug
 // re-runs idempotent and cheap.
 func (q *Queries) PropagateCollectionsToJobs(ctx context.Context) (int64, error) {
 	result, err := q.db.Exec(ctx, propagateCollectionsToJobs)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const recomputeRoleDuplicates = `-- name: RecomputeRoleDuplicates :execrows
+WITH canon AS (
+    SELECT company_slug, role_fingerprint, MIN(id) AS canon_id, COUNT(*) AS n
+    FROM jobs
+    WHERE closed_at IS NULL AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
+    GROUP BY company_slug, role_fingerprint
+),
+target AS (
+    SELECT j.id,
+        CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
+    FROM jobs j
+    JOIN canon c
+      ON j.company_slug = c.company_slug AND j.role_fingerprint = c.role_fingerprint
+    WHERE j.closed_at IS NULL
+)
+UPDATE jobs j
+SET duplicate_of = t.new_dup,
+    updated_at   = now()
+FROM target t
+WHERE j.id = t.id
+  AND j.duplicate_of IS DISTINCT FROM t.new_dup
+`
+
+// Collapse each role cluster to one canonical open job. For every OPEN, fingerprinted
+// job, the canon is the min(id) among its (company_slug, role_fingerprint) cluster's
+// open rows; the canon and any singleton/empty-fingerprint row get duplicate_of NULL,
+// the other reposts point to the canon. Rows are never deleted, so the reality counts
+// (which count the rows) are untouched. The IS DISTINCT FROM guard makes re-runs cheap
+// and idempotent, and a closed canon fails over to the next min(id) on the next run.
+// Closed rows are left as-is (excluded by closed_at everywhere the marker is read).
+func (q *Queries) RecomputeRoleDuplicates(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, recomputeRoleDuplicates)
 	if err != nil {
 		return 0, err
 	}
@@ -1387,7 +1434,7 @@ SET title        = $1,
     updated_by   = $20::bigint,
     updated_at   = now()
 WHERE public_slug = $21 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 `
 
 type UpdateManualJobParams struct {
@@ -1493,6 +1540,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.RoleFingerprint,
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
+		&i.DuplicateOf,
 	)
 	return i, err
 }
@@ -1565,7 +1613,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
     ((SELECT old_hash FROM existing) IS DISTINCT FROM $24) AS changed
 `
@@ -1695,6 +1743,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.RoleFingerprint,
 		&i.Job.SemanticEmbeddedModel,
 		&i.Job.SemanticEmbeddedHash,
+		&i.Job.DuplicateOf,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -1753,7 +1802,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 `
 
 type UpsertManualJobParams struct {
@@ -1865,6 +1914,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.RoleFingerprint,
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
+		&i.DuplicateOf,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -114,6 +114,7 @@ type Job struct {
 	RoleFingerprint       pgtype.Text        `json:"role_fingerprint"`
 	SemanticEmbeddedModel pgtype.Text        `json:"semantic_embedded_model"`
 	SemanticEmbeddedHash  pgtype.Text        `json:"semantic_embedded_hash"`
+	DuplicateOf           pgtype.Int8        `json:"duplicate_of"`
 }
 
 type JobDailyStat struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -27,9 +27,10 @@ type Querier interface {
 	// separate reaper process is needed.
 	ClaimEnrichmentBatch(ctx context.Context, arg ClaimEnrichmentBatchParams) ([]ClaimEnrichmentBatchRow, error)
 	// Claim a batch of live, unleased entries, freshest job first, by stamping claimed_at.
-	// Unlike ClaimEnrichmentBatch this does NOT filter closed jobs out: a closed entry is
-	// the removal signal, so the worker must receive it and branch on `closed`. The jobs
-	// join supplies both the freshness order and the closed flag. Freshness is
+	// Unlike ClaimEnrichmentBatch this does NOT filter unindexable jobs out: a closed OR
+	// non-canonical (duplicate_of) entry is the removal signal, so the worker must receive
+	// it and branch on `closed` (true = remove the document). The jobs join supplies both
+	// the freshness order and that flag. Freshness is
 	// COALESCE(posted_at, created_at): jobs without a source post date fall back to ingest
 	// time so they rank by recency instead of starving under NULLS LAST. FOR UPDATE OF o
 	// locks only outbox rows (a bare FOR UPDATE would also lock jobs, making concurrent
@@ -210,8 +211,11 @@ type Querier interface {
 	//      exclude_categories (enrich.NonTechCategories) are skipped so embed budget stays
 	//      on technical roles; category is NOT NULL DEFAULT '', so an empty/unrecognized
 	//      category is never excluded (empty string <> ALL keeps the row).
-	//   2. CLOSED jobs that still carry an embed stamp (were embedded while open) — so the
-	//      worker removes their now-dead document from jobs_semantic and clears the stamp.
+	//   2. UNINDEXABLE jobs that still carry an embed stamp (were embedded while open and
+	//      canonical) — a job now closed OR a non-canonical repost (duplicate_of set) — so
+	//      the worker removes their document from jobs_semantic and clears the stamp. This
+	//      mirrors the facet index: the full reindex --semantic also drops reposts (shared
+	//      splitJobs), so the incremental path must not re-add them.
 	// ON CONFLICT keeps exactly one entry per (job_id, target_model), so running this every
 	// command invocation never duplicates work.
 	EnqueuePendingSemanticJobs(ctx context.Context, arg EnqueuePendingSemanticJobsParams) (int64, error)
@@ -381,6 +385,8 @@ type Querier interface {
 	// across re-ingests), so fresh ingests surface on top regardless of how old the
 	// platform's posted_at is. id breaks ties within one ingest batch.
 	ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, error)
+	// duplicate_of IS NULL collapses role-cluster reposts to their canonical row, matching
+	// the /jobs list so a company page shows one card per role, not every repost.
 	ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyParams) ([]Job, error)
 	// Keyset scan for the reindex command: pages by the immutable primary key, so
 	// concurrent inserts/updates (which shift posted_at ordering) cannot make the

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -488,6 +488,14 @@ type Querier interface {
 	// (AT TIME ZONE 'UTC') so buckets are stable regardless of session timezone. The
 	// FULL OUTER JOIN yields one row per day that saw either an add or a removal.
 	RebuildJobDailyStats(ctx context.Context) (int64, error)
+	// Collapse each role cluster to one canonical open job. For every OPEN, fingerprinted
+	// job, the canon is the min(id) among its (company_slug, role_fingerprint) cluster's
+	// open rows; the canon and any singleton/empty-fingerprint row get duplicate_of NULL,
+	// the other reposts point to the canon. Rows are never deleted, so the reality counts
+	// (which count the rows) are untouched. The IS DISTINCT FROM guard makes re-runs cheap
+	// and idempotent, and a closed canon fails over to the next min(id) on the next run.
+	// Closed rows are left as-is (excluded by closed_at everywhere the marker is read).
+	RecomputeRoleDuplicates(ctx context.Context) (int64, error)
 	// Count a failed crawl: bump consecutive_failures, record the error, stamp the run,
 	// and RETURN the new failure count so the caller can compute the cooldown (the backoff
 	// policy lives in Go, not here). The cooldown itself is applied by SetBoardCooldown.

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -196,9 +196,12 @@ ON CONFLICT (slug) DO UPDATE SET
 -- (eventual consistency). The facet aggregates are each their own non-correlated
 -- GROUP BY so the row-multiplying unnest of one array never distorts another's count.
 WITH oj AS (
+    -- duplicate_of IS NULL counts one canonical job per role cluster, so the company
+    -- job_count matches the collapsed /jobs and company lists (reposts share facets, so
+    -- the DISTINCT region/country aggregates are unaffected — only the count changes).
     SELECT company_slug, regions, countries, enrichment, work_mode
     FROM jobs
-    WHERE closed_at IS NULL AND company_slug <> ''
+    WHERE closed_at IS NULL AND duplicate_of IS NULL AND company_slug <> ''
 ),
 counts AS (
     SELECT company_slug, count(*) AS cnt FROM oj GROUP BY company_slug

--- a/internal/db/queries/enrichment.sql
+++ b/internal/db/queries/enrichment.sql
@@ -11,6 +11,7 @@ INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, sqlc.arg(target_version)::int
 FROM jobs
 WHERE closed_at IS NULL
+  AND duplicate_of IS NULL
   AND (enriched_at IS NULL OR enrichment_version < sqlc.arg(target_version)::int)
   AND category <> ALL(COALESCE(sqlc.arg(exclude_categories)::text[], '{}'))
 ON CONFLICT (job_id, target_version) DO NOTHING;
@@ -34,6 +35,7 @@ WITH claimable AS (
       AND (o.claimed_at IS NULL
            OR o.claimed_at < now() - make_interval(secs => sqlc.arg(lease_seconds)::int))
       AND j.closed_at IS NULL
+      AND j.duplicate_of IS NULL
     ORDER BY COALESCE(j.posted_at, j.created_at) DESC, j.id DESC
     FOR UPDATE OF o SKIP LOCKED
     LIMIT sqlc.arg(batch_size)

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -4,7 +4,7 @@
 -- platform's posted_at is. id breaks ties within one ingest batch.
 SELECT *
 FROM jobs
-WHERE closed_at IS NULL
+WHERE closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
 LIMIT $1 OFFSET $2;
 
@@ -271,6 +271,35 @@ FROM jobs
 WHERE role_fingerprint IS NOT NULL AND role_fingerprint <> ''
 GROUP BY company_slug, role_fingerprint
 HAVING COUNT(*) > 1;
+
+-- name: RecomputeRoleDuplicates :execrows
+-- Collapse each role cluster to one canonical open job. For every OPEN, fingerprinted
+-- job, the canon is the min(id) among its (company_slug, role_fingerprint) cluster's
+-- open rows; the canon and any singleton/empty-fingerprint row get duplicate_of NULL,
+-- the other reposts point to the canon. Rows are never deleted, so the reality counts
+-- (which count the rows) are untouched. The IS DISTINCT FROM guard makes re-runs cheap
+-- and idempotent, and a closed canon fails over to the next min(id) on the next run.
+-- Closed rows are left as-is (excluded by closed_at everywhere the marker is read).
+WITH canon AS (
+    SELECT company_slug, role_fingerprint, MIN(id) AS canon_id, COUNT(*) AS n
+    FROM jobs
+    WHERE closed_at IS NULL AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
+    GROUP BY company_slug, role_fingerprint
+),
+target AS (
+    SELECT j.id,
+        CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
+    FROM jobs j
+    JOIN canon c
+      ON j.company_slug = c.company_slug AND j.role_fingerprint = c.role_fingerprint
+    WHERE j.closed_at IS NULL
+)
+UPDATE jobs j
+SET duplicate_of = t.new_dup,
+    updated_at   = now()
+FROM target t
+WHERE j.id = t.id
+  AND j.duplicate_of IS DISTINCT FROM t.new_dup;
 
 -- name: PropagateCollectionsToJobs :execrows
 -- Denormalize each company's curated-collection set onto its jobs, so the search

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -139,14 +139,16 @@ SELECT estimate_open_jobs()::bigint;
 -- fuller coverage needs a precomputed narrow table, not a live scan.
 SELECT public_slug, updated_at
 FROM jobs
-WHERE closed_at IS NULL
+WHERE closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY id DESC
 LIMIT sqlc.arg(row_limit);
 
 -- name: ListJobsByCompany :many
+-- duplicate_of IS NULL collapses role-cluster reposts to their canonical row, matching
+-- the /jobs list so a company page shows one card per role, not every repost.
 SELECT *
 FROM jobs
-WHERE company_slug = $1 AND closed_at IS NULL
+WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
 LIMIT $2 OFFSET $3;
 

--- a/internal/db/queries/semantic.sql
+++ b/internal/db/queries/semantic.sql
@@ -7,27 +7,31 @@
 --      exclude_categories (enrich.NonTechCategories) are skipped so embed budget stays
 --      on technical roles; category is NOT NULL DEFAULT '', so an empty/unrecognized
 --      category is never excluded (empty string <> ALL keeps the row).
---   2. CLOSED jobs that still carry an embed stamp (were embedded while open) — so the
---      worker removes their now-dead document from jobs_semantic and clears the stamp.
+--   2. UNINDEXABLE jobs that still carry an embed stamp (were embedded while open and
+--      canonical) — a job now closed OR a non-canonical repost (duplicate_of set) — so
+--      the worker removes their document from jobs_semantic and clears the stamp. This
+--      mirrors the facet index: the full reindex --semantic also drops reposts (shared
+--      splitJobs), so the incremental path must not re-add them.
 -- ON CONFLICT keeps exactly one entry per (job_id, target_model), so running this every
 -- command invocation never duplicates work.
 INSERT INTO semantic_outbox (job_id, target_model)
 SELECT id, sqlc.arg(target_model)::text
 FROM jobs
 WHERE (
-        closed_at IS NULL
+        closed_at IS NULL AND duplicate_of IS NULL
         AND (semantic_embedded_model IS DISTINCT FROM sqlc.arg(target_model)::text
              OR semantic_embedded_hash IS DISTINCT FROM content_hash)
         AND category <> ALL(COALESCE(sqlc.arg(exclude_categories)::text[], '{}'))
       )
-   OR (closed_at IS NOT NULL AND semantic_embedded_model IS NOT NULL)
+   OR ((closed_at IS NOT NULL OR duplicate_of IS NOT NULL) AND semantic_embedded_model IS NOT NULL)
 ON CONFLICT (job_id, target_model) DO NOTHING;
 
 -- name: ClaimSemanticBatch :many
 -- Claim a batch of live, unleased entries, freshest job first, by stamping claimed_at.
--- Unlike ClaimEnrichmentBatch this does NOT filter closed jobs out: a closed entry is
--- the removal signal, so the worker must receive it and branch on `closed`. The jobs
--- join supplies both the freshness order and the closed flag. Freshness is
+-- Unlike ClaimEnrichmentBatch this does NOT filter unindexable jobs out: a closed OR
+-- non-canonical (duplicate_of) entry is the removal signal, so the worker must receive
+-- it and branch on `closed` (true = remove the document). The jobs join supplies both
+-- the freshness order and that flag. Freshness is
 -- COALESCE(posted_at, created_at): jobs without a source post date fall back to ingest
 -- time so they rank by recency instead of starving under NULLS LAST. FOR UPDATE OF o
 -- locks only outbox rows (a bare FOR UPDATE would also lock jobs, making concurrent
@@ -52,7 +56,7 @@ SET claimed_at = now()
 FROM claimable c
 JOIN jobs j ON j.id = c.job_id
 WHERE o.id = c.id
-RETURNING o.id, o.job_id, (j.closed_at IS NOT NULL)::boolean AS closed;
+RETURNING o.id, o.job_id, (j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL)::boolean AS closed;
 
 -- name: GetJobsByIDs :many
 -- Batch-load the persisted rows the embed worker builds documents from. A corrupted

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -139,7 +139,7 @@ func (q *Queries) EnqueuePendingSemanticJobs(ctx context.Context, arg EnqueuePen
 }
 
 const getJobsByIDs = `-- name: GetJobsByIDs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
 FROM jobs
 WHERE id = ANY($1::bigint[])
 `
@@ -198,6 +198,7 @@ func (q *Queries) GetJobsByIDs(ctx context.Context, ids []int64) ([]Job, error) 
 			&i.RoleFingerprint,
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
+			&i.DuplicateOf,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -28,7 +28,7 @@ SET claimed_at = now()
 FROM claimable c
 JOIN jobs j ON j.id = c.job_id
 WHERE o.id = c.id
-RETURNING o.id, o.job_id, (j.closed_at IS NOT NULL)::boolean AS closed
+RETURNING o.id, o.job_id, (j.closed_at IS NOT NULL OR j.duplicate_of IS NOT NULL)::boolean AS closed
 `
 
 type ClaimSemanticBatchParams struct {
@@ -43,9 +43,10 @@ type ClaimSemanticBatchRow struct {
 }
 
 // Claim a batch of live, unleased entries, freshest job first, by stamping claimed_at.
-// Unlike ClaimEnrichmentBatch this does NOT filter closed jobs out: a closed entry is
-// the removal signal, so the worker must receive it and branch on `closed`. The jobs
-// join supplies both the freshness order and the closed flag. Freshness is
+// Unlike ClaimEnrichmentBatch this does NOT filter unindexable jobs out: a closed OR
+// non-canonical (duplicate_of) entry is the removal signal, so the worker must receive
+// it and branch on `closed` (true = remove the document). The jobs join supplies both
+// the freshness order and that flag. Freshness is
 // COALESCE(posted_at, created_at): jobs without a source post date fall back to ingest
 // time so they rank by recency instead of starving under NULLS LAST. FOR UPDATE OF o
 // locks only outbox rows (a bare FOR UPDATE would also lock jobs, making concurrent
@@ -103,12 +104,12 @@ INSERT INTO semantic_outbox (job_id, target_model)
 SELECT id, $1::text
 FROM jobs
 WHERE (
-        closed_at IS NULL
+        closed_at IS NULL AND duplicate_of IS NULL
         AND (semantic_embedded_model IS DISTINCT FROM $1::text
              OR semantic_embedded_hash IS DISTINCT FROM content_hash)
         AND category <> ALL(COALESCE($2::text[], '{}'))
       )
-   OR (closed_at IS NOT NULL AND semantic_embedded_model IS NOT NULL)
+   OR ((closed_at IS NOT NULL OR duplicate_of IS NOT NULL) AND semantic_embedded_model IS NOT NULL)
 ON CONFLICT (job_id, target_model) DO NOTHING
 `
 
@@ -125,8 +126,11 @@ type EnqueuePendingSemanticJobsParams struct {
 //     exclude_categories (enrich.NonTechCategories) are skipped so embed budget stays
 //     on technical roles; category is NOT NULL DEFAULT ”, so an empty/unrecognized
 //     category is never excluded (empty string <> ALL keeps the row).
-//  2. CLOSED jobs that still carry an embed stamp (were embedded while open) — so the
-//     worker removes their now-dead document from jobs_semantic and clears the stamp.
+//  2. UNINDEXABLE jobs that still carry an embed stamp (were embedded while open and
+//     canonical) — a job now closed OR a non-canonical repost (duplicate_of set) — so
+//     the worker removes their document from jobs_semantic and clears the stamp. This
+//     mirrors the facet index: the full reindex --semantic also drops reposts (shared
+//     splitJobs), so the incremental path must not re-add them.
 //
 // ON CONFLICT keeps exactly one entry per (job_id, target_model), so running this every
 // command invocation never duplicates work.

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -187,7 +187,7 @@ func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) 
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -278,6 +278,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.RoleFingerprint,
 			&i.Job.SemanticEmbeddedModel,
 			&i.Job.SemanticEmbeddedHash,
+			&i.Job.DuplicateOf,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,

--- a/internal/embed/runner.go
+++ b/internal/embed/runner.go
@@ -18,8 +18,9 @@ import (
 	"github.com/strelov1/freehire/internal/worker"
 )
 
-// Claimed is one outbox entry leased to this run. Closed marks whether the job has
-// since closed: open jobs are embedded, closed jobs have their document removed.
+// Claimed is one outbox entry leased to this run. Closed marks whether the job is now
+// unindexable — closed OR a non-canonical repost (duplicate_of set): open canonical jobs
+// are embedded, unindexable ones have their document removed.
 type Claimed struct {
 	OutboxID int64
 	JobID    int64

--- a/migrations/0012_job_duplicate_of.sql
+++ b/migrations/0012_job_duplicate_of.sql
@@ -1,0 +1,23 @@
+-- duplicate_of marks a job as a non-canonical repost of another job in the same role
+-- cluster ((company_slug, role_fingerprint), see 0003). Exactly one open row per
+-- cluster is canonical (duplicate_of IS NULL) — the deterministic min(id) among the
+-- cluster's open rows; the rest reference it. This collapses the catalogue to one card
+-- per role WITHOUT deleting rows, so the job-reality repost/mass-posting counts (which
+-- count the rows) are unaffected. The list, search index, and enrichment enqueue
+-- exclude rows with a non-null duplicate_of; detail-by-slug still serves them.
+--
+-- Recomputed by RecomputeRoleDuplicates (reindex + recount cadence), so a closed canon
+-- fails over to the next min(id). It is read/enqueue-time collapse, distinct from the
+-- pre-insert dedup key (source, external_id).
+--
+-- Applied to a fresh volume by initdb after 0011; on an existing prod volume this ALTER
+-- must be run manually BEFORE deploying code that reads the column, followed by a
+-- RecomputeRoleDuplicates pass so existing clusters collapse.
+ALTER TABLE public.jobs
+    ADD COLUMN duplicate_of bigint REFERENCES public.jobs(id);
+
+-- Partial index over the reposts (the minority): supports the recompute's cluster
+-- writes and any duplicate_of lookups without bloating the canonical-heavy table.
+CREATE INDEX jobs_duplicate_of_idx
+    ON public.jobs USING btree (duplicate_of)
+    WHERE duplicate_of IS NOT NULL;

--- a/openspec/changes/ingest-content-dedup/.openspec.yaml
+++ b/openspec/changes/ingest-content-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/ingest-content-dedup/design.md
+++ b/openspec/changes/ingest-content-dedup/design.md
@@ -1,0 +1,74 @@
+## Context
+
+Ingest already computes `jobs.role_fingerprint` (`hash(company_slug|norm_title|
+norm_description)`, migration 0003, `internal/jobhash.RoleFingerprint`) on every
+upsert, indexed on `(company_slug, role_fingerprint)`. The job-reality signal already
+aggregates each cluster (`RoleClusterCount`/`RoleClusterCountsAll` → repost_count,
+mass_count) at index time and shows "reposted N×". What is missing is the **collapse**:
+all reposts still render as separate cards, appear in search, and are enriched.
+
+A spike also established the boundary: exact-content reposts share a fingerprint and
+cluster cleanly, but reworded / cross-source copies get a different fingerprint (and
+sit in the same similarity band as different roles), so they are out of scope here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show one canonical job per role cluster in list + search; skip reposts in enrichment.
+- Reuse the existing fingerprint and cluster counts; do not disturb the reality signal.
+
+**Non-Goals:**
+- Reworded / cross-source near-duplicates (Track 2).
+- Dropping inserts (the reality signal needs the rows) — collapse is read/enqueue-time.
+- Backfilling existing rows in this change (a follow-up `cmd`).
+- Changing `role_fingerprint` or the reality counting.
+
+## Decisions
+
+**Collapse at read/enrichment, not pre-insert.** The reality signal counts repost rows;
+dropping inserts would break it. So every posting is still stored and counted, and a
+canonical marker decides what the catalogue/search/enrichment surface.
+
+**Stored canonical marker `jobs.duplicate_of` (bigint NULL), computed per cluster.**
+A stored marker gives ONE consistent canon across list, search, and enrichment (three
+independent query-time collapses would risk disagreeing). It matches the codebase's
+denormalized compute-at-index pattern (skills/regions/role_fingerprint). Canon =
+`min(id)` among the cluster's OPEN rows; the rest get `duplicate_of = canon.id`; canon
+and empty-fingerprint rows stay null. `min(id)` is chosen over source-preference
+because cross-source clusters are rare (rewrites diverge the fingerprint), so within-
+source `min(id)` is deterministic, stable, and avoids coupling to the source registry.
+
+**Recompute in the reindex path + a cron sibling.** The marker is refreshed by a set-
+based `RecomputeRoleDuplicates` pass over open clusters, run where the role-cluster
+counts are already recomputed (reindex) and on the recount cadence, so canon failover
+(a closed canon → new `min(id)`) reconciles on the same schedule as the reality
+counts. Incremental ingest push is best-effort consistent (a freshly-ingested repost
+may show until the next recompute — the same eventual-consistency the facets have).
+
+**Filters, not new code paths.** List and enrichment-enqueue add `duplicate_of IS
+NULL`; reindex/incremental-push skip `duplicate_of IS NOT NULL`. Detail-by-slug is
+unchanged (a repost stays reachable, like a closed job). Openings count reuses the
+cluster open count already computed for the reality view.
+
+## Risks / Trade-offs
+
+- [Eventual consistency: a new repost shows until the next recompute] → Acceptable, and
+  identical to how the reality counts and other denormalized facets already behave.
+- [Canon churn] → `min(id)` is monotone and deterministic; a canon only changes when it
+  closes, and then to the next `min(id)`. A test asserts stability across recomputes.
+- [Genuinely distinct openings collapsed (929 per-branch roles)] → We surface the open
+  count as "N openings"; the per-posting rows still exist and are reachable by slug.
+
+## Migration Plan
+
+New migration: `jobs.duplicate_of bigint NULL REFERENCES jobs(id)` + index. Manual prod
+apply before deploy (initdb gotcha). Regenerate `internal/db` via sqlc. Deploy is code-
+only after; the collapse takes effect once the recompute runs (reindex/cron). Rollback
+= revert the query filters; the column is inert if unused.
+
+## Open Questions
+
+- Whether to expose `openings_count` as a distinct wire field or reuse the reality
+  view's existing count (leaning reuse for MVP).
+- Backfill/recompute of the whole catalogue on first deploy vs. letting the reindex
+  pass populate it (leaning: run the recompute once on deploy alongside a reindex).

--- a/openspec/changes/ingest-content-dedup/proposal.md
+++ b/openspec/changes/ingest-content-dedup/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Sources repost the same role under many external ids: on prod, T-Bank alone has
+1998 open jobs but only ~619 distinct descriptions (e.g. "Представитель" is 929
+byte-identical rows). The repost-identity infrastructure already exists —
+`jobs.role_fingerprint` (`hash(company_slug|norm_title|norm_description)`, migration
+0003) is computed on every upsert and indexed, and the job-reality signal already
+counts each role cluster (`RoleClusterCount`: repost/mass-posting counts). But
+nothing **collapses** the cluster: all 929 reposts still appear as separate catalogue
+cards and search hits, and each one is enriched — burning LLM budget on duplicates.
+
+## What Changes
+
+- The catalogue shows **one canonical job per role cluster** (`company_slug` +
+  `role_fingerprint`); the other open reposts are hidden from the jobs list and
+  search. Rows are still stored (the reality signal keeps counting them) — the
+  collapse happens at **read/enrichment**, not by dropping inserts.
+- A canonical marker `jobs.duplicate_of` is computed per cluster (canon = the
+  deterministic `min(id)` among the cluster's open rows; the rest point to it),
+  reusing the existing fingerprint + cluster machinery.
+- The jobs list, the search index, and the enrichment enqueue all exclude
+  non-canonical reposts — so duplicates leave the catalogue, drop out of search, and
+  stop consuming enrichment budget.
+- The canonical job surfaces its cluster's open count (the existing `mass_count`) as
+  its number of openings, so "929 openings" is visible rather than 929 cards.
+
+Explicitly OUT of scope: reworded / cross-source near-duplicates (different
+fingerprint) — a separate Track-2 "possible duplicates" feature. Also out of scope:
+a one-off backfill of existing rows (a follow-up), and changing the reality signal's
+counting (rows are preserved precisely so it is untouched).
+
+## Capabilities
+
+### New Capabilities
+- `ingest-content-dedup`: canonical-per-role-cluster selection and the read/enrichment
+  collapse — the marker, its recompute, and the list/search/enrichment exclusions,
+  built on the existing `role_fingerprint` and role-cluster counts.
+
+### Modified Capabilities
+<!-- none: role_fingerprint/reality-signal behaviour is reused unchanged, not respecified -->
+
+## Impact
+
+- `migrations/` — `jobs.duplicate_of` (bigint NULL, indexed). Manual prod apply before
+  deploy (initdb migration gotcha). Regenerate `internal/db` via sqlc.
+- `internal/db/queries/jobs.sql` — a `RecomputeRoleDuplicates` pass (canon per open
+  cluster); the jobs-list and enrichment-enqueue queries gain `duplicate_of IS NULL`.
+- `internal/search` — reindex + incremental push skip non-canonical rows.
+- Recompute wired into the reindex path (and a cron sibling), mirroring the existing
+  role-cluster/reality recompute cadence.
+- `internal/jobview` — surface the canonical job's openings count (reusing the
+  reality `mass_count`); no other wire-shape change.

--- a/openspec/changes/ingest-content-dedup/specs/ingest-content-dedup/spec.md
+++ b/openspec/changes/ingest-content-dedup/specs/ingest-content-dedup/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: One canonical job per role cluster
+
+The system SHALL designate exactly one **canonical** open job per role cluster
+(`company_slug` + `role_fingerprint`), reusing the existing `role_fingerprint`. The
+canonical row is chosen deterministically — the `min(id)` among the cluster's open
+rows — so the choice is stable across recomputes. Non-canonical open rows in a cluster
+carry a `duplicate_of` reference to their canonical job; the canonical row and any
+row with an empty fingerprint carry no reference. Rows are never deleted or
+un-inserted, so the job-reality repost/mass-posting counts are unaffected.
+
+#### Scenario: A cluster resolves to one canonical row
+
+- **WHEN** a company has several open jobs sharing one `role_fingerprint`
+- **THEN** exactly one (the `min(id)`) is canonical and the rest reference it via
+  `duplicate_of`
+
+#### Scenario: Unfingerprinted and singleton rows stay canonical
+
+- **WHEN** an open job has an empty `role_fingerprint`, or is the only open row in its
+  cluster
+- **THEN** it is canonical (`duplicate_of` is null)
+
+#### Scenario: Canon fails over when the canonical closes
+
+- **WHEN** the canonical row of a cluster is closed and the recompute runs
+- **THEN** the new `min(id)` among the remaining open rows becomes canonical
+
+### Requirement: Non-canonical reposts are hidden from catalogue and search
+
+The jobs list and the search index SHALL exclude non-canonical reposts, so a role
+cluster appears once. A job addressed directly by its slug is still served (like a
+closed job) so existing links do not break.
+
+#### Scenario: List returns one row per cluster
+
+- **WHEN** the jobs list is queried and a cluster has a canonical row plus reposts
+- **THEN** only the canonical row is returned
+
+#### Scenario: Search omits reposts
+
+- **WHEN** the search index is built or incrementally pushed
+- **THEN** rows with a non-null `duplicate_of` are not indexed
+
+#### Scenario: A repost is still reachable by slug
+
+- **WHEN** a non-canonical repost is requested by its public slug
+- **THEN** the detail read still serves it
+
+### Requirement: Enrichment skips non-canonical reposts
+
+The enrichment enqueue SHALL exclude non-canonical reposts, so duplicate postings do
+not consume LLM budget; only the canonical row of a cluster is enriched.
+
+#### Scenario: Only the canonical row is enqueued
+
+- **WHEN** the enrichment enqueue runs over open jobs
+- **THEN** a job with a non-null `duplicate_of` is not enqueued
+
+### Requirement: The canonical job surfaces its openings count
+
+The canonical job SHALL surface how many open postings its cluster holds (the existing
+role-cluster open count), so a collapsed cluster communicates "N openings" rather than
+hiding that N postings exist.
+
+#### Scenario: Canon reports its cluster's open count
+
+- **WHEN** the canonical job of a cluster with N open postings is read
+- **THEN** its openings count is N

--- a/openspec/changes/ingest-content-dedup/tasks.md
+++ b/openspec/changes/ingest-content-dedup/tasks.md
@@ -1,0 +1,35 @@
+## 1. Schema
+
+- [x] 1.1 Migration: `jobs.duplicate_of bigint NULL REFERENCES jobs(id)` + index for
+  the list/enqueue filters. Comment "apply to prod manually before deploy".
+- [x] 1.2 Add `RecomputeRoleDuplicates` to `internal/db/queries/jobs.sql` (set
+  `duplicate_of` = the `min(id)` open canon for each open `(company_slug,
+  role_fingerprint)` cluster with >1 open rows; null out canon/singletons/empty-fp).
+  Regenerate `internal/db` via sqlc; `go build ./...` clean.
+
+## 2. Recompute correctness
+
+- [x] 2.1 RED→GREEN (integration, `-tags=integration ./internal/db/`): seed a cluster
+  of identical-fingerprint open jobs; run `RecomputeRoleDuplicates`; assert one canon
+  (`min(id)`, `duplicate_of` null) and the rest reference it. Assert an empty-fp row
+  and a singleton stay canonical, and that closing the canon promotes the next `min(id)`
+  on re-run (failover + stability).
+
+## 3. Hide reposts from list + enrichment
+
+- [x] 3.1 RED→GREEN: the jobs-list query and the enrichment-enqueue query exclude
+  `duplicate_of IS NOT NULL`. Tests: a repost is absent from the list; a repost is not
+  enqueued; the canonical row appears/enqueues normally.
+
+## 4. Hide reposts from search
+
+- [x] 4.1 RED→GREEN: the reindex and incremental-push paths skip rows with a non-null
+  `duplicate_of`. Tests: a repost is not indexed; the canonical row is.
+
+## 5. Openings count + wire-up
+
+- [x] 5.1 RED→GREEN: surface the canonical job's cluster open count as its openings
+  count in `internal/jobview` (reuse the reality `mass_count`). Test the projection.
+- [x] 5.2 Wire `RecomputeRoleDuplicates` into the reindex path (and expose it for a
+  cron recompute, mirroring the role-cluster recount). `go test ./...` and the
+  integration tests green.


### PR DESCRIPTION
## Summary
Sources repost the same role under many external_ids — prod T-Bank alone has 1998 open jobs but only ~619 distinct descriptions (a **929-row byte-identical "Представитель" cluster**). They flood the catalogue, search, and enrichment. This reuses the **existing** `role_fingerprint` + job-reality cluster counts to show **one canonical job per role cluster** (`company_slug` + `role_fingerprint`).

## Mechanism
- New `jobs.duplicate_of` (bigint NULL, self-FK). `RecomputeRoleDuplicates` marks one canonical open row per cluster — the deterministic `min(id)` — and points the rest at it. **Rows are never deleted** (the reality repost/mass counts still count them); collapse is at **read/enrichment**, not pre-insert.
- Non-canonical reposts are hidden from: `ListJobs`, `ListJobsByCompany`, the sitemap, the search index (reindex `splitJobs` + ingest incremental push), the semantic index (`cmd/embed` + `reindex --semantic`), enrichment enqueue/claim, and the company `job_count` facet.
- Recompute runs at the start of every reindex (best-effort); a closed canon fails over to the next `min(id)`.
- Openings are surfaced via the existing reality `mass_posting_count` (no new field).

## Out of scope
- Reworded / cross-source near-duplicates (different fingerprint) — a spike proved semantic/SimHash can't separate "same role reworded" from "different role"; that's a future Track-2 "possible duplicates" feature.
- One-off backfill of existing rows (follow-up; the recompute converges as reindex runs).

## Verification
- New integration tests (`internal/db/job_duplicate_of_*`, semantic): canon = min(id), singleton/unfingerprinted stay canonical, idempotent, **failover on canon close**, hidden from list/enqueue, semantic reposts excluded + removed if embedded. Unit test for `splitJobs`.
- Full `go test ./...` + `go test -tags=integration ./internal/db/ ./internal/embed/` green; `go vet`/`gofmt` clean.

## Deploy
⚠️ Migration `0012_job_duplicate_of.sql` must be applied to prod **manually before deploy** (initdb gotcha), followed by a `RecomputeRoleDuplicates` pass (runs automatically on the next reindex).

OpenSpec change: `ingest-content-dedup`.