### PR TITLE
feat(sources): add 2GIS careers adapter

### DIFF
--- a/internal/sources/jobvite.go
+++ b/internal/sources/jobvite.go
@@ -1,0 +1,121 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// jobvite adapts Jobvite career sites (jobs.jobvite.com/<company>). The board is the company's
+// Jobvite careersite slug. The listing page server-renders a /<board>/job/<code> link for every
+// posting; each job page carries a schema.org JobPosting ld+json, so the description comes from a
+// per-posting detail fetch (bounded-concurrency) over the shared ld+json helper — the same shape
+// as the careerspage/dataart adapters.
+//
+// The public careersite renders the full job list in one page (filtering is client-side, no
+// server pagination), so Fetch reads every job anchor from the single listing. Per-page crawling
+// is the seam to add here if a board ever exceeds Jobvite's server-render cap.
+type jobvite struct {
+	http HTMLGetter
+}
+
+// NewJobvite builds the Jobvite adapter over the given HTTP client.
+func NewJobvite(c HTMLGetter) Source { return jobvite{http: c} }
+
+func (jobvite) Provider() string { return "jobvite" }
+
+func (j jobvite) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://jobs.jobvite.com/%s/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("jobvite: board %q: %w", e.Board, err)
+	}
+	root, err := j.http.GetHTML(ctx, base.String()+"jobs")
+	if err != nil {
+		return nil, fmt.Errorf("jobvite: listing %s: %w", e.Board, err)
+	}
+
+	locs := jobLinks(base, root, func(href string) bool { return jobviteJobID(href) != "" })
+
+	// Each posting's fields come from its own detail fetch, fanned out under a bounded pool.
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return j.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false when
+// the URL has no code, the fetch fails, or the page carries no JobPosting, so the caller skips
+// just that posting.
+func (j jobvite) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := jobviteJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := j.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p jobvitePosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	location := p.location()
+	return Job{
+		ExternalID: id,
+		URL:        jobURL,
+		Title:      p.Title,
+		// The configured company is canonical (the board is that employer's site); the JSON-LD
+		// hiringOrganization is ignored so a board never mislabels its own postings.
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(p.Description),
+		// Jobvite states no structured jobLocationType, so remote is inferred from the location
+		// text alone; WorkMode stays empty (the pipeline parses the location).
+		Remote:   isRemote(location),
+		PostedAt: parseDate(p.DatePosted),
+	}, true
+}
+
+// jobviteJobIDPattern captures the alphanumeric posting code from a /<board>/job/<code> path,
+// terminated by a slash, query, fragment, or end of string. The /<board>/jobs listing and the
+// /<board>/jobAlerts nav link carry no /job/<code> segment and yield no match.
+var jobviteJobIDPattern = regexp.MustCompile(`/job/([A-Za-z0-9]+)(?:[/?#]|$)`)
+
+// jobviteJobID extracts the native posting code from a job page URL, or "" when the URL is not a
+// job posting.
+func jobviteJobID(loc string) string {
+	if m := jobviteJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// jobvitePosting is the schema.org JobPosting decoded from a Jobvite job page's ld+json. It
+// reuses icimsPlaces, the shared single-or-array jobLocation decoder (Jobvite emits an array, but
+// the flexible form guards a board that emits a single Place object).
+type jobvitePosting struct {
+	Title       string      `json:"title"`
+	Description string      `json:"description"`
+	DatePosted  string      `json:"datePosted"`
+	JobLocation icimsPlaces `json:"jobLocation"`
+}
+
+// location joins each jobLocation place as "City, Country" (falling back to whichever part is
+// present), deduped and separated by "; ", so a job open in several cities lists them all.
+func (p jobvitePosting) location() string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, pl := range p.JobLocation {
+		s := joinNonEmpty(pl.Address.AddressLocality, pl.Address.AddressCountry)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return strings.Join(out, "; ")
+}

--- a/internal/sources/jobvite_test.go
+++ b/internal/sources/jobvite_test.go
@@ -1,0 +1,166 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// jobviteListingHTML is a Jobvite careersite listing page (jobs.jobvite.com/<board>/jobs). It
+// carries the given job codes as /<board>/job/<code> anchors, plus the /<board>/jobs and
+// /<board>/jobAlerts navigation anchors that must NOT be treated as postings — exercising the
+// job-link predicate.
+func jobviteListingHTML(board string, codes ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jv-page-body"><ul class="jv-job-list">`)
+	for _, c := range codes {
+		b.WriteString(`<li class="jv-job-list-item">`)
+		b.WriteString(`<a class="jv-job-list-name" href="/` + board + `/job/` + c + `">A Role</a>`)
+		b.WriteString(`<span class="jv-job-list-location">New York</span>`)
+		b.WriteString(`</li>`)
+	}
+	b.WriteString(`</ul>`)
+	b.WriteString(`<a href="/` + board + `/jobs">All jobs</a>`)
+	b.WriteString(`<a href="/` + board + `/jobAlerts">Job alerts</a>`)
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// jobviteDetailHTML is a Jobvite job page: server-rendered HTML whose payload we read is the
+// schema.org JobPosting ld+json. jobLocation is an ARRAY (the shape Jobvite emits), the
+// description is RAW HTML (not entity-escaped) embedding a <script> that sanitizeHTML must
+// strip, and datePosted is date-only.
+func jobviteDetailHTML(title, code string) string {
+	return `<html><head></head><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `",
+"identifier":"` + code + `",
+"description":"<p>Build books.</p><script>alert(1)<\/script>",
+"datePosted":"2026-06-30",
+"employmentType":"Full-Time",
+"hiringOrganization":{"@type":"Organization","name":"Hachette (schema.org)"},
+"jobLocation":[{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"New York","addressRegion":"New York","addressCountry":"United States"}}]}
+</script>
+</body></html>`
+}
+
+// jobviteRemoteSingleLocationHTML is a job page whose jobLocation is a SINGLE object (not an
+// array) with a Remote locality — proving the flexible single-or-array decode and the
+// location-derived remote signal (Jobvite gives no structured jobLocationType).
+func jobviteRemoteSingleLocationHTML(title, code string) string {
+	return `<html><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `","identifier":"` + code + `",
+"description":"<p>Work anywhere.</p>","datePosted":"2026-07-01",
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"Remote","addressCountry":"United States"}}}
+</script></body></html>`
+}
+
+func TestJobviteProvider(t *testing.T) {
+	if got := NewJobvite(nil).Provider(); got != "jobvite" {
+		t.Errorf("Provider() = %q, want %q", got, "jobvite")
+	}
+}
+
+func TestJobviteJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.jobvite.com/hbg/job/ojJpAfwL":          "ojJpAfwL",
+		"https://jobs.jobvite.com/hbg/job/ode8zfwS?nl=1":     "ode8zfwS",
+		"https://jobs.jobvite.com/hbg/jobs":                  "",
+		"https://jobs.jobvite.com/hbg/jobAlerts":             "",
+		"https://jobs.jobvite.com/hbg/job/":                  "",
+		"https://www.jobvite.com/support/job-seeker-support": "",
+	}
+	for in, want := range cases {
+		if got := jobviteJobID(in); got != want {
+			t.Errorf("jobviteJobID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestJobviteFetchListingThenDetailAndMaps(t *testing.T) {
+	board := "hbg"
+	fake := (&routedHTTP{}).
+		route("/"+board+"/jobs", jobviteListingHTML(board, "ojJpAfwL")).
+		route("/"+board+"/job/ojJpAfwL", jobviteDetailHTML("Editorial Assistant", "ojJpAfwL"))
+
+	jobs, err := NewJobvite(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Hachette Book Group", Provider: "jobvite", Board: board,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "ojJpAfwL" {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, "ojJpAfwL")
+	}
+	if j.URL != "https://jobs.jobvite.com/"+board+"/job/ojJpAfwL" {
+		t.Errorf("URL = %q, want canonical detail URL", j.URL)
+	}
+	if j.Title != "Editorial Assistant" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	// The configured company is canonical (the board is that employer's site); the JSON-LD
+	// hiringOrganization is ignored so a board never mislabels its own postings.
+	if j.Company != "Hachette Book Group" {
+		t.Errorf("Company = %q, want configured company", j.Company)
+	}
+	if j.Location != "New York, United States" {
+		t.Errorf("Location = %q, want %q", j.Location, "New York, United States")
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Build books") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-30", j.PostedAt)
+	}
+	if j.Remote {
+		t.Errorf("Remote = true, want false for a New York location")
+	}
+}
+
+func TestJobviteFetchSingleObjectLocationAndRemote(t *testing.T) {
+	board := "acme"
+	fake := (&routedHTTP{}).
+		route("/"+board+"/jobs", jobviteListingHTML(board, "zzRemote1")).
+		route("/"+board+"/job/zzRemote1", jobviteRemoteSingleLocationHTML("Staff Engineer", "zzRemote1"))
+
+	jobs, err := NewJobvite(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "jobvite", Board: board,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (single-object jobLocation must decode)", len(jobs))
+	}
+	j := jobs[0]
+	if j.Location != "Remote, United States" {
+		t.Errorf("Location = %q, want %q", j.Location, "Remote, United States")
+	}
+	if !j.Remote {
+		t.Errorf("Remote = false, want true for a Remote location")
+	}
+}
+
+func TestJobviteListingErrorIsBoardLevel(t *testing.T) {
+	// An empty router returns an error for the listing fetch, which must surface as a
+	// board-level error (not a silent empty result).
+	_, err := NewJobvite(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "jobvite", Board: "acme",
+	})
+	if err == nil {
+		t.Fatal("Fetch: want board-level error on listing failure, got nil")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -243,6 +243,7 @@ func All(c HTTPClient) map[string]Source {
 		NewQuickin(c),
 		NewMindsight(c),
 		NewEnlizt(c),
+		NewJobvite(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -297,6 +297,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTBank(c),
 		NewMTS(c),
 		NewVK(c),
+		NewTwoGIS(c),
 	)
 	// USAJobs and Reed are the keyed sources: register each only when its API key is
 	// configured, so unconfigured environments (tests, local dev) leave it absent rather than

--- a/internal/sources/twogis.go
+++ b/internal/sources/twogis.go
@@ -1,0 +1,130 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// twogis adapts the 2GIS careers site (job.2gis.ru), a single-company source with no per-tenant
+// board id (boardless). 2GIS runs a custom Next.js careers SPA fronting no supported ATS, but its
+// /vacancies listing server-renders a /vacancies/<category>/<id> anchor for every posting and each
+// vacancy page carries a schema.org JobPosting ld+json, so this adapter is the jobvite/dataart
+// shape — listing to enumerate, per-vacancy detail fetch for the posting — over the shared ld+json
+// helper.
+type twogis struct {
+	http HTMLGetter
+}
+
+const twogisBaseURL = "https://job.2gis.ru"
+
+// NewTwoGIS builds the 2GIS adapter over the given HTTP client.
+func NewTwoGIS(c HTMLGetter) Source { return twogis{http: c} }
+
+func (twogis) Provider() string { return "2gis" }
+
+// twogis is single-company, so its config entries carry no board.
+func (twogis) boardless() {}
+
+func (t twogis) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(twogisBaseURL + "/")
+	if err != nil {
+		return nil, fmt.Errorf("2gis: base url: %w", err)
+	}
+	root, err := t.http.GetHTML(ctx, twogisBaseURL+"/vacancies")
+	if err != nil {
+		return nil, fmt.Errorf("2gis: listing: %w", err)
+	}
+
+	locs := jobLinks(base, root, func(href string) bool { return twogisJobID(href) != "" })
+
+	// Each posting's fields come from its own detail fetch, fanned out under a bounded pool.
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return t.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one vacancy page and maps its JobPosting ld+json to a Job, returning ok=false when
+// the URL has no id, the fetch fails, or the page carries no JobPosting, so the caller skips just
+// that posting.
+func (t twogis) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := twogisJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := t.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p twogisPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	location := p.location()
+	// jobLocationType TELECOMMUTE is 2GIS's structured remote signal, so it sets WorkMode (clean
+	// provenance); located roles leave WorkMode empty and the pipeline parses the location.
+	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+	workMode := ""
+	if remote {
+		workMode = "remote"
+	}
+	return Job{
+		ExternalID: id,
+		URL:        jobURL,
+		Title:      p.Title,
+		// The configured company is canonical (this is 2GIS's own site); the JSON-LD
+		// hiringOrganization is ignored so the board never mislabels its postings.
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(p.Description),
+		Remote:      remote || isRemote(location),
+		WorkMode:    workMode,
+		PostedAt:    parseDate(p.DatePosted),
+	}, true
+}
+
+// twogisJobIDPattern captures the numeric posting id from a /vacancies/<category>/<id> path,
+// terminated by a slash, query, fragment, or end of string. The /vacancies listing root and a
+// bare /vacancies/<category> link carry no /<id> segment and yield no match.
+var twogisJobIDPattern = regexp.MustCompile(`/vacancies/[a-z0-9_-]+/(\d+)(?:[/?#]|$)`)
+
+// twogisJobID extracts the native posting id from a vacancy page URL, or "" when the URL is not a
+// vacancy posting.
+func twogisJobID(loc string) string {
+	if m := twogisJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// twogisPosting is the schema.org JobPosting decoded from a 2GIS vacancy page's ld+json. It reuses
+// icimsPlaces, the shared single-or-array jobLocation decoder (2GIS emits a single Place object for
+// located roles and omits it for remote ones).
+type twogisPosting struct {
+	Title           string      `json:"title"`
+	Description     string      `json:"description"`
+	DatePosted      string      `json:"datePosted"`
+	JobLocationType string      `json:"jobLocationType"`
+	JobLocation     icimsPlaces `json:"jobLocation"`
+}
+
+// location joins each jobLocation place as "City, Country" (falling back to whichever part is
+// present), deduped and separated by "; ", so a job open in several cities lists them all.
+func (p twogisPosting) location() string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, pl := range p.JobLocation {
+		s := joinNonEmpty(pl.Address.AddressLocality, pl.Address.AddressCountry)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return strings.Join(out, "; ")
+}

--- a/internal/sources/twogis_test.go
+++ b/internal/sources/twogis_test.go
@@ -1,0 +1,148 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// twogisListingHTML is a 2GIS careers listing page (job.2gis.ru/vacancies). It carries the given
+// vacancy paths as /vacancies/<category>/<id> anchors, plus the /vacancies listing root and an
+// /about nav anchor that must NOT be treated as postings — exercising the job-link predicate.
+func twogisListingHTML(paths ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="VacancyList">`)
+	for _, p := range paths {
+		b.WriteString(`<a class="VacancyItem-module__root" href="/vacancies/` + p + `">A Role</a>`)
+	}
+	b.WriteString(`<a href="/vacancies">All vacancies</a>`)
+	b.WriteString(`<a href="/about">About</a>`)
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// twogisRemoteDetailHTML is a 2GIS vacancy page whose payload is the schema.org JobPosting ld+json:
+// jobLocationType TELECOMMUTE (structured remote), NO jobLocation, a nested PropertyValue
+// identifier, and a description embedding a <script> that sanitizeHTML must strip.
+func twogisRemoteDetailHTML(title, cat, id string) string {
+	return `<html><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `",
+"description":"<p>Build maps.</p><script>alert(1)<\/script>",
+"identifier":{"@type":"PropertyValue","name":"2ГИС","value":"` + id + `"},
+"hiringOrganization":{"@type":"Organization","name":"2ГИС"},
+"url":"/vacancies/` + cat + `/` + id + `",
+"jobLocationType":"TELECOMMUTE"}
+</script></body></html>`
+}
+
+// twogisOnsiteDetailHTML is a 2GIS vacancy page for an onsite role: no jobLocationType, and a
+// SINGLE jobLocation object (not an array) with a city — proving the flexible single-or-array
+// decode and that a located role is not flagged remote.
+func twogisOnsiteDetailHTML(title, cat, id, city string) string {
+	return `<html><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `","description":"<p>On site.</p>",
+"identifier":{"@type":"PropertyValue","name":"2ГИС","value":"` + id + `"},
+"url":"/vacancies/` + cat + `/` + id + `",
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"` + city + `"}}}
+</script></body></html>`
+}
+
+func TestTwoGISProvider(t *testing.T) {
+	if got := NewTwoGIS(nil).Provider(); got != "2gis" {
+		t.Errorf("Provider() = %q, want %q", got, "2gis")
+	}
+}
+
+func TestTwoGISJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://job.2gis.ru/vacancies/testing/406":       "406",
+		"https://job.2gis.ru/vacancies/saless/362?utm=x":  "362",
+		"https://job.2gis.ru/vacancies/infra_admin/329#a": "329",
+		"https://job.2gis.ru/vacancies/testing":           "", // category only, no id
+		"https://job.2gis.ru/vacancies":                   "", // listing root
+		"https://job.2gis.ru/about":                       "",
+	}
+	for in, want := range cases {
+		if got := twogisJobID(in); got != want {
+			t.Errorf("twogisJobID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestTwoGISFetchListingThenDetailAndMaps(t *testing.T) {
+	// Detail routes come first: the listing URL (.../vacancies) is a substring of every detail
+	// URL (.../vacancies/<cat>/<id>), and routedHTTP matches by first-containing route, so the
+	// specific detail paths must precede the generic listing route.
+	fake := (&routedHTTP{}).
+		route("/vacancies/testing/406", twogisRemoteDetailHTML("QA Engineer", "testing", "406")).
+		route("/vacancies/saless/362", twogisOnsiteDetailHTML("Regional Trainer", "saless", "362", "Томск")).
+		route("/vacancies", twogisListingHTML("testing/406", "saless/362"))
+
+	jobs, err := NewTwoGIS(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "2GIS", Provider: "2gis",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	remote, ok := byID["406"]
+	if !ok {
+		t.Fatal("missing job 406")
+	}
+	if remote.URL != "https://job.2gis.ru/vacancies/testing/406" {
+		t.Errorf("URL = %q, want canonical detail URL", remote.URL)
+	}
+	if remote.Title != "QA Engineer" {
+		t.Errorf("Title = %q", remote.Title)
+	}
+	// The configured company is canonical (this is 2GIS's own site); the JSON-LD
+	// hiringOrganization is ignored so the board never mislabels its postings.
+	if remote.Company != "2GIS" {
+		t.Errorf("Company = %q, want configured company", remote.Company)
+	}
+	if !remote.Remote || remote.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want structured remote from TELECOMMUTE", remote.Remote, remote.WorkMode)
+	}
+	if remote.Location != "" {
+		t.Errorf("Location = %q, want empty (no jobLocation)", remote.Location)
+	}
+	if strings.Contains(remote.Description, "<script>") || strings.Contains(remote.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", remote.Description)
+	}
+	if !strings.Contains(remote.Description, "Build maps") {
+		t.Errorf("Description lost real content: %q", remote.Description)
+	}
+
+	onsite, ok := byID["362"]
+	if !ok {
+		t.Fatal("missing job 362")
+	}
+	if onsite.Location != "Томск" {
+		t.Errorf("Location = %q, want %q", onsite.Location, "Томск")
+	}
+	if onsite.Remote || onsite.WorkMode != "" {
+		t.Errorf("Remote=%v WorkMode=%q, want not-remote for a located onsite role", onsite.Remote, onsite.WorkMode)
+	}
+}
+
+func TestTwoGISListingErrorIsBoardLevel(t *testing.T) {
+	// An empty router errors on the listing fetch, which must surface as a board-level error
+	// (not a silent empty result).
+	_, err := NewTwoGIS(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{
+		Company: "2GIS", Provider: "2gis",
+	})
+	if err == nil {
+		t.Fatal("Fetch: want board-level error on listing failure, got nil")
+	}
+}

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -50,6 +50,8 @@
   provider: dodo
 - company: DomClick
   provider: domclick
+- company: 2GIS
+  provider: 2gis
 - company: MTS Link
   provider: mtslink
 - company: T-Bank

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -1,0 +1,8 @@
+# jobvite boards. Provider is the filename; each entry is company + board.
+# board = the company's Jobvite careersite slug (see internal/sources/jobvite.go); the adapter
+# reads https://jobs.jobvite.com/<board>/jobs (server-rendered listing) then each posting's
+# schema.org JobPosting ld+json detail page.
+# Each board validated live (>0 jobs from the listing) before adding; expand with harvest-boards.
+
+- company: Hachette Book Group # hachette-book-group
+  board: hachette-book-group


### PR DESCRIPTION
## What

Adds a source adapter for **2GIS** careers (`job.2gis.ru`) and configures it in `sources/custom.yml`.

2GIS runs a custom Next.js careers SPA fronting no supported ATS, but:
- the `/vacancies` listing server-renders a `/vacancies/<category>/<id>` anchor per posting, and
- each vacancy page carries a schema.org `JobPosting` ld+json.

So the adapter is the established **jobvite/dataart shape** — enumerate the listing, then a bounded per-vacancy detail fetch over the shared `ldJobPosting` helper. Boardless single-company (no per-tenant board id).

## Notes

- `jobLocationType: "TELECOMMUTE"` is the platform's **structured** remote signal → sets `WorkMode="remote"` (clean provenance). Located roles carry a single `jobLocation` object, decoded via the shared `icimsPlaces` (single-or-array); their work mode is left for the pipeline to parse from location text.
- The configured company (`2GIS`) is canonical; the JSON-LD `hiringOrganization` is ignored so the board never mislabels its own postings.
- No `datePosted` in the source, so `posted_at` stays null (falls back to ingest time downstream).

## Verification

- Unit tests (TDD, written first): `Provider`, `twogisJobID` table, listing→detail mapping (remote + onsite), board-level error path.
- `TestCustomYAMLValidates` passes (new entry validates against the real registry).
- `go build ./...`, `go vet`, `gofmt` clean.
- **Live smoke run** against `job.2gis.ru`: fetched **15 vacancies**, remote/onsite classified correctly, locations (`Новосибирск`/`Сочи`) and ~5–6 KB descriptions extracted.