### PR TITLE
feat(web): enrich JobPosting JSON-LD with logo, skills, and requirements

### DIFF
--- a/openspec/changes/job-posting-schema-enrichment/.openspec.yaml
+++ b/openspec/changes/job-posting-schema-enrichment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/job-posting-schema-enrichment/design.md
+++ b/openspec/changes/job-posting-schema-enrichment/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`jobPostingJsonLd(job, origin)` in `web/src/lib/seo.ts` builds the `JobPosting`
+JSON-LD from the job wire shape already loaded on `/jobs/:slug`. It emits baseline
+fields conditionally (salary, location/remote, `validThrough`). The job carries a
+top-level dictionary `skills` array and an `enrichment` blob with
+`experience_years_min` and `education_level`; the company logo is derivable from
+`job.company` via the existing `logoDevUrl` helper. None of this reaches the
+`JobPosting` yet.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enrich `JobPosting` with `hiringOrganization.logo`, `skills`,
+  `experienceRequirements`, `educationRequirements`, each strictly conditional.
+- First unit coverage for `jobPostingJsonLd` (currently untested).
+
+**Non-Goals:**
+- `directApply`, `identifier`, `jobBenefits` — deferred.
+- No backend, data, or route changes.
+
+## Decisions
+
+- **Logo from the company name.** `hiringOrganization.logo = logoDevUrl(job.company)`
+  when `job.company` is non-empty. logo.dev's `fallback=404` means unknown
+  companies yield a URL that 404s; Google silently ignores a non-resolving logo
+  (it is an optional field, not a validation error), and this reuses the exact
+  source the SPA and OG cards already trust — consistent behavior over a
+  per-company availability check we cannot make server-side.
+- **Skills from the dictionary facet.** `skills = job.skills.join(', ')` when the
+  array is non-empty. `job.skills` is the production dict facet (canonical names),
+  not the raw `enrichment.skills`, matching the dict-only serving convention.
+  Emitted as Google `Text` (comma-joined), the shape Google's examples use.
+- **Experience as months, positive-only.** `experienceRequirements =
+  { '@type': 'OccupationalExperienceRequirements', monthsOfExperience:
+  experience_years_min * 12 }` only when `experience_years_min > 0`. A `0`
+  (explicit entry-level) carries no SEO signal, so it is omitted rather than
+  emitting `monthsOfExperience: 0`.
+- **Education via a small enum map.** `education_level` → `credentialCategory`:
+  `bachelor`→"bachelor degree", `master`/`phd`→"postgraduate degree"; `none` and
+  any unmapped value omit `educationRequirements`. Emitted as
+  `EducationalOccupationalCredential`, Google's accepted type.
+- **TDD on the pure function.** `seo.test.ts` gains `jobPostingJsonLd` cases:
+  each new field present, and the omission cases (no skills, zero experience,
+  `education_level: none`, missing company). All output still flows through the
+  unchanged `jsonLdScript` escaping.
+
+## Risks / Trade-offs
+
+- **404 logos.** Some emitted logo URLs will 404 for companies logo.dev doesn't
+  know. Accepted: optional field, ignored by Google, no validation impact.
+- **Skills as Text vs DefinedTerm.** Comma-joined Text is the simpler,
+  Google-documented form; DefinedTerm would add structure with no ranking benefit
+  here (YAGNI).
+- **Enrichment absence.** Unenriched jobs simply omit the new fields — the
+  baseline `JobPosting` is unchanged, so nothing regresses.

