### PR TITLE
feat(sources): add Workable marketplace adapter for widget-less employers

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -184,6 +184,7 @@ func All(c HTTPClient) map[string]Source {
 		NewLever(c),
 		NewAshby(c),
 		NewWorkable(c),
+		NewWorkableMarketplace(c),
 		NewRecruitee(c),
 		NewSmartRecruiters(c),
 		NewGupy(c),

--- a/internal/sources/workablemarketplace.go
+++ b/internal/sources/workablemarketplace.go
@@ -1,0 +1,115 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// workableMarketplaceBaseURL is the Workable public marketplace API root. Unlike the
+// company-hosted widget API (apply.workable.com/.../widget/accounts/<board>), this serves
+// postings a company published to the jobs.workable.com marketplace but not to a widget
+// board — so a "marketplace-only" employer, empty on the widget endpoint, is reachable here.
+const workableMarketplaceBaseURL = "https://jobs.workable.com/api/v1/companies"
+
+// wkMarketplaceMaxPages bounds token pagination so a feed that never stops handing back a
+// non-empty token cannot loop forever.
+const wkMarketplaceMaxPages = 100
+
+// workableMarketplace adapts the Workable marketplace API. The board is the company's
+// opaque marketplace hashid (from a posting's company URL). The list carries an inline HTML
+// description, so no per-posting detail request is needed; pages chain via nextPageToken.
+type workableMarketplace struct {
+	http JSONGetter
+}
+
+// NewWorkableMarketplace builds the Workable marketplace adapter over the given HTTP client.
+func NewWorkableMarketplace(c JSONGetter) Source { return workableMarketplace{http: c} }
+
+func (workableMarketplace) Provider() string { return "workablemarketplace" }
+
+// wkMarketplaceJob is one posting in the marketplace company feed.
+type wkMarketplaceJob struct {
+	ID             string `json:"id"`
+	Title          string `json:"title"`
+	State          string `json:"state"`
+	Description    string `json:"description"`
+	EmploymentType string `json:"employmentType"`
+	Workplace      string `json:"workplace"`
+	URL            string `json:"url"`
+	Created        string `json:"created"`
+	Location       struct {
+		City        string `json:"city"`
+		CountryName string `json:"countryName"`
+	} `json:"location"`
+}
+
+func (w workableMarketplace) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	seen := make(map[string]bool)
+	token := ""
+	for page := 0; page < wkMarketplaceMaxPages; page++ {
+		u := fmt.Sprintf("%s/%s", workableMarketplaceBaseURL, e.Board)
+		if token != "" {
+			u += "?pageToken=" + url.QueryEscape(token)
+		}
+
+		var resp struct {
+			Jobs          []wkMarketplaceJob `json:"jobs"`
+			NextPageToken string             `json:"nextPageToken"`
+		}
+		if err := w.http.GetJSON(ctx, u, &resp); err != nil {
+			if page == 0 {
+				return nil, fmt.Errorf("workablemarketplace: fetch company %s: %w", e.Board, err)
+			}
+			break // a later page failing ends enumeration with the jobs gathered so far
+		}
+
+		newCount := 0
+		for _, j := range resp.Jobs {
+			// The feed carries drafts/archived alongside live postings; only a published
+			// one is a real vacancy. seen guards against a token that re-serves a page.
+			if j.State != "published" || seen[j.ID] {
+				continue
+			}
+			seen[j.ID] = true
+			newCount++
+			remote := j.Workplace == "remote"
+			jobs = append(jobs, Job{
+				ExternalID:     j.ID,
+				URL:            j.URL,
+				Title:          j.Title,
+				Company:        e.Company,
+				Location:       joinNonEmpty(j.Location.City, j.Location.CountryName),
+				Description:    sanitizeHTML(j.Description),
+				Remote:         remote,
+				WorkMode:       workableWorkplaceMode(j.Workplace),
+				PostedAt:       parseRFC3339(j.Created),
+				EmploymentType: workableEmploymentType(j.EmploymentType),
+			})
+		}
+
+		// Stop when the feed signals the end, or a page adds nothing new (an empty page or
+		// a token that loops back), so enumeration terminates without trusting the token alone.
+		if resp.NextPageToken == "" || newCount == 0 {
+			break
+		}
+		token = resp.NextPageToken
+	}
+	return jobs, nil
+}
+
+// workableWorkplaceMode maps Workable's marketplace "workplace" enum onto the freehire
+// work-mode vocabulary, returning "" for an absent/unknown value (the location parser decides).
+func workableWorkplaceMode(v string) string {
+	switch v {
+	case "remote":
+		return "remote"
+	case "hybrid":
+		return "hybrid"
+	case "on-site", "onsite":
+		return "onsite"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/workablemarketplace_test.go
+++ b/internal/sources/workablemarketplace_test.go
@@ -1,0 +1,123 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWorkableMarketplaceProvider(t *testing.T) {
+	if got := NewWorkableMarketplace(nil).Provider(); got != "workablemarketplace" {
+		t.Errorf("Provider() = %q, want %q", got, "workablemarketplace")
+	}
+}
+
+func TestWorkableMarketplaceFetch(t *testing.T) {
+	fake := &fakeHTTP{body: `{
+		"totalSize": 2,
+		"jobs": [
+			{
+				"id": "ee3feec0-74d5-46f1-9996-5ab064f75050",
+				"title": "Senior Backend Engineer",
+				"state": "published",
+				"employmentType": "Contract",
+				"workplace": "remote",
+				"url": "https://jobs.workable.com/view/vqncebKcuVxZHgabGqKWHW/remote-senior-backend",
+				"created": "2026-01-08T15:25:12.375Z",
+				"location": {"city": "Buenos Aires", "subregion": "Buenos Aires", "countryName": "Argentina"},
+				"description": "<p>Build <strong>things</strong>.</p><script>x()</script>"
+			},
+			{
+				"id": "draft-1",
+				"title": "Draft Role",
+				"state": "draft",
+				"workplace": "onsite",
+				"url": "https://jobs.workable.com/view/draft/x",
+				"created": "2026-01-01T00:00:00.000Z",
+				"location": {"city": "", "countryName": "Brazil"},
+				"description": "<p>hidden</p>"
+			}
+		],
+		"nextPageToken": ""
+	}`}
+
+	jobs, err := NewWorkableMarketplace(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Intuition Machines", Provider: "workablemarketplace", Board: "ix7jhWd4JnugmXDK5RaQSZ",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fake.gotURL, "companies/ix7jhWd4JnugmXDK5RaQSZ") {
+		t.Errorf("requested URL %q should target the company hashid", fake.gotURL)
+	}
+	// The draft posting is dropped: only state=="published" jobs are ingested.
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (draft dropped)", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "ee3feec0-74d5-46f1-9996-5ab064f75050" {
+		t.Errorf("ExternalID = %q, want the uuid id", j.ExternalID)
+	}
+	if j.Title != "Senior Backend Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.URL != "https://jobs.workable.com/view/vqncebKcuVxZHgabGqKWHW/remote-senior-backend" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Company != "Intuition Machines" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Location != "Buenos Aires, Argentina" {
+		t.Errorf("Location = %q, want city + country joined", j.Location)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote from workplace", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "contract" {
+		t.Errorf("EmploymentType = %q, want contract", j.EmploymentType)
+	}
+	if j.PostedAt == nil || j.PostedAt.Year() != 2026 {
+		t.Errorf("PostedAt = %v, want parsed 2026 date", j.PostedAt)
+	}
+	if strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description should be sanitized: %q", j.Description)
+	}
+}
+
+// pagingHTTP returns a queued body per call and records every requested URL, so the
+// pageToken pagination flow can be exercised (fakeHTTP returns one body for any URL).
+type pagingHTTP struct {
+	bodies []string
+	urls   []string
+	i      int
+}
+
+func (p *pagingHTTP) GetJSON(_ context.Context, url string, v any) error {
+	p.urls = append(p.urls, url)
+	body := p.bodies[p.i]
+	if p.i < len(p.bodies)-1 {
+		p.i++
+	}
+	return json.Unmarshal([]byte(body), v)
+}
+
+func TestWorkableMarketplacePagination(t *testing.T) {
+	page1 := `{"jobs":[{"id":"a","title":"A","state":"published","workplace":"remote","url":"u/a","location":{"countryName":"US"}}],"nextPageToken":"TOK2"}`
+	page2 := `{"jobs":[{"id":"b","title":"B","state":"published","workplace":"remote","url":"u/b","location":{"countryName":"US"}}],"nextPageToken":""}`
+	fake := &pagingHTTP{bodies: []string{page1, page2}}
+
+	jobs, err := NewWorkableMarketplace(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "workablemarketplace", Board: "HASH",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 across two pages", len(jobs))
+	}
+	if len(fake.urls) < 2 || !strings.Contains(fake.urls[1], "pageToken=TOK2") {
+		t.Errorf("second request %v should carry pageToken from page 1", fake.urls)
+	}
+}

