### PR TITLE
feat(web): enrich company Organization + collection CollectionPage JSON-LD

### DIFF
--- a/openspec/changes/seo-structured-data-enrichment/.openspec.yaml
+++ b/openspec/changes/seo-structured-data-enrichment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/seo-structured-data-enrichment/design.md
+++ b/openspec/changes/seo-structured-data-enrichment/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`web/src/lib/seo.ts` is a pure helper module: each function takes public wire
+shapes (`Job`, `Company`, collection) and returns a plain JSON-LD object, which
+route `+page.svelte` files compose via `jsonLdScript([...])` inside
+`<svelte:head>`, emitted server-side. Two gaps: `organizationJsonLd` returns only
+`{ name, url }` despite rich `company_info`, and `/collections/:slug` emits only a
+`BreadcrumbList`. All changes stay inside this pure layer plus one route's head
+composition — the established pattern, no new infrastructure.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enrich company `Organization` JSON-LD from fields already on the `Company`
+  wire shape, each field strictly conditional.
+- Add `CollectionPage` + summary `ItemList` to collection landings from the
+  already-SSR-loaded first page of jobs.
+- Full unit coverage of both pure helpers via vitest.
+
+**Non-Goals:**
+- Per-collection FAQ, `ItemList` on company pages, meta-description rewrites,
+  Core Web Vitals — all explicitly deferred.
+- No backend / API / schema / dependency changes.
+
+## Decisions
+
+- **Conditional-field builder for Organization.** `organizationJsonLd` reads
+  `company.company_info` (logo, description, website, linkedin) and top-level
+  facts (`year_founded`, `employee_count`, `hq_country`). Each field is added
+  only when present and non-empty; `sameAs` is the filtered non-empty
+  `[website, linkedin]` array (omitted entirely if both absent); `foundingDate`
+  is `String(year_founded)`; `numberOfEmployees` is a `QuantitativeValue`;
+  `address` is a `PostalAddress` with `addressCountry` uppercased. This mirrors
+  the existing conditional style in `jobPostingJsonLd` (never emit a made-up or
+  empty value — a ranking liability).
+- **Summary ItemList, not nested JobPostings.** New `collectionPageJsonLd(title,
+  description, url, jobs, origin)` returns a `CollectionPage` whose `mainEntity`
+  is an `ItemList` of `ListItem`s (`position`, `name` = job title, `url` =
+  `${origin}/jobs/${public_slug}`). Google discourages many full `JobPosting`
+  nodes on a list page; the summary/url shape is the recommended carousel form
+  and keeps payload small.
+- **Reuse loaded data.** The collection route already loads `data.initial.jobs`
+  server-side; the helper consumes that array — no extra fetch. Composed into the
+  existing `jsonLdScript([breadcrumbJsonLd(...), collectionPageJsonLd(...)])`.
+- **TDD on the pure layer.** `seo.test.ts` (new) drives both helpers: enriched vs
+  empty `company_info`, `sameAs` filtering, empty job list → empty `ItemList`.
+  Route wiring is verified by `svelte-check` and a post-deploy live schema fetch.
+
+## Risks / Trade-offs
+
+- **`company_info` shape drift.** Fields are optional on the wire type; the
+  builder guards every access, so a missing field degrades to omission, never a
+  crash or empty node.
+- **List size.** The `ItemList` uses the first SSR page (~20–25 items); no
+  pagination of structured data — acceptable and within summary-page norms.
+- **Escaping.** Both helpers flow through the existing `jsonLdScript`, which
+  already escapes `<` — no new XSS surface.

