### PR TITLE
fix(sources): rename marketplace 'Lago' to 'Hire Lago' (slug collision with getlago)

### DIFF
--- a/sources/workablemarketplace.yml
+++ b/sources/workablemarketplace.yml
@@ -5,11 +5,15 @@
 # (so the plain `workable` adapter can't reach them). A company already crawlable via
 # sources/workable.yml must NOT be listed here too (it would double-list under a second
 # source + external-id scheme). Each hashid validated live (feed returned >0 jobs).
-# Lago is a staffing agency (mixed roles); its non-tech postings are filtered by the
-# enrich non-tech gate, its engineering roles kept.
+# "Hire Lago" (hirelago.com) is a staffing agency (mixed roles); its non-tech postings are
+# filtered by the enrich non-tech gate, its engineering roles kept. It is named "Hire Lago"
+# — NOT "Lago" — on purpose: the company slug is derived from the name, and plain "Lago"
+# collides with getlago (the dev-tooling company, ingested via ashby + workatastartup),
+# merging this agency's ~288 postings onto getlago's page. The distinct name gives it its
+# own slug (hire-lago) and leaves getlago clean under "lago".
 # NOTE: AOA is NOT here — it has a working widget board (helloaoa) in workable.yml, so
 # listing it here too would double-source the same roles under a second external-id scheme.
 - company: Intuition Machines
   board: ix7jhWd4JnugmXDK5RaQSZ
-- company: Lago
+- company: Hire Lago
   board: fLBK8dBBYxkHwkj9pperGP


### PR DESCRIPTION
The workablemarketplace board `fLBK8dBBYxkHwkj9pperGP` is the staffing agency **hirelago.com**, distinct from **getlago** (dev-tooling billing, ingested via ashby + workatastartup). Company slug = `normalize.Slug(name)`, so both named 'Lago' collapsed to slug `lago` — merging the agency's ~288 mostly-non-tech postings onto getlago's page.

Renaming getlago itself does NOT fix it (multi-source; the workatastartup aggregator names it 'Lago' and can't be overridden via yml). Renaming the **single-source agency** does: **Hire Lago → slug `hire-lago`**, leaving getlago clean under `lago`. `UpsertJob` updates `company_slug` on conflict, so a re-ingest moves the 288 existing rows off `lago`.