### PR TITLE
feat(embed): EMBED_PG_ONLY mode to embed to Postgres without Meili

### DIFF
--- a/cmd/embed/embed_integration_test.go
+++ b/cmd/embed/embed_integration_test.go
@@ -290,3 +290,48 @@ func jobStamp(t *testing.T, pool *pgxpool.Pool, id int64) (model, hash *string) 
 	}
 	return model, hash
 }
+
+// PG-only mode embeds to Postgres WITHOUT touching Meilisearch: the open job's vector
+// and stamp land in Postgres, but its document never appears in jobs_semantic (that
+// index is filled later by `reindex --semantic --from-pg`). This is the fast bulk-embed
+// path that Meili's serial task queue cannot gate.
+func TestIntegration_EmbedWorkerPGOnly(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("EMBED_URL", fakeTEI(t))
+	meiliURL, key := startMeili(t)
+	pool := startPostgres(t)
+
+	client := search.NewClient(meiliURL, key)
+	// Create the (empty) semantic index up front so we can assert pg-only leaves it empty.
+	if err := client.EnsureSemanticIndex(ctx); err != nil {
+		t.Fatalf("EnsureSemanticIndex: %v", err)
+	}
+
+	openID := seedJob(t, pool, "pgonly-open", "Senior Golang Engineer", false, true)
+
+	runner := embed.Runner{
+		Store:   newDBStore(pool),
+		Indexer: searchIndexer{client: client, q: db.New(pool), pgOnly: true},
+	}
+	stats, err := runner.Run(ctx, embed.RunOptions{
+		TargetModel: search.CurrentEmbedderModel(), BatchSize: 500, LeaseSeconds: 300, MaxAttempts: 3,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stats.Indexed != 1 {
+		t.Fatalf("stats = %+v, want indexed=1", stats)
+	}
+
+	// Postgres has the vector + the current-model stamp.
+	if l := jobVectorLen(t, pool, openID); l <= 0 {
+		t.Errorf("open job semantic_embedding length = %d, want > 0 (vector persisted)", l)
+	}
+	if model, _ := jobStamp(t, pool, openID); model == nil || *model != search.CurrentEmbedderModel() {
+		t.Errorf("open job stamp model = %v, want %q", model, search.CurrentEmbedderModel())
+	}
+	// Meili was NOT touched: the document is absent from jobs_semantic.
+	if meiliDocExists(t, meiliURL, key, openID) {
+		t.Error("pg-only mode must NOT write the document into jobs_semantic")
+	}
+}

--- a/cmd/embed/indexer.go
+++ b/cmd/embed/indexer.go
@@ -20,6 +20,11 @@ import (
 type searchIndexer struct {
 	client *search.Client
 	q      *db.Queries
+	// pgOnly makes the indexer embed to Postgres ONLY: it computes vectors (persisted by
+	// the store's CompleteOpen) but never writes Meilisearch, so a bulk backfill is not
+	// gated by Meili's serial task queue. The semantic index is rebuilt from Postgres
+	// afterwards with `reindex --semantic --from-pg`.
+	pgOnly bool
 }
 
 func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) (map[int64][]float32, error) {
@@ -29,30 +34,39 @@ func (ix searchIndexer) IndexOpen(ctx context.Context, jobs []db.Job) (map[int64
 		if err != nil {
 			return nil, fmt.Errorf("build document (job %d): %w", job.ID, err)
 		}
-		// Attach the job-reality signal so an incrementally-embedded job carries
-		// reality.class immediately, matching the ingest incremental path. Without it a
-		// recommendations query that positively filters on reality.class would silently
-		// exclude the job until reindex --semantic reconciles it. A cluster-count lookup
-		// failure degrades to a unique role (counts 1) rather than dropping the doc.
-		repost, mass := int64(1), int64(1)
-		if c, err := ix.q.RoleClusterCount(ctx, db.RoleClusterCountParams{
-			CompanySlug:     job.CompanySlug,
-			RoleFingerprint: job.RoleFingerprint,
-		}); err != nil {
-			log.Printf("embed: role-cluster count for job %d: %v", job.ID, err)
-		} else {
-			repost, mass = c.RepostCount, c.MassCount
+		// The job-reality signal is a Meili-document facet, so pg-only mode (which never
+		// builds a Meili doc) skips it — and its per-job cluster-count query. In the
+		// normal path attach it so an incrementally-embedded job carries reality.class
+		// immediately; a cluster-count lookup failure degrades to a unique role (1,1).
+		if !ix.pgOnly {
+			repost, mass := int64(1), int64(1)
+			if c, err := ix.q.RoleClusterCount(ctx, db.RoleClusterCountParams{
+				CompanySlug:     job.CompanySlug,
+				RoleFingerprint: job.RoleFingerprint,
+			}); err != nil {
+				log.Printf("embed: role-cluster count for job %d: %v", job.ID, err)
+			} else {
+				repost, mass = c.RepostCount, c.MassCount
+			}
+			reality := jobview.ClassifyReality(job, time.Now(), int(repost), int(mass))
+			doc.Reality = &reality
 		}
-		reality := jobview.ClassifyReality(job, time.Now(), int(repost), int(mass))
-		doc.Reality = &reality
 		docs = append(docs, doc)
 	}
-	// IndexSemanticJobs embeds the whole batch (chunked to the backend's limit) and
-	// upserts it as ONE Meilisearch task, so a large backfill isn't per-doc bound. It
-	// returns the computed vectors so the store can persist them beside the stamp.
+	// pg-only: compute vectors only (the store persists them to Postgres); Meili is
+	// rebuilt from Postgres afterwards via `reindex --semantic --from-pg`. Otherwise embed
+	// the whole batch AND upsert it into the live semantic index as ONE Meili task.
+	if ix.pgOnly {
+		return ix.client.EmbedJobs(ctx, docs)
+	}
 	return ix.client.IndexSemanticJobs(ctx, docs)
 }
 
 func (ix searchIndexer) RemoveClosed(ctx context.Context, ids []int64) error {
+	// pg-only mode leaves Meili untouched: the closed job's stamp+vector are cleared in
+	// Postgres by CompleteClosed, and the --from-pg rebuild simply omits closed jobs.
+	if ix.pgOnly {
+		return nil
+	}
 	return ix.client.DeleteSemanticJobs(ctx, ids)
 }

--- a/cmd/embed/main.go
+++ b/cmd/embed/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
 	"github.com/strelov1/freehire/internal/config"
 	"github.com/strelov1/freehire/internal/db"
@@ -39,6 +40,11 @@ func run() int {
 		return 1
 	}
 
+	// EMBED_PG_ONLY drains the queue writing vectors to Postgres ONLY (no Meili), for a
+	// fast bulk backfill that Meili's serial task queue can't gate; rebuild the index
+	// afterwards with `reindex --semantic --from-pg`.
+	pgOnly := os.Getenv("EMBED_PG_ONLY") != ""
+
 	ecfg := config.LoadEmbed()
 	client := search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
 
@@ -46,15 +52,18 @@ func run() int {
 	// vectors. Unlike the incremental facet path (a plain index), a semantic upsert into
 	// an index that lacks the embedder settings fails every task. `reindex --semantic` is
 	// the usual creator, but this makes the worker self-sufficient on a fresh index (e.g.
-	// the embed cron firing before the first semantic reindex). Idempotent.
-	if err := client.EnsureSemanticIndex(ctx); err != nil {
+	// the embed cron firing before the first semantic reindex). Idempotent. pg-only never
+	// writes Meili, so it skips this (the only startup Meili call).
+	if pgOnly {
+		log.Print("embed: PG-ONLY mode — writing vectors to Postgres, NOT Meili")
+	} else if err := client.EnsureSemanticIndex(ctx); err != nil {
 		log.Printf("search: ensure semantic index: %v", err)
 		return 1
 	}
 
 	runner := embed.Runner{
 		Store:   newDBStore(pool),
-		Indexer: searchIndexer{client: client, q: db.New(pool)},
+		Indexer: searchIndexer{client: client, q: db.New(pool), pgOnly: pgOnly},
 	}
 
 	stats, err := runner.Run(ctx, embed.RunOptions{

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -384,11 +384,32 @@ func (c *Client) IndexSemanticJobs(ctx context.Context, docs []JobDocument) (map
 	if err := c.awaitTask(ctx, c.semantic, task.TaskUID); err != nil {
 		return nil, err
 	}
+	return vectorsByID(sdocs), nil
+}
+
+// EmbedJobs computes each document's vector WITHOUT touching Meilisearch, returning them
+// keyed by job id. It is the pg-only backfill path: the vector is persisted to Postgres
+// (the durable source of truth) and the semantic index is rebuilt from Postgres in one
+// pass afterwards (reindex --semantic --from-pg), so a fast bulk embed is never gated by
+// Meilisearch's serial task queue.
+func (c *Client) EmbedJobs(ctx context.Context, docs []JobDocument) (map[int64][]float32, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+	sdocs, err := c.embedDocs(ctx, docs)
+	if err != nil {
+		return nil, err
+	}
+	return vectorsByID(sdocs), nil
+}
+
+// vectorsByID pulls the per-job vectors out of the embedded documents.
+func vectorsByID(sdocs []semanticDocument) map[int64][]float32 {
 	vectors := make(map[int64][]float32, len(sdocs))
 	for _, sd := range sdocs {
 		vectors[sd.ID] = sd.Vectors[embedderName]
 	}
-	return vectors, nil
+	return vectors
 }
 
 func (c *Client) indexInto(ctx context.Context, idx meilisearch.IndexManager, docs []JobDocument) error {

--- a/internal/search/embed_test.go
+++ b/internal/search/embed_test.go
@@ -182,3 +182,39 @@ func TestEmbedBatchRejectsCountMismatch(t *testing.T) {
 		t.Fatal("expected an error on vector/input count mismatch, got nil")
 	}
 }
+
+// EmbedJobs must compute a vector per job id WITHOUT touching Meilisearch — the pg-only
+// backfill path. The Client here has an embedder but no Meili wiring, so any Meili call
+// would panic; returning cleanly proves the embed side stands alone.
+func TestEmbedJobsReturnsVectorPerJobWithoutMeili(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var in struct {
+			Inputs []string `json:"inputs"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		out := make([][]float64, len(in.Inputs))
+		for i := range in.Inputs {
+			out[i] = []float64{float64(i) + 0.5} // positional so id->vector mapping is checkable
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	defer srv.Close()
+	c := &Client{embedURL: srv.URL, embedConcurrency: 1}
+
+	docs := []JobDocument{{ID: 7}, {ID: 42}}
+	docs[0].Title, docs[1].Title = "A", "B"
+
+	got, err := c.EmbedJobs(context.Background(), docs)
+	if err != nil {
+		t.Fatalf("EmbedJobs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d vectors, want 2", len(got))
+	}
+	if v := got[7]; len(v) != 1 || v[0] != 0.5 {
+		t.Errorf("vector for job 7 = %v; want [0.5]", v)
+	}
+	if v := got[42]; len(v) != 1 || v[0] != 1.5 {
+		t.Errorf("vector for job 42 = %v; want [1.5]", v)
+	}
+}


### PR DESCRIPTION
## Why

A fast bulk backfill of the semantic backlog (currently ~1.44M open jobs queued in `semantic_outbox`) against a GPU embedder is bottlenecked if every wave's vectors are upserted into the **live** `jobs_semantic` index in place — Meilisearch's serial task queue becomes the ceiling and the writes compete with live search.

Now that vectors are persisted to Postgres (the source of truth, via #729), the bulk embed can skip Meili entirely: embed → Postgres only, then rebuild the index from Postgres in one pass with `reindex --semantic --from-pg`. This decouples the expensive embedding from Meili, so a faster embedder actually translates into a faster backfill.

## What

- `search.Client.EmbedJobs` — computes each job's vector **without** touching Meilisearch.
- `cmd/embed`: `EMBED_PG_ONLY=1` makes the indexer embed to Postgres only:
  - `IndexOpen` returns the vectors (persisted by `CompleteOpen`) but never writes Meili;
  - `RemoveClosed` is a no-op (closed jobs are simply omitted by the `--from-pg` rebuild);
  - the job-reality signal + its per-job cluster-count query are skipped (they are Meili-document facets);
  - startup skips `EnsureSemanticIndex` (the only Meili call).

## Playbook

1. `EMBED_PG_ONLY=1 EMBED_URL=<gpu-endpoint> EMBED_API_KEY=<token> EMBED_CONCURRENCY=24 cmd/embed` — drains the outbox into Postgres fast.
2. `reindex --semantic --from-pg` — loads all persisted vectors into `jobs_semantic` in one swap-rebuild.

## Tests

- Unit: `EmbedJobs` returns a per-job vector with no Meili wiring (would panic if it touched Meili).
- Integration (real Meili + Postgres): a pg-only run persists `semantic_embedding` and leaves `jobs_semantic` empty; the normal path still writes Meili.
- Verified on prod CPU: a pg-only run grew the Postgres vector count while `jobs_semantic` stayed byte-for-byte unchanged (Meili untouched).