### PR TITLE
feat: positive tech-title detector (symmetric is_tech)

### DIFF
--- a/cmd/backfill-derive/main_test.go
+++ b/cmd/backfill-derive/main_test.go
@@ -103,6 +103,7 @@ func TestBackfill_IsIdempotent(t *testing.T) {
 	job.Countries, job.Regions, job.WorkMode = d.Countries, d.Regions, d.WorkMode
 	job.Cities = d.Cities
 	job.Skills, job.Seniority, job.Category = d.Skills, d.Seniority, d.Category
+	job.IsTech = d.IsTech
 	job.PostingLanguage, job.EmploymentType = d.PostingLanguage, d.EmploymentType
 	job.EducationLevel, job.ExperienceYearsMin = d.EducationLevel, d.ExperienceYearsMin
 

--- a/internal/classify/tech.go
+++ b/internal/classify/tech.go
@@ -1,0 +1,76 @@
+package classify
+
+import (
+	"strings"
+
+	"github.com/strelov1/freehire/internal/wordmatch"
+)
+
+// techTitleTerms is a curated set of confidently technical (software/IT) role
+// terms found in job titles, the positive counterpart to nonTechTitleTerms. It
+// exists because is_tech's `true` was otherwise set only by a recognized tech
+// CATEGORY, so generic software titles that resolve no sub-discipline ("Software
+// Engineer", "Web3 Developer", "System Administrator") fell into `unknown`,
+// undercounting tech.
+//
+// Same doctrine as the rest of classify: whole-word match, never guess. The
+// governing rule is the "engineer"/"developer" trap: prod titles show bare
+// "engineer" is dominated by NON-software roles (mechanical, manufacturing,
+// civil, drainage, optical, project) and bare "developer" also names non-tech
+// roles (business/real-estate developer). So every term here is SOFTWARE-ANCHORED
+// — no bare "engineer"/"developer"/"analyst"/"architect"/"administrator" — and a
+// non-software "…Engineer" stays `unknown` rather than being mislabelled tech.
+var techTitleTerms = []string{
+	// Software engineer forms (never bare "engineer")
+	"software engineer", "software development engineer", "devops engineer",
+	"site reliability engineer", "platform engineer",
+	"backend engineer", "back-end engineer", "frontend engineer", "front-end engineer",
+	"fullstack engineer", "full stack engineer", "full-stack engineer",
+	"data engineer", "machine learning engineer", "ml engineer", "ai engineer",
+	"cloud engineer", "security engineer", "qa engineer", "test engineer",
+	"network engineer", "mobile engineer", "web engineer", "firmware engineer",
+	"embedded engineer", "infrastructure engineer", "systems software engineer",
+	// Developer forms (never bare "developer")
+	"software developer", "web developer", "backend developer", "back-end developer",
+	"frontend developer", "front-end developer", "fullstack developer",
+	"full stack developer", "full-stack developer", "mobile developer",
+	"app developer", "application developer", "game developer", "salesforce developer",
+	"sharepoint developer", "web3 developer", "blockchain developer",
+	"smart contract developer", "ios developer", "android developer",
+	"python developer", "java developer", "javascript developer", "typescript developer",
+	"golang developer", "go developer", ".net developer", "dotnet developer",
+	"php developer", "ruby developer", "rails developer", "c# developer",
+	"c++ developer", "node developer", "nodejs developer", "node.js developer",
+	"react developer", "react native developer", "angular developer", "vue developer",
+	"wordpress developer", "drupal developer", "magento developer", "shopify developer",
+	"database developer", "etl developer", "bi developer", "power bi developer",
+	"rpa developer", "erp developer", "sap developer", "oracle developer", "abap developer",
+	// Administration / operations (never bare "administrator")
+	"system administrator", "systems administrator", "sysadmin", "network administrator",
+	"database administrator", "linux administrator", "windows administrator",
+	"it administrator", "devsecops",
+	// Architects (never bare "architect")
+	"software architect", "solutions architect", "cloud architect", "data architect",
+	"security architect", "enterprise architect", "technical architect",
+	// Data / ML / security specialisms
+	"data scientist", "machine learning", "deep learning", "computer vision engineer",
+	"nlp engineer", "penetration tester", "pentester", "sdet", "software tester",
+	// Unambiguous single words
+	"programmer", "sre", "devops",
+}
+
+// IsTech reports whether a job title states a confidently technical (software/IT)
+// role, matching any techTitleTerms term on word boundaries. It never guesses: a
+// title it cannot confidently place as technical returns false. It resolves ONLY
+// technical roles — a non-software "…Engineer" (mechanical, drainage, …) yields
+// false — so it can feed the is_tech derivation as an additional `true` source
+// without risking a non-tech job being mislabelled.
+func IsTech(title string) bool {
+	lower := strings.ToLower(title)
+	for _, term := range techTitleTerms {
+		if wordmatch.Contains(lower, term, wordmatch.UnicodeBoundary) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/classify/tech_test.go
+++ b/internal/classify/tech_test.go
@@ -1,0 +1,47 @@
+package classify
+
+import "testing"
+
+func TestIsTech(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		// Positives — confident software/IT titles (from the prod unknown bucket).
+		{"software engineer", "Senior Software Engineer", true},
+		{"software engineer II", "Senior Software Engineer II", true},
+		{"web3 developer", "Senior Web3 Developer", true},
+		{"salesforce developer", "Senior Salesforce Developer", true},
+		{"backend developer", "Backend Developer", true},
+		{"full stack developer", "Full Stack Developer", true},
+		{"devops engineer", "DevOps Engineer", true},
+		{"sre", "Site Reliability Engineer", true},
+		{"data scientist", "Lead Data Scientist", true},
+		{"ml engineer", "Machine Learning Engineer", true},
+		{"system administrator", "Senior System Administrator", true},
+		{"it administrator", "Senior IT Administrator für Business Software", true},
+		{"python developer", "Python Developer (Remote)", true},
+		{"programmer", "COBOL Programmer", true},
+		{"qa engineer", "QA Engineer", true},
+
+		// Trap negatives — non-software engineering / non-tech that carry "engineer"
+		// or other shared words. These MUST stay unflagged (bias: leave in unknown).
+		{"mechanical engineer", "Senior Mechanical Engineer", false},
+		{"manufacturing engineer", "Senior Manufacturing Engineer", false},
+		{"project engineer", "Sr. Project Engineer", false},
+		{"drainage engineer", "Senior Professional Engineer - Drainage", false},
+		{"optical engineer", "Senior Optical Characterization Engineer", false},
+		{"sales engineer", "Sales Engineer", false},
+		{"geologist", "Senior Geologist", false},
+		{"business developer", "Business Developer", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTech(tt.title); got != tt.want {
+				t.Errorf("IsTech(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/jobderive/istech_test.go
+++ b/internal/jobderive/istech_test.go
@@ -33,6 +33,16 @@ func TestDerive_IsTech(t *testing.T) {
 			in:   Input{Title: "Backend Engineer, Nurse Scheduling Platform"},
 			want: boolp(true),
 		},
+		{
+			name: "detector-only tech title (no category) → true",
+			in:   Input{Title: "COBOL Programmer"},
+			want: boolp(true),
+		},
+		{
+			name: "non-software engineer stays unknown → nil",
+			in:   Input{Title: "Senior Mechanical Engineer"},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/jobderive/jobderive.go
+++ b/internal/jobderive/jobderive.go
@@ -149,15 +149,16 @@ func Derive(in Input) Derived {
 }
 
 // deriveIsTech computes the tri-state is_tech signal from the already-resolved
-// category and the raw title. Technical evidence wins: a recognized technical
-// category yields true first; otherwise a known non-technical category or a
-// confident non-tech title yields false; otherwise the signal is unknown (nil),
-// never coerced, so the unclassified mass stays measurable. Because the category
-// derivation checks the tech title dictionary before anything non-technical, a
-// title carrying both a tech role and a non-tech noun ("Backend Engineer, Nurse
-// Scheduling") already resolves a tech category and never reaches IsNonTech.
+// category and the raw title. Technical evidence wins and is checked first: a
+// recognized technical category OR a confident software/IT title (classify.IsTech)
+// yields true; otherwise a known non-technical category or a confident non-tech
+// title yields false; otherwise the signal is unknown (nil), never coerced, so the
+// unclassified mass stays measurable. The tech title detector is the symmetric
+// counterpart to IsNonTech — it rescues generic software titles ("Software
+// Engineer", "COBOL Programmer") that resolve no sub-category. A non-software
+// "…Engineer" (mechanical, drainage) matches neither detector and stays unknown.
 func deriveIsTech(category, title string) *bool {
-	if slices.Contains(enrich.TechCategories, category) {
+	if slices.Contains(enrich.TechCategories, category) || classify.IsTech(title) {
 		t := true
 		return &t
 	}

--- a/openspec/changes/add-positive-tech-detector/tasks.md
+++ b/openspec/changes/add-positive-tech-detector/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Tech title detector
 
-- [ ] 1.1 Add `techTitleTerms` (confident software/IT role terms, whole-word) to `internal/classify/dictionaries.go` (or nontech.go's sibling)
-- [ ] 1.2 Add `classify.IsTech(title string) bool` with unit tests: software/IT titles → true; trap negatives (Mechanical/Sales/Project/Manufacturing Engineer, Geologist, bare "engineer"/"analyst") → false; word-boundary
+- [x] 1.1 Add `techTitleTerms` (confident software/IT role terms, whole-word) to `internal/classify/dictionaries.go` (or nontech.go's sibling)
+- [x] 1.2 Add `classify.IsTech(title string) bool` with unit tests: software/IT titles → true; trap negatives (Mechanical/Sales/Project/Manufacturing Engineer, Geologist, bare "engineer"/"analyst") → false; word-boundary
 
 ## 2. Symmetric derivation
 
-- [ ] 2.1 Fold `IsTech(title)` into `jobderive.deriveIsTech`: tech category OR `IsTech(title)` → true; else non-tech → false; else nil
-- [ ] 2.2 Unit tests: detector-only tech title → true; tech-first precedence; Mechanical Engineer stays nil; existing non-tech/unknown cases unchanged
+- [x] 2.1 Fold `IsTech(title)` into `jobderive.deriveIsTech`: tech category OR `IsTech(title)` → true; else non-tech → false; else nil
+- [x] 2.2 Unit tests: detector-only tech title → true; tech-first precedence; Mechanical Engineer stays nil; existing non-tech/unknown cases unchanged
 
 ## 3. Verify + ship
 
-- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` green
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` green
 - [ ] 3.2 Deploy, run `cmd/backfill-derive` + reindex, measure new true/false/null split on prod


### PR DESCRIPTION
## Summary

Fixes the `is_tech` asymmetry that undercounted tech. Previously `is_tech=true` was set only by a recognized tech **category**, so generic software titles ("Software Engineer", "Web3 Developer", "COBOL Programmer", "System Administrator") that resolve no sub-category fell into `unknown`. On prod that left `tech` at 294K while ~59.5% sat `unknown` — ≥170K of it obviously-tech by title.

- Adds `classify.IsTech(title)` — a curated whole-word **software/IT-anchored** dictionary (software/web/backend/... developer, devops, sre, data scientist, ml engineer, system administrator, `<lang>` developer, …). Deliberately excludes bare "engineer"/"developer"/"analyst"/"architect"/"administrator": prod titles show bare "engineer" is dominated by non-software roles (Mechanical/Manufacturing/Drainage/Project Engineer, Geologist).
- Makes `jobderive.deriveIsTech` symmetric: `true` when a tech category OR `IsTech(title)`; else `false` for non-tech; else `nil`. Tech evidence still wins.

No schema/wire/facet/UI change — `is_tech` column, jobview field, Meili facet, and the filter are untouched; only more jobs resolve to `tech`.

OpenSpec change: `add-positive-tech-detector` (MODIFIES `tech-classification`).

## Test Plan
- [x] `go build/vet/test ./...` (73 packages green)
- [x] Unit: `IsTech` positives + trap negatives (Mechanical/Manufacturing/Project/Sales Engineer, Geologist, bare engineer → not tech); derivation detector-only-tech → true, Mechanical Engineer stays nil, existing cases unchanged
- [x] Fixed the backfill idempotency fixture to seed `is_tech` (was passing by accident)

## Deploy
1. Deploy new binary.
2. `cmd/backfill-derive` + reindex (backfill's id-cursor stays ahead of a concurrent reindex → captures final values).
3. Measure: expect `tech` to roughly double, `unknown` to shrink.