--- a/sources/workablemarketplace.yml
+++ b/sources/workablemarketplace.yml
@@ -1,0 +1,15 @@
+# workablemarketplace (jobs.workable.com marketplace API) boards. Provider is the
+# filename; board = the company's opaque marketplace hashid, taken from a posting's
+# company URL (jobs.workable.com/company/<hashid>/jobs-at-<name>). Use this ONLY for
+# "marketplace-only" employers — those whose apply.workable.com widget board is empty
+# (so the plain `workable` adapter can't reach them). A company already crawlable via
+# sources/workable.yml must NOT be listed here too (it would double-list under a second
+# source + external-id scheme). Each hashid validated live (feed returned >0 jobs).
+# Lago is a staffing agency (mixed roles); its non-tech postings are filtered by the
+# enrich non-tech gate, its engineering roles kept.
+- company: AOA
+  board: v8S3GJczSWhxjzGHK1FFKW
+- company: Intuition Machines
+  board: ix7jhWd4JnugmXDK5RaQSZ
+- company: Lago
+  board: fLBK8dBBYxkHwkj9pperGP


### PR DESCRIPTION
## What

Some Workable employers publish to the **jobs.workable.com marketplace** but not to a company-hosted widget board, so the existing `workable` adapter (which reads `apply.workable.com/.../widget/accounts/<board>`) returns **0 jobs** for them. The marketplace API `jobs.workable.com/api/v1/companies/<hashid>` serves those postings inline (id, title, description, location, workplace, employmentType, created), paginated via `pageToken`.

