### PR TITLE
perf(web): server-load the tracking board (kill client waterfall)

### DIFF
--- a/web/src/lib/components/JobBoard.svelte
+++ b/web/src/lib/components/JobBoard.svelte
@@ -10,7 +10,10 @@
 
   // initialSlug (from /my/tracking/[slug]) opens that application's drawer once the
   // board has loaded, so a deep link / inbox link / refresh reopens the same card.
-  let { initialSlug }: { initialSlug?: string } = $props();
+  // initial carries the board rows fetched in the route's server load, so the board
+  // paints with the page (no client fetch on mount); a caller that omits it falls
+  // back to a client fetch. Mutations still reload() client-side.
+  let { initialSlug, initial }: { initialSlug?: string; initial?: MyJob[] } = $props();
   let openedInitial = false;
 
   function emptyColumns(): Record<BoardColumnId, BoardItem[]> {
@@ -28,47 +31,59 @@
   let openItem = $state.raw<BoardItem | null>(null);
   let pendingOutcome = $state(false);
 
+  // Lay the fetched rows out into the columns and open the deep-linked drawer once.
+  // The 'board' filter returns saved ∪ applied ∪ stage; saved-only rows are dropped
+  // here (they belong to Activity → Saved). Those rows still count toward the 500 cap,
+  // so a user with 500+ tracked jobs, many recently saved, could have older active
+  // applications fall outside the fetched window. Acceptable at this scale; revisit
+  // with a server-side board-minus-saved filter if it bites.
+  function build(rows: MyJob[]) {
+    const next = emptyColumns();
+    const cols: Record<string, BoardColumnId> = {};
+    for (const row of rows) {
+      const item: BoardItem = { ...row, id: row.job.public_slug };
+      const col = columnOf(item);
+      if (!col) continue; // saved-only rows live in Activity → Saved, not the board
+      next[col].push(item);
+      cols[item.id] = col;
+    }
+    columns = next;
+    cardCol = cols;
+    status = 'ready';
+    // Deep link: open the requested application's drawer once, after the board is
+    // built. A slug that isn't on the board (untracked / saved-only) just leaves
+    // the board showing.
+    if (initialSlug && !openedInitial) {
+      openedInitial = true;
+      const found = Object.values(next)
+        .flat()
+        .find((i) => i.id === initialSlug);
+      if (found) {
+        openItem = found;
+        pendingOutcome = false;
+      }
+    }
+  }
+
   async function load() {
     status = 'loading';
     try {
-      // The 'board' filter returns saved ∪ applied ∪ stage; we drop the saved-only
-      // rows below (they belong to Activity → Saved). Those rows still count toward
-      // this 500 cap, so a user with 500+ tracked jobs, many recently saved, could
-      // have older active applications fall outside the fetched window. Acceptable
-      // at this scale; revisit with a server-side board-minus-saved filter if it bites.
       const slice = await api.listMyJobs('board', 500, 0);
-      const next = emptyColumns();
-      const cols: Record<string, BoardColumnId> = {};
-      for (const row of slice.items) {
-        const item: BoardItem = { ...row, id: row.job.public_slug };
-        const col = columnOf(item);
-        if (!col) continue; // saved-only rows live in Activity → Saved, not the board
-        next[col].push(item);
-        cols[item.id] = col;
-      }
-      columns = next;
-      cardCol = cols;
-      status = 'ready';
-      // Deep link: open the requested application's drawer once, after the board is
-      // built. A slug that isn't on the board (untracked / saved-only) just leaves
-      // the board showing.
-      if (initialSlug && !openedInitial) {
-        openedInitial = true;
-        const found = Object.values(next)
-          .flat()
-          .find((i) => i.id === initialSlug);
-        if (found) {
-          openItem = found;
-          pendingOutcome = false;
-        }
-      }
+      build(slice.items);
     } catch {
       status = 'error';
     }
   }
 
+  // Server-preloaded rows paint immediately (SSR + client-nav both run the route's
+  // server load). `initial` is fixed for this mount (drawer open/close is pushState,
+  // not a reload), so capture its presence once and only bootstrap a client fetch
+  // when the caller gave us none.
+  const preloaded = !!initial;
+  if (initial) build(initial);
+
   $effect(() => {
-    if (isAuthenticated()) void load();
+    if (!preloaded && isAuthenticated()) void load();
   });
 
   function onconsider(id: BoardColumnId, items: BoardItem[]) {

--- a/web/src/routes/my/tracking/+page.server.ts
+++ b/web/src/routes/my/tracking/+page.server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit';
+import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
 // /my/tracking is personal: a signed-out visitor has nothing to show, so guard it
@@ -7,10 +8,21 @@ import type { PageServerLoad } from './$types';
 // dialog (no /login route), so we bounce home with ?auth=required and the TopBar
 // pops the sign-in dialog (same pattern as the ?auth_error OAuth callback). The
 // ?redirect carries the destination so sign-in returns here, not the home page.
-export const load: PageServerLoad = async ({ parent, url }) => {
+export const load: PageServerLoad = async ({ parent, url, fetch, request }) => {
   const { user } = await parent();
   if (!user) {
     const target = url.pathname + url.search;
     redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
+  }
+  // Fetch the board here so it renders with the page. Previously JobBoard fetched
+  // it client-side on mount, a waterfall (navigate → HTML → hydrate → listMyJobs →
+  // render); pulling it into the server load collapses that into one round trip.
+  // A transient API failure shouldn't 500 the page — leave board undefined and let
+  // JobBoard fall back to its client fetch (which renders the friendly error state).
+  try {
+    const board = await serverApi(fetch, request.headers.get('cookie')).listMyJobs('board', 500, 0);
+    return { board: board.items };
+  } catch {
+    return {};
   }
 };

--- a/web/src/routes/my/tracking/+page.svelte
+++ b/web/src/routes/my/tracking/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import JobBoard from '$lib/components/JobBoard.svelte';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
 </script>
 
 <svelte:head>
   <title>Tracking — freehire</title>
 </svelte:head>
 
-<JobBoard />
+<JobBoard initial={data.board} />

--- a/web/src/routes/my/tracking/[slug]/+page.server.ts
+++ b/web/src/routes/my/tracking/[slug]/+page.server.ts
@@ -1,14 +1,24 @@
 import { redirect } from '@sveltejs/kit';
+import { serverApi } from '$lib/server/api';
 import type { PageServerLoad } from './$types';
 
 // /my/tracking/[slug] renders the tracking board with the application's drawer open
 // (deep-linkable — the inbox links here, and a refresh/share reopens the same card).
 // The board itself is for any signed-in user; the Emails tab inside the drawer
 // self-gates to moderators. Guard auth like /my/tracking and pass the slug through.
-export const load: PageServerLoad = async ({ parent, params, url }) => {
+// The board is server-fetched (same as /my/tracking) so opening a deep link paints
+// the board + drawer in one round trip instead of a client fetch on mount.
+export const load: PageServerLoad = async ({ parent, params, url, fetch, request }) => {
   const { user } = await parent();
   if (!user) {
     redirect(302, `/?auth=required&redirect=${encodeURIComponent(url.pathname)}`);
   }
-  return { slug: params.slug };
+  // A transient API failure shouldn't 500 the deep link — leave board undefined and
+  // let JobBoard fall back to its client fetch (which renders the friendly error state).
+  try {
+    const board = await serverApi(fetch, request.headers.get('cookie')).listMyJobs('board', 500, 0);
+    return { slug: params.slug, board: board.items };
+  } catch {
+    return { slug: params.slug };
+  }
 };

--- a/web/src/routes/my/tracking/[slug]/+page.svelte
+++ b/web/src/routes/my/tracking/[slug]/+page.svelte
@@ -10,4 +10,4 @@
 </svelte:head>
 
 <!-- Same board as /my/tracking, but opened on the given application's drawer. -->
-<JobBoard initialSlug={data.slug} />
+<JobBoard initialSlug={data.slug} initial={data.board} />


### PR DESCRIPTION
## Problem

`/my/tracking` and `/my/tracking/[slug]` render `<JobBoard>`, which fetched its rows **client-side on mount** (`api.listMyJobs('board', 500, 0)`). The server load only did an auth guard, so the sequence was: navigate → HTML → hydrate → fetch → render. Measured on prod: the board request is **~2.0–2.8s** total (TTFB ~1–1.7s, **838 KB** for 183 cards), shown as a spinner *after* the page already arrived. A deep link (`/my/tracking/[slug]`) paid the same before it could open the drawer — which is why "opening a card first loads the whole list".

## Fix

Move the board fetch into each route's **server load** (`serverApi(fetch, cookie).listMyJobs(...)`), so the board — and, for a deep link, the opened drawer — render **with the page in one round trip**. No more post-hydration waterfall.

- `JobBoard` takes the preloaded rows via a new `initial` prop and paints from them; it only client-fetches when a caller omits `initial`. Mutations still `reload()` client-side (unchanged).
- `build(rows)` extracted from `load()` so SSR-preload and client-refetch share the same column layout + deep-link drawer logic.
- A transient server-load failure leaves `board` undefined, so `JobBoard` falls back to its client fetch + friendly error state instead of 500ing the page (mirrors `+layout.server.ts`).

## Verification

- `npm run check` — 0 errors; `npm run build` — SSR compiles.
- End-to-end SSR smoke (built node server → prod API, real session cookie): `/my/tracking` returns the **full board in the server HTML** (Applied/Interview cards present, 838 KB), and `/my/tracking/senior-...-scrumlaunch-o3jgavc6` renders **board + drawer** (Notes/Overview) server-side — no client fetch needed.

Note: payload is still the full `jobview` per card (838 KB). A lighter board projection is a follow-up seam.