### PR TITLE
feat(web): menu item icons + right-edge filter tab on profile

### DIFF
--- a/web/src/lib/components/FilterEdgeTab.svelte
+++ b/web/src/lib/components/FilterEdgeTab.svelte
@@ -1,13 +1,33 @@
 <script lang="ts">
   import { SlidersHorizontal } from '@lucide/svelte';
+  import { cn } from '$lib/utils';
 
-  // Icon-only tab pinned to the left viewport edge on mobile, opening the filters
-  // drawer — the mobile counterpart to the desktop aside panel, and a mirror of
-  // the jobs list's right-edge swipe tab. Hidden at/above `md` where the aside is
-  // always visible. The active-filter count rides as a corner badge. Used by the
-  // top-level list pages (/jobs, /companies); embedded/scoped lists (a company's
-  // jobs) keep an inline button instead, so the tab never overlaps a page hero.
-  let { active = 0, onclick }: { active?: number; onclick: () => void } = $props();
+  // Icon-only tab pinned to a viewport edge on mobile, opening the filters drawer
+  // — the mobile counterpart to the desktop aside panel, and a mirror of the jobs
+  // list's right-edge swipe tab. Hidden at/above `md` where the aside is always
+  // visible. The active-filter count rides as a corner badge. `side` picks the
+  // edge (default left); pages that carry a tab strip below the header (e.g. the
+  // account profile) pass `side="right"` + a lower `top-*` via `class` so the tab
+  // sits level with the strip instead of overlapping it. Used by the top-level
+  // list pages (/jobs, /companies); embedded/scoped lists (a company's jobs) keep
+  // an inline button instead, so the tab never overlaps a page hero.
+  let {
+    active = 0,
+    onclick,
+    side = 'left',
+    class: extra = '',
+  }: {
+    active?: number;
+    onclick: () => void;
+    side?: 'left' | 'right';
+    class?: string;
+  } = $props();
+
+  const sideClass = $derived(
+    side === 'right'
+      ? 'right-0 rounded-l-lg border-r-0 pl-2 pr-1.5'
+      : 'left-0 rounded-r-lg border-l-0 pl-1.5 pr-2',
+  );
 </script>
 
 <button
@@ -15,12 +35,19 @@
   {onclick}
   aria-label="Filters"
   title="Filters"
