### PR TITLE
feat(web): public /open transparency page + live member-growth endpoint

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -491,6 +491,15 @@ type Querier interface {
 	// Every board currently failing or cooled down, worst first — the operator's
 	// "what's broken" query and the source of the per-run summary log.
 	ListUnhealthyBoards(ctx context.Context) ([]ListUnhealthyBoardsRow, error)
+	// Dense cumulative member-growth series: one UTC calendar day per row from the
+	// first registration through today, each carrying the running total of members
+	// registered on or before that day. A daily generate_series builds the gap-free
+	// calendar (days with no new signups repeat the previous total), the LEFT JOIN
+	// attaches each day's new-signup count, and the window SUM makes it cumulative, so
+	// the series is monotonically non-decreasing. Aggregate only — no user identifier,
+	// email, or other personal field is selected. With no members the series is empty
+	// (min(day) is NULL, so generate_series yields no rows).
+	ListUserGrowth(ctx context.Context) ([]ListUserGrowthRow, error)
 	// Every job the caller has analyzed, newest first, joined to the job for display. Powers
 	// the Tracking → AI fit tab. Includes closed jobs (surfaced with a badge). The stored
 	// staleness stamps ride along so the handler can flag rows whose CV/job/model has since

--- a/internal/db/queries/stats.sql
+++ b/internal/db/queries/stats.sql
@@ -29,6 +29,31 @@ FULL OUTER JOIN (
     GROUP BY 1
 ) r ON a.day = r.day;
 
+-- name: ListUserGrowth :many
+-- Dense cumulative member-growth series: one UTC calendar day per row from the
+-- first registration through today, each carrying the running total of members
+-- registered on or before that day. A daily generate_series builds the gap-free
+-- calendar (days with no new signups repeat the previous total), the LEFT JOIN
+-- attaches each day's new-signup count, and the window SUM makes it cumulative, so
+-- the series is monotonically non-decreasing. Aggregate only — no user identifier,
+-- email, or other personal field is selected. With no members the series is empty
+-- (min(day) is NULL, so generate_series yields no rows).
+WITH daily AS (
+    SELECT (created_at AT TIME ZONE 'UTC')::date AS day, count(*) AS n
+    FROM users
+    GROUP BY 1
+)
+SELECT
+    d::date AS day,
+    sum(COALESCE(daily.n, 0)) OVER (ORDER BY d)::int AS total
+FROM generate_series(
+    (SELECT min(day) FROM daily),
+    (now() AT TIME ZONE 'UTC')::date,
+    interval '1 day'
+) AS d
+LEFT JOIN daily ON daily.day = d::date
+ORDER BY d;
+
 -- name: ListJobActivity :many
 -- Dense activity series over [from, to] at the given granularity. A daily
 -- generate_series builds the gap-free calendar; the LEFT JOIN fills each day's

--- a/internal/db/stats.sql.go
+++ b/internal/db/stats.sql.go
@@ -72,6 +72,57 @@ func (q *Queries) ListJobActivity(ctx context.Context, arg ListJobActivityParams
 	return items, nil
 }
 
+const listUserGrowth = `-- name: ListUserGrowth :many
+WITH daily AS (
+    SELECT (created_at AT TIME ZONE 'UTC')::date AS day, count(*) AS n
+    FROM users
+    GROUP BY 1
+)
+SELECT
+    d::date AS day,
+    sum(COALESCE(daily.n, 0)) OVER (ORDER BY d)::int AS total
+FROM generate_series(
+    (SELECT min(day) FROM daily),
+    (now() AT TIME ZONE 'UTC')::date,
+    interval '1 day'
+) AS d
+LEFT JOIN daily ON daily.day = d::date
+ORDER BY d
+`
+
+type ListUserGrowthRow struct {
+	Day   pgtype.Date `json:"day"`
+	Total int32       `json:"total"`
+}
+
+// Dense cumulative member-growth series: one UTC calendar day per row from the
+// first registration through today, each carrying the running total of members
+// registered on or before that day. A daily generate_series builds the gap-free
+// calendar (days with no new signups repeat the previous total), the LEFT JOIN
+// attaches each day's new-signup count, and the window SUM makes it cumulative, so
+// the series is monotonically non-decreasing. Aggregate only — no user identifier,
+// email, or other personal field is selected. With no members the series is empty
+// (min(day) is NULL, so generate_series yields no rows).
+func (q *Queries) ListUserGrowth(ctx context.Context) ([]ListUserGrowthRow, error) {
+	rows, err := q.db.Query(ctx, listUserGrowth)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListUserGrowthRow{}
+	for rows.Next() {
+		var i ListUserGrowthRow
+		if err := rows.Scan(&i.Day, &i.Total); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const rebuildJobDailyStats = `-- name: RebuildJobDailyStats :execrows
 INSERT INTO job_daily_stats (day, added, removed, computed_at)
 SELECT

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -281,6 +281,12 @@ func Register(app *fiber.App, cfg Config) {
 	// rollup (cmd/rollup-stats); the /trends SPA page renders it as a bar chart.
 	api.Get("/stats/jobs-activity", a.JobsActivity)
 
+	// Public member-growth time series (cumulative registrations per UTC day),
+	// unauthenticated like the other public reads. Computed on the fly from
+	// users.created_at (no rollup); the /open transparency page renders it as a
+	// bar chart. Aggregate-only — no user identifier is exposed.
+	api.Get("/stats/user-growth", a.UserGrowth)
+
 	// Per-user job interactions and the user-scoped reads accept either the
 	// session cookie or an API key (RequireAuthOrKey), so a script holding a key
 	// can drive the same flow as the browser. The public job reads above stay

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -93,6 +93,33 @@ func truncateToDate(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
 }
 
+// growthPoint is one point on the member-growth series: a UTC calendar date and
+// the cumulative member count as of that day.
+type growthPoint struct {
+	Date  string `json:"date"`
+	Total int32  `json:"total"`
+}
+
+// UserGrowth serves the public, unauthenticated member-growth time series: the
+// cumulative count of registered members per UTC day, from the first registration
+// through today. The dense, gap-free, monotonically non-decreasing series is
+// produced by the SQL query; this handler only maps rows to the wire envelope.
+// Aggregate-only — the query selects no user identifier, so no personal field can
+// leak here. An empty catalogue yields an empty series (200 with data: []).
+func (a *API) UserGrowth(c *fiber.Ctx) error {
+	rows, err := a.queries.ListUserGrowth(c.Context())
+	if err != nil {
+		return err
+	}
+
+	points := make([]growthPoint, len(rows))
+	for i, r := range rows {
+		points[i] = growthPoint{Date: r.Day.Time.Format(dateLayout), Total: r.Total}
+	}
+
+	return c.JSON(fiber.Map{"data": points})
+}
+
 // JobsActivity serves the public, unauthenticated job-activity time series:
 // added vs. removed vacancies per period, aggregated to the requested granularity
 // over a date range. The dense, gap-free series (missing periods → 0) is produced

--- a/internal/handler/user_growth_integration_test.go
+++ b/internal/handler/user_growth_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+// Integration test for the member-growth read endpoint. The cumulative series is
+// pure SQL over users.created_at and the handler reads through a concrete
+// *db.Queries, so it can only be exercised against a real Postgres. It asserts the
+// empty-catalogue case, then seeds registrations on controlled UTC days and checks
+// the dense, gap-filled, monotonically non-decreasing cumulative series.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestUserGrowthEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	h := &API{pool: pool, queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/stats/user-growth", h.UserGrowth)
+
+	type point struct {
+		Date  string `json:"date"`
+		Total int    `json:"total"`
+	}
+	type envelope struct {
+		Data []point `json:"data"`
+	}
+	get := func() envelope {
+		t.Helper()
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/api/v1/stats/user-growth", nil))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("status = %d, want 200 (public, unauthenticated read)", resp.StatusCode)
+		}
+		var env envelope
+		if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return env
+	}
+
+	// --- Empty catalogue: 200 with an empty (non-null) series ------------------
+	if empty := get(); len(empty.Data) != 0 {
+		t.Fatalf("empty catalogue: got %d points, want 0", len(empty.Data))
+	}
+
+	// --- Seed registrations on controlled UTC days -----------------------------
+	// mid-day, to prove UTC-date bucketing regardless of session timezone.
+	seed := func(email string, y int, m time.Month, d int) {
+		created := time.Date(y, m, d, 12, 0, 0, 0, time.UTC)
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO users (email, created_at) VALUES ($1, $2)`, email, created); err != nil {
+			t.Fatalf("seed user %q: %v", email, err)
+		}
+	}
+	// 2026-01-05: 2 members; 2026-01-10: 3 members. Cumulative: 2 from 01-05,
+	// flat through 01-09, 5 from 01-10 onward. Total = 5.
+	seed("a@example.test", 2026, 1, 5)
+	seed("b@example.test", 2026, 1, 5)
+	seed("c@example.test", 2026, 1, 10)
+	seed("d@example.test", 2026, 1, 10)
+	seed("e@example.test", 2026, 1, 10)
+
+	series := get().Data
+	if len(series) == 0 {
+		t.Fatal("seeded series is empty")
+	}
+
+	byDate := map[string]int{}
+	prev := 0
+	for i, p := range series {
+		byDate[p.Date] = p.Total
+		if p.Total < prev {
+			t.Errorf("series not monotonic at %s: %d < previous %d", p.Date, p.Total, prev)
+		}
+		prev = p.Total
+		if i == 0 && p.Date != "2026-01-05" {
+			t.Errorf("series starts at %s, want 2026-01-05 (first registration day)", p.Date)
+		}
+	}
+
+	if got := byDate["2026-01-05"]; got != 2 {
+		t.Errorf("2026-01-05 total = %d, want 2", got)
+	}
+	if got := byDate["2026-01-07"]; got != 2 { // gap day repeats the running total
+		t.Errorf("2026-01-07 total = %d, want 2 (flat gap day)", got)
+	}
+	if got := byDate["2026-01-10"]; got != 5 {
+		t.Errorf("2026-01-10 total = %d, want 5", got)
+	}
+	if last := series[len(series)-1].Total; last != 5 {
+		t.Errorf("final total = %d, want 5 (all seeded members)", last)
+	}
+}

