### PR TITLE
feat(sources): add inhire tenants talents + talentetech

### DIFF
--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -712,3 +712,9 @@
 # --- added from a LinkedIn-sourced vacancy, validated live 2026-07-08 ---
 - company: "Woba"
   board: woba
+
+# --- recruitment-agency tenants, validated live 2026-07-16 ---
+- company: "Nexa Recruitment"
+  board: talents
+- company: "Talent & Tech"
+  board: talentetech


### PR DESCRIPTION
Adds two recruitment-agency tenants to the existing `inhire` adapter — no code change, just board entries (X-Tenant routing).

- **talents** → Nexa Recruitment (6 jobs)
- **talentetech** → Talent & Tech (13 jobs)

Validated live 2026-07-16: list API returns tenant + jobs, detail endpoint returns HTML description, emitted vacancy URL (`https://<board>.inhire.app/vagas/<uuid>`) returns 200. Full `inhire.yml` (355 boards) parses and validates against the registry.