### PR TITLE
feat(open): CV / fit-check / saved-search counts on the engagement panel

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -354,10 +354,14 @@ type Querier interface {
 	// distinct row type and breaks the company-detail handler on every new column.
 	GetCompany(ctx context.Context, slug string) (Company, error)
 	GetEmail(ctx context.Context, arg GetEmailParams) (GetEmailRow, error)
-	// Aggregate interaction counts from user_jobs — saved / applied / viewed — for the
-	// public engagement endpoint. Aggregate-only: no user identifier or row-level field
-	// is selected. viewed_at is NOT NULL on every row (set on RecordView), so "viewed"
-	// equals the total interaction count.
+	// Aggregate interaction counts for the public engagement endpoint. Aggregate-only:
+	// every column is a scalar total, so no user identifier or row-level field is
+	// selected. The user_jobs counts (saved / applied / viewed) are interaction-row
+	// totals across all users — viewed_at is NOT NULL on every row (set on RecordView),
+	// so "viewed" equals the total interaction count. The remaining three mirror that
+	// event-total semantics from their own tables: cvs_uploaded is the count of users
+	// holding a stored résumé (one per user, so also a people count), fit_checks is
+	// every job-fit analysis ever run, and saved_searches is every saved search.
 	GetEngagementStats(ctx context.Context) (GetEngagementStatsRow, error)
 	GetGmailConnection(ctx context.Context, userID int64) (GetGmailConnectionRow, error)
 	GetGmailRefreshToken(ctx context.Context, userID int64) (GetGmailRefreshTokenRow, error)

--- a/internal/db/queries/stats.sql
+++ b/internal/db/queries/stats.sql
@@ -55,14 +55,21 @@ LEFT JOIN daily ON daily.day = d::date
 ORDER BY d;
 
 -- name: GetEngagementStats :one
--- Aggregate interaction counts from user_jobs — saved / applied / viewed — for the
--- public engagement endpoint. Aggregate-only: no user identifier or row-level field
--- is selected. viewed_at is NOT NULL on every row (set on RecordView), so "viewed"
--- equals the total interaction count.
+-- Aggregate interaction counts for the public engagement endpoint. Aggregate-only:
+-- every column is a scalar total, so no user identifier or row-level field is
+-- selected. The user_jobs counts (saved / applied / viewed) are interaction-row
+-- totals across all users — viewed_at is NOT NULL on every row (set on RecordView),
+-- so "viewed" equals the total interaction count. The remaining three mirror that
+-- event-total semantics from their own tables: cvs_uploaded is the count of users
+-- holding a stored résumé (one per user, so also a people count), fit_checks is
+-- every job-fit analysis ever run, and saved_searches is every saved search.
 SELECT
     count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
     count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
-    count(*) FILTER (WHERE viewed_at IS NOT NULL)::int  AS viewed
+    count(*) FILTER (WHERE viewed_at IS NOT NULL)::int  AS viewed,
+    (SELECT count(*) FROM users WHERE resume_object_key IS NOT NULL)::int AS cvs_uploaded,
+    (SELECT count(*) FROM user_job_analysis)::int AS fit_checks,
+    (SELECT count(*) FROM saved_searches)::int AS saved_searches
 FROM user_jobs;
 
 -- name: ListJobActivity :many

--- a/internal/db/stats.sql.go
+++ b/internal/db/stats.sql.go
@@ -28,24 +28,41 @@ const getEngagementStats = `-- name: GetEngagementStats :one
 SELECT
     count(*) FILTER (WHERE saved_at IS NOT NULL)::int   AS saved,
     count(*) FILTER (WHERE applied_at IS NOT NULL)::int AS applied,
-    count(*) FILTER (WHERE viewed_at IS NOT NULL)::int  AS viewed
+    count(*) FILTER (WHERE viewed_at IS NOT NULL)::int  AS viewed,
+    (SELECT count(*) FROM users WHERE resume_object_key IS NOT NULL)::int AS cvs_uploaded,
+    (SELECT count(*) FROM user_job_analysis)::int AS fit_checks,
+    (SELECT count(*) FROM saved_searches)::int AS saved_searches
 FROM user_jobs
 `
 
 type GetEngagementStatsRow struct {
-	Saved   int32 `json:"saved"`
-	Applied int32 `json:"applied"`
-	Viewed  int32 `json:"viewed"`
+	Saved         int32 `json:"saved"`
+	Applied       int32 `json:"applied"`
+	Viewed        int32 `json:"viewed"`
+	CvsUploaded   int32 `json:"cvs_uploaded"`
+	FitChecks     int32 `json:"fit_checks"`
+	SavedSearches int32 `json:"saved_searches"`
 }
 
-// Aggregate interaction counts from user_jobs — saved / applied / viewed — for the
-// public engagement endpoint. Aggregate-only: no user identifier or row-level field
-// is selected. viewed_at is NOT NULL on every row (set on RecordView), so "viewed"
-// equals the total interaction count.
+// Aggregate interaction counts for the public engagement endpoint. Aggregate-only:
+// every column is a scalar total, so no user identifier or row-level field is
+// selected. The user_jobs counts (saved / applied / viewed) are interaction-row
+// totals across all users — viewed_at is NOT NULL on every row (set on RecordView),
+// so "viewed" equals the total interaction count. The remaining three mirror that
+// event-total semantics from their own tables: cvs_uploaded is the count of users
+// holding a stored résumé (one per user, so also a people count), fit_checks is
+// every job-fit analysis ever run, and saved_searches is every saved search.
 func (q *Queries) GetEngagementStats(ctx context.Context) (GetEngagementStatsRow, error) {
 	row := q.db.QueryRow(ctx, getEngagementStats)
 	var i GetEngagementStatsRow
-	err := row.Scan(&i.Saved, &i.Applied, &i.Viewed)
+	err := row.Scan(
+		&i.Saved,
+		&i.Applied,
+		&i.Viewed,
+		&i.CvsUploaded,
+		&i.FitChecks,
+		&i.SavedSearches,
+	)
 	return i, err
 }
 

--- a/internal/handler/engagement_integration_test.go
+++ b/internal/handler/engagement_integration_test.go
@@ -1,9 +1,10 @@
 //go:build integration
 
-// Integration test for the engagement-stats read endpoint. The counts are a pure
-// aggregate over user_jobs and the handler reads through a concrete *db.Queries,
-// so it can only be exercised against a real Postgres. It asserts the empty case,
-// then seeds saves/applies/views and checks the counts.
+// Integration test for the engagement-stats read endpoint. The counts are pure
+// aggregates over user_jobs, users, user_job_analysis and saved_searches, and the
+// handler reads through a concrete *db.Queries, so it can only be exercised against
+// a real Postgres. It asserts the empty case, then seeds saves/applies/views plus a
+// résumé, a fit analysis and a saved search, and checks every count.
 // Run with: go test -tags=integration ./internal/handler/
 package handler
 
@@ -27,9 +28,12 @@ func TestEngagementStatsEndpoint(t *testing.T) {
 	app.Get("/api/v1/stats/engagement", h.EngagementStats)
 
 	type counts struct {
-		Saved   int `json:"saved"`
-		Applied int `json:"applied"`
-		Viewed  int `json:"viewed"`
+		Saved         int `json:"saved"`
+		Applied       int `json:"applied"`
+		Viewed        int `json:"viewed"`
+		CvsUploaded   int `json:"cvs_uploaded"`
+		FitChecks     int `json:"fit_checks"`
+		SavedSearches int `json:"saved_searches"`
 	}
 	type envelope struct {
 		Data counts `json:"data"`
@@ -51,9 +55,10 @@ func TestEngagementStatsEndpoint(t *testing.T) {
 		return env.Data
 	}
 
-	// --- Empty table: all zeros ------------------------------------------------
-	if c := get(); c.Saved != 0 || c.Applied != 0 || c.Viewed != 0 {
-		t.Fatalf("empty table: got %+v, want all zeros", c)
+	// --- Empty tables: all zeros -----------------------------------------------
+	if c := get(); c.Saved != 0 || c.Applied != 0 || c.Viewed != 0 ||
+		c.CvsUploaded != 0 || c.FitChecks != 0 || c.SavedSearches != 0 {
+		t.Fatalf("empty tables: got %+v, want all zeros", c)
 	}
 
 	// --- Seed a user + jobs + interactions -------------------------------------
@@ -89,7 +94,26 @@ func TestEngagementStatsEndpoint(t *testing.T) {
 	seedInteraction(j2, true, false)
 	seedInteraction(j3, false, true)
 
-	if c := get(); c.Saved != 1 || c.Applied != 1 || c.Viewed != 3 {
-		t.Errorf("got %+v, want {Saved:1 Applied:1 Viewed:3}", c)
+	// A stored résumé (→ cvs_uploaded=1), one job-fit analysis (→ fit_checks=1),
+	// and one saved search (→ saved_searches=1).
+	if _, err := pool.Exec(ctx,
+		`UPDATE users SET resume_object_key = 'cv/u.pdf', resume_uploaded_at = now() WHERE id = $1`,
+		uid); err != nil {
+		t.Fatalf("seed résumé: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO user_job_analysis (user_id, job_id, analysis, model)
+		 VALUES ($1, $2, '{}'::jsonb, 'test-model')`, uid, j1); err != nil {
+		t.Fatalf("seed fit analysis: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO saved_searches (user_id, name, query) VALUES ($1, 'my search', 'go')`,
+		uid); err != nil {
+		t.Fatalf("seed saved search: %v", err)
+	}
+
+	if c := get(); c.Saved != 1 || c.Applied != 1 || c.Viewed != 3 ||
+		c.CvsUploaded != 1 || c.FitChecks != 1 || c.SavedSearches != 1 {
+		t.Errorf("got %+v, want {Saved:1 Applied:1 Viewed:3 CvsUploaded:1 FitChecks:1 SavedSearches:1}", c)
 	}
 }

--- a/internal/handler/stats.go
+++ b/internal/handler/stats.go
@@ -121,9 +121,10 @@ func (a *API) UserGrowth(c *fiber.Ctx) error {
 }
 
 // EngagementStats serves the public, unauthenticated engagement counts: how many
-// user_jobs rows have been saved, applied to, and viewed. Aggregate-only — the
-// query selects nothing but the three integer totals, so no per-user field can
-// leak. An empty table yields all zeros (200).
+// user_jobs rows have been saved, applied to, and viewed, plus how many résumés
+// have been uploaded, job-fit analyses run, and searches saved. Aggregate-only —
+// the query selects nothing but integer totals, so no per-user field can leak. An
+// empty database yields all zeros (200).
 func (a *API) EngagementStats(c *fiber.Ctx) error {
 	s, err := a.queries.GetEngagementStats(c.Context())
 	if err != nil {
@@ -131,7 +132,14 @@ func (a *API) EngagementStats(c *fiber.Ctx) error {
 	}
 
 	return c.JSON(fiber.Map{
-		"data": fiber.Map{"saved": s.Saved, "applied": s.Applied, "viewed": s.Viewed},
+		"data": fiber.Map{
+			"saved":          s.Saved,
+			"applied":        s.Applied,
+			"viewed":         s.Viewed,
+			"cvs_uploaded":   s.CvsUploaded,
+			"fit_checks":     s.FitChecks,
+			"saved_searches": s.SavedSearches,
+		},
 	})
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -355,6 +355,9 @@ export interface EngagementStats {
   saved: number;
   applied: number;
   viewed: number;
+  cvs_uploaded: number;
+  fit_checks: number;
+  saved_searches: number;
 }
 
 /** The derived health verdict for a provider (and the fleet) on the public

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -83,6 +83,9 @@
       { value: nf.format(e.saved), label: 'jobs saved' },
       { value: nf.format(e.applied), label: 'applications' },
       { value: nf.format(e.viewed), label: 'jobs viewed' },
+      { value: nf.format(e.cvs_uploaded), label: 'CVs uploaded' },
+      { value: nf.format(e.fit_checks), label: 'fit checks' },
+      { value: nf.format(e.saved_searches), label: 'saved searches' },
     ];
   });
 </script>
@@ -189,7 +192,7 @@
       Signed-in interactions across freehire — jobs saved, applications tracked, and postings opened.
     </p>
     {#if engagement}
-      <dl class="grid grid-cols-3 gap-px overflow-hidden rounded-xl border border-border bg-border">
+      <dl class="grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3">
         {#each engagement as e (e.label)}
           <div class="bg-background p-5 sm:p-6">
             <dt class="font-mono text-xs uppercase tracking-wide text-muted-foreground">{e.label}</dt>


### PR DESCRIPTION
## What

Extends the **Engagement** section on `/open` from 3 to 6 tiles, adding three new live-from-API counts:

| New tile | Source |
|---|---|
| **CVs uploaded** | `users.resume_object_key IS NOT NULL` |
| **fit checks** | `user_job_analysis` row count |
| **saved searches** | `saved_searches` row count |

Grid becomes 2-up on mobile / 3-up on desktop (`grid-cols-2 sm:grid-cols-3`).

## How

- `GetEngagementStats` gains three scalar sub-selects alongside the existing `user_jobs` filters. Stays **aggregate-only** — every column is a plain count, so no per-user field leaks.
- Handler returns `cvs_uploaded` / `fit_checks` / `saved_searches`; `EngagementStats` TS type + `/open` tiles updated.
- **No migration** — reads existing tables.

Semantics match the page's honest "no vanity rounding" style: fit/searches are event totals (not distinct users); CVs uploaded is naturally one-per-user.

## Test

Integration test seeds a résumé, a fit analysis and a saved search and asserts all six counts. `go build`/`vet`/`gofmt` clean, unit + integration tests pass, `svelte-check` 0 errors.