### PR TITLE
feat(insights): public company hiring-signal leaderboard API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ cmd/liveness/main.go       URL-probes orphan jobs, closes dead ones
 cmd/reindex/main.go        rebuilds the Meilisearch jobs index
 cmd/rollup-stats/main.go   recomputes the job_daily_stats rollup
 cmd/rollup-facets/main.go  recomputes the insights_facet_stats snapshot (/open facets)
-cmd/rollup-company/main.go recomputes the insights_company_stats per-company hiring-signal rollup
+cmd/rollup-company/main.go recomputes insights_company_stats + insights_company_growth (per-company hiring-signal rollups; the latter backs GET /insights/companies)
 cmd/backfill-derive/main.go  re-derives all deterministic dictionary facets
 cmd/reslug/main.go         backfills public_slug/company_slug
 cmd/backfill-company-names/main.go  resolves real display names for slug-named companies
@@ -91,7 +91,7 @@ go run ./cmd/backfill-derive               # re-derive dictionary facets; follow
 go run ./cmd/backfill-company-names [--dry-run]  # resolve real names for slug-named companies; follow with make reindex
 go run ./cmd/rollup-stats                  # recompute job_daily_stats (run-once, cron ~every 3h)
 go run ./cmd/rollup-facets                 # + MEILI_URL/MEILI_MASTER_KEY — recompute insights_facet_stats (run-once, cron ~daily)
-go run ./cmd/rollup-company                 # recompute insights_company_stats per-company hiring-signal rollup (run-once, cron ~daily)
+go run ./cmd/rollup-company                 # recompute insights_company_stats + insights_company_growth (run-once, cron ~daily)
 ```
 
 For the full architecture and conventions, see the **module files** below. Each module is self-contained and can be read independently.

--- a/cmd/rollup-company/main.go
+++ b/cmd/rollup-company/main.go
@@ -4,8 +4,10 @@
 //
 // insights_company_stats holds one row per (company_slug, day) for each of a company's
 // activity days, with that day's `added`/`removed` and a running `open` count, derived
-// solely from jobs.created_at/closed_at (closed jobs are retained). It is the company-
-// grained sibling of the insights_* rollups and the foundation for a company hiring
+// solely from jobs.created_at/closed_at (closed jobs are retained). insights_company_growth
+// holds one scalar row per company (open_count now + open_count as of the growth window
+// ago) that backs the ranked /api/v1/insights/companies leaderboard. Both are the company-
+// grained siblings of the insights_* rollups and the foundation for a company hiring
 // signal (who is ramping vs. freezing).
 //
 // It is a run-once-and-exit worker (cron-scheduled, ~daily given the company grain):
@@ -19,10 +21,17 @@ package main
 import (
 	"context"
 	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/worker"
 )
+
+// growthWindowDays is how far back insights_company_growth's prior-window open-count
+// looks, so growth = open_count - open_count_prev. Matches cmd/rollup-stats.
+const growthWindowDays = 30
 
 func main() {
 	worker.Main(run)
@@ -65,11 +74,24 @@ func run() int {
 		return 1
 	}
 
+	// The scalar growth table (backs the ranked leaderboard) is rebuilt in the SAME
+	// transaction so it never diverges from the per-day rollup.
+	prevTs := pgtype.Timestamptz{Time: time.Now().UTC().AddDate(0, 0, -growthWindowDays), Valid: true}
+	if err := q.DeleteAllInsightsCompanyGrowth(ctx); err != nil {
+		log.Printf("clear growth: %v", err)
+		return 1
+	}
+	companies, err := q.RebuildInsightsCompanyGrowth(ctx, prevTs)
+	if err != nil {
+		log.Printf("rebuild growth: %v", err)
+		return 1
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		log.Printf("commit: %v", err)
 		return 1
 	}
 
-	log.Printf("rollup-company: rebuilt insights_company_stats (%d company-day rows)", rows)
+	log.Printf("rollup-company: rebuilt insights_company_stats (%d company-day rows) + insights_company_growth (%d companies)", rows, companies)
 	return 0
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -1835,6 +1835,38 @@ curl "https://freehire.dev/api/v1/insights/salary?category=backend"
 }
 ```
 
+### `GET /insights/companies`
+
+**Auth:** Public
+
+The company hiring-signal leaderboard: companies ranked by how their number of open jobs has changed over the last 30 days (`growth_30d = open_now − open_prev_30d`), so you can see who is ramping up or freezing hiring. Served from a precomputed per-company rollup. Aggregate-only — no record-level job fields.
+
+`min_open` floors the current open-count (default `5`) so a company whose whole board just appeared or vanished in ingest doesn't dominate the ranking.
+
+**Query parameters**
+
+| Name | Type | Required | Description |
+| --- | --- | --- | --- |
+| `sort` | string | no | `growth` (default, ramping first), `-growth` (freezing first), or `open` (largest first). |
+| `min_open` | integer | no | Minimum current open-job count; default `5`. |
+| `limit` | integer | no | Result cap; default `20`, max `200`. |
+
+```bash
+# Companies ramping up hiring the fastest:
+curl "https://freehire.dev/api/v1/insights/companies?sort=growth"
+# Companies pulling back:
+curl "https://freehire.dev/api/v1/insights/companies?sort=-growth&min_open=10"
+```
+
+```json
+{
+  "data": [
+    { "company_slug": "acme", "company_name": "Acme", "open_now": 42, "open_prev_30d": 18, "growth_30d": 24 }
+  ],
+  "meta": { "sort": "growth", "min_open": 5, "limit": 20 }
+}
+```
+
 ## Activity & shared boards
 
 Two public reads — the catalogue-activity time series and a shared saved-search “board” by slug — plus the session-only publish/unpublish actions that turn one of your saved searches into such a board. A published board exposes no owner identity.

