### PR TITLE
feat(sources): add Djinni (djinni.co) job-source adapter

### DIFF
--- a/internal/sources/djinni.go
+++ b/internal/sources/djinni.go
@@ -1,0 +1,128 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"html"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// djinni adapts djinni.co, a Ukrainian/CEE IT job board. Each anonymous listing page
+// (/jobs/?page=N) embeds one application/ld+json block that is an ARRAY of full schema.org
+// JobPosting objects — description included — so one fetch per page yields every posting
+// without a per-posting detail request. Boardless (djinni.co is one site with no per-tenant
+// board) and an aggregator (many companies; each posting's company comes from the feed), so it
+// stays in the source facet and inherits the reindex aggregator/ATS suppression.
+type djinni struct {
+	http HTMLResolvedGetter
+}
+
+const (
+	// djinniListBase is the guest listing; the caller appends the "page=N" (1-based) marker,
+	// which doubles as the end-of-feed sentinel checked against the resolved final URL.
+	djinniListBase = "https://djinni.co/jobs/?"
+	// djinniMaxPages caps pagination as a backstop, comfortably above the observed corpus
+	// (~488 pages). The empty-page stop below is the primary terminator; this only bounds a
+	// pathological feed that never empties.
+	djinniMaxPages = 600
+)
+
+// NewDjinni builds the djinni listing adapter over the given HTML client.
+func NewDjinni(c HTMLResolvedGetter) Source { return djinni{http: c} }
+
+func (djinni) Provider() string { return "djinni" }
+
+func (djinni) boardless() {}
+
+func (djinni) aggregator() {}
+
+// Fetch pages the listing from page 1 upward, mapping each page's JSON-LD JobPosting array to
+// jobs. It stops at the end of the feed, detected by the redirect: a past-the-end page 302s to
+// the bare listing (/jobs/), so the FINAL URL no longer carries the requested page marker.
+// (Following the redirect would otherwise re-serve page 1 indefinitely, since page 1 is not
+// empty.) A genuinely empty non-redirected page is a secondary stop.
+func (s djinni) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; page <= djinniMaxPages; page++ {
+		pageMarker := fmt.Sprintf("page=%d", page)
+		root, final, err := s.http.GetHTMLResolved(ctx, djinniListBase+pageMarker)
+		if err != nil {
+			return nil, fmt.Errorf("djinni: fetch page %d: %w", page, err)
+		}
+		if !strings.Contains(final, pageMarker) {
+			break // redirected off the end of the feed (past-the-end page 302s to /jobs/)
+		}
+		nodes := LDJobPostings(root)
+		if len(nodes) == 0 {
+			break // a non-redirected page with no postings — nothing more to read
+		}
+		for _, raw := range nodes {
+			var p djinniPosting
+			if json.Unmarshal(raw, &p) != nil {
+				continue // a posting that fails to decode is skipped, never aborting the page
+			}
+			if job, ok := p.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+	}
+	return jobs, nil
+}
+
+// djinniPosting is one schema.org JobPosting from the listing. identifier is a bare integer;
+// jobLocationType (TELECOMMUTE/ON_SITE) is the work-arrangement signal; the applicant location
+// requirement carries only a country.
+type djinniPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	URL                string `json:"url"`
+	DatePosted         string `json:"datePosted"`
+	EmploymentType     string `json:"employmentType"`
+	JobLocationType    string `json:"jobLocationType"`
+	Identifier         int64  `json:"identifier"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	ApplicantLocationRequirements struct {
+		Address struct {
+			AddressCountry string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"applicantLocationRequirements"`
+}
+
+// toJob maps a posting to a Job, returning ok=false for a posting with no identifier (no dedup
+// key), no url (no canonical address), or no company (which would break the company slug).
+func (p djinniPosting) toJob() (Job, bool) {
+	if p.Identifier == 0 || p.URL == "" || p.HiringOrganization.Name == "" {
+		return Job{}, false
+	}
+	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+	return Job{
+		ExternalID:     strconv.FormatInt(p.Identifier, 10),
+		URL:            p.URL,
+		Title:          p.Title,
+		Company:        p.HiringOrganization.Name,
+		Location:       p.ApplicantLocationRequirements.Address.AddressCountry,
+		Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:         remote,
+		WorkMode:       workModeFromRemote(remote),
+		EmploymentType: schemaEmploymentType(p.EmploymentType),
+		PostedAt:       djinniDate(p.DatePosted),
+	}, true
+}
+
+// djinniDate parses Djinni's datePosted, an ISO-8601 local datetime WITHOUT a zone (e.g.
+// "2026-07-16T04:43:20.486231"). parseRFC3339 rejects the missing zone, so this reads it as
+// UTC, trying parseRFC3339 first (should Djinni ever emit a zoned value) and a bare date last.
+func djinniDate(s string) *time.Time {
+	if t := parseRFC3339(s); t != nil {
+		return t
+	}
+	if t := parseLayout("2006-01-02T15:04:05.999999999", s); t != nil {
+		return t
+	}
+	return parseDate(s)
+}

