### PR TITLE
fix(header): prevent top-bar horizontal overflow on narrow screens

### DIFF
--- a/web/src/lib/components/HeaderSearch.svelte
+++ b/web/src/lib/components/HeaderSearch.svelte
@@ -176,7 +176,7 @@
 
 <svelte:window onkeydown={onWindowKeydown} onclick={onWindowClick} />
 
-<div bind:this={wrapEl} class="relative flex-1">
+<div bind:this={wrapEl} class="relative min-w-0 flex-1">
   <!-- Search box -->
   <div
     class="flex h-11 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm focus-within:ring-2 focus-within:ring-ring"


### PR DESCRIPTION
The global `TopBar` search wrapper was `flex-1` without `min-w-0`, so it couldn't shrink below its content and the header row overflowed by ~14px at ≤360px widths (visible as a slight horizontal page scroll). Adds `min-w-0` so the search box shrinks; no change at wider widths.

Follow-up to the API-docs redesign (already on main). Verified: no page overflow at 320/360/375px, header renders cleanly at 360px, `svelte-check` 0 errors.