### PR TITLE
feat(companies): deterministic company maturity facet

### DIFF
--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -89,6 +89,7 @@ WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '
   AND (coalesce(cardinality($10::text[]), 0) = 0 OR yc_status && $10::text[])
   AND (coalesce(cardinality($11::text[]), 0) = 0 OR yc_stage && $11::text[])
   AND (coalesce(cardinality($12::text[]), 0) = 0 OR yc_flags && $12::text[])
+  AND (coalesce(cardinality($13::text[]), 0) = 0 OR maturity = ANY($13::text[]))
 `
 
 type CountCompaniesParams struct {
@@ -104,6 +105,7 @@ type CountCompaniesParams struct {
 	YcStatus      []string `json:"yc_status"`
 	YcStage       []string `json:"yc_stage"`
 	YcFlags       []string `json:"yc_flags"`
+	Maturity      []string `json:"maturity"`
 }
 
 // Total companies matching the same optional name + facet filters as ListCompanies,
@@ -123,6 +125,7 @@ func (q *Queries) CountCompanies(ctx context.Context, arg CountCompaniesParams) 
 		arg.YcStatus,
 		arg.YcStage,
 		arg.YcFlags,
+		arg.Maturity,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -148,7 +151,7 @@ func (q *Queries) DeleteOrphanCompanies(ctx context.Context) (int64, error) {
 }
 
 const getCompany = `-- name: GetCompany :one
-SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes, industries, year_founded, employee_count, hq_country, organization_type, tagline, company_info, is_reference, company_info_at, remote_regions, yc_batch, yc_status, yc_stage, yc_flags
+SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes, industries, year_founded, employee_count, hq_country, organization_type, tagline, company_info, is_reference, company_info_at, remote_regions, yc_batch, yc_status, yc_stage, yc_flags, maturity
 FROM companies
 WHERE slug = $1
 `
@@ -185,6 +188,7 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 		&i.YcStatus,
 		&i.YcStage,
 		&i.YcFlags,
+		&i.Maturity,
 	)
 	return i, err
 }
@@ -204,8 +208,11 @@ WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '
   AND (coalesce(cardinality($10::text[]), 0) = 0 OR yc_status && $10::text[])
   AND (coalesce(cardinality($11::text[]), 0) = 0 OR yc_stage && $11::text[])
   AND (coalesce(cardinality($12::text[]), 0) = 0 OR yc_flags && $12::text[])
+  -- maturity is a SCALAR column (not an array): membership, not overlap. A NULL
+  -- (unknown) maturity matches no requested value, so ` + "`" + `NULL = ANY(...)` + "`" + ` excludes it.
+  AND (coalesce(cardinality($13::text[]), 0) = 0 OR maturity = ANY($13::text[]))
 ORDER BY job_count DESC, name
-LIMIT $14 OFFSET $13
+LIMIT $15 OFFSET $14
 `
 
 type ListCompaniesParams struct {
@@ -221,6 +228,7 @@ type ListCompaniesParams struct {
 	YcStatus      []string `json:"yc_status"`
 	YcStage       []string `json:"yc_stage"`
 	YcFlags       []string `json:"yc_flags"`
+	Maturity      []string `json:"maturity"`
 	Offset        int32    `json:"offset"`
 	Limit         int32    `json:"limit"`
 }
@@ -262,6 +270,7 @@ func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([
 		arg.YcStatus,
 		arg.YcStage,
 		arg.YcFlags,
+		arg.Maturity,
 		arg.Offset,
 		arg.Limit,
 	)
@@ -370,7 +379,7 @@ WITH oj AS (
     -- duplicate_of IS NULL counts one canonical job per role cluster, so the company
     -- job_count matches the collapsed /jobs and company lists (reposts share facets, so
     -- the DISTINCT region/country aggregates are unaffected — only the count changes).
-    SELECT company_slug, regions, countries, enrichment, work_mode
+    SELECT company_slug, regions, countries, enrichment, work_mode, source
     FROM jobs
     WHERE closed_at IS NULL AND duplicate_of IS NULL AND company_slug <> ''
 ),
@@ -413,6 +422,28 @@ csize AS (
     FROM oj
     WHERE COALESCE(enrichment->>'company_size', '') <> ''
     GROUP BY company_slug
+),
+gov AS (
+    SELECT company_slug, bool_or(source IN ('usajobs', 'neogov')) AS is_gov
+    FROM oj
+    GROUP BY company_slug
+),
+mat AS (
+    SELECT co.slug AS company_slug,
+           CASE
+               WHEN COALESCE(g.is_gov, false) OR co.organization_type = 'Government' THEN 'government'
+               -- enterprise beats startup: a grown company is enterprise regardless of a
+               -- historical YC badge (YC alumni go Public/Acquired and scale to thousands).
+               WHEN co.employee_count >= 1000 THEN 'enterprise'
+               -- startup only for a still-ACTIVE YC company (not Public/Acquired/Inactive),
+               -- or an independently small-and-recent company.
+               WHEN co.yc_status && ARRAY['Active']
+                    OR (co.year_founded >= extract(year FROM now())::int - 7 AND co.employee_count <= 50) THEN 'startup'
+               WHEN co.employee_count BETWEEN 51 AND 999 THEN 'scaleup'
+               ELSE NULL
+           END AS val
+    FROM companies co
+    LEFT JOIN gov g ON g.company_slug = co.slug
 )
 UPDATE companies c
 SET job_count      = COALESCE(counts.cnt, 0),
@@ -421,7 +452,8 @@ SET job_count      = COALESCE(counts.cnt, 0),
     countries      = COALESCE(cty.arr, '{}'),
     domains        = COALESCE(dom.arr, '{}'),
     company_types  = COALESCE(ctype.arr, '{}'),
-    company_sizes  = COALESCE(csize.arr, '{}')
+    company_sizes  = COALESCE(csize.arr, '{}'),
+    maturity       = mat.val
 FROM companies c2
 LEFT JOIN counts      ON counts.company_slug     = c2.slug
 LEFT JOIN reg         ON reg.company_slug        = c2.slug
@@ -430,6 +462,7 @@ LEFT JOIN cty         ON cty.company_slug        = c2.slug
 LEFT JOIN dom         ON dom.company_slug        = c2.slug
 LEFT JOIN ctype       ON ctype.company_slug      = c2.slug
 LEFT JOIN csize       ON csize.company_slug      = c2.slug
+LEFT JOIN mat         ON mat.company_slug        = c2.slug
 WHERE c.slug = c2.slug
   AND (c.job_count      IS DISTINCT FROM COALESCE(counts.cnt, 0)
     OR c.regions        IS DISTINCT FROM COALESCE(reg.arr, '{}')
@@ -437,7 +470,8 @@ WHERE c.slug = c2.slug
     OR c.countries      IS DISTINCT FROM COALESCE(cty.arr, '{}')
     OR c.domains        IS DISTINCT FROM COALESCE(dom.arr, '{}')
     OR c.company_types  IS DISTINCT FROM COALESCE(ctype.arr, '{}')
-    OR c.company_sizes  IS DISTINCT FROM COALESCE(csize.arr, '{}'))
+    OR c.company_sizes  IS DISTINCT FROM COALESCE(csize.arr, '{}')
+    OR c.maturity       IS DISTINCT FROM mat.val)
 `
 
 // Recompute every company's denormalized state in one set-based pass: the open-job
@@ -452,6 +486,13 @@ WHERE c.slug = c2.slug
 // reports real churn. This is cmd/recount-companies' whole job; run periodically
 // (eventual consistency). The facet aggregates are each their own non-correlated
 // GROUP BY so the row-multiplying unnest of one array never distorts another's count.
+// gov marks a company whose open jobs come from an exclusively-government source
+// (usajobs = US federal, neogov = US state/local gov ATS). Generic ATS (workday,
+// greenhouse, …) carry government jobs too, so they are deliberately NOT a signal.
+// mat is the deterministic single-valued maturity, computed per company from its own
+// signals plus the gov-source marker, in precedence order (government beats size).
+// NULL = unknown (an honest abstain when no signal fits). Computed once here so both
+// the SET and the IS DISTINCT FROM guard reference the same value.
 func (q *Queries) RefreshCompanyFacets(ctx context.Context) (int64, error) {
 	result, err := q.db.Exec(ctx, refreshCompanyFacets)
 	if err != nil {

--- a/internal/db/company_maturity_integration_test.go
+++ b/internal/db/company_maturity_integration_test.go
@@ -1,0 +1,209 @@
+//go:build integration
+
+// Integration tests for the deterministic company `maturity` facet: RefreshCompanyFacets
+// derives a single-valued lifecycle stage — government | startup | scaleup | enterprise
+// | NULL(unknown) — from signals already on the company row (organization_type,
+// yc_status, employee_count, year_founded) plus whether its open jobs come from an
+// exclusively-government source (usajobs/neogov). Pure SQL CASE in the same set-based
+// recompute, so it runs against a real Postgres. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// setCompanySignals sets the maturity input columns on an already-inserted company.
+func setCompanySignals(t *testing.T, pool *pgxpool.Pool, slug, orgType string, employeeCount, yearFounded int, ycStatus []string) {
+	t.Helper()
+	var orgPtr *string
+	if orgType != "" {
+		orgPtr = &orgType
+	}
+	var empPtr, yearPtr *int
+	if employeeCount > 0 {
+		empPtr = &employeeCount
+	}
+	if yearFounded > 0 {
+		yearPtr = &yearFounded
+	}
+	if ycStatus == nil {
+		ycStatus = []string{} // yc_status is NOT NULL (defaults to '{}')
+	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE companies SET organization_type = $2, employee_count = $3, year_founded = $4, yc_status = $5 WHERE slug = $1`,
+		slug, orgPtr, empPtr, yearPtr, ycStatus); err != nil {
+		t.Fatalf("set signals %q: %v", slug, err)
+	}
+}
+
+// insertJobFromSource seeds one open job for a company under a specific source (the
+// gov-source signal reads jobs.source).
+func insertJobFromSource(t *testing.T, pool *pgxpool.Pool, source, externalID, companySlug string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, public_slug, company_slug)
+		 VALUES ($1, $2, 'http://example.test', 'A job', 'job-' || $2, $3)`,
+		source, externalID, companySlug); err != nil {
+		t.Fatalf("insert job %q: %v", externalID, err)
+	}
+}
+
+// companyMaturity reads the nullable scalar maturity off the company row.
+func companyMaturity(t *testing.T, pool *pgxpool.Pool, slug string) *string {
+	t.Helper()
+	var got *string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT maturity FROM companies WHERE slug = $1`, slug).Scan(&got); err != nil {
+		t.Fatalf("read maturity %q: %v", slug, err)
+	}
+	return got
+}
+
+func TestRefreshCompanyMaturity(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, "TRUNCATE companies, jobs RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	// YC small company → startup.
+	insertCompany(t, pool, "yc", "YC Co")
+	setCompanySignals(t, pool, "yc", "", 20, 0, []string{"Active"})
+	// Young + small (no YC) → startup.
+	insertCompany(t, pool, "young", "Young Co")
+	setCompanySignals(t, pool, "young", "", 30, 2024, nil)
+	// Government by organization_type → government.
+	insertCompany(t, pool, "govorg", "Gov Org")
+	setCompanySignals(t, pool, "govorg", "Government", 0, 0, nil)
+	// Government by source (usajobs) — even with a big headcount, government wins.
+	insertCompany(t, pool, "govsrc", "Gov Src")
+	setCompanySignals(t, pool, "govsrc", "", 8000, 1900, nil)
+	insertJobFromSource(t, pool, "usajobs", "gov:1", "govsrc")
+	// Large headcount → enterprise.
+	insertCompany(t, pool, "bigco", "Big Co")
+	setCompanySignals(t, pool, "bigco", "", 5000, 1980, nil)
+	// YC alumnus gone public and huge → enterprise, NOT startup (the YC badge is
+	// only a startup signal while status is 'Active').
+	insertCompany(t, pool, "ycgiant", "YC Giant")
+	setCompanySignals(t, pool, "ycgiant", "", 6000, 2008, []string{"Public"})
+	// Mid headcount → scaleup.
+	insertCompany(t, pool, "midco", "Mid Co")
+	setCompanySignals(t, pool, "midco", "", 200, 2010, nil)
+	// No signal → NULL (unknown).
+	insertCompany(t, pool, "unknown", "Unknown Co")
+
+	if _, err := q.RefreshCompanyFacets(ctx); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	cases := []struct {
+		slug string
+		want *string
+	}{
+		{"yc", strptr("startup")},
+		{"young", strptr("startup")},
+		{"govorg", strptr("government")},
+		{"govsrc", strptr("government")}, // government beats enterprise
+		{"bigco", strptr("enterprise")},
+		{"ycgiant", strptr("enterprise")}, // Public YC alumnus at scale → enterprise, not startup
+		{"midco", strptr("scaleup")},
+		{"unknown", nil},
+	}
+	for _, c := range cases {
+		got := companyMaturity(t, pool, c.slug)
+		if !eqStrPtr(got, c.want) {
+			t.Errorf("%s maturity = %s, want %s", c.slug, showStrPtr(got), showStrPtr(c.want))
+		}
+	}
+}
+
+// setMaturity sets the scalar maturity column directly (bypassing the recompute) so
+// the filter test controls the exact value, including NULL.
+func setMaturity(t *testing.T, pool *pgxpool.Pool, slug string, maturity *string) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE companies SET maturity = $2 WHERE slug = $1`, slug, maturity); err != nil {
+		t.Fatalf("set maturity %q: %v", slug, err)
+	}
+}
+
+func maturityRowSlugs(rows []ListCompaniesRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Slug
+	}
+	return out
+}
+
+func TestListCompaniesFilterByMaturity(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, "TRUNCATE companies RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	insertCompany(t, pool, "sc", "Startup Co")
+	insertCompany(t, pool, "bc", "Big Co")
+	insertCompany(t, pool, "uc", "Unknown Co")
+	setMaturity(t, pool, "sc", strptr("startup"))
+	setMaturity(t, pool, "bc", strptr("enterprise"))
+	setMaturity(t, pool, "uc", nil)
+
+	t.Run("single value filters and excludes NULL", func(t *testing.T) {
+		rows, err := q.ListCompanies(ctx, ListCompaniesParams{Maturity: []string{"startup"}, Limit: 50})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if got := maturityRowSlugs(rows); len(got) != 1 || got[0] != "sc" {
+			t.Errorf("maturity=startup → %v, want [sc]", got)
+		}
+		n, err := q.CountCompanies(ctx, CountCompaniesParams{Maturity: []string{"startup"}})
+		if err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("count maturity=startup = %d, want 1", n)
+		}
+	})
+
+	t.Run("multiple values are OR-ed", func(t *testing.T) {
+		rows, err := q.ListCompanies(ctx, ListCompaniesParams{Maturity: []string{"startup", "enterprise"}, Limit: 50})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if got := maturityRowSlugs(rows); len(got) != 2 {
+			t.Errorf("maturity=startup,enterprise → %v, want 2 rows (sc,bc), excluding NULL uc", got)
+		}
+	})
+
+	t.Run("empty filter is no constraint", func(t *testing.T) {
+		rows, err := q.ListCompanies(ctx, ListCompaniesParams{Limit: 50})
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		if got := maturityRowSlugs(rows); len(got) != 3 {
+			t.Errorf("no maturity filter → %v, want all 3", got)
+		}
+	})
+}
+
+func strptr(s string) *string { return &s }
+
+func eqStrPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func showStrPtr(s *string) string {
+	if s == nil {
+		return "NULL"
+	}
+	return *s
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -59,6 +59,7 @@ type Company struct {
 	YcStatus         []string           `json:"yc_status"`
 	YcStage          []string           `json:"yc_stage"`
 	YcFlags          []string           `json:"yc_flags"`
+	Maturity         pgtype.Text        `json:"maturity"`
 }
 
 type Email struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -611,6 +611,13 @@ type Querier interface {
 	// reports real churn. This is cmd/recount-companies' whole job; run periodically
 	// (eventual consistency). The facet aggregates are each their own non-correlated
 	// GROUP BY so the row-multiplying unnest of one array never distorts another's count.
+	// gov marks a company whose open jobs come from an exclusively-government source
+	// (usajobs = US federal, neogov = US state/local gov ATS). Generic ATS (workday,
+	// greenhouse, …) carry government jobs too, so they are deliberately NOT a signal.
+	// mat is the deterministic single-valued maturity, computed per company from its own
+	// signals plus the gov-source marker, in precedence order (government beats size).
+	// NULL = unknown (an honest abstain when no signal fits). Computed once here so both
+	// the SET and the IS DISTINCT FROM guard reference the same value.
 	RefreshCompanyFacets(ctx context.Context) (int64, error)
 	// Release the lease on a subscription's claimed jobs without counting an attempt,
 	// so a soft-skipped delivery (e.g. Telegram not yet linked) is retried promptly on

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -27,6 +27,9 @@ WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || 
   AND (coalesce(cardinality(sqlc.arg('yc_status')::text[]), 0) = 0 OR yc_status && sqlc.arg('yc_status')::text[])
   AND (coalesce(cardinality(sqlc.arg('yc_stage')::text[]), 0) = 0 OR yc_stage && sqlc.arg('yc_stage')::text[])
   AND (coalesce(cardinality(sqlc.arg('yc_flags')::text[]), 0) = 0 OR yc_flags && sqlc.arg('yc_flags')::text[])
+  -- maturity is a SCALAR column (not an array): membership, not overlap. A NULL
+  -- (unknown) maturity matches no requested value, so `NULL = ANY(...)` excludes it.
+  AND (coalesce(cardinality(sqlc.arg('maturity')::text[]), 0) = 0 OR maturity = ANY(sqlc.arg('maturity')::text[]))
 ORDER BY job_count DESC, name
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
@@ -47,7 +50,8 @@ WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || 
   AND (coalesce(cardinality(sqlc.arg('yc_batch')::text[]), 0) = 0 OR yc_batch && sqlc.arg('yc_batch')::text[])
   AND (coalesce(cardinality(sqlc.arg('yc_status')::text[]), 0) = 0 OR yc_status && sqlc.arg('yc_status')::text[])
   AND (coalesce(cardinality(sqlc.arg('yc_stage')::text[]), 0) = 0 OR yc_stage && sqlc.arg('yc_stage')::text[])
-  AND (coalesce(cardinality(sqlc.arg('yc_flags')::text[]), 0) = 0 OR yc_flags && sqlc.arg('yc_flags')::text[]);
+  AND (coalesce(cardinality(sqlc.arg('yc_flags')::text[]), 0) = 0 OR yc_flags && sqlc.arg('yc_flags')::text[])
+  AND (coalesce(cardinality(sqlc.arg('maturity')::text[]), 0) = 0 OR maturity = ANY(sqlc.arg('maturity')::text[]));
 
 -- name: ListCompanySitemap :many
 -- Slim keyset page of companies for the sitemap, cursored by the slug primary key
@@ -199,7 +203,7 @@ WITH oj AS (
     -- duplicate_of IS NULL counts one canonical job per role cluster, so the company
     -- job_count matches the collapsed /jobs and company lists (reposts share facets, so
     -- the DISTINCT region/country aggregates are unaffected — only the count changes).
-    SELECT company_slug, regions, countries, enrichment, work_mode
+    SELECT company_slug, regions, countries, enrichment, work_mode, source
     FROM jobs
     WHERE closed_at IS NULL AND duplicate_of IS NULL AND company_slug <> ''
 ),
@@ -242,6 +246,35 @@ csize AS (
     FROM oj
     WHERE COALESCE(enrichment->>'company_size', '') <> ''
     GROUP BY company_slug
+),
+-- gov marks a company whose open jobs come from an exclusively-government source
+-- (usajobs = US federal, neogov = US state/local gov ATS). Generic ATS (workday,
+-- greenhouse, …) carry government jobs too, so they are deliberately NOT a signal.
+gov AS (
+    SELECT company_slug, bool_or(source IN ('usajobs', 'neogov')) AS is_gov
+    FROM oj
+    GROUP BY company_slug
+),
+-- mat is the deterministic single-valued maturity, computed per company from its own
+-- signals plus the gov-source marker, in precedence order (government beats size).
+-- NULL = unknown (an honest abstain when no signal fits). Computed once here so both
+-- the SET and the IS DISTINCT FROM guard reference the same value.
+mat AS (
+    SELECT co.slug AS company_slug,
+           CASE
+               WHEN COALESCE(g.is_gov, false) OR co.organization_type = 'Government' THEN 'government'
+               -- enterprise beats startup: a grown company is enterprise regardless of a
+               -- historical YC badge (YC alumni go Public/Acquired and scale to thousands).
+               WHEN co.employee_count >= 1000 THEN 'enterprise'
+               -- startup only for a still-ACTIVE YC company (not Public/Acquired/Inactive),
+               -- or an independently small-and-recent company.
+               WHEN co.yc_status && ARRAY['Active']
+                    OR (co.year_founded >= extract(year FROM now())::int - 7 AND co.employee_count <= 50) THEN 'startup'
+               WHEN co.employee_count BETWEEN 51 AND 999 THEN 'scaleup'
+               ELSE NULL
+           END AS val
+    FROM companies co
+    LEFT JOIN gov g ON g.company_slug = co.slug
 )
 UPDATE companies c
 SET job_count      = COALESCE(counts.cnt, 0),
@@ -250,7 +283,8 @@ SET job_count      = COALESCE(counts.cnt, 0),
     countries      = COALESCE(cty.arr, '{}'),
     domains        = COALESCE(dom.arr, '{}'),
     company_types  = COALESCE(ctype.arr, '{}'),
-    company_sizes  = COALESCE(csize.arr, '{}')
+    company_sizes  = COALESCE(csize.arr, '{}'),
+    maturity       = mat.val
 FROM companies c2
 LEFT JOIN counts      ON counts.company_slug     = c2.slug
 LEFT JOIN reg         ON reg.company_slug        = c2.slug
@@ -259,6 +293,7 @@ LEFT JOIN cty         ON cty.company_slug        = c2.slug
 LEFT JOIN dom         ON dom.company_slug        = c2.slug
 LEFT JOIN ctype       ON ctype.company_slug      = c2.slug
 LEFT JOIN csize       ON csize.company_slug      = c2.slug
+LEFT JOIN mat         ON mat.company_slug        = c2.slug
 WHERE c.slug = c2.slug
   AND (c.job_count      IS DISTINCT FROM COALESCE(counts.cnt, 0)
     OR c.regions        IS DISTINCT FROM COALESCE(reg.arr, '{}')
@@ -266,7 +301,8 @@ WHERE c.slug = c2.slug
     OR c.countries      IS DISTINCT FROM COALESCE(cty.arr, '{}')
     OR c.domains        IS DISTINCT FROM COALESCE(dom.arr, '{}')
     OR c.company_types  IS DISTINCT FROM COALESCE(ctype.arr, '{}')
-    OR c.company_sizes  IS DISTINCT FROM COALESCE(csize.arr, '{}'));
+    OR c.company_sizes  IS DISTINCT FROM COALESCE(csize.arr, '{}')
+    OR c.maturity       IS DISTINCT FROM mat.val);
 
 -- name: CompanyJobCountBySlug :one
 -- The denormalized open-job count for a slug (pgx.ErrNoRows if the company is

--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -47,6 +47,7 @@ type companyView struct {
 	YcStatus         []string        `json:"yc_status"`
 	YcStage          []string        `json:"yc_stage"`
 	YcFlags          []string        `json:"yc_flags"`
+	Maturity         pgtype.Text     `json:"maturity"`
 }
 
 // companyViewFrom projects a stored company onto its public view, dropping only the
@@ -74,6 +75,7 @@ func companyViewFrom(c db.Company) companyView {
 		YcStatus:         c.YcStatus,
 		YcStage:          c.YcStage,
 		YcFlags:          c.YcFlags,
+		Maturity:         c.Maturity,
 	}
 }
 
@@ -106,6 +108,7 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 	ycStatus := facetValues(vals, "yc_status")
 	ycStage := facetValues(vals, "yc_stage")
 	ycFlags := facetValues(vals, "yc_flags")
+	maturity := facetValues(vals, "maturity")
 
 	companies, err := a.queries.ListCompanies(c.Context(), db.ListCompaniesParams{
 		Search:        search,
@@ -120,6 +123,7 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 		YcStatus:      ycStatus,
 		YcStage:       ycStage,
 		YcFlags:       ycFlags,
+		Maturity:      maturity,
 		Limit:         int32(limit),
 		Offset:        int32(offset),
 	})
@@ -140,6 +144,7 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 		YcStatus:      ycStatus,
 		YcStage:       ycStage,
 		YcFlags:       ycFlags,
+		Maturity:      maturity,
 	})
 	if err != nil {
 		return err

--- a/migrations/0017_company_maturity.sql
+++ b/migrations/0017_company_maturity.sql
@@ -1,0 +1,19 @@
+-- Deterministic company maturity facet (see the company-classification-facets change).
+-- maturity is a single-valued classification on the company's lifecycle stage —
+-- 'government' | 'startup' | 'scaleup' | 'enterprise' — derived deterministically by
+-- RefreshCompanyFacets / cmd/recount-companies from signals already stored
+-- (organization_type, yc_status, employee_count, year_founded, and whether the
+-- company's jobs come from an exclusively-government source like usajobs/neogov).
+--
+-- Unlike the array facets (yc_*, regions, company_types), maturity is a SCALAR text
+-- column and is NULLABLE on purpose: NULL means "unknown" (an honest abstain when no
+-- signal fits), and it filters by membership (maturity = ANY(...)) rather than array
+-- overlap. It replaces the ambiguous single company_type only on the maturity axis;
+-- company_type itself is left untouched (deprecation is a later change).
+--
+-- Applied to a fresh volume by initdb after 0016; on an existing prod volume this
+-- statement must be run manually BEFORE deploying code that reads the column, then
+-- cmd/recount-companies rematerializes every company.
+
+ALTER TABLE public.companies
+    ADD COLUMN maturity text;

--- a/openspec/changes/company-classification-facets/.openspec.yaml
+++ b/openspec/changes/company-classification-facets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/company-classification-facets/design.md
+++ b/openspec/changes/company-classification-facets/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`company_type` is derived per-job by the enrichment LLM and aggregated into
+`companies.company_types`. A prod spike proved it ill-posed on the ambiguous
+business-model middle (product↔startup↔inhouse↔outsource) while reliable only on
+the maturity axis — and that axis is derivable from company signals we already
+store. `RefreshCompanyFacets` (`internal/db/queries/companies.sql`, a single
+set-based SQL pass run by `cmd/recount-companies` every 6h) already recomputes
+every company's denormalized facets under an `IS DISTINCT FROM` change-guard — the
+natural home for one more computed column.
+
+A task-1.1 prod measurement narrowed the reliable signals:
+- **Government source** is clean only for the exclusively-government sources
+  `usajobs` and `neogov` (generic ATS like workday/icims/greenhouse carry
+  government jobs too, so they are NOT a government signal).
+- **business_model / services** has NO clean signal: the `industries` "services"
+  keyword is ~87% false-positive (matches product companies), and no source
+  cleanly marks an agency — so `business_model` is **out of scope** for this
+  change (deferred to a future company-website/registry classifier).
+
+## Goals / Non-Goals
+
+**Goals:**
+- One well-posed, deterministic company facet (`maturity`), computed once per
+  company from existing signals, honest `NULL` on unknown.
+- Zero LLM, zero per-job cost, no new worker — reuse `RefreshCompanyFacets` and its
+  timer/guard.
+- Additive: `company_type` and everything reading it stay untouched.
+
+**Non-Goals:**
+- `business_model` — no reliable deterministic signal exists yet (deferred).
+- Removing or deprecating `company_type` (a later change).
+- Per-job exposure / Meilisearch faceting (company-level Postgres filter only; a
+  `jobview` join can come later if a per-job filter is wanted).
+
+## Decisions
+
+- **Scalar column, membership filter.** Unlike the existing array facets (filtered
+  by `&&` overlap), `maturity` is a single-valued `text` column filtered by
+  `maturity = ANY($1::text[])` (OR within facet). `NULL` matches nothing — the
+  honest-unknown company is simply not returned for this facet. This is a
+  deliberate divergence from the array-facet machinery, wired explicitly in
+  `ListCompanies`/`CountCompanies`.
+- **Pure-SQL rule in `RefreshCompanyFacets`.** Add `source` to the `oj` CTE, add a
+  `gov_sig` aggregate (`bool_or(source = ANY(ARRAY['usajobs','neogov']))`) per
+  company, then one `CASE` over `gov_sig` + the `companies` columns. Add it to the
+  `SET` and to the `IS DISTINCT FROM` guard so the change-guard still
+  short-circuits.
+- **Rule precedence (maturity):** `government` → `startup` → `enterprise` →
+  `scaleup` → `NULL`. Government wins over size (a large gov agency is still
+  `government`). Rules:
+  - `government` ← `gov_sig` OR `organization_type = 'Government'`
+  - `startup` ← `yc_status` non-empty OR (`year_founded >= extract(year from now()) - 7` AND `employee_count <= 50`)
+  - `enterprise` ← `employee_count >= 1000`
+  - `scaleup` ← `employee_count BETWEEN 51 AND 999`
+  - else `NULL`
+- **Backfill = recompute.** No data migration beyond the column; one
+  `cmd/recount-companies` run rematerializes the whole table. Migration applied to
+  prod manually before deploy (per the migrations gotcha).
+
+## Risks / Trade-offs
+
+- **Coverage is partial by design.** Companies with no signal (no gov source, no
+  YC, no `employee_count`) are `NULL` — intended honest behavior, not a bug.
+- **`current year` in SQL.** The `startup` recency rule uses
+  `extract(year from now())`; the recompute is periodic, so the once-a-year
+  boundary shift is acceptable and self-heals on the next run.
+- **Sqlc scalar-nullable mapping.** The new column is nullable `text`; expose it as
+  nullable (omitted/`null` when unknown), and treat an empty filter request as "no
+  constraint".

--- a/openspec/changes/company-classification-facets/proposal.md
+++ b/openspec/changes/company-classification-facets/proposal.md
@@ -1,0 +1,72 @@
+## Why
+
+The single `company_type` enrichment field is **ill-posed**. A read-only prod
+spike proved it: the enrichment LLM is ~100% correct on distinctive classes
+(`government`: 7022/7022 on usajobs, 657/659 on neogov) but the
+`product`↔`startup`↔`inhouse`↔`outsource` middle is inherently ambiguous — a YC
+company is *both* product *and* startup, so a forced single label has no ground
+truth (the LLM labels YC companies 77% `product`, 22% `startup`). A distilled
+CPU classifier confirmed the ceiling: it learned the distinctive classes but
+collapsed on the middle (macro-F1 0.42, below the trivial baseline). The field
+conflates two orthogonal axes (maturity × business-model) and pays LLM tokens
+per job to guess a company fact from a single posting.
+
+The **maturity** axis of that field is exactly the part derivable
+**deterministically from company-level signals we already store** — no LLM, no
+per-job cost, computed once per company. (The business-model axis is *not*
+reliably derivable from current signals — a task-1.1 prod measurement showed the
+`industries` "services" keyword is 87% false-positive and no source cleanly marks
+an agency — so it is deferred to a future change with a better signal, e.g.
+company-website classification.)
+
+## What Changes
+
+- Add one **well-posed, deterministic** company-classification facet on the
+  maturity axis the old field conflated:
+  - `maturity` ∈ {`government`, `startup`, `scaleup`, `enterprise`} — `NULL` = unknown
+- Compute it **once per company** (rematerialized) inside the existing
+  `RefreshCompanyFacets` recompute SQL, from signals already in the DB
+  (`organization_type`, `yc_status`, `employee_count`, `year_founded`, and a
+  government **source** signal aggregated from the company's jobs — the
+  exclusively-government sources `usajobs`/`neogov`). Pure SQL `CASE`; no LLM, no
+  per-job work, no new worker — reuses the 6h `cmd/recount-companies` timer and the
+  `IS DISTINCT FROM` change-guard.
+- **Honest abstain:** where signals are silent or conflict, the value is `NULL`
+  (unknown) rather than a fabricated label — the fix for the fake precision that
+  broke `company_type`.
+- Expose it as a repeatable filter facet on `GET /api/v1/companies` (OR within the
+  facet, AND across facets, composing with `q`) and on `GetCompany`; add a
+  FilterModal pill in the web app.
+- **Additive and non-breaking:** the old `company_type` enrichment field, its
+  search facet, its frontend filter, and its generated contract are left
+  **untouched**. Deprecating `company_type` is a later, separate change.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `companies`: the company-list facet-filter requirement gains one new scalar
+  facet (`maturity`); the denormalized-recompute requirement gains one new
+  deterministic column, maintained in the same `RefreshCompanyFacets` pass under
+  the same change-guard.
+
+## Impact
+
+- **Schema:** migration adds one nullable `text` column (`maturity`) to
+  `companies`.
+- **DB layer:** `internal/db/queries/companies.sql` — extend
+  `RefreshCompanyFacets` (add `source` to the `oj` CTE, add a government
+  source-signal aggregate, compute the `maturity` `CASE` column, add to `SET` +
+  guard); add `maturity` as a membership filter to `ListCompanies`/`CountCompanies`;
+  expose in `GetCompany`. Regenerate with `make sqlc`.
+- **API/handlers:** parse the new repeatable `maturity` facet param; include the
+  field in the company read shape.
+- **Frontend:** `web/src/lib/facets.ts` `COMPANY_FACETS` + a FilterModal pill.
+- **Backfill:** one `cmd/recount-companies` run after deploy rematerializes every
+  company (migration applied manually before deploy, per the migrations gotcha).
+- **No LLM, no per-job cost, no reindex** (company facets are Postgres-filtered,
+  not Meilisearch). Old `company_type` behavior unchanged.

--- a/openspec/changes/company-classification-facets/specs/companies/spec.md
+++ b/openspec/changes/company-classification-facets/specs/companies/spec.md
@@ -1,0 +1,172 @@
+# companies
+
+## MODIFIED Requirements
+
+### Requirement: Company list is served without joining jobs
+
+The system SHALL expose `GET /api/v1/companies` returning companies read from the
+`companies` table. Each company's job count SHALL be read from the denormalized
+`companies.job_count` column (open jobs only), not computed at query time, so the
+read path performs no join to the `jobs` table. The list SHALL be ordered by
+`job_count` descending, then `name` ascending, so the most active companies
+surface first.
+
+The endpoint SHALL accept an optional `q` query parameter that filters companies
+by a case-insensitive substring match on the company `name`. An absent or empty
+`q` SHALL return the unfiltered list.
+
+The endpoint SHALL additionally accept repeatable facet query parameters —
+`collections`, `regions`, `countries`, `domains`, `company_type`, `company_size`,
+`remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, and `yc_flags` — each
+filtering against the company's corresponding denormalized array by **array
+overlap**: a company matches a facet when its array shares at least one value with
+the requested values (OR within a facet), and a company must match every provided
+facet (AND across facets). The `remote_regions` facet filters the job-derived
+remote-hiring regions (a subset of `regions`). The `yc_batch`, `yc_status`,
+`yc_stage`, and `yc_flags` facets filter the curated YC-directory columns (see the
+`yc-company-enrichment` capability); a non-YC company has them empty and matches
+none. Facet filters SHALL compose with the `q` name search. An absent facet
+parameter SHALL not constrain the list.
+
+The endpoint SHALL additionally accept the repeatable **scalar** facet parameter
+`maturity`, filtering against the company's single-valued `companies.maturity`
+column by **membership**: a company matches when its scalar value is among the
+requested values (OR within the facet), and this facet ANDs with the others and
+with `q` exactly like the array facets. A company whose `maturity` is `NULL`
+(unknown) matches no `maturity` filter. `maturity` values are `government`,
+`startup`, `scaleup`, `enterprise`.
+
+When any filter (`q` or a facet) is applied, the list `meta.total` SHALL report
+the count of companies matching the full filter combination, so pagination over
+the filtered results is correct.
+
+#### Scenario: Listing companies most-active first
+
+- **WHEN** a client requests `GET /api/v1/companies`
+- **THEN** the response contains companies under `data` with list `meta`,
+  ordered by `job_count` descending (ties broken by `name`), each carrying its
+  denormalized `job_count`
+
+#### Scenario: Searching companies by name
+
+- **WHEN** a client requests `GET /api/v1/companies?q=acme`
+- **THEN** the response contains only companies whose name matches `acme`
+  case-insensitively, ordered by `job_count` descending, and `meta.total` is the
+  count of matching companies
+
+#### Scenario: Empty query returns the full list
+
+- **WHEN** a client requests `GET /api/v1/companies?q=` (empty or absent)
+- **THEN** the response is the unfiltered company list, identical to omitting the
+  parameter
+
+#### Scenario: Filtering by a single facet
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe`
+- **THEN** the response contains only companies whose `regions` array contains
+  `europe`, and `meta.total` is the count of such companies
+
+#### Scenario: Multiple values within one facet are OR-ed
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe&regions=asia`
+- **THEN** the response contains companies whose `regions` overlap
+  `{europe, asia}` (in Europe **or** Asia)
+
+#### Scenario: Different facets are AND-ed and compose with search
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?collections=yc&company_type=startup&q=lab`
+- **THEN** the response contains only companies that are in the `yc` collection
+  **and** have `startup` among their `company_types` **and** whose name matches
+  `lab`
+
+#### Scenario: Filtering by remote-hiring regions
+
+- **WHEN** a client requests `GET /api/v1/companies?remote_regions=eu`
+- **THEN** the response contains only companies whose `remote_regions` array
+  contains `eu`, and `meta.total` is the count of such companies
+
+#### Scenario: Filtering by YC facets
+
+- **WHEN** a client requests `GET /api/v1/companies?yc_stage=Growth&yc_flags=top_company`
+- **THEN** the response contains only companies whose `yc_stage` contains `Growth`
+  **and** whose `yc_flags` contains `top_company`, and `meta.total` is the count of
+  such companies
+
+#### Scenario: Filtering by the scalar maturity facet
+
+- **WHEN** a client requests `GET /api/v1/companies?maturity=startup&maturity=scaleup`
+- **THEN** the response contains only companies whose `maturity` is `startup` **or**
+  `scaleup`, excluding any company whose `maturity` is `NULL`, and `meta.total` is
+  the count of such companies
+
+### Requirement: Company job counts are denormalized and periodically recomputed
+
+The system SHALL store each company's count of open jobs (`closed_at IS NULL`) in
+a denormalized `companies.job_count` column, and its derived facet arrays
+(`regions`, `countries`, `domains`, `company_types`, `company_sizes`,
+`remote_regions`) in denormalized columns. Both SHALL be maintained by the same
+periodic recompute (a scheduled worker), not by a synchronous write on the job
+ingest/close paths, so they are eventually consistent with the `jobs` table within
+the recompute interval. A company with no open jobs SHALL have `job_count = 0` and
+empty facet arrays. `remote_regions` SHALL be maintained as the distinct union of
+`regions` over the company's open jobs with `work_mode = 'remote'`, so it is a
+subset of the `regions` array; a company with no open remote job has an empty
+`remote_regions`.
+
+The same recompute SHALL additionally maintain one **deterministic, single-valued**
+classification column, `companies.maturity`, computed from signals already stored
+(`organization_type`, `yc_status`, `employee_count`, `year_founded`, and whether
+the company's open jobs come from an exclusively-government `source`). The
+derivation SHALL be a pure rule (no LLM), applied in precedence order: `maturity`
+is `government` when the company is government-sourced or `organization_type` is
+`Government`, else `startup` when it is a YC company or is small and recently
+founded, else `enterprise` when its employee count is large, else `scaleup` for
+mid-size, else `NULL` (unknown). Where signals are silent, the value SHALL be
+`NULL` — an honest abstain, never a fabricated label. This column SHALL be
+maintained under the same `IS DISTINCT FROM` change-guard as the other facets, so
+an unchanged company is not rewritten.
+
+#### Scenario: Recompute reflects only open jobs
+
+- **WHEN** the recompute runs and a company has 3 open jobs and 2 closed jobs
+  (`closed_at` set)
+- **THEN** that company's `job_count` is set to 3 and its facet arrays reflect
+  only the 3 open jobs
+
+#### Scenario: Recompute zeroes a company whose jobs all closed
+
+- **WHEN** every job of a company has been closed since the last recompute and the
+  recompute runs again
+- **THEN** that company's `job_count` is set to 0 and its facet arrays are emptied
+
+#### Scenario: Counts are eventually consistent
+
+- **WHEN** a new job is ingested for a company between recompute runs
+- **THEN** the company's `job_count` and facet arrays do not change until the next
+  recompute, which then includes the new job
+
+#### Scenario: Recompute rewrites nothing when already current
+
+- **WHEN** the recompute runs and a company's `job_count` and every facet array
+  already equal the freshly computed values
+- **THEN** that company's row is not rewritten (the recompute reports it as
+  unchanged)
+
+#### Scenario: remote_regions is derived from open remote jobs only
+
+- **WHEN** the recompute runs for a company whose open jobs are one `remote` job in
+  `eu` and one `onsite` job in `north_america`
+- **THEN** that company's `remote_regions` is `{eu}` (the onsite job's region is
+  excluded) while its `regions` is `{eu, north_america}`
+
+#### Scenario: maturity is derived deterministically
+
+- **WHEN** the recompute runs for a YC company with `employee_count = 20`
+- **THEN** its `maturity` is `startup`
+
+#### Scenario: Unknown maturity abstains to NULL
+
+- **WHEN** the recompute runs for a company with no government source, no YC
+  status, and no `employee_count`
+- **THEN** its `maturity` is `NULL` (unknown), not a guessed label

--- a/openspec/changes/company-classification-facets/tasks.md
+++ b/openspec/changes/company-classification-facets/tasks.md
@@ -1,0 +1,55 @@
+# Tasks
+
+## 1. Rule inputs pinned (prod measurement — DONE)
+
+- [x] 1.1 Targeted prod measurement complete. Findings recorded in `design.md`:
+  government source = `usajobs`/`neogov` only (generic ATS carry gov jobs too, so
+  excluded); `business_model`/services has no clean signal (industries keyword ~87%
+  false-positive) → deferred, out of scope. `maturity` rules + thresholds pinned.
+
+## 2. Schema — one nullable column
+
+- [x] 2.1 Add a migration adding `maturity text` (nullable) to `companies`. Follow
+  the existing migration numbering/style. Note it must be applied to prod manually
+  before deploy.
+
+## 3. RefreshCompanyFacets — deterministic maturity (SQL)
+
+- [x] 3.1 **RED** — Add an integration test (`//go:build integration`,
+  testcontainers) in `internal/db` seeding companies with distinct signals (a YC
+  small company → `startup`; a `usajobs`-sourced company → `government`; an
+  `organization_type='Government'` company → `government`; a 1000+ employee company →
+  `enterprise`; a 200-employee company → `scaleup`; a signal-less company → `NULL`)
+  then calling `RefreshCompanyFacets` and asserting each company's `maturity`.
+  Confirm it fails (column unset).
+- [x] 3.2 **GREEN** — Extend `RefreshCompanyFacets` in
+  `internal/db/queries/companies.sql`: add `source` to the `oj` CTE, add a
+  per-company `gov_sig` aggregate, compute the `maturity` `CASE` (precedence per
+  `design.md`), add it to the `SET` and the `IS DISTINCT FROM` guard. `make sqlc`.
+- [x] 3.3 Extend the existing "rewrites nothing when already current" assertion to
+  cover the new `maturity` column (guard short-circuits an unchanged company).
+
+## 4. Filter + read exposure
+
+- [x] 4.1 **RED** — Integration test: `ListCompanies`/`CountCompanies` filtering by
+  `maturity` (membership, OR within facet), AND-composing with an existing facet and
+  `q`, and excluding `NULL`-`maturity` companies. Fails first.
+- [x] 4.2 **GREEN** — Add `maturity` as a `= ANY(sqlc.arg(...)::text[])` membership
+  filter (empty array = no constraint) to `ListCompanies` and `CountCompanies`;
+  `make sqlc`. Expose `maturity` in `GetCompany` / the company read shape (nullable
+  → omitted/null when unknown).
+- [x] 4.3 Wire the handler to parse the repeatable `maturity` query param and pass
+  it through; include the field in the company JSON. Handler test.
+
+## 5. Frontend facet pill
+
+- [x] 5.1 Add `maturity` to `COMPANY_FACETS` in `web/src/lib/facets.ts` (label +
+  values) so it renders as a FilterModal pill on the companies page. Run
+  `npm run check` + `lint` locally.
+
+## 6. Verify + backfill
+
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...` and
+  `go test -tags=integration ./internal/db/` green.
+- [x] 6.2 Document the deploy step: apply the migration manually, deploy, then run
+  `cmd/recount-companies` once to rematerialize every company.

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -414,6 +414,14 @@ export const COUNTRY_OPTIONS: FacetOption[] = COUNTRY;
 // vocabularies as the job facets so labels never drift.
 const YC_STATUS: FacetOption[] = options(['Active', 'Acquired', 'Public', 'Inactive']);
 const YC_STAGE: FacetOption[] = options(['Early', 'Growth']);
+// Deterministic company maturity (see the company-classification-facets change),
+// derived server-side from company signals; unknown (NULL) companies match nothing.
+const MATURITY: FacetOption[] = options(['startup', 'scaleup', 'enterprise', 'government'], {
+  startup: 'Startup',
+  scaleup: 'Scaleup',
+  enterprise: 'Enterprise',
+  government: 'Government',
+});
 const YC_FLAGS: FacetOption[] = options(['top_company', 'hiring'], {
   top_company: 'YC Top Company',
   hiring: 'Hiring',
@@ -432,6 +440,7 @@ export const COMPANY_FACETS: FacetDef[] = [
   { param: 'domains', label: 'Industry', control: 'select', options: DOMAINS, excludable: false, placeholder: 'Search industries' },
   { param: 'company_type', label: 'Company type', control: 'pills', options: COMPANY_TYPE, excludable: false },
   { param: 'company_size', label: 'Company size', control: 'pills', options: COMPANY_SIZE, excludable: false },
+  { param: 'maturity', label: 'Company stage', control: 'pills', options: MATURITY, excludable: false },
   { param: 'yc_status', label: 'YC status', control: 'pills', options: YC_STATUS, excludable: false },
   { param: 'yc_stage', label: 'YC stage', control: 'pills', options: YC_STAGE, excludable: false },
   { param: 'yc_flags', label: 'YC highlights', control: 'pills', options: YC_FLAGS, excludable: false },


### PR DESCRIPTION
## Summary

Adds a well-posed, deterministic **`maturity`** facet to companies —
`government` / `startup` / `scaleup` / `enterprise`, `NULL` = unknown — computed
**once per company** in the existing `RefreshCompanyFacets` recompute from signals
already stored (`organization_type`, `yc_status`, `employee_count`, `year_founded`,
and whether the company's open jobs come from an exclusively-government source
`usajobs`/`neogov`). Pure SQL `CASE`; **no LLM, no per-job cost, no new worker** —
reuses the 6h `cmd/recount-companies` timer and the `IS DISTINCT FROM` guard.

### Why
A prod spike proved the single `company_type` enrichment field is **ill-posed**:
the LLM is ~100% correct on distinctive classes (government) but the
product↔startup↔outsource middle has no ground truth (a YC company is *both*
product *and* startup), and a distilled CPU classifier collapsed there (macro-F1
0.42). This extracts the one axis that *is* reliably derivable — maturity —
deterministically. `business_model` had no clean signal (a task-1.1 measurement
showed the `industries` "services" keyword is ~87% false-positive) and is deferred.

`company_type` and everything reading it are **left untouched** (additive).

### Rules (precedence)
`government` (gov source or `organization_type='Government'`) → `enterprise`
(`employee_count >= 1000`) → `startup` (**Active** YC status, or young + ≤50
employees) → `scaleup` (51–999) → `NULL`. Enterprise beats a historical YC badge
so grown/public YC alumni (Airbnb, Coinbase) classify as `enterprise`, not startup.

### Exposure
Scalar **membership** filter on `GET /api/v1/companies?maturity=…` (OR within the
facet, ANDs with the others; a `NULL`/unknown company matches nothing), returned by
`GetCompany`, and a "Company stage" FilterModal pill.

## ⚠️ Deploy ordering (migration-first — mandatory)
`GetCompany` SELECTs the new column, so an unapplied migration 500s every company
read (42703). Deploy sequence:
1. Apply `migrations/0017_company_maturity.sql` to prod **manually**
2. Deploy the code
3. Run `cmd/recount-companies` once to rematerialize every company

## Test Plan
- [x] `go build/vet ./...`, unit tests
- [x] `go test -tags=integration ./internal/db/` — new `TestRefreshCompanyMaturity` (all six maturity outcomes incl. the YC-giant→enterprise case) + `TestListCompaniesFilterByMaturity` (membership, OR, NULL-excluded); full suite (187s) green — no sibling recompute test regressed
- [x] web `svelte-check` clean (0 errors)

OpenSpec: `company-classification-facets`