### PR TITLE
fix(skilltag): corroboration gate for ambiguous tech words

### DIFF
--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -586,6 +586,64 @@ var wordAliases = map[string]string{
 	"elt":              "elt",
 	"maven":            "maven",
 	"genai":            "generative-ai",
+	"expressjs":        "express",
+}
+
+// ambiguousWords marks the wordAliases keys whose word-pass match is "weak": Parse
+// tags it ONLY when the same text carries at least one strong tech token
+// (corroboration). Two groups qualify:
+//
+//   - English-word collisions — a common word that doubles as a tech name
+//     (react/swift/spring/rust/ruby/…). Alone it is noise: a cook's "must react to
+//     changes", a maintenance post's "inspect for rust".
+//   - Broad concepts — the batch-3 generic tags (ai/automation/cloud/api/crm/erp/
+//     saas/analytics/seo/networking/…). They appear on non-tech posts too ("AI-powered
+//     marketing", a salesperson's "CRM experience", "strong networking skills"), so
+//     they are too low-precision to stand alone AND too low-precision to corroborate
+//     one another — only a concrete named technology (python, kubernetes, typescript,
+//     a phrase, an acronym) is a trustworthy corroborator.
+//
+// The unambiguous alias forms of the collision canonicals stay strong (reactjs,
+// "react native", "spring boot", expressjs, "ruby on rails"), so a genuinely-named
+// stack is never gated. Membership is per-alias, not per-canonical; value is unused.
+var ambiguousWords = map[string]bool{
+	// English-word collisions
+	"react":   true,
+	"swift":   true,
+	"rust":    true,
+	"spring":  true,
+	"express": true,
+	"ruby":    true,
+	"dart":    true,
+	"gin":     true,
+	"fiber":   true,
+	"ember":   true,
+	"elixir":  true,
+	"rails":   true,
+	"groovy":  true,
+	"gorilla": true,
+	"koa":     true,
+	"remix":   true,
+	"astro":   true,
+	"shell":   true,
+	"apex":    true,
+	"julia":   true,
+	"maven":   true,
+	// broad concepts (batch 3) — tag only in a concrete tech context
+	"ai":         true,
+	"automation": true,
+	"crm":        true,
+	"erp":        true,
+	"saas":       true,
+	"analytics":  true,
+	"api":        true,
+	"apis":       true,
+	"cloud":      true,
+	"networking": true,
+	"statistics": true,
+	"seo":        true,
+	"ecommerce":  true,
+	"fintech":    true,
 }
 
 // phraseAlias is a punctuated or multi-word term matched against the normalized
