### PR TITLE
fix(apple): full job description as sanitized HTML

### DIFF
--- a/internal/sources/apple.go
+++ b/internal/sources/apple.go
@@ -129,6 +129,7 @@ func (s apple) detail(ctx context.Context, e CompanyEntry, p applePosting) (Job,
 	}
 	var resp struct {
 		Res struct {
+			JobSummary              string `json:"jobSummary"`
 			Description             string `json:"description"`
 			MinimumQualifications   string `json:"minimumQualifications"`
 			PreferredQualifications string `json:"preferredQualifications"`
@@ -137,7 +138,7 @@ func (s apple) detail(ctx context.Context, e CompanyEntry, p applePosting) (Job,
 	if err := s.http.GetJSON(ctx, fmt.Sprintf(appleDetailURL, p.PositionID), &resp); err != nil {
 		return Job{}, false
 	}
-	desc := appleDescription(resp.Res.Description, resp.Res.MinimumQualifications, resp.Res.PreferredQualifications)
+	desc := appleDescription(resp.Res.JobSummary, resp.Res.Description, resp.Res.MinimumQualifications, resp.Res.PreferredQualifications)
 	if desc == "" {
 		return Job{}, false
 	}
@@ -180,19 +181,39 @@ func appleLocationString(locs []appleLocation) string {
 	return strings.Join(names, "; ")
 }
 
-// appleDescription assembles the role's full description from the detail fields. Apple serves
-// these as plain text (no markup), so they are joined with blank lines under their section
-// headers rather than HTML-sanitized; an empty section is omitted.
-func appleDescription(description, minQual, prefQual string) string {
-	parts := make([]string, 0, 3)
-	if d := strings.TrimSpace(description); d != "" {
-		parts = append(parts, d)
+// appleDescription assembles the role's full description from the detail fields into sanitized
+// HTML, matching the "descriptions are sanitized HTML" convention the {@html} consumer relies
+// on (mirroring the other plain-text/Markdown adapters). Apple serves the summary and
+// description as plain-text paragraphs (blank-line separated) and the qualifications as
+// newline-separated bullet lines, so the summary/description are emitted as Markdown paragraphs
+// and each qualification section as a headed bullet list. An empty section is omitted.
+func appleDescription(jobSummary, description, minQual, prefQual string) string {
+	var b strings.Builder
+	appendParagraphs := func(s string) {
+		if s = strings.TrimSpace(s); s != "" {
+			b.WriteString(s)
+			b.WriteString("\n\n")
+		}
 	}
-	if m := strings.TrimSpace(minQual); m != "" {
-		parts = append(parts, "Minimum Qualifications\n"+m)
+	appendBullets := func(header, s string) {
+		if strings.TrimSpace(s) == "" {
+			return
+		}
+		b.WriteString("## ")
+		b.WriteString(header)
+		b.WriteString("\n\n")
+		for _, line := range strings.Split(s, "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				b.WriteString("- ")
+				b.WriteString(line)
+				b.WriteString("\n")
+			}
+		}
+		b.WriteString("\n")
 	}
-	if p := strings.TrimSpace(prefQual); p != "" {
-		parts = append(parts, "Preferred Qualifications\n"+p)
-	}
-	return strings.Join(parts, "\n\n")
+	appendParagraphs(jobSummary)
+	appendParagraphs(description)
+	appendBullets("Minimum Qualifications", minQual)
+	appendBullets("Preferred Qualifications", prefQual)
+	return sanitizeHTML(markdownToHTML(strings.TrimSpace(b.String())))
 }

--- a/internal/sources/apple_test.go
+++ b/internal/sources/apple_test.go
@@ -56,6 +56,42 @@ func TestAppleProvider(t *testing.T) {
 	}
 }
 
+func TestAppleDescriptionBuildsSanitizedHTML(t *testing.T) {
+	// Apple serves the summary + description as plain-text paragraphs (\n\n) and the
+	// qualifications as newline-separated bullet lines. The stored description must be
+	// sanitized HTML (the {@html} consumer), so paragraphs become <p> and each
+	// qualification line a <li> under an <h2> section header.
+	got := appleDescription(
+		"Apple Retail is where the best of Apple comes together.\n\nAs a Specialist, you build brand loyalty.",
+		"Deliver excellent service.\n\nStay up to date on Apple products.",
+		"Availability to work nights and weekends.\nProficient in the local language.",
+		"You can:\nDemonstrate knowledge of Apple products.\nPersonalize solutions.",
+	)
+	for _, want := range []string{
+		"<p>Apple Retail is where the best of Apple comes together.</p>",
+		"<p>As a Specialist, you build brand loyalty.</p>",
+		"<p>Deliver excellent service.</p>",
+		"<h2>Minimum Qualifications</h2>",
+		"<li>Availability to work nights and weekends.</li>",
+		"<h2>Preferred Qualifications</h2>",
+		"<li>Personalize solutions.</li>",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("appleDescription() missing %q\ngot: %q", want, got)
+		}
+	}
+}
+
+func TestAppleDescriptionOmitsEmptySections(t *testing.T) {
+	got := appleDescription("", "Just a description.", "", "")
+	if !strings.Contains(got, "<p>Just a description.</p>") {
+		t.Errorf("want the description paragraph, got %q", got)
+	}
+	if strings.Contains(got, "Qualifications") {
+		t.Errorf("empty qualification sections must be omitted, got %q", got)
+	}
+}
+
 func TestAppleFetchPaginatesDedupsAndMaps(t *testing.T) {
 	fake := &appleFake{
 		pages: map[int]string{
@@ -68,7 +104,7 @@ func TestAppleFetchPaginatesDedupsAndMaps(t *testing.T) {
 			]}}`,
 		},
 		details: map[string]string{
-			"200600664": `{"res":{"description":"Build the Watch software.","minimumQualifications":"5+ years experience.","preferredQualifications":"Swift expertise."}}`,
+			"200600664": `{"res":{"jobSummary":"Join the Watch team.","description":"Build the Watch software.","minimumQualifications":"5+ years experience.","preferredQualifications":"Swift expertise."}}`,
 			"200659431": `{"res":{"description":"Keep services running.","minimumQualifications":"","preferredQualifications":""}}`,
 		},
 	}
@@ -104,10 +140,13 @@ func TestAppleFetchPaginatesDedupsAndMaps(t *testing.T) {
 	if want := "San Diego"; j.Location != want {
 		t.Errorf("Location = %q, want first-seen %q", j.Location, want)
 	}
-	for _, part := range []string{"Build the Watch software.", "5+ years experience.", "Swift expertise."} {
+	for _, part := range []string{"Join the Watch team.", "Build the Watch software.", "5+ years experience.", "Swift expertise."} {
 		if !strings.Contains(j.Description, part) {
 			t.Errorf("Description missing %q: %q", part, j.Description)
 		}
+	}
+	if !strings.Contains(j.Description, "<p>") {
+		t.Errorf("Description should be sanitized HTML, got plain text: %q", j.Description)
 	}
 	if j.Remote || j.WorkMode != "" {
 		t.Errorf("homeOffice=false should be onsite-unknown, got Remote=%v WorkMode=%q", j.Remote, j.WorkMode)


### PR DESCRIPTION
## Problem

Apple job descriptions on freehire rendered as one unformatted wall of text and were missing the intro summary — e.g. [tr-specialist-seasonal-part-time](https://freehire.dev/jobs/tr-specialist-seasonal-part-time-apple-kcv7d6v3) vs the [source](https://jobs.apple.com/en-us/details/114438164/tr-specialist-seasonal-part-time).

Two defects in `internal/sources/apple.go`:

1. **Content incomplete** — `detail()` never read the `jobSummary` field, dropping the posting's intro paragraph.
2. **No markup** — `appleDescription` returned plain text with `\n` separators, but `jobs.description` is stored as sanitized HTML and rendered via `{@html}` (`JobView.svelte`). The newlines collapsed, so everything ran together.

## Fix

Include `jobSummary` and assemble the summary/description as Markdown paragraphs, each qualifications section as a headed bullet list, then render through `sanitizeHTML(markdownToHTML(...))` — the same convention the other text/Markdown adapters use (`join`, `uber`, `getmanfred`). The sanitizer policy already allows `h2`/`ul`/`li`/`p`.

## Verification

- TDD: added `TestAppleDescriptionBuildsSanitizedHTML` + `TestAppleDescriptionOmitsEmptySections`; extended the fetch test to assert `jobSummary` inclusion and HTML output. Watched them fail, then pass.
- `go build ./...`, `go vet`, full `internal/sources` package green; `gofmt` clean.
- Ran the real live job `114438164` through the fixed adapter: full summary + description as `<p>`, qualifications as `<h2>` + `<ul>/<li>`, matching jobs.apple.com.

## Rollout

Apple re-fetches every posting's detail each crawl, so after deploy a single `freehire-ingest@apple` run re-stores all Apple descriptions with markup (changed `content_hash` → re-indexed to live Meili). No separate backfill needed.