### PR TITLE
feat(sources): add startupandvc.com VC-jobs aggregator

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -280,6 +280,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJobicy(c),
 		NewWeWorkRemotely(c),
 		NewJobspresso(c),
+		NewStartupAndVC(c),
 		NewTheHub(c),
 		NewGetonbrd(c),
 		NewVagas(c),

--- a/internal/sources/startupandvc.go
+++ b/internal/sources/startupandvc.go
@@ -1,0 +1,163 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"regexp"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// startupandvc adapts startupandvc.com's venture-capital jobs board, a curated Webflow site
+// listing VC roles that link out to the original posting (LinkedIn, an ATS, or a company page).
+// The single listing at /venture-capital-jobs server-renders every card (≤100, Webflow's CMS
+// collection cap; there is no pagination), each linking to a /venture-capital-jobs/<slug> detail
+// page whose schema.org JobPosting ld+json carries the structured fields. The rich description
+// lives in the page's w-richtext body (the ld+json description is only a one-line stub), and an
+// "Apply now" button links to the real posting.
+//
+// Boardless (one site, no per-tenant board) and an aggregator (each posting's employer is its
+// hiringOrganization, and it re-lists jobs owned by first-party ATS boards), so it stays in the
+// source facet and inherits the reindex aggregator/ATS-duplicate suppression.
+type startupandvc struct {
+	http HTMLGetter
+}
+
+// NewStartupAndVC builds the startupandvc.com VC-jobs adapter over the given HTML client.
+func NewStartupAndVC(c HTMLGetter) Source { return startupandvc{http: c} }
+
+func (startupandvc) Provider() string { return "startupandvc" }
+
+func (startupandvc) boardless() {}
+
+func (startupandvc) aggregator() {}
+
+const (
+	// startupandvcBaseURL is the site root the listing's relative /venture-capital-jobs/<slug>
+	// links resolve against.
+	startupandvcBaseURL = "https://www.startupandvc.com/"
+	// startupandvcListURL is the single listing page. Webflow renders every card server-side
+	// (capped at 100), so one GET yields the whole board — there is no pagination to walk.
+	startupandvcListURL = "https://www.startupandvc.com/venture-capital-jobs"
+)
+
+func (s startupandvc) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	base, _ := url.Parse(startupandvcBaseURL) // a constant literal never fails to parse
+
+	root, err := s.http.GetHTML(ctx, startupandvcListURL)
+	if err != nil {
+		return nil, fmt.Errorf("startupandvc: listing: %w", err)
+	}
+	locs := jobLinks(base, root, func(href string) bool { return startupandvcSlug(href) != "" })
+
+	// Each posting's fields come from its own detail fetch (the listing card omits the
+	// description), fanned out under the shared detail pool.
+	return fetchDetails(locs, defaultDetailWorkers, func(loc string) (Job, bool) {
+		return s.detail(ctx, e, loc)
+	}), nil
+}
+
+// detail fetches one vacancy's detail page and maps its JobPosting ld+json (plus the w-richtext
+// body and the apply button) to a Job, returning ok=false when the fetch fails, the page carries
+// no JobPosting, or the URL yields no slug, so the caller skips just that posting.
+func (s startupandvc) detail(ctx context.Context, e CompanyEntry, loc string) (Job, bool) {
+	root, err := s.http.GetHTML(ctx, loc)
+	if err != nil {
+		return Job{}, false
+	}
+	var p startupandvcPosting
+	if !ldJobPosting(root, &p) || p.Title == "" {
+		return Job{}, false
+	}
+	slug := startupandvcSlug(loc)
+	if slug == "" {
+		return Job{}, false
+	}
+
+	location := p.location()
+	// URL points at the real posting the "Apply now" button links to; when the page has no
+	// external button we fall back to the stable startupandvc landing page.
+	jobURL := firstNonEmpty(startupandvcApplyURL(root), loc)
+
+	return Job{
+		ExternalID:  slug,
+		URL:         jobURL,
+		Title:       p.Title,
+		Company:     firstNonEmpty(p.HiringOrganization.Name, e.Company),
+		Location:    location,
+		Description: startupandvcDescription(root, p.Description),
+		Remote:      isRemote(location),
+		PostedAt:    startupandvcDate(p.DatePosted),
+	}, true
+}
+
+// startupandvcPosting is the schema.org JobPosting decoded from a detail page's ld+json block.
+// jobLocation is a single Place in practice, but decoded through schemaPlaces so an array form
+// does not fail the whole posting's unmarshal.
+type startupandvcPosting struct {
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	DatePosted         string `json:"datePosted"`
+	HiringOrganization struct {
+		Name string `json:"name"`
+	} `json:"hiringOrganization"`
+	JobLocation schemaPlaces `json:"jobLocation"`
+}
+
+// location builds the free-text location from the first jobLocation place, or "" when the posting
+// carries none (a remote-only vacancy often omits it).
+func (p startupandvcPosting) location() string {
+	if len(p.JobLocation) == 0 {
+		return ""
+	}
+	return p.JobLocation[0].Address.Location()
+}
+
+// startupandvcDescription returns the sanitized rich description from the page's w-richtext body,
+// which carries the full posting text; it falls back to the ld+json stub only when the page has no
+// richtext block (the ld+json description is a one-line "<Company> is looking for a <Role>" stub).
+func startupandvcDescription(root *html.Node, ldStub string) string {
+	if body := firstByClass(root, "w-richtext"); body != nil {
+		if rich := innerHTML(body); rich != "" {
+			return sanitizeHTML(rich)
+		}
+	}
+	return sanitizeHTML(html.UnescapeString(ldStub))
+}
+
+// startupandvcSlugPattern captures the <slug> from a /venture-capital-jobs/<slug> detail URL. The
+// match must end at the slug (end-of-string or a ?/# suffix), so the bare /venture-capital-jobs
+// listing path and deeper /venture-capital-jobs/x/y paths never match, and a tracking suffix does
+// not defeat it.
+var startupandvcSlugPattern = regexp.MustCompile(`/venture-capital-jobs/([a-z0-9][a-z0-9-]*)(?:$|[?#])`)
+
+// startupandvcSlug extracts the native posting slug from a URL, or "" when the URL is not a
+// vacancy detail link.
+func startupandvcSlug(loc string) string { return firstSubmatch(startupandvcSlugPattern, loc) }
+
+// startupandvcDate parses startupandvc's "Jul 07, 2026" datePosted (Webflow's "%b %d, %Y" format),
+// which the shared RFC3339/ISO parsers do not recognize. The lenient day layout ("2") accepts both
+// the zero-padded "07" the site emits and a bare "7", should a posting ever drop the pad.
+func startupandvcDate(s string) *time.Time { return parseLayout("Jan 2, 2006", s) }
+
+// startupandvcApplyURL returns the outbound "Apply now" link — the real posting on LinkedIn, an
+// ATS, or the company site — or "" when the page has no external apply button (the caller then
+// falls back to the startupandvc landing page).
+//
+// The button is the page's only <a class="button-large …">, and its href is the destination with
+// startupandvc's tracking params appended (e.g. ".../jobs/view/4417182287/?eBP=…&trk=…?utm_source=
+// startupandvc&…"). We drop the whole query/fragment: these postings carry their identity in the
+// PATH (LinkedIn /jobs/view/<id>/, /posts/<slug>), so trimming yields the clean, stable canonical
+// link and strips both startupandvc's UTM suffix and LinkedIn's session-scoped eBP/trk/refId
+// tracking — which go stale between crawl and click anyway. The trade-off: an ATS destination that
+// kept its id in the query (?gh_jid=…) would lose it, but the board's outbound links are
+// LinkedIn-dominated and path-identified, so a clean link is the better default.
+func startupandvcApplyURL(root *html.Node) string {
+	href := elementAttr(root, "a", "button-large", "href")
+	if href == "" {
+		return ""
+	}
+	return trimURLSuffix(href)
+}

