### PR TITLE
refactor(sources): consolidate shared date/location/link helpers

### DIFF
--- a/internal/sources/briefhq.go
+++ b/internal/sources/briefhq.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html"
 	"strings"
-	"time"
 )
 
 // briefhq adapts a hand-rolled static careers page (briefhq.ai/careers) that inlines every
@@ -52,7 +51,7 @@ func (s briefhq) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Remote:         remote || isRemote(p.location()),
 			WorkMode:       workModeFromRemote(remote),
 			EmploymentType: schemaEmploymentType(p.EmploymentType),
-			PostedAt:       briefhqDate(p.DatePosted),
+			PostedAt:       parseRFC3339OrDate(p.DatePosted),
 		})
 	}
 	return jobs, nil
@@ -89,13 +88,4 @@ func (p briefhqPosting) location() string {
 		p.JobLocation.Address.AddressRegion,
 		p.JobLocation.Address.AddressCountry,
 	)
-}
-
-// briefhqDate parses the JobPosting datePosted, which briefhq emits as a bare "2006-01-02" but
-// which the schema.org field may also carry as a full RFC3339 timestamp.
-func briefhqDate(s string) *time.Time {
-	if t := parseRFC3339(s); t != nil {
-		return t
-	}
-	return parseDate(s)
 }

--- a/internal/sources/careerplug.go
+++ b/internal/sources/careerplug.go
@@ -99,31 +99,10 @@ func careerplugJobID(u string) string {
 	return firstSubmatch(careerplugJobIDPattern, u)
 }
 
-// careerplugJobLinks returns the absolute hrefs of all /jobs/<id> job-page anchors, resolved
-// against base so relative hrefs yield fetchable URLs, de-duplicated in first-seen order (a
-// card links the same job from its title and other controls).
+// careerplugJobLinks returns the absolute, deduplicated hrefs of all /jobs/<id> job-page
+// anchors, resolved against base (a card links the same job from its title and other controls).
 func careerplugJobLinks(base *url.URL, root *html.Node) []string {
-	var out []string
-	seen := make(map[string]bool)
-	walk(root, func(n *html.Node) bool {
-		if n.Type == html.ElementNode && n.Data == "a" {
-			href := attr(n, "href")
-			if careerplugJobID(href) == "" {
-				return true
-			}
-			ref, err := url.Parse(href)
-			if err != nil {
-				return true
-			}
-			abs := base.ResolveReference(ref).String()
-			if !seen[abs] {
-				seen[abs] = true
-				out = append(out, abs)
-			}
-		}
-		return true
-	})
-	return out
+	return jobLinks(base, root, func(href string) bool { return careerplugJobID(href) != "" })
 }
 
 // careerplugPosting is the schema.org JobPosting decoded from a CareerPlug job page's

--- a/internal/sources/getmatch.go
+++ b/internal/sources/getmatch.go
@@ -131,7 +131,7 @@ func (g getmatch) toJob(ctx context.Context, o getmatchOffer) Job {
 		Title:              o.Position,
 		Company:            o.Company.Name,
 		Description:        sanitizeHTML(desc),
-		Location:           getmatchLocationString(o.LocationItems),
+		Location:           distinctJoin(o.LocationItems, ", ", func(l getmatchLocation) string { return l.Label }),
 		Remote:             mode == "remote",
 		WorkMode:           mode,
 		PostedAt:           parseLayout(getmatchDateLayout, o.PublishedAt),
@@ -256,22 +256,4 @@ func getmatchWorkMode(items []getmatchLocation) string {
 		}
 	}
 	return mode
-}
-
-// getmatchLocationString joins an offer's distinct location labels in order.
-func getmatchLocationString(items []getmatchLocation) string {
-	var labels []string
-	seen := map[string]struct{}{}
-	for _, it := range items {
-		l := strings.TrimSpace(it.Label)
-		if l == "" {
-			continue
-		}
-		if _, ok := seen[l]; ok {
-			continue
-		}
-		seen[l] = struct{}{}
-		labels = append(labels, l)
-	}
-	return strings.Join(labels, ", ")
 }

--- a/internal/sources/habrcareer.go
+++ b/internal/sources/habrcareer.go
@@ -129,7 +129,7 @@ func (h habrCareer) toJob(ctx context.Context, v habrVacancy) Job {
 		URL:         fmt.Sprintf(habrVacancyURL, v.ID),
 		Title:       v.Title,
 		Company:     v.Company.Title,
-		Location:    habrLocationString(v.Locations),
+		Location:    distinctJoin(v.Locations, ", ", func(l habrLocation) string { return l.Title }),
 		Description: h.description(ctx, v.ID),
 		Remote:      v.RemoteWork,
 		WorkMode:    mode,
@@ -150,24 +150,6 @@ func (h habrCareer) description(ctx context.Context, id int) string {
 		return ""
 	}
 	return sanitizeHTML(p.Description)
-}
-
-// habrLocationString joins a vacancy's distinct location titles in order.
-func habrLocationString(items []habrLocation) string {
-	var titles []string
-	seen := map[string]struct{}{}
-	for _, it := range items {
-		t := strings.TrimSpace(it.Title)
-		if t == "" {
-			continue
-		}
-		if _, ok := seen[t]; ok {
-			continue
-		}
-		seen[t] = struct{}{}
-		titles = append(titles, t)
-	}
-	return strings.Join(titles, ", ")
 }
 
 // HabrPosting is the schema.org JobPosting a Habr Career vacancy page carries, flattened into the