--- a/openspec/changes/open-transparency-page/.openspec.yaml
+++ b/openspec/changes/open-transparency-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/open-transparency-page/design.md
+++ b/openspec/changes/open-transparency-page/design.md
@@ -1,0 +1,93 @@
+## Context
+
+The site already has the raw material for a transparency page but no page that
+gathers it: `/trends` renders `GET /api/v1/stats/jobs-activity` via the
+`ActivityBars` component (SSR through `serverApi(fetch)`); `/about` SSRs the
+catalogue totals; `GET /api/v1/jobs/facets` returns facet distributions; company
+and job totals come back in list-endpoint `meta.total`. The one missing datum is a
+member-growth series — there is no per-day registration count today. The GitHub
+numbers live outside our system (GitHub REST API). This change is additive: a new
+route, one new read endpoint, and reuse of existing components.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One public `/open` page proving the "open, free search engine" claim with live data.
+- Reuse existing building blocks (`ActivityBars`, the HomeView stat-strip idiom,
+  `serverApi`, the `/trends` load pattern) — no new chart library, no redesign.
+- Best-effort per-section SSR: any single upstream failing degrades only its section.
+- Each figure links to the API endpoint that produced it (API-first proof).
+
+**Non-Goals:**
+- Traffic/analytics (GA4), revenue/burn, third-party metric verification (jitsu-style).
+- A rollup table or worker for member growth — computed on the fly.
+- Realtime/streaming updates; SSR-on-request freshness is enough.
+
+## Decisions
+
+**1. Member growth: on-the-fly SQL, no rollup.**
+Add `UserGrowth` as a `JobsActivity` sibling in `internal/handler/stats.go`, backed
+by a new hand-written query in `internal/db/queries/stats.sql` that groups
+`users.created_at` by UTC day and returns a running cumulative total (window
+`SUM() OVER (ORDER BY day)`), then `make sqlc`. At ~hundreds of users this is
+trivially cheap; a rollup table (like `job_daily_stats`) would be over-engineering.
+Wire it in `handler.Register` as an unauthenticated public read next to
+`/stats/jobs-activity`. *Alternative rejected:* mirror the `job_daily_stats`
+rollup + `cmd/rollup-stats` — unjustified infrastructure for a tiny table.
+
+**2. Reuse `ActivityBars` for both time series.**
+Section B feeds it the jobs-activity points as today. Section F feeds it the
+cumulative member series (a monotonically rising bar staircase). Reusing one
+component keeps the visual language consistent and avoids a new chart dependency.
+*Alternative considered:* a dedicated line chart for cumulative growth — deferred;
+not worth a new component for v1.
+
+**3. SSR fan-out with per-section isolation.**
+`/open/+page.server.ts` `load` calls `serverApi(fetch)` for totals, jobs-activity,
+facets, and user-growth, plus a GitHub fetch, each wrapped so a rejection resolves
+to `null` (e.g. `Promise.allSettled` or per-call `try/catch`). The page renders
+each section from its own (possibly null) slice, showing a fallback when null. This
+directly satisfies the "best-effort per-section degradation" requirement.
+
+**4. GitHub data: server-side fetch, cached, best-effort.**
+Fetch `https://api.github.com/repos/strelov1/freehire` (stars, forks, license) and
+the contributor count during SSR. Unauthenticated GitHub REST is limited to 60
+req/hr per IP, so cache the result in a module-level in-memory memo with a TTL
+(~1h) in `+page.server.ts` and set a matching `cache-control` via `setHeaders`, so
+repeated loads don't exhaust the budget. On failure the section falls back to a
+plain GitHub link. *Alternative rejected:* a server-side scheduled fetch/store —
+unneeded for one low-traffic page.
+
+**5. Constants for ATS/Telegram counts.**
+The ATS-platform count (98) and Telegram-channel count (87) are repo facts, not DB
+rows; surface them as constants on the page exactly as the homepage stat-strip
+already does. They change only when adapters/channels are added, i.e. on deploy.
+
+**6. Entry point.**
+Add an `/open` link in the footer (and/or the existing nav/menu), alongside the
+`/about`, `/trends`, `/blog` links.
+
+## Risks / Trade-offs
+
+- **GitHub rate limit (60/hr unauth)** → module-level TTL cache + `cache-control`;
+  worst case the section shows its fallback link, page still renders.
+- **Low absolute numbers pre-launch (61 stars, 161 members)** → acceptable: the
+  transparency story is the point, and the launch bends the curves (before/after
+  is itself content). No mitigation needed beyond honest framing.
+- **Constant drift (ATS=98 / TG=87 go stale)** → same trade-off the homepage already
+  accepts; refreshed on deploy when sources change. Not load-bearing.
+- **SSR fan-out latency (5 upstream calls)** → run them concurrently
+  (`Promise.allSettled`); the GitHub call is cached so steady-state is 4 internal
+  calls, all already used elsewhere.
+
+## Migration Plan
+
+No DB migration, no new env, no worker. Ship order: (1) backend endpoint +
+`make sqlc` + tests, deploy; (2) frontend page consuming it. Because the page is
+additive and unauthenticated, rollback is simply reverting the PR. The
+`/stats/user-growth` endpoint is safe to deploy ahead of the page.
+
+## Open Questions
+
+- Footer vs nav vs both for the `/open` link — decide during implementation to
+  match the existing chrome; not blocking.

