### PR TITLE
feat(sources): add Jobvite ATS adapter

### DIFF
--- a/cmd/harvest-boards/jobvite_prober.go
+++ b/cmd/harvest-boards/jobvite_prober.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// jobviteJobLinkPattern matches a Jobvite job permalink's /<board>/job/<code> segment. The
+// /<board>/jobs listing and /<board>/jobAlerts nav links carry no /job/<code> segment and are
+// not counted. Mirrors sources.jobviteJobIDPattern (unexported; this tool lives outside the
+// package).
+var jobviteJobLinkPattern = regexp.MustCompile(`/job/[A-Za-z0-9]+(?:[/?#]|$)`)
+
+// jobviteProber probes a Jobvite careersite. Jobvite exposes no public JSON list, so liveness
+// is judged from the server-rendered listing HTML: a live board links ≥1 job permalink. The
+// page carries no reliable company name, so it falls back to the slug (the seed supplies the
+// company). Best-effort: a fetch error counts the board as not live rather than aborting.
+type jobviteProber struct{}
+
+func (jobviteProber) probe(ctx context.Context, c httpClient, slug string) (string, int, error) {
+	root, err := c.GetHTML(ctx, fmt.Sprintf("https://jobs.jobvite.com/%s/jobs", slug))
+	if err != nil {
+		return "", 0, nil
+	}
+	n := countMatchingLinks(root, jobviteJobLinkPattern)
+	if n == 0 {
+		return "", 0, nil
+	}
+	return slug, n, nil
+}

--- a/cmd/harvest-boards/prober.go
+++ b/cmd/harvest-boards/prober.go
@@ -562,6 +562,7 @@ var probers = map[string]prober{
 	"gem":             gemProber{},
 	"deel":            deelProber{},
 	"freshteam":       freshteamProber{},
+	"jobvite":         jobviteProber{},
 	"join":            joinProber{},
 	"oracle":          oracleProber{},
 	"jazzhr":          jazzhrProber{},

--- a/cmd/harvest-boards/prober_test.go
+++ b/cmd/harvest-boards/prober_test.go
@@ -269,6 +269,17 @@ func TestSlugFallbackProbers(t *testing.T) {
 			},
 			live: "acme", empty: "empty",
 		},
