### PR TITLE
style(web): widen blog post content column

### DIFF
--- a/web/src/posts/2026-07-12-introducing-the-changelog.svx
+++ b/web/src/posts/2026-07-12-introducing-the-changelog.svx
@@ -1,6 +1,6 @@
 ---
 title: Introducing the freehire changelog
-date: 2026-01-15
+date: 2026-07-12
 summary: A public home for product updates — new sources, features, and fixes as they ship.
 type: changelog
 tags:

--- a/web/src/routes/blog/[slug]/+page.svelte
+++ b/web/src/routes/blog/[slug]/+page.svelte
@@ -33,7 +33,7 @@
   {@html jsonLd}
 </svelte:head>
 
-<div class="mx-auto w-full max-w-2xl px-4 py-6">
+<div class="mx-auto w-full max-w-3xl px-4 py-6">
   <a
     href={resolve('/blog')}
     class="text-sm text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
Bumps the blog post page from `max-w-2xl` (672px) to `max-w-3xl` (768px) — the 2xl column read too narrow on wide screens. Matches the blog index width. Verified via screenshot at 1440px (centered, comfortable measure).