### PR TITLE
chore(telegram): drop geekjob/habr channels now covered by direct adapters

### DIFF
--- a/sources/telegram.yml
+++ b/sources/telegram.yml
@@ -24,13 +24,9 @@ channels:
   # --- General IT boards ---
   - channel: it_vakansii_jobs
     kind: board
-  - channel: geekjobs
-    kind: board
   - channel: vakansii_it
     kind: board
   - channel: zrabota
-    kind: board
-  - channel: habr_career
     kind: board
   - channel: huntmejob
     kind: board
@@ -221,8 +217,6 @@ channels:
 
   # Remote / relocation
   - channel: evacuatejobs
-    kind: board
-  - channel: remotegeekjob
     kind: board
   - channel: zarubezhom_jobs
     kind: board


### PR DESCRIPTION
The `geekjobs`, `remotegeekjob` and `habr_career` Telegram channels are the official feeds of geekjob.ru and career.habr.com — which we now ingest **directly** via the `geekjob` (#888) and `habr_career` source adapters.

Crawling their TG channels in addition produced **cross-source duplicates**: the same vacancy appears both as a structured board job (source=`geekjob`/`habr_career`) and as an LLM-extracted `telegram` job with no canonical URL. Dedup can't match them (different source, no shared external_id) and liveness never closes telegram jobs, so they accumulate.

Overlap measured on prod (open jobs, title match): geekjob↔telegram ≈ 54, habr↔telegram ≈ 105; 146 live telegram jobs originate from these 3 channels.

This removes the 3 channels so tg-ingest stops re-creating the duplicates. Existing duplicate telegram jobs are cleaned up separately (soft-close + Meili removal). No code change — the direct adapters are the authoritative source.