### PR TITLE
feat(web): PostHog product analytics — replay, funnel events, feature-flag seam

### DIFF
--- a/openspec/changes/add-posthog-analytics/.openspec.yaml
+++ b/openspec/changes/add-posthog-analytics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/add-posthog-analytics/design.md
+++ b/openspec/changes/add-posthog-analytics/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The SvelteKit SSR frontend (`web/`) already loads GA4 inline in `app.html`
+(pageviews only, skipped on localhost) and Sentry via `hooks.client.ts`
+(env-gated by `PUBLIC_SENTRY_DSN`, errors-only, `sendDefaultPii:false`). The
+signed-in user is resolved server-side in `+layout.server.ts` and exposed as
+`page.data.user` everywhere. There is no cookie-consent banner today. CSP is set
+at the nginx layer on host2 (the reason `gtag` is partially ad-block/CSP dropped).
+
+PostHog Cloud EU is chosen for data residency (the site handles CV, inbox, and
+tracking PII).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Product funnel analytics (`search → job_view → apply/save/track`).
+- Session replay on public routes to debug filter/swipe UX.
+- One client feature flag as a demonstrator (non-tech default).
+- Zero external hosts in CSP; resilient to ad-blockers.
+- Inert-by-default, mirroring the Sentry env-gating pattern.
+
+**Non-Goals:**
+- Removing GA4 (kept for SEO/traffic; the two do not merge).
+- Server-side flag evaluation or migrating the backend `beta_tester` gate to
+  PostHog (noted as a seam; needs a server SDK + SSR flag reads).
+- A cookie-consent banner (deferred gap; matches current GA posture).
+- Formal A/B experiments (let events accumulate first).
+
+## Decisions
+
+- **SDK via npm (`posthog-js`), init in `hooks.client.ts`** — mirrors Sentry;
+  bundled into app JS so nothing external loads. Env-gated by
+  `PUBLIC_POSTHOG_KEY`; `capture_pageview:false` (SPA nav captured manually),
+  `person_profiles:'identified_only'` (no anon profiles → saves quota),
+  `session_recording:{ maskAllInputs:true }`.
+- **Reverse proxy `/ingest/`** (nginx, `freehire-ops`) → `eu.i.posthog.com`
+  (+ `/ingest/static/` → `eu-assets.i.posthog.com`). `api_host:'/ingest'`,
+  `ui_host:'https://eu.posthog.com'`. Location block must precede the SvelteKit
+  catch-all. Documented here; applied out of band (no change in this repo). Watch
+  for `proxy_buffer_size` 502s on large replay payloads (known host2 quirk).
+- **Routing-dependent logic centralized in `+layout.svelte` `afterNavigate`**:
+  capture `$pageview`; `identify(user.id)` / `reset()` on auth transitions
+  (id only, no email); toggle replay — `stopSessionRecording()` on `/my/*` and
+  inbox, `startSessionRecording()` elsewhere.
+- **`src/lib/analytics.ts` wrapper** exposing `track(event, props)` and flag
+  helpers; every call safe no-op when PostHog is uninitialized. Funnel events
+  fire on the UI action regardless of auth (unlike the authed-only interaction
+  API). Autocapture stays on for the long tail.
+- **Feature flag** read client-side via the analytics module to control
+  `default-hide-nontech`; falls back to the existing hardcoded default when the
+  flag is unavailable.
+
+## Risks / Trade-offs
+
+- **No consent banner + EU replay** — recording DOM on an EU property without
+  consent is a known GDPR gap. Mitigated by `maskAllInputs` + private-route
+  exclusion; accepted for now to match GA posture, flagged for a later pass.
+- **Replay toggle races the first paint** — `afterNavigate` fires after mount, so
+  a private route entered via full reload could record briefly. Mitigation:
+  also evaluate the route on initial load, not only on navigation.
+- **GA4 + PostHog overlap** on pageviews — accepted; they serve different
+  consumers (SEO vs product). No attempt to reconcile counts.
+- **Quota** — free tier is 1M events + 5k replays/mo; `identified_only` profiles
+  and public-only replay keep usage down. Revisit if we approach the ceiling.

