### PR TITLE
fix(auth): logout clears the leftover host-only cookie (domain migration)

### DIFF
--- a/internal/auth/cookie.go
+++ b/internal/auth/cookie.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -21,11 +22,26 @@ func SetTokenCookie(c *fiber.Ctx, token string, ttl time.Duration, secure bool, 
 	writeTokenCookie(c, token, time.Now().Add(ttl), secure, domain)
 }
 
-// ClearTokenCookie expires the auth cookie (logout). It MUST pass the same
-// secure/domain attributes used at set time — the browser only overwrites a
-// cookie whose attributes match.
+// ClearTokenCookie expires the auth cookie (logout). The browser only
+// overwrites a cookie whose attributes match, so during a cookie-domain
+// migration a `.freehire.dev` clear can't remove a leftover host-only cookie
+// (minted before COOKIE_DOMAIN was set). So when a Domain is configured, also
+// emit a host-only expiry — clearing both scopes makes logout reliable
+// regardless of which cookie the browser is still holding.
 func ClearTokenCookie(c *fiber.Ctx, secure bool, domain string) {
-	writeTokenCookie(c, "", time.Now().Add(-time.Hour), secure, domain)
+	expired := time.Now().Add(-time.Hour)
+	writeTokenCookie(c, "", expired, secure, domain)
+	if domain != "" {
+		// fasthttp dedups Set-Cookie by name, so a second `c.Cookie()` for the
+		// same name would replace the first. Emit the host-only clear as a raw
+		// header so both the `.freehire.dev` cookie and any leftover host-only
+		// cookie are expired.
+		raw := CookieName + "=; Path=/; Expires=" + expired.UTC().Format(http.TimeFormat) + "; HttpOnly; SameSite=Lax"
+		if secure {
+			raw += "; Secure"
+		}
+		c.Response().Header.Add("Set-Cookie", raw)
+	}
 }
 
 // writeTokenCookie is the single place the cookie's attributes are set, so set

--- a/internal/auth/cookie_test.go
+++ b/internal/auth/cookie_test.go
@@ -45,3 +45,55 @@ func TestSetTokenCookieEmptyDomainOmitsAttribute(t *testing.T) {
 		t.Fatalf("expected no domain attribute, got %q", sc)
 	}
 }
+
+// clearCookieHeaders runs a logout clear with the given domain and returns every
+// Set-Cookie header it emitted.
+func clearCookieHeaders(t *testing.T, domain string) []string {
+	t.Helper()
+	app := fiber.New()
+	app.Get("/", func(c *fiber.Ctx) error {
+		ClearTokenCookie(c, true, domain)
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+	resp, err := app.Test(httptest.NewRequest("GET", "/", nil))
+	if err != nil {
+		t.Fatalf("test request failed: %v", err)
+	}
+	return resp.Header.Values("Set-Cookie")
+}
+
+// Logout during the cookie-domain migration must clear BOTH the configured
+// `.freehire.dev` cookie and any leftover host-only cookie — otherwise a user
+// still holding an old host-only cookie can never log out.
+func TestClearTokenCookieClearsBothScopesWithDomain(t *testing.T) {
+	scs := clearCookieHeaders(t, ".freehire.dev")
+	if len(scs) != 2 {
+		t.Fatalf("expected 2 Set-Cookie headers (domain + host-only), got %d: %q", len(scs), scs)
+	}
+	var haveDomain, haveHostOnly bool
+	for _, sc := range scs {
+		if !strings.Contains(sc, CookieName+"=;") {
+			t.Fatalf("expected an expiring clear, got %q", sc)
+		}
+		low := strings.ToLower(sc)
+		if strings.Contains(low, "domain=.freehire.dev") {
+			haveDomain = true
+		} else if !strings.Contains(low, "domain=") {
+			haveHostOnly = true
+		}
+	}
+	if !haveDomain || !haveHostOnly {
+		t.Fatalf("expected both a .freehire.dev clear and a host-only clear, got %q", scs)
+	}
+}
+
+// With no configured domain (dev), a single host-only clear is enough.
+func TestClearTokenCookieEmptyDomainSingle(t *testing.T) {
+	scs := clearCookieHeaders(t, "")
+	if len(scs) != 1 {
+		t.Fatalf("expected 1 Set-Cookie header, got %d: %q", len(scs), scs)
+	}
+	if strings.Contains(strings.ToLower(scs[0]), "domain=") {
+		t.Fatalf("expected host-only clear, got %q", scs[0])
+	}
+}


### PR DESCRIPTION
Existing sessions minted before `COOKIE_DOMAIN=.freehire.dev` carry a **host-only** `hire_token` cookie. Logout cleared only the `.freehire.dev` scope, so the browser kept the old host-only cookie (it only overwrites a cookie whose Domain matches) and **logout did nothing** for those users — surfaced during the agent.freehire.dev rollout (same reason the cookie didn't reach the subdomain).

Fix: `ClearTokenCookie` now also emits a host-only expiry when a Domain is configured, clearing both scopes. fasthttp dedups Set-Cookie by name, so the host-only clear is added as a raw header. Tests cover both the domain+host-only (2 headers) and dev host-only-only (1 header) cases.

No behavior change for fresh `.freehire.dev` sessions; belt-and-suspenders for the migration.