### PR TITLE
fix(header): revalidate GitHub star count (was stuck behind a 6h cache)

### DIFF
--- a/web/src/lib/github.svelte.ts
+++ b/web/src/lib/github.svelte.ts
@@ -1,16 +1,16 @@
 import { browser } from '$app/environment';
 
-// Live GitHub star count for the repo, rendered as a header badge. Fetched once
-// per session on first mount and cached in localStorage for a few hours, so we
-// never hammer the unauthenticated API (60 req/h per IP) — a stale-but-instant
-// number beats a spinner, and on any failure the badge just drops the number
-// (the icon link still works). SSR-safe: every browser API is `browser`-guarded.
+// Live GitHub star count for the repo, rendered as a header badge. Stale-while-
+// revalidate: the cached value paints instantly, then the API is re-fetched once
+// per page load so a changed count can't get stuck behind a long cache — one
+// request per load stays well under the unauthenticated limit (60 req/h per IP),
+// and on any failure the badge keeps the cached number (the icon link still
+// works). SSR-safe: every browser API is `browser`-guarded.
 
 const REPO = 'strelov1/freehire';
 export const GITHUB_URL = `https://github.com/${REPO}`;
 
 const CACHE_KEY = 'hire.gh_stars';
-const TTL_MS = 6 * 60 * 60 * 1000; // 6h
 
 type Cached = { count: number; at: number };
 
@@ -40,17 +40,14 @@ class GithubStarsStore {
   count = $state<number | null>(null);
   private started = false;
 
-  /** Populate the star count: instant from cache, then refreshed from the API
-   *  when the cache is stale. Idempotent — safe to call from every mount. */
+  /** Populate the star count: instant from cache, then always revalidated from
+   *  the API. Idempotent — the fetch runs at most once per page load. */
   async load() {
     if (!browser || this.started) return;
     this.started = true;
 
     const cached = readCache();
-    if (cached) {
-      this.count = cached.count;
-      if (Date.now() - cached.at < TTL_MS) return; // fresh enough, skip the fetch
-    }
+    if (cached) this.count = cached.count; // instant paint; revalidate below
 
     try {
       const res = await fetch(`https://api.github.com/repos/${REPO}`, {


### PR DESCRIPTION
The star badge (`github.svelte.ts`) returned early whenever a localStorage cache entry was under 6h old, skipping the API fetch entirely — so a changed count stayed stuck (reported: **41** while the repo is at **61**), and only on devices holding a stale cache (mobile, with no cache, showed the fresh number). 

Switched to **stale-while-revalidate**: paint the cached value instantly, then always re-fetch once per page load (one request per load, well under the 60/h unauthenticated limit; failures keep the cached value). `svelte-check` 0 errors.