### PR TITLE
feat(web): add save-to-list bookmark button on job cards

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -467,6 +467,14 @@ type Querier interface {
 	// included (it is one of the openings). Ordered by location. An empty-fingerprint anchor
 	// clusters with no one and returns nothing.
 	ListRoleClusterCopies(ctx context.Context, arg ListRoleClusterCopiesParams) ([]ListRoleClusterCopiesRow, error)
+	// Every public_slug the user has saved (bookmarked). Used by the SPA to render
+	// the save toggle as filled on already-saved cards in the browse list and search
+	// results, without authenticating the public job-read path — the saved set is
+	// cross-referenced client-side, never joined into ListJobs/SearchJobs. Bounded by
+	// the caller's saved subset (typically small) and indexed by the (user_id, job_id)
+	// primary key, so it stays cheap for heavy users. Closed jobs are included: a
+	// saved posting that later closes still shows filled in a history surface.
+	ListSavedJobSlugs(ctx context.Context, userID int64) ([]string, error)
 	// A user's saved searches, most recently updated first (the "My filters" picker order).
 	ListSavedSearches(ctx context.Context, userID int64) ([]SavedSearch, error)
 	// "My submissions": one user's submissions, newest first, whatever their status.

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -147,6 +147,19 @@ FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1;
 
+-- name: ListSavedJobSlugs :many
+-- Every public_slug the user has saved (bookmarked). Used by the SPA to render
+-- the save toggle as filled on already-saved cards in the browse list and search
+-- results, without authenticating the public job-read path — the saved set is
+-- cross-referenced client-side, never joined into ListJobs/SearchJobs. Bounded by
+-- the caller's saved subset (typically small) and indexed by the (user_id, job_id)
+-- primary key, so it stays cheap for heavy users. Closed jobs are included: a
+-- saved posting that later closes still shows filled in a history surface.
+SELECT jobs.public_slug
+FROM user_jobs uj
+JOIN jobs ON jobs.id = uj.job_id
+WHERE uj.user_id = $1 AND uj.saved_at IS NOT NULL;
+
 -- name: CountUserJobs :one
 -- Per-filter row counts for the my-jobs tabs, in one aggregate pass. "all" is
 -- every interaction row; "viewed" is the view-only subset (neither saved nor

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -186,6 +186,40 @@ func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) 
 	return items, nil
 }
 
