### PR TITLE
feat(embed): persist semantic vectors in Postgres for backup and rehydrate

### DIFF
--- a/cmd/backfill-semantic-vectors/main.go
+++ b/cmd/backfill-semantic-vectors/main.go
@@ -1,0 +1,114 @@
+// Command backfill-semantic-vectors seeds Postgres with the semantic vectors that
+// currently live ONLY in the Meilisearch `jobs_semantic` index. Those vectors are the
+// product of a one-time, weeks-long embedding pass; until they exist in Postgres too,
+// the nightly pg_dump does not back them up and a lost Meili volume would force a full
+// re-embed. This one-off pages the index (id + stored vector), copies each vector into
+// jobs.semantic_embedding, and exits.
+//
+// It is pure data movement: it reads the already-computed vectors and NEVER calls the
+// embedding model, NEVER touches the provenance stamps (semantic_embedded_model/hash)
+// or the semantic_outbox, and NEVER changes the embedder identity — so it cannot
+// trigger a re-embed of anything. Idempotent: re-running rewrites the same values, so
+// an interrupted run just resumes by starting over.
+//
+// Env knobs: DRY_RUN (any non-empty value reads Meili and writes nothing);
+// PAGE_SIZE (documents per Meili page + Postgres batch, default 500).
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+func main() { worker.Main(run) }
+
+func run() int {
+	ctx, cfg, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	if cfg.MeiliKey == "" {
+		log.Print("config: MEILI_MASTER_KEY is required")
+		return 1
+	}
+
+	pageSize := envInt("PAGE_SIZE", 500)
+	dryRun := os.Getenv("DRY_RUN") != ""
+
+	var sink vectorSink = pgSink{pool: pool}
+	if dryRun {
+		sink = noopSink{}
+		log.Print("backfill-semantic-vectors: DRY RUN — reading Meili, writing nothing")
+	}
+
+	client := search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
+	st, err := seeder{
+		src:      meiliSource{client: client},
+		sink:     sink,
+		pageSize: pageSize,
+	}.run(ctx)
+	if err != nil {
+		log.Printf("backfill-semantic-vectors: %v (pages=%d fetched=%d saved=%d)", err, st.Pages, st.Fetched, st.Saved)
+		return 1
+	}
+
+	log.Printf("backfill-semantic-vectors done: pages=%d fetched=%d saved=%d dry_run=%v",
+		st.Pages, st.Fetched, st.Saved, dryRun)
+	return 0
+}
+
+// meiliSource is the read side: one Meili documents page per call.
+type meiliSource struct{ client *search.Client }
+
+func (m meiliSource) Page(ctx context.Context, offset, limit int) ([]search.SemanticVector, error) {
+	return m.client.ListSemanticVectors(ctx, offset, limit)
+}
+
+// pgSink writes a page of vectors into jobs.semantic_embedding in one batched round
+// trip. The UPDATE is by primary key and unconditional, so it is idempotent and a
+// vector for a since-deleted job simply affects zero rows.
+type pgSink struct{ pool *pgxpool.Pool }
+
+func (s pgSink) Save(ctx context.Context, vecs []search.SemanticVector) (int64, error) {
+	batch := &pgx.Batch{}
+	for _, v := range vecs {
+		batch.Queue(`UPDATE jobs SET semantic_embedding = $1 WHERE id = $2`, v.Vector, v.ID)
+	}
+	br := s.pool.SendBatch(ctx, batch)
+	defer br.Close()
+	var affected int64
+	for range vecs {
+		ct, err := br.Exec()
+		if err != nil {
+			return affected, err
+		}
+		affected += ct.RowsAffected()
+	}
+	return affected, nil
+}
+
+// noopSink backs --dry-run: it reports the count it would have written but touches
+// nothing.
+type noopSink struct{}
+
+func (noopSink) Save(_ context.Context, vecs []search.SemanticVector) (int64, error) {
+	return int64(len(vecs)), nil
+}
+
+func envInt(key string, def int) int {
+	if v, err := strconv.Atoi(os.Getenv(key)); err == nil && v > 0 {
+		return v
+	}
+	return def
+}

--- a/cmd/backfill-semantic-vectors/seeder.go
+++ b/cmd/backfill-semantic-vectors/seeder.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/strelov1/freehire/internal/search"
+)
+
+// vectorSource yields one offset-paged window of persisted vectors from the semantic
+// index. An empty page means the end: every jobs_semantic document carries a vector,
+// so a window past the last document returns nothing.
+type vectorSource interface {
+	Page(ctx context.Context, offset, limit int) ([]search.SemanticVector, error)
+}
+
+// vectorSink persists a batch of (id, vector) pairs into Postgres and reports how many
+// rows it wrote. A no-op counting sink implements the same port for --dry-run.
+type vectorSink interface {
+	Save(ctx context.Context, vecs []search.SemanticVector) (int64, error)
+}
+
+// seedStats reports what a backfill run moved.
+type seedStats struct {
+	Pages   int
+	Fetched int
+	Saved   int64
+}
+
+// seeder copies vectors Meili→Postgres a page at a time. The offset advances by
+// pageSize (not by the number of vectors returned) so parser-skipped documents never
+// stall the walk.
+type seeder struct {
+	src      vectorSource
+	sink     vectorSink
+	pageSize int
+}
+
+func (s seeder) run(ctx context.Context) (seedStats, error) {
+	var st seedStats
+	for offset := 0; ; offset += s.pageSize {
+		page, err := s.src.Page(ctx, offset, s.pageSize)
+		if err != nil {
+			return st, err
+		}
+		if len(page) == 0 {
+			return st, nil
+		}
+		saved, err := s.sink.Save(ctx, page)
+		if err != nil {
+			return st, err
+		}
+		st.Pages++
+		st.Fetched += len(page)
+		st.Saved += saved
+		if st.Pages%50 == 0 {
+			log.Printf("backfill-semantic-vectors: progress pages=%d fetched=%d saved=%d", st.Pages, st.Fetched, st.Saved)
+		}
+	}
+}

--- a/cmd/backfill-semantic-vectors/seeder_test.go
+++ b/cmd/backfill-semantic-vectors/seeder_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/search"
+)
+
+// fakeSource returns preloaded pages keyed by the offset the seeder requests, so a
+// test asserts both the values moved and that the walk pages by pageSize.
+type fakeSource struct {
+	pages        map[int][]search.SemanticVector
+	offsetsAsked []int
+	err          error
+}
+
+func (f *fakeSource) Page(_ context.Context, offset, _ int) ([]search.SemanticVector, error) {
+	f.offsetsAsked = append(f.offsetsAsked, offset)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.pages[offset], nil
+}
+
+type fakeSink struct {
+	saved []int64
+	err   error
+}
+
+func (f *fakeSink) Save(_ context.Context, vecs []search.SemanticVector) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	for _, v := range vecs {
+		f.saved = append(f.saved, v.ID)
+	}
+	return int64(len(vecs)), nil
+}
+
+func vecs(ids ...int64) []search.SemanticVector {
+	out := make([]search.SemanticVector, len(ids))
+	for i, id := range ids {
+		out[i] = search.SemanticVector{ID: id, Vector: []float32{float32(id)}}
+	}
+	return out
+}
+
+func TestSeederWalksPagesUntilEmpty(t *testing.T) {
+	src := &fakeSource{pages: map[int][]search.SemanticVector{
+		0:  vecs(1, 2),
+		10: vecs(3, 4),
+		20: nil, // end
+	}}
+	sink := &fakeSink{}
+
+	st, err := seeder{src: src, sink: sink, pageSize: 10}.run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if st.Fetched != 4 || st.Saved != 4 || st.Pages != 2 {
+		t.Fatalf("stats = %+v; want Fetched=4 Saved=4 Pages=2", st)
+	}
+	// Offset must advance by pageSize (0,10,20), independent of vectors returned.
+	if len(src.offsetsAsked) != 3 || src.offsetsAsked[0] != 0 || src.offsetsAsked[1] != 10 || src.offsetsAsked[2] != 20 {
+		t.Fatalf("offsets asked = %v; want [0 10 20]", src.offsetsAsked)
+	}
+	if len(sink.saved) != 4 {
+		t.Fatalf("sink saved %d ids; want 4", len(sink.saved))
+	}
+}
+
+func TestSeederPropagatesSourceError(t *testing.T) {
+	boom := errors.New("meili down")
+	_, err := seeder{src: &fakeSource{err: boom}, sink: &fakeSink{}, pageSize: 10}.run(context.Background())
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v; want %v", err, boom)
+	}
+}
+
+func TestSeederPropagatesSinkError(t *testing.T) {
+	boom := errors.New("pg down")
+	src := &fakeSource{pages: map[int][]search.SemanticVector{0: vecs(1)}}
+	_, err := seeder{src: src, sink: &fakeSink{err: boom}, pageSize: 10}.run(context.Background())
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v; want %v", err, boom)
+	}
+}

