### PR TITLE
feat(contributions): recognize Workday boards (host + site)

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -11,20 +11,24 @@ import (
 //   - subdomain: board = the leftmost DNS label under a fixed apex (<board>.recruitee.com).
 //   - host:      board = the whole careers host (the tenant identity IS the host, and the TLD
 //     varies by region, e.g. <tenant>.zohorecruit.eu / .com / .in).
+//   - hostpath:  board = "<host>/<first path segment>" (Workday: the tenant is the host, the
+//     site is the first path segment, e.g. acme.wd1.myworkdayjobs.com/Careers).
 //
-// For subdomain and host the board IS the host, so the canonical URL is the bare scheme://host —
-// collapsing a vacancy URL and the board listing to one board.
+// For subdomain and host the board IS the host; for hostpath it is host + site. In all three the
+// canonical URL is stripped to that board, collapsing a vacancy URL and the board listing to one.
 const (
 	modePath      = "path"
 	modeSubdomain = "subdomain"
 	modeHost      = "host"
+	modeHostPath  = "hostpath"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
 // its source key and extraction mode. Hosts were verified against each adapter's public job
 // URL. A wrong/missing entry is fail-safe: the link simply isn't recognized (422), never a
-// false board. Single-company brands, aggregators, and vanity-domain ATS (Workday/Taleo/
-// SuccessFactors/Oracle/…) are deliberately absent — their board can't be derived from a URL.
+// false board. Single-company brands, aggregators, and custom-domain ATS (Taleo, SuccessFactors,
+// Oracle, and Workday tenants on their own domain) are absent — their board can't be derived
+// from a URL. Workday's standard *.myworkdayjobs.com hosts ARE derivable (host + site).
 var atsBoards = []struct{ host, source, mode string }{
 	// --- path: board = first path segment on a fixed host ---
 	{"greenhouse.io", "greenhouse", modePath},
@@ -72,6 +76,9 @@ var atsBoards = []struct{ host, source, mode string }{
 
 	// --- host: board = the whole careers host (regional TLD varies) ---
 	{"zohorecruit", "zohorecruit", modeHost},
+
+	// --- hostpath: board = "<host>/<site>" (Workday tenant host + first-path-segment site) ---
+	{"myworkdayjobs.com", "workday", modeHostPath},
 }
 
 // recognizeBoard parses a pasted job link into the company board it belongs to: the source
@@ -102,6 +109,17 @@ func recognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 		// URL and the board listing to one board.
 		u.RawQuery, u.Fragment, u.Path = "", "", ""
 		return src, board, u.String(), true
+
+	case modeHostPath:
+		// Workday: board = "<host>/<site>" where site is the first path segment (case-preserved,
+		// as the ingest stores it). Canonical strips to scheme://host/site.
+		site := firstPathSegment(u)
+		if site == "" {
+			return "", "", "", false // bare host, no site
+		}
+		u.RawQuery, u.Fragment = "", ""
+		u.Path = "/" + site
+		return src, host + "/" + site, u.String(), true
 	}
 
 	// modePath: the board is the first path segment.

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -37,7 +37,13 @@ func TestRecognizeBoard(t *testing.T) {
 		{"jazzhr applytojob", "https://acme.applytojob.com/apply/abc", "jazzhr", "acme", "https://acme.applytojob.com", true},
 		{"trakstar nested apex", "https://acme.hire.trakstar.com/x", "trakstar", "acme", "https://acme.hire.trakstar.com", true},
 
+		// host+path mode — Workday: board is "<host>/<site>" (site case preserved)
+		{"workday vacancy", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM/job/Austin/Senior-Software-Engineer_JR-202614238", "workday", "generalmotors.wd5.myworkdayjobs.com/Careers_GM", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM", true},
+		{"workday board listing", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM", "workday", "generalmotors.wd5.myworkdayjobs.com/Careers_GM", "https://generalmotors.wd5.myworkdayjobs.com/Careers_GM", true},
+		{"workday other pod", "https://goodyear.wd1.myworkdayjobs.com/goodyearcareers/job/x", "workday", "goodyear.wd1.myworkdayjobs.com/goodyearcareers", "https://goodyear.wd1.myworkdayjobs.com/goodyearcareers", true},
+
 		// declined
+		{"workday bare host no site", "https://generalmotors.wd5.myworkdayjobs.com", "", "", "", false},
 		{"ashby bare host no board", "https://jobs.ashbyhq.com", "", "", "", false},
 		{"recruitee bare apex no tenant", "https://recruitee.com/", "", "", "", false},
 		{"personio bare apex no tenant", "https://jobs.personio.com", "", "", "", false},
@@ -73,6 +79,8 @@ func TestVacancyAndListingSameBoard(t *testing.T) {
 		// subdomain
 		{"https://acme.recruitee.com/o/senior-go", "https://acme.recruitee.com"},
 		{"https://acme.bamboohr.com/careers/42/detail", "https://acme.bamboohr.com/careers/list"},
+		// host+path (Workday): a vacancy and the site landing collapse to one board
+		{"https://gm.wd5.myworkdayjobs.com/Careers_GM/job/x/Eng_JR-1", "https://gm.wd5.myworkdayjobs.com/Careers_GM"},
 	}
 	for _, p := range pairs {
 		sa, ba, _, oka := recognizeBoard(p[0])


### PR DESCRIPTION
Reported: `generalmotors.wd5.myworkdayjobs.com/Careers_GM/job/…` returned 422.

Workday sites are `<tenant>.wd<N>.myworkdayjobs.com/<site>/…` and the ingest namespaces the board as **`<host>/<site>`** (e.g. `generalmotors.wd5.myworkdayjobs.com/Careers_GM`, verified on prod — GM is tracked as `general-motors`). So the board **is** derivable from the URL; the audit was over-conservative marking Workday non-recognizable.

**Fix:** a `hostpath` mode — board = `<host>/<first path segment>`, site case preserved (`Careers_GM`, `external_careers`, …). Vacancy and site-landing collapse to one board.

- Board-tracked check reuses the existing `(source, external_id text_pattern_ops)` index — **1.6 ms** on prod (the escaped `_` in a site name stays a literal in the range scan).
- Custom Workday domains (tenants on their own domain, not `*.myworkdayjobs.com`) stay out of scope — no fixed apex.
- No schema change.

Unit-tested (vacancy, site listing, other pod, bare-host rejection, vacancy/listing collapse).