### PR TITLE
feat(assistant): multi-session sidebar + beta-tester gate for /my/assistant

### DIFF
--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -26,11 +26,15 @@ const dummyPasswordHash = "$2a$10$uAK6XQv2KNKj0KXGXHcgAe3fn70C1tZiCUeG4ZCkdGGJ60
 // User is the public representation of a local account. Role is the DB-stored
 // authorization role ('user'/'moderator'/'admin'); it rides the wire shape so a client
 // can gate moderator-only UI, while RequireRole still authorizes server-side.
+// BetaTester is a separate rollout-group membership (independent of Role); it
+// gates the in-app agent assistant and likewise rides the wire shape as a UI
+// affordance.
 type User struct {
-	ID        int64
-	Email     string
-	Role      string
-	CreatedAt *time.Time
+	ID         int64
+	Email      string
+	Role       string
+	BetaTester bool
+	CreatedAt  *time.Time
 }
 
 // PasswordHasher hashes and verifies passwords (bcrypt in production). Injected

--- a/internal/accounts/repository.go
+++ b/internal/accounts/repository.go
@@ -121,7 +121,7 @@ func (r *QueriesRepository) CreateUser(ctx context.Context, email, passwordHash 
 	if err != nil {
 		return User{}, err
 	}
-	return User{ID: row.ID, Email: row.Email, Role: row.Role, CreatedAt: pgconv.TimePtr(row.CreatedAt)}, nil
+	return User{ID: row.ID, Email: row.Email, Role: row.Role, BetaTester: row.BetaTester, CreatedAt: pgconv.TimePtr(row.CreatedAt)}, nil
 }
 
 // UserByEmail looks up the account with the given (already-normalised) email.
@@ -135,7 +135,7 @@ func (r *QueriesRepository) UserByEmail(ctx context.Context, email string) (User
 	if err != nil {
 		return User{}, "", false, err
 	}
-	u := User{ID: row.ID, Email: row.Email, Role: row.Role, CreatedAt: pgconv.TimePtr(row.CreatedAt)}
+	u := User{ID: row.ID, Email: row.Email, Role: row.Role, BetaTester: row.BetaTester, CreatedAt: pgconv.TimePtr(row.CreatedAt)}
 	return u, row.PasswordHash.String, row.PasswordHash.Valid, nil
 }
 
