### PR TITLE
feat(mailclassify): add incomplete_application status signal

### DIFF
--- a/internal/mailclassify/classification.go
+++ b/internal/mailclassify/classification.go
@@ -16,14 +16,18 @@ const (
 	SignalOffer               StatusSignal = "offer"
 	SignalRejection           StatusSignal = "rejection"
 	SignalInfoRequest         StatusSignal = "info_request"
-	SignalOther               StatusSignal = "other"
+	// SignalIncompleteApplication is an actionable to-do: the application was
+	// started but not finished. Intentionally absent from signalStage — an
+	// unfinished application has not progressed.
+	SignalIncompleteApplication StatusSignal = "incomplete_application"
+	SignalOther                 StatusSignal = "other"
 )
 
 var validSignals = map[StatusSignal]bool{
 	SignalAcknowledgement: true, SignalScreening: true,
 	SignalInterviewInvitation: true, SignalAssessment: true,
 	SignalOffer: true, SignalRejection: true,
-	SignalInfoRequest: true, SignalOther: true,
+	SignalInfoRequest: true, SignalIncompleteApplication: true, SignalOther: true,
 }
 
 // Classification is the LLM output for one email: the status signal, a

--- a/internal/mailclassify/classifier.go
+++ b/internal/mailclassify/classifier.go
@@ -89,6 +89,7 @@ Return ONLY a JSON object: {"signal": <status>, "confidence": <0..1>, "matched_j
 - offer: a job offer
 - rejection: not moving forward / declined
 - info_request: they ask the candidate for more information
+- incomplete_application: the application was started but not finished; the candidate must complete/finish it
 - other: anything not about an application (e.g. a sign-in code)
 
 If a list of the candidate's applications is given, set "matched_job_id" to the id

--- a/internal/mailclassify/incomplete_test.go
+++ b/internal/mailclassify/incomplete_test.go
@@ -1,0 +1,37 @@
+package mailclassify
+
+import "testing"
+
+func TestIncompleteApplicationInVocabulary(t *testing.T) {
+	c := Classification{Signal: SignalIncompleteApplication, Confidence: 0.9}.Sanitize()
+	if c.Signal != SignalIncompleteApplication {
+		t.Errorf("Sanitize coerced %q away; want it kept in the vocabulary", SignalIncompleteApplication)
+	}
+}
+
+func TestIncompleteApplicationDoesNotAdvanceStage(t *testing.T) {
+	// An unfinished application has not progressed — it must never move a stage.
+	if stage, ok := AdvanceStage("applied", SignalIncompleteApplication); ok {
+		t.Errorf("incomplete_application advanced stage to %q; want no advance", stage)
+	}
+	if stage, ok := AdvanceStage("", SignalIncompleteApplication); ok {
+		t.Errorf("incomplete_application seeded stage %q from empty; want no advance", stage)
+	}
+}
+
+func TestKeywordStatusIncompleteApplication(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		body    string
+	}{
+		{"incomplete phrasing", "Action needed", "Your application is incomplete. Please complete your application to be considered."},
+		{"finish phrasing wins over ack opener", "Thank you for starting", "Thank you for starting your application. You must finish your application within 7 days."},
+	}
+	for _, c := range cases {
+		got, ok := KeywordStatus(c.subject, c.body)
+		if !ok || got != SignalIncompleteApplication {
+			t.Errorf("%s: KeywordStatus() = (%q, %v), want (incomplete_application, true)", c.name, got, ok)
+		}
+	}
+}

