### PR TITLE
feat(assistant): in-app AI assistant chat at /my/assistant (moderators-only)

### DIFF
--- a/openspec/changes/add-assistant-chat/.openspec.yaml
+++ b/openspec/changes/add-assistant-chat/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/add-assistant-chat/design.md
+++ b/openspec/changes/add-assistant-chat/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The `freehire-agent` backend (a trimmed fork of `roy`) runs two processes:
+`roy serve` (daemon, Unix socket) and `roy management` (axum HTTP on `:8079`).
+Management exposes `POST /auth/login` (returns a JWT cookie **and** a
+`ws_token`) and a `GET /ws` WebSocket relay that transparently bridges the
+browser to the daemon over the raw roy control protocol
+(`ClientCommand` → daemon, `ServerEvent` ← daemon, one JSON per message).
+roy-web already implements the browser half of this protocol
+(`workspace/src/lib/wire.ts` + `client.ts`) as a plain Svelte SPA. freehire's
+web is SvelteKit SSR; the chat is a new authed route consuming the same
+protocol.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A working, streamed chat at `/my/assistant` against the agent backend.
+- Reuse the proven roy control-protocol client rather than reinventing it.
+- Keep the transport contract identical to roy-web (subprotocol auth, verbatim
+  JSON lines) so the backend needs no changes.
+- Pure-logic pieces (wire types, the `RoyClient`, the event→view reducer) are
+  unit-testable; components are verified by `svelte-check` + a visual pass.
+
+**Non-Goals:**
+- Giving the agent access to freehire data (MCP tools / prompt context).
+- Sharing freehire's session cookie with the agent backend (separate login for
+  now).
+- Production wiring / host-2 deployment.
+
+## Decisions
+
+- **Port, don't rewrite.** Copy `wire.ts` and `client.ts` from roy-web into
+  `web/src/lib/assistant/`, adapting imports/style. A separate pure reducer
+  (`reduceTurnEvent`) folds streamed `TurnEvent`s into the message-list view
+  model, mirroring how freehire isolates `reduceFitEvent` in `jobFit.ts` — so
+  the streaming logic is unit-tested without a DOM.
+- **Same-origin via dev proxy.** Add `/assistant-api` to `web/vite.config.ts`
+  proxying to `127.0.0.1:8079` with `ws: true`, so `/assistant-api/ws` upgrades
+  reach the backend `/ws`. The browser connects to a same-origin relative URL;
+  prod wiring is a later seam (nginx location), noted but not built.
+- **Session lifecycle in the page.** On mount: login to the agent backend
+  (MVP: its own `roy-auth`), obtain `ws_token`, open the WS with
+  `[roy-jwt, ws_token]`, spawn a `claude` session, subscribe to its frames.
+  Submitting a message sends a `Send` command; the reply streams as frames until
+  a terminal `Result`.
+- **Auth is the backend's own for the MVP.** The page performs a separate login
+  against `freehire-agent`. Sharing freehire's JWT (common secret + cookie) is
+  deliberately deferred to keep this change frontend-only.
+- **Graceful degradation.** A backend/WS failure yields a non-fatal error state;
+  the reducer ignores unmodeled event kinds instead of throwing.
+
+## Risks / Trade-offs
+
+- **Separate login is clunky UX.** Two logins (freehire + agent) until shared
+  auth lands. Accepted for the MVP; called out as the top follow-up seam.
+- **Dev-proxy only.** Local dev works same-origin; production needs an nginx
+  location for `/assistant-api` on host-2 (out of scope here).
+- **Ported code drift.** `wire.ts`/`client.ts` are copied from roy-web and can
+  diverge from the backend protocol over time; the backend protocol is the
+  source of truth and the port is thin, so drift risk is low and localized.
+- **Component test coverage.** freehire has no component test runner; the chat
+  UI relies on `svelte-check` + visual verification, with logic coverage
+  concentrated in the pure reducer/client.

--- a/openspec/changes/add-assistant-chat/proposal.md
+++ b/openspec/changes/add-assistant-chat/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+freehire has no in-app conversational surface. A trimmed `roy` backend
+(`freehire-agent`) now exposes a chat over a `/ws` WebSocket relay, but there is
+no way for a user to reach it from the freehire web app. This change adds the
+front-end chat page so a logged-in user can talk to a Claude agent inside
+freehire. It is the MVP slice: prove a working streamed chat. What the agent can
+*access* (freehire data, tools) is intentionally deferred.
+
+## What Changes
+
+- Port the roy-web control-protocol wire types (`wire.ts`) and WebSocket client
+  (`client.ts` → `RoyClient`) into `web/src/lib`, adapted to freehire's style.
+- Add a `/my/assistant` route: a simple chat (message list + composer) that logs
+  into the `freehire-agent` backend, opens `/ws` with the
+  `[roy-jwt, ws_token]` subprotocol, spawns a `claude` session, streams
+  `TurnEvent`s, and renders assistant text / thinking / tool-use / result.
+- Add a Vite dev proxy `/assistant-api` → `127.0.0.1:8079` (the agent backend),
+  including WebSocket upgrade support for `/assistant-api/ws`.
+- Auth is **unified with freehire**: the agent backend verifies the same
+  `hire_token` session cookie (shared JWT secret, stateless `sub` trust) and
+  provisions a passwordless shadow user for the FK — so there is **no separate
+  agent login**. The WebSocket authenticates from that cookie on the
+  same-origin upgrade (not a subprotocol token). The single claude credential is
+  a server-side env var, so there is no per-user harness onboarding.
+
+Out of scope (later seams): giving the agent access to freehire data
+(MCP/context), the prod cookie `Domain=.freehire.dev` for `agent.freehire.dev`,
+and host-2 deployment.
+
+## Capabilities
+
+### New Capabilities
+- `assistant-chat`: an in-app chat page that streams a conversation with a
+  Claude agent served by the separate `freehire-agent` backend over a WebSocket
+  relay.
+
+### Modified Capabilities
+<!-- none: no existing freehire capability's requirements change -->
+
+## Impact
+
+- **Frontend only** (the `hire` repo): new `web/src/lib/assistant/` (wire +
+  client + event reducer), new route `web/src/routes/my/assistant/`, and a
+  `web/vite.config.ts` proxy entry. No Go backend changes.
+- Depends on the separately-built `freehire-agent` service (roy `serve` +
+  `management` on `:8079`); not wired into freehire's deploy yet.
+- New dev-only config: the agent backend base URL (proxied at `/assistant-api`).

--- a/openspec/changes/add-assistant-chat/specs/assistant-chat/spec.md
+++ b/openspec/changes/add-assistant-chat/specs/assistant-chat/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: Assistant chat page
+
+The freehire web app SHALL provide a `/my/assistant` route that lets a
+logged-in user hold a streamed conversation with a Claude agent served by the
+`freehire-agent` backend. The page SHALL present a message list and a composer
+input, and SHALL render assistant replies as they stream.
+
+#### Scenario: Opening the assistant page
+
+- **WHEN** an authenticated user navigates to `/my/assistant`
+- **THEN** the page connects to the agent backend, establishes a chat session,
+  and shows a ready-to-type composer with an empty (or resumed) message list
+
+#### Scenario: Sending a message and streaming the reply
+
+- **WHEN** the user submits a message in the composer
+- **THEN** the message appears immediately in the list and the assistant's
+  reply is appended incrementally as `TurnEvent`s arrive, ending when a
+  terminal `Result` event is received
+
+#### Scenario: Backend unreachable
+
+- **WHEN** the agent backend cannot be reached or the WebSocket fails to open
+- **THEN** the page shows a non-fatal error state and the rest of freehire keeps
+  working (the failure does not break navigation or other `/my` pages)
+
+### Requirement: Agent-backend WebSocket transport
+
+The web app SHALL communicate with the agent backend over a WebSocket that
+speaks the roy control protocol verbatim: the client sends `ClientCommand`
+JSON and receives `ServerEvent` JSON, one JSON value per message. The client
+SHALL authenticate by offering the `Sec-WebSocket-Protocol` values
+`roy-jwt` (marker) and the login-issued `ws_token`, and SHALL never place the
+token anywhere the browser would expose it beyond that subprotocol slot.
+
+#### Scenario: Authenticated upgrade
+
+- **WHEN** the client opens the WebSocket after a successful agent-backend login
+- **THEN** it offers `[roy-jwt, <ws_token>]` as subprotocols and, on a successful
+  upgrade, streams commands and events over the socket
+
+#### Scenario: Connection lost mid-session
+
+- **WHEN** the WebSocket closes or errors while a session is open
+- **THEN** the client surfaces a disconnected status and any awaiting command
+  calls reject rather than hanging indefinitely
+
+### Requirement: Event rendering vocabulary
+
+The chat SHALL render the streamed `TurnEvent` kinds it understands —
+assistant text, assistant thinking, tool use, and the terminal result — and
+SHALL degrade gracefully for unmodeled events (showing nothing or a raw
+fallback) rather than crashing.
+
+#### Scenario: Assistant text and thinking
+
+- **WHEN** `AssistantText` and `AssistantThought` events stream in
+- **THEN** assistant text is rendered as the reply and thinking is shown as
+  distinct, secondary content (not mixed into the final answer)
+
+#### Scenario: Unknown event kind
+
+- **WHEN** an event of an unmodeled kind arrives
+- **THEN** the reducer ignores it (or shows a raw fallback) without throwing
+
+### Requirement: Development proxy to the agent backend
+
+The web dev server SHALL proxy `/assistant-api` to the agent backend at
+`127.0.0.1:8079`, including WebSocket upgrades for `/assistant-api/ws`, so the
+SPA and agent backend are same-origin in local development.
+
+#### Scenario: Proxied WebSocket in dev
+
+- **WHEN** the SPA opens `/assistant-api/ws` during local development
+- **THEN** the Vite dev server upgrades and forwards the connection to the agent
+  backend's `/ws` endpoint

