### PR TITLE
feat(sources): arbeitsagentur derives remote/work-mode from homeofficemoeglich

### DIFF
--- a/internal/sources/arbeitsagentur.go
+++ b/internal/sources/arbeitsagentur.go
@@ -69,11 +69,20 @@ type arbeitsagenturOrt struct {
 	Land   string `json:"land"`
 }
 
-// arbeitsagenturDetail decodes the description out of the jobdetail page's ng-state JSON blob.
+// arbeitsagenturDetail decodes the fields the adapter needs out of the jobdetail page's ng-state
+// JSON blob: the description and the per-job home-office flag.
 type arbeitsagenturDetail struct {
 	Jobdetail struct {
-		Beschreibung string `json:"stellenangebotsBeschreibung"`
+		Beschreibung       string `json:"stellenangebotsBeschreibung"`
+		Homeofficemoeglich bool   `json:"homeofficemoeglich"`
 	} `json:"jobdetail"`
+}
+
+// description is the sanitized posting body. The Stellenbeschreibung is plain text (newline
+// paragraphs, no markup), so it goes through plainTextToHTML — as djinni/lumenalta do — to rebuild
+// paragraph structure rather than collapsing into one block when rendered.
+func (d arbeitsagenturDetail) description() string {
+	return sanitizeHTML(plainTextToHTML(d.Jobdetail.Beschreibung))
 }
 
 func (a arbeitsagentur) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
