### PR TITLE
feat(web): company hiring-signal leaderboard page

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -99,6 +99,13 @@ export interface InsightSalaryBand {
   p50: number;
   p75: number;
 }
+export interface InsightCompany {
+  company_slug: string;
+  company_name: string;
+  open_now: number;
+  open_prev_30d: number;
+  growth_30d: number;
+}
 
 /** One posting in a role cluster — a single city's opening under a collapsed role
  *  (see the /jobs/:slug/copies endpoint). Each keeps its own location and apply URL. */
@@ -481,6 +488,19 @@ export function createApi(
     return requestData<InsightSalaryBand[]>(
       `/api/v1/insights/salary?category=${encodeURIComponent(category)}`,
     );
+  }
+
+  /** Company hiring-signal leaderboard: companies ranked by 30-day open-job growth
+   *  (`growth` ramping, `-growth` freezing) or `open` size. `minOpen` floors the
+   *  current open-count to blunt ingest-artifact spikes. */
+  async function insightsCompanies(
+    opts: { sort?: 'growth' | '-growth' | 'open'; minOpen?: number; limit?: number } = {},
+  ): Promise<InsightCompany[]> {
+    const q = new URLSearchParams();
+    if (opts.sort) q.set('sort', opts.sort);
+    if (opts.minOpen != null) q.set('min_open', String(opts.minOpen));
+    if (opts.limit != null) q.set('limit', String(opts.limit));
+    return requestData<InsightCompany[]>(`/api/v1/insights/companies?${q.toString()}`);
   }
 
   // --- Sitemap --------------------------------------------------------------
