### PR TITLE
feat(tailor): bundle vacancy into cv-context + resume sessions for legacy CVs

### DIFF
--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -105,6 +105,50 @@ func (a *API) TailorCV(c *fiber.Ctx) error {
 	}})
 }
 
+// tailorSessionResponse re-establishes a tailoring session for an EXISTING tailored CV (one
+// created before session binding, or whose session was lost): the CV + base ids and a freshly
+// minted CLI token, so the browser can seed a new agent session bound to the same CV.
+type tailorSessionResponse struct {
+	TailorCVID int64  `json:"tailor_cv_id"`
+	BaseCVID   int64  `json:"base_cv_id"`
+	CLIToken   string `json:"cli_token"`
+}
+
+// StartTailorSession mints a CLI credential for an existing tailored CV so the workspace can
+// resume tailoring when the CV has no bound agent session yet. Cookie-only (the browser starts
+// it); 409 when the CV is not a tailored copy. Never calls the LLM.
+func (a *API) StartTailorSession(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := c.ParamsInt("id")
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
+	}
+	rec, err := a.cvStore.Get(c.Context(), int64(id), userID)
+	if err != nil {
+		return mapCVError(err)
+	}
+	if rec.JobID == 0 {
+		return fiber.NewError(fiber.StatusConflict, "not a tailored CV")
+	}
+	base, ok, err := a.cvStore.BaseCV(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fiber.NewError(fiber.StatusConflict, "no base CV")
+	}
+	token, err := mintTailoringKey(c.Context(), a.queries, userID, time.Now())
+	if err != nil {
+		return err
+	}
+	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": tailorSessionResponse{
+		TailorCVID: rec.ID, BaseCVID: base.ID, CLIToken: token,
+	}})
+}
+
 // PatchCV applies one field-level patch to an owned CV. Cookie or API key (the agent's CLI
 // uses the key). Bad addressing is a 422; a foreign/missing id is a 404.
 func (a *API) PatchCV(c *fiber.Ctx) error {
@@ -127,10 +171,21 @@ func (a *API) PatchCV(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{"data": metaResponse(meta)})
 }
 
+// tailorJob is the vacancy the agent reframes toward: enough of the posting to ground the
+// reframing in the real role. The description is free text the agent reads as data (tool
+// output), never as instructions.
+type tailorJob struct {
+	Title       string `json:"title"`
+	Company     string `json:"company"`
+	Slug        string `json:"public_slug"`
+	Description string `json:"description"`
+}
+
 // tailorContextResponse is the reasoning context the agent reads (freehire cv context): the
