### PR TITLE
feat(sources): add Likeit (Finnish staffing ATS) source adapter

### DIFF
--- a/internal/sources/likeit.go
+++ b/internal/sources/likeit.go
@@ -1,0 +1,92 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// likeit adapts a Likeit (Saarni Likeit Oy) recruiting board. Likeit is a Finnish HR/ERP
+// platform for staffing agencies; each tenant runs its board on its own subdomain
+// (<board>.likeit.fi) and publishes a keyless RSS feed of open adverts at
+// /jsp/duuni/AdvertRss.jsp. Every item carries the full posting inline — title, an
+// AdvertShow.jsp?id=<id> detail link (the id is the stable native posting id), the location
+// in <category>, and the escaped HTML body in <description> — so one request per board
+// yields every posting with no per-advert detail fetch. The board is the tenant subdomain,
+// e.g. "rekrymesta" or "go-on"; Company is the staffing agency running the board.
+type likeit struct {
+	http XMLGetter
+}
+
+// NewLikeit builds the Likeit adapter over the given HTTP client.
+func NewLikeit(c XMLGetter) Source { return likeit{http: c} }
+
+func (likeit) Provider() string { return "likeit" }
+
+// likeitRSS is a board's AdvertRss.jsp document. Only the fields the adapter maps are decoded;
+// <category> holds the location (a "region, city" string), not a job category.
+type likeitRSS struct {
+	Items []likeitItem `xml:"channel>item"`
+}
+
+type likeitItem struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	Description string `xml:"description"`
+	Category    string `xml:"category"`
+	PubDate     string `xml:"pubDate"`
+	// Date is the dc:date element (matched on local name); it is the cleaner RFC3339 form
+	// of pubDate and the preferred posted_at.
+	Date string `xml:"date"`
+}
+
+func (a likeit) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	feedURL := fmt.Sprintf("https://%s.likeit.fi/jsp/duuni/AdvertRss.jsp", e.Board)
+
+	var feed likeitRSS
+	if err := a.http.GetXML(ctx, feedURL, &feed); err != nil {
+		return nil, fmt.Errorf("likeit: fetch board %s: %w", e.Board, err)
+	}
+
+	jobs := make([]Job, 0, len(feed.Items))
+	for _, it := range feed.Items {
+		id := likeitID(it.Link)
+		if id == "" {
+			continue // no posting id (e.g. a listing link) — skip rather than emit an empty key
+		}
+		location := strings.TrimSpace(it.Category)
+		jobs = append(jobs, Job{
+			ExternalID:  id,
+			URL:         it.Link,
+			Title:       strings.TrimSpace(it.Title),
+			Company:     e.Company,
+			Location:    location,
+			Description: sanitizeHTML(it.Description),
+			Remote:      isRemote(location), // the feed has no structured remote flag
+			PostedAt:    likeitDate(it.Date, it.PubDate),
+		})
+	}
+	return jobs, nil
+}
+
+// likeitID returns the native posting id from an AdvertShow.jsp?id=<id> link, or "" when the
+// link carries no id (e.g. the channel's AdvertList link). Reading the query key is
+// order-independent, so a "?guest=1&id=…" link resolves the same as "?id=…&guest=1".
+func likeitID(link string) string {
+	u, err := url.Parse(link)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(u.Query().Get("id"))
+}
+
+// likeitDate parses a Likeit item's posted_at, preferring the RFC3339 dc:date and falling
+// back to the RFC1123 pubDate.
+func likeitDate(dcDate, pubDate string) *time.Time {
+	if t := parseRFC3339(dcDate); t != nil {
+		return t
+	}
+	return parsePubDate(pubDate)
+}