--- a/openspec/changes/seo-structured-data-enrichment/proposal.md
+++ b/openspec/changes/seo-structured-data-enrichment/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The company-detail `Organization` JSON-LD is a bare `{ name, url }` stub even
+though the company row already carries rich `company_info` (logo, description,
+website, LinkedIn, industries, founding year, employee count, HQ country) — so
+search and AI engines cannot recognize the company as an entity (no logo in the
+knowledge panel, weak citation signal). Separately, the collection landing pages
+(`/collections/:slug` — our primary SEO landings like "React jobs") emit only a
+`BreadcrumbList` and no listing structured data, so engines do not see the page
+as a curated job collection.
+
+## What Changes
+
+- Enrich the company `Organization` JSON-LD with the fields already present on
+  the company: `logo`, `description`, `sameAs` (website + LinkedIn),
+  `foundingDate`, `numberOfEmployees`, and `address.addressCountry`. Every field
+  is conditional — emitted only when the source provides it.
+- Add `CollectionPage` JSON-LD wrapping an `ItemList` of the first page of jobs
+  to `/collections/:slug`. Each `ListItem` is a summary entry (`position`,
+  `name`, `url`) pointing at the job-detail page — not an embedded full
+  `JobPosting` (Google's recommended list-page shape).
+
+Out of scope (deliberately deferred): per-collection FAQ, `ItemList` on company
+pages, meta-description rewrites, and Core Web Vitals work.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `web-ssr-seo`: the "JobPosting structured data" requirement's `Organization`
+  clause is strengthened (company `Organization` carries its known company-info
+  facts), and a new requirement adds `CollectionPage` + `ItemList` structured
+  data to collection landing pages.
+
+## Impact
+
+- `web/src/lib/seo.ts` — `organizationJsonLd` gains conditional fields; a new
+  `collectionPageJsonLd` helper is added (pure functions).
+- `web/src/routes/collections/[slug]/+page.svelte` — composes the new helper
+  into its existing `jsonLdScript([...])` block using already-loaded SSR data.
+- `web/src/lib/seo.test.ts` — new vitest unit coverage for both helpers.
+- No backend, API, schema, or data changes. No new dependencies.

--- a/openspec/changes/seo-structured-data-enrichment/specs/web-ssr-seo/spec.md
+++ b/openspec/changes/seo-structured-data-enrichment/specs/web-ssr-seo/spec.md
@@ -1,0 +1,68 @@
+## MODIFIED Requirements
+
+### Requirement: JobPosting structured data
+
+The job-detail page SHALL include a `JobPosting` JSON-LD `<script type="application/ld+json">`
+block in its server-rendered HTML, populated from the job's public fields
+(title, description, hiring organization, location/remote, posting date, and the
+application URL), so the posting is eligible for Google Jobs. Company pages SHALL
+include `Organization` JSON-LD, and that `Organization` object SHALL carry every
+company-info fact the company row provides — its logo, description, homepage and
+LinkedIn links (as `sameAs`), founding year, employee count, and HQ country — so
+the company reads as a recognizable entity, while omitting any of those fields
+the company does not have.
+
+#### Scenario: Job page emits valid JobPosting JSON-LD
+
+- **WHEN** `GET /jobs/:slug` is requested for an existing job
+- **THEN** the HTML contains one `application/ld+json` script with `@type`
+  `JobPosting` whose `title`, `description`, `hiringOrganization`, and
+  `datePosted` reflect the job
+
+#### Scenario: A closed job reflects its status in structured data
+
+- **WHEN** the job carries a `closed_at`
+- **THEN** the `JobPosting` data conveys that the posting is no longer accepting
+  applications rather than presenting it as open
+
+#### Scenario: Company Organization carries its known company-info facts
+
+- **WHEN** `GET /companies/:slug` is requested for a company whose `company_info`
+  provides a logo, description, homepage/LinkedIn links, founding year, employee
+  count, and HQ country
+- **THEN** the emitted `Organization` JSON-LD includes `logo`, `description`, a
+  `sameAs` array holding those links, `foundingDate`, `numberOfEmployees`, and an
+  `address` with the country code
+
+#### Scenario: Missing company-info facts are omitted, not emitted empty
+
+- **WHEN** the company has no `company_info` (or only some of its fields)
+- **THEN** the `Organization` JSON-LD still emits `name` and `url` and simply
+  omits every fact the company lacks (no empty strings, null values, or empty
+  arrays)
+
+## ADDED Requirements
+
+### Requirement: Collection landing structured data
+
+The collection landing page (`GET /collections/:slug`) SHALL emit a
+`CollectionPage` JSON-LD block whose `mainEntity` is an `ItemList` of the
+first page of jobs already rendered on the page. Each `ItemList` entry SHALL be a
+summary `ListItem` carrying its 1-based `position`, the job `name`, and the
+absolute `url` of the job-detail page — never an embedded full `JobPosting`, so
+the list page presents the recommended summary shape rather than many nested
+postings.
+
+#### Scenario: Collection page emits CollectionPage with a job ItemList
+
+- **WHEN** `GET /collections/:slug` is requested for a collection that has jobs
+- **THEN** the HTML contains an `application/ld+json` script with `@type`
+  `CollectionPage` whose `mainEntity` is an `ItemList` whose `itemListElement`
+  entries each carry `position`, `name`, and a `url` pointing at `/jobs/:slug`
+
+#### Scenario: An empty collection emits an empty ItemList, not broken JSON-LD
+
+- **WHEN** `GET /collections/:slug` is requested for a collection with no jobs on
+  the first page
+- **THEN** the `CollectionPage` is still valid JSON-LD with an `ItemList` whose
+  `itemListElement` is an empty array

--- a/openspec/changes/seo-structured-data-enrichment/tasks.md
+++ b/openspec/changes/seo-structured-data-enrichment/tasks.md
@@ -1,0 +1,26 @@
+## 1. Enrich company Organization JSON-LD
+
+- [x] 1.1 RED: add `seo.test.ts` cases for `organizationJsonLd` — an enriched
+  company (logo, description, website+linkedin, year_founded, employee_count,
+  hq_country) emits `logo`/`description`/`sameAs`/`foundingDate`/
+  `numberOfEmployees`/`address.addressCountry`; a bare company emits only
+  `name`+`url` with no empty fields. Watch them fail.
+- [x] 1.2 GREEN: extend `organizationJsonLd` in `web/src/lib/seo.ts` with the
+  conditional fields until tests pass.
+
+## 2. Collection landing CollectionPage + ItemList
+
+- [x] 2.1 RED: add `seo.test.ts` cases for a new `collectionPageJsonLd` — a
+  populated job list yields `CollectionPage.mainEntity` = `ItemList` with
+  correct `position`/`name`/`url` per item; an empty list yields an empty
+  `itemListElement`. Watch them fail.
+- [x] 2.2 GREEN: implement `collectionPageJsonLd(title, description, url, jobs,
+  origin)` in `seo.ts` until tests pass.
+- [x] 2.3 Wire it into `web/src/routes/collections/[slug]/+page.svelte`'s
+  existing `jsonLdScript([...])` block using `data.initial.jobs`; confirm with
+  `svelte-check`.
+
+## 3. Verify
+
+- [x] 3.1 Run `vitest run`, `svelte-check`, and lint locally; all green.
+- [x] 3.2 `simplify` pass over the diff; re-run tests green.

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { collectionPageJsonLd, organizationJsonLd } from './seo';
+import type { Company, Job } from './types';
+
+// collectionPageJsonLd reads only title + public_slug off each job.
+function job(title: string, slug: string): Job {
+  return { title, public_slug: slug } as Job;
+}
+
+// Minimal valid Company; individual tests spread in the facts under test.
+function company(overrides: Partial<Company> = {}): Company {
+  return {
+    slug: 'acme',
+    name: 'Acme',
+    collections: [],
+    created_at: null,
+    updated_at: null,
+    ...overrides,
+  };
+}
+
+const ORIGIN = 'https://freehire.dev';
+
+describe('organizationJsonLd', () => {
+  it('emits every company-info fact the company provides', () => {
+    const ld = organizationJsonLd(
+      company({
+        year_founded: 2015,
+        employee_count: 250,
+        hq_country: 'us',
+        company_info: {
+          logo: 'https://logo.dev/acme.png',
+          description: 'Acme builds rockets.',
+          website: 'https://acme.example',
+          linkedin: 'https://linkedin.com/company/acme',
+        },
+      }),
+      ORIGIN
+    );
+
+    expect(ld['@type']).toBe('Organization');
+    expect(ld.name).toBe('Acme');
+    expect(ld.url).toBe('https://freehire.dev/companies/acme');
+    expect(ld.logo).toBe('https://logo.dev/acme.png');
+    expect(ld.description).toBe('Acme builds rockets.');
+    expect(ld.sameAs).toEqual([
+      'https://acme.example',
+      'https://linkedin.com/company/acme',
+    ]);
+    expect(ld.foundingDate).toBe('2015');
+    expect(ld.numberOfEmployees).toEqual({
+      '@type': 'QuantitativeValue',
+      value: 250,
+    });
+    expect(ld.address).toEqual({
+      '@type': 'PostalAddress',
+      addressCountry: 'US',
+    });
+  });
+
+  it('omits every fact a bare company lacks', () => {
+    const ld = organizationJsonLd(company(), ORIGIN);
+
+    expect(ld).toEqual({
+      '@context': 'https://schema.org',
+      '@type': 'Organization',
+      name: 'Acme',
+      url: 'https://freehire.dev/companies/acme',
+    });
+  });
+
+  it('includes only the links that are present in sameAs', () => {
+    const ld = organizationJsonLd(
+      company({ company_info: { website: 'https://acme.example' } }),
+      ORIGIN
+    );
+
+    expect(ld.sameAs).toEqual(['https://acme.example']);
+  });
+
+  it('falls back to the homepage field and normalizes a bare domain to https', () => {
+    // The bulk company-info backfill stores the homepage under `homepage` (often a
+    // bare domain), not `website` — sameAs must still emit a valid absolute URL.
+    const ld = organizationJsonLd(
+      company({ company_info: { homepage: 'acme.com' } }),
+      ORIGIN
+    );
+
+    expect(ld.sameAs).toEqual(['https://acme.com']);
+  });
+
+  it('prefers website over homepage and leaves an already-absolute homepage as-is', () => {
+    const ld = organizationJsonLd(
+      company({
+        company_info: { website: 'https://acme.io', homepage: 'https://old.acme.com' },
+      }),
+      ORIGIN
+    );
+
+    expect(ld.sameAs).toEqual(['https://acme.io']);
+  });
+
+  it('omits sameAs entirely when no links are present', () => {
+    const ld = organizationJsonLd(
+      company({ company_info: { description: 'no links here' } }),
+      ORIGIN
+    );
+
+    expect(ld).not.toHaveProperty('sameAs');
+  });
+});
+
+describe('collectionPageJsonLd', () => {
+  const URL = 'https://freehire.dev/collections/react';
+
+  it('wraps the jobs in a CollectionPage → ItemList of summary ListItems', () => {
+    const ld = collectionPageJsonLd(
+      'React jobs',
+      'Every open React role.',
+      URL,
+      [job('Senior React Engineer', 'senior-react-engineer-abc'), job('React Native Dev', 'react-native-dev-xyz')],
+      ORIGIN
+    );
+
+    expect(ld['@type']).toBe('CollectionPage');
+    expect(ld.name).toBe('React jobs');
+    expect(ld.description).toBe('Every open React role.');
+    expect(ld.url).toBe(URL);
+    expect(ld.mainEntity).toEqual({
+      '@type': 'ItemList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Senior React Engineer',
+          url: 'https://freehire.dev/jobs/senior-react-engineer-abc',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'React Native Dev',
+          url: 'https://freehire.dev/jobs/react-native-dev-xyz',
+        },
+      ],
+    });
+  });
+
+  it('emits an empty ItemList for a collection with no jobs', () => {
+    const ld = collectionPageJsonLd('Empty', 'Nothing yet.', URL, [], ORIGIN);
+
+    expect(ld.mainEntity).toEqual({ '@type': 'ItemList', itemListElement: [] });
+  });
+});

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -138,14 +138,42 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
   return ld;
 }
 
