### PR TITLE
refactor(sources): migrate remaining sitemap adapters onto sitemap.go

### DIFF
--- a/internal/sources/avature.go
+++ b/internal/sources/avature.go
@@ -29,55 +29,32 @@ func NewAvature(c avatureHTTP) Source { return avature{http: c} }
 
 func (avature) Provider() string { return "avature" }
 
-// avatureEntry is one JobDetail URL plus its sitemap last-modified date (used as posted_at).
-type avatureEntry struct {
-	loc     string
-	lastMod string
-}
-
 func (s avature) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var index struct {
-		Sitemaps []struct {
-			Loc string `xml:"loc"`
-		} `xml:"sitemap"`
-	}
 	indexURL := fmt.Sprintf("https://%s/careers/sitemap_index.xml", e.Board)
-	if err := s.http.GetXML(ctx, indexURL, &index); err != nil {
-		return nil, fmt.Errorf("avature: sitemap index %s: %w", e.Board, err)
-	}
-
 	// One sitemap per locale lists the same postings; crawl en_US to avoid duplicates.
-	var listURL string
-	for _, sm := range index.Sitemaps {
-		if strings.Contains(sm.Loc, "/en_US/") {
-			listURL = sm.Loc
-			break
-		}
+	listURL, err := resolveSubSitemap(ctx, s.http, indexURL, "/en_US/")
+	if err != nil {
+		return nil, fmt.Errorf("avature: %s: %w", e.Board, err)
 	}
 	if listURL == "" {
 		return nil, fmt.Errorf("avature: no en_US sitemap advertised for %s", e.Board)
 	}
 
-	var urlset struct {
-		URLs []struct {
-			Loc     string `xml:"loc"`
-			LastMod string `xml:"lastmod"`
-		} `xml:"url"`
-	}
-	if err := s.http.GetXML(ctx, listURL, &urlset); err != nil {
+	urlset, err := getSitemap(ctx, s.http, listURL)
+	if err != nil {
 		return nil, fmt.Errorf("avature: sitemap %s: %w", listURL, err)
 	}
 
 	// The locale sitemap mixes JobDetail pages with utility pages (AgentCreate, …); keep
-	// only the postings.
-	var entries []avatureEntry
+	// only the postings. Each entry's lastmod is carried into detail as posted_at.
+	var entries []sitemapLoc
 	for _, u := range urlset.URLs {
 		if strings.Contains(u.Loc, "/careers/JobDetail/") {
-			entries = append(entries, avatureEntry{loc: u.Loc, lastMod: u.LastMod})
+			entries = append(entries, u)
 		}
 	}
 
-	return fetchDetails(entries, defaultDetailWorkers, func(entry avatureEntry) (Job, bool) {
+	return fetchDetails(entries, defaultDetailWorkers, func(entry sitemapLoc) (Job, bool) {
 		return s.detail(ctx, e, entry)
 	}), nil
 }
@@ -85,13 +62,13 @@ func (s avature) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 // detail fetches one job page and maps it to a Job, returning ok=false when the page fetch
 // fails, carries no parseable id, or renders no description — so the caller skips just that
 // posting.
-func (s avature) detail(ctx context.Context, e CompanyEntry, entry avatureEntry) (Job, bool) {
-	id := avatureJobID(entry.loc)
+func (s avature) detail(ctx context.Context, e CompanyEntry, entry sitemapLoc) (Job, bool) {
+	id := avatureJobID(entry.Loc)
 	if id == "" {
 		return Job{}, false // no native id → would collide on the dedup key; skip it
 	}
 
-	root, err := s.http.GetHTML(ctx, entry.loc)
+	root, err := s.http.GetHTML(ctx, entry.Loc)
 	if err != nil {
 		return Job{}, false
 	}
@@ -105,14 +82,14 @@ func (s avature) detail(ctx context.Context, e CompanyEntry, entry avatureEntry)
 	workMode := avatureWorkMode(avatureFieldValue(root, "Work Model"))
 	return Job{
 		ExternalID:  id,
-		URL:         entry.loc,
+		URL:         entry.Loc,
 		Title:       title,
 		Company:     e.Company,
 		Location:    avatureLabeledValue(root, "Locations"),
 		Description: description,
 		Remote:      workMode == "remote",
 		WorkMode:    workMode,
-		PostedAt:    parseDate(entry.lastMod),
+		PostedAt:    parseDate(entry.LastMod),
 	}, true
 }
 

--- a/internal/sources/avito.go
+++ b/internal/sources/avito.go
@@ -34,16 +34,9 @@ func (avito) Provider() string { return "avito" }
 // avito is single-company, so its config entries carry no board.
 func (avito) boardless() {}
 
-// avitoLoc is one <loc> of either the sitemap index or a sub-sitemap.
-type avitoLoc struct {
-	Loc string `xml:"loc"`
-}
-
 func (a avito) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var index struct {
-		Sitemaps []avitoLoc `xml:"sitemap"`
-	}
-	if err := a.http.GetXML(ctx, avitoSitemapIndexURL, &index); err != nil {
+	index, err := getSitemap(ctx, a.http, avitoSitemapIndexURL)
+	if err != nil {
 		return nil, fmt.Errorf("avito: sitemap index: %w", err)
 	}
 
@@ -53,10 +46,8 @@ func (a avito) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	var urls []string
 	seen := make(map[string]bool)
 	for _, sm := range index.Sitemaps {
-		var sub struct {
-			URLs []avitoLoc `xml:"url"`
-		}
-		if err := a.http.GetXML(ctx, sm.Loc, &sub); err != nil {
+		sub, err := getSitemap(ctx, a.http, sm.Loc)
+		if err != nil {
 			continue
 		}
 		for _, u := range sub.URLs {

--- a/internal/sources/clinch.go
+++ b/internal/sources/clinch.go
@@ -32,19 +32,10 @@ func NewClinch(c XMLGetter) Source { return clinch{http: c} }
 
 func (clinch) Provider() string { return "clinch" }
 
-// clinchSitemapEntry is one <url> of the career-site sitemap: the page URL and its
-// last-modified date (used as posted_at).
-type clinchSitemapEntry struct {
-	Loc     string `xml:"loc"`
-	LastMod string `xml:"lastmod"`
-}
-
 func (c clinch) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []clinchSitemapEntry `xml:"url"`
-	}
 	url := fmt.Sprintf("https://%s/sitemap.xml", e.Board)
-	if err := c.http.GetXML(ctx, url, &sitemap); err != nil {
+	sitemap, err := getSitemap(ctx, c.http, url)
+	if err != nil {
 		return nil, fmt.Errorf("clinch: sitemap %s: %w", e.Board, err)
 	}
 

--- a/internal/sources/gulftalent.go
+++ b/internal/sources/gulftalent.go
@@ -85,16 +85,9 @@ type gulftalentAddress struct {
 	AddressCountry  string `json:"addressCountry"`
 }
 
-// gtLoc is one <loc> in a sitemap or sitemap-index document.
-type gtLoc struct {
-	Loc string `xml:"loc"`
-}
-
 func (g gulftalent) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
-	var index struct {
-		Sitemaps []gtLoc `xml:"sitemap"`
-	}
-	if err := g.http.GetXML(ctx, gulftalentSitemapURL, &index); err != nil {
+	index, err := getSitemap(ctx, g.http, gulftalentSitemapURL)
+	if err != nil {
 		return nil, fmt.Errorf("gulftalent: sitemap index: %w", err)
 	}
 
@@ -103,10 +96,8 @@ func (g gulftalent) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 		if !strings.Contains(s.Loc, gulftalentJobShardMarker) {
 			continue // only the job-posting shards carry JobPostings
 		}
-		var shard struct {
-			URLs []gtLoc `xml:"url"`
-		}
-		if err := g.http.GetXML(ctx, s.Loc, &shard); err != nil {
+		shard, err := getSitemap(ctx, g.http, s.Loc)
+		if err != nil {
 			continue // a single unreadable shard just drops its slice of the catalogue this run
 		}
 		for _, u := range shard.URLs {

--- a/internal/sources/metacareers.go
+++ b/internal/sources/metacareers.go
@@ -38,22 +38,14 @@ func (metacareers) boardless() {}
 // metaSitemapURL is Meta's flat jobsearch sitemap: a <urlset> of job_details page URLs.
 const metaSitemapURL = "https://www.metacareers.com/jobsearch/sitemap.xml"
 
-// metaSitemapEntry is one <url> of the jobsearch sitemap: the job page URL and its
-// last-modified date (used as a posted_at fallback).
-type metaSitemapEntry struct {
-	Loc     string `xml:"loc"`
-	LastMod string `xml:"lastmod"`
-}
-
 func (m metacareers) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []metaSitemapEntry `xml:"url"`
-	}
-	if err := m.http.GetXML(ctx, metaSitemapURL, &sitemap); err != nil {
+	sitemap, err := getSitemap(ctx, m.http, metaSitemapURL)
+	if err != nil {
 		return nil, fmt.Errorf("meta: sitemap: %w", err)
 	}
 
-	return fetchDetails(sitemap.URLs, defaultDetailWorkers, func(entry metaSitemapEntry) (Job, bool) {
+	// The sitemap's lastmod is carried into detail as a posted_at fallback.
+	return fetchDetails(sitemap.URLs, defaultDetailWorkers, func(entry sitemapLoc) (Job, bool) {
 		return m.detail(ctx, e, entry)
 	}), nil
 }
@@ -87,7 +79,7 @@ func metaJobID(loc string) string {
 // detail fetches one job page and maps its ld+json JobPosting to a Job, returning ok=false when
 // the page fetch fails, carries no JobPosting, or has no parseable id (which would collide on the
 // dedup key) — so the caller skips just that posting.
-func (m metacareers) detail(ctx context.Context, e CompanyEntry, entry metaSitemapEntry) (Job, bool) {
+func (m metacareers) detail(ctx context.Context, e CompanyEntry, entry sitemapLoc) (Job, bool) {
 	id := metaJobID(entry.Loc)
 	if id == "" {
 		return Job{}, false

--- a/internal/sources/successfactors.go
+++ b/internal/sources/successfactors.go
@@ -27,32 +27,23 @@ func NewSuccessFactors(c successfactorsHTTP) Source { return successfactors{http
 
 func (successfactors) Provider() string { return "successfactors" }
 
-// sfSitemapEntry is one <url> of the job sitemap: the job page URL and its last-modified
-// date (used as posted_at).
-type sfSitemapEntry struct {
-	Loc     string `xml:"loc"`
-	LastMod string `xml:"lastmod"`
-}
-
 func (s successfactors) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	var sitemap struct {
-		URLs []sfSitemapEntry `xml:"url"`
-	}
 	url := fmt.Sprintf("https://%s/job_sitemap.xml", e.Board)
-	if err := s.http.GetXML(ctx, url, &sitemap); err != nil {
+	sitemap, err := getSitemap(ctx, s.http, url)
+	if err != nil {
 		return nil, fmt.Errorf("successfactors: sitemap %s: %w", e.Board, err)
 	}
 
 	// Each job's title and description come from its own page fetch, fanned out under a
-	// bounded worker pool.
-	return fetchDetails(sitemap.URLs, defaultDetailWorkers, func(entry sfSitemapEntry) (Job, bool) {
+	// bounded worker pool; the sitemap's lastmod is carried as posted_at.
+	return fetchDetails(sitemap.URLs, defaultDetailWorkers, func(entry sitemapLoc) (Job, bool) {
 		return s.detail(ctx, e, entry)
 	}), nil
 }
 
 // detail fetches one job page and maps it to a Job, returning ok=false when the page
 // fetch fails so the caller can skip just that posting.
-func (s successfactors) detail(ctx context.Context, e CompanyEntry, entry sfSitemapEntry) (Job, bool) {
+func (s successfactors) detail(ctx context.Context, e CompanyEntry, entry sitemapLoc) (Job, bool) {
 	id := sfJobID(entry.Loc)
 	if id == "" {
 		return Job{}, false // no native id → would collide on the dedup key; skip it


### PR DESCRIPTION
Sixth increment — finishes the sitemap.go migration deferred from #817 (the LastMod / fan-out crawlers that needed extra care).

## What
- **successfactors / metacareers / clinch**: replace their private `<loc>+<lastmod>` leaf struct with the shared `sitemapLoc`; the `lastmod` work-item that feeds `posted_at` is preserved (same field names).
- **avature**: resolve the `en_US` sub-sitemap via `resolveSubSitemap`, decode the urlset via `getSitemap`, and carry `sitemapLoc` (Loc/LastMod) as the `fetchDetails` work-item (drops the bespoke `avatureEntry`).
- **gulftalent / avito**: decode the sitemap index + sub-sitemap fan-out via `getSitemap`, dropping `gtLoc`/`avitoLoc`.

Behaviour-preserving. `go build/vet/test ./...` green, `gofmt` clean. **Verified live that `posted_at` is intact** (the medium-risk part): clinch 400/400 and successfactors 213/213 jobs carry a lastmod-derived `posted_at`; 0 empty ExternalIDs.

This completes the sitemap theme — only `isolvedhire` (intentionally streams >32 MiB) and `onstrider` (bool predicate + empty-result guard) remain on bespoke decode, by design.