### PR TITLE
feat(web): Beta nav badges + Gmail-connect explainer dialog

### DIFF
--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -10,13 +10,13 @@
 export const accountNav = [
   { href: '/my/profile', label: 'Profile' },
   // The agent is a restricted rollout — beta testers only (a group separate from
-  // the moderator role; see `beta_tester` on the user).
-  { href: '/my/assistant', label: 'Agent', betaOnly: true },
+  // the moderator role; see `beta_tester` on the user). `beta` shows a nav badge.
+  { href: '/my/assistant', label: 'Agent', betaOnly: true, beta: true },
   { href: '/my/tracking', label: 'Tracking' },
   { href: '/my/activity', label: 'Activity' },
   // Mail inbox is a restricted rollout — moderators OR beta testers (the server 403s
-  // everyone else).
-  { href: '/my/inbox', label: 'Inbox', moderatorOrBeta: true },
+  // everyone else). `beta` shows a nav badge.
+  { href: '/my/inbox', label: 'Inbox', moderatorOrBeta: true, beta: true },
   { href: '/my/searches', label: 'Search notifications' },
   { href: '/my/api-keys', label: 'API keys' },
   { href: '/my/submissions', label: 'My submissions' },

--- a/web/src/lib/components/GmailConnectDialog.svelte
+++ b/web/src/lib/components/GmailConnectDialog.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import { Mail, X, Lock, ExternalLink } from '@lucide/svelte';
+  import { Button } from '$lib/ui';
+
+  // The parent owns open/close; onConnect proceeds to the Google OAuth redirect.
+  let { onClose, onConnect }: { onClose: () => void; onConnect: () => void } = $props();
+
+  const REPO = 'https://github.com/strelov1/freehire/blob/main';
+  // The pipeline stages, each linking to the exact source that implements it — the
+  // project is open source, so "how it works" is verifiable, not a promise.
+  const steps: { title: string; body: string; href: string }[] = [
+    {
+      title: 'Read',
+      body: 'A Gmail search scoped to recruiting/ATS platforms only — never your personal mail. Read-only access; the token is encrypted at rest.',
+      href: `${REPO}/internal/gmailsync/senders.go`,
+    },
+    {
+      title: 'Match',
+      body: 'Each email is linked to one of your tracked applications by the company name in the sender/subject — deterministic, and it never guesses.',
+      href: `${REPO}/internal/mailmatch`,
+    },
+    {
+      title: 'Classify',
+      body: 'An LLM reads the body and tags a status: acknowledgement · screening · interview · assessment · offer · rejection.',
+      href: `${REPO}/internal/mailclassify`,
+    },
+    {
+      title: 'Sort',
+      body: 'The email appears under its application with a status badge; a confident interview/offer advances your pipeline stage (never backward).',
+      href: `${REPO}/cmd/classify-mail`,
+    },
+  ];
+</script>
+
+<svelte:window onkeydown={(e) => e.key === 'Escape' && onClose()} />
+
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+  <button type="button" aria-label="Close dialog" class="absolute inset-0 bg-black/50" onclick={onClose}></button>
+
+  <div
+    role="dialog"
+    aria-modal="true"
+    aria-label="Connect Gmail"
+    class="relative z-10 flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-xl"
+  >
+    <div class="flex items-start gap-3 border-b border-border p-5">
+      <div class="flex size-10 shrink-0 items-center justify-center rounded-xl bg-brand-muted">
+        <Mail class="size-5 text-brand-strong" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <h2 class="text-lg font-semibold leading-tight">Connect Gmail</h2>
+        <p class="mt-0.5 text-sm text-muted-foreground">
+          freehire reads only your recruiting mail and sorts it under your applications — automatically.
+        </p>
+      </div>
+      <button
+        type="button"
+        onclick={onClose}
+        aria-label="Close"
+        class="-mr-1 rounded-full p-1.5 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <X class="size-5" />
+      </button>
+    </div>
+
+    <div class="flex-1 overflow-y-auto p-5">
+      <ol class="flex flex-col gap-4">
+        {#each steps as step, i (step.title)}
+          <li class="flex gap-3">
+            <span
+              class="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-semibold text-muted-foreground"
+            >
+              {i + 1}
+            </span>
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                <span class="text-sm font-medium">{step.title}</span>
+                <a
+                  href={step.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="inline-flex items-center gap-0.5 text-xs text-brand-strong hover:underline"
+                >
+                  source <ExternalLink class="size-3" />
+                </a>
+              </div>
+              <p class="mt-0.5 text-sm text-muted-foreground">{step.body}</p>
+            </div>
+          </li>
+        {/each}
+      </ol>
+
+      <div class="mt-5 flex items-start gap-2 rounded-lg border border-border bg-muted/40 p-3 text-xs text-muted-foreground">
+        <Lock class="mt-0.5 size-3.5 shrink-0" />
+        <span>
+          Read-only Gmail scope, only mail from recruiting platforms is fetched, and it's all
+          <a
+            href="https://github.com/strelov1/freehire"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="font-medium text-brand-strong hover:underline">open source</a
+          > — you can read exactly what runs.
+        </span>
+      </div>
+    </div>
+
+    <div class="flex justify-end gap-2 border-t border-border p-4">
+      <Button variant="outline" onclick={onClose}>Cancel</Button>
+      <Button variant="primary" onclick={onConnect} class="gap-1.5">
+        Connect Gmail <Mail class="size-4" />
+      </Button>
+    </div>
+  </div>
+</div>

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -11,6 +11,7 @@
   import type { EmailLinking } from '$lib/types';
   import { statusLabel, statusClass } from '$lib/emailStatus';
   import { Badge, Button } from '$lib/ui';
+  import GmailConnectDialog from './GmailConnectDialog.svelte';
   import { Mail, AtSign, Copy, Search, RefreshCw, ChevronLeft } from '@lucide/svelte';
   import { timeAgo } from '$lib/utils';
   import { avatarInitials, avatarColor } from '$lib/avatar';
@@ -218,6 +219,10 @@
 
   // --- Gmail source ---
 
+  // First-time connect opens an explainer dialog (what's read + how the LLM pipeline
+  // sorts it, with source links); connectGmail is the actual OAuth redirect it triggers.
+  let showConnectDialog = $state(false);
+
   function connectGmail() {
     window.location.href = '/api/v1/me/gmail/connect';
   }
@@ -344,7 +349,7 @@
             </div>
           {:else if gmail?.available}
             <p class="mt-1 text-xs text-muted-foreground">Pull replies from your own Gmail (needs Google sign-in).</p>
-            <Button variant="primary" size="sm" class="mt-3" onclick={connectGmail}>
+            <Button variant="primary" size="sm" class="mt-3" onclick={() => (showConnectDialog = true)}>
               Connect Gmail <Mail class="h-4 w-4" />
             </Button>
           {:else}
@@ -584,6 +589,10 @@
       {/if}
     {/if}
   </div>
+{/if}
+
+{#if showConnectDialog}
+  <GmailConnectDialog onClose={() => (showConnectDialog = false)} onConnect={connectGmail} />
 {/if}
 
 <style>

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -99,7 +99,16 @@
           class={cn(itemClass(active), iconOnly && 'justify-center', extra)}
         >
           <Icon class="size-4 shrink-0" />
-          {#if !iconOnly}{item.label}{/if}
+          {#if !iconOnly}
+            {item.label}
+            {#if 'beta' in item && item.beta}
+              <span
+                class="ml-auto rounded-full bg-brand-muted px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none tracking-wide text-brand-strong"
+              >
+                Beta
+              </span>
+            {/if}
+          {/if}
         </a>
       {/each}
     {/snippet}


### PR DESCRIPTION
- **Beta badges** on the Agent and Inbox nav entries (new `beta` flag on the accountNav model).
- **Gmail-connect explainer dialog**: first-time connect opens a modal before the OAuth redirect explaining *what* is read (recruiting/ATS mail only, read-only scope, encrypted token) and the 4-step LLM pipeline (Read → Match → Classify → Sort), each step linking to the exact source code. The project is open source, so 'how it works' is verifiable. Reconnect stays direct.

Frontend-only. svelte-check 0 errors, build OK, accountNav vitest green.