--- a/openspec/changes/job-posting-schema-enrichment/proposal.md
+++ b/openspec/changes/job-posting-schema-enrichment/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The `JobPosting` JSON-LD on job-detail pages — the structured data that makes
+postings eligible for Google Jobs across ~99% of the catalogue — carries only the
+baseline fields (title, description, hiring org, location, date, salary). It omits
+several fields Google reads for richer job results that we already have data for:
+the company logo, the required skills, and the experience/education requirements.
+
+## What Changes
+
+- Add to the `JobPosting` JSON-LD, each emitted only when the underlying data is
+  present:
+  - `hiringOrganization.logo` — the logo.dev URL for the company name (same
+    source the SPA and OG cards already use).
+  - `skills` — the job's canonical dictionary skills (`job.skills`) joined as
+    Google-`Text`.
+  - `experienceRequirements` — an `OccupationalExperienceRequirements` with
+    `monthsOfExperience` = `experience_years_min × 12`, emitted only when the
+    minimum is **greater than zero** (a 0 carries no SEO signal).
+  - `educationRequirements` — an `EducationalOccupationalCredential` whose
+    `credentialCategory` maps the enrichment `education_level`
+    (`bachelor`→"bachelor degree", `master`/`phd`→"postgraduate degree";
+    `none` is omitted).
+
+Out of scope (deliberately deferred): `directApply`, `identifier`, `jobBenefits`.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `web-ssr-seo`: the "JobPosting structured data" requirement is strengthened —
+  the `JobPosting` object additionally carries the company logo, skills, and
+  experience/education requirements it has data for.
+
+## Impact
+
+- `web/src/lib/seo.ts` — `jobPostingJsonLd` gains four conditional fields; imports
+  `logoDevUrl` from `./logo`.
+- `web/src/lib/seo.test.ts` — new vitest coverage for `jobPostingJsonLd`
+  (previously untested).
+- No backend, API, schema, or data changes; no route wiring (the function is
+  already called on `/jobs/:slug`). No new dependencies.

--- a/openspec/changes/job-posting-schema-enrichment/specs/web-ssr-seo/spec.md
+++ b/openspec/changes/job-posting-schema-enrichment/specs/web-ssr-seo/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: JobPosting structured data
+
+The job-detail page SHALL include a `JobPosting` JSON-LD `<script type="application/ld+json">`
+block in its server-rendered HTML, populated from the job's public fields
+(title, description, hiring organization, location/remote, posting date, and the
+application URL), so the posting is eligible for Google Jobs. The `JobPosting`
+SHALL additionally carry, each only when the underlying data is present: the
+hiring organization's `logo`, the job's `skills`, an `experienceRequirements`
+derived from the minimum years of experience, and an `educationRequirements`
+derived from the required education level. Company pages SHALL include
+`Organization` JSON-LD, and that `Organization` object SHALL carry every
+company-info fact the company row provides — its logo, description, homepage and
+LinkedIn links (as `sameAs`), founding year, employee count, and HQ country — so
+the company reads as a recognizable entity, while omitting any of those fields
+the company does not have.
+
+#### Scenario: Job page emits valid JobPosting JSON-LD
+
+- **WHEN** `GET /jobs/:slug` is requested for an existing job
+- **THEN** the HTML contains one `application/ld+json` script with `@type`
+  `JobPosting` whose `title`, `description`, `hiringOrganization`, and
+  `datePosted` reflect the job
+
+#### Scenario: A closed job reflects its status in structured data
+
+- **WHEN** the job carries a `closed_at`
+- **THEN** the `JobPosting` data conveys that the posting is no longer accepting
+  applications rather than presenting it as open
+
+#### Scenario: JobPosting carries logo, skills, and requirements when present
+
+- **WHEN** `GET /jobs/:slug` is requested for a job that has a company name,
+  dictionary skills, a positive minimum years of experience, and a degree-level
+  education requirement
+- **THEN** the `JobPosting` includes a `hiringOrganization.logo` URL, a `skills`
+  value listing those skills, an `experienceRequirements` of type
+  `OccupationalExperienceRequirements` whose `monthsOfExperience` equals the
+  minimum years × 12, and an `educationRequirements` of type
+  `EducationalOccupationalCredential` with a `credentialCategory`
+
+#### Scenario: Absent or signal-free enrichment fields are omitted
+
+- **WHEN** the job has no skills, a minimum experience of zero, and an education
+  level of `none`
+- **THEN** the `JobPosting` omits `skills`, `experienceRequirements`, and
+  `educationRequirements` entirely rather than emitting empty or zero values
+
+#### Scenario: Company Organization carries its known company-info facts
+
+- **WHEN** `GET /companies/:slug` is requested for a company whose `company_info`
+  provides a logo, description, homepage/LinkedIn links, founding year, employee
+  count, and HQ country
+- **THEN** the emitted `Organization` JSON-LD includes `logo`, `description`, a
+  `sameAs` array holding those links, `foundingDate`, `numberOfEmployees`, and an
+  `address` with the country code
+
+#### Scenario: Missing company-info facts are omitted, not emitted empty
+
+- **WHEN** the company has no `company_info` (or only some of its fields)
+- **THEN** the `Organization` JSON-LD still emits `name` and `url` and simply
+  omits every fact the company lacks (no empty strings, null values, or empty
+  arrays)

