### PR TITLE
fix(web): self-host NoteEditor toolbar icons (drop FontAwesome CDN)

### DIFF
--- a/web/src/lib/components/NoteEditor.svelte
+++ b/web/src/lib/components/NoteEditor.svelte
@@ -1,3 +1,23 @@
+<script module lang="ts">
+  // Self-hosted toolbar icons (Lucide, MIT) as inline SVG. EasyMDE otherwise pulls
+  // FontAwesome from a third-party CDN for its toolbar glyphs — the only external
+  // asset in an otherwise self-hosted frontend, and blank buttons offline or under a
+  // future font-src CSP (issue #632). `stroke="currentColor"` lets each glyph inherit
+  // the toolbar button's themed color, so light/dark needs no extra rule.
+  const ICON_CLASS = 'ffh-toolbar-icon';
+  const svgIcon = (paths: string) =>
+    `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${paths}</svg>`;
+  const icons = {
+    bold: svgIcon('<path d="M6 12h9a4 4 0 0 1 0 8H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h7a4 4 0 0 1 0 8"/>'),
+    italic: svgIcon('<line x1="19" x2="10" y1="4" y2="4"/><line x1="14" x2="5" y1="20" y2="20"/><line x1="15" x2="9" y1="4" y2="20"/>'),
+    heading: svgIcon('<path d="M6 12h12"/><path d="M6 20V4"/><path d="M18 20V4"/>'),
+    unorderedList: svgIcon('<path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/>'),
+    orderedList: svgIcon('<path d="M11 5h10"/><path d="M11 12h10"/><path d="M11 19h10"/><path d="M4 4h1v5"/><path d="M4 9h2"/><path d="M6.5 20H3.4c0-1 2.6-1.925 2.6-3.5a1.5 1.5 0 0 0-2.6-1.02"/>'),
+    link: svgIcon('<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>'),
+    preview: svgIcon('<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/>'),
+  };
+</script>
+
 <script lang="ts">
   import { onMount } from 'svelte';
   import 'easymde/dist/easymde.min.css';
@@ -38,7 +58,21 @@
         spellChecker: false,
         status: false,
         minHeight: '120px',
-        toolbar: ['bold', 'italic', 'heading', '|', 'unordered-list', 'ordered-list', '|', 'link', 'preview'],
+        // Never fetch FontAwesome from the CDN; the buttons below carry their own icons.
+        autoDownloadFontAwesome: false,
+        // Built-in actions keep their default keyboard shortcuts (Cmd-B/I, bound to the
+        // CodeMirror keymap by action name, independent of the toolbar array).
+        toolbar: [
+          { name: 'bold', action: EasyMDECtor.toggleBold, className: ICON_CLASS, title: 'Bold', icon: icons.bold },
+          { name: 'italic', action: EasyMDECtor.toggleItalic, className: ICON_CLASS, title: 'Italic', icon: icons.italic },
+          { name: 'heading', action: EasyMDECtor.toggleHeadingSmaller, className: ICON_CLASS, title: 'Heading', icon: icons.heading },
+          '|',
+          { name: 'unordered-list', action: EasyMDECtor.toggleUnorderedList, className: ICON_CLASS, title: 'Bulleted list', icon: icons.unorderedList },
+          { name: 'ordered-list', action: EasyMDECtor.toggleOrderedList, className: ICON_CLASS, title: 'Numbered list', icon: icons.orderedList },
+          '|',
+          { name: 'link', action: EasyMDECtor.drawLink, className: ICON_CLASS, title: 'Create link', icon: icons.link },
+          { name: 'preview', action: EasyMDECtor.togglePreview, className: ICON_CLASS, title: 'Toggle preview', icon: icons.preview, noDisable: true },
+        ],
       });
       editor.codemirror.on('blur', persist);
     })();
@@ -83,6 +117,12 @@
   :global(.editor-toolbar button.active) {
     background: var(--accent);
     border-color: var(--border);
+  }
+  /* Center the inline SVG glyphs (see the icon table in the module script). */
+  :global(.editor-toolbar button.ffh-toolbar-icon) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
   :global(.editor-toolbar i.separator) {
     border-color: var(--border);


### PR DESCRIPTION
Closes #632.

## Problem

`NoteEditor.svelte` (the EasyMDE markdown notes editor) uses EasyMDE's default `autoDownloadFontAwesome`, so the 7 toolbar glyphs are fetched from a third-party **FontAwesome CDN** at runtime — the only external asset in an otherwise fully self-hosted frontend. Offline/air-gapped, or under a future `font-src`/`style-src` CSP, the toolbar buttons render blank.

## Fix (issue option B — no FontAwesome at all)

- `autoDownloadFontAwesome: false` — never reach for the CDN.
- Each toolbar button carries an **inline Lucide SVG** via EasyMDE's per-button `icon` field. `stroke="currentColor"` makes every glyph inherit the button's themed color, so light/dark needs no extra rule. Icons live in the component's `<script module>` block; Lucide is already a project dependency (paths copied from it, MIT).
- Toolbar entries move from string form to object form. Built-in **Cmd-B/Cmd-I shortcuts are preserved** — EasyMDE binds them to the CodeMirror keymap by action name, independent of the toolbar array.

No new dependency, no font file; net one component touched.

## Verification (local)

- `npm run check` ✅ 0 errors
- `npm run build` ✅
- `npm run test` ✅ 220/220
- Visual (headless Chrome, throwaway route): all 7 icons render as Lucide glyphs in the themed color; **zero FontAwesome references** in the rendered DOM (no injected `<link>`), confirming the CDN is no longer contacted.

_(local screenshot: B / I / H | list / ordered-list | link / preview, all rendered, no blanks)_