### PR TITLE
refactor(sources): adapter bug fixes + shared decode foundations

### DIFF
--- a/internal/sources/alfabank.go
+++ b/internal/sources/alfabank.go
@@ -100,7 +100,10 @@ func (a alfabank) list(ctx context.Context) ([]alfaItem, error) {
 			return nil, fmt.Errorf("alfabank: list skip %d: %w", skip, err)
 		}
 		all = append(all, resp.Items...)
-		if skip+alfaPageSize >= resp.Total {
+		// Stop at the reported total, but also on any empty page: a Total larger than the rows
+		// actually served (a cap/filter artifact) would otherwise spin forever, since skip never
+		// reaches it and every further page comes back empty.
+		if len(resp.Items) == 0 || skip+alfaPageSize >= resp.Total {
 			break
 		}
 	}

--- a/internal/sources/alfabank_test.go
+++ b/internal/sources/alfabank_test.go
@@ -116,6 +116,26 @@ func TestAlfaBankUnknownCityIsEmpty(t *testing.T) {
 	}
 }
 
+func TestAlfaBankStopsOnEmptyPageDespiteHigherTotal(t *testing.T) {
+	// Total is misreported as 250 (larger than the single row actually served). The empty
+	// second page must terminate the crawl; without the guard the loop advances to skip=200
+	// (unrouted here → the fake errors), so a clean single-job return proves it stopped.
+	fake := (&routedHTTP{}).
+		route("listId=cities", alfaCities).
+		route("skip=0", alfaListPage(250,
+			alfaItemJSON("1", "Job", "0100", "/moskva/office-job/job_1", "2026-05-01T09:00:00Z", "<p>x</p>"),
+		)).
+		route("skip=100", alfaListPage(250)) // empty items, but skip+take (200) still < 250
+
+	jobs, err := NewAlfaBank(fake).Fetch(context.Background(), CompanyEntry{Company: "Alfa-Bank", Provider: "alfabank"})
+	if err != nil {
+		t.Fatalf("Fetch: %v (crawl did not stop on the empty page and reached an unrouted skip)", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (empty page must stop the crawl)", len(jobs))
+	}
+}
+
 func TestAlfaBankEmptyListYieldsNoJobsNoError(t *testing.T) {
 	fake := (&routedHTTP{}).
 		route("listId=cities", alfaCities).

--- a/internal/sources/avature.go
+++ b/internal/sources/avature.go
@@ -122,10 +122,7 @@ var avatureJobIDPattern = regexp.MustCompile(`/JobDetail/[^/]+/(\d+)/?$`)
 
 // avatureJobID extracts the native numeric posting id from a job page URL.
 func avatureJobID(loc string) string {
-	if m := avatureJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(avatureJobIDPattern, loc)
 }
 
 // avatureWorkMode maps an Avature "Work Model" field value to the controlled work-mode

--- a/internal/sources/avito.go
+++ b/internal/sources/avito.go
@@ -135,10 +135,7 @@ var avitoVacancyIDPattern = regexp.MustCompile(`/vacancies/[^/]+/(\d+)`)
 // avitoVacancyID extracts the numeric vacancy id from a detail URL, or "" when the URL is
 // not a vacancy-detail page.
 func avitoVacancyID(loc string) string {
-	if m := avitoVacancyIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(avitoVacancyIDPattern, loc)
 }
 
 // avitoTitleCityPattern captures the display city from a page <title>'s
@@ -159,8 +156,5 @@ func avitoTitleCity(root *html.Node) string {
 		}
 		return true
 	})
-	if m := avitoTitleCityPattern.FindStringSubmatch(title); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(avitoTitleCityPattern, title)
 }

--- a/internal/sources/bayt.go
+++ b/internal/sources/bayt.go
@@ -58,10 +58,7 @@ var baytJobIDPattern = regexp.MustCompile(`/jobs/[^/]+-(\d+)/?$`)
 // job-detail page or carries no trailing id. Any query string or fragment is stripped first so a
 // listing href with a tracking suffix (?utm=…) still matches.
 func baytJobID(loc string) string {
-	if m := baytJobIDPattern.FindStringSubmatch(trimURLSuffix(loc)); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(baytJobIDPattern, trimURLSuffix(loc))
 }
 
 // baytLDPosting is the slice of the page's schema.org JobPosting the adapter reads. Unlike Meta,

--- a/internal/sources/careerplug.go
+++ b/internal/sources/careerplug.go
@@ -109,10 +109,7 @@ var careerplugJobIDPattern = regexp.MustCompile(`/jobs/(\d+)`)
 
 // careerplugJobID extracts the native posting id from a job URL, or "" when absent.
 func careerplugJobID(u string) string {
-	if m := careerplugJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(careerplugJobIDPattern, u)
 }
 
 // careerplugJobLinks returns the absolute hrefs of all /jobs/<id> job-page anchors, resolved

--- a/internal/sources/careerspage.go
+++ b/internal/sources/careerspage.go
@@ -141,10 +141,7 @@ var careerspageJobIDPattern = regexp.MustCompile(`/jobs/([0-9a-fA-F-]{36})(?:$|[
 // careerspageJobID extracts the native job UUID from a detail URL, or "" when the URL is
 // not a canonical job posting.
 func careerspageJobID(loc string) string {
-	if m := careerspageJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(careerspageJobIDPattern, loc)
 }
 
 // careerspageJobLinks returns the absolute, deduplicated canonical detail URL of every job

--- a/internal/sources/catsone.go
+++ b/internal/sources/catsone.go
@@ -80,10 +80,7 @@ var catsoneJobIDPattern = regexp.MustCompile(`/careers/\d+/jobs/(\d+)`)
 // catsoneJobID extracts the native numeric job id from a detail URL, or "" when the URL is
 // not a job posting.
 func catsoneJobID(loc string) string {
-	if m := catsoneJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(catsoneJobIDPattern, loc)
 }
 
 // catsoneListings parses each job row from the portal table into its absolute detail URL,

--- a/internal/sources/cornerstone.go
+++ b/internal/sources/cornerstone.go
@@ -157,11 +157,3 @@ var (
 	cornerstoneCultureIDPattern   = regexp.MustCompile(`(?i)"cultureID"\s*:\s*(\d+)`)
 	cornerstoneCultureNamePattern = regexp.MustCompile(`(?i)"cultureName"\s*:\s*"([^"]+)"`)
 )
