### PR TITLE
feat(mail): open the inbox surface to beta testers

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -97,6 +97,37 @@ func RequireRole(loader RoleLoader, role string) fiber.Handler {
 	}
 }
 
+// BetaLoader resolves an authenticated user id to its beta-tester membership. Like
+// RoleLoader it returns a primitive so this package needs no database import; it is
+// satisfied directly by *db.Queries (IsBetaTester).
+type BetaLoader interface {
+	IsBetaTester(ctx context.Context, id int64) (bool, error)
+}
+
+// RequireModeratorOrBeta authorizes a request when the caller is EITHER a moderator
+// OR a beta tester — for restricted-rollout features that moderators administer and
+// beta testers get early access to (e.g. the mail inbox). Same fail-closed discipline
+// as RequireRole: no user id → 401; neither moderator nor beta → 403.
+func RequireModeratorOrBeta(roles RoleLoader, beta BetaLoader) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		id, ok := UserID(c)
+		if !ok {
+			return fiber.NewError(fiber.StatusUnauthorized, "not authenticated")
+		}
+		if role, err := roles.GetUserRole(c.Context(), id); err == nil && role == "moderator" {
+			return c.Next()
+		}
+		isBeta, err := beta.IsBetaTester(c.Context(), id)
+		if err != nil {
+			return fiber.NewError(fiber.StatusUnauthorized, "not authenticated")
+		}
+		if !isBeta {
+			return fiber.NewError(fiber.StatusForbidden, "forbidden")
+		}
+		return c.Next()
+	}
+}
+
 // bearerToken extracts the credential from an `Authorization: Bearer <token>`
 // header, returning "" when the header is absent or not a Bearer scheme.
 func bearerToken(c *fiber.Ctx) string {

--- a/internal/auth/requiremodorbeta_test.go
+++ b/internal/auth/requiremodorbeta_test.go
@@ -1,0 +1,60 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// fakeModBeta satisfies both RoleLoader and BetaLoader with canned values.
+type fakeModBeta struct {
+	role    string
+	roleErr error
+	beta    bool
+	betaErr error
+}
+
+func (f fakeModBeta) GetUserRole(_ context.Context, _ int64) (string, error) {
+	return f.role, f.roleErr
+}
+func (f fakeModBeta) IsBetaTester(_ context.Context, _ int64) (bool, error) { return f.beta, f.betaErr }
+
+func modBetaApp(loader fakeModBeta, inject bool) *fiber.App {
+	app := fiber.New()
+	if inject {
+		app.Use(func(c *fiber.Ctx) error {
+			c.Locals(localsUserID, int64(5))
+			return c.Next()
+		})
+	}
+	app.Get("/admin", RequireModeratorOrBeta(loader, loader), func(c *fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+	return app
+}
+
+func TestRequireModeratorOrBeta(t *testing.T) {
+	cases := []struct {
+		name   string
+		loader fakeModBeta
+		inject bool
+		want   int
+	}{
+		{"moderator is allowed", fakeModBeta{role: "moderator"}, true, http.StatusOK},
+		{"beta tester is allowed", fakeModBeta{role: "user", beta: true}, true, http.StatusOK},
+		{"neither is forbidden", fakeModBeta{role: "user", beta: false}, true, http.StatusForbidden},
+		{"role-load error but beta still allows", fakeModBeta{roleErr: errors.New("x"), beta: true}, true, http.StatusOK},
+		{"both loaders error is unauthorized", fakeModBeta{roleErr: errors.New("x"), betaErr: errors.New("y")}, true, http.StatusUnauthorized},
+		{"no user id is unauthenticated", fakeModBeta{role: "moderator"}, false, http.StatusUnauthorized},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := statusOf(t, modBetaApp(c.loader, c.inject)); got != c.want {
+				t.Errorf("status = %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -395,6 +395,9 @@ type Querier interface {
 	// never reset. extracted_at is non-NULL when the ingest prefilter already
 	// decided the post holds no vacancy, so it is recorded but never queued.
 	InsertTelegramPost(ctx context.Context, arg InsertTelegramPostParams) (int64, error)
+	// Slim beta-membership lookup for the RequireModeratorOrBeta middleware — a
+	// primitive bool so the auth package stays free of a db import (same shape as GetUserRole).
+	IsBetaTester(ctx context.Context, id int64) (bool, error)
 	// Manually link (or relink) an email to a chosen application, overriding any
 	// auto-link or suggestion.
 	LinkEmailToJob(ctx context.Context, arg LinkEmailToJobParams) (int64, error)

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -103,3 +103,10 @@ WHERE id = $1 AND resume_uploaded_at = $4;
 SELECT role
 FROM users
 WHERE id = $1;
+
+-- name: IsBetaTester :one
+-- Slim beta-membership lookup for the RequireModeratorOrBeta middleware — a
+-- primitive bool so the auth package stays free of a db import (same shape as GetUserRole).
+SELECT beta_tester
+FROM users
+WHERE id = $1;

--- a/internal/db/users.sql.go
+++ b/internal/db/users.sql.go
@@ -225,6 +225,21 @@ func (q *Queries) GetUserRole(ctx context.Context, id int64) (string, error) {
 	return role, err
 }
 
+const isBetaTester = `-- name: IsBetaTester :one
+SELECT beta_tester
+FROM users
+WHERE id = $1
+`
+
+// Slim beta-membership lookup for the RequireModeratorOrBeta middleware — a
+// primitive bool so the auth package stays free of a db import (same shape as GetUserRole).
+func (q *Queries) IsBetaTester(ctx context.Context, id int64) (bool, error) {
+	row := q.db.QueryRow(ctx, isBetaTester, id)
+	var beta_tester bool
+	err := row.Scan(&beta_tester)
+	return beta_tester, err
+}
+
 const setUserATSAnalysis = `-- name: SetUserATSAnalysis :exec
 UPDATE users
 SET resume_ats_analysis = $2

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -383,34 +383,35 @@ func Register(app *fiber.App, cfg Config) {
 	api.Put("/me/profile", saved, a.PutProfile)
 	api.Delete("/me/profile", saved, a.DeleteProfile)
 
-	// Mail inbox (Gmail connect + hosted mailbox). The whole surface is
-	// moderator-gated for now (a restricted rollout) — a non-moderator gets 403
-	// and the SPA hides the nav entry. The read + disconnect routes are always
-	// registered (empty/no-op when not connected); the OAuth connect routes only
-	// when configured. Cookie-or-key auth, then the role gate.
-	api.Get("/me/gmail", saved, requireModerator, a.GmailStatus)
-	api.Delete("/me/gmail", saved, requireModerator, a.GmailDisconnect)
-	api.Get("/me/inbox", saved, requireModerator, a.GetInbox)
-	api.Get("/me/emails/:id", saved, requireModerator, a.GetEmail)
-	// Email → application linking. The detail endpoint exposes mail, so it is
-	// moderator-gated like the rest of the inbox surface; :slug is registered after
-	// the static /me/tracking/* routes above so it does not shadow them.
-	api.Get("/me/tracking/:slug", saved, requireModerator, a.GetTrackedApplication)
-	api.Post("/me/emails/:id/link", saved, requireModerator, a.LinkEmail)
-	api.Post("/me/emails/:id/unlink", saved, requireModerator, a.UnlinkEmail)
-	api.Post("/me/emails/:id/confirm", saved, requireModerator, a.ConfirmEmailLink)
-	api.Post("/me/emails/:id/reject", saved, requireModerator, a.RejectEmailLink)
+	// Mail inbox (Gmail connect + hosted mailbox). Restricted rollout: a moderator
+	// OR a beta tester may use it; everyone else gets 403 and the SPA hides the nav
+	// entry. The read + disconnect routes are always registered (empty/no-op when not
+	// connected); the OAuth connect routes only when configured. Cookie-or-key auth,
+	// then the moderator-or-beta gate.
+	requireMail := auth.RequireModeratorOrBeta(a.queries, a.queries)
+	api.Get("/me/gmail", saved, requireMail, a.GmailStatus)
+	api.Delete("/me/gmail", saved, requireMail, a.GmailDisconnect)
+	api.Get("/me/inbox", saved, requireMail, a.GetInbox)
+	api.Get("/me/emails/:id", saved, requireMail, a.GetEmail)
+	// Email → application linking. The detail endpoint exposes mail, so it rides the
+	// same mail gate; :slug is registered after the static /me/tracking/* routes above
+	// so it does not shadow them.
+	api.Get("/me/tracking/:slug", saved, requireMail, a.GetTrackedApplication)
+	api.Post("/me/emails/:id/link", saved, requireMail, a.LinkEmail)
+	api.Post("/me/emails/:id/unlink", saved, requireMail, a.UnlinkEmail)
+	api.Post("/me/emails/:id/confirm", saved, requireMail, a.ConfirmEmailLink)
+	api.Post("/me/emails/:id/reject", saved, requireMail, a.RejectEmailLink)
 	if a.gmailReady() {
-		api.Get("/me/gmail/connect", saved, requireModerator, a.GmailConnect)
-		api.Get("/me/gmail/callback", saved, requireModerator, a.GmailCallback)
-		api.Post("/me/gmail/sync", saved, requireModerator, a.SyncGmail)
+		api.Get("/me/gmail/connect", saved, requireMail, a.GmailConnect)
+		api.Get("/me/gmail/callback", saved, requireMail, a.GmailCallback)
+		api.Post("/me/gmail/sync", saved, requireMail, a.SyncGmail)
 	}
 	// Hosted-mailbox option: status is always available (reports unavailable when
 	// the feature is off); claim/release only when a receiving domain is configured.
-	api.Get("/me/mailbox", saved, requireModerator, a.GetMailbox)
+	api.Get("/me/mailbox", saved, requireMail, a.GetMailbox)
 	if a.mailboxReady() {
-		api.Post("/me/mailbox", saved, requireModerator, a.ClaimMailbox)
-		api.Delete("/me/mailbox", saved, requireModerator, a.ReleaseMailbox)
+		api.Post("/me/mailbox", saved, requireMail, a.ClaimMailbox)
+		api.Delete("/me/mailbox", saved, requireMail, a.ReleaseMailbox)
 	}
 	// The résumé verdict is a profile sub-resource: GET computes the live
 	// market-coverage verdict from the profile's skills against the selected role.

--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -38,10 +38,11 @@ describe('visibleAccountNav', () => {
     expect(modOnly).toContain('/my/inbox');
     expect(modOnly).not.toContain('/my/assistant');
 
-    // A beta tester who is not a moderator sees the Assistant but NOT Inbox.
+    // A beta tester who is not a moderator sees the Assistant AND the Inbox (Inbox
+    // is a moderator-OR-beta section).
     const betaOnly = visibleAccountNav(false, true).map((i) => i.href);
     expect(betaOnly).toContain('/my/assistant');
-    expect(betaOnly).not.toContain('/my/inbox');
+    expect(betaOnly).toContain('/my/inbox');
   });
 
   it('shows every section to a moderator who is also a beta tester', () => {

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -14,8 +14,9 @@ export const accountNav = [
   { href: '/my/assistant', label: 'Agent', betaOnly: true },
   { href: '/my/tracking', label: 'Tracking' },
   { href: '/my/activity', label: 'Activity' },
-  // Mail inbox is a restricted rollout — moderators only (the server 403s others).
-  { href: '/my/inbox', label: 'Inbox', moderatorOnly: true },
+  // Mail inbox is a restricted rollout — moderators OR beta testers (the server 403s
+  // everyone else).
+  { href: '/my/inbox', label: 'Inbox', moderatorOrBeta: true },
   { href: '/my/searches', label: 'Search notifications' },
   { href: '/my/api-keys', label: 'API keys' },
   { href: '/my/submissions', label: 'My submissions' },
@@ -23,11 +24,11 @@ export const accountNav = [
 
 export type AccountNavItem = (typeof accountNav)[number];
 
-// The sections visible to a caller: a `moderatorOnly` section is hidden unless the
-// caller is a moderator, and a `betaOnly` section unless the caller is a beta
-// tester (an independent group). This is a UI affordance only — the relevant
-// server surfaces re-check on every request, so hiding the nav is not the
-// security boundary.
+// The sections visible to a caller: a `moderatorOnly` section needs the moderator
+// role, a `betaOnly` section needs beta membership (an independent group), and a
+// `moderatorOrBeta` section needs either. This is a UI affordance only — the relevant
+// server surfaces re-check on every request, so hiding the nav is not the security
+// boundary.
 export function visibleAccountNav(
   isModerator: boolean,
   isBetaTester: boolean,
@@ -35,6 +36,7 @@ export function visibleAccountNav(
   return accountNav.filter((i) => {
     if ('moderatorOnly' in i && i.moderatorOnly) return isModerator;
     if ('betaOnly' in i && i.betaOnly) return isBetaTester;
+    if ('moderatorOrBeta' in i && i.moderatorOrBeta) return isModerator || isBetaTester;
     return true;
   });
 }

--- a/web/src/lib/components/JobDrawer.svelte
+++ b/web/src/lib/components/JobDrawer.svelte
@@ -37,9 +37,9 @@
   } = $props();
 
   type Tab = 'application' | 'fit' | 'description' | 'emails';
-  // The Emails tab is moderator-only — linked mail is a moderator-gated surface, and
-  // the getTrackedApplication read 403s everyone else.
-  const isModerator = $derived(currentUser()?.role === 'moderator');
+  // The Emails tab shows linked mail — a moderator-or-beta surface; the
+  // getTrackedApplication read 403s everyone else.
+  const canSeeMail = $derived(currentUser()?.role === 'moderator' || currentUser()?.beta_tester === true);
 
   // Emails-tab state (declared before TABS, which shows the loaded count). The
   // application's linked mail lazy-loads (see the eager $effect below); each email
@@ -56,7 +56,7 @@
     { id: 'application', label: 'Application' },
     { id: 'fit', label: 'Job Match' },
     { id: 'description', label: 'Job description' },
-    ...(isModerator ? [{ id: 'emails' as Tab, label: emails ? `Emails (${emails.length})` : 'Emails' }] : []),
+    ...(canSeeMail ? [{ id: 'emails' as Tab, label: emails ? `Emails (${emails.length})` : 'Emails' }] : []),
   ]);
   // Local UI state. The parent re-keys this component per job (JobBoard's {#key}),
   // so a fresh mount always opens on Application.
@@ -76,10 +76,10 @@
     }
   }
 
-  // Load the linked mail eagerly (moderators only) so the tab shows its count before
-  // it's opened. Re-keyed per job by the parent, so this runs once per application.
+  // Load the linked mail eagerly (moderator or beta only) so the tab shows its count
+  // before it's opened. Re-keyed per job by the parent, so this runs once per application.
   $effect(() => {
-    if (isModerator) void loadEmails();
+    if (canSeeMail) void loadEmails();
   });
 
   async function toggleEmail(id: number) {

--- a/web/src/routes/my/inbox/+page.server.ts
+++ b/web/src/routes/my/inbox/+page.server.ts
@@ -1,12 +1,13 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-// The mail inbox is a moderator-only rollout — the API 403s everyone else, so
-// redirect non-moderators to their profile instead of rendering a page whose every
-// fetch would fail. The server role check (RequireRole) remains the real boundary.
+// The mail inbox is a restricted rollout — moderators OR beta testers. The API 403s
+// everyone else, so redirect the rest to their profile instead of rendering a page
+// whose every fetch would fail. The server gate (RequireModeratorOrBeta) remains the
+// real boundary.
 export const load: PageServerLoad = async ({ parent }) => {
   const { user } = await parent();
-  if (user?.role !== 'moderator') {
+  if (!(user?.role === 'moderator' || user?.beta_tester)) {
     redirect(302, '/my/profile');
   }
   return {};


### PR DESCRIPTION
Extends the moderator-only mail feature (inbox, email→application linking, gmail/mailbox) to **beta testers** too.

**Backend:** `IsBetaTester` query + `auth.RequireModeratorOrBeta` middleware (moderator OR beta, fail-closed 401/403 like `RequireRole`, db-free), wired onto the mail routes only (jobs/submissions/reports stay moderator-only). Unit-tested.

**Frontend:** a `moderatorOrBeta` nav gate for the Inbox entry, the `/my/inbox` redirect and the tracking-drawer Emails tab now allow moderator OR beta. `accountNav` test updated.

Verified: go test + auth middleware test + accountNav vitest green; svelte-check/build OK.