### PR TITLE
feat(cv): tailoring workspace — resume sessions, editor tab, /my/cvs re-open list

### DIFF
--- a/internal/cv/session_test.go
+++ b/internal/cv/session_test.go
@@ -1,0 +1,35 @@
+package cv
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestStoreSetSessionRoundTrip(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+	cvMeta, err := s.CreateTailored(ctx, 7, 100, "Tailored", DefaultTemplateID, Document{})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+	if err := s.SetSession(ctx, cvMeta.ID, 7, "sess-abc"); err != nil {
+		t.Fatalf("set session: %v", err)
+	}
+	rec, err := s.Get(ctx, cvMeta.ID, 7)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if rec.AgentSessionID != "sess-abc" {
+		t.Errorf("session = %q, want sess-abc", rec.AgentSessionID)
+	}
+}
+
+func TestStoreSetSessionForeignOwnerIsNotFound(t *testing.T) {
+	s := NewStore(newFakeRepo())
+	ctx := context.Background()
+	cvMeta, _ := s.Create(ctx, 1, "Mine", DefaultTemplateID, Document{})
+	if err := s.SetSession(ctx, cvMeta.ID, 2, "x"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("foreign set err = %v, want ErrNotFound", err)
+	}
+}

--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -34,8 +34,18 @@ type Meta struct {
 type Record struct {
 	Meta
 	// JobID is the vacancy a tailored CV is bound to, or 0 for a base CV (job_id NULL).
-	JobID    int64
-	Document Document
+	JobID int64
+	// AgentSessionID is the roy session bound to a tailored CV (empty when none).
+	AgentSessionID string
+	Document       Document
+}
+
+// TailoredItem is a tailored CV in the re-open list: metadata plus the vacancy slug and the
+// bound agent session, so a row links straight back to its tailoring workspace.
+type TailoredItem struct {
+	Meta
+	JobSlug        string
+	AgentSessionID string
 }
 
 // Repository persists CVs. Every read/update/delete is owner-scoped by (id, userID); a
@@ -48,6 +58,8 @@ type Repository interface {
 	Delete(ctx context.Context, id, userID int64) (int64, error)
 	GetBase(ctx context.Context, userID int64) (db.GetBaseCVByUserRow, error)
 	CreateTailored(ctx context.Context, userID, jobID int64, title, templateID string, data []byte) (db.CreateTailoredCVRow, error)
+	SetSession(ctx context.Context, id, userID int64, sessionID string) (int64, error)
+	ListTailored(ctx context.Context, userID int64) ([]db.ListTailoredCVsByUserRow, error)
 }
 
 // Seeder provides the user's extracted résumé, used to seed a base CV when they have none.
@@ -104,9 +116,10 @@ func (s *Store) Get(ctx context.Context, id, userID int64) (Record, error) {
 		return Record{}, err
 	}
 	return Record{
-		Meta:     Meta{ID: row.ID, Title: row.Title, TemplateID: row.TemplateID, CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time},
-		JobID:    int8Value(row.JobID),
-		Document: doc,
+		Meta:           Meta{ID: row.ID, Title: row.Title, TemplateID: row.TemplateID, CreatedAt: row.CreatedAt.Time, UpdatedAt: row.UpdatedAt.Time},
+		JobID:          int8Value(row.JobID),
+		AgentSessionID: textValue(row.AgentSessionID),
+		Document:       doc,
 	}, nil
 }
 
@@ -116,6 +129,44 @@ func int8Value(v pgtype.Int8) int64 {
 		return v.Int64
 	}
 	return 0
+}
+
+// textValue unwraps a nullable text column to its value, mapping NULL to "".
+func textValue(v pgtype.Text) string {
+	if v.Valid {
+		return v.String
+	}
+	return ""
+}
+
+// SetSession binds (or rebinds) the agent session to an owned CV, or returns ErrNotFound.
+func (s *Store) SetSession(ctx context.Context, id, userID int64, sessionID string) error {
+	n, err := s.repo.SetSession(ctx, id, userID, sessionID)
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListTailored returns the user's tailored CVs (the re-open list): metadata plus the vacancy
+// slug and the bound agent session, newest edit first.
+func (s *Store) ListTailored(ctx context.Context, userID int64) ([]TailoredItem, error) {
+	rows, err := s.repo.ListTailored(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]TailoredItem, len(rows))
+	for i, r := range rows {
+		out[i] = TailoredItem{
+			Meta:           Meta{ID: r.ID, Title: r.Title, TemplateID: r.TemplateID, CreatedAt: r.CreatedAt.Time, UpdatedAt: r.UpdatedAt.Time},
+			JobSlug:        r.JobSlug,
+			AgentSessionID: textValue(r.AgentSessionID),
+		}
+	}
+	return out, nil
 }
 
 // Update sanitizes and replaces an owned CV's editable fields, or returns ErrNotFound.
@@ -283,4 +334,15 @@ func (r queriesRepository) CreateTailored(ctx context.Context, userID, jobID int
 		UserID: userID, Title: title, TemplateID: templateID, Data: data,
 		JobID: pgtype.Int8{Int64: jobID, Valid: true},
 	})
+}
+
+func (r queriesRepository) SetSession(ctx context.Context, id, userID int64, sessionID string) (int64, error) {
+	return r.q.SetCVSession(ctx, db.SetCVSessionParams{
+		ID: id, UserID: userID,
+		AgentSessionID: pgtype.Text{String: sessionID, Valid: sessionID != ""},
+	})
+}
+
+func (r queriesRepository) ListTailored(ctx context.Context, userID int64) ([]db.ListTailoredCVsByUserRow, error) {
+	return r.q.ListTailoredCVsByUser(ctx, userID)
 }

--- a/internal/cv/store_test.go
+++ b/internal/cv/store_test.go
@@ -24,6 +24,7 @@ type fakeRow struct {
 	templateID string
 	data       []byte
 	jobID      int64 // 0 = base CV (job_id NULL); >0 = tailored copy bound to a vacancy
+	sessionID  string
 }
 
 func newFakeRepo() *fakeRepo { return &fakeRepo{rows: map[int64]fakeRow{}, next: 1} }
