### PR TITLE
feat(web): openings-across-cities section for collapsed roles

### DIFF
--- a/internal/db/job_cluster_copies_integration_test.go
+++ b/internal/db/job_cluster_copies_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+// Integration test for ListRoleClusterCopies: the "openings across cities" list a
+// collapsed job exposes — every open posting sharing the anchor's role cluster
+// (company_slug + role_fingerprint), each with its own location, ordered by location.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func setLocation(t *testing.T, pool *pgxpool.Pool, ext, loc string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		"UPDATE jobs SET location = $1 WHERE external_id = $2", loc, ext); err != nil {
+		t.Fatalf("set location %s: %v", ext, err)
+	}
+}
+
+func TestListRoleClusterCopies_ReturnsOpenClusterByLocation(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	const fp = "role-dup"
+	cities := map[string]string{"acme:1": "Moscow", "acme:2": "Kazan", "acme:3": "Perm"}
+	for ext, city := range cities {
+		if _, err := q.UpsertJob(ctx, withFingerprint(ext, "Staff Engineer", fp)); err != nil {
+			t.Fatalf("upsert %s: %v", ext, err)
+		}
+		setLocation(t, pool, ext, city)
+	}
+	// An unrelated role and a closed cluster member must not appear.
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:other", "Designer", "role-xyz")); err != nil {
+		t.Fatalf("upsert other: %v", err)
+	}
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:closed", "Staff Engineer", fp)); err != nil {
+		t.Fatalf("upsert closed: %v", err)
+	}
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = now() WHERE external_id = $1", "acme:closed"); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	anchorID, _ := dupOf(t, pool, "acme:1")
+	copies, err := q.ListRoleClusterCopies(ctx, ListRoleClusterCopiesParams{JobID: anchorID, RowLimit: 100, RowOffset: 0})
+	if err != nil {
+		t.Fatalf("ListRoleClusterCopies: %v", err)
+	}
+
+	// The three open cluster members, ordered by location (Kazan, Moscow, Perm), each
+	// with its own location — the anchor itself included, the closed member excluded.
+	if len(copies) != 3 {
+		t.Fatalf("got %d copies, want 3 (open cluster members)", len(copies))
+	}
+	wantOrder := []string{"Kazan", "Moscow", "Perm"}
+	for i, want := range wantOrder {
+		if copies[i].Location != want {
+			t.Errorf("copies[%d].Location = %q, want %q (ordered by location)", i, copies[i].Location, want)
+		}
+	}
+
+	// An empty-fingerprint anchor clusters with no one → no copies.
+	if _, err := q.UpsertJob(ctx, withFingerprint("acme:nofp", "Untagged", "")); err != nil {
+		t.Fatalf("upsert nofp: %v", err)
+	}
+	nofpID, _ := dupOf(t, pool, "acme:nofp")
+	empty, err := q.ListRoleClusterCopies(ctx, ListRoleClusterCopiesParams{JobID: nofpID, RowLimit: 100, RowOffset: 0})
+	if err != nil {
+		t.Fatalf("ListRoleClusterCopies (nofp): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("empty-fp anchor returned %d copies, want 0", len(empty))
+	}
+}

