### PR TITLE
feat: recognize 1С (skilltag + classify) and pace hh detail fetch

### DIFF
--- a/internal/classify/classify_1c_test.go
+++ b/internal/classify/classify_1c_test.go
@@ -1,0 +1,24 @@
+package classify
+
+import "testing"
+
+// TestParse1C covers 1С category resolution: a title whose only role signal is 1С reads as backend
+// (server-side enterprise dev), but a more specific role word in the title still wins because the
+// 1С aliases sit last in the precedence table.
+func TestParse1C(t *testing.T) {
+	cases := []struct {
+		title   string
+		wantCat string
+	}{
+		{"Программист 1С", "backend"},
+		{"1С-разработчик", "backend"},
+		{"1C Developer", "backend"},
+		{"Аналитик 1С", "data_analytics"}, // analyst wins over 1С→backend
+		{"Тестировщик 1С", "qa"},          // qa wins over 1С→backend
+	}
+	for _, c := range cases {
+		if got := Parse(c.title).Category; got != c.wantCat {
+			t.Errorf("Parse(%q).Category = %q, want %q", c.title, got, c.wantCat)
+		}
+	}
+}

--- a/internal/classify/dictionaries.go
+++ b/internal/classify/dictionaries.go
@@ -212,4 +212,10 @@ var categoryTable = []aliasEntry{
 	{"менеджер", "management"},
 	{"analyst", "data_analytics"},
 	{"аналитик", "data_analytics"},
+	// 1С (the RU enterprise/ERP dev platform) resolves last so a more specific role word in the
+	// title wins first ("Аналитик 1С" → data_analytics, "Тестировщик 1С" → qa); a title whose only
+	// signal is 1С ("Программист 1С", "1С-разработчик") reads as backend — server-side enterprise
+	// development. Bare tokens so any separator ("1С-разработчик", "разработчик 1С") matches.
+	{"1c", "backend"},
+	{"1с", "backend"},
 }

--- a/internal/skilltag/dictionaries.go
+++ b/internal/skilltag/dictionaries.go
@@ -39,15 +39,19 @@ var wordAliases = map[string]string{
 	"groovy":     "groovy",
 	"solidity":   "solidity",
 	// more languages
-	"julia":      "julia",
-	"ocaml":      "ocaml",
-	"fsharp":     "fsharp",
-	"vbnet":      "vbnet",
-	"cobol":      "cobol",
-	"fortran":    "fortran",
-	"matlab":     "matlab",
-	"abap":       "abap",
-	"apex":       "apex",
+	"julia":   "julia",
+	"ocaml":   "ocaml",
+	"fsharp":  "fsharp",
+	"vbnet":   "vbnet",
+	"cobol":   "cobol",
+	"fortran": "fortran",
+	"matlab":  "matlab",
+	"abap":    "abap",
+	"apex":    "apex",
+	// 1c is the RU enterprise platform's own language. Gated (ambiguousWords) because a bare
+	// "1c" also occurs as a figure/list label in English prose; the Cyrillic "1с" form the RU
+	// market uses is a strong phrase alias instead.
+	"1c":         "1c",
 	"nim":        "nim",
 	"zig":        "zig",
 	"assembly":   "assembly",
@@ -629,6 +633,7 @@ var ambiguousWords = map[string]bool{
 	"apex":    true,
 	"julia":   true,
 	"maven":   true,
+	"1c":      true,
 	// broad concepts (batch 3) — tag only in a concrete tech context
 	"ai":         true,
 	"automation": true,
@@ -669,6 +674,9 @@ var phraseAliases = []phraseAlias{
 	{"objective-c", "objective-c"},
 	{"ci/cd", "ci-cd"}, {"ci cd", "ci-cd"},
 	{"c developer", "c"}, {"c programming", "c"}, {"ansi c", "c"},
+	// Cyrillic 1С (the RU market's spelling) — the word pass can't see it ([a-z0-9] only), so it
+	// resolves here as a strong phrase; the Latin "1c" is the gated word alias.
+	{"1с", "1c"},
 	{"machine learning", "machine-learning"},
 	// additional phrases
 	{"rest api", "rest"}, {"rest apis", "rest"},

--- a/internal/skilltag/skilltag_1c_test.go
+++ b/internal/skilltag/skilltag_1c_test.go
@@ -1,0 +1,27 @@
+package skilltag
+
+import (
+	"slices"
+	"testing"
+)
+
+// Test1C covers the two routes to the "1c" canonical: the Cyrillic "1С" the RU market uses
+// resolves as a strong phrase (tags even alone), while the Latin "1c" word alias is gated so it
+// tags only alongside another tech token — a bare "1c" in prose (a figure label) never leaks.
+func Test1C(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"cyrillic standalone is strong", "Требуется программист 1С для доработки конфигураций.", true},
+		{"cyrillic hyphenated", "Ищем 1С-разработчика в продуктовую команду.", true},
+		{"latin corroborated by another tech token", "1C:Enterprise developer, experience with SQL required.", true},
+		{"latin alone in prose is gated out", "Please review figure 1c in the attached report.", false},
+	}
+	for _, c := range cases {
+		if got := slices.Contains(Parse(c.text), "1c"); got != c.want {
+			t.Errorf("%s: Parse(%q) contains %q = %v, want %v", c.name, c.text, "1c", got, c.want)
+		}
+	}
+}

--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -108,3 +108,24 @@ func pacedTrudvsemGetter(c JSONGetter) JSONGetter {
 		limiter: rate.NewLimiter(rate.Every(trudvsemRequestInterval), trudvsemRequestBurst),
 	}
 }
