### PR TITLE
feat(sources): briefhq adapter + Stride Build & The Bulwark boards

### DIFF
--- a/internal/sources/briefhq.go
+++ b/internal/sources/briefhq.go
@@ -1,0 +1,101 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"strings"
+	"time"
+)
+
+// briefhq adapts a hand-rolled static careers page (briefhq.ai/careers) that inlines every
+// vacancy as its own schema.org JobPosting ld+json block on a single listing page. There is no
+// board API and no per-posting detail page — the listing itself carries each posting's full
+// fields — so one fetch yields every job. The board is the careers page's "<host>/<path>" (no
+// scheme), e.g. "briefhq.ai/careers/"; the native posting id is the JobPosting identifier.value
+// (a stable per-job slug), which also anchors the posting's deeplink (…/careers/#<slug>).
+type briefhq struct {
+	http HTMLGetter
+}
+
+// NewBriefHQ builds the briefhq static-careers-page adapter over the given HTML client.
+func NewBriefHQ(c HTMLGetter) Source { return briefhq{http: c} }
+
+func (briefhq) Provider() string { return "briefhq" }
+
+func (s briefhq) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	pageURL := "https://" + e.Board
+	root, err := s.http.GetHTML(ctx, pageURL)
+	if err != nil {
+		return nil, fmt.Errorf("briefhq: fetch %s: %w", e.Board, err)
+	}
+
+	nodes := LDJobPostings(root)
+	jobs := make([]Job, 0, len(nodes))
+	for _, raw := range nodes {
+		var p briefhqPosting
+		if json.Unmarshal(raw, &p) != nil || p.Title == "" {
+			continue // a block that fails to decode or carries no title is not a storable job
+		}
+		id := firstNonEmpty(p.Identifier.Value, p.URL, pageURL)
+		// jobLocationType is the schema.org work-arrangement signal: TELECOMMUTE means remote,
+		// ON_SITE means not; anything else falls back to the free-text location.
+		remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+		jobs = append(jobs, Job{
+			ExternalID:     id,
+			URL:            firstNonEmpty(p.URL, pageURL),
+			Title:          p.Title,
+			Company:        firstNonEmpty(p.HiringOrganization.Name, e.Company),
+			Location:       p.location(),
+			Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+			Remote:         remote || isRemote(p.location()),
+			WorkMode:       workModeFromRemote(remote),
+			EmploymentType: schemaEmploymentType(p.EmploymentType),
+			PostedAt:       briefhqDate(p.DatePosted),
+		})
+	}
+	return jobs, nil
+}
+
+// briefhqPosting is one schema.org JobPosting decoded from the careers page. jobLocation is a
+// single Place; jobLocationType (ON_SITE/TELECOMMUTE) is the work-arrangement signal.
+type briefhqPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	URL                string `json:"url"`
+	DatePosted         string `json:"datePosted"`
+	EmploymentType     string `json:"employmentType"`
+	JobLocationType    string `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+			AddressRegion   string `json:"addressRegion"`
+			AddressCountry  string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+	Identifier struct {
+		Value string `json:"value"`
+	} `json:"identifier"`
+}
+
+// location builds the free-text location from the jobLocation address.
+func (p briefhqPosting) location() string {
+	return joinNonEmpty(
+		p.JobLocation.Address.AddressLocality,
+		p.JobLocation.Address.AddressRegion,
+		p.JobLocation.Address.AddressCountry,
+	)
+}
+
+// briefhqDate parses the JobPosting datePosted, which briefhq emits as a bare "2006-01-02" but
+// which the schema.org field may also carry as a full RFC3339 timestamp.
+func briefhqDate(s string) *time.Time {
+	if t := parseRFC3339(s); t != nil {
+		return t
+	}
+	return parseDate(s)
+}

--- a/internal/sources/briefhq_test.go
+++ b/internal/sources/briefhq_test.go
@@ -1,0 +1,102 @@
+package sources
+
+import (
+	"context"
+	"testing"
+)
+
+// briefhqCareersHTML is a briefhq-shaped static careers page: two vacancies each inlined as their
+// own schema.org JobPosting ld+json block, plus the Organization and BreadcrumbList blocks the
+// real page also carries — which LDJobPostings must ignore. The first posting is on-site with a
+// full jobLocation address; the second is fully remote (TELECOMMUTE, no address).
+const briefhqCareersHTML = `<html><head>
+<script type="application/ld+json">{"@type":"Organization","name":"Brief"}</script>
+<script type="application/ld+json">{"@type":"BreadcrumbList","itemListElement":[]}</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Product Builder (Forward Deployed)",
+"url":"https://briefhq.ai/careers/#product-builder-forward-deployed",
+"description":"<p>Ship product with customers.</p>",
+"datePosted":"2026-07-06",
+"employmentType":"FULL_TIME",
+"jobLocationType":"ON_SITE",
+"hiringOrganization":{"@type":"Organization","name":"Brief"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"San Francisco","addressRegion":"CA","addressCountry":"US"}},
+"identifier":{"@type":"PropertyValue","name":"Brief","value":"product-builder-forward-deployed"}}
+</script>
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"JobPosting",
+"title":"Senior Product Builder (Engineering Focus)",
+"url":"https://briefhq.ai/careers/#senior-product-builder-engineering",
+"description":"<p>Own the codebase.</p>",
+"datePosted":"2026-07-06",
+"employmentType":"FULL_TIME",
+"jobLocationType":"TELECOMMUTE",
+"hiringOrganization":{"@type":"Organization","name":"Brief"},
+"identifier":{"@type":"PropertyValue","name":"Brief","value":"senior-product-builder-engineering"}}
+</script>
+</head><body></body></html>`
+
+func TestBriefHQProvider(t *testing.T) {
+	if got := NewBriefHQ(nil).Provider(); got != "briefhq" {
+		t.Errorf("Provider() = %q, want %q", got, "briefhq")
+	}
+}
+
+func TestBriefHQFetchMapsInlinePostings(t *testing.T) {
+	fake := &fakeHTTP{body: briefhqCareersHTML}
+
+	jobs, err := NewBriefHQ(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Brief", Provider: "briefhq", Board: "briefhq.ai/careers/",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if fake.gotURL != "https://briefhq.ai/careers/" {
+		t.Errorf("fetched %q, want the careers page built from the board", fake.gotURL)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (Organization/BreadcrumbList blocks must be ignored)", len(jobs))
+	}
+
+	onsite := jobs[0]
+	if onsite.ExternalID != "product-builder-forward-deployed" {
+		t.Errorf("ExternalID = %q, want identifier.value", onsite.ExternalID)
+	}
+	if onsite.URL != "https://briefhq.ai/careers/#product-builder-forward-deployed" {
+		t.Errorf("URL = %q, want the posting deeplink", onsite.URL)
+	}
+	if onsite.Title != "Product Builder (Forward Deployed)" {
+		t.Errorf("Title = %q", onsite.Title)
+	}
+	if onsite.Company != "Brief" {
+		t.Errorf("Company = %q, want hiringOrganization name", onsite.Company)
+	}
+	if onsite.Location != "San Francisco, CA, US" {
+		t.Errorf("Location = %q, want the jobLocation address", onsite.Location)
+	}
+	if onsite.Remote || onsite.WorkMode != "" {
+		t.Errorf("on-site posting Remote=%v WorkMode=%q, want false/empty", onsite.Remote, onsite.WorkMode)
+	}
+	if onsite.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", onsite.EmploymentType)
+	}
+	if onsite.Description != "<p>Ship product with customers.</p>" {
+		t.Errorf("Description = %q", onsite.Description)
+	}
+	if onsite.PostedAt == nil || onsite.PostedAt.Format("2006-01-02") != "2026-07-06" {
+		t.Errorf("PostedAt = %v, want 2026-07-06", onsite.PostedAt)
+	}
+
+	remote := jobs[1]
+	if remote.ExternalID != "senior-product-builder-engineering" {
+		t.Errorf("ExternalID = %q, want identifier.value", remote.ExternalID)
+	}
+	if !remote.Remote || remote.WorkMode != "remote" {
+		t.Errorf("TELECOMMUTE posting Remote=%v WorkMode=%q, want true/remote", remote.Remote, remote.WorkMode)
+	}
+	if remote.Location != "" {
+		t.Errorf("Location = %q, want empty (no jobLocation address)", remote.Location)
+	}
+}

--- a/internal/sources/jsonld.go
+++ b/internal/sources/jsonld.go
@@ -36,43 +36,71 @@ func ldJobPosting(root *html.Node, v any) bool {
 	return found
 }
 
-// jobPostingNode finds the schema.org JobPosting node inside one ld+json block, whatever its
-// top-level shape: a bare JobPosting object, an array of nodes ([{...}, ...], as Langford
-// emits), or a graph wrapper ({"@graph":[...]}). It returns that node's raw JSON so the caller
+// LDJobPostings decodes EVERY schema.org JobPosting block on the page, for listing pages that
+// inline multiple postings as separate ld+json blocks (e.g. a static careers page that renders
+// each vacancy's JobPosting alongside it). Unlike ldJobPosting (first block only) it walks all
+// ld+json scripts and returns each posting's raw JSON so a multi-job adapter maps every one.
+func LDJobPostings(root *html.Node) []json.RawMessage {
+	var out []json.RawMessage
+	walk(root, func(n *html.Node) bool {
+		if n.Type == html.ElementNode && n.Data == "script" &&
+			attr(n, "type") == "application/ld+json" {
+			out = append(out, jobPostingNodes([]byte(textContent(n)))...)
+		}
+		return true
+	})
+	return out
+}
+
+// jobPostingNode finds the first schema.org JobPosting node inside one ld+json block, whatever
+// its top-level shape (see jobPostingNodes). It returns that node's raw JSON so the caller
 // decodes just the fields it needs, or ok=false when the block carries no JobPosting.
 func jobPostingNode(raw []byte) (json.RawMessage, bool) {
+	nodes := jobPostingNodes(raw)
+	if len(nodes) == 0 {
+		return nil, false
+	}
+	return nodes[0], true
+}
+
+// jobPostingNodes returns every schema.org JobPosting node inside one ld+json block, whatever its
+// top-level shape: a bare JobPosting object, an array of nodes ([{...}, ...], as Langford emits),
+// or a graph wrapper ({"@graph":[...]}). Most pages carry one, but a listing block may inline
+// several — so this returns all and jobPostingNode takes the first.
+func jobPostingNodes(raw []byte) []json.RawMessage {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 {
-		return nil, false
+		return nil
 	}
 	if trimmed[0] == '[' {
 		var nodes []json.RawMessage
 		if json.Unmarshal(trimmed, &nodes) != nil {
-			return nil, false
+			return nil
 		}
-		return firstJobPosting(nodes)
+		return filterJobPostings(nodes)
 	}
 	if isJobPosting(trimmed) {
-		return trimmed, true
+		return []json.RawMessage{trimmed}
 	}
 	// Not a bare JobPosting object → it may be a @graph wrapper listing the page's nodes.
 	var wrapper struct {
 		Graph []json.RawMessage `json:"@graph"`
 	}
 	if json.Unmarshal(trimmed, &wrapper) == nil {
-		return firstJobPosting(wrapper.Graph)
+		return filterJobPostings(wrapper.Graph)
 	}
-	return nil, false
+	return nil
 }
 
-// firstJobPosting returns the first JobPosting node among a list of ld+json nodes.
-func firstJobPosting(nodes []json.RawMessage) (json.RawMessage, bool) {
+// filterJobPostings returns the JobPosting nodes among a list of ld+json nodes, in order.
+func filterJobPostings(nodes []json.RawMessage) []json.RawMessage {
+	var out []json.RawMessage
 	for _, n := range nodes {
 		if isJobPosting(n) {
-			return n, true
+			out = append(out, n)
 		}
 	}
-	return nil, false
+	return out
 }
 
 // isJobPosting reports whether a raw ld+json node is a schema.org JobPosting.

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -203,6 +203,7 @@ func All(c HTTPClient) map[string]Source {
 		NewICIMS(c),
 		NewCareerPage(c),
 		NewNorthstone(c),
+		NewBriefHQ(c),
 		NewTalentAdore(c),
 		NewLoxo(c),
 		NewHireology(c),

--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -4287,6 +4287,8 @@
   board: strava
 - company: streetgroup
   board: streetgroup
+- company: Stride Build
+  board: Stride Build
 - company: strider-technologies
   board: strider-technologies
 - company: stronghold

--- a/sources/briefhq.yml
+++ b/sources/briefhq.yml
@@ -1,0 +1,5 @@
+# briefhq boards. Provider is the filename; each entry is company + board.
+# board = the static careers page's "<host>/<path>" (no scheme); see internal/sources/briefhq.go.
+
+- company: Brief
+  board: briefhq.ai/careers/

--- a/sources/pinpoint.yml
+++ b/sources/pinpoint.yml
@@ -135,6 +135,8 @@
   board: tabby
 - company: thalamos
   board: thalamos
+- company: The Bulwark
+  board: thebulwark
 - company: togethergroup
   board: togethergroup
 - company: trivandi


### PR DESCRIPTION
## What

Onboards vacancies that were missing from a batch of links to check.

| Source | Change | Live-verified |
|---|---|---|
| **briefhq.ai/careers** | New \`briefhq\` adapter | 2 jobs |
| Ashby **Stride Build** | 1 line in \`sources/ashby.yml\` (adapter existed) | 4 jobs |
| Pinpoint **thebulwark** (The Bulwark) | 1 line in \`sources/pinpoint.yml\` (adapter existed) | 4 jobs |

Already present on prod (no change): Greenhouse `dwelly`, `payoneer`, `stackblitz`.

## briefhq adapter

briefhq.ai/careers is a hand-rolled **static** careers page that inlines **every** vacancy as its own schema.org `JobPosting` ld+json block on **one** listing page — no board API, no per-posting detail page. The existing generic link resolver takes only the *first* JobPosting on a page and strips the URL fragment, so both briefhq jobs would collapse into one row.

New reusable primitive `LDJobPostings(root)` walks **all** ld+json scripts and returns **every** JobPosting node (bare / array / `@graph`). `jobPostingNode` is refactored on top of it (takes the first) — signature unchanged, so all existing JSON-LD adapters are untouched.

- ExternalID = JobPosting `identifier.value` (stable slug); outbound URL = the posting's `url` (with `#slug`).
- Board = careers page `"<host>/<path>"` (no scheme); jobLocation/employmentType/remote mapped like the other JSON-LD adapters (northstone).

## Test

- Unit test with a 2-posting fixture (+ Organization/BreadcrumbList noise that must be ignored; on-site vs TELECOMMUTE paths).
- Smoke-tested each of the three sources through the real adapters against live pages.
- `go build ./...`, `go vet`, `gofmt`, full `internal/sources` suite green; all board files validate against the registry.