--- a/openspec/changes/add-posthog-analytics/proposal.md
+++ b/openspec/changes/add-posthog-analytics/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+GA4 tells us pageviews but nothing about the product funnel — how many searchers
+reach a job page, how many of those apply/save/track, or where users fight the
+filter and swipe UIs. We have no way to record real sessions, and feature gating
+(e.g. non-tech default) is hardcoded with no way to flip it without a deploy.
+PostHog Cloud (EU) closes all three gaps with one client SDK.
+
+## What Changes
+
+- Add `posthog-js`, initialized in `hooks.client.ts`, env-gated by
+  `PUBLIC_POSTHOG_KEY` — fully inert when the key is absent (mirrors the Sentry
+  integration; no key in dev = silent).
+- Route all PostHog traffic through a same-origin reverse proxy (`/ingest/`) so
+  ad-blockers and CSP don't drop events; no external host is added to CSP.
+- Capture SPA pageviews, `identify`/`reset` signed-in users by id only (no
+  email — matches `sendDefaultPii:false`), all from `+layout.svelte`
+  `afterNavigate`.
+- Enable **session replay** with `maskAllInputs`, and disable recording entirely
+  on private routes (`/my/*`, inbox) via a route-based toggle.
+- Emit a small set of explicit funnel events (`search`, `job_view`, `job_apply`,
+  `job_save`, `job_track`) through a thin `$lib/analytics.ts` wrapper; keep
+  autocapture on for everything else.
+- Wire one client-side **feature flag** as a demonstrator gating the
+  `default-hide-nontech` default. Backend flag migration is out of scope.
+
+## Capabilities
+
+### New Capabilities
+- `product-analytics`: client-side product analytics via PostHog — env-gated init
+  behind a same-origin reverse proxy, SPA pageview capture, identity binding,
+  privacy-scoped session replay, explicit funnel events, and a client feature
+  flag.
+
+### Modified Capabilities
+<!-- No existing spec's requirements change. GA4 stays; error-tracking (Sentry)
+     is untouched and complementary. -->
+
+## Impact
+
+- **Frontend (`web/`)**: `package.json` (+`posthog-js`), `hooks.client.ts`
+  (init), `+layout.svelte` (pageview/identify/replay toggle), new
+  `src/lib/analytics.ts`, and funnel-event call sites on `/jobs` search + job
+  action buttons (apply/save/track).
+- **Env**: new `PUBLIC_POSTHOG_KEY` (and optional `PUBLIC_POSTHOG_HOST`,
+  defaulting to `/ingest`). Documented in config; absent in dev.
+- **Ops (`freehire-ops`, host2 nginx)**: a `/ingest/` reverse-proxy location
+  block to `eu.i.posthog.com` (+ static assets). Documented here, applied out of
+  band — no change in this repo.
+- **Not touched**: GA4 (kept for SEO/traffic), Sentry, backend, no cookie-consent
+  banner (deferred gap, matches current GA posture).

--- a/openspec/changes/add-posthog-analytics/proposal.md
+++ b/openspec/changes/add-posthog-analytics/proposal.md
@@ -21,8 +21,10 @@ PostHog Cloud (EU) closes all three gaps with one client SDK.
 - Emit a small set of explicit funnel events (`search`, `job_view`, `job_apply`,
   `job_save`, `job_track`) through a thin `$lib/analytics.ts` wrapper; keep
   autocapture on for everything else.
-- Wire one client-side **feature flag** as a demonstrator gating the
-  `default-hide-nontech` default. Backend flag migration is out of scope.
+- Expose a generic client-side **feature-flag reader** (`isFeatureEnabled`) as
+  the flag capability. Wiring a concrete product default (e.g.
+  `default-hide-nontech`, not on origin/main) is left as a seam; backend flag
+  migration is out of scope.
 
 ## Capabilities
 

