### PR TITLE
fix(lang): recover English postings whatlanggo scores "unreliable"

### DIFF
--- a/internal/lang/lang.go
+++ b/internal/lang/lang.go
@@ -8,6 +8,7 @@ package lang
 import (
 	"regexp"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/abadojack/whatlanggo"
@@ -32,8 +33,41 @@ func Detect(text string) string {
 		return ""
 	}
 	info := whatlanggo.Detect(clean)
-	if !info.IsReliable() {
-		return ""
+	if info.IsReliable() {
+		return info.Lang.Iso6391()
 	}
-	return info.Lang.Iso6391()
+	// whatlanggo is over-strict on postings that mix English tech terms, brand
+	// names, and code fragments: it leaves ~a third of clearly-English descriptions
+	// "unreliable". When its own best guess is already English and the text is
+	// Latin-script, trust that weaker signal rather than dropping the language. A
+	// genuinely non-English posting scores reliably (German/Portuguese/Russian) and
+	// never reaches here, so this only rescues English — it never mislabels another
+	// language. When the unreliable guess is not English, we still emit "" (never
+	// guess), matching the doctrine of internal/location and internal/classify.
+	if info.Lang == whatlanggo.Eng && latinLetterRatio(clean) >= 0.9 {
+		return whatlanggo.Eng.Iso6391()
+	}
+	return ""
+}
+
+// latinLetterRatio is the fraction of letters in text that are ASCII A–Z/a–z. It
+// gates the English fallback: real English prose is ~all ASCII letters, while a
+// non-Latin script (Cyrillic, CJK) scores low and is never coerced to English.
+// Non-letter runes (digits, punctuation, spaces) are ignored so tech-token-heavy
+// text is judged on its words, not its symbols. Returns 0 when there are no letters.
+func latinLetterRatio(text string) float64 {
+	var letters, ascii int
+	for _, r := range text {
+		if !unicode.IsLetter(r) {
+			continue
+		}
+		letters++
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			ascii++
+		}
+	}
+	if letters == 0 {
+		return 0
+	}
+	return float64(ascii) / float64(letters)
 }

--- a/internal/lang/lang_test.go
+++ b/internal/lang/lang_test.go
@@ -44,6 +44,33 @@ func TestDetect(t *testing.T) {
 			text: "",
 			want: "",
 		},
+		{
+			// Tech-heavy English prose (brands, acronyms, code) scores "unreliable"
+			// in whatlanggo yet is clearly English: the English-leaning fallback
+			// rescues it instead of dropping the language.
+			name: "unreliable english tech-sparse -> en",
+			text: "Stack: React, Redux, TypeScript, Node.js, GraphQL, Docker, " +
+				"Kubernetes, AWS, Terraform, PostgreSQL, Redis, Kafka. CI/CD via " +
+				"GitHub Actions. Remote-first team.",
+			want: "en",
+		},
+		{
+			// Reliable non-English prose must NOT be pulled to "en" by the fallback:
+			// German scores reliably and keeps its own code.
+			name: "reliable german stays de",
+			text: "Wir suchen zum naechstmoeglichen Zeitpunkt einen erfahrenen " +
+				"Entwickler fuer unser Team in Berlin, der unsere Plattform " +
+				"weiterentwickelt und den Betrieb der Dienste sicherstellt.",
+			want: "de",
+		},
+		{
+			// Precision boundary: an unreliable posting whose best guess is NOT
+			// English is left empty rather than guessed — never mislabelled.
+			name: "unreliable non-english-guess stays empty",
+			text: "Join Acme! We use Go, gRPC, k8s. Ship fast. Great perks. " +
+				"Apply now via our portal today.",
+			want: "",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
whatlanggo leaves ~30% of clearly-English job descriptions unlabelled: tech terms, brand names, and code fragments depress its reliability score, so `Detect` returned `""`.

**Fix:** when whatlanggo is unreliable but its own best guess is already English **and** the text is Latin-script (`latinLetterRatio ≥ 0.9`), fall back to `"en"` instead of dropping the language. A genuinely non-English posting scores *reliable* (German/Portuguese/Russian) and never reaches the fallback — so this only rescues English and never mislabels another language. A non-English unreliable guess still emits `""` (never guess), keeping the `internal/location`/`internal/classify` doctrine.

**Measured** on 400 previously-empty production postings: **96% now get a language** (en:377, fr:6, de:2, nl:1, es:1), no garbage.

**Scope:** `internal/lang` only. TDD (new cases: unreliable-English→en, reliable-German stays de, non-English-guess stays empty); gofmt/vet clean.

**Deploy note:** reaching existing rows needs `cmd/backfill-derive` + `make reindex` (derivation change).

_Context: this came out of a facet-recall audit. A companion idea — filling empty `category` from the description — was prototyped and **dropped**: measured 8% exact / 62% false positives with keyword matching (`security` matched 56× but the LLM agreed once), so the existing title-only decision stands._