### PR TITLE
fix(compose): mount pgdata at /var/lib/postgresql for postgres:18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      # postgres:18+ stores data in a version-specific subdirectory and expects
+      # the volume at /var/lib/postgresql (not the legacy .../data path, which it
+      # now treats as an unused mount and refuses to start).
+      - pgdata:/var/lib/postgresql
       # Migrations are applied automatically by Postgres on first volume init.
       - ./migrations:/docker-entrypoint-initdb.d:ro
     healthcheck:


### PR DESCRIPTION
## Problem

The `db` service was bumped to `postgres:18-alpine`, but the volume mount was left at the legacy `/var/lib/postgresql/data` path. postgres:18 moves `PGDATA` into a version-specific subdirectory (`/var/lib/postgresql/18/docker`) and treats the legacy `.../data` mount as an *unused* mount, refusing to start:

```
Error: ... there appears to be PostgreSQL data in:
  /var/lib/postgresql/data (unused mount/volume)
```

This breaks `make up` / `docker compose up` on **both** a fresh volume init and an upgrade from an older volume — deleting and recreating the volume alone does not help.

## Fix

Mount the named volume at the parent `/var/lib/postgresql` (the docker-library-recommended layout, per docker-library/postgres#1259), so the data lands in the version subdirectory *inside* the volume and `pg_upgrade --link` stays possible.

## Verification

Clean recreate from zero (`docker compose down -v` → `up -d db`):

- container reaches `healthy`, no early exit
- all **22** migrations (`0001`→`0020`) run exactly once, zero `ERROR`/`FATAL`
- `data_directory = /var/lib/postgresql/18/docker` — under the mounted volume
- data persists across a container restart
- 23 public tables present; a full ingest via `cmd/resolve-url` writes and reads back cleanly