-
-// firstSubmatch returns the first capture group of pattern in s, or "".
-func firstSubmatch(pattern *regexp.Regexp, s string) string {
-	if m := pattern.FindStringSubmatch(s); m != nil {
-		return m[1]
-	}
-	return ""
-}

--- a/internal/sources/dataart.go
+++ b/internal/sources/dataart.go
@@ -103,10 +103,7 @@ var dataartVacancyCodePattern = regexp.MustCompile(`^https?://www\.dataart\.team
 // dataartVacancyCode extracts the vacancy code from a canonical English vacancy URL, returning
 // "" for the listing root, localisations, and unrelated pages.
 func dataartVacancyCode(u string) string {
-	if m := dataartVacancyCodePattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(dataartVacancyCodePattern, u)
 }
 
 // dataartPosting is the schema.org JobPosting decoded from a DataArt vacancy page's ld+json.

--- a/internal/sources/djinni.go
+++ b/internal/sources/djinni.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"html"
 	"log"
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
-	"unicode/utf8"
 )
 
 // djinni adapts djinni.co, a Ukrainian/CEE IT job board. Each anonymous listing page
@@ -131,7 +128,7 @@ func (p djinniPosting) toJob() (Job, bool) {
 		Title:          p.Title,
 		Company:        p.HiringOrganization.Name,
 		Location:       p.ApplicantLocationRequirements.Address.AddressCountry,
-		Description:    sanitizeHTML(djinniDescriptionHTML(p.Description)),
+		Description:    sanitizeHTML(plainTextToHTML(p.Description)),
 		Remote:         remote,
 		WorkMode:       workModeFromRemote(remote),
 		EmploymentType: schemaEmploymentType(p.EmploymentType),
@@ -152,71 +149,5 @@ func djinniDate(s string) *time.Time {
 	return parseDate(s)
 }
 
-// djinniBulletMarkers are the line-leading glyphs Djinni company editors use to mark list items
-// in the otherwise plain-text JSON-LD description (bullet, middle dot, triangular/hollow/filled
-// bullets, hyphen, asterisk, en/em dash). A marker counts only when it leads a line and is
-// followed by whitespace, so a mid-sentence dash, a hyphenated word, or the "*Note" footnote
-// prefix stays prose.
-var djinniBulletMarkers = map[rune]bool{
-	'•': true, '·': true, '‣': true, '◦': true, '▪': true,
-	'-': true, '*': true, '–': true, '—': true,
-}
-
-// djinniBullet reports whether a trimmed line is a bullet, returning its text with the leading
-// marker (and the space after it) removed.
-func djinniBullet(line string) (string, bool) {
-	r, size := utf8.DecodeRuneInString(line)
-	if !djinniBulletMarkers[r] {
-		return "", false
-	}
-	next, _ := utf8.DecodeRuneInString(line[size:])
-	if !unicode.IsSpace(next) {
-		return "", false // "-word" / "*Note" without a following space is prose, not a bullet
-	}
-	return strings.TrimSpace(line[size:]), true
-}
-
-// djinniDescriptionHTML rebuilds the structural HTML the {@html} consumer renders from Djinni's
-// plain-text description. The feed carries the body as newline-delimited text — blank lines
-// separate blocks, assorted leading glyphs mark bullets — with no markup, so rendered as-is every
-// newline collapses into one unbroken wall of text. This reconstructs it: a run of bullet lines
-// becomes a <ul>, a run of other text lines becomes a <p> (wrapped lines joined by <br>), and a
-// blank line closes the open block. Text is HTML-escaped because it is literal prose, not markup.
-func djinniDescriptionHTML(text string) string {
-	var out strings.Builder
-	var para, bullets []string
-	flushPara := func() {
-		if len(para) > 0 {
-			out.WriteString("<p>" + strings.Join(para, "<br>") + "</p>")
-			para = para[:0]
-		}
-	}
-	flushBullets := func() {
-		if len(bullets) > 0 {
-			out.WriteString("<ul>")
-			for _, li := range bullets {
-				out.WriteString("<li>" + li + "</li>")
-			}
-			out.WriteString("</ul>")
-			bullets = bullets[:0]
-		}
-	}
-	for _, raw := range strings.Split(text, "\n") {
-		line := strings.TrimSpace(raw)
-		if line == "" {
-			flushBullets()
-			flushPara()
-			continue
-		}
-		if item, ok := djinniBullet(line); ok {
-			flushPara()
-			bullets = append(bullets, html.EscapeString(item))
-			continue
-		}
-		flushBullets()
-		para = append(para, html.EscapeString(line))
-	}
-	flushBullets()
-	flushPara()
-	return out.String()
-}
+// djinni's plain-text JSON-LD description is rebuilt into structural HTML by the shared
+// plainTextToHTML helper (see plaintext.go), reused by other plain-text sources (lumenalta).

--- a/internal/sources/epam.go
+++ b/internal/sources/epam.go
@@ -102,10 +102,7 @@ var epamJobIDPattern = regexp.MustCompile(`/en/vacancy/[^/?#]*-(blt[a-z0-9]+)_en
 // epamJobID extracts the vacancy uid from an English vacancy URL, returning "" for the
 // listing, language roots, and non-English vacancy localisations.
 func epamJobID(u string) string {
-	if m := epamJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(epamJobIDPattern, u)
 }
 
 // epamPosting is the schema.org JobPosting decoded from an EPAM vacancy page's ld+json

--- a/internal/sources/freshteam.go
+++ b/internal/sources/freshteam.go
@@ -119,10 +119,7 @@ var ftJobIDPattern = regexp.MustCompile(`/jobs/([A-Za-z0-9_-]{12})(?:[/?#]|$)`)
 // ftJobID extracts the native posting id from a job page URL, or "" when the URL is not a
 // job permalink.
 func ftJobID(u string) string {
-	if m := ftJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(ftJobIDPattern, u)
 }
 
 // ftPosting is the schema.org JobPosting decoded from a Freshteam job page's

--- a/internal/sources/globalpayments.go
+++ b/internal/sources/globalpayments.go
@@ -115,10 +115,7 @@ var gpJobIDPattern = regexp.MustCompile(`/en/jobs/([^/?#]+)/[^/?#]+`)
 
 // gpJobID extracts the native posting id (e.g. "r0072212") from a job page URL.
 func gpJobID(u string) string {
-	if m := gpJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(gpJobIDPattern, u)
 }
 
 // gpPosting is the schema.org JobPosting decoded from a Global Payments job page's

--- a/internal/sources/gulftalent.go
+++ b/internal/sources/gulftalent.go
@@ -59,10 +59,7 @@ var gulftalentJobIDPattern = regexp.MustCompile(`/jobs/[^/]+-(\d+)/?$`)
 // is not a job-detail page or carries no trailing id. Any query string or fragment is stripped
 // first so a URL with a suffix still matches.
 func gulftalentJobID(loc string) string {
-	if m := gulftalentJobIDPattern.FindStringSubmatch(trimURLSuffix(loc)); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(gulftalentJobIDPattern, trimURLSuffix(loc))
 }
 
 // gulftalentLDPosting is the slice of the page's schema.org JobPosting the adapter reads.

--- a/internal/sources/hurma.go
+++ b/internal/sources/hurma.go
@@ -134,10 +134,7 @@ var hurmaVacancyIDPattern = regexp.MustCompile(`/public-vacancies/(\d+)`)
 
 // hurmaVacancyID extracts the native numeric vacancy id from a vacancy's public URL.
 func hurmaVacancyID(u string) string {
-	if m := hurmaVacancyIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(hurmaVacancyIDPattern, u)
 }
 
 // hurmaTitlePrefix matches the "#<id> " tag Hurma prepends to a vacancy name.

--- a/internal/sources/icims.go
+++ b/internal/sources/icims.go
@@ -206,10 +206,7 @@ var icimsJobIDPattern = regexp.MustCompile(`/jobs/(\d+)(?:[/?#]|$)`)
 // icimsJobID extracts the native numeric posting id from a job page URL, or "" when the
 // URL is not a job posting.
 func icimsJobID(loc string) string {
-	if m := icimsJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(icimsJobIDPattern, loc)
 }
 
 // icimsAvailable blanks the iCIMS "UNAVAILABLE" placeholder so it never leaks into a

--- a/internal/sources/icims.go
+++ b/internal/sources/icims.go
@@ -1,9 +1,7 @@
 package sources
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -154,47 +152,14 @@ func (s icims) detail(ctx context.Context, e CompanyEntry, host string, vanity b
 // icimsPosting is the schema.org JobPosting decoded from an iCIMS job fragment's
 // application/ld+json block.
 type icimsPosting struct {
-	Title              string      `json:"title"`
-	Description        string      `json:"description"`
-	DatePosted         string      `json:"datePosted"`
-	JobLocationType    string      `json:"jobLocationType"`
-	JobLocation        icimsPlaces `json:"jobLocation"`
+	Title              string       `json:"title"`
+	Description        string       `json:"description"`
+	DatePosted         string       `json:"datePosted"`
+	JobLocationType    string       `json:"jobLocationType"`
+	JobLocation        schemaPlaces `json:"jobLocation"`
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-}
-
-// icimsPlace is one entry of JobPosting.jobLocation.
-type icimsPlace struct {
-	Address struct {
-		AddressLocality string `json:"addressLocality"`
-		AddressRegion   string `json:"addressRegion"`
-		AddressCountry  string `json:"addressCountry"`
-	} `json:"address"`
-}
-
-// icimsPlaces decodes JobPosting.jobLocation, which iCIMS emits as EITHER a single Place
-// object (single-location jobs, the common careers-home shape) OR an array of them
-// (multi-location) — normalizing both to a slice. Without this, a single-object jobLocation
-// fails to unmarshal into a []icimsPlace and the whole posting is silently dropped.
-type icimsPlaces []icimsPlace
-
-func (p *icimsPlaces) UnmarshalJSON(b []byte) error {
-	trimmed := bytes.TrimSpace(b)
-	if len(trimmed) > 0 && trimmed[0] == '[' {
-		var arr []icimsPlace
-		if err := json.Unmarshal(trimmed, &arr); err != nil {
-			return err
-		}
-		*p = arr
-		return nil
-	}
-	var one icimsPlace
-	if err := json.Unmarshal(trimmed, &one); err != nil {
-		return err
-	}
-	*p = []icimsPlace{one}
-	return nil
 }
 
 // icimsJobIDPattern captures the numeric posting id from a job URL's /jobs/<id> segment,

--- a/internal/sources/inhire.go
+++ b/internal/sources/inhire.go
@@ -33,7 +33,6 @@ type inhirePost struct {
 	DisplayName   string `json:"displayName"`
 	WorkplaceType string `json:"workplaceType"`
 	Location      string `json:"location"`
-	Status        string `json:"status"`
 }
 
 func (h inhire) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {

--- a/internal/sources/itechart.go
+++ b/internal/sources/itechart.go
@@ -83,10 +83,7 @@ func (i itechart) detail(ctx context.Context, e CompanyEntry, jobURL string) (Jo
 var itechartJobIDPattern = regexp.MustCompile(`/job-openings/([a-z0-9-]+)(?:[/?#]|$)`)
 
 func itechartJobID(u string) string {
-	if m := itechartJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(itechartJobIDPattern, u)
 }
 
 // itechartPosting is the schema.org JobPosting on an iTechArt vacancy page. jobLocation is a

--- a/internal/sources/jazzhr.go
+++ b/internal/sources/jazzhr.go
@@ -102,10 +102,7 @@ var jazzhrJobIDPattern = regexp.MustCompile(`/apply/([A-Za-z0-9]+)/`)
 
 // jazzhrJobID extracts the native posting token from a job page URL.
 func jazzhrJobID(u string) string {
-	if m := jazzhrJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(jazzhrJobIDPattern, u)
 }
 
 // jazzhrJobLinks returns the absolute hrefs of all anchors linking an /apply/<token>/ job

--- a/internal/sources/jibe.go
+++ b/internal/sources/jibe.go
@@ -66,7 +66,9 @@ func (s jibe) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			break
 		}
 		for _, item := range listing.Jobs {
-			jobs = append(jobs, s.toJob(e, item.Data))
+			if job, ok := s.toJob(e, item.Data); ok {
+				jobs = append(jobs, job)
+			}
 		}
 		// Stop once the catalogue total is reached; the empty-page check above is the
 		// fallback if totalCount is ever absent or wrong.
@@ -78,9 +80,13 @@ func (s jibe) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 }
 
 // toJob maps one Jibe posting to the normalized Job shape. The id is the posting slug
-// (the public job-page path segment), falling back to req_id.
-func (s jibe) toJob(e CompanyEntry, p jibePosting) Job {
+// (the public job-page path segment), falling back to req_id. A posting with neither has
+// no dedup key — it would collide on a bare ".../jobs/" URL — so it is dropped (ok=false).
+func (s jibe) toJob(e CompanyEntry, p jibePosting) (Job, bool) {
 	id := firstNonEmpty(p.Slug, p.ReqID)
+	if id == "" {
+		return Job{}, false
+	}
 	location := firstNonEmpty(p.LocationName, p.FullLocation)
 	// location_type is the structured work-arrangement signal (REMOTE/HYBRID/ONSITE);
 	// "ANY" and unknown values yield no mode, leaving the pipeline to fall back to the
@@ -96,5 +102,5 @@ func (s jibe) toJob(e CompanyEntry, p jibePosting) Job {
 		Remote:      workMode == "remote" || isRemote(location),
 		WorkMode:    workMode,
 		PostedAt:    parseLayout(jibeDateLayout, p.PostedDate),
-	}
+	}, true
 }

--- a/internal/sources/jibe_test.go
+++ b/internal/sources/jibe_test.go
@@ -93,3 +93,28 @@ func TestJibeFetchPaginatesAndMaps(t *testing.T) {
 		t.Errorf("Company(5600) = %q, want configured company fallback", got)
 	}
 }
+
+func TestJibeDropsPostingWithoutID(t *testing.T) {
+	// A posting with neither slug nor req_id has no dedup key; emitting it would give an
+	// empty ExternalID and a bare ".../jobs/" URL that collides with every other id-less
+	// posting. It must be dropped, like every sibling adapter does.
+	fake := (&routedHTTP{}).
+		route("page=1", `{"totalCount": 2, "jobs": [`+
+			jibeJob("5441", "Valid Role", "US Remote", "REMOTE", "GitHub, Inc.", "2026-06-16T20:41:00+0000")+`,`+
+			jibeJob("", "No ID Role", "Berlin", "ONSITE", "GitHub, Inc.", "2026-06-15T10:00:00+0000")+
+			`]}`).
+		route("page=2", `{"totalCount": 2, "jobs": []}`)
+
+	jobs, err := NewJibe(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "GitHub", Provider: "jibe", Board: "www.github.careers",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (the id-less posting must drop)", len(jobs))
+	}
+	if jobs[0].ExternalID != "5441" {
+		t.Errorf("ExternalID = %q, want the only posting with an id", jobs[0].ExternalID)
+	}
+}

--- a/internal/sources/jobvite.go
+++ b/internal/sources/jobvite.go
@@ -89,13 +89,13 @@ func jobviteJobID(loc string) string {
 }
 
 // jobvitePosting is the schema.org JobPosting decoded from a Jobvite job page's ld+json. It
-// reuses icimsPlaces, the shared single-or-array jobLocation decoder (Jobvite emits an array, but
+// reuses schemaPlaces, the shared single-or-array jobLocation decoder (Jobvite emits an array, but
 // the flexible form guards a board that emits a single Place object).
 type jobvitePosting struct {
-	Title       string      `json:"title"`
-	Description string      `json:"description"`
-	DatePosted  string      `json:"datePosted"`
-	JobLocation icimsPlaces `json:"jobLocation"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	DatePosted  string       `json:"datePosted"`
+	JobLocation schemaPlaces `json:"jobLocation"`
 }
 
 // location joins each jobLocation place as "City, Country" (falling back to whichever part is

--- a/internal/sources/jobvite.go
+++ b/internal/sources/jobvite.go
@@ -85,10 +85,7 @@ var jobviteJobIDPattern = regexp.MustCompile(`/job/([A-Za-z0-9]+)(?:[/?#]|$)`)
 // jobviteJobID extracts the native posting code from a job page URL, or "" when the URL is not a
 // job posting.
 func jobviteJobID(loc string) string {
-	if m := jobviteJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(jobviteJobIDPattern, loc)
 }
 
 // jobvitePosting is the schema.org JobPosting decoded from a Jobvite job page's ld+json. It

--- a/internal/sources/lumenalta.go
+++ b/internal/sources/lumenalta.go
@@ -72,12 +72,14 @@ func (l lumenalta) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 // location is set to "Remote" (which the pipeline's dictionary derives a remote work-mode from).
 func (lumenalta) toJob(e CompanyEntry, j lumenaltaJob) Job {
 	return Job{
-		ExternalID:  j.ID,
-		URL:         lumenaltaJobURL + j.Slug,
-		Title:       strings.TrimSpace(j.Name),
-		Company:     e.Company,
-		Location:    "Remote",
-		Description: strings.TrimSpace(j.Description),
+		ExternalID: j.ID,
+		URL:        lumenaltaJobURL + j.Slug,
+		Title:      strings.TrimSpace(j.Name),
+		Company:    e.Company,
+		Location:   "Remote",
+		// The API serves the description as plain text; rebuild it into sanitized structural
+		// HTML so the {@html} consumer renders paragraphs/lists instead of one collapsed line.
+		Description: sanitizeHTML(plainTextToHTML(j.Description)),
 		Remote:      true,
 	}
 }

--- a/internal/sources/lumenalta_test.go
+++ b/internal/sources/lumenalta_test.go
@@ -58,11 +58,42 @@ func TestLumenaltaFetch(t *testing.T) {
 	if j.Company != "Lumenalta" {
 		t.Errorf("Company = %q, want the configured company", j.Company)
 	}
-	if j.Description != "At Lumenalta, we build technology that scales." {
-		t.Errorf("Description = %q, want trimmed plain text", j.Description)
+	// The plain-text description is rebuilt into structural HTML for the {@html} consumer.
+	if j.Description != "<p>At Lumenalta, we build technology that scales.</p>" {
+		t.Errorf("Description = %q, want the plain text wrapped as a paragraph", j.Description)
 	}
 	// Lumenalta is a remote-only consultancy; the API carries no location field.
 	if j.Location != "Remote" || !j.Remote {
 		t.Errorf("Location/Remote = %q/%v, want Remote/true", j.Location, j.Remote)
+	}
+}
+
+func TestLumenaltaDescriptionRebuiltAsSafeHTML(t *testing.T) {
+	// The list description is plain text with blank-line blocks and bullet lines. It must be
+	// rebuilt into structural HTML (paragraphs + list) so {@html} renders it, not one collapsed
+	// line, AND sanitized so a stray tag in the plain text cannot inject active content.
+	fake := &fakeHTTP{body: `{
+		"data": [{
+			"_id": "1",
+			"slug": "role",
+			"name": "Engineer",
+			"description": "We build things.\n\n- Ship code\n- Break <script>alert(1)</script>"
+		}],
+		"meta": {"total": 1}
+	}`}
+
+	jobs, err := NewLumenalta(fake).Fetch(context.Background(), CompanyEntry{Company: "Lumenalta", Provider: "lumenalta"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	d := jobs[0].Description
+	if !strings.Contains(d, "<p>We build things.</p>") {
+		t.Errorf("Description = %q, want the first block as a <p> paragraph", d)
+	}
+	if !strings.Contains(d, "<li>Ship code</li>") {
+		t.Errorf("Description = %q, want bullet lines rebuilt as <li>", d)
+	}
+	if strings.Contains(d, "<script>") {
+		t.Errorf("Description = %q, must not carry active <script> content", d)
 	}
 }

--- a/internal/sources/luxoft.go
+++ b/internal/sources/luxoft.go
@@ -127,10 +127,7 @@ var lxJobIDPattern = regexp.MustCompile(`/jobs/[^/?#]*-(\d+)(?:[/?#]|$)`)
 // lxJobID extracts the native posting id (the trailing numeric slug segment, e.g. "25262")
 // from a job page URL.
 func lxJobID(u string) string {
-	if m := lxJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(lxJobIDPattern, u)
 }
 
 // lxPosting is the schema.org JobPosting decoded from a Luxoft job page's ld+json block.

--- a/internal/sources/metacareers.go
+++ b/internal/sources/metacareers.go
@@ -81,10 +81,7 @@ var metaJobIDPattern = regexp.MustCompile(`/job_details/(\d+)/?$`)
 
 // metaJobID extracts the native numeric posting id from a job page URL, "" when absent.
 func metaJobID(loc string) string {
-	if m := metaJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(metaJobIDPattern, loc)
 }
 
 // detail fetches one job page and maps its ld+json JobPosting to a Job, returning ok=false when

--- a/internal/sources/northstone.go
+++ b/internal/sources/northstone.go
@@ -182,21 +182,3 @@ func northstoneCanonical(loc string) string {
 	u.Path += "/"
 	return u.String()
 }
-
-// schemaEmploymentType maps a schema.org JobPosting employmentType enum onto the freehire
-// vocabulary, returning "" for an unknown/absent value (e.g. "OTHER") so the description
-// parser decides.
-func schemaEmploymentType(t string) string {
-	switch strings.ToUpper(strings.TrimSpace(t)) {
-	case "FULL_TIME":
-		return "full_time"
-	case "PART_TIME":
-		return "part_time"
-	case "CONTRACTOR", "TEMPORARY":
-		return "contract"
-	case "INTERN", "INTERNSHIP":
-		return "internship"
-	default:
-		return ""
-	}
-}

--- a/internal/sources/northstone_test.go
+++ b/internal/sources/northstone_test.go
@@ -214,16 +214,3 @@ func TestNorthstoneRegisteredInAll(t *testing.T) {
 		t.Error("FilterableProviders() should include northstone (board-based)")
 	}
 }
-
-func TestSchemaEmploymentType(t *testing.T) {
-	cases := map[string]string{
-		"FULL_TIME": "full_time", "PART_TIME": "part_time",
-		"CONTRACTOR": "contract", "TEMPORARY": "contract",
-		"INTERN": "internship", "OTHER": "", "": "",
-	}
-	for in, want := range cases {
-		if got := schemaEmploymentType(in); got != want {
-			t.Errorf("schemaEmploymentType(%q) = %q, want %q", in, got, want)
-		}
-	}
-}

--- a/internal/sources/odoo.go
+++ b/internal/sources/odoo.go
@@ -76,10 +76,7 @@ var odooJobIDPattern = regexp.MustCompile(`/jobs/(?:detail/)?[^"?#]*?-(\d+)(?:[/
 // odooJobID extracts the native numeric job id from a detail URL, or "" when the URL is not
 // a job posting (e.g. the /jobs listing itself).
 func odooJobID(loc string) string {
-	if m := odooJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(odooJobIDPattern, loc)
 }
 
 // itempropAttr returns the datetime/content attribute of the first element carrying the given

--- a/internal/sources/paycom.go
+++ b/internal/sources/paycom.go
@@ -140,10 +140,7 @@ func (s paycom) detail(ctx context.Context, board, mantle string, auth map[strin
 var paycomSessionJWTPattern = regexp.MustCompile(`"sessionJWT":"([^"]+)"`)
 
 func paycomSessionJWT(page string) string {
-	if m := paycomSessionJWTPattern.FindStringSubmatch(page); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(paycomSessionJWTPattern, page)
 }
 
 // paycomMantleHostPattern captures the regional Mantle API host from the portal page; the

--- a/internal/sources/peopleforce.go
+++ b/internal/sources/peopleforce.go
@@ -121,10 +121,7 @@ var peopleforceJobIDPattern = regexp.MustCompile(`/careers/v/(\d+)`)
 // peopleforceJobID extracts the native numeric job id from a detail URL, or "" when the URL
 // is not a job posting.
 func peopleforceJobID(loc string) string {
-	if m := peopleforceJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(peopleforceJobIDPattern, loc)
 }
 
 // peopleforceListings returns each job card's absolute detail URL and title from a listing

--- a/internal/sources/plaintext.go
+++ b/internal/sources/plaintext.go
@@ -1,0 +1,78 @@
+package sources
+
+import (
+	"html"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// plainTextBulletMarkers are the line-leading glyphs ATS company editors use to mark list
+// items in an otherwise plain-text description (bullet, middle dot, triangular/hollow/filled
+// bullets, hyphen, asterisk, en/em dash). A marker counts only when it leads a line and is
+// followed by whitespace, so a mid-sentence dash, a hyphenated word, or a "*Note" footnote
+// prefix stays prose.
+var plainTextBulletMarkers = map[rune]bool{
+	'•': true, '·': true, '‣': true, '◦': true, '▪': true,
+	'-': true, '*': true, '–': true, '—': true,
+}
+
+// plainTextBullet reports whether a trimmed line is a bullet, returning its text with the
+// leading marker (and the space after it) removed.
+func plainTextBullet(line string) (string, bool) {
+	r, size := utf8.DecodeRuneInString(line)
+	if !plainTextBulletMarkers[r] {
+		return "", false
+	}
+	next, _ := utf8.DecodeRuneInString(line[size:])
+	if !unicode.IsSpace(next) {
+		return "", false // "-word" / "*Note" without a following space is prose, not a bullet
+	}
+	return strings.TrimSpace(line[size:]), true
+}
+
+// plainTextToHTML rebuilds the structural HTML the {@html} consumer renders from a source's
+// plain-text description. Such feeds carry the body as newline-delimited text — blank lines
+// separate blocks, assorted leading glyphs mark bullets — with no markup, so rendered as-is
+// every newline collapses into one unbroken wall of text. This reconstructs it: a run of
+// bullet lines becomes a <ul>, a run of other text lines becomes a <p> (wrapped lines joined
+// by <br>), and a blank line closes the open block. Text is HTML-escaped because it is literal
+// prose, not markup. Callers still pass the result through sanitizeHTML.
+func plainTextToHTML(text string) string {
+	var out strings.Builder
+	var para, bullets []string
+	flushPara := func() {
+		if len(para) > 0 {
+			out.WriteString("<p>" + strings.Join(para, "<br>") + "</p>")
+			para = para[:0]
+		}
+	}
+	flushBullets := func() {
+		if len(bullets) > 0 {
+			out.WriteString("<ul>")
+			for _, li := range bullets {
+				out.WriteString("<li>" + li + "</li>")
+			}
+			out.WriteString("</ul>")
+			bullets = bullets[:0]
+		}
+	}
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			flushBullets()
+			flushPara()
+			continue
+		}
+		if item, ok := plainTextBullet(line); ok {
+			flushPara()
+			bullets = append(bullets, html.EscapeString(item))
+			continue
+		}
+		flushBullets()
+		para = append(para, html.EscapeString(line))
+	}
+	flushBullets()
+	flushPara()
+	return out.String()
+}

--- a/internal/sources/radancy.go
+++ b/internal/sources/radancy.go
@@ -138,8 +138,5 @@ var radancyJobIDPattern = regexp.MustCompile(`/job/.*/(\d+)/?$`)
 // radancyJobID extracts the native numeric posting id from a job page URL, or "" when the
 // URL is not a job posting.
 func radancyJobID(loc string) string {
-	if m := radancyJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(radancyJobIDPattern, loc)
 }

--- a/internal/sources/rapyd.go
+++ b/internal/sources/rapyd.go
@@ -124,10 +124,7 @@ var rapydPositionIDPattern = regexp.MustCompile(`/company/careers/positions/([^/
 // rapydPositionID extracts the slug id (e.g. "sales-manager-bogota-colombia") from a
 // position page URL, or "" when the URL is not a position page.
 func rapydPositionID(u string) string {
-	if m := rapydPositionIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(rapydPositionIDPattern, u)
 }
 
 // firstByTag returns the first element node with the given tag name, or nil.

--- a/internal/sources/schema.go
+++ b/internal/sources/schema.go
@@ -1,0 +1,67 @@
+package sources
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// Shared schema.org JobPosting decode helpers. ATS boards that server-render (or inline) a
+// schema.org JobPosting ld+json block share the same field shapes; these types and mappers let
+// each adapter decode the common parts without redeclaring them.
+
+// schemaEmploymentType maps a schema.org JobPosting employmentType enum onto the freehire
+// vocabulary, returning "" for an unknown/absent value (e.g. "OTHER") so the description parser
+// decides. Shared by the ld+json adapters (northstone, briefhq, djinni, talentlyft, wantapply,
+// onstrider).
+func schemaEmploymentType(t string) string {
+	switch strings.ToUpper(strings.TrimSpace(t)) {
+	case "FULL_TIME":
+		return "full_time"
+	case "PART_TIME":
+		return "part_time"
+	case "CONTRACTOR", "TEMPORARY":
+		return "contract"
+	case "INTERN", "INTERNSHIP":
+		return "internship"
+	default:
+		return ""
+	}
+}
+
+// schemaAddress is a schema.org PostalAddress as ATS JobPosting ld+json emits it. The ld+json
+// adapters decode jobLocation.address into it instead of each redeclaring the same three fields.
+type schemaAddress struct {
+	AddressLocality string `json:"addressLocality"`
+	AddressRegion   string `json:"addressRegion"`
+	AddressCountry  string `json:"addressCountry"`
+}
+
+// schemaPlace is one schema.org Place (a jobLocation entry): its postal address.
+type schemaPlace struct {
+	Address schemaAddress `json:"address"`
+}
+
+// schemaPlaces decodes JobPosting.jobLocation, which ATS ld+json emits as EITHER a single Place
+// object (single-location jobs) OR an array of them (multi-location), normalizing both to a
+// slice. Without this a single-object jobLocation fails to unmarshal into a []schemaPlace and the
+// whole posting is silently dropped. Shared by icims, jobvite, and twogis.
+type schemaPlaces []schemaPlace
+
+func (p *schemaPlaces) UnmarshalJSON(b []byte) error {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		var arr []schemaPlace
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return err
+		}
+		*p = arr
+		return nil
+	}
+	var one schemaPlace
+	if err := json.Unmarshal(trimmed, &one); err != nil {
+		return err
+	}
+	*p = []schemaPlace{one}
+	return nil
+}

--- a/internal/sources/schema_test.go
+++ b/internal/sources/schema_test.go
@@ -1,0 +1,16 @@
+package sources
+
+import "testing"
+
+func TestSchemaEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"FULL_TIME": "full_time", "PART_TIME": "part_time",
+		"CONTRACTOR": "contract", "TEMPORARY": "contract",
+		"INTERN": "internship", "OTHER": "", "": "",
+	}
+	for in, want := range cases {
+		if got := schemaEmploymentType(in); got != want {
+			t.Errorf("schemaEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/solides.go
+++ b/internal/sources/solides.go
@@ -48,7 +48,6 @@ type solidesJob struct {
 		Name string `json:"name"`
 	} `json:"city"`
 	State struct {
-		Name string `json:"name"`
 		Code string `json:"code"`
 	} `json:"state"`
 	HomeOffice bool   `json:"homeOffice"`

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -605,6 +606,16 @@ func trimURLSuffix(u string) string {
 		return u[:i]
 	}
 	return u
+}
+
+// firstSubmatch returns the first capture group of pattern in s, or "". Adapters that pull a
+// native posting id out of a URL with a single-group regex funnel through it, so the "match,
+// else empty" idiom is written once.
+func firstSubmatch(pattern *regexp.Regexp, s string) string {
+	if m := pattern.FindStringSubmatch(s); m != nil {
+		return m[1]
+	}
+	return ""
 }
 
 // joinNonEmpty joins the non-empty parts with ", ", so a location built from

--- a/internal/sources/successfactors.go
+++ b/internal/sources/successfactors.go
@@ -88,8 +88,5 @@ var sfJobIDPattern = regexp.MustCompile(`/(\d+)(?:-[^/]*)?/?$`)
 
 // sfJobID extracts the native numeric posting id from a job page URL.
 func sfJobID(loc string) string {
-	if m := sfJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(sfJobIDPattern, loc)
 }

--- a/internal/sources/talentlyft.go
+++ b/internal/sources/talentlyft.go
@@ -93,10 +93,7 @@ var talentlyftJobIDPattern = regexp.MustCompile(`/jobs/.+-([A-Za-z0-9]{3,})$`)
 // talentlyftJobID extracts the native posting code from a detail URL, or "" for the listing
 // root and section pages that carry no code.
 func talentlyftJobID(loc string) string {
-	if m := talentlyftJobIDPattern.FindStringSubmatch(trimURLSuffix(loc)); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(talentlyftJobIDPattern, trimURLSuffix(loc))
 }
 
 // talentlyftPosting is the schema.org JobPosting decoded from a TalentLyft posting page's

--- a/internal/sources/teamtailor.go
+++ b/internal/sources/teamtailor.go
@@ -126,10 +126,7 @@ var ttJobIDPattern = regexp.MustCompile(`/jobs/(\d+)`)
 
 // ttJobID extracts the native numeric posting id from a job page URL.
 func ttJobID(u string) string {
-	if m := ttJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(ttJobIDPattern, u)
 }
 
 // ttPosting is the schema.org JobPosting decoded from a Teamtailor job page's

--- a/internal/sources/thehub.go
+++ b/internal/sources/thehub.go
@@ -119,10 +119,7 @@ var thehubJobIDPattern = regexp.MustCompile(`/jobs/([0-9a-fA-F]{12,})`)
 // thehubJobID extracts the native posting id from a job page URL, or "" when the URL is not
 // a job posting (so non-job sitemap entries are dropped).
 func thehubJobID(loc string) string {
-	if m := thehubJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(thehubJobIDPattern, loc)
 }
 
 // resolveSubSitemap fetches a sitemap index and returns the first sub-sitemap loc whose URL

--- a/internal/sources/twogis.go
+++ b/internal/sources/twogis.go
@@ -97,14 +97,14 @@ func twogisJobID(loc string) string {
 }
 
 // twogisPosting is the schema.org JobPosting decoded from a 2GIS vacancy page's ld+json. It reuses
-// icimsPlaces, the shared single-or-array jobLocation decoder (2GIS emits a single Place object for
+// schemaPlaces, the shared single-or-array jobLocation decoder (2GIS emits a single Place object for
 // located roles and omits it for remote ones).
 type twogisPosting struct {
-	Title           string      `json:"title"`
-	Description     string      `json:"description"`
-	DatePosted      string      `json:"datePosted"`
-	JobLocationType string      `json:"jobLocationType"`
-	JobLocation     icimsPlaces `json:"jobLocation"`
+	Title           string       `json:"title"`
+	Description     string       `json:"description"`
+	DatePosted      string       `json:"datePosted"`
+	JobLocationType string       `json:"jobLocationType"`
+	JobLocation     schemaPlaces `json:"jobLocation"`
 }
 
 // location joins each jobLocation place as "City, Country" (falling back to whichever part is

--- a/internal/sources/twogis.go
+++ b/internal/sources/twogis.go
@@ -93,10 +93,7 @@ var twogisJobIDPattern = regexp.MustCompile(`/vacancies/[a-z0-9_-]+/(\d+)(?:[/?#
 // twogisJobID extracts the native posting id from a vacancy page URL, or "" when the URL is not a
 // vacancy posting.
 func twogisJobID(loc string) string {
-	if m := twogisJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(twogisJobIDPattern, loc)
 }
 
 // twogisPosting is the schema.org JobPosting decoded from a 2GIS vacancy page's ld+json. It reuses

--- a/internal/sources/vagas.go
+++ b/internal/sources/vagas.go
@@ -137,10 +137,7 @@ var vagasJobIDPattern = regexp.MustCompile(`/vagas/v(\d+)`)
 
 // vagasJobID extracts the native posting id from a job URL, or "" when the URL is not a job link.
 func vagasJobID(u string) string {
-	if m := vagasJobIDPattern.FindStringSubmatch(u); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(vagasJobIDPattern, u)
 }
 
 // vagasPosting is the schema.org JobPosting decoded from a vagas.com job page. identifier.value

--- a/internal/sources/wpyoast.go
+++ b/internal/sources/wpyoast.go
@@ -129,8 +129,5 @@ var wpyoastJobIDPattern = regexp.MustCompile(`/job/(\d+)-`)
 // wpyoastJobID extracts the native numeric posting id from a job page URL, or "" when the
 // URL is not a job posting (so non-job sitemap entries are dropped).
 func wpyoastJobID(loc string) string {
-	if m := wpyoastJobIDPattern.FindStringSubmatch(loc); m != nil {
-		return m[1]
-	}
-	return ""
+	return firstSubmatch(wpyoastJobIDPattern, loc)
 }


### PR DESCRIPTION
First increment of an adapter-layer audit (dedup / simplification / abstraction). Bug fixes plus the low-risk shared-decode foundations; the broader per-adapter migrations follow as separate PRs so each stays reviewable.

## Correctness fixes (Tier 0, TDD)
- **alfabank**: pagination looped forever when the API reported a `total` larger than the rows actually served (the workday `total:0` class); break on any empty page, like the sibling paginators.
- **jibe**: a posting with neither `slug` nor `req_id` was emitted with an empty `ExternalID` and a bare `.../jobs/` URL, colliding on the dedup key; `toJob` now drops it.
- **lumenalta**: the plain-text description was written straight into the `{@html}`-rendered field, bypassing `sanitizeHTML` and collapsing every newline; reuse djinni's plain-text→structural-HTML converter, extracted into the shared `plainTextToHTML`, and sanitize the result.

## Shared foundations
- **`firstSubmatch` → `source.go`**: the "first regex capture group, else empty" idiom lived in `cornerstone.go` but was hand-reimplemented in ~30 adapters' id extractors. Promote it and collapse each pure `FindStringSubmatch→m[1]` wrapper onto it, keeping the named wrappers, docstrings, and regexes. Branching extractors (clinch/likeit/enlizt/spark/weworkremotely) untouched.
- **`schema.go`**: home the schema.org JobPosting decode helpers — move `schemaEmploymentType` out of `northstone.go`, add `schemaAddress`/`schemaPlace`, and promote `icimsPlaces` (the single-or-array `jobLocation` decoder) to `schemaPlaces`, now shared by icims/jobvite/twogis. Location-building stays per-adapter, so no behaviour change.
- **dead code**: drop the unread `inhirePost.Status` and `solidesJob.State.Name`.

All commits are behaviour-preserving except the three fixes; `go build ./... && go vet ./... && go test ./...` green, `gofmt` clean.

## Follow-ups (separate PRs)
- schema.org `.Location()` migrations for the clean 3-field joiners (watch the 2-field trap: bayt/gulftalent/teamtailor/itechart)
- `sitemap.go` (shared `<loc>` decode) + ~16 adapter migrations
- `crawlPagedLinks` for the 5 identical paginated-listing crawlers
- HTML walk-helper consolidation into `html.go`
- Tier 2/3 quick wins (parsePubDate/parseRFC3339OrDate/distinctJoin, structured WorkMode, etc.)