--- a/internal/sources/likeit_test.go
+++ b/internal/sources/likeit_test.go
@@ -1,0 +1,99 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestLikeitProvider(t *testing.T) {
+	if got := NewLikeit(nil).Provider(); got != "likeit" {
+		t.Errorf("Provider() = %q, want %q", got, "likeit")
+	}
+}
+
+// likeitFeed mirrors a live Likeit AdvertRss.jsp document: dc-namespaced, one item per
+// open advert with the posting id in the AdvertShow link's query, the location in
+// <category>, an escaped HTML <description>, and both a pubDate and dc:date. The second
+// item carries no <category> (location empty) and the third's link has no id (dropped).
+const likeitFeed = `<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+  <channel>
+    <title>Työilmoitukset</title>
+    <link>https://rekrymesta.likeit.fi/jsp/duuni/AdvertList.jsp?guest=1</link>
+    <description />
+    <item>
+      <title>Nuorempi LVI-asentaja Pirkanmaalle</title>
+      <link>https://rekrymesta.likeit.fi/jsp/duuni/AdvertShow.jsp?id=8074439&amp;guest=1</link>
+      <description>&lt;p&gt;Haemme &lt;strong&gt;LVI-asentajaa&lt;/strong&gt; Sein&amp;auml;joelle.&lt;/p&gt;</description>
+      <category>Pirkanmaa, Tampere</category>
+      <pubDate>Wed, 15 Jul 2026 05:39:11 GMT</pubDate>
+      <guid>https://rekrymesta.likeit.fi/jsp/duuni/AdvertShow.jsp?id=8074439&amp;guest=1</guid>
+      <dc:date>2026-07-15T05:39:11Z</dc:date>
+    </item>
+    <item>
+      <title>Avoin hakemus</title>
+      <link>https://rekrymesta.likeit.fi/jsp/duuni/AdvertShow.jsp?id=2145755&amp;guest=1</link>
+      <description>&lt;p&gt;Lähetä avoin hakemus.&lt;/p&gt;</description>
+      <pubDate>Tue, 14 Jul 2026 09:00:00 GMT</pubDate>
+      <guid>https://rekrymesta.likeit.fi/jsp/duuni/AdvertShow.jsp?id=2145755&amp;guest=1</guid>
+      <dc:date>2026-07-14T09:00:00Z</dc:date>
+    </item>
+    <item>
+      <title>No id here</title>
+      <link>https://rekrymesta.likeit.fi/jsp/duuni/AdvertList.jsp?guest=1</link>
+      <description>&lt;p&gt;x&lt;/p&gt;</description>
+      <category>Uusimaa, Helsinki</category>
+      <pubDate>Tue, 14 Jul 2026 09:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`
+
+func TestLikeitFetch(t *testing.T) {
+	fake := &fakeHTTP{body: likeitFeed}
+
+	jobs, err := NewLikeit(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Rekrymesta", Provider: "likeit", Board: "rekrymesta",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// The board is the tenant subdomain; the feed is the guest AdvertRss endpoint.
+	if !strings.Contains(fake.gotURL, "rekrymesta.likeit.fi/jsp/duuni/AdvertRss.jsp") {
+		t.Errorf("requested URL %q should target the board's AdvertRss feed", fake.gotURL)
+	}
+	// The third item's link carries no posting id and must be dropped.
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (id-less item dropped)", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "8074439" {
+		t.Errorf("ExternalID = %q, want the id from the AdvertShow query", j.ExternalID)
+	}
+	if j.Title != "Nuorempi LVI-asentaja Pirkanmaalle" {
+		t.Errorf("Title = %q, want the item title", j.Title)
+	}
+	if j.Company != "Rekrymesta" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.URL != "https://rekrymesta.likeit.fi/jsp/duuni/AdvertShow.jsp?id=8074439&guest=1" {
+		t.Errorf("URL = %q, want the item link", j.URL)
+	}
+	if j.Location != "Pirkanmaa, Tampere" {
+		t.Errorf("Location = %q, want the category value", j.Location)
+	}
+	// The description is double-escaped (XML then HTML entity); the Finnish umlaut must survive.
+	if !strings.Contains(j.Description, "Seinäjoelle") {
+		t.Errorf("Description should decode the Finnish umlaut, got %q", j.Description)
+	}
+	if j.Remote {
+		t.Error("Remote = true for a Pirkanmaa location, want false")
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want the parsed dc:date (2026)", j.PostedAt)
+	}
+	if jobs[1].Location != "" {
+		t.Errorf("second job Location = %q, want empty (no category)", jobs[1].Location)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -278,6 +278,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJobnet(c),
 		NewJobdanmark(c),
 		NewTyomarkkinatori(c),
+		NewLikeit(c),
 		// International single-company adapters (boardless).
 		NewTelegramCareers(c),
 		NewUber(c),

--- a/sources/likeit.yml
+++ b/sources/likeit.yml
@@ -1,0 +1,19 @@
+# Likeit (Saarni Likeit Oy) recruiting boards — a Finnish HR/ERP platform for staffing
+# agencies. Each tenant runs its board on a subdomain (<board>.likeit.fi) and publishes a
+# keyless RSS feed of open adverts at /jsp/duuni/AdvertRss.jsp; see internal/sources/likeit.go.
+# board = the tenant subdomain (e.g. "rekrymesta"); company = the staffing agency running it.
+#
+# Add a board only after validating it live: https://<board>.likeit.fi/jsp/duuni/AdvertRss.jsp
+# must return 200 with <item> adverts. Each entry below was validated live.
+- company: Mestarit Henkilöstöpalvelut
+  board: mestarit
+- company: Rekrymesta
+  board: rekrymesta
+- company: Carrot
+  board: carrot
+- company: Apuvoima
+  board: apuvoima
+- company: Duuri-tiimi
+  board: duuritiimi
+- company: Safrent
+  board: safrent


### PR DESCRIPTION
## What

Adds the `likeit` source adapter. **Likeit / Saarni Likeit Oy** is a Finnish HR/ERP platform for staffing agencies — `likeit.fi` itself hosts no jobs, but each tenant runs its board on a subdomain `<board>.likeit.fi` publishing a keyless RSS feed of open adverts at `/jsp/duuni/AdvertRss.jsp`.

## How

- **board = tenant subdomain** (e.g. `rekrymesta`). Board-based, multi-tenant — a peer of earcu/talentadore; appears in the source facet.
- **One request per board, no detail fan-out** — every `<item>` carries the full posting inline.
- Per item: `ExternalID` = the `id` in the `AdvertShow.jsp?id=<id>` link query (read order-independently); `<category>` = location; `<dc:date>` (RFC3339, fallback `<pubDate>`) = posted_at; `<description>` sanitized.
- Double-escaped Finnish entities (`&amp;auml;` → ä) decode correctly through a single `sanitizeHTML` — verified against live data.
- Remote via the shared `isRemote(location)`, consistent with the sibling Finnish adapter (tyomarkkinatori).

## Boards

Ships 6 live-validated boards (~465 postings): `mestarit` (154), `rekrymesta` (132), `carrot` (110), `apuvoima` (44), `duuritiimi` (18), `safrent` (7).

## Verification

- Unit tests (`TestLikeitFetch` incl. Finnish umlaut assertion, id-less-item drop) pass.
- Live end-to-end crawl of `rekrymesta` returned 132 jobs with correct ids, dates, locations, and Finnish diacritics.
- `go build ./...`, `go vet`, `gofmt` clean.