### PR TITLE
fix(bairesdev): capture per-job location (region facet)

### DIFF
--- a/internal/sources/bairesdev.go
+++ b/internal/sources/bairesdev.go
@@ -49,8 +49,16 @@ func (bairesdev) Provider() string { return "bairesdev" }
 func (bairesdev) boardless() {}
 
 // bairesDevRef is one distinct posting to hydrate: the career-site id and the job id parsed from a
-// listing row's apply link.
-type bairesDevRef struct{ careerID, jobID string }
+// listing row's apply link, plus the locations aggregated from every row that shares this job id
+// (the site lists the same posting once per location, so the union is where the role is open —
+// e.g. "Brazil, Colombia, Mexico, Latin America" for a LatAm role, "United States" for a US one).
+// The applicants JobPosting endpoint's applicantLocationRequirements is a generic 45-country
+// boilerplate identical across all postings, so the listing rows are the only per-job geography.
+type bairesDevRef struct {
+	careerID string
+	jobID    string
+	location string
+}
 
 // bairesDevWidgetConfig extracts the base64 Duda job-widget config from the talent site HTML.
 var bairesDevWidgetConfig = regexp.MustCompile(`data-widget-config="([A-Za-z0-9+/=]+)"`)
@@ -89,30 +97,61 @@ func parseBairesDevListing(page string) ([]bairesDevRef, error) {
 	}
 	var cfg struct {
 		JobList []struct {
-			URL string `json:"page_item_url"`
+			URL   string `json:"page_item_url"`
+			Title string `json:"jobTitle"`
 		} `json:"jobList"`
 	}
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return nil, fmt.Errorf("parse widget config: %w", err)
 	}
