### PR TITLE
fix(contribution): strip leading locale segment from Rippling board URLs

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -8,19 +8,23 @@ import (
 
 // Board extraction modes, each matching how the ingest adapter namespaces jobs.external_id:
 //   - path:      board = the first path segment on a fixed host (jobs.lever.co/<board>/…).
+//   - pathlocale: like path, but a leading xx-XX locale segment is skipped first — Rippling's
+//     public site prefixes the board with a locale (ats.rippling.com/en-GB/<board>/…) that its
+//     board API omits, so both URL shapes must resolve to the same board.
 //   - subdomain: board = the leftmost DNS label under a fixed apex (<board>.recruitee.com).
 //   - host:      board = the whole careers host (the tenant identity IS the host, and the TLD
 //     varies by region, e.g. <tenant>.zohorecruit.eu / .com / .in).
 //   - hostpath:  board = "<host>/<first path segment>" (Workday: the tenant is the host, the
 //     site is the first path segment, e.g. acme.wd1.myworkdayjobs.com/Careers).
 //
-// For subdomain and host the board IS the host; for hostpath it is host + site. In all three the
+// For subdomain and host the board IS the host; for hostpath it is host + site. In all these the
 // canonical URL is stripped to that board, collapsing a vacancy URL and the board listing to one.
 const (
-	modePath      = "path"
-	modeSubdomain = "subdomain"
-	modeHost      = "host"
-	modeHostPath  = "hostpath"
+	modePath       = "path"
+	modePathLocale = "pathlocale"
+	modeSubdomain  = "subdomain"
+	modeHost       = "host"
+	modeHostPath   = "hostpath"
 )
 
 // atsBoards lists the supported multi-tenant ATS: a host (exact or subdomain-suffix match) →
@@ -44,8 +48,10 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"careers.hireology.com", "hireology", modePath},
 	{"jobs.smartrecruiters.com", "smartrecruiters", modePath},
 	{"careers.smartrecruiters.com", "smartrecruiters", modePath},
-	{"ats.rippling.com", "rippling", modePath},
 	{"recruiting.ultipro.com", "ukg", modePath},
+
+	// --- pathlocale: like path, skipping a leading xx-XX locale segment ---
+	{"ats.rippling.com", "rippling", modePathLocale},
 
 	// --- subdomain: board = leftmost DNS label under the apex ---
 	{"recruitee.com", "recruitee", modeSubdomain},
@@ -120,6 +126,18 @@ func RecognizeBoard(rawURL string) (source, board, canonical string, ok bool) {
 		u.RawQuery, u.Fragment = "", ""
 		u.Path = "/" + site
 		return src, host + "/" + site, u.String(), true
+
+	case modePathLocale:
+		// Rippling: skip a leading xx-XX locale segment (ats.rippling.com/en-GB/<board>/…),
+		// which the board API omits, and collapse the canonical to the board root so a
+		// locale-prefixed vacancy, a bare vacancy, and the listing all map to one board.
+		board = boardAfterLocale(u)
+		if board == "" {
+			return "", "", "", false
+		}
+		u.RawQuery, u.Fragment = "", ""
+		u.Path = "/" + board
+		return src, board, u.String(), true
 	}
 
 	// modePath: the board is the first path segment.
@@ -164,6 +182,28 @@ func subdomainLabel(host, apex string) string {
 		return sub[:i]
 	}
 	return sub
