### PR TITLE
fix(bairesdev): ingest the full job description, not the teaser

### DIFF
--- a/internal/linksource/bairesdev.go
+++ b/internal/linksource/bairesdev.go
@@ -67,6 +67,12 @@ func (b bairesdev) Resolve(ctx context.Context, raw string) (sources.Job, bool, 
 		return sources.Job{}, false, nil // no live posting under this id — skip
 	}
 
+	// JobPosting carries only a teaser; the full HTML description lives on the apply-flow endpoint.
+	// Fall back to the teaser when it is unavailable so a hiccup degrades the text, not the job.
+	desc := b.fullDescription(ctx, jobID)
+	if desc == "" {
+		desc = p.Description
+	}
 	// datePosted has no timezone (e.g. "2025-06-02T10:23:21.503"), so RFC3339 rejects it;
 	// fall back to the date alone, keeping the approximate posted_at.
 	posted := sources.ParseRFC3339(p.DatePosted)
@@ -82,8 +88,26 @@ func (b bairesdev) Resolve(ctx context.Context, raw string) (sources.Job, bool, 
 		URL:         fmt.Sprintf("https://applicants.bairesdev.com/job/%s/%s/apply", careerID, jobID),
 		Title:       p.Title,
 		Company:     company,
-		Description: sources.SanitizeHTML(p.Description),
+		Description: sources.SanitizeHTML(desc),
 		Remote:      isTelecommute(p.JobLocationType),
 		PostedAt:    posted,
 	}, true, nil
+}
+
+// fullDescription reads the full HTML description from the apply-flow endpoint
+// (jobResults[0].description), or "" when the endpoint fails or carries no result.
+func (b bairesdev) fullDescription(ctx context.Context, jobID string) string {
+	var resp struct {
+		JobResults []struct {
+			Description string `json:"description"`
+		} `json:"jobResults"`
+	}
+	api := "https://applicants.bairesdev.com/api/Job?JobOfferId=" + jobID
+	if err := b.http.GetJSON(ctx, api, &resp); err != nil {
+		return ""
+	}
+	if len(resp.JobResults) == 0 {
+		return ""
+	}
+	return resp.JobResults[0].Description
 }

