### PR TITLE
feat(sources): add PeopleForce adapter (board=subdomain, HTML listing)

### DIFF
--- a/internal/sources/peopleforce.go
+++ b/internal/sources/peopleforce.go
@@ -1,0 +1,193 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// peopleforce adapts PeopleForce career sites. The board is the tenant subdomain (e.g.
+// "gigacloud"), forming the host "<board>.peopleforce.io". The tenant's listing is
+// server-rendered HTML paginated via ?page=N, each job card linking to a
+// /careers/v/<id>-<slug> detail page. The detail page carries no schema.org JobPosting, so
+// its fields are read from the DOM: the description is the Bootstrap col-lg-8 column and a
+// <dl> sidebar holds Work type / Location. The title comes from the listing anchor (the
+// detail <h1> is the generic "Work at <Company>").
+type peopleforce struct {
+	http HTMLGetter
+}
+
+// NewPeopleForce builds the PeopleForce adapter over the given HTML client.
+func NewPeopleForce(c HTMLGetter) Source { return peopleforce{http: c} }
+
+func (peopleforce) Provider() string { return "peopleforce" }
+
+// peopleforceMaxPages caps the ?page=N walk so a listing that never yields an empty page
+// cannot loop forever (the largest boards seen are a few pages; this is ample headroom).
+const peopleforceMaxPages = 100
+
+// peopleforceListing is one job card read from a listing page: its canonical detail URL and
+// the title from the anchor text (the detail page's own <h1> is not the job title).
+type peopleforceListing struct {
+	URL   string
+	Title string
+}
+
+func (s peopleforce) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://%s.peopleforce.io/careers", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("peopleforce: board %q: %w", e.Board, err)
+	}
+
+	// Page through the listing, collecting each card's detail URL + title until a page yields
+	// no new links (the tail/empty page) or the safety cap is hit. A first-page failure is a
+	// board-level error; a later-page failure just stops the walk with what we have.
+	seen := map[string]struct{}{}
+	var cards []peopleforceListing
+	for page := 1; page <= peopleforceMaxPages; page++ {
+		listURL := fmt.Sprintf("%s?page=%d", base, page)
+		root, err := s.http.GetHTML(ctx, listURL)
+		if err != nil {
+			if page == 1 {
+				return nil, fmt.Errorf("peopleforce: listing %s: %w", e.Board, err)
+			}
+			break
+		}
+		added := 0
+		for _, c := range peopleforceListings(base, root) {
+			if _, ok := seen[c.URL]; !ok {
+				seen[c.URL] = struct{}{}
+				cards = append(cards, c)
+				added++
+			}
+		}
+		if added == 0 {
+			break
+		}
+	}
+
+	// Each posting's description and structured fields come from its own detail fetch, fanned
+	// out under the shared bounded pool.
+	return fetchDetails(cards, defaultDetailWorkers, func(c peopleforceListing) (Job, bool) {
+		return s.detail(ctx, e, c)
+	}), nil
+}
+
+// detail fetches one job's detail page and maps it to a Job, returning ok=false when the fetch
+// fails or the URL carries no native id, so the caller skips just that posting.
+func (s peopleforce) detail(ctx context.Context, e CompanyEntry, c peopleforceListing) (Job, bool) {
+	id := peopleforceJobID(c.URL)
+	if id == "" {
+		return Job{}, false
+	}
+	root, err := s.http.GetHTML(ctx, c.URL)
+	if err != nil {
+		return Job{}, false
+	}
+
+	fields := peopleforceDefList(root)
+	location := fields["Location"]
+	description := ""
+	if col := firstByClass(root, "col-lg-8"); col != nil {
+		description = sanitizeHTML(innerHTML(col))
+	}
+
+	return Job{
+		ExternalID:     id,
+		URL:            c.URL,
+		Title:          c.Title,
+		Company:        e.Company,
+		Location:       location,
+		Description:    description,
+		Remote:         isRemote(location),
+		EmploymentType: peopleforceEmploymentType(fields["Work type"]),
+	}, true
+}
+
+// peopleforceJobIDPattern captures the numeric job id from a /careers/v/<id>-<slug> URL.
+var peopleforceJobIDPattern = regexp.MustCompile(`/careers/v/(\d+)`)
+
+// peopleforceJobID extracts the native numeric job id from a detail URL, or "" when the URL
+// is not a job posting.
+func peopleforceJobID(loc string) string {
+	if m := peopleforceJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// peopleforceListings returns each job card's absolute detail URL and title from a listing
+// page, resolved against base, deduplicated by URL in first-seen order.
+func peopleforceListings(base *url.URL, root *html.Node) []peopleforceListing {
+	var out []peopleforceListing
+	seen := map[string]struct{}{}
+	walk(root, func(n *html.Node) bool {
+		if n.Type != html.ElementNode || n.Data != "a" {
+			return true
+		}
+		href := attr(n, "href")
+		if peopleforceJobID(href) == "" {
+			return true
+		}
+		ref, err := url.Parse(href)
+		if err != nil {
+			return true
+		}
+		abs := base.ResolveReference(ref).String()
+		if _, ok := seen[abs]; ok {
+			return true
+		}
+		seen[abs] = struct{}{}
+		out = append(out, peopleforceListing{URL: abs, Title: textContent(n)})
+		return true
+	})
+	return out
+}
+
+// peopleforceDefList reads the detail page's <dl> sidebar into a label→value map, pairing each
+// <dd> with its preceding <dt> (e.g. "Work type"→"Full-time", "Location"→"Kyiv").
+func peopleforceDefList(root *html.Node) map[string]string {
+	out := map[string]string{}
+	walk(root, func(n *html.Node) bool {
+		if n.Type != html.ElementNode || n.Data != "dl" {
+			return true
+		}
+		var label string
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type != html.ElementNode {
+				continue
+			}
+			switch c.Data {
+			case "dt":
+				label = textContent(c)
+			case "dd":
+				if label != "" {
+					out[label] = textContent(c)
+					label = ""
+				}
+			}
+		}
+		return false // a dl is a leaf for our purposes; do not descend further
+	})
+	return out
+}
+
+// peopleforceEmploymentType maps PeopleForce's "Work type" label onto the freehire vocabulary,
+// returning "" for an unknown or absent value so the description parser decides.
+func peopleforceEmploymentType(workType string) string {
+	switch strings.ToLower(strings.TrimSpace(workType)) {
+	case "full-time", "full time":
+		return "full_time"
+	case "part-time", "part time":
+		return "part_time"
+	case "contract", "freelance", "temporary":
+		return "contract"
+	case "internship", "intern", "trainee":
+		return "internship"
+	}
+	return ""
+}

