### PR TITLE
feat(contributions): Zoho support + company link on already-tracked

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -5,13 +5,18 @@ import (
 	"strings"
 )
 
-// Board extraction modes. path = the board is the first path segment on a fixed host
-// (jobs.lever.co/<board>/…); subdomain = the board is the leftmost DNS label under the apex
-// (<board>.recruitee.com). For subdomain the board IS the host, so the canonical URL is the
-// bare scheme://host — which collapses a vacancy URL and the board listing to one board.
+// Board extraction modes, each matching how the ingest adapter namespaces jobs.external_id:
+//   - path:      board = the first path segment on a fixed host (jobs.lever.co/<board>/…).
+//   - subdomain: board = the leftmost DNS label under a fixed apex (<board>.recruitee.com).
+//   - host:      board = the whole careers host (the tenant identity IS the host, and the TLD
+//     varies by region, e.g. <tenant>.zohorecruit.eu / .com / .in).
+//
+// For subdomain and host the board IS the host, so the canonical URL is the bare scheme://host —
+// collapsing a vacancy URL and the board listing to one board.
 const (
 	modePath      = "path"
 	modeSubdomain = "subdomain"
+	modeHost      = "host"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
@@ -42,7 +47,6 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"bamboohr.com", "bamboohr", modeSubdomain},
 	{"breezy.hr", "breezy", modeSubdomain},
 	{"freshteam.com", "freshteam", modeSubdomain},
-	{"gupy.io", "gupy", modeSubdomain},
 	{"huntflow.io", "huntflow", modeSubdomain},
 	{"peopleforce.io", "peopleforce", modeSubdomain},
 	{"jobs.personio.com", "personio", modeSubdomain},
@@ -64,6 +68,9 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"hire.trakstar.com", "trakstar", modeSubdomain},
 	{"portaldetalentos.senior.com.br", "senior", modeSubdomain},
 	{"vagas.solides.com.br", "solides", modeSubdomain},
+
+	// --- host: board = the whole careers host (regional TLD varies) ---
+	{"zohorecruit", "zohorecruit", modeHost},
 }
 
 // recognizeBoard parses a pasted job link into the company board it belongs to: the source
@@ -80,8 +87,13 @@ func recognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 		return "", "", "", false
 	}
 
