### PR TITLE
feat(sources): capture structured employment_type from Oracle JobSchedule

### DIFF
--- a/internal/sources/employment_type_test.go
+++ b/internal/sources/employment_type_test.go
@@ -6,6 +6,19 @@ import "testing"
 // onto freehire's controlled values, mapping any unknown/ambiguous value to "" so the
 // pipeline's description parser decides — structured signal only, never a guess.
 
+func TestOracleEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"Full time": "full_time", "full time": "full_time",
+		"Part time": "part_time",
+		"":          "", "On Call": "",
+	}
+	for in, want := range cases {
+		if got := oracleEmploymentType(in); got != want {
+			t.Errorf("oracleEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestAshbyEmploymentType(t *testing.T) {
 	cases := map[string]string{
 		"FullTime": "full_time", "PartTime": "part_time",

--- a/internal/sources/oracle.go
+++ b/internal/sources/oracle.go
@@ -119,6 +119,7 @@ func (s oracle) detail(ctx context.Context, e CompanyEntry, b oracleBoard, r ora
 			ExternalDescriptionStr      string `json:"ExternalDescriptionStr"`
 			ExternalResponsibilitiesStr string `json:"ExternalResponsibilitiesStr"`
 			ExternalQualificationsStr   string `json:"ExternalQualificationsStr"`
+			JobSchedule                 string `json:"JobSchedule"`
 		} `json:"items"`
 	}
 	if err := s.http.GetJSON(ctx, url, &resp); err != nil || len(resp.Items) == 0 {
@@ -142,7 +143,24 @@ func (s oracle) detail(ctx context.Context, e CompanyEntry, b oracleBoard, r ora
 		Remote:      workMode == "remote" || isRemote(r.PrimaryLocation),
 		WorkMode:    workMode,
 		PostedAt:    parseDate(r.PostedDate),
+		// JobSchedule is Oracle's structured full/part-time enum; preferred over the
+		// free-text employment-type parse.
+		EmploymentType: oracleEmploymentType(d.JobSchedule),
 	}, true
+}
+
+// oracleEmploymentType maps Oracle's JobSchedule ("Full time" / "Part time") onto the
+// freehire employment-type vocabulary, returning "" for any other/absent value so the
+// description parser decides — structured signal only, never a guess.
+func oracleEmploymentType(jobSchedule string) string {
+	switch strings.TrimSpace(strings.ToLower(jobSchedule)) {
+	case "full time":
+		return "full_time"
+	case "part time":
+		return "part_time"
+	default:
+		return ""
+	}
 }
 
 // oracleWorkMode maps an ORC workplace-type code to our work-mode vocabulary; an empty or

--- a/internal/sources/oracle_test.go
+++ b/internal/sources/oracle_test.go
@@ -34,7 +34,8 @@ func TestOracleFetchListsAndFetchesDetail(t *testing.T) {
 			"Id": "30607",
 			"ExternalDescriptionStr": "<p>Build the backend.</p>",
 			"ExternalResponsibilitiesStr": "<ul><li>Own services</li></ul>",
-			"ExternalQualificationsStr": "<p>Go experience.</p>"
+			"ExternalQualificationsStr": "<p>Go experience.</p>",
+			"JobSchedule": "Full time"
 		}]}`).
 		route("30610", `{"items": [{
 			"Id": "30610",
@@ -79,6 +80,9 @@ func TestOracleFetchListsAndFetchesDetail(t *testing.T) {
 	}
 	if j.Remote {
 		t.Error("Remote = true, want false for an on-site role")
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time (from JobSchedule)", j.EmploymentType)
 	}
 	for _, want := range []string{"Build the backend.", "Own services", "Go experience."} {
 		if !strings.Contains(j.Description, want) {


### PR DESCRIPTION
## Summary
Oracle Recruiting Cloud's requisition **detail** carries a `JobSchedule` enum (Full time /
Part time) the adapter already fetched (for the description) but dropped. This maps it onto
the freehire employment-type vocabulary and emits it in the structured `EmploymentType`
slot, reusing the seam from #671 (jobderive prefers it over the free-text `jobfacts` parse)
— **no migration**.

A live probe found `JobSchedule` **100% populated** (17/18 Full time, 1 Part time) — same
clean shape as Workday's `timeType`. Any other/absent value maps to empty so the
description parser decides.

### Track B
Oracle is the **#2 source (~400K open jobs)**. Its other structured detail fields
(ManagerLevel, StudyLevel, ContractType, WorkerType) were empty for the probed tenant, so
only `JobSchedule` is captured.

## Deploy
No migration. Takes effect as Oracle boards are re-crawled by the ingest cron.

## Test Plan
- [x] `go test ./internal/sources/` — `TestOracleEmploymentType` (mapping) + the fetch test asserts the emitted `EmploymentType`
- [x] `go build/vet ./...`, full unit suite green