### PR TITLE
fix+feat(inbox): MAILBOX_DOMAIN gate + moderator-only rollout + tabs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,13 +35,14 @@ OAUTH_GOOGLE_CLIENT_SECRET=
 GMAIL_TOKEN_KEY=
 
 # Hosted mailbox (the second inbox option): each user can claim an address on a
-# receiving subdomain and read mail sent there. MAIL_DOMAIN is that subdomain
-# (e.g. inbox.freehire.dev); unset disables the option (claim route off, status
+# receiving subdomain and read mail sent there. MAILBOX_DOMAIN is that subdomain
+# (e.g. inbox.freehire.dev — NOT the MAIL_DOMAIN sending identity); unset disables
+# the option (claim route off, status
 # unavailable). The cmd/mail-ingest daemon drains inbound mail from SES → S3 →
 # SQS: set AWS_REGION (an SES inbound-capable region), MAIL_INBOUND_QUEUE_URL,
 # and MAIL_INBOUND_BUCKET (fallback bucket when a notification omits one). AWS
 # credentials come from the default chain (instance/SSO role), never here.
-MAIL_DOMAIN=
+MAILBOX_DOMAIN=
 AWS_REGION=
 MAIL_INBOUND_QUEUE_URL=
 MAIL_INBOUND_BUCKET=

--- a/cmd/mail-ingest/main.go
+++ b/cmd/mail-ingest/main.go
@@ -5,7 +5,7 @@
 // run-once cron workers it is long-lived (SES delivery is push-driven), so it
 // loops until SIGTERM.
 //
-// It is gated on config: without MAIL_DOMAIN / AWS_REGION / MAIL_INBOUND_QUEUE_URL
+// It is gated on config: without MAILBOX_DOMAIN / AWS_REGION / MAIL_INBOUND_QUEUE_URL
 // it exits cleanly (nothing to drain). AWS credentials come from the default chain
 // (instance/SSO role), never app config.
 package main
@@ -30,12 +30,12 @@ func run() int {
 	}
 	defer cleanup()
 
