### PR TITLE
feat(contributions): network fallback resolves vanity-domain careers pages

### DIFF
--- a/internal/boardresolve/boardresolve.go
+++ b/internal/boardresolve/boardresolve.go
@@ -1,0 +1,71 @@
+// Package boardresolve is the network fallback for the paste-a-link contribution flow: when a
+// URL's host is not a recognized ATS (e.g. a company careers page on its own domain with an
+// embedded ATS — company.com/careers?gh_jid=…), it fetches the page and detects the embedded
+// board via internal/atsdetect. It satisfies contribution.Resolver.
+//
+// Only providers whose (provider, board) matches how the ingest pipeline namespaces
+// jobs.external_id are accepted, so the resolved board dedups correctly against the catalogue.
+// The fetch uses the SSRF-guarded sources client (it refuses internal/metadata targets), since
+// the URL is attacker-influenced.
+package boardresolve
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/strelov1/freehire/internal/atsdetect"
+	"github.com/strelov1/freehire/internal/sources"
+)
+
+// trusted lists the providers whose atsdetect (provider, board) equals the ingest
+// external_id namespace, so a resolved board is dedup-correct. Greenhouse/Lever/Ashby/Workable
+// embed the board slug directly (verified against prod external_ids).
+var trusted = map[string]bool{
+	"greenhouse": true,
+	"lever":      true,
+	"ashby":      true,
+	"workable":   true,
+}
+
+// textFetcher is the slice of the sources client this package needs (a raw, SSRF-guarded,
+// size-capped GET). *sources.Client satisfies it.
+type textFetcher interface {
+	GetText(ctx context.Context, url string) (string, error)
+}
+
+// Resolver fetches an unrecognized careers page and detects the embedded ATS board.
+type Resolver struct {
+	http textFetcher
+}
+
+// New builds a Resolver over the default SSRF-guarded sources client.
+func New() *Resolver { return &Resolver{http: sources.NewClient()} }
+
+// Resolve fetches rawURL and detects an embedded ATS board, returning the catalogue
+// (source, board) and a canonical URL to store (query/fragment stripped). ok=false when the
+// fetch fails, no board is detected, or the detected provider is not one we trust to match the
+// ingest namespace.
+func (r *Resolver) Resolve(ctx context.Context, rawURL string) (source, board, canonical string, ok bool) {
+	html, err := r.http.GetText(ctx, rawURL)
+	if err != nil {
+		return "", "", "", false
+	}
+	provider, slug, ok := atsdetect.Detect(html)
+	if !ok || !trusted[provider] || slug == "" {
+		return "", "", "", false
+	}
+	return provider, slug, stripTails(rawURL), true
+}
+
+// stripTails returns rawURL without its query string or fragment (the identifying part of a
+// vanity careers URL is the path; the board itself comes from the page). Falls back to the raw
+// string if it does not parse.
+func stripTails(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}

