### PR TITLE
feat(sources): add onstrider (Strider) LATAM marketplace adapter

### DIFF
--- a/internal/sources/onstrider.go
+++ b/internal/sources/onstrider.go
@@ -1,0 +1,181 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// onstrider adapts Strider's careers site (www.onstrider.com), a HubSpot-hosted LATAM talent
+// marketplace. It is the DataArt shape — the sitemap enumerates every vacancy URL and each OPEN
+// vacancy page server-renders a schema.org JobPosting ld+json block, so this adapter enumerates
+// from the sitemap and maps per-vacancy details over the shared fetchDetails + ldJobPosting
+// helpers. A CLOSED vacancy keeps its sitemap URL (still HTTP 200) but drops the JobPosting
+// markup, so its absence is the open/closed signal — detail() returns ok=false and it is
+// dropped. The real employer is hidden (hiringOrganization is always "Strider"), so every
+// posting maps to the single board-file company; the adapter is boardless single-company.
+type onstrider struct {
+	http onstriderHTTP
+}
+
+// onstriderHTTP is the transport onstrider needs: the XML sitemap plus HTML detail pages.
+type onstriderHTTP interface {
+	XMLGetter
+	HTMLGetter
+}
+
+const onstriderSitemapURL = "https://www.onstrider.com/sitemap.xml"
+
+// NewOnstrider builds the onstrider adapter over the given HTTP client.
+func NewOnstrider(c onstriderHTTP) Source { return onstrider{http: c} }
+
+func (onstrider) Provider() string { return "onstrider" }
+
+// onstrider is single-company (the real employer is hidden), so its config entry carries no board.
+func (onstrider) boardless() {}
+
+func (s onstrider) Fetch(ctx context.Context, ce CompanyEntry) ([]Job, error) {
+	var sitemap struct {
+		URLs []struct {
+			Loc string `xml:"loc"`
+		} `xml:"url"`
+	}
+	if err := s.http.GetXML(ctx, onstriderSitemapURL, &sitemap); err != nil {
+		return nil, fmt.Errorf("onstrider: sitemap: %w", err)
+	}
+
+	// Keep only canonical vacancy URLs: the sitemap also carries blog, marketing, localized
+	// (/pt/, /en/), and /preview-slug-…/ duplicate URLs, none of which are ingestable vacancies.
+	var urls []string
+	for _, u := range sitemap.URLs {
+		if onstriderVacancyURL(u.Loc) {
+			urls = append(urls, u.Loc)
+		}
+	}
+
+	jobs := fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
+		return s.detail(ctx, ce, u)
+	})
+	// The sitemap listed vacancies but not one detail mapped — every fetch was blocked or empty
+	// (the Cloudflare edge can 403 the prod datacenter IP for the detail pages while the CDN
+	// still serves the sitemap). Fail the board rather than return an empty success, which the
+	// post-run unseen sweep would read as "all vacancies gone" and false-close the catalogue.
+	if len(urls) > 0 && len(jobs) == 0 {
+		return nil, fmt.Errorf("onstrider: %d vacancy URLs but 0 mapped; treating as a fetch failure", len(urls))
+	}
+	return jobs, nil
+}
+
+// detail fetches one vacancy page and maps its JobPosting ld+json to a Job. It returns ok=false
+// when the fetch fails, the page carries no JobPosting block (a closed vacancy), or the posting
+// has no identifier.value (no dedup key) — so the caller drops just that vacancy.
+func (s onstrider) detail(ctx context.Context, ce CompanyEntry, jobURL string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, jobURL)
+	if err != nil {
+		return Job{}, false
+	}
+	var p onstriderPosting
+	if !ldJobPosting(root, &p) {
+		return Job{}, false // closed vacancy: JobPosting markup dropped
+	}
+	if p.Identifier.Value == "" {
+		return Job{}, false // no native id → would collide on the dedup key; skip it
+	}
+	remote := strings.EqualFold(p.JobLocationType, "TELECOMMUTE")
+	return Job{
+		ExternalID:     p.Identifier.Value,
+		URL:            jobURL,
+		Title:          p.Title,
+		Company:        ce.Company,
+		Location:       p.location(),
+		Description:    sanitizeHTML(p.Description),
+		Remote:         remote,
+		WorkMode:       workModeFromRemote(remote),
+		EmploymentType: schemaEmploymentType(p.firstEmploymentType()),
+		PostedAt:       parseDate(p.DatePosted),
+	}, true
+}
+
+// onstriderVacancyURLPattern matches a canonical vacancy URL
+// (https://www.onstrider.com/jobs/<slug>-<8hex>). Anchoring /jobs/ directly after the host
+// excludes the /pt/ + /en/ localizations and the /preview-slug-<uuid>/… duplicate pages;
+// requiring the trailing 8-hex id excludes the /jobs listing root and marketing pages.
+var onstriderVacancyURLPattern = regexp.MustCompile(`^https?://www\.onstrider\.com/jobs/[a-z0-9-]+-[0-9a-f]{8}/?$`)
+
+// onstriderVacancyURL reports whether u is a canonical vacancy URL.
+func onstriderVacancyURL(u string) bool { return onstriderVacancyURLPattern.MatchString(u) }
+
+// onstriderPosting is the schema.org JobPosting decoded from a vacancy page's ld+json. identifier
+// is a PropertyValue whose value is the vacancy UUID; applicantLocationRequirements is an array
+// of Country nodes; employmentType is an array; jobLocationType is the remote signal.
+type onstriderPosting struct {
+	Title           string `json:"title"`
+	Description     string `json:"description"`
+	DatePosted      string `json:"datePosted"`
+	JobLocationType string `json:"jobLocationType"`
+	// EmploymentType is raw because schema.org permits either a single string ("FULL_TIME") or
+	// an array (["PART_TIME","CONTRACTOR"]); decoding it into a fixed []string would fail on the
+	// scalar form and — since ldJobPosting drops a posting whose decode errors — silently discard
+	// an otherwise-open vacancy. firstEmploymentType parses both shapes.
+	EmploymentType json.RawMessage `json:"employmentType"`
+	Identifier     struct {
+		Value string `json:"value"`
+	} `json:"identifier"`
+	ApplicantLocationRequirements []struct {
+		Name string `json:"name"`
+	} `json:"applicantLocationRequirements"`
+}
+
+// location joins the applicant-location-requirement countries (the hidden employer means there is
+// no city, only the countries a candidate may apply from), expanding each ISO 3166-1 alpha-2 code
+// to its English country name. The expansion matters: the location parser deliberately reads a
+// bare 2-letter token as a US subdivision before an ISO country code (so "CO"→Colorado, "AR"→
+// Arkansas, "PA"→Pennsylvania), which would mis-place these LATAM postings in the US. The full
+// name resolves unambiguously to the country. An unmapped code falls back to itself.
+func (p onstriderPosting) location() string {
+	var out []string
+	for _, c := range p.ApplicantLocationRequirements {
+		if c.Name == "" {
+			continue
+		}
+		if name, ok := onstriderCountryNames[strings.ToUpper(c.Name)]; ok {
+			out = append(out, name)
+		} else {
+			out = append(out, c.Name)
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+// onstriderCountryNames expands the ISO 3166-1 alpha-2 country codes onstrider emits into the
+// English names the location parser resolves without the US-subdivision collision. Strider is a
+// Latin-America talent marketplace, so this covers Latin America; an out-of-region code (rare for
+// this source) falls back to the raw code, which the parser handles directly when unambiguous.
+var onstriderCountryNames = map[string]string{
+	"AR": "Argentina", "BO": "Bolivia", "BR": "Brazil", "CL": "Chile",
+	"CO": "Colombia", "CR": "Costa Rica", "CU": "Cuba", "DO": "Dominican Republic",
+	"EC": "Ecuador", "GT": "Guatemala", "HN": "Honduras", "MX": "Mexico",
+	"NI": "Nicaragua", "PA": "Panama", "PE": "Peru", "PR": "Puerto Rico",
+	"PY": "Paraguay", "SV": "El Salvador", "UY": "Uruguay", "VE": "Venezuela",
+}
+
+// firstEmploymentType returns the first schema.org employmentType enum, accepting either shape
+// the spec permits: a JSON array (["PART_TIME","CONTRACTOR"]) or a bare string ("FULL_TIME").
+// It returns "" when the field is absent or unparseable, leaving the value to the parser.
+func (p onstriderPosting) firstEmploymentType() string {
+	if len(p.EmploymentType) == 0 {
+		return ""
+	}
+	var arr []string
+	if json.Unmarshal(p.EmploymentType, &arr) == nil {
+		if len(arr) > 0 {
+			return arr[0]
+		}
+		return ""
+	}
+	var one string
+	_ = json.Unmarshal(p.EmploymentType, &one)
+	return one
+}

--- a/internal/sources/onstrider_test.go
+++ b/internal/sources/onstrider_test.go
@@ -1,0 +1,220 @@
+package sources
+
+import (
+	"context"
+	"testing"
+)
+
+// onstriderDetailHTML builds an onstrider vacancy page carrying a schema.org JobPosting ld+json
+// block in the site's real shape: identifier is a PropertyValue object (value is the UUID),
+// applicantLocationRequirements and employmentType are arrays, jobLocationType is the remote
+// signal, and the description is already HTML (not double-escaped).
+func onstriderDetailHTML(id, title, description, datePosted, jobLocationType string, countries ...string) string {
+	var alr string
+	for i, c := range countries {
+		if i > 0 {
+			alr += ","
+		}
+		alr += `{"@type":"Country","name":"` + c + `"}`
+	}
+	return `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"JobPosting",` +
+		`"title":"` + title + `",` +
+		`"description":"` + description + `",` +
+		`"identifier":{"@type":"PropertyValue","name":"Strider","value":"` + id + `"},` +
+		`"datePosted":"` + datePosted + `",` +
+		`"employmentType":["PART_TIME","CONTRACTOR"],` +
+		`"jobLocationType":"` + jobLocationType + `",` +
+		`"applicantLocationRequirements":[` + alr + `]}` +
+		`</script></head><body></body></html>`
+}
+
+func onstriderSitemapXML(locs ...string) string {
+	s := `<?xml version="1.0" encoding="UTF-8"?><urlset>`
+	for _, l := range locs {
+		s += `<url><loc>` + l + `</loc></url>`
+	}
+	return s + `</urlset>`
+}
+
+func TestOnstriderDetailMapsJobPosting(t *testing.T) {
+	jobURL := "https://www.onstrider.com/jobs/full-stack-engineer-975f80e4"
+	detail := onstriderDetailHTML(
+		"975f80e4-ee1e-4652-b18c-d2defecf83aa",
+		"Full-stack Engineer",
+		"<ul><li>Build <b>things</b></li></ul>",
+		"2024-10-01",
+		"TELECOMMUTE",
+		"BR", "MX", "CO", "AR")
+	fake := (&routedHTTP{}).route("/jobs/full-stack-engineer-975f80e4", detail)
+
+	j, ok := onstrider{http: fake}.detail(context.Background(),
+		CompanyEntry{Company: "Strider", Provider: "onstrider"}, jobURL)
+	if !ok {
+		t.Fatal("detail returned ok=false for an open vacancy")
+	}
+	if j.ExternalID != "975f80e4-ee1e-4652-b18c-d2defecf83aa" {
+		t.Errorf("ExternalID = %q, want the identifier.value UUID", j.ExternalID)
+	}
+	if j.URL != jobURL {
+		t.Errorf("URL = %q, want %q", j.URL, jobURL)
+	}
+	if j.Title != "Full-stack Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Strider" {
+		t.Errorf("Company = %q, want Strider (real employer is hidden)", j.Company)
+	}
+	// The description is already HTML (not double-escaped); sanitizeHTML keeps safe tags.
+	if want := "<ul><li>Build <b>things</b></li></ul>"; j.Description != want {
+		t.Errorf("Description = %q, want %q (HTML sanitized)", j.Description, want)
+	}
+	// ISO codes expand to English country names so the location parser resolves them as LATAM
+	// countries, not the US subdivisions the bare codes CO/AR collide with.
+	if j.Location != "Brazil, Mexico, Colombia, Argentina" {
+		t.Errorf("Location = %q, want expanded country names", j.Location)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote/WorkMode = %v/%q, want true/remote (jobLocationType TELECOMMUTE)", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "part_time" {
+		t.Errorf("EmploymentType = %q, want part_time (first of the employmentType array)", j.EmploymentType)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2024-10-01" {
+		t.Errorf("PostedAt = %v, want 2024-10-01", j.PostedAt)
+	}
+}
+
+func TestOnstriderDropsClosedVacancy(t *testing.T) {
+	// A closed vacancy keeps its URL but drops the JobPosting markup — only an Organization
+	// ld+json block remains, so detail() must return ok=false.
+	closed := `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"Organization","name":"Strider"}` +
+		`</script></head><body></body></html>`
+	fake := (&routedHTTP{}).route("/jobs/closed-role-0f0f72b5", closed)
+
+	if _, ok := (onstrider{http: fake}).detail(context.Background(),
+		CompanyEntry{Company: "Strider"}, "https://www.onstrider.com/jobs/closed-role-0f0f72b5"); ok {
+		t.Error("detail returned ok=true for a closed vacancy (no JobPosting block)")
+	}
+}
+
+func TestOnstriderDropsPostingWithoutIdentifier(t *testing.T) {
+	// A JobPosting whose identifier.value is empty has no dedup key and must be dropped.
+	detail := onstriderDetailHTML("", "No ID Role", "<p>x</p>", "2026-01-02", "TELECOMMUTE", "BR")
+	fake := (&routedHTTP{}).route("/jobs/no-id-role-12345678", detail)
+
+	if _, ok := (onstrider{http: fake}).detail(context.Background(),
+		CompanyEntry{Company: "Strider"}, "https://www.onstrider.com/jobs/no-id-role-12345678"); ok {
+		t.Error("detail returned ok=true for a posting with an empty identifier.value")
+	}
+}
+
+func TestOnstriderFetchFiltersSitemapToVacancies(t *testing.T) {
+	jobURL := "https://www.onstrider.com/jobs/full-stack-engineer-975f80e4"
+	fake := (&routedHTTP{}).
+		route("sitemap.xml", onstriderSitemapXML(
+			jobURL,
+			"https://www.onstrider.com/preview-slug-0f985246-f06e-5582cab4c338/mobile-engineer-53604156", // preview dup
+			"https://www.onstrider.com/pt/blog/linguagens-de-programacao",                                // blog
+			"https://www.onstrider.com/hire/express-developers",                                          // marketing
+			"https://www.onstrider.com/jobs",                                                             // listing root
+		)).
+		route("/jobs/full-stack-engineer-975f80e4",
+			onstriderDetailHTML("975f80e4-ee1e-4652-b18c-d2defecf83aa",
+				"Full-stack Engineer", "<p>x</p>", "2024-10-01", "TELECOMMUTE", "BR"))
+
+	jobs, err := NewOnstrider(fake).Fetch(context.Background(),
+		CompanyEntry{Company: "Strider", Provider: "onstrider"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (only the canonical /jobs/<slug>-<8hex> URL is a vacancy)", len(jobs))
+	}
+	if jobs[0].ExternalID != "975f80e4-ee1e-4652-b18c-d2defecf83aa" {
+		t.Errorf("ExternalID = %q", jobs[0].ExternalID)
+	}
+}
+
+func TestOnstriderScalarEmploymentTypeIsNotDropped(t *testing.T) {
+	// schema.org permits employmentType as a bare string; the posting must still map (a fixed
+	// []string decode would error and ldJobPosting would silently drop the open vacancy).
+	detail := `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"JobPosting",` +
+		`"title":"Solo Eng","description":"<p>x</p>",` +
+		`"identifier":{"@type":"PropertyValue","value":"11111111-2222-3333-4444-555555555555"},` +
+		`"employmentType":"FULL_TIME","jobLocationType":"TELECOMMUTE",` +
+		`"applicantLocationRequirements":[{"@type":"Country","name":"BR"}]}` +
+		`</script></head><body></body></html>`
+	fake := (&routedHTTP{}).route("/jobs/solo-eng-11111111", detail)
+
+	j, ok := (onstrider{http: fake}).detail(context.Background(),
+		CompanyEntry{Company: "Strider"}, "https://www.onstrider.com/jobs/solo-eng-11111111")
+	if !ok {
+		t.Fatal("detail returned ok=false for a scalar employmentType (posting was dropped)")
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time (from the scalar employmentType)", j.EmploymentType)
+	}
+}
+
+func TestOnstriderFetchFailsWhenNoVacancyMaps(t *testing.T) {
+	// The sitemap lists a vacancy but its detail is closed (no JobPosting) → 0 jobs. Fetch must
+	// return an error, not an empty success, so the unseen sweep does not false-close the catalogue.
+	closed := `<html><head><script type="application/ld+json">` +
+		`{"@context":"https://schema.org/","@type":"Organization","name":"Strider"}` +
+		`</script></head><body></body></html>`
+	fake := (&routedHTTP{}).
+		route("sitemap.xml", onstriderSitemapXML("https://www.onstrider.com/jobs/closed-role-0f0f72b5")).
+		route("/jobs/closed-role-0f0f72b5", closed)
+
+	if _, err := NewOnstrider(fake).Fetch(context.Background(),
+		CompanyEntry{Company: "Strider", Provider: "onstrider"}); err == nil {
+		t.Error("Fetch returned nil error when the sitemap had vacancy URLs but none mapped")
+	}
+}
+
+func TestOnstriderLocationExpandsCountryCodes(t *testing.T) {
+	// Known LATAM codes expand to names; an unmapped code (that collides with a US state) is
+	// kept raw as a graceful fallback rather than dropped.
+	p := onstriderPosting{ApplicantLocationRequirements: []struct {
+		Name string `json:"name"`
+	}{{Name: "PA"}, {Name: "PE"}, {Name: "ZZ"}}}
+	if got, want := p.location(), "Panama, Peru, ZZ"; got != want {
+		t.Errorf("location() = %q, want %q", got, want)
+	}
+}
+
+func TestOnstriderVacancyURL(t *testing.T) {
+	cases := map[string]bool{
+		"https://www.onstrider.com/jobs/full-stack-engineer-975f80e4":                                true,
+		"https://www.onstrider.com/jobs/senior-back-end-engineer-node-express-nest-2172e283":         true,
+		"https://www.onstrider.com/jobs/full-stack-engineer-975f80e4/":                               true,
+		"https://www.onstrider.com/jobs":                                                             false, // listing root
+		"https://www.onstrider.com/pt/blog/linguagens":                                               false, // localized blog
+		"https://www.onstrider.com/hire/express-developers":                                          false, // marketing
+		"https://www.onstrider.com/preview-slug-0f985246-f06e-5582cab4c338/mobile-engineer-53604156": false, // preview dup
+	}
+	for u, want := range cases {
+		if got := onstriderVacancyURL(u); got != want {
+			t.Errorf("onstriderVacancyURL(%q) = %v, want %v", u, got, want)
+		}
+	}
+}
+
+func TestOnstriderProviderBoardlessAndProxied(t *testing.T) {
+	var s Source = NewOnstrider(nil)
+	if s.Provider() != "onstrider" {
+		t.Errorf("Provider() = %q, want onstrider", s.Provider())
+	}
+	if _, ok := s.(boardless); !ok {
+		t.Error("onstrider must be boardless (single-company, no board id)")
+	}
+	if _, ok := All(nil)["onstrider"]; !ok {
+		t.Error("onstrider must be registered in sources.All")
+	}
+	if _, ok := proxiedProviders["onstrider"]; !ok {
+		t.Error("onstrider must be in proxiedProviders (its Cloudflare edge may block the prod IP)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -297,6 +297,7 @@ func All(c HTTPClient) map[string]Source {
 		NewApple(c),
 		NewLumenalta(c),
 		NewDataArt(c),
+		NewOnstrider(c),
 		NewAlignerr(c),
 		NewBairesDev(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
@@ -393,6 +394,11 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// not a hard blocklist, so egressing through a fresh proxy IP keeps the crawl off the
 	// penalised prod IP; the adapter's narrow detail pool bounds the per-board burst.
 	"peopleforce": func(c HTTPClient) Source { return NewPeopleForce(c) },
+	// onstrider.com sits behind Cloudflare and is untested from the prod datacenter IP (the
+	// spike ran from a residential IP). It is pre-wired here so that, if the prod IP is blocked
+	// like djinni's, setting SOURCES_PROXY_URL routes only this provider through the proxy with
+	// no code change; while the proxy is unset this entry is inert.
+	"onstrider": func(c HTTPClient) Source { return NewOnstrider(c) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy

--- a/openspec/changes/add-onstrider-source/.openspec.yaml
+++ b/openspec/changes/add-onstrider-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/add-onstrider-source/design.md
+++ b/openspec/changes/add-onstrider-source/design.md
@@ -1,0 +1,87 @@
+## Context
+
+Strider (onstrider.com) runs its careers site on HubSpot CMS. A spike established:
+
+- The listing page `/jobs` server-renders only ~12 "featured" jobs and ignores `?page=N` — it
+  is **not** a usable enumeration source.
+- `https://www.onstrider.com/sitemap.xml` enumerates **all** vacancy URLs
+  (`/jobs/<slug>-<8hex>`, ~296 at spike time) plus blog/marketing/localized/`preview-slug`
+  URLs. Closed vacancies are **retained** in the sitemap and still return HTTP 200.
+- Each *open* vacancy page carries a schema.org `JobPosting` ld+json block; *closed* vacancies
+  drop the markup (Google penalizes stale `JobPosting` structured data). So **JobPosting
+  presence is the open/closed signal.** In a 25-URL spike sample only 3 were open.
+- `hiringOrganization.name` is always `"Strider"` — the real employer is hidden until a
+  candidate is matched.
+- The site sits behind Cloudflare; a plain browser UA passed from a residential IP, but the
+  prod datacenter IP is untested and may be blocked (as djinni/eightfold are).
+
+This is the exact DataArt shape (`internal/sources/dataart.go`): sitemap enumerate →
+per-vacancy detail fetch → map `JobPosting` ld+json, over the shared `fetchDetails` +
+`ldJobPosting` helpers.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless, boardless, single-company `onstrider` adapter that emits only open vacancies.
+- Reuse the existing sitemap + ld+json machinery; no new helper unless a field shape forces it.
+- Enroll in `proxiedProviders` so a blocked prod IP is a config flip, not a code change.
+
+**Non-Goals:**
+- Recovering the hidden real employer (not exposed anywhere pre-application).
+- A dedicated liveness probe. Closed vacancies simply stop being emitted; the standard 48h
+  ingest sweep soft-closes them. `cmd/liveness` would be useless here anyway (closed pages 200).
+- Aggregator/ATS suppression — every posting is company `Strider`, so there is no first-party
+  ATS twin to dedup against.
+
+## Decisions
+
+- **Enumerate via sitemap, filter to canonical `/jobs/<slug>-<8hex>`.** A single anchored regex
+  keeps canonical vacancy URLs and drops blog, marketing, `/pt/`+`/en/` localizations, and
+  `/preview-slug-<uuid>/...` duplicates. *Alternative rejected:* crawling `/jobs` — it only
+  exposes ~12 featured jobs with no pagination.
+
+- **Open/closed = `JobPosting` presence, obtained for free from `ldJobPosting`.** Like DataArt,
+  `detail()` returns `ok=false` when `ldJobPosting(root, &p)` finds no `JobPosting` block, so
+  closed vacancies are dropped with no extra logic. *Alternative rejected:* `validThrough` —
+  the spike found it unreliable (equals `datePosted`, often long past on still-open jobs).
+
+- **Map the onstrider-specific `JobPosting` shape.** Its fields differ from djinni's, so the
+  decode struct is bespoke:
+  - `identifier` is a `PropertyValue` object → read `identifier.value` (a UUID) as `ExternalID`.
+  - `applicantLocationRequirements` is an **array** of `{"@type":"Country","name":"BR"}` →
+    join the `name`s as the location.
+  - `employmentType` is an **array** (`["PART_TIME","CONTRACTOR"]`) → normalize via the existing
+    `schemaEmploymentType` over the joined/first value.
+  - `jobLocationType: "TELECOMMUTE"` → `Remote: true`, work mode `remote`.
+  - `hiringOrganization.name` ignored for the company; company is the fixed board-file `Strider`.
+
+- **Description handling captured from a real fixture.** The detail description is HTML in the
+  ld+json; sanitize with `sanitizeHTML(html.UnescapeString(...))` as DataArt does. The TDD
+  fixture is a saved real vacancy page, so the exact escaping is verified against ground truth
+  rather than assumed.
+
+- **Boardless single-company, keyless.** Config entry is `company: Strider` with no board, like
+  DataArt. One line in `sources.All`; one entry in `proxiedProviders`.
+
+## Risks / Trade-offs
+
+- **Fan-out cost: ~296 detail fetches per run to surface ~12–40 open jobs.** → Reuse
+  `fetchDetails` with the default worker pool (as DataArt/EPAM do); the sitemap set is small
+  enough that a throttled fan-out stays within the cron window. A future optimization (probe the
+  HubDB public API for a status column in one call) is noted but out of scope.
+- **Prod datacenter IP may be Cloudflare-blocked.** → Enroll in `proxiedProviders` up front so
+  the crawl egresses through `SOURCES_PROXY_URL` when set; if the direct IP turns out to work,
+  the proxy is simply not configured. Same posture as djinni.
+- **Single company facet.** All jobs collapse under `Strider`, so company-level facets are
+  coarse. Accepted — the real employer is genuinely unavailable.
+
+## Migration Plan
+
+- No DB migration, no API change, no new dependency.
+- Deploy: add a `cmd/ingest sources/onstrider.yml` cron schedule in freehire-ops; set
+  `SOURCES_PROXY_URL` if the prod IP is blocked (verify with one manual run first).
+
+## Open Questions
+
+- Does the prod datacenter IP actually get Cloudflare-blocked? Resolve with a single manual prod
+  run; `proxiedProviders` enrollment makes the answer a config flip either way.

--- a/openspec/changes/add-onstrider-source/proposal.md
+++ b/openspec/changes/add-onstrider-source/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Strider (onstrider.com) is a LATAM-focused talent marketplace placing remote engineers with
+US companies. A spike VALIDATED that its careers site is a HubSpot CMS whose sitemap enumerates
+every vacancy URL and whose *open* vacancy pages server-render a schema.org `JobPosting`
+ld+json block, while *closed* vacancies drop that markup — giving both a full enumeration
+source and a free open/closed liveness signal. Adding it widens LATAM remote coverage at the
+cost of a single adapter that reuses the existing sitemap + ld+json machinery.
+
+## What Changes
+
+- Add an `onstrider` source adapter that enumerates canonical vacancy URLs
+  (`https://www.onstrider.com/jobs/<slug>-<8hex>`) from `https://www.onstrider.com/sitemap.xml`
+  and maps each *open* vacancy page's embedded schema.org `JobPosting` ld+json to a normalized
+  `Job` (title, HTML description, `identifier.value` UUID as `ExternalID`, employment type,
+  `applicantLocationRequirements` countries, `jobLocationType: TELECOMMUTE` → remote, canonical
+  detail URL).
+- **Open/closed is the presence of the `JobPosting` block.** The sitemap retains closed and
+  `/preview-slug-…/` URLs indefinitely (both still return HTTP 200), so the adapter drops any
+  URL that is not a canonical `/jobs/` vacancy and any page without a `JobPosting` block. Jobs
+  that flip closed simply stop being emitted and are soft-closed by the standard ingest sweep.
+- The adapter is **boardless** and **single-company**: `hiringOrganization.name` is always
+  `"Strider"` (the real employer is hidden until a candidate is matched), so every posting maps
+  to one company, `Strider`. It is the DataArt shape — sitemap enumerate, per-vacancy detail
+  fetch — over the shared `fetchDetails` + `ldJobPosting` helpers.
+- Enroll `onstrider` in `sources.All` and in `proxiedProviders`: the site sits behind
+  Cloudflare and, like djinni/eightfold, the edge may block the prod datacenter IP, so its
+  crawl egresses through `SOURCES_PROXY_URL` when set.
+- Add `sources/onstrider.yml` with a single entry (`company: Strider`, boardless) crawled by
+  its own `cmd/ingest` cron schedule.
+
+## Capabilities
+
+### New Capabilities
+- `onstrider-source`: the `onstrider` adapter — its sitemap enumeration, canonical-URL filter,
+  per-vacancy `JobPosting` ld+json mapping, open/closed-via-markup drop rule, boardless
+  single-company classification, and proxied-egress enrollment.
+
+### Modified Capabilities
+<!-- None. Boardless single-company adapter; inherits the standard ingest sweep and
+     board-health machinery unchanged. No spec-level behavior of an existing capability changes. -->
+
+## Impact
+
+- **New code:** `internal/sources/onstrider.go` (+ `_test.go`); `sources/onstrider.yml`.
+- **Touched code:** one line in `sources.All` (registry) and one entry in `proxiedProviders`.
+- **Ops:** a new `cmd/ingest sources/onstrider.yml` cron schedule (deploy-time, in freehire-ops);
+  requires `SOURCES_PROXY_URL` set if the prod IP is blocked.
+- **No migrations, no API changes, no new dependencies.**

--- a/openspec/changes/add-onstrider-source/specs/onstrider-source/spec.md
+++ b/openspec/changes/add-onstrider-source/specs/onstrider-source/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Onstrider enumerates vacancies from the sitemap
+
+The system SHALL provide an `onstrider` source adapter that enumerates vacancy URLs from
+`https://www.onstrider.com/sitemap.xml`. The adapter SHALL keep only canonical vacancy URLs
+of the form `https://www.onstrider.com/jobs/<slug>-<8hex>` and SHALL drop every other entry —
+blog, marketing, localized (`/pt/`, `/en/`), and `/preview-slug-…/` duplicate URLs — so each
+vacancy is fetched at most once.
+
+The adapter is **boardless** (onstrider.com is one site with no per-tenant board). The
+configured board file entry carries no `board` value.
+
+#### Scenario: Sitemap yields only canonical vacancy URLs
+
+- **WHEN** the adapter reads a sitemap containing canonical `/jobs/<slug>-<8hex>` URLs
+  alongside blog, marketing, localized, and `/preview-slug-…/` URLs
+- **THEN** it fetches only the canonical `/jobs/<slug>-<8hex>` URLs and ignores the rest
+
+### Requirement: Onstrider maps an open vacancy's JobPosting ld+json to a Job
+
+The system SHALL fetch each canonical vacancy page and map its embedded schema.org
+`JobPosting` ld+json to a normalized `Job`. The `Job` SHALL carry the `identifier.value`
+(a UUID) as its `ExternalID`, the vacancy page URL as its canonical URL, the posting title,
+the sanitized HTML `description`, the company name `Strider` (the site's `hiringOrganization`
+is always Strider, the real employer being hidden), the countries from
+`applicantLocationRequirements[].name`, and `Remote: true` with work mode `remote` when
+`jobLocationType` is `TELECOMMUTE`. Posted-at SHALL be taken from `datePosted` when present.
+
+#### Scenario: An open vacancy page maps to a job
+
+- **WHEN** the adapter fetches a canonical vacancy page carrying a `JobPosting` ld+json block
+- **THEN** it yields one `Job` with `ExternalID` set to the posting's `identifier.value`, the
+  page URL as the canonical URL, the title, the sanitized description, company `Strider`, the
+  `applicantLocationRequirements` countries as its location, and remote work mode when
+  `jobLocationType` is `TELECOMMUTE`
+
+### Requirement: Onstrider treats a missing JobPosting block as a closed vacancy
+
+The adapter SHALL treat the presence of the `JobPosting` ld+json block as the open/closed
+signal, dropping any vacancy URL whose page carries no `JobPosting` block. The sitemap retains
+closed vacancy URLs indefinitely and they still return HTTP 200, but a closed vacancy drops its
+`JobPosting` markup. The adapter SHALL also drop any posting lacking a usable `identifier.value`
+(which would collide on the dedup key). A single dropped or failed vacancy SHALL NOT abort the
+crawl; vacancies that stop being emitted are soft-closed by the standard ingest sweep.
+
+#### Scenario: A closed vacancy is dropped
+
+- **WHEN** the adapter fetches a canonical vacancy URL whose page has no `JobPosting` ld+json
+  block (the vacancy has been closed)
+- **THEN** the adapter yields no `Job` for that URL and continues with the remaining URLs
+
+#### Scenario: A vacancy without a usable identifier is dropped
+
+- **WHEN** a fetched vacancy carries a `JobPosting` block whose `identifier.value` is empty
+- **THEN** the adapter drops that posting and continues mapping the rest
+
+### Requirement: Onstrider crawl egresses through the proxy allowlist
+
+The system SHALL register `onstrider` in `proxiedProviders` so that, when `SOURCES_PROXY_URL`
+is set, the onstrider crawl egresses through that proxy — the site sits behind Cloudflare and
+the edge may block the prod datacenter IP. When `SOURCES_PROXY_URL` is unset the provider
+crawls over the direct client unchanged.
+
+#### Scenario: Proxy egress is applied when configured
+
+- **WHEN** `SOURCES_PROXY_URL` is set and `sources.ApplyProxyEgress` runs over the registry
+- **THEN** the `onstrider` adapter's transport is routed through the configured proxy while
+  non-allowlisted providers stay on the direct client

--- a/openspec/changes/add-onstrider-source/tasks.md
+++ b/openspec/changes/add-onstrider-source/tasks.md
@@ -1,0 +1,51 @@
+## 1. Detail mapping (single open vacancy)
+
+- [x] 1.1 Add `internal/sources/onstrider_test.go` with a saved real open-vacancy HTML fixture
+  under `testdata/` and a RED test asserting the adapter maps its `JobPosting` ld+json to a
+  `Job` with the right fields: `identifier.value` (UUID) → `ExternalID`, page URL → `URL`,
+  title, sanitized HTML description, company `Strider`, `applicantLocationRequirements[].name`
+  countries → `Location`, `jobLocationType: TELECOMMUTE` → `Remote: true` + work mode `remote`,
+  `datePosted` → `PostedAt`.
+- [x] 1.2 Create `internal/sources/onstrider.go`: an `onstrider` struct over the sitemap+HTML
+  client, an `onstriderPosting` struct for the schema.org fields (nested `identifier`
+  PropertyValue, `applicantLocationRequirements` array, `employmentType` array), and a
+  `detail`/`toJob` mapper reusing `ldJobPosting`, `sanitizeHTML`, `schemaEmploymentType`, and
+  `workModeFromRemote`. Make 1.1 green.
+
+## 2. Open/closed drop rules
+
+- [x] 2.1 RED test: a saved closed-vacancy fixture (page with no `JobPosting` block) yields no
+  `Job`; a page with a `JobPosting` whose `identifier.value` is empty is dropped; a fetch error
+  on one URL does not abort the crawl.
+- [x] 2.2 Implement the drop rules in `detail` (return `ok=false` on missing `JobPosting` or
+  empty `identifier.value`) and confirm `fetchDetails` skips just that URL. Make 2.1 green.
+
+## 3. Sitemap enumeration & URL filter
+
+- [x] 3.1 RED test: given a sitemap fixture mixing canonical `/jobs/<slug>-<8hex>`, blog,
+  marketing, `/pt/`+`/en/` localized, and `/preview-slug-<uuid>/...` URLs, `Fetch` fetches only
+  the canonical vacancy URLs (assert the exact set) via a fake sitemap+detail client.
+- [x] 3.2 Implement `Fetch`: `GetXML` the sitemap, filter with an anchored
+  `onstriderVacancyURL` regex, then `fetchDetails(urls, defaultDetailWorkers, d.detail)`. Make
+  3.1 green.
+
+## 4. Classification & registration
+
+- [x] 4.1 Add the `boardless()` marker and `Provider()` returning `"onstrider"`; register
+  `onstrider` in `sources.All` (one line). Test the provider resolves from `All(nil)`.
+- [x] 4.2 Add `onstrider` to `proxiedProviders` and a test asserting membership (mirrors the
+  djinni proxied-provider test). Verify `go build ./... && go vet ./...`.
+
+## 5. Board file & docs
+
+- [x] 5.1 Add `sources/onstrider.yml` with a single boardless entry (`company: Strider`) and
+  confirm `go run ./cmd/ingest sources/onstrider.yml` validates against the registry
+  (fail-fast passes).
+- [x] 5.2 Note the new adapter in `internal/sources/AGENTS.md` if it enumerates adapters by
+  class (JSON-LD front / sitemap), keeping the surrounding style.
+
+## 6. Verify end-to-end
+
+- [x] 6.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl
+  against onstrider.com to confirm the sitemap enumerates, open vacancies map, and closed ones
+  are dropped without error (not committed).

--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -718,3 +718,25 @@
   board: talents
 - company: "Talent & Tech"
   board: talentetech
+
+# --- harvested via Wayback CDX + live API validation 2026-07-16 ---
+- company: "2Future"
+  board: 2future
+- company: "Blume Alimentos | OH! A Água"
+  board: blumeohaagua
+- company: "CAPEF"
+  board: capef
+- company: "GOPWR"
+  board: grupogopwr
+- company: "Icatu Seguros"
+  board: icatu
+- company: "Anhembi"
+  board: industriasanhembi
+- company: "LWSA"
+  board: lwsa
+- company: "MENA"
+  board: mena
+- company: "Pottencial"
+  board: pottencial
+- company: "Talentt"
+  board: talentt

--- a/sources/onstrider.yml
+++ b/sources/onstrider.yml
@@ -1,0 +1,7 @@
+# Strider careers (www.onstrider.com), a HubSpot-hosted LATAM talent marketplace. Boardless
+# single-company source: the sitemap enumerates every vacancy and each OPEN vacancy page renders
+# a schema.org JobPosting ld+json block (a closed vacancy drops the markup — that absence is the
+# open/closed signal). The real employer is hidden (hiringOrganization is always "Strider"), so
+# every posting maps to this entry's `company`. See internal/sources/onstrider.go.
+- company: Strider
+  provider: onstrider


### PR DESCRIPTION
## Summary

Adds an `onstrider` source adapter for [Strider](https://www.onstrider.com/jobs), a HubSpot-hosted LATAM talent marketplace. Boardless, single-company, keyless — the DataArt shape (sitemap enumerate → per-vacancy JobPosting ld+json) over the shared `fetchDetails` + `ldJobPosting` helpers.

A spike VALIDATED the recipe: the sitemap enumerates every vacancy URL, and each **open** vacancy page server-renders a schema.org `JobPosting` block while **closed** ones drop the markup — giving both full enumeration and a free open/closed liveness signal.

**How it works**
- Enumerates canonical `/jobs/<slug>-<8hex>` URLs from `sitemap.xml`, dropping blog/marketing/localized/`preview-slug` entries.
- Keeps only pages carrying a `JobPosting` block (closed vacancies drop out → soft-closed by the ingest sweep).
- `identifier.value` (UUID) → `ExternalID`; `applicantLocationRequirements` countries → location; `jobLocationType: TELECOMMUTE` → remote. The real employer is hidden (`hiringOrganization` is always "Strider"), so every posting maps to the single company **Strider**.
- Enrolled in `proxiedProviders`: the Cloudflare edge is untested from the prod IP, so `SOURCES_PROXY_URL` routes it through the proxy if needed (no code change).

**Hardening from code review** (each with a regression test)
- `employmentType` decoded via `json.RawMessage` to tolerate schema.org's string-or-array shape — a fixed `[]string` would error and `ldJobPosting` would silently drop the open vacancy.
- `Fetch` returns an error when the sitemap lists vacancies but none map, so a wholesale detail failure (e.g. Cloudflare blocking the prod IP) cannot false-close the catalogue via the unseen sweep.
- ISO country codes expanded to English names so the location parser resolves LATAM countries instead of the colliding US subdivisions (`CO`→Colorado, `AR`→Arkansas, `PA`→Pennsylvania).

Planned under OpenSpec change `add-onstrider-source` (proposal/design/spec/tasks included).

## Test Plan
- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/sources/` (8 new onstrider tests, all green)
- [x] Live smoke: `go run ./cmd/ingest sources/onstrider.yml` → ingested 9 open vacancies, 0 failed
- [x] Verified derived geo end-to-end: ingested jobs carry `remote=true` and `location="Brazil, Mexico, Colombia, Argentina"` (resolves to the LATAM region, not US)

## Ops note
Add a `cmd/ingest sources/onstrider.yml` cron schedule in freehire-ops. If the prod datacenter IP is Cloudflare-blocked, set `SOURCES_PROXY_URL` (verify with one manual run first).