### PR TITLE
Revert #789: careerspage fingerprint client (wrong root cause)

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -203,6 +203,7 @@ func All(c HTTPClient) map[string]Source {
 		NewTeamtailor(c),
 		NewHurma(c),
 		NewICIMS(c),
+		NewCareerPage(c),
 		NewNorthstone(c),
 		NewBriefHQ(c),
 		NewDjinni(c),
@@ -334,26 +335,20 @@ func All(c HTTPClient) map[string]Source {
 	}
 	// meta is NOT served by the shared client: Meta's edge 400s the default Go TLS+HTTP/2
 	// fingerprint, so it needs the shared Chrome-fingerprint transport (fingerprintHTTP, also used
-	// by the bayt/gulftalent aggregators and careerspage). Build it only when there is a real client
-	// to serve (the c == nil marker/listing path — e.g. FilterableProviders — must stay
-	// transport-free, so these register with a nil client there; Provider()/boardless() never touch
-	// it). If the deterministic transport build ever fails, they are left unregistered so config
-	// validation fails fast on those entries, rather than registering a client guaranteed to be
-	// rejected by the edge.
-	//
-	// careerspage joined this set once careers-page.com's Cloudflare began silently serving the
-	// default Go-client fingerprint an empty/challenge 200 (no error → board_health stays green
-	// while every board yields 0 postings); the same URLs pass under the Chrome fingerprint.
+	// by the bayt/gulftalent aggregators). Build it only when there is a real client to serve (the
+	// c == nil marker/listing path — e.g. FilterableProviders — must stay transport-free, so meta
+	// registers with a nil client there; Provider()/boardless() never touch it). If the
+	// deterministic transport build ever fails, meta is left unregistered so config validation
+	// fails fast on the "meta" entry, rather than registering a client guaranteed to be rejected by
+	// Meta's edge.
 	if c == nil {
 		registry["meta"] = NewMetaCareers(nil)
 		registry["bayt"] = NewBayt(nil)
 		registry["gulftalent"] = NewGulfTalent(nil)
-		registry["careerspage"] = NewCareerPage(nil)
 	} else if fp, err := newFingerprintHTTP(); err == nil {
 		registry["meta"] = NewMetaCareers(fp)
 		registry["bayt"] = NewBayt(fp)
 		registry["gulftalent"] = NewGulfTalent(fp)
-		registry["careerspage"] = NewCareerPage(fp)
 	}
 	return registry
 }


### PR DESCRIPTION
Reverts #789. That change misdiagnosed the problem and made it worse.

## Corrected root cause
careers-page.com **rate-limits the prod IP (HTTP 429)** under the detail-fetch burst, not a TLS-fingerprint block. Evidence:
- `curl` from the **prod IP** (bot UA, 15 details concurrently) → **15/15 = 200 + JobPosting, 0 challenge**. Spaced requests pass; it's volume that trips 429.
- The failed run logged `status 429` on the **listing** (1 request/board) for all boards — i.e. the IP is in a 429 cooldown after the detail bursts.
- `David Joseph & Company` had been frozen since 03:33 UTC (~10h) **before** #789 — so the freeze predates the fingerprint change.

## Why #789 was harmful
The shared standard client retries 429 (boards silently under-fill but `board_health` stays green). The fingerprint client (`fingerprintHTTP`) does **not** retry → boards **hard-fail** on 429 (`ingested=0 failed=3`, worker exit 1), which risks board_health cooldowns / false-closes. Reverting restores the safer baseline.

## Real fix (follow-up)
Rate-limiting is IP/volume-based → the idiomatic remedies here are **reduced detail concurrency** for careerspage and/or **proxy egress** (`proxiedProviders`, as used for eightfold/djinni/2gis). Validation must wait for the prod IP's 429 cooldown to clear.