### PR TITLE
feat(sources): onboard Secure IQ Services (Reef) workable board

### DIFF
--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -163,6 +163,8 @@
   board: runware
 - company: Sawhorse Productions
   board: sawhorse-productions
+- company: Secure IQ Services
+  board: hire-with-reef
 - company: Smoking Gun Interactive
   board: smoking-gun-interactive-1
 - company: Snowed In Studios


### PR DESCRIPTION
## What

Onboards **Secure IQ Services** (brand: Reef, `hirewithreef.com`) as a Workable board `hire-with-reef`.

## Why

Fell out of an audit of the `@remoteyeah` aggregator Telegram channel (deliberately excluded from `sources/telegram.yml` as a duplicate-of-ATS source). Cross-checking its 15 companies against prod, 12 were already covered; 3 were not. Of those three, only Reef runs on a standard ATS — Risco Group and Expansion International self-host jobs on WordPress with no structured data, so they're not cleanly ingestable and are left out.

## Verification

Targeted local ingest of just this board:
- `ingested=165 failed=0` (raw adapter listings)
- **DB after dedup: 56 rows / 56 distinct external_id** — the board country-multiplies each role ~6× under one shortcode, and `ExternalID: j.Shortcode` (`workable.go:46`) + `UNIQUE(source, external_id)` collapses them cleanly. No country duplicates.

## Caveat

This is a staffing agency: the 56 roles are mostly **non-IT** (accountant, automotive paint technician, defense attorney, property consultant). The enrich non-tech gate will filter most from enrichment, but they will still appear in `/jobs` listings. Merging on the call that breadth is acceptable.