-  class="fixed left-0 top-16 z-30 flex items-center rounded-r-lg border border-l-0 border-border bg-secondary py-2.5 pl-1.5 pr-2 text-secondary-foreground shadow-sm transition-colors hover:bg-accent md:hidden"
+  class={cn(
+    'fixed top-16 z-30 flex items-center border border-border bg-secondary py-2.5 text-secondary-foreground shadow-sm transition-colors hover:bg-accent md:hidden',
+    sideClass,
+    extra,
+  )}
 >
   <SlidersHorizontal class="size-4 shrink-0" />
   {#if active > 0}
     <span
-      class="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-semibold leading-none text-brand-foreground"
+      class={cn(
+        'absolute -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-semibold leading-none text-brand-foreground',
+        side === 'right' ? '-left-1.5' : '-right-1.5',
+      )}
     >
       {active}
     </span>

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -2,7 +2,27 @@
   import { page } from '$app/state';
   import { afterNavigate } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { Menu, X, Sun, Moon } from '@lucide/svelte';
+  import {
+    Menu,
+    X,
+    Sun,
+    Moon,
+    Briefcase,
+    Building2,
+    CircleUser,
+    ListChecks,
+    BellRing,
+    KeyRound,
+    Inbox,
+    SquarePlus,
+    ShieldCheck,
+    Layers,
+    ChartColumn,
+    TrendingUp,
+    Info,
+    LogOut,
+    LogIn,
+  } from '@lucide/svelte';
   import { isAuthenticated, currentUser, logout as doLogout } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { themeStore } from '$lib/theme.svelte';
@@ -46,24 +66,24 @@
   // Primary destinations pinned to the very top of the menu. Jobs is the homepage
   // feed (also reachable via the logo); Companies leads the browse surfaces.
   const primaryLinks = [
-    { href: '/', label: 'Jobs' },
-    { href: '/companies', label: 'Companies' },
+    { href: '/', label: 'Jobs', icon: Briefcase },
+    { href: '/companies', label: 'Companies', icon: Building2 },
   ] as const;
 
   const navLinks = [
-    { href: '/collections', label: 'Collections' },
-    { href: '/analytics', label: 'Analytics' },
-    { href: '/trends', label: 'Trends' },
+    { href: '/collections', label: 'Collections', icon: Layers },
+    { href: '/analytics', label: 'Analytics', icon: ChartColumn },
+    { href: '/trends', label: 'Trends', icon: TrendingUp },
   ] as const;
 
   // Personal account items — what the signed-in user owns/reads. "Submit a job"
   // is a create action, so it's rendered separately (below), split off from the
   // "My submissions" reading item it used to sit next to.
   const accountLinks = [
-    { href: '/my/tracking', label: 'Tracking' },
-    { href: '/my/searches', label: 'Search notifications' },
-    { href: '/my/api-keys', label: 'API keys' },
-    { href: '/my/submissions', label: 'My submissions' },
+    { href: '/my/tracking', label: 'Tracking', icon: ListChecks },
+    { href: '/my/searches', label: 'Search notifications', icon: BellRing },
+    { href: '/my/api-keys', label: 'API keys', icon: KeyRound },
+    { href: '/my/submissions', label: 'My submissions', icon: Inbox },
   ] as const;
 
   // Mobile only: the open panel is a full-screen overlay, so lock the page behind
@@ -126,7 +146,7 @@
       onclick={logout}
       class={cn(rowBase, 'w-full text-left text-muted-foreground')}
     >
-      Log out
+      <LogOut class="size-4 shrink-0" /> Log out
     </button>
   {:else}
     <button
@@ -135,7 +155,7 @@
       onclick={signIn}
       class={cn(rowBase, 'w-full text-left font-medium text-foreground')}
     >
-      Sign in
+      <LogIn class="size-4 shrink-0" /> Sign in
     </button>
   {/if}
 {/snippet}
@@ -211,7 +231,9 @@
         <!-- Primary destinations pinned to the top, then a divider before the
              signed-in personal items and the rest of the site nav. -->
         {#each primaryLinks as link (link.href)}
+          {@const Icon = link.icon}
           <a href={resolve(link.href)} role="menuitem" onclick={() => (open = false)} class={linkClass(link.href)}>
+            <Icon class="size-4 shrink-0" />
             {link.label}
           </a>
         {/each}
@@ -225,10 +247,13 @@
             class={linkClass('/my/profile')}
             title={email}
           >
+            <CircleUser class="size-4 shrink-0" />
             Profile
           </a>
           {#each accountLinks as link (link.href)}
+            {@const Icon = link.icon}
             <a href={resolve(link.href)} role="menuitem" onclick={() => (open = false)} class={linkClass(link.href)}>
+              <Icon class="size-4 shrink-0" />
               {link.label}
             </a>
           {/each}
@@ -236,6 +261,7 @@
           <!-- Create/action items, split off from the account reading items above. -->
           <div class="my-1 h-px bg-border"></div>
           <a href={resolve('/submit')} role="menuitem" onclick={() => (open = false)} class={linkClass('/submit')}>
+            <SquarePlus class="size-4 shrink-0" />
             Submit a job
           </a>
           {#if isModerator}
@@ -245,6 +271,7 @@
               onclick={() => (open = false)}
               class={linkClass('/moderation')}
             >
+              <ShieldCheck class="size-4 shrink-0" />
               Moderation
             </a>
           {/if}
@@ -252,7 +279,9 @@
         {/if}
 
         {#each navLinks as link (link.href)}
+          {@const Icon = link.icon}
           <a href={resolve(link.href)} role="menuitem" onclick={() => (open = false)} class={linkClass(link.href)}>
+            <Icon class="size-4 shrink-0" />
             {link.label}
           </a>
         {/each}
@@ -260,6 +289,7 @@
         <!-- About sits at the very bottom of the link list, just before the
              Sign in / Log out action (the marketing landing lives at /about). -->
         <a href={resolve('/about')} role="menuitem" onclick={() => (open = false)} class={linkClass('/about')}>
+          <Info class="size-4 shrink-0" />
           About
         </a>
 

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -325,7 +325,12 @@
     </div>
 
     {#if filters && tab === 'coverage'}
-      <FilterEdgeTab active={filters.active} onclick={() => (modalOpen = true)} />
+      <FilterEdgeTab
+        active={filters.active}
+        onclick={() => (modalOpen = true)}
+        side="right"
+        class="top-[5.5rem]"
+      />
       <FilterModal
         store={filters}
         {counts}


### PR DESCRIPTION
## What

- **Header menu icons.** Every item in `HeaderMenu.svelte` now carries a distinct lucide icon (Jobs, Companies, Profile, Tracking, Search notifications, API keys, My submissions, Submit a job, Moderation, Collections, Analytics, Trends, About) plus matching `LogIn`/`LogOut` on the auth row — the list no longer reads as an undifferentiated wall of text. Icon lives as an `icon` field on the link objects; rendered via `{@const Icon = link.icon}`.
- **Mobile filter on profile.** `FilterEdgeTab` gains an optional `side` prop (`'left' | 'right'`, default `left`) and a `class` passthrough. The account profile page (which carries a tab strip below the header) passes `side="right"` + `top-[5.5rem]` so the filter tab sits on the right edge, level with the tab strip, instead of overlapping the "Profile" tab on the left. Other list pages (/jobs, /companies, /analytics) are unchanged.

## Verification

- `svelte-check`: 0 warnings on touched files (2 pre-existing errors in `jobs/[slug]` unrelated).
- `eslint`: clean on touched files.

No behavior change beyond the described UI placement/icons.