### PR TITLE
fix(companyname): tighten title parser, drop greenhouse resolver

### DIFF
--- a/cmd/backfill-company-names/main.go
+++ b/cmd/backfill-company-names/main.go
@@ -51,7 +51,7 @@ func run() int {
 
 	queries := db.New(pool)
 	client := sources.NewClient()
-	registry := companyname.NewRegistry(client, client)
+	registry := companyname.NewRegistry(client)
 
 	rows, err := queries.ListSlugLikeCompaniesForBackfill(ctx)
 	if err != nil {

--- a/internal/companyname/AGENTS.md
+++ b/internal/companyname/AGENTS.md
@@ -15,15 +15,15 @@ Consumed by `cmd/backfill-company-names`.
   lowercase token, ≥1 letter; hyphens/digits allowed). The SQL filter is an
   approximation; this is the gate the worker trusts.
 - **`Resolver` + `Registry`** — one resolver per source, keyed by source name. A
-  source with no resolver is left alone, never guessed. Two shapes:
-  - *title resolvers* (Pinpoint, BambooHR, Lever, Ashby) — fetch the careers page
-    and pull the name out of `<title>` via `ExtractTitleName` (`Jobs at {Name} |
-    …` or a trailing `{Name} Careers`).
-  - *API resolvers* (Greenhouse board `name`) — read a JSON field. iCIMS needs no
-    resolver: its adapter already prefers `HiringOrganization.Name`.
+  source with no resolver is left alone, never guessed. Only *title resolvers*
+  exist so far (Pinpoint, BambooHR, Lever, Ashby): fetch the careers page and pull
+  the name out of `<title>` via `ExtractTitleName` (a `<lead-in> at {Name}` prefix
+  or a trailing `{Name} Careers`, with a stray `| …` section trimmed off).
 - **`BoardFromURL(source, url)`** — extracts the ATS board id from a representative
-  job URL (host label for Pinpoint/BambooHR; first path segment for
-  Lever/Ashby/Greenhouse), matching what each resolver fetches against.
+  job URL (host label for Pinpoint/BambooHR; first path segment for Lever/Ashby),
+  matching what each resolver fetches against. Sources whose job URL is a vanity
+  careers domain (e.g. Greenhouse's `a16z.com/about/jobs`) carry no board in the
+  URL, so they get no resolver — a board-from-source-file lookup is a future seam.
 - **`Accept(slug, candidate)`** — the gate applied before writing: decode HTML
   entities, reject junk (test/recruiter titles), and require a **confidence
   match** — the squished candidate contains the slug (or vice versa), or a

--- a/internal/companyname/board.go
+++ b/internal/companyname/board.go
@@ -20,7 +20,7 @@ func BoardFromURL(source, rawURL string) (string, bool) {
 		if i := strings.IndexByte(u.Host, '.'); i > 0 {
 			return u.Host[:i], true
 		}
-	case "lever", "ashby", "greenhouse":
+	case "lever", "ashby":
 		// board is the first path segment: jobs.lever.co/{board}/...
 		if seg := firstPathSegment(u.Path); seg != "" {
 			return seg, true

--- a/internal/companyname/board_test.go
+++ b/internal/companyname/board_test.go
@@ -13,9 +13,9 @@ func TestBoardFromURL(t *testing.T) {
 		{"bamboohr", "https://321theagency.bamboohr.com/careers/42", "321theagency", true},
 		{"lever", "https://jobs.lever.co/1inch/abc-123", "1inch", true},
 		{"ashby", "https://jobs.ashbyhq.com/0x/some-id", "0x", true},
-		{"greenhouse", "https://boards.greenhouse.io/acme/jobs/42", "acme", true},
-		{"greenhouse", "https://job-boards.greenhouse.io/acme/jobs/42", "acme", true},
-		// Unknown source or unparseable URL yields no board.
+		// Unknown source (greenhouse job URLs are vanity domains — no board) or
+		// unparseable URL yields no board.
+		{"greenhouse", "https://a16z.com/about/jobs/?gh_jid=42", "", false},
 		{"unknown-ats", "https://example.com/x", "", false},
 		{"pinpoint", "not a url", "", false},
 		{"lever", "https://jobs.lever.co/", "", false},

--- a/internal/companyname/gate.go
+++ b/internal/companyname/gate.go
@@ -21,6 +21,9 @@ var (
 	nonAlnum = regexp.MustCompile(`[^a-z0-9]+`)
 	words    = regexp.MustCompile(`[A-Za-z0-9]+`)
 	jobsAt   = regexp.MustCompile(`(?i)Jobs at (.+?)\s*\|`)
+	// A careers-page lead-in that precedes the real name: "Jobs at X",
+	// "Careers at X", "Employment Opportunities at X", "Open roles at X".
+	leadInAt = regexp.MustCompile(`(?i)^(?:jobs|careers|employment opportunities|open (?:roles|positions|jobs)) at (.+)$`)
 
 	// Titles that look resolvable but are placeholders or artifacts, not a
 	// company. The confidence gate catches most of these already; this is a
@@ -47,17 +50,32 @@ func SlugLike(name string) bool {
 }
 
 // ExtractTitleName pulls a company name out of a careers-page <title>. It
-// handles the two shapes ATS careers pages use — "Jobs at {Name} | ..." and a
-// trailing "{Name} Careers" — and returns "" when neither matches.
+// handles the shapes ATS careers pages use — a "<lead-in> at {Name}" prefix
+// (Jobs/Careers/Employment Opportunities at …) and a trailing "{Name} Careers" —
+// then cleans a stray " | …" section and collapsed whitespace off the result.
+// Returns "" when no shape matches.
 func ExtractTitleName(title string) string {
 	title = strings.TrimSpace(html.UnescapeString(title))
-	if m := jobsAt.FindStringSubmatch(title); m != nil {
-		return strings.TrimSpace(m[1])
+	switch {
+	case jobsAt.MatchString(title):
+		return clean(jobsAt.FindStringSubmatch(title)[1])
+	case leadInAt.MatchString(title):
+		return clean(leadInAt.FindStringSubmatch(title)[1])
+	default:
+		if rest, ok := cutSuffixFold(title, "Careers"); ok {
+			return clean(rest)
+		}
+		return ""
 	}
-	if rest, ok := cutSuffixFold(title, "Careers"); ok {
-		return strings.TrimSpace(strings.TrimRight(rest, " |-"))
+}
+
+// clean drops a trailing " | …" fragment (careers titles append a section name
+// after the company) and collapses runs of whitespace to single spaces.
+func clean(s string) string {
+	if i := strings.Index(s, " | "); i >= 0 {
+		s = s[:i]
 	}
-	return ""
+	return strings.Join(strings.Fields(s), " ")
 }
 
 // Accept decodes and validates a candidate name against the slug. It returns the

--- a/internal/companyname/gate_test.go
+++ b/internal/companyname/gate_test.go
@@ -33,6 +33,11 @@ func TestExtractTitleName(t *testing.T) {
 		{"Jobs at Centellic | Centellic Careers", "Centellic"},
 		{"Jobs at AFC Bournemouth | AFC Bournemouth Careers", "AFC Bournemouth"},
 		{"Bath Spa University Careers", "Bath Spa University"},
+		// A non-"Jobs at" lead-in prefix is stripped too.
+		{"Employment Opportunities at BuzzFeed, Inc.", "BuzzFeed, Inc."},
+		{"Careers at Acme", "Acme"},
+		// A trailing " | ..." fragment is dropped and whitespace collapsed.
+		{"AB InBev  | Growth Group Careers", "AB InBev"},
 		{"Just a moment...", ""}, // no recognisable pattern
 		{"Careers", ""},          // strips to empty
 		{"", ""},

--- a/internal/companyname/resolver.go
+++ b/internal/companyname/resolver.go
@@ -12,11 +12,6 @@ type textGetter interface {
 	GetText(ctx context.Context, url string) (string, error)
 }
 
-// jsonGetter decodes a URL's JSON body. Matches sources.JSONGetter.
-type jsonGetter interface {
-	GetJSON(ctx context.Context, url string, v any) error
-}
-
 // Resolver resolves a raw display-name candidate for a board from an ATS's own
 // source. It returns "" (not an error) when the source yields no usable name;
 // an error is reserved for transport failures. The candidate is unvalidated —
@@ -29,16 +24,19 @@ type Resolver interface {
 // alone rather than guessed.
 type Registry map[string]Resolver
 
-// NewRegistry wires the per-ATS resolvers over the shared HTTP getters.
-func NewRegistry(text textGetter, jsonG jsonGetter) Registry {
+// NewRegistry wires the per-ATS resolvers over the shared HTTP getter. Only ATSes
+// whose board is derivable from a job URL are here (see BoardFromURL): the board
+// is the host label (Pinpoint/BambooHR) or first path segment (Lever/Ashby).
+// Greenhouse is intentionally absent — its job URLs are the company's own vanity
+// careers domain (e.g. a16z.com/about/jobs), so no board can be recovered from
+// the URL; resolving it needs a board-from-source-file lookup, a separate seam.
+func NewRegistry(text textGetter) Registry {
 	return Registry{
 		// Careers-page <title> ATSes: same parser, different host template.
 		"pinpoint": newTitleResolver(text, "https://%s.pinpointhq.com"),
 		"bamboohr": newTitleResolver(text, "https://%s.bamboohr.com/careers"),
 		"lever":    newTitleResolver(text, "https://jobs.lever.co/%s"),
 		"ashby":    newTitleResolver(text, "https://jobs.ashbyhq.com/%s"),
-		// API-field ATSes.
-		"greenhouse": newGreenhouseResolver(jsonG),
 	}
 }
 
@@ -63,21 +61,4 @@ func (r *titleResolver) Name(ctx context.Context, board string) (string, error) 
 		return "", nil
 	}
 	return ExtractTitleName(m[1]), nil
-}
-
-type greenhouseResolver struct{ http jsonGetter }
-
-func newGreenhouseResolver(http jsonGetter) *greenhouseResolver {
-	return &greenhouseResolver{http: http}
-}
-
-func (r *greenhouseResolver) Name(ctx context.Context, board string) (string, error) {
-	var resp struct {
-		Name string `json:"name"`
-	}
-	url := fmt.Sprintf("https://boards-api.greenhouse.io/v1/boards/%s/", board)
-	if err := r.http.GetJSON(ctx, url, &resp); err != nil {
-		return "", err
-	}
-	return resp.Name, nil
 }

--- a/internal/companyname/resolver_test.go
+++ b/internal/companyname/resolver_test.go
@@ -2,19 +2,12 @@ package companyname
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 )
 
 type fakeText map[string]string
 
 func (f fakeText) GetText(_ context.Context, url string) (string, error) { return f[url], nil }
-
-type fakeJSON map[string]string // url -> raw JSON body
-
-func (f fakeJSON) GetJSON(_ context.Context, url string, v any) error {
-	return json.Unmarshal([]byte(f[url]), v)
-}
 
 func TestTitleResolver(t *testing.T) {
 	getter := fakeText{
@@ -31,23 +24,16 @@ func TestTitleResolver(t *testing.T) {
 	}
 }
 
-func TestGreenhouseResolver(t *testing.T) {
-	getter := fakeJSON{
-		"https://boards-api.greenhouse.io/v1/boards/acme/": `{"name":"Acme Corp"}`,
-	}
-	r := newGreenhouseResolver(getter)
-	if got, _ := r.Name(context.Background(), "acme"); got != "Acme Corp" {
-		t.Errorf("Name(acme) = %q, want Acme Corp", got)
-	}
-}
-
 func TestRegistryLookup(t *testing.T) {
-	reg := NewRegistry(fakeText{}, fakeJSON{})
-	if _, ok := reg["pinpoint"]; !ok {
-		t.Error("registry missing pinpoint resolver")
+	reg := NewRegistry(fakeText{})
+	for _, src := range []string{"pinpoint", "bamboohr", "lever", "ashby"} {
+		if _, ok := reg[src]; !ok {
+			t.Errorf("registry missing %s resolver", src)
+		}
 	}
-	if _, ok := reg["greenhouse"]; !ok {
-		t.Error("registry missing greenhouse resolver")
+	// Greenhouse job URLs are vanity domains, so it has no URL-derivable board.
+	if _, ok := reg["greenhouse"]; ok {
+		t.Error("registry should not have a greenhouse resolver")
 	}
 	if _, ok := reg["nonexistent-ats"]; ok {
 		t.Error("registry should not have a resolver for an unknown source")


### PR DESCRIPTION
Follow-up to #833, driven by a prod `--dry-run` of `backfill-company-names` (23195 candidates → 271 proposed renames). The dry-run surfaced two defects before any live write:

## 1. Malformed names from unhandled careers-title shapes
`ExtractTitleName` only handled `Jobs at {Name} | …` and a trailing `{Name} Careers`. Two of the 271 came out wrong:
- `buzzfeed → "Employment Opportunities at BuzzFeed, Inc."` (prefix not stripped)
- `abinbev → "AB InBev  | Growth Group"` (stray `| …` + double space)

Fix: generalize the lead-in prefix (`Jobs`/`Careers`/`Employment Opportunities`/`Open roles` `at {Name}`), trim a trailing ` | …` section, and collapse whitespace. New test cases cover both.

## 2. Greenhouse resolver can't work from job URLs
It keyed off `BoardFromURL`, but greenhouse job URLs are the company's own **vanity careers domain** (e.g. `a16z.com/about/jobs/?gh_jid=…`), so the "board" came out as `about`/`en-us`/`openings` → all 404 misses (no bad writes, just noise). Removed the greenhouse resolver + its `BoardFromURL` case. Resolving greenhouse needs a board-from-source-file lookup (the board lives in `sources/greenhouse.yml`, not the URL) — noted as a seam.

## Verification
`go build ./... && go vet ./... && go test -race ./...` green. Supported URL-derivable ATSes remain: Pinpoint, BambooHR, Lever, Ashby.