--- a/internal/linksource/bairesdev_test.go
+++ b/internal/linksource/bairesdev_test.go
@@ -19,10 +19,17 @@ const bairesDevPostingJSON = `{"@context":"https://schema.org","@type":"JobPosti
 	`"jobLocationType":"TELECOMMUTE","employmentType":"FULL_TIME",` +
 	`"hiringOrganization":{"@type":"Organization","name":"BairesDev","sameAs":"https://www.bairesdev.com"}}`
 
+// bairesDevJobJSON is the apply-flow endpoint's payload: the FULL HTML description (the JobPosting
+// block above carries only a teaser).
+const bairesDevJobJSON = `{"jobResults":[{"title":"Sales Director (Retail Background) - Remote Work",` +
+	`"description":"<h3>Own the deal.</h3><p>The full role responsibilities.</p><script>evil()</script>"}]}`
+
 func TestBairesDevResolvesFromApplyLink(t *testing.T) {
 	// A real apply link carries a career-site id, the job id, and tracking query params.
 	const link = "https://applicants.bairesdev.com/job/97/284579/apply?_gl=1*2opsly&lang=en"
-	c := (&fakeClient{}).route("JobPostingId=284579", bairesDevPostingJSON, "")
+	c := (&fakeClient{}).
+		route("JobPostingId=284579", bairesDevPostingJSON, "").
+		route("JobOfferId=284579", bairesDevJobJSON, "")
 
 	job, ok, err := NewBairesDev(c).Resolve(context.Background(), link)
 	if err != nil {
@@ -49,8 +56,9 @@ func TestBairesDevResolvesFromApplyLink(t *testing.T) {
 	if !job.Remote {
 		t.Error("Remote = false, want true for TELECOMMUTE")
 	}
-	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "Own the deal.") {
-		t.Errorf("Description not sanitized: %q", job.Description)
+	// The FULL description (Job endpoint) is used and sanitized, not the JobPosting teaser.
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "The full role responsibilities.") {
+		t.Errorf("Description not the sanitized full text: %q", job.Description)
 	}
 	// datePosted has no timezone, so it falls back to the date alone (posted_at is approximate).
 	if job.PostedAt == nil || !job.PostedAt.Equal(time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)) {

--- a/internal/sources/bairesdev.go
+++ b/internal/sources/bairesdev.go
@@ -30,9 +30,14 @@ type bairesDevHTTP interface {
 }
 
 const (
-	bairesDevListURL   = "https://talent.bairesdev.com/"
-	bairesDevJobAPIURL = "https://applicants.bairesdev.com/api/JobPosting?JobPostingId=%s"
-	bairesDevApplyURL  = "https://applicants.bairesdev.com/job/%s/%s/apply"
+	bairesDevListURL = "https://talent.bairesdev.com/"
+	// bairesDevJobPostingURL is the SEO JSON-LD endpoint: clean title, real posted date, and
+	// remote flag, but only a short teaser description.
+	bairesDevJobPostingURL = "https://applicants.bairesdev.com/api/JobPosting?JobPostingId=%s"
+	// bairesDevJobDetailURL is the apply-flow endpoint: it carries the FULL HTML description
+	// (JobPosting's is truncated to a blurb), but no date/location, so the two are merged.
+	bairesDevJobDetailURL = "https://applicants.bairesdev.com/api/Job?JobOfferId=%s"
+	bairesDevApplyURL     = "https://applicants.bairesdev.com/job/%s/%s/apply"
 )
 
 // NewBairesDev builds the BairesDev adapter over the given HTTP client.
@@ -121,18 +126,26 @@ type bairesDevPosting struct {
 	} `json:"hiringOrganization"`
 }
 
-// detail hydrates one posting from the public JobPosting endpoint. The external id and URL match
-// the linksource adapter exactly, so a job crawled here and one followed from a Telegram link dedup
-// into a single row. ok=false (skip) when the id no longer resolves to a live posting.
+// detail hydrates one posting: the JobPosting endpoint supplies the clean title, real date, and
+// remote flag; the Job endpoint supplies the full description (JobPosting's is truncated). The
+// external id and URL match the linksource adapter exactly, so a job crawled here and one followed
+// from a Telegram link dedup into a single row. ok=false (skip) when the id no longer resolves to a
+// live posting.
 func (b bairesdev) detail(ctx context.Context, r bairesDevRef) (Job, bool) {
 	var p bairesDevPosting
-	if err := b.http.GetJSON(ctx, fmt.Sprintf(bairesDevJobAPIURL, r.jobID), &p); err != nil {
+	if err := b.http.GetJSON(ctx, fmt.Sprintf(bairesDevJobPostingURL, r.jobID), &p); err != nil {
 		return Job{}, false
 	}
 	if strings.TrimSpace(p.Title) == "" {
 		return Job{}, false // no live posting under this id
 	}
 
+	// The full description lives on the apply-flow endpoint; fall back to the JobPosting teaser
+	// when it is unavailable, so a Job-endpoint hiccup degrades the text instead of dropping the job.
+	desc := b.fullDescription(ctx, r.jobID)
+	if desc == "" {
+		desc = p.Description
+	}
 	// datePosted has no timezone (e.g. "2025-06-02T10:23:21.503"), so RFC3339 rejects it; fall
 	// back to the date alone, keeping the approximate posted_at.
 	posted := parseRFC3339(p.DatePosted)
@@ -152,9 +165,26 @@ func (b bairesdev) detail(ctx context.Context, r bairesDevRef) (Job, bool) {
 		URL:         fmt.Sprintf(bairesDevApplyURL, r.careerID, r.jobID),
 		Title:       p.Title,
 		Company:     company,
-		Description: sanitizeHTML(p.Description),
+		Description: sanitizeHTML(desc),
 		Remote:      mode == "remote",
 		WorkMode:    mode,
 		PostedAt:    posted,
 	}, true
+}
+
+// fullDescription reads the full HTML description from the apply-flow endpoint
+// (jobResults[0].description), or "" when the endpoint fails or carries no result.
+func (b bairesdev) fullDescription(ctx context.Context, jobID string) string {
+	var resp struct {
+		JobResults []struct {
+			Description string `json:"description"`
+		} `json:"jobResults"`
+	}
+	if err := b.http.GetJSON(ctx, fmt.Sprintf(bairesDevJobDetailURL, jobID), &resp); err != nil {
+		return ""
+	}
+	if len(resp.JobResults) == 0 {
+		return ""
+	}
+	return resp.JobResults[0].Description
 }

--- a/internal/sources/bairesdev_test.go
+++ b/internal/sources/bairesdev_test.go
@@ -10,11 +10,13 @@ import (
 	"time"
 )
 
-// bairesDevFake routes the two calls the adapter makes: GetText → the talent listing HTML,
-// GetJSON → the per-job endpoint keyed by JobPostingId.
+// bairesDevFake routes the calls the adapter makes: GetText → the talent listing HTML, GetJSON →
+// the JobPosting endpoint (keyed by JobPostingId, for meta) and the Job endpoint (keyed by
+// JobOfferId, for the full description).
 type bairesDevFake struct {
 	listing string
 	jobs    map[string]string // JobPostingId → JSON-LD body
+	details map[string]string // JobOfferId → Job body (full description)
 }
 
 func (f *bairesDevFake) GetText(context.Context, string) (string, error) {
@@ -27,7 +29,12 @@ func (f *bairesDevFake) GetJSON(_ context.Context, url string, v any) error {
 			return json.Unmarshal([]byte(body), v)
 		}
 	}
-	return fmt.Errorf("bairesDevFake: no job for %s", url)
+	for id, body := range f.details {
+		if strings.Contains(url, "JobOfferId="+id) {
+			return json.Unmarshal([]byte(body), v)
+		}
+	}
+	return fmt.Errorf("bairesDevFake: no route for %s", url)
 }
 
 // bairesDevListingHTML wraps a widget config (built from the given apply URLs) in the one attribute
@@ -52,12 +59,17 @@ func TestBairesDevCrawlsListingDedupsAndHydrates(t *testing.T) {
 		),
 		jobs: map[string]string{
 			"284579": `{"@type":"JobPosting","title":"Sales Director - Remote Work",` +
-				`"description":"<p>Own it.</p><script>evil()</script>",` +
-				`"datePosted":"2025-06-02T10:23:21.503","jobLocationType":"TELECOMMUTE",` +
-				`"hiringOrganization":{"name":"BairesDev"}}`,
+				`"description":"Short teaser.","datePosted":"2025-06-02T10:23:21.503",` +
+				`"jobLocationType":"TELECOMMUTE","hiringOrganization":{"name":"BairesDev"}}`,
 			"176816": `{"@type":"JobPosting","title":"Node Developer",` +
 				`"description":"Build it.","datePosted":"2022-07-28T00:00:00",` +
 				`"jobLocationType":"TELECOMMUTE","hiringOrganization":{"name":"BairesDev"}}`,
+		},
+		// The Job endpoint carries the full HTML description (JobPosting's is a teaser). 284579 has
+		// one; 176816 does not (so it falls back to the teaser).
+		details: map[string]string{
+			"284579": `{"jobResults":[{"description":"<h3>Own it.</h3><p>The full role text.</p>` +
+				`<script>evil()</script>"}]}`,
 		},
 	}
 
@@ -89,8 +101,16 @@ func TestBairesDevCrawlsListingDedupsAndHydrates(t *testing.T) {
 	if !sd.Remote || sd.WorkMode != "remote" {
 		t.Errorf("Remote=%v WorkMode=%q, want remote for TELECOMMUTE", sd.Remote, sd.WorkMode)
 	}
-	if strings.Contains(sd.Description, "<script>") || !strings.Contains(sd.Description, "Own it.") {
-		t.Errorf("Description not sanitized: %q", sd.Description)
+	// The FULL description (Job endpoint) is used and sanitized, not the JobPosting teaser.
+	if strings.Contains(sd.Description, "<script>") || !strings.Contains(sd.Description, "The full role text.") {
+		t.Errorf("Description not the sanitized full text: %q", sd.Description)
+	}
+	if strings.Contains(sd.Description, "Short teaser.") {
+		t.Errorf("Description used the JobPosting teaser instead of the full Job text: %q", sd.Description)
+	}
+	// 176816 has no Job-endpoint detail → falls back to its JobPosting teaser.
+	if nd := byID["176816"]; !strings.Contains(nd.Description, "Build it.") {
+		t.Errorf("176816 Description = %q, want teaser fallback", nd.Description)
 	}
 	// datePosted has no timezone → date-only fallback.
 	if sd.PostedAt == nil || !sd.PostedAt.Equal(time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)) {


### PR DESCRIPTION
## Problem
The board source and linksource hydrated each posting from `/api/JobPosting?JobPostingId=<id>`, whose `description` is a **~600-char teaser** (it's the SEO JSON-LD block). The real posting text is much longer.

## Fix
Fetch the full HTML description from the apply-flow endpoint `/api/Job?JobOfferId=<id>` (`jobResults[0].description`, ~2.5–5.8k chars), keeping `JobPosting` for the clean title / real posted date / remote flag. Falls back to the teaser if the Job endpoint is unavailable (degrade text, never drop the job). Applied to both `internal/sources/bairesdev.go` and `internal/linksource/bairesdev.go`.

## Verification
Live crawl: **median description 2850 chars** (min 2496 / max 5818), vs ~600 before. Example job 296929 → 3767 chars. Unit tests updated to assert the full text is used and the teaser fallback works.