### PR TITLE
feat(sources): add AI inference-provider boards + fix workablemarketplace AOA double-source

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -387,6 +387,8 @@
   board: eyebot
 - company: Faculty AI
   board: faculty
+- company: fal.ai
+  board: fal-ai
 - company: fanvue.com
   board: fanvue.com
 - company: far.ai
@@ -7407,3 +7409,7 @@
   board: loki
 - company: Going
   board: going
+- company: Cerebras
+  board: cerebras
+- company: Vast.ai
+  board: vastai

--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -995,6 +995,8 @@
   board: humansignal
 - company: HunterDouglas
   board: hunterdouglas
+- company: Hyperstack
+  board: nexgencloud
 - company: IBKR External
   board: ibkrexternal
 - company: iCapital Network

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -159,6 +159,8 @@
   board: revstar
 - company: Rive
   board: rivecareers
+- company: Runware
+  board: runware
 - company: Sawhorse Productions
   board: sawhorse-productions
 - company: Smoking Gun Interactive

--- a/sources/workablemarketplace.yml
+++ b/sources/workablemarketplace.yml
@@ -7,8 +7,8 @@
 # source + external-id scheme). Each hashid validated live (feed returned >0 jobs).
 # Lago is a staffing agency (mixed roles); its non-tech postings are filtered by the
 # enrich non-tech gate, its engineering roles kept.
-- company: AOA
-  board: v8S3GJczSWhxjzGHK1FFKW
+# NOTE: AOA is NOT here — it has a working widget board (helloaoa) in workable.yml, so
+# listing it here too would double-source the same roles under a second external-id scheme.
 - company: Intuition Machines
   board: ix7jhWd4JnugmXDK5RaQSZ
 - company: Lago


### PR DESCRIPTION
## AI inference-provider harvest

Harvest of AI inference providers (fal.ai alternatives — the user asked to cover "companies doing inference"). Each new board **validated live** at its ATS endpoint (>0 jobs) via `cmd/harvest-boards` + direct probes:

| Provider | ATS | Board |
|---|---|---|
| fal.ai | ashby | `fal-ai` |
| Cerebras | ashby | `cerebras` |
| Vast.ai | ashby | `vastai` |
| Hyperstack (NexGen Cloud) | greenhouse | `nexgencloud` |
| Runware | workable | `runware` |

**Already covered** (no-op): Together (bamboohr), Fireworks/Baseten/Modal/Cohere/Mistral/RunPod/Anyscale/Lambda/Novita/Hyperbolic/Beam/OpenRouter/Crusoe/Recraft/Sieve/Featherless/Blaxel/SFCompute (ashby), Groq/GMI (gem/bamboohr), SambaNova/CoreWeave/Nebius/Nscale (greenhouse), Scaleway (lever), Leonardo (workday).

**Not addable** — no standalone board (acquired/defunct or no public ATS): Replicate (→Cloudflare), Lepton AI / OctoAI (→Nvidia), Predibase (→Rubrik), DeepInfra, Cerebrium, Inferless, BentoML, Koyeb, Segmind, Northflank, Spheron, Voltage Park, Paperspace.

## Fix: workablemarketplace AOA double-source

#717 seeded AOA into `workablemarketplace.yml`, but AOA has a **working widget board** (`helloaoa`) in `workable.yml` (added in #710). Listing it under both double-sourced the same 20 roles under two external-id schemes (shortcode vs uuid). Removed AOA from the marketplace file; the 20 orphaned `source=workablemarketplace` AOA rows were closed on prod. Intuition Machines + Lago stay (genuinely widget-empty).

All `sources/*.yml` validate against the registry.