### PR TITLE
fix(web): insights pages respect dark theme

### DIFF
--- a/web/src/lib/components/InsightsPageShell.svelte
+++ b/web/src/lib/components/InsightsPageShell.svelte
@@ -52,25 +52,25 @@
 </script>
 
 <article class="mx-auto w-full max-w-4xl px-4 py-8">
-  <nav aria-label="Breadcrumb" class="mb-4 text-sm text-gray-500">
+  <nav aria-label="Breadcrumb" class="mb-4 text-sm text-muted-foreground">
     <a href={resolve('/')} class="hover:underline">freehire</a>
     <span aria-hidden="true"> › </span>
     <a href={resolve('/insights')} class="hover:underline">Insights</a>
     <span aria-hidden="true"> › </span>
-    <span class="text-gray-700">{label} {KIND_LABEL[kind]}</span>
+    <span class="text-foreground">{label} {KIND_LABEL[kind]}</span>
   </nav>
 
-  <h1 class="text-3xl font-bold tracking-tight text-gray-900">{title}</h1>
-  <p class="mt-3 text-lg text-gray-600">{intro}</p>
-  <p class="mt-1 text-xs text-gray-400">Updated {updated}</p>
+  <h1 class="text-3xl font-bold tracking-tight text-foreground">{title}</h1>
+  <p class="mt-3 text-lg text-muted-foreground">{intro}</p>
+  <p class="mt-1 text-xs text-muted-foreground">Updated {updated}</p>
 
   <section class="mt-8">
     {@render children()}
   </section>
 
-  <aside class="mt-10 border-t border-gray-200 pt-6">
+  <aside class="mt-10 border-t border-border pt-6">
     <div class="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm">
