### PR TITLE
feat(sources): 4dayweek ingests only free (unlocked) descriptions

### DIFF
--- a/internal/sources/fourdayweek.go
+++ b/internal/sources/fourdayweek.go
@@ -12,10 +12,23 @@ import (
 // Like the other aggregators it is boardless (one public API, no per-tenant board) yet lists
 // many employers, so it stays in the source facet and takes each posting's company from the
 // feed. The list API paginates and carries the platform's structured facets inline
-// (work_arrangement, level, category, stack), but no description and no apply link, so the
-// canonical URL is synthesized from the slug and the body is left for downstream enrichment.
+// (work_arrangement, level, category, stack) but no body and no apply link, so the canonical
+// URL is synthesized from the slug and the description is hydrated from the public job page.
+//
+// 4dayweek gates most descriptions behind its paid "Pro" tier: on a locked posting's page the
+// body is replaced by an "Unlock with Pro" notice and the article.prose container is absent.
+// We ingest ONLY the postings whose full description 4dayweek serves for free (article.prose
+// present) and drop the locked ones rather than store a blank card — so every posting is
+// fetched to read its lock state, and the crawl is scheduled sparsely (daily) to bound that.
 type fourDayWeek struct {
-	http JSONGetter
+	http fourDayWeekHTTP
+}
+
+// fourDayWeekHTTP is the slice of the HTTP client the adapter needs: the JSON list and the
+// server-rendered HTML detail page. The shared *Client satisfies it.
+type fourDayWeekHTTP interface {
+	JSONGetter
+	HTMLGetter
 }
 
 const (
@@ -29,7 +42,7 @@ const (
 )
 
 // NewFourDayWeek builds the 4dayweek adapter over the given HTTP client.
-func NewFourDayWeek(c JSONGetter) Source { return fourDayWeek{http: c} }
+func NewFourDayWeek(c fourDayWeekHTTP) Source { return fourDayWeek{http: c} }
 
 func (fourDayWeek) Provider() string { return "4dayweek" }
 
@@ -62,8 +75,33 @@ type fourDayWeekPosting struct {
 	} `json:"stack"`
 }
 
+// Fetch lists the board and hydrates each posting from its page, keeping only the postings whose
+// full description 4dayweek serves for free. A posting whose body is Pro-gated (no article.prose)
+// or whose page fetch fails is dropped rather than ingested as a blank card — so a locked posting
+// never reaches the catalogue, and one that later unlocks (or re-locks) is reflected on the next
+// crawl. Detail fetches run under the shared bounded worker pool.
 func (s fourDayWeek) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
-	var jobs []Job
+	postings, err := s.crawl(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return fetchDetails(postings, defaultDetailWorkers, func(p fourDayWeekPosting) (Job, bool) {
+		job, ok := p.toJob()
+		if !ok {
+			return Job{}, false
+		}
+		desc, ok := s.detail(ctx, p.Slug)
+		if !ok {
+			return Job{}, false // Pro-gated or body-less — drop, never ingest a blank card
+		}
+		job.Description = desc
+		return job, true
+	}), nil
+}
+
+// crawl pages the list feed and returns every raw posting — the list walk behind Fetch.
+func (s fourDayWeek) crawl(ctx context.Context) ([]fourDayWeekPosting, error) {
+	var postings []fourDayWeekPosting
 	for page := 1; page <= fourDayWeekMaxPages; page++ {
 		var resp struct {
 			Jobs    []fourDayWeekPosting `json:"jobs"`
@@ -72,16 +110,32 @@ func (s fourDayWeek) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
 		if err := s.http.GetJSON(ctx, fmt.Sprintf(fourDayWeekListURL, page), &resp); err != nil {
 			return nil, fmt.Errorf("4dayweek: page %d: %w", page, err)
 		}
-		for _, p := range resp.Jobs {
-			if job, ok := p.toJob(); ok {
-				jobs = append(jobs, job)
-			}
-		}
+		postings = append(postings, resp.Jobs...)
 		if len(resp.Jobs) == 0 || !resp.HasMore {
 			break
 		}
 	}
-	return jobs, nil
+	return postings, nil
+}
+
+// detail fetches a posting's page and extracts its description from the article.prose container
+// the site renders the body in. It returns ok=false on a failed request or when article.prose is
+// absent — the signal that the posting is Pro-locked (the page shows an "Unlock with Pro" notice
+// instead of the body) or genuinely bodyless — so Fetch drops it.
+func (s fourDayWeek) detail(ctx context.Context, slug string) (string, bool) {
+	root, err := s.http.GetHTML(ctx, fmt.Sprintf(fourDayWeekJobURL, slug))
+	if err != nil {
+		return "", false
+	}
+	article := firstByClass(root, "prose")
+	if article == nil {
+		return "", false
+	}
+	body := sanitizeHTML(innerHTML(article))
+	if body == "" {
+		return "", false
+	}
+	return body, true
 }
 
 // toJob maps a posting to a Job, returning ok=false for an unusable posting (no native id,

--- a/internal/sources/fourdayweek_test.go
+++ b/internal/sources/fourdayweek_test.go
@@ -3,6 +3,7 @@ package sources
 import (
 	"context"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -41,21 +42,30 @@ func TestFourDayWeekBoardFileValidates(t *testing.T) {
 	}
 }
 
-func TestFourDayWeekFetchPaginatesAndMaps(t *testing.T) {
+func TestFourDayWeekFetchHydratesUnlockedDropsLocked(t *testing.T) {
 	page1 := `{"jobs":[
 {"id":"abc-1","slug":"senior-backend-at-acme-1","title":"Senior Backend Engineer","company_name":"Acme","work_arrangement":"remote","level":"senior","category":"devops","posted":1784307599,"locations":[{"city":"Berlin","country":"Germany","is_primary":true}],"stack":[{"name":"Go"},{"name":"Kubernetes"}]},
+{"id":"locked-2","slug":"locked-role-2","title":"Locked Role","company_name":"Globex"},
 {"id":"","slug":"","title":"skip me","company_name":"NoID"}
 ],"has_more":true}`
 	page2 := `{"jobs":[],"has_more":false}`
-	// page=2 routed first so the more specific match wins over the base jobs route.
-	fake := (&routedHTTP{}).route("page=2", page2).route("api/jobs", page1)
+	// A free posting renders its body in article.prose; a Pro-locked posting shows the unlock
+	// notice and has no article.prose.
+	unlocked := `<html><body><div class="relative"><article class="prose prose-slate"><h2>About</h2><p>Great role &amp; team.</p></article></div></body></html>`
+	locked := `<html><body><div class="paywall"><p>Full description locked. Unlock with Pro.</p></div></body></html>`
+	// Detail routes precede the base list route; none of their match strings occur in a list URL.
+	fake := (&routedHTTP{}).
+		route("page=2", page2).
+		route("/job/senior-backend-at-acme-1", unlocked).
+		route("/job/locked-role-2", locked).
+		route("api/jobs", page1)
 
 	jobs, err := NewFourDayWeek(fake).Fetch(context.Background(), CompanyEntry{})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}
 	if len(jobs) != 1 {
-		t.Fatalf("got %d jobs, want 1 (the empty-id posting dropped)", len(jobs))
+		t.Fatalf("got %d jobs, want 1 (locked and empty-id postings dropped)", len(jobs))
 	}
 	j := jobs[0]
 	if j.ExternalID != "abc-1" || j.Company != "Acme" || j.Title != "Senior Backend Engineer" {
@@ -64,14 +74,14 @@ func TestFourDayWeekFetchPaginatesAndMaps(t *testing.T) {
 	if j.URL != "https://4dayweek.io/job/senior-backend-at-acme-1" {
 		t.Errorf("URL = %q, want the public job page from the slug", j.URL)
 	}
+	if !strings.Contains(j.Description, "Great role") || !strings.Contains(j.Description, "team") {
+		t.Errorf("Description not hydrated from article.prose: %q", j.Description)
+	}
 	if j.WorkMode != "remote" || !j.Remote {
 		t.Errorf("WorkMode=%q Remote=%v, want remote/true", j.WorkMode, j.Remote)
 	}
-	if j.Seniority != "senior" {
-		t.Errorf("Seniority = %q, want senior", j.Seniority)
-	}
-	if j.Category != "devops" {
-		t.Errorf("Category = %q, want devops", j.Category)
+	if j.Seniority != "senior" || j.Category != "devops" {
+		t.Errorf("structured facets lost: seniority=%q category=%q", j.Seniority, j.Category)
 	}
 	if j.Location != "Berlin, Germany" {
 		t.Errorf("Location = %q, want \"Berlin, Germany\"", j.Location)


### PR DESCRIPTION
## Why

Follow-up to #890. On prod, 4dayweek jobs showed **blank descriptions** — a user flagged one. Investigation found 4dayweek's list API carries no body, and the public job page gates most descriptions behind its paid **Pro** tier: a locked posting's page shows *"Full description locked — Unlock with Pro"* and has no `article.prose`. On a live 40-job sample only **~17%** were free (unlocked); ~83% are Pro-gated. We can't (and shouldn't) get the locked bodies.

## What

`Fetch` now hydrates every posting from its page and **keeps only the postings whose full description 4dayweek serves for free** (`article.prose` present), dropping the Pro-gated and body-less ones rather than storing a blank card. Because lock state is only visible on the page, every posting is fetched — so the crawl is scheduled **sparsely (daily)** on prod.

- Unlocked posting → hydrated with its real description, ingested with its structured facets.
- Locked / body-less posting → dropped (never enters the catalogue).
- Previously-ingested locked rows fall out via the existing stale-close sweep once they stop being listed as ingestable (plus a one-off prod purge of the empty-description rows for immediate cleanup).

This supersedes the short-lived HydratingSource + `cmd/backfill-4dayweek` path from an earlier iteration (removed): with locked postings dropped they never become "seen", so the seen-skip optimization gave nothing, and a hydrate-and-filter `Fetch` is simpler and always reflects current lock state.

## Testing

- Unit test drives a mixed list (unlocked + Pro-locked + invalid) through fakes and asserts only the unlocked posting survives, hydrated from `article.prose`, with structured facets intact.
- Live-verified against the real API earlier in the investigation: a free posting hydrates (e.g. 14 KB body), a locked one yields no `article.prose` and is dropped.
- `go build ./...`, `go vet`, `go test ./internal/sources/` green; gofmt clean.