### PR TITLE
feat(tracking): raise board cap to 500 + dedup server loads

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -36,6 +36,10 @@ import (
 const (
 	defaultLimit = 20
 	maxLimit     = 100
+	// trackingMaxLimit is the higher ceiling for the caller's own tracked-jobs
+	// listing: the Kanban board is unpaginated (it fetches everything at once), so
+	// the shared 100 cap would silently hide a heavy user's older applications.
+	trackingMaxLimit = 500
 	// telegramLinkTTL bounds how long a deep-link token is valid — long enough to
 	// open Telegram and tap Start, short enough to limit a leaked link's window.
 	telegramLinkTTL = 10 * time.Minute
@@ -137,6 +141,13 @@ type API struct {
 // The offset is clamped into int32 range because the column binds as a Postgres
 // int4, and an unbounded query value would otherwise overflow on the conversion.
 func pageParams(c *fiber.Ctx) (limit, offset int) {
+	return pageParamsMax(c, maxLimit)
+}
+
+// pageParamsMax is pageParams with a caller-supplied limit ceiling, for endpoints
+// whose page is bounded differently than the shared list cap (e.g. the tracking
+// board, which is unpaginated and needs the whole set).
+func pageParamsMax(c *fiber.Ctx, maxLimit int) (limit, offset int) {
 	limit = min(max(c.QueryInt("limit", defaultLimit), 1), maxLimit)
 	offset = min(max(c.QueryInt("offset", 0), 0), math.MaxInt32)
 	return limit, offset

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -35,7 +35,7 @@ func (a *API) ListTrackedJobs(c *fiber.Ctx) error {
 		return err
 	}
 
-	limit, offset := pageParams(c)
+	limit, offset := pageParamsMax(c, trackingMaxLimit)
 	listing, err := a.tracking.ListTracked(c.Context(), userID, c.Query("filter"), int32(limit), int32(offset))
 	if err != nil {
 		return trackingError(err)

--- a/web/src/lib/server/tracking.ts
+++ b/web/src/lib/server/tracking.ts
@@ -1,0 +1,14 @@
+import { serverApi } from './api';
+
+/** Fetch the caller's Kanban board rows for the tracking routes' server load, so
+ *  the board renders with the page instead of after a client fetch on mount. A
+ *  transient API failure returns undefined, letting JobBoard fall back to its own
+ *  client fetch + friendly error state rather than 500ing the page. */
+export async function loadBoard(fetchImpl: typeof fetch, cookie: string | null) {
+  try {
+    const board = await serverApi(fetchImpl, cookie).listMyJobs('board', 500, 0);
+    return board.items;
+  } catch {
+    return undefined;
+  }
+}

--- a/web/src/routes/my/tracking/+page.server.ts
+++ b/web/src/routes/my/tracking/+page.server.ts
@@ -1,5 +1,5 @@
 import { redirect } from '@sveltejs/kit';
-import { serverApi } from '$lib/server/api';
+import { loadBoard } from '$lib/server/tracking';
 import type { PageServerLoad } from './$types';
 
 // /my/tracking is personal: a signed-out visitor has nothing to show, so guard it
@@ -14,15 +14,7 @@ export const load: PageServerLoad = async ({ parent, url, fetch, request }) => {
     const target = url.pathname + url.search;
     redirect(302, `/?auth=required&redirect=${encodeURIComponent(target)}`);
   }
-  // Fetch the board here so it renders with the page. Previously JobBoard fetched
-  // it client-side on mount, a waterfall (navigate → HTML → hydrate → listMyJobs →
-  // render); pulling it into the server load collapses that into one round trip.
-  // A transient API failure shouldn't 500 the page — leave board undefined and let
-  // JobBoard fall back to its client fetch (which renders the friendly error state).
-  try {
-    const board = await serverApi(fetch, request.headers.get('cookie')).listMyJobs('board', 500, 0);
-    return { board: board.items };
-  } catch {
-    return {};
-  }
+  // Fetch the board here so it renders with the page, not after a client fetch on
+  // mount (see loadBoard for the waterfall it replaces + the failure fallback).
+  return { board: await loadBoard(fetch, request.headers.get('cookie')) };
 };

--- a/web/src/routes/my/tracking/[slug]/+page.server.ts
+++ b/web/src/routes/my/tracking/[slug]/+page.server.ts
@@ -1,5 +1,5 @@
 import { redirect } from '@sveltejs/kit';
-import { serverApi } from '$lib/server/api';
+import { loadBoard } from '$lib/server/tracking';
 import type { PageServerLoad } from './$types';
 
 // /my/tracking/[slug] renders the tracking board with the application's drawer open
@@ -13,12 +13,5 @@ export const load: PageServerLoad = async ({ parent, params, url, fetch, request
   if (!user) {
     redirect(302, `/?auth=required&redirect=${encodeURIComponent(url.pathname)}`);
   }
-  // A transient API failure shouldn't 500 the deep link — leave board undefined and
-  // let JobBoard fall back to its client fetch (which renders the friendly error state).
-  try {
-    const board = await serverApi(fetch, request.headers.get('cookie')).listMyJobs('board', 500, 0);
-    return { slug: params.slug, board: board.items };
-  } catch {
-    return { slug: params.slug };
-  }
+  return { slug: params.slug, board: await loadBoard(fetch, request.headers.get('cookie')) };
 };


### PR DESCRIPTION
## Cap fix (behavior)

The Kanban board is unpaginated — `JobBoard` fetches the whole set with `limit=500` — but `/me/tracking` went through the shared `pageParams`, which clamps to `maxLimit=100`. A user with >100 board items (e.g. **183**) silently saw only the 100 most-recently-touched. Adds `pageParamsMax(c, max)` (`pageParams` now delegates) and a `trackingMaxLimit = 500` for the tracking listing, so the server honors what the board already requests.

## Simplify pass (no behavior change)

Extracted `loadBoard()` (the board fetch + undefined-on-failure fallback) into `$lib/server/tracking`, so `/my/tracking` and `/my/tracking/[slug]` share one helper instead of copy-pasted try/catch.

## Verification

- `go build`, `go vet`, `go test ./internal/handler` — pass.
- `npm run check` — 0 errors.