### PR TITLE
feat(sources): add Crelate staffing ATS adapter

### DIFF
--- a/internal/sources/crelate.go
+++ b/internal/sources/crelate.go
@@ -1,0 +1,131 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// crelate adapts Crelate candidate portals through their keyless public API. Crelate is a
+// recruiting/staffing ATS; a portal at jobs.crelate.com/portal/<slug> commonly fronts a network of
+// client companies, so this is an aggregator — each posting's employer comes from its CompanyName.
+//
+// The board is "<portalSlug>:<organizationId>": the OrganizationId GUID (public, embedded in the
+// portal page) keys the API, and the portal slug builds each posting's human job URL. One
+// GetAllJobs call returns every published posting fully populated (structured location,
+// LastPostedOnDate, an HTML/plain description), so no per-posting detail fetch or pagination is
+// needed.
+//
+// Note: the ever-jobs recipe (app.crelate.com/api3/jobs with X-Api-Key=slug) is outdated and 401s;
+// the working endpoint is this candidateportal GetAllJobs call, keyed only by the OrganizationId.
+type crelate struct {
+	http JSONGetter
+}
+
+// NewCrelate builds the Crelate adapter over the given HTTP client.
+func NewCrelate(c JSONGetter) Source { return crelate{http: c} }
+
+func (crelate) Provider() string { return "crelate" }
+
+// aggregator: a Crelate portal lists many client companies, so it stays in the source facet and
+// each job's company comes from the posting, not the board.
+func (crelate) aggregator() {}
+
+// crelateResponse is the GetAllJobs envelope.
+type crelateResponse struct {
+	Jobs         []crelateJob `json:"Jobs"`
+	IsError      bool         `json:"IsError"`
+	ErrorMessage string       `json:"ErrorMessage"`
+}
+
+type crelateJob struct {
+	ID               string `json:"Id"`
+	Title            string `json:"Title"`
+	CompanyName      string `json:"CompanyName"`
+	Description      string `json:"Description"`
+	City             string `json:"City"`
+	State            string `json:"State"`
+	Country          string `json:"Country"`
+	URL              string `json:"Url"`
+	JobCode          string `json:"JobCode"`
+	LastPostedOnDate string `json:"LastPostedOnDate"`
+}
+
+func (s crelate) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	colon := strings.Index(e.Board, ":")
+	if colon < 0 {
+		return nil, fmt.Errorf("crelate: board %q must be %q", e.Board, "<portalSlug>:<organizationId>")
+	}
+	slug, org := e.Board[:colon], e.Board[colon+1:]
+	if slug == "" || org == "" {
+		return nil, fmt.Errorf("crelate: board %q must be %q with both parts set", e.Board, "<portalSlug>:<organizationId>")
+	}
+
+	envelope := fmt.Sprintf(`{"Locations":null,"OrganizationId":%q,"SearchText":null,"Tags":null}`, org)
+	q := url.Values{}
+	q.Set("requestEnvelope", envelope)
+	reqURL := "https://jobs.crelate.com/api/candidateportal/GetAllJobs?" + q.Encode()
+
+	var resp crelateResponse
+	if err := s.http.GetJSON(ctx, reqURL, &resp); err != nil {
+		return nil, fmt.Errorf("crelate: board %s: %w", e.Board, err)
+	}
+	if resp.IsError {
+		return nil, fmt.Errorf("crelate: board %s: portal error: %s", e.Board, resp.ErrorMessage)
+	}
+
+	jobs := make([]Job, 0, len(resp.Jobs))
+	for _, j := range resp.Jobs {
+		if job, ok := toCrelateJob(j, slug, e); ok {
+			jobs = append(jobs, job)
+		}
+	}
+	return jobs, nil
+}
+
+// toCrelateJob maps a posting to a Job, returning ok=false for a posting missing an id (which
+// would collide on the dedup key). The employer is the posting's CompanyName, falling back to the
+// configured company.
+func toCrelateJob(j crelateJob, slug string, e CompanyEntry) (Job, bool) {
+	if strings.TrimSpace(j.ID) == "" {
+		return Job{}, false
+	}
+	company := strings.TrimSpace(j.CompanyName)
+	if company == "" {
+		company = e.Company
+	}
+	return Job{
+		ExternalID:  j.ID,
+		URL:         crelateJobURL(slug, j),
+		Title:       j.Title,
+		Company:     company,
+		Location:    crelateLocation(j),
+		Description: sanitizeHTML(j.Description),
+		PostedAt:    parseRFC3339(j.LastPostedOnDate),
+	}, true
+}
+
+// crelateJobURL builds the human portal job page from the slug and job code (the API's Url is a
+// relative "/<JobCode>").
+func crelateJobURL(slug string, j crelateJob) string {
+	code := j.JobCode
+	if code == "" {
+		code = strings.TrimPrefix(j.URL, "/")
+	}
+	return fmt.Sprintf("https://jobs.crelate.com/portal/%s/job/%s", slug, code)
+}
+
+// crelateLocation renders "City, State", falling back to the country.
+func crelateLocation(j crelateJob) string {
+	var parts []string
+	for _, p := range []string{j.City, j.State} {
+		if p = strings.TrimSpace(p); p != "" {
+			parts = append(parts, p)
+		}
+	}
+	if len(parts) > 0 {
+		return strings.Join(parts, ", ")
+	}
+	return strings.TrimSpace(j.Country)
+}