--- a/internal/sources/startupandvc_test.go
+++ b/internal/sources/startupandvc_test.go
@@ -1,0 +1,192 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// startupandvcDetailHTML is a startupandvc.com vacancy detail page: the schema.org JobPosting
+// ld+json (whose description is only a one-line stub), the rich w-richtext body carrying the real
+// description (with a <script> sanitizeHTML must strip), and the external "Apply now" button whose
+// href is the destination with startupandvc's tracking params appended. datePosted is the site's
+// "Jul 07, 2026" format.
+func startupandvcDetailHTML(title, company, locality, country, applyHref string) string {
+	return `<html><head></head><body>
+<h1>` + title + `</h1>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+"title":"` + title + `",
+"description":"<p>` + company + ` is looking for a ` + title + `.</p>",
+"datePosted":"Jul 07, 2026",
+"hiringOrganization":{"@type":"Organization","name":"` + company + `"},
+"jobLocation":{"@type":"Place","address":{"@type":"PostalAddress",
+"addressLocality":"` + locality + `","addressCountry":"` + country + `"}}}
+</script>
+<div class="w-richtext"><h2>POSITION SUMMARY</h2><p>Real body with detail.</p>
+<script>alert(1)</script></div>
+<a href="` + applyHref + `" target="_blank" class="button-large fw w-button">Apply now</a>
+</body></html>`
+}
+
+// startupandvcListingHTML is a listing page linking to each given slug. Like the real markup each
+// card renders several anchors to the same detail page (title, company, logo), exercising the
+// job-link dedup; a non-vacancy nav anchor and the bare listing self-link must be ignored.
+func startupandvcListingHTML(slugs ...string) string {
+	var b strings.Builder
+	b.WriteString(`<html><body><div class="w-dyn-list">`)
+	for _, slug := range slugs {
+		b.WriteString(`<a href="/venture-capital-jobs/` + slug + `">A Role</a>`)
+		b.WriteString(`<a href="/venture-capital-jobs/` + slug + `">A Company</a>`)
+	}
+	b.WriteString(`<a href="/venture-capital-jobs">All jobs</a>`) // listing self-link: ignored
+	b.WriteString(`<a href="/about-us">About</a>`)                // nav: ignored
+	b.WriteString(`</div></body></html>`)
+	return b.String()
+}
+
+func TestStartupAndVCProvider(t *testing.T) {
+	if got := NewStartupAndVC(nil).Provider(); got != "startupandvc" {
+		t.Errorf("Provider() = %q, want %q", got, "startupandvc")
+	}
+}
+
+func TestStartupAndVCSlug(t *testing.T) {
+	cases := map[string]string{
+		"https://www.startupandvc.com/venture-capital-jobs/associate-9a2fb":       "associate-9a2fb",
+		"/venture-capital-jobs/analyst-39b3f":                                     "analyst-39b3f",
+		"https://www.startupandvc.com/venture-capital-jobs/associate-9a2fb?utm=1": "associate-9a2fb",
+		"https://www.startupandvc.com/venture-capital-jobs":                       "", // listing root
+		"https://www.startupandvc.com/venture-capital-jobs/":                      "", // empty slug
+		"https://www.startupandvc.com/venture-capital-jobs/cat/x":                 "", // deeper path
+		"https://www.startupandvc.com/about-us":                                   "",
+	}
+	for loc, want := range cases {
+		if got := startupandvcSlug(loc); got != want {
+			t.Errorf("startupandvcSlug(%q) = %q, want %q", loc, got, want)
+		}
+	}
+}
+
+func TestStartupAndVCFetchListingThenDetailAndMaps(t *testing.T) {
+	slug := "associate-9a2fb"
+	apply := "https://www.linkedin.com/jobs/view/4417182287/?eBP=xyz&trk=abc?utm_source=startupandvc"
+	fake := (&routedHTTP{}).
+		// Detail route first: its slug substring never matches the bare listing URL, and the
+		// listing URL is a substring of the detail URL, so the more specific route must win.
+		route("/venture-capital-jobs/"+slug, startupandvcDetailHTML("Associate", "B Capital Group", "New York", "USA", apply)).
+		route("/venture-capital-jobs", startupandvcListingHTML(slug))
+
+	jobs, err := NewStartupAndVC(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Startup & VC", Provider: "startupandvc",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	j := jobs[0]
+	if j.ExternalID != slug {
+		t.Errorf("ExternalID = %q, want %q", j.ExternalID, slug)
+	}
+	if j.Title != "Associate" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "B Capital Group" {
+		t.Errorf("Company = %q, want hiringOrganization name", j.Company)
+	}
+	if j.Location != "New York, USA" {
+		t.Errorf("Location = %q, want %q", j.Location, "New York, USA")
+	}
+	if strings.Contains(j.Description, "<script>") || strings.Contains(j.Description, "alert(1)") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Real body with detail") {
+		t.Errorf("Description should come from the w-richtext body, got: %q", j.Description)
+	}
+	if strings.Contains(j.Description, "is looking for a") {
+		t.Errorf("Description should prefer the rich body over the ld+json stub, got: %q", j.Description)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2026, 7, 7, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-07-07", j.PostedAt)
+	}
+}
+
+// TestStartupAndVCApplyURL covers the outbound-link decision: the job URL points at the real
+// posting the "Apply now" button links to, and falls back to the stable landing page when the
+// detail page has no external button.
+func TestStartupAndVCApplyURL(t *testing.T) {
+	slug := "associate-9a2fb"
+	detail := "https://www.startupandvc.com/venture-capital-jobs/" + slug
+
+	// With an external apply button, URL is the destination (tracking suffix stripped).
+	apply := "https://www.linkedin.com/jobs/view/4417182287/?eBP=xyz&trk=abc?utm_source=startupandvc"
+	fake := (&routedHTTP{}).
+		route("/venture-capital-jobs/"+slug, startupandvcDetailHTML("Associate", "Acme", "New York", "USA", apply)).
+		route("/venture-capital-jobs", startupandvcListingHTML(slug))
+	jobs, err := NewStartupAndVC(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if want := "https://www.linkedin.com/jobs/view/4417182287/"; jobs[0].URL != want {
+		t.Errorf("URL = %q, want the cleaned external apply target %q", jobs[0].URL, want)
+	}
+
+	// Without an apply button, URL falls back to the startupandvc landing page.
+	noButton := `<html><body>
+<script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting","title":"Associate",
+"description":"stub","datePosted":"Jul 07, 2026",
+"hiringOrganization":{"@type":"Organization","name":"Acme"}}
+</script></body></html>`
+	fake2 := (&routedHTTP{}).
+		route("/venture-capital-jobs/"+slug, noButton).
+		route("/venture-capital-jobs", startupandvcListingHTML(slug))
+	jobs2, err := NewStartupAndVC(fake2).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch (no button): %v", err)
+	}
+	if len(jobs2) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs2))
+	}
+	if jobs2[0].URL != detail {
+		t.Errorf("URL = %q, want the landing-page fallback %q", jobs2[0].URL, detail)
+	}
+}
+
+func TestStartupAndVCDropsDetailWithoutJobPosting(t *testing.T) {
+	good := "associate-9a2fb"
+	bad := "analyst-39b3f"
+	fake := (&routedHTTP{}).
+		route("/venture-capital-jobs/"+good, startupandvcDetailHTML("Associate", "Acme", "New York", "USA", "https://x/apply")).
+		route("/venture-capital-jobs/"+bad, `<html><body>no ld+json here</body></html>`).
+		route("/venture-capital-jobs", startupandvcListingHTML(good, bad))
+
+	jobs, err := NewStartupAndVC(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].ExternalID != good {
+		t.Fatalf("got %v, want only the posting with a JobPosting block", jobs)
+	}
+}
+
+func TestStartupAndVCRegisteredInAll(t *testing.T) {
+	s, ok := All(nil)["startupandvc"]
+	if !ok {
+		t.Fatal("All() missing provider startupandvc")
+	}
+	if s.Provider() != "startupandvc" {
+		t.Errorf("All()[startupandvc].Provider() = %q", s.Provider())
+	}
+	// Aggregator (boardless but many companies) — it stays in the source facet.
+	if !slices.Contains(FilterableProviders(), "startupandvc") {
+		t.Error("FilterableProviders() should include startupandvc (aggregator)")
+	}
+}

