### PR TITLE
feat(bairesdev): full talent-site board source + link resolver

### DIFF
--- a/internal/linksource/bairesdev.go
+++ b/internal/linksource/bairesdev.go
@@ -1,0 +1,89 @@
+package linksource
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// bairesdev resolves BairesDev vacancies reached from an apply link
+// (applicants.bairesdev.com/job/<careerId>/<jobId>/apply). BairesDev publishes no crawlable
+// board — its openings listing is login-gated — so it is a link-only source: the sole public
+// surface is a per-job endpoint keyed by the numeric job id. The job id is the stable
+// canonical key (careerId is just the career-site the link came through and is ignored for
+// dedup), and the posting's schema.org JSON-LD comes straight from that endpoint.
+type bairesdev struct {
+	http Client
+}
+
+// NewBairesDev builds the BairesDev link-source adapter.
+func NewBairesDev(c Client) Source { return bairesdev{http: c} }
+
+func (bairesdev) Source() string { return "bairesdev" }
+
+// bairesDevJobPath captures the career-site id and the job id from an apply link path
+// (/job/<careerId>/<jobId> with an optional trailing /apply).
+var bairesDevJobPath = regexp.MustCompile(`^/job/(\d+)/(\d+)(?:/apply)?/?$`)
+
+// Match handles applicants.bairesdev.com/job/<careerId>/<jobId>[/apply] links only.
+func (bairesdev) Match(u *url.URL) bool {
+	return host(u) == "applicants.bairesdev.com" && bairesDevJobPath.MatchString(u.Path)
+}
+
+// bairesDevPosting selects the JobPosting ld+json fields the public endpoint returns.
+type bairesDevPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+}
+
+// Resolve fetches the posting from the public JobPosting endpoint keyed by the job id parsed
+// from the link. The id is numeric and the API URL is built here (the raw link is never
+// followed), so a hijacked link cannot redirect the fetch to another host.
+func (b bairesdev) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	m := bairesDevJobPath.FindStringSubmatch(u.Path)
+	if m == nil {
+		return sources.Job{}, false, nil
+	}
+	careerID, jobID := m[1], m[2]
+
+	var p bairesDevPosting
+	api := "https://applicants.bairesdev.com/api/JobPosting?JobPostingId=" + jobID
+	if err := b.http.GetJSON(ctx, api, &p); err != nil {
+		return sources.Job{}, false, err
+	}
+	if p.Title == "" {
+		return sources.Job{}, false, nil // no live posting under this id — skip
+	}
+
+	// datePosted has no timezone (e.g. "2025-06-02T10:23:21.503"), so RFC3339 rejects it;
+	// fall back to the date alone, keeping the approximate posted_at.
+	posted := sources.ParseRFC3339(p.DatePosted)
+	if posted == nil && len(p.DatePosted) >= 10 {
+		posted = sources.ParseDate(p.DatePosted[:10])
+	}
+	company := p.HiringOrganization.Name
+	if company == "" {
+		company = "BairesDev"
+	}
+	return sources.Job{
+		ExternalID:  jobID,
+		URL:         fmt.Sprintf("https://applicants.bairesdev.com/job/%s/%s/apply", careerID, jobID),
+		Title:       p.Title,
+		Company:     company,
+		Description: sources.SanitizeHTML(p.Description),
+		Remote:      isTelecommute(p.JobLocationType),
+		PostedAt:    posted,
+	}, true, nil
+}

