### PR TITLE
feat(sources): add Hurma ATS adapter (ScrumLaunch, Phenomenon Studio)

### DIFF
--- a/internal/sources/hurma.go
+++ b/internal/sources/hurma.go
@@ -1,0 +1,189 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// hurma adapts Hurma career sites. Hurma hosts each employer on its own subdomain
+// (<board>.hurma.work); the board is that subdomain (e.g. "scrumlaunch"). The public
+// job board is a client-rendered Vue app backed by a paginated JSON API whose list
+// endpoint omits the description, so the body comes from a per-vacancy detail fetch
+// (bounded-concurrency), like the other detail adapters.
+type hurma struct {
+	http HeaderJSONGetter
+}
+
+// NewHurma builds the Hurma adapter over the given HTTP client.
+func NewHurma(c HeaderJSONGetter) Source { return hurma{http: c} }
+
+func (hurma) Provider() string { return "hurma" }
+
+const (
+	// hurmaPerPage is the listing page size; Hurma paginates and reports last_page.
+	hurmaPerPage = 100
+	// hurmaMaxPages bounds pagination so a board that never reports its last page
+	// cannot loop forever.
+	hurmaMaxPages = 50
+)
+
+// hurmaXHRHeaders is the header the Vue app's fetch carries. Hurma's Laravel API gates
+// the public-vacancies JSON behind it — a bare GET returns an empty {"message":""} — so
+// every request must present it. The standard Accept: application/json still wins.
+var hurmaXHRHeaders = map[string]string{"X-Requested-With": "XMLHttpRequest"}
+
+// hurmaListItem is one entry of the /public-vacancies list page. The list omits the
+// description; residence/work_types carry the location and employment-type signal.
+type hurmaListItem struct {
+	Name      string `json:"name"`
+	PublicURL string `json:"public_url"`
+	Residence string `json:"residence"`
+	WorkTypes string `json:"work_types"`
+}
+
+// hurmaList is the paginated list response: data plus Laravel's pagination meta.
+type hurmaList struct {
+	Data []hurmaListItem `json:"data"`
+	Meta struct {
+		CurrentPage int `json:"current_page"`
+		LastPage    int `json:"last_page"`
+	} `json:"meta"`
+}
+
+// hurmaDetail is one vacancy's full record. The description is split across several
+// HTML section fields; hurmaDescription stitches the present ones together.
+type hurmaDetail struct {
+	Name              string `json:"name"`
+	Residence         string `json:"residence"`
+	WorkTypes         string `json:"work_types"`
+	Description       string `json:"description"`
+	Demand            string `json:"demand"`
+	Responsibility    string `json:"responsibility"`
+	WorkingConditions string `json:"working_conditions"`
+	Addition          string `json:"addition"`
+}
+
+func (h hurma) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base := fmt.Sprintf("https://%s.hurma.work", e.Board)
+
+	var items []hurmaListItem
+	for page := 1; page <= hurmaMaxPages; page++ {
+		listURL := fmt.Sprintf("%s/api/v1/public-vacancies?page=%d&per_page=%d", base, page, hurmaPerPage)
+		var list hurmaList
+		if err := h.http.GetJSONWithHeaders(ctx, listURL, hurmaXHRHeaders, &list); err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("hurma: fetch board %s: %w", e.Board, err)
+			}
+			break // a later page failing ends enumeration with the vacancies gathered so far
+		}
+		items = append(items, list.Data...)
+		// Stop at the reported last page; fall back to a short/empty page when meta is absent.
+		if list.Meta.LastPage > 0 {
+			if page >= list.Meta.LastPage {
+				break
+			}
+		} else if len(list.Data) < hurmaPerPage {
+			break
+		}
+	}
+
+	// Each vacancy's description comes from its own detail fetch, fanned out under a
+	// bounded pool.
+	return fetchDetails(items, defaultDetailWorkers, func(it hurmaListItem) (Job, bool) {
+		return h.detail(ctx, e, base, it)
+	}), nil
+}
+
+// detail fetches one vacancy's full record and maps it to a Job, returning ok=false when
+// the URL carries no parseable id or the fetch fails, so the caller skips just that vacancy.
+func (h hurma) detail(ctx context.Context, e CompanyEntry, base string, it hurmaListItem) (Job, bool) {
+	id := hurmaVacancyID(it.PublicURL)
+	if id == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	var resp struct {
+		Data hurmaDetail `json:"data"`
+	}
+	detailURL := fmt.Sprintf("%s/api/v1/public-vacancies/%s", base, id)
+	if err := h.http.GetJSONWithHeaders(ctx, detailURL, hurmaXHRHeaders, &resp); err != nil {
+		return Job{}, false
+	}
+	d := resp.Data
+
+	location := firstNonEmpty(d.Residence, it.Residence)
+	workTypes := firstNonEmpty(d.WorkTypes, it.WorkTypes)
+	return Job{
+		ExternalID:  id,
+		URL:         it.PublicURL,
+		Title:       hurmaTitle(firstNonEmpty(d.Name, it.Name)),
+		Company:     e.Company,
+		Location:    location,
+		Description: sanitizeHTML(hurmaDescription(d)),
+		// residence and work_types are free text ("remote", "Full-time, Remote work"),
+		// so the remote flag is a text heuristic; WorkMode is left for the parser.
+		Remote:         isRemote(location) || isRemote(workTypes),
+		EmploymentType: hurmaEmploymentType(workTypes),
+	}, true
+}
+
+// hurmaVacancyIDPattern captures the numeric vacancy id from a public_url's
+// /public-vacancies/<id> segment.
+var hurmaVacancyIDPattern = regexp.MustCompile(`/public-vacancies/(\d+)`)
+
+// hurmaVacancyID extracts the native numeric vacancy id from a vacancy's public URL.
+func hurmaVacancyID(u string) string {
+	if m := hurmaVacancyIDPattern.FindStringSubmatch(u); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// hurmaTitlePrefix matches the "#<id> " tag Hurma prepends to a vacancy name.
+var hurmaTitlePrefix = regexp.MustCompile(`^#\d+\s+`)
+
+// hurmaTitle strips the leading "#<id> " tag from a vacancy name, leaving the plain title.
+func hurmaTitle(name string) string {
+	return strings.TrimSpace(hurmaTitlePrefix.ReplaceAllString(name, ""))
+}
+
+// hurmaDescription stitches the present HTML sections of a vacancy into one body, tagging
+// the requirements/responsibilities/conditions sections with a heading and dropping empties.
+func hurmaDescription(d hurmaDetail) string {
+	var b strings.Builder
+	section := func(heading, body string) {
+		if strings.TrimSpace(body) == "" {
+			return
+		}
+		if heading != "" {
+			fmt.Fprintf(&b, "<h3>%s</h3>", heading)
+		}
+		b.WriteString(body)
+	}
+	section("", d.Description)
+	section("Requirements", d.Demand)
+	section("Responsibilities", d.Responsibility)
+	section("Working conditions", d.WorkingConditions)
+	section("", d.Addition)
+	return b.String()
+}
+
+// hurmaEmploymentType maps Hurma's free-text work_types ("Full-time, Remote work") onto the
+// freehire vocabulary from its first employment token, returning "" for an unknown/absent
+// value so the description parser decides.
+func hurmaEmploymentType(workTypes string) string {
+	for _, part := range strings.Split(workTypes, ",") {
+		switch strings.ToLower(strings.TrimSpace(part)) {
+		case "full-time", "full time":
+			return "full_time"
+		case "part-time", "part time":
+			return "part_time"
+		case "contract", "freelance":
+			return "contract"
+		case "internship", "intern":
+			return "internship"
+		}
+	}
+	return ""
+}

--- a/internal/sources/hurma_test.go
+++ b/internal/sources/hurma_test.go
@@ -1,0 +1,150 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeHurma serves the paginated list from list[page] and each vacancy's detail from
+// detail[id], recording the XHR header the adapter must present.
+type fakeHurma struct {
+	list      map[int]string
+	detail    map[string]string
+	gotHeader string
+	gotList   []string
+}
+
+func (f *fakeHurma) GetJSONWithHeaders(_ context.Context, url string, headers map[string]string, v any) error {
+	f.gotHeader = headers["X-Requested-With"]
+	// Detail URLs end in /public-vacancies/<id>; list URLs carry ?page=.
+	if i := strings.Index(url, "?page="); i >= 0 {
+		f.gotList = append(f.gotList, url)
+		page := url[i+len("?page=") : i+len("?page=")+1]
+		raw, ok := f.list[int(page[0]-'0')]
+		if !ok {
+			return errors.New("fakeHurma: no canned list page " + page)
+		}
+		return json.Unmarshal([]byte(raw), v)
+	}
+	id := url[strings.LastIndex(url, "/")+1:]
+	raw, ok := f.detail[id]
+	if !ok {
+		return errors.New("fakeHurma: no canned detail for " + id)
+	}
+	return json.Unmarshal([]byte(raw), v)
+}
+
+func TestHurmaProvider(t *testing.T) {
+	if got := NewHurma(nil).Provider(); got != "hurma" {
+		t.Errorf("Provider() = %q, want %q", got, "hurma")
+	}
+}
+
+func TestHurmaFetch(t *testing.T) {
+	fake := &fakeHurma{
+		list: map[int]string{
+			1: `{"data":[
+				{"name":"#406 Senior UI/UX Designer","public_url":"https://scrumlaunch.hurma.work/public-vacancies/406","residence":"remote","work_types":"Full-time, Remote work"}
+			],"meta":{"current_page":1,"last_page":1}}`,
+		},
+		detail: map[string]string{
+			"406": `{"data":{
+				"name":"#406 Senior UI/UX Designer","residence":"remote","work_types":"Full-time, Remote work",
+				"description":"We are looking for a designer.",
+				"demand":"- 5+ years<br />",
+				"responsibility":"- Design things<br />",
+				"working_conditions":"- 12 vacation days<br />",
+				"addition":"<script>x()</script>"
+			}}`,
+		},
+	}
+
+	jobs, err := NewHurma(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "ScrumLaunch", Provider: "hurma", Board: "scrumlaunch",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if fake.gotHeader != "XMLHttpRequest" {
+		t.Errorf("X-Requested-With header = %q, want XMLHttpRequest", fake.gotHeader)
+	}
+	if len(fake.gotList) == 0 || !strings.Contains(fake.gotList[0], "scrumlaunch.hurma.work") {
+		t.Errorf("list URL %v should target the board subdomain", fake.gotList)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "406" {
+		t.Errorf("ExternalID = %q, want 406 from the public_url", j.ExternalID)
+	}
+	if j.URL != "https://scrumlaunch.hurma.work/public-vacancies/406" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	// The "#406 " tag is stripped from the title.
+	if j.Title != "Senior UI/UX Designer" {
+		t.Errorf("Title = %q, want the tag stripped", j.Title)
+	}
+	if j.Company != "ScrumLaunch" {
+		t.Errorf("Company = %q, want the configured company", j.Company)
+	}
+	if j.Location != "remote" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	// Description stitches the sections and drops the script tag.
+	for _, want := range []string{"looking for a designer", "5+ years", "Design things", "12 vacation days"} {
+		if !strings.Contains(j.Description, want) {
+			t.Errorf("Description missing %q, got %q", want, j.Description)
+		}
+	}
+	if strings.Contains(j.Description, "<script") {
+		t.Errorf("Description retained a script tag, got %q", j.Description)
+	}
+	if !j.Remote {
+		t.Error("Remote = false, want true from residence/work_types")
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+}
+
+// A vacancy whose public_url carries no numeric id is skipped rather than emitted with a
+// colliding empty external id.
+func TestHurmaSkipsVacancyWithoutID(t *testing.T) {
+	fake := &fakeHurma{
+		list: map[int]string{
+			1: `{"data":[
+				{"name":"No id","public_url":"https://x.hurma.work/public-vacancies/","residence":"remote","work_types":"Full-time"}
+			],"meta":{"current_page":1,"last_page":1}}`,
+		},
+		detail: map[string]string{},
+	}
+	jobs, err := NewHurma(fake).Fetch(context.Background(), CompanyEntry{Company: "X", Provider: "hurma", Board: "x"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("len(jobs) = %d, want 0 (id-less vacancy skipped)", len(jobs))
+	}
+}
+
+func TestHurmaEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"Full-time, Remote work": "full_time",
+		"Part-time":              "part_time",
+		"Contract":               "contract",
+		"Internship":             "internship",
+		"Remote work":            "",
+		"":                       "",
+	}
+	for in, want := range cases {
+		if got := hurmaEmploymentType(in); got != want {
+			t.Errorf("hurmaEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -199,6 +199,7 @@ func All(c HTTPClient) map[string]Source {
 		NewGem(c),
 		NewSuccessFactors(c),
 		NewTeamtailor(c),
+		NewHurma(c),
 		NewICIMS(c),
 		NewCareerPage(c),
 		NewNorthstone(c),

--- a/sources/hurma.yml
+++ b/sources/hurma.yml
@@ -1,0 +1,9 @@
+# hurma boards. Provider is the filename; each entry is company + board.
+# board = the Hurma tenant subdomain of <board>.hurma.work (see internal/sources/hurma.go);
+# the adapter reads /api/v1/public-vacancies (XHR-gated JSON) and each vacancy's detail.
+# Each board validated live (>0 vacancies) before adding.
+
+- company: ScrumLaunch
+  board: scrumlaunch
+- company: Phenomenon Studio
+  board: phenomenonstudio


### PR DESCRIPTION
## What

New `hurma` source adapter for [Hurma](https://hurma.work) career sites, plus `sources/hurma.yml` onboarding **ScrumLaunch** and **Phenomenon Studio**.

## Why

Both companies surfaced in the dreamworkhq (631-match) catalogue audit as absent from our base. They hide their listings behind a client-rendered Vue job board (no ld+json, empty static HTML), and the apply step routes to Hurma — so the earlier static-fetch harvest couldn't see them. Browser inspection revealed Hurma's underlying JSON API.

## How

Hurma hosts each employer on a `<board>.hurma.work` subdomain (board = the subdomain). Its Laravel API exposes:
- `GET /api/v1/public-vacancies?page&per_page` — paginated list (name, public_url, residence, work_types)
- `GET /api/v1/public-vacancies/{id}` — full record (description split across demand/responsibility/working_conditions sections)

Both are gated behind `X-Requested-With: XMLHttpRequest` (a bare GET returns `{"message":""}`), carried via `GetJSONWithHeaders`. The adapter paginates the list and fetches each vacancy's detail (bounded fan-out) for the stitched description, mapping residence→location, work_types→employment type + remote, and stripping the `#<id>` tag from titles.

Follows the teamtailor pattern (subdomain board + per-vacancy detail).

## Verification

- `go build ./... && go vet ./...` clean, `gofmt` clean
- Unit tests: provider, fetch+field-mapping, id-less skip, employment-type table
- **Live smoke test** (`cmd/ingest sources/hurma.yml`): `ingested=8 failed=0` (ScrumLaunch 6 + Phenomenon 2); DB rows show clean titles, descriptions (3-5k chars), location, remote, full_time.