### PR TITLE
fix(sources): route vagas through egress proxy

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -404,6 +404,11 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// like djinni's, setting SOURCES_PROXY_URL routes only this provider through the proxy with
 	// no code change; while the proxy is unset this entry is inert.
 	"onstrider": func(c HTTPClient) Source { return NewOnstrider(c) },
+	// vagas.com.br hard-blocks the prod datacenter IP: the very first listing GET returns 403
+	// from the datacenter IP while a residential IP is served the full HTML. Unlike the volume
+	// rate-limiters above, a single request trips it, so it must egress through the proxy.
+	// NewVagas takes an HTMLGetter, which HTTPClient satisfies.
+	"vagas": func(c HTTPClient) Source { return NewVagas(c) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy

--- a/internal/sources/vagas_test.go
+++ b/internal/sources/vagas_test.go
@@ -129,6 +129,14 @@ func TestVagasFirstAreaFailure(t *testing.T) {
 	}
 }
 
+func TestVagasIsProxied(t *testing.T) {
+	// vagas.com.br 403s the prod datacenter IP on the very first listing request, so vagas
+	// must egress through the proxy (a residential IP is served the full HTML).
+	if _, ok := proxiedProviders["vagas"]; !ok {
+		t.Error("vagas must be in proxiedProviders (its edge 403s the prod datacenter IP)")
+	}
+}
+
 func TestVagasJobID(t *testing.T) {
 	cases := map[string]string{
 		"/vagas/v2820917/assistente-ti":           "2820917",


### PR DESCRIPTION
## Problem
`vagas.com.br` hard-blocks the prod datacenter IP: the very first listing `GET` returns **403** from the datacenter IP, while a residential IP is served the full HTML. Prod `board_health` showed `last_success_at = NULL` — vagas has **never** ingested a single job on prod.

## Fix
Add `vagas` to `proxiedProviders` so its crawl egresses through `SOURCES_PROXY_URL` like the other IP-blocked sources (djinni, 2gis, careerspage, …). A single request trips the block (not volume rate-limiting), so it belongs with the hard-block set.

- `internal/sources/source.go` — one entry in `proxiedProviders`
- `internal/sources/vagas_test.go` — `TestVagasIsProxied` guard (mirrors `TestDjinniIsProxied`)

Verified through the (now-restored) prod proxy: vagas listing + detail return 200. `ApplyProxyEgress` already rewires any `proxiedProviders` entry onto the proxy client; `HTTPClient` embeds `HTMLGetter`, so `NewVagas(c)` compiles.

`go build ./... && go vet ./... && go test ./internal/sources/` all green.