### PR TITLE
fix(sources): rate-limit-aware gradual hydration for tyomarkkinatori

### DIFF
--- a/internal/sources/tyomarkkinatori.go
+++ b/internal/sources/tyomarkkinatori.go
@@ -2,10 +2,13 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"html"
 	"log"
+	"net/http"
 	"strings"
+	"sync/atomic"
 )
 
 // tyomarkkinatori adapts Job Market Finland (tyomarkkinatori.fi), the Finnish national job
@@ -34,6 +37,13 @@ import (
 // Detail is the expensive fan-out (one request per posting over ~10k postings), so the adapter is
 // a HydratingSource: FetchNew fetches a posting's detail only when the catalogue does not already
 // have it, refreshing a seen posting's liveness without a detail request (see justjoin).
+//
+// The detail endpoint rate-limits under sustained load: a cold-start crawl that fetches all ~10k
+// details trips a 403 after a few hundred requests. So hydration is GRADUAL — the first 403 latches
+// off further detail requests for the rest of the run, and an un-hydrated posting is left
+// un-ingested (not stored description-less) so it stays unseen and a later run hydrates it once the
+// limit has cooled. Over successive hourly runs the catalogue fills up, every posting with a real
+// description; in steady state only the daily delta needs a detail request, well under the limit.
 type tyomarkkinatori struct {
 	http tmtClient
 }
@@ -55,6 +65,10 @@ const (
 	// still, so a shard always pages to exhaustion before either bound bites.
 	tmtPageSize = 90
 	tmtMaxPage  = 100
+	// tmtDetailWorkers bounds the detail fan-out. It is gentler than the shared default because
+	// the detail endpoint rate-limits (403) under sustained load; a lower concurrency hydrates
+	// more postings before the 403 latch trips, and the latch stops the rest for the run.
+	tmtDetailWorkers = 4
 )
 
 // tmtRegions is the fixed set of Finnish region (maakunta) codes the search filters on — the 18
@@ -189,8 +203,9 @@ func (s tyomarkkinatori) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, erro
 	if err != nil {
 		return nil, err
 	}
-	return fetchDetails(items, defaultDetailWorkers, func(it tmtListItem) (Job, bool) {
-		return s.hydrate(ctx, it, nil)
+	var limited atomic.Bool
+	return fetchDetails(items, tmtDetailWorkers, func(it tmtListItem) (Job, bool) {
+		return s.hydrate(ctx, it, nil, &limited)
 	}), nil
 }
 
@@ -204,16 +219,19 @@ func (s tyomarkkinatori) FetchNew(ctx context.Context, _ CompanyEntry, seen func
 	if err != nil {
 		return nil, err
 	}
-	return fetchDetails(items, defaultDetailWorkers, func(it tmtListItem) (Job, bool) {
-		return s.hydrate(ctx, it, seen)
+	var limited atomic.Bool
+	return fetchDetails(items, tmtDetailWorkers, func(it tmtListItem) (Job, bool) {
+		return s.hydrate(ctx, it, seen, &limited)
 	}), nil
 }
 
-// hydrate maps one list item to a Job. When seen reports the posting already ingested, it returns
-// the list-only job flagged SeenRefresh (no detail request); otherwise it fetches the detail and
-// applies its body/employer/date, falling back to the list-only job if the detail request fails.
-// A nil seen forces full hydration (the Fetch path).
-func (s tyomarkkinatori) hydrate(ctx context.Context, it tmtListItem, seen func(string) bool) (Job, bool) {
+// hydrate maps one list item to a Job. A seen posting is refreshed (SeenRefresh, no detail
+// request). An unseen posting is hydrated with its detail — except once the detail endpoint has
+// rate-limited this run (limited latched by an earlier 403), an unseen posting is SKIPPED
+// (ok=false) so it is left un-ingested and stays unseen for a later run to hydrate. A non-403
+// detail failure falls back to list-only so a genuinely broken detail does not lose the posting.
+// A nil seen forces hydration for every posting (the Fetch path).
+func (s tyomarkkinatori) hydrate(ctx context.Context, it tmtListItem, seen func(string) bool, limited *atomic.Bool) (Job, bool) {
 	base, ok := it.toJob()
 	if !ok {
 		return Job{}, false
@@ -225,7 +243,16 @@ func (s tyomarkkinatori) hydrate(ctx context.Context, it tmtListItem, seen func(
 		base.SeenRefresh = true
 		return base, true
 	}
-	d, ok := s.detail(ctx, it.ID)
+	if limited.Load() {
+		// The detail endpoint pushed back earlier this run; leave this posting unseen so a
+		// later run hydrates it with a real description rather than storing it description-less.
+		return Job{}, false
+	}
+	d, ok, rateLimited := s.detail(ctx, it.ID)
+	if rateLimited {
+		limited.Store(true)
+		return Job{}, false // skip; a later run hydrates it once the limit has cooled
+	}
 	if !ok {
 		log.Printf("tyomarkkinatori: detail %q failed; ingesting list-only", it.ID)
 		return base, true
@@ -324,14 +351,19 @@ type tmtDetail struct {
 	} `json:"application"`
 }
 
-// detail fetches a posting's detail, returning ok=false on a failed request so the caller falls
-// back to the list-only job — a posting is never dropped over a missing detail.
-func (s tyomarkkinatori) detail(ctx context.Context, id string) (tmtDetail, bool) {
-	var d tmtDetail
+// detail fetches a posting's detail. It returns ok=false on a failed request, and rateLimited=true
+// specifically when the endpoint answered 403 (its rate-limit response) — the caller latches on
+// that to stop hydrating for the rest of the run. Any other failure leaves rateLimited false so the
+// caller falls back to list-only.
+func (s tyomarkkinatori) detail(ctx context.Context, id string) (d tmtDetail, ok bool, rateLimited bool) {
 	if err := s.http.GetJSON(ctx, fmt.Sprintf(tmtDetailURL, id), &d); err != nil {
-		return tmtDetail{}, false
+		var se *StatusError
+		if errors.As(err, &se) && se.Code == http.StatusForbidden {
+			return tmtDetail{}, false, true
+		}
+		return tmtDetail{}, false, false
 	}
-	return d, true
+	return d, true, false
 }
 
 // apply enriches a list-derived job with the detail payload: the rendered body becomes the

--- a/internal/sources/tyomarkkinatori_test.go
+++ b/internal/sources/tyomarkkinatori_test.go
@@ -19,6 +19,8 @@ type tmtFake struct {
 	regions map[string][]tmtListItem
 	// details maps a posting id to its detail JSON; a missing id fails the GET.
 	details map[string]string
+	// forbidden ids answer the detail GET with a 403 (the portal's rate-limit response).
+	forbidden map[string]bool
 }
 
 func (f *tmtFake) PostJSON(_ context.Context, _ string, body, v any) error {
@@ -37,6 +39,9 @@ func (f *tmtFake) PostJSON(_ context.Context, _ string, body, v any) error {
 
 func (f *tmtFake) GetJSON(_ context.Context, url string, v any) error {
 	id := url[strings.LastIndex(url, "/")+1:]
+	if f.forbidden[id] {
+		return &StatusError{Code: 403, URL: url}
+	}
 	body, ok := f.details[id]
 	if !ok {
 		return fmt.Errorf("tmtFake: no detail for %s", id)
@@ -197,6 +202,67 @@ func TestTyomarkkinatoriFetchNewHydratesOnlyNew(t *testing.T) {
 	}
 	if nuOK && nu.Title != "New Role" {
 		t.Errorf("unseen Title = %q, want hydrated detail title", nu.Title)
+	}
+}
+
+// TestTyomarkkinatoriRateLimitedDetailSkipped verifies the 403 latch: the portal rate-limits the
+// detail endpoint under a cold-start crawl, so a 403'd unseen posting is SKIPPED (left un-ingested,
+// so it stays unseen and a later run hydrates it with a real description) rather than ingested
+// description-less. A seen posting is still refreshed. Contrast with a non-403 detail failure,
+// which falls back to list-only so the posting is not lost.
+func TestTyomarkkinatoriRateLimitedDetailSkipped(t *testing.T) {
+	fake := &tmtFake{
+		regions: map[string][]tmtListItem{
+			"01": {
+				listItem("seen1", "01", "Vanha", "Acme Oy"),
+				listItem("rl1", "01", "Kehittäjä", "Beta Oy"),
+				listItem("rl2", "01", "Suunnittelija", "Gamma Oy"),
+			},
+		},
+		forbidden: map[string]bool{"rl1": true, "rl2": true},
+	}
+	seen := func(id string) bool { return id == "seen1" }
+
+	jobs, err := NewTyomarkkinatori(fake).(HydratingSource).FetchNew(context.Background(), CompanyEntry{}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	// The two rate-limited postings must not be ingested at all (neither hydrated nor list-only).
+	if _, ok := jobByID(jobs, "rl1"); ok {
+		t.Error("rate-limited posting rl1 must be skipped, not ingested")
+	}
+	if _, ok := jobByID(jobs, "rl2"); ok {
+		t.Error("rate-limited posting rl2 must be skipped, not ingested")
+	}
+	// The seen posting is still refreshed (no detail request).
+	if s, ok := jobByID(jobs, "seen1"); !ok || !s.SeenRefresh {
+		t.Errorf("seen posting should still be SeenRefresh, got %+v (ok=%v)", s, ok)
+	}
+}
+
+// TestTyomarkkinatoriDetailFailureFallsBackToListOnly verifies a NON-403 detail failure (e.g. a
+// 404 or transient error) still ingests the posting list-only, so a genuinely broken detail does
+// not lose an otherwise-complete posting.
+func TestTyomarkkinatoriDetailFailureFallsBackToListOnly(t *testing.T) {
+	fake := &tmtFake{
+		regions: map[string][]tmtListItem{
+			// "broken" has no detail entry → generic (non-403) GET failure.
+			"01": {listItem("broken", "01", "Rikki", "Acme Oy")},
+		},
+	}
+	jobs, err := NewTyomarkkinatori(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	j, ok := jobByID(jobs, "broken")
+	if !ok {
+		t.Fatal("posting with a failed (non-403) detail should be ingested list-only")
+	}
+	if j.SeenRefresh {
+		t.Error("list-only fallback must not be a SeenRefresh")
+	}
+	if j.Description != "" {
+		t.Errorf("list-only job should have no description, got %q", j.Description)
 	}
 }
 


### PR DESCRIPTION
## Why

The first deploy of the Job Market Finland adapter (#735) surfaced a cold-start problem in prod: the detail endpoint (`/api/jobposting-new/v1/public/jobpostings/{id}`) **rate-limits with a 403 under sustained load**. A single request or a small burst is fine, but fetching all ~10k details in one run trips a 403 after a few hundred requests — the ingest run then saw *every* remaining detail 403 and fell back to storing postings description-less.

Reproduced on the prod host: a sustained 8-wide detail load returned `ok=839 fail=241`, first error `status 403` (single and 16-wide bursts return all 200s — it's a volume limit, not an IP block or size cap).

## Fix

Make hydration **gradual and rate-limit-aware**:

- The first 403 **latches** off further detail requests for the rest of the run.
- An un-hydrated posting (latched, or budget not reached) is **left un-ingested** — not stored without a body — so it stays *unseen* and a later run hydrates it once the limit has cooled.
- A **non-403** detail failure still falls back to list-only (a genuinely broken detail shouldn't lose the posting).
- Detail concurrency lowered to 4 to hydrate more before the latch trips.

Because the adapter is a `HydratingSource`, steady state only fetches details for the daily delta (well under the limit); the latch only bites on the initial fill, which spreads across successive hourly runs — every posting ends up with a real description.

`detail()` now reports the 403 distinctly via the client's typed `StatusError`, which the latch keys on (same mechanism eightfold uses for its backoff).

## Tests

- New: `TestTyomarkkinatoriRateLimitedDetailSkipped` (403 → skipped, not ingested; seen still refreshes) and `TestTyomarkkinatoriDetailFailureFallsBackToListOnly` (non-403 → list-only).
- Full `go test ./internal/sources/` green; build + vet clean.

Follow-up to #735.