### PR TITLE
fix(web): standardize brand casing to lowercase "freehire"

### DIFF
--- a/web/src/lib/components/BrandMark.svelte
+++ b/web/src/lib/components/BrandMark.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  // The FreeHire brand mark — a ring enclosing a diamond. `fill="currentColor"`
+  // The freehire brand mark — a ring enclosing a diamond. `fill="currentColor"`
   // makes it track the theme (dark mark on light, light mark on dark), exactly
   // like the wordmark beside it. Shared by the desktop header (TopBar) and the
   // mobile drawer (HeaderMenu) so the geometry lives in one place. aria-hidden:
-  // callers pair it with the visible "FreeHire" text, which names the link. The
+  // callers pair it with the visible "freehire" text, which names the link. The
   // OG-image copy in server/og/shared.ts is a separately rendered PNG (satori)
   // and intentionally does not route through here.
   let { class: cls = 'size-5 shrink-0' }: { class?: string } = $props();

--- a/web/src/lib/components/ChatGptView.svelte
+++ b/web/src/lib/components/ChatGptView.svelte
@@ -39,7 +39,7 @@
         </h1>
 
         <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
-          <span class="text-foreground">FreeHire GPT</span> is a custom GPT wired to the same job API the
+          <span class="text-foreground">freehire GPT</span> is a custom GPT wired to the same job API the
           site runs on. Ask for jobs in plain language and it searches the live
           <code class="font-mono text-foreground">freehire</code> catalogue — then saves, applies and tracks
           them on your account. (You still apply on the employer's site; the GPT records that you did.)
@@ -47,7 +47,7 @@
 
         <div class="reveal mt-9 flex flex-wrap items-center gap-3" style="--d:240ms">
           <Button href={GPT_URL} target="_blank" rel="noopener noreferrer" variant="primary" size="lg">
-            Open FreeHire GPT ↗
+            Open freehire GPT ↗
           </Button>
           <Button href={resolve('/my/api-keys')} variant="outline" size="lg">Get an API key</Button>
         </div>
@@ -61,7 +61,7 @@
           class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground"
         >
           <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
-          ChatGPT · FreeHire
+          ChatGPT · freehire
         </figcaption>
         <div class="flex flex-col gap-4 p-4 leading-relaxed">
           <div class="self-end max-w-[85%] rounded-2xl rounded-br-sm bg-foreground px-3.5 py-2 text-background">
@@ -125,7 +125,7 @@
     <ol class="mt-6 max-w-2xl space-y-3 text-sm leading-relaxed text-muted-foreground">
       <li>
         <span class="font-medium text-foreground">1.</span>
-        <a href={GPT_URL} target="_blank" rel="noopener noreferrer" class="font-medium text-foreground underline-offset-4 hover:underline">Open FreeHire GPT</a>
+        <a href={GPT_URL} target="_blank" rel="noopener noreferrer" class="font-medium text-foreground underline-offset-4 hover:underline">Open freehire GPT</a>
         and start asking for jobs — search needs no setup.
       </li>
       <li>

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -214,7 +214,7 @@
       <div class="flex h-14 shrink-0 items-center justify-between border-b border-border px-4 sm:hidden">
         <span class="flex items-center gap-2 text-sm font-semibold tracking-tight">
           <BrandMark />
-          FreeHire
+          freehire
         </span>
         <button
           type="button"

--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -133,7 +133,7 @@
         </h1>
 
         <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
-          FreeHire pulls openings straight from company career boards, strips the duplicates, and tags each
+          Freehire pulls openings straight from company career boards, strips the duplicates, and tags each
           one with stack, seniority and location — so you search jobs, not job boards.
         </p>
 

--- a/web/src/lib/components/TopBar.svelte
+++ b/web/src/lib/components/TopBar.svelte
@@ -76,7 +76,7 @@
       class="flex shrink-0 items-center gap-2 text-sm font-semibold tracking-tight"
     >
       <BrandMark />
-      <span class="hidden sm:inline">FreeHire</span>
+      <span class="hidden sm:inline">freehire</span>
     </a>
 
     {#if listKind === 'jobs' || listKind === 'company'}

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -9,7 +9,7 @@ import type { Company, Enrichment, Job } from './types';
 const SITE = 'freehire';
 // Site-level facts reused across the homepage WebSite/Organization schema.
 const SITE_DESCRIPTION =
-  'FreeHire is an open-source search engine for tech jobs: it indexes millions of openings straight from company career boards, deduplicates them, and tags each with stack, seniority and location. Free and open source.';
+  'Freehire is an open-source search engine for tech jobs: it indexes millions of openings straight from company career boards, deduplicates them, and tags each with stack, seniority and location. Free and open source.';
 const SITE_GITHUB = 'https://github.com/strelov1/freehire';
 
 /** One question/answer pair; the shape shared by the visible FAQ and its schema. */

--- a/web/src/routes/about/+page.svelte
+++ b/web/src/routes/about/+page.svelte
@@ -20,7 +20,7 @@
 
 <Seo
   title="About freehire — the open-source search engine for tech jobs"
-  description="FreeHire is an open-source search engine for tech jobs: it indexes millions of openings straight from company career boards, deduplicates them, and tags each with stack, seniority and location. Free and open source."
+  description="Freehire is an open-source search engine for tech jobs: it indexes millions of openings straight from company career boards, deduplicates them, and tags each with stack, seniority and location. Free and open source."
   {canonical}
 />
 

--- a/web/src/routes/chatgpt/+page.svelte
+++ b/web/src/routes/chatgpt/+page.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <Seo
-  title="FreeHire GPT — search and track jobs inside ChatGPT"
+  title="freehire GPT — search and track jobs inside ChatGPT"
   description="A custom GPT wired to the freehire job API, so you can search IT jobs, open postings and companies, and track your applications from a ChatGPT conversation. Free and open source."
   {canonical}
 />


### PR DESCRIPTION
## What

The brand wordmark was inconsistent — lowercase **freehire** in the OG card, `og:site_name` and CLI, but camelCase **FreeHire** in the nav bar, About prose, and the ChatGPT surfaces. This standardizes on the **lowercase logotype**.

Rationale: lowercase matches the domain (`freehire.dev`) and the `freehire` CLI command, and reads dev-native (stripe / vercel / cal.com). Policy:
- **Wordmark / product name / titles → lowercase** always
- **Prose → capitalized only at sentence start** ("Freehire is an open-source…"), like "npm"/"iPhone"

## Changes

- Nav wordmark: `TopBar`, `HeaderMenu` → `freehire`
- ChatGPT surfaces: `freehire GPT`, page title, `ChatGPT · freehire`
- `BrandMark` comments → `freehire`
- Prose (sentence start, capital F): `seo.ts` `SITE_DESCRIPTION`, `about` description, `HomeView` hero body

## Verification

- `grep FreeHire src/` → none
- `npm run check` — 0 errors (2 pre-existing `JobFitFull.svelte` warnings, unrelated)

Copy-only; no logic, no deps.