### PR TITLE
refactor(sources): residual shared-helper adoptions

### DIFF
--- a/internal/sources/careerspage.go
+++ b/internal/sources/careerspage.go
@@ -80,11 +80,7 @@ func (s careerspage) detail(ctx context.Context, e CompanyEntry, loc string) (Jo
 		return Job{}, false
 	}
 
-	location := joinNonEmpty(
-		p.JobLocation.Address.AddressLocality,
-		p.JobLocation.Address.AddressRegion,
-		p.JobLocation.Address.AddressCountry,
-	)
+	location := p.JobLocation.Address.Location()
 
 	return Job{
 		ExternalID:  id,
@@ -107,13 +103,7 @@ type careerspagePosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation struct {
-		Address struct {
-			AddressLocality string `json:"addressLocality"`
-			AddressRegion   string `json:"addressRegion"`
-			AddressCountry  string `json:"addressCountry"`
-		} `json:"address"`
-	} `json:"jobLocation"`
+	JobLocation schemaPlace `json:"jobLocation"`
 }
 
 // careerspageJobIDPattern captures the job UUID from a canonical /jobs/<uuid> URL. The

--- a/internal/sources/erecruiter.go
+++ b/internal/sources/erecruiter.go
@@ -261,11 +261,7 @@ var erecruiterCfgRe = regexp.MustCompile(`(?i)Code\.ashx\?cfg=([0-9A-Fa-f]{32})`
 // eRecruiter widget script, or "" when the page carries no such widget. It backs
 // cmd/harvest-erecruiter, the discovery bridge from a careers URL to a board entry.
 func ExtractErecruiterCfg(page string) string {
-	m := erecruiterCfgRe.FindStringSubmatch(page)
-	if len(m) < 2 {
-		return ""
-	}
-	return m[1]
+	return firstSubmatch(erecruiterCfgRe, page)
 }
 
 // ProbeErecruiterCfg live-validates a cfg by fetching its first list page and reporting how

--- a/internal/sources/factorial.go
+++ b/internal/sources/factorial.go
@@ -40,16 +40,9 @@ func (f factorial) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 		return nil, fmt.Errorf("factorial: listing %s: %w", e.Board, err)
 	}
 
