### PR TITLE
feat(inbox): flat two-pane mail list (drop subject grouping)

### DIFF
--- a/internal/db/gmail.sql.go
+++ b/internal/db/gmail.sql.go
@@ -11,8 +11,8 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const countInboxGroups = `-- name: CountInboxGroups :one
-SELECT count(DISTINCT subject_norm)
+const countEmails = `-- name: CountEmails :one
+SELECT count(*)
 FROM emails
 WHERE user_id = $1
   AND ($2::text = '' OR source = $2)
@@ -25,16 +25,15 @@ WHERE user_id = $1
   )
 `
 
-type CountInboxGroupsParams struct {
+type CountEmailsParams struct {
 	UserID int64  `json:"user_id"`
 	Src    string `json:"src"`
 	Q      string `json:"q"`
 }
 
-// Total distinct subject groups for the caller (same optional source + search),
-// so the inbox knows whether more pages remain.
-func (q *Queries) CountInboxGroups(ctx context.Context, arg CountInboxGroupsParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countInboxGroups, arg.UserID, arg.Src, arg.Q)
+// Total messages for the caller (same optional source + search), for pagination.
+func (q *Queries) CountEmails(ctx context.Context, arg CountEmailsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countEmails, arg.UserID, arg.Src, arg.Q)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -191,67 +190,10 @@ func (q *Queries) ListConnectedGmailUsers(ctx context.Context) ([]ListConnectedG
 	return items, nil
 }
 
-const listEmailsByGroup = `-- name: ListEmailsByGroup :many
-SELECT id, source, external_id, from_addr, from_name, subject, received_at,
-    (read_at IS NOT NULL)::boolean AS read
-FROM emails
-WHERE user_id = $1 AND subject_norm = $2
-ORDER BY received_at DESC
-`
-
-type ListEmailsByGroupParams struct {
-	UserID      int64  `json:"user_id"`
-	SubjectNorm string `json:"subject_norm"`
-}
-
-type ListEmailsByGroupRow struct {
-	ID         int64              `json:"id"`
-	Source     string             `json:"source"`
-	ExternalID string             `json:"external_id"`
-	FromAddr   string             `json:"from_addr"`
-	FromName   string             `json:"from_name"`
-	Subject    string             `json:"subject"`
-	ReceivedAt pgtype.Timestamptz `json:"received_at"`
-	Read       bool               `json:"read"`
-}
-
-func (q *Queries) ListEmailsByGroup(ctx context.Context, arg ListEmailsByGroupParams) ([]ListEmailsByGroupRow, error) {
-	rows, err := q.db.Query(ctx, listEmailsByGroup, arg.UserID, arg.SubjectNorm)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ListEmailsByGroupRow{}
-	for rows.Next() {
-		var i ListEmailsByGroupRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Source,
-			&i.ExternalID,
-			&i.FromAddr,
-			&i.FromName,
-			&i.Subject,
-			&i.ReceivedAt,
-			&i.Read,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listInboxGroups = `-- name: ListInboxGroups :many
-SELECT
-    subject_norm,
-    count(*)                                                   AS message_count,
-    count(*) FILTER (WHERE read_at IS NULL)                    AS unread_count,
-    max(received_at)::timestamptz                              AS latest_received,
-    ((array_agg(subject ORDER BY received_at DESC))[1])::text  AS latest_subject,
-    array_remove(array_agg(DISTINCT from_name), '')::text[]    AS senders
+const listEmails = `-- name: ListEmails :many
+SELECT id, source, external_id, from_addr, from_name, subject,
+    left(regexp_replace(body_text, E'\\s+', ' ', 'g'), 160)::text AS snippet,
+    received_at, (read_at IS NOT NULL)::boolean AS read
 FROM emails
 WHERE user_id = $1
   AND ($2::text = '' OR source = $2)
@@ -262,12 +204,11 @@ WHERE user_id = $1
     OR from_addr ILIKE '%' || $3 || '%'
     OR body_text ILIKE '%' || $3 || '%'
   )
-GROUP BY subject_norm
-ORDER BY max(received_at) DESC
+ORDER BY received_at DESC, id DESC
 LIMIT $5 OFFSET $4
 `
 
