### PR TITLE
feat(web): fullscreen tracking card — tabs, markdown notes, fit/match

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@resvg/resvg-js": "^2.6.2",
         "@sentry/sveltekit": "^10.63.0",
         "clsx": "^2.1.1",
+        "easymde": "^2.21.0",
         "satori": "^0.26.0",
         "satori-html": "^0.3.2",
         "svelte-dnd-action": "^0.9.70",
@@ -3056,6 +3057,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.17",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
+      "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -3089,6 +3099,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/marked": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-4.3.2.tgz",
+      "integrity": "sha512-a79Yc3TOk6dGdituy8hmTTJXjOkZ7zsFYV10L337ttq/rec8lRMDBpV7fL3uLx6TgbFCa5DU/h8FmIBQPSbU0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3115,6 +3131,15 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -3724,6 +3749,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "5.65.21",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.21.tgz",
+      "integrity": "sha512-6teYk0bA0nR3QP0ihGMoxuKzpl5W80FpnHpBJpgy66NK3cZv5b/d/HY8PnRvfSsCG1MTfr92u2WUl+wT0E40mQ==",
+      "license": "MIT"
+    },
+    "node_modules/codemirror-spell-checker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
+      "integrity": "sha512-2Tl6n0v+GJRsC9K3MLCdLaMOmvWL0uukajNJseorZJsslaxZyZMgENocPU8R0DyoTAiKsyqiemSOZo7kjGV0LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "typo-js": "*"
+      }
+    },
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
@@ -3880,6 +3920,19 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/easymde": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.21.0.tgz",
+      "integrity": "sha512-5uE7I/DEN8gvGRwxaqAv7h1PMEK2ykNXVX5zL0dK3nCYROGja3AMbdQz8eCEELnfvCfy7tRkTmLuvyJG8uSWjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "^5.60.10",
+        "@types/marked": "^4.0.7",
+        "codemirror": "^5.65.15",
+        "codemirror-spell-checker": "1.1.2",
+        "marked": "^4.1.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4987,6 +5040,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/mdsvex": {
@@ -6147,6 +6212,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/typo-js": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.3.2.tgz",
+      "integrity": "sha512-Z1YkJ7IIYNrFeOxAlHUercY4Q2I+PhYD/3VkWpJGy/Oqudy3bFpNcQxnv6Oa9fTSXCHPGz1eDoX1bZYm2Z891A==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ultrahtml": {
       "version": "1.6.0",

--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
     "@resvg/resvg-js": "^2.6.2",
     "@sentry/sveltekit": "^10.63.0",
     "clsx": "^2.1.1",
+    "easymde": "^2.21.0",
     "satori": "^0.26.0",
     "satori-html": "^0.3.2",
     "svelte-dnd-action": "^0.9.70",

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -201,13 +201,15 @@
 {/if}
 
 {#if openItem}
-  <JobDrawer
-    item={openItem}
-    {pendingOutcome}
-    onsetstage={setStage}
-    onsavenotes={saveNotes}
-    onchooseoutcome={chooseOutcome}
-    onremove={remove}
-    onclose={closeDrawer}
-  />
+  {#key openItem.job.public_slug}
+    <JobDrawer
+      item={openItem}
+      {pendingOutcome}
+      onsetstage={setStage}
+      onsavenotes={saveNotes}
+      onchooseoutcome={chooseOutcome}
+      onremove={remove}
+      onclose={closeDrawer}
+    />
+  {/key}
 {/if}

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { Button } from '$lib/ui';
+  import { Button, Badge } from '$lib/ui';
+  import { Trash2, X, ExternalLink } from '@lucide/svelte';
   import { STAGES, humanizeStage } from '$lib/stages';
   import { CLOSED_OUTCOMES, type ClosedOutcome } from '$lib/board';
-  import { timeAgo } from '$lib/utils';
+  import { timeAgo, cn } from '$lib/utils';
+  import { cardTags } from '$lib/enrichment';
+  import CompanyLogo from './CompanyLogo.svelte';
+  import JobFitAnalysis from './JobFitAnalysis.svelte';
+  import JobMatch from './JobMatch.svelte';
+  import NoteEditor from './NoteEditor.svelte';
   import type { MyJob } from '$lib/types';
 
   let {
@@ -24,78 +30,263 @@
     onclose: () => void;
   } = $props();
 
-  // Local notes draft, reactively re-seeded from the item: a writable $derived
-  // tracks `item.notes` (so it resets when the parent swaps to a different item)
-  // while still accepting local edits until the next swap.
-  let notes = $derived(item.notes ?? '');
+  type Tab = 'application' | 'profile' | 'fit' | 'description';
+  const TABS: { id: Tab; label: string }[] = [
+    { id: 'application', label: 'Application' },
+    { id: 'profile', label: 'Profile match' },
+    { id: 'fit', label: 'Job Match' },
+    { id: 'description', label: 'Job description' },
+  ];
+  // Local UI state. The parent re-keys this component per job (JobBoard's {#key}),
+  // so a fresh mount always opens on Application.
+  let tab = $state<Tab>('application');
+
+  // Meta pills (work arrangement, region, employment type, seniority) — only the
+  // stated ones, reusing the list-card logic.
+  let tags = $derived(cardTags(item.job));
+  let stageLabel = $derived(item.stage ? humanizeStage(item.stage) : null);
+
+  // Interaction timeline shown as a wizard-style stepper up top, in engagement-funnel
+  // order (viewed → saved → applied): Applied is the deepest step, so it anchors the
+  // right end regardless of the raw last-viewed timestamp.
+  let activity = $derived(
+    [
+      { label: 'Viewed', at: item.viewed_at },
+      item.saved_at ? { label: 'Saved', at: item.saved_at } : null,
+      item.applied_at ? { label: 'Applied', at: item.applied_at } : null,
+    ].filter((x): x is { label: string; at: string } => x !== null),
+  );
+
+  // Lock background scroll while the fullscreen panel is open, restored on unmount
+  // (close / job switch). A DOM side-effect — the legitimate use of $effect.
+  $effect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  });
+
+  // Close the panel, first blurring whatever is focused so a pending notes edit is
+  // flushed (the editor saves on blur) while the parent's openItem is still set —
+  // onclose clears it, and the deferred save reads openItem, so it must run first.
+  function close() {
+    (document.activeElement as HTMLElement | null)?.blur();
+    onclose();
+  }
+
+  const tabClass = (active: boolean) =>
+    cn(
+      'rounded-full px-4 py-1.5 text-sm transition-colors',
+      active
+        ? 'bg-card font-medium text-foreground shadow-sm'
+        : 'text-muted-foreground hover:text-foreground',
+    );
+  const sectionLabel = 'text-sm font-medium text-muted-foreground';
 </script>
 
-<div
-  class="fixed inset-0 z-40 bg-black/30"
-  role="button"
-  tabindex="-1"
-  aria-label="Close"
-  onclick={onclose}
-  onkeydown={(e) => e.key === 'Escape' && onclose()}
-></div>
+<svelte:window onkeydown={(e) => e.key === 'Escape' && close()} />
 
-<aside
-  class="fixed z-50 flex flex-col gap-4 overflow-y-auto bg-card p-5 shadow-xl
-         inset-x-0 bottom-0 max-h-[85vh] rounded-t-2xl
-         sm:inset-y-0 sm:right-0 sm:left-auto sm:w-96 sm:max-h-none sm:rounded-none"
-  aria-label="Job details"
->
-  <div class="flex items-start justify-between gap-3">
-    <div class="min-w-0">
-      <p class="text-sm text-muted-foreground">{item.job.company || 'Unknown company'}</p>
-      <h2 class="text-lg font-semibold tracking-tight">{item.job.title}</h2>
-    </div>
-    <button type="button" onclick={onclose} class="text-muted-foreground hover:text-foreground" aria-label="Close">✕</button>
-  </div>
+<!-- Fullscreen job panel (like the swipe deck): a centered column with a fixed
+     header + pill tabs, a scrolling tab body, and a pinned View-job footer. -->
+<aside class="fixed inset-0 z-50 flex flex-col bg-background text-foreground" aria-label="Job details">
+  <!-- Header: logo · title · company · close, then meta pills and tabs -->
+  <div class="shrink-0 border-b border-border">
+    <div class="mx-auto flex w-full max-w-2xl flex-col gap-4 px-5 pb-3 pt-5 sm:px-6">
+      <div class="flex items-start gap-4">
+        <div class="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-2xl">
+          <CompanyLogo name={item.job.company} size="size-9" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <h2 class="text-xl font-bold leading-tight tracking-tight">{item.job.title}</h2>
+          <p class="text-sm text-muted-foreground">{item.job.company || 'Unknown company'}</p>
+        </div>
+        <button
+          type="button"
+          onclick={close}
+          class="-mr-1 -mt-1 shrink-0 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          aria-label="Close"
+        >
+          <X class="size-5" />
+        </button>
+      </div>
 
-  <a href={resolve('/jobs/[slug]', { slug: item.job.public_slug })} class="text-sm font-medium underline underline-offset-4">Open job →</a>
+      {#if tags.length || stageLabel}
+        <div class="flex flex-wrap items-center gap-2">
+          {#each tags as tag (tag)}
+            <span class="rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground">{tag}</span>
+          {/each}
+          {#if stageLabel}
+            <span class="rounded-full bg-brand-muted px-2.5 py-0.5 text-xs font-medium text-brand-strong">{stageLabel}</span>
+          {/if}
+        </div>
+      {/if}
 
-  {#if pendingOutcome}
-    <div class="flex flex-col gap-2 rounded-lg border border-border p-3">
-      <p class="text-sm font-medium">How did it close?</p>
-      <div class="flex flex-wrap gap-2">
-        {#each CLOSED_OUTCOMES as o (o)}
-          <Button variant="outline" onclick={() => onchooseoutcome(o)}>{humanizeStage(o)}</Button>
-        {/each}
+      {#if activity.length}
+        <ol class="flex items-center gap-2">
+          {#each activity as a, i (a.label)}
+            <li class="flex shrink-0 items-center gap-1.5">
+              <span class="size-2 rounded-full bg-brand"></span>
+              <span class="whitespace-nowrap text-xs">
+                <span class="font-medium text-foreground">{a.label}</span>
+                <span class="text-muted-foreground">{timeAgo(a.at)}</span>
+              </span>
+            </li>
+            {#if i < activity.length - 1}
+              <li aria-hidden="true" class="h-px min-w-4 flex-1 bg-border"></li>
+            {/if}
+          {/each}
+        </ol>
+      {/if}
+
+      <div class="flex items-start justify-between gap-3">
+        <div role="tablist" aria-label="Job details view" class="flex flex-wrap items-center gap-1 rounded-full bg-muted p-1">
+          {#each TABS as t (t.id)}
+            <button type="button" role="tab" aria-selected={tab === t.id} class={tabClass(tab === t.id)} onclick={() => (tab = t.id)}>
+              {t.label}
+            </button>
+          {/each}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          href={resolve('/jobs/[slug]', { slug: item.job.public_slug })}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="shrink-0 gap-1.5 whitespace-nowrap"
+        >
+          View job
+          <ExternalLink class="size-3.5" />
+        </Button>
       </div>
     </div>
-  {/if}
-
-  <label class="flex flex-col gap-1 text-sm">
-    <span class="font-medium">Stage</span>
-    <select
-      value={item.stage ?? ''}
-      onchange={(e) => onsetstage(e.currentTarget.value)}
-      class="rounded-md border border-input bg-transparent px-2 py-1.5 text-sm"
-    >
-      <option value="">No stage</option>
-      {#each STAGES as s (s.value)}
-        <option value={s.value}>{s.label}</option>
-      {/each}
-    </select>
-  </label>
-
-  <label class="flex flex-col gap-1 text-sm">
-    <span class="font-medium">Notes</span>
-    <textarea
-      bind:value={notes}
-      onblur={() => onsavenotes(notes)}
-      placeholder="Notes…"
-      rows="5"
-      class="resize-y rounded-md border border-input bg-transparent px-2 py-1.5 text-sm placeholder:text-muted-foreground focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-    ></textarea>
-  </label>
-
-  <div class="flex flex-col gap-1 text-xs text-muted-foreground">
-    {#if item.saved_at}<span>Saved {timeAgo(item.saved_at)}</span>{/if}
-    {#if item.applied_at}<span>Applied {timeAgo(item.applied_at)}</span>{/if}
-    <span>Viewed {timeAgo(item.viewed_at)}</span>
   </div>
 
-  <Button variant="outline" onclick={onremove}>Remove from board</Button>
+  <!-- Scrolling tab body -->
+  <div class="min-h-0 flex-1 overflow-y-auto">
+    <div class="mx-auto w-full max-w-2xl px-5 py-5 sm:px-6">
+      {#if tab === 'application'}
+        <div class="flex flex-col gap-4">
+          {#if pendingOutcome}
+            <div class="flex flex-col gap-2 rounded-lg border border-border p-3">
+              <p class="text-sm font-medium">How did it close?</p>
+              <div class="flex flex-wrap gap-2">
+                {#each CLOSED_OUTCOMES as o (o)}
+                  <Button variant="outline" onclick={() => onchooseoutcome(o)}>{humanizeStage(o)}</Button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+
+          <label class="flex flex-col gap-1 text-sm">
+            <span class="font-medium">Stage</span>
+            <select
+              value={item.stage ?? ''}
+              onchange={(e) => onsetstage(e.currentTarget.value)}
+              class="rounded-md border border-input bg-transparent px-2 py-1.5 text-sm"
+            >
+              <option value="">No stage</option>
+              {#each STAGES as s (s.value)}
+                <option value={s.value}>{s.label}</option>
+              {/each}
+            </select>
+          </label>
+
+          <div class="flex flex-col gap-1 text-sm">
+            <span class="font-medium">Notes</span>
+            <NoteEditor value={item.notes ?? ''} onsave={onsavenotes} />
+          </div>
+        </div>
+      {:else if tab === 'profile'}
+        <JobMatch job={item.job} />
+      {:else if tab === 'fit'}
+        <JobFitAnalysis slug={item.job.public_slug} />
+      {:else}
+        <div class="flex flex-col gap-5">
+          {#if item.job.description}
+            <!-- Description is server-sanitized HTML (see internal/sources), safe to render. -->
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -- server-sanitized; the rule flags every {@html} regardless -->
+            <div class="job-description text-sm leading-relaxed">{@html item.job.description}</div>
+          {:else}
+            <p class="text-sm text-muted-foreground">No description available.</p>
+          {/if}
+
+          {#if item.job.skills?.length}
+            <div class="flex flex-col gap-2 border-t border-border pt-5">
+              <p class={sectionLabel}>Skills</p>
+              <div class="flex flex-wrap gap-1.5">
+                {#each item.job.skills as skill (skill)}
+                  <Badge variant="secondary">{skill}</Badge>
+                {/each}
+              </div>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Pinned footer: remove-from-board (destructive card action) -->
+  <div class="shrink-0 border-t border-border">
+    <div class="mx-auto flex w-full max-w-2xl justify-end px-5 py-3 sm:px-6">
+      <Button
+        variant="ghost"
+        size="sm"
+        onclick={onremove}
+        class="gap-1.5 text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-950/40 dark:hover:text-red-300"
+      >
+        <Trash2 class="size-4" />
+        Remove from board
+      </Button>
+    </div>
+  </div>
 </aside>
+
+<style>
+  /* Descriptions are arbitrary scraped HTML: a long URL — or words glued by
+     non-breaking spaces — must wrap instead of forcing a horizontal scroll.
+     Styles mirror JobView's .job-description so the read matches the job page. */
+  .job-description {
+    overflow-wrap: break-word;
+  }
+
+  .job-description :global(h1),
+  .job-description :global(h2),
+  .job-description :global(h3),
+  .job-description :global(h4) {
+    margin-top: 1.25rem;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+  }
+
+  .job-description :global(p) {
+    margin: 0.5rem 0;
+  }
+
+  .job-description :global(ul),
+  .job-description :global(ol) {
+    margin: 0.5rem 0;
+    padding-left: 1.25rem;
+  }
+
+  .job-description :global(li) {
+    display: list-item;
+    list-style: disc outside;
+    margin: 0.25rem 0;
+  }
+
+  /* ATS boards (e.g. Greenhouse) wrap each <li> in a block <p>; collapse its
+     margins so the bullet sits beside the text instead of on its own line. */
+  .job-description :global(li) > :global(p) {
+    margin: 0;
+  }
+
+  .job-description :global(a) {
+    text-decoration: underline;
+  }
+
+  .job-description :global(b),
+  .job-description :global(strong) {
+    font-weight: 600;
+  }
+</style>

--- a/web/src/lib/components/NoteEditor.svelte
+++ b/web/src/lib/components/NoteEditor.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import 'easymde/dist/easymde.min.css';
+  import type EasyMDE from 'easymde';
+
+  // A small markdown editor for notes: EasyMDE (the maintained SimpleMDE fork) over a
+  // textarea, markdown in and out. EasyMDE touches `window`, so it is dynamically
+  // imported on mount (never on the server) and torn down on unmount. `onsave` fires
+  // on blur with the current markdown; the parent persists it. The component is
+  // re-mounted per job by JobDrawer's {#key}, so the initial value never needs to be
+  // pushed reactively.
+  let { value = '', onsave }: { value?: string; onsave: (v: string) => void } = $props();
+
+  let el = $state<HTMLTextAreaElement>();
+
+  onMount(() => {
+    let editor: EasyMDE | undefined;
+    let cancelled = false;
+    // Persist on blur AND on teardown — closing via Escape (or any unmount) never
+    // blurs the editor, so a blur-only save would drop the last edit. Dedup against
+    // the last persisted value so an untouched open/close doesn't fire a redundant save.
+    let lastSaved = value;
+    const persist = () => {
+      if (!editor) return;
+      const current = editor.value();
+      if (current === lastSaved) return;
+      lastSaved = current;
+      onsave(current);
+    };
+
+    void (async () => {
+      const { default: EasyMDECtor } = await import('easymde');
+      if (cancelled || !el) return;
+      editor = new EasyMDECtor({
+        element: el,
+        initialValue: value,
+        placeholder: 'Notes…',
+        spellChecker: false,
+        status: false,
+        minHeight: '120px',
+        toolbar: ['bold', 'italic', 'heading', '|', 'unordered-list', 'ordered-list', '|', 'link', 'preview'],
+      });
+      editor.codemirror.on('blur', persist);
+    })();
+
+    return () => {
+      cancelled = true;
+      persist();
+      // toTextArea() reverts the CodeMirror DOM and detaches listeners.
+      editor?.toTextArea();
+      editor = undefined;
+    };
+  });
+</script>
+
+<textarea bind:this={el}></textarea>
+
+<style>
+  /* Theme EasyMDE to the app tokens (raw CSS vars adapt to light/dark automatically). */
+  :global(.EasyMDEContainer .CodeMirror) {
+    background: var(--card);
+    color: var(--foreground);
+    border-color: var(--input);
+    border-bottom-left-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+    font-size: 0.875rem;
+  }
+  :global(.EasyMDEContainer .CodeMirror-cursor) {
+    border-color: var(--foreground);
+  }
+  :global(.editor-toolbar) {
+    border-color: var(--input);
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
+    opacity: 1;
+  }
+  :global(.editor-toolbar button) {
+    color: var(--muted-foreground) !important;
+    font-weight: 600;
+    border-color: transparent;
+  }
+  :global(.editor-toolbar button:hover),
+  :global(.editor-toolbar button.active) {
+    background: var(--accent);
+    border-color: var(--border);
+  }
+  :global(.editor-toolbar i.separator) {
+    border-color: var(--border);
+  }
+  :global(.editor-preview) {
+    background: var(--muted);
+    color: var(--foreground);
+  }
+  :global(.CodeMirror-selected) {
+    background: var(--accent) !important;
+  }
+</style>


### PR DESCRIPTION
## What

Reworks the tracking board's job drawer (`JobDrawer`) from a right-side panel into a **full-screen job panel** modelled on the swipe deck.

- **Header** (fixed): company logo, title, company, meta pills (arrangement · region · type · seniority + stage), and a **wizard-style stepper** of the interaction timeline (Viewed → Saved → Applied).
- **Pill tabs**: `Application` · `Profile match` · `Job Match` · `Job description`.
  - **Application** — Stage select + a **markdown Notes editor** (new `NoteEditor.svelte` wrapping EasyMDE, dynamically imported client-side, themed to the app's CSS tokens for light/dark).
  - **Profile match** — reuses `JobMatch` (deterministic skills match from the job page).
  - **Job Match** — reuses `JobFitAnalysis` (AI fit summary).
  - **Job description** — sanitized-HTML description + skills, last tab.
- **View job** (top-right) opens the job page in a new tab; **Remove from board** is pinned to a right-aligned footer with a trash icon.
- Background scroll is locked while open; `JobBoard` re-keys the drawer per job so it always opens on Application.

## Notes persistence (reviewed edge case)

The editor saves on `blur`, and `JobBoard.saveNotes` reads `openItem`. A naive close nulls `openItem` before the deferred save runs, dropping the last edit. `close()` now **blurs the focused editor before calling `onclose`**, so an Escape/✕ close flushes the pending note while `openItem` is still set. Verified end-to-end: type a note → Escape → the note is persisted (API returns it).

## Verification

- `svelte-check`, `oxlint`, `eslint` clean; `vitest` 200/200 pass.
- Visual QA on desktop (1440px) and mobile (390px) across all four tabs, on the local QA account.

## Notes / follow-ups

- EasyMDE's `autoDownloadFontAwesome` (default) fetches the toolbar icons from an external CDN at runtime. Fine for now; a self-hosted FA or a text/SVG toolbar would remove the external dependency.
- Tabs use `role="tab"` but aren't fully wired to `role="tabpanel"`/`aria-controls` yet (matches the existing Board/Pipeline tabs).
- `easymde` added as a dependency (lazy-loaded, so it stays out of the main bundle).