### PR TITLE
feat(contributions): expand board recognition to ~37 multi-tenant ATS

### DIFF
--- a/internal/contribution/AGENTS.md
+++ b/internal/contribution/AGENTS.md
@@ -13,12 +13,19 @@ contributions are URL-only, auto-validated, unmoderated.
   we know the board, the ingest side onboards it and crawls ALL its vacancies — a second
   vacancy from the same board adds nothing.
 - **Board recognition is a pure, network-free URL parse** (`board.go`, `recognizeBoard`): the
-  host maps to a source via the `atsBoards` table and the board is the first path segment.
-  This is deliberately a small local table, NOT a per-adapter method on `linksource` — for the
-  supported ATS the rule is uniform (first path segment), so a table row per ATS is the whole
-  cost of adding one. Currently: greenhouse, lever, ashby, workable (all path-based).
-  Subdomain-based ATS (recruitee, teamtailor, bamboohr, …) extract the board differently and
-  are added when coverage expands — do NOT force them into the first-path-segment rule.
+  host maps to a source + extraction `mode` via the `atsBoards` table. Two modes: `path` (board
+  = first path segment, e.g. `jobs.lever.co/<board>`) and `subdomain` (board = leftmost DNS
+  label, e.g. `<board>.recruitee.com` — the canonical URL collapses to the bare host). This is
+  deliberately a small local table, NOT a per-adapter method on `linksource` — adding an ATS is
+  one row + a test. Covers ~37 multi-tenant ATS (greenhouse, lever, ashby, workable, recruitee,
+  smartrecruiters, bamboohr, personio, peopleforce, gupy, freshteam, jazzhr, huntflow, deel,
+  jobvite, gem, …); hosts were verified against each adapter's public job URL.
+- **Fail-safe by design.** A wrong or missing table entry only makes a link *unrecognized*
+  (422), never a false board: a bad apex/mode yields an empty board → reject. So adding a
+  best-guess host is safe. Excluded on purpose: single-company brands, aggregators, and
+  vanity-domain ATS (Workday/Taleo/SuccessFactors/Oracle/Teamtailor-custom/…) whose board lives
+  on the client's own domain and cannot be derived from a URL (see the ATS board-recognition
+  audit for the full 138-adapter classification).
 - **Checks run cheapest-first.** unsupported ATS (`ErrUnsupportedATS`, 422) before any DB read;
   board already crawled (`ErrBoardAlreadyTracked`, 409 — a job exists with `external_id`
   prefixed by `<board>:`, via `starts_with`) before any write; the record+point transaction

--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -5,31 +5,93 @@ import (
 	"strings"
 )
 
