### PR TITLE
feat(companies): filter companies by YC subindustry (searchable Industry facet)

### DIFF
--- a/cmd/import-yc/main.go
+++ b/cmd/import-yc/main.go
@@ -187,6 +187,7 @@ func recordToParams(r ycdir.Record) db.UpsertYCCompanyParams {
 		Slug:          r.Slug,
 		Name:          r.Name,
 		Industries:    nonNil(r.Industries),
+		Subindustry:   text(r.Subindustry),
 		YearFounded:   int4(r.YearFounded),
 		EmployeeCount: int4(r.EmployeeCount),
 		HqCountry:     text(r.HQCountry),

--- a/cmd/import-yc/main_test.go
+++ b/cmd/import-yc/main_test.go
@@ -31,7 +31,7 @@ func (f *fakeStore) UpsertYCCompany(_ context.Context, p db.UpsertYCCompanyParam
 
 func TestLoad(t *testing.T) {
 	entries := []ycdir.Entry{
-		{Name: "Stripe", OneLiner: "Payments", Industry: "Fintech", TeamSize: 8000, Batch: "Summer 2009", Status: "Public", Stage: "Growth", TopCompany: true},
+		{Name: "Stripe", OneLiner: "Payments", Industry: "Fintech", Subindustry: "Fintech -> Payments", TeamSize: 8000, Batch: "Summer 2009", Status: "Public", Stage: "Growth", TopCompany: true},
 		{Name: "New Co", Batch: "Winter 2024", Status: "Active"},
 		{Name: "Meta", FormerNames: []string{"Facebook"}, Batch: "Summer 2005", Status: "Public"}, // current absent, former exists
 		{Name: "Benchmark", TeamSize: 7, Batch: "Winter 2023", Status: "Active"},                  // homonym: tiny YC vs big non-YC company
@@ -79,6 +79,10 @@ func TestLoad(t *testing.T) {
 	if stripe.Industries == nil {
 		t.Error("industries is nil, want non-nil for the NOT NULL column")
 	}
+	// subindustry is forwarded as the clean YC leaf (nullable text).
+	if !stripe.Subindustry.Valid || stripe.Subindustry.String != "Payments" {
+		t.Errorf("stripe subindustry = %+v, want valid %q", stripe.Subindustry, "Payments")
+	}
 	var info map[string]any
 	if err := json.Unmarshal(stripe.CompanyInfo, &info); err != nil {
 		t.Fatalf("company_info not JSON: %v", err)
@@ -91,5 +95,8 @@ func TestLoad(t *testing.T) {
 	}
 	if newco.YcBatch == nil || newco.Industries == nil {
 		t.Error("newco arrays must be non-nil (NOT NULL columns)")
+	}
+	if newco.Subindustry.Valid {
+		t.Errorf("newco subindustry = %+v, want NULL (no subindustry given)", newco.Subindustry)
 	}
 }

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -74,6 +74,42 @@ func (q *Queries) CompanySitemapBoundaries(ctx context.Context, chunkSize int64)
 	return items, nil
 }
 
+const companySubindustries = `-- name: CompanySubindustries :many
+SELECT subindustry AS value, count(*) AS count
+FROM companies
+WHERE subindustry IS NOT NULL
+GROUP BY subindustry
+ORDER BY count(*) DESC, subindustry
+`
+
+type CompanySubindustriesRow struct {
+	Value pgtype.Text `json:"value"`
+	Count int64       `json:"count"`
+}
+
+// Distinct non-NULL subindustry values with their company counts, most common first
+// (ties broken by value), serving the searchable option list for the subindustry facet.
+// Counts are unconditional — they do not reflect other active list filters.
+func (q *Queries) CompanySubindustries(ctx context.Context) ([]CompanySubindustriesRow, error) {
+	rows, err := q.db.Query(ctx, companySubindustries)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []CompanySubindustriesRow{}
+	for rows.Next() {
+		var i CompanySubindustriesRow
+		if err := rows.Scan(&i.Value, &i.Count); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const countCompanies = `-- name: CountCompanies :one
 SELECT count(*)
 FROM companies
@@ -90,6 +126,7 @@ WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '
   AND (coalesce(cardinality($11::text[]), 0) = 0 OR yc_stage && $11::text[])
   AND (coalesce(cardinality($12::text[]), 0) = 0 OR yc_flags && $12::text[])
   AND (coalesce(cardinality($13::text[]), 0) = 0 OR maturity = ANY($13::text[]))
+  AND (coalesce(cardinality($14::text[]), 0) = 0 OR subindustry = ANY($14::text[]))
 `
 
 type CountCompaniesParams struct {
@@ -106,6 +143,7 @@ type CountCompaniesParams struct {
 	YcStage       []string `json:"yc_stage"`
 	YcFlags       []string `json:"yc_flags"`
 	Maturity      []string `json:"maturity"`
+	Subindustries []string `json:"subindustries"`
 }
 
 // Total companies matching the same optional name + facet filters as ListCompanies,
@@ -126,6 +164,7 @@ func (q *Queries) CountCompanies(ctx context.Context, arg CountCompaniesParams) 
 		arg.YcStage,
 		arg.YcFlags,
 		arg.Maturity,
+		arg.Subindustries,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -151,7 +190,7 @@ func (q *Queries) DeleteOrphanCompanies(ctx context.Context) (int64, error) {
 }
 
 const getCompany = `-- name: GetCompany :one
-SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes, industries, year_founded, employee_count, hq_country, organization_type, tagline, company_info, is_reference, company_info_at, remote_regions, yc_batch, yc_status, yc_stage, yc_flags, maturity
+SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes, industries, year_founded, employee_count, hq_country, organization_type, tagline, company_info, is_reference, company_info_at, remote_regions, yc_batch, yc_status, yc_stage, yc_flags, maturity, subindustry
 FROM companies
 WHERE slug = $1
 `
@@ -189,6 +228,7 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 		&i.YcStage,
 		&i.YcFlags,
 		&i.Maturity,
+		&i.Subindustry,
 	)
 	return i, err
 }
@@ -211,8 +251,10 @@ WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '
   -- maturity is a SCALAR column (not an array): membership, not overlap. A NULL
   -- (unknown) maturity matches no requested value, so ` + "`" + `NULL = ANY(...)` + "`" + ` excludes it.
   AND (coalesce(cardinality($13::text[]), 0) = 0 OR maturity = ANY($13::text[]))
+  -- subindustry is likewise a NULLABLE SCALAR: membership, not overlap; NULL matches none.
+  AND (coalesce(cardinality($14::text[]), 0) = 0 OR subindustry = ANY($14::text[]))
 ORDER BY job_count DESC, name
-LIMIT $15 OFFSET $14
+LIMIT $16 OFFSET $15
 `
 
 type ListCompaniesParams struct {
@@ -229,6 +271,7 @@ type ListCompaniesParams struct {
 	YcStage       []string `json:"yc_stage"`
 	YcFlags       []string `json:"yc_flags"`
 	Maturity      []string `json:"maturity"`
+	Subindustries []string `json:"subindustries"`
 	Offset        int32    `json:"offset"`
 	Limit         int32    `json:"limit"`
 }
@@ -271,6 +314,7 @@ func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([
 		arg.YcStage,
 		arg.YcFlags,
 		arg.Maturity,
+		arg.Subindustries,
 		arg.Offset,
 		arg.Limit,
 	)
@@ -615,17 +659,18 @@ func (q *Queries) UpsertCompanyInfo(ctx context.Context, arg UpsertCompanyInfoPa
 
 const upsertYCCompany = `-- name: UpsertYCCompany :exec
 INSERT INTO companies (
-    slug, name, industries, year_founded, employee_count, hq_country,
+    slug, name, industries, subindustry, year_founded, employee_count, hq_country,
     tagline, company_info, yc_batch, yc_status, yc_stage, yc_flags,
     is_reference, company_info_at
 ) VALUES (
     $1, $2, $3, $4,
-    $5, $6, $7,
-    $8, $9, $10,
-    $11, $12, true, now()
+    $5, $6, $7, $8,
+    $9, $10, $11,
+    $12, $13, true, now()
 )
 ON CONFLICT (slug) DO UPDATE SET
     industries      = EXCLUDED.industries,
+    subindustry     = EXCLUDED.subindustry,
     year_founded    = EXCLUDED.year_founded,
     employee_count  = EXCLUDED.employee_count,
     hq_country      = EXCLUDED.hq_country,
@@ -643,6 +688,7 @@ type UpsertYCCompanyParams struct {
 	Slug          string          `json:"slug"`
 	Name          string          `json:"name"`
 	Industries    []string        `json:"industries"`
+	Subindustry   pgtype.Text     `json:"subindustry"`
 	YearFounded   pgtype.Int4     `json:"year_founded"`
 	EmployeeCount pgtype.Int4     `json:"employee_count"`
 	HqCountry     pgtype.Text     `json:"hq_country"`
@@ -665,6 +711,7 @@ func (q *Queries) UpsertYCCompany(ctx context.Context, arg UpsertYCCompanyParams
 		arg.Slug,
 		arg.Name,
 		arg.Industries,
+		arg.Subindustry,
 		arg.YearFounded,
 		arg.EmployeeCount,
 		arg.HqCountry,

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -60,6 +60,7 @@ type Company struct {
 	YcStage          []string           `json:"yc_stage"`
 	YcFlags          []string           `json:"yc_flags"`
 	Maturity         pgtype.Text        `json:"maturity"`
+	Subindustry      pgtype.Text        `json:"subindustry"`
 }
 
 type Email struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -114,6 +114,10 @@ type Querier interface {
 	// excluding the final row, so the sitemap index can list each company sub-sitemap's
 	// keyset cursor.
 	CompanySitemapBoundaries(ctx context.Context, chunkSize int64) ([]string, error)
+	// Distinct non-NULL subindustry values with their company counts, most common first
+	// (ties broken by value), serving the searchable option list for the subindustry facet.
+	// Counts are unconditional — they do not reflect other active list filters.
+	CompanySubindustries(ctx context.Context) ([]CompanySubindustriesRow, error)
 	// Total companies matching the same optional name + facet filters as ListCompanies,
 	// so search/filter pagination reports the filtered total. Keep this WHERE identical
 	// to ListCompanies.

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -30,6 +30,8 @@ WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || 
   -- maturity is a SCALAR column (not an array): membership, not overlap. A NULL
   -- (unknown) maturity matches no requested value, so `NULL = ANY(...)` excludes it.
   AND (coalesce(cardinality(sqlc.arg('maturity')::text[]), 0) = 0 OR maturity = ANY(sqlc.arg('maturity')::text[]))
+  -- subindustry is likewise a NULLABLE SCALAR: membership, not overlap; NULL matches none.
+  AND (coalesce(cardinality(sqlc.arg('subindustries')::text[]), 0) = 0 OR subindustry = ANY(sqlc.arg('subindustries')::text[]))
 ORDER BY job_count DESC, name
 LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 
@@ -51,7 +53,18 @@ WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || 
   AND (coalesce(cardinality(sqlc.arg('yc_status')::text[]), 0) = 0 OR yc_status && sqlc.arg('yc_status')::text[])
   AND (coalesce(cardinality(sqlc.arg('yc_stage')::text[]), 0) = 0 OR yc_stage && sqlc.arg('yc_stage')::text[])
   AND (coalesce(cardinality(sqlc.arg('yc_flags')::text[]), 0) = 0 OR yc_flags && sqlc.arg('yc_flags')::text[])
-  AND (coalesce(cardinality(sqlc.arg('maturity')::text[]), 0) = 0 OR maturity = ANY(sqlc.arg('maturity')::text[]));
+  AND (coalesce(cardinality(sqlc.arg('maturity')::text[]), 0) = 0 OR maturity = ANY(sqlc.arg('maturity')::text[]))
+  AND (coalesce(cardinality(sqlc.arg('subindustries')::text[]), 0) = 0 OR subindustry = ANY(sqlc.arg('subindustries')::text[]));
+
+-- name: CompanySubindustries :many
+-- Distinct non-NULL subindustry values with their company counts, most common first
+-- (ties broken by value), serving the searchable option list for the subindustry facet.
+-- Counts are unconditional — they do not reflect other active list filters.
+SELECT subindustry AS value, count(*) AS count
+FROM companies
+WHERE subindustry IS NOT NULL
+GROUP BY subindustry
+ORDER BY count(*) DESC, subindustry;
 
 -- name: ListCompanySitemap :many
 -- Slim keyset page of companies for the sitemap, cursored by the slug primary key
@@ -163,17 +176,18 @@ ON CONFLICT (slug) DO UPDATE SET
 -- facet arrays (regions/remote_regions/countries/domains/company_types/company_sizes)
 -- are left untouched. Idempotent: re-running the same entry rewrites the same values.
 INSERT INTO companies (
-    slug, name, industries, year_founded, employee_count, hq_country,
+    slug, name, industries, subindustry, year_founded, employee_count, hq_country,
     tagline, company_info, yc_batch, yc_status, yc_stage, yc_flags,
     is_reference, company_info_at
 ) VALUES (
-    sqlc.arg(slug), sqlc.arg(name), sqlc.arg(industries), sqlc.arg(year_founded),
-    sqlc.arg(employee_count), sqlc.arg(hq_country), sqlc.arg(tagline),
+    sqlc.arg(slug), sqlc.arg(name), sqlc.arg(industries), sqlc.arg(subindustry),
+    sqlc.arg(year_founded), sqlc.arg(employee_count), sqlc.arg(hq_country), sqlc.arg(tagline),
     sqlc.arg(company_info), sqlc.arg(yc_batch), sqlc.arg(yc_status),
     sqlc.arg(yc_stage), sqlc.arg(yc_flags), true, now()
 )
 ON CONFLICT (slug) DO UPDATE SET
     industries      = EXCLUDED.industries,
+    subindustry     = EXCLUDED.subindustry,
     year_founded    = EXCLUDED.year_founded,
     employee_count  = EXCLUDED.employee_count,
     hq_country      = EXCLUDED.hq_country,

--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -109,6 +109,7 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 	ycStage := facetValues(vals, "yc_stage")
 	ycFlags := facetValues(vals, "yc_flags")
 	maturity := facetValues(vals, "maturity")
+	subindustries := facetValues(vals, "subindustries")
 
 	companies, err := a.queries.ListCompanies(c.Context(), db.ListCompaniesParams{
 		Search:        search,
@@ -124,6 +125,7 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 		YcStage:       ycStage,
 		YcFlags:       ycFlags,
 		Maturity:      maturity,
+		Subindustries: subindustries,
 		Limit:         int32(limit),
 		Offset:        int32(offset),
 	})
@@ -145,12 +147,35 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 		YcStage:       ycStage,
 		YcFlags:       ycFlags,
 		Maturity:      maturity,
+		Subindustries: subindustries,
 	})
 	if err != nil {
 		return err
 	}
 
 	return listResponse(c, companies, total, limit, offset)
+}
+
+// subindustryFacet is one option in the company subindustry vocabulary: a clean YC
+// subindustry leaf and the number of companies carrying it.
+type subindustryFacet struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
+// CompanySubindustries serves the distinct subindustry vocabulary with company counts,
+// most common first, backing the searchable "Industry" facet's option list. Counts are
+// unconditional (they do not reflect other active list filters).
+func (a *API) CompanySubindustries(c *fiber.Ctx) error {
+	rows, err := a.queries.CompanySubindustries(c.Context())
+	if err != nil {
+		return err
+	}
+	out := make([]subindustryFacet, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, subindustryFacet{Value: r.Value.String, Count: r.Count})
+	}
+	return c.JSON(fiber.Map{"data": out})
 }
 
 // facetValues reads the repeatable values of one facet query param, dropping empty

--- a/internal/handler/companies_integration_test.go
+++ b/internal/handler/companies_integration_test.go
@@ -222,6 +222,134 @@ func TestListCompaniesFacetFilterEndpoint(t *testing.T) {
 	})
 }
 
+func TestListCompaniesSubindustryFacet(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	// subindustry is a nullable SCALAR column filtered by membership (= ANY), so a
+	// NULL-subindustry company must never match a subindustries filter.
+	seed := func(slug string, subindustry any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO companies (slug, name, subindustry) VALUES ($1, $1, $2)`,
+			slug, subindustry); err != nil {
+			t.Fatalf("seed %q: %v", slug, err)
+		}
+	}
+	seed("payco", "Payments")
+	seed("payco2", "Payments")
+	seed("diagco", "Diagnostics")
+	seed("plainco", nil) // NULL subindustry
+
+	h := &API{pool: pool, queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/companies", h.ListCompanies)
+
+	assert := func(t *testing.T, url string, want []string) {
+		t.Helper()
+		resp, err := app.Test(httptest.NewRequest("GET", url, nil))
+		if err != nil {
+			t.Fatalf("request %q: %v", url, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+		var body struct {
+			Data []struct {
+				Slug string `json:"slug"`
+			} `json:"data"`
+			Meta struct {
+				Total float64 `json:"total"`
+			} `json:"meta"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		var got []string
+		for _, c := range body.Data {
+			got = append(got, c.Slug)
+		}
+		sort.Strings(got)
+		sort.Strings(want)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("%s → slugs %v, want %v", url, got, want)
+		}
+		if int(body.Meta.Total) != len(want) {
+			t.Errorf("%s → meta.total %v, want %d", url, body.Meta.Total, len(want))
+		}
+	}
+
+	t.Run("single subindustry filters by membership", func(t *testing.T) {
+		assert(t, "/api/v1/companies?subindustries=Payments", []string{"payco", "payco2"})
+	})
+
+	t.Run("multiple subindustries are OR-ed", func(t *testing.T) {
+		assert(t, "/api/v1/companies?subindustries=Payments&subindustries=Diagnostics",
+			[]string{"diagco", "payco", "payco2"})
+	})
+
+	t.Run("NULL subindustry matches no filter", func(t *testing.T) {
+		assert(t, "/api/v1/companies?subindustries=Payments", []string{"payco", "payco2"})
+	})
+
+	t.Run("no subindustry param returns all", func(t *testing.T) {
+		assert(t, "/api/v1/companies", []string{"diagco", "payco", "payco2", "plainco"})
+	})
+}
+
+func TestCompanySubindustriesEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	seed := func(slug string, subindustry any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO companies (slug, name, subindustry) VALUES ($1, $1, $2)`,
+			slug, subindustry); err != nil {
+			t.Fatalf("seed %q: %v", slug, err)
+		}
+	}
+	seed("payco", "Payments")
+	seed("payco2", "Payments")
+	seed("diagco", "Diagnostics")
+	seed("plainco", nil) // NULL — excluded from the vocabulary
+
+	h := &API{pool: pool, queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/companies/subindustries", h.CompanySubindustries)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/companies/subindustries", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+	}
+	var body struct {
+		Data []struct {
+			Value string `json:"value"`
+			Count int    `json:"count"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Distinct non-NULL subindustries, most common first; NULL excluded.
+	if len(body.Data) != 2 {
+		t.Fatalf("got %d rows, want 2: %+v", len(body.Data), body.Data)
+	}
+	if body.Data[0].Value != "Payments" || body.Data[0].Count != 2 {
+		t.Errorf("row[0] = %+v, want {Payments 2}", body.Data[0])
+	}
+	if body.Data[1].Value != "Diagnostics" || body.Data[1].Count != 1 {
+		t.Errorf("row[1] = %+v, want {Diagnostics 1}", body.Data[1])
+	}
+}
+
 func TestListCompaniesRemoteRegionsFacet(t *testing.T) {
 	pool := startPostgres(t)
 	ctx := context.Background()

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -269,6 +269,7 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/companies", a.ListCompanies)
 	api.Get("/companies/sitemap", a.CompanySitemap)
 	api.Get("/companies/sitemap/boundaries", a.CompanySitemapBoundaries)
+	api.Get("/companies/subindustries", a.CompanySubindustries)
 	api.Get("/companies/:slug", a.GetCompany)
 
 	// Public read of a shared saved-search "board" by its slug — unauthenticated, like

--- a/internal/ycdir/ycdir.go
+++ b/internal/ycdir/ycdir.go
@@ -42,6 +42,7 @@ type Record struct {
 	Name          string
 	Tagline       string
 	Industries    []string
+	Subindustry   string // clean YC subindustry-path leaf ("" = unknown)
 	EmployeeCount int    // 0 = unknown
 	YearFounded   int    // 0 = unknown
 	HQCountry     string // "" = unknown
@@ -67,6 +68,7 @@ func Map(e Entry) (Record, bool) {
 		Name:          name,
 		Tagline:       strings.TrimSpace(e.OneLiner),
 		Industries:    industries(e),
+		Subindustry:   subindustryLeaf(e.Subindustry),
 		EmployeeCount: e.TeamSize,
 		YearFounded:   launchYear(e.LaunchedAt),
 		HQCountry:     hqCountry(e.AllLocations),

--- a/internal/ycdir/ycdir_test.go
+++ b/internal/ycdir/ycdir_test.go
@@ -40,6 +40,11 @@ func TestMapFullEntry(t *testing.T) {
 	if !reflect.DeepEqual(r.Industries, []string{"Industrials", "Manufacturing", "Manufacturing and Robotics", "Robotics", "Hardware"}) {
 		t.Errorf("industries = %v", r.Industries)
 	}
+	// subindustry is the clean leaf of the YC subindustry path, stored separately from
+	// the tag-inclusive industries bag.
+	if r.Subindustry != "Manufacturing and Robotics" {
+		t.Errorf("subindustry = %q, want %q", r.Subindustry, "Manufacturing and Robotics")
+	}
 	if r.EmployeeCount != 58 {
 		t.Errorf("employee_count = %d, want 58", r.EmployeeCount)
 	}
@@ -102,5 +107,8 @@ func TestMapMissingOptionalsOmitted(t *testing.T) {
 	}
 	if !reflect.DeepEqual(r.Industries, []string{"Fintech"}) {
 		t.Errorf("industries = %v, want [Fintech]", r.Industries)
+	}
+	if r.Subindustry != "" {
+		t.Errorf("subindustry = %q, want empty (no subindustry given)", r.Subindustry)
 	}
 }

--- a/migrations/0018_company_subindustry.sql
+++ b/migrations/0018_company_subindustry.sql
@@ -1,0 +1,18 @@
+-- Clean YC subindustry classification (see the company-subindustry-facet change).
+-- subindustry is the leaf of the YC subindustry path (e.g.
+-- 'Industrials -> Manufacturing and Robotics' -> 'Manufacturing and Robotics'),
+-- populated by cmd/import-yc from the yc-oss directory entry. It is stored SEPARATELY
+-- from the flattened, tag-inclusive companies.industries display array, so the noisy
+-- free tags never reach the filter: the industry FACET reads this clean column while
+-- the display chips keep using industries.
+--
+-- Like maturity, subindustry is a SCALAR text column, NULLABLE on purpose: NULL means
+-- "no clean subindustry" (a non-YC company, or a YC entry without one) and filters by
+-- membership (subindustry = ANY(...)) rather than array overlap — never guessed.
+--
+-- Applied to a fresh volume by initdb after 0017; on an existing prod volume this
+-- statement must be run manually BEFORE deploying code that reads the column, then
+-- cmd/import-yc is re-run to populate every YC company.
+
+ALTER TABLE public.companies
+    ADD COLUMN subindustry text;

--- a/openspec/changes/company-subindustry-facet/.openspec.yaml
+++ b/openspec/changes/company-subindustry-facet/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/company-subindustry-facet/design.md
+++ b/openspec/changes/company-subindustry-facet/design.md
@@ -1,0 +1,75 @@
+## Context
+
+`companies.industries` (`TEXT[]`) flattens YC's `industry` (top-level, ~8), `industries[]`,
+`subindustry` leaf, and free `tags` into one array, and is used only for display (chips on the
+company page, first value on the card/OG image). The team's published position is that this
+flattened array is "too noisy to trust" for classification — the noise being the unbounded
+tags. The company "Industry" filter is actually the job-derived `domains` facet (14 coarse
+buckets), which does not use `industries` at all. YC's `subindustry` (a single path per company,
+~100 bounded leaves) is the clean, structured slice, and is the natural rich industry axis.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let users filter companies by their clean YC subindustry via a searchable facet.
+- Keep the noisy tags out of the filter while leaving the display bag untouched.
+
+**Non-Goals:**
+- Classifying non-YC companies into the taxonomy (an LLM project deliberately avoided);
+  coverage is YC-only.
+- Touching `companies.industries` (display) or the job-derived `domains` facet's data.
+- Conditional (filter-aware) facet counts like the Meilisearch job facets.
+
+## Decisions
+
+**Store the subindustry as a clean scalar column (`companies.subindustry TEXT`, nullable),
+separate from `industries`.** The noise lives in tags; separating the structured leaf into its
+own column is the structural answer to "industries are noisy" — the filter reads the clean
+column, the display keeps the full bag. Scalar (not array) because YC assigns one subindustry
+per company. *Alternative rejected:* faceting on the existing `industries` column with a
+curated option list — cheaper but re-admits tag contamination at filter time and offers no
+clean provenance.
+
+**Filter by membership, mirroring `maturity`.** The `subindustries` param filters
+`subindustry = ANY($)`, NULL matches nothing — an exact copy of the existing scalar `maturity`
+facet, so no new filtering pattern is introduced.
+
+**Serve the option vocabulary from a new dynamic endpoint
+`GET /api/v1/companies/subindustries` (value + count).** Companies have no facet-values
+endpoint today (job facets use Meilisearch; company facets are static frontend lists), so this
+is net-new. Chosen over a static generated TS list because a ~100-item list is better with live
+counts and self-updates as `import-yc` runs, and subindustry leaves are already human-readable
+(no label map needed). Counts are unconditional — a deliberate simplification; conditional
+faceting over SQL is out of scope.
+
+**Relabel the existing `domains` facet "Industry" → "Domain".** Two distinct axes now exist
+(job-derived domain vs YC industry); relabelling avoids two "Industry" filters. Data and param
+of `domains` are unchanged — label only.
+
+**Populate via `cmd/import-yc`; backfill by re-running it.** `ycdir.Map` gains
+`Record.Subindustry = subindustryLeaf(e.Subindustry)`; `UpsertYCCompany` writes it. The upsert
+is idempotent, so re-running `cmd/import-yc` backfills existing rows — no separate backfill
+tool.
+
+## Risks / Trade-offs
+
+- **YC-only coverage** → accepted and stated in the facet's framing; NULL is never guessed, so
+  non-YC companies simply aren't matched (honest, not wrong).
+- **Unconditional counts can overstate availability under other active filters** → acceptable
+  for a discovery filter; the list result itself is always correctly filtered.
+- **New company facet-values endpoint is a new pattern** → small (one query + handler + route);
+  a reasonable seam for future company facets.
+
+## Migration Plan
+
+- Add `companies.subindustry TEXT` migration; apply manually to prod before deploy (migrations
+  convention — no versioned runner).
+- Regenerate `internal/db` via `make sqlc`.
+- Post-deploy: re-run `cmd/import-yc` to populate `subindustry`. No reindex (SQL filter).
+- Rollback: the column and endpoint are additive; reverting the frontend facet hides it, and the
+  column can be left in place harmlessly.
+
+## Open Questions
+
+- Whether to surface `subindustry` in the company API payload for display later (out of scope
+  now; the facet does not require it).

--- a/openspec/changes/company-subindustry-facet/proposal.md
+++ b/openspec/changes/company-subindustry-facet/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The company "Industry" filter is today the job-derived `domains` facet (14 coarse buckets from
+`enrichment.domains`), which throws away the rich YC industry taxonomy carried in
+`companies.industries`. Users cannot filter companies by their actual industry vertical
+(e.g. "Payments", "Diagnostics"). We deliberately do not trust the flattened `industries`
+array for classification — it mixes YC's clean top-level industry and subindustry with an
+unbounded, noisy tag cloud. But the **structured subindustry** (`e.subindustry` leaf, ~100
+bounded YC-defined values) is clean and trustworthy, and is the natural rich industry axis.
+
+## What Changes
+
+- Store each YC company's clean **subindustry** (the leaf of YC's `subindustry` path) in a new
+  scalar `companies.subindustry` column, sourced from `cmd/import-yc`. The existing
+  `companies.industries` bag (including noisy tags) is untouched and keeps serving the company
+  display chips.
+- Add a **scalar** company-list facet `subindustries` that filters `companies.subindustry` by
+  membership (`= ANY`), mirroring the existing `maturity` facet.
+- Serve the facet's option vocabulary from a new dynamic endpoint
+  `GET /api/v1/companies/subindustries` returning the distinct subindustries with company
+  counts (a searchable ~100-item list, self-maintaining).
+- Frontend: a new searchable "Industry" facet driven by that endpoint; the existing
+  `domains` facet is relabelled from "Industry" to "Domain" so the two distinct axes
+  (job-derived domain vs YC industry) don't collide.
+
+Coverage is YC companies only — a company with no YC subindustry (`NULL`) is not matched by the
+facet (never guessed).
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `companies`: adds a clean scalar `subindustry` classification column (distinct from the noisy
+  `industries` display bag), a `subindustries` membership facet on the company list, and a
+  dynamic subindustry facet-vocabulary endpoint.
+
+## Impact
+
+- Migration: new `companies.subindustry` column (manual apply, per the migrations convention).
+- `internal/ycdir` (new `Record.Subindustry`), `internal/db/queries/companies.sql`
+  (`UpsertYCCompany` write, `ListCompanies`/`CountCompanies` filter, new facet-values query) +
+  regenerated `internal/db/*.go`, `internal/handler/companies.go` (param + new endpoint).
+- Frontend `web/src/lib/facets.ts` (new facet + `domains` relabel) and the filter modal's
+  option loading.
+- Ops: apply migration, then re-run `cmd/import-yc` to populate. No reindex.

--- a/openspec/changes/company-subindustry-facet/specs/companies/spec.md
+++ b/openspec/changes/company-subindustry-facet/specs/companies/spec.md
@@ -1,0 +1,148 @@
+## ADDED Requirements
+
+### Requirement: Companies carry a clean YC subindustry classification
+
+The system SHALL store, on each `companies` row, a nullable scalar `subindustry` (`TEXT`)
+holding the leaf of the company's YC subindustry path (e.g. `Industrials -> Manufacturing and
+Robotics` → `Manufacturing and Robotics`). It SHALL be populated by `cmd/import-yc` from the
+directory entry's `subindustry` field and SHALL be distinct from the existing
+`companies.industries` array, which continues to hold the flattened, tag-inclusive display bag
+unchanged. A company with no YC subindustry (a non-YC company, or a YC entry without one) SHALL
+have `subindustry = NULL`. The value SHALL be a clean, human-readable taxonomy leaf, not a free
+tag, so it is safe to offer as a filter option.
+
+#### Scenario: Import stores the subindustry leaf
+
+- **WHEN** `cmd/import-yc` imports a directory entry with `subindustry`
+  `"Industrials -> Manufacturing and Robotics"`
+- **THEN** that company's `companies.subindustry` is `"Manufacturing and Robotics"` and its
+  `companies.industries` display array is unchanged
+
+#### Scenario: A non-YC company has no subindustry
+
+- **WHEN** a company has no matching YC directory entry
+- **THEN** its `companies.subindustry` is `NULL`
+
+### Requirement: The subindustry facet vocabulary is served dynamically with counts
+
+The system SHALL expose `GET /api/v1/companies/subindustries` returning, under `data`, the
+distinct non-`NULL` `companies.subindustry` values each with the count of companies carrying it,
+ordered by count descending then value ascending. This serves the searchable option list for the
+subindustry facet; the counts are unconditional (they do not reflect other active filters — a
+deliberate simplification versus the Meilisearch job facets). Each item SHALL carry `value` and
+`count`.
+
+#### Scenario: Listing available subindustries with counts
+
+- **WHEN** a client requests `GET /api/v1/companies/subindustries`
+- **THEN** the response lists every distinct non-`NULL` subindustry with its company count,
+  most common first
+
+## MODIFIED Requirements
+
+### Requirement: Company list is served without joining jobs
+
+The system SHALL expose `GET /api/v1/companies` returning companies read from the
+`companies` table. Each company's job count SHALL be read from the denormalized
+`companies.job_count` column (open jobs only), not computed at query time, so the
+read path performs no join to the `jobs` table. The list SHALL be ordered by
+`job_count` descending, then `name` ascending, so the most active companies
+surface first.
+
+The endpoint SHALL accept an optional `q` query parameter that filters companies
+by a case-insensitive substring match on the company `name`. An absent or empty
+`q` SHALL return the unfiltered list.
+
+The endpoint SHALL additionally accept repeatable facet query parameters —
+`collections`, `regions`, `countries`, `domains`, `company_type`, `company_size`,
+`remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, and `yc_flags` — each
+filtering against the company's corresponding denormalized array by **array
+overlap**: a company matches a facet when its array shares at least one value with
+the requested values (OR within a facet), and a company must match every provided
+facet (AND across facets). The `remote_regions` facet filters the job-derived
+remote-hiring regions (a subset of `regions`). The `yc_batch`, `yc_status`,
+`yc_stage`, and `yc_flags` facets filter the curated YC-directory columns (see the
+`yc-company-enrichment` capability); a non-YC company has them empty and matches
+none. Facet filters SHALL compose with the `q` name search. An absent facet
+parameter SHALL not constrain the list.
+
+The endpoint SHALL additionally accept the repeatable **scalar** facet parameters
+`maturity` and `subindustries`, each filtering against a single-valued company
+column (`companies.maturity` / `companies.subindustry`) by **membership**: a company
+matches when its scalar value is among the requested values (OR within the facet),
+and each ANDs with the others and with `q` exactly like the array facets. A company
+whose column is `NULL` matches no value for that facet. `maturity` values are
+`government`, `startup`, `scaleup`, `enterprise`; `subindustries` values are the
+YC subindustry leaves served by `GET /api/v1/companies/subindustries`.
+
+When any filter (`q` or a facet) is applied, the list `meta.total` SHALL report
+the count of companies matching the full filter combination, so pagination over
+the filtered results is correct.
+
+#### Scenario: Listing companies most-active first
+
+- **WHEN** a client requests `GET /api/v1/companies`
+- **THEN** the response contains companies under `data` with list `meta`,
+  ordered by `job_count` descending (ties broken by `name`), each carrying its
+  denormalized `job_count`
+
+#### Scenario: Searching companies by name
+
+- **WHEN** a client requests `GET /api/v1/companies?q=acme`
+- **THEN** the response contains only companies whose name matches `acme`
+  case-insensitively, ordered by `job_count` descending, and `meta.total` is the
+  count of matching companies
+
+#### Scenario: Empty query returns the full list
+
+- **WHEN** a client requests `GET /api/v1/companies?q=` (empty or absent)
+- **THEN** the response is the unfiltered company list, identical to omitting the
+  parameter
+
+#### Scenario: Filtering by a single facet
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe`
+- **THEN** the response contains only companies whose `regions` array contains
+  `europe`, and `meta.total` is the count of such companies
+
+#### Scenario: Multiple values within one facet are OR-ed
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe&regions=asia`
+- **THEN** the response contains companies whose `regions` overlap
+  `{europe, asia}` (in Europe **or** Asia)
+
+#### Scenario: Different facets are AND-ed and compose with search
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?collections=yc&company_type=startup&q=lab`
+- **THEN** the response contains only companies that are in the `yc` collection
+  **and** have `startup` among their `company_types` **and** whose name matches
+  `lab`
+
+#### Scenario: Filtering by remote-hiring regions
+
+- **WHEN** a client requests `GET /api/v1/companies?remote_regions=eu`
+- **THEN** the response contains only companies whose `remote_regions` array
+  contains `eu`, and `meta.total` is the count of such companies
+
+#### Scenario: Filtering by YC facets
+
+- **WHEN** a client requests `GET /api/v1/companies?yc_stage=Growth&yc_flags=top_company`
+- **THEN** the response contains only companies whose `yc_stage` contains `Growth`
+  **and** whose `yc_flags` contains `top_company`, and `meta.total` is the count of
+  such companies
+
+#### Scenario: Filtering by the scalar maturity facet
+
+- **WHEN** a client requests `GET /api/v1/companies?maturity=startup&maturity=scaleup`
+- **THEN** the response contains only companies whose `maturity` is `startup` **or**
+  `scaleup`, excluding any company whose `maturity` is `NULL`, and `meta.total` is
+  the count of such companies
+
+#### Scenario: Filtering by the scalar subindustry facet
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?subindustries=Payments&subindustries=Diagnostics`
+- **THEN** the response contains only companies whose `subindustry` is `Payments`
+  **or** `Diagnostics`, excluding any company whose `subindustry` is `NULL`, and
+  `meta.total` is the count of such companies

--- a/openspec/changes/company-subindustry-facet/tasks.md
+++ b/openspec/changes/company-subindustry-facet/tasks.md
@@ -16,5 +16,5 @@
 
 ## 5. Verify & rollout
 
-- [ ] 5.1 Full verification: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -tags=integration ./internal/db/ ./internal/handler/`, and a manual run of the subindustry filter end-to-end
-- [ ] 5.2 Record post-deploy ops (apply the `subindustry` migration, then re-run `cmd/import-yc` to populate; no reindex) and offer a `/blog` changelog entry
+- [x] 5.1 Full verification: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -tags=integration ./internal/db/ ./internal/handler/`, and a manual run of the subindustry filter end-to-end
+- [x] 5.2 Record post-deploy ops (apply the `subindustry` migration, then re-run `cmd/import-yc` to populate; no reindex) and offer a `/blog` changelog entry

--- a/openspec/changes/company-subindustry-facet/tasks.md
+++ b/openspec/changes/company-subindustry-facet/tasks.md
@@ -1,0 +1,20 @@
+## 1. Subindustry storage & population
+
+- [ ] 1.1 Add the `companies.subindustry TEXT` (nullable) migration; add `Record.Subindustry` to `internal/ycdir` set from `subindustryLeaf(e.Subindustry)` (driven by a `ycdir` unit test), and write it in the `UpsertYCCompany` query + `cmd/import-yc`; regenerate `internal/db` via `make sqlc`
+
+## 2. Subindustry filter on the company list
+
+- [ ] 2.1 Add the scalar `subindustries` membership filter (`subindustry = ANY($)`, NULL matches nothing — mirroring `maturity`) to `ListCompanies` and `CountCompanies`, regenerate via `make sqlc`, and parse the `subindustries` param in `internal/handler/companies.go`. Driven by failing integration tests in `internal/db` / `internal/handler` covering the OR-within / AND-across / NULL-excluded scenarios
+
+## 3. Dynamic subindustry facet-values endpoint
+
+- [ ] 3.1 Add the distinct-subindustry-with-counts query (`WHERE subindustry IS NOT NULL GROUP BY subindustry ORDER BY count DESC, subindustry`), a `GET /api/v1/companies/subindustries` handler returning `{data:[{value,count}]}`, and its route wiring. Driven by failing handler/integration tests
+
+## 4. Frontend facet
+
+- [ ] 4.1 In `web/src/lib/facets.ts` add a searchable `subindustries` facet labelled "Industry" whose options load from `GET /api/v1/companies/subindustries`, and relabel the existing `domains` facet "Industry" → "Domain"; wire the option loading into the companies filter modal. Verify via `svelte-check` + a visual check of the filter
+
+## 5. Verify & rollout
+
+- [ ] 5.1 Full verification: `go build ./...`, `go vet ./...`, `go test ./...`, `go test -tags=integration ./internal/db/ ./internal/handler/`, and a manual run of the subindustry filter end-to-end
+- [ ] 5.2 Record post-deploy ops (apply the `subindustry` migration, then re-run `cmd/import-yc` to populate; no reindex) and offer a `/blog` changelog entry

--- a/openspec/changes/company-subindustry-facet/tasks.md
+++ b/openspec/changes/company-subindustry-facet/tasks.md
@@ -1,14 +1,14 @@
 ## 1. Subindustry storage & population
 
-- [ ] 1.1 Add the `companies.subindustry TEXT` (nullable) migration; add `Record.Subindustry` to `internal/ycdir` set from `subindustryLeaf(e.Subindustry)` (driven by a `ycdir` unit test), and write it in the `UpsertYCCompany` query + `cmd/import-yc`; regenerate `internal/db` via `make sqlc`
+- [x] 1.1 Add the `companies.subindustry TEXT` (nullable) migration; add `Record.Subindustry` to `internal/ycdir` set from `subindustryLeaf(e.Subindustry)` (driven by a `ycdir` unit test), and write it in the `UpsertYCCompany` query + `cmd/import-yc`; regenerate `internal/db` via `make sqlc`
 
 ## 2. Subindustry filter on the company list
 
-- [ ] 2.1 Add the scalar `subindustries` membership filter (`subindustry = ANY($)`, NULL matches nothing — mirroring `maturity`) to `ListCompanies` and `CountCompanies`, regenerate via `make sqlc`, and parse the `subindustries` param in `internal/handler/companies.go`. Driven by failing integration tests in `internal/db` / `internal/handler` covering the OR-within / AND-across / NULL-excluded scenarios
+- [x] 2.1 Add the scalar `subindustries` membership filter (`subindustry = ANY($)`, NULL matches nothing — mirroring `maturity`) to `ListCompanies` and `CountCompanies`, regenerate via `make sqlc`, and parse the `subindustries` param in `internal/handler/companies.go`. Driven by failing integration tests in `internal/db` / `internal/handler` covering the OR-within / AND-across / NULL-excluded scenarios
 
 ## 3. Dynamic subindustry facet-values endpoint
 
-- [ ] 3.1 Add the distinct-subindustry-with-counts query (`WHERE subindustry IS NOT NULL GROUP BY subindustry ORDER BY count DESC, subindustry`), a `GET /api/v1/companies/subindustries` handler returning `{data:[{value,count}]}`, and its route wiring. Driven by failing handler/integration tests
+- [x] 3.1 Add the distinct-subindustry-with-counts query (`WHERE subindustry IS NOT NULL GROUP BY subindustry ORDER BY count DESC, subindustry`), a `GET /api/v1/companies/subindustries` handler returning `{data:[{value,count}]}`, and its route wiring. Driven by failing handler/integration tests
 
 ## 4. Frontend facet
 

--- a/openspec/changes/company-subindustry-facet/tasks.md
+++ b/openspec/changes/company-subindustry-facet/tasks.md
@@ -12,7 +12,7 @@
 
 ## 4. Frontend facet
 
-- [ ] 4.1 In `web/src/lib/facets.ts` add a searchable `subindustries` facet labelled "Industry" whose options load from `GET /api/v1/companies/subindustries`, and relabel the existing `domains` facet "Industry" → "Domain"; wire the option loading into the companies filter modal. Verify via `svelte-check` + a visual check of the filter
+- [x] 4.1 In `web/src/lib/facets.ts` add a searchable `subindustries` facet labelled "Industry" whose options load from `GET /api/v1/companies/subindustries`, and relabel the existing `domains` facet "Industry" → "Domain"; wire the option loading into the companies filter modal. Verify via `svelte-check` + a visual check of the filter
 
 ## 5. Verify & rollout
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -364,6 +364,12 @@ export function createApi(
     );
   }
 
+  /** The subindustry facet vocabulary (each clean YC leaf + its company count),
+   *  count-ordered, backing the company "Industry" filter's searchable options. */
+  async function listCompanySubindustries(): Promise<{ value: string; count: number }[]> {
+    return requestData<{ value: string; count: number }[]>('/api/v1/companies/subindustries');
+  }
+
   // --- Sitemap --------------------------------------------------------------
   //
   // Feeds behind the sitemap index (server routes only). Jobs ship their freshest
@@ -844,6 +850,7 @@ export function createApi(
     jobsActivity,
     listCompanies,
     getCompany,
+    listCompanySubindustries,
     sitemapJobs,
     sitemapCompanies,
     sitemapCompanyBoundaries,

--- a/web/src/lib/components/filters/CompanyFilterModal.svelte
+++ b/web/src/lib/components/filters/CompanyFilterModal.svelte
@@ -28,7 +28,8 @@
     { key: 'collections', label: 'Collection', params: ['collections'] },
     { key: 'region', label: 'Region', params: ['regions', 'remote_regions'] },
     { key: 'countries', label: 'Country', params: ['countries'] },
-    { key: 'domains', label: 'Industry', params: ['domains'] },
+    { key: 'subindustries', label: 'Industry', params: ['subindustries'] },
+    { key: 'domains', label: 'Domain', params: ['domains'] },
     { key: 'company', label: 'Company', params: ['company_type', 'company_size'] },
     { key: 'yc', label: 'Y Combinator', params: ['yc_status', 'yc_stage', 'yc_flags', 'yc_batch'] },
   ];

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -165,6 +165,30 @@ async function companySearch(query: string): Promise<FacetOption[]> {
   return items.map((c) => ({ value: c.slug, label: c.name, count: c.job_count }));
 }
 
+// Option source for the company "Industry" facet: the full YC subindustry
+// vocabulary with company counts, fetched ONCE and searched client-side. Unlike
+// the company entity facet (thousands of rows, queried server-side per keystroke),
+// this is a bounded ~100-value list, so the whole vocabulary is loaded up front and
+// cached at module scope — the filter modal reuses it instead of re-fetching per
+// open. The subindustry leaf is already human-readable, so value == label.
+let subindustryOptions: Promise<FacetOption[]> | null = null;
+function loadSubindustries(): Promise<FacetOption[]> {
+  return (subindustryOptions ??= api
+    .listCompanySubindustries()
+    .then((rows) => rows.map((r) => ({ value: r.value, label: r.value, count: r.count })))
+    .catch((e) => {
+      // Don't cache a failed fetch — clear it so a later open retries instead of
+      // leaving the facet permanently empty until a page reload.
+      subindustryOptions = null;
+      throw e;
+    }));
+}
+async function subindustrySearch(query: string): Promise<FacetOption[]> {
+  const all = await loadSubindustries();
+  const q = query.trim().toLowerCase();
+  return q ? all.filter((o) => o.label.toLowerCase().includes(q)) : all;
+}
+
 // Role facet values are canonical slugs (senior_backend, founding_engineer); the
 // live distribution carries no display name, so map them through the generated
 // ROLE_LABELS catalog (the roletag dictionary is the source of truth), falling
@@ -446,7 +470,8 @@ export const COMPANY_FACETS: FacetDef[] = [
   { param: 'regions', label: 'Region', control: 'pills', options: REGION, excludable: false },
   { param: 'remote_regions', label: 'Remote hiring', control: 'pills', options: REGION, excludable: false },
   { param: 'countries', label: 'Country', control: 'select', options: COUNTRY, excludable: false, placeholder: 'Search countries' },
-  { param: 'domains', label: 'Industry', control: 'select', options: DOMAINS, excludable: false, placeholder: 'Search industries' },
+  { param: 'subindustries', label: 'Industry', control: 'remote', excludable: false, placeholder: 'Search industries', remote: subindustrySearch },
+  { param: 'domains', label: 'Domain', control: 'select', options: DOMAINS, excludable: false, placeholder: 'Search domains' },
   { param: 'company_type', label: 'Company type', control: 'pills', options: COMPANY_TYPE, excludable: false },
   { param: 'company_size', label: 'Company size', control: 'pills', options: COMPANY_SIZE, excludable: false },
   { param: 'maturity', label: 'Company stage', control: 'pills', options: MATURITY, excludable: false },


### PR DESCRIPTION
## What

Adds a searchable **Industry** filter to the companies catalogue, driven by the clean YC **subindustry** taxonomy — replacing the previous "Industry" label on the coarse job-derived `domains` facet (now relabelled **Domain**).

Two distinct axes now read distinctly:
- **Industry** — the company's own YC subindustry leaf (~100 bounded, trustworthy values), searchable with counts.
- **Domain** — the job-enrichment `domains` facet (14 coarse buckets), unchanged.

## Why

The old "Industry" filter was the job-derived `domains` facet and ignored `companies.industries` entirely. The rich YC taxonomy sat unused. The flattened `industries` array is deliberately not trusted (noisy free tags), but its **structured subindustry** slice is clean — so we surface that, never the tags.

## How

- **Storage:** new nullable scalar `companies.subindustry` (migration `0018`), the YC subindustry-path leaf, populated by `cmd/import-yc`. Kept separate from the tag-noisy `industries` display bag. NULL = no clean subindustry (non-YC / not guessed).
- **Filter:** scalar `subindustries` membership filter on the company list (`subindustry = ANY($)`), a mirror of the existing `maturity` facet.
- **Vocabulary:** new `GET /api/v1/companies/subindustries` returns distinct subindustries with counts (unconditional). The web facet fetches it once (cached), searched client-side via the existing `RemoteSearchSelect` control.
- **Frontend:** new remote "Industry" facet; `domains` relabelled to "Domain".

Coverage is YC companies only (honest NULL for the rest).

## Verification

- `go vet ./...`, `go test ./...` — green
- `go test -tags=integration ./internal/db/ ./internal/handler/` — green (new subindustry filter + endpoint scenarios: OR-within, NULL-excluded, counts/order)
- web: `npm run build` ✓, `svelte-check` 0 errors, `vitest` 225 passed
- Live browser check deferred to preview (reuses the production-proven `RemoteSearchSelect` control).

## ⚠️ Deploy ops (manual, in order)

1. Apply migration `0018_company_subindustry.sql` to prod **before** deploying this code (no versioned runner — see migrations convention).
2. After deploy, re-run `cmd/import-yc` to populate `subindustry`.
3. No reindex (SQL-filtered, not Meilisearch).

OpenSpec change: `company-subindustry-facet`.