### PR TITLE
fix(web): complete the ARIA tabs pattern (tabpanels + arrow-key nav)

### DIFF
--- a/web/src/lib/actions/tablist.test.ts
+++ b/web/src/lib/actions/tablist.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { nextTabIndex } from './tablist';
+
+describe('nextTabIndex', () => {
+  it('moves right and wraps past the last tab', () => {
+    expect(nextTabIndex(0, 'ArrowRight', 3)).toBe(1);
+    expect(nextTabIndex(2, 'ArrowRight', 3)).toBe(0);
+  });
+
+  it('moves left and wraps before the first tab', () => {
+    expect(nextTabIndex(1, 'ArrowLeft', 3)).toBe(0);
+    expect(nextTabIndex(0, 'ArrowLeft', 3)).toBe(2);
+  });
+
+  it('jumps to the ends with Home/End', () => {
+    expect(nextTabIndex(1, 'Home', 3)).toBe(0);
+    expect(nextTabIndex(1, 'End', 3)).toBe(2);
+  });
+
+  it('returns null for non-navigation keys (manual activation is left to the browser)', () => {
+    expect(nextTabIndex(0, 'Enter', 3)).toBeNull();
+    expect(nextTabIndex(0, ' ', 3)).toBeNull();
+    expect(nextTabIndex(0, 'a', 3)).toBeNull();
+  });
+
+  it('returns null when there are no tabs', () => {
+    expect(nextTabIndex(0, 'ArrowRight', 0)).toBeNull();
+  });
+});

--- a/web/src/lib/actions/tablist.ts
+++ b/web/src/lib/actions/tablist.ts
@@ -1,0 +1,65 @@
+import type { Action } from 'svelte/action';
+
+/**
+ * Next focus index for a horizontal tablist, or `null` when `key` is not a
+ * navigation key. Left/Right wrap around; Home/End jump to the ends. Pure so it can
+ * be unit-tested in Node (the DOM glue below is verified via svelte-check + visually).
+ */
+export function nextTabIndex(current: number, key: string, count: number): number | null {
+  if (count <= 0) return null;
+  switch (key) {
+    case 'ArrowRight':
+      return (current + 1) % count;
+    case 'ArrowLeft':
+      return (current - 1 + count) % count;
+    case 'Home':
+      return 0;
+    case 'End':
+      return count - 1;
+    default:
+      return null;
+  }
+}
+
+/**
+ * WAI-ARIA tabs keyboard behaviour on a `role="tablist"` container: roving tabindex
+ * (only the selected tab is in the Tab sequence) plus Left/Right/Home/End to move
+ * focus between tabs. Activation is **manual** — arrows only move focus, and the
+ * native Enter/Space (button) or Enter (link) activates — so link-based tabs never
+ * navigate on an arrow press.
+ *
+ * The relationships (`role="tabpanel"`, `id`, `aria-controls`/`aria-labelledby`) are
+ * wired declaratively in each tablist's markup; this action owns only the behaviour.
+ *
+ * Pass the active tab identifier as the parameter so the roving tabindex re-syncs
+ * whenever the selection (or route, for link tabs) changes.
+ */
+export const tablist: Action<HTMLElement, unknown> = (node) => {
+  const tabs = () => Array.from(node.querySelectorAll<HTMLElement>('[role="tab"]'));
+
+  // Only the selected tab (or the first, if none) stays tabbable.
+  const syncTabindex = () => {
+    const items = tabs();
+    const selected = items.findIndex((el) => el.getAttribute('aria-selected') === 'true');
+    const active = selected === -1 ? 0 : selected;
+    items.forEach((el, i) => (el.tabIndex = i === active ? 0 : -1));
+  };
+
+  const onKeydown = (e: KeyboardEvent) => {
+    const items = tabs();
+    const current = items.indexOf(document.activeElement as HTMLElement);
+    if (current === -1) return;
+    const next = nextTabIndex(current, e.key, items.length);
+    if (next === null) return;
+    e.preventDefault();
+    items[next]?.focus();
+  };
+
+  node.addEventListener('keydown', onKeydown);
+  syncTabindex();
+
+  return {
+    update: syncTabindex,
+    destroy: () => node.removeEventListener('keydown', onKeydown),
+  };
+};

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -5,6 +5,7 @@
   import { STAGES, humanizeStage } from '$lib/stages';
   import { CLOSED_OUTCOMES, type ClosedOutcome } from '$lib/board';
   import { timeAgo, cn } from '$lib/utils';
+  import { tablist } from '$lib/actions/tablist';
   import { cardTags } from '$lib/enrichment';
   import CompanyLogo from './CompanyLogo.svelte';
   import JobFitFull from './JobFitFull.svelte';
@@ -152,9 +153,22 @@
       {/if}
 
       <div class="no-scrollbar overflow-x-auto">