--- a/internal/linksource/bairesdev_test.go
+++ b/internal/linksource/bairesdev_test.go
@@ -1,0 +1,97 @@
+package linksource
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// bairesDevPostingJSON mirrors the public JobPosting bridge response: plain schema.org
+// JSON-LD returned directly (not embedded in HTML), keyed by the numeric job id. The
+// timestamp carries no timezone and the description is untrusted third-party text.
+const bairesDevPostingJSON = `{"@context":"https://schema.org","@type":"JobPosting",` +
+	`"title":"Sales Director (Retail Background) - Remote Work",` +
+	`"description":"<p>Own the deal.</p><script>evil()</script>",` +
+	`"identifier":{"@type":"PropertyValue","name":"Job ID","value":284579},` +
+	`"datePosted":"2025-06-02T10:23:21.503","validThrough":"2026-10-12T12:40:14.313",` +
+	`"jobLocationType":"TELECOMMUTE","employmentType":"FULL_TIME",` +
+	`"hiringOrganization":{"@type":"Organization","name":"BairesDev","sameAs":"https://www.bairesdev.com"}}`
+
+func TestBairesDevResolvesFromApplyLink(t *testing.T) {
+	// A real apply link carries a career-site id, the job id, and tracking query params.
+	const link = "https://applicants.bairesdev.com/job/97/284579/apply?_gl=1*2opsly&lang=en"
+	c := (&fakeClient{}).route("JobPostingId=284579", bairesDevPostingJSON, "")
+
+	job, ok, err := NewBairesDev(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	// External id is the job id alone (career-site id is just the link's entry point), so
+	// the same posting dedups regardless of which career link brought it in.
+	if job.ExternalID != "284579" {
+		t.Errorf("ExternalID = %q, want the bare job id", job.ExternalID)
+	}
+	// The stored URL is the canonical apply link with tracking params stripped.
+	if job.URL != "https://applicants.bairesdev.com/job/97/284579/apply" {
+		t.Errorf("URL = %q, want canonical apply link without tracking", job.URL)
+	}
+	if job.Title != "Sales Director (Retail Background) - Remote Work" {
+		t.Errorf("Title = %q", job.Title)
+	}
+	if job.Company != "BairesDev" {
+		t.Errorf("Company = %q, want BairesDev", job.Company)
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true for TELECOMMUTE")
+	}
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "Own the deal.") {
+		t.Errorf("Description not sanitized: %q", job.Description)
+	}
+	// datePosted has no timezone, so it falls back to the date alone (posted_at is approximate).
+	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2025-06-02 (date-only fallback)", job.PostedAt)
+	}
+}
+
+func TestBairesDevMatch(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"https://applicants.bairesdev.com/job/97/284579/apply", true},
+		{"https://applicants.bairesdev.com/job/111/176816", true}, // no /apply suffix
+		{"https://applicants.bairesdev.com/job/97/284579/apply?lang=en", true},
+		{"https://applicants.bairesdev.com/openings", false},     // listing, not a job
+		{"https://applicants.bairesdev.com/job/97/apply", false}, // missing job id
+		{"https://talent.bairesdev.com/pt/vagas/arquiteto-node-remote", false},
+	}
+	for _, tc := range cases {
+		u, err := url.Parse(tc.raw)
+		if err != nil {
+			t.Fatalf("parse %q: %v", tc.raw, err)
+		}
+		if got := (bairesdev{}).Match(u); got != tc.want {
+			t.Errorf("Match(%q) = %v, want %v", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestBairesDevSkipsWhenPostingGone(t *testing.T) {
+	// The bridge answers 200 with an empty body for a stale/invalid id — a matched link
+	// that is no longer a live vacancy, so skip (ok=false) rather than error.
+	const link = "https://applicants.bairesdev.com/job/97/999999/apply"
+	c := (&fakeClient{}).route("JobPostingId=999999", `{}`, "")
+
+	_, ok, err := NewBairesDev(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if ok {
+		t.Error("ok=true, want skip for a posting no longer live")
+	}
+}

--- a/internal/linksource/registry.go
+++ b/internal/linksource/registry.go
@@ -48,6 +48,7 @@ func All(c Client) []Source {
 		NewAshby(c),
 		NewLever(c),
 		NewWorkable(c),
+		NewBairesDev(c),
 	}
 }
 

--- a/internal/sources/bairesdev.go
+++ b/internal/sources/bairesdev.go
@@ -1,0 +1,160 @@
+package sources
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// bairesdev adapts BairesDev, a Latin-American software-outsourcing company. It has no crawlable
+// ATS board — its applicants portal's openings list is login-gated — but its public talent site
+// (talent.bairesdev.com) embeds the whole open-req list client-side in a Duda job widget's base64
+// config, each row carrying an apply link to applicants.bairesdev.com/job/<career>/<id>. So the
+// crawl reads that single page, dedups the country/city-template rows by the numeric job id (the
+// site lists one posting once per location under a shared id), and hydrates each distinct id from
+// the public per-job endpoint (/api/JobPosting?JobPostingId=<id>) — the same schema.org JSON-LD
+// the linksource adapter reads, giving a clean title, description, date, and remote flag.
+// Single-company (every posting is BairesDev) and boardless, so its config entry is a placeholder.
+type bairesdev struct {
+	http bairesDevHTTP
+}
+
+// bairesDevHTTP is the transport bairesdev needs: the talent site's raw HTML (to read the embedded
+// widget config) plus the JSON per-job endpoint.
+type bairesDevHTTP interface {
+	TextGetter
+	JSONGetter
+}
+
+const (
+	bairesDevListURL   = "https://talent.bairesdev.com/"
+	bairesDevJobAPIURL = "https://applicants.bairesdev.com/api/JobPosting?JobPostingId=%s"
+	bairesDevApplyURL  = "https://applicants.bairesdev.com/job/%s/%s/apply"
+)
+
+// NewBairesDev builds the BairesDev adapter over the given HTTP client.
+func NewBairesDev(c bairesDevHTTP) Source { return bairesdev{http: c} }
+
+func (bairesdev) Provider() string { return "bairesdev" }
+
+// bairesdev has one global talent listing, so its config entry carries no board.
+func (bairesdev) boardless() {}
+
+// bairesDevRef is one distinct posting to hydrate: the career-site id and the job id parsed from a
+// listing row's apply link.
+type bairesDevRef struct{ careerID, jobID string }
+
+// bairesDevWidgetConfig extracts the base64 Duda job-widget config from the talent site HTML.
+var bairesDevWidgetConfig = regexp.MustCompile(`data-widget-config="([A-Za-z0-9+/=]+)"`)
+
+// bairesDevApplyPath captures the career-site id and job id from an apply URL.
+var bairesDevApplyPath = regexp.MustCompile(`/job/(\d+)/(\d+)/apply`)
+
+func (b bairesdev) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	page, err := b.http.GetText(ctx, bairesDevListURL)
+	if err != nil {
+		return nil, fmt.Errorf("bairesdev: fetch talent listing: %w", err)
+	}
+	refs, err := parseBairesDevListing(page)
+	if err != nil {
+		return nil, fmt.Errorf("bairesdev: %w", err)
+	}
+	// The listing carries only the apply id; the clean title, description, date, and remote flag
+	// come from the per-job endpoint, so each ref is hydrated (skipped on a per-job failure so one
+	// bad id never aborts the crawl).
+	return fetchDetails(refs, defaultDetailWorkers, func(r bairesDevRef) (Job, bool) {
+		return b.detail(ctx, r)
+	}), nil
+}
+
+// parseBairesDevListing decodes the talent site's embedded widget config and returns each distinct
+// posting, deduped by job id (the site lists the same posting once per country/city under a shared
+// id, so dedup collapses the location templates to the real openings).
+func parseBairesDevListing(page string) ([]bairesDevRef, error) {
+	m := bairesDevWidgetConfig.FindStringSubmatch(page)
+	if m == nil {
+		return nil, fmt.Errorf("no job widget on talent listing")
+	}
+	raw, err := base64.StdEncoding.DecodeString(m[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode widget config: %w", err)
+	}
+	var cfg struct {
+		JobList []struct {
+			URL string `json:"page_item_url"`
+		} `json:"jobList"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("parse widget config: %w", err)
+	}
+	var refs []bairesDevRef
+	seen := map[string]struct{}{}
+	for _, j := range cfg.JobList {
+		mm := bairesDevApplyPath.FindStringSubmatch(j.URL)
+		if mm == nil {
+			continue
+		}
+		jobID := mm[2]
+		if _, ok := seen[jobID]; ok {
+			continue
+		}
+		seen[jobID] = struct{}{}
+		refs = append(refs, bairesDevRef{careerID: mm[1], jobID: jobID})
+	}
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("no apply links in widget config")
+	}
+	return refs, nil
+}
+
+// bairesDevPosting selects the JobPosting ld+json fields the public endpoint returns.
+type bairesDevPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+}
+
+// detail hydrates one posting from the public JobPosting endpoint. The external id and URL match
+// the linksource adapter exactly, so a job crawled here and one followed from a Telegram link dedup
+// into a single row. ok=false (skip) when the id no longer resolves to a live posting.
+func (b bairesdev) detail(ctx context.Context, r bairesDevRef) (Job, bool) {
+	var p bairesDevPosting
+	if err := b.http.GetJSON(ctx, fmt.Sprintf(bairesDevJobAPIURL, r.jobID), &p); err != nil {
+		return Job{}, false
+	}
+	if strings.TrimSpace(p.Title) == "" {
+		return Job{}, false // no live posting under this id
+	}
+
+	// datePosted has no timezone (e.g. "2025-06-02T10:23:21.503"), so RFC3339 rejects it; fall
+	// back to the date alone, keeping the approximate posted_at.
+	posted := parseRFC3339(p.DatePosted)
+	if posted == nil && len(p.DatePosted) >= 10 {
+		posted = parseDate(p.DatePosted[:10])
+	}
+	company := p.HiringOrganization.Name
+	if company == "" {
+		company = "BairesDev"
+	}
+	mode := ""
+	if strings.EqualFold(p.JobLocationType, "TELECOMMUTE") {
+		mode = "remote"
+	}
+	return Job{
+		ExternalID:  r.jobID,
+		URL:         fmt.Sprintf(bairesDevApplyURL, r.careerID, r.jobID),
+		Title:       p.Title,
+		Company:     company,
+		Description: sanitizeHTML(p.Description),
+		Remote:      mode == "remote",
+		WorkMode:    mode,
+		PostedAt:    posted,
+	}, true
+}

--- a/internal/sources/bairesdev_test.go
+++ b/internal/sources/bairesdev_test.go
@@ -1,0 +1,121 @@
+package sources
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// bairesDevFake routes the two calls the adapter makes: GetText → the talent listing HTML,
+// GetJSON → the per-job endpoint keyed by JobPostingId.
+type bairesDevFake struct {
+	listing string
+	jobs    map[string]string // JobPostingId → JSON-LD body
+}
+
+func (f *bairesDevFake) GetText(context.Context, string) (string, error) {
+	return f.listing, nil
+}
+
+func (f *bairesDevFake) GetJSON(_ context.Context, url string, v any) error {
+	for id, body := range f.jobs {
+		if strings.Contains(url, "JobPostingId="+id) {
+			return json.Unmarshal([]byte(body), v)
+		}
+	}
+	return fmt.Errorf("bairesDevFake: no job for %s", url)
+}
+
+// bairesDevListingHTML wraps a widget config (built from the given apply URLs) in the one attribute
+// the adapter reads.
+func bairesDevListingHTML(applyURLs ...string) string {
+	rows := make([]string, len(applyURLs))
+	for i, u := range applyURLs {
+		rows[i] = fmt.Sprintf(`{"page_item_url":%q}`, u)
+	}
+	cfg := `{"jobList":[` + strings.Join(rows, ",") + `]}`
+	b64 := base64.StdEncoding.EncodeToString([]byte(cfg))
+	return `<div data-widget-config="` + b64 + `"></div>`
+}
+
+func TestBairesDevCrawlsListingDedupsAndHydrates(t *testing.T) {
+	// The same posting 284579 is listed twice (two locations under one id) plus a distinct 176816.
+	fake := &bairesDevFake{
+		listing: bairesDevListingHTML(
+			"https://applicants.bairesdev.com/job/97/284579/apply",
+			"https://applicants.bairesdev.com/job/97/284579/apply",
+			"https://applicants.bairesdev.com/job/111/176816/apply",
+		),
+		jobs: map[string]string{
+			"284579": `{"@type":"JobPosting","title":"Sales Director - Remote Work",` +
+				`"description":"<p>Own it.</p><script>evil()</script>",` +
+				`"datePosted":"2025-06-02T10:23:21.503","jobLocationType":"TELECOMMUTE",` +
+				`"hiringOrganization":{"name":"BairesDev"}}`,
+			"176816": `{"@type":"JobPosting","title":"Node Developer",` +
+				`"description":"Build it.","datePosted":"2022-07-28T00:00:00",` +
+				`"jobLocationType":"TELECOMMUTE","hiringOrganization":{"name":"BairesDev"}}`,
+		},
+	}
+
+	jobs, err := NewBairesDev(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (284579 deduped, 176816)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	sd, ok := byID["284579"]
+	if !ok {
+		t.Fatal("missing job 284579")
+	}
+	if sd.Title != "Sales Director - Remote Work" {
+		t.Errorf("Title = %q", sd.Title)
+	}
+	if sd.Company != "BairesDev" {
+		t.Errorf("Company = %q", sd.Company)
+	}
+	if sd.URL != "https://applicants.bairesdev.com/job/97/284579/apply" {
+		t.Errorf("URL = %q, want canonical apply link (matches linksource identity)", sd.URL)
+	}
+	if !sd.Remote || sd.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote for TELECOMMUTE", sd.Remote, sd.WorkMode)
+	}
+	if strings.Contains(sd.Description, "<script>") || !strings.Contains(sd.Description, "Own it.") {
+		t.Errorf("Description not sanitized: %q", sd.Description)
+	}
+	// datePosted has no timezone → date-only fallback.
+	if sd.PostedAt == nil || !sd.PostedAt.Equal(time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2025-06-02", sd.PostedAt)
+	}
+}
+
+func TestBairesDevSkipsPostingThatNoLongerResolves(t *testing.T) {
+	// The listing references 999999, but the endpoint returns an empty body (id gone) → skipped.
+	fake := &bairesDevFake{
+		listing: bairesDevListingHTML("https://applicants.bairesdev.com/job/97/999999/apply"),
+		jobs:    map[string]string{"999999": `{}`},
+	}
+	jobs, err := NewBairesDev(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (stale id skipped)", len(jobs))
+	}
+}
+
+func TestBairesDevErrorsWhenNoWidget(t *testing.T) {
+	fake := &bairesDevFake{listing: "<html>no widget here</html>"}
+	if _, err := NewBairesDev(fake).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("want error when the talent listing has no job widget")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -282,6 +282,7 @@ func All(c HTTPClient) map[string]Source {
 		NewApple(c),
 		NewLumenalta(c),
 		NewDataArt(c),
+		NewBairesDev(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/sources/bairesdev.yml
+++ b/sources/bairesdev.yml
@@ -1,0 +1,6 @@
+# BairesDev (talent.bairesdev.com), a Latin-American software-outsourcing company. Boardless
+# single-company source: the whole open-req list is embedded in the talent site's Duda job widget,
+# so the entry carries no board, and the crawl hydrates each distinct posting from the public
+# applicants.bairesdev.com/api/JobPosting endpoint. Gets its own cron slot (per-job detail fetch).
+- company: BairesDev
+  provider: bairesdev


### PR DESCRIPTION
## What

Two complementary ways to ingest **BairesDev** openings, both off the one public surface that exists.

### 1. Board source (`internal/sources/bairesdev.go`) — bulk crawl
BairesDev has no crawlable ATS board (its applicants openings list is **login-gated, 401**). But its public talent site `talent.bairesdev.com` embeds the **whole open-req list** client-side in a Duda job widget's base64 config, each row linking to `applicants.bairesdev.com/job/<career>/<id>`.

The adapter:
- reads that **single page**, base64-decodes the widget config;
- **dedups** the country/city-template rows by numeric job id (**600 rows → 171 real openings** — the site lists one posting once per location under a shared id);
- hydrates each distinct id from the public `/api/JobPosting?JobPostingId=<id>` endpoint (schema.org JSON-LD) → clean title, description, **real posted date**, remote flag.

Boardless single-company; `sources/bairesdev.yml` gets its own cron slot.

### 2. LinkSource (`internal/linksource/bairesdev.go`) — Telegram apply links
Resolves an `applicants.bairesdev.com/job/<c>/<id>` link found in a Telegram post via the same `/api/JobPosting` endpoint.

## Identity

Both use `source=bairesdev`, `external_id=<jobId>`, canonical apply URL — so a job crawled from the board and one followed from a Telegram link **dedup into one row**.

## Why not the `/pt/vagas` SEO pages
Those are a frozen 2023 SEO snapshot (all `datePosted` = 2023-02-28, PT/BR-only, no apply links). The talent **home widget** is the live list with fresh per-job dates via the applicants API — that's what this uses.

## Verification
- Board source live: **171 openings, all with real dates** (2025/2023, not the frozen SEO).
- LinkSource live: known + older apply links resolve correctly.
- Unit tests: dedup+hydrate, skip-stale-id, no-widget error (sources); resolve/Match/skip (linksource). Build, vet, gofmt clean.

## Ops
No migration, no new env. New cron slot for `sources/bairesdev.yml` (per-job detail fetch, like getmatch/habr_career).