### PR TITLE
refactor(sources): consolidate HTML helpers (walk + crawlPagedLinks)

### DIFF
--- a/internal/sources/avito.go
+++ b/internal/sources/avito.go
@@ -145,16 +145,5 @@ var avitoTitleCityPattern = regexp.MustCompile(`в городе\s+(.+?)\s*$`)
 // avitoTitleCity returns the display city parsed from the page <title>'s "в городе"
 // suffix, or "" when the page has no such title.
 func avitoTitleCity(root *html.Node) string {
-	var title string
-	walk(root, func(n *html.Node) bool {
-		if title != "" {
-			return false
-		}
-		if n.Type == html.ElementNode && n.Data == "title" {
-			title = textContent(n)
-			return false
-		}
-		return true
-	})
-	return firstSubmatch(avitoTitleCityPattern, title)
+	return firstSubmatch(avitoTitleCityPattern, titleText(root))
 }

--- a/internal/sources/careerplug.go
+++ b/internal/sources/careerplug.go
@@ -38,31 +38,18 @@ func (s careerplug) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, fmt.Errorf("careerplug: board %q: %w", e.Board, err)
 	}
 
-	var urls []string
-	seen := make(map[string]bool)
-	for page := 1; page <= careerplugMaxPages; page++ {
-		listURL := fmt.Sprintf("https://%s/jobs", host)
-		if page > 1 {
-			listURL = fmt.Sprintf("https://%s/jobs?page=%d", host, page)
-		}
-		root, err := s.http.GetHTML(ctx, listURL)
-		if err != nil {
-			if page == 1 {
-				return nil, fmt.Errorf("careerplug: listing %s: %w", e.Board, err)
+	// Page through the listing until a page adds no new links (an empty page, or a board that
+	// clamps ?page=N past its last page — de-dup turns the repeat into zero new).
+	urls, err := crawlPagedLinks(ctx, s.http, careerplugMaxPages,
+		func(page int) string {
+			if page > 1 {
+				return fmt.Sprintf("https://%s/jobs?page=%d", host, page)
 			}
-			break // a later page failing ends enumeration with the jobs gathered so far
-		}
-		newLinks := 0
-		for _, link := range careerplugJobLinks(base, root) {
-			if !seen[link] {
-				seen[link] = true
-				urls = append(urls, link)
-				newLinks++
-			}
-		}
-		if newLinks == 0 { // empty page, or a board clamping ?page=N past its last page
-			break
-		}
+			return fmt.Sprintf("https://%s/jobs", host)
+		},
+		func(root *html.Node) []string { return careerplugJobLinks(base, root) })
+	if err != nil {
+		return nil, fmt.Errorf("careerplug: listing %s: %w", e.Board, err)
 	}
 
 	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {

--- a/internal/sources/careerspage.go
+++ b/internal/sources/careerspage.go
@@ -42,31 +42,14 @@ func (s careerspage) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, fmt.Errorf("careerspage: board %q: %w", e.Board, err)
 	}
 
-	// Page through the listing, collecting canonical job-detail URLs until a page yields
-	// no new links (the tail/empty page) or the safety cap is hit. A first-page failure is
-	// a board-level error; a later-page failure just stops the walk with what we have.
-	seen := map[string]struct{}{}
-	var locs []string
-	for page := 1; page <= careerspageMaxPages; page++ {
-		listURL := fmt.Sprintf("%s?page=%d", base, page)
-		root, err := s.http.GetHTML(ctx, listURL)
-		if err != nil {
-			if page == 1 {
-				return nil, fmt.Errorf("careerspage: listing %s: %w", e.Board, err)
-			}
-			break
-		}
-		added := 0
-		for _, l := range careerspageJobLinks(base, root) {
-			if _, ok := seen[l]; !ok {
-				seen[l] = struct{}{}
-				locs = append(locs, l)
-				added++
-			}
-		}
-		if added == 0 {
-			break
-		}
+	// Page through the listing until a page yields no new links (the tail/empty page) or the
+	// safety cap is hit. A first-page failure is a board-level error; a later-page failure just
+	// stops the walk with what we have.
+	locs, err := crawlPagedLinks(ctx, s.http, careerspageMaxPages,
+		func(page int) string { return fmt.Sprintf("%s?page=%d", base, page) },
+		func(root *html.Node) []string { return careerspageJobLinks(base, root) })
+	if err != nil {
+		return nil, fmt.Errorf("careerspage: listing %s: %w", e.Board, err)
 	}
 
 	// Each posting's fields come from its own detail fetch, fanned out under a narrow pool

--- a/internal/sources/erecruiter.go
+++ b/internal/sources/erecruiter.go
@@ -221,7 +221,7 @@ var erecruiterBodyExcludeIDs = map[string]bool{"JobTitle": true, "WorkPlace": tr
 // rather than a fixed list of section ids. It falls back to the known section ids for a page
 // without the standard container, and returns "" when neither yields anything.
 func erecruiterBody(root *html.Node) string {
-	if cont := elementByID(root, "offCont"); cont != nil {
+	if cont := firstByID(root, "offCont"); cont != nil {
 		var drop []*html.Node
 		walk(cont, func(n *html.Node) bool {
 			if n.Type == html.ElementNode && erecruiterBodyExcludeIDs[attr(n, "id")] {
@@ -237,7 +237,7 @@ func erecruiterBody(root *html.Node) string {
 	}
 	var body strings.Builder
 	for _, id := range []string{"t1", "Opportunities", "CompanyDescription"} {
-		if n := elementByID(root, id); n != nil {
+		if n := firstByID(root, id); n != nil {
 			body.WriteString(innerHTML(n))
 		}
 	}
@@ -246,7 +246,7 @@ func erecruiterBody(root *html.Node) string {
 
 // erecruiterIDText returns the trimmed text of the element with the given id, or "".
 func erecruiterIDText(root *html.Node, id string) string {
-	if n := elementByID(root, id); n != nil {
+	if n := firstByID(root, id); n != nil {
 		return textContent(n)
 	}
 	return ""

--- a/internal/sources/freshteam.go
+++ b/internal/sources/freshteam.go
@@ -36,30 +36,13 @@ func (f freshteam) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, fmt.Errorf("freshteam: board %q: %w", e.Board, err)
 	}
 
-	var urls []string
-	seen := make(map[string]bool)
-	for page := 1; page <= ftMaxPages; page++ {
-		listURL := fmt.Sprintf("https://%s.freshteam.com/jobs?page=%d", e.Board, page)
-		root, err := f.http.GetHTML(ctx, listURL)
-		if err != nil {
-			if page == 1 {
-				return nil, fmt.Errorf("freshteam: listing %s: %w", e.Board, err)
-			}
-			break // a later page failing ends enumeration with the jobs gathered so far
-		}
-		// Stop on the first page that adds no new links: an empty page, or a board that
-		// serves the same page for any ?page=N (de-dup turns the repeat into zero new).
-		newLinks := 0
-		for _, link := range ftJobLinks(base, root) {
-			if !seen[link] {
-				seen[link] = true
-				urls = append(urls, link)
-				newLinks++
-			}
-		}
-		if newLinks == 0 {
-			break
-		}
+	// Page through the listing until a page adds no new links (an empty page, or a board that
+	// serves the same page for any ?page=N — de-dup turns the repeat into zero new).
+	urls, err := crawlPagedLinks(ctx, f.http, ftMaxPages,
+		func(page int) string { return fmt.Sprintf("https://%s.freshteam.com/jobs?page=%d", e.Board, page) },
+		func(root *html.Node) []string { return ftJobLinks(base, root) })
+	if err != nil {
+		return nil, fmt.Errorf("freshteam: listing %s: %w", e.Board, err)
 	}
 
 	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.

--- a/internal/sources/globalpayments.go
+++ b/internal/sources/globalpayments.go
@@ -36,30 +36,13 @@ func (g globalpayments) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error
 		return nil, fmt.Errorf("globalpayments: board %q: %w", e.Board, err)
 	}
 
-	var urls []string
-	seen := make(map[string]bool)
-	for page := 1; page <= gpMaxPages; page++ {
-		listURL := fmt.Sprintf("https://%s/en/jobs/?page=%d", e.Board, page)
-		root, err := g.http.GetHTML(ctx, listURL)
-		if err != nil {
-			if page == 1 {
-				return nil, fmt.Errorf("globalpayments: listing %s: %w", e.Board, err)
-			}
-			break // a later page failing ends enumeration with the jobs gathered so far
-		}
-		// Stop on the first page that adds no new links: an empty page, or a board that
-		// clamps ?page=N past its last page (de-dup turns the repeat into zero new).
-		newLinks := 0
-		for _, link := range gpJobLinks(base, root) {
-			if !seen[link] {
-				seen[link] = true
-				urls = append(urls, link)
-				newLinks++
-			}
-		}
-		if newLinks == 0 {
-			break
-		}
+	// Page through the listing until a page adds no new links (an empty page, or a board that
+	// clamps ?page=N past its last page — de-dup turns the repeat into zero new).
+	urls, err := crawlPagedLinks(ctx, g.http, gpMaxPages,
+		func(page int) string { return fmt.Sprintf("https://%s/en/jobs/?page=%d", e.Board, page) },
+		func(root *html.Node) []string { return gpJobLinks(base, root) })
+	if err != nil {
+		return nil, fmt.Errorf("globalpayments: listing %s: %w", e.Board, err)
 	}
 
 	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.

--- a/internal/sources/html.go
+++ b/internal/sources/html.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"context"
 	"net/url"
 	"strings"
 
@@ -241,4 +242,37 @@ func metaProperty(root *html.Node, property string) string {
 		return true
 	})
 	return found
+}
+
+// crawlPagedLinks pages a listing from page 1, collecting the deduplicated links each page
+// yields (in first-seen order) until a page adds no new link or maxPages is hit — the shared
+// body of the paginated HTML-listing crawlers, which differ only in their page-URL builder and
+// link extractor. pageURL builds the listing URL for a 1-based page number; links extracts a
+// page's job links. It returns an error ONLY when the FIRST page fails (a board-level failure)
+// — the caller adds its board context; a later page failing ends the walk with the links
+// gathered so far, so a partial crawl survives a mid-listing hiccup.
+func crawlPagedLinks(ctx context.Context, get HTMLGetter, maxPages int, pageURL func(page int) string, links func(*html.Node) []string) ([]string, error) {
+	var out []string
+	seen := make(map[string]bool)
+	for page := 1; page <= maxPages; page++ {
+		root, err := get.GetHTML(ctx, pageURL(page))
+		if err != nil {
+			if page == 1 {
+				return nil, err
+			}
+			break // a later page failing ends enumeration with the links gathered so far
+		}
+		added := 0
+		for _, link := range links(root) {
+			if !seen[link] {
+				seen[link] = true
+				out = append(out, link)
+				added++
+			}
+		}
+		if added == 0 { // empty page, or a board clamping ?page=N past its last page
+			break
+		}
+	}
+	return out, nil
 }

--- a/internal/sources/html.go
+++ b/internal/sources/html.go
@@ -134,6 +134,55 @@ func firstByID(root *html.Node, id string) *html.Node {
 	return found
 }
 
+// firstByTag returns the first element node with the given tag name, or nil.
+func firstByTag(root *html.Node, tag string) *html.Node {
+	var found *html.Node
+	walk(root, func(n *html.Node) bool {
+		if found != nil {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == tag {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// firstByClass returns the first element node carrying the given class, or nil.
+func firstByClass(root *html.Node, class string) *html.Node {
+	var found *html.Node
+	walk(root, func(n *html.Node) bool {
+		if found != nil {
+			return false
+		}
+		if n.Type == html.ElementNode && hasClass(n, class) {
+			found = n
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// titleText returns the trimmed text of the page's first <title> element, or "" when the
+// page has none.
+func titleText(root *html.Node) string {
+	var t string
+	walk(root, func(n *html.Node) bool {
+		if t != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "title" {
+			t = textContent(n)
+			return false
+		}
+		return true
+	})
+	return t
+}
+
 // hasClass reports whether n's space-separated class attribute contains class; an empty
 // class matches any element.
 func hasClass(n *html.Node, class string) bool {

--- a/internal/sources/loxo.go
+++ b/internal/sources/loxo.go
@@ -180,22 +180,6 @@ func loxoCompany(title string, e CompanyEntry) (company, roleTitle string) {
 	return e.Company, title
 }
 
-// titleText returns the document <title> text, or "".
-func titleText(root *html.Node) string {
-	var t string
-	walk(root, func(n *html.Node) bool {
-		if t != "" {
-			return false
-		}
-		if n.Type == html.ElementNode && n.Data == "title" {
-			t = textContent(n)
-			return false
-		}
-		return true
-	})
-	return t
-}
-
 // loxoStripAgencySuffix drops a trailing " | <agency>" from a document title.
 func loxoStripAgencySuffix(title string) string {
 	if i := strings.LastIndex(title, " | "); i >= 0 {

--- a/internal/sources/luxoft.go
+++ b/internal/sources/luxoft.go
@@ -40,36 +40,22 @@ func (l luxoft) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, fmt.Errorf("luxoft: board %q: %w", e.Board, err)
 	}
 
-	var urls []string
-	seen := make(map[string]bool)
-	for page := 1; page <= lxMaxPages; page++ {
-		// page=1 is the default; Luxoft 301-redirects /jobs?page=1 to a broken relative
-		// Location that resolves to a 404, so omit the page param on the first page and add
-		// it only from page 2 on.
-		listURL := fmt.Sprintf("https://%s/jobs?perPage=%d", e.Board, lxPerPage)
-		if page > 1 {
-			listURL += fmt.Sprintf("&page=%d", page)
-		}
-		root, err := l.http.GetHTML(ctx, listURL)
-		if err != nil {
-			if page == 1 {
-				return nil, fmt.Errorf("luxoft: listing %s: %w", e.Board, err)
+	// Page through the listing until a page adds no new links (an empty page, or a board that
+	// clamps ?page=N past its last page — de-dup turns the repeat into zero new).
+	urls, err := crawlPagedLinks(ctx, l.http, lxMaxPages,
+		func(page int) string {
+			// page=1 is the default; Luxoft 301-redirects /jobs?page=1 to a broken relative
+			// Location that resolves to a 404, so omit the page param on the first page and add
+			// it only from page 2 on.
+			listURL := fmt.Sprintf("https://%s/jobs?perPage=%d", e.Board, lxPerPage)
+			if page > 1 {
+				listURL += fmt.Sprintf("&page=%d", page)
 			}
-			break // a later page failing ends enumeration with the jobs gathered so far
-		}
-		// Stop on the first page that adds no new links: an empty page, or a board that
-		// clamps ?page=N past its last page (de-dup turns the repeat into zero new).
-		newLinks := 0
-		for _, link := range lxJobLinks(base, root) {
-			if !seen[link] {
-				seen[link] = true
-				urls = append(urls, link)
-				newLinks++
-			}
-		}
-		if newLinks == 0 {
-			break
-		}
+			return listURL
+		},
+		func(root *html.Node) []string { return lxJobLinks(base, root) })
+	if err != nil {
+		return nil, fmt.Errorf("luxoft: listing %s: %w", e.Board, err)
 	}
 
 	// Each job's posting comes from its own page fetch, fanned out under a bounded pool.

--- a/internal/sources/rapyd.go
+++ b/internal/sources/rapyd.go
@@ -126,35 +126,3 @@ var rapydPositionIDPattern = regexp.MustCompile(`/company/careers/positions/([^/
 func rapydPositionID(u string) string {
 	return firstSubmatch(rapydPositionIDPattern, u)
 }
-
-// firstByTag returns the first element node with the given tag name, or nil.
-func firstByTag(root *html.Node, tag string) *html.Node {
-	var found *html.Node
-	walk(root, func(n *html.Node) bool {
-		if found != nil {
-			return false
-		}
-		if n.Type == html.ElementNode && n.Data == tag {
-			found = n
-			return false
-		}
-		return true
-	})
-	return found
-}
-
-// firstByClass returns the first element node carrying the given class, or nil.
-func firstByClass(root *html.Node, class string) *html.Node {
-	var found *html.Node
-	walk(root, func(n *html.Node) bool {
-		if found != nil {
-			return false
-		}
-		if n.Type == html.ElementNode && hasClass(n, class) {
-			found = n
-			return false
-		}
-		return true
-	})
-	return found
-}

--- a/internal/sources/telegramcareers.go
+++ b/internal/sources/telegramcareers.go
@@ -33,7 +33,7 @@ func (t telegramcareers) Fetch(ctx context.Context, e CompanyEntry) ([]Job, erro
 	if err != nil {
 		return nil, fmt.Errorf("telegramcareers: fetch jobs page: %w", err)
 	}
-	content := elementByID(root, "dev_page_content")
+	content := firstByID(root, "dev_page_content")
 	if content == nil {
 		return nil, fmt.Errorf("telegramcareers: jobs content not found")
 	}
@@ -70,20 +70,4 @@ func (t telegramcareers) Fetch(ctx context.Context, e CompanyEntry) ([]Job, erro
 	}
 	flush()
 	return jobs, nil
-}
-
-// elementByID returns the first element node whose id attribute equals id, or nil.
-func elementByID(root *html.Node, id string) *html.Node {
-	var found *html.Node
-	walk(root, func(n *html.Node) bool {
-		if found != nil {
-			return false
-		}
-		if n.Type == html.ElementNode && attr(n, "id") == id {
-			found = n
-			return false
-		}
-		return true
-	})
-	return found
 }

--- a/internal/sources/zoho.go
+++ b/internal/sources/zoho.go
@@ -43,7 +43,13 @@ func (z zoho) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	if err != nil {
 		return nil, fmt.Errorf("zoho: listing %s: %w", e.Board, err)
 	}
-	raw := elementAttrByID(root, "input", "jobs", "value")
+	// The listing JSON is embedded in a hidden <input id="jobs" value="…">; the HTML parser
+	// decodes the &#34;-escaped JSON in the value attribute back to plain JSON. Ids are unique,
+	// so the id alone locates the input.
+	raw := ""
+	if n := firstByID(root, "jobs"); n != nil {
+		raw = attr(n, "value")
+	}
 	if raw == "" {
 		return nil, fmt.Errorf("zoho: %s: no #jobs data", e.Board)
 	}
@@ -187,24 +193,4 @@ func zohoUnescapeOnce(s string) string {
 		}
 	}
 	return b.String()
-}
-
-// elementAttrByID returns the named attribute of the first element with the given tag and id,
-// or "". The HTML parser decodes character references in the attribute value, so a value that
-// embeds an &#34;-escaped JSON array comes back as plain JSON.
-func elementAttrByID(root *html.Node, tag, id, name string) string {
-	var out string
-	found := false
-	walk(root, func(n *html.Node) bool {
-		if found {
-			return false
-		}
-		if n.Type == html.ElementNode && n.Data == tag && attr(n, "id") == id {
-			out = attr(n, name)
-			found = true
-			return false
-		}
-		return true
-	})
-	return out
 }

--- a/internal/sources/zoho_test.go
+++ b/internal/sources/zoho_test.go
@@ -28,13 +28,14 @@ func TestZohoUnescape(t *testing.T) {
 	}
 }
 
-func TestZohoElementAttrByID(t *testing.T) {
+func TestZohoJobsInputExtraction(t *testing.T) {
+	// The listing JSON is read off the hidden <input id="jobs"> via the shared firstByID+attr.
 	root := parseHTML(t, `<html><body><input id="other" value="x"><input id="jobs" value='[{"id":"1"}]'></body></html>`)
-	if got := elementAttrByID(root, "input", "jobs", "value"); got != `[{"id":"1"}]` {
-		t.Errorf("elementAttrByID = %q", got)
+	if n := firstByID(root, "jobs"); n == nil || attr(n, "value") != `[{"id":"1"}]` {
+		t.Error("firstByID(jobs) did not yield the #jobs array value")
 	}
-	if got := elementAttrByID(root, "input", "missing", "value"); got != "" {
-		t.Errorf("missing id = %q, want empty", got)
+	if n := firstByID(root, "missing"); n != nil {
+		t.Error("firstByID(missing) = non-nil, want nil")
 	}
 }
 


### PR DESCRIPTION
Third increment of the adapter-layer audit (follows #812 and #817, both on main). HTML-helper consolidation.

## Commits
1. **Walk-helper consolidation** — move `firstByTag`/`firstByClass` (rapyd.go) and `titleText` (loxo.go) into `html.go`; delete byte-identical `elementByID` (telegramcareers.go) and single-use `elementAttrByID` (zoho.go), redirecting call sites onto the shared `firstByID`/`attr`; avito's re-inlined `<title>` walk now calls `titleText`.
2. **`crawlPagedLinks`** — careerspage/globalpayments/luxoft/freshteam/careerplug ran a byte-identical pagination loop (page from 1 → collect deduped links → stop on first zero-new page; page-1 error fails the board, later-page error keeps what's gathered). Extracted into `crawlPagedLinks(ctx, get, maxPages, pageURL, links)` in html.go.

Behaviour-preserving; `go build/vet/test ./...` green, `gofmt` clean. Verified live: careerplug 80 jobs, freshteam 1063 jobs end-to-end. The one test exercising a deleted helper was rewritten onto the shared `firstByID`+`attr`.

(Supersedes #815, auto-closed when its base branch was deleted on #817 merge.)