### PR TITLE
fix(sources): throttle careerspage detail concurrency (2 workers)

### DIFF
--- a/internal/sources/careerspage.go
+++ b/internal/sources/careerspage.go
@@ -29,6 +29,13 @@ func (careerspage) Provider() string { return "careerspage" }
 // page cannot loop forever (the boards seen are ~10 pages; this is ample headroom).
 const careerspageMaxPages = 100
 
+// careerspageDetailWorkers throttles the per-board detail fan-out well below the shared
+// defaultDetailWorkers (8): careers-page.com rate-limits by request volume, and a wide burst
+// trips a 429 window after ~8 requests — starving large boards even through the proxy egress
+// (see proxiedProviders). A narrow pool keeps the crawl under the window; the standard client's
+// 429-retry backoff absorbs the occasional overshoot, so a full board converges in one run.
+const careerspageDetailWorkers = 2
+
 func (s careerspage) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	base, err := url.Parse(fmt.Sprintf("https://%s.careers-page.com/", e.Board))
 	if err != nil {
@@ -62,8 +69,9 @@ func (s careerspage) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		}
 	}
 
-	// Each posting's fields come from its own detail fetch, fanned out under a bounded pool.
-	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+	// Each posting's fields come from its own detail fetch, fanned out under a narrow pool
+	// (careerspageDetailWorkers) to stay under careers-page.com's rate-limit window.
+	return fetchDetails(locs, careerspageDetailWorkers, func(loc string) (Job, bool) {
 		return s.detail(ctx, e, loc)
 	}), nil
 }


### PR DESCRIPTION
Completes the careerspage rate-limit fix.

## Context
- #789 (fingerprint) was the wrong root cause → reverted #790.
- #791 routed careerspage through proxy egress: board-level 429 hard-fails gone, provider un-froze — but the **volume** rate-limit remained. Evidence: each run fetched only ~8 of Alcor's ~40 details (`defaultDetailWorkers=8`) before careers-page.com throttled even the proxy IP; the union crept ~1/run (8→9).

## Fix
Narrow careerspage's detail fan-out to a **2-worker** pool (`careerspageDetailWorkers=2`) so the per-board burst stays under the rate-limit window. The standard client's 429-retry backoff absorbs overshoot. Proxy (fresh IP) + gentle pace = the full board should converge in one run.

## Validation
After deploy I'll run the careerspage ingest and confirm Alcor climbs toward ~40 (and David Joseph fully refreshes) with `failed=0`.