-	var refs []bairesDevRef
-	seen := map[string]struct{}{}
+	// Aggregate by job id: the same posting appears once per location, so union the location tails
+	// of every row sharing an id (insertion order, deduped) into the ref's location.
+	byJob := map[string]*bairesDevRef{}
+	var order []string
 	for _, j := range cfg.JobList {
 		mm := bairesDevApplyPath.FindStringSubmatch(j.URL)
 		if mm == nil {
 			continue
 		}
-		jobID := mm[2]
-		if _, ok := seen[jobID]; ok {
-			continue
+		careerID, jobID := mm[1], mm[2]
+		ref, ok := byJob[jobID]
+		if !ok {
+			ref = &bairesDevRef{careerID: careerID, jobID: jobID}
+			byJob[jobID] = ref
+			order = append(order, jobID)
 		}
-		seen[jobID] = struct{}{}
-		refs = append(refs, bairesDevRef{careerID: mm[1], jobID: jobID})
+		if loc := bairesDevTitleLocation(j.Title); loc != "" && !strings.Contains(ref.location, loc) {
+			if ref.location == "" {
+				ref.location = loc
+			} else {
+				ref.location += ", " + loc
+			}
+		}
 	}
-	if len(refs) == 0 {
+	if len(order) == 0 {
 		return nil, fmt.Errorf("no apply links in widget config")
 	}
+	refs := make([]bairesDevRef, 0, len(order))
+	for _, jobID := range order {
+		refs = append(refs, *byJob[jobID])
+	}
 	return refs, nil
+}
+
+// bairesDevTitleLocation returns the location tail of a widget row title
+// ("Python Developer | Remote Work | Brazil" → "Brazil"), or "" when the title carries no location
+// segment. The listing embeds the per-variant location only in the title (the JobPosting title is
+// location-stripped), so this is the sole per-job geography.
+func bairesDevTitleLocation(title string) string {
+	parts := strings.Split(title, "|")
+	if len(parts) < 3 {
+		return "" // not the "role | Remote Work | location" shape
+	}
+	loc := strings.TrimSpace(parts[len(parts)-1])
+	if strings.EqualFold(loc, "Remote Work") {
+		return ""
+	}
+	return loc
 }
 
 // bairesDevPosting selects the JobPosting ld+json fields the public endpoint returns.
@@ -165,6 +204,7 @@ func (b bairesdev) detail(ctx context.Context, r bairesDevRef) (Job, bool) {
 		URL:         fmt.Sprintf(bairesDevApplyURL, r.careerID, r.jobID),
 		Title:       p.Title,
 		Company:     company,
+		Location:    r.location,
 		Description: sanitizeHTML(desc),
 		Remote:      mode == "remote",
 		WorkMode:    mode,

--- a/internal/sources/bairesdev_test.go
+++ b/internal/sources/bairesdev_test.go
@@ -37,14 +37,14 @@ func (f *bairesDevFake) GetJSON(_ context.Context, url string, v any) error {
 	return fmt.Errorf("bairesDevFake: no route for %s", url)
 }
 
-// bairesDevListingHTML wraps a widget config (built from the given apply URLs) in the one attribute
-// the adapter reads.
-func bairesDevListingHTML(applyURLs ...string) string {
-	rows := make([]string, len(applyURLs))
-	for i, u := range applyURLs {
-		rows[i] = fmt.Sprintf(`{"page_item_url":%q}`, u)
+// bairesDevListingHTML wraps a widget config (built from the given {applyURL, jobTitle} rows) in the
+// one attribute the adapter reads. The title tail carries the row's location.
+func bairesDevListingHTML(rows ...[2]string) string {
+	items := make([]string, len(rows))
+	for i, r := range rows {
+		items[i] = fmt.Sprintf(`{"page_item_url":%q,"jobTitle":%q}`, r[0], r[1])
 	}
-	cfg := `{"jobList":[` + strings.Join(rows, ",") + `]}`
+	cfg := `{"jobList":[` + strings.Join(items, ",") + `]}`
 	b64 := base64.StdEncoding.EncodeToString([]byte(cfg))
 	return `<div data-widget-config="` + b64 + `"></div>`
 }
@@ -53,9 +53,9 @@ func TestBairesDevCrawlsListingDedupsAndHydrates(t *testing.T) {
 	// The same posting 284579 is listed twice (two locations under one id) plus a distinct 176816.
 	fake := &bairesDevFake{
 		listing: bairesDevListingHTML(
-			"https://applicants.bairesdev.com/job/97/284579/apply",
-			"https://applicants.bairesdev.com/job/97/284579/apply",
-			"https://applicants.bairesdev.com/job/111/176816/apply",
+			[2]string{"https://applicants.bairesdev.com/job/97/284579/apply", "Sales Director | Remote Work | New York, United States"},
+			[2]string{"https://applicants.bairesdev.com/job/97/284579/apply", "Sales Director | Remote Work | Brazil"},
+			[2]string{"https://applicants.bairesdev.com/job/111/176816/apply", "Node Developer | Remote Work | Colombia"},
 		),
 		jobs: map[string]string{
 			"284579": `{"@type":"JobPosting","title":"Sales Director - Remote Work",` +
@@ -98,6 +98,10 @@ func TestBairesDevCrawlsListingDedupsAndHydrates(t *testing.T) {
 	if sd.URL != "https://applicants.bairesdev.com/job/97/284579/apply" {
 		t.Errorf("URL = %q, want canonical apply link (matches linksource identity)", sd.URL)
 	}
+	// Location unions the distinct location tails of every row sharing the id (insertion order).
+	if sd.Location != "New York, United States, Brazil" {
+		t.Errorf("Location = %q, want the two rows' locations unioned", sd.Location)
+	}
 	if !sd.Remote || sd.WorkMode != "remote" {
 		t.Errorf("Remote=%v WorkMode=%q, want remote for TELECOMMUTE", sd.Remote, sd.WorkMode)
 	}
@@ -121,7 +125,7 @@ func TestBairesDevCrawlsListingDedupsAndHydrates(t *testing.T) {
 func TestBairesDevSkipsPostingThatNoLongerResolves(t *testing.T) {
 	// The listing references 999999, but the endpoint returns an empty body (id gone) → skipped.
 	fake := &bairesDevFake{
-		listing: bairesDevListingHTML("https://applicants.bairesdev.com/job/97/999999/apply"),
+		listing: bairesDevListingHTML([2]string{"https://applicants.bairesdev.com/job/97/999999/apply", "Ghost | Remote Work | Brazil"}),
 		jobs:    map[string]string{"999999": `{}`},
 	}
 	jobs, err := NewBairesDev(fake).Fetch(context.Background(), CompanyEntry{})


### PR DESCRIPTION
## Problem
BairesDev jobs had an **empty location** → no country/region facet. BairesDev is **not LatAm-only** (US sales, LatAm dev, EU engineering), so this dropped real geography.

## Why the obvious source doesn't work
The JobPosting endpoint's `applicantLocationRequirements` is a **generic 45-country LatAm/Caribbean boilerplate, identical for every posting** (even the US "New York" sales roles) — it's "where BairesDev hires from", not the job's location.

## Fix
The real per-job location lives in the talent-widget row titles (`<role> | Remote Work | <location>`) — the site lists a posting once per location under a shared job id. The parser now **unions those location tails per job id** into `Job.Location`.

Verified live — the geo dictionary resolves them correctly:
- Sales Director → `us` / `north_america`
- Python/dev → `br co mx` / `latam`
- Senior Rust → `eu`

**171/171 jobs now carry a location.** Board source only (the linksource single-link path has no listing to aggregate; enrichment infers its geo from the description).