### PR TITLE
feat(sources): add functionalworks boardless aggregator adapter

### DIFF
--- a/internal/sources/functionalworks.go
+++ b/internal/sources/functionalworks.go
@@ -1,0 +1,119 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/strelov1/freehire/internal/skilltag"
+)
+
+// functionalWorks adapts functional.works-hub.com, a niche board for functional-programming and
+// adjacent engineering roles. Like the other aggregators it is boardless (one public GraphQL
+// endpoint, no per-tenant board) yet lists many employers, so it stays in the source facet and
+// takes each posting's company from the feed. One query returns the whole backlog (the API has
+// no offset/page argument, so the page_size just needs to exceed the catalogue size) with the
+// body inline — no per-posting detail request.
+type functionalWorks struct {
+	http JSONPoster
+}
+
+const (
+	functionalWorksURL = "https://functional.works-hub.com/api/graphql"
+	// functionalWorksQuery pulls the whole board in one request: page_size is set well above the
+	// live catalogue (~900 postings) because the endpoint exposes no pagination argument.
+	functionalWorksQuery = `{ jobs(page_size:2000, vertical:"functional", published:true) { ` +
+		`title slug remote firstPublished descriptionHtml company { name } ` +
+		`location { city country } tags { label } } }`
+	// functionalWorksJobURL is the public job page, keyed by slug — the outbound apply link.
+	functionalWorksJobURL = "https://functional.works-hub.com/jobs/%s"
+)
+
+// NewFunctionalWorks builds the functionalworks adapter over the given HTTP client.
+func NewFunctionalWorks(c JSONPoster) Source { return functionalWorks{http: c} }
+
+func (functionalWorks) Provider() string { return "functionalworks" }
+
+// functionalworks needs no board id (one GraphQL endpoint), so its config carries no board.
+func (functionalWorks) boardless() {}
+
+// functionalworks aggregates postings from many companies, so it stays in the source facet.
+func (functionalWorks) aggregator() {}
+
+// functionalWorksPosting is one posting from the GraphQL feed, body inline (no detail call).
+type functionalWorksPosting struct {
+	Title          string `json:"title"`
+	Slug           string `json:"slug"`
+	Remote         bool   `json:"remote"`
+	FirstPublished string `json:"firstPublished"`
+	DescriptionML  string `json:"descriptionHtml"`
+	Company        struct {
+		Name string `json:"name"`
+	} `json:"company"`
+	Location struct {
+		City    string `json:"city"`
+		Country string `json:"country"`
+	} `json:"location"`
+	Tags []struct {
+		Label string `json:"label"`
+	} `json:"tags"`
+}
+
+func (s functionalWorks) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	body := struct {
+		Query string `json:"query"`
+	}{Query: functionalWorksQuery}
+	var resp struct {
+		Data struct {
+			Jobs []functionalWorksPosting `json:"jobs"`
+		} `json:"data"`
+	}
+	if err := s.http.PostJSON(ctx, functionalWorksURL, body, &resp); err != nil {
+		return nil, fmt.Errorf("functionalworks: query: %w", err)
+	}
+	jobs := make([]Job, 0, len(resp.Data.Jobs))
+	for _, p := range resp.Data.Jobs {
+		if job, ok := p.toJob(); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a posting to a Job, returning ok=false for an unusable posting (no slug to build
+// the URL and key on, or no company, which would break the slug). The structured remote flag
+// sets the work mode; the location text is a fallback. tags canonicalize into skills.
+func (p functionalWorksPosting) toJob() (Job, bool) {
+	if p.Slug == "" || p.Company.Name == "" {
+		return Job{}, false
+	}
+	labels := make([]string, 0, len(p.Tags))
+	for _, t := range p.Tags {
+		labels = append(labels, t.Label)
+	}
+	return Job{
+		ExternalID:  p.Slug,
+		URL:         fmt.Sprintf(functionalWorksJobURL, p.Slug),
+		Title:       p.Title,
+		Company:     p.Company.Name,
+		Location:    p.location(),
+		Description: sanitizeHTML(p.DescriptionML),
+		Remote:      p.Remote || isRemote(p.location()),
+		WorkMode:    workModeFromRemote(p.Remote),
+		Skills:      skilltag.Parse(strings.Join(labels, " ")),
+		PostedAt:    parseRFC3339(p.FirstPublished),
+	}, true
+}
+
+// location formats the posting's location as "City, Country", degrading to whichever part is
+// present (the API leaves city null for country-only postings).
+func (p functionalWorksPosting) location() string {
+	switch {
+	case p.Location.City != "" && p.Location.Country != "":
+		return p.Location.City + ", " + p.Location.Country
+	case p.Location.City != "":
+		return p.Location.City
+	default:
+		return p.Location.Country
+	}
+}

--- a/internal/sources/functionalworks_test.go
+++ b/internal/sources/functionalworks_test.go
@@ -1,0 +1,92 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestFunctionalWorksProvider(t *testing.T) {
+	if got := NewFunctionalWorks(nil).Provider(); got != "functionalworks" {
+		t.Errorf("Provider() = %q, want functionalworks", got)
+	}
+}
+
+func TestFunctionalWorksIsBoardlessAggregator(t *testing.T) {
+	s := NewFunctionalWorks(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("functionalworks should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("functionalworks should implement the aggregator marker")
+	}
+}
+
+func TestFunctionalWorksRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["functionalworks"]; !ok {
+		t.Error("All() should register provider functionalworks")
+	}
+	if !slices.Contains(FilterableProviders(), "functionalworks") {
+		t.Error("FilterableProviders() should include functionalworks")
+	}
+}
+
+func TestFunctionalWorksBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/functionalworks.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/functionalworks.yml fails validation: %v", err)
+	}
+}
+
+func TestFunctionalWorksFetchMaps(t *testing.T) {
+	resp := `{"data":{"jobs":[
+{"title":"Senior Scala Engineer","slug":"remote-senior-scala-engineer-abc","company":{"name":"Acme"},"location":{"city":"Berlin","country":"Germany"},"remote":true,"firstPublished":"2026-07-15T21:18:56.516Z","descriptionHtml":"<p>Build &amp; ship with Scala.</p>","tags":[{"label":"Scala"},{"label":"Kafka"}]},
+{"title":"On-site Clojure Dev","slug":"clojure-dev-2","company":{"name":"Globex"},"location":{"city":null,"country":"France"},"remote":false,"firstPublished":"2026-07-10T00:00:00Z","descriptionHtml":"<p>Onsite role.</p>","tags":[]},
+{"title":"No slug","slug":"","company":{"name":"NoSlug"}},
+{"title":"No company","slug":"has-slug-3","company":{"name":""}}
+]}}`
+	fake := (&routedHTTP{}).route("graphql", resp)
+
+	jobs, err := NewFunctionalWorks(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (empty-slug and empty-company dropped)", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != "remote-senior-scala-engineer-abc" || j.Company != "Acme" || j.Title != "Senior Scala Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://functional.works-hub.com/jobs/remote-senior-scala-engineer-abc" {
+		t.Errorf("URL = %q, want the public job page from the slug", j.URL)
+	}
+	if j.Location != "Berlin, Germany" {
+		t.Errorf("Location = %q, want \"Berlin, Germany\"", j.Location)
+	}
+	if j.WorkMode != "remote" || !j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want remote/true", j.WorkMode, j.Remote)
+	}
+	if !strings.Contains(j.Description, "Build") || !strings.Contains(j.Description, "ship") {
+		t.Errorf("Description lost content: %q", j.Description)
+	}
+	if len(j.Skills) == 0 {
+		t.Errorf("Skills empty, want the tags canonicalized through skilltag")
+	}
+	if j.PostedAt == nil {
+		t.Error("PostedAt nil, want parsed firstPublished")
+	}
+
+	// The second job: city is null (country only) and a non-remote role leaves WorkMode empty.
+	j2 := jobs[1]
+	if j2.Location != "France" {
+		t.Errorf("Location = %q, want \"France\" (city null)", j2.Location)
+	}
+	if j2.WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty for a non-remote posting", j2.WorkMode)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -282,6 +282,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJobspresso(c),
 		NewStartupAndVC(c),
 		NewFourDayWeek(c),
