### PR TITLE
feat(web): reorder account nav — Profile/Activity/Tracking/Inbox first

### DIFF
--- a/web/src/lib/accountNav.test.ts
+++ b/web/src/lib/accountNav.test.ts
@@ -6,10 +6,9 @@ describe('accountNav config', () => {
     expect(accountNav).toHaveLength(8);
   });
 
-  it('places Activity directly after Tracking', () => {
+  it('leads with the four everyday sections in use order', () => {
     const hrefs = accountNav.map((i) => i.href);
-    expect(hrefs.indexOf('/my/activity')).toBe(hrefs.indexOf('/my/tracking') + 1);
-    expect(accountNav.find((i) => i.href === '/my/activity')?.label).toBe('Activity');
+    expect(hrefs.slice(0, 4)).toEqual(['/my/profile', '/my/activity', '/my/tracking', '/my/inbox']);
   });
 
   it('every item links under /my/ and has a label', () => {

--- a/web/src/lib/accountNav.ts
+++ b/web/src/lib/accountNav.ts
@@ -2,21 +2,22 @@
 // the active-item rule. Kept free of Svelte/icon imports so it stays pure and
 // unit-testable; the `my/+layout.svelte` shell maps each href to its icon.
 
-// Order = the order shown in the sidebar / tab strip. Identity (Profile) first,
-// then the reading/working sections. Create actions (Submit a job, Moderation)
-// deliberately live in the header menu, not here. `as const` keeps each href a
-// literal route so the layout can pass it to `resolve()` type-safely (mirroring
-// HeaderMenu's navLinks).
+// Order = the order shown in the sidebar / tab strip. The four everyday sections
+// lead in the order they're used — Profile (identity), Activity, Tracking, Inbox —
+// then the occasional ones (Agent, notifications, keys, submissions). Create actions
+// (Submit a job, Moderation) deliberately live in the header menu, not here.
+// `as const` keeps each href a literal route so the layout can pass it to `resolve()`
+// type-safely (mirroring HeaderMenu's navLinks).
 export const accountNav = [
   { href: '/my/profile', label: 'Profile' },
-  // The agent is a restricted rollout — beta testers only (a group separate from
-  // the moderator role; see `beta_tester` on the user). `beta` shows a nav badge.
-  { href: '/my/assistant', label: 'Agent', betaOnly: true, beta: true },
-  { href: '/my/tracking', label: 'Tracking' },
   { href: '/my/activity', label: 'Activity' },
+  { href: '/my/tracking', label: 'Tracking' },
   // Mail inbox: connect Gmail and/or claim a freehire mailbox to track application
   // replies. Open to every signed-in user.
   { href: '/my/inbox', label: 'Inbox' },
+  // The agent is a restricted rollout — beta testers only (a group separate from
+  // the moderator role; see `beta_tester` on the user). `beta` shows a nav badge.
+  { href: '/my/assistant', label: 'Agent', betaOnly: true, beta: true },
   { href: '/my/searches', label: 'Search notifications' },
   { href: '/my/api-keys', label: 'API keys' },
   { href: '/my/submissions', label: 'My submissions' },

--- a/web/src/lib/components/HeaderMenu.svelte
+++ b/web/src/lib/components/HeaderMenu.svelte
@@ -10,10 +10,12 @@
     Briefcase,
     Building2,
     CircleUser,
+    Activity,
     ListChecks,
     BellRing,
     KeyRound,
     Inbox,
+    FileText,
     SquarePlus,
     ShieldCheck,
     Layers,
@@ -76,14 +78,18 @@
     { href: '/trends', label: 'Trends', icon: TrendingUp },
   ] as const;
 
-  // Personal account items — what the signed-in user owns/reads. "Submit a job"
-  // is a create action, so it's rendered separately (below), split off from the
-  // "My submissions" reading item it used to sit next to.
+  // Personal account items — what the signed-in user owns/reads, in the same order
+  // as the account sidebar (Profile is rendered separately just above these, so the
+  // full run reads Profile · Activity · Tracking · Inbox · …). "Submit a job" is a
+  // create action, rendered separately (below), split off from the "My submissions"
+  // reading item it used to sit next to.
   const accountLinks = [
+    { href: '/my/activity', label: 'Activity', icon: Activity },
     { href: '/my/tracking', label: 'Tracking', icon: ListChecks },
+    { href: '/my/inbox', label: 'Inbox', icon: Inbox },
     { href: '/my/searches', label: 'Search notifications', icon: BellRing },
     { href: '/my/api-keys', label: 'API keys', icon: KeyRound },
-    { href: '/my/submissions', label: 'My submissions', icon: Inbox },
+    { href: '/my/submissions', label: 'My submissions', icon: FileText },
   ] as const;
 
   // Mobile only: the open panel is a full-screen overlay, so lock the page behind


### PR DESCRIPTION
Leads the account sidebar and header (hamburger) menu with the four everyday sections in use order — **Profile · Activity · Tracking · Inbox** — then the occasional ones (Agent, Search notifications, API keys, My submissions).

- `accountNav.ts`: reorder; comment + unit test updated to assert the new leading four.
- `HeaderMenu.svelte`: add **Activity** and **Inbox** to the personal section so it mirrors the sidebar order; move the `Inbox` icon to the real Inbox item and give **My submissions** the `FileText` icon (matching the sidebar's canonical mapping).

Verification: `npm run check` 0 errors; `accountNav` vitest 11/11 pass.