### PR TITLE
feat(sources): route djinni through the egress proxy

### DIFF
--- a/internal/sources/djinni_test.go
+++ b/internal/sources/djinni_test.go
@@ -233,6 +233,13 @@ func TestDjinniFailsHardWhenFirstPageErrors(t *testing.T) {
 	}
 }
 
+func TestDjinniIsProxied(t *testing.T) {
+	// djinni.co IP-blocklists the prod datacenter IP, so djinni must egress through the proxy.
+	if _, ok := proxiedProviders["djinni"]; !ok {
+		t.Error("djinni must be in proxiedProviders (its edge blocks the prod datacenter IP)")
+	}
+}
+
 func TestDjinniIsAggregator(t *testing.T) {
 	reg := All(nil)
 	if got := ProviderKind(reg, "djinni"); got != KindAggregator {

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -365,6 +365,9 @@ func All(c HTTPClient) map[string]Source {
 var proxiedProviders = map[string]func(HTTPClient) Source{
 	"eightfold": func(c HTTPClient) Source { return NewEightfold(c) },
 	"wantapply": func(c HTTPClient) Source { return NewWantapply(c) },
+	// djinni.co IP-blocklists the prod datacenter IP: a fast crawl escalates to a hard "your
+	// IP has been blocked" page, while a residential IP is served the full JSON-LD listing.
+	"djinni": func(c HTTPClient) Source { return NewDjinni(c) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy


### PR DESCRIPTION
## Summary

Wires Djinni into the existing `proxiedProviders` egress-proxy mechanism (added alongside eightfold/wantapply). The first prod ingest run proved djinni.co **IP-blocklists the datacenter IP** — a fast crawl escalates from a rate-limit `403` to a hard `Your IP address … has been blocked` page, while a residential IP is served the full JSON-LD listing.

One line in `proxiedProviders`, so `ApplyProxyEgress` routes djinni through `SOURCES_PROXY_URL` when it's configured, exactly like the other blocked providers.

## Activation (when the residential proxy is live)

1. Set `SOURCES_PROXY_URL=http://user:pass@host:port` in prod `/opt/freehire/.env`.
2. Re-enable the ingest timer: recreate `freehire-ingest@djinni.timer` (disabled after the block was hit) and `systemctl enable --now` it.
3. Verify a run ingests jobs (`select count(*) from jobs where source='djinni'`) and `board_health` stays healthy.

Dormant until then: with `SOURCES_PROXY_URL` unset, djinni stays on the direct (blocked) IP and the timer is off, so no pointless requests hit the ban page.

## Test Plan

- [x] `go build ./...`, `go test ./internal/sources/...` green
- [x] `TestDjinniIsProxied` asserts djinni is in `proxiedProviders`
- [ ] Post-proxy: real crawl through the proxy ingests the full corpus without a block