@@ -640,7 +698,11 @@ var phraseAliases = []phraseAlias{
 	{"retrieval augmented generation", "rag"},
 	// LLM-mined multi-word gaps (jobs.enrichment->skills). Multi-word or ambiguous
 	// terms routed as phrases so the bare token can't misfire on non-tech jobs.
-	// ("spring boot" needs no entry — the "spring" word alias already tags it.)
+	// Unambiguous names for the frameworks whose bare word is now corroboration-gated
+	// (see ambiguousWords) — these strong forms tag without needing a co-token.
+	{"spring boot", "spring"}, {"spring framework", "spring"}, {"spring mvc", "spring"},
+	{"ruby on rails", "ruby"}, {"ruby on rails", "rails"},
+	{"express.js", "express"},
 	{"azure devops", "azure-devops"},
 	{"power apps", "powerapps"}, {"powerapps", "powerapps"},
 	{"power automate", "power-automate"},

--- a/internal/skilltag/skilltag.go
+++ b/internal/skilltag/skilltag.go
@@ -134,35 +134,55 @@ func WithResumeAcronyms() Option {
 // that union into a set: a case-preserving acronym pass over the HTML-stripped
 // original-case text (shared tier always, résumé tier when opted in), then a phrase
 // pass (separator-insensitive) and a word pass over the lowercased, normalized text.
+//
+// Matches split into two tiers. A "strong" match is any acronym, any phrase, or an
+// unambiguous word alias; it always tags. A "weak" match is a word alias listed in
+// ambiguousWords (react/swift/spring/networking/…) — an English word that doubles
+// as a tech name — and it tags ONLY when the text also carries at least one strong
+// match (corroboration). So "must react to changes" on a non-tech post drops react,
+// while "React and TypeScript" keeps it. Unambiguous forms (reactjs, "react native",
+// "spring boot") stay strong, so a genuinely-named stack never needs corroboration.
 func Parse(text string, opts ...Option) []string {
 	var o options
 	for _, fn := range opts {
 		fn(&o)
 	}
-	set := map[string]struct{}{}
+	strong := map[string]struct{}{}
+	weak := map[string]struct{}{}
 
 	// Acronym pass: case-sensitive whole-word match over case-preserved text, so an
 	// UPPERCASE acronym resolves while its ambiguous lowercase form does not. Uses a
 	// Unicode word boundary because the text is not lowercased here (ASCIIBoundary's
 	// word test is lowercase-only and would misjudge uppercase neighbours).
 	cased := htmlTagRE.ReplaceAllString(text, " ")
-	matchAcronyms(cased, sharedAcronyms, set)
+	matchAcronyms(cased, sharedAcronyms, strong)
 	if o.resumeAcronyms {
-		matchAcronyms(cased, resumeAcronyms, set)
+		matchAcronyms(cased, resumeAcronyms, strong)
 	}
 
 	norm := normalize(text)
 	for _, m := range phraseMatchers {
 		if m.matches(norm) {
-			set[m.canonical] = struct{}{}
+			strong[m.canonical] = struct{}{}
 		}
 	}
 	for _, tok := range wordTokens(norm) {
 		if c, ok := wordAliases[tok]; ok {
-			set[c] = struct{}{}
+			if ambiguousWords[tok] {
+				weak[c] = struct{}{}
+			} else {
+				strong[c] = struct{}{}
+			}
 		}
 	}
-	return stringset.Sorted(set)
+	// A weak (ambiguous-word) match survives only when corroborated by a strong tech
+	// token in the same text; alone it is English-word noise and is dropped.
+	if len(strong) > 0 {
+		for c := range weak {
+			strong[c] = struct{}{}
+		}
+	}
+	return stringset.Sorted(strong)
 }
 
 // matchAcronyms adds the canonical of each acronym whose exact surface form occurs

--- a/internal/skilltag/skilltag_test.go
+++ b/internal/skilltag/skilltag_test.go
@@ -473,3 +473,76 @@ func TestParse_ExpansionBatch3(t *testing.T) {
 		})
 	}
 }
