### PR TITLE
feat(inbox): 5 per page, narrower list, borderless reading pane

### DIFF
--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -13,7 +13,7 @@
   import { timeAgo } from '$lib/utils';
   import { avatarInitials, avatarColor } from '$lib/avatar';
 
-  const PAGE_SIZE = 20;
+  const PAGE_SIZE = 5;
 
   let gmail = $state<GmailStatus | null>(null);
   let mailbox = $state<MailboxStatus | null>(null);
@@ -336,8 +336,8 @@
           {search ? 'No mail matches your search.' : 'No mail yet — it appears here as it arrives.'}
         </p>
       {:else}
-        <!-- Two-pane mail client: the flat message list, then the reading pane. -->
-        <div class="grid gap-4 md:grid-cols-[minmax(0,24rem)_1fr]">
+        <!-- Two-pane mail client: a compact message list, then a borderless reading pane. -->
+        <div class="grid gap-5 md:grid-cols-[minmax(0,19rem)_1fr]">
           <div class="flex flex-col gap-2">
             <ul class="flex flex-col gap-1">
               {#each messages as m, i (m.id)}
@@ -387,8 +387,8 @@
             {/if}
           </div>
 
-          <!-- Reading pane. -->
-          <div class="min-h-[20rem] rounded-xl border border-border bg-card p-5">
+          <!-- Reading pane — borderless, flush, to give the content the room. -->
+          <div class="min-h-[20rem]">
             {#if bodyLoading}
               <p class="py-16 text-center text-sm text-muted-foreground">Loading…</p>
             {:else if !selected}

--- a/web/src/routes/my/inbox/+page.svelte
+++ b/web/src/routes/my/inbox/+page.svelte
@@ -6,7 +6,8 @@
   <title>Inbox — freehire</title>
 </svelte:head>
 
-<!-- The account shell (my/+layout) owns the container, auth gate, and noindex. -->
-<div class="max-w-3xl">
+<!-- The account shell (my/+layout) owns the container, auth gate, and noindex. A
+     touch wider than the single-column pages so the two-pane inbox has room. -->
+<div class="max-w-4xl">
   <InboxView />
 </div>


### PR DESCRIPTION
Per feedback: list pages at 5 (Load more), message column 24rem→19rem, page max-w-3xl→4xl, and the reading pane loses its border/card frame so the content has more room. Frontend-only; svelte-check clean; visually verified.