--- a/internal/sources/crelate_test.go
+++ b/internal/sources/crelate_test.go
@@ -1,0 +1,135 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// crelateFeedJSON mirrors a candidateportal GetAllJobs response: a Jobs array plus the
+// IsError/ErrorMessage envelope. Fields match the live Career Tree Network portal — a per-posting
+// CompanyName (aggregator), structured City/State/Country, a relative Url job code, and an
+// RFC3339 LastPostedOnDate with fractional seconds.
+const crelateFeedJSON = `{
+  "Jobs": [
+    {
+      "Id": "2ab5a6fa-8b64-414a-9cd0-d6de0804d599",
+      "Title": "Physical Therapist Assistant",
+      "CompanyName": "Career Tree Network (Discovery At Home)",
+      "Description": "<p>Home Health role.</p><script>alert(1)</script>",
+      "City": "Tampa",
+      "State": "FL",
+      "Country": "United States",
+      "Url": "/mw9k5zg5f4m8hfigm4p8hnzz6w",
+      "JobCode": "mw9k5zg5f4m8hfigm4p8hnzz6w",
+      "LastPostedOnDate": "2026-07-17T17:17:12.81Z"
+    },
+    {
+      "Id": "no-company-1",
+      "Title": "Recruiter",
+      "Description": "<p>Join us.</p>",
+      "Country": "United States",
+      "JobCode": "abc123",
+      "LastPostedOnDate": "2026-07-01T00:00:00Z"
+    }
+  ],
+  "IsError": false,
+  "ErrorMessage": null
+}`
+
+func newCrelateFake() *routedHTTP {
+	return (&routedHTTP{}).route("candidateportal/GetAllJobs", crelateFeedJSON)
+}
+
+const crelateBoard = "careertree:ec546cba-84d5-4d8a-97e5-52e8ef47db08"
+
+func TestCrelateProvider(t *testing.T) {
+	if got := NewCrelate(nil).Provider(); got != "crelate" {
+		t.Errorf("Provider() = %q, want %q", got, "crelate")
+	}
+}
+
+func TestCrelateIsAggregator(t *testing.T) {
+	if _, ok := NewCrelate(nil).(aggregator); !ok {
+		t.Error("NewCrelate should implement aggregator (a portal fronts many client companies)")
+	}
+}
+
+func TestCrelateFetchMapsJobs(t *testing.T) {
+	jobs, err := NewCrelate(newCrelateFake()).Fetch(context.Background(), CompanyEntry{
+		Company: "Career Tree Network", Provider: "crelate", Board: crelateBoard,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+
+	a := jobs[0]
+	if a.ExternalID != "2ab5a6fa-8b64-414a-9cd0-d6de0804d599" {
+		t.Errorf("ExternalID = %q", a.ExternalID)
+	}
+	if a.Title != "Physical Therapist Assistant" {
+		t.Errorf("Title = %q", a.Title)
+	}
+	if a.Company != "Career Tree Network (Discovery At Home)" {
+		t.Errorf("Company = %q, want per-posting CompanyName (aggregator)", a.Company)
+	}
+	wantURL := "https://jobs.crelate.com/portal/careertree/job/mw9k5zg5f4m8hfigm4p8hnzz6w"
+	if a.URL != wantURL {
+		t.Errorf("URL = %q, want %q", a.URL, wantURL)
+	}
+	if a.Location != "Tampa, FL" {
+		t.Errorf("Location = %q, want \"Tampa, FL\"", a.Location)
+	}
+	if strings.Contains(a.Description, "<script>") {
+		t.Errorf("Description not sanitized: %q", a.Description)
+	}
+	if a.PostedAt == nil || !a.PostedAt.Equal(time.Date(2026, 7, 17, 17, 17, 12, 810000000, time.UTC)) {
+		t.Errorf("PostedAt = %v, want 2026-07-17T17:17:12.81Z", a.PostedAt)
+	}
+}
+
+func TestCrelateCompanyFallsBackToConfig(t *testing.T) {
+	jobs, err := NewCrelate(newCrelateFake()).Fetch(context.Background(), CompanyEntry{
+		Company: "Career Tree Network", Board: crelateBoard,
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if jobs[1].Company != "Career Tree Network" {
+		t.Errorf("Company = %q, want config fallback when posting omits CompanyName", jobs[1].Company)
+	}
+	// The second posting has no City/State — Country is the location fallback.
+	if jobs[1].Location != "United States" {
+		t.Errorf("Location = %q, want country fallback", jobs[1].Location)
+	}
+}
+
+func TestCrelateDropsJobWithNoID(t *testing.T) {
+	fake := (&routedHTTP{}).route("GetAllJobs", `{"Jobs":[{"Title":"No ID"}],"IsError":false}`)
+	jobs, err := NewCrelate(fake).Fetch(context.Background(), CompanyEntry{Company: "C", Board: crelateBoard})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("got %d jobs, want 0 (no-id dropped)", len(jobs))
+	}
+}
+
+func TestCrelateIsErrorFails(t *testing.T) {
+	fake := (&routedHTTP{}).route("GetAllJobs", `{"Jobs":[],"IsError":true,"ErrorMessage":"bad org"}`)
+	if _, err := NewCrelate(fake).Fetch(context.Background(), CompanyEntry{Board: crelateBoard}); err == nil {
+		t.Fatal("expected error when IsError is true")
+	}
+}
+
+func TestCrelateBoardMustBeSlugColonOrg(t *testing.T) {
+	for _, board := range []string{"", "nocolon", ":org", "slug:"} {
+		if _, err := NewCrelate(&routedHTTP{}).Fetch(context.Background(), CompanyEntry{Board: board}); err == nil {
+			t.Errorf("board %q: expected error, got nil", board)
+		}
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -265,6 +265,7 @@ func All(c HTTPClient) map[string]Source {
 		NewBullhorn(c),
 		NewManatal(c),
 		NewJobscore(c),
+		NewCrelate(c),
 		// Ashby boards whose public Posting API is disabled, served via the embed GraphQL.
 		NewAshbyGraphQL(c),
 		// Multi-company aggregators (boardless): one global feed, company per posting.

--- a/openspec/changes/add-crelate-source/.openspec.yaml
+++ b/openspec/changes/add-crelate-source/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-crelate-source/design.md
+++ b/openspec/changes/add-crelate-source/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Crelate hosts each customer's public careers page as a candidate portal at
+`jobs.crelate.com/portal/<slug>`. The portal SPA reads jobs from a keyless JSON API keyed by an
+`OrganizationId` GUID that is embedded in the portal page. One request returns every published
+posting, fully populated, so no per-posting detail fetch or pagination is needed.
+
+The ever-jobs recipe (`app.crelate.com/api3/jobs` with header `X-Api-Key: <slug>`) is outdated —
+it returns 401 against live portals. The real, validated endpoint is the candidate-portal
+`GetAllJobs` call. This was confirmed live against the Career Tree Network portal
+(slug `careertree`, OrganizationId `ec546cba-84d5-4d8a-97e5-52e8ef47db08`, 154 jobs).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A keyless `crelate` adapter that crawls one portal's published jobs in a single request.
+- Map the structured fields the feed provides (location, posted date, per-job employer, human job URL).
+- Fit the existing `Source` interface and board-file conventions; no new infrastructure.
+
+**Non-Goals:**
+- No salary ingestion (the `Job` contract has no salary field; enrichment derives it).
+- No work-mode facet — the feed exposes no structured remote flag; the pipeline's location/text
+  dictionaries decide.
+- No bulk board discovery in this change beyond seeding one validated board.
+
+## Decisions
+
+- **Endpoint (keyless):** `GET https://jobs.crelate.com/api/candidateportal/GetAllJobs` with a
+  URL-encoded `requestEnvelope` query param `{"Locations":null,"OrganizationId":"<GUID>","SearchText":null,"Tags":null}`.
+  Response: `{"Jobs":[...],"IsError":bool,"ErrorMessage":string}`. Treat `IsError:true` as a
+  board-level failure. All jobs return in one call — no pagination.
+
+- **Board format `<portalSlug>:<organizationId>`.** The GUID keys the API; the slug is needed to
+  build the human job URL (the API's `Url` is a relative `/<JobCode>`). Split on the first colon;
+  both parts required. Mirrors Bullhorn's `<cls>:<corpToken>` two-part board.
+
+- **Aggregator.** A Crelate portal often fronts a staffing network of client companies (the
+  per-posting `CompanyName` varies, e.g. "Career Tree Network (Discovery At Home)"). Mark the
+  adapter `aggregator()` and set each `Job.Company` from `CompanyName`, falling back to config.
+
+- **Field mapping (per job):**
+  - `Id` (GUID) → `ExternalID` (drop postings with empty Id — dedup-key collision).
+  - `Title` → `Title`.
+  - Human URL → `https://jobs.crelate.com/portal/<slug>/job/<JobCode>` (JobCode = `Url` without
+    the leading slash; falls back to the `JobCode` field).
+  - `City`/`State`/`Country` → `Location` ("City, State", country fallback).
+  - `LastPostedOnDate` (RFC3339, fractional seconds + Z) → `PostedAt` via `parseRFC3339`.
+  - `Description` → `sanitizeHTML` (portals may emit HTML or plain text; sanitize is safe for both).
+  - `CompanyName` → `Company` (fallback config).
+  - `Compensation`, `Tags`, `SEO`, `SocialUrls` → dropped (no matching structured Job field).
+
+## Risks / Trade-offs
+
+- **OrganizationId discovery is manual** — the GUID is scraped from the portal page, not
+  guessable. Acceptable: board files are curated; this change seeds one validated board and
+  documents where the GUID lives for future additions.
+- **No work-mode / seniority structured signal** — unlike JobScore, Crelate's feed omits these, so
+  those facets rely entirely on the dictionaries. Accepted; the location and posted-date signal is
+  still structured and reliable.
+- **Two-part board is easy to misconfigure** — mitigated by validating both parts are non-empty
+  and failing the board (not the run) with a clear error.

--- a/openspec/changes/add-crelate-source/proposal.md
+++ b/openspec/changes/add-crelate-source/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Crelate is a recruiting/staffing ATS whose candidate portals expose a keyless public API, yet it is not among freehire's source adapters. Adding it opens a family of staffing-agency boards (Crelate powers many recruiting networks) at zero credential cost, extending catalogue coverage of the ever-jobs ATS list.
+
+## What Changes
+
+- Add a new `crelate` source adapter over the keyless Crelate candidate-portal API (`jobs.crelate.com/api/candidateportal/GetAllJobs`), returning all of a portal's published jobs in one call.
+- Register `crelate` in `sources.All` and add a `sources/crelate.yml` board file seeded with one live, validated board (Career Tree Network).
+- The board is `<portalSlug>:<organizationId>`: the OrganizationId GUID keys the API; the portal slug builds the human job URL.
+- Mark the adapter `aggregator()` — a Crelate portal commonly lists many client companies (the per-posting `CompanyName` is the employer), so the adapter takes each job's company from the posting.
+
+## Capabilities
+
+### New Capabilities
+- `crelate-source`: crawl a Crelate candidate portal's published jobs through its keyless public API and normalize them into the catalogue, resolving each posting's employer from the feed.
+
+### Modified Capabilities
+<!-- None: this adds an isolated adapter behind the existing Source interface; no existing requirement changes. -->
+
+## Impact
+
+- New files: `internal/sources/crelate.go`, `internal/sources/crelate_test.go`, `sources/crelate.yml`.
+- One-line registration in `internal/sources/source.go` (`sources.All`).
+- No schema, migration, or API changes. A new hourly ingest timer (`freehire-ingest@crelate`) is installed on prod at deploy, per the standard per-board-file ingest convention.

--- a/openspec/changes/add-crelate-source/specs/crelate-source/spec.md
+++ b/openspec/changes/add-crelate-source/specs/crelate-source/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Keyless Crelate portal crawl
+
+The system SHALL crawl a Crelate candidate portal's published jobs through its keyless public API,
+returning all postings for one configured board in a single request. The adapter SHALL be
+registered under provider key `crelate` in the source registry.
+
+#### Scenario: Fetch returns all published jobs
+
+- **WHEN** the adapter fetches a board whose OrganizationId keys a portal with published jobs
+- **THEN** it issues one `GET jobs.crelate.com/api/candidateportal/GetAllJobs` request whose
+  `requestEnvelope` carries that OrganizationId, and returns one `Job` per posting in the
+  response's `Jobs` array
+
+#### Scenario: Portal-level error is surfaced
+
+- **WHEN** the API responds with `IsError: true`
+- **THEN** the adapter returns an error for that board (it does not return a partial or empty
+  success)
+
+### Requirement: Two-part board identifier
+
+The board SHALL be `<portalSlug>:<organizationId>`: the OrganizationId GUID keys the API and the
+portal slug builds each posting's human job URL. Both parts are required.
+
+#### Scenario: Well-formed board is accepted
+
+- **WHEN** a board is `careertree:ec546cba-84d5-4d8a-97e5-52e8ef47db08`
+- **THEN** the adapter queries the API with the OrganizationId and builds job URLs under
+  `jobs.crelate.com/portal/careertree/`
+
+#### Scenario: Malformed board is rejected
+
+- **WHEN** a board is missing the colon, the slug, or the OrganizationId
+- **THEN** the adapter returns an error identifying the expected `<portalSlug>:<organizationId>`
+  form, and does not issue a request
+
+### Requirement: Aggregator employer resolution
+
+Because a Crelate portal commonly fronts many client companies, the adapter SHALL be marked as an
+aggregator and SHALL set each job's company from the posting's `CompanyName`, falling back to the
+configured company when the posting omits it.
+
+#### Scenario: Employer taken from the posting
+
+- **WHEN** a posting carries `CompanyName` "Career Tree Network (Discovery At Home)"
+- **THEN** the resulting `Job.Company` is that value, not the board's configured company name
+
+### Requirement: Posting normalization
+
+The adapter SHALL map each posting onto the catalogue's `Job` shape: `Id` to the external id,
+`Title`, a human job URL from the portal slug and job code, structured `City`/`State`/`Country` to
+the location, `LastPostedOnDate` to the posted date, and the sanitized `Description`. A posting with
+an empty `Id` SHALL be dropped so it cannot collide on the dedup key.
+
+#### Scenario: Structured fields are mapped
+
+- **WHEN** a posting has an `Id`, a `City`/`State`, a `LastPostedOnDate` timestamp, and a `Description`
+- **THEN** the `Job` carries that id, a "City, State" location, a parsed posted-at time, a URL under
+  the portal, and the sanitized description
+
+#### Scenario: Posting without an id is skipped
+
+- **WHEN** a posting has an empty `Id`
+- **THEN** it produces no `Job`

--- a/openspec/changes/add-crelate-source/tasks.md
+++ b/openspec/changes/add-crelate-source/tasks.md
@@ -1,0 +1,15 @@
+## 1. Adapter
+
+- [x] 1.1 Add `crelate.go`: provider key `crelate`, `<portalSlug>:<organizationId>` board parsing (both parts required, else a clear board-level error), the `GetAllJobs` request with the URL-encoded `requestEnvelope`, and the `{Jobs, IsError, ErrorMessage}` response struct (treat `IsError:true` as a board failure). Cover board validation and the IsError path with a fake HTTP client.
+- [x] 1.2 Map a posting onto `Job`: `Id`→`ExternalID` (drop empty-id postings), `Title`, human URL `jobs.crelate.com/portal/<slug>/job/<JobCode>`, `City`/`State`/`Country`→`Location`, `LastPostedOnDate`→`PostedAt`, sanitized `Description`. Cover the mapping and the empty-id drop with tests.
+- [x] 1.3 Mark the adapter `aggregator()` and resolve each `Job.Company` from the posting's `CompanyName`, falling back to the configured company. Cover both paths with tests.
+
+## 2. Wiring
+
+- [x] 2.1 Register `NewCrelate` in `sources.All`.
+- [x] 2.2 Add `sources/crelate.yml` seeded with the Career Tree Network board (`careertree:ec546cba-84d5-4d8a-97e5-52e8ef47db08`) and a header documenting the board format and where the OrganizationId GUID lives; confirm the file validates against the registry.
+
+## 3. Verify & ship
+
+- [x] 3.1 Validate end-to-end against the live portal through the real adapter: fetch the seeded board and confirm postings, location coverage, and posted dates.
+- [ ] 3.2 Ship: open a PR, merge to main after CI is green, deploy on host-2 (`release.sh`), install and enable the `freehire-ingest@crelate` hourly timer, run one ingest, and confirm the jobs land in the prod database.

--- a/sources/crelate.yml
+++ b/sources/crelate.yml
@@ -1,0 +1,9 @@
+# Crelate — a recruiting/staffing ATS. Each board is a Crelate candidate portal, and a portal
+# commonly fronts a network of client companies (aggregator: each job's employer is its own
+# CompanyName). The board is "<portalSlug>:<organizationId>": the OrganizationId GUID keys the
+# keyless candidate-portal API, and the portal slug builds the human job URL. Find both on the
+# live portal at jobs.crelate.com/portal/<slug> — the OrganizationId GUID is embedded in the page
+# (it is the value the portal's GetAllJobs XHR sends). Keyless; one call returns every job.
+- company: Career Tree Network
+  provider: crelate
+  board: careertree:ec546cba-84d5-4d8a-97e5-52e8ef47db08


### PR DESCRIPTION
## What

Adds a keyless **Crelate** source adapter — a recruiting/staffing ATS from the ever-jobs catalogue. Planned via OpenSpec (`openspec/changes/add-crelate-source`) under the spec-driven-tdd workflow.

## How it works

- **Keyless candidate-portal API.** `board` is `<portalSlug>:<organizationId>`: the OrganizationId GUID keys the API, the portal slug builds the human job URL. One `GET jobs.crelate.com/api/candidateportal/GetAllJobs?requestEnvelope={…OrganizationId…}` returns every published posting — no pagination, no per-posting detail.
- **Aggregator.** A Crelate portal fronts a network of client companies (the seeded Career Tree Network board lists **154 jobs across 56 employers**), so the adapter is marked `aggregator()` and takes each job's company from the posting's `CompanyName`, falling back to config.
- **Mapping:** `Id`→external id (empty-id dropped), `Title`, human URL from slug+`JobCode`, structured `City`/`State`/`Country`→location, `LastPostedOnDate`→posted_at, sanitized `Description`. `IsError:true` fails the board. Salary/tags dropped (no matching `Job` field).

## Recipe note

The ever-jobs recipe (`app.crelate.com/api3/jobs` + `X-Api-Key: <slug>`) is outdated and 401s against live portals. The real recipe (the candidate-portal `GetAllJobs` endpoint) was discovered by capturing the portal's XHR and validated live against Career Tree Network (OrganizationId `ec546cba-…`, 154 jobs).

## Tests

`go build`, `go vet`, `gofmt` clean; 7 unit tests cover feed mapping, the aggregator company resolution + config fallback, empty-id drop, `IsError` handling, and board-format validation. Validated end-to-end against the live portal (154 jobs, location + posted-date 100%).