### PR TITLE
feat(web): link the Insights hub from the footer

### DIFF
--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -19,6 +19,7 @@
       title: 'Resources',
       links: [
         { label: 'Blog', href: resolve('/blog') },
+        { label: 'Insights', href: resolve('/insights') },
         { label: 'Trends', href: resolve('/trends') },
         { label: 'CLI', href: resolve('/cli') },
         { label: 'ChatGPT', href: resolve('/chatgpt') },


### PR DESCRIPTION
Adds an 'Insights' link to the footer Resources group (next to Trends), making the new /insights pages reachable site-wide and crawlable from every footer. Open is already linked (Company group).