### PR TITLE
feat(sources): add Bullhorn staffing ATS adapter

### DIFF
--- a/internal/sources/bullhorn.go
+++ b/internal/sources/bullhorn.go
@@ -1,0 +1,165 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// bullhorn adapts Bullhorn ATS career boards through the vendor's public REST API. Bullhorn
+// is the largest staffing ATS, so a board is a staffing agency rather than a single employer;
+// the company name comes from config (the API exposes only the opaque corpToken).
+//
+// The board is "<cls>:<corpToken>": cls is the numeric cluster (a.k.a. swimlane) that selects
+// the API host public-rest<cls>.bullhornstaffing.com, and corpToken is the public alphanumeric
+// company token embedded in every Bullhorn career portal. Both are public — the public API is
+// keyless, gated only by the customer publishing a job as "Published - Approved". One
+// search/JobOrder call returns every open posting fully populated (structured location, an HTML
+// publicDescription, dateAdded), so no per-posting detail fetch is needed.
+//
+// The API exposes no human-facing job page (only this REST endpoint and POST /apply), so the
+// job URL is the REST entity reference: it uniquely and stably identifies the posting on
+// Bullhorn's own domain. Board sources are not liveness-probed, so a URL that is not GET-able
+// without OAuth never triggers a false close.
+type bullhorn struct {
+	http JSONGetter
+}
+
+const (
+	// bullhornPageSize is the JobOrder page size. Bullhorn's own career portal requests 500.
+	bullhornPageSize = 500
+	// bullhornMaxPages bounds pagination as a runaway guard; a large staffing agency can list
+	// many thousands of jobs, and 500·40 = 20k caps a single run without truncating typical boards.
+	bullhornMaxPages = 40
+	// bullhornFields is the JobOrder field projection. address's subfields are requested
+	// explicitly — a bare "address" returns an empty object, while address(city,state,countryName)
+	// populates the location. Salary and categories are omitted: the Job contract carries no
+	// salary (enrichment derives it from the body) and Category expects freehire's controlled
+	// vocabulary, not Bullhorn's free-text category names.
+	bullhornFields = "id,title,publicDescription,address(city,state,countryName),dateAdded,employmentType"
+)
+
+// NewBullhorn builds the Bullhorn adapter over the given HTTP client.
+func NewBullhorn(c JSONGetter) Source { return bullhorn{http: c} }
+
+func (bullhorn) Provider() string { return "bullhorn" }
+
+// bullhornSearchResponse is the search/JobOrder envelope. total is the full match count; the
+// response returns a start-offset window of it in data.
+type bullhornSearchResponse struct {
+	Total int                `json:"total"`
+	Start int                `json:"start"`
+	Count int                `json:"count"`
+	Data  []bullhornJobOrder `json:"data"`
+}
+
+type bullhornJobOrder struct {
+	ID                int             `json:"id"`
+	Title             string          `json:"title"`
+	PublicDescription string          `json:"publicDescription"`
+	Address           bullhornAddress `json:"address"`
+	// DateAdded is epoch milliseconds when the posting was created.
+	DateAdded      int64  `json:"dateAdded"`
+	EmploymentType string `json:"employmentType"`
+}
+
+// bullhornAddress is a JobOrder's structured location. The public field set reliably carries
+// city/state; country is included when the customer exposes countryName.
+type bullhornAddress struct {
+	City    string `json:"city"`
+	State   string `json:"state"`
+	Country string `json:"countryName"`
+}
+
+// String renders the location as "City, State", falling back to the country name, then "".
+func (a bullhornAddress) String() string {
+	var parts []string
+	for _, p := range []string{a.City, a.State} {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, ", ")
+	}
+	return strings.TrimSpace(a.Country)
+}
+
+func (s bullhorn) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	colon := strings.Index(e.Board, ":")
+	if colon < 0 {
+		return nil, fmt.Errorf("bullhorn: board %q must be %q", e.Board, "<cls>:<corpToken>")
+	}
+	cls, corpToken := e.Board[:colon], e.Board[colon+1:]
+	if cls == "" || corpToken == "" {
+		return nil, fmt.Errorf("bullhorn: board %q must be %q with both parts set", e.Board, "<cls>:<corpToken>")
+	}
+	base := fmt.Sprintf("https://public-rest%s.bullhornstaffing.com/rest-services/%s/search/JobOrder", cls, corpToken)
+
+	var jobs []Job
+	for page := 0; page < bullhornMaxPages; page++ {
+		start := page * bullhornPageSize
+		q := url.Values{}
+		q.Set("query", "(isOpen:1)")
+		q.Set("fields", bullhornFields)
+		q.Set("sort", "-dateAdded")
+		q.Set("count", strconv.Itoa(bullhornPageSize))
+		q.Set("start", strconv.Itoa(start))
+
+		var resp bullhornSearchResponse
+		if err := s.http.GetJSON(ctx, base+"?"+q.Encode(), &resp); err != nil {
+			return nil, fmt.Errorf("bullhorn: board %s start %d: %w", e.Board, start, err)
+		}
+		for _, o := range resp.Data {
+			if j, ok := s.toJob(o, cls, corpToken, e); ok {
+				jobs = append(jobs, j)
+			}
+		}
+		if len(resp.Data) == 0 || start+len(resp.Data) >= resp.Total {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps a JobOrder to a Job, returning ok=false for a posting missing an id (which would
+// collide on the dedup key). The company is the configured staffing agency; the API has no
+// employer name to fall back to.
+func (bullhorn) toJob(o bullhornJobOrder, cls, corpToken string, e CompanyEntry) (Job, bool) {
+	if o.ID == 0 {
+		return Job{}, false
+	}
+	return Job{
+		ExternalID:     strconv.Itoa(o.ID),
+		URL:            fmt.Sprintf("https://public-rest%s.bullhornstaffing.com/rest-services/%s/entity/JobOrder/%d", cls, corpToken, o.ID),
+		Title:          o.Title,
+		Company:        e.Company,
+		Location:       o.Address.String(),
+		Description:    sanitizeHTML(o.PublicDescription),
+		PostedAt:       parseEpochMillis(o.DateAdded),
+		EmploymentType: bullhornEmploymentType(o.EmploymentType),
+	}, true
+}
+
+// bullhornEmploymentType maps Bullhorn's free-text employmentType (per-customer labels like
+// "Permanent", "Contract To Hire", "Direct Hire", "Temporary") onto the freehire vocabulary via
+// keyword containment, in priority order. An unrecognized value maps to "" so the description
+// parser decides — structured signal only, never a guess.
+func bullhornEmploymentType(t string) string {
+	s := strings.ToLower(t)
+	switch {
+	case strings.Contains(s, "intern"):
+		return "internship"
+	case strings.Contains(s, "part-time") || strings.Contains(s, "part time"):
+		return "part_time"
+	case strings.Contains(s, "contract") || strings.Contains(s, "temp") || strings.Contains(s, "seasonal"):
+		return "contract"
+	case strings.Contains(s, "full-time") || strings.Contains(s, "full time") ||
+		strings.Contains(s, "permanent") || strings.Contains(s, "direct hire"):
+		return "full_time"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/bullhorn_test.go
+++ b/internal/sources/bullhorn_test.go
@@ -1,0 +1,144 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// bullhornPage1JSON mirrors a search/JobOrder envelope: an HTML publicDescription, a structured
+// address, dateAdded as epoch milliseconds, and a per-customer employmentType label. total
+// exceeds the page's data length so the adapter pages again.
+const bullhornPage1JSON = `{
+  "total": 1000,
+  "start": 0,
+  "count": 500,
+  "data": [
+    {
+      "id": 4231,
+      "title": "Senior Go Engineer",
+      "publicDescription": "<p>Build backends.</p><script>alert(1)</script>",
+      "address": {"city": "Austin", "state": "TX", "countryName": "United States"},
+      "dateAdded": 1750617799000,
+      "employmentType": "Contract To Hire"
+    }
+  ]
+}`
+
+// bullhornPage2JSON is the next window: empty data ends pagination.
+const bullhornPage2JSON = `{"total": 1000, "start": 500, "count": 500, "data": []}`
+
+func TestBullhornProvider(t *testing.T) {
+	if got := NewBullhorn(nil).Provider(); got != "bullhorn" {
+		t.Errorf("Provider() = %q, want %q", got, "bullhorn")
+	}
+}
+
+func TestBullhornFetchMapsJobOrders(t *testing.T) {
+	fake := (&routedHTTP{}).
+		route("start=0", bullhornPage1JSON).
+		route("start=500", bullhornPage2JSON)
+
+	jobs, err := NewBullhorn(fake).Fetch(context.Background(), CompanyEntry{
+		Company: "Acme Staffing", Provider: "bullhorn", Board: "91:abc123def",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if fake.calls != 2 {
+		t.Errorf("calls = %d, want 2 (paged until empty window)", fake.calls)
+	}
+	j := jobs[0]
+	if j.ExternalID != "4231" {
+		t.Errorf("ExternalID = %q, want 4231", j.ExternalID)
+	}
+	if j.Title != "Senior Go Engineer" {
+		t.Errorf("Title = %q", j.Title)
+	}
+	if j.Company != "Acme Staffing" {
+		t.Errorf("Company = %q, want config company", j.Company)
+	}
+	wantURL := "https://public-rest91.bullhornstaffing.com/rest-services/abc123def/entity/JobOrder/4231"
+	if j.URL != wantURL {
+		t.Errorf("URL = %q, want %q", j.URL, wantURL)
+	}
+	if j.Location != "Austin, TX" {
+		t.Errorf("Location = %q, want \"Austin, TX\"", j.Location)
+	}
+	if strings.Contains(j.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", j.Description)
+	}
+	if !strings.Contains(j.Description, "Build backends.") {
+		t.Errorf("Description missing body: %q", j.Description)
+	}
+	if j.EmploymentType != "contract" {
+		t.Errorf("EmploymentType = %q, want contract", j.EmploymentType)
+	}
+	if j.PostedAt == nil || !j.PostedAt.Equal(time.Date(2025, 6, 22, 18, 43, 19, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2025-06-22T18:43:19Z", j.PostedAt)
+	}
+}
+
+func TestBullhornBreaksOnFullResult(t *testing.T) {
+	// total equals the window size, so the adapter must stop after one call.
+	single := `{"total": 1, "start": 0, "count": 500, "data": [
+		{"id": 7, "title": "X", "publicDescription": "<p>y</p>", "address": {"city": "Remote"}, "dateAdded": 0, "employmentType": ""}
+	]}`
+	fake := (&routedHTTP{}).route("start=0", single)
+	jobs, err := NewBullhorn(fake).Fetch(context.Background(), CompanyEntry{Company: "C", Board: "1:tok"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 || fake.calls != 1 {
+		t.Fatalf("jobs=%d calls=%d, want 1 job in 1 call", len(jobs), fake.calls)
+	}
+	if jobs[0].PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil for dateAdded 0", jobs[0].PostedAt)
+	}
+	if jobs[0].Location != "Remote" {
+		t.Errorf("Location = %q, want Remote (city fallback)", jobs[0].Location)
+	}
+}
+
+func TestBullhornDropsJobOrderWithNoID(t *testing.T) {
+	body := `{"total": 1, "start": 0, "count": 500, "data": [{"title": "No ID"}]}`
+	fake := (&routedHTTP{}).route("start=0", body)
+	jobs, err := NewBullhorn(fake).Fetch(context.Background(), CompanyEntry{Company: "C", Board: "1:tok"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (no-id dropped)", len(jobs))
+	}
+}
+
+func TestBullhornBoardMustBeClsColonToken(t *testing.T) {
+	for _, board := range []string{"nocolon", ":tok", "91:"} {
+		if _, err := NewBullhorn(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Board: board}); err == nil {
+			t.Errorf("board %q: expected error, got nil", board)
+		}
+	}
+}
+
+func TestBullhornEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"Contract To Hire": "contract",
+		"Temporary":        "contract",
+		"Permanent":        "full_time",
+		"Direct Hire":      "full_time",
+		"Full-Time":        "full_time",
+		"Part-Time":        "part_time",
+		"Internship":       "internship",
+		"Variable Hour":    "",
+		"":                 "",
+	}
+	for in, want := range cases {
+		if got := bullhornEmploymentType(in); got != want {
+			t.Errorf("bullhornEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -262,6 +262,7 @@ func All(c HTTPClient) map[string]Source {
 		NewMindsight(c),
 		NewEnlizt(c),
 		NewJobvite(c),
+		NewBullhorn(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/sources/bullhorn.yml
+++ b/sources/bullhorn.yml
@@ -1,0 +1,15 @@
+# Bullhorn — the largest staffing ATS. Each board is a staffing agency (the public API exposes
+# only the opaque corpToken, so the company name is set here). The board is "<cls>:<corpToken>":
+# cls is the numeric cluster/swimlane that selects the API host
+# (public-rest<cls>.bullhornstaffing.com) and corpToken is the public company token embedded in
+# the agency's Bullhorn career portal. The public API is keyless — only Open, Published-Approved
+# jobs are returned. Discover a board's cls/corpToken from the career portal's app.json (or the
+# XHR it makes to public-rest*). Staffing agencies list across industries, not only tech. Beware
+# the shared Bullhorn demo token 91:1VCNF4 (it ships as the career-portal default) — it is sample
+# data, not a real company.
+- company: Optomi
+  provider: bullhorn
+  board: 41:DJVM1
+- company: Flanders Job Creators
+  provider: bullhorn
+  board: 70:D1Z9J4


### PR DESCRIPTION
## What

Adds a **Bullhorn** source adapter — the single high-value ATS gap versus the [ever-jobs](https://github.com/ever-jobs/ever-jobs) catalogue. Bullhorn is the largest staffing ATS (#1, 10k+ agencies).

## How it works

- **Keyless public API.** `board` is `"<cls>:<corpToken>"`: `cls` (numeric cluster/swimlane) selects the host `public-rest<cls>.bullhornstaffing.com`, `corpToken` is the public company token embedded in the agency's career portal. No env secret.
- One `search/JobOrder` call returns every open, published posting fully populated (HTML `publicDescription`, `address(city,state,countryName)`, `dateAdded`), paginated by `count`/`start` (500/page, 40-page guard).
- `dateAdded` (epoch millis) → `posted_at`; `publicDescription` sanitized; `employmentType` keyword-mapped to the freehire vocabulary.

## Deliberate omissions

- **Salary/categories dropped** — the `Job` contract has no salary field (enrichment derives it) and `Category` expects freehire's controlled vocabulary, not Bullhorn's free-text names.
- **No human job URL** — the public API exposes only the REST endpoint + `POST /apply`, so the URL is the REST entity ref. Safe because board sources aren't liveness-probed.

## Gotcha handled

A bare `address` field returns an empty object; the projection requests `address(city,state,countryName)` explicitly so Location actually populates.

## Boards seeded

`sources/bullhorn.yml` — two boards, **validated end-to-end against the live API**:
- **Optomi** `41:DJVM1` — US IT staffing (53 open jobs)
- **Flanders Job Creators** `70:D1Z9J4` — Belgian technical staffing (17 open jobs)

(The shared Bullhorn demo token `91:1VCNF4` is documented as a trap to avoid — it ships as the career-portal default and is sample data, not a real company.)

## Tests

`go build ./...`, `go vet`, `gofmt` clean; 6 unit tests cover mapping, pagination, break-on-total, no-id drop, board-format validation, and employment-type mapping.