### PR TITLE
feat(sources): add 4dayweek boardless aggregator adapter

### DIFF
--- a/internal/sources/fourdayweek.go
+++ b/internal/sources/fourdayweek.go
@@ -1,0 +1,188 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// fourDayWeek adapts 4dayweek.io, a curated board of roles offering a shortened work week.
+// Like the other aggregators it is boardless (one public API, no per-tenant board) yet lists
+// many employers, so it stays in the source facet and takes each posting's company from the
+// feed. The list API paginates and carries the platform's structured facets inline
+// (work_arrangement, level, category, stack), but no description and no apply link, so the
+// canonical URL is synthesized from the slug and the body is left for downstream enrichment.
+type fourDayWeek struct {
+	http JSONGetter
+}
+
+const (
+	// fourDayWeekListURL pages the public listing; limit=100 is the largest page the API honours.
+	fourDayWeekListURL = "https://4dayweek.io/api/jobs?page=%d&limit=100"
+	// fourDayWeekJobURL is the public job page, keyed by slug — the outbound apply link.
+	fourDayWeekJobURL = "https://4dayweek.io/job/%s"
+	// fourDayWeekMaxPages bounds pagination so a feed that never reports has_more=false cannot
+	// loop forever. The catalogue is ~21k postings at 100/page, so this leaves ample headroom.
+	fourDayWeekMaxPages = 400
+)
+
+// NewFourDayWeek builds the 4dayweek adapter over the given HTTP client.
+func NewFourDayWeek(c JSONGetter) Source { return fourDayWeek{http: c} }
+
+func (fourDayWeek) Provider() string { return "4dayweek" }
+
+// 4dayweek needs no board id (one API), so its config carries no board.
+func (fourDayWeek) boardless() {}
+
+// 4dayweek aggregates postings from many companies, so it stays in the source facet.
+func (fourDayWeek) aggregator() {}
+
+// fourDayWeekLocation is one location entry; the primary (or first) supplies the display string.
+type fourDayWeekLocation struct {
+	City      string `json:"city"`
+	Country   string `json:"country"`
+	IsPrimary bool   `json:"is_primary"`
+}
+
+// fourDayWeekPosting is one posting from the list API (facets inline, no body, no apply link).
+type fourDayWeekPosting struct {
+	ID              string                `json:"id"`
+	Slug            string                `json:"slug"`
+	Title           string                `json:"title"`
+	CompanyName     string                `json:"company_name"`
+	WorkArrangement string                `json:"work_arrangement"`
+	Level           string                `json:"level"`
+	Category        string                `json:"category"`
+	Posted          int64                 `json:"posted"`
+	Locations       []fourDayWeekLocation `json:"locations"`
+	Stack           []struct {
+		Name string `json:"name"`
+	} `json:"stack"`
+}
+
+func (s fourDayWeek) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; page <= fourDayWeekMaxPages; page++ {
+		var resp struct {
+			Jobs    []fourDayWeekPosting `json:"jobs"`
+			HasMore bool                 `json:"has_more"`
+		}
+		if err := s.http.GetJSON(ctx, fmt.Sprintf(fourDayWeekListURL, page), &resp); err != nil {
+			return nil, fmt.Errorf("4dayweek: page %d: %w", page, err)
+		}
+		for _, p := range resp.Jobs {
+			if job, ok := p.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		if len(resp.Jobs) == 0 || !resp.HasMore {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a posting to a Job, returning ok=false for an unusable posting (no native id,
+// which would collide on the dedup key, no slug to build the URL, or no company, which would
+// break the slug). The platform's structured facets map straight into freehire's vocabularies;
+// values it does not state (or that have no clean equivalent) are left empty for the pipeline's
+// dictionaries to decide.
+func (p fourDayWeekPosting) toJob() (Job, bool) {
+	if p.ID == "" || p.Slug == "" || p.CompanyName == "" {
+		return Job{}, false
+	}
+	names := make([]string, 0, len(p.Stack))
+	for _, s := range p.Stack {
+		names = append(names, s.Name)
+	}
+	return Job{
+		ExternalID: p.ID,
+		URL:        fmt.Sprintf(fourDayWeekJobURL, p.Slug),
+		Title:      p.Title,
+		Company:    p.CompanyName,
+		Location:   p.location(),
+		Remote:     p.WorkArrangement == "remote",
+		WorkMode:   fourDayWeekWorkMode(p.WorkArrangement),
+		Seniority:  fourDayWeekSeniority(p.Level),
+		Category:   fourDayWeekCategory(p.Category),
+		Skills:     skilltag.Parse(strings.Join(names, " ")),
+		PostedAt:   parseEpochSeconds(p.Posted),
+	}, true
+}
+
+// location formats the primary (or first) location as "City, Country", degrading to whichever
+// part is present, and empty when the posting carries no location (e.g. some remote roles).
+func (p fourDayWeekPosting) location() string {
+	if len(p.Locations) == 0 {
+		return ""
+	}
+	loc := p.Locations[0]
+	for _, l := range p.Locations {
+		if l.IsPrimary {
+			loc = l
+			break
+		}
+	}
+	switch {
+	case loc.City != "" && loc.Country != "":
+		return loc.City + ", " + loc.Country
+	case loc.City != "":
+		return loc.City
+	default:
+		return loc.Country
+	}
+}
+
+// fourDayWeekWorkMode passes through the platform's structured work_arrangement when it is one
+// of freehire's work modes, else empty so the location heuristic decides.
+func fourDayWeekWorkMode(wa string) string {
+	switch wa {
+	case "remote", "hybrid", "onsite":
+		return wa
+	default:
+		return ""
+	}
+}
+
+// fourDayWeekSeniority maps the platform's level onto enrich.SeniorityValues; an unknown or
+// absent level yields empty so the title dictionary decides.
+func fourDayWeekSeniority(level string) string {
+	switch level {
+	case "entry":
+		return "junior"
+	case "mid":
+		return "middle"
+	case "senior":
+		return "senior"
+	case "lead":
+		return "lead"
+	case "executive":
+		return "c_level"
+	default:
+		return ""
+	}
+}
+
+// fourDayWeekCategory maps the platform's category onto enrich.CategoryValues for the ones with
+// a clean equivalent; generic ("engineering"), ambiguous ("data"), or non-tech-with-no-vocab
+// categories stay empty so the title dictionary decides rather than guessing.
+func fourDayWeekCategory(category string) string {
+	switch category {
+	case "devops":
+		return "devops"
+	case "security":
+		return "security"
+	case "product":
+		return "product"
+	case "design":
+		return "design"
+	case "sales":
+		return "sales"
+	case "marketing":
+		return "marketing"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/fourdayweek_test.go
+++ b/internal/sources/fourdayweek_test.go
@@ -1,0 +1,138 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func TestFourDayWeekProvider(t *testing.T) {
+	if got := NewFourDayWeek(nil).Provider(); got != "4dayweek" {
+		t.Errorf("Provider() = %q, want 4dayweek", got)
+	}
+}
+
+func TestFourDayWeekIsBoardlessAggregator(t *testing.T) {
+	s := NewFourDayWeek(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("4dayweek should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("4dayweek should implement the aggregator marker")
+	}
+}
+
+func TestFourDayWeekRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["4dayweek"]; !ok {
+		t.Error("All() should register provider 4dayweek")
+	}
+	if !slices.Contains(FilterableProviders(), "4dayweek") {
+		t.Error("FilterableProviders() should include 4dayweek")
+	}
+}
+
+func TestFourDayWeekBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/4dayweek.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/4dayweek.yml fails validation: %v", err)
+	}
+}
+
+func TestFourDayWeekFetchPaginatesAndMaps(t *testing.T) {
+	page1 := `{"jobs":[
+{"id":"abc-1","slug":"senior-backend-at-acme-1","title":"Senior Backend Engineer","company_name":"Acme","work_arrangement":"remote","level":"senior","category":"devops","posted":1784307599,"locations":[{"city":"Berlin","country":"Germany","is_primary":true}],"stack":[{"name":"Go"},{"name":"Kubernetes"}]},
+{"id":"","slug":"","title":"skip me","company_name":"NoID"}
+],"has_more":true}`
+	page2 := `{"jobs":[],"has_more":false}`
+	// page=2 routed first so the more specific match wins over the base jobs route.
+	fake := (&routedHTTP{}).route("page=2", page2).route("api/jobs", page1)
+
+	jobs, err := NewFourDayWeek(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (the empty-id posting dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "abc-1" || j.Company != "Acme" || j.Title != "Senior Backend Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://4dayweek.io/job/senior-backend-at-acme-1" {
+		t.Errorf("URL = %q, want the public job page from the slug", j.URL)
+	}
+	if j.WorkMode != "remote" || !j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want remote/true", j.WorkMode, j.Remote)
+	}
+	if j.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior", j.Seniority)
+	}
+	if j.Category != "devops" {
+		t.Errorf("Category = %q, want devops", j.Category)
+	}
+	if j.Location != "Berlin, Germany" {
+		t.Errorf("Location = %q, want \"Berlin, Germany\"", j.Location)
+	}
+	if len(j.Skills) == 0 {
+		t.Errorf("Skills empty, want the stack canonicalized through skilltag")
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed epoch")
+	}
+}
+
+func TestFourDayWeekSeniorityMapping(t *testing.T) {
+	cases := map[string]string{
+		"entry":     "junior",
+		"mid":       "middle",
+		"senior":    "senior",
+		"lead":      "lead",
+		"executive": "c_level",
+		"":          "",
+		"nonsense":  "",
+	}
+	for in, want := range cases {
+		if got := fourDayWeekSeniority(in); got != want {
+			t.Errorf("fourDayWeekSeniority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFourDayWeekCategoryMapping(t *testing.T) {
+	cases := map[string]string{
+		"devops":    "devops",
+		"security":  "security",
+		"product":   "product",
+		"design":    "design",
+		"sales":     "sales",
+		"marketing": "marketing",
+		// Generic or unmapped 4dayweek categories stay empty so the title dictionary decides.
+		"engineering":      "",
+		"data":             "",
+		"operations":       "",
+		"customer-success": "",
+	}
+	for in, want := range cases {
+		if got := fourDayWeekCategory(in); got != want {
+			t.Errorf("fourDayWeekCategory(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFourDayWeekWorkModeMapping(t *testing.T) {
+	cases := map[string]string{
+		"remote": "remote",
+		"hybrid": "hybrid",
+		"onsite": "onsite",
+		"":       "",
+		"weird":  "",
+	}
+	for in, want := range cases {
+		if got := fourDayWeekWorkMode(in); got != want {
+			t.Errorf("fourDayWeekWorkMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -281,6 +281,7 @@ func All(c HTTPClient) map[string]Source {
 		NewWeWorkRemotely(c),
 		NewJobspresso(c),
 		NewStartupAndVC(c),
+		NewFourDayWeek(c),
 		NewTheHub(c),
 		NewGetonbrd(c),
 		NewVagas(c),

--- a/sources/4dayweek.yml
+++ b/sources/4dayweek.yml
@@ -1,0 +1,5 @@
+# 4dayweek.io job board (roles with a shortened work week). Boardless: one public API
+# (4dayweek.io/api/jobs), so the entry carries no board; each job's company comes from the
+# posting, not this placeholder.
+- company: 4dayweek
+  provider: 4dayweek

--- a/web/src/posts/2026-07-18-4dayweek-source.svx
+++ b/web/src/posts/2026-07-18-4dayweek-source.svx
@@ -1,0 +1,20 @@
+---
+title: New source — 4 Day Week
+date: 2026-07-18
+summary: Roles from 4dayweek.io, a curated board of companies hiring on a shortened work week, now feed the catalogue — each posting arrives with its work mode, seniority, and tech stack.
+type: changelog
+tags:
+  - sources
+  - remote
+draft: false
+---
+
+The catalogue now includes **[4 Day Week](https://4dayweek.io)** — a curated board
+of companies that hire on a shortened work week (four-day weeks, nine-day
+fortnights, compressed schedules, and the like).
+
+Each posting comes straight from the hiring company and arrives already tagged with
+its work arrangement (remote, hybrid, or on-site), seniority, and tech stack, so the
+filters work on them from day one.
+
+[Browse the newest jobs](/jobs) to see them arrive.


### PR DESCRIPTION
## What

Adds a source adapter for **[4dayweek.io](https://4dayweek.io)**, a curated board of roles offering a shortened work week — discovered via the ever-jobs source catalogue.

## Shape

- **Boardless aggregator** (one public list API, no per-tenant board), so it stays in the `source` facet and takes each posting's company from the feed — same class as `remoteok`/`arbeitnow`/`jobspresso`.
- Paginates `4dayweek.io/api/jobs?page=N&limit=100` with a `has_more` terminator (bounded by `fourDayWeekMaxPages`). ~21k live postings.
- The list carries the platform's **structured facets inline**, mapped straight into freehire's controlled vocabularies (no LLM needed — the structured-source facets seam):
  - `work_arrangement` → `WorkMode` (remote/hybrid/onsite) + `Remote`
  - `level` → `Seniority` (entry→junior, mid→middle, senior, lead, executive→c_level)
  - `category` → `Category` — **clean equivalents only** (devops/security/product/design/sales/marketing); generic `engineering` and ambiguous `data` are left empty so the title dictionary decides rather than guessing
  - `stack[]` → `Skills` canonicalized through `skilltag.Parse` (same as getmatch/nofluffjobs)
- The API exposes **no description and no apply link**, so the canonical URL is synthesized from the slug (`4dayweek.io/job/<slug>`) and the body is left for downstream enrichment.

## Notes

- 4dayweek is a general board (~65% of postings are non-tech: ops/sales/hr/finance). Per product decision this adapter ingests **all** categories; the enrich non-tech gate keeps LLM budget off marketing/sales/support/management as usual.
- No description means enrichment has limited input, but the rich structured facets (work mode, seniority, category, skills, geo) still populate deterministically.

## Testing

- Unit tests: provider key, boardless+aggregator markers, registry+filterable, board-file validation, pagination+mapping, and table tests for the level/category/work-mode maps.
- Verified against the **live** API (one page, real data): URLs, geo (`Houston, United States` / country-only `United States`), work modes, seniority, category mapping, and skilltag canonicalization all map correctly.
- `go build ./...`, `go vet`, `go test ./internal/sources/` all green; gofmt clean.