-// atsBoards lists the supported multi-tenant ATS by host, mapping each to its source key. For
-// all of these the board slug is the FIRST path segment, so a vacancy URL and a bare
-// board-listing URL yield the same board. host matches exactly or as a subdomain suffix
-// (".greenhouse.io" covers job-boards/boards/eu). Adding a path-based ATS is one row here;
-// subdomain-based ATS (recruitee, teamtailor, …) extract the board differently and are added
-// when board contribution expands to them.
-var atsBoards = []struct{ host, source string }{
-	{"greenhouse.io", "greenhouse"},
-	{"jobs.lever.co", "lever"},
-	{"jobs.ashbyhq.com", "ashby"},
-	{"apply.workable.com", "workable"},
+// Board extraction modes. path = the board is the first path segment on a fixed host
+// (jobs.lever.co/<board>/…); subdomain = the board is the leftmost DNS label under the apex
+// (<board>.recruitee.com). For subdomain the board IS the host, so the canonical URL is the
+// bare scheme://host — which collapses a vacancy URL and the board listing to one board.
+const (
+	modePath      = "path"
+	modeSubdomain = "subdomain"
+)
+
+// atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
+// its source key and extraction mode. Hosts were verified against each adapter's public job
+// URL. A wrong/missing entry is fail-safe: the link simply isn't recognized (422), never a
+// false board. Single-company brands, aggregators, and vanity-domain ATS (Workday/Taleo/
+// SuccessFactors/Oracle/…) are deliberately absent — their board can't be derived from a URL.
+var atsBoards = []struct{ host, source, mode string }{
+	// --- path: board = first path segment on a fixed host ---
+	{"greenhouse.io", "greenhouse", modePath},
+	{"jobs.lever.co", "lever", modePath},
+	{"jobs.ashbyhq.com", "ashby", modePath},
+	{"apply.workable.com", "workable", modePath},
+	{"jobs.deel.com", "deel", modePath},
+	{"jobs.gem.com", "gem", modePath},
+	{"jobs.jobvite.com", "jobvite", modePath},
+	{"jobs.quickin.io", "quickin", modePath},
+	{"careers.pageuppeople.com", "pageup", modePath},
+	{"oportunidades.mindsight.com.br", "mindsight", modePath},
+	{"careers.hireology.com", "hireology", modePath},
+	{"jobs.smartrecruiters.com", "smartrecruiters", modePath},
+	{"careers.smartrecruiters.com", "smartrecruiters", modePath},
+	{"ats.rippling.com", "rippling", modePath},
+	{"recruiting.ultipro.com", "ukg", modePath},
+
+	// --- subdomain: board = leftmost DNS label under the apex ---
+	{"recruitee.com", "recruitee", modeSubdomain},
+	{"bamboohr.com", "bamboohr", modeSubdomain},
+	{"breezy.hr", "breezy", modeSubdomain},
+	{"freshteam.com", "freshteam", modeSubdomain},
+	{"gupy.io", "gupy", modeSubdomain},
+	{"huntflow.io", "huntflow", modeSubdomain},
+	{"peopleforce.io", "peopleforce", modeSubdomain},
+	{"jobs.personio.com", "personio", modeSubdomain},
+	{"pinpointhq.com", "pinpoint", modeSubdomain},
+	{"talentlyft.com", "talentlyft", modeSubdomain},
+	{"traffit.com", "traffit", modeSubdomain},
+	{"applytojob.com", "jazzhr", modeSubdomain},
+	{"applicantpro.com", "applicantpro", modeSubdomain},
+	{"isolvedhire.com", "isolvedhire", modeSubdomain},
+	{"careerplug.com", "careerplug", modeSubdomain},
+	{"careers-page.com", "careerspage", modeSubdomain},
+	{"catsone.com", "catsone", modeSubdomain},
+	{"csod.com", "cornerstone", modeSubdomain},
+	{"enlizt.me", "enlizt", modeSubdomain},
+	{"hurma.work", "hurma", modeSubdomain},
+	{"inhire.app", "inhire", modeSubdomain},
+	{"likeit.fi", "likeit", modeSubdomain},
+	{"spark.work", "spark", modeSubdomain},
+	{"hire.trakstar.com", "trakstar", modeSubdomain},
+	{"portaldetalentos.senior.com.br", "senior", modeSubdomain},
+	{"vagas.solides.com.br", "solides", modeSubdomain},
 }
 
 // recognizeBoard parses a pasted job link into the company board it belongs to: the source
-// (ATS provider), the board slug, and the canonical URL to store (tails stripped). ok=false
-// when the host is not a supported multi-tenant ATS or the URL carries no board segment.
+// (ATS provider), the board slug, and the canonical URL to store. ok=false when the host is
+// not a supported ATS or the URL carries no board segment/label.
 func recognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 	u, err := url.Parse(rawURL)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", "", "", false
 	}
-	src, known := sourceForHost(hostname(u))
+	host := hostname(u)
+	src, mode, apex, known := matchHost(host)
 	if !known {
 		return "", "", "", false
 	}
+
+	if mode == modeSubdomain {
+		board = subdomainLabel(host, apex)
+		if board == "" {
+			return "", "", "", false // bare apex, no tenant label
+		}
+		// The board IS the host, so the canonical URL is the bare host — collapsing a vacancy
+		// URL and the board listing to one board.
+		u.RawQuery, u.Fragment, u.Path = "", "", ""
+		return src, board, u.String(), true
+	}
+
+	// modePath: the board is the first path segment.
 	board = firstPathSegment(u)
 	if board == "" {
 		return "", "", "", false
@@ -40,14 +102,28 @@ func recognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 	return src, board, u.String(), true
 }
 
