### PR TITLE
fix(sources): drain Workday boards that report total only on page one

### DIFF
--- a/internal/sources/workday.go
+++ b/internal/sources/workday.go
@@ -81,6 +81,11 @@ func (s workday) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 func (s workday) listPostings(ctx context.Context, b workdayBoard) ([]workdayPosting, error) {
 	url := fmt.Sprintf("https://%s/wday/cxs/%s/%s/jobs", b.host, b.tenant, b.site)
 	var postings []workdayPosting
+	// Some boards (e.g. pg.wd5.myworkdayjobs.com) report the real total only on the
+	// first page and total:0 thereafter, so latch the first non-zero total and page
+	// against it — reading each page's total would break after page one and silently
+	// truncate the board, which the 48h unseen sweep then reads as postings removed.
+	total := -1
 	for offset := 0; ; {
 		reqBody := map[string]any{
 			"appliedFacets": map[string]any{},
@@ -100,7 +105,10 @@ func (s workday) listPostings(ctx context.Context, b workdayBoard) ([]workdayPos
 		}
 		postings = append(postings, page.JobPostings...)
 		offset += len(page.JobPostings)
-		if offset >= page.Total {
+		if total < 0 && page.Total > 0 {
+			total = page.Total
+		}
+		if total >= 0 && offset >= total {
 			break
 		}
 	}

--- a/internal/sources/workday_test.go
+++ b/internal/sources/workday_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -119,6 +120,62 @@ func TestWorkdayFetchSkipsFailedDetail(t *testing.T) {
 	}
 	if len(jobs) != 1 || jobs[0].ExternalID != "/job/X/JR-1" {
 		t.Fatalf("want only JR-1 to survive, got %d jobs", len(jobs))
+	}
+}
+
+// pagedWorkday returns a canned list page per call (in order), delegating detail
+// GetJSONs to the embedded routedHTTP. It mimics pg.wd5.myworkdayjobs.com, which
+// reports the real `total` only on the first page and `total:0` thereafter.
+type pagedWorkday struct {
+	*routedHTTP
+	pages []string
+	call  int
+}
+
+func (p *pagedWorkday) PostJSON(_ context.Context, _ string, _, v any) error {
+	body := `{"total":0,"jobPostings":[]}`
+	if p.call < len(p.pages) {
+		body = p.pages[p.call]
+	}
+	p.call++
+	return json.Unmarshal([]byte(body), v)
+}
+
+func workdayDetailBody(title string) string {
+	return `{"jobPostingInfo":{"title":"` + title + `","jobDescription":"<p>x</p>","location":"Berlin, Germany","startDate":"2024-06-11"}}`
+}
+
+// A board reporting total only on its first page must still be drained fully:
+// stopping at a later page's total:0 drops the postings past it, and a dropped
+// posting loses its last_seen_at stamp and is closed by the 48h unseen sweep.
+func TestWorkdayPagesByFirstPageTotal(t *testing.T) {
+	fake := &pagedWorkday{
+		routedHTTP: (&routedHTTP{}).
+			route("A_JR-1", workdayDetailBody("A")).
+			route("B_JR-2", workdayDetailBody("B")).
+			route("C_JR-3", workdayDetailBody("C")).
+			route("D_JR-4", workdayDetailBody("D")),
+		pages: []string{
+			`{"total":4,"jobPostings":[{"title":"A","externalPath":"/job/X/A_JR-1"},{"title":"B","externalPath":"/job/X/B_JR-2"}]}`,
+			`{"total":0,"jobPostings":[{"title":"C","externalPath":"/job/X/C_JR-3"}]}`,
+			`{"total":0,"jobPostings":[{"title":"D","externalPath":"/job/X/D_JR-4"}]}`,
+		},
+	}
+	jobs, err := NewWorkday(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "workday", Board: "acme.wd1.myworkdayjobs.com/Careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 4 {
+		t.Fatalf("len(jobs) = %d, want 4 (all pages drained despite total:0 after page one)", len(jobs))
+	}
+	got := map[string]bool{}
+	for _, j := range jobs {
+		got[j.ExternalID] = true
+	}
+	if !got["/job/X/D_JR-4"] {
+		t.Error("posting on page three missing — pagination stopped early on a later page's total:0")
 	}
 }
 


### PR DESCRIPTION
## Problem

A live Workday posting (`pg.wd5.myworkdayjobs.com/1000` → `Site-P2P-Owner_R000147274`) was marked closed on freehire while the board and posting were fully alive.

Root cause: `pg.wd5` (and other large Workday boards) report the real `total` **only on the first listing page** and `total:0` on every page after. `listPostings` compared each page's `total` against the running offset, so page two's zero tripped `offset >= page.Total` and stopped the crawl at ~40 of **648** postings. Everything past the first page silently dropped, lost its `last_seen_at` stamp, and the 48h unseen sweep (`CloseUnseenJobs`) closed it — a false close. The target posting sits at offset 80.

## Fix

Latch the first non-zero `total` and page against that instead of each page's total; keep the empty-page break as the fallback for boards that never report a total.

## Test

`TestWorkdayPagesByFirstPageTotal` reproduces the truncation (page one total=4, later pages total:0, target on page three) — fails before the fix (3/4 postings), passes after.

## Remediation

Once deployed, the next Workday ingest of the P&G board drains all 648 postings; the upsert's `ON CONFLICT` path clears `closed_at`, auto-reopening the falsely-closed jobs. Same benefit for every large Workday board hit by this quirk.