### PR TITLE
fix(web): merge Profile match into the Job Match tab

### DIFF
--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -30,10 +30,9 @@
     onclose: () => void;
   } = $props();
 
-  type Tab = 'application' | 'profile' | 'fit' | 'description';
+  type Tab = 'application' | 'fit' | 'description';
   const TABS: { id: Tab; label: string }[] = [
     { id: 'application', label: 'Application' },
-    { id: 'profile', label: 'Profile match' },
     { id: 'fit', label: 'Job Match' },
     { id: 'description', label: 'Job description' },
   ];
@@ -199,10 +198,11 @@
             <NoteEditor value={item.notes ?? ''} onsave={onsavenotes} />
           </div>
         </div>
-      {:else if tab === 'profile'}
-        <JobMatch job={item.job} />
       {:else if tab === 'fit'}
-        <JobFitFull job={item.job} />
+        <div class="flex flex-col gap-6">
+          <JobMatch job={item.job} />
+          <JobFitFull job={item.job} />
+        </div>
       {:else}
         <div class="flex flex-col gap-5">
           {#if item.job.description}


### PR DESCRIPTION
Follow-up to #638. Drops the separate **Profile match** tab and renders the deterministic skills comparison (`JobMatch`) **above** the AI fit analysis inside the **Job Match** tab, so both match views live together (skills comparison on top, "Analyze match" below).

Tabs are now **Application · Job Match · Job description**.

- `svelte-check` clean; verified visually — the Job Match tab shows the PROFILE MATCH skills block above the fit analysis (both empty states on the QA account, which has no CV).