### PR TITLE
refactor(sources): decode schema.org location via schemaPlace + .Location()

### DIFF
--- a/internal/sources/briefhq.go
+++ b/internal/sources/briefhq.go
@@ -69,23 +69,13 @@ type briefhqPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation struct {
-		Address struct {
-			AddressLocality string `json:"addressLocality"`
-			AddressRegion   string `json:"addressRegion"`
-			AddressCountry  string `json:"addressCountry"`
-		} `json:"address"`
-	} `json:"jobLocation"`
-	Identifier struct {
+	JobLocation schemaPlace `json:"jobLocation"`
+	Identifier  struct {
 		Value string `json:"value"`
 	} `json:"identifier"`
 }
 
 // location builds the free-text location from the jobLocation address.
 func (p briefhqPosting) location() string {
-	return joinNonEmpty(
-		p.JobLocation.Address.AddressLocality,
-		p.JobLocation.Address.AddressRegion,
-		p.JobLocation.Address.AddressCountry,
-	)
+	return p.JobLocation.Address.Location()
 }

--- a/internal/sources/careerplug.go
+++ b/internal/sources/careerplug.go
@@ -114,17 +114,10 @@ type careerplugPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation struct {
-		Address struct {
-			AddressLocality string `json:"addressLocality"`
-			AddressRegion   string `json:"addressRegion"`
-			AddressCountry  string `json:"addressCountry"`
-		} `json:"address"`
-	} `json:"jobLocation"`
+	JobLocation schemaPlace `json:"jobLocation"`
 }
 
 // location builds the display location from the posting's address (city, region, country).
 func (p careerplugPosting) location() string {
-	a := p.JobLocation.Address
-	return joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry)
+	return p.JobLocation.Address.Location()
 }

--- a/internal/sources/enlizt.go
+++ b/internal/sources/enlizt.go
@@ -58,11 +58,7 @@ func (s enlizt) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bo
 		return Job{}, false
 	}
 
-	location := joinNonEmpty(
-		p.JobLocation.Address.AddressLocality,
-		p.JobLocation.Address.AddressRegion,
-		p.JobLocation.Address.AddressCountry,
-	)
+	location := p.JobLocation.Address.Location()
 	mode := ""
 	if strings.EqualFold(p.JobLocationType, "TELECOMMUTE") {
 		mode = "remote" // schema.org's structured remote signal
@@ -95,13 +91,7 @@ type enliztPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation struct {
-		Address struct {
-			AddressLocality string `json:"addressLocality"`
-			AddressRegion   string `json:"addressRegion"`
-			AddressCountry  string `json:"addressCountry"`
-		} `json:"address"`
-	} `json:"jobLocation"`
+	JobLocation schemaPlace `json:"jobLocation"`
 }
 
 // enliztVagaPattern matches a /vagas/<slug> posting path: a leading path boundary, one

--- a/internal/sources/freshteam.go
+++ b/internal/sources/freshteam.go
@@ -68,11 +68,7 @@ func (f freshteam) detail(ctx context.Context, e CompanyEntry, jobURL string) (J
 		return Job{}, false
 	}
 
-	location := joinNonEmpty(
-		p.JobLocation.Address.AddressLocality,
-		p.JobLocation.Address.AddressRegion,
-		p.JobLocation.Address.AddressCountry,
-	)
+	location := p.JobLocation.Address.Location()
 
 	// Freshteam carries an explicit remote flag as a string ("true"/"false"); isRemote
 	// (location) is only a fallback (never the title, which false-positives on "Remote …"
@@ -112,14 +108,8 @@ type ftPosting struct {
 	Description string `json:"description"`
 	DatePosted  string `json:"datePosted"`
 	// Freshteam serializes remote as a JSON string ("true"/"false"), not a bool.
-	Remote      string `json:"remote"`
-	JobLocation struct {
-		Address struct {
-			AddressLocality string `json:"addressLocality"`
-			AddressRegion   string `json:"addressRegion"`
-			AddressCountry  string `json:"addressCountry"`
-		} `json:"address"`
-	} `json:"jobLocation"`
+	Remote      string      `json:"remote"`
+	JobLocation schemaPlace `json:"jobLocation"`
 }
 
 // ftJobLinks returns the absolute hrefs of all anchors linking a /jobs/<id> job page,

