### PR TITLE
feat(inbox): read-side triage — unread/label filters, mark-all-read, soft-delete

### DIFF
--- a/internal/db/gmail.sql.go
+++ b/internal/db/gmail.sql.go
@@ -15,25 +15,37 @@ const countEmails = `-- name: CountEmails :one
 SELECT count(*)
 FROM emails
 WHERE user_id = $1
+  AND deleted_at IS NULL
   AND ($2::text = '' OR source = $2)
+  AND ($3::bool = false OR read_at IS NULL)
+  AND ($4::text = '' OR status_signal = $4)
   AND (
-    $3::text = ''
-    OR subject   ILIKE '%' || $3 || '%'
-    OR from_name ILIKE '%' || $3 || '%'
-    OR from_addr ILIKE '%' || $3 || '%'
-    OR body_text ILIKE '%' || $3 || '%'
+    $5::text = ''
+    OR subject   ILIKE '%' || $5 || '%'
+    OR from_name ILIKE '%' || $5 || '%'
+    OR from_addr ILIKE '%' || $5 || '%'
+    OR body_text ILIKE '%' || $5 || '%'
   )
 `
 
 type CountEmailsParams struct {
 	UserID int64  `json:"user_id"`
 	Src    string `json:"src"`
+	Unread bool   `json:"unread"`
+	Status string `json:"status"`
 	Q      string `json:"q"`
 }
 
-// Total messages for the caller (same optional source + search), for pagination.
+// Total live messages for the caller (same optional filters as ListEmails), for
+// pagination.
 func (q *Queries) CountEmails(ctx context.Context, arg CountEmailsParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countEmails, arg.UserID, arg.Src, arg.Q)
+	row := q.db.QueryRow(ctx, countEmails,
+		arg.UserID,
+		arg.Src,
+		arg.Unread,
+		arg.Status,
+		arg.Q,
+	)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -73,7 +85,7 @@ SELECT emails.id, emails.source, emails.external_id, emails.s3_key, emails.from_
 FROM emails
 LEFT JOIN jobs lj ON lj.id = emails.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
