### PR TITLE
wantapply: preserve description formatting + lower detail concurrency

### DIFF
--- a/internal/sources/wantapply.go
+++ b/internal/sources/wantapply.go
@@ -35,6 +35,10 @@ const (
 	// wantapplyHostname is the sitemap host a vacancy loc must carry (guards against a foreign
 	// or malformed URL slipping through as a slug).
 	wantapplyHostname = "wantapply.cy"
+	// wantapplyDetailWorkers bounds the detail-fetch fan-out below the shared default (8): the
+	// .cy mirror throttles a burst of concurrent requests (a prod run at 8 landed only ~32% of
+	// the catalogue), while 4 fetches the full sitemap cleanly (~2 min for ~930 vacancies).
+	wantapplyDetailWorkers = 4
 )
 
 // wantapplyReserved are the single-segment paths that are pages, not vacancies. Multi-segment
@@ -67,7 +71,7 @@ func (s wantapply) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 	if err != nil {
 		return nil, err
 	}
-	return fetchDetails(vacancies, defaultDetailWorkers, func(v wantapplyVacancy) (Job, bool) {
+	return fetchDetails(vacancies, wantapplyDetailWorkers, func(v wantapplyVacancy) (Job, bool) {
 		return s.detail(ctx, v)
 	}), nil
 }
@@ -76,13 +80,13 @@ func (s wantapply) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 // whether a slug is already ingested. A seen vacancy yields a liveness-refresh job (no detail
 // request) so the pipeline refreshes its last-seen/open state WITHOUT rewriting the content
 // hydrated when it was new; an unseen vacancy is hydrated from its detail page. Detail fetches
-// run under the shared bounded worker pool, and a single vacancy's detail failure is isolated.
+// run under a bounded worker pool, and a single vacancy's detail failure is isolated.
 func (s wantapply) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
 	vacancies, err := s.crawl(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return fetchDetails(vacancies, defaultDetailWorkers, func(v wantapplyVacancy) (Job, bool) {
+	return fetchDetails(vacancies, wantapplyDetailWorkers, func(v wantapplyVacancy) (Job, bool) {
 		if seen(v.slug) {
 			// Already ingested: refresh liveness only, no detail request. Just the identity
 			// fields the pipeline's touch needs (ExternalID); content is left untouched.

--- a/internal/sources/wantapply.go
+++ b/internal/sources/wantapply.go
@@ -134,6 +134,13 @@ func (s wantapply) detail(ctx context.Context, v wantapplyVacancy) (Job, bool) {
 	if company == "" {
 		return Job{}, false // aggregator: no employer name → cannot normalize
 	}
+	// Prefer the page's rendered <div class="Description"> body — it keeps the headings and
+	// lists that the flat JobPosting `description` field strips to run-together plain text. Fall
+	// back to the (unformatted) JSON-LD description when the container is absent.
+	description := wantapplyDescription(root)
+	if description == "" {
+		description = sanitizeHTML(html.UnescapeString(p.Description))
+	}
 	location := p.location()
 	// jobLocationType is the structured work-arrangement signal: TELECOMMUTE means remote. Absent
 	// → leave WorkMode empty and fall back to the location text for the remote flag.
@@ -153,12 +160,30 @@ func (s wantapply) detail(ctx context.Context, v wantapplyVacancy) (Job, bool) {
 		Title:          p.Title,
 		Company:        company,
 		Location:       location,
-		Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+		Description:    description,
 		Remote:         remote || isRemote(location),
 		WorkMode:       workMode,
 		EmploymentType: schemaEmploymentType(employmentType),
 		PostedAt:       parseRFC3339(p.DatePosted),
 	}, true
+}
+
+// wantapplyDescription returns the sanitized rich HTML of the page's <div class="Description">
+// body — the block that preserves the headings and lists the flat JobPosting `description` field
+// loses. It returns "" when the container is absent, so the caller falls back to the JSON-LD text.
+func wantapplyDescription(root *html.Node) string {
+	var body string
+	walk(root, func(n *html.Node) bool {
+		if body != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "div" && hasClass(n, "Description") {
+			body = innerHTML(n)
+			return false
+		}
+		return true
+	})
+	return sanitizeHTML(body)
 }
 
 // wantapplyVacancySlug returns the vacancy slug for a sitemap loc that is a single-segment,

--- a/internal/sources/wantapply_test.go
+++ b/internal/sources/wantapply_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -138,6 +139,55 @@ func TestWantapplyFetchSitemapThenDetailAndMaps(t *testing.T) {
 	}
 	if j.WorkMode != "" {
 		t.Errorf("WorkMode = %q, want empty (no TELECOMMUTE)", j.WorkMode)
+	}
+}
+
+func TestWantapplyDetailPrefersFormattedDescriptionDiv(t *testing.T) {
+	jobURL := "https://wantapply.cy/senior-backend-developer-at-acclaim"
+	// The JobPosting `description` is flat run-together text; the visible <div class="Description">
+	// carries the real formatting (headings + lists). The adapter must use the div.
+	page := `<html><head><script type="application/ld+json">` +
+		`{"@type":"JobPosting","title":"Senior Backend Developer","datePosted":"2026-07-15T10:00:00Z",` +
+		`"employmentType":["FULL_TIME"],` +
+		`"hiringOrganization":{"name":"Acclaim"},` +
+		`"jobLocation":[{"@type":"Place","address":{"addressCountry":"Cyprus"}}],` +
+		`"description":"REQUIREMENTS 6+ years Python RESPONSIBILITIES Build services"}` +
+		`</script></head><body>` +
+		`<div class="Description"><p>Intro paragraph.</p><h3><strong>REQUIREMENTS</strong></h3>` +
+		`<ul><li><p>6+ years Python</p></li></ul><script>alert(1)</script></div>` +
+		`</body></html>`
+	fake := (&routedHTTP{}).route("/senior-backend-developer-at-acclaim", page)
+
+	j, ok := wantapply{http: fake}.detail(context.Background(),
+		wantapplyVacancy{slug: "senior-backend-developer-at-acclaim", url: jobURL})
+	if !ok {
+		t.Fatal("detail returned ok=false")
+	}
+	for _, want := range []string{"<h3>", "<strong>REQUIREMENTS</strong>", "<ul>", "<li>", "<p>6+ years Python</p>"} {
+		if !strings.Contains(j.Description, want) {
+			t.Errorf("Description missing %q; got %q", want, j.Description)
+		}
+	}
+	if strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description kept <script>; got %q", j.Description)
+	}
+}
+
+func TestWantapplyDetailFallsBackToJSONLDDescription(t *testing.T) {
+	jobURL := "https://wantapply.cy/role-no-div"
+	// No <div class="Description"> → fall back to the (sanitized) JSON-LD description.
+	detail := wantapplyDetailHTML("Some Role", "Acme",
+		"&lt;p&gt;Plain body.&lt;/p&gt;", "2026-07-15T10:00:00Z", "",
+		[3]string{"", "", "Cyprus"})
+	fake := (&routedHTTP{}).route("/role-no-div", detail)
+
+	j, ok := wantapply{http: fake}.detail(context.Background(),
+		wantapplyVacancy{slug: "role-no-div", url: jobURL})
+	if !ok {
+		t.Fatal("detail returned ok=false")
+	}
+	if j.Description != "<p>Plain body.</p>" {
+		t.Errorf("Description = %q, want the JSON-LD fallback", j.Description)
 	}
 }
 


### PR DESCRIPTION
## Summary
Two follow-ups to the wantapply adapter (#775). The concurrency fix was previously merged as #779 but dropped from main by a parallel deploy that rewrote history — re-landing it here alongside the formatting fix.

1. **Preserve description formatting.** The JobPosting `description` field is flat run-together plain text (headings and bullets collapsed into one paragraph). Extract the rendered `<div class="Description">` body instead — it keeps the `h3`/`ul`/`li`/`strong` structure that `sanitizeHTML` allows. Falls back to the JSON-LD text when the container is absent.
2. **Lower detail concurrency to 4.** A prod run at the shared default (8 workers) landed only ~301/932 vacancies — `.cy` throttles a concurrent burst. Sequential (40/40) and 4-worker (120/120) crawls fetch the full sitemap cleanly.

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./internal/sources/` green
- [x] New unit tests: formatted `<div class="Description">` → `h3`/`ul`/`li` kept, `<script>` stripped; no-div → JSON-LD fallback
- [x] Live on `wantapply.cy`: description now carries `<h3>/<ul>/<li>/<strong>` (was flat text); conc=4 → 120/120 vs conc=8 → ~301/932
- [ ] Post-deploy: re-run `freehire-ingest@wantapply`, confirm full coverage (~930 open) and formatted descriptions render on freehire.dev