@@ -52,7 +53,31 @@ func (f *fakeRepo) Get(_ context.Context, id, userID int64) (db.GetCVByIDRow, er
 	if !ok || r.userID != userID {
 		return db.GetCVByIDRow{}, pgx.ErrNoRows
 	}
-	return db.GetCVByIDRow{ID: id, Title: r.title, TemplateID: r.templateID, Data: r.data, JobID: pgtype.Int8{Int64: r.jobID, Valid: r.jobID != 0}, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
+	return db.GetCVByIDRow{ID: id, Title: r.title, TemplateID: r.templateID, Data: r.data, JobID: pgtype.Int8{Int64: r.jobID, Valid: r.jobID != 0}, AgentSessionID: pgtype.Text{String: r.sessionID, Valid: r.sessionID != ""}, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
+}
+
+func (f *fakeRepo) SetSession(_ context.Context, id, userID int64, sessionID string) (int64, error) {
+	r, ok := f.rows[id]
+	if !ok || r.userID != userID {
+		return 0, nil
+	}
+	r.sessionID = sessionID
+	f.rows[id] = r
+	return 1, nil
+}
+
+func (f *fakeRepo) ListTailored(_ context.Context, userID int64) ([]db.ListTailoredCVsByUserRow, error) {
+	var out []db.ListTailoredCVsByUserRow
+	for id, r := range f.rows {
+		if r.userID == userID && r.jobID != 0 {
+			out = append(out, db.ListTailoredCVsByUserRow{
+				ID: id, Title: r.title, TemplateID: r.templateID,
+				AgentSessionID: pgtype.Text{String: r.sessionID, Valid: r.sessionID != ""},
+				JobSlug:        "job-slug", CreatedAt: stamp(), UpdatedAt: stamp(),
+			})
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeRepo) Update(_ context.Context, id, userID int64, title, templateID string, data []byte) (db.UpdateCVRow, error) {
@@ -60,7 +85,7 @@ func (f *fakeRepo) Update(_ context.Context, id, userID int64, title, templateID
 	if !ok || r.userID != userID {
 		return db.UpdateCVRow{}, pgx.ErrNoRows
 	}
-	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data, jobID: r.jobID}
+	f.rows[id] = fakeRow{userID: userID, title: title, templateID: templateID, data: data, jobID: r.jobID, sessionID: r.sessionID}
 	return db.UpdateCVRow{ID: id, Title: title, TemplateID: templateID, CreatedAt: stamp(), UpdatedAt: stamp()}, nil
 }
 

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -151,7 +151,7 @@ func (q *Queries) GetBaseCVByUser(ctx context.Context, userID int64) (GetBaseCVB
 }
 
 const getCVByID = `-- name: GetCVByID :one
-SELECT id, title, template_id, data, job_id, created_at, updated_at
+SELECT id, title, template_id, data, job_id, agent_session_id, created_at, updated_at
 FROM cvs
 WHERE id = $1 AND user_id = $2
 `
@@ -162,18 +162,19 @@ type GetCVByIDParams struct {
 }
 
 type GetCVByIDRow struct {
-	ID         int64              `json:"id"`
-	Title      string             `json:"title"`
-	TemplateID string             `json:"template_id"`
-	Data       []byte             `json:"data"`
-	JobID      pgtype.Int8        `json:"job_id"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	ID             int64              `json:"id"`
+	Title          string             `json:"title"`
+	TemplateID     string             `json:"template_id"`
+	Data           []byte             `json:"data"`
+	JobID          pgtype.Int8        `json:"job_id"`
+	AgentSessionID pgtype.Text        `json:"agent_session_id"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
 }
 
 // One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
 // missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
-// the vacancy id for a tailored copy — the tailoring-context read resolves it to the analysis.
+// the vacancy id for a tailored copy; agent_session_id is the bound roy session (or NULL).
 func (q *Queries) GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByIDRow, error) {
 	row := q.db.QueryRow(ctx, getCVByID, arg.ID, arg.UserID)
 	var i GetCVByIDRow
@@ -183,6 +184,7 @@ func (q *Queries) GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByID
 		&i.TemplateID,
 		&i.Data,
 		&i.JobID,
+		&i.AgentSessionID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -229,6 +231,78 @@ func (q *Queries) ListCVsByUser(ctx context.Context, userID int64) ([]ListCVsByU
 		return nil, err
 	}
 	return items, nil
+}
+
+const listTailoredCVsByUser = `-- name: ListTailoredCVsByUser :many
+SELECT c.id, c.title, c.template_id, c.agent_session_id, j.public_slug AS job_slug,
+       c.created_at, c.updated_at
+FROM cvs c
+JOIN jobs j ON j.id = c.job_id
+WHERE c.user_id = $1 AND c.job_id IS NOT NULL
+ORDER BY c.updated_at DESC
+`
+
+type ListTailoredCVsByUserRow struct {
+	ID             int64              `json:"id"`
+	Title          string             `json:"title"`
+	TemplateID     string             `json:"template_id"`
+	AgentSessionID pgtype.Text        `json:"agent_session_id"`
+	JobSlug        string             `json:"job_slug"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+}
+
+// A user's TAILORED CVs (bound to a vacancy), newest edit first — the re-open list. Carries the
+// vacancy's public slug and the bound agent session so each row links back to its workspace.
+// Base CVs (job_id NULL) are excluded; the JOIN also drops tailored CVs whose job was deleted.
+func (q *Queries) ListTailoredCVsByUser(ctx context.Context, userID int64) ([]ListTailoredCVsByUserRow, error) {
+	rows, err := q.db.Query(ctx, listTailoredCVsByUser, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListTailoredCVsByUserRow{}
+	for rows.Next() {
+		var i ListTailoredCVsByUserRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Title,
+			&i.TemplateID,
+			&i.AgentSessionID,
+			&i.JobSlug,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const setCVSession = `-- name: SetCVSession :execrows
+UPDATE cvs
+SET agent_session_id = $3
+WHERE id = $1 AND user_id = $2
+`
+
+type SetCVSessionParams struct {
+	ID             int64       `json:"id"`
+	UserID         int64       `json:"user_id"`
+	AgentSessionID pgtype.Text `json:"agent_session_id"`
+}
+
+// Bind (or rebind) the agent session to an owned CV. Owner-scoped: returns 0 affected rows for
+// a foreign or missing id (the handler maps that to 404).
+func (q *Queries) SetCVSession(ctx context.Context, arg SetCVSessionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setCVSession, arg.ID, arg.UserID, arg.AgentSessionID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateCV = `-- name: UpdateCV :one

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -64,14 +64,15 @@ type Company struct {
 }
 
 type Cv struct {
-	ID         int64              `json:"id"`
-	UserID     int64              `json:"user_id"`
-	Title      string             `json:"title"`
-	TemplateID string             `json:"template_id"`
-	Data       []byte             `json:"data"`
-	JobID      pgtype.Int8        `json:"job_id"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	ID             int64              `json:"id"`
+	UserID         int64              `json:"user_id"`
+	Title          string             `json:"title"`
+	TemplateID     string             `json:"template_id"`
+	Data           []byte             `json:"data"`
+	JobID          pgtype.Int8        `json:"job_id"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
+	AgentSessionID pgtype.Text        `json:"agent_session_id"`
 }
 
 type Email struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -347,7 +347,7 @@ type Querier interface {
 	GetBoardCooldown(ctx context.Context, arg GetBoardCooldownParams) (pgtype.Timestamptz, error)
 	// One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
 	// missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
-	// the vacancy id for a tailored copy — the tailoring-context read resolves it to the analysis.
+	// the vacancy id for a tailored copy; agent_session_id is the bound roy session (or NULL).
 	GetCVByID(ctx context.Context, arg GetCVByIDParams) (GetCVByIDRow, error)
 	// SELECT * (not an explicit column list) so the generated row stays db.Company as
 	// the table grows columns (e.g. collections); an explicit subset makes sqlc emit a
@@ -652,6 +652,10 @@ type Querier interface {
 	// The caller's subscriptions joined to each saved search's display name and query,
 	// newest first — the "My subscriptions" view.
 	ListSubscriptions(ctx context.Context, userID int64) ([]ListSubscriptionsRow, error)
+	// A user's TAILORED CVs (bound to a vacancy), newest edit first — the re-open list. Carries the
+	// vacancy's public slug and the bound agent session so each row links back to its workspace.
+	// Base CVs (job_id NULL) are excluded; the JOIN also drops tailored CVs whose job was deleted.
+	ListTailoredCVsByUser(ctx context.Context, userID int64) ([]ListTailoredCVsByUserRow, error)
 	// Every board currently failing or cooled down, worst first — the operator's
 	// "what's broken" query and the source of the per-run summary log.
 	ListUnhealthyBoards(ctx context.Context) ([]ListUnhealthyBoardsRow, error)
@@ -892,6 +896,9 @@ type Querier interface {
 	// Apply the Go-computed cooldown window to a board (called only when the backoff
 	// policy says to cool down).
 	SetBoardCooldown(ctx context.Context, arg SetBoardCooldownParams) error
+	// Bind (or rebind) the agent session to an owned CV. Owner-scoped: returns 0 affected rows for
+	// a foreign or missing id (the handler maps that to 404).
+	SetCVSession(ctx context.Context, arg SetCVSessionParams) (int64, error)
 	// Replace a company's collection set. The import worker computes the full set in Go
 	// (preserving unmanaged tags) and writes it here; updated_at is bumped for parity
 	// with the other write paths.

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -13,12 +13,30 @@ FROM cvs
 WHERE user_id = $1
 ORDER BY updated_at DESC;
 
+-- name: ListTailoredCVsByUser :many
+-- A user's TAILORED CVs (bound to a vacancy), newest edit first — the re-open list. Carries the
+-- vacancy's public slug and the bound agent session so each row links back to its workspace.
+-- Base CVs (job_id NULL) are excluded; the JOIN also drops tailored CVs whose job was deleted.
+SELECT c.id, c.title, c.template_id, c.agent_session_id, j.public_slug AS job_slug,
+       c.created_at, c.updated_at
+FROM cvs c
+JOIN jobs j ON j.id = c.job_id
+WHERE c.user_id = $1 AND c.job_id IS NOT NULL
+ORDER BY c.updated_at DESC;
+
 -- name: GetCVByID :one
 -- One CV owned by the user, including the full data blob. Owner-scoped: a foreign or
 -- missing id returns no row (the handler maps it to 404). job_id is NULL for a base CV and
--- the vacancy id for a tailored copy — the tailoring-context read resolves it to the analysis.
-SELECT id, title, template_id, data, job_id, created_at, updated_at
+-- the vacancy id for a tailored copy; agent_session_id is the bound roy session (or NULL).
+SELECT id, title, template_id, data, job_id, agent_session_id, created_at, updated_at
 FROM cvs
+WHERE id = $1 AND user_id = $2;
+
+-- name: SetCVSession :execrows
+-- Bind (or rebind) the agent session to an owned CV. Owner-scoped: returns 0 affected rows for
+-- a foreign or missing id (the handler maps that to 404).
+UPDATE cvs
+SET agent_session_id = $3
 WHERE id = $1 AND user_id = $2;
 
 -- name: UpdateCV :one

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -28,7 +28,18 @@ type cvMetaResponse struct {
 
 type cvResponse struct {
 	cvMetaResponse
-	Document cv.Document `json:"document"`
+	// AgentSessionID is the roy session bound to a tailored CV (empty when none) — the tailoring
+	// workspace resumes it.
+	AgentSessionID string      `json:"agent_session_id"`
+	Document       cv.Document `json:"document"`
+}
+
+// cvTailoredResponse is a tailored CV in the /my/cvs re-open list: metadata plus the vacancy
+// slug and the bound agent session, so the client links each row to its tailoring workspace.
+type cvTailoredResponse struct {
+	cvMetaResponse
+	JobSlug        string `json:"job_slug"`
+	AgentSessionID string `json:"agent_session_id"`
 }
 
 type createCVRequest struct {
@@ -49,19 +60,28 @@ func metaResponse(m cv.Meta) cvMetaResponse {
 	return cvMetaResponse{ID: m.ID, Title: m.Title, TemplateID: m.TemplateID, CreatedAt: m.CreatedAt, UpdatedAt: m.UpdatedAt}
 }
 
-// ListCVs returns the caller's CVs as metadata, newest edit first.
+func recordResponse(rec cv.Record) cvResponse {
+	return cvResponse{cvMetaResponse: metaResponse(rec.Meta), AgentSessionID: rec.AgentSessionID, Document: rec.Document}
+}
+
+// ListCVs returns the caller's TAILORED CVs (the re-open list), newest edit first, each with
+// its vacancy slug and bound agent session so the client links back to the tailoring workspace.
 func (a *API) ListCVs(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
 		return err
 	}
-	metas, err := a.cvStore.List(c.Context(), userID)
+	items, err := a.cvStore.ListTailored(c.Context(), userID)
 	if err != nil {
 		return err
 	}
-	out := make([]cvMetaResponse, len(metas))
-	for i, m := range metas {
-		out[i] = metaResponse(m)
+	out := make([]cvTailoredResponse, len(items))
+	for i, m := range items {
+		out[i] = cvTailoredResponse{
+			cvMetaResponse: cvMetaResponse{ID: m.ID, Title: m.Title, TemplateID: m.TemplateID, CreatedAt: m.CreatedAt, UpdatedAt: m.UpdatedAt},
+			JobSlug:        m.JobSlug,
+			AgentSessionID: m.AgentSessionID,
+		}
 	}
 	return c.JSON(fiber.Map{"data": out})
 }
@@ -100,7 +120,7 @@ func (a *API) CreateCV(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": cvResponse{metaResponse(rec.Meta), rec.Document}})
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": recordResponse(rec)})
 }
 
 // GetCV returns one owned CV with its full document.
@@ -117,7 +137,7 @@ func (a *API) GetCV(c *fiber.Ctx) error {
 	if err != nil {
 		return mapCVError(err)
 	}
-	return c.JSON(fiber.Map{"data": cvResponse{metaResponse(rec.Meta), rec.Document}})
+	return c.JSON(fiber.Map{"data": recordResponse(rec)})
 }
 
 // UpdateCV replaces an owned CV's title, template, and document.
@@ -156,6 +176,31 @@ func (a *API) DeleteCV(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
 	}
 	if err := a.cvStore.Delete(c.Context(), int64(id), userID); err != nil {
+		return mapCVError(err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
+}
+
+type setCVSessionRequest struct {
+	SessionID string `json:"session_id"`
+}
+
+// SetCVSession binds a roy agent session to an owned CV so the tailoring workspace can re-open
+// that exact session later. Cookie or API key; owner-scoped (a foreign/missing id is a 404).
+func (a *API) SetCVSession(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := c.ParamsInt("id")
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+	}
+	var in setCVSessionRequest
+	if err := c.BodyParser(&in); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	}
+	if err := a.cvStore.SetSession(c.Context(), int64(id), userID, in.SessionID); err != nil {
 		return mapCVError(err)
 	}
 	return c.SendStatus(fiber.StatusNoContent)

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -254,5 +255,51 @@ func TestTailorContextSplit(t *testing.T) {
 	base, _ := h.cvStore.Create(ctx, user, "Base", cv.DefaultTemplateID, cv.Document{})
 	if resp := doBearer(t, app, fiber.MethodGet, "/api/v1/me/cvs/"+strconv.FormatInt(base.ID, 10)+"/tailor-context", key, nil); resp.StatusCode != fiber.StatusConflict {
 		t.Fatalf("base-cv context = %d, want 409", resp.StatusCode)
+	}
+}
+
+// TestCVSessionAndTailoredList covers the CV↔session link over real Postgres: SetSession
+// round-trips on Get, ListTailored returns the vacancy slug + session (and excludes base CVs),
+// and SetSession is owner-scoped.
+func TestCVSessionAndTailoredList(t *testing.T) {
+	h, _ := newTailorAPI(t)
+	ctx := context.Background()
+	user := seedAccount(t, h, "sess@example.test", true)
+	jobID := seedJobSlug(t, h, "backend-eng")
+
+	// A base CV (job_id NULL) must NOT appear in the tailored list.
+	if _, err := h.cvStore.Create(ctx, user, "Base", cv.DefaultTemplateID, cv.Document{}); err != nil {
+		t.Fatalf("create base: %v", err)
+	}
+	tailored, err := h.cvStore.CreateTailored(ctx, user, jobID, "Tailored", cv.DefaultTemplateID, cv.Document{})
+	if err != nil {
+		t.Fatalf("create tailored: %v", err)
+	}
+
+	if err := h.cvStore.SetSession(ctx, tailored.ID, user, "sess-xyz"); err != nil {
+		t.Fatalf("set session: %v", err)
+	}
+	rec, err := h.cvStore.Get(ctx, tailored.ID, user)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if rec.AgentSessionID != "sess-xyz" {
+		t.Errorf("session = %q, want sess-xyz", rec.AgentSessionID)
+	}
+
+	items, err := h.cvStore.ListTailored(ctx, user)
+	if err != nil {
+		t.Fatalf("list tailored: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("tailored list len = %d, want 1 (base excluded)", len(items))
+	}
+	if items[0].JobSlug != "backend-eng" || items[0].AgentSessionID != "sess-xyz" {
+		t.Errorf("tailored item = %+v, want slug backend-eng + session sess-xyz", items[0])
+	}
+
+	other := seedAccount(t, h, "other-sess@example.test", true)
+	if err := h.cvStore.SetSession(ctx, tailored.ID, other, "hijack"); !errors.Is(err, cv.ErrNotFound) {
+		t.Errorf("foreign set-session err = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -464,6 +464,7 @@ func Register(app *fiber.App, cfg Config) {
 	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
 	api.Post("/me/cvs/tailor", saved, cvGate, a.TailorCV)
 	api.Patch("/me/cvs/:id", keyAuth, cvGate, a.PatchCV)
+	api.Put("/me/cvs/:id/session", keyAuth, cvGate, a.SetCVSession)
 	api.Get("/me/cvs/:id/tailor-context", keyAuth, cvGate, a.TailorContext)
 
 	// Mail inbox (Gmail connect + hosted mailbox). Open to every signed-in user.

--- a/migrations/0028_cvs_agent_session.sql
+++ b/migrations/0028_cvs_agent_session.sql
@@ -1,0 +1,3 @@
+-- The roy agent session bound to a tailored CV, so the CV list can re-open the exact session
+-- instead of starting a new one. NULL for a base CV, or a tailored CV created before this column.
+ALTER TABLE cvs ADD COLUMN agent_session_id text;

--- a/openspec/changes/add-tailor-workspace/.openspec.yaml
+++ b/openspec/changes/add-tailor-workspace/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/add-tailor-workspace/design.md
+++ b/openspec/changes/add-tailor-workspace/design.md
@@ -1,0 +1,60 @@
+## Context
+
+`/tailor/[slug]` bootstraps a NEW tailored CV + agent session on every open, and CV editing
+lives in a separate `/my/cvs` builder. The user wants one workspace and a `/my/cvs` that
+re-opens the *existing* session for a CV. That requires a durable CV→session link, a resume
+mode, and the editor moved into the workspace. Backend persistence was chosen over localStorage
+(robust, cross-device).
+
+## Goals / Non-Goals
+
+**Goals:** persist `cvs.agent_session_id`; `/tailor` resume mode (`?cv=<id>`); CV editor as a
+workspace tab; `/my/cvs` re-open list with no create.
+
+**Non-Goals:** re-minting the CLI token on resume (noted seam); changing the roy agent; multi-CV
+composition.
+
+## Decisions
+
+**D1 — Store the session on the CV (`cvs.agent_session_id text`).** Migration `0028`. Set via a
+small owner-scoped endpoint after the frontend creates the session; returned by the CV reads.
+Chosen over localStorage for cross-device durability.
+
+**D2 — Set-session endpoint, not fold into PATCH.** `PUT /me/cvs/:id/session {session_id}`
+(cookie or key, owner-scoped). Keeps the document PATCH surface clean; the session id is
+metadata, not document content.
+
+**D3 — `/tailor/[slug]` has two modes.**
+- No `?cv`: bootstrap (create tailored CV + session + kickoff), then `PUT` the session id.
+- `?cv=<id>`: GET the CV (`agent_session_id`, `job_id`) + the job + the analysis; attach the
+  existing session with NO kickoff. Resume needs no new token — the session already holds the
+  one injected at creation (short-lived; see risk).
+
+**D4 — CV editor as a tab.** `ArtifactPanel` gains an Edit tab that reuses the existing
+`CvEditor` (loads the CV doc, saves via the existing update endpoint). The standalone
+`/my/cvs/[id]` editor route redirects into the workspace so there is one editing surface.
+
+**D5 — `/my/cvs` re-open list.** `ListCVsByUser` joins `jobs` for the public slug and returns
+`agent_session_id`; `CvList` drops the create button and links each row to
+`/tailor/<slug>?cv=<id>`. Only tailored CVs (`job_id NOT NULL`) are listed.
+
+## Risks / Trade-offs
+
+- **Token TTL vs resume** → the CLI token minted at bootstrap is 2h; resuming later means the
+  agent's `freehire cv edit` 401s. Mitigation (follow-up): re-mint + re-inject on resume, or
+  lengthen the tailoring key TTL. For now resume works within the session's life.
+- **roy session liveness on resume** → re-attach replays the journal; if the harness process was
+  reaped the agent restarts fresh in the same cwd (its `freehire` auth env may be gone). Same
+  token seam; acceptable for MVP.
+- **Editing in a tab while the agent also edits** → both go through the same CV; last write wins.
+  The preview refreshes on turns; the editor re-loads on tab open. Acceptable.
+
+## Migration Plan
+
+Additive column (`0028`), nullable — no backfill. Deploy backend (migration applied first per
+prod ops), then the web. Rollback: the column is unused if the web is reverted.
+
+## Open Questions
+
+- Whether `/my/cvs` should also surface base CVs (job_id NULL) — leaning no (the list is the
+  tailoring re-open surface); a base CV is an implementation detail seeded on first tailor.

--- a/openspec/changes/add-tailor-workspace/proposal.md
+++ b/openspec/changes/add-tailor-workspace/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Tailoring now opens a fresh agent session every time and edits the CV in a separate `/my/cvs`
+builder. The user wants one coherent workspace: `/tailor/[slug]` is where you chat, view, AND
+edit a tailored CV; `/my/cvs` becomes a list that RE-OPENS an existing tailoring session (not a
+new one); and CVs are created only from the match page. That needs a durable link between a
+tailored CV and its agent session, a resume mode, and the CV editor moved into the workspace.
+
+## What Changes
+
+- Persist the agent session on a tailored CV: `cvs.agent_session_id` (**migration**), set after
+  the session starts, returned by the CV reads. So a CV can re-open its exact session.
+- **Resume mode** for `/tailor/[slug]?cv=<id>`: reuse the existing tailored CV + its stored
+  session (re-attach, **no re-bootstrap, no kickoff**). Absent `?cv` still bootstraps a new one
+  (from the match CTA), then stores the session id on the new CV.
+- **CV editor as a tab** on `/tailor`: move the structured `CvEditor` form into a workspace tab
+  (CV · Edit · Job description · Verdict), so editing happens beside the chat and preview.
+- **`/my/cvs` becomes a re-open list**: each tailored CV links to `/tailor/[slug]?cv=<id>`
+  (resume). **Remove the "Create" button** — tailored CVs are created only via the match page.
+- List CVs returns the job's public slug + the session id so the list can build resume links.
+
+## Capabilities
+
+### New Capabilities
+- `tailor-workspace`: the `cvs.agent_session_id` link + its set/read endpoints, the `/tailor`
+  resume mode, the in-workspace CV editor tab, and the `/my/cvs` re-open list (no create).
+
+### Modified Capabilities
+<!-- The /my/cvs rework (list re-opens sessions, no create) is part of the tailor-workspace
+     capability above, not a separate spec-level change to cv-builder's own requirements. -->
+
+## Impact
+
+- **Backend:** migration `0028_cvs_agent_session.sql`; `internal/db/queries/cvs.sql` (return +
+  set `agent_session_id`, join job slug in the list); `internal/cv` (Meta/Record fields, store
+  method); `internal/handler/cv*.go` (a set-session endpoint; list returns the new fields).
+- **Frontend:** `/tailor/[slug]` resume mode + `ArtifactPanel` Edit tab (reuses `CvEditor`);
+  `CvList` rework; `/my/cvs/[id]` editor route redirects into the workspace.
+- **Tests:** Go unit (store) + integration (session set/read, list-with-slug); web vitest for
+  any pure logic; svelte-check + visual for components.
+- **Risk/seam:** the minted CLI token is short-lived (2h); resuming after it expires means the
+  agent's `freehire cv edit` would 401 — noted; a re-mint on resume is a follow-up.

--- a/openspec/changes/add-tailor-workspace/specs/tailor-workspace/spec.md
+++ b/openspec/changes/add-tailor-workspace/specs/tailor-workspace/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: A tailored CV remembers its agent session
+
+The system SHALL persist the agent session id bound to a tailored CV and return it on the CV
+reads, so the CV can re-open its exact session later. Writing the session id MUST be owner-scoped
+(a caller can only set it on their own CV).
+
+#### Scenario: The session id round-trips on a tailored CV
+
+- **WHEN** the owner sets the agent session id on their tailored CV and then reads the CV
+- **THEN** the read returns that session id
+
+#### Scenario: A foreign caller cannot set the session
+
+- **WHEN** a caller sets the session id on a CV they do not own
+- **THEN** the write is rejected (not found) and the CV is unchanged
+
+### Requirement: The tailoring workspace resumes an existing session
+
+The system SHALL, when `/tailor/[slug]` is opened for an existing tailored CV (`?cv=<id>`),
+re-attach to that CV's stored agent session WITHOUT bootstrapping a new CV or sending a kickoff
+prompt. Opening `/tailor/[slug]` without a CV reference SHALL bootstrap a new tailored CV and
+session and store the session id on it.
+
+#### Scenario: Re-opening a CV continues its conversation
+
+- **WHEN** a user opens the workspace for an existing tailored CV
+- **THEN** the existing agent session is attached (its prior messages replay) and no new session or kickoff is created
+
+#### Scenario: Opening without a CV starts a fresh session
+
+- **WHEN** a user opens the workspace from the match CTA (no CV reference)
+- **THEN** a new tailored CV + seeded session are created, the agent auto-starts, and the session id is stored on the new CV
+
+### Requirement: The CV editor lives in the workspace
+
+The workspace SHALL offer the structured CV editor as a tab alongside the CV preview, job
+description, and verdict, so the user edits the same tailored CV beside the chat.
+
+#### Scenario: The editor tab edits the tailored CV
+
+- **WHEN** the user opens the Edit tab and changes a field
+- **THEN** the change persists to the tailored CV (the same CV the chat and preview show)
+
+### Requirement: The CV list re-opens sessions and has no create action
+
+The CV list SHALL show the user's tailored CVs, each linking to its tailoring workspace
+(`/tailor/[slug]?cv=<id>`, resume), and SHALL NOT offer a create action — a tailored CV is
+created only from the match page. The list MUST carry the job slug and the session id needed to
+build each re-open link.
+
+#### Scenario: A list item re-opens its workspace
+
+- **WHEN** the user clicks a tailored CV in the list
+- **THEN** they land on that CV's tailoring workspace with its existing session
+
+#### Scenario: There is no create button
+
+- **WHEN** the user views the CV list
+- **THEN** no "create CV" action is shown

--- a/openspec/changes/add-tailor-workspace/tasks.md
+++ b/openspec/changes/add-tailor-workspace/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Backend: persist the CV→session link
 
-- [ ] 1.1 Migration `migrations/0028_cvs_agent_session.sql` — `ALTER TABLE cvs ADD COLUMN agent_session_id text;`
-- [ ] 1.2 `cvs.sql`: return `agent_session_id` on `GetCVByID`; add `SetCVSession(id, user_id, session_id)`; extend `ListCVsByUser` to `job_id IS NOT NULL`, joining `jobs` for `public_slug`, returning `agent_session_id`. Regenerate `internal/db` (`make sqlc`)
-- [ ] 1.3 `internal/cv`: `Record.AgentSessionID`, `Meta`/list shape gains `JobSlug` + `AgentSessionID`; `Store.SetSession(ctx, id, userID, sessionID)`; unit tests (fake repo): set→get round-trip, owner-scoping
+- [x] 1.1 Migration `migrations/0028_cvs_agent_session.sql` — `ALTER TABLE cvs ADD COLUMN agent_session_id text;`
+- [x] 1.2 `cvs.sql`: return `agent_session_id` on `GetCVByID`; add `SetCVSession(id, user_id, session_id)`; extend `ListCVsByUser` to `job_id IS NOT NULL`, joining `jobs` for `public_slug`, returning `agent_session_id`. Regenerate `internal/db` (`make sqlc`)
+- [x] 1.3 `internal/cv`: `Record.AgentSessionID`, `Meta`/list shape gains `JobSlug` + `AgentSessionID`; `Store.SetSession(ctx, id, userID, sessionID)`; unit tests (fake repo): set→get round-trip, owner-scoping
 
 ## 2. Backend: endpoints
 
-- [ ] 2.1 `PUT /me/cvs/:id/session {session_id}` handler (cookie or key + beta gate) → `Store.SetSession`; 404 on non-owner; wire route
-- [ ] 2.2 List/detail responses carry `agent_session_id` + `job_slug`; handler integration tests (set-session owner-scoping, list returns slug + session)
+- [x] 2.1 `PUT /me/cvs/:id/session {session_id}` handler (cookie or key + beta gate) → `Store.SetSession`; 404 on non-owner; wire route
+- [x] 2.2 List/detail responses carry `agent_session_id` + `job_slug`; handler integration tests (set-session owner-scoping, list returns slug + session)
 
 ## 3. Backend: contracts + verify
 
-- [ ] 3.1 Update the CV wire types (list/detail) in `cmd/gen-contracts` if the TS shape changed; regenerate
-- [ ] 3.2 `go build ./... && go vet ./... && go test ./...`; integration tests green
+- [x] 3.1 Update the CV wire types (list/detail) in `cmd/gen-contracts` if the TS shape changed; regenerate
+- [x] 3.2 `go build ./... && go vet ./... && go test ./...`; integration tests green
 
 ## 4. Frontend: /tailor resume mode + editor tab
 

--- a/openspec/changes/add-tailor-workspace/tasks.md
+++ b/openspec/changes/add-tailor-workspace/tasks.md
@@ -1,0 +1,32 @@
+## 1. Backend: persist the CV→session link
+
+- [ ] 1.1 Migration `migrations/0028_cvs_agent_session.sql` — `ALTER TABLE cvs ADD COLUMN agent_session_id text;`
+- [ ] 1.2 `cvs.sql`: return `agent_session_id` on `GetCVByID`; add `SetCVSession(id, user_id, session_id)`; extend `ListCVsByUser` to `job_id IS NOT NULL`, joining `jobs` for `public_slug`, returning `agent_session_id`. Regenerate `internal/db` (`make sqlc`)
+- [ ] 1.3 `internal/cv`: `Record.AgentSessionID`, `Meta`/list shape gains `JobSlug` + `AgentSessionID`; `Store.SetSession(ctx, id, userID, sessionID)`; unit tests (fake repo): set→get round-trip, owner-scoping
+
+## 2. Backend: endpoints
+
+- [ ] 2.1 `PUT /me/cvs/:id/session {session_id}` handler (cookie or key + beta gate) → `Store.SetSession`; 404 on non-owner; wire route
+- [ ] 2.2 List/detail responses carry `agent_session_id` + `job_slug`; handler integration tests (set-session owner-scoping, list returns slug + session)
+
+## 3. Backend: contracts + verify
+
+- [ ] 3.1 Update the CV wire types (list/detail) in `cmd/gen-contracts` if the TS shape changed; regenerate
+- [ ] 3.2 `go build ./... && go vet ./... && go test ./...`; integration tests green
+
+## 4. Frontend: /tailor resume mode + editor tab
+
+- [ ] 4.1 `api`: `setCvSession(id, sessionId)`; extend CV list/detail types with `agent_session_id` + `job_slug`
+- [ ] 4.2 `/tailor/[slug]`: resume mode (`?cv=<id>` → GET CV + job + analysis, attach existing `agent_session_id`, no kickoff); bootstrap mode stores the session id via `setCvSession` after `createSession`
+- [ ] 4.3 `ArtifactPanel`: an **Edit** tab reusing `CvEditor` (load + save the tailored CV)
+- [ ] 4.4 `<AssistantChat>` already opens a given `session` with no kickoff — verify resume attaches without re-sending
+
+## 5. Frontend: /my/cvs rework
+
+- [ ] 5.1 `CvList`: drop the create button; list tailored CVs; each row → `/tailor/<job_slug>?cv=<id>`
+- [ ] 5.2 `/my/cvs/[id]` editor route → redirect into the workspace (`/tailor/<slug>?cv=<id>`)
+
+## 6. Verify
+
+- [ ] 6.1 `svelte-check` + `vitest` + `npm run build` green
+- [ ] 6.2 Drive: match → tailor (fresh, stores session) → /my/cvs lists it → re-open resumes the SAME session (no kickoff) → Edit tab persists a field

--- a/openspec/changes/add-tailor-workspace/tasks.md
+++ b/openspec/changes/add-tailor-workspace/tasks.md
@@ -16,17 +16,17 @@
 
 ## 4. Frontend: /tailor resume mode + editor tab
 
-- [ ] 4.1 `api`: `setCvSession(id, sessionId)`; extend CV list/detail types with `agent_session_id` + `job_slug`
-- [ ] 4.2 `/tailor/[slug]`: resume mode (`?cv=<id>` → GET CV + job + analysis, attach existing `agent_session_id`, no kickoff); bootstrap mode stores the session id via `setCvSession` after `createSession`
-- [ ] 4.3 `ArtifactPanel`: an **Edit** tab reusing `CvEditor` (load + save the tailored CV)
-- [ ] 4.4 `<AssistantChat>` already opens a given `session` with no kickoff — verify resume attaches without re-sending
+- [x] 4.1 `api`: `setCvSession(id, sessionId)`; extend CV list/detail types with `agent_session_id` + `job_slug`
+- [x] 4.2 `/tailor/[slug]`: resume mode (`?cv=<id>` → GET CV + job + analysis, attach existing `agent_session_id`, no kickoff); bootstrap mode stores the session id via `setCvSession` after `createSession`
+- [x] 4.3 `ArtifactPanel`: an **Edit** tab reusing `CvEditor` (load + save the tailored CV); plus an "Open PDF" action opening the CV in a new tab
+- [x] 4.4 `<AssistantChat>` already opens a given `session` with no kickoff — verify resume attaches without re-sending
 
 ## 5. Frontend: /my/cvs rework
 
-- [ ] 5.1 `CvList`: drop the create button; list tailored CVs; each row → `/tailor/<job_slug>?cv=<id>`
-- [ ] 5.2 `/my/cvs/[id]` editor route → redirect into the workspace (`/tailor/<slug>?cv=<id>`)
+- [x] 5.1 `CvList`: drop the create button; list tailored CVs; each row → `/tailor/<job_slug>?cv=<id>`
+- [x] 5.2 `/my/cvs/[id]` editor route → redirect into the workspace (`/tailor/<slug>?cv=<id>`)
 
 ## 6. Verify
 
-- [ ] 6.1 `svelte-check` + `vitest` + `npm run build` green
+- [x] 6.1 `svelte-check` (0 errors) + `vitest` (301 pass) + `npm run build` green
 - [ ] 6.2 Drive: match → tailor (fresh, stores session) → /my/cvs lists it → re-open resumes the SAME session (no kickoff) → Edit tab persists a field

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -10,7 +10,14 @@
 // fetch per call site — not a module-level variable — keeps concurrent SSR
 // requests from sharing (and racing on) a session.
 
-import type { CvMeta, CvRecord, CreateCvInput, UpdateCvInput, TailorResult } from './cv';
+import type {
+  CvMeta,
+  CvRecord,
+  CvTailoredItem,
+  CreateCvInput,
+  UpdateCvInput,
+  TailorResult,
+} from './cv';
 import type {
   Job,
   EmailLinking,
@@ -1007,9 +1014,15 @@ export function createApi(
 
   // --- CV builder (beta-gated on the server) ---
 
-  /** List the caller's CVs (metadata, newest edit first). */
-  async function listCvs(): Promise<CvMeta[]> {
-    return requestData<CvMeta[]>('/api/v1/me/cvs');
+  /** List the caller's TAILORED CVs (the re-open list): each with its vacancy slug + bound
+   *  agent session, newest edit first. */
+  async function listCvs(): Promise<CvTailoredItem[]> {
+    return requestData<CvTailoredItem[]>('/api/v1/me/cvs');
+  }
+
+  /** Bind a roy agent session to a CV so its workspace can re-open that exact session. */
+  async function setCvSession(id: number, sessionId: string): Promise<void> {
+    await call(`/api/v1/me/cvs/${id}/session`, jsonBody('PUT', { session_id: sessionId }));
   }
 
   /** Create a CV, optionally seeded from the stored résumé structure. */
@@ -1149,6 +1162,7 @@ export function createApi(
     getCv,
     updateCv,
     deleteCv,
+    setCvSession,
     cvPdfUrl,
     tailorCv,
   };

--- a/web/src/lib/components/cv/CvEditor.svelte
+++ b/web/src/lib/components/cv/CvEditor.svelte
@@ -21,7 +21,9 @@
   // `as entry` and binds to the entry's fields — Svelte proxies each element of the
   // $state array, so edits flow back without index-based access.
 
-  let { id }: { id: number } = $props();
+  // `embedded` drops the standalone chrome (the "All CVs" back-link) when the editor lives
+  // inside the tailoring workspace tab, where navigation is owned by the surrounding surface.
+  let { id, embedded = false }: { id: number; embedded?: boolean } = $props();
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');
   let error = $state<string | null>(null);
@@ -84,9 +86,13 @@
 {:else}
   <div class="space-y-8">
     <div class="flex items-center justify-between gap-4">
-      <a href="/my/cvs" class="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
-        <ArrowLeft class="h-4 w-4" /> All CVs
-      </a>
+      {#if embedded}
+        <span></span>
+      {:else}
+        <a href="/my/cvs" class="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft class="h-4 w-4" /> All CVs
+        </a>
+      {/if}
       <div class="flex items-center gap-2">
         {#if notice}<span class="text-sm text-muted-foreground">{notice}</span>{/if}
         {#if error}<span class="text-sm text-destructive">{error}</span>{/if}

--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { FileText, Download, Trash2, Plus } from '@lucide/svelte';
+  import { FileText, Download, Trash2 } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { Button } from '$lib/ui';
-  import { cvTitle, type CvMeta } from '$lib/cv';
+  import { cvTitle, type CvTailoredItem } from '$lib/cv';
 
-  // The CV builder landing: the caller's CVs with create / edit / download / delete.
-  // Creating seeds from the stored résumé structure when one exists (the server decides).
+  // The tailored-CV landing: every CV the caller built for a specific vacancy, each a shortcut
+  // back into its tailoring workspace (which resumes the same agent session). CVs are created
+  // only from a vacancy's match page, so there is no create action here.
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');
   let error = $state<string | null>(null);
-  let creating = $state(false);
-  let items = $state<CvMeta[]>([]);
+  let items = $state<CvTailoredItem[]>([]);
 
   onMount(load);
 
@@ -27,19 +26,7 @@
     }
   }
 
-  async function create() {
-    creating = true;
-    error = null;
-    try {
-      const rec = await api.createCv({ seed: true });
-      await goto(`/my/cvs/${rec.id}`);
-    } catch (e) {
-      error = e instanceof ApiError ? e.message : 'Could not create a CV. Please try again.';
-      creating = false;
-    }
-  }
-
-  async function remove(cv: CvMeta) {
+  async function remove(cv: CvTailoredItem) {
     if (!window.confirm(`Delete “${cvTitle(cv.title)}”? This cannot be undone.`)) return;
     try {
       await api.deleteCv(cv.id);
@@ -53,14 +40,12 @@
 </script>
 
 <div class="space-y-6">
-  <div class="flex items-center justify-between gap-4">
-    <div>
-      <h1 class="text-2xl font-semibold">CV builder</h1>
-      <p class="text-sm text-muted-foreground">Build tailored, ATS-friendly CVs and export them to PDF.</p>
-    </div>
-    <Button variant="primary" onclick={create} disabled={creating}>
-      <Plus class="mr-1 h-4 w-4" /> {creating ? 'Creating…' : 'New CV'}
-    </Button>
+  <div>
+    <h1 class="text-2xl font-semibold">Tailored CVs</h1>
+    <p class="text-sm text-muted-foreground">
+      CVs you tailored for specific roles. Open one to resume its tailoring session, or start a new
+      one from any vacancy’s match page.
+    </p>
   </div>
 
   {#if error}<p class="text-sm text-destructive">{error}</p>{/if}
@@ -70,16 +55,16 @@
   {:else if status === 'ready' && items.length === 0}
     <div class="rounded-lg border border-dashed border-border p-10 text-center">
       <FileText class="mx-auto h-8 w-8 text-muted-foreground" />
-      <p class="mt-2 font-medium">No CVs yet</p>
+      <p class="mt-2 font-medium">No tailored CVs yet</p>
       <p class="text-sm text-muted-foreground">
-        Create your first CV — it starts from your uploaded résumé when you have one.
+        Open a vacancy, run the match analysis, and choose “Tailor my CV” to build one here.
       </p>
     </div>
   {:else}
     <ul class="divide-y divide-border rounded-lg border border-border">
       {#each items as cv (cv.id)}
         <li class="flex items-center justify-between gap-4 p-4">
-          <a href="/my/cvs/{cv.id}" class="min-w-0 flex-1">
+          <a href="/tailor/{cv.job_slug}?cv={cv.id}" class="min-w-0 flex-1">
             <span class="block truncate font-medium">{cvTitle(cv.title)}</span>
             <span class="text-xs text-muted-foreground">Updated {fmt(cv.updated_at)} · {cv.template_id}</span>
           </a>

--- a/web/src/lib/cv.ts
+++ b/web/src/lib/cv.ts
@@ -23,9 +23,18 @@ export interface CvMeta {
   updated_at: string;
 }
 
-/** A CV with its full editable document. */
+/** A CV with its full editable document. `agent_session_id` is the roy session bound to a
+ *  tailored CV (empty when none) — the workspace resumes it. */
 export interface CvRecord extends CvMeta {
+  agent_session_id: string;
   document: Document;
+}
+
+/** A tailored CV in the /my/cvs re-open list: metadata plus the vacancy slug and the bound
+ *  agent session, so a row links straight to its tailoring workspace. */
+export interface CvTailoredItem extends CvMeta {
+  job_slug: string;
+  agent_session_id: string;
 }
 
 /**

--- a/web/src/lib/tailor/ArtifactPanel.svelte
+++ b/web/src/lib/tailor/ArtifactPanel.svelte
@@ -4,9 +4,11 @@
   // verdict. JD and verdict reuse the SAME components the job page / fit page use, so they read
   // identically. Splitter width is clamped by the vitest-covered clampWidth.
   import { clampWidth } from './geometry';
+  import { ExternalLink } from '@lucide/svelte';
   import { api } from '$lib/api';
   import JobDescription from '$lib/components/JobDescription.svelte';
   import JobFitFull from '$lib/components/JobFitFull.svelte';
+  import CvEditor from '$lib/components/cv/CvEditor.svelte';
   import type { Analysis } from '$lib/generated/contracts';
   import type { Job, JobFitResponse } from '$lib/types';
 
@@ -22,9 +24,10 @@
     refreshKey?: number;
   } = $props();
 
-  type Tab = 'cv' | 'jd' | 'verdict';
+  type Tab = 'cv' | 'edit' | 'jd' | 'verdict';
   const tabs: [Tab, string][] = [
     ['cv', 'CV'],
+    ['edit', 'Edit'],
     ['jd', 'Job description'],
     ['verdict', 'Verdict'],
   ];
@@ -65,24 +68,40 @@
   class="hidden shrink-0 flex-col border-l border-border bg-background lg:flex"
   style="width: {width}px"
 >
-  <div class="flex items-center gap-1 border-b border-border px-2 py-1.5 text-sm">
-    {#each tabs as [id, label] (id)}
-      <button
-        type="button"
-        onclick={() => (tab = id)}
-        class={[
-          'rounded px-2 py-1 transition-colors',
-          tab === id ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground',
-        ]}
-      >
-        {label}
-      </button>
-    {/each}
+  <div class="flex items-center justify-between border-b border-border px-2 py-1.5 text-sm">
+    <div class="flex items-center gap-1">
+      {#each tabs as [id, label] (id)}
+        <button
+          type="button"
+          onclick={() => (tab = id)}
+          class={[
+            'rounded px-2 py-1 transition-colors',
+            tab === id ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:text-foreground',
+          ]}
+        >
+          {label}
+        </button>
+      {/each}
+    </div>
+    <a
+      href={api.cvPdfUrl(cvId)}
+      target="_blank"
+      rel="noopener"
+      title="Open the CV PDF in a new tab"
+      class="inline-flex items-center gap-1 rounded px-2 py-1 text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <ExternalLink class="size-4" />
+      <span class="hidden xl:inline">Open PDF</span>
+    </a>
   </div>
 
   <div class="min-h-0 flex-1 overflow-auto">
     {#if tab === 'cv'}
       <iframe src={cvUrl} title="CV preview" class="h-full w-full"></iframe>
+    {:else if tab === 'edit'}
+      <div class="p-4">
+        <CvEditor id={cvId} embedded />
+      </div>
     {:else if tab === 'jd'}
       <div class="p-4">
         {#if job.description}

--- a/web/src/routes/my/cvs/[id]/+page.svelte
+++ b/web/src/routes/my/cvs/[id]/+page.svelte
@@ -1,24 +1,25 @@
 <script lang="ts">
+  // Legacy entry point: the standalone CV editor moved into the tailoring workspace tab. Resolve
+  // this CV's vacancy slug from the tailored list and redirect into /tailor/<slug>?cv=<id>. A CV
+  // that isn't tied to a vacancy (or a load failure) falls back to the tailored-CV list.
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
   import { page } from '$app/state';
-  import { currentUser } from '$lib/auth.svelte';
-  import CvEditor from '$lib/components/cv/CvEditor.svelte';
+  import { api } from '$lib/api';
 
   const id = $derived(Number(page.params.id));
-  const eligible = $derived(
-    currentUser()?.beta_tester === true || currentUser()?.role === 'moderator',
-  );
+
+  onMount(async () => {
+    try {
+      const items = await api.listCvs();
+      const match = items.find((cv) => cv.id === id);
+      await goto(match ? `/tailor/${match.job_slug}?cv=${id}` : '/my/cvs', { replaceState: true });
+    } catch {
+      await goto('/my/cvs', { replaceState: true });
+    }
+  });
 </script>
 
-<svelte:head>
-  <title>Edit CV — freehire</title>
-</svelte:head>
+<svelte:head><title>Opening CV… — freehire</title></svelte:head>
 
-<div class="max-w-3xl">
-  {#if eligible}
-    {#key id}
-      <CvEditor {id} />
-    {/key}
-  {:else}
-    <p class="text-muted-foreground">The CV builder is in beta and not available on your account yet.</p>
-  {/if}
-</div>
+<p class="text-muted-foreground">Opening your tailoring workspace…</p>

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
-  // The dedicated CV-tailoring surface: full-width, chat on the left, a tabbed artifact panel
-  // (CV / Job description / Verdict) on the right. On load it bootstraps the tailored CV and a
-  // seeded agent session, then auto-starts the agent (kickoff). Reuses <AssistantChat>.
+  // The dedicated CV-tailoring workspace: full-width, chat on the left, a tabbed artifact panel
+  // (CV · Edit · Job description · Verdict) on the right. Two modes:
+  //  - bootstrap (no ?cv): create the tailored CV + a seeded agent session, auto-start, and
+  //    store the session id on the CV so it can be re-opened.
+  //  - resume (?cv=<id>): reuse the existing CV + its stored session — re-attach, NO kickoff.
   import { onMount } from 'svelte';
   import { page } from '$app/state';
   import { api, ApiError } from '$lib/api';
@@ -13,6 +15,7 @@
   import type { Job } from '$lib/types';
 
   const slug = $derived(page.params.slug ?? '');
+  const cvParam = $derived(page.url.searchParams.get('cv'));
   const eligible = $derived(
     currentUser()?.beta_tester === true || currentUser()?.role === 'moderator',
   );
@@ -20,6 +23,7 @@
   let status = $state<'loading' | 'ready' | 'error'>('loading');
   let errorMsg = $state('');
   let sessionId = $state<string | undefined>(undefined);
+  let resuming = $state(false);
   let cvId = $state(0);
   let analysis = $state<Analysis | null>(null);
   let job = $state<Job | null>(null);
@@ -36,19 +40,35 @@
       return;
     }
     try {
-      // The job (for the JD tab + session name) and the tailoring bootstrap in parallel.
-      const [j, tailor] = await Promise.all([api.getJob(slug), api.tailorCv(slug)]);
-      job = j;
-      cvId = tailor.tailor_cv_id;
-      analysis = tailor.analysis;
-      sessionId = await createSession({
-        cli_token: tailor.cli_token,
-        cv_id: tailor.tailor_cv_id,
-        base_cv_id: tailor.base_cv_id,
-      });
+      if (cvParam) {
+        // Resume: reuse the existing tailored CV and re-attach its stored session.
+        resuming = true;
+        const existing = Number(cvParam);
+        const [j, rec, fit] = await Promise.all([
+          api.getJob(slug),
+          api.getCv(existing),
+          api.getJobFit(slug).catch(() => null),
+        ]);
+        job = j;
+        cvId = existing;
+        analysis = fit?.analysis ?? null;
+        sessionId = rec.agent_session_id || undefined;
+      } else {
+        // Bootstrap: create the tailored CV + a seeded session, then bind the session to the CV.
+        const [j, tailor] = await Promise.all([api.getJob(slug), api.tailorCv(slug)]);
+        job = j;
+        cvId = tailor.tailor_cv_id;
+        analysis = tailor.analysis;
+        sessionId = await createSession({
+          cli_token: tailor.cli_token,
+          cv_id: tailor.tailor_cv_id,
+          base_cv_id: tailor.base_cv_id,
+        });
+        await api.setCvSession(tailor.tailor_cv_id, sessionId).catch(() => {}); // best-effort
+      }
       status = 'ready';
     } catch (e) {
-      errorMsg = e instanceof ApiError ? e.message : 'Could not start tailoring. Please try again.';
+      errorMsg = e instanceof ApiError ? e.message : 'Could not open the tailoring workspace.';
       status = 'error';
     }
   });
@@ -58,7 +78,7 @@
 
 {#if status === 'loading'}
   <div class="flex h-[calc(100svh-3.5rem)] items-center justify-center text-sm text-muted-foreground">
-    Preparing your tailoring session…
+    {resuming ? 'Re-opening your tailoring session…' : 'Preparing your tailoring session…'}
   </div>
 {:else if status === 'error'}
   <div class="flex h-[calc(100svh-3.5rem)] flex-col items-center justify-center gap-3 p-6 text-center">
@@ -69,7 +89,7 @@
   <div class="flex h-[calc(100svh-3.5rem)]">
     <AssistantChat
       session={sessionId}
-      {kickoff}
+      kickoff={resuming ? undefined : kickoff}
       {sessionLabel}
       showSessionRail={false}
       onTurnComplete={() => (refreshKey += 1)}


### PR DESCRIPTION
## What

The dedicated CV-tailoring surface (`/tailor/[slug]`) becomes re-openable: a tailored CV now remembers the roy agent session that shaped it, so `/my/cvs` links reopen the **same** conversation instead of starting fresh. The section-form editor moves into a tab on the workspace, and CVs are created only from a vacancy's match page.

## Backend (`add-tailor-workspace`)
- Migration `0028_cvs_agent_session.sql` — `cvs.agent_session_id text`
- `SetCVSession` (owner-scoped) + `PUT /me/cvs/:id/session` (cookie-or-key, beta-gated)
- `ListTailoredCVsByUser` — tailored CVs only, joined to `jobs` for `public_slug`, carrying the bound session id
- List/detail responses carry `agent_session_id` + `job_slug`

## Frontend
- `/tailor/[slug]` two modes: **bootstrap** (create CV + seeded session, bind the session id) and **resume** (`?cv=<id>` → reuse CV + stored `agent_session_id`, no kickoff)
- `ArtifactPanel`: **Edit** tab reusing `CvEditor` (embedded chrome) + an **Open PDF** action (new tab)
- `CvList`: drop the create button; list tailored CVs; each row → `/tailor/<job_slug>?cv=<id>`
- `/my/cvs/[id]`: redirect the legacy editor route into the workspace

## Verify
- `go build/vet/test` green; `internal/cv` + `internal/handler` (incl. integration) pass
- `svelte-check` 0 errors · `vitest` 301 pass · `npm run build` green

## Deploy note
⚠️ Apply migration `0028` to prod **before** rolling the backend (unapplied column → 500s on the new query path).