--- a/internal/boardresolve/boardresolve_test.go
+++ b/internal/boardresolve/boardresolve_test.go
@@ -1,0 +1,64 @@
+package boardresolve
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeFetcher struct {
+	html string
+	err  error
+}
+
+func (f fakeFetcher) GetText(_ context.Context, _ string) (string, error) {
+	return f.html, f.err
+}
+
+func resolver(html string, err error) *Resolver {
+	return &Resolver{http: fakeFetcher{html: html, err: err}}
+}
+
+func TestResolveDetectsGreenhouseEmbed(t *testing.T) {
+	// A vanity careers page embedding Greenhouse — the board is in the embed script's for=.
+	html := `<html><body>
+	  <script src="https://boards.greenhouse.io/embed/job_board/js?for=talkspace"></script>
+	</body></html>`
+	src, board, canon, ok := resolver(html, nil).Resolve(context.Background(),
+		"https://www.talkspace.com/careers/job?gh_jid=6118228004")
+	if !ok {
+		t.Fatal("ok=false, want the embedded greenhouse board detected")
+	}
+	if src != "greenhouse" || board != "talkspace" {
+		t.Errorf("(source, board) = (%q, %q), want (greenhouse, talkspace)", src, board)
+	}
+	if canon != "https://www.talkspace.com/careers/job" {
+		t.Errorf("canonical = %q, want the URL without query/fragment", canon)
+	}
+}
+
+func TestResolveDetectsDirectAshbyLinkOnPage(t *testing.T) {
+	html := `<a href="https://jobs.ashbyhq.com/acme/uuid">Apply</a>`
+	src, board, _, ok := resolver(html, nil).Resolve(context.Background(), "https://acme.io/careers")
+	if !ok || src != "ashby" || board != "acme" {
+		t.Errorf("(%q,%q,%v), want (ashby, acme, true)", src, board, ok)
+	}
+}
+
+func TestResolveRejectsUntrustedProvider(t *testing.T) {
+	// A page that only exposes a Workday link: atsdetect may recognize it, but workday's board
+	// semantics don't match our ingest namespace, so we decline.
+	html := `<a href="https://acme.wd1.myworkdayjobs.com/en-US/careers/job/123">Apply</a>`
+	if _, _, _, ok := resolver(html, nil).Resolve(context.Background(), "https://acme.com/jobs"); ok {
+		t.Error("ok=true for an untrusted provider, want false")
+	}
+}
+
+func TestResolveNoAtsAndFetchError(t *testing.T) {
+	if _, _, _, ok := resolver("<html>no ats here</html>", nil).Resolve(context.Background(), "https://x.com"); ok {
+		t.Error("ok=true for a page with no ATS, want false")
+	}
+	if _, _, _, ok := resolver("", errors.New("boom")).Resolve(context.Background(), "https://x.com"); ok {
+		t.Error("ok=true on fetch error, want false")
+	}
+}

--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -57,41 +57,57 @@ type Repository interface {
 	ListByUser(ctx context.Context, userID int64) ([]Contribution, error)
 }
 
