### PR TITLE
perf(enrich): drop dict-served facets from the LLM prompt

### DIFF
--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -79,36 +79,29 @@ func buildSystemPrompt() string {
 	enum := func(field string, vals []string) {
 		fmt.Fprintf(&b, "- %s: %s\n", field, strings.Join(vals, ", "))
 	}
-	enum("work_mode", WorkModeValues)
+	// work_mode, seniority, category, employment_type, education_level, and
+	// english_level are deliberately NOT requested: jobview serves them from the
+	// deterministic dictionaries (internal/jobderive), so the LLM's copies were never
+	// served — asking for them only burned output tokens (see enrich-prompt-trim).
 	enum("regions (array)", RegionValues)
-	enum("employment_type", EmploymentTypeValues)
 	enum("relocation", RelocationValues)
 	enum("salary_period", SalaryPeriodValues)
-	enum("seniority", SeniorityValues)
-	enum("english_level", EnglishLevelValues)
-	enum("education_level", EducationLevelValues)
-	enum("category", CategoryValues)
 	enum("domains (array)", DomainValues)
 	enum("company_type", CompanyTypeValues)
 	enum("company_size", CompanySizeValues)
 
-	// Discovery facets: these seven (plus the open countries/skills) are served from
-	// our own dictionaries, not from your value, so they are a discovery signal.
-	// Prefer an allowed value, but emit your own label when none fits — this surfaces
-	// vocabulary we are missing. The other enum fields above stay strict.
-	b.WriteString("\nException for work_mode, regions, seniority, category, employment_type, ")
-	b.WriteString("education_level, english_level: prefer an allowed value above, but if none ")
-	b.WriteString("accurately fits, you MAY return a concise lowercase label of your own ")
-	b.WriteString("(e.g. seniority \"staff_plus\", category \"ml_platform\"). ")
+	// Discovery facets: countries/regions are served as a dict-then-LLM hybrid (the
+	// LLM fills the unpinned geographic bucket via jobview.geoFacet), so they are the
+	// sole facets we still let the model coin its own label for. The other enum fields
+	// above stay strict.
+	b.WriteString("\nException for countries and regions: prefer an allowed value above, but if none ")
+	b.WriteString("accurately fits, you MAY return a concise lowercase label of your own. ")
 	b.WriteString("Still omit the key when the posting does not state it.\n")
 
 	b.WriteString("\nOther keys (omit when unstated): ")
 	b.WriteString("visa_sponsorship (boolean), countries (array of ISO 3166-1 alpha-2), ")
 	b.WriteString("cities (array of strings), timezone_note (string), ")
-	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217), ")
-	b.WriteString("experience_years_min (non-negative int), ")
-	b.WriteString("skills (array of lowercase tokens, e.g. go, postgresql), ")
-	b.WriteString("posting_language (ISO 639-1, e.g. en, uk, ru).\n")
+	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217).\n")
 
 	b.WriteString("\nregions is the job's geographic area, for ANY work mode — a remote role's ")
 	b.WriteString("reach or an onsite/hybrid role's location: ")

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -37,19 +37,45 @@ func TestSystemPromptIncludesRegionVocabulary(t *testing.T) {
 	}
 }
 
