### PR TITLE
fix(sources): drop duplicate Sigma Software SmartRecruiters board

### DIFF
--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -415,8 +415,6 @@
   board: servicenow
 - company: Sigma Software
   board: sigmasoftware2
-- company: Sigma Software
-  board: SigmaSoftware2
 - company: Sika Group
   board: SikaAG
 - company: Skeleton key


### PR DESCRIPTION
SmartRecruiters company ids are **case-insensitive**: `sigmasoftware2` and `SigmaSoftware2` resolve to the same board (both `total=88`, identical posting ids like `744000137651758`). #710 added a case-variant of the pre-existing `sigmasoftware2` entry because the insert-boards dedup is case-sensitive and didn't recognize it.

Harmless at runtime (jobs dedup by `(source, external_id)`, so no duplicate jobs in the catalogue) but it caused a **redundant crawl of the same board** every cycle. Drop the `SigmaSoftware2` duplicate, keep the lowercase original.

Sibling note (left as-is, not a bug): Ciklum has two Oracle sites (`CX_1001` + `ciklum-career`) on the same tenant that share requisition-ids — deduped at the job level, only a redundant crawl.