### PR TITLE
feat(sources): add TTeam Huntflow board

### DIFF
--- a/sources/huntflow.yml
+++ b/sources/huntflow.yml
@@ -31,5 +31,7 @@
   board: telematika
 - company: Tripster
   board: tripster
+- company: TTeam
+  board: tteam.global
 - company: Vinou
   board: vinou


### PR DESCRIPTION
Adds the TTeam career board (Huntflow, global region).

- `board: tteam.global` — the global-region subdomain `tteam.global.huntflow.io`; first huntflow board with a two-part subdomain (adapter formats `%s.huntflow.io`).
- Verified live before adding: list `_payload.json` → 200 with 8 open vacancies; a detail payload resolves with body/position/requirements/conditions.

Jobs ingest on the next huntflow crawl.