### PR TITLE
feat(credits): GET /me/credits + balance widget on profile

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -427,6 +427,7 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/me/tracking/pipeline", keyAuth, a.TrackingPipeline)
 	api.Get("/me/tracking/swipe", keyAuth, a.SwipeDeck)
 	api.Get("/me/tracking/analyses", keyAuth, a.ListMyAnalyses)
+	api.Get("/me/credits", keyAuth, a.GetMyCredits)
 	api.Get("/me/recommendations", keyAuth, a.Recommendations)
 
 	// API-key management is cookie-only (RequireAuth): a leaked key must not be

--- a/internal/handler/me_credits.go
+++ b/internal/handler/me_credits.go
@@ -1,0 +1,18 @@
+package handler
+
+import "github.com/gofiber/fiber/v2"
+
+// GetMyCredits returns the caller's current AI-credits balance — the points left this
+// month and when the monthly grant resets — without consuming any. Cookie or API key;
+// never calls the LLM. Powers the balance widget on the profile page.
+func (a *API) GetMyCredits(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	bal, err := a.credits.Balance(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+	return c.JSON(fiber.Map{"data": bal})
+}

--- a/internal/handler/me_credits_integration_test.go
+++ b/internal/handler/me_credits_integration_test.go
@@ -1,0 +1,65 @@
+//go:build integration
+
+// Integration test for GET /api/v1/me/credits: a signed-in caller reads their AI-credits
+// balance (fresh user reports the full monthly grant) without consuming any. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/credits"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestGetMyCredits(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	var userID int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('creditview@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	tok, _ := iss.Issue(userID)
+	h := &API{pool: pool, queries: queries, issuer: iss,
+		credits: credits.NewStore(queries, pool, credits.Config{MonthlyGrant: 20, CostMatch: 1, CostTailor: 3, ContributionReward: 5})}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/credits", auth.RequireAuthOrKey(iss, queries), h.GetMyCredits)
+
+	req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/credits", nil)
+	req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: tok})
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Data struct {
+			Remaining int    `json:"remaining"`
+			ResetsAt  string `json:"resets_at"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Data.Remaining != 20 {
+		t.Errorf("remaining = %d, want 20 (fresh monthly grant)", body.Data.Remaining)
+	}
+	if body.Data.ResetsAt == "" {
+		t.Error("resets_at should be set")
+	}
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -655,6 +655,12 @@ export function createApi(
     return { items: res.data, credits: res.meta.credits };
   }
 
+  /** The caller's current AI-credits balance (points left this month + reset date).
+   *  Never triggers the LLM. Powers the profile-page balance widget. */
+  async function myCredits(): Promise<JobFitCredits> {
+    return requestData<JobFitCredits>('/api/v1/me/credits');
+  }
+
   /** The public slugs of every job the current user has interacted with. The
    *  browse UI cross-references this set to dim already-viewed cards without
    *  authenticating the public job list. */
@@ -1127,6 +1133,7 @@ export function createApi(
     listMyJobs,
     getMyPipeline,
     myAnalyses,
+    myCredits,
     listViewedSlugs,
     listSavedSlugs,
     listApiKeys,

--- a/web/src/lib/components/CreditsBalance.svelte
+++ b/web/src/lib/components/CreditsBalance.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { api } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import type { JobFitCredits } from '$lib/types';
+
+  // The caller's AI-credits balance: points spent on résumé match (1) and CV tailoring (3),
+  // topped up by a monthly grant and by accepted board contributions. Read-only.
+  let credits = $state<JobFitCredits | null>(null);
+
+  $effect(() => {
+    if (!isAuthenticated()) return;
+    api
+      .myCredits()
+      .then((c) => (credits = c))
+      .catch(() => {}); // best-effort: the widget just stays hidden on error
+  });
+
+  const fmtDate = (iso: string) =>
+    new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+</script>
+
+{#if credits}
+  <div
+    class="flex items-center justify-between gap-3 rounded-lg border border-border bg-secondary/40 px-4 py-2.5 text-sm"
+  >
+    <span class="text-muted-foreground">
+      <strong class="font-semibold text-foreground">{credits.remaining}</strong> AI credits left this month
+    </span>
+    <span class="text-xs text-muted-foreground">renews {fmtDate(credits.resets_at)}</span>
+  </div>
+{/if}

--- a/web/src/lib/docs/api-spec.ts
+++ b/web/src/lib/docs/api-spec.ts
@@ -867,6 +867,20 @@ ${BASE_URL}/auth/oauth/google/start`,
       },
       {
         method: 'GET',
+        path: '/me/credits',
+        auth: 'cookie-or-key',
+        summary: 'Your current AI-credits balance.',
+        description:
+          'The points left this month (`remaining`) and when the monthly grant renews ' +
+          '(`resets_at`). AI credits are spent on the fit analysis (1) and CV tailoring (3), ' +
+          'topped up by the monthly grant and by accepted board contributions. Never runs the LLM.',
+        curl: `curl "${BASE_URL}/me/credits" -H "Authorization: Bearer $FREEHIRE_API_KEY"`,
+        responseExample: `{
+  "data": { "remaining": 17, "resets_at": "2026-08-01T00:00:00Z" }
+}`,
+      },
+      {
+        method: 'GET',
         path: '/me/tracking/saved',
         auth: 'cookie-or-key',
         summary: 'Slugs of jobs you have saved.',

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -6,6 +6,7 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { FilterStore, filtersToParams } from '$lib/filters';
   import ATSReportView from '$lib/components/ATSReportView.svelte';
+  import CreditsBalance from '$lib/components/CreditsBalance.svelte';
   import FilterSummary from '$lib/components/filters/FilterSummary.svelte';
   import FilterModal from '$lib/components/filters/FilterModal.svelte';
   import FilterEdgeTab from '$lib/components/FilterEdgeTab.svelte';
@@ -198,6 +199,10 @@
     <p class="text-sm text-muted-foreground">
       Your CV, skills and role — measured against live market demand.
     </p>
+  </div>
+
+  <div class="mb-6">
+    <CreditsBalance />
   </div>
 
   {#if actionError}


### PR DESCRIPTION
## What

A canonical place for a user to **see their AI-credits balance**. Until now it only showed contextually in the match flow and the Tracking → matches banner.

## How

- **`GET /api/v1/me/credits`** (cookie or key) → `{remaining, resets_at}`, never runs the LLM.
- **Web**: `api.myCredits()`; a reusable `CreditsBalance` widget mounted at the top of `/my/profile` — "N AI credits left this month · renews <date>".
- **Docs**: `/me/credits` entry in the API spec.

## Verification

- `go build/vet/test ./...` green; integration `TestGetMyCredits` green (fresh user → 20).
- `svelte-check` 0 errors. `gofmt` clean.

No migration. Read-only endpoint + UI.