### PR TITLE
feat(sources): onboard 10 Likeit tenants from jobcrawls harvest

### DIFF
--- a/sources/likeit.yml
+++ b/sources/likeit.yml
@@ -17,3 +17,24 @@
   board: duuritiimi
 - company: Safrent
   board: safrent
+# Additional tenants harvested from jobcrawls.com (2026-07, RSS-validated >0 items)
+- company: Worker
+  board: worker
+- company: Visio HR
+  board: visiohr
+- company: WulffWorks
+  board: wulffworks
+- company: Amiko
+  board: amiko
+- company: Basso HR
+  board: bassohr
+- company: Henkilöstöliiga
+  board: henkilostoliiga
+- company: Maximus
+  board: maximus
+- company: NordRec
+  board: nordrec
+- company: Canvas
+  board: canvas
+- company: Best Workers
+  board: bestworkers


### PR DESCRIPTION
Onboards 10 Finnish staffing-agency **Likeit** boards discovered by mining outbound apply URLs on jobcrawls.com. The `likeit` adapter already exists — these were simply un-onboarded tenants.

Each board RSS-validated live (`https://<board>.likeit.fi/jsp/duuni/AdvertRss.jsp` returns >0 `<item>`):

`worker, visiohr, wulffworks, amiko, bassohr, henkilostoliiga, maximus, nordrec, canvas, bestworkers`

Covers ~770 postings from the jobcrawls gap analysis. `go test ./internal/sources -run Config` green; no duplicate boards.

Companion to #758 (Teamtailor onboarding from the same harvest).