### PR TITLE
fix(contributions): index-backed board-tracked check (was 37s seq scan)

### DIFF
--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -51,7 +51,7 @@ type RecordInput struct {
 // the contribution and increments the submitter's points atomically, mapping a duplicate
 // board to ErrBoardAlreadyContributed.
 type Repository interface {
-	BoardTracked(ctx context.Context, source, boardPrefix string) (bool, error)
+	BoardTracked(ctx context.Context, source, board string) (bool, error)
 	Record(ctx context.Context, in RecordInput) (Contribution, error)
 	ListByUser(ctx context.Context, userID int64) ([]Contribution, error)
 }
@@ -77,7 +77,7 @@ func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) 
 		return Contribution{}, ErrUnsupportedATS
 	}
 
-	tracked, err := s.repo.BoardTracked(ctx, source, board+":")
+	tracked, err := s.repo.BoardTracked(ctx, source, board)
 	if err != nil {
 		return Contribution{}, err
 	}

--- a/internal/contribution/repository.go
+++ b/internal/contribution/repository.go
@@ -2,6 +2,7 @@ package contribution
 
 import (
 	"context"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -26,9 +27,18 @@ func NewQueriesRepository(q *db.Queries, pool *pgxpool.Pool) *QueriesRepository 
 }
 
 // BoardTracked reports whether the catalogue already crawls this board (any job whose
