### PR TITLE
feat(credits): reward AI credits for accepted board contributions

### DIFF
--- a/internal/config/credits.go
+++ b/internal/config/credits.go
@@ -5,9 +5,10 @@ package config
 // are env-overridable so the free-tier economics can be tuned without a deploy, and
 // so a future paid tier can widen the grant. See the add-ai-credits change.
 type Credits struct {
-	MonthlyGrant int // points granted per calendar month (use-it-or-lose-it)
-	CostMatch    int // points debited per fresh résumé fit analysis
-	CostTailor   int // points debited per new tailored CV
+	MonthlyGrant       int // points granted per calendar month (use-it-or-lose-it)
+	CostMatch          int // points debited per fresh résumé fit analysis
+	CostTailor         int // points debited per new tailored CV
+	ContributionReward int // points earned per accepted board contribution (banks, no expiry)
 }
 
 // LoadCredits reads the credits tunables from the environment, falling back to the
@@ -15,9 +16,10 @@ type Credits struct {
 // every action, and a non-positive cost would append meaningless zero-delta debits.
 func LoadCredits() Credits {
 	c := Credits{
-		MonthlyGrant: envInt("CREDITS_MONTHLY_GRANT", 20),
-		CostMatch:    envInt("CREDITS_COST_MATCH", 1),
-		CostTailor:   envInt("CREDITS_COST_TAILOR", 3),
+		MonthlyGrant:       envInt("CREDITS_MONTHLY_GRANT", 20),
+		CostMatch:          envInt("CREDITS_COST_MATCH", 1),
+		CostTailor:         envInt("CREDITS_COST_TAILOR", 3),
+		ContributionReward: envInt("CREDITS_CONTRIBUTION_REWARD", 5),
 	}
 	if c.MonthlyGrant < 0 {
 		c.MonthlyGrant = 0
@@ -27,6 +29,9 @@ func LoadCredits() Credits {
 	}
 	if c.CostTailor < 1 {
 		c.CostTailor = 1
+	}
+	if c.ContributionReward < 0 {
+		c.ContributionReward = 0
 	}
 	return c
 }

--- a/internal/config/credits_test.go
+++ b/internal/config/credits_test.go
@@ -17,15 +17,19 @@ func TestLoadCredits_defaults(t *testing.T) {
 	if got.CostTailor != 3 {
 		t.Errorf("CostTailor default = %d, want 3", got.CostTailor)
 	}
+	if got.ContributionReward != 5 {
+		t.Errorf("ContributionReward default = %d, want 5", got.ContributionReward)
+	}
 }
 
 func TestLoadCredits_overrides(t *testing.T) {
 	t.Setenv("CREDITS_MONTHLY_GRANT", "50")
 	t.Setenv("CREDITS_COST_MATCH", "2")
 	t.Setenv("CREDITS_COST_TAILOR", "5")
+	t.Setenv("CREDITS_CONTRIBUTION_REWARD", "10")
 
 	got := LoadCredits()
-	if got.MonthlyGrant != 50 || got.CostMatch != 2 || got.CostTailor != 5 {
+	if got.MonthlyGrant != 50 || got.CostMatch != 2 || got.CostTailor != 5 || got.ContributionReward != 10 {
 		t.Errorf("overrides not applied: %+v", got)
 	}
 }
@@ -37,6 +41,7 @@ func TestLoadCredits_clampsInvalid(t *testing.T) {
 	t.Setenv("CREDITS_MONTHLY_GRANT", "-5")
 	t.Setenv("CREDITS_COST_MATCH", "0")
 	t.Setenv("CREDITS_COST_TAILOR", "-2")
+	t.Setenv("CREDITS_CONTRIBUTION_REWARD", "-9")
 
 	got := LoadCredits()
 	if got.MonthlyGrant != 0 {
@@ -47,5 +52,8 @@ func TestLoadCredits_clampsInvalid(t *testing.T) {
 	}
 	if got.CostTailor != 1 {
 		t.Errorf("CostTailor clamp = %d, want 1", got.CostTailor)
+	}
+	if got.ContributionReward != 0 {
+		t.Errorf("ContributionReward clamp = %d, want 0", got.ContributionReward)
 	}
 }

--- a/internal/credits/credits.go
+++ b/internal/credits/credits.go
@@ -30,11 +30,13 @@ const (
 	FeatureTailor Feature = "tailor"
 )
 
-// Config carries the points economics: the monthly grant and per-action costs.
+// Config carries the points economics: the monthly grant, per-action costs, and the
+// reward granted for an accepted board contribution.
 type Config struct {
-	MonthlyGrant int
-	CostMatch    int
-	CostTailor   int
+	MonthlyGrant       int
+	CostMatch          int
+	CostTailor         int
+	ContributionReward int
 }
 
 // cost returns the points a given feature debits.
@@ -68,6 +70,20 @@ func NewStore(q *db.Queries, pool *pgxpool.Pool, cfg Config) *Store {
 // Cost returns the points a feature debits, so callers can pre-check a balance.
 func (s *Store) Cost(f Feature) int { return s.cfg.cost(f) }
 
+// applicableRemaining resolves the balance to work from given the stored row's period.
+// Same period: the stored remaining. A rolled-over period: floor at the monthly grant but
+// preserve any banked surplus above it — the monthly grant never lifts a balance above
+// MonthlyGrant, so anything higher is earned (reward) or bought and must not expire.
+func (s *Store) applicableRemaining(period, cur string, remaining int32) int32 {
+	if period == cur {
+		return remaining
+	}
+	if grant := int32(s.cfg.MonthlyGrant); remaining < grant {
+		return grant
+	}
+	return remaining
+}
+
 // Balance returns the caller's current points without consuming any. A user with no
 // stored row, or whose stored balance is from an earlier period, is reported at the
 // full monthly grant (the lazy reset applied in-memory for display); the persisted
@@ -78,9 +94,7 @@ func (s *Store) Balance(ctx context.Context, userID int64) (Balance, error) {
 	row, err := s.q.GetBalance(ctx, userID)
 	switch {
 	case err == nil:
-		if row.Period == periodKey(now) {
-			remaining = int(row.Remaining)
-		}
+		remaining = int(s.applicableRemaining(row.Period, periodKey(now), row.Remaining))
 	case errors.Is(err, pgx.ErrNoRows):
 		// fresh user — full grant remaining
 	default:
@@ -120,10 +134,8 @@ func (s *Store) Debit(ctx context.Context, userID int64, feature Feature, ref st
 		return Balance{}, err
 	}
 
-	remaining := row.Remaining
-	if row.Period != cur {
-		remaining = grant // period rolled over: reset, discarding unused prior-period points
-	}
+	// Period rolled over: floor at the grant but keep any banked surplus (rewards/purchases).
+	remaining := s.applicableRemaining(row.Period, cur, row.Remaining)
 
 	already, err := q.DebitExists(ctx, db.DebitExistsParams{UserID: userID, Feature: string(feature), Ref: ref})
 	if err != nil {
@@ -153,6 +165,57 @@ func (s *Store) Debit(ctx context.Context, userID int64, feature Feature, ref st
 		return Balance{}, err
 	}
 	return Balance{Remaining: int(remaining), ResetsAt: resetsAt(now)}, debitErr
+}
+
+// Reward credits the configured contribution reward to a user, atomically and idempotently
+// by ref (e.g. the accepted contribution id). The reward banks above the monthly grant and
+// survives the period reset (applicableRemaining preserves any surplus). A non-positive
+// configured reward is a no-op that just reports the current balance.
+func (s *Store) Reward(ctx context.Context, userID int64, ref string) (Balance, error) {
+	if s.cfg.ContributionReward <= 0 {
+		return s.Balance(ctx, userID)
+	}
+	now := time.Now().UTC()
+	cur := periodKey(now)
+	grant := int32(s.cfg.MonthlyGrant)
+	amount := int32(s.cfg.ContributionReward)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return Balance{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	q := s.q.WithTx(tx)
+
+	if err := q.EnsureBalance(ctx, db.EnsureBalanceParams{UserID: userID, Period: cur, Remaining: grant}); err != nil {
+		return Balance{}, err
+	}
+	row, err := q.GetBalanceForUpdate(ctx, userID)
+	if err != nil {
+		return Balance{}, err
+	}
+	if err := q.InsertGrant(ctx, db.InsertGrantParams{UserID: userID, Period: cur, Delta: grant}); err != nil {
+		return Balance{}, err
+	}
+	remaining := s.applicableRemaining(row.Period, cur, row.Remaining)
+
+	already, err := q.RewardExists(ctx, db.RewardExistsParams{UserID: userID, Ref: ref})
+	if err != nil {
+		return Balance{}, err
+	}
+	if !already {
+		remaining += amount
+		if err := q.InsertReward(ctx, db.InsertRewardParams{UserID: userID, Period: cur, Delta: amount, Ref: ref}); err != nil {
+			return Balance{}, err
+		}
+	}
+	if err := q.UpdateBalance(ctx, db.UpdateBalanceParams{UserID: userID, Period: cur, Remaining: remaining}); err != nil {
+		return Balance{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Balance{}, err
+	}
+	return Balance{Remaining: int(remaining), ResetsAt: resetsAt(now)}, nil
 }
 
 // periodKey is the calendar-month key (UTC) a grant and its debits share.

--- a/internal/credits/store_integration_test.go
+++ b/internal/credits/store_integration_test.go
@@ -203,6 +203,80 @@ func TestDebit_lazyResetThenDebit(t *testing.T) {
 	}
 }
 
+func TestReward_addsAndIsIdempotent(t *testing.T) {
+	pool := startPostgres(t)
+	s := newStore(pool, Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3, ContributionReward: 5})
+	uid := insertUser(t, pool, "reward@example.test")
+	ctx := context.Background()
+
+	bal, err := s.Reward(ctx, uid, "contrib-1")
+	if err != nil {
+		t.Fatalf("Reward: %v", err)
+	}
+	if bal.Remaining != 25 { // 20 grant + 5 reward
+		t.Errorf("Remaining after reward = %d, want 25", bal.Remaining)
+	}
+	// Same contribution again → no double reward.
+	bal, err = s.Reward(ctx, uid, "contrib-1")
+	if err != nil {
+		t.Fatalf("second Reward: %v", err)
+	}
+	if bal.Remaining != 25 {
+		t.Errorf("Remaining after repeat reward = %d, want 25 (idempotent)", bal.Remaining)
+	}
+	// A distinct contribution stacks.
+	bal, _ = s.Reward(ctx, uid, "contrib-2")
+	if bal.Remaining != 30 {
+		t.Errorf("Remaining after second distinct reward = %d, want 30", bal.Remaining)
+	}
+}
+
+func TestReward_banksAboveGrantAcrossPeriod(t *testing.T) {
+	pool := startPostgres(t)
+	s := newStore(pool, Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3, ContributionReward: 5})
+	uid := insertUser(t, pool, "bank@example.test")
+	ctx := context.Background()
+
+	// Earn a reward this... actually seed a prior period with a banked surplus (grant 20 +
+	// 5 reward, unspent) and roll over: the surplus above the grant must survive.
+	seedBalance(t, pool, uid, "2000-01", 25)
+	bal, err := s.Balance(ctx, uid)
+	if err != nil {
+		t.Fatalf("Balance: %v", err)
+	}
+	if bal.Remaining != 25 {
+		t.Errorf("rolled-over Remaining = %d, want 25 (banked surplus survives)", bal.Remaining)
+	}
+	// A debit in the new period works off the banked balance and persists the reset.
+	bal, err = s.Debit(ctx, uid, FeatureMatch, "job-1")
+	if err != nil {
+		t.Fatalf("Debit: %v", err)
+	}
+	if bal.Remaining != 24 {
+		t.Errorf("Remaining after reset+debit = %d, want 24 (25 banked - 1)", bal.Remaining)
+	}
+}
+
+func TestReward_zeroConfigIsNoOp(t *testing.T) {
+	pool := startPostgres(t)
+	s := newStore(pool, Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3, ContributionReward: 0})
+	uid := insertUser(t, pool, "noreward@example.test")
+
+	bal, err := s.Reward(context.Background(), uid, "contrib-1")
+	if err != nil {
+		t.Fatalf("Reward: %v", err)
+	}
+	if bal.Remaining != 20 {
+		t.Errorf("Remaining with zero reward = %d, want 20 (no-op)", bal.Remaining)
+	}
+	var rewards int
+	_ = pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM credit_ledger WHERE user_id=$1 AND kind='reward'`, uid).Scan(&rewards)
+	if rewards != 0 {
+		t.Errorf("reward rows with zero config = %d, want 0", rewards)
+	}
+}
+
 func TestDebit_concurrentNoOversell(t *testing.T) {
 	pool := startPostgres(t)
 	s := newStore(pool, Config{MonthlyGrant: 1, CostMatch: 1, CostTailor: 3})

--- a/internal/db/credits.sql.go
+++ b/internal/db/credits.sql.go
@@ -145,6 +145,53 @@ func (q *Queries) InsertGrant(ctx context.Context, arg InsertGrantParams) error 
 	return err
 }
 
+const insertReward = `-- name: InsertReward :exec
+INSERT INTO credit_ledger (user_id, period, kind, feature, delta, ref)
+VALUES ($1, $2, 'reward', NULL, $3, $4::text)
+`
+
+type InsertRewardParams struct {
+	UserID int64  `json:"user_id"`
+	Period string `json:"period"`
+	Delta  int32  `json:"delta"`
+	Ref    string `json:"ref"`
+}
+
+// Append a reward: points earned (e.g. for an accepted board contribution), delta positive,
+// feature NULL. Rewards bank above the monthly grant and survive the period reset.
+func (q *Queries) InsertReward(ctx context.Context, arg InsertRewardParams) error {
+	_, err := q.db.Exec(ctx, insertReward,
+		arg.UserID,
+		arg.Period,
+		arg.Delta,
+		arg.Ref,
+	)
+	return err
+}
+
+const rewardExists = `-- name: RewardExists :one
+SELECT EXISTS (
+    SELECT 1 FROM credit_ledger
+    WHERE user_id = $1
+      AND kind = 'reward'
+      AND ref = $2::text
+)
+`
+
+type RewardExistsParams struct {
+	UserID int64  `json:"user_id"`
+	Ref    string `json:"ref"`
+}
+
+// Whether the caller already received a reward for this ref (e.g. an accepted contribution).
+// True means the reward was already granted and must not be granted again (idempotency).
+func (q *Queries) RewardExists(ctx context.Context, arg RewardExistsParams) (bool, error) {
+	row := q.db.QueryRow(ctx, rewardExists, arg.UserID, arg.Ref)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const updateBalance = `-- name: UpdateBalance :exec
 UPDATE credit_balances
 SET period = $1, remaining = $2, updated_at = now()

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -500,6 +500,9 @@ type Querier interface {
 	// has a mailbox) or address (taken) — the allocation service handles both: it
 	// reads-back on a user conflict and retries the next suffix on an address conflict.
 	InsertMailbox(ctx context.Context, arg InsertMailboxParams) (Mailbox, error)
+	// Append a reward: points earned (e.g. for an accepted board contribution), delta positive,
+	// feature NULL. Rewards bank above the monthly grant and survive the period reset.
+	InsertReward(ctx context.Context, arg InsertRewardParams) error
 	// Crawl write path: store a fetched post once. ON CONFLICT DO NOTHING makes
 	// re-crawling idempotent — a stored post (pending, done, or dead-lettered) is
 	// never reset. extracted_at is non-NULL when the ingest prefilter already
@@ -924,6 +927,9 @@ type Querier interface {
 	// Undo a soft-delete, scoped to the caller and idempotent. Returns 0 rows only
 	// when it is not the caller's message (→ 404).
 	RestoreEmail(ctx context.Context, arg RestoreEmailParams) (int64, error)
+	// Whether the caller already received a reward for this ref (e.g. an accepted contribution).
+	// True means the reward was already granted and must not be granted again (idempotency).
+	RewardExists(ctx context.Context, arg RewardExistsParams) (bool, error)
 	// The job-reality repost/mass-posting counts for one role cluster: how many postings
 	// of the same role (by role_fingerprint within a company) exist of any status
 	// (repost_count = repost history) and how many are still open (mass_count = concurrent

--- a/internal/db/queries/credits.sql
+++ b/internal/db/queries/credits.sql
@@ -43,6 +43,22 @@ SELECT EXISTS (
 INSERT INTO credit_ledger (user_id, period, kind, feature, delta, ref)
 VALUES (sqlc.arg(user_id), sqlc.arg(period), 'debit', sqlc.arg(feature)::text, sqlc.arg(delta), sqlc.arg(ref)::text);
 
+-- name: RewardExists :one
+-- Whether the caller already received a reward for this ref (e.g. an accepted contribution).
+-- True means the reward was already granted and must not be granted again (idempotency).
+SELECT EXISTS (
+    SELECT 1 FROM credit_ledger
+    WHERE user_id = sqlc.arg(user_id)
+      AND kind = 'reward'
+      AND ref = sqlc.arg(ref)::text
+);
+
+-- name: InsertReward :exec
+-- Append a reward: points earned (e.g. for an accepted board contribution), delta positive,
+-- feature NULL. Rewards bank above the monthly grant and survive the period reset.
+INSERT INTO credit_ledger (user_id, period, kind, feature, delta, ref)
+VALUES (sqlc.arg(user_id), sqlc.arg(period), 'reward', NULL, sqlc.arg(delta), sqlc.arg(ref)::text);
+
 -- name: UpdateBalance :exec
 -- Persist the post-transaction balance: the current period and remaining points. Called at
 -- the end of the debit transaction to write back any lazy reset and/or decrement. The row is

--- a/internal/handler/contributions.go
+++ b/internal/handler/contributions.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"errors"
+	"log"
+	"strconv"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -80,6 +82,12 @@ func (a *API) CreateContribution(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusConflict).JSON(body)
 		}
 		return contributionError(err)
+	}
+	// Reward the contributor with AI credits, idempotent by the contribution id. Best-effort:
+	// the contribution is already recorded and its point awarded, so a reward error (or a
+	// zero configured reward) is logged, not surfaced.
+	if _, err := a.credits.Reward(c.Context(), userID, strconv.FormatInt(rec.ID, 10)); err != nil {
+		log.Printf("credits: contribution reward user=%d contribution=%d: %v", userID, rec.ID, err)
 	}
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"data": toContributionResponse(rec)})
 }

--- a/internal/handler/contributions_integration_test.go
+++ b/internal/handler/contributions_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/strelov1/freehire/internal/accounts"
 	"github.com/strelov1/freehire/internal/auth"
 	"github.com/strelov1/freehire/internal/contribution"
+	"github.com/strelov1/freehire/internal/credits"
 	"github.com/strelov1/freehire/internal/db"
 )
 
@@ -49,6 +50,7 @@ func TestContributionsEndToEnd(t *testing.T) {
 		issuer:       iss,
 		contribution: contribution.New(contribution.NewQueriesRepository(queries, pool), nil),
 		accounts:     accounts.New(accounts.NewQueriesRepository(queries, pool), authHasher{}),
+		credits:      credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3, ContributionReward: 5}),
 	}
 
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
@@ -124,6 +126,15 @@ func TestContributionsEndToEnd(t *testing.T) {
 		}
 		if me.Data.Points != 1 {
 			t.Errorf("points = %d, want 1", me.Data.Points)
+		}
+
+		// The novel contribution also rewarded AI credits: 20 monthly grant + 5 reward.
+		var remaining int
+		if err := pool.QueryRow(ctx, `SELECT remaining FROM credit_balances WHERE user_id = $1`, userID).Scan(&remaining); err != nil {
+			t.Fatalf("read credit balance: %v", err)
+		}
+		if remaining != 25 {
+			t.Errorf("credit balance after contribution = %d, want 25 (20 grant + 5 reward)", remaining)
 		}
 	})
 

