### PR TITLE
feat(status): public /status page for ingest fleet health

### DIFF
--- a/internal/db/board_health.sql.go
+++ b/internal/db/board_health.sql.go
@@ -76,6 +76,64 @@ func (q *Queries) ListUnhealthyBoards(ctx context.Context) ([]ListUnhealthyBoard
 	return items, nil
 }
 
+const providerHealthRollup = `-- name: ProviderHealthRollup :many
+SELECT
+    provider,
+    count(*)                                                         AS total_boards,
+    count(*) FILTER (WHERE consecutive_failures = 0)                 AS healthy_boards,
+    count(*) FILTER (WHERE cooldown_until IS NOT NULL AND cooldown_until > now()) AS cooled_boards,
+    max(last_run_at)::timestamptz                                    AS last_run_at,
+    max(last_success_at)::timestamptz                                AS last_success_at,
+    coalesce(sum(last_ingested_count) FILTER (WHERE consecutive_failures = 0), 0)::bigint AS ingested_total
+FROM board_health
+GROUP BY provider
+ORDER BY provider
+`
+
+type ProviderHealthRollupRow struct {
+	Provider      string             `json:"provider"`
+	TotalBoards   int64              `json:"total_boards"`
+	HealthyBoards int64              `json:"healthy_boards"`
+	CooledBoards  int64              `json:"cooled_boards"`
+	LastRunAt     pgtype.Timestamptz `json:"last_run_at"`
+	LastSuccessAt pgtype.Timestamptz `json:"last_success_at"`
+	IngestedTotal int64              `json:"ingested_total"`
+}
+
+// Per-provider health rollup that backs the public /status page: one row per
+// provider with board counts and freshness. Read-only — it never touches cooldown
+// state. Aggregate-only: it selects no board identifier and no error text, so the
+// public endpoint built on it cannot leak internal detail. ingested_total is
+// coalesced/cast to bigint so it reads as a plain int64 (an all-failing provider
+// yields 0, not NULL).
+func (q *Queries) ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRollupRow, error) {
+	rows, err := q.db.Query(ctx, providerHealthRollup)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ProviderHealthRollupRow{}
+	for rows.Next() {
+		var i ProviderHealthRollupRow
+		if err := rows.Scan(
+			&i.Provider,
+			&i.TotalBoards,
+			&i.HealthyBoards,
+			&i.CooledBoards,
+			&i.LastRunAt,
+			&i.LastSuccessAt,
+			&i.IngestedTotal,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const recordBoardFailure = `-- name: RecordBoardFailure :one
 INSERT INTO board_health (provider, board, consecutive_failures, last_error, last_error_at, last_run_at)
 VALUES ($1, $2, 1, $3, now(), now())

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -604,6 +604,13 @@ type Querier interface {
 	// picks the changed rows up; the IS DISTINCT FROM guard skips unchanged rows, making
 	// re-runs idempotent and cheap.
 	PropagateCollectionsToJobs(ctx context.Context) (int64, error)
+	// Per-provider health rollup that backs the public /status page: one row per
+	// provider with board counts and freshness. Read-only — it never touches cooldown
+	// state. Aggregate-only: it selects no board identifier and no error text, so the
+	// public endpoint built on it cannot leak internal detail. ingested_total is
+	// coalesced/cast to bigint so it reads as a plain int64 (an all-failing provider
+	// yields 0, not NULL).
+	ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRollupRow, error)
 	// Second half of the atomic rebuild: recompute every active day from jobs. `added`
 	// counts jobs by their created_at day; `removed` counts jobs by their CURRENT
 	// closed_at day (NULL = still open, excluded). Days are UTC calendar dates

--- a/internal/db/queries/board_health.sql
+++ b/internal/db/queries/board_health.sql
@@ -45,3 +45,22 @@ SELECT provider, board, consecutive_failures, cooldown_until, last_error, last_e
 FROM board_health
 WHERE consecutive_failures > 0 OR (cooldown_until IS NOT NULL AND cooldown_until > now())
 ORDER BY consecutive_failures DESC, provider, board;
+
+-- name: ProviderHealthRollup :many
+-- Per-provider health rollup that backs the public /status page: one row per
+-- provider with board counts and freshness. Read-only — it never touches cooldown
+-- state. Aggregate-only: it selects no board identifier and no error text, so the
+-- public endpoint built on it cannot leak internal detail. ingested_total is
+-- coalesced/cast to bigint so it reads as a plain int64 (an all-failing provider
+-- yields 0, not NULL).
+SELECT
+    provider,
+    count(*)                                                         AS total_boards,
+    count(*) FILTER (WHERE consecutive_failures = 0)                 AS healthy_boards,
+    count(*) FILTER (WHERE cooldown_until IS NOT NULL AND cooldown_until > now()) AS cooled_boards,
+    max(last_run_at)::timestamptz                                    AS last_run_at,
+    max(last_success_at)::timestamptz                                AS last_success_at,
+    coalesce(sum(last_ingested_count) FILTER (WHERE consecutive_failures = 0), 0)::bigint AS ingested_total
+FROM board_health
+GROUP BY provider
+ORDER BY provider;

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -292,6 +292,11 @@ func Register(app *fiber.App, cfg Config) {
 	// the /open transparency page renders them as a stat-strip.
 	api.Get("/stats/engagement", a.EngagementStats)
 
+	// Public ingest-fleet status, unauthenticated like the other public reads.
+	// A per-provider health rollup over board_health, sanitized (no error text or
+	// board identifiers); the /status page renders it as a status board.
+	api.Get("/status", a.IngestStatus)
+
 	// Per-user job interactions and the user-scoped reads accept either the
 	// session cookie or an API key (RequireAuthOrKey), so a script holding a key
 	// can drive the same flow as the browser. The public job reads above stay

--- a/internal/handler/status.go
+++ b/internal/handler/status.go
@@ -1,0 +1,155 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// providerStatus is the public health verdict for a provider (and the fleet):
+// operational, degraded, or down. String values are the wire encoding.
+type providerStatus string
+
+const (
+	statusOperational providerStatus = "operational"
+	statusDegraded    providerStatus = "degraded"
+	statusDown        providerStatus = "down"
+)
+
+// Status-derivation thresholds. The healthy fraction (healthy/total) classifies a
+// provider so a handful of failing boards can't drag a thousand-board provider
+// into "degraded". Success freshness guards against a provider whose boards all
+// read healthy but haven't actually succeeded in a long time (a stalled crawl).
+// These are the single knobs to tune the policy.
+const (
+	// healthyOperationalFrac: at or above this fraction healthy (and fresh) is green.
+	healthyOperationalFrac = 0.9
+	// healthyDownFrac: at or below this fraction healthy is red regardless of freshness.
+	healthyDownFrac = 0.1
+	// successFreshness: a provider with no success within this window reads down.
+	successFreshness = 48 * time.Hour
+)
+
+// providerRollup is the derivation input for one provider: only the facts the
+// status policy needs (board totals and last-success instant), decoupled from the
+// db row so deriveStatus is a pure, unit-testable function. A zero lastSuccess
+// means "never succeeded".
+type providerRollup struct {
+	total       int64
+	healthy     int64
+	lastSuccess time.Time
+}
+
+// deriveStatus maps a provider's rollup to its status at instant now:
+//   - down    when it has no boards, no fresh success, or ≤10% healthy;
+//   - operational when ≥90% healthy and fresh;
+//   - degraded  otherwise.
+func deriveStatus(r providerRollup, now time.Time) providerStatus {
+	if r.total <= 0 {
+		return statusDown
+	}
+	fresh := !r.lastSuccess.IsZero() && now.Sub(r.lastSuccess) <= successFreshness
+	if !fresh {
+		return statusDown
+	}
+	frac := float64(r.healthy) / float64(r.total)
+	switch {
+	case frac <= healthyDownFrac:
+		return statusDown
+	case frac >= healthyOperationalFrac:
+		return statusOperational
+	default:
+		return statusDegraded
+	}
+}
+
+// overallStatus is the fleet verdict: the worst individual provider status. An
+// empty fleet is operational (nothing is broken).
+func overallStatus(statuses []providerStatus) providerStatus {
+	worst := statusOperational
+	rank := map[providerStatus]int{statusOperational: 0, statusDegraded: 1, statusDown: 2}
+	for _, s := range statuses {
+		if rank[s] > rank[worst] {
+			worst = s
+		}
+	}
+	return worst
+}
+
+// statusProvider is the public, sanitized per-provider entry: board counts,
+// freshness, and the derived status. It deliberately has no field for last_error
+// or board identifiers — sanitization by construction, so an internal detail
+// cannot leak by omission.
+type statusProvider struct {
+	Provider      string         `json:"provider"`
+	Status        providerStatus `json:"status"`
+	TotalBoards   int64          `json:"total_boards"`
+	HealthyBoards int64          `json:"healthy_boards"`
+	CooledBoards  int64          `json:"cooled_boards"`
+	LastRun       *string        `json:"last_run"`
+	LastSuccess   *string        `json:"last_success"`
+	IngestedTotal int64          `json:"ingested_total"`
+}
+
+// IngestStatus serves the public, unauthenticated ingest-fleet status: a
+// per-provider health rollup over board_health with a derived operational/
+// degraded/down status per provider and an overall fleet status. Sanitized by
+// construction — the DTO carries no error text or board identifier — so no
+// internal detail can leak. An empty fleet yields overall "operational" with no
+// providers.
+func (a *API) IngestStatus(c *fiber.Ctx) error {
+	rows, err := a.queries.ProviderHealthRollup(c.Context())
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	providers := make([]statusProvider, len(rows))
+	statuses := make([]providerStatus, len(rows))
+	for i, r := range rows {
+		st := deriveStatus(providerRollup{
+			total:       r.TotalBoards,
+			healthy:     r.HealthyBoards,
+			lastSuccess: tsTime(r.LastSuccessAt),
+		}, now)
+		statuses[i] = st
+		providers[i] = statusProvider{
+			Provider:      r.Provider,
+			Status:        st,
+			TotalBoards:   r.TotalBoards,
+			HealthyBoards: r.HealthyBoards,
+			CooledBoards:  r.CooledBoards,
+			LastRun:       isoOrNil(r.LastRunAt),
+			LastSuccess:   isoOrNil(r.LastSuccessAt),
+			IngestedTotal: r.IngestedTotal,
+		}
+	}
+
+	return c.JSON(fiber.Map{
+		"data": fiber.Map{
+			"overall":      overallStatus(statuses),
+			"generated_at": now.Format(time.RFC3339),
+			"providers":    providers,
+		},
+	})
+}
+
+// tsTime unwraps a nullable timestamp to a time.Time, using the zero value for
+// NULL so deriveStatus reads it as "never".
+func tsTime(ts pgtype.Timestamptz) time.Time {
+	if !ts.Valid {
+		return time.Time{}
+	}
+	return ts.Time
+}
+
+// isoOrNil renders a nullable timestamp as an RFC 3339 UTC string, or nil for
+// NULL so the wire field is `null` rather than a zero date.
+func isoOrNil(ts pgtype.Timestamptz) *string {
+	if !ts.Valid {
+		return nil
+	}
+	s := ts.Time.UTC().Format(time.RFC3339)
+	return &s
+}

--- a/internal/handler/status_integration_test.go
+++ b/internal/handler/status_integration_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+
+// Integration test for the public ingest-status endpoint. The per-provider rollup
+// is SQL over board_health and the handler reads through a concrete *db.Queries,
+// so the wire contract (envelope shape, derived status, and — critically —
+// sanitization) can only be exercised against a real Postgres. It asserts the
+// empty-fleet case, then seeds boards in controlled states and checks the rollup,
+// the derived per-provider and overall status, and that no raw error text or
+// board identifier leaks into the public body.
+// Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestIngestStatusEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	h := &API{pool: pool, queries: db.New(pool)}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/status", h.IngestStatus)
+
+	type providerEntry struct {
+		Provider      string  `json:"provider"`
+		Status        string  `json:"status"`
+		TotalBoards   int     `json:"total_boards"`
+		HealthyBoards int     `json:"healthy_boards"`
+		CooledBoards  int     `json:"cooled_boards"`
+		LastRun       *string `json:"last_run"`
+		LastSuccess   *string `json:"last_success"`
+		IngestedTotal int     `json:"ingested_total"`
+	}
+	type statusData struct {
+		Overall     string          `json:"overall"`
+		GeneratedAt string          `json:"generated_at"`
+		Providers   []providerEntry `json:"providers"`
+	}
+	type envelope struct {
+		Data statusData `json:"data"`
+	}
+
+	get := func(t *testing.T) (envelope, string) {
+		t.Helper()
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, "/api/v1/status", nil))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			t.Fatalf("status = %d, want 200 (public, unauthenticated read)", resp.StatusCode)
+		}
+		raw, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var env envelope
+		if err := json.Unmarshal(raw, &env); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return env, string(raw)
+	}
+
+	// --- Empty fleet: 200, operational, no providers ---------------------------
+	if env, _ := get(t); env.Data.Overall != "operational" || len(env.Data.Providers) != 0 {
+		t.Fatalf("empty fleet: overall=%q providers=%d, want operational/0", env.Data.Overall, len(env.Data.Providers))
+	}
+
+	// --- Seed boards in controlled states --------------------------------------
+	// A healthy board: no failures, fresh success. board id + count control the rollup.
+	healthy := func(provider, board string, ingested int) {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO board_health
+			  (provider, board, consecutive_failures, last_success_at, last_ingested_count, last_run_at)
+			VALUES ($1, $2, 0, now(), $3, now())`, provider, board, ingested); err != nil {
+			t.Fatalf("seed healthy %s/%s: %v", provider, board, err)
+		}
+	}
+	// A failing board: carries a distinctive error text and board id that must NOT
+	// surface in the public body.
+	failing := func(provider, board string) {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO board_health
+			  (provider, board, consecutive_failures, last_error, last_error_at, last_run_at)
+			VALUES ($1, $2, 3, 'SECRET_ERROR_TEXT', now(), now())`, provider, board); err != nil {
+			t.Fatalf("seed failing %s/%s: %v", provider, board, err)
+		}
+	}
+	// A cooled board: failing and currently in an active cooldown window, so it
+	// counts toward both healthy=0 and cooled_boards.
+	cooled := func(provider, board string) {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO board_health
+			  (provider, board, consecutive_failures, last_error, last_error_at, cooldown_until, last_run_at)
+			VALUES ($1, $2, 5, 'SECRET_ERROR_TEXT', now(), now() + interval '1 hour', now())`, provider, board); err != nil {
+			t.Fatalf("seed cooled %s/%s: %v", provider, board, err)
+		}
+	}
+
+	// greenhouse: 2/2 healthy, fresh → operational, ingested_total 100.
+	healthy("greenhouse", "acme", 40)
+	healthy("greenhouse", "globex", 60)
+	// lever: 4/10 healthy (0.4 frac), fresh success present → degraded.
+	for _, b := range []string{"lv1", "lv2", "lv3", "lv4"} {
+		healthy("lever", b, 5)
+	}
+	for _, b := range []string{"secret-board-1", "secret-board-2", "secret-board-3", "secret-board-4", "secret-board-5", "secret-board-6"} {
+		failing("lever", b)
+	}
+	// workday: 5/5 failing, 2 of them in active cooldown, no success at all → down.
+	for _, b := range []string{"secret-wd-1", "secret-wd-2", "secret-wd-3"} {
+		failing("workday", b)
+	}
+	for _, b := range []string{"secret-wd-4", "secret-wd-5"} {
+		cooled("workday", b)
+	}
+
+	env, raw := get(t)
+
+	// Overall = worst(operational, degraded, down) = down.
+	if env.Data.Overall != "down" {
+		t.Errorf("overall = %q, want down", env.Data.Overall)
+	}
+	if env.Data.GeneratedAt == "" {
+		t.Error("generated_at is empty")
+	}
+
+	byProvider := map[string]providerEntry{}
+	for _, p := range env.Data.Providers {
+		byProvider[p.Provider] = p
+	}
+
+	gh, ok := byProvider["greenhouse"]
+	if !ok {
+		t.Fatal("greenhouse missing from providers")
+	}
+	if gh.Status != "operational" || gh.TotalBoards != 2 || gh.HealthyBoards != 2 || gh.IngestedTotal != 100 {
+		t.Errorf("greenhouse = %+v, want operational/2/2/100", gh)
+	}
+
+	lv, ok := byProvider["lever"]
+	if !ok {
+		t.Fatal("lever missing from providers")
+	}
+	if lv.Status != "degraded" || lv.TotalBoards != 10 || lv.HealthyBoards != 4 {
+		t.Errorf("lever = %+v, want degraded/10/4", lv)
+	}
+
+	wd, ok := byProvider["workday"]
+	if !ok {
+		t.Fatal("workday missing from providers")
+	}
+	if wd.Status != "down" || wd.TotalBoards != 5 || wd.HealthyBoards != 0 || wd.CooledBoards != 2 {
+		t.Errorf("workday = %+v, want down/5/0/2 (cooled)", wd)
+	}
+	// A down provider never succeeded, so last_success serializes as null.
+	if wd.LastSuccess != nil {
+		t.Errorf("workday last_success = %v, want null (never succeeded)", *wd.LastSuccess)
+	}
+	// It was still crawled, so last_run is present.
+	if wd.LastRun == nil {
+		t.Error("workday last_run is null, want a timestamp (it was crawled)")
+	}
+
+	// --- Sanitization: no internal detail leaks --------------------------------
+	for _, leak := range []string{"SECRET_ERROR_TEXT", "secret-board", "last_error"} {
+		if strings.Contains(raw, leak) {
+			t.Errorf("public body leaked %q:\n%s", leak, raw)
+		}
+	}
+}