-      <span class="font-medium text-gray-700">More on {label}:</span>
+      <span class="font-medium text-foreground">More on {label}:</span>
       {#each otherKinds as k (k)}
         <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is resolve()d inside kindHref; the linter can't trace it through the helper -->
         <a href={kindHref(k, category)} class="text-blue-600 hover:underline">{KIND_LABEL[k]}</a>
@@ -83,10 +83,10 @@
 
     {#if siblings.length > 0}
       <div class="mt-4 flex flex-wrap items-center gap-2 text-sm">
-        <span class="font-medium text-gray-700">Other categories:</span>
+        <span class="font-medium text-foreground">Other categories:</span>
         {#each siblings as s (s.category)}
           <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- href is resolve()d inside kindHref; the linter can't trace it through the helper -->
-          <a href={kindHref(kind, s.category)} class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 hover:bg-gray-200">
+          <a href={kindHref(kind, s.category)} class="rounded-full bg-secondary px-3 py-1 text-secondary-foreground hover:bg-accent">
             {s.label}
           </a>
         {/each}

--- a/web/src/routes/insights/+page.svelte
+++ b/web/src/routes/insights/+page.svelte
@@ -28,32 +28,32 @@
 </svelte:head>
 
 <div class="mx-auto w-full max-w-4xl px-4 py-8">
-  <h1 class="text-3xl font-bold tracking-tight text-gray-900">Job Market Insights</h1>
-  <p class="mt-3 text-lg text-gray-600">{description}</p>
-  <p class="mt-1 text-sm text-gray-500">
+  <h1 class="text-3xl font-bold tracking-tight text-foreground">Job Market Insights</h1>
+  <p class="mt-3 text-lg text-muted-foreground">{description}</p>
+  <p class="mt-1 text-sm text-muted-foreground">
     Aggregated from open postings on freehire, refreshed through the day. All data is
     also available on the <a href={resolve('/docs/api')} class="text-blue-600 hover:underline">open API</a>.
   </p>
 
   <a
     href={resolve('/insights/companies')}
-    class="mt-6 flex items-center justify-between rounded-lg border border-gray-200 p-4 hover:border-gray-300 hover:bg-gray-50"
+    class="mt-6 flex items-center justify-between rounded-lg border border-border p-4 hover:bg-accent"
   >
     <span>
-      <span class="text-lg font-semibold text-gray-900">Company hiring signal</span>
-      <span class="mt-0.5 block text-sm text-gray-500">Which companies are ramping up or slowing down hiring</span>
+      <span class="text-lg font-semibold text-foreground">Company hiring signal</span>
+      <span class="mt-0.5 block text-sm text-muted-foreground">Which companies are ramping up or slowing down hiring</span>
     </span>
-    <span aria-hidden="true" class="text-gray-400">→</span>
+    <span aria-hidden="true" class="text-muted-foreground">→</span>
   </a>
 
   {#if data.covered.length === 0}
-    <p class="mt-8 text-gray-500">Insights are being computed — check back shortly.</p>
+    <p class="mt-8 text-muted-foreground">Insights are being computed — check back shortly.</p>
   {:else}
     <div class="mt-8 grid gap-4 sm:grid-cols-2">
       {#each data.covered as c (c.category)}
-        <div class="rounded-lg border border-gray-200 p-4">
-          <h2 class="text-lg font-semibold text-gray-900">{c.label}</h2>
-          <p class="mt-0.5 text-xs text-gray-500">{c.openCount.toLocaleString('en-US')} open roles</p>
+        <div class="rounded-lg border border-border p-4">
+          <h2 class="text-lg font-semibold text-foreground">{c.label}</h2>
+          <p class="mt-0.5 text-xs text-muted-foreground">{c.openCount.toLocaleString('en-US')} open roles</p>
           <div class="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm">
             <a href={resolve('/insights/salary/[category]', { category: c.category })} class="text-blue-600 hover:underline">Salaries</a>
             <a href={resolve('/insights/skills/[category]', { category: c.category })} class="text-blue-600 hover:underline">Skills</a>

--- a/web/src/routes/insights/companies/+page.svelte
+++ b/web/src/routes/insights/companies/+page.svelte
@@ -35,15 +35,15 @@
 </svelte:head>
 
 {#snippet board(heading: string, blurb: string, rows: InsightCompany[])}
-  <section class="rounded-lg border border-gray-200 p-4 sm:p-5">
-    <h2 class="text-lg font-semibold text-gray-900">{heading}</h2>
-    <p class="mt-0.5 text-xs text-gray-500">{blurb}</p>
+  <section class="rounded-lg border border-border p-4 sm:p-5">
+    <h2 class="text-lg font-semibold text-foreground">{heading}</h2>
+    <p class="mt-0.5 text-xs text-muted-foreground">{blurb}</p>
     {#if rows.length === 0}
-      <p class="mt-4 text-sm text-gray-500">Not enough data yet.</p>
+      <p class="mt-4 text-sm text-muted-foreground">Not enough data yet.</p>
     {:else}
       <table class="mt-3 w-full border-collapse text-left text-sm">
         <thead>
-          <tr class="border-b border-gray-300 text-gray-500">
+          <tr class="border-b border-border text-muted-foreground">
             <th class="py-2 pr-3 font-medium">Company</th>
             <th class="py-2 pr-3 text-right font-medium">Open</th>
             <th class="py-2 text-right font-medium">30-day</th>
@@ -51,25 +51,26 @@
         </thead>
         <tbody>
           {#each rows as c, i (c.company_slug)}
-            <tr class="border-b border-gray-100">
+            {@const growthTone =
+              c.growth_30d > 0
+                ? 'text-green-600 dark:text-green-400'
+                : c.growth_30d < 0
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-muted-foreground'}
+            <tr class="border-b border-border">
               <td class="py-2 pr-3">
-                <span class="mr-1.5 tabular-nums text-gray-400">{i + 1}.</span>
+                <span class="mr-1.5 tabular-nums text-muted-foreground">{i + 1}.</span>
                 <a
                   href={resolve('/companies/[slug]', { slug: c.company_slug })}
-                  class="font-medium text-gray-900 hover:text-blue-600 hover:underline"
+                  class="font-medium text-foreground hover:text-blue-600 hover:underline"
                 >
                   {c.company_name}
                 </a>
               </td>
-              <td class="py-2 pr-3 text-right tabular-nums text-gray-700">
+              <td class="py-2 pr-3 text-right tabular-nums text-foreground">
                 {c.open_now.toLocaleString('en-US')}
               </td>
-              <td
-                class="py-2 text-right font-medium tabular-nums"
-                class:text-green-600={c.growth_30d > 0}
-                class:text-gray-400={c.growth_30d === 0}
-                class:text-red-600={c.growth_30d < 0}
-              >
+              <td class="py-2 text-right font-medium tabular-nums {growthTone}">
                 {c.growth_30d > 0 ? '+' : ''}{c.growth_30d.toLocaleString('en-US')}
               </td>
             </tr>
@@ -81,18 +82,18 @@
 {/snippet}
 
 <div class="mx-auto w-full max-w-4xl px-4 py-8">
-  <nav class="text-sm text-gray-500">
+  <nav class="text-sm text-muted-foreground">
     <a href={resolve('/insights')} class="hover:underline">Insights</a>
     <span class="mx-1">/</span>
-    <span class="text-gray-700">Companies</span>
+    <span class="text-foreground">Companies</span>
   </nav>
 
-  <h1 class="mt-3 text-3xl font-bold tracking-tight text-gray-900">Company Hiring Signal</h1>
-  <p class="mt-3 text-lg text-gray-600">{description}</p>
-  <p class="mt-1 text-sm text-gray-500">
+  <h1 class="mt-3 text-3xl font-bold tracking-tight text-foreground">Company Hiring Signal</h1>
+  <p class="mt-3 text-lg text-muted-foreground">{description}</p>
+  <p class="mt-1 text-sm text-muted-foreground">
     Change is the difference between open jobs now and 30 days ago. Refreshed daily; also on the
     <a href={resolve('/docs/api')} class="text-blue-600 hover:underline">open API</a>.
-    <span class="text-gray-400">Updated {updated}.</span>
+    <span class="text-muted-foreground">Updated {updated}.</span>
   </p>
 
   <div class="mt-8 grid gap-4 md:grid-cols-2">

--- a/web/src/routes/insights/roles/[category]/+page.svelte
+++ b/web/src/routes/insights/roles/[category]/+page.svelte
@@ -42,11 +42,11 @@
   covered={data.covered}
 >
   {#if data.roles.length === 0}
-    <p class="text-gray-500">No role data for this category yet.</p>
+    <p class="text-muted-foreground">No role data for this category yet.</p>
   {:else}
     <table class="w-full border-collapse text-left text-sm">
       <thead>
-        <tr class="border-b border-gray-300 text-gray-500">
+        <tr class="border-b border-border text-muted-foreground">
           <th class="py-2 pr-4 font-medium">Level</th>
           <th class="py-2 pr-4 font-medium text-right">Open roles</th>
           <th class="py-2 font-medium text-right">30-day growth</th>
@@ -54,15 +54,16 @@
       </thead>
       <tbody>
         {#each data.roles as r (r.seniority)}
-          <tr class="border-b border-gray-100">
-            <td class="py-2 pr-4 font-medium text-gray-900">{seniorityLabel(r.seniority)}</td>
+          {@const growthTone =
+            r.growth > 0
+              ? 'text-green-600 dark:text-green-400'
+              : r.growth < 0
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-muted-foreground'}
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(r.seniority)}</td>
             <td class="py-2 pr-4 text-right tabular-nums">{r.open_count.toLocaleString('en-US')}</td>
-            <td
-              class="py-2 text-right tabular-nums"
-              class:text-green-600={r.growth > 0}
-              class:text-gray-400={r.growth === 0}
-              class:text-red-600={r.growth < 0}
-            >
+            <td class="py-2 text-right tabular-nums {growthTone}">
               {r.growth > 0 ? '+' : ''}{r.growth.toLocaleString('en-US')}
             </td>
           </tr>

--- a/web/src/routes/insights/salary/[category]/+page.svelte
+++ b/web/src/routes/insights/salary/[category]/+page.svelte
@@ -42,11 +42,11 @@
   covered={data.covered}
 >
   {#if data.bands.length === 0}
-    <p class="text-gray-500">No salary figures disclosed for this category yet.</p>
+    <p class="text-muted-foreground">No salary figures disclosed for this category yet.</p>
   {:else}
     <table class="w-full border-collapse text-left text-sm">
       <thead>
-        <tr class="border-b border-gray-300 text-gray-500">
+        <tr class="border-b border-border text-muted-foreground">
           <th class="py-2 pr-4 font-medium">Level</th>
           <th class="py-2 pr-4 font-medium">Currency</th>
           <th class="py-2 pr-4 font-medium">Period</th>
@@ -58,14 +58,14 @@
       </thead>
       <tbody>
         {#each data.bands as b (b.seniority + b.currency + b.period)}
-          <tr class="border-b border-gray-100">
-            <td class="py-2 pr-4 font-medium text-gray-900">{seniorityLabel(b.seniority)}</td>
-            <td class="py-2 pr-4 text-gray-600">{b.currency.toUpperCase()}</td>
-            <td class="py-2 pr-4 text-gray-600">{b.period}</td>
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 font-medium text-foreground">{seniorityLabel(b.seniority)}</td>
+            <td class="py-2 pr-4 text-muted-foreground">{b.currency.toUpperCase()}</td>
+            <td class="py-2 pr-4 text-muted-foreground">{b.period}</td>
             <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p25, b.currency)}</td>
             <td class="py-2 pr-4 text-right font-semibold tabular-nums">{formatSalary(b.p50, b.currency)}</td>
             <td class="py-2 pr-4 text-right tabular-nums">{formatSalary(b.p75, b.currency)}</td>
-            <td class="py-2 text-right tabular-nums text-gray-500">{b.sample_size}</td>
+            <td class="py-2 text-right tabular-nums text-muted-foreground">{b.sample_size}</td>
           </tr>
         {/each}
       </tbody>

--- a/web/src/routes/insights/skills/[category]/+page.svelte
+++ b/web/src/routes/insights/skills/[category]/+page.svelte
@@ -41,11 +41,11 @@
   covered={data.covered}
 >
   {#if data.skills.length === 0}
-    <p class="text-gray-500">No skill data for this category yet.</p>
+    <p class="text-muted-foreground">No skill data for this category yet.</p>
   {:else}
     <table class="w-full border-collapse text-left text-sm">
       <thead>
-        <tr class="border-b border-gray-300 text-gray-500">
+        <tr class="border-b border-border text-muted-foreground">
           <th class="py-2 pr-4 font-medium">#</th>
           <th class="py-2 pr-4 font-medium">Skill</th>
           <th class="py-2 pr-4 font-medium text-right">Open postings</th>
@@ -54,16 +54,17 @@
       </thead>
       <tbody>
         {#each data.skills as s, i (s.skill)}
-          <tr class="border-b border-gray-100">
-            <td class="py-2 pr-4 text-gray-400 tabular-nums">{i + 1}</td>
-            <td class="py-2 pr-4 font-medium text-gray-900">{s.skill}</td>
+          {@const growthTone =
+            s.growth > 0
+              ? 'text-green-600 dark:text-green-400'
+              : s.growth < 0
+                ? 'text-red-600 dark:text-red-400'
+                : 'text-muted-foreground'}
+          <tr class="border-b border-border">
+            <td class="py-2 pr-4 text-muted-foreground tabular-nums">{i + 1}</td>
+            <td class="py-2 pr-4 font-medium text-foreground">{s.skill}</td>
             <td class="py-2 pr-4 text-right tabular-nums">{s.open_count.toLocaleString('en-US')}</td>
-            <td
-              class="py-2 text-right tabular-nums"
-              class:text-green-600={s.growth > 0}
-              class:text-gray-400={s.growth === 0}
-              class:text-red-600={s.growth < 0}
-            >
+            <td class="py-2 text-right tabular-nums {growthTone}">
               {s.growth > 0 ? '+' : ''}{s.growth.toLocaleString('en-US')}
             </td>
           </tr>


### PR DESCRIPTION
## Problem

The insights section renders broken in **dark theme** — headings are near-black on the dark canvas (invisible) and card borders come out harsh white. Reported on `/insights` and `/insights/companies`.

## Root cause

These 5 route files (+ the shared `InsightsPageShell.svelte`) are the **only** routes in the app written against hardcoded Tailwind palette classes — `text-gray-900/700/600/500/400`, `border-gray-100/200/300`, `bg-gray-100` — with no `dark:` variants. Those colors are fixed and don't consume the CSS-variable theme, so they never flip when `.dark` is applied. The rest of the app (45× `text-foreground`, 90× `text-muted-foreground`, 25× `border-border`) uses the design system's semantic tokens, which flip correctly.

`text-gray-900` (≈ `oklch(0.21)`) on the dark background (`oklch(0.16)`) is what made the headings disappear.

## Fix

Route neutral text and borders through the semantic tokens, matching the rest of the app:

| Hardcoded | Semantic token |
|---|---|
| `text-gray-900` / `text-gray-700` | `text-foreground` |
| `text-gray-600/500/400` | `text-muted-foreground` |
| `border-gray-100/200/300` | `border-border` |
| `bg-gray-100 … hover:bg-gray-200` (chips) | `bg-secondary text-secondary-foreground hover:bg-accent` |
| `hover:border-gray-300 hover:bg-gray-50` (card) | `hover:bg-accent` |

Hiring-signal up/down figures get a dark-mode brightener (`dark:text-green-400` / `dark:text-red-400`), mirroring `StatusBoard.svelte`; the three-way `class:` directives collapse into a single derived `growthTone` class. Blue links (`text-blue-600`) are left untouched — readable in both themes and consistent with 8 other usages.

## Verification

- `npm run check` — 0 errors (5 pre-existing warnings, unrelated).
- Built the app, ran the node preview with `API_INTERNAL_URL=https://freehire.dev` (real prod data), screenshotted both pages under emulated dark mode. Computed `h1` color is now `oklch(0.985)` (near-white) on `oklch(0.16)` background. Headings, tables, and green/red growth figures all read cleanly.