### PR TITLE
fix(inbox): revert wide layout, keep collapsible sidebar

### DIFF
--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -336,8 +336,8 @@
           {search ? 'No mail matches your search.' : 'No mail yet — it appears here as it arrives.'}
         </p>
       {:else}
-        <!-- Two-pane mail client: a compact message list, then a wide reading pane. -->
-        <div class="grid gap-4 md:grid-cols-[minmax(0,20rem)_1fr]">
+        <!-- Two-pane mail client: the flat message list, then the reading pane. -->
+        <div class="grid gap-4 md:grid-cols-[minmax(0,24rem)_1fr]">
           <div class="flex flex-col gap-2">
             <ul class="flex flex-col gap-1">
               {#each messages as m, i (m.id)}
@@ -442,8 +442,7 @@
                   class="h-[30rem] w-full rounded-md border border-border bg-white"
                 ></iframe>
               {:else}
-                <!-- Plain text: cap at a readable measure even in the wide pane. -->
-                <pre class="max-w-3xl whitespace-pre-wrap font-sans text-sm leading-relaxed">{s.body_text}</pre>
+                <pre class="whitespace-pre-wrap font-sans text-sm leading-relaxed">{s.body_text}</pre>
               {/if}
             {/if}
           </div>

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -32,10 +32,6 @@
 
   const path = $derived(page.url.pathname);
 
-  // The inbox is a two-pane mail client that wants the room — give it a wider
-  // container than the single-column pages (which self-constrain their own width).
-  const wide = $derived(path.startsWith('/my/inbox'));
-
   // Collapsible sidebar (lg+), persisted so it stays across navigations/sessions.
   let collapsed = $state(false);
   onMount(() => {
@@ -78,7 +74,7 @@
   <meta name="robots" content="noindex" />
 </svelte:head>
 
-<div class={cn('mx-auto w-full px-4 py-6', wide ? 'max-w-[100rem]' : 'max-w-6xl')}>
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
   {#if !isAuthenticated()}
     <div class="flex flex-col items-center gap-3 py-12 text-center">
       <p class="text-sm text-muted-foreground">Sign in to access your account.</p>

--- a/web/src/routes/my/inbox/+page.svelte
+++ b/web/src/routes/my/inbox/+page.svelte
@@ -6,6 +6,7 @@
   <title>Inbox — freehire</title>
 </svelte:head>
 
-<!-- The account shell (my/+layout) owns the container (wide for inbox), auth gate,
-     and noindex. The inbox fills the content column full-width. -->
-<InboxView />
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex. -->
+<div class="max-w-3xl">
+  <InboxView />
+</div>


### PR DESCRIPTION
Per feedback: undo the inbox-wide container + narrow list column from #634 (back to `max-w-6xl` / `max-w-3xl` / 24rem list). Keeps only the collapsible sidebar. Frontend-only; svelte-check clean.