### PR TITLE
feat(sources): harvest 10 more inhire tenants

### DIFF
--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -718,3 +718,25 @@
   board: talents
 - company: "Talent & Tech"
   board: talentetech
+
+# --- harvested via Wayback CDX + live API validation 2026-07-16 ---
+- company: "2Future"
+  board: 2future
+- company: "Blume Alimentos | OH! A Água"
+  board: blumeohaagua
+- company: "CAPEF"
+  board: capef
+- company: "GOPWR"
+  board: grupogopwr
+- company: "Icatu Seguros"
+  board: icatu
+- company: "Anhembi"
+  board: industriasanhembi
+- company: "LWSA"
+  board: lwsa
+- company: "MENA"
+  board: mena
+- company: "Pottencial"
+  board: pottencial
+- company: "Talentt"
+  board: talentt


### PR DESCRIPTION
Wayback CDX enum of `*.inhire.app` (402 subdomains) minus the 355 known boards left 54 candidates; live `X-Tenant` validation kept 10 with >0 published jobs (~99 jobs):

2Future, Blume Alimentos, CAPEF, GOPWR, Icatu Seguros, Anhembi, LWSA, MENA, Pottencial, Talentt.

Excluded inhire's own `demo` tenant (248 fake jobs). No code change — data entries on the existing adapter. Full `inhire.yml` (365 boards) parses, validates against the registry, no dup boards.