### PR TITLE
feat(sources): ingest Proxify internal roles via Teamtailor

### DIFF
--- a/internal/sources/teamtailor.go
+++ b/internal/sources/teamtailor.go
@@ -2,7 +2,9 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 
@@ -36,11 +38,24 @@ func (t teamtailor) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, fmt.Errorf("teamtailor: board %q: %w", e.Board, err)
 	}
 
+	// Most sites list postings under /jobs; a few (e.g. jobs.proxify.io) disable that path
+	// and render the listing on the site root instead. Probe /jobs first and, when page 1
+	// 404s, fall back to the root for this board — a standard site answers /jobs with 200 and
+	// never enters the fallback, so their enumeration is unchanged.
+	listPath := "jobs"
 	var urls []string
 	seen := make(map[string]bool)
 	for page := 1; page <= ttMaxPages; page++ {
-		listURL := fmt.Sprintf("https://%s/jobs?page=%d", e.Board, page)
+		listURL := fmt.Sprintf("https://%s/%s?page=%d", e.Board, listPath, page)
 		root, err := t.http.GetHTML(ctx, listURL)
+		if err != nil {
+			var se *StatusError
+			if page == 1 && listPath == "jobs" && errors.As(err, &se) && se.Code == http.StatusNotFound {
+				listPath = ""
+				listURL = fmt.Sprintf("https://%s/?page=%d", e.Board, page)
+				root, err = t.http.GetHTML(ctx, listURL)
+			}
+		}
 		if err != nil {
 			if page == 1 {
 				return nil, fmt.Errorf("teamtailor: listing %s: %w", e.Board, err)

--- a/internal/sources/teamtailor_test.go
+++ b/internal/sources/teamtailor_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/net/html"
 )
 
 func mustURL(t *testing.T, s string) *url.URL {
@@ -275,6 +277,42 @@ func TestTeamtailorRegisteredInAll(t *testing.T) {
 	}
 	if s.Provider() != "teamtailor" {
 		t.Errorf("All()[teamtailor].Provider() = %q", s.Provider())
+	}
+}
+
+// ttRootListingHTTP models a Teamtailor site that disables /jobs (404) and renders its
+// listing on the root instead: /jobs?page=N → 404, /?page=1 → one job, /?page=2 → empty.
+type ttRootListingHTTP struct {
+	jobURL, detail string
+}
+
+func (h ttRootListingHTTP) GetHTML(_ context.Context, u string) (*html.Node, error) {
+	switch {
+	case strings.Contains(u, "/jobs?page="):
+		return nil, &StatusError{Code: 404, URL: u}
+	case strings.Contains(u, "/jobs/"): // detail page
+		return html.Parse(strings.NewReader(h.detail))
+	case strings.Contains(u, "/?page=1"):
+		return html.Parse(strings.NewReader(ttListingHTML(h.jobURL)))
+	default: // /?page=2 and beyond → empty listing ends enumeration
+		return html.Parse(strings.NewReader(ttListingHTML()))
+	}
+}
+
+func TestTeamtailorFallsBackToRootListingWhenJobsPath404s(t *testing.T) {
+	jobURL := "https://jobs.proxify.io/jobs/8024669-enterprise-account-executive"
+	d := ttDetailHTML("Enterprise Account Executive", "&lt;p&gt;x&lt;/p&gt;",
+		"2026-07-06T00:00:00+02:00", "Stockholm", "SE", "")
+	fake := ttRootListingHTTP{jobURL: jobURL, detail: d}
+
+	jobs, err := NewTeamtailor(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Proxify", Board: "jobs.proxify.io",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "8024669" {
+		t.Fatalf("got %v, want the one root-listed posting", jobs)
 	}
 }
 

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -29,6 +29,8 @@
   board: producthackers.teamtailor.com
 - company: Prometeo Talent
   board: jobs.prometeotalent.com
+- company: Proxify
+  board: jobs.proxify.io
 - company: Rooftop
   board: rooftop.na.teamtailor.com
 - company: Sofka


### PR DESCRIPTION
## What

Adds **Proxify** as an ingested source and teaches the Teamtailor adapter to handle sites that disable the `/jobs` listing path.

`jobs.proxify.io` is a Teamtailor career site (`= proxify.teamtailor.com`, plain nginx, no Cloudflare) but — unlike every other board we carry — **404s on `/jobs`** and renders its postings on the site **root `/`** (with `?page=`). The adapter hardcoded `/jobs?page=N`, so the board failed live validation.

## Change

- **`internal/sources/teamtailor.go`** — fallback: on a page-1 `*StatusError{Code:404}` at `/jobs`, retry the listing at `/?page=N`. Standard boards answer `/jobs` with 200 and never enter the fallback → their enumeration is unchanged. Uses the typed `StatusError` via `errors.As` (no string scraping).
- **`internal/sources/teamtailor_test.go`** — `TestTeamtailorFallsBackToRootListingWhenJobsPath404s` with a purpose-built fake (404 on `/jobs`, listing on `/`).
- **`sources/teamtailor.yml`** — board `jobs.proxify.io` (company Proxify).

## Scope note

Only Proxify's **internal team roles** (~6: BDR / Account Executive, Stockholm) are in scope. Proxify's ~300/mo **developer contract network** lives on `career.proxify.io`, a custom marketing portal behind a **Cloudflare managed challenge** — not an ATS, out of scope here.

## Verification

- Live fetch against `jobs.proxify.io` → **6 jobs**, correctly normalized (title, location, posted date, URL).
- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./internal/sources/` passes (incl. new fallback test + all existing Teamtailor tests).