### PR TITLE
feat(web): tracking application URL + Emails tab in the board drawer

### DIFF
--- a/internal/linksource/generic.go
+++ b/internal/linksource/generic.go
@@ -77,10 +77,10 @@ func (g generic) Resolve(ctx context.Context, raw string) (sources.Job, bool, er
 		canonical = fu.String()
 	}
 	return sources.Job{
-		ExternalID:  canonical,
-		URL:         canonical,
-		Title:       p.Title,
-		Company:     p.HiringOrganization.Name,
+		ExternalID: canonical,
+		URL:        canonical,
+		Title:      p.Title,
+		Company:    p.HiringOrganization.Name,
 		// Unescape BEFORE sanitizing: some ATSes (Teamtailor) entity-encode the HTML
 		// inside the ld+json string (`&lt;p&gt;…`), so without a decode the sanitizer
 		// sees plain text and stores literal tags that render broken under {@html}.

--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { pushState } from '$app/navigation';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import type { MyJob } from '$lib/types';
@@ -6,6 +7,11 @@
   import BoardColumn from './BoardColumn.svelte';
   import JobDrawer from './JobDrawer.svelte';
   import States from './States.svelte';
+
+  // initialSlug (from /my/tracking/[slug]) opens that application's drawer once the
+  // board has loaded, so a deep link / inbox link / refresh reopens the same card.
+  let { initialSlug }: { initialSlug?: string } = $props();
+  let openedInitial = false;
 
   function emptyColumns(): Record<BoardColumnId, BoardItem[]> {
     return { applied: [], interview: [], offer: [], closed: [] };
@@ -43,6 +49,19 @@
       columns = next;
       cardCol = cols;
       status = 'ready';
+      // Deep link: open the requested application's drawer once, after the board is
+      // built. A slug that isn't on the board (untracked / saved-only) just leaves
+      // the board showing.
+      if (initialSlug && !openedInitial) {
+        openedInitial = true;
+        const found = Object.values(next)
+          .flat()
+          .find((i) => i.id === initialSlug);
+        if (found) {
+          openItem = found;
+          pendingOutcome = false;
+        }
+      }
     } catch {
       status = 'error';
     }
@@ -173,11 +192,14 @@
       void load();
     }
     openItem = null;
+    pushState('/my/tracking', {}); // drop the per-application slug from the URL
   }
 
   function openDrawer(item: MyJob) {
     openItem = item as BoardItem;
     pendingOutcome = false;
+    // Give the open application its own shareable URL without a full navigation.
+    pushState(`/my/tracking/${item.job.public_slug}`, {});
   }
 </script>
 

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -11,7 +11,12 @@
   import JobFitFull from './JobFitFull.svelte';
   import JobMatch from './JobMatch.svelte';
   import NoteEditor from './NoteEditor.svelte';
-  import type { MyJob } from '$lib/types';
+  import { api } from '$lib/api';
+  import type { EmailBody } from '$lib/api';
+  import { currentUser } from '$lib/auth.svelte';
+  import { statusLabel, statusClass } from '$lib/emailStatus';
+  import { avatarInitials, avatarColor } from '$lib/avatar';
+  import type { MyJob, ApplicationEmail } from '$lib/types';
 
   let {
     item,
@@ -31,15 +36,66 @@
     onclose: () => void;
   } = $props();
 
-  type Tab = 'application' | 'fit' | 'description';
-  const TABS: { id: Tab; label: string }[] = [
+  type Tab = 'application' | 'fit' | 'description' | 'emails';
+  // The Emails tab is moderator-only — linked mail is a moderator-gated surface, and
+  // the getTrackedApplication read 403s everyone else.
+  const isModerator = $derived(currentUser()?.role === 'moderator');
+  const TABS = $derived<{ id: Tab; label: string }[]>([
     { id: 'application', label: 'Application' },
     { id: 'fit', label: 'Job Match' },
     { id: 'description', label: 'Job description' },
-  ];
+    ...(isModerator ? [{ id: 'emails' as Tab, label: 'Emails' }] : []),
+  ]);
   // Local UI state. The parent re-keys this component per job (JobBoard's {#key}),
   // so a fresh mount always opens on Application.
   let tab = $state<Tab>('application');
