### PR TITLE
fix(cv): key-auth on CV read/render for the tailoring agent CLI

### DIFF
--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -11,9 +11,10 @@ import (
 )
 
 // CV-builder HTTP surface: per-user structured CVs (CRUD + seed) and on-demand PDF
-// rendering. All routes are cookie-only (RequireAuth) and gated to beta testers /
-// moderators (RequireModeratorOrBeta) at registration. Every operation is owner-scoped —
-// a foreign id is a 404, never a leak.
+// rendering. Mutations are cookie-only (RequireAuth); the read + render endpoints also
+// accept an API key (RequireAuthOrKey) so the tailoring agent's CLI can fetch a CV and its
+// PDF. All routes are gated to beta testers / moderators (RequireModeratorOrBeta) at
+// registration. Every operation is owner-scoped — a foreign id is a 404, never a leak.
 
 const maxCVTitleRunes = 200
 

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -50,7 +50,7 @@ func buildTailorApp(h *API, iss *auth.Issuer) *fiber.App {
 	saved := auth.RequireAuth(iss)
 	keyAuth := auth.RequireAuthOrKey(iss, h.queries)
 	gate := auth.RequireModeratorOrBeta(h.queries, h.queries)
-	app.Get("/api/v1/me/cvs/:id", saved, gate, h.GetCV)
+	app.Get("/api/v1/me/cvs/:id", keyAuth, gate, h.GetCV)
 	app.Post("/api/v1/me/cvs/tailor", saved, gate, h.TailorCV)
 	app.Patch("/api/v1/me/cvs/:id", keyAuth, gate, h.PatchCV)
 	app.Get("/api/v1/me/cvs/:id/tailor-context", keyAuth, gate, h.TailorContext)
@@ -196,6 +196,12 @@ func TestPatchCVViaKey(t *testing.T) {
 	rec, _ := h.cvStore.Get(ctx, base.ID, owner)
 	if got := rec.Document.Experience[0].Bullets; len(got) != 2 || got[1] != "Cut latency" {
 		t.Errorf("bullets after patch = %v", got)
+	}
+
+	// The minted key can also READ the CV back (GET /me/cvs/:id is keyAuth) — the agent
+	// needs this to see the current document before patching.
+	if resp := doBearer(t, app, fiber.MethodGet, path, ownerKey, nil); resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("get via key = %d, want 200", resp.StatusCode)
 	}
 
 	// Bad addressing is a 422.

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -451,12 +451,14 @@ func Register(app *fiber.App, cfg Config) {
 	cvGate := auth.RequireModeratorOrBeta(a.queries, a.queries)
 	api.Get("/me/cvs", saved, cvGate, a.ListCVs)
 	api.Post("/me/cvs", saved, cvGate, a.CreateCV)
-	api.Get("/me/cvs/:id", saved, cvGate, a.GetCV)
+	// Read + render accept a key too (keyAuth), so the tailoring agent's CLI can fetch a CV
+	// and its PDF; mutations stay cookie-only (POST/PUT/DELETE — the browser owns authoring).
+	api.Get("/me/cvs/:id", keyAuth, cvGate, a.GetCV)
 	api.Put("/me/cvs/:id", saved, cvGate, a.UpdateCV)
 	api.Delete("/me/cvs/:id", saved, cvGate, a.DeleteCV)
-	api.Get("/me/cvs/:id/pdf", saved, cvGate, a.RenderCVPDF)
+	api.Get("/me/cvs/:id/pdf", keyAuth, cvGate, a.RenderCVPDF)
 	// Tailoring: the browser starts a session (cookie-only bootstrap); the agent's CLI drives
-	// the edit + context reads with its minted API key (keyAuth = cookie or Bearer).
+	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
 	api.Post("/me/cvs/tailor", saved, cvGate, a.TailorCV)
 	api.Patch("/me/cvs/:id", keyAuth, cvGate, a.PatchCV)
 	api.Get("/me/cvs/:id/tailor-context", keyAuth, cvGate, a.TailorContext)


### PR DESCRIPTION
The tailoring agent drives `freehire cv …` with an API key, but GET /me/cvs/:id and /pdf were cookie-only (`saved`) — so `freehire cv get`/`render` returned 401 (verified against prod). Broaden those two reads to `keyAuth` (cookie OR key); mutations stay cookie-only. Owner-scoped + beta-gated unchanged. Integration test asserts a minted key can GET a CV.