### PR TITLE
feat: deterministic tech/non-tech classification + is_tech facet

### DIFF
--- a/cmd/backfill-derive/main.go
+++ b/cmd/backfill-derive/main.go
@@ -103,6 +103,7 @@ func deriveFacets(j db.Job) (db.UpdateJobFacetsParams, bool) {
 		WorkMode:    j.WorkMode, // preserves a set work_mode (jobderive precedence)
 	})
 	experience := pgconv.Int4(d.ExperienceYearsMin)
+	isTech := pgconv.Bool(d.IsTech)
 	changed := !(slices.Equal(d.Countries, j.Countries) &&
 		slices.Equal(d.Regions, j.Regions) &&
 		slices.Equal(d.Cities, j.Cities) &&
@@ -110,6 +111,7 @@ func deriveFacets(j db.Job) (db.UpdateJobFacetsParams, bool) {
 		slices.Equal(d.Skills, j.Skills) &&
 		d.Seniority == j.Seniority &&
 		d.Category == j.Category &&
+		isTech == j.IsTech &&
 		d.PostingLanguage == j.PostingLanguage &&
 		d.EmploymentType == j.EmploymentType &&
 		d.EducationLevel == j.EducationLevel &&
@@ -124,6 +126,7 @@ func deriveFacets(j db.Job) (db.UpdateJobFacetsParams, bool) {
 		Skills:             d.Skills,
 		Seniority:          d.Seniority,
 		Category:           d.Category,
+		IsTech:             isTech,
 		PostingLanguage:    d.PostingLanguage,
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,

--- a/cmd/backfill-derive/main_test.go
+++ b/cmd/backfill-derive/main_test.go
@@ -45,6 +45,7 @@ func expectedFacets(j db.Job) db.UpdateJobFacetsParams {
 	return db.UpdateJobFacetsParams{
 		ID: j.ID, Countries: d.Countries, Regions: d.Regions, Cities: d.Cities, WorkMode: d.WorkMode,
 		Skills: d.Skills, Seniority: d.Seniority, Category: d.Category,
+		IsTech:             pgconv.Bool(d.IsTech),
 		PostingLanguage:    d.PostingLanguage,
 		EmploymentType:     d.EmploymentType,
 		EducationLevel:     d.EducationLevel,

--- a/internal/classify/nontech.go
+++ b/internal/classify/nontech.go
@@ -1,0 +1,68 @@
+package classify
+
+import (
+	"strings"
+
+	"github.com/strelov1/freehire/internal/wordmatch"
+)
+
+// nonTechTitleTerms is a curated set of confidently non-technical role nouns
+// found in job titles, beyond the four non-tech categories the categoryTable
+// already resolves (marketing/sales/support/management). It exists to place the
+// large tail of non-engineering roles that generic ATS boards pour into the
+// catalogue — healthcare, trades, hospitality, retail, logistics, education,
+// personal care, facilities — which the tech-focused categoryTable leaves empty.
+//
+// The same doctrine as the rest of classify: whole-word match, never guess. Two
+// rules keep it from ever shadowing a technical role:
+//   - No term that also occurs in tech titles. Bare "engineer"/"technician"/
+//     "analyst"/"driver" (device driver)/"server" (backend)/"warehouse" (data
+//     warehouse) are deliberately absent; ambiguous roles use a full non-tech
+//     phrase ("truck driver", "line cook") instead.
+//   - This detector is consulted only after the tech category dictionary is
+//     silent (see jobderive), so tech evidence always wins.
+var nonTechTitleTerms = []string{
+	// Healthcare & care
+	"nurse", "nursing", "caregiver", "caretaker", "home health aide",
+	"veterinary", "veterinarian", "dental hygienist", "dental assistant",
+	"pharmacist", "phlebotomist", "paramedic", "medical assistant",
+	"physical therapist", "occupational therapist", "massage therapist",
+	// Skilled trades
+	"electrician", "plumber", "welder", "carpenter", "machinist", "millwright",
+	"forklift",
+	// Hospitality & food service. Bare "chef" is deliberately absent — it collides
+	// with Progress Chef (config-management), which would mislabel a DevOps/SRE
+	// title the tech dictionary did not place; the cook terms cover food service.
+	"barista", "bartender", "line cook", "prep cook", "dishwasher",
+	"housekeeper", "housekeeping", "banquet", "waiter", "waitress", "busser",
+	"concierge", "valet",
+	// Retail & warehouse
+	"cashier", "stocker", "merchandiser",
+	// Personal care & fitness
+	"pilates instructor", "yoga instructor", "fitness instructor",
+	"personal trainer", "cosmetologist", "hair stylist", "hairstylist",
+	"barber", "esthetician",
+	// Education & childcare
+	"teacher", "tutor", "preschool",
+	// Facilities & cleaning
+	"janitor", "janitorial", "cleaner", "custodian", "groundskeeper",
+	// Security & transport
+	"security guard", "truck driver", "delivery driver", "bus driver", "courier",
+	// Front-of-house administration
+	"receptionist", "front desk",
+}
+
+// IsNonTech reports whether a job title states a confidently non-technical role,
+// matching any nonTechTitleTerms term on word boundaries. It never guesses: a
+// title it cannot confidently place returns false. It resolves ONLY non-technical
+// roles — a technical title yields false — so it can feed the is_tech derivation
+// without risking a technical job being mislabelled.
+func IsNonTech(title string) bool {
+	lower := strings.ToLower(title)
+	for _, term := range nonTechTitleTerms {
+		if wordmatch.Contains(lower, term, wordmatch.UnicodeBoundary) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/classify/nontech_test.go
+++ b/internal/classify/nontech_test.go
@@ -1,0 +1,47 @@
+package classify
+
+import "testing"
+
+func TestIsNonTech(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		// Positives — confident non-tech role nouns beyond the 4 category buckets.
+		{"nurse", "NICU Registered Nurse - Per Diem", true},
+		{"veterinary nurse", "Veterinary Nurse", true},
+		{"forklift operator", "Forklift Operator - Night Shift", true},
+		{"warehouse cleaner", "Warehouse Janitorial Cleaner", true},
+		{"cashier", "Cashier / Front End Associate", true},
+		{"housekeeping", "Accommodation Cleaner Part Time", true},
+		{"electrician", "Journeyman Electrician", true},
+		{"plumber", "Commercial Plumber", true},
+		{"pilates instructor", "Pilates Instructor", true},
+		{"dental hygienist", "Dental Hygienist", true},
+		{"line cook", "Line Cook - Banquet Setup", true},
+		{"barista", "Barista (Seasonal)", true},
+		{"truck driver", "Class A Truck Driver", true},
+		{"security guard", "Overnight Security Guard", true},
+		{"teacher", "Preschool Teacher", true},
+
+		// Trap negatives — technical titles that must NOT be flagged, including
+		// shared words ("engineer") and non-tech-adjacent substrings from real data.
+		{"software engineer", "Software Engineer II, AWS DynamoDB", false},
+		{"hris engineer", "Senior HRIS Engineer (SAP SuccessFactors)", false},
+		{"devops engineer", "DevOps Engineer", false},
+		{"data scientist", "Data Scientist", false},
+		{"retail application engineer", "Principal Systems Engineer - Retail Application Engineer", false},
+		{"device driver engineer", "Storage Driver Engineer", false},
+		{"support engineer", "Application Support Engineer", false},
+		{"chef config tool", "Configuration Engineer (Chef, Puppet)", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNonTech(tt.title); got != tt.want {
+				t.Errorf("IsNonTech(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -238,7 +238,7 @@ func (q *Queries) ExistingExternalIDs(ctx context.Context, source string) ([]str
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE id = $1
 `
@@ -289,12 +289,13 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
+		&i.IsTech,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE public_slug = $1
 `
@@ -345,12 +346,13 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
+		&i.IsTech,
 	)
 	return i, err
 }
 
 const getJobBySourceExternalID = `-- name: GetJobBySourceExternalID :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE source = $1 AND external_id = $2
 `
@@ -408,6 +410,7 @@ func (q *Queries) GetJobBySourceExternalID(ctx context.Context, arg GetJobBySour
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
+		&i.IsTech,
 	)
 	return i, err
 }
@@ -543,7 +546,7 @@ func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
@@ -610,6 +613,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
+			&i.IsTech,
 		); err != nil {
 			return nil, err
 		}
@@ -622,7 +626,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
@@ -689,6 +693,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
+			&i.IsTech,
 		); err != nil {
 			return nil, err
 		}
@@ -701,7 +706,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -768,6 +773,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
+			&i.IsTech,
 		); err != nil {
 			return nil, err
 		}
@@ -780,7 +786,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsBySourceAfter = `-- name: ListJobsBySourceAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE source = $1 AND id > $2
 ORDER BY id
@@ -848,6 +854,7 @@ func (q *Queries) ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourc
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
+			&i.IsTech,
 		); err != nil {
 			return nil, err
 		}
@@ -860,7 +867,7 @@ func (q *Queries) ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourc
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -931,6 +938,7 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
+			&i.IsTech,
 		); err != nil {
 			return nil, err
 		}
@@ -979,7 +987,7 @@ func (q *Queries) ListOpenJobIDsPostedAfter(ctx context.Context, arg ListOpenJob
 }
 
 const listOpenJobsPostedAfter = `-- name: ListOpenJobsPostedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE id > $1 AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= $2
 ORDER BY id
@@ -1052,6 +1060,7 @@ func (q *Queries) ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsP
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
+			&i.IsTech,
 		); err != nil {
 			return nil, err
 		}
@@ -1570,12 +1579,13 @@ SET countries = COALESCE($1::text[], '{}'),
     skills    = COALESCE($5::text[], '{}'),
     seniority = $6,
     category  = $7,
-    posting_language     = $8,
-    employment_type      = $9,
-    education_level      = $10,
-    english_level        = $11,
-    experience_years_min = $12
-WHERE id = $13
+    is_tech   = $8,
+    posting_language     = $9,
+    employment_type      = $10,
+    education_level      = $11,
+    english_level        = $12,
+    experience_years_min = $13
+WHERE id = $14
 `
 
 type UpdateJobFacetsParams struct {
@@ -1586,6 +1596,7 @@ type UpdateJobFacetsParams struct {
 	Skills             []string    `json:"skills"`
 	Seniority          string      `json:"seniority"`
 	Category           string      `json:"category"`
+	IsTech             pgtype.Bool `json:"is_tech"`
 	PostingLanguage    string      `json:"posting_language"`
 	EmploymentType     string      `json:"employment_type"`
 	EducationLevel     string      `json:"education_level"`
@@ -1595,7 +1606,7 @@ type UpdateJobFacetsParams struct {
 }
 
 // One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
-// facet column — countries, regions, work_mode, skills, seniority, category, plus the
+// facet column — countries, regions, work_mode, skills, seniority, category, is_tech, plus the
 // synthetic enrichment facets posting_language, employment_type, education_level,
 // english_level, and experience_years_min — from the row's raw content
 // (title/location/description) in one
@@ -1615,6 +1626,7 @@ func (q *Queries) UpdateJobFacets(ctx context.Context, arg UpdateJobFacetsParams
 		arg.Skills,
 		arg.Seniority,
 		arg.Category,
+		arg.IsTech,
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
@@ -1670,15 +1682,16 @@ SET title        = $1,
     skills       = COALESCE($12::text[], '{}'),
     seniority    = $13,
     category     = $14,
-    posting_language     = $15,
-    employment_type      = $16,
-    education_level      = $17,
-    english_level        = $18,
-    experience_years_min = $19,
-    updated_by   = $20::bigint,
+    is_tech      = $15,
+    posting_language     = $16,
+    employment_type      = $17,
+    education_level      = $18,
+    english_level        = $19,
+    experience_years_min = $20,
+    updated_by   = $21::bigint,
     updated_at   = now()
-WHERE public_slug = $21 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+WHERE public_slug = $22 AND created_by IS NOT NULL
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 `
 
 type UpdateManualJobParams struct {
@@ -1696,6 +1709,7 @@ type UpdateManualJobParams struct {
 	Skills             []string           `json:"skills"`
 	Seniority          string             `json:"seniority"`
 	Category           string             `json:"category"`
+	IsTech             pgtype.Bool        `json:"is_tech"`
 	PostingLanguage    string             `json:"posting_language"`
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
@@ -1733,6 +1747,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		arg.Skills,
 		arg.Seniority,
 		arg.Category,
+		arg.IsTech,
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
@@ -1785,6 +1800,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
+		&i.IsTech,
 	)
 	return i, err
 }
@@ -1804,7 +1820,7 @@ company_upsert AS (
 )
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
-    public_slug, countries, regions, cities, work_mode, skills, seniority, category,
+    public_slug, countries, regions, cities, work_mode, skills, seniority, category, is_tech,
     posting_language, employment_type, education_level, english_level, experience_years_min,
     content_hash, role_fingerprint
 ) VALUES (
@@ -1813,9 +1829,9 @@ INSERT INTO jobs (
     $9, $10,
     $11,
     COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'), COALESCE($14::text[], '{}'),
-    $15, COALESCE($16::text[], '{}'), $17, $18,
-    $19, $20, $21, $22, $23,
-    $24, $25
+    $15, COALESCE($16::text[], '{}'), $17, $18, $19,
+    $20, $21, $22, $23, $24,
+    $25, $26
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -1841,6 +1857,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     skills       = EXCLUDED.skills,
     seniority    = EXCLUDED.seniority,
     category     = EXCLUDED.category,
+    is_tech      = EXCLUDED.is_tech,
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
@@ -1857,9 +1874,9 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
-    ((SELECT old_hash FROM existing) IS DISTINCT FROM $24) AS changed
+    ((SELECT old_hash FROM existing) IS DISTINCT FROM $25) AS changed
 `
 
 type UpsertJobParams struct {
@@ -1881,6 +1898,7 @@ type UpsertJobParams struct {
 	Skills             []string           `json:"skills"`
 	Seniority          string             `json:"seniority"`
 	Category           string             `json:"category"`
+	IsTech             pgtype.Bool        `json:"is_tech"`
 	PostingLanguage    string             `json:"posting_language"`
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
@@ -1936,6 +1954,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		arg.Skills,
 		arg.Seniority,
 		arg.Category,
+		arg.IsTech,
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
@@ -1988,6 +2007,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.SemanticEmbeddedModel,
 		&i.Job.SemanticEmbeddedHash,
 		&i.Job.DuplicateOf,
+		&i.Job.IsTech,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -2005,7 +2025,7 @@ WITH company_upsert AS (
 )
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
-    public_slug, countries, regions, cities, work_mode, skills, seniority, category,
+    public_slug, countries, regions, cities, work_mode, skills, seniority, category, is_tech,
     posting_language, employment_type, education_level, english_level, experience_years_min,
     created_by
 ) VALUES (
@@ -2015,9 +2035,9 @@ INSERT INTO jobs (
     $11,
     COALESCE($12::text[], '{}'), COALESCE($13::text[], '{}'), COALESCE($14::text[], '{}'),
     $15, COALESCE($16::text[], '{}'),
-    $17, $18,
-    $19, $20, $21, $22, $23,
-    $24::bigint
+    $17, $18, $19,
+    $20, $21, $22, $23, $24,
+    $25::bigint
 )
 ON CONFLICT (source, external_id) DO UPDATE SET
     url          = EXCLUDED.url,
@@ -2035,18 +2055,19 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     skills       = EXCLUDED.skills,
     seniority    = EXCLUDED.seniority,
     category     = EXCLUDED.category,
+    is_tech      = EXCLUDED.is_tech,
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
     english_level        = EXCLUDED.english_level,
     experience_years_min = EXCLUDED.experience_years_min,
-    updated_by   = $25::bigint,
+    updated_by   = $26::bigint,
     -- A moderator re-create reopens the job; reset the strike count too so the
     -- two-strike liveness grace survives a reopen (see UpsertJob).
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 `
 
 type UpsertManualJobParams struct {
@@ -2068,6 +2089,7 @@ type UpsertManualJobParams struct {
 	Skills             []string           `json:"skills"`
 	Seniority          string             `json:"seniority"`
 	Category           string             `json:"category"`
+	IsTech             pgtype.Bool        `json:"is_tech"`
 	PostingLanguage    string             `json:"posting_language"`
 	EmploymentType     string             `json:"employment_type"`
 	EducationLevel     string             `json:"education_level"`
@@ -2107,6 +2129,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		arg.Skills,
 		arg.Seniority,
 		arg.Category,
+		arg.IsTech,
 		arg.PostingLanguage,
 		arg.EmploymentType,
 		arg.EducationLevel,
@@ -2159,6 +2182,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.SemanticEmbeddedModel,
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
+		&i.IsTech,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -142,6 +142,7 @@ type Job struct {
 	SemanticEmbeddedModel pgtype.Text        `json:"semantic_embedded_model"`
 	SemanticEmbeddedHash  pgtype.Text        `json:"semantic_embedded_hash"`
 	DuplicateOf           pgtype.Int8        `json:"duplicate_of"`
+	IsTech                pgtype.Bool        `json:"is_tech"`
 }
 
 type JobDailyStat struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -744,7 +744,7 @@ type Querier interface {
 	// and hash move; the deterministic facets are re-derived separately by cmd/backfill-derive.
 	UpdateJobDescription(ctx context.Context, arg UpdateJobDescriptionParams) (int64, error)
 	// One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
-	// facet column — countries, regions, work_mode, skills, seniority, category, plus the
+	// facet column — countries, regions, work_mode, skills, seniority, category, is_tech, plus the
 	// synthetic enrichment facets posting_language, employment_type, education_level,
 	// english_level, and experience_years_min — from the row's raw content
 	// (title/location/description) in one

--- a/internal/db/queries/jobs.sql
+++ b/internal/db/queries/jobs.sql
@@ -183,7 +183,7 @@ company_upsert AS (
 )
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
-    public_slug, countries, regions, cities, work_mode, skills, seniority, category,
+    public_slug, countries, regions, cities, work_mode, skills, seniority, category, is_tech,
     posting_language, employment_type, education_level, english_level, experience_years_min,
     content_hash, role_fingerprint
 ) VALUES (
@@ -192,7 +192,7 @@ INSERT INTO jobs (
     sqlc.arg(description), sqlc.arg(posted_at),
     sqlc.arg(public_slug),
     COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'), COALESCE(sqlc.arg(cities)::text[], '{}'),
-    sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'), sqlc.arg(seniority), sqlc.arg(category),
+    sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'), sqlc.arg(seniority), sqlc.arg(category), sqlc.arg(is_tech),
     sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(english_level), sqlc.arg(experience_years_min),
     sqlc.arg(content_hash), sqlc.arg(role_fingerprint)
 )
@@ -224,6 +224,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     skills       = EXCLUDED.skills,
     seniority    = EXCLUDED.seniority,
     category     = EXCLUDED.category,
+    is_tech      = EXCLUDED.is_tech,
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
@@ -482,7 +483,7 @@ WITH company_upsert AS (
 )
 INSERT INTO jobs (
     source, external_id, url, title, company, company_slug, location, remote, description, posted_at,
-    public_slug, countries, regions, cities, work_mode, skills, seniority, category,
+    public_slug, countries, regions, cities, work_mode, skills, seniority, category, is_tech,
     posting_language, employment_type, education_level, english_level, experience_years_min,
     created_by
 ) VALUES (
@@ -492,7 +493,7 @@ INSERT INTO jobs (
     sqlc.arg(public_slug),
     COALESCE(sqlc.arg(countries)::text[], '{}'), COALESCE(sqlc.arg(regions)::text[], '{}'), COALESCE(sqlc.arg(cities)::text[], '{}'),
     sqlc.arg(work_mode), COALESCE(sqlc.arg(skills)::text[], '{}'),
-    sqlc.arg(seniority), sqlc.arg(category),
+    sqlc.arg(seniority), sqlc.arg(category), sqlc.arg(is_tech),
     sqlc.arg(posting_language), sqlc.arg(employment_type), sqlc.arg(education_level), sqlc.arg(english_level), sqlc.arg(experience_years_min),
     sqlc.arg(created_by)::bigint
 )
@@ -512,6 +513,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     skills       = EXCLUDED.skills,
     seniority    = EXCLUDED.seniority,
     category     = EXCLUDED.category,
+    is_tech      = EXCLUDED.is_tech,
     posting_language     = EXCLUDED.posting_language,
     employment_type      = EXCLUDED.employment_type,
     education_level      = EXCLUDED.education_level,
@@ -561,6 +563,7 @@ SET title        = sqlc.arg(title),
     skills       = COALESCE(sqlc.arg(skills)::text[], '{}'),
     seniority    = sqlc.arg(seniority),
     category     = sqlc.arg(category),
+    is_tech      = sqlc.arg(is_tech),
     posting_language     = sqlc.arg(posting_language),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),
@@ -716,7 +719,7 @@ WHERE id = sqlc.arg(id);
 
 -- name: UpdateJobFacets :exec
 -- One-off backfill (cmd/backfill-derive): rewrite every deterministic dictionary
--- facet column — countries, regions, work_mode, skills, seniority, category, plus the
+-- facet column — countries, regions, work_mode, skills, seniority, category, is_tech, plus the
 -- synthetic enrichment facets posting_language, employment_type, education_level,
 -- english_level, and experience_years_min — from the row's raw content
 -- (title/location/description) in one
@@ -735,6 +738,7 @@ SET countries = COALESCE(sqlc.arg(countries)::text[], '{}'),
     skills    = COALESCE(sqlc.arg(skills)::text[], '{}'),
     seniority = sqlc.arg(seniority),
     category  = sqlc.arg(category),
+    is_tech   = sqlc.arg(is_tech),
     posting_language     = sqlc.arg(posting_language),
     employment_type      = sqlc.arg(employment_type),
     education_level      = sqlc.arg(education_level),

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -143,7 +143,7 @@ func (q *Queries) EnqueuePendingSemanticJobs(ctx context.Context, arg EnqueuePen
 }
 
 const getJobsByIDs = `-- name: GetJobsByIDs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
 FROM jobs
 WHERE id = ANY($1::bigint[])
 `
@@ -203,6 +203,7 @@ func (q *Queries) GetJobsByIDs(ctx context.Context, ids []int64) ([]Job, error) 
 			&i.SemanticEmbeddedModel,
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
+			&i.IsTech,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -221,7 +221,7 @@ func (q *Queries) ListSavedJobSlugs(ctx context.Context, userID int64) ([]string
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -313,6 +313,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.SemanticEmbeddedModel,
 			&i.Job.SemanticEmbeddedHash,
 			&i.Job.DuplicateOf,
+			&i.Job.IsTech,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,

--- a/internal/enrich/enrichment.go
+++ b/internal/enrich/enrichment.go
@@ -127,7 +127,21 @@ var (
 	// empty/"other"/unrecognized category still enqueues, so a tech job the title
 	// dictionary could not place is never silently skipped.
 	NonTechCategories = []string{"marketing", "sales", "support", "management"}
-	DomainValues      = []string{
+	// TechCategories are the CategoryValues for recognized technical roles: every
+	// category that is neither a NonTechCategories member nor the residual "other".
+	// It is the single source of truth for "is this a technical category?" that the
+	// is_tech derivation reads, so the tech/non-tech/other split stays in one place;
+	// a test asserts the three sets partition CategoryValues exactly. Product/design/
+	// project_management count as technical here (IT-industry roles), matching the
+	// blacklist that treats only marketing/sales/support/management as non-tech.
+	TechCategories = []string{
+		"backend", "frontend", "fullstack", "mobile", "devops", "sre",
+		"network_engineering",
+		"data_engineering", "data_science", "data_analytics", "ml_ai", "ai_engineering",
+		"qa", "security", "hardware", "embedded", "blockchain", "architecture",
+		"design", "product", "project_management",
+	}
+	DomainValues = []string{
 		"fintech", "gambling", "ecommerce", "crypto", "healthcare",
 		"saas", "gamedev", "edtech", "adtech", "govtech",
 		"media", "travel", "logistics", "other",

--- a/internal/enrich/techcategories_test.go
+++ b/internal/enrich/techcategories_test.go
@@ -1,0 +1,51 @@
+package enrich
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestCategoryPartition locks the invariant the is_tech derivation relies on:
+// TechCategories, NonTechCategories, and the residual {"other"} must partition
+// CategoryValues exactly — every category classified once, none twice, none left
+// out. If a new category is added to CategoryValues without placing it, this fails.
+func TestCategoryPartition(t *testing.T) {
+	seen := map[string]int{}
+	for _, c := range TechCategories {
+		seen[c]++
+	}
+	for _, c := range NonTechCategories {
+		seen[c]++
+	}
+	seen["other"]++
+
+	for _, c := range CategoryValues {
+		switch seen[c] {
+		case 0:
+			t.Errorf("category %q is in CategoryValues but neither Tech nor NonTech nor other", c)
+		case 1:
+			// classified exactly once — good
+		default:
+			t.Errorf("category %q is classified %d times (must be exactly one bucket)", c, seen[c])
+		}
+	}
+	for c, n := range seen {
+		if !slices.Contains(CategoryValues, c) {
+			t.Errorf("category %q is bucketed (%d) but not a member of CategoryValues", c, n)
+		}
+	}
+}
+
+func TestTechCategoriesExcludesNonTech(t *testing.T) {
+	if !slices.Contains(TechCategories, "backend") {
+		t.Error("TechCategories must contain a recognized technical category like backend")
+	}
+	for _, nt := range NonTechCategories {
+		if slices.Contains(TechCategories, nt) {
+			t.Errorf("TechCategories must not contain non-tech category %q", nt)
+		}
+	}
+	if slices.Contains(TechCategories, "other") {
+		t.Error("TechCategories must not contain the residual \"other\"")
+	}
+}

--- a/internal/job/istech_test.go
+++ b/internal/job/istech_test.go
@@ -1,0 +1,47 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestNew_IsTechThreadedToFieldsAndParams(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  *bool // nil = unknown
+	}{
+		{"tech title", "Senior Backend Developer", boolp(true)},
+		{"non-tech title", "Warehouse Janitorial Cleaner", boolp(false)},
+		{"unknown title", "Yard Coordinator", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j, err := New(Draft{Source: "src", ExternalID: "ext", Title: tt.title})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if got := j.Fields().IsTech; !eqBoolp(got, tt.want) {
+				t.Errorf("Fields().IsTech = %v, want %v", got, tt.want)
+			}
+			// UpsertParams must carry the same signal as a nullable pgtype.Bool.
+			wantPg := pgtype.Bool{}
+			if tt.want != nil {
+				wantPg = pgtype.Bool{Bool: *tt.want, Valid: true}
+			}
+			if got := j.Fields().UpsertParams().IsTech; got != wantPg {
+				t.Errorf("UpsertParams().IsTech = %+v, want %+v", got, wantPg)
+			}
+		})
+	}
+}
+
+func boolp(b bool) *bool { return &b }
+
+func eqBoolp(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -68,6 +68,9 @@ type Fields struct {
 	Skills    []string
 	Seniority string
 	Category  string
+	// IsTech is the tri-state technical/non-technical signal (nil = unknown), derived
+	// from title + category; served as a filterable facet. See jobderive.Derived.IsTech.
+	IsTech *bool
 
 	// synthetic enrichment facets (deterministic stand-ins)
 	PostingLanguage    string
@@ -144,6 +147,7 @@ func New(d Draft) (Job, error) {
 		Skills:    der.Skills,
 		Seniority: der.Seniority,
 		Category:  der.Category,
+		IsTech:    der.IsTech,
 
 		PostingLanguage:    der.PostingLanguage,
 		EmploymentType:     der.EmploymentType,
@@ -183,6 +187,7 @@ func (f Fields) UpsertParams() db.UpsertJobParams {
 		Skills:      f.Skills,
 		Seniority:   f.Seniority,
 		Category:    f.Category,
+		IsTech:      pgconv.Bool(f.IsTech),
 
 		PostingLanguage:    f.PostingLanguage,
 		EmploymentType:     f.EmploymentType,

--- a/internal/job/repository.go
+++ b/internal/job/repository.go
@@ -67,6 +67,7 @@ func jobFromRow(r db.Job) (Job, error) {
 		Skills:    r.Skills,
 		Seniority: r.Seniority,
 		Category:  r.Category,
+		IsTech:    boolPtr(r.IsTech),
 
 		PostingLanguage:    r.PostingLanguage,
 		EmploymentType:     r.EmploymentType,
@@ -105,6 +106,16 @@ func tsPtr(ts pgtype.Timestamptz) *time.Time {
 	}
 	t := ts.Time
 	return &t
+}
+
+// boolPtr renders a nullable Postgres bool as *bool (nil when unset), keeping the
+// tri-state is_tech signal out of pgtype in the aggregate.
+func boolPtr(b pgtype.Bool) *bool {
+	if !b.Valid {
+		return nil
+	}
+	v := b.Bool
+	return &v
 }
 
 // int4Ptr renders a nullable Postgres int4 as *int (nil when unset).

--- a/internal/jobderive/istech_test.go
+++ b/internal/jobderive/istech_test.go
@@ -1,0 +1,64 @@
+package jobderive
+
+import "testing"
+
+func TestDerive_IsTech(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Input
+		want *bool // nil = unknown
+	}{
+		{
+			name: "recognized tech category via title → true",
+			in:   Input{Title: "Senior Backend Developer"},
+			want: boolp(true),
+		},
+		{
+			name: "blacklist non-tech category via title → false",
+			in:   Input{Title: "Sales Manager"},
+			want: boolp(false),
+		},
+		{
+			name: "detector-only non-tech title → false",
+			in:   Input{Title: "Warehouse Janitorial Cleaner"},
+			want: boolp(false),
+		},
+		{
+			name: "unresolved title stays unknown → nil",
+			in:   Input{Title: "Yard Coordinator"},
+			want: nil,
+		},
+		{
+			name: "tech wins over a non-tech noun in the same title",
+			in:   Input{Title: "Backend Engineer, Nurse Scheduling Platform"},
+			want: boolp(true),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Derive(tt.in).IsTech
+			if !eqBoolp(got, tt.want) {
+				t.Errorf("IsTech = %s, want %s", showBoolp(got), showBoolp(tt.want))
+			}
+		})
+	}
+}
+
+func boolp(b bool) *bool { return &b }
+
+func eqBoolp(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	return *a == *b
+}
+
+func showBoolp(b *bool) string {
+	if b == nil {
+		return "nil"
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -6,9 +6,11 @@
 package jobderive
 
 import (
+	"slices"
 	"sort"
 
 	"github.com/strelov1/freehire/internal/classify"
+	"github.com/strelov1/freehire/internal/enrich"
 	"github.com/strelov1/freehire/internal/jobfacts"
 	"github.com/strelov1/freehire/internal/lang"
 	"github.com/strelov1/freehire/internal/location"
@@ -53,6 +55,12 @@ type Derived struct {
 	Skills      []string
 	Seniority   string
 	Category    string
+	// IsTech is the tri-state technical/non-technical signal: non-nil true when the
+	// derived category is a recognized technical category, non-nil false when it is a
+	// known non-technical category or the title states a confident non-tech role, and
+	// nil when neither resolves (unknown — never coerced, so the coverage gap stays
+	// measurable).
+	IsTech *bool
 	// Synthetic enrichment facets (category B): deterministic stand-ins for fields
 	// the LLM also emits, served dict-only like the facets above. ExperienceYearsMin
 	// is nil when the description states no figure.
@@ -113,6 +121,7 @@ func Derive(in Input) Derived {
 	if category == "" {
 		category = classify.NonTechFromDescription(in.Description)
 	}
+	isTech := deriveIsTech(category, in.Title)
 	// Experience precedence: structured source signal → description text parse.
 	experience := in.ExperienceYearsMin
 	if experience == nil {
@@ -130,12 +139,33 @@ func Derive(in Input) Derived {
 		Skills:             unionSkills(in.Skills, skilltag.Parse(in.Description)),
 		Seniority:          seniority,
 		Category:           category,
+		IsTech:             isTech,
 		PostingLanguage:    lang.Detect(in.Description),
 		EmploymentType:     jobfacts.EmploymentType(in.Title, in.Description),
 		EducationLevel:     jobfacts.EducationLevel(in.Description),
 		EnglishLevel:       jobfacts.EnglishLevel(in.Description),
 		ExperienceYearsMin: experience,
 	}
+}
+
+// deriveIsTech computes the tri-state is_tech signal from the already-resolved
+// category and the raw title. Technical evidence wins: a recognized technical
+// category yields true first; otherwise a known non-technical category or a
+// confident non-tech title yields false; otherwise the signal is unknown (nil),
+// never coerced, so the unclassified mass stays measurable. Because the category
+// derivation checks the tech title dictionary before anything non-technical, a
+// title carrying both a tech role and a non-tech noun ("Backend Engineer, Nurse
+// Scheduling") already resolves a tech category and never reaches IsNonTech.
+func deriveIsTech(category, title string) *bool {
+	if slices.Contains(enrich.TechCategories, category) {
+		t := true
+		return &t
+	}
+	if slices.Contains(enrich.NonTechCategories, category) || classify.IsNonTech(title) {
+		f := false
+		return &f
+	}
+	return nil
 }
 
 // usOnly reports whether a job's geography is unpinned by the location dictionary —

--- a/internal/jobview/istech_test.go
+++ b/internal/jobview/istech_test.go
@@ -1,0 +1,34 @@
+package jobview
+
+import (
+	"testing"
+
+	"github.com/strelov1/freehire/internal/job"
+)
+
+func TestFromDomain_IsTechFacet(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string // "" = omitted (unknown)
+	}{
+		{"tech", "Senior Backend Developer", "tech"},
+		{"non_tech", "Warehouse Janitorial Cleaner", "non_tech"},
+		{"unknown", "Yard Coordinator", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			j, err := job.New(job.Draft{Source: "src", ExternalID: "ext", Title: tt.title})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			v, err := FromDomain(j, job.Extras{})
+			if err != nil {
+				t.Fatalf("FromDomain: %v", err)
+			}
+			if v.IsTech != tt.want {
+				t.Errorf("IsTech = %q, want %q", v.IsTech, tt.want)
+			}
+		})
+	}
+}

--- a/internal/jobview/jobview.go
+++ b/internal/jobview/jobview.go
@@ -69,9 +69,14 @@ type Job struct {
 	// deterministic source fact (no LLM counterpart) served straight from the jobs
 	// column; an untagged job serializes it as [].
 	Collections []string `json:"collections"`
-	PostedAt    *string  `json:"posted_at"`
-	CreatedAt   *string  `json:"created_at"`
-	UpdatedAt   *string  `json:"updated_at"`
+	// IsTech is the deterministic technical/non-technical facet: "tech" or "non_tech",
+	// omitted when unknown (the tri-state jobs.is_tech NULL). Served top-level and
+	// indexed as a filterable Meili facet; an unknown value is absent so it filters as
+	// empty. Derived from title + category (jobderive), never from the LLM.
+	IsTech    string  `json:"is_tech,omitempty"`
+	PostedAt  *string `json:"posted_at"`
+	CreatedAt *string `json:"created_at"`
+	UpdatedAt *string `json:"updated_at"`
 	// ClosedAt is non-null when the posting is no longer open. Lists and the
 	// search index never contain closed jobs; only the detail endpoint serves
 	// them, and the SPA renders the closed state from this field.
@@ -149,6 +154,7 @@ func FromDomain(j job.Job, x job.Extras) (Job, error) {
 		Skills:            skills,
 		Cities:            cities,
 		Collections:       collections,
+		IsTech:            isTechFacet(f.IsTech),
 		PostedAt:          rfc3339Ptr(effectivePosted(f.PostedAt, f.CreatedAt)),
 		CreatedAt:         rfc3339Ptr(f.CreatedAt),
 		UpdatedAt:         rfc3339Ptr(f.UpdatedAt),
@@ -159,6 +165,20 @@ func FromDomain(j job.Job, x job.Extras) (Job, error) {
 		ViewCount:         x.ViewCount,
 		AppliedCount:      x.AppliedCount,
 	}, nil
+}
+
+// isTechFacet renders the tri-state is_tech signal as its served facet value:
+// "tech" for true, "non_tech" for false, and "" (omitted) for unknown (nil), so an
+// unclassified job carries no facet value and filters as empty rather than as a
+// misleading bucket.
+func isTechFacet(isTech *bool) string {
+	if isTech == nil {
+		return ""
+	}
+	if *isTech {
+		return "tech"
+	}
+	return "non_tech"
 }
 
 // effectivePosted is EffectivePostedAt over domain *time.Time: the source posted

--- a/internal/moderation/repository.go
+++ b/internal/moderation/repository.go
@@ -61,6 +61,7 @@ func (r *QueriesRepository) Create(ctx context.Context, f job.Fields, actorID in
 		Skills:      f.Skills,
 		Seniority:   f.Seniority,
 		Category:    f.Category,
+		IsTech:      pgconv.Bool(f.IsTech),
 
 		PostingLanguage:    f.PostingLanguage,
 		EmploymentType:     f.EmploymentType,
@@ -124,6 +125,7 @@ func (r *QueriesRepository) Update(ctx context.Context, slug string, f job.Field
 		Skills:      f.Skills,
 		Seniority:   f.Seniority,
 		Category:    f.Category,
+		IsTech:      pgconv.Bool(f.IsTech),
 
 		PostingLanguage:    f.PostingLanguage,
 		EmploymentType:     f.EmploymentType,

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -39,3 +39,13 @@ func Int4(n *int) pgtype.Int4 {
 	}
 	return pgtype.Int4{Int32: int32(*n), Valid: true}
 }
+
+// Bool maps an optional bool to the pgtype the generated params expect: nil becomes
+// the zero (NULL) value, a non-nil pointer a valid bool. It is the write-side
+// adapter for a tri-state (true/false/NULL) column such as jobs.is_tech.
+func Bool(b *bool) pgtype.Bool {
+	if b == nil {
+		return pgtype.Bool{}
+	}
+	return pgtype.Bool{Bool: *b, Valid: true}
+}

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -631,6 +631,9 @@ func facetSettings() *meilisearch.Settings {
 			"id",
 			"source", "company_slug",
 			"work_mode", "regions", "countries", "cities", "skills", "collections",
+			// is_tech is the served top-level tech/non-tech facet (jobview), filtered on
+			// the bare attribute; an unknown value is absent so it filters as empty.
+			"is_tech",
 			// roles is derived at index time (roletag) and served top-level like the
 			// other bare facets, so it filters on the plain attribute, not a dot path.
 			"roles",

--- a/internal/search/facets_integration_test.go
+++ b/internal/search/facets_integration_test.go
@@ -118,3 +118,63 @@ func TestIntegration_FacetCounts(t *testing.T) {
 		}
 	})
 }
+
+// TestIntegration_IsTechFilter locks the is_tech facet spec scenarios against a real
+// Meilisearch: the distribution reports the tech/non_tech buckets (an unknown/NULL
+// is_tech job is absent, since jobview omits it), and filtering to tech excludes both
+// the non_tech and the unknown jobs. The is_tech column is set on the fixtures the way
+// UpsertJob persists it (the derivation itself is unit-tested); this covers the
+// index/filter round-trip the config-level unit tests cannot.
+func TestIntegration_IsTechFilter(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+	if err := c.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+
+	yes := pgtype.Bool{Bool: true, Valid: true}
+	no := pgtype.Bool{Bool: false, Valid: true}
+	unknown := pgtype.Bool{} // NULL — jobview omits the facet
+	jobs := []db.Job{
+		{ID: 1, Title: "Senior Go Engineer", Company: "Acme", PublicSlug: "a", Category: "backend", IsTech: yes},
+		{ID: 2, Title: "Warehouse Cleaner", Company: "Beta", PublicSlug: "b", IsTech: no},
+		{ID: 3, Title: "Yard Coordinator", Company: "Gamma", PublicSlug: "c", IsTech: unknown},
+	}
+	docs := make([]JobDocument, 0, len(jobs))
+	for _, j := range jobs {
+		d, err := FromJob(j)
+		if err != nil {
+			t.Fatalf("FromJob: %v", err)
+		}
+		docs = append(docs, d)
+	}
+	if err := c.IndexJobs(ctx, docs); err != nil {
+		t.Fatalf("IndexJobs: %v", err)
+	}
+
+	t.Run("distribution reports tech and non_tech, unknown absent", func(t *testing.T) {
+		res, err := c.FacetCounts(ctx, FacetParams{Facets: []string{"is_tech"}})
+		if err != nil {
+			t.Fatalf("FacetCounts: %v", err)
+		}
+		if res.Facets["is_tech"]["tech"] != 1 || res.Facets["is_tech"]["non_tech"] != 1 {
+			t.Errorf("is_tech dist = %v, want tech:1 non_tech:1", res.Facets["is_tech"])
+		}
+		if len(res.Facets["is_tech"]) != 2 {
+			t.Errorf("is_tech dist should have no unknown bucket, got %v", res.Facets["is_tech"])
+		}
+	})
+
+	t.Run("filter to tech excludes non_tech and unknown", func(t *testing.T) {
+		res, err := c.FacetCounts(ctx, FacetParams{
+			Facets: []string{"is_tech"},
+			Filter: Filter([]string{Eq("is_tech", "tech")}),
+		})
+		if err != nil {
+			t.Fatalf("FacetCounts: %v", err)
+		}
+		if res.Total != 1 {
+			t.Errorf("filtered Total = %d, want 1 (only the tech job)", res.Total)
+		}
+	})
+}

--- a/internal/search/query_filter.go
+++ b/internal/search/query_filter.go
@@ -30,6 +30,7 @@ var StringFacets = map[string]string{
 	"salary_currency":  "enrichment.salary_currency",
 	"salary_period":    "enrichment.salary_period",
 	"skills":           "skills",
+	"is_tech":          "is_tech",
 	"role":             "roles",
 	"reality":          "reality.class",
 	"collections":      "collections",

--- a/internal/search/settings_test.go
+++ b/internal/search/settings_test.go
@@ -48,6 +48,18 @@ func TestRolesIsFilterable(t *testing.T) {
 	}
 }
 
+func TestIsTechIsFilterableFacet(t *testing.T) {
+	// is_tech is served top-level (jobview) and filtered on the bare attribute, so it
+	// must be declared filterable for `is_tech=` to take effect and its facet counts.
+	s := facetSettings()
+	if !contains(s.FilterableAttributes, "is_tech") {
+		t.Errorf("is_tech must be filterable for the tech/non-tech facet, got %v", s.FilterableAttributes)
+	}
+	if StringFacets["is_tech"] != "is_tech" {
+		t.Errorf("StringFacets[is_tech] = %q, want the bare attribute \"is_tech\"", StringFacets["is_tech"])
+	}
+}
+
 func TestIDIsFilterable(t *testing.T) {
 	// The swipe deck excludes the caller's already-judged jobs via an
 	// `id NOT IN [...]` filter, which requires id to be a filterable attribute.

--- a/migrations/0017_jobs_is_tech.sql
+++ b/migrations/0017_jobs_is_tech.sql
@@ -1,0 +1,7 @@
+-- is_tech is the tri-state deterministic technical/non-technical signal derived
+-- from a job's title and category (internal/jobderive): TRUE for a recognized
+-- technical category, FALSE for a known non-technical category or a confident
+-- non-tech title, and NULL when neither resolves (unknown). Nullable on purpose —
+-- NULL is the honest "unclassified" state, kept measurable rather than coerced.
+-- Backfill existing rows with cmd/backfill-derive, then reindex.
+ALTER TABLE jobs ADD COLUMN is_tech boolean;

--- a/openspec/changes/add-is-tech-facet/.openspec.yaml
+++ b/openspec/changes/add-is-tech-facet/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/add-is-tech-facet/design.md
+++ b/openspec/changes/add-is-tech-facet/design.md
@@ -1,0 +1,53 @@
+## Context
+
+freehire derives deterministic facets (geography, skills, seniority, category) from a job's title/description via curated whole-word dictionaries (`internal/classify`, `internal/location`, `internal/skilltag`) at ingest, persisted on `jobs.*` columns, served through `jobview`, and indexed as Meilisearch facets. `category` already distinguishes 4 confidently non-tech buckets (marketing/sales/support/management) — the `enrich.NonTechCategories` blacklist that gates AI enrichment. But generic ATS boards flood the catalogue with non-tech roles the title dictionary cannot place: on prod, 69% of ~3.07M open jobs have an empty `category`, a mix where ≥0.5M titles match obvious non-tech nouns. This change adds a confident non-tech title detector and a tri-state `is_tech` signal, exposed as a filterable facet.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Deterministically flag confidently non-tech titles beyond the 4 blacklist categories, never guessing.
+- Derive a tri-state `is_tech` (`true`/`false`/unknown) that stays honest about coverage.
+- Expose `is_tech` as a search facet with a Tech / Non-tech filter in the web UI.
+- Persist `is_tech` on the job row so the split is measurable with plain SQL on prod.
+
+**Non-Goals:**
+- Excluding non-tech from the catalogue or search index (a later decision, made on the measured split).
+- Gating `cmd/enrich` / `cmd/embed` on `is_tech` (the existing category blacklist still gates them).
+- Description-based non-tech detection (title-only first; add prose later only if the numbers demand it).
+- Any change to the `category` vocabulary or its facet — `is_tech` is a separate, additive signal.
+
+## Decisions
+
+**1. A separate non-tech detector, not new `category` values.**
+Add `classify.IsNonTech(title) bool` backed by a new `nonTechTable` of confident non-tech role nouns (whole-word via `wordmatch.UnicodeBoundary`, EN first). Rationale: keeping it out of `enrich.CategoryValues` avoids touching the enrichment contract, the `jobview` category override, and the generated contracts, and it decouples "is this technical?" from "which technical role?". Alternative considered — a single `non_tech` catch-all category or granular non-tech categories (healthcare/hospitality/…) — rejected for now: both widen the contract and the `category` facet for a question a boolean answers.
+
+**2. Tri-state `is_tech` (`*bool`), tech-wins precedence.**
+In `jobderive.Derive`: `true` if the derived category is a recognized technical category; else `false` if the category ∈ `NonTechCategories` OR `classify.IsNonTech(title)`; else `nil`. Rationale: technical evidence (the title dictionary) is checked first and always wins, so a non-tech noun never overrides a real tech role ("Sales Engineer" already resolves a tech category). `nil` for unknown is deliberate — coercing unknown to `true` (the current enrichment-gate blacklist logic) would hide exactly the mass we want to measure and shrink. Alternative — strict boolean, unknown→true — rejected: it makes the 69% invisible.
+
+Which categories count as "technical" = `CategoryValues` minus `NonTechCategories` minus `other`. Expose this partition as `enrich.TechCategories` (or a helper) so the derivation reads from one source of truth, guarded by a test that the three sets partition `CategoryValues`.
+
+**3. DB boolean nullable; wire + facet as a string enum.**
+`jobs.is_tech boolean` (nullable) — natural for SQL measurement (`is_tech IS TRUE/FALSE/NULL`). `jobview` maps the `*bool` to a string enum `is_tech: "tech" | "non_tech"` (omitted when unknown), because the whole facet stack (Meili facetDistribution, `search/facets.go`, `query_filter`, the FilterModal) is string-value oriented and `roles`/`work_mode` set the precedent for an index-time string facet with `IS EMPTY` for the absent bucket. Meili boolean faceting is avoided as less predictable than string faceting.
+
+**4. Persisted + backfilled like the other dict facets.**
+`is_tech` flows through `job.New` → `UpsertJob` (new column in the upsert) and is re-derived by `cmd/backfill-derive` (which already re-derives every dict facet in one pass). No new worker.
+
+## Risks / Trade-offs
+
+- **False-positive: a tech job flagged non-tech** → Mitigated by tech-wins precedence (title dictionary checked first) and by curating `nonTechTable` with unambiguous role nouns only (no bare "engineer"/"technician"/"analyst"); bias is to under-detect (leave in unknown) rather than mislabel. A unit test locks representative tech titles to `is_tech != false`.
+- **New filterable attribute 500s until reindex** → Meili rejects a filter on an attribute not yet in the index settings. Mitigated by the standard order: deploy the new binary, run `make reindex` (rebuilds settings + docs) before the UI filter is used. Documented in the migration plan.
+- **Unknown bucket still large after title-only detection** → Accepted: this change is measurement-first. The `nil` state quantifies the remaining gap; description-based detection is the noted next slice.
+- **Backfill + reindex cost at 3M jobs** → Same cost profile as any dict-facet change; run backfill-derive then reindex off-peak (per the reindex freeze / cron-stacking notes).
+
+## Migration Plan
+
+1. Apply migration `jobs.is_tech boolean` to prod manually **before** deploy (per the migrations gotcha — initdb does not re-run).
+2. Deploy the new binary (ingest now persists `is_tech`; search settings include the new filterable attribute).
+3. Run `cmd/backfill-derive` to populate `is_tech` on existing jobs, then `make reindex` so the facet/filter is live (reindex must follow backfill and precede UI use of the filter).
+4. Measure: `SELECT is_tech, count(*) FROM jobs WHERE closed_at IS NULL GROUP BY 1` — decide facet-only vs catalogue exclusion on the real split.
+
+Rollback: the column and detector are additive; reverting the binary leaves `is_tech` unread. No data migration to undo.
+
+## Open Questions
+
+- None blocking. The choice between facet-only and catalogue exclusion is intentionally deferred to post-measurement, not part of this change.

--- a/openspec/changes/add-is-tech-facet/proposal.md
+++ b/openspec/changes/add-is-tech-facet/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+freehire is an IT job aggregator, but generic ATS boards (Oracle, Workday, UKG, iCIMS…) pour a company's entire job board into the catalogue — nurses, cleaners, warehouse, retail, hospitality. On prod, of ~3.07M open jobs only 9.5% carry a recognized tech category, 21.5% are confidently non-tech (the 4-category blacklist), and **69% have an empty category** — a mix where at least ~0.5M titles match obvious non-tech nouns. There is no way for a user (or the pipeline) to tell tech from non-tech across that empty mass, and the current `category` facet cannot express it.
+
+## What Changes
+
+- Add a deterministic, confident **non-tech title detector** (`classify.IsNonTech`) — a curated whole-word dictionary of unambiguous non-tech role nouns (registered nurse, forklift operator, warehouse, cashier, housekeeping, electrician, teacher…), same "never guess" doctrine as the existing `classify`/`location`/`skilltag` dictionaries.
+- Derive a **tri-state `is_tech` signal** (`*bool`: `true` recognized-tech / `false` confident-non-tech / `nil` unknown) in `jobderive`, tech-category-wins precedence, persisted on `jobs.is_tech` and re-derived by `cmd/backfill-derive`.
+- Expose `is_tech` as a **search facet with a filter**: a Meilisearch filterable attribute (`nil` → absent, filterable via IS EMPTY), facet counts on the jobs search, a `jobview` field, and a Tech / Non-tech control in the web FilterModal.
+
+Out of scope (deliberate, later slices): catalog/index exclusion of non-tech, gating enrich/embed on `is_tech`, description-based non-tech detection.
+
+## Capabilities
+
+### New Capabilities
+- `tech-classification`: deterministic non-tech title detection, the tri-state `is_tech` derivation and persistence, and its exposure as a filterable search facet.
+
+### Modified Capabilities
+<!-- none: is_tech is additive; existing category/facet requirements are unchanged -->
+
+## Impact
+
+- **Code:** `internal/classify` (new non-tech dictionary + `IsNonTech`), `internal/jobderive` (derive `IsTech`), `internal/job` (aggregate field), `internal/jobview` (served field), `internal/search` (filterable attribute + facet + `FromJob` doc), `web/src/lib/facets.ts` + labels (FilterModal control), generated contracts.
+- **DB:** new migration `jobs.is_tech boolean` (nullable); `UpsertJob` + backfill-derive queries (`make sqlc`). Apply migration to prod manually before deploy (per the migrations gotcha).
+- **Ops:** after deploy, run `cmd/backfill-derive` + `make reindex` to reach existing jobs; then measure the `true/false/null` split on prod.

--- a/openspec/changes/add-is-tech-facet/specs/tech-classification/spec.md
+++ b/openspec/changes/add-is-tech-facet/specs/tech-classification/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Deterministic non-tech title detection
+
+The system SHALL provide a deterministic, curated dictionary that identifies confidently non-technical job titles by whole-word match, and MUST NOT guess: a title it cannot confidently place as non-tech yields no signal. The dictionary MUST only match unambiguous non-tech role nouns (e.g. registered nurse, forklift operator, warehouse associate, cashier, housekeeping, electrician, teacher) and MUST NOT contain generic terms that also occur in technical roles (e.g. bare "engineer", "technician", "analyst").
+
+#### Scenario: Confident non-tech title is detected
+- **WHEN** a title contains a curated non-tech role noun as a whole word (e.g. "Registered Nurse (RBT)")
+- **THEN** the detector reports the title as non-tech
+
+#### Scenario: Technical title is not flagged
+- **WHEN** a title states a technical role (e.g. "Software Engineer II, AWS DynamoDB")
+- **THEN** the detector reports no non-tech signal
+
+#### Scenario: Ambiguous substring does not match
+- **WHEN** a non-tech term appears only as a substring of another word (e.g. "warehouse" inside a longer token) or the title carries a shared term like "engineer"
+- **THEN** the detector does not flag the title, matching only on word boundaries
+
+### Requirement: Tri-state is_tech derivation
+
+The system SHALL derive a tri-state `is_tech` signal for every job during facet derivation, from the title and the derived category, with technical evidence taking precedence over non-technical evidence. The value MUST be `true` when the derived category is a recognized technical category, `false` when the derived category is a known non-technical category OR the non-tech detector flags the title, and otherwise unknown (absent). An unknown value MUST NOT be coerced to `true` or `false` — the absence is the honest state used to measure remaining coverage.
+
+#### Scenario: Recognized tech category yields true
+- **WHEN** the title resolves to a technical category (e.g. `backend`)
+- **THEN** `is_tech` is `true`
+
+#### Scenario: Blacklist non-tech category yields false
+- **WHEN** the derived category is one of the non-technical categories (marketing, sales, support, management)
+- **THEN** `is_tech` is `false`
+
+#### Scenario: Detector-only non-tech yields false
+- **WHEN** the derived category is empty but the non-tech detector flags the title (e.g. "Warehouse Cleaner")
+- **THEN** `is_tech` is `false`
+
+#### Scenario: Unresolved job stays unknown
+- **WHEN** neither a technical nor a non-technical category resolves and the detector is silent
+- **THEN** `is_tech` is unknown (absent), not `true` and not `false`
+
+### Requirement: is_tech persistence and backfill
+
+The system SHALL persist the derived `is_tech` on the job row through the same write path as the other deterministic facets, and MUST re-derive it for existing jobs via the backfill-derive maintenance pass. A job written or re-crawled MUST carry the `is_tech` value its title and category currently derive.
+
+#### Scenario: Ingest persists is_tech
+- **WHEN** a job is upserted through the ingest write path
+- **THEN** its `is_tech` column reflects the value derived from its title and category
+
+#### Scenario: Backfill re-derives is_tech
+- **WHEN** the backfill-derive pass runs over existing jobs
+- **THEN** every processed job's `is_tech` is recomputed from its current title and category
+
+### Requirement: is_tech search facet with filter
+
+The system SHALL expose `is_tech` as a filterable search facet: the served job wire shape MUST include the value, the search index MUST make it filterable (an unknown value indexed as absent so it is filterable as empty), the search API MUST report its facet distribution, and the web filter UI MUST offer a Tech / Non-tech control that filters the results.
+
+#### Scenario: Facet distribution is reported
+- **WHEN** the jobs search is queried with faceting on `is_tech`
+- **THEN** the response reports counts for the tech and non-tech buckets
+
+#### Scenario: Filtering to tech excludes non-tech
+- **WHEN** a search filters `is_tech` to tech
+- **THEN** only jobs with `is_tech` true are returned, and non-tech and unknown jobs are excluded
+
+#### Scenario: Served job carries is_tech
+- **WHEN** a job is returned by any list, detail, company, or search response
+- **THEN** its wire shape includes the `is_tech` value (or null when unknown)

--- a/openspec/changes/add-is-tech-facet/tasks.md
+++ b/openspec/changes/add-is-tech-facet/tasks.md
@@ -15,24 +15,24 @@
 
 ## 4. Persistence (DB + aggregate)
 
-- [ ] 4.1 Migration: add nullable `jobs.is_tech boolean`
-- [ ] 4.2 Thread `IsTech` through the `internal/job` aggregate (field + `job.New` + `job.FromRow`)
-- [ ] 4.3 Update `UpsertJob` and the backfill-derive update query in `internal/db/queries/*.sql`; run `make sqlc`
-- [ ] 4.4 Verify `cmd/backfill-derive` writes `is_tech` (it re-derives via jobderive); DB integration/handler test as applicable
+- [x] 4.1 Migration: add nullable `jobs.is_tech boolean`
+- [x] 4.2 Thread `IsTech` through the `internal/job` aggregate (field + `job.New` + `job.FromRow`)
+- [x] 4.3 Update `UpsertJob` and the backfill-derive update query in `internal/db/queries/*.sql`; run `make sqlc`
+- [x] 4.4 Verify `cmd/backfill-derive` writes `is_tech` (it re-derives via jobderive); DB integration/handler test as applicable
 
 ## 5. Served wire shape
 
-- [ ] 5.1 Add `is_tech` string-enum field to `jobview` (`"tech"`/`"non_tech"`, omitted when unknown), mapped from the aggregate `*bool`
-- [ ] 5.2 Unit test `jobview.FromDomain` for the three states
+- [x] 5.1 Add `is_tech` string-enum field to `jobview` (`"tech"`/`"non_tech"`, omitted when unknown), mapped from the aggregate `*bool`
+- [x] 5.2 Unit test `jobview.FromDomain` for the three states
 
 ## 6. Search facet + filter
 
-- [ ] 6.1 Include `is_tech` in the search document (top-level string facet, like `roles`) and add it to `facetSettings` FilterableAttributes
-- [ ] 6.2 Wire `is_tech` into `internal/search` facet request + `query_filter` mapping; test filter (tech excludes non_tech + unknown) and facet distribution
-- [ ] 6.3 Add the Tech / Non-tech control to `web/src/lib/facets.ts` + labels (FilterModal), values `tech`/`non_tech`
+- [x] 6.1 Include `is_tech` in the search document (top-level string facet, like `roles`) and add it to `facetSettings` FilterableAttributes
+- [x] 6.2 Wire `is_tech` into `internal/search` facet request + `query_filter` mapping; test filter (tech excludes non_tech + unknown) and facet distribution
+- [x] 6.3 Add the Tech / Non-tech control to `web/src/lib/facets.ts` + labels (FilterModal), values `tech`/`non_tech`
 
 ## 7. Contracts + verification
 
-- [ ] 7.1 Regenerate TS contracts (`cmd/gen-contracts`) so the `is_tech` field reaches the frontend types
-- [ ] 7.2 `go build ./... && go vet ./... && go test ./...`; web `svelte-check` for touched files
-- [ ] 7.3 Confirm end-to-end locally: ingest a job → `is_tech` persisted → served in jobview → filterable in search (reindex first)
+- [x] 7.1 Regenerate TS contracts (`cmd/gen-contracts`) so the `is_tech` field reaches the frontend types
+- [x] 7.2 `go build ./... && go vet ./... && go test ./...`; web `svelte-check` for touched files
+- [x] 7.3 Confirm end-to-end locally: ingest a job → `is_tech` persisted → served in jobview → filterable in search (reindex first)

--- a/openspec/changes/add-is-tech-facet/tasks.md
+++ b/openspec/changes/add-is-tech-facet/tasks.md
@@ -1,0 +1,38 @@
+## 1. Non-tech title detector
+
+- [ ] 1.1 Add `nonTechTable` (confident non-tech role nouns, EN, whole-word) to `internal/classify/dictionaries.go`
+- [ ] 1.2 Add `classify.IsNonTech(title string) bool` with unit tests: confident non-tech → true, tech titles → false, substring/word-boundary and shared-term ("engineer") negatives
+
+## 2. Tech-category partition
+
+- [ ] 2.1 Add `enrich.TechCategories` (CategoryValues minus NonTechCategories minus `other`) as the single source of truth for "recognized technical category"
+- [ ] 2.2 Test that TechCategories / NonTechCategories / {`other`} partition `CategoryValues` (no overlap, full cover)
+
+## 3. is_tech derivation
+
+- [ ] 3.1 Add `IsTech *bool` to the `jobderive.Derived` result
+- [ ] 3.2 Derive it in `jobderive.Derive`: tech category → true; category ∈ NonTechCategories OR `IsNonTech(title)` → false; else nil. Unit tests for all four states, tech-wins precedence
+
+## 4. Persistence (DB + aggregate)
+
+- [ ] 4.1 Migration: add nullable `jobs.is_tech boolean`
+- [ ] 4.2 Thread `IsTech` through the `internal/job` aggregate (field + `job.New` + `job.FromRow`)
+- [ ] 4.3 Update `UpsertJob` and the backfill-derive update query in `internal/db/queries/*.sql`; run `make sqlc`
+- [ ] 4.4 Verify `cmd/backfill-derive` writes `is_tech` (it re-derives via jobderive); DB integration/handler test as applicable
+
+## 5. Served wire shape
+
+- [ ] 5.1 Add `is_tech` string-enum field to `jobview` (`"tech"`/`"non_tech"`, omitted when unknown), mapped from the aggregate `*bool`
+- [ ] 5.2 Unit test `jobview.FromDomain` for the three states
+
+## 6. Search facet + filter
+
+- [ ] 6.1 Include `is_tech` in the search document (top-level string facet, like `roles`) and add it to `facetSettings` FilterableAttributes
+- [ ] 6.2 Wire `is_tech` into `internal/search` facet request + `query_filter` mapping; test filter (tech excludes non_tech + unknown) and facet distribution
+- [ ] 6.3 Add the Tech / Non-tech control to `web/src/lib/facets.ts` + labels (FilterModal), values `tech`/`non_tech`
+
+## 7. Contracts + verification
+
+- [ ] 7.1 Regenerate TS contracts (`cmd/gen-contracts`) so the `is_tech` field reaches the frontend types
+- [ ] 7.2 `go build ./... && go vet ./... && go test ./...`; web `svelte-check` for touched files
+- [ ] 7.3 Confirm end-to-end locally: ingest a job → `is_tech` persisted → served in jobview → filterable in search (reindex first)

--- a/openspec/changes/add-is-tech-facet/tasks.md
+++ b/openspec/changes/add-is-tech-facet/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Non-tech title detector
 
-- [ ] 1.1 Add `nonTechTable` (confident non-tech role nouns, EN, whole-word) to `internal/classify/dictionaries.go`
-- [ ] 1.2 Add `classify.IsNonTech(title string) bool` with unit tests: confident non-tech → true, tech titles → false, substring/word-boundary and shared-term ("engineer") negatives
+- [x] 1.1 Add `nonTechTable` (confident non-tech role nouns, EN, whole-word) to `internal/classify/dictionaries.go`
+- [x] 1.2 Add `classify.IsNonTech(title string) bool` with unit tests: confident non-tech → true, tech titles → false, substring/word-boundary and shared-term ("engineer") negatives
 
 ## 2. Tech-category partition
 
-- [ ] 2.1 Add `enrich.TechCategories` (CategoryValues minus NonTechCategories minus `other`) as the single source of truth for "recognized technical category"
-- [ ] 2.2 Test that TechCategories / NonTechCategories / {`other`} partition `CategoryValues` (no overlap, full cover)
+- [x] 2.1 Add `enrich.TechCategories` (CategoryValues minus NonTechCategories minus `other`) as the single source of truth for "recognized technical category"
+- [x] 2.2 Test that TechCategories / NonTechCategories / {`other`} partition `CategoryValues` (no overlap, full cover)
 
 ## 3. is_tech derivation
 
-- [ ] 3.1 Add `IsTech *bool` to the `jobderive.Derived` result
-- [ ] 3.2 Derive it in `jobderive.Derive`: tech category → true; category ∈ NonTechCategories OR `IsNonTech(title)` → false; else nil. Unit tests for all four states, tech-wins precedence
+- [x] 3.1 Add `IsTech *bool` to the `jobderive.Derived` result
+- [x] 3.2 Derive it in `jobderive.Derive`: tech category → true; category ∈ NonTechCategories OR `IsNonTech(title)` → false; else nil. Unit tests for all four states, tech-wins precedence
 
 ## 4. Persistence (DB + aggregate)
 

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -355,6 +355,15 @@ const REALITY: FacetOption[] = [
   { value: 'likely-evergreen', label: 'Likely evergreen' },
 ];
 
+// Tech vs non-tech: the deterministic is_tech facet (internal/jobderive), a small
+// closed set spelled out like REALITY. Unknown jobs carry no value (absent) and are
+// matched by neither bucket. Offered excludable so the common use is "exclude
+// Non-tech" to hide the non-engineering roles generic ATS boards pull in.
+const IS_TECH: FacetOption[] = [
+  { value: 'tech', label: 'Tech' },
+  { value: 'non_tech', label: 'Non-tech' },
+];
+
 const CURRENCY: FacetOption[] = [
   { value: 'USD', label: 'USD' },
   { value: 'EUR', label: 'EUR' },
@@ -442,6 +451,7 @@ export const FACETS: FacetDef[] = [
   { param: 'collections', label: 'Collection', control: 'pills', options: COLLECTION, excludable: false },
   { param: 'regions', label: 'Region', control: 'pills', options: JOB_REGION, excludable: true },
   { param: 'work_mode', label: 'Work format', control: 'pills', options: WORK_MODE, excludable: true },
+  { param: 'is_tech', label: 'Tech / Non-tech', control: 'pills', options: IS_TECH, excludable: true },
   { param: 'role', label: 'Role', control: 'select', dynamic: true, excludable: true, hasAndOr: true, placeholder: 'Search roles', cap: 8, related: ROLE_RELATED, searchAliases: ROLE_ALIASES },
   { param: 'category', label: 'Specialization', control: 'select', options: CATEGORY, excludable: true, placeholder: 'Search specializations' },
   { param: 'seniority', label: 'Seniority', control: 'pills', options: SENIORITY, excludable: true },

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -120,6 +120,13 @@ export interface Job {
    * column; an untagged job serializes it as [].
    */
   collections: string[];
+  /**
+   * IsTech is the deterministic technical/non-technical facet: "tech" or "non_tech",
+   * omitted when unknown (the tri-state jobs.is_tech NULL). Served top-level and
+   * indexed as a filterable Meili facet; an unknown value is absent so it filters as
+   * empty. Derived from title + category (jobderive), never from the LLM.
+   */
+  is_tech?: string;
   posted_at?: string;
   created_at?: string;
   updated_at?: string;
@@ -473,7 +480,7 @@ export interface Education {
   year?: string;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'icims', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobstash', 'jobtech', 'join', 'justjoin', 'lever', 'loxo', 'luxoft', 'mindsight', 'mycareersfuture', 'oracle', 'paycom', 'paylocity', 'personio', 'phenom', 'pinpoint', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'ukg', 'vention', 'vouch', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'icims', 'infojobs', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobstash', 'jobtech', 'jobvite', 'join', 'justjoin', 'lever', 'loxo', 'luxoft', 'mindsight', 'mycareersfuture', 'neogov', 'oracle', 'pageup', 'paycom', 'paylocity', 'personio', 'phenom', 'pinpoint', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'successfactors', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'ukg', 'vagas', 'vention', 'vouch', 'wantedkr', 'weworkremotely', 'workable', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];

--- a/web/src/posts/2026-07-13-filter-tech-non-tech.svx
+++ b/web/src/posts/2026-07-13-filter-tech-non-tech.svx
@@ -1,0 +1,23 @@
+---
+title: Filter out non-tech jobs
+date: 2026-07-13
+summary: A new Tech / Non-tech filter hides the nursing, retail, and warehouse roles that big company job boards drag in.
+type: changelog
+tags:
+  - search
+  - filters
+draft: false
+---
+
+We pull jobs straight from company career systems, and the big ones (Oracle, Workday,
+UKG and friends) hand us a company's *entire* board — not just engineering. That means
+nurses, cashiers, warehouse and hospitality roles land in the catalogue next to the
+software jobs.
+
+There's now a **Tech / Non-tech** filter in the job filters. Pick "Tech" to keep only the
+engineering-and-adjacent roles, or exclude "Non-tech" to hide the rest. The classification
+is deterministic — read off the job title, never guessed — so it errs toward leaving a role
+in rather than wrongly hiding a real tech job.
+
+Try it on [search](/jobs). Jobs we can't confidently place either way stay visible under
+both — we'd rather show a maybe than hide something you were looking for.


### PR DESCRIPTION
## Summary

Adds a deterministic **tech vs non-tech** signal and exposes it as a filterable search facet. Motivated by prod data: of ~3.07M open jobs only **9.5%** carry a recognized tech category, **21.5%** are confidently non-tech (the 4-category blacklist), and **69% have an empty category** — a mix into which generic ATS boards (Oracle/Workday/UKG/iCIMS) pour non-engineering roles (nurses, cleaners, warehouse, hospitality). At least ~0.5M of the empty bucket match obvious non-tech title nouns.

- **`classify.IsNonTech(title)`** — a curated, whole-word non-tech title dictionary (healthcare, trades, hospitality, retail, education, facilities…), same "never guess" doctrine as the other dictionaries. Deliberately omits terms that collide with tech ("chef" = Progress Chef, bare "driver" = device driver, "warehouse" = data warehouse).
- **`enrich.TechCategories`** — the CategoryValues ∖ NonTechCategories ∖ `other` partition, single source of truth, guarded by a partition test.
- **Tri-state `is_tech`** (`*bool`: true / false / nil-unknown) derived in `jobderive`, tech-category-wins precedence. `nil` for unknown is intentional — it keeps the unclassified mass measurable rather than coercing it.
- **Persistence**: `jobs.is_tech boolean` (migration `0017`), threaded through the job aggregate and **all four facet write paths** (ingest upsert, moderator create/edit, backfill-derive).
- **Facet + filter**: served as a top-level string enum (`"tech"`/`"non_tech"`, omitted when unknown → `IS EMPTY`), added to Meilisearch filterable attributes + facet distribution, and a **Tech / Non-tech** control in the web FilterModal. TS contracts regenerated.

Out of scope (deliberate, later slices): catalogue/index exclusion of non-tech, gating enrich/embed on `is_tech`, description-based detection — decided post-measurement.

OpenSpec change: `add-is-tech-facet` (proposal/design/specs/tasks).

## Test Plan

- [x] `go build ./... && go vet ./... && go test ./...` (73 packages green)
- [x] Unit: `IsNonTech` (incl. tech-collision negatives), `TechCategories` partition, tri-state derivation, aggregate roundtrip, jobview 3-state mapping, filterable-config lock
- [x] Integration (real PG, testcontainers): `is_tech` persist + roundtrip through UpsertJob
- [x] Integration (real Meilisearch): facet distribution reports tech/non_tech (unknown absent), filter to tech excludes non_tech + unknown
- [x] `svelte-check` — 0 errors on the touched frontend

## Deploy (ordered, per migration plan)

1. Apply `migrations/0017_jobs_is_tech.sql` to prod **before** deploy (initdb does not re-run).
2. Deploy the new binary.
3. `cmd/backfill-derive` to populate existing rows, then `make reindex` so the facet/filter is live (reindex must precede UI use — new filterable attribute 500s until indexed).
4. Measure: `SELECT is_tech, count(*) FROM jobs WHERE closed_at IS NULL GROUP BY 1` → decide facet-only vs catalogue exclusion.