### PR TITLE
feat(sources): capture SmartRecruiters experienceLevel as structured seniority

### DIFF
--- a/internal/sources/smartrecruiters.go
+++ b/internal/sources/smartrecruiters.go
@@ -26,6 +26,26 @@ func NewSmartRecruiters(c JSONGetter) Source { return smartRecruiters{http: c} }
 
 func (smartRecruiters) Provider() string { return "smartrecruiters" }
 
+// smartRecruitersSeniorityMap maps the SmartRecruiters experienceLevel enum onto
+// freehire's seniority vocabulary. Values not in the map (notably "not_applicable",
+// the plurality, plus any unknown/empty id) yield "" so the Job carries no structured
+// seniority and the pipeline's title dictionary decides — structured signal only,
+// never a guess (the sources.Job.Seniority contract).
+var smartRecruitersSeniorityMap = map[string]string{
+	"internship":       "intern",
+	"entry_level":      "junior",
+	"associate":        "middle",
+	"mid_senior_level": "senior",
+	"director":         "lead",
+	"executive":        "c_level",
+}
+
+// smartRecruitersSeniority maps an experienceLevel id to a freehire seniority, or ""
+// when the level is unset/ambiguous/unknown.
+func smartRecruitersSeniority(experienceLevelID string) string {
+	return smartRecruitersSeniorityMap[experienceLevelID]
+}
+
 // srSection is one HTML section of a posting's job ad (the description lives here).
 type srSection struct {
 	Text string `json:"text"`
@@ -88,8 +108,11 @@ func (s smartRecruiters) detail(ctx context.Context, e CompanyEntry, p smartRecr
 	url := fmt.Sprintf("%s/%s/postings/%s", smartRecruitersBaseURL, e.Board, p.ID)
 
 	var d struct {
-		PostingURL string `json:"postingUrl"`
-		JobAd      struct {
+		PostingURL      string `json:"postingUrl"`
+		ExperienceLevel struct {
+			ID string `json:"id"`
+		} `json:"experienceLevel"`
+		JobAd struct {
 			Sections struct {
 				JobDescription        srSection `json:"jobDescription"`
 				Qualifications        srSection `json:"qualifications"`
@@ -115,5 +138,8 @@ func (s smartRecruiters) detail(ctx context.Context, e CompanyEntry, p smartRecr
 		Remote:      p.Location.Remote,
 		WorkMode:    workModeFromRemote(p.Location.Remote),
 		PostedAt:    parseRFC3339(p.ReleasedDate),
+		// experienceLevel is the employer's own structured seniority; the pipeline gives it
+		// precedence over the title dictionary, so it fills the grade for title-silent roles.
+		Seniority: smartRecruitersSeniority(d.ExperienceLevel.ID),
 	}, true
 }

--- a/internal/sources/smartrecruiters_test.go
+++ b/internal/sources/smartrecruiters_test.go
@@ -86,6 +86,7 @@ func detailBody(id, title string) string {
 	return fmt.Sprintf(`{
 		"id": %q,
 		"postingUrl": "https://jobs.smartrecruiters.com/Acme/%s",
+		"experienceLevel": {"id": "mid_senior_level", "label": "Mid-Senior Level"},
 		"jobAd": {"sections": {
 			"companyDescription": {"title": "Company", "text": "<p>boilerplate</p>"},
 			"jobDescription": {"title": "Job", "text": "<p>%s do the job.</p>"},
@@ -98,6 +99,28 @@ func detailBody(id, title string) string {
 func TestSmartRecruitersProvider(t *testing.T) {
 	if got := NewSmartRecruiters(nil).Provider(); got != "smartrecruiters" {
 		t.Errorf("Provider() = %q, want %q", got, "smartrecruiters")
+	}
+}
+
+// The SmartRecruiters experienceLevel enum maps onto freehire's seniority vocabulary.
+// Ambiguous/unset values (not_applicable, unknown) map to "" so the title dictionary
+// decides instead — structured signal only, never a guess.
+func TestSmartRecruitersSeniority(t *testing.T) {
+	cases := map[string]string{
+		"internship":       "intern",
+		"entry_level":      "junior",
+		"associate":        "middle",
+		"mid_senior_level": "senior",
+		"director":         "lead",
+		"executive":        "c_level",
+		"not_applicable":   "",
+		"":                 "",
+		"something_new":    "",
+	}
+	for in, want := range cases {
+		if got := smartRecruitersSeniority(in); got != want {
+			t.Errorf("smartRecruitersSeniority(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 
@@ -154,6 +177,9 @@ func TestSmartRecruitersFetchPaginatesAndFetchesDetail(t *testing.T) {
 	}
 	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2024 {
 		t.Errorf("PostedAt = %v, want parsed releasedDate (2024)", j.PostedAt)
+	}
+	if j.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior (mapped from experienceLevel mid_senior_level)", j.Seniority)
 	}
 }
 


### PR DESCRIPTION
## Summary
The SmartRecruiters posting detail carries an `experienceLevel` enum (Entry level,
Mid-Senior, Director, …) that the adapter already fetched — for the description — but
threw away. This maps it onto freehire's seniority vocabulary and emits it in the Job's
structured `Seniority` slot.

The pipeline (`jobderive`) already gives a **structured source signal precedence over
the title dictionary**, so this fills the seniority grade for the many title-silent
roles across ~306K open SmartRecruiters jobs — more accurate than guessing from the
title.

### First slice of Track B
A spike found top ATS sources drop structured fields we then re-derive. This is the
cheapest, highest-coverage slice: `Seniority`'s slot already exists (no schema change).
Salary was deliberately dropped (structured salary is only ~8% populated) and
`employment_type` (92%, but needs a new slot) is a possible follow-up.

### Mapping (conservative)
`internship/entry_level/associate/mid_senior_level/director/executive` →
`intern/junior/middle/senior/lead/c_level`. `not_applicable` (the plurality, ~35%) and
any unknown id map to empty, leaving the title dictionary to decide — structured signal
only, never a guess.

## Deploy
No migration. Takes effect as SmartRecruiters boards are re-crawled by the ingest cron
(new/changed jobs pick up the seniority; the whole set fills over crawl cycles).

## Test Plan
- [x] `go test ./internal/sources/` — new `TestSmartRecruitersSeniority` (mapping table incl. abstain cases) + the fetch test asserts the emitted `Seniority`
- [x] `go build/vet ./...`, full unit tests green