--- a/internal/sources/djinni_test.go
+++ b/internal/sources/djinni_test.go
@@ -1,0 +1,211 @@
+package sources
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// djinniListingHTML is a djinni.co-shaped listing page: one application/ld+json block whose
+// payload is an ARRAY of JobPosting objects (as the real listing emits), alongside the
+// Organization/BreadcrumbList blocks the real page also carries — which LDJobPostings must
+// ignore. The first posting is a fully-populated remote UA role; the second is a minimal but
+// usable posting; the third is unusable (no company) and must be dropped.
+const djinniListingHTML = `<html><head>
+<script type="application/ld+json">{"@type":"Organization","name":"Djinni"}</script>
+<script type="application/ld+json">
+[{"@context":"https://schema.org/","@type":"JobPosting",
+"title":"Senior Backend Go Engineer",
+"url":"https://djinni.co/jobs/837549-senior-backend-go-engineer/",
+"description":"<p>Build &amp; ship services.</p>",
+"datePosted":"2026-07-06T04:43:20.486231",
+"employmentType":"FULL_TIME",
+"jobLocationType":"TELECOMMUTE",
+"identifier":837549,
+"hiringOrganization":{"@type":"Organization","name":"Acme","sameAs":"https://acme.example/"},
+"applicantLocationRequirements":{"@type":"AdministrativeArea","address":{"@type":"PostalAddress","addressCountry":"UA"}},
+"validThrough":"2026-08-15T04:43:20.486231"},
+{"@context":"https://schema.org/","@type":"JobPosting",
+"title":"Recruiter",
+"url":"https://djinni.co/jobs/837547-recruiter/",
+"description":"Hire people.",
+"employmentType":"FULL_TIME",
+"identifier":837547,
+"hiringOrganization":{"@type":"Organization","name":"Beta"}},
+{"@context":"https://schema.org/","@type":"JobPosting",
+"title":"Orphan role",
+"url":"https://djinni.co/jobs/1-orphan/",
+"identifier":1,
+"hiringOrganization":{"@type":"Organization"}}]
+</script>
+</head><body></body></html>`
+
+// djinniSingleHTML carries one JobPosting as a lone object (not wrapped in an array), which the
+// adapter must still map.
+const djinniSingleHTML = `<html><head>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+"title":"Lone Posting","url":"https://djinni.co/jobs/900-lone/","identifier":900,
+"hiringOrganization":{"@type":"Organization","name":"Solo"}}
+</script>
+</head><body></body></html>`
+
+const djinniEmptyHTML = `<html><head></head><body></body></html>`
+
+// djinniPagedHTTP models djinni.co's listing pagination. A page present in bodies is served
+// directly (final URL == requested URL, no redirect). A page ABSENT from bodies models the real
+// past-the-end behavior: djinni 302s to the bare listing (/jobs/) and serves page 1's content —
+// so the resolved final URL loses the page marker, which is the adapter's end-of-feed signal.
+type djinniPagedHTTP struct {
+	bodies  map[int]string
+	gotURLs []string
+}
+
+func (f *djinniPagedHTTP) GetHTMLResolved(_ context.Context, url string) (*html.Node, string, error) {
+	f.gotURLs = append(f.gotURLs, url)
+	page := djinniPageOf(url)
+	if body, ok := f.bodies[page]; ok {
+		node, err := html.Parse(strings.NewReader(body))
+		return node, url, err // served directly, no redirect
+	}
+	// Past the end: 302 → /jobs/, re-serving page 1's content under a page-less final URL.
+	node, err := html.Parse(strings.NewReader(f.bodies[1]))
+	return node, "https://djinni.co/jobs/", err
+}
+
+// djinniPageOf extracts N from a "…?page=N" URL, or 0 when absent.
+func djinniPageOf(url string) int {
+	_, after, ok := strings.Cut(url, "page=")
+	if !ok {
+		return 0
+	}
+	n, _ := strconv.Atoi(after)
+	return n
+}
+
+func TestDjinniProvider(t *testing.T) {
+	if got := NewDjinni(nil).Provider(); got != "djinni" {
+		t.Errorf("Provider() = %q, want %q", got, "djinni")
+	}
+}
+
+func TestDjinniFetchMapsListingArray(t *testing.T) {
+	fake := &djinniPagedHTTP{bodies: map[int]string{1: djinniListingHTML}}
+
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// Page 1 has three JobPostings; the third is unusable (no company) and is dropped.
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want the 2 usable postings", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "837549" {
+		t.Errorf("ExternalID = %q, want the numeric identifier as string", j.ExternalID)
+	}
+	if j.URL != "https://djinni.co/jobs/837549-senior-backend-go-engineer/" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Senior Backend Go Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Acme" {
+		t.Errorf("Company = %q, want hiringOrganization.name", j.Company)
+	}
+	if j.Location != "UA" {
+		t.Errorf("Location = %q, want addressCountry", j.Location)
+	}
+	// sanitizeHTML keeps structural markup (bluemonday allows <p>) and re-encodes bare &,
+	// so a description round-trips as safe HTML rather than being flattened to plain text.
+	if j.Description != "<p>Build &amp; ship services.</p>" {
+		t.Errorf("Description = %q, want sanitized description HTML", j.Description)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want true/remote for TELECOMMUTE", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.PostedAt == nil {
+		t.Errorf("PostedAt = nil, want the zone-less datePosted parsed")
+	}
+}
+
+func TestDjinniDropsUnusablePosting(t *testing.T) {
+	fake := &djinniPagedHTTP{bodies: map[int]string{1: djinniListingHTML}}
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	for _, j := range jobs {
+		if j.Title == "Orphan role" {
+			t.Fatalf("mapped the company-less posting %q, want it dropped", j.Title)
+		}
+	}
+}
+
+func TestDjinniAcceptsSingleObjectBlock(t *testing.T) {
+	fake := &djinniPagedHTTP{bodies: map[int]string{1: djinniSingleHTML}}
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "900" {
+		t.Fatalf("got %#v, want the lone-object posting mapped", jobs)
+	}
+}
+
+// TestDjinniStopsAtPastEndRedirect is the regression guard for the redirect trap: a past-the-end
+// page 302s to /jobs/ and re-serves page 1 (which is NOT empty), so a naive "stop on empty page"
+// would loop, re-ingesting page 1 up to the page cap. The adapter must instead stop on the
+// redirect (final URL lost the page marker) after requesting exactly page 1 then page 2.
+func TestDjinniStopsAtPastEndRedirect(t *testing.T) {
+	fake := &djinniPagedHTTP{bodies: map[int]string{1: djinniListingHTML}}
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want only page 1's 2 usable postings (no re-ingested duplicates)", len(jobs))
+	}
+	if len(fake.gotURLs) != 2 {
+		t.Fatalf("requested %d pages (%v), want page 1 then the redirected page 2 only", len(fake.gotURLs), fake.gotURLs)
+	}
+}
+
+// TestDjinniStopsOnEmptyNonRedirectedPage covers the secondary stop: a page that returns 200
+// with no JobPosting (not a redirect) also ends the crawl.
+func TestDjinniStopsOnEmptyNonRedirectedPage(t *testing.T) {
+	fake := &djinniPagedHTTP{bodies: map[int]string{1: djinniListingHTML, 2: djinniEmptyHTML}}
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want page 1's 2 postings then a stop at the empty page 2", len(jobs))
+	}
+	if len(fake.gotURLs) != 2 {
+		t.Fatalf("requested %d pages, want page 1 then the empty page 2", len(fake.gotURLs))
+	}
+}
+
+func TestDjinniIsAggregator(t *testing.T) {
+	reg := All(nil)
+	if got := ProviderKind(reg, "djinni"); got != KindAggregator {
+		t.Errorf("ProviderKind(djinni) = %q, want %q", got, KindAggregator)
+	}
+	found := false
+	for _, p := range AggregatorProviders(reg) {
+		if p == "djinni" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("djinni missing from AggregatorProviders — it would not inherit ATS suppression")
+	}
+}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -50,6 +50,14 @@ type HTMLGetter interface {
 	GetHTML(ctx context.Context, url string) (*html.Node, error)
 }
 
