### PR TITLE
fix(sources): drop duplicate LatamCent Ashby board

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -625,8 +625,6 @@
   board: langchain
 - company: Langfuse
   board: langfuse
-- company: LatamCent
-  board: latamcent
 - company: ledger
   board: ledger
 - company: Legion Health


### PR DESCRIPTION
Follow-up to #741. `latamcent` was already present in `sources/ashby.yml` (lowercase, from the #128 bulk harvest) and has been crawling in prod all along; #741 added a second entry for the same board. This removes the duplicate, keeping the pre-existing one.

No behavior change — the Ashby upsert is idempotent on `(source, external_id)`; the dup just made the board get crawled twice per run.