### PR TITLE
feat(sources): track PX.Center on Senior board

### DIFF
--- a/sources/senior.yml
+++ b/sources/senior.yml
@@ -165,3 +165,5 @@
   board: vempraunusoutsourcing
 - company: "WOLBITO DO BRASIL"
   board: wolbito
+- company: "PX.Center"
+  board: pxcenter


### PR DESCRIPTION
Add the `pxcenter` tenant to `sources/senior.yml`.

**Validation:** confirmed live against the keyless Senior Portal de Talentos API — `getProfileIdBySubdomain` resolves `pxcenter` → profileId, and `searchVacancies` returns 5 pages of open vacancies.

**Company:** PX.Center — transport-tech company in Joinville, BR (Laravel/Golang stack, Great Place To Work certified). Sourced from the two other links in the request (OpenTable/Greenhouse and withclutch/Ashby) which were already tracked.

Ingest will pick up the board on the next `cmd/ingest sources/senior.yml` run.