### PR TITLE
perf(companies): scope /companies catalog to hiring companies

### DIFF
--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -113,7 +113,8 @@ func (q *Queries) CompanySubindustries(ctx context.Context) ([]CompanySubindustr
 const countCompanies = `-- name: CountCompanies :one
 SELECT count(*)
 FROM companies
-WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '%')
+WHERE job_count > 0
+  AND ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '%')
   AND (coalesce(cardinality($2::text[]), 0) = 0 OR collections && $2::text[])
   AND (coalesce(cardinality($3::text[]), 0) = 0 OR regions && $3::text[])
   AND (coalesce(cardinality($4::text[]), 0) = 0 OR countries && $4::text[])
@@ -148,7 +149,7 @@ type CountCompaniesParams struct {
 
 // Total companies matching the same optional name + facet filters as ListCompanies,
 // so search/filter pagination reports the filtered total. Keep this WHERE identical
-// to ListCompanies.
+// to ListCompanies (including the job_count > 0 hiring scope).
 func (q *Queries) CountCompanies(ctx context.Context, arg CountCompaniesParams) (int64, error) {
 	row := q.db.QueryRow(ctx, countCompanies,
 		arg.Search,
@@ -236,7 +237,8 @@ func (q *Queries) GetCompany(ctx context.Context, slug string) (Company, error) 
 const listCompanies = `-- name: ListCompanies :many
 SELECT slug, name, job_count, tagline, industries, hq_country
 FROM companies
-WHERE ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '%')
+WHERE job_count > 0
+  AND ($1::text = '' OR name ILIKE '%' || $1 || '%' OR slug ILIKE '%' || $1 || '%')
   AND (coalesce(cardinality($2::text[]), 0) = 0 OR collections && $2::text[])
   AND (coalesce(cardinality($3::text[]), 0) = 0 OR regions && $3::text[])
   AND (coalesce(cardinality($4::text[]), 0) = 0 OR countries && $4::text[])
