### PR TITLE
fix(contributions): ack Telegram webhook immediately, reply async

### DIFF
--- a/internal/handler/telegram.go
+++ b/internal/handler/telegram.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"context"
 	"crypto/subtle"
 	"errors"
 	"log"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/jackc/pgx/v5"
@@ -119,19 +121,29 @@ func (a *API) TelegramWebhook(c *fiber.Ctx) error {
 // replyTelegram sends a confirmation back to the chat; a send failure is logged,
 // not surfaced (the link itself already succeeded or failed independently).
 func (a *API) replyTelegram(c *fiber.Ctx, chatID int64, msg string) {
-	if err := a.telegramBot.SendMessage(c.Context(), chatID, msg); err != nil {
-		log.Printf("telegram webhook: reply to chat=%d: %v", chatID, err)
+	a.sendTelegram(c.Context(), chatID, msg)
+}
+
+// sendTelegram posts msg to the chat, logging (not surfacing) a send failure.
+func (a *API) sendTelegram(ctx context.Context, chatID int64, msg string) {
+	if err := a.telegramBot.SendMessage(ctx, chatID, msg); err != nil {
+		log.Printf("telegram: send to chat=%d: %v", chatID, err)
 	}
 }
+
+// telegramContribTimeout bounds the background contribution work spawned from a webhook
+// update — the DB lookups plus the outbound reply — so a stuck goroutine cannot leak.
+const telegramContribTimeout = 15 * time.Second
 
 // telegramURL matches the first http(s) link in a message.
 var telegramURL = regexp.MustCompile(`https?://[^\s]+`)
 
-// handleTelegramContribution runs a board link pasted into the linked chat through the same
-// contribution flow as the website: it resolves the chat to its user, submits the first URL
-// in the message, and replies with the outcome. A message with no link is ignored silently
-// (so ordinary chatter draws no reply); a link from an unlinked chat prompts the user to link.
-func (a *API) handleTelegramContribution(c *fiber.Ctx, update telegramnotify.Update) {
+// handleTelegramContribution routes a board link pasted into the linked chat through the same
+// contribution flow as the website. It extracts the link and hands the DB + reply work to a
+// background goroutine so the webhook can ACK immediately: a slow webhook makes Telegram time
+// out and RE-DELIVER the update (a reply storm), and the request context is canceled the moment
+// we return. A message with no link is ignored silently.
+func (a *API) handleTelegramContribution(_ *fiber.Ctx, update telegramnotify.Update) {
 	if update.Message == nil {
 		return
 	}
@@ -142,29 +154,38 @@ func (a *API) handleTelegramContribution(c *fiber.Ctx, update telegramnotify.Upd
 	}
 	// Trim trailing punctuation a user (or Telegram) may append to the link.
 	rawURL := strings.TrimRight(m, ").,!?;:")
+	go a.processTelegramContribution(chatID, rawURL)
+}
 
-	userID, err := a.queries.GetUserIDByTelegramChat(c.Context(), chatID)
+// processTelegramContribution resolves the chat to its user, submits the link, and replies —
+// on its own bounded background context (the webhook has already returned). A link from an
+// unlinked chat prompts the user to link first.
+func (a *API) processTelegramContribution(chatID int64, rawURL string) {
+	ctx, cancel := context.WithTimeout(context.Background(), telegramContribTimeout)
+	defer cancel()
+
+	userID, err := a.queries.GetUserIDByTelegramChat(ctx, chatID)
 	if errors.Is(err, pgx.ErrNoRows) {
-		a.replyTelegram(c, chatID, "🔗 Link your freehire account first (Settings → Telegram on the site), then send board links here.")
+		a.sendTelegram(ctx, chatID, "🔗 Link your freehire account first (Settings → Telegram on the site), then send board links here.")
 		return
 	}
 	if err != nil {
-		log.Printf("telegram webhook: resolve chat=%d: %v", chatID, err)
+		log.Printf("telegram: resolve chat=%d: %v", chatID, err)
 		return
 	}
 
-	rec, err := a.contribution.Submit(c.Context(), userID, rawURL)
+	rec, err := a.contribution.Submit(ctx, userID, rawURL)
 	switch {
 	case errors.Is(err, contribution.ErrUnsupportedATS):
-		a.replyTelegram(c, chatID, "🤔 That link isn't from a supported ATS board. Send a link from a company's Greenhouse, Lever, Ashby, or Workable careers page.")
+		a.sendTelegram(ctx, chatID, "🤔 That link isn't from a supported ATS board. Send a link from a company's Greenhouse, Lever, Ashby, or Workable careers page.")
 	case errors.Is(err, contribution.ErrBoardAlreadyTracked):
-		a.replyTelegram(c, chatID, "👍 We already track that board — nothing to add.")
+		a.sendTelegram(ctx, chatID, "👍 We already track that board — nothing to add.")
 	case errors.Is(err, contribution.ErrBoardAlreadyContributed):
-		a.replyTelegram(c, chatID, "✅ That board was already contributed — no new point, but thanks!")
+		a.sendTelegram(ctx, chatID, "✅ That board was already contributed — no new point, but thanks!")
 	case err != nil:
-		log.Printf("telegram webhook: submit user=%d: %v", userID, err)
-		a.replyTelegram(c, chatID, "⚠️ Something went wrong. Please try again.")
+		log.Printf("telegram: submit user=%d: %v", userID, err)
+		a.sendTelegram(ctx, chatID, "⚠️ Something went wrong. Please try again.")
 	default:
-		a.replyTelegram(c, chatID, "🎉 <b>"+rec.Board+"</b> ("+rec.Source+") is a new board — we'll start crawling it. +1 point!")
+		a.sendTelegram(ctx, chatID, "🎉 <b>"+rec.Board+"</b> ("+rec.Source+") is a new board — we'll start crawling it. +1 point!")
 	}
 }

--- a/internal/handler/telegram_contribution_integration_test.go
+++ b/internal/handler/telegram_contribution_integration_test.go
@@ -37,18 +37,31 @@ func TestTelegramContribution(t *testing.T) {
 		t.Fatalf("seed link: %v", err)
 	}
 
-	// Stub Bot API that captures each reply's text.
-	var lastReply string
+	// Stub Bot API that streams each reply's text over a channel. The reply now happens in a
+	// background goroutine (the webhook ACKs first), so tests wait on this rather than reading
+	// a shared variable — race-free and async-aware.
+	replies := make(chan string, 8)
 	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
 			Text string `json:"text"`
 		}
 		b, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(b, &body)
-		lastReply = body.Text
+		replies <- body.Text
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer stub.Close()
+
+	waitReply := func(t *testing.T) string {
+		t.Helper()
+		select {
+		case msg := <-replies:
+			return msg
+		case <-time.After(5 * time.Second):
+			t.Fatal("no reply within 5s")
+			return ""
+		}
+	}
 
 	queries := db.New(pool)
 	h := &API{
@@ -85,14 +98,20 @@ func TestTelegramContribution(t *testing.T) {
 		return p
 	}
 
-	t.Run("a linked user's board link is recorded and rewarded", func(t *testing.T) {
-		lastReply = ""
+	t.Run("the webhook ACKs fast, then records and rewards in the background", func(t *testing.T) {
+		start := time.Now()
 		post(chatID, "found this: https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7")
+		// The webhook must return well before the reply is sent — that's the whole point of the
+		// async fix (a slow ACK triggers Telegram's retry storm).
+		if d := time.Since(start); d > 2*time.Second {
+			t.Errorf("webhook took %v to ACK, want fast (reply is async)", d)
+		}
+		reply := waitReply(t)
+		if !strings.Contains(reply, "blitzy") || !strings.Contains(reply, "new board") {
+			t.Errorf("reply = %q, want a new-board confirmation naming blitzy", reply)
+		}
 		if points() != 1 {
 			t.Errorf("points = %d, want 1", points())
-		}
-		if !strings.Contains(lastReply, "blitzy") || !strings.Contains(lastReply, "new board") {
-			t.Errorf("reply = %q, want a new-board confirmation naming blitzy", lastReply)
 		}
 		var board string
 		if err := pool.QueryRow(ctx, `SELECT board FROM link_contributions WHERE submitted_by=$1`, userID).Scan(&board); err != nil || board != "blitzy" {
@@ -101,29 +120,29 @@ func TestTelegramContribution(t *testing.T) {
 	})
 
 	t.Run("a second link on the same board earns no point", func(t *testing.T) {
-		lastReply = ""
 		post(chatID, "https://jobs.ashbyhq.com/blitzy") // the board listing this time
+		if reply := waitReply(t); !strings.Contains(reply, "already contributed") {
+			t.Errorf("reply = %q, want already-contributed", reply)
+		}
 		if points() != 1 {
 			t.Errorf("points = %d, want still 1", points())
-		}
-		if !strings.Contains(lastReply, "already contributed") {
-			t.Errorf("reply = %q, want already-contributed", lastReply)
 		}
 	})
 
 	t.Run("a non-link message draws no reply", func(t *testing.T) {
-		lastReply = ""
 		post(chatID, "hello bot how are you")
-		if lastReply != "" {
-			t.Errorf("reply = %q, want none for ordinary chatter", lastReply)
+		select {
+		case msg := <-replies:
+			t.Errorf("reply = %q, want none for ordinary chatter", msg)
+		case <-time.After(500 * time.Millisecond):
+			// no reply — correct
 		}
 	})
 
 	t.Run("a link from an unlinked chat prompts to link", func(t *testing.T) {
-		lastReply = ""
 		post(999999, "https://jobs.ashbyhq.com/newco/uuid")
-		if !strings.Contains(strings.ToLower(lastReply), "link your") {
-			t.Errorf("reply = %q, want a link-your-account prompt", lastReply)
+		if reply := waitReply(t); !strings.Contains(strings.ToLower(reply), "link your") {
+			t.Errorf("reply = %q, want a link-your-account prompt", reply)
 		}
 	})
 }


### PR DESCRIPTION
**Incident:** after #810 deployed, the FreeHire bot repeated `👍 We already track that board` every minute to a linked user.

**Root cause:** `handleTelegramContribution` replied synchronously (`SendMessage`) inside the webhook, so the response could exceed Telegram's read timeout. `getWebhookInfo` showed `last_error: Read timeout expired` → Telegram re-delivered the same update repeatedly (a retry storm; concurrent handlers also exhausted the DB pool, ballooning latency to 1-2 min).

**Fix:** extract the link fast, then hand the chat→user lookup + `Submit` + reply to a background goroutine on a bounded `context.Background()`. The webhook now ACKs in ms, so Telegram never retries. Verified by an integration test asserting the webhook returns fast and the reply/point land asynchronously (run with `-race`).

Mitigated in prod by rollback to green; this re-lands the feature safely.