### PR TITLE
chore(sources): drop 2gis from prod board list

### DIFF
--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -50,8 +50,6 @@
   provider: dodo
 - company: DomClick
   provider: domclick
-- company: 2GIS
-  provider: 2gis
 - company: MTS Link
   provider: mtslink
 - company: T-Bank


### PR DESCRIPTION
Follow-up to #647. `job.2gis.ru` tarpits the prod datacenter IP — the listing returns 200 but the body drip-stalls and never completes (verified with plain curl, HTTP/1.1, and a full Chrome TLS+HTTP/2 fingerprint client; all stall → IP-reputation, not a fingerprint check). The `twogis` adapter is correct and crawls fine from a residential IP, so the adapter + tests stay in the tree; only the `custom.yml` board entry is removed until a residential/RU egress proxy exists for it. Same call as the vagas datacenter-IP entry.