-// Relax: the prompt permits a novel own-label for the seven discovery facets while
-// keeping the strict "exactly one allowed value" instruction for the served fields.
-func TestSystemPromptRelaxesDiscoveryFacets(t *testing.T) {
+// The prompt must NOT request the dict-backed facets: jobview serves them from the
+// deterministic dictionaries (internal/jobderive), so the LLM's copies are never
+// served and asking for them only burns output tokens. Removing them from the prompt
+// is the whole point of the enrich-prompt-trim change.
+func TestSystemPromptOmitsDictBackedFacets(t *testing.T) {
 	p := buildSystemPrompt()
+	for _, f := range []string{
+		"work_mode", "seniority", "category", "skills",
+		"employment_type", "education_level", "english_level",
+		"posting_language", "experience_years_min",
+	} {
+		if strings.Contains(p, f) {
+			t.Errorf("prompt must not request dict-backed facet %q (served from dictionaries), got:\n%s", f, p)
+		}
+	}
+}
+
+// The prompt must still request every served or hybrid field it is the source of:
+// the synthesized summary, salary extraction, the served enums, the geographic
+// hybrid (countries/regions), and relocation. countries/regions keep their novel
+// own-label allowance (they are the sole remaining discovery facets); the served
+// enums keep the strict "exactly one allowed value" instruction.
+func TestSystemPromptKeepsServedAndHybridFields(t *testing.T) {
+	p := buildSystemPrompt()
+	for _, f := range []string{
+		"summary",
+		"salary_min", "salary_max", "salary_currency", "salary_period",
+		"visa_sponsorship", "timezone_note",
+		"company_type", "company_size", "domains",
+		"relocation", "countries", "regions",
+	} {
+		if !strings.Contains(p, f) {
+			t.Errorf("prompt must still request served/hybrid field %q, got:\n%s", f, p)
+		}
+	}
 	if !strings.Contains(p, "exactly one of the allowed values") {
 		t.Errorf("served enum fields must keep the strict instruction")
 	}
 	if !strings.Contains(p, "concise lowercase label of your own") {
-		t.Errorf("discovery facets must permit a novel own label")
-	}
-	for _, f := range []string{"work_mode", "regions", "seniority", "category", "employment_type", "education_level", "english_level"} {
-		if !strings.Contains(p, f) {
-			t.Errorf("discovery instruction should name the facet %q", f)
-		}
+		t.Errorf("countries/regions must keep the novel own-label allowance")
 	}
 }

--- a/openspec/changes/enrich-prompt-trim/.openspec.yaml
+++ b/openspec/changes/enrich-prompt-trim/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/enrich-prompt-trim/design.md
+++ b/openspec/changes/enrich-prompt-trim/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`internal/enrich/langchain.go:buildSystemPrompt` asks the LLM for the full
+`Enrichment` contract. Nine of those fields are served dict-only: `jobview`
+overwrites `work_mode`/`seniority`/`category` with the `internal/jobderive`
+dictionary values, serves `skills`/`posting_language`/`experience_years_min`/
+`employment_type`/`education_level`/`english_level` from the same deterministic
+derivation, and the Meilisearch facets are built from that dict-fed projection.
+The LLM's copies are captured only as unserved "discovery material" (per the
+`ai-enrichment` "Unserved discovery facets are captured raw" requirement).
+
+The paid LLM is a metered proxy (per-token spend), so every enrichment pays
+output tokens — including a full `skills` array and several enums — for data no
+reader ever sees. A read-only prod spike over `jobs.enrichment` (1.52M enriched
+rows) confirmed these fields are dict-served across the catalogue.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stop asking the LLM for the nine dict-backed fields, cutting per-call output
+  tokens with zero change to any served value.
+- Keep the change forward-only and contract-stable: no `enrich.Version` bump, no
+  re-enrichment, no struct/DB/frontend change.
+
+**Non-Goals:**
+- Dropping `relocation` — it is a live search facet (`enrichment.relocation` in
+  `internal/search`) and a profile-match input (`web/src/lib/facetModel.ts`) with
+  no dictionary backing; removing it would break a user filter for a single
+  scalar enum's worth of tokens. Out of scope.
+- Shrinking `maxDescriptionRunes` (input-token saving) — unvalidated risk to
+  `summary`/salary extraction depth; a separate change if pursued.
+- Removing the fields from the `Enrichment` struct — kept so old payloads parse
+  and the contract stays stable; they simply read back empty going forward.
+
+## Decisions
+
+- **Prompt-only edit.** The only production change is `buildSystemPrompt`: remove
+  the `enum(...)` lines for `work_mode`, `seniority`, `category`,
+  `employment_type`, `education_level`, `english_level`; drop `skills`,
+  `posting_language`, `experience_years_min` from the "Other keys" line; and
+  remove the discovery-facet "you MAY return a concise lowercase label of your
+  own" exception paragraph **except** for `countries`/`regions`, which stay
+  requested (the hybrid geographic bucket). `Validate`/`Sanitize` are untouched —
+  they are a no-op on an absent field and must still capture a raw
+  `countries`/`regions` or an old payload's discovery value.
+- **Keep the geographic hybrid.** `countries`/`regions` remain in the prompt with
+  their novel-label allowance; the "regions is the job's geographic area…"
+  guidance and the "If the Location field is empty, the URL path…" hint stay.
+- **No version bump.** Consistent with the discovery-facet convention this
+  amends: the change is going-forward only; existing payloads keep their
+  now-orphaned discovery copies untouched.
+
+## Risks / Trade-offs
+
+- **Lost discovery material.** We stop mining novel out-of-vocabulary labels for
+  `work_mode`/`seniority`/`category`/`skills` (the deliberate purpose of the
+  amended requirement). Accepted: the mining has no active consumer, and
+  `countries`/`regions` discovery is retained. Reversible by re-adding the enum
+  lines.
+- **Budget-model prompt sensitivity.** The enrichment prompt is order- and
+  wording-sensitive (a budget model can drop trailing keys). Removing keys
+  shortens the prompt and should not regress the retained fields, but the tests
+  MUST assert the retained keys (`summary`, salary, `company_type/size`,
+  `domains`, `countries`/`regions`, `relocation`) are still requested, not only
+  that the removed ones are gone.
+- **Spec/code drift reconciled.** The amended requirement corrects the
+  served-and-validated enum set to the actual `servedScalarEnums`+`domains`
+  (`relocation`, `salary_period`, `company_type`, `company_size`, `domains`),
+  dropping `employment_type`/`english_level`/`education_level` from that claim
+  (they are dict-covered, not in `servedScalarEnums`).