-/** schema.org Organization for a company page. */
+/** schema.org Organization for a company page. Every company-info fact is added
+ *  only when present and non-empty — an omitted field is never emitted as an empty
+ *  string, null, or empty array (mismatched/empty structured data is a ranking
+ *  liability, mirroring `jobPostingJsonLd`). */
 export function organizationJsonLd(company: Company, origin: string): Record<string, unknown> {
-  return {
+  const info = company.company_info ?? {};
+  const ld: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'Organization',
     name: company.name,
     url: `${origin}/companies/${company.slug}`,
   };
+
+  if (info.logo) ld.logo = info.logo;
+  if (info.description) ld.description = info.description;
+
+  // sameAs advertises the company's canonical outbound links (homepage, LinkedIn);
+  // emit only the ones we have, and drop the field entirely when we have none. The
+  // homepage lives under `website` (hirebase/YC) or `homepage` (the bulk backfill,
+  // often a bare domain) — read whichever is present and normalize to an absolute
+  // URL, mirroring CompanyHeader.svelte, so sameAs never holds a relative string.
+  const homepage = info.website ?? info.homepage;
+  const sameAs: string[] = [];
+  if (homepage) sameAs.push(homepage.startsWith('http') ? homepage : `https://${homepage}`);
+  if (info.linkedin) sameAs.push(info.linkedin);
+  if (sameAs.length > 0) ld.sameAs = sameAs;
+
+  if (company.year_founded != null) ld.foundingDate = String(company.year_founded);
+  if (company.employee_count != null) {
+    ld.numberOfEmployees = { '@type': 'QuantitativeValue', value: company.employee_count };
+  }
+  if (company.hq_country) {
+    ld.address = { '@type': 'PostalAddress', addressCountry: company.hq_country.toUpperCase() };
+  }
+
+  return ld;
 }
 
 /** schema.org WebSite for the homepage. The SearchAction advertises the job
@@ -195,6 +223,36 @@ export function breadcrumbJsonLd(items: { name: string; url: string }[]): Record
       name: item.name,
       item: item.url,
     })),
+  };
+}
+
+/** schema.org CollectionPage wrapping an `ItemList` of the jobs rendered on a
+ *  collection landing page. Each item is a summary `ListItem` (position + name +
+ *  detail URL), not an embedded `JobPosting` — Google's recommended shape for a
+ *  list page, and it keeps the payload small. An empty `jobs` yields an empty
+ *  `itemListElement`, still valid JSON-LD. */
+export function collectionPageJsonLd(
+  title: string,
+  description: string,
+  url: string,
+  jobs: Job[],
+  origin: string
+): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: title,
+    description,
+    url,
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: jobs.map((job, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: job.title,
+        url: `${origin}/jobs/${job.public_slug}`,
+      })),
+    },
   };
 }
 