--- a/openspec/changes/add-posthog-analytics/specs/product-analytics/spec.md
+++ b/openspec/changes/add-posthog-analytics/specs/product-analytics/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Env-gated PostHog initialization
+
+The frontend SHALL initialize the PostHog client only when `PUBLIC_POSTHOG_KEY`
+is set, and SHALL remain fully inert (no network calls, no globals mutated) when
+it is absent. Initialization SHALL configure a same-origin API host and
+`identified_only` person profiles.
+
+#### Scenario: Key present
+
+- **WHEN** the client app boots with `PUBLIC_POSTHOG_KEY` set
+- **THEN** PostHog is initialized with `api_host` pointing at the same-origin
+  reverse-proxy path and `person_profiles: 'identified_only'`
+
+#### Scenario: Key absent
+
+- **WHEN** the client app boots without `PUBLIC_POSTHOG_KEY` (e.g. local dev)
+- **THEN** PostHog is not initialized and no analytics network requests are made
+
+### Requirement: Same-origin reverse proxy
+
+PostHog event ingestion and session-replay assets SHALL be served through a
+same-origin path (`/ingest/`) that proxies to the EU PostHog instance, so that
+no external host is added to the Content-Security-Policy and ad-blockers cannot
+drop the traffic.
+
+#### Scenario: Events go through the proxy
+
+- **WHEN** the client captures any event
+- **THEN** the request targets the same-origin `/ingest/` path, not an external
+  `*.posthog.com` host
+
+### Requirement: SPA pageview capture
+
+Because automatic pageview capture is disabled, the app SHALL capture a
+`$pageview` event on every client-side navigation.
+
+#### Scenario: Client-side navigation
+
+- **WHEN** the user navigates between routes without a full page reload
+- **THEN** a `$pageview` event is captured for the new route
+
+### Requirement: Identity binding without PII
+
+The app SHALL identify a signed-in user to PostHog by user id only, never
+sending email or other PII, and SHALL reset identity when the user signs out.
+
+#### Scenario: Signed-in user
+
+- **WHEN** `page.data.user` is present after navigation
+- **THEN** the user is identified by id only, with no email in the identify call
+
+#### Scenario: Signed-out transition
+
+- **WHEN** the user transitions from signed-in to signed-out
+- **THEN** `posthog.reset()` is called so subsequent events are anonymous
+
+### Requirement: Privacy-scoped session replay
+
+Session replay SHALL be enabled with all inputs masked, and SHALL be disabled on
+private routes (`/my/*` and the inbox) so that sensitive content (résumé,
+tracking, email) is never recorded.
+
+#### Scenario: Public route
+
+- **WHEN** the user is on a public route (e.g. `/jobs`)
+- **THEN** session recording is active with input values masked
+
+#### Scenario: Private route
+
+- **WHEN** the user navigates to a route under `/my` or the inbox
+- **THEN** session recording is stopped for the duration of that route
+
+### Requirement: Explicit funnel events
+
+The app SHALL emit explicit events for the core funnel — `search`, `job_view`,
+`job_apply`, `job_save`, `job_track` — through a single analytics module, fired
+on the UI action regardless of authentication state. A no-op SHALL be safe when
+PostHog is uninitialized.
+
+#### Scenario: Anonymous user applies
+
+- **WHEN** an unauthenticated user clicks Apply on a job
+- **THEN** a `job_apply` event is captured with the job slug and source
+
+#### Scenario: PostHog uninitialized
+
+- **WHEN** a tracked action fires while PostHog is not initialized
+- **THEN** the analytics call is a safe no-op and does not throw
+
+### Requirement: Client feature flag
+
+The app SHALL read a client-side PostHog feature flag to control the
+`default-hide-nontech` default, falling back to the current hardcoded default
+when the flag is unavailable.
+
+#### Scenario: Flag resolves
+
+- **WHEN** the PostHog feature flag for the non-tech default is available
+- **THEN** the default hide-non-tech behavior follows the flag value
+
+#### Scenario: Flag unavailable
+
+- **WHEN** the flag cannot be resolved (PostHog inert or flags not loaded)
+- **THEN** the app uses its existing hardcoded default with no error

--- a/openspec/changes/add-posthog-analytics/specs/product-analytics/spec.md
+++ b/openspec/changes/add-posthog-analytics/specs/product-analytics/spec.md
@@ -89,18 +89,19 @@ PostHog is uninitialized.
 - **WHEN** a tracked action fires while PostHog is not initialized
 - **THEN** the analytics call is a safe no-op and does not throw
 
-### Requirement: Client feature flag
+### Requirement: Client feature flag reader
 
-The app SHALL read a client-side PostHog feature flag to control the
-`default-hide-nontech` default, falling back to the current hardcoded default
-when the flag is unavailable.
+The app SHALL expose a generic client-side feature-flag reader that returns a
+PostHog flag's value when available and a caller-supplied fallback otherwise.
+Wiring specific product defaults (e.g. `default-hide-nontech`) to flags is out of
+scope here and left as a seam until those features land.
 
 #### Scenario: Flag resolves
 
-- **WHEN** the PostHog feature flag for the non-tech default is available
-- **THEN** the default hide-non-tech behavior follows the flag value
+- **WHEN** a caller reads a feature flag that PostHog has loaded
+- **THEN** the reader returns the flag's value
 
 #### Scenario: Flag unavailable
 
 - **WHEN** the flag cannot be resolved (PostHog inert or flags not loaded)
-- **THEN** the app uses its existing hardcoded default with no error
+- **THEN** the reader returns the caller-supplied fallback with no error

