### PR TITLE
fix(sources): rebuild djinni plain-text descriptions into structural HTML

### DIFF
--- a/internal/sources/djinni.go
+++ b/internal/sources/djinni.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // djinni adapts djinni.co, a Ukrainian/CEE IT job board. Each anonymous listing page
@@ -129,7 +131,7 @@ func (p djinniPosting) toJob() (Job, bool) {
 		Title:          p.Title,
 		Company:        p.HiringOrganization.Name,
 		Location:       p.ApplicantLocationRequirements.Address.AddressCountry,
-		Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+		Description:    sanitizeHTML(djinniDescriptionHTML(p.Description)),
 		Remote:         remote,
 		WorkMode:       workModeFromRemote(remote),
 		EmploymentType: schemaEmploymentType(p.EmploymentType),
@@ -148,4 +150,73 @@ func djinniDate(s string) *time.Time {
 		return t
 	}
 	return parseDate(s)
+}
+
+// djinniBulletMarkers are the line-leading glyphs Djinni company editors use to mark list items
+// in the otherwise plain-text JSON-LD description (bullet, middle dot, triangular/hollow/filled
+// bullets, hyphen, asterisk, en/em dash). A marker counts only when it leads a line and is
+// followed by whitespace, so a mid-sentence dash, a hyphenated word, or the "*Note" footnote
+// prefix stays prose.
+var djinniBulletMarkers = map[rune]bool{
+	'•': true, '·': true, '‣': true, '◦': true, '▪': true,
+	'-': true, '*': true, '–': true, '—': true,
+}
+
+// djinniBullet reports whether a trimmed line is a bullet, returning its text with the leading
+// marker (and the space after it) removed.
+func djinniBullet(line string) (string, bool) {
+	r, size := utf8.DecodeRuneInString(line)
+	if !djinniBulletMarkers[r] {
+		return "", false
+	}
+	next, _ := utf8.DecodeRuneInString(line[size:])
+	if !unicode.IsSpace(next) {
+		return "", false // "-word" / "*Note" without a following space is prose, not a bullet
+	}
+	return strings.TrimSpace(line[size:]), true
+}
+
+// djinniDescriptionHTML rebuilds the structural HTML the {@html} consumer renders from Djinni's
+// plain-text description. The feed carries the body as newline-delimited text — blank lines
+// separate blocks, assorted leading glyphs mark bullets — with no markup, so rendered as-is every
+// newline collapses into one unbroken wall of text. This reconstructs it: a run of bullet lines
+// becomes a <ul>, a run of other text lines becomes a <p> (wrapped lines joined by <br>), and a
+// blank line closes the open block. Text is HTML-escaped because it is literal prose, not markup.
+func djinniDescriptionHTML(text string) string {
+	var out strings.Builder
+	var para, bullets []string
+	flushPara := func() {
+		if len(para) > 0 {
+			out.WriteString("<p>" + strings.Join(para, "<br>") + "</p>")
+			para = para[:0]
+		}
+	}
+	flushBullets := func() {
+		if len(bullets) > 0 {
+			out.WriteString("<ul>")
+			for _, li := range bullets {
+				out.WriteString("<li>" + li + "</li>")
+			}
+			out.WriteString("</ul>")
+			bullets = bullets[:0]
+		}
+	}
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			flushBullets()
+			flushPara()
+			continue
+		}
+		if item, ok := djinniBullet(line); ok {
+			flushPara()
+			bullets = append(bullets, html.EscapeString(item))
+			continue
+		}
+		flushBullets()
+		para = append(para, html.EscapeString(line))
+	}
+	flushBullets()
+	flushPara()
+	return out.String()
 }

--- a/internal/sources/djinni_test.go
+++ b/internal/sources/djinni_test.go
@@ -21,7 +21,7 @@ const djinniListingHTML = `<html><head>
 [{"@context":"https://schema.org/","@type":"JobPosting",
 "title":"Senior Backend Go Engineer",
 "url":"https://djinni.co/jobs/837549-senior-backend-go-engineer/",
-"description":"<p>Build &amp; ship services.</p>",
+"description":"Build & ship services.\n\nHiring process:\nA short call.\n\nWhat you will do:\n• Design APIs\n• Ship features\n\nMinimum:\n- Go\n— Postgres",
 "datePosted":"2026-07-06T04:43:20.486231",
 "employmentType":"FULL_TIME",
 "jobLocationType":"TELECOMMUTE",
@@ -128,10 +128,16 @@ func TestDjinniFetchMapsListingArray(t *testing.T) {
 	if j.Location != "UA" {
 		t.Errorf("Location = %q, want addressCountry", j.Location)
 	}
-	// sanitizeHTML keeps structural markup (bluemonday allows <p>) and re-encodes bare &,
-	// so a description round-trips as safe HTML rather than being flattened to plain text.
-	if j.Description != "<p>Build &amp; ship services.</p>" {
-		t.Errorf("Description = %q, want sanitized description HTML", j.Description)
+	// Djinni's JSON-LD description is plain text (newline-delimited, glyph-marked bullets), not
+	// markup, so the adapter rebuilds structural HTML from it: blank lines split paragraphs,
+	// consecutive text lines join with <br>, and runs of bullet lines (•, -, — all recognized)
+	// become a <ul>. Text is HTML-escaped, so a bare & round-trips as &amp;.
+	wantDesc := "<p>Build &amp; ship services.</p>" +
+		"<p>Hiring process:<br>A short call.</p>" +
+		"<p>What you will do:</p><ul><li>Design APIs</li><li>Ship features</li></ul>" +
+		"<p>Minimum:</p><ul><li>Go</li><li>Postgres</li></ul>"
+	if j.Description != wantDesc {
+		t.Errorf("Description = %q,\nwant %q", j.Description, wantDesc)
 	}
 	if !j.Remote || j.WorkMode != "remote" {
 		t.Errorf("Remote=%v WorkMode=%q, want true/remote for TELECOMMUTE", j.Remote, j.WorkMode)


### PR DESCRIPTION
## Problem

Djinni's JSON-LD `description` is newline-delimited **plain text** with glyph-marked bullets (the marker varies by company — `•`, `-`, `—`), not markup. The adapter ran it through `sanitizeHTML` alone, which treats newlines as insignificant HTML whitespace. Rendered via `{@html}`, the description collapsed into one unbroken wall of text — no paragraphs, no lists.

Reported on e.g. [data-analytics-lead-uklon](https://freehire.dev/jobs/data-analytics-lead-uklon-fxdxsrgn) vs the [djinni original](https://djinni.co/jobs/815449-data-analytics-lead/).

## Fix

New `djinniDescriptionHTML` rebuilds structure from the text before sanitizing:

- blank lines → paragraph breaks (`<p>`)
- consecutive text lines → one `<p>`, joined with `<br>`
- runs of bullet lines → `<ul><li>`
- all text HTML-escaped as literal content

A marker is recognized **only** at line start and when followed by whitespace, so mid-sentence dashes, hyphenated words, and the `*Note` footnote prefix stay prose. Verified end-to-end against the real 89-line Uklon description — paragraphs, headers, and every list reconstructed correctly.

Confirmed via sampling that **all** sampled Djinni descriptions are plain text (no HTML tags), so this is the correct universal contract for the source.

## Notes

- Fixes the **parser**; already-ingested jobs reformat on the next Djinni ingest (upsert rewrites `description`).
- Djinni ingest currently egresses through the proxy (prod IP is edge-blocked), so effect lands once it re-crawls.

## Test

`go vet` + full `internal/sources` suite pass; `djinni_test.go` updated to the real plain-text contract.