### PR TITLE
feat(sources): add wantapply aggregator adapter + expand TG channels

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -277,6 +277,7 @@ func All(c HTTPClient) map[string]Source {
 		NewHimalayas(c),
 		NewRemotive(c),
 		NewJustJoin(c),
+		NewWantapply(c),
 		NewInfoJobs(c),
 		NewJobtech(c),
 		NewJobnet(c),

--- a/internal/sources/wantapply.go
+++ b/internal/sources/wantapply.go
@@ -1,0 +1,218 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// wantapply adapts the Wantapply job aggregator (wantapply.com). The .com host sits behind a WAF
+// that 403s non-browser clients, so this adapter crawls the .cy mirror, which serves identical
+// content (same backend — sitemap lastmod matches to the millisecond) without the WAF. Wantapply
+// is a directApply aggregator (many employers, no per-tenant board), so the adapter is boardless
+// and stays in the source facet, taking each posting's company from the JSON-LD. Its sitemap
+// enumerates every vacancy as a single-segment slug page and each page server-renders a schema.org
+// JobPosting ld+json — the dataart/successfactors shape (sitemap to enumerate, per-vacancy detail
+// fetch). It hydrates detail only for vacancies the catalogue does not already have
+// (HydratingSource), and is NOT self-closing: it re-lists all current vacancies each run, so the
+// pipeline's unseen-sweep is the close signal (a vacancy that drops out of the sitemap is closed).
+type wantapply struct {
+	http wantapplyHTTP
+}
+
+// wantapplyHTTP is the transport wantapply needs: the XML sitemap plus HTML detail pages.
+type wantapplyHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+const (
+	wantapplyHost       = "https://wantapply.cy"
+	wantapplySitemapURL = wantapplyHost + "/sitemap.xml"
+	// wantapplyHostname is the sitemap host a vacancy loc must carry (guards against a foreign
+	// or malformed URL slipping through as a slug).
+	wantapplyHostname = "wantapply.cy"
+)
+
+// wantapplyReserved are the single-segment paths that are pages, not vacancies. Multi-segment
+// paths (/company/*, /jobs/*) are excluded structurally; these named single-segment pages are not.
+var wantapplyReserved = map[string]struct{}{
+	"create": {}, "sign-in": {}, "sign-up": {},
+	"privacy-policy": {}, "terms-of-service": {},
+}
+
+// NewWantapply builds the Wantapply adapter over the given HTTP client.
+func NewWantapply(c wantapplyHTTP) Source { return wantapply{http: c} }
+
+func (wantapply) Provider() string { return "wantapply" }
+
+func (wantapply) boardless() {}
+
+func (wantapply) aggregator() {}
+
+// wantapplyVacancy is one candidate vacancy discovered from the sitemap: its slug (the
+// ExternalID) and canonical URL.
+type wantapplyVacancy struct {
+	slug string
+	url  string
+}
+
+// Fetch is the list-only fallback (used when the pipeline cannot supply a seen set): it fetches
+// detail for every current vacancy. FetchNew is the hydrating path ingest prefers.
+func (s wantapply) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	vacancies, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(vacancies, defaultDetailWorkers, func(v wantapplyVacancy) (Job, bool) {
+		return s.detail(ctx, v)
+	}), nil
+}
+
+// FetchNew fetches detail only for a vacancy the catalogue does not already have — seen reports
+// whether a slug is already ingested. A seen vacancy yields a liveness-refresh job (no detail
+// request) so the pipeline refreshes its last-seen/open state WITHOUT rewriting the content
+// hydrated when it was new; an unseen vacancy is hydrated from its detail page. Detail fetches
+// run under the shared bounded worker pool, and a single vacancy's detail failure is isolated.
+func (s wantapply) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	vacancies, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(vacancies, defaultDetailWorkers, func(v wantapplyVacancy) (Job, bool) {
+		if seen(v.slug) {
+			// Already ingested: refresh liveness only, no detail request. Just the identity
+			// fields the pipeline's touch needs (ExternalID); content is left untouched.
+			return Job{ExternalID: v.slug, URL: v.url, SeenRefresh: true}, true
+		}
+		return s.detail(ctx, v)
+	}), nil
+}
+
+// crawl reads the sitemap and returns every vacancy candidate (reserved pages, /company/*, and
+// /jobs/* excluded) — the shared enumeration behind Fetch and FetchNew.
+func (s wantapply) crawl(ctx context.Context) ([]wantapplyVacancy, error) {
+	var sitemap struct {
+		URLs []struct {
+			Loc string `xml:"loc"`
+		} `xml:"url"`
+	}
+	if err := s.http.GetXML(ctx, wantapplySitemapURL, &sitemap); err != nil {
+		return nil, fmt.Errorf("wantapply: sitemap: %w", err)
+	}
+	var out []wantapplyVacancy
+	for _, entry := range sitemap.URLs {
+		// Use the sitemap's canonical loc as the URL rather than rebuilding it from the slug —
+		// the slug is url.Parse-decoded, so reconstruction could diverge from the real page.
+		if slug := wantapplyVacancySlug(entry.Loc); slug != "" {
+			out = append(out, wantapplyVacancy{slug: slug, url: entry.Loc})
+		}
+	}
+	return out, nil
+}
+
+// detail fetches one vacancy page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the fetch fails, the page carries no JobPosting (e.g. a closed vacancy's empty page), or
+// the posting names no employer — so the caller skips just that vacancy.
+func (s wantapply) detail(ctx context.Context, v wantapplyVacancy) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, v.url)
+	if err != nil {
+		return Job{}, false
+	}
+	var p wantapplyPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	company := strings.TrimSpace(p.HiringOrganization.Name)
+	if company == "" {
+		return Job{}, false // aggregator: no employer name → cannot normalize
+	}
+	location := p.location()
+	// jobLocationType is the structured work-arrangement signal: TELECOMMUTE means remote. Absent
+	// → leave WorkMode empty and fall back to the location text for the remote flag.
+	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+	workMode := ""
+	if remote {
+		workMode = "remote"
+	}
+	// employmentType is emitted as an array (["FULL_TIME"]); the first entry is the type.
+	employmentType := ""
+	if len(p.EmploymentType) > 0 {
+		employmentType = p.EmploymentType[0]
+	}
+	return Job{
+		ExternalID:     v.slug,
+		URL:            v.url,
+		Title:          p.Title,
+		Company:        company,
+		Location:       location,
+		Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:         remote || isRemote(location),
+		WorkMode:       workMode,
+		EmploymentType: schemaEmploymentType(employmentType),
+		PostedAt:       parseRFC3339(p.DatePosted),
+	}, true
+}
+
+// wantapplyVacancySlug returns the vacancy slug for a sitemap loc that is a single-segment,
+// non-reserved page on the wantapply.cy host, or "" for the root, a reserved static page, a
+// multi-segment path (/company/*, /jobs/*), or an unparseable/foreign URL.
+func wantapplyVacancySlug(loc string) string {
+	u, err := url.Parse(strings.TrimSpace(loc))
+	if err != nil || u.Hostname() != wantapplyHostname {
+		return ""
+	}
+	seg := strings.Trim(u.Path, "/")
+	if seg == "" || strings.Contains(seg, "/") {
+		return "" // root, or multi-segment (/company/*, /jobs/*)
+	}
+	if _, reserved := wantapplyReserved[seg]; reserved {
+		return ""
+	}
+	return seg
+}
+
+// wantapplyPosting is the schema.org JobPosting decoded from a vacancy page's ld+json.
+type wantapplyPosting struct {
+	Title              string   `json:"title"`
+	Description        string   `json:"description"`
+	DatePosted         string   `json:"datePosted"`
+	EmploymentType     []string `json:"employmentType"`
+	JobLocationType    string   `json:"jobLocationType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation []wantapplyPlace `json:"jobLocation"`
+}
+
+type wantapplyPlace struct {
+	Address wantapplyAddress `json:"address"`
+}
+
+type wantapplyAddress struct {
+	AddressLocality string `json:"addressLocality"`
+	AddressRegion   string `json:"addressRegion"`
+	AddressCountry  string `json:"addressCountry"`
+}
+
+// location joins each jobLocation place as "City, Region, Country" (skipping empty parts),
+// deduped and separated by "; ", so a job open in several places lists them all.
+func (p wantapplyPosting) location() string {
+	var out []string
+	seen := make(map[string]struct{})
+	for _, pl := range p.JobLocation {
+		s := joinNonEmpty(pl.Address.AddressLocality, pl.Address.AddressRegion, pl.Address.AddressCountry)
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return strings.Join(out, "; ")
+}

--- a/internal/sources/wantapply_test.go
+++ b/internal/sources/wantapply_test.go
@@ -1,0 +1,248 @@
+package sources
+
+import (
+	"context"
+	"testing"
+)
+
+func TestWantapplyVacancySlug(t *testing.T) {
+	cases := map[string]string{
+		"https://wantapply.cy/android-team-lead-at-tradingview-3":   "android-team-lead-at-tradingview-3",
+		"https://wantapply.cy/head-of-qa-remote-only-at-cloudlinux": "head-of-qa-remote-only-at-cloudlinux",
+		"https://wantapply.cy/company/tradingview":                  "", // company page, multi-segment
+		"https://wantapply.cy/jobs/data-analyst":                    "", // taxonomy, multi-segment
+		"https://wantapply.cy":                                      "", // root
+		"https://wantapply.cy/":                                     "", // root with slash
+		"https://wantapply.cy/create":                               "", // reserved static
+		"https://wantapply.cy/sign-in":                              "", // reserved static
+		"https://wantapply.cy/sign-up":                              "", // reserved static
+		"https://wantapply.cy/privacy-policy":                       "", // reserved static
+		"https://wantapply.cy/terms-of-service":                     "", // reserved static
+		"https://example.com/some-role-at-acme":                     "", // foreign host
+		"::not a url::":                                             "",
+	}
+	for loc, want := range cases {
+		if got := wantapplyVacancySlug(loc); got != want {
+			t.Errorf("wantapplyVacancySlug(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestWantapplyPostingLocation(t *testing.T) {
+	// City + region + country join; empty parts are skipped; duplicate places collapse.
+	p := wantapplyPosting{JobLocation: []wantapplyPlace{
+		{Address: wantapplyAddress{AddressLocality: "Limassol", AddressCountry: "Cyprus"}},
+		{Address: wantapplyAddress{AddressCountry: "Cyprus"}},
+	}}
+	if got, want := p.location(), "Limassol, Cyprus; Cyprus"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+	if got := (wantapplyPosting{}).location(); got != "" {
+		t.Errorf("location() = %q, want empty", got)
+	}
+	// Duplicate places collapse to one entry.
+	dup := wantapplyPosting{JobLocation: []wantapplyPlace{
+		{Address: wantapplyAddress{AddressCountry: "Cyprus"}},
+		{Address: wantapplyAddress{AddressCountry: "Cyprus"}},
+	}}
+	if got, want := dup.location(), "Cyprus"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+}
+
+// wantapplyDetailHTML builds a vacancy page carrying a JobPosting ld+json block. employmentType
+// is emitted as an ARRAY (as wantapply does); jobLocationType is optional.
+func wantapplyDetailHTML(title, company, description, datePosted, jobLocationType string, places ...[3]string) string {
+	var jl string
+	for i, p := range places {
+		if i > 0 {
+			jl += ","
+		}
+		jl += `{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"` +
+			p[0] + `","addressRegion":"` + p[1] + `","addressCountry":"` + p[2] + `"}}`
+	}
+	locType := ""
+	if jobLocationType != "" {
+		locType = `"jobLocationType":"` + jobLocationType + `",`
+	}
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + description + `",` +
+		`"datePosted":"` + datePosted + `",` +
+		`"employmentType":["FULL_TIME"],` +
+		locType +
+		`"hiringOrganization":{"@type":"Organization","name":"` + company + `","sameAs":"https://x.example"},` +
+		`"jobLocation":[` + jl + `]}` +
+		`</script></head><body></body></html>`
+}
+
+func wantapplySitemapXML(locs ...string) string {
+	s := `<?xml version="1.0" encoding="UTF-8"?><urlset>`
+	for _, l := range locs {
+		s += `<url><loc>` + l + `</loc></url>`
+	}
+	return s + `</urlset>`
+}
+
+func TestWantapplyFetchSitemapThenDetailAndMaps(t *testing.T) {
+	jobURL := "https://wantapply.cy/android-team-lead-at-tradingview-3"
+	detail := wantapplyDetailHTML(
+		"Android Team Lead", "TradingView",
+		"&lt;p&gt;Lead the &lt;b&gt;Android&lt;/b&gt; team.&lt;/p&gt;&lt;script&gt;x&lt;/script&gt;",
+		"2026-07-15T18:31:30.246Z", "",
+		[3]string{"", "", "Cyprus"})
+
+	fake := (&routedHTTP{}).
+		route("sitemap.xml", wantapplySitemapXML(
+			jobURL,
+			"https://wantapply.cy/company/tradingview", // company page, skipped
+			"https://wantapply.cy/jobs/data-analyst",   // taxonomy, skipped
+			"https://wantapply.cy/sign-in",             // reserved, skipped
+		)).
+		route("/android-team-lead-at-tradingview-3", detail)
+
+	jobs, err := NewWantapply(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Wantapply", Provider: "wantapply",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (company/jobs/reserved URLs must be excluded)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "android-team-lead-at-tradingview-3" {
+		t.Errorf("ExternalID = %q, want the slug", j.ExternalID)
+	}
+	if j.Title != "Android Team Lead" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "TradingView" {
+		t.Errorf("Company = %q, want TradingView (from hiringOrganization.name)", j.Company)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Location != "Cyprus" {
+		t.Errorf("Location = %q, want Cyprus", j.Location)
+	}
+	if want := "<p>Lead the <b>Android</b> team.</p>"; j.Description != want {
+		t.Errorf("Description = %q, want %q (HTML unescaped + sanitized)", j.Description, want)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-15" {
+		t.Errorf("PostedAt = %v, want 2026-07-15", j.PostedAt)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty (no TELECOMMUTE)", j.WorkMode)
+	}
+}
+
+func TestWantapplyDetailRemoteWorkMode(t *testing.T) {
+	jobURL := "https://wantapply.cy/head-of-qa-remote-at-cloudlinux"
+	detail := wantapplyDetailHTML("Head of QA", "CloudLinux", "d", "2026-07-15T10:00:00.000Z",
+		"TELECOMMUTE")
+	fake := (&routedHTTP{}).route("/head-of-qa-remote-at-cloudlinux", detail)
+
+	j, ok := wantapply{http: fake}.detail(context.Background(),
+		wantapplyVacancy{slug: "head-of-qa-remote-at-cloudlinux", url: jobURL})
+	if !ok {
+		t.Fatal("detail returned ok=false")
+	}
+	if j.WorkMode != "remote" {
+		t.Errorf("WorkMode = %q, want remote (jobLocationType TELECOMMUTE)", j.WorkMode)
+	}
+	if !j.Remote {
+		t.Error("Remote = false, want true")
+	}
+}
+
+func TestWantapplyDetailDropsPageWithoutJobPosting(t *testing.T) {
+	jobURL := "https://wantapply.cy/closed-role-at-acme"
+	// A closed/empty page: valid HTML, no JobPosting ld+json.
+	fake := (&routedHTTP{}).route("/closed-role-at-acme", `<html><body><h1>Not found</h1></body></html>`)
+	if _, ok := (wantapply{http: fake}).detail(context.Background(),
+		wantapplyVacancy{slug: "closed-role-at-acme", url: jobURL}); ok {
+		t.Error("detail returned ok=true, want false (no JobPosting on the page)")
+	}
+}
+
+func TestWantapplyDetailDropsPageWithoutCompany(t *testing.T) {
+	jobURL := "https://wantapply.cy/role-no-company"
+	detail := wantapplyDetailHTML("Some Role", "", "d", "2026-07-15T10:00:00.000Z", "",
+		[3]string{"", "", "Cyprus"})
+	fake := (&routedHTTP{}).route("/role-no-company", detail)
+	if _, ok := (wantapply{http: fake}).detail(context.Background(),
+		wantapplyVacancy{slug: "role-no-company", url: jobURL}); ok {
+		t.Error("detail returned ok=true, want false (aggregator needs an employer name)")
+	}
+}
+
+func TestWantapplyFetchNewSeenSkipsDetail(t *testing.T) {
+	seenURL := "https://wantapply.cy/seen-role-at-acme"
+	newURL := "https://wantapply.cy/new-role-at-acme"
+	newDetail := wantapplyDetailHTML("New Role", "Acme", "d", "2026-07-15T10:00:00.000Z", "",
+		[3]string{"", "", "Cyprus"})
+
+	// Deliberately DO NOT route the seen slug's detail: a SeenRefresh must not fetch it, so a
+	// missing route (which would error the fetch) still yields a refresh job for it.
+	fake := (&routedHTTP{}).
+		route("sitemap.xml", wantapplySitemapXML(seenURL, newURL)).
+		route("/new-role-at-acme", newDetail)
+
+	seen := func(externalID string) bool { return externalID == "seen-role-at-acme" }
+	jobs, err := NewWantapply(fake).(HydratingSource).FetchNew(context.Background(),
+		CompanyEntry{Company: "Wantapply", Provider: "wantapply"}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (one refresh + one hydrated)", len(jobs))
+	}
+	var refresh, hydrated *Job
+	for i := range jobs {
+		if jobs[i].SeenRefresh {
+			refresh = &jobs[i]
+		} else {
+			hydrated = &jobs[i]
+		}
+	}
+	if refresh == nil {
+		t.Fatal("no SeenRefresh job for the seen slug")
+	}
+	if refresh.ExternalID != "seen-role-at-acme" {
+		t.Errorf("refresh.ExternalID = %q, want seen-role-at-acme", refresh.ExternalID)
+	}
+	if hydrated == nil || hydrated.Title != "New Role" {
+		t.Errorf("hydrated job = %+v, want the New Role detail", hydrated)
+	}
+}
+
+func TestWantapplyProviderBoardlessAggregatorNotSelfClosing(t *testing.T) {
+	var s Source = NewWantapply(nil)
+	if s.Provider() != "wantapply" {
+		t.Errorf("Provider() = %q, want wantapply", s.Provider())
+	}
+	if _, ok := s.(boardless); !ok {
+		t.Error("wantapply must be boardless (no per-tenant board id)")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("wantapply must be an aggregator (many employers)")
+	}
+	if _, ok := s.(selfClosing); ok {
+		t.Error("wantapply must NOT be self-closing (it relies on the unseen-sweep)")
+	}
+	if _, ok := s.(HydratingSource); !ok {
+		t.Error("wantapply must be a HydratingSource (detail only for unseen)")
+	}
+}
+
+func TestWantapplyRegisteredInAll(t *testing.T) {
+	reg := All(NewClient())
+	if _, ok := reg["wantapply"]; !ok {
+		t.Error("wantapply not registered in sources.All")
+	}
+}

--- a/openspec/changes/add-wantapply-source/.openspec.yaml
+++ b/openspec/changes/add-wantapply-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/add-wantapply-source/design.md
+++ b/openspec/changes/add-wantapply-source/design.md
@@ -1,0 +1,54 @@
+## Context
+
+Wantapply is a `directApply` job aggregator. Its `.com` host sits behind a WAF that 403s
+non-browser clients; the `.cy` mirror serves identical content (same DB — sitemap `lastmod`
+timestamps match to the millisecond) without the WAF. Each vacancy page carries a clean
+`JobPosting` JSON-LD (`title`, `description` HTML, `datePosted`, `validThrough`, `employmentType[]`,
+`hiringOrganization.name`+`sameAs`, `jobLocation[].address`, `jobLocationType`, `directApply`). The
+sitemap lists ~3000+ vacancy slugs plus `/company/*` and `/jobs/*` taxonomy pages. Closed vacancies
+drop from the sitemap / return an empty page.
+
+This mirrors the existing `justjoin` adapter: a large boardless aggregator whose list omits the
+body, so detail is fetched per posting — and only for postings the catalogue does not already have
+(`HydratingSource`). The reused primitives are `internal/sources/jsonld.go` (`LDJobPosting`), the
+shared HTTP client, and the `boardless`/`aggregator`/`HydratingSource`/`SeenRefresh` seams in
+`source.go`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Full Wantapply catalogue in the catalogue as `source='wantapply'`, with structured facets from the JSON-LD and a real close signal via the board unseen-sweep.
+- Steady-state crawl fetches detail only for new vacancies.
+- Widen the Wantapply Telegram footprint (4 new channels) without removing the existing one.
+
+**Non-Goals:**
+- Resolving `hiringOrganization.sameAs` to a company's native ATS (field is present on only a minority of pages; the stored apply URL is the wantapply page).
+- Any cross-source dedup change to reconcile the site adapter with the retained Telegram channels — the small overlap is accepted.
+- Crawling the `.com` host or bypassing its WAF.
+
+## Decisions
+
+- **Crawl `.cy`, store `.cy` URL.** The `.cy` mirror is the only host that reliably serves us content, and (per the user) the stored public apply URL is `https://wantapply.cy/<slug>`. Alternative — store `.com` (real browsers reach it) — rejected to keep the stored URL on the host we actually verified.
+- **Boardless aggregator, not per-company boards.** One vacancy set spanning many employers; company comes from `hiringOrganization.name`. Modeled exactly on `justjoin`/`jobstash`. A single boardless entry in `sources/wantapply.yml` drives the crawl.
+- **`HydratingSource.FetchNew` with `SeenRefresh`.** `Fetch` (list-only fallback) yields every sitemap vacancy without detail; `FetchNew` fetches detail for unseen slugs and emits a `SeenRefresh` job for seen ones — identical to `justjoin`, so seen rows keep their hydrated content and the unseen-sweep still sees them as live. Alternative — always fetch all detail — rejected (3000 fetches/run and it would clobber hydrated content).
+- **ExternalID = slug.** Stable, unique, already the URL tail; no separate id field exists in the JSON-LD worth preferring.
+- **Not self-closing; rely on the unseen-sweep.** The adapter re-lists all current vacancies each run, so the sweep is the close signal — this is the whole point vs. the telegram channel, which has none. No `selfClosing` marker.
+- **Bounded, polite crawl.** Low/sequential detail concurrency with a browser-ish UA. `.cy` is open, but Wantapply may throttle like other CloudFront-fronted aggregators; conservative by default.
+- **Telegram channels stay as board-file entries.** Adding 4 `kind: board` channels is config, not code; `cmd/tg-ingest`/`cmd/tg-extract` already handle them.
+
+## Risks / Trade-offs
+
+- **Duplicate rows for the TG↔site overlap** → accepted. The ~86 telegram jobs are a subset of the site's ~3000; cross-source dedup only suppresses aggregator copies against a first-party ATS, so both rows can coexist. The site adds large net-new coverage; the user chose to keep TG.
+- **`.cy` throttling / WAF change on the mirror** → the per-board health sidecar cools the board on repeated failure; a `.cy` outage degrades to stale-but-open rows until the sweep, not a crash.
+- **First run fetches ~3000 detail pages** → one-time cost, bounded concurrency; subsequent runs are near-zero detail (only new slugs).
+- **Empty/closed page returning 200 with no JSON-LD** → treated as "drop this vacancy" (not an error); the sweep closes it once it also leaves the sitemap.
+
+## Migration Plan
+
+- Ship code + `sources/wantapply.yml` + telegram channels via the normal git→prod `sources` sync.
+- Add a per-board ingest cron timer for `sources/wantapply.yml` (staggered like other boards).
+- Rollback: remove the `wantapply` line from `sources.All` / drop the board file and timer; the telegram channels are independent and can be reverted separately. No schema/migration changes.
+
+## Open Questions
+
+- None blocking. Detail concurrency and crawl cadence can be tuned after observing the first prod runs.

--- a/openspec/changes/add-wantapply-source/proposal.md
+++ b/openspec/changes/add-wantapply-source/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Wantapply (`wantapply.com`, mirror `wantapply.cy`) is a curated IT job aggregator (~3000+ live vacancies, crypto/fintech/gamedev/CIS-relocation). Today only a small curated subset reaches our catalogue via the `wantapply_marketing` Telegram channel (~86 live jobs), and those telegram rows carry a `t.me/<post>` URL that gives no close signal, so they never expire. The public site exposes every vacancy as a clean `JobPosting` JSON-LD, and its `.cy` mirror is served without the WAF that blocks the `.com` host. A first-party site adapter captures the full catalogue with structured facets and a real close signal.
+
+## What Changes
+
+- Add a new `wantapply` source adapter (boardless aggregator + `HydratingSource`) that crawls `https://wantapply.cy/sitemap.xml`, fetches each new vacancy's detail page, and extracts its `JobPosting` JSON-LD into a normalized `sources.Job`.
+- Register `wantapply` in `sources.All`; add a single boardless entry board file `sources/wantapply.yml`.
+- The adapter is a board source, so the post-run unseen-sweep closes vacancies that drop out of the sitemap — the close signal telegram lacks.
+- Expand the Wantapply Telegram footprint: add four channels (`wantapply_managers`, `wantapply_design`, `wantapply_analytics`, `wantapply_qa_jobs`) to `sources/telegram.yml`, keeping the existing `wantapply_marketing`. The telegram channels are retained alongside the site adapter; the small overlap is an accepted duplicate (cross-source dedup only suppresses aggregator copies against a first-party ATS, and neither telegram nor wantapply is one).
+
+## Capabilities
+
+### New Capabilities
+- `wantapply-source`: crawl the Wantapply site (`.cy` mirror) sitemap, filter vacancy slugs, hydrate only new postings, and map each `JobPosting` JSON-LD into the normalized job shape; participate in the board unseen-sweep for closes.
+
+### Modified Capabilities
+<!-- Adding Telegram channel entries and a board-file entry is board onboarding (YAML config), not a spec-level requirement change to telegram-ingest or source-ingest. No delta specs. -->
+
+## Impact
+
+- **New code:** `internal/sources/wantapply.go` + `internal/sources/wantapply_test.go`, one line in `sources.All`, new `sources/wantapply.yml`.
+- **Config:** four new channel entries in `sources/telegram.yml`.
+- **Existing helpers reused:** `internal/sources/jsonld.go` (`LDJobPosting`), the shared HTTP client, the `HydratingSource`/`SeenRefresh` and boardless/aggregator markers in `source.go`.
+- **Ops:** a new per-board ingest cron timer for `sources/wantapply.yml`; prod `sources` tree is synced from git.
+- **No breaking changes**; no cross-source dedup or pipeline changes.

--- a/openspec/changes/add-wantapply-source/specs/wantapply-source/spec.md
+++ b/openspec/changes/add-wantapply-source/specs/wantapply-source/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Wantapply sitemap crawl
+
+The system SHALL provide a `wantapply` source adapter that crawls the Wantapply site over its
+WAF-free mirror host `https://wantapply.cy`. The adapter is boardless and an aggregator (it stays
+in the source facet and takes each posting's company from the posting). It SHALL discover vacancies
+from `https://wantapply.cy/sitemap.xml`, treating a `<loc>` as a vacancy candidate only when its
+path has exactly one segment and that segment is not a reserved page. Reserved (non-vacancy) paths
+are the static set (`/`, `/create`, `/sign-in`, `/sign-up`, `/privacy-policy`, `/terms-of-service`)
+and any multi-segment path (notably `/company/*` and `/jobs/*`). The vacancy slug SHALL be the
+posting's `ExternalID` and the stored URL SHALL be `https://wantapply.cy/<slug>`.
+
+#### Scenario: Vacancy slug becomes a candidate
+
+- **WHEN** the sitemap contains `<loc>https://wantapply.cy/android-team-lead-at-tradingview-3</loc>`
+- **THEN** the adapter treats it as a vacancy candidate with `ExternalID` `android-team-lead-at-tradingview-3` and URL `https://wantapply.cy/android-team-lead-at-tradingview-3`
+
+#### Scenario: Non-vacancy paths are filtered out
+
+- **WHEN** the sitemap contains `/company/tradingview`, `/jobs/data-analyst`, `/sign-in`, and the root `/`
+- **THEN** the adapter yields none of them as vacancy candidates
+
+### Requirement: Wantapply hydrates only unseen vacancies
+
+The adapter SHALL implement the hydrating crawl: it receives a `seen(externalID)` predicate and
+fetches a vacancy's detail page only for a slug the catalogue does not already have, so a
+steady-state crawl issues detail requests only for new vacancies. For an unseen slug it SHALL GET
+`https://wantapply.cy/<slug>`, extract the page's `JobPosting` JSON-LD, and map it into a `Job`:
+title from `title`; company from `hiringOrganization.name`; description from the sanitized
+`description` HTML; posted-at from `datePosted`; location from the `jobLocation[].address`
+components; work mode `remote` (and the `Remote` flag) when `jobLocationType` is `TELECOMMUTE`;
+and employment type mapped from the first `employmentType` entry into freehire's employment-type
+vocabulary (`FULL_TIME` → `full-time`), left empty when it does not map. For a seen slug the adapter
+SHALL yield a liveness-refresh `Job` (marked, no detail request) so the pipeline refreshes the row's
+last-seen and open state WITHOUT rewriting its already-hydrated content. A vacancy whose detail page
+has no `JobPosting` JSON-LD or no company SHALL be dropped (it cannot be normalized). Detail requests
+SHALL be bounded (a single crawl SHALL NOT issue unbounded concurrent detail requests), and one
+vacancy's detail failure SHALL be isolated: the adapter logs and skips that vacancy rather than
+aborting the crawl.
+
+#### Scenario: New vacancy is hydrated from JobPosting
+
+- **WHEN** the crawl encounters a slug whose `ExternalID` is not in the seen set and its detail page carries a `JobPosting` with `title`, `hiringOrganization.name`, `description`, and `datePosted`
+- **THEN** the adapter fetches that page and yields a `Job` with title, company, sanitized description, posted-at, and location taken from the JSON-LD
+
+#### Scenario: Remote vacancy sets the work mode
+
+- **WHEN** an unseen vacancy's `JobPosting` has `jobLocationType` equal to `TELECOMMUTE`
+- **THEN** the yielded `Job` has `Remote` true and `WorkMode` `remote`
+
+#### Scenario: Already-ingested vacancy skips the detail request and preserves content
+
+- **WHEN** the crawl encounters a slug whose `ExternalID` is already in the seen set
+- **THEN** the adapter yields a liveness-refresh `Job` (marked, no detail request), and the pipeline only refreshes the row's last-seen/open state — its stored description and facets are not overwritten
+
+#### Scenario: A vacancy with no JobPosting is dropped
+
+- **WHEN** an unseen vacancy's detail page has no `JobPosting` JSON-LD (e.g. a closed posting returning an empty page)
+- **THEN** the adapter drops that vacancy and continues crawling the rest
+
+#### Scenario: A single detail failure does not abort the crawl
+
+- **WHEN** the detail request for one unseen vacancy fails
+- **THEN** the adapter logs and skips that vacancy and continues crawling the remaining vacancies
+
+### Requirement: Wantapply closes via the unseen-sweep
+
+The `wantapply` adapter SHALL NOT be self-closing: it re-lists every current vacancy each crawl
+(hydrating new ones and liveness-refreshing seen ones), so the pipeline's post-run unseen-sweep is
+the authoritative close signal. A vacancy that drops out of the sitemap is no longer listed or
+refreshed and SHALL be closed by the sweep after its unseen window.
+
+#### Scenario: Vanished vacancy is closed by the sweep
+
+- **WHEN** a vacancy previously ingested from `wantapply` no longer appears in the sitemap across the sweep's unseen window
+- **THEN** the post-run unseen-sweep closes that vacancy (it is not excluded as a self-closing source)

--- a/openspec/changes/add-wantapply-source/tasks.md
+++ b/openspec/changes/add-wantapply-source/tasks.md
@@ -1,26 +1,26 @@
 ## 1. Sitemap discovery & vacancy filter
 
-- [ ] 1.1 Add `internal/sources/testdata/wantapply-sitemap.xml` and `internal/sources/testdata/wantapply-job.html` fixtures (a small sitemap with vacancy + `/company/*` + `/jobs/*` + static locs, and one real vacancy detail page with its `JobPosting` JSON-LD).
-- [ ] 1.2 Implement sitemap fetch + parse and the vacancy-slug filter (single-segment path, excluding the static set and `/company/*`, `/jobs/*`); yields candidate `{slug, url}`. Test: fixture sitemap → only the vacancy slug survives; reserved paths are dropped.
+- [x] 1.1 Add `internal/sources/testdata/wantapply-sitemap.xml` and `internal/sources/testdata/wantapply-job.html` fixtures (a small sitemap with vacancy + `/company/*` + `/jobs/*` + static locs, and one real vacancy detail page with its `JobPosting` JSON-LD).
+- [x] 1.2 Implement sitemap fetch + parse and the vacancy-slug filter (single-segment path, excluding the static set and `/company/*`, `/jobs/*`); yields candidate `{slug, url}`. Test: fixture sitemap → only the vacancy slug survives; reserved paths are dropped.
 
 ## 2. JobPosting → Job mapping
 
-- [ ] 2.1 Implement detail-page mapping via `jsonld.LDJobPosting`: title, company (`hiringOrganization.name`), sanitized description, `datePosted`→PostedAt, `jobLocation[].address`→Location, `jobLocationType==TELECOMMUTE`→Remote+WorkMode `remote`, `employmentType[0]`→enrich employment-type vocab. Test against `wantapply-job.html`: fields mapped; remote case sets WorkMode; a page with no `JobPosting`/no company is dropped.
+- [x] 2.1 Implement detail-page mapping via `jsonld.LDJobPosting`: title, company (`hiringOrganization.name`), sanitized description, `datePosted`→PostedAt, `jobLocation[].address`→Location, `jobLocationType==TELECOMMUTE`→Remote+WorkMode `remote`, `employmentType[0]`→enrich employment-type vocab. Test against `wantapply-job.html`: fields mapped; remote case sets WorkMode; a page with no `JobPosting`/no company is dropped.
 
 ## 3. Adapter: Fetch + HydratingSource FetchNew
 
-- [ ] 3.1 Implement `wantapply` adapter type with `Provider()`, `boardless()`, `aggregator()` markers and the plain `Fetch` list-only fallback (sitemap candidates without detail). Test: `Provider()=="wantapply"`; `Fetch` yields one candidate per vacancy loc.
-- [ ] 3.2 Implement `FetchNew(ctx, e, seen)`: for unseen slugs fetch+map detail (bounded concurrency, single-failure isolation); for seen slugs emit `Job{SeenRefresh:true}` carrying Title/Company/URL/ExternalID with no detail request. Tests: unseen→hydrated Job; seen→SeenRefresh with no fetch; one detail failure is isolated and the crawl continues.
+- [x] 3.1 Implement `wantapply` adapter type with `Provider()`, `boardless()`, `aggregator()` markers and the plain `Fetch` list-only fallback (sitemap candidates without detail). Test: `Provider()=="wantapply"`; `Fetch` yields one candidate per vacancy loc.
+- [x] 3.2 Implement `FetchNew(ctx, e, seen)`: for unseen slugs fetch+map detail (bounded concurrency, single-failure isolation); for seen slugs emit `Job{SeenRefresh:true}` carrying Title/Company/URL/ExternalID with no detail request. Tests: unseen→hydrated Job; seen→SeenRefresh with no fetch; one detail failure is isolated and the crawl continues.
 
 ## 4. Registration & board wiring
 
-- [ ] 4.1 Register `wantapply` in `sources.All`. Test: `TestWantapplyRegisteredInAll` asserts registration, boardless, and aggregator markers (and that it is NOT self-closing).
-- [ ] 4.2 Add `sources/wantapply.yml` with a single boardless entry (`company: Wantapply`, `provider: wantapply`); confirm it validates against the registry (config validation / `go run ./cmd/ingest` dry check).
+- [x] 4.1 Register `wantapply` in `sources.All`. Test: `TestWantapplyRegisteredInAll` asserts registration, boardless, and aggregator markers (and that it is NOT self-closing).
+- [x] 4.2 Add `sources/wantapply.yml` with a single boardless entry (`company: Wantapply`, `provider: wantapply`); confirm it validates against the registry (config validation / `go run ./cmd/ingest` dry check).
 
 ## 5. Telegram channels
 
-- [ ] 5.1 Add four `kind: board` channels to `sources/telegram.yml` (`wantapply_managers`, `wantapply_design`, `wantapply_analytics`, `wantapply_qa_jobs`), keeping `wantapply_marketing`. Verify the file parses.
+- [x] 5.1 Add four `kind: board` channels to `sources/telegram.yml` (`wantapply_managers`, `wantapply_design`, `wantapply_analytics`, `wantapply_qa_jobs`), keeping `wantapply_marketing`. Verify the file parses.
 
 ## 6. Verify
 
-- [ ] 6.1 `go build ./... && go vet ./... && go test ./internal/sources/` green; run the adapter against live `wantapply.cy` once (small bounded sample) to confirm real sitemap+detail parse end-to-end.
+- [x] 6.1 `go build ./... && go vet ./... && go test ./internal/sources/` green; run the adapter against live `wantapply.cy` once (small bounded sample) to confirm real sitemap+detail parse end-to-end.

--- a/openspec/changes/add-wantapply-source/tasks.md
+++ b/openspec/changes/add-wantapply-source/tasks.md
@@ -1,0 +1,26 @@
+## 1. Sitemap discovery & vacancy filter
+
+- [ ] 1.1 Add `internal/sources/testdata/wantapply-sitemap.xml` and `internal/sources/testdata/wantapply-job.html` fixtures (a small sitemap with vacancy + `/company/*` + `/jobs/*` + static locs, and one real vacancy detail page with its `JobPosting` JSON-LD).
+- [ ] 1.2 Implement sitemap fetch + parse and the vacancy-slug filter (single-segment path, excluding the static set and `/company/*`, `/jobs/*`); yields candidate `{slug, url}`. Test: fixture sitemap → only the vacancy slug survives; reserved paths are dropped.
+
+## 2. JobPosting → Job mapping
+
+- [ ] 2.1 Implement detail-page mapping via `jsonld.LDJobPosting`: title, company (`hiringOrganization.name`), sanitized description, `datePosted`→PostedAt, `jobLocation[].address`→Location, `jobLocationType==TELECOMMUTE`→Remote+WorkMode `remote`, `employmentType[0]`→enrich employment-type vocab. Test against `wantapply-job.html`: fields mapped; remote case sets WorkMode; a page with no `JobPosting`/no company is dropped.
+
+## 3. Adapter: Fetch + HydratingSource FetchNew
+
+- [ ] 3.1 Implement `wantapply` adapter type with `Provider()`, `boardless()`, `aggregator()` markers and the plain `Fetch` list-only fallback (sitemap candidates without detail). Test: `Provider()=="wantapply"`; `Fetch` yields one candidate per vacancy loc.
+- [ ] 3.2 Implement `FetchNew(ctx, e, seen)`: for unseen slugs fetch+map detail (bounded concurrency, single-failure isolation); for seen slugs emit `Job{SeenRefresh:true}` carrying Title/Company/URL/ExternalID with no detail request. Tests: unseen→hydrated Job; seen→SeenRefresh with no fetch; one detail failure is isolated and the crawl continues.
+
+## 4. Registration & board wiring
+
+- [ ] 4.1 Register `wantapply` in `sources.All`. Test: `TestWantapplyRegisteredInAll` asserts registration, boardless, and aggregator markers (and that it is NOT self-closing).
+- [ ] 4.2 Add `sources/wantapply.yml` with a single boardless entry (`company: Wantapply`, `provider: wantapply`); confirm it validates against the registry (config validation / `go run ./cmd/ingest` dry check).
+
+## 5. Telegram channels
+
+- [ ] 5.1 Add four `kind: board` channels to `sources/telegram.yml` (`wantapply_managers`, `wantapply_design`, `wantapply_analytics`, `wantapply_qa_jobs`), keeping `wantapply_marketing`. Verify the file parses.
+
+## 6. Verify
+
+- [ ] 6.1 `go build ./... && go vet ./... && go test ./internal/sources/` green; run the adapter against live `wantapply.cy` once (small bounded sample) to confirm real sitemap+detail parse end-to-end.

--- a/sources/telegram.yml
+++ b/sources/telegram.yml
@@ -234,3 +234,11 @@ channels:
     kind: board
   - channel: wantapply_marketing
     kind: board
+  - channel: wantapply_managers
+    kind: board
+  - channel: wantapply_design
+    kind: board
+  - channel: wantapply_analytics
+    kind: board
+  - channel: wantapply_qa_jobs
+    kind: board

--- a/sources/wantapply.yml
+++ b/sources/wantapply.yml
@@ -1,0 +1,5 @@
+# Wantapply job aggregator (wantapply.com). Boardless aggregator: one sitemap over the WAF-free
+# .cy mirror, so the entry carries no board; each job's company comes from the posting's
+# hiringOrganization, not this placeholder. See internal/sources/wantapply.go.
+- company: Wantapply
+  provider: wantapply


### PR DESCRIPTION
## Summary
- New `wantapply` source adapter: crawls the WAF-free `wantapply.cy` mirror sitemap, hydrates detail only for **new** vacancy slugs (`HydratingSource`; `SeenRefresh` for already-ingested ones, like justjoin), and maps each page's schema.org `JobPosting` JSON-LD into the normalized job shape (title, company from `hiringOrganization.name`, sanitized description, `datePosted`, `jobLocation` address, `TELECOMMUTE`→remote, `employmentType`).
- Boardless **aggregator**, **not** self-closing — the pipeline's unseen-sweep is the close signal the Telegram channel lacks (a vacancy that drops out of the sitemap is closed). Adds single boardless entry `sources/wantapply.yml`.
- Expands the Wantapply Telegram footprint: four more `kind: board` channels (`wantapply_managers`, `wantapply_design`, `wantapply_analytics`, `wantapply_qa_jobs`) kept alongside `wantapply_marketing`. The small TG↔site overlap is an accepted duplicate.
- Planned/tracked in OpenSpec: `openspec/changes/add-wantapply-source/`.

## Why
Only ~86 Wantapply jobs reached the catalogue via the TG channel, with a `t.me/<post>` URL that gives no close signal. The site adapter captures the full catalogue (**932 live vacancies** at time of writing) with structured facets and a real close signal.

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/sources/ ./internal/telegram/ ./internal/pipeline/` green
- [x] New `wantapply_test.go`: sitemap slug filter (`/company/*`, `/jobs/*`, reserved excluded), JobPosting mapping (onsite + remote), `FetchNew` seen→SeenRefresh (no detail fetch)→unseen→hydrated, drops page without JobPosting/company, registered-in-All + boardless + aggregator + not-selfClosing markers.
- [x] Live end-to-end against `wantapply.cy`: 932 vacancy candidates parsed; first vacancy fully mapped (TradingView / Cyprus / full_time / description).
- [ ] Post-deploy: add the per-board ingest cron timer for `sources/wantapply.yml`; prod `sources` synced from git.