### PR TITLE
feat(sources): Job Market Finland (tyomarkkinatori.fi) adapter

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -277,6 +277,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJobtech(c),
 		NewJobnet(c),
 		NewJobdanmark(c),
+		NewTyomarkkinatori(c),
 		// International single-company adapters (boardless).
 		NewTelegramCareers(c),
 		NewUber(c),

--- a/internal/sources/tyomarkkinatori.go
+++ b/internal/sources/tyomarkkinatori.go
@@ -1,0 +1,373 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"log"
+	"strings"
+)
+
+// tyomarkkinatori adapts Job Market Finland (tyomarkkinatori.fi), the Finnish national job
+// portal run by KEHA-keskus (the successor to the retired te-palvelut). Like the other national
+// feeds (jobdanmark/jobnet/jobtech) it is boardless (one public API, no per-tenant board) and an
+// aggregator (every posting carries its own employer), and it covers every sector — the
+// downstream dictionaries and the enrich non-tech gate decide relevance, not the adapter.
+//
+// The catalogue is served by a same-origin JSON API behind a rewriting gateway, discovered by
+// capturing the search SPA's own XHR:
+//   - list:   POST /api/jobpostingfulltext/search/v2/search — an empty query returns the whole
+//     catalogue freshest-first, but the list item omits the posting body.
+//   - detail: GET /api/jobposting-new/v1/public/jobpostings/{id} — the body (plain or markdown),
+//     the authoritative employer name, and the publish date.
+//
+// The search is a thin Elasticsearch proxy: it hard-caps deep paging at (pageNumber*pageSize)+
+// pageSize ≤ 10000 (the max_result_window), and the whole portal (~10.7k open postings) exceeds
+// that. So the crawl SHARDS by region — every region's slice is well under the window and pages
+// fully — and dedups the ids a multi-region posting returns in several shards. Region assignment
+// is stable across runs, so a posting we ingest via a region shard stays reachable via the same
+// shard, which is what keeps the post-run unseen sweep from false-closing the tail (unlike a
+// single freshest-10k sweep, whose oldest open postings would age out of view and be closed).
+// Region-less postings (rare, fully foreign with no Finnish municipality) simply never enter the
+// catalogue — a coverage gap, not a false-close.
+//
+// Detail is the expensive fan-out (one request per posting over ~10k postings), so the adapter is
+// a HydratingSource: FetchNew fetches a posting's detail only when the catalogue does not already
+// have it, refreshing a seen posting's liveness without a detail request (see justjoin).
+type tyomarkkinatori struct {
+	http tmtClient
+}
+
+// tmtClient is the transport role this adapter needs: a POST search plus a GET JSON detail.
+type tmtClient interface {
+	JSONPoster
+	JSONGetter
+}
+
+const (
+	tmtSearchURL = "https://tyomarkkinatori.fi/api/jobpostingfulltext/search/v2/search"
+	tmtDetailURL = "https://tyomarkkinatori.fi/api/jobposting-new/v1/public/jobpostings/%s"
+	// tmtPublicURL is the human-facing posting page (the API urls are not browsable). The trailing
+	// segment is the display language, chosen to match the description we picked.
+	tmtPublicURL = "https://tyomarkkinatori.fi/henkiloasiakkaat/avoimet-tyopaikat/%s/%s"
+	// tmtPageSize is the API's per-page maximum; tmtMaxPage is its pageNumber ceiling. Their
+	// product stays under the 10000-item deep-paging window, and every region shard is smaller
+	// still, so a shard always pages to exhaustion before either bound bites.
+	tmtPageSize = 90
+	tmtMaxPage  = 100
+)
+
+// tmtRegions is the fixed set of Finnish region (maakunta) codes the search filters on — the 18
+// mainland regions plus Åland (21). The two historically-vacant codes (03, 20) are omitted; a
+// live-but-empty region would merely return no postings, so the list is a convenience, not a
+// correctness dependency. A posting is matched into a region via its municipality, so the shards
+// collectively over-cover the catalogue (a multi-region posting appears in several), which the
+// id-dedup in listAll collapses.
+var tmtRegions = []string{
+	"01", "02", "04", "05", "06", "07", "08", "09", "10",
+	"11", "12", "13", "14", "15", "16", "17", "18", "19", "21",
+}
+
+// NewTyomarkkinatori builds the Job Market Finland adapter over the given POST+GET JSON client.
+func NewTyomarkkinatori(c tmtClient) Source { return tyomarkkinatori{http: c} }
+
+func (tyomarkkinatori) Provider() string { return "tyomarkkinatori" }
+
+// tyomarkkinatori is a national portal with one global feed, so its config entry carries no board.
+func (tyomarkkinatori) boardless() {}
+
+// tyomarkkinatori aggregates postings from many employers, so it stays in the source facet.
+func (tyomarkkinatori) aggregator() {}
+
+// tmtLang is a Finnish public-sector multilingual value: a map of ISO-639-1 code → text, present
+// for whichever languages the employer filled in ("fi", "sv", "en", commonly just one).
+type tmtLang map[string]string
+
+// tmtLangOrder is the preference order pick/lang walk: English first (this is an English-facing
+// aggregator), then Finnish, then Swedish (Finland's second official language).
+var tmtLangOrder = []string{"en", "fi", "sv"}
+
+// pick returns the best-available text: the first non-empty value in tmtLangOrder, then any other
+// language present, else "".
+func (m tmtLang) pick() string {
+	for _, k := range tmtLangOrder {
+		if v := strings.TrimSpace(m[k]); v != "" {
+			return v
+		}
+	}
+	for _, v := range m {
+		if v := strings.TrimSpace(v); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// lang returns the language code pick would draw from, so the public URL's language segment
+// matches the text shown. It defaults to "fi" for an empty value (the portal's primary language).
+func (m tmtLang) lang() string {
+	for _, k := range tmtLangOrder {
+		if strings.TrimSpace(m[k]) != "" {
+			return k
+		}
+	}
+	for k, v := range m {
+		if strings.TrimSpace(v) != "" {
+			return k
+		}
+	}
+	return "fi"
+}
+
+// tmtSearchBody is the POST search request. An empty query with a single-region filter returns
+// that region's whole slice freshest-first (sorting LATEST).
+type tmtSearchBody struct {
+	Query   string     `json:"query"`
+	Filters tmtFilters `json:"filters"`
+	Paging  tmtPaging  `json:"paging"`
+	Sorting string     `json:"sorting"`
+}
+
+type tmtFilters struct {
+	Regions []string `json:"regions"`
+}
+
+type tmtPaging struct {
+	PageNumber int `json:"pageNumber"`
+	PageSize   int `json:"pageSize"`
+}
+
+// tmtSearchResponse is one search page: content is the postings, lastPage bounds pagination.
+type tmtSearchResponse struct {
+	Content  []tmtListItem `json:"content"`
+	LastPage int           `json:"lastPage"`
+}
+
+// tmtListItem is one list posting. It carries the id, a multilingual title, the employer, the
+// location (the only place municipality labels appear — the detail exposes only their codes), and
+// the publish date. The body is not in the list; it comes from the detail.
+type tmtListItem struct {
+	ID       string  `json:"id"`
+	Title    tmtLang `json:"title"`
+	Employer struct {
+		OwnerName       tmtLang `json:"ownerName"`
+		OwnerOfficeName string  `json:"ownerOfficeName"`
+	} `json:"employer"`
+	Location    tmtListLocation `json:"location"`
+	PublishDate string          `json:"publishDate"`
+}
+
+// tmtListLocation holds the geographic fields the list exposes: municipalities carry their own
+// labels (unlike the detail, which has only codes), so the free-text location is built from here.
+type tmtListLocation struct {
+	ForeignCountry bool `json:"foreignCountry"`
+	Municipalities []struct {
+		Label tmtLang `json:"label"`
+	} `json:"municipalities"`
+}
+
+// text builds the free-text location from the municipality labels, appending "Finland" for a
+// domestic posting so the geo dictionary resolves the country (a foreign posting keeps only its
+// municipality text, which carries its own country).
+func (l tmtListLocation) text() string {
+	parts := make([]string, 0, len(l.Municipalities)+1)
+	for _, m := range l.Municipalities {
+		if s := m.Label.pick(); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if !l.ForeignCountry {
+		parts = append(parts, "Finland")
+	}
+	return joinNonEmpty(parts...)
+}
+
+// Fetch is the full-hydration crawl (each posting completed with its detail), the fallback for
+// callers that do not drive incremental hydration. FetchNew is the hydrating path used by ingest.
+func (s tyomarkkinatori) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	items, err := s.listAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(items, defaultDetailWorkers, func(it tmtListItem) (Job, bool) {
+		return s.hydrate(ctx, it, nil)
+	}), nil
+}
+
+// FetchNew is the hydrating crawl: it lists every region shard, but fetches a posting's detail
+// (the body the list omits) only for a posting the catalogue does not already have — seen reports
+// whether an id is already ingested. A seen posting yields the list-only job flagged SeenRefresh
+// (liveness refresh, no detail request, content preserved); an unseen posting is hydrated with
+// its detail; a single detail failure is isolated (logged, falling back to list-only).
+func (s tyomarkkinatori) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	items, err := s.listAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(items, defaultDetailWorkers, func(it tmtListItem) (Job, bool) {
+		return s.hydrate(ctx, it, seen)
+	}), nil
+}
+
+// hydrate maps one list item to a Job. When seen reports the posting already ingested, it returns
+// the list-only job flagged SeenRefresh (no detail request); otherwise it fetches the detail and
+// applies its body/employer/date, falling back to the list-only job if the detail request fails.
+// A nil seen forces full hydration (the Fetch path).
+func (s tyomarkkinatori) hydrate(ctx context.Context, it tmtListItem, seen func(string) bool) (Job, bool) {
+	base, ok := it.toJob()
+	if !ok {
+		return Job{}, false
+	}
+	if seen != nil && seen(it.ID) {
+		// Already ingested: refresh liveness only. Re-upserting content would wipe the
+		// description/facets hydrated when the posting was new (an empty body re-derives to
+		// empty facets). base carries just the identity fields.
+		base.SeenRefresh = true
+		return base, true
+	}
+	d, ok := s.detail(ctx, it.ID)
+	if !ok {
+		log.Printf("tyomarkkinatori: detail %q failed; ingesting list-only", it.ID)
+		return base, true
+	}
+	return d.apply(base), true
+}
+
+// listAll pages every region shard and returns the deduplicated list items. A multi-region
+// posting is kept once (first shard wins). A first-shard failure aborts the crawl (the API is
+// down); a later shard failing ends enumeration with what was gathered, so one region's outage
+// does not lose the rest.
+func (s tyomarkkinatori) listAll(ctx context.Context) ([]tmtListItem, error) {
+	var items []tmtListItem
+	seen := make(map[string]bool)
+	for i, region := range tmtRegions {
+		shard, err := s.listRegion(ctx, region)
+		if err != nil {
+			if i == 0 {
+				return nil, err
+			}
+			break
+		}
+		for _, it := range shard {
+			if it.ID == "" || seen[it.ID] {
+				continue
+			}
+			seen[it.ID] = true
+			items = append(items, it)
+		}
+	}
+	return items, nil
+}
+
+// listRegion pages one region's slice freshest-first, stopping on an empty page or the last page.
+// Every region is smaller than the deep-paging window, so the loop always terminates on content
+// rather than the tmtMaxPage backstop.
+func (s tyomarkkinatori) listRegion(ctx context.Context, region string) ([]tmtListItem, error) {
+	var items []tmtListItem
+	for page := 0; page <= tmtMaxPage; page++ {
+		body := tmtSearchBody{
+			Filters: tmtFilters{Regions: []string{region}},
+			Paging:  tmtPaging{PageNumber: page, PageSize: tmtPageSize},
+			Sorting: "LATEST",
+		}
+		var resp tmtSearchResponse
+		if err := s.http.PostJSON(ctx, tmtSearchURL, body, &resp); err != nil {
+			return nil, fmt.Errorf("tyomarkkinatori: search region %s page %d: %w", region, page, err)
+		}
+		if len(resp.Content) == 0 {
+			break
+		}
+		items = append(items, resp.Content...)
+		if page >= resp.LastPage {
+			break
+		}
+	}
+	return items, nil
+}
+
+// toJob maps a list item to the list-only Job (no body): the identity, title, employer, location,
+// and publish date. It returns ok=false for an item with no id (would collide on the dedup key),
+// no title, or no employer (which would break the company slug). The URL is the public posting
+// page in the title's language.
+func (it tmtListItem) toJob() (Job, bool) {
+	title := it.Title.pick()
+	company := firstNonEmpty(it.Employer.OwnerName.pick(), strings.TrimSpace(it.Employer.OwnerOfficeName))
+	if it.ID == "" || title == "" || company == "" {
+		return Job{}, false
+	}
+	location := it.Location.text()
+	return Job{
+		ExternalID: it.ID,
+		URL:        fmt.Sprintf(tmtPublicURL, it.ID, it.Title.lang()),
+		Title:      title,
+		Company:    company,
+		Location:   location,
+		Remote:     isRemote(location),
+		PostedAt:   parseRFC3339(it.PublishDate),
+	}, true
+}
+
+// tmtDetail is the per-posting detail payload (GET public/jobpostings/{id}). It carries the body
+// (plain or markdown, flagged by descriptionsContentType), the authoritative employer name
+// (owner.company, present even when the list hides it), and the publish date.
+type tmtDetail struct {
+	DescriptionsContentType string `json:"descriptionsContentType"`
+	Position                struct {
+		Title          tmtLang `json:"title"`
+		JobDescription tmtLang `json:"jobDescription"`
+	} `json:"position"`
+	Owner struct {
+		Company tmtLang `json:"company"`
+	} `json:"owner"`
+	Application struct {
+		Published string `json:"published"`
+	} `json:"application"`
+}
+
+// detail fetches a posting's detail, returning ok=false on a failed request so the caller falls
+// back to the list-only job — a posting is never dropped over a missing detail.
+func (s tyomarkkinatori) detail(ctx context.Context, id string) (tmtDetail, bool) {
+	var d tmtDetail
+	if err := s.http.GetJSON(ctx, fmt.Sprintf(tmtDetailURL, id), &d); err != nil {
+		return tmtDetail{}, false
+	}
+	return d, true
+}
+
+// apply enriches a list-derived job with the detail payload: the rendered body becomes the
+// description, and the detail's authoritative title/employer/publish date win over the list's
+// (each only when present, so a sparse detail never blanks a good list value).
+func (d tmtDetail) apply(base Job) Job {
+	base.Description = tmtDescription(d.DescriptionsContentType, d.Position.JobDescription.pick())
+	if t := d.Position.Title.pick(); t != "" {
+		base.Title = t
+	}
+	if c := d.Owner.Company.pick(); c != "" {
+		base.Company = c
+	}
+	if p := parseRFC3339(d.Application.Published); p != nil {
+		base.PostedAt = p
+	}
+	return base
+}
+
+// tmtDescription renders a posting's description body into the sanitized HTML the catalogue
+// stores. The body arrives as either plain text or CommonMark markdown, flagged by the detail's
+// descriptionsContentType ("plain" or "markdown"):
+//   - markdown is rendered (markdownToHTML), so "**bold**" and lists become real tags.
+//   - plain text is escaped (it is literal, not HTML) with its newlines turned into <br> — the
+//     postings lay out fields line by line ("Location: …\nWork mode: …"), and feeding plain text
+//     through the CommonMark renderer would collapse those single newlines into spaces (soft
+//     breaks) and merge the lines.
+//
+// An empty body yields "". The result is always sanitized.
+func tmtDescription(contentType, body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	if strings.EqualFold(contentType, "markdown") {
+		return sanitizeHTML(markdownToHTML(body))
+	}
+	return sanitizeHTML("<p>" + strings.ReplaceAll(html.EscapeString(body), "\n", "<br>") + "</p>")
+}

--- a/internal/sources/tyomarkkinatori_test.go
+++ b/internal/sources/tyomarkkinatori_test.go
@@ -1,0 +1,236 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// tmtFake is a bespoke test client for the Job Market Finland adapter. The search URL is constant
+// (region and page live in the POST body), so it decodes the body to serve the right region's
+// page, and it serves details by the id in the GET URL. Unset regions/ids return an empty page /
+// a not-found error, exercising the shard-dedup and detail-fallback paths.
+type tmtFake struct {
+	// regions maps a region code to its postings (a single page; page>0 returns empty).
+	regions map[string][]tmtListItem
+	// details maps a posting id to its detail JSON; a missing id fails the GET.
+	details map[string]string
+}
+
+func (f *tmtFake) PostJSON(_ context.Context, _ string, body, v any) error {
+	raw, _ := json.Marshal(body)
+	var req tmtSearchBody
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return err
+	}
+	resp := tmtSearchResponse{LastPage: 0}
+	if req.Paging.PageNumber == 0 && len(req.Filters.Regions) == 1 {
+		resp.Content = f.regions[req.Filters.Regions[0]]
+	}
+	out, _ := json.Marshal(resp)
+	return json.Unmarshal(out, v)
+}
+
+func (f *tmtFake) GetJSON(_ context.Context, url string, v any) error {
+	id := url[strings.LastIndex(url, "/")+1:]
+	body, ok := f.details[id]
+	if !ok {
+		return fmt.Errorf("tmtFake: no detail for %s", id)
+	}
+	return json.Unmarshal([]byte(body), v)
+}
+
+func listItem(id, region, titleFI, company string) tmtListItem {
+	it := tmtListItem{ID: id, PublishDate: "2026-07-15T17:55:01.597Z"}
+	it.Title = tmtLang{"fi": titleFI}
+	it.Employer.OwnerName = tmtLang{"fi": company}
+	it.Location.Municipalities = []struct {
+		Label tmtLang `json:"label"`
+	}{{Label: tmtLang{"fi": "Helsinki", "en": "Helsinki"}}}
+	_ = region
+	return it
+}
+
+func detailJSON(titleEN, company, contentType, body string) string {
+	return fmt.Sprintf(`{
+		"descriptionsContentType": %q,
+		"position": {"title": {"en": %q}, "jobDescription": {"en": %q}},
+		"owner": {"company": {"en": %q}},
+		"application": {"published": "2026-07-10T09:00:00Z"}
+	}`, contentType, titleEN, body, company)
+}
+
+func TestTyomarkkinatoriProvider(t *testing.T) {
+	if got := NewTyomarkkinatori(nil).Provider(); got != "tyomarkkinatori" {
+		t.Errorf("Provider() = %q, want %q", got, "tyomarkkinatori")
+	}
+}
+
+func TestTyomarkkinatoriBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/tyomarkkinatori.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig(sources/tyomarkkinatori.yml): %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/tyomarkkinatori.yml fails registry validation: %v", err)
+	}
+}
+
+func TestTyomarkkinatoriIsBoardlessAggregator(t *testing.T) {
+	s := NewTyomarkkinatori(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("tyomarkkinatori must be boardless (no per-tenant board id)")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("tyomarkkinatori must be an aggregator (stays in the source facet)")
+	}
+	if _, ok := s.(HydratingSource); !ok {
+		t.Error("tyomarkkinatori must be a HydratingSource (detail only for new postings)")
+	}
+}
+
+func TestTyomarkkinatoriRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["tyomarkkinatori"]
+	if !ok {
+		t.Fatal("All() missing provider tyomarkkinatori")
+	}
+	if s.Provider() != "tyomarkkinatori" {
+		t.Errorf("Provider() = %q", s.Provider())
+	}
+	// Multi-company aggregator: filtering by it is meaningful, so it stays in the source facet.
+	if !slices.Contains(FilterableProviders(), "tyomarkkinatori") {
+		t.Error("FilterableProviders() should include the aggregator tyomarkkinatori")
+	}
+}
+
+func TestTyomarkkinatoriLangPick(t *testing.T) {
+	if got := (tmtLang{"fi": "Kokki", "en": "Cook"}).pick(); got != "Cook" {
+		t.Errorf("pick() = %q, want English preferred", got)
+	}
+	if got := (tmtLang{"sv": "Kock", "fi": "Kokki"}).pick(); got != "Kokki" {
+		t.Errorf("pick() = %q, want Finnish over Swedish", got)
+	}
+	if got := (tmtLang{}).pick(); got != "" {
+		t.Errorf("pick() = %q, want empty", got)
+	}
+	if got := (tmtLang{"fi": "x"}).lang(); got != "fi" {
+		t.Errorf("lang() = %q, want fi", got)
+	}
+	if got := (tmtLang{"en": "x", "fi": "y"}).lang(); got != "en" {
+		t.Errorf("lang() = %q, want en", got)
+	}
+}
+
+// TestTyomarkkinatoriFetchShardsAndMaps verifies the region-shard crawl: a posting returned by two
+// region shards is kept once, and its fields come from the list plus the detail (detail title,
+// employer, and published date win).
+func TestTyomarkkinatoriFetchShardsAndMaps(t *testing.T) {
+	shared := listItem("a1", "01", "Ohjelmistokehittäjä", "Bambu Food Oy")
+	fake := &tmtFake{
+		regions: map[string][]tmtListItem{
+			"01": {shared, listItem("a2", "01", "Kokki", "Ravintola Oy")},
+			"06": {shared}, // same posting surfaces in a second region — must dedup
+		},
+		details: map[string]string{
+			"a1": detailJSON("Software Developer", "Hyperion Robotics", "plain", "Build things."),
+			"a2": detailJSON("Cook", "Ravintola Oy", "plain", "Cook things."),
+		},
+	}
+
+	jobs, err := NewTyomarkkinatori(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (deduped across shards)", len(jobs))
+	}
+	a1, ok := jobByID(jobs, "a1")
+	if !ok {
+		t.Fatal("posting a1 missing")
+	}
+	if a1.Title != "Software Developer" {
+		t.Errorf("Title = %q, want detail title", a1.Title)
+	}
+	if a1.Company != "Hyperion Robotics" {
+		t.Errorf("Company = %q, want detail owner.company", a1.Company)
+	}
+	if a1.URL != "https://tyomarkkinatori.fi/henkiloasiakkaat/avoimet-tyopaikat/a1/fi" {
+		t.Errorf("URL = %q", a1.URL)
+	}
+	if a1.Location != "Helsinki, Finland" {
+		t.Errorf("Location = %q, want municipality + Finland", a1.Location)
+	}
+	if a1.PostedAt == nil || !a1.PostedAt.Equal(time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want detail published 2026-07-10T09:00:00Z", a1.PostedAt)
+	}
+}
+
+// TestTyomarkkinatoriFetchNewHydratesOnlyNew verifies the HydratingSource contract: a seen posting
+// is refreshed (SeenRefresh, no detail request, empty description), an unseen one is hydrated.
+func TestTyomarkkinatoriFetchNewHydratesOnlyNew(t *testing.T) {
+	fake := &tmtFake{
+		regions: map[string][]tmtListItem{
+			"01": {listItem("old", "01", "Vanha", "Acme Oy"), listItem("new", "01", "Uusi", "Beta Oy")},
+		},
+		details: map[string]string{
+			// Only "new" has a detail; "old" must never be fetched (it is seen).
+			"new": detailJSON("New Role", "Beta Oy", "plain", "Fresh body."),
+		},
+	}
+	seen := func(id string) bool { return id == "old" }
+
+	jobs, err := NewTyomarkkinatori(fake).(HydratingSource).FetchNew(context.Background(), CompanyEntry{}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	old, oldOK := jobByID(jobs, "old")
+	nu, nuOK := jobByID(jobs, "new")
+	if !oldOK || !old.SeenRefresh {
+		t.Errorf("seen posting should be SeenRefresh, got %+v (ok=%v)", old, oldOK)
+	}
+	if !nuOK || nu.SeenRefresh {
+		t.Errorf("unseen posting should be hydrated, got %+v (ok=%v)", nu, nuOK)
+	}
+	if nuOK && nu.Title != "New Role" {
+		t.Errorf("unseen Title = %q, want hydrated detail title", nu.Title)
+	}
+}
+
+// TestTMTDescription pins the contract for the description renderer (the learning contribution).
+//
+// The body is stored as sanitized HTML. It arrives in two shapes, flagged by contentType:
+//   - "markdown": CommonMark — render it (markdownToHTML) so "**bold**" etc. become real tags.
+//   - "plain": literal text whose SINGLE newlines are meaningful (postings lay out
+//     "Location: …\nWork mode: …\n" line by line). Feeding plain text straight through a
+//     CommonMark renderer collapses those single newlines into spaces (soft breaks) and merges the
+//     lines — the trade-off to resolve. Preserve the line structure in the rendered HTML.
+//
+// An empty body renders to "". The output is always sanitized HTML.
+func TestTMTDescription(t *testing.T) {
+	// Empty stays empty regardless of content type.
+	if got := tmtDescription("plain", "  "); got != "" {
+		t.Errorf("tmtDescription(plain, blank) = %q, want empty", got)
+	}
+
+	// Markdown is rendered: bold becomes a tag, not literal asterisks.
+	md := tmtDescription("markdown", "We need a **developer**.")
+	if strings.Contains(md, "**") {
+		t.Errorf("markdown not rendered: %q", md)
+	}
+	if !strings.Contains(md, "developer") {
+		t.Errorf("markdown lost content: %q", md)
+	}
+
+	// Plain text keeps its two lines distinct — they must not be merged into one run of text.
+	plain := tmtDescription("plain", "Location: Espoo\nWork mode: Hybrid")
+	if !strings.Contains(plain, "Location: Espoo") || !strings.Contains(plain, "Work mode: Hybrid") {
+		t.Errorf("plain lost content: %q", plain)
+	}
+	if strings.Contains(plain, "Location: Espoo Work mode: Hybrid") {
+		t.Errorf("plain merged its two lines into one: %q", plain)
+	}
+}

--- a/sources/tyomarkkinatori.yml
+++ b/sources/tyomarkkinatori.yml
@@ -1,0 +1,8 @@
+# Job Market Finland (tyomarkkinatori.fi), the Finnish national job portal (KEHA-keskus, successor
+# to te-palvelut). Boardless aggregator: one public, keyless JSON API
+# (tyomarkkinatori.fi/api/jobpostingfulltext/search/v2/search), so the entry carries no board, and
+# each job's employer comes from the posting, not this placeholder. The list omits the body, so the
+# crawl fetches a detail page per posting for the description; it shards the search by region to
+# clear the API's 10k deep-paging cap. Its own cron slot.
+- company: Job Market Finland
+  provider: tyomarkkinatori


### PR DESCRIPTION
## What

New boardless-aggregator source adapter for **Job Market Finland** ([tyomarkkinatori.fi](https://tyomarkkinatori.fi)), the Finnish national job portal (KEHA-keskus, successor to the retired te-palvelut). Closes a known RU/EU source gap.

## How it serves data (discovered by capturing the search SPA's XHR)

Same-origin JSON API behind a rewriting gateway, anonymous/keyless:

| | endpoint |
|---|---|
| list/search | `POST /api/jobpostingfulltext/search/v2/search` — empty query → whole catalogue freshest-first; omits the posting body |
| detail | `GET /api/jobposting-new/v1/public/jobpostings/{id}` — body (plain/markdown), authoritative `owner.company`, publish date |

## Design notes

- **Region sharding.** The search is a thin Elasticsearch proxy that hard-caps deep paging at `(pageNumber*pageSize)+pageSize ≤ 10000`, below the ~10.7k open postings. A single freshest-10k sweep would leave the oldest ~700 open postings unreachable → the post-run unseen sweep would false-close them. Instead the crawl **shards by region** (18 mainland maakunta + Åland); every region's slice is well under the window and pages fully. A multi-region posting surfaces in several shards and is deduped by id. Region assignment is stable across runs, so an ingested posting stays reachable via the same shard.
- **HydratingSource** (like justjoin): detail is fetched only for postings the catalogue does not already have; a seen posting refreshes liveness (`SeenRefresh`) without a detail request — important at ~10k postings.
- **Descriptions** arrive as plain text or CommonMark (`descriptionsContentType`) and render to sanitized HTML. The plain branch escapes + `<br>`s newlines so the line-by-line field layout survives (a CommonMark render would collapse single newlines).
- Covers every sector (not just IT), like the other national feeds — the downstream dictionaries and the enrich non-tech gate decide relevance.

## Verification

- `go build ./... && go vet ./internal/sources/` clean; `go test ./internal/sources/` green.
- New unit tests: region-shard dedup, full-hydration mapping, HydratingSource seen/unseen split, multilingual pick (en→fi→sv), plain-vs-markdown description rendering, board-file registry validation.
- **Live end-to-end** through the real HTTP client: `search` (region 21/Åland, lastPage 22) + `detail` (plain Swedish body, `owner.company` present) — the shared Chrome-fingerprint client is accepted, no keyed transport needed.

## Ops

Boardless single-entry `sources/tyomarkkinatori.yml`; wants its own cron slot (like getmatch/jobdanmark). No migration.