--- a/sources/startupandvc.yml
+++ b/sources/startupandvc.yml
@@ -1,0 +1,8 @@
+# startupandvc.com venture-capital jobs board. Boardless aggregator: one Webflow site
+# (/venture-capital-jobs) whose cards each link to a /venture-capital-jobs/<slug> detail page,
+# so the entry carries no board. Each job's company comes from the posting's hiringOrganization
+# and its url points at the original posting (LinkedIn/ATS), so `company` here is only the board's
+# display name and the startupandvc copy is dedup-suppressed in favour of the first-party ATS when
+# freehire crawls it directly. See internal/sources/startupandvc.go.
+- company: Startup & VC
+  provider: startupandvc


### PR DESCRIPTION
## What

Adds a source adapter for [startupandvc.com/venture-capital-jobs](https://www.startupandvc.com/venture-capital-jobs) — a curated Webflow board of venture-capital roles (associate/analyst/principal/etc).

## How it works

- **List → detail.** The single listing renders every card server-side (Webflow's 100-item CMS collection cap; no pagination), each linking to a `/venture-capital-jobs/<slug>` detail page.
- **Structured fields from JSON-LD.** Each detail page carries a schema.org `JobPosting` ld+json (title, company, location, datePosted in `Jul 07, 2026` format).
- **Rich description from the body.** The ld+json `description` is a one-line stub; the real text lives in the page's `w-richtext` container, sanitized and stored.
- **Outbound URL = the real posting.** `Job.URL` is the "Apply now" button's destination (LinkedIn/ATS), with the tracking query stripped (identity is path-based), falling back to the stable landing page when there is no button.
- **Boardless aggregator** — dedup-suppressed in favour of the first-party ATS when freehire crawls it directly.

## Verification

- `go build ./... && go vet` clean; 6 unit tests (`internal/sources/startupandvc_test.go`) green.
- Board file validates against the registry.
- Live run against the site: **100 jobs**, 98/100 with rich descriptions (>200 chars), 100/100 dated, 100/100 with a cleaned external URL + external_id.