### PR TITLE
refactor(sources): drop unused alignerrJob.ID field

### DIFF
--- a/internal/sources/alignerr.go
+++ b/internal/sources/alignerr.go
@@ -52,7 +52,6 @@ type alignerrListItem struct {
 // isActive gates closed postings; jobType is the structured employment enum; firstPostDate is
 // the publish date (createdAt is the fallback).
 type alignerrJob struct {
-	ID                  string `json:"id"`
 	Name                string `json:"name"`
 	HTMLLongDescription string `json:"htmlLongDescription"`
 	ShortDescription    string `json:"shortDescription"`


### PR DESCRIPTION
Simplify pass over the Alignerr adapter (#731). The posting id comes from the listing item (`it.ID`); `alignerrJob.ID` was decoded but never read — dead field, removed. No behavior change; `go test ./internal/sources/` green.