### PR TITLE
feat(discover): mine ATS boards from aggregator apply-URLs (+32 boards)

### DIFF
--- a/scripts/ats_boards.py
+++ b/scripts/ats_boards.py
@@ -33,6 +33,11 @@ SLUG_PATTERNS = [
     (re.compile(r"([A-Za-z0-9_-]+)\.jobs\.personio\.(?:com|de)"), "personio"),
     (re.compile(r"([A-Za-z0-9_-]+)\.applytojob\.com"), "jazzhr"),
     (re.compile(r"jobs\.jobvite\.com/([A-Za-z0-9_-]+)"), "jobvite"),
+    # Traffit's board is the tenant subdomain (<board>.traffit.com), so a public apply
+    # link (<board>.traffit.com/public/form/...) exposes it directly. eRecruiter is
+    # deliberately absent: its apply link carries a per-form WebID, not the cfg board
+    # token our adapter needs, so it is not derivable here (see cmd/harvest-erecruiter).
+    (re.compile(r"([A-Za-z0-9_-]+)\.traffit\.com"), "traffit"),
     # Teamtailor's "slug" is the whole board host — the adapter takes board = hostname.
     # Only *.teamtailor.com hosts are detectable here; boards on a custom domain
     # (e.g. jobs.tibber.com) carry no teamtailor marker in the URL and are missed.
@@ -59,6 +64,7 @@ VALIDATORS = {
     "jazzhr": lambda s: f"https://{s}.applytojob.com/apply",  # /apply listing HTML
     "jobvite": lambda s: f"https://jobs.jobvite.com/{s}",  # careersite listing HTML
     "teamtailor": lambda s: f"https://{s}/jobs",  # s is the board host, not a slug
+    "traffit": lambda s: f"https://{s}.traffit.com/public/an/list/?limit=10&offset=0",  # {count, items}
 }
 
 
@@ -133,6 +139,8 @@ def validate(provider: str, slug: str) -> int | None:
         count = len(d.get("offers", []))
     elif provider == "bamboohr":
         count = len(d.get("result", []))
+    elif provider == "traffit":
+        count = d.get("count") or len(d.get("items", []))
     else:
         count = len(d.get("jobs", []))
     return count or None

--- a/scripts/mine_aggregators.py
+++ b/scripts/mine_aggregators.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Mine ATS board slugs from the outbound apply-URLs of job aggregators we already crawl.
+
+Where harvest_boards.py reads static ATS-slug dumps and discover_boards.py runs web
+search, this script exploits a third signal: an aggregator lists a company's posting but
+its *apply* link points straight at that company's own ATS board (justjoin's applyUrl ->
+grapeup.traffit.com, arbeitnow's posting body -> job-boards.greenhouse.io/<slug>). Follow
+those links, extract (provider, slug), and we discover boards without ever probing an ATS
+platform ourselves.
+
+Each aggregator reduces to a list of "rows" — dicts carrying a company name plus whatever
+string fields may hide an ATS URL — and the shared _rows_candidates() sweeps them with the
+same extract_slugs() regexes the other two scripts use. From there the ats_boards core
+(dedup vs sources/*.yml, live validation, YAML emit) is reused verbatim.
+
+Usage:
+    python3 scripts/mine_aggregators.py                          # both aggregators, default limit
+    python3 scripts/mine_aggregators.py --aggregator justjoin    # one aggregator
+    python3 scripts/mine_aggregators.py --limit 500 --write      # deeper crawl, append survivors
+    python3 scripts/mine_aggregators.py --provider greenhouse,lever   # only emit these providers
+
+Stdlib only. The board coverage equals ats_boards.VALIDATORS — an applyUrl to an ATS we
+have no pattern for (e.g. traffit) is silently dropped; adding one is a line in ats_boards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from ats_boards import fetch, extract_slugs, emit_survivors  # noqa: E402
+
+# Company-name keys, ordered by how the aggregators spell them (justjoin: companyName,
+# arbeitnow: company_name). First non-empty wins; a row with none falls back to the slug.
+NAME_KEYS = ("companyName", "company_name", "company", "name", "employer")
+
+JUSTJOIN_LIST = "https://api.justjoin.it/v2/user-panel/offers/by-cursor"
+JUSTJOIN_DETAIL = "https://api.justjoin.it/v1/offers/%s"  # carries applyUrl the list omits
+ARBEITNOW_API = "https://www.arbeitnow.com/api/job-board-api"
+
+
+def _get_json(url: str) -> dict | list | None:
+    """GET a URL and parse JSON, returning None on any transport or decode failure."""
+    body = fetch(url)
+    if body is None:
+        return None
+    try:
+        return json.loads(body)
+    except Exception:
+        return None
+
+
+def _rows_candidates(rows: list[dict]) -> dict[tuple[str, str], str]:
+    """Sweep aggregator rows for ATS boards -> {(provider, slug): company_name}.
+
+    A row's company name is attributed to every board slug found in its string fields; the
+    first row to surface a (provider, slug) wins the attribution, so an earlier, richer row
+    is not overwritten by a later bare one.
+    """
+    cand: dict[tuple[str, str], str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = next((str(row[k]).strip() for k in NAME_KEYS if row.get(k)), "")
+        blob = " ".join(v for v in row.values() if isinstance(v, str))
+        for prov, slug in extract_slugs(blob):
+            cand.setdefault((prov, slug), name or slug)
+    return cand
+
+
+def harvest_justjoin(limit: int, get_json=_get_json, max_workers: int = 8) -> dict[tuple[str, str], str]:
+    """Page justjoin's cursor feed, then fetch each offer's detail for its applyUrl.
+
+    The list omits the apply link, so the ATS is only reachable via GET /v1/offers/{slug} —
+    one request per offer, which is why limit bounds the number of detail fetches (the
+    expensive part), not just the listing walk.
+    """
+    offers: list[dict] = []
+    cursor = 0
+    while len(offers) < limit:
+        url = JUSTJOIN_LIST if cursor == 0 else f"{JUSTJOIN_LIST}?from={cursor}"
+        resp = get_json(url)
+        if not isinstance(resp, dict):
+            break
+        offers.extend(resp.get("data") or [])
+        nxt = (resp.get("meta") or {}).get("next")
+        ncur = nxt.get("cursor") if isinstance(nxt, dict) else None
+        # Stop at feed end or a non-advancing cursor (the `from` param was ignored) — the
+        # same guard the Go adapter uses to avoid refetching page 1 forever.
+        if not ncur or ncur <= cursor:
+            break
+        cursor = ncur
+    offers = offers[:limit]
+
+    def one(o: dict) -> dict:
+        slug = o.get("slug")
+        detail = get_json(JUSTJOIN_DETAIL % slug) if slug else None
+        apply_url = detail.get("applyUrl") if isinstance(detail, dict) else ""
+        return {"companyName": o.get("companyName", ""), "applyUrl": apply_url or ""}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        rows = list(ex.map(one, offers))
+    print(f"  justjoin: {len(offers)} offers inspected", file=sys.stderr)
+    return _rows_candidates(rows)
+
+
+def harvest_arbeitnow(limit: int, get_json=_get_json) -> dict[tuple[str, str], str]:
+    """Page arbeitnow's public feed; the ATS link lives in the posting body, not a field.
+
+    arbeitnow re-lists jobs it sourced from greenhouse/lever/recruitee boards, so the board
+    URL appears inside the description HTML — a plain regex sweep of the row surfaces it, no
+    per-offer request needed.
+    """
+    rows: list[dict] = []
+    page = 1
+    while len(rows) < limit:
+        resp = get_json(f"{ARBEITNOW_API}?page={page}")
+        if not isinstance(resp, dict):
+            break
+        data = resp.get("data") or []
+        if not data:
+            break
+        rows.extend(data)
+        page += 1
+    rows = rows[:limit]
+    print(f"  arbeitnow: {len(rows)} postings inspected", file=sys.stderr)
+    return _rows_candidates(rows)
+
+
+HARVESTERS = {
+    "justjoin": harvest_justjoin,
+    "arbeitnow": harvest_arbeitnow,
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--aggregator", default=",".join(HARVESTERS),
+                    help="comma-separated aggregators to mine (default: all)")
+    ap.add_argument("--limit", type=int, default=200,
+                    help="max postings to inspect per aggregator (bounds justjoin detail fetches)")
+    ap.add_argument("--provider", default="",
+                    help="comma-separated ATS providers to emit (default: all)")
+    ap.add_argument("--write", action="store_true", help="append survivors to sources/<provider>.yml")
+    args = ap.parse_args()
+
+    names = [n.strip() for n in args.aggregator.split(",") if n.strip()]
+    unknown = [n for n in names if n not in HARVESTERS]
+    if unknown:
+        ap.error(f"unknown aggregator(s): {', '.join(unknown)}; known: {', '.join(HARVESTERS)}")
+
+    cand: dict[tuple[str, str], str] = {}
+    for name in names:
+        print(f"# mining {name} ...", file=sys.stderr)
+        for key, company in HARVESTERS[name](args.limit).items():
+            cand.setdefault(key, company)
+
+    if args.provider:
+        keep = {p.strip() for p in args.provider.split(",") if p.strip()}
+        cand = {(prov, slug): n for (prov, slug), n in cand.items() if prov in keep}
+
+    emit_survivors(cand, args.write)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_mine_aggregators.py
+++ b/scripts/test_mine_aggregators.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Plain-assert tests for mine_aggregators harvesters (no pytest, stdlib only, no network).
+Run: python3 scripts/test_mine_aggregators.py"""
+
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import mine_aggregators as m  # noqa: E402
+
+
+def _router(routes):
+    """Return a get_json stub that dispatches by substring match against routes, counting calls."""
+    calls = {"n": 0}
+
+    def get_json(url):
+        calls["n"] += 1
+        for frag, payload in routes.items():
+            if frag in url:
+                return payload
+        return None
+
+    return get_json, calls
+
+
+def test_rows_candidates_attributes_company_from_applyurl():
+    rows = [{"companyName": "Grape Up", "applyUrl": "https://job-boards.greenhouse.io/grapeup"}]
+    cand = m._rows_candidates(rows)
+    assert cand[("greenhouse", "grapeup")] == "Grape Up"
+
+
+def test_rows_candidates_falls_back_to_slug_without_name():
+    rows = [{"applyUrl": "https://jobs.lever.co/standalone"}]
+    cand = m._rows_candidates(rows)
+    assert cand[("lever", "standalone")] == "standalone"
+
+
+def test_rows_candidates_first_row_wins_attribution():
+    rows = [
+        {"companyName": "Acme", "applyUrl": "https://jobs.ashbyhq.com/acme"},
+        {"companyName": "", "applyUrl": "https://jobs.ashbyhq.com/acme"},
+    ]
+    assert m._rows_candidates(rows)[("ashby", "acme")] == "Acme"
+
+
+def test_harvest_justjoin_follows_detail_applyurl():
+    get_json, calls = _router({
+        "by-cursor": {"data": [{"slug": "acme-dev", "companyName": "Acme"}], "meta": {"next": None}},
+        "/v1/offers/acme-dev": {"applyUrl": "https://apply.workable.com/acme"},
+    })
+    cand = m.harvest_justjoin(limit=10, get_json=get_json, max_workers=1)
+    assert cand[("workable", "acme")] == "Acme"
+    # one list page + one detail fetch for the single offer
+    assert calls["n"] == 2, calls["n"]
+
+
+def test_harvest_justjoin_limit_bounds_detail_fetches():
+    # A feed of 5 offers across cursor pages, but limit=2 must fetch only 2 details.
+    page1 = {"data": [{"slug": f"s{i}", "companyName": f"C{i}"} for i in range(3)],
+             "meta": {"next": {"cursor": 9}}}
+    page2 = {"data": [{"slug": f"s{i}", "companyName": f"C{i}"} for i in range(3, 5)],
+             "meta": {"next": None}}
+    seq = {"n": 0}
+
+    def get_json(url):
+        if "by-cursor" in url and "from=" not in url:
+            return page1
+        if "from=9" in url:
+            return page2
+        return {"applyUrl": ""}  # detail
+
+    cand = m.harvest_justjoin(limit=2, get_json=get_json, max_workers=1)
+    assert cand == {}  # empty applyUrls -> no boards, but must not crash
+
+
+def test_harvest_arbeitnow_sweeps_description_body():
+    get_json, calls = _router({
+        "page=1": {"data": [{"company_name": "Foo Inc",
+                             "description": 'apply at <a href="https://jobs.lever.co/fooinc">x</a>'}]},
+        "page=2": {"data": []},
+    })
+    cand = m.harvest_arbeitnow(limit=100, get_json=get_json)
+    assert cand[("lever", "fooinc")] == "Foo Inc"
+
+
+def test_harvest_arbeitnow_stops_on_empty_page():
+    get_json, calls = _router({"page=1": {"data": []}})
+    assert m.harvest_arbeitnow(limit=100, get_json=get_json) == {}
+    assert calls["n"] == 1
+
+
+def _run():
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for fn in fns:
+        try:
+            fn()
+            print(f"ok   {fn.__name__}")
+        except Exception:
+            failed += 1
+            print(f"FAIL {fn.__name__}")
+            traceback.print_exc()
+    print(f"\n{len(fns) - failed}/{len(fns)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_run())

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3665,3 +3665,5 @@
   board: krila
 - company: gro
   board: gro
+- company: Tidio
+  board: tidiocareer

--- a/sources/traffit.yml
+++ b/sources/traffit.yml
@@ -33,3 +33,63 @@
   board: itlt
 - company: HR|hub
   board: hrhub
+- company: Antal Sp. z o.o.
+  board: antalpl
+- company: SCALO
+  board: scalo
+- company: RITS Professional Services
+  board: rits
+- company: Be in IT
+  board: beinit
+- company: KUBO Poland Sp. z o.o.
+  board: kubo
+- company: BPX S.A.
+  board: bpxsa
+- company: Neontri
+  board: neontri
+- company: Primaris Services Sp. z o.o.
+  board: primaris
+- company: speedapp
+  board: speedapp
+- company: XTB
+  board: xtb
+- company: Transition Technologies MS
+  board: ttms
+- company: Team Up
+  board: teamuprecruitment
+- company: Billennium
+  board: billennium
+- company: Xopero Software
+  board: xoperosoftware
+- company: Clurgo
+  board: clurgo
+- company: Autopay S.A.
+  board: autopay
+- company: Immersion Labs
+  board: immersion
+- company: TeaCode S.C.
+  board: teacode
+- company: Sigmoidal
+  board: sigmoidal
+- company: Lumicode Sp. z o.o. (Pentacomp Group)
+  board: lumicode
+- company: Blazity Sp. z o.o.
+  board: blazity
+- company: Altkom Software&CONSULTING/Kreatik/Altkom Akademia
+  board: asc
+- company: MOWI
+  board: mowi
+- company: Bluebinary.io
+  board: bluebinary
+- company: Incubly
+  board: incubly
+- company: Aplitt
+  board: aplitt
+- company: Pekao CoNext
+  board: pekaoconext
+- company: CloudFerro S.A.
+  board: cloudferro
+- company: Rite NRG Sp. z o.o.
+  board: ritenrg
+- company: Datumo
+  board: datumo

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -1400,3 +1400,5 @@
   board: david-protein
 - company: Future Publishing
   board: futureplc
+- company: Base.
+  board: base-com


### PR DESCRIPTION
## What

New discovery script `scripts/mine_aggregators.py` that mines the outbound **apply-URLs of aggregators we already crawl** to find a company's own ATS board — without probing any ATS platform directly.

- **justjoin**: cursor-paginate the feed, fetch each offer's detail for its `applyUrl` (e.g. `grapeup.traffit.com`).
- **arbeitnow**: regex-sweep the posting body (ATS link sits in the description).
- Both reduce to a list of rows fed through the shared `ats_boards` core (extract → dedup vs `sources/*.yml` → live-validate → YAML emit).
- Harvesters take an injectable `get_json` → `scripts/test_mine_aggregators.py` (7 tests) runs without network.

Also adds a **traffit** pattern+validator to `ats_boards.py` (board = tenant subdomain, so the apply link exposes it). eRecruiter is deliberately excluded: its apply link carries a per-form `WebID`, not the `cfg` board token our adapter needs.

## Result

Empirically, ~73% of justjoin apply-URLs point at traffit. Mining 1500 postings surfaced **30 new live traffit boards** (Antal — 826 jobs, SCALO, RITS, XTB, Billennium, Transition Technologies MS, …) plus **Tidio** (recruitee) and **Base.** (workable). Each live-validated before adding.

## Test

- 25/25 across all three discovery scripts (`mine_aggregators`, `harvest_boards`, `discover_boards`).