### PR TITLE
feat(companies): backfill real display names for slug-named boards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ cmd/rollup-stats/main.go   recomputes the job_daily_stats rollup
 cmd/rollup-facets/main.go  recomputes the insights_facet_stats snapshot (/open facets)
 cmd/backfill-derive/main.go  re-derives all deterministic dictionary facets
 cmd/reslug/main.go         backfills public_slug/company_slug
+cmd/backfill-company-names/main.go  resolves real display names for slug-named companies
 cmd/import-yc/main.go      enriches companies from yc-oss directory
 sources/                   board files + sources/custom.yml + sources/telegram.yml
 internal/
@@ -60,6 +61,7 @@ internal/
   job/               Job domain aggregate: sealed type built only through job.New
   jobview/           single public wire shape of a job, projected from Job aggregate
   normalize/         slug normalization
+  companyname/       resolves real display names for slug-named companies (see companyname/AGENTS.md)
   jobfit/            AI fit analysis: three-stage LLM prompt-chain (see jobfit/AGENTS.md)
   resumeextract/     structured résumé extraction from stored CV (see resumeextract/AGENTS.md)
   userjob/           per-user job tracking (see userjob/AGENTS.md)
@@ -85,6 +87,7 @@ go run ./cmd/tg-ingest                     # crawl sources/telegram.yml (path vi
 go run ./cmd/tg-extract                    # + LLM_* — drain telegram_posts into the catalogue
 go run ./cmd/liveness                      # URL-probe orphan jobs, close dead ones
 go run ./cmd/backfill-derive               # re-derive dictionary facets; follow with make reindex