--- a/migrations/0032_credit_reward_kind.sql
+++ b/migrations/0032_credit_reward_kind.sql
@@ -1,0 +1,13 @@
+-- Reward AI credits for accepted board contributions: widen the credit_ledger kind
+-- CHECK to admit 'reward' entries (a positive, non-expiring grant, feature NULL, keyed
+-- by the contribution id). Rewards bank above the monthly grant and carry over — the
+-- lazy period reset floors the balance at the grant but preserves any banked surplus.
+-- See the credits-contribution-reward change.
+--
+-- Applied to a fresh volume by initdb after 0031; on an existing prod volume run this
+-- manually (SET ROLE hire) BEFORE deploying code that inserts 'reward' rows.
+
+ALTER TABLE public.credit_ledger DROP CONSTRAINT credit_ledger_kind_check;
+
+ALTER TABLE public.credit_ledger
+    ADD CONSTRAINT credit_ledger_kind_check CHECK (kind IN ('grant', 'debit', 'purchase', 'reward'));


### PR DESCRIPTION
## What

Links the AI-credits balance (shipped in #914) to the **contribution flow**: an accepted board contribution now grants the user AI credits alongside the existing contribution point — a growth loop where contributing a board earns credits to spend on résumé match / CV tailoring.

## How

- **Migration** `0032_credit_reward_kind.sql`: widen `credit_ledger.kind` CHECK to admit `'reward'`.
- **`credits.Store.Reward(userID, ref)`** — atomic, idempotent-by-ref grant of the configured reward.
- **Banking semantics**: rewards bank **above** the monthly grant and survive the period reset. The lazy reset now floors the balance at the monthly grant but preserves any surplus above it (`applicableRemaining`). Since the monthly grant never lifts a balance above `MonthlyGrant`, anything higher is earned/bought and never expires — while the monthly grant stays use-it-or-lose-it.
- **Config**: `CREDITS_CONTRIBUTION_REWARD` (default **5**), clamped `>= 0`.
- **Handler**: `CreateContribution` rewards the contributor (best-effort, idempotent by contribution id) on the 201 path.

The ledger was built for this: the grant-period unique index is scoped to `kind='grant'`, so `'reward'` rows are unconstrained and stack.

## Verification

- `go build/vet/test ./...` — green. `gofmt` clean.
- Integration (`-tags=integration`) for `internal/credits`, `internal/handler`, `internal/db` — green (reward idempotency, banks-above-grant-across-period, zero-config no-op, contribution 201 → balance 25 = 20 grant + 5 reward).

## ⚠️ Deploy note

`migrations/0032_credit_reward_kind.sql` only auto-applies on a fresh volume. **On prod run it manually (under `hire`) BEFORE the code deploy**, else inserting a `'reward'` row violates the old CHECK.