--- a/internal/mailclassify/keyword.go
+++ b/internal/mailclassify/keyword.go
@@ -33,6 +33,9 @@ var keywordRules = []keywordRule{
 	// "unfortunately" alone is intentionally excluded: too weak to skip the LLM on
 	// (it appears in some acknowledgements) — those emails defer to the LLM instead.
 	{SignalRejection, []string{"we regret", "regret to inform", "not to proceed", "not moving forward", "not be moving forward", "won't be moving forward", "won’t be moving forward", "decided not to move", "decided not to proceed", "other candidates", "not be progressing", "will not be progressing", "not selected", "move forward with other", "not the right fit", "not a fit for", "decided to move forward with"}},
+	// Ordered before acknowledgement: an "…thank you for starting your application,
+	// please complete it…" email is an incomplete-application to-do, not an ack.
+	{SignalIncompleteApplication, []string{"application is incomplete", "incomplete application", "complete your application", "finish your application", "action required to complete", "to complete your application", "your application is not complete", "did not complete your application"}},
 	{SignalAcknowledgement, []string{"thank you for applying", "thank you for your application", "thanks for applying", "we have received your application", "we've received your", "we’ve received your", "received your application", "received your resume", "application submitted", "your application has been received"}},
 }
 

--- a/openspec/changes/mailclassify-incomplete-application/.openspec.yaml
+++ b/openspec/changes/mailclassify-incomplete-application/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/mailclassify-incomplete-application/design.md
+++ b/openspec/changes/mailclassify-incomplete-application/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`StatusSignal` is the controlled vocabulary an email is classified into; unknown
+values coerce to `other` (`Sanitize`). Confident status skips the LLM via
+`KeywordStatus` for auto-linked emails. `signalStage` maps a signal to the stage
+it advances to; negative/non-progress signals are absent (never auto-advance).
+
+## Goals / Non-Goals
+
+**Goals:** capture the actionable "you did not finish applying" case as its own
+signal; keep it on the deterministic fast-path where possible; do not let it
+touch the application stage.
+
+**Non-Goals:** the descriptive interview-lifecycle split (invite/follow-up/
+feedback) — deliberately not added (no action attached). No schema change.
+
+## Decisions
+
+- **Non-advancing.** `incomplete_application` is left OUT of `signalStage`: an
+  unfinished application has not reached `applied`, so it must not move the stage.
+- **Keyword rule, ordered before acknowledgement.** Its phrases ("complete your
+  application", "application is incomplete", "finish your application", "action
+  required to complete") are templated and unambiguous; ordering it before the
+  acknowledgement templates prevents an "…thank you for starting your application,
+  please complete it…" email from resolving to acknowledgement.
+
+## Risks / Trade-offs
+
+- Minor overlap with `info_request` (both ask the user to act); the keyword rule
+  targets the "incomplete/complete your application" phrasing specifically, and
+  the ambiguous remainder still defers to the LLM.

--- a/openspec/changes/mailclassify-incomplete-application/proposal.md
+++ b/openspec/changes/mailclassify-incomplete-application/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Application emails include a distinct, actionable case the current vocabulary
+misses: the application was **started but not finished** ("your application is
+incomplete", "action required to complete your application"). Today these fall
+into `info_request` or `other`, burying a genuine to-do. Unlike the finer
+interview-lifecycle labels (invite/follow-up/feedback), which are descriptive
+only, "incomplete application" tells the user to *do* something.
+
+## What Changes
+
+- Add an `incomplete_application` status signal to the controlled vocabulary,
+  the LLM prompt, and the deterministic keyword fast-path (its language is
+  templated, so it stays off the LLM). It does NOT auto-advance the application
+  stage — an unfinished application has not progressed.
+- Surface it in the inbox status badge.
+
+## Capabilities
+
+### Modified Capabilities
+- `email-body-classification`: add `incomplete_application` to the classified
+  status vocabulary.
+
+## Impact
+
+- `internal/mailclassify/classification.go` (vocab + Sanitize), `classifier.go`
+  (prompt), `keyword.go` (fast-path rule).
+- `web/src/lib/emailStatus.ts` (badge label + colour).
+- No stage-mapping change (it is intentionally non-advancing). Existing emails
+  keep their labels; a re-classification applies it to history.

--- a/openspec/changes/mailclassify-incomplete-application/specs/email-body-classification/spec.md
+++ b/openspec/changes/mailclassify-incomplete-application/specs/email-body-classification/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Incomplete-application status
+
+The classifier SHALL recognise an `incomplete_application` status for emails
+telling the caller their application was started but not finished (e.g. "your
+application is incomplete", "action required to complete your application"), and
+SHALL NOT auto-advance the application stage on this signal (an unfinished
+application has not progressed).
+
+#### Scenario: Incomplete application is its own status
+
+- **WHEN** an email says the caller's application is incomplete and must be
+  completed
+- **THEN** it is classified as `incomplete_application`
+
+#### Scenario: Incomplete application does not advance the stage
+
+- **WHEN** an `incomplete_application` email is linked to an application
+- **THEN** the application's stage is not automatically advanced

--- a/openspec/changes/mailclassify-incomplete-application/tasks.md
+++ b/openspec/changes/mailclassify-incomplete-application/tasks.md
@@ -1,0 +1,18 @@
+## 1. Vocabulary + keyword
+
+- [x] 1.1 RED: test that `Sanitize` keeps `incomplete_application` (not coerced to
+      other) and that it is NOT in the stage-advancing map; test `KeywordStatus`
+      returns it for templated "complete your application" phrasing, ordered
+      before the acknowledgement opener.
+- [x] 1.2 GREEN: add `SignalIncompleteApplication` to the vocab + `validSignals`,
+      a keyword rule before acknowledgement, and the prompt category.
+
+## 2. Frontend badge
+
+- [x] 2.1 Add the `incomplete_application` label + colour to `emailStatus.ts`;
+      `svelte-check` clean.
+
+## 3. Verify
+
+- [x] 3.1 `go build/vet/test ./internal/mailclassify/... ./internal/maillink/...`
+      green; frontend build passes.

--- a/web/src/lib/emailStatus.ts
+++ b/web/src/lib/emailStatus.ts
@@ -9,6 +9,7 @@ export const STATUS_LABELS: Record<string, string> = {
   offer: 'Offer',
   rejection: 'Rejected',
   info_request: 'Info requested',
+  incomplete_application: 'Incomplete',
   other: '',
 };
 
@@ -20,6 +21,7 @@ export const STATUS_CLASSES: Record<string, string> = {
   offer: 'border-emerald-500/60 font-semibold text-emerald-700 dark:text-emerald-300',
   rejection: 'border-destructive/40 text-destructive',
   info_request: 'border-amber-400/50 text-amber-600 dark:text-amber-400',
+  incomplete_application: 'border-orange-400/50 text-orange-600 dark:text-orange-400',
   other: '',
 };
 


### PR DESCRIPTION
## Summary
- Adds an `incomplete_application` status signal — the actionable "you started but didn't finish your application" case, previously lost in `info_request`/`other`.
- Wired into the controlled vocabulary + `Sanitize`, the LLM prompt, and the deterministic keyword fast-path (templated phrasing like "complete your application", ordered before the acknowledgement templates so a "thank you for starting… please complete it" email resolves correctly).
- **Not** in `signalStage`: an unfinished application has not progressed, so it never auto-advances the stage.
- Inbox badge: renders as "Incomplete" (orange).

Deliberately scoped to the one label with a real to-do; the descriptive interview-lifecycle split (invite/follow-up/feedback) was considered and rejected (no action attached). Planned under OpenSpec `mailclassify-incomplete-application`.

## Test Plan
- [x] `Sanitize` keeps the new signal; `AdvanceStage` never advances on it (from `applied` or empty).
- [x] `KeywordStatus` returns it for templated "complete/finish your application" phrasing, ordered before acknowledgement.
- [x] `go build/vet/test ./internal/mailclassify/... ./internal/maillink/...`, gofmt clean; `svelte-check` 0 errors.

## Follow-up (ops)
The prompt changed, so historical emails keep their old labels — a re-classification (reset `classified_at`) applies the new signal to past mail.