### PR TITLE
fix(enrich): guard against decimal-stripping fractional hourly salaries

### DIFF
--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -103,6 +103,13 @@ func buildSystemPrompt() string {
 	b.WriteString("cities (array of strings), timezone_note (string), ")
 	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217).\n")
 
+	// Salary guard: the model, told the field is an int, otherwise decimal-strips a
+	// fractional hourly rate ($26.08 -> 2608), inflating it 100x. A concrete
+	// counter-example is what makes a budget model round instead of strip.
+	b.WriteString("\nsalary_min and salary_max are WHOLE units of the currency. ")
+	b.WriteString("Round a fractional rate to the nearest whole unit and NEVER strip the ")
+	b.WriteString("decimal point: an hourly \"$26.08\" is 26 (with salary_period=hour), never 2608.\n")
+
 	b.WriteString("\nregions is the job's geographic area, for ANY work mode — a remote role's ")
 	b.WriteString("reach or an onsite/hybrid role's location: ")
 	b.WriteString("use 'global' ONLY when the posting explicitly says the role is open worldwide / ")

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -79,3 +79,15 @@ func TestSystemPromptKeepsServedAndHybridFields(t *testing.T) {
 		t.Errorf("countries/regions must keep the novel own-label allowance")
 	}
 }
+
+// A fractional hourly rate ("$26.08/hr") must be rounded to a whole currency unit,
+// never decimal-stripped into an inflated integer (26.08 -> 2608). The guard anchors
+// the weak model on the exact counter-example, so the prompt must carry it verbatim.
+func TestSystemPromptGuardsFractionalHourlySalary(t *testing.T) {
+	p := buildSystemPrompt()
+	for _, want := range []string{"whole", "26.08", "2608"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("salary guard must mention %q, got:\n%s", want, p)
+		}
+	}
+}

--- a/internal/enrich/provider.go
+++ b/internal/enrich/provider.go
@@ -6,7 +6,9 @@ import "context"
 // it on every job it writes (jobs.enrichment_version) and uses it as the target
 // version when enqueuing work; bumping it enqueues re-enrichment of every job that
 // was written under an older version.
-const Version = 1
+// v2: salary prompt guard — round fractional hourly rates to whole currency units
+// instead of decimal-stripping them (26.08 -> 2608). Re-enriches corrupted rows.
+const Version = 2
 
 // JobInput is the raw, source-shaped view of a job that a Provider reads to derive
 // an Enrichment. It carries exactly the fields the model extracts from — no

--- a/openspec/changes/enrich-hourly-salary-guard/.openspec.yaml
+++ b/openspec/changes/enrich-hourly-salary-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/enrich-hourly-salary-guard/design.md
+++ b/openspec/changes/enrich-hourly-salary-guard/design.md
@@ -1,0 +1,69 @@
+## Context
+
+Salary is not a DB column — it lives in the `jobs.enrichment` JSONB, extracted by
+the enrichment LLM (`cmd/enrich`). The contract types `SalaryMin`/`SalaryMax` as
+`*int` (`internal/enrich/enrichment.go`), and the system prompt asks for
+`salary_min (int)` (`internal/enrich/langchain.go`). Faced with a fractional
+hourly rate under an integer contract, the model drops the decimal point
+(`26.08 → 2608`), inflating the displayed rate ×100. The frontend renders the
+stored value verbatim (`web/src/lib/enrichment.ts`), so the corruption is at the
+source, not the view.
+
+A live spike (privatclaw/light, the production model) confirmed the mechanism and
+compared three fixes; results in "Decisions".
+
+## Goals / Non-Goals
+
+**Goals:**
+- The LLM populates `salary_min`/`salary_max` faithfully for fractional hourly
+  rates (round to whole currency units; never strip the decimal point).
+- Already-corrupted jobs are re-enriched through the corrected prompt.
+
+**Non-Goals:**
+- No change to the salary representation (stays `*int`, whole currency units).
+- No sub-dollar precision (cents) in storage or display.
+- No post-hoc heuristic that tries to "repair" already-stored corrupted numbers.
+
+## Decisions
+
+**Decision: prompt guard with a concrete counter-example (variant A).**
+Add one instruction to the system prompt anchoring on the exact failure:
+`$26.08/hr → 26, never 2608`. The spike proved this works deterministically on
+the budget model (3/3 runs returned `salary_min=26, salary_max=38, period=hour`;
+the guard also corrected the `salary_period`, which the baseline mislabelled
+`day`/`month`). A concrete numeric counter-example, not an abstract rule, is what
+made the weak model comply.
+
+Alternatives considered and rejected, both by spike evidence:
+- **B — sanitize heuristic (divide-by-100 when `period=hour` and value large).**
+  INVALIDATED. The corruption also mangles `salary_period`, so a `period=hour`
+  gate misses part of the corrupted data; and any magnitude threshold also
+  divides genuine high hourly rates ($1200/hr → $12/hr). The lost decimal is
+  unrecoverable information.
+- **C — store minor units (cents).** Faithful representation, but does not fix
+  extraction on its own — the model must still emit the right number, so C would
+  merely store the corruption precisely. Complementary, not a substitute;
+  deferred as a noted seam if cent-precision display is ever wanted.
+
+**Decision: bump `enrich.Version` to re-enrich corrupted rows.**
+Re-enrichment is the established mechanism (`enrich.Version` is the provenance
+stamp; the outbox re-enqueues jobs below the current version). This reaches every
+already-corrupted posting without a bespoke backfill.
+
+## Risks / Trade-offs
+
+- [Weak model may still occasionally slip on an unusual pay format] → The guard is
+  best-effort like all enrichment; sanitize already drops non-positive and
+  min>max values. This change strictly reduces the error rate, and the spike
+  showed 3/3 correct on the real posting.
+- [Re-enriching the catalogue costs LLM budget] → Bounded by the existing
+  freshest-first, open-jobs-only enrichment drain; the version bump is the
+  standard cost of any contract correction and re-enriches incrementally.
+
+## Migration Plan
+
+1. Merge the prompt guard + `enrich.Version` bump.
+2. Deploy `cmd/enrich`; the outbox re-enqueues jobs below the new version and
+   drains them freshest-first through the corrected prompt.
+3. Rollback: revert the version bump (jobs stay at the prior version; no schema
+   change to undo).