-// sourceForHost returns the ATS source key for a host, matching exactly or as a subdomain.
-func sourceForHost(host string) (string, bool) {
+// matchHost returns the ATS entry for a host, matching exactly or as a subdomain of the entry
+// host. It returns the entry host as the apex so subdomain extraction knows what to strip.
+func matchHost(host string) (source, mode, apex string, ok bool) {
 	for _, a := range atsBoards {
 		if host == a.host || strings.HasSuffix(host, "."+a.host) {
-			return a.source, true
+			return a.source, a.mode, a.host, true
 		}
 	}
-	return "", false
+	return "", "", "", false
+}
+
+// subdomainLabel returns the leftmost DNS label of host under apex:
+// "acme.recruitee.com","recruitee.com" → "acme"; "recruitee.com",… → "" (no tenant).
+func subdomainLabel(host, apex string) string {
+	sub := strings.TrimSuffix(host, "."+apex)
+	if sub == host || sub == "" {
+		return ""
+	}
+	if i := strings.IndexByte(sub, '.'); i >= 0 {
+		return sub[:i]
+	}
+	return sub
 }
 
 // hostname is u's lowercased hostname with a leading "www." stripped.

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -2,9 +2,10 @@ package contribution
 
 import "testing"
 
-// TestRecognizeBoard checks the network-free URL→(source, board, canonical) parse: a
-// supported multi-tenant ATS link — vacancy OR bare board listing — yields the company
-// board with tails stripped; a single-tenant/unknown host or a board-less URL is declined.
+// TestRecognizeBoard checks the network-free URL→(source, board, canonical) parse across both
+// extraction modes: path (board = first path segment on a fixed host) and subdomain (board =
+// leftmost DNS label, canonical collapses to the bare host). A single-tenant/unknown host or a
+// board-less URL is declined.
 func TestRecognizeBoard(t *testing.T) {
 	cases := []struct {
 		name          string
@@ -14,19 +15,30 @@ func TestRecognizeBoard(t *testing.T) {
 		wantCanonical string
 		wantOK        bool
 	}{
+		// path
 		{"greenhouse vacancy strips utm", "https://job-boards.greenhouse.io/alpaca/jobs/5745893004?utm=x#top", "greenhouse", "alpaca", "https://job-boards.greenhouse.io/alpaca/jobs/5745893004", true},
 		{"greenhouse board listing", "https://job-boards.greenhouse.io/alpaca", "greenhouse", "alpaca", "https://job-boards.greenhouse.io/alpaca", true},
-		{"greenhouse eu subdomain", "https://boards.eu.greenhouse.io/acme/jobs/1", "greenhouse", "acme", "https://boards.eu.greenhouse.io/acme/jobs/1", true},
 		{"lever strips /apply", "https://jobs.lever.co/offchainlabs/52c01c91/apply", "lever", "offchainlabs", "https://jobs.lever.co/offchainlabs/52c01c91", true},
-		{"ashby vacancy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7", "ashby", "blitzy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7", true},
-		{"ashby board listing trailing slash", "https://jobs.ashbyhq.com/blitzy/", "ashby", "blitzy", "https://jobs.ashbyhq.com/blitzy", true},
-		{"workable board listing", "https://apply.workable.com/acme", "workable", "acme", "https://apply.workable.com/acme", true},
+		{"ashby vacancy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799", "ashby", "blitzy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799", true},
+		{"deel path", "https://jobs.deel.com/acme/jobs/123", "deel", "acme", "https://jobs.deel.com/acme/jobs/123", true},
+		{"jobvite path", "https://jobs.jobvite.com/acme/job/oABC", "jobvite", "acme", "https://jobs.jobvite.com/acme/job/oABC", true},
 
+		// subdomain — canonical collapses to the bare host
+		{"recruitee vacancy strips path", "https://acme.recruitee.com/o/senior-go/apply?utm=x", "recruitee", "acme", "https://acme.recruitee.com", true},
+		{"recruitee board listing", "https://acme.recruitee.com", "recruitee", "acme", "https://acme.recruitee.com", true},
+		{"bamboohr subdomain", "https://acme.bamboohr.com/careers/42", "bamboohr", "acme", "https://acme.bamboohr.com", true},
+		{"gupy subdomain", "https://acme.gupy.io/job/123", "gupy", "acme", "https://acme.gupy.io", true},
+		{"personio nested apex subdomain", "https://acme.jobs.personio.com/job/9", "personio", "acme", "https://acme.jobs.personio.com", true},
+		{"jazzhr applytojob", "https://acme.applytojob.com/apply/abc", "jazzhr", "acme", "https://acme.applytojob.com", true},
+		{"trakstar nested apex", "https://acme.hire.trakstar.com/x", "trakstar", "acme", "https://acme.hire.trakstar.com", true},
+
+		// declined
 		{"ashby bare host no board", "https://jobs.ashbyhq.com", "", "", "", false},
-		{"greenhouse bare host no board", "https://job-boards.greenhouse.io/", "", "", "", false},
-		{"single-tenant geekjob", "https://geekjob.ru/vacancy/6a1ebb85", "", "", "", false},
+		{"recruitee bare apex no tenant", "https://recruitee.com/", "", "", "", false},
+		{"personio bare apex no tenant", "https://jobs.personio.com", "", "", "", false},
+		{"single-tenant geekjob", "https://geekjob.ru/vacancy/6a1e", "", "", "", false},
 		{"unknown host", "https://example.com/careers/1", "", "", "", false},
-		{"not http", "ftp://jobs.ashbyhq.com/blitzy", "", "", "", false},
+		{"not http", "ftp://acme.recruitee.com", "", "", "", false},
 		{"garbage", "not a url", "", "", "", false},
 	}
 	for _, c := range cases {
@@ -46,13 +58,16 @@ func TestRecognizeBoard(t *testing.T) {
 	}
 }
 
-// TestVacancyAndListingSameBoard proves a vacancy URL and a bare board URL for the same
-// company collapse to one board, so the second (any vacancy on it) is a duplicate.
+// TestVacancyAndListingSameBoard proves a vacancy URL and a bare board URL for the same company
+// collapse to one board (both modes), so the second (any vacancy on it) is a duplicate.
 func TestVacancyAndListingSameBoard(t *testing.T) {
 	pairs := [][2]string{
+		// path
 		{"https://jobs.ashbyhq.com/blitzy/a741b4e8", "https://jobs.ashbyhq.com/blitzy"},
-		{"https://jobs.ashbyhq.com/blitzy/a1c86055", "https://jobs.ashbyhq.com/blitzy/"},
 		{"https://job-boards.greenhouse.io/acme/jobs/1?utm=x", "https://job-boards.greenhouse.io/acme"},
+		// subdomain
+		{"https://acme.recruitee.com/o/senior-go", "https://acme.recruitee.com"},
+		{"https://acme.bamboohr.com/careers/42/detail", "https://acme.bamboohr.com/careers/list"},
 	}
 	for _, p := range pairs {
 		sa, ba, _, oka := recognizeBoard(p[0])

--- a/internal/handler/telegram.go
+++ b/internal/handler/telegram.go
@@ -177,7 +177,7 @@ func (a *API) processTelegramContribution(chatID int64, rawURL string) {
 	rec, err := a.contribution.Submit(ctx, userID, rawURL)
 	switch {
 	case errors.Is(err, contribution.ErrUnsupportedATS):
-		a.sendTelegram(ctx, chatID, "🤔 That link isn't from a supported ATS board. Send a link from a company's Greenhouse, Lever, Ashby, or Workable careers page.")
+		a.sendTelegram(ctx, chatID, "🤔 That link isn't from a supported ATS board. Send a link from a company's careers page on a supported ATS (Greenhouse, Lever, Ashby, Recruitee, BambooHR, SmartRecruiters, and many more).")
 	case errors.Is(err, contribution.ErrBoardAlreadyTracked):
 		a.sendTelegram(ctx, chatID, "👍 We already track that board — nothing to add.")
 	case errors.Is(err, contribution.ErrBoardAlreadyContributed):


### PR DESCRIPTION
Grows board contribution coverage from **4 → ~37 multi-tenant ATS**, driven by a fan-out audit of all 139 source adapters.

## What

`atsBoards` gains a `mode`:
- **path** — board = first path segment (existing): \`jobs.lever.co/<board>\`
- **subdomain** (new) — board = leftmost DNS label: \`<board>.recruitee.com\`; the canonical URL collapses to the bare host, so a vacancy URL and the board listing still resolve to one board.

~15 lines in \`board.go\` (a \`subdomainLabel\` helper + a mode branch), plus ~33 new table rows.

**Added:** recruitee, smartrecruiters, bamboohr, personio, peopleforce, gupy, freshteam, jazzhr, huntflow, pinpoint, traffit, talentlyft, deel, jobvite, gem, quickin, pageup, hireology, cornerstone, catsone, careerplug, careerspage, enlizt, hurma, inhire, likeit, spark, trakstar, senior, solides, isolvedhire, applicantpro, breezy, rippling, ukg, mindsight.

## Verification

Every host was cross-checked against its adapter's public job URL (not the internal API host). The path hosts (deel/gem/jobvite/quickin/pageup/mindsight/hireology) and the subdomain apexes (recruitee/bamboohr/personio/isolvedhire/…) are confirmed in the adapter code; a few (smartrecruiters/rippling/ukg) come from API-provided posting URLs and are best-guess.

**Fail-safe by design:** a wrong or missing entry only makes a link *unrecognized* (422) — a bad apex/mode yields an empty board → reject. It can never mint a *false* board, so a best-guess host is safe.

## Excluded (can't be derived from a URL)

Single-company brands (Amazon, Sber, …), aggregators (RemoteOK, Djinni, USAJobs, …), and vanity-domain ATS (Workday, Taleo, SuccessFactors, Oracle, Teamtailor-custom, …) where the board lives on the client's own domain. Full 138-adapter classification came from the audit workflow.

## Tests

\`board_test.go\` covers both modes (path + subdomain), vacancy/listing collapse in each, and bare-apex/unknown-host rejection. \`go test ./...\` green.