--- a/internal/sources/isolvedhire.go
+++ b/internal/sources/isolvedhire.go
@@ -102,11 +102,7 @@ func (s isolvedFamily) detail(ctx context.Context, e CompanyEntry, id string) (J
 		return Job{}, false
 	}
 
-	location := joinNonEmpty(
-		p.JobLocation.Address.AddressLocality,
-		p.JobLocation.Address.AddressRegion,
-		p.JobLocation.Address.AddressCountry,
-	)
+	location := p.JobLocation.Address.Location()
 
 	// datePosted is a space-separated "2006-01-02 15:04:05" with no zone; the date part is
 	// the reliable signal, so posted_at is date-granularity.
@@ -135,11 +131,5 @@ type isolvedPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation struct {
-		Address struct {
-			AddressLocality string `json:"addressLocality"`
-			AddressRegion   string `json:"addressRegion"`
-			AddressCountry  string `json:"addressCountry"`
-		} `json:"address"`
-	} `json:"jobLocation"`
+	JobLocation schemaPlace `json:"jobLocation"`
 }

--- a/internal/sources/jazzhr.go
+++ b/internal/sources/jazzhr.go
@@ -59,8 +59,7 @@ func (s jazzhr) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job,
 		return Job{}, false
 	}
 
-	a := p.JobLocation.Address
-	location := joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry)
+	location := p.JobLocation.Address.Location()
 
 	return Job{
 		ExternalID:  id,
@@ -82,18 +81,10 @@ type jazzhrPosting struct {
 	Title              string      `json:"title"`
 	Description        string      `json:"description"`
 	DatePosted         string      `json:"datePosted"`
-	JobLocation        jazzhrPlace `json:"jobLocation"`
+	JobLocation        schemaPlace `json:"jobLocation"`
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-}
-
-type jazzhrPlace struct {
-	Address struct {
-		AddressLocality string `json:"addressLocality"`
-		AddressRegion   string `json:"addressRegion"`
-		AddressCountry  string `json:"addressCountry"`
-	} `json:"address"`
 }
 
 // jazzhrJobIDPattern captures the JazzHR posting token from an /apply/<token>/ URL (the

--- a/internal/sources/schema.go
+++ b/internal/sources/schema.go
@@ -37,6 +37,13 @@ type schemaAddress struct {
 	AddressCountry  string `json:"addressCountry"`
 }
 
+// Location joins the address parts as "City, Region, Country", skipping blanks. Adapters whose
+// jobLocation carries all three parts use it instead of re-spelling the joinNonEmpty. A board
+// that intentionally omits the region (to avoid it surfacing in the text) must NOT use this.
+func (a schemaAddress) Location() string {
+	return joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry)
+}
+
 // schemaPlace is one schema.org Place (a jobLocation entry): its postal address.
 type schemaPlace struct {
 	Address schemaAddress `json:"address"`

--- a/internal/sources/thehub.go
+++ b/internal/sources/thehub.go
@@ -66,8 +66,7 @@ func (s thehub) detail(ctx context.Context, loc string) (Job, bool) {
 		return Job{}, false
 	}
 
-	a := p.JobLocation.Address
-	location := joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry)
+	location := p.JobLocation.Address.Location()
 
 	return Job{
 		ExternalID:  thehubJobID(loc),
@@ -87,18 +86,10 @@ type thehubPosting struct {
 	Title              string      `json:"title"`
 	Description        string      `json:"description"`
 	DatePosted         string      `json:"datePosted"`
-	JobLocation        thehubPlace `json:"jobLocation"`
+	JobLocation        schemaPlace `json:"jobLocation"`
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-}
-
-type thehubPlace struct {
-	Address struct {
-		AddressLocality string `json:"addressLocality"`
-		AddressRegion   string `json:"addressRegion"`
-		AddressCountry  string `json:"addressCountry"`
-	} `json:"address"`
 }
 
 // thehubJobIDPattern captures the posting id from a /jobs/<id> URL (a 24-hex object id).

--- a/internal/sources/vagas.go
+++ b/internal/sources/vagas.go
@@ -118,8 +118,7 @@ func (v vagas) detail(ctx context.Context, jobURL string) (Job, bool) {
 		return Job{}, false
 	}
 
-	location := joinNonEmpty(p.JobLocation.Address.AddressLocality,
-		p.JobLocation.Address.AddressRegion, p.JobLocation.Address.AddressCountry)
+	location := p.JobLocation.Address.Location()
 	return Job{
 		ExternalID:  id,
 		URL:         jobURL,
@@ -149,11 +148,5 @@ type vagasPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation struct {
-		Address struct {
-			AddressLocality string `json:"addressLocality"`
-			AddressRegion   string `json:"addressRegion"`
-			AddressCountry  string `json:"addressCountry"`
-		} `json:"address"`
-	} `json:"jobLocation"`
+	JobLocation schemaPlace `json:"jobLocation"`
 }

--- a/internal/sources/wpyoast.go
+++ b/internal/sources/wpyoast.go
@@ -65,8 +65,7 @@ func (s wpyoast) detail(ctx context.Context, e CompanyEntry, loc string) (Job, b
 		return Job{}, false
 	}
 
-	a := p.JobLocation.Address
-	location := joinNonEmpty(a.AddressLocality, a.AddressRegion, a.AddressCountry)
+	location := p.JobLocation.Address.Location()
 
 	return Job{
 		ExternalID:  wpyoastJobID(loc),
@@ -83,21 +82,13 @@ func (s wpyoast) detail(ctx context.Context, e CompanyEntry, loc string) (Job, b
 // wpyoastPosting is the schema.org JobPosting decoded from a WP/Yoast job page's
 // application/ld+json block. jobLocation is a single Place (not an array).
 type wpyoastPosting struct {
-	Title              string       `json:"title"`
-	Description        string       `json:"description"`
-	DatePosted         string       `json:"datePosted"`
-	JobLocation        wpyoastPlace `json:"jobLocation"`
+	Title              string      `json:"title"`
+	Description        string      `json:"description"`
+	DatePosted         string      `json:"datePosted"`
+	JobLocation        schemaPlace `json:"jobLocation"`
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-}
-
-type wpyoastPlace struct {
-	Address struct {
-		AddressLocality string `json:"addressLocality"`
-		AddressRegion   string `json:"addressRegion"`
-		AddressCountry  string `json:"addressCountry"`
-	} `json:"address"`
 }
 
 // wpyoastJobIDPattern captures the numeric posting id from a /job/<id>-<slug>/ URL.


### PR DESCRIPTION
Stacked on #821 (base = `refactor/sources-helpers-tier2`). Fifth increment — completes the schema.org decode theme from #812/#817.

## What
- Add `Location()` to `schemaAddress` (`joinNonEmpty(locality, region, country)`).
- Migrate the **9 clean 3-field single-Place** ld+json adapters to decode `jobLocation` as the shared `schemaPlace` and build the location via `Address.Location()`, dropping each private `Address` struct + its `joinNonEmpty` spelling: **careerplug, briefhq, jazzhr, freshteam, enlizt, vagas, thehub, wpyoast, isolvedhire**.

## Deliberately NOT migrated (verified by reading each)
- **talentlyft** — 2-field (locality + country only); `.Location()` would surface the region it intentionally omits (the 2-field trap).
- **wantapply / globalpayments** — `jobLocation` is an array (+ gp has a name fallback).
- **northstone** — `location()` has fallback logic, not a plain 3-field join.

Behaviour-preserving (`.Location()` is exactly the old `joinNonEmpty`); `go build/vet/test ./...` green, `gofmt` clean. Verified live: careerplug location unchanged (`Bloomington, IL, US`).

Merge order: #821 → this.