### PR TITLE
fix(sources): vagas description from HTML block, not glued JSON-LD

### DIFF
--- a/internal/sources/vagas.go
+++ b/internal/sources/vagas.go
@@ -106,10 +106,21 @@ func (v vagas) detail(ctx context.Context, jobURL string) (Job, bool) {
 		Title:       p.Title,
 		Company:     p.HiringOrganization.Name,
 		Location:    location,
-		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Description: sanitizeHTML(vagasDescription(root, p.Description)),
 		Remote:      isRemote(location),
 		PostedAt:    parseDate(p.DatePosted),
 	}, true
+}
+
+// vagasDescription returns the job's description HTML. It prefers the page's
+// job-description__text block, whose markup (paragraphs, lists, emphasis) is preserved by
+// sanitizeHTML; the JSON-LD description is a flattened, separator-stripped version that glues
+// headings and list items into the prose, so it is only a fallback when the block is absent.
+func vagasDescription(root *html.Node, ldDescription string) string {
+	if block := firstByClass(root, "job-description__text"); block != nil {
+		return innerHTML(block)
+	}
+	return html.UnescapeString(ldDescription)
 }
 
 // vagasJobIDPattern captures the native posting id from a /vagas/v<id>/<slug> URL.

--- a/internal/sources/vagas_test.go
+++ b/internal/sources/vagas_test.go
@@ -103,6 +103,41 @@ func TestVagasFetch(t *testing.T) {
 	}
 }
 
+// vagas's JSON-LD description is a flattened, separator-stripped blob that glues words
+// together (headings/list items run into the prose); the page's job-description__text block
+// carries the real formatted HTML. The adapter must prefer the block so lists/paragraphs survive.
+func TestVagasDetailPrefersStructuredHTMLBlock(t *testing.T) {
+	const host = "https://www.vagas.com.br/"
+	page := `<html><head>` +
+		`<script type="application/ld+json">{"@context":"http://schema.org/","@type":"JobPosting",` +
+		`"title":"Dev","datePosted":"2026-06-18",` +
+		`"description":"Missao do cargo.REQUISITOS:Item um;Item dois",` +
+		`"hiringOrganization":{"@type":"Organization","name":"Acme"},` +
+		`"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress","addressLocality":"SP","addressCountry":"Brasil"}}}` +
+		`</script></head><body>` +
+		`<div class="job-tab-content job-description__text texto">` +
+		`<p>Missao do cargo.</p><p><strong>REQUISITOS:</strong></p><ul><li>Item um</li><li>Item dois</li></ul>` +
+		`</div></body></html>`
+	pages := map[string]string{
+		"https://www.vagas.com.br/vagas-de-tecnologia?pagina=1": vagasListingHTML("/vagas/v900/dev"),
+		host + "vagas/v900/dev":                                 page,
+	}
+	jobs, err := vagas{http: &vagasHTTP{pages: pages}}.Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("want 1 job, got %d", len(jobs))
+	}
+	d := jobs[0].Description
+	if !strings.Contains(d, "<li>Item um</li>") || !strings.Contains(d, "<li>Item dois</li>") {
+		t.Fatalf("description should preserve the HTML list from the block, got: %q", d)
+	}
+	if strings.Contains(d, "REQUISITOS:Item") {
+		t.Fatalf("description still glued from JSON-LD, got: %q", d)
+	}
+}
+
 // A detail page with no JobPosting is skipped, not turned into a blank job.
 func TestVagasDetailWithoutJobPostingSkipped(t *testing.T) {
 	const host = "https://www.vagas.com.br/"


### PR DESCRIPTION
## Problem
vagas descriptions render as one glued blob — e.g. `...da empresa.REQUISITOS TÉCNICOS:Graduação em...` ([reported job](https://freehire.dev/jobs/11309-diretor-de-tecnologia-da-informacao-talent-group-vwh6pvj4)). Root cause: vagas.com.br's JSON-LD `description` is a flattened, separator-stripped version of the posting — headings and `<li>` items are concatenated with no whitespace at the source, before we ever touch it. So it's not a `sanitizeHTML` bug; we were feeding the sanitizer an already-degraded string.

## Fix
The page's `job-description__text` block carries the real formatted markup (`<p>/<ul>/<li>/<strong>`), which `descriptionPolicy` already keeps. Prefer that block (`firstByClass` + `innerHTML`); fall back to the JSON-LD description only when the block is absent.

- `internal/sources/vagas.go` — `vagasDescription(root, ld)` helper
- `internal/sources/vagas_test.go` — `TestVagasDetailPrefersStructuredHTMLBlock` (fallback still covered by `TestVagasFetch`)

Existing ~1800 vagas rows self-heal on the next crawl (description change flips `content_hash` → re-upsert). `go build/vet/test ./internal/sources/` green.