-// external_id is prefixed by "<board>:").
-func (r *QueriesRepository) BoardTracked(ctx context.Context, source, boardPrefix string) (bool, error) {
-	return r.q.JobsExistForBoard(ctx, db.JobsExistForBoardParams{Source: source, BoardPrefix: boardPrefix})
+// external_id is "<board>:…"). It matches with a LIKE-prefix served by the
+// (source, external_id text_pattern_ops) index; the board's LIKE metacharacters are escaped
+// so a slug with % or _ cannot widen the match.
+func (r *QueriesRepository) BoardTracked(ctx context.Context, source, board string) (bool, error) {
+	return r.q.JobsExistForBoard(ctx, db.JobsExistForBoardParams{Source: source, BoardPattern: likePrefix(board)})
+}
+
+// likePrefix builds a LIKE pattern matching external_ids on board ("<board>:…"), escaping the
+// LIKE metacharacters \ % _ in the (URL-derived) board with the default backslash escape.
+func likePrefix(board string) string {
+	esc := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(board)
+	return esc + ":%"
 }
 
 // Record inserts the contribution and awards the submitter a point in one transaction, so a

--- a/internal/contribution/repository_integration_test.go
+++ b/internal/contribution/repository_integration_test.go
@@ -126,12 +126,16 @@ func TestBoardTracked(t *testing.T) {
 
 	insertJob(t, pool, "greenhouse", "acme:100")
 
-	// Board tracked by prefix; a different board is not.
-	if ok, err := repo.BoardTracked(ctx, "greenhouse", "acme:"); err != nil || !ok {
-		t.Errorf("BoardTracked(acme:) = %v,%v, want true", ok, err)
+	// Board tracked; a different board is not.
+	if ok, err := repo.BoardTracked(ctx, "greenhouse", "acme"); err != nil || !ok {
+		t.Errorf("BoardTracked(acme) = %v,%v, want true", ok, err)
 	}
-	if ok, err := repo.BoardTracked(ctx, "greenhouse", "globex:"); err != nil || ok {
-		t.Errorf("BoardTracked(globex:) = %v,%v, want false", ok, err)
+	if ok, err := repo.BoardTracked(ctx, "greenhouse", "globex"); err != nil || ok {
+		t.Errorf("BoardTracked(globex) = %v,%v, want false", ok, err)
+	}
+	// A LIKE metacharacter in the board must not widen the match: "ac_e" must not match "acme".
+	if ok, err := repo.BoardTracked(ctx, "greenhouse", "ac_e"); err != nil || ok {
+		t.Errorf("BoardTracked(ac_e) = %v,%v, want false — '_' must be escaped, not a wildcard", ok, err)
 	}
 }
 

--- a/internal/db/link_contributions.sql.go
+++ b/internal/db/link_contributions.sql.go
@@ -59,20 +59,21 @@ func (q *Queries) IncrementUserPoints(ctx context.Context, id int64) error {
 
 const jobsExistForBoard = `-- name: JobsExistForBoard :one
 SELECT EXISTS (
-    SELECT 1 FROM jobs WHERE source = $1 AND starts_with(external_id, $2)
+    SELECT 1 FROM jobs WHERE source = $1 AND external_id LIKE $2
 ) AS exists
 `
 
 type JobsExistForBoardParams struct {
-	Source      string `json:"source"`
-	BoardPrefix string `json:"board_prefix"`
+	Source       string `json:"source"`
+	BoardPattern string `json:"board_pattern"`
 }
 
-// Whether the catalogue already crawls this board — any job whose external_id is prefixed by
-// "<board>:" for the multi-tenant sources. Used to reject a board we already track before any
-// write. starts_with is a plain prefix test — no LIKE wildcards to escape.
+// Whether the catalogue already crawls this board — any job whose external_id is "<board>:…".
+// Matched with a LIKE-prefix so the (source, external_id text_pattern_ops) index serves it as
+// a range scan; starts_with()/a default-collation LIKE would seq-scan the whole source (37s
+// over greenhouse's ~300k rows). board_pattern is "<escaped board>:%", built by the repository.
 func (q *Queries) JobsExistForBoard(ctx context.Context, arg JobsExistForBoardParams) (bool, error) {
-	row := q.db.QueryRow(ctx, jobsExistForBoard, arg.Source, arg.BoardPrefix)
+	row := q.db.QueryRow(ctx, jobsExistForBoard, arg.Source, arg.BoardPattern)
 	var exists bool
 	err := row.Scan(&exists)
 	return exists, err

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -452,9 +452,10 @@ type Querier interface {
 	// Slim beta-membership lookup for the RequireModeratorOrBeta middleware — a
 	// primitive bool so the auth package stays free of a db import (same shape as GetUserRole).
 	IsBetaTester(ctx context.Context, id int64) (bool, error)
-	// Whether the catalogue already crawls this board — any job whose external_id is prefixed by
-	// "<board>:" for the multi-tenant sources. Used to reject a board we already track before any
-	// write. starts_with is a plain prefix test — no LIKE wildcards to escape.
+	// Whether the catalogue already crawls this board — any job whose external_id is "<board>:…".
+	// Matched with a LIKE-prefix so the (source, external_id text_pattern_ops) index serves it as
+	// a range scan; starts_with()/a default-collation LIKE would seq-scan the whole source (37s
+	// over greenhouse's ~300k rows). board_pattern is "<escaped board>:%", built by the repository.
 	JobsExistForBoard(ctx context.Context, arg JobsExistForBoardParams) (bool, error)
 	// Manually link (or relink) an email to a chosen application, overriding any
 	// auto-link or suggestion.

--- a/internal/db/queries/link_contributions.sql
+++ b/internal/db/queries/link_contributions.sql
@@ -8,11 +8,12 @@ VALUES (sqlc.arg(submitted_by)::bigint, sqlc.arg(url), sqlc.arg(source), sqlc.ar
 RETURNING *;
 
 -- name: JobsExistForBoard :one
--- Whether the catalogue already crawls this board — any job whose external_id is prefixed by
--- "<board>:" for the multi-tenant sources. Used to reject a board we already track before any
--- write. starts_with is a plain prefix test — no LIKE wildcards to escape.
+-- Whether the catalogue already crawls this board — any job whose external_id is "<board>:…".
+-- Matched with a LIKE-prefix so the (source, external_id text_pattern_ops) index serves it as
+-- a range scan; starts_with()/a default-collation LIKE would seq-scan the whole source (37s
+-- over greenhouse's ~300k rows). board_pattern is "<escaped board>:%", built by the repository.
 SELECT EXISTS (
-    SELECT 1 FROM jobs WHERE source = sqlc.arg(source) AND starts_with(external_id, sqlc.arg(board_prefix))
+    SELECT 1 FROM jobs WHERE source = sqlc.arg(source) AND external_id LIKE sqlc.arg(board_pattern)
 ) AS exists;
 
 -- name: ListContributionsByUser :many

--- a/migrations/0026_jobs_extid_pattern_idx.sql
+++ b/migrations/0026_jobs_extid_pattern_idx.sql
@@ -1,0 +1,10 @@
+-- A prefix-search index for the board-tracked check in link contributions
+-- (internal/contribution). external_id is "<board>:<id>", so "does this board already have
+-- any crawled job" is `external_id LIKE '<board>:%'`. The default-collation
+-- (source, external_id) unique index cannot serve a LIKE-prefix (nor starts_with()), so this
+-- text_pattern_ops index does — turning a whole-source sequential filter (37s over greenhouse's
+-- ~300k rows) into an index range scan.
+--
+-- On a fresh initdb volume this plain CREATE INDEX is fine; on the live prod DB it was applied
+-- manually as CREATE INDEX CONCURRENTLY (the jobs table is large and serving traffic).
+CREATE INDEX jobs_source_extid_pattern_idx ON public.jobs (source, external_id text_pattern_ops);


### PR DESCRIPTION
**Incident:** a Telegram board link got no reply, and the web form was slow.

**Root cause:** the board-tracked check (`JobsExistForBoard`) used `starts_with(external_id, '<board>:')`, which the planner can't turn into an index range scan — it sequentially filters the whole source. `EXPLAIN ANALYZE` on prod for a greenhouse board: **37,585 ms**, 236k rows filtered. On the Telegram path that exceeded the 15s handler context, so both `Submit` and the reply failed with `context deadline exceeded` (bot silent); the web form was just very slow.

**Fix:** `external_id LIKE '<board>:%'` served by a new **`(source, external_id text_pattern_ops)`** index. A plain LIKE-prefix / `starts_with` can't use the default-collation unique index; `text_pattern_ops` can. Board LIKE metacharacters (`% _ \`) are escaped so a slug can't widen the match. **37s → ~0.1ms.**

- migration `0026` adds the index (initdb on fresh volumes; applied to prod manually as `CREATE INDEX CONCURRENTLY`)
- `BoardTracked` now takes the board and builds the escaped pattern
- integration test asserts the escape (`ac_e` must not match `acme`)

⚠️ Deploy after the prod index is built (in progress via CONCURRENTLY).