--- a/internal/db/job_cluster_copies_integration_test.go
+++ b/internal/db/job_cluster_copies_integration_test.go
@@ -57,6 +57,9 @@ func TestListRoleClusterCopies_ReturnsOpenClusterByLocation(t *testing.T) {
 	if len(copies) != 3 {
 		t.Fatalf("got %d copies, want 3 (open cluster members)", len(copies))
 	}
+	if copies[0].Total != 3 {
+		t.Errorf("total = %d, want 3 (whole open cluster, pre-limit)", copies[0].Total)
+	}
 	wantOrder := []string{"Kazan", "Moscow", "Perm"}
 	for i, want := range wantOrder {
 		if copies[i].Location != want {

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1032,6 +1032,61 @@ func (q *Queries) ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsP
 	return items, nil
 }
 
+const listRoleClusterCopies = `-- name: ListRoleClusterCopies :many
+SELECT j.public_slug, j.location, j.url, j.posted_at
+FROM jobs j
+JOIN jobs anchor ON anchor.id = $1
+WHERE j.company_slug = anchor.company_slug
+  AND j.role_fingerprint = anchor.role_fingerprint
+  AND anchor.role_fingerprint <> ''
+  AND j.closed_at IS NULL
+ORDER BY j.location, j.id
+LIMIT $3 OFFSET $2
+`
+
+type ListRoleClusterCopiesParams struct {
+	JobID     int64 `json:"job_id"`
+	RowOffset int32 `json:"row_offset"`
+	RowLimit  int32 `json:"row_limit"`
+}
+
+type ListRoleClusterCopiesRow struct {
+	PublicSlug string             `json:"public_slug"`
+	Location   string             `json:"location"`
+	URL        string             `json:"url"`
+	PostedAt   pgtype.Timestamptz `json:"posted_at"`
+}
+
+// The open postings sharing a role cluster (company_slug + role_fingerprint) with the
+// anchor job — the "N openings across cities" list for a collapsed role. Each copy keeps
+// its own location and apply URL, so a seeker picks their city; the anchor itself is
+// included (it is one of the openings). Ordered by location. An empty-fingerprint anchor
+// clusters with no one and returns nothing.
+func (q *Queries) ListRoleClusterCopies(ctx context.Context, arg ListRoleClusterCopiesParams) ([]ListRoleClusterCopiesRow, error) {
+	rows, err := q.db.Query(ctx, listRoleClusterCopies, arg.JobID, arg.RowOffset, arg.RowLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListRoleClusterCopiesRow{}
+	for rows.Next() {
+		var i ListRoleClusterCopiesRow
+		if err := rows.Scan(
+			&i.PublicSlug,
+			&i.Location,
+			&i.URL,
+			&i.PostedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markLivenessExpired = `-- name: MarkLivenessExpired :one
 UPDATE jobs
 SET liveness_strikes = liveness_strikes + 1,

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1033,7 +1033,8 @@ func (q *Queries) ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsP
 }
 
 const listRoleClusterCopies = `-- name: ListRoleClusterCopies :many
-SELECT j.public_slug, j.location, j.url, j.posted_at
+SELECT j.public_slug, j.location, j.url, j.posted_at,
+    COUNT(*) OVER()::bigint AS total
 FROM jobs j
 JOIN jobs anchor ON anchor.id = $1
 WHERE j.company_slug = anchor.company_slug
@@ -1055,6 +1056,7 @@ type ListRoleClusterCopiesRow struct {
 	Location   string             `json:"location"`
 	URL        string             `json:"url"`
 	PostedAt   pgtype.Timestamptz `json:"posted_at"`
+	Total      int64              `json:"total"`
 }
 
 // The open postings sharing a role cluster (company_slug + role_fingerprint) with the
@@ -1076,6 +1078,7 @@ func (q *Queries) ListRoleClusterCopies(ctx context.Context, arg ListRoleCluster
 			&i.Location,
 			&i.URL,
 			&i.PostedAt,
+			&i.Total,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -428,6 +428,12 @@ type Querier interface {
 	// The moderator review queue: every pending submission, newest first, with the submitter's
 	// email so the moderator can judge provenance.
 	ListPendingSubmissions(ctx context.Context) ([]ListPendingSubmissionsRow, error)
+	// The open postings sharing a role cluster (company_slug + role_fingerprint) with the
+	// anchor job — the "N openings across cities" list for a collapsed role. Each copy keeps
+	// its own location and apply URL, so a seeker picks their city; the anchor itself is
+	// included (it is one of the openings). Ordered by location. An empty-fingerprint anchor
+	// clusters with no one and returns nothing.
+	ListRoleClusterCopies(ctx context.Context, arg ListRoleClusterCopiesParams) ([]ListRoleClusterCopiesRow, error)
 	// A user's saved searches, most recently updated first (the "My filters" picker order).
 	ListSavedSearches(ctx context.Context, userID int64) ([]SavedSearch, error)
 	// "My submissions": one user's submissions, newest first, whatever their status.

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -259,6 +259,22 @@ WHERE company_slug = sqlc.arg(company_slug)
   AND role_fingerprint = sqlc.arg(role_fingerprint)
   AND role_fingerprint <> '';
 
+-- name: ListRoleClusterCopies :many
+-- The open postings sharing a role cluster (company_slug + role_fingerprint) with the
+-- anchor job — the "N openings across cities" list for a collapsed role. Each copy keeps
+-- its own location and apply URL, so a seeker picks their city; the anchor itself is
+-- included (it is one of the openings). Ordered by location. An empty-fingerprint anchor
+-- clusters with no one and returns nothing.
+SELECT j.public_slug, j.location, j.url, j.posted_at
+FROM jobs j
+JOIN jobs anchor ON anchor.id = sqlc.arg(job_id)
+WHERE j.company_slug = anchor.company_slug
+  AND j.role_fingerprint = anchor.role_fingerprint
+  AND anchor.role_fingerprint <> ''
+  AND j.closed_at IS NULL
+ORDER BY j.location, j.id
+LIMIT sqlc.arg(row_limit) OFFSET sqlc.arg(row_offset);
+
 -- name: RoleClusterCountsAll :many
 -- The whole-catalogue role-cluster counts in one aggregate pass, for the reindex to
 -- build its (company_slug, role_fingerprint) -> counts lookup once. Only clusters with

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -265,7 +265,8 @@ WHERE company_slug = sqlc.arg(company_slug)
 -- its own location and apply URL, so a seeker picks their city; the anchor itself is
 -- included (it is one of the openings). Ordered by location. An empty-fingerprint anchor
 -- clusters with no one and returns nothing.
-SELECT j.public_slug, j.location, j.url, j.posted_at
+SELECT j.public_slug, j.location, j.url, j.posted_at,
+    COUNT(*) OVER()::bigint AS total
 FROM jobs j
 JOIN jobs anchor ON anchor.id = sqlc.arg(job_id)
 WHERE j.company_slug = anchor.company_slug

--- a/internal/handler/copies.go
+++ b/internal/handler/copies.go
@@ -55,5 +55,12 @@ func (a *API) JobCopies(c *fiber.Ctx) error {
 		}
 		copies[i] = cp
 	}
-	return c.JSON(fiber.Map{"data": copies})
+
+	// total is the whole cluster's open size (COUNT(*) OVER, pre-LIMIT), so the client's
+	// "N openings" header stays accurate even when the list is a capped page.
+	var total int64
+	if len(rows) > 0 {
+		total = rows[0].Total
+	}
+	return c.JSON(fiber.Map{"data": copies, "meta": fiber.Map{"total": total}})
 }

--- a/internal/handler/copies.go
+++ b/internal/handler/copies.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// defaultCopiesLimit / maxCopiesLimit bound the "openings across cities" list a
+// collapsed job exposes, capped so a client cannot pull an unbounded cluster at once.
+const (
+	defaultCopiesLimit = 50
+	maxCopiesLimit     = 200
+)
+
+// jobCopy is one posting in a role cluster — a single city's opening under a collapsed
+// role. Each keeps its own location and apply URL so a seeker picks their city.
+type jobCopy struct {
+	PublicSlug string     `json:"public_slug"`
+	Location   string     `json:"location"`
+	ApplyURL   string     `json:"apply_url"`
+	PostedAt   *time.Time `json:"posted_at"`
+}
+
+// JobCopies lists the open postings sharing the role cluster of the job addressed by
+// :slug — the per-city openings folded under one canonical card by the content-dedup
+// collapse. Public (unauthenticated) like the other job reads; the anchor itself is
+// included (it is one of the openings). Response: {"data": [copy...]}.
+func (a *API) JobCopies(c *fiber.Ctx) error {
+	id, err := a.queries.GetJobIDBySlug(c.Context(), c.Params("slug"))
+	if err != nil {
+		// RenderError maps pgx.ErrNoRows to 404, anything else to 500.
+		return err
+	}
+
+	limit := min(max(c.QueryInt("limit", defaultCopiesLimit), 1), maxCopiesLimit)
+	offset := max(c.QueryInt("offset", 0), 0)
+	rows, err := a.queries.ListRoleClusterCopies(c.Context(), db.ListRoleClusterCopiesParams{
+		JobID:     id,
+		RowLimit:  int32(limit),
+		RowOffset: int32(offset),
+	})
+	if err != nil {
+		return err
+	}
+
+	copies := make([]jobCopy, len(rows))
+	for i, r := range rows {
+		cp := jobCopy{PublicSlug: r.PublicSlug, Location: r.Location, ApplyURL: r.URL}
+		if r.PostedAt.Valid {
+			t := r.PostedAt.Time
+			cp.PostedAt = &t
+		}
+		copies[i] = cp
+	}
+	return c.JSON(fiber.Map{"data": copies})
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -244,6 +244,7 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/jobs/sitemap", a.JobSitemap)
 	api.Get("/jobs/:slug", a.GetJob)
 	api.Get("/jobs/:slug/similar", a.SimilarJobs)
+	api.Get("/jobs/:slug/copies", a.JobCopies)
 	api.Get("/companies", a.ListCompanies)
 	api.Get("/companies/sitemap", a.CompanySitemap)
 	api.Get("/companies/sitemap/boundaries", a.CompanySitemapBoundaries)

--- a/openspec/changes/job-cluster-copies/.openspec.yaml
+++ b/openspec/changes/job-cluster-copies/.openspec.yaml
@@ -1,0 +1,2 @@
+name: job-cluster-copies
+schema: spec-driven

--- a/openspec/changes/job-cluster-copies/proposal.md
+++ b/openspec/changes/job-cluster-copies/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The content-dedup collapse hides a role cluster's reposts behind one canonical card and
+surfaces an openings count ("929 open copies"), but there is no way to SEE those copies.
+For a mass-posted role (e.g. Lowe's Cashier across 1251 stores, T-Bank Представитель
+across cities) a seeker wants to pick their own city — each copy keeps its own location
+and apply URL, but they are only reachable by a slug nobody has.
+
+## What Changes
+
+- New `GET /api/v1/jobs/:slug/copies` returns the open postings sharing the job's role
+  cluster (`company_slug` + `role_fingerprint`) — each with its location, apply URL, and
+  public slug, ordered by location, paginated. Public, like the other job reads; the
+  anchor itself is included (it is one of the openings).
+- The job detail page renders an "N openings across locations" section (component
+  `JobCopies.svelte`), listing the cities with links, shown only for a genuinely
+  mass-posted role (more than one copy). Degrades to nothing on failure.
+
+## Capabilities
+
+### New Capabilities
+- `job-cluster-copies`: the per-city openings list under a collapsed role — the copies
+  endpoint and the detail-page section.
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+- `internal/db/queries/jobs.sql` — `ListRoleClusterCopies`; regenerate sqlc.
+- `internal/handler/copies.go` + route in `handler.go`.
+- `web/` — `getJobCopies` API client, detail loader fetch, `JobCopies.svelte`.
+- No schema change; reuses the existing `role_fingerprint` cluster.

--- a/openspec/changes/job-cluster-copies/specs/job-cluster-copies/spec.md
+++ b/openspec/changes/job-cluster-copies/specs/job-cluster-copies/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Role-cluster copies are listable from a job
+
+The system SHALL expose `GET /jobs/:slug/copies` returning the OPEN postings sharing the
+addressed job's role cluster (`company_slug` + `role_fingerprint`), each carrying its
+location, apply URL, and public slug, ordered by location and paginated. The anchor job
+itself is included. A job whose fingerprint is empty clusters with no one and returns an
+empty list. The endpoint is public.
+
+#### Scenario: Copies of a collapsed role list every open city
+
+- **WHEN** a client requests the copies of a canonical job whose cluster has N open
+  postings across cities
+- **THEN** the response lists all N, each with its own location and apply URL, ordered
+  by location
+
+#### Scenario: A closed posting and unrelated roles are excluded
+
+- **WHEN** the cluster has a closed member and the company has other unrelated roles
+- **THEN** neither appears in the copies list
+
+### Requirement: The detail page shows the openings-by-location section
+
+The job detail page SHALL render an "N openings across locations" section listing the
+copies with links, shown only when the role has more than one open copy, and degrading
+to nothing when the list is empty or the fetch fails.
+
+#### Scenario: Mass-posted role shows the section
+
+- **WHEN** a job's role cluster has multiple open copies
+- **THEN** the detail page shows the openings-by-location list linking to each city

--- a/openspec/changes/job-cluster-copies/tasks.md
+++ b/openspec/changes/job-cluster-copies/tasks.md
@@ -1,0 +1,9 @@
+## 1. Backend
+
+- [x] 1.1 `ListRoleClusterCopies` query (open cluster members by location) + sqlc; integration test.
+- [x] 1.2 `JobCopies` handler + `/jobs/:slug/copies` route.
+
+## 2. Frontend
+
+- [x] 2.1 `getJobCopies` API client + `JobCopy` type.
+- [x] 2.2 Detail loader parallel fetch (degrade to []) + `JobCopies.svelte` section on the page.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -172,9 +172,13 @@ export function createApi(
   }
 
   /** The open postings sharing this job's role cluster — the "openings across cities"
-   *  list under a collapsed role. Each copy keeps its own location and apply URL. */
-  async function getJobCopies(slug: string): Promise<JobCopy[]> {
-    return requestData<JobCopy[]>(`/api/v1/jobs/${slug}/copies`);
+   *  list under a collapsed role. `total` is the whole cluster's open size (pre-limit),
+   *  so the header stays accurate when `copies` is a capped page. */
+  async function getJobCopies(slug: string): Promise<{ copies: JobCopy[]; total: number }> {
+    const res = await request<{ data: JobCopy[]; meta: { total: number } }>(
+      `/api/v1/jobs/${slug}/copies`,
+    );
+    return { copies: res.data, total: res.meta?.total ?? res.data.length };
   }
 
   /** How well the job addressed by `slug` is covered by the caller's profile skills:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -65,6 +65,15 @@ export interface SitemapEntry {
   updated_at: string;
 }
 
+/** One posting in a role cluster — a single city's opening under a collapsed role
+ *  (see the /jobs/:slug/copies endpoint). Each keeps its own location and apply URL. */
+export interface JobCopy {
+  public_slug: string;
+  location: string;
+  apply_url: string;
+  posted_at: string | null;
+}
+
 /** A non-2xx API response. Carries the HTTP status so callers can branch on it
  *  (e.g. 401 invalid credentials, 409 email taken) instead of parsing strings.
  *  `message` is the backend's `{ "error": msg }` text when present, so logs and
@@ -160,6 +169,12 @@ export function createApi(
    *  renders them; the source job is excluded by the backend. */
   async function getSimilarJobs(slug: string): Promise<Job[]> {
     return requestData<Job[]>(`/api/v1/jobs/${slug}/similar`);
+  }
+
+  /** The open postings sharing this job's role cluster — the "openings across cities"
+   *  list under a collapsed role. Each copy keeps its own location and apply URL. */
+  async function getJobCopies(slug: string): Promise<JobCopy[]> {
+    return requestData<JobCopy[]>(`/api/v1/jobs/${slug}/copies`);
   }
 
   /** How well the job addressed by `slug` is covered by the caller's profile skills:
@@ -697,6 +712,7 @@ export function createApi(
     listJobs,
     getJob,
     getSimilarJobs,
+    getJobCopies,
     getJobMatch,
     getJobFit,
     runJobFit,

--- a/web/src/lib/components/JobCopies.svelte
+++ b/web/src/lib/components/JobCopies.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import type { JobCopy } from '$lib/api';
 
-  // The per-city openings folded under this collapsed role. Only worth a section when
-  // there is more than one (a genuinely mass-posted role); a single opening is just the
-  // job itself.
-  let { copies }: { copies: JobCopy[] } = $props();
+  // The per-city openings folded under this collapsed role. `copies` is a capped page;
+  // `total` is the whole cluster's open size. Only worth a section for a genuinely
+  // mass-posted role (more than one opening).
+  let { copies, total }: { copies: JobCopy[]; total: number } = $props();
 </script>
 
-{#if copies.length > 1}
+{#if total > 1}
   <section class="mt-10">
-    <h2 class="mb-4 text-lg font-semibold">{copies.length} openings across locations</h2>
+    <h2 class="mb-4 text-lg font-semibold">{total} openings across locations</h2>
     <ul class="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-100">
       {#each copies as copy (copy.public_slug)}
         <li>

--- a/web/src/lib/components/JobCopies.svelte
+++ b/web/src/lib/components/JobCopies.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { JobCopy } from '$lib/api';
+
+  // The per-city openings folded under this collapsed role. Only worth a section when
+  // there is more than one (a genuinely mass-posted role); a single opening is just the
+  // job itself.
+  let { copies }: { copies: JobCopy[] } = $props();
+</script>
+
+{#if copies.length > 1}
+  <section class="mt-10">
+    <h2 class="mb-4 text-lg font-semibold">{copies.length} openings across locations</h2>
+    <ul class="divide-y divide-gray-100 overflow-hidden rounded-lg border border-gray-100">
+      {#each copies as copy (copy.public_slug)}
+        <li>
+          <a
+            href={`/jobs/${copy.public_slug}`}
+            class="flex items-center justify-between px-4 py-2.5 text-sm hover:bg-gray-50"
+          >
+            <span class="text-gray-800">{copy.location || 'Location not specified'}</span>
+            <span class="text-xs text-gray-400">View →</span>
+          </a>
+        </li>
+      {/each}
+    </ul>
+  </section>
+{/if}

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -15,12 +15,15 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
   //
   // Similar jobs are a non-essential discovery aid: a failure (search disabled,
   // no neighbours yet) must not break the page, so it degrades to an empty list.
-  const [job, similar] = await Promise.all([
+  const [job, similar, copies] = await Promise.all([
     api.getJob(params.slug).catch((e) => {
       if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
       throw e;
     }),
     api.getSimilarJobs(params.slug).catch(() => []),
+    // The "openings across cities" list for a collapsed role. Non-essential and only
+    // meaningful for a mass-posted role, so it degrades to an empty list on failure.
+    api.getJobCopies(params.slug).catch(() => []),
   ]);
-  return { job, similar };
+  return { job, similar, copies };
 };

--- a/web/src/routes/jobs/[slug]/+page.server.ts
+++ b/web/src/routes/jobs/[slug]/+page.server.ts
@@ -15,15 +15,15 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
   //
   // Similar jobs are a non-essential discovery aid: a failure (search disabled,
   // no neighbours yet) must not break the page, so it degrades to an empty list.
-  const [job, similar, copies] = await Promise.all([
+  const [job, similar, copiesResult] = await Promise.all([
     api.getJob(params.slug).catch((e) => {
       if (e instanceof ApiError && e.status === 404) error(404, 'Job not found');
       throw e;
     }),
     api.getSimilarJobs(params.slug).catch(() => []),
     // The "openings across cities" list for a collapsed role. Non-essential and only
-    // meaningful for a mass-posted role, so it degrades to an empty list on failure.
-    api.getJobCopies(params.slug).catch(() => []),
+    // meaningful for a mass-posted role, so it degrades to empty on failure.
+    api.getJobCopies(params.slug).catch(() => ({ copies: [], total: 0 })),
   ]);
-  return { job, similar, copies };
+  return { job, similar, copies: copiesResult.copies, copiesTotal: copiesResult.total };
 };

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { page } from '$app/state';
+  import JobCopies from '$lib/components/JobCopies.svelte';
   import JobRow from '$lib/components/JobRow.svelte';
   import JobView from '$lib/components/JobView.svelte';
   import Seo from '$lib/components/Seo.svelte';
@@ -41,6 +42,8 @@
 
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <JobView job={data.job} />
+
+  <JobCopies copies={data.copies} />
 
   {#if data.similar.length > 0}
     <section class="mt-10">

--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -43,7 +43,7 @@
 <div class="mx-auto w-full max-w-6xl px-4 py-6">
   <JobView job={data.job} />
 
-  <JobCopies copies={data.copies} />
+  <JobCopies copies={data.copies} total={data.copiesTotal} />
 
   {#if data.similar.length > 0}
     <section class="mt-10">


### PR DESCRIPTION
## Why
The content-dedup collapse hides a role cluster's reposts behind one canonical card and shows an openings count ("929 open copies"), but there was no way to SEE the copies. For a mass-posted role (Lowe's Cashier across 1251 stores, T-Bank Представитель across cities) a seeker wants their own city — each copy keeps its location + apply URL but was only reachable by an unknown slug.

## What
- `GET /api/v1/jobs/:slug/copies` → the open postings sharing the job's role cluster (`company_slug` + `role_fingerprint`), each with location, apply URL, public slug, ordered by location, paginated. Returns `meta.total` (whole cluster size via `COUNT(*) OVER()`) so the header is accurate even when the list is a capped page. Public read, like `/jobs/:slug/similar`.
- Detail page renders an "N openings across locations" section (`JobCopies.svelte`), shown only for a genuinely mass-posted role. SSR, degrades to nothing on failure.
- Reuses the existing `role_fingerprint` cluster + `jobs_open_role_cluster_idx`; no schema change.

## Verification
- Integration test: cluster listing, location order, closed/unrelated exclusion, empty-fingerprint anchor → empty, accurate `total`. `go build`/`vet`/`-tags=integration` green; `npm run check` 0 errors. Reviewed (query scoping, param safety, SSR degrade) — Ready; header-count fix applied.

OpenSpec change: `job-cluster-copies`. Follow-up to the content-dedup collapse (#598/#602).