### PR TITLE
fix(sources): bound trudvsem in-flight requests + keep partial region harvest

### DIFF
--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -71,40 +71,39 @@ func pacedVagasGetter(c HTMLGetter) HTMLGetter {
 	}
 }
 
-// rateLimitedJSONGetter is the JSONGetter analog of rateLimitedHTMLGetter: it wraps a JSONGetter
-// with a shared limiter so its aggregate GetJSON rate stays under the limit regardless of the
-// pipeline's board-worker concurrency. All requests through one instance share one token bucket.
-type rateLimitedJSONGetter struct {
-	inner   JSONGetter
-	limiter waiter
+// concurrencyLimitedJSONGetter bounds how many GetJSON calls are in flight at once via a shared
+// semaphore, independent of the pipeline's board-worker pool. Unlike a rate limiter — which caps
+// the request START rate but lets slow requests pile up concurrently — this caps simultaneous
+// in-flight requests, the right lever for an API that degrades under sustained concurrent load
+// rather than by rate. One instance carries one semaphore, shared across every board and page.
+type concurrencyLimitedJSONGetter struct {
+	inner JSONGetter
+	sem   chan struct{}
 }
 
-// GetJSON blocks on the limiter before delegating, so a cancelled context surfaces as the Wait
-// error and the inner fetch is skipped.
-func (g rateLimitedJSONGetter) GetJSON(ctx context.Context, url string, v any) error {
-	if err := g.limiter.Wait(ctx); err != nil {
-		return err
+// GetJSON acquires a semaphore slot before delegating (releasing it after), so at most cap
+// requests run at once; a cancelled context surfaces while waiting and skips the inner fetch.
+func (g concurrencyLimitedJSONGetter) GetJSON(ctx context.Context, url string, v any) error {
+	select {
+	case g.sem <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+	defer func() { <-g.sem }()
 	return g.inner.GetJSON(ctx, url, v)
 }
 
-// opendata.trudvsem.ru does not 429, but its gov infra answers large region pages slowly, and
-// the pipeline's 8-way board concurrency fires ~8 of those reads at once from the prod IP —
-// enough that the 15s client read timeout trips and most regions fail (85/90 on the first
-// full-board run), while a single sequential crawl never times out. So pace the aggregate rate
-// to serialize those workers into a gentle stream the API answers within the timeout. ~4 req/s
-// keeps the whole ~4900-page board inside the 40-min ingest window while staying far below the
-// concurrency that overwhelmed it; tune from observed convergence.
-const (
-	trudvsemRequestInterval = 250 * time.Millisecond // ~4 req/s
-	trudvsemRequestBurst    = 3
-)
+// opendata.trudvsem.ru answers a page in ~0.5s in isolation and tolerates a brief burst, but its
+// gov infra degrades under the SUSTAINED concurrent load of the pipeline's 8 board workers
+// hammering it for a whole crawl — intermittent 500s and slow bodies that trip the 15s read
+// timeout, failing most regions (a rate limiter did not help, since slow reads keep the workers
+// busy and never wait on it). Bounding in-flight requests to a gentle few keeps the crawl in the
+// API's healthy regime; at ~0.5s a page and 2 in flight the whole ~4900-page board still finishes
+// well inside the 40-min ingest window. Tune from observed convergence.
+const trudvsemMaxInFlight = 2
 
-// pacedTrudvsemGetter wraps a getter with a fresh limiter shared across one registry build, so
-// all of trudvsem's region-shard requests in a run are paced under one gentle aggregate rate.
-func pacedTrudvsemGetter(c JSONGetter) JSONGetter {
-	return rateLimitedJSONGetter{
-		inner:   c,
-		limiter: rate.NewLimiter(rate.Every(trudvsemRequestInterval), trudvsemRequestBurst),
-	}
+// limitedTrudvsemGetter wraps a getter with a fresh semaphore shared across one registry build, so
+// all of trudvsem's region-shard requests in a run stay under one gentle in-flight cap.
+func limitedTrudvsemGetter(c JSONGetter) JSONGetter {
+	return concurrencyLimitedJSONGetter{inner: c, sem: make(chan struct{}, trudvsemMaxInFlight)}
 }

--- a/internal/sources/pacer_test.go
+++ b/internal/sources/pacer_test.go
@@ -76,32 +76,34 @@ func (g *recordingJSONGetter) GetJSON(_ context.Context, url string, _ any) erro
 	return nil
 }
 
-func TestRateLimitedJSONGetter_GatesThenDelegates(t *testing.T) {
-	waiter := &recordingWaiter{}
+func TestConcurrencyLimitedJSONGetter_AcquiresThenDelegates(t *testing.T) {
 	inner := &recordingJSONGetter{}
-	g := rateLimitedJSONGetter{inner: inner, limiter: waiter}
+	g := concurrencyLimitedJSONGetter{inner: inner, sem: make(chan struct{}, 2)}
 
 	if err := g.GetJSON(context.Background(), "https://opendata.trudvsem.ru/api/v1/vacancies/region/x", nil); err != nil {
 		t.Fatalf("GetJSON returned error: %v", err)
 	}
-	if waiter.calls != 1 {
-		t.Fatalf("limiter.Wait called %d times, want 1", waiter.calls)
-	}
 	if len(inner.urls) != 1 {
 		t.Fatalf("inner GetJSON called %d times, want 1", len(inner.urls))
 	}
+	// The slot must be released after the call, so the getter is reusable up to its cap.
+	if len(g.sem) != 0 {
+		t.Fatalf("semaphore slot not released: len=%d, want 0", len(g.sem))
+	}
 }
 
-func TestRateLimitedJSONGetter_WaitErrorShortCircuits(t *testing.T) {
-	sentinel := errors.New("rate wait cancelled")
-	waiter := &recordingWaiter{err: sentinel}
+func TestConcurrencyLimitedJSONGetter_CancelledContextShortCircuits(t *testing.T) {
 	inner := &recordingJSONGetter{}
-	g := rateLimitedJSONGetter{inner: inner, limiter: waiter}
+	sem := make(chan struct{}, 1)
+	sem <- struct{}{} // fill the only slot so the next acquire must wait
+	g := concurrencyLimitedJSONGetter{inner: inner, sem: sem}
 
-	if err := g.GetJSON(context.Background(), "https://opendata.trudvsem.ru/", nil); !errors.Is(err, sentinel) {
-		t.Fatalf("GetJSON error = %v, want %v", err, sentinel)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := g.GetJSON(ctx, "https://opendata.trudvsem.ru/", nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetJSON error = %v, want context.Canceled", err)
 	}
 	if len(inner.urls) != 0 {
-		t.Fatalf("inner GetJSON called despite Wait error (%d times)", len(inner.urls))
+		t.Fatalf("inner GetJSON called despite no free slot (%d times)", len(inner.urls))
 	}
 }

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -314,9 +314,9 @@ func All(c HTTPClient) map[string]Source {
 		NewMicro1(c),
 		NewBairesDev(c),
 		// RU federal open-data aggregator: board-based, sharded per region (board = OKATO code).
-		// Paced: its gov API slows under the pipeline's board concurrency until the read timeout
-		// trips, so the aggregate request rate is throttled to a gentle serialized stream.
-		NewTrudvsem(pacedTrudvsemGetter(c)),
+		// Concurrency-limited: its gov API degrades under the pipeline's board concurrency (500s +
+		// read-timeouts), so its in-flight requests are capped to a gentle few.
+		NewTrudvsem(limitedTrudvsemGetter(c)),
 		// hh.ru: multi-company aggregator, enumerated by professional_role (board), reading the
 		// server-rendered search page's embedded state.
 		NewHH(c),

--- a/internal/sources/trudvsem.go
+++ b/internal/sources/trudvsem.go
@@ -80,6 +80,12 @@ func (t trudvsem) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	for page := 0; page < trudvsemMaxPages; page++ {
 		var resp trudvsemResponse
 		if err := t.http.GetJSON(ctx, t.pageURL(e.Board, page), &resp); err != nil {
+			// The gov API intermittently 500s / times out under load. A blip mid-pagination must
+			// not discard the pages already gathered: keep them (the region self-heals next run),
+			// and only surface a hard failure when page 0 itself failed (nothing harvested at all).
+			if len(jobs) > 0 {
+				return jobs, nil
+			}
 			return nil, fmt.Errorf("trudvsem: region %q page %d: %w", e.Board, page, err)
 		}
 		for _, w := range resp.Results.Vacancies {

--- a/internal/sources/trudvsem_test.go
+++ b/internal/sources/trudvsem_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/url"
 	"slices"
 	"strconv"
@@ -14,6 +15,7 @@ import (
 // whole region-shard pagination loop.
 type trudvsemFake struct {
 	byOffset   map[int]string // offset -> response JSON ("" => empty page envelope)
+	errAt      map[int]error  // offset -> transport error (simulates a 500/timeout blip)
 	offsets    []int          // offsets requested, in order
 	gotRegions []string       // region codes taken from the request path
 }
@@ -26,6 +28,9 @@ func (f *trudvsemFake) GetJSON(_ context.Context, u string, v any) error {
 	}
 	offset, _ := strconv.Atoi(pu.Query().Get("offset"))
 	f.offsets = append(f.offsets, offset)
+	if err := f.errAt[offset]; err != nil {
+		return err
+	}
 	body := f.byOffset[offset]
 	if body == "" {
 		body = `{"status":"200","meta":{"total":0},"results":{"vacancies":[]}}`
@@ -149,6 +154,31 @@ func TestTrudvsemStopsAtTotalMultiplePages(t *testing.T) {
 	}
 	if len(jobs) != 2*trudvsemPageSize {
 		t.Errorf("len(jobs) = %d, want %d", len(jobs), 2*trudvsemPageSize)
+	}
+}
+
+func TestTrudvsemKeepsPartialOnMidPageError(t *testing.T) {
+	// The gov API blips (500/timeout) on page 1 after a full page 0. The jobs already gathered
+	// must survive — Fetch returns page 0's postings and no error, not a discarded region.
+	fake := &trudvsemFake{
+		byOffset: map[int]string{0: trudvsemPage(trudvsemPageSize, 0, 100000)},
+		errAt:    map[int]error{1: errors.New("status 500")},
+	}
+	jobs, err := NewTrudvsem(fake).Fetch(context.Background(), CompanyEntry{Board: "5200000000000"})
+	if err != nil {
+		t.Fatalf("Fetch returned error on a mid-page blip, want partial success: %v", err)
+	}
+	if len(jobs) != trudvsemPageSize {
+		t.Errorf("len(jobs) = %d, want %d (page 0 kept despite page 1 error)", len(jobs), trudvsemPageSize)
+	}
+}
+
+func TestTrudvsemFailsWhenFirstPageErrors(t *testing.T) {
+	// A blip on page 0 harvested nothing, so the region is a genuine failure the pipeline must
+	// see (board_health) rather than a silent empty success.
+	fake := &trudvsemFake{errAt: map[int]error{0: errors.New("status 500")}}
+	if _, err := NewTrudvsem(fake).Fetch(context.Background(), CompanyEntry{Board: "5200000000000"}); err == nil {
+		t.Fatal("Fetch returned nil error when page 0 failed, want an error")
 	}
 }
 


### PR DESCRIPTION
Follow-up to #895, which did **not** fix the trudvsem crawl. Rate-limiting caps the request *start* rate, but slow reads keep the board workers busy so the limiter never engages — ~8 concurrent reads still hammer the API. opendata.trudvsem.ru answers a page in ~0.5s in isolation and tolerates a brief burst, but degrades (intermittent 500s + slow bodies tripping the 15s read timeout) under the **sustained concurrent load** of a whole crawl (85/90 regions failed).

## Fix

1. **Concurrency limiter, not rate limiter** — replace the JSON rate-limiter with a semaphore capping trudvsem's *in-flight* requests to 2. That's the actual lever for an API that degrades by concurrency, not rate. At ~0.5s/page and 2 in flight the whole ~4900-page board still finishes inside the 40-min ingest window.
2. **Partial-region resilience** — a blip mid-pagination now keeps the pages already gathered (the region self-heals on the next 6h run) instead of discarding the whole region; only a page-0 failure (nothing harvested) surfaces as a board error for board_health.

## Test

New tests: concurrency-limiter acquire/release + cancelled-context short-circuit; adapter keeps-partial-on-mid-page-error and fails-when-first-page-errors. Full `internal/sources` suite green.