### PR TITLE
feat(web): show source link on closed job pages

### DIFF
--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -176,18 +176,16 @@
         {/if}
       </div>
 
-      {#if !job.closed_at}
-        <Button
-          variant="primary"
-          href={job.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          onclick={onApplyClick}
-          class="w-full shrink-0 sm:w-auto"
-        >
-          Show <ArrowRight class="size-4" />
-        </Button>
-      {/if}
+      <Button
+        variant="primary"
+        href={job.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        onclick={onApplyClick}
+        class="w-full shrink-0 sm:w-auto"
+      >
+        Show <ArrowRight class="size-4" />
+      </Button>
     </div>
 
     <RealityBadge reality={job.reality} postedAt={job.posted_at} detailed />


### PR DESCRIPTION
On closed job pages (e.g. `/jobs/site-p2p-owner-procter-gamble-p-g-cyw3pecy`) the primary **Show** button was hidden, so there was no way to reach the original posting. Closed postings often stay viewable and are useful for reference.

This removes the `{#if !job.closed_at}` guard so the Show link renders regardless of closed state. The existing "no longer accepting applications" banner below still explains the state.

Frontend-only; no migrations, no new facets. `svelte-check`: 0 errors.