### PR TITLE
fix(sources): collapse case-variant board duplicates at config load

### DIFF
--- a/internal/sources/config.go
+++ b/internal/sources/config.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,7 +43,41 @@ func ParseConfig(provider string, data []byte) (Config, error) {
 			entries[i].Provider = provider
 		}
 	}
+	entries = dedupeBoards(entries)
 	return Config{Provider: provider, Sources: entries}, nil
+}
+
+// dedupeBoards collapses entries that address the same case-insensitive board on the same
+// provider and region, keeping the first occurrence. ATS board ids are case-insensitive at
+// the platform (e.g. SmartRecruiters serves the same tenant for "SopraSteria1" and
+// "soprasteria1"), but the pipeline namespaces external_id with the literal board string
+// (see NamespaceExternalID), so a case-variant duplicate crawls identical postings yet
+// stores them as a SECOND row-set under a different namespace but the SAME company_slug.
+// The post-run unseen sweep is scoped by company_slug (not board), so whenever a run
+// refreshes one variant but not the other, it closes the un-refreshed variant's still-live
+// rows — a false-close. Collapsing here at load time keeps one row-set per board.
+//
+// Only board-bearing entries dedupe: a boardless entry (empty board) has no tenant id and
+// is its own company, so an empty board is never a dedupe key. Region is part of the key so
+// a same-name board on two regional hosts (a real, distinct crawl target) is preserved.
+func dedupeBoards(entries []CompanyEntry) []CompanyEntry {
+	seen := make(map[string]struct{}, len(entries))
+	kept := make([]CompanyEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.Board == "" {
+			kept = append(kept, e)
+			continue
+		}
+		key := e.Provider + "\x00" + strings.ToLower(e.Board) + "\x00" + e.Region
+		if _, dup := seen[key]; dup {
+			log.Printf("sources: dropping duplicate board %q (provider %s, company %q) — case-variant of an earlier entry",
+				e.Board, e.Provider, e.Company)
+			continue
+		}
+		seen[key] = struct{}{}
+		kept = append(kept, e)
+	}
+	return kept
 }
 
 // Validate checks every entry against the registry by its own resolved provider, so the

--- a/internal/sources/config_test.go
+++ b/internal/sources/config_test.go
@@ -31,6 +31,76 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
+// Two entries whose board ids differ only by case address the same case-insensitive ATS
+// tenant, so they crawl identical postings but namespace external_id differently — one
+// posting becomes two rows under the same company_slug, and the post-run unseen sweep
+// (scoped by company_slug) closes whichever side a run failed to refresh. ParseConfig
+// collapses such entries to the first occurrence so only one row-set is ever created.
+func TestParseConfigDropsCaseInsensitiveBoardDuplicates(t *testing.T) {
+	data := []byte(`
+- company: SopraSteria1
+  board: SopraSteria1
+- company: Stripe
+  board: stripe
+- company: soprasteria1
+  board: soprasteria1
+`)
+	cfg, err := ParseConfig("smartrecruiters", data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	want := []CompanyEntry{
+		{Company: "SopraSteria1", Provider: "smartrecruiters", Board: "SopraSteria1"}, // first wins
+		{Company: "Stripe", Provider: "smartrecruiters", Board: "stripe"},
+	}
+	if len(cfg.Sources) != len(want) {
+		t.Fatalf("len(Sources) = %d, want %d: %+v", len(cfg.Sources), len(want), cfg.Sources)
+	}
+	for i, w := range want {
+		if cfg.Sources[i] != w {
+			t.Errorf("Sources[%d] = %+v, want %+v", i, cfg.Sources[i], w)
+		}
+	}
+}
+
+// A same-name board on two different regional hosts (distinct Region) is a genuinely
+// different crawl target, not a case duplicate, so both are kept.
+func TestParseConfigKeepsSameBoardOnDifferentRegions(t *testing.T) {
+	data := []byte(`
+- company: Acme
+  board: acme
+  region: us
+- company: Acme
+  board: acme
+  region: eu
+`)
+	cfg, err := ParseConfig("lever", data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(cfg.Sources) != 2 {
+		t.Fatalf("len(Sources) = %d, want 2 (region variants kept): %+v", len(cfg.Sources), cfg.Sources)
+	}
+}
+
+// Boardless entries carry no board id, so they must never collapse together on an empty
+// board key — each is its own company.
+func TestParseConfigKeepsBoardlessEntries(t *testing.T) {
+	data := []byte(`
+- company: VK
+  provider: vk
+- company: Ozon
+  provider: ozon
+`)
+	cfg, err := ParseConfig("custom", data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if len(cfg.Sources) != 2 {
+		t.Fatalf("len(Sources) = %d, want 2 (boardless entries kept): %+v", len(cfg.Sources), cfg.Sources)
+	}
+}
+
 // LoadConfig takes the provider from the file name, so the board file never repeats
 // it per entry.
 func TestLoadConfigInfersProviderFromFilename(t *testing.T) {


### PR DESCRIPTION
## Problem

A genuinely-open SmartRecruiters posting showed as **closed** on the site
(e.g. `openshift-module-lead-soprasteria1-eanpf4ij`), while an identical
open copy existed under a different slug (`…-z6zhgujo`).

Root cause: `sources/smartrecruiters.yml` lists the same company twice with
board ids differing only by case:

```yaml
- company: SopraSteria1
  board: SopraSteria1
- company: soprasteria1
  board: soprasteria1
```

SmartRecruiters' API is case-insensitive (both boards return the same 1983
postings), but the pipeline namespaces `external_id` with the **literal**
board string (`NamespaceExternalID` → `board:id`), so one posting is stored
as **two rows** under different namespaces but the **same `company_slug`**.

The post-run unseen sweep (`CloseUnseenJobs`) is scoped by `company_slug`,
not by board/external_id. Whenever a run refreshes one variant's rows but
not the other's (a one-sided fetch failure or board_health cooldown — and
one company means ~4000 detail fetches across two boards), the un-refreshed
variant goes stale and the sweep closes its **still-live** rows. A false
close.

## Fix

`ParseConfig` now collapses entries sharing `(provider, lower(board),
region)` to the first occurrence, logging each dropped board. Boardless
entries (empty board) and same-name boards on distinct regional hosts are
preserved. Provider-agnostic; does not touch the `external_id` scheme.

Self-healing: the surviving entry keeps crawling and reopens its row via
upsert; the dropped duplicate's row goes stale and closes — net exactly one
open row per posting.

## Scale

~324 duplicate entries collapse across providers: smartrecruiters 208,
ashby 72, trakstar 29, paycom 9, workday 3, plus a few singletons — every
one a latent false-close.

## Tests

- `TestParseConfigDropsCaseInsensitiveBoardDuplicates`
- `TestParseConfigKeepsSameBoardOnDifferentRegions`
- `TestParseConfigKeepsBoardlessEntries`

`go test ./internal/sources/` green; `go vet` / `go build ./...` clean.