### PR TITLE
feat(companies): derive company_sizes from employee_count when known

### DIFF
--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -444,6 +444,20 @@ mat AS (
            END AS val
     FROM companies co
     LEFT JOIN gov g ON g.company_slug = co.slug
+),
+csize_final AS (
+    SELECT co.slug AS company_slug,
+           CASE
+               WHEN co.employee_count IS NULL   THEN COALESCE(cs.arr, '{}')
+               WHEN co.employee_count <= 10     THEN ARRAY['1-10']
+               WHEN co.employee_count <= 50     THEN ARRAY['11-50']
+               WHEN co.employee_count <= 200    THEN ARRAY['51-200']
+               WHEN co.employee_count <= 500    THEN ARRAY['201-500']
+               WHEN co.employee_count <= 1000   THEN ARRAY['501-1000']
+               ELSE ARRAY['1000+']
+           END AS arr
+    FROM companies co
+    LEFT JOIN csize cs ON cs.company_slug = co.slug
 )
 UPDATE companies c
 SET job_count      = COALESCE(counts.cnt, 0),
@@ -452,7 +466,7 @@ SET job_count      = COALESCE(counts.cnt, 0),
     countries      = COALESCE(cty.arr, '{}'),
     domains        = COALESCE(dom.arr, '{}'),
     company_types  = COALESCE(ctype.arr, '{}'),
-    company_sizes  = COALESCE(csize.arr, '{}'),
+    company_sizes  = csize_final.arr,
     maturity       = mat.val
 FROM companies c2
 LEFT JOIN counts      ON counts.company_slug     = c2.slug
@@ -461,7 +475,7 @@ LEFT JOIN remote_reg  ON remote_reg.company_slug = c2.slug
 LEFT JOIN cty         ON cty.company_slug        = c2.slug
 LEFT JOIN dom         ON dom.company_slug        = c2.slug
 LEFT JOIN ctype       ON ctype.company_slug      = c2.slug
