### PR TITLE
fix(web): repair inbox delete, link and undo actions

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -922,12 +922,12 @@ export function createApi(
 
   /** Soft-delete a message (hidden from the inbox, restorable via restoreEmail). */
   async function deleteEmail(id: number): Promise<void> {
-    await request(`/api/v1/me/emails/${id}/delete`, { method: 'POST' });
+    await call(`/api/v1/me/emails/${id}/delete`, { method: 'POST' });
   }
 
   /** Undo a soft-delete, bringing the message back into the inbox. */
   async function restoreEmail(id: number): Promise<void> {
-    await request(`/api/v1/me/emails/${id}/restore`, { method: 'POST' });
+    await call(`/api/v1/me/emails/${id}/restore`, { method: 'POST' });
   }
 
   /** The caller's hosted-mailbox address (or null) + feature availability. */
@@ -967,10 +967,7 @@ export function createApi(
 
   /** Manually link an email to the application named by slug. */
   async function linkEmail(id: number, slug: string): Promise<EmailBody> {
-    return requestData<EmailBody>(`/api/v1/me/emails/${id}/link`, {
-      method: 'POST',
-      body: JSON.stringify({ slug }),
-    });
+    return requestData<EmailBody>(`/api/v1/me/emails/${id}/link`, jsonBody('POST', { slug }));
   }
 
   /** Clear an email's application link. */


### PR DESCRIPTION
## Problem

Three inbox actions on `/my/inbox` were broken, all traced to two frontend defects in `web/src/lib/api.ts` where hand-rolled calls bypassed the established helpers:

1. **Delete / restore** → `Unexpected token 'O', "OK" is not valid JSON`.
   `deleteEmail`/`restoreEmail` used `request()`, which unconditionally `.json()`-parses the body. The delete endpoint replies `SendStatus(200)`, which in Fiber writes the status text `OK` as the body — not JSON.

2. **Link + Undo** → `{"error":"slug required"}`.
   `linkEmail` built `body: JSON.stringify({ slug })` without a `Content-Type` header, so the browser sent `text/plain`. Fiber's `BodyParser` dispatches on content type and skipped the body, leaving `slug` empty. The inbox **Undo** relinks via `linkEmail`, so it broke too.

## Fix

- `deleteEmail`/`restoreEmail`: use `call()` (returns the `Response`, ignores the body) — same pattern as `deleteSavedSearch`/`unshareSavedSearch`.
- `linkEmail`: use `jsonBody('POST', { slug })`, the single source of the `Content-Type: application/json` header.

Frontend-only; works against the currently deployed backend without a backend redeploy.

## Verification

- `npm run check` — 0 errors (2 pre-existing warnings in `JobFitFull.svelte`, unrelated).