### PR TITLE
feat(sources): add Revenue Vessel and ThirdLaw Ashby boards

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -7413,3 +7413,7 @@
   board: cerebras
 - company: Vast.ai
   board: vastai
+- company: Revenue Vessel
+  board: RevenueVessel
+- company: ThirdLaw
+  board: thirdlaw


### PR DESCRIPTION
Two companies surfaced by the dreamworkhq (631-match) catalogue audit as absent from our base, now onboarded as Ashby boards.

Both validated live via the Ashby posting API with `harvest-boards ashby` before committing:
- **Revenue Vessel** — `ashby/RevenueVessel` — 1 open role
- **ThirdLaw** — `ashby/thirdlaw` — 4 open roles

Audit context: of 414 unique companies in the dreamwork export, all but a handful were already ingested (many under their real company name rather than the ATS board token — e.g. "GigaML" is our `giga-ai`). The remainder without an ingestable ATS (self-hosted careers, Hurma, staffing agencies) were left out. ScrumLaunch has a valid Workable account but currently 0 open roles, so it was not added.