### PR TITLE
feat(contributions): resolve server-side vanity pages by Greenhouse job id

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -2,6 +2,7 @@ package contribution
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -145,6 +146,38 @@ func subdomainLabel(host, apex string) string {
 		return sub[:i]
 	}
 	return sub
+}
+
+// ghNumericID matches a Greenhouse-style numeric job id.
+var ghNumericID = regexp.MustCompile(`^[0-9]{7,12}$`)
+
+// greenhouseJobID extracts a Greenhouse job id from a link that carries one but no board token:
+// the gh_jid query param (Greenhouse's embed param, e.g. company.com/careers?gh_jid=123), or a
+// trailing all-numeric path segment (company.com/careers/…/<id>/). ok=false when neither is
+// present. A non-Greenhouse id won't be found downstream, so a false positive is harmless.
+func greenhouseJobID(rawURL string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	if id := u.Query().Get("gh_jid"); ghNumericID.MatchString(id) {
+		return id, true
+	}
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if last := segs[len(segs)-1]; ghNumericID.MatchString(last) {
+		return last, true
+	}
+	return "", false
+}
+
+// stripQueryFragment returns rawURL without its query or fragment; the raw string on parse error.
+func stripQueryFragment(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.RawQuery, u.Fragment = "", ""
+	return u.String()
 }
 
 // hostname is u's lowercased hostname with a leading "www." stripped.

--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -53,6 +53,7 @@ type RecordInput struct {
 type Repository interface {
 	BoardTracked(ctx context.Context, source, board string) (bool, error)
 	CompanyForBoard(ctx context.Context, source, board string) (name, slug string, ok bool, err error)
+	BoardByGreenhouseJobID(ctx context.Context, jobID string) (board string, ok bool, err error)
 	Record(ctx context.Context, in RecordInput) (Contribution, error)
 	ListByUser(ctx context.Context, userID int64) ([]Contribution, error)
 }
@@ -88,6 +89,15 @@ func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) 
 		// Unknown host — the link may be a company careers page with an embedded ATS. Fetch it
 		// and detect the board (network fallback).
 		source, board, canonical, ok = s.resolver.Resolve(ctx, rawURL)
