### PR TITLE
feat: expand non-tech dictionary across 8 role clusters

### DIFF
--- a/internal/classify/nontech.go
+++ b/internal/classify/nontech.go
@@ -22,30 +22,51 @@ import (
 //   - This detector is consulted only after the tech category dictionary is
 //     silent (see jobderive), so tech evidence always wins.
 var nonTechTitleTerms = []string{
-	// Healthcare & care
-	"nurse", "nursing", "caregiver", "caretaker", "home health aide",
-	"veterinary", "veterinarian", "dental hygienist", "dental assistant",
-	"pharmacist", "phlebotomist", "paramedic", "medical assistant",
-	"physical therapist", "occupational therapist", "massage therapist",
-	// Skilled trades
+	// Healthcare & care. "…technician" collides with IT/field-service technician, so
+	// only anchored forms ("pharmacy technician", "surgical technician") are listed.
+	"nurse", "nursing", "registered nurse", "nurse practitioner",
+	"certified nursing assistant", "cna", "lpn", "licensed practical nurse",
+	"caregiver", "caretaker", "home health aide", "home health", "hospice",
+	"veterinary", "veterinarian", "dentist", "dental hygienist", "dental assistant",
+	"pharmacist", "pharmacy technician", "phlebotomist", "phlebotomy", "paramedic",
+	"medical assistant", "certified medical assistant", "medical scribe",
+	"medical technologist", "patient care", "patient access",
+	"surgical technologist", "surgical technician", "scrub tech",
+	"physical therapist", "occupational therapist", "respiratory therapist",
+	"speech therapist", "massage therapist", "radiologic technologist", "sonographer",
+	// Skilled trades. "…engineer"/"…technician" excluded; "hvac technician" anchored.
 	"electrician", "plumber", "welder", "carpenter", "machinist", "millwright",
-	"forklift",
+	"forklift", "ironworker", "iron worker", "laborer", "general labor",
+	"pipefitter", "stone mason", "brick mason", "bricklayer", "roofer", "hvac",
+	"hvac technician", "mechanic", "boilermaker", "sheet metal",
 	// Hospitality & food service. Bare "chef" is deliberately absent — it collides
 	// with Progress Chef (config-management), which would mislabel a DevOps/SRE
 	// title the tech dictionary did not place; the cook terms cover food service.
-	"barista", "bartender", "line cook", "prep cook", "dishwasher",
-	"housekeeper", "housekeeping", "banquet", "waiter", "waitress", "busser",
-	"concierge", "valet",
-	// Retail & warehouse
-	"cashier", "stocker", "merchandiser",
+	"cook", "line cook", "prep cook", "fry cook", "grill cook", "food service",
+	"barista", "bartender", "dishwasher", "housekeeper", "housekeeping", "banquet",
+	"waiter", "waitress", "busser", "concierge", "valet",
+	// Retail & warehouse. Bare "warehouse" excluded (data-warehouse engineer); only
+	// anchored role forms.
+	"cashier", "stocker", "merchandiser", "retail associate", "retail sales",
+	"sales associate", "sales clerk", "store associate", "store clerk",
+	"warehouse associate", "warehouse worker", "order picker", "picker", "packer",
+	"material handler", "package handler", "cdl driver",
 	// Personal care & fitness
 	"pilates instructor", "yoga instructor", "fitness instructor",
 	"personal trainer", "cosmetologist", "hair stylist", "hairstylist",
-	"barber", "esthetician",
+	"barber", "esthetician", "manicurist", "nail technician",
 	// Education & childcare
-	"teacher", "tutor", "preschool",
+	"teacher", "substitute teacher", "teaching assistant", "tutor", "preschool",
+	"childcare", "child care", "daycare", "camp counselor", "paraprofessional",
+	// Office & finance administration. Anchored forms only ("data entry clerk", not
+	// bare "data"; "loan officer", not bare "officer").
+	"paralegal", "bookkeeper", "accountant", "accounting clerk", "payroll clerk",
+	"payroll specialist", "accounts payable", "accounts receivable", "teller",
+	"bank teller", "loan officer", "underwriter", "claims adjuster",
+	"administrative assistant", "office assistant", "data entry clerk", "file clerk",
 	// Facilities & cleaning
-	"janitor", "janitorial", "cleaner", "custodian", "groundskeeper",
+	"janitor", "janitorial", "cleaner", "custodian", "custodial", "groundskeeper",
+	"maintenance worker", "parking attendant", "flight attendant",
 	// Security & transport
 	"security guard", "truck driver", "delivery driver", "bus driver", "courier",
 	// Front-of-house administration

--- a/internal/classify/nontech_clusters_test.go
+++ b/internal/classify/nontech_clusters_test.go
@@ -1,0 +1,63 @@
+package classify
+
+import "testing"
+
+// TestIsNonTech_ExpandedClusters locks the widened non-tech coverage across the
+// clusters the prod unknown bucket is dominated by, plus the tech-collision traps
+// the expansion must never flip.
+func TestIsNonTech_ExpandedClusters(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		// Healthcare
+		{"cna", "Certified Nursing Assistant (CNA)", true},
+		{"pharmacy technician", "Pharmacy Technician - Night", true},
+		{"phlebotomy", "Phlebotomy Technician", true},
+		{"respiratory therapist", "Registered Respiratory Therapist", true},
+		{"medical scribe", "Medical Scribe", true},
+		// Food service
+		{"cook", "Cook", true},
+		{"food service", "Food Service Worker", true},
+		// Retail
+		{"retail associate", "Retail Sales Associate", true},
+		{"sales clerk", "Sales Clerk", true},
+		// Warehouse / logistics
+		{"warehouse associate", "Warehouse Associate", true},
+		{"order picker", "Order Picker / Packer", true},
+		{"material handler", "Material Handler II", true},
+		{"cdl driver", "CDL Driver - Local", true},
+		// Trades
+		{"ironworker", "Reinforcing Ironworker", true},
+		{"laborer", "General Laborer", true},
+		{"pipefitter", "Pipefitter", true},
+		{"hvac technician", "HVAC Technician", true},
+		// Office / finance
+		{"paralegal", "Paralegal - EL/PL", true},
+		{"bookkeeper", "Full Charge Bookkeeper", true},
+		{"accountant", "Staff Accountant", true},
+		{"payroll clerk", "Payroll Clerk", true},
+		{"teller", "Bank Teller", true},
+		// Education
+		{"substitute teacher", "Substitute Teacher", true}, // also via "teacher"
+		{"teaching assistant", "Teaching Assistant", true},
+		{"childcare", "Childcare Provider", true},
+
+		// Trap negatives — tech or tech-adjacent that MUST stay unflagged.
+		{"it technician", "IT Technician", false},
+		{"field service technician", "Field Service Technician", false},
+		{"data warehouse engineer", "Data Warehouse Engineer", false},
+		{"security engineer", "Security Engineer", false},
+		{"systems coordinator", "Systems Coordinator", false},
+		{"data analyst", "Data Analyst", false},
+		{"software engineer", "Software Engineer II", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNonTech(tt.title); got != tt.want {
+				t.Errorf("IsNonTech(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/expand-nontech-dictionary/tasks.md
+++ b/openspec/changes/expand-nontech-dictionary/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Expand the non-tech dictionary
 
-- [ ] 1.1 Grow `classify.nonTechTitleTerms` (internal/classify/nontech.go) across the eight measured clusters (healthcare, food, retail, warehouse/logistics, trades, office/finance, education, facilities), unambiguous role nouns only
-- [ ] 1.2 Extend the `IsNonTech` test: positives per cluster (Registered Nurse, Line Cook, Warehouse Associate, Order Picker, Ironworker, Paralegal, Bookkeeper, Substitute Teacher…) and trap negatives (IT Technician, Field Service Technician, Data Warehouse Engineer, Security Engineer, Systems Coordinator, Data Analyst → NOT non-tech)
+- [x] 1.1 Grow `classify.nonTechTitleTerms` (internal/classify/nontech.go) across the eight measured clusters (healthcare, food, retail, warehouse/logistics, trades, office/finance, education, facilities), unambiguous role nouns only
+- [x] 1.2 Extend the `IsNonTech` test: positives per cluster (Registered Nurse, Line Cook, Warehouse Associate, Order Picker, Ironworker, Paralegal, Bookkeeper, Substitute Teacher…) and trap negatives (IT Technician, Field Service Technician, Data Warehouse Engineer, Security Engineer, Systems Coordinator, Data Analyst → NOT non-tech)
 
 ## 2. Verify + ship
 
-- [ ] 2.1 `go build ./... && go vet ./... && go test ./...` green
+- [x] 2.1 `go build ./... && go vet ./... && go test ./...` green
 - [ ] 2.2 Deploy, chained `backfill-derive && reindex`, measure new true/false/null split on prod


### PR DESCRIPTION
## Summary

The `is_tech=unknown` bucket is 58% of the open catalogue (1.8M) and is dominated by **non-tech roles the ~70-term `classify.IsNonTech` dictionary misses**, not hidden tech (generic ATS boards dump whole company boards). Cluster census of the unknown bucket: healthcare ~80K, warehouse/logistics ~62K, retail ~45K, food ~43K, trades ~31K, office/finance ~25K, education ~24K, facilities ~12K.

This substantially grows `nonTechTitleTerms` across those eight clusters (registered nurse, CNA, pharmacy technician, cook, warehouse associate, order picker, ironworker, laborer, paralegal, bookkeeper, accountant, teller, substitute teacher, childcare, …), so far more `unknown` resolves to `non_tech` — making the "exclude Non-tech" filter actually clean the catalogue.

**Never-guess doctrine held.** Only anchored, unambiguous non-tech nouns; the tech-collision terms stay excluded (bare "technician"/"engineer"/"analyst"/"coordinator"/"specialist"/"warehouse"/"server"/"chef"/"administrator"/"officer"). Location/name collisions avoided (dropped bare "mason"→"stone mason", "porter").

No derivation/schema/wire/facet/UI change — only more jobs resolve to `non_tech`.

OpenSpec: `expand-nontech-dictionary` (MODIFIES `tech-classification`).

## Test Plan
- [x] `go build/vet/test ./...` (73 packages green), gofmt clean
- [x] Unit: per-cluster positives (Cook, Warehouse Associate, Order Picker, Ironworker, Paralegal, Bookkeeper, Accountant, Substitute Teacher, Pharmacy Technician…) + trap negatives (IT Technician, Field Service Technician, Data Warehouse Engineer, Security Engineer, Systems Coordinator, Data Analyst, Software Engineer → NOT non-tech)

## Expected impact (post backfill + reindex)
`non_tech` up ~300-500K, `unknown` down correspondingly, `tech` flat.