### PR TITLE
perf(enrich): skip countries/regions ask when dictionary already pinned geo

### DIFF
--- a/cmd/enrich/store.go
+++ b/cmd/enrich/store.go
@@ -63,6 +63,9 @@ func (s *dbStore) Job(ctx context.Context, id int64) (enrich.JobInput, error) {
 		Remote:      j.Remote,
 		Description: j.Description,
 		URL:         j.URL,
+		// The dictionary-derived country/region columns tell the prompt builder to skip
+		// the geo ask when geography is already pinned (see enrich.GeoPinned).
+		GeoPinned: enrich.GeoPinned(j.Countries, j.Regions),
 	}, nil
 }
 

--- a/internal/enrich/langchain.go
+++ b/internal/enrich/langchain.go
@@ -31,7 +31,7 @@ func NewLangChainProvider(c *llm.Client) *LangChainProvider {
 // Enrich asks the model for a structured Enrichment for the job and parses the JSON
 // response. It does not validate the result — the caller validates before persisting.
 func (p *LangChainProvider) Enrich(ctx context.Context, job JobInput) (Enrichment, error) {
-	raw, err := p.client.GenerateJSON(ctx, systemPrompt, userPrompt(job))
+	raw, err := p.client.GenerateJSON(ctx, buildSystemPrompt(!job.GeoPinned), userPrompt(job))
 	if err != nil {
 		return Enrichment{}, fmt.Errorf("enrich: %w", err)
 	}
@@ -53,16 +53,20 @@ func parseEnrichment(raw string) (Enrichment, error) {
 	return e, nil
 }
 
-// systemPrompt instructs the model to emit only stated fields and to draw the
+// buildSystemPrompt instructs the model to emit only stated fields and to draw the
 // SERVED enum values from the controlled vocabularies — the same lists Validate
 // enforces. The dictionary-covered discovery facets (work_mode, regions,
 // seniority, category, employment_type, education_level, english_level) are
 // deliberately relaxed: the prompt invites a novel label when none fits, and Validate
 // does not reject it (it is unserved discovery material), so prompt and validator
 // diverge there on purpose.
-var systemPrompt = buildSystemPrompt()
-
-func buildSystemPrompt() string {
+//
+// askGeo is false when the deterministic dictionary already pinned the job's
+// countries/regions (see GeoPinned): geoFacet then discards the LLM's copy, so asking
+// for it only burns tokens. The geo enum, its own-label exception, its "Other keys"
+// mention, and the geographic-area paragraph are dropped in that case. It stays true
+// when the dictionary left geography unpinned and the LLM fills the bucket.
+func buildSystemPrompt(askGeo bool) string {
 	var b strings.Builder
 	b.WriteString("You read an IT job posting and return ONLY a JSON object.\n")
 	// summary is the one SYNTHESIZED field and must lead: stating it first, and
@@ -83,23 +87,30 @@ func buildSystemPrompt() string {
 	// english_level are deliberately NOT requested: jobview serves them from the
 	// deterministic dictionaries (internal/jobderive), so the LLM's copies were never
 	// served — asking for them only burned output tokens (see enrich-prompt-trim).
-	enum("regions (array)", RegionValues)
+	if askGeo {
+		enum("regions (array)", RegionValues)
+	}
 	enum("relocation", RelocationValues)
 	enum("salary_period", SalaryPeriodValues)
 	enum("domains (array)", DomainValues)
 	enum("company_type", CompanyTypeValues)
 	enum("company_size", CompanySizeValues)
 
-	// Discovery facets: countries/regions are served as a dict-then-LLM hybrid (the
-	// LLM fills the unpinned geographic bucket via jobview.geoFacet), so they are the
-	// sole facets we still let the model coin its own label for. The other enum fields
-	// above stay strict.
-	b.WriteString("\nException for countries and regions: prefer an allowed value above, but if none ")
-	b.WriteString("accurately fits, you MAY return a concise lowercase label of your own. ")
-	b.WriteString("Still omit the key when the posting does not state it.\n")
+	if askGeo {
+		// Discovery facets: countries/regions are served as a dict-then-LLM hybrid (the
+		// LLM fills the unpinned geographic bucket via jobview.geoFacet), so they are the
+		// sole facets we still let the model coin its own label for. The other enum fields
+		// above stay strict.
+		b.WriteString("\nException for countries and regions: prefer an allowed value above, but if none ")
+		b.WriteString("accurately fits, you MAY return a concise lowercase label of your own. ")
+		b.WriteString("Still omit the key when the posting does not state it.\n")
+	}
 
 	b.WriteString("\nOther keys (omit when unstated): ")
-	b.WriteString("visa_sponsorship (boolean), countries (array of ISO 3166-1 alpha-2), ")
+	b.WriteString("visa_sponsorship (boolean), ")
+	if askGeo {
+		b.WriteString("countries (array of ISO 3166-1 alpha-2), ")
+	}
 	b.WriteString("cities (array of strings), timezone_note (string), ")
 	b.WriteString("salary_min (int), salary_max (int), salary_currency (ISO 4217).\n")
 
@@ -110,11 +121,13 @@ func buildSystemPrompt() string {
 	b.WriteString("Round a fractional rate to the nearest whole unit and NEVER strip the ")
 	b.WriteString("decimal point: an hourly \"$26.08\" is 26 (with salary_period=hour), never 2608.\n")
 
-	b.WriteString("\nregions is the job's geographic area, for ANY work mode — a remote role's ")
-	b.WriteString("reach or an onsite/hybrid role's location: ")
-	b.WriteString("use 'global' ONLY when the posting explicitly says the role is open worldwide / ")
-	b.WriteString("anywhere / from any country; otherwise list the region(s) or country code(s) ")
-	b.WriteString("the role covers, from the allowed values. Omit when unstated (unknown is not global).\n")
+	if askGeo {
+		b.WriteString("\nregions is the job's geographic area, for ANY work mode — a remote role's ")
+		b.WriteString("reach or an onsite/hybrid role's location: ")
+		b.WriteString("use 'global' ONLY when the posting explicitly says the role is open worldwide / ")
+		b.WriteString("anywhere / from any country; otherwise list the region(s) or country code(s) ")
+		b.WriteString("the role covers, from the allowed values. Omit when unstated (unknown is not global).\n")
+	}
 	b.WriteString("\nIf the Location field is empty, the URL path may still encode the location ")
 	b.WriteString("(e.g. a city as the first slug segment); read it as a location signal.\n")
 	return b.String()

--- a/internal/enrich/langchain_test.go
+++ b/internal/enrich/langchain_test.go
@@ -25,7 +25,7 @@ func TestUserPromptIncludesURL(t *testing.T) {
 // use, drawn from the same list Validate enforces, so prompt and validator
 // cannot drift.
 func TestSystemPromptIncludesRegionVocabulary(t *testing.T) {
-	p := buildSystemPrompt()
+	p := buildSystemPrompt(true)
 
 	if !strings.Contains(p, "regions") {
 		t.Errorf("prompt must mention regions, got:\n%s", p)
@@ -42,7 +42,7 @@ func TestSystemPromptIncludesRegionVocabulary(t *testing.T) {
 // served and asking for them only burns output tokens. Removing them from the prompt
 // is the whole point of the enrich-prompt-trim change.
 func TestSystemPromptOmitsDictBackedFacets(t *testing.T) {
-	p := buildSystemPrompt()
+	p := buildSystemPrompt(true)
 	for _, f := range []string{
 		"work_mode", "seniority", "category", "skills",
 		"employment_type", "education_level", "english_level",
@@ -60,7 +60,7 @@ func TestSystemPromptOmitsDictBackedFacets(t *testing.T) {
 // own-label allowance (they are the sole remaining discovery facets); the served
 // enums keep the strict "exactly one allowed value" instruction.
 func TestSystemPromptKeepsServedAndHybridFields(t *testing.T) {
-	p := buildSystemPrompt()
+	p := buildSystemPrompt(true)
 	for _, f := range []string{
 		"summary",
 		"salary_min", "salary_max", "salary_currency", "salary_period",
@@ -84,10 +84,62 @@ func TestSystemPromptKeepsServedAndHybridFields(t *testing.T) {
 // never decimal-stripped into an inflated integer (26.08 -> 2608). The guard anchors
 // the weak model on the exact counter-example, so the prompt must carry it verbatim.
 func TestSystemPromptGuardsFractionalHourlySalary(t *testing.T) {
-	p := buildSystemPrompt()
-	for _, want := range []string{"whole", "26.08", "2608"} {
+	for _, askGeo := range []bool{true, false} {
+		p := buildSystemPrompt(askGeo)
+		for _, want := range []string{"whole", "26.08", "2608"} {
+			if !strings.Contains(p, want) {
+				t.Errorf("askGeo=%v: salary guard must mention %q, got:\n%s", askGeo, want, p)
+			}
+		}
+	}
+}
+
+// When the dictionary already pinned the job's geography, the LLM's countries/regions
+// are discarded by geoFacet, so the prompt must not ask for them — dropping the enum,
+// the exception block, the "Other keys" mention, and the geographic-area paragraph.
+func TestSystemPromptOmitsGeoWhenPinned(t *testing.T) {
+	p := buildSystemPrompt(false)
+	for _, absent := range []string{"regions", "countries", "geographic area", "Exception for countries"} {
+		if strings.Contains(p, absent) {
+			t.Errorf("pinned-geo prompt must omit %q, got:\n%s", absent, p)
+		}
+	}
+	// Non-geo fields it is still the source of must remain.
+	for _, want := range []string{"summary", "salary_min", "domains", "company_type"} {
 		if !strings.Contains(p, want) {
-			t.Errorf("salary guard must mention %q, got:\n%s", want, p)
+			t.Errorf("pinned-geo prompt must keep non-geo field %q, got:\n%s", want, p)
+		}
+	}
+}
+
+// When the dictionary left geography unpinned, the LLM fills the bucket, so the
+// prompt must still request countries/regions and explain the regions facet.
+func TestSystemPromptAsksGeoWhenUnpinned(t *testing.T) {
+	p := buildSystemPrompt(true)
+	for _, want := range []string{"regions", "countries", "geographic area"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("unpinned-geo prompt must request %q, got:\n%s", want, p)
+		}
+	}
+}
+
+// GeoPinned mirrors jobview.geoPinned: a country, or a region more specific than the
+// open-anywhere "global" bucket, counts as pinned; nothing, or only "global", does not.
+func TestGeoPinned(t *testing.T) {
+	cases := []struct {
+		name       string
+		countries  []string
+		regions    []string
+		wantPinned bool
+	}{
+		{"country pins", []string{"us"}, nil, true},
+		{"non-global region pins", nil, []string{"eu"}, true},
+		{"only global is unpinned", nil, []string{"global"}, false},
+		{"empty is unpinned", nil, nil, false},
+	}
+	for _, c := range cases {
+		if got := GeoPinned(c.countries, c.regions); got != c.wantPinned {
+			t.Errorf("%s: GeoPinned(%v,%v)=%v, want %v", c.name, c.countries, c.regions, got, c.wantPinned)
 		}
 	}
 }

--- a/internal/enrich/provider.go
+++ b/internal/enrich/provider.go
@@ -23,6 +23,29 @@ type JobInput struct {
 	// the role) in the URL path — e.g. SuccessFactors /job/Limburg-Maschinenfuhrer/
 	// — so it is a location signal even when the structured Location is empty.
 	URL string
+	// GeoPinned is the one derived signal on this otherwise source-shaped input: the
+	// deterministic dictionary already resolved the job's country/region (see
+	// GeoPinned). When true, the prompt drops the countries/regions ask — geoFacet
+	// would discard the LLM's copy anyway — so the model spends no tokens on geography
+	// we already know.
+	GeoPinned bool
+}
+
+// GeoPinned reports whether the deterministic dictionary resolved a concrete place for
+// a job: a country, or a region more specific than the open-anywhere "global" bucket.
+// It mirrors jobview.geoPinned (the read-side hybrid that discards the LLM's geo when
+// the dictionary pinned one); the two layers are independent, so the small predicate is
+// duplicated rather than shared. A pinned job needs no LLM geography in its prompt.
+func GeoPinned(countries, regions []string) bool {
+	if len(countries) > 0 {
+		return true
+	}
+	for _, r := range regions {
+		if r != "global" {
+			return true
+		}
+	}
+	return false
 }
 
 // Provider derives a structured Enrichment for a job by calling an LLM.


### PR DESCRIPTION
## Summary

The enrichment system prompt always asked the LLM for `countries`/`regions`, but `jobview.geoFacet` **discards** the LLM's copy whenever the deterministic dictionary pinned a place (a country, or a region more specific than the open-anywhere `global` bucket). For any job with a resolved location — a large share of the catalogue — that ask only burned input + output tokens.

- The system prompt is now built **per-job**: when `enrich.GeoPinned(countries, regions)` reports the dictionary already resolved the geography, it drops the `regions` enum, the countries/regions own-label exception, the `countries` key, and the geographic-area paragraph.
- **~32% shorter** system prompt for pinned-geo jobs (2170 → 1478 chars). Unpinned jobs are unchanged — the LLM still fills the geographic bucket via the hybrid.
- `enrich.GeoPinned` mirrors `jobview.geoPinned`; the derived flag flows in through `cmd/enrich`'s `dbStore.Job` from the dict-derived `jobs.countries`/`jobs.regions` columns.

## Why no `enrich.Version` bump

Served output is **identical**: for a pinned job, `geoFacet` already discarded the LLM's `countries`/`regions`, and no consumer reads `enrichment.countries/regions` except `geoFacet`. So not asking for them changes nothing observable — this is a pure token optimization that applies to future + backfill enrich calls without re-enriching the catalogue.

## Test Plan

- [x] `go build ./... && go vet ./...` — clean
- [x] `go test ./...` — 0 failures
- [x] New tests: `TestSystemPromptOmitsGeoWhenPinned`, `TestSystemPromptAsksGeoWhenUnpinned`, `TestGeoPinned` (table); salary guard asserted in both branches
- [x] Dumped both variants: pinned drops geo blocks, keeps summary/salary/domains/company_type