-// Service implements the contribution use cases over a Repository. Board recognition is a
-// pure, network-free URL parse (see board.go).
-type Service struct {
-	repo Repository
+// Resolver is the network fallback for links whose host is not a recognized ATS: it fetches
+// the page and detects an embedded board (a company careers page on its own domain — see
+// internal/boardresolve). Optional — a nil resolver keeps the flow network-free.
+type Resolver interface {
+	Resolve(ctx context.Context, rawURL string) (source, board, canonical string, ok bool)
 }
 
-// New creates a Service backed by the given Repository.
-func New(repo Repository) *Service {
-	return &Service{repo: repo}
+// Service implements the contribution use cases over a Repository. Board recognition is a
+// pure, network-free URL parse (board.go); an optional Resolver adds a network fallback for
+// vanity domains with an embedded ATS.
+type Service struct {
+	repo     Repository
+	resolver Resolver
+}
+
+// New creates a Service backed by the given Repository and an optional network Resolver (nil =
+// network-free recognition only).
+func New(repo Repository, resolver Resolver) *Service {
+	return &Service{repo: repo, resolver: resolver}
 }
 
 // Submit validates and records a contributed board, awarding the submitter a point for a novel
 // one. The checks run cheapest-first: unsupported ATS (422) before any DB read;
 // already-tracked (409) before any write; the record+point transaction last, where a
 // duplicate-board race surfaces as ErrBoardAlreadyContributed (409).
-func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) (Contribution, error) {
+func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) (rec Contribution, source, board string, err error) {
 	source, board, canonical, ok := recognizeBoard(rawURL)
+	if !ok && s.resolver != nil {
+		// Unknown host — the link may be a company careers page with an embedded ATS. Fetch it
+		// and detect the board (network fallback).
+		source, board, canonical, ok = s.resolver.Resolve(ctx, rawURL)
+	}
 	if !ok {
-		return Contribution{}, ErrUnsupportedATS
+		return Contribution{}, "", "", ErrUnsupportedATS
 	}
 
 	tracked, err := s.repo.BoardTracked(ctx, source, board)
 	if err != nil {
-		return Contribution{}, err
+		return Contribution{}, source, board, err
 	}
 	if tracked {
-		return Contribution{}, ErrBoardAlreadyTracked
+		return Contribution{}, source, board, ErrBoardAlreadyTracked
 	}
 
-	return s.repo.Record(ctx, RecordInput{
+	rec, err = s.repo.Record(ctx, RecordInput{
 		SubmittedBy: submittedBy,
 		URL:         canonical,
 		Source:      source,
 		Board:       board,
 	})
+	return rec, source, board, err
 }
 
 // ListMine returns the given user's contributions, newest first.
@@ -99,14 +115,11 @@ func (s *Service) ListMine(ctx context.Context, userID int64) ([]Contribution, e
 	return s.repo.ListByUser(ctx, userID)
 }
 
-// TrackedCompany resolves the company already tracked on the board a link points to — for the
-// "we already cover this" reply, so the caller can link to the company page. ok=false when the
-// link is unrecognized or the board has no resolved company.
-func (s *Service) TrackedCompany(ctx context.Context, rawURL string) (name, slug string, ok bool) {
-	source, board, _, recognized := recognizeBoard(rawURL)
-	if !recognized {
-		return "", "", false
-	}
+// CompanyForBoard resolves the company already tracked on a (source, board) — for the "we
+// already cover this" reply, so the caller can link to the company page. ok=false when the
+// board has no resolved company. The (source, board) come from Submit, so no re-recognition
+// (or re-fetch, for a resolved vanity domain) is needed.
+func (s *Service) CompanyForBoard(ctx context.Context, source, board string) (name, slug string, ok bool) {
 	name, slug, found, err := s.repo.CompanyForBoard(ctx, source, board)
 	if err != nil || !found {
 		return "", "", false

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -42,13 +42,26 @@ func (f *fakeRepo) ListByUser(_ context.Context, _ int64) ([]Contribution, error
 	return f.listByUserRet, nil
 }
 
+// fakeResolver stands in for the network fallback.
+type fakeResolver struct {
+	source, board, canonical string
+	ok                       bool
+	calls                    int
+}
+
+func (r *fakeResolver) Resolve(_ context.Context, _ string) (string, string, string, bool) {
+	r.calls++
+	return r.source, r.board, r.canonical, r.ok
+}
+
+// newService wires the service with a network-free recognizer only (nil resolver).
 func newService(repo Repository) *Service {
-	return New(repo)
+	return New(repo, nil)
 }
 
 func TestSubmitRejectsUnsupportedATS(t *testing.T) {
 	repo := &fakeRepo{}
-	_, err := newService(repo).Submit(context.Background(), 7, "https://example.com/careers/123")
+	_, _, _, err := newService(repo).Submit(context.Background(), 7, "https://example.com/careers/123")
 	if !errors.Is(err, ErrUnsupportedATS) {
 		t.Fatalf("err = %v, want ErrUnsupportedATS", err)
 	}
@@ -59,14 +72,14 @@ func TestSubmitRejectsUnsupportedATS(t *testing.T) {
 
 func TestSubmitRejectsSingleTenantSource(t *testing.T) {
 	// geekjob is a single-tenant aggregator — not a per-company board.
-	_, err := newService(&fakeRepo{}).Submit(context.Background(), 7, "https://geekjob.ru/vacancy/6a1ebb85")
+	_, _, _, err := newService(&fakeRepo{}).Submit(context.Background(), 7, "https://geekjob.ru/vacancy/6a1ebb85")
 	if !errors.Is(err, ErrUnsupportedATS) {
 		t.Fatalf("err = %v, want ErrUnsupportedATS", err)
 	}
 }
 
 func TestSubmitRejectsNonURL(t *testing.T) {
-	_, err := newService(&fakeRepo{}).Submit(context.Background(), 7, "not a url")
+	_, _, _, err := newService(&fakeRepo{}).Submit(context.Background(), 7, "not a url")
 	if !errors.Is(err, ErrUnsupportedATS) {
 		t.Fatalf("err = %v, want ErrUnsupportedATS", err)
 	}
@@ -74,9 +87,14 @@ func TestSubmitRejectsNonURL(t *testing.T) {
 
 func TestSubmitRejectsWhenBoardAlreadyTracked(t *testing.T) {
 	repo := &fakeRepo{boardTracked: true}
-	_, err := newService(repo).Submit(context.Background(), 7, "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7")
+	_, source, board, err := newService(repo).Submit(context.Background(), 7, "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7")
 	if !errors.Is(err, ErrBoardAlreadyTracked) {
 		t.Fatalf("err = %v, want ErrBoardAlreadyTracked", err)
+	}
+	// Submit returns the resolved identity even on the tracked path, so the caller can look up
+	// the company without re-recognizing.
+	if source != "ashby" || board != "blitzy" {
+		t.Errorf("returned (%q,%q), want (ashby, blitzy)", source, board)
 	}
 	if repo.recordCalls != 0 {
 		t.Errorf("recorded %d times, want 0", repo.recordCalls)
@@ -85,7 +103,7 @@ func TestSubmitRejectsWhenBoardAlreadyTracked(t *testing.T) {
 
 func TestSubmitRejectsDuplicateBoard(t *testing.T) {
 	repo := &fakeRepo{recordErr: ErrBoardAlreadyContributed}
-	_, err := newService(repo).Submit(context.Background(), 7, "https://jobs.ashbyhq.com/blitzy")
+	_, _, _, err := newService(repo).Submit(context.Background(), 7, "https://jobs.ashbyhq.com/blitzy")
 	if !errors.Is(err, ErrBoardAlreadyContributed) {
 		t.Fatalf("err = %v, want ErrBoardAlreadyContributed", err)
 	}
@@ -93,11 +111,11 @@ func TestSubmitRejectsDuplicateBoard(t *testing.T) {
 
 func TestSubmitRecordsBoardFromVacancyURL(t *testing.T) {
 	repo := &fakeRepo{}
-	got, err := newService(repo).Submit(context.Background(), 7, "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7?utm=x")
+	got, source, board, err := newService(repo).Submit(context.Background(), 7, "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7?utm=x")
 	if err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
-	if repo.recorded.Source != "ashby" || repo.recorded.Board != "blitzy" {
+	if source != "ashby" || board != "blitzy" || repo.recorded.Source != "ashby" || repo.recorded.Board != "blitzy" {
 		t.Errorf("recorded = (%q,%q), want (ashby, blitzy)", repo.recorded.Source, repo.recorded.Board)
 	}
 	if repo.recorded.URL != "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799-4539-b1c2-78d69ff625e7" {
@@ -106,30 +124,53 @@ func TestSubmitRecordsBoardFromVacancyURL(t *testing.T) {
 	if got.SubmittedBy != 7 {
 		t.Errorf("SubmittedBy = %d, want 7", got.SubmittedBy)
 	}
-	// The board-tracked check must scope to the board namespace, not the whole source.
-	// (Covered implicitly: BoardTracked was called with prefix "blitzy:".)
 }
 
-func TestSubmitRecordsBoardFromListingURL(t *testing.T) {
+func TestSubmitUsesResolverForUnknownHost(t *testing.T) {
+	// A vanity careers page (unknown host): recognizeBoard fails, the resolver detects the
+	// embedded board.
 	repo := &fakeRepo{}
-	_, err := newService(repo).Submit(context.Background(), 7, "https://job-boards.greenhouse.io/acme")
+	res := &fakeResolver{source: "greenhouse", board: "talkspace", canonical: "https://www.talkspace.com/careers/job", ok: true}
+	_, source, board, err := New(repo, res).Submit(context.Background(), 7, "https://www.talkspace.com/careers/job?gh_jid=123")
 	if err != nil {
 		t.Fatalf("Submit: %v", err)
 	}
-	if repo.recorded.Source != "greenhouse" || repo.recorded.Board != "acme" {
-		t.Errorf("recorded = (%q,%q), want (greenhouse, acme)", repo.recorded.Source, repo.recorded.Board)
+	if res.calls != 1 {
+		t.Errorf("resolver called %d times, want 1", res.calls)
+	}
+	if source != "greenhouse" || board != "talkspace" || repo.recorded.Board != "talkspace" {
+		t.Errorf("recorded = (%q,%q), want (greenhouse, talkspace)", repo.recorded.Source, repo.recorded.Board)
+	}
+	if repo.recorded.URL != "https://www.talkspace.com/careers/job" {
+		t.Errorf("stored URL = %q, want the resolver's canonical", repo.recorded.URL)
 	}
 }
 
-func TestTrackedCompanyResolvesFromLink(t *testing.T) {
-	repo := &fakeRepo{companyName: "Acme Corp", companySlug: "acme"}
-	name, slug, ok := newService(repo).TrackedCompany(context.Background(), "https://jobs.ashbyhq.com/blitzy/uuid")
-	if !ok || name != "Acme Corp" || slug != "acme" {
-		t.Errorf("TrackedCompany = (%q,%q,%v), want (Acme Corp, acme, true)", name, slug, ok)
+func TestSubmitSkipsResolverForRecognizedHost(t *testing.T) {
+	// A known ATS host resolves network-free; the resolver must not be called.
+	repo := &fakeRepo{}
+	res := &fakeResolver{ok: true, source: "x", board: "y"}
+	_, _, _, err := New(repo, res).Submit(context.Background(), 7, "https://jobs.ashbyhq.com/blitzy")
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
 	}
-	// An unrecognized link resolves nothing.
-	if _, _, ok := newService(repo).TrackedCompany(context.Background(), "https://example.com/x"); ok {
-		t.Error("TrackedCompany(unknown host) ok = true, want false")
+	if res.calls != 0 {
+		t.Errorf("resolver called %d times for a known host, want 0", res.calls)
+	}
+	if repo.recorded.Source != "ashby" {
+		t.Errorf("recorded source = %q, want ashby (network-free)", repo.recorded.Source)
+	}
+}
+
+func TestCompanyForBoard(t *testing.T) {
+	repo := &fakeRepo{companyName: "Acme Corp", companySlug: "acme"}
+	name, slug, ok := newService(repo).CompanyForBoard(context.Background(), "greenhouse", "acme")
+	if !ok || name != "Acme Corp" || slug != "acme" {
+		t.Errorf("CompanyForBoard = (%q,%q,%v), want (Acme Corp, acme, true)", name, slug, ok)
+	}
+	// No company on the board → not ok.
+	if _, _, ok := newService(&fakeRepo{}).CompanyForBoard(context.Background(), "greenhouse", "empty"); ok {
+		t.Error("CompanyForBoard(no company) ok = true, want false")
 	}
 }
 

--- a/internal/handler/contributions.go
+++ b/internal/handler/contributions.go
@@ -67,13 +67,13 @@ func (a *API) CreateContribution(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
 	}
 
-	rec, err := a.contribution.Submit(c.Context(), userID, in.URL)
+	rec, source, board, err := a.contribution.Submit(c.Context(), userID, in.URL)
 	if err != nil {
 		// On "already tracked", enrich the 409 with the company we cover so the UI can link to
 		// it (and say the exact role will land on the next crawl).
 		if errors.Is(err, contribution.ErrBoardAlreadyTracked) {
 			body := fiber.Map{"error": "this board is already in the catalogue"}
-			if name, slug, ok := a.contribution.TrackedCompany(c.Context(), in.URL); ok {
+			if name, slug, ok := a.contribution.CompanyForBoard(c.Context(), source, board); ok {
 				body["company_name"] = name
 				body["company_slug"] = slug
 			}

--- a/internal/handler/contributions_integration_test.go
+++ b/internal/handler/contributions_integration_test.go
@@ -47,7 +47,7 @@ func TestContributionsEndToEnd(t *testing.T) {
 		pool:         pool,
 		queries:      queries,
 		issuer:       iss,
-		contribution: contribution.New(contribution.NewQueriesRepository(queries, pool)),
+		contribution: contribution.New(contribution.NewQueriesRepository(queries, pool), nil),
 		accounts:     accounts.New(accounts.NewQueriesRepository(queries, pool), authHasher{}),
 	}
 

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/auth/oauth"
 	"github.com/strelov1/freehire/internal/blobstore"
+	"github.com/strelov1/freehire/internal/boardresolve"
 	"github.com/strelov1/freehire/internal/contribution"
 	"github.com/strelov1/freehire/internal/cv"
 	"github.com/strelov1/freehire/internal/db"
@@ -241,8 +242,10 @@ func Register(app *fiber.App, cfg Config) {
 	// submission approval mints through the same moderation service, so derivation,
 	// dedup, and the enrichment enqueue are reused rather than duplicated.
 	a.submission = submission.New(submission.NewQueriesRepository(queries), a.moderation)
-	// Contributions detect the ATS board from the URL alone (network-free, see board.go).
-	a.contribution = contribution.New(contribution.NewQueriesRepository(queries, cfg.Pool))
+	// Contributions detect the ATS board from the URL alone (network-free, board.go), with a
+	// network fallback (boardresolve) that fetches a company careers page and detects an
+	// embedded ATS — so vanity-domain links (company.com/careers?gh_jid=…) resolve too.
+	a.contribution = contribution.New(contribution.NewQueriesRepository(queries, cfg.Pool), boardresolve.New())
 	// The report queue uses one QueriesRepository for both persistence and the
 	// job soft-close (it implements report.Repository and report.JobCloser).
 	reportRepo := report.NewQueriesRepository(queries)

--- a/internal/handler/telegram.go
+++ b/internal/handler/telegram.go
@@ -135,8 +135,8 @@ func (a *API) sendTelegram(ctx context.Context, chatID int64, msg string) {
 
 // alreadyTrackedReply is the "we already cover this" message, linking to the company page when
 // the board resolves to a tracked company; otherwise a plain acknowledgement.
-func (a *API) alreadyTrackedReply(ctx context.Context, rawURL string) string {
-	name, slug, ok := a.contribution.TrackedCompany(ctx, rawURL)
+func (a *API) alreadyTrackedReply(ctx context.Context, source, board string) string {
+	name, slug, ok := a.contribution.CompanyForBoard(ctx, source, board)
 	if !ok || slug == "" || a.frontendOrigin == "" {
 		return "👍 We already track that board — nothing to add."
 	}
@@ -189,12 +189,12 @@ func (a *API) processTelegramContribution(chatID int64, rawURL string) {
 		return
 	}
 
-	rec, err := a.contribution.Submit(ctx, userID, rawURL)
+	rec, source, board, err := a.contribution.Submit(ctx, userID, rawURL)
 	switch {
 	case errors.Is(err, contribution.ErrUnsupportedATS):
 		a.sendTelegram(ctx, chatID, "🤔 That link isn't from a supported ATS board. Send a link from a company's careers page on a supported ATS (Greenhouse, Lever, Ashby, Recruitee, BambooHR, SmartRecruiters, and many more).")
 	case errors.Is(err, contribution.ErrBoardAlreadyTracked):
-		a.sendTelegram(ctx, chatID, a.alreadyTrackedReply(ctx, rawURL))
+		a.sendTelegram(ctx, chatID, a.alreadyTrackedReply(ctx, source, board))
 	case errors.Is(err, contribution.ErrBoardAlreadyContributed):
 		a.sendTelegram(ctx, chatID, "✅ That board was already contributed — no new point, but thanks!")
 	case err != nil:

--- a/internal/handler/telegram_contribution_integration_test.go
+++ b/internal/handler/telegram_contribution_integration_test.go
@@ -78,7 +78,7 @@ func TestTelegramContribution(t *testing.T) {
 		telegramLinks:         telegramnotify.NewLinkTokens("test-secret", 10*time.Minute),
 		telegramBot:           telegramnotify.NewClientWithBase("bottoken", stub.URL),
 		telegramWebhookSecret: "hook-secret",
-		contribution:          contribution.New(contribution.NewQueriesRepository(queries, pool)),
+		contribution:          contribution.New(contribution.NewQueriesRepository(queries, pool), nil),
 	}
 
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})


### PR DESCRIPTION
Reported: `talkspace.com/careers/job?gh_jid=…` and `sumup.com/careers/.../8578073002/` returned 422. These are the **most common** real-world careers URLs — a company's own domain with an **embedded ATS**, where the board token isn't in the URL (only the ATS job id).

## Fix
New `internal/boardresolve`: for an unrecognized host, fetch the page (SSRF-guarded `sources` client, 2 MiB cap) and detect the embedded ATS board via the existing `internal/atsdetect` (greenhouse `embed…for=<board>`, plus lever/ashby links on the page). So `company.com/careers` resolves to its real greenhouse/lever/ashby board.

- **Only greenhouse/lever/ashby/workable are trusted** — their `(provider, board)` matches how ingest namespaces `external_id`, so the resolved board dedups correctly. Anything else (e.g. a workday link) is declined → still 422 (fail-safe).
- Wired as an **optional** `Resolver` on the Service (nil = network-free); known ATS hosts stay fast/sync and never fetch.
- `Submit` now returns the recognized `(source, board)`, so the already-tracked reply links to the company **without a second fetch**.

## Notes / tradeoffs
- The fallback fetches user-supplied URLs (auth-gated, SSRF-guarded, bounded). A mild amplification vector, acceptable for now.
- On the web path the fetch adds latency only on the fallback (unknown host).

Unit-tested (embed detection, untrusted-provider rejection, service fallback + skip-for-known-host); existing integration suite green. Code-only, no schema change.