--- a/openspec/changes/enrich-prompt-trim/proposal.md
+++ b/openspec/changes/enrich-prompt-trim/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+Every `cmd/enrich` LLM call currently asks the model to emit a set of enum/array
+fields — `work_mode`, `seniority`, `category`, `skills`, `employment_type`,
+`education_level`, `english_level`, `posting_language`, `experience_years_min` —
+whose values are **never served**. These facets are served dict-only: `jobview`
+overwrites them with the deterministic dictionary values (`internal/jobderive`),
+and the search index is built from the dictionary-fed projection, so the LLM's
+copies are captured only as unserved "discovery material" for later vocabulary
+mining. We pay output tokens on every enrichment (including a full `skills`
+array and multiple enums) for data no reader ever sees. The paid LLM is a
+metered proxy, so this is direct, unconditional spend on unused output.
+
+## What Changes
+
+- Remove the nine dict-backed fields above from the enrichment system prompt
+  (`internal/enrich/langchain.go`, `buildSystemPrompt`): drop their `enum(...)`
+  lines, the discovery-facet "you MAY return a concise lowercase label of your
+  own" exception paragraph (it only governs these), and the `skills` /
+  `posting_language` / `experience_years_min` entries from the "Other keys" line.
+- **Reverse the deliberate "prompt captures discovery facets raw" decision** for
+  `work_mode`, `seniority`, `category`, `skills`: we stop mining novel
+  out-of-vocabulary labels for these facets in exchange for lower per-call cost.
+  The dictionaries remain the sole served source (unchanged), so no served output
+  changes.
+- **KEEP in the prompt** (genuinely served or hybrid, must not be trimmed):
+  `summary` (synthesized), `salary_min/max/currency`, `visa_sponsorship`,
+  `timezone_note`, `company_type`, `company_size`, `domains`, `relocation`, and
+  `countries`/`regions` (the deliberate dict-then-LLM hybrid where the LLM fills
+  the unpinned geographic bucket via `jobview.geoFacet`).
+- **No contract change and no re-enrichment.** The `Enrichment` struct fields
+  stay (they now simply read back empty from new enrichments); `enrich.Version`
+  is NOT bumped and existing payloads are NOT re-enriched. The change is
+  forward-only, exactly like the discovery-facet convention it amends.
+- **Not in scope (deliberately excluded):** dropping `relocation` (it is a live
+  search facet + profile-match input with no dictionary backing — removing it
+  would break a user filter while saving only a single scalar enum); shrinking
+  `maxDescriptionRunes` (input-token saving, unvalidated risk to summary/salary
+  extraction depth — a separate change if pursued).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `ai-enrichment`: the requirement that the worker captures the discovery facets
+  raw **via a prompt that asks for them** narrows — the prompt SHALL no longer
+  request `work_mode`, `seniority`, `category`, `skills` (nor the non-enum
+  `posting_language`, `experience_years_min`, and the served-but-dict-covered
+  `employment_type`, `education_level`, `english_level`). The extraction scenario
+  that asserts the returned `Enrichment` carries `seniority`/`work_mode`/`skills`
+  is updated to reflect that these are no longer requested. Also reconciles a
+  spec/code drift: `employment_type`/`english_level`/`education_level` are
+  described as validated "served enum fields" but are dict-served and not in
+  `servedScalarEnums`.
+
+## Impact
+
+- **Code:** `internal/enrich/langchain.go` (`buildSystemPrompt`) only. No change
+  to `internal/enrich/enrichment.go` contract, `Validate`, or `Sanitize`
+  (removed fields simply stop arriving; existing sanitize/validate logic is a
+  no-op on an absent field).
+- **No DB / migration / reindex / frontend** impact: served facets are dict-fed
+  and unchanged; the search index is unaffected.
+- **Observable effect:** new enrichment payloads stop carrying LLM copies of the
+  nine facets (and any novel discovery labels for them); per-call output token
+  count drops. Existing payloads are untouched.

