### PR TITLE
feat(sources): add 26 more LATAM/remote engineering boards (batch 2)

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -1517,6 +1517,8 @@
   board: palmettocleantech
 - company: PandaDoc
   board: pandadoc
+- company: Pandvil
+  board: pandvil
 - company: Panic Button
   board: panicbutton
 - company: Parachute Health

--- a/sources/oracle.yml
+++ b/sources/oracle.yml
@@ -62,6 +62,8 @@
   board: ebhu.fa.us2.oraclecloud.com/CX
 - company: Chubb
   board: fa-ewgu-saasfaprod1.fa.ocs.oraclecloud.com/CX_2001
+- company: Ciklum
+  board: ialmme.fa.ocs.oraclecloud.com/ciklum-career
 - company: Citco
   board: fa-euxc-saasfaprod1.fa.ocs.oraclecloud.com/CX_1
 - company: Citizens Financial Group

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -415,6 +415,8 @@
   board: servicenow
 - company: Sigma Software
   board: sigmasoftware2
+- company: Sigma Software
+  board: SigmaSoftware2
 - company: Sika Group
   board: SikaAG
 - company: Skeleton key

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3,18 +3,38 @@
 # reads https://<board>/jobs and follows pagination, then each job page's JobPosting ld+json.
 # Each board validated live (>0 jobs in its listing, full normalized sample) before adding.
 
+- company: Arrive Logistics
+  board: careers.arrive.com
 - company: BRYTER
   board: bryter.teamtailor.com
+- company: Insense
+  board: insense.na.teamtailor.com
 - company: ioet
   board: ioet.na.teamtailor.com
+- company: Knowmad Mood
+  board: knowmadmood.teamtailor.com
 - company: Latino Legends
   board: talent.latinolegends.com
+- company: Loft
+  board: loft.teamtailor.com
+- company: Marvik
+  board: marvik.na.teamtailor.com
 - company: Naranja X
   board: naranjax.na.teamtailor.com
+- company: Opinov8
+  board: jobs.opinov8.com
 - company: Periferia IT Group
   board: jobs.periferiaitgroup.com
+- company: Product Hackers
+  board: producthackers.teamtailor.com
 - company: Prometeo Talent
   board: jobs.prometeotalent.com
+- company: Rooftop
+  board: rooftop.na.teamtailor.com
+- company: Sofka
+  board: oportunidades.sofka.com.co
+- company: TalyCap Global
+  board: jobs.talycapglobal.com
 - company: Tibber
   board: jobs.tibber.com
 
@@ -64,6 +84,8 @@
   board: tacticaladventures.teamtailor.com
 - company: Tangle Wood Games
   board: tanglewoodgameslive-1744291072.teamtailor.com
+- company: Tightline Software
+  board: careers.tightlinesoftware.com
 - company: Tried and True Media
   board: triedandtruemedia.na.teamtailor.com
 - company: Venoeer

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -7,6 +7,8 @@
   board: abzorbagames
 - company: Antarctica Global
   board: antarcticaglobal
+- company: AOA
+  board: helloaoa
 - company: Arkadium
   board: arkadium-1
 - company: Axes InMotion
@@ -39,6 +41,8 @@
   board: datavisor-jobs
 - company: Detroit Labs
   board: detroitlabs
+- company: Dev.Pro
+  board: devpro
 - company: Devoted Studios
   board: devoted-studios-1
 - company: Devsu
@@ -75,6 +79,8 @@
   board: hardsuit-labs-1
 - company: High Voltage Software
   board: high-voltage-software
+- company: Hire Overseas
+  board: hire-overseas
 - company: Homa Games
   board: homa-games
 - company: Hugging Face
@@ -95,6 +101,8 @@
   board: kingsisle-entertainment-inc
 - company: Lakshya Digital
   board: lakshyadigitalglobal
+- company: Legacy People
+  board: legacypeople
 - company: Lighthouse Games
   board: lighthousegames
 - company: Liquid Advertising
@@ -111,6 +119,8 @@
   board: followloop
 - company: Magic Media
   board: magic-media
+- company: Maxana
+  board: maxana
 - company: Moonbug Entertainment
   board: moonbug-entertainment
 - company: nDreams
@@ -125,18 +135,24 @@
   board: ninetwothree-ai-studio
 - company: Nuvei
   board: nuvei
+- company: Partner One Capital
+  board: partner-one-capital
 - company: Peaksware
   board: peaksware
 - company: Persado
   board: persado
 - company: PikPok
   board: pikpok
+- company: Plain Concepts
+  board: plainconcepts
 - company: powtoon
   board: powtoon
 - company: PTW
   board: sideinc
 - company: Rebellion
   board: rebellion
+- company: RecargaPay
+  board: recargapay
 - company: reversing labs
   board: reversinglabs
 - company: RevStar
@@ -179,6 +195,10 @@
   board: vizrt
 - company: We are social
   board: we-are-social-1
+- company: Wingz LatAm
+  board: wingz-latam
+- company: Workstate
+  board: workstate
 - company: ZeptoLab
   board: zeptolab
 - company: zipdev

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -1,6 +1,10 @@
 # workday boards. Provider is the filename; each entry is company + board.
 # board = platform-specific id (see internal/sources/workday.go).
 
+- company: Equifax
+  board: equifax.wd5.myworkdayjobs.com/External
+- company: Fugro
+  board: fugro.wd3.myworkdayjobs.com/Careers
 - company: RingCentral
   board: ringcentral.wd1.myworkdayjobs.com/RingCentral_Careers
 - company: NVIDIA


### PR DESCRIPTION
Second coverage-audit batch, each board validated live at its adapter endpoint before adding. Skipped Vairix (empty listing — covered via `resolve-url`), Keppri (path-only careers-page, adapter needs subdomain), and 410-Gone dead postings (OrderMesh/RemoteBase/some Hire Overseas).