--- a/openspec/changes/add-posthog-analytics/tasks.md
+++ b/openspec/changes/add-posthog-analytics/tasks.md
@@ -1,0 +1,54 @@
+## 1. Dependency & config
+
+- [ ] 1.1 Add `posthog-js` to `web/package.json` and install
+- [ ] 1.2 Document `PUBLIC_POSTHOG_KEY` (+ optional `PUBLIC_POSTHOG_HOST`
+      defaulting to `/ingest`) in the frontend env/config reference; confirm dev
+      leaves the key unset
+
+## 2. Analytics module (`src/lib/analytics.ts`)
+
+- [ ] 2.1 Write failing vitest for the pure helpers: `isPrivateRoute(path)` (true
+      for `/my/*` and inbox, false for public), `track()` no-op safety when
+      uninitialized, and the non-tech flag fallback resolver
+- [ ] 2.2 Implement `analytics.ts`: `track(event, props)`, `identifyUser(user)` /
+      `resetIdentity()` (id only, no email), `syncReplayForRoute(path)`, and
+      `nonTechDefaultHidden()` flag reader with hardcoded fallback — all safe
+      no-ops when PostHog is uninitialized; make tests green
+- [ ] 2.3 simplify pass on the module; re-run vitest green
+
+## 3. Initialization (`hooks.client.ts`)
+
+- [ ] 3.1 Initialize PostHog env-gated by `PUBLIC_POSTHOG_KEY` with `api_host`
+      `/ingest`, `ui_host` EU, `capture_pageview:false`,
+      `person_profiles:'identified_only'`, `session_recording:{maskAllInputs:true}`;
+      inert when key absent (mirror Sentry block)
+
+## 4. Routing-dependent wiring (`+layout.svelte`)
+
+- [ ] 4.1 In `afterNavigate` (and on initial load): capture `$pageview`, call
+      `identifyUser`/`resetIdentity` from `page.data.user`, and
+      `syncReplayForRoute` to start/stop recording per route
+
+## 5. Funnel events
+
+- [ ] 5.1 Fire `search` on `/jobs` when filters/query are applied (query + active
+      facet count)
+- [ ] 5.2 Fire `job_view` on job card/page open (slug, source)
+- [ ] 5.3 Fire `job_apply`, `job_save`, `job_track` on the respective action
+      buttons (slug, source; stage for track) — independent of auth state
+
+## 6. Feature flag demonstrator
+
+- [ ] 6.1 Gate the `default-hide-nontech` default via `nonTechDefaultHidden()`,
+      preserving current behavior when the flag is unavailable
+
+## 7. Ops documentation
+
+- [ ] 7.1 Document the `/ingest/` nginx reverse-proxy location block (events +
+      static assets → `eu.i.posthog.com`) for `freehire-ops`, ordered before the
+      SvelteKit catch-all
+
+## 8. Verify
+
+- [ ] 8.1 Run `svelte-check` + vitest; visual-verify a public route emits events
+      to `/ingest` and a `/my/*` route does not record (dev with a test key)

--- a/openspec/changes/add-posthog-analytics/tasks.md
+++ b/openspec/changes/add-posthog-analytics/tasks.md
@@ -1,54 +1,59 @@
 ## 1. Dependency & config
 
