### PR TITLE
feat(sources): capture structured employment_type from Lever, Ashby, Workable

### DIFF
--- a/internal/sources/ashby.go
+++ b/internal/sources/ashby.go
@@ -31,6 +31,7 @@ func (a ashby) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			PublishedAt     string `json:"publishedAt"`
 			DescriptionHTML string `json:"descriptionHtml"`
 			IsRemote        bool   `json:"isRemote"`
+			EmploymentType  string `json:"employmentType"`
 		} `json:"jobs"`
 	}
 	if err := a.http.GetJSON(ctx, url, &resp); err != nil {
@@ -40,16 +41,34 @@ func (a ashby) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	jobs := make([]Job, 0, len(resp.Jobs))
 	for _, j := range resp.Jobs {
 		jobs = append(jobs, Job{
-			ExternalID:  j.ID,
-			URL:         j.JobURL,
-			Title:       j.Title,
-			Company:     e.Company,
-			Location:    j.Location,
-			Description: sanitizeHTML(j.DescriptionHTML),
-			Remote:      j.IsRemote,
-			WorkMode:    workModeFromRemote(j.IsRemote),
-			PostedAt:    parseRFC3339(j.PublishedAt),
+			ExternalID:     j.ID,
+			URL:            j.JobURL,
+			Title:          j.Title,
+			Company:        e.Company,
+			Location:       j.Location,
+			Description:    sanitizeHTML(j.DescriptionHTML),
+			Remote:         j.IsRemote,
+			WorkMode:       workModeFromRemote(j.IsRemote),
+			PostedAt:       parseRFC3339(j.PublishedAt),
+			EmploymentType: ashbyEmploymentType(j.EmploymentType),
 		})
 	}
 	return jobs, nil
+}
+
+// ashbyEmploymentType maps Ashby's employmentType enum onto the freehire vocabulary,
+// returning "" for an unknown/absent value so the description parser decides.
+func ashbyEmploymentType(t string) string {
+	switch t {
+	case "FullTime":
+		return "full_time"
+	case "PartTime":
+		return "part_time"
+	case "Contract", "Temporary":
+		return "contract"
+	case "Intern", "Internship":
+		return "internship"
+	default:
+		return ""
+	}
 }