--- a/internal/db/insights.sql.go
+++ b/internal/db/insights.sql.go
@@ -11,6 +11,19 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllInsightsCompanyGrowth = `-- name: DeleteAllInsightsCompanyGrowth :exec
+
+DELETE FROM insights_company_growth
+`
+
+// ---------------------------------------------------------------------------
+// Per-company open/growth scalar (backs the /insights/companies leaderboard)
+// ---------------------------------------------------------------------------
+func (q *Queries) DeleteAllInsightsCompanyGrowth(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllInsightsCompanyGrowth)
+	return err
+}
+
 const deleteAllInsightsCompanyStats = `-- name: DeleteAllInsightsCompanyStats :exec
 
 DELETE FROM insights_company_stats
@@ -80,6 +93,70 @@ DELETE FROM insights_velocity_daily
 func (q *Queries) DeleteAllInsightsVelocityDaily(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, deleteAllInsightsVelocityDaily)
 	return err
+}
+
+const listInsightsCompanies = `-- name: ListInsightsCompanies :many
+SELECT
+    g.company_slug,
+    coalesce(c.name, g.company_slug) AS company_name,
+    g.open_count,
+    g.open_count_prev,
+    (g.open_count - g.open_count_prev)::int AS growth
+FROM insights_company_growth g
+LEFT JOIN companies c ON c.slug = g.company_slug
+WHERE g.open_count >= $1::int
+ORDER BY
+    (CASE
+        WHEN $2::text = 'open'     THEN g.open_count
+        WHEN $2::text = '-growth'  THEN -(g.open_count - g.open_count_prev)
+        ELSE (g.open_count - g.open_count_prev)
+    END) DESC,
+    g.open_count DESC
+LIMIT $3::int
+`
+
+type ListInsightsCompaniesParams struct {
+	MinOpen int32  `json:"min_open"`
+	Sort    string `json:"sort"`
+	Lim     int32  `json:"lim"`
+}
+
+type ListInsightsCompaniesRow struct {
+	CompanySlug   string `json:"company_slug"`
+	CompanyName   string `json:"company_name"`
+	OpenCount     int32  `json:"open_count"`
+	OpenCountPrev int32  `json:"open_count_prev"`
+	Growth        int32  `json:"growth"`
+}
+
+// The leaderboard read: companies ranked by growth (open_count - open_count_prev),
+// '-growth' (freezing) reverses it, 'open' ranks by raw size; open_count is the
+// tiebreak. @min_open floors the current open-count (blunts ingest-artifact spikes).
+// company_name falls back to the slug when no companies row exists.
+func (q *Queries) ListInsightsCompanies(ctx context.Context, arg ListInsightsCompaniesParams) ([]ListInsightsCompaniesRow, error) {
+	rows, err := q.db.Query(ctx, listInsightsCompanies, arg.MinOpen, arg.Sort, arg.Lim)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListInsightsCompaniesRow{}
+	for rows.Next() {
+		var i ListInsightsCompaniesRow
+		if err := rows.Scan(
+			&i.CompanySlug,
+			&i.CompanyName,
+			&i.OpenCount,
+			&i.OpenCountPrev,
+			&i.Growth,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listInsightsRoles = `-- name: ListInsightsRoles :many
@@ -351,6 +428,32 @@ func (q *Queries) ListInsightsVelocity(ctx context.Context, arg ListInsightsVelo
 		return nil, err
 	}
 	return items, nil
