### PR TITLE
chore(web): rotate logo.dev publishable token

### DIFF
--- a/web/src/lib/logo.ts
+++ b/web/src/lib/logo.ts
@@ -2,8 +2,10 @@
 // `fallback=404` makes it return 404 — rather than a generic monogram — when it
 // has no logo, so each consumer can pick its own fallback (the globe icon in the
 // SPA, a monogram tile in the OG card). The token is a logo.dev publishable key,
-// designed to live in a client img src.
-export const LOGO_DEV_TOKEN = 'pk_OywHLHTfSOuQesyeqep_nw';
+// designed to live in a client img src; it is domain-restricted (the allowlist —
+// freehire.dev + localhost for dev — is configured against the key in the logo.dev
+// dashboard, since the browser attaches the page origin as the Referer).
+export const LOGO_DEV_TOKEN = 'pk_fKgOEo0OT4KXvUshjPMGAQ';
 
 /** The logo.dev image URL for a company name, or null when there is no name. */
 export function logoDevUrl(name: string): string | null {


### PR DESCRIPTION
Старый ключ `pk_Oyw…` вернулся с `{"msg":"token is disabled"}` — причина, почему логотипы перестали грузиться. Ротация на новый `pk_fKg…`.

**getlogo.dev** как замену не берём: он domain-only, а все места вызова передают имя компании (`img.logo.dev/name/{name}`), поэтому оставили logo.dev.

⚠️ Новый ключ **domain-restricted** — чтобы он работал в браузере, в дашборде logo.dev к ключу надо добавить `freehire.dev` и `localhost` в allowlist (иначе 401 → фолбэк на монограмму).

Тесты `seo.test.ts` зелёные.