-	// The careers root renders every posting; dedup the links (the same job can appear under
-	// multiple team sections).
-	var urls []string
-	seen := make(map[string]bool)
-	for _, link := range jobLinks(base, root, func(href string) bool { return strings.Contains(href, "/job_posting/") }) {
-		if !seen[link] {
-			seen[link] = true
-			urls = append(urls, link)
-		}
-	}
+	// The careers root renders every posting; jobLinks already dedups (the same job can appear
+	// under multiple team sections).
+	urls := jobLinks(base, root, func(href string) bool { return strings.Contains(href, "/job_posting/") })
 
 	return fetchDetails(urls, defaultDetailWorkers, func(u string) (Job, bool) {
 		return f.detail(ctx, e, u)

--- a/internal/sources/rapyd.go
+++ b/internal/sources/rapyd.go
@@ -94,27 +94,7 @@ func (r rapyd) detail(ctx context.Context, e CompanyEntry, jobURL string) (Job, 
 // relative hrefs still yield fetchable URLs, de-duplicated in first-seen order (a card
 // links the same position from its title and other controls).
 func rapydPositionLinks(base *url.URL, root *html.Node) []string {
-	var out []string
-	seen := make(map[string]bool)
-	walk(root, func(n *html.Node) bool {
-		if n.Type == html.ElementNode && n.Data == "a" {
-			href := attr(n, "href")
-			if rapydPositionID(href) == "" {
-				return true
-			}
-			ref, err := url.Parse(href)
-			if err != nil {
-				return true // unparseable href → not a usable position link
-			}
-			abs := base.ResolveReference(ref).String()
-			if !seen[abs] {
-				seen[abs] = true
-				out = append(out, abs)
-			}
-		}
-		return true
-	})
-	return out
+	return jobLinks(base, root, func(href string) bool { return rapydPositionID(href) != "" })
 }
 
 // rapydPositionIDPattern captures the slug from a /company/careers/positions/<slug>/ path.

--- a/internal/sources/vagas.go
+++ b/internal/sources/vagas.go
@@ -76,30 +76,11 @@ func (v vagas) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 // listArea enumerates one area's job URLs across its paginated listing, stopping on the first
 // page that adds no new links (an empty tail page, or a board that repeats a page for any pagina).
 func (v vagas) listArea(ctx context.Context, area string) ([]string, error) {
-	var urls []string
-	seen := make(map[string]bool)
-	for page := 1; page <= vagasMaxPages; page++ {
-		listURL := fmt.Sprintf("https://www.vagas.com.br/%s?pagina=%d", area, page)
-		root, err := v.http.GetHTML(ctx, listURL)
-		if err != nil {
-			if page == 1 {
-				return nil, err
-			}
-			break // a later page failing ends enumeration with the URLs gathered so far
-		}
-		newLinks := 0
-		for _, link := range jobLinks(vagasBase, root, func(href string) bool { return vagasJobID(href) != "" }) {
-			if !seen[link] {
-				seen[link] = true
-				urls = append(urls, link)
-				newLinks++
-			}
-		}
-		if newLinks == 0 {
-			break
-		}
-	}
-	return urls, nil
+	return crawlPagedLinks(ctx, v.http, vagasMaxPages,
+		func(page int) string { return fmt.Sprintf("https://www.vagas.com.br/%s?pagina=%d", area, page) },
+		func(root *html.Node) []string {
+			return jobLinks(vagasBase, root, func(href string) bool { return vagasJobID(href) != "" })
+		})
 }
 
 // detail fetches one job page and maps its JobPosting ld+json to a Job, returning ok=false when

--- a/internal/sources/wantapply.go
+++ b/internal/sources/wantapply.go
@@ -100,12 +100,8 @@ func (s wantapply) FetchNew(ctx context.Context, _ CompanyEntry, seen func(exter
 // crawl reads the sitemap and returns every vacancy candidate (reserved pages, /company/*, and
 // /jobs/* excluded) — the shared enumeration behind Fetch and FetchNew.
 func (s wantapply) crawl(ctx context.Context) ([]wantapplyVacancy, error) {
-	var sitemap struct {
-		URLs []struct {
-			Loc string `xml:"loc"`
-		} `xml:"url"`
-	}
-	if err := s.http.GetXML(ctx, wantapplySitemapURL, &sitemap); err != nil {
+	sitemap, err := getSitemap(ctx, s.http, wantapplySitemapURL)
+	if err != nil {
 		return nil, fmt.Errorf("wantapply: sitemap: %w", err)
 	}
 	var out []wantapplyVacancy

--- a/internal/sources/workablemarketplace.go
+++ b/internal/sources/workablemarketplace.go
@@ -83,7 +83,7 @@ func (w workableMarketplace) Fetch(ctx context.Context, e CompanyEntry) ([]Job, 
 				Location:       joinNonEmpty(j.Location.City, j.Location.CountryName),
 				Description:    sanitizeHTML(j.Description),
 				Remote:         remote,
-				WorkMode:       workableWorkplaceMode(j.Workplace),
+				WorkMode:       workplaceTypeMode(j.Workplace),
 				PostedAt:       parseRFC3339(j.Created),
 				EmploymentType: workableEmploymentType(j.EmploymentType),
 			})
@@ -97,19 +97,4 @@ func (w workableMarketplace) Fetch(ctx context.Context, e CompanyEntry) ([]Job, 
 		token = resp.NextPageToken
 	}
 	return jobs, nil
-}
-
-// workableWorkplaceMode maps Workable's marketplace "workplace" enum onto the freehire
-// work-mode vocabulary, returning "" for an absent/unknown value (the location parser decides).
-func workableWorkplaceMode(v string) string {
-	switch v {
-	case "remote":
-		return "remote"
-	case "hybrid":
-		return "hybrid"
-	case "on-site", "onsite":
-		return "onsite"
-	default:
-		return ""
-	}
 }


### PR DESCRIPTION
Final increment — a completeness pass (adversarial re-scan of merged `main`) found a handful of low-risk shared-helper adoptions in adapters the earlier audit PRs did not touch. All behaviour-preserving.

- **careerspage** → `schemaPlace` + `Address.Location()` (clean 3-field single-Place the schema migration list missed)
- **vagas** `listArea` → `crawlPagedLinks` (byte-identical page loop)
- **rapyd** `rapydPositionLinks` → shared `jobLinks`; **factorial** drops a redundant re-dedup (`jobLinks` already dedups)
- **erecruiter** `ExtractErecruiterCfg` → `firstSubmatch`
- **workablemarketplace** `workableWorkplaceMode` → the shared `workplaceTypeMode`
- **wantapply** `crawl()` sitemap → `getSitemap`/`sitemapDoc`

`go build/vet/test ./...` green, `gofmt` clean.

**Deliberately left** (bias toward caution): comeet/cornerstone/traffit location loops TRIM each part while `joinNonEmpty` does not — not an equivalent swap; **bayt** link collection is deferred to its own PR (it also fixes a latent protocol-relative-`//`-href bug and changes fingerprint-client link semantics).

Also: the completeness pass produced 3 false positives (claimed successfactors/metacareers/clinch/avature/gulftalent/avito still un-migrated) — those are already done in #826; the workflow agents had read a stale checkout.