### PR TITLE
fix(maillink): classify from HTML body when plain-text is empty

### DIFF
--- a/cmd/classify-mail/store.go
+++ b/cmd/classify-mail/store.go
@@ -47,6 +47,7 @@ func (s *dbStore) ClaimBatch(ctx context.Context, leaseSeconds, batchSize int) (
 			FromName: r.FromName,
 			Subject:  r.Subject,
 			Body:     r.BodyText,
+			BodyHTML: r.BodyHtml,
 		}
 	}
 	return out, nil

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gzuidhof/tygo v0.2.21
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056
 	github.com/jhillyerd/enmime v1.3.0
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/meilisearch/meilisearch-go v0.36.3
@@ -87,7 +88,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect

--- a/internal/db/mail_classification.sql.go
+++ b/internal/db/mail_classification.sql.go
@@ -45,7 +45,7 @@ SET claimed_at = now()
 FROM claimable c
 JOIN emails e ON e.id = c.email_id
 WHERE o.id = c.id
-RETURNING o.id, o.email_id, e.user_id, e.thread_id, e.from_name, e.subject, e.body_text
+RETURNING o.id, o.email_id, e.user_id, e.thread_id, e.from_name, e.subject, e.body_text, e.body_html
 `
 
 type ClaimEmailClassificationBatchParams struct {
@@ -61,6 +61,7 @@ type ClaimEmailClassificationBatchRow struct {
 	FromName string `json:"from_name"`
 	Subject  string `json:"subject"`
 	BodyText string `json:"body_text"`
+	BodyHtml string `json:"body_html"`
 }
 
 // Claim a wave of live, unleased entries by stamping claimed_at, newest email first,
@@ -84,6 +85,7 @@ func (q *Queries) ClaimEmailClassificationBatch(ctx context.Context, arg ClaimEm
 			&i.FromName,
 			&i.Subject,
 			&i.BodyText,
+			&i.BodyHtml,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/db/queries/mail_classification.sql
+++ b/internal/db/queries/mail_classification.sql
@@ -27,7 +27,7 @@ SET claimed_at = now()
 FROM claimable c
 JOIN emails e ON e.id = c.email_id
 WHERE o.id = c.id
-RETURNING o.id, o.email_id, e.user_id, e.thread_id, e.from_name, e.subject, e.body_text;
+RETURNING o.id, o.email_id, e.user_id, e.thread_id, e.from_name, e.subject, e.body_text, e.body_html;
 
 -- name: SetEmailClassification :exec
 -- Persist the resolved link + classification and stamp classified_at + model in one

--- a/internal/maillink/body.go
+++ b/internal/maillink/body.go
@@ -1,0 +1,25 @@
+package maillink
+
+import (
+	"strings"
+
+	"github.com/jaytaylor/html2text"
+)
+
+// readableBody picks the text the classifier reads for one email. The plain-text
+// part is preferred; when it is absent (many ATS templates are HTML-only) the
+// HTML part is stripped to readable text so the LLM sees the actual message body
+// rather than only the subject. Length is bounded downstream by the classifier.
+func readableBody(text, html string) string {
+	if strings.TrimSpace(text) != "" {
+		return text
+	}
+	if html == "" {
+		return ""
+	}
+	stripped, err := html2text.FromString(html, html2text.Options{OmitLinks: false})
+	if err != nil {
+		return html // last resort: text among tags beats an empty body
+	}
+	return stripped
+}

--- a/internal/maillink/body_test.go
+++ b/internal/maillink/body_test.go
@@ -1,0 +1,41 @@
+package maillink
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadableBody_PrefersNonWhitespaceText(t *testing.T) {
+	got := readableBody("Thanks for applying, we'll be in touch.", "<p>ignored html</p>")
+	if got != "Thanks for applying, we'll be in touch." {
+		t.Fatalf("plain-text part should be used verbatim, got %q", got)
+	}
+}
+
+func TestReadableBody_HTMLOnlyStripsToReadableText(t *testing.T) {
+	html := `<html><head><style>.x{color:red}</style></head><body>` +
+		`<p>We regret to inform you that we have decided not to proceed.</p></body></html>`
+	got := readableBody("", html)
+	if got == "" {
+		t.Fatal("HTML-only body must not classify to an empty string")
+	}
+	if strings.Contains(got, "<") || strings.Contains(got, "color:red") {
+		t.Fatalf("readable body should be tag/style-free, got %q", got)
+	}
+	if !strings.Contains(got, "decided not to proceed") {
+		t.Fatalf("readable body should carry the message text, got %q", got)
+	}
+}
+
+func TestReadableBody_WhitespaceOnlyTextFallsBackToHTML(t *testing.T) {
+	got := readableBody("   \n\t ", "<p>Interview invitation for next Tuesday.</p>")
+	if !strings.Contains(got, "Interview invitation") {
+		t.Fatalf("whitespace-only text should fall back to HTML, got %q", got)
+	}
+}
+
+func TestReadableBody_BothEmptyYieldsEmpty(t *testing.T) {
+	if got := readableBody("", ""); got != "" {
+		t.Fatalf("both parts empty should yield empty body, got %q", got)
+	}
+}

--- a/internal/maillink/runner.go
+++ b/internal/maillink/runner.go
@@ -30,7 +30,8 @@ type Claimed struct {
 	ThreadID string
 	FromName string
 	Subject  string
-	Body     string
+	Body     string // plain-text part; empty for HTML-only mail (e.g. many ATS templates)
+	BodyHTML string // HTML part, stripped to text as the classifier body fallback
 }
 
 // Application is one of the caller's tracked applications offered to the matcher.
@@ -138,7 +139,7 @@ func (r *Runner) process(ctx context.Context, c Claimed) error {
 		candidates = classifyCandidates(apps)
 	}
 	cls, err := r.classifier.Classify(ctx, mailclassify.Input{
-		FromName: c.FromName, Subject: c.Subject, Body: c.Body, Candidates: candidates,
+		FromName: c.FromName, Subject: c.Subject, Body: readableBody(c.Body, c.BodyHTML), Candidates: candidates,
 	})
 	if err != nil {
 		return err

--- a/internal/maillink/runner_test.go
+++ b/internal/maillink/runner_test.go
@@ -2,6 +2,7 @@ package maillink
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/strelov1/freehire/internal/mailclassify"
@@ -40,10 +41,12 @@ func (s *fakeStore) Fail(context.Context, int64, string, int) error { return nil
 type fakeClassifier struct {
 	out        mailclassify.Classification
 	gotCandCnt int
+	gotBody    string
 }
 
 func (c *fakeClassifier) Classify(_ context.Context, in mailclassify.Input) (mailclassify.Classification, error) {
 	c.gotCandCnt = len(in.Candidates)
+	c.gotBody = in.Body
 	return c.out, nil
 }
 
@@ -80,6 +83,37 @@ func TestRunnerAutoLinksDeterministicMatchAndAdvancesStage(t *testing.T) {
 	}
 	if store.savedOutbox[0] != 100 {
 		t.Errorf("saved outbox id = %d, want 100", store.savedOutbox[0])
+	}
+}
+
+func TestRunnerFeedsHTMLOnlyBodyToClassifier(t *testing.T) {
+	store := &fakeStore{
+		apps: []Application{{JobID: 7, Company: "Fingerprint"}},
+		claimed: []Claimed{{
+			OutboxID: 102, EmailID: 202, UserID: 1,
+			FromName: "Fingerprint Recruiting", Subject: "Regarding your Application to Fingerprint",
+			Body: "", // HTML-only ATS mail: no plain-text part
+			BodyHTML: `<html><body><p>We regret to inform you that we have ` +
+				`decided not to proceed with your application.</p></body></html>`,
+		}},
+	}
+	cls := &fakeClassifier{out: mailclassify.Classification{Signal: mailclassify.SignalRejection, Confidence: 0.9}}
+	r := New(store, cls, "test-model")
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if cls.gotBody == "" {
+		t.Fatal("classifier received an empty body for an HTML-only email")
+	}
+	if !strings.Contains(cls.gotBody, "decided not to proceed") {
+		t.Errorf("classifier body missing message text, got %q", cls.gotBody)
+	}
+	if strings.Contains(cls.gotBody, "<p>") {
+		t.Errorf("classifier body should be tag-free, got %q", cls.gotBody)
+	}
+	if store.saved[0].Signal != mailclassify.SignalRejection {
+		t.Errorf("persisted signal = %q, want rejection", store.saved[0].Signal)
 	}
 }
 

--- a/openspec/changes/mail-classify-html-body-fallback/.openspec.yaml
+++ b/openspec/changes/mail-classify-html-body-fallback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/mail-classify-html-body-fallback/design.md
+++ b/openspec/changes/mail-classify-html-body-fallback/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The classify-mail worker (`internal/maillink`) resolves each inbox email to an
+application and classifies its status via an LLM (`internal/mailclassify`). The
+LLM `Input.Body` is currently fed straight from `emails.body_text`, which the
+`ClaimEmailClassificationBatch` query is the only source of. HTML-only ATS mail
+has an empty `body_text`, so the LLM classifies from subject alone.
+
+The Gmail sync already extracts and stores both parts (`bodies()` in
+`internal/gmailsync/gmailapi.go` → `emails.body_text`, `emails.body_html`). The
+gap is purely which column the classifier query reads.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The classifier always receives the actual message text when it exists in
+  either part, so HTML-only rejections are no longer misread as `screening`.
+- Keep the change surgical: no prompt/vocabulary/stage-rule changes, no change to
+  what `body_text`/`body_html` mean at rest, no new top-level dependency.
+
+**Non-Goals:**
+- Re-classifying already-stored, already-misclassified emails (an ops re-enqueue,
+  tracked separately).
+- Fixing the same latent gap in the SES/hosted-mailbox ingest path
+  (`internal/mailingest`) — that path did not produce the reported bug.
+- HTML sanitization for display (the reading pane already renders `body_html`).
+
+## Decisions
+
+- **Fix in the worker, not at ingest.** `readableBody(text, html)` derives the
+  classifier body at classify time. This fixes already-stored rows on
+  re-classification without a data backfill and leaves `body_text` semantics
+  intact (chosen with the user over the ingest-time alternative).
+- **Selection order:** prefer `text` when `strings.TrimSpace(text) != ""` (Gmail
+  sometimes stores a whitespace-only plain part); else strip `html` via
+  `html2text.FromString`; if stripping errors, fall back to the raw `html`
+  (text-among-tags beats an empty body); if both are empty, return `""` and the
+  classifier keeps working from the subject as today.
+- **Length is bounded downstream** by the classifier's `TruncateRunes(...,
+  maxBodyRunes)`, so `readableBody` does not truncate.
+- **Plumbing:** `ClaimEmailClassificationBatch` returns `e.body_html`;
+  `maillink.Claimed` gains `BodyHTML`; the store maps it; the runner passes
+  `readableBody(c.Body, c.BodyHTML)`.
+
+## Risks / Trade-offs
+
+- `html2text` output is lossy vs. the original HTML, but it is strictly more
+  signal than the empty string the LLM sees today; acceptable and bounded.
+- Promoting `html2text` from indirect to direct dependency is intentional and
+  low-risk (already compiled into the binary via `enmime`).

--- a/openspec/changes/mail-classify-html-body-fallback/proposal.md
+++ b/openspec/changes/mail-classify-html-body-fallback/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+The mail classifier that maps an inbox email onto an application stage reads only
+the plain-text body (`emails.body_text`). Many ATS senders (Gem, Ashby,
+Greenhouse) send **HTML-only** mail with no `text/plain` part, so `body_text` is
+empty and the classifier sees only the sender name and subject. A real rejection
+("Regarding your Application to Fingerprint" → "we regret to inform you… not to
+proceed") then gets classified as `screening`, because the bare subject reads
+like a recruiter reaching out. Users see wrong application stages.
+
+The full message text is already stored in `emails.body_html`; it just never
+reaches the classifier. The fix is small and adds no new dependency
+(`github.com/jaytaylor/html2text` is already an indirect dep via `enmime`).
+
+## What Changes
+
+- The classify-mail worker feeds the classifier the email's **readable body**:
+  the plain-text part when it has real content, otherwise the HTML part stripped
+  to text. The reading pane still renders the rich HTML unchanged.
+- `ClaimEmailClassificationBatch` also returns `emails.body_html`; the worker's
+  `Claimed` carries it; a new pure `readableBody(text, html)` selects the source.
+- No change to the classification prompt, the controlled vocabulary, the stage
+  rules, or stored-data semantics (`body_text`/`body_html` keep their meanings).
+
+## Capabilities
+
+### New Capabilities
+- `email-body-classification`: how the readable body is selected from an email's
+  plain-text and HTML parts before it is classified.
+
+### Modified Capabilities
+<!-- none: the parent email-application-linking capability is not yet in main specs -->
+
+## Impact
+
+- `internal/db/queries/mail_classification.sql` (+ regenerated sqlc): claim query
+  returns `body_html`.
+- `internal/maillink/`: `Claimed.BodyHTML`, new `readableBody` helper, runner
+  wiring.
+- `cmd/classify-mail/store.go`: map `body_html` into `Claimed`.
+- Dependency `github.com/jaytaylor/html2text` promoted from indirect to direct.
+- Operational (out of scope here): re-classifying already-misclassified emails
+  requires re-enqueueing them (reset `classified_at`); noted, not done in code.

--- a/openspec/changes/mail-classify-html-body-fallback/specs/email-body-classification/spec.md
+++ b/openspec/changes/mail-classify-html-body-fallback/specs/email-body-classification/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Classifier reads the readable email body
+
+The mail classifier SHALL be given the email's readable body, selected from its
+plain-text and HTML parts, so that HTML-only messages are classified from their
+actual content rather than from the subject alone.
+
+The readable body SHALL be the plain-text part when that part contains
+non-whitespace text; otherwise it SHALL be the HTML part converted to readable
+text; when HTML-to-text conversion fails it SHALL be the raw HTML; when neither
+part has content it SHALL be empty.
+
+Selecting the readable body SHALL NOT change how the email is stored: the
+plain-text and HTML parts are preserved unchanged for display.
+
+#### Scenario: HTML-only rejection is classified from its body
+
+- **WHEN** an email has an empty plain-text part and an HTML body that says the
+  application will not proceed
+- **THEN** the classifier receives the HTML stripped to readable text
+- **AND** the email is classified as a rejection, not as screening
+
+#### Scenario: Plain-text part is preferred when present
+
+- **WHEN** an email has a non-empty plain-text part and also an HTML part
+- **THEN** the classifier receives the plain-text part unchanged
+
+#### Scenario: Whitespace-only plain-text falls back to HTML
+
+- **WHEN** an email's plain-text part contains only whitespace and its HTML part
+  has content
+- **THEN** the classifier receives the HTML stripped to readable text
+
+#### Scenario: Both parts empty yields an empty body
+
+- **WHEN** an email has neither a plain-text nor an HTML part
+- **THEN** the readable body is empty and classification proceeds from the
+  sender and subject

--- a/openspec/changes/mail-classify-html-body-fallback/tasks.md
+++ b/openspec/changes/mail-classify-html-body-fallback/tasks.md
@@ -1,0 +1,23 @@
+## 1. readableBody helper (behavioral core)
+
+- [x] 1.1 RED: unit-test `readableBody(text, html)` for all four spec scenarios —
+      non-whitespace text preferred; whitespace-only text falls back to stripped
+      HTML; HTML-only yields readable text (no tags); both-empty yields "".
+- [x] 1.2 GREEN: implement `readableBody` in `internal/maillink/body.go` (prefer
+      trimmed text, else `html2text.FromString`, raw html on strip error, "" when
+      both empty). REFACTOR + simplify under green.
+
+## 2. body_html plumbing to the classifier
+
+- [x] 2.1 Verify claim query returns `e.body_html`, `Claimed.BodyHTML` is mapped
+      by the store, and the runner passes `readableBody(c.Body, c.BodyHTML)`.
+- [x] 2.2 RED→GREEN: runner test proving an HTML-only email reaches the classifier
+      with the stripped body (fake classifier captures `Input.Body`) and that its
+      rejection signal is what gets persisted, not screening.
+
+## 3. Dependency + verification
+
+- [x] 3.1 Promote `github.com/jaytaylor/html2text` from indirect to direct in
+      `go.mod`; `go mod tidy`.
+- [x] 3.2 `go build ./... && go vet ./... && go test ./internal/maillink/...
+      ./internal/mailclassify/... ./cmd/classify-mail/...` all green.

--- a/scripts/reclassify_htmlonly_emails.sql
+++ b/scripts/reclassify_htmlonly_emails.sql
@@ -1,0 +1,40 @@
+-- One-off: re-classify HTML-only emails the pre-fix classifier misread.
+--
+-- Before the readableBody fix (PR #726), the classifier read only emails.body_text.
+-- HTML-only ATS mail (Gem, Ashby, Greenhouse) has an empty body_text, so those
+-- emails were classified from the subject alone (e.g. a rejection read as
+-- "screening"). This resets the "done" marker for exactly that set so the next
+-- cmd/classify-mail run re-enqueues and re-classifies them with the HTML body.
+--
+-- Run as role hire, and ONLY AFTER the fix is deployed — running it against the
+-- old binary would re-produce the same wrong result. Sequence:
+--   1. deploy PR #726
+--   2. (preview) run the SELECT below to see how many rows are affected
+--   3. run the UPDATE
+--   4. run `cmd/classify-mail` (its EnqueuePending sweep re-enqueues the reset rows)
+--
+-- Targeted: whitespace-only body_text WITH a non-empty body_html, already
+-- classified. Correctly-classified plain-text mail is left untouched (no LLM spend).
+--
+-- Caveat: this corrects emails.status_signal and the link, but does NOT un-advance
+-- an application stage that the first (wrong) classification already moved forward
+-- — stage advancement only moves forward and rejection never auto-applies. Jobs
+-- wrongly bumped to "screening" must be corrected by the user in /my/tracking.
+
+-- Preview (run first):
+-- SELECT count(*) FROM public.emails
+--  WHERE classified_at IS NOT NULL AND btrim(body_text) = '' AND body_html <> '';
+
+UPDATE public.emails
+SET classified_at = NULL
+WHERE classified_at IS NOT NULL
+  AND btrim(body_text) = ''
+  AND body_html <> '';
+
+-- Belt-and-suspenders: drop any leftover outbox rows for the target set so the
+-- enqueue sweep re-inserts clean entries (classified rows normally have none).
+DELETE FROM public.email_classification_outbox o
+USING public.emails e
+WHERE o.email_id = e.id
+  AND btrim(e.body_text) = ''
+  AND e.body_html <> '';


### PR DESCRIPTION
## Summary
- HTML-only ATS mail (Gem, Ashby, Greenhouse) has an empty `emails.body_text`, so the mail classifier saw only the subject and misread rejections as `screening` (the reported Gem "Regarding your Application to Fingerprint" rejection).
- The classifier now reads a **readable body**: the plain-text part when it has non-whitespace content, otherwise the HTML part stripped to text via `html2text` (promoted from indirect → direct dep; already compiled in via `enmime`).
- Plumbing: `ClaimEmailClassificationBatch` also returns `body_html`; `maillink.Claimed` carries `BodyHTML`; the store maps it; the runner passes `readableBody(c.Body, c.BodyHTML)` to the classifier.
- No change to the classification prompt, controlled vocabulary, stage rules, or stored-data semantics (`body_text`/`body_html` keep their meanings; the reading pane still renders rich HTML).

Planned under OpenSpec change `mail-classify-html-body-fallback` (proposal/design/specs/tasks included).

## Test Plan
- [x] `readableBody` unit tests cover all four cases: plain-text preferred; whitespace-only → HTML; HTML-only → tag-free text; both-empty → "".
- [x] Runner test proves an HTML-only email reaches the classifier with the stripped body and persists the rejection signal (RED verified by temporarily reverting the wiring).
- [x] `go build ./... && go vet ./...` clean; `go test ./internal/maillink/... ./internal/mailclassify/... ./internal/gmailsync/...` green.
- [x] Code review: no Critical/Important findings.

## Follow-up (not in this PR)
- Re-classifying already-misclassified emails is an ops re-enqueue (reset `classified_at`); tracked, not done here.