### PR TITLE
fix(dedup): batch role-duplicate recompute per company (prod incident fix)

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -382,12 +382,21 @@ func recomputeRoleDuplicates(ctx context.Context, q *db.Queries) (int64, error) 
 		return 0, err
 	}
 	var total int64
+	var failures int
+	var lastErr error
 	for _, c := range companies {
+		// Companies are independent, so one failure (e.g. a statement timeout on an
+		// unusually large cluster) must not starve the rest — log-and-continue.
 		n, err := q.RecomputeRoleDuplicatesForCompany(ctx, c)
 		if err != nil {
-			return total, fmt.Errorf("company %q: %w", c, err)
+			failures++
+			lastErr = fmt.Errorf("company %q: %w", c, err)
+			continue
 		}
 		total += n
+	}
+	if failures > 0 {
+		return total, fmt.Errorf("%d/%d companies failed; last: %w", failures, len(companies), lastErr)
 	}
 	return total, nil
 }

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -113,11 +113,11 @@ func run() int {
 	}
 
 	// Refresh the role-cluster canonical markers before reading jobs, so the collapse
-	// (splitJobs drops non-canonical reposts) reflects the current catalogue and a
-	// closed canon has failed over. Whole-table but IS DISTINCT FROM-guarded, so steady
-	// state only re-marks changed rows. Best-effort: a hiccup here must not block the
-	// reindex (which also owns settings/compaction), so it degrades to the prior markers.
-	if n, err := q.RecomputeRoleDuplicates(ctx); err != nil {
+	// (splitJobs drops non-canonical reposts) reflects the current catalogue and a closed
+	// canon has failed over. Done per company in short transactions (never a table-wide
+	// lock that would stall ingest). Best-effort: a hiccup here must not block the reindex
+	// (which also owns settings/compaction), so it degrades to the prior markers.
+	if n, err := recomputeRoleDuplicates(ctx, q); err != nil {
 		log.Printf("reindex: recompute role duplicates (continuing with prior markers): %v", err)
 	} else if n > 0 {
 		log.Printf("reindex: recomputed role duplicates (%d rows re-marked)", n)
@@ -370,6 +370,27 @@ func reindexFull(ctx context.Context, reader worker.PageReader, b rebuilder, loo
 // yields (1, 1) — a unique, non-reposted role. A nil lookup means the counts default
 // to (1, 1) everywhere (used by tests that do not exercise clustering).
 type realityLookup func(companySlug, fingerprint string) (repost, mass int)
+
+// recomputeRoleDuplicates refreshes jobs.duplicate_of one company at a time, returning
+// the total rows re-marked. Scoping each UPDATE to a single company keeps its lock
+// window to that company's rows for a moment, so the pass never holds the table-wide
+// lock that would stall concurrent ingest crawls. A per-company failure aborts (the
+// caller treats the whole pass as best-effort and continues with the prior markers).
+func recomputeRoleDuplicates(ctx context.Context, q *db.Queries) (int64, error) {
+	companies, err := q.CompaniesWithRoleClusters(ctx)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, c := range companies {
+		n, err := q.RecomputeRoleDuplicatesForCompany(ctx, c)
+		if err != nil {
+			return total, fmt.Errorf("company %q: %w", c, err)
+		}
+		total += n
+	}
+	return total, nil
+}
 
 // buildRealityLookup precomputes the whole-catalogue role-cluster counts once, so the
 // per-job classification during the rebuild is a map read, not N queries.

--- a/internal/db/job_duplicate_of_integration_test.go
+++ b/internal/db/job_duplicate_of_integration_test.go
@@ -1,10 +1,11 @@
 //go:build integration
 
-// Integration tests for RecomputeRoleDuplicates: it collapses each role cluster
-// (company_slug + role_fingerprint) to one canonical open job (min(id)), pointing the
-// other open reposts at it via duplicate_of, while leaving singletons and
-// unfingerprinted rows canonical. Canon failover on close and the min(id) tie-break are
-// SQL behaviors verifiable only against a real Postgres.
+// Integration tests for the role-duplicate recompute: driven per company
+// (CompaniesWithRoleClusters + RecomputeRoleDuplicatesForCompany, as the reindex does),
+// it collapses each role cluster (company_slug + role_fingerprint) to one canonical open
+// job (min(id)), pointing the other open reposts at it via duplicate_of, while leaving
+// singletons and unfingerprinted rows canonical. Canon failover on close and the min(id)
+// tie-break are SQL behaviors verifiable only against a real Postgres.
 // Run with: go test -tags=integration ./internal/db/
 package db
 
@@ -14,6 +15,21 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// recomputeDuplicates runs the batched recompute exactly as the reindex does: fetch the
+// companies needing work, then recompute each in its own short transaction.
+func recomputeDuplicates(t *testing.T, q *Queries) {
+	t.Helper()
+	companies, err := q.CompaniesWithRoleClusters(context.Background())
+	if err != nil {
+		t.Fatalf("companies with clusters: %v", err)
+	}
+	for _, c := range companies {
+		if _, err := q.RecomputeRoleDuplicatesForCompany(context.Background(), c); err != nil {
+			t.Fatalf("recompute company %q: %v", c, err)
+		}
+	}
+}
 
 // dupOf reads a job's id and duplicate_of by external_id. dup is -1 when NULL (canon).
 func dupOf(t *testing.T, pool *pgxpool.Pool, ext string) (id int64, dup int64) {
@@ -50,9 +66,7 @@ func TestRecomputeRoleDuplicates_CollapsesClusterToMinIDCanon(t *testing.T) {
 		t.Fatalf("upsert nofp: %v", err)
 	}
 
-	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
-		t.Fatalf("recompute: %v", err)
-	}
+	recomputeDuplicates(t, q)
 
 	canonID, canonDup := dupOf(t, pool, "acme:1")
 	if canonDup != -1 {
@@ -71,9 +85,7 @@ func TestRecomputeRoleDuplicates_CollapsesClusterToMinIDCanon(t *testing.T) {
 	}
 
 	// Idempotent: a second run does not flip the canon.
-	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
-		t.Fatalf("recompute again: %v", err)
-	}
+	recomputeDuplicates(t, q)
 	if _, dup := dupOf(t, pool, "acme:1"); dup != -1 {
 		t.Errorf("canon changed on re-run: acme:1 duplicate_of = %d, want NULL", dup)
 	}
@@ -82,15 +94,44 @@ func TestRecomputeRoleDuplicates_CollapsesClusterToMinIDCanon(t *testing.T) {
 	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = now() WHERE external_id = $1", "acme:1"); err != nil {
 		t.Fatalf("close canon: %v", err)
 	}
-	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
-		t.Fatalf("recompute after close: %v", err)
-	}
+	recomputeDuplicates(t, q)
 	newCanonID, newCanonDup := dupOf(t, pool, "acme:2")
 	if newCanonDup != -1 {
 		t.Errorf("failover: acme:2 duplicate_of = %d, want NULL (new canon)", newCanonDup)
 	}
 	if _, dup := dupOf(t, pool, "acme:3"); dup != newCanonID {
 		t.Errorf("failover: acme:3 duplicate_of = %d, want new canon %d", dup, newCanonID)
+	}
+}
+
+// When a cluster shrinks to a single open row, the survivor's stale duplicate_of must be
+// cleared — otherwise the last remaining posting stays hidden forever. CompaniesWithRoleClusters
+// surfaces the company via its lingering marker even though it no longer has a cluster > 1.
+func TestRecomputeRoleDuplicates_ClearsMarkerWhenClusterShrinksToOne(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	const fp = "role-dup"
+	for _, ext := range []string{"acme:1", "acme:2"} {
+		if _, err := q.UpsertJob(ctx, withFingerprint(ext, "Staff Engineer", fp)); err != nil {
+			t.Fatalf("upsert %s: %v", ext, err)
+		}
+	}
+	recomputeDuplicates(t, q)
+	if _, dup := dupOf(t, pool, "acme:2"); dup == -1 {
+		t.Fatal("precondition: acme:2 should be a repost after first recompute")
+	}
+
+	// Close the canon, leaving acme:2 as the only open row in its cluster.
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = now() WHERE external_id = $1", "acme:1"); err != nil {
+		t.Fatalf("close canon: %v", err)
+	}
+	recomputeDuplicates(t, q)
+
+	if _, dup := dupOf(t, pool, "acme:2"); dup != -1 {
+		t.Errorf("acme:2 duplicate_of = %d, want NULL (sole survivor must be canonical)", dup)
 	}
 }
 
