### PR TITLE
fix: untrack accidentally-committed cmd/embed binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,32 @@ __pycache__/
 
 # Superpowers visual brainstorm scratch
 .superpowers/
+
+# Compiled cmd/* worker binaries (go build ./cmd/<name>/ writes <name> into the repo root)
+/backfill-company-info
+/backfill-derive
+/backfill-descriptions
+/backfill-justjoin
+/embed
+/enrich
+/gen-cities
+/gen-contracts
+/gmail-sync
+/harvest-ats
+/harvest-boards
+/harvest-erecruiter
+/harvest-loxo
+/harvest-role
+/import-collections
+/import-yc
+/ingest
+/liveness
+/mail-ingest
+/notify
+/recount-companies
+/reindex
+/reslug
+/rollup-stats
+/server
+/tg-extract
+/tg-ingest


### PR DESCRIPTION
Follow-up to #644. A compiled `embed` Mach-O binary was staged by a `git add -A` (a `go build ./cmd/embed/` without `-o` had written it to the repo root). It blocked the production `release.sh` deploy at `git pull` (the host checkout has an untracked worker binary of the same name). Remove the binary from the tree and extend `.gitignore` to cover every `cmd/<name>` build artifact so the class of bug can't recur. No source/behavior change.