### PR TITLE
feat(sources): add Manatal ATS adapter + migrate careers-page.com boards

### DIFF
--- a/internal/sources/manatal.go
+++ b/internal/sources/manatal.go
@@ -1,0 +1,117 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// manatal adapts Manatal career pages (the recruitment ATS behind careers-page.com). The
+// board is the tenant's career-page slug (e.g. "davidjoseph-co"), which keys the public,
+// keyless list endpoint https://open.api.manatal.com/open/v3/career-page/<slug>/jobs/. That
+// endpoint carries every posting's full HTML description and its structured location,
+// remote flag, and contract type inline, so there is no per-posting detail request; it
+// paginates DRF-style via a top-level "next" link, walked until it is null.
+//
+// This is the JSON path for the same platform careers-page.com serves as server-rendered
+// HTML: the careerspage adapter crawls a tenant's <slug>.careers-page.com pages and fetches
+// each posting's ld+json detail, whereas this reads the whole board from one paginated JSON
+// feed with the description and facets already inline — so a Manatal tenant is best onboarded
+// here rather than under careerspage.
+type manatal struct {
+	http JSONGetter
+}
+
+// NewManatal builds the Manatal adapter over the given HTTP client.
+func NewManatal(c JSONGetter) Source { return manatal{http: c} }
+
+func (manatal) Provider() string { return "manatal" }
+
+const (
+	// manatalListURL is the public career-page jobs list, taking the tenant slug. It returns
+	// a DRF page {count,next,previous,results}; the next link carries ?page=N.
+	manatalListURL = "https://open.api.manatal.com/open/v3/career-page/%s/jobs/"
+	// manatalJobURL is the public human-facing posting page, keyed by the tenant slug and the
+	// posting hash (the id that appears in the career-page URL).
+	manatalJobURL = "https://www.careers-page.com/%s/job/%s"
+	// manatalMaxPages bounds the next-link walk so a feed that never stops handing out a next
+	// page cannot loop forever (the largest boards seen are ~10 pages; this is ample headroom).
+	manatalMaxPages = 200
+)
+
+// manatalPosting is one job from the career-page list, with its body and facets inline.
+type manatalPosting struct {
+	Hash            string `json:"hash"`
+	PositionName    string `json:"position_name"`
+	Description     string `json:"description"`
+	Country         string `json:"country"`
+	State           string `json:"state"`
+	City            string `json:"city"`
+	LocationDisplay string `json:"location_display"`
+	// IsRemote is the platform's structured remote flag; it is null for postings that leave
+	// it unset, which decodes to false — indistinguishable from an explicit "not remote", and
+	// treated the same (no structured remote signal).
+	IsRemote        bool   `json:"is_remote"`
+	ContractDetails string `json:"contract_details"`
+}
+
+func (m manatal) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	next := fmt.Sprintf(manatalListURL, url.PathEscape(e.Board))
+	var jobs []Job
+	for page := 0; page < manatalMaxPages && next != ""; page++ {
+		var resp struct {
+			Next    string           `json:"next"`
+			Results []manatalPosting `json:"results"`
+		}
+		if err := m.http.GetJSON(ctx, next, &resp); err != nil {
+			return nil, fmt.Errorf("manatal: board %s page %d: %w", e.Board, page, err)
+		}
+		for _, p := range resp.Results {
+			if job, ok := p.toJob(e); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		next = resp.Next
+	}
+	return jobs, nil
+}
+
+// toJob maps a posting to a Job, returning ok=false when it has no hash — the hash is the
+// posting's public id and the dedup key, so a hashless posting (which would collide on the
+// (source, external_id) key) is dropped. The configured company is canonical: organization_name
+// is the tenant's internal department, not the employer, so it never labels the job.
+func (p manatalPosting) toJob(e CompanyEntry) (Job, bool) {
+	if p.Hash == "" {
+		return Job{}, false
+	}
+	location := firstNonEmpty(p.LocationDisplay, joinNonEmpty(p.City, p.State, p.Country))
+	return Job{
+		ExternalID:     p.Hash,
+		URL:            fmt.Sprintf(manatalJobURL, url.PathEscape(e.Board), p.Hash),
+		Title:          p.PositionName,
+		Company:        e.Company,
+		Location:       location,
+		Description:    sanitizeHTML(p.Description),
+		Remote:         p.IsRemote || isRemote(location),
+		WorkMode:       workModeFromRemote(p.IsRemote),
+		EmploymentType: manatalEmploymentType(p.ContractDetails),
+		// The API carries no publish date, so posted_at is left unset (nullable).
+	}, true
+}
+
+// manatalEmploymentType maps Manatal's contract_details onto the freehire employment-type
+// vocabulary, returning "" for an unset/unknown value so the description parser decides.
+func manatalEmploymentType(t string) string {
+	switch t {
+	case "full_time":
+		return "full_time"
+	case "part_time":
+		return "part_time"
+	case "contract", "temporary", "freelance":
+		return "contract"
+	case "internship":
+		return "internship"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/manatal_test.go
+++ b/internal/sources/manatal_test.go
@@ -1,0 +1,121 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestManatalProvider(t *testing.T) {
+	if got := NewManatal(nil).Provider(); got != "manatal" {
+		t.Errorf("Provider() = %q, want manatal", got)
+	}
+}
+
+func TestManatalIsBoardBasedAndFilterable(t *testing.T) {
+	s := NewManatal(nil)
+	// Manatal is per-tenant (board = career-page slug), so it must NOT be boardless.
+	if _, ok := s.(boardless); ok {
+		t.Error("manatal must not implement the boardless marker (it is board-based)")
+	}
+	if _, ok := All(nil)["manatal"]; !ok {
+		t.Error("All() should register provider manatal")
+	}
+	if !slices.Contains(FilterableProviders(), "manatal") {
+		t.Error("FilterableProviders() should include manatal")
+	}
+}
+
+func TestManatalBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/manatal.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/manatal.yml fails validation: %v", err)
+	}
+}
+
+func TestManatalFetchPaginatesAndMaps(t *testing.T) {
+	page1 := `{"count":3,"next":"https://open.api.manatal.com/open/v3/career-page/acme/jobs/?page=2","previous":null,"results":[
+{"id":1,"hash":"AB12CD34","organization_name":"Engineering","position_name":"Backend Engineer","description":"<p>Build &amp; ship.</p>","country":"Thailand","state":"Bangkok","city":"Bangkok","location_display":"Bangkok, Thailand","is_remote":true,"contract_details":"full_time"},
+{"id":2,"hash":"","organization_name":"Sales","position_name":"skip me","description":"x","location_display":"Remote","is_remote":null,"contract_details":"internship"}
+]}`
+	// page2 carries a null next, terminating the walk.
+	page2 := `{"count":3,"next":null,"previous":"x","results":[
+{"id":3,"hash":"ZZ99","position_name":"QA Intern","description":"<p>Test.</p>","country":"","state":"","city":"","location_display":"Remote","is_remote":null,"contract_details":"internship"}
+]}`
+	// page=2 routed first so it wins over the base career-page route (routedHTTP is first-match).
+	fake := (&routedHTTP{}).route("page=2", page2).route("career-page/acme", page1)
+
+	jobs, err := NewManatal(fake).Fetch(context.Background(), CompanyEntry{Company: "Acme", Board: "acme"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (the hashless posting dropped)", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "AB12CD34" {
+		t.Errorf("ExternalID = %q, want the posting hash AB12CD34", j.ExternalID)
+	}
+	// URL is the public career-page posting page, keyed by tenant slug + hash.
+	if j.URL != "https://www.careers-page.com/acme/job/AB12CD34" {
+		t.Errorf("URL = %q, want careers-page.com/acme/job/AB12CD34", j.URL)
+	}
+	// Company is the configured tenant, never organization_name (a department).
+	if j.Company != "Acme" {
+		t.Errorf("Company = %q, want the configured Acme (not organization_name)", j.Company)
+	}
+	if j.Location != "Bangkok, Thailand" {
+		t.Errorf("Location = %q, want location_display", j.Location)
+	}
+	if j.WorkMode != "remote" || !j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want remote/true from is_remote", j.WorkMode, j.Remote)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if !strings.Contains(j.Description, "Build") || !strings.Contains(j.Description, "ship") {
+		t.Errorf("Description lost content: %q", j.Description)
+	}
+	if j.PostedAt != nil {
+		t.Errorf("PostedAt = %v, want nil (the API carries no publish date)", j.PostedAt)
+	}
+
+	// The second-page posting: no structured remote flag, but location text is "Remote" so the
+	// heuristic still flags it; WorkMode stays empty (structured signal only).
+	q := jobs[1]
+	if q.ExternalID != "ZZ99" || q.Title != "QA Intern" {
+		t.Errorf("bad page-2 mapping: %+v", q)
+	}
+	if !q.Remote {
+		t.Error("page-2 job should be Remote via the location heuristic")
+	}
+	if q.WorkMode != "" {
+		t.Errorf("WorkMode = %q, want empty (is_remote unset → no structured signal)", q.WorkMode)
+	}
+	if q.EmploymentType != "internship" {
+		t.Errorf("EmploymentType = %q, want internship", q.EmploymentType)
+	}
+}
+
+func TestManatalEmploymentType(t *testing.T) {
+	cases := map[string]string{
+		"full_time":  "full_time",
+		"part_time":  "part_time",
+		"contract":   "contract",
+		"temporary":  "contract",
+		"freelance":  "contract",
+		"internship": "internship",
+		"":           "",
+		"weird":      "",
+	}
+	for in, want := range cases {
+		if got := manatalEmploymentType(in); got != want {
+			t.Errorf("manatalEmploymentType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -263,6 +263,7 @@ func All(c HTTPClient) map[string]Source {
 		NewEnlizt(c),
 		NewJobvite(c),
 		NewBullhorn(c),
+		NewManatal(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/sources/careerspage.yml
+++ b/sources/careerspage.yml
@@ -1,12 +1,9 @@
 # careers-page.com career sites. Provider is the filename; each entry is company + board.
 # board = the tenant subdomain (<board>.careers-page.com); see internal/sources/careerspage.go.
-# The listing is server-rendered HTML paged via ?page=N; each job's canonical /jobs/<uuid>
-# detail page carries a schema.org JobPosting ld+json the adapter maps into a posting.
-# Each board validated live (listing lists >0 job postings) before adding.
-
-- company: David Joseph & Company
-  board: davidjoseph-co
-- company: Zarego
-  board: zarego
-- company: Alcor
-  board: alcor
+#
+# EMPTY: careers-page.com is Manatal's hosted career-page domain, and Manatal exposes a public
+# JSON API (open.api.manatal.com/open/v3/career-page/<slug>/jobs/) that is far more complete than
+# this adapter's server-rendered HTML crawl — the subdomain path under-fetches badly (davidjoseph-co
+# listed 6 of 182, zarego 0 of 9). All former boards were migrated to sources/manatal.yml; new
+# careers-page.com tenants should be onboarded there (provider "manatal"), not here. The careerspage
+# adapter stays registered but is superseded — see internal/sources/manatal.go.

--- a/sources/manatal.yml
+++ b/sources/manatal.yml
@@ -1,0 +1,45 @@
+# manatal boards. Provider is the filename; each entry is company + board.
+# board = the tenant's Manatal career-page slug (see internal/sources/manatal.go); the adapter
+# reads https://open.api.manatal.com/open/v3/career-page/<board>/jobs/ (public, keyless), which
+# carries every posting's description and structured location/remote/contract inline and
+# paginates via its "next" link. The human-facing posting lives at
+# https://www.careers-page.com/<board>/job/<hash>.
+#
+# Discovery footprint: careers-page.com is Manatal's hosted career-page domain, so a tenant is a
+# careers-page.com/<slug> path or a <slug>.careers-page.com subdomain (search-engine footprint
+# "careers-page.com"). Validate a candidate live before adding it:
+#   curl -s "https://open.api.manatal.com/open/v3/career-page/<slug>/jobs/" | jq .count   # want >0
+#
+# Note: many Manatal tenants are recruitment agencies posting many clients' roles; the adapter
+# labels each job with the configured company (the agency), the same as bullhorn/careerspage —
+# the per-vacancy employer is not resolved (a hub seam for later).
+
+- company: Syfe
+  board: syfe
+- company: IDR
+  board: idr
+- company: PHRS Recruitment
+  board: phrsrecruitment
+- company: GAP Recruitment Services
+  board: gaprecruitment
+- company: CPJ Recruitment
+  board: cpj-recruitment
+- company: One Recruitment
+  board: one-recruitment
+- company: MyCareerCraft
+  board: mycareercraft
+- company: Nexus Recruitment Group
+  board: nexusrecruitment
+- company: Recruitment Apple Lovers
+  board: recruitment-apple-lovers
+- company: AGC Recruitment
+  board: job-listings
+
+# Migrated from careerspage.yml: careers-page.com IS Manatal, and the JSON API is far more
+# complete than the old <slug>.careers-page.com HTML crawl (davidjoseph-co 182 vs 6, zarego 9 vs 0).
+- company: David Joseph & Company
+  board: davidjoseph-co
+- company: Zarego
+  board: zarego
+- company: Alcor
+  board: alcor


### PR DESCRIPTION
## What

Adds a `manatal` source adapter for the **Manatal** recruitment ATS and migrates the existing `careers-page.com` boards to it.

**Key finding:** careers-page.com *is* Manatal's hosted career-page domain. Manatal exposes a public, keyless JSON API — `open.api.manatal.com/open/v3/career-page/<slug>/jobs/` — returning each posting's full HTML description and structured location / `is_remote` / `contract_details` inline, paginated DRF-style via the top-level `next` link. So a board reads in one paginated JSON pass with **no per-posting detail fetch** (unlike `careerspage`, which crawls `<slug>.careers-page.com` HTML + per-job ld+json under a rate-limited 2-worker pool + proxy).

- `board` = tenant career-page slug; public job URL `https://www.careers-page.com/<slug>/job/<hash>`.
- Facets: `contract_details` -> `EmploymentType`, `is_remote` -> `WorkMode`/`Remote`; `external_id` = `hash`; company from config.

## Discovery
`sources/manatal.yml` seeds 10 web-discovered boards (footprint `careers-page.com`), each live-validated (`count > 0`).

## Migration
`davidjoseph-co`, `zarego`, `alcor` moved careerspage -> manatal; the JSON API is far more complete than the HTML crawl (davidjoseph-co 182 vs 6, zarego 9 vs 0). `sources/careerspage.yml` is now empty-but-valid; the careerspage adapter stays registered but superseded. `external_id` changes UUID->hash, so old careerspage rows close via the unseen sweep (~48h) and re-ingest under `source=manatal`.

## Verification
gofmt/build/vet clean, full `internal/sources` tests green; live E2E: Syfe 26 jobs, Nexus 326 (multi-page pagination).
