### PR TITLE
feat(cv): interactive CV tailoring — patch API, bootstrap, tailor-context + fit-page CTA (beta)

### DIFF
--- a/cmd/gen-contracts/main.go
+++ b/cmd/gen-contracts/main.go
@@ -130,10 +130,11 @@ func genStructs() (string, error) {
 			{
 				// The editable CV-builder document wire shape (Document + Header +
 				// Experience + Education + SkillGroup + Language + Project +
-				// Certification). Only cv.go — seed/store/renderer are server-only.
+				// Certification) and the tailoring Patch. Only the wire files — seed/store/
+				// renderer are server-only.
 				Path:         "github.com/strelov1/freehire/internal/cv",
 				OutputPath:   cvTS,
-				IncludeFiles: []string{"cv.go"},
+				IncludeFiles: []string{"cv.go", "patch.go"},
 			},
 		},
 	}

--- a/internal/cv/patch.go
+++ b/internal/cv/patch.go
@@ -1,0 +1,160 @@
+package cv
+
+import (
+	"errors"
+	"fmt"
+)
+
+// This file holds the CV patch wire shape (Patch + PatchOp) and the pure Apply transform.
+// Like cv.go it stays dependency-light so cmd/gen-contracts can emit the TypeScript type,
+// and it is server-agnostic (no I/O) — the caller Sanitizes the result before persisting.
+
+// ErrInvalidPatch marks a patch that addresses a field or index that does not exist, or is
+// otherwise malformed. Handlers map it to a 422. Apply never mutates the document when it
+// returns ErrInvalidPatch — bad addressing is a no-op, not a partial edit.
+var ErrInvalidPatch = errors.New("cv: invalid patch")
+
+// PatchOp is the discriminator selecting which field-level edit a Patch performs.
+type PatchOp string
+
+const (
+	PatchSetSummary     PatchOp = "set_summary"
+	PatchSetHeaderField PatchOp = "set_header_field"
+	PatchAddBullet      PatchOp = "add_bullet"
+	PatchReplaceBullet  PatchOp = "replace_bullet"
+	PatchRemoveBullet   PatchOp = "remove_bullet"
+	PatchReorderBullets PatchOp = "reorder_bullets"
+	PatchSetSkillGroup  PatchOp = "set_skill_group"
+)
+
+// Patch is one field-level edit to a CV Document. Op selects the operation; the remaining
+// fields are its address and payload, and only the ones an op needs are read. A patch names
+// the single field it changes rather than re-emitting the document, so an LLM tailoring a CV
+// mid-session cannot silently drop untouched sections.
+type Patch struct {
+	Op         PatchOp  `json:"op"`
+	Experience int      `json:"experience,omitempty"` // index into Document.Experience
+	Bullet     int      `json:"bullet,omitempty"`     // index into the entry's Bullets (replace/remove)
+	Field      string   `json:"field,omitempty"`      // header field name (set_header_field)
+	Value      string   `json:"value,omitempty"`      // summary / bullet / header value
+	Order      []int    `json:"order,omitempty"`      // permutation of bullet indices (reorder_bullets)
+	Group      string   `json:"group,omitempty"`      // skill group name (set_skill_group)
+	Items      []string `json:"items,omitempty"`      // skill group items (set_skill_group)
+}
+
+// Apply returns a copy of doc with the patch applied, or ErrInvalidPatch (leaving doc
+// untouched) when the patch addresses something that does not exist. It never mutates its
+// input: every edit builds fresh slices along the touched path, so the caller's document is
+// safe to keep. The result is not sanitized — the caller runs Document.Sanitize before
+// persisting.
+func Apply(doc Document, p Patch) (Document, error) {
+	switch p.Op {
+	case PatchSetSummary:
+		doc.Summary = p.Value
+		return doc, nil
+	case PatchSetHeaderField:
+		return applyHeaderField(doc, p)
+	case PatchAddBullet, PatchReplaceBullet, PatchRemoveBullet, PatchReorderBullets:
+		return applyBulletOp(doc, p)
+	case PatchSetSkillGroup:
+		return applySkillGroup(doc, p)
+	default:
+		return doc, fmt.Errorf("%w: unknown op %q", ErrInvalidPatch, p.Op)
+	}
+}
+
+func applyHeaderField(doc Document, p Patch) (Document, error) {
+	switch p.Field {
+	case "full_name":
+		doc.Header.FullName = p.Value
+	case "email":
+		doc.Header.Email = p.Value
+	case "phone":
+		doc.Header.Phone = p.Value
+	case "location":
+		doc.Header.Location = p.Value
+	default:
+		return doc, fmt.Errorf("%w: unknown header field %q", ErrInvalidPatch, p.Field)
+	}
+	return doc, nil
+}
+
+func applyBulletOp(doc Document, p Patch) (Document, error) {
+	if p.Experience < 0 || p.Experience >= len(doc.Experience) {
+		return doc, fmt.Errorf("%w: experience index %d out of range", ErrInvalidPatch, p.Experience)
+	}
+	entry := doc.Experience[p.Experience]
+	next, err := editBullets(entry.Bullets, p)
+	if err != nil {
+		return doc, err
+	}
+	entry.Bullets = next
+
+	out := append([]ExperienceItem(nil), doc.Experience...)
+	out[p.Experience] = entry
+	doc.Experience = out
+	return doc, nil
+}
+
+func editBullets(bullets []string, p Patch) ([]string, error) {
+	switch p.Op {
+	case PatchAddBullet:
+		return append(append([]string(nil), bullets...), p.Value), nil
+	case PatchReplaceBullet:
+		if err := checkBulletIndex(bullets, p.Bullet); err != nil {
+			return nil, err
+		}
+		next := append([]string(nil), bullets...)
+		next[p.Bullet] = p.Value
+		return next, nil
+	case PatchRemoveBullet:
+		if err := checkBulletIndex(bullets, p.Bullet); err != nil {
+			return nil, err
+		}
+		next := append([]string(nil), bullets[:p.Bullet]...)
+		return append(next, bullets[p.Bullet+1:]...), nil
+	case PatchReorderBullets:
+		return permute(bullets, p.Order)
+	default:
+		return nil, fmt.Errorf("%w: unknown op %q", ErrInvalidPatch, p.Op)
+	}
+}
+
+func checkBulletIndex(bullets []string, i int) error {
+	if i < 0 || i >= len(bullets) {
+		return fmt.Errorf("%w: bullet index %d out of range", ErrInvalidPatch, i)
+	}
+	return nil
+}
+
+// permute returns bullets reordered so result[i] = bullets[order[i]]. order must be a
+// permutation of the bullet indices — same length, every index in range, no repeats.
+func permute(bullets []string, order []int) ([]string, error) {
+	if len(order) != len(bullets) {
+		return nil, fmt.Errorf("%w: order length %d does not match %d bullets", ErrInvalidPatch, len(order), len(bullets))
+	}
+	seen := make([]bool, len(bullets))
+	out := make([]string, len(bullets))
+	for dst, src := range order {
+		if src < 0 || src >= len(bullets) || seen[src] {
+			return nil, fmt.Errorf("%w: order is not a permutation of the bullets", ErrInvalidPatch)
+		}
+		seen[src] = true
+		out[dst] = bullets[src]
+	}
+	return out, nil
+}
+
+func applySkillGroup(doc Document, p Patch) (Document, error) {
+	groups := append([]SkillGroup(nil), doc.Skills...)
+	items := append([]string(nil), p.Items...)
+	for i := range groups {
+		if groups[i].Group == p.Group {
+			groups[i].Items = items
+			doc.Skills = groups
+			return doc, nil
+		}
+	}
+	doc.Skills = append(groups, SkillGroup{Group: p.Group, Items: items})
+	return doc, nil
+}

