### PR TITLE
feat(sources): add Dataforest and WorkeronAI Hurma boards

### DIFF
--- a/sources/hurma.yml
+++ b/sources/hurma.yml
@@ -7,3 +7,7 @@
   board: scrumlaunch
 - company: Phenomenon Studio
   board: phenomenonstudio
+- company: Dataforest
+  board: dataforest
+- company: WorkeronAI
+  board: workeronai


### PR DESCRIPTION
Two more dreamworkhq-audit companies found on Hurma once the adapter (#761) made them ingestable:
- **Dataforest** — `dataforest.hurma.work` — 15 vacancies
- **WorkeronAI** — `workeronai.hurma.work` — 11 vacancies

Live-validated. Local smoke over sources/hurma.yml: ingested=34 failed=0 (all 4 Hurma boards).