### PR TITLE
fix(sources): resolve bayt protocol-relative listing hrefs correctly

### DIFF
--- a/internal/sources/bayt.go
+++ b/internal/sources/bayt.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -135,13 +136,20 @@ func baytListingLinks(root *html.Node) []string {
 	return hrefs
 }
 
-// baytAbsURL resolves a listing href against the Bayt origin; an already-absolute href is
-// returned unchanged.
+// baytBase is the parsed Bayt origin, resolved against once per listing href.
+var baytBase, _ = url.Parse(baytBaseURL)
+
+// baytAbsURL resolves a listing href against the Bayt origin, handling all three forms via
+// ResolveReference: an already-absolute href keeps itself, a protocol-relative "//host/path"
+// keeps its own host under the origin's scheme, and a root-relative "/path" gets the origin. The
+// old strings.HasPrefix(href, "http") guess mis-resolved a protocol-relative href into
+// "https://www.bayt.com//host/path", silently dropping those postings at the detail fetch.
 func baytAbsURL(href string) string {
-	if strings.HasPrefix(href, "http") {
-		return href
+	ref, err := url.Parse(href)
+	if err != nil {
+		return baytBaseURL + href
 	}
-	return baytBaseURL + href
+	return baytBase.ResolveReference(ref).String()
 }
 
 // detail fetches one job page and maps its ld+json JobPosting to a Job, returning ok=false when

--- a/internal/sources/bayt_test.go
+++ b/internal/sources/bayt_test.go
@@ -62,6 +62,22 @@ func TestBaytJobID(t *testing.T) {
 	}
 }
 
+func TestBaytAbsURLResolvesHrefForms(t *testing.T) {
+	const want = "https://www.bayt.com/en/saudi-arabia/jobs/senior-dev-42/"
+	cases := map[string]string{
+		"/en/saudi-arabia/jobs/senior-dev-42/":                     want, // root-relative
+		"https://www.bayt.com/en/saudi-arabia/jobs/senior-dev-42/": want, // already absolute
+		// protocol-relative: keeps its own host; the old "http" prefix guess mis-built
+		// "https://www.bayt.com//www.bayt.com/…".
+		"//www.bayt.com/en/saudi-arabia/jobs/senior-dev-42/": want,
+	}
+	for href, w := range cases {
+		if got := baytAbsURL(href); got != w {
+			t.Errorf("baytAbsURL(%q) = %q, want %q", href, got, w)
+		}
+	}
+}
+
 func TestBaytRegisteredAndFacet(t *testing.T) {
 	if _, ok := All(nil)["bayt"]; !ok {
 		t.Fatal("bayt not registered in sources.All")


### PR DESCRIPTION
The last item from the adapter-audit completeness pass — a latent bug (not just a duplicate).

`baytAbsURL` decided absolute-vs-relative with `strings.HasPrefix(href, "http")`. A protocol-relative `//www.bayt.com/en/<country>/jobs/<slug>-<id>/` href does **not** start with `"http"`, so it was prepended with the origin into `https://www.bayt.com//www.bayt.com/en/…` — a 404 that silently dropped those postings at the detail fetch (the listing link was collected and id-matched, then the mangled URL failed to fetch).

Fix: resolve via `url.ResolveReference` against the parsed origin, which correctly handles all three href forms (absolute keeps itself, protocol-relative keeps its host under the origin scheme, root-relative gets the origin). The id-based dedup is unchanged (not switched to `jobLinks`' URL-dedup, which would keep tracking-suffix duplicates).

TDD: added `TestBaytAbsURLResolvesHrefForms` (red on the `//host` case, green after). `go build/vet/test ./...` green, `gofmt` clean. **Verified live** (bayt/bahrain: 203 jobs, 0 empty IDs, 0 malformed URLs).