### PR TITLE
feat(sources): add getro VC/accelerator job-board aggregator

### DIFF
--- a/internal/sources/getro.go
+++ b/internal/sources/getro.go
@@ -1,0 +1,284 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/enrich"
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// getro adapts Getro-powered job boards (<label>.getro.com), the platform many VC/accelerator
+// portfolios use to publish their companies' openings (e.g. jobsinvc.getro.com). The board is
+// the numeric network id — the search API rejects the human-readable subdomain and demands an
+// integer collection id. It is an aggregator, not a single company: each posting carries its own
+// employer (organization.name) and its url points at the company's first-party ATS
+// (greenhouse/lever/workday/…), so it stays in the source facet and its copies are suppressed in
+// favour of the first-party posting when freehire also crawls that ATS directly.
+//
+// The search listing carries rich STRUCTURED facets (work_mode, seniority, skills, locations) but
+// no description; the description lives only in the SSR detail page's __NEXT_DATA__. So — like
+// justjoin/nofluffjobs — getro is a HydratingSource: FetchNew fetches a posting's detail only for
+// postings the catalogue does not already have, and re-lists the rest as liveness refreshes.
+type getro struct {
+	http getroHTTP
+}
+
+// getroHTTP is the transport getro needs: the POST search listing (JSONPoster), the collection
+// metadata GET that resolves the board's subdomain (JSONGetter), and the SSR detail page whose
+// __NEXT_DATA__ carries the description (HTMLGetter).
+type getroHTTP interface {
+	JSONPoster
+	JSONGetter
+	HTMLGetter
+}
+
+// NewGetro builds the Getro adapter over the given HTTP client.
+func NewGetro(c getroHTTP) Source { return getro{http: c} }
+
+func (getro) Provider() string { return "getro" }
+
+// getro aggregates postings from many companies (company per posting), so it stays in the source
+// facet and its ATS-duplicate copies are suppressed by the cross-source dedup pass. It is NOT
+// boardless — the board is the numeric network id the search API requires.
+func (getro) aggregator() {}
+
+const (
+	// getroSearchURL is the public job-search endpoint; the path segment is the numeric network
+	// (collection) id. It is POST-only and paginates by a 0-based page with a hits_per_page size.
+	getroSearchURL = "https://api.getro.com/api/v2/collections/%s/search/jobs"
+	// getroMetaURL is the collection metadata; its data.attributes.label is the board subdomain
+	// (<label>.getro.com) the SSR detail page is served from.
+	getroMetaURL = "https://api.getro.com/api/v2/collections/%s"
+	// getroDetailURL is the SSR job page carrying the description. The company path segment is
+	// cosmetic — the page resolves off the job slug (which embeds the job id) — but the real
+	// organization slug is used when the listing provides it.
+	getroDetailURL = "https://%s.getro.com/companies/%s/jobs/%s"
+	// getroPageSize is the listing page size. The API caps the returned page but honours a large
+	// hits_per_page; 100 keeps each response modest while bounding the page count.
+	getroPageSize = 100
+	// getroMaxPages bounds pagination so a server that mis-reports count (never emptying its data)
+	// cannot loop forever; the count/empty-page check ends it sooner.
+	getroMaxPages = 200
+)
+
+// getroSearchResponse is one search page: the postings plus the network-wide total (count), used
+// to stop paging once every posting has been collected.
+type getroSearchResponse struct {
+	Results struct {
+		Jobs  []getroPosting `json:"jobs"`
+		Count int            `json:"count"`
+	} `json:"results"`
+}
+
+// getroPosting is one listing entry. url is already the first-party ATS apply link; created_at is
+// epoch seconds; slug embeds the job id and drives the detail URL.
+type getroPosting struct {
+	ID           int64    `json:"id"`
+	Slug         string   `json:"slug"`
+	Title        string   `json:"title"`
+	URL          string   `json:"url"`
+	WorkMode     string   `json:"work_mode"`
+	Seniority    string   `json:"seniority"`
+	Skills       []string `json:"skills"`
+	Locations    []string `json:"locations"`
+	CreatedAt    int64    `json:"created_at"`
+	Organization struct {
+		Name string `json:"name"`
+		Slug string `json:"slug"`
+	} `json:"organization"`
+}
+
+// Fetch is the list-only crawl (no description): kept as the fallback for callers that do not
+// drive hydration. FetchNew is the hydrating path used by ingest.
+func (s getro) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	postings, err := s.list(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+	var jobs []Job
+	for _, p := range postings {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// FetchNew is the hydrating crawl: it lists the same board, but fetches a posting's detail (the
+// description the listing omits) only for a posting the catalogue does not already have — seen
+// reports whether a posting's id is already ingested. A seen posting yields the list-only job as a
+// liveness refresh (no detail request); an unseen posting is hydrated with its description; a
+// single detail failure is isolated (logged, falling back to list-only so the posting is still
+// ingested). Detail fetches run under the shared bounded worker pool.
+func (s getro) FetchNew(ctx context.Context, e CompanyEntry, seen func(externalID string) bool) ([]Job, error) {
+	postings, err := s.list(ctx, e.Board)
+	if err != nil {
+		return nil, err
+	}
+	// Resolve the board's subdomain once — every detail page is served from it. If it cannot be
+	// resolved the crawl degrades to list-only (detail returns ok=false for an empty label), so a
+	// metadata hiccup never fails the board.
+	label := s.label(ctx, e.Board)
+	return fetchDetails(postings, defaultDetailWorkers, func(p getroPosting) (Job, bool) {
+		base, ok := p.toJob()
+		if !ok {
+			return Job{}, false // unusable posting — dropped, as in Fetch
+		}
+		if seen(base.ExternalID) {
+			// Already ingested: refresh liveness only, no detail request. The pipeline must not
+			// re-upsert content — an empty description would re-derive its facets to empty. base
+			// carries just the identity fields toJob set.
+			base.SeenRefresh = true
+			return base, true
+		}
+		desc, ok := s.detail(ctx, label, p)
+		if !ok {
+			log.Printf("getro: detail %d failed; ingesting list-only", p.ID)
+			return base, true
+		}
+		base.Description = desc
+		return base, true
+	}), nil
+}
+
+// list pages the search endpoint (page size getroPageSize, 0-based) until the reported count is
+// reached or a page returns no postings, whichever comes first. Each page carries the postings
+// with their structured facets inline.
+func (s getro) list(ctx context.Context, board string) ([]getroPosting, error) {
+	url := fmt.Sprintf(getroSearchURL, board)
+	var all []getroPosting
+	for page := 0; page < getroMaxPages; page++ {
+		var resp getroSearchResponse
+		body := map[string]int{"hits_per_page": getroPageSize, "page": page}
+		if err := s.http.PostJSON(ctx, url, body, &resp); err != nil {
+			return nil, fmt.Errorf("getro: search page %d: %w", page, err)
+		}
+		all = append(all, resp.Results.Jobs...)
+		if len(resp.Results.Jobs) == 0 || len(all) >= resp.Results.Count {
+			break
+		}
+	}
+	return all, nil
+}
+
+// label resolves the board's subdomain from the collection metadata (data.attributes.label). It
+// returns "" on any failure, which degrades FetchNew to list-only rather than failing the board.
+func (s getro) label(ctx context.Context, board string) string {
+	var resp struct {
+		Data struct {
+			Attributes struct {
+				Label string `json:"label"`
+			} `json:"attributes"`
+		} `json:"data"`
+	}
+	if err := s.http.GetJSON(ctx, fmt.Sprintf(getroMetaURL, board), &resp); err != nil {
+		return ""
+	}
+	return resp.Data.Attributes.Label
+}
+
+// getroNextData is the slice of the SSR detail page's __NEXT_DATA__ we read: the current job's
+// description (HTML). Only the fields we render are modelled; encoding/json ignores the rest.
+type getroNextData struct {
+	Props struct {
+		PageProps struct {
+			InitialState struct {
+				Jobs struct {
+					CurrentJob struct {
+						Description string `json:"description"`
+					} `json:"currentJob"`
+				} `json:"jobs"`
+			} `json:"initialState"`
+		} `json:"pageProps"`
+	} `json:"props"`
+}
+
+// detail fetches a posting's SSR page and extracts its description from the __NEXT_DATA__ payload,
+// returning ok=false when the label/slug is missing, the fetch fails, the script is absent or
+// unparseable, or the job carries no description — so the caller falls back to the list-only job.
+func (s getro) detail(ctx context.Context, label string, p getroPosting) (string, bool) {
+	if label == "" || p.Slug == "" {
+		return "", false
+	}
+	url := fmt.Sprintf(getroDetailURL, label, firstNonEmpty(p.Organization.Slug, "-"), p.Slug)
+	root, err := s.http.GetHTML(ctx, url)
+	if err != nil {
+		return "", false
+	}
+	raw := scriptTextByID(root, "__NEXT_DATA__")
+	if raw == "" {
+		return "", false
+	}
+	var data getroNextData
+	if json.Unmarshal([]byte(raw), &data) != nil {
+		return "", false
+	}
+	desc := sanitizeHTML(data.Props.PageProps.InitialState.Jobs.CurrentJob.Description)
+	if desc == "" {
+		return "", false
+	}
+	return desc, true
+}
+
+// toJob maps a listing posting to a Job, returning ok=false for an unusable posting (no id to key
+// on, no url to link to, or no company which would break the slug). The structured facets Getro
+// states — work_mode, seniority, skills — are mapped into freehire's vocabularies; the description
+// is left for detail hydration.
+func (p getroPosting) toJob() (Job, bool) {
+	if p.ID == 0 || p.URL == "" || p.Organization.Name == "" {
+		return Job{}, false
+	}
+	location := distinctJoin(p.Locations, "; ", func(s string) string { return s })
+	workMode := getroWorkMode(p.WorkMode)
+	return Job{
+		ExternalID: strconv.FormatInt(p.ID, 10),
+		URL:        p.URL,
+		Title:      strings.TrimSpace(p.Title),
+		Company:    strings.TrimSpace(p.Organization.Name),
+		Location:   location,
+		WorkMode:   workMode,
+		Remote:     workMode == "remote" || isRemote(location),
+		Seniority:  getroSeniority(p.Seniority),
+		Skills:     skilltag.Parse(strings.Join(p.Skills, " ")),
+		PostedAt:   parseEpochSeconds(p.CreatedAt),
+	}, true
+}
+
+// getroWorkMode maps Getro's work_mode enum into freehire's work-mode vocabulary. Getro spells the
+// office value with an underscore ("on_site"); normalising it to a hyphen lets the shared
+// workplaceTypeMode do the rest (remote/hybrid/on-site → remote/hybrid/onsite, unknown → "").
+func getroWorkMode(m string) string {
+	return workplaceTypeMode(strings.ReplaceAll(m, "_", "-"))
+}
+
+// getroSeniority maps Getro's LinkedIn-style seniority grade into freehire's vocabulary
+// (enrich.SeniorityValues: intern/junior/middle/senior/lead/staff/principal/c_level). It maps to a
+// candidate then checks vocabulary membership, so an unmapped or mis-mapped grade drops to "" and
+// lets the title dictionary decide rather than being guessed.
+func getroSeniority(level string) string {
+	var l string
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "internship":
+		l = "intern"
+	case "entry_level":
+		l = "junior"
+	case "senior":
+		l = "senior"
+	case "cxo":
+		l = "c_level"
+		// Getro's remaining grades — "associate", "mid_senior", "director", "vice_president" — are
+		// LinkedIn's cross-functional levels with no exact twin in freehire's IC-oriented ladder, so
+		// they are deliberately left unmapped: the title dictionary classifies them from the job
+		// title instead of this adapter guessing (per the dict-only "never guess unknowns" convention).
+	}
+	if slices.Contains(enrich.SeniorityValues, l) {
+		return l
+	}
+	return ""
+}

--- a/internal/sources/getro_test.go
+++ b/internal/sources/getro_test.go
@@ -1,0 +1,255 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+// getroFake serves the POST search listing by page, the collection metadata (label), and the SSR
+// detail HTML routed by the job slug in the URL.
+type getroFake struct {
+	pages      map[int]string    // page number -> search response JSON
+	label      string            // collection metadata label (board subdomain)
+	labelErr   bool              // metadata lookup fails
+	detailHTML map[string]string // job slug -> detail page HTML
+	detailErr  map[string]bool   // job slug -> detail fetch fails
+	detailURLs []string          // detail URLs fetched, for asserting new-only hydration
+}
+
+func (f *getroFake) PostJSON(_ context.Context, _ string, body, v any) error {
+	page := body.(map[string]int)["page"]
+	return json.Unmarshal([]byte(f.pages[page]), v)
+}
+
+func (f *getroFake) GetJSON(_ context.Context, _ string, v any) error {
+	if f.labelErr {
+		return errors.New("meta boom")
+	}
+	return json.Unmarshal([]byte(fmt.Sprintf(`{"data":{"attributes":{"label":%q}}}`, f.label)), v)
+}
+
+func (f *getroFake) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	f.detailURLs = append(f.detailURLs, url)
+	slug := url[strings.LastIndex(url, "/")+1:]
+	if f.detailErr[slug] {
+		return nil, errors.New("detail boom")
+	}
+	return html.Parse(strings.NewReader(f.detailHTML[slug]))
+}
+
+// getroDetailPage builds a minimal SSR detail page carrying the description in __NEXT_DATA__.
+func getroDetailPage(desc string) string {
+	payload, _ := json.Marshal(map[string]any{
+		"props": map[string]any{"pageProps": map[string]any{
+			"initialState": map[string]any{"jobs": map[string]any{
+				"currentJob": map[string]any{"description": desc},
+			}},
+		}},
+	})
+	return `<html><body><script id="__NEXT_DATA__" type="application/json">` + string(payload) + `</script></body></html>`
+}
+
+// 1700000000 is a safely-past epoch (2023-11-14) so NotFuture never drops it regardless of the
+// test clock.
+const getroPostedEpoch = 1700000000
+
+var getroListingJSON = fmt.Sprintf(`{"results":{"count":3,"jobs":[
+  {"id":101,"slug":"101-desktop-analyst","title":"Desktop Analyst","url":"https://boards.greenhouse.io/acme/jobs/1","work_mode":"on_site","seniority":"internship","skills":["Python","Widgets"],"locations":["Zürich, Switzerland"],"created_at":%d,"organization":{"name":"Acme","slug":"acme-1"}},
+  {"id":102,"slug":"102-backend","title":"Backend Engineer","url":"https://jobs.lever.co/beta/2","work_mode":"remote","seniority":"senior","skills":[],"locations":["Anywhere"],"created_at":%d,"organization":{"name":"Beta","slug":"beta-2"}},
+  {"id":103,"slug":"103-drop","title":"No Company","url":"https://x/3","work_mode":"on_site","seniority":"director","skills":[],"locations":[],"created_at":%d,"organization":{"name":"","slug":""}}
+]}}`, getroPostedEpoch, getroPostedEpoch, getroPostedEpoch)
+
+func TestGetroFetchMapsAndDrops(t *testing.T) {
+	fake := &getroFake{pages: map[int]string{0: getroListingJSON}}
+	jobs, err := NewGetro(fake).Fetch(context.Background(), CompanyEntry{Board: "15272"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (no-company dropped)", len(jobs))
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	j := byID["101"]
+	if j.URL != "https://boards.greenhouse.io/acme/jobs/1" {
+		t.Errorf("URL = %q, want the first-party ATS link", j.URL)
+	}
+	if j.Title != "Desktop Analyst" || j.Company != "Acme" {
+		t.Errorf("title/company: %q / %q", j.Title, j.Company)
+	}
+	if j.Location != "Zürich, Switzerland" {
+		t.Errorf("Location = %q", j.Location)
+	}
+	if j.WorkMode != "onsite" {
+		t.Errorf("WorkMode = %q, want onsite (on_site normalized)", j.WorkMode)
+	}
+	if j.Remote {
+		t.Error("Remote = true for a Zürich onsite job, want false")
+	}
+	if j.Seniority != "intern" {
+		t.Errorf("Seniority = %q, want intern (internship->intern)", j.Seniority)
+	}
+	if !slices.Contains(j.Skills, "python") {
+		t.Errorf("Skills = %v, want the canonicalized python", j.Skills)
+	}
+	if j.PostedAt == nil || j.PostedAt.UTC().Year() != 2023 {
+		t.Errorf("PostedAt = %v, want 2023 (epoch seconds)", j.PostedAt)
+	}
+	r := byID["102"]
+	if !r.Remote || r.WorkMode != "remote" || r.Seniority != "senior" {
+		t.Errorf("remote job: Remote=%v WorkMode=%q Seniority=%q", r.Remote, r.WorkMode, r.Seniority)
+	}
+}
+
+func TestGetroListPaginates(t *testing.T) {
+	page0 := fmt.Sprintf(`{"results":{"count":3,"jobs":[
+	  {"id":1,"slug":"1-a","title":"A","url":"https://x/1","organization":{"name":"Co"},"created_at":%d},
+	  {"id":2,"slug":"2-b","title":"B","url":"https://x/2","organization":{"name":"Co"},"created_at":%d}
+	]}}`, getroPostedEpoch, getroPostedEpoch)
+	page1 := fmt.Sprintf(`{"results":{"count":3,"jobs":[
+	  {"id":3,"slug":"3-c","title":"C","url":"https://x/3","organization":{"name":"Co"},"created_at":%d}
+	]}}`, getroPostedEpoch)
+	fake := &getroFake{pages: map[int]string{0: page0, 1: page1}}
+	jobs, err := NewGetro(fake).Fetch(context.Background(), CompanyEntry{Board: "15272"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3 across two pages", len(jobs))
+	}
+}
+
+func TestGetroFetchNewHydratesNewOnly(t *testing.T) {
+	listing := fmt.Sprintf(`{"results":{"count":3,"jobs":[
+	  {"id":201,"slug":"201-seen","title":"Seen","url":"https://x/201","organization":{"name":"Co","slug":"co"},"created_at":%d},
+	  {"id":202,"slug":"202-new","title":"New","url":"https://x/202","organization":{"name":"Co","slug":"co"},"created_at":%d},
+	  {"id":203,"slug":"203-err","title":"Err","url":"https://x/203","organization":{"name":"Co","slug":"co"},"created_at":%d}
+	]}}`, getroPostedEpoch, getroPostedEpoch, getroPostedEpoch)
+	fake := &getroFake{
+		pages:      map[int]string{0: listing},
+		label:      "jobsinvc",
+		detailHTML: map[string]string{"202-new": getroDetailPage("<p>Great role</p>")},
+		detailErr:  map[string]bool{"203-err": true},
+	}
+	seen := func(id string) bool { return id == "201" }
+	jobs, err := NewGetro(fake).(HydratingSource).FetchNew(context.Background(), CompanyEntry{Board: "15272"}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("len(jobs) = %d, want 3", len(jobs))
+	}
+	// Detail is fetched only for the unseen postings (202, 203), never for the seen one (201).
+	var slugs []string
+	for _, u := range fake.detailURLs {
+		slugs = append(slugs, u[strings.LastIndex(u, "/")+1:])
+	}
+	slices.Sort(slugs)
+	if !slices.Equal(slugs, []string{"202-new", "203-err"}) {
+		t.Errorf("detail slugs = %v, want [202-new 203-err] (201 not fetched)", slugs)
+	}
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+	if !byID["201"].SeenRefresh || byID["201"].Description != "" {
+		t.Errorf("201: SeenRefresh=%v desc=%q, want refresh-only with empty desc", byID["201"].SeenRefresh, byID["201"].Description)
+	}
+	if d := byID["202"].Description; !strings.Contains(d, "Great role") {
+		t.Errorf("202 description = %q, want the hydrated body", d)
+	}
+	if byID["203"].SeenRefresh || byID["203"].Description != "" {
+		t.Errorf("203 should fall back to list-only (empty desc, not a refresh), got desc=%q refresh=%v", byID["203"].Description, byID["203"].SeenRefresh)
+	}
+}
+
+// When the board subdomain cannot be resolved, FetchNew must degrade to list-only rather than
+// failing the board: no detail is fetched and every posting is ingested list-only.
+func TestGetroFetchNewDegradesWithoutLabel(t *testing.T) {
+	listing := fmt.Sprintf(`{"results":{"count":1,"jobs":[
+	  {"id":301,"slug":"301-x","title":"X","url":"https://x/301","organization":{"name":"Co"},"created_at":%d}
+	]}}`, getroPostedEpoch)
+	fake := &getroFake{pages: map[int]string{0: listing}, labelErr: true}
+	seen := func(string) bool { return false }
+	jobs, err := NewGetro(fake).(HydratingSource).FetchNew(context.Background(), CompanyEntry{Board: "15272"}, seen)
+	if err != nil {
+		t.Fatalf("FetchNew: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].Description != "" {
+		t.Fatalf("jobs = %+v, want one list-only job with empty description", jobs)
+	}
+	if len(fake.detailURLs) != 0 {
+		t.Errorf("detailURLs = %v, want none fetched without a label", fake.detailURLs)
+	}
+}
+
+func TestGetroWorkMode(t *testing.T) {
+	cases := map[string]string{
+		"on_site": "onsite",
+		"remote":  "remote",
+		"hybrid":  "hybrid",
+		"":        "",
+		"unknown": "",
+	}
+	for in, want := range cases {
+		if got := getroWorkMode(in); got != want {
+			t.Errorf("getroWorkMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGetroSeniority(t *testing.T) {
+	cases := map[string]string{
+		"internship":  "intern",
+		"entry_level": "junior",
+		"senior":      "senior",
+		"cxo":         "c_level",
+		"":            "",
+	}
+	for in, want := range cases {
+		if got := getroSeniority(in); got != want {
+			t.Errorf("getroSeniority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestGetroProviderRegistered(t *testing.T) {
+	s := NewGetro(nil)
+	if s.Provider() != "getro" {
+		t.Errorf("Provider() = %q", s.Provider())
+	}
+	if _, ok := s.(boardless); ok {
+		t.Error("getro is board-based (network id), it must NOT be boardless")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("getro should be an aggregator")
+	}
+	if _, ok := s.(HydratingSource); !ok {
+		t.Error("getro should implement HydratingSource")
+	}
+	if _, ok := All(nil)["getro"]; !ok {
+		t.Error("All() should register getro")
+	}
+	if !slices.Contains(FilterableProviders(), "getro") {
+		t.Error("FilterableProviders() should include getro")
+	}
+}
+
+func TestGetroBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/getro.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/getro.yml fails validation: %v", err)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -272,6 +272,7 @@ func All(c HTTPClient) map[string]Source {
 		NewGetmanfred(c),
 		NewHabrCareer(c),
 		NewGeekjob(c),
+		NewGetro(c),
 		NewWorkAtAStartup(c),
 		NewJobStash(c),
 		NewArbeitnow(c),

--- a/sources/getro.yml
+++ b/sources/getro.yml
@@ -1,0 +1,10 @@
+# Getro-powered VC/accelerator job boards (<label>.getro.com). Aggregator: each job carries its
+# own employer (organization.name) and its url points at the company's first-party ATS, so the
+# `company` here is only the board's display name and the getro copy is dedup-suppressed in favour
+# of the first-party ATS when freehire crawls it directly. The `board` is the numeric network
+# (collection) id the search API requires — read it from the board's __NEXT_DATA__
+# (props.pageProps.network.id) or GET https://api.getro.com/api/v2/collections/<id>. See
+# internal/sources/getro.go.
+- company: Jobs in VC
+  provider: getro
+  board: "15272"


### PR DESCRIPTION
Adds a source adapter for **Getro**-powered job boards (`<label>.getro.com`), the platform many VC/accelerator portfolios use (e.g. jobsinvc.getro.com).

## Shape
- **Board = numeric network id.** The search endpoint `POST api.getro.com/api/v2/collections/<id>/search/jobs` demands an integer collection id (the subdomain is rejected `422`). First board: `Jobs in VC` → `15272`.
- **Aggregator, not boardless.** Each posting carries its own employer (`organization.name`) and its `url` points at the company's first-party ATS (greenhouse/lever/workday/…), so it stays in the source facet and its copies are dedup-suppressed in favour of the first-party posting.
- **HydratingSource** (like justjoin/nofluffjobs). The listing carries structured facets (`work_mode`, `seniority`, `skills`, `locations`) but no description; the description lives only in the SSR detail page's `__NEXT_DATA__`. `FetchNew` fetches a posting's SSR detail only for postings not already ingested, resolving the board subdomain once from the collection metadata.

## Mapping notes
- `work_mode`: `on_site`→onsite / `remote` / `hybrid` (underscore normalised).
- `seniority`: LinkedIn-style ladder → freehire vocab. `internship`→intern, `entry_level`→junior, `senior`, `cxo`→c_level. The cross-functional grades (associate/mid_senior/director/vice_president) are deliberately left unmapped so the title dictionary classifies them (dict-only "never guess" convention).
- `skills` canonicalised via `skilltag.Parse`.

## Verification
Live against jobsinvc (network 15272): `Fetch` → 409 postings; `FetchNew` → 376/409 hydrated with descriptions (the rest are structurally description-less, correctly list-only). Unit tests cover mapping, pagination, new-only hydration, label-failure degradation, and config validation.