### PR TITLE
feat(insights): SEO landing pages over the Insights API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1729,12 +1729,13 @@ Roles (category × seniority) ranked by the number of open jobs, with a growth m
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
+| `category` | string | no | Restrict to one category's seniorities (enrichment vocabulary); omitted = all categories. (e.g. `backend`) |
 | `country` | string | no | ISO 3166-1 alpha-2 scope; omitted = all countries. (e.g. `DE`) |
 | `sort` | string | no | `open` (default) ranks by open-count, `growth` by the window delta. |
 | `limit` | integer | no | Result cap, 1–200 (default 20). |
 
 ```bash
-curl "https://freehire.dev/api/v1/insights/roles?country=DE&sort=growth"
+curl "https://freehire.dev/api/v1/insights/roles?category=backend&sort=growth"
 ```
 
 ```json
@@ -1804,26 +1805,33 @@ curl "https://freehire.dev/api/v1/insights/velocity?granularity=week&category=ba
 
 **Auth:** Public
 
-Salary distribution bands (25th/50th/75th percentiles) for a role and geography, one entry per currency and pay period. Currencies are never combined, and a band with too few disclosed salaries is omitted rather than returned unreliable. Figures are integers in the currency's own units.
+Salary distribution bands (25th/50th/75th percentiles) for a role and geography, one entry per currency and pay period. Currencies are never combined, and a band with too few disclosed salaries is omitted rather than returned unreliable. Figures are integers in the currency's own units. Each row carries the `seniority` it applies to.
+
+Passing `category` alone (no `seniority`, no `country`) returns the **per-seniority breakdown** for that category in one call — every seniority's bands plus the category-wide band (`seniority: ""`) — with `meta.breakdown = "seniority"`. This is what the per-category salary page reads.
 
 **Query parameters**
 
 | Name | Type | Required | Description |
 | --- | --- | --- | --- |
-| `category` | string | no | Role category (enrichment vocabulary). (e.g. `backend`) |
+| `category` | string | no | Role category (enrichment vocabulary). Alone → per-seniority breakdown. (e.g. `backend`) |
 | `seniority` | string | no | Role seniority (enrichment vocabulary). (e.g. `senior`) |
 | `country` | string | no | ISO 3166-1 alpha-2 scope; omitted = all countries. |
 
 ```bash
+# Exact scope (one grade):
 curl "https://freehire.dev/api/v1/insights/salary?category=backend&seniority=senior"
+# Per-seniority breakdown for a category (the salary page's read):
+curl "https://freehire.dev/api/v1/insights/salary?category=backend"
 ```
 
 ```json
 {
   "data": [
-    { "currency": "USD", "period": "year", "sample_size": 84, "p25": 130000, "p50": 155000, "p75": 180000 }
+    { "seniority": "junior", "currency": "USD", "period": "year", "sample_size": 40, "p25": 95000, "p50": 110000, "p75": 125000 },
+    { "seniority": "senior", "currency": "USD", "period": "year", "sample_size": 84, "p25": 130000, "p50": 155000, "p75": 180000 },
+    { "seniority": "", "currency": "USD", "period": "year", "sample_size": 210, "p25": 110000, "p50": 150000, "p75": 185000 }
   ],
-  "meta": { "category": "backend", "seniority": "senior", "country": "" }
+  "meta": { "category": "backend", "seniority": "", "country": "", "breakdown": "seniority" }
 }
 ```
 

--- a/internal/db/insights.sql.go
+++ b/internal/db/insights.sql.go
@@ -73,16 +73,18 @@ const listInsightsRoles = `-- name: ListInsightsRoles :many
 SELECT category, seniority, open_count, (open_count - open_count_prev)::int AS growth
 FROM insights_role_stats
 WHERE country = $1
+  AND ($2::text = '' OR category = $2)
 ORDER BY
-    (CASE WHEN $2::text = 'growth' THEN (open_count - open_count_prev) ELSE open_count END) DESC,
+    (CASE WHEN $3::text = 'growth' THEN (open_count - open_count_prev) ELSE open_count END) DESC,
     open_count DESC
