### PR TITLE
fix(sources): route careerspage through proxy egress

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -371,6 +371,12 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// 2gis tarpits datacenter IPs (the prod IP times out at 25s); the residential proxy is
 	// served in ~2s. It uses the standard HTMLGetter, so the proxied client serves it directly.
 	"2gis": func(c HTTPClient) Source { return NewTwoGIS(c) },
+	// careers-page.com rate-limits the prod datacenter IP (429) once the per-board detail
+	// fan-out exceeds its window — every large board then under-fills silently (board_health
+	// stays green) and even the single-request listing 429s during the cooldown. Unlike the
+	// others this is volume rate-limiting, not a hard blocklist (spaced requests from the prod
+	// IP pass), so egressing through a fresh proxy IP keeps its crawl off the penalised prod IP.
+	"careerspage": func(c HTTPClient) Source { return NewCareerPage(c) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy


### PR DESCRIPTION
Real fix for careerspage under-filling on prod, after reverting the wrong fingerprint hypothesis (#789 → reverted in #790).

## Root cause
careers-page.com **rate-limits the prod datacenter IP (HTTP 429)** once the per-board detail fan-out exceeds its window. Large boards then under-fill silently (`board_health` stays green), and even the single-request listing 429s during the cooldown. This is **volume rate-limiting, not a hard blocklist** — spaced requests from the prod IP pass (verified: `curl` from prod, 15 details concurrently, 15/15 200+JobPosting).

## Fix
Add `careerspage` to `proxiedProviders` so its crawl egresses through the fresh proxy IP (`SOURCES_PROXY_URL`), off the penalised prod IP — same pattern as eightfold/djinni/2gis. One line; careerspage is on the standard client after #790, so the proxied `HTTPClient` serves it directly.

## Validation
Prod `SOURCES_PROXY_URL` is set and `cmd/ingest` calls `ApplyProxyEgress`. After deploy I'll run the careerspage ingest and confirm David Joseph refreshes + Alcor (#788) fills. Note: the prod IP is currently in a 429 cooldown from diagnosis runs; the proxy IP is independent, so the proxied crawl shouldn't be affected.