### PR TITLE
feat(sources): jobspresso remote-jobs RSS adapter

### DIFF
--- a/internal/sources/jobspresso.go
+++ b/internal/sources/jobspresso.go
@@ -1,0 +1,119 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// jobspresso adapts jobspresso.co, a curated remote-jobs board running WordPress Job Manager.
+// Boardless (one public RSS feed, no per-tenant board) and multi-company, so it stays in the
+// source facet and takes each posting's company from the feed. The RSS carries every posting's
+// body inline (no detail call); the feed is the recent window, not the full backlog. jobspresso
+// lists only remote work, so every posting maps to remote.
+type jobspresso struct {
+	http XMLGetter
+}
+
+const jobspressoFeedURL = "https://jobspresso.co/feed/?post_type=job_listing"
+
+// NewJobspresso builds the Jobspresso adapter over the given HTTP client.
+func NewJobspresso(c XMLGetter) Source { return jobspresso{http: c} }
+
+func (jobspresso) Provider() string { return "jobspresso" }
+
+func (jobspresso) boardless() {}
+
+func (jobspresso) aggregator() {}
+
+// jobspressoItem is one RSS <item>. Company and location are packed into <dc:creator>, the
+// numeric post id lives in the <guid>'s p= param, and the body is in <content:encoded> (with a
+// truncated <description> summary as fallback). The dc/content-namespaced elements are matched by
+// their local name, which Go's encoding/xml resolves regardless of prefix.
+type jobspressoItem struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	GUID        string `xml:"guid"`
+	Creator     string `xml:"creator"` // dc:creator
+	Encoded     string `xml:"encoded"` // content:encoded
+	Description string `xml:"description"`
+	PubDate     string `xml:"pubDate"`
+}
+
+func (s jobspresso) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var feed struct {
+		Channel struct {
+			Items []jobspressoItem `xml:"item"`
+		} `xml:"channel"`
+	}
+	if err := s.http.GetXML(ctx, jobspressoFeedURL, &feed); err != nil {
+		return nil, fmt.Errorf("jobspresso: feed: %w", err)
+	}
+	jobs := make([]Job, 0, len(feed.Channel.Items))
+	for _, it := range feed.Channel.Items {
+		if job, ok := it.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an RSS item to a Job, returning ok=false for an unusable item — no id (neither a
+// guid p= nor a link slug) would leave the dedup key empty, and an empty company would break the
+// public slug.
+func (it jobspressoItem) toJob() (Job, bool) {
+	id := jobspressoID(it.GUID, it.Link)
+	company, location := jobspressoCompanyLocation(it.Creator)
+	if id == "" || company == "" {
+		return Job{}, false
+	}
+	body := it.Encoded
+	if strings.TrimSpace(body) == "" {
+		body = it.Description
+	}
+	return Job{
+		ExternalID:  id,
+		URL:         strings.TrimSpace(it.Link),
+		Title:       strings.TrimSpace(it.Title),
+		Company:     company,
+		Location:    location,
+		Description: sanitizeHTML(html.UnescapeString(body)),
+		Remote:      true,
+		WorkMode:    "remote",
+		PostedAt:    parsePubDate(it.PubDate),
+	}, true
+}
+
+// jobspressoID is the native post id: the numeric p= param from the guid URL, falling back to
+// the last path segment (post slug) of the item link when the guid carries no p=.
+func jobspressoID(guid, link string) string {
+	if u, err := url.Parse(strings.TrimSpace(guid)); err == nil {
+		if p := strings.TrimSpace(u.Query().Get("p")); p != "" {
+			return p
+		}
+	}
+	link = strings.TrimRight(strings.TrimSpace(link), "/")
+	if i := strings.LastIndex(link, "/"); i >= 0 {
+		return link[i+1:]
+	}
+	return ""
+}
+
+// jobspressoCompanyLocation splits the <dc:creator> string, whose form is
+// "Company<br>⚲&nbsp;Location". The left of the <br> is the company; the right is the location
+// after dropping the ⚲ marker (a creator with no <br> is company-only). dc:creator is CDATA, so
+// encoding/xml leaves its entities intact — both halves are HTML-unescaped here (e.g. a company
+// "AT&amp;T" or the location's &nbsp;).
+func jobspressoCompanyLocation(creator string) (company, location string) {
+	company, rest, found := strings.Cut(creator, "<br>")
+	company = strings.TrimSpace(html.UnescapeString(company))
+	if !found {
+		return company, ""
+	}
+	rest = strings.TrimPrefix(strings.TrimSpace(rest), "⚲")
+	location = strings.TrimSpace(html.UnescapeString(rest))
+	return company, location
+}

--- a/internal/sources/jobspresso_test.go
+++ b/internal/sources/jobspresso_test.go
@@ -1,0 +1,207 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// jobspressoFeed mirrors a live jobspresso.co WordPress Job Manager RSS document. The single
+// item is a real posting: the title carries an HTML char reference (&#124;), the guid is a URL
+// whose numeric post id sits in a `p=` param (the `&#038;` XML-decodes to `&`), the dc:creator
+// is a CDATA `Company<br>⚲&nbsp;Location` string, and both a truncated <description> summary and
+// a fuller <content:encoded> body are present so the adapter's body preference is verifiable.
+const jobspressoFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
+<channel>
+	<title>Jobs &#8211; Jobspresso</title>
+	<link>https://jobspresso.co</link>
+	<item>
+		<title>Mitarbeiter/in (m/w/d) f&#252;r Datenanalysen &#124; Remote</title>
+		<link>https://jobspresso.co/job/wet-germany-various-mitarbeiter-in-fur-datenanalysen-remote/</link>
+		<dc:creator><![CDATA[WET Beratungs- und Beteiligungsgesellschaft mbH<br>⚲&nbsp;Germany , Austria, Luxemburg]]></dc:creator>
+		<pubDate>Thu, 16 Jul 2026 15:15:16 +0000</pubDate>
+		<guid isPermaLink="false">https://jobspresso.co/?post_type=job_listing&#038;p=163363</guid>
+		<description><![CDATA[<p>Wir suchen Sie als Mitarbeiter/in f&uuml;r Datenanalysen im Minijob.</p>]]></description>
+		<content:encoded><![CDATA[<p>Wir suchen Sie als Mitarbeiter/in f&uuml;r Datenanalysen.</p><p>Komplett remote &#8211; arbeiten Sie von zu Hause aus.</p>]]></content:encoded>
+	</item>
+</channel>
+</rss>`
+
+func TestJobspressoFetchMapsItem(t *testing.T) {
+	fake := &fakeHTTP{body: jobspressoFeed}
+
+	jobs, err := NewJobspresso(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Jobspresso", Provider: "jobspresso",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(fake.gotURL, "jobspresso.co/feed/?post_type=job_listing") {
+		t.Errorf("requested URL %q should target the WPJM feed", fake.gotURL)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1", len(jobs))
+	}
+	j := jobs[0]
+
+	// ExternalID is the numeric post id from the guid's p= param.
+	if j.ExternalID != "163363" {
+		t.Errorf("ExternalID = %q, want 163363", j.ExternalID)
+	}
+	if j.URL != "https://jobspresso.co/job/wet-germany-various-mitarbeiter-in-fur-datenanalysen-remote/" {
+		t.Errorf("URL = %q, want the item link", j.URL)
+	}
+	if j.Title != "Mitarbeiter/in (m/w/d) für Datenanalysen | Remote" {
+		t.Errorf("Title = %q, want the char-reference-decoded title", j.Title)
+	}
+	// Company and location split out of dc:creator (Company<br>⚲&nbsp;Location).
+	if j.Company != "WET Beratungs- und Beteiligungsgesellschaft mbH" {
+		t.Errorf("Company = %q", j.Company)
+	}
+	if j.Location != "Germany , Austria, Luxemburg" {
+		t.Errorf("Location = %q, want the ⚲-stripped, nbsp-trimmed location", j.Location)
+	}
+	// The fuller content:encoded body is preferred over the truncated description.
+	if !strings.Contains(j.Description, "Komplett remote") {
+		t.Errorf("Description should come from content:encoded, got %q", j.Description)
+	}
+	// jobspresso lists only remote work.
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want true/remote", j.Remote, j.WorkMode)
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want the parsed pubDate (2026)", j.PostedAt)
+	}
+}
+
+func TestJobspressoID(t *testing.T) {
+	cases := []struct {
+		name, guid, link, want string
+	}{
+		{"guid p= param", "https://jobspresso.co/?post_type=job_listing&p=163363", "https://jobspresso.co/job/x/", "163363"},
+		{"no p= falls back to link slug", "https://jobspresso.co/job/acme-role/", "https://jobspresso.co/job/acme-role/", "acme-role"},
+		{"trailing slash trimmed", "", "https://jobspresso.co/job/acme-role", "acme-role"},
+		{"empty guid and link", "", "", ""},
+	}
+	for _, c := range cases {
+		if got := jobspressoID(c.guid, c.link); got != c.want {
+			t.Errorf("%s: jobspressoID(%q, %q) = %q, want %q", c.name, c.guid, c.link, got, c.want)
+		}
+	}
+}
+
+func TestJobspressoCompanyLocation(t *testing.T) {
+	cases := []struct {
+		name, creator, wantCompany, wantLocation string
+	}{
+		{"company and location", "Acme<br>⚲&nbsp;Remote", "Acme", "Remote"},
+		{"multi-region location", "WET mbH<br>⚲&nbsp;Germany , Austria", "WET mbH", "Germany , Austria"},
+		{"no br is company-only", "Acme", "Acme", ""},
+		{"empty company", "<br>⚲&nbsp;Remote", "", "Remote"},
+		// dc:creator is CDATA, so the company half keeps its raw entities until unescaped here.
+		{"entity-encoded company", "AT&amp;T<br>⚲&nbsp;Remote", "AT&T", "Remote"},
+	}
+	for _, c := range cases {
+		gotC, gotL := jobspressoCompanyLocation(c.creator)
+		if gotC != c.wantCompany || gotL != c.wantLocation {
+			t.Errorf("%s: jobspressoCompanyLocation(%q) = (%q, %q), want (%q, %q)",
+				c.name, c.creator, gotC, gotL, c.wantCompany, c.wantLocation)
+		}
+	}
+}
+
+// jobspressoEdgeFeed exercises the field-fallback and drop rules: item A has no guid p= (id
+// from the link slug); item B has neither guid p= nor a link slug (dropped); item C resolves to
+// an empty company (dropped); item D carries only a <description> summary (body falls back to it).
+const jobspressoEdgeFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/">
+<channel>
+	<item>
+		<title>A Role</title>
+		<link>https://jobspresso.co/job/acme-a-role/</link>
+		<dc:creator><![CDATA[Acme<br>⚲&nbsp;Worldwide]]></dc:creator>
+		<pubDate>Thu, 16 Jul 2026 15:15:16 +0000</pubDate>
+		<guid isPermaLink="true">https://jobspresso.co/job/acme-a-role/</guid>
+		<content:encoded><![CDATA[<p>Full body A.</p>]]></content:encoded>
+	</item>
+	<item>
+		<title>No Id</title>
+		<link></link>
+		<dc:creator><![CDATA[Beta<br>⚲&nbsp;Remote]]></dc:creator>
+		<guid></guid>
+	</item>
+	<item>
+		<title>No Company</title>
+		<link>https://jobspresso.co/job/mystery/</link>
+		<dc:creator><![CDATA[<br>⚲&nbsp;Remote]]></dc:creator>
+		<guid isPermaLink="false">https://jobspresso.co/?post_type=job_listing&#038;p=99</guid>
+	</item>
+	<item>
+		<title>Summary Only</title>
+		<link>https://jobspresso.co/job/delta-role/</link>
+		<dc:creator><![CDATA[Delta<br>⚲&nbsp;Canada]]></dc:creator>
+		<pubDate>Thu, 16 Jul 2026 15:15:16 +0000</pubDate>
+		<guid isPermaLink="false">https://jobspresso.co/?post_type=job_listing&#038;p=42</guid>
+		<description><![CDATA[<p>Summary body D.</p>]]></description>
+	</item>
+</channel>
+</rss>`
+
+func TestJobspressoFetchAppliesRules(t *testing.T) {
+	jobs, err := NewJobspresso(&fakeHTTP{body: jobspressoEdgeFeed}).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (no-id and no-company items dropped)", len(jobs))
+	}
+	// Item A: id from the link slug (guid carries no p=).
+	if jobs[0].ExternalID != "acme-a-role" {
+		t.Errorf("jobs[0].ExternalID = %q, want the link slug acme-a-role", jobs[0].ExternalID)
+	}
+	// Item D: body falls back to <description> when content:encoded is absent.
+	if jobs[1].ExternalID != "42" || !strings.Contains(jobs[1].Description, "Summary body D") {
+		t.Errorf("jobs[1] = {id:%q, desc:%q}, want id 42 with the description body", jobs[1].ExternalID, jobs[1].Description)
+	}
+}
+
+func TestJobspressoProvider(t *testing.T) {
+	if got := NewJobspresso(nil).Provider(); got != "jobspresso" {
+		t.Errorf("Provider() = %q, want jobspresso", got)
+	}
+}
+
+func TestJobspressoIsBoardlessAggregator(t *testing.T) {
+	s := NewJobspresso(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("jobspresso should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("jobspresso should implement the aggregator marker")
+	}
+}
+
+func TestJobspressoRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["jobspresso"]; !ok {
+		t.Error("All() should register provider jobspresso")
+	}
+	if !slices.Contains(FilterableProviders(), "jobspresso") {
+		t.Error("FilterableProviders() should include jobspresso")
+	}
+}
+
+func TestJobspressoBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/jobspresso.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/jobspresso.yml fails validation: %v", err)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -277,6 +277,7 @@ func All(c HTTPClient) map[string]Source {
 		NewRemoteOK(c),
 		NewJobicy(c),
 		NewWeWorkRemotely(c),
+		NewJobspresso(c),
 		NewTheHub(c),
 		NewGetonbrd(c),
 		NewVagas(c),

--- a/openspec/changes/add-jobspresso-source/.openspec.yaml
+++ b/openspec/changes/add-jobspresso-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-jobspresso-source/design.md
+++ b/openspec/changes/add-jobspresso-source/design.md
@@ -1,0 +1,76 @@
+## Context
+
+Jobspresso (jobspresso.co) runs on WordPress with the WP Job Manager plugin. Live probing
+established:
+
+- `https://jobspresso.co/feed/?post_type=job_listing` returns a well-formed RSS 2.0 document
+  with ~20 `<item>` entries (the recent window; `?paged=N` does not page further reliably).
+- Each `<item>` carries the posting inline: `<title>` is the role, `<link>` is the canonical
+  detail URL, `<pubDate>` is RFC1123Z, `<guid isPermaLink="false">` is a URL carrying the numeric
+  post id as its `p=` query param (e.g. `…?post_type=job_listing&p=163363`), `<dc:creator>` is a
+  CDATA string of the form `Company<br>⚲&nbsp;Location`, `<description>` is a truncated HTML
+  summary, and `<content:encoded>` is the full HTML body.
+- The board lists only remote work.
+
+This is the exact weworkremotely shape (`internal/sources/weworkremotely.go`): a boardless
+aggregator over one RSS feed, company taken per posting, body inline, remote-only. The only real
+differences are where company/location and the id live.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless, boardless, aggregator `jobspresso` adapter that maps the RSS feed to `Job`s.
+- Reuse the existing `XMLGetter` + `sanitizeHTML` machinery; no new shared helper.
+
+**Non-Goals:**
+- A generalized WordPress Job Manager adapter. The `dc:creator`/`⚲` conventions are jobspresso's;
+  generalize only when a second live WPJM board appears (noted as a seam, not built now).
+- Backlog pagination. The feed is a recent window; incremental crawls keep the catalogue fresh
+  and the standard ingest sweep soft-closes anything that ages out.
+- A detail fetch or liveness probe. The feed carries the full body inline.
+
+## Decisions
+
+- **`ExternalID` = the `p=` numeric post id from `<guid>`, falling back to the `<link>` slug.**
+  The guid's `p=` is the stable native WordPress post id; a `url.Parse(...).Query().Get("p")`
+  reads it order-independently. If a future item ever lacks it, the last path segment of `<link>`
+  (the post slug) is a stable fallback. An item with neither is dropped. *Alternative rejected:*
+  using the slug as the primary id — the numeric post id is shorter and immune to slug edits.
+
+- **Company/location split from `<dc:creator>`.** The CDATA text is `Company<br>⚲&nbsp;Location`.
+  Split on the literal `<br>`: the left side is the company, the right side is the location after
+  stripping the `⚲` (U+26B2) marker and unescaping `&nbsp;`. A creator with no `<br>` is treated
+  as company-only with an empty location. An item whose company resolves empty is dropped (an
+  empty company breaks the public slug), mirroring weworkremotely.
+
+- **Body from `<content:encoded>`, falling back to `<description>`.** `content:encoded` is the
+  full posting; `description` is a truncated summary. Decode both by their local element names
+  (`encoded`, `description`) — Go's `encoding/xml` matches the local name regardless of the
+  `content:` / prefix — and sanitize with `sanitizeHTML(html.UnescapeString(...))` as
+  weworkremotely does. Prefer `content:encoded` when non-empty.
+
+- **Remote-only.** Jobspresso lists only remote roles, so every mapped `Job` gets `Remote: true`
+  and work mode `remote`, exactly as weworkremotely hard-codes it.
+
+- **Boardless aggregator, keyless.** Add the `boardless()` and `aggregator()` markers; the config
+  entry is a single boardless line with `company:` present only as a label. One line in
+  `sources.All`. No proxy — a direct datacenter fetch of the public RSS works.
+
+## Risks / Trade-offs
+
+- **Recent-window only (~20 items/crawl).** → Accepted; the same as weworkremotely and the other
+  RSS aggregators. Frequent crawls keep coverage current; aged-out postings are soft-closed by the
+  standard sweep.
+- **`dc:creator` format could drift** (a board could stop emitting the `⚲` marker). → The split is
+  defensive: no `<br>` yields company-only, a missing `⚲` just leaves the raw remainder as
+  location; neither aborts the crawl. Verified against a saved real fixture in the RED test.
+
+## Migration Plan
+
+- No DB migration, no API change, no new dependency.
+- Deploy: add a `cmd/ingest sources/jobspresso.yml` cron schedule in freehire-ops.
+
+## Open Questions
+
+- None. The feed is keyless, public, and fetched directly; the mapping is pinned to a real
+  fixture.

--- a/openspec/changes/add-jobspresso-source/proposal.md
+++ b/openspec/changes/add-jobspresso-source/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Jobspresso (jobspresso.co) is a curated remote-jobs board. It publishes a keyless WordPress Job
+Manager RSS feed at `/feed/?post_type=job_listing` that carries every listed posting inline —
+title, canonical detail URL, company + location, HTML body, and posted date — so one request per
+crawl yields the recent window with no per-posting detail fetch. Adding it widens remote coverage
+at the cost of a single adapter that reuses the existing RSS + aggregator machinery.
+
+## What Changes
+
+- Add a `jobspresso` source adapter that fetches the WordPress Job Manager RSS feed at
+  `https://jobspresso.co/feed/?post_type=job_listing` and maps each `<item>` to a normalized
+  `Job`: the numeric `p=` post id from `<guid>` as `ExternalID` (falling back to the link slug),
+  the item `<link>` as the canonical URL, the item `<title>` as the role, the company and
+  location split out of `<dc:creator>` (format `Company<br>⚲&nbsp;Location`), the inline
+  `<content:encoded>` HTML (falling back to `<description>`) as the sanitized body, and
+  `<pubDate>` as `PostedAt`.
+- The adapter is **boardless** and an **aggregator**: one global feed with no per-tenant board,
+  and the company comes from each posting, so it stays in the source facet. Jobspresso lists only
+  remote work, so every posting maps to `Remote: true` with work mode `remote`.
+- An item with no usable `ExternalID` or an empty company is dropped rather than emitted with an
+  empty dedup key / broken slug (mirrors the weworkremotely rule).
+- Enroll `jobspresso` in `sources.All` and add `sources/jobspresso.yml` with a single boardless
+  entry, crawled by its own `cmd/ingest` cron schedule.
+
+## Capabilities
+
+### New Capabilities
+- `jobspresso-source`: the `jobspresso` adapter — its RSS fetch, `<item>` → `Job` mapping,
+  `dc:creator` company/location split, `guid` `p=` id extraction with slug fallback, drop rules
+  for unusable items, and boardless-aggregator remote-only classification.
+
+### Modified Capabilities
+<!-- None. Boardless aggregator adapter; inherits the standard ingest sweep, aggregator dedup,
+     and board-health machinery unchanged. No spec-level behavior of an existing capability
+     changes. -->
+
+## Impact
+
+- **New code:** `internal/sources/jobspresso.go` (+ `_test.go`); `sources/jobspresso.yml`.
+- **Touched code:** one line in `sources.All` (registry).
+- **Ops:** a new `cmd/ingest sources/jobspresso.yml` cron schedule (deploy-time, in freehire-ops).
+- **No migrations, no API changes, no new dependencies, no proxy (keyless, direct fetch works).**

--- a/openspec/changes/add-jobspresso-source/specs/jobspresso-source/spec.md
+++ b/openspec/changes/add-jobspresso-source/specs/jobspresso-source/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Jobspresso maps its RSS feed to jobs
+
+The system SHALL provide a `jobspresso` source adapter that fetches the WordPress Job Manager
+RSS feed at `https://jobspresso.co/feed/?post_type=job_listing` and maps each `<item>` to a
+normalized `Job`. The `Job` SHALL carry the numeric `p=` post id from the item `<guid>` as its
+`ExternalID` — falling back to the last path segment (slug) of the item `<link>` when no `p=` is
+present — the item `<link>` as its canonical URL, the item `<title>` as its title, the company
+and location split out of `<dc:creator>`, the sanitized inline HTML body from
+`<content:encoded>` (falling back to `<description>`), and `<pubDate>` as `PostedAt`.
+
+Jobspresso lists only remote work, so every mapped `Job` SHALL have `Remote: true` and work mode
+`remote`.
+
+The adapter is **boardless** (jobspresso.co is one site with no per-tenant board) and an
+**aggregator** (one global feed whose company comes from each posting), so it stays in the source
+facet. The configured board file entry carries no `board` value.
+
+#### Scenario: An RSS item maps to a job
+
+- **WHEN** the adapter fetches the feed and reads an `<item>` with a `<guid>` carrying `p=163363`,
+  a `<link>`, a `<title>`, a `<dc:creator>` of `Acme<br>⚲&nbsp;Remote`, a `<content:encoded>`
+  body, and a `<pubDate>`
+- **THEN** it yields one `Job` with `ExternalID` `163363`, the item link as the canonical URL, the
+  title, company `Acme`, location `Remote`, the sanitized `content:encoded` body, `Remote: true`
+  with work mode `remote`, and `PostedAt` parsed from `pubDate`
+
+#### Scenario: The full body is preferred over the summary
+
+- **WHEN** an item carries both a truncated `<description>` summary and a fuller
+  `<content:encoded>` body
+- **THEN** the mapped `Job` description comes from `<content:encoded>`
+
+### Requirement: Jobspresso splits company and location from dc:creator
+
+The adapter SHALL parse `<dc:creator>`, whose text is of the form `Company<br>⚲&nbsp;Location`,
+by splitting on the literal `<br>`: the left side is the company and the right side is the
+location after stripping the `⚲` (U+26B2) marker and unescaping HTML entities. A `<dc:creator>`
+with no `<br>` SHALL be treated as company-only with an empty location.
+
+#### Scenario: Creator without a location marker yields company-only
+
+- **WHEN** an item's `<dc:creator>` is `Acme` with no `<br>` separator
+- **THEN** the mapped `Job` has company `Acme` and an empty location
+
+### Requirement: Jobspresso drops unusable items
+
+The adapter SHALL drop any `<item>` that yields no usable `ExternalID` (no `p=` and no link slug)
+or whose company resolves empty — an empty dedup key or empty company would break the posting's
+public slug. A single dropped item SHALL NOT abort the crawl.
+
+#### Scenario: An item with an empty company is dropped
+
+- **WHEN** an item's `<dc:creator>` resolves to an empty company
+- **THEN** the adapter yields no `Job` for that item and continues mapping the rest

--- a/openspec/changes/add-jobspresso-source/tasks.md
+++ b/openspec/changes/add-jobspresso-source/tasks.md
@@ -1,0 +1,47 @@
+## 1. Item mapping (single open posting)
+
+- [ ] 1.1 Add `internal/sources/jobspresso_test.go` with a saved real feed excerpt fixture under
+  `testdata/` and a RED test asserting the adapter maps one `<item>` to a `Job` with the right
+  fields: `guid` `p=` → `ExternalID`, `<link>` → `URL`, `<title>` → `Title`, `dc:creator`
+  `Company<br>⚲&nbsp;Location` → company + location, `content:encoded` → sanitized description,
+  `Remote: true` + work mode `remote`, `pubDate` → `PostedAt`.
+- [ ] 1.2 Create `internal/sources/jobspresso.go`: a `jobspresso` struct over the RSS
+  (`XMLGetter`) client, a `jobspressoItem` struct decoding `title`, `link`, `guid`, `creator`
+  (dc:creator local name), `encoded` (content:encoded local name), `description`, and `pubDate`,
+  and a `toJob` mapper reusing `sanitizeHTML`, `html.UnescapeString`, and `parsePubDate`. Make
+  1.1 green.
+
+## 2. Field-extraction rules
+
+- [ ] 2.1 RED test: `guid` with no `p=` falls back to the `<link>` slug; `content:encoded` empty
+  falls back to `<description>`; `dc:creator` with no `<br>` yields company-only + empty location;
+  the `⚲` marker and `&nbsp;` are stripped from the location.
+- [ ] 2.2 Implement `jobspressoID` (parse `p=`, fallback to link slug) and the `dc:creator` split
+  helper; wire the `content:encoded`/`description` preference. Make 2.1 green.
+
+## 3. Drop rules
+
+- [ ] 3.1 RED test: an item with neither `p=` nor a link slug is dropped; an item whose company
+  resolves empty is dropped; the remaining items still map.
+- [ ] 3.2 Implement the `toJob` drop rules (return ok=false on empty id or empty company). Make
+  3.1 green.
+
+## 4. Classification & registration
+
+- [ ] 4.1 Add the `boardless()` and `aggregator()` markers and `Provider()` returning
+  `"jobspresso"`; register `jobspresso` in `sources.All` (one line, under the multi-company
+  aggregators). Test the provider resolves from `All(nil)`. Verify `go build ./... && go vet ./...`.
+
+## 5. Board file & docs
+
+- [ ] 5.1 Add `sources/jobspresso.yml` with a single boardless entry (`company: Jobspresso`) and
+  confirm `go run ./cmd/ingest sources/jobspresso.yml` validates against the registry (fail-fast
+  passes).
+- [ ] 5.2 Note the new adapter in `internal/sources/AGENTS.md` if it enumerates adapters by class
+  (keyless RSS feed), keeping the surrounding style.
+
+## 6. Verify end-to-end
+
+- [ ] 6.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl
+  against the real feed to confirm items map and unusable ones are dropped without error (not
+  committed).

--- a/openspec/changes/add-jobspresso-source/tasks.md
+++ b/openspec/changes/add-jobspresso-source/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Item mapping (single open posting)
 
-- [ ] 1.1 Add `internal/sources/jobspresso_test.go` with a saved real feed excerpt fixture under
-  `testdata/` and a RED test asserting the adapter maps one `<item>` to a `Job` with the right
+- [x] 1.1 Add `internal/sources/jobspresso_test.go` with a saved real feed excerpt fixture under
+  an inline feed constant (matching the weworkremotely/likeit convention — no `testdata/` file) and a RED test asserting the adapter maps one `<item>` to a `Job` with the right
   fields: `guid` `p=` → `ExternalID`, `<link>` → `URL`, `<title>` → `Title`, `dc:creator`
   `Company<br>⚲&nbsp;Location` → company + location, `content:encoded` → sanitized description,
   `Remote: true` + work mode `remote`, `pubDate` → `PostedAt`.
-- [ ] 1.2 Create `internal/sources/jobspresso.go`: a `jobspresso` struct over the RSS
+- [x] 1.2 Create `internal/sources/jobspresso.go`: a `jobspresso` struct over the RSS
   (`XMLGetter`) client, a `jobspressoItem` struct decoding `title`, `link`, `guid`, `creator`
   (dc:creator local name), `encoded` (content:encoded local name), `description`, and `pubDate`,
   and a `toJob` mapper reusing `sanitizeHTML`, `html.UnescapeString`, and `parsePubDate`. Make
@@ -13,35 +13,35 @@
 
 ## 2. Field-extraction rules
 
-- [ ] 2.1 RED test: `guid` with no `p=` falls back to the `<link>` slug; `content:encoded` empty
+- [x] 2.1 RED test: `guid` with no `p=` falls back to the `<link>` slug; `content:encoded` empty
   falls back to `<description>`; `dc:creator` with no `<br>` yields company-only + empty location;
   the `⚲` marker and `&nbsp;` are stripped from the location.
-- [ ] 2.2 Implement `jobspressoID` (parse `p=`, fallback to link slug) and the `dc:creator` split
+- [x] 2.2 Implement `jobspressoID` (parse `p=`, fallback to link slug) and the `dc:creator` split
   helper; wire the `content:encoded`/`description` preference. Make 2.1 green.
 
 ## 3. Drop rules
 
-- [ ] 3.1 RED test: an item with neither `p=` nor a link slug is dropped; an item whose company
+- [x] 3.1 RED test: an item with neither `p=` nor a link slug is dropped; an item whose company
   resolves empty is dropped; the remaining items still map.
-- [ ] 3.2 Implement the `toJob` drop rules (return ok=false on empty id or empty company). Make
+- [x] 3.2 Implement the `toJob` drop rules (return ok=false on empty id or empty company). Make
   3.1 green.
 
 ## 4. Classification & registration
 
-- [ ] 4.1 Add the `boardless()` and `aggregator()` markers and `Provider()` returning
+- [x] 4.1 Add the `boardless()` and `aggregator()` markers and `Provider()` returning
   `"jobspresso"`; register `jobspresso` in `sources.All` (one line, under the multi-company
   aggregators). Test the provider resolves from `All(nil)`. Verify `go build ./... && go vet ./...`.
 
 ## 5. Board file & docs
 
-- [ ] 5.1 Add `sources/jobspresso.yml` with a single boardless entry (`company: Jobspresso`) and
+- [x] 5.1 Add `sources/jobspresso.yml` with a single boardless entry (`company: Jobspresso`) and
   confirm `go run ./cmd/ingest sources/jobspresso.yml` validates against the registry (fail-fast
   passes).
-- [ ] 5.2 Note the new adapter in `internal/sources/AGENTS.md` if it enumerates adapters by class
-  (keyless RSS feed), keeping the surrounding style.
+- [x] 5.2 No-op: `internal/sources/AGENTS.md` does not enumerate adapters by class, so there is
+  nothing to add.
 
 ## 6. Verify end-to-end
 
-- [ ] 6.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl
+- [x] 6.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl
   against the real feed to confirm items map and unusable ones are dropped without error (not
   committed).

--- a/sources/jobspresso.yml
+++ b/sources/jobspresso.yml
@@ -1,0 +1,5 @@
+# Jobspresso curated remote-jobs board. Boardless: one public WordPress Job Manager RSS feed
+# (jobspresso.co/feed/?post_type=job_listing), so the entry carries no board; each job's company
+# comes from the posting, not this placeholder.
+- company: Jobspresso
+  provider: jobspresso


### PR DESCRIPTION
## Summary
- Add a `jobspresso` source adapter for [jobspresso.co](https://jobspresso.co), a curated remote-jobs board publishing a WordPress Job Manager RSS feed at `/feed/?post_type=job_listing`.
- Boardless + aggregator (one global feed, company per posting), mirroring the `weworkremotely` adapter. Maps each `<item>` → `Job`: numeric `p=` post id from `<guid>` (slug fallback), `<dc:creator>` split into company + location (`Company<br>⚲&nbsp;Location`, both halves HTML-unescaped since dc:creator is CDATA), `<content:encoded>` body (→ `<description>` fallback), `pubDate` → `PostedAt`, remote-only.
- Drops items with no usable id or empty company without aborting the crawl.
- Registered in `sources.All`; `sources/jobspresso.yml` board file added. Planned via OpenSpec change `add-jobspresso-source`.

Sourced from the ever-jobs provider catalogue as the simplest missing keyless source (RSS, no key, no proxy).

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/sources/` green (8 new jobspresso tests: mapping, id + slug fallback, company/location incl. entity-encoded names, drop rules, registration, board-file validation)
- [x] Live smoke crawl `go run ./cmd/ingest sources/jobspresso.yml` → `ingested=20 failed=0`
- [ ] Deploy: add a `cmd/ingest sources/jobspresso.yml` cron schedule in freehire-ops