--- a/internal/sources/employment_type_test.go
+++ b/internal/sources/employment_type_test.go
@@ -1,0 +1,55 @@
+package sources
+
+import "testing"
+
+// The per-adapter employment-type mappings translate each platform's own vocabulary
+// onto freehire's controlled values, mapping any unknown/ambiguous value to "" so the
+// pipeline's description parser decides — structured signal only, never a guess.
+
+func TestAshbyEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"FullTime": "full_time", "PartTime": "part_time",
+		"Contract": "contract", "Temporary": "contract",
+		"Intern": "internship", "Internship": "internship",
+		"": "", "Volunteer": "",
+	}
+	for in, want := range cases {
+		if got := ashbyEmploymentType(in); got != want {
+			t.Errorf("ashbyEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWorkableEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"Full-time": "full_time", "Part-time": "part_time",
+		"Contract": "contract", "Temporary": "contract",
+		"Internship": "internship",
+		"Other":      "", "": "",
+	}
+	for in, want := range cases {
+		if got := workableEmploymentType(in); got != want {
+			t.Errorf("workableEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestLeverEmploymentType(t *testing.T) {
+	// Lever's commitment is per-company free text, so the mapping matches keywords.
+	cases := map[string]string{
+		"Regular Full-Time":     "full_time",
+		"Full-Time Maintenance": "full_time",
+		"Full Time":             "full_time",
+		"Part-Time":             "part_time",
+		"Intern":                "internship",
+		"Temporary":             "contract",
+		"Contractor":            "contract",
+		"Variable Hour":         "", // ambiguous → abstain
+		"":                      "",
+	}
+	for in, want := range cases {
+		if got := leverEmploymentType(in); got != want {
+			t.Errorf("leverEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/lever.go
+++ b/internal/sources/lever.go
@@ -46,7 +46,8 @@ func (l lever) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Content string `json:"content"`
 		} `json:"lists"`
 		Categories struct {
-			Location string `json:"location"`
+			Location   string `json:"location"`
+			Commitment string `json:"commitment"`
 		} `json:"categories"`
 	}
 	if err := l.http.GetJSON(ctx, url, &postings); err != nil {
@@ -71,16 +72,37 @@ func (l lever) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		body.WriteString(p.Additional)
 
 		jobs = append(jobs, Job{
-			ExternalID:  p.ID,
-			URL:         p.HostedURL,
-			Title:       p.Text,
-			Company:     e.Company,
-			Location:    p.Categories.Location,
-			Description: sanitizeHTML(body.String()),
-			Remote:      isRemote(p.Categories.Location),
-			WorkMode:    workplaceTypeMode(p.WorkplaceType),
-			PostedAt:    parseEpochMillis(p.CreatedAt),
+			ExternalID:     p.ID,
+			URL:            p.HostedURL,
+			Title:          p.Text,
+			Company:        e.Company,
+			Location:       p.Categories.Location,
+			Description:    sanitizeHTML(body.String()),
+			Remote:         isRemote(p.Categories.Location),
+			WorkMode:       workplaceTypeMode(p.WorkplaceType),
+			PostedAt:       parseEpochMillis(p.CreatedAt),
+			EmploymentType: leverEmploymentType(p.Categories.Commitment),
 		})
 	}
 	return jobs, nil
+}
+
+// leverEmploymentType maps Lever's free-text categories.commitment (a per-company label
+// like "Regular Full-Time" or "Full-Time Maintenance") onto the freehire vocabulary via
+// keyword containment, in priority order. An unrecognized/ambiguous value (e.g. "Variable
+// Hour") maps to "" so the description parser decides — structured signal only, never a guess.
+func leverEmploymentType(commitment string) string {
+	c := strings.ToLower(commitment)
+	switch {
+	case strings.Contains(c, "intern"):
+		return "internship"
+	case strings.Contains(c, "part-time") || strings.Contains(c, "part time"):
+		return "part_time"
+	case strings.Contains(c, "full-time") || strings.Contains(c, "full time"):
+		return "full_time"
+	case strings.Contains(c, "contract") || strings.Contains(c, "temporary") || strings.Contains(c, "seasonal"):
+		return "contract"
+	default:
+		return ""
+	}
 }

--- a/internal/sources/workable.go
+++ b/internal/sources/workable.go
@@ -33,6 +33,7 @@ func (w workable) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			State         string `json:"state"`
 			Country       string `json:"country"`
 			Telecommuting bool   `json:"telecommuting"`
+			Type          string `json:"type"`
 		} `json:"jobs"`
 	}
 	if err := w.http.GetJSON(ctx, url, &resp); err != nil {
@@ -42,16 +43,34 @@ func (w workable) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	jobs := make([]Job, 0, len(resp.Jobs))
 	for _, j := range resp.Jobs {
 		jobs = append(jobs, Job{
-			ExternalID:  j.Shortcode,
-			URL:         j.URL,
-			Title:       j.Title,
-			Company:     e.Company,
-			Location:    joinNonEmpty(j.City, j.State, j.Country),
-			Description: sanitizeHTML(j.Description),
-			Remote:      j.Telecommuting,
-			WorkMode:    workModeFromRemote(j.Telecommuting),
-			PostedAt:    parseDate(j.PublishedOn),
+			ExternalID:     j.Shortcode,
+			URL:            j.URL,
+			Title:          j.Title,
+			Company:        e.Company,
+			Location:       joinNonEmpty(j.City, j.State, j.Country),
+			Description:    sanitizeHTML(j.Description),
+			Remote:         j.Telecommuting,
+			WorkMode:       workModeFromRemote(j.Telecommuting),
+			PostedAt:       parseDate(j.PublishedOn),
+			EmploymentType: workableEmploymentType(j.Type),
 		})
 	}
 	return jobs, nil
+}
+
+// workableEmploymentType maps Workable's widget "type" onto the freehire vocabulary,
+// returning "" for "Other"/absent so the description parser decides.
+func workableEmploymentType(t string) string {
+	switch t {
+	case "Full-time":
+		return "full_time"
+	case "Part-time":
+		return "part_time"
+	case "Contract", "Temporary":
+		return "contract"
+	case "Internship":
+		return "internship"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
## Summary
Extends the employment_type ingest seam (#671) to three more adapters, all reusing the
existing `sources.Job.EmploymentType` slot + jobderive precedence — **no new architecture,
no migration**:

- **ashby** — `employmentType` enum (FullTime/PartTime/Contract/Intern/Temporary), clean
- **workable** — widget `type` (Full-time/Part-time/Contract/Temporary/Internship, ~79% filled)
- **lever** — `categories.commitment`, which is per-company **free text** ("Regular Full-Time",
  "Full-Time Maintenance", "Variable Hour"), so keyword-containment matching; ambiguous values
  abstain to empty

A live probe grounded each mapping. Any unknown/absent value maps to empty so the
description parser decides — structured signal only, never a guess.

### Track B
Follow-up to #669/#671. (Greenhouse was spiked and rejected — its public board API doesn't
expose structured employment/seniority/salary: `education` is a form-config flag,
`departments` is free-text, pay ranges 0% in sample.)

## Deploy
No migration. Takes effect as Lever/Ashby/Workable boards are re-crawled by the ingest cron.

## Test Plan
- [x] `go test ./...` — `TestAshbyEmploymentType`/`TestWorkableEmploymentType`/`TestLeverEmploymentType` (mapping tables incl. abstain cases), full suite green
- [x] `go build/vet ./...`, gofmt clean