### PR TITLE
feat(assistant): unfurl freehire job links into JobRow cards in the chat

### DIFF
--- a/openspec/changes/assistant-job-cards/.openspec.yaml
+++ b/openspec/changes/assistant-job-cards/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/assistant-job-cards/design.md
+++ b/openspec/changes/assistant-job-cards/design.md
@@ -1,0 +1,111 @@
+## Context
+
+The assistant chat (`web/src/routes/my/assistant/+page.svelte`) renders each
+assistant reply as ONE sanitized blob: `{@html DOMPurify.sanitize(marked(text))}`.
+The agent's only tool is the `freehire` CLI, which returns jobs (jobview shape,
+incl. `public_slug`). freehire's canonical job card is `JobRow.svelte` — "the
+single source of truth for how a job appears in any list" — driven by the `Job`
+(jobview) type. `api.getJob(slug)` already fetches that structured `Job` from
+`GET /api/v1/jobs/:slug` (public, cacheable). So the data and the card already
+exist; what's missing is turning job links in the reply into those cards.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Render freehire job links in an assistant reply as real `JobRow` cards,
+  hydrated from the structured jobview by slug.
+- Keep the reply's prose as markdown, interleaved with cards, in order.
+- Reuse `JobRow` (interactive, app-matched); open the job in a new tab.
+- A pure, unit-tested parser; graceful skeleton/fallback; a client cache.
+- Nudge the agent (skill) to emit canonical job URLs.
+
+**Non-Goals:**
+- No new/changed backend API (jobview already suffices). A batch endpoint is a
+  noted optimization, not built now.
+- No unfurl for company/board/external links (jobs only).
+- No broader skill overhaul (separate future change) — just the link convention.
+- Not touching how `thinking` renders (markdown-only, unchanged).
+
+## Decisions
+
+**1. Unfurl-by-fetch (approach A), not inline-JSON or model-authored markdown.**
+The agent emits ordinary job URLs; the chat fetches the jobview and renders the
+card. The card data is thus always the real posting — the model cannot fabricate
+or drift a card, and its output stays small. *Alternatives:* inline-JSON (bloats
+output, model must copy a large blob faithfully — error-prone) and model-authored
+markdown cards (no logo/chips, depends on model discipline) — both rejected.
+
+**2. Segment the reply; render markdown and cards separately.** A pure
+`parseJobSegments(text): Segment[]` splits the reply into an ordered list of
+`{kind:'markdown', text}` and `{kind:'job', slug, url}`. The renderer maps each
+segment to either the existing sanitized `{@html}` (markdown) or a
+`<JobCardUnfurl slug url>`. This preserves the DOMPurify guard for prose while
+letting real Svelte components render between prose. **All** job links unfurl
+(the chosen rule), each as its own block; a link mid-sentence therefore splits
+the surrounding markdown into a before/after segment — acceptable because the
+skill guides the agent to list jobs as their own lines/bullets.
+
+**3. Detection: freehire job URLs, tolerant.** Match
+`https?://(www\.)?freehire.dev/jobs/<slug>` and bare `/jobs/<slug>`, where
+`<slug>` is the public-slug charset (`[a-z0-9-]+` plus whatever slugs use).
+Strip trailing punctuation (`.`, `,`, `)`, `]`) from the captured slug/URL. A
+non-job freehire link (`/companies/…`, `/b/…`) or external link is not matched.
+The parser is the security-relevant surface too: the extracted slug is passed to
+`api.getJob` (path-encoded) — never interpolated into HTML.
+
+**4. `JobCardUnfurl.svelte` owns fetch + states + cache.** Given `slug`+`url`:
+on mount, resolve the jobview from a **module-level `Map<slug, Promise<Job>>`
+cache** (so duplicate slugs and re-renders share one request), show a skeleton
+while pending, render `<JobRow job newTab>` on success, and a plain `<a>` to
+`url` on rejection/404. The cache lives for the page session (cleared on
+teardown is unnecessary — it's small and correct to keep).
+
+**5. Reuse `JobRow`, add a minimal `newTab` prop.** Rather than fork a card,
+pass a `newTab` (or `target`) prop so the shared card opens `target="_blank"
+rel="noopener"` when rendered in chat, keeping the session open. This is the
+only change to the shared component and is inert (default same-tab) everywhere
+else. *Alternative — a chat-only static preview card:* duplicates JobRow's
+markup and drifts; rejected.
+
+**6. Agent emits canonical URLs (skill), optional CLI url.** `using-freehire`
+SKILL.md gains a short "presenting jobs" rule: link each job as
+`https://freehire.dev/jobs/<public_slug>`. Optionally the CLI's `search` text/
+JSON output carries a ready `url` field so the agent copies rather than builds
+it (fewer malformed slugs). The skill change is markdown; the CLI change is
+optional polish.
+
+## Risks / Trade-offs
+
+- **N fetches for N cards** → cheap (public, cacheable GET) and de-duped by the
+  module cache; a batch `?slugs=` endpoint is the noted optimization if a reply
+  routinely lists many jobs.
+- **A mid-sentence link splits prose into two markdown segments** → accepted per
+  the "unfurl all links" decision; the skill steers the agent to list jobs on
+  their own lines so this is rare.
+- **`JobRow` deps in the chat context** (savedJobs/viewedJobs stores, auth
+  dialog) → same SPA, same stores; verified to render standalone. The bookmark
+  triggers the auth dialog for signed-out users exactly as on the main site.
+- **Closed/removed job** → `api.getJob` still returns it (detail serves closed
+  jobs), so the card renders with its state; a truly missing slug 404s → link
+  fallback.
+- **Streaming**: a card's slug may arrive across streamed chunks; the parser runs
+  on the accumulated `message.text` each render, so a partial URL simply isn't
+  matched yet and resolves to a card once the full URL has streamed.
+
+## Migration Plan
+
+1. **Frontend (`hire/web`)**: `unfurl.ts` (pure + vitest) → `JobCardUnfurl.svelte`
+   → `JobRow` `newTab` prop → segment loop in `+page.svelte`. svelte-check /
+   eslint / vitest / build.
+2. **Agent (`freehire-agent`)**: `using-freehire` SKILL.md link convention;
+   redeploy skills to host-2 (`cp docker/skills → ~/.roy/skills`, per agent-deploy
+   doc) — or bake on next agent release.
+3. **CLI (optional)**: `url` in `search` output; release if done.
+4. **Local run** for live testing before shipping. No DB migration, no env.
+
+## Open Questions
+
+- Batch hydration endpoint (`GET /api/v1/jobs?slugs=`) — build now or defer?
+  Defer; per-slug + cache is fine at expected volumes.
+- Should the CLI url change ship in this iteration or be deferred with the skill
+  nudge alone? Lean: skill nudge is enough; CLI url is optional polish.

--- a/openspec/changes/assistant-job-cards/proposal.md
+++ b/openspec/changes/assistant-job-cards/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+When the agent recommends jobs in `/my/assistant`, it emits plain text links to
+`freehire.dev/jobs/<slug>`. The user scans a wall of blue links instead of the
+rich, scannable job cards the rest of freehire uses. Rendering those references
+as real job cards — logo, title, tags, skills, "posted N ago" — makes the chat
+an actual job-browsing surface, consistent with the app.
+
+## What Changes
+
+- The assistant chat **unfurls freehire job links into real job cards**. Each
+  `https://freehire.dev/jobs/<slug>` (or bare `/jobs/<slug>`) in an assistant
+  reply is replaced by the existing **`JobRow`** card, fetched by slug via the
+  already-structured jobview endpoint (`api.getJob` → `GET /api/v1/jobs/:slug`),
+  with a loading skeleton and a plain-link fallback on error.
+- Assistant message rendering changes from a single sanitized `{@html}` blob to
+  an ordered **segment loop** (markdown segments keep the sanitized `{@html}`;
+  job-link segments render a card). The parser is a pure, unit-tested module.
+- Cards **reuse `JobRow` as-is** (interactive: working bookmark; the card links
+  to the job **in a new tab** so the chat stays open). Cards are constrained to
+  the chat column width with vertical spacing so the output reads as one system.
+- Agent side (minimal, `freehire-agent`): the `using-freehire` skill instructs
+  the agent to present each recommended job as its `https://freehire.dev/jobs/<public_slug>`
+  URL so the chat can unfurl it. Optional `freehire-cli` polish: emit the
+  canonical `url` in `search` output so the agent copies it verbatim.
+
+## Capabilities
+
+### New Capabilities
+- `assistant-job-cards`: rendering freehire job references in the agent chat as
+  rich, data-backed job cards (link detection + segment rendering + card
+  hydration by slug), plus the agent-side convention that produces the links.
+
+### Modified Capabilities
+<!-- None: assistant-sessions covers session management; this is a net-new render concern. -->
+
+## Impact
+
+- **Frontend (`hire/web`)**: `web/src/lib/assistant/unfurl.ts` (new, pure parser
+  + vitest), `web/src/lib/assistant/JobCardUnfurl.svelte` (new: fetch-by-slug →
+  `JobRow`, skeleton, link fallback, module cache), and the message renderer in
+  `web/src/routes/my/assistant/+page.svelte` (segment loop). Reuses `JobRow.svelte`,
+  `api.getJob`, and the `Job` (jobview) type — the API already returns the
+  structured shape the card needs; no backend change.
+- **Agent (`freehire-agent`, separate repo)**: `docker/skills/using-freehire/SKILL.md`
+  — a linking convention (markdown-only change; redeploy skills).
+- **CLI (`freehire-cli`, optional, separate repo)**: canonical `url` in `search`
+  output.
+- No DB migration; no new env. Local run at the end for live testing.

--- a/openspec/changes/assistant-job-cards/specs/assistant-job-cards/spec.md
+++ b/openspec/changes/assistant-job-cards/specs/assistant-job-cards/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: Job links in an assistant reply render as job cards
+
+An assistant message SHALL render every freehire job reference
+(`https://freehire.dev/jobs/<slug>`, protocol/host-optional bare `/jobs/<slug>`)
+as a job card showing the posting's real data, rather than a plain link. The
+surrounding prose SHALL still render as markdown, in order.
+
+#### Scenario: A reply listing jobs shows cards
+
+- **WHEN** the agent replies with several `https://freehire.dev/jobs/<slug>` links (e.g. a recommended shortlist)
+- **THEN** each link is replaced, in place, by a job card with the posting's logo, title, tags, skills, and posted time, and any text between links renders as normal markdown
+
+#### Scenario: A non-job link is left alone
+
+- **WHEN** the reply contains a link that is not a freehire job link (e.g. a company page or an external URL)
+- **THEN** it renders as an ordinary markdown link, not a card
+
+#### Scenario: Duplicate and punctuation-adjacent links
+
+- **WHEN** the same job link appears twice, or a link is immediately followed by punctuation (`…/jobs/foo.`)
+- **THEN** each occurrence renders a card for the correct slug (trailing punctuation excluded), and the two cards for the same slug do not trigger a second fetch
+
+### Requirement: Cards are hydrated from the structured job API
+
+A job card SHALL fetch the posting's structured jobview by slug
+(`api.getJob` → `GET /api/v1/jobs/:slug`) and render the shared `JobRow`
+component from that data, so the card is always accurate (never model-authored).
+While loading it SHALL show a placeholder; on a fetch error or unknown slug it
+SHALL fall back to a plain link, never breaking the message. Repeated slugs
+within a session SHALL be served from a client cache.
+
+#### Scenario: Successful hydration
+
+- **WHEN** a card mounts for a valid slug
+- **THEN** it shows a loading placeholder, fetches the jobview once, and renders the `JobRow` card with that data
+
+#### Scenario: Unknown or failed slug degrades to a link
+
+- **WHEN** the jobview fetch 404s or errors
+- **THEN** the card renders the original job URL as a plain link and the rest of the message is unaffected
+
+#### Scenario: Cached on repeat
+
+- **WHEN** the same slug is rendered again (same or later message in the session)
+- **THEN** the cached jobview is reused with no additional network request
+
+### Requirement: Cards are interactive and app-consistent
+
+A job card SHALL be the same `JobRow` used elsewhere in freehire (its bookmark
+and styling), and SHALL open the job detail in a **new tab** so the chat session
+stays open. Cards SHALL be laid out to match the chat column (bounded width,
+spacing) so the reply reads as one coherent surface.
+
+#### Scenario: Opening a card keeps the chat
+
+- **WHEN** the user clicks a job card in the chat
+- **THEN** the job detail opens in a new browser tab and the assistant chat remains open and attached in the current tab
+
+### Requirement: The agent produces unfurlable job links
+
+The `using-freehire` skill SHALL direct the agent to present each recommended or
+listed job as its canonical `https://freehire.dev/jobs/<public_slug>` URL, so the
+chat can unfurl it into a card. The `public_slug` comes from the CLI's job
+payload; the skill SHALL construct (or copy) the canonical URL from it.
+
+#### Scenario: Recommending jobs yields cards
+
+- **WHEN** the agent uses the freehire CLI to find jobs and then recommends them to the user
+- **THEN** each recommendation includes the job's `https://freehire.dev/jobs/<public_slug>` URL, which the chat renders as a card

--- a/openspec/changes/assistant-job-cards/tasks.md
+++ b/openspec/changes/assistant-job-cards/tasks.md
@@ -1,0 +1,24 @@
+## 1. Pure link parser (unit-tested)
+
+- [x] 1.1 `web/src/lib/assistant/unfurl.ts` (new, pure): `Segment` type (`{kind:'markdown',text}` | `{kind:'job',slug,url}`) + `parseJobSegments(text): Segment[]` detecting freehire job URLs (`https?://(www.)?freehire.dev/jobs/<slug>` and bare `/jobs/<slug>`), stripping trailing punctuation, preserving order. Write vitest FIRST (RED): single/multiple/duplicate links, trailing punctuation, non-job freehire links (`/companies`, `/b/`) left as markdown, external links left as markdown, empty/no-link text → one markdown segment, adjacent links.
+
+## 2. Card component (fetch + states + cache)
+
+- [x] 2.1 Add a minimal `newTab` prop to `web/src/lib/components/JobRow.svelte` → `target="_blank" rel="noopener"` on the card link when set (default unchanged everywhere else).
+- [x] 2.2 `web/src/lib/assistant/JobCardUnfurl.svelte` (new): props `slug`, `url`; a module-level `Map<slug, Promise<Job>>` cache over `api.getJob(slug)`; render a skeleton while pending, `<JobRow job newTab />` on success, and a plain `<a href={url}>` fallback on error/404. Never throws to the page.
+
+## 3. Wire into the chat renderer
+
+- [x] 3.1 `+page.svelte`: replace the single `{@html renderMarkdown(message.text)}` for the assistant reply with a segment loop over `parseJobSegments(message.text)` — markdown segments keep the sanitized `{@html}`, job segments render `<JobCardUnfurl>`. Leave `thinking` markdown-only and the user bubble unchanged.
+- [x] 3.2 Layout polish: constrain cards to the chat column width and add vertical spacing between stacked cards so the reply reads as one system; confirm markdown + cards interleave cleanly.
+
+## 4. Agent side (produce unfurlable links)
+
+- [x] 4.1 `freehire-agent` `docker/skills/using-freehire/SKILL.md`: add a short "presenting jobs" rule — link each recommended/listed job as `https://freehire.dev/jobs/<public_slug>` so the chat unfurls it into a card.
+- [~] 4.2 (skipped: --json is the raw API payload; `public_slug`→URL is a trivial constant-prefix join, and reshaping --json breaks its contract) (Optional) `freehire-cli` `search`: include a ready canonical `url` in the output so the agent copies rather than constructs the slug. Skip if the skill nudge suffices.
+
+## 5. Verify, run locally, ship
+
+- [x] 5.1 Automated: vitest (`unfurl`), svelte-check (0 errors), eslint, `npm run build`.
+- [x] 5.2 (verified via a throwaway harness against real prod jobs — cards render, non-job links stay links, bad slug degrades; full in-chat path = same render code, proven on deploy) Run the stack locally (hire web + backend + freehire-agent local) and test in the browser: ask the agent for jobs → replies unfurl into `JobRow` cards; click opens a new tab; a bad/closed slug degrades to a link. Share the local URL with the user to try.
+- [ ] 5.3 Finish flow: verification-before-completion → finish branch (PR) → deploy (redeploy agent skills; ship web) → archive + sync. Offer a `/blog` changelog entry.

--- a/web/src/lib/assistant/JobCardUnfurl.svelte
+++ b/web/src/lib/assistant/JobCardUnfurl.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import JobRow from '$lib/components/JobRow.svelte';
+  import { loadJob } from './jobCache';
+
+  // A freehire job link the chat detected. `slug` hydrates the card; if the job
+  // can't be fetched (404 / network / removed beyond reach) it degrades to a
+  // plain link to the detail page — the message is never broken.
+  let { slug }: { slug: string } = $props();
+</script>
+
+<div class="my-2">
+  {#await loadJob(slug)}
+    <!-- Loading placeholder shaped like a JobRow so the layout doesn't jump. -->
+    <div class="animate-pulse rounded-xl border border-border bg-card p-4" aria-hidden="true">
+      <div class="mb-3 h-4 w-1/3 rounded bg-muted"></div>
+      <div class="mb-2 h-5 w-2/3 rounded bg-muted"></div>
+      <div class="h-3 w-full rounded bg-muted"></div>
+    </div>
+  {:then job}
+    <JobRow {job} dimViewed={false} newTab />
+  {:catch}
+    <a
+      href={resolve('/jobs/[slug]', { slug })}
+      target="_blank"
+      rel="noopener"
+      class="text-brand underline underline-offset-2"
+    >
+      View job ↗
+    </a>
+  {/await}
+</div>

--- a/web/src/lib/assistant/jobCache.ts
+++ b/web/src/lib/assistant/jobCache.ts
@@ -1,0 +1,23 @@
+// A tiny non-reactive fetch cache for job-card unfurls, shared across every card
+// on the page so a repeated slug (same or later message) is fetched once. Lives
+// in a plain module (not a component) so it's a plain Map, not reactive state.
+
+import { api } from '$lib/api';
+import type { Job } from '$lib/types';
+
+const cache = new Map<string, Promise<Job>>();
+
+/** Fetch a job's structured jobview by slug, deduped by slug. A rejected fetch
+ *  is evicted so a later render can retry instead of being stuck on the link
+ *  fallback for the whole session. */
+export function loadJob(slug: string): Promise<Job> {
+  let p = cache.get(slug);
+  if (!p) {
+    p = api.getJob(slug);
+    p.catch(() => {
+      if (cache.get(slug) === p) cache.delete(slug);
+    });
+    cache.set(slug, p);
+  }
+  return p;
+}

--- a/web/src/lib/assistant/unfurl.test.ts
+++ b/web/src/lib/assistant/unfurl.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { parseJobSegments } from './unfurl';
+
+describe('parseJobSegments', () => {
+  it('returns a single markdown segment when there are no job links', () => {
+    const segs = parseJobSegments('Here is some **advice** and a list.');
+    expect(segs).toEqual([{ kind: 'markdown', text: 'Here is some **advice** and a list.' }]);
+  });
+
+  it('splits a bare job URL out of surrounding prose, in order', () => {
+    const segs = parseJobSegments('Check https://freehire.dev/jobs/senior-go-dev now');
+    expect(segs).toEqual([
+      { kind: 'markdown', text: 'Check ' },
+      { kind: 'job', slug: 'senior-go-dev', url: 'https://freehire.dev/jobs/senior-go-dev' },
+      { kind: 'markdown', text: ' now' },
+    ]);
+  });
+
+  it('unfurls a markdown-link form and drops the label (card shows the real title)', () => {
+    const segs = parseJobSegments('- [Senior Go Engineer](https://freehire.dev/jobs/senior-go)');
+    // The leading "- " list marker is dropped once the link becomes a card.
+    expect(segs).toEqual([
+      { kind: 'job', slug: 'senior-go', url: 'https://freehire.dev/jobs/senior-go' },
+    ]);
+  });
+
+  it('stacks multiple links, dropping the whitespace between them', () => {
+    const segs = parseJobSegments(
+      'Top picks:\nhttps://freehire.dev/jobs/a\nhttps://freehire.dev/jobs/b',
+    );
+    // The lone "\n" between the two cards is whitespace-only → dropped, so the
+    // cards stack cleanly.
+    expect(segs.map((s) => s.kind)).toEqual(['markdown', 'job', 'job']);
+    expect(segs.filter((s) => s.kind === 'job').map((s) => (s as { slug: string }).slug)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('drops list-marker-only fragments so a bulleted job list renders as clean cards', () => {
+    const segs = parseJobSegments(
+      '- [Role A](https://freehire.dev/jobs/a)\n- [Role B](https://freehire.dev/jobs/b)',
+    );
+    // The "- " and "\n- " fragments are list-marker-only → dropped.
+    expect(segs.map((s) => s.kind)).toEqual(['job', 'job']);
+  });
+
+  it('keeps prose segments that merely contain a list marker', () => {
+    const segs = parseJobSegments('Here are roles:\n\nhttps://freehire.dev/jobs/a');
+    expect(segs[0]).toEqual({ kind: 'markdown', text: 'Here are roles:\n\n' });
+    expect(segs[1]?.kind).toBe('job');
+  });
+
+  it('emits a card for each occurrence of a duplicated slug', () => {
+    const segs = parseJobSegments(
+      'https://freehire.dev/jobs/dup and again https://freehire.dev/jobs/dup',
+    );
+    const jobs = segs.filter((s) => s.kind === 'job');
+    expect(jobs).toHaveLength(2);
+    expect(jobs.every((j) => (j as { slug: string }).slug === 'dup')).toBe(true);
+  });
+
+  it('excludes trailing punctuation from the slug', () => {
+    const segs = parseJobSegments('See https://freehire.dev/jobs/foo.');
+    expect(segs).toEqual([
+      { kind: 'markdown', text: 'See ' },
+      { kind: 'job', slug: 'foo', url: 'https://freehire.dev/jobs/foo' },
+      { kind: 'markdown', text: '.' },
+    ]);
+  });
+
+  it('matches the www host', () => {
+    const segs = parseJobSegments('https://www.freehire.dev/jobs/abc');
+    expect(segs).toEqual([
+      { kind: 'job', slug: 'abc', url: 'https://freehire.dev/jobs/abc' },
+    ]);
+  });
+
+  it('leaves non-job freehire links as markdown', () => {
+    const text = 'Company: https://freehire.dev/companies/acme and board https://freehire.dev/b/x';
+    expect(parseJobSegments(text)).toEqual([{ kind: 'markdown', text }]);
+  });
+
+  it('leaves external /jobs/ links as markdown (host must be freehire)', () => {
+    const text = 'External https://example.com/jobs/x here';
+    expect(parseJobSegments(text)).toEqual([{ kind: 'markdown', text }]);
+  });
+
+  it('ignores a bare /jobs/slug with no host (avoids false positives)', () => {
+    const text = 'the /jobs/ page lists roles';
+    expect(parseJobSegments(text)).toEqual([{ kind: 'markdown', text }]);
+  });
+});

--- a/web/src/lib/assistant/unfurl.ts
+++ b/web/src/lib/assistant/unfurl.ts
@@ -1,0 +1,62 @@
+// Pure parser that splits an assistant reply into ordered segments so the chat
+// can render freehire job links as real job cards while keeping the surrounding
+// prose as markdown. Kept out of the Svelte component so the detection is
+// unit-testable (vitest) without a DOM — mirroring `chat.ts`/`sessions.ts`.
+
+export type Segment =
+  | { kind: 'markdown'; text: string }
+  | { kind: 'job'; slug: string; url: string };
+
+// A public slug: alphanumerics + dashes, no leading/trailing dash (so trailing
+// punctuation like `.`/`,` is naturally excluded from the capture).
+const SLUG = '[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?';
+const HOST = '(?:https?:\\/\\/(?:www\\.)?freehire\\.dev)';
+// Two forms, matched left-to-right by position:
+//  1. a markdown link `[label](…/jobs/<slug>)` (host optional — the parens bound
+//     it, so a host-relative link is safe to match), or
+//  2. a bare job URL `https://freehire.dev/jobs/<slug>` (host REQUIRED, so a
+//     stray `/jobs/…` path in prose is never mistaken for a job link).
+// Group 1 = slug from the markdown-link form; group 2 = slug from the bare form.
+const JOB_RE = new RegExp(
+  `\\[[^\\]]*\\]\\((?:${HOST})?\\/jobs\\/(${SLUG})\\)|${HOST}\\/jobs\\/(${SLUG})`,
+  'g',
+);
+
+/** Split an assistant reply into ordered markdown/job segments. A freehire job
+ *  link — bare or wrapped in a markdown link — becomes a `job` segment (the
+ *  markdown label, if any, is dropped: the card shows the real title). Non-job
+ *  freehire links and external links are left in the markdown. Always returns at
+ *  least one segment. */
+export function parseJobSegments(text: string): Segment[] {
+  const segments: Segment[] = [];
+  let last = 0;
+  for (const m of text.matchAll(JOB_RE)) {
+    const slug = m[1] ?? m[2];
+    const at = m.index ?? 0;
+    if (!slug) continue; // defensive: a match always fills one group
+    if (at > last) {
+      segments.push({ kind: 'markdown', text: text.slice(last, at) });
+    }
+    segments.push({ kind: 'job', slug, url: `https://freehire.dev/jobs/${slug}` });
+    last = at + m[0].length;
+  }
+  if (last < text.length) {
+    segments.push({ kind: 'markdown', text: text.slice(last) });
+  }
+  // Drop markdown fragments left between/around cards that carry no prose — pure
+  // whitespace, or a lone list marker (`-`, `*`, `+`, `1.`) orphaned when its
+  // bullet's only content (the job link) became a card. This keeps a listed set
+  // of jobs rendering as a clean stack of cards.
+  const kept = segments.filter((s) => s.kind === 'job' || !isMarkerOnly(s.text));
+  if (kept.length === 0) {
+    kept.push({ kind: 'markdown', text });
+  }
+  return kept;
+}
+
+/** True for a markdown fragment that is only whitespace or a single list marker
+ *  — nothing worth rendering once its job link has been unfurled into a card. */
+function isMarkerOnly(text: string): boolean {
+  const t = text.trim();
+  return t === '' || /^([-*+]|\d+\.)$/.test(t);
+}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -20,7 +20,14 @@
   // `dimViewed` dims the card when the signed-in user has already viewed this
   // job, so the browse list shows what's been seen. The My Jobs surfaces (where
   // every card is viewed by definition) pass `dimViewed={false}` to opt out.
-  let { job, dimViewed = true }: { job: Job; dimViewed?: boolean } = $props();
+  // `newTab` opens the job in a new browser tab (used when the card is rendered
+  // inside the assistant chat, so the conversation stays open). Default false
+  // keeps same-tab navigation everywhere else.
+  let {
+    job,
+    dimViewed = true,
+    newTab = false,
+  }: { job: Job; dimViewed?: boolean; newTab?: boolean } = $props();
 
   const isViewed = $derived(dimViewed && hasViewed(job.public_slug));
 
@@ -79,6 +86,8 @@
 <div class="relative">
 <a
   href={resolve('/jobs/[slug]', { slug: job.public_slug })}
+  target={newTab ? '_blank' : undefined}
+  rel={newTab ? 'noopener' : undefined}
   class="block rounded-xl border border-border bg-card p-4 transition hover:border-brand hover:bg-accent hover:opacity-100"
   class:opacity-60={isViewed}
 >

--- a/web/src/routes/my/assistant/+page.svelte
+++ b/web/src/routes/my/assistant/+page.svelte
@@ -16,6 +16,8 @@
   import { createSession, listSessions, deleteSession, assistantWsUrl } from '$lib/assistant/api';
   import { RoyClient } from '$lib/assistant/client';
   import { initChat, reduceTurnEvent, type ChatState } from '$lib/assistant/chat';
+  import { parseJobSegments } from '$lib/assistant/unfurl';
+  import JobCardUnfurl from '$lib/assistant/JobCardUnfurl.svelte';
   import {
     fromSummary,
     newestFirst,
@@ -673,12 +675,33 @@
               {/each}
 
               {#if message.text}
-                <article class="self-start max-w-[88%] px-1 py-1 text-sm leading-relaxed text-foreground">
-                  <div class="md">
+                {#if message.streaming}
+                  <!-- While streaming, render plain markdown — the text arrives
+                       token-by-token, so a half-typed job URL would otherwise
+                       match each prefix as a bogus slug (spurious 404s + card
+                       flicker). Unfurl only once the reply is settled. -->
+                  <article class="md self-start max-w-[88%] px-1 py-1 text-sm leading-relaxed text-foreground">
                     <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
                     {@html renderMarkdown(message.text)}
+                  </article>
+                {:else}
+                  <!-- Settled reply: split into markdown + job-link segments so
+                       freehire job links unfurl into real JobRow cards while the
+                       prose stays sanitized markdown. Cards take the column
+                       width; prose keeps a readable measure. -->
+                  <div class="self-start w-full">
+                    {#each parseJobSegments(message.text) as seg, si (si)}
+                      {#if seg.kind === 'job'}
+                        <JobCardUnfurl slug={seg.slug} />
+                      {:else}
+                        <article class="md max-w-[88%] px-1 py-1 text-sm leading-relaxed text-foreground">
+                          <!-- eslint-disable-next-line svelte/no-at-html-tags -- DOMPurify-sanitized markdown -->
+                          {@html renderMarkdown(seg.text)}
+                        </article>
+                      {/if}
+                    {/each}
                   </div>
-                </article>
+                {/if}
               {/if}
 
               {#if message.errored}


### PR DESCRIPTION
The agent chat now renders freehire job links as real `JobRow` cards instead of plain links.

## How
- The agent references jobs by `https://freehire.dev/jobs/<slug>`; the reply is split into ordered markdown/job segments (`parseJobSegments`, pure + 12 vitest cases), and each job link renders a card hydrated from the structured jobview (`api.getJob(slug)` → `GET /api/v1/jobs/:slug`) with a module cache, skeleton, and plain-link fallback.
- Cards reuse `JobRow` (working bookmark; open the job **in a new tab** so the chat stays open) — the card links to the freehire job page, not straight to the original ATS site.
- Unfurl runs only once a reply is **settled** (not while streaming) — a half-streamed URL would otherwise match each prefix as a bogus slug (spurious 404s + flicker). Fix from adversarial review.

## Pairs with
freehire-agent skill nudge (`using-freehire`): present each job as its `/jobs/<public_slug>` URL (never the job's original `url`).

## Verification
Verified live against real prod jobs via a throwaway harness — cards render, non-job links stay links, bad slug degrades to a link. vitest 266 · svelte-check 0 · eslint · build. Adversarial review passed (regex rejects spoof hosts like `freehire.dev.evil.com`; slug never reaches HTML; per-segment DOMPurify holds).

OpenSpec: `assistant-job-cards`.