+const listSavedJobSlugs = `-- name: ListSavedJobSlugs :many
+SELECT jobs.public_slug
+FROM user_jobs uj
+JOIN jobs ON jobs.id = uj.job_id
+WHERE uj.user_id = $1 AND uj.saved_at IS NOT NULL
+`
+
+// Every public_slug the user has saved (bookmarked). Used by the SPA to render
+// the save toggle as filled on already-saved cards in the browse list and search
+// results, without authenticating the public job-read path — the saved set is
+// cross-referenced client-side, never joined into ListJobs/SearchJobs. Bounded by
+// the caller's saved subset (typically small) and indexed by the (user_id, job_id)
+// primary key, so it stays cheap for heavy users. Closed jobs are included: a
+// saved posting that later closes still shows filled in a history surface.
+func (q *Queries) ListSavedJobSlugs(ctx context.Context, userID int64) ([]string, error) {
+	rows, err := q.db.Query(ctx, listSavedJobSlugs, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var public_slug string
+		if err := rows.Scan(&public_slug); err != nil {
+			return nil, err
+		}
+		items = append(items, public_slug)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUserJobs = `-- name: ListUserJobs :many
 SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -338,6 +338,7 @@ func Register(app *fiber.App, cfg Config) {
 	// list, and analyses lists the jobs the caller has run the AI fit analysis on.
 	api.Get("/me/tracking", keyAuth, a.ListTrackedJobs)
 	api.Get("/me/tracking/viewed", keyAuth, a.ListViewedSlugs)
+	api.Get("/me/tracking/saved", keyAuth, a.ListSavedSlugs)
 	api.Get("/me/tracking/pipeline", keyAuth, a.TrackingPipeline)
 	api.Get("/me/tracking/swipe", keyAuth, a.SwipeDeck)
 	api.Get("/me/tracking/analyses", keyAuth, a.ListMyAnalyses)

--- a/internal/handler/me_saved_integration_test.go
+++ b/internal/handler/me_saved_integration_test.go
@@ -1,0 +1,148 @@
+//go:build integration
+
+// Integration test for the saved-slugs wire contract: GET /api/v1/me/tracking/saved
+// must return exactly the public_slugs the authenticated caller has SAVED
+// (bookmarked) — not merely viewed or applied — scoped to that caller, as a flat
+// {"data": [...]} list, and reject an unauthenticated request. The SPA reads this
+// to render the save toggle as filled on already-saved cards without authenticating
+// the public job-read path. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobtracking"
+)
+
+func TestListSavedSlugsEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	seedUser := func(t *testing.T, email string) int64 {
+		t.Helper()
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+			t.Fatalf("seed user %q: %v", email, err)
+		}
+		return id
+	}
+	seedJob := func(t *testing.T, ext string) int64 {
+		t.Helper()
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug)
+			 VALUES ('test', $1, 'http://example.test', 'Job ' || $1, 'job-' || $1)
+			 RETURNING id`, ext).Scan(&id); err != nil {
+			t.Fatalf("seed job %q: %v", ext, err)
+		}
+		return id
+	}
+
+	saver := seedUser(t, "saver@example.test")
+	other := seedUser(t, "other@example.test")
+	jobA := seedJob(t, "saved-a")
+	jobB := seedJob(t, "viewed-b")
+	jobC := seedJob(t, "other-c")
+
+	// saver SAVED A, but only VIEWED B — the viewed-only job must be excluded from
+	// the saved set (the saved_at IS NOT NULL predicate is the whole point).
+	if _, err := queries.SaveJob(ctx, db.SaveJobParams{UserID: saver, JobID: jobA}); err != nil {
+		t.Fatalf("save A: %v", err)
+	}
+	if _, err := queries.RecordJobView(ctx, db.RecordJobViewParams{UserID: saver, JobID: jobB}); err != nil {
+		t.Fatalf("view B: %v", err)
+	}
+	// other user saved C — must never leak into saver's set.
+	if _, err := queries.SaveJob(ctx, db.SaveJobParams{UserID: other, JobID: jobC}); err != nil {
+		t.Fatalf("save C: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &API{pool: pool, queries: queries, issuer: iss, tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries))}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/tracking/saved", auth.RequireAuthOrKey(iss, queries), h.ListSavedSlugs)
+
+	getSlugs := func(t *testing.T, userID int64) []string {
+		t.Helper()
+		token, err := iss.Issue(userID)
+		if err != nil {
+			t.Fatalf("issue token: %v", err)
+		}
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking/saved", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET saved: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+		var body struct {
+			Data []string `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		sort.Strings(body.Data)
+		return body.Data
+	}
+
+	t.Run("returns only the caller's saved slugs, scoped to the caller", func(t *testing.T) {
+		got := getSlugs(t, saver)
+		want := []string{"job-saved-a"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("saver slugs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("unsaving drops the slug from the set", func(t *testing.T) {
+		if _, err := queries.UnsaveJob(ctx, db.UnsaveJobParams{UserID: saver, JobID: jobA}); err != nil {
+			t.Fatalf("unsave A: %v", err)
+		}
+		got := getSlugs(t, saver)
+		if len(got) != 0 {
+			t.Fatalf("after unsave slugs = %v, want []", got)
+		}
+		// Restore for isolation from any later assertions.
+		if _, err := queries.SaveJob(ctx, db.SaveJobParams{UserID: saver, JobID: jobA}); err != nil {
+			t.Fatalf("re-save A: %v", err)
+		}
+	})
+
+	t.Run("user with no saves gets an empty list", func(t *testing.T) {
+		fresh := seedUser(t, "fresh@example.test")
+		got := getSlugs(t, fresh)
+		if len(got) != 0 {
+			t.Fatalf("fresh user slugs = %v, want []", got)
+		}
+	})
+
+	t.Run("unauthenticated request is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking/saved", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET saved (no auth): %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+}

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -106,3 +106,23 @@ func (a *API) ListViewedSlugs(c *fiber.Ctx) error {
 
 	return c.JSON(fiber.Map{"data": slugs})
 }
+
+// ListSavedSlugs returns the set of public job slugs the authenticated caller has
+// saved (bookmarked). The SPA reads this to render the save toggle as filled on
+// already-saved cards in the browse list and search results without
+// authenticating the public job-read path — saved state is cross-referenced
+// client-side, never joined into ListJobs/SearchJobs. The response is a flat
+// {"data": [slug, ...]} list scoped to the caller.
+func (a *API) ListSavedSlugs(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+
+	slugs, err := a.tracking.SavedSlugs(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{"data": slugs})
+}

--- a/internal/handler/track_test.go
+++ b/internal/handler/track_test.go
@@ -56,6 +56,7 @@ func (stubTrackingRepo) CountInteractions(context.Context, int64) (jobtracking.C
 	return jobtracking.Counts{}, nil
 }
 func (stubTrackingRepo) ViewedSlugs(context.Context, int64) ([]string, error) { return nil, nil }
+func (stubTrackingRepo) SavedSlugs(context.Context, int64) ([]string, error)  { return nil, nil }
 func (stubTrackingRepo) ExcludedJobIDs(context.Context, int64, int32) ([]int64, error) {
 	return nil, nil
 }

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -158,6 +158,9 @@ type Repository interface {
 	// ViewedSlugs returns every public job slug the caller has interacted with.
 	ViewedSlugs(ctx context.Context, userID int64) ([]string, error)
 
+	// SavedSlugs returns every public job slug the caller has saved (bookmarked).
+	SavedSlugs(ctx context.Context, userID int64) ([]string, error)
+
 	// ExcludedJobIDs returns up to limit job ids the caller has already interacted
 	// with (viewed, saved, applied, or dismissed), most-recently-touched first.
 	ExcludedJobIDs(ctx context.Context, userID int64, limit int32) ([]int64, error)
@@ -201,6 +204,11 @@ func (s *Service) ListTracked(ctx context.Context, userID int64, filter string, 
 // ViewedSlugs returns every public job slug the caller has interacted with.
 func (s *Service) ViewedSlugs(ctx context.Context, userID int64) ([]string, error) {
 	return s.repo.ViewedSlugs(ctx, userID)
+}
+
+// SavedSlugs returns every public job slug the caller has saved (bookmarked).
+func (s *Service) SavedSlugs(ctx context.Context, userID int64) ([]string, error) {
+	return s.repo.SavedSlugs(ctx, userID)
 }
 
 // ExcludedJobIDs returns the job ids the caller has already interacted with

--- a/internal/jobtracking/jobtracking_test.go
+++ b/internal/jobtracking/jobtracking_test.go
@@ -40,6 +40,8 @@ type fakeRepo struct {
 	countErr            error
 	viewedResult        []string
 	viewedErr           error
+	savedResult         []string
+	savedErr            error
 	excludedResult      []int64
 	excludedErr         error
 	excludedLimit       int32
@@ -113,6 +115,10 @@ func (f *fakeRepo) CountInteractions(_ context.Context, _ int64) (jobtracking.Co
 
 func (f *fakeRepo) ViewedSlugs(_ context.Context, _ int64) ([]string, error) {
 	return f.viewedResult, f.viewedErr
+}
+
+func (f *fakeRepo) SavedSlugs(_ context.Context, _ int64) ([]string, error) {
+	return f.savedResult, f.savedErr
 }
 
 func (f *fakeRepo) ExcludedJobIDs(_ context.Context, _ int64, limit int32) ([]int64, error) {
@@ -596,6 +602,20 @@ func TestViewedSlugs_Passthrough(t *testing.T) {
 	svc := jobtracking.New(repo)
 
 	slugs, err := svc.ViewedSlugs(ctx(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(slugs) != 2 || slugs[0] != "job-a" {
+		t.Errorf("slugs = %v, want [job-a job-b]", slugs)
+	}
+}
+
+func TestSavedSlugs_Passthrough(t *testing.T) {
+	repo := newRepo()
+	repo.savedResult = []string{"job-a", "job-b"}
+	svc := jobtracking.New(repo)
+
+	slugs, err := svc.SavedSlugs(ctx(), userID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -194,6 +194,11 @@ func (r *QueriesRepository) ViewedSlugs(ctx context.Context, userID int64) ([]st
 	return r.q.ListViewedJobSlugs(ctx, userID)
 }
 
+// SavedSlugs returns every public job slug the caller has saved (bookmarked).
+func (r *QueriesRepository) SavedSlugs(ctx context.Context, userID int64) ([]string, error) {
+	return r.q.ListSavedJobSlugs(ctx, userID)
+}
+
 // ExcludedJobIDs returns up to limit job ids the caller has already interacted
 // with (viewed, saved, applied, or dismissed).
 func (r *QueriesRepository) ExcludedJobIDs(ctx context.Context, userID int64, limit int32) ([]int64, error) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -523,6 +523,13 @@ export function createApi(
     return requestData<string[]>('/api/v1/me/tracking/viewed');
   }
 
+  /** The public slugs of every job the current user has saved (bookmarked). The
+   *  browse UI cross-references this set to render the save toggle as filled on
+   *  already-saved cards without authenticating the public job list. */
+  async function listSavedSlugs(): Promise<string[]> {
+    return requestData<string[]>('/api/v1/me/tracking/saved');
+  }
+
   // --- API keys -------------------------------------------------------------
   //
   // Personal API keys for non-browser access. Management is cookie-only (these
@@ -858,6 +865,7 @@ export function createApi(
     getMyPipeline,
     myAnalyses,
     listViewedSlugs,
+    listSavedSlugs,
     listApiKeys,
     createApiKey,
     revokeApiKey,

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
+  import { Bookmark } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import { api } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { cardTags, formatSalary } from '$lib/enrichment';
   import { metaDescription } from '$lib/seo';
   import type { Job } from '$lib/types';
@@ -8,6 +12,7 @@
   import RealityBadge from './RealityBadge.svelte';
   import { timeAgo } from '$lib/utils';
   import { hasViewed } from '$lib/viewedJobs.svelte';
+  import { isSaved, markSaved, markUnsaved } from '$lib/savedJobs.svelte';
 
   // Single source of truth for how a job appears in any list (jobs list and
   // company detail). The whole card is a link to the job detail.
@@ -36,8 +41,42 @@
   const MAX_SKILLS = 5;
   const shownSkills = $derived(skills.slice(0, MAX_SKILLS));
   const extraSkills = $derived(skills.length - MAX_SKILLS);
+
+  // Whether the signed-in user has saved this job, read from the shared saved set
+  // (loaded once on the browse view). The bookmark reflects this and updates the
+  // set on toggle, so every card for the same job stays in sync.
+  const saved = $derived(isSaved(job.public_slug));
+  // Guards against a double-click racing two requests for the same job.
+  let saving = $state(false);
+
+  // Toggle the save mark. Optimistic: flip the shared set first so the bookmark
+  // fills instantly, then confirm with the server and roll back on failure. A
+  // signed-out click routes to sign-in instead (no auto-save afterwards). The
+  // button is an overlay sibling of the card link — not a descendant — so this
+  // never triggers the card's navigation.
+  async function toggleSave() {
+    if (!isAuthenticated()) {
+      openAuthDialog('login');
+      return;
+    }
+    if (saving) return;
+    saving = true;
+    const wasSaved = saved;
+    if (wasSaved) markUnsaved(job.public_slug);
+    else markSaved(job.public_slug);
+    try {
+      if (wasSaved) await api.unsaveJob(job.public_slug);
+      else await api.saveJob(job.public_slug);
+    } catch {
+      if (wasSaved) markSaved(job.public_slug);
+      else markUnsaved(job.public_slug);
+    } finally {
+      saving = false;
+    }
+  }
 </script>
 
+<div class="relative">
 <a
   href={resolve('/jobs/[slug]', { slug: job.public_slug })}
   class="block rounded-xl border border-border bg-card p-4 transition hover:border-brand hover:bg-accent hover:opacity-100"
@@ -47,7 +86,9 @@
        The name truncates to a single line, so a long company (e.g. "Veterinary
        Emergency Group (VEG)") keeps the logo centred and the card rhythm even
        instead of wrapping into a ragged multi-line header. -->
-  <div class="flex items-center justify-between gap-3">
+  <!-- pr-9 reserves the top-right corner for the save button (an overlay outside
+       this link), so the timestamp never slides under it. -->
+  <div class="flex items-center justify-between gap-3 pr-9">
     <div class="flex min-w-0 items-center gap-2">
       <CompanyLogo name={job.company} size="size-7" />
       <span class="truncate text-sm font-medium text-muted-foreground">
@@ -94,3 +135,22 @@
     {/if}
   </div>
 </a>
+
+<!-- Save toggle: an icon-only overlay in the card's top-right corner. It sits
+     outside the <a> (a sibling, not a descendant), so clicking it toggles the
+     bookmark without navigating to the job. -->
+<button
+  type="button"
+  onclick={toggleSave}
+  disabled={saving}
+  aria-pressed={saved}
+  aria-label={saved ? 'Remove from saved' : 'Save job'}
+  title={saved ? 'Saved' : 'Save'}
+  class={[
+    'absolute right-2.5 top-2.5 grid size-8 place-items-center rounded-lg transition hover:bg-accent hover:text-brand disabled:pointer-events-none disabled:opacity-50',
+    saved ? 'text-brand' : 'text-muted-foreground',
+  ]}
+>
+  <Bookmark class="size-[1.05rem] {saved ? 'fill-current' : ''}" aria-hidden="true" />
+</button>
+</div>

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -6,6 +6,7 @@
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { filterHref, formatSalary, summaryFacets } from '$lib/enrichment';
   import { markViewed } from '$lib/viewedJobs.svelte';
+  import { markSaved, markUnsaved } from '$lib/savedJobs.svelte';
   import type { Job, UserJob } from '$lib/types';
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
@@ -130,6 +131,10 @@
   async function toggleSave() {
     try {
       interaction = saved ? await api.unsaveJob(job.public_slug) : await api.saveJob(job.public_slug);
+      // Keep the shared saved set in sync so a browse card's bookmark reflects this
+      // on back-navigation without a reload (mirrors markViewed above).
+      if (interaction?.saved_at != null) markSaved(job.public_slug);
+      else markUnsaved(job.public_slug);
     } catch {
       // Leave the current state; the user can retry.
     }

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -8,6 +8,7 @@
   import { api, type Slice } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
+  import { ensureSavedLoaded } from '$lib/savedJobs.svelte';
   import { latestOnly } from '$lib/latestOnly';
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams, activeFilterCount, type SortField } from '$lib/filters';
@@ -206,11 +207,15 @@
   // Detect that mismatch so the first effect run reloads instead of keeping `initial`.
   const initialStale = browser && page.url.search !== location.search;
 
-  // For a signed-in user, load the set of already-viewed slugs so JobRow can dim
-  // seen cards (no-op when signed out — the set stays empty). Cleanup: cancel any
-  // pending debounced reload so it can't fire after this view is gone.
+  // For a signed-in user, load the set of already-viewed and already-saved slugs so
+  // JobRow can dim seen cards and fill saved bookmarks (no-op when signed out — the
+  // sets stay empty). Cleanup: cancel any pending debounced reload so it can't fire
+  // after this view is gone.
   onMount(() => {
-    if (isAuthenticated()) ensureViewedLoaded();
+    if (isAuthenticated()) {
+      ensureViewedLoaded();
+      ensureSavedLoaded();
+    }
     // Register this page's store so the header search drives it. This holds for the
     // standalone /jobs list AND the company page's embedded, scoped list — on
     // /companies/:slug the header search filters that company's postings (there's

--- a/web/src/lib/savedJobs.svelte.ts
+++ b/web/src/lib/savedJobs.svelte.ts
@@ -1,0 +1,70 @@
+// Tracks which jobs the signed-in user has saved (bookmarked), so the browse list
+// and search results can render the save toggle as already-filled. The set of
+// saved public_slugs is read once from GET /api/v1/me/tracking/saved (the browse
+// view triggers the load); toggling save on a card updates the set locally so the
+// bookmark reflects the change immediately, without waiting for a reload.
+//
+// Sibling of viewedJobs.svelte.ts, with one difference: saving is a two-way toggle,
+// so this store both adds (mark) and removes (unmark), whereas a view is only ever
+// added.
+//
+// SSR-safe and auth-agnostic (see UserResource): the load is a browser-only no-op
+// and the set stays empty for signed-out users. A failed load leaves the set empty —
+// nothing shows filled, the correct degraded state.
+
+import { SvelteSet } from 'svelte/reactivity';
+import { api } from '$lib/api';
+import { UserResource } from '$lib/userResource.svelte';
+
+class SavedJobs extends UserResource<string[]> {
+  // SvelteSet (not a plain Set): a plain Set in $state is not deeply reactive, so
+  // an in-place `.add`/`.delete` would not re-run readers. SvelteSet makes both the
+  // mutation and the load reassignment trigger dependent $derived/$effect (e.g.
+  // JobRow's `saved`).
+  #slugs = $state(new SvelteSet<string>());
+
+  has(slug: string): boolean {
+    return this.#slugs.has(slug);
+  }
+
+  /** Mark a slug saved locally (e.g. right after a successful save), so its card's
+   *  bookmark fills immediately without re-fetching the whole set. */
+  mark(slug: string) {
+    this.#slugs.add(slug);
+  }
+
+  /** Clear a slug's saved mark locally (e.g. right after a successful unsave). */
+  unmark(slug: string) {
+    this.#slugs.delete(slug);
+  }
+
+  protected load(): Promise<string[]> {
+    return api.listSavedSlugs();
+  }
+
+  protected apply(slugs: string[]) {
+    this.#slugs = new SvelteSet(slugs);
+  }
+
+  protected clearState() {
+    this.#slugs = new SvelteSet();
+  }
+}
+
+const savedJobs = new SavedJobs();
+
+export function isSaved(slug: string): boolean {
+  return savedJobs.has(slug);
+}
+
+export function markSaved(slug: string) {
+  savedJobs.mark(slug);
+}
+
+export function markUnsaved(slug: string) {
+  savedJobs.unmark(slug);
+}
+
+export function ensureSavedLoaded(): Promise<void> {
+  return savedJobs.ensureLoaded();
+}


### PR DESCRIPTION
## What

A small icon-only **save** (bookmark) button on every job card (`JobRow`), so a user can save a job to their list straight from the browse list / search results / company page — without opening the job.

![card with bookmark button — saved cards show a filled bookmark](https://user-images.githubusercontent.com/placeholder)

## Design

- **Overlay, not a nested button.** The whole card is an `<a>`; a `<button>` inside an anchor is invalid HTML and would fight navigation. The bookmark is an **absolutely-positioned sibling** of the link (top-right corner), so a click toggles save and never navigates — no `stopPropagation` hacks. `pr-9` on the header row reserves the corner so the timestamp never slides under it.
- **Optimistic + shared source of truth.** Toggling flips the shared `savedJobs` store first (instant fill), then confirms with the server and rolls back on failure. Because the state lives in the store, every card for the same job stays in sync. Signed-out clicks open the sign-in dialog.
- **Persisted state, efficiently.** New endpoint `GET /api/v1/me/tracking/saved` mirrors the existing `/viewed` pattern — one indexed query over the caller's (small) saved subset, hydrated **once** into a `SvelteSet` store with O(1) membership per card (no per-card request). `JobView`'s existing save toggle now also updates the store, so back-navigation reflects it.

This follows the codebase's established "one `UserResource` per concern" pattern (`viewedJobs`, `savedSearches`, `notifications`) rather than a combined endpoint.

## Backend

- `ListSavedJobSlugs` SQL (`saved_at IS NOT NULL`) + sqlc regen.
- `SavedSlugs` through `jobtracking` Repository → Service → `ListSavedSlugs` handler → route.

## Tests / verification

- Unit: `TestSavedSlugs_Passthrough`; integration: `TestListSavedSlugsEndpoint` (saved-only, scoped, unsave drops it, empty, 401).
- `go build ./...`, `go vet`, `gofmt`, `go test ./internal/jobtracking/... ./internal/handler/...` — green.
- `svelte-check` 0 errors; eslint clean on changed files.
- Verified end-to-end locally in a browser: save two jobs → filled bookmark + server set updated → reload → state re-hydrated from the new endpoint.

## Notes

- No new migration (`user_jobs.saved_at` already exists).