### PR TITLE
fix(sources): peopleforce proxy egress + detail throttle

### DIFF
--- a/internal/sources/peopleforce.go
+++ b/internal/sources/peopleforce.go
@@ -30,6 +30,13 @@ func (peopleforce) Provider() string { return "peopleforce" }
 // cannot loop forever (the largest boards seen are a few pages; this is ample headroom).
 const peopleforceMaxPages = 100
 
+// peopleforceDetailWorkers throttles the per-board detail fan-out below the shared
+// defaultDetailWorkers (8): peopleforce.io rate-limits by request volume (429), and a wide
+// burst across 61 boards poisons the egress IP — starving later boards whose listing then
+// 429s. A narrow pool keeps each board's burst small; the crawl also egresses through the
+// proxy (see proxiedProviders) so the volume never lands on the prod IP.
+const peopleforceDetailWorkers = 3
+
 // peopleforceListing is one job card read from a listing page: its canonical detail URL and
 // the title from the anchor text (the detail page's own <h1> is not the job title).
 type peopleforceListing struct {
@@ -72,7 +79,7 @@ func (s peopleforce) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 
 	// Each posting's description and structured fields come from its own detail fetch, fanned
 	// out under the shared bounded pool.
-	return fetchDetails(cards, defaultDetailWorkers, func(c peopleforceListing) (Job, bool) {
+	return fetchDetails(cards, peopleforceDetailWorkers, func(c peopleforceListing) (Job, bool) {
 		return s.detail(ctx, e, c)
 	}), nil
 }

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -387,6 +387,12 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// SOURCES_PROXY_URL routes only this provider through the proxy with no code change; while
 	// the proxy is unset this entry is inert.
 	"cleverstaff": func(c HTTPClient) Source { return NewCleverstaff(c) },
+	// peopleforce.io rate-limits the prod datacenter IP (429): a full 61-board run's
+	// listing+detail volume poisons the IP after the first few boards, and every later
+	// board's single listing GET then 429s. Like careerspage this is volume rate-limiting,
+	// not a hard blocklist, so egressing through a fresh proxy IP keeps the crawl off the
+	// penalised prod IP; the adapter's narrow detail pool bounds the per-board burst.
+	"peopleforce": func(c HTTPClient) Source { return NewPeopleForce(c) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy


### PR DESCRIPTION
Follow-up to #798: the prod datacenter IP is volume-rate-limited (429) by peopleforce.io — a full 61-board run poisons the IP so later boards' listings 429. Route peopleforce through `SOURCES_PROXY_URL` egress (`proxiedProviders`) and narrow the per-board detail pool to 3, mirroring the careerspage fix.