### PR TITLE
feat(sources): nofluffjobs Polish/CEE IT hydrating adapter

### DIFF
--- a/internal/sources/nofluffjobs.go
+++ b/internal/sources/nofluffjobs.go
@@ -1,0 +1,225 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// nofluffjobs adapts nofluffjobs.com, a Polish/CEE IT job board (the complement to justjoin).
+// Boardless (one public API, no per-tenant board) and multi-company, so it stays in the source
+// facet and takes each posting's company from the feed. The listing carries structured facets but
+// no description, so — like justjoin — the description is hydrated per posting from a detail
+// endpoint, and only for postings not already ingested (HydratingSource.FetchNew).
+type nofluffjobs struct {
+	http nofluffjobsHTTP
+}
+
+// nofluffjobsHTTP is the two-stage transport: a streamed listing (the ~60 MB document exceeds the
+// size-capped GetJSON) and a per-posting JSON detail.
+type nofluffjobsHTTP interface {
+	GetStream(ctx context.Context, url, accept string, fn func(io.Reader) error) error
+	GetJSON(ctx context.Context, url string, v any) error
+}
+
+const (
+	nofluffjobsListURL   = "https://nofluffjobs.com/api/posting"
+	nofluffjobsOfferURL  = "https://nofluffjobs.com/job/%s"
+	nofluffjobsDetailURL = "https://nofluffjobs.com/api/posting/%s"
+)
+
+// NewNoFluffJobs builds the NoFluffJobs adapter over the given two-stage client.
+func NewNoFluffJobs(c nofluffjobsHTTP) Source { return nofluffjobs{http: c} }
+
+func (nofluffjobs) Provider() string { return "nofluffjobs" }
+
+func (nofluffjobs) boardless() {}
+
+func (nofluffjobs) aggregator() {}
+
+// nofluffjobsListing is the single listing document.
+type nofluffjobsListing struct {
+	Postings []nofluffjobsPosting `json:"postings"`
+}
+
+// nofluffjobsPosting is one listing entry. posted is epoch milliseconds; technology is a single
+// skill string; seniority is an array whose first entry is the grade.
+type nofluffjobsPosting struct {
+	ID          string   `json:"id"`
+	URL         string   `json:"url"`
+	Name        string   `json:"name"`
+	Title       string   `json:"title"`
+	Technology  string   `json:"technology"`
+	Seniority   []string `json:"seniority"`
+	FullyRemote bool     `json:"fullyRemote"`
+	Posted      int64    `json:"posted"`
+	Location    struct {
+		Places []struct {
+			City    string `json:"city"`
+			Country struct {
+				Name string `json:"name"`
+			} `json:"country"`
+		} `json:"places"`
+	} `json:"location"`
+}
+
+// nofluffjobsDetail is the per-posting detail payload; the description is split across the offer
+// (details.description) and the requirements (requirements.description) HTML sections.
+type nofluffjobsDetail struct {
+	Details struct {
+		Description string `json:"description"`
+	} `json:"details"`
+	Requirements struct {
+		Description string `json:"description"`
+	} `json:"requirements"`
+}
+
+// crawl streams and decodes the listing document — the shared list walk behind Fetch and FetchNew.
+func (s nofluffjobs) crawl(ctx context.Context) ([]nofluffjobsPosting, error) {
+	var doc nofluffjobsListing
+	err := s.http.GetStream(ctx, nofluffjobsListURL, "application/json", func(r io.Reader) error {
+		return json.NewDecoder(r).Decode(&doc)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("nofluffjobs: listing: %w", err)
+	}
+	return doc.Postings, nil
+}
+
+// Fetch is the list-only crawl (no description) — the fallback for a non-hydrating pipeline.
+func (s nofluffjobs) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	postings, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make([]Job, 0, len(postings))
+	for _, p := range postings {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// FetchNew is the hydrating crawl: it fetches a posting's detail description only for a posting the
+// catalogue does not already have (seen). A seen posting yields the list-only job (no detail
+// request, marked SeenRefresh so the pipeline refreshes liveness without wiping the hydrated body);
+// an unseen posting is hydrated; a single detail failure is isolated (logged, list-only fallback).
+func (s nofluffjobs) FetchNew(ctx context.Context, _ CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	postings, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(postings, defaultDetailWorkers, func(p nofluffjobsPosting) (Job, bool) {
+		base, ok := p.toJob()
+		if !ok {
+			return Job{}, false // unusable posting — dropped, as in Fetch
+		}
+		if seen(base.ExternalID) {
+			base.SeenRefresh = true
+			return base, true
+		}
+		d, ok := s.detail(ctx, p.URL)
+		if !ok {
+			log.Printf("nofluffjobs: detail %q failed; ingesting list-only", p.URL)
+			return base, true
+		}
+		base.Description = d.description()
+		return base, true
+	}), nil
+}
+
+// detail fetches a posting's detail, returning ok=false on a failed request so the caller falls
+// back to the list-only job — a posting is never dropped over a missing detail.
+func (s nofluffjobs) detail(ctx context.Context, slug string) (nofluffjobsDetail, bool) {
+	var d nofluffjobsDetail
+	if err := s.http.GetJSON(ctx, fmt.Sprintf(nofluffjobsDetailURL, slug), &d); err != nil {
+		return nofluffjobsDetail{}, false
+	}
+	return d, true
+}
+
+// description assembles the sanitized body from the offer and requirements HTML sections.
+func (d nofluffjobsDetail) description() string {
+	parts := make([]string, 0, 2)
+	for _, s := range []string{d.Details.Description, d.Requirements.Description} {
+		if strings.TrimSpace(s) != "" {
+			parts = append(parts, s)
+		}
+	}
+	return sanitizeHTML(strings.Join(parts, "\n"))
+}
+
+// toJob maps a listing posting to a Job, returning ok=false for an unusable posting (no id to key
+// on, no url slug to build the canonical URL, or no company which would break the slug). Skills and
+// seniority come straight from the listing — no detail request needed for the structured facets.
+func (p nofluffjobsPosting) toJob() (Job, bool) {
+	if p.ID == "" || p.URL == "" || p.Name == "" {
+		return Job{}, false
+	}
+	job := Job{
+		ExternalID: p.ID,
+		URL:        fmt.Sprintf(nofluffjobsOfferURL, p.URL),
+		Title:      strings.TrimSpace(p.Title),
+		Company:    strings.TrimSpace(p.Name),
+		Location:   nofluffjobsLocation(p),
+		Remote:     p.FullyRemote,
+		Skills:     skilltag.Parse(p.Technology),
+		Seniority:  nofluffjobsSeniority(p.Seniority),
+	}
+	if p.FullyRemote {
+		job.WorkMode = "remote"
+	}
+	if p.Posted > 0 {
+		t := time.UnixMilli(p.Posted).UTC()
+		job.PostedAt = &t
+	}
+	return job, true
+}
+
+// nofluffjobsLocation is the first place's "City, Country", or empty when the posting lists no place.
+func nofluffjobsLocation(p nofluffjobsPosting) string {
+	if len(p.Location.Places) == 0 {
+		return ""
+	}
+	place := p.Location.Places[0]
+	parts := make([]string, 0, 2)
+	for _, s := range []string{place.City, place.Country.Name} {
+		if s = strings.TrimSpace(s); s != "" {
+			parts = append(parts, s)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// nofluffjobsSeniority maps NoFluffJobs' first seniority grade into freehire's vocabulary. Its
+// ladder is Trainee < Junior < Mid < Senior < Expert; three names differ from freehire's and are
+// renamed (mid→middle, trainee→intern, expert→principal, the top individual-contributor grade).
+// After the renames, vocabulary membership is the map — an unrecognized grade drops rather than
+// being guessed (the title dictionary then decides).
+func nofluffjobsSeniority(levels []string) string {
+	if len(levels) == 0 {
+		return ""
+	}
+	l := strings.ToLower(strings.TrimSpace(levels[0]))
+	switch l {
+	case "mid":
+		l = "middle"
+	case "trainee":
+		l = "intern"
+	case "expert":
+		l = "principal"
+	}
+	if slices.Contains(enrich.SeniorityValues, l) {
+		return l
+	}
+	return ""
+}

--- a/internal/sources/nofluffjobs_test.go
+++ b/internal/sources/nofluffjobs_test.go
@@ -1,0 +1,173 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// nofluffjobsFake serves the streamed listing and routes detail calls by the slug in the URL.
+type nofluffjobsFake struct {
+	listing     string
+	detailByURL map[string]string
+	detailErr   map[string]bool
+	detailSlugs []string
+}
+
+func (f *nofluffjobsFake) GetStream(_ context.Context, _ string, _ string, fn func(io.Reader) error) error {
+	return fn(strings.NewReader(f.listing))
+}
+
+func (f *nofluffjobsFake) GetJSON(_ context.Context, url string, v any) error {
+	slug := url[strings.LastIndex(url, "/")+1:]
+	f.detailSlugs = append(f.detailSlugs, slug)
+	if f.detailErr[slug] {
+		return errors.New("detail boom")
+	}
+	return json.Unmarshal([]byte(f.detailByURL[slug]), v)
+}
+
+const nofluffjobsListingJSON = `{"postings":[
+  {"id":"gcp-verita-Kraków","url":"gcp-verita-krakow","name":"Verita HR","title":"GCP Data ETL","technology":"Python","category":"data","seniority":["Mid"],"fullyRemote":false,"posted":1784034271774,"location":{"places":[{"city":"Kraków","country":{"name":"Poland"}}],"fullyRemote":false}},
+  {"id":"remote-dev","url":"remote-dev","name":"Acme","title":"Backend Dev","technology":"Java","seniority":["Senior"],"fullyRemote":true,"posted":1784034271774,"location":{"places":[],"fullyRemote":true}},
+  {"id":"no-company","url":"no-company","name":"","title":"X","seniority":["Junior"],"posted":1784034271774}
+]}`
+
+func TestNoFluffJobsFetchMapsAndDrops(t *testing.T) {
+	jobs, err := NewNoFluffJobs(&nofluffjobsFake{listing: nofluffjobsListingJSON}).
+		Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (no-company dropped)", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	j := byID["gcp-verita-Kraków"]
+	if j.URL != "https://nofluffjobs.com/job/gcp-verita-krakow" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "GCP Data ETL" || j.Company != "Verita HR" {
+		t.Errorf("title/company: %q / %q", j.Title, j.Company)
+	}
+	if j.Location != "Kraków, Poland" {
+		t.Errorf("Location = %q, want 'Kraków, Poland'", j.Location)
+	}
+	if j.Seniority != "middle" {
+		t.Errorf("Seniority = %q, want middle (Mid->middle)", j.Seniority)
+	}
+	if len(j.Skills) == 0 {
+		t.Errorf("Skills empty, want the canonicalized technology")
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2026 {
+		t.Errorf("PostedAt = %v, want 2026 (epoch ms)", j.PostedAt)
+	}
+	if j.Remote {
+		t.Error("Remote = true for a Kraków job, want false")
+	}
+	r := byID["remote-dev"]
+	if !r.Remote || r.WorkMode != "remote" || r.Seniority != "senior" {
+		t.Errorf("remote job: Remote=%v WorkMode=%q Seniority=%q", r.Remote, r.WorkMode, r.Seniority)
+	}
+}
+
+func TestNoFluffJobsFetchNewHydratesNewOnly(t *testing.T) {
+	const listing = `{"postings":[
+	  {"id":"seen-1","url":"seen-1","name":"Co","title":"A","seniority":["Mid"],"posted":1784034271774},
+	  {"id":"new-2","url":"new-2","name":"Co","title":"B","seniority":["Mid"],"posted":1784034271774},
+	  {"id":"err-3","url":"err-3","name":"Co","title":"C","seniority":["Mid"],"posted":1784034271774}
+	]}`
+	fake := &nofluffjobsFake{
+		listing: listing,
+		detailByURL: map[string]string{
+			"new-2": `{"details":{"description":"<span>Great offer</span>"},"requirements":{"description":"<ul><li>Java skills</li></ul>"}}`,
+		},
+		detailErr: map[string]bool{"err-3": true},
+	}
+	seen := func(id string) bool { return id == "seen-1" }
+	jobs, err := NewNoFluffJobs(fake).(HydratingSource).FetchNew(context.Background(), CompanyEntry{}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3", len(jobs))
+	}
+	// Detail is fetched only for the unseen postings (new-2, err-3), never for seen-1.
+	slices.Sort(fake.detailSlugs)
+	if !slices.Equal(fake.detailSlugs, []string{"err-3", "new-2"}) {
+		t.Errorf("detail slugs = %v, want [err-3 new-2] (seen-1 not fetched)", fake.detailSlugs)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if !byID["seen-1"].SeenRefresh || byID["seen-1"].Description != "" {
+		t.Errorf("seen-1: SeenRefresh=%v desc=%q, want refresh-only with empty desc", byID["seen-1"].SeenRefresh, byID["seen-1"].Description)
+	}
+	if d := byID["new-2"].Description; !strings.Contains(d, "Great offer") || !strings.Contains(d, "Java skills") {
+		t.Errorf("new-2 description = %q, want details+requirements assembled", d)
+	}
+	if byID["err-3"].SeenRefresh || byID["err-3"].Description != "" {
+		t.Errorf("err-3 should fall back to list-only (empty desc, not a refresh), got desc=%q refresh=%v", byID["err-3"].Description, byID["err-3"].SeenRefresh)
+	}
+}
+
+func TestNoFluffJobsSeniority(t *testing.T) {
+	cases := map[string]string{
+		"Mid":     "middle",
+		"Trainee": "intern",
+		"Expert":  "principal",
+		"Junior":  "junior",
+		"Senior":  "senior",
+		"Manager": "", // not a freehire seniority — dropped, not guessed
+		"":        "",
+	}
+	for in, want := range cases {
+		var levels []string
+		if in != "" {
+			levels = []string{in}
+		}
+		if got := nofluffjobsSeniority(levels); got != want {
+			t.Errorf("nofluffjobsSeniority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNoFluffJobsProviderRegistered(t *testing.T) {
+	s := NewNoFluffJobs(nil)
+	if s.Provider() != "nofluffjobs" {
+		t.Errorf("Provider() = %q", s.Provider())
+	}
+	if _, ok := s.(boardless); !ok {
+		t.Error("nofluffjobs should be boardless")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("nofluffjobs should be an aggregator")
+	}
+	if _, ok := s.(HydratingSource); !ok {
+		t.Error("nofluffjobs should implement HydratingSource")
+	}
+	if _, ok := All(nil)["nofluffjobs"]; !ok {
+		t.Error("All() should register nofluffjobs")
+	}
+	if !slices.Contains(FilterableProviders(), "nofluffjobs") {
+		t.Error("FilterableProviders() should include nofluffjobs")
+	}
+}
+
+func TestNoFluffJobsBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/nofluffjobs.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/nofluffjobs.yml fails validation: %v", err)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -286,6 +286,7 @@ func All(c HTTPClient) map[string]Source {
 		NewHimalayas(c),
 		NewRemotive(c),
 		NewJustJoin(c),
+		NewNoFluffJobs(c),
 		NewWantapply(c),
 		NewInfoJobs(c),
 		NewJobtech(c),

--- a/openspec/changes/add-nofluffjobs-source/.openspec.yaml
+++ b/openspec/changes/add-nofluffjobs-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-nofluffjobs-source/design.md
+++ b/openspec/changes/add-nofluffjobs-source/design.md
@@ -1,0 +1,78 @@
+## Context
+
+A spike against NoFluffJobs established:
+
+- `GET https://nofluffjobs.com/api/posting` returns a single keyless JSON object `{ postings: [...] }`
+  — ~8 400 postings, ~60 MB. No pagination. The 60 MB body exceeds the size-capped `GetJSON`, so it
+  must be read via `GetStream` (as isolvedhire does for its large sitemap).
+- Each listing posting carries: `id` (stable, e.g. `gcp-…-verita-hr-Kraków`), `url` (ASCII slug,
+  e.g. `gcp-…-verita-hr-krakow`), `name` (company), `title`, `posted`/`renewed` (epoch ms),
+  `technology` (a skill string), `seniority` (array, e.g. `["Mid"]`), `category`, `fullyRemote`,
+  `salary`, and `location.places[]` (`{city, country{name}}`). **No description.**
+- `GET https://nofluffjobs.com/api/posting/<url>` (keyless, ~12 KB) carries the description across
+  `requirements.description` (HTML), `details.description` (HTML), `requirements.musts` (skills),
+  and `specs.dailyTasks`.
+
+This is the justjoin shape (`internal/sources/justjoin.go`): a boardless aggregator whose list omits
+the body, hydrated per-posting via a detail endpoint, using the pipeline's `HydratingSource`
+(`FetchNew(ctx, entry, seen)`) so only new postings pay the detail cost.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless, boardless, aggregator `nofluffjobs` adapter mirroring justjoin's hydrating pattern.
+- Structured facets (skills, seniority) taken from the **listing** — no detail request needed for them.
+- Reuse `GetStream`, `skilltag.Parse`, `enrich.SeniorityValues`, `sanitizeHTML`; no new shared helper.
+
+**Non-Goals:**
+- A freshness/keyword filter. The user chose full detail hydration; `FetchNew`'s seen-set already
+  bounds steady-state cost to new postings, and the standard sweep soft-closes anything that ages out.
+- Structured salary mapping. justjoin does not map salary either; the description + enrichment cover it.
+- Category mapping. Like justjoin, nofluffjobs `category` is a stack/language tag that doesn't pin a
+  freehire role category — the title dictionary decides it.
+
+## Decisions
+
+- **Stream the listing.** `GetStream(ctx, listURL, "application/json", func(r) { json.NewDecoder(r).Decode(&resp) })`
+  decodes the 60 MB `{postings:[…]}` past the `GetJSON` size cap. *Alternative rejected:* `GetJSON` —
+  it caps and truncates the body.
+
+- **Facets from the list, description from the (new-only) detail.** `toJob` maps every list field
+  including skills (`skilltag.Parse(technology)`) and seniority. `FetchNew` fetches `/api/posting/<url>`
+  only for postings the seen-predicate reports as new, assembling the description from
+  `details.description` + `requirements.description` (both HTML) and sanitizing; a seen posting keeps
+  its list-only job so the pipeline refreshes liveness without wiping the previously-hydrated body.
+  *Alternative rejected:* detail-fetch every posting every run — ~8 400 requests per crawl; the
+  seen-set is exactly the justjoin mitigation.
+
+- **ExternalID = `id`; URL from `url` slug.** `id` is the stable dedup key; the ASCII `url` slug builds
+  both the canonical page (`https://nofluffjobs.com/job/<url>`) and the detail request. A posting with
+  no `id`, no `url`, or no company is dropped (empty id/URL/company would break dedup or the slug).
+
+- **Seniority mapping.** NoFluffJobs names the middle grade `Mid`; map `mid`→`middle`, then keep the
+  value only if it is in `enrich.SeniorityValues` (unrecognized grades drop rather than being guessed)
+  — the same rule justjoin uses.
+
+- **Boardless aggregator, keyless.** `boardless()` + `aggregator()` markers; the config entry is a
+  single boardless line. One line in `sources.All`. No key. No proxy unless the prod IP is
+  rate-limited (a later config flip).
+
+## Risks / Trade-offs
+
+- **60 MB listing per run.** → `GetStream` avoids the size cap; the decode holds ~8 400 structs in
+  memory briefly (acceptable). The response is uncompressed JSON; the standard client sends
+  `Accept-Encoding: gzip`, so the wire transfer is far smaller.
+- **First-run detail fan-out (~8 400 requests).** → `FetchNew`'s seen-set makes this a one-time cost;
+  steady state hydrates only new postings. If the site rate-limits, `proxiedProviders` is the seam.
+- **Polish-language descriptions.** → Skill tags and structured seniority survive; enrichment prose
+  is weaker but the structured facets carry value. Accepted (same as justjoin).
+
+## Migration Plan
+
+- No DB migration, no API change, no new dependency, no key.
+- Deploy: add a `cmd/ingest sources/nofluffjobs.yml` cron schedule in freehire-ops.
+
+## Open Questions
+
+- Does the prod datacenter IP get rate-limited on ~8 400 first-run detail requests? Resolve with a
+  manual prod run; `proxiedProviders` enrollment is the fallback.

--- a/openspec/changes/add-nofluffjobs-source/proposal.md
+++ b/openspec/changes/add-nofluffjobs-source/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+NoFluffJobs (nofluffjobs.com) is a major Polish/CEE IT job board — the complement to justjoin.it,
+which we already crawl. A spike VALIDATED that its `/api/posting` listing is a single keyless JSON
+document enumerating every open posting with structured facets (technology, seniority, category,
+salary, location, remote flag), and that a keyless per-posting `/api/posting/<slug>` detail carries
+the full description. Adding it widens Polish/CEE IT coverage through the same hydrating-adapter
+pattern justjoin already uses.
+
+## What Changes
+
+- Add a `nofluffjobs` source adapter that streams the `https://nofluffjobs.com/api/posting` listing
+  (a single ~60 MB JSON document — fetched via `GetStream`, past the size-capped `GetJSON`) and maps
+  each posting to a normalized `Job`: `id` → `ExternalID`, `https://nofluffjobs.com/job/<url>` →
+  canonical URL, `title`, `name` → company, `location.places[0]` / `fullyRemote` → location + remote,
+  `posted` (epoch ms) → posted-at, `technology` → skills (via the skilltag dictionary), and
+  `seniority[0]` → seniority (mapped into freehire's vocabulary).
+- **Hydrating adapter (justjoin pattern).** Implement `FetchNew(ctx, entry, seen)`: the listing has
+  no description, so a posting's description is fetched from `/api/posting/<url>` (assembling
+  `details.description` + `requirements.description`) only when it is **new** (not in the seen set);
+  already-ingested postings refresh liveness from the list without a detail request. Plain `Fetch`
+  is the list-only fallback. This bounds the per-run detail fan-out to genuinely new postings.
+- The adapter is **boardless** (one global API, no per-tenant board) and an **aggregator** (company
+  per posting), so it stays in the source facet — exactly like justjoin.
+- Drop a posting with no `id`, no `url` (no canonical URL), or no company (empty company breaks the
+  slug).
+- Register `nofluffjobs` in `sources.All` and add `sources/nofluffjobs.yml` with a single boardless
+  entry, crawled by its own `cmd/ingest` cron schedule.
+
+## Capabilities
+
+### New Capabilities
+- `nofluffjobs-source`: the `nofluffjobs` adapter — its streamed listing crawl, posting→`Job` mapping
+  with structured facets, hydrating `FetchNew` detail description, drop rules, and boardless-aggregator
+  classification.
+
+### Modified Capabilities
+<!-- None. Boardless hydrating aggregator; inherits the standard ingest sweep, seen-set hydration,
+     aggregator dedup, and board-health machinery unchanged. -->
+
+## Impact
+
+- **New code:** `internal/sources/nofluffjobs.go` (+ `_test.go`); `sources/nofluffjobs.yml`.
+- **Touched code:** one line in `sources.All` (registry).
+- **Ops:** a new `cmd/ingest sources/nofluffjobs.yml` cron schedule (deploy-time, in freehire-ops).
+- **Cost:** first run hydrates all ~8 400 postings (one detail request each); steady-state runs
+  hydrate only new postings. If the site rate-limits the prod IP, enroll in `proxiedProviders`
+  (a config flip; noted as a seam, not built now).
+- **No migrations, no API changes, no new dependencies, no key (keyless).**

--- a/openspec/changes/add-nofluffjobs-source/specs/nofluffjobs-source/spec.md
+++ b/openspec/changes/add-nofluffjobs-source/specs/nofluffjobs-source/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: NoFluffJobs maps its streamed listing to jobs
+
+The system SHALL provide a `nofluffjobs` source adapter that reads the
+`https://nofluffjobs.com/api/posting` listing (a single large JSON document, fetched via streaming
+past the size-capped JSON getter) and maps each posting to a normalized `Job`. The `Job` SHALL carry
+the posting `id` as its `ExternalID`, `https://nofluffjobs.com/job/<url>` (the ASCII slug) as its
+canonical URL, the `title`, the `name` as its company, the `location.places[0]` city/country (or
+remote) as its location with `fullyRemote` as its remote flag, the `posted` epoch-milliseconds value
+as its posted-at, the canonicalized `technology` as its skills, and the mapped `seniority` as its
+seniority.
+
+The adapter is **boardless** (nofluffjobs.com is one API with no per-tenant board) and an
+**aggregator** (company per posting), so it stays in the source facet. The configured board file
+entry carries no `board` value.
+
+#### Scenario: A listing posting maps to a job
+
+- **WHEN** the adapter reads a posting with an `id`, a `url` slug, a `title`, a `name`, a `posted`
+  timestamp, a `technology`, and a `seniority`
+- **THEN** it yields one `Job` with `ExternalID` = `id`, the `job/<url>` canonical URL, the title,
+  the company, the location/remote flag, the posted-at from `posted`, the canonicalized skills, and
+  the mapped seniority
+
+### Requirement: NoFluffJobs hydrates new postings' descriptions from the detail endpoint
+
+The listing carries no description, so the adapter SHALL implement the hydrating `FetchNew` path: for
+a posting the seen-predicate reports as **new**, it SHALL fetch `https://nofluffjobs.com/api/posting/<url>`
+and set the `Job` description to the sanitized `details.description` combined with
+`requirements.description`; for a posting already ingested (seen), it SHALL emit the list-only `Job`
+without a detail request so the pipeline refreshes liveness without wiping the previously-hydrated body.
+A detail request that fails SHALL fall back to the list-only `Job` rather than dropping the posting.
+The plain `Fetch` path SHALL map the listing without any detail request.
+
+#### Scenario: A new posting is hydrated with its description
+
+- **WHEN** `FetchNew` runs and a posting's `id` is not in the seen set
+- **THEN** the adapter fetches that posting's detail and the resulting `Job` carries the sanitized
+  description assembled from the detail's `details.description` and `requirements.description`
+
+#### Scenario: An already-seen posting is not detail-fetched
+
+- **WHEN** `FetchNew` runs and a posting's `id` is already in the seen set
+- **THEN** the adapter emits the list-only `Job` for it and makes no detail request
+
+### Requirement: NoFluffJobs drops unusable postings
+
+The adapter SHALL drop any posting with no `id`, no `url` slug, or no company — an empty dedup key,
+an unbuildable canonical URL, or an empty company (which breaks the public slug). A single dropped
+posting SHALL NOT abort the crawl.
+
+#### Scenario: A posting with no company is dropped
+
+- **WHEN** a posting has an empty `name`
+- **THEN** the adapter yields no `Job` for it and continues mapping the rest

--- a/openspec/changes/add-nofluffjobs-source/tasks.md
+++ b/openspec/changes/add-nofluffjobs-source/tasks.md
@@ -1,11 +1,11 @@
 ## 1. Listing crawl & mapping
 
-- [ ] 1.1 Add `internal/sources/nofluffjobs_test.go` with an inline listing fixture (`{"postings":[…]}`
+- [x] 1.1 Add `internal/sources/nofluffjobs_test.go` with an inline listing fixture (`{"postings":[…]}`
   with `id`, `url`, `name`, `title`, `posted`, `technology`, `seniority`, `fullyRemote`,
   `location.places[]`) and a RED test asserting `Fetch` (list-only) maps each posting to a `Job` with
   the mapped fields (id→ExternalID, job/<url> URL, title, company, location/remote, posted→PostedAt,
   technology→Skills, seniority→Seniority) and drops postings missing id/url/company.
-- [ ] 1.2 Create `internal/sources/nofluffjobs.go`: the `nofluffjobs` struct over a client interface
+- [x] 1.2 Create `internal/sources/nofluffjobs.go`: the `nofluffjobs` struct over a client interface
   combining `GetStream` (listing) and `GetJSON` (detail); the `nofluffjobsPosting` list struct; a
   `crawl` that streams+decodes `{postings:[…]}`; a `toJob` mapper (with `nofluffjobsSeniority` via
   `enrich.SeniorityValues`, skills via `skilltag.Parse`, epoch-ms posted-at, place/remote location);
@@ -13,27 +13,27 @@
 
 ## 2. Hydrating FetchNew + detail description
 
-- [ ] 2.1 RED test: `FetchNew` with a fake seen-predicate fetches the detail only for new postings
+- [x] 2.1 RED test: `FetchNew` with a fake seen-predicate fetches the detail only for new postings
   (assert the exact set of detail slugs requested), sets the description from
   `details.description`+`requirements.description`, leaves seen postings list-only (no detail request),
   and falls back to the list-only job when a detail request errors.
-- [ ] 2.2 Implement `FetchNew(ctx, entry, seen)`, the `nofluffjobsDetail` struct, `detail(slug)`, and
+- [x] 2.2 Implement `FetchNew(ctx, entry, seen)`, the `nofluffjobsDetail` struct, `detail(slug)`, and
   the description assembly + `apply`. Make 2.1 green.
 
 ## 3. Classification & registration
 
-- [ ] 3.1 Add the `boardless()` and `aggregator()` markers and `Provider()` returning `"nofluffjobs"`;
+- [x] 3.1 Add the `boardless()` and `aggregator()` markers and `Provider()` returning `"nofluffjobs"`;
   register `nofluffjobs` in `sources.All` (one line, under the multi-company aggregators). Test the
   provider resolves from `All(nil)` and is in `FilterableProviders()`. Verify `go build ./... && go vet ./...`.
 
 ## 4. Board file & docs
 
-- [ ] 4.1 Add `sources/nofluffjobs.yml` with a single boardless entry (`company: NoFluffJobs`) and
+- [x] 4.1 Add `sources/nofluffjobs.yml` with a single boardless entry (`company: NoFluffJobs`) and
   confirm `go run ./cmd/ingest sources/nofluffjobs.yml` validates against the registry (fail-fast passes).
-- [ ] 4.2 Note the new adapter in `internal/sources/AGENTS.md` only if it enumerates adapters by class.
+- [x] 4.2 No-op: `internal/sources/AGENTS.md` does not enumerate adapters by class.
 
 ## 5. Verify end-to-end
 
-- [ ] 5.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl against
+- [x] 5.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl against
   the real API (a bounded sample) to confirm the listing streams, postings map with facets, and a new
   posting's detail description hydrates without error (not committed).

--- a/openspec/changes/add-nofluffjobs-source/tasks.md
+++ b/openspec/changes/add-nofluffjobs-source/tasks.md
@@ -1,0 +1,39 @@
+## 1. Listing crawl & mapping
+
+- [ ] 1.1 Add `internal/sources/nofluffjobs_test.go` with an inline listing fixture (`{"postings":[…]}`
+  with `id`, `url`, `name`, `title`, `posted`, `technology`, `seniority`, `fullyRemote`,
+  `location.places[]`) and a RED test asserting `Fetch` (list-only) maps each posting to a `Job` with
+  the mapped fields (id→ExternalID, job/<url> URL, title, company, location/remote, posted→PostedAt,
+  technology→Skills, seniority→Seniority) and drops postings missing id/url/company.
+- [ ] 1.2 Create `internal/sources/nofluffjobs.go`: the `nofluffjobs` struct over a client interface
+  combining `GetStream` (listing) and `GetJSON` (detail); the `nofluffjobsPosting` list struct; a
+  `crawl` that streams+decodes `{postings:[…]}`; a `toJob` mapper (with `nofluffjobsSeniority` via
+  `enrich.SeniorityValues`, skills via `skilltag.Parse`, epoch-ms posted-at, place/remote location);
+  and `Fetch`. Make 1.1 green.
+
+## 2. Hydrating FetchNew + detail description
+
+- [ ] 2.1 RED test: `FetchNew` with a fake seen-predicate fetches the detail only for new postings
+  (assert the exact set of detail slugs requested), sets the description from
+  `details.description`+`requirements.description`, leaves seen postings list-only (no detail request),
+  and falls back to the list-only job when a detail request errors.
+- [ ] 2.2 Implement `FetchNew(ctx, entry, seen)`, the `nofluffjobsDetail` struct, `detail(slug)`, and
+  the description assembly + `apply`. Make 2.1 green.
+
+## 3. Classification & registration
+
+- [ ] 3.1 Add the `boardless()` and `aggregator()` markers and `Provider()` returning `"nofluffjobs"`;
+  register `nofluffjobs` in `sources.All` (one line, under the multi-company aggregators). Test the
+  provider resolves from `All(nil)` and is in `FilterableProviders()`. Verify `go build ./... && go vet ./...`.
+
+## 4. Board file & docs
+
+- [ ] 4.1 Add `sources/nofluffjobs.yml` with a single boardless entry (`company: NoFluffJobs`) and
+  confirm `go run ./cmd/ingest sources/nofluffjobs.yml` validates against the registry (fail-fast passes).
+- [ ] 4.2 Note the new adapter in `internal/sources/AGENTS.md` only if it enumerates adapters by class.
+
+## 5. Verify end-to-end
+
+- [ ] 5.1 Run `go test ./internal/sources/...` (all green), then a throwaway live smoke crawl against
+  the real API (a bounded sample) to confirm the listing streams, postings map with facets, and a new
+  posting's detail description hydrates without error (not committed).

--- a/sources/nofluffjobs.yml
+++ b/sources/nofluffjobs.yml
@@ -1,0 +1,6 @@
+# NoFluffJobs Polish/CEE IT job board. Boardless: one public API (nofluffjobs.com/api/posting),
+# so the entry carries no board; each job's company comes from the posting, not this placeholder.
+# Hydrating adapter — descriptions are fetched per new posting from /api/posting/<slug>; see
+# internal/sources/nofluffjobs.go.
+- company: NoFluffJobs
+  provider: nofluffjobs


### PR DESCRIPTION
## Summary
- Add a `nofluffjobs` source adapter for nofluffjobs.com (Polish/CEE IT board) — the complement to the existing `justjoin` adapter, using the same **HydratingSource** pattern.
- Stage 1: stream the keyless `/api/posting` listing (~60 MB single JSON, ~8 400 postings) via `GetStream` (past the size-capped `GetJSON`); map each posting to a `Job` with structured facets **from the listing** — `technology`→Skills (skilltag), `seniority`→Seniority (Mid→middle, Trainee→intern, Expert→principal), `posted` epoch-ms→PostedAt, `fullyRemote`→Remote, `location.places[0]`→Location.
- Stage 2 (`FetchNew`): the listing has no description, so `/api/posting/<slug>` is fetched **only for new postings** (seen-set predicate) and the description is assembled from `details.description`+`requirements.description`; already-ingested postings refresh liveness (`SeenRefresh`) with no detail request. Bounds steady-state detail fan-out to new postings.
- Boardless aggregator; drops postings with empty id/url/company. Registered; `sources/nofluffjobs.yml` added.

Sourced from the ever-jobs provider catalogue (`source-nofluffjobs`); third in the series after #867 (jobspresso) and #870 (arbeitsagentur).

## Test Plan
- [x] `go build ./... && go vet ./...` clean; `go test ./...` green
- [x] 6 new nofluffjobs tests: list mapping + drop rules, FetchNew hydrate-new-only + SeenRefresh + detail-error fallback, seniority mapping, registration, board-file validation
- [x] Live smoke (real client): listing streams 8 412 postings, fields+facets map, a new posting's detail description hydrates
- [ ] Deploy: add a `cmd/ingest sources/nofluffjobs.yml` cron schedule in freehire-ops (note first-run detail fan-out; enroll in proxiedProviders if rate-limited)