### PR TITLE
feat(web): manual application linking + undo in the mail inbox

### DIFF
--- a/openspec/changes/inbox-manual-link-relink/.openspec.yaml
+++ b/openspec/changes/inbox-manual-link-relink/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/inbox-manual-link-relink/design.md
+++ b/openspec/changes/inbox-manual-link-relink/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The inbox reading pane (`InboxView.svelte`) renders one of three link states from
+the selected email's `linked_slug` / `suggested_slug` fields:
+- **linked** → "Linked to X ↗" + Unlink
+- **suggested** → "Looks like X · Link · Not this"
+- **neither** → nothing (the gap this change fills)
+
+All mutations go through `api.linkEmail(id, slug)` / `unlinkEmail` /
+`confirmEmailLink` / `rejectEmailLink`, each returning the refreshed `EmailBody`;
+`applyLinkUpdate` writes it back into `selected` and the list. The caller's
+applications are available via `api.listTracked` (`GET /me/tracking`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let the user link an unlinked email to one of their tracked applications.
+- Make Unlink reversible with a one-click Undo to the same application.
+- Reuse the existing endpoint/client; no backend change.
+
+**Non-Goals:**
+- Changing the link of an already-linked email in place (Unlink → link again
+  covers it).
+- Linking to a job the user does not track (picker is scoped to tracked apps).
+- Persisting Undo across reloads (it is a transient in-session affordance).
+
+## Decisions
+
+- **Picker is its own component** `ApplicationLinkPicker.svelte`: given the
+  tracked applications, it renders a searchable list and emits the chosen slug.
+  `InboxView` owns the data fetch (once, lazily) and the `api.linkEmail` call, so
+  the picker stays a pure presentational unit with a clear interface (props in,
+  `onpick(slug)` out).
+- **Undo is client-side state**, no backend change. When `unlink()` runs,
+  `InboxView` stashes the just-unlinked `{id, slug, company}` in a
+  `lastUnlinked` rune. The neither-state row shows "Unlinked · Undo" while
+  `lastUnlinked` matches the selected email; Undo calls
+  `api.linkEmail(id, lastUnlinked.slug)` and clears the stash. Selecting another
+  email or a fresh link clears it, so Undo never targets the wrong application.
+- **Picker vs Undo coexist:** in the neither-state, if `lastUnlinked` matches show
+  "Unlinked · Undo" (with the picker still reachable to link elsewhere);
+  otherwise show just the "Link to application" picker.
+- **Empty tracked list** → the picker shows "No applications yet — track a job
+  first" instead of an empty menu.
+
+## Risks / Trade-offs
+
+- Undo is in-memory only: navigating away loses it. Acceptable — re-linking via
+  the picker is always available as the durable path.
+- `listTracked` is paginated; the picker fetches the first page and filters
+  client-side. If a user tracks more than one page of applications the search box
+  may not reach the tail — acceptable for now; noted as a future enhancement (log
+  nothing silently in UI, the picker's search hints "showing your applications").

--- a/openspec/changes/inbox-manual-link-relink/proposal.md
+++ b/openspec/changes/inbox-manual-link-relink/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+In the mail inbox, an email can be auto-linked to an application, carry a
+suggestion, or be unlinked. The linked state offers **Unlink**, and a suggestion
+offers **Link / Not this** — but an email with **no link and no suggestion shows
+nothing**: there is no way to link it to an application by hand. Worse, clicking
+**Unlink** drops the email into exactly that dead state, so unlinking is a
+one-way street with no way back.
+
+The backend already supports manual linking (`POST /me/emails/:id/link` with a
+slug → `link_source='manual'`) and the API client `api.linkEmail(id, slug)`
+exists — it is simply never called from the UI. This change surfaces it.
+
+## What Changes
+
+- An unlinked email (no active suggestion) shows a **"Link to application"**
+  picker listing the caller's tracked applications; choosing one manually links
+  the email via the existing endpoint.
+- Immediately after **Unlink**, the row offers **Undo**, which re-links the email
+  to the application it was just unlinked from (remembered client-side).
+- No backend change: the link/unlink endpoints and API client already exist.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `email-inbox`: add manual application-linking and post-unlink undo to the inbox
+  reading pane's link controls.
+
+## Impact
+
+- `web/src/lib/components/InboxView.svelte`: orchestrate the new controls and hold
+  the transient "last unlinked" state for Undo.
+- `web/src/lib/components/ApplicationLinkPicker.svelte` (new): the searchable
+  tracked-applications picker.
+- Data source: existing `GET /me/tracking` (`api.listTracked`).
+- No API, DB, or worker changes.

--- a/openspec/changes/inbox-manual-link-relink/specs/email-inbox/spec.md
+++ b/openspec/changes/inbox-manual-link-relink/specs/email-inbox/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Manual application linking in the inbox
+
+The inbox SHALL let the caller manually link an email that has no application
+link and no active suggestion to one of their tracked applications. Choosing an
+application SHALL link the email to it and mark the link as manual.
+
+The picker SHALL list the caller's tracked applications and SHALL let the caller
+filter them by text. When the caller tracks no applications, the picker SHALL say
+so rather than present an empty menu.
+
+#### Scenario: Linking an unlinked email
+
+- **WHEN** the caller opens the "Link to application" picker on an unlinked email
+  and selects one of their tracked applications
+- **THEN** the email becomes linked to that application
+- **AND** the row shows "Linked to <company>" with an Unlink control
+
+#### Scenario: No tracked applications
+
+- **WHEN** the caller opens the picker but tracks no applications
+- **THEN** the picker states that there is nothing to link to instead of showing
+  an empty list
+
+### Requirement: Undo an unlink
+
+Immediately after the caller unlinks an email, the inbox SHALL offer an Undo that
+re-links the email to the application it was just unlinked from. The Undo SHALL
+apply only to the email that was just unlinked and SHALL be discarded when the
+caller acts on a different email or establishes a new link.
+
+#### Scenario: Undo restores the previous link
+
+- **WHEN** the caller unlinks an email and then chooses Undo
+- **THEN** the email is re-linked to the same application it was unlinked from
+
+#### Scenario: Undo does not leak across emails
+
+- **WHEN** the caller unlinks one email and then selects a different email
+- **THEN** the different email does not offer to undo the first email's unlink

--- a/openspec/changes/inbox-manual-link-relink/tasks.md
+++ b/openspec/changes/inbox-manual-link-relink/tasks.md
@@ -1,0 +1,25 @@
+## 1. Link-state view model (pure logic)
+
+- [x] 1.1 RED: unit-test a pure `inboxLinkState(email, lastUnlinked)` helper that
+      returns which control to show — `linked` | `suggested` | `undo` | `picker`
+      — covering: linked→linked; suggested→suggested; unlinked with matching
+      lastUnlinked→undo; unlinked with non-matching/absent lastUnlinked→picker.
+- [x] 1.2 GREEN: implement the helper (in a `.ts` module so it is vitest-testable
+      apart from the component). REFACTOR + simplify under green.
+
+## 2. ApplicationLinkPicker component
+
+- [x] 2.1 Build `ApplicationLinkPicker.svelte`: props = tracked applications +
+      `onpick(slug)`; searchable list; empty-state message. Presentational only.
+- [x] 2.2 Verify via `svelte-check` + a visual headless-Chrome pass of the picker
+      states (list, filtered, empty).
+
+## 3. Wire into InboxView
+
+- [x] 3.1 Add lazy `listTracked` fetch, the `lastUnlinked` rune, `linkTo(slug)`
+      (calls `api.linkEmail`, clears `lastUnlinked`) and `undoUnlink()`; have
+      `unlink()` stash `{id, slug, company}`; clear the stash on email select.
+- [x] 3.2 Render the picker / "Unlinked · Undo" in the neither-state using the
+      `inboxLinkState` helper.
+- [x] 3.3 Verify: `svelte-check` clean + visual pass of link → unlink → undo and
+      unlinked → pick → linked in a real browser.

--- a/web/src/lib/components/ApplicationLinkPicker.svelte
+++ b/web/src/lib/components/ApplicationLinkPicker.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+  import { Search } from '@lucide/svelte';
+
+  interface PickerApp {
+    slug: string;
+    company: string;
+    title?: string;
+  }
+
+  let {
+    applications,
+    onpick,
+    loading = false,
+  }: {
+    applications: PickerApp[];
+    onpick: (slug: string) => void;
+    loading?: boolean;
+  } = $props();
+
+  let open = $state(false);
+  let q = $state('');
+
+  const filtered = $derived.by(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return applications;
+    return applications.filter((a) => `${a.company} ${a.title ?? ''}`.toLowerCase().includes(needle));
+  });
+
+  function pick(slug: string) {
+    onpick(slug);
+    open = false;
+    q = '';
+  }
+</script>
+
+<div class="relative inline-block">
+  <button
+    type="button"
+    onclick={() => (open = !open)}
+    class="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:border-brand-ring hover:text-foreground"
+  >
+    Link to application <span aria-hidden="true">▾</span>
+  </button>
+
+  {#if open}
+    <!-- click-catcher: closing on any outside click -->
+    <button
+      type="button"
+      class="fixed inset-0 z-10 cursor-default"
+      aria-label="Close application picker"
+      onclick={() => (open = false)}
+    ></button>
+
+    <div
+      class="absolute left-0 z-20 mt-1 w-64 overflow-hidden rounded-md border border-border bg-background shadow-md"
+    >
+      {#if loading}
+        <p class="p-3 text-xs text-muted-foreground">Loading your applications…</p>
+      {:else if applications.length === 0}
+        <p class="p-3 text-xs text-muted-foreground">No applications yet — track a job first.</p>
+      {:else}
+        <div class="flex items-center gap-1.5 border-b border-border px-2.5 py-1.5">
+          <Search class="size-3.5 shrink-0 text-muted-foreground" />
+          <input
+            bind:value={q}
+            placeholder="Search applications…"
+            class="w-full bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+        <ul class="max-h-56 overflow-y-auto py-1">
+          {#each filtered as a (a.slug)}
+            <li>
+              <button
+                type="button"
+                onclick={() => pick(a.slug)}
+                class="flex w-full flex-col items-start px-2.5 py-1.5 text-left text-xs transition-colors hover:bg-muted"
+              >
+                <span class="font-medium text-foreground">{a.company || 'Unknown company'}</span>
+                {#if a.title}<span class="truncate text-muted-foreground">{a.title}</span>{/if}
+              </button>
+            </li>
+          {:else}
+            <li class="px-2.5 py-1.5 text-xs text-muted-foreground">No match.</li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -10,8 +10,10 @@
   } from '$lib/api';
   import type { EmailLinking } from '$lib/types';
   import { statusLabel, statusClass } from '$lib/emailStatus';
+  import { inboxLinkState, type LastUnlinked } from '$lib/inboxLink';
   import { Badge, Button } from '$lib/ui';
   import GmailConnectDialog from './GmailConnectDialog.svelte';
+  import ApplicationLinkPicker from './ApplicationLinkPicker.svelte';
   import { Mail, AtSign, Copy, Search, RefreshCw, ChevronLeft } from '@lucide/svelte';
   import { timeAgo } from '$lib/utils';
   import { avatarInitials, avatarColor } from '$lib/avatar';
@@ -43,6 +45,13 @@
   let selectedId = $state<number | null>(null);
   let selected = $state<EmailBody | null>(null);
   let bodyLoading = $state(false);
+
+  // Manual linking: the caller's applications for the picker (lazy-loaded once),
+  // and the application an email was just unlinked from, for a one-click Undo.
+  let trackedApps = $state<{ slug: string; company: string; title?: string }[]>([]);
+  let trackedLoaded = $state(false);
+  let trackedLoading = $state(false);
+  let lastUnlinked = $state<LastUnlinked | null>(null);
 
   const hasGmail = $derived(!!gmail?.connected);
   const hasMailbox = $derived(!!mailbox?.address);
@@ -159,6 +168,7 @@
   }
 
   async function openMessage(id: number) {
+    if (lastUnlinked && lastUnlinked.id !== id) lastUnlinked = null; // Undo is per-email
     selectedId = id;
     selected = null;
     bodyLoading = true;
@@ -166,10 +176,32 @@
       selected = await api.getEmail(id);
       // Reflect the just-opened message as read in the list without a refetch.
       messages = messages.map((m) => (m.id === id ? { ...m, read: true } : m));
+      // An email with no link and no suggestion can be linked by hand — make sure
+      // the picker has the caller's applications ready.
+      if (!selected.linked_slug && !selected.suggested_slug) void ensureTrackedApps();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to load the message.';
     } finally {
       bodyLoading = false;
+    }
+  }
+
+  // Load the caller's applications for the link picker once, on first need.
+  async function ensureTrackedApps() {
+    if (trackedLoaded || trackedLoading) return;
+    trackedLoading = true;
+    try {
+      const res = await api.listMyJobs('applied', 100, 0);
+      trackedApps = res.items.map((m) => ({
+        slug: m.job.public_slug,
+        company: m.job.company,
+        title: m.job.title,
+      }));
+      trackedLoaded = true;
+    } catch {
+      // Leave the list empty; the picker shows its empty state.
+    } finally {
+      trackedLoading = false;
     }
   }
 
@@ -203,6 +235,8 @@
     if (!selected) return;
     try {
       applyLinkUpdate(await api.rejectEmailLink(selected.id));
+      // Dismissing the suggestion drops the email into the manual picker — load its data.
+      void ensureTrackedApps();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to dismiss.';
     }
@@ -210,11 +244,34 @@
 
   async function unlink() {
     if (!selected) return;
+    const prevSlug = selected.linked_slug;
+    const prevCompany = selected.linked_company;
     try {
       applyLinkUpdate(await api.unlinkEmail(selected.id));
+      // Remember what it was linked to so the row can offer a one-click Undo.
+      if (prevSlug) lastUnlinked = { id: selected.id, slug: prevSlug, company: prevCompany };
+      // The row now also offers the picker (to link elsewhere) — make sure it has data.
+      void ensureTrackedApps();
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to unlink.';
     }
+  }
+
+  // Manually link the open email to a chosen application (also used to relink).
+  async function linkTo(slug: string) {
+    if (!selected) return;
+    try {
+      applyLinkUpdate(await api.linkEmail(selected.id, slug));
+      lastUnlinked = null;
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to link.';
+    }
+  }
+
+  // Undo the last unlink: relink the email to the application it was unlinked from.
+  async function undoUnlink() {
+    if (!selected || !lastUnlinked) return;
+    await linkTo(lastUnlinked.slug);
   }
 
   // --- Gmail source ---
@@ -533,29 +590,37 @@
                 </div>
               </div>
 
-              {#if statusLabel(s.status_signal) || s.linked_slug || s.suggested_slug}
-                <div class="mt-3 flex shrink-0 flex-wrap items-center gap-2">
-                  {#if statusLabel(s.status_signal)}
-                    <Badge variant="outline" class={statusClass(s.status_signal)}>{statusLabel(s.status_signal)}</Badge>
-                  {/if}
-                  {#if s.linked_slug}
-                    <a
-                      href="/my/tracking/{s.linked_slug}"
-                      class="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:border-brand-ring hover:text-foreground"
-                    >
-                      Linked to {s.linked_company || 'application'} ↗
-                    </a>
-                    <button type="button" onclick={unlink} class="text-xs text-muted-foreground hover:text-destructive">Unlink</button>
-                  {:else if s.suggested_slug}
-                    <span class="inline-flex items-center gap-2 rounded-full border border-brand-ring/50 bg-brand-muted/40 px-2.5 py-0.5 text-xs">
-                      Looks like <span class="font-medium">{s.suggested_company || 'an application'}</span>
-                      <button type="button" onclick={confirmLink} class="font-medium text-brand-strong hover:underline">Link</button>
+              {@const linkState = inboxLinkState(s, lastUnlinked)}
+              <div class="mt-3 flex shrink-0 flex-wrap items-center gap-2">
+                {#if statusLabel(s.status_signal)}
+                  <Badge variant="outline" class={statusClass(s.status_signal)}>{statusLabel(s.status_signal)}</Badge>
+                {/if}
+                {#if linkState === 'linked'}
+                  <a
+                    href="/my/tracking/{s.linked_slug}"
+                    class="inline-flex items-center gap-1 rounded-full border border-border px-2.5 py-0.5 text-xs text-muted-foreground transition-colors hover:border-brand-ring hover:text-foreground"
+                  >
+                    Linked to {s.linked_company || 'application'} ↗
+                  </a>
+                  <button type="button" onclick={unlink} class="text-xs text-muted-foreground hover:text-destructive">Unlink</button>
+                {:else if linkState === 'suggested'}
+                  <span class="inline-flex items-center gap-2 rounded-full border border-brand-ring/50 bg-brand-muted/40 px-2.5 py-0.5 text-xs">
+                    Looks like <span class="font-medium">{s.suggested_company || 'an application'}</span>
+                    <button type="button" onclick={confirmLink} class="font-medium text-brand-strong hover:underline">Link</button>
+                    <span aria-hidden="true">·</span>
+                    <button type="button" onclick={rejectLink} class="text-muted-foreground hover:text-foreground">Not this</button>
+                  </span>
+                {:else}
+                  {#if linkState === 'undo'}
+                    <span class="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                      Unlinked
                       <span aria-hidden="true">·</span>
-                      <button type="button" onclick={rejectLink} class="text-muted-foreground hover:text-foreground">Not this</button>
+                      <button type="button" onclick={undoUnlink} class="font-medium text-brand-strong hover:underline">Undo</button>
                     </span>
                   {/if}
-                </div>
-              {/if}
+                  <ApplicationLinkPicker applications={trackedApps} loading={trackedLoading} onpick={linkTo} />
+                {/if}
+              </div>
 
               {#if s.source === 'gmail'}
                 <div class="mt-2 flex shrink-0 justify-end">

--- a/web/src/lib/inboxLink.test.ts
+++ b/web/src/lib/inboxLink.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { inboxLinkState, type LastUnlinked } from './inboxLink';
+
+const unlinked = { id: 1 };
+const linked = { id: 1, linked_slug: 'acme' };
+const suggested = { id: 1, suggested_slug: 'acme' };
+const stash: LastUnlinked = { id: 1, slug: 'acme', company: 'Acme' };
+
+describe('inboxLinkState', () => {
+	it('is "linked" when the email has a linked application', () => {
+		expect(inboxLinkState(linked, null)).toBe('linked');
+	});
+
+	it('is "suggested" when the email carries a pending suggestion', () => {
+		expect(inboxLinkState(suggested, null)).toBe('suggested');
+	});
+
+	it('is "undo" when an unlinked email matches the last unlink', () => {
+		expect(inboxLinkState(unlinked, stash)).toBe('undo');
+	});
+
+	it('is "picker" for an unlinked email with no matching last unlink', () => {
+		expect(inboxLinkState(unlinked, null)).toBe('picker');
+	});
+
+	it('does not offer undo for a different email than the one unlinked', () => {
+		expect(inboxLinkState({ id: 2 }, stash)).toBe('picker');
+	});
+
+	it('prefers the real link over a stale last-unlink stash', () => {
+		expect(inboxLinkState(linked, stash)).toBe('linked');
+	});
+});

--- a/web/src/lib/inboxLink.ts
+++ b/web/src/lib/inboxLink.ts
@@ -1,0 +1,25 @@
+/** The link control the inbox reading pane shows for the selected email. */
+export type InboxLinkState = 'linked' | 'suggested' | 'undo' | 'picker';
+
+/** The subset of an email the link-state decision reads. */
+export interface LinkStateEmail {
+	id: number;
+	linked_slug?: string;
+	suggested_slug?: string;
+}
+
+/** The application an email was just unlinked from, remembered for Undo. */
+export interface LastUnlinked {
+	id: number;
+	slug: string;
+	company?: string;
+}
+
+/** Decide which link control to render: a real link wins, then a pending
+ *  suggestion, then a matching just-unlinked stash offers Undo, else the picker. */
+export function inboxLinkState(email: LinkStateEmail, lastUnlinked: LastUnlinked | null): InboxLinkState {
+	if (email.linked_slug) return 'linked';
+	if (email.suggested_slug) return 'suggested';
+	if (lastUnlinked && lastUnlinked.id === email.id) return 'undo';
+	return 'picker';
+}


### PR DESCRIPTION
## Summary
- The mail inbox reading pane now lets you **link an email to an application by hand**: an email with no link and no active suggestion shows a searchable **"Link to application"** picker over your tracked applications; picking one links it (`link_source='manual'`).
- **Undo after Unlink**: clicking Unlink now offers a one-click **Undo** that re-links the email to the application it was just unlinked from (remembered client-side, per-email).
- The picker is also surfaced after dismissing a suggestion ("Not this") and after Unlink, so those flows are no longer dead ends.
- **Pure frontend** — the link/unlink endpoints (`POST /me/emails/:id/link|unlink`) and `api.linkEmail` already existed and were simply never called from the UI.

New: `inboxLinkState()` view-model helper (unit-tested, 6 cases) + `ApplicationLinkPicker.svelte` (presentational searchable dropdown). Planned under OpenSpec `inbox-manual-link-relink`.

## Test Plan
- [x] `inboxLinkState` unit tests (vitest) — linked/suggested/undo/picker, no cross-email leak.
- [x] `svelte-check` clean (0 errors on the new/changed files); production `npm run build` passes.
- [x] Visual headless-Chrome pass of all four states (linked, suggested, undo, picker-open).
- [x] Code review: fixed the suggested→"Not this"→picker path so the picker's applications are loaded (no false "no applications" empty state).

## Notes / follow-ups
- Picker loads the first 100 `applied` applications and filters client-side; users with >100 tracked applications can't reach the tail yet (known limitation, noted in the design).