-        <div role="tablist" aria-label="Job details view" class="flex w-max items-center gap-1 rounded-full bg-muted p-1">
+        <div
+          role="tablist"
+          aria-label="Job details view"
+          use:tablist={tab}
+          class="flex w-max items-center gap-1 rounded-full bg-muted p-1"
+        >
           {#each TABS as t (t.id)}
-            <button type="button" role="tab" aria-selected={tab === t.id} class={tabClass(tab === t.id)} onclick={() => (tab = t.id)}>
+            <button
+              type="button"
+              role="tab"
+              id="jobdrawer-tab-{t.id}"
+              aria-selected={tab === t.id}
+              aria-controls="jobdrawer-tabpanel"
+              class={tabClass(tab === t.id)}
+              onclick={() => (tab = t.id)}
+            >
               {t.label}
             </button>
           {/each}
@@ -165,7 +179,13 @@
 
   <!-- Scrolling tab body -->
   <div class="min-h-0 flex-1 overflow-y-auto">
-    <div class="mx-auto w-full max-w-2xl px-5 py-5 sm:px-6">
+    <div
+      role="tabpanel"
+      id="jobdrawer-tabpanel"
+      aria-labelledby="jobdrawer-tab-{tab}"
+      tabindex="0"
+      class="mx-auto w-full max-w-2xl px-5 py-5 sm:px-6"
+    >
       {#if tab === 'application'}
         <div class="flex flex-col gap-4">
           {#if pendingOutcome}

--- a/web/src/lib/components/ModerationView.svelte
+++ b/web/src/lib/components/ModerationView.svelte
@@ -7,6 +7,7 @@
   import { cn, timeAgo } from '$lib/utils';
   import ReportQueue from './ReportQueue.svelte';
   import States from './States.svelte';
+  import { tablist } from '$lib/actions/tablist';
 
   const isModerator = $derived(currentUser()?.role === 'moderator');
 
@@ -74,12 +75,14 @@
   <div class="flex flex-col gap-6">
     <h1 class="text-2xl font-semibold tracking-tight">Moderation</h1>
 
-    <div role="tablist" aria-label="Moderation view" class="flex items-center gap-1">
+    <div role="tablist" aria-label="Moderation view" use:tablist={view} class="flex items-center gap-1">
       {#each tabs as tab (tab.value)}
         <button
           type="button"
           role="tab"
+          id="mod-tab-{tab.value}"
           aria-selected={view === tab.value}
+          aria-controls="mod-tabpanel"
           onclick={() => (view = tab.value)}
           class={cn(
             'rounded-md px-3 py-1.5 text-sm transition-colors',
@@ -93,6 +96,7 @@
       {/each}
     </div>
 
+    <div role="tabpanel" id="mod-tabpanel" aria-labelledby="mod-tab-{view}" tabindex="0">
     {#if view === 'queue'}
       <div class="flex flex-col gap-6">
         <p class="text-sm text-muted-foreground">
@@ -145,5 +149,6 @@
     {:else}
       <ReportQueue />
     {/if}
+    </div>
   </div>
 {/if}

--- a/web/src/routes/my/activity/+layout.svelte
+++ b/web/src/routes/my/activity/+layout.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { cn } from '$lib/utils';
+  import { tablist } from '$lib/actions/tablist';
 
   let { children }: { children: Snippet } = $props();
 
@@ -15,6 +16,10 @@
   const savedActive = $derived(path === '/my/activity');
   const historyActive = $derived(path.startsWith('/my/activity/history'));
   const matchesActive = $derived(path.startsWith('/my/activity/matches'));
+  // The id of the active tab, so the routed panel can point back at it (aria-labelledby).
+  const activeTabId = $derived(
+    historyActive ? 'activity-tab-history' : matchesActive ? 'activity-tab-matches' : 'activity-tab-saved',
+  );
 
   const tabClass = (active: boolean) =>
     cn(
@@ -33,13 +38,22 @@
 <div class="flex flex-col gap-4">
   <h1 class="text-2xl font-semibold tracking-tight">Activity</h1>
 
-  <div role="tablist" aria-label="Activity view" class="flex items-center gap-1">
-    <a role="tab" aria-selected={savedActive} href={resolve('/my/activity')} class={tabClass(savedActive)}>
+  <div role="tablist" aria-label="Activity view" use:tablist={path} class="flex items-center gap-1">
+    <a
+      role="tab"
+      id="activity-tab-saved"
+      aria-selected={savedActive}
+      aria-controls="activity-tabpanel"
+      href={resolve('/my/activity')}
+      class={tabClass(savedActive)}
+    >
       Saved
     </a>
     <a
       role="tab"
+      id="activity-tab-history"
       aria-selected={historyActive}
+      aria-controls="activity-tabpanel"
       href={resolve('/my/activity/history')}
       class={tabClass(historyActive)}
     >
@@ -47,7 +61,9 @@
     </a>
     <a
       role="tab"
+      id="activity-tab-matches"
       aria-selected={matchesActive}
+      aria-controls="activity-tabpanel"
       href={resolve('/my/activity/matches')}
       class={tabClass(matchesActive)}
     >
@@ -55,5 +71,7 @@
     </a>
   </div>
 
-  {@render children()}
+  <div role="tabpanel" id="activity-tabpanel" aria-labelledby={activeTabId} tabindex="0">
+    {@render children()}
+  </div>
 </div>

--- a/web/src/routes/my/tracking/+layout.svelte
+++ b/web/src/routes/my/tracking/+layout.svelte
@@ -3,6 +3,7 @@
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { cn } from '$lib/utils';
+  import { tablist } from '$lib/actions/tablist';
 
   let { children }: { children: Snippet } = $props();
 
@@ -14,6 +15,8 @@
   // Board (index) matches exactly so it is not also active on the child routes.
   const boardActive = $derived(path === '/my/tracking');
   const pipelineActive = $derived(path.startsWith('/my/tracking/pipeline'));
+  // The id of the active tab, so the routed panel can point back at it (aria-labelledby).
+  const activeTabId = $derived(pipelineActive ? 'tracking-tab-pipeline' : 'tracking-tab-board');
 
   const tabClass = (active: boolean) =>
     cn(
@@ -32,13 +35,22 @@
 <div class="flex flex-col gap-4">
   <h1 class="text-2xl font-semibold tracking-tight">Tracking</h1>
 
-  <div role="tablist" aria-label="Tracking view" class="flex items-center gap-1">
-    <a role="tab" aria-selected={boardActive} href={resolve('/my/tracking')} class={tabClass(boardActive)}>
+  <div role="tablist" aria-label="Tracking view" use:tablist={path} class="flex items-center gap-1">
+    <a
+      role="tab"
+      id="tracking-tab-board"
+      aria-selected={boardActive}
+      aria-controls="tracking-tabpanel"
+      href={resolve('/my/tracking')}
+      class={tabClass(boardActive)}
+    >
       Board
     </a>
     <a
       role="tab"
+      id="tracking-tab-pipeline"
       aria-selected={pipelineActive}
+      aria-controls="tracking-tabpanel"
       href={resolve('/my/tracking/pipeline')}
       class={tabClass(pipelineActive)}
     >
@@ -46,5 +58,7 @@
     </a>
   </div>
 
-  {@render children()}
+  <div role="tabpanel" id="tracking-tabpanel" aria-labelledby={activeTabId} tabindex="0">
+    {@render children()}
+  </div>
 </div>


### PR DESCRIPTION
Closes #633.

## Problem

Four tablists — **Job details** (`JobDrawer`), **Moderation** (`ModerationView`), **Tracking** and **Activity** layouts — declared `role="tablist"`/`role="tab"`/`aria-selected` but only did half the [WAI-ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/):

- panels had no `role="tabpanel"`/`id`, and tabs no `aria-controls` → screen readers announced "tab" controls with no panel association to jump to;
- no arrow-key navigation → keyboard users tabbed through each button individually, and the group wasn't perceived as a single tabs widget.

Mouse and plain Tab worked, so this was correctness/a11y, not a functional bug (low priority per the issue).

## Fix — one shared action, wired at all four sites

**`src/lib/actions/tablist.ts`** — a Svelte action on the `role="tablist"` container that owns the keyboard behaviour:
- **roving tabindex** — only the selected tab stays in the Tab sequence;
- **Left/Right/Home/End** move focus between tabs;
- **manual activation** — arrows move focus only; the native Enter/Space (button) or Enter (link) activates. This is what lets the two **link-based** nav layouts (Tracking/Activity) adopt the same helper without arrow presses triggering navigation.

The pure index math (`nextTabIndex`) is unit-tested (Node, no DOM — matching the repo's test convention); the DOM glue is verified via svelte-check and a real-browser keyboard check.

Relationships are wired declaratively per site: each tab gets an `id` + `aria-controls`, and the panel gets `role="tabpanel"` + `id` + `aria-labelledby` + `tabindex=0` (wrapping `{@render children()}` for the two routed layouts).

## Verification (local)

- `npm run check` ✅ 0 errors
- `npm run build` ✅
- `npm run test` ✅ 225/225 (5 new for `nextTabIndex`)
- Browser keyboard check (throwaway route, headless Chrome, real `tablist` action): roving tabindex `0,-1,-1`, ArrowRight/ArrowLeft (with wrap), Home, End all move focus correctly — 6/6 PASS. Lint introduces no new errors.