### PR TITLE
fix(jobtech): use employer.workplace as company name

### DIFF
--- a/internal/sources/jobtech.go
+++ b/internal/sources/jobtech.go
@@ -66,7 +66,11 @@ type jobtechItem struct {
 		TextFormatted string `json:"text_formatted"`
 	} `json:"description"`
 	Employer struct {
-		Name string `json:"name"`
+		// Name is the legal entity (often a numbered shell AB, e.g. "Miro 461704 AB");
+		// Workplace is the trading name the shop actually operates under ("Direkten Nöje
+		// Casablanca"). Workplace is the meaningful company display — see toJob.
+		Name      string `json:"name"`
+		Workplace string `json:"workplace"`
 	} `json:"employer"`
 	WorkplaceAddress struct {
 		Municipality string `json:"municipality"`
@@ -126,11 +130,18 @@ func (s jobtech) FetchStream(ctx context.Context, _ CompanyEntry, emit func(Job)
 }
 
 // toJob maps a live ad to a Job, returning ok=false for an ad with no id to key on or no
-// employer name (which would break the company slug). Remote/WorkMode are left unset: the
-// API's remote_work flag is effectively always null, so the work arrangement is derived
-// downstream from the location string by the deterministic dictionary, not guessed here.
+// company to attribute it to (which would break the company slug). The company is the
+// trading name (employer.workplace) when present, falling back to the legal entity
+// (employer.name) — the numbered shell AB the workplace registers under is both a poor
+// display and a magnet for a wrong-brand logo.dev name match. Remote/WorkMode are left
+// unset: the API's remote_work flag is effectively always null, so the work arrangement is
+// derived downstream from the location string by the deterministic dictionary, not guessed.
 func (it jobtechItem) toJob() (Job, bool) {
-	if it.ID == "" || it.Employer.Name == "" {
+	company := it.Employer.Workplace
+	if company == "" {
+		company = it.Employer.Name
+	}
+	if it.ID == "" || company == "" {
 		return Job{}, false
 	}
 	desc := it.Description.TextFormatted
@@ -141,7 +152,7 @@ func (it jobtechItem) toJob() (Job, bool) {
 		ExternalID:  it.ID,
 		URL:         it.WebpageURL,
 		Title:       it.Headline,
-		Company:     it.Employer.Name,
+		Company:     company,
 		Location:    joinNonEmpty(it.WorkplaceAddress.Municipality, it.WorkplaceAddress.Region, it.WorkplaceAddress.Country),
 		Description: sanitizeHTML(desc),
 		PostedAt:    parseLayout(jobtechDateLayout, it.PublicationDate),

--- a/internal/sources/jobtech_test.go
+++ b/internal/sources/jobtech_test.go
@@ -112,6 +112,31 @@ func TestJobtechStreamMapsLiveClosesRemovedDropsInvalid(t *testing.T) {
 	}
 }
 
+func TestJobtechPrefersWorkplaceOverLegalName(t *testing.T) {
+	// Swedish ads often register under a numbered shell AB (employer.name, e.g. "Miro
+	// 461704 AB") while the real trading name sits in employer.workplace ("Direkten Nöje
+	// Casablanca"). The workplace is the meaningful company display — and using the shell
+	// name would let logo.dev fuzzy-match a well-known brand ("Miro") onto the wrong firm.
+	// Prefer workplace, fall back to name when the ad carries no workplace.
+	body := `[
+{"id":"1","removed":false,"webpage_url":"u","headline":"Butikssäljare","publication_date":"2026-06-10T12:00:00","employer":{"name":"Miro 461704 AB","workplace":"Direkten Nöje Casablanca"}},
+{"id":"2","removed":false,"webpage_url":"u","headline":"h","publication_date":"2026-06-10T12:00:00","employer":{"name":"Tatvanord AB"}}
+]`
+	jobs, err := NewJobtech(&fakeStream{body: body}).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2", len(jobs))
+	}
+	if jobs[0].Company != "Direkten Nöje Casablanca" {
+		t.Errorf("Company = %q, want the workplace trading name over the shell AB", jobs[0].Company)
+	}
+	if jobs[1].Company != "Tatvanord AB" {
+		t.Errorf("Company = %q, want employer.name fallback when workplace is empty", jobs[1].Company)
+	}
+}
+
 func TestJobtechRequestsTrailingWindow(t *testing.T) {
 	fake := &fakeStream{body: `[]`}
 	if _, err := NewJobtech(fake).Fetch(context.Background(), CompanyEntry{}); err != nil {


### PR DESCRIPTION
## Problem

The Platsbanken ad [31280916](https://arbetsformedlingen.se/platsbanken/annonser/31280916) surfaced on freehire as company **"Miro 461704 AB"** wearing the **SaaS Miro** logo — clearly not that Miro.

Root cause is a two-link chain:

1. **Adapter picked the legal shell name.** Swedish ads register under a numbered shell AB (`employer.name` = `"Miro 461704 AB"`) while the real trading name sits in `employer.workplace` = `"Direkten Nöje Casablanca"`. The jobtech adapter mapped `Company` from `employer.name`.
2. **Logo is resolved by name.** The SPA (`web/src/lib/logo.ts`) hits logo.dev's fuzzy **name endpoint**, which strips the `461704 AB` noise and matches the token `Miro` → returns the wrong brand's logo.

Fixing link (1) also fixes the logo: logo.dev finds no match for "Direkten Nöje Casablanca" and the SPA falls back to its own monogram.

## Change

`internal/sources/jobtech.go`: company is now `employer.workplace` (trading name), falling back to `employer.name` when the ad has no workplace; an ad is dropped only when **both** are empty.

## Notes

- jobtech is a `selfClosing` stream source (rolling 72h change window), so already-ingested ads keep the old name until they're re-reported or age out — not backfilled here.
- The systemic issue (logo.dev name endpoint can fuzzy-match any company whose name contains a brand token) is left as a known seam; this PR fixes the concrete data-quality root cause.

## Test

Added `TestJobtechPrefersWorkplaceOverLegalName` covering both the workplace preference and the name fallback. `go test ./internal/sources/`, `go build`, `go vet` all pass.