--- a/openspec/changes/job-posting-schema-enrichment/tasks.md
+++ b/openspec/changes/job-posting-schema-enrichment/tasks.md
@@ -1,0 +1,18 @@
+## 1. Enrich JobPosting JSON-LD
+
+- [x] 1.1 RED: add `seo.test.ts` cases for `jobPostingJsonLd` — a fully-enriched
+  job (company name, `skills`, `experience_years_min > 0`, `education_level`
+  bachelor/master/phd) emits `hiringOrganization.logo`, `skills` (joined),
+  `experienceRequirements.monthsOfExperience` = years×12, and
+  `educationRequirements.credentialCategory` (correct mapping); an omission job
+  (no skills, `experience_years_min` 0, `education_level` none, no company) emits
+  none of the four. Watch them fail.
+- [x] 1.2 GREEN: extend `jobPostingJsonLd` in `web/src/lib/seo.ts` (import
+  `logoDevUrl`, add the four conditional fields + the education map) until tests
+  pass.
+
+## 2. Verify
+
+- [x] 2.1 Run `vitest run`, `svelte-check`, and lint on changed files locally;
+  all green.
+- [x] 2.2 `simplify` pass over the diff; re-run tests green.

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { collectionPageJsonLd, organizationJsonLd } from './seo';
+import { collectionPageJsonLd, jobPostingJsonLd, organizationJsonLd } from './seo';
+import { logoDevUrl } from './logo';
 import type { Company, Job } from './types';
 
 // collectionPageJsonLd reads only title + public_slug off each job.
 function job(title: string, slug: string): Job {
   return { title, public_slug: slug } as Job;
+}
+
+// A job carrying the fields jobPostingJsonLd reads; tests spread the facts under test.
+function postingJob(overrides: Partial<Job> = {}): Job {
+  return {
+    public_slug: 'engineer-abc',
+    title: 'Engineer',
+    company: 'Acme',
+    description: 'Build things.',
+    skills: [],
+    ...overrides,
+  } as Job;
 }
 
 // Minimal valid Company; individual tests spread in the facts under test.
@@ -107,6 +120,56 @@ describe('organizationJsonLd', () => {
     );
 
     expect(ld).not.toHaveProperty('sameAs');
+  });
+});
+
+describe('jobPostingJsonLd', () => {
+  it('adds logo, skills, and experience/education requirements when present', () => {
+    const ld = jobPostingJsonLd(
+      postingJob({
+        company: 'Acme',
+        skills: ['Go', 'Kubernetes'],
+        enrichment: { experience_years_min: 5, education_level: 'bachelor' },
+      }),
+      ORIGIN
+    );
+
+    expect((ld.hiringOrganization as Record<string, unknown>).logo).toBe(logoDevUrl('Acme'));
+    expect(ld.skills).toBe('Go, Kubernetes');
+    expect(ld.experienceRequirements).toEqual({
+      '@type': 'OccupationalExperienceRequirements',
+      monthsOfExperience: 60,
+    });
+    expect(ld.educationRequirements).toEqual({
+      '@type': 'EducationalOccupationalCredential',
+      credentialCategory: 'bachelor degree',
+    });
+  });
+
+  it('maps master and phd education to a postgraduate degree', () => {
+    for (const level of ['master', 'phd']) {
+      const ld = jobPostingJsonLd(postingJob({ enrichment: { education_level: level } }), ORIGIN);
+      expect(ld.educationRequirements).toEqual({
+        '@type': 'EducationalOccupationalCredential',
+        credentialCategory: 'postgraduate degree',
+      });
+    }
+  });
+
+  it('omits logo, skills, and signal-free requirements', () => {
+    const ld = jobPostingJsonLd(
+      postingJob({
+        company: '',
+        skills: [],
+        enrichment: { experience_years_min: 0, education_level: 'none' },
+      }),
+      ORIGIN
+    );
+
+    expect(ld.hiringOrganization).not.toHaveProperty('logo');
+    expect(ld).not.toHaveProperty('skills');
+    expect(ld).not.toHaveProperty('experienceRequirements');
+    expect(ld).not.toHaveProperty('educationRequirements');
   });
 });
 

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -2,6 +2,7 @@
 // public wire shapes. Emitted server-side (see the route +page.svelte files) so
 // crawlers and Google Jobs see structured data in the initial HTML.
 
