### PR TITLE
fix(sources): cap join pageSize at 5 to match tightened public API

### DIFF
--- a/internal/sources/join.go
+++ b/internal/sources/join.go
@@ -9,9 +9,11 @@ import (
 	"github.com/yuin/goldmark"
 )
 
-// joinPageSize is the list-API page size.
+// joinPageSize is the list-API page size. Join's public API caps pageSize at 5; any larger
+// value is rejected with HTTP 422. Pagination is driven by pagination.pageCount, so a smaller
+// page just means more list pages — the per-job detail fetches (the bulk of the work) are unaffected.
 const (
-	joinPageSize = 100
+	joinPageSize = 5
 )
 
 // join adapts Join.com career pages over its public JSON API. The board is the numeric Join


### PR DESCRIPTION
## Problem

All **4111 join.com boards** were failing on prod (100% in `board_health`, driving the `/status` page to "Major Outage").

Root cause: join.com tightened its public list API. `pageSize` is now capped at **5** — any larger value returns **HTTP 422** with body `[{"param":"pageSize","msg":"Invalid value"}]`. The adapter hardcoded `pageSize=100`, so every board's list request failed.

Diagnosed by probing from two IPs (same 422 → not an IP block) and binary-searching the limit: `pageSize` 1–5 → 200, 6+ → 422.

## Fix

`joinPageSize` 100 → 5. Pagination is already driven by `pagination.pageCount`, so a smaller page just means more list requests — the per-job detail fetches (the bulk of the cost) are unchanged. Verified the response shape is otherwise unchanged at `pageSize=5`.

Restores all join boards on the next crawl (cooldown clears automatically on first success).

## Test

- `go build ./internal/sources/` + `go vet ./internal/sources/` pass
- Live API returns 200 with the expected `{items, pagination{pageCount}}` shape at `pageSize=5`