### PR TITLE
feat(sources): add TalentAdore (Nordic ATS) source adapter

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -202,6 +202,7 @@ func All(c HTTPClient) map[string]Source {
 		NewICIMS(c),
 		NewCareerPage(c),
 		NewNorthstone(c),
+		NewTalentAdore(c),
 		NewLoxo(c),
 		NewHireology(c),
 		NewIsolvedHire(c),

--- a/internal/sources/talentadore.go
+++ b/internal/sources/talentadore.go
@@ -1,0 +1,88 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// talentadoreFeedURL templates TalentAdore Hire's public positions feed. TalentAdore
+// (careers.talentadore.com is only their WordPress marketing site) hosts each employer's
+// live openings as a JSON feed at ats.talentadore.com/positions/<token>/json — the same
+// endpoint the ta-json-careers.js widget reads to render a customer's career page. The
+// board is that per-employer feed token (e.g. "9wmfASE"), not a human-readable slug; it
+// is the data-url token embedded in the career-site widget. The v=2 query param is
+// load-bearing: without it start_date/updated arrive as timezone-less "2006-01-02T15:04:05"
+// strings that RFC3339 rejects (posted_at silently null); v=2 emits proper RFC3339 with Z.
+const talentadoreFeedURL = "https://ats.talentadore.com/positions/%s/json?v=2"
+
+// talentadore adapts TalentAdore Hire, a Nordic AI-assisted ATS. The feed carries each
+// posting's full description_html inline, so no per-posting detail request is needed. It
+// exposes no structured remote/work-mode field, so remote is inferred from the location
+// text like the other free-text-location adapters.
+type talentadore struct {
+	http JSONGetter
+}
+
+// NewTalentAdore builds the TalentAdore adapter over the given HTTP client.
+func NewTalentAdore(c JSONGetter) Source { return talentadore{http: c} }
+
+func (talentadore) Provider() string { return "talentadore" }
+
+// talentadoreFeed is the slice of the positions feed we read. Each job carries its own
+// description_html, so the list is the only request per board.
+type talentadoreFeed struct {
+	Jobs []talentadoreJob `json:"jobs"`
+}
+
+// talentadoreJob is one posting. job_token is the stable native id — it is what the public
+// apply URL (link, e.g. .../apply/<slug>/<token>) is keyed on, so it survives the internal
+// id being regenerated. description_html is the full body (description_text is the plain
+// fallback); start_date is the publish date and updated the last-modified fallback. city,
+// county, and country compose the location; the plain location field is a street address we
+// omit as noise. employment_type is present in the schema but unset in observed feeds, so it
+// is left to the description parser/dictionaries rather than mapped from an unknown vocabulary.
+type talentadoreJob struct {
+	JobToken        string `json:"job_token"`
+	Name            string `json:"name"`
+	Link            string `json:"link"`
+	DescriptionHTML string `json:"description_html"`
+	DescriptionText string `json:"description_text"`
+	StartDate       string `json:"start_date"`
+	Updated         string `json:"updated"`
+	City            string `json:"city"`
+	County          string `json:"county"`
+	Country         string `json:"country"`
+}
+
+func (s talentadore) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	url := fmt.Sprintf(talentadoreFeedURL, e.Board)
+	var feed talentadoreFeed
+	if err := s.http.GetJSON(ctx, url, &feed); err != nil {
+		return nil, fmt.Errorf("talentadore: fetch board %s: %w", e.Board, err)
+	}
+
+	jobs := make([]Job, 0, len(feed.Jobs))
+	for _, j := range feed.Jobs {
+		token := strings.TrimSpace(j.JobToken)
+		if token == "" {
+			continue // no native id → would collide on the dedup key; skip it
+		}
+		location := joinNonEmpty(j.City, j.County, j.Country)
+		description := sanitizeHTML(j.DescriptionHTML)
+		if description == "" {
+			description = strings.TrimSpace(j.DescriptionText)
+		}
+		jobs = append(jobs, Job{
+			ExternalID:  token,
+			URL:         j.Link,
+			Title:       j.Name,
+			Company:     e.Company,
+			Location:    location,
+			Description: description,
+			Remote:      isRemote(location),
+			PostedAt:    parseRFC3339(firstNonEmpty(j.StartDate, j.Updated)),
+		})
+	}
+	return jobs, nil
+}

