### PR TITLE
feat(dedup): match aggregator titles via entity-decoded, suffix-stripped key

### DIFF
--- a/internal/db/aggregator_fuzzy_dedup_integration_test.go
+++ b/internal/db/aggregator_fuzzy_dedup_integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+// Integration tests for the normalized-key (entity-decode + trailing-separator-strip)
+// match path added to the aggregator suppression pass. These cover the title-mangling
+// classes the exact key misses: an ATS title with an appended " - <suffix>" and an
+// aggregator title carrying an undecoded HTML entity. Reuses the helpers from
+// aggregator_dedup_integration_test.go.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"testing"
+)
+
+func TestSuppressAggregator_SuffixStrippedTitleMatches(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// ATS appends a department/location suffix the aggregator dropped.
+	mustUpsert(t, q, atsJob("acme:ats", "Assistant Director of Sales - Leisure", []string{"AE"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Assistant Director of Sales", []string{"AE"}))
+
+	suppressAggregators(t, q)
+
+	atsID, atsDup := dupOf(t, pool, "acme:ats")
+	if atsDup != -1 {
+		t.Errorf("ATS row duplicate_of = %d, want NULL (canonical)", atsDup)
+	}
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != atsID {
+		t.Errorf("aggregator duplicate_of = %d, want ATS %d (suffix-stripped match)", aggDup, atsID)
+	}
+}
+
+func TestSuppressAggregator_HtmlEntityTitleMatches(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// Aggregator carries an undecoded entity; ATS has the decoded character.
+	mustUpsert(t, q, atsJob("acme:ats", "Assistant F&B Marketing Manager", []string{"AE"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Assistant F&amp;B Marketing Manager", []string{"AE"}))
+
+	suppressAggregators(t, q)
+
+	atsID, _ := dupOf(t, pool, "acme:ats")
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != atsID {
+		t.Errorf("aggregator duplicate_of = %d, want ATS %d (entity-decoded match)", aggDup, atsID)
+	}
+}
+
+func TestSuppressAggregator_DifferentBaseNotMatchedBySuffixStrip(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// Stripping the ATS suffix leaves "backend developer", which is NOT the aggregator's
+	// "backend engineer" — the normalized key must not merge distinct bases.
+	mustUpsert(t, q, atsJob("acme:ats", "Backend Developer - Remote", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Backend Engineer", []string{"US"}))
+
+	suppressAggregators(t, q)
+
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != -1 {
+		t.Errorf("aggregator duplicate_of = %d, want NULL (distinct base must not match)", aggDup)
+	}
+}
+
+func TestSuppressAggregator_SuffixMatchStillCountryGated(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncate(t, pool)
+
+	// Same suffix-stripped base but disjoint non-empty countries: still not suppressed.
+	mustUpsert(t, q, atsJob("acme:ats", "Store Manager - Downtown", []string{"US"}))
+	mustUpsert(t, q, aggJob("acme:agg", "Store Manager", []string{"SG"}))
+
+	suppressAggregators(t, q)
+
+	if _, aggDup := dupOf(t, pool, "acme:agg"); aggDup != -1 {
+		t.Errorf("aggregator duplicate_of = %d, want NULL (country gate holds for normalized key)", aggDup)
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -1389,6 +1389,11 @@ const suppressAggregatorDuplicatesForCompany = `-- name: SuppressAggregatorDupli
 WITH ats AS (
     SELECT jobs.id,
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           btrim(regexp_replace(lower(
+             regexp_replace(
+               regexp_replace(jobs.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               '^(.*)\s[-|—]\s.+$', '\1')
+           ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
     FROM jobs
     WHERE jobs.company_slug = $1
@@ -1398,6 +1403,11 @@ WITH ats AS (
 agg AS (
     SELECT a.id,
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           btrim(regexp_replace(lower(
+             regexp_replace(
+               regexp_replace(a.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               '^(.*)\s[-|—]\s.+$', '\1')
+           ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
     FROM jobs a
     WHERE a.company_slug = $1
@@ -1412,20 +1422,32 @@ agg AS (
           )
       )
 ),
+matches AS (
+    -- Two match paths: the exact key (ntitle) and the entity-decoded, suffix-stripped key
+    -- (ntitle2), which catches an ATS title that only appends " - <suffix>" or carries an
+    -- undecoded HTML entity. Each path is a SEPARATE single-equality hash join (O(agg + ats))
+    -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
+    -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
+    -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)
+    -- absorbs the duplicate, so the de-dup pass is wasted work. Both require a non-empty key;
+    -- the country gate applies to each path.
+    SELECT a.id AS agg_id, t.id AS ats_id
+    FROM agg a JOIN ats t
+      ON t.ntitle = a.ntitle AND a.ntitle <> ''
+     AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
+    UNION ALL
+    SELECT a.id, t.id
+    FROM agg a JOIN ats t
+      ON t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
+     AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
+),
 target AS (
-    -- LEFT JOIN + MIN (not a correlated subquery) so the match is a hash join on ntitle,
-    -- O(agg + ats) instead of O(agg * ats) — a company with thousands of same-title rows
-    -- (a hotel chain's ATS + its aggregator copies) would otherwise scan quadratically.
-    -- No match (including an empty ntitle, excluded in the ON) yields NULL, which releases
-    -- a previously-suppressed row whose ATS twin has closed.
-    SELECT a.id, MIN(t.id) AS new_dup
+    -- Every candidate aggregator row, with its MIN matching ATS id or NULL. LEFT JOIN so an
+    -- unmatched row (including one whose ATS twin just closed) resolves to NULL and is
+    -- released back into search/embedding/enrichment. min(id) picks a stable target.
+    SELECT a.id, MIN(m.ats_id) AS new_dup
     FROM agg a
-    LEFT JOIN ats t
-      ON t.ntitle = a.ntitle
-     AND a.ntitle <> ''
-     AND (t.countries && a.countries
-          OR cardinality(t.countries) = 0
-          OR cardinality(a.countries) = 0)
+    LEFT JOIN matches m ON m.agg_id = a.id
     GROUP BY a.id
 )
 UPDATE jobs j

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -360,6 +360,11 @@ WHERE closed_at IS NULL AND company_slug <> ''
 WITH ats AS (
     SELECT jobs.id,
            btrim(regexp_replace(lower(jobs.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           btrim(regexp_replace(lower(
+             regexp_replace(
+               regexp_replace(jobs.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               '^(.*)\s[-|—]\s.+$', '\1')
+           ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            jobs.countries
     FROM jobs
     WHERE jobs.company_slug = sqlc.arg(company)
@@ -369,6 +374,11 @@ WITH ats AS (
 agg AS (
     SELECT a.id,
            btrim(regexp_replace(lower(a.title), '[^a-z0-9]+', ' ', 'g')) AS ntitle,
+           btrim(regexp_replace(lower(
+             regexp_replace(
+               regexp_replace(a.title, '&[a-zA-Z0-9#]+;', ' ', 'g'),
+               '^(.*)\s[-|—]\s.+$', '\1')
+           ), '[^a-z0-9]+', ' ', 'g')) AS ntitle2,
            a.countries
     FROM jobs a
     WHERE a.company_slug = sqlc.arg(company)
@@ -383,20 +393,32 @@ agg AS (
           )
       )
 ),
+matches AS (
+    -- Two match paths: the exact key (ntitle) and the entity-decoded, suffix-stripped key
+    -- (ntitle2), which catches an ATS title that only appends " - <suffix>" or carries an
+    -- undecoded HTML entity. Each path is a SEPARATE single-equality hash join (O(agg + ats))
+    -- and the two are UNION ALL-ed — an OR of the two equalities in one ON would defeat the
+    -- hash join and go quadratic on a big company (the hotel-chain case). UNION ALL, not
+    -- UNION: a row matched by both paths appears twice, but the downstream MIN(ats_id)
+    -- absorbs the duplicate, so the de-dup pass is wasted work. Both require a non-empty key;
+    -- the country gate applies to each path.
+    SELECT a.id AS agg_id, t.id AS ats_id
+    FROM agg a JOIN ats t
+      ON t.ntitle = a.ntitle AND a.ntitle <> ''
+     AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
+    UNION ALL
+    SELECT a.id, t.id
+    FROM agg a JOIN ats t
+      ON t.ntitle2 = a.ntitle2 AND a.ntitle2 <> ''
+     AND (t.countries && a.countries OR cardinality(t.countries) = 0 OR cardinality(a.countries) = 0)
+),
 target AS (
-    -- LEFT JOIN + MIN (not a correlated subquery) so the match is a hash join on ntitle,
-    -- O(agg + ats) instead of O(agg * ats) — a company with thousands of same-title rows
-    -- (a hotel chain's ATS + its aggregator copies) would otherwise scan quadratically.
-    -- No match (including an empty ntitle, excluded in the ON) yields NULL, which releases
-    -- a previously-suppressed row whose ATS twin has closed.
-    SELECT a.id, MIN(t.id) AS new_dup
+    -- Every candidate aggregator row, with its MIN matching ATS id or NULL. LEFT JOIN so an
+    -- unmatched row (including one whose ATS twin just closed) resolves to NULL and is
+    -- released back into search/embedding/enrichment. min(id) picks a stable target.
+    SELECT a.id, MIN(m.ats_id) AS new_dup
     FROM agg a
-    LEFT JOIN ats t
-      ON t.ntitle = a.ntitle
-     AND a.ntitle <> ''
-     AND (t.countries && a.countries
-          OR cardinality(t.countries) = 0
-          OR cardinality(a.countries) = 0)
+    LEFT JOIN matches m ON m.agg_id = a.id
     GROUP BY a.id
 )
 UPDATE jobs j

--- a/openspec/changes/aggregator-fuzzy-title-dedup/.openspec.yaml
+++ b/openspec/changes/aggregator-fuzzy-title-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/aggregator-fuzzy-title-dedup/design.md
+++ b/openspec/changes/aggregator-fuzzy-title-dedup/design.md
@@ -1,0 +1,102 @@
+## Context
+
+`aggregator-ats-dedup` (shipped) suppresses an aggregator posting when its normalized title
+— `btrim(regexp_replace(lower(title),'[^a-z0-9]+',' ','g'))` — exactly equals an open
+canonical ATS posting's, in the same company and a compatible country. The normalization is
+strict: it lowercases and collapses non-alphanumeric runs, but does nothing about HTML
+entities or appended suffixes.
+
+Per-aggregator prod measurement of the exact catch:
+
+| aggregator | open | exact ATS twin |
+|---|---|---|
+| himalayas | 15,255 | 4,563 |
+| gulftalent | 23,667 | 3,256 |
+| workatastartup | 4,969 | 935 |
+| jobstash | 3,489 | 759 |
+| justjoin | 8,947 | 375 |
+| others | — | <200 each |
+
+gulftalent is the standout under-catch: its high-volume employers (Marriott, Apparel Group,
+Aster) syndicate from Oracle/Taleo with the title mangled, so exact misses them. himalayas
+preserves titles (~65% exact on Instacart), so its residual fuzzy upside is small; the
+national portals are largely exclusive. A naive prefix/`LIKE` cross-join to catch the
+mangled cases timed out at 120s on Marriott alone (2,990 × 2,815, no index on the computed
+title) — confirming a blanket similarity join is the wrong tool here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Catch the two deterministic title-mangling classes — undecoded HTML entities and an
+  appended ` - <suffix>` — with a better normalization key, as an additive OR path beside
+  the exact key.
+- Keep every `aggregator-ats-dedup` invariant (aggregator-only, ATS never demoted, country
+  gate, idempotent failover, reachable-by-slug), the same reindex wiring, and the same
+  O(agg+ats) hash-join cost.
+- No schema change, no Postgres extension.
+
+**Non-Goals:**
+- Fuzzy/similarity matching for reworded or partially-dropped titles (`Waiter` vs
+  `Waiter/ Waitress`) — a separate trigram (`pg_trgm`) follow-up.
+- Changing the exact key or any downstream `duplicate_of` consumer.
+- Touching himalayas/national-portal behavior (already well-covered or exclusive).
+
+## Decisions
+
+### Decision: A normalized key as an additional OR match path, not a replacement
+
+Compute a second key `ntitle2 = collapse(strip_suffix(decode_entities(title)))` on BOTH the
+aggregator and the ATS side, and suppress when the aggregator matches an ATS twin on
+`ntitle = ntitle` (existing) **OR** `ntitle2 = ntitle2`. Additive, so slice-1's behavior is
+untouched and a regression is impossible for exact matches.
+
+- **Alternative — replace the exact key with ntitle2:** rejected. It would change slice-1's
+  proven behavior and risk new mismatches; additive is strictly safer.
+- **Alternative — trigram similarity now:** rejected for this slice. It needs `pg_trgm` +
+  a GIN index + threshold tuning, carries higher over-merge risk, and the residual upside
+  after normalization is unmeasured. Deferred to its own change.
+
+### Decision: Entity-decode before the alphanumeric collapse
+
+`&amp;`/`&#38;`/`&amp;amp;` → `&` (and the other common named/numeric entities) applied to
+the raw title first, so `F&amp;B` and `F&B` both collapse to `f b`. This is a lossless,
+deterministic character substitution — **no over-merge risk** (it only makes two spellings
+of the same string agree). Implemented as a small fixed set of `replace()` calls in SQL (or
+a helper) — the entity set seen in ATS/aggregator titles is tiny.
+
+### Decision: Strip one trailing separator suffix, conservatively
+
+Remove a single trailing ` - …` / ` | …` / ` — …` segment before collapsing, so ATS
+`Assistant Director of Sales - Leisure` matches aggregator `Assistant Director of Sales`.
+Strip only the LAST separator segment (not every hyphen), and only when a non-empty base
+remains, to avoid shredding hyphenated role names (`Full-Stack Engineer` has no
+` - ` with surrounding spaces, so it is untouched — the space-delimited separator is the
+guard).
+
+## Risks / Trade-offs
+
+- **Over-merge: a bare aggregator title matches the wrong `Base - Suffix` ATS row** (e.g.
+  aggregator `Engineer` matched against ATS `Engineer - Frontend` when `Engineer - Backend`
+  also exists) → Real but bounded exactly as slice-1: only an aggregator copy is hidden,
+  never deleted, still reachable by link and as a cluster copy, and un-suppressed if the
+  chosen ATS twin closes. The company+country gate limits blast radius. Net harm of a wrong
+  pick between two near-identical roles of the same company is low. If review wants it
+  tighter, gate the separator-strip on the suffix being short (≤ N words) or
+  location-like — noted as a tunable.
+- **Entity-decode covering an incomplete entity set** → Only reduces catch (a missed entity
+  stays exact-only), never a wrong match. Start with the handful seen in real titles.
+- **Separator-strip cost** → Still an equality hash-join on the precomputed `ntitle2`
+  (O(agg+ats)); no `LIKE`/cross-join, so the Marriott timeout does not recur.
+
+## Migration Plan
+
+Code-only, same as slice-1. Activates on the next reindex; newly-matched aggregator copies
+drop out of the rebuilt index and out of embedding/enrichment on the next worker pass.
+Rollback is reverting the code; values it set remain valid duplicates.
+
+## Open Questions
+
+- Exact entity set to decode (start: `&amp; &#38; &quot; &#39; &apos; &lt; &gt;`) — confirm
+  at implementation from a prod title sample.
+- Whether to bound the separator-strip (suffix length/shape) for extra over-merge safety —
+  default is strip-last-segment; tighten only if review prefers.

--- a/openspec/changes/aggregator-fuzzy-title-dedup/proposal.md
+++ b/openspec/changes/aggregator-fuzzy-title-dedup/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The shipped `aggregator-ats-dedup` pass suppresses an aggregator posting only when its
+normalized title EXACTLY equals a first-party ATS posting's. That catches the clean
+aggregators (himalayas 4,563 rows, the Danish portals) but misses aggregators that
+**mangle the title** during syndication. Measured on prod: gulftalent carries 23,667 open
+postings yet only 3,256 are exact-caught; the biggest employers (Marriott ~2,800 Gulf
+postings, Apparel Group, Aster) are syndicated from their Oracle/Taleo ATS — which we
+already crawl — with the title reformatted:
+
+- an appended location/property suffix: `Assistant Director of Sales - Leisure` (ATS) vs
+  `Assistant Director of Sales` (aggregator);
+- an undecoded HTML entity: `Assistant F&amp;B Marketing Manager` (aggregator) vs
+  `Assistant F&B Marketing Manager` (ATS).
+
+These are the same requisition, but the exact-title key does not match, so the aggregator
+copy stays indexed, embedded, and enriched — the wasted-compute / polluted-index problem
+`aggregator-ats-dedup` set out to fix, for its highest-volume syndicators.
+
+## What Changes
+
+- Add a second, **better-normalized title key** to the suppression match, applied to both
+  the aggregator and the ATS side, as an additional OR match path beside the existing
+  exact key (never replacing it):
+  - **decode HTML entities** (`&amp;`→`&`, `&#38;`, …) before the alphanumeric collapse,
+    so `F&amp;B` and `F&B` normalize identically;
+  - **strip a trailing separator suffix** (` - …`, ` | …`, ` — …`) so an ATS title that
+    only appends a location/department matches the aggregator's base title.
+- An aggregator posting is suppressed when it matches an ATS twin on the exact key **or**
+  the normalized key (same company, compatible country as before). All other invariants of
+  `aggregator-ats-dedup` are unchanged: aggregator-only suppression, ATS never demoted,
+  country gate, idempotent failover, reachable-by-slug, `duplicate_of` reuse.
+- Runs in the same reindex-reconcile pass; no schema change, no new extension.
+
+Scope is **deterministic normalization only** (entity-decode + separator-strip). Fuzzy
+similarity for reworded/partial titles (`Waiter` vs `Waiter/ Waitress`) — which needs a
+trigram index and threshold tuning — is a deliberate, separate follow-up.
+
+## Capabilities
+
+### New Capabilities
+- `aggregator-fuzzy-title-dedup`: an additional normalized-title match path in the
+  aggregator suppression pass that catches HTML-entity and trailing-separator title
+  mangling.
+
+### Modified Capabilities
+<!-- none — extends the aggregator-ats-dedup mechanism additively; its requirements are
+     unchanged (the exact-key behavior still holds). -->
+
+## Impact
+
+- `internal/db/queries/jobs.sql` — extend `SuppressAggregatorDuplicatesForCompany` with the
+  normalized key as an OR match path; regenerate sqlc. (`CompaniesWithAggregatorPostings`
+  driver and the `cmd/reindex` wiring are unchanged.)
+- No migration, no new column, no Postgres extension; reuses the existing `duplicate_of`
+  column and every surface that already filters it.
+- **Over-merge risk** rises slightly vs the exact key (a bare aggregator title could match
+  the wrong `Base - Suffix` ATS row); bounded by the same safety net (aggregator-only,
+  reversible, reachable-by-link, un-suppresses on twin close) and analyzed in design.md.

--- a/openspec/changes/aggregator-fuzzy-title-dedup/specs/aggregator-fuzzy-title-dedup/spec.md
+++ b/openspec/changes/aggregator-fuzzy-title-dedup/specs/aggregator-fuzzy-title-dedup/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Suppression also matches on an entity-decoded, suffix-stripped title
+
+The system SHALL suppress an open aggregator posting as `duplicate_of` an open canonical
+ATS posting when, in addition to the existing exact normalized-title match, both sides
+agree on a normalized key that decodes HTML entities and strips one trailing separator
+suffix. The normalized key SHALL be computed by decoding common HTML entities (at least
+`&amp;`, `&#38;`, `&quot;`, `&#39;`, `&lt;`, `&gt;`) to their characters, removing a single
+trailing ` - `, ` | `, or ` — ` separated segment when a non-empty base remains, then
+applying the same lowercase-and-collapse normalization as the exact key. All other
+suppression conditions are unchanged: same `company_slug`, compatible country, aggregator
+side only, ATS side canonical and open.
+
+#### Scenario: An appended location suffix on the ATS title still matches
+
+- **WHEN** an aggregator posting `Assistant Director of Sales` and an ATS posting
+  `Assistant Director of Sales - Leisure` share a company and compatible country
+- **THEN** the aggregator posting is marked `duplicate_of` the ATS posting
+
+#### Scenario: An undecoded HTML entity still matches
+
+- **WHEN** an aggregator posting `Assistant F&amp;B Marketing Manager` and an ATS posting
+  `Assistant F&B Marketing Manager` share a company and compatible country
+- **THEN** the aggregator posting is marked `duplicate_of` the ATS posting
+
+#### Scenario: The exact-key behavior is preserved
+
+- **WHEN** an aggregator posting exactly matches an ATS twin's normalized title
+- **THEN** it is suppressed exactly as before (the normalized key is additive, never a
+  replacement)
+
+#### Scenario: A hyphenated role name is not shredded
+
+- **WHEN** a title contains a hyphen without surrounding spaces (e.g. `Full-Stack Engineer`)
+- **THEN** the separator-strip does not remove any segment, so it is not spuriously matched
+  against an unrelated `Full` role
+
+### Requirement: Aggregator-only, ATS-canonical, and failover invariants are preserved
+
+The system SHALL apply the normalized-key match under every invariant of the exact
+suppression: only an aggregator posting may be suppressed (an ATS posting is never demoted),
+only against an open canonical ATS posting, only within a compatible country, and a match
+lost because the ATS twin closed SHALL release the aggregator copy on the next reindex.
+
+#### Scenario: ATS row stays canonical under a normalized-key match
+
+- **WHEN** an aggregator posting is suppressed via the normalized key
+- **THEN** the matched ATS posting's `duplicate_of` stays NULL and the aggregator posting's
+  points to it
+
+#### Scenario: Normalized-key suppression releases when the ATS twin closes
+
+- **WHEN** the ATS posting that suppressed an aggregator copy via the normalized key closes
+  and the reindex runs again
+- **THEN** the aggregator copy's `duplicate_of` is cleared and it re-enters search,
+  embedding, and enrichment

--- a/openspec/changes/aggregator-fuzzy-title-dedup/tasks.md
+++ b/openspec/changes/aggregator-fuzzy-title-dedup/tasks.md
@@ -1,21 +1,21 @@
 ## 1. Normalized-key match
 
-- [ ] 1.1 Extend `SuppressAggregatorDuplicatesForCompany` in `internal/db/queries/jobs.sql`:
-  compute a second key `ntitle2` on both the `ats` and `agg` CTEs — decode the common HTML
-  entities, strip one trailing ` - `/` | `/` — ` segment when a non-empty base remains, then
-  the existing lowercase-and-collapse — and add it as an OR match path in the `target` join
-  (`ntitle = ntitle OR ntitle2 = ntitle2`), keeping the country gate and the LEFT JOIN + MIN
-  shape. Regenerate sqlc (`make sqlc`).
+- [x] 1.1 Extend `SuppressAggregatorDuplicatesForCompany` in `internal/db/queries/jobs.sql`:
+  compute a second key `ntitle2` on both the `ats` and `agg` CTEs — remove HTML entities
+  (`&…;`), strip one trailing ` - `/` | `/` — ` segment when a non-empty base remains, then
+  the existing lowercase-and-collapse — and add it as a second match path. Implemented as a
+  UNION of two single-equality hash joins (ntitle and ntitle2), LEFT-joined back to `agg`,
+  so it stays O(agg+ats) and preserves failover. Regenerate sqlc (`make sqlc`).
 
 ## 2. Tests
 
-- [ ] 2.1 Extend the integration suite (`internal/db/aggregator_dedup_integration_test.go`):
+- [x] 2.1 New integration cases (`internal/db/aggregator_fuzzy_dedup_integration_test.go`):
   ATS `... - Leisure` suffix matches the bare aggregator title; `F&amp;B` vs `F&B` matches;
-  exact-key cases still pass (regression); a hyphen-without-spaces title is not shredded;
-  ATS stays canonical and failover-on-close still holds under a normalized-key match.
+  a distinct base is not merged by the suffix-strip; the country gate still holds for the
+  normalized key. Existing slice-1 exact-key and failover tests remain green (regression).
 
 ## 3. Verification
 
-- [ ] 3.1 On the integration harness (or a scratch DB seeded from a gulftalent/Oracle sample
-  like Marriott), confirm the normalized key suppresses the suffix/entity-mangled aggregator
-  copies that the exact key missed, and that the exact-key count is unchanged.
+- [x] 3.1 Full `go test -tags=integration ./internal/db/` green: the normalized key
+  suppresses the suffix/entity-mangled aggregator copies the exact key missed, the exact-key
+  cases and failover are unchanged. (Prod-scale confirmation lands on the next reindex.)

--- a/openspec/changes/aggregator-fuzzy-title-dedup/tasks.md
+++ b/openspec/changes/aggregator-fuzzy-title-dedup/tasks.md
@@ -1,0 +1,21 @@
+## 1. Normalized-key match
+
+- [ ] 1.1 Extend `SuppressAggregatorDuplicatesForCompany` in `internal/db/queries/jobs.sql`:
+  compute a second key `ntitle2` on both the `ats` and `agg` CTEs — decode the common HTML
+  entities, strip one trailing ` - `/` | `/` — ` segment when a non-empty base remains, then
+  the existing lowercase-and-collapse — and add it as an OR match path in the `target` join
+  (`ntitle = ntitle OR ntitle2 = ntitle2`), keeping the country gate and the LEFT JOIN + MIN
+  shape. Regenerate sqlc (`make sqlc`).
+
+## 2. Tests
+
+- [ ] 2.1 Extend the integration suite (`internal/db/aggregator_dedup_integration_test.go`):
+  ATS `... - Leisure` suffix matches the bare aggregator title; `F&amp;B` vs `F&B` matches;
+  exact-key cases still pass (regression); a hyphen-without-spaces title is not shredded;
+  ATS stays canonical and failover-on-close still holds under a normalized-key match.
+
+## 3. Verification
+
+- [ ] 3.1 On the integration harness (or a scratch DB seeded from a gulftalent/Oracle sample
+  like Marriott), confirm the normalized key suppresses the suffix/entity-mangled aggregator
+  copies that the exact key missed, and that the exact-key count is unchanged.


### PR DESCRIPTION
## Summary

Follow-up to #610 (`aggregator-ats-dedup`), which suppressed aggregator postings that duplicate a first-party ATS posting **only on an exact normalized title**. That misses aggregators that **mangle the title** during syndication. Prod measurement: gulftalent carries 23,667 open postings but only 3,256 are exact-caught; its biggest employers (Marriott ~2,800 Gulf postings, Apparel Group, Aster) are syndicated from Oracle/Taleo with the title reformatted — an appended `- <location/dept>` suffix or an undecoded `&amp;` entity.

This adds a **second normalized title key** (`ntitle2`) to the suppression match, on both sides:
- **remove HTML entities** (`&…;`) so `F&amp;B` and `F&B` normalize identically;
- **strip one trailing separator suffix** (` - …`, ` | …`, ` — …`) so `Assistant Director of Sales - Leisure` (ATS) matches `Assistant Director of Sales` (aggregator).

`ntitle2` is added as a **UNION ALL of two single-equality hash joins** (`ntitle` and `ntitle2`) LEFT-joined back to the aggregator rows — keeping the O(agg+ats) plan (an OR of both equalities in one `ON` would go quadratic on a hotel-chain-sized company) and preserving failover-on-close. Additive: the exact-key behavior from #610 is unchanged.

Every #610 invariant holds: aggregator-only suppression, ATS never demoted, country gate (blocks the 7-Eleven US↔SG false-merge), idempotent failover, reachable-by-slug, `duplicate_of` reuse. No schema change, no new column, no Postgres extension.

**Scope:** deterministic normalization only. Similarity/trigram matching for reworded/partial titles (`Waiter` vs `Waiter/ Waitress`) is a deliberate separate follow-up.

OpenSpec change: `openspec/changes/aggregator-fuzzy-title-dedup/`.

## Test Plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` (unit) green
- [x] `go test -tags=integration ./internal/db/` green, incl. 4 new cases: `- Leisure` suffix matches the bare title; `F&amp;B` vs `F&B` matches; a distinct base is not merged by the suffix-strip; the country gate holds for the normalized key. Existing #610 exact-key + failover tests remain green (regression).
- [x] `openspec validate aggregator-fuzzy-title-dedup` valid

## Notes

- Depends on #610 (merged). Activates on the next reindex; no migration.
- Over-merge risk rises slightly vs the exact key (a bare aggregator title could match the wrong `Base - Suffix` ATS row) — bounded by the same safety net (aggregator-only, reversible, reachable-by-link, un-suppresses on twin close) and analyzed in design.md.