### PR TITLE
fix(linksource): HTML-unescape ld+json description in generic resolver

### DIFF
--- a/internal/linksource/generic.go
+++ b/internal/linksource/generic.go
@@ -2,6 +2,7 @@ package linksource
 
 import (
 	"context"
+	"html"
 	"net/url"
 
 	"github.com/strelov1/freehire/internal/sources"
@@ -80,7 +81,13 @@ func (g generic) Resolve(ctx context.Context, raw string) (sources.Job, bool, er
 		URL:         canonical,
 		Title:       p.Title,
 		Company:     p.HiringOrganization.Name,
-		Description: sources.SanitizeHTML(p.Description),
+		// Unescape BEFORE sanitizing: some ATSes (Teamtailor) entity-encode the HTML
+		// inside the ld+json string (`&lt;p&gt;…`), so without a decode the sanitizer
+		// sees plain text and stores literal tags that render broken under {@html}.
+		// Decoding first also turns an entity-encoded `&lt;script&gt;` into a real one
+		// the sanitizer then strips — the same order the teamtailor/breezy board
+		// adapters use, so it is both correct and safe.
+		Description: sources.SanitizeHTML(html.UnescapeString(p.Description)),
 		Remote:      isTelecommute(p.JobLocationType),
 		PostedAt:    sources.ParseDate(p.DatePosted),
 	}, true, nil

--- a/internal/linksource/generic_test.go
+++ b/internal/linksource/generic_test.go
@@ -71,6 +71,34 @@ func TestGenericResolvesJobPosting(t *testing.T) {
 	}
 }
 
+// entityEncodedJobHTML mirrors a Teamtailor detail page whose ld+json description is
+// HTML-entity-encoded (`&lt;p&gt;…`) — including an entity-encoded <script>. The resolver
+// must decode it before sanitizing, so the stored markup is real HTML (not literal tags
+// that render broken under {@html}) and the decoded script is still stripped.
+const entityEncodedJobHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Senior Backend Engineer","hiringOrganization":{"name":"Vairix"},
+ "description":"&lt;p&gt;We build &lt;strong&gt;distributed systems&lt;/strong&gt;.&lt;/p&gt;&lt;script&gt;evil()&lt;/script&gt;"}
+</script></head><body></body></html>`
+
+func TestGenericDecodesEntityEncodedDescription(t *testing.T) {
+	c := (&fakeClient{}).route("/jobs/1", entityEncodedJobHTML, "")
+	job, ok, err := NewGeneric(c).Resolve(context.Background(), "https://careers.vairix.com/jobs/1-x")
+	if err != nil || !ok {
+		t.Fatalf("Resolve: ok=%v err=%v", ok, err)
+	}
+	if strings.Contains(job.Description, "&lt;") {
+		t.Errorf("description kept literal entities (not decoded): %q", job.Description)
+	}
+	if !strings.Contains(job.Description, "<strong>distributed systems</strong>") {
+		t.Errorf("description lost its real markup after decode+sanitize: %q", job.Description)
+	}
+	if strings.Contains(job.Description, "evil") {
+		t.Errorf("decoded <script> was not stripped: %q", job.Description)
+	}
+}
+
 func TestGenericSkipsNonVacancy(t *testing.T) {
 	c := (&fakeClient{}).route("/jobs", genericListingHTML, "")
 	_, ok, err := NewGeneric(c).Resolve(context.Background(), "https://acme.com/jobs")


### PR DESCRIPTION
The Vairix job page rendered broken HTML: Teamtailor entity-encodes the HTML inside the JobPosting ld+json string (`&lt;p&gt;…`), and the generic resolver sanitized without decoding first, so it stored literal `&lt;p&gt;` tags that render as raw text under `{@html}`. Fix: `SanitizeHTML(html.UnescapeString(desc))`, mirroring the teamtailor/breezy board adapters — decoding first also turns an entity-encoded `<script>` into a real one the sanitizer strips (safe). Adds a regression test. Verified live-resolving Vairix now yields clean `<p>…<strong>…` markup.