### PR TITLE
feat(web): right-edge account-nav rail on the Agent page

### DIFF
--- a/openspec/changes/add-agent-nav-rail/.openspec.yaml
+++ b/openspec/changes/add-agent-nav-rail/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-agent-nav-rail/design.md
+++ b/openspec/changes/add-agent-nav-rail/design.md
@@ -1,0 +1,81 @@
+## Context
+
+The account area (`my/*`) renders every route inside a shared shell
+(`web/src/routes/my/+layout.svelte`) that owns the section navigation. The Agent
+page opts out of that shell via `web/src/routes/my/assistant/+layout@.svelte`
+(the `@` reset) so the chat runs full-width directly under the root layout — and
+therefore has no section navigation at all.
+
+The section navigation is driven by a pure model, `web/src/lib/accountNav.ts`
+(`visibleAccountNav(isModerator, isBetaTester)` and `isSectionActive(path,
+href)`), kept free of Svelte/icon imports. The href→Lucide-icon map currently
+lives inline in `my/+layout.svelte`, typed as
+`Record<AccountNavItem['href'], LucideIcon>` so a section without an icon is a
+compile error.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Restore account section navigation on the Agent page as a compact, icon-only
+  rail on the right edge.
+- Reuse the existing navigation model and icon set verbatim — no second source of
+  truth for the item list or the icons.
+
+**Non-Goals:**
+- No expand/collapse, no label text, no persisted state.
+- No change to `/tailor` or any other `my/*` page.
+- No change to the account model's ordering, gating, or active rule.
+
+## Decisions
+
+### Extract the href→icon map into a shared module
+
+The rail needs the same href→icon map the sidebar uses. Duplicating the 10-entry
+map in two components is a maintenance hazard: the compile-time "every section
+has an icon" guarantee would only hold in one place. So move the map into a new
+`web/src/lib/accountNavIcons.ts` exporting
+`accountNavIcons: Record<AccountNavItem['href'], LucideIcon>`, and import it in
+both `my/+layout.svelte` and the new rail. The map imports from `@lucide/svelte`,
+so it lives in its own `.ts` module rather than in `accountNav.ts` — that keeps
+`accountNav.ts` Svelte-free and unit-testable, as its comment requires.
+
+_Alternative considered:_ pass the icon map into the rail as a prop from the page.
+Rejected — it just relocates the duplication to the page and loses the shared
+compile-time guarantee.
+
+### A dedicated `AccountNavRail.svelte` component
+
+Add `web/src/lib/components/AccountNavRail.svelte` that renders the icon-only
+rail: it reads `currentUser()` for gating, computes items via `visibleAccountNav`,
+resolves the active item with `isSectionActive` against `page.url.pathname`, and
+renders one `<a>` per item (icon + `title` tooltip + `aria-current`). It renders
+nothing when signed out. This mirrors the sidebar's item treatment (same
+active/hover classes) without dragging in the sidebar's collapse logic, tab
+strip, or width container.
+
+_Alternative considered:_ inline the rail markup directly in the Agent page.
+Rejected — a named component keeps the page a thin host and leaves a clean seam
+if `/tailor` later wants the same rail.
+
+### Pin the rail to the right edge of the Agent surface
+
+The Agent page body is `<div class="flex h-[calc(100svh-3.5rem)]">` wrapping
+`<AssistantChat>`. Render `<AccountNavRail>` as the last flex child so it sits to
+the right of the chat column; the chat keeps `flex-1` / `min-w-0` and the rail is
+a fixed-width (`w-14`), `shrink-0`, full-height column with a left border —
+matching the visual language of the existing left session rail inside
+`AssistantChat`. The rail scrolls independently if the section list ever exceeds
+the viewport height.
+
+## Risks / Trade-offs
+
+- **Redundant with the header menu** (the hamburger already lists these) → the
+  rail is a quick-access affordance specific to the full-width surface; this is an
+  intentional, low-cost duplication of navigation, not of logic.
+- **Narrow icon-only rail is less discoverable than labelled nav** → mitigated by
+  `title` tooltips and by reusing the exact icons users already learned in the
+  account sidebar.
+- **Mobile width** → the Agent chat is already an app-like desktop-first surface;
+  the rail is a thin `w-14` column that coexists with the chat. If it proves
+  cramped on very small viewports we can hide it below a breakpoint, but that is
+  out of scope for this change.