--- a/openspec/changes/add-assistant-chat/tasks.md
+++ b/openspec/changes/add-assistant-chat/tasks.md
@@ -1,0 +1,49 @@
+## 1. Wire protocol + client (ported, unit-tested)
+
+- [ ] 1.1 Port `wire.ts` (control-protocol types: `ClientCommand`, `ServerEvent`,
+      `TurnEvent`/`JournalEntry`, `WS_SUBPROTOCOL_MARKER`) from roy-web into
+      `web/src/lib/assistant/wire.ts`, adapted to freehire's TS style.
+- [ ] 1.2 Port `client.ts` (`RoyClient` WS client: connect/close/call/fire/
+      subscribeFrames/onStatus) into `web/src/lib/assistant/client.ts`.
+
+## 2. Event reducer (pure logic, TDD)
+
+- [ ] 2.1 RED: write `web/src/lib/assistant/chat.test.ts` for `reduceTurnEvent`
+      — folds a stream of `TurnEvent`s into a message-list view model
+      (assistant text accumulates; thinking is separate; terminal `Result`
+      closes the turn; unknown kinds are ignored).
+- [ ] 2.2 GREEN: implement `reduceTurnEvent` in `web/src/lib/assistant/chat.ts`
+      until 2.1 passes.
+
+## 3. Chat page
+
+- [ ] 3.1 Add route `web/src/routes/my/assistant/+page.svelte`: message list +
+      composer; on mount login → `ws_token` → open `/assistant-api/ws` with
+      `[roy-jwt, ws_token]` → spawn a `claude` session → subscribe frames.
+- [ ] 3.2 Wire the composer: submit sends a `Send` command, optimistic user
+      message, stream reply via `reduceTurnEvent`; render text/thinking/tool-
+      use/result; show a non-fatal error state on backend/WS failure.
+- [ ] 3.3 Add the assistant entry to the `/my` navigation surface.
+
+## 4. Dev proxy
+
+- [ ] 4.1 Add `/assistant-api` proxy (with `ws: true`) → `127.0.0.1:8079` in
+      `web/vite.config.ts`.
+
+## 5. Unified auth (supersedes the separate agent login)
+
+- [x] 5.1 Backend (`freehire-agent`): verify freehire's `hire_token` cookie
+      (shared secret, `ROY_COOKIE_NAME`), WS auth from the handshake cookie,
+      single server-side harness credential, shadow-user provisioning.
+- [x] 5.2 Frontend: drop the inline agent-login form; WS opens with no
+      subprotocol token (freehire cookie carries auth); `createSession` via
+      cookie.
+
+## 6. Verify
+
+- [x] 6.1 `npm run check` clean (no new errors); `reduceTurnEvent` tests green.
+- [x] 6.2 Local end-to-end: with `roy serve` + `roy management` + a
+      `claude-code-acp` on PATH, one freehire login → `/my/assistant` streams a
+      real reply (verified: Claude replied "hi"/"pong").
+- [ ] 6.3 Port roy-web message rendering (markdown, tool-use cards, polished
+      design) into the assistant page.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,8 @@
         "@sentry/sveltekit": "^10.63.0",
         "clsx": "^2.1.1",
         "easymde": "^2.21.0",
+        "isomorphic-dompurify": "^3.18.0",
+        "marked": "^18.0.6",
         "satori": "^0.26.0",
         "satori-html": "^0.3.2",
         "svelte-dnd-action": "^0.9.70",
@@ -88,6 +90,53 @@
         "debug": "^4.4.1",
         "module-details-from-path": "^1.0.4"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -313,6 +362,152 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
@@ -470,6 +665,23 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -3440,6 +3652,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -3654,6 +3875,19 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3665,6 +3899,54 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -3683,6 +3965,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3715,6 +4003,15 @@
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -3738,6 +4035,18 @@
         "codemirror": "^5.65.15",
         "codemirror-spell-checker": "1.1.2",
         "marked": "^4.1.0"