+// HTMLResolvedGetter fetches a URL following redirects and returns its parsed HTML tree
+// together with the FINAL URL after redirects — for adapters that must observe a redirect
+// (e.g. djinni's listing, whose past-the-end page 302s to the bare listing, so the final
+// URL is the only reliable end-of-feed signal).
+type HTMLResolvedGetter interface {
+	GetHTMLResolved(ctx context.Context, url string) (*html.Node, string, error)
+}
+
 // TextGetter fetches a URL and returns its raw response body, for adapters that regex a
 // token or config blob out of a page rather than parsing its DOM (e.g. Cornerstone).
 type TextGetter interface {
@@ -89,6 +97,7 @@ type HTTPClient interface {
 	StreamGetter
 	XMLGetter
 	HTMLGetter
+	HTMLResolvedGetter
 	TextGetter
 	HeaderTextGetter
 	JSONPoster

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -204,6 +204,7 @@ func All(c HTTPClient) map[string]Source {
 		NewCareerPage(c),
 		NewNorthstone(c),
 		NewBriefHQ(c),
+		NewDjinni(c),
 		NewTalentAdore(c),
 		NewLoxo(c),
 		NewHireology(c),

--- a/openspec/changes/add-djinni-source/.openspec.yaml
+++ b/openspec/changes/add-djinni-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/add-djinni-source/design.md
+++ b/openspec/changes/add-djinni-source/design.md
@@ -1,0 +1,103 @@
+## Context
+
+freehire ingests jobs through single-responsibility `Source` adapters registered in
+`sources.All`, each a read-only reader over a public feed. A spike confirmed Djinni exposes
+its whole guest corpus (~488 pages × 15 postings) as embedded JSON-LD `JobPosting` arrays on
+`/jobs/?page=N`, with full descriptions on the listing, stable numeric ids, working
+anonymous pagination, and no anti-bot wall.
+
+The user's requirement — "don't re-ingest what an ATS already gives us" — is already a
+solved, specced capability in this codebase (`aggregator-ats-dedup` + the fuzzy/subset title
+variants), implemented in the **reindex** suppression pass, not in adapters. A crucial
+constraint from the spike: Djinni handles applications in-platform, so postings carry **no
+outbound ATS apply URL**; the apply-URL → `atsdetect.FromURL` reroute path (used by
+link-source adapters) therefore has nothing to bite on and is not applicable here.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A `djinni` adapter that maps the listing JSON-LD to normalized `Job`s and pages to the end.
+- ATS-dedup that reuses the existing reindex suppression by classifying `djinni` as an
+  aggregator — no new dedup code, no adapter DB access.
+- Keep the adapter a pure HTTP reader, unit-testable against a saved HTML fixture.
+
+**Non-Goals:**
+- No new cross-source dedup mechanism, DB-backed port, or company registry.
+- No per-posting detail hydration (the listing already carries the description).
+- No sharding by specialization (single board is acceptable at ~16 min/full crawl); the
+  seam is noted but not built.
+- No `cmd/backfill-*` worker (nothing to backfill for a brand-new source).
+
+## Decisions
+
+### Decision: Inherit ATS-dedup via the `aggregator` marker, not a company-skip callback
+
+An earlier framing proposed skipping every Djinni posting whose company already has a
+registered ATS board (a DB-backed callback into the adapter). Investigation of the existing
+specs showed the codebase already suppresses aggregator/ATS twins at reindex, keyed on
+`company_slug` + normalized title + compatible country, self-healing when the ATS twin
+closes. Marking `djinni` with the existing `aggregator()` marker (and thus surfacing it in
+`sources.AggregatorProviders()`) enrolls it in that pass for free.
+
+- **Why over the company-skip callback:** the callback suppresses at company granularity and
+  would hide Djinni-exclusive roles at any company we also crawl via an ATS — the exact risk
+  flagged when that option was considered. The reindex pass suppresses at posting granularity
+  (title + country), so exclusives survive. It also keeps the adapter a pure HTTP reader with
+  no DB dependency, matching every other adapter and keeping tests offline.
+- **Alternative considered — apply-URL reroute (`atsdetect.FromURL`):** rejected because
+  Djinni has no outbound ATS apply URL to detect.
+
+### Decision: Parse the listing JSON-LD; accept both array and single object
+
+Each page has one `ld+json` block that is a JSON array of `JobPosting`. The adapter unmarshals
+into `[]jobPosting`, falling back to a single object when the payload is not an array (a
+defensive shape other JSON-LD sources in this repo also tolerate). Fields map directly:
+`identifier`→`ExternalID`, `url`→`URL`, `title`, `description`(sanitized via the shared
+`sanitizeHTML`), `hiringOrganization.name`→`Company`,
+`applicantLocationRequirements.address.addressCountry`→location, `datePosted`→
+`PostedAt`, `employmentType`/`jobLocationType`→work-mode/type hints mapped through existing
+helpers where a clean mapping exists (empty otherwise, so dictionaries decide). The
+`hiringOrganization.sameAs` (company website) is deliberately dropped: the `Job` aggregate has
+no company-website field (company homepage is owned by the separate `company_info` mechanism),
+and the ATS-suppression pass keys on `company_slug` derived from the company name, not the site.
+
+### Decision: Stop pagination on the past-the-end redirect, not on an empty page
+
+The obvious stop — "page until a page yields no `JobPosting`" — is WRONG for Djinni and was
+caught only by exercising the real end of the feed (the spike verified the data but not the
+boundary). A past-the-end `?page=N` returns `302 → /jobs/`, and Go's HTTP client follows the
+redirect, re-serving page 1 (which is NOT empty); the naive stop would then loop, re-ingesting
+page 1 up to the page cap. The adapter therefore fetches via `GetHTMLResolved` and stops when
+the resolved FINAL URL no longer carries the `page=N` marker — a URL-level signal robust to
+Djinni re-ordering the feed by freshness mid-crawl (a content/first-id signature would be
+fragile against that). This needed a new `HTMLResolvedGetter` interface (added to the
+`HTTPClient` composition; the concrete `*Client` already implements `GetHTMLResolved`). A
+non-redirected empty page is kept as a secondary stop, and `djinniMaxPages` (above the observed
+~488) is the backstop against a pathological feed, mirroring `justJoinMaxPages`.
+
+## Risks / Trade-offs
+
+- **Full-corpus crawl is ~488 sequential requests (~16 min/run).** → Acceptable for a
+  run-once cron; requests are cheap and Djinni showed no rate limiting on rapid sequential
+  hits during the spike. Sharding by `?primary_keyword=` is a noted seam if latency ever
+  matters.
+- **One failing board = the whole source in cooldown** (single-board granularity of
+  `board_health`). → Inherent to a single-board source; consistent with other boardless
+  aggregators (justjoin, himalayas).
+- **JSON-LD shape drift** (Djinni changes its microdata). → The adapter fails the crawl
+  loudly (parse error surfaces as a board failure/cooldown) rather than silently ingesting
+  garbage; a fixture-based unit test pins the current shape.
+- **Country-only location** from `addressCountry`. → Matches the granularity Djinni exposes;
+  the geography dictionary derives country/region facets downstream as for every source.
+
+## Migration Plan
+
+- Pure addition. Deploy the binary, then add a `cmd/ingest sources/djinni.yml` cron schedule
+  in freehire-ops. No DB migration, no API change.
+- **Rollback:** remove the cron schedule and the `sources.All` registration; existing Djinni
+  rows age out via the standard unseen sweep. No data migration to undo.
+
+## Open Questions
+
+- None blocking. Sharding by specialization and a possible description-language signal are
+  deferred until there is a concrete need.

--- a/openspec/changes/add-djinni-source/proposal.md
+++ b/openspec/changes/add-djinni-source/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Djinni (djinni.co) is a major Ukrainian/CEE IT job board (~7,300 open postings) whose
+entire guest-visible corpus is served as structured JSON-LD, with full descriptions on the
+listing itself. A spike VALIDATED that the listing pages embed a JSON-LD array of complete
+`JobPosting` objects, pagination works for anonymous users, ids are stable, and there is no
+anti-bot wall. Adding it widens coverage of the CEE market at the cost of a single adapter.
+
+## What Changes
+
+- Add a `djinni` source adapter that crawls the guest listing `https://djinni.co/jobs/?page=N`
+  and maps each page's embedded JSON-LD `JobPosting` array to normalized `Job`s (title,
+  description, company, employment type, country, posted-at, numeric `identifier` as
+  `ExternalID`, canonical detail URL).
+- The adapter is **boardless** (one site, no per-tenant board) and an **aggregator** (many
+  companies, stays in the source facet, takes each posting's company from the feed).
+- Enroll `djinni` in `sources.All` and — via the `aggregator` marker — in the existing
+  reindex suppression pass, so a Djinni posting that duplicates a first-party ATS posting
+  (same `company_slug` + normalized title + compatible country) is suppressed automatically.
+  No new dedup mechanism is introduced; Djinni inherits `aggregator-ats-dedup` and the
+  fuzzy/subset title variants.
+- Add `sources/djinni.yml` with a single entry (`company: djinni`, `board: all`) crawled by
+  its own `cmd/ingest` cron schedule.
+
+## Capabilities
+
+### New Capabilities
+- `djinni-source`: the `djinni` adapter — its listing crawl, JSON-LD `JobPosting` mapping,
+  pagination and end-of-feed stop, aggregator/boardless classification, and the drop rules
+  for unusable postings.
+
+### Modified Capabilities
+<!-- None. ATS-dedup is inherited unchanged from aggregator-ats-dedup via the aggregator
+     marker + sources.AggregatorProviders(); no spec-level behavior of that capability
+     changes. -->
+
+## Impact
+
+- **New code:** `internal/sources/djinni.go` (+ `_test.go`); `sources/djinni.yml`.
+- **Touched code:** one line in `sources.All` (registry); the provider becomes visible to
+  `sources.AggregatorProviders()` and thus the reindex suppression pass automatically.
+- **Ops:** a new `cmd/ingest sources/djinni.yml` cron schedule (deploy-time, in freehire-ops).
+- **No migrations, no API changes, no new dependencies.**

--- a/openspec/changes/add-djinni-source/specs/djinni-source/spec.md
+++ b/openspec/changes/add-djinni-source/specs/djinni-source/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Djinni listing crawl over embedded JSON-LD
+
+The system SHALL provide a `djinni` source adapter that crawls the anonymous listing
+`https://djinni.co/jobs/?page=N`. Each listing page embeds a single
+`<script type="application/ld+json">` block whose payload is a JSON array of `JobPosting`
+objects carrying the full posting; the adapter SHALL parse that array and yield one `Job`
+per `JobPosting` — no per-posting detail request is made, because the listing already
+carries the description.
+
+The adapter is **boardless** (djinni.co is one site with no per-tenant board) and an
+**aggregator** (one crawl enumerates postings from many companies; it stays in the source
+facet and takes each posting's company from the feed). The configured board file entry's
+`board` value is not used to shape a URL.
+
+#### Scenario: A listing page maps to jobs
+
+- **WHEN** the adapter reads a listing page whose JSON-LD block is an array of `JobPosting`
+  objects
+- **THEN** it yields one `Job` per element carrying the posting's title, description (the
+  `description` field, sanitized), company (from `hiringOrganization.name`), location/country
+  (from `applicantLocationRequirements.address.addressCountry`), work mode (from
+  `jobLocationType`), employment type (from `employmentType`), posted-at timestamp (from
+  `datePosted`), the numeric `identifier` as the `ExternalID`, and the `url` as the canonical
+  detail URL
+
+#### Scenario: A page whose JSON-LD is a single object, not an array
+
+- **WHEN** a listing page's JSON-LD block is a single `JobPosting` object rather than an array
+- **THEN** the adapter still yields that one `Job` (it accepts both an array and a lone object)
+
+### Requirement: Djinni pages the listing to the end of the feed
+
+The adapter SHALL page the listing from `page=1` upward, fetching each page while FOLLOWING
+redirects and observing the final URL. A past-the-end page 302-redirects to the bare listing
+(`/jobs/`, which re-serves page 1 and is therefore NOT empty), so the adapter SHALL stop when
+the resolved final URL no longer carries the requested `page=N` marker — the reliable
+end-of-feed signal. A page that returns without a redirect but carries no `JobPosting` SHALL
+also stop the crawl. Pagination SHALL be bounded by a page cap as a backstop against a
+pathological feed, so a crawl can never loop unboundedly.
+
+#### Scenario: Crawl stops when a past-the-end page redirects to the bare listing
+
+- **WHEN** the adapter requests the page past the last populated one and the request redirects
+  to `/jobs/` (whose content is page 1, not empty)
+- **THEN** the adapter detects the missing page marker in the final URL, stops paging, and
+  returns only the earlier pages' jobs — it does NOT re-ingest the redirected page-1 content
+
+#### Scenario: Crawl stops on a non-redirected empty page
+
+- **WHEN** a page returns without a redirect and carries no `JobPosting`
+- **THEN** the adapter stops paging and returns the accumulated jobs
+
+#### Scenario: Page cap bounds a pathological feed
+
+- **WHEN** the listing never signals the end within the configured page cap
+- **THEN** the adapter stops at the cap rather than paging without bound
+
+### Requirement: Djinni drops a posting it cannot key or address
+
+The adapter SHALL drop a `JobPosting` that lacks a usable `identifier` (no dedup key), a
+usable `url` (no canonical address), or a company name (which would break the company slug),
+rather than yielding an unusable `Job`. A single unusable posting SHALL NOT abort the page or
+the crawl.
+
+#### Scenario: Posting without id, url, or company is dropped
+
+- **WHEN** a `JobPosting` in the array has no `identifier`, no `url`, or no
+  `hiringOrganization.name`
+- **THEN** the adapter drops that posting and continues mapping the rest of the page
+
+### Requirement: Djinni postings inherit aggregator ATS suppression
+
+The system SHALL register `djinni` as an aggregator (present in
+`sources.AggregatorProviders()`) so that a Djinni posting duplicating a first-party ATS
+posting is suppressed by the existing reindex suppression pass under its unchanged rules
+(same `company_slug`, matching normalized title, compatible country; the ATS posting stays
+canonical). The adapter itself SHALL NOT implement any cross-source dedup — it only supplies
+the company, title, and country the suppression pass keys on.
+
+#### Scenario: A Djinni copy of an ATS job is suppressed at reindex
+
+- **WHEN** a company has an open first-party ATS posting and an open Djinni posting with the
+  same normalized title and compatible country, and the reindex suppression pass runs
+- **THEN** the Djinni posting is marked `duplicate_of` the ATS posting and the ATS posting
+  stays canonical, exactly as for any other aggregator source
+
+#### Scenario: A Djinni-exclusive posting is not suppressed
+
+- **WHEN** a Djinni posting has no matching first-party ATS twin (a role posted only on
+  Djinni, even for a company otherwise crawled via an ATS)
+- **THEN** the posting is not suppressed and remains in search, embedding, and enrichment

--- a/openspec/changes/add-djinni-source/tasks.md
+++ b/openspec/changes/add-djinni-source/tasks.md
@@ -1,0 +1,43 @@
+## 1. Adapter mapping (single page)
+
+- [x] 1.1 Add `internal/sources/djinni_test.go` with a compact djinni-shaped listing fixture
+  (one `ld+json` JobPosting array + noise blocks) and a RED test asserting the adapter maps its
+  JSON-LD `JobPosting` array to `Job`s with the right fields (title, sanitized description,
+  company from `hiringOrganization.name`, country from
+  `applicantLocationRequirements.address.addressCountry`, `identifier` → `ExternalID`,
+  `url` → `URL`, `datePosted` → `PostedAt`).
+- [x] 1.2 Create `internal/sources/djinni.go`: a `djinni` struct over the HTML client, a
+  `djinniPosting` struct for the schema.org fields, and a `toJob` mapper that reuses the shared
+  `LDJobPostings` extractor and `sanitizeHTML`. Make 1.1 green.
+- [x] 1.3 Add the drop-rule test + code: a `JobPosting` with no `identifier`, no `url`, or no
+  company is dropped (not yielded), and one bad posting does not abort the page.
+
+## 2. Pagination & crawl
+
+- [x] 2.1 RED test: `Fetch` pages from 1 upward and stops at the end of the feed. Cover BOTH
+  stops: the past-the-end 302→/jobs/ redirect (final URL loses the `page=N` marker; must NOT
+  re-ingest the redirected page-1 content) and a non-redirected empty page.
+- [x] 2.2 Implement the page loop in `djinni.go` using `GetHTMLResolved` with the redirect-based
+  end-of-feed detection and a `djinniMaxPages` backstop constant; make 2.1 green. (Added the
+  `HTMLResolvedGetter` interface to the `HTTPClient` composition.)
+
+## 3. Classification & registration
+
+- [x] 3.1 Add the `boardless()` and `aggregator()` markers to `djinni`; test that
+  `ProviderKind(All(nil), "djinni") == KindAggregator` and that `"djinni"` appears in
+  `AggregatorProviders(All(nil))` (so it inherits the reindex ATS-suppression pass).
+- [x] 3.2 Register `djinni` in `sources.All` (one line) and add `Provider()` returning
+  `"djinni"`. Verify `go build ./... && go vet ./...`.
+
+## 4. Board file & docs
+
+- [x] 4.1 Add `sources/djinni.yml` with a single boardless entry (`company: Djinni`,
+  `provider: djinni`) and confirm it validates against the registry (LoadConfig + Validate).
+- [x] 4.2 No AGENTS.md change: `internal/sources/AGENTS.md` lists adapters only illustratively
+  (`greenhouse.go, lever.go, ashby.go, …`), not by class — nothing to enumerate.
+
+## 5. Verify end-to-end
+
+- [x] 5.1 Ran `go test ./internal/sources/...` (green) and live smoke checks against djinni.co:
+  a real captured listing page maps 15 jobs, and the live Go client's `GetHTMLResolved` confirms
+  the redirect contract (page 2 keeps its marker; page 489 redirects to /jobs/, marker gone).

--- a/sources/djinni.yml
+++ b/sources/djinni.yml
@@ -1,0 +1,6 @@
+# Djinni.co Ukrainian/CEE IT job board. Boardless: one guest listing (djinni.co/jobs/?page=N)
+# aggregating many companies, so the entry carries no board; each job's company comes from the
+# posting's hiringOrganization, not this placeholder. Aggregator — inherits the reindex ATS
+# suppression, so a posting that duplicates a first-party ATS twin is hidden automatically.
+- company: Djinni
+  provider: djinni


### PR DESCRIPTION
## Summary

Adds a `djinni` source adapter for [djinni.co](https://djinni.co/jobs/), a Ukrainian/CEE IT job board. A spike VALIDATED that the guest listing serves its whole corpus (~7,300 postings, ~488 pages) as embedded JSON-LD `JobPosting` **arrays with full descriptions on the listing itself**, so one `GET ?page=N` yields 15 complete jobs without any per-posting detail request.

- **Boardless + aggregator.** Registered with the `aggregator` marker, so it inherits the existing reindex ATS-suppression pass (`aggregator-ats-dedup`): a Djinni copy of a first-party ATS posting is hidden automatically by `company_slug` + normalized title + compatible country — no new dedup mechanism, no DB access in the adapter. Djinni-exclusive roles at ATS-crawled companies survive (posting-granularity, not company-granularity).
- **End-of-feed via redirect detection.** A past-the-end `?page=N` `302`s to `/jobs/` and re-serves page 1 (which is *not* empty), so a naive "stop on empty page" would loop and re-ingest page 1 up to the cap. The adapter fetches via a new `HTMLResolvedGetter` and stops when the resolved **final URL** loses its `page=N` marker. Confirmed against the live server (page 2 keeps the marker; page 489 redirects, marker gone).
- `sources/djinni.yml`: single boardless entry; one line added to `sources.All`.

No migrations, no API changes, no new dependencies. Ops: add a `cmd/ingest sources/djinni.yml` cron schedule at deploy time.

Planned under OpenSpec (`openspec/changes/add-djinni-source/`): proposal, design, delta spec (`djinni-source`), tasks — all complete and strict-validated.

## Test Plan

- [x] `go build ./...`, `go vet ./internal/sources/`, `gofmt` clean
- [x] `go test ./...` — full unit suite green (7 new `TestDjinni*`, incl. the redirect regression guard)
- [x] Live smoke: a real captured listing page maps 15 jobs; live Go client's `GetHTMLResolved` confirms the redirect contract
- [x] `sources/djinni.yml` validates against the registry (LoadConfig + Validate)
- [x] Geo derivation of the country code verified (`location.Parse("UA")` → `countries=[ua] regions=[eu]`)