### PR TITLE
feat(sources): spark.work adapter + AgileEngine/Associated Nerd boards

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -244,6 +244,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTraffit(c),
 		NewErecruiter(c),
 		NewQuickin(c),
+		NewSpark(c),
 		NewMindsight(c),
 		NewEnlizt(c),
 		NewJobvite(c),

--- a/internal/sources/spark.go
+++ b/internal/sources/spark.go
@@ -1,0 +1,124 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// spark adapts Spark.work's public career API (hub.spark.work), the ATS behind
+// <workspace>.spark.work career sites. A board is the workspace slug (the subdomain),
+// passed on every request as the X-workspace header, which is how the shared API resolves
+// the tenant. The listing carries each posting's rich fields inline, so no per-posting
+// detail call is needed.
+type spark struct {
+	http HeaderJSONGetter
+}
+
+const (
+	sparkListURL    = "https://hub.spark.work/api/jobOpenings?pageNumber=%d&pageSize=%d"
+	sparkVacancyURL = "https://%s.spark.work/career/job/%d/%s"
+	sparkPageSize   = 100
+	// sparkMaxPages bounds the page walk well above any single workspace's postings.
+	sparkMaxPages = 100
+	// sparkActive is the vacancyStatusId marking a live posting (the platform's status enum
+	// is Upcoming=10, Active=20, Closed=30, Discarded=40, Expired=50); anything else is skipped.
+	sparkActive = 20
+)
+
+// NewSpark builds the Spark.work adapter over the given HTTP client.
+func NewSpark(c HeaderJSONGetter) Source { return spark{http: c} }
+
+func (spark) Provider() string { return "spark" }
+
+// sparkJob is one posting from the listing. name and openDate are stable top-level fields;
+// fields is a form-template-keyed map (numeric field ids -> string values, some null) whose
+// ids vary by workspace, so its semantics are recovered by content, not by id (see sparkBody
+// and sparkMode).
+type sparkJob struct {
+	ID              int64             `json:"id"`
+	Name            string            `json:"name"`
+	VacancyStatusID int               `json:"vacancyStatusId"`
+	OpenDate        string            `json:"openDate"`
+	Fields          map[string]string `json:"fields"`
+}
+
+func (s spark) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; page <= sparkMaxPages; page++ {
+		var resp struct {
+			Items     []sparkJob `json:"items"`
+			PageCount int        `json:"pageCount"`
+		}
+		url := fmt.Sprintf(sparkListURL, page, sparkPageSize)
+		if err := s.http.GetJSONWithHeaders(ctx, url, sparkWorkspace(e.Board), &resp); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("spark: list workspace %s: %w", e.Board, err)
+			}
+			break // partial: keep what earlier pages yielded
+		}
+		for _, it := range resp.Items {
+			if it.VacancyStatusID != sparkActive {
+				continue
+			}
+			mode := sparkMode(it.Fields)
+			jobs = append(jobs, Job{
+				ExternalID:  fmt.Sprintf("%d", it.ID),
+				URL:         fmt.Sprintf(sparkVacancyURL, e.Board, it.ID, sparkSlug(it.Name)),
+				Title:       strings.TrimSpace(it.Name),
+				Company:     e.Company,
+				Description: sparkBody(it.Fields),
+				Remote:      mode == "remote",
+				WorkMode:    mode,
+				PostedAt:    parseRFC3339(it.OpenDate),
+			})
+		}
+		if resp.PageCount > 0 && page >= resp.PageCount {
+			break
+		}
+		if len(resp.Items) < sparkPageSize {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// sparkWorkspace is the per-tenant routing header every Spark.work call carries.
+func sparkWorkspace(board string) map[string]string {
+	return map[string]string{"X-workspace": board}
+}
+
+// sparkBody recovers the description from the form-template fields by content rather than by
+// a workspace-specific field id: the description is the rich-text field, so it is the longest
+// value carrying HTML markup. The value is literal (not entity-escaped) HTML, so it goes
+// straight to the sanitizer. Returns "" when no field looks like rich text.
+func sparkBody(fields map[string]string) string {
+	var best string
+	for _, v := range fields {
+		if strings.Contains(v, "<") && len(v) > len(best) {
+			best = v
+		}
+	}
+	if best == "" {
+		return ""
+	}
+	return sanitizeHTML(best)
+}
+
+// sparkMode recovers the work arrangement from the fields by matching a value against the
+// structured workplace enum, so it stays clean structured signal (never a location heuristic).
+// Returns "" when no field states remote/hybrid/onsite.
+func sparkMode(fields map[string]string) string {
+	for _, v := range fields {
+		if m := workplaceTypeMode(v); m != "" {
+			return m
+		}
+	}
+	return ""
+}
+
+// sparkSlug renders a posting title into the dash-joined slug the career URL uses. The public
+// page resolves by id alone, so the slug is cosmetic; a best-effort rendering suffices.
+func sparkSlug(name string) string {
+	return strings.Join(strings.Fields(name), "-")
+}

--- a/internal/sources/spark_test.go
+++ b/internal/sources/spark_test.go
@@ -1,0 +1,70 @@
+package sources
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSparkProvider(t *testing.T) {
+	if got := NewSpark(nil).Provider(); got != "spark" {
+		t.Errorf("Provider() = %q, want %q", got, "spark")
+	}
+}
+
+// sparkListBody builds a one-page listing with the given items already serialized.
+func sparkListBody(items ...string) string {
+	body := `{"pageCount":1,"page":1,"pageSize":100,"items":[`
+	for i, it := range items {
+		if i > 0 {
+			body += ","
+		}
+		body += it
+	}
+	return body + `]}`
+}
+
+func TestSparkFetchMapsListing(t *testing.T) {
+	// An Active job whose fields carry the description as the lone HTML field and the work
+	// mode as the enum-valued field; recovered by content, not by the numeric field id.
+	active := `{"id":203,"name":"  Business Development Assistant  ","vacancyStatusId":20,` +
+		`"openDate":"2026-07-14T00:00:00+00:00","fields":{` +
+		`"50":"Yerevan","60":"Permanent","120":"<p>Build &amp; grow.</p>","130":"Onsite"}}`
+	// A Closed job (status 30) must be skipped.
+	closed := `{"id":9,"name":"Old Role","vacancyStatusId":30,"openDate":"2026-01-01T00:00:00+00:00","fields":{}}`
+
+	fake := (&routedHTTP{}).route("/api/jobOpenings", sparkListBody(active, closed))
+
+	jobs, err := NewSpark(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "VOLO", Provider: "spark", Board: "volo",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (Closed job must be skipped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "203" {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, "203")
+	}
+	if j.Title != "Business Development Assistant" {
+		t.Errorf("Title = %q, want trimmed name", j.Title)
+	}
+	if want := "https://volo.spark.work/career/job/203/Business-Development-Assistant"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if j.WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want %q (recovered from the enum-valued field)", j.WorkMode, "onsite")
+	}
+	if j.Remote {
+		t.Error("Remote = true, want false for an onsite role")
+	}
+	// The description retains sanitized structural HTML (bluemonday allowlist keeps <p>),
+	// rather than being flattened to plain text.
+	if want := "<p>Build &amp; grow.</p>"; j.Description != want {
+		t.Errorf("Description = %q, want %q (the HTML field, sanitized)", j.Description, want)
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt = nil, want the openDate")
+	}
+}

--- a/sources/quickin.yml
+++ b/sources/quickin.yml
@@ -2,6 +2,8 @@
 # board = the Quickin account slug in jobs.quickin.io/<slug> (resolved to the account's
 # opaque id via api.quickin.io, which keys the paginated jobs listing — see
 # internal/sources/quickin.go).
+- company: Associated Nerd Global
+  board: anerd
 - company: BotCity
   board: botcity
 - company: Igma

--- a/sources/spark.yml
+++ b/sources/spark.yml
@@ -1,0 +1,5 @@
+# Spark.work career sites. Provider is the filename; each entry is company + board.
+# board = the workspace slug in <workspace>.spark.work, passed as the X-workspace header to
+# the shared hub.spark.work API (see internal/sources/spark.go).
+- company: VOLO
+  board: volo

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -53,6 +53,8 @@
   board: aertsen.zohorecruit.in
 - company: African Management Institute
   board: africanmanagers.zohorecruit.com
+- company: AgileEngine
+  board: agileengine.zohorecruit.com
 - company: Agnikul Cosmos
   board: agnikul.zohorecruit.in
 - company: Agrosmart


### PR DESCRIPTION
## What

Closes three coverage gaps found while auditing a batch of pasted job URLs.

**New adapter — Spark.work** (`internal/sources/spark.go`)
- Career sites at `<workspace>.spark.work`, served by the shared `hub.spark.work/api`.
- Tenant resolved by the `X-workspace: <subdomain>` header (public, no auth token).
- Listing `/jobOpenings` carries each posting's fields inline → no per-posting detail call.
- Filters to `vacancyStatusId == 20` (Active).
- **Field mapping by content, not by id:** the `fields` map is keyed by per-workspace
  form-template ids (I could only verify one workspace), so description = the lone rich-text
  (HTML-bearing) field and work-mode = the field whose value matches the workplace enum. This
  is robust across templates. `Location` is left empty (no reliable heuristic) and derived
  downstream from the description, per the `Job.WorkMode` provenance-clean convention.

**Two untracked boards** (adapters already existed):
- `sources/zohorecruit.yml` → AgileEngine (`agileengine.zohorecruit.com`)
- `sources/quickin.yml` → Associated Nerd Global (`anerd`)

## Validation
- `go build ./...`, `go vet`, `gofmt`, `go test ./internal/sources/` — all green.
- Unit test covers mapping + skipping non-Active postings.
- Live run of the adapter through the real HTTP client pulled all 4 VOLO postings correctly
  (title, onsite work-mode, posted date, sanitized HTML description, canonical URL).
- Both new boards validated live at their endpoints (zoho `/jobs/Careers` 200; quickin
  account resolve → 20 published postings).

## Note
Several roles on `anerd`/VOLO are non-tech and will be dropped by the enrichment non-tech gate — expected; the boards are still worth tracking for their engineering roles.