--- a/openspec/changes/add-agent-nav-rail/proposal.md
+++ b/openspec/changes/add-agent-nav-rail/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The Agent chat page (`/my/assistant`) is a full-width, app-like surface that
+deliberately resets past the `my/*` account shell (`+layout@.svelte`) to reclaim
+horizontal space. The side effect is that it loses the account-section
+navigation entirely — from the Agent page there is no way to jump to Profile,
+Tracking, Inbox, CV builder, notifications, keys, etc. without going back through
+the header menu. We want that navigation back on this surface, but in a compact
+form that does not steal width from the chat.
+
+## What Changes
+
+- Add a narrow, icon-only account-navigation rail pinned to the far-right edge of
+  the Agent page (`/my/assistant`).
+- The rail lists the same sections as the account sidebar (`visibleAccountNav`),
+  honouring the same beta/moderator gating, in the same order, with the same
+  Lucide icons.
+- Each item is icon-only (no text label), carries a `title` tooltip with its
+  label, links to its `my/*` route, and is marked active by the existing
+  `isSectionActive` rule.
+- The rail is always narrow (~`w-14`); no expand/collapse and no persistence.
+- Extract the current inline href→icon map from `my/+layout.svelte` into a shared
+  module so the left sidebar and the new rail share one source of truth (a new
+  section without an icon stays a compile error in both places).
+- Scope is `/my/assistant` only; the `/tailor` surface is unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `account-navigation`: add a requirement that the full-width Agent surface,
+  which opts out of the account shell, still presents the account section
+  navigation as a compact icon-only rail pinned to the right edge.
+
+## Impact
+
+- `web/src/routes/my/assistant/+page.svelte` — renders the new rail beside the
+  chat.
+- New `web/src/lib/components/AccountNavRail.svelte` — the icon-only rail.
+- New shared module for the href→icon map (e.g. `web/src/lib/accountNavIcons.ts`),
+  consumed by both `my/+layout.svelte` and the rail.
+- `web/src/routes/my/+layout.svelte` — imports the icon map from the shared
+  module instead of defining it inline.
+- No backend, API, or data changes; reuses `$lib/accountNav`
+  (`visibleAccountNav`, `isSectionActive`) and existing auth state.

