### PR TITLE
fix(sources): route habr_career crawl through proxy to beat Qrator

### DIFF
--- a/internal/sources/habrcareer_test.go
+++ b/internal/sources/habrcareer_test.go
@@ -238,3 +238,11 @@ func TestHabrCareerLaterPageErrorEndsEnumeration(t *testing.T) {
 		t.Fatalf("got %d jobs, want 2 (page 1 only, page 2 failed)", len(jobs))
 	}
 }
+
+func TestHabrCareerIsProxied(t *testing.T) {
+	// Qrator challenges habr's per-vacancy detail HTML from the prod datacenter IP (the listing
+	// JSON passes, but the description parse fails), so the crawl must egress through the proxy.
+	if _, ok := proxiedProviders["habr_career"]; !ok {
+		t.Error("habr_career must be in proxiedProviders (Qrator blocks detail fetches from the prod datacenter IP)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -407,6 +407,12 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// like djinni's, setting SOURCES_PROXY_URL routes only this provider through the proxy with
 	// no code change; while the proxy is unset this entry is inert.
 	"onstrider": func(c HTTPClient) Source { return NewOnstrider(c) },
+	// career.habr.com sits behind Qrator, which challenges the per-vacancy detail HTML from the
+	// prod datacenter IP (the listing JSON passes, but the description parse fails, leaving jobs
+	// with empty descriptions and so no derived skills/geo/enrichment). A residential IP is served
+	// the full page, so the whole crawl egresses through the proxy — like the others, listing and
+	// detail alike. A fixed, trusted host, so it satisfies the SSRF caveat above.
+	"habr_career": func(c HTTPClient) Source { return NewHabrCareer(c) },
 	// vagas.com.br blocks the prod datacenter IP (403 on the first listing GET) AND rate-limits
 	// by a per-IP request budget (429 once a full crawl's volume hits one IP). So it egresses
 	// through the proxy like careerspage AND is rate-paced (pacedVagasGetter) to hold its


### PR DESCRIPTION
Habr Career jobs ingest with empty descriptions on prod: the listing JSON passes from the datacenter IP, but Qrator challenges each per-vacancy detail page (where the `JobPosting` description lives), so the description parse fails and the job lands empty — and with no derived skills/geo/enrichment downstream.

A residential IP is served the full page (verified: 200 + 2954-char JobPosting through the egress proxy), so this adds `habr_career` to `proxiedProviders`. When `SOURCES_PROXY_URL` is set the whole crawl egresses through the proxy (listing and detail alike); the entry is inert while the proxy is unset. Fixed, trusted host, so it satisfies the SSRF caveat.

- one line in `proxiedProviders` + `TestHabrCareerIsProxied` membership test
- existing empties self-heal on the next successful crawl (PR#390 COALESCE invariant)