-WHERE emails.id = $1 AND emails.user_id = $2
+WHERE emails.id = $1 AND emails.user_id = $2 AND emails.deleted_at IS NULL
 `
 
 type GetEmailParams struct {
@@ -222,21 +234,26 @@ FROM emails
 LEFT JOIN jobs lj ON lj.id = emails.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
 WHERE emails.user_id = $1
+  AND emails.deleted_at IS NULL
   AND ($2::text = '' OR emails.source = $2)
+  AND ($3::bool = false OR emails.read_at IS NULL)
+  AND ($4::text = '' OR emails.status_signal = $4)
   AND (
-    $3::text = ''
-    OR emails.subject   ILIKE '%' || $3 || '%'
-    OR emails.from_name ILIKE '%' || $3 || '%'
-    OR emails.from_addr ILIKE '%' || $3 || '%'
-    OR emails.body_text ILIKE '%' || $3 || '%'
+    $5::text = ''
+    OR emails.subject   ILIKE '%' || $5 || '%'
+    OR emails.from_name ILIKE '%' || $5 || '%'
+    OR emails.from_addr ILIKE '%' || $5 || '%'
+    OR emails.body_text ILIKE '%' || $5 || '%'
   )
 ORDER BY emails.received_at DESC, emails.id DESC
-LIMIT $5 OFFSET $4
+LIMIT $7 OFFSET $6
 `
 
 type ListEmailsParams struct {
 	UserID int64  `json:"user_id"`
 	Src    string `json:"src"`
+	Unread bool   `json:"unread"`
+	Status string `json:"status"`
 	Q      string `json:"q"`
 	Off    int32  `json:"off"`
 	Lim    int32  `json:"lim"`
@@ -262,9 +279,10 @@ type ListEmailsRow struct {
 	SuggestedCompany pgtype.Text        `json:"suggested_company"`
 }
 
-// Flat inbox listing, newest first — one row per message (no subject grouping).
-// An optional source filter (empty = all accounts) narrows to one source; an
-// optional search term (empty = no filter) matches subject, sender, or body. The
+// Flat inbox listing, newest first — one row per message (no subject grouping),
+// soft-deleted messages excluded. Optional filters (each empty/false = no filter):
+// source narrows to one account; unread hides already-read mail; status narrows to
+// one classified signal; the search term matches subject, sender, or body. The
 // snippet is the body's leading text with whitespace collapsed, for the list row.
 // The link/classification columns ride alongside so the inbox can render the
 // confirm chip and application link without a second lookup; the LEFT JOINs
@@ -273,6 +291,8 @@ func (q *Queries) ListEmails(ctx context.Context, arg ListEmailsParams) ([]ListE
 	rows, err := q.db.Query(ctx, listEmails,
 		arg.UserID,
 		arg.Src,
+		arg.Unread,
+		arg.Status,
 		arg.Q,
 		arg.Off,
 		arg.Lim,
@@ -313,6 +333,45 @@ func (q *Queries) ListEmails(ctx context.Context, arg ListEmailsParams) ([]ListE
 	return items, nil
 }
 
+const markAllEmailsRead = `-- name: MarkAllEmailsRead :execrows
+UPDATE emails SET read_at = now()
+WHERE user_id = $1
+  AND read_at IS NULL
+  AND deleted_at IS NULL
+  AND ($2::text = '' OR source = $2)
+  AND ($3::text = '' OR status_signal = $3)
+  AND (
+    $4::text = ''
+    OR subject   ILIKE '%' || $4 || '%'
+    OR from_name ILIKE '%' || $4 || '%'
+    OR from_addr ILIKE '%' || $4 || '%'
+    OR body_text ILIKE '%' || $4 || '%'
+  )
+`
+
+type MarkAllEmailsReadParams struct {
+	UserID int64  `json:"user_id"`
+	Src    string `json:"src"`
+	Status string `json:"status"`
+	Q      string `json:"q"`
+}
+
+// Bulk mark-as-read for the caller, honoring the same optional filters as the
+// listing, so "mark all read" means "everything currently shown". Only unread,
+// live rows are touched; returns how many it marked.
+func (q *Queries) MarkAllEmailsRead(ctx context.Context, arg MarkAllEmailsReadParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markAllEmailsRead,
+		arg.UserID,
+		arg.Src,
+		arg.Status,
+		arg.Q,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const markEmailRead = `-- name: MarkEmailRead :exec
 UPDATE emails SET read_at = now()
 WHERE id = $1 AND user_id = $2 AND read_at IS NULL
@@ -327,6 +386,26 @@ type MarkEmailReadParams struct {
 func (q *Queries) MarkEmailRead(ctx context.Context, arg MarkEmailReadParams) error {
 	_, err := q.db.Exec(ctx, markEmailRead, arg.ID, arg.UserID)
 	return err
+}
+
+const restoreEmail = `-- name: RestoreEmail :execrows
+UPDATE emails SET deleted_at = NULL
+WHERE id = $1 AND user_id = $2
+`
+
+type RestoreEmailParams struct {
+	ID     int64 `json:"id"`
+	UserID int64 `json:"user_id"`
+}
+
+// Undo a soft-delete, scoped to the caller and idempotent. Returns 0 rows only
+// when it is not the caller's message (→ 404).
+func (q *Queries) RestoreEmail(ctx context.Context, arg RestoreEmailParams) (int64, error) {
+	result, err := q.db.Exec(ctx, restoreEmail, arg.ID, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const setGmailStatus = `-- name: SetGmailStatus :exec
@@ -357,6 +436,27 @@ type SetGmailSyncedParams struct {
 func (q *Queries) SetGmailSynced(ctx context.Context, arg SetGmailSyncedParams) error {
 	_, err := q.db.Exec(ctx, setGmailSynced, arg.UserID, arg.SyncCursor)
 	return err
+}
+
+const softDeleteEmail = `-- name: SoftDeleteEmail :execrows
+UPDATE emails SET deleted_at = now()
+WHERE id = $1 AND user_id = $2
+`
+
+type SoftDeleteEmailParams struct {
+	ID     int64 `json:"id"`
+	UserID int64 `json:"user_id"`
+}
+
+// Soft-delete one message (hidden from the listing, retained for restore),
+// scoped to the caller and idempotent. Returns 0 rows only when it is not the
+// caller's message (→ 404).
+func (q *Queries) SoftDeleteEmail(ctx context.Context, arg SoftDeleteEmailParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteEmail, arg.ID, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const upsertEmail = `-- name: UpsertEmail :exec

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -85,6 +85,7 @@ type Email struct {
 	StatusSignal        pgtype.Text        `json:"status_signal"`
 	ClassifiedAt        pgtype.Timestamptz `json:"classified_at"`
 	ClassificationModel pgtype.Text        `json:"classification_model"`
+	DeletedAt           pgtype.Timestamptz `json:"deleted_at"`
 }
 
 type EmailClassificationOutbox struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -135,7 +135,8 @@ type Querier interface {
 	// so search/filter pagination reports the filtered total. Keep this WHERE identical
 	// to ListCompanies.
 	CountCompanies(ctx context.Context, arg CountCompaniesParams) (int64, error)
-	// Total messages for the caller (same optional source + search), for pagination.
+	// Total live messages for the caller (same optional filters as ListEmails), for
+	// pagination.
 	CountEmails(ctx context.Context, arg CountEmailsParams) (int64, error)
 	// Per-stage application counts for the Pipeline snapshot. An application is any
 	// row the user applied to or staged (saved-only rows are excluded); a row with
@@ -435,9 +436,10 @@ type Querier interface {
 	ListCompanySitemap(ctx context.Context, arg ListCompanySitemapParams) ([]ListCompanySitemapRow, error)
 	// Drives the sync worker: every connection still authorized.
 	ListConnectedGmailUsers(ctx context.Context) ([]ListConnectedGmailUsersRow, error)
-	// Flat inbox listing, newest first — one row per message (no subject grouping).
-	// An optional source filter (empty = all accounts) narrows to one source; an
-	// optional search term (empty = no filter) matches subject, sender, or body. The
+	// Flat inbox listing, newest first — one row per message (no subject grouping),
+	// soft-deleted messages excluded. Optional filters (each empty/false = no filter):
+	// source narrows to one account; unread hides already-read mail; status narrows to
+	// one classified signal; the search term matches subject, sender, or body. The
 	// snippet is the body's leading text with whitespace collapsed, for the list row.
 	// The link/classification columns ride alongside so the inbox can render the
 	// confirm chip and application link without a second lookup; the LEFT JOINs
@@ -566,6 +568,10 @@ type Querier interface {
 	// Closed jobs are included: dimming a closed posting that still shows in a
 	// history surface is correct, and the browse list filters closed jobs itself.
 	ListViewedJobSlugs(ctx context.Context, userID int64) ([]string, error)
+	// Bulk mark-as-read for the caller, honoring the same optional filters as the
+	// listing, so "mark all read" means "everything currently shown". Only unread,
+	// live rows are touched; returns how many it marked.
+	MarkAllEmailsRead(ctx context.Context, arg MarkAllEmailsReadParams) (int64, error)
 	// Stamp read on first open; a no-op once already read.
 	MarkEmailRead(ctx context.Context, arg MarkEmailReadParams) error
 	// Mark a job as applied for a user. Idempotent and independent of a prior view:
@@ -703,6 +709,9 @@ type Querier interface {
 	// expired probes can close a job. Guarded to the non-zero case so probing an
 	// already-clean job does not churn the row.
 	ResetLivenessStrikes(ctx context.Context, id int64) error
+	// Undo a soft-delete, scoped to the caller and idempotent. Returns 0 rows only
+	// when it is not the caller's message (→ 404).
+	RestoreEmail(ctx context.Context, arg RestoreEmailParams) (int64, error)
 	// The job-reality repost/mass-posting counts for one role cluster: how many postings
 	// of the same role (by role_fingerprint within a company) exist of any status
 	// (repost_count = repost history) and how many are still open (mass_count = concurrent
@@ -775,6 +784,10 @@ type Querier interface {
 	// time) matches no row and is dropped, so a late writer can't clobber a newer CV's
 	// structure with an already-stale stamp (which Store.Structured would then hide forever).
 	SetUserResumeStructured(ctx context.Context, arg SetUserResumeStructuredParams) error
+	// Soft-delete one message (hidden from the listing, retained for restore),
+	// scoped to the caller and idempotent. Returns 0 rows only when it is not the
+	// caller's message (→ 404).
+	SoftDeleteEmail(ctx context.Context, arg SoftDeleteEmailParams) (int64, error)
 	// Record that a batch of jobs' content is embedded under the given model. Run in the
 	// same transaction as DeleteSemanticEntriesBatch on the success path, so a crash between
 	// the index write and this stamp is safely retried (idempotent re-embed). The stamp

--- a/internal/db/queries/gmail.sql
+++ b/internal/db/queries/gmail.sql
@@ -50,9 +50,10 @@ INSERT INTO emails (
 ON CONFLICT (user_id, source, external_id) DO NOTHING;
 
 -- name: ListEmails :many
--- Flat inbox listing, newest first — one row per message (no subject grouping).
--- An optional source filter (empty = all accounts) narrows to one source; an
--- optional search term (empty = no filter) matches subject, sender, or body. The
+-- Flat inbox listing, newest first — one row per message (no subject grouping),
+-- soft-deleted messages excluded. Optional filters (each empty/false = no filter):
+-- source narrows to one account; unread hides already-read mail; status narrows to
+-- one classified signal; the search term matches subject, sender, or body. The
 -- snippet is the body's leading text with whitespace collapsed, for the list row.
 -- The link/classification columns ride alongside so the inbox can render the
 -- confirm chip and application link without a second lookup; the LEFT JOINs
@@ -67,7 +68,10 @@ FROM emails
 LEFT JOIN jobs lj ON lj.id = emails.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
 WHERE emails.user_id = $1
+  AND emails.deleted_at IS NULL
   AND (sqlc.arg(src)::text = '' OR emails.source = sqlc.arg(src))
+  AND (sqlc.arg(unread)::bool = false OR emails.read_at IS NULL)
+  AND (sqlc.arg(status)::text = '' OR emails.status_signal = sqlc.arg(status))
   AND (
     sqlc.arg(q)::text = ''
     OR emails.subject   ILIKE '%' || sqlc.arg(q) || '%'
@@ -79,11 +83,15 @@ ORDER BY emails.received_at DESC, emails.id DESC
 LIMIT sqlc.arg(lim) OFFSET sqlc.arg(off);
 
 -- name: CountEmails :one
--- Total messages for the caller (same optional source + search), for pagination.
+-- Total live messages for the caller (same optional filters as ListEmails), for
+-- pagination.
 SELECT count(*)
 FROM emails
 WHERE user_id = $1
+  AND deleted_at IS NULL
   AND (sqlc.arg(src)::text = '' OR source = sqlc.arg(src))
+  AND (sqlc.arg(unread)::bool = false OR read_at IS NULL)
+  AND (sqlc.arg(status)::text = '' OR status_signal = sqlc.arg(status))
   AND (
     sqlc.arg(q)::text = ''
     OR subject   ILIKE '%' || sqlc.arg(q) || '%'
@@ -101,9 +109,40 @@ SELECT emails.id, emails.source, emails.external_id, emails.s3_key, emails.from_
 FROM emails
 LEFT JOIN jobs lj ON lj.id = emails.job_id
 LEFT JOIN jobs sj ON sj.id = emails.suggested_job_id
-WHERE emails.id = $1 AND emails.user_id = $2;
+WHERE emails.id = $1 AND emails.user_id = $2 AND emails.deleted_at IS NULL;
 
 -- name: MarkEmailRead :exec
 -- Stamp read on first open; a no-op once already read.
 UPDATE emails SET read_at = now()
 WHERE id = $1 AND user_id = $2 AND read_at IS NULL;
+
+-- name: MarkAllEmailsRead :execrows
+-- Bulk mark-as-read for the caller, honoring the same optional filters as the
+-- listing, so "mark all read" means "everything currently shown". Only unread,
+-- live rows are touched; returns how many it marked.
+UPDATE emails SET read_at = now()
+WHERE user_id = $1
+  AND read_at IS NULL
+  AND deleted_at IS NULL
+  AND (sqlc.arg(src)::text = '' OR source = sqlc.arg(src))
+  AND (sqlc.arg(status)::text = '' OR status_signal = sqlc.arg(status))
+  AND (
+    sqlc.arg(q)::text = ''
+    OR subject   ILIKE '%' || sqlc.arg(q) || '%'
+    OR from_name ILIKE '%' || sqlc.arg(q) || '%'
+    OR from_addr ILIKE '%' || sqlc.arg(q) || '%'
+    OR body_text ILIKE '%' || sqlc.arg(q) || '%'
+  );
+
+-- name: SoftDeleteEmail :execrows
+-- Soft-delete one message (hidden from the listing, retained for restore),
+-- scoped to the caller and idempotent. Returns 0 rows only when it is not the
+-- caller's message (→ 404).
+UPDATE emails SET deleted_at = now()
+WHERE id = $1 AND user_id = $2;
+
+-- name: RestoreEmail :execrows
+-- Undo a soft-delete, scoped to the caller and idempotent. Returns 0 rows only
+-- when it is not the caller's message (→ 404).
+UPDATE emails SET deleted_at = NULL
+WHERE id = $1 AND user_id = $2;

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -397,7 +397,10 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/me/gmail", saved, requireMail, a.GmailStatus)
 	api.Delete("/me/gmail", saved, requireMail, a.GmailDisconnect)
 	api.Get("/me/inbox", saved, requireMail, a.GetInbox)
+	api.Post("/me/inbox/read-all", saved, requireMail, a.MarkAllReadInbox)
 	api.Get("/me/emails/:id", saved, requireMail, a.GetEmail)
+	api.Post("/me/emails/:id/delete", saved, requireMail, a.DeleteEmail)
+	api.Post("/me/emails/:id/restore", saved, requireMail, a.RestoreEmail)
 	// Email → application linking. The detail endpoint exposes mail, so it rides the
 	// same mail gate; :slug is registered after the static /me/tracking/* routes above
 	// so it does not shadow them.

--- a/internal/handler/inbox.go
+++ b/internal/handler/inbox.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/mailclassify"
 )
 
 // inboxSources is the account-switcher vocabulary: "" means all accounts.
@@ -62,27 +63,54 @@ type emailBody struct {
 	emailLinking
 }
 
-// GetInbox returns the caller's mail as a flat list, newest first. An optional
-// ?source= (gmail|hosted) filters to one account (the switcher); ?q= searches
-// subject/sender/body; standard limit/offset pagination.
+// inboxFilters are the shared listing filters carried by the query string:
+// ?source=(gmail|hosted), ?unread=1, ?status=<signal>, ?q=<term>.
+type inboxFilters struct {
+	Source string
+	Unread bool
+	Status string
+	Q      string
+}
+
+// parseInboxFilters reads and validates the inbox filter query params. Source and
+// status are validated against their vocabularies; an unknown value is a 400
+// rather than a silently empty listing.
+func parseInboxFilters(c *fiber.Ctx) (inboxFilters, error) {
+	src := c.Query("source")
+	if !inboxSources[src] {
+		return inboxFilters{}, fiber.NewError(fiber.StatusBadRequest, "unknown source")
+	}
+	status := c.Query("status")
+	if status != "" && !mailclassify.IsValidSignal(status) {
+		return inboxFilters{}, fiber.NewError(fiber.StatusBadRequest, "unknown label")
+	}
+	return inboxFilters{Source: src, Unread: c.QueryBool("unread"), Status: status, Q: c.Query("q")}, nil
+}
+
+// GetInbox returns the caller's mail as a flat list, newest first, excluding
+// soft-deleted messages. Optional filters: ?source= (account switcher), ?unread=1
+// (hide read), ?status= (one classified label), ?q= (subject/sender/body search);
+// standard limit/offset pagination.
 func (a *API) GetInbox(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
 		return err
 	}
-	src := c.Query("source")
-	if !inboxSources[src] {
-		return fiber.NewError(fiber.StatusBadRequest, "unknown source")
+	f, err := parseInboxFilters(c)
+	if err != nil {
+		return err
 	}
-	q := c.Query("q")
 	limit, offset := pageParams(c) // default 20, clamped
 	rows, err := a.queries.ListEmails(c.Context(), db.ListEmailsParams{
-		UserID: userID, Src: src, Q: q, Lim: int32(limit), Off: int32(offset),
+		UserID: userID, Src: f.Source, Unread: f.Unread, Status: f.Status, Q: f.Q,
+		Lim: int32(limit), Off: int32(offset),
 	})
 	if err != nil {
 		return err
 	}
-	total, err := a.queries.CountEmails(c.Context(), db.CountEmailsParams{UserID: userID, Src: src, Q: q})
+	total, err := a.queries.CountEmails(c.Context(), db.CountEmailsParams{
+		UserID: userID, Src: f.Source, Unread: f.Unread, Status: f.Status, Q: f.Q,
+	})
 	if err != nil {
 		return err
 	}
@@ -135,4 +163,61 @@ func (a *API) GetEmail(c *fiber.Ctx) error {
 			SuggestedCompany: pgStr(row.SuggestedCompany),
 		},
 	}})
+}
+
+// MarkAllReadInbox marks every unread message matching the caller's active
+// filters (source/status/search) as read and reports how many it marked. The
+// unread filter is implicit — the query only ever touches unread rows.
+func (a *API) MarkAllReadInbox(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	f, err := parseInboxFilters(c)
+	if err != nil {
+		return err
+	}
+	marked, err := a.queries.MarkAllEmailsRead(c.Context(), db.MarkAllEmailsReadParams{
+		UserID: userID, Src: f.Source, Status: f.Status, Q: f.Q,
+	})
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": fiber.Map{"marked": marked}})
+}
+
+// DeleteEmail soft-deletes one message, scoped to the caller (404 if not theirs).
+func (a *API) DeleteEmail(c *fiber.Ctx) error {
+	return a.setEmailDeleted(c, true)
+}
+
+// RestoreEmail undoes a soft-delete, scoped to the caller (404 if not theirs).
+func (a *API) RestoreEmail(c *fiber.Ctx) error {
+	return a.setEmailDeleted(c, false)
+}
+
+// setEmailDeleted flips one message's soft-delete flag (delete or restore),
+// scoped to the caller. A message that is not theirs matches no row → 404.
+func (a *API) setEmailDeleted(c *fiber.Ctx, deleted bool) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := c.ParamsInt("id")
+	if err != nil {
+		return fiber.NewError(fiber.StatusNotFound, "not found")
+	}
+	var n int64
+	if deleted {
+		n, err = a.queries.SoftDeleteEmail(c.Context(), db.SoftDeleteEmailParams{ID: int64(id), UserID: userID})
+	} else {
+		n, err = a.queries.RestoreEmail(c.Context(), db.RestoreEmailParams{ID: int64(id), UserID: userID})
+	}
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fiber.NewError(fiber.StatusNotFound, "not found")
+	}
+	return c.SendStatus(fiber.StatusOK)
 }

--- a/internal/handler/inbox_integration_test.go
+++ b/internal/handler/inbox_integration_test.go
@@ -1,0 +1,176 @@
+//go:build integration
+
+// Integration tests for the inbox read-side triage controls against a real
+// Postgres: the unread-only and label filters, mark-all-read (respecting the
+// active filters), and per-message soft-delete + restore. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestInboxReadSideEndToEnd(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var uid int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('triage@example.test') RETURNING id`).Scan(&uid); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	// Three messages: an unread rejection, a read interview invite, and an unread
+	// message with no classification — enough to exercise every filter.
+	seed := func(ext, subject, status string, read bool) int64 {
+		var readAt any // nil → NULL (unread)
+		if read {
+			readAt = time.Now()
+		}
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO emails (user_id, source, external_id, subject, body_text, status_signal, received_at, read_at)
+			 VALUES ($1, 'hosted', $2, $3, 'body', $4, now(), $5) RETURNING id`,
+			uid, ext, subject, status, readAt).Scan(&id); err != nil {
+			t.Fatalf("seed email %s: %v", ext, err)
+		}
+		return id
+	}
+	rejID := seed("m-rej", "Rejection", "rejection", false)
+	_ = seed("m-int", "Interview", "interview_invitation", true)
+	_ = seed("m-plain", "Plain", "", false)
+
+	iss := auth.NewIssuer("test-secret-that-is-long-enough-0001", time.Hour)
+	cookie, _ := iss.Issue(uid)
+	h := &API{pool: pool, queries: db.New(pool), issuer: iss, mailDomain: "inbox.freehire.test"}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	ra := auth.RequireAuth(iss)
+	app.Get("/api/v1/me/inbox", ra, h.GetInbox)
+	app.Get("/api/v1/me/emails/:id", ra, h.GetEmail)
+	app.Post("/api/v1/me/inbox/read-all", ra, h.MarkAllReadInbox)
+	app.Post("/api/v1/me/emails/:id/delete", ra, h.DeleteEmail)
+	app.Post("/api/v1/me/emails/:id/restore", ra, h.RestoreEmail)
+
+	do := func(method, path string) (int, map[string]any) {
+		r := httptest.NewRequest(method, path, nil)
+		r.AddCookie(&http.Cookie{Name: auth.CookieName, Value: cookie})
+		resp, err := app.Test(r, -1)
+		if err != nil {
+			t.Fatalf("%s %s: %v", method, path, err)
+		}
+		b, _ := io.ReadAll(resp.Body)
+		var body map[string]any
+		_ = json.Unmarshal(b, &body)
+		return resp.StatusCode, body
+	}
+	listLen := func(path string) int {
+		_, body := do("GET", path)
+		g, _ := body["data"].([]any)
+		return len(g)
+	}
+
+	// Baseline: all three visible.
+	if n := listLen("/api/v1/me/inbox"); n != 3 {
+		t.Fatalf("baseline inbox = %d, want 3", n)
+	}
+
+	// Unread-only filter: hides the read interview invite.
+	if n := listLen("/api/v1/me/inbox?unread=1"); n != 2 {
+		t.Errorf("unread filter = %d, want 2", n)
+	}
+
+	// Label filter: only the rejection.
+	if n := listLen("/api/v1/me/inbox?status=rejection"); n != 1 {
+		t.Errorf("label filter = %d, want 1", n)
+	}
+	// Unknown label is a 400, not a silent empty list.
+	if code, _ := do("GET", "/api/v1/me/inbox?status=bogus"); code != 400 {
+		t.Errorf("unknown label status = %d, want 400", code)
+	}
+
+	// Mark-all-read under the unread filter marks the two unread ones read; the
+	// unread list then empties. The interview invite was already read.
+	if code, _ := do("POST", "/api/v1/me/inbox/read-all?unread=1"); code != 200 {
+		t.Errorf("mark-all-read status = %d", code)
+	}
+	if n := listLen("/api/v1/me/inbox?unread=1"); n != 0 {
+		t.Errorf("unread after mark-all = %d, want 0", n)
+	}
+
+	// Soft-delete the rejection: it drops out of the listing.
+	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(rejID, 10)+"/delete"); code != 200 {
+		t.Errorf("delete status = %d", code)
+	}
+	if n := listLen("/api/v1/me/inbox"); n != 2 {
+		t.Errorf("inbox after delete = %d, want 2", n)
+	}
+	// A soft-deleted message is not readable by direct id either — 404, consistent
+	// with the listing that now hides it.
+	if code, _ := do("GET", "/api/v1/me/emails/"+strconv.FormatInt(rejID, 10)); code != 404 {
+		t.Errorf("GET deleted email = %d, want 404", code)
+	}
+	// Restore brings it back.
+	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(rejID, 10)+"/restore"); code != 200 {
+		t.Errorf("restore status = %d", code)
+	}
+	if n := listLen("/api/v1/me/inbox"); n != 3 {
+		t.Errorf("inbox after restore = %d, want 3", n)
+	}
+
+	// Deleting another user's message is a 404.
+	var otherUID int64
+	_ = pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('other@example.test') RETURNING id`).Scan(&otherUID)
+	var otherID int64
+	_ = pool.QueryRow(ctx,
+		`INSERT INTO emails (user_id, source, external_id, subject, body_text, received_at)
+		 VALUES ($1, 'hosted', 'x1', 'Theirs', 'body', now()) RETURNING id`, otherUID).Scan(&otherID)
+	if code, _ := do("POST", "/api/v1/me/emails/"+strconv.FormatInt(otherID, 10)+"/delete"); code != 404 {
+		t.Errorf("cross-user delete = %d, want 404", code)
+	}
+}
+
+// TestSoftDeleteSurvivesResync proves a soft-deleted Gmail message stays deleted
+// when the sync worker re-encounters it: UpsertEmail is ON CONFLICT DO NOTHING,
+// so it never clears deleted_at.
+func TestSoftDeleteSurvivesResync(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	q := db.New(pool)
+
+	var uid int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('resync@example.test') RETURNING id`).Scan(&uid); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	now := pgtype.Timestamptz{Time: time.Now(), Valid: true}
+	if err := q.UpsertEmail(ctx, db.UpsertEmailParams{UserID: uid, ExternalID: "g-sync", Subject: "First", ReceivedAt: now}); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE emails SET deleted_at = now() WHERE user_id=$1 AND external_id='g-sync'`, uid); err != nil {
+		t.Fatalf("soft-delete: %v", err)
+	}
+
+	// Re-sync the same message.
+	if err := q.UpsertEmail(ctx, db.UpsertEmailParams{UserID: uid, ExternalID: "g-sync", Subject: "First", ReceivedAt: now}); err != nil {
+		t.Fatalf("re-sync upsert: %v", err)
+	}
+
+	rows, err := q.ListEmails(ctx, db.ListEmailsParams{UserID: uid, Lim: 20})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("re-synced deleted message reappeared: %d rows, want 0", len(rows))
+	}
+}

--- a/internal/mailclassify/classification.go
+++ b/internal/mailclassify/classification.go
@@ -26,6 +26,12 @@ var validSignals = map[StatusSignal]bool{
 	SignalInfoRequest: true, SignalOther: true,
 }
 
+// IsValidSignal reports whether s is a known classification label — used to
+// validate a caller-supplied inbox label filter before it reaches the query.
+func IsValidSignal(s string) bool {
+	return validSignals[StatusSignal(s)]
+}
+
 // Classification is the LLM output for one email: the status signal, a
 // confidence in [0,1], and (only used when deterministic matching was
 // ambiguous/none) the disambiguation pick — 0 meaning "none".

--- a/migrations/0022_emails_deleted_at.sql
+++ b/migrations/0022_emails_deleted_at.sql
@@ -1,0 +1,13 @@
+-- Inbox soft-delete: a deleted message is hidden from the listing but retained
+-- (recoverable via Undo / restore). Gmail's UpsertEmail is ON CONFLICT DO NOTHING,
+-- so a re-synced message never clears this flag — soft-delete is durable.
+--
+-- initdb applies this once on a fresh volume; on an existing prod volume apply it
+-- by hand before deploying the new binary (no versioned runner yet).
+
+ALTER TABLE emails ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+
+-- The per-user newest-first listing only ever reads live rows; a partial index
+-- keeps that scan off soft-deleted tombstones.
+CREATE INDEX IF NOT EXISTS emails_user_live_idx
+    ON emails (user_id, received_at DESC) WHERE deleted_at IS NULL;

--- a/openspec/changes/inbox-read-side-enhancements/.openspec.yaml
+++ b/openspec/changes/inbox-read-side-enhancements/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/inbox-read-side-enhancements/design.md
+++ b/openspec/changes/inbox-read-side-enhancements/design.md
@@ -1,0 +1,72 @@
+## Context
+
+`/my/inbox` is a read-only aggregator over the shared `emails` table (Gmail sync
++ hosted SES intake). `ListEmails`/`CountEmails` already filter by `user_id`, an
+optional `src`, and an optional `q`, ordered `received_at DESC`. `read` is
+derived (`read_at IS NOT NULL`), not a stored boolean; `status_signal` holds the
+mailclassify label. The frontend `InboxView.svelte` toolbar is `[account
+switcher] [search] [Refresh]` and already carries an optimistic Undo pattern for
+unlink. Full brainstormed spec:
+`docs/superpowers/specs/2026-07-15-inbox-read-side-enhancements-design.md`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Triage controls over existing data: unread filter, label filter, bulk
+  mark-all-read, and per-message soft-delete with Undo.
+- Reuse existing patterns (optional `sqlc.arg = '' OR ...` filters, the unlink
+  Undo UX, the `emailStatus.ts` vocabulary). Minimal new surface.
+
+**Non-Goals:**
+- Priority sort, outbound mail (Reply/Forward/Sent), a folder dropdown, and a
+  persistent "Deleted" folder view.
+
+## Decisions
+
+**Soft-delete via a `deleted_at` column, not a status enum or hard delete.**
+A nullable timestamp is the least invasive: listing excludes `deleted_at IS NOT
+NULL`, restore clears it. Hard delete was rejected because a deleted Gmail
+message would reappear on the next sync; a status enum was overkill for a binary
+state. Gmail's `UpsertEmail` is `ON CONFLICT DO NOTHING`, so re-sync never clears
+the flag — soft-delete is durable with no extra guard.
+
+**Filters ride the existing optional-arg idiom.** `unread` and `status` extend
+`ListEmails`/`CountEmails` with `(sqlc.arg(x) = <empty> OR predicate)`, matching
+how `src`/`q` already work. No new query shape, and the count stays consistent
+with the listing.
+
+**Mark-all-read respects active filters, not the whole mailbox.** The bulk
+`UPDATE` takes the same source/unread/label/search args as the listing, so "mark
+all read" means "everything currently shown". This is more predictable than a
+blind whole-mailbox mark and avoids surprising the user when a filter is active.
+(User-confirmed during brainstorming.)
+
+**`status` is validated against the mailclassify vocabulary.** An unknown label
+is a 400, mirroring the existing `inboxSources` guard — keeps the query from
+silently returning empty on a typo.
+
+## Risks / Trade-offs
+
+- [No Deleted folder means deleted mail is only recoverable via the immediate
+  Undo] → Acceptable: chosen deliberately; the row is soft-deleted (recoverable
+  in the DB) even though the UI offers no browse-deleted view this iteration.
+- [Mark-all-read is not itself undoable] → Low impact: marking read is
+  low-stakes and reversible only per-message is fine; we do not add bulk-undo.
+- [`unread`/`status` filters increase `ListEmails` WHERE complexity] → The new
+  partial index on live rows plus the existing `(user_id, received_at)` index
+  keep it cheap; filters are equality/`IS NULL`, sargable.
+
+## Migration Plan
+
+1. Apply migration `0022_emails_deleted_at.sql` (add column + partial index) —
+   backward compatible; existing rows have `deleted_at = NULL` (live).
+2. Deploy backend (new queries + endpoints) — old clients keep working; new
+   params are optional.
+3. Deploy web (toolbar controls + Delete/Undo).
+
+Rollback: the column is additive and unused by old code; no data migration to
+reverse.
+
+## Open Questions
+
+None — scope and the mark-all-read semantics were settled during brainstorming.

--- a/openspec/changes/inbox-read-side-enhancements/proposal.md
+++ b/openspec/changes/inbox-read-side-enhancements/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+The `/my/inbox` surface is a read-only aggregator with only account-switch and
+search controls. As a user's ATS mail piles up, they need to triage it: hide
+what they've read, focus one classification, clear the unread pile, and remove
+noise. These are all read-side operations we can build on data we already have
+(`read_at`, `status_signal`) plus one soft-delete flag.
+
+## What Changes
+
+- Add an **Unread only** filter to the inbox listing (messages with no `read_at`).
+- Add an **All Labels** filter that narrows the listing to one `status_signal`
+  (the existing mailclassify classification), validated against the vocabulary.
+- Add **Mark all read**: a bulk action that marks every message matching the
+  currently active filters (source / unread / label / search) as read.
+- Add **Delete** as a soft-delete (`deleted_at`): deleted mail is hidden from the
+  listing and offers an inline **Undo** (restore), mirroring the existing
+  unlink-Undo pattern. No separate "Deleted" folder.
+
+Out of scope (explicitly deferred): Priority sort, outbound mail
+(Reply/Forward/Sent), and a folder dropdown.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `email-inbox`: the inbox listing gains unread and label filters; a bulk
+  mark-all-read action; and a per-message soft-delete with Undo.
+
+## Impact
+
+- Migration: `emails` gains a nullable `deleted_at` column + a partial index on
+  live rows.
+- SQL (`internal/db/queries/gmail.sql`): `ListEmails`/`CountEmails` exclude
+  soft-deleted rows and accept `unread`/`status` filters; new `MarkAllEmailsRead`,
+  `SoftDeleteEmail`, `RestoreEmail` queries.
+- API (`internal/handler/inbox.go` + routes): `GetInbox` accepts `unread` and
+  `status`; new `POST /me/inbox/read-all`, `POST /me/emails/:id/delete`,
+  `POST /me/emails/:id/restore`.
+- Web (`web/src/lib/api.ts`, `web/src/lib/components/InboxView.svelte`): new
+  toolbar controls and Delete/Undo wiring; reuses `emailStatus.ts` vocabulary.

--- a/openspec/changes/inbox-read-side-enhancements/specs/email-inbox/spec.md
+++ b/openspec/changes/inbox-read-side-enhancements/specs/email-inbox/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Unread-only inbox filter
+
+The inbox listing SHALL accept an optional unread-only filter that restricts the
+returned messages to those the caller has not yet read. The filter SHALL compose
+with the existing account-source and search filters and SHALL be reflected in the
+message count used for pagination.
+
+#### Scenario: Unread filter narrows the listing
+
+- **WHEN** an authenticated user requests the inbox with the unread-only filter on
+- **THEN** only messages with no read timestamp are returned, and the total count reflects only those
+
+#### Scenario: Unread filter composes with source and search
+
+- **WHEN** the unread-only filter is combined with an account source and a search term
+- **THEN** the listing returns only unread messages of that source matching the search
+
+### Requirement: Label filter by classified status
+
+The inbox listing SHALL accept an optional label filter that restricts the
+returned messages to a single classified status signal. The filter value MUST be
+one of the known classification labels; an unknown value SHALL be rejected with a
+client error rather than silently returning nothing.
+
+#### Scenario: Label filter narrows to one status
+
+- **WHEN** an authenticated user requests the inbox filtered to a valid status label
+- **THEN** only messages classified with that status are returned
+
+#### Scenario: Unknown label is rejected
+
+- **WHEN** the inbox is requested with a label value that is not a known classification
+- **THEN** the request is rejected with a 400 error
+
+### Requirement: Mark all read respecting active filters
+
+The system SHALL expose an action that marks every unread message matching the
+caller's currently active filters (account source, unread, label, and search) as
+read, scoped to the caller, and SHALL leave soft-deleted messages untouched. The
+action SHALL report how many messages it marked.
+
+#### Scenario: Mark all read under a filter
+
+- **WHEN** the caller invokes mark-all-read while a label filter is active
+- **THEN** only unread messages matching that filter become read
+- **AND** messages outside the filter remain unchanged
+
+#### Scenario: Scoped to caller
+
+- **WHEN** the caller invokes mark-all-read
+- **THEN** only their own messages are affected, never another user's
+
+### Requirement: Soft-delete a message with Undo
+
+The inbox SHALL let the caller delete a message, which soft-deletes it: the
+message is hidden from the listing and its count but is retained and can be
+restored. Immediately after a delete the inbox SHALL offer an Undo that restores
+the message. Delete and restore SHALL be scoped to the caller, and a message that
+is not the caller's SHALL be a 404. A soft-deleted message SHALL remain deleted
+across a re-sync of its source.
+
+#### Scenario: Deleting hides the message
+
+- **WHEN** the caller deletes a message
+- **THEN** the message no longer appears in the listing and is excluded from the count
+
+#### Scenario: Undo restores the message
+
+- **WHEN** the caller deletes a message and then chooses Undo
+- **THEN** the message is restored and appears in the listing again
+
+#### Scenario: Delete is scoped to the caller
+
+- **WHEN** a user attempts to delete or restore a message that is not theirs
+- **THEN** the request returns a 404 and no message is changed
+
+#### Scenario: Soft-delete survives re-sync
+
+- **WHEN** a soft-deleted Gmail message is re-encountered during a later sync
+- **THEN** it stays deleted rather than reappearing in the listing

--- a/openspec/changes/inbox-read-side-enhancements/tasks.md
+++ b/openspec/changes/inbox-read-side-enhancements/tasks.md
@@ -1,0 +1,33 @@
+## 1. Data & SQL layer
+
+- [ ] 1.1 Add migration `migrations/0022_emails_deleted_at.sql`: `ALTER TABLE emails ADD COLUMN deleted_at timestamptz` + partial index `emails_user_live_idx ON emails (user_id, received_at DESC) WHERE deleted_at IS NULL`
+- [ ] 1.2 Extend `ListEmails`/`CountEmails` in `internal/db/queries/gmail.sql`: exclude `deleted_at IS NOT NULL`, add optional `unread` (bool) and `status` (text) filters via the existing `sqlc.arg = <empty> OR predicate` idiom
+- [ ] 1.3 Add `MarkAllEmailsRead` (`:execrows`) taking the same source/unread/status/search args, updating only unread, non-deleted rows scoped to the user
+- [ ] 1.4 Add `SoftDeleteEmail` and `RestoreEmail` (`SET deleted_at = now()` / `= NULL`, scoped by `id + user_id`)
+- [ ] 1.5 Regenerate sqlc (`make sqlc`) and confirm `go build ./...`
+
+## 2. Backend handlers & routes
+
+- [ ] 2.1 In `internal/handler/inbox.go`, extend `GetInbox` to read `?unread=1` and `?status=<signal>`, validating `status` against the mailclassify vocabulary (400 on unknown) and passing both into the query
+- [ ] 2.2 Add `MarkAllReadInbox` handler (reads the same query filters) + route `POST /me/inbox/read-all`
+- [ ] 2.3 Add `DeleteEmail` + `RestoreEmail` handlers + routes `POST /me/emails/:id/delete` and `POST /me/emails/:id/restore`, scoped to the caller (404 for another user's message)
+- [ ] 2.4 Integration test (build-tag, like `mailbox_integration_test.go`): `ListEmails` with `unread`/`status`/`deleted_at`; `MarkAllEmailsRead` honoring filters; soft-delete/restore round-trip
+
+## 3. Frontend API client
+
+- [ ] 3.1 In `web/src/lib/api.ts`, add optional `unread`/`status` params to `getInbox`, and new methods `markAllRead`, `deleteEmail`, `restoreEmail`
+
+## 4. Frontend toolbar filters
+
+- [ ] 4.1 In `InboxView.svelte`, add `unread`/`label` `$state` and wire an **Unread only** toggle + **All Labels** dropdown (from `emailStatus.ts` `STATUS_LABELS`) that call `reloadList()` on change; thread both into `fetchFirstPage()`
+- [ ] 4.2 Update the empty-state copy to "No mail matches your filters" when a filter is active
+
+## 5. Frontend mark-all-read & delete/undo
+
+- [ ] 5.1 Add a **Mark all read** toolbar button: call `api.markAllRead(...)`, optimistically mark visible rows read, drop the unread count; on error `reloadList()`
+- [ ] 5.2 Add a **Delete** control (reading pane) with optimistic removal, `total` decrement, and a "Deleted · Undo" toast reusing the `lastUnlinked`/`undoUnlink` pattern (`lastDeleted` + `restoreEmail`)
+
+## 6. Verify
+
+- [ ] 6.1 `go build ./... && go vet ./... && go test ./...`
+- [ ] 6.2 Web: `svelte-check` clean + visual check of the toolbar (throwaway route + headless Chrome)

--- a/openspec/changes/inbox-read-side-enhancements/tasks.md
+++ b/openspec/changes/inbox-read-side-enhancements/tasks.md
@@ -15,19 +15,19 @@
 
 ## 3. Frontend API client
 
-- [ ] 3.1 In `web/src/lib/api.ts`, add optional `unread`/`status` params to `getInbox`, and new methods `markAllRead`, `deleteEmail`, `restoreEmail`
+- [x] 3.1 In `web/src/lib/api.ts`, add optional `unread`/`status` params to `getInbox`, and new methods `markAllRead`, `deleteEmail`, `restoreEmail`
 
 ## 4. Frontend toolbar filters
 
-- [ ] 4.1 In `InboxView.svelte`, add `unread`/`label` `$state` and wire an **Unread only** toggle + **All Labels** dropdown (from `emailStatus.ts` `STATUS_LABELS`) that call `reloadList()` on change; thread both into `fetchFirstPage()`
-- [ ] 4.2 Update the empty-state copy to "No mail matches your filters" when a filter is active
+- [x] 4.1 In `InboxView.svelte`, add `unread`/`label` `$state` and wire an **Unread only** toggle + **All Labels** dropdown (from `emailStatus.ts` `STATUS_LABELS`) that call `reloadList()` on change; thread both into `fetchFirstPage()`
+- [x] 4.2 Update the empty-state copy to "No mail matches your filters" when a filter is active
 
 ## 5. Frontend mark-all-read & delete/undo
 
-- [ ] 5.1 Add a **Mark all read** toolbar button: call `api.markAllRead(...)`, optimistically mark visible rows read, drop the unread count; on error `reloadList()`
-- [ ] 5.2 Add a **Delete** control (reading pane) with optimistic removal, `total` decrement, and a "Deleted · Undo" toast reusing the `lastUnlinked`/`undoUnlink` pattern (`lastDeleted` + `restoreEmail`)
+- [x] 5.1 Add a **Mark all read** toolbar button: call `api.markAllRead(...)`, optimistically mark visible rows read, drop the unread count; on error `reloadList()`
+- [x] 5.2 Add a **Delete** control (reading pane) with optimistic removal, `total` decrement, and a "Deleted · Undo" toast reusing the `lastUnlinked`/`undoUnlink` pattern (`lastDeleted` + `restoreEmail`)
 
 ## 6. Verify
 
-- [ ] 6.1 `go build ./... && go vet ./... && go test ./...`
-- [ ] 6.2 Web: `svelte-check` clean + visual check of the toolbar (throwaway route + headless Chrome)
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...`
+- [~] 6.2 Web: `svelte-check` clean (my files 0 problems). Browser visual blocked by a pre-existing posthog-js env gap in this checkout (hooks.client.ts/+layout import analytics); verify on a running instance.

--- a/openspec/changes/inbox-read-side-enhancements/tasks.md
+++ b/openspec/changes/inbox-read-side-enhancements/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Data & SQL layer
 
-- [ ] 1.1 Add migration `migrations/0022_emails_deleted_at.sql`: `ALTER TABLE emails ADD COLUMN deleted_at timestamptz` + partial index `emails_user_live_idx ON emails (user_id, received_at DESC) WHERE deleted_at IS NULL`
-- [ ] 1.2 Extend `ListEmails`/`CountEmails` in `internal/db/queries/gmail.sql`: exclude `deleted_at IS NOT NULL`, add optional `unread` (bool) and `status` (text) filters via the existing `sqlc.arg = <empty> OR predicate` idiom
-- [ ] 1.3 Add `MarkAllEmailsRead` (`:execrows`) taking the same source/unread/status/search args, updating only unread, non-deleted rows scoped to the user
-- [ ] 1.4 Add `SoftDeleteEmail` and `RestoreEmail` (`SET deleted_at = now()` / `= NULL`, scoped by `id + user_id`)
-- [ ] 1.5 Regenerate sqlc (`make sqlc`) and confirm `go build ./...`
+- [x] 1.1 Add migration `migrations/0022_emails_deleted_at.sql`: `ALTER TABLE emails ADD COLUMN deleted_at timestamptz` + partial index `emails_user_live_idx ON emails (user_id, received_at DESC) WHERE deleted_at IS NULL`
+- [x] 1.2 Extend `ListEmails`/`CountEmails` in `internal/db/queries/gmail.sql`: exclude `deleted_at IS NOT NULL`, add optional `unread` (bool) and `status` (text) filters via the existing `sqlc.arg = <empty> OR predicate` idiom
+- [x] 1.3 Add `MarkAllEmailsRead` (`:execrows`) taking the same source/unread/status/search args, updating only unread, non-deleted rows scoped to the user
+- [x] 1.4 Add `SoftDeleteEmail` and `RestoreEmail` (`SET deleted_at = now()` / `= NULL`, scoped by `id + user_id`)
+- [x] 1.5 Regenerate sqlc (`make sqlc`) and confirm `go build ./...`
 
 ## 2. Backend handlers & routes
 
-- [ ] 2.1 In `internal/handler/inbox.go`, extend `GetInbox` to read `?unread=1` and `?status=<signal>`, validating `status` against the mailclassify vocabulary (400 on unknown) and passing both into the query
-- [ ] 2.2 Add `MarkAllReadInbox` handler (reads the same query filters) + route `POST /me/inbox/read-all`
-- [ ] 2.3 Add `DeleteEmail` + `RestoreEmail` handlers + routes `POST /me/emails/:id/delete` and `POST /me/emails/:id/restore`, scoped to the caller (404 for another user's message)
-- [ ] 2.4 Integration test (build-tag, like `mailbox_integration_test.go`): `ListEmails` with `unread`/`status`/`deleted_at`; `MarkAllEmailsRead` honoring filters; soft-delete/restore round-trip
+- [x] 2.1 In `internal/handler/inbox.go`, extend `GetInbox` to read `?unread=1` and `?status=<signal>`, validating `status` against the mailclassify vocabulary (400 on unknown) and passing both into the query
+- [x] 2.2 Add `MarkAllReadInbox` handler (reads the same query filters) + route `POST /me/inbox/read-all`
+- [x] 2.3 Add `DeleteEmail` + `RestoreEmail` handlers + routes `POST /me/emails/:id/delete` and `POST /me/emails/:id/restore`, scoped to the caller (404 for another user's message)
+- [x] 2.4 Integration test (build-tag, like `mailbox_integration_test.go`): `ListEmails` with `unread`/`status`/`deleted_at`; `MarkAllEmailsRead` honoring filters; soft-delete/restore round-trip
 
 ## 3. Frontend API client
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -830,14 +830,42 @@ export function createApi(
     limit = 20,
     offset = 0,
     source: InboxSource = '',
+    unread = false,
+    status = '',
   ): Promise<{ messages: InboxMessage[]; total: number }> {
     const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
     if (q) params.set('q', q);
     if (source) params.set('source', source);
+    if (unread) params.set('unread', '1');
+    if (status) params.set('status', status);
     const res = await request<{ data: InboxMessage[]; meta: { total: number } }>(
       `/api/v1/me/inbox?${params.toString()}`,
     );
     return { messages: res.data, total: res.meta.total };
+  }
+
+  /** Mark every unread message matching the active filters as read; returns the
+   *  count marked. The unread flag is implicit server-side, so it is not sent. */
+  async function markAllRead(source: InboxSource = '', status = '', q = ''): Promise<number> {
+    const params = new URLSearchParams();
+    if (source) params.set('source', source);
+    if (status) params.set('status', status);
+    if (q) params.set('q', q);
+    const res = await requestData<{ marked: number }>(
+      `/api/v1/me/inbox/read-all?${params.toString()}`,
+      { method: 'POST' },
+    );
+    return res.marked;
+  }
+
+  /** Soft-delete a message (hidden from the inbox, restorable via restoreEmail). */
+  async function deleteEmail(id: number): Promise<void> {
+    await request(`/api/v1/me/emails/${id}/delete`, { method: 'POST' });
+  }
+
+  /** Undo a soft-delete, bringing the message back into the inbox. */
+  async function restoreEmail(id: number): Promise<void> {
+    await request(`/api/v1/me/emails/${id}/restore`, { method: 'POST' });
   }
 
   /** The caller's hosted-mailbox address (or null) + feature availability. */
@@ -972,6 +1000,9 @@ export function createApi(
     releaseMailbox,
     getInbox,
     getEmail,
+    markAllRead,
+    deleteEmail,
+    restoreEmail,
     getTrackedApplication,
     confirmEmailLink,
     rejectEmailLink,

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -9,12 +9,12 @@
     EmailBody,
   } from '$lib/api';
   import type { EmailLinking } from '$lib/types';
-  import { statusLabel, statusClass } from '$lib/emailStatus';
+  import { statusLabel, statusClass, STATUS_LABELS } from '$lib/emailStatus';
   import { inboxLinkState, type LastUnlinked } from '$lib/inboxLink';
   import { Badge, Button } from '$lib/ui';
   import GmailConnectDialog from './GmailConnectDialog.svelte';
   import ApplicationLinkPicker from './ApplicationLinkPicker.svelte';
-  import { Mail, AtSign, Copy, Search, RefreshCw, ChevronLeft } from '@lucide/svelte';
+  import { Mail, AtSign, Copy, Search, RefreshCw, ChevronLeft, CheckCheck, Trash2 } from '@lucide/svelte';
   import { timeAgo } from '$lib/utils';
   import { avatarInitials, avatarColor } from '$lib/avatar';
 
@@ -34,9 +34,20 @@
   let search = $state('');
   let searchTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Triage filters: unread-only and one classification label ('' = all).
+  let unread = $state(false);
+  let label = $state('');
+  // The dropdown offers only signals with a human label (drops 'other' → blank).
+  const LABEL_OPTIONS = Object.entries(STATUS_LABELS).filter(([, l]) => l !== '');
+  const filterActive = $derived(unread || label !== '' || search !== '');
+
   let syncing = $state(false);
   let claiming = $state(false);
   let refreshing = $state(false);
+  let markingAll = $state(false);
+
+  // The message just soft-deleted, for a one-click Undo (per-email, like unlink).
+  let lastDeleted = $state<{ id: number; subject: string } | null>(null);
 
   // Which pane: the mail list ('inbox') or the account setup ('settings').
   let tab = $state<'inbox' | 'settings'>('inbox');
@@ -77,7 +88,7 @@
   // Load the first page for the current search term + source filter, then top up
   // until the list overflows its pane so infinite scroll has room to work.
   async function fetchFirstPage() {
-    const res = await api.getInbox(search, PAGE_SIZE, 0, source);
+    const res = await api.getInbox(search, PAGE_SIZE, 0, source, unread, label);
     messages = res.messages;
     total = res.total;
     await fillViewport();
@@ -110,7 +121,7 @@
 
   async function loadMore() {
     try {
-      const res = await api.getInbox(search, PAGE_SIZE, messages.length, source);
+      const res = await api.getInbox(search, PAGE_SIZE, messages.length, source, unread, label);
       messages = [...messages, ...res.messages];
       total = res.total;
     } catch (e) {
@@ -160,6 +171,70 @@
     await reloadList();
   }
 
+  async function toggleUnread() {
+    unread = !unread;
+    await reloadList();
+  }
+
+  async function setLabel(l: string) {
+    if (label === l) return;
+    label = l;
+    await reloadList();
+  }
+
+  // Mark every unread message matching the active filters as read. Optimistically
+  // flip the visible rows so the dots clear without a refetch; on failure, reload.
+  async function markAllRead() {
+    if (markingAll) return;
+    markingAll = true;
+    error = null;
+    try {
+      await api.markAllRead(source, label, search);
+      messages = messages.map((m) => ({ ...m, read: true }));
+      if (selected) selected = { ...selected, read: true };
+      if (unread) await reloadList(); // the unread view should now be empty
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to mark all read.';
+      await reloadList();
+    } finally {
+      markingAll = false;
+    }
+  }
+
+  // Soft-delete the open message: drop it from the list optimistically, clear the
+  // reading pane, and remember it for a one-click Undo (per-email, like unlink).
+  async function deleteSelected() {
+    if (!selected) return;
+    const id = selected.id;
+    const subject = selected.subject;
+    const prev = messages;
+    messages = messages.filter((m) => m.id !== id);
+    total = Math.max(0, total - 1);
+    selectedId = null;
+    selected = null;
+    try {
+      await api.deleteEmail(id);
+      lastDeleted = { id, subject };
+    } catch (e) {
+      messages = prev; // put the row back
+      total += 1;
+      error = e instanceof Error ? e.message : 'Failed to delete.';
+    }
+  }
+
+  // Undo the last delete: restore the message and reload so it lands in order.
+  async function undoDelete() {
+    if (!lastDeleted) return;
+    const { id } = lastDeleted;
+    lastDeleted = null;
+    try {
+      await api.restoreEmail(id);
+      await reloadList();
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Failed to restore.';
+    }
+  }
+
   // Mobile master-detail: clear the selection to return from the reading pane to
   // the list (on md+ both panes are always visible, so this only matters below md).
   function backToList() {
@@ -169,6 +244,7 @@
 
   async function openMessage(id: number) {
     if (lastUnlinked && lastUnlinked.id !== id) lastUnlinked = null; // Undo is per-email
+    if (lastDeleted && lastDeleted.id !== id) lastDeleted = null;
     selectedId = id;
     selected = null;
     bodyLoading = true;
@@ -444,7 +520,7 @@
         <button type="button" class="font-medium text-primary hover:underline" onclick={() => (tab = 'settings')}>set one up in Settings</button>.
       </p>
     {:else}
-      <!-- Toolbar: account switcher, search, refresh. -->
+      <!-- Toolbar: account switcher, unread + label filters, search, mark-all-read, refresh. -->
       <div class="flex flex-wrap items-center gap-2">
         {#if bothConnected}
           <div class="flex gap-1 rounded-lg border border-border p-1 text-sm">
@@ -462,6 +538,31 @@
           </div>
         {/if}
 
+        <button
+          type="button"
+          onclick={toggleUnread}
+          aria-pressed={unread}
+          class="rounded-lg border px-3 py-1.5 text-sm transition-colors {unread
+            ? 'border-brand-ring bg-brand-muted/60 font-medium text-foreground'
+            : 'border-border text-muted-foreground hover:text-foreground'}"
+        >
+          Unread only
+        </button>
+
+        <select
+          bind:value={label}
+          onchange={() => setLabel(label)}
+          aria-label="Filter by label"
+          class="rounded-lg border border-border bg-background py-1.5 pl-3 pr-8 text-sm outline-none transition focus:border-brand focus:ring-2 focus:ring-brand-ring/40 {label
+            ? 'font-medium text-foreground'
+            : 'text-muted-foreground'}"
+        >
+          <option value="">All labels</option>
+          {#each LABEL_OPTIONS as [value, text] (value)}
+            <option {value}>{text}</option>
+          {/each}
+        </select>
+
         <div class="relative min-w-0 flex-1">
           <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <input
@@ -473,15 +574,28 @@
           />
         </div>
 
+        <Button variant="outline" size="sm" disabled={markingAll} onclick={markAllRead} title="Mark all read">
+          <CheckCheck class="h-4 w-4" />
+          Mark all read
+        </Button>
+
         <Button variant="outline" size="sm" disabled={refreshing} onclick={refreshInbox} title="Refresh">
           <RefreshCw class="h-4 w-4 {refreshing ? 'animate-spin' : ''}" />
           Refresh
         </Button>
       </div>
 
+      {#if lastDeleted}
+        <div class="flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+          Deleted “{lastDeleted.subject || '(no subject)'}”
+          <span aria-hidden="true">·</span>
+          <button type="button" onclick={undoDelete} class="font-medium text-brand-strong hover:underline">Undo</button>
+        </div>
+      {/if}
+
       {#if messages.length === 0}
         <p class="py-12 text-center text-sm text-muted-foreground">
-          {search ? 'No mail matches your search.' : 'No mail yet — it appears here as it arrives.'}
+          {filterActive ? 'No mail matches your filters.' : 'No mail yet — it appears here as it arrives.'}
         </p>
       {:else}
         <!-- Fixed-height two-pane so the page itself never scrolls: each pane scrolls
@@ -588,6 +702,15 @@
                     <span class="ml-auto shrink-0">{timeAgo(s.received_at)}</span>
                   </div>
                 </div>
+                <button
+                  type="button"
+                  onclick={deleteSelected}
+                  title="Delete"
+                  aria-label="Delete message"
+                  class="shrink-0 rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                >
+                  <Trash2 class="h-4 w-4" />
+                </button>
               </div>
 
               {@const linkState = inboxLinkState(s, lastUnlinked)}

--- a/web/src/lib/components/InboxView.svelte
+++ b/web/src/lib/components/InboxView.svelte
@@ -176,23 +176,21 @@
     await reloadList();
   }
 
-  async function setLabel(l: string) {
-    if (label === l) return;
-    label = l;
-    await reloadList();
-  }
-
-  // Mark every unread message matching the active filters as read. Optimistically
-  // flip the visible rows so the dots clear without a refetch; on failure, reload.
+  // Mark every unread message matching the active filters as read. When the unread
+  // view is active it should now be empty, so reload; otherwise flip the visible
+  // rows optimistically so the dots clear without a refetch.
   async function markAllRead() {
     if (markingAll) return;
     markingAll = true;
     error = null;
     try {
       await api.markAllRead(source, label, search);
-      messages = messages.map((m) => ({ ...m, read: true }));
-      if (selected) selected = { ...selected, read: true };
-      if (unread) await reloadList(); // the unread view should now be empty
+      if (unread) {
+        await reloadList();
+      } else {
+        messages = messages.map((m) => ({ ...m, read: true }));
+        if (selected) selected = { ...selected, read: true };
+      }
     } catch (e) {
       error = e instanceof Error ? e.message : 'Failed to mark all read.';
       await reloadList();
@@ -551,7 +549,7 @@
 
         <select
           bind:value={label}
-          onchange={() => setLabel(label)}
+          onchange={reloadList}
           aria-label="Filter by label"
           class="rounded-lg border border-border bg-background py-1.5 pl-3 pr-8 text-sm outline-none transition focus:border-brand focus:ring-2 focus:ring-brand-ring/40 {label
             ? 'font-medium text-foreground'


### PR DESCRIPTION
## Summary

Adds read-side triage controls to `/my/inbox`, built on data we already have (`read_at`, `status_signal`) plus one soft-delete flag:

- **Unread only** filter and **All Labels** filter (over the existing mailclassify `status_signal` vocabulary).
- **Mark all read** — bulk-marks everything matching the *active* filters (source/label/search), not the whole mailbox.
- **Delete** — soft-delete (`emails.deleted_at`) with an inline per-email **Undo**, mirroring the existing unlink/Undo pattern. No separate Deleted folder.

Out of scope (deferred): Priority sort, outbound mail (Reply/Forward/Sent), folder dropdown.

### Backend
- Migration `0022_emails_deleted_at.sql`: `deleted_at` column + partial live index.
- `ListEmails`/`CountEmails` exclude soft-deleted rows, add optional `unread`/`status` filters (existing `sqlc.arg = '' OR …` idiom). `GetEmail` also hides soft-deleted (404, consistent with the listing).
- New queries: `MarkAllEmailsRead`, `SoftDeleteEmail`, `RestoreEmail`.
- `GetInbox` validates `?status` against the mailclassify vocabulary (400 on unknown). New handlers/routes: `POST /me/inbox/read-all`, `POST /me/emails/:id/delete`, `POST /me/emails/:id/restore`.

### Frontend
- `api.ts`: `getInbox` gains `unread`/`status`; new `markAllRead`/`deleteEmail`/`restoreEmail`.
- `InboxView.svelte`: toolbar toggle + label dropdown + Mark-all-read; reading-pane Delete with optimistic removal and an Undo toast.

Planned via OpenSpec change `inbox-read-side-enhancements` (spec-driven-tdd).

## Test Plan
- [x] Backend integration tests (real Postgres): filters, mark-all-read honoring filters, soft-delete/restore round-trip, cross-user 404, re-sync durability, GET-deleted 404 — all green.
- [x] `go build ./... && go vet ./... && go test ./...` green.
- [x] `svelte-check` clean on changed files (pre-existing posthog-js/JobFitFull noise unrelated).
- [ ] Visual check of the toolbar on a running instance (blocked locally by a stale-checkout posthog-js gap).

## Deploy note
⚠️ Apply migration `0022_emails_deleted_at.sql` to the prod DB **before** deploying the new binary — `ListEmails` reads `deleted_at`.