--- a/openspec/changes/enrich-hourly-salary-guard/proposal.md
+++ b/openspec/changes/enrich-hourly-salary-guard/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Jobs quoting a fractional hourly rate (e.g. DoorDash's `$26.08–$38.40 / hr`) are
+displayed with a salary inflated ×100 — `2 608 – 3 840 $ / hr`. The enrichment
+LLM, told the contract wants `salary_min (int)`, strips the decimal point of a
+sub-dollar-precision rate (`26.08 → 2608`) instead of rounding it (`→ 26`). A
+live spike against the production model confirmed the bug reproduces on the
+current prompt (and also mangles `salary_period`), and that a single prompt
+guard with a concrete counter-example fixes it deterministically (3/3 runs
+returned `26 / 38 / hour`). This corrupts every hourly-rate posting with cents —
+a mass format in US retail/logistics.
+
+## What Changes
+
+- Add an explicit instruction to the enrichment system prompt: salary figures
+  are **whole units of the currency**; an hourly rate written with cents
+  (`$26.08/hr`) MUST be rounded to the nearest whole unit (`26`), and the
+  decimal point MUST NEVER be stripped (`26.08` must never become `2608`).
+- Bump `enrich.Version` so already-corrupted jobs are re-enriched through the
+  corrected prompt (the existing re-enrichment mechanism).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `ai-enrichment`: the requirement that enrichment is extracted from a job's
+  description by an LLM provider gains a constraint — the provider MUST instruct
+  the model to represent salary amounts as whole currency units and to preserve
+  fractional hourly rates by rounding, never by dropping the decimal point.
+
+## Impact
+
+- `internal/enrich/langchain.go` — the salary line of the system prompt.
+- `internal/enrich/enrichment.go` — `enrich.Version` bump (triggers re-enrich of
+  existing rows).
+- Tests: `internal/enrich/langchain_test.go` (prompt asserts the guard).
+- No schema, migration, API, or frontend change. `salary_min`/`salary_max` stay
+  `*int`; this change makes the LLM populate them faithfully rather than
+  changing their representation.

--- a/openspec/changes/enrich-hourly-salary-guard/specs/ai-enrichment/spec.md
+++ b/openspec/changes/enrich-hourly-salary-guard/specs/ai-enrichment/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Enrichment is extracted from a job's description by an LLM provider
+
+The system SHALL define a `Provider` abstraction in `internal/enrich` that, given a
+job's source fields (at minimum `title`, `company`, `location`, `remote`,
+`description`), returns a populated `Enrichment` value. The provider SHALL instruct
+the LLM with the controlled vocabularies from the phase-1 contract so that the enum
+fields it is asked for are constrained to their allowed values. The provider SHALL
+NOT ask the LLM for the dictionary-covered facets that the read layer serves from the
+deterministic dictionaries (see "Unserved discovery facets are captured raw, not
+validated"); those are derived by `internal/jobderive`, not the LLM. Fields not
+determinable from the input SHALL be omitted, not guessed. The provider SHALL instruct
+the LLM that salary amounts are whole units of the currency: a fractional rate written
+with cents (e.g. an hourly `$26.08`) MUST be rounded to the nearest whole unit (`26`),
+and the decimal point MUST NEVER be stripped (`26.08` MUST NOT become `2608`).
+
+#### Scenario: Description fields are mapped into the contract
+
+- **WHEN** the provider is given a job whose description states "Senior Go engineer,
+  fully remote, €70k–90k/year"
+- **THEN** it returns an `Enrichment` with `salary_min=70000`, `salary_max=90000`,
+  `salary_currency=EUR`, and `salary_period=year`
+- **AND** it does not populate `seniority`, `work_mode`, or `skills` from the LLM —
+  those are derived by the deterministic dictionaries, not requested in the prompt
+
+#### Scenario: A fractional hourly rate is rounded, not decimal-stripped
+
+- **WHEN** the provider is given a job whose description states an hourly base pay
+  range of "$26.08—$38.40 USD"
+- **THEN** the prompt instructs the model to round each figure to a whole currency
+  unit, so the returned `Enrichment` has `salary_min=26`, `salary_max=38`,
+  `salary_currency=USD`, and `salary_period=hour`
+- **AND** it never returns `salary_min=2608` (the decimal point is not stripped)
+
+#### Scenario: Unstated fields are omitted
+
+- **WHEN** a job description says nothing about visa sponsorship or company size
+- **THEN** the returned `Enrichment` leaves `visa_sponsorship`, `company_size`, and
+  every other unstated field absent rather than filled with a guess

--- a/openspec/changes/enrich-hourly-salary-guard/tasks.md
+++ b/openspec/changes/enrich-hourly-salary-guard/tasks.md
@@ -1,0 +1,19 @@
+## 1. Prompt guard (variant A)
+
+- [x] 1.1 RED: add a test in `internal/enrich/langchain_test.go` asserting the
+  system prompt instructs whole-currency-unit salary and forbids stripping the
+  decimal of a fractional hourly rate (e.g. it contains the `26.08`/`2608`
+  counter-example).
+- [x] 1.2 GREEN: add the salary guard sentence to the system prompt in
+  `internal/enrich/langchain.go` so the test passes.
+
+## 2. Re-enrich corrupted rows
+
+- [x] 2.1 Bump `enrich.Version` from 1 to 2 in `internal/enrich/provider.go` so
+  already-enriched jobs re-enqueue through the corrected prompt. (Config
+  constant — verified by `go build`/`go vet`, no dedicated unit test.)
+
+## 3. Verify
+
+- [x] 3.1 `go build ./... && go vet ./... && go test ./internal/enrich/...` all
+  green.


### PR DESCRIPTION
## Summary

A job quoting a fractional hourly rate (e.g. DoorDash's `$26.08–$38.40 / hr`) was displayed with the salary inflated ×100 — `2 608 – 3 840 $ / hr`. Salary isn't a DB column; it's LLM-extracted into `jobs.enrichment`. Told `salary_min` is an `int`, the model **stripped the decimal** of a sub-dollar-precision rate (`26.08 → 2608`) instead of rounding (`→ 26`). The frontend renders the stored value verbatim, so the corruption is at the source.

- Add a system-prompt guard anchored on the exact counter-example: `$26.08 → 26, never 2608` (`internal/enrich/langchain.go`).
- Bump `enrich.Version` 1 → 2 so already-corrupted rows re-enrich through the corrected prompt.

## How it was decided (spike)

A live spike against the production model compared three fixes:
- **A — prompt guard (this PR): VALIDATED.** 3/3 runs returned `26 / 38 / hour`; the guard also corrected `salary_period` (baseline mislabelled it `day`/`month`). A concrete numeric counter-example is what makes the budget model comply.
- **B — post-hoc divide-by-100 heuristic: INVALIDATED.** The corruption also mangles `salary_period`, so a `period=hour` gate misses part of it; any magnitude threshold also divides genuine high hourly rates. The lost decimal is unrecoverable.
- **C — store cents (minor units): deferred.** Faithful representation, but doesn't fix extraction on its own — it would store the corruption precisely. Noted as a seam.

See `openspec/changes/enrich-hourly-salary-guard/design.md`.

## Test Plan

- [x] `go build ./... && go vet ./...` — exit 0
- [x] `go test ./...` — 0 failures; new `TestSystemPromptGuardsFractionalHourlySalary`
- [x] End-to-end: the **real shipped** `buildSystemPrompt()` fed to the live LLM on the DoorDash text returns `salary_min=26, salary_period=hour` — no `2608`.

## Deploy note

No schema/migration. After merge + deploy of `cmd/enrich`, the version bump re-enqueues corrupted rows; they drain freshest-first through the corrected prompt.