### PR TITLE
feat(contributions): resolver scans page URLs through the full board recognizer

### DIFF
--- a/internal/boardresolve/boardresolve.go
+++ b/internal/boardresolve/boardresolve.go
@@ -12,8 +12,10 @@ package boardresolve
 import (
 	"context"
 	"net/url"
+	"regexp"
 
 	"github.com/strelov1/freehire/internal/atsdetect"
+	"github.com/strelov1/freehire/internal/contribution"
 	"github.com/strelov1/freehire/internal/sources"
 )
 
@@ -41,20 +43,38 @@ type Resolver struct {
 // New builds a Resolver over the default SSRF-guarded sources client.
 func New() *Resolver { return &Resolver{http: sources.NewClient()} }
 
-// Resolve fetches rawURL and detects an embedded ATS board, returning the catalogue
-// (source, board) and a canonical URL to store (query/fragment stripped). ok=false when the
-// fetch fails, no board is detected, or the detected provider is not one we trust to match the
-// ingest namespace.
+// absURLRe extracts absolute http(s) URLs from markup (href/src or bare URLs in inline JSON),
+// stopping at the first quote, angle bracket, or whitespace.
+var absURLRe = regexp.MustCompile(`https?://[^\s"'<>)\\]+`)
+
+// Resolve fetches rawURL and finds the ATS board it belongs to, returning the catalogue
+// (source, board) and a canonical URL to store. It looks two ways:
+//  1. the Greenhouse embed shape (script for=<board>) via atsdetect — which the URL recognizer
+//     can't parse (it would read the path word "embed" as the board);
+//  2. any supported ATS apply/board URL embedded in the page, run through the full
+//     contribution.RecognizeBoard (all ~40 ATS, all modes) — this catches a company careers page
+//     that links to its recruitee/peopleforce/zoho/workday board.
+//
+// ok=false when the fetch fails or no board is found.
 func (r *Resolver) Resolve(ctx context.Context, rawURL string) (source, board, canonical string, ok bool) {
 	html, err := r.http.GetText(ctx, rawURL)
 	if err != nil {
 		return "", "", "", false
 	}
-	provider, slug, ok := atsdetect.Detect(html)
-	if !ok || !trusted[provider] || slug == "" {
-		return "", "", "", false
+
+	// 1. Greenhouse embed (and atsdetect's own gh/lever/ashby URL scan). Trusted set only.
+	if provider, slug, ok := atsdetect.Detect(html); ok && trusted[provider] && slug != "" {
+		return provider, slug, stripTails(rawURL), true
 	}
-	return provider, slug, stripTails(rawURL), true
+
+	// 2. Any supported ATS URL in the page, via the full recognizer. First recognized wins;
+	//    a Greenhouse embed URL misparses to board "embed" (step 1 owns Greenhouse), so skip it.
+	for _, u := range absURLRe.FindAllString(html, -1) {
+		if s, b, _, matched := contribution.RecognizeBoard(u); matched && b != "embed" {
+			return s, b, stripTails(rawURL), true
+		}
+	}
+	return "", "", "", false
 }
 
 // stripTails returns rawURL without its query string or fragment (the identifying part of a

--- a/internal/boardresolve/boardresolve_test.go
+++ b/internal/boardresolve/boardresolve_test.go
@@ -37,6 +37,16 @@ func TestResolveDetectsGreenhouseEmbed(t *testing.T) {
 	}
 }
 
+func TestResolveDetectsPeopleForceApplyUrl(t *testing.T) {
+	// A company careers page on its own domain that links to its PeopleForce board — caught by
+	// scanning the page's URLs through the full recognizer (atsdetect doesn't know peopleforce).
+	html := `{"applyUrl":"https://akvelon.peopleforce.io/careers/v/215183-senior-dev/a/new"}`
+	src, board, _, ok := resolver(html, nil).Resolve(context.Background(), "https://akvelon.dev/jobs/215183")
+	if !ok || src != "peopleforce" || board != "akvelon" {
+		t.Errorf("(%q,%q,%v), want (peopleforce, akvelon, true)", src, board, ok)
+	}
+}
+
 func TestResolveDetectsDirectAshbyLinkOnPage(t *testing.T) {
 	html := `<a href="https://jobs.ashbyhq.com/acme/uuid">Apply</a>`
 	src, board, _, ok := resolver(html, nil).Resolve(context.Background(), "https://acme.io/careers")
@@ -45,12 +55,19 @@ func TestResolveDetectsDirectAshbyLinkOnPage(t *testing.T) {
 	}
 }
 
-func TestResolveRejectsUntrustedProvider(t *testing.T) {
-	// A page that only exposes a Workday link: atsdetect may recognize it, but workday's board
-	// semantics don't match our ingest namespace, so we decline.
-	html := `<a href="https://acme.wd1.myworkdayjobs.com/en-US/careers/job/123">Apply</a>`
+func TestResolveDetectsWorkdayLinkOnPage(t *testing.T) {
+	html := `<a href="https://acme.wd1.myworkdayjobs.com/Careers/job/x/Eng_JR-1">Apply</a>`
+	src, board, _, ok := resolver(html, nil).Resolve(context.Background(), "https://acme.com/jobs")
+	if !ok || src != "workday" || board != "acme.wd1.myworkdayjobs.com/Careers" {
+		t.Errorf("(%q,%q,%v), want (workday, acme.wd1.myworkdayjobs.com/Careers, true)", src, board, ok)
+	}
+}
+
+func TestResolveRejectsUnsupportedAts(t *testing.T) {
+	// Taleo isn't in the recognizer — a page exposing only a Taleo link resolves nothing.
+	html := `<a href="https://acme.taleo.net/careersection/x/jobdetail.ftl?job=123">Apply</a>`
 	if _, _, _, ok := resolver(html, nil).Resolve(context.Background(), "https://acme.com/jobs"); ok {
-		t.Error("ok=true for an untrusted provider, want false")
+		t.Error("ok=true for an unsupported ATS, want false")
 	}
 }
 

--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -81,10 +81,10 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"myworkdayjobs.com", "workday", modeHostPath},
 }
 