--- a/openspec/changes/enrich-prompt-trim/specs/ai-enrichment/spec.md
+++ b/openspec/changes/enrich-prompt-trim/specs/ai-enrichment/spec.md
@@ -1,0 +1,76 @@
+# ai-enrichment
+
+## MODIFIED Requirements
+
+### Requirement: Enrichment is extracted from a job's description by an LLM provider
+
+The system SHALL define a `Provider` abstraction in `internal/enrich` that, given a
+job's source fields (at minimum `title`, `company`, `location`, `remote`,
+`description`), returns a populated `Enrichment` value. The provider SHALL instruct
+the LLM with the controlled vocabularies from the phase-1 contract so that the enum
+fields it is asked for are constrained to their allowed values. The provider SHALL
+NOT ask the LLM for the dictionary-covered facets that the read layer serves from the
+deterministic dictionaries (see "Unserved discovery facets are captured raw, not
+validated"); those are derived by `internal/jobderive`, not the LLM. Fields not
+determinable from the input SHALL be omitted, not guessed.
+
+#### Scenario: Description fields are mapped into the contract
+
+- **WHEN** the provider is given a job whose description states "Senior Go engineer,
+  fully remote, €70k–90k/year"
+- **THEN** it returns an `Enrichment` with `salary_min=70000`, `salary_max=90000`,
+  `salary_currency=EUR`, and `salary_period=year`
+- **AND** it does not populate `seniority`, `work_mode`, or `skills` from the LLM —
+  those are derived by the deterministic dictionaries, not requested in the prompt
+
+#### Scenario: Unstated fields are omitted
+
+- **WHEN** a job description says nothing about visa sponsorship or company size
+- **THEN** the returned `Enrichment` leaves `visa_sponsorship`, `company_size`, and
+  every other unstated field absent rather than filled with a guess
+
+### Requirement: Unserved discovery facets are captured raw, not validated
+
+The enrichment prompt SHALL NOT request the dictionary-covered facets `work_mode`, `seniority`, `category`, or `skills`, nor the non-enum dict-derived `posting_language` and `experience_years_min`, nor the dict-covered `employment_type`, `education_level`, and `english_level` — the read layer serves all of these from the deterministic dictionaries (`internal/jobderive`), so the LLM's copies are never served and paying output tokens for them is waste.
+
+The prompt SHALL continue to request `countries`/`regions` as the sole discovery
+facets — the dict-then-LLM hybrid where the LLM fills only the unpinned geographic
+bucket via `jobview.geoFacet` — and for those two it MAY permit a concise lowercase
+label of the model's own when no allowed value fits.
+
+For any discovery value that is present (from the still-requested `countries`/`regions`
+facets, or a pre-existing payload), the worker SHALL capture it raw: `Sanitize` SHALL
+NOT blank or filter an out-of-vocabulary `work_mode`, `seniority`, `category`, or
+`regions`, and `Validate` SHALL NOT reject the payload for an out-of-vocabulary value
+in those facets. The served enum fields (`relocation`, `salary_period`,
+`company_type`, `company_size`, `domains`) SHALL still be sanitized and validated, and
+salary clamping is unchanged. This applies going forward only — `enrich.Version` MUST
+NOT be bumped and existing payloads MUST NOT be re-enriched.
+
+#### Scenario: The prompt does not request dict-covered facets
+
+- **WHEN** the enrichment system prompt is built
+- **THEN** it contains no request for `work_mode`, `seniority`, `category`, `skills`,
+  `posting_language`, `experience_years_min`, `employment_type`, `education_level`, or
+  `english_level`
+- **AND** a new enrichment payload for a job whose description states "Senior Go
+  engineer" leaves those fields absent
+
+#### Scenario: A still-requested discovery value is persisted raw
+
+- **WHEN** the LLM returns `regions=["antarctica"]` (not a defined value) for a job
+- **THEN** `Sanitize` keeps it, `Validate` passes, and it is written to the job's
+  `enrichment` JSONB
+
+#### Scenario: An out-of-vocabulary served value is still rejected
+
+- **WHEN** the LLM returns `company_type="conglomerate"` (not a defined value)
+- **THEN** `Sanitize` blanks it, so no out-of-vocabulary value reaches the served
+  `company_type`
+
+#### Scenario: The discovery values do not reach the served object
+
+- **WHEN** a job's `enrichment` carries a raw `seniority="staff_plus"` discovery value
+  (e.g. from an older payload)
+- **THEN** the served job object's `seniority` is the dictionary value (or empty),
+  never the raw LLM discovery value

--- a/openspec/changes/enrich-prompt-trim/tasks.md
+++ b/openspec/changes/enrich-prompt-trim/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## 1. Prompt trim: stop requesting the nine dict-backed facets
+
+- [x] 1.1 **RED** — Rewrite `TestSystemPromptRelaxesDiscoveryFacets` in
+  `internal/enrich/langchain_test.go` to encode the new contract: the built
+  system prompt MUST NOT request `work_mode`, `seniority`, `category`, `skills`,
+  `employment_type`, `education_level`, `english_level`, `posting_language`, or
+  `experience_years_min`; it MUST still request `countries`/`regions` (with the
+  "concise lowercase label of your own" allowance) and the retained served keys
+  (`summary`, `salary_min`/`salary_max`/`salary_currency`/`salary_period`,
+  `visa_sponsorship`, `timezone_note`, `company_type`, `company_size`, `domains`,
+  `relocation`). Assert both directions (removed absent AND retained present).
+  Confirm it fails against the current prompt.
+- [x] 1.2 **GREEN** — Edit `buildSystemPrompt` in `internal/enrich/langchain.go`:
+  remove the `enum(...)` lines for `work_mode`, `seniority`, `category`,
+  `employment_type`, `education_level`, `english_level`; drop `skills`,
+  `posting_language`, and `experience_years_min` from the "Other keys" line;
+  narrow the discovery-facet exception paragraph so its novel-label allowance
+  names only `countries`/`regions`. Keep `relocation`, `salary_period`,
+  `company_type`, `company_size`, `domains` enums and the geographic guidance
+  intact.
+- [x] 1.3 Sweep the `internal/enrich` tests for any other assertion tied to a
+  removed field being present in the prompt (e.g. `enrichment_test.go`,
+  `provider_test.go`); update or remove them to match the new prompt. Do NOT
+  touch `Validate`/`Sanitize` behavior or their tests — those stay unchanged.
+- [x] 1.4 **Verify green** — `go test ./internal/enrich/...`, then
+  `go build ./... && go vet ./...`. All pass.


### PR DESCRIPTION
## Summary

The enrich system prompt asked the LLM for nine facets that `jobview` serves
**dict-only** from the deterministic dictionaries — `work_mode`, `seniority`,
`category`, `skills`, `employment_type`, `education_level`, `english_level`,
`posting_language`, `experience_years_min`. `jobview` (`jobview.go:121-132`)
overrides them with the `jobs` dictionary columns and the search index is built
from that projection, so the LLM's copies were **never served** — only paid for
in output tokens on every enrichment.

This drops them from the prompt. Every served/hybrid field stays: `summary`,
`salary_*`, `visa_sponsorship`, `timezone_note`, `company_type`/`company_size`,
`domains`, `relocation`, and the `countries`/`regions` dict-then-LLM hybrid where
the model still fills the unpinned geographic bucket via `jobview.geoFacet`.

`relocation` is **deliberately kept** — a spike showed it is a live search facet
(`internal/search`) and a profile-match input (`web/src/lib/facetModel.ts`) with
no dictionary backing, so removing it would break a user filter for a single
scalar enum's worth of tokens.

Prompt-only change: no `Enrichment` contract change, no `enrich.Version` bump, no
re-enrichment. Existing payloads are untouched (they keep their now-orphaned
discovery copies); new enrichments simply stop carrying the nine facets.

OpenSpec: `enrich-prompt-trim` (modifies the `ai-enrichment` "Unserved discovery
facets are captured raw" requirement — the prompt no longer requests them — and
reconciles a spec/code drift on the served-and-validated enum set).

## Test Plan

- [x] `go test ./internal/enrich/...` — new `TestSystemPromptOmitsDictBackedFacets` + `TestSystemPromptKeepsServedAndHybridFields` assert both directions
- [x] `go build ./... && go vet ./...`
- [x] Verified `jobview.go:121-132` serves all nine from dict columns (search facets are dict-fed, not LLM-fed)