### PR TITLE
Revert to 6h-cached GitHub star count

### DIFF
--- a/web/src/lib/github.svelte.ts
+++ b/web/src/lib/github.svelte.ts
@@ -1,16 +1,16 @@
 import { browser } from '$app/environment';
 
-// Live GitHub star count for the repo, rendered as a header badge. Stale-while-
-// revalidate: the cached value paints instantly, then the API is re-fetched once
-// per page load so a changed count can't get stuck behind a long cache — one
-// request per load stays well under the unauthenticated limit (60 req/h per IP),
-// and on any failure the badge keeps the cached number (the icon link still
-// works). SSR-safe: every browser API is `browser`-guarded.
+// Live GitHub star count for the repo, rendered as a header badge. Fetched once
+// per session on first mount and cached in localStorage for a few hours, so we
+// never hammer the unauthenticated API (60 req/h per IP) — a stale-but-instant
+// number beats a spinner, and on any failure the badge just drops the number
+// (the icon link still works). SSR-safe: every browser API is `browser`-guarded.
 
 const REPO = 'strelov1/freehire';
 export const GITHUB_URL = `https://github.com/${REPO}`;
 
 const CACHE_KEY = 'hire.gh_stars';
+const TTL_MS = 6 * 60 * 60 * 1000; // 6h
 
 type Cached = { count: number; at: number };
 
@@ -40,14 +40,17 @@ class GithubStarsStore {
   count = $state<number | null>(null);
   private started = false;
 
-  /** Populate the star count: instant from cache, then always revalidated from
-   *  the API. Idempotent — the fetch runs at most once per page load. */
+  /** Populate the star count: instant from cache, then refreshed from the API
+   *  when the cache is stale. Idempotent — safe to call from every mount. */
   async load() {
     if (!browser || this.started) return;
     this.started = true;
 
     const cached = readCache();
-    if (cached) this.count = cached.count; // instant paint; revalidate below
+    if (cached) {
+      this.count = cached.count;
+      if (Date.now() - cached.at < TTL_MS) return; // fresh enough, skip the fetch
+    }
 
     try {
       const res = await fetch(`https://api.github.com/repos/${REPO}`, {


### PR DESCRIPTION
Reverts #702. Restores the original stale-while-cache behaviour: the star badge caches the count in localStorage for 6h and skips the API fetch while fresh. Per request — the per-load revalidation is not wanted; the 6h cache is fine.