### PR TITLE
feat(insights): add per-company hiring-signal rollup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Non-negotiable. Bias toward caution over speed; use judgment on trivial tasks.
 
 `freehire` ([freehire.dev](https://freehire.dev)) is an open-source IT job aggregator backend. Intended shape: many source parsers feed a pipeline that normalizes jobs into one schema, deduplicates them, and enriches them with AI; served over an HTTP API with rich filters.
 
-**Current state: working backend.** Fiber HTTP server with `/health`, `/api/v1/jobs[/:slug]`, Meilisearch-backed `/api/v1/jobs/search`, companies endpoints, a `/api/v1/auth` surface (register/login/me with stateless JWT + OAuth sign-in), per-user job-interaction endpoints (view/apply/save/track, behind auth, addressed by slug), and API-key management under `/api/v1/me`; Postgres via sqlc with `jobs`, `companies`, `users`, `user_jobs`, `user_identities`, and `api_keys` tables; a typed, versioned enrichment schema on `jobs`; and a family of standalone, run-once-and-exit workers: `cmd/ingest` (crawls one board file, normalizes and upserts, enqueues new postings for enrichment), `cmd/enrich` (drains the enrichment outbox via an LLM), `cmd/embed` (incremental semantic-embedding worker), `cmd/tg-ingest`/`cmd/tg-extract` (Telegram crawl + LLM-extract), `cmd/liveness` (URL-probes orphan jobs, closes dead ones), `cmd/reindex`/`cmd/backfill-derive`/`cmd/reslug` (maintenance), `cmd/rollup-stats` (activity rollup), `cmd/rollup-facets` (daily /open facet snapshot), `cmd/import-yc` (YC directory enrichment). A Svelte SPA lives under `web/` and consumes the API.
+**Current state: working backend.** Fiber HTTP server with `/health`, `/api/v1/jobs[/:slug]`, Meilisearch-backed `/api/v1/jobs/search`, companies endpoints, a `/api/v1/auth` surface (register/login/me with stateless JWT + OAuth sign-in), per-user job-interaction endpoints (view/apply/save/track, behind auth, addressed by slug), and API-key management under `/api/v1/me`; Postgres via sqlc with `jobs`, `companies`, `users`, `user_jobs`, `user_identities`, and `api_keys` tables; a typed, versioned enrichment schema on `jobs`; and a family of standalone, run-once-and-exit workers: `cmd/ingest` (crawls one board file, normalizes and upserts, enqueues new postings for enrichment), `cmd/enrich` (drains the enrichment outbox via an LLM), `cmd/embed` (incremental semantic-embedding worker), `cmd/tg-ingest`/`cmd/tg-extract` (Telegram crawl + LLM-extract), `cmd/liveness` (URL-probes orphan jobs, closes dead ones), `cmd/reindex`/`cmd/backfill-derive`/`cmd/reslug` (maintenance), `cmd/rollup-stats` (activity rollup), `cmd/rollup-facets` (daily /open facet snapshot), `cmd/rollup-company` (per-company hiring-signal rollup), `cmd/import-yc` (YC directory enrichment). A Svelte SPA lives under `web/` and consumes the API.
 
 Stack: **Go + Fiber v2**, **PostgreSQL**, **sqlc**, **Docker Compose**, **langchaingo**.
 
@@ -36,6 +36,7 @@ cmd/liveness/main.go       URL-probes orphan jobs, closes dead ones
 cmd/reindex/main.go        rebuilds the Meilisearch jobs index
 cmd/rollup-stats/main.go   recomputes the job_daily_stats rollup
 cmd/rollup-facets/main.go  recomputes the insights_facet_stats snapshot (/open facets)
+cmd/rollup-company/main.go recomputes the insights_company_stats per-company hiring-signal rollup
 cmd/backfill-derive/main.go  re-derives all deterministic dictionary facets
 cmd/reslug/main.go         backfills public_slug/company_slug
 cmd/backfill-company-names/main.go  resolves real display names for slug-named companies
@@ -90,6 +91,7 @@ go run ./cmd/backfill-derive               # re-derive dictionary facets; follow
 go run ./cmd/backfill-company-names [--dry-run]  # resolve real names for slug-named companies; follow with make reindex
 go run ./cmd/rollup-stats                  # recompute job_daily_stats (run-once, cron ~every 3h)
 go run ./cmd/rollup-facets                 # + MEILI_URL/MEILI_MASTER_KEY — recompute insights_facet_stats (run-once, cron ~daily)
+go run ./cmd/rollup-company                 # recompute insights_company_stats per-company hiring-signal rollup (run-once, cron ~daily)
 ```
 
 For the full architecture and conventions, see the **module files** below. Each module is self-contained and can be read independently.

--- a/cmd/rollup-company/main.go
+++ b/cmd/rollup-company/main.go
@@ -1,0 +1,75 @@
+// Command rollup-company is the standalone per-company hiring-signal rollup worker.
+// It fully recomputes insights_company_stats from the jobs table and swaps it in
+// atomically.
+//
+// insights_company_stats holds one row per (company_slug, day) for each of a company's
+// activity days, with that day's `added`/`removed` and a running `open` count, derived
+// solely from jobs.created_at/closed_at (closed jobs are retained). It is the company-
+// grained sibling of the insights_* rollups and the foundation for a company hiring
+// signal (who is ramping vs. freezing).
+//
+// It is a run-once-and-exit worker (cron-scheduled, ~daily given the company grain):
+// the clear and rebuild run inside one transaction, so a reader never sees a table
+// mid-rebuild and orphaned rows (e.g. a reopened job) vanish in the same step. Kept
+// separate from rollup-stats so its heavier, company-grained recompute schedules
+// independently and its failure never blocks the public /insights rollups. Re-running
+// is safe; it exits non-zero if the rebuild transaction fails, so cron can alert.
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+func main() {
+	worker.Main(run)
+}
+
+func run() int {
+	ctx, _, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	// The clear + rebuild run in one transaction so the swap is atomic: readers keep
+	// seeing the previous rollup until commit, and orphaned rows vanish in the same step.
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		log.Printf("begin: %v", err)
+		return 1
+	}
+	defer tx.Rollback(ctx)
+
+	// The rebuild aggregates the whole jobs lifecycle with a window sum; at the
+	// OLTP-default work_mem its sort/hash spills to disk and drags. Raise work_mem for
+	// this batch transaction only (SET LOCAL — reset on commit) so it stays in memory.
+	if _, err := tx.Exec(ctx, "SET LOCAL work_mem = '256MB'"); err != nil {
+		log.Printf("set work_mem: %v", err)
+		return 1
+	}
+
+	q := db.New(pool).WithTx(tx)
+
+	if err := q.DeleteAllInsightsCompanyStats(ctx); err != nil {
+		log.Printf("clear rollup: %v", err)
+		return 1
+	}
+	rows, err := q.RebuildInsightsCompanyStats(ctx)
+	if err != nil {
+		log.Printf("rebuild rollup: %v", err)
+		return 1
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		log.Printf("commit: %v", err)
+		return 1
+	}
+
+	log.Printf("rollup-company: rebuilt insights_company_stats (%d company-day rows)", rows)
+	return 0
+}

--- a/internal/db/insights.sql.go
+++ b/internal/db/insights.sql.go
@@ -11,6 +11,19 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllInsightsCompanyStats = `-- name: DeleteAllInsightsCompanyStats :exec
+
+DELETE FROM insights_company_stats
+`
+
+// ---------------------------------------------------------------------------
+// Per-company hiring signal
+// ---------------------------------------------------------------------------
+func (q *Queries) DeleteAllInsightsCompanyStats(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllInsightsCompanyStats)
+	return err
+}
+
 const deleteAllInsightsRoleStats = `-- name: DeleteAllInsightsRoleStats :exec
 
 
@@ -338,6 +351,45 @@ func (q *Queries) ListInsightsVelocity(ctx context.Context, arg ListInsightsVelo
 		return nil, err
 	}
 	return items, nil
+}
+
+const rebuildInsightsCompanyStats = `-- name: RebuildInsightsCompanyStats :execrows
+INSERT INTO insights_company_stats (company_slug, day, added, removed, open)
+SELECT
+    company_slug,
+    day,
+    added,
+    removed,
+    sum(added - removed) OVER (PARTITION BY company_slug ORDER BY day)::int AS open
+FROM (
+    SELECT j.company_slug, day, sum(added)::int AS added, sum(removed)::int AS removed
+    FROM jobs j
+    CROSS JOIN LATERAL (
+        -- Added event on the created_at day; removed event on the closed_at day.
+        SELECT (j.created_at AT TIME ZONE 'UTC')::date AS day, 1 AS added, 0 AS removed
+        UNION ALL
+        SELECT (j.closed_at AT TIME ZONE 'UTC')::date, 0, 1
+        WHERE j.closed_at IS NOT NULL
+    ) e
+    WHERE j.company_slug <> '' AND j.duplicate_of IS NULL
+    GROUP BY j.company_slug, day
+) daily
+`
+
+// Per-(company, day) hiring velocity with a running open count, from the retained
+// jobs lifecycle. Each canonical, attributable job (company_slug <> ” AND
+// duplicate_of IS NULL) emits an added event on its created_at (UTC) day and, if
+// closed, a removed event on its closed_at (UTC) day; the inner aggregate collapses
+// those to one row per (company_slug, day), and the window SUM over (added - removed)
+// ordered by day yields open = cumulative(added) - cumulative(removed) as of that day
+// (a job is created no later than it closes, so this equals the point-in-time open
+// count). Only a company's activity days get a row.
+func (q *Queries) RebuildInsightsCompanyStats(ctx context.Context) (int64, error) {
+	result, err := q.db.Exec(ctx, rebuildInsightsCompanyStats)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const rebuildInsightsRoleStatsByCountry = `-- name: RebuildInsightsRoleStatsByCountry :execrows

--- a/internal/db/insights_company_integration_test.go
+++ b/internal/db/insights_company_integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+// Integration tests for the per-company hiring-signal rollup (insights_company_stats).
+// Like the other insights_* rollups the recompute lives entirely in SQL, so it is only
+// verifiable against a real Postgres: seed jobs with known open/close ages, run the
+// rebuild, and assert the per-(company, day) added/removed and running open counts.
+// Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// companyStatRow mirrors one insights_company_stats row for assertions.
+type companyStatRow struct {
+	day     string
+	added   int
+	removed int
+	open    int
+}
+
+// seedCompanyJob inserts one job for a company with explicit open/close ages (days
+// before now) and an optional duplicate_of parent, then returns its id. It writes the
+// jobs table directly so the test controls company_slug, created_at, closed_at, and
+// duplicate_of precisely.
+func seedCompanyJob(t *testing.T, pool *pgxpool.Pool, ext, slug string, createdAgo int, closedAgo *int, dupOf *int64) int64 {
+	t.Helper()
+	var closed any
+	if closedAgo != nil {
+		closed = *closedAgo
+	}
+	var id int64
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO jobs (source, external_id, url, title, public_slug, company_slug, duplicate_of,
+			created_at, closed_at)
+		VALUES ('test', $1, 'http://example.test', 'A job', 'job-' || $1, $2, $3,
+			now() - make_interval(days => $4::int),
+			CASE WHEN $5::int IS NULL THEN NULL ELSE now() - make_interval(days => $5::int) END)
+		RETURNING id`,
+		ext, slug, dupOf, createdAgo, closed).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed company job %s: %v", ext, err)
+	}
+	return id
+}
+
+func companyStats(t *testing.T, ctx context.Context, pool *pgxpool.Pool, slug string) []companyStatRow {
+	t.Helper()
+	rows, err := pool.Query(ctx,
+		`SELECT day::text, added, removed, open FROM insights_company_stats
+		 WHERE company_slug = $1 ORDER BY day`, slug)
+	if err != nil {
+		t.Fatalf("query company stats: %v", err)
+	}
+	defer rows.Close()
+	var out []companyStatRow
+	for rows.Next() {
+		var r companyStatRow
+		if err := rows.Scan(&r.day, &r.added, &r.removed, &r.open); err != nil {
+			t.Fatalf("scan company stat: %v", err)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+func TestInsightsCompanyRollupVelocityAndRunningOpen(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// acme: two jobs opened 20d ago (one later closed 5d ago), a third opened 3d ago,
+	// plus a repost copy (duplicate_of) that must be ignored.
+	closed5 := 5
+	a1 := seedCompanyJob(t, pool, "a1", "acme", 20, nil, nil)
+	seedCompanyJob(t, pool, "a2", "acme", 20, &closed5, nil)
+	seedCompanyJob(t, pool, "a3", "acme", 3, nil, nil)
+	seedCompanyJob(t, pool, "adup", "acme", 10, nil, &a1) // duplicate → excluded
+
+	// globex: one job, still open.
+	seedCompanyJob(t, pool, "g1", "globex", 15, nil, nil)
+
+	// company-less job → excluded entirely.
+	seedCompanyJob(t, pool, "e1", "", 8, nil, nil)
+
+	if err := q.DeleteAllInsightsCompanyStats(ctx); err != nil {
+		t.Fatalf("delete company stats: %v", err)
+	}
+	if _, err := q.RebuildInsightsCompanyStats(ctx); err != nil {
+		t.Fatalf("rebuild company stats: %v", err)
+	}
+
+	acme := companyStats(t, ctx, pool, "acme")
+	var addedSum, removedSum int
+	for _, r := range acme {
+		addedSum += r.added
+		removedSum += r.removed
+	}
+	// Three canonical jobs opened (a1,a2,a3); the duplicate contributes nothing.
+	if addedSum != 3 {
+		t.Errorf("acme added total = %d, want 3 (duplicate excluded)", addedSum)
+	}
+	// One job closed (a2).
+	if removedSum != 1 {
+		t.Errorf("acme removed total = %d, want 1", removedSum)
+	}
+	// The close day carries removed=1 and a running open of 1 (a1 still open, a3 not
+	// yet opened as of 5d ago).
+	var closeRow *companyStatRow
+	for i := range acme {
+		if acme[i].removed > 0 {
+			closeRow = &acme[i]
+		}
+	}
+	if closeRow == nil || closeRow.removed != 1 || closeRow.open != 1 {
+		t.Errorf("acme close-day row = %+v, want removed=1 open=1", closeRow)
+	}
+	// The latest row's running open is the current open count: a1 + a3 = 2.
+	if len(acme) == 0 || acme[len(acme)-1].open != 2 {
+		t.Errorf("acme latest open = %v, want 2", acme)
+	}
+
+	// globex: one add, no removals, running open 1.
+	glob := companyStats(t, ctx, pool, "globex")
+	if len(glob) != 1 || glob[0].added != 1 || glob[0].removed != 0 || glob[0].open != 1 {
+		t.Errorf("globex rows = %+v, want single {added 1, removed 0, open 1}", glob)
+	}
+
+	// company-less job produced no rows under the empty slug.
+	if empty := companyStats(t, ctx, pool, ""); len(empty) != 0 {
+		t.Errorf("empty-slug rows = %+v, want none", empty)
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -131,6 +131,14 @@ type GmailConnection struct {
 	LastSyncedAt    pgtype.Timestamptz `json:"last_synced_at"`
 }
 
+type InsightsCompanyStat struct {
+	CompanySlug string      `json:"company_slug"`
+	Day         pgtype.Date `json:"day"`
+	Added       int32       `json:"added"`
+	Removed     int32       `json:"removed"`
+	Open        int32       `json:"open"`
+}
+
 type InsightsFacetStat struct {
 	Facet string `json:"facet"`
 	Value string `json:"value"`

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -218,6 +218,10 @@ type Querier interface {
 	// First half of the atomic rebuild: clear the snapshot. Run in the same transaction
 	// as the InsertFacetStat loop so a reader never sees an empty or partial table.
 	DeleteAllFacetStats(ctx context.Context) error
+	// ---------------------------------------------------------------------------
+	// Per-company hiring signal
+	// ---------------------------------------------------------------------------
+	DeleteAllInsightsCompanyStats(ctx context.Context) error
 	// Trends & Insights rollups (insights_*), recomputed by cmd/rollup-stats as an
 	// atomic delete-and-reinsert, and the read queries the public /api/v1/insights/*
 	// endpoints serve from them. All rollups are a pure function of current `jobs`
@@ -744,6 +748,15 @@ type Querier interface {
 	// coalesced/cast to bigint so it reads as a plain int64 (an all-failing provider
 	// yields 0, not NULL).
 	ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRollupRow, error)
+	// Per-(company, day) hiring velocity with a running open count, from the retained
+	// jobs lifecycle. Each canonical, attributable job (company_slug <> '' AND
+	// duplicate_of IS NULL) emits an added event on its created_at (UTC) day and, if
+	// closed, a removed event on its closed_at (UTC) day; the inner aggregate collapses
+	// those to one row per (company_slug, day), and the window SUM over (added - removed)
+	// ordered by day yields open = cumulative(added) - cumulative(removed) as of that day
+	// (a job is created no later than it closes, so this equals the point-in-time open
+	// count). Only a company's activity days get a row.
+	RebuildInsightsCompanyStats(ctx context.Context) (int64, error)
 	// Per-country role demand: a job contributes once to each of its countries.
 	RebuildInsightsRoleStatsByCountry(ctx context.Context, prevTs pgtype.Timestamptz) (int64, error)
 	// Country-agnostic ('' bucket) role demand. open_count = jobs open now

--- a/internal/db/queries/insights.sql
+++ b/internal/db/queries/insights.sql
@@ -283,3 +283,40 @@ LEFT JOIN insights_velocity_daily v
    AND v.facet_value = sqlc.arg('facet_value')
 GROUP BY date_trunc(sqlc.arg('unit')::text, d)
 ORDER BY date_trunc(sqlc.arg('unit')::text, d);
+
+-- ---------------------------------------------------------------------------
+-- Per-company hiring signal
+-- ---------------------------------------------------------------------------
+
+-- name: DeleteAllInsightsCompanyStats :exec
+DELETE FROM insights_company_stats;
+
+-- name: RebuildInsightsCompanyStats :execrows
+-- Per-(company, day) hiring velocity with a running open count, from the retained
+-- jobs lifecycle. Each canonical, attributable job (company_slug <> '' AND
+-- duplicate_of IS NULL) emits an added event on its created_at (UTC) day and, if
+-- closed, a removed event on its closed_at (UTC) day; the inner aggregate collapses
+-- those to one row per (company_slug, day), and the window SUM over (added - removed)
+-- ordered by day yields open = cumulative(added) - cumulative(removed) as of that day
+-- (a job is created no later than it closes, so this equals the point-in-time open
+-- count). Only a company's activity days get a row.
+INSERT INTO insights_company_stats (company_slug, day, added, removed, open)
+SELECT
+    company_slug,
+    day,
+    added,
+    removed,
+    sum(added - removed) OVER (PARTITION BY company_slug ORDER BY day)::int AS open
+FROM (
+    SELECT j.company_slug, day, sum(added)::int AS added, sum(removed)::int AS removed
+    FROM jobs j
+    CROSS JOIN LATERAL (
+        -- Added event on the created_at day; removed event on the closed_at day.
+        SELECT (j.created_at AT TIME ZONE 'UTC')::date AS day, 1 AS added, 0 AS removed
+        UNION ALL
+        SELECT (j.closed_at AT TIME ZONE 'UTC')::date, 0, 1
+        WHERE j.closed_at IS NOT NULL
+    ) e
+    WHERE j.company_slug <> '' AND j.duplicate_of IS NULL
+    GROUP BY j.company_slug, day
+) daily;

--- a/migrations/0029_insights_company_stats.sql
+++ b/migrations/0029_insights_company_stats.sql
@@ -1,0 +1,37 @@
+-- Per-company hiring-signal rollup: the company-grained sibling of the insights_*
+-- rollups (0022). Like them it is a pure function of the current `jobs` table, fully
+-- recomputed by cmd/rollup-company as an atomic delete-and-reinsert inside one
+-- transaction (never an upsert), so a reader never sees a partially rebuilt table.
+--
+-- One row per (company_slug, day) for each of a company's ACTIVITY days — a UTC day
+-- on which it opened (`added`) or closed (`removed`) at least one job. `open` is the
+-- company's open-job count as of the end of that day, i.e. the running total
+-- cumulative(added) - cumulative(removed) up to and including it. Because a job is
+-- always created no later than it closes, open_at(D) = (created<=D) - (closed<=D),
+-- so the running difference equals the point-in-time open count. Growth over any
+-- window is a carry-forward read of `open` (open now minus open as-of the window
+-- start), so no separate "previous window" column is stored.
+--
+-- Only canonical, attributable rows are counted (company_slug <> '' AND
+-- duplicate_of IS NULL), matching companies.job_count / RefreshCompanyFacets, so the
+-- per-company numbers reconcile with the rest of the app. Repost copies and
+-- company-less rows contribute nothing.
+--
+-- Applied to a fresh volume by initdb after 0028; on an existing prod volume this
+-- CREATE statement must be run manually BEFORE deploying code that reads it (per the
+-- migrations gotcha).
+
+CREATE TABLE public.insights_company_stats (
+    company_slug text    NOT NULL,
+    day          date    NOT NULL,
+    added        integer NOT NULL DEFAULT 0,
+    removed      integer NOT NULL DEFAULT 0,
+    open         integer NOT NULL DEFAULT 0,
+    PRIMARY KEY (company_slug, day)
+);
+
+-- Cross-company "as of a day" reads (e.g. top movers on a date) scan by day; this
+-- index serves them without a full-table scan. Per-company time-series reads are
+-- served by the (company_slug, day) primary key.
+CREATE INDEX insights_company_stats_day_idx
+    ON public.insights_company_stats (day);

--- a/openspec/changes/add-company-hiring-signal-rollup/.openspec.yaml
+++ b/openspec/changes/add-company-hiring-signal-rollup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-company-hiring-signal-rollup/design.md
+++ b/openspec/changes/add-company-hiring-signal-rollup/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The catalogue retains closed jobs (`jobs.closed_at` is set, rows are never deleted), so a per-company hiring time series is latent in `jobs` but not precomputed anywhere. The existing rollups established the pattern to follow:
+
+- `migrations/0022_insights_rollups.sql` — `insights_*` tables, each a pure function of current `jobs`, rebuilt as an atomic `DELETE`+`INSERT` in one transaction. Openness for a date is `created_at <= D AND (closed_at IS NULL OR closed_at > D)`.
+- `cmd/rollup-stats/main.go` — the run-once worker: `worker.Bootstrap`, one transaction, `SET LOCAL work_mem = '256MB'` for the big aggregates, `DeleteAll…` then `Rebuild…`, commit, exit non-zero on failure.
+- `internal/db/queries/insights.sql` / `stats.sql` — the `count(*) FILTER (…)` open-count idiom and the `generate_series` gap-free calendar idiom.
+
+This change adds one more rollup of the same kind, keyed by company.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Precompute a per-`(company_slug, day)` velocity series (`added`, `removed`, running `open`) from current `jobs`.
+- Make it fully retroactive and a pure function of `jobs` — no snapshot dependency.
+- Match the existing rollup conventions exactly (atomic rebuild worker, same idioms).
+
+**Non-Goals:**
+- No HTTP API/read endpoint (a later change).
+- No daily company-attribute snapshot (`employee_count`/`maturity` history stays lossy for now).
+- No stored "previous-window" column — growth is derived from the `open` series.
+
+## Decisions
+
+### One per-day table, activity days only, with running `open`
+
+`insights_company_stats(company_slug text, day date, added int, removed int, open int, PRIMARY KEY (company_slug, day))`.
+
+- A row exists only for a company's **activity days** (a day where `added > 0` or `removed > 0`), keeping the table bounded rather than companies × all-days.
+- `open` on a row is the company's open count as of the end of that day, i.e. the running total `cumulative(added) − cumulative(removed)` up to and including that day. Because a job is always created no later than it closes, `open_at(D) = (created ≤ D) − (closed ≤ D)`, so the running difference equals the point-in-time open count — no per-day scan needed.
+- Growth over any window is a read-time carry-forward lookup on `open` (see spec), so **no `open_count_prev` column** is stored.
+
+**Alternatives considered:**
+- *Scalar-per-company table* (`open_count`, `open_count_prev`) like `insights_role_stats`: smaller, but throws away the time series that is the actual signal. Rejected — the series is the product.
+- *Two tables* (per-day velocity + scalar growth): more surface for no gain, since `open` per day already yields growth. Rejected.
+- *Store `open` for every company on every day*: gap-free per-company calendar explodes row count. Rejected in favour of activity-days + carry-forward.
+
+### Canonical rows only
+
+The rebuild counts rows with non-empty `company_slug` and `duplicate_of IS NULL`, matching `RefreshCompanyFacets`/`companies.job_count` semantics so per-company numbers reconcile with the rest of the app. Repost copies and company-less rows contribute nothing.
+
+### Rebuild as a single `INSERT … SELECT`
+
+Per company, unnest the two event streams — `created_at::date` as `+1 added`, `closed_at::date` as `+1 removed` — aggregate to `(company_slug, day)`, then a window `SUM` ordered by day yields the running `open`. Delivered as `RebuildInsightsCompanyStats` alongside `DeleteAllInsightsCompanyStats` in `internal/db/queries/insights.sql`; sqlc regenerates `internal/db/`.
+
+### Separate worker `cmd/rollup-company`
+
+A new run-once worker mirroring `cmd/rollup-stats` (own transaction, `SET LOCAL work_mem`, delete+rebuild, atomic commit). Kept separate rather than folded into `rollup-stats` so its (heavier, company-grained) cadence can be scheduled independently and a failure doesn't block the public `/insights` rollups.
+
+## Risks / Trade-offs
+
+- **Row volume**: companies × activity-days is larger than the facet-bounded `insights_velocity_daily`. → Bounded to activity days only; it is an internal rollup with no live-read latency budget yet. Revisit if it grows unwieldy.
+- **Lossy reopen history**: only the current `closed_at` survives, so a reopen/reclose cycle is not fully reconstructed. → Accepted and already true for every existing rollup; documented, not fixed here.
+- **Enrichment reflects current, not post-time values**: role/skill/salary per company would use today's enrichment. → Out of scope; this change stores only counts (`added`/`removed`/`open`), no enrichment dimensions yet.
+
+## Migration Plan
+
+- New migration `migrations/00NN_insights_company_stats.sql` creating the table (+ an index for as-of/`day` scans). Applied by initdb on a fresh volume; on prod it must be run manually **before** deploying code that reads it (existing migrations gotcha) — though nothing reads it yet in this change.
+- Deploy the worker; schedule it on cron like `rollup-stats`. Re-running is safe (idempotent atomic rebuild).
+- Rollback: drop the table and remove the worker; nothing else depends on it.
+
+## Open Questions
+
+- Cron cadence for `cmd/rollup-company` (likely daily, given company grain) — an ops decision, not a code decision for this change.

--- a/openspec/changes/add-company-hiring-signal-rollup/proposal.md
+++ b/openspec/changes/add-company-hiring-signal-rollup/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The catalogue already retains closed jobs (`jobs.closed_at` is set, never deleted), so a per-company hiring time series is *latent* in the data but nowhere precomputed. Every existing rollup (`job_daily_stats`, `insights_role_stats`, `insights_skill_stats`, `insights_salary_stats`, `insights_velocity_daily`) is global or keyed by category/seniority/country/skill — **none is keyed by company**. A company-grain rollup is the missing foundation for a "company hiring-signal" product (who is ramping vs. freezing, and what they hire), and it can be built entirely from data we already hold.
+
+## What Changes
+
+- Add a new precomputed rollup table `insights_company_stats` keyed per `(company_slug, day)`, holding `added` / `removed` / `open` job counts derived from `jobs.created_at` / `jobs.closed_at`, plus current-vs-prev-30d open counts for a growth read.
+- Add a rebuild SQL query in `internal/db/queries/insights.sql` that recomputes the table in one atomic `DELETE` + re-`INSERT`, matching the existing `insights_*` rollup pattern.
+- Add a run-once-and-exit worker `cmd/rollup-company` that runs the rebuild in a single transaction (same shape as `cmd/rollup-stats`).
+- The rollup is **retroactive**: on first run it reconstructs the full history back to the earliest `created_at`, using retained closed rows — no wait to accumulate data.
+
+Out of scope for this change (deliberately, one change at a time):
+- No HTTP API endpoint to read the rollup.
+- No daily company-attribute snapshot table (accepting that `employee_count`/`maturity` history stays lossy for now).
+
+## Capabilities
+
+### New Capabilities
+- `company-hiring-signal`: a precomputed per-company, per-day rollup of hiring velocity (jobs added/removed/open) and 30-day open-count growth, derived from the retained `jobs` lifecycle, produced by a standalone rollup worker.
+
+### Modified Capabilities
+<!-- None: existing insights rollups and the market-insights API are unchanged; this adds a new, independent company-grain rollup. -->
+
+## Impact
+
+- **Schema:** new migration adding `insights_company_stats` (+ supporting index). Follows the initdb-only migration convention.
+- **DB layer:** new query in `internal/db/queries/insights.sql`; regenerated sqlc code in `internal/db/`.
+- **New worker:** `cmd/rollup-company/main.go` (needs `DATABASE_URL` only); intended to run on a cron cadence like `cmd/rollup-stats`.
+- **No API, frontend, or search impact.** Purely additive; no existing behavior changes.

--- a/openspec/changes/add-company-hiring-signal-rollup/specs/company-hiring-signal/spec.md
+++ b/openspec/changes/add-company-hiring-signal-rollup/specs/company-hiring-signal/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Per-company daily hiring-velocity rollup
+
+The system SHALL maintain a precomputed rollup table `insights_company_stats` keyed by `(company_slug, day)` that records, for each company and each UTC day the company had activity, the number of jobs `added` (jobs whose `created_at` falls on that day), `removed` (jobs whose current `closed_at` falls on that day), and `open` (jobs open as of the end of that day).
+
+Openness for a day `D` SHALL be computed as `created_at <= D AND (closed_at IS NULL OR closed_at > D)`, matching the convention documented in `migrations/0022_insights_rollups.sql`.
+
+Only canonical, attributable job rows SHALL be counted: rows with a non-empty `company_slug` and `duplicate_of IS NULL` (repost copies are excluded so counts match `companies.job_count` semantics).
+
+#### Scenario: A company's posting is reflected as added and open
+
+- **WHEN** a company has one job with `created_at = 2026-01-10` and `closed_at IS NULL`, and the rollup is rebuilt
+- **THEN** `insights_company_stats` has a row for that `company_slug` on day `2026-01-10` with `added = 1`
+- **AND** `open` is `1` for that company on `2026-01-10` and every subsequent day up to the rollup's latest day
+
+#### Scenario: A closed posting is reflected as removed
+
+- **WHEN** a company's job has `created_at = 2026-01-10` and `closed_at = 2026-01-20`
+- **THEN** the rollup records `added = 1` on `2026-01-10` and `removed = 1` on `2026-01-20`
+- **AND** `open` for that company is `0` from `2026-01-20` onward (the close day itself is no longer open)
+
+#### Scenario: Repost copies are not double-counted
+
+- **WHEN** a job row has `duplicate_of` pointing at a canonical row
+- **THEN** that duplicate row contributes nothing to `added`, `removed`, or `open`
+
+#### Scenario: Jobs without a company are excluded
+
+- **WHEN** a job row has an empty `company_slug`
+- **THEN** it contributes to no `insights_company_stats` row
+
+### Requirement: Retroactive full-history rebuild
+
+The rollup SHALL be reconstructable in full from the current `jobs` table alone, back to the earliest `created_at`, because closed jobs are retained rather than deleted. A rebuild SHALL NOT depend on any prior rollup state or external snapshot.
+
+#### Scenario: First rebuild reconstructs prior days
+
+- **WHEN** the rollup is run for the first time against a catalogue containing jobs created and closed across past days
+- **THEN** `insights_company_stats` contains rows for those past days derived solely from `created_at`/`closed_at`
+
+### Requirement: Hiring growth derivable from the open time series
+
+Hiring growth (ramping vs. freezing) over any window SHALL be derivable from the stored per-day `open` series alone, without scanning `jobs`: a company's open count as of a date is the value of `open` on its latest rollup row at or before that date (carry-forward across days with no activity). The rollup therefore SHALL NOT need a separate stored "previous window" column.
+
+#### Scenario: 30-day growth reads from the open series
+
+- **WHEN** a company's rollup shows `open = 4` on its latest row at or before 30 days ago and `open = 10` on its most recent row
+- **THEN** its 30-day growth is `10 - 4 = 6`, computed from `insights_company_stats` alone
+
+### Requirement: Atomic rebuild worker
+
+A run-once-and-exit worker `cmd/rollup-company` SHALL rebuild `insights_company_stats` inside a single database transaction using a `DELETE`-then-`INSERT` recompute, so that readers never observe a partially rebuilt table. The worker SHALL require only `DATABASE_URL` and SHALL exit non-zero on failure without leaving the table partially written.
+
+#### Scenario: Rebuild is all-or-nothing
+
+- **WHEN** the rebuild transaction fails partway
+- **THEN** the previously committed contents of `insights_company_stats` remain intact (no partial state is committed)
+
+#### Scenario: Successful run replaces contents atomically
+
+- **WHEN** the worker completes successfully
+- **THEN** `insights_company_stats` reflects exactly the recomputed rows for the current `jobs` state

--- a/openspec/changes/add-company-hiring-signal-rollup/tasks.md
+++ b/openspec/changes/add-company-hiring-signal-rollup/tasks.md
@@ -1,0 +1,18 @@
+## 1. Schema
+
+- [x] 1.1 Add migration `migrations/0029_insights_company_stats.sql` creating `insights_company_stats(company_slug text NOT NULL, day date NOT NULL, added int NOT NULL DEFAULT 0, removed int NOT NULL DEFAULT 0, open int NOT NULL DEFAULT 0, PRIMARY KEY (company_slug, day))` plus an index on `(day)` for as-of/cross-company scans, with a header comment matching the `insights_*` rollup convention (pure function of `jobs`, atomic rebuild, initdb-only + manual-on-prod note).
+
+## 2. Rebuild query (TDD)
+
+- [x] 2.1 RED: add a failing integration test (`//go:build integration`) in `internal/db` that seeds `jobs` covering the spec scenarios — a canonical open job, a job closed on a later day, a `duplicate_of` repost copy, and an empty-`company_slug` job — runs the rebuild, and asserts `added`/`removed`/running `open` rows per company/day (including that duplicates and company-less rows contribute nothing, and `open` is the running `cumAdded − cumRemoved`).
+- [x] 2.2 GREEN: add `DeleteAllInsightsCompanyStats` and `RebuildInsightsCompanyStats` to `internal/db/queries/insights.sql` (per-company aggregate of `created_at::date` as added and `closed_at::date` as removed, filtered to `company_slug <> '' AND duplicate_of IS NULL`, with a window `SUM(...) OVER (PARTITION BY company_slug ORDER BY day)` for running `open`); regenerate sqlc (`make sqlc`); make the test pass.
+- [x] 2.3 REFACTOR + simplify the query and test under green.
+
+## 3. Rollup worker
+
+- [x] 3.1 Add `cmd/rollup-company/main.go` mirroring `cmd/rollup-stats`: `worker.Main`/`worker.Bootstrap`, one transaction, `SET LOCAL work_mem = '256MB'`, `DeleteAllInsightsCompanyStats` then `RebuildInsightsCompanyStats`, atomic commit, non-zero exit + log on failure, with a package doc comment describing it as a run-once-and-exit rollup.
+- [x] 3.2 `go build ./... && go vet ./...`; run the integration test (`go test -tags=integration ./internal/db/`) green.
+
+## 4. Docs
+
+- [x] 4.1 Update `CLAUDE.md` (layout tree + Commands section) to list `cmd/rollup-company` alongside `cmd/rollup-stats`/`cmd/rollup-facets`, noting it needs only `DATABASE_URL` and is cron-scheduled (~daily).


### PR DESCRIPTION
## Summary
- Adds `insights_company_stats` — a per-`(company_slug, day)` rollup of hiring velocity (`added`/`removed`) with a running `open` count, derived from the retained `jobs` lifecycle (`created_at`/`closed_at`).
- Counts only canonical attributable rows (`company_slug <> '' AND duplicate_of IS NULL`), so numbers reconcile with `companies.job_count`. Growth over any window is derivable from the `open` series — no snapshot table needed.
- New run-once `cmd/rollup-company` worker rebuilds it atomically (single tx, `SET LOCAL work_mem`, delete+rebuild), mirroring `cmd/rollup-stats`.
- **Scope: data layer only** — no HTTP API and no company-attribute snapshots (both deliberately deferred). Foundation for a company hiring-signal product (who's ramping vs. freezing).

Planned via OpenSpec change `add-company-hiring-signal-rollup` (proposal/design/specs/tasks included).

## Test Plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` — 84 packages green
- [x] `go test -tags=integration ./internal/db/` — new `TestInsightsCompanyRollupVelocityAndRunningOpen` applies migration 0029, runs the rebuild, and asserts velocity, running `open`, and duplicate/empty-slug exclusion
- [ ] Deploy note: migration `0029_insights_company_stats.sql` must be applied manually on prod **before** scheduling the worker (existing migrations gotcha); schedule `cmd/rollup-company` on cron (~daily)