### PR TITLE
feat(web): make the header location filter cross-cutting (jobs/companies/launcher)

### DIFF
--- a/openspec/changes/header-filter-cross-cutting/.openspec.yaml
+++ b/openspec/changes/header-filter-cross-cutting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/header-filter-cross-cutting/design.md
+++ b/openspec/changes/header-filter-cross-cutting/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`HeaderLocationFilter` (shipped in `header-location-workmode-filter`) renders a
+trigger + popover driven by a page's `FacetStore`, gated behind the optional
+`ListSearchTarget.filterScope`. It is currently jobs-only. Companies already carry
+`regions`/`remote_regions` facets on `CompanyFilterStore` (which also satisfies
+`FacetStore`), and listless pages render the `HeaderSearch` launcher with no store.
+
+## Goals / Non-Goals
+
+**Goals:** one menu, three context modes (jobs / companies / launcher); reuse the
+existing stores and facet counts; no text-search, backend, or extra-request change.
+
+**Non-Goals:** an ephemeral store or an "Apply" step for the launcher; company work
+format / city facets (companies don't have them); the full location accordion on the
+launcher (it appears live once you land on `/jobs`).
+
+## Decisions
+
+### One component, a `variant` discriminator
+`HeaderLocationFilter` gains `variant: 'jobs' | 'companies' | 'launcher'`. The shell
+(trigger, open/close, summary label) is shared; the body switches:
+- **jobs** — unchanged: work-format pills + `<LocationPane>`, drives the store.
+- **companies** — Region pills + Remote-hiring pills (both `REGION` options; drive
+  `store.cycle('regions'|'remote_regions', code)`), counts from the company facet
+  distribution. No work format / LocationPane.
+- **launcher** — work-format pills + Region pills; **no store**. Each pick calls
+  `goto('/jobs?<param>=<value>')` and lands on the live feed.
+
+*Alternative for launcher:* an ephemeral non-URL store + Apply button. Rejected as
+over-built — "pick jumps to the feed, refine live there" needs zero new state.
+
+### Bridge carries the variant
+`ListSearchTarget.filterScope` gains `variant: 'jobs' | 'companies'`. `JobsView`
+registers `'jobs'` (unchanged shape otherwise); `CompaniesView` registers
+`'companies'` with its store + company facet counts. The launcher is **not** a
+bridge target — `HeaderSearch` renders the trigger directly in `'launcher'` mode.
+
+### `summarizeScope` generalized over a facet spec
+`summarizeScope(store, spec?)` takes a `{ format?: string; geo: string[] }` spec
+(default = the jobs spec, so existing callers/tests are unchanged). Companies pass
+`{ geo: ['regions', 'remote_regions'] }`. A per-param labeler maps `countries`→
+`countryLabel`, `cities`→raw, everything else (`regions`/`remote_regions`)→
+`REGION_LABELS`. Launcher uses a static neutral label (no persisted selection).
+
+## Risks / Trade-offs
+
+- **Launcher single-pick navigation loses multi-select before the jump** → mitigated
+  by live refinement on `/jobs` after landing; the first pick is the entry point.
+- **Company facet counts shape** → `CompaniesView` already fetches `FacetCounts`;
+  Region/Remote-hiring pills read `counts.facets.regions`/`.remote_regions`, degrade
+  to countless pills if absent (same null-safety as jobs mode).
+
+## Migration Plan
+
+Frontend-only, no schema/API change, no migration. Ships with a normal web deploy.

--- a/openspec/changes/header-filter-cross-cutting/proposal.md
+++ b/openspec/changes/header-filter-cross-cutting/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The header Location & work-format quick-filter currently appears only on jobs-backed
+lists. Location intent is just as strong when browsing companies or landing on any
+other page, so the menu should be reachable across the app — while the text search
+stays exactly as it is.
+
+## What Changes
+
+- Make the header filter menu **cross-cutting**, with three context-aware modes:
+  - **Jobs lists** (`/`, `/companies/:slug`) — unchanged: work format + full location.
+  - **Companies list** (`/companies`) — new: **Region** + **Remote hiring**
+    (`remote_regions`) pills, live-filtering the company list. No work format /
+    cities (companies don't carry those facets).
+  - **Other pages** (job detail, `/about`, `/collections`, …) — new: the same trigger
+    on the global launcher; picking a value **navigates to `/jobs`** with that scope,
+    landing on the filtered feed where further tweaks are live.
+- The trigger summary label extends to company geo (`remote_regions`) and to the
+  empty launcher state.
+- **No change to text search, no new backend, no new facet-count request.** Company
+  and jobs modes drive their existing stores; launcher mode navigates.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `header-location-filter`: the quick-filter is no longer jobs-feed-only — it also
+  filters the companies list (region + remote-hiring) and appears on listless pages
+  as a launcher that scopes the jobs feed.
+
+## Impact
+
+- **Frontend only** (`web/`):
+  - `HeaderLocationFilter.svelte` — generalize to a `variant` (`jobs` | `companies` |
+    `launcher`) with per-mode sections; jobs mode unchanged.
+  - `listSearch.svelte.ts` — `filterScope` gains a `variant` discriminator.
+  - `CompaniesView.svelte` — register a `variant: 'companies'` filter scope.
+  - `HeaderSearch.svelte` — render the trigger in `launcher` mode (navigates to
+    `/jobs`).
+  - `headerScope.ts` (+ test) — summary handles `remote_regions` and empty launcher.
+- No backend/API/DB/search changes.

--- a/openspec/changes/header-filter-cross-cutting/specs/header-location-filter/spec.md
+++ b/openspec/changes/header-filter-cross-cutting/specs/header-location-filter/spec.md
@@ -18,8 +18,8 @@ company mode (companies do not carry those facets).
 
 ### Requirement: Launcher mode on listless pages
 
-On pages without a filterable list (job detail, `/about`, `/collections`, …), the
-header search launcher SHALL show the same filter trigger; because there is no list
+The header search launcher SHALL show the filter trigger on pages without a
+filterable list (job detail, `/about`, `/collections`, …); because there is no list
 to filter in place, selecting a value SHALL navigate to the jobs feed (`/jobs`) with
 that scope applied, where further changes filter live.
 

--- a/openspec/changes/header-filter-cross-cutting/specs/header-location-filter/spec.md
+++ b/openspec/changes/header-filter-cross-cutting/specs/header-location-filter/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Company-list filter mode
+
+On the companies list (`/companies`), the header filter menu SHALL present a
+company-appropriate scope — **Region** and **Remote hiring** pills — that
+live-filters the company list through its existing filter store's `regions` and
+`remote_regions` facets. Work format, countries, and cities SHALL NOT appear in
+company mode (companies do not carry those facets).
+
+#### Scenario: Companies list shows the company scope
+- **WHEN** a user opens the filter menu on `/companies`
+- **THEN** the popover shows Region and Remote-hiring pills and no work-format section
+
+#### Scenario: Selecting a company region filters the list
+- **WHEN** the user activates a Region or Remote-hiring pill
+- **THEN** the `regions`/`remote_regions` facet updates, the company list and its counts reload, and the choice is mirrored to the URL
+
+### Requirement: Launcher mode on listless pages
+
+On pages without a filterable list (job detail, `/about`, `/collections`, …), the
+header search launcher SHALL show the same filter trigger; because there is no list
+to filter in place, selecting a value SHALL navigate to the jobs feed (`/jobs`) with
+that scope applied, where further changes filter live.
+
+#### Scenario: Trigger present on a listless page
+- **WHEN** a user is on a page served by the global search launcher
+- **THEN** the filter trigger is shown in the header search box
+
+#### Scenario: Selecting a scope jumps to the filtered feed
+- **WHEN** the user picks a work format or region from the launcher popover
+- **THEN** the app navigates to `/jobs` with that value applied as a facet in the URL
+
+### Requirement: Trigger summary covers company and empty-launcher states
+
+The trigger's summary label SHALL reflect the active scope in every mode: company
+geography (including `remote_regions`) on the companies list, and a neutral label on
+a launcher with no selection.
+
+#### Scenario: Company remote-hiring selection summarized
+- **WHEN** a company Remote-hiring region is selected on `/companies`
+- **THEN** the trigger label reflects that region
+
+#### Scenario: Empty launcher shows the neutral label
+- **WHEN** the launcher popover has no selection
+- **THEN** the trigger shows the neutral "Location" label

--- a/openspec/changes/header-filter-cross-cutting/tasks.md
+++ b/openspec/changes/header-filter-cross-cutting/tasks.md
@@ -1,0 +1,34 @@
+## 1. Generalize the scope-summary helper
+
+- [ ] 1.1 Extend `web/src/lib/headerScope.test.ts`: keep the existing jobs cases green via the default spec, and add company-spec cases — `summarizeScope(store, COMPANIES_SCOPE)` with `remote_regions=[eu]` → `{ icon: 'globe', label: 'Europe' }`; `regions=[eu]`+`remote_regions=[uk]` → `{ icon: 'globe', label: 'Europe +1' }` (geo order regions then remote_regions); company spec ignores `work_mode` (a selected `work_mode` does not change the label/icon).
+- [ ] 1.2 Refactor `web/src/lib/headerScope.ts`: `summarizeScope(store, spec = JOBS_SCOPE)` where `spec: { format?: string; geo: string[] }`. Export `JOBS_SCOPE = { format: 'work_mode', geo: ['regions','countries','cities'] }` and `COMPANIES_SCOPE = { geo: ['regions','remote_regions'] }`. Icon from `spec.format`'s first selected work mode (else `'globe'`). Geo label per param: `countries`→`countryLabel`, `cities`→raw, else `REGION_LABELS[v] ?? v`. Same `+N` roll-up.
+- [ ] 1.3 Run `npx vitest run src/lib/headerScope.test.ts` — all pass.
+
+## 2. Bridge variant
+
+- [ ] 2.1 In `web/src/lib/listSearch.svelte.ts`, add `variant: 'jobs' | 'companies'` to the `filterScope` object type (alongside `store`/`counts`); document that it selects the popover body.
+
+## 3. Register the two list variants
+
+- [ ] 3.1 In `web/src/lib/components/JobsView.svelte`, add `variant: 'jobs'` to the `filterScope` it registers (store/counts unchanged).
+- [ ] 3.2 In `web/src/lib/components/CompaniesView.svelte`, change `setListSearchTarget(filters)` to register an adapter `{ get value(){return filters.value}, setQuery:(q)=>filters.setQuery(q), filterScope: { store: filters, counts: () => null, variant: 'companies' } }` (CompaniesView fetches no facet counts, so counts is null — pills render countless, null-safe). Leave the cleanup `setListSearchTarget(null)` as-is.
+
+## 4. Variant-aware popover
+
+- [ ] 4.1 In `web/src/lib/components/HeaderLocationFilter.svelte`, add prop `variant: 'jobs' | 'companies' | 'launcher'` (default `'jobs'`). Compute the trigger summary with `summarizeScope(store, variant === 'companies' ? COMPANIES_SCOPE : JOBS_SCOPE)`; the `jobs` body is unchanged.
+- [ ] 4.2 Add the **companies** body: a `Region` pill row (`REGION_OPTIONS` → `store.cycle('regions', v)`) and a `Remote hiring` pill row (`REGION_OPTIONS` → `store.cycle('remote_regions', v)`), each pill styled with `pillClass`/`pillTitle` and state from `store.facet(...)`. `Clear all` clears `regions` + `remote_regions`. No work-format / LocationPane in this mode.
+- [ ] 4.3 Run `npx svelte-check` — no new errors; visually verify jobs mode is unchanged and companies mode renders on `/companies`.
+
+## 5. Launcher mode (listless pages)
+
+- [ ] 5.1 Add the **launcher** body to `HeaderLocationFilter.svelte` (no store): a `Work format` pill row and a flat `Region` pill row (`REGION_OPTIONS`); each pill's `onclick` runs `goto(\`${resolve('/')}?${param}=${value}\`)` (mirroring HeaderSearch's `runFullSearch` eslint-disable pattern) and closes the popover. Trigger label is the static neutral `Location`.
+- [ ] 5.2 In `web/src/lib/components/HeaderSearch.svelte`, render `<HeaderLocationFilter variant="launcher" />` + a divider before the `<Search>` icon inside the box (so listless pages get the trigger). Text search + dropdown unchanged.
+
+## 6. Wire the variant into the list search box
+
+- [ ] 6.1 In `web/src/lib/components/HeaderListSearch.svelte`, pass `variant={target.filterScope.variant}` to `<HeaderLocationFilter>` (store/counts as today).
+
+## 7. Verify end-to-end
+
+- [ ] 7.1 Dev server: (a) jobs feed `/` unchanged (work format + location, live, URL); (b) `/companies` shows Region + Remote-hiring, selecting filters the company list + URL; (c) a job-detail page shows the launcher trigger, picking a region navigates to `/jobs?regions=…`.
+- [ ] 7.2 Run `npx vitest run`, `npx svelte-check`; changed files clean on `eslint`.

--- a/openspec/changes/header-filter-cross-cutting/tasks.md
+++ b/openspec/changes/header-filter-cross-cutting/tasks.md
@@ -17,7 +17,7 @@
 
 - [x] 4.1 In `web/src/lib/components/HeaderLocationFilter.svelte`, add prop `variant: 'jobs' | 'companies' | 'launcher'` (default `'jobs'`). Compute the trigger summary with `summarizeScope(store, variant === 'companies' ? COMPANIES_SCOPE : JOBS_SCOPE)`; the `jobs` body is unchanged.
 - [x] 4.2 Add the **companies** body: a `Region` pill row (`REGION_OPTIONS` → `store.cycle('regions', v)`) and a `Remote hiring` pill row (`REGION_OPTIONS` → `store.cycle('remote_regions', v)`), each pill styled with `pillClass`/`pillTitle` and state from `store.facet(...)`. `Clear all` clears `regions` + `remote_regions`. No work-format / LocationPane in this mode.
-- [ ] 4.3 Run `npx svelte-check` — no new errors; visually verify jobs mode is unchanged and companies mode renders on `/companies`.
+- [x] 4.3 Run `npx svelte-check` — no new errors; visually verify jobs mode is unchanged and companies mode renders on `/companies`.
 
 ## 5. Launcher mode (listless pages)
 
@@ -30,5 +30,5 @@
 
 ## 7. Verify end-to-end
 
-- [ ] 7.1 Dev server: (a) jobs feed `/` unchanged (work format + location, live, URL); (b) `/companies` shows Region + Remote-hiring, selecting filters the company list + URL; (c) a job-detail page shows the launcher trigger, picking a region navigates to `/jobs?regions=…`.
-- [ ] 7.2 Run `npx vitest run`, `npx svelte-check`; changed files clean on `eslint`.
+- [x] 7.1 Dev server: (a) jobs feed `/` unchanged (work format + location, live, URL); (b) `/companies` shows Region + Remote-hiring, selecting filters the company list + URL; (c) a job-detail page shows the launcher trigger, picking a region navigates to `/jobs?regions=…`.
+- [x] 7.2 Run `npx vitest run`, `npx svelte-check`; changed files clean on `eslint`.

--- a/openspec/changes/header-filter-cross-cutting/tasks.md
+++ b/openspec/changes/header-filter-cross-cutting/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Generalize the scope-summary helper
 
-- [ ] 1.1 Extend `web/src/lib/headerScope.test.ts`: keep the existing jobs cases green via the default spec, and add company-spec cases — `summarizeScope(store, COMPANIES_SCOPE)` with `remote_regions=[eu]` → `{ icon: 'globe', label: 'Europe' }`; `regions=[eu]`+`remote_regions=[uk]` → `{ icon: 'globe', label: 'Europe +1' }` (geo order regions then remote_regions); company spec ignores `work_mode` (a selected `work_mode` does not change the label/icon).
-- [ ] 1.2 Refactor `web/src/lib/headerScope.ts`: `summarizeScope(store, spec = JOBS_SCOPE)` where `spec: { format?: string; geo: string[] }`. Export `JOBS_SCOPE = { format: 'work_mode', geo: ['regions','countries','cities'] }` and `COMPANIES_SCOPE = { geo: ['regions','remote_regions'] }`. Icon from `spec.format`'s first selected work mode (else `'globe'`). Geo label per param: `countries`→`countryLabel`, `cities`→raw, else `REGION_LABELS[v] ?? v`. Same `+N` roll-up.
-- [ ] 1.3 Run `npx vitest run src/lib/headerScope.test.ts` — all pass.
+- [x] 1.1 Extend `web/src/lib/headerScope.test.ts`: keep the existing jobs cases green via the default spec, and add company-spec cases — `summarizeScope(store, COMPANIES_SCOPE)` with `remote_regions=[eu]` → `{ icon: 'globe', label: 'Europe' }`; `regions=[eu]`+`remote_regions=[uk]` → `{ icon: 'globe', label: 'Europe +1' }` (geo order regions then remote_regions); company spec ignores `work_mode` (a selected `work_mode` does not change the label/icon).
+- [x] 1.2 Refactor `web/src/lib/headerScope.ts`: `summarizeScope(store, spec = JOBS_SCOPE)` where `spec: { format?: string; geo: string[] }`. Export `JOBS_SCOPE = { format: 'work_mode', geo: ['regions','countries','cities'] }` and `COMPANIES_SCOPE = { geo: ['regions','remote_regions'] }`. Icon from `spec.format`'s first selected work mode (else `'globe'`). Geo label per param: `countries`→`countryLabel`, `cities`→raw, else `REGION_LABELS[v] ?? v`. Same `+N` roll-up.
+- [x] 1.3 Run `npx vitest run src/lib/headerScope.test.ts` — all pass.
 
 ## 2. Bridge variant
 
-- [ ] 2.1 In `web/src/lib/listSearch.svelte.ts`, add `variant: 'jobs' | 'companies'` to the `filterScope` object type (alongside `store`/`counts`); document that it selects the popover body.
+- [x] 2.1 In `web/src/lib/listSearch.svelte.ts`, add `variant: 'jobs' | 'companies'` to the `filterScope` object type (alongside `store`/`counts`); document that it selects the popover body.
 
 ## 3. Register the two list variants
 
-- [ ] 3.1 In `web/src/lib/components/JobsView.svelte`, add `variant: 'jobs'` to the `filterScope` it registers (store/counts unchanged).
-- [ ] 3.2 In `web/src/lib/components/CompaniesView.svelte`, change `setListSearchTarget(filters)` to register an adapter `{ get value(){return filters.value}, setQuery:(q)=>filters.setQuery(q), filterScope: { store: filters, counts: () => null, variant: 'companies' } }` (CompaniesView fetches no facet counts, so counts is null — pills render countless, null-safe). Leave the cleanup `setListSearchTarget(null)` as-is.
+- [x] 3.1 In `web/src/lib/components/JobsView.svelte`, add `variant: 'jobs'` to the `filterScope` it registers (store/counts unchanged).
+- [x] 3.2 In `web/src/lib/components/CompaniesView.svelte`, change `setListSearchTarget(filters)` to register an adapter `{ get value(){return filters.value}, setQuery:(q)=>filters.setQuery(q), filterScope: { store: filters, counts: () => null, variant: 'companies' } }` (CompaniesView fetches no facet counts, so counts is null — pills render countless, null-safe). Leave the cleanup `setListSearchTarget(null)` as-is.
 
 ## 4. Variant-aware popover
 
-- [ ] 4.1 In `web/src/lib/components/HeaderLocationFilter.svelte`, add prop `variant: 'jobs' | 'companies' | 'launcher'` (default `'jobs'`). Compute the trigger summary with `summarizeScope(store, variant === 'companies' ? COMPANIES_SCOPE : JOBS_SCOPE)`; the `jobs` body is unchanged.
-- [ ] 4.2 Add the **companies** body: a `Region` pill row (`REGION_OPTIONS` → `store.cycle('regions', v)`) and a `Remote hiring` pill row (`REGION_OPTIONS` → `store.cycle('remote_regions', v)`), each pill styled with `pillClass`/`pillTitle` and state from `store.facet(...)`. `Clear all` clears `regions` + `remote_regions`. No work-format / LocationPane in this mode.
+- [x] 4.1 In `web/src/lib/components/HeaderLocationFilter.svelte`, add prop `variant: 'jobs' | 'companies' | 'launcher'` (default `'jobs'`). Compute the trigger summary with `summarizeScope(store, variant === 'companies' ? COMPANIES_SCOPE : JOBS_SCOPE)`; the `jobs` body is unchanged.
+- [x] 4.2 Add the **companies** body: a `Region` pill row (`REGION_OPTIONS` → `store.cycle('regions', v)`) and a `Remote hiring` pill row (`REGION_OPTIONS` → `store.cycle('remote_regions', v)`), each pill styled with `pillClass`/`pillTitle` and state from `store.facet(...)`. `Clear all` clears `regions` + `remote_regions`. No work-format / LocationPane in this mode.
 - [ ] 4.3 Run `npx svelte-check` — no new errors; visually verify jobs mode is unchanged and companies mode renders on `/companies`.
 
 ## 5. Launcher mode (listless pages)
 
-- [ ] 5.1 Add the **launcher** body to `HeaderLocationFilter.svelte` (no store): a `Work format` pill row and a flat `Region` pill row (`REGION_OPTIONS`); each pill's `onclick` runs `goto(\`${resolve('/')}?${param}=${value}\`)` (mirroring HeaderSearch's `runFullSearch` eslint-disable pattern) and closes the popover. Trigger label is the static neutral `Location`.
-- [ ] 5.2 In `web/src/lib/components/HeaderSearch.svelte`, render `<HeaderLocationFilter variant="launcher" />` + a divider before the `<Search>` icon inside the box (so listless pages get the trigger). Text search + dropdown unchanged.
+- [x] 5.1 Add the **launcher** body to `HeaderLocationFilter.svelte` (no store): a `Work format` pill row and a flat `Region` pill row (`REGION_OPTIONS`); each pill's `onclick` runs `goto(\`${resolve('/')}?${param}=${value}\`)` (mirroring HeaderSearch's `runFullSearch` eslint-disable pattern) and closes the popover. Trigger label is the static neutral `Location`.
+- [x] 5.2 In `web/src/lib/components/HeaderSearch.svelte`, render `<HeaderLocationFilter variant="launcher" />` + a divider before the `<Search>` icon inside the box (so listless pages get the trigger). Text search + dropdown unchanged.
 
 ## 6. Wire the variant into the list search box
 