+import { logoDevUrl } from './logo';
 import type { Company, Enrichment, Job } from './types';
 
 const SITE = 'freehire';
@@ -87,11 +88,23 @@ function applicantRegions(regions?: string[]): unknown {
   return named.length === 1 ? named[0] : named;
 }
 
+// schema.org educationRequirements.credentialCategory, from the enrich
+// education_level vocabulary ("none"/"bachelor"/"master"/"phd"). "none" and any
+// unmapped value carry no requirement and are omitted.
+const EDUCATION_CREDENTIAL: Record<string, string> = {
+  bachelor: 'bachelor degree',
+  master: 'postgraduate degree',
+  phd: 'postgraduate degree',
+};
+
 /** schema.org JobPosting for a job-detail page, eligible for Google Jobs. A
  *  closed posting sets `validThrough` to its close time so it reads as expired,
  *  not open. `origin` is the absolute site origin (e.g. https://freehire.dev). */
 export function jobPostingJsonLd(job: Job, origin: string): Record<string, unknown> {
   const e = job.enrichment ?? {};
+  // logo.dev resolves a logo from the company name (404s for unknown companies,
+  // which Google silently ignores); same source the SPA and OG cards use.
+  const logo = logoDevUrl(job.company);
   const ld: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'JobPosting',
@@ -102,6 +115,7 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
       '@type': 'Organization',
       name: job.company || 'Unknown',
       ...(job.company_slug ? { sameAs: `${origin}/companies/${job.company_slug}` } : {}),
+      ...(logo ? { logo } : {}),
     },
   };
 
@@ -133,6 +147,25 @@ export function jobPostingJsonLd(job: Job, origin: string): Record<string, unkno
 
   if (e.salary_min != null || e.salary_max != null) {
     ld.baseSalary = baseSalary(e);
+  }
+
+  // skills is the dictionary facet (canonical names), served as Google Text.
+  if (job.skills?.length) ld.skills = job.skills.join(', ');
+
+  // A zero minimum (explicit entry-level) carries no SEO signal, so omit it.
+  if (e.experience_years_min != null && e.experience_years_min > 0) {
+    ld.experienceRequirements = {
+      '@type': 'OccupationalExperienceRequirements',
+      monthsOfExperience: e.experience_years_min * 12,
+    };
+  }
+
+  const credential = e.education_level ? EDUCATION_CREDENTIAL[e.education_level] : undefined;
+  if (credential) {
+    ld.educationRequirements = {
+      '@type': 'EducationalOccupationalCredential',
+      credentialCategory: credential,
+    };
   }
 
   return ld;


### PR DESCRIPTION
## Summary

Enriches the `JobPosting` JSON-LD on `/jobs/:slug` (structured data for Google Jobs across ~99% of the catalogue), all in the pure `web/src/lib/seo.ts` helper. Each field is emitted only when the underlying data is present:

- `hiringOrganization.logo` — logo.dev URL from the company name (same source the SPA/OG cards use; Google ignores a non-resolving logo)
- `skills` — the dictionary skills facet (`job.skills`, canonical names) joined as Google `Text`
- `experienceRequirements` — `OccupationalExperienceRequirements{monthsOfExperience: experience_years_min × 12}`, omitted when the minimum is 0 (entry-level carries no SEO signal)
- `educationRequirements` — `EducationalOccupationalCredential{credentialCategory}`: `bachelor`→"bachelor degree", `master`/`phd`→"postgraduate degree"; `none` omitted

Baseline `JobPosting` fields are unchanged.

## Test Plan

- [x] `vitest run` — 166 pass (3 new `jobPostingJsonLd` cases: enriched, master/phd→postgraduate, omission; the function was previously untested)
- [x] `svelte-check` — 0 errors / 0 warnings
- [x] `eslint` on changed files — clean
- [ ] Post-deploy: fetch a live `/jobs/:slug` and validate JSON-LD in Google Rich Results