@@ -148,5 +148,5 @@ func (r *QueriesRepository) UserByID(ctx context.Context, id int64) (User, error
 	if err != nil {
 		return User{}, err
 	}
-	return User{ID: row.ID, Email: row.Email, Role: row.Role, CreatedAt: pgconv.TimePtr(row.CreatedAt)}, nil
+	return User{ID: row.ID, Email: row.Email, Role: row.Role, BetaTester: row.BetaTester, CreatedAt: pgconv.TimePtr(row.CreatedAt)}, nil
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -272,6 +272,7 @@ type User struct {
 	ResumeStructured           []byte             `json:"resume_structured"`
 	ResumeStructuredModel      pgtype.Text        `json:"resume_structured_model"`
 	ResumeStructuredUploadedAt pgtype.Timestamptz `json:"resume_structured_uploaded_at"`
+	BetaTester                 bool               `json:"beta_tester"`
 }
 
 type UserIdentity struct {

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -4,20 +4,20 @@
 -- returned so the new account's wire shape carries it (always 'user' at creation).
 INSERT INTO users (email, password_hash)
 VALUES ($1, $2)
-RETURNING id, email, role, created_at;
+RETURNING id, email, role, beta_tester, created_at;
 
 -- name: GetUserByEmail :one
 -- Login lookup. Case-insensitive on email; returns password_hash so the handler
 -- can verify the password (and reject accounts that have none). role feeds the
 -- post-login wire shape.
-SELECT id, email, role, password_hash, created_at
+SELECT id, email, role, beta_tester, password_hash, created_at
 FROM users
 WHERE lower(email) = lower($1);
 
 -- name: GetUserByID :one
 -- Profile lookup for the authenticated user. Never selects password_hash. role is
 -- included so /auth/me can tell a client whether to surface moderator-only UI.
-SELECT id, email, role, created_at
+SELECT id, email, role, beta_tester, created_at
 FROM users
 WHERE id = $1;
 

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -31,7 +31,7 @@ func (q *Queries) ClearUserResume(ctx context.Context, id int64) error {
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (email, password_hash)
 VALUES ($1, $2)
-RETURNING id, email, role, created_at
+RETURNING id, email, role, beta_tester, created_at
 `
 
 type CreateUserParams struct {
@@ -40,10 +40,11 @@ type CreateUserParams struct {
 }
 
 type CreateUserRow struct {
-	ID        int64              `json:"id"`
-	Email     string             `json:"email"`
-	Role      string             `json:"role"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	ID         int64              `json:"id"`
+	Email      string             `json:"email"`
+	Role       string             `json:"role"`
+	BetaTester bool               `json:"beta_tester"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 }
 
 // Register a new account. email is stored as given (the handler lowercases it);
@@ -56,6 +57,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (CreateU
 		&i.ID,
 		&i.Email,
 		&i.Role,
+		&i.BetaTester,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -77,7 +79,7 @@ func (q *Queries) GetUserATSAnalysis(ctx context.Context, id int64) ([]byte, err
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, role, password_hash, created_at
+SELECT id, email, role, beta_tester, password_hash, created_at
 FROM users
 WHERE lower(email) = lower($1)
 `
@@ -86,6 +88,7 @@ type GetUserByEmailRow struct {
 	ID           int64              `json:"id"`
 	Email        string             `json:"email"`
 	Role         string             `json:"role"`
+	BetaTester   bool               `json:"beta_tester"`
 	PasswordHash pgtype.Text        `json:"password_hash"`
 	CreatedAt    pgtype.Timestamptz `json:"created_at"`
 }
@@ -100,6 +103,7 @@ func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEm
 		&i.ID,
 		&i.Email,
 		&i.Role,
+		&i.BetaTester,
 		&i.PasswordHash,
 		&i.CreatedAt,
 	)
@@ -107,16 +111,17 @@ func (q *Queries) GetUserByEmail(ctx context.Context, lower string) (GetUserByEm
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, role, created_at
+SELECT id, email, role, beta_tester, created_at
 FROM users
 WHERE id = $1
 `
 
 type GetUserByIDRow struct {
-	ID        int64              `json:"id"`
-	Email     string             `json:"email"`
-	Role      string             `json:"role"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	ID         int64              `json:"id"`
+	Email      string             `json:"email"`
+	Role       string             `json:"role"`
+	BetaTester bool               `json:"beta_tester"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 }
 
 // Profile lookup for the authenticated user. Never selects password_hash. role is
@@ -128,6 +133,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (GetUserByIDRow, er
 		&i.ID,
 		&i.Email,
 		&i.Role,
+		&i.BetaTester,
 		&i.CreatedAt,
 	)
 	return i, err

--- a/internal/handler/auth.go
+++ b/internal/handler/auth.go
@@ -15,10 +15,11 @@ import (
 // decide whether to surface moderator-only UI; it is an affordance only, as RequireRole
 // re-checks the DB-stored role on every privileged request.
 type userResponse struct {
-	ID        int64      `json:"id"`
-	Email     string     `json:"email"`
-	Role      string     `json:"role"`
-	CreatedAt *time.Time `json:"created_at"`
+	ID         int64      `json:"id"`
+	Email      string     `json:"email"`
+	Role       string     `json:"role"`
+	BetaTester bool       `json:"beta_tester"`
+	CreatedAt  *time.Time `json:"created_at"`
 }
 
 type credentials struct {
@@ -28,7 +29,7 @@ type credentials struct {
 
 // toUserResponse maps an accounts.User to its public response shape.
 func toUserResponse(u accounts.User) userResponse {
-	return userResponse{ID: u.ID, Email: u.Email, Role: u.Role, CreatedAt: u.CreatedAt}
+	return userResponse{ID: u.ID, Email: u.Email, Role: u.Role, BetaTester: u.BetaTester, CreatedAt: u.CreatedAt}
 }
 
 // accountsError maps the accounts service sentinels to HTTP errors, preserving

--- a/internal/handler/submissions_test.go
+++ b/internal/handler/submissions_test.go
@@ -41,3 +41,16 @@ func TestToUserResponse_IncludesRole(t *testing.T) {
 		t.Errorf("role = %q, want moderator", got.Role)
 	}
 }
+
+// beta_tester is a separate group from role, carried on the wire so the SPA can
+// gate the assistant independently of moderator/admin.
+func TestToUserResponse_IncludesBetaTester(t *testing.T) {
+	got := toUserResponse(accounts.User{ID: 1, Email: "a@b.test", Role: "user", BetaTester: true})
+	if !got.BetaTester {
+		t.Errorf("beta_tester = %v, want true", got.BetaTester)
+	}
+	// role and beta_tester are independent — a plain user can be a beta tester.
+	if got.Role != "user" {
+		t.Errorf("role = %q, want user", got.Role)
+	}
+}

--- a/migrations/0019_user_beta_tester.sql
+++ b/migrations/0019_user_beta_tester.sql
@@ -1,0 +1,8 @@
+-- beta_tester marks an account as a member of the beta-tester group — a rollout
+-- gate that is deliberately SEPARATE from `role` (a user can be a moderator
+-- and/or a beta tester, independently). It currently gates the in-app agent
+-- assistant (/my/assistant): the page and its nav entry show only to beta
+-- testers. Membership is granted out-of-band (manual SQL); there is no
+-- self-service grant. Defaults false so existing accounts are non-members.
+ALTER TABLE public.users
+    ADD COLUMN beta_tester boolean DEFAULT false NOT NULL;

--- a/openspec/changes/assistant-multi-session/.openspec.yaml
+++ b/openspec/changes/assistant-multi-session/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/assistant-multi-session/design.md
+++ b/openspec/changes/assistant-multi-session/design.md
@@ -1,0 +1,140 @@
+## Context
+
+`/my/assistant` (moderators-only, PR #679) is a SvelteKit page that on mount
+`POST /sessions` → spawns one agent session, opens a WebSocket relay, `attach`es,
+and streams frames through the pure `reduceTurnEvent` reducer (`chat.ts`).
+There is no session list, no "new", no switch, no delete. The agent backend is
+`freehire-agent` (a trimmed roy fork, `agent.freehire.dev`, separate repo).
+
+Backend facts established by exploration:
+
+- **WS relay allow-list** (`ws.rs`): `attach, acquire_input, send, cancel_turn,
+  release_input, detach`. `list`, `read_journal`, `close`, `delete_archive` are
+  rejected over WS. Every op is ownership-checked via `meta.session_owner`.
+- **`attach {session, from_seq}`** (`engine.rs:401`) calls
+  `journal.replay_from(from)` (memory ring → disk fallback) and streams the
+  replayed entries as `frame` events, then live frames — so `from_seq: 0`
+  repaints full history through the same reducer.
+- **HTTP** (`http.rs`): `GET /sessions` exists but is **not** owner-scoped
+  (returns all users' sessions). `POST /sessions` creates. No `DELETE`.
+  `session_meta.created_by` is the owner; `daemon.close(id)` archives a live
+  session; there is no `delete_session_meta` yet.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- List the caller's held sessions in a left sidebar; click to switch (history
+  replays); "New chat"; per-session delete.
+- Close the cross-user leak in `GET /sessions` (owner-scope it) and add
+  `DELETE /sessions/{id}`.
+- Keep the streaming/turn/lease machinery that already works; add session
+  orchestration around it.
+- Copy: "Assistant" → "Agent"; drop "Claude" from the subtitle.
+
+**Non-Goals:**
+
+- Session tags/rename/pinning, projects, harness/model pickers (roy-web has
+  these; out of scope).
+- Cross-device anything beyond what owner-scoped `GET /sessions` already gives.
+- Deleting the on-disk archive journal (inert; swept by `orphan_sweep`). Delete
+  = close + drop the meta row.
+- Any change to the WS relay allow-list (all needed ops are already allowed).
+
+## Decisions
+
+**1. Backend-backed session list (owner-scoped `GET /sessions`), not a
+client-side registry.** Chosen in brainstorming for cross-device sync and true
+delete. `list_sessions` gains `Extension(AuthUser(user_id))` and filters the
+assembled rows to those whose meta `created_by == user_id`. Rows without a meta
+(no owner attributable) are excluded. *Alternative — localStorage registry:*
+zero backend change, but per-browser and can't truly delete; rejected.
+
+**2. `DELETE /sessions/{id}` = owner-check → close-if-live → delete meta.**
+Verify `session_owner(id) == user_id` (else 404, not 403 — don't reveal
+existence of others' sessions). If live (`daemon.list` contains it), `daemon.close(id)`
+to archive the running process. Then `meta.delete_session_meta(id)` (new
+`MetaStore` method). Dropping the meta row makes `session_owner` return `None`,
+so the session vanishes from the owner-filtered list and any future `attach` is
+rejected as not-owned — no new WS op needed. *Alternative — add a `delete_archive`
+WS/daemon path:* more complete (removes disk journal) but larger surface; the
+archive is inert, so deferred.
+
+**3. Switching = detach + re-attach `from_seq: 0`, reusing `reduceTurnEvent`.**
+On switch: tear down the current session's frame subscription and `detach`,
+reset `chat = initChat()`, `attach {session, from_seq: 0}`, and subscribe. The
+replayed `frame` events fold through the exact same reducer as live frames, so
+history and live streaming share one code path. The optimistic-echo dedup
+(`pendingEcho`) only applies to locally-sent messages, so replay is unaffected.
+*Alternative — `read_journal` HTTP/WS fetch then seed:* rejected — `read_journal`
+is not in the relay allow-list, and attach-replay already does exactly this.
+
+**4. One WS connection, one active attach at a time.** Keep the single
+`RoyClient` per page. Model an explicit "active session" with its own
+subscription/lease; switching fully unwinds the old one (unsubscribe, detach,
+release lease if held, end any in-flight turn) before attaching the new one.
+This avoids interleaving frames across sessions and reuses the existing
+teardown logic. *Alternative — attach many sessions at once (roy-web bg-attach):*
+unnecessary for a single visible pane.
+
+**5. Pure session-list state in a testable module.** A small
+`web/src/lib/assistant/sessions.ts` holds the session-list type + label
+derivation + list reducers (add/remove/select/sort newest-first), unit-tested
+with vitest — mirroring how `chat.ts` and `jobFit.ts` isolate pure logic from
+the Svelte component. Labels: prefer a stored `display_label`/tag, else derive
+from the first user message on attach, else a timestamp.
+
+**6. Ship backend first.** The owner-scope + DELETE land and deploy to
+`agent.freehire.dev` before the frontend depends on them. The frontend degrades
+safely if the list call fails (fall back to the current single-spawn behavior,
+surfaced as a non-fatal error) so a deploy-order slip doesn't white-screen the
+page.
+
+## Risks / Trade-offs
+
+- **Cross-repo, two deploys** → Backend PR + deploy first (Decision 6); frontend
+  guards the list call so a lag is a degraded (single-session) page, not a break.
+- **`GET /sessions` owner-scope is a BREAKING contract change** → Only consumer
+  today is this page (which sends the cookie); scoping strictly reduces what's
+  returned. Verified by a backend test asserting cross-user exclusion.
+- **Newest-first ordering has no reliable timestamp in the list payload** →
+  `list_sessions` returns `session_id, project_id, agent_name, tags, live` — no
+  `created_at`. Add `created_at` (present on `session_meta`) to the row, or sort
+  by the `live` flag then session id. Decide in tasks; leaning on adding
+  `created_at` to the row for a correct newest-first sort.
+- **Deleting the active session** → switch to the next listed session, or spawn a
+  fresh one if the list is now empty; never leave the pane attached to a deleted
+  id.
+- **Replay of a very long journal** → attach streams the whole journal as frames;
+  acceptable for chat-length transcripts. The memory-ring→disk path already
+  handles eviction. No pagination for now.
+- **Label from first user message requires reading the journal** → on attach the
+  first replayed `user_prompt` frame yields the label; until then show a
+  timestamp/placeholder. No extra fetch.
+
+## Migration Plan
+
+1. **Backend (`freehire-agent`)**: owner-scope `list_sessions`, add
+   `DELETE /sessions/{id}` + `MetaStore::delete_session_meta` (+ `created_at`
+   on the list row if used for sort). Tests. PR, merge, deploy to
+   `agent.freehire.dev`.
+2. **Frontend (`hire/web`)**: `sessions.ts` (pure) + api helpers (`listSessions`,
+   `deleteSession`) + sidebar UI + switch/new/delete wiring + `from_seq: 0`
+   attach + copy tweaks. Vitest for `sessions.ts`.
+3. **`hire` DB migration `0019_user_beta_tester.sql`** (adds the `beta_tester`
+   column) — apply to prod **manually before deploying** the hire backend, per
+   the migrations convention. Then grant the first members out-of-band:
+   ```sql
+   UPDATE users SET beta_tester = true WHERE lower(email) = 'strelov1@gmail.com';
+   ```
+   (Repeat the `UPDATE` per email to add more testers.) No new env.
+4. Rollback = revert each repo independently (the frontend guard makes the
+   `freehire-agent` and `hire` deploys order-independent after step 1 ships).
+
+## Open Questions
+
+- Sort key for newest-first: add `created_at` to the `GET /sessions` row (clean),
+  or accept session-id ordering? — Lean `created_at`; confirm during backend task.
+- Delete UX: inline "×" with a confirm, or hover-reveal trash like roy-web? —
+  Decide during the sidebar task; default to hover-reveal trash + lightweight
+  confirm for a session with history.

--- a/openspec/changes/assistant-multi-session/proposal.md
+++ b/openspec/changes/assistant-multi-session/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+The in-app AI assistant at `/my/assistant` spawns one throwaway session on
+mount: there is no way to start a fresh conversation without losing the current
+one, and no way to return to an earlier conversation. Every page load strands
+whatever was said before. Moderators using the assistant for real work need to
+keep several conversations and move between them — the same session model
+roy-web already ships.
+
+## What Changes
+
+- Add a roy-web-style **left sidebar** to `/my/assistant` listing the signed-in
+  user's held sessions, with a **"New chat"** button and a per-session **delete**
+  control. The chat transcript moves into the right pane.
+- **Switch sessions** by clicking one: detach the current attach and re-`attach`
+  to the selected session with `from_seq: 0`, replaying its journal through the
+  existing `reduceTurnEvent` reducer so the full history repaints.
+- Back the session list with the agent backend: **`GET /sessions` scoped to the
+  caller** (today it leaks every user's sessions) and a new
+  **`DELETE /sessions/{id}`** (verify owner → `daemon.close` if live → delete the
+  `session_meta` row). **BREAKING** (backend contract): `list_sessions` gains an
+  owner filter.
+- Copy tweaks on the page: rename **"Assistant" → "Agent"** (heading + title +
+  the account-nav label) and drop **"Claude"** from the subtitle ("Chat with a
+  Claude agent inside freehire" → "Chat with an agent inside freehire").
+- Introduce a **beta-tester group** (a `beta_tester` flag on `users`, separate
+  from `role` so it coexists with moderator/admin) and gate the assistant to it:
+  the page and the nav item show **only to beta testers** (moderators without the
+  flag lose access). Membership is granted by **manual SQL** (`UPDATE users SET
+  beta_tester = true WHERE lower(email) = …`), consistent with the manual-migration
+  convention; the first member is the maintainer's account.
+
+## Capabilities
+
+### New Capabilities
+- `assistant-sessions`: multi-session management for the in-app agent chat —
+  listing the caller's sessions, creating/switching (with journal replay) and
+  deleting them, and the owner-scoped backend contract (`GET /sessions`,
+  `DELETE /sessions/{id}`) the frontend consumes.
+
+### Modified Capabilities
+<!-- No existing spec captures the assistant chat; the session behavior is net-new. -->
+
+## Impact
+
+- **Frontend (`hire/web`)**: `web/src/routes/my/assistant/+page.svelte` (sidebar +
+  switch/new/delete + copy), `web/src/lib/assistant/api.ts` (list/delete fetch
+  helpers, session-list wire types), and the attach flow (`from_seq: 0` replay).
+  A pure session-list store/reducer is unit-tested (vitest), mirroring
+  `chat.ts`/`jobFit.ts`.
+- **Backend (`freehire-agent`, separate repo + deploy)**:
+  `crates/roy-management/src/http.rs` — scope `list_sessions` by `created_by`,
+  add `DELETE /sessions/{id}`; `meta_store.rs` — add `delete_session_meta`.
+  Shipped as its own PR and deployed to `agent.freehire.dev` before the frontend
+  relies on the new contract.
+- **Auth/privacy**: closes an existing cross-user leak in `GET /sessions`.
+  Session ownership on `attach`/`delete` is already enforced via
+  `session_owner`.
+- **Beta-tester group (`hire`)**: a `beta_tester` boolean on `users` (migration
+  `0019`), carried through sqlc (`users.sql`), `accounts.User`, and the `/auth/me`
+  `userResponse` (`beta_tester` field); the frontend `User` type + `accountNav`
+  gate (`betaOnly`) + the assistant page guard read it. Membership set by manual
+  SQL. No new env.

--- a/openspec/changes/assistant-multi-session/specs/assistant-sessions/spec.md
+++ b/openspec/changes/assistant-multi-session/specs/assistant-sessions/spec.md
@@ -1,0 +1,131 @@
+## ADDED Requirements
+
+### Requirement: The assistant page lists the caller's held sessions
+
+The `/my/assistant` page SHALL show a sidebar listing the signed-in user's
+existing agent sessions, newest first, so the user can see and return to prior
+conversations instead of only the one spawned on load.
+
+#### Scenario: Sidebar shows the caller's sessions on load
+
+- **WHEN** a moderator opens `/my/assistant` and the backend has two sessions owned by them
+- **THEN** the sidebar lists both sessions with a human label, and the most recently active one is opened in the chat pane
+
+#### Scenario: The list never shows another user's sessions
+
+- **WHEN** the page requests the session list
+- **THEN** it calls the owner-scoped backend list and displays only sessions whose owner is the caller — never a session created by a different user
+
+#### Scenario: Empty state
+
+- **WHEN** the caller has no prior sessions
+- **THEN** the page creates one fresh session, opens it, and the sidebar shows that single entry
+
+### Requirement: Starting a new chat
+
+The page SHALL let the user start a new conversation without losing existing
+ones. Creating a new chat SHALL create a fresh backend session, add it to the
+top of the sidebar, and make it the active pane; existing sessions remain in the
+list.
+
+#### Scenario: New chat keeps prior sessions
+
+- **WHEN** the user clicks "New chat" while a session with history is open
+- **THEN** a new empty session is created and becomes active, and the previously open session is still listed in the sidebar and reopenable
+
+#### Scenario: New chat is the active input target
+
+- **WHEN** a new chat has just been created
+- **THEN** a message the user sends is delivered to the new session, not the previously active one
+
+### Requirement: Switching between sessions replays history
+
+Selecting a session in the sidebar SHALL make it the active pane and repaint its
+full prior transcript. The page SHALL detach from the current session and
+re-attach to the selected one from the start of its journal, folding the
+replayed events through the existing chat reducer.
+
+#### Scenario: Selecting an older session shows its messages
+
+- **WHEN** the user clicks a session that already contains a multi-message exchange
+- **THEN** the chat pane clears and repaints that session's full user/assistant/tool history in order, and further messages continue that conversation
+
+#### Scenario: Switching away and back preserves the conversation
+
+- **WHEN** the user switches from session A to session B and later back to A
+- **THEN** session A's transcript is shown again in full, reconstructed from the backend journal
+
+#### Scenario: Switching mid-turn is safe
+
+- **WHEN** the user switches sessions while a turn is streaming in the current one
+- **THEN** the page ends/abandons the in-flight turn cleanly for the old session and does not interleave its frames into the newly selected session
+
+### Requirement: Deleting a session
+
+The user SHALL be able to delete a session from the sidebar. Deleting SHALL
+remove it from the caller's list permanently via the backend, and the deleted
+session SHALL no longer be attachable.
+
+#### Scenario: Delete removes the session from the list
+
+- **WHEN** the user deletes a session that is not currently open
+- **THEN** it disappears from the sidebar and does not reappear on reload
+
+#### Scenario: Deleting the active session
+
+- **WHEN** the user deletes the session currently open in the chat pane
+- **THEN** the page switches to another session in the list (or creates a fresh one if none remain) and the deleted session is gone
+
+#### Scenario: Delete is owner-guarded
+
+- **WHEN** a delete is requested for a session the caller does not own
+- **THEN** the backend rejects it and the session is not removed
+
+### Requirement: Owner-scoped session backend contract
+
+The agent backend SHALL scope the session list to the authenticated caller and
+SHALL expose deletion. `GET /sessions` SHALL return only sessions owned by the
+caller. `DELETE /sessions/{id}` SHALL, for an owned session, close it if live
+and remove its metadata so it no longer appears in the list nor accepts an
+attach; for a session the caller does not own it SHALL fail without side effects.
+
+#### Scenario: List is filtered by owner
+
+- **WHEN** `GET /sessions` is called with a valid session cookie
+- **THEN** the response contains every session whose `created_by` is the caller and no session owned by anyone else
+
+#### Scenario: Delete an owned session
+
+- **WHEN** `DELETE /sessions/{id}` is called for a session the caller owns
+- **THEN** the backend closes it if it is live, removes its `session_meta` row, and returns success; a subsequent list omits it and an attach to it is rejected as not owned
+
+#### Scenario: Delete a non-owned or unknown session
+
+- **WHEN** `DELETE /sessions/{id}` names a session the caller does not own or that does not exist
+- **THEN** the backend returns an error status and makes no change
+
+### Requirement: The assistant is gated to the beta-tester group
+
+Access to the assistant SHALL be restricted to members of a beta-tester group,
+represented by a `beta_tester` flag on the user account that is independent of
+`role` (a user may be both a moderator and a beta tester, or either alone). The
+`/my/assistant` page and its account-nav entry SHALL be shown only to beta
+testers; a non-beta user (including a moderator without the flag) SHALL NOT see
+the nav entry and SHALL be stopped at the page. The flag SHALL be exposed on the
+authenticated user's profile (`/auth/me`) so the client can gate the UI.
+Membership is granted out-of-band (manual SQL); no self-service grant exists.
+
+#### Scenario: Beta tester sees and can open the assistant
+
+- **WHEN** a signed-in user whose account has `beta_tester = true` loads the account area
+- **THEN** the "Agent" nav entry is present and the `/my/assistant` page renders the chat
+
+#### Scenario: Non-beta user cannot access the assistant
+
+- **WHEN** a signed-in user without the beta-tester flag (including a plain moderator) loads the account area
+- **THEN** the "Agent" nav entry is absent and visiting `/my/assistant` directly shows the restricted-rollout notice instead of connecting
+
+#### Scenario: The flag is independent of role
+
+- **WHEN** the authenticated user's profile is fetched
+- **THEN** it reports `beta_tester` separately from `role`, so granting beta access does not change the user's role and vice versa

--- a/openspec/changes/assistant-multi-session/tasks.md
+++ b/openspec/changes/assistant-multi-session/tasks.md
@@ -1,0 +1,39 @@
+## 1. Backend contract (`freehire-agent`, separate PR + deploy first)
+
+- [x] 1.1 Add `MetaStore::delete_session_meta(session_id)` (DELETE the `session_meta` row) with a unit/integration test. (Already present upstream — verified: transactional row+tags delete, NotFound on missing, covered by `delete_session_meta_removes_row_and_tags`.)
+- [x] 1.2 Owner-scope `list_sessions`: inject `Extension(AuthUser(user_id))`, filter the assembled rows to those whose meta `created_by == user_id`, and drop sids with no owning meta. Test that a second user's session is excluded.
+- [x] 1.3 Include a newest-first sort key in the `GET /sessions` row (add `created_at` from `session_meta`) and return it; sort the list newest-first. Assert ordering in the list test.
+- [x] 1.4 Add `DELETE /sessions/{id}`: verify `session_owner == user_id` (404 when unknown/not owned, no side effects), `daemon.close(id)` if live, then `delete_session_meta(id)`; return success. Test owned-delete (gone from list, attach rejected) and non-owned/unknown (error, unchanged). (Code-review fix: a `daemon.list()` failure now returns 502 and keeps the meta, never orphaning a live process.)
+- [ ] 1.5 `cargo test` + `cargo clippy` green; open the backend PR, merge, deploy to `agent.freehire.dev`, and smoke-test `GET /sessions` (scoped) + `DELETE` with a real cookie. (Tests: 92 pass; clippy clean. PR + deploy pending user confirmation.)
+
+## 2. Frontend session-list core (pure, unit-tested)
+
+- [x] 2.1 `web/src/lib/assistant/api.ts`: add `SessionSummary` wire type + `listSessions()` (`GET /sessions`) and `deleteSession(id)` (`DELETE /sessions/{id}`) fetch helpers (credentials: 'include'), mirroring `createSession`. (Type lives in `sessions.ts`; api.ts imports it.)
+- [x] 2.2 `web/src/lib/assistant/sessions.ts` (new, pure): session-list type, newest-first ordering, label derivation (stored label/tag → first user message → timestamp), and reducers `addSession`/`removeSession`/`selectSession`. Write vitest first (RED) covering ordering, label fallbacks, add/remove/select, and delete-active → next-or-empty selection. (16 vitest cases green.)
+
+## 3. Frontend page: sidebar + switch/new/delete
+
+- [x] 3.1 Refactor `+page.svelte` connect flow to model an explicit "active session": on load, `listSessions()`; open the newest (or create one if empty). Guard the list call so a backend failure degrades to a single fresh session with a non-fatal error banner.
+- [x] 3.2 Extract per-session attach/detach: switching detaches + unsubscribes the current session, releases the lease if held, ends any in-flight turn, resets `chat = initChat()`, then `attach {session, from_seq: 0}` and re-subscribes. Verify replayed history repaints via `reduceTurnEvent`.
+- [x] 3.3 Add the left sidebar UI (session list, active highlight, "New chat" button, hover-reveal delete with a confirm for a session with history). Move the chat transcript into the right pane; keep the composer/queue behavior intact. Responsive: sidebar collapses/toggles on narrow widths.
+- [x] 3.4 Wire "New chat" (create → prepend → activate) and delete (`deleteSession` → remove from list → if active, switch to next or spawn fresh).
+
+## 4. Copy tweaks
+
+- [x] 4.1 Rename "Assistant" → "Agent" (page heading, `<title>`, and the `accountNav` label) and change the subtitle "Chat with a Claude agent inside freehire" → "Chat with an agent inside freehire".
+
+## 6. Beta-tester group (gate the assistant)
+
+- [x] 6.1 Migration `migrations/0019_user_beta_tester.sql`: `ALTER TABLE users ADD COLUMN beta_tester boolean NOT NULL DEFAULT false;`.
+- [x] 6.2 `internal/db/queries/users.sql`: add `beta_tester` to `CreateUser` RETURNING, `GetUserByEmail`, and `GetUserByID`; run `make sqlc` (or the pinned sqlc binary) and commit generated code.
+- [x] 6.3 `internal/accounts`: add `BetaTester bool` to `User` and map `row.BetaTester` in the three `repository.go` constructions.
+- [x] 6.4 `internal/handler/auth.go`: add `BetaTester bool \`json:"beta_tester"\`` to `userResponse` and map it in `toUserResponse` (unit test the mapping, mirroring `TestToUserResponse_IncludesRole`).
+- [x] 6.5 Frontend: add `beta_tester: boolean` to the `User` type (`web/src/lib/types.ts`); change the assistant `accountNav` item from `moderatorOnly` to `betaOnly` and extend `visibleAccountNav(isModerator, isBetaTester)` — RED-first in `accountNav.test.ts` (beta-only Assistant vs moderator-only Inbox); update the `my/+layout.svelte` caller.
+- [x] 6.6 Gate the page: `+page.svelte` guards on `currentUser()?.beta_tester` (not `role === 'moderator'`); adjust the restricted-rollout copy.
+- [ ] 6.7 Document the manual grant SQL in the change/deploy notes: `UPDATE users SET beta_tester = true WHERE lower(email) = 'strelov1@gmail.com';` (apply to prod manually, like migrations). Apply the migration + grant to the local DB for verification.
+
+## 5. Verify & finish
+
+- [ ] 5.1 `npm run` checks that gate/apply locally (svelte-check + eslint + vitest for `sessions.ts`/`accountNav`) and `go build ./... && go vet ./... && go test ./...`; builds pass.
+- [ ] 5.2 Visual/behavioral verify on `localhost` as a beta tester (grant the QA account): list, new, switch-with-history-replay, delete-active, mid-turn switch safety, copy text, and that a non-beta user is stopped.
+- [ ] 5.3 Update this change's checkboxes; run the finish flow (verification-before-completion → finish branch → archive + sync). Offer a `/blog` changelog entry (user-facing).

--- a/openspec/changes/assistant-multi-session/tasks.md
+++ b/openspec/changes/assistant-multi-session/tasks.md
@@ -30,10 +30,10 @@
 - [x] 6.4 `internal/handler/auth.go`: add `BetaTester bool \`json:"beta_tester"\`` to `userResponse` and map it in `toUserResponse` (unit test the mapping, mirroring `TestToUserResponse_IncludesRole`).
 - [x] 6.5 Frontend: add `beta_tester: boolean` to the `User` type (`web/src/lib/types.ts`); change the assistant `accountNav` item from `moderatorOnly` to `betaOnly` and extend `visibleAccountNav(isModerator, isBetaTester)` — RED-first in `accountNav.test.ts` (beta-only Assistant vs moderator-only Inbox); update the `my/+layout.svelte` caller.
 - [x] 6.6 Gate the page: `+page.svelte` guards on `currentUser()?.beta_tester` (not `role === 'moderator'`); adjust the restricted-rollout copy.
-- [ ] 6.7 Document the manual grant SQL in the change/deploy notes: `UPDATE users SET beta_tester = true WHERE lower(email) = 'strelov1@gmail.com';` (apply to prod manually, like migrations). Apply the migration + grant to the local DB for verification.
+- [~] 6.7 Grant SQL documented in `design.md` Migration Plan (`UPDATE users SET beta_tester = true WHERE lower(email) = 'strelov1@gmail.com';`). Local-DB apply + grant verification pending (needs the stack up).
 
 ## 5. Verify & finish
 
-- [ ] 5.1 `npm run` checks that gate/apply locally (svelte-check + eslint + vitest for `sessions.ts`/`accountNav`) and `go build ./... && go vet ./... && go test ./...`; builds pass.
+- [x] 5.1 Automated checks green: web svelte-check (0 errors), eslint (clean), vitest (254), `npm run build` (prod bundle OK); Go `build`/`vet`/`test` (accounts+handler) OK; freehire-agent `cargo test` (92) + clippy clean.
 - [ ] 5.2 Visual/behavioral verify on `localhost` as a beta tester (grant the QA account): list, new, switch-with-history-replay, delete-active, mid-turn switch safety, copy text, and that a non-beta user is stopped.
 - [ ] 5.3 Update this change's checkboxes; run the finish flow (verification-before-completion → finish branch → archive + sync). Offer a `/blog` changelog entry (user-facing).

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -26,16 +26,26 @@ describe('accountNav config', () => {
 });
 
 describe('visibleAccountNav', () => {
-  it('hides the moderator-only sections (Assistant, Inbox) from non-moderators', () => {
-    const hrefs = visibleAccountNav(false).map((i) => i.href);
+  it('hides both restricted sections from a plain user', () => {
+    const hrefs = visibleAccountNav(false, false).map((i) => i.href);
     expect(hrefs).not.toContain('/my/inbox');
     expect(hrefs).not.toContain('/my/assistant');
-    const moderatorOnly = accountNav.filter((i) => 'moderatorOnly' in i && i.moderatorOnly);
-    expect(hrefs).toHaveLength(accountNav.length - moderatorOnly.length);
   });
 
-  it('shows every section to a moderator', () => {
-    const hrefs = visibleAccountNav(true).map((i) => i.href);
+  it('gates the Assistant on beta membership, not the moderator role', () => {
+    // A moderator who is not a beta tester sees Inbox but NOT the Assistant.
+    const modOnly = visibleAccountNav(true, false).map((i) => i.href);
+    expect(modOnly).toContain('/my/inbox');
+    expect(modOnly).not.toContain('/my/assistant');
+
+    // A beta tester who is not a moderator sees the Assistant but NOT Inbox.
+    const betaOnly = visibleAccountNav(false, true).map((i) => i.href);
+    expect(betaOnly).toContain('/my/assistant');
+    expect(betaOnly).not.toContain('/my/inbox');
+  });
+
+  it('shows every section to a moderator who is also a beta tester', () => {
+    const hrefs = visibleAccountNav(true, true).map((i) => i.href);
     expect(hrefs).toContain('/my/inbox');
     expect(hrefs).toContain('/my/assistant');
     expect(hrefs).toHaveLength(accountNav.length);

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -9,8 +9,9 @@
 // HeaderMenu's navLinks).
 export const accountNav = [
   { href: '/my/profile', label: 'Profile' },
-  // Assistant is a restricted rollout — moderators only for now.
-  { href: '/my/assistant', label: 'Assistant', moderatorOnly: true },
+  // The agent is a restricted rollout — beta testers only (a group separate from
+  // the moderator role; see `beta_tester` on the user).
+  { href: '/my/assistant', label: 'Agent', betaOnly: true },
   { href: '/my/tracking', label: 'Tracking' },
   { href: '/my/activity', label: 'Activity' },
   // Mail inbox is a restricted rollout — moderators only (the server 403s others).
@@ -23,10 +24,19 @@ export const accountNav = [
 export type AccountNavItem = (typeof accountNav)[number];
 
 // The sections visible to a caller: a `moderatorOnly` section is hidden unless the
-// caller is a moderator. This is a UI affordance only — the server re-checks the
-// role on every request, so hiding the nav is not the security boundary.
-export function visibleAccountNav(isModerator: boolean): readonly AccountNavItem[] {
-  return accountNav.filter((i) => !('moderatorOnly' in i && i.moderatorOnly) || isModerator);
+// caller is a moderator, and a `betaOnly` section unless the caller is a beta
+// tester (an independent group). This is a UI affordance only — the relevant
+// server surfaces re-check on every request, so hiding the nav is not the
+// security boundary.
+export function visibleAccountNav(
+  isModerator: boolean,
+  isBetaTester: boolean,
+): readonly AccountNavItem[] {
+  return accountNav.filter((i) => {
+    if ('moderatorOnly' in i && i.moderatorOnly) return isModerator;
+    if ('betaOnly' in i && i.betaOnly) return isBetaTester;
+    return true;
+  });
 }
 
 // A section is active when the current path equals its route or is a descendant

--- a/web/src/lib/assistant/api.ts
+++ b/web/src/lib/assistant/api.ts
@@ -1,4 +1,5 @@
 import { env } from '$env/dynamic/public';
+import type { SessionSummary } from './sessions';
 
 // Fetch helpers for the agent backend (`freehire-agent`). Auth is UNIFIED with
 // freehire: the agent verifies the same httpOnly `hire_token` cookie (shared JWT
@@ -35,4 +36,23 @@ export async function createSession(): Promise<string> {
   const body = (await res.json()) as { session_id?: string };
   if (!body?.session_id) throw new Error('session response missing session_id');
   return body.session_id;
+}
+
+/** List the caller's held sessions from the agent backend. The list is
+ *  owner-scoped and newest-first server-side (only the caller's own sessions;
+ *  orphans excluded). */
+export async function listSessions(): Promise<SessionSummary[]> {
+  const res = await fetch(`${BASE}/sessions`, { credentials: 'include' });
+  if (!res.ok) throw new Error(`could not list sessions (${res.status})`);
+  return (await res.json()) as SessionSummary[];
+}
+
+/** Delete one of the caller's sessions by id (204 on success; the backend 404s
+ *  for a session the caller does not own). */
+export async function deleteSession(id: string): Promise<void> {
+  const res = await fetch(`${BASE}/sessions/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`could not delete session (${res.status})`);
 }

--- a/web/src/lib/assistant/sessions.test.ts
+++ b/web/src/lib/assistant/sessions.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import {
+  labelFromMessage,
+  resolveLabel,
+  fromSummary,
+  newestFirst,
+  upsertSession,
+  removeSession,
+  setLabel,
+  activeAfterDelete,
+  type SessionItem,
+  type SessionSummary,
+} from './sessions';
+
+const item = (id: string, createdAt: number, extra: Partial<SessionItem> = {}): SessionItem => ({
+  id,
+  label: id,
+  createdAt,
+  live: false,
+  ...extra,
+});
+
+const summary = (over: Partial<SessionSummary> = {}): SessionSummary => ({
+  session_id: 's1',
+  display_label: null,
+  created_at: 100,
+  live: false,
+  ...over,
+});
+
+describe('labelFromMessage', () => {
+  it('collapses whitespace and trims', () => {
+    expect(labelFromMessage('  hello   there\n world ')).toBe('hello there world');
+  });
+
+  it('truncates long text with an ellipsis', () => {
+    const long = 'a'.repeat(80);
+    const label = labelFromMessage(long);
+    expect(label.length).toBeLessThanOrEqual(60);
+    expect(label.endsWith('…')).toBe(true);
+  });
+
+  it('leaves short text intact', () => {
+    expect(labelFromMessage('short')).toBe('short');
+  });
+});
+
+describe('resolveLabel', () => {
+  it('prefers a derived/cached label over everything', () => {
+    expect(resolveLabel(summary({ display_label: 'backend' }), 'derived', 'fallback')).toBe(
+      'derived',
+    );
+  });
+
+  it('falls back to backend display_label when no cached label', () => {
+    expect(resolveLabel(summary({ display_label: 'backend' }), undefined, 'fallback')).toBe(
+      'backend',
+    );
+  });
+
+  it('uses the fallback when neither cached nor backend label is present', () => {
+    expect(resolveLabel(summary({ display_label: null }), undefined, 'fallback')).toBe('fallback');
+    // blank strings are ignored, not shown as an empty label
+    expect(resolveLabel(summary({ display_label: '  ' }), '  ', 'fallback')).toBe('fallback');
+  });
+});
+
+describe('fromSummary', () => {
+  it('maps a wire row to a session item using resolveLabel', () => {
+    const it = fromSummary(summary({ session_id: 'x', created_at: 42, live: true }), undefined, 'fb');
+    expect(it).toEqual({ id: 'x', label: 'fb', createdAt: 42, live: true });
+  });
+});
+
+describe('newestFirst', () => {
+  it('sorts by createdAt descending without mutating the input', () => {
+    const input = [item('a', 1), item('b', 3), item('c', 2)];
+    const sorted = newestFirst(input);
+    expect(sorted.map((i) => i.id)).toEqual(['b', 'c', 'a']);
+    expect(input.map((i) => i.id)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('upsertSession', () => {
+  it('adds a new session at the top when it is the newest', () => {
+    const items = [item('a', 1), item('b', 2)];
+    const out = upsertSession(items, item('c', 3));
+    expect(out.map((i) => i.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('replaces an existing session by id (no duplicate) and re-sorts', () => {
+    const items = [item('a', 1), item('b', 2)];
+    const out = upsertSession(items, item('a', 5, { label: 'renamed' }));
+    expect(out.map((i) => i.id)).toEqual(['a', 'b']);
+    expect(out.find((i) => i.id === 'a')?.label).toBe('renamed');
+  });
+});
+
+describe('removeSession', () => {
+  it('drops the matching id', () => {
+    expect(removeSession([item('a', 1), item('b', 2)], 'a').map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('is a no-op for an unknown id', () => {
+    expect(removeSession([item('a', 1)], 'zzz').map((i) => i.id)).toEqual(['a']);
+  });
+});
+
+describe('setLabel', () => {
+  it('updates only the targeted session label', () => {
+    const out = setLabel([item('a', 1), item('b', 2)], 'b', 'New');
+    expect(out.find((i) => i.id === 'b')?.label).toBe('New');
+    expect(out.find((i) => i.id === 'a')?.label).toBe('a');
+  });
+});
+
+describe('activeAfterDelete', () => {
+  it('keeps the current active when a non-active session is deleted', () => {
+    const remaining = [item('a', 1), item('b', 2)];
+    expect(activeAfterDelete(remaining, false, 'a')).toBe('a');
+  });
+
+  it('activates the newest remaining when the active session is deleted', () => {
+    const remaining = [item('a', 1), item('b', 3), item('c', 2)];
+    expect(activeAfterDelete(remaining, true, 'deleted')).toBe('b');
+  });
+
+  it('returns null when the last session is deleted', () => {
+    expect(activeAfterDelete([], true, 'deleted')).toBeNull();
+  });
+});

--- a/web/src/lib/assistant/sessions.ts
+++ b/web/src/lib/assistant/sessions.ts
@@ -1,0 +1,94 @@
+// Pure session-list logic for the assistant sidebar: label derivation, ordering,
+// and the add/remove/select reducers. Kept out of the Svelte component so it is
+// unit-testable (vitest) without a DOM — mirroring how `chat.ts` isolates
+// `reduceTurnEvent`. Everything here is pure; localStorage/label caching and the
+// backend fetches live in the component and `api.ts`.
+
+/** One row of the owner-scoped `GET /sessions` response. `project_id`,
+ *  `agent_name`, and `tags` also come over the wire but the sidebar ignores
+ *  them, so they are omitted from this shape. */
+export interface SessionSummary {
+  session_id: string;
+  display_label: string | null;
+  created_at: number;
+  live: boolean;
+}
+
+/** A session as rendered in the sidebar. */
+export interface SessionItem {
+  id: string;
+  label: string;
+  createdAt: number;
+  live: boolean;
+}
+
+const MAX_LABEL = 60;
+
+/** Turn a first user message into a compact one-line sidebar label
+ *  (whitespace collapsed, trimmed, truncated with an ellipsis). */
+export function labelFromMessage(text: string): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  if (oneLine.length <= MAX_LABEL) return oneLine;
+  return oneLine.slice(0, MAX_LABEL - 1).trimEnd() + '…';
+}
+
+/** Resolve a session's display label by priority: a derived/cached label (e.g.
+ *  from the first user message) > the backend `display_label` > the supplied
+ *  timezone-formatted `fallback`. Blank strings are ignored so an empty label is
+ *  never shown. */
+export function resolveLabel(
+  s: SessionSummary,
+  cached: string | undefined,
+  fallback: string,
+): string {
+  if (cached && cached.trim()) return cached;
+  if (s.display_label && s.display_label.trim()) return s.display_label;
+  return fallback;
+}
+
+/** Map a wire row to a `SessionItem`, resolving its label. */
+export function fromSummary(
+  s: SessionSummary,
+  cached: string | undefined,
+  fallback: string,
+): SessionItem {
+  return {
+    id: s.session_id,
+    label: resolveLabel(s, cached, fallback),
+    createdAt: s.created_at,
+    live: s.live,
+  };
+}
+
+/** Newest-first by `createdAt`, without mutating the input. */
+export function newestFirst(items: SessionItem[]): SessionItem[] {
+  return [...items].sort((a, b) => b.createdAt - a.createdAt);
+}
+
+/** Insert or replace a session by id (no duplicates), keeping newest-first order. */
+export function upsertSession(items: SessionItem[], item: SessionItem): SessionItem[] {
+  return newestFirst([item, ...items.filter((i) => i.id !== item.id)]);
+}
+
+/** Drop the session with `id` (no-op if absent). */
+export function removeSession(items: SessionItem[], id: string): SessionItem[] {
+  return items.filter((i) => i.id !== id);
+}
+
+/** Set the label of the session with `id`, leaving the rest untouched. */
+export function setLabel(items: SessionItem[], id: string, label: string): SessionItem[] {
+  return items.map((i) => (i.id === id ? { ...i, label } : i));
+}
+
+/** Which session should be active after a deletion. `remaining` is the list
+ *  AFTER removal. If the deleted session was the active one, activate the newest
+ *  remaining (or `null` if none are left, so the caller can spawn a fresh one);
+ *  otherwise keep `currentActive`. */
+export function activeAfterDelete(
+  remaining: SessionItem[],
+  deletedWasActive: boolean,
+  currentActive: string | null,
+): string | null {
+  if (!deletedWasActive) return currentActive;
+  return newestFirst(remaining)[0]?.id ?? null;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -152,6 +152,9 @@ export interface User {
   // Authorization role ('user' | 'moderator' | 'admin'). A UI affordance only —
   // the server re-checks it on every privileged request.
   role: string;
+  // Beta-tester group membership, independent of `role`. Gates the agent
+  // assistant (/my/assistant) in the UI.
+  beta_tester: boolean;
   created_at: string | null;
 }
 

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -43,9 +43,12 @@
     if (browser) localStorage.setItem('hire.myNavCollapsed', collapsed ? '1' : '0');
   }
 
-  // Moderator-only sections (Inbox) are hidden from the nav for everyone else; the
-  // server enforces the real 403, this just declutters the UI.
-  const navItems = $derived(visibleAccountNav(currentUser()?.role === 'moderator'));
+  // Moderator-only sections (Inbox) and beta-only sections (Agent) are hidden
+  // from the nav for everyone else; the relevant server surfaces enforce the
+  // real gate, this just declutters the UI.
+  const navItems = $derived(
+    visibleAccountNav(currentUser()?.role === 'moderator', currentUser()?.beta_tester ?? false),
+  );
 
   // Icon per section, kept out of the pure accountNav model so that stays
   // Svelte-free and unit-testable. Keyed by the nav hrefs so a new section

--- a/web/src/routes/my/assistant/+page.svelte
+++ b/web/src/routes/my/assistant/+page.svelte
@@ -2,11 +2,30 @@
   import { onMount, tick } from 'svelte';
   import { Marked } from 'marked';
   import DOMPurify from 'isomorphic-dompurify';
-  import { Bot, AlertTriangle, Terminal, ChevronRight, ArrowUp, Loader2, Trash2 } from '@lucide/svelte';
+  import {
+    Bot,
+    AlertTriangle,
+    Terminal,
+    ChevronRight,
+    ArrowUp,
+    Loader2,
+    Trash2,
+    Plus,
+  } from '@lucide/svelte';
   import { currentUser } from '$lib/auth.svelte';
-  import { createSession, assistantWsUrl } from '$lib/assistant/api';
+  import { createSession, listSessions, deleteSession, assistantWsUrl } from '$lib/assistant/api';
   import { RoyClient } from '$lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
+  import {
+    fromSummary,
+    newestFirst,
+    upsertSession,
+    removeSession,
+    setLabel,
+    activeAfterDelete,
+    labelFromMessage,
+    type SessionItem,
+  } from '$lib/assistant/sessions';
   import {
     classifyFamily,
     groupTitle,
@@ -20,22 +39,23 @@
   } from '$lib/assistant/tool-formatters';
   import type { TurnEvent } from '$lib/assistant/wire';
 
-  // The assistant chat. Auth is UNIFIED with freehire: the /my shell already
-  // gates the freehire session, and the agent backend verifies that same
-  // `hire_token` cookie (shared JWT secret) — so there is no separate agent
-  // login. On mount the page spawns a claude session, opens the WebSocket relay
-  // (the browser sends the freehire cookie on the same-origin upgrade), attaches,
-  // and streams frames through the pure `reduceTurnEvent` reducer. Everything
-  // WebSocket-shaped runs client-side (onMount / handlers), so SSR renders only
-  // the empty shell.
+  // The agent chat. Auth is UNIFIED with freehire: the /my shell already gates
+  // the freehire session, and the agent backend verifies that same `hire_token`
+  // cookie (shared JWT secret) — so there is no separate agent login. On mount
+  // the page loads the caller's held sessions (owner-scoped `GET /sessions`),
+  // opens ONE WebSocket relay, and attaches to the newest session with
+  // `from_seq: 0` so its full journal replays through the same pure
+  // `reduceTurnEvent` reducer as live frames. Switching sessions detaches and
+  // re-attaches the one socket; "New chat" spawns a session; delete removes one.
+  // Everything WebSocket-shaped runs client-side, so SSR renders only the shell.
 
   type Phase = 'connecting' | 'ready';
 
-  // Assistant is a moderators-only rollout. The nav hides it for others, but
+  // The agent is a beta-tester-only rollout. The nav hides it for others, but
   // guard the route directly too — the agent backend only checks the freehire
-  // cookie, not the role, so a non-moderator reaching this URL must be stopped
+  // cookie, not the group, so a non-beta user reaching this URL must be stopped
   // here (never connect / spawn a session for them).
-  const isModerator = $derived(currentUser()?.role === 'moderator');
+  const isBeta = $derived(currentUser()?.beta_tester ?? false);
 
   let phase = $state<Phase>('connecting');
   let error = $state<string | null>(null);
@@ -43,12 +63,20 @@
   // prompts a reload, instead of silently accepting sends that can't go out.
   let connectionLost = $state(false);
 
-  // Session/transport (client-only; created in the connect flow).
+  // Transport: one RoyClient per page. `activeId` is the session currently
+  // attached and shown in the chat pane; `frameUnsub` is that session's frame
+  // subscription; `statusUnsubs` are page-lifetime status/error subs.
   let client: RoyClient | null = null;
-  let session = '';
-  let unsubscribers: (() => void)[] = [];
+  let activeId = $state<string | null>(null);
+  let frameUnsub: (() => void) | null = null;
+  let statusUnsubs: (() => void)[] = [];
 
-  // Chat.
+  // Sidebar: the caller's held sessions (newest-first). `switching` disables the
+  // composer and list while a detach→attach is in flight.
+  let sessions = $state<SessionItem[]>([]);
+  let switching = $state(false);
+
+  // Chat (active session).
   let chat = $state<ChatState>(initChat());
   let draft = $state('');
   let turnActive = $state(false);
@@ -72,6 +100,46 @@
   function enqueue(text: string, toFront = false) {
     const item = { id: `q${++queueCounter}`, text };
     queue = toFront ? [item, ...queue] : [...queue, item];
+  }
+
+  // --- Session labels ------------------------------------------------------
+  // The backend has no `display_label` for freehire sessions, so the sidebar
+  // labels a session by its first user message, cached client-side (cosmetic;
+  // the session list itself is backend-backed) so it survives reloads. Until a
+  // session has a message, it shows a timestamp fallback.
+  const LABELS_KEY = 'hire.assistant.labels';
+  let labelCache: Record<string, string> = {};
+
+  function loadLabels() {
+    try {
+      labelCache = JSON.parse(localStorage.getItem(LABELS_KEY) ?? '{}') as Record<string, string>;
+    } catch {
+      labelCache = {};
+    }
+  }
+  function persistLabels() {
+    try {
+      localStorage.setItem(LABELS_KEY, JSON.stringify(labelCache));
+    } catch {
+      // ignore — labels are best-effort cosmetics
+    }
+  }
+  function fallbackLabel(createdAtSec: number): string {
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(createdAtSec * 1000));
+  }
+  // Record a session's first user message as its sidebar label (once).
+  function noteFirstUserMessage(id: string, text: string) {
+    if (labelCache[id]) return;
+    const label = labelFromMessage(text);
+    if (!label) return;
+    labelCache[id] = label;
+    persistLabels();
+    sessions = setLabel(sessions, id, label);
   }
 
   // Auto-grow the composer textarea up to a cap (px), like roy-web's `autosize`.
@@ -141,102 +209,167 @@
     if (scroller) scroller.scrollTop = scroller.scrollHeight;
   }
 
-  // Persist the session id so a page refresh re-attaches to the same daemon
-  // session and replays its journal (the chat history) instead of starting over.
-  // Keyed by freehire user so a different account on the same browser never
-  // adopts the previous user's session (the relay also enforces ownership).
-  const sessionKey = () => `freehire.assistant.session.${currentUser()?.id ?? 'anon'}`;
-  function storeSession(id: string) {
-    try {
-      localStorage.setItem(sessionKey(), id);
-    } catch {
-      /* private mode / storage disabled — history just won't persist */
-    }
-  }
-  function loadStoredSession(): string | null {
-    try {
-      return localStorage.getItem(sessionKey());
-    } catch {
-      return null;
-    }
-  }
-  function clearStoredSession() {
-    try {
-      localStorage.removeItem(sessionKey());
-    } catch {
-      /* ignore */
-    }
-  }
+  // --- Connection + session orchestration ----------------------------------
 
-  async function connect() {
+  async function boot() {
     phase = 'connecting';
     error = null;
     connectionLost = false;
+    loadLabels();
     try {
-      const url = assistantWsUrl();
+      // Load the caller's held sessions (owner-scoped, newest-first). Degrade to
+      // a single fresh session if the backend can't list them.
+      let summaries: Awaited<ReturnType<typeof listSessions>> = [];
+      try {
+        summaries = await listSessions();
+      } catch {
+        error = 'Could not load your chats — starting a new one.';
+      }
+
       client = new RoyClient();
-      // Surface a mid-session disconnect instead of stranding the UI: once we're
-      // live, a socket close/error stops the turn and disables the composer.
-      unsubscribers.push(
+      // Surface a mid-session disconnect instead of stranding the UI.
+      statusUnsubs.push(
         client.onStatus((s) => {
           if ((s === 'closed' || s === 'error') && phase === 'ready') {
             connectionLost = true;
-            error = 'Connection to the assistant was lost. Reload the page to reconnect.';
+            error = 'Connection to the agent was lost. Reload the page to reconnect.';
             endTurn();
           }
         }),
       );
       // A turn that fails with an `error` event (agent crash, tool failure)
       // instead of a terminal `result` would otherwise hang the turn forever.
-      unsubscribers.push(
+      statusUnsubs.push(
         client.onError((e) => {
-          error = `The assistant hit an error: ${e.message}`;
+          error = `The agent hit an error: ${e.message}`;
           endTurn();
         }),
       );
-      await client.connect(url);
+      await client.connect(assistantWsUrl());
 
-      // Re-attach to the previous session (replaying its journal = the history)
-      // when we still have a live, owned one; otherwise start a fresh session.
-      const stored = loadStoredSession();
-      if (!(stored && (await tryAttach(stored)))) {
-        clearStoredSession();
-        chat = initChat();
-        session = await createSession();
-        storeSession(session);
-        unsubscribers.push(client.subscribeFrames(session, (entry) => onFrame(entry.event)));
-        await client.call({ op: 'attach', session }, 'attached');
-      }
+      sessions = newestFirst(
+        summaries.map((s) =>
+          fromSummary(s, labelCache[s.session_id], fallbackLabel(s.created_at)),
+        ),
+      );
+      const newest = sessions[0];
+      if (newest) await openSession(newest.id);
+      else await createAndOpen();
       phase = 'ready';
-      void scrollToBottom();
     } catch (err) {
-      error = err instanceof Error ? err.message : 'Could not reach the assistant backend.';
+      error = err instanceof Error ? err.message : 'Could not reach the agent backend.';
       teardown();
     }
   }
 
-  // Subscribe to frames BEFORE attaching so the journal replay isn't missed,
-  // then attach. Returns false (leaving no subscription) if the stored session
-  // is gone or not ours — the caller then starts a fresh one.
-  async function tryAttach(id: string): Promise<boolean> {
-    if (!client) return false;
-    session = id;
-    const off = client.subscribeFrames(id, (entry) => onFrame(entry.event));
+  // Attach to `id` and replay its journal. Detaches the current session first,
+  // subscribes to frames BEFORE attaching (so the `from_seq: 0` replay frames,
+  // emitted right after `attached`, are captured), and resets the chat so the
+  // replay repaints from scratch.
+  async function openSession(id: string) {
+    if (!client) return;
+    if (activeId === id && frameUnsub) return;
+    switching = true;
     try {
-      await client.call({ op: 'attach', session: id }, 'attached');
-      unsubscribers.push(off);
-      return true;
+      await closeActiveSession();
+      chat = initChat();
+      pendingEcho = null;
+      activeId = id;
+      frameUnsub = client.subscribeFrames(id, (entry) => onFrame(entry.event));
+      await client.call({ op: 'attach', session: id, from_seq: 0 }, 'attached');
+    } finally {
+      switching = false;
+    }
+    void scrollToBottom();
+  }
+
+  // Unwind the current attach: stop its frames, drop any in-flight turn/queue,
+  // release the lease, and detach. Safe when nothing is attached.
+  async function closeActiveSession() {
+    frameUnsub?.();
+    frameUnsub = null;
+    turnActive = false;
+    queue = [];
+    const id = activeId;
+    if (!client || !id) {
+      inputAcquired = false;
+      return;
+    }
+    if (inputAcquired) {
+      inputAcquired = false;
+      void client.call({ op: 'release_input', session: id }, 'input_released').catch(() => {});
+    }
+    await client.call({ op: 'detach', session: id }, 'detached').catch(() => {});
+  }
+
+  // Create a fresh session, add it to the top of the list, and open it.
+  async function createAndOpen() {
+    if (!client) return;
+    const id = await createSession();
+    const nowSec = Math.floor(Date.now() / 1000);
+    sessions = upsertSession(sessions, { id, label: 'New chat', createdAt: nowSec, live: true });
+    await openSession(id);
+  }
+
+  async function newChat() {
+    if (!client || switching || phase !== 'ready') return;
+    error = null;
+    try {
+      await createAndOpen();
+    } catch (err) {
+      error = err instanceof Error ? err.message : 'Could not start a new chat.';
+    }
+  }
+
+  async function selectSession(id: string) {
+    if (!client || switching || id === activeId) return;
+    error = null;
+    try {
+      await openSession(id);
     } catch {
-      off();
-      chat = initChat(); // discard any partial replay before falling back
-      return false;
+      error = 'Could not open that chat.';
+    }
+  }
+
+  async function removeChat(id: string) {
+    if (!client || switching) return;
+    // A chat with a derived label has real history — confirm before deleting.
+    if (labelCache[id] && !confirm('Delete this chat? This cannot be undone.')) return;
+    error = null;
+    const wasActive = id === activeId;
+    try {
+      await deleteSession(id);
+    } catch {
+      error = 'Could not delete the chat.';
+      return;
+    }
+    const remaining = removeSession(sessions, id);
+    sessions = remaining;
+    if (labelCache[id]) {
+      delete labelCache[id];
+      persistLabels();
+    }
+    if (wasActive) {
+      // The session is already closed server-side, so skip the detach (it would
+      // be rejected as not-owned); just stop its frames and open the next one.
+      frameUnsub?.();
+      frameUnsub = null;
+      inputAcquired = false;
+      turnActive = false;
+      queue = [];
+      activeId = null;
+      const next = activeAfterDelete(remaining, true, null);
+      try {
+        if (next) await openSession(next);
+        else await createAndOpen();
+      } catch (err) {
+        error = err instanceof Error ? err.message : 'Could not open a chat.';
+      }
     }
   }
 
   // End the current turn: clear the in-flight flag, then either drain the next
   // queued message (reusing the held lease) or release the lease when idle.
-  // Shared by the terminal `result` frame and abnormal turn-enders (error /
-  // disconnect).
   function endTurn() {
     turnActive = false;
     if (connectionLost) {
@@ -247,9 +380,9 @@
       const [next, ...rest] = queue;
       queue = rest;
       if (next) void dispatch(next.text);
-    } else if (inputAcquired) {
+    } else if (inputAcquired && activeId) {
       inputAcquired = false;
-      void client?.call({ op: 'release_input', session }, 'input_released').catch(() => {});
+      void client?.call({ op: 'release_input', session: activeId }, 'input_released').catch(() => {});
     }
   }
 
@@ -259,6 +392,8 @@
       pendingEcho = null;
       return;
     }
+    // A replayed (or non-echoed) first user message names the session.
+    if (event.type === 'user_prompt' && activeId) noteFirstUserMessage(activeId, event.text);
     chat = reduceTurnEvent(chat, event);
     if (event.type === 'result') endTurn();
     void scrollToBottom();
@@ -269,7 +404,7 @@
   function submit(e: SubmitEvent) {
     e.preventDefault();
     const text = draft.trim();
-    if (!text || !client || phase !== 'ready' || connectionLost) return;
+    if (!text || !client || phase !== 'ready' || connectionLost || switching || !activeId) return;
     draft = '';
     if (turnActive || queue.length > 0) {
       enqueue(text);
@@ -283,26 +418,39 @@
   // fire the prompt. `turnActive` is set synchronously up front so a second
   // submit during the acquire round-trip queues instead of double-dispatching.
   async function dispatch(text: string) {
-    if (!client) return;
+    if (!client || !activeId) return;
+    const id = activeId;
     error = null;
     turnActive = true;
     try {
       if (!inputAcquired) {
-        const acquired = await client.call({ op: 'acquire_input', session }, 'input_acquired');
+        const acquired = await client.call({ op: 'acquire_input', session: id }, 'input_acquired');
+        // The user may have switched sessions during the acquire round-trip (the
+        // list isn't disabled by an in-flight turn). If so, this dispatch belongs
+        // to the now-detached old session: release the lease we just took on it
+        // and abandon — never attribute the lease to, or paint a phantom message
+        // into, the newly-active session.
+        if (activeId !== id) {
+          if (acquired.acquired) {
+            void client.call({ op: 'release_input', session: id }, 'input_released').catch(() => {});
+          }
+          return;
+        }
         if (!acquired.acquired) {
           // Another client (e.g. this chat open in a second tab) holds the
           // lease. Don't silently queue forever — surface it and restore the
           // text so the user can retry, rather than deadlocking the queue.
           turnActive = false;
-          error = 'The assistant is busy (is it open in another tab?). Try again in a moment.';
+          error = 'The agent is busy (is it open in another tab?). Try again in a moment.';
           if (!draft.trim()) draft = text;
           return;
         }
         inputAcquired = true;
       }
       pendingEcho = text;
+      noteFirstUserMessage(id, text);
       chat = reduceTurnEvent(chat, { type: 'user_prompt', text });
-      client.fire({ op: 'send', session, text });
+      client.fire({ op: 'send', session: id, text });
       void scrollToBottom();
     } catch (err) {
       turnActive = false;
@@ -316,31 +464,31 @@
   }
 
   function teardown() {
-    for (const off of unsubscribers) off();
-    unsubscribers = [];
+    frameUnsub?.();
+    frameUnsub = null;
+    for (const off of statusUnsubs) off();
+    statusUnsubs = [];
     client?.close();
     client = null;
   }
 
   onMount(() => {
-    if (!isModerator) return;
-    void connect();
+    if (!isBeta) return;
+    void boot();
     return teardown;
   });
 </script>
 
 <svelte:head>
-  <title>Assistant — freehire</title>
+  <title>Agent — freehire</title>
 </svelte:head>
 
 <div class="mb-6 flex flex-col gap-1">
   <h1 class="flex items-center gap-2 text-2xl font-semibold tracking-tight">
     <Bot class="size-6 text-brand" />
-    Assistant
+    Agent
   </h1>
-  <p class="text-sm text-muted-foreground">
-    Chat with a Claude agent inside freehire.
-  </p>
+  <p class="text-sm text-muted-foreground">Chat with an agent inside freehire.</p>
 </div>
 
 {#if error}
@@ -353,189 +501,269 @@
   </div>
 {/if}
 
-{#if !isModerator}
+{#if !isBeta}
   <div class="rounded-xl border border-border bg-card p-8 text-center text-sm text-muted-foreground">
-    The assistant is a limited rollout and isn't available for your account yet.
+    The agent is a limited beta and isn't available for your account yet.
   </div>
 {:else}
-  <div class="flex h-[calc(100vh-16rem)] min-h-100 flex-col rounded-xl border border-border bg-card">
-    <!-- Message list -->
-    <div bind:this={scroller} class="flex-1 overflow-y-auto p-4">
-      <div class="mx-auto flex max-w-3xl flex-col gap-3">
-        {#if phase === 'connecting'}
-          <p class="text-sm text-muted-foreground">Connecting to the assistant…</p>
-        {:else if chat.messages.length === 0}
-          <p class="text-sm text-muted-foreground">Ask the assistant anything to get started.</p>
-        {/if}
-
-        {#each chat.messages as message, i (i)}
-          {#if message.role === 'user'}
-            <article class="self-end max-w-[80%] rounded-2xl rounded-br-md bg-secondary px-4 py-2.5 text-sm leading-relaxed text-secondary-foreground">
-              <pre class="m-0 whitespace-pre-wrap break-words font-sans">{message.text}</pre>
-            </article>
-          {:else}
-            {@const active = i === chat.messages.length - 1 && message.streaming}
-            {#if message.thinking}
-              <details class="self-start max-w-[88%] text-xs text-muted-foreground" open={active}>
-                <summary class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-muted/50 [&::-webkit-details-marker]:hidden [&::marker]:hidden">
-                  <span
-                    class={[
-                      'font-mono text-[0.85rem] font-semibold',
-                      active ? 'star-glow' : 'text-muted-foreground/60',
-                    ]}
-                  >
-                    {active ? SPINNER_GLYPHS[spinnerIdx] : '✶'}
-                  </span>
-                  <span class={['font-medium', active && 'shimmer']}>Thinking</span>
-                  {#if active}
-                    <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
-                  {/if}
-                </summary>
-                <div class="md mt-1 max-h-56 overflow-y-auto border-l-2 border-border pl-3 py-1 text-muted-foreground">
-                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
-                  {@html renderMarkdown(message.thinking)}
-                </div>
-              </details>
-            {/if}
-
-            {#each groupTools(message.tools) as g, t (t)}
-              {@const title = groupTitle(g.family, g.calls)}
-              {#if !isExpandable(g.family, g.calls)}
-                <div class="self-start flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
-                  <Terminal class="size-4 shrink-0" />
-                  <span>{title}</span>
-                </div>
-              {:else}
-                <details class="self-start max-w-[90%]">
-                  <summary class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground hover:bg-muted/70 [&::-webkit-details-marker]:hidden [&::marker]:hidden [&[open]>span>svg.chev]:rotate-90">
-                    <Terminal class="size-4 shrink-0" />
-                    <span class="flex items-center gap-1.5">
-                      {title}
-                      <ChevronRight class="chev size-3.5 shrink-0 transition-transform" />
-                    </span>
-                  </summary>
-                  {#if g.family === 'bash'}
-                    <div class="mt-2 overflow-hidden rounded-md border border-border bg-background">
-                      <div class="border-b border-border bg-muted/40 px-3 py-1.5 text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground/80">
-                        Shell
-                      </div>
-                      {#each g.calls as c, ci (ci)}
-                        <pre class={['m-0 whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs', ci > 0 && 'border-t border-border']}>$ {bashCommand(c.input) ?? ''}</pre>
-                      {/each}
-                    </div>
-                  {:else if g.family === 'fs'}
-                    <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
-                      {#each g.calls as c, ci (ci)}
-                        <li>{callLine(c)}</li>
-                      {/each}
-                    </ul>
-                  {:else}
-                    <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
-                      {#each g.calls as c, ci (ci)}
-                        <li class="flex flex-wrap items-baseline gap-1.5">
-                          <span class="font-medium text-foreground/80">{c.name}</span>
-                          {#if nonEmptyInput(c.input)}
-                            <code class="rounded bg-muted px-1.5 py-0.5 font-mono">{previewToolInput(c.input)}</code>
-                          {/if}
-                        </li>
-                      {/each}
-                    </ul>
-                  {/if}
-                </details>
-              {/if}
-            {/each}
-
-            {#if message.text}
-              <article class="self-start max-w-[88%] px-1 py-1 text-sm leading-relaxed text-foreground">
-                <div class="md">
-                  <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
-                  {@html renderMarkdown(message.text)}
-                </div>
-              </article>
-            {/if}
-
-            {#if message.errored}
-              <p class="self-start text-xs text-destructive">The assistant ended the turn with an error.</p>
-            {/if}
-          {/if}
+  <div class="flex h-[calc(100vh-16rem)] min-h-100 gap-3">
+    <!-- Sidebar (desktop): session list + New chat -->
+    <aside class="hidden w-60 shrink-0 flex-col rounded-xl border border-border bg-card md:flex">
+      <div class="p-2">
+        <button
+          type="button"
+          onclick={newChat}
+          disabled={switching || phase !== 'ready'}
+          class="flex w-full items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm font-medium transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Plus class="size-4" />
+          New chat
+        </button>
+      </div>
+      <ul class="flex-1 space-y-1 overflow-y-auto px-2 pb-2">
+        {#each sessions as s (s.id)}
+          <li class="group relative">
+            <button
+              type="button"
+              onclick={() => selectSession(s.id)}
+              disabled={switching}
+              class={[
+                'flex w-full items-center rounded-lg py-2 pl-3 pr-9 text-left text-sm transition-colors',
+                s.id === activeId ? 'bg-secondary text-secondary-foreground' : 'hover:bg-muted',
+              ]}
+            >
+              <span class="min-w-0 flex-1 truncate">{s.label}</span>
+            </button>
+            <button
+              type="button"
+              aria-label="Delete chat"
+              title="Delete chat"
+              onclick={() => removeChat(s.id)}
+              class="absolute right-1 top-1/2 flex size-7 -translate-y-1/2 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+            >
+              <Trash2 class="size-4" />
+            </button>
+          </li>
         {/each}
+      </ul>
+    </aside>
 
-        {#if turnActive}
-          <div class="self-start inline-flex items-baseline gap-2 px-2 py-1 text-xs text-muted-foreground">
-            <span class="star-glow font-mono text-[0.85rem] font-semibold">
-              {SPINNER_GLYPHS[spinnerIdx]}
-            </span>
-            <span class="shimmer font-medium">{currentVerb}…</span>
-            <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
-          </div>
+    <!-- Chat pane -->
+    <div class="flex min-w-0 flex-1 flex-col rounded-xl border border-border bg-card">
+      <!-- Mobile session switcher -->
+      <div class="flex items-center gap-2 border-b border-border p-2 md:hidden">
+        <select
+          value={activeId}
+          onchange={(e) => selectSession(e.currentTarget.value)}
+          disabled={switching}
+          aria-label="Select chat"
+          class="min-w-0 flex-1 rounded-lg border border-border bg-background px-2 py-1.5 text-sm"
+        >
+          {#each sessions as s (s.id)}
+            <option value={s.id}>{s.label}</option>
+          {/each}
+        </select>
+        <button
+          type="button"
+          onclick={newChat}
+          disabled={switching || phase !== 'ready'}
+          aria-label="New chat"
+          title="New chat"
+          class="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-muted disabled:opacity-50"
+        >
+          <Plus class="size-4" />
+        </button>
+        {#if activeId}
+          <button
+            type="button"
+            onclick={() => removeChat(activeId as string)}
+            aria-label="Delete chat"
+            title="Delete chat"
+            class="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border text-muted-foreground hover:bg-muted"
+          >
+            <Trash2 class="size-4" />
+          </button>
         {/if}
       </div>
-    </div>
 
-    <!-- Composer -->
-    <div class="border-t border-border p-3">
-      <div class="mx-auto w-full max-w-3xl">
-        {#if queue.length > 0}
-          <!-- Queued messages: sent one-by-one as each turn finishes. -->
-          <div class="mb-2 overflow-hidden rounded-2xl border border-border/60 bg-card">
-            <div class="px-4 py-2 text-xs font-medium text-brand">{queue.length} queued</div>
-            <ul class="divide-y divide-border/40 border-t border-border/40">
-              {#each queue as item (item.id)}
-                <li class="group flex items-start gap-3 px-4 py-2">
-                  <span class="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-foreground">{item.text}</span>
-                  <button
-                    type="button"
-                    aria-label="Remove from queue"
-                    title="Remove"
-                    onclick={() => removeQueued(item.id)}
-                    class="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-60 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
-                  >
-                    <Trash2 class="size-4" />
-                  </button>
-                </li>
-              {/each}
-            </ul>
-          </div>
-        {/if}
+      <!-- Message list -->
+      <div bind:this={scroller} class="flex-1 overflow-y-auto p-4">
+        <div class="mx-auto flex max-w-3xl flex-col gap-3">
+          {#if phase === 'connecting'}
+            <p class="text-sm text-muted-foreground">Connecting to the agent…</p>
+          {:else if chat.messages.length === 0}
+            <p class="text-sm text-muted-foreground">Ask the agent anything to get started.</p>
+          {/if}
 
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-        <form
-          onsubmit={submit}
-          onclick={(e) => {
-            if ((e.target as HTMLElement).closest('button')) return;
-            textareaEl?.focus();
-          }}
-          class="relative flex w-full cursor-text items-end gap-2 rounded-3xl border border-border/60 bg-card px-4 py-2.5 shadow-sm transition-colors focus-within:border-ring/60"
-        >
-          <textarea
-            bind:this={textareaEl}
-            bind:value={draft}
-            rows="1"
-            placeholder="Message the assistant — Enter to send, Shift+Enter for newline"
-            disabled={phase !== 'ready' || connectionLost}
-            onkeydown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                (e.currentTarget.form as HTMLFormElement | null)?.requestSubmit();
-              }
-            }}
-            class="block max-h-[200px] min-h-[1.5rem] flex-1 resize-none cursor-text bg-transparent py-1 text-sm leading-6 text-foreground placeholder:text-muted-foreground/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-          ></textarea>
-          <button
-            type="submit"
-            aria-label={turnActive ? 'Queue message' : 'Send message'}
-            aria-busy={turnActive}
-            disabled={phase !== 'ready' || connectionLost || !draft.trim()}
-            class="flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {#if turnActive}
-              <Loader2 class="size-4 animate-spin" />
+          {#each chat.messages as message, i (i)}
+            {#if message.role === 'user'}
+              <article class="self-end max-w-[80%] rounded-2xl rounded-br-md bg-secondary px-4 py-2.5 text-sm leading-relaxed text-secondary-foreground">
+                <pre class="m-0 whitespace-pre-wrap break-words font-sans">{message.text}</pre>
+              </article>
             {:else}
-              <ArrowUp class="size-4" strokeWidth={2.5} />
+              {@const active = i === chat.messages.length - 1 && message.streaming}
+              {#if message.thinking}
+                <details class="self-start max-w-[88%] text-xs text-muted-foreground" open={active}>
+                  <summary class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 hover:bg-muted/50 [&::-webkit-details-marker]:hidden [&::marker]:hidden">
+                    <span
+                      class={[
+                        'font-mono text-[0.85rem] font-semibold',
+                        active ? 'star-glow' : 'text-muted-foreground/60',
+                      ]}
+                    >
+                      {active ? SPINNER_GLYPHS[spinnerIdx] : '✶'}
+                    </span>
+                    <span class={['font-medium', active && 'shimmer']}>Thinking</span>
+                    {#if active}
+                      <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
+                    {/if}
+                  </summary>
+                  <div class="md mt-1 max-h-56 overflow-y-auto border-l-2 border-border pl-3 py-1 text-muted-foreground">
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
+                    {@html renderMarkdown(message.thinking)}
+                  </div>
+                </details>
+              {/if}
+
+              {#each groupTools(message.tools) as g, t (t)}
+                {@const title = groupTitle(g.family, g.calls)}
+                {#if !isExpandable(g.family, g.calls)}
+                  <div class="self-start flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+                    <Terminal class="size-4 shrink-0" />
+                    <span>{title}</span>
+                  </div>
+                {:else}
+                  <details class="self-start max-w-[90%]">
+                    <summary class="flex cursor-pointer items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground hover:bg-muted/70 [&::-webkit-details-marker]:hidden [&::marker]:hidden [&[open]>span>svg.chev]:rotate-90">
+                      <Terminal class="size-4 shrink-0" />
+                      <span class="flex items-center gap-1.5">
+                        {title}
+                        <ChevronRight class="chev size-3.5 shrink-0 transition-transform" />
+                      </span>
+                    </summary>
+                    {#if g.family === 'bash'}
+                      <div class="mt-2 overflow-hidden rounded-md border border-border bg-background">
+                        <div class="border-b border-border bg-muted/40 px-3 py-1.5 text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground/80">
+                          Shell
+                        </div>
+                        {#each g.calls as c, ci (ci)}
+                          <pre class={['m-0 whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs', ci > 0 && 'border-t border-border']}>$ {bashCommand(c.input) ?? ''}</pre>
+                        {/each}
+                      </div>
+                    {:else if g.family === 'fs'}
+                      <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
+                        {#each g.calls as c, ci (ci)}
+                          <li>{callLine(c)}</li>
+                        {/each}
+                      </ul>
+                    {:else}
+                      <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
+                        {#each g.calls as c, ci (ci)}
+                          <li class="flex flex-wrap items-baseline gap-1.5">
+                            <span class="font-medium text-foreground/80">{c.name}</span>
+                            {#if nonEmptyInput(c.input)}
+                              <code class="rounded bg-muted px-1.5 py-0.5 font-mono">{previewToolInput(c.input)}</code>
+                            {/if}
+                          </li>
+                        {/each}
+                      </ul>
+                    {/if}
+                  </details>
+                {/if}
+              {/each}
+
+              {#if message.text}
+                <article class="self-start max-w-[88%] px-1 py-1 text-sm leading-relaxed text-foreground">
+                  <div class="md">
+                    <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
+                    {@html renderMarkdown(message.text)}
+                  </div>
+                </article>
+              {/if}
+
+              {#if message.errored}
+                <p class="self-start text-xs text-destructive">The agent ended the turn with an error.</p>
+              {/if}
             {/if}
-          </button>
-        </form>
+          {/each}
+
+          {#if turnActive}
+            <div class="self-start inline-flex items-baseline gap-2 px-2 py-1 text-xs text-muted-foreground">
+              <span class="star-glow font-mono text-[0.85rem] font-semibold">
+                {SPINNER_GLYPHS[spinnerIdx]}
+              </span>
+              <span class="shimmer font-medium">{currentVerb}…</span>
+              <span class="font-mono text-[0.7rem] text-muted-foreground/70">({elapsedSec}s)</span>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      <!-- Composer -->
+      <div class="border-t border-border p-3">
+        <div class="mx-auto w-full max-w-3xl">
+          {#if queue.length > 0}
+            <!-- Queued messages: sent one-by-one as each turn finishes. -->
+            <div class="mb-2 overflow-hidden rounded-2xl border border-border/60 bg-card">
+              <div class="px-4 py-2 text-xs font-medium text-brand">{queue.length} queued</div>
+              <ul class="divide-y divide-border/40 border-t border-border/40">
+                {#each queue as item (item.id)}
+                  <li class="group flex items-start gap-3 px-4 py-2">
+                    <span class="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm text-foreground">{item.text}</span>
+                    <button
+                      type="button"
+                      aria-label="Remove from queue"
+                      title="Remove"
+                      onclick={() => removeQueued(item.id)}
+                      class="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-60 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+                    >
+                      <Trash2 class="size-4" />
+                    </button>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+          <form
+            onsubmit={submit}
+            onclick={(e) => {
+              if ((e.target as HTMLElement).closest('button')) return;
+              textareaEl?.focus();
+            }}
+            class="relative flex w-full cursor-text items-end gap-2 rounded-3xl border border-border/60 bg-card px-4 py-2.5 shadow-sm transition-colors focus-within:border-ring/60"
+          >
+            <textarea
+              bind:this={textareaEl}
+              bind:value={draft}
+              rows="1"
+              placeholder="Message the agent — Enter to send, Shift+Enter for newline"
+              disabled={phase !== 'ready' || connectionLost || switching}
+              onkeydown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  (e.currentTarget.form as HTMLFormElement | null)?.requestSubmit();
+                }
+              }}
+              class="block max-h-[200px] min-h-[1.5rem] flex-1 resize-none cursor-text bg-transparent py-1 text-sm leading-6 text-foreground placeholder:text-muted-foreground/70 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            ></textarea>
+            <button
+              type="submit"
+              aria-label={turnActive ? 'Queue message' : 'Send message'}
+              aria-busy={turnActive}
+              disabled={phase !== 'ready' || connectionLost || switching || !draft.trim()}
+              class="flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground text-background transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {#if turnActive}
+                <Loader2 class="size-4 animate-spin" />
+              {:else}
+                <ArrowUp class="size-4" strokeWidth={2.5} />
+              {/if}
+            </button>
+          </form>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adds roy-web-style multi-session management to the in-app agent chat, and gates it behind a new beta-tester group.

## Frontend
- Left **sidebar** of the caller's held sessions; click to **switch** (attach `from_seq:0` → journal replay through the existing `reduceTurnEvent`), **New chat**, per-session **delete**. One WebSocket, one active attach; switching detaches + resets turn/queue/lease before re-attaching. Sidebar labels derive from each chat's first message (cached client-side), timestamp fallback.
- Pure `sessions.ts` (16 vitest cases) + `api.ts` `listSessions`/`deleteSession`.
- Copy: **Assistant → Agent**, dropped "Claude" from the subtitle + nav label.

## Beta-tester group
- `beta_tester` flag on `users` (**migration 0019**), independent of `role`, carried through sqlc → `accounts.User` → `/auth/me`; frontend `User` type + `accountNav` `betaOnly` filter + page guard. Assistant is now **beta-only** (a moderator without the flag no longer sees it). Grant via manual SQL.

## Backend contract (separate repo)
Pairs with **freehire-agent#2** (owner-scoped `GET /sessions` + `DELETE /sessions/{id}`), already merged — **deploy agent.freehire.dev first**.

## Deploy notes
- Apply **migration 0019** to prod manually before deploying hire.
- Grant beta access: `UPDATE users SET beta_tester = true WHERE lower(email) = 'strelov1@gmail.com';`

## Verification
svelte-check 0 errors · eslint clean · vitest 254 · `npm run build` OK · Go build/vet/test OK · freehire-agent 92 tests + clippy. Two adversarial code reviews; both Important findings fixed (backend: daemon-list-error keeps meta; frontend: session-switch-during-acquire lease race). E2E WS flow to be verified on staging post-deploy.

OpenSpec change: `assistant-multi-session`.