--- a/internal/handler/status_test.go
+++ b/internal/handler/status_test.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"testing"
+	"time"
+)
+
+// statusNow is a fixed reference instant so freshness assertions don't couple to
+// the wall clock.
+var statusNow = time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+
+// fresh/stale success timestamps relative to statusNow and the 48h window.
+var (
+	freshSuccess = statusNow.Add(-1 * time.Hour)  // well within the window
+	staleSuccess = statusNow.Add(-72 * time.Hour) // older than 48h
+)
+
+func TestDeriveStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		roll providerRollup
+		want providerStatus
+	}{
+		{
+			name: "all healthy and fresh is operational",
+			roll: providerRollup{total: 100, healthy: 100, lastSuccess: freshSuccess},
+			want: statusOperational,
+		},
+		{
+			name: "exactly 90 percent healthy and fresh is operational",
+			roll: providerRollup{total: 100, healthy: 90, lastSuccess: freshSuccess},
+			want: statusOperational,
+		},
+		{
+			name: "a minority failing is degraded",
+			roll: providerRollup{total: 100, healthy: 80, lastSuccess: freshSuccess},
+			want: statusDegraded,
+		},
+		{
+			name: "almost all failing is down",
+			roll: providerRollup{total: 100, healthy: 5, lastSuccess: freshSuccess},
+			want: statusDown,
+		},
+		{
+			name: "exactly 10 percent healthy is down",
+			roll: providerRollup{total: 100, healthy: 10, lastSuccess: freshSuccess},
+			want: statusDown,
+		},
+		{
+			name: "healthy counts but stale success is down",
+			roll: providerRollup{total: 100, healthy: 100, lastSuccess: staleSuccess},
+			want: statusDown,
+		},
+		{
+			name: "never succeeded is down",
+			roll: providerRollup{total: 100, healthy: 100}, // zero lastSuccess = never
+			want: statusDown,
+		},
+		{
+			name: "no boards is down (defensive, avoids div-by-zero)",
+			roll: providerRollup{total: 0, healthy: 0, lastSuccess: freshSuccess},
+			want: statusDown,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveStatus(tc.roll, statusNow); got != tc.want {
+				t.Errorf("deriveStatus(%+v) = %q, want %q", tc.roll, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOverallStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []providerStatus
+		want providerStatus
+	}{
+		{"empty fleet is operational", nil, statusOperational},
+		{"all operational is operational", []providerStatus{statusOperational, statusOperational}, statusOperational},
+		{"any degraded drags to degraded", []providerStatus{statusOperational, statusDegraded, statusOperational}, statusDegraded},
+		{"any down drags to down despite degraded", []providerStatus{statusOperational, statusDegraded, statusDown}, statusDown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := overallStatus(tc.in); got != tc.want {
+				t.Errorf("overallStatus(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/openspec/changes/add-status-page/.openspec.yaml
+++ b/openspec/changes/add-status-page/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/add-status-page/design.md
+++ b/openspec/changes/add-status-page/design.md
@@ -1,0 +1,77 @@
+## Context
+
+The ingest fleet records per-board outcomes in `board_health` (migration
+`0006`): one row per `(provider, board)` holding the *latest* result —
+`consecutive_failures`, `cooldown_until`, `last_error`, `last_error_at`,
+`last_success_at`, `last_ingested_count`, `last_run_at`. It is a runtime-state
+sidecar (drives cooldown), not an audit log, so there is no run-by-run history —
+only the current snapshot. Today the data escapes only as a per-run summary log
+(`ListUnhealthyBoards`); no HTTP surface exposes it.
+
+We want a public `/status` page. Constraints: it is public, so raw error text and
+board identifiers must not leak; provider keys are already public (the `sources/`
+board files are in git). The frontend is SvelteKit SSR; the backend is Fiber with
+a public `/health` endpoint the new route sits beside.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A public per-provider health rollup, derived entirely from the existing
+  `board_health` snapshot — no new tables, no writes.
+- A clear operational/degraded/down signal per provider plus an overall banner,
+  robust to noise on large fleets (thousands of boards).
+- Sanitized output: no `last_error`, no board identifiers.
+
+**Non-Goals:**
+- Run-by-run history / time-series (that would need a new `ingest_run` table and
+  a write on every crawl — deferred; noted as a future seam).
+- Per-board drill-down in the public page.
+- Any change to ingest, cooldown, or recording behavior.
+
+## Decisions
+
+**Rollup in SQL, status policy in Go.** A new sqlc query `ProviderHealthRollup`
+does the `GROUP BY provider` aggregation (counts via `FILTER`, `max` timestamps,
+`sum` ingested). The operational/degraded/down classification lives in a pure Go
+function, matching the codebase convention that policy (like backoff) lives in Go
+while SQL stays declarative. This keeps the thresholds unit-testable in isolation.
+
+**Thresholds: 90% / 10% healthy fraction + 48h freshness.** Healthy fraction
+`healthy_boards / total_boards`: `operational` ≥ 0.9 (and fresh), `down` ≤ 0.1 or
+stale (no success in 48h), `degraded` otherwise. A fraction-based rule keeps a
+single failing board out of "degraded" on a 6000-board provider (Workday), which
+a strict any-failure rule could not. Constants so they are easy to tune.
+*Alternative considered:* freshness-only (simplest) — rejected because it hides
+partial breakage; strict any-failure — rejected as perpetually yellow on big
+fleets.
+
+**Overall = worst provider status.** Standard status-page semantics; empty fleet
+→ `operational` (nothing is broken).
+
+**Public unauthenticated endpoint, sanitized DTO.** `GET /api/v1/status` sits
+beside `/health` (no auth middleware). The handler projects the rollup into a DTO
+that simply omits `last_error` and board identifiers — sanitization by
+construction, not by filtering, so a leak can't happen by forgetting a field.
+
+**Provider display name = title-cased key.** No separate label registry (YAGNI);
+`greenhouse` → `Greenhouse` at render time. A registry can come later if labels
+need to diverge from keys.
+
+## Risks / Trade-offs
+
+- **Boards never crawled don't appear** → the page reflects "what we're actively
+  tracking", not the full YAML catalog. Acceptable for a health view; documented.
+- **Snapshot, not history** → a provider that flapped and recovered shows green;
+  the page answers "healthy now?", not "was it flaky?". Accepted per Non-Goals;
+  the future `ingest_run` table is the seam if history is wanted.
+- **Fixed 48h freshness vs varied cadences** → some crons run every 6h, some
+  daily; 48h is a lenient common denominator that won't false-alarm. If a
+  provider legitimately runs less often than 48h, it would read `down` — none
+  currently do; revisit per-provider cadence only if that changes.
+- **Public counts reveal fleet size** → provider board counts become public.
+  Low sensitivity (sources are open); accepted.
+
+## Migration Plan
+
+No DB migration (table exists). Ship backend endpoint + query, then the web page.
+Rollback is removing the route and page — no data or schema to revert.

--- a/openspec/changes/add-status-page/proposal.md
+++ b/openspec/changes/add-status-page/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The ingest fleet's health already lives in the `board_health` table (per-board
+last outcome, cooldown, failure count), but it is only ever surfaced in a
+per-run summary log — there is no way for anyone to *see* how the parsing is
+doing. We want a public `/status` page that answers "are the sources healthy?"
+at a glance, rolled up per ATS provider.
+
+## What Changes
+
+- Add a read-only, per-provider rollup query over `board_health` (grouped by
+  `provider`: total boards, healthy boards, boards in cooldown, last run,
+  last success, ingested total).
+- Add a pure status-derivation policy (in Go) that maps each provider's healthy
+  fraction and success-freshness to `operational` / `degraded` / `down`, plus an
+  overall fleet status.
+- Add a public, unauthenticated `GET /api/v1/status` endpoint returning the
+  sanitized rollup (no raw error text, no board identifiers).
+- Add a public `/status` page in the web app: an overall banner + a flat list of
+  providers with a status pill, board counts, and relative last-run time.
+
+## Capabilities
+
+### New Capabilities
+- `ingest-status-page`: A public status surface — a per-provider health rollup
+  over `board_health`, a status-derivation policy, a public `GET /api/v1/status`
+  endpoint, and a `/status` web page.
+
+### Modified Capabilities
+<!-- None: board_health behavior (recording, cooldown) is unchanged; this change
+     only adds a read surface over the existing snapshot. -->
+
+## Impact
+
+- **DB / queries**: new sqlc query `ProviderHealthRollup` in
+  `internal/db/queries/board_health.sql` (read-only; no migration — the table
+  already exists).
+- **Backend**: new `internal/handler/status.go` (handler + status-derivation
+  policy) and a public route wired next to `/health` in `internal/handler/handler.go`.
+- **Frontend**: new `web/src/routes/status/` page consuming `/api/v1/status`.
+- No new tables, no writes, no auth surface. Existing ingest/cooldown behavior
+  is untouched.

--- a/openspec/changes/add-status-page/specs/ingest-status-page/spec.md
+++ b/openspec/changes/add-status-page/specs/ingest-status-page/spec.md
@@ -1,0 +1,107 @@
+## ADDED Requirements
+
+### Requirement: Per-provider health rollup
+
+The system SHALL provide a read-only rollup over `board_health` grouped by
+`provider`, exposing for each provider: total boards, healthy boards
+(`consecutive_failures = 0`), boards currently in cooldown (`cooldown_until >
+now()`), the most recent `last_run_at`, the most recent `last_success_at`, and
+the sum of `last_ingested_count` over healthy boards. The rollup SHALL be pure
+read: it SHALL NOT modify `board_health` or affect cooldown behavior.
+
+#### Scenario: Rollup aggregates a provider's boards
+
+- **WHEN** a provider has 3 boards recorded in `board_health`, 2 with
+  `consecutive_failures = 0` and 1 in active cooldown
+- **THEN** the rollup returns one row for that provider with `total_boards = 3`,
+  `healthy_boards = 2`, and `cooled_boards = 1`
+
+#### Scenario: Rollup ignores providers with no recorded boards
+
+- **WHEN** a provider exists in the source YAML but has never been crawled (no
+  `board_health` row)
+- **THEN** the rollup returns no row for that provider
+
+### Requirement: Provider status derivation
+
+The system SHALL derive each provider's status from its rollup via a pure
+function using the healthy fraction (`healthy_boards / total_boards`) and success
+freshness:
+
+- `operational` WHEN the healthy fraction is at least 0.9 AND a success occurred
+  within the freshness window (48 hours).
+- `down` WHEN the healthy fraction is at most 0.1, OR no success occurred within
+  the freshness window.
+- `degraded` in every other case.
+
+The thresholds and freshness window SHALL be named constants.
+
+#### Scenario: All boards healthy and fresh
+
+- **WHEN** a provider has 100 boards, all healthy, with a success 1 hour ago
+- **THEN** its derived status is `operational`
+
+#### Scenario: A minority of boards failing
+
+- **WHEN** a provider has 100 boards, 20 failing, with a recent success
+- **THEN** its derived status is `degraded`
+
+#### Scenario: Almost all boards failing
+
+- **WHEN** a provider has 100 boards, 95 failing
+- **THEN** its derived status is `down`
+
+#### Scenario: Stale despite healthy counts
+
+- **WHEN** a provider's boards all show `consecutive_failures = 0` but the most
+  recent `last_success_at` is older than the freshness window
+- **THEN** its derived status is `down`
+
+### Requirement: Overall fleet status
+
+The system SHALL derive an overall fleet status as the worst individual provider
+status: `down` if any provider is `down`, else `degraded` if any provider is
+`degraded`, else `operational`.
+
+#### Scenario: One provider down drags the fleet
+
+- **WHEN** every provider is `operational` except one that is `down`
+- **THEN** the overall status is `down`
+
+#### Scenario: Empty fleet
+
+- **WHEN** there are no providers in the rollup
+- **THEN** the overall status is `operational`
+
+### Requirement: Public status endpoint
+
+The system SHALL expose `GET /api/v1/status` as a public, unauthenticated
+endpoint returning `{ "data": { overall, generated_at, providers[] } }`. Each
+provider entry SHALL include only sanitized fields: provider key, derived status,
+total/healthy/cooled board counts, last run, last success, and ingested total.
+The response SHALL NOT include raw error text (`last_error`) or individual board
+identifiers.
+
+#### Scenario: Anonymous request succeeds
+
+- **WHEN** an unauthenticated client requests `GET /api/v1/status`
+- **THEN** the response is `200` with `data.overall` and a `data.providers`
+  array
+
+#### Scenario: No internal detail leaks
+
+- **WHEN** the response is inspected
+- **THEN** it contains no `last_error` field and no board-level identifiers
+
+### Requirement: Public status page
+
+The web app SHALL serve a public `/status` page that renders the overall fleet
+status as a banner and a flat list of providers, each showing a status pill,
+board counts (total and healthy), and a relative last-run time. The page SHALL be
+reachable without authentication.
+
+#### Scenario: Visitor views the status page
+
+- **WHEN** an unauthenticated visitor opens `/status`
+- **THEN** they see an overall status banner and one row per provider with its
+  status pill and board counts

--- a/openspec/changes/add-status-page/tasks.md
+++ b/openspec/changes/add-status-page/tasks.md
@@ -1,0 +1,19 @@
+## 1. Rollup query
+
+- [x] 1.1 Add `ProviderHealthRollup :many` to `internal/db/queries/board_health.sql` (GROUP BY provider: total/healthy/cooled counts via FILTER, max last_run_at/last_success_at, sum ingested over healthy)
+- [x] 1.2 Regenerate `internal/db` via sqlc; confirm `go build ./...` passes with the new generated method
+
+## 2. Status derivation policy
+
+- [x] 2.1 RED: table test for the pure status-derivation function — operational (≥90% healthy + fresh), degraded (minority failing), down (≤10% healthy), down-when-stale (healthy counts but no success in 48h), and empty-fleet → operational overall
+- [x] 2.2 GREEN: implement `deriveProviderStatus` + overall-status helper + named threshold/freshness constants in `internal/handler/status.go`; tests pass
+
+## 3. Public status endpoint
+
+- [x] 3.1 RED: integration test (build-tag `integration`) — seed `board_health` rows, call `GET /api/v1/status`, assert 200, sanitized DTO shape (overall + providers[]), and absence of `last_error`/board identifiers
+- [x] 3.2 GREEN: implement the handler in `internal/handler/status.go` (rollup → derive → sanitized DTO) and wire the public route beside `/health` in `internal/handler/handler.go`; tests pass
+
+## 4. Public status page
+
+- [x] 4.1 Add `web/src/routes/status/` page: SSR-fetch `/api/v1/status`, render overall banner + flat provider list (status pill, total/healthy counts, relative last-run time)
+- [x] 4.2 Visual-verify the page (headless Chrome screenshot) in operational and degraded states

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,7 @@ import type {
   ActivityPoint,
   UserGrowthPoint,
   EngagementStats,
+  IngestStatus,
   LocationPreferences,
 } from './types';
 
@@ -351,6 +352,13 @@ export function createApi(
    *  Aggregate-only, unauthenticated. */
   async function engagementStats(): Promise<EngagementStats> {
     return requestData<EngagementStats>(`/api/v1/stats/engagement`);
+  }
+
+  /** The public ingest-fleet status: a per-provider health rollup with a derived
+   *  operational/degraded/down verdict and an overall status. Sanitized
+   *  (no error text or board identifiers), aggregate-only, unauthenticated. */
+  async function ingestStatus(): Promise<IngestStatus> {
+    return requestData<IngestStatus>(`/api/v1/status`);
   }
 
   /** List companies, optionally filtered by a name query `q` (a case-insensitive
@@ -896,6 +904,7 @@ export function createApi(
     jobsActivity,
     userGrowth,
     engagementStats,
+    ingestStatus,
     listCompanies,
     getCompany,
     listCompanySubindustries,

--- a/web/src/lib/components/StatusBoard.svelte
+++ b/web/src/lib/components/StatusBoard.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import { timeAgo } from '$lib/utils';
+  import type { HealthStatus, IngestStatus } from '$lib/types';
+
+  // The presentational half of the /status page: given the ingest-fleet rollup (or
+  // null when the API read failed), it renders the overall banner and the
+  // worst-first provider list. Kept separate from the route so it can be previewed
+  // and reasoned about without a live API. The route owns data loading + SEO.
+  let { status }: { status: IngestStatus | null } = $props();
+
+  // Status → display metadata. Tone classes mirror RealityBadge's light/dark
+  // convention; the dot is the at-a-glance signal, the pill spells it out.
+  const STATUS_META: Record<HealthStatus, { label: string; dot: string; pill: string }> = {
+    operational: {
+      label: 'Operational',
+      dot: 'bg-emerald-500',
+      pill: 'border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400',
+    },
+    degraded: {
+      label: 'Degraded',
+      dot: 'bg-amber-500',
+      pill: 'border-amber-500/40 bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    },
+    down: {
+      label: 'Down',
+      dot: 'bg-red-500',
+      pill: 'border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-400',
+    },
+  };
+
+  const OVERALL_HEADLINE: Record<HealthStatus, string> = {
+    operational: 'All systems operational',
+    degraded: 'Partial degradation',
+    down: 'Major outage',
+  };
+
+  const SEVERITY: Record<HealthStatus, number> = { operational: 0, degraded: 1, down: 2 };
+
+  const titleCase = (s: string) => s.charAt(0).toUpperCase() + s.slice(1).replace(/[_-]/g, ' ');
+  const nf = new Intl.NumberFormat('en');
+
+  // Worst-first, then alphabetical — problem providers surface at the top.
+  const providers = $derived(
+    [...(status?.providers ?? [])].sort(
+      (a, b) => SEVERITY[b.status] - SEVERITY[a.status] || a.provider.localeCompare(b.provider),
+    ),
+  );
+  const overall = $derived(status?.overall ?? null);
+</script>
+
+{#if !status || !overall}
+  <div class="rounded-xl border border-border p-8 text-center text-muted-foreground">
+    Status is unavailable right now. Try again in a moment.
+  </div>
+{:else}
+  <!-- Overall banner -->
+  <div class="mb-10 flex items-center gap-4 rounded-xl border p-5 sm:p-6 {STATUS_META[overall].pill}">
+    <span class="inline-flex h-3 w-3 shrink-0 rounded-full {STATUS_META[overall].dot}"></span>
+    <div>
+      <div class="text-lg font-semibold tracking-tight">{OVERALL_HEADLINE[overall]}</div>
+      <div class="text-sm opacity-80">
+        {providers.length} provider{providers.length === 1 ? '' : 's'} monitored
+      </div>
+    </div>
+  </div>
+
+  <!-- Provider list -->
+  <section>
+    <div class="flex items-baseline justify-between">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// providers</p>
+      <!-- A raw JSON API endpoint, not a SvelteKit page route — there is nothing
+           for resolve() to map, so the internal-navigation rule doesn't apply. -->
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
+      <a href="/api/v1/status" class="font-mono text-xs text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">
+        /status ↗
+      </a>
+    </div>
+
+    {#if providers.length === 0}
+      <p class="mt-6 text-sm text-muted-foreground">No providers have run yet.</p>
+    {:else}
+      <ul class="mt-6 divide-y divide-border overflow-hidden rounded-xl border border-border">
+        {#each providers as p (p.provider)}
+          {@const meta = STATUS_META[p.status]}
+          <li class="flex flex-wrap items-center gap-x-4 gap-y-1 bg-background p-4 sm:p-5">
+            <span class="h-2.5 w-2.5 shrink-0 rounded-full {meta.dot}"></span>
+            <div class="min-w-0 flex-1">
+              <div class="font-medium">{titleCase(p.provider)}</div>
+              <div class="text-sm text-muted-foreground">
+                {nf.format(p.healthy_boards)} / {nf.format(p.total_boards)} boards healthy{#if p.cooled_boards > 0}<span
+                    class="text-amber-600 dark:text-amber-500"
+                  >
+                    · {nf.format(p.cooled_boards)} in cooldown</span
+                  >{/if}
+              </div>
+            </div>
+            <div class="flex flex-col items-end gap-1">
+              <span
+                class="inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-medium {meta.pill}"
+              >
+                {meta.label}
+              </span>
+              {#if p.last_run}
+                <span class="text-xs text-muted-foreground" title={p.last_run}>
+                  ran {timeAgo(p.last_run)}
+                </span>
+              {/if}
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+{/if}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -339,6 +339,32 @@ export interface EngagementStats {
   viewed: number;
 }
 
+/** The derived health verdict for a provider (and the fleet) on the public
+ *  /status page. */
+export type HealthStatus = 'operational' | 'degraded' | 'down';
+
+/** One provider's health on the public /status page: board counts, freshness, and
+ *  the derived status. Sanitized — no error text or board identifiers are exposed.
+ *  Timestamps are RFC3339 strings, or null when the provider has never run/succeeded. */
+export interface ProviderHealth {
+  provider: string;
+  status: HealthStatus;
+  total_boards: number;
+  healthy_boards: number;
+  cooled_boards: number;
+  last_run: string | null;
+  last_success: string | null;
+  ingested_total: number;
+}
+
+/** The public ingest-fleet status: the overall (worst-provider) verdict, the
+ *  generation timestamp, and one entry per provider. */
+export interface IngestStatus {
+  overall: HealthStatus;
+  generated_at: string;
+  providers: ProviderHealth[];
+}
+
 /** An API key as returned by the management endpoints — metadata only; the
  *  plaintext token is never part of this shape. `token_prefix` is a short,
  *  non-secret leading slice (e.g. "fhk_Ab12cd") shown so the user can tell keys

--- a/web/src/routes/status/+page.server.ts
+++ b/web/src/routes/status/+page.server.ts
@@ -1,0 +1,19 @@
+import { serverApi } from '$lib/server/api';
+import type { PageServerLoad } from './$types';
+
+// The public /status page pulls the ingest-fleet health live from our own public
+// API. Best-effort: if the read fails, the page renders an "unavailable" state
+// rather than erroring the whole route.
+
+export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
+  const api = serverApi(fetch);
+
+  // The rollup moves slowly (crons run hourly-plus); let the CDN/browser hold it briefly.
+  setHeaders({ 'cache-control': 'public, max-age=60' });
+
+  try {
+    return { status: await api.ingestStatus() };
+  } catch {
+    return { status: null };
+  }
+};

--- a/web/src/routes/status/+page.svelte
+++ b/web/src/routes/status/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import StatusBoard from '$lib/components/StatusBoard.svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const canonical = $derived(`${page.url.origin}/status`);
+</script>
+
+<Seo
+  title="Status — freehire ingest fleet"
+  description="Live health of the freehire ingest fleet: which ATS providers are operational, degraded, or down, rolled up from the crawl's own board-health signal."
+  {canonical}
+/>
+
+<div class="mx-auto w-full max-w-4xl px-4 py-10 sm:py-14">
+  <header class="mb-10">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// system status</p>
+    <h1 class="mt-4 text-4xl font-semibold tracking-tighter sm:text-5xl">Ingest fleet status.</h1>
+    <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+      Live health of every source adapter, rolled up from the crawl's own board-health signal — how
+      recently each ATS provider ran and how many of its boards are healthy.
+    </p>
+  </header>
+
+  <StatusBoard status={data.status} />
+</div>


### PR DESCRIPTION
## Summary

Surface the ingest fleet's health on a **public `/status` page**, rolled up per ATS provider from the existing `board_health` snapshot. No new tables, no writes — a read-only view over data the crawl already records.

- **`ProviderHealthRollup` query** — per-provider board counts (total / healthy / cooled) + freshness (`max(last_run_at)`, `max(last_success_at)`, ingested total). Read-only; never touches cooldown state.
- **Pure status policy** (`internal/handler/status.go`) — healthy-fraction thresholds (≥90% → operational, ≤10% or stale → down, else degraded) with a 48h success-freshness guard, plus a worst-provider overall status. Thresholds are named constants; the policy is unit-tested in isolation.
- **`GET /api/v1/status`** — public, unauthenticated (beside the other `/stats/*` reads). **Sanitized by construction**: the DTO carries no `last_error` and no board identifiers, so internal detail can't leak by omission.
- **`/status` SvelteKit page** — overall banner + worst-first provider list (status pill, `X / Y boards healthy`, cooldown note, relative last-run time). Presentation extracted into `StatusBoard.svelte`; the route just loads data + SEO.

Design decisions and rejected alternatives (freshness-only, strict any-failure) are recorded in `openspec/changes/add-status-page/design.md`.

## Test Plan

- [x] `go build ./...`, `go vet ./...`, gofmt clean, full unit suite green
- [x] Unit: `TestDeriveStatus` / `TestOverallStatus` — thresholds, boundaries (exact 90%/10%), stale, never-succeeded, empty fleet
- [x] Integration (`-tags=integration`): `TestIngestStatusEndpoint` — seeds boards across operational/degraded/down + cooldown, asserts rollup, derived statuses, overall, and **no `SECRET_ERROR_TEXT` / board-id / `last_error` leak** in the public body
- [x] Frontend: `svelte-check` 0 errors, eslint clean, headless-Chrome screenshot verified across all statuses + cooldown

🤖 Generated with [Claude Code](https://claude.com/claude-code)