### PR TITLE
feat(sources): add hurma/recruitee/rippling tenants + fix Spellbook Ashby board

### DIFF
--- a/sources/ashby.yml
+++ b/sources/ashby.yml
@@ -6664,7 +6664,7 @@
 - company: KIMARU Talent
   board: kimarutalent
 - company: Spellbook
-  board: spellbook.legal
+  board: spellbook.com
 - company: The Browser Company
   board: the browser company
 - company: intangible.ai

--- a/sources/hurma.yml
+++ b/sources/hurma.yml
@@ -11,3 +11,5 @@
   board: dataforest
 - company: WorkeronAI
   board: workeronai
+- company: Platipus
+  board: platipus

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3547,3 +3547,5 @@
 # Recruitee tenant from jobcrawls harvest (2026-07, offers API-validated)
 - company: Norrin
   board: norrin
+- company: Wizdaa
+  board: wizdaa

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -151,3 +151,5 @@
   board: banner-house-at-t-bar-m
 - company: Yaqeen Institute
   board: yaqeencareers
+- company: Rippling
+  board: rippling


### PR DESCRIPTION
Harvested from a live URL dump; each board validated against its ATS feed **before** adding (per the board-file convention):

| Company | ATS | File | Live feed |
|---|---|---|---|
| Platipus | Hurma | `hurma.yml` | 8 vacancies |
| Wizdaa | Recruitee | `recruitee.yml` | 7 offers |
| Rippling | Rippling | `rippling.yml` | 780 jobs |
| Spellbook | Ashby | `ashby.yml` | swap dead `spellbook.legal` → live `spellbook.com` (28 jobs) |

The Spellbook change is a **replacement**, not an add: the old `spellbook.legal` board is dead (empty feed) and would otherwise keep flagging red in board_health; `spellbook.com` is the company's live board (identity preserved via `company: Spellbook`).

Verified: `go vet ./internal/sources/` clean, sources config parse test passes.

### Not included (needs adapter work, not a tenant add)
- **nearshore-business-solutions** (careers-page): lives only on the `www.careers-page.com/<slug>/job/<CODE>` form; our adapter supports only the subdomain form (`<board>.careers-page.com/jobs/<uuid>`). Subdomain → 404.