--- a/openspec/changes/open-transparency-page/proposal.md
+++ b/openspec/changes/open-transparency-page/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+freehire positions itself as an open, free "search engine for jobs", but that claim
+is asserted, not shown. An "open startup" transparency page — live catalogue and
+project metrics on one public URL, in the spirit of cal.com/open — turns the
+positioning into proof, doubles as launch content (Product Hunt / HN), and, because
+every figure links to the public API endpoint that produced it, becomes a live
+demonstration of the API-first / agent-friendly story.
+
+## What Changes
+
+- Add a public **`/open`** page (SSR, unauthenticated) rendering live freehire
+  metrics in five sections:
+  - **A. Catalogue scale** — open jobs, companies, ATS platforms, Telegram channels.
+  - **B. Catalogue movement** — added vs removed over time, reusing the existing
+    `/trends` jobs-activity bar chart.
+  - **C. What's inside** — facet distributions (top countries, top skills, remote
+    share, seniority split) from the existing `/jobs/facets` backend.
+  - **D. Open source** — GitHub stars/forks/contributors + MIT badge + a
+    "add a source = one PR" call to action, fetched from the GitHub API.
+  - **F. Member growth** — cumulative registrations over time, a `/trends`-style
+    chart backed by a new public endpoint.
+- Add a new public endpoint **`GET /api/v1/stats/user-growth`** — a per-day
+  cumulative count of user registrations, computed on the fly from `users.created_at`
+  (no rollup table, no worker).
+- Each headline figure links to the public API endpoint that produced it.
+- Add an **`/open`** link in the site footer/nav.
+
+Non-goals (deliberately deferred): traffic/analytics (GA4), revenue/burn, and any
+third-party metric verification. Data is served live from our own API and the
+GitHub API; the page degrades per-section so a failing upstream never breaks it.
+
+## Capabilities
+
+### New Capabilities
+- `open-transparency-page`: the public `/open` page that aggregates live catalogue
+  scale, catalogue movement, facet distributions, open-source stats, and member
+  growth into one SSR transparency dashboard, with each figure linking to its API
+  source and best-effort per-section degradation.
+- `user-growth-stats`: a public `GET /api/v1/stats/user-growth` endpoint returning
+  the cumulative count of registered members over time (per-day series), computed
+  directly from `users.created_at`.
+
+### Modified Capabilities
+<!-- None: the page consumes job-activity-stats, companies, and deterministic-facets
+     read-only without changing their requirements. -->
+
+## Impact
+
+- **Frontend (`web/`)**: new `src/routes/open/+page.svelte` + `+page.server.ts`
+  (SSR load fanning out to the totals, jobs-activity, facets, user-growth, and
+  GitHub API calls, best-effort); reuse of the HomeView stat-strip and the
+  `/trends` chart component; a new footer/nav link; `src/lib/api.ts` gains a
+  `userGrowth` method.
+- **Backend (`internal/`)**: new `JobsActivity`-sibling handler for
+  `/stats/user-growth`; a new hand-written query in
+  `internal/db/queries/stats.sql` (→ `make sqlc`); route wired in
+  `handler.Register` as an unauthenticated public read.
+- **Constants**: ATS platform count (98) and Telegram channel count (87) are repo
+  constants surfaced on the page, mirroring the homepage stat-strip.
+- **No migrations, no new env, no new worker.**

