### PR TITLE
feat(cv): autostart tailoring agent + tidy CTA icon

### DIFF
--- a/web/src/routes/jobs/[slug]/fit/+page.svelte
+++ b/web/src/routes/jobs/[slug]/fit/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { goto } from '$app/navigation';
-  import { ArrowLeft, Sparkles } from '@lucide/svelte';
+  import { ArrowLeft, SquarePen } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { createSession } from '$lib/assistant/api';
   import { currentUser } from '$lib/auth.svelte';
@@ -37,7 +37,10 @@
         cv_id: res.tailor_cv_id,
         base_cv_id: res.base_cv_id,
       });
-      await goto(`/my/assistant?session=${sessionId}`);
+      // Pass a first prompt so the agent starts working on arrival instead of waiting for the
+      // user to type — the assistant page auto-sends it into the fresh session.
+      const kickoff = "Let's tailor my CV for this role — review the fit analysis and walk me through the gaps.";
+      await goto(`/my/assistant?session=${sessionId}&prompt=${encodeURIComponent(kickoff)}`);
     } catch (e) {
       tailorError =
         e instanceof ApiError ? e.message : 'Could not start tailoring. Please try again.';
@@ -74,7 +77,7 @@
     >
       <div class="flex flex-col gap-1">
         <h2 class="flex items-center gap-2 text-sm font-semibold">
-          <Sparkles class="size-4 text-primary" />Tailor your CV to this role
+          <SquarePen class="size-4 text-primary" />Tailor your CV to this role
         </h2>
         <p class="text-sm text-muted-foreground">
           Create a copy of your CV reframed toward this vacancy — starting from the gaps this

--- a/web/src/routes/my/assistant/+page.svelte
+++ b/web/src/routes/my/assistant/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, tick } from 'svelte';
+  import { replaceState } from '$app/navigation';
   import { Marked } from 'marked';
   import DOMPurify from 'isomorphic-dompurify';
   import {
@@ -287,6 +288,18 @@
         await createAndOpen();
       }
       phase = 'ready';
+
+      // Autostart: a CTA (e.g. CV tailoring) can pass a first prompt via ?prompt so the agent
+      // begins immediately instead of waiting for the user to type. Only fire on a fresh
+      // (empty) session — on a refresh the kickoff and its reply are already in the journal,
+      // so chat is non-empty and we never re-send.
+      const kickoff = new URLSearchParams(location.search).get('prompt');
+      if (requested && kickoff && chat.messages.length === 0) {
+        // Drop ?prompt from the URL first: a refresh replays the journal asynchronously, so
+        // chat is momentarily empty again — without this the kickoff would re-send.
+        replaceState(`${location.pathname}?session=${requested}`, {});
+        await dispatch(kickoff);
+      }
     } catch (err) {
       error = err instanceof Error ? err.message : 'Could not reach the agent backend.';
       teardown();


### PR DESCRIPTION
Two fixes from testing the live CTA:

- **Autostart** — the fit CTA now passes a first prompt via ?prompt, and the assistant page auto-sends it into the fresh session so the agent starts working on arrival instead of waiting for the user to type. The prompt is stripped from the URL after firing so a refresh (async journal replay ⇒ momentarily-empty chat) never re-sends it.
- **Icon** — swap the sparkle/star icon on the 'Tailor your CV' card for a neutral SquarePen (edit) icon.