### PR TITLE
feat(sources): arbeitsagentur first-party IT adapter (berufsfeld search + SSR detail)

### DIFF
--- a/internal/sources/arbeitsagentur.go
+++ b/internal/sources/arbeitsagentur.go
@@ -1,0 +1,192 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// arbeitsagentur adapts the Bundesagentur für Arbeit (Germany's federal employment agency) job
+// board. Its jobsuche-service search API is reachable keyless with the well-known public
+// X-API-Key "jobboerse-jobsuche"; postings are enumerated by professional field (berufsfeld),
+// carried as the board file entry's board. The search payload has no description and the detail
+// API is 403, so the description is scraped from the server-rendered public jobdetail page. Most
+// results carry an externeUrl (re-listed from other boards) and are dropped — only the agency's
+// own first-party postings are kept. Multi-company (company per posting), board-based.
+type arbeitsagentur struct {
+	http arbeitsagenturHTTP
+}
+
+// arbeitsagenturHTTP is the two-stage transport: a keyed JSON search and an SSR detail page fetch.
+type arbeitsagenturHTTP interface {
+	GetJSONWithHeaders(ctx context.Context, url string, headers map[string]string, v any) error
+	GetHTML(ctx context.Context, url string) (*html.Node, error)
+}
+
+const (
+	arbeitsagenturSearchURL = "https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs"
+	arbeitsagenturDetailURL = "https://www.arbeitsagentur.de/jobsuche/jobdetail/"
+	arbeitsagenturAPIKey    = "jobboerse-jobsuche"
+	arbeitsagenturPageSize  = 100
+	// arbeitsagenturWithinDays bounds each crawl to a fresh window, keeping the result set well
+	// inside the API's page*size ≈ 10 000 pagination depth cap.
+	arbeitsagenturWithinDays = 7
+	// arbeitsagenturMaxPages backstops the loop at the depth cap (page*size ≤ 10 000).
+	arbeitsagenturMaxPages = 10000 / arbeitsagenturPageSize
+)
+
+// NewArbeitsagentur builds the Arbeitsagentur adapter over the given two-stage client.
+func NewArbeitsagentur(c arbeitsagenturHTTP) Source { return arbeitsagentur{http: c} }
+
+func (arbeitsagentur) Provider() string { return "arbeitsagentur" }
+
+// arbeitsagenturSearch is one search-API page.
+type arbeitsagenturSearch struct {
+	Stellenangebote []arbeitsagenturPosting `json:"stellenangebote"`
+	MaxErgebnisse   int                     `json:"maxErgebnisse"`
+}
+
+// arbeitsagenturPosting is one search result. externeUrl is present when the posting is re-listed
+// from another board; such postings are dropped.
+type arbeitsagenturPosting struct {
+	Refnr       string            `json:"refnr"`
+	Titel       string            `json:"titel"`
+	Arbeitgeber string            `json:"arbeitgeber"`
+	Arbeitsort  arbeitsagenturOrt `json:"arbeitsort"`
+	Datum       string            `json:"aktuelleVeroeffentlichungsdatum"`
+	ExterneURL  string            `json:"externeUrl"`
+}
+
+type arbeitsagenturOrt struct {
+	Ort    string `json:"ort"`
+	Region string `json:"region"`
+	Land   string `json:"land"`
+}
+
+// arbeitsagenturDetail decodes the description out of the jobdetail page's ng-state JSON blob.
+type arbeitsagenturDetail struct {
+	Jobdetail struct {
+		Beschreibung string `json:"stellenangebotsBeschreibung"`
+	} `json:"jobdetail"`
+}
+
+func (a arbeitsagentur) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	headers := map[string]string{"X-API-Key": arbeitsagenturAPIKey}
+	var kept []arbeitsagenturPosting
+	for page := 1; page <= arbeitsagenturMaxPages; page++ {
+		var resp arbeitsagenturSearch
+		if err := a.http.GetJSONWithHeaders(ctx, a.searchURL(e.Board, page), headers, &resp); err != nil {
+			return nil, fmt.Errorf("arbeitsagentur: search board %q page %d: %w", e.Board, page, err)
+		}
+		for _, p := range resp.Stellenangebote {
+			if strings.TrimSpace(p.ExterneURL) == "" && p.Refnr != "" {
+				kept = append(kept, p) // first-party only
+			}
+		}
+		if len(resp.Stellenangebote) < arbeitsagenturPageSize || page*arbeitsagenturPageSize >= resp.MaxErgebnisse {
+			break
+		}
+	}
+	// A missing/failed description does not drop the posting, so the mapper always keeps it.
+	return fetchDetails(kept, defaultDetailWorkers, func(p arbeitsagenturPosting) (Job, bool) {
+		return a.toJob(ctx, p), true
+	}), nil
+}
+
+// searchURL builds a berufsfeld search request bounded to the recent-publish window.
+func (arbeitsagentur) searchURL(berufsfeld string, page int) string {
+	q := url.Values{}
+	q.Set("berufsfeld", berufsfeld)
+	q.Set("size", strconv.Itoa(arbeitsagenturPageSize))
+	q.Set("page", strconv.Itoa(page))
+	q.Set("veroeffentlichtseit", strconv.Itoa(arbeitsagenturWithinDays))
+	return arbeitsagenturSearchURL + "?" + q.Encode()
+}
+
+func (a arbeitsagentur) toJob(ctx context.Context, p arbeitsagenturPosting) Job {
+	detailURL := arbeitsagenturDetailURL + p.Refnr
+	return Job{
+		ExternalID:  p.Refnr,
+		URL:         detailURL,
+		Title:       strings.TrimSpace(p.Titel),
+		Company:     strings.TrimSpace(p.Arbeitgeber),
+		Location:    arbeitsagenturLocation(p.Arbeitsort),
+		Description: a.description(ctx, detailURL),
+		PostedAt:    arbeitsagenturDate(p.Datum),
+	}
+}
+
+// description scrapes the SSR jobdetail page's ng-state JSON for the Stellenbeschreibung. Any
+// failure (fetch error, no ng-state block, bad JSON) yields an empty description rather than an
+// error — the posting is still worth emitting. The Stellenbeschreibung is plain text (newline
+// paragraphs, no markup), so it goes through plainTextToHTML — as djinni/lumenalta do — to rebuild
+// paragraph structure rather than collapsing into one block when rendered.
+func (a arbeitsagentur) description(ctx context.Context, detailURL string) string {
+	root, err := a.http.GetHTML(ctx, detailURL)
+	if err != nil {
+		return ""
+	}
+	blob := scriptTextByID(root, "ng-state")
+	if blob == "" {
+		return ""
+	}
+	var d arbeitsagenturDetail
+	if err := json.Unmarshal([]byte(blob), &d); err != nil {
+		return ""
+	}
+	return sanitizeHTML(plainTextToHTML(d.Jobdetail.Beschreibung))
+}
+
+// arbeitsagenturLocation joins the non-empty parts of an arbeitsort, dropping the literal "null"
+// the API emits for absent fields.
+func arbeitsagenturLocation(o arbeitsagenturOrt) string {
+	parts := make([]string, 0, 3)
+	for _, s := range []string{o.Ort, o.Region, o.Land} {
+		if s = strings.TrimSpace(s); s != "" && s != "null" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// arbeitsagenturDate parses the "2006-01-02" publish date.
+func arbeitsagenturDate(s string) *time.Time {
+	t, err := time.Parse("2006-01-02", strings.TrimSpace(s))
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// scriptTextByID returns the text of the first <script> element with the given id, or "".
+func scriptTextByID(root *html.Node, id string) string {
+	var found *html.Node
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if found != nil {
+			return
+		}
+		if n.Type == html.ElementNode && n.Data == "script" {
+			for _, a := range n.Attr {
+				if a.Key == "id" && a.Val == id {
+					found = n
+					return
+				}
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(root)
+	if found == nil {
+		return ""
+	}
+	return textContent(found)
+}

--- a/internal/sources/arbeitsagentur_test.go
+++ b/internal/sources/arbeitsagentur_test.go
@@ -1,0 +1,193 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// arbeitsagenturFake routes search calls by their page param and detail calls by the refnr in
+// the URL, so a single fake drives both stages (paginated JSON search + per-posting SSR detail).
+type arbeitsagenturFake struct {
+	searchByPage map[int]string    // page -> search JSON body ("" => empty page)
+	detailByRef  map[string]string // refnr -> detail HTML ("" => no ng-state)
+	detailErr    map[string]bool   // refnr -> GetHTML returns an error
+	gotHeaders   map[string]string
+	searchPages  []int // pages requested, in order
+}
+
+func (f *arbeitsagenturFake) GetJSONWithHeaders(_ context.Context, u string, headers map[string]string, v any) error {
+	f.gotHeaders = headers
+	page := 1
+	if pu, err := url.Parse(u); err == nil {
+		if p, err := strconv.Atoi(pu.Query().Get("page")); err == nil {
+			page = p
+		}
+	}
+	f.searchPages = append(f.searchPages, page)
+	body := f.searchByPage[page]
+	if body == "" {
+		body = `{"stellenangebote":[],"maxErgebnisse":0}`
+	}
+	return json.Unmarshal([]byte(body), v)
+}
+
+func (f *arbeitsagenturFake) GetHTML(_ context.Context, u string) (*html.Node, error) {
+	ref := u[strings.LastIndex(u, "/")+1:]
+	if f.detailErr[ref] {
+		return nil, errors.New("detail boom")
+	}
+	return html.Parse(strings.NewReader(f.detailByRef[ref]))
+}
+
+// detailHTML wraps an ng-state script carrying the given description, mirroring the real SSR page.
+func detailHTML(desc string) string {
+	return `<html><body><script id="ng-state" type="application/json">{"jobdetail":{"stellenangebotsBeschreibung":` +
+		strconv.Quote(desc) + `}}</script></body></html>`
+}
+
+func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
+	const page1 = `{"maxErgebnisse":2,"stellenangebote":[
+	  {"refnr":"20177-44320844-717-S","titel":"Fachinformatiker*in","arbeitgeber":"Boehringer Ingelheim Pharma GmbH & Co. KG","arbeitsort":{"ort":"Biberach an der Riß","region":"Baden-Württemberg","land":"Deutschland","strasse":"null"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"},
+	  {"refnr":"EXT-1","titel":"Re-listed","arbeitgeber":"Other","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-10","externeUrl":"https://aubi-plus.de/x"},
+	  {"refnr":"AC-2","titel":"DevOps Engineer","arbeitgeber":"Acme GmbH","arbeitsort":{"ort":"München","region":"Bayern","land":"Deutschland"},"aktuelleVeroeffentlichungsdatum":"2026-07-15"}
+	]}`
+	fake := &arbeitsagenturFake{
+		searchByPage: map[int]string{1: page1},
+		detailByRef: map[string]string{
+			"20177-44320844-717-S": detailHTML("Bei Boehringer Ingelheim entwickeln wir <b>bahnbrechende</b> Therapien."),
+			"AC-2":                 detailHTML("Wir suchen einen DevOps Engineer."),
+		},
+	}
+	jobs, err := NewArbeitsagentur(fake).Fetch(context.Background(), CompanyEntry{
+		Provider: "arbeitsagentur", Board: "Softwareentwicklung und Programmierung",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// The externeUrl re-list is dropped; two first-party postings map.
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (externeUrl dropped)", len(jobs))
+	}
+	// Header carried the static public key.
+	if fake.gotHeaders["X-API-Key"] != "jobboerse-jobsuche" {
+		t.Errorf("X-API-Key header = %q", fake.gotHeaders["X-API-Key"])
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	j, ok := byID["20177-44320844-717-S"]
+	if !ok {
+		t.Fatalf("first-party posting not mapped; got %d jobs", len(jobs))
+	}
+	if j.URL != "https://www.arbeitsagentur.de/jobsuche/jobdetail/20177-44320844-717-S" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Fachinformatiker*in" || j.Company != "Boehringer Ingelheim Pharma GmbH & Co. KG" {
+		t.Errorf("title/company wrong: %q / %q", j.Title, j.Company)
+	}
+	if j.Location != "Biberach an der Riß, Baden-Württemberg, Deutschland" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-18" {
+		t.Errorf("PostedAt = %v, want 2026-07-18", j.PostedAt)
+	}
+}
+
+func TestArbeitsagenturScrapesDescription(t *testing.T) {
+	const page1 = `{"maxErgebnisse":2,"stellenangebote":[
+	  {"refnr":"OK-1","titel":"A","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"},
+	  {"refnr":"NODESC-2","titel":"B","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"},
+	  {"refnr":"ERR-3","titel":"C","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"}
+	]}`
+	fake := &arbeitsagenturFake{
+		searchByPage: map[int]string{1: page1},
+		detailByRef: map[string]string{
+			// The real Stellenbeschreibung is plain text with newline paragraphs, no markup.
+			"OK-1":     detailHTML("Bei uns arbeitest du remote.\n\nZweiter Absatz mit Details."),
+			"NODESC-2": `<html><body><p>no ng-state here</p></body></html>`,
+		},
+		detailErr: map[string]bool{"ERR-3": true},
+	}
+	jobs, err := NewArbeitsagentur(fake).Fetch(context.Background(), CompanyEntry{Board: "Informatik"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// A detail error or a page without a description must not drop the posting.
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 (missing/failed descriptions still emit)", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	// Plain-text newlines must be rebuilt into paragraph structure, not collapsed into one block.
+	if d := byID["OK-1"].Description; !strings.Contains(d, "remote") || !strings.Contains(d, "Zweiter Absatz") || !strings.Contains(d, "<p>") {
+		t.Errorf("OK-1 description = %q, want both paragraphs with rebuilt <p> structure", d)
+	}
+	if d := byID["NODESC-2"].Description; d != "" {
+		t.Errorf("NODESC-2 description = %q, want empty (no ng-state block)", d)
+	}
+	if d := byID["ERR-3"].Description; d != "" {
+		t.Errorf("ERR-3 description = %q, want empty (detail fetch failed)", d)
+	}
+}
+
+func TestArbeitsagenturPaginates(t *testing.T) {
+	full := arbeitsagenturPage(arbeitsagenturPageSize, 1) // a full page => keep paginating
+	short := arbeitsagenturPage(3, 1000)                  // a short page => stop after it
+	fake := &arbeitsagenturFake{
+		searchByPage: map[int]string{1: full, 2: short},
+		detailByRef:  map[string]string{}, // details resolve to empty descriptions
+	}
+	jobs, err := NewArbeitsagentur(fake).Fetch(context.Background(), CompanyEntry{Board: "Informatik"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !slices.Equal(fake.searchPages, []int{1, 2}) {
+		t.Errorf("requested pages = %v, want [1 2]", fake.searchPages)
+	}
+	if len(jobs) != arbeitsagenturPageSize+3 {
+		t.Errorf("len(jobs) = %d, want %d", len(jobs), arbeitsagenturPageSize+3)
+	}
+}
+
+// arbeitsagenturPage builds a search body of n first-party postings with ids offset by base.
+func arbeitsagenturPage(n, base int) string {
+	items := make([]string, n)
+	for i := range items {
+		items[i] = fmt.Sprintf(`{"refnr":"R-%d","titel":"T","arbeitgeber":"Co","arbeitsort":{"ort":"Berlin"},"aktuelleVeroeffentlichungsdatum":"2026-07-18"}`, base+i)
+	}
+	return `{"maxErgebnisse":100000,"stellenangebote":[` + strings.Join(items, ",") + `]}`
+}
+
+func TestArbeitsagenturProviderRegistered(t *testing.T) {
+	if got := NewArbeitsagentur(nil).Provider(); got != "arbeitsagentur" {
+		t.Errorf("Provider() = %q, want arbeitsagentur", got)
+	}
+	if _, ok := All(nil)["arbeitsagentur"]; !ok {
+		t.Error("All() should register provider arbeitsagentur")
+	}
+	if !slices.Contains(FilterableProviders(), "arbeitsagentur") {
+		t.Error("FilterableProviders() should include arbeitsagentur")
+	}
+}
+
+func TestArbeitsagenturBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/arbeitsagentur.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/arbeitsagentur.yml fails validation: %v", err)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -293,6 +293,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJobdanmark(c),
 		NewTyomarkkinatori(c),
 		NewLikeit(c),
+		NewArbeitsagentur(c),
 		// International single-company adapters (boardless).
 		NewTelegramCareers(c),
 		NewUber(c),

--- a/openspec/changes/add-arbeitsagentur-source/.openspec.yaml
+++ b/openspec/changes/add-arbeitsagentur-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-arbeitsagentur-source/design.md
+++ b/openspec/changes/add-arbeitsagentur-source/design.md
@@ -1,0 +1,91 @@
+## Context
+
+The Bundesagentur für Arbeit exposes `jobsuche-service`. A spike established:
+
+- `GET pc/v4/jobs?berufsfeld=<field>&size=100&page=N` with header `X-API-Key: jobboerse-jobsuche`
+  returns HTTP 200 keyless. Response: `{ stellenangebote: [...], maxErgebnisse, page, size, facetten }`.
+- Each posting: `refnr` (stable id, e.g. `13647-2027459153-S`), `titel`, `arbeitgeber` (company),
+  `arbeitsort` (`{ort, region, land, plz, ...}`), `aktuelleVeroeffentlichungsdatum` (YYYY-MM-DD),
+  and optionally `externeUrl` (present when the posting is re-listed from another board).
+- **No description in the search payload.** The detail API (`pc/v2|v4/jobsdetails/<base64(refnr)>`,
+  `ed/v1/jobdetails/…`) returns 403. But the public SSR page
+  `https://www.arbeitsagentur.de/jobsuche/jobdetail/<refnr>` returns 200 and carries the
+  `Stellenbeschreibung` block and a `<meta name="description">` summary.
+- **externeUrl dominates.** For `was=Softwareentwickler`, 46/50 carried `externeUrl`. Filtering by
+  `berufsfeld` (the agency's own taxonomy) rather than `was` raises the first-party share sharply
+  (11–29 of 50). So `berufsfeld` is both the scoping and the quality lever.
+- **Pagination cap.** `page*size ≲ 10 000` (page 400 → HTTP 400). Each IT berufsfeld totals
+  ~700–10 400, so a `veroeffentlichtseit`-bounded window stays well inside the cap.
+- Repeated `berufsfeld` params do NOT OR (multi-value → `maxErgebnisse=0`); each field is a separate
+  query, hence a separate board file entry.
+
+This is the DataArt/onstrider two-stage shape — enumerate, then per-item detail fetch over
+`fetchDetails` — but with a keyed JSON search front (`GetJSONWithHeaders`) instead of a sitemap.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless (public static key), board-per-`berufsfeld`, multi-company `arbeitsagentur` adapter that
+  emits only first-party postings with a scraped description.
+- Reuse `GetJSONWithHeaders`, `GetHTML`, and `fetchDetails`; no new shared helper unless a shape forces it.
+
+**Non-Goals:**
+- Ingesting `externeUrl` re-lists. They duplicate other boards and apply off-site; dropped.
+- Following `externeUrl` to its destination (a linksource job); out of scope for this change.
+- Full-backlog crawl. Each run is a `veroeffentlichtseit` window; the standard sweep soft-closes
+  postings that age out and stop being emitted.
+- German-language enrichment tuning. Skill tags survive; seniority/category will be sparse. Accepted.
+
+## Decisions
+
+- **Board = `berufsfeld`.** The board file entry's `board` is the professional-field label passed as
+  the `berufsfeld` query param. Multi-company (company per posting = `arbeitgeber`), board-based, so
+  the adapter carries neither the `boardless` nor `aggregator` marker and is filterable by default —
+  the same posture as other board-keyed multi-company sources. *Alternative rejected:* `was=` keyword
+  boards — far more `externeUrl` noise and less precise.
+
+- **First-party = absence of `externeUrl`.** The mapper drops any posting with a non-empty
+  `externeUrl`. *Alternative rejected:* keeping all and deduping later — the re-lists are mostly
+  German boards we do not otherwise cover, so there is no first-party twin to dedup against, and the
+  apply URL would point off-site.
+
+- **Description from the SSR jobdetail page.** For each kept posting, `fetchDetails` GETs
+  `https://www.arbeitsagentur.de/jobsuche/jobdetail/<refnr>` and extracts the `Stellenbeschreibung`
+  content (falling back to the `<meta name="description">` summary when the block is absent). The
+  same URL is the `Job.URL`. A detail fetch that fails or yields no description does not drop the
+  posting — it is emitted with an empty description (title/company/location still carry value) and a
+  failed page does not abort the crawl. *Alternative rejected:* shipping with no description at all —
+  too thin; the SSR page is the only description source.
+
+- **Pagination.** Loop `page=1..N` at `size=100`, stopping when a page returns fewer than `size`
+  postings, when `page*size` reaches `maxErgebnisse`, or at the depth cap. Bound the set up front with
+  `veroeffentlichtseit=<days>` so each run is a small, fresh window.
+
+- **Public static key as a constant.** `X-API-Key: jobboerse-jobsuche` is a well-known public value,
+  not a secret; it lives as a code constant and the provider registers unconditionally in
+  `sources.All` (unlike the env-keyed USAJobs/Reed).
+
+## Risks / Trade-offs
+
+- **Detail fan-out.** Up to a few thousand SSR page fetches per berufsfeld per run. → The
+  first-party filter drops the majority up front, and `veroeffentlichtseit` bounds each run to a
+  fresh window; `fetchDetails` throttles with the default worker pool. If the site rate-limits the
+  prod IP, enroll in `proxiedProviders` later (a config flip, noted as a seam — not built now).
+- **German language weakens enrichment facets.** → Accepted; skill tags are language-agnostic and
+  the raw title/company/location are still useful. Not a blocker.
+- **`page*size` depth cap (~10 000).** A berufsfeld larger than the cap loses its deep tail. → The
+  `veroeffentlichtseit` window keeps each run under the cap; if a field still exceeds it, the drop is
+  logged rather than silent.
+- **Static key could be revoked or the SSR markup could drift.** → Both surface as a board-health
+  failure (search 4xx or empty descriptions); the mapping is pinned to real fixtures in tests.
+
+## Migration Plan
+
+- No DB migration, no API change, no new dependency, no secret.
+- Deploy: add a `cmd/ingest sources/arbeitsagentur.yml` cron schedule in freehire-ops.
+
+## Open Questions
+
+- Does the prod datacenter IP get rate-limited on the SSR jobdetail pages? Resolve with a manual prod
+  run; `proxiedProviders` enrollment is the fallback (config flip).
+- Exact `veroeffentlichtseit` window (7 vs 14 days) — tune during implementation against real volume.

--- a/openspec/changes/add-arbeitsagentur-source/proposal.md
+++ b/openspec/changes/add-arbeitsagentur-source/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+The Bundesagentur für Arbeit (Germany's federal employment agency) runs the country's largest job
+board. A spike VALIDATED that its `jobsuche-service` REST API is reachable keyless with the
+well-known public `X-API-Key: jobboerse-jobsuche` and enumerates postings by professional field
+(`berufsfeld`), returning employer, title, location, publish date, and a stable `refnr`. Adding a
+first-party IT slice widens German-market coverage — a market we otherwise reach only indirectly.
+
+## What Changes
+
+- Add an `arbeitsagentur` source adapter that queries the search API
+  (`https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs`) with the static public
+  `X-API-Key: jobboerse-jobsuche` header, filtered by `berufsfeld` (the professional field, carried
+  as the board file entry's `board`), paginating `size=100&page=N` until the result set or the
+  API's `page*size ≈ 10 000` depth cap is reached.
+- **First-party only.** ~92% of keyword hits and a large share of `berufsfeld` hits carry an
+  `externeUrl` — arbeitsagentur re-lists postings that live on other boards. The adapter SHALL drop
+  every posting that carries an `externeUrl`, keeping only the agency's own first-party postings
+  (no external destination), which are the non-redundant value and far less likely to duplicate our
+  existing ATS/board sources.
+- **Description via the SSR detail page.** The search response carries no description and the detail
+  API returns 403, but the public `https://www.arbeitsagentur.de/jobsuche/jobdetail/<refnr>` page is
+  server-rendered and carries the `Stellenbeschreibung`. The adapter fetches that page per kept
+  posting (reusing the shared `fetchDetails` pool) and extracts the description; the same URL is the
+  posting's canonical/apply URL.
+- Map each kept posting to a normalized `Job`: `refnr` → `ExternalID`, `titel` → title, `arbeitgeber`
+  → company, `arbeitsort` (`ort`, `region`, `land`) → location, `aktuelleVeroeffentlichungsdatum` →
+  posted-at, the jobdetail page → URL and description. Bound per-run work with `veroeffentlichtseit`
+  (published-within-N-days) so each crawl is a fresh, incremental window rather than the full backlog.
+- The key is a public constant (not a secret), so `arbeitsagentur` registers unconditionally in
+  `sources.All` — unlike the env-keyed USAJobs/Reed.
+- Add `sources/arbeitsagentur.yml` with one entry per IT `berufsfeld` (`Informatik`,
+  `Softwareentwicklung und Programmierung`, `IT-Netzwerktechnik, -Administration, -Organisation`,
+  `IT-Systemanalyse, -Anwendungsberatung und -Vertrieb`); overlap across fields collapses on the
+  `refnr` dedup key.
+
+## Capabilities
+
+### New Capabilities
+- `arbeitsagentur-source`: the `arbeitsagentur` adapter — its keyed `berufsfeld` search + pagination,
+  first-party (`externeUrl`-drop) filter, SSR jobdetail description fetch, posting→`Job` mapping, and
+  board-as-`berufsfeld` classification.
+
+### Modified Capabilities
+<!-- None. Multi-company board-based adapter; inherits the standard ingest sweep, dedup, and
+     board-health machinery unchanged. No spec-level behavior of an existing capability changes. -->
+
+## Impact
+
+- **New code:** `internal/sources/arbeitsagentur.go` (+ `_test.go`); `sources/arbeitsagentur.yml`.
+- **Touched code:** one line in `sources.All` (registry).
+- **Ops:** a new `cmd/ingest sources/arbeitsagentur.yml` cron schedule (deploy-time, in freehire-ops).
+- **Language:** postings are German; skill tags (Python/AWS…) survive but seniority/category
+  classification (EN+RU-tuned) will be sparse. Accepted.
+- **No migrations, no API changes, no new dependencies, no secret key (public static key).**

--- a/openspec/changes/add-arbeitsagentur-source/specs/arbeitsagentur-source/spec.md
+++ b/openspec/changes/add-arbeitsagentur-source/specs/arbeitsagentur-source/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Arbeitsagentur enumerates postings by professional field
+
+The system SHALL provide an `arbeitsagentur` source adapter that queries the Bundesagentur für
+Arbeit search API at `https://rest.arbeitsagentur.de/jobboerse/jobsuche-service/pc/v4/jobs`,
+attaching the static public `X-API-Key: jobboerse-jobsuche` header. The adapter SHALL filter by the
+`berufsfeld` professional-field value carried as the board file entry's `board`, and SHALL paginate
+(`size=100`, `page=1..N`) until a page returns fewer than `size` postings, the cumulative count
+reaches `maxErgebnisse`, or the API's pagination depth cap is reached. A run SHALL bound its window
+with a `veroeffentlichtseit` (published-within-N-days) filter so each crawl is an incremental window.
+
+The adapter is board-based (the `board` is the `berufsfeld`) and multi-company (each posting's
+company is its `arbeitgeber`); it carries neither the boardless nor the aggregator marker. The public
+key is a constant, so the provider registers unconditionally.
+
+#### Scenario: A berufsfeld board is paginated
+
+- **WHEN** the adapter crawls a board whose `board` is a `berufsfeld` value
+- **THEN** it requests the search API with that `berufsfeld` and the `X-API-Key` header, advancing
+  `page` until the results are exhausted or the depth cap is reached
+
+### Requirement: Arbeitsagentur keeps only first-party postings
+
+The adapter SHALL drop every search result that carries a non-empty `externeUrl` — those postings are
+re-listed from other boards and apply off-site — and keep only the agency's own first-party postings.
+
+#### Scenario: An externeUrl re-list is dropped
+
+- **WHEN** a search result carries a non-empty `externeUrl`
+- **THEN** the adapter yields no `Job` for it and continues with the remaining results
+
+### Requirement: Arbeitsagentur maps a first-party posting to a Job with a scraped description
+
+For each kept posting the adapter SHALL fetch the server-rendered detail page
+`https://www.arbeitsagentur.de/jobsuche/jobdetail/<refnr>` and map the posting to a normalized `Job`
+carrying `refnr` as its `ExternalID`, the detail page URL as its canonical URL, `titel` as its title,
+`arbeitgeber` as its company, the `arbeitsort` (`ort`, `region`, `land`) as its location,
+`aktuelleVeroeffentlichungsdatum` as its posted-at, and the detail page's `Stellenbeschreibung` (or,
+when that block is absent, the page's meta-description summary) as its sanitized description.
+
+A detail-page fetch that fails or yields no description SHALL NOT drop the posting — it is emitted with
+an empty description — and a single failed page SHALL NOT abort the crawl.
+
+#### Scenario: A first-party posting maps to a job
+
+- **WHEN** the adapter keeps a first-party posting and fetches its detail page
+- **THEN** it yields one `Job` with `ExternalID` set to `refnr`, the jobdetail page as the URL, the
+  title, company `arbeitgeber`, the `arbeitsort` location, the publish date, and the scraped
+  `Stellenbeschreibung` as the description
+
+#### Scenario: A posting whose detail page yields no description is still emitted
+
+- **WHEN** a kept posting's detail page fetch fails or carries no description block
+- **THEN** the adapter still yields the `Job` (with an empty description) and continues the crawl

--- a/openspec/changes/add-arbeitsagentur-source/tasks.md
+++ b/openspec/changes/add-arbeitsagentur-source/tasks.md
@@ -1,0 +1,47 @@
+## 1. Search mapping & first-party filter
+
+- [ ] 1.1 Add `internal/sources/arbeitsagentur_test.go` with an inline search-response fixture (real
+  shape: `stellenangebote` with `refnr`, `titel`, `arbeitgeber`, `arbeitsort{ort,region,land}`,
+  `aktuelleVeroeffentlichungsdatum`, some with `externeUrl`) and a RED test asserting that a fake
+  search+detail client yields a `Job` per first-party posting with the mapped fields, and that
+  `externeUrl` postings are dropped.
+- [ ] 1.2 Create `internal/sources/arbeitsagentur.go`: the `arbeitsagentur` struct over a client
+  interface combining `GetJSONWithHeaders` (search) and `GetHTML` (detail), the `arbeitsagenturJob`
+  search-result struct, the `X-API-Key` constant, the `berufsfeld`/`veroeffentlichtseit`/`size`/`page`
+  query builder, and a `toJob` mapper (refnr→ExternalID, jobdetail URL, titel, arbeitgeber, arbeitsort
+  location, publish date) that drops `externeUrl` postings. Make 1.1 green.
+
+## 2. Detail-page description
+
+- [ ] 2.1 RED test: given a saved real jobdetail HTML fixture under `testdata/`, the adapter extracts
+  the `Stellenbeschreibung` (meta-description fallback) into the sanitized `Job.Description`; a detail
+  fetch error or a page with no description yields the `Job` with an empty description without aborting.
+- [ ] 2.2 Implement the detail fetch via `fetchDetails(kept, defaultDetailWorkers, ...)` over
+  `GetHTML(jobdetailURL)` and the description extractor. Make 2.1 green.
+
+## 3. Pagination
+
+- [ ] 3.1 RED test: a fake search client returning two full pages then a short page is paginated until
+  exhausted (assert the exact set of requested `page` values and the total kept jobs); the depth cap is
+  respected.
+- [ ] 3.2 Implement the `page=1..N` loop (stop on short page / `maxErgebnisse` / depth cap). Make 3.1 green.
+
+## 4. Classification & registration
+
+- [ ] 4.1 Add `Provider()` returning `"arbeitsagentur"` (no boardless/aggregator marker); register
+  `arbeitsagentur` in `sources.All` unconditionally (public constant key). Test the provider resolves
+  from `All(nil)` and is in `FilterableProviders()`. Verify `go build ./... && go vet ./...`.
+
+## 5. Board file & docs
+
+- [ ] 5.1 Add `sources/arbeitsagentur.yml` with one entry per IT `berufsfeld` (`Informatik`,
+  `Softwareentwicklung und Programmierung`, `IT-Netzwerktechnik, -Administration, -Organisation`,
+  `IT-Systemanalyse, -Anwendungsberatung und -Vertrieb`), `board` = the field label; confirm
+  `go run ./cmd/ingest sources/arbeitsagentur.yml` validates against the registry (fail-fast passes).
+- [ ] 5.2 Note the new adapter in `internal/sources/AGENTS.md` only if it enumerates adapters by class.
+
+## 6. Verify end-to-end
+
+- [ ] 6.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl against
+  the real API for one berufsfeld to confirm first-party postings map, descriptions scrape, and
+  externeUrl re-lists drop without error (not committed).

--- a/openspec/changes/add-arbeitsagentur-source/tasks.md
+++ b/openspec/changes/add-arbeitsagentur-source/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Search mapping & first-party filter
 
-- [ ] 1.1 Add `internal/sources/arbeitsagentur_test.go` with an inline search-response fixture (real
+- [x] 1.1 Add `internal/sources/arbeitsagentur_test.go` with an inline search-response fixture (real
   shape: `stellenangebote` with `refnr`, `titel`, `arbeitgeber`, `arbeitsort{ort,region,land}`,
   `aktuelleVeroeffentlichungsdatum`, some with `externeUrl`) and a RED test asserting that a fake
   search+detail client yields a `Job` per first-party posting with the mapped fields, and that
   `externeUrl` postings are dropped.
-- [ ] 1.2 Create `internal/sources/arbeitsagentur.go`: the `arbeitsagentur` struct over a client
+- [x] 1.2 Create `internal/sources/arbeitsagentur.go`: the `arbeitsagentur` struct over a client
   interface combining `GetJSONWithHeaders` (search) and `GetHTML` (detail), the `arbeitsagenturJob`
   search-result struct, the `X-API-Key` constant, the `berufsfeld`/`veroeffentlichtseit`/`size`/`page`
   query builder, and a `toJob` mapper (refnr→ExternalID, jobdetail URL, titel, arbeitgeber, arbeitsort
@@ -13,35 +13,35 @@
 
 ## 2. Detail-page description
 
-- [ ] 2.1 RED test: given a saved real jobdetail HTML fixture under `testdata/`, the adapter extracts
+- [x] 2.1 RED test: given a saved real jobdetail HTML fixture under `testdata/`, the adapter extracts
   the `Stellenbeschreibung` (meta-description fallback) into the sanitized `Job.Description`; a detail
   fetch error or a page with no description yields the `Job` with an empty description without aborting.
-- [ ] 2.2 Implement the detail fetch via `fetchDetails(kept, defaultDetailWorkers, ...)` over
+- [x] 2.2 Implement the detail fetch via `fetchDetails(kept, defaultDetailWorkers, ...)` over
   `GetHTML(jobdetailURL)` and the description extractor. Make 2.1 green.
 
 ## 3. Pagination
 
-- [ ] 3.1 RED test: a fake search client returning two full pages then a short page is paginated until
+- [x] 3.1 RED test: a fake search client returning two full pages then a short page is paginated until
   exhausted (assert the exact set of requested `page` values and the total kept jobs); the depth cap is
   respected.
-- [ ] 3.2 Implement the `page=1..N` loop (stop on short page / `maxErgebnisse` / depth cap). Make 3.1 green.
+- [x] 3.2 Implement the `page=1..N` loop (stop on short page / `maxErgebnisse` / depth cap). Make 3.1 green.
 
 ## 4. Classification & registration
 
-- [ ] 4.1 Add `Provider()` returning `"arbeitsagentur"` (no boardless/aggregator marker); register
+- [x] 4.1 Add `Provider()` returning `"arbeitsagentur"` (no boardless/aggregator marker); register
   `arbeitsagentur` in `sources.All` unconditionally (public constant key). Test the provider resolves
   from `All(nil)` and is in `FilterableProviders()`. Verify `go build ./... && go vet ./...`.
 
 ## 5. Board file & docs
 
-- [ ] 5.1 Add `sources/arbeitsagentur.yml` with one entry per IT `berufsfeld` (`Informatik`,
+- [x] 5.1 Add `sources/arbeitsagentur.yml` with one entry per IT `berufsfeld` (`Informatik`,
   `Softwareentwicklung und Programmierung`, `IT-Netzwerktechnik, -Administration, -Organisation`,
   `IT-Systemanalyse, -Anwendungsberatung und -Vertrieb`), `board` = the field label; confirm
   `go run ./cmd/ingest sources/arbeitsagentur.yml` validates against the registry (fail-fast passes).
-- [ ] 5.2 Note the new adapter in `internal/sources/AGENTS.md` only if it enumerates adapters by class.
+- [x] 5.2 No-op: `internal/sources/AGENTS.md` does not enumerate adapters by class.
 
 ## 6. Verify end-to-end
 
-- [ ] 6.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl against
+- [x] 6.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl against
   the real API for one berufsfeld to confirm first-party postings map, descriptions scrape, and
   externeUrl re-lists drop without error (not committed).

--- a/sources/arbeitsagentur.yml
+++ b/sources/arbeitsagentur.yml
@@ -1,0 +1,17 @@
+# Bundesagentur für Arbeit (Germany's federal employment agency) job board. Keyless search API
+# (jobsuche-service, public X-API-Key baked into the adapter); see internal/sources/arbeitsagentur.go.
+# board = the professional field (berufsfeld) passed as the search filter; company comes from each
+# posting. Only first-party postings are kept (externeUrl re-lists are dropped). Overlap across
+# fields collapses on the refnr dedup key. One entry per IT berufsfeld:
+- provider: arbeitsagentur
+  company: Bundesagentur für Arbeit
+  board: Informatik
+- provider: arbeitsagentur
+  company: Bundesagentur für Arbeit
+  board: Softwareentwicklung und Programmierung
+- provider: arbeitsagentur
+  company: Bundesagentur für Arbeit
+  board: IT-Netzwerktechnik, -Administration, -Organisation
+- provider: arbeitsagentur
+  company: Bundesagentur für Arbeit
+  board: IT-Systemanalyse, -Anwendungsberatung und -Vertrieb


### PR DESCRIPTION
## Summary
- Add an `arbeitsagentur` source adapter for the **Bundesagentur für Arbeit** (Germany's federal employment agency), the country's largest job board. Reached keyless via the public static `X-API-Key: jobboerse-jobsuche`.
- Two-stage: (1) JSON search `pc/v4/jobs?berufsfeld=<board>&size=100&page=N&veroeffentlichtseit=7`, paginated to the ~10k depth cap; (2) per kept posting, scrape the SSR `jobsuche/jobdetail/<refnr>` page's `ng-state` JSON for the `Stellenbeschreibung` (plain text → `plainTextToHTML`).
- **First-party only:** drops the ~90% of results carrying an `externeUrl` (re-lists of other boards); `berufsfeld` filtering (not keyword `was=`) keeps first-party share high.
- `board` = IT professional field; `sources/arbeitsagentur.yml` lists 4 IT berufsfelder (overlap collapses on the `refnr` dedup key). Registered unconditionally (public key).

Sourced from the ever-jobs provider catalogue (`source-arbeitsagentur`) — see companion PR #867 (jobspresso).

## Notes / tradeoffs
- Postings are German: skill tags survive, but seniority/category classification (EN+RU-tuned) will be sparse. Accepted.
- `veroeffentlichtseit=7` bounds each run to a fresh window (~700–1500 per field), well under the pagination cap.

## Test Plan
- [x] `go build ./... && go vet ./...` clean; `go test ./...` green (104 pkgs)
- [x] 5 new arbeitsagentur tests: search mapping + externeUrl drop, description scrape incl. detail-failure/no-desc still-emits, pagination page-set, registration, board-file validation
- [x] Live smoke (real client): search returns first-party (8/10, maxErgebnisse=709 for 7d window), ng-state yields real Stellenbeschreibung
- [ ] Deploy: add a `cmd/ingest sources/arbeitsagentur.yml` cron schedule in freehire-ops