### PR TITLE
feat(assistant): auto-reconnect + button; /my/cvs company cards

### DIFF
--- a/internal/cv/store.go
+++ b/internal/cv/store.go
@@ -40,11 +40,14 @@ type Record struct {
 	Document       Document
 }
 
-// TailoredItem is a tailored CV in the re-open list: metadata plus the vacancy slug and the
-// bound agent session, so a row links straight back to its tailoring workspace.
+// TailoredItem is a tailored CV in the re-open list: metadata plus the vacancy (slug, title,
+// company) and the bound agent session, so a row renders as a company card that links straight
+// back to its tailoring workspace.
 type TailoredItem struct {
 	Meta
 	JobSlug        string
+	JobTitle       string
+	JobCompany     string
 	AgentSessionID string
 }
 
@@ -163,6 +166,8 @@ func (s *Store) ListTailored(ctx context.Context, userID int64) ([]TailoredItem,
 		out[i] = TailoredItem{
 			Meta:           Meta{ID: r.ID, Title: r.Title, TemplateID: r.TemplateID, CreatedAt: r.CreatedAt.Time, UpdatedAt: r.UpdatedAt.Time},
 			JobSlug:        r.JobSlug,
+			JobTitle:       r.JobTitle,
+			JobCompany:     r.JobCompany,
 			AgentSessionID: textValue(r.AgentSessionID),
 		}
 	}

--- a/internal/db/cvs.sql.go
+++ b/internal/db/cvs.sql.go
@@ -235,7 +235,7 @@ func (q *Queries) ListCVsByUser(ctx context.Context, userID int64) ([]ListCVsByU
 
 const listTailoredCVsByUser = `-- name: ListTailoredCVsByUser :many
 SELECT c.id, c.title, c.template_id, c.agent_session_id, j.public_slug AS job_slug,
-       c.created_at, c.updated_at
+       j.title AS job_title, j.company AS job_company, c.created_at, c.updated_at
 FROM cvs c
 JOIN jobs j ON j.id = c.job_id
 WHERE c.user_id = $1 AND c.job_id IS NOT NULL
@@ -248,6 +248,8 @@ type ListTailoredCVsByUserRow struct {
 	TemplateID     string             `json:"template_id"`
 	AgentSessionID pgtype.Text        `json:"agent_session_id"`
 	JobSlug        string             `json:"job_slug"`
+	JobTitle       string             `json:"job_title"`
+	JobCompany     string             `json:"job_company"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
 	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
 }
