### PR TITLE
feat(web): engagement stats on /open (saved/applied/viewed) + endpoint

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -271,6 +271,11 @@ type Querier interface {
 	// distinct row type and breaks the company-detail handler on every new column.
 	GetCompany(ctx context.Context, slug string) (Company, error)
 	GetEmail(ctx context.Context, arg GetEmailParams) (GetEmailRow, error)
+	// Aggregate interaction counts from user_jobs — saved / applied / viewed — for the
+	// public engagement endpoint. Aggregate-only: no user identifier or row-level field
+	// is selected. viewed_at is NOT NULL on every row (set on RecordView), so "viewed"
+	// equals the total interaction count.
+	GetEngagementStats(ctx context.Context) (GetEngagementStatsRow, error)
 	GetGmailConnection(ctx context.Context, userID int64) (GetGmailConnectionRow, error)
 	GetGmailRefreshToken(ctx context.Context, userID int64) (GetGmailRefreshTokenRow, error)
 	GetJob(ctx context.Context, id int64) (Job, error)

--- a/internal/db/queries/stats.sql
+++ b/internal/db/queries/stats.sql
@@ -54,6 +54,17 @@ FROM generate_series(
 LEFT JOIN daily ON daily.day = d::date
 ORDER BY d;
 
+-- name: GetEngagementStats :one
+-- Aggregate interaction counts from user_jobs — saved / applied / viewed — for the
+-- public engagement endpoint. Aggregate-only: no user identifier or row-level field
+-- is selected. viewed_at is NOT NULL on every row (set on RecordView), so "viewed"
+-- equals the total interaction count.
+SELECT
+    count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
+    count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
+    count(*) FILTER (WHERE viewed_at IS NOT NULL)::int  AS viewed
+FROM user_jobs;
+
 -- name: ListJobActivity :many
 -- Dense activity series over [from, to] at the given granularity. A daily
 -- generate_series builds the gap-free calendar; the LEFT JOIN fills each day's

--- a/internal/db/stats.sql.go
+++ b/internal/db/stats.sql.go
@@ -24,6 +24,31 @@ func (q *Queries) DeleteAllJobDailyStats(ctx context.Context) error {
 	return err
 }
 
+const getEngagementStats = `-- name: GetEngagementStats :one
+SELECT
+    count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
+    count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
+    count(*) FILTER (WHERE viewed_at IS NOT NULL)::int  AS viewed
+FROM user_jobs
+`
+
+type GetEngagementStatsRow struct {
+	Saved   int32 `json:"saved"`
+	Applied int32 `json:"applied"`
+	Viewed  int32 `json:"viewed"`
+}
+
+// Aggregate interaction counts from user_jobs — saved / applied / viewed — for the
+// public engagement endpoint. Aggregate-only: no user identifier or row-level field
+// is selected. viewed_at is NOT NULL on every row (set on RecordView), so "viewed"
+// equals the total interaction count.
+func (q *Queries) GetEngagementStats(ctx context.Context) (GetEngagementStatsRow, error) {
+	row := q.db.QueryRow(ctx, getEngagementStats)
+	var i GetEngagementStatsRow
+	err := row.Scan(&i.Saved, &i.Applied, &i.Viewed)
+	return i, err
+}
+
 const listJobActivity = `-- name: ListJobActivity :many
 SELECT
     date_trunc($1::text, d)::date AS period,

--- a/internal/handler/engagement_integration_test.go
+++ b/internal/handler/engagement_integration_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+// Integration test for the engagement-stats read endpoint. The counts are a pure
+// aggregate over user_jobs and the handler reads through a concrete *db.Queries,
+// so it can only be exercised against a real Postgres. It asserts the empty case,
+// then seeds saves/applies/views and checks the counts.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestEngagementStatsEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	h := &API{pool: pool, queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/stats/engagement", h.EngagementStats)
+
+	type counts struct {
+		Saved   int `json:"saved"`
+		Applied int `json:"applied"`
+		Viewed  int `json:"viewed"`
+	}
+	type envelope struct {
+		Data counts `json:"data"`
+	}
+	get := func() counts {
+		t.Helper()
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/api/v1/stats/engagement", nil))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("status = %d, want 200 (public, unauthenticated read)", resp.StatusCode)
+		}
+		var env envelope
+		if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return env.Data
+	}
+
+	// --- Empty table: all zeros ------------------------------------------------
+	if c := get(); c.Saved != 0 || c.Applied != 0 || c.Viewed != 0 {
+		t.Fatalf("empty table: got %+v, want all zeros", c)
+	}
+
+	// --- Seed a user + jobs + interactions -------------------------------------
+	var uid int64
+	if err := pool.QueryRow(ctx,
+		`INSERT INTO users (email) VALUES ('u@example.test') RETURNING id`).Scan(&uid); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	jobID := func(ext string) int64 {
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug)
+			 VALUES ('test', $1, 'http://example.test', 'J', $1) RETURNING id`, ext).Scan(&id); err != nil {
+			t.Fatalf("seed job %q: %v", ext, err)
+		}
+		return id
+	}
+	j1, j2, j3 := jobID("j1"), jobID("j2"), jobID("j3")
+
+	// j1: viewed only; j2: viewed + saved; j3: viewed + applied.
+	// Expected: saved=1, applied=1, viewed=3 (viewed_at is set on every row).
+	seedInteraction := func(jid int64, saved, applied bool) {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO user_jobs (user_id, job_id, viewed_at, saved_at, applied_at)
+			 VALUES ($1, $2, now(),
+			         CASE WHEN $3 THEN now() END,
+			         CASE WHEN $4 THEN now() END)`,
+			uid, jid, saved, applied); err != nil {
+			t.Fatalf("seed interaction job=%d: %v", jid, err)
+		}
+	}
+	seedInteraction(j1, false, false)
+	seedInteraction(j2, true, false)
+	seedInteraction(j3, false, true)
+
+	if c := get(); c.Saved != 1 || c.Applied != 1 || c.Viewed != 3 {
+		t.Errorf("got %+v, want {Saved:1 Applied:1 Viewed:3}", c)
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -287,6 +287,11 @@ func Register(app *fiber.App, cfg Config) {
 	// bar chart. Aggregate-only — no user identifier is exposed.
 	api.Get("/stats/user-growth", a.UserGrowth)
 
+	// Public engagement counts (jobs saved / applied / viewed across all users),
+	// unauthenticated like the other public reads. Aggregate-only from user_jobs;
+	// the /open transparency page renders them as a stat-strip.
+	api.Get("/stats/engagement", a.EngagementStats)
+
 	// Per-user job interactions and the user-scoped reads accept either the
 	// session cookie or an API key (RequireAuthOrKey), so a script holding a key
 	// can drive the same flow as the browser. The public job reads above stay

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -120,6 +120,21 @@ func (a *API) UserGrowth(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": points})
 }
 
+// EngagementStats serves the public, unauthenticated engagement counts: how many
+// user_jobs rows have been saved, applied to, and viewed. Aggregate-only — the
+// query selects nothing but the three integer totals, so no per-user field can
+// leak. An empty table yields all zeros (200).
+func (a *API) EngagementStats(c *fiber.Ctx) error {
+	s, err := a.queries.GetEngagementStats(c.Context())
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{
+		"data": fiber.Map{"saved": s.Saved, "applied": s.Applied, "viewed": s.Viewed},
+	})
+}
+
 // JobsActivity serves the public, unauthenticated job-activity time series:
 // added vs. removed vacancies per period, aggregated to the requested granularity
 // over a date range. The dense, gap-free series (missing periods → 0) is produced

--- a/openspec/changes/open-engagement-stats/tasks.md
+++ b/openspec/changes/open-engagement-stats/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Backend — engagement endpoint (engagement-stats)
 
-- [ ] 1.1 Add a `GetEngagementStats :one` query to `internal/db/queries/stats.sql` — `count(*) FILTER (WHERE saved_at/applied_at/viewed_at IS NOT NULL)::int` over `user_jobs`; run `make sqlc` and commit the generated code
-- [ ] 1.2 Add an `EngagementStats` handler in `internal/handler/stats.go` (a `UserGrowth` sibling) returning `{"data": {"saved","applied","viewed"}}`; aggregate-only, no PII
-- [ ] 1.3 Wire `GET /stats/engagement` in `handler.Register` as an unauthenticated public read next to `/stats/user-growth`
-- [ ] 1.4 Integration test: seeded saves/applies/views produce the expected counts; empty table → all zeros; public (no auth) 200
+- [x] 1.1 Add a `GetEngagementStats :one` query to `internal/db/queries/stats.sql` — `count(*) FILTER (WHERE saved_at/applied_at/viewed_at IS NOT NULL)::int` over `user_jobs`; run `make sqlc` and commit the generated code
+- [x] 1.2 Add an `EngagementStats` handler in `internal/handler/stats.go` (a `UserGrowth` sibling) returning `{"data": {"saved","applied","viewed"}}`; aggregate-only, no PII
+- [x] 1.3 Wire `GET /stats/engagement` in `handler.Register` as an unauthenticated public read next to `/stats/user-growth`
+- [x] 1.4 Integration test: seeded saves/applies/views produce the expected counts; empty table → all zeros; public (no auth) 200
 
 ## 2. Frontend — API client + /open section
 
-- [ ] 2.1 Add an `EngagementStats` type and `api.engagementStats()` in `web/src/lib/api.ts` / types, mirroring `userGrowth`
-- [ ] 2.2 Add an `engagement` best-effort leg to `/open/+page.server.ts`'s `Promise.allSettled` fan-out
-- [ ] 2.3 Add an "Engagement" stat-strip section to `/open/+page.svelte` (jobs saved · applications · jobs viewed), each figure linking to `/api/v1/stats/engagement`; render a fallback when the slice is null
+- [x] 2.1 Add an `EngagementStats` type and `api.engagementStats()` in `web/src/lib/api.ts` / types, mirroring `userGrowth`
+- [x] 2.2 Add an `engagement` best-effort leg to `/open/+page.server.ts`'s `Promise.allSettled` fan-out
+- [x] 2.3 Add an "Engagement" stat-strip section to `/open/+page.svelte` (jobs saved · applications · jobs viewed), each figure linking to `/api/v1/stats/engagement`; render a fallback when the slice is null
 
 ## 3. Verification
 
-- [ ] 3.1 `go build ./... && go vet ./... && go test ./...` and `npm run check` pass; load `/open` against the live API and confirm the Engagement section renders (and degrades when the endpoint is unreachable)
+- [x] 3.1 `go build ./... && go vet ./... && go test ./...` and `npm run check` pass; load `/open` against the live API and confirm the Engagement section renders (and degrades when the endpoint is unreachable)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -43,6 +43,7 @@ import type {
   ActivityGranularity,
   ActivityPoint,
   UserGrowthPoint,
+  EngagementStats,
   LocationPreferences,
 } from './types';
 
@@ -342,6 +343,12 @@ export function createApi(
    *  Aggregate-only — no user field is exposed. Unauthenticated. */
   async function userGrowth(): Promise<UserGrowthPoint[]> {
     return requestData<UserGrowthPoint[]>(`/api/v1/stats/user-growth`);
+  }
+
+  /** Aggregate engagement counts (jobs saved / applied / viewed across all users).
+   *  Aggregate-only, unauthenticated. */
+  async function engagementStats(): Promise<EngagementStats> {
+    return requestData<EngagementStats>(`/api/v1/stats/engagement`);
   }
 
   /** List companies, optionally filtered by a name query `q` (a case-insensitive
@@ -858,6 +865,7 @@ export function createApi(
     facetCounts,
     jobsActivity,
     userGrowth,
+    engagementStats,
     listCompanies,
     getCompany,
     listCompanySubindustries,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -295,6 +295,14 @@ export interface UserGrowthPoint {
   total: number;
 }
 
+/** Aggregate engagement counts across all users: jobs saved, applications marked,
+ *  and jobs viewed. Aggregate-only — no per-user or row-level field. */
+export interface EngagementStats {
+  saved: number;
+  applied: number;
+  viewed: number;
+}
+
 /** An API key as returned by the management endpoints — metadata only; the
  *  plaintext token is never part of this shape. `token_prefix` is a short,
  *  non-secret leading slice (e.g. "fhk_Ab12cd") shown so the user can tell keys

--- a/web/src/routes/open/+page.server.ts
+++ b/web/src/routes/open/+page.server.ts
@@ -61,12 +61,13 @@ async function fetchGithub(fetchImpl: typeof fetch): Promise<GithubStats | null>
 
 export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
   const api = serverApi(fetch);
-  const [jobs, companies, activity, facets, growth, github] = await Promise.allSettled([
+  const [jobs, companies, activity, facets, growth, engagement, github] = await Promise.allSettled([
     api.listJobs(1, 0),
     api.listCompanies('', 1, 0),
     api.jobsActivity('day'),
     api.facetCounts(new URLSearchParams()),
     api.userGrowth(),
+    api.engagementStats(),
     fetchGithub(fetch),
   ]);
 
@@ -84,6 +85,7 @@ export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
     activity: value(activity) ?? [],
     facets: value(facets)?.facets ?? null,
     growth: value(growth) ?? [],
+    engagement: value(engagement),
     github: value(github),
   };
 };

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -65,6 +65,16 @@
     const last = data.growth[data.growth.length - 1];
     return last ? last.total : null;
   });
+
+  const engagement = $derived.by(() => {
+    const e = data.engagement;
+    if (!e) return null;
+    return [
+      { value: nf.format(e.saved), label: 'jobs saved' },
+      { value: nf.format(e.applied), label: 'applications' },
+      { value: nf.format(e.viewed), label: 'jobs viewed' },
+    ];
+  });
 </script>
 
 {#snippet distributionBars(items: Bar[])}
@@ -156,6 +166,30 @@
       Cumulative registered members over time. Early days — and that's the point of showing it.
     </p>
     <GrowthArea points={data.growth} />
+  </section>
+
+  <!-- Engagement -->
+  <section class="mb-14">
+    <div class="flex items-baseline justify-between">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// engagement</p>
+      {@render sourceLink('/api/v1/stats/engagement', '/stats/engagement')}
+    </div>
+    <h2 class="mt-3 text-xl font-semibold tracking-tight">What people do here</h2>
+    <p class="mb-6 mt-1 text-sm text-muted-foreground">
+      Signed-in interactions across freehire — jobs saved, applications tracked, and postings opened.
+    </p>
+    {#if engagement}
+      <dl class="grid grid-cols-3 gap-px overflow-hidden rounded-xl border border-border bg-border">
+        {#each engagement as e (e.label)}
+          <div class="bg-background p-5 sm:p-6">
+            <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{e.label}</dt>
+            <dd class="mt-2 text-3xl font-semibold tracking-tight tabular-nums sm:text-4xl">{e.value}</dd>
+          </div>
+        {/each}
+      </dl>
+    {:else}
+      <p class="text-sm text-muted-foreground">Engagement data is unavailable right now.</p>
+    {/if}
   </section>
 
   <!-- C. What's inside -->


### PR DESCRIPTION
## What

Extends the `/open` transparency page with an **Engagement** section — how many jobs people have **saved**, **applied** to, and **viewed** — backed by a new public endpoint. No new instrumentation: the data already lives in `user_jobs`.

Planned in `openspec/changes/open-engagement-stats`. Follows the `user-growth-stats` pattern.

## Backend — new capability `engagement-stats`
- `GET /api/v1/stats/engagement`: `count(*) FILTER (WHERE saved_at/applied_at/viewed_at IS NOT NULL)` over `user_jobs` → `{"data":{"saved","applied","viewed"}}`. **Aggregate-only, no PII.** Empty table → all zeros. `make sqlc` regenerated.
- `EngagementStats` handler (a `UserGrowth` sibling) + public route wiring.
- Integration test: empty → zeros; seeded 1 saved / 1 applied / 3 viewed → `{1,1,3}`.

## Frontend
- `api.engagementStats()` + `EngagementStats` type.
- `/open/+page.server.ts` gains a best-effort `engagement` leg in the `Promise.allSettled` fan-out.
- New Engagement stat-strip section (jobs saved · applications · jobs viewed), each linking to the endpoint; renders a fallback when the slice is null.

## Deferred (by decision)
Counting **search queries** — needs new write-path instrumentation on the hot `/jobs/search` endpoint (and would count bots). Tracked separately.

## Verification
- `go build/vet/test` + `npm run check` clean (2 pre-existing `JobFitFull` warnings).
- `/open` rendered against the live API — Engagement section **best-effort degradation confirmed** (endpoint 404s pre-deploy → "unavailable", page whole); Members chart now populated (168, live `user-growth`).
- ⚠️ Integration test compiles but not executed locally (no Docker) — runs in CI.

## Deploy
Endpoint safe ahead of the page. No migration, env, or worker.