+
+  // Emails tab: the application's linked mail, lazy-loaded on first open. Each email
+  // expands inline (accordion) to its full body, itself lazy-fetched. $state.raw —
+  // these are API payloads we only ever reassign, never mutate.
+  let emails = $state.raw<ApplicationEmail[] | null>(null);
+  let emailsLoading = $state(false);
+  let emailsError = $state<string | null>(null);
+  let expandedId = $state<number | null>(null);
+  let expandedBody = $state.raw<EmailBody | null>(null);
+  let bodyLoading = $state(false);
+
+  async function loadEmails() {
+    if (emails !== null || emailsLoading) return;
+    emailsLoading = true;
+    emailsError = null;
+    try {
+      const app = await api.getTrackedApplication(item.job.public_slug);
+      emails = app.emails;
+    } catch (e) {
+      emailsError = e instanceof Error ? e.message : 'Failed to load emails.';
+    } finally {
+      emailsLoading = false;
+    }
+  }
+
+  async function toggleEmail(id: number) {
+    if (expandedId === id) {
+      expandedId = null;
+      expandedBody = null;
+      return;
+    }
+    expandedId = id;
+    expandedBody = null;
+    bodyLoading = true;
+    try {
+      expandedBody = await api.getEmail(id);
+    } catch {
+      /* leave the row collapsed-open with no body; the list still shows */
+    } finally {
+      bodyLoading = false;
+    }
+  }
+
+  function selectTab(id: Tab) {
+    tab = id;
+    if (id === 'emails') void loadEmails();
+  }
 
   // Meta pills (work arrangement, region, employment type, seniority) — only the
   // stated ones, reusing the list-card logic.
@@ -167,7 +223,7 @@
               aria-selected={tab === t.id}
               aria-controls="jobdrawer-tabpanel"
               class={tabClass(tab === t.id)}
-              onclick={() => (tab = t.id)}
+              onclick={() => selectTab(t.id)}
             >
               {t.label}
             </button>
@@ -222,6 +278,65 @@
         <div class="flex flex-col gap-6">
           <JobMatch job={item.job} />
           <JobFitFull job={item.job} />