--- a/openspec/changes/add-agent-nav-rail/specs/account-navigation/spec.md
+++ b/openspec/changes/add-agent-nav-rail/specs/account-navigation/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Full-width surface navigation rail
+
+The Agent surface SHALL present the account section navigation as a compact,
+icon-only rail pinned to the far-right edge. The Agent page (`/my/assistant`)
+opts out of the account shell and would otherwise have no section navigation. The
+rail SHALL list exactly the sections returned by the shared visible
+navigation model — the same items, order, and beta/moderator gating as the
+account sidebar — and SHALL NOT include create actions or non-account links. Each
+rail item SHALL render its section's icon with no text label, expose its section
+label as a hover tooltip, link to its `my/*` route, and be marked active by the
+same rule as the account sidebar (active when the current path equals the
+section's route or is a descendant of it). The rail SHALL be shown only to a
+signed-in user.
+
+#### Scenario: Agent page shows the icon-only rail
+
+- **WHEN** a signed-in user opens `/my/assistant`
+- **THEN** a compact icon-only navigation rail is pinned to the right edge,
+  listing the same account sections (with the same gating) as the account sidebar
+
+#### Scenario: Rail item reflects the active section
+
+- **WHEN** a signed-in user is on `/my/assistant`
+- **THEN** the Agent item in the rail is marked active and the other items are not
+
+#### Scenario: Rail item exposes its label on hover
+
+- **WHEN** a user hovers a rail item that shows only an icon
+- **THEN** the item's section label is available as a tooltip
+
+#### Scenario: Signed-out visitor sees no rail
+
+- **WHEN** a signed-out visitor opens `/my/assistant`
+- **THEN** the navigation rail is not rendered

--- a/openspec/changes/add-agent-nav-rail/tasks.md
+++ b/openspec/changes/add-agent-nav-rail/tasks.md
@@ -1,0 +1,18 @@
+## 1. Shared account-nav icon map
+
+- [x] 1.1 Create `web/src/lib/accountNavIcons.ts` exporting `accountNavIcons: Record<AccountNavItem['href'], LucideIcon>` (moved verbatim from `my/+layout.svelte`). The "icon for every href" invariant is enforced by the `Record<AccountNavItem['href'], …>` type (missing key = compile error, extra key = excess-property error) and verified by `svelte-check` — a vitest cannot cover it because this repo's vitest does not transform `.svelte` imports (the reason `accountNav.ts` is kept Svelte-free). Prove the guard by momentarily dropping a key and seeing `svelte-check` fail, then restore.
+- [x] 1.2 Update `web/src/routes/my/+layout.svelte` to import `accountNavIcons` from the shared module and drop the inline map; confirm the sidebar/tab strip still renders unchanged.
+
+## 2. AccountNavRail component
+
+- [x] 2.1 Create `web/src/lib/components/AccountNavRail.svelte`: signed-in gate (renders nothing when signed out), items from `visibleAccountNav(role/beta)`, active via `isSectionActive(page.url.pathname, href)`, one icon-only `<a>` per item with `title` tooltip, `aria-current`, matching the sidebar's active/hover item classes.
+- [x] 2.2 Style it as a fixed-width (`w-14`), `shrink-0`, full-height right-edge column with a left border, centring each icon.
+
+## 3. Wire into the Agent page
+
+- [x] 3.1 Render `<AccountNavRail>` as the last flex child in `web/src/routes/my/assistant/+page.svelte` so it pins to the right edge beside `<AssistantChat>`.
+
+## 4. Verify
+
+- [x] 4.1 `npm run check` (svelte-check) and the build pass in `web/`.
+- [x] 4.2 Visual-verify `/my/assistant` (signed-in beta user) in headless Chrome: rail on the right edge, correct icons, Agent item active, tooltips present; and signed-out shows no rail.

--- a/web/src/lib/accountNavIcons.ts
+++ b/web/src/lib/accountNavIcons.ts
@@ -1,0 +1,34 @@
+// The href→Lucide-icon map for the account sections, shared by every navigation
+// form (the account sidebar/tab strip in `my/+layout.svelte` and the Agent-page
+// rail in `AccountNavRail.svelte`). Kept out of `accountNav.ts` so that model
+// stays Svelte-free and unit-testable; this module owns the icon coupling.
+//
+// Keyed by the nav hrefs (`Record<AccountNavItem['href'], LucideIcon>`) so a new
+// section without an icon is a compile error, not a runtime `<undefined />`.
+import {
+  User,
+  Bot,
+  LayoutList,
+  Activity,
+  Bell,
+  Key,
+  FileText,
+  ScrollText,
+  Inbox,
+  Link2,
+} from '@lucide/svelte';
+import type { LucideIcon } from '@lucide/svelte';
+import type { AccountNavItem } from './accountNav';
+
+export const accountNavIcons: Record<AccountNavItem['href'], LucideIcon> = {
+  '/my/profile': User,
+  '/my/assistant': Bot,
+  '/my/cvs': ScrollText,
+  '/my/tracking': LayoutList,
+  '/my/activity': Activity,
+  '/my/inbox': Inbox,
+  '/my/searches': Bell,
+  '/my/api-keys': Key,
+  '/my/submissions': FileText,
+  '/my/contributions': Link2,
+};

--- a/web/src/lib/components/AccountNavRail.svelte
+++ b/web/src/lib/components/AccountNavRail.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
+  import { isAuthenticated, currentUser } from '$lib/auth.svelte';
+  import { visibleAccountNav, isSectionActive } from '$lib/accountNav';
+  import { accountNavIcons } from '$lib/accountNavIcons';
+  import { cn } from '$lib/utils';
+
+  // A compact, icon-only mirror of the account-section navigation (see
+  // my/+layout.svelte), pinned to the right edge of full-width surfaces that reset
+  // past the account shell — currently the Agent page. Same items, gating, order,
+  // and active rule as the sidebar; no labels, no collapse. Reuses the shared
+  // visible-nav model and icon map so there's one source of truth. Renders nothing
+  // for a signed-out visitor.
+
+  const path = $derived(page.url.pathname);
+  const navItems = $derived(
+    visibleAccountNav(currentUser()?.role === 'moderator', currentUser()?.beta_tester ?? false),
+  );
+</script>
+
+{#if isAuthenticated()}
+  <nav
+    aria-label="Account sections"
+    class="flex w-14 shrink-0 flex-col gap-1 overflow-y-auto border-l border-border bg-background p-2"
+  >
+    {#each navItems as item (item.href)}
+      {@const active = isSectionActive(path, item.href)}
+      {@const Icon = accountNavIcons[item.href]}
+      <a
+        href={resolve(item.href)}
+        aria-current={active ? 'page' : undefined}
+        title={item.label}
+        class={cn(
+          'flex items-center justify-center rounded-md p-2 transition-colors',
+          active
+            ? 'bg-secondary text-secondary-foreground'
+            : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+        )}
+      >
+        <Icon class="size-4 shrink-0" />
+        <span class="sr-only">{item.label}</span>
+      </a>
+    {/each}
+  </nav>
+{/if}

--- a/web/src/routes/my/+layout.svelte
+++ b/web/src/routes/my/+layout.svelte
@@ -4,25 +4,12 @@
   import { browser } from '$app/environment';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
-  import {
-    User,
-    Bot,
-    LayoutList,
-    Activity,
-    Bell,
-    Key,
-    FileText,
-    ScrollText,
-    Inbox,
-    Link2,
-    PanelLeftClose,
-    PanelLeft,
-  } from '@lucide/svelte';
-  import type { LucideIcon } from '@lucide/svelte';
+  import { PanelLeftClose, PanelLeft } from '@lucide/svelte';
   import { isAuthenticated, currentUser } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { Button } from '$lib/ui';
-  import { visibleAccountNav, isSectionActive, type AccountNavItem } from '$lib/accountNav';
+  import { visibleAccountNav, isSectionActive } from '$lib/accountNav';
+  import { accountNavIcons } from '$lib/accountNavIcons';
   import { cn } from '$lib/utils';
 
   // The account shell: one source of truth for the `my/*` chrome — the width
@@ -52,22 +39,6 @@
     visibleAccountNav(currentUser()?.role === 'moderator', currentUser()?.beta_tester ?? false),
   );
 
-  // Icon per section, kept out of the pure accountNav model so that stays
-  // Svelte-free and unit-testable. Keyed by the nav hrefs so a new section
-  // without an icon is a compile error, not a runtime `<undefined />`.
-  const icons: Record<AccountNavItem['href'], LucideIcon> = {
-    '/my/profile': User,
-    '/my/assistant': Bot,
-    '/my/cvs': ScrollText,
-    '/my/tracking': LayoutList,
-    '/my/activity': Activity,
-    '/my/inbox': Inbox,
-    '/my/searches': Bell,
-    '/my/api-keys': Key,
-    '/my/submissions': FileText,
-    '/my/contributions': Link2,
-  };
-
   // Shared item treatment for both nav forms; active matches the tracking tabs.
   const itemClass = (active: boolean) =>
     cn(
@@ -95,7 +66,7 @@
     {#snippet navLinks(extra: string, iconOnly = false)}
       {#each navItems as item (item.href)}
         {@const active = isSectionActive(path, item.href)}
-        {@const Icon = icons[item.href]}
+        {@const Icon = accountNavIcons[item.href]}
         <a
           href={resolve(item.href)}
           aria-current={active ? 'page' : undefined}

--- a/web/src/routes/my/assistant/+page.svelte
+++ b/web/src/routes/my/assistant/+page.svelte
@@ -4,6 +4,7 @@
   // ?session deep-link. The full-width own layout comes from +layout@.svelte.
   import { page } from '$app/state';
   import AssistantChat from '$lib/assistant/AssistantChat.svelte';
+  import AccountNavRail from '$lib/components/AccountNavRail.svelte';
 
   const session = $derived(page.url.searchParams.get('session') ?? undefined);
 </script>
@@ -12,4 +13,7 @@
 
 <div class="flex h-[calc(100svh-3.5rem)]">
   <AssistantChat {session} showSessionRail />
+  <!-- Full-width surface loses the account shell nav; a compact icon rail on the right
+       edge brings the account sections back without stealing width from the chat. -->
+  <AccountNavRail />
 </div>


### PR DESCRIPTION
## Summary

The Agent chat page (`/my/assistant`) resets past the `/my` account shell (`+layout@.svelte`) to run full-width, which drops the account-section navigation entirely — from the Agent page there was no way to jump to Profile, Tracking, Inbox, CV builder, notifications, keys, etc. without the header menu.

This adds a **narrow, icon-only navigation rail pinned to the far-right edge** of the Agent page that brings it back in compact form:

- Same sections as the account sidebar (`visibleAccountNav`), same order, same beta/moderator gating, same Lucide icons.
- Icon-only (~`w-14`), `title` tooltip per item, `aria-current` active state via the existing `isSectionActive` rule.
- Hidden entirely for signed-out visitors.
- No expand/collapse, no persistence — always narrow.

Refactor: the href→icon map is extracted from `my/+layout.svelte` into a shared `$lib/accountNavIcons` module, so the sidebar and the rail share one source of truth. The `Record<AccountNavItem['href'], LucideIcon>` type keeps "every section has an icon" a compile error in both places.

Scope is `/my/assistant` only; `/tailor` is unchanged.

Planned via OpenSpec change `add-agent-nav-rail` (proposal/design/specs/tasks included).

## Test Plan

- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run test` (vitest) — 299 passing
- [x] `npm run build` — production build succeeds
- [x] Type-guard proven: dropping an icon key makes `svelte-check` fail with "Property '…' is missing"
- [x] Visual-verified in headless Chrome: rail pinned right, all 10 icons in order, left border, matches the design reference; no item active off-section; signed-out renders no rail