+	}
+	if !ok {
+		// Server-side embeds expose only the Greenhouse job id (no board token in URL or page).
+		// Find the board by that id — only resolves boards we already track (network-free).
+		if id, has := greenhouseJobID(rawURL); has {
+			if b, found, err := s.repo.BoardByGreenhouseJobID(ctx, id); err == nil && found {
+				source, board, canonical, ok = "greenhouse", b, stripQueryFragment(rawURL), true
+			}
+		}
 	}
 	if !ok {
 		return Contribution{}, "", "", ErrUnsupportedATS

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -16,6 +16,7 @@ type fakeRepo struct {
 	listByUserRet []Contribution
 	companyName   string
 	companySlug   string
+	jobIDBoard    string // BoardByGreenhouseJobID returns this (ok when non-empty)
 }
 
 func (f *fakeRepo) BoardTracked(_ context.Context, _, _ string) (bool, error) {
@@ -24,6 +25,10 @@ func (f *fakeRepo) BoardTracked(_ context.Context, _, _ string) (bool, error) {
 
 func (f *fakeRepo) CompanyForBoard(_ context.Context, _, _ string) (string, string, bool, error) {
 	return f.companyName, f.companySlug, f.companyName != "" || f.companySlug != "", nil
+}
+
+func (f *fakeRepo) BoardByGreenhouseJobID(_ context.Context, _ string) (string, bool, error) {
+	return f.jobIDBoard, f.jobIDBoard != "", nil
 }
 
 func (f *fakeRepo) Record(_ context.Context, in RecordInput) (Contribution, error) {
@@ -159,6 +164,29 @@ func TestSubmitSkipsResolverForRecognizedHost(t *testing.T) {
 	}
 	if repo.recorded.Source != "ashby" {
 		t.Errorf("recorded source = %q, want ashby (network-free)", repo.recorded.Source)
+	}
+}
+
+func TestSubmitResolvesGreenhouseJobIDForServerSideVanity(t *testing.T) {
+	// A company careers page that exposes only the Greenhouse job id (gh_jid or a trailing
+	// numeric path segment) — no host or embed. The job-id lookup finds the tracked board.
+	repo := &fakeRepo{jobIDBoard: "sumup", boardTracked: true}
+	cases := []string{
+		"https://www.sumup.com/careers/positions/x/8578073002/?city=Brazil",
+		"https://www.talkspace.com/careers/job?gh_jid=6118228004",
+	}
+	for _, raw := range cases {
+		_, source, board, err := New(repo, nil).Submit(context.Background(), 7, raw)
+		if !errors.Is(err, ErrBoardAlreadyTracked) {
+			t.Errorf("Submit(%q) err = %v, want ErrBoardAlreadyTracked", raw, err)
+		}
+		if source != "greenhouse" || board != "sumup" {
+			t.Errorf("Submit(%q) = (%q,%q), want (greenhouse, sumup)", raw, source, board)
+		}
+	}
+	// No id in the URL → not resolved.
+	if _, _, _, err := New(repo, nil).Submit(context.Background(), 7, "https://example.com/careers/about"); !errors.Is(err, ErrUnsupportedATS) {
+		t.Errorf("err = %v, want ErrUnsupportedATS for a URL with no job id", err)
 	}
 }
 

--- a/internal/contribution/repository.go
+++ b/internal/contribution/repository.go
@@ -36,6 +36,19 @@ func (r *QueriesRepository) BoardTracked(ctx context.Context, source, board stri
 	return r.q.JobsExistForBoard(ctx, db.JobsExistForBoardParams{Source: source, BoardPattern: likePrefix(board)})
 }
 
+// BoardByGreenhouseJobID returns the greenhouse board already carrying a job with the given
+// Greenhouse job id, or ok=false when none is tracked.
+func (r *QueriesRepository) BoardByGreenhouseJobID(ctx context.Context, jobID string) (board string, ok bool, err error) {
+	board, err = r.q.BoardByGreenhouseJobID(ctx, jobID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return board, true, nil
+}
+
 // CompanyForBoard returns the company name + slug already tracked on the board, or ok=false
 // when the board has no job with a resolved company.
 func (r *QueriesRepository) CompanyForBoard(ctx context.Context, source, board string) (name, slug string, ok bool, err error) {

--- a/internal/db/link_contributions.sql.go
+++ b/internal/db/link_contributions.sql.go
@@ -9,6 +9,24 @@ import (
 	"context"
 )
 
+const boardByGreenhouseJobID = `-- name: BoardByGreenhouseJobID :one
+SELECT split_part(external_id, ':', 1) AS board
+FROM jobs
+WHERE source = 'greenhouse' AND split_part(external_id, ':', 2) = $1
+LIMIT 1
+`
+
+// Find the greenhouse board already carrying a job with this Greenhouse job id — for links on
+// a company's own domain that expose only the ATS job id (server-side embeds, no board token
+// in the URL/page). external_id is "<board>:<id>"; served by the
+// (split_part(external_id,':',2)) WHERE source='greenhouse' partial index.
+func (q *Queries) BoardByGreenhouseJobID(ctx context.Context, jobID string) (string, error) {
+	row := q.db.QueryRow(ctx, boardByGreenhouseJobID, jobID)
+	var board string
+	err := row.Scan(&board)
+	return board, err
+}
+
 const companyForBoard = `-- name: CompanyForBoard :one
 SELECT company, company_slug FROM jobs
 WHERE source = $1 AND external_id LIKE $2 AND company_slug <> ''

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -18,6 +18,11 @@ type Querier interface {
 	// expiry and touching last_used_at in one atomic statement. No row means the key is
 	// unknown, revoked, or expired; the caller treats pgx.ErrNoRows as 401.
 	AuthenticateAPIKey(ctx context.Context, tokenHash string) (int64, error)
+	// Find the greenhouse board already carrying a job with this Greenhouse job id — for links on
+	// a company's own domain that expose only the ATS job id (server-side embeds, no board token
+	// in the URL/page). external_id is "<board>:<id>"; served by the
+	// (split_part(external_id,':',2)) WHERE source='greenhouse' partial index.
+	BoardByGreenhouseJobID(ctx context.Context, jobID string) (string, error)
 	// Claim a wave of live, unleased entries by stamping claimed_at, newest email first,
 	// returning the email fields the matcher/classifier need. FOR UPDATE OF o locks only
 	// outbox rows; SKIP LOCKED lets concurrent workers take disjoint rows; the lease

--- a/internal/db/queries/link_contributions.sql
+++ b/internal/db/queries/link_contributions.sql
@@ -16,6 +16,16 @@ SELECT EXISTS (
     SELECT 1 FROM jobs WHERE source = sqlc.arg(source) AND external_id LIKE sqlc.arg(board_pattern)
 ) AS exists;
 
+-- name: BoardByGreenhouseJobID :one
+-- Find the greenhouse board already carrying a job with this Greenhouse job id — for links on
+-- a company's own domain that expose only the ATS job id (server-side embeds, no board token
+-- in the URL/page). external_id is "<board>:<id>"; served by the
+-- (split_part(external_id,':',2)) WHERE source='greenhouse' partial index.
+SELECT split_part(external_id, ':', 1) AS board
+FROM jobs
+WHERE source = 'greenhouse' AND split_part(external_id, ':', 2) = sqlc.arg(job_id)
+LIMIT 1;
+
 -- name: CompanyForBoard :one
 -- The tracked company on a board — for the "already tracked" reply: a job's company name and
 -- slug so the bot/UI can link to /companies/<slug>. board_pattern is "<escaped board>:%" (same

--- a/migrations/0027_jobs_greenhouse_jobid_idx.sql
+++ b/migrations/0027_jobs_greenhouse_jobid_idx.sql
@@ -1,0 +1,15 @@
+-- A partial index for the greenhouse job-id lookup in link contributions
+-- (internal/contribution). Many companies embed Greenhouse on their own careers domain
+-- server-side (company.com/careers/…/<gh_id>/), so the board token never appears in the URL
+-- or page — only the Greenhouse job id. external_id is "<board>:<id>", so we find the board by
+-- the id component: split_part(external_id, ':', 2) = '<gh_id>'.
+--
+-- Partial on source='greenhouse' (numeric ids are Greenhouse's; other ATS use UUIDs), so the
+-- index is small (~greenhouse rows only). The expression must match the query's exactly
+-- (literal ':', not chr(58)) for the planner to use it.
+--
+-- On a fresh initdb volume this plain CREATE INDEX is fine; on the live prod DB it was applied
+-- manually as CREATE INDEX CONCURRENTLY.
+CREATE INDEX jobs_greenhouse_jobid_idx
+    ON public.jobs (split_part(external_id, ':', 2))
+    WHERE source = 'greenhouse';


### PR DESCRIPTION
Follow-up to the page-scrape fallback (#841). Reported: `sumup.com/careers/.../8578073002/` still returned 422.

**Why #841 missed it:** SumUp embeds Greenhouse **server-side** — the fetched HTML has only `"type":"greenhouse"` + the job id, **no board token** (`sumup`). So `atsdetect` finds nothing. (Talkspace works because it uses the client-side embed script `…/embed/job_board/js?for=talkspace`.)

**Fix:** a third resolve step — extract the Greenhouse job id (`gh_jid=` param or a trailing numeric path segment) and look up which board already carries it (`split_part(external_id,':',2)`, source='greenhouse'). Both reported URLs resolve → "already tracked → here's the company" reply.

- **Only resolves boards we already track** (the job must be in the catalogue). A *new* server-side board still can't be derived from a URL — that's inherent (the token exists nowhere in the link or page).
- Served by a new **partial index** `jobs_greenhouse_jobid_idx` (greenhouse rows only) — migration 0027, applied to prod as CREATE INDEX CONCURRENTLY.
- A non-Greenhouse trailing number simply isn't found (fail-safe).

Unit-tested (gh_jid + path-segment extraction, both example URLs, no-id case). ⚠️ Deploy after the prod index is valid.