### PR TITLE
feat(sources): add Northstone and Alignerr adapters

### DIFF
--- a/internal/sources/alignerr.go
+++ b/internal/sources/alignerr.go
@@ -1,0 +1,148 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// alignerr adapts Alignerr's careers site (www.alignerr.com), a single-company source with no
+// per-tenant board id (boardless). Each page is a Next.js app embedding its data in the
+// __NEXT_DATA__ script: the /jobs listing carries every active posting's id and title (its
+// description truncated to a preview), so the full body, dates, and structured fields come
+// from each posting's own detail page, fanned out like the other detail-fetching adapters.
+type alignerr struct {
+	http TextGetter
+}
+
+// NewAlignerr builds the Alignerr adapter over the given HTTP client.
+func NewAlignerr(c TextGetter) Source { return alignerr{http: c} }
+
+func (alignerr) Provider() string { return "alignerr" }
+
+// alignerr is single-company, so its config entry carries no board.
+func (alignerr) boardless() {}
+
+const (
+	alignerrListURL = "https://www.alignerr.com/jobs"
+	alignerrJobURL  = "https://www.alignerr.com/jobs/"
+)
+
+// alignerrNextData is the slice of the __NEXT_DATA__ payload we read: the listing exposes
+// initialJobs, a detail page exposes a single job.
+type alignerrNextData struct {
+	Props struct {
+		PageProps struct {
+			InitialJobs []alignerrListItem `json:"initialJobs"`
+			Job         *alignerrJob       `json:"job"`
+		} `json:"pageProps"`
+	} `json:"props"`
+}
+
+// alignerrListItem is one posting from the listing's initialJobs array; it carries the id used
+// to build the detail URL and a location/title fallback for when the detail fetch fails.
+type alignerrListItem struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Location string `json:"location"`
+}
+
+// alignerrJob is the detail page's job record. htmlLongDescription is the full posting body;
+// isActive gates closed postings; jobType is the structured employment enum; firstPostDate is
+// the publish date (createdAt is the fallback).
+type alignerrJob struct {
+	ID                  string `json:"id"`
+	Name                string `json:"name"`
+	HTMLLongDescription string `json:"htmlLongDescription"`
+	ShortDescription    string `json:"shortDescription"`
+	IsActive            bool   `json:"isActive"`
+	FirstPostDate       string `json:"firstPostDate"`
+	CreatedAt           string `json:"createdAt"`
+	JobType             string `json:"jobType"`
+	Location            string `json:"location"`
+}
+
+func (a alignerr) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	body, err := a.http.GetText(ctx, alignerrListURL)
+	if err != nil {
+		return nil, fmt.Errorf("alignerr: listing: %w", err)
+	}
+	raw, ok := bracketSlice(body, "__NEXT_DATA__", '{', '}')
+	if !ok {
+		return nil, fmt.Errorf("alignerr: no __NEXT_DATA__ in listing")
+	}
+	var data alignerrNextData
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		return nil, fmt.Errorf("alignerr: decode listing: %w", err)
+	}
+
+	// Each posting's body and structured fields come from its own detail page, fanned out
+	// under a bounded pool.
+	return fetchDetails(data.Props.PageProps.InitialJobs, defaultDetailWorkers, func(it alignerrListItem) (Job, bool) {
+		return a.detail(ctx, e, it)
+	}), nil
+}
+
+// detail fetches one posting's detail page and maps its job record to a Job, returning ok=false
+// when the id is missing, the fetch fails, the page carries no job, or the posting is inactive —
+// so the caller skips just that posting.
+func (a alignerr) detail(ctx context.Context, e CompanyEntry, it alignerrListItem) (Job, bool) {
+	id := strings.TrimSpace(it.ID)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	jobURL := alignerrJobURL + id
+	body, err := a.http.GetText(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	raw, ok := bracketSlice(body, "__NEXT_DATA__", '{', '}')
+	if !ok {
+		return Job{}, false
+	}
+	var data alignerrNextData
+	if json.Unmarshal([]byte(raw), &data) != nil {
+		return Job{}, false
+	}
+	j := data.Props.PageProps.Job
+	if j == nil || !j.IsActive {
+		return Job{}, false
+	}
+
+	description := sanitizeHTML(j.HTMLLongDescription)
+	if description == "" {
+		description = strings.TrimSpace(j.ShortDescription)
+	}
+	// The listing presents every posting's location as "Remote"; the detail's own location is
+	// the fallback when the listing item is absent.
+	location := firstNonEmpty(it.Location, j.Location)
+	return Job{
+		ExternalID:     id,
+		URL:            jobURL,
+		Title:          firstNonEmpty(strings.TrimSpace(j.Name), strings.TrimSpace(it.Title)),
+		Company:        e.Company,
+		Location:       location,
+		Description:    description,
+		Remote:         isRemote(location),
+		EmploymentType: alignerrEmploymentType(j.JobType),
+		PostedAt:       parseRFC3339(firstNonEmpty(j.FirstPostDate, j.CreatedAt)),
+	}, true
+}
+
+// alignerrEmploymentType maps Alignerr's jobType enum onto the freehire vocabulary, returning
+// "" for an unknown/absent value so the description parser decides.
+func alignerrEmploymentType(t string) string {
+	switch strings.ToUpper(strings.TrimSpace(t)) {
+	case "FULL_TIME", "FULLTIME":
+		return "full_time"
+	case "PART_TIME", "PARTTIME":
+		return "part_time"
+	case "CONTRACT", "CONTRACTOR", "TEMPORARY":
+		return "contract"
+	case "INTERN", "INTERNSHIP":
+		return "internship"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/alignerr_test.go
+++ b/internal/sources/alignerr_test.go
@@ -1,0 +1,128 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// alignerrListingJSON is the /jobs page's __NEXT_DATA__: initialJobs carries each posting's id
+// and a truncated preview, so the adapter enumerates ids here and fetches each detail.
+func alignerrListingJSON(ids ...string) string {
+	var items []string
+	for _, id := range ids {
+		items = append(items, `{"id":"`+id+`","title":"Preview Title","location":"Remote","applyUrl":"/jobs/`+id+`"}`)
+	}
+	return `<script id="__NEXT_DATA__" type="application/json">` +
+		`{"props":{"pageProps":{"initialJobs":[` + strings.Join(items, ",") + `]}}}` +
+		`</script>`
+}
+
+// alignerrDetailJSON is a detail page's __NEXT_DATA__ job record. The description embeds a
+// <script> that sanitizeHTML must strip; jobType is the structured employment enum and
+// firstPostDate the publish date.
+func alignerrDetailJSON(id, name, jobType string, active bool) string {
+	activeStr := "false"
+	if active {
+		activeStr = "true"
+	}
+	return `<script id="__NEXT_DATA__" type="application/json">` +
+		`{"props":{"pageProps":{"job":{"id":"` + id + `","name":"` + name + `",` +
+		`"htmlLongDescription":"<p>Build tasks.</p><script>alert(1)</script>",` +
+		`"shortDescription":"short","isActive":` + activeStr + `,` +
+		`"firstPostDate":"2026-07-07T00:00:01.353Z","createdAt":"2026-06-26T21:41:06.513Z",` +
+		`"jobType":"` + jobType + `","location":"United States"}}}}` +
+		`</script>`
+}
+
+func TestAlignerrProvider(t *testing.T) {
+	if got := NewAlignerr(nil).Provider(); got != "alignerr" {
+		t.Errorf("Provider() = %q, want %q", got, "alignerr")
+	}
+}
+
+func TestAlignerrFetchListingThenDetailAndMaps(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/jobs/aaa", alignerrDetailJSON("aaa", "Software Engineer Task Author (AI Training)", "CONTRACT", true)).
+		route("alignerr.com/jobs", alignerrListingJSON("aaa"))
+
+	jobs, err := NewAlignerr(fake).Fetch(context.Background(), CompanyEntry{Company: "Alignerr", Provider: "alignerr"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "aaa" {
+		t.Errorf("ExternalID = %q, want aaa", j.ExternalID)
+	}
+	if j.URL != "https://www.alignerr.com/jobs/aaa" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Software Engineer Task Author (AI Training)" {
+		t.Errorf("Title = %q, want detail name", j.Title)
+	}
+	if j.Company != "Alignerr" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Remote" || !j.Remote {
+		t.Errorf("Location=%q Remote=%v, want listing Remote", j.Location, j.Remote)
+	}
+	if j.EmploymentType != "contract" {
+		t.Errorf("EmploymentType = %q, want contract", j.EmploymentType)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Build tasks") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 7, 0, 0, 1, 353000000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want firstPostDate 2026-07-07T00:00:01.353Z", j.PostedAt)
+	}
+}
+
+func TestAlignerrDropsInactiveAndMissingDetail(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/jobs/live", alignerrDetailJSON("live", "Live Role", "CONTRACT", true)).
+		route("/jobs/closed", alignerrDetailJSON("closed", "Closed Role", "CONTRACT", false)).
+		// no route for "gone" → its detail fetch fails
+		route("alignerr.com/jobs", alignerrListingJSON("live", "closed", "gone"))
+
+	jobs, err := NewAlignerr(fake).Fetch(context.Background(), CompanyEntry{Company: "Alignerr"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "live" {
+		t.Fatalf("got %v, want only the active posting with a reachable detail", jobs)
+	}
+}
+
+func TestAlignerrEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"CONTRACT": "contract", "FULL_TIME": "full_time",
+		"PART_TIME": "part_time", "INTERNSHIP": "internship", "": "", "WEIRD": "",
+	}
+	for in, want := range cases {
+		if got := alignerrEmploymentType(in); got != want {
+			t.Errorf("alignerrEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestAlignerrRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["alignerr"]
+	if !ok {
+		t.Fatal("All() missing provider alignerr")
+	}
+	if s.Provider() != "alignerr" {
+		t.Errorf("All()[alignerr].Provider() = %q", s.Provider())
+	}
+	// Single-company boardless: redundant with the company filter, so excluded from the facet.
+	if slices.Contains(FilterableProviders(), "alignerr") {
+		t.Error("FilterableProviders() should exclude boardless alignerr")
+	}
+}

--- a/internal/sources/jsonld.go
+++ b/internal/sources/jsonld.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 
@@ -14,7 +15,8 @@ func LDJobPosting(root *html.Node, v any) bool { return ldJobPosting(root, v) }
 // ldJobPosting decodes the first application/ld+json JobPosting block on the page into v,
 // returning false when the page carries no such block. Shared by the HTML detail adapters
 // (teamtailor, breezy) whose job pages server-render a schema.org JobPosting; each passes
-// a struct selecting just the fields it needs.
+// a struct selecting just the fields it needs. The JobPosting may sit at the block's top
+// level, inside an array of nodes, or under a @graph wrapper (see jobPostingNode).
 func ldJobPosting(root *html.Node, v any) bool {
 	found := false
 	walk(root, func(n *html.Node) bool {
@@ -23,13 +25,8 @@ func ldJobPosting(root *html.Node, v any) bool {
 		}
 		if n.Type == html.ElementNode && n.Data == "script" &&
 			attr(n, "type") == "application/ld+json" {
-			raw := []byte(textContent(n))
-			var probe struct {
-				Type string `json:"@type"`
-			}
-			if json.Unmarshal(raw, &probe) == nil &&
-				strings.EqualFold(probe.Type, "JobPosting") &&
-				json.Unmarshal(raw, v) == nil {
+			if msg, ok := jobPostingNode([]byte(textContent(n))); ok &&
+				json.Unmarshal(msg, v) == nil {
 				found = true
 				return false
 			}
@@ -37,4 +34,51 @@ func ldJobPosting(root *html.Node, v any) bool {
 		return true
 	})
 	return found
+}
+
+// jobPostingNode finds the schema.org JobPosting node inside one ld+json block, whatever its
+// top-level shape: a bare JobPosting object, an array of nodes ([{...}, ...], as Langford
+// emits), or a graph wrapper ({"@graph":[...]}). It returns that node's raw JSON so the caller
+// decodes just the fields it needs, or ok=false when the block carries no JobPosting.
+func jobPostingNode(raw []byte) (json.RawMessage, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, false
+	}
+	if trimmed[0] == '[' {
+		var nodes []json.RawMessage
+		if json.Unmarshal(trimmed, &nodes) != nil {
+			return nil, false
+		}
+		return firstJobPosting(nodes)
+	}
+	if isJobPosting(trimmed) {
+		return trimmed, true
+	}
+	// Not a bare JobPosting object → it may be a @graph wrapper listing the page's nodes.
+	var wrapper struct {
+		Graph []json.RawMessage `json:"@graph"`
+	}
+	if json.Unmarshal(trimmed, &wrapper) == nil {
+		return firstJobPosting(wrapper.Graph)
+	}
+	return nil, false
+}
+
+// firstJobPosting returns the first JobPosting node among a list of ld+json nodes.
+func firstJobPosting(nodes []json.RawMessage) (json.RawMessage, bool) {
+	for _, n := range nodes {
+		if isJobPosting(n) {
+			return n, true
+		}
+	}
+	return nil, false
+}
+
+// isJobPosting reports whether a raw ld+json node is a schema.org JobPosting.
+func isJobPosting(raw json.RawMessage) bool {
+	var probe struct {
+		Type string `json:"@type"`
+	}
+	return json.Unmarshal(raw, &probe) == nil && strings.EqualFold(probe.Type, "JobPosting")
 }

--- a/internal/sources/jsonld_shape_test.go
+++ b/internal/sources/jsonld_shape_test.go
@@ -1,0 +1,43 @@
+package sources
+
+import (
+	"golang.org/x/net/html"
+	"strings"
+	"testing"
+)
+
+// ldPage wraps a raw ld+json body in a minimal HTML page.
+func ldPage(body string) *html.Node {
+	n, _ := html.Parse(strings.NewReader(
+		`<html><body><script type="application/ld+json">` + body + `</script></body></html>`))
+	return n
+}
+
+func TestLDJobPostingShapes(t *testing.T) {
+	posting := `{"@type":"JobPosting","title":"Role","identifier":{"value":"x1"}}`
+	cases := map[string]string{
+		"bare object":    posting,
+		"array of nodes": `[{"@type":"Organization","name":"Co"},` + posting + `]`,
+		"graph wrapper":  `{"@context":"https://schema.org","@graph":[{"@type":"WebSite"},` + posting + `]}`,
+	}
+	for name, body := range cases {
+		var got struct {
+			Title      string `json:"title"`
+			Identifier struct {
+				Value string `json:"value"`
+			} `json:"identifier"`
+		}
+		if !ldJobPosting(ldPage(body), &got) {
+			t.Errorf("%s: ldJobPosting = false, want true", name)
+			continue
+		}
+		if got.Title != "Role" || got.Identifier.Value != "x1" {
+			t.Errorf("%s: decoded %+v, want title=Role value=x1", name, got)
+		}
+	}
+	// A page with no JobPosting node anywhere yields false.
+	var sink struct{}
+	if ldJobPosting(ldPage(`[{"@type":"Organization"}]`), &sink) {
+		t.Error("ldJobPosting on non-JobPosting array = true, want false")
+	}
+}

--- a/internal/sources/northstone.go
+++ b/internal/sources/northstone.go
@@ -1,0 +1,202 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// northstone adapts the Northstone Holdings recruiting-brand career sites (e.g. Revun,
+// Langford Staffing, "Vetted by EnzRossi"). The brands share one server-rendered Next.js
+// template: a listing at https://<host>/<section>/ (the trailing slash is required — without
+// it the site 308-redirects) whose anchors link to /<section>/<slug> detail pages, each
+// carrying a schema.org JobPosting ld+json. The board encodes both parts as "<host>/<section>"
+// (e.g. "www.revun.com/careers", "vetted.enzrossi.com/positions"); the native posting id is the
+// JobPosting identifier.value (a per-brand backend id — a UUID for EnzRossi, a Zoho Recruit id
+// for Revun/Langford), which is stable across the site's slug changes. Description and structured
+// fields come from a per-posting detail fetch (bounded-concurrency), like the other JSON-LD
+// detail adapters (careerspage/epam).
+type northstone struct {
+	http HTMLGetter
+}
+
+// NewNorthstone builds the Northstone recruiting-brand adapter over the given HTML client.
+func NewNorthstone(c HTMLGetter) Source { return northstone{http: c} }
+
+func (northstone) Provider() string { return "northstone" }
+
+func (s northstone) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	host, section, err := northstoneBoard(e.Board)
+	if err != nil {
+		return nil, err
+	}
+	// The trailing slash is load-bearing: the listing 308-redirects without it.
+	base, err := url.Parse(fmt.Sprintf("https://%s/%s/", host, section))
+	if err != nil {
+		return nil, fmt.Errorf("northstone: board %q: %w", e.Board, err)
+	}
+	root, err := s.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("northstone: listing %s: %w", e.Board, err)
+	}
+
+	// Each posting's fields come from its own detail fetch, fanned out under a bounded pool.
+	locs := jobLinks(base, root, northstoneIsJob(section))
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one job's detail page and maps its JobPosting ld+json to a Job, returning
+// ok=false when the fetch fails, the page carries no JobPosting, or the posting has no native
+// id — so the caller skips just that posting.
+func (s northstone) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	loc = northstoneCanonical(loc)
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p northstonePosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	id := strings.TrimSpace(p.Identifier.Value)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+
+	location := p.location()
+	// jobLocationType is the only structured work-arrangement signal: TELECOMMUTE means remote.
+	// Absent → leave WorkMode empty and fall back to the location text for the remote flag.
+	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+	workMode := ""
+	if remote {
+		workMode = "remote"
+	}
+	return Job{
+		ExternalID:     id,
+		URL:            loc,
+		Title:          p.Title,
+		Company:        firstNonEmpty(p.HiringOrganization.Name, e.Company),
+		Location:       location,
+		Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:         remote || isRemote(location),
+		WorkMode:       workMode,
+		EmploymentType: schemaEmploymentType(p.EmploymentType),
+		PostedAt:       northstoneDate(p.DatePosted),
+	}, true
+}
+
+// northstoneDate parses the JobPosting datePosted, which arrives as a full RFC3339 timestamp
+// on some brands (EnzRossi) and as a bare date on others (Revun's "2026-07-01").
+func northstoneDate(s string) *time.Time {
+	if t := parseRFC3339(s); t != nil {
+		return t
+	}
+	return parseDate(s)
+}
+
+// northstonePosting is the schema.org JobPosting decoded from a detail page's ld+json block.
+// jobLocation is a single Place (null for a fully-remote posting) and applicantLocationRequirements
+// an array of Country; location() prefers the former and falls back to the latter.
+type northstonePosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	EmploymentType     string `json:"employmentType"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+			AddressRegion   string `json:"addressRegion"`
+			AddressCountry  string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+	ApplicantLocationRequirements []struct {
+		Name string `json:"name"`
+	} `json:"applicantLocationRequirements"`
+	Identifier struct {
+		Value string `json:"value"`
+	} `json:"identifier"`
+}
+
+// location builds the free-text location, preferring the explicit jobLocation address and
+// falling back to the applicant-location countries (the only signal a fully-remote posting
+// exposes, its jobLocation being null).
+func (p northstonePosting) location() string {
+	if loc := joinNonEmpty(
+		p.JobLocation.Address.AddressLocality,
+		p.JobLocation.Address.AddressRegion,
+		p.JobLocation.Address.AddressCountry,
+	); loc != "" {
+		return loc
+	}
+	names := make([]string, 0, len(p.ApplicantLocationRequirements))
+	for _, c := range p.ApplicantLocationRequirements {
+		names = append(names, c.Name)
+	}
+	return joinNonEmpty(names...)
+}
+
+// northstoneBoard splits the "<host>/<section>" board into its host and single-segment
+// listing path, rejecting a board that is missing either part or carries a deeper path.
+func northstoneBoard(board string) (host, section string, err error) {
+	board = strings.Trim(strings.TrimSpace(board), "/")
+	host, section, ok := strings.Cut(board, "/")
+	if !ok || host == "" || section == "" || strings.Contains(section, "/") {
+		return "", "", fmt.Errorf("northstone: board %q must be %q", board, "<host>/<section>")
+	}
+	return host, section, nil
+}
+
+// northstoneIsJob returns the job-link predicate for a listing under /<section>/: it accepts a
+// single-segment /<section>/<slug> detail anchor and rejects the bare listing, other sections,
+// and any deeper sub-path. A non-job link that slips through (e.g. /careers/faq) just fails the
+// JobPosting decode and is dropped, so the predicate need not be exhaustive.
+func northstoneIsJob(section string) func(string) bool {
+	re := regexp.MustCompile(`^/` + regexp.QuoteMeta(section) + `/[^/?#]+/?$`)
+	return func(href string) bool {
+		u, err := url.Parse(href)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(u.Path)
+	}
+}
+
+// northstoneCanonical ensures the detail URL ends in the trailing slash the sites redirect to,
+// so we fetch (and store) the canonical form directly rather than through a 308.
+func northstoneCanonical(loc string) string {
+	u, err := url.Parse(loc)
+	if err != nil || u.Path == "" || strings.HasSuffix(u.Path, "/") {
+		return loc
+	}
+	u.Path += "/"
+	return u.String()
+}
+
+// schemaEmploymentType maps a schema.org JobPosting employmentType enum onto the freehire
+// vocabulary, returning "" for an unknown/absent value (e.g. "OTHER") so the description
+// parser decides.
+func schemaEmploymentType(t string) string {
+	switch strings.ToUpper(strings.TrimSpace(t)) {
+	case "FULL_TIME":
+		return "full_time"
+	case "PART_TIME":
+		return "part_time"
+	case "CONTRACTOR", "TEMPORARY":
+		return "contract"
+	case "INTERN", "INTERNSHIP":
+		return "internship"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/northstone_test.go
+++ b/internal/sources/northstone_test.go
@@ -1,0 +1,229 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// northstoneListingHTML is a Northstone brand listing page: server-rendered anchors to
+// /<section>/<slug> detail pages, plus noise anchors (the bare listing and another section)
+// that the job-link predicate must reject.
+func northstoneListingHTML(section string, slugs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><ul>`)
+	for _, s := range slugs {
+		b.WriteString(`<li><a href="/` + section + `/` + s + `">A Role</a></li>`)
+	}
+	b.WriteString(`<a href="/` + section + `/">All roles</a>`) // bare listing — not a posting
+	b.WriteString(`<a href="/about">About</a>`)                // other section — not a posting
+	b.WriteString(`</ul></body></html>`)
+	return b.String()
+}
+
+// northstoneRemoteDetailHTML is a fully-remote detail page (EnzRossi-shaped): jobLocation is
+// null and the location comes from applicantLocationRequirements; jobLocationType TELECOMMUTE
+// makes it remote. The description embeds a <script> (escaped as <\/script>) sanitizeHTML strips.
+func northstoneRemoteDetailHTML(title, id string) string {
+	return `<html><head></head><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"` + title + `",
+"description":"<h2>Role</h2><p>Ship features.</p><script>alert(1)<\/script>",
+"datePosted":"2026-07-14T13:34:41.575+00:00",
+"employmentType":"FULL_TIME",
+"jobLocationType":"TELECOMMUTE",
+"jobLocation":null,
+"applicantLocationRequirements":[{"@type":"Country","name":"Brazil"},{"@type":"Country","name":"Argentina"}],
+"hiringOrganization":{"@type":"Organization","name":"EnzRossi","sameAs":"https://vetted.enzrossi.com"},
+"identifier":{"@type":"PropertyValue","name":"EnzRossi","value":"` + id + `"}}
+</script></body></html>`
+}
+
+// northstoneOnsiteDetailHTML is an on-site detail page (Langford-shaped): the JobPosting is
+// wrapped in a single-element ARRAY (as Langford emits), the location comes from the jobLocation
+// address, there is no jobLocationType so WorkMode stays empty, employmentType "OTHER" maps to
+// no structured type, and datePosted is a bare date the RFC3339 parser must fall back on.
+func northstoneOnsiteDetailHTML(title, id string) string {
+	return `<html><body>
+<script type="application/ld+json">
+[{"@type":"JobPosting","title":"` + title + `",
+"description":"<p>On location.</p>",
+"datePosted":"2026-07-01",
+"employmentType":"OTHER",
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"Calgary","addressRegion":"Alberta","addressCountry":"CA"}},
+"identifier":{"@type":"PropertyValue","name":"Langford Staffing","value":"` + id + `"}}]
+</script></body></html>`
+}
+
+func TestNorthstoneProvider(t *testing.T) {
+	if got := NewNorthstone(nil).Provider(); got != "northstone" {
+		t.Errorf("Provider() = %q, want %q", got, "northstone")
+	}
+}
+
+func TestNorthstoneBoard(t *testing.T) {
+	okCases := map[string]struct{ host, section string }{
+		"vetted.enzrossi.com/positions":      {"vetted.enzrossi.com", "positions"},
+		"www.revun.com/careers":              {"www.revun.com", "careers"},
+		"/www.langfordstaffing.com/careers/": {"www.langfordstaffing.com", "careers"},
+	}
+	for board, want := range okCases {
+		host, section, err := northstoneBoard(board)
+		if err != nil {
+			t.Errorf("northstoneBoard(%q) error: %v", board, err)
+			continue
+		}
+		if host != want.host || section != want.section {
+			t.Errorf("northstoneBoard(%q) = (%q,%q), want (%q,%q)", board, host, section, want.host, want.section)
+		}
+	}
+	for _, bad := range []string{"", "hostonly", "host/", "/careers", "host/a/b"} {
+		if _, _, err := northstoneBoard(bad); err == nil {
+			t.Errorf("northstoneBoard(%q) = nil error, want error", bad)
+		}
+	}
+}
+
+func TestNorthstoneIsJob(t *testing.T) {
+	isJob := northstoneIsJob("careers")
+	accept := []string{"/careers/cto-head-of-engineering-calgary", "https://www.revun.com/careers/some-role/"}
+	reject := []string{"/careers/", "/careers", "/about", "/careers/role/apply", "/positions/role"}
+	for _, href := range accept {
+		if !isJob(href) {
+			t.Errorf("isJob(%q) = false, want true", href)
+		}
+	}
+	for _, href := range reject {
+		if isJob(href) {
+			t.Errorf("isJob(%q) = true, want false", href)
+		}
+	}
+}
+
+func TestNorthstoneFetchMapsRemotePosting(t *testing.T) {
+	id := "5ec4e6b2-364d-4e4b-be3d-ede0c77da0de"
+	// Detail routes precede the listing route: the listing URL matches only "/positions/",
+	// while a detail URL matches its more specific slug substring first.
+	fake := (&routedHTTP{}).
+		route("positions/senior-go-engineer", northstoneRemoteDetailHTML("Senior Go Engineer", id)).
+		route("/positions/", northstoneListingHTML("positions", "senior-go-engineer"))
+
+	jobs, err := NewNorthstone(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Fallback Co", Provider: "northstone", Board: "vetted.enzrossi.com/positions",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != id {
+		t.Errorf("ExternalID = %q, want identifier.value %q", j.ExternalID, id)
+	}
+	if j.URL != "https://vetted.enzrossi.com/positions/senior-go-engineer/" {
+		t.Errorf("URL = %q, want canonical trailing-slash detail URL", j.URL)
+	}
+	if j.Title != "Senior Go Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "EnzRossi" {
+		t.Errorf("Company = %q, want hiringOrganization name", j.Company)
+	}
+	if j.Location != "Brazil, Argentina" {
+		t.Errorf("Location = %q, want applicant-location countries", j.Location)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote from TELECOMMUTE", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Ship features") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 14, 13, 34, 41, 575000000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-07-14T13:34:41.575Z", j.PostedAt)
+	}
+}
+
+func TestNorthstoneFetchMapsOnsitePostingFromJobLocation(t *testing.T) {
+	id := "2842000000195206"
+	fake := (&routedHTTP{}).
+		route("careers/account-manager-calgary", northstoneOnsiteDetailHTML("Account Manager", id)).
+		route("/careers/", northstoneListingHTML("careers", "account-manager-calgary"))
+
+	jobs, err := NewNorthstone(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Langford Staffing", Provider: "northstone", Board: "www.langfordstaffing.com/careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != id {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, id)
+	}
+	if j.Location != "Calgary, Alberta, CA" {
+		t.Errorf("Location = %q, want jobLocation address", j.Location)
+	}
+	if j.Remote || j.WorkMode != "" {
+		t.Errorf("Remote=%v WorkMode=%q, want on-site (no jobLocationType)", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "" {
+		t.Errorf("EmploymentType = %q, want empty for OTHER", j.EmploymentType)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want bare-date 2026-07-01", j.PostedAt)
+	}
+}
+
+func TestNorthstoneDropsDetailWithoutJobPosting(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("positions/good-role", northstoneRemoteDetailHTML("Good Role", "abc")).
+		route("positions/no-ld", `<html><body>no ld+json here</body></html>`).
+		route("/positions/", northstoneListingHTML("positions", "good-role", "no-ld"))
+
+	jobs, err := NewNorthstone(fake).Fetch(context.Background(), CompanyEntry{Board: "vetted.enzrossi.com/positions"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "abc" {
+		t.Fatalf("got %v, want only the posting with a JobPosting block", jobs)
+	}
+}
+
+func TestNorthstoneRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["northstone"]
+	if !ok {
+		t.Fatal("All() missing provider northstone")
+	}
+	if s.Provider() != "northstone" {
+		t.Errorf("All()[northstone].Provider() = %q", s.Provider())
+	}
+	if !slices.Contains(FilterableProviders(), "northstone") {
+		t.Error("FilterableProviders() should include northstone (board-based)")
+	}
+}
+
+func TestSchemaEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"FULL_TIME": "full_time", "PART_TIME": "part_time",
+		"CONTRACTOR": "contract", "TEMPORARY": "contract",
+		"INTERN": "internship", "OTHER": "", "": "",
+	}
+	for in, want := range cases {
+		if got := schemaEmploymentType(in); got != want {
+			t.Errorf("schemaEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -201,6 +201,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTeamtailor(c),
 		NewICIMS(c),
 		NewCareerPage(c),
+		NewNorthstone(c),
 		NewLoxo(c),
 		NewHireology(c),
 		NewIsolvedHire(c),
@@ -284,6 +285,7 @@ func All(c HTTPClient) map[string]Source {
 		NewApple(c),
 		NewLumenalta(c),
 		NewDataArt(c),
+		NewAlignerr(c),
 		NewBairesDev(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).

--- a/sources/alignerr.yml
+++ b/sources/alignerr.yml
@@ -1,0 +1,5 @@
+# Alignerr careers (www.alignerr.com). Boardless single-company source: one fixed host with no
+# per-tenant board id, so the entry carries no board. The job's company is this entry's
+# `company` (Alignerr), not read per posting. See internal/sources/alignerr.go.
+- company: Alignerr
+  provider: alignerr

--- a/sources/northstone.yml
+++ b/sources/northstone.yml
@@ -1,0 +1,10 @@
+# Northstone Holdings recruiting-brand career sites (see internal/sources/northstone.go).
+# board = "<host>/<section>": the careers host plus the listing path segment. The brands share
+# one server-rendered Next.js template; the native id comes from the JobPosting identifier.value.
+# Each board validated live (the /<section>/ listing returns the job anchors) before adding.
+- company: EnzRossi
+  board: vetted.enzrossi.com/positions
+- company: Revun
+  board: www.revun.com/careers
+- company: Langford Staffing
+  board: www.langfordstaffing.com/careers

--- a/web/src/posts/2026-07-15-new-job-sources.svx
+++ b/web/src/posts/2026-07-15-new-job-sources.svx
@@ -1,0 +1,22 @@
+---
+title: Four new job sources — remote LATAM engineering and AI-training work
+date: 2026-07-15
+summary: We added EnzRossi, Revun, Langford Staffing, and Alignerr to the crawl, bringing remote engineering roles and hourly AI-training contract work into the catalogue.
+type: changelog
+tags:
+  - sources
+  - remote
+draft: false
+---
+
+freehire keeps widening the net. Four more career sites just started feeding the
+catalogue:
+
+- **EnzRossi** — remote software engineering roles (full-stack, backend
+  Python/FastAPI, React/Node) open across Latin America.
+- **Revun** and **Langford Staffing** — recruiting brands placing
+  engineering-leadership and operations roles.
+- **Alignerr** — remote, contract "AI training" work: writing the expert tasks
+  that train and evaluate AI models, paid by the hour.
+
+[Browse the newest jobs](/jobs) to see them roll in.


### PR DESCRIPTION
Adds two source adapters, both validated live and end-to-end (local ingest: northstone 51/51, alignerr 60/60, 0 failed).

## Northstone (`northstone`)
One JSON-LD-front adapter for the Northstone Holdings recruiting brands — **Revun**, **Langford Staffing**, and **Vetted by EnzRossi** — which share a single server-rendered Next.js template.

- `board = "<host>/<section>"` (e.g. `vetted.enzrossi.com/positions`, `www.revun.com/careers`, `www.langfordstaffing.com/careers`).
- Listing at `/<section>/` (**trailing slash required** — the sites 308-redirect without it) → `/<section>/<slug>` detail pages carrying a schema.org `JobPosting` ld+json → `external_id = identifier.value` (a UUID for EnzRossi's own backend, a Zoho Recruit id for Revun/Langford).
- **Root-causes the shared `ldJobPosting` helper** (`jsonld.go`) to also find the JobPosting inside an array-of-nodes (`[{...}]`, as Langford emits) or a `@graph` wrapper — not just a bare object. Benefits every JSON-LD detail adapter.

## Alignerr (`alignerr`)
Boardless single-company adapter over www.alignerr.com.

- Reads the `__NEXT_DATA__` `initialJobs` listing to enumerate ids, then each detail page for the full `htmlLongDescription`, `isActive` gate, dates, and `jobType`.

## Notes
- These are lower-value sources (Northstone brands repost the same role across many cities; Alignerr lists gig/RLHF task-author roles). Included by explicit request. If the near-dupes prove noisy, they can be dropped by removing the board files.

## Test plan
- `go build ./... && go vet ./... && go test ./...` — green.
- Live fetch validated for all four brands before commit.
- Full `cmd/ingest` against a local DB: northstone 51/51, alignerr 60/60, 0 failed.