+      }
+    },
+    "node_modules/easymde/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3767,6 +4076,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-errors": {
@@ -4293,6 +4614,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -4386,6 +4719,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -4402,6 +4741,19 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.18.0.tgz",
+      "integrity": "sha512-ajp0D8laIHeoYlhBTevpE2HUhqWaqLXFk6K/wV3Ok8kDraBZpZsifwVWaY8IfJntMRIo1VSksgKV+lXyet9Q7A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.11",
+        "jsdom": "^29.1.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -4417,6 +4769,90 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -4819,16 +5255,22 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.6.tgz",
+      "integrity": "sha512-MrV5puXBfuiy6wl6DLaq3BtIJQAJToAd5zt/ZKhRfGRAuFPALE7/4Y7jnxRQoEgK/pBgurGqLyAuRgZ2xOjr6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 20"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/mdsvex": {
       "version": "0.12.7",
@@ -5101,6 +5543,18 @@
         "hex-rgb": "^4.1.0"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5365,7 +5819,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5383,6 +5836,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-in-the-middle": {
@@ -5540,6 +6002,18 @@
       "license": "MIT",
       "dependencies": {
         "ultrahtml": "^1.2.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semifies": {
@@ -5848,6 +6322,12 @@
         "@types/estree": "^1.0.6"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -5958,6 +6438,24 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "license": "MIT"
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -5965,6 +6463,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -6065,6 +6575,15 @@
       "resolved": "https://registry.npmjs.org/ultrahtml/-/ultrahtml-1.7.0.tgz",
       "integrity": "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "8.3.0",
@@ -6387,11 +6906,32 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -6445,27 +6985,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,8 @@
     "@sentry/sveltekit": "^10.63.0",
     "clsx": "^2.1.1",
     "easymde": "^2.21.0",
+    "isomorphic-dompurify": "^3.18.0",
+    "marked": "^18.0.6",
     "satori": "^0.26.0",
     "satori-html": "^0.3.2",
     "svelte-dnd-action": "^0.9.70",

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { accountNav, isSectionActive, visibleAccountNav } from './accountNav';
 
 describe('accountNav config', () => {
-  it('lists the seven account sections', () => {
-    expect(accountNav).toHaveLength(7);
+  it('lists the eight account sections', () => {
+    expect(accountNav).toHaveLength(8);
   });
 
   it('places Activity directly after Tracking', () => {
@@ -26,15 +26,18 @@ describe('accountNav config', () => {
 });
 
 describe('visibleAccountNav', () => {
-  it('hides the moderator-only Inbox from non-moderators', () => {
+  it('hides the moderator-only sections (Assistant, Inbox) from non-moderators', () => {
     const hrefs = visibleAccountNav(false).map((i) => i.href);
     expect(hrefs).not.toContain('/my/inbox');
-    expect(hrefs).toHaveLength(accountNav.length - 1);
+    expect(hrefs).not.toContain('/my/assistant');
+    const moderatorOnly = accountNav.filter((i) => 'moderatorOnly' in i && i.moderatorOnly);
+    expect(hrefs).toHaveLength(accountNav.length - moderatorOnly.length);
   });
 
   it('shows every section to a moderator', () => {
     const hrefs = visibleAccountNav(true).map((i) => i.href);
     expect(hrefs).toContain('/my/inbox');
+    expect(hrefs).toContain('/my/assistant');
     expect(hrefs).toHaveLength(accountNav.length);
   });
 });

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -9,6 +9,8 @@
 // HeaderMenu's navLinks).
 export const accountNav = [
   { href: '/my/profile', label: 'Profile' },
+  // Assistant is a restricted rollout — moderators only for now.
+  { href: '/my/assistant', label: 'Assistant', moderatorOnly: true },
   { href: '/my/tracking', label: 'Tracking' },
   { href: '/my/activity', label: 'Activity' },
   // Mail inbox is a restricted rollout — moderators only (the server 403s others).

--- a/web/src/lib/assistant/api.ts
+++ b/web/src/lib/assistant/api.ts
@@ -1,0 +1,38 @@
+import { env } from '$env/dynamic/public';
+
+// Fetch helpers for the agent backend (`freehire-agent`). Auth is UNIFIED with
+// freehire: the agent verifies the same httpOnly `hire_token` cookie (shared JWT
+// secret + `.freehire.dev` cookie domain), so `credentials: 'include'` carries
+// it and there is no separate agent login.
+//
+// Base origin:
+//  - prod: `PUBLIC_ASSISTANT_ORIGIN=https://agent.freehire.dev` — a cross-origin
+//    but SAME-SITE subdomain (shared eTLD+1), so the Lax cookie is still sent;
+//    the agent's nginx adds the CORS headers for the freehire.dev origin.
+//  - dev: unset → the same-origin `/assistant-api` path (the Vite proxy).
+const BASE = env.PUBLIC_ASSISTANT_ORIGIN || '/assistant-api';
+
+/** The agent's WebSocket URL, derived from the same base as the fetch calls. */
+export function assistantWsUrl(): string {
+  if (env.PUBLIC_ASSISTANT_ORIGIN) {
+    return env.PUBLIC_ASSISTANT_ORIGIN.replace(/^http/, 'ws') + '/ws';
+  }
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${location.host}/assistant-api/ws`;
+}
+
+/** Create the assistant session. The client sends an empty body and knows
+ *  nothing about the agent's configuration — the backend decides everything
+ *  (harness, persona/system prompt, the `freehire`-only sandbox, scope). */
+export async function createSession(): Promise<string> {
+  const res = await fetch(`${BASE}/sessions`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: '{}',
+  });
+  if (!res.ok) throw new Error(`could not create session (${res.status})`);
+  const body = (await res.json()) as { session_id?: string };
+  if (!body?.session_id) throw new Error('session response missing session_id');
+  return body.session_id;
+}

--- a/web/src/lib/assistant/chat.test.ts
+++ b/web/src/lib/assistant/chat.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { initChat, reduceTurnEvent } from './chat';
+import type { TurnEvent } from './wire';
+
+describe('reduceTurnEvent', () => {
+  it('accumulates assistant_text chunks into one message', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'Hello' });
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: ', world' });
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0]?.role).toBe('assistant');
+    expect(s.messages[0]?.text).toBe('Hello, world');
+    expect(s.messages[0]?.streaming).toBe(true);
+  });
+
+  it('keeps assistant_thought separate from the reply text', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'assistant_thought', text: 'Let me think. ' });
+    s = reduceTurnEvent(s, { type: 'assistant_thought', text: 'OK.' });
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'The answer.' });
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0]?.thinking).toBe('Let me think. OK.');
+    expect(s.messages[0]?.text).toBe('The answer.');
+  });
+
+  it('records tool_use calls with their name and input on the current assistant message', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'tool_use', name: 'read_file', input: {} });
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'Done' });
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0]?.tools).toEqual([{ name: 'read_file', input: {} }]);
+  });
+
+  it('captures the tool input so tool cards can render details', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'tool_use', name: 'Bash', input: { command: 'ls -la' } });
+    s = reduceTurnEvent(s, { type: 'tool_use', name: 'Read', input: { file_path: '/tmp/x.ts' } });
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0]?.tools).toEqual([
+      { name: 'Bash', input: { command: 'ls -la' } },
+      { name: 'Read', input: { file_path: '/tmp/x.ts' } },
+    ]);
+  });
+
+  it('appends a user message for a user_prompt event', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'user_prompt', text: 'Hi there' });
+    expect(s.messages).toHaveLength(1);
+    expect(s.messages[0]?.role).toBe('user');
+    expect(s.messages[0]?.text).toBe('Hi there');
+  });
+
+  it('starts a fresh assistant message after a user prompt', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'user_prompt', text: 'Question?' });
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'Answer.' });
+    expect(s.messages).toHaveLength(2);
+    expect(s.messages[0]?.role).toBe('user');
+    expect(s.messages[1]?.role).toBe('assistant');
+  });
+
+  it('closes the turn on a terminal result event', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'Reply' });
+    s = reduceTurnEvent(s, {
+      type: 'result',
+      cost_usd: 0.01,
+      stop_reason: 'end_turn',
+      is_error: false,
+    });
+    expect(s.messages[0]?.streaming).toBe(false);
+    expect(s.messages[0]?.errored).toBe(false);
+  });
+
+  it('marks the message errored when the turn ends with an error', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'partial' });
+    s = reduceTurnEvent(s, { type: 'result', cost_usd: null, stop_reason: 'error', is_error: true });
+    expect(s.messages[0]?.streaming).toBe(false);
+    expect(s.messages[0]?.errored).toBe(true);
+  });
+
+  it('opens a new assistant message for the next turn after a result', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'First' });
+    s = reduceTurnEvent(s, { type: 'result', cost_usd: null, stop_reason: 'end_turn', is_error: false });
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'Second' });
+    expect(s.messages).toHaveLength(2);
+    expect(s.messages[1]?.text).toBe('Second');
+    expect(s.messages[1]?.streaming).toBe(true);
+  });
+
+  it('ignores a result with no open turn instead of creating a message', () => {
+    const s = reduceTurnEvent(initChat(), {
+      type: 'result',
+      cost_usd: null,
+      stop_reason: 'end_turn',
+      is_error: false,
+    });
+    expect(s.messages).toHaveLength(0);
+  });
+
+  it('ignores unmodeled/raw event kinds without throwing', () => {
+    let s = initChat();
+    s = reduceTurnEvent(s, { type: 'assistant_text', text: 'Hi' });
+    const before = s;
+    s = reduceTurnEvent(s, { type: 'raw', value: { anything: true } });
+    s = reduceTurnEvent(s, { type: 'usage', input_tokens: 1, output_tokens: 2, cost_usd: null });
+    s = reduceTurnEvent(s, { type: 'system', subtype: 'init' });
+    // An unknown kind not in the union must also be a no-op, not a throw.
+    s = reduceTurnEvent(s, { type: 'totally_unknown' } as unknown as TurnEvent);
+    expect(s).toBe(before);
+    expect(s.messages).toHaveLength(1);
+  });
+
+  it('does not mutate the previous state', () => {
+    const prev = initChat();
+    const next = reduceTurnEvent(prev, { type: 'user_prompt', text: 'x' });
+    expect(prev.messages).toHaveLength(0);
+    expect(next).not.toBe(prev);
+  });
+});

--- a/web/src/lib/assistant/chat.ts
+++ b/web/src/lib/assistant/chat.ts
@@ -1,0 +1,80 @@
+// Pure presentation logic for the assistant chat: folds the streamed
+// `TurnEvent`s into a message list, kept out of the component so the
+// accumulation is unit-testable (vitest) without a DOM — mirroring how
+// `jobFit.ts` isolates `reduceFitEvent`.
+
+import type { TurnEvent } from './wire';
+import type { ToolCall } from './tool-formatters';
+
+/** One rendered message. Assistant messages accumulate `text` (the reply),
+ *  `thinking` (secondary, never mixed into the reply), and `tools` (each tool
+ *  call's `{name, input}`, so the renderer can show details like the bash
+ *  command or the file read) while `streaming`; `errored` is set when the turn
+ *  ends with an error. User messages carry only `text`. */
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  text: string;
+  thinking: string;
+  tools: ToolCall[];
+  streaming: boolean;
+  errored: boolean;
+}
+
+export interface ChatState {
+  messages: ChatMessage[];
+}
+
+export function initChat(): ChatState {
+  return { messages: [] };
+}
+
+/** Fold one `TurnEvent` into the chat state, returning a new state (never
+ *  mutates the input). Unmodeled/unknown event kinds are ignored (no throw). */
+export function reduceTurnEvent(prev: ChatState, event: TurnEvent): ChatState {
+  switch (event.type) {
+    case 'user_prompt':
+      return { messages: [...prev.messages, userMessage(event.text)] };
+    case 'assistant_text':
+      return upsertAssistant(prev, (m) => ({ ...m, text: m.text + event.text }));
+    case 'assistant_thought':
+      return upsertAssistant(prev, (m) => ({ ...m, thinking: m.thinking + event.text }));
+    case 'tool_use':
+      return upsertAssistant(prev, (m) => ({
+        ...m,
+        tools: [...m.tools, { name: event.name, input: event.input }],
+      }));
+    case 'result':
+      return closeAssistant(prev, event.is_error);
+    default:
+      // system, note, usage, raw, and anything not in the union — ignored.
+      return prev;
+  }
+}
+
+function userMessage(text: string): ChatMessage {
+  return { role: 'user', text, thinking: '', tools: [], streaming: false, errored: false };
+}
+
+function newAssistant(): ChatMessage {
+  return { role: 'assistant', text: '', thinking: '', tools: [], streaming: true, errored: false };
+}
+
+/** Apply `fn` to the open (streaming) assistant message, or start a new one if
+ *  the last message isn't an open assistant turn (e.g. after a user prompt or a
+ *  closed turn). */
+function upsertAssistant(prev: ChatState, fn: (m: ChatMessage) => ChatMessage): ChatState {
+  const last = prev.messages[prev.messages.length - 1];
+  if (last && last.role === 'assistant' && last.streaming) {
+    return { messages: [...prev.messages.slice(0, -1), fn(last)] };
+  }
+  return { messages: [...prev.messages, fn(newAssistant())] };
+}
+
+/** Close the open assistant turn. A result with no open turn is ignored (never
+ *  fabricates an empty message). */
+function closeAssistant(prev: ChatState, errored: boolean): ChatState {
+  const last = prev.messages[prev.messages.length - 1];
+  if (!last || last.role !== 'assistant' || !last.streaming) return prev;
+  const closed: ChatMessage = { ...last, streaming: false, errored };
+  return { messages: [...prev.messages.slice(0, -1), closed] };
+}

--- a/web/src/lib/assistant/client.ts
+++ b/web/src/lib/assistant/client.ts
@@ -1,0 +1,228 @@
+import {
+  type ClientCommand,
+  type JournalEntry,
+  type ServerEvent,
+  type ServerEventKind,
+} from './wire';
+
+// The browser half of the roy control protocol, ported from roy-web
+// (`workspace/src/lib/client.ts`). One `RoyClient` owns one WebSocket to the
+// agent relay: `call` sends a command and awaits its matching reply, `fire` is
+// fire-and-forget (`send`), and frame events flow to `subscribeFrames`. Unlike
+// roy-web this exports no module singleton — the chat page owns a per-page
+// instance and closes it on teardown (SvelteKit route lifecycle, not HMR).
+
+export type ConnectionStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'error';
+
+/** An unsolicited backend error (not a reply to a pending `call`). */
+export type ServerError = { code: string; message: string; session?: string };
+
+type Pending = {
+  expected: ServerEventKind;
+  resolve: (ev: ServerEvent) => void;
+  reject: (err: Error) => void;
+};
+
+export class RoyClient {
+  private ws: WebSocket | null = null;
+  private queue: Pending[] = [];
+  private frameSubs = new Map<string, Set<(entry: JournalEntry) => void>>();
+  private statusSubs = new Set<(s: ConnectionStatus) => void>();
+  private errorSubs = new Set<(err: ServerError) => void>();
+  private _status: ConnectionStatus = 'idle';
+
+  get status(): ConnectionStatus {
+    return this._status;
+  }
+
+  /**
+   * Connect to the agent relay's WebSocket. Resolves when the socket reaches
+   * OPEN, rejects if it errors, closes before opening, or fails to upgrade
+   * within `timeoutMs` (default 10s).
+   *
+   * Auth is UNIFIED with freehire: the relay authenticates from the freehire
+   * `hire_token` cookie the browser sends automatically on the same-origin
+   * upgrade (shared JWT secret), so no token is passed here.
+   *
+   * Without the timeout a half-open TCP socket (backend crashed mid-handshake,
+   * network stall) leaves `onopen`/`onerror` silent and the returned Promise
+   * pends forever, hanging the awaiting caller.
+   */
+  connect(url: string, timeoutMs = 10_000): Promise<void> {
+    if (this.ws) this.close();
+    this.setStatus('connecting');
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url);
+      this.ws = ws;
+      const timer = setTimeout(() => {
+        this.setStatus('error');
+        try {
+          ws.close();
+        } catch {
+          // already closed
+        }
+        reject(new Error(`timed out connecting to ${url} after ${timeoutMs}ms`));
+      }, timeoutMs);
+      ws.onopen = () => {
+        clearTimeout(timer);
+        this.setStatus('open');
+        resolve();
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        this.setStatus('error');
+        if (ws.readyState !== WebSocket.OPEN) {
+          reject(new Error(`failed to connect to ${url}`));
+        }
+        this.flushQueueWithError('websocket error');
+      };
+      ws.onclose = () => {
+        clearTimeout(timer);
+        this.setStatus('closed');
+        this.flushQueueWithError('websocket closed');
+      };
+      ws.onmessage = (msg) => this.handleMessage(msg.data);
+    });
+  }
+
+  close() {
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  /**
+   * Send a command and await the matching server reply. Frame events are not
+   * counted as replies — they flow through `subscribeFrames` instead.
+   *
+   * Rejects with the Error event's message if the backend answered with an
+   * Error of any code.
+   */
+  call<K extends ServerEventKind>(
+    cmd: ClientCommand,
+    expected: K,
+  ): Promise<Extract<ServerEvent, { kind: K }>> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('not connected'));
+    }
+    return new Promise((resolve, reject) => {
+      this.queue.push({
+        expected,
+        resolve: (ev) => resolve(ev as Extract<ServerEvent, { kind: K }>),
+        reject,
+      });
+      this.ws!.send(JSON.stringify(cmd));
+    });
+  }
+
+  /**
+   * Fire-and-forget command. `send` is the canonical case: the backend emits no
+   * ack on success — the observable effect is the stream of `frame` events that
+   * follows, terminated by a `result`. Only an `error` event can come back, and
+   * that resolves whatever command is at the head of the queue (so don't
+   * interleave `fire` with pending `call`s).
+   */
+  fire(cmd: ClientCommand) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new Error('not connected');
+    }
+    this.ws.send(JSON.stringify(cmd));
+  }
+
+  /**
+   * Subscribe to live frame events for a session. Returns an unsubscribe
+   * function.
+   */
+  subscribeFrames(session: string, cb: (entry: JournalEntry) => void): () => void {
+    let set = this.frameSubs.get(session);
+    if (!set) {
+      set = new Set();
+      this.frameSubs.set(session, set);
+    }
+    set.add(cb);
+    return () => {
+      const s = this.frameSubs.get(session);
+      s?.delete(cb);
+      if (s && s.size === 0) this.frameSubs.delete(session);
+    };
+  }
+
+  onStatus(cb: (s: ConnectionStatus) => void): () => void {
+    this.statusSubs.add(cb);
+    cb(this._status);
+    return () => this.statusSubs.delete(cb);
+  }
+
+  /**
+   * Subscribe to backend `error` events that arrive UNsolicited — i.e. not as
+   * the reply to a pending `call`. A fire-and-forget `send` produces no pending
+   * entry, so if a turn fails with `{kind:'error'}` instead of a terminal
+   * `result` it lands here; without a subscriber the turn would hang forever.
+   */
+  onError(cb: (err: ServerError) => void): () => void {
+    this.errorSubs.add(cb);
+    return () => this.errorSubs.delete(cb);
+  }
+
+  private setStatus(s: ConnectionStatus) {
+    this._status = s;
+    for (const cb of this.statusSubs) cb(s);
+  }
+
+  private handleMessage(data: unknown) {
+    if (typeof data !== 'string') return;
+    let ev: ServerEvent;
+    try {
+      ev = JSON.parse(data) as ServerEvent;
+    } catch (e) {
+      console.error('assistant: invalid JSON from backend', e, data);
+      return;
+    }
+
+    if (ev.kind === 'frame') {
+      this.dispatchFrame(ev.session, ev.entry);
+      return;
+    }
+
+    // Progress ack, not the awaited reply — returning here (instead of
+    // dequeuing) keeps FIFO matching aligned for the real reply behind it.
+    if (ev.kind === 'resuming') {
+      return;
+    }
+
+    // Every other event resolves the head of the pending queue. The backend
+    // processes commands serially per connection, so FIFO matching is sound.
+    const pending = this.queue.shift();
+    if (!pending) {
+      // A `send` is fire-and-forget (no pending entry). If a turn fails with an
+      // `error` instead of a terminal `result`, it lands here — route it to
+      // `onError` subscribers so the turn can be ended instead of hanging.
+      if (ev.kind === 'error') {
+        for (const cb of this.errorSubs) cb({ code: ev.code, message: ev.message, session: ev.session });
+      } else {
+        console.warn('assistant: unsolicited event', ev);
+      }
+      return;
+    }
+    if (ev.kind === 'error') {
+      pending.reject(new Error(`${ev.code}: ${ev.message}`));
+      return;
+    }
+    if (ev.kind !== pending.expected) {
+      pending.reject(new Error(`expected ${pending.expected}, got ${ev.kind}`));
+      return;
+    }
+    pending.resolve(ev);
+  }
+
+  private dispatchFrame(session: string, entry: JournalEntry) {
+    const set = this.frameSubs.get(session);
+    if (!set) return;
+    for (const cb of set) cb(entry);
+  }
+
+  private flushQueueWithError(reason: string) {
+    const q = this.queue;
+    this.queue = [];
+    for (const p of q) p.reject(new Error(reason));
+  }
+}

--- a/web/src/lib/assistant/tool-formatters.ts
+++ b/web/src/lib/assistant/tool-formatters.ts
@@ -1,0 +1,126 @@
+// Per-tool header/line formatting for the assistant chat transcript. Centralizes
+// the claude-style "Ran <cmd>" / "Explored N files" affordances so the renderer
+// in the assistant page stays free of name-dispatch ladders.
+//
+// Ported from roy-web (`workspace/src/lib/tool-formatters.ts`); the only local
+// change is inlining `truncate` (roy imports it from `./utils`).
+
+export type ToolFamily = 'fs' | 'bash' | 'other';
+
+export interface ToolCall {
+  name: string;
+  input: unknown;
+}
+
+/** Truncate `s` to at most `n` characters, appending an ellipsis when cut. */
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + '…';
+}
+
+const FS_TOOLS = new Set(['Read', 'Glob', 'Grep', 'LS']);
+
+export function classifyFamily(name: string): ToolFamily {
+  if (name === 'Bash') return 'bash';
+  if (FS_TOOLS.has(name)) return 'fs';
+  return 'other';
+}
+
+/** Title shown in the collapsed header. */
+export function groupTitle(family: ToolFamily, calls: readonly ToolCall[]): string {
+  const first = calls[0];
+  if (!first) return '';
+  if (family === 'bash') {
+    if (calls.length === 1) {
+      const cmd = bashCommand(first.input);
+      return cmd ? `Ran ${shortenCommand(cmd)}` : 'Ran command';
+    }
+    return `Ran ${calls.length} commands`;
+  }
+  if (family === 'fs') {
+    if (calls.length === 1) return callLine(first);
+    return `Explored ${calls.length} files`;
+  }
+  const name = first.name;
+  return calls.length > 1 ? `Called ${name} × ${calls.length}` : `Called ${name}`;
+}
+
+/** One line in the expanded list. */
+export function callLine(call: ToolCall): string {
+  switch (call.name) {
+    case 'Read': {
+      const p = readField(call.input, 'file_path', 'path');
+      return p ? `Read ${basename(p)}` : 'Read';
+    }
+    case 'Glob': {
+      const p = readField(call.input, 'pattern');
+      return p ? `Globbed ${p}` : 'Glob';
+    }
+    case 'Grep': {
+      const p = readField(call.input, 'pattern');
+      return p ? `Grepped ${p}` : 'Grep';
+    }
+    case 'LS': {
+      const p = readField(call.input, 'path');
+      return p ? `Listed ${basename(p)}` : 'LS';
+    }
+    case 'Bash': {
+      const cmd = bashCommand(call.input);
+      return cmd ? `$ ${cmd}` : 'Bash';
+    }
+    case 'Write':
+    case 'Edit': {
+      const p = readField(call.input, 'file_path', 'path');
+      return p ? `${call.name} ${basename(p)}` : call.name;
+    }
+    default:
+      return call.name;
+  }
+}
+
+export function bashCommand(input: unknown): string | null {
+  return readField(input, 'command', 'cmd');
+}
+
+export function nonEmptyInput(input: unknown): boolean {
+  if (input === null || input === undefined) return false;
+  if (typeof input === 'object' && Object.keys(input as object).length === 0) return false;
+  return true;
+}
+
+export function previewToolInput(input: unknown): string {
+  try {
+    return truncate(JSON.stringify(input), 200);
+  } catch {
+    return String(input);
+  }
+}
+
+/** Whether the group's body adds anything beyond its title — used to decide
+ *  between a flat chip and an expandable `<details>` in the renderer. */
+export function isExpandable(family: ToolFamily, calls: readonly ToolCall[]): boolean {
+  if (family === 'bash') return true;
+  if (family === 'fs') return calls.length > 1;
+  return calls.some((c) => nonEmptyInput(c.input));
+}
+
+function readField(input: unknown, ...keys: string[]): string | null {
+  if (!input || typeof input !== 'object') return null;
+  const obj = input as Record<string, unknown>;
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  return null;
+}
+
+function basename(path: string): string {
+  const i = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+  return i >= 0 ? path.slice(i + 1) : path;
+}
+
+const TITLE_MAX = 60;
+function shortenCommand(cmd: string): string {
+  const nl = cmd.indexOf('\n');
+  const firstLine = (nl >= 0 ? cmd.slice(0, nl) : cmd).trim();
+  return truncate(firstLine, TITLE_MAX);
+}

--- a/web/src/lib/assistant/wire.ts
+++ b/web/src/lib/assistant/wire.ts
@@ -1,0 +1,133 @@
+// TypeScript mirror of the roy control protocol (`ClientCommand`/`ServerEvent`)
+// and the `TurnEvent` enum, ported from roy-web (`workspace/src/lib/wire.ts`).
+// The agent backend (`freehire-agent`) speaks this protocol verbatim over its
+// `/ws` relay: the client sends `ClientCommand` JSON and receives `ServerEvent`
+// JSON, one JSON value per WebSocket message. The backend is the source of
+// truth for this shape; this port is thin and read-only.
+
+export type Harness = 'claude' | 'gemini' | 'opencode' | 'codex' | 'pi';
+
+/** Shape returned by `listed`. `session, harness, model, cwd` come from the
+ *  daemon; `project_id`/`tags` may be spliced in server-side. */
+export interface SessionInfo {
+  session: string;
+  harness: string;
+  cwd: string;
+  model?: string;
+  project_id?: string;
+  tags?: Record<string, string>;
+}
+
+export type Seq = number;
+
+// ---- TurnEvent (tag: "type") ---------------------------------------------
+
+export type StopReason =
+  | 'end_turn'
+  | 'max_tokens'
+  | 'max_turn_requests'
+  | 'refusal'
+  | 'cancelled'
+  | 'error'
+  | (string & {});
+
+export type TurnEvent =
+  | { type: 'system'; subtype: string }
+  | { type: 'user_prompt'; text: string }
+  | { type: 'note'; text: string; source_session: string | null }
+  | { type: 'assistant_text'; text: string }
+  | { type: 'assistant_thought'; text: string }
+  | { type: 'tool_use'; name: string; input: unknown }
+  | {
+      type: 'usage';
+      input_tokens: number | null;
+      output_tokens: number | null;
+      cost_usd: number | null;
+    }
+  | {
+      type: 'result';
+      cost_usd: number | null;
+      stop_reason: StopReason;
+      is_error: boolean;
+    }
+  | { type: 'raw'; value: unknown };
+
+export interface JournalEntry {
+  seq: Seq;
+  /// Wall-clock millis since epoch, stamped by the daemon when the entry hit
+  /// the journal. UIs render this as the send/receive time of the message.
+  ts_ms: number;
+  event: TurnEvent;
+}
+
+// ---- ClientCommand (tag: "op") -------------------------------------------
+
+export type ClientCommand =
+  | { op: 'attach'; session: string; from_seq?: Seq }
+  | { op: 'acquire_input'; session: string }
+  | { op: 'send'; session: string; text: string }
+  | { op: 'cancel_turn'; session: string }
+  | { op: 'set_model'; session: string; model: string }
+  | { op: 'release_input'; session: string }
+  | { op: 'detach'; session: string }
+  | { op: 'close'; session: string }
+  | { op: 'delete_archive'; session: string }
+  | { op: 'list' }
+  | { op: 'list_archived' }
+  | { op: 'list_harnesses' }
+  | { op: 'resume'; session: string }
+  | {
+      op: 'read_journal';
+      session: string;
+      from_seq?: Seq;
+      max_entries?: number;
+    };
+
+// ---- ServerEvent (tag: "kind") -------------------------------------------
+
+export type ErrorCode =
+  | 'bad_request'
+  | 'spawn_failed'
+  | 'no_session'
+  | 'attach_failed'
+  | 'archive_read_failed'
+  | 'no_lease'
+  | 'send_failed'
+  | 'close_failed'
+  | 'list_archived_failed'
+  | 'resume_failed'
+  | 'read_journal_failed'
+  | 'delete_failed'
+  | 'cancel_failed'
+  | 'set_model_failed'
+  | (string & {});
+
+export type ServerEvent =
+  | { kind: 'resuming'; session: string }
+  | {
+      kind: 'attached';
+      session: string;
+      seq_at_attach: Seq;
+      harness: string;
+      model?: string;
+    }
+  | { kind: 'frame'; session: string; entry: JournalEntry }
+  | { kind: 'input_acquired'; session: string; acquired: boolean }
+  | { kind: 'input_released'; session: string }
+  | { kind: 'detached'; session: string }
+  | { kind: 'model_changed'; session: string; model: string }
+  | { kind: 'closed'; session: string }
+  | { kind: 'deleted'; session: string }
+  | { kind: 'listed'; sessions: SessionInfo[] }
+  | { kind: 'listed_archived'; sessions: SessionInfo[] }
+  | { kind: 'resumed'; session: string; resume_cursor?: string }
+  | {
+      kind: 'journal_read';
+      session: string;
+      entries: JournalEntry[];
+      next_seq: Seq;
+      has_more: boolean;
+    }
+  | { kind: 'error'; session?: string; code: ErrorCode; message: string };
+
+export type ServerEventKind = ServerEvent['kind'];

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -6,6 +6,7 @@
   import { resolve } from '$app/paths';
   import {
     User,
+    Bot,
     LayoutList,
     Activity,
     Bell,
@@ -51,6 +52,7 @@
   // without an icon is a compile error, not a runtime `<undefined />`.
   const icons: Record<AccountNavItem['href'], LucideIcon> = {
     '/my/profile': User,
+    '/my/assistant': Bot,
     '/my/tracking': LayoutList,
     '/my/activity': Activity,
     '/my/inbox': Inbox,

--- a/web/src/routes/my/assistant/+page.svelte
+++ b/web/src/routes/my/assistant/+page.svelte
@@ -1,0 +1,601 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { Marked } from 'marked';
+  import DOMPurify from 'isomorphic-dompurify';
+  import { Bot, AlertTriangle, Terminal, ChevronRight, ArrowUp, Loader2, Trash2 } from '@lucide/svelte';
+  import { currentUser } from '$lib/auth.svelte';
+  import { createSession, assistantWsUrl } from '$lib/assistant/api';
+  import { RoyClient } from '$lib/assistant/client';
+  import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
+  import {
+    classifyFamily,
+    groupTitle,
+    isExpandable,
+    callLine,
+    bashCommand,
+    nonEmptyInput,
+    previewToolInput,
+    type ToolCall,
+    type ToolFamily,
+  } from '$lib/assistant/tool-formatters';
+  import type { TurnEvent } from '$lib/assistant/wire';
+
+  // The assistant chat. Auth is UNIFIED with freehire: the /my shell already
+  // gates the freehire session, and the agent backend verifies that same
+  // `hire_token` cookie (shared JWT secret) — so there is no separate agent
+  // login. On mount the page spawns a claude session, opens the WebSocket relay
+  // (the browser sends the freehire cookie on the same-origin upgrade), attaches,
+  // and streams frames through the pure `reduceTurnEvent` reducer. Everything
+  // WebSocket-shaped runs client-side (onMount / handlers), so SSR renders only
+  // the empty shell.
+
+  type Phase = 'connecting' | 'ready';
+
+  // Assistant is a moderators-only rollout. The nav hides it for others, but
+  // guard the route directly too — the agent backend only checks the freehire
+  // cookie, not the role, so a non-moderator reaching this URL must be stopped
+  // here (never connect / spawn a session for them).
+  const isModerator = $derived(currentUser()?.role === 'moderator');
+
+  let phase = $state<Phase>('connecting');
+  let error = $state<string | null>(null);
+  // Set when the socket drops after we were live — the composer disables and
+  // prompts a reload, instead of silently accepting sends that can't go out.
+  let connectionLost = $state(false);
+
+  // Session/transport (client-only; created in the connect flow).
+  let client: RoyClient | null = null;
+  let session = '';
+  let unsubscribers: (() => void)[] = [];
+
+  // Chat.
+  let chat = $state<ChatState>(initChat());
+  let draft = $state('');
+  let turnActive = $state(false);
+  // The optimistically-shown user text, so we drop the backend's echoed
+  // `user_prompt` frame for it instead of rendering the message twice.
+  let pendingEcho: string | null = null;
+
+  let scroller = $state<HTMLDivElement | null>(null);
+  let textareaEl = $state<HTMLTextAreaElement | null>(null);
+
+  // Whether we currently hold the session's input lease. Held across a queued
+  // run of turns (acquired lazily on the first dispatch, released on idle when
+  // the queue drains) so back-to-back messages don't fight for the lease.
+  let inputAcquired = false;
+
+  // Messages typed while a turn is in flight. Drained one-by-one when a
+  // terminal `result` frame lands (see onFrame), mirroring roy-web's composer.
+  let queue = $state<{ id: string; text: string }[]>([]);
+  let queueCounter = 0;
+
+  function enqueue(text: string, toFront = false) {
+    const item = { id: `q${++queueCounter}`, text };
+    queue = toFront ? [item, ...queue] : [...queue, item];
+  }
+
+  // Auto-grow the composer textarea up to a cap (px), like roy-web's `autosize`.
+  const COMPOSER_CAP = 200;
+  $effect(() => {
+    void draft;
+    const el = textareaEl;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, COMPOSER_CAP)}px`;
+  });
+
+  // --- Markdown rendering (sanitized) --------------------------------------
+  // freehire is a PUBLIC app and the model output is untrusted, so — unlike
+  // roy-web — we never render raw model HTML: marked's output is run through
+  // DOMPurify before it reaches `{@html}`. `isomorphic-dompurify` is SSR-safe,
+  // so the guard holds even though this page only paints messages client-side.
+  const md = new Marked({ gfm: true, breaks: true });
+  function renderMarkdown(text: string): string {
+    const html = md.parse(text, { async: false }) as string;
+    return DOMPurify.sanitize(html);
+  }
+
+  // Fold a message's flat tool-call list into consecutive same-family groups,
+  // so the renderer shows one card per run of e.g. bash commands or file reads.
+  function groupTools(calls: readonly ToolCall[]): { family: ToolFamily; calls: ToolCall[] }[] {
+    const groups: { family: ToolFamily; calls: ToolCall[] }[] = [];
+    for (const c of calls) {
+      const family = classifyFamily(c.name);
+      const last = groups[groups.length - 1];
+      if (last && last.family === family) last.calls.push(c);
+      else groups.push({ family, calls: [c] });
+    }
+    return groups;
+  }
+
+  // --- Streaming spinner / thinking timers ---------------------------------
+  const SPINNER_GLYPHS = ['·', '✢', '✳', '✶', '✻', '✽'] as const;
+  const VERBS = ['Thinking', 'Working', 'Crunching', 'Pondering', 'Composing', 'Simmering'] as const;
+  let elapsedSec = $state(0);
+  let spinnerIdx = $state(0);
+  let turnStartedAt = $state<number | null>(null);
+  let currentVerb = $state<string>('Thinking');
+
+  $effect(() => {
+    if (turnActive && turnStartedAt === null) {
+      turnStartedAt = Date.now();
+      elapsedSec = 0;
+      spinnerIdx = 0;
+      currentVerb = VERBS[Math.floor(Math.random() * VERBS.length)] ?? 'Thinking';
+    } else if (!turnActive) {
+      turnStartedAt = null;
+      elapsedSec = 0;
+    }
+  });
+  $effect(() => {
+    if (!turnActive || turnStartedAt === null) return;
+    const id = setInterval(() => {
+      elapsedSec = Math.floor((Date.now() - (turnStartedAt as number)) / 1000);
+      spinnerIdx = (spinnerIdx + 1) % SPINNER_GLYPHS.length;
+    }, 120);
+    return () => clearInterval(id);
+  });
+
+  async function scrollToBottom() {
+    await tick();
+    if (scroller) scroller.scrollTop = scroller.scrollHeight;
+  }
+
+  async function connect() {
+    phase = 'connecting';
+    error = null;
+    connectionLost = false;
+    try {
+      session = await createSession();
+      const url = assistantWsUrl();
+      client = new RoyClient();
+      // Surface a mid-session disconnect instead of stranding the UI: once we're
+      // live, a socket close/error stops the turn and disables the composer.
+      unsubscribers.push(
+        client.onStatus((s) => {
+          if ((s === 'closed' || s === 'error') && phase === 'ready') {
+            connectionLost = true;
+            error = 'Connection to the assistant was lost. Reload the page to reconnect.';
+            endTurn();
+          }
+        }),
+      );
+      // A turn that fails with an `error` event (agent crash, tool failure)
+      // instead of a terminal `result` would otherwise hang the turn forever.
+      unsubscribers.push(
+        client.onError((e) => {
+          error = `The assistant hit an error: ${e.message}`;
+          endTurn();
+        }),
+      );
+      await client.connect(url);
+      await client.call({ op: 'attach', session }, 'attached');
+      unsubscribers.push(client.subscribeFrames(session, (entry) => onFrame(entry.event)));
+      phase = 'ready';
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Could not reach the assistant backend.';
+      teardown();
+    }
+  }
+
+  // End the current turn: clear the in-flight flag, then either drain the next
+  // queued message (reusing the held lease) or release the lease when idle.
+  // Shared by the terminal `result` frame and abnormal turn-enders (error /
+  // disconnect).
+  function endTurn() {
+    turnActive = false;
+    if (connectionLost) {
+      inputAcquired = false;
+      return;
+    }
+    if (queue.length > 0) {
+      const [next, ...rest] = queue;
+      queue = rest;
+      if (next) void dispatch(next.text);
+    } else if (inputAcquired) {
+      inputAcquired = false;
+      void client?.call({ op: 'release_input', session }, 'input_released').catch(() => {});
+    }
+  }
+
+  function onFrame(event: TurnEvent) {
+    // Suppress the echoed user_prompt for a message we already showed optimistically.
+    if (event.type === 'user_prompt' && pendingEcho !== null && event.text === pendingEcho) {
+      pendingEcho = null;
+      return;
+    }
+    chat = reduceTurnEvent(chat, event);
+    if (event.type === 'result') endTurn();
+    void scrollToBottom();
+  }
+
+  // Composer submit: while a turn is in flight (or the queue is non-empty) the
+  // message is queued and drained later; otherwise it dispatches immediately.
+  function submit(e: SubmitEvent) {
+    e.preventDefault();
+    const text = draft.trim();
+    if (!text || !client || phase !== 'ready' || connectionLost) return;
+    draft = '';
+    if (turnActive || queue.length > 0) {
+      enqueue(text);
+      void scrollToBottom();
+      return;
+    }
+    void dispatch(text);
+  }
+
+  // Acquire the lease (if not held), show the user message optimistically, and
+  // fire the prompt. `turnActive` is set synchronously up front so a second
+  // submit during the acquire round-trip queues instead of double-dispatching.
+  async function dispatch(text: string) {
+    if (!client) return;
+    error = null;
+    turnActive = true;
+    try {
+      if (!inputAcquired) {
+        const acquired = await client.call({ op: 'acquire_input', session }, 'input_acquired');
+        if (!acquired.acquired) {
+          // Another client (e.g. this chat open in a second tab) holds the
+          // lease. Don't silently queue forever — surface it and restore the
+          // text so the user can retry, rather than deadlocking the queue.
+          turnActive = false;
+          error = 'The assistant is busy (is it open in another tab?). Try again in a moment.';
+          if (!draft.trim()) draft = text;
+          return;
+        }
+        inputAcquired = true;
+      }
+      pendingEcho = text;
+      chat = reduceTurnEvent(chat, { type: 'user_prompt', text });
+      client.fire({ op: 'send', session, text });
+      void scrollToBottom();
+    } catch (err) {
+      turnActive = false;
+      inputAcquired = false;
+      error = err instanceof Error ? err.message : 'Could not send the message.';
+    }
+  }
+
+  function removeQueued(id: string) {
+    queue = queue.filter((q) => q.id !== id);
+  }
+
+  function teardown() {
+    for (const off of unsubscribers) off();
+    unsubscribers = [];
+    client?.close();
+    client = null;
+  }
+
+  onMount(() => {
+    if (!isModerator) return;
+    void connect();
+    return teardown;
+  });
+</script>
+
+<svelte:head>
+  <title>Assistant — freehire</title>
+</svelte:head>
+
+<div class="mb-6 flex flex-col gap-1">
+  <h1 class="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+    <Bot class="size-6 text-brand" />
+    Assistant
+  </h1>
+  <p class="text-sm text-muted-foreground">
+    Chat with a Claude agent inside freehire.
+  </p>
+</div>
+
+{#if error}
+  <div
+    class="mb-4 flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+    role="alert"
+  >
+    <AlertTriangle class="mt-0.5 size-4 shrink-0" />
+    <span>{error}</span>
+  </div>
+{/if}
+
+{#if !isModerator}
+  <div class="rounded-xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
+    The assistant is a limited rollout and isn't available for your account yet.
+  </div>
+{:else}
+  <div class="flex h-[calc(100vh-16rem)] min-h-100 flex-col rounded-xl border border-border bg-card">
+    <!-- Message list -->
+    <div bind:this={scroller} class="flex-1 overflow-y-auto p-4">
+      <div class="mx-auto flex max-w-3xl flex-col gap-3">
+        {#if phase === 'connecting'}
+          <p class="text-sm text-muted-foreground">Connecting to the assistant…</p>
+        {:else if chat.messages.length === 0}
+          <p class="text-sm text-muted-foreground">Ask the assistant anything to get started.</p>
+        {/if}
+
+        {#each chat.messages as message, i (i)}
+          {#if message.role === 'user'}
+            <article class="self-end max-w-[80%] rounded-2xl rounded-br-md bg-secondary px-4 py-2.5 text-sm leading-relaxed text-secondary-foreground">
+              <pre class="m-0 whitespace-pre-wrap break-words font-sans">{message.text}</pre>
+            </article>
+          {:else}
+            {@const active = i === chat.messages.length - 1 && message.streaming}
+            {#if message.thinking}
+              <details class="self-start max-w-[88%] text-xs text-muted-foreground" open={active}>
+                <summary class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-muted/50 [&::-webkit-details-marker]:hidden [&::marker]:hidden">
+                  <span
+                    class={[
+                      'font-mono text-[0.85rem] font-semibold',
+                      active ? 'star-glow' : 'text-muted-foreground/60',
+                    ]}
+                  >
+                    {active ? SPINNER_GLYPHS[spinnerIdx] : '✶'}
+                  </span>
+                  <span class={['font-medium', active && 'shimmer']}>Thinking</span>
+                  {#if active}
+                    <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
+                  {/if}
+                </summary>
+                <div class="md mt-1 max-h-56 overflow-y-auto border-l-2 border-border pl-3 py-1 text-muted-foreground">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
+                  {@html renderMarkdown(message.thinking)}
+                </div>
+              </details>
+            {/if}
+
+            {#each groupTools(message.tools) as g, t (t)}
+              {@const title = groupTitle(g.family, g.calls)}
+              {#if !isExpandable(g.family, g.calls)}
+                <div class="self-start flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+                  <Terminal class="size-4 shrink-0" />
+                  <span>{title}</span>
+                </div>
+              {:else}
+                <details class="self-start max-w-[90%]">
+                  <summary class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground hover:bg-muted/70 [&::-webkit-details-marker]:hidden [&::marker]:hidden [&[open]>span>svg.chev]:rotate-90">
+                    <Terminal class="size-4 shrink-0" />
+                    <span class="flex items-center gap-1.5">
+                      {title}
+                      <ChevronRight class="chev size-3.5 shrink-0 transition-transform" />
+                    </span>
+                  </summary>
+                  {#if g.family === 'bash'}
+                    <div class="mt-2 overflow-hidden rounded-md border border-border bg-background">
+                      <div class="border-b border-border bg-muted/40 px-3 py-1.5 text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground/80">
+                        Shell
+                      </div>
+                      {#each g.calls as c, ci (ci)}
+                        <pre class={['m-0 whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs', ci > 0 && 'border-t border-border']}>$ {bashCommand(c.input) ?? ''}</pre>
+                      {/each}
+                    </div>
+                  {:else if g.family === 'fs'}
+                    <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
+                      {#each g.calls as c, ci (ci)}
+                        <li>{callLine(c)}</li>
+                      {/each}
+                    </ul>
+                  {:else}
+                    <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
+                      {#each g.calls as c, ci (ci)}
+                        <li class="flex flex-wrap items-baseline gap-1.5">
+                          <span class="font-medium text-foreground/80">{c.name}</span>
+                          {#if nonEmptyInput(c.input)}
+                            <code class="rounded bg-muted px-1.5 py-0.5 font-mono">{previewToolInput(c.input)}</code>
+                          {/if}
+                        </li>
+                      {/each}
+                    </ul>
+                  {/if}
+                </details>
+              {/if}
+            {/each}
+
+            {#if message.text}
+              <article class="self-start max-w-[88%] px-1 py-1 text-sm leading-relaxed text-foreground">
+                <div class="md">
+                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
+                  {@html renderMarkdown(message.text)}
+                </div>
+              </article>
+            {/if}
+
+            {#if message.errored}
+              <p class="self-start text-xs text-destructive">The assistant ended the turn with an error.</p>
+            {/if}
+          {/if}
+        {/each}
+
+        {#if turnActive}
+          <div class="self-start inline-flex items-baseline gap-2 px-2 py-1 text-xs text-muted-foreground">
+            <span class="star-glow font-mono text-[0.85rem] font-semibold">
+              {SPINNER_GLYPHS[spinnerIdx]}
+            </span>
+            <span class="shimmer font-medium">{currentVerb}…</span>
+            <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Composer -->
+    <div class="border-t border-border p-3">
+      <div class="mx-auto w-full max-w-3xl">
+        {#if queue.length > 0}
+          <!-- Queued messages: sent one-by-one as each turn finishes. -->
+          <div class="mb-2 overflow-hidden rounded-2xl border border-border/60 bg-card">
+            <div class="px-4 py-2 text-xs font-medium text-brand">{queue.length} queued</div>
+            <ul class="divide-y divide-border/40 border-t border-border/40">
+              {#each queue as item (item.id)}
+                <li class="group flex items-start gap-3 px-4 py-2">
+                  <span class="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-foreground">{item.text}</span>
+                  <button
+                    type="button"
+                    aria-label="Remove from queue"
+                    title="Remove"
+                    onclick={() => removeQueued(item.id)}
+                    class="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-60 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+                  >
+                    <Trash2 class="size-4" />
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+        <form
+          onsubmit={submit}
+          onclick={(e) => {
+            if ((e.target as HTMLElement).closest('button')) return;
+            textareaEl?.focus();
+          }}
+          class="relative flex w-full cursor-text items-end gap-2 rounded-3xl border border-border/60 bg-card px-4 py-2.5 shadow-sm transition-colors focus-within:border-ring/60"
+        >
+          <textarea
+            bind:this={textareaEl}
+            bind:value={draft}
+            rows="1"
+            placeholder="Message the assistant — Enter to send, Shift+Enter for newline"
+            disabled={phase !== 'ready' || connectionLost}
+            onkeydown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                (e.currentTarget.form as HTMLFormElement | null)?.requestSubmit();
+              }
+            }}
+            class="block max-h-[200px] min-h-[1.5rem] flex-1 resize-none cursor-text bg-transparent py-1 text-sm leading-6 text-foreground placeholder:text-muted-foreground/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+          ></textarea>
+          <button
+            type="submit"
+            aria-label={turnActive ? 'Queue message' : 'Send message'}
+            aria-busy={turnActive}
+            disabled={phase !== 'ready' || connectionLost || !draft.trim()}
+            class="flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {#if turnActive}
+              <Loader2 class="size-4 animate-spin" />
+            {:else}
+              <ArrowUp class="size-4" strokeWidth={2.5} />
+            {/if}
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* Shimmer over the spinner verb. background-clip masks the text shape onto
+     a moving gradient — no JS, no repaints beyond the GPU-composited layer. */
+  .shimmer {
+    background: linear-gradient(
+      90deg,
+      var(--color-muted-foreground) 0%,
+      var(--color-muted-foreground) 35%,
+      var(--color-foreground) 50%,
+      var(--color-muted-foreground) 65%,
+      var(--color-muted-foreground) 100%
+    );
+    background-size: 200% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    animation: shimmer-pan 2.4s linear infinite;
+  }
+  @keyframes shimmer-pan {
+    0%   { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+  }
+
+  .star-glow {
+    color: var(--color-foreground);
+    animation: star-pulse 1.8s ease-in-out infinite;
+  }
+  @keyframes star-pulse {
+    0%, 100% { opacity: 0.7; }
+    50%      { opacity: 1; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .star-glow { animation: none; opacity: 1; }
+    .shimmer {
+      animation: none;
+      background: none;
+      color: var(--color-foreground);
+      -webkit-text-fill-color: currentColor;
+    }
+  }
+
+  /* Markdown rendering — scoped, applied with :global to reach @html output. */
+  .md :global(*:first-child) { margin-top: 0; }
+  .md :global(*:last-child)  { margin-bottom: 0; }
+  .md :global(p) { margin: 0 0 0.5rem; line-height: 1.55; }
+  .md :global(h1),
+  .md :global(h2),
+  .md :global(h3),
+  .md :global(h4) {
+    margin: 0.8rem 0 0.35rem;
+    line-height: 1.3;
+    font-weight: 600;
+  }
+  .md :global(h1) { font-size: 1.1rem; }
+  .md :global(h2) { font-size: 1.0rem; }
+  .md :global(h3),
+  .md :global(h4) { font-size: 0.95rem; }
+  .md :global(ul),
+  .md :global(ol) { margin: 0 0 0.5rem; padding-left: 1.25rem; }
+  .md :global(li) { margin: 0.1rem 0; }
+  .md :global(li > p) { margin: 0; }
+  .md :global(a) {
+    color: oklch(0.6 0.18 280);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .md :global(strong) { font-weight: 600; }
+  .md :global(em) { font-style: italic; }
+  .md :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    padding: 0.05rem 0.3rem;
+    border-radius: 4px;
+    background: color-mix(in oklab, currentColor 10%, transparent);
+  }
+  .md :global(pre) {
+    background: color-mix(in oklab, currentColor 12%, transparent);
+    padding: 0.65rem 0.8rem;
+    border-radius: 6px;
+    overflow-x: auto;
+    margin: 0.4rem 0;
+    font-size: 0.85em;
+  }
+  .md :global(pre code) {
+    background: transparent;
+    padding: 0;
+    font-size: 1em;
+  }
+  .md :global(blockquote) {
+    margin: 0.4rem 0;
+    padding: 0.2rem 0.7rem;
+    border-left: 3px solid var(--color-border);
+    color: var(--color-muted-foreground);
+  }
+  .md :global(table) {
+    border-collapse: collapse;
+    margin: 0.4rem 0;
+    font-size: 0.85em;
+  }
+  .md :global(th),
+  .md :global(td) {
+    border: 1px solid var(--color-border);
+    padding: 0.25rem 0.55rem;
+    text-align: left;
+  }
+  .md :global(hr) {
+    border: none;
+    border-top: 1px solid var(--color-border);
+    margin: 0.6rem 0;
+  }
+</style>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -48,6 +48,17 @@ export default defineConfig({
         target: process.env.VITE_API_URL ?? 'http://localhost:8080',
         changeOrigin: true,
       },
+      // The freehire-agent backend (roy management on :8079), reached same-origin
+      // so the assistant chat's httpOnly cookie is sent and the `/ws` upgrade has
+      // no CORS. `ws:true` forwards the WebSocket; the rewrite strips the prefix
+      // so `/assistant-api/ws` → backend `/ws`, `/assistant-api/auth/login` →
+      // `/auth/login`. Prod wiring (an nginx location) is a later seam.
+      '/assistant-api': {
+        target: process.env.VITE_ASSISTANT_API_URL ?? 'http://127.0.0.1:8079',
+        changeOrigin: true,
+        ws: true,
+        rewrite: (path) => path.replace(/^\/assistant-api/, ''),
+      },
     },
   },
 });


### PR DESCRIPTION
## What

Adds an in-app **AI assistant chat** at `/my/assistant` — a logged-in user talks
to a Claude agent, streamed live. **Frontend-only in this repo**; the backend is
a separate service (`freehire-agent`, a trimmed roy fork) and its host-2 deploy
lives in `freehire-ops`. Gated to the **moderator role** for the initial rollout.

Tracked as OpenSpec change `add-assistant-chat` (proposal/design/specs/tasks).

## Highlights

- **Chat UI** (`web/src/routes/my/assistant/`, `web/src/lib/assistant/`): message
  list + composer, ported from roy-web's design — **sanitized markdown**
  (`marked` + `isomorphic-dompurify`), tool-use cards, a thinking panel, a
  streaming spinner, an auto-growing rounded composer, and a **message queue**
  (type while a turn is in flight; drained under one input-lease).
- **Unified auth, no Go change:** the agent backend verifies the *same*
  `hire_token` cookie (shared `JWT_SECRET`, `Domain=.freehire.dev`), so there's
  no second login. `freehire.dev` ↔ `agent.freehire.dev` are same-site, so the
  Lax cookie is sent; base URL is `PUBLIC_ASSISTANT_ORIGIN` (prod
  `https://agent.freehire.dev`; dev unset → same-origin `/assistant-api` via the
  Vite proxy).
- **Moderators-only:** nav entry hidden (`accountNav` `moderatorOnly`) **and** the
  route guarded (the agent backend only checks the cookie, not the role).
- **Pure logic is unit-tested** (`chat.ts` reducer, `accountNav`); components via
  `svelte-check` + manual/visual + live end-to-end.

## Not in this PR (separate repos)

- Backend `freehire-agent` (private): `/ws` relay, unified-auth verification,
  `/ws` tenant-isolation + server-forced sandbox (`Bash(freehire:*)` only),
  bundled skills, `freehire` CLI.
- Deploy `freehire-ops`: `agent.freehire.dev` nginx vhost (CORS + WS), systemd
  units, `release-agent.sh`, `docs/agent-deploy.md`.

## Verification

- `npm run check` — 0 errors (2 pre-existing warnings in `JobFitFull.svelte`).
- `npx vitest run src/lib/assistant/chat.test.ts src/lib/accountNav.test.ts` — green.
- Live end-to-end (local): moderator opens `/my/assistant`, the assistant runs
  the `freehire` CLI and streams a real markdown answer; a full code review of
  the branch was applied (disconnect/error handling, no queue deadlock,
  double-dispatch guard).

## Rollout notes

- Requires the `freehire-agent` backend deployed at `agent.freehire.dev` and
  `PUBLIC_ASSISTANT_ORIGIN` set in the hire-web service env; harmless until then
  (the route is moderators-only and simply fails to connect without a backend).