--- a/openspec/changes/open-transparency-page/specs/open-transparency-page/spec.md
+++ b/openspec/changes/open-transparency-page/specs/open-transparency-page/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Public transparency page
+The system SHALL serve a public, unauthenticated `/open` page that renders live
+freehire metrics server-side (SSR), covering catalogue scale, catalogue movement,
+facet distributions, open-source stats, and member growth.
+
+#### Scenario: Page is public and server-rendered
+- **WHEN** an anonymous visitor opens `/open`
+- **THEN** the page responds 200 with the metrics present in the initial server-rendered HTML (no client-only data fetch required to see the figures)
+
+#### Scenario: Catalogue scale section
+- **WHEN** the page renders
+- **THEN** it shows a stat-strip with the live open-job count, company count, the ATS-platform count, and the Telegram-channel count
+
+#### Scenario: Catalogue movement section
+- **WHEN** the page renders
+- **THEN** it shows the added-vs-removed activity over time, reusing the same chart as `/trends` fed by `/api/v1/stats/jobs-activity`
+
+#### Scenario: What's-inside section
+- **WHEN** the page renders
+- **THEN** it shows facet distributions (top countries, top skills, remote share, seniority split) derived from `/api/v1/jobs/facets`
+
+#### Scenario: Member-growth section
+- **WHEN** the page renders
+- **THEN** it shows a cumulative member-growth chart fed by `/api/v1/stats/user-growth`
+
+#### Scenario: Open-source section
+- **WHEN** the page renders and the GitHub API is reachable
+- **THEN** it shows the repository stars, forks, and contributor count, an MIT-license badge, and a contribute call to action
+
+### Requirement: Best-effort per-section degradation
+The system SHALL render each section independently so that a failing upstream (the
+GitHub API or any single freehire endpoint) degrades only its own section and never
+fails the whole page.
+
+#### Scenario: GitHub API unavailable
+- **WHEN** the GitHub API call fails or times out during SSR
+- **THEN** the page still renders every other section, and the open-source section shows a graceful fallback (e.g. the GitHub link) instead of an error
+
+#### Scenario: A metric endpoint fails
+- **WHEN** one freehire metric source (e.g. facets) returns an error during SSR
+- **THEN** the remaining sections render normally and only the affected section is omitted or shows a fallback
+
+### Requirement: Figures link to their API source
+The system SHALL link each headline figure to the public API endpoint that produced
+it, reinforcing the API-first positioning.
+
+#### Scenario: Stat links to endpoint
+- **WHEN** a visitor inspects a headline figure (e.g. open jobs, member growth)
+- **THEN** it links to the corresponding public API endpoint that returns that data
+
+### Requirement: Discoverable entry point
+The system SHALL expose an `/open` link in the site footer or navigation so the
+page is reachable from the rest of the site.
+
+#### Scenario: Link present
+- **WHEN** a visitor views the site chrome (footer/nav)
+- **THEN** an `/open` link is present and navigates to the transparency page

--- a/openspec/changes/open-transparency-page/specs/user-growth-stats/spec.md
+++ b/openspec/changes/open-transparency-page/specs/user-growth-stats/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Public member-growth series
+The system SHALL expose an unauthenticated `GET /api/v1/stats/user-growth` endpoint
+returning the cumulative count of registered members over time as a per-day series,
+computed directly from `users.created_at` with no rollup table or worker.
+
+#### Scenario: Cumulative series returned
+- **WHEN** a client requests `GET /api/v1/stats/user-growth`
+- **THEN** the response is `{"data": [...]}` where each item is `{ "date": "YYYY-MM-DD", "total": <cumulative member count as of that day> }`
+- **AND** `total` is monotonically non-decreasing across the series
+
+#### Scenario: No authentication required
+- **WHEN** the endpoint is requested without a session cookie or API key
+- **THEN** the request succeeds (it is a public read, like `/stats/jobs-activity`)
+
+#### Scenario: Aggregate only, no PII
+- **WHEN** the series is produced
+- **THEN** it contains only dates and counts — never any user identifier, email, or other personal field
+
+#### Scenario: Empty catalogue
+- **WHEN** there are no registered members
+- **THEN** the endpoint returns `{"data": []}` with a 200 status, not an error