## How

New `workablemarketplace` adapter — `board` = the company's opaque marketplace hashid (taken from a posting's `company` URL). Enumerates **published** postings across pages (stops on empty token or a page with no new ids), maps `workplace`→work_mode and `employmentType`→the shared vocabulary, sanitizes the HTML description.

Seeded `sources/workablemarketplace.yml` with **AOA**, **Intuition Machines** (hCaptcha), **Lago** — all marketplace-only (their widget boards are empty).

Kept **separate** from the widget `workable` provider: different endpoint and external-id scheme (uuid vs shortcode), and a company must not be listed under both (would double-list).

## Verification

- Unit tests: mapping, `state != published` drop, pageToken pagination.
- Live end-to-end (real HTTP client): Intuition Machines 51 jobs (paginated), AOA 20, Lago 288 — all with title/location/ext-id/posted populated.
- `go build/vet/test ./...` + gofmt clean; new yml validates against the registry.

## Background

Came out of a spike (VALIDATED) proving that marketplace-only postings — earlier written off as unreachable — parse via this endpoint. The same postings are also reachable one-off via `cmd/resolve-url` (view page carries JobPosting ld+json); this adapter is the durable, whole-company version.

## Ops note

A new `sources/*.yml` needs its per-file ingest timer generated on host-2 (`gen-ingest-timers.sh`) — run after deploy so `freehire-ingest@workablemarketplace` exists.