-LIMIT $3::int
+LIMIT $4::int
 `
 
 type ListInsightsRolesParams struct {
-	Country string `json:"country"`
-	Sort    string `json:"sort"`
-	Lim     int32  `json:"lim"`
+	Country  string `json:"country"`
+	Category string `json:"category"`
+	Sort     string `json:"sort"`
+	Lim      int32  `json:"lim"`
 }
 
 type ListInsightsRolesRow struct {
@@ -94,8 +96,15 @@ type ListInsightsRolesRow struct {
 
 // Ranked roles within one country slice (” = all countries), ordered by raw
 // demand or by growth (open_count - open_count_prev), demand as the tiebreak.
+// An empty @category means all categories (the original behavior); a non-empty
+// @category restricts the ranking to that category's seniorities.
 func (q *Queries) ListInsightsRoles(ctx context.Context, arg ListInsightsRolesParams) ([]ListInsightsRolesRow, error) {
-	rows, err := q.db.Query(ctx, listInsightsRoles, arg.Country, arg.Sort, arg.Lim)
+	rows, err := q.db.Query(ctx, listInsightsRoles,
+		arg.Country,
+		arg.Category,
+		arg.Sort,
+		arg.Lim,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +164,57 @@ func (q *Queries) ListInsightsSalary(ctx context.Context, arg ListInsightsSalary
 	for rows.Next() {
 		var i ListInsightsSalaryRow
 		if err := rows.Scan(
+			&i.Currency,
+			&i.Period,
+			&i.SampleSize,
+			&i.P25,
+			&i.P50,
+			&i.P75,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listInsightsSalaryByCategory = `-- name: ListInsightsSalaryByCategory :many
+SELECT seniority, currency, period, sample_size, p25, p50, p75
+FROM insights_salary_stats
+WHERE category = $1
+  AND country = ''
+ORDER BY seniority, sample_size DESC
+`
+
+type ListInsightsSalaryByCategoryRow struct {
+	Seniority  string `json:"seniority"`
+	Currency   string `json:"currency"`
+	Period     string `json:"period"`
+	SampleSize int32  `json:"sample_size"`
+	P25        int32  `json:"p25"`
+	P50        int32  `json:"p50"`
+	P75        int32  `json:"p75"`
+}
+
+// All-seniority salary bands for one category (country-agnostic ” bucket), so a
+// per-category salary page is one call: one row per (seniority, currency, period),
+// richest samples first. seniority ” is the category-wide band; the named
+// seniorities are the per-grade bands. Bands below the sample floor are already
+// absent from the rollup.
+func (q *Queries) ListInsightsSalaryByCategory(ctx context.Context, category string) ([]ListInsightsSalaryByCategoryRow, error) {
+	rows, err := q.db.Query(ctx, listInsightsSalaryByCategory, category)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListInsightsSalaryByCategoryRow{}
+	for rows.Next() {
+		var i ListInsightsSalaryByCategoryRow
+		if err := rows.Scan(
+			&i.Seniority,
 			&i.Currency,
 			&i.Period,
 			&i.SampleSize,

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -468,10 +468,18 @@ type Querier interface {
 	ListEmails(ctx context.Context, arg ListEmailsParams) ([]ListEmailsRow, error)
 	// Ranked roles within one country slice ('' = all countries), ordered by raw
 	// demand or by growth (open_count - open_count_prev), demand as the tiebreak.
+	// An empty @category means all categories (the original behavior); a non-empty
+	// @category restricts the ranking to that category's seniorities.
 	ListInsightsRoles(ctx context.Context, arg ListInsightsRolesParams) ([]ListInsightsRolesRow, error)
 	// Salary bands for one role × country scope, one row per (currency, period),
 	// richest samples first. Currencies are never combined.
 	ListInsightsSalary(ctx context.Context, arg ListInsightsSalaryParams) ([]ListInsightsSalaryRow, error)
+	// All-seniority salary bands for one category (country-agnostic '' bucket), so a
+	// per-category salary page is one call: one row per (seniority, currency, period),
+	// richest samples first. seniority '' is the category-wide band; the named
+	// seniorities are the per-grade bands. Bands below the sample floor are already
+	// absent from the rollup.
+	ListInsightsSalaryByCategory(ctx context.Context, category string) ([]ListInsightsSalaryByCategoryRow, error)
 	// Ranked skills within one (category, country) scope; scoping is one-dimensional
 	// (either category or country carries a value, the other is ''), matching what the
 	// rollup materializes.

--- a/internal/db/queries/insights.sql
+++ b/internal/db/queries/insights.sql
@@ -50,9 +50,12 @@ WHERE open_count > 0 OR open_count_prev > 0;
 -- name: ListInsightsRoles :many
 -- Ranked roles within one country slice ('' = all countries), ordered by raw
 -- demand or by growth (open_count - open_count_prev), demand as the tiebreak.
+-- An empty @category means all categories (the original behavior); a non-empty
+-- @category restricts the ranking to that category's seniorities.
 SELECT category, seniority, open_count, (open_count - open_count_prev)::int AS growth
 FROM insights_role_stats
 WHERE country = sqlc.arg('country')
+  AND (sqlc.arg('category')::text = '' OR category = sqlc.arg('category'))
 ORDER BY
     (CASE WHEN sqlc.arg('sort')::text = 'growth' THEN (open_count - open_count_prev) ELSE open_count END) DESC,
     open_count DESC
@@ -212,6 +215,18 @@ WHERE category = sqlc.arg('category')
   AND seniority = sqlc.arg('seniority')
   AND country = sqlc.arg('country')
 ORDER BY sample_size DESC;
+
+-- name: ListInsightsSalaryByCategory :many
+-- All-seniority salary bands for one category (country-agnostic '' bucket), so a
+-- per-category salary page is one call: one row per (seniority, currency, period),
+-- richest samples first. seniority '' is the category-wide band; the named
+-- seniorities are the per-grade bands. Bands below the sample floor are already
+-- absent from the rollup.
+SELECT seniority, currency, period, sample_size, p25, p50, p75
+FROM insights_salary_stats
+WHERE category = sqlc.arg('category')
+  AND country = ''
+ORDER BY seniority, sample_size DESC;
 
 -- ---------------------------------------------------------------------------
 -- Hiring velocity (faceted)

--- a/internal/handler/insights.go
+++ b/internal/handler/insights.go
@@ -44,6 +44,7 @@ type skillInsight struct {
 
 // salaryBand is one (currency, period) salary distribution on the wire.
 type salaryBand struct {
+	Seniority  string `json:"seniority"`
 	Currency   string `json:"currency"`
 	Period     string `json:"period"`
 	SampleSize int32  `json:"sample_size"`
@@ -171,8 +172,12 @@ func (a *API) InsightsRoles(c *fiber.Ctx) error {
 	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
+	category, err := parseCategory(c.Query("category"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
 
-	rows, err := a.queries.ListInsightsRoles(c.Context(), db.ListInsightsRolesParams{Country: country, Sort: sort, Lim: limit})
+	rows, err := a.queries.ListInsightsRoles(c.Context(), db.ListInsightsRolesParams{Country: country, Category: category, Sort: sort, Lim: limit})
 	if err != nil {
 		return err
 	}
@@ -182,7 +187,7 @@ func (a *API) InsightsRoles(c *fiber.Ctx) error {
 	}
 	return c.JSON(fiber.Map{
 		"data": data,
-		"meta": fiber.Map{"country": country, "sort": sort, "limit": limit},
+		"meta": fiber.Map{"country": country, "category": category, "sort": sort, "limit": limit},
 	})
 }
 
@@ -292,13 +297,31 @@ func (a *API) InsightsSalary(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, err.Error())
 	}
 
+	// Per-category breakdown: a category with no seniority and no country scope
+	// returns every seniority's bands (plus the category-wide '' band) in one call —
+	// what the per-category salary page needs. Each row carries its own seniority.
+	if category != "" && seniority == "" && country == "" {
+		rows, err := a.queries.ListInsightsSalaryByCategory(c.Context(), category)
+		if err != nil {
+			return err
+		}
+		data := make([]salaryBand, len(rows))
+		for i, r := range rows {
+			data[i] = salaryBand{Seniority: r.Seniority, Currency: r.Currency, Period: r.Period, SampleSize: r.SampleSize, P25: r.P25, P50: r.P50, P75: r.P75}
+		}
+		return c.JSON(fiber.Map{
+			"data": data,
+			"meta": fiber.Map{"category": category, "seniority": "", "country": "", "breakdown": "seniority"},
+		})
+	}
+
 	rows, err := a.queries.ListInsightsSalary(c.Context(), db.ListInsightsSalaryParams{Category: category, Seniority: seniority, Country: country})
 	if err != nil {
 		return err
 	}
 	data := make([]salaryBand, len(rows))
 	for i, r := range rows {
-		data[i] = salaryBand{Currency: r.Currency, Period: r.Period, SampleSize: r.SampleSize, P25: r.P25, P50: r.P50, P75: r.P75}
+		data[i] = salaryBand{Seniority: seniority, Currency: r.Currency, Period: r.Period, SampleSize: r.SampleSize, P25: r.P25, P50: r.P50, P75: r.P75}
 	}
 	return c.JSON(fiber.Map{
 		"data": data,

--- a/internal/handler/insights_integration_test.go
+++ b/internal/handler/insights_integration_test.go
@@ -178,6 +178,42 @@ func TestInsightsEndpoints(t *testing.T) {
 		t.Errorf("salary seniority-only: status %d, missing USD band: %s", code, raw)
 	}
 
+	// --- roles scoped to one category (SEO-page read) ---------------------------
+	out, raw, code = get(t, "/api/v1/insights/roles?category=backend")
+	bodies = append(bodies, raw)
+	if code != fiber.StatusOK {
+		t.Fatalf("roles?category: status %d, want 200: %s", code, raw)
+	}
+	rows, _ := out["data"].([]any)
+	if len(rows) == 0 {
+		t.Errorf("roles?category=backend returned no rows: %s", raw)
+	}
+	for _, e := range rows {
+		if m, ok := e.(map[string]any); ok && m["category"] != "backend" {
+			t.Errorf("roles?category=backend leaked category %v: %s", m["category"], raw)
+		}
+	}
+
+	// --- per-category salary breakdown (all seniorities in one call) -------------
+	out, raw, code = get(t, "/api/v1/insights/salary?category=backend")
+	bodies = append(bodies, raw)
+	if code != fiber.StatusOK {
+		t.Fatalf("salary?category breakdown: status %d, want 200: %s", code, raw)
+	}
+	if out["meta"].(map[string]any)["breakdown"] != "seniority" {
+		t.Errorf("salary?category: expected breakdown meta, got %v", out["meta"])
+	}
+	// Breakdown carries per-row seniority and includes the senior grade's USD band.
+	foundSeniorUSD := false
+	for _, e := range out["data"].([]any) {
+		if m, ok := e.(map[string]any); ok && m["seniority"] == "senior" && m["currency"] == "USD" {
+			foundSeniorUSD = true
+		}
+	}
+	if !foundSeniorUSD {
+		t.Errorf("salary?category=backend breakdown missing senior USD band: %s", raw)
+	}
+
 	// --- aggregate-only: no record-level string leaks into any body -------------
 	for _, raw := range bodies {
 		for _, leak := range []string{"SECRET_TITLE", "secret-slug", "secret-ext", "ex.test"} {

--- a/openspec/changes/add-seo-insights-pages/.openspec.yaml
+++ b/openspec/changes/add-seo-insights-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/add-seo-insights-pages/design.md
+++ b/openspec/changes/add-seo-insights-pages/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`market-insights` shipped four public JSON endpoints over precomputed `insights_*`
+rollups. The web app is SvelteKit SSR (adapter-node, `API_INTERNAL_URL`) and already
+runs programmatic landing pages (`/collections/[slug]`) and a keyset sitemap index
+(`sitemap.xml` → `sitemap-{jobs,companies,pages}.xml`). This change adds a new family
+of landing pages that consume the insights data, plus the small API reads they need.
+
+Two current-API gaps block a single-call-per-page design: `GET /insights/roles` has
+no category filter (it returns all category×seniority pairs), and `GET
+/insights/salary` with an empty seniority returns only the category-aggregate band,
+not per-seniority bands. Both rows already exist in the rollups — only the read
+queries/params are missing.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Hub + per-category salary/skills/roles pages under `/insights`, server-rendered.
+- Substantive, indexable pages (auto-intro, tables, internal links, JSON-LD) gated on
+  real data so no thin pages ship.
+- Reuse existing SSR, collections-landing, and sitemap-index patterns.
+- Two minimal API additions, served from the existing rollups (no schema change).
+
+**Non-Goals:**
+- Geo/country page matrix, editorial prose/FAQ, charts, velocity pages (later).
+- Any rollup/worker/migration change — the rows already exist.
+- New auth or non-public surface.
+
+## Decisions
+
+### D1: SSR-live with CDN caching, not prerender
+
+`server-load` fetches the internal API per request and sets `Cache-Control:
+s-maxage=3600`. Matches how `/jobs` and `/collections` already render, keeps data
+fresh within the rollup's own cadence, and lets nginx/CDN absorb crawler bursts.
+Prerender rejected: the covered-category set changes with data, and static pages go
+stale between deploys.
+
+### D2: Extend the API rather than read the DB from web
+
+The pages need category-scoped roles and per-category salary. Add these as insights
+API reads (roles gains an optional `category`; a category-salary read returns all
+seniorities). Rejected: giving the web SSR layer direct Postgres access — it has none
+today, and the API boundary is the project's contract. The additions are pure read
+queries over the existing rollups + handler params (sqlc regen, no migration).
+
+### D3: Data-driven quality gate derives the covered set
+
+A category is "covered" iff its insights data clears a threshold (min open jobs
+and/or a salary band at/above the sample floor). The covered set is computed from the
+API, not hard-coded, and is the single source of truth for: hub links, valid page
+params (uncovered → 404), and sitemap entries. This keeps thin pages from ever
+shipping and self-heals as data changes.
+
+### D4: One shared page component, three thin route wrappers
+
+`salary/[category]`, `skills/[category]`, `roles/[category]` share a common insights
+page layout (breadcrumb, auto-intro, data section, internal-link rail, JSON-LD); each
+route's `+page.server.ts` fetches its slice and passes a typed view model. Keeps the
+SEO scaffolding in one place and the routes thin.
+
+### D5: Auto-intro is templated from data, not LLM
+
+The intro sentence is a deterministic template filled from the fetched aggregates
+("Senior backend roles pay a median of $X across N postings"). No LLM call — cheap,
+stable, no per-page cost, and it can't hallucinate.
+
+## Risks / Trade-offs
+
+- **Thin content / Google non-indexing** → Mitigation: the D3 gate + Standard content
+  (intro, table, internal links, JSON-LD) keep each page substantive; gated-out
+  categories 404 rather than ship empty.
+- **Crawler load on the API** → Mitigation: `s-maxage=3600` + CDN/nginx cache; the API
+  reads are indexed single-row-set lookups on small rollup tables.
+- **Cannibalization with `/collections` and `/jobs`** → Mitigation: insights pages
+  target aggregate/informational intent ("what pays / what's in demand"), link OUT to
+  the transactional `/jobs` filtered views, and use distinct canonical URLs.
+- **Category slug vs enrichment value** → the category vocabulary is lowercase tokens
+  (e.g. `backend`); page slugs use them directly, validated against the vocab.
+
+## Migration Plan
+
+Pure additive: new web routes + two API reads. Deploy is the standard `release.sh`
+(builds api + web). No migration, no worker change. Rollback = revert the routes/reads
+(pages disappear; API additions are inert if unused). The sitemap shard only lists
+covered pages, so search engines pick them up after deploy.
+
+## Open Questions
+
+- Gate thresholds (min open jobs; salary sample floor for "covered") — pick
+  conservative defaults during implementation, tune from Search Console later.
+- Category-salary read shape: a new `category` mode on the existing salary endpoint
+  vs a dedicated route — decide at implementation, favor the smallest change that
+  returns per-seniority bands in one call.

--- a/openspec/changes/add-seo-insights-pages/proposal.md
+++ b/openspec/changes/add-seo-insights-pages/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The Insights API (`market-insights`) exposes rich aggregate market data but has no
+human-facing surface — only JSON. freehire's proven growth channel is organic
+search (collection landing pages, programmatic SEO). Turning the insights data into
+crawlable, keyword-targeted landing pages ("Backend developer salaries", "Most
+in-demand backend skills") drives organic traffic to freehire and reuses data that
+already exists. This is the follow-up the Trends & Insights work was sequenced
+before.
+
+## What Changes
+
+- Add server-rendered **insights landing pages** under `/insights`:
+  - `/insights` — a hub linking every covered category and insight type.
+  - `/insights/salary/[category]` — salary bands by seniority for a role category.
+  - `/insights/skills/[category]` — most in-demand skills in a category, with growth.
+  - `/insights/roles/[category]` — most-hiring roles (seniorities) in a category.
+- Pages are **SSR-live**: `server-load` reads the internal Insights API, with
+  `Cache-Control: s-maxage=3600` so CDN/nginx absorbs repeat crawls.
+- **Standard SEO content** per page: a data-driven auto-generated intro, the
+  ranking table / salary bands, an "updated" date, internal links (to `/jobs`
+  filtered views, sibling categories, and the other insight types for the same
+  category), canonical/meta/OG, and JSON-LD (BreadcrumbList + Dataset).
+- A **quality gate**: only categories whose data clears a threshold (enough open
+  jobs / a salary band above the sample floor) get a page and a sitemap entry;
+  thin categories are excluded (no thin-content pages).
+- New **`sitemap-insights.xml`** shard, wired into the existing sitemap index.
+- **Two small Insights API additions** to serve the pages that today's endpoints
+  can't in one call: an optional `category` filter on `GET /insights/roles`
+  (return the category's seniorities), and an all-seniority salary read for a
+  category.
+
+Out of scope for v1 (explicit): geo/country page matrix, editorial prose / FAQ,
+charts, and dedicated velocity pages.
+
+## Capabilities
+
+### New Capabilities
+- `seo-insights-pages`: public server-rendered landing pages over the insights
+  data — hub + per-category salary/skills/roles pages — with SEO content, a
+  data-quality gate, internal linking, and a sitemap shard.
+
+### Modified Capabilities
+- `market-insights`: add an optional `category` scope to the roles read, and a
+  per-category all-seniority salary read, so the landing pages can be served from
+  single API calls.
+
+## Impact
+
+- **Backend**: extend `internal/db/queries/insights.sql` read queries + handler
+  params for the roles `category` filter and the category salary read (sqlc
+  regen); no rollup/schema change (the rollups already hold the rows).
+- **Frontend**: new SvelteKit routes under `web/src/routes/insights/**`
+  (`+page.server.ts` + `+page.svelte`), a shared insights page component, and the
+  category quality-gate helper; new `web/src/routes/sitemap-insights.xml` +
+  registration in the sitemap index; `docs/API.md` + `web/static/openapi.yaml`
+  updated for the two new read shapes.
+- No changes to the rollup worker, migrations, auth, or ingest.

--- a/openspec/changes/add-seo-insights-pages/specs/market-insights/spec.md
+++ b/openspec/changes/add-seo-insights-pages/specs/market-insights/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Category-scoped role demand
+
+The `GET /api/v1/insights/roles` endpoint SHALL accept an optional `category`
+parameter that restricts the ranked roles to that category's seniorities, so a
+per-category roles view can be served in a single call. The parameter SHALL be
+validated against the enrichment category vocabulary; an unknown value SHALL be a
+`400`. When omitted, the endpoint behaves as before (all category × seniority pairs).
+
+#### Scenario: Roles scoped to one category
+
+- **WHEN** a client requests `GET /api/v1/insights/roles?category=backend`
+- **THEN** the `data` array contains only `backend` roles (one row per seniority
+  present), ranked by the requested sort, and `meta` echoes the `category`
+
+#### Scenario: Unknown category rejected
+
+- **WHEN** a client requests `GET /api/v1/insights/roles?category=not-a-category`
+- **THEN** the response is `400` with an `{"error": ...}` body
+
+### Requirement: All-seniority salary bands for a category
+
+The system SHALL provide a way to read, in a single call, the salary bands for every
+seniority within a category (each per currency and period), so a per-category salary
+page does not need one request per seniority. Bands below the minimum sample size
+SHALL remain suppressed as for the existing salary read.
+
+#### Scenario: Category salary spans seniorities in one call
+
+- **WHEN** a client requests the category salary read for `backend`
+- **THEN** the response contains the salary bands for each seniority in `backend`
+  that has a qualifying sample, grouped by seniority and currency, in one response

--- a/openspec/changes/add-seo-insights-pages/specs/seo-insights-pages/spec.md
+++ b/openspec/changes/add-seo-insights-pages/specs/seo-insights-pages/spec.md
@@ -1,0 +1,97 @@
+## ADDED Requirements
+
+### Requirement: Insights hub page
+
+The system SHALL serve a server-rendered `GET /insights` hub page that links every
+covered category and each insight type, so crawlers and users can reach the
+per-category pages from one indexable entry point. The page SHALL be server-rendered
+(content present in the initial HTML) and carry canonical, meta, and Open Graph tags.
+
+#### Scenario: Hub lists covered categories
+
+- **WHEN** a client requests `/insights`
+- **THEN** the initial HTML contains links to each covered category's salary,
+  skills, and roles pages, and no client-side fetch is required to see them
+
+### Requirement: Per-category salary page
+
+The system SHALL serve a server-rendered `GET /insights/salary/[category]` page
+showing salary bands (percentiles) for the category broken down by seniority,
+reported per currency. The page SHALL read the insights data server-side and render
+it into the initial HTML.
+
+#### Scenario: Salary page renders bands server-side
+
+- **WHEN** a client requests `/insights/salary/backend` for a covered category
+- **THEN** the response is `200` with the salary bands present in the server-rendered
+  HTML, a data-driven intro sentence, and an "updated" date
+
+#### Scenario: Uncovered category is not a live page
+
+- **WHEN** a client requests `/insights/salary/<category>` for a category that does
+  not clear the data-quality gate
+- **THEN** the response is `404` (the page is not published) rather than a thin or
+  empty page
+
+### Requirement: Per-category skills page
+
+The system SHALL serve a server-rendered `GET /insights/skills/[category]` page
+ranking the most in-demand skills in that category with a growth measure, rendered
+into the initial HTML.
+
+#### Scenario: Skills page renders ranking server-side
+
+- **WHEN** a client requests `/insights/skills/backend` for a covered category
+- **THEN** the response is `200` with the ranked skills present in the server-rendered
+  HTML
+
+### Requirement: Per-category roles page
+
+The system SHALL serve a server-rendered `GET /insights/roles/[category]` page
+ranking the category's roles (its seniorities) by open-job demand with a growth
+measure, rendered into the initial HTML.
+
+#### Scenario: Roles page renders ranking server-side
+
+- **WHEN** a client requests `/insights/roles/backend` for a covered category
+- **THEN** the response is `200` with the ranked seniorities present in the
+  server-rendered HTML
+
+### Requirement: Data-quality gate for published pages
+
+A category SHALL be published (given live pages and sitemap entries) only when its
+insights data clears a configured threshold (e.g. a minimum number of open jobs, or
+a salary band at/above the sample floor). Categories that do not clear the gate SHALL
+NOT be linked from the hub, SHALL NOT appear in the sitemap, and their pages SHALL
+return `404`. The set of covered categories SHALL be derived from live data, not
+hard-coded.
+
+#### Scenario: Thin category excluded everywhere
+
+- **WHEN** a category's data is below the gate threshold
+- **THEN** it is absent from the hub links and the sitemap, and its pages `404`
+
+### Requirement: SEO content and structured data
+
+Each insights page SHALL carry, server-rendered: a unique `<title>` and meta
+description, a canonical URL, Open Graph tags, JSON-LD (at least BreadcrumbList and a
+Dataset descriptor), and internal links to the relevant `/jobs` filtered view, to the
+sibling categories, and to the other insight types for the same category.
+
+#### Scenario: Structured data and internal links present
+
+- **WHEN** any covered insights page is fetched
+- **THEN** its HTML contains a canonical tag, JSON-LD with BreadcrumbList, and links
+  to a `/jobs` filtered view plus the other insight types for the same category
+
+### Requirement: Insights sitemap shard
+
+The system SHALL expose a `sitemap-insights.xml` listing exactly the published
+insights URLs (hub + covered categories × insight types), and SHALL reference this
+shard from the sitemap index so search engines discover the pages.
+
+#### Scenario: Sitemap lists only published pages
+
+- **WHEN** `sitemap-insights.xml` is fetched
+- **THEN** it lists the hub and every covered category's pages, and no uncovered
+  (gated-out) category appears; the sitemap index references the shard

--- a/openspec/changes/add-seo-insights-pages/tasks.md
+++ b/openspec/changes/add-seo-insights-pages/tasks.md
@@ -1,0 +1,70 @@
+# Tasks
+
+Each task runs the spec-driven-tdd micro-cycle (RED → GREEN → REFACTOR → simplify →
+re-test → review) before it is checked off. Backend uses Go tests; pure web logic uses
+vitest; Svelte pages are verified via svelte-check + a visual screenshot pass.
+
+## 1. API: category-scoped roles
+
+- [ ] 1.1 Add an optional `category` param to the `ListInsightsRoles` read query in
+      `internal/db/queries/insights.sql` (filter `WHERE category = @category` when
+      non-empty; unchanged when empty). Regenerate sqlc; `go build ./...`.
+- [ ] 1.2 Wire the `category` param through `InsightsRoles` handler with vocab
+      validation (reuse `parseCategory`); echo it in `meta`. Unit-test the parse/echo
+      and add the `category` filter assertion to the roles integration test.
+
+## 2. API: per-category salary (all seniorities)
+
+- [ ] 2.1 Add a read that returns every seniority's salary bands for a category in one
+      call (query over `insights_salary_stats` for `category=@category`, all
+      seniorities, country `''`), preserving sample suppression. Regenerate sqlc.
+- [ ] 2.2 Expose it via the salary handler (a `category`-only mode returning
+      per-seniority bands) or a sibling route per design D2/Open-Questions; validate
+      params; extend the salary integration test to assert per-seniority grouping.
+
+## 3. Web: covered-set quality gate
+
+- [ ] 3.1 Add a helper (e.g. `web/src/lib/insights.ts`) that fetches the insights data
+      and derives the covered-category set + per-category view models, applying the
+      gate thresholds (min open jobs / salary sample floor). Pure logic — vitest-cover
+      the gate (covered vs excluded, empty-data case).
+
+## 4. Web: shared page component + hub
+
+- [ ] 4.1 Build the shared insights page layout component (breadcrumb, data-driven
+      auto-intro, data section slot, internal-link rail) as pure/presentational as
+      possible; svelte-check clean.
+- [ ] 4.2 Add `/insights` hub route (`+page.server.ts` + `+page.svelte`): lists covered
+      categories × insight types from the gate helper; server-rendered links.
+
+## 5. Web: per-category routes
+
+- [ ] 5.1 `/insights/salary/[category]` — `+page.server.ts` loads the category salary
+      bands (404 if not covered), `+page.svelte` renders bands by seniority + intro +
+      links + `Cache-Control: s-maxage=3600`.
+- [ ] 5.2 `/insights/skills/[category]` — same shape over the skills read.
+- [ ] 5.3 `/insights/roles/[category]` — same shape over the category-scoped roles read.
+
+## 6. Web: SEO metadata & structured data
+
+- [ ] 6.1 Per page: unique `<title>`/meta description, canonical, Open Graph, and
+      JSON-LD (BreadcrumbList + Dataset) rendered server-side; internal links to the
+      `/jobs` filtered view, sibling categories, and the other insight types.
+- [ ] 6.2 Verify the rendered HTML carries the structured data and links (svelte-check
+      + a headless-Chrome screenshot/DOM check on a covered category and a 404 on a
+      gated-out one).
+
+## 7. Sitemap
+
+- [ ] 7.1 Add `web/src/routes/sitemap-insights.xml` listing only covered pages (hub +
+      covered categories × insight types), and reference it from the sitemap index
+      (`sitemap.xml`). Assert (test/manual) an uncovered category is absent.
+
+## 8. Docs & verify
+
+- [ ] 8.1 Document the two API additions in `docs/API.md` and `web/static/openapi.yaml`.
+- [ ] 8.2 `go build ./... && go vet ./... && go test ./...`; run insights integration
+      tests; `npm run check` in web.
+- [ ] 8.3 verification-before-completion: run the app against a seeded DB with rollups
+      populated, load `/insights`, a covered category's three pages, `sitemap-insights.xml`,
+      and a gated-out category (expect 404); confirm server-rendered content + JSON-LD.

--- a/openspec/changes/add-seo-insights-pages/tasks.md
+++ b/openspec/changes/add-seo-insights-pages/tasks.md
@@ -6,65 +6,65 @@ vitest; Svelte pages are verified via svelte-check + a visual screenshot pass.
 
 ## 1. API: category-scoped roles
 
-- [ ] 1.1 Add an optional `category` param to the `ListInsightsRoles` read query in
+- [x] 1.1 Add an optional `category` param to the `ListInsightsRoles` read query in
       `internal/db/queries/insights.sql` (filter `WHERE category = @category` when
       non-empty; unchanged when empty). Regenerate sqlc; `go build ./...`.
-- [ ] 1.2 Wire the `category` param through `InsightsRoles` handler with vocab
+- [x] 1.2 Wire the `category` param through `InsightsRoles` handler with vocab
       validation (reuse `parseCategory`); echo it in `meta`. Unit-test the parse/echo
       and add the `category` filter assertion to the roles integration test.
 
 ## 2. API: per-category salary (all seniorities)
 
-- [ ] 2.1 Add a read that returns every seniority's salary bands for a category in one
+- [x] 2.1 Add a read that returns every seniority's salary bands for a category in one
       call (query over `insights_salary_stats` for `category=@category`, all
       seniorities, country `''`), preserving sample suppression. Regenerate sqlc.
-- [ ] 2.2 Expose it via the salary handler (a `category`-only mode returning
+- [x] 2.2 Expose it via the salary handler (a `category`-only mode returning
       per-seniority bands) or a sibling route per design D2/Open-Questions; validate
       params; extend the salary integration test to assert per-seniority grouping.
 
 ## 3. Web: covered-set quality gate
 
-- [ ] 3.1 Add a helper (e.g. `web/src/lib/insights.ts`) that fetches the insights data
+- [x] 3.1 Add a helper (e.g. `web/src/lib/insights.ts`) that fetches the insights data
       and derives the covered-category set + per-category view models, applying the
       gate thresholds (min open jobs / salary sample floor). Pure logic — vitest-cover
       the gate (covered vs excluded, empty-data case).
 
 ## 4. Web: shared page component + hub
 
-- [ ] 4.1 Build the shared insights page layout component (breadcrumb, data-driven
+- [x] 4.1 Build the shared insights page layout component (breadcrumb, data-driven
       auto-intro, data section slot, internal-link rail) as pure/presentational as
       possible; svelte-check clean.
-- [ ] 4.2 Add `/insights` hub route (`+page.server.ts` + `+page.svelte`): lists covered
+- [x] 4.2 Add `/insights` hub route (`+page.server.ts` + `+page.svelte`): lists covered
       categories × insight types from the gate helper; server-rendered links.
 
 ## 5. Web: per-category routes
 
-- [ ] 5.1 `/insights/salary/[category]` — `+page.server.ts` loads the category salary
+- [x] 5.1 `/insights/salary/[category]` — `+page.server.ts` loads the category salary
       bands (404 if not covered), `+page.svelte` renders bands by seniority + intro +
       links + `Cache-Control: s-maxage=3600`.
-- [ ] 5.2 `/insights/skills/[category]` — same shape over the skills read.
-- [ ] 5.3 `/insights/roles/[category]` — same shape over the category-scoped roles read.
+- [x] 5.2 `/insights/skills/[category]` — same shape over the skills read.
+- [x] 5.3 `/insights/roles/[category]` — same shape over the category-scoped roles read.
 
 ## 6. Web: SEO metadata & structured data
 
-- [ ] 6.1 Per page: unique `<title>`/meta description, canonical, Open Graph, and
+- [x] 6.1 Per page: unique `<title>`/meta description, canonical, Open Graph, and
       JSON-LD (BreadcrumbList + Dataset) rendered server-side; internal links to the
       `/jobs` filtered view, sibling categories, and the other insight types.
-- [ ] 6.2 Verify the rendered HTML carries the structured data and links (svelte-check
+- [x] 6.2 Verify the rendered HTML carries the structured data and links (svelte-check
       + a headless-Chrome screenshot/DOM check on a covered category and a 404 on a
       gated-out one).
 
 ## 7. Sitemap
 
-- [ ] 7.1 Add `web/src/routes/sitemap-insights.xml` listing only covered pages (hub +
+- [x] 7.1 Add `web/src/routes/sitemap-insights.xml` listing only covered pages (hub +
       covered categories × insight types), and reference it from the sitemap index
       (`sitemap.xml`). Assert (test/manual) an uncovered category is absent.
 
 ## 8. Docs & verify
 
-- [ ] 8.1 Document the two API additions in `docs/API.md` and `web/static/openapi.yaml`.
-- [ ] 8.2 `go build ./... && go vet ./... && go test ./...`; run insights integration
+- [x] 8.1 Document the two API additions in `docs/API.md` and `web/static/openapi.yaml`.
+- [x] 8.2 `go build ./... && go vet ./... && go test ./...`; run insights integration
       tests; `npm run check` in web.
-- [ ] 8.3 verification-before-completion: run the app against a seeded DB with rollups
+- [x] 8.3 verification-before-completion: run the app against a seeded DB with rollups
       populated, load `/insights`, a covered category's three pages, `sitemap-insights.xml`,
       and a gated-out category (expect 404); confirm server-rendered content + JSON-LD.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -70,6 +70,28 @@ export interface SitemapEntry {
   updated_at: string;
 }
 
+/** Aggregate market-insight wire shapes (the /api/v1/insights/* reads). */
+export interface InsightRole {
+  category: string;
+  seniority: string;
+  open_count: number;
+  growth: number;
+}
+export interface InsightSkill {
+  skill: string;
+  open_count: number;
+  growth: number;
+}
+export interface InsightSalaryBand {
+  seniority: string;
+  currency: string;
+  period: string;
+  sample_size: number;
+  p25: number;
+  p50: number;
+  p75: number;
+}
+
 /** One posting in a role cluster — a single city's opening under a collapsed role
  *  (see the /jobs/:slug/copies endpoint). Each keeps its own location and apply URL. */
 export interface JobCopy {
@@ -394,6 +416,46 @@ export function createApi(
    *  count-ordered, backing the company "Industry" filter's searchable options. */
   async function listCompanySubindustries(): Promise<{ value: string; count: number }[]> {
     return requestData<{ value: string; count: number }[]>('/api/v1/companies/subindustries');
+  }
+
+  // --- Insights (aggregate market data behind the /insights SEO pages) --------
+
+  function insightsQuery(opts: {
+    category?: string;
+    country?: string;
+    sort?: 'open' | 'growth';
+    limit?: number;
+  }): string {
+    const q = new URLSearchParams();
+    if (opts.category) q.set('category', opts.category);
+    if (opts.country) q.set('country', opts.country);
+    if (opts.sort) q.set('sort', opts.sort);
+    if (opts.limit != null) q.set('limit', String(opts.limit));
+    return q.toString();
+  }
+
+  /** Ranked roles (category × seniority). Pass `category` to restrict to one
+   *  category's seniorities (the per-category roles page); omit for all. */
+  async function insightsRoles(
+    opts: { category?: string; country?: string; sort?: 'open' | 'growth'; limit?: number } = {},
+  ): Promise<InsightRole[]> {
+    return requestData<InsightRole[]>(`/api/v1/insights/roles?${insightsQuery(opts)}`);
+  }
+
+  /** Ranked skills, optionally scoped by category or country (not both). */
+  async function insightsSkills(
+    opts: { category?: string; country?: string; sort?: 'open' | 'growth'; limit?: number } = {},
+  ): Promise<InsightSkill[]> {
+    return requestData<InsightSkill[]>(`/api/v1/insights/skills?${insightsQuery(opts)}`);
+  }
+
+  /** Every seniority's salary bands for one category, in a single call (the
+   *  per-category salary page). Rows carry their own `seniority` ('' = the
+   *  category-wide band). */
+  async function insightsSalaryByCategory(category: string): Promise<InsightSalaryBand[]> {
+    return requestData<InsightSalaryBand[]>(
+      `/api/v1/insights/salary?category=${encodeURIComponent(category)}`,
+    );
   }
 
   // --- Sitemap --------------------------------------------------------------
@@ -936,6 +998,9 @@ export function createApi(
     listCompanies,
     getCompany,
     listCompanySubindustries,
+    insightsRoles,
+    insightsSkills,
+    insightsSalaryByCategory,
     sitemapJobs,
     sitemapCompanies,
     sitemapCompanyBoundaries,

--- a/web/src/lib/components/InsightsPageShell.svelte
+++ b/web/src/lib/components/InsightsPageShell.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  // Shared chrome for the per-category insights pages (salary / skills / roles):
+  // a visible breadcrumb, the H1, the data-driven intro, an "updated" line, the
+  // data section (passed as a snippet), and the internal-link rail (the other two
+  // insight types for this category, a link into the filtered /jobs feed, and
+  // sibling-category chips). Purely presentational — the route loads the data.
+  import { resolve } from '$app/paths';
+  import type { Snippet } from 'svelte';
+  import type { CoveredCategory } from '$lib/insights';
+
+  type Kind = 'salary' | 'skills' | 'roles';
+
+  // resolve() needs a literal route id, so map the dynamic kind explicitly.
+  function kindHref(k: Kind, cat: string): string {
+    if (k === 'salary') return resolve('/insights/salary/[category]', { category: cat });
+    if (k === 'skills') return resolve('/insights/skills/[category]', { category: cat });
+    return resolve('/insights/roles/[category]', { category: cat });
+  }
+
+  let {
+    category,
+    label,
+    kind,
+    title,
+    intro,
+    updated,
+    covered,
+    children,
+  }: {
+    category: string;
+    label: string;
+    kind: Kind;
+    title: string;
+    intro: string;
+    updated: string;
+    covered: CoveredCategory[];
+    children: Snippet;
+  } = $props();
+
+  const KIND_LABEL: Record<Kind, string> = {
+    salary: 'Salaries',
+    skills: 'Skills',
+    roles: 'Roles',
+  };
+
+  // The other two insight types for this same category.
+  const otherKinds = $derived(
+    (['salary', 'skills', 'roles'] as Kind[]).filter((k) => k !== kind),
+  );
+  // A few sibling categories to cross-link (excluding the current one).
+  const siblings = $derived(covered.filter((c) => c.category !== category).slice(0, 8));
+</script>
+
+<article class="mx-auto w-full max-w-4xl px-4 py-8">
+  <nav aria-label="Breadcrumb" class="mb-4 text-sm text-gray-500">
+    <a href={resolve('/')} class="hover:underline">freehire</a>
+    <span aria-hidden="true"> › </span>
+    <a href={resolve('/insights')} class="hover:underline">Insights</a>
+    <span aria-hidden="true"> › </span>
+    <span class="text-gray-700">{label} {KIND_LABEL[kind]}</span>
+  </nav>
+
+  <h1 class="text-3xl font-bold tracking-tight text-gray-900">{title}</h1>
+  <p class="mt-3 text-lg text-gray-600">{intro}</p>
+  <p class="mt-1 text-xs text-gray-400">Updated {updated}</p>
+
+  <section class="mt-8">
+    {@render children()}
+  </section>
+
+  <aside class="mt-10 border-t border-gray-200 pt-6">
+    <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
+      <span class="font-medium text-gray-700">More on {label}:</span>
+      {#each otherKinds as k (k)}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is resolve()d inside kindHref; the linter can't trace it through the helper -->
+        <a href={kindHref(k, category)} class="text-blue-600 hover:underline">{KIND_LABEL[k]}</a>
+      {/each}
+      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal /jobs filter link; resolve()d base plus a query string, no dynamic route to resolve -->
+      <a href={`${resolve('/jobs')}?category=${encodeURIComponent(category)}`} class="text-blue-600 hover:underline">
+        Browse {label} jobs →
+      </a>
+    </div>
+
+    {#if siblings.length > 0}
+      <div class="mt-4 flex flex-wrap items-center gap-2 text-sm">
+        <span class="font-medium text-gray-700">Other categories:</span>
+        {#each siblings as s (s.category)}
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is resolve()d inside kindHref; the linter can't trace it through the helper -->
+          <a href={kindHref(kind, s.category)} class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 hover:bg-gray-200">
+            {s.label}
+          </a>
+        {/each}
+      </div>
+    {/if}
+  </aside>
+</article>

--- a/web/src/lib/insights.test.ts
+++ b/web/src/lib/insights.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import type { InsightRole, InsightSalaryBand, InsightSkill } from './api';
+import {
+  coveredCategories,
+  isCovered,
+  sortBandsBySeniority,
+  formatSalary,
+  salaryIntro,
+  skillsIntro,
+  rolesIntro,
+  MIN_CATEGORY_OPEN,
+  categoryLabel,
+} from './insights';
+
+const role = (category: string, seniority: string, open_count: number): InsightRole => ({
+  category,
+  seniority,
+  open_count,
+  growth: 0,
+});
+
+describe('coveredCategories', () => {
+  it('publishes only categories whose total open-count clears the floor', () => {
+    const roles = [
+      role('backend', 'senior', MIN_CATEGORY_OPEN),
+      role('backend', 'junior', 5),
+      role('mobile', 'senior', MIN_CATEGORY_OPEN - 1), // below floor → excluded
+    ];
+    const covered = coveredCategories(roles).map((c) => c.category);
+    expect(covered).toContain('backend');
+    expect(covered).not.toContain('mobile');
+  });
+
+  it("excludes 'other' and blank categories", () => {
+    const roles = [role('other', 'senior', 1000), role('', 'senior', 1000)];
+    expect(coveredCategories(roles)).toHaveLength(0);
+  });
+
+  it('sorts by demand descending', () => {
+    const roles = [
+      role('frontend', 'senior', 100),
+      role('backend', 'senior', 300),
+      role('design', 'senior', 200),
+    ];
+    expect(coveredCategories(roles).map((c) => c.category)).toEqual(['backend', 'design', 'frontend']);
+  });
+
+  it('isCovered mirrors the gate', () => {
+    const roles = [role('backend', 'senior', 1000)];
+    expect(isCovered(roles, 'backend')).toBe(true);
+    expect(isCovered(roles, 'mobile')).toBe(false);
+  });
+});
+
+describe('sortBandsBySeniority', () => {
+  it('orders by seniority rank with the category-wide band last', () => {
+    const band = (seniority: string): InsightSalaryBand => ({
+      seniority,
+      currency: 'USD',
+      period: 'year',
+      sample_size: 10,
+      p25: 1,
+      p50: 2,
+      p75: 3,
+    });
+    const sorted = sortBandsBySeniority([band('senior'), band(''), band('junior')]).map((b) => b.seniority);
+    expect(sorted).toEqual(['junior', 'senior', '']);
+  });
+});
+
+describe('formatSalary', () => {
+  it('formats a known currency as currency', () => {
+    expect(formatSalary(155000, 'USD')).toBe('$155,000');
+  });
+  it('normalizes a lowercase ISO code (Intl is case-insensitive)', () => {
+    expect(formatSalary(1000, 'usd')).toBe('$1,000');
+  });
+  it('falls back gracefully for a malformed currency code', () => {
+    expect(formatSalary(1000, 'US')).toBe('1,000 US');
+  });
+});
+
+describe('auto-intros', () => {
+  it('salaryIntro states the median from the richest yearly band', () => {
+    const bands: InsightSalaryBand[] = [
+      { seniority: '', currency: 'USD', period: 'year', sample_size: 200, p25: 130000, p50: 155000, p75: 180000 },
+    ];
+    const intro = salaryIntro('backend', bands);
+    expect(intro).toContain('Backend');
+    expect(intro).toContain('$155,000');
+    expect(intro).toContain('200 postings');
+  });
+
+  it('salaryIntro degrades when there is no yearly band', () => {
+    expect(salaryIntro('backend', [])).toContain('Backend');
+  });
+
+  it('skillsIntro names the top skills', () => {
+    const skills: InsightSkill[] = [
+      { skill: 'go', open_count: 100, growth: 5 },
+      { skill: 'sql', open_count: 60, growth: 2 },
+      { skill: 'kubernetes', open_count: 40, growth: 1 },
+    ];
+    expect(skillsIntro('backend', skills)).toContain('go, sql, kubernetes');
+  });
+
+  it('rolesIntro totals open roles', () => {
+    const roles = [role('backend', 'senior', 30), role('backend', 'junior', 20)];
+    expect(rolesIntro('backend', roles)).toContain('50 open Backend roles');
+  });
+});
+
+describe('categoryLabel', () => {
+  it('maps known tokens and title-cases unknowns', () => {
+    expect(categoryLabel('ml_ai')).toBe('ML / AI');
+    expect(categoryLabel('quantum_widgets')).toBe('Quantum Widgets');
+  });
+});

--- a/web/src/lib/insights.ts
+++ b/web/src/lib/insights.ts
@@ -1,0 +1,156 @@
+// Pure helpers behind the /insights SEO pages: the data-quality gate that decides
+// which categories get published pages, human labels for the enrichment category /
+// seniority tokens, and the deterministic auto-intro sentences. Kept free of fetch
+// and Svelte so it is unit-testable in isolation; the routes fetch via the API and
+// feed these functions.
+
+import type { InsightRole, InsightSalaryBand, InsightSkill } from './api';
+
+/** A category is published only when its open-job demand clears this floor, so no
+ *  thin page ships. Tunable; deliberately conservative. */
+export const MIN_CATEGORY_OPEN = 25;
+
+/** Human labels for the lowercase enrichment category tokens. Unlisted tokens fall
+ *  back to a title-cased form. `other` is intentionally never published. */
+export const CATEGORY_LABELS: Record<string, string> = {
+  backend: 'Backend',
+  frontend: 'Frontend',
+  fullstack: 'Full-Stack',
+  mobile: 'Mobile',
+  devops: 'DevOps',
+  sre: 'SRE',
+  network_engineering: 'Network Engineering',
+  data_engineering: 'Data Engineering',
+  data_science: 'Data Science',
+  data_analytics: 'Data Analytics',
+  ml_ai: 'ML / AI',
+  ai_engineering: 'AI Engineering',
+  qa: 'QA',
+  security: 'Security',
+  hardware: 'Hardware',
+  embedded: 'Embedded',
+  blockchain: 'Blockchain',
+  architecture: 'Architecture',
+  design: 'Design',
+  product: 'Product',
+  project_management: 'Project Management',
+  management: 'Management',
+  marketing: 'Marketing',
+  sales: 'Sales',
+  support: 'Support',
+};
+
+/** Seniority tokens in rank order, with labels. '' is the category-wide band. */
+export const SENIORITY_ORDER = [
+  'intern',
+  'junior',
+  'middle',
+  'senior',
+  'lead',
+  'staff',
+  'principal',
+  'c_level',
+] as const;
+
+export const SENIORITY_LABELS: Record<string, string> = {
+  '': 'All levels',
+  intern: 'Intern',
+  junior: 'Junior',
+  middle: 'Middle',
+  senior: 'Senior',
+  lead: 'Lead',
+  staff: 'Staff',
+  principal: 'Principal',
+  c_level: 'C-level',
+};
+
+export function categoryLabel(category: string): string {
+  return CATEGORY_LABELS[category] ?? category.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function seniorityLabel(seniority: string): string {
+  return SENIORITY_LABELS[seniority] ?? seniority;
+}
+
+export interface CoveredCategory {
+  category: string;
+  label: string;
+  openCount: number;
+}
+
+/** Derive the published category set from the global roles ranking: a category is
+ *  covered when its total open-count across seniorities clears MIN_CATEGORY_OPEN.
+ *  `other` and blanks are excluded. Sorted by demand, so the hub lists the biggest
+ *  categories first. */
+export function coveredCategories(roles: InsightRole[]): CoveredCategory[] {
+  const totals = new Map<string, number>();
+  for (const r of roles) {
+    if (!r.category || r.category === 'other') continue;
+    totals.set(r.category, (totals.get(r.category) ?? 0) + r.open_count);
+  }
+  return [...totals.entries()]
+    .filter(([, open]) => open >= MIN_CATEGORY_OPEN)
+    .map(([category, openCount]) => ({ category, label: categoryLabel(category), openCount }))
+    .sort((a, b) => b.openCount - a.openCount);
+}
+
+/** Whether a specific category clears the gate (drives the per-page 404). */
+export function isCovered(roles: InsightRole[], category: string): boolean {
+  return coveredCategories(roles).some((c) => c.category === category);
+}
+
+/** Sort salary bands into seniority order (category-wide '' band last). */
+export function sortBandsBySeniority(bands: InsightSalaryBand[]): InsightSalaryBand[] {
+  const rank = (s: string) => {
+    const i = (SENIORITY_ORDER as readonly string[]).indexOf(s);
+    return i === -1 ? SENIORITY_ORDER.length + 1 : i;
+  };
+  return [...bands].sort((a, b) => rank(a.seniority) - rank(b.seniority) || b.sample_size - a.sample_size);
+}
+
+/** Format an integer salary figure in its currency, compactly (e.g. $155,000). */
+export function formatSalary(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    // Unknown/lowercase currency code → plain number with the code appended.
+    return `${amount.toLocaleString('en-US')} ${currency.toUpperCase()}`;
+  }
+}
+
+// --- Deterministic auto-intro sentences (no LLM) -----------------------------
+
+/** Pick the richest yearly band for the intro figure, preferring the category-wide
+ *  ('' seniority) row, else the largest sample. Returns null if none qualify. */
+function headlineBand(bands: InsightSalaryBand[]): InsightSalaryBand | null {
+  const yearly = bands.filter((b) => b.period === 'year');
+  if (yearly.length === 0) return null;
+  const wide = yearly.filter((b) => b.seniority === '');
+  const pool = wide.length ? wide : yearly;
+  return pool.reduce((best, b) => (b.sample_size > best.sample_size ? b : best));
+}
+
+export function salaryIntro(category: string, bands: InsightSalaryBand[]): string {
+  const label = categoryLabel(category);
+  const b = headlineBand(bands);
+  if (!b) return `Salary ranges for ${label} roles, aggregated from open postings on freehire.`;
+  return `${label} roles pay a median of ${formatSalary(b.p50, b.currency)} per year across ${b.sample_size} postings that disclose pay, ranging from ${formatSalary(b.p25, b.currency)} to ${formatSalary(b.p75, b.currency)}.`;
+}
+
+export function skillsIntro(category: string, skills: InsightSkill[]): string {
+  const label = categoryLabel(category);
+  if (skills.length === 0) return `The most in-demand skills for ${label} roles on freehire.`;
+  const top = skills.slice(0, 3).map((s) => s.skill).join(', ');
+  return `The most in-demand skills for ${label} roles right now are ${top} — ranked across ${skills.reduce((n, s) => n + s.open_count, 0)} open postings.`;
+}
+
+export function rolesIntro(category: string, roles: InsightRole[]): string {
+  const label = categoryLabel(category);
+  const total = roles.reduce((n, r) => n + r.open_count, 0);
+  if (total === 0) return `Open ${label} roles by seniority on freehire.`;
+  return `There are ${total} open ${label} roles on freehire right now, broken down by seniority and how fast each level is growing.`;
+}

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -303,6 +303,27 @@ export function collectionPageJsonLd(
   };
 }
 
+/** schema.org Dataset descriptor for an insights page — tells search/AI engines
+ *  the page presents an aggregate dataset (salary bands, demand rankings) free to
+ *  access, published by freehire. Aggregate-only, so no distribution file is
+ *  advertised. */
+export function datasetJsonLd(
+  name: string,
+  description: string,
+  url: string,
+  origin: string
+): Record<string, unknown> {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name,
+    description,
+    url,
+    isAccessibleForFree: true,
+    creator: { '@type': 'Organization', name: SITE, url: `${origin}/` },
+  };
+}
+
 /** schema.org FAQPage. The questions must also appear as visible text on the page
  *  (Google's requirement), so it is built from the same source as the rendered FAQ. */
 export function faqPageJsonLd(faqs: FaqItem[]): Record<string, unknown> {

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -36,6 +36,17 @@ export function blogPaths(posts: { slug: string }[]): string[] {
   return ['/blog', ...posts.map((post) => `/blog/${post.slug}`)];
 }
 
+/** Sitemap paths for the insights pages: the hub plus salary/skills/roles for each
+ *  covered category. Takes the already-gated category tokens (from
+ *  `coveredCategories`) so it stays pure — a thin category is never listed. */
+export function insightsPaths(categories: string[]): string[] {
+  const paths = ['/insights'];
+  for (const c of categories) {
+    paths.push(`/insights/salary/${c}`, `/insights/skills/${c}`, `/insights/roles/${c}`);
+  }
+  return paths;
+}
+
 export interface UrlEntry {
   loc: string;
   lastmod?: string;

--- a/web/src/routes/insights/+page.server.ts
+++ b/web/src/routes/insights/+page.server.ts
@@ -1,0 +1,12 @@
+import { serverApi } from '$lib/server/api';
+import { coveredCategories } from '$lib/insights';
+import type { PageServerLoad } from './$types';
+
+// The insights hub: the entry point that links every covered category's three
+// pages, so crawlers reach them from one indexable page. Covered set is derived
+// from the global roles ranking (the gate). SSR-live + CDN cache window.
+export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
+  const globalRoles = await serverApi(fetch).insightsRoles({ limit: 200 });
+  setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=3600' });
+  return { covered: coveredCategories(globalRoles) };
+};

--- a/web/src/routes/insights/+page.svelte
+++ b/web/src/routes/insights/+page.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import Seo from '$lib/components/Seo.svelte';
+  import { breadcrumbJsonLd, jsonLdScript } from '$lib/seo';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/insights`);
+  const description =
+    'Aggregate job-market data from freehire: salaries, in-demand skills, and hiring demand for every tech category.';
+  const jsonLd = $derived(
+    jsonLdScript([
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Insights', url: canonical },
+      ]),
+    ]),
+  );
+</script>
+
+<Seo title="Job Market Insights · freehire" {description} {canonical} />
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD from jsonLdScript, which escapes `<` -->
+  {@html jsonLd}
+</svelte:head>
+
+<div class="mx-auto w-full max-w-4xl px-4 py-8">
+  <h1 class="text-3xl font-bold tracking-tight text-gray-900">Job Market Insights</h1>
+  <p class="mt-3 text-lg text-gray-600">{description}</p>
+  <p class="mt-1 text-sm text-gray-500">
+    Aggregated from open postings on freehire, refreshed through the day. All data is
+    also available on the <a href={resolve('/docs/api')} class="text-blue-600 hover:underline">open API</a>.
+  </p>
+
+  {#if data.covered.length === 0}
+    <p class="mt-8 text-gray-500">Insights are being computed — check back shortly.</p>
+  {:else}
+    <div class="mt-8 grid gap-4 sm:grid-cols-2">
+      {#each data.covered as c (c.category)}
+        <div class="rounded-lg border border-gray-200 p-4">
+          <h2 class="text-lg font-semibold text-gray-900">{c.label}</h2>
+          <p class="mt-0.5 text-xs text-gray-500">{c.openCount.toLocaleString('en-US')} open roles</p>
+          <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+            <a href={resolve('/insights/salary/[category]', { category: c.category })} class="text-blue-600 hover:underline">Salaries</a>
+            <a href={resolve('/insights/skills/[category]', { category: c.category })} class="text-blue-600 hover:underline">Skills</a>
+            <a href={resolve('/insights/roles/[category]', { category: c.category })} class="text-blue-600 hover:underline">Roles</a>
+          </div>
+        </div>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/web/src/routes/insights/roles/[category]/+page.server.ts
+++ b/web/src/routes/insights/roles/[category]/+page.server.ts
@@ -1,0 +1,27 @@
+import { error } from '@sveltejs/kit';
+import { serverApi } from '$lib/server/api';
+import { coveredCategories, isCovered, categoryLabel, rolesIntro } from '$lib/insights';
+import type { PageServerLoad } from './$types';
+
+// Per-category roles landing page: the category's seniorities ranked by open-job
+// demand. Gated + SSR-live like the sibling pages. The global roles ranking drives
+// the gate + cross-links; the page's own rows come from the category-scoped read so
+// a low-volume seniority isn't lost past the global top-N cutoff.
+export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
+  const category = params.category;
+  const api = serverApi(fetch);
+
+  const globalRoles = await api.insightsRoles({ limit: 200 });
+  if (!isCovered(globalRoles, category)) error(404, 'No role insights for this category yet');
+
+  const roles = await api.insightsRoles({ category, sort: 'open', limit: 20 });
+  setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=3600' });
+
+  return {
+    category,
+    label: categoryLabel(category),
+    covered: coveredCategories(globalRoles),
+    roles,
+    intro: rolesIntro(category, roles),
+  };
+};

--- a/web/src/routes/insights/roles/[category]/+page.svelte
+++ b/web/src/routes/insights/roles/[category]/+page.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
+  import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import { seniorityLabel } from '$lib/insights';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/insights/roles/${data.category}`);
+  const title = $derived(`Most-Hiring ${data.label} Roles · freehire`);
+  const updated = $derived(
+    new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
+  );
+  const jsonLd = $derived(
+    jsonLdScript([
+      datasetJsonLd(`${data.label} roles by demand`, data.intro, canonical, origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Insights', url: `${origin}/insights` },
+        { name: `${data.label} Roles`, url: canonical },
+      ]),
+    ]),
+  );
+</script>
+
+<Seo {title} description={data.intro} {canonical} />
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD from jsonLdScript, which escapes `<` -->
+  {@html jsonLd}
+</svelte:head>
+
+<InsightsPageShell
+  category={data.category}
+  label={data.label}
+  kind="roles"
+  {title}
+  intro={data.intro}
+  {updated}
+  covered={data.covered}
+>
+  {#if data.roles.length === 0}
+    <p class="text-gray-500">No role data for this category yet.</p>
+  {:else}
+    <table class="w-full border-collapse text-left text-sm">
+      <thead>
+        <tr class="border-b border-gray-300 text-gray-500">
+          <th class="py-2 pr-4 font-medium">Level</th>
+          <th class="py-2 pr-4 font-medium text-right">Open roles</th>
+          <th class="py-2 font-medium text-right">30-day growth</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.roles as r (r.seniority)}
+          <tr class="border-b border-gray-100">
+            <td class="py-2 pr-4 font-medium text-gray-900">{seniorityLabel(r.seniority)}</td>
+            <td class="py-2 pr-4 text-right tabular-nums">{r.open_count.toLocaleString('en-US')}</td>
+            <td
+              class="py-2 text-right tabular-nums"
+              class:text-green-600={r.growth > 0}
+              class:text-gray-400={r.growth === 0}
+              class:text-red-600={r.growth < 0}
+            >
+              {r.growth > 0 ? '+' : ''}{r.growth.toLocaleString('en-US')}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</InsightsPageShell>

--- a/web/src/routes/insights/salary/[category]/+page.server.ts
+++ b/web/src/routes/insights/salary/[category]/+page.server.ts
@@ -1,0 +1,27 @@
+import { error } from '@sveltejs/kit';
+import { serverApi } from '$lib/server/api';
+import { coveredCategories, isCovered, categoryLabel, sortBandsBySeniority, salaryIntro } from '$lib/insights';
+import type { PageServerLoad } from './$types';
+
+// Per-category salary landing page. The gate (global roles ranking) decides whether
+// this category is published; an uncovered category (or an unknown slug) 404s rather
+// than rendering a thin page. Served SSR-live with a CDN cache window so crawler
+// bursts don't hit the API per request.
+export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
+  const category = params.category;
+  const api = serverApi(fetch);
+
+  const globalRoles = await api.insightsRoles({ limit: 200 });
+  if (!isCovered(globalRoles, category)) error(404, 'No salary insights for this category yet');
+
+  const bands = sortBandsBySeniority(await api.insightsSalaryByCategory(category));
+  setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=3600' });
+
+  return {
+    category,
+    label: categoryLabel(category),
+    covered: coveredCategories(globalRoles),
+    bands,
+    intro: salaryIntro(category, bands),
+  };
+};

--- a/web/src/routes/insights/salary/[category]/+page.svelte
+++ b/web/src/routes/insights/salary/[category]/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
+  import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import { formatSalary, seniorityLabel } from '$lib/insights';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/insights/salary/${data.category}`);
+  const title = $derived(`${data.label} Salaries · freehire`);
+  const updated = $derived(
+    new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
+  );
+  const jsonLd = $derived(
+    jsonLdScript([
+      datasetJsonLd(`${data.label} salaries`, data.intro, canonical, origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Insights', url: `${origin}/insights` },
+        { name: `${data.label} Salaries`, url: canonical },
+      ]),
+    ]),
+  );
+</script>
+
+<Seo {title} description={data.intro} {canonical} />
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD from jsonLdScript, which escapes `<` -->
+  {@html jsonLd}
+</svelte:head>
+
+<InsightsPageShell
+  category={data.category}
+  label={data.label}
+  kind="salary"
+  {title}
+  intro={data.intro}
+  {updated}
+  covered={data.covered}
+>
+  {#if data.bands.length === 0}
+    <p class="text-gray-500">No salary figures disclosed for this category yet.</p>
+  {:else}
+    <table class="w-full border-collapse text-left text-sm">
+      <thead>
+        <tr class="border-b border-gray-300 text-gray-500">
+          <th class="py-2 pr-4 font-medium">Level</th>
+          <th class="py-2 pr-4 font-medium">Currency</th>
+          <th class="py-2 pr-4 font-medium">Period</th>
+          <th class="py-2 pr-4 font-medium text-right">25th</th>
+          <th class="py-2 pr-4 font-medium text-right">Median</th>
+          <th class="py-2 pr-4 font-medium text-right">75th</th>
+          <th class="py-2 font-medium text-right">Postings</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.bands as b (b.seniority + b.currency + b.period)}
+          <tr class="border-b border-gray-100">
+            <td class="py-2 pr-4 font-medium text-gray-900">{seniorityLabel(b.seniority)}</td>
+            <td class="py-2 pr-4 text-gray-600">{b.currency.toUpperCase()}</td>
+            <td class="py-2 pr-4 text-gray-600">{b.period}</td>
+            <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p25, b.currency)}</td>
+            <td class="py-2 pr-4 text-right font-semibold tabular-nums">{formatSalary(b.p50, b.currency)}</td>
+            <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p75, b.currency)}</td>
+            <td class="py-2 text-right tabular-nums text-gray-500">{b.sample_size}</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</InsightsPageShell>

--- a/web/src/routes/insights/skills/[category]/+page.server.ts
+++ b/web/src/routes/insights/skills/[category]/+page.server.ts
@@ -1,0 +1,25 @@
+import { error } from '@sveltejs/kit';
+import { serverApi } from '$lib/server/api';
+import { coveredCategories, isCovered, categoryLabel, skillsIntro } from '$lib/insights';
+import type { PageServerLoad } from './$types';
+
+// Per-category skill-demand landing page. Gated like the salary page: an uncovered
+// category 404s. SSR-live + CDN cache window.
+export const load: PageServerLoad = async ({ params, fetch, setHeaders }) => {
+  const category = params.category;
+  const api = serverApi(fetch);
+
+  const globalRoles = await api.insightsRoles({ limit: 200 });
+  if (!isCovered(globalRoles, category)) error(404, 'No skill insights for this category yet');
+
+  const skills = await api.insightsSkills({ category, sort: 'open', limit: 40 });
+  setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=3600' });
+
+  return {
+    category,
+    label: categoryLabel(category),
+    covered: coveredCategories(globalRoles),
+    skills,
+    intro: skillsIntro(category, skills),
+  };
+};

--- a/web/src/routes/insights/skills/[category]/+page.svelte
+++ b/web/src/routes/insights/skills/[category]/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import Seo from '$lib/components/Seo.svelte';
+  import InsightsPageShell from '$lib/components/InsightsPageShell.svelte';
+  import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/insights/skills/${data.category}`);
+  const title = $derived(`Most In-Demand ${data.label} Skills · freehire`);
+  const updated = $derived(
+    new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
+  );
+  const jsonLd = $derived(
+    jsonLdScript([
+      datasetJsonLd(`In-demand ${data.label} skills`, data.intro, canonical, origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Insights', url: `${origin}/insights` },
+        { name: `${data.label} Skills`, url: canonical },
+      ]),
+    ]),
+  );
+</script>
+
+<Seo {title} description={data.intro} {canonical} />
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD from jsonLdScript, which escapes `<` -->
+  {@html jsonLd}
+</svelte:head>
+
+<InsightsPageShell
+  category={data.category}
+  label={data.label}
+  kind="skills"
+  {title}
+  intro={data.intro}
+  {updated}
+  covered={data.covered}
+>
+  {#if data.skills.length === 0}
+    <p class="text-gray-500">No skill data for this category yet.</p>
+  {:else}
+    <table class="w-full border-collapse text-left text-sm">
+      <thead>
+        <tr class="border-b border-gray-300 text-gray-500">
+          <th class="py-2 pr-4 font-medium">#</th>
+          <th class="py-2 pr-4 font-medium">Skill</th>
+          <th class="py-2 pr-4 font-medium text-right">Open postings</th>
+          <th class="py-2 font-medium text-right">30-day growth</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each data.skills as s, i (s.skill)}
+          <tr class="border-b border-gray-100">
+            <td class="py-2 pr-4 text-gray-400 tabular-nums">{i + 1}</td>
+            <td class="py-2 pr-4 font-medium text-gray-900">{s.skill}</td>
+            <td class="py-2 pr-4 text-right tabular-nums">{s.open_count.toLocaleString('en-US')}</td>
+            <td
+              class="py-2 text-right tabular-nums"
+              class:text-green-600={s.growth > 0}
+              class:text-gray-400={s.growth === 0}
+              class:text-red-600={s.growth < 0}
+            >
+              {s.growth > 0 ? '+' : ''}{s.growth.toLocaleString('en-US')}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</InsightsPageShell>