--- a/openspec/changes/open-transparency-page/tasks.md
+++ b/openspec/changes/open-transparency-page/tasks.md
@@ -1,0 +1,25 @@
+## 1. Backend — member-growth endpoint (user-growth-stats)
+
+- [x] 1.1 Add a hand-written query to `internal/db/queries/stats.sql` grouping `users.created_at` by UTC day with a running cumulative total (`SUM() OVER (ORDER BY day)`); run `make sqlc` and commit the generated `internal/db` code
+- [x] 1.2 Add a `UserGrowth` handler in `internal/handler/stats.go` (a `JobsActivity` sibling) returning `{"data": [{date,total}]}`; empty catalogue → `{"data": []}`; aggregate-only, no PII
+- [x] 1.3 Wire `GET /stats/user-growth` in `handler.Register` as an unauthenticated public read next to `/stats/jobs-activity`
+- [x] 1.4 Handler tests: cumulative monotonicity, empty-catalogue 200, no-auth access (mirror the `job-activity-stats` test shape)
+
+## 2. Frontend — API client + types
+
+- [x] 2.1 Add the `UserGrowthPoint` type and an `api.userGrowth()` method (+ `serverApi` variant) in `web/src/lib/api.ts` / types, mirroring `jobsActivity`
+- [x] 2.2 Unit-test the pure client mapping if any transformation is added (vitest)
+
+## 3. Frontend — /open page
+
+- [x] 3.1 `web/src/routes/open/+page.server.ts`: concurrent best-effort SSR fan-out (`Promise.allSettled`) over totals, jobs-activity, facets, user-growth, and a cached GitHub fetch; each slice resolves to null on failure; set `cache-control` via `setHeaders`
+- [x] 3.2 Module-level TTL (~1h) in-memory cache for the GitHub call to stay under the 60/hr unauth limit; on failure return null (section falls back to a plain GitHub link)
+- [x] 3.3 `web/src/routes/open/+page.svelte`: render sections A (scale stat-strip) · B (`ActivityBars` from jobs-activity) · F (`ActivityBars` from cumulative user-growth) · C (facet-distribution bars from `/jobs/facets`) · D (GitHub stars/forks/contributors + MIT badge + "add a source = one PR" CTA), reusing the HomeView stat-strip idiom and the site aesthetic (Inter, monochrome, `// section` mono labels)
+- [x] 3.4 Each headline figure links to the public API endpoint that produced it
+- [x] 3.5 Per-section fallback UI when its slice is null (best-effort degradation), including the GitHub-unavailable case
+- [x] 3.6 `Seo` title/description for `/open`; intro copy ("all our numbers, live") noting figures come live from the public API
+
+## 4. Navigation + verification
+
+- [x] 4.1 Add an `/open` link to the footer (and/or nav/menu), matching the existing `/about`·`/trends`·`/blog` chrome
+- [x] 4.2 Verify: `go build ./... && go vet ./... && go test ./...` (backend) and `npm run check` (web) pass; manually load `/open` and confirm every section renders, figures link to their API, and killing the GitHub call still renders the page

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -42,6 +42,7 @@ import type {
   ResumeMeta,
   ActivityGranularity,
   ActivityPoint,
+  UserGrowthPoint,
   LocationPreferences,
 } from './types';
 
