### PR TITLE
feat(sources): reclaim enterprise boards behind vanity domains

### DIFF
--- a/sources/avature.yml
+++ b/sources/avature.yml
@@ -6,3 +6,5 @@
 
 - company: Electronic Arts
   board: jobs.ea.com
+- company: Harman
+  board: jobsearch.harman.com

--- a/sources/smartrecruiters.yml
+++ b/sources/smartrecruiters.yml
@@ -5701,3 +5701,7 @@
   board: StudyAbroadEurope
 - company: Caribbean University
   board: CaribbeanUniversity
+- company: Renesas Electronics
+  board: RenesasElectronics
+- company: AUTO1 Group
+  board: AUTO1

--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -17,3 +17,9 @@
   board: jobs.helsinki.fi
 - company: Bilfinger
   board: jobs.bilfinger.com
+- company: Black & Veatch
+  board: careers.bv.com
+- company: Dentsply Sirona
+  board: careers.dentsplysirona.com
+- company: GFT Technologies
+  board: jobs.gft.com


### PR DESCRIPTION
6 boards added to existing adapters for companies whose careers vanity domains front a known ATS (identified via ATS fingerprinting of an aggregator corpus):

- **SmartRecruiters**: RenesasElectronics (389), AUTO1 (505)
- **SuccessFactors**: careers.bv.com (404), careers.dentsplysirona.com (377), jobs.gft.com (265)
- **Avature**: jobsearch.harman.com (218)

Each verified live end-to-end through its adapter (~2.1k jobs total). No code changes — board-file entries only.