+go run ./cmd/backfill-company-names [--dry-run]  # resolve real names for slug-named companies; follow with make reindex
 go run ./cmd/rollup-stats                  # recompute job_daily_stats (run-once, cron ~every 3h)
 go run ./cmd/rollup-facets                 # + MEILI_URL/MEILI_MASTER_KEY — recompute insights_facet_stats (run-once, cron ~daily)
 ```

--- a/cmd/backfill-company-names/main.go
+++ b/cmd/backfill-company-names/main.go
@@ -1,0 +1,165 @@
+// Command backfill-company-names replaces slug-like company names with the
+// company's real display name, resolved from that ATS's own careers-page title
+// or API. Many ATS adapters set jobs.company straight from the board file, so a
+// board whose file entry is a squished slug (e.g. "lbresearch", "gs1ca", "afcb")
+// carries that slug as its display name — which leaks into the UI, the public
+// /companies/<slug> URL, and breaks logo.dev name resolution.
+//
+//	backfill-company-names [--dry-run]   # needs DATABASE_URL
+//
+// It touches only companies whose name is still slug-like AND that have open
+// jobs, resolves a candidate name per board (bounded-concurrent HTTP), and
+// applies it only when it passes the confidence gate (never guessing from the
+// slug). Renames re-key company_slug via normalize.Slug; the derived companies
+// catalogue reconciles through SyncCompaniesFromJobs + DeleteOrphanCompanies.
+// Idempotent — a second run finds nothing slug-like left to fix. Follow with
+// `make reindex` so corrected names reach search.
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"sort"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/strelov1/freehire/internal/companyname"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/normalize"
+	"github.com/strelov1/freehire/internal/sources"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// resolveConcurrency bounds simultaneous careers-page / API fetches so a large
+// ATS completes without hammering a single host.
+const resolveConcurrency = 24
+
+func main() { worker.Main(run) }
+
+func run() int {
+	dryRun := flag.Bool("dry-run", false, "print proposed renames without writing")
+	flag.Parse()
+
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	queries := db.New(pool)
+	client := sources.NewClient()
+	registry := companyname.NewRegistry(client, client)
+
+	rows, err := queries.ListSlugLikeCompaniesForBackfill(ctx)
+	if err != nil {
+		log.Printf("list companies: %v", err)
+		return 1
+	}
+
+	renames, stats := resolveNames(ctx, rows, registry)
+	sort.Slice(renames, func(i, j int) bool { return renames[i].oldSlug < renames[j].oldSlug })
+
+	if *dryRun {
+		for _, r := range renames {
+			log.Printf("dry-run: %s -> %q", r.oldSlug, r.name)
+		}
+		log.Printf("backfill-company-names dry-run: candidates=%d would_resolve=%d no_source=%d rejected=%d",
+			len(rows), len(renames), stats.noSource, stats.rejected)
+		return 0
+	}
+
+	applied := 0
+	for _, r := range renames {
+		n, err := queries.RenameSlugCompany(ctx, db.RenameSlugCompanyParams{
+			Name:    r.name,
+			NewSlug: normalize.Slug(r.name),
+			OldSlug: r.oldSlug,
+		})
+		if err != nil {
+			log.Printf("rename %s: %v", r.oldSlug, err)
+			continue
+		}
+		if n > 0 {
+			applied++
+		}
+	}
+
+	// jobs now carry the resolved names/slugs; re-key the derived catalogue and
+	// sweep the rows orphaned by the re-key so company pages resolve.
+	if err := queries.SyncCompaniesFromJobs(ctx); err != nil {
+		log.Printf("sync companies: %v", err)
+		return 1
+	}
+	orphans, err := queries.DeleteOrphanCompanies(ctx)
+	if err != nil {
+		log.Printf("delete orphan companies: %v", err)
+		return 1
+	}
+
+	log.Printf("backfill-company-names done: candidates=%d resolved=%d applied=%d no_source=%d rejected=%d companies_orphaned=%d",
+		len(rows), len(renames), applied, stats.noSource, stats.rejected, orphans)
+	return 0
+}
+
+type rename struct {
+	oldSlug string
+	name    string
+}
+
+type resolveStats struct {
+	noSource int // no resolver for the source, or board not derivable from the URL
+	rejected int // candidate failed the confidence gate
+}
+
+// resolveNames fetches a display-name candidate per eligible company concurrently
+// and keeps those that pass the gate. It is order-independent; the caller sorts.
+func resolveNames(ctx context.Context, rows []db.ListSlugLikeCompaniesForBackfillRow, registry companyname.Registry) ([]rename, resolveStats) {
+	var (
+		mu      sync.Mutex
+		renames []rename
+		stats   resolveStats
+	)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(resolveConcurrency)
+
+	for _, row := range rows {
+		// Authoritative slug check (the SQL filter is an approximation).
+		if !companyname.SlugLike(row.Name) {
+			continue
+		}
+		resolver, ok := registry[row.Source]
+		if !ok {
+			stats.noSource++
+			continue
+		}
+		board, ok := companyname.BoardFromURL(row.Source, row.URL)
+		if !ok {
+			stats.noSource++
+			continue
+		}
+
+		g.Go(func() error {
+			candidate, err := resolver.Name(ctx, board)
+			if err != nil {
+				log.Printf("resolve %s (%s): %v", row.Slug, row.Source, err)
+				return nil // a single board failing must not abort the run
+			}
+			name, ok := companyname.Accept(row.Name, candidate)
+			mu.Lock()
+			defer mu.Unlock()
+			if !ok {
+				stats.rejected++
+				return nil
+			}
+			renames = append(renames, rename{oldSlug: row.Slug, name: name})
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	return renames, stats
+}

--- a/cmd/backfill-company-names/main_test.go
+++ b/cmd/backfill-company-names/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/companyname"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+// stubResolver returns a canned candidate per board, standing in for a real ATS
+// fetch so resolveNames can be exercised without network.
+type stubResolver struct{ byBoard map[string]string }
+
+func (s stubResolver) Name(_ context.Context, board string) (string, error) {
+	return s.byBoard[board], nil
+}
+
+func TestResolveNames(t *testing.T) {
+	registry := companyname.Registry{
+		"pinpoint": stubResolver{byBoard: map[string]string{
+			"afcb":       "AFC Bournemouth",          // accepted (substring)
+			"kempinski":  "Elena - Meta Recruitment", // rejected (unrelated)
+			"lbresearch": "Centellic",                // rejected (rebrand shares nothing)
+		}},
+	}
+	rows := []db.ListSlugLikeCompaniesForBackfillRow{
+		{Slug: "afcb", Name: "afcb", Source: "pinpoint", URL: "https://afcb.pinpointhq.com/x"},
+		{Slug: "kempinski", Name: "kempinski", Source: "pinpoint", URL: "https://kempinski.pinpointhq.com/x"},
+		{Slug: "lbresearch", Name: "lbresearch", Source: "pinpoint", URL: "https://lbresearch.pinpointhq.com/x"},
+		{Slug: "acme", Name: "acme", Source: "unknown-ats", URL: "https://acme.example.com/x"},  // no resolver
+		{Slug: "bar", Name: "Bar Inc", Source: "pinpoint", URL: "https://bar.pinpointhq.com/x"}, // not slug-like
+	}
+
+	renames, stats := resolveNames(context.Background(), rows, registry)
+
+	if len(renames) != 1 || renames[0].oldSlug != "afcb" || renames[0].name != "AFC Bournemouth" {
+		t.Fatalf("renames = %+v, want [{afcb AFC Bournemouth}]", renames)
+	}
+	if stats.noSource != 1 {
+		t.Errorf("noSource = %d, want 1", stats.noSource)
+	}
+	if stats.rejected != 2 {
+		t.Errorf("rejected = %d, want 2 (kempinski, lbresearch)", stats.rejected)
+	}
+}

--- a/internal/companyname/AGENTS.md
+++ b/internal/companyname/AGENTS.md
@@ -1,0 +1,44 @@
+# companyname
+
+Resolves a real company **display name** for boards whose ingested `jobs.company`
+is still a squished slug (e.g. `lbresearch`, `gs1ca`, `afcb`). Most ATS adapters
+set `Job.Company = e.Company` straight from the board file, so a slug in that file
+becomes the company's name — leaking into the UI label, the public
+`/companies/<slug>` URL, and breaking logo.dev's *name* endpoint (which 404s on a
+squished single token, degrading the logo to a monogram).
+
+Consumed by `cmd/backfill-company-names`.
+
+## Pieces
+
+- **`SlugLike(name)`** — the authoritative "is this still a slug" test (single
+  lowercase token, ≥1 letter; hyphens/digits allowed). The SQL filter is an
+  approximation; this is the gate the worker trusts.
+- **`Resolver` + `Registry`** — one resolver per source, keyed by source name. A
+  source with no resolver is left alone, never guessed. Two shapes:
+  - *title resolvers* (Pinpoint, BambooHR, Lever, Ashby) — fetch the careers page
+    and pull the name out of `<title>` via `ExtractTitleName` (`Jobs at {Name} |
+    …` or a trailing `{Name} Careers`).
+  - *API resolvers* (Greenhouse board `name`) — read a JSON field. iCIMS needs no
+    resolver: its adapter already prefers `HiringOrganization.Name`.
+- **`BoardFromURL(source, url)`** — extracts the ATS board id from a representative
+  job URL (host label for Pinpoint/BambooHR; first path segment for
+  Lever/Ashby/Greenhouse), matching what each resolver fetches against.
+- **`Accept(slug, candidate)`** — the gate applied before writing: decode HTML
+  entities, reject junk (test/recruiter titles), and require a **confidence
+  match** — the squished candidate contains the slug (or vice versa), or a
+  ≥2-letter word-initial acronym lines up. Single-letter acronyms are too weak.
+
+## Design stance
+
+Conservative on purpose: a wrong-but-plausible name reads worse than the monogram
+fallback, so a candidate is applied only when it demonstrably shares text with the
+slug. That means genuine **rebrands** whose new name shares nothing with the slug
+(e.g. `lbresearch` → "Centellic") are deliberately *not* auto-resolved — they need
+a human or a different signal (the domain). Resolvers return `""` (not an error)
+when a source yields no usable name; errors are reserved for transport failures so
+one dead board never aborts a run.
+
+The confidence rules and the accept/reject corpus are the same ones validated by
+the manual Pinpoint pass (PR #825): 104 accepted, 10 correctly rejected across 241
+slug boards.

--- a/internal/companyname/board.go
+++ b/internal/companyname/board.go
@@ -1,0 +1,38 @@
+package companyname
+
+import (
+	"net/url"
+	"strings"
+)
+
+// BoardFromURL extracts the ATS board identifier from a representative job URL
+// for the given source, matching the host/path shape each resolver fetches
+// against. It returns ("", false) for unknown sources or unparseable URLs so the
+// caller skips rather than guesses.
+func BoardFromURL(source, rawURL string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return "", false
+	}
+	switch source {
+	case "pinpoint", "bamboohr":
+		// board is the leftmost host label: {board}.pinpointhq.com
+		if i := strings.IndexByte(u.Host, '.'); i > 0 {
+			return u.Host[:i], true
+		}
+	case "lever", "ashby", "greenhouse":
+		// board is the first path segment: jobs.lever.co/{board}/...
+		if seg := firstPathSegment(u.Path); seg != "" {
+			return seg, true
+		}
+	}
+	return "", false
+}
+
+func firstPathSegment(p string) string {
+	p = strings.TrimPrefix(p, "/")
+	if i := strings.IndexByte(p, '/'); i >= 0 {
+		p = p[:i]
+	}
+	return p
+}

--- a/internal/companyname/board_test.go
+++ b/internal/companyname/board_test.go
@@ -1,0 +1,30 @@
+package companyname
+
+import "testing"
+
+func TestBoardFromURL(t *testing.T) {
+	cases := []struct {
+		source string
+		url    string
+		want   string
+		wantOK bool
+	}{
+		{"pinpoint", "https://lbresearch.pinpointhq.com/en/postings/78ba", "lbresearch", true},
+		{"bamboohr", "https://321theagency.bamboohr.com/careers/42", "321theagency", true},
+		{"lever", "https://jobs.lever.co/1inch/abc-123", "1inch", true},
+		{"ashby", "https://jobs.ashbyhq.com/0x/some-id", "0x", true},
+		{"greenhouse", "https://boards.greenhouse.io/acme/jobs/42", "acme", true},
+		{"greenhouse", "https://job-boards.greenhouse.io/acme/jobs/42", "acme", true},
+		// Unknown source or unparseable URL yields no board.
+		{"unknown-ats", "https://example.com/x", "", false},
+		{"pinpoint", "not a url", "", false},
+		{"lever", "https://jobs.lever.co/", "", false},
+	}
+	for _, c := range cases {
+		got, ok := BoardFromURL(c.source, c.url)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("BoardFromURL(%q, %q) = (%q, %v), want (%q, %v)",
+				c.source, c.url, got, ok, c.want, c.wantOK)
+		}
+	}
+}

--- a/internal/companyname/gate.go
+++ b/internal/companyname/gate.go
@@ -1,0 +1,122 @@
+// Package companyname resolves a real company display name for boards whose
+// ingested company name is still a squished slug (e.g. "lbresearch", "gs1ca",
+// "afcb"). The name is sourced deterministically from each ATS's own careers-page
+// title or API; a slug is never prettified into a name. The acceptance gate here
+// is conservative on purpose: a wrong-but-plausible name reads worse than the
+// monogram fallback, so a candidate is applied only when it demonstrably shares
+// text with the slug.
+package companyname
+
+import (
+	"html"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	// A slug carried into the company field: one token, no whitespace, no
+	// uppercase, at least one letter. Hyphens and digits are allowed
+	// (chetwood-bank, gs1ca).
+	nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
+	words    = regexp.MustCompile(`[A-Za-z0-9]+`)
+	jobsAt   = regexp.MustCompile(`(?i)Jobs at (.+?)\s*\|`)
+
+	// Titles that look resolvable but are placeholders or artifacts, not a
+	// company. The confidence gate catches most of these already; this is a
+	// belt-and-braces reject for cases that could otherwise share text.
+	junkMarkers = []string{"test platform", "meta recruitment", "just a moment", "not found"}
+)
+
+// SlugLike reports whether name is still a squished slug rather than a real
+// display name — a single lowercase token with at least one letter.
+func SlugLike(name string) bool {
+	if name == "" || strings.ContainsFunc(name, unicode.IsSpace) {
+		return false
+	}
+	hasLetter := false
+	for _, r := range name {
+		if unicode.IsUpper(r) {
+			return false
+		}
+		if unicode.IsLetter(r) {
+			hasLetter = true
+		}
+	}
+	return hasLetter
+}
+
+// ExtractTitleName pulls a company name out of a careers-page <title>. It
+// handles the two shapes ATS careers pages use — "Jobs at {Name} | ..." and a
+// trailing "{Name} Careers" — and returns "" when neither matches.
+func ExtractTitleName(title string) string {
+	title = strings.TrimSpace(html.UnescapeString(title))
+	if m := jobsAt.FindStringSubmatch(title); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	if rest, ok := cutSuffixFold(title, "Careers"); ok {
+		return strings.TrimSpace(strings.TrimRight(rest, " |-"))
+	}
+	return ""
+}
+
+// Accept decodes and validates a candidate name against the slug. It returns the
+// cleaned name and true only when the candidate is non-junk and confidently
+// related to the slug (shares a substring or a multi-letter acronym).
+func Accept(slug, candidate string) (string, bool) {
+	candidate = strings.TrimSpace(html.UnescapeString(candidate))
+	// An empty or still-slug-like candidate is no improvement over what's stored,
+	// so reject it: applying it would be a no-op write that also keeps the company
+	// slug-like, so every subsequent run would re-fetch and re-write it.
+	if candidate == "" || SlugLike(candidate) {
+		return "", false
+	}
+	low := strings.ToLower(candidate)
+	for _, m := range junkMarkers {
+		if strings.Contains(low, m) {
+			return "", false
+		}
+	}
+	if !confident(slug, candidate) {
+		return "", false
+	}
+	return candidate, true
+}
+
+// confident reports whether candidate demonstrably refers to the same entity as
+// slug: the squished forms contain one another, or the candidate's word-initial
+// acronym (2+ letters) lines up with the slug. A single-letter acronym is too
+// weak — it would match any same-initial name.
+func confident(slug, candidate string) bool {
+	s := squish(slug)
+	r := squish(candidate)
+	if s == "" || r == "" {
+		return false
+	}
+	if strings.Contains(r, s) || strings.Contains(s, r) {
+		return true
+	}
+	acr := acronym(candidate)
+	if len(acr) >= 2 && (strings.HasPrefix(s, acr) || strings.HasPrefix(acr, s) || acr == s) {
+		return true
+	}
+	return false
+}
+
+func squish(s string) string { return nonAlnum.ReplaceAllString(strings.ToLower(s), "") }
+
+func acronym(s string) string {
+	var b strings.Builder
+	for _, w := range words.FindAllString(s, -1) {
+		b.WriteByte(w[0])
+	}
+	return strings.ToLower(b.String())
+}
+
+// cutSuffixFold is strings.CutSuffix but case-insensitive on the suffix.
+func cutSuffixFold(s, suffix string) (string, bool) {
+	if len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix) {
+		return s[:len(s)-len(suffix)], true
+	}
+	return s, false
+}

--- a/internal/companyname/gate_test.go
+++ b/internal/companyname/gate_test.go
@@ -1,0 +1,80 @@
+package companyname
+
+import "testing"
+
+func TestSlugLike(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"lbresearch", true},
+		{"gs1ca", true},
+		{"chetwood-bank", true}, // hyphens and digits are still slug-like
+		{"franklin-electric", true},
+		{"afcb", true},
+		{"AFC Bournemouth", false}, // has space and uppercase
+		{"Centellic", false},       // has uppercase
+		{"Bob's Red Mill", false},  // has spaces
+		{"", false},                // nothing to work with
+		{"123", false},             // no letter
+	}
+	for _, c := range cases {
+		if got := SlugLike(c.name); got != c.want {
+			t.Errorf("SlugLike(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestExtractTitleName(t *testing.T) {
+	cases := []struct {
+		title string
+		want  string
+	}{
+		{"Jobs at Centellic | Centellic Careers", "Centellic"},
+		{"Jobs at AFC Bournemouth | AFC Bournemouth Careers", "AFC Bournemouth"},
+		{"Bath Spa University Careers", "Bath Spa University"},
+		{"Just a moment...", ""}, // no recognisable pattern
+		{"Careers", ""},          // strips to empty
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := ExtractTitleName(c.title); got != c.want {
+			t.Errorf("ExtractTitleName(%q) = %q, want %q", c.title, got, c.want)
+		}
+	}
+}
+
+func TestAccept(t *testing.T) {
+	cases := []struct {
+		slug      string
+		candidate string
+		wantName  string
+		wantOK    bool
+	}{
+		// Accepted: candidate is a spaced-out form of the slug (substring match).
+		{"afcb", "AFC Bournemouth", "AFC Bournemouth", true},
+		{"gs1ca", "GS1 Canada", "GS1 Canada", true},
+		{"bathspa", "Bath Spa University", "Bath Spa University", true},
+		// Accepted with HTML-entity decode.
+		{"bobsredmill", "Bob&#39;s Red Mill", "Bob's Red Mill", true},
+		{"aspireallergy", "Aspire Allergy &amp; Sinus", "Aspire Allergy & Sinus", true},
+		// Rejected: unrelated name (recruiter / rebrand / wrong subdomain).
+		{"kempinski", "Elena - Meta Recruitment", "", false},
+		{"mountainwarehouse", "Mountain Group", "", false},
+		{"nxcus", "NexCore", "", false},        // single-letter acronym is not enough
+		{"lbresearch", "Centellic", "", false}, // rebrand shares nothing with slug
+		// Rejected: empty / junk.
+		{"anything", "", "", false},
+		{"joe-testing", "Joe's Test Platform", "", false},
+		// Rejected: candidate is itself a slug — no improvement, and applying it
+		// would keep the company slug-like (non-idempotent re-runs).
+		{"osapiens", "osapiens", "", false},
+	}
+	for _, c := range cases {
+		gotName, gotOK := Accept(c.slug, c.candidate)
+		if gotOK != c.wantOK || gotName != c.wantName {
+			t.Errorf("Accept(%q, %q) = (%q, %v), want (%q, %v)",
+				c.slug, c.candidate, gotName, gotOK, c.wantName, c.wantOK)
+		}
+	}
+}

--- a/internal/companyname/resolver.go
+++ b/internal/companyname/resolver.go
@@ -1,0 +1,83 @@
+package companyname
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+)
+
+// textGetter fetches a URL's raw body (careers-page HTML). Matches
+// sources.TextGetter so the production sources.Client satisfies it.
+type textGetter interface {
+	GetText(ctx context.Context, url string) (string, error)
+}
+
+// jsonGetter decodes a URL's JSON body. Matches sources.JSONGetter.
+type jsonGetter interface {
+	GetJSON(ctx context.Context, url string, v any) error
+}
+
+// Resolver resolves a raw display-name candidate for a board from an ATS's own
+// source. It returns "" (not an error) when the source yields no usable name;
+// an error is reserved for transport failures. The candidate is unvalidated —
+// the caller gates it with Accept against the company's slug.
+type Resolver interface {
+	Name(ctx context.Context, board string) (string, error)
+}
+
+// Registry maps a source name to its resolver. Sources with no entry are left
+// alone rather than guessed.
+type Registry map[string]Resolver
+
+// NewRegistry wires the per-ATS resolvers over the shared HTTP getters.
+func NewRegistry(text textGetter, jsonG jsonGetter) Registry {
+	return Registry{
+		// Careers-page <title> ATSes: same parser, different host template.
+		"pinpoint": newTitleResolver(text, "https://%s.pinpointhq.com"),
+		"bamboohr": newTitleResolver(text, "https://%s.bamboohr.com/careers"),
+		"lever":    newTitleResolver(text, "https://jobs.lever.co/%s"),
+		"ashby":    newTitleResolver(text, "https://jobs.ashbyhq.com/%s"),
+		// API-field ATSes.
+		"greenhouse": newGreenhouseResolver(jsonG),
+	}
+}
+
+var titleTag = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
+
+type titleResolver struct {
+	http textGetter
+	tmpl string // host/careers URL template with a single %s for the board
+}
+
+func newTitleResolver(http textGetter, tmpl string) *titleResolver {
+	return &titleResolver{http: http, tmpl: tmpl}
+}
+
+func (r *titleResolver) Name(ctx context.Context, board string) (string, error) {
+	body, err := r.http.GetText(ctx, fmt.Sprintf(r.tmpl, board))
+	if err != nil {
+		return "", err
+	}
+	m := titleTag.FindStringSubmatch(body)
+	if m == nil {
+		return "", nil
+	}
+	return ExtractTitleName(m[1]), nil
+}
+
+type greenhouseResolver struct{ http jsonGetter }
+
+func newGreenhouseResolver(http jsonGetter) *greenhouseResolver {
+	return &greenhouseResolver{http: http}
+}
+
+func (r *greenhouseResolver) Name(ctx context.Context, board string) (string, error) {
+	var resp struct {
+		Name string `json:"name"`
+	}
+	url := fmt.Sprintf("https://boards-api.greenhouse.io/v1/boards/%s/", board)
+	if err := r.http.GetJSON(ctx, url, &resp); err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}

--- a/internal/companyname/resolver_test.go
+++ b/internal/companyname/resolver_test.go
@@ -1,0 +1,55 @@
+package companyname
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type fakeText map[string]string
+
+func (f fakeText) GetText(_ context.Context, url string) (string, error) { return f[url], nil }
+
+type fakeJSON map[string]string // url -> raw JSON body
+
+func (f fakeJSON) GetJSON(_ context.Context, url string, v any) error {
+	return json.Unmarshal([]byte(f[url]), v)
+}
+
+func TestTitleResolver(t *testing.T) {
+	getter := fakeText{
+		"https://lbresearch.pinpointhq.com": `<html><head><title>Jobs at Centellic | Centellic Careers</title></head></html>`,
+		"https://empty.pinpointhq.com":      `<html><head><title>Just a moment...</title></head></html>`,
+	}
+	r := newTitleResolver(getter, "https://%s.pinpointhq.com")
+
+	if got, _ := r.Name(context.Background(), "lbresearch"); got != "Centellic" {
+		t.Errorf("Name(lbresearch) = %q, want Centellic", got)
+	}
+	if got, _ := r.Name(context.Background(), "empty"); got != "" {
+		t.Errorf("Name(empty) = %q, want empty", got)
+	}
+}
+
+func TestGreenhouseResolver(t *testing.T) {
+	getter := fakeJSON{
+		"https://boards-api.greenhouse.io/v1/boards/acme/": `{"name":"Acme Corp"}`,
+	}
+	r := newGreenhouseResolver(getter)
+	if got, _ := r.Name(context.Background(), "acme"); got != "Acme Corp" {
+		t.Errorf("Name(acme) = %q, want Acme Corp", got)
+	}
+}
+
+func TestRegistryLookup(t *testing.T) {
+	reg := NewRegistry(fakeText{}, fakeJSON{})
+	if _, ok := reg["pinpoint"]; !ok {
+		t.Error("registry missing pinpoint resolver")
+	}
+	if _, ok := reg["greenhouse"]; !ok {
+		t.Error("registry missing greenhouse resolver")
+	}
+	if _, ok := reg["nonexistent-ats"]; ok {
+		t.Error("registry should not have a resolver for an unknown source")
+	}
+}

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -423,6 +423,57 @@ func (q *Queries) ListCompanySitemap(ctx context.Context, arg ListCompanySitemap
 	return items, nil
 }
 
+const listSlugLikeCompaniesForBackfill = `-- name: ListSlugLikeCompaniesForBackfill :many
+SELECT DISTINCT ON (company_slug)
+       company_slug AS slug,
+       company      AS name,
+       source,
+       url
+FROM jobs
+WHERE closed_at IS NULL
+  AND duplicate_of IS NULL
+  AND company_slug <> ''
+  AND company ~ '^[a-z0-9._-]+$'
+ORDER BY company_slug, created_at DESC
+`
+
+type ListSlugLikeCompaniesForBackfillRow struct {
+	Slug   string `json:"slug"`
+	Name   string `json:"name"`
+	Source string `json:"source"`
+	URL    string `json:"url"`
+}
+
+// Companies whose ingested name is still a squished slug (lowercase, no
+// whitespace or uppercase) and that have at least one open job, with a
+// representative open job's source and URL so the backfill worker can locate the
+// ATS board. Only boards with live jobs matter, so dead ones never appear. The Go
+// side re-validates slug-likeness authoritatively before touching anything.
+func (q *Queries) ListSlugLikeCompaniesForBackfill(ctx context.Context) ([]ListSlugLikeCompaniesForBackfillRow, error) {
+	rows, err := q.db.Query(ctx, listSlugLikeCompaniesForBackfill)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSlugLikeCompaniesForBackfillRow{}
+	for rows.Next() {
+		var i ListSlugLikeCompaniesForBackfillRow
+		if err := rows.Scan(
+			&i.Slug,
+			&i.Name,
+			&i.Source,
+			&i.URL,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const refreshCompanyFacets = `-- name: RefreshCompanyFacets :execrows
 WITH oj AS (
     -- duplicate_of IS NULL counts one canonical job per role cluster, so the company
@@ -563,6 +614,31 @@ WHERE c.slug = c2.slug
 // CTE). Computed once so the SET and the IS DISTINCT FROM guard share one value.
 func (q *Queries) RefreshCompanyFacets(ctx context.Context) (int64, error) {
 	result, err := q.db.Exec(ctx, refreshCompanyFacets)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const renameSlugCompany = `-- name: RenameSlugCompany :execrows
+UPDATE jobs
+SET company = $1, company_slug = $2, updated_at = now()
+WHERE company_slug = $3
+  AND company ~ '^[a-z0-9._-]+$'
+`
+
+type RenameSlugCompanyParams struct {
+	Name    string `json:"name"`
+	NewSlug string `json:"new_slug"`
+	OldSlug string `json:"old_slug"`
+}
+
+// Apply a resolved display name to every job under a slug-like company and
+// re-key its company_slug (computed by the caller via normalize.Slug), so the
+// derived catalogue re-keys through SyncCompaniesFromJobs + DeleteOrphanCompanies.
+// The name guard keeps a re-run from overwriting a name that is no longer a slug.
+func (q *Queries) RenameSlugCompany(ctx context.Context, arg RenameSlugCompanyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, renameSlugCompany, arg.Name, arg.NewSlug, arg.OldSlug)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -626,6 +626,12 @@ type Querier interface {
 	ListSavedJobSlugs(ctx context.Context, userID int64) ([]string, error)
 	// A user's saved searches, most recently updated first (the "My filters" picker order).
 	ListSavedSearches(ctx context.Context, userID int64) ([]SavedSearch, error)
+	// Companies whose ingested name is still a squished slug (lowercase, no
+	// whitespace or uppercase) and that have at least one open job, with a
+	// representative open job's source and URL so the backfill worker can locate the
+	// ATS board. Only boards with live jobs matter, so dead ones never appear. The Go
+	// side re-validates slug-likeness authoritatively before touching anything.
+	ListSlugLikeCompaniesForBackfill(ctx context.Context) ([]ListSlugLikeCompaniesForBackfillRow, error)
 	// "My submissions": one user's submissions, newest first, whatever their status.
 	// LEFT JOIN the minted job (present only once approved) to surface its public_slug,
 	// so the UI can link an approved submission straight to its live vacancy page.
@@ -837,6 +843,11 @@ type Querier interface {
 	// so a soft-skipped delivery (e.g. Telegram not yet linked) is retried promptly on
 	// a later pass instead of waiting out the lease.
 	ReleaseMatchClaim(ctx context.Context, arg ReleaseMatchClaimParams) error
+	// Apply a resolved display name to every job under a slug-like company and
+	// re-key its company_slug (computed by the caller via normalize.Slug), so the
+	// derived catalogue re-keys through SyncCompaniesFromJobs + DeleteOrphanCompanies.
+	// The name guard keeps a re-run from overwriting a name that is no longer a slug.
+	RenameSlugCompany(ctx context.Context, arg RenameSlugCompanyParams) (int64, error)
 	// A healthy (not-expired) probe clears any accumulated strikes, so only CONSECUTIVE
 	// expired probes can close a job. Guarded to the non-zero case so probing an
 	// already-clean job does not churn the row.

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -133,6 +133,34 @@ ON CONFLICT (slug) DO UPDATE SET
     name       = EXCLUDED.name,
     updated_at = now();
 
+-- name: ListSlugLikeCompaniesForBackfill :many
+-- Companies whose ingested name is still a squished slug (lowercase, no
+-- whitespace or uppercase) and that have at least one open job, with a
+-- representative open job's source and URL so the backfill worker can locate the
+-- ATS board. Only boards with live jobs matter, so dead ones never appear. The Go
+-- side re-validates slug-likeness authoritatively before touching anything.
+SELECT DISTINCT ON (company_slug)
+       company_slug AS slug,
+       company      AS name,
+       source,
+       url
+FROM jobs
+WHERE closed_at IS NULL
+  AND duplicate_of IS NULL
+  AND company_slug <> ''
+  AND company ~ '^[a-z0-9._-]+$'
+ORDER BY company_slug, created_at DESC;
+
+-- name: RenameSlugCompany :execrows
+-- Apply a resolved display name to every job under a slug-like company and
+-- re-key its company_slug (computed by the caller via normalize.Slug), so the
+-- derived catalogue re-keys through SyncCompaniesFromJobs + DeleteOrphanCompanies.
+-- The name guard keeps a re-run from overwriting a name that is no longer a slug.
+UPDATE jobs
+SET company = @name, company_slug = @new_slug, updated_at = now()
+WHERE company_slug = @old_slug
+  AND company ~ '^[a-z0-9._-]+$';
+
 -- name: DeleteOrphanCompanies :execrows
 -- Drop companies no longer referenced by any job — the stale rows left behind
 -- when a slug-builder change re-keys jobs onto new slugs. Reference rows imported

--- a/openspec/changes/add-company-name-backfill/.openspec.yaml
+++ b/openspec/changes/add-company-name-backfill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/add-company-name-backfill/design.md
+++ b/openspec/changes/add-company-name-backfill/design.md
@@ -1,0 +1,37 @@
+## Context
+
+ATS adapters set `Job.Company = e.Company` from the board file (`internal/sources/*.go`; iCIMS is the sole exception, preferring `HiringOrganization.Name`). A large fraction of `sources/*.yml` entries carry a squished slug in `company:`, so the slug becomes the canonical company name. The `companies` table is derived from `jobs` (`SyncCompaniesFromJobs`: `slug = company_slug`, `name = company`; `DeleteOrphanCompanies` sweeps unreferenced rows). The SPA resolves logos via logo.dev's *name* endpoint (`web/src/lib/logo.ts`), which 404s on squished single-token names and degrades to a monogram.
+
+Pinpoint was fixed manually (PR #825): 105 names harvested from careers-page titles (`Jobs at {Name} | {Name} Careers`), decoded, and gated by a confidence check. This change generalizes that ad-hoc process into a reusable worker rather than repeating hand-edits across ~20k slug entries (bamboohr ~7223, workday ~5029, ashby ~2712, lever ~1624, …).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace slug-like company names with real display names sourced deterministically from each ATS's native title/API.
+- Scale across ATSes via a small per-ATS resolver interface; make adding a resolver cheap.
+- Be safe: touch only slug-like names on boards with live jobs; never invent a name; require a confidence match; be idempotent.
+- Be observable: report resolved / skipped / rejected counts.
+
+**Non-Goals:**
+- No change to display, `companies` table shape, or logo-resolution logic — only the stored name value improves.
+- No prettify-the-slug fallback (`afcb` → "Afcb"): out of scope, violates dict-only spirit.
+- No adapter refactor to read API names at ingest time — that is a separate, complementary change; this worker is the backfill for boards where the API gives nothing (Lever/BambooHR) and a catch-up for the rest.
+- No new schema/migration.
+
+## Decisions
+
+- **Run-once worker + resolver package.** `cmd/backfill-company-names/main.go` orchestrates; `internal/companyname/` holds the strategies and the acceptance gate. Mirrors existing run-once workers (`cmd/import-yc`, `cmd/backfill-derive`) and keeps HTTP/parse logic unit-testable without a DB.
+- **Resolver interface keyed by source.** `Resolver interface { Name(ctx, board string) (string, error) }` with a registry `map[source]Resolver`. Title-based resolvers (BambooHR, Lever, Ashby, Pinpoint) share one careers-`<title>` parser differing only by URL template and title shape; API resolvers (Greenhouse board `name`, Workday) parse a field. Sources without a resolver are skipped, not guessed.
+- **Selection query.** Add a read query for companies whose `name` is slug-like (`name !~ '[[:space:][:upper:]]'` and single token) AND `EXISTS` an open job on the slug. Prefer doing the slug predicate in SQL to keep the worker's working set small; final slug classification still validated in Go to stay authoritative.
+- **Acceptance gate (shared with the manual pinpoint pass).** `html.UnescapeString` → trim → reject empty / test / recruiter titles → confidence: squished-candidate contains the slug, or slug contains squished-candidate, or the candidate's word-initial acronym (len ≥ 2) matches the slug. Reject otherwise. This is the exact logic validated on the 241 pinpoint boards (104 accepted, 10 correctly rejected).
+- **Application path.** Update `jobs.company` for the board's postings (so the derived catalogue re-keys), then rely on the existing `SyncCompaniesFromJobs` + `DeleteOrphanCompanies` reconciliation the ingest already runs; the worker may invoke the sync queries at the end so a standalone run is self-contained. Renaming can change `company_slug`, which is expected (the public URL follows the real name) and identical to how PR #825 behaves on next ingest.
+- **Concurrency + politeness.** Bounded worker pool over the sources HTTP client (proxy/User-Agent aware, like the manual pass at ~24 concurrent), so large ATSes complete in reasonable wall-clock without hammering a single host.
+- **Prioritization by live jobs.** The `EXISTS open job` filter means the tens-of-thousands slug count collapses to the boards that actually surface in the UI; dead boards cost nothing.
+
+## Risks / Trade-offs
+
+- **Subdomain reuse / rebrands** can yield a wrong-but-plausible title (e.g. `mountainwarehouse` → "Mountain Group", `doradosoftwaregroup` → "Optitex"). The confidence gate catches unrelated names, but same-prefix mismatches can slip through. Mitigation: keep the gate conservative, log low-confidence/near-miss decisions, and treat the worker's output as reviewable (dry-run mode that prints proposed renames without writing).
+- **Title-format drift.** Careers-page title shapes vary and change over time; a resolver that stops matching simply yields no name (safe no-op), surfaced in the summary rather than corrupting data.
+- **Slug churn on rename.** Changing a name re-keys `company_slug`, orphaning the old `/companies/<old-slug>` URL. Accepted: it matches the rebrand reality and the existing PR #825 behavior; sitemaps/redirects are out of scope here.
+- **Cost of native fetches.** One HTTP round-trip per eligible board; bounded by the live-jobs filter and concurrency. Acceptable for a run-once maintenance job.
+- **Overlap with a future ingest-time adapter fix.** If adapters later read API names at ingest, this worker's role shrinks to title-only ATSes; the resolver package is shared, so no wasted work.

--- a/openspec/changes/add-company-name-backfill/proposal.md
+++ b/openspec/changes/add-company-name-backfill/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Most ATS adapters set `Job.Company = e.Company` straight from the board file, and a large share of `sources/*.yml` entries carry a squished slug in that field instead of a real name (e.g. `lbresearch`, `gs1ca`, `afcb`). That slug then leaks everywhere the company is shown: the UI label, the public `/companies/<slug>` URL, OG cards, and — because the SPA resolves logos through logo.dev's *name* endpoint — it fails to resolve (404) so the logo silently degrades to a monogram. Pinpoint was fixed by a one-off manual batch (PR #825, 105 names harvested from careers-page titles); the same defect spans tens of thousands of entries across bamboohr (~7223), workday (~5029), ashby (~2712), lever (~1624) and others. A hand-edit-per-file approach does not scale and rots as new slug boards arrive.
+
+## What Changes
+
+- Add a run-once-and-exit worker `cmd/backfill-company-names` that finds companies whose stored name is still slug-like and replaces it with the company's real display name resolved from that ATS's own native source.
+- Per-ATS resolvers: careers-page HTML `<title>` (BambooHR/Lever/Ashby/Pinpoint, format like `Jobs at {Name} | {Name} Careers`) and, where the ATS exposes it, an API field (Greenhouse board `name`, Workday). iCIMS already prefers `HiringOrganization.Name` and needs no backfill.
+- A shared name-resolution gate: decode HTML entities, reject garbage (recruiter names, test boards, empty titles), and require a confidence match (returned name shares tokens or an acronym with the slug) before accepting a name.
+- Only rewrite companies whose current name is still slug-like AND that have live jobs — dead/empty boards are skipped so effort tracks real UX impact.
+- Dict-only spirit: never invent or prettify a slug into a name; when no trustworthy source name is found, leave the company untouched.
+
+## Capabilities
+
+### New Capabilities
+- `company-name-backfill`: A maintenance worker that resolves and applies real company display names for boards whose ingested company name is a slug, sourced deterministically from each ATS's native title/API with a confidence gate.
+
+### Modified Capabilities
+<!-- none: display, companies table, and logo resolution behavior are unchanged; this only improves the stored name value -->
+
+## Impact
+
+- New: `cmd/backfill-company-names/main.go`; a resolver package under `internal/` (e.g. `internal/companyname/`) with per-ATS strategies and the confidence/entity-decode gate.
+- Reuses existing DB layer: reads slug-like companies with live jobs, updates `companies.name` / `jobs.company`; the derived catalogue reconciles through the existing `SyncCompaniesFromJobs` + `DeleteOrphanCompanies` queries.
+- Reuses the existing sources HTTP client (proxy/User-Agent) for careers-page and API fetches.
+- Operational: a new cron-style run-once worker (needs `DATABASE_URL`, optionally the sources proxy); follow with `make reindex` so corrected names reach Meilisearch. No schema migration required.
+- No API-contract or frontend changes.

--- a/openspec/changes/add-company-name-backfill/specs/company-name-backfill/spec.md
+++ b/openspec/changes/add-company-name-backfill/specs/company-name-backfill/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Slug-like company selection
+
+The worker SHALL operate only on companies whose stored name is still slug-like — a single lowercase token with no whitespace and no uppercase letters (e.g. `lbresearch`, `gs1ca`, `afcb`) — and SHALL restrict work to companies that have at least one live (open) job. Companies with a human-readable name, and dead or empty boards, SHALL be skipped.
+
+#### Scenario: Slug-like name with live jobs is selected
+- **WHEN** a company's stored name is a single lowercase token and the company has one or more open jobs
+- **THEN** the worker attempts to resolve a real display name for it
+
+#### Scenario: Human-readable name is skipped
+- **WHEN** a company's stored name already contains a space or an uppercase letter (e.g. `AFC Bournemouth`)
+- **THEN** the worker leaves the company untouched and does not attempt resolution
+
+#### Scenario: Slug-like name with no live jobs is skipped
+- **WHEN** a company's stored name is slug-like but no open job references it
+- **THEN** the worker does not attempt resolution for that company
+
+### Requirement: Native-source name resolution per ATS
+
+The worker SHALL resolve a candidate display name from the ATS's own native source for that company's board: the careers-page HTML `<title>` for title-bearing ATSes (BambooHR, Lever, Ashby, Pinpoint), or an ATS API field where exposed (Greenhouse board `name`, Workday). The worker SHALL NOT derive a name by prettifying or guessing from the slug itself.
+
+#### Scenario: Careers-page title yields a name
+- **WHEN** the board's careers page returns a title of the form `Jobs at {Name} | {Name} Careers`
+- **THEN** the worker extracts `{Name}` as the candidate display name
+
+#### Scenario: API field yields a name
+- **WHEN** the ATS exposes an organization/board display name via its API (e.g. Greenhouse board `name`)
+- **THEN** the worker uses that field as the candidate display name
+
+#### Scenario: No name is invented from the slug
+- **WHEN** no native source name is available for a board
+- **THEN** the worker emits no candidate name and leaves the company untouched
+
+### Requirement: Name acceptance gate
+
+Before applying a resolved name the worker SHALL decode HTML entities in the candidate, reject empty, test-board, and recruiter-style titles, and require a confidence match — the decoded candidate SHALL share a token or an acronym with the slug. A candidate that fails any check SHALL be discarded and the company left untouched.
+
+#### Scenario: HTML entities are decoded
+- **WHEN** a candidate name contains HTML entities (e.g. `Bob&#39;s Red Mill`, `Aspire Allergy &amp; Sinus`)
+- **THEN** the applied name is the decoded form (`Bob's Red Mill`, `Aspire Allergy & Sinus`)
+
+#### Scenario: Low-confidence candidate is rejected
+- **WHEN** the decoded candidate shares no token or acronym with the slug (e.g. slug `kempinski` → `Elena - Meta Recruitment`)
+- **THEN** the candidate is discarded and the company name is left unchanged
+
+#### Scenario: Test/empty title is rejected
+- **WHEN** the candidate is empty or a test-board artifact (e.g. `Joe's Test Platform`)
+- **THEN** the candidate is discarded and the company name is left unchanged
+
+### Requirement: Idempotent application and propagation
+
+Applying a resolved name SHALL update the ingested company name so that the derived `companies` catalogue reconciles through the existing sync path, and SHALL be idempotent — a second run over the same data resolves nothing new because previously fixed names are no longer slug-like.
+
+#### Scenario: Applied name propagates to the catalogue
+- **WHEN** the worker applies a resolved name to a company's ingested jobs
+- **THEN** the `companies` catalogue reflects the new name after the existing `SyncCompaniesFromJobs` + `DeleteOrphanCompanies` reconciliation, with no manual DB edit
+
+#### Scenario: Re-run is a no-op
+- **WHEN** the worker runs again after a successful backfill with no new slug-like companies
+- **THEN** it resolves and applies nothing
+
+### Requirement: Run-once worker contract
+
+The capability SHALL be delivered as a standalone run-once-and-exit worker (`cmd/backfill-company-names`) that requires `DATABASE_URL`, reuses the existing sources HTTP client for outbound fetches, and reports a summary of resolved, skipped, and low-confidence counts so operators can review coverage.
+
+#### Scenario: Worker runs to completion and exits
+- **WHEN** the worker is invoked with a valid `DATABASE_URL`
+- **THEN** it processes eligible companies, prints a summary of resolved / skipped / rejected counts, and exits
+
+#### Scenario: Coverage is observable, not silently capped
+- **WHEN** the worker finishes a run
+- **THEN** its summary distinguishes companies it fixed from those it left untouched and why (no trustworthy source vs. low confidence)

--- a/openspec/changes/add-company-name-backfill/tasks.md
+++ b/openspec/changes/add-company-name-backfill/tasks.md
@@ -1,0 +1,32 @@
+## 1. Resolver package (`internal/companyname/`)
+
+- [x] 1.1 Define `Resolver interface { Name(ctx context.Context, board string) (string, error) }` and a `registry map[string]Resolver` keyed by source name.
+- [x] 1.2 Implement the shared careers-`<title>` parser (URL template + title-shape per ATS) covering BambooHR, Lever, Ashby, Pinpoint; extract `{Name}` from `Jobs at {Name} | {Name} Careers` and fall back to the `... Careers` trailing form.
+- [x] 1.3 Implement API-field resolvers where exposed: Greenhouse board `name`. iCIMS needs none (already uses `HiringOrganization.Name`). Workday deferred — its POST/tenant request shape is a separate seam; the registry adds it without touching callers.
+- [x] 1.4 Implement the acceptance gate `Accept(slug, candidate) (string, bool)`: `html.UnescapeString` → trim → reject empty/still-slug-like/test/recruiter titles → confidence match (squished-candidate ⊇ slug, or slug ⊇ squished-candidate, or word-initial acronym len ≥ 2 matches slug).
+- [x] 1.5 Add a `SlugLike(name string) bool` helper (single lowercase token, no space, no uppercase) shared by the selection filter and tests.
+
+## 2. Data access
+
+- [x] 2.1 Add sqlc query `ListSlugLikeCompaniesForBackfill` returning company slug + name + a representative open job's source and URL for slug-like companies with ≥1 open job; regenerated `internal/db`.
+- [x] 2.2 Add `RenameSlugCompany` that rewrites `jobs.company` + re-keys `company_slug` for a board's postings, then reuse existing `SyncCompaniesFromJobs` + `DeleteOrphanCompanies` for reconciliation.
+
+## 3. Worker (`cmd/backfill-company-names/main.go`)
+
+- [x] 3.1 Wire config (`DATABASE_URL`), pgx pool, and the sources HTTP client via `worker.Bootstrap`.
+- [x] 3.2 Load eligible companies, dispatch to the per-source resolver via a bounded errgroup (24 concurrent) over the shared HTTP client.
+- [x] 3.3 Apply accepted names through `RenameSlugCompany`; run the catalogue reconciliation at the end so a standalone run is self-contained.
+- [x] 3.4 Add a `--dry-run` flag that prints proposed `slug -> name` renames without writing.
+- [x] 3.5 Print a summary: resolved / applied / skipped-no-source / rejected counts + companies orphaned.
+
+## 4. Tests
+
+- [x] 4.1 Unit-test `SlugLike` and the acceptance gate against the pinpoint corpus cases (accepts AFC Bournemouth, GS1 Canada; rejects `kempinski`→recruiter, `joe-testing`, `mountainwarehouse`, `lbresearch`→Centellic rebrand, still-slug candidates).
+- [x] 4.2 Unit-test the careers-`<title>` parser and entity decoding (title-tag extraction + `ExtractTitleName` + `Accept` decode cases).
+- [x] 4.3 Unit-test the Greenhouse resolver and the registry lookup against a fake JSON getter.
+
+## 5. Docs & rollout
+
+- [x] 5.1 Add `internal/companyname/AGENTS.md` and a `cmd/backfill-company-names` entry to the root `AGENTS.md` command list + layout.
+- [x] 5.2 Document the run recipe (`go run ./cmd/backfill-company-names` [`--dry-run`], then `make reindex`) and note slug/URL churn on rename.
+- [x] 5.3 `go build ./... && go vet ./... && go test -race ./...` green. NOTE (operational, pre-live): run `--dry-run` against prod data and eyeball the proposed renames before the first live run.


### PR DESCRIPTION
## Problem

Most ATS adapters set `jobs.company` straight from the board file, so boards whose file entry is a squished slug (`lbresearch`, `gs1ca`, `afcb`) carry that slug as the display name. It leaks into the UI label, the public `/companies/<slug>` URL, and breaks logo.dev's *name* endpoint (404 → monogram). PR #825 fixed Pinpoint by hand across 105 boards; this generalizes that ad-hoc pass so it scales and doesn't rot as new slug boards arrive.

Implements OpenSpec change `add-company-name-backfill`.

## What's here

**`internal/companyname/`** — per-source `Resolver` registry + a conservative acceptance gate:
- *title resolvers* (Pinpoint / BambooHR / Lever / Ashby) pull the name from the careers-page `<title>` (`Jobs at {Name} | …`); *API resolver* (Greenhouse board `name`). iCIMS needs none (already uses `HiringOrganization.Name`); Workday is a noted seam.
- `Accept(slug, candidate)`: decode HTML entities, reject junk / still-slug-like candidates, and require a **confidence match** (squished candidate ⊇ slug or vice-versa, or a ≥2-letter acronym). Rebrands sharing nothing with the slug (e.g. `lbresearch` → Centellic) are deliberately **not** auto-resolved — a wrong name reads worse than the monogram.

**`cmd/backfill-company-names`** — run-once worker: selects slug-like companies **with open jobs** (dead boards cost nothing), resolves names bounded-concurrently (24), applies via `RenameSlugCompany` (re-keys `company_slug`), and reconciles through the existing `SyncCompaniesFromJobs` + `DeleteOrphanCompanies`. `--dry-run` prints proposed renames. Idempotent — an accepted name is never itself slug-like.

## Verification

- `go build ./... && go vet ./... && go test -race ./...` all green.
- Unit tests cover the gate against the Pinpoint corpus (accepts AFC Bournemouth / GS1 Canada; rejects recruiter/test/rebrand/still-slug candidates), the title parser + entity decode, `BoardFromURL`, the Greenhouse resolver, and the worker's `resolveNames`.
- **Pre-live (operational):** run `--dry-run` against prod data and eyeball proposed renames before the first live run; follow a live run with `make reindex`.

## Notes / follow-ups

- Workday resolver deferred (POST/tenant request shape) — registry adds it without touching callers.
- Greenhouse vanity/aggregator job URLs may not encode the board in the first path segment → a harmless miss (gated), not a wrong write.