### PR TITLE
feat(sources): add geekjob.ru RU IT job board adapter

### DIFF
--- a/internal/sources/geekjob.go
+++ b/internal/sources/geekjob.go
@@ -1,0 +1,159 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// geekjob adapts geekjob.ru, a Russian IT job board. The public listing is server-rendered HTML
+// paginated as /vacancies/N (1-based), each card linking to a /vacancy/<hex id> detail page whose
+// schema.org JobPosting ld+json carries the posting (title, company, description, date). geekjob
+// has no board API, so the description and structured fields come from a per-vacancy detail fetch,
+// fanned out under a bounded pool like the other JSON-LD detail adapters (careerspage, freshteam).
+//
+// Boardless (geekjob.ru is one site with no per-tenant board) and an aggregator (many companies;
+// each posting's employer comes from the feed's hiringOrganization, not a placeholder), so it
+// stays in the source facet and inherits the reindex aggregator/ATS-duplicate suppression.
+type geekjob struct {
+	http HTMLGetter
+}
+
+// NewGeekjob builds the geekjob.ru listing adapter over the given HTML client.
+func NewGeekjob(c HTMLGetter) Source { return geekjob{http: c} }
+
+func (geekjob) Provider() string { return "geekjob" }
+
+func (geekjob) boardless() {}
+
+func (geekjob) aggregator() {}
+
+const (
+	// geekjobBaseURL is the site root the listing's relative /vacancy/<id> links resolve against.
+	geekjobBaseURL = "https://geekjob.ru/"
+	// geekjobMaxPages caps the /vacancies/N walk so a listing that never yields an empty page
+	// cannot loop forever. The public feed is ~13 pages; this is ample headroom.
+	geekjobMaxPages = 100
+)
+
+func (s geekjob) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, _ := url.Parse(geekjobBaseURL) // a constant literal never fails to parse
+
+	// Page through the listing until a page yields no new links (the tail/empty page, which the
+	// public feed reaches around page 14) or the safety cap is hit. A first-page failure is a
+	// board-level error; a later-page failure just stops the walk with what we have.
+	locs, err := crawlPagedLinks(ctx, s.http, geekjobMaxPages,
+		func(page int) string { return fmt.Sprintf("%svacancies/%d", geekjobBaseURL, page) },
+		func(root *html.Node) []string {
+			return jobLinks(base, root, func(href string) bool { return geekjobJobID(href) != "" })
+		})
+	if err != nil {
+		return nil, fmt.Errorf("geekjob: listing: %w", err)
+	}
+
+	// Each posting's fields come from its own detail fetch (the listing card omits the
+	// description), fanned out under the shared detail pool.
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one vacancy's detail page and maps its JobPosting ld+json to a Job, returning
+// ok=false when the fetch fails, the page carries no JobPosting, or the URL yields no native id,
+// so the caller skips just that posting.
+func (s geekjob) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p geekjobPosting
+	if !ldJobPosting(root, &p) || p.Title == "" {
+		return Job{}, false
+	}
+	id := geekjobJobID(loc)
+	if id == "" {
+		return Job{}, false
+	}
+
+	location := p.location()
+	// geekjob states the work arrangement only in the "jobinfo" chip block, never in the ld+json,
+	// so the mode and the remote flag are read from there.
+	mode, remote := geekjobArrangement(root)
+
+	return Job{
+		ExternalID:     id,
+		URL:            loc,
+		Title:          p.Title,
+		Company:        firstNonEmpty(p.HiringOrganization.Name, e.Company),
+		Location:       location,
+		Description:    sanitizeHTML(html.UnescapeString(p.Description)),
+		Remote:         remote || isRemote(location),
+		WorkMode:       mode,
+		EmploymentType: schemaEmploymentType(p.EmploymentType),
+		PostedAt:       parseRFC3339OrDate(p.DatePosted),
+	}, true
+}
+
+// geekjobPosting is the schema.org JobPosting decoded from a detail page's ld+json block.
+// jobLocation is a single Place in practice, but decoded through schemaPlaces so an array form
+// (should geekjob ever emit one) does not fail the whole posting's unmarshal.
+type geekjobPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	EmploymentType     string `json:"employmentType"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation schemaPlaces `json:"jobLocation"`
+}
+
+// location builds the free-text location from the first jobLocation place, or "" when the posting
+// carries none (a remote-only vacancy often omits it).
+func (p geekjobPosting) location() string {
+	if len(p.JobLocation) == 0 {
+		return ""
+	}
+	return p.JobLocation[0].Address.Location()
+}
+
+// geekjobJobIDPattern captures the 24-hex vacancy id from a /vacancy/<id> URL. The match must end
+// at the id (end-of-string or a ?/# suffix), so a tracking suffix does not defeat it and the
+// plural /vacancies listing path never matches.
+var geekjobJobIDPattern = regexp.MustCompile(`/vacancy/([0-9a-f]{24})(?:$|[?#])`)
+
+// geekjobJobID extracts the native vacancy id from a URL, or "" when the URL is not a vacancy
+// detail link.
+func geekjobJobID(loc string) string { return firstSubmatch(geekjobJobIDPattern, loc) }
+
+const (
+	// geekjobRemoteChip and geekjobOfficeChip are the two work-arrangement chips geekjob renders
+	// in the "jobinfo" block, bullet-separated and followed by the experience line.
+	geekjobRemoteChip = "удаленная работа"
+	geekjobOfficeChip = "работа в офисе"
+)
+
+// geekjobArrangement reads the work arrangement from a detail page's "jobinfo" chip block. A
+// posting that offers remote is treated as remote — freehire is remote-first and the remote is
+// genuinely available — so the remote chip wins even when an office chip is co-listed; an
+// office-only posting maps to onsite; neither leaves the mode unset for the pipeline/LLM to
+// resolve. The bool reports whether the remote chip is present, for the Job.Remote flag.
+func geekjobArrangement(root *html.Node) (workMode string, remote bool) {
+	info := firstByClass(root, "jobinfo")
+	if info == nil {
+		return "", false
+	}
+	text := strings.ToLower(textContent(info))
+	switch {
+	case strings.Contains(text, geekjobRemoteChip):
+		return "remote", true
+	case strings.Contains(text, geekjobOfficeChip):
+		return "onsite", false
+	default:
+		return "", false
+	}
+}

--- a/internal/sources/geekjob_test.go
+++ b/internal/sources/geekjob_test.go
@@ -1,0 +1,219 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// geekjobDetailHTML is a geekjob.ru vacancy detail page: a server-rendered page whose payload we
+// read is the schema.org JobPosting ld+json, plus the "jobinfo" chip block that carries the work
+// arrangement (geekjob states it there, never in the ld+json). datePosted is a bare date. The
+// description embeds a <script> that sanitizeHTML must strip. arrangement is the raw jobinfo text.
+func geekjobDetailHTML(title, company, arrangement string) string {
+	return `<html><head></head><body>
+<div class="location">Бишкек, Кыргызстан</div>
+<div class="jobinfo">` + arrangement + ` Опыт работы более 5 лет</div>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+"identifier":{"@type":"PropertyValue","name":"Geekjob","value":"171366"},
+"datePosted":"2026-07-16",
+"employmentType":"FULL_TIME",
+"hiringOrganization":{"@type":"Organization","name":"` + company + `"},
+"title":"` + title + `",
+"description":"<p>Build things.</p><script>alert(1)<\/script>",
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"Бишкек","addressCountry":"Кыргызстан"}}}
+</script>
+</body></html>`
+}
+
+// geekjobListingHTML is a geekjob.ru listing page carrying the given vacancy ids. Each card, like
+// the real markup, renders SEVERAL anchors to the same /vacancy/<id> (title, company, date, logo),
+// exercising the job-link dedup; a non-vacancy nav anchor must be ignored by the id predicate.
+func geekjobListingHTML(ids ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><ul class="collection">`)
+	for _, id := range ids {
+		b.WriteString(`<li class="collection-item">`)
+		b.WriteString(`<a href="/vacancy/` + id + `" class="title">A Role</a>`)
+		b.WriteString(`<a href="/vacancy/` + id + `">A Company</a>`)
+		b.WriteString(`<a href="/vacancy/` + id + `">16 июля</a>`)
+		b.WriteString(`</li>`)
+	}
+	b.WriteString(`<a href="/vacancies">All vacancies</a>`)
+	b.WriteString(`</ul></body></html>`)
+	return b.String()
+}
+
+// geekjobEmptyListingHTML is a listing page past the last real page: no vacancy cards, so the
+// pagination loop stops when it yields no new job links.
+const geekjobEmptyListingHTML = `<html><body><ul class="collection"></ul></body></html>`
+
+func TestGeekjobProvider(t *testing.T) {
+	if got := NewGeekjob(nil).Provider(); got != "geekjob" {
+		t.Errorf("Provider() = %q, want %q", got, "geekjob")
+	}
+}
+
+func TestGeekjobJobID(t *testing.T) {
+	cases := map[string]string{
+		"https://geekjob.ru/vacancy/6a5880f9186d0bddab0010e9":       "6a5880f9186d0bddab0010e9",
+		"/vacancy/6a589c8bda741b31f007fe90":                         "6a589c8bda741b31f007fe90",
+		"https://geekjob.ru/vacancy/6a5880f9186d0bddab0010e9?utm=1": "6a5880f9186d0bddab0010e9",
+		"https://geekjob.ru/vacancies/2":                            "", // listing, not a vacancy
+		"https://geekjob.ru/vacancy/short":                          "", // not a 24-hex id
+		"https://geekjob.ru/":                                       "",
+	}
+	for loc, want := range cases {
+		if got := geekjobJobID(loc); got != want {
+			t.Errorf("geekjobJobID(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestGeekjobFetchListingThenDetailAndMaps(t *testing.T) {
+	id := "6a5880f9186d0bddab0010e9"
+	fake := (&routedHTTP{}).
+		route("/vacancies/1", geekjobListingHTML(id)).
+		route("/vacancies/2", geekjobEmptyListingHTML).
+		route("/vacancy/"+id, geekjobDetailHTML("Backend Engineer", "Mad Devs", "Удаленная работа"))
+
+	jobs, err := NewGeekjob(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Geekjob", Provider: "geekjob",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != id {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, id)
+	}
+	if j.URL != "https://geekjob.ru/vacancy/"+id {
+		t.Errorf("URL = %q, want canonical detail URL", j.URL)
+	}
+	if j.Title != "Backend Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Mad Devs" {
+		t.Errorf("Company = %q, want hiringOrganization name", j.Company)
+	}
+	if j.Location != "Бишкек, Кыргызстан" {
+		t.Errorf("Location = %q, want %q", j.Location, "Бишкек, Кыргызстан")
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Build things") {
+		t.Errorf("Description lost real content: %q", j.Description)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if j.WorkMode != "remote" || !j.Remote {
+		t.Errorf("WorkMode/Remote = %q/%v, want remote/true", j.WorkMode, j.Remote)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 16, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-07-16", j.PostedAt)
+	}
+}
+
+// TestGeekjobArrangementMapping covers the work-mode mapping decision: any posting offering
+// remote is remote (even when an office chip is co-listed); office-only is onsite; neither leaves
+// the mode unset with the remote flag falling back to the location heuristic.
+func TestGeekjobArrangementMapping(t *testing.T) {
+	cases := []struct {
+		arrangement string
+		wantMode    string
+		wantRemote  bool
+	}{
+		{"Удаленная работа", "remote", true},
+		{"Удаленная работа • Работа в офисе", "remote", true}, // remote wins over co-listed office
+		{"Релокация • Удаленная работа", "remote", true},
+		{"Работа в офисе", "onsite", false},
+		{"Частичная занятость", "", false}, // no arrangement chip → unset, location decides Remote
+	}
+	for _, tc := range cases {
+		id := "6a5880f9186d0bddab0010e9"
+		fake := (&routedHTTP{}).
+			route("/vacancies/1", geekjobListingHTML(id)).
+			route("/vacancies/2", geekjobEmptyListingHTML).
+			route("/vacancy/"+id, geekjobDetailHTML("Role", "Acme", tc.arrangement))
+
+		jobs, err := NewGeekjob(fake).Fetch(context.Background(), CompanyEntry{})
+		if err != nil {
+			t.Fatalf("Fetch(%q): %v", tc.arrangement, err)
+		}
+		if len(jobs) != 1 {
+			t.Fatalf("Fetch(%q): got %d jobs, want 1", tc.arrangement, len(jobs))
+		}
+		if jobs[0].WorkMode != tc.wantMode || jobs[0].Remote != tc.wantRemote {
+			t.Errorf("arrangement %q: WorkMode/Remote = %q/%v, want %q/%v",
+				tc.arrangement, jobs[0].WorkMode, jobs[0].Remote, tc.wantMode, tc.wantRemote)
+		}
+	}
+}
+
+func TestGeekjobPaginatesAndDedupsAnchors(t *testing.T) {
+	id1 := "6a5880f9186d0bddab0010e9"
+	id2 := "6a589c8bda741b31f007fe90"
+	id3 := "6a589d7ef00925a5be04b9ae"
+	fake := (&routedHTTP{}).
+		route("/vacancies/1", geekjobListingHTML(id1, id2)).
+		route("/vacancies/2", geekjobListingHTML(id3)).
+		route("/vacancies/3", geekjobEmptyListingHTML).
+		route("/vacancy/"+id1, geekjobDetailHTML("Role 1", "Acme", "Удаленная работа")).
+		route("/vacancy/"+id2, geekjobDetailHTML("Role 2", "Acme", "Работа в офисе")).
+		route("/vacancy/"+id3, geekjobDetailHTML("Role 3", "Acme", "Удаленная работа"))
+
+	jobs, err := NewGeekjob(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (across two listing pages, anchors deduped)", len(jobs))
+	}
+	ids := []string{jobs[0].ExternalID, jobs[1].ExternalID, jobs[2].ExternalID}
+	for _, want := range []string{id1, id2, id3} {
+		if !slices.Contains(ids, want) {
+			t.Errorf("missing job %q in %v", want, ids)
+		}
+	}
+}
+
+func TestGeekjobDropsDetailWithoutJobPosting(t *testing.T) {
+	id1 := "6a5880f9186d0bddab0010e9"
+	id2 := "6a589c8bda741b31f007fe90"
+	fake := (&routedHTTP{}).
+		route("/vacancies/1", geekjobListingHTML(id1, id2)).
+		route("/vacancies/2", geekjobEmptyListingHTML).
+		route("/vacancy/"+id1, geekjobDetailHTML("Good Role", "Acme", "Удаленная работа")).
+		route("/vacancy/"+id2, `<html><body>no ld+json here</body></html>`)
+
+	jobs, err := NewGeekjob(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != id1 {
+		t.Fatalf("got %v, want only the posting with a JobPosting block", jobs)
+	}
+}
+
+func TestGeekjobRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["geekjob"]
+	if !ok {
+		t.Fatal("All() missing provider geekjob")
+	}
+	if s.Provider() != "geekjob" {
+		t.Errorf("All()[geekjob].Provider() = %q", s.Provider())
+	}
+	// Aggregator (boardless but many companies) — it stays in the source facet.
+	if !slices.Contains(FilterableProviders(), "geekjob") {
+		t.Error("FilterableProviders() should include geekjob (aggregator)")
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -271,6 +271,7 @@ func All(c HTTPClient) map[string]Source {
 		NewGetmatch(c),
 		NewGetmanfred(c),
 		NewHabrCareer(c),
+		NewGeekjob(c),
 		NewWorkAtAStartup(c),
 		NewJobStash(c),
 		NewArbeitnow(c),
@@ -409,6 +410,13 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// like djinni's, setting SOURCES_PROXY_URL routes only this provider through the proxy with
 	// no code change; while the proxy is unset this entry is inert.
 	"onstrider": func(c HTTPClient) Source { return NewOnstrider(c) },
+	// geekjob.ru is a Russian board reached only over the prod datacenter IP in production and is
+	// untested from it (the spike ran from a residential IP). Like its RU sibling habr_career it
+	// fetches a per-vacancy detail page for the description, so a WAF challenge on the detail HTML
+	// would leave jobs with empty descriptions. It is pre-wired here so that, if the prod IP is
+	// blocked, setting SOURCES_PROXY_URL routes only this provider through the proxy with no code
+	// change; while the proxy is unset this entry is inert. A fixed, trusted host (SSRF caveat).
+	"geekjob": func(c HTTPClient) Source { return NewGeekjob(c) },
 	// career.habr.com sits behind Qrator, which challenges the per-vacancy detail HTML from the
 	// prod datacenter IP (the listing JSON passes, but the description parse fails, leaving jobs
 	// with empty descriptions and so no derived skills/geo/enrichment). A residential IP is served

--- a/sources/geekjob.yml
+++ b/sources/geekjob.yml
@@ -1,0 +1,7 @@
+# Geekjob (geekjob.ru), a Russian-language IT job board. Boardless aggregator: one public
+# listing (geekjob.ru/vacancies/N) aggregating many companies, so the entry carries no board,
+# and each job's company comes from the posting's hiringOrganization, not this placeholder.
+# The crawl fetches a detail page per vacancy for the description, so it gets its own cron slot
+# (like habr_career and getmatch). Aggregator — inherits the reindex ATS-duplicate suppression.
+- company: Geekjob
+  provider: geekjob


### PR DESCRIPTION
## What

Adds `geekjob` — a source adapter for [geekjob.ru](https://geekjob.ru/vacancies), a Russian-language IT job board. Registered as a **boardless aggregator** (one public feed, company per posting from `hiringOrganization`), modeled on the `careerspage` list→detail template.

## How it works

- **Listing:** server-rendered HTML paginated `/vacancies/N`; cards link to `/vacancy/<hex id>`. `crawlPagedLinks` + `jobLinks` collect + dedup links (each card renders several anchors to the same vacancy); an empty page (~page 14) stops the walk.
- **Detail:** each vacancy's schema.org `JobPosting` ld+json carries title, company, description (HTML), `datePosted`, `employmentType`, `jobLocation`. `external_id` is the 24-hex id from the URL. `baseSalary` is present but unused (the `Job` struct has no salary field — enrichment sets it).
- **Work arrangement gotcha:** remote/onsite is **not** in the ld+json — it lives only in the detail page's `jobinfo` chip block ("Удаленная работа" / "Работа в офисе"). Read via `firstByClass`. A posting offering remote maps to `WorkMode=remote` + `Remote=true` (remote wins over a co-listed office chip); office-only → onsite; neither → unset with the location heuristic deciding `Remote`.

## Proxy pre-wire

Pre-wired (inert) into `proxiedProviders` like its RU sibling `habr_career`: the crawl is verified only from a residential IP; a Russian board behind a WAF may challenge the detail HTML from the prod datacenter IP (leaving empty descriptions). If so, setting `SOURCES_PROXY_URL` routes only this provider through the proxy — no code change. Inert while unset.

## Verification

- `go build ./...`, `go vet`, `gofmt` clean; 7 unit tests pass (field mapping, WorkMode cases, anchor dedup, pagination stop, drop-without-JobPosting, registry).
- Live end-to-end (residential IP): board file validates, `Fetch` returned 131 vacancies — all with description, date, and real company; fields map correctly.