+}
+
+const rebuildInsightsCompanyGrowth = `-- name: RebuildInsightsCompanyGrowth :execrows
+INSERT INTO insights_company_growth (company_slug, open_count, open_count_prev)
+SELECT
+    company_slug,
+    count(*) FILTER (WHERE closed_at IS NULL)::int AS open_count,
+    count(*) FILTER (WHERE created_at <= $1 AND (closed_at IS NULL OR closed_at > $1))::int AS open_count_prev
+FROM jobs
+WHERE company_slug <> '' AND duplicate_of IS NULL
+GROUP BY company_slug
+HAVING count(*) FILTER (WHERE closed_at IS NULL) > 0
+    OR count(*) FILTER (WHERE created_at <= $1 AND (closed_at IS NULL OR closed_at > $1)) > 0
+`
+
+// One row per company with its current open-count and the open-count as of @prev_ts,
+// from a single scan of jobs over canonical rows only (same count(*) FILTER idiom as
+// insights_role_stats). open_count uses closed_at IS NULL (open now); open_count_prev
+// uses open-as-of @prev_ts. Companies open at neither point are dropped (HAVING) to
+// keep the table lean.
+func (q *Queries) RebuildInsightsCompanyGrowth(ctx context.Context, prevTs pgtype.Timestamptz) (int64, error) {
+	result, err := q.db.Exec(ctx, rebuildInsightsCompanyGrowth, prevTs)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const rebuildInsightsCompanyStats = `-- name: RebuildInsightsCompanyStats :execrows

--- a/internal/db/insights_company_growth_integration_test.go
+++ b/internal/db/insights_company_growth_integration_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+// Integration test for the per-company open/growth scalar (insights_company_growth)
+// that backs the /insights/companies leaderboard. The recompute is SQL, so it is only
+// verifiable against a real Postgres. Run with: go test -tags=integration ./internal/db/
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+// companyGrowthRow mirrors an insights_company_growth row for assertions.
+type companyGrowthRow struct {
+	openCount     int
+	openCountPrev int
+}
+
+func companyGrowth(t *testing.T, ctx context.Context, q *Queries, slug string) (companyGrowthRow, bool) {
+	t.Helper()
+	// Read straight from the table by slug; a missing row means the company was
+	// filtered out entirely.
+	rows, err := q.db.Query(ctx,
+		`SELECT open_count, open_count_prev FROM insights_company_growth WHERE company_slug = $1`, slug)
+	if err != nil {
+		t.Fatalf("query company growth: %v", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		return companyGrowthRow{}, false
+	}
+	var r companyGrowthRow
+	if err := rows.Scan(&r.openCount, &r.openCountPrev); err != nil {
+		t.Fatalf("scan company growth: %v", err)
+	}
+	return r, true
+}
+
+func TestInsightsCompanyGrowthScalar(t *testing.T) {
+	pool := startPostgres(t)
+	q := New(pool)
+	ctx := context.Background()
+	truncate(t, pool)
+
+	// acme (ramping): a1 open from 40d ago, a2 open from 3d ago → open now 2, open a
+	// window ago 1 (a2 too new). A duplicate copy must not inflate the count.
+	a1 := seedCompanyJob(t, pool, "a1", "acme", 40, nil, nil)
+	seedCompanyJob(t, pool, "a2", "acme", 3, nil, nil)
+	seedCompanyJob(t, pool, "adup", "acme", 10, nil, &a1) // duplicate → excluded
+
+	// beta (freezing): b1 still open from 60d ago, b2 opened 60d ago but closed 2d ago
+	// → open now 1, open a window ago 2 (b2 closed after the window start).
+	closed2 := 2
+	seedCompanyJob(t, pool, "b1", "beta", 60, nil, nil)
+	seedCompanyJob(t, pool, "b2", "beta", 60, &closed2, nil)
+
+	// company-less job → excluded.
+	seedCompanyJob(t, pool, "e1", "", 8, nil, nil)
+
+	if err := q.DeleteAllInsightsCompanyGrowth(ctx); err != nil {
+		t.Fatalf("delete growth: %v", err)
+	}
+	if _, err := q.RebuildInsightsCompanyGrowth(ctx, windowStart()); err != nil {
+		t.Fatalf("rebuild growth: %v", err)
+	}
+
+	acme, ok := companyGrowth(t, ctx, q, "acme")
+	if !ok || acme.openCount != 2 || acme.openCountPrev != 1 {
+		t.Errorf("acme growth = %+v (present=%v), want open_count=2 open_count_prev=1 (dup excluded)", acme, ok)
+	}
+	beta, ok := companyGrowth(t, ctx, q, "beta")
+	if !ok || beta.openCount != 1 || beta.openCountPrev != 2 {
+		t.Errorf("beta growth = %+v (present=%v), want open_count=1 open_count_prev=2", beta, ok)
+	}
+	if _, ok := companyGrowth(t, ctx, q, ""); ok {
+		t.Errorf("empty-slug company should have no growth row")
+	}
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -131,6 +131,12 @@ type GmailConnection struct {
 	LastSyncedAt    pgtype.Timestamptz `json:"last_synced_at"`
 }
 
+type InsightsCompanyGrowth struct {
+	CompanySlug   string `json:"company_slug"`
+	OpenCount     int32  `json:"open_count"`
+	OpenCountPrev int32  `json:"open_count_prev"`
+}
+
 type InsightsCompanyStat struct {
 	CompanySlug string      `json:"company_slug"`
 	Day         pgtype.Date `json:"day"`

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -219,6 +219,10 @@ type Querier interface {
 	// as the InsertFacetStat loop so a reader never sees an empty or partial table.
 	DeleteAllFacetStats(ctx context.Context) error
 	// ---------------------------------------------------------------------------
+	// Per-company open/growth scalar (backs the /insights/companies leaderboard)
+	// ---------------------------------------------------------------------------
+	DeleteAllInsightsCompanyGrowth(ctx context.Context) error
+	// ---------------------------------------------------------------------------
 	// Per-company hiring signal
 	// ---------------------------------------------------------------------------
 	DeleteAllInsightsCompanyStats(ctx context.Context) error
@@ -540,6 +544,11 @@ type Querier interface {
 	// top-N per facet without re-sorting. Aggregate only — per-value counts, no
 	// record-level data.
 	ListFacetStats(ctx context.Context) ([]InsightsFacetStat, error)
+	// The leaderboard read: companies ranked by growth (open_count - open_count_prev),
+	// '-growth' (freezing) reverses it, 'open' ranks by raw size; open_count is the
+	// tiebreak. @min_open floors the current open-count (blunts ingest-artifact spikes).
+	// company_name falls back to the slug when no companies row exists.
+	ListInsightsCompanies(ctx context.Context, arg ListInsightsCompaniesParams) ([]ListInsightsCompaniesRow, error)
 	// Ranked roles within one country slice ('' = all countries), ordered by raw
 	// demand or by growth (open_count - open_count_prev), demand as the tiebreak.
 	// An empty @category means all categories (the original behavior); a non-empty
@@ -748,6 +757,12 @@ type Querier interface {
 	// coalesced/cast to bigint so it reads as a plain int64 (an all-failing provider
 	// yields 0, not NULL).
 	ProviderHealthRollup(ctx context.Context) ([]ProviderHealthRollupRow, error)
+	// One row per company with its current open-count and the open-count as of @prev_ts,
+	// from a single scan of jobs over canonical rows only (same count(*) FILTER idiom as
+	// insights_role_stats). open_count uses closed_at IS NULL (open now); open_count_prev
+	// uses open-as-of @prev_ts. Companies open at neither point are dropped (HAVING) to
+	// keep the table lean.
+	RebuildInsightsCompanyGrowth(ctx context.Context, prevTs pgtype.Timestamptz) (int64, error)
 	// Per-(company, day) hiring velocity with a running open count, from the retained
 	// jobs lifecycle. Each canonical, attributable job (company_slug <> '' AND
 	// duplicate_of IS NULL) emits an added event on its created_at (UTC) day and, if

--- a/internal/db/queries/insights.sql
+++ b/internal/db/queries/insights.sql
@@ -320,3 +320,50 @@ FROM (
     WHERE j.company_slug <> '' AND j.duplicate_of IS NULL
     GROUP BY j.company_slug, day
 ) daily;
+
+-- ---------------------------------------------------------------------------
+-- Per-company open/growth scalar (backs the /insights/companies leaderboard)
+-- ---------------------------------------------------------------------------
+
+-- name: DeleteAllInsightsCompanyGrowth :exec
+DELETE FROM insights_company_growth;
+
+-- name: RebuildInsightsCompanyGrowth :execrows
+-- One row per company with its current open-count and the open-count as of @prev_ts,
+-- from a single scan of jobs over canonical rows only (same count(*) FILTER idiom as
+-- insights_role_stats). open_count uses closed_at IS NULL (open now); open_count_prev
+-- uses open-as-of @prev_ts. Companies open at neither point are dropped (HAVING) to
+-- keep the table lean.
+INSERT INTO insights_company_growth (company_slug, open_count, open_count_prev)
+SELECT
+    company_slug,
+    count(*) FILTER (WHERE closed_at IS NULL)::int AS open_count,
+    count(*) FILTER (WHERE created_at <= sqlc.arg('prev_ts') AND (closed_at IS NULL OR closed_at > sqlc.arg('prev_ts')))::int AS open_count_prev
+FROM jobs
+WHERE company_slug <> '' AND duplicate_of IS NULL
+GROUP BY company_slug
+HAVING count(*) FILTER (WHERE closed_at IS NULL) > 0
+    OR count(*) FILTER (WHERE created_at <= sqlc.arg('prev_ts') AND (closed_at IS NULL OR closed_at > sqlc.arg('prev_ts'))) > 0;
+
+-- name: ListInsightsCompanies :many
+-- The leaderboard read: companies ranked by growth (open_count - open_count_prev),
+-- '-growth' (freezing) reverses it, 'open' ranks by raw size; open_count is the
+-- tiebreak. @min_open floors the current open-count (blunts ingest-artifact spikes).
+-- company_name falls back to the slug when no companies row exists.
+SELECT
+    g.company_slug,
+    coalesce(c.name, g.company_slug) AS company_name,
+    g.open_count,
+    g.open_count_prev,
+    (g.open_count - g.open_count_prev)::int AS growth
+FROM insights_company_growth g
+LEFT JOIN companies c ON c.slug = g.company_slug
+WHERE g.open_count >= sqlc.arg('min_open')::int
+ORDER BY
+    (CASE
+        WHEN sqlc.arg('sort')::text = 'open'     THEN g.open_count
+        WHEN sqlc.arg('sort')::text = '-growth'  THEN -(g.open_count - g.open_count_prev)
+        ELSE (g.open_count - g.open_count_prev)
+    END) DESC,
+    g.open_count DESC
+LIMIT sqlc.arg('lim')::int;

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -344,6 +344,7 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/insights/skills", a.InsightsSkills)
 	api.Get("/insights/velocity", a.InsightsVelocity)
 	api.Get("/insights/salary", a.InsightsSalary)
+	api.Get("/insights/companies", a.InsightsCompanies)
 
 	// Public ingest-fleet status, unauthenticated like the other public reads.
 	// A per-provider health rollup over board_health, sanitized (no error text or

--- a/internal/handler/insights.go
+++ b/internal/handler/insights.go
@@ -25,7 +25,20 @@ import (
 const (
 	insightsDefaultLimit = 20
 	insightsMaxLimit     = 200
+	// companiesDefaultMinOpen floors the leaderboard's current open-count by default,
+	// so a company whose whole board just appeared/vanished (an ingest artifact) does
+	// not dominate the ranking. Callers can override with min_open.
+	companiesDefaultMinOpen = 5
 )
+
+// companyInsight is one ranked company on the hiring-signal leaderboard.
+type companyInsight struct {
+	CompanySlug string `json:"company_slug"`
+	CompanyName string `json:"company_name"`
+	OpenNow     int32  `json:"open_now"`
+	OpenPrev30d int32  `json:"open_prev_30d"`
+	Growth30d   int32  `json:"growth_30d"`
+}
 
 // roleInsight is one ranked role on the wire.
 type roleInsight struct {
@@ -78,6 +91,35 @@ func parseInsightsLimit(s string) (int32, error) {
 	}
 	if n > insightsMaxLimit {
 		return 0, fmt.Errorf("limit %d exceeds max %d", n, insightsMaxLimit)
+	}
+	return int32(n), nil
+}
+
+// parseCompaniesSort resolves the leaderboard order: "growth" (default) ranks by the
+// window delta descending (ramping first), "-growth" ascending (freezing first),
+// "open" by raw open-count. Anything else is a 400.
+func parseCompaniesSort(s string) (string, error) {
+	switch s {
+	case "", "growth":
+		return "growth", nil
+	case "-growth":
+		return "-growth", nil
+	case "open":
+		return "open", nil
+	default:
+		return "", fmt.Errorf("unknown sort %q (want growth, -growth or open)", s)
+	}
+}
+
+// parseMinOpen resolves the current-open-count floor: empty → companiesDefaultMinOpen,
+// else a non-negative integer.
+func parseMinOpen(s string) (int32, error) {
+	if s == "" {
+		return companiesDefaultMinOpen, nil
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("invalid min_open %q (want a non-negative integer)", s)
 	}
 	return int32(n), nil
 }
@@ -188,6 +230,43 @@ func (a *API) InsightsRoles(c *fiber.Ctx) error {
 	return c.JSON(fiber.Map{
 		"data": data,
 		"meta": fiber.Map{"country": country, "category": category, "sort": sort, "limit": limit},
+	})
+}
+
+// InsightsCompanies serves GET /api/v1/insights/companies: the hiring-signal
+// leaderboard — companies ranked by 30-day growth (ramping/freezing) or open-count,
+// from the precomputed insights_company_growth scalar. Aggregate-only.
+func (a *API) InsightsCompanies(c *fiber.Ctx) error {
+	sort, err := parseCompaniesSort(c.Query("sort"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	minOpen, err := parseMinOpen(c.Query("min_open"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+	limit, err := parseInsightsLimit(c.Query("limit"))
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, err.Error())
+	}
+
+	rows, err := a.queries.ListInsightsCompanies(c.Context(), db.ListInsightsCompaniesParams{MinOpen: minOpen, Sort: sort, Lim: limit})
+	if err != nil {
+		return err
+	}
+	data := make([]companyInsight, len(rows))
+	for i, r := range rows {
+		data[i] = companyInsight{
+			CompanySlug: r.CompanySlug,
+			CompanyName: r.CompanyName,
+			OpenNow:     r.OpenCount,
+			OpenPrev30d: r.OpenCountPrev,
+			Growth30d:   r.Growth,
+		}
+	}
+	return c.JSON(fiber.Map{
+		"data": data,
+		"meta": fiber.Map{"sort": sort, "min_open": minOpen, "limit": limit},
 	})
 }
 

--- a/internal/handler/insights_companies_integration_test.go
+++ b/internal/handler/insights_companies_integration_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+// Integration test for the public company hiring-signal leaderboard endpoint
+// (GET /api/v1/insights/companies). It seeds companies with known ramping/freezing
+// shapes, rebuilds the growth scalar, and asserts ordering, the min_open filter, the
+// display-name join, and input validation. Run with: go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestInsightsCompaniesEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	q := db.New(pool)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, "TRUNCATE jobs, companies RESTART IDENTITY CASCADE"); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	// ramp: 5 open jobs opened 3d ago → open_now 5, open 30d ago 0, growth +5.
+	// freeze: 6 opened 60d ago, 4 closed 2d ago → open_now 2, open 30d ago 6, growth -4.
+	// small: 1 open job (open_now 1) — excluded by min_open>=2.
+	mustExec := func(sql string) {
+		if _, err := pool.Exec(ctx, sql); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	mustExec(`INSERT INTO companies (slug, name) VALUES ('ramp','Ramp Inc'),('freeze','Freeze Co'),('small','Small LLC')`)
+	mustExec(`INSERT INTO jobs (source,external_id,url,title,public_slug,company_slug,created_at)
+	          SELECT 'test','rp-'||g,'http://x','J','rp-'||g,'ramp', now()-interval '3 days' FROM generate_series(1,5) g`)
+	mustExec(`INSERT INTO jobs (source,external_id,url,title,public_slug,company_slug,created_at)
+	          SELECT 'test','fz-o-'||g,'http://x','J','fz-o-'||g,'freeze', now()-interval '60 days' FROM generate_series(1,2) g`)
+	mustExec(`INSERT INTO jobs (source,external_id,url,title,public_slug,company_slug,created_at,closed_at)
+	          SELECT 'test','fz-c-'||g,'http://x','J','fz-c-'||g,'freeze', now()-interval '60 days', now()-interval '2 days' FROM generate_series(1,4) g`)
+	mustExec(`INSERT INTO jobs (source,external_id,url,title,public_slug,company_slug,created_at)
+	          VALUES ('test','sm-1','http://x','J','sm-1','small', now()-interval '3 days')`)
+
+	prev := pgtype.Timestamptz{Time: time.Now().UTC().AddDate(0, 0, -30), Valid: true}
+	if err := q.DeleteAllInsightsCompanyGrowth(ctx); err != nil {
+		t.Fatalf("delete growth: %v", err)
+	}
+	if _, err := q.RebuildInsightsCompanyGrowth(ctx, prev); err != nil {
+		t.Fatalf("rebuild growth: %v", err)
+	}
+
+	h := &API{pool: pool, queries: q}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/insights/companies", h.InsightsCompanies)
+
+	get := func(path string) (map[string]any, int) {
+		resp, err := app.Test(httptest.NewRequest(fiber.MethodGet, path, nil))
+		if err != nil {
+			t.Fatalf("request %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		raw, _ := io.ReadAll(resp.Body)
+		var out map[string]any
+		if resp.StatusCode == fiber.StatusOK {
+			if err := json.Unmarshal(raw, &out); err != nil {
+				t.Fatalf("decode %s: %v (%s)", path, err, raw)
+			}
+		}
+		return out, resp.StatusCode
+	}
+
+	rowsOf := func(out map[string]any) []map[string]any {
+		data, _ := out["data"].([]any)
+		res := make([]map[string]any, len(data))
+		for i, r := range data {
+			res[i], _ = r.(map[string]any)
+		}
+		return res
+	}
+
+	// sort=growth, min_open=2 → ramp (+5) before freeze (-4); small excluded.
+	out, code := get("/api/v1/insights/companies?sort=growth&min_open=2")
+	if code != fiber.StatusOK {
+		t.Fatalf("growth: code %d", code)
+	}
+	rows := rowsOf(out)
+	if len(rows) != 2 {
+		t.Fatalf("growth rows = %d, want 2 (small filtered)", len(rows))
+	}
+	if rows[0]["company_slug"] != "ramp" || rows[0]["company_name"] != "Ramp Inc" {
+		t.Errorf("top = %v/%v, want ramp/Ramp Inc", rows[0]["company_slug"], rows[0]["company_name"])
+	}
+	if rows[0]["open_now"].(float64) != 5 || rows[0]["open_prev_30d"].(float64) != 0 || rows[0]["growth_30d"].(float64) != 5 {
+		t.Errorf("ramp row = %+v, want open_now=5 open_prev_30d=0 growth_30d=5", rows[0])
+	}
+	if rows[1]["company_slug"] != "freeze" {
+		t.Errorf("second = %v, want freeze", rows[1]["company_slug"])
+	}
+
+	// sort=-growth → freeze (largest decline) first.
+	out, _ = get("/api/v1/insights/companies?sort=-growth&min_open=2")
+	rows = rowsOf(out)
+	if rows[0]["company_slug"] != "freeze" || rows[0]["growth_30d"].(float64) != -4 {
+		t.Errorf("freezing top = %+v, want freeze growth -4", rows[0])
+	}
+
+	// invalid sort → 400.
+	if _, code := get("/api/v1/insights/companies?sort=bogus"); code != fiber.StatusBadRequest {
+		t.Errorf("bogus sort code = %d, want 400", code)
+	}
+}

--- a/migrations/0030_insights_company_growth.sql
+++ b/migrations/0030_insights_company_growth.sql
@@ -1,0 +1,29 @@
+-- Per-company open/growth scalar backing the /api/v1/insights/companies leaderboard.
+-- The company-grained sibling of insights_role_stats (0022): one row per company with
+-- its current open-job count and the open count as of the growth window ago, so a
+-- ranked "who is ramping / freezing" read is a trivial ORDER BY … LIMIT rather than a
+-- per-request aggregate over the whole catalogue.
+--
+-- Like the other rollups it is a pure function of the current `jobs` table, rebuilt by
+-- cmd/rollup-company as an atomic delete-and-reinsert (never an upsert) inside the SAME
+-- transaction as insights_company_stats, so the two never diverge and a reader never
+-- sees a partially rebuilt table. open_count = open canonical jobs now; open_count_prev
+-- = open canonical jobs as of now − growth_window (growth = open_count − open_count_prev).
+-- Only canonical, attributable rows are counted (company_slug <> '' AND
+-- duplicate_of IS NULL), matching companies.job_count and insights_company_stats.
+--
+-- Applied to a fresh volume by initdb after 0029; on an existing prod volume this
+-- CREATE statement must be run manually BEFORE deploying code that reads it (per the
+-- migrations gotcha).
+
+CREATE TABLE public.insights_company_growth (
+    company_slug    text    NOT NULL PRIMARY KEY,
+    open_count      integer NOT NULL DEFAULT 0,
+    open_count_prev integer NOT NULL DEFAULT 0
+);
+
+-- The leaderboard's `open` sort and its `min_open` floor both key off open_count;
+-- this index serves that ranked read. The `growth` sort orders by
+-- (open_count - open_count_prev) and sorts the (one-row-per-company) table in memory.
+CREATE INDEX insights_company_growth_open_idx
+    ON public.insights_company_growth (open_count DESC);

--- a/openspec/changes/add-company-hiring-signal-api/.openspec.yaml
+++ b/openspec/changes/add-company-hiring-signal-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-company-hiring-signal-api/design.md
+++ b/openspec/changes/add-company-hiring-signal-api/design.md
@@ -1,0 +1,55 @@
+## Context
+
+The prior change shipped `insights_company_stats` (per-day velocity + running open) and the `cmd/rollup-company` worker, deployed on prod. This change adds the first read surface — a public leaderboard — following two existing patterns:
+
+- **`market-insights`** (`internal/handler/insights.go`): public `/insights/*` endpoints, `{"data":[...],"meta":{...}}` envelope, `parseInsightsSort`/`parseInsightsLimit` helpers, ranked SQL `ORDER BY (CASE WHEN sort='growth' …) DESC LIMIT`.
+- **`insights_role_stats`** (`migrations/0022`): a precomputed per-entity scalar (`open_count`, `open_count_prev`) that makes ranked reads a trivial indexed sort — the model for how a leaderboard should be backed.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Public `GET /api/v1/insights/companies` leaderboard (ramping / freezing / size).
+- Back it with a precomputed scalar so reads never aggregate ~155k companies per request.
+- A `min_open` floor so ingest-artifact spikes don't dominate the default view.
+
+**Non-Goals:**
+- Single-company detail/time-series endpoint (later slice).
+- Any auth/API-key gating (public, like the rest of `/insights/*`).
+- Smoothing/deduping ingest churn beyond the blunt `min_open` floor.
+
+## Decisions
+
+### Precompute a per-company scalar `insights_company_growth`
+
+`insights_company_growth(company_slug text PRIMARY KEY, open_count int, open_count_prev int)`, rebuilt from `jobs` (not from `insights_company_stats`) with the same `count(*) FILTER (…)` idiom as `insights_role_stats`: `open_count` = open canonical jobs now, `open_count_prev` = open as of `now − 30d`. Ranked read = `ORDER BY (open_count − open_count_prev)` or `open_count`, `LIMIT`.
+
+**Alternatives considered:**
+- *Read-time `DISTINCT ON (company_slug)` over `insights_company_stats` per request*: a full sort/dedup over ~681k rows / ~155k groups on every call. Rejected — that is exactly the read-time aggregation `insights_role_stats` exists to avoid.
+- *Derive the scalar from `insights_company_stats` (carry-forward)*: more complex than counting `jobs` directly, and couples the two tables. Rejected — counting `jobs` is one simple aggregate, same as the sibling rollups.
+
+### Rebuild inside the existing rollup transaction
+
+`cmd/rollup-company` already opens one transaction with `SET LOCAL work_mem` for `insights_company_stats`. The new table's delete+rebuild joins that same transaction (before commit), so both are swapped atomically and a single cron run keeps them consistent. The 30-day `prev_ts` is computed in Go and passed to the SQL, exactly like `cmd/rollup-stats` does (`growthWindowDays = 30`).
+
+### Read query joins `companies` for the display name
+
+`ListInsightsCompanies` LEFT JOINs `companies` on `slug = company_slug` for `company_name`, falling back to the slug when no company row exists. The join touches only the `LIMIT`ed result rows.
+
+### Sort + params
+
+New `parseCompaniesSort` accepting `growth` (default), `-growth`, `open` — the existing `parseInsightsSort` only knows `growth`/`open` and has no descending-growth (freezing) case, so a dedicated parser is clearer than overloading it. `min_open` parsed with a small positive default and a floor of 0; `limit` reuses `parseInsightsLimit` (shared cap).
+
+## Risks / Trade-offs
+
+- **Ingest-artifact spikes** (a board fully appearing/disappearing shows as a huge ramp/freeze) → mitigated bluntly by the `min_open` default; a real smoothing/attribution layer is explicitly a later concern (noted in the shipped rollup's memory).
+- **Scalar staleness between rollup runs** (daily cron) → acceptable; the signal moves slowly and this matches how the other `insights_*` reads work.
+- **155k-row sort per request for growth sort** (not index-friendly) → acceptable at that size (one row per company, ints only); `insights_role_stats` sorts similarly. An index on `(open_count DESC)` serves the `open` sort and the `min_open` filter.
+
+## Migration Plan
+
+- New migration `migrations/0030_insights_company_growth.sql` (table + index). Apply by hand to prod before the worker rebuilds it, then the next `cmd/rollup-company` run (or a manual `systemctl start`) fills it. The endpoint returns an empty list until the first fill — acceptable.
+- Rollback: drop the table, revert the worker + handler; `insights_company_stats` is untouched.
+
+## Open Questions
+
+- Default `min_open` value (start at 5, tune from prod once the leaderboard is observed) — a constant, not a blocking decision.

--- a/openspec/changes/add-company-hiring-signal-api/proposal.md
+++ b/openspec/changes/add-company-hiring-signal-api/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The per-company hiring-signal rollup (`insights_company_stats`, shipped in the prior change) is populated on prod but has no read surface — the "who is ramping vs. freezing" leaderboard that is the headline product value cannot be queried. This adds the first public read over that signal, matching the existing `market-insights` `/insights/*` family.
+
+## What Changes
+
+- Add a public, unauthenticated `GET /api/v1/insights/companies` endpoint returning companies ranked by hiring growth or open-count, with `sort` (`growth` = ramping, `-growth` = freezing, `open` = size), a `min_open` sanity filter (guards against ingest-artifact spikes — a board fully appearing/disappearing), and a capped `limit`. Standard `{"data": [...], "meta": {...}}` envelope.
+- Add a small precomputed per-company scalar table `insights_company_growth(company_slug, open_count, open_count_prev)` — the ranked-read backing, mirroring `insights_role_stats`. The endpoint reads this with a trivial indexed `ORDER BY … LIMIT` rather than aggregating ~155k companies per request.
+- Extend the existing `cmd/rollup-company` worker to rebuild `insights_company_growth` in the same atomic transaction as `insights_company_stats`, using a 30-day `prev_ts` (as `cmd/rollup-stats` does for `insights_role_stats`).
+
+Out of scope (later slice): the single-company detail/time-series endpoint (`GET /api/v1/insights/companies/:slug`), and any auth/API-key gating.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `market-insights`: add a new public `GET /api/v1/insights/companies` leaderboard endpoint (existing `/insights/*` endpoints unchanged).
+- `company-hiring-signal`: add a precomputed per-company open/growth scalar (`insights_company_growth`) produced by the rollup worker, alongside the existing per-day `insights_company_stats`.
+
+## Impact
+
+- **Schema:** new migration adding `insights_company_growth` (+ index for the ranked read). initdb-only + manual-on-prod per the migrations gotcha.
+- **Worker:** `cmd/rollup-company` gains a second delete+rebuild in its existing transaction.
+- **DB layer:** new `DeleteAllInsightsCompanyGrowth` / `RebuildInsightsCompanyGrowth` / `ListInsightsCompanies` queries in `internal/db/queries/insights.sql`; regenerated sqlc.
+- **HTTP:** new handler `InsightsCompanies` in `internal/handler/insights.go` + route in `handler.go`. No auth, no frontend, no search impact.

--- a/openspec/changes/add-company-hiring-signal-api/specs/company-hiring-signal/spec.md
+++ b/openspec/changes/add-company-hiring-signal-api/specs/company-hiring-signal/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Precomputed per-company open/growth scalar
+
+The rollup SHALL maintain a per-company scalar table
+`insights_company_growth(company_slug, open_count, open_count_prev)` to back a
+ranked leaderboard without per-request aggregation over the full catalogue, where
+`open_count` is the company's current count of open canonical jobs and
+`open_count_prev` is that count as of 30 days earlier. Only canonical, attributable
+rows SHALL be counted (`company_slug <> '' AND duplicate_of IS NULL`), consistent
+with `insights_company_stats` and `companies.job_count`. The 30-day window SHALL be
+the same constant the existing `insights_*` rollups use.
+
+The table SHALL be rebuilt by `cmd/rollup-company` in the **same transaction** as
+`insights_company_stats`, as an atomic delete-and-reinsert, so a reader never sees
+one rebuilt without the other.
+
+#### Scenario: Scalar reflects current and prior open counts
+
+- **WHEN** a company has 10 open canonical jobs now and had 4 open 30 days ago
+- **THEN** its `insights_company_growth` row has `open_count = 10` and
+  `open_count_prev = 4`
+
+#### Scenario: Only canonical rows counted
+
+- **WHEN** a company has open jobs that are repost copies (`duplicate_of` set) or
+  have an empty `company_slug`
+- **THEN** those jobs do not contribute to `open_count` or `open_count_prev`
+
+#### Scenario: Rebuilt atomically with the per-day rollup
+
+- **WHEN** `cmd/rollup-company` runs
+- **THEN** both `insights_company_stats` and `insights_company_growth` are replaced
+  within one transaction, or neither is (a failure leaves both prior tables intact)

--- a/openspec/changes/add-company-hiring-signal-api/specs/market-insights/spec.md
+++ b/openspec/changes/add-company-hiring-signal-api/specs/market-insights/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Company hiring-signal leaderboard
+
+The system SHALL expose a public, unauthenticated `GET /api/v1/insights/companies`
+endpoint that returns companies ranked by hiring growth or current open-count,
+served from a precomputed per-company scalar (never aggregated per request over the
+full catalogue). It SHALL accept `sort` (`growth` = ramping first, `-growth` =
+freezing first, `open` = largest first; default `growth`), a `min_open` threshold
+(a small positive default) that excludes companies whose current open-count is below
+it, and a `limit` capped to a fixed maximum. It SHALL respond with the standard list
+envelope `{"data": [...], "meta": {...}}` where each row carries `company_slug`,
+`company_name`, `open_now`, `open_prev_30d`, and `growth_30d`. The response SHALL be
+aggregate-only — no record-level job fields.
+
+#### Scenario: Top ramping companies
+
+- **WHEN** a client requests `GET /api/v1/insights/companies?sort=growth`
+- **THEN** the response is `200` with a `data` array ordered by
+  `growth_30d` (= `open_now − open_prev_30d`) descending, each row carrying
+  `company_slug`, `company_name`, `open_now`, `open_prev_30d`, `growth_30d`
+- **AND** `meta` echoes the applied `sort`, `min_open`, and `limit`
+
+#### Scenario: Freezing companies
+
+- **WHEN** a client requests `GET /api/v1/insights/companies?sort=-growth`
+- **THEN** companies are ordered by `growth_30d` ascending (largest declines first)
+
+#### Scenario: min_open excludes small companies
+
+- **WHEN** a client requests `GET /api/v1/insights/companies?min_open=10`
+- **THEN** only companies whose `open_now` is at least `10` appear in `data`
+
+#### Scenario: Invalid sort rejected
+
+- **WHEN** a client requests `GET /api/v1/insights/companies?sort=bogus`
+- **THEN** the response is `400` and no data is returned
+
+#### Scenario: Limit is capped
+
+- **WHEN** a client requests a `limit` above the endpoint's maximum
+- **THEN** the applied limit is clamped to that maximum (or `400`), never unbounded

--- a/openspec/changes/add-company-hiring-signal-api/tasks.md
+++ b/openspec/changes/add-company-hiring-signal-api/tasks.md
@@ -1,0 +1,20 @@
+## 1. Schema
+
+- [x] 1.1 Add migration `migrations/0030_insights_company_growth.sql` creating `insights_company_growth(company_slug text PRIMARY KEY, open_count int NOT NULL DEFAULT 0, open_count_prev int NOT NULL DEFAULT 0)` plus an index on `(open_count DESC)` (serves the `open` sort and the `min_open` filter), with a header comment matching the `insights_*` rollup convention (pure function of `jobs`, atomic rebuild by `cmd/rollup-company`, initdb-only + manual-on-prod).
+
+## 2. Growth-scalar rollup (TDD)
+
+- [x] 2.1 RED: add a failing `//go:build integration` test in `internal/db` seeding jobs (open now, open-then-closed within/before the 30d window, a duplicate, an empty-slug), running the growth rebuild, and asserting per-company `open_count` / `open_count_prev` and that duplicates/empty-slug rows are excluded.
+- [x] 2.2 GREEN: add `DeleteAllInsightsCompanyGrowth` and `RebuildInsightsCompanyGrowth` (takes a `prev_ts`) to `internal/db/queries/insights.sql` using the `count(*) FILTER (…)` idiom over canonical rows; regenerate sqlc; make the test pass.
+- [x] 2.3 Extend `cmd/rollup-company` to delete+rebuild `insights_company_growth` in the SAME transaction as `insights_company_stats`, computing `prev_ts = now − 30d` (a `growthWindowDays` const, as `cmd/rollup-stats`); update its log line + package doc.
+- [x] 2.4 REFACTOR + simplify under green.
+
+## 3. Leaderboard read + endpoint (TDD)
+
+- [x] 3.1 RED: add a failing handler integration test (`internal/handler`) wiring `GET /api/v1/insights/companies`, asserting: `sort=growth` orders by `growth_30d` desc; `sort=-growth` orders asc; `min_open` filters; `sort=bogus` → 400; `limit` capped; `{data,meta}` envelope with `company_slug`/`company_name`/`open_now`/`open_prev_30d`/`growth_30d`.
+- [x] 3.2 GREEN: add `ListInsightsCompanies` to `internal/db/queries/insights.sql` (LEFT JOIN `companies` for `company_name`, `WHERE open_count >= @min_open`, `ORDER BY` per sort, `LIMIT @lim`); regenerate sqlc. Add `InsightsCompanies` handler + `parseCompaniesSort` (growth/-growth/open) + `min_open` parse in `internal/handler/insights.go`, and wire the route in `internal/handler/handler.go`. Make the test pass.
+- [x] 3.3 REFACTOR + simplify under green.
+
+## 4. Docs
+
+- [x] 4.1 Update `AGENTS.md` — note `cmd/rollup-company` now rebuilds both `insights_company_stats` and `insights_company_growth`; add `/api/v1/insights/companies` to the endpoint surface description if the insights endpoints are listed.


### PR DESCRIPTION
## Summary
- Adds public `GET /api/v1/insights/companies` — companies ranked by 30-day hiring growth (`sort=growth|-growth|open`), with a `min_open` floor (default 5, blunts ingest-artifact spikes) and capped `limit`. Standard `{data,meta}` envelope, aggregate-only, matching the other `/insights/*` reads.
- Backed by a precomputed scalar `insights_company_growth(company_slug, open_count, open_count_prev)` (mirrors `insights_role_stats`) so the read is a trivial indexed `ORDER BY … LIMIT`, not a per-request aggregate over ~155k companies.
- `cmd/rollup-company` rebuilds it in the **same transaction** as `insights_company_stats` (30-day `prev_ts`).

Follow-up to #868. Planned via OpenSpec `add-company-hiring-signal-api`.

## Test Plan
- [x] `go build/vet ./...`, `go test ./...` (84 pkgs) green
- [x] `go test -tags=integration ./internal/db/ ./internal/handler/` — growth-scalar correctness (dup/empty-slug excluded) + endpoint ordering, `min_open` filter, `400` on bad sort, `company_name` join
- [ ] Deploy: apply `migrations/0030_insights_company_growth.sql` manually (SET ROLE hire) before deploy; next `cmd/rollup-company` run fills it. Endpoint returns `[]` until first fill.