### PR TITLE
feat(sources): add JobScore ATS adapter

### DIFF
--- a/internal/sources/jobscore.go
+++ b/internal/sources/jobscore.go
@@ -1,0 +1,172 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// jobscore adapts JobScore career sites through the public per-company job feed. JobScore is a
+// US ATS whose feed is keyless: the board is the company shortcode from its careers URL
+// (careers.jobscore.com/careers/<slug>), and one feed.json call returns every published posting
+// fully populated — structured city/state/country, a Yes/No remote string, job_type,
+// experience_level, opened_date, a human careers-page detail_url, and the HTML description — so no
+// per-posting detail fetch is needed.
+//
+// JobScore asks integrations to poll a feed at most once per hour (it may disable access on more
+// frequent polling); the hourly ingest timer stays within that.
+type jobscore struct {
+	http JSONGetter
+}
+
+// jobscoreLimit caps a single feed read. JobScore feeds are slow-changing per-company lists that
+// fit one response; a generous limit avoids truncating a large board without inviting abuse.
+const jobscoreLimit = 1000
+
+// NewJobscore builds the JobScore adapter over the given HTTP client.
+func NewJobscore(c JSONGetter) Source { return jobscore{http: c} }
+
+func (jobscore) Provider() string { return "jobscore" }
+
+// jobscoreFeed is the feed.json envelope: company identity plus the posting list.
+type jobscoreFeed struct {
+	CompanyName string        `json:"company_name"`
+	Jobs        []jobscoreJob `json:"jobs"`
+}
+
+type jobscoreJob struct {
+	ID              string `json:"id"`
+	Title           string `json:"title"`
+	DetailURL       string `json:"detail_url"`
+	Description     string `json:"description"`
+	City            string `json:"city"`
+	State           string `json:"state"`
+	Country         string `json:"country"`
+	Location        string `json:"location"`
+	Remote          string `json:"remote"`
+	JobType         string `json:"job_type"`
+	ExperienceLevel string `json:"experience_level"`
+	OpenedDate      string `json:"opened_date"`
+}
+
+func (s jobscore) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	if e.Board == "" {
+		return nil, fmt.Errorf("jobscore: empty board")
+	}
+	url := fmt.Sprintf("https://careers.jobscore.com/jobs/%s/feed.json?sort=date&limit=%d", e.Board, jobscoreLimit)
+
+	var feed jobscoreFeed
+	if err := s.http.GetJSON(ctx, url, &feed); err != nil {
+		return nil, fmt.Errorf("jobscore: board %s: %w", e.Board, err)
+	}
+
+	company := e.Company
+	if company == "" {
+		company = feed.CompanyName
+	}
+
+	jobs := make([]Job, 0, len(feed.Jobs))
+	for _, j := range feed.Jobs {
+		if job, ok := toJobscoreJob(j, company); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toJobscoreJob maps a feed posting to a Job, returning ok=false for a posting missing an id
+// (which would collide on the dedup key).
+func toJobscoreJob(j jobscoreJob, company string) (Job, bool) {
+	if strings.TrimSpace(j.ID) == "" {
+		return Job{}, false
+	}
+	mode := jobscoreWorkMode(j.Remote)
+	return Job{
+		ExternalID:     j.ID,
+		URL:            j.DetailURL,
+		Title:          j.Title,
+		Company:        company,
+		Location:       jobscoreLocation(j),
+		Description:    sanitizeHTML(j.Description),
+		Remote:         mode == "remote",
+		WorkMode:       mode,
+		PostedAt:       parseRFC3339OrDate(j.OpenedDate),
+		Seniority:      jobscoreSeniority(j.ExperienceLevel),
+		EmploymentType: jobscoreEmploymentType(j.JobType),
+	}, true
+}
+
+// jobscoreLocation renders "City, State" from the structured fields, falling back to the country,
+// then the free-text location string.
+func jobscoreLocation(j jobscoreJob) string {
+	var parts []string
+	for _, p := range []string{j.City, j.State} {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, ", ")
+	}
+	if c := strings.TrimSpace(j.Country); c != "" {
+		return c
+	}
+	return strings.TrimSpace(j.Location)
+}
+
+// jobscoreWorkMode maps JobScore's remote string onto the work-mode vocabulary. The field is
+// free text prefixed Yes/No with an "all/some of the time" qualifier, e.g. "No | Must be able to
+// work onsite all of the time" or "Yes | Can work remotely some of the time".
+func jobscoreWorkMode(remote string) string {
+	r := strings.ToLower(strings.TrimSpace(remote))
+	switch {
+	case strings.HasPrefix(r, "yes"):
+		if strings.Contains(r, "some") {
+			return "hybrid"
+		}
+		return "remote"
+	case strings.HasPrefix(r, "no"):
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// jobscoreSeniority maps JobScore's experience_level label onto the freehire seniority vocabulary
+// via keyword containment. Only the individual-contributor levels map; management/executive labels
+// (Manager, Executive) are left "" so the title dictionary decides rather than forcing a
+// people-manager into an IC-seniority bucket. Structured signal only, never a guess.
+func jobscoreSeniority(level string) string {
+	l := strings.ToLower(level)
+	switch {
+	case strings.Contains(l, "student") || strings.Contains(l, "intern"):
+		return "intern"
+	case strings.Contains(l, "entry") || strings.Contains(l, "associate"):
+		return "junior"
+	case strings.Contains(l, "mid"):
+		return "middle"
+	case strings.Contains(l, "experienced") || strings.Contains(l, "senior"):
+		return "senior"
+	default:
+		return ""
+	}
+}
+
+// jobscoreEmploymentType maps JobScore's job_type label (Full Time, Part Time, Contractor,
+// Temporary, Intern, Seasonal) onto the freehire vocabulary via keyword containment. An
+// unrecognized value maps to "".
+func jobscoreEmploymentType(t string) string {
+	s := strings.ToLower(t)
+	switch {
+	case strings.Contains(s, "intern"):
+		return "internship"
+	case strings.Contains(s, "part"):
+		return "part_time"
+	case strings.Contains(s, "contract") || strings.Contains(s, "temp") || strings.Contains(s, "seasonal"):
+		return "contract"
+	case strings.Contains(s, "full"):
+		return "full_time"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/jobscore_test.go
+++ b/internal/sources/jobscore_test.go
@@ -1,0 +1,169 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// jobscoreFeedJSON mirrors a careers.jobscore.com feed.json response: company identity plus
+// postings with structured location, a Yes/No remote string, job_type, experience_level, an
+// opened_date with millisecond precision, and an HTML description.
+const jobscoreFeedJSON = `{
+  "company_name": "IERUS Technologies, Inc.",
+  "jobs": [
+    {
+      "id": "dgLTVq3fbbbkS61af48PpK",
+      "title": "Systems and Network Administrator",
+      "detail_url": "https://careers.jobscore.com/careers/ierustechnologiesinc/jobs/systems-and-network-administrator-dgLTVq3fbbbkS61af48PpK?ref=rss&sid=68",
+      "description": "<p>IERUS specializes in RF.</p><script>alert(1)</script>",
+      "city": "Huntsville",
+      "state": "AL",
+      "country": "US",
+      "location": "Huntsville, AL, US",
+      "remote": "No | Must be able to work onsite all of the time",
+      "job_type": "Full Time",
+      "experience_level": "Mid-Level",
+      "opened_date": "2026-03-31T17:04:28.293Z"
+    },
+    {
+      "id": "remote42",
+      "title": "Senior Front-End Engineer",
+      "detail_url": "https://careers.jobscore.com/careers/x/jobs/fe-remote42",
+      "description": "<p>Build UI.</p>",
+      "location": "Remote in Joinville, Santa Catarina, Brazil",
+      "remote": "Yes | Can work remotely all of the time",
+      "job_type": "Contractor",
+      "experience_level": "Experienced (Non-Manager)",
+      "opened_date": "2026-05-01"
+    }
+  ]
+}`
+
+func newJobscoreFake() *routedHTTP {
+	return (&routedHTTP{}).route("/jobs/ierustechnologiesinc/feed.json", jobscoreFeedJSON)
+}
+
+func TestJobscoreProvider(t *testing.T) {
+	if got := NewJobscore(nil).Provider(); got != "jobscore" {
+		t.Errorf("Provider() = %q, want %q", got, "jobscore")
+	}
+}
+
+func TestJobscoreFetchMapsFeed(t *testing.T) {
+	jobs, err := NewJobscore(newJobscoreFake()).Fetch(context.Background(), CompanyEntry{
+		Company: "IERUS Technologies", Provider: "jobscore", Board: "ierustechnologiesinc",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+
+	a := jobs[0]
+	if a.ExternalID != "dgLTVq3fbbbkS61af48PpK" {
+		t.Errorf("ExternalID = %q", a.ExternalID)
+	}
+	if a.Company != "IERUS Technologies" {
+		t.Errorf("Company = %q, want config company", a.Company)
+	}
+	if !strings.HasPrefix(a.URL, "https://careers.jobscore.com/careers/ierustechnologiesinc/") {
+		t.Errorf("URL = %q, want the detail_url", a.URL)
+	}
+	if a.Location != "Huntsville, AL" {
+		t.Errorf("Location = %q, want \"Huntsville, AL\"", a.Location)
+	}
+	if a.WorkMode != "onsite" || a.Remote {
+		t.Errorf("WorkMode = %q Remote = %v, want onsite/false", a.WorkMode, a.Remote)
+	}
+	if a.Seniority != "middle" {
+		t.Errorf("Seniority = %q, want middle", a.Seniority)
+	}
+	if a.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", a.EmploymentType)
+	}
+	if strings.Contains(a.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", a.Description)
+	}
+	if a.PostedAt == nil || !a.PostedAt.Equal(time.Date(2026, 3, 31, 17, 4, 28, 293000000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-03-31T17:04:28.293Z", a.PostedAt)
+	}
+
+	b := jobs[1]
+	if b.WorkMode != "remote" || !b.Remote {
+		t.Errorf("WorkMode = %q Remote = %v, want remote/true", b.WorkMode, b.Remote)
+	}
+	if b.EmploymentType != "contract" {
+		t.Errorf("EmploymentType = %q, want contract", b.EmploymentType)
+	}
+	if b.Seniority != "senior" {
+		t.Errorf("Seniority = %q, want senior", b.Seniority)
+	}
+	if b.Location != "Remote in Joinville, Santa Catarina, Brazil" {
+		t.Errorf("Location = %q, want the free-text location fallback", b.Location)
+	}
+	if b.PostedAt == nil || !b.PostedAt.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-05-01", b.PostedAt)
+	}
+}
+
+func TestJobscoreCompanyFallsBackToFeed(t *testing.T) {
+	jobs, err := NewJobscore(newJobscoreFake()).Fetch(context.Background(), CompanyEntry{Board: "ierustechnologiesinc"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if jobs[0].Company != "IERUS Technologies, Inc." {
+		t.Errorf("Company = %q, want feed company_name fallback", jobs[0].Company)
+	}
+}
+
+func TestJobscoreDropsJobWithNoID(t *testing.T) {
+	fake := (&routedHTTP{}).route("/jobs/x/feed.json", `{"company_name":"X","jobs":[{"title":"No ID"}]}`)
+	jobs, err := NewJobscore(fake).Fetch(context.Background(), CompanyEntry{Company: "X", Board: "x"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (no-id dropped)", len(jobs))
+	}
+}
+
+func TestJobscoreEmptyBoardErrors(t *testing.T) {
+	if _, err := NewJobscore(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{}); err == nil {
+		t.Fatal("expected error for empty board")
+	}
+}
+
+func TestJobscoreWorkMode(t *testing.T) {
+	cases := map[string]string{
+		"No | Must be able to work onsite all of the time": "onsite",
+		"Yes | Can work remotely all of the time":          "remote",
+		"Yes | Can work remotely some of the time":         "hybrid",
+		"": "",
+	}
+	for in, want := range cases {
+		if got := jobscoreWorkMode(in); got != want {
+			t.Errorf("jobscoreWorkMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestJobscoreSeniority(t *testing.T) {
+	cases := map[string]string{
+		"Student (College)":                     "intern",
+		"Entry Level":                           "junior",
+		"Associate":                             "junior",
+		"Mid-Level":                             "middle",
+		"Experienced (Non-Manager)":             "senior",
+		"Manager (Manager/Supervisor of Staff)": "",
+		"Executive (SVP, VP, Department Head)":  "",
+		"":                                      "",
+	}
+	for in, want := range cases {
+		if got := jobscoreSeniority(in); got != want {
+			t.Errorf("jobscoreSeniority(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -264,6 +264,7 @@ func All(c HTTPClient) map[string]Source {
 		NewJobvite(c),
 		NewBullhorn(c),
 		NewManatal(c),
+		NewJobscore(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/sources/jobscore.yml
+++ b/sources/jobscore.yml
@@ -1,0 +1,23 @@
+# JobScore — a US ATS. Each board is a company shortcode from its careers URL
+# (careers.jobscore.com/careers/<board>); one feed.json call returns every published posting with
+# structured location, a Yes/No remote string, job_type, experience_level, opened_date, and a
+# human detail_url. Keyless. JobScore asks integrations to poll a feed at most once per hour, so
+# this file is crawled on the standard hourly ingest timer — do not shard it to sub-hourly.
+- company: IERUS Technologies
+  provider: jobscore
+  board: ierustechnologiesinc
+- company: MAQ Software
+  provider: jobscore
+  board: maqsoftware
+- company: Caldera Medical
+  provider: jobscore
+  board: calderamedical
+- company: Aria Systems
+  provider: jobscore
+  board: ariasystems
+- company: Solutions 2 GO
+  provider: jobscore
+  board: solutions2go
+- company: Finalsite
+  provider: jobscore
+  board: finalsite


### PR DESCRIPTION
## What

Adds a **JobScore** source adapter — the next keyless ATS gap from the [ever-jobs](https://github.com/ever-jobs/ever-jobs) catalogue (after Bullhorn; Manatal already exists).

## How it works

- **Keyless per-company feed.** `board` is the company shortcode from the careers URL (`careers.jobscore.com/careers/<board>`). One `GET careers.jobscore.com/jobs/<board>/feed.json?sort=date&limit=1000` returns `{company_name, jobs:[…]}` — every published posting, fully populated, no per-posting detail fetch.
- **Rich structured signal**, mapped onto freehire's controlled vocabularies (much of it beyond what the ever-jobs mapping used):

| Job field | JobScore source |
|---|---|
| URL | `detail_url` — human careers page |
| Location | structured `city`/`state`/`country`, free-text `location` fallback |
| WorkMode | `remote` string → onsite / remote / hybrid (`No…` / `Yes…all` / `Yes…some`) |
| EmploymentType | `job_type` |
| Seniority | `experience_level` (IC levels only; Manager/Executive left to the title dictionary) |
| PostedAt | `opened_date` |
| Company | config, falling back to feed `company_name` |

## Polling note

JobScore disables feed access on polling faster than once per hour. The board file is documented to stay on the standard hourly ingest timer (do not shard to sub-hourly).

## Boards seeded

`sources/jobscore.yml` — six boards, **validated end-to-end against the live feed** (89 jobs total): IERUS Technologies (31), Caldera Medical (18), Finalsite (11), Aria Systems (10), Solutions 2 GO (10), MAQ Software (9).

## Tests

`go build ./...`, `go vet`, `gofmt` clean; 7 unit tests cover feed mapping, company fallback, no-id drop, empty-board error, and the work-mode + seniority mappers.