--- a/web/src/routes/collections/[slug]/+page.svelte
+++ b/web/src/routes/collections/[slug]/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/state';
   import JobsView from '$lib/components/JobsView.svelte';
   import Seo from '$lib/components/Seo.svelte';
-  import { breadcrumbJsonLd, jsonLdScript } from '$lib/seo';
+  import { breadcrumbJsonLd, collectionPageJsonLd, jsonLdScript } from '$lib/seo';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
@@ -20,16 +20,25 @@
   // collection's constraint (JobsView.scopedParams) — hiding those controls is a
   // deferred UI polish, not a correctness gap.
   const excludeFacets = $derived(Object.keys(data.collection.params));
-  // Breadcrumb structured data (freehire → Collections → this collection), mirroring
-  // the company landing — this is an SEO landing page, so the trail helps engines.
+  // Structured data for this SEO landing page: a CollectionPage wrapping the
+  // first page of jobs as an ItemList (so engines read the page as a curated
+  // collection), plus a breadcrumb trail (freehire → Collections → this one),
+  // mirroring the company landing.
   const jsonLd = $derived(
-    jsonLdScript(
+    jsonLdScript([
+      collectionPageJsonLd(
+        heading,
+        data.collection.description,
+        canonical,
+        data.initial.items,
+        origin
+      ),
       breadcrumbJsonLd([
         { name: 'freehire', url: `${origin}/` },
         { name: 'Collections', url: `${origin}/collections` },
         { name: heading, url: canonical },
-      ])
-    )
+      ]),
+    ])
   );
 </script>
 