-// recognizeBoard parses a pasted job link into the company board it belongs to: the source
+// RecognizeBoard parses a pasted job link into the company board it belongs to: the source
 // (ATS provider), the board slug, and the canonical URL to store. ok=false when the host is
 // not a supported ATS or the URL carries no board segment/label.
-func recognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
+func RecognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 	u, err := url.Parse(rawURL)
 	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
 		return "", "", "", false

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -54,15 +54,15 @@ func TestRecognizeBoard(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			src, board, canon, ok := recognizeBoard(c.raw)
+			src, board, canon, ok := RecognizeBoard(c.raw)
 			if ok != c.wantOK {
-				t.Fatalf("recognizeBoard(%q) ok = %v, want %v", c.raw, ok, c.wantOK)
+				t.Fatalf("RecognizeBoard(%q) ok = %v, want %v", c.raw, ok, c.wantOK)
 			}
 			if !ok {
 				return
 			}
 			if src != c.wantSource || board != c.wantBoard || canon != c.wantCanonical {
-				t.Errorf("recognizeBoard(%q) = (%q, %q, %q), want (%q, %q, %q)",
+				t.Errorf("RecognizeBoard(%q) = (%q, %q, %q), want (%q, %q, %q)",
 					c.raw, src, board, canon, c.wantSource, c.wantBoard, c.wantCanonical)
 			}
 		})
@@ -83,8 +83,8 @@ func TestVacancyAndListingSameBoard(t *testing.T) {
 		{"https://gm.wd5.myworkdayjobs.com/Careers_GM/job/x/Eng_JR-1", "https://gm.wd5.myworkdayjobs.com/Careers_GM"},
 	}
 	for _, p := range pairs {
-		sa, ba, _, oka := recognizeBoard(p[0])
-		sb, bb, _, okb := recognizeBoard(p[1])
+		sa, ba, _, oka := RecognizeBoard(p[0])
+		sb, bb, _, okb := RecognizeBoard(p[1])
 		if !oka || !okb || sa != sb || ba != bb {
 			t.Errorf("boards diverged: (%q,%q,%v) vs (%q,%q,%v)", sa, ba, oka, sb, bb, okb)
 		}

--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -86,7 +86,7 @@ func New(repo Repository, resolver Resolver) *Service {
 // already-tracked (409) before any write; the record+point transaction last, where a
 // duplicate-board race surfaces as ErrBoardAlreadyContributed (409).
 func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) (rec Contribution, source, board string, err error) {
-	source, board, canonical, ok := recognizeBoard(rawURL)
+	source, board, canonical, ok := RecognizeBoard(rawURL)
 	if !ok && s.resolver != nil {
 		// Unknown host — the link may be a company careers page with an embedded ATS. Fetch it
 		// and detect the board (network fallback).


### PR DESCRIPTION
Reported: `akvelon.dev/jobs/215183` logged as unrecognized — but it's **PeopleForce** (which we support): the page exposes `akvelon.peopleforce.io/careers/v/215183-…`.

**Why the network fallback missed it:** it relied on `atsdetect`, whose detectors are only greenhouse/lever/ashby, and my trusted-filter excluded the rest.

**Fix:** export `contribution.RecognizeBoard` and scan every absolute URL in the fetched page through it — the full ~40-ATS recognizer (all modes). So an embedded recruitee/peopleforce/zoho/workday apply URL on a company's own careers page now resolves. Order: `atsdetect` first (it alone parses the Greenhouse embed `for=<board>`, which the URL recognizer would misread as "embed"), then the full-recognizer scan.

Unit-tested: greenhouse embed, **peopleforce apply URL (akvelon)**, workday link, ashby link, unsupported (taleo) rejected, no-ATS/fetch-error. No schema change.