### PR TITLE
feat(sources): onboard 5 known-ATS tenants from jobcrawls harvest

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -14103,3 +14103,7 @@
 # Greenhouse tenant behind vanity domain (jobcrawls harvest 2026-07, API-validated)
 - company: Sector Alarm
   board: sectoralarmgroup
+
+# Greenhouse tenant behind vanity domain (jobcrawls harvest 2026-07, API-validated)
+- company: Solita
+  board: solita

--- a/sources/phenom.yml
+++ b/sources/phenom.yml
@@ -97,3 +97,7 @@
   board: careers.activision.com
 - company: BNSF Railway
   board: jobs.bnsf.com
+
+# Phenom tenant from jobcrawls harvest (2026-07, refineSearch-validated 482 postings)
+- company: Exyte
+  board: careers.exyte.net

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3543,3 +3543,7 @@
   board: elegantresorts
 - company: Avant Arte
   board: avantarte
+
+# Recruitee tenant from jobcrawls harvest (2026-07, offers API-validated)
+- company: Norrin
+  board: norrin

--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -11,3 +11,9 @@
   board: jobs.paysafe.com
 - company: Worldline
   board: jobs.worldline.com
+
+# SuccessFactors tenants from jobcrawls harvest (2026-07, job_sitemap.xml validated)
+- company: University of Helsinki
+  board: jobs.helsinki.fi
+- company: Bilfinger
+  board: jobs.bilfinger.com


### PR DESCRIPTION
Second onboarding batch from the jobcrawls.com apply-URL mine. These vanity-domain companies were flagged as 'gap' by host-level analysis, but fingerprinting revealed they run on ATS we already support — so no new adapters, just board entries, each live-validated against the adapter's own API:

| Adapter | Company | Board | Validated |
|---|---|---|---|
| greenhouse | Solita | `solita` | boards-api 53 jobs |
| recruitee | Norrin | `norrin` | offers API 16 |
| phenom | Exyte | `careers.exyte.net` | refineSearch 482 |
| successfactors | University of Helsinki | `jobs.helsinki.fi` | sitemap 114 |
| successfactors | Bilfinger | `jobs.bilfinger.com` | sitemap 1790 |

Follows #758 (Teamtailor) and #766 (Likeit). `go test ./internal/sources -run Config` green.