### PR TITLE
feat(sources): onboard contributed boards (inhire jobler, zoho be-exec)

### DIFF
--- a/sources/inhire.yml
+++ b/sources/inhire.yml
@@ -740,3 +740,5 @@
   board: pottencial
 - company: "Talentt"
   board: talentt
+- company: "Jobler"
+  board: jobler

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -241,6 +241,8 @@
   board: bceglobaltech.zohorecruit.in
 - company: BDO EDGE
   board: bdoedge.zohorecruit.in
+- company: Be Exec.Tech DOO
+  board: be-exec.zohorecruit.eu
 - company: Beyond Tech
   board: be-y.zohorecruit.eu
 - company: Beautonomi


### PR DESCRIPTION
Onboards the first two boards submitted through the **/contribute** crowdsourcing flow into ingest.

Both live-validated before adding (per each board file's convention):

| source | board | company | check |
|---|---|---|---|
| inhire | `jobler` | Jobler | 25 open posts via `X-Tenant` API |
| zohorecruit | `be-exec.zohorecruit.eu` | Be Exec.Tech DOO | `/jobs/Careers` → 200 |

Closes the loop on the contribution feature: once the ingest worker crawls these, jobs exist for the boards, so `BoardTracked` returns true and a re-submission of the same board correctly hits *already-tracked* instead of double-awarding a point.