+		NewFunctionalWorks(c),
 		NewTheHub(c),
 		NewGetonbrd(c),
 		NewVagas(c),

--- a/sources/functionalworks.yml
+++ b/sources/functionalworks.yml
@@ -1,0 +1,5 @@
+# Functional Works (functional.works-hub.com) niche engineering board. Boardless: one public
+# GraphQL endpoint (functional.works-hub.com/api/graphql), so the entry carries no board; each
+# job's company comes from the posting, not this placeholder.
+- company: Functional Works
+  provider: functionalworks

--- a/web/src/posts/2026-07-18-functionalworks-source.svx
+++ b/web/src/posts/2026-07-18-functionalworks-source.svx
@@ -1,0 +1,19 @@
+---
+title: New source — Functional Works
+date: 2026-07-18
+summary: Roles from Functional Works, a niche board for functional-programming and adjacent engineering jobs, now feed the catalogue — each posting arrives with its full description, tech stack, and work mode.
+type: changelog
+tags:
+  - sources
+  - remote
+draft: false
+---
+
+The catalogue now includes **[Functional Works](https://functional.works-hub.com)** —
+a niche board for functional-programming and adjacent engineering roles (Scala,
+Haskell, Clojure, Rust, and the like), heavy on remote and blockchain work.
+
+Each posting comes straight from the hiring company with its full description, tech
+stack, and work mode, so it lands ready to filter and search.
+
+[Browse the newest jobs](/jobs) to see them arrive.


### PR DESCRIPTION
## What

Adds a source adapter for **[Functional Works](https://functional.works-hub.com)** (functional.works-hub.com) — a niche board for functional-programming and adjacent engineering roles (Scala, Haskell, Clojure, Rust, blockchain-heavy). Discovered via the ever-jobs source catalogue.

## Shape

- **Boardless aggregator** (one public GraphQL endpoint, no per-tenant board), so it stays in the `source` facet and takes each posting's company from the feed — same class as `remoteok`/`arbeitnow`/`jobspresso`/`4dayweek`.
- **Single GraphQL POST returns the whole backlog** (~886 live postings). The endpoint exposes no offset/page argument, so `page_size` is simply set above the catalogue size (verified: `page_size` 1000 and 3000 both return 886). No per-posting detail request — the body is inline.
- Maps the inline fields into the normalized `Job`:
  - `descriptionHtml` → `Description` (sanitized)
  - `remote` → `WorkMode` (remote) + `Remote`, with the location text as fallback
  - `tags[].label` → `Skills` canonicalized through `skilltag.Parse` (same as getmatch/nofluffjobs)
  - `location{city,country}` → `"City, Country"` (city is null for country-only postings)
  - `firstPublished` → `PostedAt`
  - URL synthesized from the slug: `functional.works-hub.com/jobs/<slug>`
- Seniority/category are left to the title/description dictionaries (the feed has no structured level/category field).

## Testing

- Unit tests: provider key, boardless+aggregator markers, registry+filterable, board-file validation, and a mapping test covering the full happy path plus dropped postings (empty slug / empty company) and the country-only + non-remote cases.
- Verified against the **live** GraphQL API through the real adapter: 886 jobs mapped, full descriptions, geo, work mode, `firstPublished` (fractional-second RFC3339), and skilltag canonicalization (`aws clojure haskell kinesis redshift rust scala sql ...`) all correct.
- `go build ./...`, `go vet`, `go test ./internal/sources/` all green; gofmt clean.