+        </div>
+      {:else if tab === 'emails'}
+        <div class="flex flex-col gap-2">
+          {#if emailsLoading}
+            <p class="text-sm text-muted-foreground">Loading emails…</p>
+          {:else if emailsError}
+            <p class="text-sm text-destructive">{emailsError}</p>
+          {:else if !emails || emails.length === 0}
+            <p class="text-sm text-muted-foreground">No emails linked to this application yet.</p>
+          {:else}
+            {#each emails as e (e.id)}
+              <div class="overflow-hidden rounded-xl border border-border">
+                <button
+                  type="button"
+                  onclick={() => toggleEmail(e.id)}
+                  aria-expanded={expandedId === e.id}
+                  class="flex w-full items-start gap-3 p-3 text-left transition-colors hover:bg-accent"
+                >
+                  <div
+                    class="mt-0.5 flex size-9 shrink-0 select-none items-center justify-center rounded-full text-xs font-semibold text-white"
+                    style="background-color: {avatarColor(e.from_addr || e.from_name)}"
+                  >
+                    {avatarInitials(e.from_name, e.from_addr)}
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-baseline gap-2">
+                      <span class="min-w-0 flex-1 truncate text-sm font-medium">{e.from_name || e.from_addr}</span>
+                      <span class="shrink-0 text-[11px] text-muted-foreground">{timeAgo(e.received_at)}</span>
+                    </div>
+                    <div class="mt-0.5 truncate text-sm text-muted-foreground">{e.subject || '(no subject)'}</div>
+                    {#if statusLabel(e.status_signal)}
+                      <span class="mt-1 inline-block rounded border px-1.5 text-[10px] leading-4 {statusClass(e.status_signal)}">
+                        {statusLabel(e.status_signal)}
+                      </span>
+                    {/if}
+                  </div>
+                </button>
+                {#if expandedId === e.id}
+                  <div class="border-t border-border p-3">
+                    {#if bodyLoading}
+                      <p class="text-sm text-muted-foreground">Loading…</p>
+                    {:else if expandedBody?.body_html}
+                      <!-- Untrusted sender HTML isolated in a sandboxed iframe (no scripts/forms/navigation). -->
+                      <iframe
+                        title="Message body"
+                        sandbox=""
+                        srcdoc={expandedBody.body_html}
+                        class="h-96 w-full rounded-md border border-border bg-white"
+                      ></iframe>
+                    {:else if expandedBody?.body_text}
+                      <pre class="max-h-96 overflow-y-auto whitespace-pre-wrap font-sans text-sm leading-relaxed">{expandedBody.body_text}</pre>
+                    {:else}
+                      <p class="text-sm text-muted-foreground">No content.</p>
+                    {/if}
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          {/if}
         </div>
       {:else}
         <div class="flex flex-col gap-5">

--- a/web/src/routes/my/tracking/[slug]/+page.server.ts
+++ b/web/src/routes/my/tracking/[slug]/+page.server.ts
@@ -1,26 +1,14 @@
-import { error, redirect } from '@sveltejs/kit';
-import { ApiError } from '$lib/api';
-import { serverApi } from '$lib/server/api';
+import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-// The application detail page shows the mail linked to an application, so it is
-// moderator-only like the rest of the inbox surface. Server-render the application
-// (with its linked emails) for an instant paint; a signed-out visitor bounces to
-// sign-in, a non-moderator to their tracking board, and an untracked slug is a 404.
-export const load: PageServerLoad = async ({ parent, params, fetch, request }) => {
+// /my/tracking/[slug] renders the tracking board with the application's drawer open
+// (deep-linkable — the inbox links here, and a refresh/share reopens the same card).
+// The board itself is for any signed-in user; the Emails tab inside the drawer
+// self-gates to moderators. Guard auth like /my/tracking and pass the slug through.
+export const load: PageServerLoad = async ({ parent, params, url }) => {
   const { user } = await parent();
   if (!user) {
-    const target = `/my/tracking/${params.slug}`;
-    redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
+    redirect(302, `/?auth=required&redirect=${encodeURIComponent(url.pathname)}`);
   }
-  if (user.role !== 'moderator') {
-    redirect(302, '/my/tracking');
-  }
-  const application = await serverApi(fetch, request.headers.get('cookie'))
-    .getTrackedApplication(params.slug)
-    .catch((e) => {
-      if (e instanceof ApiError && e.status === 404) error(404, 'Application not found');
-      throw e;
-    });
-  return { application };
+  return { slug: params.slug };
 };

--- a/web/src/routes/my/tracking/[slug]/+page.svelte
+++ b/web/src/routes/my/tracking/[slug]/+page.svelte
@@ -1,59 +1,13 @@
 <script lang="ts">
-  import JobRow from '$lib/components/JobRow.svelte';
-  import { statusLabel, statusClass } from '$lib/emailStatus';
-  import { timeAgo } from '$lib/utils';
-  import { avatarInitials, avatarColor } from '$lib/avatar';
+  import JobBoard from '$lib/components/JobBoard.svelte';
   import type { PageData } from './$types';
 
   let { data }: { data: PageData } = $props();
-  const app = $derived(data.application);
 </script>
 
 <svelte:head>
-  <title>{app.job.company} — application — freehire</title>
+  <title>Tracking — freehire</title>
 </svelte:head>
 
-<div class="flex flex-col gap-5">
-  <JobRow job={app.job} dimViewed={false} />
-
-  <div class="flex flex-wrap items-center gap-2 text-sm">
-    {#if app.stage}
-      <span class="rounded-full border border-border px-2.5 py-0.5 text-xs capitalize">{app.stage}</span>
-    {/if}
-    {#if app.applied_at}
-      <span class="text-xs text-muted-foreground">Applied {timeAgo(app.applied_at)}</span>
-    {/if}
-  </div>
-
-  <div>
-    <h2 class="mb-2 text-sm font-semibold">Linked emails ({app.emails.length})</h2>
-    {#if app.emails.length === 0}
-      <p class="text-sm text-muted-foreground">No emails linked to this application yet.</p>
-    {:else}
-      <ul class="flex flex-col gap-1">
-        {#each app.emails as e (e.id)}
-          <li class="flex items-start gap-3 rounded-xl border border-border p-3">
-            <div
-              class="mt-0.5 flex h-9 w-9 shrink-0 select-none items-center justify-center rounded-full text-xs font-semibold text-white"
-              style="background-color: {avatarColor(e.from_addr || e.from_name)}"
-            >
-              {avatarInitials(e.from_name, e.from_addr)}
-            </div>
-            <div class="min-w-0 flex-1">
-              <div class="flex items-baseline gap-2">
-                <span class="min-w-0 flex-1 truncate text-sm font-medium">{e.from_name || e.from_addr}</span>
-                <span class="shrink-0 text-[11px] text-muted-foreground">{timeAgo(e.received_at)}</span>
-              </div>
-              <div class="mt-0.5 truncate text-sm text-muted-foreground">{e.subject || '(no subject)'}</div>
-              {#if statusLabel(e.status_signal)}
-                <span class="mt-1 inline-block rounded border px-1.5 text-[10px] leading-4 {statusClass(e.status_signal)}">
-                  {statusLabel(e.status_signal)}
-                </span>
-              {/if}
-            </div>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-  </div>
-</div>
+<!-- Same board as /my/tracking, but opened on the given application's drawer. -->
+<JobBoard initialSlug={data.slug} />


### PR DESCRIPTION
## What

Follow-up to #706. Makes each tracked application addressable and surfaces its linked mail where the user actually looks — the board card drawer.

- **`/my/tracking/[slug]` opens the board drawer** for that application (deep-linkable: the inbox chip links here, and a refresh/share reopens the same card), replacing the standalone detail page.
- **Shallow routing**: opening a card `pushState`s the URL to `/my/tracking/[slug]` (no full navigation), so every application has its own shareable URL; closing drops back to `/my/tracking`.
- **Emails tab in the drawer** (moderator-only, beside Application / Job Match / Job description): the application's linked mail lazy-loads on open; each email expands inline (accordion) to its full body — sandboxed iframe for untrusted HTML, `<pre>` for text — with the classified status badge.

Frontend-only: reuses the existing `getTrackedApplication` (list + statuses) and `getEmail` (body) endpoints; no API/schema change.

## Verified

svelte-check 0 errors, `npm run build` OK.