--- a/cmd/embed/embed_integration_test.go
+++ b/cmd/embed/embed_integration_test.go
@@ -207,6 +207,16 @@ func TestIntegration_EmbedWorkerDrainsQueue(t *testing.T) {
 		t.Errorf("closed job stamp model = %v, want NULL (cleared)", model)
 	}
 
+	// Durability: the open job's vector is persisted to Postgres beside the stamp (the
+	// backup copy that lets the index be rehydrated without re-embedding); the removed
+	// job carries none.
+	if l := jobVectorLen(t, pool, openID); l <= 0 {
+		t.Errorf("open job semantic_embedding length = %d, want > 0 (vector persisted)", l)
+	}
+	if l := jobVectorLen(t, pool, closedID); l != 0 {
+		t.Errorf("closed job semantic_embedding length = %d, want 0/NULL (cleared)", l)
+	}
+
 	// Outbox drained.
 	var n int
 	if err := pool.QueryRow(ctx, "SELECT count(*) FROM semantic_outbox").Scan(&n); err != nil {
@@ -246,7 +256,7 @@ func preIndexClosed(t *testing.T, ctx context.Context, client *search.Client, po
 	if err != nil || len(jobs) != 1 {
 		t.Fatalf("load closed job: rows=%d err=%v", len(jobs), err)
 	}
-	if err := ix.IndexOpen(ctx, jobs); err != nil {
+	if _, err := ix.IndexOpen(ctx, jobs); err != nil {
 		t.Fatalf("pre-index closed job: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
@@ -254,6 +264,21 @@ func preIndexClosed(t *testing.T, ctx context.Context, client *search.Client, po
 		search.CurrentEmbedderModel(), id); err != nil {
 		t.Fatalf("stamp closed job: %v", err)
 	}
+}
+
+// jobVectorLen returns the length of a job's persisted semantic_embedding, or 0 when
+// the column is NULL (no vector).
+func jobVectorLen(t *testing.T, pool *pgxpool.Pool, id int64) int {
+	t.Helper()
+	var n *int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT array_length(semantic_embedding, 1) FROM jobs WHERE id = $1", id).Scan(&n); err != nil {
+		t.Fatalf("read vector length: %v", err)
+	}
+	if n == nil {
+		return 0
+	}
+	return *n
 }
 
 func jobStamp(t *testing.T, pool *pgxpool.Pool, id int64) (model, hash *string) {

--- a/cmd/embed/indexer.go
+++ b/cmd/embed/indexer.go
@@ -22,12 +22,12 @@ type searchIndexer struct {
 	q      *db.Queries
 }
 
-func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) error {
+func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) (map[int64][]float32, error) {
 	docs := make([]search.JobDocument, 0, len(jobs))
 	for _, job := range jobs {
 		doc, err := search.FromJob(job)
 		if err != nil {
-			return fmt.Errorf("build document (job %d): %w", job.ID, err)
+			return nil, fmt.Errorf("build document (job %d): %w", job.ID, err)
 		}
 		// Attach the job-reality signal so an incrementally-embedded job carries
 		// reality.class immediately, matching the ingest incremental path. Without it a
@@ -48,7 +48,8 @@ func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) error {
 		docs = append(docs, doc)
 	}
 	// IndexSemanticJobs embeds the whole batch (chunked to the backend's limit) and
-	// upserts it as ONE Meilisearch task, so a large backfill isn't per-doc bound.
+	// upserts it as ONE Meilisearch task, so a large backfill isn't per-doc bound. It
+	// returns the computed vectors so the store can persist them beside the stamp.
 	return ix.client.IndexSemanticJobs(ctx, docs)
 }
 

--- a/cmd/embed/store.go
+++ b/cmd/embed/store.go
@@ -51,13 +51,27 @@ func (s *dbStore) Jobs(ctx context.Context, ids []int64) ([]db.Job, error) {
 	return s.q.GetJobsByIDs(ctx, ids)
 }
 
-func (s *dbStore) CompleteOpen(ctx context.Context, entries []embed.Claimed, model string) error {
+func (s *dbStore) CompleteOpen(ctx context.Context, entries []embed.Claimed, model string, vectors map[int64][]float32) error {
 	jobIDs, outboxIDs := splitIDs(entries)
 	return s.tx(ctx, func(qtx *db.Queries) error {
 		if err := qtx.StampSemanticEmbeddedBatch(ctx, db.StampSemanticEmbeddedBatchParams{
 			Model: model, Ids: jobIDs,
 		}); err != nil {
 			return fmt.Errorf("stamp: %w", err)
+		}
+		// Persist each job's vector in the same transaction as the stamp, so a job is
+		// never marked embedded without its vector reaching Postgres. A missing vector
+		// for an entry is skipped (leaves the column untouched) rather than nulling it.
+		for _, e := range entries {
+			v, ok := vectors[e.JobID]
+			if !ok {
+				continue
+			}
+			if err := qtx.SetSemanticEmbedding(ctx, db.SetSemanticEmbeddingParams{
+				ID: e.JobID, Embedding: v,
+			}); err != nil {
+				return fmt.Errorf("set embedding (job %d): %w", e.JobID, err)
+			}
 		}
 		return qtx.DeleteSemanticEntriesBatch(ctx, outboxIDs)
 	})

--- a/cmd/reindex/main.go
+++ b/cmd/reindex/main.go
@@ -87,6 +87,15 @@ func run() int {
 		return 1
 	}
 
+	// --from-pg rehydrates the semantic index from the vectors already in Postgres
+	// (jobs.semantic_embedding) instead of re-embedding via TEI. It only makes sense for
+	// the semantic pass — the facet index carries no vectors.
+	fromPG := fromPGRequested(os.Args[1:])
+	if fromPG && !semantic {
+		log.Print("reindex: --from-pg applies only to a --semantic rebuild")
+		return 1
+	}
+
 	// Refresh the role-cluster canonical markers before reading jobs, so the collapse
 	// (splitJobs drops non-canonical reposts) reflects the current catalogue and a closed
 	// canon has failed over. Done per company in short transactions (never a table-wide
@@ -111,6 +120,9 @@ func run() int {
 	var b rebuilder = client.NewFacetRebuild()
 	if semantic {
 		b = client.NewSemanticRebuild()
+		if fromPG {
+			b = client.NewSemanticRebuildFromPG()
+		}
 	}
 	// The semantic rebuild optionally scopes to a fresh posting window (--posted-within);
 	// every other full pass scans the whole table. A scoped reader returns open jobs only,
@@ -121,7 +133,13 @@ func run() int {
 		reader = worker.NewPostedSinceReader(q, time.Now().Add(-postedWithin))
 		scope = "posted-within " + postedWithin.String()
 	}
-	log.Printf("reindex: target=%s scope=%s mode=swap", target, scope)
+	vectors := "n/a"
+	if semantic {
+		if vectors = "tei"; fromPG {
+			vectors = "pg"
+		}
+	}
+	log.Printf("reindex: target=%s scope=%s mode=swap vectors=%s", target, scope, vectors)
 	lookup, err := buildRealityLookup(ctx, q)
 	if err != nil {
 		log.Printf("reindex: build reality lookup: %v", err)
@@ -171,6 +189,18 @@ func postedWithinFrom(args []string) (time.Duration, bool, error) {
 func semanticRequested(args []string) bool {
 	for _, a := range args {
 		if a == "--semantic" || a == "semantic" {
+			return true
+		}
+	}
+	return false
+}
+
+// fromPGRequested reports whether a --semantic rebuild should rehydrate from the
+// vectors persisted in Postgres (jobs.semantic_embedding) instead of re-embedding via
+// TEI — the fast disaster-recovery path that costs no model calls.
+func fromPGRequested(args []string) bool {
+	for _, a := range args {
+		if a == "--from-pg" {
 			return true
 		}
 	}

--- a/cmd/reindex/main_test.go
+++ b/cmd/reindex/main_test.go
@@ -50,6 +50,15 @@ func TestSemanticRequested(t *testing.T) {
 	}
 }
 
+func TestFromPGRequested(t *testing.T) {
+	if !fromPGRequested([]string{"--semantic", "--from-pg"}) {
+		t.Error("--from-pg should be detected among other args")
+	}
+	if fromPGRequested([]string{"--semantic"}) {
+		t.Error("absent --from-pg must not be reported")
+	}
+}
+
 // The reindex feed deliberately includes closed jobs: open ones are upserted as
 // documents, closed ones become deletions so they leave the index (job-search
 // spec: the index contains only open jobs).

--- a/internal/db/jobs.sql.go
+++ b/internal/db/jobs.sql.go
@@ -238,7 +238,7 @@ func (q *Queries) ExistingExternalIDs(ctx context.Context, source string) ([]str
 }
 
 const getJob = `-- name: GetJob :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE id = $1
 `
@@ -290,12 +290,13 @@ func (q *Queries) GetJob(ctx context.Context, id int64) (Job, error) {
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
 		&i.IsTech,
+		&i.SemanticEmbedding,
 	)
 	return i, err
 }
 
 const getJobBySlug = `-- name: GetJobBySlug :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE public_slug = $1
 `
@@ -347,12 +348,13 @@ func (q *Queries) GetJobBySlug(ctx context.Context, publicSlug string) (Job, err
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
 		&i.IsTech,
+		&i.SemanticEmbedding,
 	)
 	return i, err
 }
 
 const getJobBySourceExternalID = `-- name: GetJobBySourceExternalID :one
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE source = $1 AND external_id = $2
 `
@@ -411,6 +413,7 @@ func (q *Queries) GetJobBySourceExternalID(ctx context.Context, arg GetJobBySour
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
 		&i.IsTech,
+		&i.SemanticEmbedding,
 	)
 	return i, err
 }
@@ -546,7 +549,7 @@ func (q *Queries) ListJobSitemapFreshest(ctx context.Context, rowLimit int32) ([
 }
 
 const listJobs = `-- name: ListJobs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
@@ -614,6 +617,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
 			&i.IsTech,
+			&i.SemanticEmbedding,
 		); err != nil {
 			return nil, err
 		}
@@ -626,7 +630,7 @@ func (q *Queries) ListJobs(ctx context.Context, arg ListJobsParams) ([]Job, erro
 }
 
 const listJobsByCompany = `-- name: ListJobsByCompany :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE company_slug = $1 AND closed_at IS NULL AND duplicate_of IS NULL
 ORDER BY created_at DESC, id DESC
@@ -694,6 +698,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
 			&i.IsTech,
+			&i.SemanticEmbedding,
 		); err != nil {
 			return nil, err
 		}
@@ -706,7 +711,7 @@ func (q *Queries) ListJobsByCompany(ctx context.Context, arg ListJobsByCompanyPa
 }
 
 const listJobsByIDAfter = `-- name: ListJobsByIDAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE id > $1
 ORDER BY id
@@ -774,6 +779,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
 			&i.IsTech,
+			&i.SemanticEmbedding,
 		); err != nil {
 			return nil, err
 		}
@@ -786,7 +792,7 @@ func (q *Queries) ListJobsByIDAfter(ctx context.Context, arg ListJobsByIDAfterPa
 }
 
 const listJobsBySourceAfter = `-- name: ListJobsBySourceAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE source = $1 AND id > $2
 ORDER BY id
@@ -855,6 +861,7 @@ func (q *Queries) ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourc
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
 			&i.IsTech,
+			&i.SemanticEmbedding,
 		); err != nil {
 			return nil, err
 		}
@@ -867,7 +874,7 @@ func (q *Queries) ListJobsBySourceAfter(ctx context.Context, arg ListJobsBySourc
 }
 
 const listJobsUpdatedAfter = `-- name: ListJobsUpdatedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE id > $1 AND updated_at >= $2
 ORDER BY id
@@ -939,6 +946,7 @@ func (q *Queries) ListJobsUpdatedAfter(ctx context.Context, arg ListJobsUpdatedA
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
 			&i.IsTech,
+			&i.SemanticEmbedding,
 		); err != nil {
 			return nil, err
 		}
@@ -987,7 +995,7 @@ func (q *Queries) ListOpenJobIDsPostedAfter(ctx context.Context, arg ListOpenJob
 }
 
 const listOpenJobsPostedAfter = `-- name: ListOpenJobsPostedAfter :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE id > $1 AND closed_at IS NULL AND COALESCE(posted_at, created_at) >= $2
 ORDER BY id
@@ -1061,6 +1069,7 @@ func (q *Queries) ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsP
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
 			&i.IsTech,
+			&i.SemanticEmbedding,
 		); err != nil {
 			return nil, err
 		}
@@ -1691,7 +1700,7 @@ SET title        = $1,
     updated_by   = $21::bigint,
     updated_at   = now()
 WHERE public_slug = $22 AND created_by IS NOT NULL
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 `
 
 type UpdateManualJobParams struct {
@@ -1801,6 +1810,7 @@ func (q *Queries) UpdateManualJob(ctx context.Context, arg UpdateManualJobParams
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
 		&i.IsTech,
+		&i.SemanticEmbedding,
 	)
 	return i, err
 }
@@ -1874,7 +1884,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech,
+RETURNING jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, jobs.semantic_embedding,
     NOT COALESCE((SELECT existed FROM existing), false) AS inserted,
     ((SELECT old_hash FROM existing) IS DISTINCT FROM $25) AS changed
 `
@@ -2008,6 +2018,7 @@ func (q *Queries) UpsertJob(ctx context.Context, arg UpsertJobParams) (UpsertJob
 		&i.Job.SemanticEmbeddedHash,
 		&i.Job.DuplicateOf,
 		&i.Job.IsTech,
+		&i.Job.SemanticEmbedding,
 		&i.Inserted,
 		&i.Changed,
 	)
@@ -2067,7 +2078,7 @@ ON CONFLICT (source, external_id) DO UPDATE SET
     closed_at    = NULL,
     liveness_strikes = CASE WHEN jobs.closed_at IS NOT NULL THEN 0 ELSE jobs.liveness_strikes END,
     updated_at   = now()
-RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+RETURNING id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 `
 
 type UpsertManualJobParams struct {
@@ -2183,6 +2194,7 @@ func (q *Queries) UpsertManualJob(ctx context.Context, arg UpsertManualJobParams
 		&i.SemanticEmbeddedHash,
 		&i.DuplicateOf,
 		&i.IsTech,
+		&i.SemanticEmbedding,
 	)
 	return i, err
 }

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -162,6 +162,7 @@ type Job struct {
 	SemanticEmbeddedHash  pgtype.Text        `json:"semantic_embedded_hash"`
 	DuplicateOf           pgtype.Int8        `json:"duplicate_of"`
 	IsTech                pgtype.Bool        `json:"is_tech"`
+	SemanticEmbedding     []float32          `json:"semantic_embedding"`
 }
 
 type JobDailyStat struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -67,8 +67,10 @@ type Querier interface {
 	// affected row count: 1 for an owned row (whether or not it was shared — unshare is an
 	// idempotent no-op when already private), 0 when missing or not the caller's (→ 404).
 	ClearSavedSearchPublicSlug(ctx context.Context, arg ClearSavedSearchPublicSlugParams) (int64, error)
-	// Clear a batch of jobs' embed provenance after their documents are removed from
-	// jobs_semantic (closed-job path). Run in the same transaction as DeleteSemanticEntriesBatch.
+	// Clear a batch of jobs' embed provenance AND their durable vector after their documents
+	// are removed from jobs_semantic (closed-job path). Run in the same transaction as
+	// DeleteSemanticEntriesBatch. Dropping semantic_embedding keeps Postgres consistent with
+	// the index: a closed job has no vector in either place.
 	ClearSemanticEmbeddedBatch(ctx context.Context, ids []int64) error
 	// Clear the user's résumé pointer (after deleting the object from storage), any
 	// cached ATS review, the derived CV embedding (no CV → no recommendations), and the
@@ -746,6 +748,13 @@ type Querier interface {
 	// author_label is set verbatim (NULL clears it → anonymous). No matching owner-scoped
 	// row returns no row (→ ErrNotFound).
 	SetSavedSearchPublicSlug(ctx context.Context, arg SetSavedSearchPublicSlugParams) (SavedSearch, error)
+	// Persist one job's semantic vector — the durable copy of what was just upserted into
+	// the jobs_semantic index. Called once per embedded job inside the SAME transaction as
+	// StampSemanticEmbeddedBatch on the open-job success path, so the stamp and the vector
+	// commit together (a job is never marked embedded without its vector reaching Postgres).
+	// Postgres thus becomes the source of truth for the vector: the nightly pg_dump backs it
+	// up and reindex can rehydrate Meili from it without re-embedding. Idempotent by primary key.
+	SetSemanticEmbedding(ctx context.Context, arg SetSemanticEmbeddingParams) error
 	// Pause/resume a subscription, scoped to its owner. No matching owner-scoped row
 	// returns no row (the handler maps that to 404).
 	SetSubscriptionActive(ctx context.Context, arg SetSubscriptionActiveParams) (Subscription, error)

--- a/internal/db/queries/semantic.sql
+++ b/internal/db/queries/semantic.sql
@@ -84,12 +84,26 @@ SET semantic_embedded_model = sqlc.arg(model)::text,
     semantic_embedded_hash  = content_hash
 WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 
+-- name: SetSemanticEmbedding :exec
+-- Persist one job's semantic vector — the durable copy of what was just upserted into
+-- the jobs_semantic index. Called once per embedded job inside the SAME transaction as
+-- StampSemanticEmbeddedBatch on the open-job success path, so the stamp and the vector
+-- commit together (a job is never marked embedded without its vector reaching Postgres).
+-- Postgres thus becomes the source of truth for the vector: the nightly pg_dump backs it
+-- up and reindex can rehydrate Meili from it without re-embedding. Idempotent by primary key.
+UPDATE jobs
+SET semantic_embedding = sqlc.arg(embedding)::real[]
+WHERE id = sqlc.arg(id);
+
 -- name: ClearSemanticEmbeddedBatch :exec
--- Clear a batch of jobs' embed provenance after their documents are removed from
--- jobs_semantic (closed-job path). Run in the same transaction as DeleteSemanticEntriesBatch.
+-- Clear a batch of jobs' embed provenance AND their durable vector after their documents
+-- are removed from jobs_semantic (closed-job path). Run in the same transaction as
+-- DeleteSemanticEntriesBatch. Dropping semantic_embedding keeps Postgres consistent with
+-- the index: a closed job has no vector in either place.
 UPDATE jobs
 SET semantic_embedded_model = NULL,
-    semantic_embedded_hash  = NULL
+    semantic_embedded_hash  = NULL,
+    semantic_embedding      = NULL
 WHERE id = ANY(sqlc.arg(ids)::bigint[]);
 
 -- name: DeleteSemanticEntriesBatch :exec

--- a/internal/db/semantic.sql.go
+++ b/internal/db/semantic.sql.go
@@ -78,12 +78,15 @@ func (q *Queries) ClaimSemanticBatch(ctx context.Context, arg ClaimSemanticBatch
 const clearSemanticEmbeddedBatch = `-- name: ClearSemanticEmbeddedBatch :exec
 UPDATE jobs
 SET semantic_embedded_model = NULL,
-    semantic_embedded_hash  = NULL
+    semantic_embedded_hash  = NULL,
+    semantic_embedding      = NULL
 WHERE id = ANY($1::bigint[])
 `
 
-// Clear a batch of jobs' embed provenance after their documents are removed from
-// jobs_semantic (closed-job path). Run in the same transaction as DeleteSemanticEntriesBatch.
+// Clear a batch of jobs' embed provenance AND their durable vector after their documents
+// are removed from jobs_semantic (closed-job path). Run in the same transaction as
+// DeleteSemanticEntriesBatch. Dropping semantic_embedding keeps Postgres consistent with
+// the index: a closed job has no vector in either place.
 func (q *Queries) ClearSemanticEmbeddedBatch(ctx context.Context, ids []int64) error {
 	_, err := q.db.Exec(ctx, clearSemanticEmbeddedBatch, ids)
 	return err
@@ -143,7 +146,7 @@ func (q *Queries) EnqueuePendingSemanticJobs(ctx context.Context, arg EnqueuePen
 }
 
 const getJobsByIDs = `-- name: GetJobsByIDs :many
-SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech
+SELECT id, source, external_id, url, title, company, location, remote, description, posted_at, created_at, updated_at, company_slug, enrichment, enriched_at, enrichment_version, public_slug, last_seen_at, closed_at, countries, regions, work_mode, liveness_strikes, skills, seniority, category, created_by, updated_by, posting_language, employment_type, education_level, experience_years_min, collections, content_hash, english_level, cities, view_count, applied_count, role_fingerprint, semantic_embedded_model, semantic_embedded_hash, duplicate_of, is_tech, semantic_embedding
 FROM jobs
 WHERE id = ANY($1::bigint[])
 `
@@ -204,6 +207,7 @@ func (q *Queries) GetJobsByIDs(ctx context.Context, ids []int64) ([]Job, error) 
 			&i.SemanticEmbeddedHash,
 			&i.DuplicateOf,
 			&i.IsTech,
+			&i.SemanticEmbedding,
 		); err != nil {
 			return nil, err
 		}
@@ -248,6 +252,28 @@ func (q *Queries) RecordSemanticFailure(ctx context.Context, arg RecordSemanticF
 	var i RecordSemanticFailureRow
 	err := row.Scan(&i.Attempts, &i.FailedAt)
 	return i, err
+}
+
+const setSemanticEmbedding = `-- name: SetSemanticEmbedding :exec
+UPDATE jobs
+SET semantic_embedding = $1::real[]
+WHERE id = $2
+`
+
+type SetSemanticEmbeddingParams struct {
+	Embedding []float32 `json:"embedding"`
+	ID        int64     `json:"id"`
+}
+
+// Persist one job's semantic vector — the durable copy of what was just upserted into
+// the jobs_semantic index. Called once per embedded job inside the SAME transaction as
+// StampSemanticEmbeddedBatch on the open-job success path, so the stamp and the vector
+// commit together (a job is never marked embedded without its vector reaching Postgres).
+// Postgres thus becomes the source of truth for the vector: the nightly pg_dump backs it
+// up and reindex can rehydrate Meili from it without re-embedding. Idempotent by primary key.
+func (q *Queries) SetSemanticEmbedding(ctx context.Context, arg SetSemanticEmbeddingParams) error {
+	_, err := q.db.Exec(ctx, setSemanticEmbedding, arg.Embedding, arg.ID)
+	return err
 }
 
 const stampSemanticEmbeddedBatch = `-- name: StampSemanticEmbeddedBatch :exec

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -221,7 +221,7 @@ func (q *Queries) ListSavedJobSlugs(ctx context.Context, userID int64) ([]string
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, jobs.semantic_embedding, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -314,6 +314,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.Job.SemanticEmbeddedHash,
 			&i.Job.DuplicateOf,
 			&i.Job.IsTech,
+			&i.Job.SemanticEmbedding,
 			&i.ViewedAt,
 			&i.SavedAt,
 			&i.AppliedAt,

--- a/internal/embed/runner.go
+++ b/internal/embed/runner.go
@@ -39,8 +39,10 @@ type Store interface {
 	// aborts the whole load, so the runner retries such a batch per item to isolate it.
 	Jobs(ctx context.Context, ids []int64) ([]db.Job, error)
 	// CompleteOpen stamps each entry's job embed provenance (model + its current
-	// content_hash) and deletes the outbox entries, atomically.
-	CompleteOpen(ctx context.Context, entries []Claimed, model string) error
+	// content_hash), persists each job's semantic vector, and deletes the outbox
+	// entries, atomically. vectors maps job id to the vector just upserted into the
+	// index, so the durable Postgres copy commits with the provenance stamp.
+	CompleteOpen(ctx context.Context, entries []Claimed, model string, vectors map[int64][]float32) error
 	// CompleteClosed clears each entry's job embed provenance and deletes the outbox
 	// entries, atomically (their documents were just removed from the index).
 	CompleteClosed(ctx context.Context, entries []Claimed) error
@@ -51,8 +53,9 @@ type Store interface {
 // Indexer is the semantic-index side: embed+upsert open jobs, or remove closed ones.
 type Indexer interface {
 	// IndexOpen embeds the jobs' documents and upserts their vectors into the semantic
-	// index in one batch.
-	IndexOpen(ctx context.Context, jobs []db.Job) error
+	// index in one batch, returning the vectors keyed by job id so they can be persisted
+	// to Postgres alongside the provenance stamp.
+	IndexOpen(ctx context.Context, jobs []db.Job) (map[int64][]float32, error)
 	// RemoveClosed deletes the jobs' documents from the semantic index in one batch.
 	RemoveClosed(ctx context.Context, ids []int64) error
 }
@@ -146,11 +149,12 @@ func (rn *run) processOpenBatch(ctx context.Context, entries []Claimed) {
 		rn.fallbackOpen(ctx, entries)
 		return
 	}
-	if err := rn.indexer.IndexOpen(callCtx, jobs); err != nil {
+	vectors, err := rn.indexer.IndexOpen(callCtx, jobs)
+	if err != nil {
 		rn.fallbackOpen(ctx, entries)
 		return
 	}
-	if err := rn.store.CompleteOpen(callCtx, entries, rn.opt.TargetModel); err != nil {
+	if err := rn.store.CompleteOpen(callCtx, entries, rn.opt.TargetModel, vectors); err != nil {
 		rn.fallbackOpen(ctx, entries)
 		return
 	}
@@ -183,11 +187,12 @@ func (rn *run) processOpenOne(ctx context.Context, entry Claimed) {
 		rn.fail(entry, fmt.Errorf("job %d not found", entry.JobID))
 		return
 	}
-	if err := rn.indexer.IndexOpen(callCtx, jobs); err != nil {
+	vectors, err := rn.indexer.IndexOpen(callCtx, jobs)
+	if err != nil {
 		rn.fail(entry, fmt.Errorf("embed/index: %w", err))
 		return
 	}
-	if err := rn.store.CompleteOpen(callCtx, []Claimed{entry}, rn.opt.TargetModel); err != nil {
+	if err := rn.store.CompleteOpen(callCtx, []Claimed{entry}, rn.opt.TargetModel, vectors); err != nil {
 		rn.fail(entry, fmt.Errorf("complete open: %w", err))
 		return
 	}

--- a/internal/embed/runner_test.go
+++ b/internal/embed/runner_test.go
@@ -22,10 +22,11 @@ type fakeStore struct {
 
 	indexErr map[int64]error // CompleteOpen error for a job id (single-item path)
 
-	openBatches   [][]int64 // job ids per CompleteOpen call (len>1 = a real batch)
-	closedBatches [][]int64 // job ids per CompleteClosed call
-	openDone      []int64   // all job ids CompleteOpen'd
-	closedDone    []int64   // all job ids CompleteClosed'd
+	openBatches   [][]int64           // job ids per CompleteOpen call (len>1 = a real batch)
+	openVectors   map[int64][]float32 // vectors handed to CompleteOpen, keyed by job id
+	closedBatches [][]int64           // job ids per CompleteClosed call
+	openDone      []int64             // all job ids CompleteOpen'd
+	closedDone    []int64             // all job ids CompleteClosed'd
 	failCalls     []failCall
 	attempts      map[int64]int // outbox id -> attempts so far
 }
@@ -78,7 +79,7 @@ func (s *fakeStore) Jobs(_ context.Context, ids []int64) ([]db.Job, error) {
 	return out, nil
 }
 
-func (s *fakeStore) CompleteOpen(_ context.Context, entries []Claimed, _ string) error {
+func (s *fakeStore) CompleteOpen(_ context.Context, entries []Claimed, _ string, vectors map[int64][]float32) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	var ids []int64
@@ -90,6 +91,12 @@ func (s *fakeStore) CompleteOpen(_ context.Context, entries []Claimed, _ string)
 	}
 	s.openBatches = append(s.openBatches, ids)
 	s.openDone = append(s.openDone, ids...)
+	if s.openVectors == nil {
+		s.openVectors = map[int64][]float32{}
+	}
+	for id, v := range vectors {
+		s.openVectors[id] = v
+	}
 	return nil
 }
 
@@ -127,24 +134,26 @@ type fakeIndexer struct {
 
 func newFakeIndexer() *fakeIndexer { return &fakeIndexer{indexErr: map[int64]error{}} }
 
-func (ix *fakeIndexer) IndexOpen(_ context.Context, jobs []db.Job) error {
+func (ix *fakeIndexer) IndexOpen(_ context.Context, jobs []db.Job) (map[int64][]float32, error) {
 	ix.mu.Lock()
 	defer ix.mu.Unlock()
 	ids := make([]int64, len(jobs))
+	vecs := make(map[int64][]float32, len(jobs))
 	for i, j := range jobs {
 		ids[i] = j.ID
+		vecs[j.ID] = []float32{float32(j.ID)} // deterministic per-job vector
 	}
 	ix.indexCalls = append(ix.indexCalls, ids)
 	if ix.batchFails && len(jobs) > 1 {
-		return errors.New("batch embed failed")
+		return nil, errors.New("batch embed failed")
 	}
 	for _, j := range jobs {
 		if err := ix.indexErr[j.ID]; err != nil {
-			return err
+			return nil, err
 		}
 	}
 	ix.indexed = append(ix.indexed, ids...)
-	return nil
+	return vecs, nil
 }
 
 func (ix *fakeIndexer) RemoveClosed(_ context.Context, ids []int64) error {
@@ -258,5 +267,32 @@ func TestRunnerCorruptedRowDeadLettersInFallback(t *testing.T) {
 	}
 	if len(store.failCalls) != 1 || store.failCalls[0].maxAttempts != 1 {
 		t.Errorf("failCalls = %+v, want one with maxAttempts=1 (immediate dead-letter)", store.failCalls)
+	}
+}
+
+func TestRunnerPersistsVectorsToStore(t *testing.T) {
+	store := newFakeStore()
+	ix := newFakeIndexer()
+	for _, id := range []int64{1, 2} {
+		store.jobs[id] = db.Job{ID: id}
+	}
+	store.pending = []Claimed{
+		{OutboxID: 10, JobID: 1, Closed: false},
+		{OutboxID: 20, JobID: 2, Closed: false},
+	}
+
+	if _, err := (Runner{Store: store, Indexer: ix}).Run(context.Background(), opt()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The vectors IndexOpen produced must reach CompleteOpen so they commit to Postgres
+	// alongside the provenance stamp (the fake indexer returns [float32(id)] per job).
+	if len(store.openVectors) != 2 {
+		t.Fatalf("openVectors = %v; want 2 entries", store.openVectors)
+	}
+	if got := store.openVectors[1]; len(got) != 1 || got[0] != 1 {
+		t.Fatalf("vector for job 1 = %v; want [1]", got)
+	}
+	if got := store.openVectors[2]; len(got) != 1 || got[0] != 2 {
+		t.Fatalf("vector for job 2 = %v; want [2]", got)
 	}
 }

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -165,8 +165,11 @@ type Rebuild struct {
 	// semantic marks this a hybrid-index rebuild: Push embeds each batch (via TEI) and
 	// attaches the vectors, since the semantic index uses a userProvided embedder.
 	semantic bool
-	rebuild  meilisearch.IndexManager
-	tasks    []int64
+	// fromPG makes a semantic rebuild rehydrate from the vectors persisted in Postgres
+	// (jobs.semantic_embedding) instead of re-embedding via TEI — the fast recovery path.
+	fromPG  bool
+	rebuild meilisearch.IndexManager
+	tasks   []int64
 }
 
 // NewFacetRebuild starts a full rebuild of the facet/keyword production index.
@@ -177,6 +180,15 @@ func (c *Client) NewFacetRebuild() *Rebuild {
 // NewSemanticRebuild starts a full rebuild of the hybrid semantic index.
 func (c *Client) NewSemanticRebuild() *Rebuild {
 	return &Rebuild{c: c, liveUID: semanticIndexUID, rebuildUID: semanticRebuildUID, settings: semanticSettings(), semantic: true}
+}
+
+// NewSemanticRebuildFromPG starts a full rebuild of the hybrid semantic index that
+// rehydrates from the vectors already stored in Postgres instead of re-embedding via
+// TEI. Jobs without a persisted vector are left out of the rebuild (the embed worker
+// fills them incrementally). Use it to restore the index after a Meili data loss
+// without paying the weeks-long re-embedding cost.
+func (c *Client) NewSemanticRebuildFromPG() *Rebuild {
+	return &Rebuild{c: c, liveUID: semanticIndexUID, rebuildUID: semanticRebuildUID, settings: semanticSettings(), semantic: true, fromPG: true}
 }
 
 // Prepare creates a fresh, empty rebuild index with this pass's settings, ready to
@@ -220,9 +232,20 @@ func (r *Rebuild) Push(ctx context.Context, docs []JobDocument) error {
 	// pushes the plain documents.
 	var payload any = docs
 	if r.semantic {
-		sdocs, err := r.c.embedDocs(ctx, docs)
-		if err != nil {
-			return err
+		var sdocs []semanticDocument
+		if r.fromPG {
+			// Rehydrate: reuse the vectors already stored in Postgres, no TEI call.
+			// Documents without a persisted vector are dropped from this batch (the
+			// embed worker fills them incrementally).
+			sdocs = semanticDocsFromPG(docs)
+		} else {
+			var err error
+			if sdocs, err = r.c.embedDocs(ctx, docs); err != nil {
+				return err
+			}
+		}
+		if len(sdocs) == 0 {
+			return nil // nothing to push this batch (e.g. none carried a persisted vector)
 		}
 		payload = sdocs
 	}
@@ -341,22 +364,31 @@ func (c *Client) IndexJobs(ctx context.Context, docs []JobDocument) error {
 }
 
 // IndexSemanticJobs embeds a batch (via TEI) and upserts it into the semantic index
-// with each document's vector, since that index uses a userProvided embedder. Used by
-// the incremental reindex --semantic pass.
-func (c *Client) IndexSemanticJobs(ctx context.Context, docs []JobDocument) error {
+// with each document's vector, since that index uses a userProvided embedder. It
+// returns the computed vectors keyed by job id so the caller can persist them to
+// Postgres in the same unit of work — the durable copy that lets the index be
+// rehydrated without re-embedding. Used by the incremental embed worker.
+func (c *Client) IndexSemanticJobs(ctx context.Context, docs []JobDocument) (map[int64][]float32, error) {
 	if len(docs) == 0 {
-		return nil
+		return nil, nil
 	}
 	sdocs, err := c.embedDocs(ctx, docs)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	pk := primaryKey
 	task, err := c.semantic.UpdateDocumentsWithContext(ctx, sdocs, &meilisearch.DocumentOptions{PrimaryKey: &pk})
 	if err != nil {
-		return fmt.Errorf("search: index semantic documents: %w", err)
+		return nil, fmt.Errorf("search: index semantic documents: %w", err)
 	}
-	return c.awaitTask(ctx, c.semantic, task.TaskUID)
+	if err := c.awaitTask(ctx, c.semantic, task.TaskUID); err != nil {
+		return nil, err
+	}
+	vectors := make(map[int64][]float32, len(sdocs))
+	for _, sd := range sdocs {
+		vectors[sd.ID] = sd.Vectors[embedderName]
+	}
+	return vectors, nil
 }
 
 func (c *Client) indexInto(ctx context.Context, idx meilisearch.IndexManager, docs []JobDocument) error {

--- a/internal/search/document.go
+++ b/internal/search/document.go
@@ -41,6 +41,11 @@ type JobDocument struct {
 	// document (not jobview.Job), so it backs the `roles` facet but is never part
 	// of the served public wire shape.
 	Roles []string `json:"roles"`
+	// semanticVector is the job's persisted embedding (jobs.semantic_embedding), carried
+	// transiently so a --from-pg rebuild can rehydrate the semantic index from the stored
+	// vectors instead of re-embedding via TEI. Unexported, so it is never serialized into
+	// the Meili document body — the vector rides _vectors on the semanticDocument wrapper.
+	semanticVector []float32
 }
 
 // FromJob maps a database job row to its index document. An empty or absent
@@ -61,6 +66,7 @@ func FromJob(j db.Job) (JobDocument, error) {
 	// its own jobview.FromRow, unaffected by this local copy.
 	view.Description = truncateRunes(view.Description, maxIndexedDescriptionRunes)
 	doc := JobDocument{ID: j.ID, Job: view, Roles: roletag.Derive(j.Seniority, j.Category, j.Title)}
+	doc.semanticVector = j.SemanticEmbedding
 	if eff := jobview.EffectivePostedAt(j.PostedAt, j.CreatedAt); eff.Valid {
 		doc.PostedTS = eff.Time.Unix()
 	}

--- a/internal/search/search_integration_test.go
+++ b/internal/search/search_integration_test.go
@@ -239,7 +239,7 @@ func TestIntegration_EnsureIndexIndexAndSearch(t *testing.T) {
 		if err := c.EnsureSemanticIndex(ctx); err != nil {
 			t.Fatalf("EnsureSemanticIndex: %v", err)
 		}
-		if err := c.IndexSemanticJobs(ctx, docs); err != nil {
+		if _, err := c.IndexSemanticJobs(ctx, docs); err != nil {
 			t.Fatalf("IndexSemanticJobs: %v", err)
 		}
 		res, err := c.Search(ctx, SearchParams{Query: "backend engineering role", SemanticRatio: 0.5, Limit: 10})
@@ -476,7 +476,7 @@ func TestIntegration_SimilarJobs(t *testing.T) {
 			PublicSlug:  "data-scientist-delta-ddd",
 			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
 	}
-	if err := c.IndexSemanticJobs(ctx, toDocs(t, jobs)); err != nil {
+	if _, err := c.IndexSemanticJobs(ctx, toDocs(t, jobs)); err != nil {
 		t.Fatalf("IndexSemanticJobs: %v", err)
 	}
 
@@ -564,7 +564,7 @@ func TestIntegration_EmbedTextAndRecommend(t *testing.T) {
 			PublicSlug:  "frontend-react-developer-gamma-ccc",
 			Enrichment:  enrichedJSON(t, enrich.Enrichment{})},
 	}
-	if err := c.IndexSemanticJobs(ctx, toDocs(t, jobs)); err != nil {
+	if _, err := c.IndexSemanticJobs(ctx, toDocs(t, jobs)); err != nil {
 		t.Fatalf("IndexSemanticJobs: %v", err)
 	}
 
@@ -692,5 +692,65 @@ func TestIntegration_RebuildSwapsFreshIndexAndDropsOld(t *testing.T) {
 
 	if _, err := c.manager.GetIndexWithContext(ctx, "jobs_rebuild"); err == nil {
 		t.Error("jobs_rebuild still exists; Promote should drop it")
+	}
+}
+
+// A --from-pg semantic rebuild rehydrates the index from the vectors persisted in
+// Postgres (jobs.semantic_embedding) instead of re-embedding via TEI: a job carrying a
+// stored vector lands in jobs_semantic with that exact vector, and a job without one is
+// left out (for the embed worker to fill). This is the disaster-recovery path.
+func TestIntegration_SemanticRebuildFromPG(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+	if err := c.EnsureSemanticIndex(ctx); err != nil {
+		t.Fatalf("EnsureSemanticIndex: %v", err)
+	}
+
+	vec := func(seed float32) []float32 {
+		v := make([]float32, embedderDimensions)
+		for i := range v {
+			v[i] = seed
+		}
+		return v
+	}
+	jobs := []db.Job{
+		{ID: 1, Title: "Senior Golang Engineer", Company: "Acme", Location: "Berlin",
+			Description: "Build backend services in Go.",
+			PublicSlug:  "senior-golang-engineer-acme-aaa",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{}),
+			// 0.5 is exactly representable in float32, so the round-trip is exact.
+			SemanticEmbedding: vec(0.5)},
+		{ID: 2, Title: "Frontend Developer", Company: "Beta", Location: "Remote",
+			Description: "Build UIs in React.",
+			PublicSlug:  "frontend-developer-beta-bbb",
+			Enrichment:  enrichedJSON(t, enrich.Enrichment{})}, // no persisted vector
+	}
+
+	b := c.NewSemanticRebuildFromPG()
+	if err := b.Prepare(ctx); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if err := b.Push(ctx, toDocs(t, jobs)); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if err := b.Promote(ctx); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+
+	got, err := c.ListSemanticVectors(ctx, 0, 100)
+	if err != nil {
+		t.Fatalf("ListSemanticVectors: %v", err)
+	}
+	byID := make(map[int64][]float32, len(got))
+	for _, v := range got {
+		byID[v.ID] = v.Vector
+	}
+	if v, ok := byID[1]; !ok {
+		t.Fatal("job 1 missing from jobs_semantic after from-pg rebuild")
+	} else if len(v) != embedderDimensions || v[0] != 0.5 {
+		t.Errorf("job 1 vector[0] = %v (len %d); want 0.5 (len %d)", v[0], len(v), embedderDimensions)
+	}
+	if _, ok := byID[2]; ok {
+		t.Error("job 2 has no persisted vector and must be absent from the rehydrated index")
 	}
 }

--- a/internal/search/semantic_rehydrate.go
+++ b/internal/search/semantic_rehydrate.go
@@ -1,0 +1,21 @@
+package search
+
+// semanticDocsFromPG wraps each document that carries a persisted vector as a
+// userProvided semantic document, skipping any without one. It is the rehydrate path:
+// a --from-pg rebuild reuses the vectors already stored in Postgres instead of
+// re-embedding via TEI. A document with no persisted vector is left out of the rebuild
+// (the embed worker fills it incrementally) rather than indexed without a vector, which
+// the userProvided embedder rejects.
+func semanticDocsFromPG(docs []JobDocument) []semanticDocument {
+	out := make([]semanticDocument, 0, len(docs))
+	for _, d := range docs {
+		if len(d.semanticVector) == 0 {
+			continue
+		}
+		out = append(out, semanticDocument{
+			JobDocument: d,
+			Vectors:     map[string][]float32{embedderName: d.semanticVector},
+		})
+	}
+	return out
+}

--- a/internal/search/semantic_rehydrate_test.go
+++ b/internal/search/semantic_rehydrate_test.go
@@ -1,0 +1,32 @@
+package search
+
+import "testing"
+
+func TestSemanticDocsFromPG(t *testing.T) {
+	docs := []JobDocument{
+		{ID: 1, semanticVector: []float32{0.1, 0.2}},
+		{ID: 2}, // no persisted vector — must be skipped
+		{ID: 3, semanticVector: []float32{0.3, 0.4}},
+	}
+
+	got := semanticDocsFromPG(docs)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d semantic docs, want 2 (id 2 has no vector)", len(got))
+	}
+	if got[0].ID != 1 || got[1].ID != 3 {
+		t.Fatalf("ids = %d,%d; want 1,3", got[0].ID, got[1].ID)
+	}
+	// The persisted vector must ride _vectors under the embedder name, unchanged.
+	v := got[0].Vectors[embedderName]
+	if len(v) != 2 || v[0] != 0.1 || v[1] != 0.2 {
+		t.Fatalf("vector for id 1 = %v; want [0.1 0.2]", v)
+	}
+}
+
+func TestSemanticDocsFromPGAllEmpty(t *testing.T) {
+	got := semanticDocsFromPG([]JobDocument{{ID: 1}, {ID: 2}})
+	if len(got) != 0 {
+		t.Fatalf("got %d docs, want 0 (none carry a vector)", len(got))
+	}
+}

--- a/internal/search/semantic_vectors.go
+++ b/internal/search/semantic_vectors.go
@@ -1,0 +1,74 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// SemanticVector is one job's persisted vector read back from the semantic index —
+// the (job id, vector) pair the Postgres backfill needs so the durable copy of the
+// embeddings can live beside the jobs they belong to.
+type SemanticVector struct {
+	ID     int64
+	Vector []float32
+}
+
+// ListSemanticVectors reads one offset-paged window of (id, vector) pairs from the
+// semantic index, fetching only the id and the stored vector. It is the read side of
+// the Postgres backfill: these vectors already exist in Meili (computed once, at great
+// expense), so persisting them costs no embedding. An empty slice means the window is
+// past the last document. It uses the raw documents route because the SDK's typed
+// query does not expose retrieveVectors on this engine version.
+func (c *Client) ListSemanticVectors(ctx context.Context, offset, limit int) ([]SemanticVector, error) {
+	url := fmt.Sprintf("%s/indexes/%s/documents?retrieveVectors=true&fields=id&offset=%d&limit=%d",
+		c.url, semanticIndexUID, offset, limit)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("search: list semantic vectors request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.key)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search: list semantic vectors: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("search: list semantic vectors: unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("search: read semantic vectors: %w", err)
+	}
+	return parseSemanticVectorsPage(body)
+}
+
+// parseSemanticVectorsPage decodes one page of the `GET /indexes/<uid>/documents?
+// retrieveVectors=true` response into (id, vector) pairs. Documents that carry no
+// stored vector are skipped, so the caller only persists real embeddings.
+func parseSemanticVectorsPage(raw []byte) ([]SemanticVector, error) {
+	var page struct {
+		Results []struct {
+			ID      int64 `json:"id"`
+			Vectors map[string]struct {
+				// embeddings is a LIST of embeddings ([[...]]); a userProvided doc
+				// carries exactly one, so its vector is embeddings[0].
+				Embeddings [][]float32 `json:"embeddings"`
+			} `json:"_vectors"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &page); err != nil {
+		return nil, fmt.Errorf("search: decode semantic vectors page: %w", err)
+	}
+	out := make([]SemanticVector, 0, len(page.Results))
+	for _, r := range page.Results {
+		emb := r.Vectors[embedderName].Embeddings
+		if len(emb) == 0 || len(emb[0]) == 0 {
+			continue // no stored vector — nothing to persist
+		}
+		out = append(out, SemanticVector{ID: r.ID, Vector: emb[0]})
+	}
+	return out, nil
+}

--- a/internal/search/semantic_vectors_test.go
+++ b/internal/search/semantic_vectors_test.go
@@ -1,0 +1,66 @@
+package search
+
+import "testing"
+
+func TestParseSemanticVectorsPage(t *testing.T) {
+	// Shape mirrors the live Meili response: _vectors.default.embeddings is a list of
+	// embeddings ([[...]]) and the seeded vector is its single element.
+	raw := []byte(`{
+	  "results": [
+	    {"id": 1, "_vectors": {"default": {"embeddings": [[0.1, 0.2, 0.3]], "regenerate": false}}},
+	    {"id": 2, "_vectors": {"default": {"embeddings": [[0.4, 0.5, 0.6]], "regenerate": false}}}
+	  ],
+	  "offset": 0, "limit": 2, "total": 100
+	}`)
+
+	got, err := parseSemanticVectorsPage(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d vectors, want 2", len(got))
+	}
+	if got[0].ID != 1 || got[1].ID != 2 {
+		t.Fatalf("ids = %d,%d; want 1,2", got[0].ID, got[1].ID)
+	}
+	want0 := []float32{0.1, 0.2, 0.3}
+	if len(got[0].Vector) != 3 || got[0].Vector[0] != want0[0] || got[0].Vector[2] != want0[2] {
+		t.Fatalf("vector[0] = %v; want %v", got[0].Vector, want0)
+	}
+}
+
+func TestParseSemanticVectorsPageSkipsDocsWithoutVector(t *testing.T) {
+	// A doc with no _vectors, or an empty embeddings list, has nothing to persist —
+	// it must be skipped, not surfaced as a zero-length vector that would overwrite
+	// a real one with garbage.
+	raw := []byte(`{
+	  "results": [
+	    {"id": 1, "_vectors": {"default": {"embeddings": [[0.1, 0.2]], "regenerate": false}}},
+	    {"id": 2},
+	    {"id": 3, "_vectors": {"default": {"embeddings": [], "regenerate": false}}}
+	  ],
+	  "offset": 0, "limit": 3, "total": 3
+	}`)
+
+	got, err := parseSemanticVectorsPage(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d vectors, want 1 (only id 1 carries a vector)", len(got))
+	}
+	if got[0].ID != 1 {
+		t.Fatalf("kept id %d; want 1", got[0].ID)
+	}
+}
+
+func TestParseSemanticVectorsPageEmpty(t *testing.T) {
+	// The end-of-pagination page: no results, no error, empty slice.
+	got, err := parseSemanticVectorsPage([]byte(`{"results": [], "offset": 200, "limit": 100, "total": 200}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("got %d vectors, want 0", len(got))
+	}
+}

--- a/migrations/0021_jobs_semantic_embedding.sql
+++ b/migrations/0021_jobs_semantic_embedding.sql
@@ -1,0 +1,17 @@
+-- semantic_embedding is the durable copy of a job's semantic search vector — the
+-- e5-base (768-dim) embedding the cmd/embed worker computes and upserts into the
+-- Meilisearch jobs_semantic index. Until now those vectors lived ONLY in Meili, so a
+-- lost Meili volume would force a full re-embed of the whole catalogue (a weeks-long
+-- pass). Persisting them here makes Postgres the source of truth: the nightly pg_dump
+-- backs the vectors up, and the index can be rehydrated from Postgres without any
+-- re-embedding. Stored as real[] (float4) — e5 vectors are natively float32, so this
+-- preserves precision at half the footprint of double precision[].
+--
+-- Nullable: a job carries a vector only once cmd/embed has embedded it (technical,
+-- open jobs). The embed provenance already lives in jobs.semantic_embedded_model /
+-- semantic_embedded_hash; this column adds only the vector itself. Seed existing rows
+-- from Meili with cmd/backfill-semantic-vectors (no re-embedding).
+--
+-- Applied to a fresh volume by initdb after 0020; on the existing prod volume this
+-- ALTER must be run manually BEFORE deploying code that writes the column.
+ALTER TABLE jobs ADD COLUMN semantic_embedding real[];


### PR DESCRIPTION
## Why

The job semantic-search vectors (e5-base, 768-dim, ~1.75M) lived **only** in the Meili `jobs_semantic` index (`userProvided`, `regenerate:false` — Meili cannot recompute them). Re-embedding the whole catalogue takes **~2 weeks**, and the nightly `pg_dump` did not cover them — a lost Meili volume would mean weeks of lost work. This makes **Postgres the source of truth** for the vectors, so the nightly dump backs them up and the index can be rebuilt without re-embedding.

## What

- **Migration 0021** — `jobs.semantic_embedding real[]` (float4: e5 vectors are natively float32, half the footprint of `float8[]`).
- **Write-path** — `search.IndexSemanticJobs` returns the computed vectors; `embed.Runner` threads them `IndexOpen → CompleteOpen`; `CompleteOpen` persists each via `SetSemanticEmbedding` **in the same transaction** as the provenance stamp (never stamped-without-vector). The closed-job path also NULLs the vector.
- **Rehydrate** — `reindex --semantic --from-pg` rebuilds `jobs_semantic` from the persisted vectors **without** calling TEI (`NewSemanticRebuildFromPG` + `semanticDocsFromPG`; docs lacking a vector are left for the embed worker). Reuses the safe swap-rebuild machinery.
- **Backfill** — one-off `cmd/backfill-semantic-vectors` seeds the column from the existing Meili vectors (no re-embedding).

## Safety invariant

Nothing here touches `semantic_embedded_model`/`hash` stamps, the outbox, or the embedder identity — so **none of it can trigger a re-embed**. Verified on prod during the backfill: stamped-job count and outbox unchanged by the copy.

## Tests

- Unit (TDD): page parser, seeder loop, runner vector-threading, `semanticDocsFromPG`, `--from-pg` flag parsing.
- Integration (real Meili + Postgres): embed persists `semantic_embedding`; `--from-pg` rebuild round-trips PG → Meili → read-back exact, job-without-vector absent.

## Ops notes

- Migration 0021 already applied on prod; existing 1.75M vectors already backfilled into PG (covered by tonight's dump).
- Write-path takes effect only after `release.sh freehire`.