### PR TITLE
fix(sources): rate-pace vagas crawl through the proxy

### DIFF
--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -50,3 +50,23 @@ func pacedCareerPageGetter(c HTMLGetter) HTMLGetter {
 		limiter: rate.NewLimiter(rate.Every(careerspageRequestInterval), careerspageRequestBurst),
 	}
 }
+
+// vagas.com.br rate-limits by a per-IP request budget: a full national-board crawl (three area
+// listings paginated + a detail fan-out over hundreds of postings) fired unpaced through the
+// single egress proxy IP 429s that IP and then 429s even spaced requests during the penalty
+// window. Its detail pool bursts to defaultDetailWorkers, so the pacer — not the pool — must
+// hold the aggregate rate under the window. The interval is more conservative than careerspage's
+// because vagas 429'd hard and its true budget is unknown; tune from observed convergence.
+const (
+	vagasRequestInterval = time.Second // ~1 req/s
+	vagasRequestBurst    = 1
+)
+
+// pacedVagasGetter wraps a getter with a fresh limiter shared across one registry build, so all
+// of vagas's requests in a run stay under vagas.com.br's per-IP window on the single proxy IP.
+func pacedVagasGetter(c HTMLGetter) HTMLGetter {
+	return rateLimitedHTMLGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(vagasRequestInterval), vagasRequestBurst),
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -404,11 +404,13 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// like djinni's, setting SOURCES_PROXY_URL routes only this provider through the proxy with
 	// no code change; while the proxy is unset this entry is inert.
 	"onstrider": func(c HTTPClient) Source { return NewOnstrider(c) },
-	// vagas.com.br hard-blocks the prod datacenter IP: the very first listing GET returns 403
-	// from the datacenter IP while a residential IP is served the full HTML. Unlike the volume
-	// rate-limiters above, a single request trips it, so it must egress through the proxy.
-	// NewVagas takes an HTMLGetter, which HTTPClient satisfies.
-	"vagas": func(c HTTPClient) Source { return NewVagas(c) },
+	// vagas.com.br blocks the prod datacenter IP (403 on the first listing GET) AND rate-limits
+	// by a per-IP request budget (429 once a full crawl's volume hits one IP). So it egresses
+	// through the proxy like careerspage AND is rate-paced (pacedVagasGetter) to hold its
+	// aggregate request rate under vagas's window on the single proxy IP — concurrency bounds the
+	// burst, pacing bounds the total-per-window. NewVagas takes an HTMLGetter, which HTTPClient
+	// satisfies, and the pacer wraps it before NewVagas.
+	"vagas": func(c HTTPClient) Source { return NewVagas(pacedVagasGetter(c)) },
 }
 
 // ApplyProxyEgress rewires the proxiedProviders in registry to egress through the proxy

--- a/internal/sources/vagas_test.go
+++ b/internal/sources/vagas_test.go
@@ -137,6 +137,22 @@ func TestVagasIsProxied(t *testing.T) {
 	}
 }
 
+func TestPacedVagasGetterPaces(t *testing.T) {
+	// vagas 429s the single proxy IP under an unpaced burst, so its crawl must go through a
+	// rate limiter (mirrors careerspage). Guard that the wrapper actually paces, not passes raw.
+	inner := &recordingHTMLGetter{node: &html.Node{}}
+	g, ok := pacedVagasGetter(inner).(rateLimitedHTMLGetter)
+	if !ok {
+		t.Fatal("pacedVagasGetter must return a rate-limited getter")
+	}
+	if g.inner != HTMLGetter(inner) {
+		t.Fatal("pacedVagasGetter must wrap the given getter")
+	}
+	if g.limiter == nil {
+		t.Fatal("pacedVagasGetter must install a limiter")
+	}
+}
+
 func TestVagasJobID(t *testing.T) {
 	cases := map[string]string{
 		"/vagas/v2820917/assistente-ti":           "2820917",


### PR DESCRIPTION
## Why
Follow-up to #862. Adding vagas to `proxiedProviders` was necessary (it 403s the prod datacenter IP) but **not sufficient**: verified on prod that a full vagas crawl fired unpaced (8-way detail burst) through the single egress proxy IP gets **429**-rate-limited by vagas.com.br, and the run then stalls on the penalised connection. vagas has careerspage's *volume rate-limit* profile, not a pure hard-block.

## Fix
Wrap vagas in a shared `rate.Limiter` via a new `pacedVagasGetter` — mirrors `pacedCareerPageGetter`, reusing the existing `rateLimitedHTMLGetter`. The detail pool bounds the burst; the pacer bounds total-per-window so the aggregate request rate stays under vagas's per-IP budget on the single proxy IP.

- `internal/sources/pacer.go` — `pacedVagasGetter` + `vagasRequestInterval`/`vagasRequestBurst` (~1 req/s, conservative)
- `internal/sources/source.go` — `"vagas": NewVagas(pacedVagasGetter(c))`
- `internal/sources/vagas_test.go` — `TestPacedVagasGetterPaces` guard against reverting to unpaced

Interval is conservative (vagas 429'd hard, true budget unknown); tune from observed convergence. `go build/vet/test ./internal/sources/` all green.