@@ -270,6 +272,8 @@ func (q *Queries) ListTailoredCVsByUser(ctx context.Context, userID int64) ([]Li
 			&i.TemplateID,
 			&i.AgentSessionID,
 			&i.JobSlug,
+			&i.JobTitle,
+			&i.JobCompany,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {

--- a/internal/db/queries/cvs.sql
+++ b/internal/db/queries/cvs.sql
@@ -18,7 +18,7 @@ ORDER BY updated_at DESC;
 -- vacancy's public slug and the bound agent session so each row links back to its workspace.
 -- Base CVs (job_id NULL) are excluded; the JOIN also drops tailored CVs whose job was deleted.
 SELECT c.id, c.title, c.template_id, c.agent_session_id, j.public_slug AS job_slug,
-       c.created_at, c.updated_at
+       j.title AS job_title, j.company AS job_company, c.created_at, c.updated_at
 FROM cvs c
 JOIN jobs j ON j.id = c.job_id
 WHERE c.user_id = $1 AND c.job_id IS NOT NULL

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -39,6 +39,8 @@ type cvResponse struct {
 type cvTailoredResponse struct {
 	cvMetaResponse
 	JobSlug        string `json:"job_slug"`
+	JobTitle       string `json:"job_title"`
+	JobCompany     string `json:"job_company"`
 	AgentSessionID string `json:"agent_session_id"`
 }
 
@@ -80,6 +82,8 @@ func (a *API) ListCVs(c *fiber.Ctx) error {
 		out[i] = cvTailoredResponse{
 			cvMetaResponse: metaResponse(m.Meta),
 			JobSlug:        m.JobSlug,
+			JobTitle:       m.JobTitle,
+			JobCompany:     m.JobCompany,
 			AgentSessionID: m.AgentSessionID,
 		}
 	}

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -12,6 +12,7 @@
     Trash2,
     Plus,
     PanelLeft,
+    RefreshCw,
   } from '@lucide/svelte';
   import { currentUser } from '$lib/auth.svelte';
   import { createSession, listSessions, deleteSession, assistantWsUrl } from '$lib/assistant/api';
@@ -82,9 +83,13 @@
 
   let phase = $state<Phase>('connecting');
   let error = $state<string | null>(null);
-  // Set when the socket drops after we were live — the composer disables and
-  // prompts a reload, instead of silently accepting sends that can't go out.
+  // Set when the socket drops after we were live AND auto-reconnect has given up — the composer
+  // disables and offers a manual Reconnect button (never a full page reload).
   let connectionLost = $state(false);
+  // True while an automatic/manual reconnect attempt is in flight.
+  let reconnecting = $state(false);
+  let reconnectAttempts = 0;
+  const MAX_RECONNECT = 3;
 
   // Transport: one RoyClient per page. `activeId` is the session currently
   // attached and shown in the chat pane; `frameUnsub` is that session's frame
@@ -251,7 +256,9 @@
 
   // --- Connection + session orchestration ----------------------------------
 
-  async function boot() {
+  // `reopenId` (reconnect) re-attaches to a specific session and suppresses the kickoff; a bare
+  // boot (initial mount) opens the requested/newest/fresh session and may auto-start the kickoff.
+  async function boot(reopenId?: string) {
     phase = 'connecting';
     error = null;
     connectionLost = false;
@@ -270,11 +277,7 @@
       // Surface a mid-session disconnect instead of stranding the UI.
       statusUnsubs.push(
         client.onStatus((s) => {
-          if ((s === 'closed' || s === 'error') && phase === 'ready') {
-            connectionLost = true;
-            error = 'Connection to the agent was lost. Reload the page to reconnect.';
-            endTurn();
-          }
+          if ((s === 'closed' || s === 'error') && phase === 'ready') onConnectionDrop();
         }),
       );
       // A turn that fails with an `error` event (agent crash, tool failure)
@@ -292,10 +295,10 @@
           fromSummary(s, labelCache[s.session_id], fallbackLabel(s.created_at)),
         ),
       );
-      // Open the requested session (host prop), else the newest, else a fresh chat. A host
-      // (e.g. the /tailor route) seeds `session` + `sessionLabel`; seeding labelCache also stops
-      // noteFirstUserMessage from overwriting the name with the kickoff text.
-      const requested = session;
+      // Open the requested session (reconnect target, else the host prop), else the newest, else
+      // a fresh chat. A host (e.g. the /tailor route) seeds `session` + `sessionLabel`; seeding
+      // labelCache also stops noteFirstUserMessage from overwriting the name with the kickoff text.
+      const requested = reopenId ?? session;
       if (requested) {
         if (sessionLabel) {
           labelCache[requested] = sessionLabel;
@@ -318,14 +321,65 @@
       phase = 'ready';
 
       // Autostart: the host can pass a kickoff prompt so the agent begins immediately instead
-      // of waiting for the user to type. Only fire on a fresh (empty) session.
-      if (requested && kickoff && chat.messages.length === 0) {
+      // of waiting for the user to type. Only fire on a fresh (empty) session — never on reconnect.
+      if (!reopenId && requested && kickoff && chat.messages.length === 0) {
         await dispatch(kickoff);
       }
     } catch (err) {
       error = err instanceof Error ? err.message : 'Could not reach the agent backend.';
       teardown();
     }
+  }
+
+  // A mid-session socket drop: end the turn, then auto-reconnect (unless one is already running).
+  function onConnectionDrop() {
+    endTurn();
+    if (reconnecting) return;
+    reconnectAttempts = 0;
+    void reconnect();
+  }
+
+  // Re-establish the socket and re-attach to the session we were on (its journal replays, so the
+  // chat repaints intact). Auto-retries with backoff up to MAX_RECONNECT, then leaves a manual
+  // Reconnect button.
+  async function reconnect() {
+    reconnecting = true;
+    connectionLost = false;
+    error = null;
+    const keep = activeId ?? undefined;
+    // Drop the stale transport but keep the session id to reopen.
+    frameUnsub?.();
+    frameUnsub = null;
+    for (const off of statusUnsubs) off();
+    statusUnsubs = [];
+    client?.close();
+    client = null;
+    inputAcquired = false;
+    turnActive = false;
+    queue = [];
+    await boot(keep);
+    if (phase === 'ready') {
+      reconnecting = false;
+      reconnectAttempts = 0;
+      return;
+    }
+    // boot() failed internally (it set `error` + tore down). Retry with backoff, then give up
+    // to the manual button.
+    reconnecting = false;
+    if (reconnectAttempts < MAX_RECONNECT) {
+      reconnectAttempts += 1;
+      setTimeout(() => void reconnect(), 800 * 2 ** (reconnectAttempts - 1));
+    } else {
+      connectionLost = true;
+      error = 'Could not reconnect to the agent.';
+    }
+  }
+
+  // The manual "Reconnect" button: reset the attempt counter and try again.
+  function manualReconnect() {
+    if (reconnecting) return;
+    reconnectAttempts = 0;
+    void reconnect();
   }
 
   // Attach to `id` and replay its journal. Detaches the current session first,
@@ -550,7 +604,30 @@
 <!-- Single flex-1 root so a host can compose the chat beside another pane (e.g. the tailor
      artifact panel); the host supplies the outer height + flex row. -->
 <div class="flex min-w-0 flex-1 flex-col">
-{#if error}
+{#if reconnecting}
+  <div
+    class="m-3 mb-0 flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground"
+    role="status"
+  >
+    <Loader2 class="size-4 shrink-0 animate-spin" />
+    <span>Reconnecting to the agent…</span>
+  </div>
+{:else if connectionLost}
+  <div
+    class="m-3 mb-0 flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+    role="alert"
+  >
+    <AlertTriangle class="size-4 shrink-0" />
+    <span class="flex-1">Connection to the agent was lost.</span>
+    <button
+      type="button"
+      onclick={manualReconnect}
+      class="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium transition-colors hover:bg-destructive/15"
+    >
+      <RefreshCw class="size-3.5" /> Reconnect
+    </button>
+  </div>
+{:else if error}
   <div
     class="m-3 mb-0 flex items-start gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
     role="alert"

--- a/web/src/lib/components/cv/CvList.svelte
+++ b/web/src/lib/components/cv/CvList.svelte
@@ -2,12 +2,12 @@
   import { onMount } from 'svelte';
   import { FileText, Download, Trash2 } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
-  import { Button } from '$lib/ui';
-  import { cvTitle, type CvTailoredItem } from '$lib/cv';
+  import CompanyLogo from '$lib/components/CompanyLogo.svelte';
+  import { type CvTailoredItem } from '$lib/cv';
 
-  // The tailored-CV landing: every CV the caller built for a specific vacancy, each a shortcut
-  // back into its tailoring workspace (which resumes the same agent session). CVs are created
-  // only from a vacancy's match page, so there is no create action here.
+  // The tailored-CV landing: one company card per CV the caller built for a vacancy, styled like
+  // the saved-jobs cards. The card opens the tailoring workspace (which resumes the same agent
+  // session); the PDF and delete actions sit on the card without triggering the open.
 
   let status = $state<'loading' | 'error' | 'ready'>('loading');
   let error = $state<string | null>(null);
@@ -27,7 +27,7 @@
   }
 
   async function remove(cv: CvTailoredItem) {
-    if (!window.confirm(`Delete “${cvTitle(cv.title)}”? This cannot be undone.`)) return;
+    if (!window.confirm(`Delete your tailored CV for “${cv.job_title}”? This cannot be undone.`)) return;
     try {
       await api.deleteCv(cv.id);
       items = items.filter((i) => i.id !== cv.id);
@@ -61,20 +61,39 @@
       </p>
     </div>
   {:else}
-    <ul class="divide-y divide-border rounded-lg border border-border">
+    <ul class="flex flex-col gap-3">
       {#each items as cv (cv.id)}
-        <li class="flex items-center justify-between gap-4 p-4">
-          <a href="/tailor/{cv.job_slug}?cv={cv.id}" class="min-w-0 flex-1">
-            <span class="block truncate font-medium">{cvTitle(cv.title)}</span>
-            <span class="text-xs text-muted-foreground">Updated {fmt(cv.updated_at)} · {cv.template_id}</span>
-          </a>
-          <div class="flex items-center gap-1">
-            <Button variant="ghost" size="icon" href={api.cvPdfUrl(cv.id)} aria-label="Download PDF">
+        <li
+          class="group relative flex items-center gap-4 rounded-xl border border-border bg-card p-4 transition-colors hover:border-border/80 hover:bg-muted/30"
+        >
+          <!-- The whole card opens the workspace; the action buttons stop propagation below. -->
+          <a href="/tailor/{cv.job_slug}?cv={cv.id}" class="absolute inset-0" aria-label="Open {cv.job_title}"></a>
+          <CompanyLogo name={cv.job_company} size="size-11" />
+          <div class="min-w-0 flex-1">
+            <p class="truncate font-medium">{cv.job_title}</p>
+            <p class="truncate text-sm text-muted-foreground">{cv.job_company}</p>
+            <p class="mt-0.5 text-xs text-muted-foreground/80">Updated {fmt(cv.updated_at)}</p>
+          </div>
+          <div class="relative z-10 flex items-center gap-1">
+            <a
+              href={api.cvPdfUrl(cv.id)}
+              target="_blank"
+              rel="noopener"
+              aria-label="Open PDF"
+              title="Open PDF"
+              class="flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
               <Download class="h-4 w-4" />
-            </Button>
-            <Button variant="ghost" size="icon" aria-label="Delete" onclick={() => remove(cv)}>
+            </a>
+            <button
+              type="button"
+              aria-label="Delete"
+              title="Delete"
+              onclick={() => remove(cv)}
+              class="flex size-9 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
               <Trash2 class="h-4 w-4" />
-            </Button>
+            </button>
           </div>
         </li>
       {/each}

--- a/web/src/lib/cv.ts
+++ b/web/src/lib/cv.ts
@@ -30,10 +30,12 @@ export interface CvRecord extends CvMeta {
   document: Document;
 }
 
-/** A tailored CV in the /my/cvs re-open list: metadata plus the vacancy slug and the bound
- *  agent session, so a row links straight to its tailoring workspace. */
+/** A tailored CV in the /my/cvs re-open list: metadata plus the vacancy (slug, title, company)
+ *  and the bound agent session, so a row renders as a company card linking to its workspace. */
 export interface CvTailoredItem extends CvMeta {
   job_slug: string;
+  job_title: string;
+  job_company: string;
   agent_session_id: string;
 }
 


### PR DESCRIPTION
## Agent reconnect
On a mid-session socket drop, the chat now **auto-reconnects** (up to 3 tries with backoff), re-attaching to the SAME session — its journal replays so the conversation repaints intact. If auto-reconnect gives up, a manual **Reconnect** button appears. No more 'reload the page to reconnect'.

## /my/cvs company cards
Tailored CVs now render as **company cards** (logo + role + company, styled like the saved-jobs cards). The whole card opens the tailoring workspace (`?cv=<id>`); the **PDF** and **delete** actions stay on the card. `ListTailoredCVsByUser` returns the vacancy title + company (one extra JOIN column).

## Verify
- `svelte-check` 0 errors · `vitest` 299 pass · `npm run build` green
- `go build` + integration (`TestCVSessionAndTailoredList`, `TestTailorContextSplit`) green