### PR TITLE
refactor(sources): share the RSC-flight opener + array decode

### DIFF
--- a/internal/sources/deel.go
+++ b/internal/sources/deel.go
@@ -34,11 +34,7 @@ func NewDeel(c HTMLGetter) Source { return deel{http: c} }
 func (deel) Provider() string { return "deel" }
 
 func (d deel) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	root, err := d.http.GetHTML(ctx, fmt.Sprintf(deelBoardURL, e.Board))
-	if err != nil {
-		return nil, fmt.Errorf("deel: board %q: %w", e.Board, err)
-	}
-	flight, err := decodeNextFlight(root)
+	flight, err := fetchFlight(ctx, d.http, fmt.Sprintf(deelBoardURL, e.Board))
 	if err != nil {
 		return nil, fmt.Errorf("deel: board %q: %w", e.Board, err)
 	}
@@ -123,15 +119,7 @@ type deelPosting struct {
 // array is an error (a markup change must surface loudly rather than silently empty the
 // catalogue); an empty array is valid and yields no postings.
 func extractDeelPostings(flight string) ([]deelPosting, error) {
-	raw, ok := bracketSlice(flight, `"jobPostings":`, '[', ']')
-	if !ok {
-		return nil, fmt.Errorf("jobPostings payload not found")
-	}
-	var postings []deelPosting
-	if err := json.Unmarshal([]byte(raw), &postings); err != nil {
-		return nil, fmt.Errorf("decode jobPostings: %w", err)
-	}
-	return postings, nil
+	return flightArray[deelPosting](flight, `"jobPostings":`)
 }
 
 // extractDeelOrgName reads careerPageSettings.preferredOrganizationName from the flight

--- a/internal/sources/nextflight.go
+++ b/internal/sources/nextflight.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -12,7 +13,33 @@ import (
 // Shared Next.js App Router RSC-flight primitives. A Next.js server-rendered page inlines
 // its data as a sequence of self.__next_f.push([1,"…"]) chunks; concatenating and
 // JS-string-decoding the chunks yields one flight string that embeds the page's JSON.
-// The deel and vouch adapters both read their postings out of this stream.
+// The deel, vouch, and topco adapters read their postings out of this stream.
+
+// fetchFlight fetches a Next.js page and returns its decoded RSC-flight stream — the shared
+// opener for the flight adapters (they wrap the error with their own board context).
+func fetchFlight(ctx context.Context, c HTMLGetter, url string) (string, error) {
+	root, err := c.GetHTML(ctx, url)
+	if err != nil {
+		return "", err
+	}
+	return decodeNextFlight(root)
+}
+
+// flightArray decodes the JSON array that follows key in the flight stream into a []T. A
+// missing array is an error — a markup change must surface loudly rather than silently empty
+// the catalogue; an empty array is valid and yields no elements. key includes the trailing
+// colon (e.g. `"listings":`).
+func flightArray[T any](flight, key string) ([]T, error) {
+	raw, ok := bracketSlice(flight, key, '[', ']')
+	if !ok {
+		return nil, fmt.Errorf("flight array %s not found", key)
+	}
+	var out []T
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("decode flight array %s: %w", key, err)
+	}
+	return out, nil
+}
 
 // nextFlightPush captures the JS-string body of one self.__next_f.push([1,"…"]) flight
 // chunk (the init push, push([0]), carries no [1,"…"] payload and is ignored). The capture

--- a/internal/sources/topco.go
+++ b/internal/sources/topco.go
@@ -54,24 +54,14 @@ type topcoVacancy struct {
 }
 
 func (s topco) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
-	root, err := s.http.GetHTML(ctx, topcoCareersURL)
-	if err != nil {
-		return nil, fmt.Errorf("topco: careers page: %w", err)
-	}
-	flight, err := decodeNextFlight(root)
+	flight, err := fetchFlight(ctx, s.http, topcoCareersURL)
 	if err != nil {
 		return nil, fmt.Errorf("topco: %w", err)
 	}
-	// The postings are the flight's "vacancies":[…] array. A missing array is an error (a
-	// markup change must surface loudly rather than silently empty the catalogue); an empty
-	// array is valid and yields no jobs.
-	raw, ok := bracketSlice(flight, `"vacancies":`, '[', ']')
-	if !ok {
-		return nil, fmt.Errorf("topco: vacancies payload not found")
-	}
-	var vacancies []topcoVacancy
-	if err := json.Unmarshal([]byte(raw), &vacancies); err != nil {
-		return nil, fmt.Errorf("topco: decode vacancies: %w", err)
+	// The postings are the flight's "vacancies":[…] array.
+	vacancies, err := flightArray[topcoVacancy](flight, `"vacancies":`)
+	if err != nil {
+		return nil, fmt.Errorf("topco: %w", err)
 	}
 
 	// Each posting takes one RSC detail fetch for its body; a failed fetch keeps the posting

--- a/internal/sources/vouch.go
+++ b/internal/sources/vouch.go
@@ -2,7 +2,6 @@ package sources
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"strings"
@@ -30,24 +29,14 @@ func (vouch) Provider() string { return "vouch" }
 
 func (s vouch) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	pageURL := fmt.Sprintf("%s/companies/%s", vouchBaseURL, e.Board)
-	root, err := s.http.GetHTML(ctx, pageURL)
+	flight, err := fetchFlight(ctx, s.http, pageURL)
 	if err != nil {
 		return nil, fmt.Errorf("vouch: board %q: %w", e.Board, err)
 	}
-	flight, err := decodeNextFlight(root)
+	// The postings are the flight's "listings":[…] array.
+	listings, err := flightArray[vouchListing](flight, `"listings":`)
 	if err != nil {
 		return nil, fmt.Errorf("vouch: board %q: %w", e.Board, err)
-	}
-	// The postings are the flight's "listings":[…] array. A missing array is an error (a
-	// markup change must surface loudly rather than silently empty the catalogue); an empty
-	// array is valid and yields no jobs.
-	raw, ok := bracketSlice(flight, `"listings":`, '[', ']')
-	if !ok {
-		return nil, fmt.Errorf("vouch: board %q: listings payload not found", e.Board)
-	}
-	var listings []vouchListing
-	if err := json.Unmarshal([]byte(raw), &listings); err != nil {
-		return nil, fmt.Errorf("vouch: board %q: decode listings: %w", e.Board, err)
 	}
 
 	var jobs []Job


### PR DESCRIPTION
Tier 3 dedup for the Next.js RSC-flight adapters.

deel/vouch/topco ran the same `GetHTML → decodeNextFlight` opener and the same `bracketSlice → json.Unmarshal` array extraction. Add two helpers to `nextflight.go`:
- `fetchFlight(ctx, c, url) (string, error)` — the shared opener.
- `flightArray[T](flight, key) ([]T, error)` — decode the JSON array after `key`.

and route the three adapters through them (deel keeps the flight string for its org-name / text-row extraction). The missing-array case stays a hard error (markup drift surfaces loudly); the error strings are not asserted by any test.

`go build/vet/test ./...` green, `gofmt` clean. Behaviour-preserving.