+}
+
+// localeSegment matches an xx-XX language-COUNTRY locale (e.g. en-GB) — the optional leading
+// path segment Rippling's public board site inserts before the tenant. Tenant slugs are
+// lowercase (satomic, 360-fire-flood), so the uppercase country code never collides.
+var localeSegment = regexp.MustCompile(`^[a-z]{2}-[A-Z]{2}$`)
+
+// boardAfterLocale returns the first path segment that isn't a leading locale — the tenant board
+// in ats.rippling.com/<locale?>/<board>/… . "" when the path is empty or carries only a locale.
+func boardAfterLocale(u *url.URL) string {
+	p := strings.Trim(u.Path, "/")
+	if p == "" {
+		return ""
+	}
+	segs := strings.Split(p, "/")
+	if localeSegment.MatchString(segs[0]) {
+		segs = segs[1:]
+	}
+	if len(segs) == 0 {
+		return ""
+	}
+	return segs[0]
 }
 
 // ghNumericID matches a Greenhouse-style numeric job id.

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -23,6 +23,14 @@ func TestRecognizeBoard(t *testing.T) {
 		{"deel path", "https://jobs.deel.com/acme/jobs/123", "deel", "acme", "https://jobs.deel.com/acme/jobs/123", true},
 		{"jobvite path", "https://jobs.jobvite.com/acme/job/oABC", "jobvite", "acme", "https://jobs.jobvite.com/acme/job/oABC", true},
 
+		// pathlocale — Rippling: an optional leading xx-XX locale segment is skipped; canonical
+		// collapses to the board root so a locale-prefixed vacancy, a bare vacancy, and the
+		// listing all map to one board.
+		{"rippling locale-prefixed vacancy", "https://ats.rippling.com/en-GB/satomic/jobs/48384892-1b6b?utm=x", "rippling", "satomic", "https://ats.rippling.com/satomic", true},
+		{"rippling no locale vacancy", "https://ats.rippling.com/satomic/jobs/34aaf2aa", "rippling", "satomic", "https://ats.rippling.com/satomic", true},
+		{"rippling board listing", "https://ats.rippling.com/satomic", "rippling", "satomic", "https://ats.rippling.com/satomic", true},
+		{"rippling locale only no tenant", "https://ats.rippling.com/en-GB", "", "", "", false},
+
 		// subdomain — canonical collapses to the bare host
 		{"recruitee vacancy strips path", "https://acme.recruitee.com/o/senior-go/apply?utm=x", "recruitee", "acme", "https://acme.recruitee.com", true},
 		{"recruitee board listing", "https://acme.recruitee.com", "recruitee", "acme", "https://acme.recruitee.com", true},
@@ -76,6 +84,8 @@ func TestVacancyAndListingSameBoard(t *testing.T) {
 		// path
 		{"https://jobs.ashbyhq.com/blitzy/a741b4e8", "https://jobs.ashbyhq.com/blitzy"},
 		{"https://job-boards.greenhouse.io/acme/jobs/1?utm=x", "https://job-boards.greenhouse.io/acme"},
+		// pathlocale (Rippling): a locale-prefixed vacancy and the bare listing collapse to one board
+		{"https://ats.rippling.com/en-GB/satomic/jobs/48384892", "https://ats.rippling.com/satomic"},
 		// subdomain
 		{"https://acme.recruitee.com/o/senior-go", "https://acme.recruitee.com"},
 		{"https://acme.bamboohr.com/careers/42/detail", "https://acme.bamboohr.com/careers/list"},


### PR DESCRIPTION
Re-open of #900 (accidentally closed when its branch was deleted before a base-modified merge landed). Rebased on latest main.

## Problem
`RecognizeBoard` takes the first path segment as the board, but `ats.rippling.com`'s public site prefixes the tenant with an `xx-XX` locale (`ats.rippling.com/en-GB/<board>/…`) that the board API omits. A locale-prefixed link derived the locale (e.g. `en-GB`) as the board — a dead board that 404s. Surfaced onboarding a contribution recorded as `rippling/en-GB` (real tenant `satomic`, onboarded in #896).

## Fix
New `pathlocale` extraction mode: skip a leading `^[a-z]{2}-[A-Z]{2}$` locale segment, take the tenant, collapse canonical to the board root. Locale-prefixed vacancy, bare vacancy, and listing all map to one board; a locale-only URL rejects. Tenant slugs are lowercase so the uppercase country code never collides. Covered by new table cases in `board_test.go`.