### PR TITLE
fix(sources): route careerspage through Chrome-fingerprint client

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -203,7 +203,6 @@ func All(c HTTPClient) map[string]Source {
 		NewTeamtailor(c),
 		NewHurma(c),
 		NewICIMS(c),
-		NewCareerPage(c),
 		NewNorthstone(c),
 		NewBriefHQ(c),
 		NewDjinni(c),
@@ -335,20 +334,26 @@ func All(c HTTPClient) map[string]Source {
 	}
 	// meta is NOT served by the shared client: Meta's edge 400s the default Go TLS+HTTP/2
 	// fingerprint, so it needs the shared Chrome-fingerprint transport (fingerprintHTTP, also used
-	// by the bayt/gulftalent aggregators). Build it only when there is a real client to serve (the
-	// c == nil marker/listing path — e.g. FilterableProviders — must stay transport-free, so meta
-	// registers with a nil client there; Provider()/boardless() never touch it). If the
-	// deterministic transport build ever fails, meta is left unregistered so config validation
-	// fails fast on the "meta" entry, rather than registering a client guaranteed to be rejected by
-	// Meta's edge.
+	// by the bayt/gulftalent aggregators and careerspage). Build it only when there is a real client
+	// to serve (the c == nil marker/listing path — e.g. FilterableProviders — must stay
+	// transport-free, so these register with a nil client there; Provider()/boardless() never touch
+	// it). If the deterministic transport build ever fails, they are left unregistered so config
+	// validation fails fast on those entries, rather than registering a client guaranteed to be
+	// rejected by the edge.
+	//
+	// careerspage joined this set once careers-page.com's Cloudflare began silently serving the
+	// default Go-client fingerprint an empty/challenge 200 (no error → board_health stays green
+	// while every board yields 0 postings); the same URLs pass under the Chrome fingerprint.
 	if c == nil {
 		registry["meta"] = NewMetaCareers(nil)
 		registry["bayt"] = NewBayt(nil)
 		registry["gulftalent"] = NewGulfTalent(nil)
+		registry["careerspage"] = NewCareerPage(nil)
 	} else if fp, err := newFingerprintHTTP(); err == nil {
 		registry["meta"] = NewMetaCareers(fp)
 		registry["bayt"] = NewBayt(fp)
 		registry["gulftalent"] = NewGulfTalent(fp)
+		registry["careerspage"] = NewCareerPage(fp)
 	}
 	return registry
 }


### PR DESCRIPTION
## Problem
careers-page.com's Cloudflare started silently serving the **default Go-client fingerprint** an empty/challenge `200` (not an error), so `board_health` stays green while every careerspage board yields **0 postings**. The whole provider froze — `David Joseph & Company` last-refreshed 03:33 UTC and eroding via liveness (100→44 open), only tiny `Zarego` (2 jobs) still lands.

Verified from the **prod IP**: `curl` gets the listing (15 links) + detail `JobPosting` under any UA (bot or Chrome), sequential or concurrent — so it's the Go client's TLS/HTTP fingerprint CF filters, **not** IP, UA, or concurrency.

## Fix
Move `careerspage` onto the shared Chrome-fingerprint transport (`fingerprintHTTP`, already used by meta/bayt/gulftalent), mirroring that exact wiring: real `fp` client when serving, `nil` on the transport-free marker/listing path. Parsing is unchanged (fp's `GetHTML` returns the same `*html.Node`).

## Follow-up seam
`fingerprintHTTP` doesn't retry on 429 (the shared client did). careerspage boards can burst (David Joseph ~100 detail fetches); if 429s surface, revisit retry/backoff on the fp transport. Getting past CF is the immediate win.

Unblocks the **Alcor** board added in #788 (15 jobs, currently 0 on prod).