### PR TITLE
fix(web): blog prod 500 (frontmatter date) + footer Blog link

### DIFF
--- a/web/src/lib/blog.test.ts
+++ b/web/src/lib/blog.test.ts
@@ -34,6 +34,18 @@ describe('parseFrontmatter', () => {
     });
   });
 
+  // YAML parses an unquoted `2026-01-15` as a timestamp; mdsvex serializes it to a
+  // Date (in memory) or an ISO datetime string (in the production build). All must
+  // normalize to the YYYY-MM-DD day. Regression: prod 500 "invalid date 2026-01-15T00:00:00.000Z".
+  it.each([
+    ['plain ISO string', '2026-01-15'],
+    ['ISO datetime string', '2026-01-15T00:00:00.000Z'],
+    ['Date object', new Date('2026-01-15T00:00:00.000Z')],
+  ])('normalizes a %s date to YYYY-MM-DD', (_label, date) => {
+    const post = parseFrontmatter({ ...full, date }, '/src/posts/launch.svx');
+    expect(post.date).toBe('2026-01-15');
+  });
+
   it('defaults type to changelog, tags to [], draft to false when omitted', () => {
     const post = parseFrontmatter(
       { title: 'Note', date: '2026-02-01', summary: 'Small fix.' },

--- a/web/src/lib/blog.ts
+++ b/web/src/lib/blog.ts
@@ -39,11 +39,34 @@ function isIsoDate(value: string): boolean {
   return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
 }
 
+// Normalize the frontmatter `date` to a `YYYY-MM-DD` string. YAML parses an
+// unquoted `2026-01-15` as a timestamp, which mdsvex surfaces as a Date (in dev)
+// or an ISO datetime string like `2026-01-15T00:00:00.000Z` (in the production
+// build); a quoted value stays a plain string. Accept all three, then validate
+// the calendar day. Throws (naming the file) on a missing or unreal date.
+function normalizeDate(value: unknown, filePath: string): string {
+  let day: string;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      throw new Error(`blog post ${filePath}: invalid date (unparseable)`);
+    }
+    day = value.toISOString().slice(0, 10);
+  } else if (typeof value === 'string' && value.trim() !== '') {
+    day = value.trim().slice(0, 10);
+  } else {
+    throw new Error(`blog post ${filePath}: missing or empty required field "date"`);
+  }
+  if (!isIsoDate(day)) {
+    throw new Error(`blog post ${filePath}: invalid date "${String(value)}" (expected ISO YYYY-MM-DD)`);
+  }
+  return day;
+}
+
 /** Validate and normalize one post's raw frontmatter into a `PostMeta`. Throws,
  *  naming the offending file, on a missing required field or an out-of-enum
  *  `type` — a loud build failure beats shipping a post with blank metadata. */
 export function parseFrontmatter(raw: Record<string, unknown>, filePath: string): PostMeta {
-  const required = (key: 'title' | 'date' | 'summary'): string => {
+  const required = (key: 'title' | 'summary'): string => {
     const value = raw[key];
     if (typeof value !== 'string' || value.trim() === '') {
       throw new Error(`blog post ${filePath}: missing or empty required field "${key}"`);
@@ -51,10 +74,7 @@ export function parseFrontmatter(raw: Record<string, unknown>, filePath: string)
     return value;
   };
 
-  const date = required('date');
-  if (!isIsoDate(date)) {
-    throw new Error(`blog post ${filePath}: invalid date "${date}" (expected ISO YYYY-MM-DD)`);
-  }
+  const date = normalizeDate(raw.date, filePath);
 
   let type: PostType = 'changelog';
   if (raw.type !== undefined) {

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -18,6 +18,7 @@
     {
       title: 'Resources',
       links: [
+        { label: 'Blog', href: resolve('/blog') },
         { label: 'Trends', href: resolve('/trends') },
         { label: 'CLI', href: resolve('/cli') },
         { label: 'ChatGPT', href: resolve('/chatgpt') },


### PR DESCRIPTION
## Summary

Hotfix for the blog shipped in #619.

- **fix(web): normalize blog frontmatter date.** In the production build, mdsvex serializes an unquoted YAML date (`date: 2026-01-15`) as an ISO datetime string (`2026-01-15T00:00:00.000Z`), which the strict `isIsoDate` validator rejected → `/blog`, post pages, RSS, and OG all 500'd on prod (dev was fine — the dev transform kept it a plain string). `parseFrontmatter` now accepts a Date, an ISO datetime string, or a plain string and normalizes to the `YYYY-MM-DD` day.
- **feat(web): footer Blog link** under Resources (discoverability).

Root cause of the miss: runtime verification was done against `npm run dev`, not the production build; the prod-only serialization diverged. This time verified against the actual `node build` server (`/blog`, post, rss, og.png all 200).

## Test Plan
- [x] `vitest` — 198 pass (added regression tests: Date / ISO-datetime / plain-string all normalize to `2026-01-15`)
- [x] `svelte-check` — 0 errors
- [x] `npm run build` + `node build` — `/blog` 200, post 200, `/blog/rss.xml` 200, `/blog/<slug>/og.png` 200 (verified on the production server, not dev)
- [x] `eslint` — clean