### PR TITLE
feat(sources): add Finom (lever EU) + Alcor (careerspage) boards

### DIFF
--- a/sources/careerspage.yml
+++ b/sources/careerspage.yml
@@ -8,3 +8,5 @@
   board: davidjoseph-co
 - company: Zarego
   board: zarego
+- company: Alcor
+  board: alcor

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -297,6 +297,9 @@
   board: findem
 - company: finn
   board: finn
+- company: Finom
+  board: pnlfin
+  region: eu
 - company: Firemon
   board: firemon
 - company: fiscalnote


### PR DESCRIPTION
Adds two source boards from JDs shared for coverage check.

## Boards
| Company | Provider | Board | Notes |
|---|---|---|---|
| Finom | lever | `pnlfin` (`region: eu`) | 71 postings via `api.eu.lever.co`; EU flag required — default host 404s |
| Alcor | careerspage | `alcor` | 15 postings on `alcor.careers-page.com` |

## Notes
- **Alcor is not a duplicate**: an `Alcor` already exists via `bamboohr` (Alcor BPO, Kyiv — internal recruiting/admin staff). This careerspage Alcor lists software engineers in Bogotá/Warsaw — different company, different `source`, no `(source, external_id)` dedup collision.
- Both boards validated live (listing >0 postings) before adding.
- `.yml`-only change — no binary rebuild needed; picked up by `cmd/ingest` on next run.

The other 4 JDs checked (gitlab, jetbrains, airhelp, QS Games) are already covered.