### PR TITLE
fix(gmailsync): add missing ATS mail-relay domains to the sync allow-list

### DIFF
--- a/internal/gmailsync/senders.go
+++ b/internal/gmailsync/senders.go
@@ -29,6 +29,21 @@ var ATSDomains = []string{
 	"eightfold.ai",
 	"gem.com",
 	"rippling.com",
+	// Mail-relay domains that differ from a platform's board domain — applicant
+	// mail arrives from these, so they must be listed to be synced (observed in a
+	// real inbox; the board-domain entries above do not cover them).
+	"workablemail.com",         // Workable (board domain: workable.com)
+	"teamtailor-mail.com",      // Teamtailor (board domain: teamtailor.com)
+	"comeet-notifications.com", // Comeet
+	"recruitee-mailbox.com",    // Recruitee (also uses recruitee.com)
+	"freshteam.com",            // Freshteam
+	"gupy.com.br",              // Gupy
+	"talentlyft.com",           // TalentLyft
+	"join.com",                 // Join
+	"icims.eu",                 // iCIMS EU (also icims.com)
+	"successfactors.eu",        // SuccessFactors EU (also successfactors.com)
+	"m.personio.com",           // Personio applicant relay (subdomain: avoid product mail)
+	"mail.paylocity.com",       // Paylocity applicant relay (subdomain: avoid product mail)
 }
 
 // BuildQuery builds a Gmail search query for ATS mail newer than the given Unix

--- a/internal/gmailsync/senders_test.go
+++ b/internal/gmailsync/senders_test.go
@@ -25,6 +25,33 @@ func TestIsATSSender(t *testing.T) {
 	}
 }
 
+// TestIsATSSender_RelayDomains locks in the ATS mail-relay domains observed in a
+// real inbox that the original allow-list missed — the mail domains differ from
+// the platforms' board domains (e.g. Workable sends from workablemail.com, not
+// workable.com), so applicant mail from them was never synced.
+func TestIsATSSender_RelayDomains(t *testing.T) {
+	yes := []string{
+		"GigaBrands <x@candidates.workablemail.com>", // Workable (board domain is workable.com)
+		"y@inbound.workablemail.com",
+		"Avenga Careers <x@avenga.teamtailor-mail.com>",              // Teamtailor relay
+		"Moon Active <no-reply@moonactive.comeet-notifications.com>", // Comeet relay
+		"Bitfinex <noreply@join.com>",                                // Join
+		"x@recruitee-mailbox.com",                                    // Recruitee relay
+		"careers@getambush-talent.freshteam.com",                     // Freshteam
+		"G42 Careers <g42+autoreply@talent.icims.eu>",                // iCIMS EU
+		"Wiser <system@successfactors.eu>",                           // SuccessFactors EU
+		"no-reply@gupy.com.br",                                       // Gupy
+		"jobs@m.personio.com",                                        // Personio relay
+		"do-not-reply@mail.paylocity.com",                            // Paylocity relay
+		"Linh <linh@m.talentlyft.com>",                               // TalentLyft relay
+	}
+	for _, s := range yes {
+		if !IsATSSender(s) {
+			t.Errorf("IsATSSender(%q) = false, want true", s)
+		}
+	}
+}
+
 func TestBuildQuery(t *testing.T) {
 	q := BuildQuery(1_700_000_000)
 	if !strings.Contains(q, "from:(") {


### PR DESCRIPTION
## Summary
An audit of a real connected inbox (630 application-related emails across 197 sender domains, pulled unfiltered via the Gmail API) found the `ATSDomains` allow-list — which scopes both the Gmail sync query and `IsATSSender` — misses the **mail-relay domains** ATS platforms actually send applicant mail from. These differ from the platforms' board domains, so their mail was silently never synced.

Added: `workablemail.com` (Workable — **56 emails** missed in the audit), `teamtailor-mail.com`, `comeet-notifications.com`, `recruitee-mailbox.com`, `freshteam.com`, `gupy.com.br`, `talentlyft.com`, `join.com`, `icims.eu`, `successfactors.eu`, `m.personio.com`, `mail.paylocity.com`.

## Test Plan
- [x] `TestIsATSSender_RelayDomains` (RED→GREEN) covers a representative address from each new relay domain.
- [x] `go test ./internal/gmailsync/`, build, vet, gofmt clean.

## Follow-up (ops, after deploy)
Sync uses a per-user watermark, so this only affects **new** mail going forward. To backfill the historical missed mail, reset the connected users' `gmail_connections.sync_cursor` to 0 for a one-time full re-sync.