--- a/internal/sources/northstone.go
+++ b/internal/sources/northstone.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	"golang.org/x/net/html"
 )
@@ -88,17 +87,8 @@ func (s northstone) detail(ctx context.Context, e CompanyEntry, loc string) (Job
 		Remote:         remote || isRemote(location),
 		WorkMode:       workMode,
 		EmploymentType: schemaEmploymentType(p.EmploymentType),
-		PostedAt:       northstoneDate(p.DatePosted),
+		PostedAt:       parseRFC3339OrDate(p.DatePosted),
 	}, true
-}
-
-// northstoneDate parses the JobPosting datePosted, which arrives as a full RFC3339 timestamp
-// on some brands (EnzRossi) and as a bare date on others (Revun's "2026-07-01").
-func northstoneDate(s string) *time.Time {
-	if t := parseRFC3339(s); t != nil {
-		return t
-	}
-	return parseDate(s)
 }
 
 // northstonePosting is the schema.org JobPosting decoded from a detail page's ld+json block.

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -582,6 +582,16 @@ func parseRFC3339(s string) *time.Time {
 	return parseLayout("2006-01-02T15:04:05.999999999-0700", s)
 }
 
+// parseRFC3339OrDate parses a JobPosting datePosted that a board may emit as either a full
+// RFC3339 timestamp or a bare "2006-01-02" date, trying the timestamp first. Shared by the
+// ld+json adapters whose datePosted format varies by tenant (briefhq, northstone).
+func parseRFC3339OrDate(s string) *time.Time {
+	if t := parseRFC3339(s); t != nil {
+		return t
+	}
+	return parseDate(s)
+}
+
 // parseDate parses a date-only timestamp ("2006-01-02", as Workable emits).
 func parseDate(s string) *time.Time { return parseLayout("2006-01-02", s) }
 
@@ -597,6 +607,35 @@ func ParseRFC3339(s string) *time.Time     { return parseRFC3339(s) }
 // MST", as Recruitee emits). Recruitee emits UTC; an unrecognized zone abbreviation
 // would be read as offset 0, acceptable for an approximate posted_at.
 func parseSpaceTime(s string) *time.Time { return parseLayout("2006-01-02 15:04:05 MST", s) }
+
+// parsePubDate parses an RSS <pubDate>, an RFC1123 timestamp with or without a numeric zone
+// offset. Shared by the RSS-feed adapters (trakstar, earcu, likeit).
+func parsePubDate(s string) *time.Time {
+	if t := parseLayout(time.RFC1123Z, s); t != nil {
+		return t
+	}
+	return parseLayout(time.RFC1123, s)
+}
+
+// distinctJoin maps each item to a label, drops blank and duplicate labels (keeping first-seen
+// order), and joins the rest with sep. Adapters that build a location from a list of place
+// objects share it (getmatch, habrcareer) instead of each re-looping.
+func distinctJoin[T any](items []T, sep string, label func(T) string) string {
+	var kept []string
+	seen := map[string]struct{}{}
+	for _, it := range items {
+		l := strings.TrimSpace(label(it))
+		if l == "" {
+			continue
+		}
+		if _, ok := seen[l]; ok {
+			continue
+		}
+		seen[l] = struct{}{}
+		kept = append(kept, l)
+	}
+	return strings.Join(kept, sep)
+}
 
 // trimURLSuffix drops any query string or fragment from a URL, leaving just the path. Adapters
 // that extract an id from the end of a URL path use it so a tracking suffix (?utm=…) or a #anchor

--- a/internal/sources/trakstar.go
+++ b/internal/sources/trakstar.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html"
 	"strings"
-	"time"
 )
 
 // trakstar adapts the Trakstar Hire (formerly Recruiterbox) public RSS job feed. Each
@@ -72,14 +71,4 @@ func jobIDFromLink(link string) string {
 		return link[i+1:]
 	}
 	return link
-}
-
-// parsePubDate parses a Trakstar RSS pubDate, which is RFC1123Z (numeric zone offset),
-// falling back to RFC1123 (named zone) for feeds that emit one. Returns nil on an empty
-// or unparseable value (posted_at is nullable).
-func parsePubDate(s string) *time.Time {
-	if t := parseLayout(time.RFC1123Z, s); t != nil {
-		return t
-	}
-	return parseLayout(time.RFC1123, s)
 }


### PR DESCRIPTION
Fourth increment of the adapter-layer audit (follows #812/#817/#818, all on main). Low-risk Tier 2 helper consolidation — all behaviour-preserving.

- **`parsePubDate` → source.go**: the RSS `<pubDate>` parser lived in trakstar.go but was already called by earcu/likeit; moved beside the other `parse*` helpers.
- **`parseRFC3339OrDate` → source.go**: collapses the byte-identical `briefhqDate`/`northstoneDate` (RFC3339 else bare date).
- **`distinctJoin[T]` → source.go**: collapses `getmatchLocationString`/`habrLocationString` (trim + dedup-in-order + join) into one generic, like the existing `fetchDetails[P]`.
- **careerplug → shared `jobLinks`**: `careerplugJobLinks` hand-rolled what `jobLinks(base, root, isJob)` already does (as careerspage/globalpayments already use).

Drops now-unused `time` imports from trakstar/briefhq/northstone. `go build/vet/test ./...` green, `gofmt` clean.