### PR TITLE
feat(contributions): log unrecognized links for manual triage

### DIFF
--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -10,6 +10,8 @@ package contribution
 import (
 	"context"
 	"errors"
+	"log"
+	"net/url"
 	"time"
 )
 
@@ -100,6 +102,9 @@ func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) 
 		}
 	}
 	if !ok {
+		// Log an unrecognized-but-plausible link (a valid http(s) URL) so a maintainer can
+		// review the feed and add support for a missed ATS. Garbage (non-URLs) is skipped.
+		logUnrecognized(submittedBy, rawURL)
 		return Contribution{}, "", "", ErrUnsupportedATS
 	}
 
@@ -123,6 +128,17 @@ func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) 
 // ListMine returns the given user's contributions, newest first.
 func (s *Service) ListMine(ctx context.Context, userID int64) ([]Contribution, error) {
 	return s.repo.ListByUser(ctx, userID)
+}
+
+// logUnrecognized emits a log line for a rejected link that parses as an http(s) URL — a
+// review feed for missed ATS. Grep prod for "contribution: unrecognized". Non-URL garbage is
+// skipped so the feed stays signal.
+func logUnrecognized(submittedBy int64, rawURL string) {
+	u, err := url.Parse(rawURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return
+	}
+	log.Printf("contribution: unrecognized link (user=%d): %s", submittedBy, rawURL)
 }
 
 // CompanyForBoard resolves the company already tracked on a (source, board) — for the "we

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -1,8 +1,12 @@
 package contribution
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -199,6 +203,25 @@ func TestCompanyForBoard(t *testing.T) {
 	// No company on the board → not ok.
 	if _, _, ok := newService(&fakeRepo{}).CompanyForBoard(context.Background(), "greenhouse", "empty"); ok {
 		t.Error("CompanyForBoard(no company) ok = true, want false")
+	}
+}
+
+func TestSubmitLogsUnrecognizedURLsOnly(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	svc := New(&fakeRepo{}, nil)
+	// A valid http(s) URL that resolves to nothing is logged for review.
+	_, _, _, _ = svc.Submit(context.Background(), 42, "https://acme.io/careers/some-role")
+	if !strings.Contains(buf.String(), "unrecognized link (user=42): https://acme.io/careers/some-role") {
+		t.Errorf("log = %q, want the unrecognized http link logged", buf.String())
+	}
+	// Garbage (not a URL) is not logged — the feed stays signal.
+	buf.Reset()
+	_, _, _, _ = svc.Submit(context.Background(), 42, "not a url")
+	if buf.Len() != 0 {
+		t.Errorf("log = %q, want nothing for non-URL garbage", buf.String())
 	}
 }
 


### PR DESCRIPTION
Requested: when a contributed link isn't recognized, log it so a maintainer can review and add support manually.

Emits one log line in `Service.Submit` (covers web + Telegram) when all resolve strategies miss — only for valid http(s) URLs, so non-URL garbage stays out of the feed.

```
contribution: unrecognized link (user=42): https://acme.io/careers/some-role
```

Grep prod: `journalctl -u freehire-api@<color> | grep 'contribution: unrecognized'`.

Note: logs rotate — if you want a durable, queryable "to-triage" queue (URL + user + date + status), that's a small table as a follow-up. Unit-tested (http logged, garbage skipped). No schema change.