### PR TITLE
fix(sources): make Djinni crawl survive datacenter rate-limit

### DIFF
--- a/internal/sources/djinni.go
+++ b/internal/sources/djinni.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -30,6 +31,12 @@ const (
 	djinniMaxPages = 600
 )
 
+// djinniPageDelay paces the sequential page crawl. Djinni rate-limits a fast burst from a
+// datacenter IP with a 403 (a no-delay crawl 403'd around page ~200 from prod, while the same
+// pages spaced ~1s apart return 200), so we throttle to stay under the limit and be a polite
+// crawler; partial-on-error bounds the damage if a 403 still lands. A var so tests zero it.
+var djinniPageDelay = 600 * time.Millisecond
+
 // NewDjinni builds the djinni listing adapter over the given HTML client.
 func NewDjinni(c HTMLResolvedGetter) Source { return djinni{http: c} }
 
@@ -44,13 +51,29 @@ func (djinni) aggregator() {}
 // the bare listing (/jobs/), so the FINAL URL no longer carries the requested page marker.
 // (Following the redirect would otherwise re-serve page 1 indefinitely, since page 1 is not
 // empty.) A genuinely empty non-redirected page is a secondary stop.
+//
+// A page fetch that fails partway (Djinni 403s a datacenter IP that crawls too fast) does NOT
+// discard the crawl: the pages already collected are the freshest postings (Djinni orders by
+// recency), so Fetch keeps them and stops. It fails the whole board only when page 1 itself
+// fails — an empty successful crawl would otherwise let the unseen-sweep close the catalogue.
 func (s djinni) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 	var jobs []Job
 	for page := 1; page <= djinniMaxPages; page++ {
+		if page > 1 {
+			select {
+			case <-ctx.Done():
+				return jobs, ctx.Err()
+			case <-time.After(djinniPageDelay):
+			}
+		}
 		pageMarker := fmt.Sprintf("page=%d", page)
 		root, final, err := s.http.GetHTMLResolved(ctx, djinniListBase+pageMarker)
 		if err != nil {
-			return nil, fmt.Errorf("djinni: fetch page %d: %w", page, err)
+			if len(jobs) == 0 {
+				return nil, fmt.Errorf("djinni: fetch page %d: %w", page, err)
+			}
+			log.Printf("djinni: page %d failed (%v); keeping %d jobs from pages 1..%d", page, err, len(jobs), page-1)
+			break // partial crawl — keep the freshest pages rather than losing everything
 		}
 		if !strings.Contains(final, pageMarker) {
 			break // redirected off the end of the feed (past-the-end page 302s to /jobs/)

--- a/internal/sources/djinni_test.go
+++ b/internal/sources/djinni_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -55,18 +56,25 @@ const djinniSingleHTML = `<html><head>
 
 const djinniEmptyHTML = `<html><head></head><body></body></html>`
 
+func init() { djinniPageDelay = 0 } // don't pace the crawl in unit tests
+
 // djinniPagedHTTP models djinni.co's listing pagination. A page present in bodies is served
-// directly (final URL == requested URL, no redirect). A page ABSENT from bodies models the real
-// past-the-end behavior: djinni 302s to the bare listing (/jobs/) and serves page 1's content —
-// so the resolved final URL loses the page marker, which is the adapter's end-of-feed signal.
+// directly (final URL == requested URL, no redirect). A page listed in errPages fails with a 403
+// (modelling Djinni rate-limiting a fast datacenter crawl). A page ABSENT from both models the
+// real past-the-end behavior: djinni 302s to the bare listing (/jobs/) and serves page 1's
+// content — so the resolved final URL loses the page marker, the adapter's end-of-feed signal.
 type djinniPagedHTTP struct {
-	bodies  map[int]string
-	gotURLs []string
+	bodies   map[int]string
+	errPages map[int]bool
+	gotURLs  []string
 }
 
 func (f *djinniPagedHTTP) GetHTMLResolved(_ context.Context, url string) (*html.Node, string, error) {
 	f.gotURLs = append(f.gotURLs, url)
 	page := djinniPageOf(url)
+	if f.errPages[page] {
+		return nil, "", fmt.Errorf("GET %s: status 403", url)
+	}
 	if body, ok := f.bodies[page]; ok {
 		node, err := html.Parse(strings.NewReader(body))
 		return node, url, err // served directly, no redirect
@@ -191,6 +199,37 @@ func TestDjinniStopsOnEmptyNonRedirectedPage(t *testing.T) {
 	}
 	if len(fake.gotURLs) != 2 {
 		t.Fatalf("requested %d pages, want page 1 then the empty page 2", len(fake.gotURLs))
+	}
+}
+
+// TestDjinniPartialOnMidCrawlError covers the datacenter rate-limit case: page 1 maps, then
+// page 2 403s. The adapter must keep page 1's jobs and return no error (a partial crawl of the
+// freshest pages beats losing everything and dropping the board into cooldown).
+func TestDjinniPartialOnMidCrawlError(t *testing.T) {
+	fake := &djinniPagedHTTP{
+		bodies:   map[int]string{1: djinniListingHTML},
+		errPages: map[int]bool{2: true},
+	}
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err != nil {
+		t.Fatalf("Fetch returned error %v, want nil (partial success on a mid-crawl 403)", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want page 1's 2 usable postings kept despite the page-2 403", len(jobs))
+	}
+}
+
+// TestDjinniFailsHardWhenFirstPageErrors guards the sweep: an error on page 1 (zero jobs
+// collected) must surface as a board failure, never an empty successful crawl — otherwise the
+// unseen-sweep would close the whole Djinni catalogue.
+func TestDjinniFailsHardWhenFirstPageErrors(t *testing.T) {
+	fake := &djinniPagedHTTP{
+		bodies:   map[int]string{1: djinniListingHTML},
+		errPages: map[int]bool{1: true},
+	}
+	jobs, err := NewDjinni(fake).Fetch(context.Background(), CompanyEntry{Provider: "djinni"})
+	if err == nil {
+		t.Fatalf("Fetch returned nil error with %d jobs, want a board failure when page 1 fails", len(jobs))
 	}
 }
 

--- a/openspec/changes/add-djinni-source/design.md
+++ b/openspec/changes/add-djinni-source/design.md
@@ -75,12 +75,29 @@ fragile against that). This needed a new `HTMLResolvedGetter` interface (added t
 non-redirected empty page is kept as a secondary stop, and `djinniMaxPages` (above the observed
 ~488) is the backstop against a pathological feed, mirroring `justJoinMaxPages`.
 
+### Decision: Pace the crawl and keep partial results on a datacenter 403
+
+The spike (residential IP) saw no rate limiting, but the FIRST prod run (host-2 datacenter IP)
+`403`'d at page ~204 of a no-delay crawl — Djinni throttles a fast burst by IP. Two changes
+make the crawl production-viable: (1) a `djinniPageDelay` (~600ms) between page requests to stay
+under the limit and be a polite crawler; (2) **partial-on-error** — a mid-crawl fetch error
+stops the crawl but keeps the pages already collected (the freshest, since Djinni orders by
+recency), instead of the original "abort the whole board on any page error" which lost ~3,000
+already-crawled jobs and dropped the board into cooldown. The board fails hard ONLY when page 1
+fails, so an empty successful crawl never reaches the unseen-sweep (the workday-total:0
+false-close class). Trade-off: the crawl depth per run is whatever stays under the limit (the
+freshest N pages), not guaranteed full corpus; the older tail is lower value and a residential
+egress / deeper pacing is the noted seam if full coverage is ever wanted.
+
 ## Risks / Trade-offs
 
-- **Full-corpus crawl is ~488 sequential requests (~16 min/run).** → Acceptable for a
-  run-once cron; requests are cheap and Djinni showed no rate limiting on rapid sequential
-  hits during the spike. Sharding by `?primary_keyword=` is a noted seam if latency ever
-  matters.
+- **Full-corpus crawl is ~488 sequential requests.** → Paced at ~600ms/page (~5 min) and
+  bounded by partial-on-error when Djinni's datacenter rate-limit lands; each run reliably gets
+  the freshest pages. Sharding by `?primary_keyword=` or a residential egress is a noted seam
+  if full-corpus coverage ever matters.
+- **A moving 403 boundary causes minor unseen-sweep churn** (jobs near the boundary flip in/out
+  between runs). → The 48h unseen window absorbs it — a job must be missed for 48h straight to
+  close, which a near-boundary posting rarely is.
 - **One failing board = the whole source in cooldown** (single-board granularity of
   `board_health`). → Inherent to a single-board source; consistent with other boardless
   aggregators (justjoin, himalayas).

--- a/openspec/changes/add-djinni-source/specs/djinni-source/spec.md
+++ b/openspec/changes/add-djinni-source/specs/djinni-source/spec.md
@@ -57,6 +57,28 @@ pathological feed, so a crawl can never loop unboundedly.
 - **WHEN** the listing never signals the end within the configured page cap
 - **THEN** the adapter stops at the cap rather than paging without bound
 
+### Requirement: Djinni survives a datacenter rate-limit mid-crawl
+
+Djinni rate-limits a fast page burst from a datacenter IP with a `403`. The adapter SHALL pace
+its sequential page requests to stay under that limit, and SHALL treat a page fetch that fails
+partway through the crawl as a partial success: it keeps the postings already collected (the
+freshest pages, since Djinni orders by recency) and stops, rather than discarding the whole
+crawl. The adapter SHALL fail the board (return an error) ONLY when the FIRST page fails, so a
+successful crawl never returns an empty set that would let the unseen-sweep close the catalogue.
+
+#### Scenario: A mid-crawl 403 keeps the pages already collected
+
+- **WHEN** page 1 maps successfully and a later page fails with a fetch error (e.g. a rate-limit
+  `403`)
+- **THEN** the adapter returns the jobs from the pages it did fetch, with no error, and does not
+  request further pages
+
+#### Scenario: A first-page failure fails the board
+
+- **WHEN** the very first page fails with a fetch error (no jobs collected yet)
+- **THEN** the adapter returns an error so the board is counted failed and cooled down — an
+  empty successful crawl (which the unseen-sweep would act on) is never returned
+
 ### Requirement: Djinni drops a posting it cannot key or address
 
 The adapter SHALL drop a `JobPosting` that lacks a usable `identifier` (no dedup key), a


### PR DESCRIPTION
## Summary

Follow-up to #774. The first prod ingest run **failed**: Djinni `403`'d at page ~204. The spike ran from a residential IP and saw no rate limiting, but host-2's datacenter IP gets throttled on a fast page burst (individual pages spaced ~1s apart return `200`). On top of that, the adapter aborted the **whole board** on any page error, discarding the ~3,000 jobs already crawled and dropping the board into cooldown → 0 jobs ingested.

- **Pace the crawl** (~600ms/page) to stay under Djinni's rate limit and be a polite crawler.
- **Partial-on-error:** a mid-crawl fetch failure now keeps the pages already collected (the freshest, since Djinni orders by recency) and stops, instead of losing everything. The board fails hard **only** when page 1 fails — so an empty successful crawl never reaches the unseen-sweep (the workday-total:0 false-close class).

Trade-off: crawl depth per run is whatever stays under the limit (freshest N pages), not guaranteed full corpus; the older tail is lower value, and a residential egress / deeper pacing is the noted seam for full coverage. Design + delta spec updated (`add-djinni-source`).

## Test Plan

- [x] `go build ./...`, `go vet`, `gofmt` clean; full unit suite green
- [x] New tests: `TestDjinniPartialOnMidCrawlError` (page-2 403 → keep page 1, no error), `TestDjinniFailsHardWhenFirstPageErrors` (page-1 403 → board failure)
- [ ] Post-deploy: observe the real crawl reaches deeper / completes and ingests jobs without failing the board