### PR TITLE
feat(linksource): generic ld+json resolver + cmd/resolve-url (ingest a job by URL)

### DIFF
--- a/cmd/resolve-url/main.go
+++ b/cmd/resolve-url/main.go
@@ -1,0 +1,151 @@
+// Command resolve-url ingests individual job postings by URL. It is the on-demand
+// counterpart to the board crawlers: some vacancies live only as a single detail page
+// that no board feed enumerates (a Teamtailor custom-domain site with an empty listing,
+// a Breezy private-link posting), so a board entry cannot reach them. resolve-url takes
+// one or more job URLs (as arguments or on stdin), resolves each through the same
+// internal/linksource registry the Telegram link-following uses — the per-ATS adapters
+// first (greenhouse/ashby/lever/workable/... read the platform's public API), then a
+// last-resort generic resolver that maps any page carrying a schema.org JobPosting
+// ld+json block — and upserts each resolved job through the canonical UpsertJob (+
+// enrichment enqueue), exactly as ingest and tg-extract do.
+//
+// Run once and exit (an operator tool, not a cron worker): needs DATABASE_URL.
+//
+//	go run ./cmd/resolve-url https://careers.vairix.com/jobs/605143-... https://tekton-labs.breezy.hr/p/...
+package main
+
+import (
+	"bufio"
+	"context"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/job"
+	"github.com/strelov1/freehire/internal/jobhash"
+	"github.com/strelov1/freehire/internal/linksource"
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+func main() { worker.Main(run) }
+
+func run() int {
+	urls := readURLs()
+	if len(urls) == 0 {
+		log.Print("resolve-url: no URLs given (pass them as arguments or on stdin, one per line)")
+		return 1
+	}
+
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+	q := db.New(pool)
+
+	// The generic resolver is appended AFTER the host-scoped adapters (so a known ATS is
+	// handled by its richer API adapter) and only here, never in the shared registry —
+	// its always-true Match must not leak into the Telegram crawl.
+	client := sources.NewClient()
+	reg := append(linksource.All(client), linksource.NewGeneric(client))
+
+	resolved, err := linksource.ResolveLinks(ctx, reg, urls)
+	if err != nil {
+		// Non-nil only when links matched but all failed — a transient outcome.
+		log.Printf("resolve-url: %v", err)
+		return 1
+	}
+	if len(resolved) == 0 {
+		log.Printf("resolve-url: none of the %d URL(s) resolved to a vacancy", len(urls))
+		return 1
+	}
+
+	var saved, failed int
+	for _, r := range resolved {
+		if err := upsert(ctx, pool, q, r); err != nil {
+			failed++
+			log.Printf("resolve-url: %s/%s: %v", r.Source, r.Job.ExternalID, err)
+			continue
+		}
+		saved++
+		log.Printf("resolve-url: saved %s — %q at %s", r.Source, r.Job.Title, r.Job.Company)
+	}
+	log.Printf("resolve-url: done — %d saved, %d failed, %d of %d URL(s) resolved",
+		saved, failed, len(resolved), len(urls))
+	if failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+// upsert writes one resolved job through the Job aggregate factory and the canonical
+// UpsertJob, enqueuing it for enrichment in the same transaction — the same write path as
+// ingest and tg-extract, so facets, slugs and the enrichment outbox stay consistent.
+func upsert(ctx context.Context, pool *pgxpool.Pool, q *db.Queries, r linksource.Resolved) error {
+	j, err := job.New(job.Draft{
+		Source:      r.Source,
+		ExternalID:  r.Job.ExternalID,
+		URL:         r.Job.URL,
+		Title:       r.Job.Title,
+		Company:     r.Job.Company,
+		Location:    r.Job.Location,
+		Remote:      r.Job.Remote,
+		Description: r.Job.Description,
+		WorkMode:    r.Job.WorkMode,
+	})
+	if err != nil {
+		return err
+	}
+	params := j.Fields().UpsertParams()
+	if r.Job.PostedAt != nil {
+		params.PostedAt = pgtype.Timestamptz{Time: *r.Job.PostedAt, Valid: true}
+	}
+	params.RoleFingerprint = pgtype.Text{String: jobhash.RoleFingerprint(params), Valid: true}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	qtx := q.WithTx(tx)
+	res, err := qtx.UpsertJob(ctx, params)
+	if err != nil {
+		return err
+	}
+	if _, err := qtx.EnqueueJobEnrichment(ctx, db.EnqueueJobEnrichmentParams{
+		TargetVersion:     int32(enrich.Version),
+		JobID:             res.Job.ID,
+		ExcludeCategories: enrich.NonTechCategories,
+	}); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// readURLs collects job URLs from the command line, falling back to stdin (one per line,
+// blank lines ignored) so a list can be piped in.
+func readURLs() []string {
+	var urls []string
+	for _, a := range os.Args[1:] {
+		if a = strings.TrimSpace(a); a != "" && !strings.HasPrefix(a, "-") {
+			urls = append(urls, a)
+		}
+	}
+	if len(urls) > 0 {
+		return urls
+	}
+	sc := bufio.NewScanner(os.Stdin)
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" {
+			urls = append(urls, line)
+		}
+	}
+	return urls
+}

--- a/internal/linksource/generic.go
+++ b/internal/linksource/generic.go
@@ -1,0 +1,87 @@
+package linksource
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// generic resolves any server-rendered job page that carries a top-level schema.org
+// JobPosting ld+json block. Unlike the per-ATS adapters it is NOT host-scoped — it
+// matches any http(s) URL and relies on the presence of a JobPosting block to decide
+// whether the page is a single vacancy (ok=false when absent). It is therefore the
+// last-resort resolver: callers put it AFTER the specific adapters so a known ATS is
+// still handled by its richer API-based adapter, and generic only catches the rest
+// (e.g. Teamtailor custom domains, Breezy private-link postings) that no board feed
+// enumerates.
+//
+// It is deliberately kept OUT of the shared All() registry: its always-true Match would
+// make the Telegram crawl treat every outbound link as a vacancy. Only the operator-run
+// cmd/resolve-url appends it, where the URL is a deliberate, trusted input.
+type generic struct {
+	http Client
+}
+
+// NewGeneric builds the last-resort JobPosting-ld+json link resolver.
+func NewGeneric(c Client) Source { return generic{http: c} }
+
+// Source is a fixed provenance tag for hand-imported links. It is not in sources.All, so
+// these jobs are treated as orphans by the liveness worker (URL-probed and closed when
+// dead) — the right lifecycle for a one-off posting that has no board to re-crawl it.
+func (generic) Source() string { return "weblink" }
+
+// Match accepts any absolute http(s) URL. The real gate is Resolve finding a JobPosting
+// block, so a non-vacancy page returns ok=false rather than a bogus job.
+func (generic) Match(u *url.URL) bool {
+	return u != nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+// genericPosting selects only string-typed JobPosting fields. Declaring nothing whose
+// schema.org shape varies (jobLocation may be an object OR an array; addressCountry may
+// be a string OR an object) keeps json.Unmarshal from failing on a shape mismatch and
+// dropping an otherwise-valid posting — LDJobPosting requires the whole decode to succeed.
+// Geography is left to enrichment, which fills countries/regions for tech jobs anyway.
+type genericPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+}
+
+// Resolve fetches the page and maps its JobPosting ld+json. ok=false (no error) when the
+// page has no JobPosting block or lacks a title/company — it is simply not a vacancy we
+// can store. The canonical id is the final URL without query/fragment, so re-importing
+// the same posting (or a tracking-tagged copy of it) dedups on (weblink, that URL).
+func (g generic) Resolve(ctx context.Context, raw string) (sources.Job, bool, error) {
+	node, final, err := g.http.GetHTMLResolved(ctx, raw)
+	if err != nil {
+		return sources.Job{}, false, err
+	}
+	var p genericPosting
+	if !sources.LDJobPosting(node, &p) {
+		return sources.Job{}, false, nil // not a JobPosting page — skip, not an error
+	}
+	if p.Title == "" || p.HiringOrganization.Name == "" {
+		return sources.Job{}, false, nil // missing the minimum identity to store
+	}
+
+	canonical := final
+	if fu, err := url.Parse(final); err == nil {
+		fu.RawQuery = ""
+		fu.Fragment = ""
+		canonical = fu.String()
+	}
+	return sources.Job{
+		ExternalID:  canonical,
+		URL:         canonical,
+		Title:       p.Title,
+		Company:     p.HiringOrganization.Name,
+		Description: sources.SanitizeHTML(p.Description),
+		Remote:      isTelecommute(p.JobLocationType),
+		PostedAt:    sources.ParseDate(p.DatePosted),
+	}, true, nil
+}

--- a/internal/linksource/generic_test.go
+++ b/internal/linksource/generic_test.go
@@ -1,0 +1,83 @@
+package linksource
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// genericJobHTML is a top-level JobPosting ld+json block as Teamtailor/Breezy detail
+// pages server-render it: a clean title/company, a TELECOMMUTE location type, and an
+// HTML description with an entity and an embedded script to strip.
+const genericJobHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Senior Backend Engineer (Java / Go)",
+ "datePosted":"2026-07-01",
+ "jobLocationType":"TELECOMMUTE",
+ "description":"<p>Build &amp; scale.</p><script>evil()<\/script>",
+ "hiringOrganization":{"@type":"Organization","name":"Vairix"}}
+</script></head><body></body></html>`
+
+// a listing/search page with no JobPosting block.
+const genericListingHTML = `<html><head>
+<script type="application/ld+json">{"@type":"WebSite","name":"Careers"}</script>
+</head><body></body></html>`
+
+func TestGenericMatch(t *testing.T) {
+	g := NewGeneric(nil)
+	for _, raw := range []string{"https://careers.vairix.com/jobs/605143-x", "http://tekton-labs.breezy.hr/p/abc"} {
+		u, _ := url.Parse(raw)
+		if !g.Match(u) {
+			t.Errorf("Match(%s) = false, want true", raw)
+		}
+	}
+	for _, raw := range []string{"ftp://x/y", "mailto:a@b.c", "/relative/path"} {
+		u, _ := url.Parse(raw)
+		if g.Match(u) {
+			t.Errorf("Match(%s) = true, want false", raw)
+		}
+	}
+}
+
+func TestGenericResolvesJobPosting(t *testing.T) {
+	const link = "https://careers.vairix.com/jobs/605143-senior-backend?utm_source=x#apply"
+	c := (&fakeClient{}).route("/jobs/605143", genericJobHTML, "")
+
+	job, ok, err := NewGeneric(c).Resolve(context.Background(), link)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !ok {
+		t.Fatal("ok=false, want the vacancy resolved")
+	}
+	// The canonical id/URL drops the query and fragment so a tracking-tagged copy dedups.
+	const want = "https://careers.vairix.com/jobs/605143-senior-backend"
+	if job.ExternalID != want || job.URL != want {
+		t.Errorf("id/url = %q / %q, want %q", job.ExternalID, job.URL, want)
+	}
+	if !strings.Contains(job.Title, "Senior Backend Engineer") {
+		t.Errorf("Title = %q", job.Title)
+	}
+	if job.Company != "Vairix" {
+		t.Errorf("Company = %q, want Vairix", job.Company)
+	}
+	if !job.Remote {
+		t.Error("Remote = false, want true (TELECOMMUTE)")
+	}
+	if strings.Contains(job.Description, "<script>") || !strings.Contains(job.Description, "Build &amp; scale.") {
+		t.Errorf("Description not sanitized/decoded: %q", job.Description)
+	}
+}
+
+func TestGenericSkipsNonVacancy(t *testing.T) {
+	c := (&fakeClient{}).route("/jobs", genericListingHTML, "")
+	_, ok, err := NewGeneric(c).Resolve(context.Background(), "https://acme.com/jobs")
+	if err != nil {
+		t.Fatalf("Resolve: unexpected error %v", err)
+	}
+	if ok {
+		t.Error("ok=true, want false for a page with no JobPosting block")
+	}
+}


### PR DESCRIPTION
## Why

A coverage audit turned up postings that **no board feed can reach**: a Teamtailor custom-domain site whose `/jobs` listing is empty (Vairix), a Breezy private-link posting whose `/json` is empty (Tekton Labs). The vacancy exists only as a single detail page. Adding a board entry does nothing — the listing the adapter crawls is empty. The only way to ingest these (and any future one-off URL a user pastes) is to resolve the single URL.

## What

- **`internal/linksource/generic.go`** — a last-resort `Source` that matches any `http(s)` URL and maps a page's top-level `schema.org` `JobPosting` ld+json into a `sources.Job`. Source tag `weblink` (so the liveness worker treats these as orphans to URL-probe and close when dead — the right lifecycle for a posting with no board to re-crawl it). Canonical id = final URL without query/fragment, so a tracking-tagged re-import dedups.
  - Declares only string-typed ld+json fields, so a shape-varying `jobLocation`/`addressCountry` can't fail the strict `LDJobPosting` decode and drop a valid posting; geography is left to enrichment.
  - **Deliberately not in the shared `All()` registry** — its always-true `Match` would make the Telegram crawl follow every outbound link. Only `cmd/resolve-url` appends it.
- **`cmd/resolve-url`** — operator worker: takes job URLs (args or stdin), resolves each through the per-ATS adapters first (greenhouse/ashby/lever/workable/… read the platform API) then the generic resolver, and upserts via the canonical `UpsertJob` + enrichment enqueue — same write path as ingest/tg-extract.

## Verification

- `go build ./... && go vet ./... && go test ./internal/linksource/` green; new `generic_test.go` covers match scope, resolve+sanitize+canonicalization, and non-vacancy skip.
- Live-resolved both target URLs end to end:
  - Vairix → *Senior Backend Engineer (Java / Go + AI-Driven Development)*, remote
  - Tekton Labs → *AI Engineer – Agentes Conversacionales & GenAI Workflows*, remote

## Usage

```
go run ./cmd/resolve-url https://careers.vairix.com/jobs/605143-... https://tekton-labs.breezy.hr/p/8cd5eafe4ae6-...
# or: printf '%s\n' url1 url2 | go run ./cmd/resolve-url
```

Run on host-2 to actually ingest the two postings (needs `DATABASE_URL`).