-	domain := cfg.MailDomain
+	domain := cfg.MailboxDomain
 	region := os.Getenv("AWS_REGION")
 	queueURL := os.Getenv("MAIL_INBOUND_QUEUE_URL")
 	bucket := os.Getenv("MAIL_INBOUND_BUCKET")
 	if domain == "" || region == "" || queueURL == "" {
-		log.Print("mail-ingest: not configured (MAIL_DOMAIN / AWS_REGION / MAIL_INBOUND_QUEUE_URL) — nothing to do")
+		log.Print("mail-ingest: not configured (MAILBOX_DOMAIN / AWS_REGION / MAIL_INBOUND_QUEUE_URL) — nothing to do")
 		return 0
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -151,7 +151,7 @@ func main() {
 		OAuthProviders: oauthProviders,
 		GmailConnector: gmailConnector,
 		GmailCipher:    gmailCipher,
-		MailDomain:     cfg.MailDomain,
+		MailboxDomain:  cfg.MailboxDomain,
 		Search:         searchClient,
 		Blob:           blobStore,
 		LLM:            llmClient,

--- a/docs/hosted-mailbox.md
+++ b/docs/hosted-mailbox.md
@@ -21,7 +21,7 @@ migration discipline.
 ## 2. Receiving domain + MX
 
 - Use a dedicated subdomain, e.g. `inbox.freehire.dev` — **not** the apex domain,
-  whose MX serves real mail. This is `MAIL_DOMAIN`.
+  whose MX serves real mail. This is `MAILBOX_DOMAIN`.
 - Verify the subdomain in SES **for receiving** (SES email receiving is only
   available in a subset of regions — pick one and use it for `AWS_REGION`).
 - Add an `MX` record for the subdomain pointing at SES inbound:
@@ -56,14 +56,14 @@ release the same way as the other `cmd/*` binaries.
 
 | var | purpose |
 |-----|---------|
-| `MAIL_DOMAIN` | receiving subdomain; also enables the claim route + status on the server |
+| `MAILBOX_DOMAIN` | receiving subdomain; also enables the claim route + status on the server |
 | `AWS_REGION` | an SES-inbound-capable region |
 | `MAIL_INBOUND_QUEUE_URL` | the SQS queue the SES notifications land in |
 | `MAIL_INBOUND_BUCKET` | fallback S3 bucket for the raw MIME |
 
-`MAIL_DOMAIN` is read by **both** the server (to offer the option and gate the
+`MAILBOX_DOMAIN` is read by **both** the server (to offer the option and gate the
 claim route) and the worker; the rest are worker-only. AWS credentials come from
-the instance/SSO role. With `MAIL_DOMAIN` unset the option is off (claim route
+the instance/SSO role. With `MAILBOX_DOMAIN` unset the option is off (claim route
 unregistered, status reports unavailable); with the AWS vars unset the worker
 exits cleanly (nothing to drain).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,10 +42,12 @@ type Settings struct {
 	// inbox feature is disabled (like an unset optional integration).
 	GmailTokenKey []byte
 
-	// MailDomain is the receiving domain hosted mailboxes live on
-	// (<handle>@MailDomain, e.g. inbox.freehire.dev). Empty = the hosted-mailbox
-	// option is off (claim route unregistered, status reports unavailable).
-	MailDomain string
+	// MailboxDomain is the receiving domain hosted mailboxes live on
+	// (<handle>@MailboxDomain, e.g. inbox.freehire.dev). Empty = the hosted-mailbox
+	// option is off (claim route unregistered, status reports unavailable). It is
+	// deliberately NOT named MAIL_DOMAIN — that shared var already holds the SES
+	// *sending* identity (notifications), a different, non-receiving domain.
+	MailboxDomain string
 
 	// Meilisearch backs the job search endpoint and the reindex command. Shared
 	// via Load (both cmd/server and cmd/reindex read it). Search is optional:
@@ -126,7 +128,7 @@ func Load() Settings {
 		CookieDomain:   os.Getenv("COOKIE_DOMAIN"),
 		OAuth:          loadOAuth(),
 		GmailTokenKey:  decodeKey(os.Getenv("GMAIL_TOKEN_KEY")),
-		MailDomain:     os.Getenv("MAIL_DOMAIN"),
+		MailboxDomain:  os.Getenv("MAILBOX_DOMAIN"),
 		MeiliURL:       env("MEILI_URL", "http://localhost:7700"),
 		MeiliKey:       os.Getenv("MEILI_MASTER_KEY"),
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -187,9 +187,9 @@ type Config struct {
 	// feature is off (connect routes unregistered, inbox empty).
 	GmailConnector *gmailsync.Connector
 	GmailCipher    *tokencrypt.Cipher
-	// MailDomain enables the hosted-mailbox option: the receiving domain user
-	// addresses live on (<handle>@MailDomain). Empty = the feature is off.
-	MailDomain string
+	// MailboxDomain enables the hosted-mailbox option: the receiving domain user
+	// addresses live on (<handle>@MailboxDomain). Empty = the feature is off.
+	MailboxDomain string
 }
 
 // Register wires all routes onto the application from cfg. Auth is same-origin
@@ -209,7 +209,7 @@ func Register(app *fiber.App, cfg Config) {
 		frontendOrigin: cfg.FrontendOrigin,
 		gmailConnector: cfg.GmailConnector,
 		gmailCipher:    cfg.GmailCipher,
-		mailDomain:     cfg.MailDomain,
+		mailDomain:     cfg.MailboxDomain,
 		tracking:       jobtracking.New(jobtracking.NewQueriesRepository(queries)),
 		accounts:       accounts.New(accounts.NewQueriesRepository(queries, cfg.Pool), authHasher{}),
 		moderation:     moderation.New(moderation.NewQueriesRepository(queries, cfg.Pool, enrich.Version)),
@@ -370,26 +370,27 @@ func Register(app *fiber.App, cfg Config) {
 	api.Put("/me/profile", saved, a.PutProfile)
 	api.Delete("/me/profile", saved, a.DeleteProfile)
 
-	// Connect-Gmail inbox. The read + disconnect routes are always available
-	// (empty/no-op when not connected); the OAuth connect routes only when the
-	// feature is configured (Google creds + token key present). Cookie-only, as
-	// they are browser OAuth flows.
-	api.Get("/me/gmail", saved, a.GmailStatus)
-	api.Delete("/me/gmail", saved, a.GmailDisconnect)
-	api.Get("/me/inbox", saved, a.GetInbox)
-	api.Get("/me/inbox/group", saved, a.GetInboxGroup)
-	api.Get("/me/emails/:id", saved, a.GetEmail)
+	// Mail inbox (Gmail connect + hosted mailbox). The whole surface is
+	// moderator-gated for now (a restricted rollout) — a non-moderator gets 403
+	// and the SPA hides the nav entry. The read + disconnect routes are always
+	// registered (empty/no-op when not connected); the OAuth connect routes only
+	// when configured. Cookie-or-key auth, then the role gate.
+	api.Get("/me/gmail", saved, requireModerator, a.GmailStatus)
+	api.Delete("/me/gmail", saved, requireModerator, a.GmailDisconnect)
+	api.Get("/me/inbox", saved, requireModerator, a.GetInbox)
+	api.Get("/me/inbox/group", saved, requireModerator, a.GetInboxGroup)
+	api.Get("/me/emails/:id", saved, requireModerator, a.GetEmail)
 	if a.gmailReady() {
-		api.Get("/me/gmail/connect", saved, a.GmailConnect)
-		api.Get("/me/gmail/callback", saved, a.GmailCallback)
-		api.Post("/me/gmail/sync", saved, a.SyncGmail)
+		api.Get("/me/gmail/connect", saved, requireModerator, a.GmailConnect)
+		api.Get("/me/gmail/callback", saved, requireModerator, a.GmailCallback)
+		api.Post("/me/gmail/sync", saved, requireModerator, a.SyncGmail)
 	}
 	// Hosted-mailbox option: status is always available (reports unavailable when
 	// the feature is off); claim/release only when a receiving domain is configured.
-	api.Get("/me/mailbox", saved, a.GetMailbox)
+	api.Get("/me/mailbox", saved, requireModerator, a.GetMailbox)
 	if a.mailboxReady() {
-		api.Post("/me/mailbox", saved, a.ClaimMailbox)
-		api.Delete("/me/mailbox", saved, a.ReleaseMailbox)
+		api.Post("/me/mailbox", saved, requireModerator, a.ClaimMailbox)
+		api.Delete("/me/mailbox", saved, requireModerator, a.ReleaseMailbox)
 	}
 	// The résumé verdict is a profile sub-resource: GET computes the live
 	// market-coverage verdict from the profile's skills against the selected role.

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { accountNav, isSectionActive } from './accountNav';
+import { accountNav, isSectionActive, visibleAccountNav } from './accountNav';
 
 describe('accountNav config', () => {
   it('lists the seven account sections', () => {
@@ -22,6 +22,20 @@ describe('accountNav config', () => {
   it('has unique hrefs', () => {
     const hrefs = accountNav.map((i) => i.href);
     expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+});
+
+describe('visibleAccountNav', () => {
+  it('hides the moderator-only Inbox from non-moderators', () => {
+    const hrefs = visibleAccountNav(false).map((i) => i.href);
+    expect(hrefs).not.toContain('/my/inbox');
+    expect(hrefs).toHaveLength(accountNav.length - 1);
+  });
+
+  it('shows every section to a moderator', () => {
+    const hrefs = visibleAccountNav(true).map((i) => i.href);
+    expect(hrefs).toContain('/my/inbox');
+    expect(hrefs).toHaveLength(accountNav.length);
   });
 });
 

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -11,13 +11,21 @@ export const accountNav = [
   { href: '/my/profile', label: 'Profile' },
   { href: '/my/tracking', label: 'Tracking' },
   { href: '/my/activity', label: 'Activity' },
-  { href: '/my/inbox', label: 'Inbox' },
+  // Mail inbox is a restricted rollout — moderators only (the server 403s others).
+  { href: '/my/inbox', label: 'Inbox', moderatorOnly: true },
   { href: '/my/searches', label: 'Search notifications' },
   { href: '/my/api-keys', label: 'API keys' },
   { href: '/my/submissions', label: 'My submissions' },
 ] as const;
 
 export type AccountNavItem = (typeof accountNav)[number];
+
+// The sections visible to a caller: a `moderatorOnly` section is hidden unless the
+// caller is a moderator. This is a UI affordance only — the server re-checks the
+// role on every request, so hiding the nav is not the security boundary.
+export function visibleAccountNav(isModerator: boolean): readonly AccountNavItem[] {
+  return accountNav.filter((i) => !('moderatorOnly' in i && i.moderatorOnly) || isModerator);
+}
 
 // A section is active when the current path equals its route or is a descendant
 // of it. The trailing-slash guard means a shared string prefix that is not a path

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -32,6 +32,10 @@
   let syncing = $state(false);
   let claiming = $state(false);
 
+  // Which pane: the mail list ('inbox') or the account setup ('settings'). Kept in
+  // separate tabs so the page doesn't dump connection cards and mail at once.
+  let tab = $state<'inbox' | 'settings'>('inbox');
+
   // Expanded group's messages, cached by key; and the opened message body.
   let expanded = $state<string | null>(null);
   let threads = $state<Record<string, InboxMessage[]>>({});
@@ -51,6 +55,7 @@
     try {
       [gmail, mailbox] = await Promise.all([api.gmailStatus(), api.mailboxStatus()]);
       if (hasAnySource) await fetchFirstPage();
+      else tab = 'settings'; // nothing to read yet — land on setup
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to load the inbox.';
     } finally {
@@ -234,8 +239,24 @@
   <p class="text-sm text-destructive">{error}</p>
 {:else}
   <div class="flex flex-col gap-4">
-    <!-- Sources: the two ways to get mail in — connect Gmail and/or claim a mailbox. -->
-    <div class="grid gap-3 sm:grid-cols-2">
+    <!-- Tabs: keep the mail list and the account setup on separate panes. -->
+    <div class="flex gap-4 border-b border-border text-sm">
+      {#each [{ id: 'inbox', label: 'Inbox' }, { id: 'settings', label: 'Settings' }] as t (t.id)}
+        <button
+          type="button"
+          onclick={() => (tab = t.id as 'inbox' | 'settings')}
+          class="-mb-px border-b-2 px-1 py-2 transition-colors {tab === t.id
+            ? 'border-brand font-medium text-foreground'
+            : 'border-transparent text-muted-foreground hover:text-foreground'}"
+        >
+          {t.label}
+        </button>
+      {/each}
+    </div>
+
+    {#if tab === 'settings'}
+      <!-- Sources: the two ways to get mail in — connect Gmail and/or claim a mailbox. -->
+      <div class="grid gap-3 sm:grid-cols-2">
       <!-- Gmail -->
       <div class="rounded-xl border border-border bg-card p-4">
         <div class="flex items-center gap-2 text-sm font-medium">
@@ -290,9 +311,10 @@
       </div>
     </div>
 
-    {#if !hasAnySource}
+    {:else if !hasAnySource}
       <p class="py-8 text-center text-sm text-muted-foreground">
-        Connect Gmail or get a freehire mailbox above to start seeing your ATS mail here.
+        No mail source yet —
+        <button type="button" class="font-medium text-primary hover:underline" onclick={() => (tab = 'settings')}>set one up in Settings</button>.
       </p>
     {:else}
       <!-- Account switcher (only when both sources feed the inbox). -->

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -4,10 +4,10 @@
   import { resolve } from '$app/paths';
   import { User, LayoutList, Activity, Bell, Key, FileText, Inbox } from '@lucide/svelte';
   import type { LucideIcon } from '@lucide/svelte';
-  import { isAuthenticated } from '$lib/auth.svelte';
+  import { isAuthenticated, currentUser } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { Button } from '$lib/ui';
-  import { accountNav, isSectionActive, type AccountNavItem } from '$lib/accountNav';
+  import { visibleAccountNav, isSectionActive, type AccountNavItem } from '$lib/accountNav';
   import { cn } from '$lib/utils';
 
   // The account shell: one source of truth for the `my/*` chrome — the width
@@ -19,6 +19,10 @@
   let { children }: { children: Snippet } = $props();
 
   const path = $derived(page.url.pathname);
+
+  // Moderator-only sections (Inbox) are hidden from the nav for everyone else; the
+  // server enforces the real 403, this just declutters the UI.
+  const navItems = $derived(visibleAccountNav(currentUser()?.role === 'moderator'));
 
   // Icon per section, kept out of the pure accountNav model so that stays
   // Svelte-free and unit-testable. Keyed by the nav hrefs so a new section
@@ -57,7 +61,7 @@
   {:else}
     <!-- Same items, two forms; `extra` carries the per-form item tweaks. -->
     {#snippet navLinks(extra: string)}
-      {#each accountNav as item (item.href)}
+      {#each navItems as item (item.href)}
         {@const active = isSectionActive(path, item.href)}
         {@const Icon = icons[item.href]}
         <a

--- a/web/src/routes/my/inbox/+page.server.ts
+++ b/web/src/routes/my/inbox/+page.server.ts
@@ -1,0 +1,13 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+// The mail inbox is a moderator-only rollout — the API 403s everyone else, so
+// redirect non-moderators to their profile instead of rendering a page whose every
+// fetch would fail. The server role check (RequireRole) remains the real boundary.
+export const load: PageServerLoad = async ({ parent }) => {
+  const { user } = await parent();
+  if (user?.role !== 'moderator') {
+    redirect(302, '/my/profile');
+  }
+  return {};
+};


### PR DESCRIPTION
Follow-up to #625.

## Summary
- **Fix accidental enable**: gate the hosted mailbox on `MAILBOX_DOMAIN`, not the shared `MAIL_DOMAIN` (already set in prod to the SES *sending* identity `mail.freehire.dev` — reading it turned the option on with a domain that has no receiving pipeline for hire, so a claimed address silently receives nothing).
- **Moderator-only rollout**: `RequireRole("moderator")` on every `/me/gmail|inbox|emails|mailbox` route (403 for others); the `/my/inbox` nav entry hidden via `visibleAccountNav`; a `+page.server` redirect for non-moderators.
- **Tabs**: split `InboxView` into **Inbox** / **Settings** so connection cards and the mail list no longer show at once (lands on Settings when no source is connected).

## Test Plan
- [x] `go build ./...`, `go vet`, `gofmt` clean
- [x] `svelte-check` clean; `accountNav` vitest (incl. new `visibleAccountNav` tests) 10/10