+		{
+			name: "jobvite",
+			p:    jobviteProber{},
+			getter: fakeGetter{
+				// Live: a /<slug>/job/<code> permalink. Empty: only the /jobs and /jobAlerts
+				// nav anchors, which the job pattern must not count.
+				"https://jobs.jobvite.com/acme/jobs":  `<html><body><a href="/acme/job/ojJpAfwL">Engineer</a></body></html>`,
+				"https://jobs.jobvite.com/empty/jobs": `<html><body><a href="/empty/jobs">All</a><a href="/empty/jobAlerts">Alerts</a></body></html>`,
+			},
+			live: "acme", empty: "empty",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/sources/jobvite.go
+++ b/internal/sources/jobvite.go
@@ -1,0 +1,121 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// jobvite adapts Jobvite career sites (jobs.jobvite.com/<company>). The board is the company's
+// Jobvite careersite slug. The listing page server-renders a /<board>/job/<code> link for every
+// posting; each job page carries a schema.org JobPosting ld+json, so the description comes from a
+// per-posting detail fetch (bounded-concurrency) over the shared ld+json helper — the same shape
+// as the careerspage/dataart adapters.
+//
+// The public careersite renders the full job list in one page (filtering is client-side, no
+// server pagination), so Fetch reads every job anchor from the single listing. Per-page crawling
+// is the seam to add here if a board ever exceeds Jobvite's server-render cap.
+type jobvite struct {
+	http HTMLGetter
+}
+
+// NewJobvite builds the Jobvite adapter over the given HTTP client.
+func NewJobvite(c HTMLGetter) Source { return jobvite{http: c} }
+
+func (jobvite) Provider() string { return "jobvite" }
+
+func (j jobvite) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://jobs.jobvite.com/%s/", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("jobvite: board %q: %w", e.Board, err)
+	}
+	root, err := j.http.GetHTML(ctx, base.String()+"jobs")
+	if err != nil {
+		return nil, fmt.Errorf("jobvite: listing %s: %w", e.Board, err)
+	}
+
+	locs := jobLinks(base, root, func(href string) bool { return jobviteJobID(href) != "" })
+
+	// Each posting's fields come from its own detail fetch, fanned out under a bounded pool.
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return j.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false when
+// the URL has no code, the fetch fails, or the page carries no JobPosting, so the caller skips
+// just that posting.
+func (j jobvite) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := jobviteJobID(jobURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	root, err := j.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p jobvitePosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	location := p.location()
+	return Job{
+		ExternalID: id,
+		URL:        jobURL,
+		Title:      p.Title,
+		// The configured company is canonical (the board is that employer's site); the JSON-LD
+		// hiringOrganization is ignored so a board never mislabels its own postings.
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(p.Description),
+		// Jobvite states no structured jobLocationType, so remote is inferred from the location
+		// text alone; WorkMode stays empty (the pipeline parses the location).
+		Remote:   isRemote(location),
+		PostedAt: parseDate(p.DatePosted),
+	}, true
+}
+
+// jobviteJobIDPattern captures the alphanumeric posting code from a /<board>/job/<code> path,
+// terminated by a slash, query, fragment, or end of string. The /<board>/jobs listing and the
+// /<board>/jobAlerts nav link carry no /job/<code> segment and yield no match.
+var jobviteJobIDPattern = regexp.MustCompile(`/job/([A-Za-z0-9]+)(?:[/?#]|$)`)
+
+// jobviteJobID extracts the native posting code from a job page URL, or "" when the URL is not a
+// job posting.
+func jobviteJobID(loc string) string {
+	if m := jobviteJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// jobvitePosting is the schema.org JobPosting decoded from a Jobvite job page's ld+json. It
+// reuses icimsPlaces, the shared single-or-array jobLocation decoder (Jobvite emits an array, but
+// the flexible form guards a board that emits a single Place object).
+type jobvitePosting struct {
+	Title       string      `json:"title"`
+	Description string      `json:"description"`
+	DatePosted  string      `json:"datePosted"`
+	JobLocation icimsPlaces `json:"jobLocation"`
+}
+
+// location joins each jobLocation place as "City, Country" (falling back to whichever part is
+// present), deduped and separated by "; ", so a job open in several cities lists them all.
+func (p jobvitePosting) location() string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, pl := range p.JobLocation {
+		s := joinNonEmpty(pl.Address.AddressLocality, pl.Address.AddressCountry)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return strings.Join(out, "; ")
+}

--- a/internal/sources/jobvite_test.go
+++ b/internal/sources/jobvite_test.go
@@ -1,0 +1,166 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// jobviteListingHTML is a Jobvite careersite listing page (jobs.jobvite.com/<board>/jobs). It
+// carries the given job codes as /<board>/job/<code> anchors, plus the /<board>/jobs and
+// /<board>/jobAlerts navigation anchors that must NOT be treated as postings — exercising the
+// job-link predicate.
+func jobviteListingHTML(board string, codes ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jv-page-body"><ul class="jv-job-list">`)
+	for _, c := range codes {
+		b.WriteString(`<li class="jv-job-list-item">`)
+		b.WriteString(`<a class="jv-job-list-name" href="/` + board + `/job/` + c + `">A Role</a>`)
+		b.WriteString(`<span class="jv-job-list-location">New York</span>`)
+		b.WriteString(`</li>`)
+	}
+	b.WriteString(`</ul>`)
+	b.WriteString(`<a href="/` + board + `/jobs">All jobs</a>`)
+	b.WriteString(`<a href="/` + board + `/jobAlerts">Job alerts</a>`)
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// jobviteDetailHTML is a Jobvite job page: server-rendered HTML whose payload we read is the
+// schema.org JobPosting ld+json. jobLocation is an ARRAY (the shape Jobvite emits), the
+// description is RAW HTML (not entity-escaped) embedding a <script> that sanitizeHTML must
+// strip, and datePosted is date-only.
+func jobviteDetailHTML(title, code string) string {
+	return `<html><head></head><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `",
+"identifier":"` + code + `",
+"description":"<p>Build books.</p><script>alert(1)<\/script>",
+"datePosted":"2026-06-30",
+"employmentType":"Full-Time",
+"hiringOrganization":{"@type":"Organization","name":"Hachette (schema.org)"},
+"jobLocation":[{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"New York","addressRegion":"New York","addressCountry":"United States"}}]}
+</script>
+</body></html>`
+}
+
+// jobviteRemoteSingleLocationHTML is a job page whose jobLocation is a SINGLE object (not an
+// array) with a Remote locality — proving the flexible single-or-array decode and the
+// location-derived remote signal (Jobvite gives no structured jobLocationType).
+func jobviteRemoteSingleLocationHTML(title, code string) string {
+	return `<html><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `","identifier":"` + code + `",
+"description":"<p>Work anywhere.</p>","datePosted":"2026-07-01",
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"Remote","addressCountry":"United States"}}}
+</script></body></html>`
+}
+
+func TestJobviteProvider(t *testing.T) {
+	if got := NewJobvite(nil).Provider(); got != "jobvite" {
+		t.Errorf("Provider() = %q, want %q", got, "jobvite")
+	}
+}
+
+func TestJobviteJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.jobvite.com/hbg/job/ojJpAfwL":          "ojJpAfwL",
+		"https://jobs.jobvite.com/hbg/job/ode8zfwS?nl=1":     "ode8zfwS",
+		"https://jobs.jobvite.com/hbg/jobs":                  "",
+		"https://jobs.jobvite.com/hbg/jobAlerts":             "",
+		"https://jobs.jobvite.com/hbg/job/":                  "",
+		"https://www.jobvite.com/support/job-seeker-support": "",
+	}
+	for in, want := range cases {
+		if got := jobviteJobID(in); got != want {
+			t.Errorf("jobviteJobID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestJobviteFetchListingThenDetailAndMaps(t *testing.T) {
+	board := "hbg"
+	fake := (&routedHTTP{}).
+		route("/"+board+"/jobs", jobviteListingHTML(board, "ojJpAfwL")).
+		route("/"+board+"/job/ojJpAfwL", jobviteDetailHTML("Editorial Assistant", "ojJpAfwL"))
+
+	jobs, err := NewJobvite(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Hachette Book Group", Provider: "jobvite", Board: board,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "ojJpAfwL" {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, "ojJpAfwL")
+	}
+	if j.URL != "https://jobs.jobvite.com/"+board+"/job/ojJpAfwL" {
+		t.Errorf("URL = %q, want canonical detail URL", j.URL)
+	}
+	if j.Title != "Editorial Assistant" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	// The configured company is canonical (the board is that employer's site); the JSON-LD
+	// hiringOrganization is ignored so a board never mislabels its own postings.
+	if j.Company != "Hachette Book Group" {
+		t.Errorf("Company = %q, want configured company", j.Company)
+	}
+	if j.Location != "New York, United States" {
+		t.Errorf("Location = %q, want %q", j.Location, "New York, United States")
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Build books") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-30", j.PostedAt)
+	}
+	if j.Remote {
+		t.Errorf("Remote = true, want false for a New York location")
+	}
+}
+
+func TestJobviteFetchSingleObjectLocationAndRemote(t *testing.T) {
+	board := "acme"
+	fake := (&routedHTTP{}).
+		route("/"+board+"/jobs", jobviteListingHTML(board, "zzRemote1")).
+		route("/"+board+"/job/zzRemote1", jobviteRemoteSingleLocationHTML("Staff Engineer", "zzRemote1"))
+
+	jobs, err := NewJobvite(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "jobvite", Board: board,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (single-object jobLocation must decode)", len(jobs))
+	}
+	j := jobs[0]
+	if j.Location != "Remote, United States" {
+		t.Errorf("Location = %q, want %q", j.Location, "Remote, United States")
+	}
+	if !j.Remote {
+		t.Errorf("Remote = false, want true for a Remote location")
+	}
+}
+
+func TestJobviteListingErrorIsBoardLevel(t *testing.T) {
+	// An empty router returns an error for the listing fetch, which must surface as a
+	// board-level error (not a silent empty result).
+	_, err := NewJobvite(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "jobvite", Board: "acme",
+	})
+	if err == nil {
+		t.Fatal("Fetch: want board-level error on listing failure, got nil")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -243,6 +243,7 @@ func All(c HTTPClient) map[string]Source {
 		NewQuickin(c),
 		NewMindsight(c),
 		NewEnlizt(c),
+		NewJobvite(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/sources/jobvite.yml
+++ b/sources/jobvite.yml
@@ -1,0 +1,8 @@
+# jobvite boards. Provider is the filename; each entry is company + board.
+# board = the company's Jobvite careersite slug (see internal/sources/jobvite.go); the adapter
+# reads https://jobs.jobvite.com/<board>/jobs (server-rendered listing) then each posting's
+# schema.org JobPosting ld+json detail page.
+# Each board validated live (>0 jobs from the listing) before adding; expand with harvest-boards.
+
+- company: Hachette Book Group # hachette-book-group
+  board: hachette-book-group


### PR DESCRIPTION
## What

Adds a **Jobvite** ATS source adapter — Jobvite career sites (`jobs.jobvite.com/<company>`).

## How

- **Listing:** `jobs.jobvite.com/<board>/jobs` is server-rendered; every posting link (`/<board>/job/<code>`) is read from the HTML, ignoring the `/jobs` and `/jobAlerts` nav anchors.
- **Detail:** each job page carries a schema.org **JobPosting `ld+json`** (title, datePosted, jobLocation, description). Same shape as the `careerspage`/`dataart` adapters — listing enumerate + per-job detail over the shared `ldJobPosting` helper.
- Reuses `icimsPlaces` for the single-or-array `jobLocation` decode (Jobvite emits an array; the flexible form guards a single-object board).
- Jobvite states no structured `jobLocationType`, so remote is inferred from the location text; `WorkMode` stays empty for the pipeline to parse.
- `board` = the careersite slug. Full listing is server-rendered (client-side filtering, no server pagination); per-page crawling noted as the seam if a board exceeds the render cap.

## Validation

- `go build ./... && go vet && go test ./...` clean; committed snapshot verified building standalone in a fresh worktree.
- Unit tests (`jobvite_test.go`): provider key, job-id extraction, listing→detail mapping + sanitization, single-object `jobLocation` + remote, board-level listing error.
- **Live-validated** against `hachette-book-group` → 16 postings with correct ids/titles/locations/dates/descriptions. Seeds `sources/jobvite.yml` with that board; expand via `harvest-boards`.

## Context

Found while evaluating [The Muse](https://www.themuse.com) as a source (verdict: not a source — it duplicates ATS we already crawl). Jobvite surfaced as a genuinely-uncovered ATS **platform** (Hachette, plus many other boards), so the adapter — not the aggregator — is the right addition.