### PR TITLE
fix(sources): route wantapply through the proxy egress (IP-blocked on prod)

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -364,6 +364,7 @@ func All(c HTTPClient) map[string]Source {
 // providers (bayt/gulftalent) would need proxy support wired into fingerprintHTTP instead.
 var proxiedProviders = map[string]func(HTTPClient) Source{
 	"eightfold": func(c HTTPClient) Source { return NewEightfold(c) },
+	"wantapply": func(c HTTPClient) Source { return NewWantapply(c) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy

--- a/internal/sources/wantapply_test.go
+++ b/internal/sources/wantapply_test.go
@@ -290,6 +290,13 @@ func TestWantapplyProviderBoardlessAggregatorNotSelfClosing(t *testing.T) {
 	}
 }
 
+func TestWantapplyIsProxied(t *testing.T) {
+	// The .cy edge IP-blocks the prod datacenter IP, so wantapply must egress through the proxy.
+	if _, ok := proxiedProviders["wantapply"]; !ok {
+		t.Error("wantapply must be in proxiedProviders (its edge blocks the prod datacenter IP)")
+	}
+}
+
 func TestWantapplyRegisteredInAll(t *testing.T) {
 	reg := All(NewClient())
 	if _, ok := reg["wantapply"]; !ok {


### PR DESCRIPTION
## Summary
The wantapply `.cy` edge **IP-blocks the prod datacenter IP** — every request from prod now returns 403 (browser UA and bot UA alike), while a residential IP is served normally. The first prod crawl slipped through (301 jobs) before the IP was blocked; subsequent runs get nothing.

Add `wantapply` to `proxiedProviders` (the #776 mechanism) so its crawl egresses through `SOURCES_PROXY_URL`, exactly like `eightfold`. wantapply is a fixed-host provider on the standard client, so it satisfies the proxied-path SSRF constraint.

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./internal/sources/` green (incl. `TestWantapplyIsProxied` + existing `ApplyProxyEgress` rewiring tests)
- [x] Confirmed on prod: `curl https://wantapply.cy/sitemap.xml` from the prod host → 403 (both UAs); from a residential IP → 200
- [ ] Post-deploy: re-run `freehire-ingest@wantapply` and confirm the crawl succeeds through the proxy (coverage climbs toward ~930)