### PR TITLE
feat(sources): add trudvsem RU federal open-data adapter

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -308,6 +308,8 @@ func All(c HTTPClient) map[string]Source {
 		NewAlignerr(c),
 		NewMicro1(c),
 		NewBairesDev(c),
+		// RU federal open-data aggregator: board-based, sharded per region (board = OKATO code).
+		NewTrudvsem(c),
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),

--- a/internal/sources/trudvsem.go
+++ b/internal/sources/trudvsem.go
@@ -1,0 +1,146 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// trudvsem adapts opendata.trudvsem.ru — the open-data API of "Работа России", the Russian
+// federal employment service's job board. It is keyless. Postings are enumerated per federal
+// subject (region), carried as the board file entry's board: a 13-digit OKATO region code
+// (e.g. 7700000000000 = Moscow). The API hard-caps pagination — the offset param is a 0-based
+// page index, page size maxes at 100, and page 100 errors — so a region with more than ~10k
+// open vacancies yields only its freshest 10k (results are date_modify-descending; the lost
+// tail is the stalest postings), while every smaller region is exhausted in full. Multi-company
+// (employer per posting), board-based like arbeitsagentur — no new source shape needed.
+type trudvsem struct {
+	http JSONGetter
+}
+
+const (
+	trudvsemRegionURL = "https://opendata.trudvsem.ru/api/v1/vacancies/region/%s"
+	trudvsemPageSize  = 100
+	// trudvsemMaxPages caps the page loop at the API's pagination ceiling. The offset param is
+	// a 0-based PAGE index (not a record offset); page index 100 (offset=100) errors with a 500,
+	// so at most 100 pages — the freshest ~10k postings — are reachable per region.
+	trudvsemMaxPages = 100
+)
+
+// NewTrudvsem builds the Trudvsem adapter over the given JSON client.
+func NewTrudvsem(c JSONGetter) Source { return trudvsem{http: c} }
+
+func (trudvsem) Provider() string { return "trudvsem" }
+
+// trudvsemResponse is one vacancies page. A page past the end of a region's results 500s
+// (surfaced as a transport error), so the loop stops before requesting one by watching the
+// per-page count and the reported total.
+type trudvsemResponse struct {
+	Meta struct {
+		Total int `json:"total"`
+	} `json:"meta"`
+	Results struct {
+		Vacancies []struct {
+			Vacancy trudvsemVacancy `json:"vacancy"`
+		} `json:"vacancies"`
+	} `json:"results"`
+}
+
+// trudvsemVacancy is one posting. Only the fields the adapter maps are decoded.
+type trudvsemVacancy struct {
+	ID     string `json:"id"`
+	Region struct {
+		Name string `json:"name"`
+	} `json:"region"`
+	Company struct {
+		Name string `json:"name"`
+	} `json:"company"`
+	CreationDate string `json:"creation-date"`
+	JobName      string `json:"job-name"`
+	VacURL       string `json:"vac_url"`
+	Employment   string `json:"employment"`
+	Requirements string `json:"requirements"`
+	Duty         string `json:"duty"`
+}
+
+// trudvsemEmployment maps Trudvsem's employment enum to freehire's controlled EmploymentType
+// vocabulary. Only the confidently-known values are listed; an unrecognized value maps to ""
+// so the dictionaries decide, rather than guessing at a mapping the board does not warrant
+// (e.g. temporary/seasonal has no clean equivalent).
+var trudvsemEmployment = map[string]string{
+	"Полная занятость":    "full_time",
+	"Частичная занятость": "part_time",
+	"Стажировка":          "internship",
+}
+
+func (t trudvsem) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 0; page < trudvsemMaxPages; page++ {
+		var resp trudvsemResponse
+		if err := t.http.GetJSON(ctx, t.pageURL(e.Board, page), &resp); err != nil {
+			return nil, fmt.Errorf("trudvsem: region %q page %d: %w", e.Board, page, err)
+		}
+		for _, w := range resp.Results.Vacancies {
+			if j, ok := t.toJob(w.Vacancy, e.Company); ok {
+				jobs = append(jobs, j)
+			}
+		}
+		// Stop at a short/empty page (the last one) or once the reported total is covered — the
+		// API pages by index, so after this page we have seen (page+1)*pageSize records. Both
+		// guards keep the loop from requesting a page past the end, which 500s.
+		if len(resp.Results.Vacancies) < trudvsemPageSize || (page+1)*trudvsemPageSize >= resp.Meta.Total {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// pageURL builds a region-shard request for the given 0-based page index (the API's offset
+// param is a page number, not a record offset).
+func (trudvsem) pageURL(region string, page int) string {
+	q := url.Values{}
+	q.Set("limit", strconv.Itoa(trudvsemPageSize))
+	q.Set("offset", strconv.Itoa(page))
+	return fmt.Sprintf(trudvsemRegionURL, region) + "?" + q.Encode()
+}
+
+// toJob maps a vacancy to a Job, dropping one with no id or blank title. hubName is the board
+// entry's company, used only as the employer fallback when a posting omits its own.
+func (trudvsem) toJob(v trudvsemVacancy, hubName string) (Job, bool) {
+	if v.ID == "" || strings.TrimSpace(v.JobName) == "" {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:     v.ID,
+		URL:            strings.TrimSpace(v.VacURL),
+		Title:          strings.TrimSpace(v.JobName),
+		Company:        firstNonEmpty(strings.TrimSpace(v.Company.Name), hubName),
+		Location:       strings.TrimSpace(v.Region.Name),
+		Description:    trudvsemDescription(v),
+		EmploymentType: trudvsemEmployment[strings.TrimSpace(v.Employment)],
+		PostedAt:       parseDate(strings.TrimSpace(v.CreationDate)),
+	}, true
+}
+
+// trudvsemDescription assembles the posting body from its duty and requirements text — both
+// plain text with no markup — under Russian headings, then rebuilds paragraph/list structure
+// via plainTextToHTML so it does not render as one unbroken block. An empty result is fine:
+// a description-less posting is still worth emitting.
+func trudvsemDescription(v trudvsemVacancy) string {
+	var b strings.Builder
+	if duty := strings.TrimSpace(v.Duty); duty != "" {
+		b.WriteString("Обязанности:\n" + duty)
+	}
+	if req := strings.TrimSpace(v.Requirements); req != "" {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString("Требования:\n" + req)
+	}
+	if b.Len() == 0 {
+		return ""
+	}
+	return sanitizeHTML(plainTextToHTML(b.String()))
+}

--- a/internal/sources/trudvsem_test.go
+++ b/internal/sources/trudvsem_test.go
@@ -1,0 +1,185 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// trudvsemFake routes each vacancies request by its offset param, so one fake drives the
+// whole region-shard pagination loop.
+type trudvsemFake struct {
+	byOffset   map[int]string // offset -> response JSON ("" => empty page envelope)
+	offsets    []int          // offsets requested, in order
+	gotRegions []string       // region codes taken from the request path
+}
+
+func (f *trudvsemFake) GetJSON(_ context.Context, u string, v any) error {
+	pu, _ := url.Parse(u)
+	// .../vacancies/region/<code>?offset=&limit=
+	if i := strings.LastIndex(pu.Path, "/region/"); i >= 0 {
+		f.gotRegions = append(f.gotRegions, pu.Path[i+len("/region/"):])
+	}
+	offset, _ := strconv.Atoi(pu.Query().Get("offset"))
+	f.offsets = append(f.offsets, offset)
+	body := f.byOffset[offset]
+	if body == "" {
+		body = `{"status":"200","meta":{"total":0},"results":{"vacancies":[]}}`
+	}
+	return json.Unmarshal([]byte(body), v)
+}
+
+func TestTrudvsemFetchMaps(t *testing.T) {
+	const page = `{"status":"200","meta":{"total":3},"results":{"vacancies":[
+	  {"vacancy":{"id":"AA-1","source":"Вакансия работодателя",
+	    "region":{"region_code":"7700000000000","name":"Город Москва"},
+	    "company":{"name":"ООО Рога и Копыта"},
+	    "creation-date":"2026-07-15",
+	    "job-name":"Программист",
+	    "vac_url":"https://trudvsem.ru/vacancy/card/123/AA-1",
+	    "employment":"Полная занятость",
+	    "requirements":"Опыт от 3 лет.",
+	    "duty":"Писать код."}},
+	  {"vacancy":{"id":"","job-name":"No id","region":{"name":"X"},"company":{"name":"Y"}}},
+	  {"vacancy":{"id":"CC-3","job-name":"  ","region":{"name":"X"},"company":{"name":"Y"}}},
+	  {"vacancy":{"id":"DD-4","job-name":"Стажёр",
+	    "region":{"region_code":"7700000000000","name":"Город Москва"},
+	    "company":{"name":""},
+	    "creation-date":"2026-07-10",
+	    "vac_url":"https://trudvsem.ru/vacancy/card/9/DD-4",
+	    "employment":"Стажировка",
+	    "duty":"Учиться."}}
+	]}}`
+	fake := &trudvsemFake{byOffset: map[int]string{0: page}}
+	jobs, err := NewTrudvsem(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Работа России", Provider: "trudvsem", Board: "7700000000000",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	// The empty-id and blank-title vacancies are dropped; two map.
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (empty id / blank title dropped)", len(jobs))
+	}
+	if len(fake.gotRegions) == 0 || fake.gotRegions[0] != "7700000000000" {
+		t.Errorf("region path = %v, want first 7700000000000", fake.gotRegions)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	j, ok := byID["AA-1"]
+	if !ok {
+		t.Fatalf("AA-1 not mapped")
+	}
+	if j.URL != "https://trudvsem.ru/vacancy/card/123/AA-1" {
+		t.Errorf("URL = %q", j.URL)
+	}
+	if j.Title != "Программист" || j.Company != "ООО Рога и Копыта" {
+		t.Errorf("title/company wrong: %q / %q", j.Title, j.Company)
+	}
+	if j.Location != "Город Москва" {
+		t.Errorf("Location = %q, want region name", j.Location)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.PostedAt == nil || j.PostedAt.Format("2006-01-02") != "2026-07-15" {
+		t.Errorf("PostedAt = %v, want 2026-07-15", j.PostedAt)
+	}
+	// duty + requirements are rebuilt into paragraph HTML.
+	if d := j.Description; !strings.Contains(d, "Писать код") || !strings.Contains(d, "Опыт от 3 лет") || !strings.Contains(d, "<p>") {
+		t.Errorf("Description = %q, want both duty and requirements in <p> structure", d)
+	}
+	// A vacancy with a blank employer name falls back to the entry's company (the hub name).
+	if dd := byID["DD-4"]; dd.Company != "Работа России" {
+		t.Errorf("DD-4 Company = %q, want fallback to entry company", dd.Company)
+	}
+	if dd := byID["DD-4"]; dd.EmploymentType != "internship" {
+		t.Errorf("DD-4 EmploymentType = %q, want internship", dd.EmploymentType)
+	}
+}
+
+func TestTrudvsemPaginates(t *testing.T) {
+	// offset is a 0-based page index: page 0 full => keep going, page 1 short => stop.
+	full := trudvsemPage(trudvsemPageSize, 0, 100000)
+	short := trudvsemPage(3, 100, 100000)
+	fake := &trudvsemFake{byOffset: map[int]string{0: full, 1: short}}
+	jobs, err := NewTrudvsem(fake).Fetch(context.Background(), CompanyEntry{Board: "5200000000000"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !slices.Equal(fake.offsets, []int{0, 1}) {
+		t.Errorf("requested pages = %v, want [0 1]", fake.offsets)
+	}
+	if len(jobs) != trudvsemPageSize+3 {
+		t.Errorf("len(jobs) = %d, want %d", len(jobs), trudvsemPageSize+3)
+	}
+}
+
+func TestTrudvsemStopsAtTotal(t *testing.T) {
+	// A first full page whose size already covers the total must not request page 1.
+	full := trudvsemPage(trudvsemPageSize, 0, trudvsemPageSize)
+	fake := &trudvsemFake{byOffset: map[int]string{0: full}}
+	if _, err := NewTrudvsem(fake).Fetch(context.Background(), CompanyEntry{Board: "5200000000000"}); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !slices.Equal(fake.offsets, []int{0}) {
+		t.Errorf("requested pages = %v, want [0] (total reached)", fake.offsets)
+	}
+}
+
+func TestTrudvsemStopsAtTotalMultiplePages(t *testing.T) {
+	// total=200 is an exact multiple of the page size: pages 0 and 1 cover it, so the loop
+	// must stop after page 1 rather than requesting page 2 (which the API 500s past the end).
+	fake := &trudvsemFake{byOffset: map[int]string{
+		0: trudvsemPage(trudvsemPageSize, 0, 200),
+		1: trudvsemPage(trudvsemPageSize, 100, 200),
+	}}
+	jobs, err := NewTrudvsem(fake).Fetch(context.Background(), CompanyEntry{Board: "5200000000000"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !slices.Equal(fake.offsets, []int{0, 1}) {
+		t.Errorf("requested pages = %v, want [0 1] (no page 2 past the end)", fake.offsets)
+	}
+	if len(jobs) != 2*trudvsemPageSize {
+		t.Errorf("len(jobs) = %d, want %d", len(jobs), 2*trudvsemPageSize)
+	}
+}
+
+// trudvsemPage builds a response of n vacancies with ids offset by base and the given total.
+func trudvsemPage(n, base, total int) string {
+	items := make([]string, n)
+	for i := range items {
+		items[i] = `{"vacancy":{"id":"R-` + strconv.Itoa(base+i) +
+			`","job-name":"T","region":{"name":"Нижегородская область"},"company":{"name":"Co"},"creation-date":"2026-07-15"}}`
+	}
+	return `{"status":"200","meta":{"total":` + strconv.Itoa(total) + `},"results":{"vacancies":[` + strings.Join(items, ",") + `]}}`
+}
+
+func TestTrudvsemProviderRegistered(t *testing.T) {
+	if got := NewTrudvsem(nil).Provider(); got != "trudvsem" {
+		t.Errorf("Provider() = %q, want trudvsem", got)
+	}
+	if _, ok := All(nil)["trudvsem"]; !ok {
+		t.Error("All() should register provider trudvsem")
+	}
+	if !slices.Contains(FilterableProviders(), "trudvsem") {
+		t.Error("FilterableProviders() should include trudvsem")
+	}
+}
+
+func TestTrudvsemBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/trudvsem.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/trudvsem.yml fails validation: %v", err)
+	}
+}

--- a/sources/trudvsem.yml
+++ b/sources/trudvsem.yml
@@ -1,0 +1,190 @@
+# Trudvsem — opendata.trudvsem.ru, the open-data API of "Работа России" (the Russian federal
+# employment service). Keyless. One entry per federal subject (region): board is the 13-digit
+# OKATO region code, company is the region name (the real employer comes from each posting).
+#
+# The crawl shards by region because the API hard-caps pagination at offset < 10000 with a page
+# size of 100 — at most the freshest ~10k postings per region are reachable (results are ordered
+# by date_modify descending, so the unreachable tail is the stalest). 17 regions currently
+# exceed 10k (their oldest overflow is dropped); the other 73 are exhausted in full.
+# Regenerate the list from the /vacancies/region/<code> endpoint; totals below are informational.
+
+- company: Краснодарский край
+  board: "2300000000000"  # ~23766 vacancies
+- company: Город Москва
+  board: "7700000000000"  # ~18078 vacancies
+- company: Свердловская область
+  board: "6600000000000"  # ~17809 vacancies
+- company: Московская область
+  board: "5000000000000"  # ~15061 vacancies
+- company: Город Санкт-Петербург
+  board: "7800000000000"  # ~14410 vacancies
+- company: Самарская область
+  board: "6300000000000"  # ~14275 vacancies
+- company: Ростовская область
+  board: "6100000000000"  # ~13211 vacancies
+- company: Челябинская область
+  board: "7400000000000"  # ~12474 vacancies
+- company: Приморский край
+  board: "2500000000000"  # ~11570 vacancies
+- company: Красноярский край
+  board: "2400000000000"  # ~11256 vacancies
+- company: Республика Татарстан (Татарстан)
+  board: "1600000000000"  # ~11005 vacancies
+- company: Ленинградская область
+  board: "4700000000000"  # ~10974 vacancies
+- company: Волгоградская область
+  board: "3400000000000"  # ~10908 vacancies
+- company: Нижегородская область
+  board: "5200000000000"  # ~10898 vacancies
+- company: Республика Башкортостан
+  board: "0200000000000"  # ~10889 vacancies
+- company: Иркутская область
+  board: "3800000000000"  # ~10695 vacancies
+- company: Ставропольский край
+  board: "2600000000000"  # ~10377 vacancies
+- company: Новосибирская область
+  board: "5400000000000"  # ~9916 vacancies
+- company: Пермский край
+  board: "5900000000000"  # ~8914 vacancies
+- company: Тульская область
+  board: "7100000000000"  # ~8770 vacancies
+- company: Саратовская область
+  board: "6400000000000"  # ~8668 vacancies
+- company: Донецкая Народная Республика
+  board: "9300000000000"  # ~8450 vacancies
+- company: Алтайский край
+  board: "2200000000000"  # ~7940 vacancies
+- company: Хабаровский край
+  board: "2700000000000"  # ~7844 vacancies
+- company: Кировская область
+  board: "4300000000000"  # ~7732 vacancies
+- company: Оренбургская область
+  board: "5600000000000"  # ~7490 vacancies
+- company: Кемеровская область - Кузбасс
+  board: "4200000000000"  # ~7332 vacancies
+- company: Республика Крым
+  board: "9100000000000"  # ~7315 vacancies
+- company: Удмуртская Республика
+  board: "1800000000000"  # ~7281 vacancies
+- company: Омская область
+  board: "5500000000000"  # ~7260 vacancies
+- company: Луганская Народная Республика
+  board: "9400000000000"  # ~6982 vacancies
+- company: Воронежская область
+  board: "3600000000000"  # ~6832 vacancies
+- company: Ханты-Мансийский автономный округ - Югра
+  board: "8600000000000"  # ~6515 vacancies
+- company: Вологодская область
+  board: "3500000000000"  # ~6385 vacancies
+- company: Владимирская область
+  board: "3300000000000"  # ~6244 vacancies
+- company: Калужская область
+  board: "4000000000000"  # ~6160 vacancies
+- company: Тверская область
+  board: "6900000000000"  # ~6018 vacancies
+- company: Смоленская область
+  board: "6700000000000"  # ~5934 vacancies
+- company: Белгородская область
+  board: "3100000000000"  # ~5929 vacancies
+- company: Тюменская область
+  board: "7200000000000"  # ~5856 vacancies
+- company: Ульяновская область
+  board: "7300000000000"  # ~5743 vacancies
+- company: Забайкальский край
+  board: "7500000000000"  # ~5300 vacancies
+- company: Пензенская область
+  board: "5800000000000"  # ~5092 vacancies
+- company: Тамбовская область
+  board: "6800000000000"  # ~4739 vacancies
+- company: Калининградская область
+  board: "3900000000000"  # ~4559 vacancies
+- company: Рязанская область
+  board: "6200000000000"  # ~4381 vacancies
+- company: Амурская область
+  board: "2800000000000"  # ~4327 vacancies
+- company: Ярославская область
+  board: "7600000000000"  # ~4324 vacancies
+- company: Республика Саха (Якутия)
+  board: "1400000000000"  # ~4311 vacancies
+- company: Брянская область
+  board: "3200000000000"  # ~4219 vacancies
+- company: Липецкая область
+  board: "4800000000000"  # ~4178 vacancies
+- company: Запорожская область
+  board: "9000000000000"  # ~4103 vacancies
+- company: Республика Бурятия
+  board: "0300000000000"  # ~4077 vacancies
+- company: Томская область
+  board: "7000000000000"  # ~4053 vacancies
+- company: Ивановская область
+  board: "3700000000000"  # ~4009 vacancies
+- company: Мурманская область
+  board: "5100000000000"  # ~3890 vacancies
+- company: Курганская область
+  board: "4500000000000"  # ~3781 vacancies
+- company: Курская область
+  board: "4600000000000"  # ~3775 vacancies
+- company: Чувашская Республика - Чувашия
+  board: "2100000000000"  # ~3761 vacancies
+- company: Орловская область
+  board: "5700000000000"  # ~3725 vacancies
+- company: Астраханская область
+  board: "3000000000000"  # ~3694 vacancies
+- company: Ямало-Ненецкий автономный округ
+  board: "8900000000000"  # ~3455 vacancies
+- company: Камчатский край
+  board: "4100000000000"  # ~3398 vacancies
+- company: Республика Марий Эл
+  board: "1200000000000"  # ~3387 vacancies
+- company: Архангельская область
+  board: "2900000000000"  # ~3239 vacancies
+- company: Костромская область
+  board: "4400000000000"  # ~3201 vacancies
+- company: Республика Коми
+  board: "1100000000000"  # ~3153 vacancies
+- company: Республика Карелия
+  board: "1000000000000"  # ~3041 vacancies
+- company: Сахалинская область
+  board: "6500000000000"  # ~2814 vacancies
+- company: Республика Мордовия
+  board: "1300000000000"  # ~2809 vacancies
+- company: Псковская область
+  board: "6000000000000"  # ~2802 vacancies
+- company: Еврейская автономная область
+  board: "7900000000000"  # ~2742 vacancies
+- company: Новгородская область
+  board: "5300000000000"  # ~2641 vacancies
+- company: Республика Хакасия
+  board: "1900000000000"  # ~2304 vacancies
+- company: Республика Адыгея (Адыгея)
+  board: "0100000000000"  # ~2244 vacancies
+- company: Город Севастополь
+  board: "9200000000000"  # ~1439 vacancies
+- company: Магаданская область
+  board: "4900000000000"  # ~1375 vacancies
+- company: Кабардино-Балкарская Республика
+  board: "0700000000000"  # ~1373 vacancies
+- company: Республика Дагестан
+  board: "0500000000000"  # ~1282 vacancies
+- company: Херсонская область
+  board: "9500000000000"  # ~1068 vacancies
+- company: Республика Калмыкия
+  board: "0800000000000"  # ~909 vacancies
+- company: Республика Алтай
+  board: "0400000000000"  # ~852 vacancies
+- company: Чукотский автономный округ
+  board: "8700000000000"  # ~705 vacancies
+- company: Республика Северная Осетия - Алания
+  board: "1500000000000"  # ~680 vacancies
+- company: Чеченская Республика
+  board: "2000000000000"  # ~659 vacancies
+- company: Республика Тыва
+  board: "1700000000000"  # ~612 vacancies
+- company: Карачаево-Черкесская Республика
+  board: "0900000000000"  # ~542 vacancies
+- company: Ненецкий автономный округ
+  board: "8300000000000"  # ~287 vacancies
+- company: Город Байконур
+  board: "9900000000000"  # ~163 vacancies
+- company: Республика Ингушетия
+  board: "0600000000000"  # ~82 vacancies


### PR DESCRIPTION
## What

Adds the `trudvsem` adapter — [opendata.trudvsem.ru](https://opendata.trudvsem.ru/api/v1/vacancies), the **keyless** open-data API of «Работа России» (the Russian federal employment service, ~539k vacancies).

Board-based multi-company, following the **arbeitsagentur** pattern (a national gov board where `board` is a query facet, employer-per-posting) — no new source shape needed. `board` = 13-digit OKATO region code; the crawl shards per region. `sources/trudvsem.yml` lists all **90 federal subjects**.

## API gotchas (found via live probing, undocumented)

- The `offset` param is a **0-based page index**, not a record offset; page size caps at 100.
- **Page 100 (offset=100) 500s**, and a page past a region's end 500s too — so at most the freshest **~10k postings per region** are reachable (results are `date_modify` DESC, so the unreachable tail is the stalest, which liveness/sweep would close anyway). Regions under 10k are exhausted in full.
- No server-side date filter; the only server-side filters are `text=`, `/region/{code}`, `/company/{code}`.
- Coverage: **~89% of the ~539k total** (17 regions exceed 10k). True 100% isn't reachable via this API.
- `region` shard is the **employer's registration region**, not the job's work location (real city is in `addresses`); `region.name` is used as Location for v1.

## Test

- `go test ./internal/sources/ -run TestTrudvsem` — 6 unit tests (mapping, page-index pagination, termination, registration, board-file validation).
- Verified live end-to-end: fetched 852/852 for the Altai region with correct field mapping.

## Notes

Grabs the whole board (all sectors, not IT-only) by design; the enrich non-tech gate bounds LLM cost.