### PR TITLE
feat(cv): fit-page CTA opens a seeded CV-tailoring agent session

### DIFF
--- a/web/src/lib/assistant/api.ts
+++ b/web/src/lib/assistant/api.ts
@@ -22,15 +22,24 @@ export function assistantWsUrl(): string {
   return `${proto}//${location.host}/assistant-api/ws`;
 }
 
-/** Create the assistant session. The client sends an empty body and knows
- *  nothing about the agent's configuration — the backend decides everything
- *  (harness, persona/system prompt, the `freehire`-only sandbox, scope). */
-export async function createSession(): Promise<string> {
+/** Optional context that turns the new session into a CV-tailoring session: the agent is
+ *  seeded to reframe the given CV toward a vacancy, acting on the freehire API with the
+ *  short-lived key the tailoring bootstrap minted. */
+export interface TailoringSession {
+  cli_token: string;
+  cv_id: number;
+  base_cv_id: number;
+}
+
+/** Create the assistant session. For a normal chat the client sends an empty body and the
+ *  backend decides everything (harness, persona, sandbox, scope). Passing `tailoring` seeds
+ *  a CV-tailoring session instead (persona + FREEHIRE_TOKEN); the backend still owns the rest. */
+export async function createSession(tailoring?: TailoringSession): Promise<string> {
   const res = await fetch(`${BASE}/sessions`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     credentials: 'include',
-    body: '{}',
+    body: JSON.stringify(tailoring ? { tailoring } : {}),
   });
   if (!res.ok) throw new Error(`could not create session (${res.status})`);
   const body = (await res.json()) as { session_id?: string };

--- a/web/src/routes/jobs/[slug]/fit/+page.svelte
+++ b/web/src/routes/jobs/[slug]/fit/+page.svelte
@@ -3,6 +3,7 @@
   import { goto } from '$app/navigation';
   import { ArrowLeft, Sparkles } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
+  import { createSession } from '$lib/assistant/api';
   import { currentUser } from '$lib/auth.svelte';
   import { Button } from '$lib/ui';
   import CompanyLogo from '$lib/components/CompanyLogo.svelte';
@@ -28,8 +29,16 @@
     tailoring = true;
     tailorError = '';
     try {
+      // Bootstrap the tailored CV + cached analysis + a short-lived CLI key, then open an
+      // agent session seeded to reframe it — the agent drives the honest-wall dialogue and
+      // edits the CV through `freehire cv …` with that key.
       const res = await api.tailorCv(data.job.public_slug);
-      await goto(`/my/cvs/${res.tailor_cv_id}`);
+      const sessionId = await createSession({
+        cli_token: res.cli_token,
+        cv_id: res.tailor_cv_id,
+        base_cv_id: res.base_cv_id,
+      });
+      await goto(`/my/assistant?session=${sessionId}`);
     } catch (e) {
       tailorError =
         e instanceof ApiError ? e.message : 'Could not start tailoring. Please try again.';

--- a/web/src/routes/my/assistant/+page.svelte
+++ b/web/src/routes/my/assistant/+page.svelte
@@ -267,9 +267,25 @@
           fromSummary(s, labelCache[s.session_id], fallbackLabel(s.created_at)),
         ),
       );
-      const newest = sessions[0];
-      if (newest) await openSession(newest.id);
-      else await createAndOpen();
+      // ?session=<id> opens a specific session (e.g. a tailoring session just started from
+      // the fit page); ensure it shows in the list even if listSessions is momentarily stale.
+      // Otherwise open the newest, or start a fresh chat when there are none.
+      const requested = new URLSearchParams(location.search).get('session');
+      if (requested) {
+        if (!sessions.some((s) => s.id === requested)) {
+          sessions = upsertSession(sessions, {
+            id: requested,
+            label: 'CV tailoring',
+            createdAt: Math.floor(Date.now() / 1000),
+            live: true,
+          });
+        }
+        await openSession(requested);
+      } else if (sessions[0]) {
+        await openSession(sessions[0].id);
+      } else {
+        await createAndOpen();
+      }
       phase = 'ready';
     } catch (err) {
       error = err instanceof Error ? err.message : 'Could not reach the agent backend.';


### PR DESCRIPTION
Closes the interactive loop. The 'Tailor my CV' CTA now, instead of opening the editor: bootstraps the tailored CV (`api.tailorCv`), starts an agent session seeded with the tailoring context (`createSession({cli_token, cv_id, base_cv_id})` → roy injects FREEHIRE_TOKEN + tailoring persona), and navigates to `/my/assistant?session=<id>`. The assistant page opens the requested session. Agent + CLI already deployed (agent.freehire.dev + CLI v0.7.0). svelte-check clean.

Follow-up: a live CV preview pane beside the chat (the agent can `freehire cv render` meanwhile).