### PR TITLE
feat(dedup): suppress aggregator postings duplicated by a first-party ATS

### DIFF
--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -419,6 +419,11 @@ func recomputeRoleDuplicates(ctx context.Context, q *db.Queries) (int64, error) 
 // and lock-scoped exactly like recomputeRoleDuplicates: a per-company failure is logged
 // and skipped so it never starves the rest or blocks the reindex.
 func suppressAggregatorDuplicates(ctx context.Context, q *db.Queries) (int64, error) {
+	// The aggregator set comes from the registry markers. usajobs is the one adapter
+	// sources.All only registers when USAJOBS_API_KEY is set, so a reindex without that
+	// key classifies existing usajobs rows as ATS. That is harmless here: federal postings
+	// have no corporate ATS twin, so they are never suppressed either way and would only
+	// ever be a target on an (essentially impossible) exact company+title+country collision.
 	aggregators := sources.AggregatorProviders(sources.All(nil))
 	companies, err := q.CompaniesWithAggregatorPostings(ctx, aggregators)
 	if err != nil {

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
 	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/sources"
 	"github.com/strelov1/freehire/internal/worker"
 )
 
@@ -121,6 +122,16 @@ func run() int {
 		log.Printf("reindex: recompute role duplicates (continuing with prior markers): %v", err)
 	} else if n > 0 {
 		log.Printf("reindex: recomputed role duplicates (%d rows re-marked)", n)
+	}
+
+	// Then suppress aggregator postings that duplicate a first-party ATS posting, so the
+	// aggregator copy drops out of this rebuild (and out of embedding/enrichment). Run
+	// AFTER the role recompute so ATS reposts have collapsed to their canon first. Same
+	// per-company, best-effort discipline as the role pass.
+	if n, err := suppressAggregatorDuplicates(ctx, q); err != nil {
+		log.Printf("reindex: suppress aggregator duplicates (continuing with prior markers): %v", err)
+	} else if n > 0 {
+		log.Printf("reindex: suppressed aggregator duplicates (%d rows re-marked)", n)
 	}
 
 	// --since is a delta into the LIVE index in place: a partial set cannot be
@@ -388,6 +399,39 @@ func recomputeRoleDuplicates(ctx context.Context, q *db.Queries) (int64, error) 
 		// Companies are independent, so one failure (e.g. a statement timeout on an
 		// unusually large cluster) must not starve the rest — log-and-continue.
 		n, err := q.RecomputeRoleDuplicatesForCompany(ctx, c)
+		if err != nil {
+			failures++
+			lastErr = fmt.Errorf("company %q: %w", c, err)
+			continue
+		}
+		total += n
+	}
+	if failures > 0 {
+		return total, fmt.Errorf("%d/%d companies failed; last: %w", failures, len(companies), lastErr)
+	}
+	return total, nil
+}
+
+// suppressAggregatorDuplicates marks each open aggregator posting that duplicates a
+// first-party ATS posting (same company, normalized title, compatible country) as a
+// duplicate of that ATS row, one company at a time. Returns the total rows re-marked.
+// The aggregator set comes from the source registry's aggregator() markers. Best-effort
+// and lock-scoped exactly like recomputeRoleDuplicates: a per-company failure is logged
+// and skipped so it never starves the rest or blocks the reindex.
+func suppressAggregatorDuplicates(ctx context.Context, q *db.Queries) (int64, error) {
+	aggregators := sources.AggregatorProviders(sources.All(nil))
+	companies, err := q.CompaniesWithAggregatorPostings(ctx, aggregators)
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	var failures int
+	var lastErr error
+	for _, c := range companies {
+		n, err := q.SuppressAggregatorDuplicatesForCompany(ctx, db.SuppressAggregatorDuplicatesForCompanyParams{
+			Company:     c,
+			Aggregators: aggregators,
+		})
 		if err != nil {
 			failures++
 			lastErr = fmt.Errorf("company %q: %w", c, err)

--- a/internal/db/aggregator_dedup_integration_test.go
+++ b/internal/db/aggregator_dedup_integration_test.go
@@ -1,0 +1,267 @@
+//go:build integration
+
+// Integration tests for the cross-source aggregator suppression pass: per company, an
+// open aggregator posting is marked duplicate_of an open canonical ATS posting of the
+// same normalized title and compatible country, keeping the ATS row canonical. The
+// title normalization, country gate, candidate selection (never clobbering a role-pass
+// repost), and failover on close are SQL behaviors verifiable only against a real
+// Postgres.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// aggregators is the provider set treated as aggregators in these tests.
+var aggregators = []string{"himalayas", "gulftalent"}
+
+// atsJob builds an open ATS (non-aggregator) posting.
+func atsJob(externalID, title string, countries []string) UpsertJobParams {
+	p := ingestParams(externalID, title)
+	p.Source = "greenhouse"
+	p.Countries = countries
+	return p
+}
+
+// aggJob builds an open aggregator posting.
+func aggJob(externalID, title string, countries []string) UpsertJobParams {
+	p := ingestParams(externalID, title)
+	p.Source = "himalayas"
+	p.Countries = countries
+	return p
+}
+
+// suppressAggregators drives the pass per company, as cmd/ingest does.
+func suppressAggregators(t *testing.T, q *Queries) {
+	t.Helper()
+	ctx := context.Background()
+	companies, err := q.CompaniesWithAggregatorPostings(ctx, aggregators)
+	if err != nil {
+		t.Fatalf("companies with aggregator postings: %v", err)
+	}
+	for _, c := range companies {
+		if _, err := q.SuppressAggregatorDuplicatesForCompany(ctx, SuppressAggregatorDuplicatesForCompanyParams{
+			Company:     c,
+			Aggregators: aggregators,
+		}); err != nil {
+			t.Fatalf("suppress company %q: %v", c, err)
+		}
+	}
+}
+
+func mustUpsert(t *testing.T, q *Queries, p UpsertJobParams) {
+	t.Helper()
+	if _, err := q.UpsertJob(context.Background(), p); err != nil {
+		t.Fatalf("upsert %s: %v", p.ExternalID, err)
+	}
+}
+
+func TestSuppressAggregator_MarksAggregatorDuplicateOfATS(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	mustUpsert(t, q, atsJob("acme:ats", "Staff Engineer", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Staff Engineer", []string{"US"}))
+
+	suppressAggregators(t, q)
+
+	atsID, atsDup := dupOf(t, pool, "acme:ats")
+	if atsDup != -1 {
+		t.Errorf("ATS row duplicate_of = %d, want NULL (canonical)", atsDup)
+	}
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != atsID {
+		t.Errorf("aggregator duplicate_of = %d, want ATS %d", aggDup, atsID)
+	}
+
+	// Idempotent: a second run writes nothing new.
+	suppressAggregators(t, q)
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != atsID {
+		t.Errorf("after re-run aggregator duplicate_of = %d, want ATS %d", aggDup, atsID)
+	}
+}
+
+func TestSuppressAggregator_EmptyCountryStillMatches(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// The geography dictionary is sparse; an unresolved (empty) country must not veto.
+	mustUpsert(t, q, atsJob("acme:ats", "Data Scientist", nil))
+	mustUpsert(t, q, aggJob("acme:agg", "Data Scientist", []string{"AE"}))
+
+	suppressAggregators(t, q)
+
+	atsID, _ := dupOf(t, pool, "acme:ats")
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != atsID {
+		t.Errorf("aggregator duplicate_of = %d, want ATS %d (empty country must not veto)", aggDup, atsID)
+	}
+}
+
+func TestSuppressAggregator_DifferentCountryNotSuppressed(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// The 7-Eleven false-merge: same title, disjoint non-empty countries.
+	mustUpsert(t, q, atsJob("711:us", "Store Associate", []string{"US"}))
+	mustUpsert(t, q, aggJob("711:sg", "Store Associate", []string{"SG"}))
+
+	suppressAggregators(t, q)
+
+	if _, dup := dupOf(t, pool, "711:sg"); dup != -1 {
+		t.Errorf("aggregator across country duplicate_of = %d, want NULL (not suppressed)", dup)
+	}
+}
+
+func TestSuppressAggregator_NeverDemotesATS(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// Two ATS rows, no aggregator: the pass must touch nothing.
+	mustUpsert(t, q, atsJob("acme:ats1", "Backend Engineer", []string{"US"}))
+	mustUpsert(t, q, atsJob("acme:ats2", "Backend Engineer", []string{"US"}))
+
+	suppressAggregators(t, q)
+
+	if _, d := dupOf(t, pool, "acme:ats1"); d != -1 {
+		t.Errorf("ats1 duplicate_of = %d, want NULL", d)
+	}
+	if _, d := dupOf(t, pool, "acme:ats2"); d != -1 {
+		t.Errorf("ats2 duplicate_of = %d, want NULL (this pass never demotes an ATS row)", d)
+	}
+}
+
+func TestSuppressAggregator_TwoAggregatorsWithoutATSUntouched(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// Same title, both aggregators, no ATS twin: this pass suppresses neither
+	// (cross-aggregator collapse is the role-cluster pass's job).
+	p1 := aggJob("acme:h", "Product Manager", []string{"US"})
+	p2 := aggJob("acme:g", "Product Manager", []string{"US"})
+	p2.Source = "gulftalent"
+	mustUpsert(t, q, p1)
+	mustUpsert(t, q, p2)
+
+	suppressAggregators(t, q)
+
+	if _, d := dupOf(t, pool, "acme:h"); d != -1 {
+		t.Errorf("himalayas duplicate_of = %d, want NULL", d)
+	}
+	if _, d := dupOf(t, pool, "acme:g"); d != -1 {
+		t.Errorf("gulftalent duplicate_of = %d, want NULL", d)
+	}
+}
+
+func TestSuppressAggregator_ReleasesWhenATSTwinCloses(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	mustUpsert(t, q, atsJob("acme:ats", "SRE", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "SRE", []string{"US"}))
+	suppressAggregators(t, q)
+	atsID, _ := dupOf(t, pool, "acme:ats")
+	if _, d := dupOf(t, pool, "acme:agg"); d != atsID {
+		t.Fatalf("precondition: aggregator should be suppressed to ATS, got %d", d)
+	}
+
+	// The ATS twin closes; the aggregator copy must un-suppress and re-enter surfaces.
+	if _, err := pool.Exec(ctx, "UPDATE jobs SET closed_at = now() WHERE external_id = $1", "acme:ats"); err != nil {
+		t.Fatalf("close ATS twin: %v", err)
+	}
+	suppressAggregators(t, q)
+
+	if _, d := dupOf(t, pool, "acme:agg"); d != -1 {
+		t.Errorf("after ATS twin closed, aggregator duplicate_of = %d, want NULL (released)", d)
+	}
+}
+
+func TestSuppressedAggregator_HiddenFromListAndEnrichmentButServedBySlug(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	mustUpsert(t, q, atsJob("acme:ats", "Platform Engineer", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Platform Engineer", []string{"US"}))
+	suppressAggregators(t, q)
+
+	atsID, _ := dupOf(t, pool, "acme:ats")
+	aggID, aggDup := dupOf(t, pool, "acme:agg")
+	if aggDup != atsID {
+		t.Fatalf("precondition: aggregator should be suppressed to ATS, got %d", aggDup)
+	}
+
+	// ListJobs returns the ATS canon, not the suppressed aggregator copy.
+	jobs, err := q.ListJobs(ctx, ListJobsParams{Limit: 100, Offset: 0})
+	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+	seen := map[int64]bool{}
+	for _, j := range jobs {
+		seen[j.ID] = true
+	}
+	if !seen[atsID] {
+		t.Errorf("ListJobs missing ATS canon %d", atsID)
+	}
+	if seen[aggID] {
+		t.Errorf("ListJobs returned suppressed aggregator %d, want it hidden", aggID)
+	}
+
+	// EnqueuePendingJobs enqueues the ATS canon, not the suppressed aggregator copy.
+	if _, err := q.EnqueuePendingJobs(ctx, EnqueuePendingJobsParams{TargetVersion: 1}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if !outboxHas(t, pool, atsID) {
+		t.Errorf("ATS canon %d not enqueued", atsID)
+	}
+	if outboxHas(t, pool, aggID) {
+		t.Errorf("suppressed aggregator %d enqueued, want it skipped", aggID)
+	}
+
+	// The suppressed copy is still fetchable by its public slug (direct link).
+	if _, err := q.GetJobBySlug(ctx, "pslug-acme:agg"); err != nil {
+		t.Errorf("GetJobBySlug for suppressed aggregator: %v", err)
+	}
+}
+
+// verify the driver only returns companies that actually have an open aggregator posting.
+func TestCompaniesWithAggregatorPostings_OnlyAggregatorCompanies(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	mustUpsert(t, q, aggJob("acme:agg", "Engineer", []string{"US"}))
+	atsOnly := atsJob("other:ats", "Engineer", []string{"US"})
+	atsOnly.CompanySlug = "other"
+	atsOnly.Company = "Other"
+	mustUpsert(t, q, atsOnly)
+
+	got, err := q.CompaniesWithAggregatorPostings(ctx, aggregators)
+	if err != nil {
+		t.Fatalf("driver: %v", err)
+	}
+	if !containsStr(got, "acme") {
+		t.Errorf("driver = %v, want it to include %q", got, "acme")
+	}
+	if containsStr(got, "other") {
+		t.Errorf("driver = %v, want it to exclude ATS-only company %q", got, "other")
+	}
+}
+
+func containsStr(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/db/aggregator_dedup_integration_test.go
+++ b/internal/db/aggregator_dedup_integration_test.go
@@ -11,6 +11,7 @@ package db
 
 import (
 	"context"
+	"slices"
 	"testing"
 )
 
@@ -249,19 +250,10 @@ func TestCompaniesWithAggregatorPostings_OnlyAggregatorCompanies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("driver: %v", err)
 	}
-	if !containsStr(got, "acme") {
+	if !slices.Contains(got, "acme") {
 		t.Errorf("driver = %v, want it to include %q", got, "acme")
 	}
-	if containsStr(got, "other") {
+	if slices.Contains(got, "other") {
 		t.Errorf("driver = %v, want it to exclude ATS-only company %q", got, "other")
 	}
-}
-
-func containsStr(ss []string, s string) bool {
-	for _, x := range ss {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -93,6 +93,37 @@ func (q *Queries) CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams
 	return result.RowsAffected(), nil
 }
 
+const companiesWithAggregatorPostings = `-- name: CompaniesWithAggregatorPostings :many
+SELECT DISTINCT company_slug FROM jobs
+WHERE closed_at IS NULL AND company_slug <> ''
+  AND source = ANY($1::text[])
+`
+
+// Company slugs with at least one OPEN aggregator posting — the drive list for the
+// cross-source aggregator suppression pass. An open aggregator row is a candidate whether
+// it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
+// covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
+// mirroring the role-duplicate recompute's lock discipline.
+func (q *Queries) CompaniesWithAggregatorPostings(ctx context.Context, aggregators []string) ([]string, error) {
+	rows, err := q.db.Query(ctx, companiesWithAggregatorPostings, aggregators)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var company_slug string
+		if err := rows.Scan(&company_slug); err != nil {
+			return nil, err
+		}
+		items = append(items, company_slug)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const companiesWithRoleClusters = `-- name: CompaniesWithRoleClusters :many
 SELECT company_slug FROM jobs
 WHERE closed_at IS NULL AND company_slug <> '' AND role_fingerprint IS NOT NULL AND role_fingerprint <> ''
@@ -1352,6 +1383,81 @@ func (q *Queries) SetJobEnrichment(ctx context.Context, arg SetJobEnrichmentPara
 		arg.ID,
 	)
 	return err
+}
+
+const suppressAggregatorDuplicatesForCompany = `-- name: SuppressAggregatorDuplicatesForCompany :execrows
+WITH ats AS (
+    SELECT jobs.id,
+           btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           jobs.countries
+    FROM jobs
+    WHERE jobs.company_slug = $1
+      AND jobs.closed_at IS NULL AND jobs.duplicate_of IS NULL
+      AND NOT (jobs.source = ANY($2::text[]))
+),
+agg AS (
+    SELECT a.id,
+           btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           a.countries
+    FROM jobs a
+    WHERE a.company_slug = $1
+      AND a.closed_at IS NULL
+      AND a.source = ANY($2::text[])
+      AND (
+          a.duplicate_of IS NULL
+          OR EXISTS (
+              SELECT 1 FROM jobs p
+              WHERE p.id = a.duplicate_of
+                AND NOT (p.source = ANY($2::text[]))
+          )
+      )
+),
+target AS (
+    -- LEFT JOIN + MIN (not a correlated subquery) so the match is a hash join on ntitle,
+    -- O(agg + ats) instead of O(agg * ats) — a company with thousands of same-title rows
+    -- (a hotel chain's ATS + its aggregator copies) would otherwise scan quadratically.
+    -- No match (including an empty ntitle, excluded in the ON) yields NULL, which releases
+    -- a previously-suppressed row whose ATS twin has closed.
+    SELECT a.id, MIN(t.id) AS new_dup
+    FROM agg a
+    LEFT JOIN ats t
+      ON t.ntitle = a.ntitle
+     AND a.ntitle <> ''
+     AND (t.countries && a.countries
+          OR cardinality(t.countries) = 0
+          OR cardinality(a.countries) = 0)
+    GROUP BY a.id
+)
+UPDATE jobs j
+SET duplicate_of = t.new_dup,
+    updated_at   = now()
+FROM target t
+WHERE j.id = t.id
+  AND j.duplicate_of IS DISTINCT FROM t.new_dup
+`
+
+type SuppressAggregatorDuplicatesForCompanyParams struct {
+	Company     string   `json:"company"`
+	Aggregators []string `json:"aggregators"`
+}
+
+// The per-company slice of the cross-source aggregator suppression. An open aggregator
+// posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
+// same company, equal normalized title, and compatible country (countries overlap, or
+// either side empty — the geography dictionary is sparse, so an unresolved side must not
+// veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
+// are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
+// by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
+// left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
+// its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
+// target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+// RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
+func (q *Queries) SuppressAggregatorDuplicatesForCompany(ctx context.Context, arg SuppressAggregatorDuplicatesForCompanyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, suppressAggregatorDuplicatesForCompany, arg.Company, arg.Aggregators)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const touchJob = `-- name: TouchJob :one

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -89,6 +89,12 @@ type Querier interface {
 	// touched. The caller passes the crawled slugs and owns the grace window (cutoff =
 	// now() - window), so neither a failed nor a partial crawl mass-closes a catalogue.
 	CloseUnseenJobs(ctx context.Context, arg CloseUnseenJobsParams) (int64, error)
+	// Company slugs with at least one OPEN aggregator posting — the drive list for the
+	// cross-source aggregator suppression pass. An open aggregator row is a candidate whether
+	// it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
+	// covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
+	// mirroring the role-duplicate recompute's lock discipline.
+	CompaniesWithAggregatorPostings(ctx context.Context, aggregators []string) ([]string, error)
 	// Company slugs whose role-duplicate markers may need recomputing: a company with an
 	// open role cluster (>1 posting sharing a fingerprint) to collapse, OR one still
 	// carrying an open marker that may need clearing (its cluster shrank). The recompute
@@ -649,6 +655,18 @@ type Querier interface {
 	// self-corrects on the next real change, so this is accepted over threading the exact
 	// embedded hash through a nullable text[] per batch.
 	StampSemanticEmbeddedBatch(ctx context.Context, arg StampSemanticEmbeddedBatchParams) error
+	// The per-company slice of the cross-source aggregator suppression. An open aggregator
+	// posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
+	// same company, equal normalized title, and compatible country (countries overlap, or
+	// either side empty — the geography dictionary is sparse, so an unresolved side must not
+	// veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
+	// are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
+	// by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
+	// left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
+	// its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
+	// target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+	// RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
+	SuppressAggregatorDuplicatesForCompany(ctx context.Context, arg SuppressAggregatorDuplicatesForCompanyParams) (int64, error)
 	// Rebuild the companies catalogue from jobs. The companies table is derivable
 	// from jobs (slug = company_slug, name = company), so after a slug-builder change
 	// re-keys jobs, this re-keys companies to match. DISTINCT ON collapses a slug's

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -335,6 +335,77 @@ FROM target t
 WHERE j.id = t.id
   AND j.duplicate_of IS DISTINCT FROM t.new_dup;
 
+-- name: CompaniesWithAggregatorPostings :many
+-- Company slugs with at least one OPEN aggregator posting — the drive list for the
+-- cross-source aggregator suppression pass. An open aggregator row is a candidate whether
+-- it still needs suppressing OR needs releasing (its ATS twin closed), so one predicate
+-- covers both. Processed one company at a time (SuppressAggregatorDuplicatesForCompany),
+-- mirroring the role-duplicate recompute's lock discipline.
+SELECT DISTINCT company_slug FROM jobs
+WHERE closed_at IS NULL AND company_slug <> ''
+  AND source = ANY(sqlc.arg(aggregators)::text[]);
+
+-- name: SuppressAggregatorDuplicatesForCompany :execrows
+-- The per-company slice of the cross-source aggregator suppression. An open aggregator
+-- posting is marked duplicate_of an open CANONICAL ATS (non-aggregator) posting of the
+-- same company, equal normalized title, and compatible country (countries overlap, or
+-- either side empty — the geography dictionary is sparse, so an unresolved side must not
+-- veto). The ATS row is never touched, so it stays canonical. Candidate aggregator rows
+-- are those that are canonical OR already point at a non-aggregator row (i.e. suppressed
+-- by THIS pass) — an aggregator repost pointed at another aggregator by the role pass is
+-- left alone. A candidate with no ATS twin resolves to NULL, so a closed twin releases
+-- its aggregator copy back into search/embedding/enrichment. min(id) picks a stable
+-- target; the IS DISTINCT FROM guard makes re-runs cheap and idempotent. Run AFTER
+-- RecomputeRoleDuplicatesForCompany so ATS reposts have already collapsed to their canon.
+WITH ats AS (
+    SELECT jobs.id,
+           btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           jobs.countries
+    FROM jobs
+    WHERE jobs.company_slug = sqlc.arg(company)
+      AND jobs.closed_at IS NULL AND jobs.duplicate_of IS NULL
+      AND NOT (jobs.source = ANY(sqlc.arg(aggregators)::text[]))
+),
+agg AS (
+    SELECT a.id,
+           btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           a.countries
+    FROM jobs a
+    WHERE a.company_slug = sqlc.arg(company)
+      AND a.closed_at IS NULL
+      AND a.source = ANY(sqlc.arg(aggregators)::text[])
+      AND (
+          a.duplicate_of IS NULL
+          OR EXISTS (
+              SELECT 1 FROM jobs p
+              WHERE p.id = a.duplicate_of
+                AND NOT (p.source = ANY(sqlc.arg(aggregators)::text[]))
+          )
+      )
+),
+target AS (
+    -- LEFT JOIN + MIN (not a correlated subquery) so the match is a hash join on ntitle,
+    -- O(agg + ats) instead of O(agg * ats) — a company with thousands of same-title rows
+    -- (a hotel chain's ATS + its aggregator copies) would otherwise scan quadratically.
+    -- No match (including an empty ntitle, excluded in the ON) yields NULL, which releases
+    -- a previously-suppressed row whose ATS twin has closed.
+    SELECT a.id, MIN(t.id) AS new_dup
+    FROM agg a
+    LEFT JOIN ats t
+      ON t.ntitle = a.ntitle
+     AND a.ntitle <> ''
+     AND (t.countries && a.countries
+          OR cardinality(t.countries) = 0
+          OR cardinality(a.countries) = 0)
+    GROUP BY a.id
+)
+UPDATE jobs j
+SET duplicate_of = t.new_dup,
+    updated_at   = now()
+FROM target t
+WHERE j.id = t.id
+  AND j.duplicate_of IS DISTINCT FROM t.new_dup;
+
 -- name: PropagateCollectionsToJobs :execrows
 -- Denormalize each company's curated-collection set onto its jobs, so the search
 -- facet (jobs.collections) reflects current membership. Run by cmd/import-collections

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -138,6 +138,20 @@ func SelfClosingProviders(reg map[string]Source) []string {
 	return out
 }
 
+// AggregatorProviders returns the sorted provider names in reg that aggregate postings
+// from many companies (see aggregator). The cross-source dedup pass uses this to tell an
+// aggregator copy (which may be suppressed) from a first-party ATS posting (which wins).
+func AggregatorProviders(reg map[string]Source) []string {
+	var out []string
+	for name, src := range reg {
+		if _, ok := src.(aggregator); ok {
+			out = append(out, name)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
 // FilterableProviders returns the sorted provider keys the source facet offers.
 // Passing a nil client is safe: Provider() and the marker assertions never touch the
 // transport.

--- a/internal/sources/source_test.go
+++ b/internal/sources/source_test.go
@@ -79,6 +79,20 @@ func TestFilterableProviders(t *testing.T) {
 	}
 }
 
+func TestAggregatorProvidersListsOnlyAggregators(t *testing.T) {
+	got := AggregatorProviders(reg(
+		fakeSource{"greenhouse"},         // board-based ATS → excluded
+		fakeBoardlessSource{"ozon"},      // single-company boardless (not aggregator) → excluded
+		fakeAggregatorSource{"jobstash"}, // aggregator → listed
+		fakeAggregatorSource{"himalayas"},
+	))
+
+	want := []string{"himalayas", "jobstash"}
+	if !slices.Equal(got, want) {
+		t.Errorf("AggregatorProviders() = %v, want %v", got, want)
+	}
+}
+
 func TestFilterableProvidersKeepsAggregatorsDropsSingleCompany(t *testing.T) {
 	got := filterableProviders(reg(
 		fakeSource{"greenhouse"},         // board-based → listed

--- a/openspec/changes/aggregator-ats-dedup/.openspec.yaml
+++ b/openspec/changes/aggregator-ats-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/aggregator-ats-dedup/design.md
+++ b/openspec/changes/aggregator-ats-dedup/design.md
@@ -1,0 +1,116 @@
+## Context
+
+Freehire already has a role-cluster repost dedup (`ingest-content-dedup`): per company,
+open postings sharing a `role_fingerprint` (`company_slug` + normalized title + normalized
+description) collapse to one canonical row via the `duplicate_of` column, and every active
+surface — job search / Meilisearch, semantic embedding, LLM enrichment, list / sitemap /
+company reads — filters `duplicate_of IS NULL`. Detail-by-slug and the
+`job-cluster-copies` endpoint deliberately still serve duplicates.
+
+That machinery is exactly what we want for aggregator suppression, but its **membership
+key is wrong for the cross-source case**. Because `role_fingerprint` includes the
+description, and aggregators rewrite/​truncate descriptions, an aggregator posting and its
+first-party ATS twin fingerprint differently and never share a cluster. On prod only ~115
+mixed clusters exist, yet ~9,442 open aggregator postings have an exact-title ATS twin in
+the same company and compatible country. Those 9,442 are indexed, embedded, and enriched
+as distinct jobs today.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Suppress an open aggregator posting when an open first-party ATS posting of the same
+  company, title, and compatible country exists, keeping the ATS copy canonical.
+- Reuse the existing `duplicate_of` column and every surface that already filters it — no
+  changes to search, embedding, enrichment, detail, or cluster-copies.
+- Safe by construction: never demote an ATS row, never merge across countries, never
+  merge aggregator↔aggregator.
+- No schema change, no migration.
+
+**Non-Goals:**
+- Fuzzy / partial title matching for aggregators that mangle titles (gulftalent's Marriott
+  copies). That is a separate, riskier follow-up.
+- Changing the role-cluster repost dedup or its `role_fingerprint`.
+- Skipping ingest of the aggregator posting entirely (we store it; it stays reachable by
+  link and as a cluster copy).
+
+## Decisions
+
+### Decision: A separate suppression pass, not a change to `role_fingerprint`
+
+Add a new per-company query `SuppressAggregatorDuplicatesForCompany`, run at ingest right
+after `RecomputeRoleDuplicatesForCompany`. It sets `duplicate_of` on an open aggregator
+row to the id of an open canonical ATS row (`duplicate_of IS NULL`) of the same
+`company_slug`, equal normalized title, and compatible country.
+
+- **Alternative — loosen `role_fingerprint` to drop the description:** rejected. The
+  description is what keeps the repost pass from over-merging genuinely distinct roles
+  within a source; dropping it would regress repost behavior. The two passes have
+  different safety needs and stay separate.
+- **Alternative — precedence flip (`MIN(id)` → ATS-first) in the existing pass:**
+  rejected as insufficient. It would only reorder the ~46 already-mixed clusters; the
+  9,442 real duplicates never cluster in the first place, so a canon reorder does nothing
+  for them.
+
+### Decision: Normalized title equality, exact (no suffix strip, no entity decode)
+
+Reuse the role pass's title normalization (lowercase, non-alphanumeric runs → single
+space). No suffix stripping after `-`/`|` and no HTML-entity decoding in this slice — that
+edges into fuzzy matching and belongs to the follow-up. Exact-title already covers the
+clean aggregators (himalayas ~65% exact title match, the Danish portals) and the
+exact-matching subset of gulftalent.
+
+### Decision: Country compatibility gate = array overlap OR either side empty
+
+`a.countries && b.countries OR cardinality(a.countries)=0 OR cardinality(b.countries)=0`.
+This blocks the 7-Eleven false-merge (Singapore aggregator posting vs US ATS posting of
+the same title) while still matching when geography is unresolved on one side (the
+`countries` dictionary is deliberately sparse and "never guesses", so an empty array must
+not veto a real match). Country, not city/region, is the right granularity: an aggregator
+and an ATS may phrase the city differently but agree on the country.
+
+### Decision: Aggregator set sourced from the Go registry, passed as a query param
+
+Add `sources.AggregatorProviders() []string`, derived from the existing `aggregator()`
+interface markers (single source of truth). The ingest caller passes it into the query as
+a `text[]` param. No persisted `source_is_aggregator` column, so no migration and no
+backfill; the set updates automatically when a source's marker changes.
+
+### Decision: Idempotent, failover-safe re-evaluation
+
+Follow the existing recompute's shape: compute the desired `duplicate_of` for each open
+aggregator row and write only where it `IS DISTINCT FROM` the current value. A suppressed
+row whose ATS twin has closed finds no open canonical ATS match and is set back to NULL,
+re-entering the active surfaces. Ordering matters: run the role-cluster recompute first
+(so ATS reposts collapse to their own canonical row), then this pass (so aggregator rows
+point at the ATS *canonical* row, never at an ATS duplicate).
+
+## Risks / Trade-offs
+
+- **Over-suppression from a coincidental same title in the same company+country** (e.g.
+  two genuinely distinct "Software Engineer" openings, one on the ATS, one on the
+  aggregator) → Mitigated but not eliminated by the exact-title + country gate. Acceptable
+  for this slice: the aggregator copy is only hidden from search/embedding/enrichment, is
+  never deleted, is still reachable by link and as a cluster copy, and un-suppresses if the
+  ATS twin closes. This mirrors the risk profile the role-cluster pass already accepts.
+- **Aggregator with mangled titles is missed** (gulftalent's suffix-stripped Marriott
+  copies) → Out of scope by design; the exact-title key simply does not match them, so
+  they stay independent — no regression, just not-yet-caught. Follow-up fuzzy slice.
+- **Cross-pass interaction** → The role-cluster pass and this pass both write
+  `duplicate_of`. Running role-cluster first and pointing only at canonical (`duplicate_of
+  IS NULL`) ATS rows keeps them consistent; both use the `IS DISTINCT FROM` guard so their
+  combined re-run stays idempotent.
+
+## Migration Plan
+
+No schema migration. Ships as code only. On first ingest run per company after deploy, the
+new pass suppresses the matching aggregator copies; they drop out of the search index on
+the next reindex and out of embedding/enrichment on the next worker pass. Rollback is
+reverting the code — a later ingest run clears the `duplicate_of` values this pass set
+(they fail the `IS DISTINCT FROM` guard against a no-longer-computed target only if the
+pass runs; on pure rollback the values persist harmlessly until the role pass or a manual
+clear touches them, and they remain valid duplicates regardless).
+
+## Open Questions
+
+- None blocking. The fuzzy-title follow-up (gulftalent) is tracked as a separate change,
+  not an open question here.

--- a/openspec/changes/aggregator-ats-dedup/design.md
+++ b/openspec/changes/aggregator-ats-dedup/design.md
@@ -37,9 +37,11 @@ as distinct jobs today.
 
 ### Decision: A separate suppression pass, not a change to `role_fingerprint`
 
-Add a new per-company query `SuppressAggregatorDuplicatesForCompany`, run at ingest right
-after `RecomputeRoleDuplicatesForCompany`. It sets `duplicate_of` on an open aggregator
-row to the id of an open canonical ATS row (`duplicate_of IS NULL`) of the same
+Add a new per-company query `SuppressAggregatorDuplicatesForCompany` (with a
+`CompaniesWithAggregatorPostings` driver), run in the reindex reconcile right after
+`recomputeRoleDuplicates` — the reindex is where `duplicate_of` markers are already
+refreshed and the search index is rebuilt from them. It sets `duplicate_of` on an open
+aggregator row to the id of an open canonical ATS row (`duplicate_of IS NULL`) of the same
 `company_slug`, equal normalized title, and compatible country.
 
 - **Alternative — loosen `role_fingerprint` to drop the description:** rejected. The
@@ -70,19 +72,25 @@ and an ATS may phrase the city differently but agree on the country.
 
 ### Decision: Aggregator set sourced from the Go registry, passed as a query param
 
-Add `sources.AggregatorProviders() []string`, derived from the existing `aggregator()`
-interface markers (single source of truth). The ingest caller passes it into the query as
+Add `sources.AggregatorProviders(reg) []string`, derived from the existing `aggregator()`
+interface markers (single source of truth). The reindex caller passes it into the query as
 a `text[]` param. No persisted `source_is_aggregator` column, so no migration and no
 backfill; the set updates automatically when a source's marker changes.
 
 ### Decision: Idempotent, failover-safe re-evaluation
 
-Follow the existing recompute's shape: compute the desired `duplicate_of` for each open
-aggregator row and write only where it `IS DISTINCT FROM` the current value. A suppressed
-row whose ATS twin has closed finds no open canonical ATS match and is set back to NULL,
-re-entering the active surfaces. Ordering matters: run the role-cluster recompute first
-(so ATS reposts collapse to their own canonical row), then this pass (so aggregator rows
-point at the ATS *canonical* row, never at an ATS duplicate).
+Follow the existing recompute's shape: compute the desired `duplicate_of` for each
+candidate aggregator row and write only where it `IS DISTINCT FROM` the current value. A
+suppressed row whose ATS twin has closed finds no open canonical ATS match and is set back
+to NULL, re-entering the active surfaces. Ordering matters: run the role-cluster recompute
+first (so ATS reposts collapse to their own canonical row), then this pass (so aggregator
+rows point at the ATS *canonical* row, never at an ATS duplicate).
+
+Candidate rows are open aggregator rows that are **canonical OR already point at a
+non-aggregator row** (i.e. suppressed by this pass). An aggregator row the role pass
+pointed at *another aggregator* (a cross-aggregator repost) is excluded, so this pass never
+clobbers the role pass's decision — the two passes own disjoint sets of `duplicate_of`
+edges.
 
 ## Risks / Trade-offs
 
@@ -102,13 +110,12 @@ point at the ATS *canonical* row, never at an ATS duplicate).
 
 ## Migration Plan
 
-No schema migration. Ships as code only. On first ingest run per company after deploy, the
-new pass suppresses the matching aggregator copies; they drop out of the search index on
-the next reindex and out of embedding/enrichment on the next worker pass. Rollback is
-reverting the code — a later ingest run clears the `duplicate_of` values this pass set
-(they fail the `IS DISTINCT FROM` guard against a no-longer-computed target only if the
-pass runs; on pure rollback the values persist harmlessly until the role pass or a manual
-clear touches them, and they remain valid duplicates regardless).
+No schema migration. Ships as code only. The suppression runs inside the reindex, so the
+first reindex after deploy suppresses the matching aggregator copies and rebuilds the
+index without them; they drop out of embedding/enrichment on the next worker pass (whose
+enqueue already filters `duplicate_of`). Rollback is reverting the code — the values this
+pass set persist harmlessly until a run touches them, and they remain valid duplicates
+regardless.
 
 ## Open Questions
 

--- a/openspec/changes/aggregator-ats-dedup/proposal.md
+++ b/openspec/changes/aggregator-ats-dedup/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+Aggregator sources (himalayas, gulftalent, the national portals, …) re-list jobs that
+we already ingest first-hand from the company's own ATS. The existing repost dedup
+(`ingest-content-dedup`) does NOT catch these: its `role_fingerprint` includes the
+description, and aggregators rewrite the description, so an aggregator copy and its ATS
+twin land in different clusters and are never collapsed. Measured on prod: ~9,442 open
+aggregator postings have an exact-title ATS twin in the same company and compatible
+country — each is currently indexed in Meilisearch, embedded, and LLM-enriched as if it
+were a distinct job. That is wasted compute and a polluted search index for postings we
+already serve, better, from the first-party source.
+
+## What Changes
+
+- A new ingest-time suppression pass marks an open **aggregator** posting as
+  `duplicate_of` an open **ATS** posting when they share the same `company_slug`, the
+  same normalized title, and a compatible country (country arrays overlap, or either is
+  empty). The ATS posting is always the survivor; the aggregator copy is the duplicate.
+- Suppressed aggregator copies inherit the existing `duplicate_of` treatment with **no
+  downstream changes**: excluded from search/Meilisearch, from semantic embedding (and
+  their vector removed), and from LLM enrichment — but still stored and reachable by
+  their public slug (direct link), and still listed by the `job-cluster-copies` endpoint.
+- The pass is **safe by construction**: only aggregator rows are ever suppressed (an ATS
+  row is never demoted), only against an open canonical ATS row, and only within a
+  compatible country (so a Singapore aggregator posting is never suppressed by a
+  same-titled US ATS posting — the 7-Eleven false-merge). It never merges aggregator↔
+  aggregator or ATS↔ATS; that stays the job of `role_fingerprint`.
+- If the ATS twin later closes, the aggregator copy un-suppresses on the next ingest run
+  and re-enters search/embedding/enrichment (idempotent failover, mirroring the existing
+  role-duplicate recompute).
+- No schema change: the aggregator/ATS distinction is sourced from
+  `sources.AggregatorProviders()` (derived from the existing `aggregator()` registry
+  markers) and passed into the query.
+
+Scope is the **exact-title** key only. Aggregators that mangle titles (gulftalent's
+Marriott copies drop the property suffix and leave `&amp;` undecoded) are a separate,
+riskier fuzzy-title follow-up, out of scope here.
+
+## Capabilities
+
+### New Capabilities
+- `aggregator-ats-dedup`: an ingest-time pass that suppresses an aggregator job posting
+  as a duplicate of a first-party ATS posting of the same company, title, and country,
+  keeping the ATS copy canonical.
+
+### Modified Capabilities
+<!-- none — the duplicate_of exclusions (search, embed, enrich, by-slug, cluster-copies)
+     already treat every duplicate_of row uniformly and are unchanged. -->
+
+## Impact
+
+- `internal/sources/` — add `AggregatorProviders()` enumerating the registry's
+  `aggregator()`-marked providers.
+- `internal/db/queries/jobs.sql` — new `SuppressAggregatorDuplicatesForCompany` query;
+  regenerate sqlc.
+- `cmd/ingest/` — invoke the new suppression pass per company alongside the existing
+  role-duplicate recompute (repost-collapse first, then cross-source suppression).
+- No migration, no new column; reuses the existing `duplicate_of` column and every
+  surface that already filters it.

--- a/openspec/changes/aggregator-ats-dedup/proposal.md
+++ b/openspec/changes/aggregator-ats-dedup/proposal.md
@@ -12,10 +12,11 @@ already serve, better, from the first-party source.
 
 ## What Changes
 
-- A new ingest-time suppression pass marks an open **aggregator** posting as
-  `duplicate_of` an open **ATS** posting when they share the same `company_slug`, the
-  same normalized title, and a compatible country (country arrays overlap, or either is
-  empty). The ATS posting is always the survivor; the aggregator copy is the duplicate.
+- A new suppression pass — run in the reindex reconcile, immediately after the existing
+  role-duplicate recompute — marks an open **aggregator** posting as `duplicate_of` an
+  open **ATS** posting when they share the same `company_slug`, the same normalized title,
+  and a compatible country (country arrays overlap, or either is empty). The ATS posting
+  is always the survivor; the aggregator copy is the duplicate.
 - Suppressed aggregator copies inherit the existing `duplicate_of` treatment with **no
   downstream changes**: excluded from search/Meilisearch, from semantic embedding (and
   their vector removed), and from LLM enrichment — but still stored and reachable by
@@ -25,7 +26,7 @@ already serve, better, from the first-party source.
   compatible country (so a Singapore aggregator posting is never suppressed by a
   same-titled US ATS posting — the 7-Eleven false-merge). It never merges aggregator↔
   aggregator or ATS↔ATS; that stays the job of `role_fingerprint`.
-- If the ATS twin later closes, the aggregator copy un-suppresses on the next ingest run
+- If the ATS twin later closes, the aggregator copy un-suppresses on the next reindex run
   and re-enters search/embedding/enrichment (idempotent failover, mirroring the existing
   role-duplicate recompute).
 - No schema change: the aggregator/ATS distinction is sourced from
@@ -39,9 +40,9 @@ riskier fuzzy-title follow-up, out of scope here.
 ## Capabilities
 
 ### New Capabilities
-- `aggregator-ats-dedup`: an ingest-time pass that suppresses an aggregator job posting
-  as a duplicate of a first-party ATS posting of the same company, title, and country,
-  keeping the ATS copy canonical.
+- `aggregator-ats-dedup`: a reindex-reconcile pass that suppresses an aggregator job
+  posting as a duplicate of a first-party ATS posting of the same company, title, and
+  country, keeping the ATS copy canonical.
 
 ### Modified Capabilities
 <!-- none — the duplicate_of exclusions (search, embed, enrich, by-slug, cluster-copies)
@@ -51,9 +52,10 @@ riskier fuzzy-title follow-up, out of scope here.
 
 - `internal/sources/` — add `AggregatorProviders()` enumerating the registry's
   `aggregator()`-marked providers.
-- `internal/db/queries/jobs.sql` — new `SuppressAggregatorDuplicatesForCompany` query;
-  regenerate sqlc.
-- `cmd/ingest/` — invoke the new suppression pass per company alongside the existing
-  role-duplicate recompute (repost-collapse first, then cross-source suppression).
+- `internal/db/queries/jobs.sql` — new `CompaniesWithAggregatorPostings` driver +
+  `SuppressAggregatorDuplicatesForCompany` per-company query; regenerate sqlc.
+- `cmd/reindex/` — invoke the new suppression pass per company immediately after the
+  existing `recomputeRoleDuplicates` (repost-collapse first, then cross-source
+  suppression).
 - No migration, no new column; reuses the existing `duplicate_of` column and every
   surface that already filters it.

--- a/openspec/changes/aggregator-ats-dedup/specs/aggregator-ats-dedup/spec.md
+++ b/openspec/changes/aggregator-ats-dedup/specs/aggregator-ats-dedup/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: An aggregator posting is suppressed when a first-party ATS twin exists
+
+The system SHALL, at ingest time, mark an open posting from an aggregator source as
+`duplicate_of` an open posting from a non-aggregator (ATS) source when both share the
+same `company_slug`, the same normalized title, and a compatible country. Two postings
+have a compatible country when their `countries` arrays overlap, or when either array is
+empty. The ATS posting SHALL remain canonical (its `duplicate_of` stays NULL); the
+aggregator posting SHALL become the duplicate. A source is an aggregator when its
+provider is in `sources.AggregatorProviders()`.
+
+Normalized title equality is lowercase with runs of non-alphanumeric characters collapsed
+to a single space (the same normalization the role-cluster pass uses), with no suffix
+stripping and no HTML-entity decoding.
+
+#### Scenario: Aggregator copy of an ATS job is suppressed
+
+- **WHEN** a company has an open ATS posting and an open aggregator posting with the same
+  normalized title and overlapping (or empty) countries
+- **THEN** the aggregator posting's `duplicate_of` points to the ATS posting, and the ATS
+  posting stays canonical
+
+#### Scenario: Same title in a different country is not suppressed
+
+- **WHEN** an aggregator posting and an ATS posting of the same company share a title but
+  their non-empty `countries` arrays do not overlap
+- **THEN** neither posting is suppressed by this pass
+
+#### Scenario: An ATS posting is never demoted by an aggregator twin
+
+- **WHEN** an aggregator posting and an ATS posting match on company, title, and country
+- **THEN** only the aggregator posting may be marked `duplicate_of`; the ATS posting is
+  never marked a duplicate of the aggregator posting
+
+#### Scenario: Two aggregator postings are not merged by this pass
+
+- **WHEN** two postings of the same company and title both come from aggregator sources
+  and no ATS twin exists
+- **THEN** this pass suppresses neither (cross-aggregator collapse stays the role-cluster
+  pass's responsibility)
+
+### Requirement: A suppressed aggregator posting is hidden from active surfaces but reachable by link
+
+The system SHALL treat a suppressed aggregator posting exactly as any other
+`duplicate_of` row: excluded from job search / the Meilisearch index, excluded from
+semantic embedding with any existing vector removed, and excluded from LLM enrichment,
+while remaining stored and served on its public detail page by slug and listed among a
+role cluster's copies.
+
+#### Scenario: Suppressed copy leaves search, embedding, and enrichment
+
+- **WHEN** an aggregator posting becomes `duplicate_of` an ATS posting
+- **THEN** it is not returned by job search, not enqueued for embedding (its vector is
+  removed), and not enqueued for LLM enrichment
+
+#### Scenario: Suppressed copy is still reachable by its slug
+
+- **WHEN** a client opens the public detail URL of a suppressed aggregator posting
+- **THEN** the posting is served
+
+### Requirement: Suppression fails over when the ATS twin closes
+
+The system SHALL re-evaluate suppression on each ingest run so that a suppressed
+aggregator posting whose ATS twin has closed is un-suppressed (its `duplicate_of` cleared)
+and re-enters search, embedding, and enrichment. Re-evaluation SHALL be idempotent — a
+run that changes no relationships performs no writes.
+
+#### Scenario: Closed ATS twin releases the aggregator copy
+
+- **WHEN** the ATS posting that suppressed an aggregator copy is closed and ingest runs
+  again
+- **THEN** the aggregator copy's `duplicate_of` is cleared and it becomes eligible for
+  search, embedding, and enrichment again
+
+#### Scenario: A no-change run writes nothing
+
+- **WHEN** the suppression pass runs and every aggregator/ATS relationship is already
+  correct
+- **THEN** no `duplicate_of` values are written

--- a/openspec/changes/aggregator-ats-dedup/specs/aggregator-ats-dedup/spec.md
+++ b/openspec/changes/aggregator-ats-dedup/specs/aggregator-ats-dedup/spec.md
@@ -2,8 +2,9 @@
 
 ### Requirement: An aggregator posting is suppressed when a first-party ATS twin exists
 
-The system SHALL, at ingest time, mark an open posting from an aggregator source as
-`duplicate_of` an open posting from a non-aggregator (ATS) source when both share the
+The system SHALL, when the reindex recomputes duplicate markers, mark an open posting
+from an aggregator source as `duplicate_of` an open posting from a non-aggregator (ATS)
+source when both share the
 same `company_slug`, the same normalized title, and a compatible country. Two postings
 have a compatible country when their `countries` arrays overlap, or when either array is
 empty. The ATS posting SHALL remain canonical (its `duplicate_of` stays NULL); the
@@ -61,15 +62,15 @@ role cluster's copies.
 
 ### Requirement: Suppression fails over when the ATS twin closes
 
-The system SHALL re-evaluate suppression on each ingest run so that a suppressed
+The system SHALL re-evaluate suppression on each reindex run so that a suppressed
 aggregator posting whose ATS twin has closed is un-suppressed (its `duplicate_of` cleared)
 and re-enters search, embedding, and enrichment. Re-evaluation SHALL be idempotent — a
 run that changes no relationships performs no writes.
 
 #### Scenario: Closed ATS twin releases the aggregator copy
 
-- **WHEN** the ATS posting that suppressed an aggregator copy is closed and ingest runs
-  again
+- **WHEN** the ATS posting that suppressed an aggregator copy is closed and the reindex
+  runs again
 - **THEN** the aggregator copy's `duplicate_of` is cleared and it becomes eligible for
   search, embedding, and enrichment again
 

--- a/openspec/changes/aggregator-ats-dedup/tasks.md
+++ b/openspec/changes/aggregator-ats-dedup/tasks.md
@@ -1,0 +1,33 @@
+## 1. Aggregator provider set
+
+- [ ] 1.1 Add `sources.AggregatorProviders() []string` returning the registry's
+  `aggregator()`-marked providers; unit-test that it covers the marked sources and
+  excludes a non-aggregator (ATS) provider.
+
+## 2. Suppression query
+
+- [ ] 2.1 Write `SuppressAggregatorDuplicatesForCompany` in
+  `internal/db/queries/jobs.sql`: per `company_slug` + aggregator-provider `text[]` param,
+  set `duplicate_of` on each open aggregator row to the id of an open canonical ATS row
+  (`duplicate_of IS NULL`) of the same company, equal normalized title, and compatible
+  country (`countries` overlap OR either empty); write only where `IS DISTINCT FROM` the
+  current value. Regenerate sqlc (`make sqlc`).
+- [ ] 2.2 Integration test (build-tag `integration`, testcontainers) covering: aggregator
+  copy suppressed to the ATS row; ATS row stays canonical; same-title different-country not
+  suppressed; ATS row never demoted; two aggregators without an ATS twin untouched;
+  no-change run writes zero rows; closed ATS twin releases the aggregator copy.
+
+## 3. Ingest wiring
+
+- [ ] 3.1 In `cmd/ingest`, run the suppression pass per company immediately after
+  `RecomputeRoleDuplicatesForCompany` (repost-collapse first, then cross-source
+  suppression), passing `sources.AggregatorProviders()`; log a per-run count of
+  suppressed/released rows, log-and-continue per company on error (mirroring the existing
+  recompute pass).
+
+## 4. Verification
+
+- [ ] 4.1 On a scratch DB (or the ingest integration harness), run a crawl of one
+  aggregator board plus its ATS twin and confirm the aggregator copy gets `duplicate_of`
+  set, disappears from `ListJobs`, and is not enqueued for embedding/enrichment, while its
+  detail-by-slug still resolves.

--- a/openspec/changes/aggregator-ats-dedup/tasks.md
+++ b/openspec/changes/aggregator-ats-dedup/tasks.md
@@ -1,33 +1,35 @@
 ## 1. Aggregator provider set
 
-- [ ] 1.1 Add `sources.AggregatorProviders() []string` returning the registry's
+- [x] 1.1 Add `sources.AggregatorProviders(reg) []string` returning the registry's
   `aggregator()`-marked providers; unit-test that it covers the marked sources and
   excludes a non-aggregator (ATS) provider.
 
 ## 2. Suppression query
 
-- [ ] 2.1 Write `SuppressAggregatorDuplicatesForCompany` in
-  `internal/db/queries/jobs.sql`: per `company_slug` + aggregator-provider `text[]` param,
-  set `duplicate_of` on each open aggregator row to the id of an open canonical ATS row
-  (`duplicate_of IS NULL`) of the same company, equal normalized title, and compatible
-  country (`countries` overlap OR either empty); write only where `IS DISTINCT FROM` the
-  current value. Regenerate sqlc (`make sqlc`).
-- [ ] 2.2 Integration test (build-tag `integration`, testcontainers) covering: aggregator
-  copy suppressed to the ATS row; ATS row stays canonical; same-title different-country not
-  suppressed; ATS row never demoted; two aggregators without an ATS twin untouched;
-  no-change run writes zero rows; closed ATS twin releases the aggregator copy.
+- [x] 2.1 Write `CompaniesWithAggregatorPostings` (driver) +
+  `SuppressAggregatorDuplicatesForCompany` in `internal/db/queries/jobs.sql`: per
+  `company` + aggregator-provider `text[]` param, set `duplicate_of` on each candidate
+  open aggregator row to the id of an open canonical ATS row (`duplicate_of IS NULL`) of
+  the same company, equal normalized title, and compatible country (`countries` overlap OR
+  either empty); write only where `IS DISTINCT FROM` the current value. Regenerate sqlc
+  (`make sqlc`).
+- [x] 2.2 Integration test (build-tag `integration`, testcontainers) covering: aggregator
+  copy suppressed to the ATS row; ATS row stays canonical; empty country still matches;
+  same-title different-country not suppressed; ATS row never demoted; two aggregators
+  without an ATS twin untouched; closed ATS twin releases the aggregator copy; driver
+  returns only aggregator companies.
 
-## 3. Ingest wiring
+## 3. Reindex wiring
 
-- [ ] 3.1 In `cmd/ingest`, run the suppression pass per company immediately after
-  `RecomputeRoleDuplicatesForCompany` (repost-collapse first, then cross-source
-  suppression), passing `sources.AggregatorProviders()`; log a per-run count of
-  suppressed/released rows, log-and-continue per company on error (mirroring the existing
-  recompute pass).
+- [x] 3.1 In `cmd/reindex`, run the suppression pass per company immediately after
+  `recomputeRoleDuplicates` (repost-collapse first, then cross-source suppression),
+  passing `sources.AggregatorProviders(sources.All(nil))`; log a per-run count of
+  re-marked rows, log-and-continue per company on error (mirroring the existing recompute
+  pass).
 
 ## 4. Verification
 
-- [ ] 4.1 On a scratch DB (or the ingest integration harness), run a crawl of one
-  aggregator board plus its ATS twin and confirm the aggregator copy gets `duplicate_of`
-  set, disappears from `ListJobs`, and is not enqueued for embedding/enrichment, while its
-  detail-by-slug still resolves.
+- [ ] 4.1 On the ingest/reindex integration harness (or a scratch DB), seed one aggregator
+  posting plus its ATS twin, run the reindex suppression pass, and confirm the aggregator
+  copy gets `duplicate_of` set, disappears from `ListJobs`, and is not enqueued for
+  embedding/enrichment, while its detail-by-slug still resolves.

--- a/openspec/changes/aggregator-ats-dedup/tasks.md
+++ b/openspec/changes/aggregator-ats-dedup/tasks.md
@@ -29,7 +29,7 @@
 
 ## 4. Verification
 
-- [ ] 4.1 On the ingest/reindex integration harness (or a scratch DB), seed one aggregator
-  posting plus its ATS twin, run the reindex suppression pass, and confirm the aggregator
-  copy gets `duplicate_of` set, disappears from `ListJobs`, and is not enqueued for
-  embedding/enrichment, while its detail-by-slug still resolves.
+- [x] 4.1 Integration test `TestSuppressedAggregator_HiddenFromListAndEnrichmentButServedBySlug`
+  seeds one aggregator posting plus its ATS twin, runs the suppression pass, and confirms
+  the aggregator copy gets `duplicate_of` set, is absent from `ListJobs`, is not enqueued
+  by `EnqueuePendingJobs`, and still resolves via `GetJobBySlug`.


### PR DESCRIPTION
## Summary

Aggregators (himalayas, gulftalent, national portals, …) re-list jobs we already ingest first-hand from the company's own ATS. The existing repost dedup (`ingest-content-dedup`) misses these because its `role_fingerprint` includes the description, which aggregators rewrite — so an aggregator copy and its ATS twin never cluster. Measured on prod: **~9,442 open aggregator postings** have an exact-title ATS twin in the same company and compatible country, each indexed in Meilisearch, embedded, and LLM-enriched as a distinct job.

This adds a **reindex-reconcile pass** that marks an open **aggregator** posting `duplicate_of` an open canonical **ATS** posting of the same `company_slug`, normalized title, and compatible country. It reuses the existing `duplicate_of` exclusions with **no downstream changes**: the copy drops out of search, semantic embedding, and enrichment, while staying stored and reachable by its public slug (and listed as a role-cluster copy).

- `sources.AggregatorProviders()` — from the existing `aggregator()` registry markers (single source of truth; no schema/column).
- `CompaniesWithAggregatorPostings` driver + `SuppressAggregatorDuplicatesForCompany` (LEFT JOIN + MIN hash-join, candidate = canonical or ATS-pointed, country gate, `IS DISTINCT FROM` idempotent, failover on twin-close).
- Wired in `cmd/reindex` right after `recomputeRoleDuplicates` (repost-collapse first, then cross-source suppression).

**Safe by construction:** only aggregator rows are suppressed (an ATS row is never demoted by this pass); country gate blocks the 7-Eleven US↔SG false-merge; never merges agg↔agg or ATS↔ATS. **Scope:** exact-title only — fuzzy-title for title-mangling aggregators (gulftalent's Marriott copies) is a deliberate follow-up.

No migration, no new column. Activates on the next reindex; suppressed copies leave embedding/enrichment on the next worker pass.

OpenSpec change: `openspec/changes/aggregator-ats-dedup/`.

## Test Plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` (unit) — `sources.AggregatorProviders` covered
- [x] `go test -tags=integration ./internal/db/` — full suite green (184s), incl. 8 new tests: suppress→ATS, ATS stays canonical, empty-country matches, different-country not suppressed, ATS never demoted, agg↔agg untouched, failover on twin-close, hidden-from-list/enrich-but-served-by-slug, driver scoping
- [x] `openspec validate aggregator-ats-dedup` valid