-- [ ] 1.1 Add `posthog-js` to `web/package.json` and install
-- [ ] 1.2 Document `PUBLIC_POSTHOG_KEY` (+ optional `PUBLIC_POSTHOG_HOST`
+- [x] 1.1 Add `posthog-js` to `web/package.json` and install
+- [x] 1.2 Document `PUBLIC_POSTHOG_KEY` (+ optional `PUBLIC_POSTHOG_HOST`
       defaulting to `/ingest`) in the frontend env/config reference; confirm dev
       leaves the key unset
 
 ## 2. Analytics module (`src/lib/analytics.ts`)
 
-- [ ] 2.1 Write failing vitest for the pure helpers: `isPrivateRoute(path)` (true
+- [x] 2.1 Write failing vitest for the pure helpers: `isPrivateRoute(path)` (true
       for `/my/*` and inbox, false for public), `track()` no-op safety when
-      uninitialized, and the non-tech flag fallback resolver
-- [ ] 2.2 Implement `analytics.ts`: `track(event, props)`, `identifyUser(user)` /
-      `resetIdentity()` (id only, no email), `syncReplayForRoute(path)`, and
-      `nonTechDefaultHidden()` flag reader with hardcoded fallback — all safe
-      no-ops when PostHog is uninitialized; make tests green
-- [ ] 2.3 simplify pass on the module; re-run vitest green
+      uninitialized, and `isFeatureEnabled(flag, fallback)` returning the fallback
+      when PostHog is inert
+- [x] 2.2 Implement `analytics.ts`: `track(event, props)`, `identifyUser(user)` /
+      `resetIdentity()` (id only, no email), `syncReplayForRoute(path)`, and a
+      generic `isFeatureEnabled(flag, fallback)` reader — all safe no-ops when
+      PostHog is uninitialized; make tests green
+- [x] 2.3 simplify pass on the module; re-run vitest green
 
 ## 3. Initialization (`hooks.client.ts`)
 
-- [ ] 3.1 Initialize PostHog env-gated by `PUBLIC_POSTHOG_KEY` with `api_host`
+- [x] 3.1 Initialize PostHog env-gated by `PUBLIC_POSTHOG_KEY` with `api_host`
       `/ingest`, `ui_host` EU, `capture_pageview:false`,
       `person_profiles:'identified_only'`, `session_recording:{maskAllInputs:true}`;
       inert when key absent (mirror Sentry block)
 
 ## 4. Routing-dependent wiring (`+layout.svelte`)
 
-- [ ] 4.1 In `afterNavigate` (and on initial load): capture `$pageview`, call
+- [x] 4.1 In `afterNavigate` (and on initial load): capture `$pageview`, call
       `identifyUser`/`resetIdentity` from `page.data.user`, and
       `syncReplayForRoute` to start/stop recording per route
 
 ## 5. Funnel events
 
-- [ ] 5.1 Fire `search` on `/jobs` when filters/query are applied (query + active
+- [x] 5.1 Fire `search` on `/jobs` when filters/query are applied (query + active
       facet count)
-- [ ] 5.2 Fire `job_view` on job card/page open (slug, source)
-- [ ] 5.3 Fire `job_apply`, `job_save`, `job_track` on the respective action
+- [x] 5.2 Fire `job_view` on job card/page open (slug, source)
+- [x] 5.3 Fire `job_apply`, `job_save`, `job_track` on the respective action
       buttons (slug, source; stage for track) — independent of auth state
 
-## 6. Feature flag demonstrator
+## 6. Feature flag seam
 
-- [ ] 6.1 Gate the `default-hide-nontech` default via `nonTechDefaultHidden()`,
-      preserving current behavior when the flag is unavailable
+- [x] 6.1 Ship the generic `isFeatureEnabled(flag, fallback)` reader (from 2.2)
+      as the flag capability; leave wiring a concrete product default (e.g.
+      `default-hide-nontech`, not present on origin/main) as a documented seam —
+      no consumer added in this change
 
 ## 7. Ops documentation
 
-- [ ] 7.1 Document the `/ingest/` nginx reverse-proxy location block (events +
+- [x] 7.1 Document the `/ingest/` nginx reverse-proxy location block (events +
       static assets → `eu.i.posthog.com`) for `freehire-ops`, ordered before the
       SvelteKit catch-all
 
 ## 8. Verify
 
-- [ ] 8.1 Run `svelte-check` + vitest; visual-verify a public route emits events
-      to `/ingest` and a `/my/*` route does not record (dev with a test key)
+- [x] 8.1 Static verification green: `svelte-check` (0 errors), vitest (270
+      pass), and prod `build` (SSR import-safe). Live smoke — events reaching
+      `/ingest`, replay off on `/my/*` with a real key + nginx proxy — is a
+      deploy-time step (mirrors the archived Sentry change), not run pre-merge.

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -12,6 +12,7 @@ Svelte SPA under `web/` consuming the freehire API (same-origin; Vite proxy forw
 - `JobFitAnalysis.svelte` is a compact summary (overall % + verdict + top gap) linking to the full `/jobs/[slug]/fit/` page; it never computes inline.
 - `ResumeStructuredView.svelte` is read-only — the structured resume is display-only, never editable.
 - Sentry is gated on `PUBLIC_SENTRY_DSN` (+ `PUBLIC_SENTRY_ENVIRONMENT`); source map upload only when `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` are set (build succeeds without them).
+- PostHog product analytics is gated on `PUBLIC_POSTHOG_KEY` (inert without it — no init, no events); ingestion goes through the same-origin `/ingest` reverse proxy (nginx → `eu.i.posthog.com`), overridable via `PUBLIC_POSTHOG_HOST` (default `/ingest`). Both are injected by `freehire-ops`, never committed, and unset in dev.
 
 ## How it works
 The SPA is built with SvelteKit and consumes the API at `/api/v1/*`. Auth is handled via httpOnly cookies, transported transparently by the browser (no client-side token management). The Vite proxy forwards `/api` to the backend in dev; in production the SPA and API are same-origin.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "easymde": "^2.21.0",
         "isomorphic-dompurify": "^3.18.0",
         "marked": "^18.0.6",
+        "posthog-js": "^1.402.0",
         "satori": "^0.26.0",
         "satori-html": "^0.3.2",
         "shiki": "^3.23.0",
@@ -1273,6 +1274,21 @@
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "license": "MIT"
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.41.1.tgz",
+      "integrity": "sha512-lKjPdeawDSvRhHnP14RwTSI5CofuyluhG3ISHRa+Kj6PyfSrEUyIkoVOpYWicFGgWikeaJCZzFQpo7ngHt9BcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.394.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.395.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.395.0.tgz",
+      "integrity": "sha512-Ty0gbVc6d9ku9H3caF54PmEfu4PHUGpJKTriMyDb4rjCTsEYOOjD4r6Fw/UMYSSWg8Ls3KnCtTow8LL6ciqNDg==",
       "license": "MIT"
     },
     "node_modules/@resvg/resvg-js": {
@@ -3940,6 +3956,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6143,6 +6170,46 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.402.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.402.0.tgz",
+      "integrity": "sha512-HVgg9DmRLdiZP9nQHXcmDgCZmjbTr9s7Ttf23r5lcPWOxV/3PEhItJdRCYYZVGefvL+AYLpudGHu7rGWByT/xg==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@posthog/core": "^1.41.1",
+        "@posthog/types": "^1.395.0",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/posthog-js/node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6203,6 +6270,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "4.1.2",
@@ -7437,6 +7510,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -52,6 +52,7 @@
     "easymde": "^2.21.0",
     "isomorphic-dompurify": "^3.18.0",
     "marked": "^18.0.6",
+    "posthog-js": "^1.402.0",
     "satori": "^0.26.0",
     "satori-html": "^0.3.2",
     "shiki": "^3.23.0",

--- a/web/src/hooks.client.ts
+++ b/web/src/hooks.client.ts
@@ -1,5 +1,6 @@
 import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
+import { initAnalytics } from '$lib/analytics';
 
 // Error tracking is opt-in and env-gated: without PUBLIC_SENTRY_DSN Sentry stays
 // uninitialized and the app runs unchanged (mirrors the backend integration).
@@ -13,6 +14,15 @@ if (env.PUBLIC_SENTRY_DSN) {
     sendDefaultPii: false,
   });
 }
+
+// Product analytics is likewise opt-in and env-gated. This hook is client-only,
+// so no browser guard is needed; ingestion goes through the same-origin /ingest
+// reverse proxy (overridable via PUBLIC_POSTHOG_HOST). initAnalytics is inert
+// when the key is absent.
+initAnalytics({
+  key: env.PUBLIC_POSTHOG_KEY ?? '',
+  apiHost: env.PUBLIC_POSTHOG_HOST || '/ingest',
+});
 
 // Reports uncaught client-side errors to Sentry; inert when init was skipped above.
 export const handleError = Sentry.handleErrorWithSentry();

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { isPrivateRoute, track, isFeatureEnabled } from './analytics';
+
+// These tests exercise only the pure/guarded surface — no PostHog init happens,
+// so the module is in its uninitialized state throughout.
+
+describe('isPrivateRoute', () => {
+  it('treats /my and its subtree as private', () => {
+    expect(isPrivateRoute('/my')).toBe(true);
+    expect(isPrivateRoute('/my/inbox')).toBe(true);
+    expect(isPrivateRoute('/my/tracking')).toBe(true);
+  });
+
+  it('treats public routes as not private', () => {
+    expect(isPrivateRoute('/')).toBe(false);
+    expect(isPrivateRoute('/jobs')).toBe(false);
+    expect(isPrivateRoute('/companies/acme')).toBe(false);
+    // A route that merely starts with the letters "my" is not under /my.
+    expect(isPrivateRoute('/mystery')).toBe(false);
+  });
+});
+
+describe('track (uninitialized)', () => {
+  it('is a safe no-op when PostHog is not initialized', () => {
+    expect(() => track('job_apply', { slug: 'x', source: 'greenhouse' })).not.toThrow();
+  });
+});
+
+describe('isFeatureEnabled (uninitialized)', () => {
+  it('returns the caller-supplied fallback when PostHog is inert', () => {
+    expect(isFeatureEnabled('some-flag', true)).toBe(true);
+    expect(isFeatureEnabled('other-flag', false)).toBe(false);
+  });
+});

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,80 @@
+// PostHog product analytics — a thin, guarded wrapper so call sites never touch
+// the SDK directly and every entry point is a safe no-op when PostHog is not
+// initialized (no key in dev, or SSR). Mirrors the Sentry env-gating posture:
+// without PUBLIC_POSTHOG_KEY nothing initializes and no events are sent.
+//
+// Only the pure/guarded surface (isPrivateRoute, track no-op, isFeatureEnabled
+// fallback) is unit-tested; the SDK side effects (identify/reset/replay) are
+// exercised via visual verification, per the frontend testing convention.
+import posthog from 'posthog-js';
+
+export interface AnalyticsConfig {
+  /** PostHog project key; empty/absent leaves analytics inert. */
+  key: string;
+  /** Same-origin reverse-proxy path events are sent through (e.g. `/ingest`). */
+  apiHost: string;
+}
+
+let initialized = false;
+
+// The runtime env read and browser guard live in the caller (hooks.client.ts,
+// which is client-only) so this module stays free of SvelteKit runtime imports
+// and unit-testable in a plain node environment.
+
+/** Initialize PostHog once, only when a key is configured. */
+export function initAnalytics(config: AnalyticsConfig): void {
+  if (initialized || !config.key) return;
+  posthog.init(config.key, {
+    api_host: config.apiHost,
+    ui_host: 'https://eu.posthog.com',
+    capture_pageview: false, // SPA navigation is captured manually (see layout)
+    person_profiles: 'identified_only', // no anonymous profiles → saves quota
+    session_recording: { maskAllInputs: true },
+  });
+  initialized = true;
+}
+
+/** Routes whose DOM must never be recorded (résumé, tracking, inbox all live
+ *  under /my). Session replay is stopped for their duration. */
+export function isPrivateRoute(path: string): boolean {
+  return path === '/my' || path.startsWith('/my/');
+}
+
+/** Capture an explicit funnel event. No-op until initialized. */
+export function track(event: string, props?: Record<string, unknown>): void {
+  if (!initialized) return;
+  posthog.capture(event, props);
+}
+
+/** Bind analytics identity to a signed-in user by id only — never PII. */
+export function identifyUser(user: { id: number }): void {
+  if (!initialized) return;
+  posthog.identify(String(user.id));
+}
+
+/** Drop identity so subsequent events are anonymous (on sign-out). */
+export function resetIdentity(): void {
+  if (!initialized) return;
+  posthog.reset();
+}
+
+/** Start or stop session recording based on route privacy. */
+export function syncReplayForRoute(path: string): void {
+  if (!initialized) return;
+  if (isPrivateRoute(path)) posthog.stopSessionRecording();
+  else posthog.startSessionRecording();
+}
+
+/** Capture a pageview for the current SPA route. */
+export function capturePageview(): void {
+  if (!initialized) return;
+  posthog.capture('$pageview');
+}
+
+/** Generic feature-flag reader: the flag's value when loaded, else the fallback.
+ *  Wiring a concrete product default to a flag is left to the caller. */
+export function isFeatureEnabled(flag: string, fallback: boolean): boolean {
+  if (!initialized) return fallback;
+  const value = posthog.isFeatureEnabled(flag);
+  return value === undefined ? fallback : value;
+}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -7,6 +7,7 @@
   import { filterHref, formatSalary, summaryFacets } from '$lib/enrichment';
   import { markViewed } from '$lib/viewedJobs.svelte';
   import { markSaved, markUnsaved } from '$lib/savedJobs.svelte';
+  import { track } from '$lib/analytics';
   import type { Job, UserJob } from '$lib/types';
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
@@ -44,6 +45,14 @@
   const views = $derived(job.view_count ?? 0);
   const applies = $derived(job.applied_count ?? 0);
 
+  // Funnel view — captured for everyone (unlike the authed-only server record
+  // below). Keyed on the slug alone so it fires once per job and never re-emits
+  // when an unrelated dependency (e.g. auth state) changes mid-view.
+  $effect(() => {
+    const slug = job.public_slug;
+    track('job_view', { slug, source: job.source });
+  });
+
   // Record a view for signed-in users once the page hydrates (browser only).
   // Silent history that also tells us whether they
   // already applied; a failed view must not break the page. Re-runs on client
@@ -70,6 +79,8 @@
   // not open) and a sign-in offer is shown instead — the posting opens only via
   // "View without signing in" below.
   function onApplyClick(e: MouseEvent) {
+    // Apply-intent — fired regardless of auth (the CTA click is the funnel step).
+    track('job_apply', { slug: job.public_slug, source: job.source });
     if (!isAuthenticated()) {
       e.preventDefault();
       showSignInPrompt = true;
@@ -99,6 +110,7 @@
     }
     showApplyPrompt = false;
     justApplied = true; // offer the board link now that the job is tracked
+    track('job_track', { slug: job.public_slug, stage: 'applied' });
   }
 
   // "No": purely local — the job must not enter the tracker.
@@ -133,8 +145,10 @@
       interaction = saved ? await api.unsaveJob(job.public_slug) : await api.saveJob(job.public_slug);
       // Keep the shared saved set in sync so a browse card's bookmark reflects this
       // on back-navigation without a reload (mirrors markViewed above).
-      if (interaction?.saved_at != null) markSaved(job.public_slug);
-      else markUnsaved(job.public_slug);
+      if (interaction?.saved_at != null) {
+        markSaved(job.public_slug);
+        track('job_save', { slug: job.public_slug });
+      } else markUnsaved(job.public_slug);
     } catch {
       // Leave the current state; the user can retry.
     }

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -28,6 +28,7 @@
   import OnboardingAlertBanner from './onboarding/OnboardingAlertBanner.svelte';
   import { syncOnNavigation } from '$lib/urlSynced.svelte';
   import { setListSearchTarget } from '$lib/listSearch.svelte';
+  import { track } from '$lib/analytics';
   import type { Job, FacetCounts } from '$lib/types';
   import FilterSummary from './filters/FilterSummary.svelte';
   import FilterModal from './filters/FilterModal.svelte';
@@ -134,6 +135,10 @@
 
   let modalOpen = $state(false);
   let started = false;
+  // Signature of the applied filters last reported as a search, so a re-run that
+  // didn't change the filters (back/forward re-seed, CV sign-in prompt toggle)
+  // doesn't emit a spurious funnel event.
+  let lastSearchKey = '';
 
   // Onboarding: the one-time nudge banner + wizard, standalone-only. The lifecycle
   // lives in localStorage (client-only); seed it at init on the client so a returning
@@ -261,7 +266,8 @@
     const blocked = cvSignInPrompt; // read in the tracked scope so a sign-in refetches
     untrack(() => {
       refreshCounts();
-      if (!started) {
+      const firstRun = !started;
+      if (firstRun) {
         started = true;
         // Keep the SSR `initial` page unless it was loaded for a different URL than
         // the address bar (stale shallow-routing restore) or the feed is in CV mode
@@ -269,6 +275,17 @@
         if (!initialStale && !cvMode) return;
       }
       if (blocked) return;
+      // Funnel search — only when the applied filters actually changed: not the
+      // initial paint, a back/forward re-seed to the same set, or an unrelated
+      // effect re-run (the CV sign-in prompt toggling reads into this scope too).
+      const searchKey = filtersToParams(filters.applied).toString();
+      if (!firstRun && searchKey !== lastSearchKey) {
+        track('search', {
+          q: filters.applied.q.trim(),
+          facets: activeFilterCount(filters.applied),
+        });
+      }
+      lastSearchKey = searchKey;
       reloadList();
     });
   });

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
   import { navigating, page } from '$app/state';
+  import { afterNavigate } from '$app/navigation';
   import { onMount } from 'svelte';
   import { initTheme } from '$lib/theme.svelte';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { resetUserStores } from '$lib/userResource.svelte';
+  import {
+    capturePageview,
+    syncReplayForRoute,
+    identifyUser,
+    resetIdentity,
+  } from '$lib/analytics';
   import TopBar from '$lib/components/TopBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
   import '../app.css';
@@ -29,6 +36,29 @@
   // signed out.
   $effect(() => {
     if (!isAuthenticated()) resetUserStores();
+  });
+
+  // Analytics is inert unless PostHog was initialized (see hooks.client.ts), so
+  // every call below is a no-op when the key is absent. afterNavigate also fires
+  // on the initial load, so the pageview and the replay privacy toggle cover a
+  // hard-loaded route too — replay is stopped on /my/* before it can leak.
+  afterNavigate(() => {
+    capturePageview();
+    syncReplayForRoute(page.url.pathname);
+  });
+
+  // Bind/clear analytics identity only on a real session transition. page.data is
+  // a fresh object per navigation, so acting on every run would call posthog.reset()
+  // on each anonymous navigation — reset() mints a new anonymous id each time and
+  // would fragment one visitor into many. Tracking the last identified id makes
+  // identify fire once at sign-in and reset once at sign-out.
+  let lastIdentified: number | null = null;
+  $effect(() => {
+    const id = page.data.user?.id ?? null;
+    if (id === lastIdentified) return;
+    lastIdentified = id;
+    if (page.data.user) identifyUser(page.data.user);
+    else resetIdentity();
   });
 </script>
 

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -50,6 +50,12 @@ export default {
         // client SDK ships in the same-origin bundle and injects no external script,
         // so script-src needs nothing either. If a connect-src is ever introduced,
         // it MUST include the Sentry ingest host above (and GA's collect host).
+        //
+        // PostHog: needs no CSP entry either. Ingestion and the lazily-loaded
+        // session-replay recorder both go through the same-origin /ingest reverse
+        // proxy (nginx → eu.i.posthog.com; see the add-posthog-analytics design),
+        // so 'self' already covers script-src and no external host is contacted. A
+        // future connect-src must include /ingest (same origin).
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds env-gated PostHog product analytics to the SvelteKit frontend, complementing (not replacing) GA4 and Sentry.

- **Inert by default** — `initAnalytics` no-ops without `PUBLIC_POSTHOG_KEY`, mirroring the Sentry posture (`hooks.client.ts`).
- **Same-origin `/ingest` reverse proxy** — events + the lazily-loaded session-replay recorder go through nginx → `eu.i.posthog.com` (EU residency), so ad-blockers/CSP are a non-issue and no external host is added to `script-src`.
- **SPA pageviews + identity** — captured in `+layout.svelte` `afterNavigate`; users identified by **id only** (no PII), bound/cleared **only on real session transitions** (avoids `posthog.reset()` fragmenting anonymous visitors).
- **Privacy-scoped session replay** — inputs masked globally, recording **stopped on `/my/*`** (résumé, tracking, inbox) so sensitive DOM is never recorded.
- **Funnel events** via a thin, guarded `$lib/analytics.ts` wrapper: `search`, `job_view`, `job_apply`, `job_save`, `job_track`.
- **Generic `isFeatureEnabled(flag, fallback)`** reader ships as the flag capability; wiring a concrete product default (e.g. `default-hide-nontech`) is left as a documented seam.

Pure/guarded surface is unit-tested (`analytics.test.ts`); SDK side effects are verified visually / at deploy.

Planned in OpenSpec: `openspec/changes/add-posthog-analytics/` (proposal + design + `product-analytics` spec + tasks).

## Test Plan

- [x] `svelte-check` — 0 errors
- [x] `vitest run` — 270 passed (4 new for `isPrivateRoute` / `track` no-op / `isFeatureEnabled` fallback)
- [x] `npm run build` — SSR import-safe (posthog-js imported in SSR-rendered `JobView`)
- [ ] **Deploy-time (ops):** set `PUBLIC_POSTHOG_KEY` in `freehire-ops`; add the `/ingest/` nginx location block (snapshot in `design.md`); live smoke — events reach `/ingest`, replay off on `/my/*`