### PR TITLE
feat(sources): add Ubiminds lever board

### DIFF
--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -718,3 +718,25 @@
   board: talents
 - company: "Talent & Tech"
   board: talentetech
+
+# --- harvested via Wayback CDX + live API validation 2026-07-16 ---
+- company: "2Future"
+  board: 2future
+- company: "Blume Alimentos | OH! A Água"
+  board: blumeohaagua
+- company: "CAPEF"
+  board: capef
+- company: "GOPWR"
+  board: grupogopwr
+- company: "Icatu Seguros"
+  board: icatu
+- company: "Anhembi"
+  board: industriasanhembi
+- company: "LWSA"
+  board: lwsa
+- company: "MENA"
+  board: mena
+- company: "Pottencial"
+  board: pottencial
+- company: "Talentt"
+  board: talentt

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -772,6 +772,8 @@
   board: trellis
 - company: Trendyol
   board: trendyol
+- company: Ubiminds
+  board: Ubiminds
 - company: UntilLabs
   board: until
 - company: Valkyrie Trading


### PR DESCRIPTION
Adds the Ubiminds Lever board (22 live postings, Brazil-focused) to `sources/lever.yml`.

Verified live: `api.lever.co/v0/postings/Ubiminds?mode=json` returns 200 with 22 postings; the specific posting from the LinkedIn link resolves 200.

Keyless JSON adapter already exists — one-line source addition.