### PR TITLE
feat(sources): add CATS, Odoo, TalentLyft adapters

### DIFF
--- a/internal/sources/catsone.go
+++ b/internal/sources/catsone.go
@@ -1,0 +1,143 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// catsone adapts CATS (catsone.com) career portals. The board is the careers host — a
+// tenant subdomain (<board>.catsone.com) or a custom domain mapped to CATS (e.g.
+// jobs.<company>.com). GET /careers redirects to the portal (/careers/<portalId>) whose
+// server-rendered table lists every job as an <a class="table-row"> carrying the title
+// (.title-cell) and location (data-label="Location") in cells; the
+// /careers/<portalId>/jobs/<id> detail page holds the description (.job-description).
+// There is no pagination — the portal table lists all open jobs.
+type catsone struct {
+	http HTMLGetter
+}
+
+// NewCatsone builds the CATS adapter over the given HTML client.
+func NewCatsone(c HTMLGetter) Source { return catsone{http: c} }
+
+func (catsone) Provider() string { return "catsone" }
+
+// catsoneListing is one job row read from the portal table: its detail URL plus the title
+// and location the row cells carry (so only the description needs a detail fetch).
+type catsoneListing struct {
+	URL      string
+	Title    string
+	Location string
+}
+
+func (s catsone) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://%s/careers", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("catsone: board %q: %w", e.Board, err)
+	}
+	root, err := s.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("catsone: listing %s: %w", e.Board, err)
+	}
+	cards := catsoneListings(base, root)
+	return fetchDetails(cards, defaultDetailWorkers, func(c catsoneListing) (Job, bool) {
+		return s.detail(ctx, e, c)
+	}), nil
+}
+
+// detail fetches one job's detail page for its description, returning ok=false when the
+// fetch fails or the URL carries no native id so the caller skips just that posting.
+func (s catsone) detail(ctx context.Context, e CompanyEntry, c catsoneListing) (Job, bool) {
+	id := catsoneJobID(c.URL)
+	if id == "" {
+		return Job{}, false
+	}
+	root, err := s.http.GetHTML(ctx, c.URL)
+	if err != nil {
+		return Job{}, false
+	}
+	description := ""
+	if body := firstByClass(root, "job-description"); body != nil {
+		description = sanitizeHTML(innerHTML(body))
+	}
+	return Job{
+		ExternalID:  id,
+		URL:         c.URL,
+		Title:       c.Title,
+		Company:     e.Company,
+		Location:    c.Location,
+		Description: description,
+		Remote:      isRemote(c.Location),
+	}, true
+}
+
+// catsoneJobIDPattern captures the numeric job id from a /careers/<portalId>/jobs/<id> URL.
+var catsoneJobIDPattern = regexp.MustCompile(`/careers/\d+/jobs/(\d+)`)
+
+// catsoneJobID extracts the native numeric job id from a detail URL, or "" when the URL is
+// not a job posting.
+func catsoneJobID(loc string) string {
+	if m := catsoneJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// catsoneListings parses each job row from the portal table into its absolute detail URL,
+// title (.title-cell), and location (data-label="Location"), deduplicated by URL.
+func catsoneListings(base *url.URL, root *html.Node) []catsoneListing {
+	var out []catsoneListing
+	seen := map[string]struct{}{}
+	walk(root, func(n *html.Node) bool {
+		if n.Type != html.ElementNode || n.Data != "a" || !hasClass(n, "table-row") {
+			return true
+		}
+		href := attr(n, "href")
+		if catsoneJobID(href) == "" {
+			return true
+		}
+		ref, err := url.Parse(href)
+		if err != nil {
+			return true
+		}
+		abs := base.ResolveReference(ref).String()
+		if _, ok := seen[abs]; ok {
+			return true
+		}
+		seen[abs] = struct{}{}
+		out = append(out, catsoneListing{
+			URL:      abs,
+			Title:    nodeText(firstByClass(n, "title-cell")),
+			Location: nodeText(firstByAttr(n, "data-label", "Location")),
+		})
+		return true
+	})
+	return out
+}
+
+// nodeText is textContent guarded against a nil node (a missing cell yields "").
+func nodeText(n *html.Node) string {
+	if n == nil {
+		return ""
+	}
+	return textContent(n)
+}
+
+// firstByAttr returns the first element whose named attribute equals val, or nil.
+func firstByAttr(root *html.Node, key, val string) *html.Node {
+	var found *html.Node
+	walk(root, func(n *html.Node) bool {
+		if found != nil {
+			return false
+		}
+		if n.Type == html.ElementNode && attr(n, key) == val {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/internal/sources/catsone_test.go
+++ b/internal/sources/catsone_test.go
@@ -1,0 +1,126 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// catsoneListingHTML is a CATS portal page: a server-rendered table whose rows are
+// <a class="table-row"> anchors carrying the job's title (.title-cell) and location
+// (data-label="Location") in cells, linking to /careers/<portalId>/jobs/<id> detail pages.
+func catsoneListingHTML(rows ...[3]string) string { // row = {idSlug, title, location}
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="jobs-table"><div class="table-header">` +
+		`<div class="header-cell">Job Title</div></div>`)
+	for _, r := range rows {
+		b.WriteString(`<a class="table-row" href="/careers/90438/jobs/` + r[0] + `">` +
+			`<div class="data-cell title-cell">` + r[1] + `</div>` +
+			`<div class="data-cell" data-label="Category">General</div>` +
+			`<div class="data-cell" data-label="Location">` + r[2] + `</div></a>`)
+	}
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// catsoneDetailHTML is a CATS job detail page: the description body is the .job-description
+// element inside .job-description-container (which also carries a "View all jobs" link and a
+// repeated header). The description embeds a <script> that sanitizeHTML must strip.
+func catsoneDetailHTML() string {
+	return `<html><body><div class="job-description-container">
+<a class="view-all-jobs" href="/careers/90438">View all jobs</a>
+<div><div class="job-header"><h2>Ignored Header</h2><div class="job-tags"><div>Brazil, Remote</div></div></div>
+<hr/><div class="job-description"><p><strong>About</strong></p><p>Sell things.</p><script>alert(1)</script></div></div>
+</div></body></html>`
+}
+
+func TestCatsoneProvider(t *testing.T) {
+	if got := NewCatsone(nil).Provider(); got != "catsone" {
+		t.Errorf("Provider() = %q, want catsone", got)
+	}
+}
+
+func TestCatsoneJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://acme.catsone.com/careers/90438/jobs/16831828-sdr": "16831828",
+		"/careers/2531/jobs/8124207":                               "8124207",
+		"https://acme.catsone.com/careers/90438":                   "",
+		"/careers/90438/jobs/":                                     "",
+	}
+	for loc, want := range cases {
+		if got := catsoneJobID(loc); got != want {
+			t.Errorf("catsoneJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestCatsoneFetchListingThenDetailAndMaps(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/jobs/16831828", catsoneDetailHTML()). // detail routes first (Contains-matching)
+		route("/jobs/16823910", catsoneDetailHTML()).
+		route("/careers", catsoneListingHTML(
+			[3]string{"16831828-sdr", "Sales Development Representative (SDR)", "Brazil, Remote"},
+			[3]string{"16823910-ai", "AI Engineer", "Kyiv"}))
+
+	jobs, err := NewCatsone(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Sphere", Provider: "catsone", Board: "sphereinc.catsone.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	j, ok := byID["16831828"]
+	if !ok {
+		t.Fatalf("missing job 16831828 in %v", byID)
+	}
+	if j.URL != "https://sphereinc.catsone.com/careers/90438/jobs/16831828-sdr" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Sales Development Representative (SDR)" {
+		t.Errorf("Title = %q, want listing title-cell", j.Title)
+	}
+	if j.Company != "Sphere" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Brazil, Remote" {
+		t.Errorf("Location = %q, want listing Location cell", j.Location)
+	}
+	if !j.Remote {
+		t.Errorf("Remote = false, want true for %q", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Sell things") {
+		t.Errorf("Description lost body: %q", j.Description)
+	}
+	if strings.Contains(j.Description, "View all jobs") || strings.Contains(j.Description, "Ignored Header") {
+		t.Errorf("Description leaked chrome (header/view-all): %q", j.Description)
+	}
+}
+
+func TestCatsoneListingErrorIsBoardError(t *testing.T) {
+	if _, err := NewCatsone(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Board: "acme.catsone.com"}); err == nil {
+		t.Fatal("want a board-level error when the listing fails")
+	}
+}
+
+func TestCatsoneRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["catsone"]
+	if !ok {
+		t.Fatal("All() missing provider catsone")
+	}
+	if s.Provider() != "catsone" {
+		t.Errorf("Provider() = %q", s.Provider())
+	}
+	if !slices.Contains(FilterableProviders(), "catsone") {
+		t.Error("FilterableProviders() should include catsone")
+	}
+}

--- a/internal/sources/odoo.go
+++ b/internal/sources/odoo.go
@@ -1,0 +1,94 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// odoo adapts self-hosted Odoo recruitment sites (the website_hr_recruitment module). The
+// board is the careers host (e.g. jobs.<company>.com or <company>.com). GET /jobs is a
+// server-rendered listing whose cards link to /jobs/detail/<slug>-<id> pages carrying a
+// schema.org JobPosting expressed as microdata (itemprop): the description
+// (itemprop="description") and datePosted, with the title in the page <h1>. There is no
+// pagination — Odoo lists all published positions on the one page.
+type odoo struct {
+	http HTMLGetter
+}
+
+// NewOdoo builds the Odoo adapter over the given HTML client.
+func NewOdoo(c HTMLGetter) Source { return odoo{http: c} }
+
+func (odoo) Provider() string { return "odoo" }
+
+func (s odoo) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, err := url.Parse(fmt.Sprintf("https://%s/jobs", e.Board))
+	if err != nil {
+		return nil, fmt.Errorf("odoo: board %q: %w", e.Board, err)
+	}
+	root, err := s.http.GetHTML(ctx, base.String())
+	if err != nil {
+		return nil, fmt.Errorf("odoo: listing %s: %w", e.Board, err)
+	}
+	locs := jobLinks(base, root, func(href string) bool { return odooJobID(href) != "" })
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one job's detail page and maps its JobPosting microdata to a Job, returning
+// ok=false when the fetch fails or the page carries no id/description so the caller skips it.
+func (s odoo) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	id := odooJobID(loc)
+	if id == "" {
+		return Job{}, false
+	}
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	description := sanitizeHTML(itempropHTML(root, "description"))
+	if description == "" {
+		return Job{}, false // not a JobPosting page (or an empty stub) — skip it
+	}
+	title := firstNonEmpty(firstElementText(root, "h1"), itempropText(root, "title"))
+	location := joinNonEmpty(itempropText(root, "addressLocality"), itempropText(root, "addressCountry"))
+
+	return Job{
+		ExternalID:  id,
+		URL:         loc,
+		Title:       title,
+		Company:     e.Company,
+		Location:    location,
+		Description: description,
+		Remote:      isRemote(location),
+		PostedAt:    parseDate(itempropAttr(root, "datePosted")),
+	}, true
+}
+
+// odooJobIDPattern captures the trailing numeric id from a /jobs/<slug>-<id> or
+// /jobs/detail/<slug>-<id> URL (any leading language prefix is ignored).
+var odooJobIDPattern = regexp.MustCompile(`/jobs/(?:detail/)?[^"?#]*?-(\d+)(?:[/?#]|$)`)
+
+// odooJobID extracts the native numeric job id from a detail URL, or "" when the URL is not
+// a job posting (e.g. the /jobs listing itself).
+func odooJobID(loc string) string {
+	if m := odooJobIDPattern.FindStringSubmatch(loc); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// itempropAttr returns the datetime/content attribute of the first element carrying the given
+// schema.org itemprop (Odoo dates a posting with a datePosted whose value is an attribute, not
+// text), or "" when none is present.
+func itempropAttr(root *html.Node, prop string) string {
+	ns := findItemprops(root, prop)
+	if len(ns) == 0 {
+		return ""
+	}
+	return firstNonEmpty(attr(ns[0], "datetime"), attr(ns[0], "content"))
+}

--- a/internal/sources/odoo_test.go
+++ b/internal/sources/odoo_test.go
@@ -1,0 +1,124 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// odooListingHTML is an Odoo /jobs listing: server-rendered cards linking to
+// /jobs/detail/<slug>-<id> pages, plus a non-posting nav link that the id predicate rejects.
+func odooListingHTML(links ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="o_job_index"><a href="/jobs">All positions</a>`)
+	for _, l := range links {
+		b.WriteString(`<a href="/jobs/detail/` + l + `">A Role</a>`)
+	}
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+// odooDetailHTML is an Odoo job detail page: a schema.org JobPosting as microdata. The title
+// is the page <h1>; the description is itemprop="description"; datePosted is a content attr.
+func odooDetailHTML(title string) string {
+	return `<html><body itemscope itemtype="https://schema.org/JobPosting">
+<h1 itemprop="title">` + title + `</h1>
+<span itemprop="datePosted" content="2026-07-10">Jul 10</span>
+<span itemprop="addressLocality">Kyiv</span><span itemprop="addressCountry">Ukraine</span>
+<div itemprop="description"><p>Build things.</p><script>alert(1)</script></div>
+</body></html>`
+}
+
+func TestOdooProvider(t *testing.T) {
+	if got := NewOdoo(nil).Provider(); got != "odoo" {
+		t.Errorf("Provider() = %q, want odoo", got)
+	}
+}
+
+func TestOdooJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://jobs.acme.com/jobs/detail/recruiter-157":         "157",
+		"/en_US/jobs/detail/full-stack-python-developer-1":        "1",
+		"https://acme.com/jobs/analista-de-facilities-2621":       "2621",
+		"https://acme.com/jobs/detail/senior-ios-developer-2?x=1": "2",
+		"https://acme.com/jobs":                                   "",
+	}
+	for loc, want := range cases {
+		if got := odooJobID(loc); got != want {
+			t.Errorf("odooJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestOdooFetchListingThenDetailAndMaps(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/jobs/detail/recruiter-157", odooDetailHTML("Recruiter")).
+		route("/jobs", odooListingHTML("recruiter-157"))
+
+	jobs, err := NewOdoo(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Ameware", Provider: "odoo", Board: "jobs.amewaregroup.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "157" {
+		t.Errorf("ExternalID = %q, want 157", j.ExternalID)
+	}
+	if j.URL != "https://jobs.amewaregroup.com/jobs/detail/recruiter-157" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Recruiter" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Ameware" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Kyiv, Ukraine" {
+		t.Errorf("Location = %q, want %q", j.Location, "Kyiv, Ukraine")
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-07-10", j.PostedAt)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Build things") {
+		t.Errorf("Description lost body: %q", j.Description)
+	}
+}
+
+func TestOdooDropsDetailWithoutJobPosting(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("/jobs/detail/good-1", odooDetailHTML("Good")).
+		route("/jobs/detail/bare-2", `<html><body>no microdata</body></html>`).
+		route("/jobs", odooListingHTML("good-1", "bare-2"))
+
+	jobs, err := NewOdoo(fake).Fetch(context.Background(), CompanyEntry{Board: "acme.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "1" {
+		t.Fatalf("got %v, want only the posting with a JobPosting description", jobs)
+	}
+}
+
+func TestOdooListingErrorIsBoardError(t *testing.T) {
+	if _, err := NewOdoo(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Board: "acme.com"}); err == nil {
+		t.Fatal("want a board-level error when the listing fails")
+	}
+}
+
+func TestOdooRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["odoo"]
+	if !ok {
+		t.Fatal("All() missing provider odoo")
+	}
+	if s.Provider() != "odoo" {
+		t.Errorf("Provider() = %q", s.Provider())
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -195,6 +195,7 @@ func All(c HTTPClient) map[string]Source {
 		NewPeopleForce(c),
 		NewCatsone(c),
 		NewOdoo(c),
+		NewTalentLyft(c),
 		NewPinpoint(c),
 		NewRippling(c),
 		NewBambooHR(c),

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -193,6 +193,7 @@ func All(c HTTPClient) map[string]Source {
 		NewSolides(c),
 		NewPersonio(c),
 		NewPeopleForce(c),
+		NewCatsone(c),
 		NewPinpoint(c),
 		NewRippling(c),
 		NewBambooHR(c),

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -194,6 +194,7 @@ func All(c HTTPClient) map[string]Source {
 		NewPersonio(c),
 		NewPeopleForce(c),
 		NewCatsone(c),
+		NewOdoo(c),
 		NewPinpoint(c),
 		NewRippling(c),
 		NewBambooHR(c),

--- a/internal/sources/talentlyft.go
+++ b/internal/sources/talentlyft.go
@@ -1,0 +1,115 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"golang.org/x/net/html"
+)
+
+// talentlyft adapts TalentLyft career sites. The board is the tenant subdomain (e.g.
+// "inetec"), forming the host "<board>.talentlyft.com". The tenant's sitemap.xml enumerates
+// every /jobs/<slug>-<code> posting, and each posting page server-renders a schema.org
+// JobPosting ld+json — the dataart/SuccessFactors shape (sitemap to enumerate, per-posting
+// detail fetch for the posting) over the shared ld+json helper.
+type talentlyft struct {
+	http talentlyftHTTP
+}
+
+// talentlyftHTTP is the transport talentlyft needs: the XML sitemap plus HTML detail pages.
+type talentlyftHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+// NewTalentLyft builds the TalentLyft adapter over the given HTTP client.
+func NewTalentLyft(c talentlyftHTTP) Source { return talentlyft{http: c} }
+
+func (talentlyft) Provider() string { return "talentlyft" }
+
+func (s talentlyft) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var sitemap struct {
+		URLs []struct {
+			Loc string `xml:"loc"`
+		} `xml:"url"`
+	}
+	sitemapURL := fmt.Sprintf("https://%s.talentlyft.com/sitemap.xml", e.Board)
+	if err := s.http.GetXML(ctx, sitemapURL, &sitemap); err != nil {
+		return nil, fmt.Errorf("talentlyft: sitemap %s: %w", e.Board, err)
+	}
+
+	// Keep only posting URLs (the listing root and section pages carry no job code).
+	var urls []string
+	for _, u := range sitemap.URLs {
+		if talentlyftJobID(u.Loc) != "" {
+			urls = append(urls, u.Loc)
+		}
+	}
+
+	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return s.detail(ctx, e, u)
+	}), nil
+}
+
+// detail fetches one posting page and maps its JobPosting ld+json to a Job, returning ok=false
+// when the URL has no code, the fetch fails, or the page carries no JobPosting, so the caller
+// skips just that posting.
+func (s talentlyft) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, bool) {
+	id := talentlyftJobID(jobURL)
+	if id == "" {
+		return Job{}, false
+	}
+	root, err := s.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p talentlyftPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false
+	}
+	location := joinNonEmpty(
+		p.JobLocation.Address.AddressLocality,
+		p.JobLocation.Address.AddressCountry,
+	)
+	return Job{
+		ExternalID:     id,
+		URL:            jobURL,
+		Title:          p.Title,
+		Company:        e.Company,
+		Location:       location,
+		Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:         isRemote(location),
+		EmploymentType: schemaEmploymentType(p.EmploymentType),
+		PostedAt:       parseDate(p.DatePosted),
+	}, true
+}
+
+// talentlyftJobIDPattern captures the trailing code from a /jobs/<slug>-<code> URL (the
+// human slug carries the TalentLyft posting code as its final hyphen segment). The greedy
+// prefix backtracks to the LAST hyphen, so a multi-word slug still yields just the code.
+var talentlyftJobIDPattern = regexp.MustCompile(`/jobs/.+-([A-Za-z0-9]{3,})$`)
+
+// talentlyftJobID extracts the native posting code from a detail URL, or "" for the listing
+// root and section pages that carry no code.
+func talentlyftJobID(loc string) string {
+	if m := talentlyftJobIDPattern.FindStringSubmatch(trimURLSuffix(loc)); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// talentlyftPosting is the schema.org JobPosting decoded from a TalentLyft posting page's
+// ld+json. jobLocation is a single Place.
+type talentlyftPosting struct {
+	Title          string `json:"title"`
+	Description    string `json:"description"`
+	DatePosted     string `json:"datePosted"`
+	EmploymentType string `json:"employmentType"`
+	JobLocation    struct {
+		Address struct {
+			AddressLocality string `json:"addressLocality"`
+			AddressCountry  string `json:"addressCountry"`
+		} `json:"address"`
+	} `json:"jobLocation"`
+}

--- a/internal/sources/talentlyft_test.go
+++ b/internal/sources/talentlyft_test.go
@@ -1,0 +1,120 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// talentlyftSitemapXML is a TalentLyft tenant sitemap: <loc> entries for postings
+// (/jobs/<slug>-<code>) plus the listing root, which carries no code and must be skipped.
+func talentlyftSitemapXML(host string, jobPaths ...string) string {
+	var b strings.Builder
+	b.WriteString(`<?xml version="1.0"?><urlset>`)
+	for _, p := range jobPaths {
+		b.WriteString(`<url><loc>https://` + host + p + `</loc></url>`)
+	}
+	b.WriteString(`<url><loc>https://` + host + `</loc></url></urlset>`)
+	return b.String()
+}
+
+// talentlyftDetailHTML is a TalentLyft posting page carrying a schema.org JobPosting ld+json.
+// The description embeds a <script> (escaped) that sanitizeHTML must strip.
+func talentlyftDetailHTML(title string) string {
+	return `<html><body>
+<script type="application/ld+json">
+{"context":"https://schema.org/","@type":"JobPosting","title":"` + title + `",
+"description":"<p>Build eddy current instruments.</p><script>alert(1)<\/script>",
+"datePosted":"2026-06-23","employmentType":"FULL_TIME",
+"hiringOrganization":{"@type":"Organization","name":"INETEC"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"Donji Stupnik","addressCountry":"Croatia"}}}
+</script></body></html>`
+}
+
+func TestTalentLyftProvider(t *testing.T) {
+	if got := NewTalentLyft(nil).Provider(); got != "talentlyft" {
+		t.Errorf("Provider() = %q, want talentlyft", got)
+	}
+}
+
+func TestTalentLyftJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://inetec.talentlyft.com/jobs/senior-electronics-engineer-cjVz":                 "cjVz",
+		"https://flyer.talentlyft.com/matchmatch/jobs/creative-marketing-manager-attain-chMH": "chMH",
+		"https://inetec.talentlyft.com/jobs/role-cj4t?utm=x":                                  "cj4t",
+		"https://inetec.talentlyft.com":                                                       "",
+		"https://flyer.talentlyft.com/matchmatch":                                             "",
+	}
+	for loc, want := range cases {
+		if got := talentlyftJobID(loc); got != want {
+			t.Errorf("talentlyftJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestTalentLyftFetchSitemapThenDetailAndMaps(t *testing.T) {
+	host := "inetec.talentlyft.com"
+	fake := (&routedHTTP{}).
+		route("sitemap.xml", talentlyftSitemapXML(host, "/jobs/senior-electronics-engineer-cjVz")).
+		route("/jobs/senior-electronics-engineer-cjVz", talentlyftDetailHTML("Senior Electronics Engineer"))
+
+	jobs, err := NewTalentLyft(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "INETEC d.o.o.", Provider: "talentlyft", Board: "inetec",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (root skipped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "cjVz" {
+		t.Errorf("ExternalID = %q, want cjVz", j.ExternalID)
+	}
+	if j.URL != "https://inetec.talentlyft.com/jobs/senior-electronics-engineer-cjVz" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Senior Electronics Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "INETEC d.o.o." {
+		t.Errorf("Company = %q, want configured company", j.Company)
+	}
+	if j.Location != "Donji Stupnik, Croatia" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-06-23", j.PostedAt)
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "eddy current") {
+		t.Errorf("Description lost body: %q", j.Description)
+	}
+}
+
+func TestTalentLyftSitemapErrorIsBoardError(t *testing.T) {
+	if _, err := NewTalentLyft(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Board: "inetec"}); err == nil {
+		t.Fatal("want a board-level error when the sitemap fails")
+	}
+}
+
+func TestTalentLyftRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["talentlyft"]
+	if !ok {
+		t.Fatal("All() missing provider talentlyft")
+	}
+	if s.Provider() != "talentlyft" {
+		t.Errorf("Provider() = %q", s.Provider())
+	}
+	if !slices.Contains(FilterableProviders(), "talentlyft") {
+		t.Error("FilterableProviders() should include talentlyft")
+	}
+}

--- a/sources/catsone.yml
+++ b/sources/catsone.yml
@@ -1,0 +1,12 @@
+# CATS (catsone.com) career portals. Provider is the filename; each entry is company + board.
+# board = the careers host: a tenant subdomain (<board>.catsone.com) or a custom domain mapped
+# to CATS (e.g. jobs.<company>.com). See internal/sources/catsone.go. GET /careers redirects to
+# the portal table listing every job; the /careers/<portalId>/jobs/<id> detail carries the body.
+- company: Authority Partners
+  board: authoritypartnersinc.catsone.com
+- company: Business & Finance Consulting
+  board: bfc.catsone.com
+- company: EVOPLAY
+  board: jobs.evoplay.com.ua
+- company: Sphere Partners
+  board: sphereinc.catsone.com

--- a/sources/odoo.yml
+++ b/sources/odoo.yml
@@ -1,0 +1,10 @@
+# Self-hosted Odoo recruitment sites (website_hr_recruitment module). Provider is the
+# filename; each entry is company + board. board = the careers host. GET /jobs lists every
+# position; the /jobs/detail/<slug>-<id> detail carries a schema.org JobPosting as microdata.
+# See internal/sources/odoo.go. (odoo.com itself is excluded — its detail structure diverges.)
+- company: Ameware Group
+  board: jobs.amewaregroup.com
+- company: ERP Ukraine
+  board: erp.co.ua
+- company: Garazd Creation
+  board: garazd.biz

--- a/sources/talentlyft.yml
+++ b/sources/talentlyft.yml
@@ -1,0 +1,10 @@
+# TalentLyft career sites. Provider is the filename; each entry is company + board.
+# board = the tenant subdomain (<board>.talentlyft.com); see internal/sources/talentlyft.go.
+# The tenant's sitemap.xml enumerates every /jobs/<slug>-<code> posting, each carrying a
+# schema.org JobPosting ld+json the adapter maps into a posting.
+- company: Inetec d.o.o.
+  board: inetec
+- company: Flyer One Ventures
+  board: flyer-one-ventures
+- company: Selecto
+  board: selecto


### PR DESCRIPTION
Three new multi-tenant ATS adapters (source-discovery follow-up):

- **CATS** (`catsone.com`) — portal table listing (title+location in cells) + `/careers/<pid>/jobs/<id>` detail (`.job-description`). 4 tenants.
- **Odoo** (self-hosted `website_hr_recruitment`) — `/jobs` listing → `/jobs/(detail/)<slug>-<id>` JobPosting **microdata** (itemprop description + datePosted). 3 tenants. (odoo.com excluded — divergent structure.)
- **TalentLyft** (`<board>.talentlyft.com`) — `sitemap.xml` enumerates postings → JobPosting **ld+json** detail. 3 tenants.

Each: TDD unit tests + live-verified (CATS sphereinc=13, Odoo amewaregroup=11, TalentLyft inetec=9). Low tenant counts → direct ingest (no proxy needed). SageHR was investigated and deferred — no stable public listing URL, harvested URLs dead.