@@ -106,9 +147,7 @@ func TestDuplicateReposts_HiddenFromListAndEnrichment(t *testing.T) {
 			t.Fatalf("upsert %s: %v", ext, err)
 		}
 	}
-	if _, err := q.RecomputeRoleDuplicates(ctx); err != nil {
-		t.Fatalf("recompute: %v", err)
-	}
+	recomputeDuplicates(t, q)
 	canonID, _ := dupOf(t, pool, "acme:1")
 	repostID, _ := dupOf(t, pool, "acme:2")
 

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -93,6 +93,42 @@ func (q *Queries) CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams
 	return result.RowsAffected(), nil
 }
 
+const companiesWithRoleClusters = `-- name: CompaniesWithRoleClusters :many
+SELECT company_slug FROM jobs
+WHERE closed_at IS NULL AND company_slug <> '' AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
+GROUP BY company_slug, role_fingerprint
+HAVING COUNT(*) > 1
+UNION
+SELECT DISTINCT company_slug FROM jobs
+WHERE closed_at IS NULL AND company_slug <> '' AND duplicate_of IS NOT NULL
+`
+
+// Company slugs whose role-duplicate markers may need recomputing: a company with an
+// open role cluster (>1 posting sharing a fingerprint) to collapse, OR one still
+// carrying an open marker that may need clearing (its cluster shrank). The recompute
+// processes these ONE COMPANY AT A TIME (RecomputeRoleDuplicatesForCompany) in short
+// transactions, so it never holds a table-wide lock that would stall concurrent ingest
+// crawls (a whole-table UPDATE did: it locked ~1.4M rows for minutes).
+func (q *Queries) CompaniesWithRoleClusters(ctx context.Context) ([]string, error) {
+	rows, err := q.db.Query(ctx, companiesWithRoleClusters)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var company_slug string
+		if err := rows.Scan(&company_slug); err != nil {
+			return nil, err
+		}
+		items = append(items, company_slug)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const enqueueJobEnrichment = `-- name: EnqueueJobEnrichment :execrows
 INSERT INTO enrichment_outbox (job_id, target_version)
 SELECT id, $1::int
@@ -1052,20 +1088,20 @@ func (q *Queries) PropagateCollectionsToJobs(ctx context.Context) (int64, error)
 	return result.RowsAffected(), nil
 }
 
-const recomputeRoleDuplicates = `-- name: RecomputeRoleDuplicates :execrows
+const recomputeRoleDuplicatesForCompany = `-- name: RecomputeRoleDuplicatesForCompany :execrows
 WITH canon AS (
-    SELECT company_slug, role_fingerprint, MIN(id) AS canon_id, COUNT(*) AS n
+    SELECT jobs.role_fingerprint, MIN(jobs.id) AS canon_id, COUNT(*) AS n
     FROM jobs
-    WHERE closed_at IS NULL AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
-    GROUP BY company_slug, role_fingerprint
+    WHERE jobs.company_slug = $1
+      AND jobs.closed_at IS NULL AND jobs.role_fingerprint IS NOT NULL AND jobs.role_fingerprint <> ''
+    GROUP BY jobs.role_fingerprint
 ),
 target AS (
     SELECT j.id,
         CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
     FROM jobs j
-    JOIN canon c
-      ON j.company_slug = c.company_slug AND j.role_fingerprint = c.role_fingerprint
-    WHERE j.closed_at IS NULL
+    JOIN canon c ON j.role_fingerprint = c.role_fingerprint
+    WHERE j.company_slug = $1 AND j.closed_at IS NULL
 )
 UPDATE jobs j
 SET duplicate_of = t.new_dup,
@@ -1075,15 +1111,15 @@ WHERE j.id = t.id
   AND j.duplicate_of IS DISTINCT FROM t.new_dup
 `
 
-// Collapse each role cluster to one canonical open job. For every OPEN, fingerprinted
-// job, the canon is the min(id) among its (company_slug, role_fingerprint) cluster's
-// open rows; the canon and any singleton/empty-fingerprint row get duplicate_of NULL,
-// the other reposts point to the canon. Rows are never deleted, so the reality counts
-// (which count the rows) are untouched. The IS DISTINCT FROM guard makes re-runs cheap
-// and idempotent, and a closed canon fails over to the next min(id) on the next run.
-// Closed rows are left as-is (excluded by closed_at everywhere the marker is read).
-func (q *Queries) RecomputeRoleDuplicates(ctx context.Context) (int64, error) {
-	result, err := q.db.Exec(ctx, recomputeRoleDuplicates)
+// The per-company slice of the role-duplicate recompute. Canon = min(id) among the
+// company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
+// row get duplicate_of NULL, the other reposts point to the canon. Rows are never
+// deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
+// only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
+// aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
+// idempotent, and a closed canon fails over to the next min(id) on the next run.
+func (q *Queries) RecomputeRoleDuplicatesForCompany(ctx context.Context, company string) (int64, error) {
+	result, err := q.db.Exec(ctx, recomputeRoleDuplicatesForCompany, company)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -89,6 +89,13 @@ type Querier interface {
 	// touched. The caller passes the crawled slugs and owns the grace window (cutoff =
 	// now() - window), so neither a failed nor a partial crawl mass-closes a catalogue.
 	CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams) (int64, error)
+	// Company slugs whose role-duplicate markers may need recomputing: a company with an
+	// open role cluster (>1 posting sharing a fingerprint) to collapse, OR one still
+	// carrying an open marker that may need clearing (its cluster shrank). The recompute
+	// processes these ONE COMPANY AT A TIME (RecomputeRoleDuplicatesForCompany) in short
+	// transactions, so it never holds a table-wide lock that would stall concurrent ingest
+	// crawls (a whole-table UPDATE did: it locked ~1.4M rows for minutes).
+	CompaniesWithRoleClusters(ctx context.Context) ([]string, error)
 	// Whether a company row already exists for the slug. The backfill checks this
 	// before upserting to log matched-existing vs inserted-reference counts — the
 	// upsert itself is blind to which path (insert or update) it took.
@@ -494,14 +501,14 @@ type Querier interface {
 	// (AT TIME ZONE 'UTC') so buckets are stable regardless of session timezone. The
 	// FULL OUTER JOIN yields one row per day that saw either an add or a removal.
 	RebuildJobDailyStats(ctx context.Context) (int64, error)
-	// Collapse each role cluster to one canonical open job. For every OPEN, fingerprinted
-	// job, the canon is the min(id) among its (company_slug, role_fingerprint) cluster's
-	// open rows; the canon and any singleton/empty-fingerprint row get duplicate_of NULL,
-	// the other reposts point to the canon. Rows are never deleted, so the reality counts
-	// (which count the rows) are untouched. The IS DISTINCT FROM guard makes re-runs cheap
-	// and idempotent, and a closed canon fails over to the next min(id) on the next run.
-	// Closed rows are left as-is (excluded by closed_at everywhere the marker is read).
-	RecomputeRoleDuplicates(ctx context.Context) (int64, error)
+	// The per-company slice of the role-duplicate recompute. Canon = min(id) among the
+	// company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
+	// row get duplicate_of NULL, the other reposts point to the canon. Rows are never
+	// deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
+	// only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
+	// aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
+	// idempotent, and a closed canon fails over to the next min(id) on the next run.
+	RecomputeRoleDuplicatesForCompany(ctx context.Context, company string) (int64, error)
 	// Count a failed crawl: bump consecutive_failures, record the error, stamp the run,
 	// and RETURN the new failure count so the caller can compute the cooldown (the backoff
 	// policy lives in Go, not here). The cooldown itself is applied by SetBoardCooldown.

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -274,27 +274,42 @@ WHERE role_fingerprint IS NOT NULL AND role_fingerprint <> ''
 GROUP BY company_slug, role_fingerprint
 HAVING COUNT(*) > 1;
 
--- name: RecomputeRoleDuplicates :execrows
--- Collapse each role cluster to one canonical open job. For every OPEN, fingerprinted
--- job, the canon is the min(id) among its (company_slug, role_fingerprint) cluster's
--- open rows; the canon and any singleton/empty-fingerprint row get duplicate_of NULL,
--- the other reposts point to the canon. Rows are never deleted, so the reality counts
--- (which count the rows) are untouched. The IS DISTINCT FROM guard makes re-runs cheap
--- and idempotent, and a closed canon fails over to the next min(id) on the next run.
--- Closed rows are left as-is (excluded by closed_at everywhere the marker is read).
+-- name: CompaniesWithRoleClusters :many
+-- Company slugs whose role-duplicate markers may need recomputing: a company with an
+-- open role cluster (>1 posting sharing a fingerprint) to collapse, OR one still
+-- carrying an open marker that may need clearing (its cluster shrank). The recompute
+-- processes these ONE COMPANY AT A TIME (RecomputeRoleDuplicatesForCompany) in short
+-- transactions, so it never holds a table-wide lock that would stall concurrent ingest
+-- crawls (a whole-table UPDATE did: it locked ~1.4M rows for minutes).
+SELECT company_slug FROM jobs
+WHERE closed_at IS NULL AND company_slug <> '' AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
+GROUP BY company_slug, role_fingerprint
+HAVING COUNT(*) > 1
+UNION
+SELECT DISTINCT company_slug FROM jobs
+WHERE closed_at IS NULL AND company_slug <> '' AND duplicate_of IS NOT NULL;
+
+-- name: RecomputeRoleDuplicatesForCompany :execrows
+-- The per-company slice of the role-duplicate recompute. Canon = min(id) among the
+-- company's open rows sharing a role_fingerprint; the canon and any singleton/empty-fp
+-- row get duplicate_of NULL, the other reposts point to the canon. Rows are never
+-- deleted, so the reality counts are untouched. Scoped to one company_slug so it locks
+-- only that company's rows briefly; the (company_slug, role_fingerprint) index makes the
+-- aggregation a range scan. The IS DISTINCT FROM guard makes re-runs cheap and
+-- idempotent, and a closed canon fails over to the next min(id) on the next run.
 WITH canon AS (
-    SELECT company_slug, role_fingerprint, MIN(id) AS canon_id, COUNT(*) AS n
+    SELECT jobs.role_fingerprint, MIN(jobs.id) AS canon_id, COUNT(*) AS n
     FROM jobs
-    WHERE closed_at IS NULL AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
-    GROUP BY company_slug, role_fingerprint
+    WHERE jobs.company_slug = sqlc.arg(company)
+      AND jobs.closed_at IS NULL AND jobs.role_fingerprint IS NOT NULL AND jobs.role_fingerprint <> ''
+    GROUP BY jobs.role_fingerprint
 ),
 target AS (
     SELECT j.id,
         CASE WHEN c.n > 1 AND j.id <> c.canon_id THEN c.canon_id END AS new_dup
     FROM jobs j
-    JOIN canon c
-      ON j.company_slug = c.company_slug AND j.role_fingerprint = c.role_fingerprint
-    WHERE j.closed_at IS NULL
+    JOIN canon c ON j.role_fingerprint = c.role_fingerprint
+    WHERE j.company_slug = sqlc.arg(company) AND j.closed_at IS NULL
 )
 UPDATE jobs j
 SET duplicate_of = t.new_dup,

--- a/migrations/0013_jobs_open_role_cluster_idx.sql
+++ b/migrations/0013_jobs_open_role_cluster_idx.sql
@@ -1,0 +1,15 @@
+-- Partial index supporting the role-duplicate recompute's per-company aggregation
+-- (MIN(id)/COUNT(*) GROUP BY company_slug, role_fingerprint over OPEN fingerprinted
+-- jobs). Without it the recompute seq-scans the whole jobs table and spills the
+-- HashAggregate to disk; with it each company's cluster read is an index range scan.
+-- The existing jobs_company_role_fingerprint_idx is NOT partial (no closed_at filter),
+-- so the planner falls back to a seq scan for the open-only aggregation.
+--
+-- Applied to a fresh volume by initdb after 0012; on an existing prod volume build it
+-- CONCURRENTLY out of band (a plain CREATE INDEX would lock the live jobs table):
+--   CREATE INDEX CONCURRENTLY jobs_open_role_cluster_idx
+--     ON public.jobs (company_slug, role_fingerprint)
+--     WHERE closed_at IS NULL AND role_fingerprint <> '';
+CREATE INDEX IF NOT EXISTS jobs_open_role_cluster_idx
+    ON public.jobs (company_slug, role_fingerprint)
+    WHERE closed_at IS NULL AND role_fingerprint <> '';


### PR DESCRIPTION
## Why
The whole-table `RecomputeRoleDuplicates` UPDATE from #598, run on prod (3M rows / ~1.4M reposts), **locked rows for minutes and stalled ~15 concurrent ingest crawls** (blocked on `transactionid`), and its nested-loop plan never finished. It's the reason the collapse couldn't be turned on.

## Fix
- **Per-company recompute** replaces the single whole-table UPDATE:
  - `CompaniesWithRoleClusters` = (companies with an open cluster >1) ∪ (companies with an open row still carrying a marker — catches a cluster that shrank to 1 needing its stale marker cleared).
  - `RecomputeRoleDuplicatesForCompany(company)` = the same canon/min(id) logic scoped to one company.
  - `cmd/reindex` loops companies, each UPDATE its own short autocommit transaction → **locks only one company's rows for a moment, never table-wide**. Log-and-continue so one poison company can't starve the rest.
- **Migration 0013**: partial index `(company_slug, role_fingerprint) WHERE closed_at IS NULL AND role_fingerprint <> ''` so the per-company aggregation is a range scan, not a seq scan + hashagg spill.

## Verification
- Integration tests drive the exact per-company path: collapse to min(id) canon, singleton/unfingerprinted stay canonical, idempotent, failover on canon close, and **cluster-shrinks-to-1 clears the survivor's stale marker**. `go build`/`vet`/`go test ./...` + `-tags=integration ./internal/db/` green. Reviewed (per-company scoping, locking, reset completeness).

## Deploy
⚠️ Build the index out-of-band before deploy (already applied on prod during the incident):
`CREATE INDEX CONCURRENTLY jobs_open_role_cluster_idx ON public.jobs (company_slug, role_fingerprint) WHERE closed_at IS NULL AND role_fingerprint <> '';`
Then deploy; the next reindex runs the batched recompute safely and collapses the catalogue. (Re-enable the `freehire-reindexw.timer`, stopped during the incident.)

Follow-up to #598.