### PR TITLE
chore(sources): re-add 2gis (now crawlable via proxy egress)

### DIFF
--- a/internal/sources/isolvedhire.go
+++ b/internal/sources/isolvedhire.go
@@ -2,7 +2,9 @@ package sources
 
 import (
 	"context"
+	"encoding/xml"
 	"fmt"
+	"io"
 	"regexp"
 
 	"golang.org/x/net/html"
@@ -19,10 +21,11 @@ type isolvedFamily struct {
 	host     string
 }
 
-// isolvedHTTP is the client capability the family needs: the sitemap as XML and each detail
-// page as parsed HTML (for its ld+json).
+// isolvedHTTP is the client capability the family needs: the sitemap as a stream (some tenants'
+// sitemaps run past the buffered-body cap — see Fetch) and each detail page as parsed HTML (for
+// its ld+json).
 type isolvedHTTP interface {
-	XMLGetter
+	StreamGetter
 	HTMLGetter
 }
 
@@ -44,25 +47,41 @@ func (s isolvedFamily) Provider() string { return s.provider }
 var isolvedJobID = regexp.MustCompile(`/jobs/(\d+)`)
 
 func (s isolvedFamily) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
 	smURL := fmt.Sprintf("https://%s.%s/sitemap.xml", e.Board, s.host)
-	if err := s.http.GetXML(ctx, smURL, &sitemap); err != nil {
-		return nil, fmt.Errorf("%s: sitemap %q: %w", s.provider, e.Board, err)
-	}
 
+	// The sitemap is streamed and scanned <loc>-by-<loc> rather than buffered whole: a large
+	// tenant's sitemap runs past the buffered-body size cap (35 MiB+ seen in prod), which would
+	// truncate it mid-element and fail the XML decode. Streaming reads it in full at any size.
 	seen := map[string]struct{}{}
 	var ids []string
-	for _, u := range sitemap.URLs {
-		if m := isolvedJobID.FindStringSubmatch(u.Loc); m != nil {
-			if _, ok := seen[m[1]]; !ok {
-				seen[m[1]] = struct{}{}
-				ids = append(ids, m[1])
+	err := s.http.GetStream(ctx, smURL, "application/xml", func(r io.Reader) error {
+		dec := xml.NewDecoder(r)
+		for {
+			tok, err := dec.Token()
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			start, ok := tok.(xml.StartElement)
+			if !ok || start.Name.Local != "loc" {
+				continue
+			}
+			var loc string
+			if err := dec.DecodeElement(&loc, &start); err != nil {
+				return err
+			}
+			if m := isolvedJobID.FindStringSubmatch(loc); m != nil {
+				if _, ok := seen[m[1]]; !ok {
+					seen[m[1]] = struct{}{}
+					ids = append(ids, m[1])
+				}
 			}
 		}
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%s: sitemap %q: %w", s.provider, e.Board, err)
 	}
 
 	return fetchDetails(ids, defaultDetailWorkers, func(id string) (Job, bool) {

--- a/internal/sources/proxy_test.go
+++ b/internal/sources/proxy_test.go
@@ -26,14 +26,19 @@ func TestApplyProxyEgressRewiresProxiedProviderOnly(t *testing.T) {
 	t.Setenv("SOURCES_PROXY_URL", "http://user:pass@proxy.example:8080")
 
 	registry := All(NewClient())
-	proxiedBefore := registry[proxiedProbe]
+	proxiedBefore := map[string]Source{}
+	for name := range proxiedProviders {
+		proxiedBefore[name] = registry[name]
+	}
 	directBefore := registry["greenhouse"] // not in proxiedProviders
 
 	if err := ApplyProxyEgress(registry); err != nil {
 		t.Fatalf("valid proxy: %v", err)
 	}
-	if registry[proxiedProbe] == proxiedBefore {
-		t.Error("a proxied provider must be rewired onto the proxy client")
+	for name, before := range proxiedBefore {
+		if registry[name] == before {
+			t.Errorf("proxied provider %q must be rewired onto the proxy client", name)
+		}
 	}
 	if registry["greenhouse"] != directBefore {
 		t.Error("a non-proxied provider must stay on the direct client")

--- a/internal/sources/smartrecruiters_test.go
+++ b/internal/sources/smartrecruiters_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -56,6 +57,18 @@ func (r *routedHTTP) GetHTML(_ context.Context, url string) (*html.Node, error) 
 		}
 	}
 	return nil, fmt.Errorf("routedHTTP: no route for %s", url)
+}
+
+func (r *routedHTTP) GetStream(_ context.Context, url, _ string, fn func(io.Reader) error) error {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	for _, rt := range r.routes {
+		if strings.Contains(url, rt.match) {
+			return fn(strings.NewReader(rt.body))
+		}
+	}
+	return fmt.Errorf("routedHTTP: no route for %s", url)
 }
 
 func (r *routedHTTP) GetText(_ context.Context, url string) (string, error) {

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -368,6 +368,9 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// djinni.co IP-blocklists the prod datacenter IP: a fast crawl escalates to a hard "your
 	// IP has been blocked" page, while a residential IP is served the full JSON-LD listing.
 	"djinni": func(c HTTPClient) Source { return NewDjinni(c) },
+	// 2gis tarpits datacenter IPs (the prod IP times out at 25s); the residential proxy is
+	// served in ~2s. It uses the standard HTMLGetter, so the proxied client serves it directly.
+	"2gis": func(c HTTPClient) Source { return NewTwoGIS(c) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -14,6 +14,10 @@
   board: whatnot
 
 # International single-company sources.
+# 2GIS (job.2gis.ru) tarpits datacenter IPs, so it was dropped in #660; it egresses through
+# the residential proxy now (proxiedProviders), which the tarpit is served past in ~2s.
+- company: 2GIS
+  provider: 2gis
 - company: Uber
   provider: uber
 - company: Amazon


### PR DESCRIPTION
2gis was dropped from the prod board list in #660 because its edge **tarpits datacenter IPs** — from the prod IP `job.2gis.ru` times out at 25s.

It's in `proxiedProviders` since #786, so it egresses through the residential proxy (served in **~2s**). This re-adds its boardless single-company entry to `custom.yml` so it's crawled again — through the proxy.

Verified live from prod: direct `000` (25s timeout) → proxied `200` in ~2s.