@@ -1086,6 +1106,7 @@ export function createApi(
     insightsRoles,
     insightsSkills,
     insightsSalaryByCategory,
+    insightsCompanies,
     sitemapJobs,
     sitemapCompanies,
     sitemapCompanyBoundaries,

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -20,6 +20,7 @@
       links: [
         { label: 'Blog', href: resolve('/blog') },
         { label: 'Insights', href: resolve('/insights') },
+        { label: 'Hiring signal', href: resolve('/insights/companies') },
         { label: 'Trends', href: resolve('/trends') },
         { label: 'CLI', href: resolve('/cli') },
         { label: 'ChatGPT', href: resolve('/chatgpt') },

--- a/web/src/routes/insights/+page.svelte
+++ b/web/src/routes/insights/+page.svelte
@@ -35,6 +35,17 @@
     also available on the <a href={resolve('/docs/api')} class="text-blue-600 hover:underline">open API</a>.
   </p>
 
+  <a
+    href={resolve('/insights/companies')}
+    class="mt-6 flex items-center justify-between rounded-lg border border-gray-200 p-4 hover:border-gray-300 hover:bg-gray-50"
+  >
+    <span>
+      <span class="text-lg font-semibold text-gray-900">Company hiring signal</span>
+      <span class="mt-0.5 block text-sm text-gray-500">Which companies are ramping up or slowing down hiring</span>
+    </span>
+    <span aria-hidden="true" class="text-gray-400">→</span>
+  </a>
+
   {#if data.covered.length === 0}
     <p class="mt-8 text-gray-500">Insights are being computed — check back shortly.</p>
   {:else}

--- a/web/src/routes/insights/companies/+page.server.ts
+++ b/web/src/routes/insights/companies/+page.server.ts
@@ -1,0 +1,16 @@
+import { serverApi } from '$lib/server/api';
+import type { PageServerLoad } from './$types';
+
+// The company hiring-signal leaderboard: which companies grew or shrank their number
+// of open jobs most over the last 30 days. Public, SSR-live with a CDN cache window
+// like the sibling insights pages. min_open floors out tiny boards so ingest-artifact
+// spikes don't dominate the ranking.
+export const load: PageServerLoad = async ({ fetch, setHeaders }) => {
+  const api = serverApi(fetch);
+  const [ramping, freezing] = await Promise.all([
+    api.insightsCompanies({ sort: 'growth', minOpen: 10, limit: 25 }),
+    api.insightsCompanies({ sort: '-growth', minOpen: 10, limit: 25 }),
+  ]);
+  setHeaders({ 'cache-control': 'public, max-age=0, s-maxage=3600' });
+  return { ramping, freezing };
+};

--- a/web/src/routes/insights/companies/+page.svelte
+++ b/web/src/routes/insights/companies/+page.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import Seo from '$lib/components/Seo.svelte';
+  import { breadcrumbJsonLd, datasetJsonLd, jsonLdScript } from '$lib/seo';
+  import type { InsightCompany } from '$lib/api';
+  import type { PageData } from './$types';
+
+  let { data }: { data: PageData } = $props();
+
+  const origin = $derived(page.url.origin);
+  const canonical = $derived(`${origin}/insights/companies`);
+  const title = 'Company Hiring Signal · freehire';
+  const description =
+    'Which companies are ramping up or slowing down hiring — ranked by the 30-day change in their number of open jobs across the freehire catalogue.';
+  const updated = $derived(
+    new Date().toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
+  );
+  const jsonLd = $derived(
+    jsonLdScript([
+      datasetJsonLd('Company hiring signal', description, canonical, origin),
+      breadcrumbJsonLd([
+        { name: 'freehire', url: `${origin}/` },
+        { name: 'Insights', url: `${origin}/insights` },
+        { name: 'Companies', url: canonical },
+      ]),
+    ]),
+  );
+</script>
+
+<Seo {title} {description} {canonical} />
+<svelte:head>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -- non-executable JSON-LD from jsonLdScript, which escapes `<` -->
+  {@html jsonLd}
+</svelte:head>
+
+{#snippet board(heading: string, blurb: string, rows: InsightCompany[])}
+  <section class="rounded-lg border border-gray-200 p-4 sm:p-5">
+    <h2 class="text-lg font-semibold text-gray-900">{heading}</h2>
+    <p class="mt-0.5 text-xs text-gray-500">{blurb}</p>
+    {#if rows.length === 0}
+      <p class="mt-4 text-sm text-gray-500">Not enough data yet.</p>
+    {:else}
+      <table class="mt-3 w-full border-collapse text-left text-sm">
+        <thead>
+          <tr class="border-b border-gray-300 text-gray-500">
+            <th class="py-2 pr-3 font-medium">Company</th>
+            <th class="py-2 pr-3 text-right font-medium">Open</th>
+            <th class="py-2 text-right font-medium">30-day</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each rows as c, i (c.company_slug)}
+            <tr class="border-b border-gray-100">
+              <td class="py-2 pr-3">
+                <span class="mr-1.5 tabular-nums text-gray-400">{i + 1}.</span>
+                <a
+                  href={resolve('/companies/[slug]', { slug: c.company_slug })}
+                  class="font-medium text-gray-900 hover:text-blue-600 hover:underline"
+                >
+                  {c.company_name}
+                </a>
+              </td>
+              <td class="py-2 pr-3 text-right tabular-nums text-gray-700">
+                {c.open_now.toLocaleString('en-US')}
+              </td>
+              <td
+                class="py-2 text-right font-medium tabular-nums"
+                class:text-green-600={c.growth_30d > 0}
+                class:text-gray-400={c.growth_30d === 0}
+                class:text-red-600={c.growth_30d < 0}
+              >
+                {c.growth_30d > 0 ? '+' : ''}{c.growth_30d.toLocaleString('en-US')}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    {/if}
+  </section>
+{/snippet}
+
+<div class="mx-auto w-full max-w-4xl px-4 py-8">
+  <nav class="text-sm text-gray-500">
+    <a href={resolve('/insights')} class="hover:underline">Insights</a>
+    <span class="mx-1">/</span>
+    <span class="text-gray-700">Companies</span>
+  </nav>
+
+  <h1 class="mt-3 text-3xl font-bold tracking-tight text-gray-900">Company Hiring Signal</h1>
+  <p class="mt-3 text-lg text-gray-600">{description}</p>
+  <p class="mt-1 text-sm text-gray-500">
+    Change is the difference between open jobs now and 30 days ago. Refreshed daily; also on the
+    <a href={resolve('/docs/api')} class="text-blue-600 hover:underline">open API</a>.
+    <span class="text-gray-400">Updated {updated}.</span>
+  </p>
+
+  <div class="mt-8 grid gap-4 md:grid-cols-2">
+    {@render board('Ramping up', 'Biggest 30-day increase in open jobs', data.ramping)}
+    {@render board('Slowing down', 'Biggest 30-day decrease in open jobs', data.freezing)}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Adds public SSR page `/insights/companies` — a "who's ramping up / slowing down hiring" leaderboard over the new `GET /api/v1/insights/companies` endpoint (#871). Two boards, company names linking to their pages, 30-day change coloured green/red.
- Linked from the `/insights` hub (featured card) and the footer (Resources → "Hiring signal").
- Adds `insightsCompanies()` to the web API client.

Follow-up to #871.

## Test Plan
- [x] `svelte-check` clean (0 errors)
- [x] SSR renders live prod data — 50 companies, both boards, real names (verified via dev server pointed at prod API + screenshot)
- [ ] Deploy: web-only (no Go/migration) — ships on the next `release.sh` flip