### PR TITLE
refactor(sources): share sitemap <loc> decoding

### DIFF
--- a/internal/sources/dataart.go
+++ b/internal/sources/dataart.go
@@ -35,22 +35,11 @@ func (dataart) Provider() string { return "dataart" }
 func (dataart) boardless() {}
 
 func (d dataart) Fetch(ctx context.Context, ce CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
-	if err := d.http.GetXML(ctx, dataartSitemapURL, &sitemap); err != nil {
-		return nil, fmt.Errorf("dataart: sitemap: %w", err)
-	}
-
 	// Keep only canonical English vacancy pages: the listing root, unrelated pages, and the
 	// /xx/vacancies/… localisations yield no code, so each vacancy is ingested once.
-	var urls []string
-	for _, u := range sitemap.URLs {
-		if dataartVacancyCode(u.Loc) != "" {
-			urls = append(urls, u.Loc)
-		}
+	urls, err := sitemapJobLocs(ctx, d.http, dataartSitemapURL, dataartVacancyCode)
+	if err != nil {
+		return nil, fmt.Errorf("dataart: sitemap: %w", err)
 	}
 
 	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {

--- a/internal/sources/epam.go
+++ b/internal/sources/epam.go
@@ -31,23 +31,12 @@ func NewEPAM(c epamHTTP) Source { return epam{http: c} }
 func (epam) Provider() string { return "epam" }
 
 func (e epam) Fetch(ctx context.Context, ce CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
 	sitemapURL := fmt.Sprintf("https://%s/sitemap.xml.gz", ce.Board)
-	if err := e.http.GetXML(ctx, sitemapURL, &sitemap); err != nil {
-		return nil, fmt.Errorf("epam: sitemap %s: %w", ce.Board, err)
-	}
-
 	// Keep only English vacancy pages (epamJobID is empty for the listing, language roots,
 	// and the /uk//de/… localisations, so each vacancy is ingested once under its English url).
-	var urls []string
-	for _, u := range sitemap.URLs {
-		if epamJobID(u.Loc) != "" {
-			urls = append(urls, u.Loc)
-		}
+	urls, err := sitemapJobLocs(ctx, e.http, sitemapURL, epamJobID)
+	if err != nil {
+		return nil, fmt.Errorf("epam: sitemap %s: %w", ce.Board, err)
 	}
 
 	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.

--- a/internal/sources/icims.go
+++ b/internal/sources/icims.go
@@ -30,12 +30,6 @@ func NewICIMS(c icimsHTTP) Source { return icims{http: c} }
 
 func (icims) Provider() string { return "icims" }
 
-// icimsSitemapEntry is one <url> of the sitemap: the page URL (a job page, the search
-// page, or the intro page).
-type icimsSitemapEntry struct {
-	Loc string `xml:"loc"`
-}
-
 func (s icims) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	host := icimsHost(e.Board)
 	locs, err := s.jobLocs(ctx, host, e.Board)
@@ -65,26 +59,19 @@ func icimsHost(board string) string {
 	return "careers-" + board + ".icims.com"
 }
 
-// icimsSitemap decodes either sitemap shape: a flat <urlset> (child <url>) or a
-// <sitemapindex> (child <sitemap>). Both nest a <loc>, so one entry type serves both.
-type icimsSitemap struct {
-	URLs     []icimsSitemapEntry `xml:"url"`
-	Sitemaps []icimsSitemapEntry `xml:"sitemap"`
-}
-
 // jobLocs collects the board's job-posting URLs from its sitemap, following a sitemap index
 // one level deep (vanity/careers-home sites nest their <url> entries under sub-sitemaps) and
 // keeping only locs with a parseable /jobs/<id> segment — dropping the /jobs/search and
 // /jobs/intro entries, which carry no numeric id.
 func (s icims) jobLocs(ctx context.Context, host, board string) ([]string, error) {
-	var root icimsSitemap
-	if err := s.http.GetXML(ctx, fmt.Sprintf("https://%s/sitemap.xml", host), &root); err != nil {
+	root, err := getSitemap(ctx, s.http, fmt.Sprintf("https://%s/sitemap.xml", host))
+	if err != nil {
 		return nil, fmt.Errorf("icims: sitemap %s: %w", board, err)
 	}
 	entries := root.URLs
 	for _, sm := range root.Sitemaps {
-		var sub icimsSitemap
-		if err := s.http.GetXML(ctx, sm.Loc, &sub); err != nil {
+		sub, err := getSitemap(ctx, s.http, sm.Loc)
+		if err != nil {
 			// Skip a flaky sub-sitemap rather than losing the whole board — the same
 			// per-entry isolation the detail fan-out uses; the missed postings reappear
 			// on the next crawl. Only a failed ROOT sitemap fails the board.

--- a/internal/sources/itechart.go
+++ b/internal/sources/itechart.go
@@ -28,21 +28,10 @@ func NewITechArt(c itechartHTTP) Source { return itechart{http: c} }
 func (itechart) Provider() string { return "itechart" }
 
 func (i itechart) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
 	sitemapURL := fmt.Sprintf("https://%s/sitemap.xml", e.Board)
-	if err := i.http.GetXML(ctx, sitemapURL, &sitemap); err != nil {
+	urls, err := sitemapJobLocs(ctx, i.http, sitemapURL, itechartJobID)
+	if err != nil {
 		return nil, fmt.Errorf("itechart: sitemap %s: %w", e.Board, err)
-	}
-
-	var urls []string
-	for _, u := range sitemap.URLs {
-		if itechartJobID(u.Loc) != "" {
-			urls = append(urls, u.Loc)
-		}
 	}
 
 	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {

--- a/internal/sources/radancy.go
+++ b/internal/sources/radancy.go
@@ -29,28 +29,13 @@ func NewRadancy(c radancyHTTP) Source { return radancy{http: c} }
 
 func (radancy) Provider() string { return "radancy" }
 
-// radancySitemapEntry is one <url> of the sitemap: the page URL (a job page, a category
-// page, or the landing page).
-type radancySitemapEntry struct {
-	Loc string `xml:"loc"`
-}
-
 func (s radancy) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []radancySitemapEntry `xml:"url"`
-	}
 	url := fmt.Sprintf("https://%s/sitemap.xml", e.Board)
-	if err := s.http.GetXML(ctx, url, &sitemap); err != nil {
-		return nil, fmt.Errorf("radancy: sitemap %s: %w", e.Board, err)
-	}
-
 	// Keep only real job postings: a loc with a /job/ segment and a trailing numeric id.
 	// This drops the /category/ and landing entries, which carry no posting id.
-	var locs []string
-	for _, u := range sitemap.URLs {
-		if radancyJobID(u.Loc) != "" {
-			locs = append(locs, u.Loc)
-		}
+	locs, err := sitemapJobLocs(ctx, s.http, url, radancyJobID)
+	if err != nil {
+		return nil, fmt.Errorf("radancy: sitemap %s: %w", e.Board, err)
 	}
 
 	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.

--- a/internal/sources/sitemap.go
+++ b/internal/sources/sitemap.go
@@ -1,0 +1,65 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// Shared sitemaps.org decode helpers. Adapters that enumerate a platform's postings from its
+// sitemap.xml decode into these types and funnel through these helpers rather than each
+// redeclaring the same leaf struct and <loc>-scan loop.
+
+// sitemapLoc is one <url> or <sitemap> entry: the URL and its optional last-modified date.
+type sitemapLoc struct {
+	Loc     string `xml:"loc"`
+	LastMod string `xml:"lastmod"`
+}
+
+// sitemapDoc decodes either sitemap shape — a flat <urlset> (child <url>) or a <sitemapindex>
+// (child <sitemap>). Both nest a <loc>, so one type serves both.
+type sitemapDoc struct {
+	URLs     []sitemapLoc `xml:"url"`
+	Sitemaps []sitemapLoc `xml:"sitemap"`
+}
+
+// getSitemap fetches and decodes a sitemap document.
+func getSitemap(ctx context.Context, c XMLGetter, url string) (sitemapDoc, error) {
+	var doc sitemapDoc
+	if err := c.GetXML(ctx, url, &doc); err != nil {
+		return sitemapDoc{}, err
+	}
+	return doc, nil
+}
+
+// sitemapJobLocs fetches a flat sitemap and returns each <url> loc that id maps to a non-empty
+// posting id — the shared body of the sitemap-enumerating adapters, which differ only in their
+// id extractor. The error is returned unwrapped so the caller can add its own board context.
+func sitemapJobLocs(ctx context.Context, c XMLGetter, url string, id func(string) string) ([]string, error) {
+	doc, err := getSitemap(ctx, c, url)
+	if err != nil {
+		return nil, err
+	}
+	var locs []string
+	for _, u := range doc.URLs {
+		if id(u.Loc) != "" {
+			locs = append(locs, u.Loc)
+		}
+	}
+	return locs, nil
+}
+
+// resolveSubSitemap fetches a sitemap index and returns the first sub-sitemap loc whose URL
+// contains needle, or "" when none matches. Shared by the sitemap-index adapters.
+func resolveSubSitemap(ctx context.Context, c XMLGetter, indexURL, needle string) (string, error) {
+	doc, err := getSitemap(ctx, c, indexURL)
+	if err != nil {
+		return "", fmt.Errorf("sitemap index: %w", err)
+	}
+	for _, sm := range doc.Sitemaps {
+		if strings.Contains(sm.Loc, needle) {
+			return sm.Loc, nil
+		}
+	}
+	return "", nil
+}

--- a/internal/sources/talentlyft.go
+++ b/internal/sources/talentlyft.go
@@ -29,22 +29,11 @@ func NewTalentLyft(c talentlyftHTTP) Source { return talentlyft{http: c} }
 func (talentlyft) Provider() string { return "talentlyft" }
 
 func (s talentlyft) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
 	sitemapURL := fmt.Sprintf("https://%s.talentlyft.com/sitemap.xml", e.Board)
-	if err := s.http.GetXML(ctx, sitemapURL, &sitemap); err != nil {
-		return nil, fmt.Errorf("talentlyft: sitemap %s: %w", e.Board, err)
-	}
-
 	// Keep only posting URLs (the listing root and section pages carry no job code).
-	var urls []string
-	for _, u := range sitemap.URLs {
-		if talentlyftJobID(u.Loc) != "" {
-			urls = append(urls, u.Loc)
-		}
+	urls, err := sitemapJobLocs(ctx, s.http, sitemapURL, talentlyftJobID)
+	if err != nil {
+		return nil, fmt.Errorf("talentlyft: sitemap %s: %w", e.Board, err)
 	}
 
 	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {

--- a/internal/sources/thehub.go
+++ b/internal/sources/thehub.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"golang.org/x/net/html"
 )
@@ -44,20 +43,9 @@ func (s thehub) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 		return nil, nil
 	}
 
-	var urls struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
-	if err := s.http.GetXML(ctx, jobSitemap, &urls); err != nil {
+	locs, err := sitemapJobLocs(ctx, s.http, jobSitemap, thehubJobID)
+	if err != nil {
 		return nil, fmt.Errorf("thehub: job sitemap: %w", err)
-	}
-
-	var locs []string
-	for _, u := range urls.URLs {
-		if thehubJobID(u.Loc) != "" {
-			locs = append(locs, u.Loc)
-		}
 	}
 
 	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
@@ -120,23 +108,4 @@ var thehubJobIDPattern = regexp.MustCompile(`/jobs/([0-9a-fA-F]{12,})`)
 // a job posting (so non-job sitemap entries are dropped).
 func thehubJobID(loc string) string {
 	return firstSubmatch(thehubJobIDPattern, loc)
-}
-
-// resolveSubSitemap fetches a sitemap index and returns the first sub-sitemap loc whose URL
-// contains needle, or "" when none matches. Shared by the sitemap-index aggregators.
-func resolveSubSitemap(ctx context.Context, c XMLGetter, indexURL, needle string) (string, error) {
-	var index struct {
-		Sitemaps []struct {
-			Loc string `xml:"loc"`
-		} `xml:"sitemap"`
-	}
-	if err := c.GetXML(ctx, indexURL, &index); err != nil {
-		return "", fmt.Errorf("sitemap index: %w", err)
-	}
-	for _, sm := range index.Sitemaps {
-		if strings.Contains(sm.Loc, needle) {
-			return sm.Loc, nil
-		}
-	}
-	return "", nil
 }

--- a/internal/sources/wpyoast.go
+++ b/internal/sources/wpyoast.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"golang.org/x/net/html"
 )
@@ -35,39 +34,17 @@ func (s wpyoast) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	// The Yoast sitemap index lists per-post-type sub-sitemaps; the postings live in the
 	// "job_listing" one. Resolving it from the index (rather than guessing the filename)
 	// keeps the adapter working across Yoast versions that name the file differently.
-	var index struct {
-		Sitemaps []struct {
-			Loc string `xml:"loc"`
-		} `xml:"sitemap"`
-	}
-	if err := s.http.GetXML(ctx, fmt.Sprintf("https://%s/sitemap.xml", e.Board), &index); err != nil {
-		return nil, fmt.Errorf("wpyoast: sitemap index %s: %w", e.Board, err)
-	}
-	jobSitemap := ""
-	for _, sm := range index.Sitemaps {
-		if strings.Contains(sm.Loc, "job_listing") {
-			jobSitemap = sm.Loc
-			break
-		}
+	jobSitemap, err := resolveSubSitemap(ctx, s.http, fmt.Sprintf("https://%s/sitemap.xml", e.Board), "job_listing")
+	if err != nil {
+		return nil, fmt.Errorf("wpyoast: %s: %w", e.Board, err)
 	}
 	if jobSitemap == "" {
 		return nil, nil // no job_listing sub-sitemap → no postings, not an error
 	}
 
-	var urls struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
-	if err := s.http.GetXML(ctx, jobSitemap, &urls); err != nil {
+	locs, err := sitemapJobLocs(ctx, s.http, jobSitemap, wpyoastJobID)
+	if err != nil {
 		return nil, fmt.Errorf("wpyoast: job sitemap %s: %w", e.Board, err)
-	}
-
-	var locs []string
-	for _, u := range urls.URLs {
-		if wpyoastJobID(u.Loc) != "" {
-			locs = append(locs, u.Loc)
-		}
 	}
 
 	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.


### PR DESCRIPTION
Stacked on #812 (base = `refactor/sources-adapter-dedup`). Second increment of the adapter-layer audit — the sitemap-enumeration foundation.

## What
- **`sitemap.go`**: `sitemapLoc`/`sitemapDoc` decode types, `getSitemap`, `sitemapJobLocs(ctx, c, url, id)` (fetch a flat sitemap → locs whose `id(loc)` is non-empty), and `resolveSubSitemap` moved out of `thehub.go`.
- Migrate the flat string-filter crawlers onto `sitemapJobLocs`: **dataart, epam, itechart, talentlyft, radancy**.
- Migrate **wpyoast**/**thehub** onto `resolveSubSitemap` + `sitemapJobLocs` (drops their inline index loops + now-unused `strings` import).
- Migrate **icims**'s one-level sub-sitemap fan-out onto `getSitemap`/`sitemapDoc` (drops `icimsSitemap`/`icimsSitemapEntry`).

All behaviour-preserving; `go build ./... && go vet ./... && go test ./...` green, `gofmt` clean.

## Deliberately deferred (follow-up PR, higher care)
- **successfactors / metacareers / avature / clinch** carry `<lastmod>` as a `posted_at` work-item into `detail()`/inline mapping — migrating them touches `detail()` signatures, the most likely place for a `posted_at` regression, so they get their own reviewed PR.
- **gulftalent / avito** fan out over *all* sub-sitemaps (collect-many) — they'd share only `sitemapDoc`, deferred with the above.
- **isolvedhire** intentionally STREAMS its sitemap (`GetStream`, >32 MiB prod sitemaps) — left as-is.
- **onstrider** uses a bool predicate + a special empty-result guard — left as-is.

Merge order: land #812 first, then this.