@@ -111,36 +120,37 @@ func (arbeitsagentur) searchURL(berufsfeld string, page int) string {
 
 func (a arbeitsagentur) toJob(ctx context.Context, p arbeitsagenturPosting) Job {
 	detailURL := arbeitsagenturDetailURL + p.Refnr
+	d := a.detail(ctx, detailURL)
 	return Job{
 		ExternalID:  p.Refnr,
 		URL:         detailURL,
 		Title:       strings.TrimSpace(p.Titel),
 		Company:     strings.TrimSpace(p.Arbeitgeber),
 		Location:    arbeitsagenturLocation(p.Arbeitsort),
-		Description: a.description(ctx, detailURL),
+		Description: d.description(),
+		Remote:      d.Jobdetail.Homeofficemoeglich,
+		WorkMode:    workModeFromRemote(d.Jobdetail.Homeofficemoeglich),
 		PostedAt:    arbeitsagenturDate(p.Datum),
 	}
 }
 
-// description scrapes the SSR jobdetail page's ng-state JSON for the Stellenbeschreibung. Any
-// failure (fetch error, no ng-state block, bad JSON) yields an empty description rather than an
-// error — the posting is still worth emitting. The Stellenbeschreibung is plain text (newline
-// paragraphs, no markup), so it goes through plainTextToHTML — as djinni/lumenalta do — to rebuild
-// paragraph structure rather than collapsing into one block when rendered.
-func (a arbeitsagentur) description(ctx context.Context, detailURL string) string {
+// detail scrapes and decodes the SSR jobdetail page's ng-state JSON. Any failure (fetch error, no
+// ng-state block, bad JSON) yields the zero detail rather than an error — the posting is still worth
+// emitting, just without a description or the home-office flag.
+func (a arbeitsagentur) detail(ctx context.Context, detailURL string) arbeitsagenturDetail {
 	root, err := a.http.GetHTML(ctx, detailURL)
 	if err != nil {
-		return ""
+		return arbeitsagenturDetail{}
 	}
 	blob := scriptTextByID(root, "ng-state")
 	if blob == "" {
-		return ""
+		return arbeitsagenturDetail{}
 	}
 	var d arbeitsagenturDetail
 	if err := json.Unmarshal([]byte(blob), &d); err != nil {
-		return ""
+		return arbeitsagenturDetail{}
 	}
-	return sanitizeHTML(plainTextToHTML(d.Jobdetail.Beschreibung))
+	return d
 }
 
 // arbeitsagenturLocation joins the non-empty parts of an arbeitsort, dropping the literal "null"

--- a/internal/sources/arbeitsagentur_test.go
+++ b/internal/sources/arbeitsagentur_test.go
@@ -48,10 +48,11 @@ func (f *arbeitsagenturFake) GetHTML(_ context.Context, u string) (*html.Node, e
 	return html.Parse(strings.NewReader(f.detailByRef[ref]))
 }
 
-// detailHTML wraps an ng-state script carrying the given description, mirroring the real SSR page.
-func detailHTML(desc string) string {
+// detailHTML wraps an ng-state script carrying the given description and home-office flag,
+// mirroring the real SSR page.
+func detailHTML(desc string, homeOffice bool) string {
 	return `<html><body><script id="ng-state" type="application/json">{"jobdetail":{"stellenangebotsBeschreibung":` +
-		strconv.Quote(desc) + `}}</script></body></html>`
+		strconv.Quote(desc) + `,"homeofficemoeglich":` + strconv.FormatBool(homeOffice) + `}}</script></body></html>`
 }
 
 func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
@@ -63,8 +64,8 @@ func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
 	fake := &arbeitsagenturFake{
 		searchByPage: map[int]string{1: page1},
 		detailByRef: map[string]string{
-			"20177-44320844-717-S": detailHTML("Bei Boehringer Ingelheim entwickeln wir <b>bahnbrechende</b> Therapien."),
-			"AC-2":                 detailHTML("Wir suchen einen DevOps Engineer."),
+			"20177-44320844-717-S": detailHTML("Bei Boehringer Ingelheim entwickeln wir <b>bahnbrechende</b> Therapien.", true),
+			"AC-2":                 detailHTML("Wir suchen einen DevOps Engineer.", false),
 		},
 	}
 	jobs, err := NewArbeitsagentur(fake).Fetch(context.Background(), CompanyEntry{
@@ -101,6 +102,13 @@ func TestArbeitsagenturFetchMapsFirstPartyAndDropsExterne(t *testing.T) {
 	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-18" {
 		t.Errorf("PostedAt = %v, want 2026-07-18", j.PostedAt)
 	}
+	// homeofficemoeglich:true → remote; the non-home-office posting stays unset.
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("home-office job: Remote=%v WorkMode=%q, want true/remote", j.Remote, j.WorkMode)
+	}
+	if ac := byID["AC-2"]; ac.Remote || ac.WorkMode != "" {
+		t.Errorf("non-home-office job AC-2: Remote=%v WorkMode=%q, want false/empty", ac.Remote, ac.WorkMode)
+	}
 }
 
 func TestArbeitsagenturScrapesDescription(t *testing.T) {
@@ -113,7 +121,7 @@ func TestArbeitsagenturScrapesDescription(t *testing.T) {
 		searchByPage: map[int]string{1: page1},
 		detailByRef: map[string]string{
 			// The real Stellenbeschreibung is plain text with newline paragraphs, no markup.
-			"OK-1":     detailHTML("Bei uns arbeitest du remote.\n\nZweiter Absatz mit Details."),
+			"OK-1":     detailHTML("Bei uns arbeitest du remote.\n\nZweiter Absatz mit Details.", false),
 			"NODESC-2": `<html><body><p>no ng-state here</p></body></html>`,
 		},
 		detailErr: map[string]bool{"ERR-3": true},
@@ -139,6 +147,10 @@ func TestArbeitsagenturScrapesDescription(t *testing.T) {
 	}
 	if d := byID["ERR-3"].Description; d != "" {
 		t.Errorf("ERR-3 description = %q, want empty (detail fetch failed)", d)
+	}
+	// A failed/blockless detail leaves the remote flag unset.
+	if byID["ERR-3"].Remote || byID["NODESC-2"].Remote {
+		t.Error("postings with no usable detail should not be marked remote")
 	}
 }
 

--- a/openspec/changes/arbeitsagentur-workmode/.openspec.yaml
+++ b/openspec/changes/arbeitsagentur-workmode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/arbeitsagentur-workmode/design.md
+++ b/openspec/changes/arbeitsagentur-workmode/design.md
@@ -1,0 +1,30 @@
+## Context
+
+A spike confirmed the per-job remote signal is NOT in the search listing (the `homeoffice` facet is
+aggregate-only), but the detail page's `ng-state` JSON carries `jobdetail.homeofficemoeglich`
+(boolean) alongside the `stellenangebotsBeschreibung` the adapter already reads. Sampled remote
+postings return `homeofficemoeglich: true` with `homeofficetyp: "NACH_VEREINBARUNG"`.
+
+## Decisions
+
+- **Map the boolean home-office flag through `workModeFromRemote`.** `homeofficemoeglich: true` →
+  `Remote: true`, `WorkMode: "remote"`; `false`/absent → left unset. This mirrors `apple.go`, which
+  maps its own `HomeOffice` boolean the same way, so the codebase already treats a home-office flag
+  as "remote". *Alternative rejected:* mapping `homeofficetyp` to `hybrid` vs `remote` — the type is
+  overwhelmingly `NACH_VEREINBARUNG` (by arrangement) and adds a bespoke sub-map for no filter-level
+  benefit; the boolean is the signal users filter on.
+
+- **Reuse the existing detail fetch.** The description already parses `ng-state`; the detail struct
+  gains one field (`homeofficemoeglich`) and `toJob` sets remote/work mode from the same parse. No
+  extra request, no new failure mode — a failed detail still yields the posting (now simply without
+  the remote flag, as before it lacked a description).
+
+## Risks / Trade-offs
+
+- **"By arrangement" ≠ fully remote.** Flagging it `remote` is slightly generous, but matches the
+  apple precedent and the user intent (home-office-possible German jobs should be findable under the
+  remote filter). Accepted.
+
+## Migration Plan
+
+- No DB migration, no API change. A re-crawl re-derives the flag for existing arbeitsagentur rows.

--- a/openspec/changes/arbeitsagentur-workmode/proposal.md
+++ b/openspec/changes/arbeitsagentur-workmode/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The `arbeitsagentur` adapter never sets a work mode, so its German postings show 0% work-mode
+coverage and none surface under the remote filter until (if ever) enrichment fills it. The detail
+page's `ng-state` JSON — already fetched for the description — carries a per-job
+`jobdetail.homeofficemoeglich` boolean, so the remote signal is available for free.
+
+## What Changes
+
+- Read `jobdetail.homeofficemoeglich` from the same detail `ng-state` blob the adapter already
+  parses for the description, and set `Remote` + `WorkMode` from it via the existing
+  `workModeFromRemote` helper (`true` → remote, `false` → unset) — the same mapping `apple` uses
+  for its home-office flag.
+- No extra request: the flag rides the detail fetch that already happens per kept posting.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `arbeitsagentur-source`: the job-mapping requirement now also derives the job's remote flag and
+  work mode from the detail page's `homeofficemoeglich`.
+
+## Impact
+
+- **Touched code:** `internal/sources/arbeitsagentur.go` (+ `_test.go`) — the detail struct gains
+  one field and `toJob` sets remote/work mode.
+- **No migrations, no API changes, no new dependencies, no new requests.**

--- a/openspec/changes/arbeitsagentur-workmode/specs/arbeitsagentur-source/spec.md
+++ b/openspec/changes/arbeitsagentur-workmode/specs/arbeitsagentur-source/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Arbeitsagentur maps a first-party posting to a Job with a scraped description
+
+For each kept posting the adapter SHALL fetch the server-rendered detail page
+`https://www.arbeitsagentur.de/jobsuche/jobdetail/<refnr>` and map the posting to a normalized `Job`
+carrying `refnr` as its `ExternalID`, the detail page URL as its canonical URL, `titel` as its title,
+`arbeitgeber` as its company, the `arbeitsort` (`ort`, `region`, `land`) as its location,
+`aktuelleVeroeffentlichungsdatum` as its posted-at, and the detail page's `Stellenbeschreibung` (or,
+when that block is absent, the page's meta-description summary) as its sanitized description.
+
+The adapter SHALL also read the detail page's `jobdetail.homeofficemoeglich` boolean from the same
+`ng-state` payload and set the `Job`'s remote flag and work mode from it: `true` marks the job remote
+with work mode `remote`; `false` or absent leaves both unset. No additional request is made — the
+flag is taken from the detail fetch that already supplies the description.
+
+A detail-page fetch that fails or yields no description SHALL NOT drop the posting — it is emitted with
+an empty description (and no remote flag) — and a single failed page SHALL NOT abort the crawl.
+
+#### Scenario: A first-party posting maps to a job
+
+- **WHEN** the adapter keeps a first-party posting and fetches its detail page
+- **THEN** it yields one `Job` with `ExternalID` set to `refnr`, the jobdetail page as the URL, the
+  title, company `arbeitgeber`, the `arbeitsort` location, the publish date, and the scraped
+  `Stellenbeschreibung` as the description
+
+#### Scenario: A home-office posting is marked remote
+
+- **WHEN** a kept posting's detail page reports `homeofficemoeglich: true`
+- **THEN** the mapped `Job` has `Remote: true` and work mode `remote`
+
+#### Scenario: A non-home-office posting is not marked remote
+
+- **WHEN** a kept posting's detail page reports `homeofficemoeglich: false` or omits it
+- **THEN** the mapped `Job` leaves the remote flag and work mode unset
+
+#### Scenario: A posting whose detail page yields no description is still emitted
+
+- **WHEN** a kept posting's detail page fetch fails or carries no description block
+- **THEN** the adapter still yields the `Job` (with an empty description and no remote flag) and
+  continues the crawl

--- a/openspec/changes/arbeitsagentur-workmode/tasks.md
+++ b/openspec/changes/arbeitsagentur-workmode/tasks.md
@@ -1,15 +1,15 @@
 ## 1. Derive remote/work-mode from homeofficemoeglich
 
-- [ ] 1.1 Update `internal/sources/arbeitsagentur_test.go`: extend the detail fixture(s) with
+- [x] 1.1 Update `internal/sources/arbeitsagentur_test.go`: extend the detail fixture(s) with
   `jobdetail.homeofficemoeglich` and assert a `true` posting maps to `Remote: true` + work mode
   `remote`, a `false`/absent posting leaves both unset, and a failed/empty detail still emits the
   posting with no remote flag (RED).
-- [ ] 1.2 Update `internal/sources/arbeitsagentur.go`: add `Homeofficemoeglich bool` to the detail
+- [x] 1.2 Update `internal/sources/arbeitsagentur.go`: add `Homeofficemoeglich bool` to the detail
   struct, have the detail parse return it, and set `Remote` + `WorkMode` in `toJob` via
   `workModeFromRemote`. Make 1.1 green.
 
 ## 2. Verify
 
-- [ ] 2.1 `gofmt`, `go build ./... && go vet ./...`, `go test ./internal/sources/` green; then a
+- [x] 2.1 `gofmt`, `go build ./... && go vet ./...`, `go test ./internal/sources/` green; then a
   throwaway live check that a real `homeofficemoeglich: true` arbeitsagentur posting maps to remote
   (not committed).

--- a/openspec/changes/arbeitsagentur-workmode/tasks.md
+++ b/openspec/changes/arbeitsagentur-workmode/tasks.md
@@ -1,0 +1,15 @@
+## 1. Derive remote/work-mode from homeofficemoeglich
+
+- [ ] 1.1 Update `internal/sources/arbeitsagentur_test.go`: extend the detail fixture(s) with
+  `jobdetail.homeofficemoeglich` and assert a `true` posting maps to `Remote: true` + work mode
+  `remote`, a `false`/absent posting leaves both unset, and a failed/empty detail still emits the
+  posting with no remote flag (RED).
+- [ ] 1.2 Update `internal/sources/arbeitsagentur.go`: add `Homeofficemoeglich bool` to the detail
+  struct, have the detail parse return it, and set `Remote` + `WorkMode` in `toJob` via
+  `workModeFromRemote`. Make 1.1 green.
+
+## 2. Verify
+
+- [ ] 2.1 `gofmt`, `go build ./... && go vet ./...`, `go test ./internal/sources/` green; then a
+  throwaway live check that a real `homeofficemoeglich: true` arbeitsagentur posting maps to remote
+  (not committed).


### PR DESCRIPTION
## Summary
Follow-up to #870 closing the gap surfaced in the post-deploy spot-check: arbeitsagentur postings had **0% work-mode coverage** — no German remote jobs surfaced under the remote filter.

- Read `jobdetail.homeofficemoeglich` (boolean) from the **same** detail-page `ng-state` JSON already parsed for the description, and set `Remote` + `WorkMode` via the existing `workModeFromRemote` helper (`true` → remote) — the same mapping `apple.go` uses for its home-office flag.
- No extra request: the flag rides the detail fetch that already runs per kept posting. A failed/blockless detail still emits the posting (now simply without the remote flag).

## Test Plan
- [x] `go build ./... && go vet ./...` clean; `go test ./...` green
- [x] Unit: home-office posting → `Remote: true` + `remote`; non-home-office → unset; failed detail → unset
- [x] Live spike confirmed `homeofficemoeglich: true` rides the ng-state for `homeoffice=nv_true` postings
- Existing arbeitsagentur rows pick up the flag on the next hourly re-crawl.