### PR TITLE
feat(sources): add hh.ru (HeadHunter) ingest adapter

### DIFF
--- a/internal/sources/hhru.go
+++ b/internal/sources/hhru.go
@@ -1,0 +1,318 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// hh adapts hh.ru (HeadHunter), Russia's largest job board. It aggregates postings from many
+// companies (company per posting), enumerated by professional_role id carried as the board file
+// entry's board. Its public search API is IP-blocklisted from datacenter egress, so the crawl
+// reads the server-rendered search page and decodes the vacancy list from its embedded
+// client-hydration state (a <template id="HH-Lux-InitialState"> JSON blob). The list carries every
+// field except the description, which — like justjoin/nofluffjobs — is hydrated per posting from
+// the vacancy page's JobPosting ld+json, and only for postings the catalogue does not already have
+// (HydratingSource.FetchNew). Multi-company, board-based.
+//
+// Caveat/seam: HH-Lux-InitialState is a frontend detail (the client-hydration state), not a
+// documented API, so a hh.ru frontend change can move the vacancy list within it. The public
+// render must carry the data somewhere; today it is this template.
+type hh struct {
+	http HTMLGetter
+}
+
+// NewHH builds the hh.ru adapter over the shared HTML-getter client.
+func NewHH(c HTMLGetter) Source { return hh{http: c} }
+
+func (hh) Provider() string { return "hh" }
+
+// aggregator marks hh as a genuine multi-company aggregator: the same vacancy a company also
+// posts on its own ATS appears here too, so the cross-source dedup pass prefers the first-party
+// ATS copy over the hh.ru re-listing. Unlike the boardless aggregators hh still requires a board
+// (professional_role id) to bound the crawl, so it is not boardless.
+func (hh) aggregator() {}
+
+const (
+	hhSearchURL  = "https://hh.ru/search/vacancy"
+	hhVacancyURL = "https://hh.ru/vacancy/"
+	hhStateID    = "HH-Lux-InitialState"
+	hhPageSize   = 100
+	// hhWithinDays bounds each crawl to a recent-publish window; ordered newest-first this keeps
+	// the walked set inside hh.ru's ~2000-result search depth cap and lets repeated runs converge.
+	hhWithinDays = 7
+	// hhMaxPages backstops the page loop at hh.ru's search depth cap (page*size ≤ ~2000).
+	hhMaxPages = 2000 / hhPageSize
+)
+
+// hhState is the slice of the HH-Lux-InitialState blob the adapter reads: the vacancy list.
+type hhState struct {
+	VacancySearchResult struct {
+		Vacancies []hhVacancy `json:"vacancies"`
+	} `json:"vacancySearchResult"`
+}
+
+// hhVacancy is one search-result vacancy from the embedded state. It carries every field the
+// adapter needs except the description, which is hydrated from the vacancy page.
+type hhVacancy struct {
+	VacancyID int64  `json:"vacancyId"`
+	Name      string `json:"name"`
+	IsAdv     bool   `json:"@isAdv"`
+	Area      struct {
+		Name string `json:"name"`
+	} `json:"area"`
+	Company struct {
+		VisibleName string `json:"visibleName"`
+		Name        string `json:"name"`
+	} `json:"company"`
+	Compensation hhCompensation `json:"compensation"`
+	Employment   struct {
+		Type string `json:"@type"`
+	} `json:"employment"`
+	WorkFormats []struct {
+		Elements []string `json:"workFormatsElement"`
+	} `json:"workFormats"`
+	PublicationTime struct {
+		Value string `json:"$"`
+	} `json:"publicationTime"`
+	Links struct {
+		Desktop string `json:"desktop"`
+	} `json:"links"`
+}
+
+// hhCompensation is the structured salary the list carries (the detail ld+json omits it). From/To
+// are whole currency units; a bare {noCompensation:{}} leaves both nil (salary unstated).
+type hhCompensation struct {
+	From         *int64 `json:"from"`
+	To           *int64 `json:"to"`
+	CurrencyCode string `json:"currencyCode"`
+	Gross        *bool  `json:"gross"`
+}
+
+// Fetch is the list-only crawl (no description) — the fallback for a non-hydrating pipeline.
+func (s hh) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	postings, err := s.crawl(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+	jobs := make([]Job, 0, len(postings))
+	for _, v := range postings {
+		if job, ok := v.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// FetchNew hydrates a posting's description from its vacancy page only for a posting the catalogue
+// does not already have (seen); a seen posting yields the list-only job marked SeenRefresh, so the
+// pipeline refreshes liveness without re-downloading the ~1 MB detail page or wiping the hydrated
+// body. A single detail failure is isolated (logged, list-only fallback) — a posting is never
+// dropped over a missing detail.
+func (s hh) FetchNew(ctx context.Context, e CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	postings, err := s.crawl(ctx, e)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(postings, defaultDetailWorkers, func(v hhVacancy) (Job, bool) {
+		base, ok := v.toJob()
+		if !ok {
+			return Job{}, false // unusable posting — dropped, as in Fetch
+		}
+		if seen(base.ExternalID) {
+			base.SeenRefresh = true
+			return base, true
+		}
+		if body, ok := s.detail(ctx, base.URL); ok {
+			base.Description += body // base.Description is the salary paragraph (or "")
+		} else {
+			log.Printf("hh: detail %q failed; ingesting list-only", base.URL)
+		}
+		return base, true
+	}), nil
+}
+
+// crawl pages the search listing, decoding each page's embedded state, until a page yields no new
+// vacancy or the depth cap is hit — the shared list walk behind Fetch and FetchNew. Promoted (ad)
+// vacancies are skipped: they are injected across searches regardless of the role filter, so each
+// role crawl keeps only genuine matches. A first-page failure is a board-level error; a later page
+// failing ends the walk with the postings gathered so far, so a partial crawl survives a hiccup.
+func (s hh) crawl(ctx context.Context, e CompanyEntry) ([]hhVacancy, error) {
+	var out []hhVacancy
+	seen := map[int64]bool{}
+	for page := 0; page < hhMaxPages; page++ {
+		root, err := s.http.GetHTML(ctx, s.searchURL(e.Board, page))
+		if err != nil {
+			if page == 0 {
+				return nil, fmt.Errorf("hh: search role %q page %d: %w", e.Board, page, err)
+			}
+			break
+		}
+		st, ok := hhStateOf(root)
+		if !ok {
+			if page == 0 {
+				return nil, fmt.Errorf("hh: search role %q page %d: no %s state", e.Board, page, hhStateID)
+			}
+			break
+		}
+		added := 0
+		for _, v := range st.VacancySearchResult.Vacancies {
+			if v.IsAdv || v.VacancyID == 0 || seen[v.VacancyID] {
+				continue
+			}
+			seen[v.VacancyID] = true
+			out = append(out, v)
+			added++
+		}
+		if added == 0 { // empty page, or hh clamping ?page past its last page
+			break
+		}
+	}
+	return out, nil
+}
+
+// searchURL builds a professional_role search page, newest-first and bounded to the recent-publish
+// window.
+func (hh) searchURL(role string, page int) string {
+	q := url.Values{}
+	q.Set("professional_role", role)
+	q.Set("items_on_page", strconv.Itoa(hhPageSize))
+	q.Set("page", strconv.Itoa(page))
+	q.Set("order_by", "publication_time")
+	q.Set("period", strconv.Itoa(hhWithinDays))
+	return hhSearchURL + "?" + q.Encode()
+}
+
+// toJob maps a listing vacancy to a Job, returning ok=false for an unusable posting (no id to key
+// on, or no company which would break the company slug). The salary the list carries is folded into
+// the description (Job has no salary field); the body is hydrated separately by FetchNew.
+func (v hhVacancy) toJob() (Job, bool) {
+	company := hhCompanyName(firstNonEmpty(v.Company.VisibleName, v.Company.Name))
+	if v.VacancyID == 0 || company == "" {
+		return Job{}, false
+	}
+	id := strconv.FormatInt(v.VacancyID, 10)
+	jobURL := v.Links.Desktop
+	if jobURL == "" {
+		jobURL = hhVacancyURL + id
+	}
+	return Job{
+		ExternalID:     id,
+		URL:            jobURL,
+		Title:          strings.TrimSpace(v.Name),
+		Company:        company,
+		Location:       strings.TrimSpace(v.Area.Name),
+		Description:    v.salaryParagraph(),
+		Remote:         v.workMode() == "remote",
+		WorkMode:       v.workMode(),
+		EmploymentType: hhEmploymentType(v.Employment.Type),
+		PostedAt:       parseRFC3339(v.PublicationTime.Value),
+	}, true
+}
+
+// hhCompanyName cleans an employer display name: hh.ru appends an employer's internal org-structure
+// path to visibleName with a "::" separator for large employers (e.g. "HeadHunter::Analytics/Data
+// Science"), which would otherwise become a bogus company name and slug. Only the top-level employer
+// name is kept; clean names (no "::") pass through untouched.
+func hhCompanyName(name string) string {
+	name, _, _ = strings.Cut(name, "::")
+	return strings.TrimSpace(name)
+}
+
+// salaryParagraph renders the structured compensation as a leading paragraph, folded into the
+// description because Job has no salary field. Empty when the vacancy states no amount.
+func (v hhVacancy) salaryParagraph() string {
+	c := v.Compensation
+	if c.From == nil && c.To == nil {
+		return ""
+	}
+	var amount string
+	switch {
+	case c.From != nil && c.To != nil:
+		amount = fmt.Sprintf("%d–%d %s", *c.From, *c.To, c.CurrencyCode)
+	case c.From != nil:
+		amount = fmt.Sprintf("от %d %s", *c.From, c.CurrencyCode)
+	default:
+		amount = fmt.Sprintf("до %d %s", *c.To, c.CurrencyCode)
+	}
+	if c.Gross != nil {
+		if *c.Gross {
+			amount += " (до вычета налогов)"
+		} else {
+			amount += " (на руки)"
+		}
+	}
+	return sanitizeHTML("<p>Зарплата: " + strings.TrimSpace(amount) + "</p>")
+}
+
+// workMode maps hh's structured workFormats enum to our work-mode vocabulary, preferring the most
+// remote arrangement a vacancy offers; an unstated/unknown format yields "".
+func (v hhVacancy) workMode() string {
+	set := map[string]bool{}
+	for _, wf := range v.WorkFormats {
+		for _, e := range wf.Elements {
+			set[strings.ToUpper(strings.TrimSpace(e))] = true
+		}
+	}
+	switch {
+	case set["REMOTE"]:
+		return "remote"
+	case set["HYBRID"]:
+		return "hybrid"
+	case set["ON_SITE"]:
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// hhEmploymentType maps hh's employment @type enum into enrich.EmploymentTypeValues, leaving
+// unmapped types empty so the pipeline's dictionaries decide.
+func hhEmploymentType(t string) string {
+	switch strings.ToUpper(strings.TrimSpace(t)) {
+	case "FULL":
+		return "full_time"
+	case "PART":
+		return "part_time"
+	case "PROJECT":
+		return "contract"
+	default:
+		return ""
+	}
+}
+
+// detail fetches the vacancy page and returns its sanitized JobPosting description, ok=false on a
+// failed request or a page with no JobPosting ld+json so the caller falls back to the list-only job.
+func (s hh) detail(ctx context.Context, vacancyURL string) (string, bool) {
+	root, err := s.http.GetHTML(ctx, vacancyURL)
+	if err != nil {
+		return "", false
+	}
+	var p struct {
+		Description string `json:"description"`
+	}
+	if !LDJobPosting(root, &p) || strings.TrimSpace(p.Description) == "" {
+		return "", false
+	}
+	return sanitizeHTML(p.Description), true
+}
+
+// hhStateOf decodes the HH-Lux-InitialState template blob into the slice of state the adapter
+// reads. ok=false when the page carries no such template or its JSON does not decode.
+func hhStateOf(root *html.Node) (hhState, bool) {
+	node := firstByID(root, hhStateID)
+	if node == nil {
+		return hhState{}, false
+	}
+	var st hhState
+	if err := json.Unmarshal([]byte(textContent(node)), &st); err != nil {
+		return hhState{}, false
+	}
+	return st, true
+}

--- a/internal/sources/hhru_test.go
+++ b/internal/sources/hhru_test.go
@@ -1,0 +1,270 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// hhFake routes search calls by their page param (returning a page's embedded-state HTML) and
+// detail calls by the vacancy id in the URL, so one fake drives both stages of the crawl.
+type hhFake struct {
+	searchByPage map[int][]hhVacancy // page -> vacancies in that page's state
+	detailByID   map[string]string   // vacancy id -> ld+json description
+	detailErr    map[string]bool     // vacancy id -> GetHTML returns an error
+	searchPages  []int               // search pages requested, in order
+	detailHits   []string            // vacancy ids whose detail page was fetched, in order
+}
+
+func (f *hhFake) GetHTML(_ context.Context, u string) (*html.Node, error) {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+	if strings.Contains(pu.Path, "/search/vacancy") {
+		page, _ := strconv.Atoi(pu.Query().Get("page"))
+		f.searchPages = append(f.searchPages, page)
+		return html.Parse(strings.NewReader(hhSearchHTML(f.searchByPage[page])))
+	}
+	id := pu.Path[strings.LastIndex(pu.Path, "/")+1:]
+	f.detailHits = append(f.detailHits, id)
+	if f.detailErr[id] {
+		return nil, errors.New("detail boom")
+	}
+	return html.Parse(strings.NewReader(hhDetailHTML(f.detailByID[id])))
+}
+
+// hhSearchHTML wraps the vacancy list in an HH-Lux-InitialState template, mirroring the real
+// server-rendered search page. Marshaling hhState round-trips through the adapter's own decode.
+func hhSearchHTML(vs []hhVacancy) string {
+	var st hhState
+	st.VacancySearchResult.Vacancies = vs
+	b, _ := json.Marshal(st)
+	return `<html><body><template style="display:none" id="HH-Lux-InitialState">` +
+		string(b) + `</template></body></html>`
+}
+
+// hhDetailHTML wraps a JobPosting ld+json carrying the given description, as the vacancy page does.
+func hhDetailHTML(desc string) string {
+	if desc == "" {
+		return `<html><body><p>no ld+json here</p></body></html>`
+	}
+	b, _ := json.Marshal(map[string]any{"@type": "JobPosting", "description": desc})
+	return `<html><body><script type="application/ld+json">` + string(b) + `</script></body></html>`
+}
+
+// hhVac builds a minimal usable listing vacancy (id, title, company, desktop link).
+func hhVac(id int64, name, company string) hhVacancy {
+	var v hhVacancy
+	v.VacancyID = id
+	v.Name = name
+	v.Company.VisibleName = company
+	v.Links.Desktop = hhVacancyURL + strconv.FormatInt(id, 10)
+	return v
+}
+
+func i64(n int64) *int64 { return &n }
+func boolp(b bool) *bool { return &b }
+
+func TestHHFetchMapsListingAndSkipsAds(t *testing.T) {
+	dev := hhVac(101, "Go Developer", "Контур")
+	dev.Area.Name = "Новосибирск"
+	dev.Employment.Type = "FULL"
+	dev.WorkFormats = []struct {
+		Elements []string `json:"workFormatsElement"`
+	}{{Elements: []string{"REMOTE", "HYBRID"}}}
+	dev.PublicationTime.Value = "2026-07-06T20:42:48.702+03:00"
+	dev.Compensation = hhCompensation{From: i64(200000), To: i64(300000), CurrencyCode: "RUR", Gross: boolp(true)}
+
+	ad := hhVac(999, "Promoted elsewhere", "AdCo")
+	ad.IsAdv = true
+
+	fake := &hhFake{searchByPage: map[int][]hhVacancy{0: {dev, ad}}}
+	jobs, err := NewHH(fake).Fetch(context.Background(), CompanyEntry{Provider: "hh", Board: "96"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("len(jobs) = %d, want 1 (ad skipped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "101" || j.Title != "Go Developer" || j.Company != "Контур" {
+		t.Errorf("id/title/company wrong: %q / %q / %q", j.ExternalID, j.Title, j.Company)
+	}
+	if j.URL != "https://hh.ru/vacancy/101" || j.Location != "Новосибирск" {
+		t.Errorf("url/location wrong: %q / %q", j.URL, j.Location)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("workFormats REMOTE → Remote=%v WorkMode=%q, want true/remote", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-06" {
+		t.Errorf("PostedAt = %v, want 2026-07-06", j.PostedAt)
+	}
+	// Fetch is list-only: the salary the list carries is folded in, but there is no body yet.
+	if !strings.Contains(j.Description, "200000–300000 RUR") || !strings.Contains(j.Description, "до вычета налогов") {
+		t.Errorf("salary paragraph missing from description: %q", j.Description)
+	}
+}
+
+func TestHHWorkModeAndEmploymentMapping(t *testing.T) {
+	wf := func(els ...string) []struct {
+		Elements []string `json:"workFormatsElement"`
+	} {
+		return []struct {
+			Elements []string `json:"workFormatsElement"`
+		}{{Elements: els}}
+	}
+	cases := []struct {
+		formats  []string
+		wantMode string
+	}{
+		{[]string{"ON_SITE", "HYBRID"}, "hybrid"},
+		{[]string{"ON_SITE"}, "onsite"},
+		{[]string{"REMOTE", "ON_SITE"}, "remote"},
+		{nil, ""},
+	}
+	for _, c := range cases {
+		v := hhVac(1, "T", "Co")
+		v.WorkFormats = wf(c.formats...)
+		if c.formats == nil {
+			v.WorkFormats = nil
+		}
+		if got := v.workMode(); got != c.wantMode {
+			t.Errorf("workMode(%v) = %q, want %q", c.formats, got, c.wantMode)
+		}
+	}
+	for typ, want := range map[string]string{"FULL": "full_time", "PART": "part_time", "PROJECT": "contract", "PROBATION": ""} {
+		if got := hhEmploymentType(typ); got != want {
+			t.Errorf("hhEmploymentType(%q) = %q, want %q", typ, got, want)
+		}
+	}
+}
+
+func TestHHCleansCompanyOrgSuffix(t *testing.T) {
+	v := hhVac(1, "T", "HeadHunter::Analytics/Data Science")
+	j, ok := v.toJob()
+	if !ok || j.Company != "HeadHunter" {
+		t.Errorf("company = %q, want HeadHunter (org-path suffix stripped)", j.Company)
+	}
+	// A clean name (no "::") is untouched.
+	if got := hhCompanyName("МТС Банк. Головной офис"); got != "МТС Банк. Головной офис" {
+		t.Errorf("clean company altered: %q", got)
+	}
+}
+
+func TestHHDropsUnusablePostings(t *testing.T) {
+	noCompany := hhVac(1, "T", "")
+	noID := hhVac(0, "T", "Co")
+	fake := &hhFake{searchByPage: map[int][]hhVacancy{0: {hhVac(2, "Ok", "Co"), noCompany, noID}}}
+	jobs, err := NewHH(fake).Fetch(context.Background(), CompanyEntry{Board: "96"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != "2" {
+		t.Fatalf("want only the usable posting; got %d jobs", len(jobs))
+	}
+}
+
+func TestHHFetchNewHydratesOnlyNew(t *testing.T) {
+	newV := hhVac(101, "New role", "Co")
+	seenV := hhVac(202, "Seen role", "Co")
+	failV := hhVac(303, "Detail fails", "Co")
+	fake := &hhFake{
+		searchByPage: map[int][]hhVacancy{0: {newV, seenV, failV}},
+		detailByID:   map[string]string{"101": "<p>Full body for the new role.</p>"},
+		detailErr:    map[string]bool{"303": true},
+	}
+	seen := func(id string) bool { return id == "202" }
+	jobs, err := NewHH(fake).(HydratingSource).FetchNew(context.Background(), CompanyEntry{Board: "96"}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	// The new posting is hydrated with its body; the seen one is a SeenRefresh with no detail fetch.
+	if d := byID["101"].Description; !strings.Contains(d, "Full body for the new role") {
+		t.Errorf("new posting not hydrated: %q", d)
+	}
+	if byID["101"].SeenRefresh {
+		t.Error("new posting must not be marked SeenRefresh")
+	}
+	if !byID["202"].SeenRefresh {
+		t.Error("seen posting must be marked SeenRefresh")
+	}
+	// Only the new and the (attempted) failing posting hit the detail page; the seen one is skipped.
+	if slices.Contains(fake.detailHits, "202") {
+		t.Errorf("seen posting should not fetch detail; detail hits = %v", fake.detailHits)
+	}
+	// A detail failure still emits the list-only job (never dropped).
+	if _, ok := byID["303"]; !ok {
+		t.Error("posting with failing detail should still be emitted list-only")
+	}
+}
+
+func TestHHPaginatesAndStops(t *testing.T) {
+	full := make([]hhVacancy, hhPageSize)
+	for i := range full {
+		full[i] = hhVac(int64(1000+i), "T", "Co")
+	}
+	short := []hhVacancy{hhVac(1, "T", "Co"), hhVac(2, "T", "Co")}
+	fake := &hhFake{searchByPage: map[int][]hhVacancy{0: full, 1: short}} // page 2 absent → empty → stop
+	jobs, err := NewHH(fake).Fetch(context.Background(), CompanyEntry{Board: "96"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !slices.Equal(fake.searchPages, []int{0, 1, 2}) {
+		t.Errorf("requested pages = %v, want [0 1 2] (0/1 full/short, 2 empty stops)", fake.searchPages)
+	}
+	if len(jobs) != hhPageSize+2 {
+		t.Errorf("len(jobs) = %d, want %d", len(jobs), hhPageSize+2)
+	}
+}
+
+func TestHHFirstPageFailureIsBoardError(t *testing.T) {
+	fake := &hhFake{searchByPage: map[int][]hhVacancy{}} // page 0 yields empty state, not an error
+	// An empty first page is not an error — it is a role with no fresh vacancies.
+	jobs, err := NewHH(fake).Fetch(context.Background(), CompanyEntry{Board: "96"})
+	if err != nil || len(jobs) != 0 {
+		t.Fatalf("empty first page: jobs=%d err=%v, want 0/nil", len(jobs), err)
+	}
+}
+
+func TestHHProviderRegisteredAndAggregator(t *testing.T) {
+	if got := NewHH(nil).Provider(); got != "hh" {
+		t.Errorf("Provider() = %q, want hh", got)
+	}
+	if _, ok := All(nil)["hh"]; !ok {
+		t.Error("All() should register provider hh")
+	}
+	if !slices.Contains(FilterableProviders(), "hh") {
+		t.Error("FilterableProviders() should include hh")
+	}
+	if !slices.Contains(AggregatorProviders(All(nil)), "hh") {
+		t.Error("AggregatorProviders() should include hh (multi-company aggregator)")
+	}
+}
+
+func TestHHBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/hh.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/hh.yml fails validation: %v", err)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -311,6 +311,9 @@ func All(c HTTPClient) map[string]Source {
 		NewBairesDev(c),
 		// RU federal open-data aggregator: board-based, sharded per region (board = OKATO code).
 		NewTrudvsem(c),
+		// hh.ru: multi-company aggregator, enumerated by professional_role (board), reading the
+		// server-rendered search page's embedded state.
+		NewHH(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),
@@ -417,6 +420,12 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// blocked, setting SOURCES_PROXY_URL routes only this provider through the proxy with no code
 	// change; while the proxy is unset this entry is inert. A fixed, trusted host (SSRF caveat).
 	"geekjob": func(c HTTPClient) Source { return NewGeekjob(c) },
+	// hh.ru already 403s its public search API from the datacenter IP, so the HTML crawl may be
+	// blocked from prod too (untested there; the spike ran from a residential IP). Pre-wired so a
+	// block is a one-env-var fix. Caveat: hh's per-vacancy detail fan-out is high-volume, so a
+	// single proxy IP may itself get rate-limited — pacing (like careerspage/vagas) may be needed
+	// if the proxy path 429s. While SOURCES_PROXY_URL is unset this entry is inert.
+	"hh": func(c HTTPClient) Source { return NewHH(c) },
 	// career.habr.com sits behind Qrator, which challenges the per-vacancy detail HTML from the
 	// prod datacenter IP (the listing JSON passes, but the description parse fails, leaving jobs
 	// with empty descriptions and so no derived skills/geo/enrichment). A residential IP is served

--- a/sources/hh.yml
+++ b/sources/hh.yml
@@ -1,0 +1,14 @@
+# hh.ru (HeadHunter) — Russia's largest job board, crawled as a multi-company aggregator.
+# Each entry's board is a professional_role id: the crawl enumerates that role's freshest
+# vacancies from the server-rendered search page. company is a display label only — the real
+# employer comes from each posting. Role ids below are live-verified as cleanly IT-focused.
+- company: hh.ru — Developers
+  board: "96" # Программист, разработчик
+- company: hh.ru — Data science / ML
+  board: "165" # Дата-сайентист
+- company: hh.ru — Data analysts
+  board: "156" # BI-аналитик, аналитик данных
+- company: hh.ru — DevOps
+  board: "160" # DevOps-инженер
+- company: hh.ru — QA
+  board: "124" # Тестировщик


### PR DESCRIPTION
## What

Adds an ingest adapter for **hh.ru** (HeadHunter), Russia's largest job board, as a multi-company aggregator.

## How

- **API is IP-blocklisted** from datacenter egress (403s late-2025), so the crawl reads the server-rendered `hh.ru/search/vacancy` page and decodes the vacancy list from its embedded `<template id="HH-Lux-InitialState">` JSON blob. HTML pages return 200 with the plain `freehire/0.1` UA.
- `board` = a hh.ru **professional_role** id (like arbeitsagentur's `berufsfeld`). `sources/hh.yml` seeds 5 live-verified IT roles (96 dev, 165 data-science, 156 data-analyst, 160 devops, 124 QA).
- The list carries every field except description → **HydratingSource.FetchNew** fetches the JobPosting `ld+json` description only for *new* postings (justjoin/nofluffjobs pattern); seen postings refresh liveness via `SeenRefresh` without re-downloading the ~1 MB detail page.
- Structured facets mapped: `workFormats`→WorkMode, `employment.@type`→EmploymentType. Salary (`compensation`) folded into the description (Job has no salary field). Ad (`@isAdv`) results and hh's `::` org-path company suffix are stripped.
- Marked `aggregator()` so cross-source dedup prefers a first-party ATS copy. Pre-wired inert in `proxiedProviders` in case the prod IP is blocked like the API.

## Verification

- `go build ./...`, `go vet`, 9 `TestHH*` unit tests (fake HTMLGetter driving both stages) — all green.
- **Live e2e** against real hh.ru: role 165 → 848 jobs, correct mapping, real 4 KB+ ld+json bodies hydrated for new postings.

> Note: hh.ru's developer agreement restricts republishing; shipping per repo owner's explicit decision.