### PR TITLE
feat(sources): add LatamCent Ashby board

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -625,6 +625,8 @@
   board: langchain
 - company: Langfuse
   board: langfuse
+- company: LatamCent
+  board: latamcent
 - company: ledger
   board: ledger
 - company: Legion Health


### PR DESCRIPTION
Adds the LatamCent board to `sources/ashby.yml`.

LatamCent ([latamcent.com](https://latamcent.com)) is a LATAM staffing agency. Its WordPress storefront (e.g. `/job/go-backend-engineer/`) routes every application through its Ashby board (`jobs.ashbyhq.com/latamcent`). The public posting API (`api.ashbyhq.com/posting-api/job-board/latamcent`) serves all 19 listings with `descriptionHtml`/`applyUrl`/`employmentType`/`isRemote`, so the existing Ashby adapter covers it — one board entry, no new code.

Company resolves to "LatamCent" (the agency); the end-client name that the WordPress storefront adds editorially is not exposed in the structured ATS feed.

Also verified already-covered: `revun.com/careers` (northstone adapter) and `alignerr.com` (alignerr adapter).