### PR TITLE
fix(sources): pace trudvsem crawl to survive board concurrency

### DIFF
--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -70,3 +70,41 @@ func pacedVagasGetter(c HTMLGetter) HTMLGetter {
 		limiter: rate.NewLimiter(rate.Every(vagasRequestInterval), vagasRequestBurst),
 	}
 }
+
+// rateLimitedJSONGetter is the JSONGetter analog of rateLimitedHTMLGetter: it wraps a JSONGetter
+// with a shared limiter so its aggregate GetJSON rate stays under the limit regardless of the
+// pipeline's board-worker concurrency. All requests through one instance share one token bucket.
+type rateLimitedJSONGetter struct {
+	inner   JSONGetter
+	limiter waiter
+}
+
+// GetJSON blocks on the limiter before delegating, so a cancelled context surfaces as the Wait
+// error and the inner fetch is skipped.
+func (g rateLimitedJSONGetter) GetJSON(ctx context.Context, url string, v any) error {
+	if err := g.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	return g.inner.GetJSON(ctx, url, v)
+}
+
+// opendata.trudvsem.ru does not 429, but its gov infra answers large region pages slowly, and
+// the pipeline's 8-way board concurrency fires ~8 of those reads at once from the prod IP —
+// enough that the 15s client read timeout trips and most regions fail (85/90 on the first
+// full-board run), while a single sequential crawl never times out. So pace the aggregate rate
+// to serialize those workers into a gentle stream the API answers within the timeout. ~4 req/s
+// keeps the whole ~4900-page board inside the 40-min ingest window while staying far below the
+// concurrency that overwhelmed it; tune from observed convergence.
+const (
+	trudvsemRequestInterval = 250 * time.Millisecond // ~4 req/s
+	trudvsemRequestBurst    = 3
+)
+
+// pacedTrudvsemGetter wraps a getter with a fresh limiter shared across one registry build, so
+// all of trudvsem's region-shard requests in a run are paced under one gentle aggregate rate.
+func pacedTrudvsemGetter(c JSONGetter) JSONGetter {
+	return rateLimitedJSONGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(trudvsemRequestInterval), trudvsemRequestBurst),
+	}
+}

--- a/internal/sources/pacer_test.go
+++ b/internal/sources/pacer_test.go
@@ -65,3 +65,43 @@ func TestRateLimitedHTMLGetter_WaitErrorShortCircuits(t *testing.T) {
 		t.Fatalf("inner GetHTML called despite Wait error (%d times)", len(inner.urls))
 	}
 }
+
+// recordingJSONGetter records the URLs it was asked to fetch.
+type recordingJSONGetter struct {
+	urls []string
+}
+
+func (g *recordingJSONGetter) GetJSON(_ context.Context, url string, _ any) error {
+	g.urls = append(g.urls, url)
+	return nil
+}
+
+func TestRateLimitedJSONGetter_GatesThenDelegates(t *testing.T) {
+	waiter := &recordingWaiter{}
+	inner := &recordingJSONGetter{}
+	g := rateLimitedJSONGetter{inner: inner, limiter: waiter}
+
+	if err := g.GetJSON(context.Background(), "https://opendata.trudvsem.ru/api/v1/vacancies/region/x", nil); err != nil {
+		t.Fatalf("GetJSON returned error: %v", err)
+	}
+	if waiter.calls != 1 {
+		t.Fatalf("limiter.Wait called %d times, want 1", waiter.calls)
+	}
+	if len(inner.urls) != 1 {
+		t.Fatalf("inner GetJSON called %d times, want 1", len(inner.urls))
+	}
+}
+
+func TestRateLimitedJSONGetter_WaitErrorShortCircuits(t *testing.T) {
+	sentinel := errors.New("rate wait cancelled")
+	waiter := &recordingWaiter{err: sentinel}
+	inner := &recordingJSONGetter{}
+	g := rateLimitedJSONGetter{inner: inner, limiter: waiter}
+
+	if err := g.GetJSON(context.Background(), "https://opendata.trudvsem.ru/", nil); !errors.Is(err, sentinel) {
+		t.Fatalf("GetJSON error = %v, want %v", err, sentinel)
+	}
+	if len(inner.urls) != 0 {
+		t.Fatalf("inner GetJSON called despite Wait error (%d times)", len(inner.urls))
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -314,7 +314,9 @@ func All(c HTTPClient) map[string]Source {
 		NewMicro1(c),
 		NewBairesDev(c),
 		// RU federal open-data aggregator: board-based, sharded per region (board = OKATO code).
-		NewTrudvsem(c),
+		// Paced: its gov API slows under the pipeline's board concurrency until the read timeout
+		// trips, so the aggregate request rate is throttled to a gentle serialized stream.
+		NewTrudvsem(pacedTrudvsemGetter(c)),
 		// hh.ru: multi-company aggregator, enumerated by professional_role (board), reading the
 		// server-rendered search page's embedded state.
 		NewHH(c),


### PR DESCRIPTION
The first full-board prod run of the [Trudvsem source](https://github.com/strelov1/freehire/pull/886) failed **85 of 90 regions** with `context deadline exceeded while reading body`. opendata.trudvsem.ru's government API answers large region pages slowly, and the pipeline crawls ~8 boards at once (`defaultConcurrency=8`), so ~8 slow reads fire from the prod IP simultaneously and trip the 15s client read timeout. A single sequential crawl (the local smoke) never timed out — the cause is concurrency, not the source.

## Fix

Mirror the existing HTML request-pacer for JSON: a `rateLimitedJSONGetter` sharing one limiter across the registry build, wrapping trudvsem's client at ~4 req/s (`rate.Every(250ms)`, burst 3). The 8 board workers now serialize through one gentle token bucket instead of bursting, so the API answers within the timeout. ~4 req/s still finishes the whole ~4900-page board inside the 40-min ingest window, so no region sharding is needed yet.

## Test

`go test ./internal/sources/ -run 'RateLimited|TestTrudvsem'` — new gate-then-delegate + wait-error tests for the JSON pacer, mirroring the HTML pacer's.