@@ -333,6 +334,14 @@ export function createApi(
     if (from) params.set('from', from);
     if (to) params.set('to', to);
     return requestData<ActivityPoint[]>(`/api/v1/stats/jobs-activity?${params}`);
+  }
+
+  /** The public member-growth series: the cumulative count of registered members
+   *  per UTC day, from the first registration through today. Dense and
+   *  monotonically non-decreasing (gap days repeat the running total).
+   *  Aggregate-only — no user field is exposed. Unauthenticated. */
+  async function userGrowth(): Promise<UserGrowthPoint[]> {
+    return requestData<UserGrowthPoint[]>(`/api/v1/stats/user-growth`);
   }
 
   /** List companies, optionally filtered by a name query `q` (a case-insensitive
@@ -848,6 +857,7 @@ export function createApi(
     recommendations,
     facetCounts,
     jobsActivity,
+    userGrowth,
     listCompanies,
     getCompany,
     listCompanySubindustries,

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -29,6 +29,7 @@
       title: 'Company',
       links: [
         { label: 'About', href: resolve('/about') },
+        { label: 'Open', href: resolve('/open') },
         { label: 'For companies', href: resolve('/for-companies') },
         { label: 'Submit a job', href: resolve('/submit') },
         { label: 'Privacy', href: resolve('/privacy') },

--- a/web/src/lib/components/GrowthArea.svelte
+++ b/web/src/lib/components/GrowthArea.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import type { UserGrowthPoint } from '$lib/types';
+
+  // A minimal single-series cumulative area chart for the member-growth series —
+  // one monotonically rising line, unlike ActivityBars' two-series added/removed
+  // bars. Hand-built SVG scaled to its container width, no charting dependency,
+  // matching the site's other bespoke charts. The series is dense and sorted by
+  // date (the backend guarantees it), so the x-axis is just even spacing.
+  let { points }: { points: UserGrowthPoint[] } = $props();
+
+  const W = 640;
+  const H = 180;
+  const PAD = 10;
+  const baseY = H - PAD;
+
+  const model = $derived.by(() => {
+    const n = points.length;
+    const first = points[0];
+    const last = points[n - 1];
+    if (!first || !last) return null;
+    const peak = Math.max(1, last.total); // monotonic → last point is the max
+    const x = (i: number) => (n === 1 ? W / 2 : PAD + (i / (n - 1)) * (W - 2 * PAD));
+    const y = (t: number) => PAD + (1 - t / peak) * (H - 2 * PAD);
+    const line = points.map((p, i) => `${x(i).toFixed(1)},${y(p.total).toFixed(1)}`).join(' ');
+    const area = `${x(0).toFixed(1)},${baseY} ${line} ${x(n - 1).toFixed(1)},${baseY}`;
+    return {
+      peak,
+      line,
+      area,
+      endX: x(n - 1),
+      endY: y(last.total),
+      first: first.date,
+      last: last.date,
+    };
+  });
+
+  function shortDate(iso: string): string {
+    return new Date(iso + 'T00:00:00Z').toLocaleDateString(undefined, {
+      month: 'short',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+  }
+</script>
+
+{#if !model}
+  <p class="py-16 text-center text-sm text-muted-foreground">No members yet.</p>
+{:else}
+  <figure class="flex flex-col gap-3">
+    <svg viewBox="0 0 {W} {H + 20}" class="w-full" role="img" aria-label="Cumulative members over time">
+      <!-- peak reference line + label -->
+      <line x1={PAD} y1={PAD} x2={W - PAD} y2={PAD} class="stroke-border" stroke-dasharray="2 3" />
+      <text x={PAD} y={PAD - 2} class="fill-muted-foreground" font-size="11">
+        {model.peak.toLocaleString()}
+      </text>
+
+      <!-- baseline -->
+      <line x1="0" y1={baseY} x2={W} y2={baseY} class="stroke-border" stroke-width="1" />
+
+      <!-- filled area + line -->
+      <polygon points={model.area} class="fill-foreground/10" />
+      <polyline
+        points={model.line}
+        fill="none"
+        class="stroke-foreground"
+        stroke-width="2"
+        stroke-linejoin="round"
+      />
+      <!-- end marker -->
+      <circle cx={model.endX} cy={model.endY} r="3.5" class="fill-foreground" />
+
+      <!-- x-axis endpoints -->
+      <text x={PAD} y={baseY + 15} class="fill-muted-foreground" font-size="11">
+        {shortDate(model.first)}
+      </text>
+      <text x={W - PAD} y={baseY + 15} text-anchor="end" class="fill-muted-foreground" font-size="11">
+        {shortDate(model.last)}
+      </text>
+    </svg>
+  </figure>
+{/if}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -286,6 +286,15 @@ export interface ActivityPoint {
   removed: number;
 }
 
+/** One point on the member-growth series: the ISO date and the cumulative count of
+ *  registered members as of that day. The backend returns a dense, gap-free series
+ *  (days with no new signups repeat the running total), monotonically
+ *  non-decreasing. */
+export interface UserGrowthPoint {
+  date: string;
+  total: number;
+}
+
 /** An API key as returned by the management endpoints — metadata only; the
  *  plaintext token is never part of this shape. `token_prefix` is a short,
  *  non-secret leading slice (e.g. "fhk_Ab12cd") shown so the user can tell keys

--- a/web/src/routes/open/+page.server.ts
+++ b/web/src/routes/open/+page.server.ts
@@ -1,0 +1,89 @@
+import { serverApi } from '$lib/server/api';
+import type { PageServerLoad } from './$types';
+
+// The /open transparency page pulls its numbers live at request time from our own
+// public API plus the GitHub API. Every leg is best-effort (`Promise.allSettled`):
+// a failing upstream yields null/[] and the page drops or falls back that one
+// section, never the whole page.
+
+export type GithubStats = {
+  stars: number;
+  forks: number;
+  contributors: number | null;
+  license: string | null;
+};
+
+// Unauthenticated GitHub REST is capped at 60 requests/hour per IP, so the repo
+// stats are memoized module-side and refreshed at most once per TTL, shared across
+// all page loads. (Date.now() is fine here — this is a server module, not a
+// resumable workflow script.)
+const GH_TTL_MS = 60 * 60 * 1000;
+const GH_REPO = 'strelov1/freehire';
+let ghCache: { at: number; data: GithubStats | null } | null = null;
+
+async function fetchGithub(fetchImpl: typeof fetch): Promise<GithubStats | null> {
+  if (ghCache && Date.now() - ghCache.at < GH_TTL_MS) return ghCache.data;
+
+  const headers = { Accept: 'application/vnd.github+json' };
+  let data: GithubStats | null = null;
+  try {
+    const res = await fetchImpl(`https://api.github.com/repos/${GH_REPO}`, { headers });
+    if (!res.ok) throw new Error(`github repo ${res.status}`);
+    const repo = await res.json();
+
+    // Contributor count without pulling the whole list: page it one-per-page and
+    // read the last-page number out of the Link header.
+    let contributors: number | null = null;
+    try {
+      const c = await fetchImpl(
+        `https://api.github.com/repos/${GH_REPO}/contributors?per_page=1&anon=true`,
+        { headers },
+      );
+      const last = c.headers.get('link')?.match(/[?&]page=(\d+)>;\s*rel="last"/);
+      contributors = last ? Number(last[1]) : c.ok ? 1 : null;
+    } catch {
+      contributors = null;
+    }
+
+    data = {
+      stars: repo.stargazers_count ?? 0,
+      forks: repo.forks_count ?? 0,
+      contributors,
+      license: repo.license?.spdx_id ?? null,
+    };
+  } catch {
+    data = null; // caching the null too, so a rate-limit spell doesn't retry every request
+  }
+
+  ghCache = { at: Date.now(), data };
+  return data;
+}
+
+export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
+  const api = serverApi(fetch);
+  const [jobs, companies, activity, facets, growth, github] = await Promise.allSettled([
+    api.listJobs(1, 0),
+    api.listCompanies('', 1, 0),
+    api.jobsActivity('day'),
+    api.facetCounts(new URLSearchParams()),
+    api.userGrowth(),
+    fetchGithub(fetch),
+  ]);
+
+  const value = <T>(r: PromiseSettledResult<T>): T | null =>
+    r.status === 'fulfilled' ? r.value : null;
+
+  // The figures move slowly; let the CDN/browser hold the page briefly.
+  setHeaders({ 'cache-control': 'public, max-age=300' });
+
+  return {
+    scale: {
+      jobs: value(jobs)?.total ?? null,
+      companies: value(companies)?.total ?? null,
+    },
+    activity: value(activity) ?? [],
+    facets: value(facets)?.facets ?? null,
+    growth: value(growth) ?? [],
+    github: value(github),
+  };
+};

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import ActivityBars from '$lib/components/ActivityBars.svelte';
+  import GrowthArea from '$lib/components/GrowthArea.svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const canonical = $derived(`${page.url.origin}/open`);
+
+  // Repo constants — the crawler covers this many ATS platforms and Telegram
+  // channels. Not DB rows; they change only when adapters/channels are added (i.e.
+  // on deploy), mirroring the homepage stat-strip.
+  const ATS_PLATFORMS = 98;
+  const TELEGRAM_CHANNELS = 87;
+
+  const nf = new Intl.NumberFormat('en');
+  const compactNf = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });
+  const fmt = (n: number | null, fallback: string) => (n == null ? fallback : compactNf.format(n));
+
+  const regionNames = new Intl.DisplayNames(['en'], { type: 'region' });
+  function countryName(code: string): string {
+    try {
+      return regionNames.of(code.toUpperCase()) ?? code.toUpperCase();
+    } catch {
+      return code.toUpperCase();
+    }
+  }
+  const titleCase = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).replace(/_/g, ' ');
+
+  type Bar = { label: string; count: number };
+  function top(facet: Record<string, number> | undefined, n: number, label: (k: string) => string): Bar[] {
+    if (!facet) return [];
+    return Object.entries(facet)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, n)
+      .map(([k, count]) => ({ label: label(k), count }));
+  }
+
+  const facets = $derived(data.facets);
+  const countries = $derived(top(facets?.countries, 8, countryName));
+  const skills = $derived(top(facets?.skills, 8, titleCase));
+  const seniority = $derived(top(facets?.seniority, 6, titleCase));
+  const workMode = $derived(top(facets?.work_mode, 3, titleCase));
+
+  // Remote share across the resolved work-mode buckets.
+  const remoteShare = $derived.by(() => {
+    const wm = facets?.work_mode;
+    if (!wm) return null;
+    const total = Object.values(wm).reduce((a, b) => a + b, 0);
+    if (total === 0) return null;
+    return Math.round(((wm.remote ?? 0) / total) * 100);
+  });
+
+  const stats = $derived([
+    { value: fmt(data.scale.jobs, '3M+'), label: 'open jobs', href: '/api/v1/jobs' },
+    { value: fmt(data.scale.companies, '220K+'), label: 'companies', href: '/api/v1/companies' },
+    { value: nf.format(ATS_PLATFORMS), label: 'ATS platforms', href: null },
+    { value: nf.format(TELEGRAM_CHANNELS), label: 'Telegram channels', href: null },
+  ]);
+
+  const gh = $derived(data.github);
+  const members = $derived.by(() => {
+    const last = data.growth[data.growth.length - 1];
+    return last ? last.total : null;
+  });
+</script>
+
+{#snippet distributionBars(items: Bar[])}
+  {@const peak = Math.max(1, ...items.map((i) => i.count))}
+  <div class="flex flex-col gap-2.5">
+    {#each items as it (it.label)}
+      <div class="flex items-center gap-3">
+        <div class="w-32 shrink-0 truncate text-sm" title={it.label}>{it.label}</div>
+        <div class="h-2.5 flex-1 overflow-hidden rounded-full bg-secondary">
+          <div class="h-full rounded-full bg-foreground" style="width: {(it.count / peak) * 100}%"></div>
+        </div>
+        <div class="w-16 shrink-0 text-right text-sm tabular-nums text-muted-foreground">
+          {compactNf.format(it.count)}
+        </div>
+      </div>
+    {/each}
+  </div>
+{/snippet}
+
+{#snippet sourceLink(href: string, label: string)}
+  <a
+    {href}
+    class="font-mono text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+  >
+    {label} ↗
+  </a>
+{/snippet}
+
+<Seo
+  title="Open — freehire's numbers, live"
+  description="The open startup page for freehire: live catalogue scale, daily job movement, what's inside, member growth, and open-source stats. Every figure comes straight from the public API."
+  {canonical}
+/>
+
+<div class="mx-auto w-full max-w-4xl px-4 py-10 sm:py-14">
+  <!-- Intro -->
+  <header class="mb-12">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// open startup</p>
+    <h1 class="mt-4 text-4xl font-semibold tracking-tighter sm:text-5xl">All our numbers, live.</h1>
+    <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+      freehire is an open, free search engine for jobs — so our metrics are open too. Every figure
+      below is pulled live from the same public API anyone (or any AI agent) can query. No dashboards
+      behind a login, no vanity rounding.
+    </p>
+  </header>
+
+  <!-- A. Catalogue scale -->
+  <section class="mb-14">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// the catalogue</p>
+    <dl class="mt-6 grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
+      {#each stats as s (s.label)}
+        <div class="bg-background p-5 sm:p-6">
+          <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{s.label}</dt>
+          <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">
+            {#if s.href}
+              <a href={s.href} class="hover:underline">{s.value}</a>
+            {:else}
+              {s.value}
+            {/if}
+          </dd>
+        </div>
+      {/each}
+    </dl>
+  </section>
+
+  <!-- B. Catalogue movement -->
+  <section class="mb-14">
+    <div class="flex items-baseline justify-between">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// daily movement</p>
+      {@render sourceLink('/api/v1/stats/jobs-activity', '/stats/jobs-activity')}
+    </div>
+    <h2 class="mt-3 text-xl font-semibold tracking-tight">Jobs added vs. removed</h2>
+    <p class="mb-6 mt-1 text-sm text-muted-foreground">
+      New vacancies crawled in versus postings we detected as closed, per day.
+    </p>
+    <ActivityBars points={data.activity} />
+  </section>
+
+  <!-- F. Member growth -->
+  <section class="mb-14">
+    <div class="flex items-baseline justify-between">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// members</p>
+      {@render sourceLink('/api/v1/stats/user-growth', '/stats/user-growth')}
+    </div>
+    <h2 class="mt-3 text-xl font-semibold tracking-tight">
+      {members == null ? 'People on freehire' : `${nf.format(members)} people on freehire`}
+    </h2>
+    <p class="mb-6 mt-1 text-sm text-muted-foreground">
+      Cumulative registered members over time. Early days — and that's the point of showing it.
+    </p>
+    <GrowthArea points={data.growth} />
+  </section>
+
+  <!-- C. What's inside -->
+  <section class="mb-14">
+    <div class="flex items-baseline justify-between">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// what's inside</p>
+      {@render sourceLink('/api/v1/jobs/facets', '/jobs/facets')}
+    </div>
+    {#if facets}
+      <div class="mt-6 grid gap-x-10 gap-y-8 sm:grid-cols-2">
+        <div>
+          <h3 class="mb-4 text-sm font-semibold">Top countries</h3>
+          {@render distributionBars(countries)}
+        </div>
+        <div>
+          <h3 class="mb-4 text-sm font-semibold">Top skills</h3>
+          {@render distributionBars(skills)}
+        </div>
+        <div>
+          <h3 class="mb-4 text-sm font-semibold">Seniority</h3>
+          {@render distributionBars(seniority)}
+        </div>
+        <div>
+          <h3 class="mb-4 text-sm font-semibold">
+            Work mode{#if remoteShare != null}<span class="ml-2 font-normal text-muted-foreground">{remoteShare}% remote</span>{/if}
+          </h3>
+          {@render distributionBars(workMode)}
+        </div>
+      </div>
+    {:else}
+      <p class="mt-6 text-sm text-muted-foreground">Distribution data is unavailable right now.</p>
+    {/if}
+  </section>
+
+  <!-- D. Open source -->
+  <section class="mb-6">
+    <div class="flex items-baseline justify-between">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// open source</p>
+      {@render sourceLink('https://github.com/strelov1/freehire', 'github.com/strelov1/freehire')}
+    </div>
+    <div class="mt-6 rounded-xl border border-border p-6 sm:p-8">
+      {#if gh}
+        <div class="flex flex-wrap gap-x-12 gap-y-6">
+          <div>
+            <div class="text-3xl font-semibold tabular-nums">{nf.format(gh.stars)}</div>
+            <div class="font-mono text-xs uppercase tracking-wide text-muted-foreground">stars</div>
+          </div>
+          <div>
+            <div class="text-3xl font-semibold tabular-nums">{nf.format(gh.forks)}</div>
+            <div class="font-mono text-xs uppercase tracking-wide text-muted-foreground">forks</div>
+          </div>
+          {#if gh.contributors != null}
+            <div>
+              <div class="text-3xl font-semibold tabular-nums">{nf.format(gh.contributors)}</div>
+              <div class="font-mono text-xs uppercase tracking-wide text-muted-foreground">contributors</div>
+            </div>
+          {/if}
+          {#if gh.license}
+            <div>
+              <div class="text-3xl font-semibold">{gh.license}</div>
+              <div class="font-mono text-xs uppercase tracking-wide text-muted-foreground">license</div>
+            </div>
+          {/if}
+        </div>
+      {/if}
+      <p class="mt-6 max-w-xl text-sm leading-relaxed text-muted-foreground">
+        The whole pipeline is open source. Missing a job source you use? Adding it is usually one
+        small adapter — <a
+          href="https://github.com/strelov1/freehire"
+          class="font-medium text-foreground underline-offset-4 hover:underline">a PR is very welcome</a
+        >.
+      </p>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
## What

An **open-startup transparency page** at `/open` (in the spirit of cal.com/open) that turns the "open, free search engine" positioning into proof — live catalogue and project metrics on one public URL, each figure linking to the public API that produced it (reinforcing the API-first / agent-friendly story). Doubles as launch content for Product Hunt / HN.

Planned in `openspec/changes/open-transparency-page` (proposal / design / specs / tasks).

## Sections
- **A. Catalogue scale** — open jobs · companies · ATS platforms · Telegram channels
- **B. Daily movement** — added vs removed, reusing the `/trends` `ActivityBars`
- **F. Member growth** — cumulative registrations (new `GrowthArea` chart + new endpoint)
- **C. What's inside** — top countries / skills / seniority / work-mode from `/jobs/facets`
- **D. Open source** — GitHub stars/forks/contributors + MIT badge + "add a source = one PR" CTA

## Backend — new capability `user-growth-stats`
- `GET /api/v1/stats/user-growth`: dense, gap-filled, **cumulative** registrations per UTC day via a window `SUM` over `users.created_at` — **aggregate-only, no PII**; empty catalogue → empty series. `make sqlc` regenerated.
- `UserGrowth` handler (a `JobsActivity` sibling) + public route wiring.
- Integration test: empty case, cumulative monotonicity, dense gap days.

## Frontend
- `/open/+page.server.ts`: best-effort `Promise.allSettled` fan-out (totals, jobs-activity, facets, user-growth, GitHub). A failing leg degrades **only its section**. GitHub stats memoized (1h TTL) under the 60/hr unauth limit.
- `GrowthArea.svelte` — minimal single-series cumulative area chart (ActivityBars is two-series added/removed, so not reusable for a monotonic total — design decision updated).
- `api.userGrowth()` + `UserGrowthPoint`; `/open` footer link.

## Verification
- `go build ./... && go vet ./... && go test ./...` clean; `npm run check` clean (2 pre-existing `JobFitFull` warnings).
- `/open` rendered against the **live prod API** — every section renders; member-growth **best-effort degradation confirmed** (endpoint 404s pre-deploy → "No members yet", page still whole).
- ⚠️ The integration test compiles but was **not executed locally** (no Docker) — runs in CI / with testcontainers.

## Deploy order
Backend endpoint is safe to ship ahead of the page. No migration, no new env, no worker.