--- a/internal/sources/talentadore_test.go
+++ b/internal/sources/talentadore_test.go
@@ -1,0 +1,137 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestTalentAdoreProvider(t *testing.T) {
+	if got := NewTalentAdore(nil).Provider(); got != "talentadore" {
+		t.Errorf("Provider() = %q, want %q", got, "talentadore")
+	}
+}
+
+func TestTalentAdoreFetch(t *testing.T) {
+	fake := &fakeHTTP{body: `{
+		"company": "Acme",
+		"jobs": [
+			{
+				"id": "yjMOo",
+				"job_token": "mWXEgr",
+				"name": "AI Engineer",
+				"link": "https://ats.talentadore.com/apply/ai-engineer/mWXEgr",
+				"description_html": "<p>Build models.</p><script>alert(1)</script>",
+				"description_text": "Build models.",
+				"start_date": "2026-07-10T12:16:20Z",
+				"updated": "2026-07-11T09:00:00Z",
+				"city": "Helsinki",
+				"county": "",
+				"country": "Finland",
+				"location": "Pasilankatu 2 A"
+			},
+			{
+				"id": "RyGxO",
+				"job_token": "m5n9e1",
+				"name": "Remote Designer",
+				"link": "https://ats.talentadore.com/apply/remote-designer/m5n9e1",
+				"description_html": "",
+				"description_text": "Design things.",
+				"start_date": "",
+				"updated": "2026-07-09T08:00:00Z",
+				"city": "",
+				"county": "",
+				"country": "Remote"
+			}
+		]
+	}`}
+
+	jobs, err := NewTalentAdore(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "talentadore", Board: "9wmfASE",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fake.gotURL, "/positions/9wmfASE/json") {
+		t.Errorf("requested URL %q should target the board positions feed", fake.gotURL)
+	}
+	// v=2 is load-bearing: it makes the feed emit RFC3339 (Z) dates the bare endpoint omits.
+	if !strings.Contains(fake.gotURL, "v=2") {
+		t.Errorf("requested URL %q must carry v=2 for RFC3339 dates", fake.gotURL)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "mWXEgr" {
+		t.Errorf("ExternalID = %q, want the job_token", j.ExternalID)
+	}
+	if j.URL != "https://ats.talentadore.com/apply/ai-engineer/mWXEgr" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "AI Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Acme" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Location != "Helsinki, Finland" {
+		t.Errorf("Location = %q, want city+country (street omitted)", j.Location)
+	}
+	if j.Remote {
+		t.Error("Remote = true, want false for a Helsinki posting")
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Build models.") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Day() != 10 {
+		t.Errorf("PostedAt = %v, want start_date (2026-07-10)", j.PostedAt)
+	}
+
+	// Second posting: empty description_html falls back to description_text; a "Remote"
+	// country flags remote; a missing start_date falls back to updated.
+	r := jobs[1]
+	if !strings.Contains(r.Description, "Design things.") {
+		t.Errorf("Description = %q, want description_text fallback", r.Description)
+	}
+	if !r.Remote {
+		t.Error("Remote = false, want true from the Remote location")
+	}
+	if r.PostedAt == nil || r.PostedAt.UTC().Day() != 9 {
+		t.Errorf("PostedAt = %v, want updated fallback (2026-07-09)", r.PostedAt)
+	}
+}
+
+func TestTalentAdoreSkipsMissingToken(t *testing.T) {
+	fake := &fakeHTTP{body: `{"jobs":[
+		{"job_token":"","name":"No Token","link":"x"},
+		{"job_token":"keep","name":"Kept","link":"y"}
+	]}`}
+
+	jobs, err := NewTalentAdore(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "b"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "keep" {
+		t.Fatalf("got %v, want only the posting with a job_token", jobs)
+	}
+}
+
+func TestTalentAdoreRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["talentadore"]
+	if !ok {
+		t.Fatal("All() missing provider talentadore")
+	}
+	if s.Provider() != "talentadore" {
+		t.Errorf("All()[talentadore].Provider() = %q", s.Provider())
+	}
+	// Board-based (per-employer feed token): stays in the source facet.
+	if !slices.Contains(FilterableProviders(), "talentadore") {
+		t.Error("FilterableProviders() should include board-based talentadore")
+	}
+}

--- a/sources/talentadore.yml
+++ b/sources/talentadore.yml
@@ -1,0 +1,5 @@
+# TalentAdore Hire — Nordic AI-assisted ATS. The board is the per-employer positions
+# feed token from the career-site widget's data-url
+# (ats.talentadore.com/positions/<token>/json), not a human-readable slug.
+- company: TalentAdore
+  board: 9wmfASE


### PR DESCRIPTION
## What

Adds a source adapter for **TalentAdore Hire**, a Nordic (Finnish) AI-assisted ATS — the last of the Finnish-market gap (tyomarkkinatori #735, likeit #739 already landed).

## How it works

- **Feed:** keyless JSON at `ats.talentadore.com/positions/<token>/json?v=2` — the same endpoint the `ta-json-careers.js` career-site widget reads. Carries `description_html` inline, so one request per board (no per-job detail fan-out).
- **Board = per-employer feed token** (e.g. `9wmfASE`), taken from the widget's `data-url`, not a human-readable slug. `careers.talentadore.com` is only their WordPress marketing site; real jobs live on customer domains embedding the widget.
- **`ExternalID = job_token`** — stable, lives in the public apply URL `/apply/<slug>/<token>`; the internal `id` is regenerable.
- **`v=2` is load-bearing:** without it `start_date`/`updated` arrive timezone-less (`2006-01-02T15:04:05`) and RFC3339 rejects them, silently nulling `posted_at`. Caught only by a live ingest run; locked with a test asserting the URL carries `v=2`.

## Verification

Ran `cmd/ingest sources/talentadore.yml` against a local DB: **3 open jobs**, correct titles, locations (`Helsinki, Finland`), sanitized ~12k descriptions, and populated `posted_at`. Unit tests cover field mapping, description fallback, missing-token skip, and registry membership (board-based → filterable).

Board file seeds TalentAdore's own board; customer tokens can be added later.