+
+// hh.ru egresses through the single proxy IP (its detail pages 403 the direct datacenter IP), and
+// its per-vacancy detail fan-out is large — thousands of ~1 MB pages across the seeded roles. Fired
+// unpaced at defaultDetailWorkers concurrency, that burst 429s the proxy IP and ~2/3 of details
+// fall back to list-only (which never back-fill, since a seen posting skips detail). Pacing the
+// aggregate rate — not the worker pool — holds it under the proxy window so nearly every detail
+// lands. The interval is a middle ground: fast enough to finish a full role sweep inside the
+// ingest unit's TimeoutStartSec, gentle enough to stop the 429s. Tune from observed convergence.
+const (
+	hhRequestInterval = 250 * time.Millisecond // ~4 req/s
+	hhRequestBurst    = 4
+)
+
+// pacedHHGetter wraps a getter with a fresh limiter shared across one registry build, so all of
+// hh.ru's search and detail requests in a run stay under the proxy IP's per-window budget.
+func pacedHHGetter(c HTMLGetter) HTMLGetter {
+	return rateLimitedHTMLGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(hhRequestInterval), hhRequestBurst),
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -426,12 +426,12 @@ var proxiedProviders = map[string]func(HTTPClient) Source{
 	// blocked, setting SOURCES_PROXY_URL routes only this provider through the proxy with no code
 	// change; while the proxy is unset this entry is inert. A fixed, trusted host (SSRF caveat).
 	"geekjob": func(c HTTPClient) Source { return NewGeekjob(c) },
-	// hh.ru already 403s its public search API from the datacenter IP, so the HTML crawl may be
-	// blocked from prod too (untested there; the spike ran from a residential IP). Pre-wired so a
-	// block is a one-env-var fix. Caveat: hh's per-vacancy detail fan-out is high-volume, so a
-	// single proxy IP may itself get rate-limited — pacing (like careerspage/vagas) may be needed
-	// if the proxy path 429s. While SOURCES_PROXY_URL is unset this entry is inert.
-	"hh": func(c HTTPClient) Source { return NewHH(c) },
+	// hh.ru's detail pages 403 the direct datacenter IP, so on prod it egresses through the proxy;
+	// its high-volume per-vacancy detail fan-out then 429s the single proxy IP unless paced (the
+	// first prod run landed only ~34% of descriptions unpaced), so — like careerspage/vagas — it is
+	// rate-paced (pacedHHGetter) to hold the aggregate rate under the proxy window. While
+	// SOURCES_PROXY_URL is unset this entry is inert (direct crawl is unpaced, fine for local/dev).
+	"hh": func(c HTTPClient) Source { return NewHH(pacedHHGetter(c)) },
 	// career.habr.com sits behind Qrator, which challenges the per-vacancy detail HTML from the
 	// prod datacenter IP (the listing JSON passes, but the description parse fails, leaving jobs
 	// with empty descriptions and so no derived skills/geo/enrichment). A residential IP is served


### PR DESCRIPTION
## What

- **skilltag:** adds **1С** to the skill dictionary. The Cyrillic `1С` (the RU market's spelling, invisible to the ASCII word pass) resolves as a **strong phrase**; the Latin `1c` is a **gated** word alias so a bare `1c` figure/list label in English prose never leaks. SQL was already present.
- **classify:** maps a 1С-only title to **backend** (server-side enterprise dev), placed **last** in the precedence table so a more specific role still wins — `Аналитик 1С` → data_analytics, `Тестировщик 1С` → qa, but `Программист 1С`/`1С-разработчик` → backend.
- **hh pacing:** hh.ru's per-vacancy detail fan-out 429'd the single proxy IP unpaced (the first prod run landed only ~34% of descriptions). It now uses `pacedHHGetter` (~4 req/s) like careerspage/vagas so nearly every detail lands.

## Verification
- `go build ./...`, `go vet`, dictionary-invariant + new `Test1C`/`TestParse1C` + existing skilltag/classify/hh suites — all green.

## Follow-up (ops, after merge+deploy)
- `backfill-derive` + `reindex` to reach existing jobs with the new dictionaries.
- Re-hydrate the hh jobs ingested list-only before pacing (they're `seen` so won't self-heal).