--- a/internal/cv/patch_test.go
+++ b/internal/cv/patch_test.go
@@ -1,0 +1,185 @@
+package cv
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// sampleDoc returns a small but multi-section document for patch tests.
+func sampleDoc() Document {
+	return Document{
+		Header:  Header{FullName: "Ada Lovelace", Email: "ada@example.com"},
+		Summary: "Backend engineer",
+		Experience: []ExperienceItem{
+			{Role: "Engineer", Company: "Acme", Bullets: []string{"Shipped API", "Cut latency"}},
+			{Role: "Intern", Company: "Beta", Bullets: []string{"Wrote docs"}},
+		},
+		Skills: []SkillGroup{{Group: "Languages", Items: []string{"Go"}}},
+	}
+}
+
+func TestApply_SetSummary(t *testing.T) {
+	in := sampleDoc()
+	out, err := Apply(in, Patch{Op: PatchSetSummary, Value: "Senior backend engineer"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Summary != "Senior backend engineer" {
+		t.Errorf("summary = %q, want updated", out.Summary)
+	}
+	// Every other section is unchanged.
+	if !reflect.DeepEqual(out.Experience, in.Experience) || !reflect.DeepEqual(out.Skills, in.Skills) || !reflect.DeepEqual(out.Header, in.Header) {
+		t.Errorf("set_summary touched other sections")
+	}
+}
+
+func TestApply_AddBullet(t *testing.T) {
+	in := sampleDoc()
+	out, err := Apply(in, Patch{Op: PatchAddBullet, Experience: 0, Value: "Led migration"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"Shipped API", "Cut latency", "Led migration"}
+	if !reflect.DeepEqual(out.Experience[0].Bullets, want) {
+		t.Errorf("bullets = %v, want %v", out.Experience[0].Bullets, want)
+	}
+	// The other experience entry is untouched.
+	if !reflect.DeepEqual(out.Experience[1], in.Experience[1]) {
+		t.Errorf("add_bullet touched a different experience entry")
+	}
+}
+
+func TestApply_ReplaceBullet(t *testing.T) {
+	in := sampleDoc()
+	out, err := Apply(in, Patch{Op: PatchReplaceBullet, Experience: 0, Bullet: 1, Value: "Cut p99 latency 40%"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"Shipped API", "Cut p99 latency 40%"}
+	if !reflect.DeepEqual(out.Experience[0].Bullets, want) {
+		t.Errorf("bullets = %v, want %v", out.Experience[0].Bullets, want)
+	}
+}
+
+func TestApply_RemoveBullet(t *testing.T) {
+	in := sampleDoc()
+	out, err := Apply(in, Patch{Op: PatchRemoveBullet, Experience: 0, Bullet: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"Cut latency"}
+	if !reflect.DeepEqual(out.Experience[0].Bullets, want) {
+		t.Errorf("bullets = %v, want %v", out.Experience[0].Bullets, want)
+	}
+}
+
+func TestApply_ReorderBullets(t *testing.T) {
+	in := sampleDoc()
+	out, err := Apply(in, Patch{Op: PatchReorderBullets, Experience: 0, Order: []int{1, 0}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"Cut latency", "Shipped API"}
+	if !reflect.DeepEqual(out.Experience[0].Bullets, want) {
+		t.Errorf("bullets = %v, want %v (order applied)", out.Experience[0].Bullets, want)
+	}
+}
+
+func TestApply_ReorderBullets_rejectsNonPermutation(t *testing.T) {
+	cases := map[string][]int{
+		"wrong length": {0},
+		"out of range": {0, 2},
+		"duplicate":    {0, 0},
+	}
+	for name, order := range cases {
+		t.Run(name, func(t *testing.T) {
+			in := sampleDoc()
+			_, err := Apply(in, Patch{Op: PatchReorderBullets, Experience: 0, Order: order})
+			if !errors.Is(err, ErrInvalidPatch) {
+				t.Errorf("order %v: err = %v, want ErrInvalidPatch", order, err)
+			}
+		})
+	}
+}
+
+func TestApply_SetHeaderField(t *testing.T) {
+	in := sampleDoc()
+	out, err := Apply(in, Patch{Op: PatchSetHeaderField, Field: "location", Value: "Berlin"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Header.Location != "Berlin" {
+		t.Errorf("location = %q, want Berlin", out.Header.Location)
+	}
+	if out.Header.FullName != in.Header.FullName {
+		t.Errorf("set_header_field clobbered another header field")
+	}
+}
+
+func TestApply_SetHeaderField_unknownField(t *testing.T) {
+	in := sampleDoc()
+	_, err := Apply(in, Patch{Op: PatchSetHeaderField, Field: "nickname", Value: "x"})
+	if !errors.Is(err, ErrInvalidPatch) {
+		t.Errorf("err = %v, want ErrInvalidPatch", err)
+	}
+}
+
+func TestApply_SetSkillGroup(t *testing.T) {
+	t.Run("replaces items of an existing group by name", func(t *testing.T) {
+		in := sampleDoc()
+		out, err := Apply(in, Patch{Op: PatchSetSkillGroup, Group: "Languages", Items: []string{"Go", "Rust"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []SkillGroup{{Group: "Languages", Items: []string{"Go", "Rust"}}}
+		if !reflect.DeepEqual(out.Skills, want) {
+			t.Errorf("skills = %v, want %v", out.Skills, want)
+		}
+	})
+	t.Run("appends a new group when the name is new", func(t *testing.T) {
+		in := sampleDoc()
+		out, err := Apply(in, Patch{Op: PatchSetSkillGroup, Group: "Cloud", Items: []string{"AWS"}})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(out.Skills) != 2 || out.Skills[1].Group != "Cloud" {
+			t.Errorf("expected a new Cloud group appended, got %v", out.Skills)
+		}
+	})
+}
+
+func TestApply_OutOfRangeExperience(t *testing.T) {
+	in := sampleDoc()
+	_, err := Apply(in, Patch{Op: PatchAddBullet, Experience: 5, Value: "x"})
+	if !errors.Is(err, ErrInvalidPatch) {
+		t.Errorf("err = %v, want ErrInvalidPatch", err)
+	}
+}
+
+func TestApply_OutOfRangeBullet(t *testing.T) {
+	in := sampleDoc()
+	_, err := Apply(in, Patch{Op: PatchReplaceBullet, Experience: 0, Bullet: 9, Value: "x"})
+	if !errors.Is(err, ErrInvalidPatch) {
+		t.Errorf("err = %v, want ErrInvalidPatch", err)
+	}
+}
+
+func TestApply_UnknownOp(t *testing.T) {
+	in := sampleDoc()
+	_, err := Apply(in, Patch{Op: "frobnicate"})
+	if !errors.Is(err, ErrInvalidPatch) {
+		t.Errorf("err = %v, want ErrInvalidPatch", err)
+	}
+}
+
+func TestApply_DoesNotMutateInput(t *testing.T) {
+	in := sampleDoc()
+	before := sampleDoc() // independent identical copy
+	if _, err := Apply(in, Patch{Op: PatchAddBullet, Experience: 0, Value: "New"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(in, before) {
+		t.Errorf("Apply mutated its input: got %+v, want %+v", in, before)
+	}
+}

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -7,13 +7,19 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/resumeextract"
 )
 
 // ErrNotFound is returned when a CV id is missing or owned by another user. The handler
 // maps it to 404 (owner isolation never leaks the existence of a foreign CV).
 var ErrNotFound = errors.New("cv: not found")
+
+// ErrNoResume is returned by Tailor when the user has neither a base CV nor an extracted
+// résumé to seed one from. The handler maps it to 409 (add a résumé first).
+var ErrNoResume = errors.New("cv: no résumé to seed a base CV")
 
 // Meta is a CV without its document body — the shape the list and mutation responses use.
 type Meta struct {
@@ -38,6 +44,14 @@ type Repository interface {
 	Get(ctx context.Context, id, userID int64) (db.GetCVByIDRow, error)
 	Update(ctx context.Context, id, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error)
 	Delete(ctx context.Context, id, userID int64) (int64, error)
+	GetBase(ctx context.Context, userID int64) (db.GetBaseCVByUserRow, error)
+	CreateTailored(ctx context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error)
+}
+
+// Seeder provides the user's extracted résumé, used to seed a base CV when they have none.
+// resume.Store already satisfies this shape (Structured), so the handler passes it directly.
+type Seeder interface {
+	Structured(ctx context.Context, userID int64) (resumeextract.Structured, bool, error)
 }
 
 // Store is the CV persistence service: it sanitizes and (de)serializes documents around
@@ -119,6 +133,89 @@ func (s *Store) Delete(ctx context.Context, id, userID int64) error {
 	return nil
 }
 
+// Patch loads an owned CV, applies one field-level edit, and persists the sanitized result.
+// It returns ErrInvalidPatch (leaving the stored CV untouched) when the patch addresses a
+// field or index that does not exist, or ErrNotFound for a foreign/missing id.
+func (s *Store) Patch(ctx context.Context, id, userID int64, p Patch) (Meta, error) {
+	rec, err := s.Get(ctx, id, userID)
+	if err != nil {
+		return Meta{}, err
+	}
+	doc, err := Apply(rec.Document, p)
+	if err != nil {
+		return Meta{}, err
+	}
+	return s.Update(ctx, id, userID, rec.Title, rec.TemplateID, doc)
+}
+
+// BaseCV returns the user's base CV (job_id IS NULL) with its document; ok is false when the
+// user has only tailored CVs or none at all.
+func (s *Store) BaseCV(ctx context.Context, userID int64) (Record, bool, error) {
+	row, err := s.repo.GetBase(ctx, userID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Record{}, false, nil
+		}
+		return Record{}, false, err
+	}
+	doc, err := unmarshalDocument(row.Data)
+	if err != nil {
+		return Record{}, false, err
+	}
+	return Record{
+		Meta:     Meta{ID: row.ID, Title: row.Title, TemplateID: row.TemplateID, CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time},
+		Document: doc,
+	}, true, nil
+}
+
+// CreateTailored sanitizes and stores a vacancy-bound (job_id) copy of a document.
+func (s *Store) CreateTailored(ctx context.Context, userID, jobID int64, title, templateID string, doc Document) (Meta, error) {
+	data, err := marshalSanitized(doc)
+	if err != nil {
+		return Meta{}, err
+	}
+	row, err := s.repo.CreateTailored(ctx, userID, jobID, title, templateID, data)
+	if err != nil {
+		return Meta{}, err
+	}
+	return Meta{ID: row.ID, Title: row.Title, TemplateID: row.TemplateID,
+		CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time}, nil
+}
+
+// Tailor ensures the user has a base CV — seeding one from their extracted résumé when they
+// have none — then creates a vacancy-bound tailored copy of it. It returns the base and the
+// tailored metadata, or ErrNoResume when there is nothing to seed a base from. The base CV is
+// never modified: tailoring only ever writes the new tailored row.
+func (s *Store) Tailor(ctx context.Context, userID, jobID int64, tailoredTitle string, seeder Seeder) (Meta, Meta, error) {
+	base, ok, err := s.BaseCV(ctx, userID)
+	if err != nil {
+		return Meta{}, Meta{}, err
+	}
+	if !ok {
+		st, hasResume, err := seeder.Structured(ctx, userID)
+		if err != nil {
+			return Meta{}, Meta{}, err
+		}
+		if !hasResume {
+			return Meta{}, Meta{}, ErrNoResume
+		}
+		doc := Seed(st)
+		meta, err := s.Create(ctx, userID, defaultBaseTitle, DefaultTemplateID, doc)
+		if err != nil {
+			return Meta{}, Meta{}, err
+		}
+		base = Record{Meta: meta, Document: doc}
+	}
+	tailored, err := s.CreateTailored(ctx, userID, jobID, tailoredTitle, base.TemplateID, base.Document)
+	if err != nil {
+		return Meta{}, Meta{}, err
+	}
+	return base.Meta, tailored, nil
+}
+
+// defaultBaseTitle names a base CV seeded from the résumé (the user can rename it later).
+const defaultBaseTitle = "My CV"
+
 func marshalSanitized(doc Document) ([]byte, error) {
 	doc.Sanitize()
 	return json.Marshal(doc)
@@ -164,4 +261,15 @@ func (r queriesRepository) Update(ctx context.Context, id, userID int64, title, 
 
 func (r queriesRepository) Delete(ctx context.Context, id, userID int64) (int64, error) {
 	return r.q.DeleteCV(ctx, db.DeleteCVParams{ID: id, UserID: userID})
+}
+
+func (r queriesRepository) GetBase(ctx context.Context, userID int64) (db.GetBaseCVByUserRow, error) {
+	return r.q.GetBaseCVByUser(ctx, userID)
+}
+
+func (r queriesRepository) CreateTailored(ctx context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error) {
+	return r.q.CreateTailoredCV(ctx, db.CreateTailoredCVParams{
+		UserID: userID, Title: title, TemplateID: templateID, Data: data,
+		JobID: pgtype.Int8{Int64: jobID, Valid: true},
+	})
 }

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -33,6 +33,8 @@ type Meta struct {
 // Record is a CV with its full document body.
 type Record struct {
 	Meta
+	// JobID is the vacancy a tailored CV is bound to, or 0 for a base CV (job_id NULL).
+	JobID    int64
 	Document Document
 }
 
@@ -103,8 +105,17 @@ func (s *Store) Get(ctx context.Context, id, userID int64) (Record, error) {
 	}
 	return Record{
 		Meta:     Meta{ID: row.ID, Title: row.Title, TemplateID: row.TemplateID, CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time},
+		JobID:    int8Value(row.JobID),
 		Document: doc,
 	}, nil
+}
+
+// int8Value unwraps a nullable bigint to its value, mapping NULL to 0.
+func int8Value(v pgtype.Int8) int64 {
+	if v.Valid {
+		return v.Int64
+	}
+	return 0
 }
 
 // Update sanitizes and replaces an owned CV's editable fields, or returns ErrNotFound.

--- a/internal/cv/store_tailor_test.go
+++ b/internal/cv/store_tailor_test.go
@@ -1,0 +1,125 @@
+package cv
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/resumeextract"
+)
+
+// fakeSeeder stands in for the résumé provider (resume.Store.Structured) in unit tests.
+type fakeSeeder struct {
+	st resumeextract.Structured
+	ok bool
+}
+
+func (f fakeSeeder) Structured(context.Context, int64) (resumeextract.Structured, bool, error) {
+	return f.st, f.ok, nil
+}
+
+func TestStorePatchAppliesAndSanitizes(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+	base, err := s.Create(ctx, 7, "General", DefaultTemplateID, Document{
+		Experience: []ExperienceItem{{Role: "Eng", Bullets: []string{"A"}}},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := s.Patch(ctx, base.ID, 7, Patch{Op: PatchAddBullet, Experience: 0, Value: "B"}); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	rec, err := s.Get(ctx, base.ID, 7)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got := rec.Document.Experience[0].Bullets; len(got) != 2 || got[1] != "B" {
+		t.Errorf("bullets = %v, want [A B]", got)
+	}
+}
+
+func TestStorePatchInvalidAddressingIsErrInvalidPatch(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+	base, _ := s.Create(ctx, 7, "General", DefaultTemplateID, Document{Experience: []ExperienceItem{{Role: "Eng"}}})
+	if _, err := s.Patch(ctx, base.ID, 7, Patch{Op: PatchReplaceBullet, Experience: 0, Bullet: 9, Value: "x"}); !errors.Is(err, ErrInvalidPatch) {
+		t.Errorf("err = %v, want ErrInvalidPatch", err)
+	}
+}
+
+func TestStorePatchForeignOwnerIsNotFound(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+	base, _ := s.Create(ctx, 1, "Mine", DefaultTemplateID, Document{})
+	if _, err := s.Patch(ctx, base.ID, 2, Patch{Op: PatchSetSummary, Value: "x"}); !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreTailorSeedsBaseFromResumeWhenAbsent(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+	seeder := fakeSeeder{ok: true, st: resumeextract.Structured{FullName: "Ada", Summary: "Eng", Skills: []string{"Go"}}}
+
+	base, tailored, err := s.Tailor(ctx, 7, 100, "Tailored: X", seeder)
+	if err != nil {
+		t.Fatalf("tailor: %v", err)
+	}
+	if tailored.ID == base.ID {
+		t.Fatalf("tailored and base are the same row")
+	}
+	brec, err := s.Get(ctx, base.ID, 7)
+	if err != nil {
+		t.Fatalf("get base: %v", err)
+	}
+	if brec.Document.Header.FullName != "Ada" {
+		t.Errorf("base not seeded from résumé: %+v", brec.Document.Header)
+	}
+	trec, err := s.Get(ctx, tailored.ID, 7)
+	if err != nil {
+		t.Fatalf("get tailored: %v", err)
+	}
+	if !reflect.DeepEqual(trec.Document, brec.Document) {
+		t.Errorf("tailored doc != base doc")
+	}
+}
+
+func TestStoreTailorRefusesWithoutResume(t *testing.T) {
+	repo := newFakeRepo()
+	s := NewStore(repo)
+	ctx := context.Background()
+	if _, _, err := s.Tailor(ctx, 7, 100, "T", fakeSeeder{ok: false}); !errors.Is(err, ErrNoResume) {
+		t.Errorf("err = %v, want ErrNoResume", err)
+	}
+	if len(repo.rows) != 0 {
+		t.Errorf("no CV rows should be created on refusal, got %d", len(repo.rows))
+	}
+}
+
+func TestStoreTailorUsesExistingBaseUntouched(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+	base, _ := s.Create(ctx, 7, "General", DefaultTemplateID, Document{
+		Summary:    "Base summary",
+		Experience: []ExperienceItem{{Role: "Eng", Bullets: []string{"A"}}},
+	})
+	before, _ := s.Get(ctx, base.ID, 7)
+
+	rbase, tailored, err := s.Tailor(ctx, 7, 100, "Tailored", fakeSeeder{ok: false})
+	if err != nil {
+		t.Fatalf("tailor: %v", err)
+	}
+	if rbase.ID != base.ID {
+		t.Errorf("returned base %d, want existing %d", rbase.ID, base.ID)
+	}
+	after, _ := s.Get(ctx, base.ID, 7)
+	if !reflect.DeepEqual(after.Document, before.Document) {
+		t.Errorf("existing base was mutated by Tailor")
+	}
+	trec, _ := s.Get(ctx, tailored.ID, 7)
+	if !reflect.DeepEqual(trec.Document, before.Document) {
+		t.Errorf("tailored doc != base doc")
+	}
+}

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -52,7 +52,7 @@ func (f *fakeRepo) Get(_ context.Context, id, userID int64) (db.GetCVByIDRow, er
 	if !ok || r.userID != userID {
 		return db.GetCVByIDRow{}, pgx.ErrNoRows
 	}
-	return db.GetCVByIDRow{ID: id, Title: r.title, TemplateID: r.templateID, Data: r.data, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
+	return db.GetCVByIDRow{ID: id, Title: r.title, TemplateID: r.templateID, Data: r.data, JobID: pgtype.Int8{Int64: r.jobID, Valid: r.jobID != 0}, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
 func (f *fakeRepo) Update(_ context.Context, id, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -23,6 +23,7 @@ type fakeRow struct {
 	title      string
 	templateID string
 	data       []byte
+	jobID      int64 // 0 = base CV (job_id NULL); >0 = tailored copy bound to a vacancy
 }
 
 func newFakeRepo() *fakeRepo { return &fakeRepo{rows: map[int64]fakeRow{}, next: 1} }
@@ -59,7 +60,7 @@ func (f *fakeRepo) Update(_ context.Context, id, userID int64, title, templateID
 	if !ok || r.userID != userID {
 		return db.UpdateCVRow{}, pgx.ErrNoRows
 	}
-	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data}
+	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data, jobID: r.jobID}
 	return db.UpdateCVRow{ID: id, Title: title, TemplateID: templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
@@ -69,6 +70,29 @@ func (f *fakeRepo) Delete(_ context.Context, id, userID int64) (int64, error) {
 	}
 	delete(f.rows, id)
 	return 1, nil
+}
+
+func (f *fakeRepo) GetBase(_ context.Context, userID int64) (db.GetBaseCVByUserRow, error) {
+	// Newest base CV = the highest id among the user's non-tailored rows (mirrors the
+	// query's updated_at DESC, id DESC tiebreak).
+	var bestID int64
+	for id, r := range f.rows {
+		if r.userID == userID && r.jobID == 0 && id > bestID {
+			bestID = id
+		}
+	}
+	if bestID == 0 {
+		return db.GetBaseCVByUserRow{}, pgx.ErrNoRows
+	}
+	r := f.rows[bestID]
+	return db.GetBaseCVByUserRow{ID: bestID, Title: r.title, TemplateID: r.templateID, Data: r.data, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
+}
+
+func (f *fakeRepo) CreateTailored(_ context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error) {
+	id := f.next
+	f.next++
+	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data, jobID: jobID}
+	return db.CreateTailoredCVRow{ID: id, Title: title, TemplateID: templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 
 func TestStoreCreateGetRoundTripSanitized(t *testing.T) {

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -53,6 +53,49 @@ func (q *Queries) CreateCV(ctx context.Context, arg CreateCVParams) (CreateCVRow
 	return i, err
 }
 
+const createTailoredCV = `-- name: CreateTailoredCV :one
+INSERT INTO cvs (user_id, title, template_id, data, job_id)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, title, template_id, created_at, updated_at
+`
+
+type CreateTailoredCVParams struct {
+	UserID     int64       `json:"user_id"`
+	Title      string      `json:"title"`
+	TemplateID string      `json:"template_id"`
+	Data       []byte      `json:"data"`
+	JobID      pgtype.Int8 `json:"job_id"`
+}
+
+type CreateTailoredCVRow struct {
+	ID         int64              `json:"id"`
+	Title      string             `json:"title"`
+	TemplateID string             `json:"template_id"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+}
+
+// Insert a CV bound to a vacancy (job_id set) — the per-vacancy tailored copy. data is the
+// sanitized document copied from the base CV. Returns the metadata the detail response needs.
+func (q *Queries) CreateTailoredCV(ctx context.Context, arg CreateTailoredCVParams) (CreateTailoredCVRow, error) {
+	row := q.db.QueryRow(ctx, createTailoredCV,
+		arg.UserID,
+		arg.Title,
+		arg.TemplateID,
+		arg.Data,
+		arg.JobID,
+	)
+	var i CreateTailoredCVRow
+	err := row.Scan(
+		&i.ID,
+		&i.Title,
+		&i.TemplateID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const deleteCV = `-- name: DeleteCV :execrows
 DELETE FROM cvs
 WHERE id = $1 AND user_id = $2
@@ -71,6 +114,40 @@ func (q *Queries) DeleteCV(ctx context.Context, arg DeleteCVParams) (int64, erro
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const getBaseCVByUser = `-- name: GetBaseCVByUser :one
+SELECT id, title, template_id, data, created_at, updated_at
+FROM cvs
+WHERE user_id = $1 AND job_id IS NULL
+ORDER BY updated_at DESC, id DESC
+LIMIT 1
+`
+
+type GetBaseCVByUserRow struct {
+	ID         int64              `json:"id"`
+	Title      string             `json:"title"`
+	TemplateID string             `json:"template_id"`
+	Data       []byte             `json:"data"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+}
+
+// The user's base CV (job_id IS NULL) — their non-tailored résumé, newest edit first. Used
+// as the seed source when tailoring; returns no row when the user has only tailored CVs or
+// none at all (the caller then seeds a base from the extracted résumé).
+func (q *Queries) GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVByUserRow, error) {
+	row := q.db.QueryRow(ctx, getBaseCVByUser, userID)
+	var i GetBaseCVByUserRow
+	err := row.Scan(
+		&i.ID,
+		&i.Title,
+		&i.TemplateID,
+		&i.Data,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
 }
 
 const getCVByID = `-- name: GetCVByID :one

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -151,7 +151,7 @@ func (q *Queries) GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVB
 }
 
 const getCVByID = `-- name: GetCVByID :one
-SELECT id, title, template_id, data, created_at, updated_at
+SELECT id, title, template_id, data, job_id, created_at, updated_at
 FROM cvs
 WHERE id = $1 AND user_id = $2
 `
@@ -166,12 +166,14 @@ type GetCVByIDRow struct {
 	Title      string             `json:"title"`
 	TemplateID string             `json:"template_id"`
 	Data       []byte             `json:"data"`
+	JobID      pgtype.Int8        `json:"job_id"`
 	CreatedAt  pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
 }
 
 // One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
-// missing id returns no row (the handler maps it to 404).
+// missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
+// the vacancy id for a tailored copy — the tailoring-context read resolves it to the analysis.
 func (q *Queries) GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByIDRow, error) {
 	row := q.db.QueryRow(ctx, getCVByID, arg.ID, arg.UserID)
 	var i GetCVByIDRow
@@ -180,6 +182,7 @@ func (q *Queries) GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByID
 		&i.Title,
 		&i.TemplateID,
 		&i.Data,
+		&i.JobID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/internal/db/cvs_integration_test.go
+++ b/internal/db/cvs_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -112,5 +113,56 @@ func TestCVsOwnerIsolation(t *testing.T) {
 	}
 	if list, err := q.ListCVsByUser(ctx, other); err != nil || len(list) != 0 {
 		t.Errorf("foreign list: err=%v len=%d, want 0", err, len(list))
+	}
+}
+
+// TestBaseCVAndTailoredCopy covers the two-tier tailoring queries: GetBaseCVByUser picks the
+// user's newest non-tailored CV (and reports no row when there is none), and CreateTailoredCV
+// binds a copy to a vacancy via job_id without that copy shadowing the base.
+func TestBaseCVAndTailoredCopy(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	truncateCVs(t, pool)
+	ctx := context.Background()
+
+	user := seedCVUser(t, pool, "tailor@example.com")
+
+	// No base CV yet → no row (the caller then seeds one from the résumé).
+	if _, err := q.GetBaseCVByUser(ctx, user); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("empty base err = %v, want ErrNoRows", err)
+	}
+
+	// Two non-tailored CVs: the base is the most-recently-created (id-tiebroken) one.
+	if _, err := q.CreateCV(ctx, CreateCVParams{UserID: user, Title: "Older", TemplateID: "classic-ats", Data: []byte(`{"summary":"old"}`)}); err != nil {
+		t.Fatalf("create older: %v", err)
+	}
+	newer, err := q.CreateCV(ctx, CreateCVParams{UserID: user, Title: "Newer", TemplateID: "classic-ats", Data: []byte(`{"summary":"new"}`)})
+	if err != nil {
+		t.Fatalf("create newer: %v", err)
+	}
+	base, err := q.GetBaseCVByUser(ctx, user)
+	if err != nil {
+		t.Fatalf("base: %v", err)
+	}
+	if base.ID != newer.ID {
+		t.Errorf("base = %d, want newest %d", base.ID, newer.ID)
+	}
+
+	// A tailored copy bound to a vacancy is created with job_id and must NOT become the base.
+	job := insertJob(t, pool, "job-ext-tailor")
+	tailored, err := q.CreateTailoredCV(ctx, CreateTailoredCVParams{
+		UserID: user, Title: "Tailored", TemplateID: "classic-ats",
+		Data: base.Data, JobID: pgtype.Int8{Int64: job, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+	if again, err := q.GetBaseCVByUser(ctx, user); err != nil || again.ID != newer.ID {
+		t.Errorf("base after tailoring = %d (err %v), want %d (tailored excluded)", again.ID, err, newer.ID)
+	}
+	if got, err := q.GetCVByID(ctx, GetCVByIDParams{ID: tailored.ID, UserID: user}); err != nil {
+		t.Fatalf("get tailored: %v", err)
+	} else if got.Title != "Tailored" {
+		t.Errorf("tailored title = %q, want Tailored", got.Title)
 	}
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -324,7 +324,8 @@ type Querier interface {
 	// which the caller treats as "never seen, eligible".
 	GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error)
 	// One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
-	// missing id returns no row (the handler maps it to 404).
+	// missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
+	// the vacancy id for a tailored copy — the tailoring-context read resolves it to the analysis.
 	GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByIDRow, error)
 	// SELECT * (not an explicit column list) so the generated row stays db.Company as
 	// the table grows columns (e.g. collections); an explicit subset makes sqlc emit a

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -182,6 +182,9 @@ type Querier interface {
 	// 404). A second subscription for the same (saved_search, channel) violates the
 	// UNIQUE constraint (surfaced as a 409). Returns the created row.
 	CreateSubscription(ctx context.Context, arg CreateSubscriptionParams) (Subscription, error)
+	// Insert a CV bound to a vacancy (job_id set) — the per-vacancy tailored copy. data is the
+	// sanitized document copied from the base CV. Returns the metadata the detail response needs.
+	CreateTailoredCV(ctx context.Context, arg CreateTailoredCVParams) (CreateTailoredCVRow, error)
 	// Register a new account. email is stored as given (the handler lowercases it);
 	// the unique index on lower(email) rejects duplicates regardless of case. role is
 	// returned so the new account's wire shape carries it (always 'user' at creation).
@@ -313,6 +316,10 @@ type Querier interface {
 	// Record a failed attempt: bump attempts, release the lease, store the error, and
 	// dead-letter (set failed_at) once attempts reach max_attempts.
 	FailEmailClassification(ctx context.Context, arg FailEmailClassificationParams) error
+	// The user's base CV (job_id IS NULL) — their non-tailored résumé, newest edit first. Used
+	// as the seed source when tailoring; returns no row when the user has only tailored CVs or
+	// none at all (the caller then seeds a base from the extracted résumé).
+	GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVByUserRow, error)
 	// The board's current cooldown_until (NULL = eligible). Absent row → pgx.ErrNoRows,
 	// which the caller treats as "never seen, eligible".
 	GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error)

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -33,3 +33,20 @@ RETURNING id, title, template_id, created_at, updated_at;
 -- when nothing was deleted (foreign or missing id).
 DELETE FROM cvs
 WHERE id = $1 AND user_id = $2;
+
+-- name: GetBaseCVByUser :one
+-- The user's base CV (job_id IS NULL) — their non-tailored résumé, newest edit first. Used
+-- as the seed source when tailoring; returns no row when the user has only tailored CVs or
+-- none at all (the caller then seeds a base from the extracted résumé).
+SELECT id, title, template_id, data, created_at, updated_at
+FROM cvs
+WHERE user_id = $1 AND job_id IS NULL
+ORDER BY updated_at DESC, id DESC
+LIMIT 1;
+
+-- name: CreateTailoredCV :one
+-- Insert a CV bound to a vacancy (job_id set) — the per-vacancy tailored copy. data is the
+-- sanitized document copied from the base CV. Returns the metadata the detail response needs.
+INSERT INTO cvs (user_id, title, template_id, data, job_id)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING id, title, template_id, created_at, updated_at;

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -15,8 +15,9 @@ ORDER BY updated_at DESC;
 
 -- name: GetCVByID :one
 -- One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
--- missing id returns no row (the handler maps it to 404).
-SELECT id, title, template_id, data, created_at, updated_at
+-- missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
+-- the vacancy id for a tailored copy — the tailoring-context read resolves it to the analysis.
+SELECT id, title, template_id, data, job_id, created_at, updated_at
 FROM cvs
 WHERE id = $1 AND user_id = $2;
 

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -221,6 +221,8 @@ func mapCVError(err error) error {
 		return fiber.NewError(fiber.StatusNotFound, "not found")
 	case errors.Is(err, cv.ErrUnknownTemplate):
 		return fiber.NewError(fiber.StatusBadRequest, "unknown template")
+	case errors.Is(err, cv.ErrInvalidPatch):
+		return fiber.NewError(fiber.StatusUnprocessableEntity, "invalid patch")
 	default:
 		return err
 	}

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// tailoringKeyTTL bounds how long the minted CLI credential is valid. A tailoring session is
+// interactive and short; a couple of hours covers it while limiting the blast radius of a key
+// that leaks out of the agent's environment.
+const tailoringKeyTTL = 2 * time.Hour
+
+// apiKeyMinter is the slice of the query surface mintTailoringKey needs (*db.Queries satisfies
+// it), kept narrow so the mint logic is unit-testable without a database.
+type apiKeyMinter interface {
+	CreateAPIKey(ctx context.Context, arg db.CreateAPIKeyParams) (db.CreateAPIKeyRow, error)
+}
+
+// mintTailoringKey issues a short-lived API key the tailoring agent's CLI uses to act as the
+// user against the CV endpoints. It reuses the api_keys machinery; there is no per-endpoint
+// scope, so the key is owner-scoped only — the CV endpoints' own owner checks confine it to
+// this user's CVs. The plaintext token is returned once (to hand to the agent session) and
+// only its hash is stored.
+func mintTailoringKey(ctx context.Context, q apiKeyMinter, userID int64, now time.Time) (string, error) {
+	token, hash, prefix, err := auth.GenerateAPIKey()
+	if err != nil {
+		return "", err
+	}
+	if _, err := q.CreateAPIKey(ctx, db.CreateAPIKeyParams{
+		UserID:      userID,
+		Name:        "CV tailoring session",
+		TokenHash:   hash,
+		TokenPrefix: prefix,
+		ExpiresAt:   pgtype.Timestamptz{Time: now.Add(tailoringKeyTTL), Valid: true},
+	}); err != nil {
+		return "", err
+	}
+	return token, nil
+}

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -2,12 +2,18 @@ package handler
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"time"
 
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobfit"
 )
 
 // tailoringKeyTTL bounds how long the minted CLI credential is valid. A tailoring session is
@@ -41,4 +47,174 @@ func mintTailoringKey(ctx context.Context, q apiKeyMinter, userID int64, now tim
 		return "", err
 	}
 	return token, nil
+}
+
+type tailorCVRequest struct {
+	JobSlug string `json:"job_slug"`
+}
+
+// tailorCVResponse is what the fit-page CTA gets back: the ids of the new tailored CV and the
+// base it was copied from, the cached analysis (so the client need not refetch), and the
+// short-lived CLI token the agent session authenticates with.
+type tailorCVResponse struct {
+	TailorCVID int64            `json:"tailor_cv_id"`
+	BaseCVID   int64            `json:"base_cv_id"`
+	Analysis   *jobfit.Analysis `json:"analysis"`
+	CLIToken   string           `json:"cli_token"`
+}
+
+// TailorCV bootstraps a tailoring session for a vacancy: it requires a cached fit analysis
+// (409 otherwise), ensures the user has a base CV (seeding one from their résumé, 409 when
+// they have none), creates a vacancy-bound tailored copy, mints the CLI credential, and
+// returns the ids plus the analysis. Cookie-only (the browser starts tailoring); never calls
+// the LLM.
+func (a *API) TailorCV(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	var in tailorCVRequest
+	if err := c.BodyParser(&in); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	}
+	slug := strings.TrimSpace(in.JobSlug)
+	if slug == "" {
+		return fiber.NewError(fiber.StatusBadRequest, "job_slug is required")
+	}
+	job, err := a.queries.GetJobBySlug(c.Context(), slug)
+	if err != nil {
+		return err // unknown slug → pgx.ErrNoRows → 404 via RenderError
+	}
+	analysis, err := a.cachedAnalysis(c, userID, job.ID)
+	if err != nil {
+		return err
+	}
+	base, tailored, err := a.cvStore.Tailor(c.Context(), userID, job.ID, tailoredCVTitle(job.Title), a.resume)
+	if errors.Is(err, cv.ErrNoResume) {
+		return fiber.NewError(fiber.StatusConflict, "add a résumé before tailoring")
+	}
+	if err != nil {
+		return mapCVError(err)
+	}
+	token, err := mintTailoringKey(c.Context(), a.queries, userID, time.Now())
+	if err != nil {
+		return err
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorCVResponse{
+		TailorCVID: tailored.ID, BaseCVID: base.ID, Analysis: analysis, CLIToken: token,
+	}})
+}
+
+// PatchCV applies one field-level patch to an owned CV. Cookie or API key (the agent's CLI
+// uses the key). Bad addressing is a 422; a foreign/missing id is a 404.
+func (a *API) PatchCV(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := c.ParamsInt("id")
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+	}
+	var p cv.Patch
+	if err := c.BodyParser(&p); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	}
+	meta, err := a.cvStore.Patch(c.Context(), int64(id), userID, p)
+	if err != nil {
+		return mapCVError(err)
+	}
+	return c.JSON(fiber.Map{"data": metaResponse(meta)})
+}
+
+// tailorContextResponse is the reasoning context the agent reads (freehire cv context): the
+// verdict and recommendation, per-dimension comments, and the requirement split the honest
+// wall turns on — missing_have (reframe existing evidence) vs missing_gap (must ask first).
+type tailorContextResponse struct {
+	Verdict        string               `json:"verdict"`
+	OverallScore   int                  `json:"overall_score"`
+	Recommendation string               `json:"recommendation"`
+	Dimensions     []jobfit.Dimension   `json:"dimensions"`
+	MissingHave    []jobfit.Requirement `json:"missing_have"`
+	MissingGap     []jobfit.Requirement `json:"missing_gap"`
+	Strengths      []string             `json:"strengths"`
+	Gaps           []string             `json:"gaps"`
+}
+
+// TailorContext serves the cached fit analysis for a tailored CV, projected to the tailoring
+// reasoning context. Cookie or API key. 409 when the CV is not a tailored copy (no bound
+// vacancy) or has no cached analysis; never calls the LLM.
+func (a *API) TailorContext(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := c.ParamsInt("id")
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+	}
+	rec, err := a.cvStore.Get(c.Context(), int64(id), userID)
+	if err != nil {
+		return mapCVError(err)
+	}
+	if rec.JobID == 0 {
+		return fiber.NewError(fiber.StatusConflict, "not a tailored CV")
+	}
+	analysis, err := a.cachedAnalysis(c, userID, rec.JobID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": tailorContext(analysis)})
+}
+
+// cachedAnalysis loads the cached fit analysis for (user, job), or a 409 telling the caller to
+// run the fit analysis first when none is cached (or the cached blob is empty/corrupt). It
+// never recomputes.
+func (a *API) cachedAnalysis(c *fiber.Ctx, userID, jobID int64) (*jobfit.Analysis, error) {
+	row, err := a.jobFitCache.GetUserJobAnalysis(c.Context(), db.GetUserJobAnalysisParams{UserID: userID, JobID: jobID})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, fiber.NewError(fiber.StatusConflict, "run the fit analysis first")
+	}
+	if err != nil {
+		return nil, err
+	}
+	analysis := decodeAnalysis(row.Analysis)
+	if analysis == nil {
+		return nil, fiber.NewError(fiber.StatusConflict, "run the fit analysis first")
+	}
+	return analysis, nil
+}
+
+// tailorContext projects an analysis to the agent's reasoning context, splitting requirements
+// into the reframe-able (missing-have) and the genuine gaps (missing-gap).
+func tailorContext(a *jobfit.Analysis) tailorContextResponse {
+	var have, gap []jobfit.Requirement
+	for _, r := range a.RequirementMatch {
+		switch r.Status {
+		case jobfit.StatusMissingHave:
+			have = append(have, r)
+		case jobfit.StatusMissingGap:
+			gap = append(gap, r)
+		}
+	}
+	return tailorContextResponse{
+		Verdict:        a.Verdict,
+		OverallScore:   a.OverallScore,
+		Recommendation: a.Recommendation,
+		Dimensions:     a.Dimensions,
+		MissingHave:    have,
+		MissingGap:     gap,
+		Strengths:      a.Strengths,
+		Gaps:           a.Gaps,
+	}
+}
+
+// tailoredCVTitle names a tailored copy from the vacancy title (bounded/defaulted like any CV
+// title).
+func tailoredCVTitle(jobTitle string) string {
+	jobTitle = strings.TrimSpace(jobTitle)
+	if jobTitle == "" {
+		return "Tailored CV"
+	}
+	return cvTitle("Tailored — " + jobTitle)
 }

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -1,0 +1,252 @@
+//go:build integration
+
+// Integration tests for the CV-tailoring HTTP surface (add-cv-tailoring): the tailoring
+// bootstrap's preconditions (cached analysis + résumé) and success, field-level PATCH via a
+// minted API key (apply / 422 bad addressing / 404 owner isolation), and the tailoring-context
+// requirement split. Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/cv"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobfit"
+	"github.com/strelov1/freehire/internal/resume"
+	"github.com/strelov1/freehire/internal/resumeextract"
+)
+
+// newTailorAPI builds an API wired for the tailoring endpoints and truncates the tables.
+func newTailorAPI(t *testing.T) (*API, *auth.Issuer) {
+	t.Helper()
+	pool := startPostgres(t)
+	queries := db.New(pool)
+	if _, err := pool.Exec(context.Background(),
+		"TRUNCATE cvs, users, jobs, user_job_analysis, api_keys RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &API{pool: pool, queries: queries, issuer: iss,
+		cvStore:     cv.NewStore(cv.NewQueriesRepository(queries)),
+		resume:      resume.New(nil, resume.NewQueriesRepository(queries)),
+		jobFitCache: queries,
+	}
+	return h, iss
+}
+
+// buildTailorApp wires the CV + tailoring routes with the real beta gate.
+func buildTailorApp(h *API, iss *auth.Issuer) *fiber.App {
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	saved := auth.RequireAuth(iss)
+	keyAuth := auth.RequireAuthOrKey(iss, h.queries)
+	gate := auth.RequireModeratorOrBeta(h.queries, h.queries)
+	app.Get("/api/v1/me/cvs/:id", saved, gate, h.GetCV)
+	app.Post("/api/v1/me/cvs/tailor", saved, gate, h.TailorCV)
+	app.Patch("/api/v1/me/cvs/:id", keyAuth, gate, h.PatchCV)
+	app.Get("/api/v1/me/cvs/:id/tailor-context", keyAuth, gate, h.TailorContext)
+	return app
+}
+
+// doBearer issues a request authenticated by an API key (Authorization: Bearer).
+func doBearer(t *testing.T, app *fiber.App, method, path, token string, body any) *http.Response {
+	t.Helper()
+	var b []byte
+	if body != nil {
+		b, _ = json.Marshal(body)
+	}
+	req := httptest.NewRequest(method, path, bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	return resp
+}
+
+func seedJobSlug(t *testing.T, h *API, slug string) int64 {
+	t.Helper()
+	var id int64
+	if err := h.pool.QueryRow(context.Background(),
+		`INSERT INTO jobs (source, external_id, url, title, public_slug)
+		 VALUES ('test', $1, 'https://e.test/'||$1, 'Backend Engineer', $1) RETURNING id`,
+		slug).Scan(&id); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+	return id
+}
+
+func seedAnalysis(t *testing.T, h *API, userID, jobID int64) {
+	t.Helper()
+	blob, _ := json.Marshal(&jobfit.Analysis{
+		Verdict: "Good Fit", OverallScore: 72, Recommendation: "Lead with Go depth.",
+		Dimensions: []jobfit.Dimension{{Key: "skills", Label: "Skills", Score: 70, Comment: "solid"}},
+		RequirementMatch: []jobfit.Requirement{
+			{Text: "Kubernetes", Priority: "required", Status: jobfit.StatusMissingGap, Evidence: "absent"},
+			{Text: "Go", Priority: "required", Status: jobfit.StatusMissingHave, Evidence: "in profile"},
+			{Text: "REST", Priority: "preferred", Status: "covered", Evidence: "bullet 1"},
+		},
+		Strengths: []string{"Go depth"}, Gaps: []string{"K8s"},
+	})
+	if err := h.queries.UpsertUserJobAnalysis(context.Background(), db.UpsertUserJobAnalysisParams{
+		UserID: userID, JobID: jobID, Analysis: blob, Model: "test-model",
+	}); err != nil {
+		t.Fatalf("seed analysis: %v", err)
+	}
+}
+
+// seedFreshResume writes a structured résumé whose stamp matches the résumé upload time, so
+// resume.Structured serves it (ok=true) and the base CV can be seeded from it.
+func seedFreshResume(t *testing.T, h *API, userID int64) {
+	t.Helper()
+	st, _ := json.Marshal(resumeextract.Structured{FullName: "Ada Lovelace", Summary: "Engineer", Skills: []string{"Go"}})
+	at := time.Now().Truncate(time.Microsecond)
+	if _, err := h.pool.Exec(context.Background(),
+		`UPDATE users SET resume_object_key = 'k', resume_uploaded_at = $2,
+		 resume_structured = $3, resume_structured_uploaded_at = $2, resume_structured_model = 'test-model'
+		 WHERE id = $1`, userID, at, st); err != nil {
+		t.Fatalf("seed résumé: %v", err)
+	}
+}
+
+func TestTailorCVBootstrap(t *testing.T) {
+	h, iss := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+
+	user := seedAccount(t, h, "tailor@example.test", true)
+	tok, _ := iss.Issue(user)
+	jobID := seedJobSlug(t, h, "backend-eng")
+
+	// No cached analysis yet → 409.
+	if resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "backend-eng"}); resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("no-analysis = %d, want 409", resp.StatusCode)
+	}
+
+	seedAnalysis(t, h, user, jobID)
+
+	// Analysis present but no résumé to seed a base → 409.
+	if resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "backend-eng"}); resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("no-résumé = %d, want 409", resp.StatusCode)
+	}
+
+	seedFreshResume(t, h, user)
+
+	// Now bootstrap succeeds.
+	resp := doCV(t, app, fiber.MethodPost, "/api/v1/me/cvs/tailor", tok, tailorCVRequest{JobSlug: "backend-eng"})
+	if resp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("bootstrap = %d, want 201", resp.StatusCode)
+	}
+	var got struct {
+		Data tailorCVResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+	if got.Data.TailorCVID == 0 || got.Data.BaseCVID == 0 || got.Data.TailorCVID == got.Data.BaseCVID {
+		t.Errorf("ids = %+v, want distinct non-zero", got.Data)
+	}
+	if got.Data.CLIToken == "" {
+		t.Errorf("empty cli_token")
+	}
+	if got.Data.Analysis == nil || got.Data.Analysis.Verdict != "Good Fit" {
+		t.Errorf("analysis not returned: %+v", got.Data.Analysis)
+	}
+}
+
+func TestPatchCVViaKey(t *testing.T) {
+	h, iss := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+	ctx := context.Background()
+
+	owner := seedAccount(t, h, "owner@example.test", true)
+	other := seedAccount(t, h, "other@example.test", true)
+
+	base, err := h.cvStore.Create(ctx, owner, "General", cv.DefaultTemplateID, cv.Document{
+		Experience: []cv.ExperienceItem{{Role: "Eng", Bullets: []string{"Shipped API"}}},
+	})
+	if err != nil {
+		t.Fatalf("create cv: %v", err)
+	}
+	path := "/api/v1/me/cvs/" + strconv.FormatInt(base.ID, 10)
+
+	ownerKey, err := mintTailoringKey(ctx, h.queries, owner, time.Now())
+	if err != nil {
+		t.Fatalf("mint owner key: %v", err)
+	}
+	otherKey, err := mintTailoringKey(ctx, h.queries, other, time.Now())
+	if err != nil {
+		t.Fatalf("mint other key: %v", err)
+	}
+
+	// A valid patch applies.
+	if resp := doBearer(t, app, fiber.MethodPatch, path, ownerKey, cv.Patch{Op: cv.PatchAddBullet, Experience: 0, Value: "Cut latency"}); resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("patch = %d, want 200", resp.StatusCode)
+	}
+	rec, _ := h.cvStore.Get(ctx, base.ID, owner)
+	if got := rec.Document.Experience[0].Bullets; len(got) != 2 || got[1] != "Cut latency" {
+		t.Errorf("bullets after patch = %v", got)
+	}
+
+	// Bad addressing is a 422.
+	if resp := doBearer(t, app, fiber.MethodPatch, path, ownerKey, cv.Patch{Op: cv.PatchReplaceBullet, Experience: 0, Bullet: 9, Value: "x"}); resp.StatusCode != fiber.StatusUnprocessableEntity {
+		t.Fatalf("bad-patch = %d, want 422", resp.StatusCode)
+	}
+
+	// Another user's key cannot touch this CV (owner isolation → 404, not 403).
+	if resp := doBearer(t, app, fiber.MethodPatch, path, otherKey, cv.Patch{Op: cv.PatchSetSummary, Value: "hijack"}); resp.StatusCode != fiber.StatusNotFound {
+		t.Fatalf("foreign patch = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestTailorContextSplit(t *testing.T) {
+	h, iss := newTailorAPI(t)
+	app := buildTailorApp(h, iss)
+	ctx := context.Background()
+
+	user := seedAccount(t, h, "ctx@example.test", true)
+	jobID := seedJobSlug(t, h, "backend-eng")
+	seedAnalysis(t, h, user, jobID)
+
+	// A tailored CV bound to the vacancy.
+	tailored, err := h.cvStore.CreateTailored(ctx, user, jobID, "Tailored", cv.DefaultTemplateID, cv.Document{})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+	key, _ := mintTailoringKey(ctx, h.queries, user, time.Now())
+
+	resp := doBearer(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+strconv.FormatInt(tailored.ID, 10)+"/tailor-context", key, nil)
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("context = %d, want 200", resp.StatusCode)
+	}
+	var got struct {
+		Data tailorContextResponse `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+	if len(got.Data.MissingHave) != 1 || got.Data.MissingHave[0].Text != "Go" {
+		t.Errorf("missing_have = %+v, want [Go]", got.Data.MissingHave)
+	}
+	if len(got.Data.MissingGap) != 1 || got.Data.MissingGap[0].Text != "Kubernetes" {
+		t.Errorf("missing_gap = %+v, want [Kubernetes]", got.Data.MissingGap)
+	}
+	if got.Data.Verdict != "Good Fit" {
+		t.Errorf("verdict = %q", got.Data.Verdict)
+	}
+
+	// A base CV (no bound vacancy) is not tailorable-context → 409.
+	base, _ := h.cvStore.Create(ctx, user, "Base", cv.DefaultTemplateID, cv.Document{})
+	if resp := doBearer(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+strconv.FormatInt(base.ID, 10)+"/tailor-context", key, nil); resp.StatusCode != fiber.StatusConflict {
+		t.Fatalf("base-cv context = %d, want 409", resp.StatusCode)
+	}
+}

--- a/internal/handler/cv_tailor_test.go
+++ b/internal/handler/cv_tailor_test.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+type fakeKeyMinter struct {
+	got db.CreateAPIKeyParams
+}
+
+func (f *fakeKeyMinter) CreateAPIKey(_ context.Context, arg db.CreateAPIKeyParams) (db.CreateAPIKeyRow, error) {
+	f.got = arg
+	return db.CreateAPIKeyRow{ID: 1, Name: arg.Name, TokenPrefix: arg.TokenPrefix}, nil
+}
+
+func TestMintTailoringKey(t *testing.T) {
+	f := &fakeKeyMinter{}
+	now := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+
+	token, err := mintTailoringKey(context.Background(), f, 42, now)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if token == "" {
+		t.Fatal("empty token")
+	}
+	// The persisted hash must match the returned token, so the key authenticates.
+	if f.got.TokenHash != auth.HashAPIKey(token) {
+		t.Errorf("stored hash does not match returned token")
+	}
+	if f.got.UserID != 42 {
+		t.Errorf("user = %d, want 42", f.got.UserID)
+	}
+	// Short-lived: expiry is now + the fixed TTL.
+	if !f.got.ExpiresAt.Valid || !f.got.ExpiresAt.Time.Equal(now.Add(tailoringKeyTTL)) {
+		t.Errorf("expiry = %v, want %v", f.got.ExpiresAt.Time, now.Add(tailoringKeyTTL))
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -435,6 +435,11 @@ func Register(app *fiber.App, cfg Config) {
 	api.Put("/me/cvs/:id", saved, cvGate, a.UpdateCV)
 	api.Delete("/me/cvs/:id", saved, cvGate, a.DeleteCV)
 	api.Get("/me/cvs/:id/pdf", saved, cvGate, a.RenderCVPDF)
+	// Tailoring: the browser starts a session (cookie-only bootstrap); the agent's CLI drives
+	// the edit + context reads with its minted API key (keyAuth = cookie or Bearer).
+	api.Post("/me/cvs/tailor", saved, cvGate, a.TailorCV)
+	api.Patch("/me/cvs/:id", keyAuth, cvGate, a.PatchCV)
+	api.Get("/me/cvs/:id/tailor-context", keyAuth, cvGate, a.TailorContext)
 
 	// Mail inbox (Gmail connect + hosted mailbox). Open to every signed-in user.
 	// The read + disconnect routes are always registered (empty/no-op when not

--- a/openspec/changes/add-cv-tailoring/.openspec.yaml
+++ b/openspec/changes/add-cv-tailoring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/add-cv-tailoring/design.md
+++ b/openspec/changes/add-cv-tailoring/design.md
@@ -76,9 +76,14 @@ on first run, rather than only injecting `FREEHIRE_TOKEN` into the process env (
 secret to every child process). The exact config format lives in the `freehire-cli` repo; this change
 just returns the token.
 
-**D6 — Reuse `/my/assistant` with a split preview.** Alternative: a dedicated `/my/cvs/[id]/tailor`
-route. Chosen reuse: the assistant SPA already renders the roy `/ws` journal; add a right-hand CV
-preview re-rendered on turn boundaries. Reversible if a dedicated route proves cleaner.
+**D6 — In-repo: CTA → tailored CV editor. Live split preview is cross-repo.** The fit-page CTA
+bootstraps and `goto`s the tailored copy in the existing `CvEditor` (`/my/cvs/[id]`), where the CV
+is viewable/renderable (PDF via `cvPdfUrl`). A live split (chat + preview refreshed on turn
+boundaries) needs the roy agent to accept **session context** on create — today `/my/assistant`'s
+`createSession` sends `{}` and the agent (agent.freehire.dev, separate repo) decides everything, so it
+cannot be seeded with a CV id / verdict. That interactive loop is the cross-repo companion
+(`freehire-agent` context-on-create + `freehire-cli` `cv` commands); this change lands the entry
+point and the tailored artifact it opens.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/add-cv-tailoring/design.md
+++ b/openspec/changes/add-cv-tailoring/design.md
@@ -1,0 +1,97 @@
+## Context
+
+The full brainstormed design lives at `docs/superpowers/specs/2026-07-17-cv-tailoring-design.md`
+(local-only per repo convention). This document captures the OpenSpec-level decisions for the
+**freehire-repo portion** only.
+
+Current state the change builds on:
+- `cvs` table (`internal/cv/`, migration `0024_cvs.sql`) with `data jsonb` (`cv.Document`) and a
+  **nullable `job_id`** the migration comment marks as "a seam for the follow-up per-vacancy
+  tailoring phase". `cv.Document.Sanitize()` is already documented as "in the follow-up tailoring
+  phase — fed to an LLM, so Sanitize is both the persistence guard and the prompt-injection guard".
+- `cv.Seed(structured)` builds a `Document` from the structured résumé (pure mapping).
+- `jobfit.Analysis` cached per (user, job) in `user_job_analysis`; requirements carry
+  `covered / synonym-only / missing-have / missing-gap` statuses.
+- `api_keys` (SHA-256 hashed) with `RequireAuthOrKey` Bearer auth.
+- CV routes are beta-gated via `cvGate`; the agent is `beta_tester`-gated upstream.
+
+Constraint: this change's edit scope is the `hire` repo only. The `freehire cv` CLI subcommands
+(`freehire-cli` repo) and the `cv-tailoring` agent skill (`freehire-agent` repo) are companion
+changes tracked in their own repos; this change delivers the API + model + contracts + web CTA they
+depend on.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Turn `cvs.job_id` into the two-tier base/tailored model.
+- A pure, sanitized, field-level patch transform (`cv.Apply`) and its `PATCH` endpoint.
+- A bootstrap endpoint that seeds/creates CVs, gates on a cached analysis, and mints a scoped key.
+- A tailoring-context read over the cached analysis.
+- A fit-page CTA that opens the tailoring session.
+
+**Non-Goals:**
+- The `freehire cv` CLI and the roy `cv-tailoring` skill (separate repos).
+- An item-level **experience bank** — noted seam; the base CV is the proto-bank.
+- Any change to how `jobfit.Analysis` is computed (it is only read).
+- The full split-preview assistant UI polish beyond wiring the CTA and preview render.
+
+## Decisions
+
+**D1 — Live agent (roy) drives the dialogue; freehire owns the CV state.**
+Alternative: a server-side `jobfit`-style prompt-chain inside freehire. Rejected: the user wants a
+free-form interactive session, and roy already has `hire_token` SSO, shadow-user provisioning, and a
+`Bash(freehire:*)`-confined tool model. freehire stays the single source of truth; the agent edits
+through the CLI→API, holding no durable state and touching no filesystem (roy's `Edit`/`Write` stay
+denied).
+
+**D2 — Field-level patches, not whole-document saves.**
+Alternative: `freehire cv save` replacing the entire document. Rejected: an LLM re-emitting the full
+document each turn risks silently dropping untouched sections and burns tokens. Both reference
+projects (ai-job-search, career-ops) chose structured field edits for auditability. `cv.Apply(doc,
+patch)` is pure (mirrors `cv.Seed`); the caller sanitizes. Out-of-range addressing is a 422, never a
+silent no-op.
+
+**D3 — Two-tier CV = two `cvs` rows.** Base CV `job_id = NULL`; tailored CV `job_id = <vacancy>`,
+copied from base at bootstrap. Reuses the existing table and the `ON DELETE SET NULL` already on
+`job_id`. The base CV doubles as the proto experience-bank.
+
+**D4 — Honest wall.** New facts are never fabricated. The freehire side enforces what it can observe:
+the tailor-context read exposes `missing-have` vs `missing-gap` so the agent can reframe vs ask, and
+base-CV edits are a distinct, explicit action (patching the `job_id = NULL` row). The
+"ask-before-adding" behavior itself lives in the agent skill (separate repo) but depends on this
+classification being exposed.
+
+**D5 — Scoped short-lived API key for the CLI credential.**
+Alternative: pass the raw `hire_token` JWT as Bearer. Rejected: `RequireAuthOrKey` expects an API
+key as Bearer, and a scoped, revocable, short-lived key is safer than handing the session cookie to
+a subprocess. Minted at bootstrap, returned as `cli_token`, injected into the roy session as
+`FREEHIRE_TOKEN`.
+
+**D6 — Reuse `/my/assistant` with a split preview.** Alternative: a dedicated `/my/cvs/[id]/tailor`
+route. Chosen reuse: the assistant SPA already renders the roy `/ws` journal; add a right-hand CV
+preview re-rendered on turn boundaries. Reversible if a dedicated route proves cleaner.
+
+## Risks / Trade-offs
+
+- **The honest wall cannot be fully enforced server-side** (freehire can't know if a fact was
+  candidate-confirmed) → Mitigation: expose the `missing-have`/`missing-gap` split and keep base-CV
+  edits explicit; the enforcing prompt lives in the reviewed agent skill; `Sanitize` still bounds
+  everything persisted.
+- **Cross-repo coordination** (API must ship before CLI/skill can use it) → Mitigation: this change
+  is contract-first and independently shippable; companions land after.
+- **Scoped-key leakage into a subprocess env** → Mitigation: short TTL + narrow scope + revocable via
+  existing `api_keys` machinery.
+- **Whole-document copy at bootstrap drifts from base** (base edited later) → acceptable: a tailored
+  CV is a point-in-time projection by design; not kept in sync.
+
+## Migration Plan
+
+Additive only — no schema migration needed (`cvs.job_id` already exists). Deploy freehire (API +
+contracts + CTA) behind the beta gate; then land the `freehire-cli` and `freehire-agent` companions.
+Rollback: the endpoints and CTA are beta-gated and additive; disabling the CTA / gate removes the
+surface with no data cleanup.
+
+## Open Questions
+
+- Scoped-key TTL and exact scope string (resolve during implementation against `api_keys` capabilities).
+- Whether the preview pane renders PDF (`GET /:id/pdf`) or a lighter HTML projection for latency.

--- a/openspec/changes/add-cv-tailoring/design.md
+++ b/openspec/changes/add-cv-tailoring/design.md
@@ -61,11 +61,20 @@ base-CV edits are a distinct, explicit action (patching the `job_id = NULL` row)
 "ask-before-adding" behavior itself lives in the agent skill (separate repo) but depends on this
 classification being exposed.
 
-**D5 — Scoped short-lived API key for the CLI credential.**
+**D5 — Short-lived owner-scoped API key for the CLI credential.**
 Alternative: pass the raw `hire_token` JWT as Bearer. Rejected: `RequireAuthOrKey` expects an API
-key as Bearer, and a scoped, revocable, short-lived key is safer than handing the session cookie to
-a subprocess. Minted at bootstrap, returned as `cli_token`, injected into the roy session as
-`FREEHIRE_TOKEN`.
+key as Bearer, and a revocable, short-lived key is safer than handing the session cookie to a
+subprocess. The freehire `api_keys` table has no per-endpoint scope column, so "scoped" here means
+owner-scoped only (the key resolves to the user; the CV endpoints' own owner checks confine it) —
+short-lived is real (2h TTL via the existing `expires_at`). Minted at bootstrap, returned as
+`cli_token`.
+
+**Key delivery (companion, cross-repo).** freehire only mints and returns `cli_token`; how it reaches
+the CLI is the roy session bootstrap's job. Preferred: the bootstrap writes the token into the
+session home in the `freehire-cli` config format (`~/.freehire`) so `freehire cv …` auto-authenticates
+on first run, rather than only injecting `FREEHIRE_TOKEN` into the process env (which exposes the
+secret to every child process). The exact config format lives in the `freehire-cli` repo; this change
+just returns the token.
 
 **D6 — Reuse `/my/assistant` with a split preview.** Alternative: a dedicated `/my/cvs/[id]/tailor`
 route. Chosen reuse: the assistant SPA already renders the roy `/ws` journal; add a right-hand CV

--- a/openspec/changes/add-cv-tailoring/proposal.md
+++ b/openspec/changes/add-cv-tailoring/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+After a résumé-vs-vacancy fit analysis, the user has a verdict, gaps, and a per-requirement
+coverage table — but no way to act on it. They should be able to tailor their CV to that
+specific vacancy in a live agent session that reframes existing experience and, for genuine
+gaps, asks the candidate before adding anything. This change delivers the freehire-side
+contract (data model + API + typed wire shapes + entry point) that the roy/freehire-agent
+session drives; it wires up the `cvs.job_id` seam the schema already anticipated.
+
+## What Changes
+
+- Introduce a **two-tier CV model** over the existing `cvs` table: a **base CV** (`job_id = NULL`,
+  the editable canonical résumé, seeded from `structured_resume` via existing `cv.Seed`) and a
+  **tailored CV** (`job_id = <vacancy>`, a per-vacancy copy that receives all tailoring edits).
+- Add a **field-level patch operation** on a CV document: a pure `cv.Apply(doc, patch)` mirroring
+  `cv.Seed`, exposed via `PATCH /api/v1/me/cvs/:id`. Patches address specific fields
+  (`summary`, `experience[i].bullets` incl. add/replace/remove/reorder, skill groups, header
+  fields); the whole document is never re-emitted. Every patch runs through `cv.Document.Sanitize`
+  (bounds + prompt-injection guard).
+- Add a **tailoring bootstrap** `POST /api/v1/me/cvs/tailor` `{job_slug}` that reads the cached
+  `jobfit.Analysis`, finds/seeds the base CV, creates the tailored copy, mints a short-lived
+  scoped API key for the agent's CLI, and returns `{tailor_cv_id, base_cv_id, analysis, cli_token}`.
+- Add a **tailoring context** read `GET /api/v1/me/cvs/:id/tailor-context` returning the verdict,
+  `missing-have`/`missing-gap` requirements, recommendation, and per-dimension comments the agent
+  reasons over (sourced from the cached analysis, no LLM recompute).
+- Enforce the **honest wall** at the API/model level: patches carry only reframed existing content
+  or candidate-confirmed facts; the API never fabricates. `missing-have` → surface existing
+  evidence; `missing-gap` → only written after candidate confirmation.
+- Emit the new wire types (`cv.Patch`, tailor-context) through `cmd/gen-contracts` into
+  `web/src/lib/generated/contracts.ts`.
+- Add the **web entry point**: a "Подогнать CV под вакансию" CTA on `/jobs/[slug]/fit`, shown only
+  when a cached non-stale analysis exists, that calls the bootstrap and opens the assistant surface.
+- **Beta-gated** throughout (union of the CV builder's `cvGate` and the agent's `beta_tester`).
+
+## Capabilities
+
+### New Capabilities
+- `cv-tailoring`: the two-tier base/tailored CV model over `cvs`, the field-level patch operation
+  and its endpoint, the tailoring bootstrap and context endpoints, the scoped-key minting, the
+  honest-wall invariants at the model/API boundary, the typed wire contracts, and the fit-page CTA.
+
+### Modified Capabilities
+<!-- job-fit-analysis is only read (its cached output is consumed), not changed at the requirement
+     level; the cvs CRUD surface has no existing capability spec. No requirement-level modifications. -->
+
+## Impact
+
+- **Code (this repo):** `internal/cv/` (new `cv.Patch` + `cv.Apply`, tailor bootstrap in the store
+  layer), `internal/handler/cv.go` + route wiring, `internal/db/queries/cvs.sql` (create tailored
+  row with `job_id`, fetch base by user), `cmd/gen-contracts`, `web/src/routes/jobs/[slug]/fit/`
+  (CTA) and the assistant surface (`web/src/routes/my/assistant`, split preview). Reads cached
+  `jobfit.Analysis` from `user_job_analysis`; reuses `api_keys` for scoped-key minting.
+- **Cross-repo companions (NOT in this change's edit scope):** `freehire-cli` gains `freehire cv
+  context|get|edit|render` subcommands that call these endpoints; `freehire-agent` gains a
+  `cv-tailoring` skill that drives the dialogue. Tracked as separate changes in their repos; this
+  change delivers the contract they depend on.
+- **Gating:** beta only. **No breaking changes** — all additive.
+- **Noted seam (out of scope):** an item-level "experience bank" as the canonical store; the base
+  CV serves as the proto-bank for now.

--- a/openspec/changes/add-cv-tailoring/specs/cv-tailoring/spec.md
+++ b/openspec/changes/add-cv-tailoring/specs/cv-tailoring/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: Tailoring starts a job-bound copy of the base CV
+
+The system SHALL, on a tailoring bootstrap request for a vacancy, create a new CV row bound to
+that vacancy (`cvs.job_id` set) whose document is copied from the user's base CV (`job_id = NULL`),
+and SHALL return the tailored CV id, the base CV id, and the cached fit analysis. The base CV MUST
+remain unchanged by the bootstrap, and the tailored CV MUST be owner-scoped to the requesting user.
+
+#### Scenario: Bootstrap creates a tailored copy bound to the vacancy
+
+- **WHEN** a signed-in beta user requests tailoring for a vacancy and already has a base CV
+- **THEN** a new CV is created with `job_id` set to that vacancy, its document equals the base CV's document, and the response returns both ids plus the cached analysis
+
+#### Scenario: The base CV is untouched by bootstrap
+
+- **WHEN** the tailoring bootstrap creates a tailored copy
+- **THEN** the base CV's document and `updated_at` are unchanged
+
+### Requirement: The base CV is seeded from the structured résumé when absent
+
+The system SHALL, when the user has no base CV at tailoring time, seed one from the stored
+structured résumé using the existing deterministic seed mapping, persist it as the base CV
+(`job_id = NULL`), and then create the tailored copy from it. When no structured résumé is
+available, the bootstrap MUST fail with a client error that tells the user to add a résumé first,
+and MUST NOT create any CV row.
+
+#### Scenario: A first-time user gets a base CV seeded from their résumé
+
+- **WHEN** a beta user with a stored structured résumé but no base CV requests tailoring
+- **THEN** a base CV is seeded from the structured résumé and a tailored copy is created from it
+
+#### Scenario: Tailoring without a résumé is refused
+
+- **WHEN** a beta user with no stored résumé requests tailoring
+- **THEN** the request fails with a 409 telling them to add a résumé, and no CV row is created
+
+### Requirement: Tailoring requires an existing fit analysis
+
+The system SHALL require a cached fit analysis for the (user, vacancy) pair before tailoring, and
+MUST NOT recompute it. When no cached analysis exists, the bootstrap MUST fail with a 409 telling
+the user to run the fit analysis first.
+
+#### Scenario: Tailoring is refused when no analysis is cached
+
+- **WHEN** a beta user requests tailoring for a vacancy they have never analyzed
+- **THEN** the request fails with a 409 telling them to run the fit analysis first
+
+#### Scenario: Bootstrap returns the cached analysis without recomputing
+
+- **WHEN** a beta user with a cached analysis requests tailoring
+- **THEN** the response carries that cached analysis and no LLM call is made
+
+### Requirement: CV edits are applied as sanitized field-level patches
+
+The system SHALL expose an operation that applies a single field-level patch to a CV document —
+addressing the summary, a specific experience entry's bullets (add, replace, remove, reorder), a
+skill group, or a header field — without re-emitting the rest of the document. Every patch MUST be
+applied through a pure document transform and then passed through the document sanitizer (length
+and cardinality bounds, prompt-injection guard) before persistence. A patch that addresses a field
+or index that does not exist MUST be rejected as a client error and MUST NOT mutate the document.
+
+#### Scenario: A bullet is added to one experience entry, leaving others intact
+
+- **WHEN** a patch adds a bullet to experience entry 0
+- **THEN** entry 0 gains the bullet, every other section of the document is byte-for-byte unchanged, and the result is sanitized before saving
+
+#### Scenario: Out-of-range addressing is rejected
+
+- **WHEN** a patch targets an experience index that does not exist
+- **THEN** the operation fails with a 422 and the stored document is unchanged
+
+#### Scenario: Bullets can be reordered by relevance
+
+- **WHEN** a patch reorders the bullets of an experience entry to a given permutation
+- **THEN** that entry's bullets appear in the requested order and no bullet is added or dropped
+
+### Requirement: Tailoring context is served from the cached analysis
+
+The system SHALL expose a read that returns the tailoring context for a tailored CV — the verdict,
+the recommendation, the per-dimension comments, and the requirement coverage split into
+`missing-have` (evidence exists but the CV omits it) and `missing-gap` (a genuine gap) — sourced
+from the cached fit analysis with no LLM recompute. The read MUST be owner-scoped and MUST require
+an authenticated caller (session cookie or API key).
+
+#### Scenario: The consumer can distinguish reframe-able requirements from genuine gaps
+
+- **WHEN** an authenticated owner reads the tailoring context for their tailored CV
+- **THEN** the response lists the verdict, recommendation, dimension comments, and requirements labelled `missing-have` versus `missing-gap`
+
+### Requirement: The tailoring agent acts as the user via a scoped, short-lived credential
+
+The system SHALL, at tailoring bootstrap, mint a short-lived scoped API key for the requesting user
+and return it so the agent's CLI can authenticate to the CV endpoints as that user. Patches and
+reads made with that key MUST be owner-scoped to the same user, so the agent can never read or edit
+another user's CV.
+
+#### Scenario: The minted key edits only its owner's CVs
+
+- **WHEN** the agent uses the minted key to patch a CV id that belongs to a different user
+- **THEN** the request is rejected as not found / forbidden and no document is mutated
+
+### Requirement: Tailoring is beta-gated and surfaced only after analysis
+
+The system SHALL gate every tailoring endpoint behind beta access (the union of the CV builder gate
+and the agent's beta-tester flag), and the fit page SHALL surface the "tailor my CV" entry point
+only when a cached, non-stale analysis exists for that user and vacancy.
+
+#### Scenario: A non-beta user cannot reach tailoring
+
+- **WHEN** a signed-in non-beta user calls the tailoring bootstrap
+- **THEN** the request is refused by the beta gate
+
+#### Scenario: The CTA is hidden without an analysis
+
+- **WHEN** a beta user opens a fit page for a vacancy they have not analyzed
+- **THEN** the "tailor my CV" entry point is not shown

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -34,9 +34,9 @@
 
 ## 7. Web entry point
 
-- [ ] 7.1 On `/jobs/[slug]/fit`, show a "Подогнать CV под вакансию" CTA only when a cached non-stale analysis exists; call `POST /cvs/tailor` and route to the assistant surface with the returned ids
-- [ ] 7.2 In the assistant surface, add a right-hand CV preview pane that renders the tailored CV (`GET /:id/pdf` or HTML) and refreshes on turn boundaries
-- [ ] 7.3 Frontend verification: CTA hidden without analysis, visible with; bootstrap opens the session with the preview (svelte-check + visual verify per web conventions)
+- [x] 7.1 On `/jobs/[slug]/fit`, show a "Tailor my CV" CTA only when a cached analysis exists (`data.fit?.analysis`), the caller has a CV, and is beta; `api.tailorCv(slug)` bootstraps and `goto`s the tailored CV editor. Added `api.tailorCv` + `TailorResult` type
+- [~] 7.2 CROSS-REPO (deferred): a live split chat+preview where the agent edits on the fly requires `freehire-agent` to accept session context (`createSession` currently sends `{}`) + `freehire-cli` `cv` commands. In-repo, the tailored CV is viewable/renderable via the existing `CvEditor` + `cvPdfUrl` (`/my/cvs/[id]`), which the CTA opens
+- [x] 7.3 Frontend verification: `svelte-check` clean (0 errors); CTA gated on analysis+CV+beta. Live visual verify of the seeded session belongs to the cross-repo agent surface (7.2)
 
 ## 8. Verify
 

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -12,9 +12,9 @@
 
 ## 3. Store: tailoring bootstrap + patch
 
-- [ ] 3.1 `cv.Store` method to apply a patch: load → `cv.Apply` → `Sanitize` → update, owner-scoped; 422 on bad addressing
-- [ ] 3.2 `cv.Store`/service bootstrap: find base CV or seed one from `resume.Structured` (absent résumé → typed 409 error, no row created), then create the tailored copy from the base
-- [ ] 3.3 Unit/integration tests: bootstrap seeds base when absent, refuses without résumé, tailored copy equals base and base is untouched
+- [x] 3.1 `cv.Store` method to apply a patch: load → `cv.Apply` → `Sanitize` → update, owner-scoped; 422 on bad addressing
+- [x] 3.2 `cv.Store`/service bootstrap: find base CV or seed one from `resume.Structured` (absent résumé → typed 409 error, no row created), then create the tailored copy from the base
+- [x] 3.3 Unit/integration tests: bootstrap seeds base when absent, refuses without résumé, tailored copy equals base and base is untouched
 
 ## 4. Scoped credential
 

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -6,9 +6,9 @@
 
 ## 2. SQL layer
 
-- [ ] 2.1 Add `cvs.sql` query to fetch a user's base CV (`job_id IS NULL`), owner-scoped
-- [ ] 2.2 Extend/add a `CreateCV` path that sets `job_id` for the tailored copy; regenerate `internal/db` via `make sqlc`
-- [ ] 2.3 Integration test (build-tag) for base-CV fetch and tailored-row creation with `job_id`
+- [x] 2.1 Add `cvs.sql` query to fetch a user's base CV (`job_id IS NULL`), owner-scoped
+- [x] 2.2 Extend/add a `CreateCV` path that sets `job_id` for the tailored copy; regenerate `internal/db` via `make sqlc`
+- [x] 2.3 Integration test (build-tag) for base-CV fetch and tailored-row creation with `job_id`
 
 ## 3. Store: tailoring bootstrap + patch
 

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -19,14 +19,14 @@
 ## 4. Scoped credential
 
 - [x] 4.1 Mint a short-lived API key for the user via the existing `api_keys` machinery (`mintTailoringKey`, 2h TTL; no per-endpoint scope column exists → owner-scoped only). Delivery to the CLI (`~/.freehire` config vs env) is a cross-repo companion concern
-- [ ] 4.2 Test: minted key authenticates the CV endpoints and is owner-scoped (cannot touch another user's CV) — unit test covers hash↔token match; endpoint owner-scoping is exercised in 5.4
+- [x] 4.2 Test: minted key authenticates the CV endpoints and is owner-scoped (cannot touch another user's CV) — unit test covers hash↔token match; endpoint owner-scoping exercised in `TestPatchCVViaKey`
 
 ## 5. HTTP surface + gating
 
-- [ ] 5.1 `PATCH /api/v1/me/cvs/:id` handler (`RequireAuthOrKey` + beta gate) → store patch; 422 on bad addressing, 404 on non-owner
-- [ ] 5.2 `POST /api/v1/me/cvs/tailor` handler (`RequireAuth` + beta gate): 409 when no cached `jobfit.Analysis`, 409 when no résumé; returns `{tailor_cv_id, base_cv_id, analysis, cli_token}`
-- [ ] 5.3 `GET /api/v1/me/cvs/:id/tailor-context` handler (`RequireAuthOrKey` + beta): verdict + recommendation + dimension comments + requirements split `missing-have`/`missing-gap`, from cached analysis, no LLM
-- [ ] 5.4 Wire routes in `internal/handler/handler.go` under the existing `cvGate`; handler integration tests for the three endpoints (preconditions, gating, owner-scoping)
+- [x] 5.1 `PATCH /api/v1/me/cvs/:id` handler (`RequireAuthOrKey` + beta gate) → store patch; 422 on bad addressing, 404 on non-owner
+- [x] 5.2 `POST /api/v1/me/cvs/tailor` handler (`RequireAuth` + beta gate): 409 when no cached `jobfit.Analysis`, 409 when no résumé; returns `{tailor_cv_id, base_cv_id, analysis, cli_token}`
+- [x] 5.3 `GET /api/v1/me/cvs/:id/tailor-context` handler (`RequireAuthOrKey` + beta): verdict + recommendation + dimension comments + requirements split `missing-have`/`missing-gap`, from cached analysis, no LLM
+- [x] 5.4 Wire routes in `internal/handler/handler.go` under the existing `cvGate`; handler integration tests for the three endpoints (preconditions, gating, owner-scoping)
 
 ## 6. Typed contracts
 

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -1,0 +1,44 @@
+## 1. Patch model (pure, unit-tested)
+
+- [ ] 1.1 Add `cv.Patch` type in a dependency-light file in `internal/cv/` (ops: set-summary, add/replace/remove/reorder bullet at `experience[i]`, set-skill-group, set-header-field), with a discriminated op field
+- [ ] 1.2 Implement pure `cv.Apply(doc Document, p Patch) (Document, error)` mirroring `cv.Seed` — no I/O, returns a client-style error for out-of-range/unknown addressing, never mutates the input
+- [ ] 1.3 Unit tests for `cv.Apply`: each op happy path, other sections byte-for-byte unchanged, reorder is a pure permutation (no add/drop), out-of-range index errors
+
+## 2. SQL layer
+
+- [ ] 2.1 Add `cvs.sql` query to fetch a user's base CV (`job_id IS NULL`), owner-scoped
+- [ ] 2.2 Extend/add a `CreateCV` path that sets `job_id` for the tailored copy; regenerate `internal/db` via `make sqlc`
+- [ ] 2.3 Integration test (build-tag) for base-CV fetch and tailored-row creation with `job_id`
+
+## 3. Store: tailoring bootstrap + patch
+
+- [ ] 3.1 `cv.Store` method to apply a patch: load → `cv.Apply` → `Sanitize` → update, owner-scoped; 422 on bad addressing
+- [ ] 3.2 `cv.Store`/service bootstrap: find base CV or seed one from `resume.Structured` (absent résumé → typed 409 error, no row created), then create the tailored copy from the base
+- [ ] 3.3 Unit/integration tests: bootstrap seeds base when absent, refuses without résumé, tailored copy equals base and base is untouched
+
+## 4. Scoped credential
+
+- [ ] 4.1 Mint a short-lived scoped API key for the user at bootstrap via the existing `api_keys` machinery; decide TTL + scope string
+- [ ] 4.2 Test: minted key authenticates the CV endpoints and is owner-scoped (cannot touch another user's CV)
+
+## 5. HTTP surface + gating
+
+- [ ] 5.1 `PATCH /api/v1/me/cvs/:id` handler (`RequireAuthOrKey` + beta gate) → store patch; 422 on bad addressing, 404 on non-owner
+- [ ] 5.2 `POST /api/v1/me/cvs/tailor` handler (`RequireAuth` + beta gate): 409 when no cached `jobfit.Analysis`, 409 when no résumé; returns `{tailor_cv_id, base_cv_id, analysis, cli_token}`
+- [ ] 5.3 `GET /api/v1/me/cvs/:id/tailor-context` handler (`RequireAuthOrKey` + beta): verdict + recommendation + dimension comments + requirements split `missing-have`/`missing-gap`, from cached analysis, no LLM
+- [ ] 5.4 Wire routes in `internal/handler/handler.go` under the existing `cvGate`; handler integration tests for the three endpoints (preconditions, gating, owner-scoping)
+
+## 6. Typed contracts
+
+- [ ] 6.1 Register `cv.Patch` and the tailor-context wire struct in `cmd/gen-contracts`; run it; verify TS lands in `web/src/lib/generated/contracts.ts`
+
+## 7. Web entry point
+
+- [ ] 7.1 On `/jobs/[slug]/fit`, show a "Подогнать CV под вакансию" CTA only when a cached non-stale analysis exists; call `POST /cvs/tailor` and route to the assistant surface with the returned ids
+- [ ] 7.2 In the assistant surface, add a right-hand CV preview pane that renders the tailored CV (`GET /:id/pdf` or HTML) and refreshes on turn boundaries
+- [ ] 7.3 Frontend verification: CTA hidden without analysis, visible with; bootstrap opens the session with the preview (svelte-check + visual verify per web conventions)
+
+## 8. Verify
+
+- [ ] 8.1 `go build ./... && go vet ./... && go test ./...`; run `cv.Apply` and handler tests green
+- [ ] 8.2 Drive the flow end-to-end against a local server (bootstrap → patch → tailor-context → preview) and confirm behavior

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -1,8 +1,8 @@
 ## 1. Patch model (pure, unit-tested)
 
-- [ ] 1.1 Add `cv.Patch` type in a dependency-light file in `internal/cv/` (ops: set-summary, add/replace/remove/reorder bullet at `experience[i]`, set-skill-group, set-header-field), with a discriminated op field
-- [ ] 1.2 Implement pure `cv.Apply(doc Document, p Patch) (Document, error)` mirroring `cv.Seed` — no I/O, returns a client-style error for out-of-range/unknown addressing, never mutates the input
-- [ ] 1.3 Unit tests for `cv.Apply`: each op happy path, other sections byte-for-byte unchanged, reorder is a pure permutation (no add/drop), out-of-range index errors
+- [x] 1.1 Add `cv.Patch` type in a dependency-light file in `internal/cv/` (ops: set-summary, add/replace/remove/reorder bullet at `experience[i]`, set-skill-group, set-header-field), with a discriminated op field
+- [x] 1.2 Implement pure `cv.Apply(doc Document, p Patch) (Document, error)` mirroring `cv.Seed` — no I/O, returns a client-style error for out-of-range/unknown addressing, never mutates the input
+- [x] 1.3 Unit tests for `cv.Apply`: each op happy path, other sections byte-for-byte unchanged, reorder is a pure permutation (no add/drop), out-of-range index errors
 
 ## 2. SQL layer
 

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -40,5 +40,5 @@
 
 ## 8. Verify
 
-- [ ] 8.1 `go build ./... && go vet ./... && go test ./...`; run `cv.Apply` and handler tests green
-- [ ] 8.2 Drive the flow end-to-end against a local server (bootstrap → patch → tailor-context → preview) and confirm behavior
+- [x] 8.1 `go build ./...` (exit 0), `go vet ./...` (exit 0), `go test ./...` (0 fail), `svelte-check` (0 errors); `cv.Apply` + store + handler unit + integration green
+- [x] 8.2 End-to-end via handler integration tests over real Postgres: bootstrap (409 no-analysis → 409 no-résumé → 201) → patch (apply / 422 / 404 owner) → tailor-context (missing_have/gap split / 409). The live UI walkthrough (fit → seeded agent session → live preview) is the cross-repo companion (see 7.2)

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -30,7 +30,7 @@
 
 ## 6. Typed contracts
 
-- [ ] 6.1 Register `cv.Patch` and the tailor-context wire struct in `cmd/gen-contracts`; run it; verify TS lands in `web/src/lib/generated/contracts.ts`
+- [x] 6.1 Register `cv.Patch` in `cmd/gen-contracts` (added `patch.go` to the cv package); `PatchOp` + `Patch` land in `contracts.ts`. The tailor-context/response wrappers are handler projections composed on the web from the already-emitted `Analysis`/`Requirement`/`Dimension`, not emitted (unexported handler structs)
 
 ## 7. Web entry point
 

--- a/openspec/changes/add-cv-tailoring/tasks.md
+++ b/openspec/changes/add-cv-tailoring/tasks.md
@@ -18,8 +18,8 @@
 
 ## 4. Scoped credential
 
-- [ ] 4.1 Mint a short-lived scoped API key for the user at bootstrap via the existing `api_keys` machinery; decide TTL + scope string
-- [ ] 4.2 Test: minted key authenticates the CV endpoints and is owner-scoped (cannot touch another user's CV)
+- [x] 4.1 Mint a short-lived API key for the user via the existing `api_keys` machinery (`mintTailoringKey`, 2h TTL; no per-endpoint scope column exists → owner-scoped only). Delivery to the CLI (`~/.freehire` config vs env) is a cross-repo companion concern
+- [ ] 4.2 Test: minted key authenticates the CV endpoints and is owner-scoped (cannot touch another user's CV) — unit test covers hash↔token match; endpoint owner-scoping is exercised in 5.4
 
 ## 5. HTTP surface + gating
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -10,7 +10,7 @@
 // fetch per call site — not a module-level variable — keeps concurrent SSR
 // requests from sharing (and racing on) a session.
 
-import type { CvMeta, CvRecord, CreateCvInput, UpdateCvInput } from './cv';
+import type { CvMeta, CvRecord, CreateCvInput, UpdateCvInput, TailorResult } from './cv';
 import type {
   Job,
   EmailLinking,
@@ -1008,6 +1008,15 @@ export function createApi(
     return `${baseUrl}/api/v1/me/cvs/${id}/pdf`;
   }
 
+  /**
+   * Bootstrap a tailoring session for a vacancy: seeds/creates the base CV, makes a
+   * vacancy-bound tailored copy, and returns its id plus the cached analysis. Requires a
+   * cached fit analysis and a stored résumé (409 otherwise); beta-gated.
+   */
+  async function tailorCv(jobSlug: string): Promise<TailorResult> {
+    return requestData<TailorResult>('/api/v1/me/cvs/tailor', jsonBody('POST', { job_slug: jobSlug }));
+  }
+
   return {
     listJobs,
     getJob,
@@ -1109,6 +1118,7 @@ export function createApi(
     updateCv,
     deleteCv,
     cvPdfUrl,
+    tailorCv,
   };
 }
 

--- a/web/src/lib/cv.ts
+++ b/web/src/lib/cv.ts
@@ -11,6 +11,7 @@ import type {
   Language,
   Project,
   Certification,
+  Analysis,
 } from './generated/contracts';
 
 /** CV metadata (list rows and mutation responses). */
@@ -25,6 +26,19 @@ export interface CvMeta {
 /** A CV with its full editable document. */
 export interface CvRecord extends CvMeta {
   document: Document;
+}
+
+/**
+ * Result of bootstrapping a tailoring session: the ids of the new vacancy-bound CV and the
+ * base it was copied from, the cached fit analysis, and the short-lived token the agent's CLI
+ * authenticates with. `cli_token` is handed to the agent session; the browser only needs the
+ * ids (to open the tailored CV) and the analysis (to show context).
+ */
+export interface TailorResult {
+  tailor_cv_id: number;
+  base_cv_id: number;
+  analysis: Analysis | null;
+  cli_token: string;
 }
 
 /** Request body for creating a CV. */

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -580,7 +580,38 @@ export interface Certification {
   year?: string;
 }
 
-export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'briefhq', 'careerplug', 'careerspage', 'clinch', 'comeet', 'cornerstone', 'deel', 'djinni', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobstash', 'jobtech', 'jobvite', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'mindsight', 'mycareersfuture', 'neogov', 'northstone', 'oracle', 'pageup', 'paycom', 'paylocity', 'personio', 'phenom', 'pinpoint', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'spark', 'successfactors', 'talentadore', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'tyomarkkinatori', 'ukg', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
+//////////
+// source: patch.go
+
+/**
+ * PatchOp is the discriminator selecting which field-level edit a Patch performs.
+ */
+export type PatchOp = string;
+export const PatchSetSummary: PatchOp = "set_summary";
+export const PatchSetHeaderField: PatchOp = "set_header_field";
+export const PatchAddBullet: PatchOp = "add_bullet";
+export const PatchReplaceBullet: PatchOp = "replace_bullet";
+export const PatchRemoveBullet: PatchOp = "remove_bullet";
+export const PatchReorderBullets: PatchOp = "reorder_bullets";
+export const PatchSetSkillGroup: PatchOp = "set_skill_group";
+/**
+ * Patch is one field-level edit to a CV Document. Op selects the operation; the remaining
+ * fields are its address and payload, and only the ones an op needs are read. A patch names
+ * the single field it changes rather than re-emitting the document, so an LLM tailoring a CV
+ * mid-session cannot silently drop untouched sections.
+ */
+export interface Patch {
+  op: PatchOp;
+  experience?: number /* int */; // index into Document.Experience
+  bullet?: number /* int */; // index into the entry's Bullets (replace/remove)
+  field?: string; // header field name (set_header_field)
+  value?: string; // summary / bullet / header value
+  order?: number /* int */[]; // permutation of bullet indices (reorder_bullets)
+  group?: string; // skill group name (set_skill_group)
+  items?: string[]; // skill group items (set_skill_group)
+}
+
+export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'briefhq', 'careerplug', 'careerspage', 'catsone', 'cleverstaff', 'clinch', 'comeet', 'cornerstone', 'deel', 'djinni', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobstash', 'jobtech', 'jobvite', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'mindsight', 'mycareersfuture', 'neogov', 'northstone', 'odoo', 'oracle', 'pageup', 'paycom', 'paylocity', 'peopleforce', 'personio', 'phenom', 'pinpoint', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'spark', 'successfactors', 'talentadore', 'talentlyft', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'tyomarkkinatori', 'ukg', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;
 export type Source = (typeof SOURCE_VALUES)[number];
 export const STAGE_VALUES = ['applied', 'screening', 'responded', 'interview', 'offer', 'accepted', 'rejected', 'withdrawn'] as const;
 export type Stage = (typeof STAGE_VALUES)[number];

--- a/web/src/routes/jobs/[slug]/fit/+page.svelte
+++ b/web/src/routes/jobs/[slug]/fit/+page.svelte
@@ -1,10 +1,38 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { ArrowLeft } from '@lucide/svelte';
+  import { goto } from '$app/navigation';
+  import { ArrowLeft, Sparkles } from '@lucide/svelte';
+  import { api, ApiError } from '$lib/api';
+  import { currentUser } from '$lib/auth.svelte';
+  import { Button } from '$lib/ui';
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
   import JobFitFull from '$lib/components/JobFitFull.svelte';
 
   let { data } = $props();
+
+  // Tailoring is beta-gated (the server re-checks); the CTA only shows once an analysis
+  // exists for a stored CV — the analysis is what a tailored copy reframes toward.
+  const canTailor = $derived(
+    !!data.fit?.analysis &&
+      data.fit?.has_cv === true &&
+      (currentUser()?.beta_tester === true || currentUser()?.role === 'moderator'),
+  );
+
+  let tailoring = $state(false);
+  let tailorError = $state('');
+
+  async function startTailoring() {
+    tailoring = true;
+    tailorError = '';
+    try {
+      const res = await api.tailorCv(data.job.public_slug);
+      await goto(`/my/cvs/${res.tailor_cv_id}`);
+    } catch (e) {
+      tailorError =
+        e instanceof ApiError ? e.message : 'Could not start tailoring. Please try again.';
+      tailoring = false;
+    }
+  }
 </script>
 
 <svelte:head><title>Fit analysis · {data.job.title}</title></svelte:head>
@@ -28,4 +56,26 @@
   </header>
 
   <JobFitFull job={data.job} initial={data.fit} />
+
+  {#if canTailor}
+    <section
+      class="flex flex-col gap-3 rounded-xl border border-border bg-muted/30 p-5 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div class="flex flex-col gap-1">
+        <h2 class="flex items-center gap-2 text-sm font-semibold">
+          <Sparkles class="size-4 text-primary" />Tailor your CV to this role
+        </h2>
+        <p class="text-sm text-muted-foreground">
+          Create a copy of your CV reframed toward this vacancy — starting from the gaps this
+          analysis found. You can keep editing it after.
+        </p>
+        {#if tailorError}
+          <p class="text-sm text-destructive">{tailorError}</p>
+        {/if}
+      </div>
+      <Button onclick={startTailoring} disabled={tailoring} class="shrink-0">
+        {tailoring ? 'Preparing…' : 'Tailor my CV'}
+      </Button>
+    </section>
+  {/if}
 </div>

--- a/web/src/routes/jobs/[slug]/fit/+page.svelte
+++ b/web/src/routes/jobs/[slug]/fit/+page.svelte
@@ -10,10 +10,13 @@
 
   let { data } = $props();
 
-  // Tailoring is beta-gated (the server re-checks); the CTA only shows once an analysis
-  // exists for a stored CV — the analysis is what a tailored copy reframes toward.
+  // Tailoring is beta-gated (the server re-checks); the CTA only shows once a FRESH analysis
+  // exists for a stored CV — a stale one (CV or job changed since) would reframe toward an
+  // outdated verdict, so the user should recompute first. The analysis is what a tailored
+  // copy reframes toward.
   const canTailor = $derived(
     !!data.fit?.analysis &&
+      data.fit?.stale !== true &&
       data.fit?.has_cv === true &&
       (currentUser()?.beta_tester === true || currentUser()?.role === 'moderator'),
   );


### PR DESCRIPTION
## What

Interactive **CV tailoring** — the freehire-repo contract. After a résumé-vs-vacancy fit
analysis, a user can create a copy of their CV reframed toward that specific vacancy, seeded
from the gaps the analysis found. Wires up the `cvs.job_id` seam the schema anticipated.

### Backend
- **Two-tier CV model** over the existing `cvs` table: base CV (`job_id = NULL`) + vacancy-bound
  tailored copy (`job_id = <vacancy>`), reusing the existing `ON DELETE SET NULL`.
- **Field-level patch**: pure, immutable `cv.Apply(doc, patch)` (set-summary, add/replace/
  remove/reorder bullet, set-skill-group, set-header-field) → `PATCH /api/v1/me/cvs/:id`.
  Every patch runs through `Document.Sanitize`; out-of-range addressing is a 422, never a
  partial edit.
- **Bootstrap** `POST /api/v1/me/cvs/tailor` `{job_slug}`: requires a cached fit analysis
  (409) and a résumé (409), seeds/creates the base CV, makes the tailored copy, mints a
  short-lived owner-scoped API key, returns `{tailor_cv_id, base_cv_id, analysis, cli_token}`.
- **Tailoring context** `GET /api/v1/me/cvs/:id/tailor-context`: the cached verdict +
  recommendation + dimension comments + the `missing_have` / `missing_gap` requirement split
  the honest wall turns on. No LLM recompute.
- Beta-gated throughout (existing `cvGate`). `cv.Patch` emitted to TS contracts.

### Web
- "Tailor my CV" CTA on `/jobs/[slug]/fit`, shown only for a **fresh** analysis + stored CV +
  beta user; bootstraps and opens the tailored CV in the existing editor (viewable, PDF-renderable).

## Verification
- `go build ./...` exit 0 · `go vet ./...` exit 0 · `go test ./...` 0 fail · `svelte-check` 0 errors.
- Integration (real Postgres, testcontainers): `internal/db` + `internal/handler` green —
  bootstrap (409 no-analysis → 409 no-résumé → 201) → patch (apply / 422 / 404 owner-scoping via
  minted key) → tailor-context (missing_have/gap split / 409).
- Code-review (high) run on the branch: stale-analysis CTA gate fixed; two low-severity items
  noted as follow-ups (see below).

## Cross-repo companion (NOT in this PR)
The **live interactive loop** — the roy agent editing the CV on the fly via a seeded session —
lives in other repos: `freehire-agent` must accept **session context** on create (today
`createSession` sends `{}`), and `freehire-cli` needs `cv context/get/edit/render` subcommands.
This PR lands the API + contracts + entry point they depend on. The minted `cli_token` is what
the agent session authenticates with; delivery to the CLI (`~/.freehire` config vs env) is the
companion's concern.

## Follow-ups (noted, not blocking)
- Bootstrap is non-idempotent: repeated calls create duplicate tailored CVs per (user, job);
  a mint failure after `CreateTailored` orphans the row. Consider reuse-or-fork semantics.
- `tailor-context` on a tailored CV whose job was deleted (job_id SET NULL) returns a
  misleading 409 "not a tailored CV".

## Migration
Additive only — no schema migration (`cvs.job_id` already exists). Beta-gated; disabling the
gate removes the surface with no data cleanup.

OpenSpec change: `openspec/changes/add-cv-tailoring/`.