-type ListInboxGroupsParams struct {
+type ListEmailsParams struct {
 	UserID int64  `json:"user_id"`
 	Src    string `json:"src"`
 	Q      string `json:"q"`
@@ -275,22 +216,24 @@ type ListInboxGroupsParams struct {
 	Lim    int32  `json:"lim"`
 }
 
-type ListInboxGroupsRow struct {
-	SubjectNorm    string             `json:"subject_norm"`
-	MessageCount   int64              `json:"message_count"`
-	UnreadCount    int64              `json:"unread_count"`
-	LatestReceived pgtype.Timestamptz `json:"latest_received"`
-	LatestSubject  string             `json:"latest_subject"`
-	Senders        []string           `json:"senders"`
+type ListEmailsRow struct {
+	ID         int64              `json:"id"`
+	Source     string             `json:"source"`
+	ExternalID string             `json:"external_id"`
+	FromAddr   string             `json:"from_addr"`
+	FromName   string             `json:"from_name"`
+	Subject    string             `json:"subject"`
+	Snippet    string             `json:"snippet"`
+	ReceivedAt pgtype.Timestamptz `json:"received_at"`
+	Read       bool               `json:"read"`
 }
 
-// One row per normalized subject: total + unread counts, newest receipt, distinct
-// sender names, and the newest message's original subject for display. An optional
-// source filter (empty = all accounts) narrows to one source; an optional search
-// term (empty = no filter) matches a message's subject, sender, or body — a group
-// surfaces when any of its messages matches.
-func (q *Queries) ListInboxGroups(ctx context.Context, arg ListInboxGroupsParams) ([]ListInboxGroupsRow, error) {
-	rows, err := q.db.Query(ctx, listInboxGroups,
+// Flat inbox listing, newest first — one row per message (no subject grouping).
+// An optional source filter (empty = all accounts) narrows to one source; an
+// optional search term (empty = no filter) matches subject, sender, or body. The
+// snippet is the body's leading text with whitespace collapsed, for the list row.
+func (q *Queries) ListEmails(ctx context.Context, arg ListEmailsParams) ([]ListEmailsRow, error) {
+	rows, err := q.db.Query(ctx, listEmails,
 		arg.UserID,
 		arg.Src,
 		arg.Q,
@@ -301,16 +244,19 @@ func (q *Queries) ListInboxGroups(ctx context.Context, arg ListInboxGroupsParams
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListInboxGroupsRow{}
+	items := []ListEmailsRow{}
 	for rows.Next() {
-		var i ListInboxGroupsRow
+		var i ListEmailsRow
 		if err := rows.Scan(
-			&i.SubjectNorm,
-			&i.MessageCount,
-			&i.UnreadCount,
-			&i.LatestReceived,
-			&i.LatestSubject,
-			&i.Senders,
+			&i.ID,
+			&i.Source,
+			&i.ExternalID,
+			&i.FromAddr,
+			&i.FromName,
+			&i.Subject,
+			&i.Snippet,
+			&i.ReceivedAt,
+			&i.Read,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -118,9 +118,8 @@ type Querier interface {
 	// so search/filter pagination reports the filtered total. Keep this WHERE identical
 	// to ListCompanies.
 	CountCompanies(ctx context.Context, arg CountCompaniesParams) (int64, error)
-	// Total distinct subject groups for the caller (same optional source + search),
-	// so the inbox knows whether more pages remain.
-	CountInboxGroups(ctx context.Context, arg CountInboxGroupsParams) (int64, error)
+	// Total messages for the caller (same optional source + search), for pagination.
+	CountEmails(ctx context.Context, arg CountEmailsParams) (int64, error)
 	// Per-stage application counts for the Pipeline snapshot. An application is any
 	// row the user applied to or staged (saved-only rows are excluded); a row with
 	// applied_at set but no stage groups under a NULL stage. The Go layer folds these
@@ -395,13 +394,11 @@ type Querier interface {
 	ListCompanySitemap(ctx context.Context, arg ListCompanySitemapParams) ([]ListCompanySitemapRow, error)
 	// Drives the sync worker: every connection still authorized.
 	ListConnectedGmailUsers(ctx context.Context) ([]ListConnectedGmailUsersRow, error)
-	ListEmailsByGroup(ctx context.Context, arg ListEmailsByGroupParams) ([]ListEmailsByGroupRow, error)
-	// One row per normalized subject: total + unread counts, newest receipt, distinct
-	// sender names, and the newest message's original subject for display. An optional
-	// source filter (empty = all accounts) narrows to one source; an optional search
-	// term (empty = no filter) matches a message's subject, sender, or body — a group
-	// surfaces when any of its messages matches.
-	ListInboxGroups(ctx context.Context, arg ListInboxGroupsParams) ([]ListInboxGroupsRow, error)
+	// Flat inbox listing, newest first — one row per message (no subject grouping).
+	// An optional source filter (empty = all accounts) narrows to one source; an
+	// optional search term (empty = no filter) matches subject, sender, or body. The
+	// snippet is the body's leading text with whitespace collapsed, for the list row.
+	ListEmails(ctx context.Context, arg ListEmailsParams) ([]ListEmailsRow, error)
 	// Dense activity series over [from, to] at the given granularity. A daily
 	// generate_series builds the gap-free calendar; the LEFT JOIN fills each day's
 	// counts (missing days → 0), and date_trunc(unit, ...) rolls those days up to the

--- a/internal/db/queries/gmail.sql
+++ b/internal/db/queries/gmail.sql
@@ -49,19 +49,14 @@ INSERT INTO emails (
 ) VALUES ($1, 'gmail', $2, $3, $4, $5, $6, $7, $8, $9, $10)
 ON CONFLICT (user_id, source, external_id) DO NOTHING;
 
--- name: ListInboxGroups :many
--- One row per normalized subject: total + unread counts, newest receipt, distinct
--- sender names, and the newest message's original subject for display. An optional
--- source filter (empty = all accounts) narrows to one source; an optional search
--- term (empty = no filter) matches a message's subject, sender, or body — a group
--- surfaces when any of its messages matches.
-SELECT
-    subject_norm,
-    count(*)                                                   AS message_count,
-    count(*) FILTER (WHERE read_at IS NULL)                    AS unread_count,
-    max(received_at)::timestamptz                              AS latest_received,
-    ((array_agg(subject ORDER BY received_at DESC))[1])::text  AS latest_subject,
-    array_remove(array_agg(DISTINCT from_name), '')::text[]    AS senders
+-- name: ListEmails :many
+-- Flat inbox listing, newest first — one row per message (no subject grouping).
+-- An optional source filter (empty = all accounts) narrows to one source; an
+-- optional search term (empty = no filter) matches subject, sender, or body. The
+-- snippet is the body's leading text with whitespace collapsed, for the list row.
+SELECT id, source, external_id, from_addr, from_name, subject,
+    left(regexp_replace(body_text, E'\\s+', ' ', 'g'), 160)::text AS snippet,
+    received_at, (read_at IS NOT NULL)::boolean AS read
 FROM emails
 WHERE user_id = $1
   AND (sqlc.arg(src)::text = '' OR source = sqlc.arg(src))
@@ -72,14 +67,12 @@ WHERE user_id = $1
     OR from_addr ILIKE '%' || sqlc.arg(q) || '%'
     OR body_text ILIKE '%' || sqlc.arg(q) || '%'
   )
-GROUP BY subject_norm
-ORDER BY max(received_at) DESC
+ORDER BY received_at DESC, id DESC
 LIMIT sqlc.arg(lim) OFFSET sqlc.arg(off);
 
--- name: CountInboxGroups :one
--- Total distinct subject groups for the caller (same optional source + search),
--- so the inbox knows whether more pages remain.
-SELECT count(DISTINCT subject_norm)
+-- name: CountEmails :one
+-- Total messages for the caller (same optional source + search), for pagination.
+SELECT count(*)
 FROM emails
 WHERE user_id = $1
   AND (sqlc.arg(src)::text = '' OR source = sqlc.arg(src))
@@ -90,13 +83,6 @@ WHERE user_id = $1
     OR from_addr ILIKE '%' || sqlc.arg(q) || '%'
     OR body_text ILIKE '%' || sqlc.arg(q) || '%'
   );
-
--- name: ListEmailsByGroup :many
-SELECT id, source, external_id, from_addr, from_name, subject, received_at,
-    (read_at IS NOT NULL)::boolean AS read
-FROM emails
-WHERE user_id = $1 AND subject_norm = $2
-ORDER BY received_at DESC;
 
 -- name: GetEmail :one
 SELECT id, source, external_id, s3_key, from_addr, from_name, subject,

--- a/internal/handler/gmail_integration_test.go
+++ b/internal/handler/gmail_integration_test.go
@@ -1,7 +1,7 @@
 //go:build integration
 
 // Integration tests for the Gmail inbox HTTP flow against a real Postgres: the
-// inbox groups mail by normalized subject (Re:/Fwd: folded), a message body is
+// inbox is a flat per-user message list (search filters it), a message body is
 // caller-scoped (another user's is a 404), and disconnect purges the connection
 // and all synced mail. Run with: go test -tags=integration ./internal/handler/
 package handler
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
@@ -62,7 +61,6 @@ func TestGmailInboxEndToEnd(t *testing.T) {
 	app.Get("/api/v1/me/gmail", ra, h.GmailStatus)
 	app.Delete("/api/v1/me/gmail", ra, h.GmailDisconnect)
 	app.Get("/api/v1/me/inbox", ra, h.GetInbox)
-	app.Get("/api/v1/me/inbox/group", ra, h.GetInboxGroup)
 	app.Get("/api/v1/me/emails/:id", ra, h.GetEmail)
 
 	do := func(method, path string) (int, map[string]any) {
@@ -85,32 +83,17 @@ func TestGmailInboxEndToEnd(t *testing.T) {
 		t.Errorf("status data = %v", body["data"])
 	}
 
-	// Inbox: two groups; the applying group folds m1+m2 (count 2).
+	// Inbox: a flat list of this user's three messages (m1, m2, m3); m4 is another
+	// user's and must not appear.
 	_, body := do("GET", "/api/v1/me/inbox")
-	groups, _ := body["data"].([]any)
-	if len(groups) != 2 {
-		t.Fatalf("groups = %d, want 2", len(groups))
-	}
-	var applyCount float64
-	for _, g := range groups {
-		if gm, _ := g.(map[string]any); gm["key"] == "thank you for applying to acme" {
-			applyCount, _ = gm["message_count"].(float64)
-		}
-	}
-	if applyCount != 2 {
-		t.Errorf("apply group count = %v, want 2", applyCount)
+	if msgs, _ := body["data"].([]any); len(msgs) != 3 {
+		t.Fatalf("messages = %d, want 3", len(msgs))
 	}
 
-	// Group thread: two messages.
-	_, body = do("GET", "/api/v1/me/inbox/group?key="+url.QueryEscape("thank you for applying to acme"))
-	if msgs, _ := body["data"].([]any); len(msgs) != 2 {
-		t.Errorf("group messages = %d, want 2", len(msgs))
-	}
-
-	// Search: "interview" matches only the interview group.
+	// Search: "interview" matches only m3.
 	_, body = do("GET", "/api/v1/me/inbox?q=interview")
-	if g, _ := body["data"].([]any); len(g) != 1 {
-		t.Errorf("search 'interview' groups = %d, want 1", len(g))
+	if m, _ := body["data"].([]any); len(m) != 1 {
+		t.Errorf("search 'interview' messages = %d, want 1", len(m))
 	}
 
 	// Message body, caller-scoped.

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -378,7 +378,6 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/me/gmail", saved, requireModerator, a.GmailStatus)
 	api.Delete("/me/gmail", saved, requireModerator, a.GmailDisconnect)
 	api.Get("/me/inbox", saved, requireModerator, a.GetInbox)
-	api.Get("/me/inbox/group", saved, requireModerator, a.GetInboxGroup)
 	api.Get("/me/emails/:id", saved, requireModerator, a.GetEmail)
 	if a.gmailReady() {
 		api.Get("/me/gmail/connect", saved, requireModerator, a.GmailConnect)

--- a/internal/handler/inbox.go
+++ b/internal/handler/inbox.go
@@ -11,14 +11,17 @@ import (
 // inboxSources is the account-switcher vocabulary: "" means all accounts.
 var inboxSources = map[string]bool{"": true, "gmail": true, "hosted": true}
 
-// inboxGroup is one subject-grouped bucket in the inbox listing.
-type inboxGroup struct {
-	Key            string    `json:"key"`     // normalized subject (group key)
-	Subject        string    `json:"subject"` // newest message's original subject
-	MessageCount   int64     `json:"message_count"`
-	UnreadCount    int64     `json:"unread_count"`
-	LatestReceived time.Time `json:"latest_received"`
-	Senders        []string  `json:"senders"`
+// inboxMessage is one row in the flat inbox listing.
+type inboxMessage struct {
+	ID         int64     `json:"id"`
+	Source     string    `json:"source"`
+	ExternalID string    `json:"external_id"`
+	FromAddr   string    `json:"from_addr"`
+	FromName   string    `json:"from_name"`
+	Subject    string    `json:"subject"`
+	Snippet    string    `json:"snippet"`
+	ReceivedAt time.Time `json:"received_at"`
+	Read       bool      `json:"read"`
 }
 
 // emailBody is the single-message wire shape. s3_key (the internal raw-MIME
@@ -36,8 +39,9 @@ type emailBody struct {
 	Read       bool      `json:"read"`
 }
 
-// GetInbox returns the caller's mail grouped by normalized subject, newest group
-// first. An optional ?source= (gmail|hosted) filters to one account (the switcher).
+// GetInbox returns the caller's mail as a flat list, newest first. An optional
+// ?source= (gmail|hosted) filters to one account (the switcher); ?q= searches
+// subject/sender/body; standard limit/offset pagination.
 func (a *API) GetInbox(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
@@ -49,42 +53,25 @@ func (a *API) GetInbox(c *fiber.Ctx) error {
 	}
 	q := c.Query("q")
 	limit, offset := pageParams(c) // default 20, clamped
-	rows, err := a.queries.ListInboxGroups(c.Context(), db.ListInboxGroupsParams{
+	rows, err := a.queries.ListEmails(c.Context(), db.ListEmailsParams{
 		UserID: userID, Src: src, Q: q, Lim: int32(limit), Off: int32(offset),
 	})
 	if err != nil {
 		return err
 	}
-	total, err := a.queries.CountInboxGroups(c.Context(), db.CountInboxGroupsParams{UserID: userID, Src: src, Q: q})
+	total, err := a.queries.CountEmails(c.Context(), db.CountEmailsParams{UserID: userID, Src: src, Q: q})
 	if err != nil {
 		return err
 	}
-	out := make([]inboxGroup, 0, len(rows))
+	out := make([]inboxMessage, 0, len(rows))
 	for _, r := range rows {
-		out = append(out, inboxGroup{
-			Key: r.SubjectNorm, Subject: r.LatestSubject,
-			MessageCount: r.MessageCount, UnreadCount: r.UnreadCount,
-			LatestReceived: r.LatestReceived.Time, Senders: r.Senders,
+		out = append(out, inboxMessage{
+			ID: r.ID, Source: r.Source, ExternalID: r.ExternalID,
+			FromAddr: r.FromAddr, FromName: r.FromName, Subject: r.Subject,
+			Snippet: r.Snippet, ReceivedAt: r.ReceivedAt.Time, Read: r.Read,
 		})
 	}
 	return listResponse(c, out, total, limit, offset)
-}
-
-// GetInboxGroup returns one subject group's messages, newest first. The group key
-// (a normalized subject, which may contain spaces) is passed as ?key=. A group may
-// span sources, so it is not source-filtered.
-func (a *API) GetInboxGroup(c *fiber.Ctx) error {
-	userID, err := requireUserID(c)
-	if err != nil {
-		return err
-	}
-	rows, err := a.queries.ListEmailsByGroup(c.Context(), db.ListEmailsByGroupParams{
-		UserID: userID, SubjectNorm: c.Query("key"),
-	})
-	if err != nil {
-		return err
-	}
-	return c.JSON(fiber.Map{"data": rows})
 }
 
 // GetEmail returns one message body, scoped to the caller (404 for another user's),

--- a/internal/handler/mailbox_integration_test.go
+++ b/internal/handler/mailbox_integration_test.go
@@ -93,11 +93,11 @@ func TestHostedMailboxEndToEnd(t *testing.T) {
 		t.Fatalf("seed hosted email: %v", err)
 	}
 	if _, body := do("GET", "/api/v1/me/inbox"); func() bool { g, _ := body["data"].([]any); return len(g) != 2 }() {
-		t.Error("inbox should list 2 groups (gmail + hosted)")
+		t.Error("inbox should list 2 messages (gmail + hosted)")
 	}
 	// Source filter narrows to the hosted account only.
 	if _, body := do("GET", "/api/v1/me/inbox?source=hosted"); func() bool { g, _ := body["data"].([]any); return len(g) != 1 }() {
-		t.Error("hosted filter should list 1 group")
+		t.Error("hosted filter should list 1 message")
 	}
 
 	// Release purges hosted mail + the mailbox; Gmail mail survives.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -137,17 +137,7 @@ export interface MailboxStatus {
 /** The account switcher value: '' = all sources. */
 export type InboxSource = '' | 'gmail' | 'hosted';
 
-/** One subject-grouped bucket in the inbox. */
-export interface InboxGroup {
-  key: string;
-  subject: string;
-  message_count: number;
-  unread_count: number;
-  latest_received: string;
-  senders: string[];
-}
-
-/** A message row within a group. */
+/** One row in the flat inbox listing. */
 export interface InboxMessage {
   id: number;
   source: string;
@@ -155,6 +145,7 @@ export interface InboxMessage {
   from_addr: string;
   from_name: string;
   subject: string;
+  snippet: string;
   received_at: string;
   read: boolean;
 }
@@ -792,22 +783,22 @@ export function createApi(
     await requestData<unknown>('/api/v1/me/gmail/sync', { method: 'POST' });
   }
 
-  /** A page of the inbox grouped by normalized subject, newest group first, with
-   *  the total group count. Optional search term filters by message subject,
-   *  sender, or body; optional source narrows to one account (the switcher). */
+  /** A page of the flat inbox listing, newest first, with the total message count.
+   *  Optional search term filters by subject, sender, or body; optional source
+   *  narrows to one account (the switcher). */
   async function getInbox(
     q = '',
     limit = 20,
     offset = 0,
     source: InboxSource = '',
-  ): Promise<{ groups: InboxGroup[]; total: number }> {
+  ): Promise<{ messages: InboxMessage[]; total: number }> {
     const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
     if (q) params.set('q', q);
     if (source) params.set('source', source);
-    const res = await request<{ data: InboxGroup[]; meta: { total: number } }>(
+    const res = await request<{ data: InboxMessage[]; meta: { total: number } }>(
       `/api/v1/me/inbox?${params.toString()}`,
     );
-    return { groups: res.data, total: res.meta.total };
+    return { messages: res.data, total: res.meta.total };
   }
 
   /** The caller's hosted-mailbox address (or null) + feature availability. */
@@ -823,11 +814,6 @@ export function createApi(
   /** Release the hosted mailbox: drop the address and purge its received mail. */
   async function releaseMailbox(): Promise<MailboxStatus> {
     return requestData<MailboxStatus>('/api/v1/me/mailbox', { method: 'DELETE' });
-  }
-
-  /** One subject group's messages, newest first. */
-  async function getInboxGroup(key: string): Promise<InboxMessage[]> {
-    return requestData<InboxMessage[]>(`/api/v1/me/inbox/group?key=${encodeURIComponent(key)}`);
   }
 
   /** One message's full body. */
@@ -913,7 +899,6 @@ export function createApi(
     claimMailbox,
     releaseMailbox,
     getInbox,
-    getInboxGroup,
     getEmail,
   };
 }

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -5,7 +5,6 @@
     GmailStatus,
     MailboxStatus,
     InboxSource,
-    InboxGroup,
     InboxMessage,
     EmailBody,
   } from '$lib/api';
@@ -17,7 +16,7 @@
 
   let gmail = $state<GmailStatus | null>(null);
   let mailbox = $state<MailboxStatus | null>(null);
-  let groups = $state<InboxGroup[]>([]);
+  let messages = $state<InboxMessage[]>([]);
   let total = $state(0);
   let loading = $state(true);
   let error = $state<string | null>(null);
@@ -25,22 +24,20 @@
   // Account switcher: '' = all sources, 'gmail' | 'hosted' = one account.
   let source = $state<InboxSource>('');
 
-  // Search: filters groups by message subject/sender/body server-side, debounced.
+  // Search: filters by subject/sender/body server-side, debounced.
   let search = $state('');
   let searchTimer: ReturnType<typeof setTimeout> | undefined;
 
   let syncing = $state(false);
   let claiming = $state(false);
 
-  // Which pane: the mail list ('inbox') or the account setup ('settings'). Kept in
-  // separate tabs so the page doesn't dump connection cards and mail at once.
+  // Which pane: the mail list ('inbox') or the account setup ('settings').
   let tab = $state<'inbox' | 'settings'>('inbox');
 
-  // Expanded group's messages, cached by key; and the opened message body.
-  let expanded = $state<string | null>(null);
-  let threads = $state<Record<string, InboxMessage[]>>({});
-  let openMsgId = $state<number | null>(null);
-  let bodies = $state<Record<number, EmailBody>>({});
+  // The selected message and its loaded body (reading pane).
+  let selectedId = $state<number | null>(null);
+  let selected = $state<EmailBody | null>(null);
+  let bodyLoading = $state(false);
 
   const hasGmail = $derived(!!gmail?.connected);
   const hasMailbox = $derived(!!mailbox?.address);
@@ -63,17 +60,17 @@
     }
   }
 
-  // Load the first page of groups for the current search term + source filter.
+  // Load the first page for the current search term + source filter.
   async function fetchFirstPage() {
     const res = await api.getInbox(search, PAGE_SIZE, 0, source);
-    groups = res.groups;
+    messages = res.messages;
     total = res.total;
   }
 
-  // Reload the first page for the current filters; collapses any open group.
-  async function reloadGroups() {
-    expanded = null;
-    openMsgId = null;
+  // Reload the first page; clears the reading pane.
+  async function reloadList() {
+    selectedId = null;
+    selected = null;
     try {
       await fetchFirstPage();
     } catch (e) {
@@ -83,8 +80,8 @@
 
   async function loadMore() {
     try {
-      const res = await api.getInbox(search, PAGE_SIZE, groups.length, source);
-      groups = [...groups, ...res.groups];
+      const res = await api.getInbox(search, PAGE_SIZE, messages.length, source);
+      messages = [...messages, ...res.messages];
       total = res.total;
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to load more.';
@@ -93,13 +90,28 @@
 
   function onSearchInput() {
     clearTimeout(searchTimer);
-    searchTimer = setTimeout(reloadGroups, 250);
+    searchTimer = setTimeout(reloadList, 250);
   }
 
   async function setSource(s: InboxSource) {
     if (source === s) return;
     source = s;
-    await reloadGroups();
+    await reloadList();
+  }
+
+  async function openMessage(id: number) {
+    selectedId = id;
+    selected = null;
+    bodyLoading = true;
+    try {
+      selected = await api.getEmail(id);
+      // Reflect the just-opened message as read in the list without a refetch.
+      messages = messages.map((m) => (m.id === id ? { ...m, read: true } : m));
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to load the message.';
+    } finally {
+      bodyLoading = false;
+    }
   }
 
   // --- Gmail source ---
@@ -175,61 +187,13 @@
   // Refresh the listing after a source is added/removed; empties it when none left.
   async function refresh() {
     if (!hasAnySource) {
-      groups = [];
+      messages = [];
       total = 0;
+      selectedId = null;
+      selected = null;
       return;
     }
-    await reloadGroups();
-  }
-
-  // --- Reading ---
-
-  async function toggleGroup(key: string) {
-    if (expanded === key) {
-      expanded = null;
-      return;
-    }
-    expanded = key;
-    openMsgId = null;
-    if (!threads[key]) {
-      try {
-        threads = { ...threads, [key]: await api.getInboxGroup(key) };
-      } catch (e) {
-        error = e instanceof Error ? e.message : 'Failed to load the thread.';
-      }
-    }
-  }
-
-  async function openMessage(id: number) {
-    if (openMsgId === id) {
-      openMsgId = null;
-      return;
-    }
-    openMsgId = id;
-    if (!bodies[id]) {
-      try {
-        const body = await api.getEmail(id);
-        bodies = { ...bodies, [id]: body };
-        // Reflect the just-opened message as read in the current thread + group counts.
-        markReadLocally(id);
-      } catch (e) {
-        error = e instanceof Error ? e.message : 'Failed to load the message.';
-      }
-    }
-  }
-
-  // Optimistically flip a message to read in the cached thread and decrement its
-  // group's unread count, so the list matches the server without a refetch.
-  function markReadLocally(id: number) {
-    for (const [key, msgs] of Object.entries(threads)) {
-      const idx = msgs.findIndex((m) => m.id === id && !m.read);
-      if (idx === -1) continue;
-      threads[key] = msgs.map((m) => (m.id === id ? { ...m, read: true } : m));
-      groups = groups.map((g) =>
-        g.key === key ? { ...g, unread_count: Math.max(0, g.unread_count - 1) } : g,
-      );
-      break;
-    }
+    await reloadList();
   }
 </script>
 
@@ -257,60 +221,59 @@
     {#if tab === 'settings'}
       <!-- Sources: the two ways to get mail in — connect Gmail and/or claim a mailbox. -->
       <div class="grid gap-3 sm:grid-cols-2">
-      <!-- Gmail -->
-      <div class="rounded-xl border border-border bg-card p-4">
-        <div class="flex items-center gap-2 text-sm font-medium">
-          <Mail class="h-4 w-4 text-muted-foreground" /> Gmail
-        </div>
-        {#if hasGmail}
-          <p class="mt-1 truncate text-xs text-muted-foreground">{gmail?.email}</p>
-          {#if gmail?.status === 'needs_reconsent'}
-            <Badge variant="outline" class="mt-2 border-destructive/40 text-destructive">Reconnect needed</Badge>
-          {/if}
-          <div class="mt-3 flex flex-wrap gap-2">
+        <!-- Gmail -->
+        <div class="rounded-xl border border-border bg-card p-4">
+          <div class="flex items-center gap-2 text-sm font-medium">
+            <Mail class="h-4 w-4 text-muted-foreground" /> Gmail
+          </div>
+          {#if hasGmail}
+            <p class="mt-1 truncate text-xs text-muted-foreground">{gmail?.email}</p>
             {#if gmail?.status === 'needs_reconsent'}
-              <Button variant="secondary" size="sm" onclick={connectGmail}>Reconnect</Button>
+              <Badge variant="outline" class="mt-2 border-destructive/40 text-destructive">Reconnect needed</Badge>
             {/if}
-            <Button variant="secondary" size="sm" disabled={syncing} onclick={sync}>
-              {syncing ? 'Syncing…' : 'Sync'}
+            <div class="mt-3 flex flex-wrap gap-2">
+              {#if gmail?.status === 'needs_reconsent'}
+                <Button variant="secondary" size="sm" onclick={connectGmail}>Reconnect</Button>
+              {/if}
+              <Button variant="secondary" size="sm" disabled={syncing} onclick={sync}>
+                {syncing ? 'Syncing…' : 'Sync'}
+              </Button>
+              <Button variant="outline" size="sm" onclick={disconnectGmail}>Disconnect</Button>
+            </div>
+          {:else if gmail?.available}
+            <p class="mt-1 text-xs text-muted-foreground">Pull replies from your own Gmail (needs Google sign-in).</p>
+            <Button variant="primary" size="sm" class="mt-3" onclick={connectGmail}>
+              Connect Gmail <Mail class="h-4 w-4" />
             </Button>
-            <Button variant="outline" size="sm" onclick={disconnectGmail}>Disconnect</Button>
-          </div>
-        {:else if gmail?.available}
-          <p class="mt-1 text-xs text-muted-foreground">Pull replies from your own Gmail (needs Google sign-in).</p>
-          <Button variant="primary" size="sm" class="mt-3" onclick={connectGmail}>
-            Connect Gmail <Mail class="h-4 w-4" />
-          </Button>
-        {:else}
-          <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
-        {/if}
-      </div>
-
-      <!-- Hosted mailbox -->
-      <div class="rounded-xl border border-border bg-card p-4">
-        <div class="flex items-center gap-2 text-sm font-medium">
-          <AtSign class="h-4 w-4 text-muted-foreground" /> freehire mailbox
+          {:else}
+            <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
+          {/if}
         </div>
-        {#if hasMailbox}
-          <div class="mt-1 flex items-center gap-1">
-            <code class="truncate rounded bg-muted px-1.5 py-0.5 text-xs">{mailbox?.address}</code>
-            <button type="button" onclick={copyAddress} title="Copy address" class="shrink-0 text-muted-foreground hover:text-foreground">
-              <Copy class="h-3.5 w-3.5" />
-            </button>
-          </div>
-          <p class="mt-2 text-xs text-muted-foreground">Use this address when you apply — replies land here.</p>
-          <Button variant="outline" size="sm" class="mt-3" onclick={releaseMailbox}>Release</Button>
-        {:else if mailbox?.available}
-          <p class="mt-1 text-xs text-muted-foreground">Get an address on our domain — no Google needed.</p>
-          <Button variant="primary" size="sm" class="mt-3" disabled={claiming} onclick={claimMailbox}>
-            {claiming ? 'Creating…' : 'Get a freehire mailbox'} <AtSign class="h-4 w-4" />
-          </Button>
-        {:else}
-          <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
-        {/if}
-      </div>
-    </div>
 
+        <!-- Hosted mailbox -->
+        <div class="rounded-xl border border-border bg-card p-4">
+          <div class="flex items-center gap-2 text-sm font-medium">
+            <AtSign class="h-4 w-4 text-muted-foreground" /> freehire mailbox
+          </div>
+          {#if hasMailbox}
+            <div class="mt-1 flex items-center gap-1">
+              <code class="truncate rounded bg-muted px-1.5 py-0.5 text-xs">{mailbox?.address}</code>
+              <button type="button" onclick={copyAddress} title="Copy address" class="shrink-0 text-muted-foreground hover:text-foreground">
+                <Copy class="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <p class="mt-2 text-xs text-muted-foreground">Use this address when you apply — replies land here.</p>
+            <Button variant="outline" size="sm" class="mt-3" onclick={releaseMailbox}>Release</Button>
+          {:else if mailbox?.available}
+            <p class="mt-1 text-xs text-muted-foreground">Get an address on our domain — no Google needed.</p>
+            <Button variant="primary" size="sm" class="mt-3" disabled={claiming} onclick={claimMailbox}>
+              {claiming ? 'Creating…' : 'Get a freehire mailbox'} <AtSign class="h-4 w-4" />
+            </Button>
+          {:else}
+            <p class="mt-1 text-xs text-muted-foreground">Not available yet.</p>
+          {/if}
+        </div>
+      </div>
     {:else if !hasAnySource}
       <p class="py-8 text-center text-sm text-muted-foreground">
         No mail source yet —
@@ -342,100 +305,98 @@
         class="w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
       />
 
-      {#if groups.length === 0}
+      {#if messages.length === 0}
         <p class="py-12 text-center text-sm text-muted-foreground">
           {search ? 'No mail matches your search.' : 'No mail yet — it appears here as it arrives.'}
         </p>
       {:else}
-        <ul class="flex flex-col gap-2">
-          {#each groups as g (g.key)}
-            <li class="overflow-hidden rounded-xl border border-border bg-card transition hover:border-brand">
-              <button
-                type="button"
-                onclick={() => toggleGroup(g.key)}
-                class="flex w-full items-center gap-3 p-4 text-left hover:bg-accent"
-              >
-                {#if g.unread_count > 0}
-                  <span class="h-2 w-2 shrink-0 rounded-full bg-brand" aria-label="unread"></span>
-                {/if}
-                <div class="min-w-0 flex-1">
-                  <div class="truncate {g.unread_count > 0 ? 'font-semibold' : 'font-medium'}">
-                    {g.subject || '(no subject)'}
-                  </div>
-                  <div class="truncate text-xs text-muted-foreground">{g.senders.join(', ')}</div>
-                </div>
-                <span class="shrink-0 text-xs text-muted-foreground">{timeAgo(g.latest_received)}</span>
-                <Badge variant="secondary">{g.message_count}</Badge>
-              </button>
+        <!-- Two-pane mail client: the flat message list, then the reading pane. -->
+        <div class="grid gap-4 md:grid-cols-[minmax(0,22rem)_1fr]">
+          <div class="flex flex-col gap-2">
+            <ul class="flex flex-col gap-1">
+              {#each messages as m (m.id)}
+                <li>
+                  <button
+                    type="button"
+                    onclick={() => openMessage(m.id)}
+                    aria-current={selectedId === m.id}
+                    class="w-full rounded-lg border p-3 text-left transition-colors {selectedId === m.id
+                      ? 'border-brand bg-secondary'
+                      : 'border-border bg-card hover:bg-accent'}"
+                  >
+                    <div class="flex items-center gap-2">
+                      {#if !m.read}
+                        <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-brand" aria-label="unread"></span>
+                      {/if}
+                      <span class="min-w-0 truncate text-sm {m.read ? 'font-normal' : 'font-semibold'}">
+                        {m.from_name || m.from_addr}
+                      </span>
+                      <span class="ml-auto shrink-0 text-xs text-muted-foreground">{timeAgo(m.received_at)}</span>
+                    </div>
+                    <div class="mt-0.5 truncate text-sm {m.read ? 'text-muted-foreground' : 'text-foreground'}">
+                      {m.subject || '(no subject)'}
+                    </div>
+                    {#if m.snippet}
+                      <div class="mt-0.5 truncate text-xs text-muted-foreground">{m.snippet}</div>
+                    {/if}
+                  </button>
+                </li>
+              {/each}
+            </ul>
 
-              {#if expanded === g.key}
-                <div class="border-t border-border p-3">
-                  {#if !threads[g.key]}
-                    <p class="text-sm text-muted-foreground">Loading…</p>
-                  {:else}
-                    <ul class="flex flex-col gap-2">
-                      {#each threads[g.key] as m (m.id)}
-                        <li class="overflow-hidden rounded-lg border border-border">
-                          <button
-                            type="button"
-                            onclick={() => openMessage(m.id)}
-                            class="flex w-full flex-col gap-0.5 p-3 text-left hover:bg-accent"
-                          >
-                            <div class="flex items-center gap-2">
-                              <span class="min-w-0 truncate text-sm {m.read ? 'font-normal' : 'font-semibold'}">{m.subject}</span>
-                              <span class="ml-auto shrink-0 text-xs text-muted-foreground">{timeAgo(m.received_at)}</span>
-                            </div>
-                            <div class="truncate text-xs text-muted-foreground">{m.from_name || m.from_addr}</div>
-                          </button>
-                          {#if openMsgId === m.id}
-                            <div class="border-t border-border p-3">
-                              {#if !bodies[m.id]}
-                                <p class="text-sm text-muted-foreground">Loading…</p>
-                              {:else}
-                                {@const body = bodies[m.id]}
-                                {#if body?.source === 'gmail'}
-                                  <div class="mb-2 flex justify-end">
-                                    <a
-                                      href={gmailUrl(body?.external_id ?? '')}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      class="text-xs font-medium text-primary hover:underline"
-                                    >
-                                      Open in Gmail ↗
-                                    </a>
-                                  </div>
-                                {/if}
-                                {#if body?.body_html}
-                                  <!-- Untrusted sender HTML isolated in a sandboxed iframe (no scripts/forms/navigation). -->
-                                  <iframe
-                                    title="Message body"
-                                    sandbox=""
-                                    srcdoc={body.body_html}
-                                    class="h-[24rem] w-full rounded-md border border-border bg-white"
-                                  ></iframe>
-                                {:else}
-                                  <pre class="whitespace-pre-wrap font-sans text-sm">{body?.body_text}</pre>
-                                {/if}
-                              {/if}
-                            </div>
-                          {/if}
-                        </li>
-                      {/each}
-                    </ul>
+            {#if messages.length < total}
+              <div class="flex justify-center pt-1">
+                <Button variant="outline" size="sm" onclick={loadMore}>
+                  Load more ({messages.length} of {total})
+                </Button>
+              </div>
+            {/if}
+          </div>
+
+          <!-- Reading pane. -->
+          <div class="rounded-xl border border-border bg-card p-4">
+            {#if bodyLoading}
+              <p class="py-12 text-center text-sm text-muted-foreground">Loading…</p>
+            {:else if !selected}
+              <p class="py-12 text-center text-sm text-muted-foreground">Select a message to read it.</p>
+            {:else}
+              <div class="flex flex-col gap-1">
+                <h2 class="text-lg font-semibold tracking-tight">{selected.subject || '(no subject)'}</h2>
+                <div class="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                  <span>{selected.from_name || selected.from_addr}</span>
+                  {#if selected.from_name}
+                    <Badge variant="outline">{selected.from_addr}</Badge>
                   {/if}
+                  <span class="ml-auto text-xs">{timeAgo(selected.received_at)}</span>
+                </div>
+              </div>
+              {#if selected.source === 'gmail'}
+                <div class="mt-2 flex justify-end">
+                  <a
+                    href={gmailUrl(selected.external_id)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-xs font-medium text-primary hover:underline"
+                  >
+                    Open in Gmail ↗
+                  </a>
                 </div>
               {/if}
-            </li>
-          {/each}
-        </ul>
-
-        {#if groups.length < total}
-          <div class="flex justify-center pt-1">
-            <Button variant="outline" onclick={loadMore}>
-              Load more ({groups.length} of {total})
-            </Button>
+              <hr class="my-3 border-border" />
+              {#if selected.body_html}
+                <!-- Untrusted sender HTML isolated in a sandboxed iframe (no scripts/forms/navigation). -->
+                <iframe
+                  title="Message body"
+                  sandbox=""
+                  srcdoc={selected.body_html}
+                  class="h-[28rem] w-full rounded-md border border-border bg-white"
+                ></iframe>
+              {:else}
+                <pre class="whitespace-pre-wrap font-sans text-sm">{selected.body_text}</pre>
+              {/if}
+            {/if}
           </div>
-        {/if}
+        </div>
       {/if}
     {/if}
   </div>


### PR DESCRIPTION
Follow-up to #625/#626 — replace the subject-grouped inbox with a flat two-pane mail client like freehire-apply.

## Summary
- **Backend**: `ListEmails`/`CountEmails` (flat, newest-first, source + search filtered, with a body snippet) replace `ListInboxGroups`/`CountInboxGroups`/`ListEmailsByGroup`. `GetInbox` returns a flat message list; `GetInboxGroup` + the `/me/inbox/group` route are removed.
- **Frontend**: `InboxView` renders a two-pane client — the flat message list (sender · subject · snippet · time, read/unread) on the left, a sandboxed reading pane on the right. Account switcher, search, pagination, tabs, and the Gmail deep-link (gmail-source only) are unchanged.

## Test Plan
- [x] `go build`, `go vet`, `gofmt` clean
- [x] `go test -tags=integration ./internal/handler/` — gmail + mailbox flows updated to the flat shape, pass on real Postgres
- [x] `svelte-check` clean; no new lint errors