-	if mode == modeSubdomain {
-		board = subdomainLabel(host, apex)
+	switch mode {
+	case modeSubdomain, modeHost:
+		if mode == modeSubdomain {
+			board = subdomainLabel(host, apex)
+		} else {
+			board = host // the whole careers host is the tenant identity
+		}
 		if board == "" {
 			return "", "", "", false // bare apex, no tenant label
 		}
@@ -102,10 +114,19 @@ func recognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 	return src, board, u.String(), true
 }
 
-// matchHost returns the ATS entry for a host, matching exactly or as a subdomain of the entry
-// host. It returns the entry host as the apex so subdomain extraction knows what to strip.
+// matchHost returns the ATS entry for a host. path/subdomain entries match the host exactly or
+// as a subdomain of the entry host (the returned apex). A host entry keys on a domain LABEL
+// (e.g. "zohorecruit") and matches any host containing ".<label>." — a tenant subdomain on any
+// regional TLD (<tenant>.zohorecruit.eu/.com/.in); the bare apex ("zohorecruit.com") does not
+// match, so it is never taken as a board.
 func matchHost(host string) (source, mode, apex string, ok bool) {
 	for _, a := range atsBoards {
+		if a.mode == modeHost {
+			if strings.Contains(host, "."+a.host+".") {
+				return a.source, a.mode, a.host, true
+			}
+			continue
+		}
 		if host == a.host || strings.HasSuffix(host, "."+a.host) {
 			return a.source, a.mode, a.host, true
 		}

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -27,8 +27,13 @@ func TestRecognizeBoard(t *testing.T) {
 		{"recruitee vacancy strips path", "https://acme.recruitee.com/o/senior-go/apply?utm=x", "recruitee", "acme", "https://acme.recruitee.com", true},
 		{"recruitee board listing", "https://acme.recruitee.com", "recruitee", "acme", "https://acme.recruitee.com", true},
 		{"bamboohr subdomain", "https://acme.bamboohr.com/careers/42", "bamboohr", "acme", "https://acme.bamboohr.com", true},
-		{"gupy subdomain", "https://acme.gupy.io/job/123", "gupy", "acme", "https://acme.gupy.io", true},
 		{"personio nested apex subdomain", "https://acme.jobs.personio.com/job/9", "personio", "acme", "https://acme.jobs.personio.com", true},
+
+		// host mode — board is the whole careers host, regional TLD varies
+		{"zoho eu vacancy strips encoded path + query", "https://be-exec.zohorecruit.eu/jobs/Careers/73534000009044079/%D0%9F%D1%80%D0%BE?source=CareerSite", "zohorecruit", "be-exec.zohorecruit.eu", "https://be-exec.zohorecruit.eu", true},
+		{"zoho com host", "https://kaptiva.zohorecruit.com/jobs/Careers/568", "zohorecruit", "kaptiva.zohorecruit.com", "https://kaptiva.zohorecruit.com", true},
+		{"zoho in host", "https://incubyte.zohorecruit.in/jobs/Careers/141", "zohorecruit", "incubyte.zohorecruit.in", "https://incubyte.zohorecruit.in", true},
+		{"zoho bare apex not a board", "https://zohorecruit.com/", "", "", "", false},
 		{"jazzhr applytojob", "https://acme.applytojob.com/apply/abc", "jazzhr", "acme", "https://acme.applytojob.com", true},
 		{"trakstar nested apex", "https://acme.hire.trakstar.com/x", "trakstar", "acme", "https://acme.hire.trakstar.com", true},
 

--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -52,6 +52,7 @@ type RecordInput struct {
 // board to ErrBoardAlreadyContributed.
 type Repository interface {
 	BoardTracked(ctx context.Context, source, board string) (bool, error)
+	CompanyForBoard(ctx context.Context, source, board string) (name, slug string, ok bool, err error)
 	Record(ctx context.Context, in RecordInput) (Contribution, error)
 	ListByUser(ctx context.Context, userID int64) ([]Contribution, error)
 }
@@ -96,4 +97,19 @@ func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) 
 // ListMine returns the given user's contributions, newest first.
 func (s *Service) ListMine(ctx context.Context, userID int64) ([]Contribution, error) {
 	return s.repo.ListByUser(ctx, userID)
+}
+
+// TrackedCompany resolves the company already tracked on the board a link points to — for the
+// "we already cover this" reply, so the caller can link to the company page. ok=false when the
+// link is unrecognized or the board has no resolved company.
+func (s *Service) TrackedCompany(ctx context.Context, rawURL string) (name, slug string, ok bool) {
+	source, board, _, recognized := recognizeBoard(rawURL)
+	if !recognized {
+		return "", "", false
+	}
+	name, slug, found, err := s.repo.CompanyForBoard(ctx, source, board)
+	if err != nil || !found {
+		return "", "", false
+	}
+	return name, slug, true
 }

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -14,10 +14,16 @@ type fakeRepo struct {
 	recorded      RecordInput
 	recordCalls   int
 	listByUserRet []Contribution
+	companyName   string
+	companySlug   string
 }
 
 func (f *fakeRepo) BoardTracked(_ context.Context, _, _ string) (bool, error) {
 	return f.boardTracked, nil
+}
+
+func (f *fakeRepo) CompanyForBoard(_ context.Context, _, _ string) (string, string, bool, error) {
+	return f.companyName, f.companySlug, f.companyName != "" || f.companySlug != "", nil
 }
 
 func (f *fakeRepo) Record(_ context.Context, in RecordInput) (Contribution, error) {
@@ -112,6 +118,18 @@ func TestSubmitRecordsBoardFromListingURL(t *testing.T) {
 	}
 	if repo.recorded.Source != "greenhouse" || repo.recorded.Board != "acme" {
 		t.Errorf("recorded = (%q,%q), want (greenhouse, acme)", repo.recorded.Source, repo.recorded.Board)
+	}
+}
+
+func TestTrackedCompanyResolvesFromLink(t *testing.T) {
+	repo := &fakeRepo{companyName: "Acme Corp", companySlug: "acme"}
+	name, slug, ok := newService(repo).TrackedCompany(context.Background(), "https://jobs.ashbyhq.com/blitzy/uuid")
+	if !ok || name != "Acme Corp" || slug != "acme" {
+		t.Errorf("TrackedCompany = (%q,%q,%v), want (Acme Corp, acme, true)", name, slug, ok)
+	}
+	// An unrecognized link resolves nothing.
+	if _, _, ok := newService(repo).TrackedCompany(context.Background(), "https://example.com/x"); ok {
+		t.Error("TrackedCompany(unknown host) ok = true, want false")
 	}
 }
 

--- a/internal/contribution/repository.go
+++ b/internal/contribution/repository.go
@@ -2,8 +2,10 @@ package contribution
 
 import (
 	"context"
+	"errors"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/strelov1/freehire/internal/db"
@@ -32,6 +34,19 @@ func NewQueriesRepository(q *db.Queries, pool *pgxpool.Pool) *QueriesRepository 
 // so a slug with % or _ cannot widen the match.
 func (r *QueriesRepository) BoardTracked(ctx context.Context, source, board string) (bool, error) {
 	return r.q.JobsExistForBoard(ctx, db.JobsExistForBoardParams{Source: source, BoardPattern: likePrefix(board)})
+}
+
+// CompanyForBoard returns the company name + slug already tracked on the board, or ok=false
+// when the board has no job with a resolved company.
+func (r *QueriesRepository) CompanyForBoard(ctx context.Context, source, board string) (name, slug string, ok bool, err error) {
+	row, err := r.q.CompanyForBoard(ctx, db.CompanyForBoardParams{Source: source, BoardPattern: likePrefix(board)})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", "", false, nil
+	}
+	if err != nil {
+		return "", "", false, err
+	}
+	return row.Company, row.CompanySlug, true, nil
 }
 
 // likePrefix builds a LIKE pattern matching external_ids on board ("<board>:…"), escaping the

--- a/internal/db/link_contributions.sql.go
+++ b/internal/db/link_contributions.sql.go
@@ -9,6 +9,32 @@ import (
 	"context"
 )
 
+const companyForBoard = `-- name: CompanyForBoard :one
+SELECT company, company_slug FROM jobs
+WHERE source = $1 AND external_id LIKE $2 AND company_slug <> ''
+LIMIT 1
+`
+
+type CompanyForBoardParams struct {
+	Source       string `json:"source"`
+	BoardPattern string `json:"board_pattern"`
+}
+
+type CompanyForBoardRow struct {
+	Company     string `json:"company"`
+	CompanySlug string `json:"company_slug"`
+}
+
+// The tracked company on a board — for the "already tracked" reply: a job's company name and
+// slug so the bot/UI can link to /companies/<slug>. board_pattern is "<escaped board>:%" (same
+// index-backed LIKE as JobsExistForBoard). Only rows with a resolved company_slug qualify.
+func (q *Queries) CompanyForBoard(ctx context.Context, arg CompanyForBoardParams) (CompanyForBoardRow, error) {
+	row := q.db.QueryRow(ctx, companyForBoard, arg.Source, arg.BoardPattern)
+	var i CompanyForBoardRow
+	err := row.Scan(&i.Company, &i.CompanySlug)
+	return i, err
+}
+
 const createContribution = `-- name: CreateContribution :one
 INSERT INTO link_contributions (submitted_by, url, source, board)
 VALUES ($1::bigint, $2, $3, $4)

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -116,6 +116,10 @@ type Querier interface {
 	// before upserting to log matched-existing vs inserted-reference counts — the
 	// upsert itself is blind to which path (insert or update) it took.
 	CompanyExists(ctx context.Context, slug string) (bool, error)
+	// The tracked company on a board — for the "already tracked" reply: a job's company name and
+	// slug so the bot/UI can link to /companies/<slug>. board_pattern is "<escaped board>:%" (same
+	// index-backed LIKE as JobsExistForBoard). Only rows with a resolved company_slug qualify.
+	CompanyForBoard(ctx context.Context, arg CompanyForBoardParams) (CompanyForBoardRow, error)
 	// The denormalized open-job count for a slug (pgx.ErrNoRows if the company is
 	// absent). cmd/import-yc uses it to guard against homonym collisions: it skips
 	// enriching an existing company whose job_count dwarfs a matched YC entry's team.

--- a/internal/db/queries/link_contributions.sql
+++ b/internal/db/queries/link_contributions.sql
@@ -16,6 +16,14 @@ SELECT EXISTS (
     SELECT 1 FROM jobs WHERE source = sqlc.arg(source) AND external_id LIKE sqlc.arg(board_pattern)
 ) AS exists;
 
+-- name: CompanyForBoard :one
+-- The tracked company on a board — for the "already tracked" reply: a job's company name and
+-- slug so the bot/UI can link to /companies/<slug>. board_pattern is "<escaped board>:%" (same
+-- index-backed LIKE as JobsExistForBoard). Only rows with a resolved company_slug qualify.
+SELECT company, company_slug FROM jobs
+WHERE source = sqlc.arg(source) AND external_id LIKE sqlc.arg(board_pattern) AND company_slug <> ''
+LIMIT 1;
+
 -- name: ListContributionsByUser :many
 -- The "my contributions" list: one user's contributions, newest first.
 SELECT * FROM link_contributions

--- a/internal/handler/contributions.go
+++ b/internal/handler/contributions.go
@@ -69,6 +69,16 @@ func (a *API) CreateContribution(c *fiber.Ctx) error {
 
 	rec, err := a.contribution.Submit(c.Context(), userID, in.URL)
 	if err != nil {
+		// On "already tracked", enrich the 409 with the company we cover so the UI can link to
+		// it (and say the exact role will land on the next crawl).
+		if errors.Is(err, contribution.ErrBoardAlreadyTracked) {
+			body := fiber.Map{"error": "this board is already in the catalogue"}
+			if name, slug, ok := a.contribution.TrackedCompany(c.Context(), in.URL); ok {
+				body["company_name"] = name
+				body["company_slug"] = slug
+			}
+			return c.Status(fiber.StatusConflict).JSON(body)
+		}
 		return contributionError(err)
 	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": toContributionResponse(rec)})

--- a/internal/handler/telegram.go
+++ b/internal/handler/telegram.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/subtle"
 	"errors"
+	"fmt"
+	"html"
 	"log"
 	"regexp"
 	"strings"
@@ -131,6 +133,19 @@ func (a *API) sendTelegram(ctx context.Context, chatID int64, msg string) {
 	}
 }
 
+// alreadyTrackedReply is the "we already cover this" message, linking to the company page when
+// the board resolves to a tracked company; otherwise a plain acknowledgement.
+func (a *API) alreadyTrackedReply(ctx context.Context, rawURL string) string {
+	name, slug, ok := a.contribution.TrackedCompany(ctx, rawURL)
+	if !ok || slug == "" || a.frontendOrigin == "" {
+		return "👍 We already track that board — nothing to add."
+	}
+	return fmt.Sprintf(
+		"👍 <b>%s</b> is already tracked. That exact role might not be in the catalogue yet, but it'll appear on the next crawl.\n%s/companies/%s",
+		html.EscapeString(name), a.frontendOrigin, slug,
+	)
+}
+
 // telegramContribTimeout bounds the background contribution work spawned from a webhook
 // update — the DB lookups plus the outbound reply — so a stuck goroutine cannot leak.
 const telegramContribTimeout = 15 * time.Second
@@ -179,7 +194,7 @@ func (a *API) processTelegramContribution(chatID int64, rawURL string) {
 	case errors.Is(err, contribution.ErrUnsupportedATS):
 		a.sendTelegram(ctx, chatID, "🤔 That link isn't from a supported ATS board. Send a link from a company's careers page on a supported ATS (Greenhouse, Lever, Ashby, Recruitee, BambooHR, SmartRecruiters, and many more).")
 	case errors.Is(err, contribution.ErrBoardAlreadyTracked):
-		a.sendTelegram(ctx, chatID, "👍 We already track that board — nothing to add.")
+		a.sendTelegram(ctx, chatID, a.alreadyTrackedReply(ctx, rawURL))
 	case errors.Is(err, contribution.ErrBoardAlreadyContributed):
 		a.sendTelegram(ctx, chatID, "✅ That board was already contributed — no new point, but thanks!")
 	case err != nil:

--- a/internal/handler/telegram_contribution_integration_test.go
+++ b/internal/handler/telegram_contribution_integration_test.go
@@ -63,10 +63,18 @@ func TestTelegramContribution(t *testing.T) {
 		}
 	}
 
+	// A board we already crawl, with a resolved company — for the "already tracked" reply.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO jobs (source, external_id, url, title, public_slug, company, company_slug)
+		 VALUES ('greenhouse', 'acmeco:1', 'http://example.test', 'Go Dev', 'go-dev-acmeco', 'Acme Co', 'acme-co')`); err != nil {
+		t.Fatalf("seed tracked job: %v", err)
+	}
+
 	queries := db.New(pool)
 	h := &API{
 		pool:                  pool,
 		queries:               queries,
+		frontendOrigin:        "https://freehire.test",
 		telegramLinks:         telegramnotify.NewLinkTokens("test-secret", 10*time.Minute),
 		telegramBot:           telegramnotify.NewClientWithBase("bottoken", stub.URL),
 		telegramWebhookSecret: "hook-secret",
@@ -143,6 +151,14 @@ func TestTelegramContribution(t *testing.T) {
 		post(999999, "https://jobs.ashbyhq.com/newco/uuid")
 		if reply := waitReply(t); !strings.Contains(strings.ToLower(reply), "link your") {
 			t.Errorf("reply = %q, want a link-your-account prompt", reply)
+		}
+	})
+
+	t.Run("an already-tracked board replies with the company link", func(t *testing.T) {
+		post(chatID, "https://job-boards.greenhouse.io/acmeco/jobs/1")
+		reply := waitReply(t)
+		if !strings.Contains(reply, "Acme Co") || !strings.Contains(reply, "https://freehire.test/companies/acme-co") {
+			t.Errorf("reply = %q, want the company name + /companies/acme-co link", reply)
 		}
 	})
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -108,23 +108,30 @@ export interface JobCopy {
  *  `message` is the backend's `{ "error": msg }` text when present, so logs and
  *  any raw-error surface read the real reason rather than a bare status line. */
 export class ApiError extends Error {
-  constructor(public readonly status: number, message: string) {
+  constructor(
+    public readonly status: number,
+    message: string,
+    /** The parsed JSON error body, when present — so callers can read extra fields a
+     *  specific endpoint attaches to a failure (e.g. the already-tracked company). */
+    public readonly body?: Record<string, unknown>,
+  ) {
     super(message);
     this.name = 'ApiError';
   }
 }
 
-/** Extract a human-readable message from a failed response. The backend's
- *  standard error envelope is `{ "error": msg }`; surface that when present,
- *  falling back to the status line for a non-JSON error (e.g. a proxy 502). */
-async function errorMessage(res: Response): Promise<string> {
+/** Parse a failed response into an ApiError. The backend's standard error envelope is
+ *  `{ "error": msg }`; surface that as the message (falling back to the status line for a
+ *  non-JSON error, e.g. a proxy 502) and keep the whole parsed body for callers that need
+ *  extra fields. Reads the body once. */
+async function toApiError(res: Response): Promise<ApiError> {
   try {
     const body = await res.json();
-    if (body && typeof body.error === 'string') return body.error;
+    const msg = body && typeof body.error === 'string' ? body.error : `${res.status} ${res.statusText}`;
+    return new ApiError(res.status, msg, body ?? undefined);
   } catch {
-    // Body was not JSON (proxy/HTML error page) — fall through to the status line.
+    return new ApiError(res.status, `${res.status} ${res.statusText}`);
   }
-  return `${res.status} ${res.statusText}`;
 }
 
 function query(limit: number, offset: number): string {
@@ -209,7 +216,7 @@ export function createApi(
       headers: { ...defaultHeaders, ...init?.headers },
     });
     if (!res.ok) {
-      throw new ApiError(res.status, await errorMessage(res));
+      throw await toApiError(res);
     }
     return res;
   }

--- a/web/src/lib/components/ContributeView.svelte
+++ b/web/src/lib/components/ContributeView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { invalidateAll } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { api, ApiError } from '$lib/api';
   import { AsyncData } from '$lib/asyncData.svelte';
   import { currentUser, isAuthenticated } from '$lib/auth.svelte';
@@ -13,6 +14,9 @@
   let formError = $state<string | null>(null);
   // The just-accepted contribution, shown as confirmation (and whether it opened a new board).
   let accepted = $state.raw<Contribution | null>(null);
+  // Set when the submitted board is already tracked: the company we cover, so we can link to it
+  // instead of a bare "already tracked" error.
+  let tracked = $state.raw<{ name: string; slug: string } | null>(null);
 
   // The reward balance rides on the session user (page.data.user); invalidateAll() after a
   // successful contribution re-resolves it so the count updates without a manual refresh.
@@ -34,6 +38,7 @@
     submitting = true;
     formError = null;
     accepted = null;
+    tracked = null;
     try {
       accepted = await api.submitContribution(url.trim());
       url = '';
@@ -41,10 +46,17 @@
       // reads page.data.user, this also re-runs it, refreshing the list in one shot.
       await invalidateAll();
     } catch (err) {
-      // 422 = unsupported ATS, 409 = already held / already contributed — surface the
-      // backend's specific message so the user knows which it was.
-      formError =
-        err instanceof ApiError ? err.message : 'Could not submit the link. Please try again.';
+      // A 409 for a board we already track carries the company, so link to it instead of a
+      // bare error. Otherwise (422 unsupported, 409 already-contributed) surface the message.
+      if (err instanceof ApiError && err.status === 409 && typeof err.body?.company_slug === 'string') {
+        tracked = {
+          name: typeof err.body.company_name === 'string' ? err.body.company_name : 'This company',
+          slug: err.body.company_slug,
+        };
+      } else {
+        formError =
+          err instanceof ApiError ? err.message : 'Could not submit the link. Please try again.';
+      }
     } finally {
       submitting = false;
     }
@@ -77,6 +89,14 @@
       <div class="rounded-lg border border-border bg-secondary/40 p-4 text-sm" role="status">
         Thanks — <span class="font-medium">{accepted.board}</span> ({accepted.source}) is a new
         board for us. We'll start crawling it. <span class="font-medium">+1 point.</span>
+      </div>
+    {:else if tracked}
+      <div class="rounded-lg border border-border bg-secondary/40 p-4 text-sm" role="status">
+        We already cover <span class="font-medium">{tracked.name}</span>. That exact role might not
+        be in the catalogue yet, but it'll appear on the next crawl.
+        <a href={resolve('/companies/[slug]', { slug: tracked.slug })} class="font-medium underline underline-offset-4">
+          View {tracked.name} →
+        </a>
       </div>
     {/if}
 


### PR DESCRIPTION
Two related changes, driven by testing real links.

## 1. Zoho Recruit (host mode) + gupy fix
`<tenant>.zohorecruit.<tld>` — the whole host is the board, region TLD varies (.eu/.com/.in/…). New extraction mode `host` (board = full careers host), matched by a `.zohorecruit.` infix so any TLD works; the bare apex isn't a board. Matches the ingest adapter (external_id = `<full-host>:<id>`, verified on prod). A reported `be-exec.zohorecruit.eu/...` URL now parses.

**gupy dropped** — it namespaces external_id by a numeric internal id, not the URL subdomain, so the subdomain rule extracted the wrong board (over-reward). Verified on prod; other subdomain entries are correct label-based.

## 2. Company link when a board is already tracked
When a link points to a board we already crawl, resolve the company and point the user at it instead of a bare rejection:
- **Telegram:** `<Company> is already tracked … it'll appear on the next crawl` + a `/companies/<slug>` link.
- **Web form:** the same, with a link instead of the 409 message.

Adds `CompanyForBoard` (index-backed LIKE), `Service.TrackedCompany(url)`, company fields on the 409, and `ApiError.body` so the SPA can read them. Integration-tested on real Postgres (bot reply links to the seeded company).