@@ -298,7 +300,10 @@ type ListCompaniesRow struct {
 // subset of `regions`. The name search also matches the slug, so a hyphenated slug
 // query ("ge-vernova") finds the company even though its name has a space ("GE
 // Vernova"). CountCompanies MUST keep an identical WHERE so the filtered total
-// matches the page.
+// matches the page. `job_count > 0` scopes the catalog to companies that are
+// actually hiring, excluding the ~92k job-less reference rows imported by the YC
+// and company-info backfills; it also lets both reads ride companies_hiring_job_count_idx
+// (partial index) instead of scanning the full 2.3 GB heap.
 func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error) {
 	rows, err := q.db.Query(ctx, listCompanies,
 		arg.Search,

--- a/internal/db/companies_integration_test.go
+++ b/internal/db/companies_integration_test.go
@@ -15,10 +15,14 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// insertCompany seeds a listable company: job_count = 1 so it satisfies the
+// catalog's `job_count > 0` scope (ListCompanies/CountCompanies). Tests that
+// exercise the derived count seed jobs and call RefreshCompanyFacets, which
+// overwrites this placeholder with the real open-job count.
 func insertCompany(t *testing.T, pool *pgxpool.Pool, slug, name string) {
 	t.Helper()
 	if _, err := pool.Exec(context.Background(),
-		`INSERT INTO companies (slug, name) VALUES ($1, $2)`, slug, name); err != nil {
+		`INSERT INTO companies (slug, name, job_count) VALUES ($1, $2, 1)`, slug, name); err != nil {
 		t.Fatalf("insert company %q: %v", slug, err)
 	}
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -133,7 +133,7 @@ type Querier interface {
 	ConfirmEmailLink(ctx context.Context, arg ConfirmEmailLinkParams) (int64, error)
 	// Total companies matching the same optional name + facet filters as ListCompanies,
 	// so search/filter pagination reports the filtered total. Keep this WHERE identical
-	// to ListCompanies.
+	// to ListCompanies (including the job_count > 0 hiring scope).
 	CountCompanies(ctx context.Context, arg CountCompaniesParams) (int64, error)
 	// Total live messages for the caller (same optional filters as ListEmails), for
 	// pagination.
@@ -445,7 +445,10 @@ type Querier interface {
 	// subset of `regions`. The name search also matches the slug, so a hyphenated slug
 	// query ("ge-vernova") finds the company even though its name has a space ("GE
 	// Vernova"). CountCompanies MUST keep an identical WHERE so the filtered total
-	// matches the page.
+	// matches the page. `job_count > 0` scopes the catalog to companies that are
+	// actually hiring, excluding the ~92k job-less reference rows imported by the YC
+	// and company-info backfills; it also lets both reads ride companies_hiring_job_count_idx
+	// (partial index) instead of scanning the full 2.3 GB heap.
 	ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error)
 	// All companies with their current collection membership. cmd/import-collections
 	// reads this to know the existing company slugs (the match target) and each

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -12,10 +12,14 @@
 -- subset of `regions`. The name search also matches the slug, so a hyphenated slug
 -- query ("ge-vernova") finds the company even though its name has a space ("GE
 -- Vernova"). CountCompanies MUST keep an identical WHERE so the filtered total
--- matches the page.
+-- matches the page. `job_count > 0` scopes the catalog to companies that are
+-- actually hiring, excluding the ~92k job-less reference rows imported by the YC
+-- and company-info backfills; it also lets both reads ride companies_hiring_job_count_idx
+-- (partial index) instead of scanning the full 2.3 GB heap.
 SELECT slug, name, job_count, tagline, industries, hq_country
 FROM companies
-WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%' OR slug ILIKE '%' || sqlc.arg('search') || '%')
+WHERE job_count > 0
+  AND (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%' OR slug ILIKE '%' || sqlc.arg('search') || '%')
   AND (coalesce(cardinality(sqlc.arg('collections')::text[]), 0) = 0 OR collections && sqlc.arg('collections')::text[])
   AND (coalesce(cardinality(sqlc.arg('regions')::text[]), 0) = 0 OR regions && sqlc.arg('regions')::text[])
   AND (coalesce(cardinality(sqlc.arg('countries')::text[]), 0) = 0 OR countries && sqlc.arg('countries')::text[])
@@ -38,10 +42,11 @@ LIMIT sqlc.arg('limit') OFFSET sqlc.arg('offset');
 -- name: CountCompanies :one
 -- Total companies matching the same optional name + facet filters as ListCompanies,
 -- so search/filter pagination reports the filtered total. Keep this WHERE identical
--- to ListCompanies.
+-- to ListCompanies (including the job_count > 0 hiring scope).
 SELECT count(*)
 FROM companies
-WHERE (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%' OR slug ILIKE '%' || sqlc.arg('search') || '%')
+WHERE job_count > 0
+  AND (sqlc.arg('search')::text = '' OR name ILIKE '%' || sqlc.arg('search') || '%' OR slug ILIKE '%' || sqlc.arg('search') || '%')
   AND (coalesce(cardinality(sqlc.arg('collections')::text[]), 0) = 0 OR collections && sqlc.arg('collections')::text[])
   AND (coalesce(cardinality(sqlc.arg('regions')::text[]), 0) = 0 OR regions && sqlc.arg('regions')::text[])
   AND (coalesce(cardinality(sqlc.arg('countries')::text[]), 0) = 0 OR countries && sqlc.arg('countries')::text[])

--- a/internal/handler/companies_integration_test.go
+++ b/internal/handler/companies_integration_test.go
@@ -72,7 +72,7 @@ func TestListCompaniesSearchEndpoint(t *testing.T) {
 		{"acme", "Acme Corp"}, {"acme-labs", "ACME Labs"}, {"globex", "Globex"},
 	} {
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO companies (slug, name) VALUES ($1, $2)`, c.slug, c.name); err != nil {
+			`INSERT INTO companies (slug, name, job_count) VALUES ($1, $2, 1)`, c.slug, c.name); err != nil {
 			t.Fatalf("seed %q: %v", c.slug, err)
 		}
 	}
@@ -141,8 +141,8 @@ func TestListCompaniesFacetFilterEndpoint(t *testing.T) {
 	seed := func(slug, name string, collections, regions, companyTypes []string) {
 		t.Helper()
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO companies (slug, name, collections, regions, company_types)
-			 VALUES ($1, $2, $3, $4, $5)`,
+			`INSERT INTO companies (slug, name, job_count, collections, regions, company_types)
+			 VALUES ($1, $2, 1, $3, $4, $5)`,
 			slug, name, collections, regions, companyTypes); err != nil {
 			t.Fatalf("seed %q: %v", slug, err)
 		}
@@ -231,7 +231,7 @@ func TestListCompaniesSubindustryFacet(t *testing.T) {
 	seed := func(slug string, subindustry any) {
 		t.Helper()
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO companies (slug, name, subindustry) VALUES ($1, $1, $2)`,
+			`INSERT INTO companies (slug, name, job_count, subindustry) VALUES ($1, $1, 1, $2)`,
 			slug, subindustry); err != nil {
 			t.Fatalf("seed %q: %v", slug, err)
 		}
@@ -306,7 +306,7 @@ func TestCompanySubindustriesEndpoint(t *testing.T) {
 	seed := func(slug string, subindustry any) {
 		t.Helper()
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO companies (slug, name, subindustry) VALUES ($1, $1, $2)`,
+			`INSERT INTO companies (slug, name, job_count, subindustry) VALUES ($1, $1, 1, $2)`,
 			slug, subindustry); err != nil {
 			t.Fatalf("seed %q: %v", slug, err)
 		}
@@ -362,7 +362,7 @@ func TestListCompaniesRemoteRegionsFacet(t *testing.T) {
 	seed := func(slug string, remote, regions []string) {
 		t.Helper()
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO companies (slug, name, remote_regions, regions) VALUES ($1, $1, $2, $3)`,
+			`INSERT INTO companies (slug, name, job_count, remote_regions, regions) VALUES ($1, $1, 1, $2, $3)`,
 			slug, remote, regions); err != nil {
 			t.Fatalf("seed %q: %v", slug, err)
 		}
@@ -427,7 +427,7 @@ func TestListCompaniesYCFacets(t *testing.T) {
 	seed := func(slug string, batch, status []string) {
 		t.Helper()
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO companies (slug, name, yc_batch, yc_status) VALUES ($1, $1, $2, $3)`,
+			`INSERT INTO companies (slug, name, job_count, yc_batch, yc_status) VALUES ($1, $1, 1, $2, $3)`,
 			slug, batch, status); err != nil {
 			t.Fatalf("seed %q: %v", slug, err)
 		}
@@ -493,7 +493,7 @@ func TestListCompaniesYCStageFlags(t *testing.T) {
 	seed := func(slug string, stage, flags []string) {
 		t.Helper()
 		if _, err := pool.Exec(ctx,
-			`INSERT INTO companies (slug, name, yc_stage, yc_flags) VALUES ($1, $1, $2, $3)`,
+			`INSERT INTO companies (slug, name, job_count, yc_stage, yc_flags) VALUES ($1, $1, 1, $2, $3)`,
 			slug, stage, flags); err != nil {
 			t.Fatalf("seed %q: %v", slug, err)
 		}

--- a/migrations/0023_companies_hiring_idx.sql
+++ b/migrations/0023_companies_hiring_idx.sql
@@ -1,0 +1,18 @@
+-- Partial index backing the /companies catalog, which now lists only companies
+-- with at least one open job (ListCompanies/CountCompanies filter job_count > 0).
+-- Half the companies table is job-less reference rows (~92k of ~226k) imported by
+-- the YC and company-info backfills; they carry job_count = 0 and are excluded from
+-- the catalog. Without this partial index the default CountCompanies degrades to a
+-- seq scan of the whole 2.3 GB heap (~60 s under load), and ListCompanies scans the
+-- full non-partial companies_job_count_idx. With it, both reads touch only the ~134k
+-- hiring rows: ListCompanies' ORDER BY job_count DESC, name LIMIT is a tiny index
+-- range scan, and the default (unfiltered) count is an index-only scan.
+--
+-- Applied to a fresh volume by initdb after 0022; on an existing prod volume build it
+-- CONCURRENTLY out of band (a plain CREATE INDEX would lock the live companies table):
+--   CREATE INDEX CONCURRENTLY companies_hiring_job_count_idx
+--     ON public.companies (job_count DESC, name)
+--     WHERE job_count > 0;
+CREATE INDEX IF NOT EXISTS companies_hiring_job_count_idx
+    ON public.companies (job_count DESC, name)
+    WHERE job_count > 0;


### PR DESCRIPTION
## Problem

`/companies` is slow (measured 10–33s TTFB on prod). Root cause is `CountCompanies`, which runs on **every** request:

- `SELECT count(*)` with no usable index → **seq scan of the whole 2.3 GB `companies` heap** (~60s under load, per `EXPLAIN (ANALYZE, BUFFERS)`).
- Of ~226k companies, **~92k carry `job_count = 0`** — job-less reference rows imported by the YC and company-info backfills. A "companies hiring" catalog scans and counts them for nothing.
- SSR (`+page.server.ts`) blocks on both `listCompanies` queries, so the query time becomes the HTML TTFB.

Verified on prod that adding `job_count > 0` **alone** does not fix it — the existing non-partial `companies_job_count_idx` degrades `count(*)` to a lossy Bitmap Heap Scan. A **partial** index is required.

## Change

- `ListCompanies` / `CountCompanies`: add `AND job_count > 0` (kept identical between the two so the filtered total still matches the page).
- Migration `0023`: partial index `companies_hiring_job_count_idx ON companies (job_count DESC, name) WHERE job_count > 0`. The default (unfiltered) count becomes an index-only scan over the ~134k hiring rows; the `ORDER BY job_count DESC, name LIMIT` rides a tiny range scan.

Reference companies (no open jobs) remain reachable by direct slug — they just drop out of the browse catalog, which matches the page's intent.

## Deploy notes

- On the live prod volume, build the index out-of-band (a plain `CREATE INDEX` would lock `companies`):
  ```sql
  CREATE INDEX CONCURRENTLY IF NOT EXISTS companies_hiring_job_count_idx
    ON public.companies (job_count DESC, name) WHERE job_count > 0;
  ```
  (Already in progress on prod at time of writing; validation is queued behind the nightly `pg_dump` snapshot.)
- Follow with `VACUUM ANALYZE companies` so the index-only count avoids heap visibility checks (the table's visibility map is stale after the 92k backfill inserts).

## Verification

`go build ./...` + `go vet` clean; sqlc regenerated. Before/after `EXPLAIN` numbers to be attached once the nightly backup releases its snapshot and the partial index validates.