### PR TITLE
feat(sources): emit structured WorkMode where the platform states it

### DIFF
--- a/internal/sources/bamboohr.go
+++ b/internal/sources/bamboohr.go
@@ -73,6 +73,7 @@ func (b bambooHR) detail(ctx context.Context, e CompanyEntry, p bambooHRPosting)
 		Location:    joinNonEmpty(jo.Location.City, jo.Location.State, jo.Location.AddressCountry),
 		Description: sanitizeHTML(jo.Description),
 		Remote:      p.IsRemote,
+		WorkMode:    workModeFromRemote(p.IsRemote),
 		PostedAt:    parseDate(jo.DatePosted),
 	}, true
 }

--- a/internal/sources/breezy.go
+++ b/internal/sources/breezy.go
@@ -82,6 +82,7 @@ func (b breezy) detail(ctx context.Context, e CompanyEntry, p breezyPosting) (Jo
 		// is_remote is the authoritative structured signal; isRemote(location) is only a
 		// fallback (never the title, which false-positives on "Remote …" role names).
 		Remote:   p.Location.IsRemote || isRemote(location),
+		WorkMode: workModeFromRemote(p.Location.IsRemote),
 		PostedAt: parseRFC3339(p.PublishedDate),
 	}, true
 }

--- a/internal/sources/gem.go
+++ b/internal/sources/gem.go
@@ -143,6 +143,7 @@ func (g gem) detail(ctx context.Context, e CompanyEntry, p gemPosting) (Job, boo
 		Location:    joinNonEmpty(city, country),
 		Description: sanitizeHTML(resp.Data.Posting.DescriptionHTML),
 		Remote:      remote || p.Job.LocationType == "REMOTE",
+		WorkMode:    workplaceTypeMode(p.Job.LocationType),
 		PostedAt:    parseEpochSeconds(int64(resp.Data.Posting.FirstPublishedTsSec)),
 	}, true
 }

--- a/internal/sources/paycom.go
+++ b/internal/sources/paycom.go
@@ -131,6 +131,7 @@ func (s paycom) detail(ctx context.Context, board, mantle string, auth map[strin
 		Location:    p.Location,
 		Description: sanitizeHTML(html.UnescapeString(p.Description)),
 		Remote:      strings.EqualFold(p.RemoteType, "remote") || isRemote(p.Location),
+		WorkMode:    workModeFromRemote(strings.EqualFold(p.RemoteType, "remote")),
 		PostedAt:    parseRFC3339(p.StartDate),
 	}, true
 }

--- a/internal/sources/pinpoint.go
+++ b/internal/sources/pinpoint.go
@@ -57,6 +57,7 @@ func (p pinpoint) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 			Location:    firstNonEmpty(joinNonEmpty(d.Location.City, d.Location.Province), d.Location.Name),
 			Description: sanitizeHTML(body),
 			Remote:      d.WorkplaceType == "remote",
+			WorkMode:    workplaceTypeMode(d.WorkplaceType),
 			PostedAt:    nil, // the postings feed carries no publish date
 		})
 	}


### PR DESCRIPTION
Tier 3 provenance improvement — purely additive.

Five adapters decoded a structured work-arrangement field but set only `Remote`, leaving the clean `WorkMode` facet empty (the package norm is to feed both from a structured signal). Add it, sourced only from the structured field (never a heuristic); `Remote` is unchanged:
- **bamboohr** (`isRemote`), **breezy** (`location.is_remote`), **paycom** (`remoteType`) → `workModeFromRemote`
- **gem** (`job.locationType`), **pinpoint** (`workplace_type`) → `workplaceTypeMode`

**domclick** is deliberately left out: its `work_format` is a `[]string` needing a bespoke hybrid/onsite mapping.

`go build/vet/test ./...` green, `gofmt` clean. Additive: no existing behaviour changes (the helpers `workModeFromRemote`/`workplaceTypeMode` are already unit-tested).