+
+// Ambiguous English words that double as tech names (react/swift/rust/spring/…)
+// must only tag when the same text carries an unambiguous tech token
+// (corroboration). This kills the dominant false-positive class — a non-tech post
+// that merely says "must react to changes" or "strong networking skills" — while a
+// real posting that also names its stack keeps the tag. Unambiguous alias forms
+// (reactjs, "react native", "spring boot") always tag, no corroboration needed.
+func TestParse_AmbiguousCorroboration(t *testing.T) {
+	contains := func(hay []string, needle string) bool {
+		for _, h := range hay {
+			if h == needle {
+				return true
+			}
+		}
+		return false
+	}
+	cases := []struct {
+		name   string
+		in     string
+		want   []string
+		absent []string
+	}{
+		// bare ambiguous word, NO unambiguous tech token → dropped
+		{"react verb (cook)", "Must be able to react to changes in schedules.", nil, []string{"react"}},
+		{"networking soft skill", "Strong networking and negotiation skills.", nil, []string{"networking"}},
+		{"spring season", "Spring and summer seasonal cleaning crew.", nil, []string{"spring"}},
+		{"rust corrosion", "Inspect the railings for rust and repaint.", nil, []string{"rust"}},
+		{"swift adjective", "We need a swift and friendly barista.", nil, []string{"swift"}},
+		{"ruby name", "Report directly to Ruby, the floor manager.", nil, []string{"ruby"}},
+		{"cloud weather", "Outdoor role, rain or cloud, year round.", nil, []string{"cloud"}},
+		// broad concepts alone (non-tech context) → dropped
+		{"ai marketing", "AI-powered marketing automation for our sales team.", nil, []string{"ai", "automation"}},
+		{"crm sales role", "Manage our CRM as an account executive.", nil, []string{"crm"}},
+		{"broad concepts don't self-corroborate", "AI, automation and analytics for retail.", nil, []string{"ai", "automation", "analytics"}},
+		// broad concept + concrete tech → kept
+		{"ai + pytorch", "AI models with PyTorch and Python.", []string{"ai", "pytorch", "python"}, nil},
+		// corroborated by an unambiguous tech token → kept
+		{"react + typescript", "React and TypeScript for our UI.", []string{"react", "typescript"}, nil},
+		{"networking + linux", "Networking with Linux, BGP and firewalls.", []string{"networking", "linux", "bgp"}, nil},
+		{"swift + ios", "Swift developer building for iOS.", []string{"swift", "ios"}, nil},
+		{"cloud + aws", "Cloud infrastructure on AWS and Kubernetes.", []string{"cloud", "aws", "kubernetes"}, nil},
+		// unambiguous alias forms tag WITHOUT corroboration
+		{"reactjs standalone", "We build with reactjs.", []string{"react"}, nil},
+		{"react native phrase", "React Native mobile apps.", []string{"react-native", "react"}, nil},
+		{"spring boot phrase", "Spring Boot services.", []string{"spring"}, nil},
+		{"ruby on rails phrase", "A Ruby on Rails shop.", []string{"ruby", "rails"}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Parse(c.in)
+			for _, w := range c.want {
+				if !contains(got, w) {
+					t.Errorf("Parse(%q) = %v, missing %q", c.in, got, w)
+				}
+			}
+			for _, a := range c.absent {
+				if contains(got, a) {
+					t.Errorf("Parse(%q) = %v, must NOT contain %q", c.in, got, a)
+				}
+			}
+		})
+	}
+}
+
+// Every ambiguousWords key must be a real wordAliases entry — an ambiguous marker
+// on a token the word pass never emits would be dead config.
+func TestAmbiguousWordsSubsetOfAliases(t *testing.T) {
+	for w := range ambiguousWords {
+		if _, ok := wordAliases[w]; !ok {
+			t.Errorf("ambiguousWords[%q] has no wordAliases entry", w)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A **cook** job was tagged with skill `react` — the word pass matched the verb in *"must be able to react to changes in schedules"*. On prod ~**10.8K** jobs had `react` as their only skill (overwhelmingly this false positive), plus the same collision class for `swift`/`rust`/`spring`/`ruby`/`networking`/…

## Fix — corroboration gate

`skilltag.Parse` now splits matches into two tiers:

- **strong** — acronyms, phrases, and concrete named-technology word aliases (python, kubernetes, typescript, …). Always tags.
- **weak** — `ambiguousWords`: English-word collisions (react, swift, spring, rust, ruby, maven, …) **and** the batch-3 broad concepts (ai, automation, crm, erp, saas, analytics, api, cloud, networking, seo, ecommerce, fintech). Tags **only when the text also carries a strong token** — a concrete tech anchor. Broad concepts are weak too, so they can't corroborate one another (an "AI-powered marketing automation" post tags nothing).

Unambiguous alias forms stay strong (`reactjs`, `react native`, `spring boot`, `ruby on rails`, `expressjs`), so a genuinely-named stack is never gated.

## Validation (real prod data)

Ran the new parser over 400 `react`-only prod descriptions: **99.0% drop `react`** (the false positives); the ~1% retained also name a concrete stack (e-commerce / data-analytics React apps) — i.e. genuinely React jobs the old dict under-tagged.

## Not in scope (your call: defer)

The LLM **also** enriches non-tech: ~**538K** open empty-category jobs (cooks/nurses/trades) have `enriched_at` set — the `NonTechCategories` blacklist is too narrow. Tracked as a separate follow-up (non-tech title dictionary → gate enrich), not blocking this dictionary fix.

## Verification

- `go build ./...`, `go vet`, `go test ./...` — green (new `TestParse_AmbiguousCorroboration` + `TestAmbiguousWordsSubsetOfAliases`)

## Deploy

Like every dictionary change: reaches existing jobs after `cmd/backfill-derive` → `reindex` on prod (run together with the batch-3 backfill).