-- [ ] 6.1 In `web/src/lib/components/HeaderListSearch.svelte`, pass `variant={target.filterScope.variant}` to `<HeaderLocationFilter>` (store/counts as today).
+- [x] 6.1 In `web/src/lib/components/HeaderListSearch.svelte`, pass `variant={target.filterScope.variant}` to `<HeaderLocationFilter>` (store/counts as today).
 
 ## 7. Verify end-to-end
 

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -47,9 +47,18 @@
   const initialStale = browser && page.url.search !== location.search;
 
   // Register this page's store so the header search drives it (the header hosts
-  // the text field here — see HeaderListSearch).
+  // the text field here — see HeaderListSearch). The adapter also exposes a
+  // `companies` filter scope so the header's Location popover shows region +
+  // remote-hiring pills here (no facet counts are fetched on this page, so counts
+  // is null and the pills render countless).
   onMount(() => {
-    setListSearchTarget(filters);
+    setListSearchTarget({
+      get value() {
+        return filters.value;
+      },
+      setQuery: (q) => filters.setQuery(q),
+      filterScope: { store: filters, counts: () => null, variant: 'companies' },
+    });
     return () => {
       setListSearchTarget(null);
       filters.dispose();

--- a/web/src/lib/components/HeaderListSearch.svelte
+++ b/web/src/lib/components/HeaderListSearch.svelte
@@ -40,11 +40,15 @@
   <div
     class="flex h-11 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"
   >
-    <!-- Jobs-backed lists expose a filter scope: surface the Location & work-format
-         quick-filter as a scope-prefix, divided from the search icon. Absent on the
-         company list (no filterScope), so the box renders exactly as before there. -->
+    <!-- List pages expose a filter scope: surface the Location quick-filter as a
+         scope-prefix, divided from the search icon. `variant` picks the popover body
+         (jobs work-format+location vs the company region/remote-hiring pills). -->
     {#if target?.filterScope}
-      <HeaderLocationFilter store={target.filterScope.store} counts={target.filterScope.counts()} />
+      <HeaderLocationFilter
+        variant={target.filterScope.variant}
+        store={target.filterScope.store}
+        counts={target.filterScope.counts()}
+      />
       <div class="h-5 w-px shrink-0 bg-border"></div>
     {/if}
     <Search class="size-4 shrink-0 text-muted-foreground" />

--- a/web/src/lib/components/HeaderLocationFilter.svelte
+++ b/web/src/lib/components/HeaderLocationFilter.svelte
@@ -1,32 +1,59 @@
 <script lang="ts">
-  import { afterNavigate } from '$app/navigation';
+  import { afterNavigate, goto } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { ChevronDown, Globe, House, Blend, Building } from '@lucide/svelte';
-  import { WORK_MODE_OPTIONS, type FacetStore } from '$lib/facets';
+  import { WORK_MODE_OPTIONS, REGION_OPTIONS, type FacetStore, type FacetOption } from '$lib/facets';
   import type { FacetCounts } from '$lib/types';
-  import { summarizeScope } from '$lib/headerScope';
+  import { summarizeScope, JOBS_SCOPE, COMPANIES_SCOPE } from '$lib/headerScope';
   import { pillClass, pillTitle } from './facets/pill';
   import LocationPane from './filters/LocationPane.svelte';
 
-  // The header's Location & work-format quick-filter: a scope-prefix trigger inside
-  // the search box that opens a popover of work-format pills + the full LocationPane.
-  // Pure UI over the page's existing job-filter store — every control drives the same
-  // facet API the FilterModal uses (store.cycle/clearFacet), so there is no new filter
-  // logic here and selections still mirror to the URL/localStorage and reload the list.
-  let { store, counts }: { store: FacetStore; counts: FacetCounts | null } = $props();
+  // The header's cross-cutting location filter — a scope-prefix trigger inside the
+  // search box that opens a popover, in one of three modes:
+  //   • jobs      — work-format pills + the full LocationPane, live-filtering the feed
+  //   • companies — Region + Remote-hiring pills, live-filtering the company list
+  //   • launcher  — listless pages: pills navigate to the jobs feed with that scope
+  // jobs/companies drive the page's existing FacetStore (store.cycle/clearFacet), so
+  // there is no new filter logic; launcher has no store and jumps to /jobs instead.
+  let {
+    variant = 'jobs',
+    store,
+    counts = null,
+  }: {
+    variant?: 'jobs' | 'companies' | 'launcher';
+    store?: FacetStore;
+    counts?: FacetCounts | null;
+  } = $props();
 
   let open = $state(false);
   let root = $state<HTMLElement | null>(null);
 
-  const summary = $derived(summarizeScope(store));
+  // Launcher has no persisted selection, so its trigger stays the neutral label.
+  const summary = $derived(
+    store
+      ? summarizeScope(store, variant === 'companies' ? COMPANIES_SCOPE : JOBS_SCOPE)
+      : { icon: 'globe' as const, label: 'Location' },
+  );
   const ICONS = { globe: Globe, remote: House, hybrid: Blend, onsite: Building } as const;
   const TriggerIcon = $derived(ICONS[summary.icon]);
 
-  const wm = $derived(store.facet('work_mode'));
-
-  // Facets this popover owns, cleared together by "Clear all".
-  const SCOPE_PARAMS = ['work_mode', 'regions', 'countries', 'cities'] as const;
+  // Facets "Clear all" resets, per mode.
+  const CLEAR_PARAMS = {
+    jobs: ['work_mode', 'regions', 'countries', 'cities'],
+    companies: ['regions', 'remote_regions'],
+    launcher: [],
+  } as const;
   function clearAll() {
-    for (const p of SCOPE_PARAMS) store.clearFacet(p);
+    if (!store) return;
+    for (const p of CLEAR_PARAMS[variant]) store.clearFacet(p);
+  }
+
+  // Launcher pick: no list to filter in place, so land on the jobs feed with the
+  // chosen facet applied (further tweaks are live there).
+  function launch(param: string, value: string) {
+    open = false;
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- one facet appended to the resolved feed path
+    void goto(`${resolve('/')}?${param}=${encodeURIComponent(value)}`);
   }
 
   function onWindowClick(e: MouseEvent) {
@@ -38,6 +65,38 @@
 </script>
 
 <svelte:window onclick={onWindowClick} onkeydown={(e) => e.key === 'Escape' && (open = false)} />
+
+{#snippet storePills(param: string, options: FacetOption[])}
+  {@const f = store!.facet(param)}
+  <div class="flex flex-wrap gap-2">
+    {#each options as opt (opt.value)}
+      {@const inc = f.include.includes(opt.value)}
+      {@const exc = f.exclude.includes(opt.value)}
+      <button
+        type="button"
+        onclick={() => store!.cycle(param, opt.value)}
+        title={pillTitle(inc, exc, true)}
+        class={pillClass(inc || exc, exc, 'px-3 py-1.5 text-sm')}
+      >
+        {opt.label}
+      </button>
+    {/each}
+  </div>
+{/snippet}
+
+{#snippet navPills(param: string, options: FacetOption[])}
+  <div class="flex flex-wrap gap-2">
+    {#each options as opt (opt.value)}
+      <button
+        type="button"
+        onclick={() => launch(param, opt.value)}
+        class={pillClass(false, false, 'px-3 py-1.5 text-sm')}
+      >
+        {opt.label}
+      </button>
+    {/each}
+  </div>
+{/snippet}
 
 <div class="relative shrink-0" bind:this={root}>
   <button
@@ -63,37 +122,47 @@
       class="absolute left-0 top-[calc(100%+0.75rem)] z-50 max-h-[70vh] w-80 overflow-y-auto rounded-md border border-border bg-background p-4 shadow-lg"
     >
       <div class="mb-3 flex items-center justify-between">
-        <span class="text-sm font-semibold tracking-tight">Location &amp; format</span>
-        <button
-          type="button"
-          onclick={clearAll}
-          class="text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Clear all
-        </button>
+        <span class="text-sm font-semibold tracking-tight">
+          {variant === 'companies' ? 'Location' : 'Location & format'}
+        </span>
+        {#if variant !== 'launcher'}
+          <button
+            type="button"
+            onclick={clearAll}
+            class="text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Clear all
+          </button>
+        {/if}
       </div>
 
-      <div class="mb-4">
-        <div class="mb-2 text-sm font-semibold tracking-tight">Work format</div>
-        <div class="flex flex-wrap gap-2">
-          {#each WORK_MODE_OPTIONS as opt (opt.value)}
-            {@const inc = wm.include.includes(opt.value)}
-            {@const exc = wm.exclude.includes(opt.value)}
-            <button
-              type="button"
-              onclick={() => store.cycle('work_mode', opt.value)}
-              title={pillTitle(inc, exc, true)}
-              class={pillClass(inc || exc, exc, 'px-3 py-1.5 text-sm')}
-            >
-              {opt.label}
-            </button>
-          {/each}
+      {#if variant === 'jobs'}
+        <div class="mb-4">
+          <div class="mb-2 text-sm font-semibold tracking-tight">Work format</div>
+          {@render storePills('work_mode', WORK_MODE_OPTIONS)}
         </div>
-      </div>
-
-      <div class="border-t border-border pt-4">
-        <LocationPane {store} {counts} />
-      </div>
+        <div class="border-t border-border pt-4">
+          <LocationPane store={store!} {counts} />
+        </div>
+      {:else if variant === 'companies'}
+        <div class="mb-4">
+          <div class="mb-2 text-sm font-semibold tracking-tight">Region</div>
+          {@render storePills('regions', REGION_OPTIONS)}
+        </div>
+        <div>
+          <div class="mb-2 text-sm font-semibold tracking-tight">Remote hiring</div>
+          {@render storePills('remote_regions', REGION_OPTIONS)}
+        </div>
+      {:else}
+        <div class="mb-4">
+          <div class="mb-2 text-sm font-semibold tracking-tight">Work format</div>
+          {@render navPills('work_mode', WORK_MODE_OPTIONS)}
+        </div>
+        <div>
+          <div class="mb-2 text-sm font-semibold tracking-tight">Region</div>
+          {@render navPills('regions', REGION_OPTIONS)}
+        </div>
+      {/if}
     </div>
   {/if}
 </div>

--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -7,6 +7,7 @@
   import { lockScroll, unlockScroll } from '$lib/scrollLock';
   import { cn } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
+  import HeaderLocationFilter from './HeaderLocationFilter.svelte';
 
   // The global launcher: jumps straight to a job/company or hands a free-text
   // query to /jobs. TopBar renders it on every page EXCEPT the list pages
@@ -180,6 +181,10 @@
   <div
     class="flex h-11 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"
   >
+    <!-- Launcher mode: listless pages have no list to filter, so the location trigger
+         scopes the jobs feed — a pick navigates to /jobs with that facet. -->
+    <HeaderLocationFilter variant="launcher" />
+    <div class="h-5 w-px shrink-0 bg-border"></div>
     <Search class="size-4 shrink-0 text-muted-foreground" />
     <input
       bind:this={inputEl}

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -229,7 +229,7 @@
         return filters.value;
       },
       setQuery: (q) => filters.setQuery(q),
-      filterScope: { store: filters, counts: () => counts },
+      filterScope: { store: filters, counts: () => counts, variant: 'jobs' },
     });
     return () => {
       setListSearchTarget(null);

--- a/web/src/lib/headerScope.test.ts
+++ b/web/src/lib/headerScope.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { FacetStore, FacetSelection } from './facets';
-import { summarizeScope } from './headerScope';
+import { summarizeScope, COMPANIES_SCOPE } from './headerScope';
 
 // Minimal fake store: only `facet` is exercised by summarizeScope.
 type Sel = { include?: string[]; exclude?: string[] };
@@ -57,6 +57,28 @@ describe('summarizeScope', () => {
     expect(summarizeScope(fakeStore({ regions: { include: ['eu'], exclude: ['uk'] } }))).toEqual({
       icon: 'globe',
       label: 'Europe +1',
+    });
+  });
+
+  describe('company spec', () => {
+    it('summarizes remote_regions', () => {
+      expect(summarizeScope(fakeStore({ remote_regions: { include: ['eu'] } }), COMPANIES_SCOPE)).toEqual({
+        icon: 'globe',
+        label: 'Europe',
+      });
+    });
+
+    it('rolls up regions then remote_regions', () => {
+      expect(
+        summarizeScope(fakeStore({ regions: { include: ['eu'] }, remote_regions: { include: ['uk'] } }), COMPANIES_SCOPE),
+      ).toEqual({ icon: 'globe', label: 'Europe +1' });
+    });
+
+    it('ignores work_mode (companies have no work format)', () => {
+      expect(summarizeScope(fakeStore({ work_mode: { include: ['remote'] } }), COMPANIES_SCOPE)).toEqual({
+        icon: 'globe',
+        label: 'Location',
+      });
     });
   });
 });

--- a/web/src/lib/headerScope.ts
+++ b/web/src/lib/headerScope.ts
@@ -1,7 +1,8 @@
-// Pure summary of the header Location & work-format scope, driving the search-box
-// trigger label. Kept out of the component so the roll-up logic (none / format /
-// geo +N / both) is unit-testable without a DOM. Reads the same facet params the
-// popover writes: work_mode, regions, countries, cities.
+// Pure summary of the header filter scope, driving the search-box trigger label.
+// Kept out of the component so the roll-up logic (none / format / geo +N / both) is
+// unit-testable without a DOM. A `ScopeSpec` names the facets a mode cares about, so
+// the jobs feed (work format + regions/countries/cities) and the companies list
+// (regions + remote_regions, no work format) share one summarizer.
 
 import type { FacetStore } from './facets';
 import { countryLabel } from './facets';
@@ -10,8 +11,23 @@ import { REGION_LABELS, WORK_MODE_LABELS } from './labels';
 
 export type ScopeIcon = 'globe' | WorkMode;
 
+/** Which facets a mode summarizes: an optional work-format param (drives the icon)
+ *  plus the ordered geography params rolled into "first +N". */
+export interface ScopeSpec {
+  format?: string;
+  geo: string[];
+}
+
+export const JOBS_SCOPE: ScopeSpec = { format: 'work_mode', geo: ['regions', 'countries', 'cities'] };
+export const COMPANIES_SCOPE: ScopeSpec = { geo: ['regions', 'remote_regions'] };
+
 const titleCase = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 const workModeLabel = (code: string) => WORK_MODE_LABELS[code] ?? titleCase(code);
+
+// Per-param display label: countries via Intl, cities verbatim, every region-shaped
+// param (regions/remote_regions) via the shared region vocabulary.
+const geoLabel = (param: string, v: string) =>
+  param === 'countries' ? countryLabel(v) : param === 'cities' ? v : (REGION_LABELS[v] ?? v);
 
 // A facet's full selection (include ∪ exclude): both narrow the scope, so both
 // count toward the trigger summary.
@@ -20,18 +36,16 @@ function selected(store: Pick<FacetStore, 'facet'>, param: string): string[] {
   return [...f.include, ...f.exclude];
 }
 
-/** Derive the trigger's `{ icon, label }` from the current scope facets. */
-export function summarizeScope(store: Pick<FacetStore, 'facet'>): { icon: ScopeIcon; label: string } {
-  const modes = selected(store, 'work_mode');
+/** Derive the trigger's `{ icon, label }` from the scope facets named by `spec`. */
+export function summarizeScope(
+  store: Pick<FacetStore, 'facet'>,
+  spec: ScopeSpec = JOBS_SCOPE,
+): { icon: ScopeIcon; label: string } {
+  const modes = spec.format ? selected(store, spec.format) : [];
   const firstMode = WORK_MODE_VALUES.find((m) => modes.includes(m));
   const icon: ScopeIcon = firstMode ?? 'globe';
 
-  // Geography in display order: regions, then countries, then cities.
-  const geo = [
-    ...selected(store, 'regions').map((v) => REGION_LABELS[v] ?? v),
-    ...selected(store, 'countries').map(countryLabel),
-    ...selected(store, 'cities'),
-  ];
+  const geo = spec.geo.flatMap((param) => selected(store, param).map((v) => geoLabel(param, v)));
 
   const parts: string[] = [];
   if (firstMode) parts.push(workModeLabel(firstMode));

--- a/web/src/lib/listSearch.svelte.ts
+++ b/web/src/lib/listSearch.svelte.ts
@@ -14,14 +14,15 @@ export interface ListSearchTarget {
   readonly value: { q: string };
   setQuery(q: string): void;
 
-  /** Jobs-only capability: the geography + work-format facet scope the header's
-   *  Location & format popover drives. Present only for jobs-backed lists (the
-   *  jobs feed and a company's jobs list, both on FilterStore); absent on the
-   *  company list, so the popover stays hidden there. `counts` is a getter so the
-   *  view's live facet distribution stays reactive across the bridge. */
+  /** The geography (+ work-format) facet scope the header's Location & format popover
+   *  drives, present on both list surfaces. `variant` selects the popover body: jobs
+   *  lists show work format + the full location pane; the company list shows region +
+   *  remote-hiring pills. `counts` is a getter so the view's live facet distribution
+   *  stays reactive across the bridge (null on the company list, which fetches none). */
   readonly filterScope?: {
     store: FacetStore;
     counts(): FacetCounts | null;
+    variant: 'jobs' | 'companies';
   };
 }
 


### PR DESCRIPTION
## Summary
Extends the header Location filter (shipped in #661) from jobs-feed-only to **cross-cutting**, with three context modes driven by one component:

- **Jobs lists** (`/`, `/companies/:slug`) — unchanged: work format + full LocationPane.
- **Companies list** (`/companies`) — new: **Region** + **Remote hiring** pills, live-filtering `CompanyFilterStore` (`regions`/`remote_regions`).
- **Listless pages** (job detail, `/about`, `/collections`) — new: the launcher shows the trigger; a pick navigates to `/jobs?<facet>` and refines live there.

Text search is unchanged everywhere. No new backend/API/DB/search, no extra facet-count request.

- `filterScope` gains a `variant` discriminator; `JobsView`/`CompaniesView` register their variant.
- `summarizeScope(store, spec)` generalized over a facet spec (jobs vs companies); `JOBS_SCOPE`/`COMPANIES_SCOPE`.
- `HeaderLocationFilter` is variant-aware (jobs/companies/launcher) via `storePills`/`navPills` snippets.

OpenSpec: `header-filter-cross-cutting` (modifies `header-location-filter`).

## Test Plan
- [x] `summarizeScope` company-spec cases (vitest, 220 pass)
- [x] `svelte-check` 0 errors in changed files; changed files eslint-clean
- [x] Browser E2E: `/companies` Region/Remote-hiring filters list + URL (`?regions=eu`); `/about` launcher pick navigates to `/?regions=eu`; jobs feed popover unchanged