--- a/internal/sources/peopleforce_test.go
+++ b/internal/sources/peopleforce_test.go
@@ -1,0 +1,153 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// peopleforceListingHTML is a PeopleForce careers listing page: server-rendered job cards, each
+// an <h4><a href="/careers/v/<id>-<slug>">Title</a></h4>, plus a ?page=2 pagination anchor. The
+// title is read from the anchor text (the detail page's <h1> is the generic "Work at <Company>").
+func peopleforceListingHTML(cards ...[2]string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="row">`)
+	for _, c := range cards { // c = {id-slug, title}
+		b.WriteString(`<div class="col-12"><h4><a class="stretched-link" data-turbo-frame="_top" ` +
+			`href="/careers/v/` + c[0] + `">` + c[1] + `</a></h4></div>`)
+	}
+	b.WriteString(`<nav><a href="?page=2">Next</a></nav></div></body></html>`)
+	return b.String()
+}
+
+// emptyPeopleforceListingHTML is a listing past the last page: no job cards, so the pagination
+// walk stops when it yields no new links.
+const emptyPeopleforceListingHTML = `<html><body><div class="row"></div></body></html>`
+
+// peopleforceDetailHTML is a PeopleForce job detail page: the description lives in the Bootstrap
+// col-lg-8 column, and a <dl> sidebar carries Work type / Department / Location. The description
+// embeds a <script> that sanitizeHTML must strip.
+func peopleforceDetailHTML(workType, location string) string {
+	wt := ""
+	if workType != "" {
+		wt = `<dt>Work type</dt><dd>` + workType + `</dd>`
+	}
+	return `<html><head><meta property="og:title" content="Acme - A Role"></head><body>
+<h1>Work at Acme</h1>
+<div class="row">
+  <div class="col-lg-8 col-12">
+    <h2>About the role</h2><p>Build things.</p><script>alert(1)</script>
+    <ul><li>Ship</li></ul>
+  </div>
+  <div class="col-lg-4 col-12"><dl>` + wt + `<dt>Department</dt><dd>Sales</dd>
+    <dt>Location</dt><dd>` + location + `</dd></dl></div>
+</div></body></html>`
+}
+
+func TestPeopleForceProvider(t *testing.T) {
+	if got := NewPeopleForce(nil).Provider(); got != "peopleforce" {
+		t.Errorf("Provider() = %q, want %q", got, "peopleforce")
+	}
+}
+
+func TestPeopleForceJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://acme.peopleforce.io/careers/v/222906-brand-leader": "222906",
+		"/careers/v/145060-brand-leader":                            "145060",
+		"https://acme.peopleforce.io/careers/v/145060?x=1":          "145060",
+		"https://acme.peopleforce.io/careers":                       "",
+		"/careers/v/":                                               "",
+	}
+	for loc, want := range cases {
+		if got := peopleforceJobID(loc); got != want {
+			t.Errorf("peopleforceJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestPeopleForceFetchListingThenDetailAndMaps(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("?page=1", peopleforceListingHTML([2]string{"222906-brand-leader", "Brand Leader"})).
+		route("?page=2", emptyPeopleforceListingHTML).
+		route("/careers/v/222906-brand-leader", peopleforceDetailHTML("Full-time", "Philippines/Metro Manila/Manila"))
+
+	jobs, err := NewPeopleForce(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme", Provider: "peopleforce", Board: "acme",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "222906" {
+		t.Errorf("ExternalID = %q, want 222906", j.ExternalID)
+	}
+	if j.URL != "https://acme.peopleforce.io/careers/v/222906-brand-leader" {
+		t.Errorf("URL = %q, want canonical detail URL", j.URL)
+	}
+	if j.Title != "Brand Leader" {
+		t.Errorf("Title = %q, want anchor text", j.Title)
+	}
+	if j.Company != "Acme" {
+		t.Errorf("Company = %q, want configured company", j.Company)
+	}
+	if j.Location != "Philippines/Metro Manila/Manila" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "About the role") || !strings.Contains(j.Description, "Build things") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+}
+
+func TestPeopleForcePaginatesAcrossPages(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("?page=1", peopleforceListingHTML([2]string{"1-a", "Role 1"}, [2]string{"2-b", "Role 2"})).
+		route("?page=2", peopleforceListingHTML([2]string{"3-c", "Role 3"})).
+		route("?page=3", emptyPeopleforceListingHTML).
+		route("/careers/v/1-a", peopleforceDetailHTML("Part-time", "Kyiv")).
+		route("/careers/v/2-b", peopleforceDetailHTML("", "Kyiv")).
+		route("/careers/v/3-c", peopleforceDetailHTML("Full-time", "Remote"))
+
+	jobs, err := NewPeopleForce(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3", len(jobs))
+	}
+	ids := []string{jobs[0].ExternalID, jobs[1].ExternalID, jobs[2].ExternalID}
+	for _, want := range []string{"1", "2", "3"} {
+		if !slices.Contains(ids, want) {
+			t.Errorf("missing job %q in %v", want, ids)
+		}
+	}
+}
+
+func TestPeopleForceListingErrorIsBoardError(t *testing.T) {
+	fake := &routedHTTP{} // no routes → first listing GET fails
+	if _, err := NewPeopleForce(fake).Fetch(context.Background(), CompanyEntry{Board: "acme"}); err == nil {
+		t.Fatal("want a board-level error when the first listing page fails")
+	}
+}
+
+func TestPeopleForceRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["peopleforce"]
+	if !ok {
+		t.Fatal("All() missing provider peopleforce")
+	}
+	if s.Provider() != "peopleforce" {
+		t.Errorf("All()[peopleforce].Provider() = %q", s.Provider())
+	}
+	if !slices.Contains(FilterableProviders(), "peopleforce") {
+		t.Error("FilterableProviders() should include peopleforce (board-based)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -192,6 +192,7 @@ func All(c HTTPClient) map[string]Source {
 		NewGupy(c),
 		NewSolides(c),
 		NewPersonio(c),
+		NewPeopleForce(c),
 		NewPinpoint(c),
 		NewRippling(c),
 		NewBambooHR(c),

--- a/sources/peopleforce.yml
+++ b/sources/peopleforce.yml
@@ -1,0 +1,126 @@
+# PeopleForce career sites. Provider is the filename; each entry is company + board.
+# board = the tenant subdomain (<board>.peopleforce.io); see internal/sources/peopleforce.go.
+# The listing is server-rendered HTML paged via ?page=N; each job's /careers/v/<id> detail
+# page carries the description (col-lg-8 column) and a <dl> of Work type / Location.
+- company: Acropolium
+  board: acropolium
+- company: Better Regulation Delivery Office
+  board: brdo
+- company: Brights
+  board: brights
+- company: CHOICE
+  board: choiceqr
+- company: Devlight
+  board: devlight
+- company: Legarithm
+  board: dss-legarithm
+- company: Dwarf Engineering
+  board: dwarfengineering
+- company: EasySoftGroup
+  board: easysoftgroup
+- company: Empat
+  board: empattech
+- company: Energise.pro
+  board: energisepro
+- company: EPC Network
+  board: epc
+- company: Exalate
+  board: exalate
+- company: expla
+  board: expla
+- company: Fedoriv Group
+  board: fedoriv
+- company: Fintech Farm
+  board: fintech-farm
+- company: Galaktica
+  board: galaktica
+- company: Genome
+  board: genome
+- company: GigaCloud
+  board: gigacloud
+- company: Forward Media
+  board: havasvillage
+- company: Hitapps
+  board: hitapps
+- company: ICONIC21
+  board: iconic21
+- company: Infingame
+  board: infingame
+- company: Introduct Group
+  board: introduct-tech
+- company: Ixilix
+  board: ixilix
+- company: JATAPP
+  board: jatapp
+- company: SkyUp Airlines
+  board: joinup
+- company: Kasta.ua
+  board: kasta
+- company: King Group
+  board: kinggroup
+- company: Kombine
+  board: kombine
+- company: The Kyiv Independent
+  board: kyivindependent
+- company: Lej.me
+  board: leime
+- company: LTVplus
+  board: ltvplus
+- company: LYNKSEN DIGITAL
+  board: lynksen
+- company: Magnetics.io
+  board: magnetics
+- company: Media24
+  board: media24
+- company: Frontline
+  board: miltech-1
+- company: Мрія
+  board: mriia
+- company: Multiplex
+  board: multiplex
+- company: Nov8
+  board: nove8
+- company: Pecode software
+  board: pecode
+- company: Point2Web
+  board: point2web
+- company: Creative&Tech Online Institute Projector
+  board: prjctr
+- company: Qwerty.Software
+  board: qwertysoftware
+- company: Respeecher
+  board: respeecher
+- company: REW Technology
+  board: rewtechnology
+- company: RIA.com
+  board: riacomtech
+- company: Повернись живим
+  board: savelife
+- company: Seeton
+  board: seeton
+- company: SOFTCOM
+  board: softcom
+- company: Spendbase
+  board: spendbase
+- company: Strimco
+  board: strimco
+- company: YouScan
+  board: team
+- company: Trueplay
+  board: trueplay
+- company: Trypillian
+  board: trypillian
+- company: uSoftware
+  board: unitedsoftware
+- company: You are launched
+  board: urlaunched
+- company: UTECH
+  board: utechcorp
+- company: Vyriy Drone
+  board: vyriy
+- company: Weltrade
+  board: weltrade
+- company: YouScan
+  board: youscan
+- company: Zagoriy Foundation
+  board: zagofoundation


### PR DESCRIPTION
New source adapter for PeopleForce career sites (`<board>.peopleforce.io`).

- board = tenant subdomain; server-rendered HTML listing paged `?page=N`; per-job `/careers/v/<id>` detail carries the description (col-lg-8 column) and a `<dl>` of Work type / Location.
- Ships `sources/peopleforce.yml` with 61 tenants.
- TDD unit tests + live-verified (kinggroup=50 across 5 pages, gigacloud=10 with full fields).

Ops follow-up: needs an ingest timer for the new board file; add to `proxiedProviders` only if the prod IP gets rate-limited.