### PR TITLE
fix(web): refresh stale ATS-platform and Telegram-channel counts

### DIFF
--- a/web/src/lib/components/HomeView.svelte
+++ b/web/src/lib/components/HomeView.svelte
@@ -15,11 +15,12 @@
   const compact = (n: number | null, fallback: string) => (n == null ? fallback : `${nf.format(n)}+`);
 
   // The under-the-fold stats strip: two live totals, then the two constants —
-  // ATS breadth and licensing — that don't need a query.
+  // ATS breadth and licensing — that don't need a query. The ATS count mirrors the
+  // /open stat-strip: registered adapters in internal/sources/source.go `All()`.
   const figures = $derived([
     { value: compact(stats.jobs, '3.1M+'), label: 'open jobs' },
     { value: compact(stats.companies, '220K+'), label: 'companies' },
-    { value: '98', label: 'ATS platforms' },
+    { value: '137', label: 'ATS platforms' },
     { value: '100%', label: 'open source' },
   ]);
 

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -11,9 +11,11 @@
 
   // Repo constants — the crawler covers this many ATS platforms and Telegram
   // channels. Not DB rows; they change only when adapters/channels are added (i.e.
-  // on deploy), mirroring the homepage stat-strip.
-  const ATS_PLATFORMS = 98;
-  const TELEGRAM_CHANNELS = 87;
+  // on deploy), mirroring the homepage stat-strip. Recount on change:
+  //   ATS platforms   → registered adapters in internal/sources/source.go `All()`
+  //   Telegram channels → `- channel:` entries in sources/telegram.yml
+  const ATS_PLATFORMS = 137;
+  const TELEGRAM_CHANNELS = 91;
 
   const nf = new Intl.NumberFormat('en');
   const compactNf = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });


### PR DESCRIPTION
The hardcoded stat-strip figures on `/open` and the homepage/`/about` had drifted from reality:

| stat | was | now | source of truth |
|---|---|---|---|
| ATS platforms | 98 | **137** | registered adapters in `internal/sources/source.go` `All()` (verified via `len(sources.All(nil))`) |
| Telegram channels | 87 | **91** | `- channel:` entries in `sources/telegram.yml` |

Touches both surfaces that render these: `web/src/routes/open/+page.svelte` and `web/src/lib/components/HomeView.svelte` (the latter feeds both the homepage and `/about`). Comments now name the recount source so the next bump is obvious.

Still hardcoded (deploy-time constants, per the existing pattern) — a fully-dynamic count would mean the API server importing all source adapters + embedding `telegram.yml`, which isn't worth the coupling for a marketing figure.