-// verdict and recommendation, per-dimension comments, and the requirement split the honest
-// wall turns on — missing_have (reframe existing evidence) vs missing_gap (must ask first).
+// vacancy, the verdict and recommendation, per-dimension comments, and the requirement split
+// the honest wall turns on — missing_have (reframe existing evidence) vs missing_gap (ask first).
 type tailorContextResponse struct {
+	Job            tailorJob            `json:"job"`
 	Verdict        string               `json:"verdict"`
 	OverallScore   int                  `json:"overall_score"`
 	Recommendation string               `json:"recommendation"`
@@ -164,7 +219,11 @@ func (a *API) TailorContext(c *fiber.Ctx) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(fiber.Map{"data": tailorContext(analysis)})
+	job, err := a.queries.GetJob(c.Context(), rec.JobID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": tailorContext(analysis, job)})
 }
 
 // cachedAnalysis loads the cached fit analysis for (user, job), or a 409 telling the caller to
@@ -185,9 +244,9 @@ func (a *API) cachedAnalysis(c *fiber.Ctx, userID, jobID int64) (*jobfit.Analysi
 	return analysis, nil
 }
 
-// tailorContext projects an analysis to the agent's reasoning context, splitting requirements
-// into the reframe-able (missing-have) and the genuine gaps (missing-gap).
-func tailorContext(a *jobfit.Analysis) tailorContextResponse {
+// tailorContext projects an analysis + its vacancy to the agent's reasoning context, splitting
+// requirements into the reframe-able (missing-have) and the genuine gaps (missing-gap).
+func tailorContext(a *jobfit.Analysis, job db.Job) tailorContextResponse {
 	var have, gap []jobfit.Requirement
 	for _, r := range a.RequirementMatch {
 		switch r.Status {
@@ -198,6 +257,12 @@ func tailorContext(a *jobfit.Analysis) tailorContextResponse {
 		}
 	}
 	return tailorContextResponse{
+		Job: tailorJob{
+			Title:       job.Title,
+			Company:     job.Company,
+			Slug:        job.PublicSlug,
+			Description: job.Description,
+		},
 		Verdict:        a.Verdict,
 		OverallScore:   a.OverallScore,
 		Recommendation: a.Recommendation,

--- a/internal/handler/cv_tailor_integration_test.go
+++ b/internal/handler/cv_tailor_integration_test.go
@@ -250,6 +250,10 @@ func TestTailorContextSplit(t *testing.T) {
 	if got.Data.Verdict != "Good Fit" {
 		t.Errorf("verdict = %q", got.Data.Verdict)
 	}
+	// The vacancy is bundled in so the agent sees the role it reframes toward.
+	if got.Data.Job.Title != "Backend Engineer" || got.Data.Job.Slug != "backend-eng" {
+		t.Errorf("job = %+v, want title=Backend Engineer slug=backend-eng", got.Data.Job)
+	}
 
 	// A base CV (no bound vacancy) is not tailorable-context → 409.
 	base, _ := h.cvStore.Create(ctx, user, "Base", cv.DefaultTemplateID, cv.Document{})

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -463,6 +463,7 @@ func Register(app *fiber.App, cfg Config) {
 	// Tailoring: the browser starts a session (cookie-only bootstrap); the agent's CLI drives
 	// the edit + context/get/render reads with its minted API key (keyAuth = cookie or Bearer).
 	api.Post("/me/cvs/tailor", saved, cvGate, a.TailorCV)
+	api.Post("/me/cvs/:id/tailor-session", saved, cvGate, a.StartTailorSession)
 	api.Patch("/me/cvs/:id", keyAuth, cvGate, a.PatchCV)
 	api.Put("/me/cvs/:id/session", keyAuth, cvGate, a.SetCVSession)
 	api.Get("/me/cvs/:id/tailor-context", keyAuth, cvGate, a.TailorContext)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1053,6 +1053,15 @@ export function createApi(
     return requestData<TailorResult>('/api/v1/me/cvs/tailor', jsonBody('POST', { job_slug: jobSlug }));
   }
 
+  /**
+   * Re-establish a tailoring session for an EXISTING tailored CV that has no bound agent session
+   * (one created before session binding): mints a fresh CLI token and returns the CV + base ids
+   * so the workspace can seed a new agent session against the same CV.
+   */
+  async function startTailorSession(id: number): Promise<TailorResult> {
+    return requestData<TailorResult>(`/api/v1/me/cvs/${id}/tailor-session`, jsonBody('POST', {}));
+  }
+
   return {
     listJobs,
     getJob,
@@ -1158,6 +1167,7 @@ export function createApi(
     setCvSession,
     cvPdfUrl,
     tailorCv,
+    startTailorSession,
   };
 }
 

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -41,8 +41,9 @@
     }
     try {
       if (cvParam) {
-        // Resume: reuse the existing tailored CV and re-attach its stored session.
-        resuming = true;
+        // Resume an existing tailored CV. If it already has a bound session, re-attach it with
+        // no kickoff. If it has none (a CV created before session binding), mint a fresh
+        // tailoring session for it and let the kickoff orient the agent.
         const existing = Number(cvParam);
         const [j, rec, fit] = await Promise.all([
           api.getJob(slug),
@@ -52,7 +53,18 @@
         job = j;
         cvId = existing;
         analysis = fit?.analysis ?? null;
-        sessionId = rec.agent_session_id || undefined;
+        if (rec.agent_session_id) {
+          resuming = true;
+          sessionId = rec.agent_session_id;
+        } else {
+          const s = await api.startTailorSession(existing);
+          sessionId = await createSession({
+            cli_token: s.cli_token,
+            cv_id: existing,
+            base_cv_id: s.base_cv_id,
+          });
+          await api.setCvSession(existing, sessionId).catch(() => {}); // best-effort
+        }
       } else {
         // Bootstrap: create the tailored CV + a seeded session, then bind the session to the CV.
         const [j, tailor] = await Promise.all([api.getJob(slug), api.tailorCv(slug)]);


### PR DESCRIPTION
The tailoring agent couldn't see the job posting — `freehire cv context` returned only the fit verdict/requirements, so the agent had no vacancy to ground reframing in (and answered generically).

## Changes
- **Bundle the vacancy into `freehire cv context`**: `job` (title, company, public_slug, description). Free text read by the agent as tool output (data), never as system-prompt instructions — the prompt-injection boundary is preserved.
- **`POST /me/cvs/:id/tailor-session`**: mint a CLI token + base id for an EXISTING tailored CV with no bound agent session (created before session binding).
- **`/tailor` resume flow**: when the CV has no bound session, seed a fresh tailoring session against it and kick off orientation — instead of falling back to a generic non-tailoring session.

Pairs with the freehire-agent persona update (agent now loads `cv context` + `cv get` before its first reply). CLI needs no change — `cv context` is pass-through JSON.

## Verify
- `go build/vet` green; integration `TestTailorContextSplit` asserts the vacancy is bundled
- `svelte-check` 0 errors · `npm run build` green