### PR DESCRIPTION
## Summary

SEO/GEO structured-data enrichment for two page types, all inside the pure
`web/src/lib/seo.ts` helper layer (OpenSpec change `seo-structured-data-enrichment`).

- **Company `Organization` JSON-LD** now carries every company-info fact the row
  provides — `logo`, `description`, `sameAs` (homepage/website + LinkedIn,
  normalized to absolute URLs), `foundingDate`, `numberOfEmployees`,
  `address.addressCountry` — each emitted only when present (never empty/null).
  Previously a bare `{ name, url }` stub despite rich `company_info`.
- **Collection landing pages** (`/collections/:slug`) emit a `CollectionPage`
  wrapping a summary `ItemList` of the first page of jobs (`position`/`name`/`url`
  → `/jobs/:slug`), so engines read the page as a curated collection rather than
  only a breadcrumb.

`sameAs` reads `company_info.website ?? homepage` and prefixes bare domains with
`https://`, mirroring `CompanyHeader.svelte` so the structured-data link matches
the visible one (caught in code review).

## Test Plan

- [x] `vitest run` — 163 pass (6 new `seo.test.ts` cases: enriched/bare
  Organization, homepage fallback + normalization, website precedence,
  CollectionPage ItemList, empty-collection ItemList)
- [x] `svelte-check` — 0 errors / 0 warnings (collection route wiring type-checks)
- [x] `eslint` on changed files — clean
- [ ] Post-deploy: fetch a live `/companies/:slug` and `/collections/:slug`,
  validate the JSON-LD in Google Rich Results / schema.org validator