--- a/web/src/routes/sitemap-insights.xml/+server.ts
+++ b/web/src/routes/sitemap-insights.xml/+server.ts
@@ -1,0 +1,15 @@
+import { serverApi } from '$lib/server/api';
+import { coveredCategories } from '$lib/insights';
+import { insightsPaths, urlsetXml, xmlResponse } from '$lib/sitemap';
+import type { RequestHandler } from './$types';
+
+// Sub-sitemap for the insights landing pages, referenced by the sitemap index. It
+// lists only categories that clear the data-quality gate (via coveredCategories),
+// so a thin/gated-out category never appears — matching what the pages actually
+// serve (uncovered → 404).
+export const GET: RequestHandler = async ({ url, fetch }) => {
+  const roles = await serverApi(fetch).insightsRoles({ limit: 200 });
+  const categories = coveredCategories(roles).map((c) => c.category);
+  const entries = insightsPaths(categories).map((path) => ({ loc: `${url.origin}${path}` }));
+  return xmlResponse(urlsetXml(entries));
+};

--- a/web/src/routes/sitemap.xml/+server.ts
+++ b/web/src/routes/sitemap.xml/+server.ts
@@ -11,7 +11,11 @@ export const GET: RequestHandler = async ({ url, fetch }) => {
   const origin = url.origin;
   const companyCursors = await serverApi(fetch).sitemapCompanyBoundaries(SITEMAP_CHUNK);
 
-  const locs = [`${origin}/sitemap-pages.xml`, `${origin}/sitemap-jobs.xml`];
+  const locs = [
+    `${origin}/sitemap-pages.xml`,
+    `${origin}/sitemap-jobs.xml`,
+    `${origin}/sitemap-insights.xml`,
+  ];
   // The first company chunk starts before every slug (empty string); each boundary
   // cursor starts the next chunk.
   for (const after of ['', ...companyCursors]) {

--- a/web/static/openapi.yaml
+++ b/web/static/openapi.yaml
@@ -806,6 +806,11 @@ paths:
       summary: Rank roles by open-job demand and growth
       x-openai-isConsequential: false
       parameters:
+      - name: category
+        in: query
+        schema:
+          type: string
+        description: Restrict to one category's seniorities (enrichment vocabulary); omit for all categories.
       - name: country
         in: query
         schema:
@@ -968,7 +973,7 @@ paths:
         in: query
         schema:
           type: string
-        description: Role category (enrichment vocabulary).
+        description: Role category (enrichment vocabulary). Alone (no seniority/country) returns the per-seniority breakdown for the category.
       - name: seniority
         in: query
         schema:
@@ -992,6 +997,7 @@ paths:
                     items:
                       type: object
                       properties:
+                        seniority: { type: string }
                         currency: { type: string }
                         period: { type: string }
                         sample_size: { type: integer }


### PR DESCRIPTION
## Summary

Turns the aggregate Insights data (#746) into crawlable, keyword-targeted landing pages — the SEO follow-up the Trends & Insights work was sequenced before.

- **`/insights`** hub + **`/insights/{salary,skills,roles}/[category]`**, server-rendered (`server-load` → internal API, `Cache-Control: s-maxage=3600`).
- **Data-quality gate**: a category is published only when its open-job demand clears a floor (`coveredCategories`). Thin categories 404 and are absent from the sitemap — no thin-content pages.
- **SEO content** per page: data-driven auto-intro, ranking table / salary bands, "updated" date, internal links (filtered `/jobs`, sibling categories, the other insight types), canonical/meta/OG, and JSON-LD (Dataset + BreadcrumbList).
- **`sitemap-insights.xml`** shard wired into the sitemap index (lists only covered pages).
- **Two small API additions**: optional `category` filter on `GET /insights/roles`; `GET /insights/salary?category=X` (alone) returns the per-seniority breakdown in one call. Each salary row now carries its `seniority`. Served from the existing rollups — no migration.

## Test Plan

- [x] `go build/vet/test` green; insights integration tests extended (roles `category` filter, salary breakdown)
- [x] Web: vitest (gate/intro logic, 289 pass), svelte-check 0 errors, eslint clean
- [x] End-to-end against a seeded DB + rollups: hub lists only covered categories; salary/skills/roles pages render server-side with JSON-LD + intro + internal links; a gated-out category (present in data but below the floor) and an absent category both **404**; `sitemap-insights.xml` lists only covered pages and is referenced by the index
- [x] Code review (medium): fixed the roles page to read the category-scoped API instead of filtering the global top-N (avoids dropping a low-volume seniority)

Scope excludes (v1): geo/country page matrix, editorial prose/FAQ, charts, dedicated velocity pages.