### PR TITLE
fix(sources): render EPAM descriptions in full (structure + benefits)

### DIFF
--- a/internal/sources/epam.go
+++ b/internal/sources/epam.go
@@ -2,8 +2,10 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"golang.org/x/net/html"
 )
@@ -70,13 +72,20 @@ func (e epam) detail(ctx context.Context, ce CompanyEntry, jobURL string) (Job, 
 	if remote {
 		workMode = "remote"
 	}
+	// The ld+json description is a flattened, structure-less blob (headings and bullet lists
+	// collapsed into one run of text, benefits dropped). The page's __NEXT_DATA__ carries the
+	// same content as structured sections, so prefer it and keep the ld+json as the fallback.
+	description := sanitizeHTML(html.UnescapeString(p.Description))
+	if structured := epamStructuredDescription(root); structured != "" {
+		description = structured
+	}
 	return Job{
 		ExternalID:  id,
 		URL:         jobURL,
 		Title:       p.Title,
 		Company:     ce.Company,
 		Location:    location,
-		Description: sanitizeHTML(html.UnescapeString(p.Description)),
+		Description: description,
 		Remote:      remote || isRemote(location),
 		WorkMode:    workMode,
 		PostedAt:    parseDate(p.DatePosted),
@@ -117,4 +126,97 @@ func (p epamPosting) location() string {
 		names = append(names, c.Name)
 	}
 	return joinNonEmpty(names...)
+}
+
+// epamNextData is the slice of the vacancy page's __NEXT_DATA__ payload we read: the job's
+// structured description. Only the fields we render are modelled; encoding/json ignores the
+// rest, and absent/null fields decode to their zero value.
+type epamNextData struct {
+	Props struct {
+		PageProps struct {
+			Job epamJob `json:"job"`
+		} `json:"pageProps"`
+	} `json:"props"`
+}
+
+// epamJob is the structured description EPAM flattens away in its ld+json: an HTML intro, the
+// three bullet-list categories, and the benefits blocks (already HTML). The category also
+// exposes about_the_project/about_the_customer/technologies, but those are null across every
+// sampled vacancy, so they are left as a seam rather than modelled speculatively.
+type epamJob struct {
+	Description string `json:"description"` // intro, already HTML
+	Category    struct {
+		Responsibilities []string `json:"responsibilities"`
+		Requirements     []string `json:"requirements"`
+		NiceToHave       []string `json:"nice_to_have"`
+	} `json:"category"`
+	Benefits []struct {
+		Content string `json:"content"` // already HTML (<ul><li>…</li></ul>)
+	} `json:"benefits"`
+}
+
+// epamStructuredDescription reconstructs a structured HTML description from the page's
+// __NEXT_DATA__ payload, returning "" when the script is absent, unparseable, or carries no
+// description content — so the caller falls back to the flat ld+json description.
+func epamStructuredDescription(root *html.Node) string {
+	raw := scriptTextByID(root, "__NEXT_DATA__")
+	if raw == "" {
+		return ""
+	}
+	var data epamNextData
+	if json.Unmarshal([]byte(raw), &data) != nil {
+		return ""
+	}
+	return sanitizeHTML(data.Props.PageProps.Job.descriptionHTML())
+}
+
+// descriptionHTML assembles the intro, the three bullet-list sections, and the benefits into a
+// single HTML document ready for sanitizing. Empty sections are skipped so a job that omits,
+// say, "Nice to have" carries no dangling heading.
+func (j epamJob) descriptionHTML() string {
+	var b strings.Builder
+	b.WriteString(j.Description)
+	epamListSection(&b, "Responsibilities", j.Category.Responsibilities)
+	epamListSection(&b, "Requirements", j.Category.Requirements)
+	epamListSection(&b, "Nice to have", j.Category.NiceToHave)
+
+	var benefits strings.Builder
+	for _, ben := range j.Benefits {
+		if strings.TrimSpace(ben.Content) != "" {
+			benefits.WriteString(ben.Content)
+		}
+	}
+	if benefits.Len() > 0 {
+		b.WriteString("<h3>Benefits</h3>")
+		b.WriteString(benefits.String())
+	}
+	return b.String()
+}
+
+// epamSectionLabels are the section headings EPAM's data occasionally leaks as the last bullet
+// of the preceding list; such items are dropped so they don't render as stray one-word bullets.
+var epamSectionLabels = map[string]bool{
+	"responsibilities": true,
+	"requirements":     true,
+	"nice to have":     true,
+	"benefits":         true,
+}
+
+// epamListSection appends a "<h3>title</h3><ul><li>…</li></ul>" block for the non-empty items,
+// or nothing when every item is blank. Items that are just a leaked section heading are skipped.
+func epamListSection(b *strings.Builder, title string, items []string) {
+	var lis strings.Builder
+	for _, it := range items {
+		s := strings.TrimSpace(it)
+		if s == "" || epamSectionLabels[strings.ToLower(s)] {
+			continue
+		}
+		lis.WriteString("<li>" + s + "</li>")
+	}
+	if lis.Len() == 0 {
+		return
+	}
+	b.WriteString("<h3>" + title + "</h3><ul>")
+	b.WriteString(lis.String())
+	b.WriteString("</ul>")
 }

--- a/internal/sources/epam_test.go
+++ b/internal/sources/epam_test.go
@@ -2,10 +2,35 @@ package sources
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 )
+
+// epamNextDataScript builds the __NEXT_DATA__ script EPAM's vacancy pages embed, carrying the
+// structured description slices (intro HTML, category bullet arrays, benefits HTML) that the
+// flattened ld+json description drops. Marshaled via encoding/json so the fixture cannot drift
+// from valid JSON.
+func epamNextDataScript(intro string, resp, req, nice []string, benefitsHTML string) string {
+	payload := map[string]any{
+		"props": map[string]any{
+			"pageProps": map[string]any{
+				"job": map[string]any{
+					"description": intro,
+					"category": map[string]any{
+						"responsibilities": resp,
+						"requirements":     req,
+						"nice_to_have":     nice,
+					},
+					"benefits": []map[string]any{{"content": benefitsHTML}},
+				},
+			},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	return `<script id="__NEXT_DATA__" type="application/json">` + string(b) + `</script>`
+}
 
 // epamSitemapXML builds the (gzip-decoded) sitemap urlset linking the given <loc> URLs.
 func epamSitemapXML(locs ...string) string {
@@ -109,6 +134,67 @@ func TestEPAMFetchSitemapThenDetailAndMaps(t *testing.T) {
 	}
 	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 6, 18, 0, 0, 0, 0, time.UTC)) {
 		t.Errorf("PostedAt = %v, want 2026-06-18", j.PostedAt)
+	}
+}
+
+func TestEPAMDescriptionFromNextDataStructured(t *testing.T) {
+	jobURL := "https://careers.epam.com/en/vacancy/senior-full-stack-developer-bltx6xf2xw5owhbw1rh_en"
+	nd := epamNextDataScript(
+		"<p>We are seeking a talented <strong>Senior Full Stack Developer</strong>.</p>",
+		[]string{"Design and maintain backend services", "Build user interfaces with React"},
+		[]string{"At least 3 years of experience"},
+		[]string{"Experience with Docker and Kubernetes"},
+		"<ul><li>International projects with top brands</li><li>Healthcare benefits</li></ul>",
+	)
+	// The ld+json still carries the flat, structure-less blob EPAM emits; the adapter must
+	// prefer the structured __NEXT_DATA__ payload over it.
+	detail := strings.Replace(
+		epamDetailHTML("Senior Full Stack Developer",
+			"Flat blob Responsibilities Design and maintain Requirements At least 3",
+			"2026-07-16", "TELECOMMUTE", "Argentina"),
+		"</body>", nd+"</body>", 1)
+	fake := (&routedHTTP{}).
+		route("sitemap.xml.gz", epamSitemapXML(jobURL)).
+		route("/en/vacancy/senior-full-stack-developer-bltx6xf2xw5owhbw1rh_en", detail)
+
+	jobs, err := NewEPAM(fake).Fetch(context.Background(), CompanyEntry{Company: "EPAM Systems", Board: "careers.epam.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	d := jobs[0].Description
+	for _, want := range []string{
+		"<strong>Senior Full Stack Developer</strong>", // intro HTML preserved
+		"<h3>Responsibilities</h3>",
+		"<li>Build user interfaces with React</li>",
+		"<h3>Requirements</h3>",
+		"<h3>Nice to have</h3>",
+		"<li>Experience with Docker and Kubernetes</li>",
+		"Healthcare benefits", // benefits section recovered (absent from ld+json)
+	} {
+		if !strings.Contains(d, want) {
+			t.Errorf("Description missing %q\n got: %s", want, d)
+		}
+	}
+	if strings.Contains(d, "Flat blob") {
+		t.Errorf("Description used flat ld+json blob instead of structured __NEXT_DATA__: %s", d)
+	}
+}
+
+func TestEPAMDescriptionDropsLeakedSectionLabels(t *testing.T) {
+	// EPAM's own data leaks the next section's heading as the last bullet of the previous
+	// list (the artifact that also duplicates "Requirements Requirements" in the ld+json).
+	j := epamJob{}
+	j.Category.Responsibilities = []string{"Build services", "Requirements"}
+	j.Category.Requirements = []string{"3 years experience", "Nice to have"}
+	d := j.descriptionHTML()
+	if strings.Contains(d, "<li>Requirements</li>") || strings.Contains(d, "<li>Nice to have</li>") {
+		t.Errorf("leaked section label rendered as a bullet: %s", d)
+	}
+	if !strings.Contains(d, "<li>Build services</li>") || !strings.Contains(d, "<li>3 years experience</li>") {
+		t.Errorf("dropped a real bullet: %s", d)
 	}
 }
 

--- a/web/src/posts/2026-07-18-epam-job-descriptions.svx
+++ b/web/src/posts/2026-07-18-epam-job-descriptions.svx
@@ -1,0 +1,21 @@
+---
+title: EPAM job descriptions now render in full
+date: 2026-07-18
+summary: EPAM postings now keep their headings, bullet lists, and benefits section instead of collapsing into one wall of text.
+type: changelog
+tags:
+  - sources
+draft: false
+---
+
+EPAM job posts used to arrive as a single unbroken paragraph — responsibilities,
+requirements, and nice-to-haves all run together, with the benefits section
+missing entirely. That was an artifact of the structured data EPAM exposes for
+search engines, which flattens the real layout.
+
+We now read the page's full structured content instead, so each EPAM posting
+shows its **Responsibilities**, **Requirements**, **Nice to have**, and
+**Benefits** as proper headings and lists — matching what you'd see on EPAM's own
+careers site.
+
+[Browse EPAM roles](/companies/epam-systems) to see the difference.


### PR DESCRIPTION
## Problem

EPAM job pages on freehire rendered as a single wall of text — `Responsibilities`, `Requirements`, and `Nice to have` all run together, the `Benefits` section missing entirely, and `Requirements` duplicated.

Root cause: the adapter read the description from EPAM's schema.org `ld+json`, but EPAM flattens that field to structure-less plain text (and omits benefits). It ≠ what the page actually renders.

Example: https://freehire.dev/jobs/senior-full-stack-developer-epam-systems-36eqh5bt

## Fix

Read the vacancy page's `__NEXT_DATA__` payload instead, which carries the live structured content, and reassemble a proper HTML description:

- intro (already HTML)
- `<h3>Responsibilities</h3>` / `Requirements` / `Nice to have` → `<ul><li>` from `category.*`
- `<h3>Benefits</h3>` from `benefits[].content` — **recovers a whole section we dropped before**
- drop section headings EPAM leaks as stray one-word bullets (the artifact behind `Requirements Requirements`)

Falls back to the old `ld+json` description when `__NEXT_DATA__` is absent, so the change is additive. `about_the_project` / `about_the_customer` / `technologies` are `null` across every sampled vacancy, so they're left as a seam.

Verified end-to-end against the live EPAM page: the reconstructed HTML matches EPAM's own careers-site layout, benefits included.

## Retroactivity

Existing EPAM jobs keep their old flat descriptions until re-ingested; a normal EPAM re-crawl + `reindex` upgrades them via `UpsertJob`. No backfill needed.

## Tests

- `TestEPAMDescriptionFromNextDataStructured` — structured sections + recovered benefits, prefers `__NEXT_DATA__` over the flat blob
- `TestEPAMDescriptionDropsLeakedSectionLabels` — leaked headings not rendered as bullets
- existing `TestEPAMFetchSitemapThenDetailAndMaps` now exercises the ld+json fallback path unchanged

Includes a `/blog` changelog note.