-LEFT JOIN csize       ON csize.company_slug      = c2.slug
+LEFT JOIN csize_final ON csize_final.company_slug = c2.slug
 LEFT JOIN mat         ON mat.company_slug        = c2.slug
 WHERE c.slug = c2.slug
   AND (c.job_count      IS DISTINCT FROM COALESCE(counts.cnt, 0)
@@ -470,7 +484,7 @@ WHERE c.slug = c2.slug
     OR c.countries      IS DISTINCT FROM COALESCE(cty.arr, '{}')
     OR c.domains        IS DISTINCT FROM COALESCE(dom.arr, '{}')
     OR c.company_types  IS DISTINCT FROM COALESCE(ctype.arr, '{}')
-    OR c.company_sizes  IS DISTINCT FROM COALESCE(csize.arr, '{}')
+    OR c.company_sizes  IS DISTINCT FROM csize_final.arr
     OR c.maturity       IS DISTINCT FROM mat.val)
 `
 
@@ -493,6 +507,11 @@ WHERE c.slug = c2.slug
 // signals plus the gov-source marker, in precedence order (government beats size).
 // NULL = unknown (an honest abstain when no signal fits). Computed once here so both
 // the SET and the IS DISTINCT FROM guard reference the same value.
+// csize_final is the employee_count-authoritative company_sizes hybrid: the company's
+// own recorded headcount (bucketed into the company_size vocabulary) is a single, more
+// accurate value than the LLM's per-posting guess, so it wins when present; otherwise
+// fall back to the distinct union of enrichment.company_size over open jobs (the csize
+// CTE). Computed once so the SET and the IS DISTINCT FROM guard share one value.
 func (q *Queries) RefreshCompanyFacets(ctx context.Context) (int64, error) {
 	result, err := q.db.Exec(ctx, refreshCompanyFacets)
 	if err != nil {

--- a/internal/db/company_size_integration_test.go
+++ b/internal/db/company_size_integration_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+// Integration tests for the employee_count-authoritative company_sizes hybrid:
+// RefreshCompanyFacets derives company_sizes from the company's stored employee_count
+// (bucketed into the company_size vocabulary) when it is known — a recorded fact more
+// accurate than the LLM's per-posting guess — and falls back to the distinct union of
+// enrichment.company_size over open jobs otherwise. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestRefreshCompanySizesFromHeadcount(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, "TRUNCATE companies, jobs RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	// employee_count known → authoritative bucket, overriding the noisy LLM union.
+	insertCompany(t, pool, "hc", "Headcount Co")
+	setCompanySignals(t, pool, "hc", "", 320, 0, nil)
+	insertJobWithFacets(t, pool, "hc:1", "hc", []string{}, []string{}, `{"company_size":"11-50"}`)
+	insertJobWithFacets(t, pool, "hc:2", "hc", []string{}, []string{}, `{"company_size":"51-200"}`)
+	// no employee_count → fall back to the enrichment union.
+	insertCompany(t, pool, "nohc", "No Headcount Co")
+	insertJobWithFacets(t, pool, "nohc:1", "nohc", []string{}, []string{}, `{"company_size":"11-50"}`)
+	// tiny headcount, no jobs → still gets the bucket (a company fact).
+	insertCompany(t, pool, "tiny", "Tiny Co")
+	setCompanySignals(t, pool, "tiny", "", 5, 0, nil)
+	// headcount but zero open jobs → bucket, not empty.
+	insertCompany(t, pool, "hcnojobs", "Headcount No Jobs")
+	setCompanySignals(t, pool, "hcnojobs", "", 800, 0, nil)
+
+	if _, err := q.RefreshCompanyFacets(ctx); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	cases := []struct {
+		slug string
+		want []string
+	}{
+		{"hc", []string{"201-500"}},       // bucket wins over the {11-50,51-200} union
+		{"nohc", []string{"11-50"}},       // fallback to enrichment union
+		{"tiny", []string{"1-10"}},        // <=10
+		{"hcnojobs", []string{"501-1000"}}, // bucket even with no jobs
+	}
+	for _, c := range cases {
+		got := companyTextArray(t, pool, c.slug, "company_sizes")
+		if !slices.Equal(got, c.want) {
+			t.Errorf("%s company_sizes = %v, want %v", c.slug, got, c.want)
+		}
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -618,6 +618,11 @@ type Querier interface {
 	// signals plus the gov-source marker, in precedence order (government beats size).
 	// NULL = unknown (an honest abstain when no signal fits). Computed once here so both
 	// the SET and the IS DISTINCT FROM guard reference the same value.
+	// csize_final is the employee_count-authoritative company_sizes hybrid: the company's
+	// own recorded headcount (bucketed into the company_size vocabulary) is a single, more
+	// accurate value than the LLM's per-posting guess, so it wins when present; otherwise
+	// fall back to the distinct union of enrichment.company_size over open jobs (the csize
+	// CTE). Computed once so the SET and the IS DISTINCT FROM guard share one value.
 	RefreshCompanyFacets(ctx context.Context) (int64, error)
 	// Release the lease on a subscription's claimed jobs without counting an attempt,
 	// so a soft-skipped delivery (e.g. Telegram not yet linked) is retried promptly on

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -275,6 +275,25 @@ mat AS (
            END AS val
     FROM companies co
     LEFT JOIN gov g ON g.company_slug = co.slug
+),
+-- csize_final is the employee_count-authoritative company_sizes hybrid: the company's
+-- own recorded headcount (bucketed into the company_size vocabulary) is a single, more
+-- accurate value than the LLM's per-posting guess, so it wins when present; otherwise
+-- fall back to the distinct union of enrichment.company_size over open jobs (the csize
+-- CTE). Computed once so the SET and the IS DISTINCT FROM guard share one value.
+csize_final AS (
+    SELECT co.slug AS company_slug,
+           CASE
+               WHEN co.employee_count IS NULL   THEN COALESCE(cs.arr, '{}')
+               WHEN co.employee_count <= 10     THEN ARRAY['1-10']
+               WHEN co.employee_count <= 50     THEN ARRAY['11-50']
+               WHEN co.employee_count <= 200    THEN ARRAY['51-200']
+               WHEN co.employee_count <= 500    THEN ARRAY['201-500']
+               WHEN co.employee_count <= 1000   THEN ARRAY['501-1000']
+               ELSE ARRAY['1000+']
+           END AS arr
+    FROM companies co
+    LEFT JOIN csize cs ON cs.company_slug = co.slug
 )
 UPDATE companies c
 SET job_count      = COALESCE(counts.cnt, 0),
@@ -283,7 +302,7 @@ SET job_count      = COALESCE(counts.cnt, 0),
     countries      = COALESCE(cty.arr, '{}'),
     domains        = COALESCE(dom.arr, '{}'),
     company_types  = COALESCE(ctype.arr, '{}'),
-    company_sizes  = COALESCE(csize.arr, '{}'),
+    company_sizes  = csize_final.arr,
     maturity       = mat.val
 FROM companies c2
 LEFT JOIN counts      ON counts.company_slug     = c2.slug
@@ -292,7 +311,7 @@ LEFT JOIN remote_reg  ON remote_reg.company_slug = c2.slug
 LEFT JOIN cty         ON cty.company_slug        = c2.slug
 LEFT JOIN dom         ON dom.company_slug        = c2.slug
 LEFT JOIN ctype       ON ctype.company_slug      = c2.slug
-LEFT JOIN csize       ON csize.company_slug      = c2.slug
+LEFT JOIN csize_final ON csize_final.company_slug = c2.slug
 LEFT JOIN mat         ON mat.company_slug        = c2.slug
 WHERE c.slug = c2.slug
   AND (c.job_count      IS DISTINCT FROM COALESCE(counts.cnt, 0)
@@ -301,7 +320,7 @@ WHERE c.slug = c2.slug
     OR c.countries      IS DISTINCT FROM COALESCE(cty.arr, '{}')
     OR c.domains        IS DISTINCT FROM COALESCE(dom.arr, '{}')
     OR c.company_types  IS DISTINCT FROM COALESCE(ctype.arr, '{}')
-    OR c.company_sizes  IS DISTINCT FROM COALESCE(csize.arr, '{}')
+    OR c.company_sizes  IS DISTINCT FROM csize_final.arr
     OR c.maturity       IS DISTINCT FROM mat.val);
 
 -- name: CompanyJobCountBySlug :one

--- a/openspec/changes/company-size-from-headcount/.openspec.yaml
+++ b/openspec/changes/company-size-from-headcount/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/company-size-from-headcount/design.md
+++ b/openspec/changes/company-size-from-headcount/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`RefreshCompanyFacets` (`internal/db/queries/companies.sql`) aggregates
+`company_sizes` as the distinct union of `enrichment.company_size` over a
+company's open jobs (the `csize` CTE). A prod spike found the company's stored
+`employee_count` is a more accurate size signal than the LLM guess (34% coverage,
+and where both exist the deterministic bucket is the more trustworthy — a recorded
+fact vs a per-posting inference). The recompute already reads company columns and
+runs under an `IS DISTINCT FROM` change-guard, so this is a one-CTE change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `company_sizes` = `employee_count` bucket when known, else the current
+  enrichment union — a dict-then-LLM hybrid, in place, more accurate.
+- Zero new column/field/filter/frontend; reuse the recompute + guard.
+
+**Non-Goals:**
+- A separate size field or a new filter (the `company_size` facet/param/pill are
+  unchanged).
+- Changing the `company_size` *vocabulary* or the per-job `enrichment.company_size`
+  (still produced and still the fallback source).
+
+## Decisions
+
+- **Compute the final `company_sizes` in a CTE** (mirroring the `mat` CTE added by
+  the maturity change) so both the `SET` and the `IS DISTINCT FROM` guard reference
+  one value, no `CASE` duplication:
+  ```
+  csize_final AS (
+    SELECT co.slug AS company_slug,
+      CASE WHEN co.employee_count IS NULL THEN COALESCE(cs.arr, '{}')
+           WHEN co.employee_count <= 10   THEN ARRAY['1-10']
+           WHEN co.employee_count <= 50   THEN ARRAY['11-50']
+           WHEN co.employee_count <= 200  THEN ARRAY['51-200']
+           WHEN co.employee_count <= 500  THEN ARRAY['201-500']
+           WHEN co.employee_count <= 1000 THEN ARRAY['501-1000']
+           ELSE ARRAY['1000+'] END AS arr
+    FROM companies co LEFT JOIN csize cs ON cs.company_slug = co.slug
+  )
+  ```
+  Then `SET company_sizes = csize_final.arr`, guard
+  `c.company_sizes IS DISTINCT FROM csize_final.arr`, and `LEFT JOIN csize_final`.
+- **Single-element array.** The `company_sizes` filter is array-overlap (`&&`), so
+  a one-bucket array `{201-500}` filters correctly with no filter/API change.
+- **Backfill = recompute.** No migration; one `cmd/recount-companies` run
+  rematerializes `company_sizes` from the better source.
+
+## Risks / Trade-offs
+
+- **Existing values change.** Companies with an `employee_count` may see their
+  `company_sizes` shift from a noisy multi-value LLM aggregation to the single
+  authoritative bucket. That is the intended improvement, but it is a visible facet
+  change — call it out in the changelog if announced.
+- **Bucket boundary vs the LLM's brackets.** The bucket edges match the existing
+  `company_size` vocabulary exactly, so a headcount of 200 maps to `51-200` (not
+  `201-500`) — consistent with how the LLM brackets are labelled.
+- **`employee_count` staleness.** It is only as fresh as the last company-info /
+  YC-directory enrichment; an outdated headcount yields an outdated bucket. Same
+  trust model as every other use of `employee_count`; acceptable.

--- a/openspec/changes/company-size-from-headcount/proposal.md
+++ b/openspec/changes/company-size-from-headcount/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The company-size facet (`companies.company_sizes`) is aggregated from the LLM's
+per-job `enrichment.company_size` guess. A prod spike showed the company's own
+stored `employee_count` (from YC-directory / company-info enrichment) is a **more
+accurate** size signal than the LLM guess — the LLM infers headcount from a single
+posting, while `employee_count` is a recorded fact — and it covers ~34% of the
+catalogue. We already store `employee_count`; we're just not using it for the size
+facet.
+
+## What Changes
+
+- Make `companies.company_sizes` a **dict-then-LLM hybrid** (the same shape as the
+  geography facets): when the company has an `employee_count`, the facet is the
+  single authoritative size bucket derived from it; when it does not, the facet
+  falls back to the existing distinct union of `enrichment.company_size` over the
+  company's open jobs (unchanged behavior).
+- The bucketing follows the existing `company_size` vocabulary
+  (`1-10` … `1000+`). This is computed in the existing `RefreshCompanyFacets`
+  recompute (pure SQL `CASE`), under the same `IS DISTINCT FROM` change-guard.
+- **No new column, filter, API field, or frontend change** — the `company_sizes`
+  facet, its `company_size` filter param, and the FilterModal pill are all
+  unchanged; only the *source* of the facet's values becomes more accurate where
+  `employee_count` is known.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `companies`: the "Companies carry derived facet arrays" requirement changes the
+  derivation of `company_sizes` from a pure enrichment union to an
+  `employee_count`-authoritative bucket with the enrichment union as fallback.
+
+## Impact
+
+- **DB layer:** `internal/db/queries/companies.sql` — in `RefreshCompanyFacets`,
+  derive `company_sizes` from `employee_count` when present (bucketed), else the
+  current `csize` union. Regenerate with `make sqlc` (query-string change only; no
+  schema/model change).
+- **No migration, no new field, no handler/frontend/reindex change.**
+- **Backfill:** one `cmd/recount-companies` run after deploy rematerializes every
+  company's `company_sizes` from the more accurate source.
+- **Observable effect:** companies with a known `employee_count` get a single,
+  accurate size bucket (replacing a possibly-noisy multi-value LLM aggregation);
+  companies without one are unchanged.

--- a/openspec/changes/company-size-from-headcount/specs/companies/spec.md
+++ b/openspec/changes/company-size-from-headcount/specs/companies/spec.md
@@ -1,0 +1,84 @@
+# companies
+
+## MODIFIED Requirements
+
+### Requirement: Companies carry derived facet arrays aggregated from their open jobs
+
+The system SHALL store, on each `companies` row, a set of denormalized facet
+arrays derived from the company's **open** jobs (`closed_at IS NULL`):
+`regions`, `countries`, `domains`, `company_types`, `company_sizes`, and
+`remote_regions` (each a `TEXT[]`). Each array SHALL be the **distinct union** of
+the corresponding value across the company's open jobs, except `company_sizes`
+which is an `employee_count`-authoritative hybrid (below):
+
+- `regions` and `countries` from the top-level `jobs.regions` / `jobs.countries`
+  columns.
+- `remote_regions` from `jobs.regions` but restricted to jobs with
+  `work_mode = 'remote'` — the regions the company hires remotely in, always a
+  subset of `regions`.
+- `domains`, `company_types` from the job's `enrichment` payload (`domains`
+  array, `company_type` scalar); an unenriched or value-less job contributes
+  nothing, so these arrays are sparse until jobs are enriched.
+- `company_sizes` is a **dict-then-LLM hybrid**: when the company has a known
+  `companies.employee_count`, the array SHALL be the single authoritative size
+  bucket derived from it (bucketed into the `company_size` vocabulary
+  `1-10`/`11-50`/`51-200`/`201-500`/`501-1000`/`1000+`); when `employee_count` is
+  absent, it SHALL fall back to the distinct union of `enrichment.company_size`
+  over the company's open jobs. The `employee_count` value is a recorded company
+  fact and is more accurate than the LLM's per-posting guess, so it wins when
+  present.
+
+A company with no open jobs SHALL have every facet array empty (`'{}'`), except
+that `company_sizes` still reflects the company's `employee_count` bucket when one
+is stored (it is a company fact, independent of open jobs). The arrays SHALL be
+maintained by the same periodic recompute that maintains `job_count` (see the
+recompute requirement), not by a synchronous write on the ingest/close paths, so
+they are eventually consistent with `jobs`.
+
+#### Scenario: Region and country unions are derived from open jobs
+
+- **WHEN** the recompute runs for a company whose open jobs have regions
+  `{europe}`, `{europe, asia}` and countries `{de}`, `{de, sg}`
+- **THEN** that company's `regions` is `{asia, europe}` and `countries` is
+  `{de, sg}` (distinct union, closed jobs excluded)
+
+#### Scenario: remote_regions unions only the remote jobs' regions
+
+- **WHEN** the recompute runs for a company whose open jobs are a `remote` job in
+  `{eu}`, a `remote` job in `{apac}`, and an `onsite` job in `{north_america}`
+- **THEN** that company's `remote_regions` is `{apac, eu}` and its `regions` is
+  `{apac, eu, north_america}`
+
+#### Scenario: company_sizes uses the employee_count bucket when known
+
+- **WHEN** the recompute runs for a company with `employee_count = 320` whose open
+  jobs carry `enrichment.company_size` values `11-50` and `51-200`
+- **THEN** that company's `company_sizes` is `{201-500}` (the authoritative
+  headcount bucket), not the LLM union
+
+#### Scenario: company_sizes falls back to the enrichment union without employee_count
+
+- **WHEN** the recompute runs for a company with no `employee_count` whose open,
+  enriched jobs carry `enrichment.company_size` `11-50`
+- **THEN** that company's `company_sizes` is `{11-50}` (the enrichment union)
+
+#### Scenario: Other enrichment facets are derived from the enrichment payload
+
+- **WHEN** the recompute runs for a company whose open, enriched jobs carry
+  `enrichment.domains` `{fintech}` and `{fintech, ecommerce}` and
+  `enrichment.company_type` `startup` and `product`
+- **THEN** that company's `domains` is `{ecommerce, fintech}` and `company_types`
+  is `{product, startup}`
+
+#### Scenario: Unenriched jobs contribute no enrichment facets
+
+- **WHEN** a company's only open job has never been enriched (empty `enrichment`)
+  and the company has no `employee_count`
+- **THEN** that company's `domains`, `company_types`, and `company_sizes` are all
+  empty, while `regions`/`countries` still reflect the job's geography columns
+
+#### Scenario: Closing all jobs empties the job-derived facet arrays
+
+- **WHEN** every open job of a company (with no `employee_count`) is closed and the
+  recompute runs again
+- **THEN** that company's facet arrays are all set to empty (`'{}'`)

--- a/openspec/changes/company-size-from-headcount/tasks.md
+++ b/openspec/changes/company-size-from-headcount/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## 1. RefreshCompanyFacets — employee_count-authoritative company_sizes (SQL)
+
+- [x] 1.1 **RED** — Add an integration test (`//go:build integration`,
+  testcontainers) in `internal/db` seeding: a company with `employee_count = 320`
+  plus open jobs whose `enrichment.company_size` is `11-50`/`51-200` (expect
+  `company_sizes = {201-500}`, the bucket, not the LLM union); a company with no
+  `employee_count` and an enriched job `11-50` (expect `{11-50}`, fallback); a
+  company with `employee_count = 5` (expect `{1-10}`); a company with
+  `employee_count` but zero open jobs (expect the bucket, not empty). Call
+  `RefreshCompanyFacets` and assert. Confirm it fails (current union ignores
+  `employee_count`).
+- [x] 1.2 **GREEN** — Add the `csize_final` CTE to `RefreshCompanyFacets` in
+  `internal/db/queries/companies.sql` (employee_count bucket, else `csize` union),
+  point `company_sizes` SET + the `IS DISTINCT FROM` guard at `csize_final.arr`,
+  and `LEFT JOIN csize_final`. `make sqlc`.
+- [x] 1.3 Confirm the existing `company_sizes` facet tests still pass (the
+  no-`employee_count` companies keep the union), and the idempotency guard still
+  short-circuits an unchanged company.
+
+## 2. Verify + backfill
+
+- [x] 2.1 `go build ./... && go vet ./...` and
+  `go test -tags=integration ./internal/db/` green.
+- [x] 2.2 Document the deploy step: deploy (no migration needed), then run
+  `cmd/recount-companies` once to rematerialize `company_sizes` from the more
+  accurate source.


### PR DESCRIPTION
## Summary
Makes `companies.company_sizes` an **employee_count-authoritative hybrid**: when a
company has a recorded headcount, the facet is the single accurate size bucket
derived from it (a stored fact beats the LLM's per-posting `enrichment.company_size`
guess — a spike found it more accurate, ~34% coverage); otherwise it falls back to
the existing distinct union over open jobs. Same dict-then-LLM shape as the geography
facets.

Pure SQL in `RefreshCompanyFacets` (a new `csize_final` CTE under the existing
`IS DISTINCT FROM` guard). **No migration, no new column/field/filter, no frontend
change** — only the *source* of the existing `company_sizes` facet gets more accurate.

## Deploy
No migration. Deploy, then run `cmd/recount-companies` once to rematerialize
`company_sizes` from the better source.

## Test Plan
- [x] `go build/vet ./...`, unit tests
- [x] `go test -tags=integration ./internal/db/` — new `TestRefreshCompanySizesFromHeadcount` (bucket wins over LLM union; fallback without headcount; bucket even with zero jobs) + full suite (190s) green, no sibling regression
- [x] code-review: removed a dead `LEFT JOIN csize` the rewire orphaned

OpenSpec: `company-size-from-headcount`