### PR TITLE
feat(tracking): per-card linked-email badge on the board

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -603,7 +603,9 @@ type Querier interface {
 	// first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
 	// viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is
 	// the passive history (rows neither saved nor applied). Closed jobs stay
-	// listed: a user's history must not shrink when a posting closes.
+	// listed: a user's history must not shrink when a posting closes. email_count is
+	// the caller's live (non-deleted) inbox messages linked to this job — the board's
+	// per-card ✉ badge; 0 for everyone without a connected mailbox.
 	ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error)
 	// Every public_slug the user has interacted with (viewed_at is always set, so
 	// any interaction row counts as viewed). Used by the SPA to dim already-seen

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -122,8 +122,15 @@ RETURNING *;
 -- first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
 -- viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is
 -- the passive history (rows neither saved nor applied). Closed jobs stay
--- listed: a user's history must not shrink when a posting closes.
-SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+-- listed: a user's history must not shrink when a posting closes. email_count is
+-- the caller's live (non-deleted) inbox messages linked to this job — the board's
+-- per-card ✉ badge; 0 for everyone without a connected mailbox.
+SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes,
+       (SELECT count(*)
+          FROM emails e
+         WHERE e.user_id = uj.user_id
+           AND e.job_id = jobs.id
+           AND e.deleted_at IS NULL) AS email_count
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -221,7 +221,12 @@ func (q *Queries) ListSavedJobSlugs(ctx context.Context, userID int64) ([]string
 }
 
 const listUserJobs = `-- name: ListUserJobs :many
-SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, jobs.semantic_embedding, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes
+SELECT jobs.id, jobs.source, jobs.external_id, jobs.url, jobs.title, jobs.company, jobs.location, jobs.remote, jobs.description, jobs.posted_at, jobs.created_at, jobs.updated_at, jobs.company_slug, jobs.enrichment, jobs.enriched_at, jobs.enrichment_version, jobs.public_slug, jobs.last_seen_at, jobs.closed_at, jobs.countries, jobs.regions, jobs.work_mode, jobs.liveness_strikes, jobs.skills, jobs.seniority, jobs.category, jobs.created_by, jobs.updated_by, jobs.posting_language, jobs.employment_type, jobs.education_level, jobs.experience_years_min, jobs.collections, jobs.content_hash, jobs.english_level, jobs.cities, jobs.view_count, jobs.applied_count, jobs.role_fingerprint, jobs.semantic_embedded_model, jobs.semantic_embedded_hash, jobs.duplicate_of, jobs.is_tech, jobs.semantic_embedding, uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes,
+       (SELECT count(*)
+          FROM emails e
+         WHERE e.user_id = uj.user_id
+           AND e.job_id = jobs.id
+           AND e.deleted_at IS NULL) AS email_count
 FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1
@@ -243,19 +248,22 @@ type ListUserJobsParams struct {
 }
 
 type ListUserJobsRow struct {
-	Job       Job                `json:"job"`
-	ViewedAt  pgtype.Timestamptz `json:"viewed_at"`
-	SavedAt   pgtype.Timestamptz `json:"saved_at"`
-	AppliedAt pgtype.Timestamptz `json:"applied_at"`
-	Stage     pgtype.Text        `json:"stage"`
-	Notes     pgtype.Text        `json:"notes"`
+	Job        Job                `json:"job"`
+	ViewedAt   pgtype.Timestamptz `json:"viewed_at"`
+	SavedAt    pgtype.Timestamptz `json:"saved_at"`
+	AppliedAt  pgtype.Timestamptz `json:"applied_at"`
+	Stage      pgtype.Text        `json:"stage"`
+	Notes      pgtype.Text        `json:"notes"`
+	EmailCount int64              `json:"email_count"`
 }
 
 // A user's job interactions joined with the job rows, most recently touched
 // first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
 // viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is
 // the passive history (rows neither saved nor applied). Closed jobs stay
-// listed: a user's history must not shrink when a posting closes.
+// listed: a user's history must not shrink when a posting closes. email_count is
+// the caller's live (non-deleted) inbox messages linked to this job — the board's
+// per-card ✉ badge; 0 for everyone without a connected mailbox.
 func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error) {
 	rows, err := q.db.Query(ctx, listUserJobs,
 		arg.UserID,
@@ -320,6 +328,7 @@ func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]L
 			&i.AppliedAt,
 			&i.Stage,
 			&i.Notes,
+			&i.EmailCount,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -12,12 +12,13 @@ import (
 // jobview wire shape with the caller's interaction timestamps riding alongside
 // (not flattened in — the job shape stays identical to every other job surface).
 type myJobResponse struct {
-	Job       jobview.Job `json:"job"`
-	ViewedAt  *time.Time  `json:"viewed_at"`
-	SavedAt   *time.Time  `json:"saved_at"`
-	AppliedAt *time.Time  `json:"applied_at"`
-	Stage     *string     `json:"stage"`
-	Notes     *string     `json:"notes"`
+	Job        jobview.Job `json:"job"`
+	ViewedAt   *time.Time  `json:"viewed_at"`
+	SavedAt    *time.Time  `json:"saved_at"`
+	AppliedAt  *time.Time  `json:"applied_at"`
+	Stage      *string     `json:"stage"`
+	Notes      *string     `json:"notes"`
+	EmailCount int         `json:"email_count"`
 }
 
 // ListTrackedJobs returns the authenticated user's job interactions joined with the
@@ -43,12 +44,13 @@ func (a *API) ListTrackedJobs(c *fiber.Ctx) error {
 	items := make([]myJobResponse, 0, len(listing.Items))
 	for _, it := range listing.Items {
 		items = append(items, myJobResponse{
-			Job:       it.Job,
-			ViewedAt:  it.ViewedAt,
-			SavedAt:   it.SavedAt,
-			AppliedAt: it.AppliedAt,
-			Stage:     it.Stage,
-			Notes:     it.Notes,
+			Job:        it.Job,
+			ViewedAt:   it.ViewedAt,
+			SavedAt:    it.SavedAt,
+			AppliedAt:  it.AppliedAt,
+			Stage:      it.Stage,
+			Notes:      it.Notes,
+			EmailCount: it.EmailCount,
 		})
 	}
 

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -84,6 +84,9 @@ func (c Counts) Total(f Filter) int64 {
 type TrackedJob struct {
 	Job jobview.Job
 	Interaction
+	// EmailCount is the caller's live inbox messages linked to this job — the
+	// board's per-card ✉ badge. 0 for users without a connected mailbox.
+	EmailCount int
 }
 
 // Listing is the result of ListTracked: a page of tracked jobs for the active

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -169,6 +169,7 @@ func (r *QueriesRepository) ListInteractions(
 				Stage:     textPtr(row.Stage),
 				Notes:     textPtr(row.Notes),
 			},
+			EmailCount: int(row.EmailCount),
 		})
 	}
 	return items, nil

--- a/web/src/lib/components/BoardCard.svelte
+++ b/web/src/lib/components/BoardCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Mail } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import { Badge } from '$lib/ui';
   import { humanizeStage } from '$lib/stages';
@@ -22,6 +23,16 @@
   <span class="flex items-center gap-1.5">
     {#if item.stage}
       <Badge variant="secondary">{humanizeStage(item.stage)}</Badge>
+    {/if}
+    {#if item.email_count > 0}
+      <span
+        class="flex items-center gap-0.5 text-xs tabular-nums text-muted-foreground"
+        title="{item.email_count} linked email{item.email_count === 1 ? '' : 's'}"
+        aria-label="{item.email_count} linked email{item.email_count === 1 ? '' : 's'}"
+      >
+        <Mail class="size-3 shrink-0" aria-hidden="true" />
+        {item.email_count}
+      </span>
     {/if}
     {#if hasNotes}
       <svg

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -244,6 +244,9 @@ export interface MyJob {
   applied_at: string | null;
   stage: string | null;
   notes: string | null;
+  /** Live inbox messages linked to this job — the board card's ✉ badge. 0 for
+   *  users without a connected mailbox / no linked mail. */
+  email_count: number;
 }
 
 /** The classification/link overlay an inbox email carries: its classified status


### PR DESCRIPTION
Each Kanban card on `/my/tracking` now shows a **✉ N** badge with the count of the caller's live (non-deleted) inbox messages linked to that application — so a card that has mail replies is visible at a glance.

## How

- `ListUserJobs` carries `email_count` via a correlated subquery over `emails` (`user_id` + `job_id`, `deleted_at IS NULL`, served by the existing `emails_job_id_idx` partial index).
- Threads through `TrackedJob.EmailCount` → the `/me/tracking` response (`email_count`) → `MyJob` → `BoardCard`, which renders the badge **only when the count is > 0** (invisible for users without a connected mailbox / linked mail).
- **No migration**: `emails.job_id` and `deleted_at` already exist in prod (0020, 0022).

## Verification

- `go build ./...`, `go vet`, `go test ./internal/jobtracking ./internal/handler` — pass.
- `npm run check` — 0 errors.
- Post-deploy: will confirm `/me/tracking` returns `email_count` live.