### PR TITLE
feat(sources): capture structured employment_type from UKG FullTime

### DIFF
--- a/internal/sources/employment_type_test.go
+++ b/internal/sources/employment_type_test.go
@@ -6,6 +6,23 @@ import "testing"
 // onto freehire's controlled values, mapping any unknown/ambiguous value to "" so the
 // pipeline's description parser decides — structured signal only, never a guess.
 
+func TestUKGEmploymentType(t *testing.T) {
+	tru, fls := true, false
+	cases := []struct {
+		in   *bool
+		want string
+	}{
+		{&tru, "full_time"},
+		{&fls, "part_time"},
+		{nil, ""}, // absent flag → let the description parser decide
+	}
+	for _, c := range cases {
+		if got := ukgEmploymentType(c.in); got != c.want {
+			t.Errorf("ukgEmploymentType(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestOracleEmploymentType(t *testing.T) {
 	cases := map[string]string{
 		"Full time": "full_time", "full time": "full_time",

--- a/internal/sources/ukg.go
+++ b/internal/sources/ukg.go
@@ -134,8 +134,10 @@ func (u ukg) list(ctx context.Context, host, tenant, guid string) ([]ukgOpportun
 func (u ukg) toJob(ctx context.Context, host, tenant, guid string, o ukgOpportunity) Job {
 	url := fmt.Sprintf("https://%s/%s/JobBoard/%s/OpportunityDetail?opportunityId=%s", host, tenant, guid, o.ID)
 	body := o.BriefDescription
-	if full, ok := u.fullDescription(ctx, url); ok {
-		body = full
+	var employmentType string
+	if detail, ok := u.fetchDetail(ctx, url); ok {
+		body = detail.Description
+		employmentType = ukgEmploymentType(detail.FullTime)
 	}
 	location := o.location()
 	return Job{
@@ -146,33 +148,56 @@ func (u ukg) toJob(ctx context.Context, host, tenant, guid string, o ukgOpportun
 		Description: sanitizeHTML(html.UnescapeString(body)),
 		Remote:      isRemote(location),
 		PostedAt:    parseRFC3339(o.PostedDate),
+		// FullTime is UKG's structured full/part-time flag; preferred over the free-text
+		// employment-type parse.
+		EmploymentType: employmentType,
 	}
 }
 
-// fullDescription fetches a detail page and returns the opportunity's full HTML description,
-// which the page bootstraps as the JSON argument of a CandidateOpportunityDetail(...) call.
-// It returns ok=false (so the caller keeps the brief body) when the page fetch fails or
-// carries no parseable opportunity.
-func (u ukg) fullDescription(ctx context.Context, url string) (string, bool) {
+// ukgDetail is the parsed subset of the CandidateOpportunityDetail JSON the detail page
+// bootstraps: the full HTML description plus the structured full-time flag (a pointer so an
+// absent field is distinguishable from false).
+type ukgDetail struct {
+	Description string `json:"Description"`
+	FullTime    *bool  `json:"FullTime"`
+}
+
+// fetchDetail fetches a detail page and returns the opportunity's parsed detail (full HTML
+// description + FullTime flag), which the page bootstraps as the JSON argument of a
+// CandidateOpportunityDetail(...) call. It returns ok=false (so the caller keeps the brief
+// body) when the page fetch fails or carries no parseable opportunity.
+func (u ukg) fetchDetail(ctx context.Context, url string) (ukgDetail, bool) {
 	root, err := u.http.GetHTML(ctx, url)
 	if err != nil {
-		return "", false
+		return ukgDetail{}, false
 	}
 	script := scriptContaining(root, ukgDetailMarker)
 	if script == "" {
-		return "", false
+		return ukgDetail{}, false
 	}
 	raw, ok := bracketSlice(script, ukgDetailMarker, '{', '}')
 	if !ok {
-		return "", false
+		return ukgDetail{}, false
 	}
-	var detail struct {
-		Description string `json:"Description"`
-	}
+	var detail ukgDetail
 	if err := json.Unmarshal([]byte(raw), &detail); err != nil || detail.Description == "" {
-		return "", false
+		return ukgDetail{}, false
 	}
-	return detail.Description, true
+	return detail, true
+}
+
+// ukgEmploymentType maps UKG's FullTime boolean onto the freehire vocabulary: true →
+// full_time, false → part_time. A nil flag (the field is absent) yields "" so the
+// description parser decides — structured signal only.
+func ukgEmploymentType(fullTime *bool) string {
+	switch {
+	case fullTime == nil:
+		return ""
+	case *fullTime:
+		return "full_time"
+	default:
+		return "part_time"
+	}
 }
 
 // ukgDetailMarker is the bootstrap call whose JSON argument carries the full opportunity

--- a/internal/sources/ukg_test.go
+++ b/internal/sources/ukg_test.go
@@ -70,7 +70,7 @@ func TestUKGLocation(t *testing.T) {
 func ukgDetailHTML(description string) string {
 	return `<html><head></head><body>` +
 		`<script>var opportunity = new US.Opportunity.CandidateOpportunityDetail(` +
-		`{"Id":"x","Title":"t","Description":"` + description + `"});</script>` +
+		`{"Id":"x","Title":"t","FullTime":true,"Description":"` + description + `"});</script>` +
 		`</body></html>`
 }
 
@@ -107,6 +107,10 @@ func TestUKGFetch(t *testing.T) {
 	// The detail page upgrades the brief body to the full description.
 	if !strings.Contains(j.Description, "Full body") {
 		t.Errorf("job0 description = %q, want full body", j.Description)
+	}
+	// The detail page's FullTime flag maps to the structured employment type.
+	if j.EmploymentType != "full_time" {
+		t.Errorf("job0 EmploymentType = %q, want full_time (from FullTime:true)", j.EmploymentType)
 	}
 	if j.PostedAt == nil {
 		t.Errorf("job0 PostedAt is nil")


### PR DESCRIPTION
## Summary
UKG Pro Recruiting's OpportunityDetail page bootstraps a `CandidateOpportunityDetail({...})`
JSON that carries a **`FullTime` boolean** the adapter already fetched (for the full
description) but dropped. This parses it alongside the description and emits it in the
structured `EmploymentType` slot, reusing the seam from #671 (jobderive prefers it over the
free-text `jobfacts` parse) — **no migration**.

A live probe found `FullTime` **100% present** (7 true / 5 false of 12 sampled).

## 🔎 Decision to review
Mapping is `true → full_time`, **`false → part_time`**, `nil → ""` (absent → let the
description parser decide). The `false → part_time` reading is the direct meaning of UKG's
boolean, but a `false` role *could* occasionally be a contract/intern rather than strictly
part-time — UKG's `OpportunityType` was `0` for every sampled job, so there's no signal to
distinguish those. Flagging this in case you'd rather map `false → ""` (abstain) and only
trust the confident `true → full_time`. **Left as `false → part_time` for now** — the
part-time signal is otherwise hard to get, and jobderive still lets `jobfacts` refine when
FullTime is absent.

Salary fields exist (`CompensationAnnual*`/`PayRange`) but were only ~8% visible in the
probe, so not captured. `JobCategoryName`/`OpportunityType` weren't useful.

### Track B
UKG is a top-5 source (~196K open jobs). Follow-up to #669/#671/#673/#675.

## Deploy
No migration. Takes effect as UKG boards are re-crawled by the ingest cron.

## Test Plan
- [x] `go test ./...` — `TestUKGEmploymentType` (bool mapping incl. nil/abstain) + `TestUKGFetch` asserts the emitted `EmploymentType`
- [x] `go build/vet ./...`, gofmt clean, full unit suite green