### PR TITLE
fix(web): move Agent-page account-nav rail to the left edge

### DIFF
--- a/web/src/lib/components/AccountNavRail.svelte
+++ b/web/src/lib/components/AccountNavRail.svelte
@@ -7,7 +7,7 @@
   import { cn } from '$lib/utils';
 
   // A compact, icon-only mirror of the account-section navigation (see
-  // my/+layout.svelte), pinned to the right edge of full-width surfaces that reset
+  // my/+layout.svelte), pinned to the left edge of full-width surfaces that reset
   // past the account shell — currently the Agent page. Same items, gating, order,
   // and active rule as the sidebar; no labels, no collapse. Reuses the shared
   // visible-nav model and icon map so there's one source of truth. Renders nothing
@@ -22,7 +22,7 @@
 {#if isAuthenticated()}
   <nav
     aria-label="Account sections"
-    class="flex w-14 shrink-0 flex-col gap-1 overflow-y-auto border-l border-border bg-background p-2"
+    class="flex w-14 shrink-0 flex-col gap-1 overflow-y-auto border-r border-border bg-background p-2"
   >
     {#each navItems as item (item.href)}
       {@const active = isSectionActive(path, item.href)}

--- a/web/src/routes/my/assistant/+page.svelte
+++ b/web/src/routes/my/assistant/+page.svelte
@@ -12,8 +12,8 @@
 <svelte:head><title>Agent — freehire</title></svelte:head>
 
 <div class="flex h-[calc(100svh-3.5rem)]">
-  <AssistantChat {session} showSessionRail />
-  <!-- Full-width surface loses the account shell nav; a compact icon rail on the right
+  <!-- Full-width surface loses the account shell nav; a compact icon rail on the left
        edge brings the account sections back without stealing width from the chat. -->
   <AccountNavRail />
+  <AssistantChat {session} showSessionRail />
 </div>


### PR DESCRIPTION
Hotfix follow-up to #916. The account-nav rail on the Agent page (`/my/assistant`) was requested on the **left** edge, not the right.

- Render `<AccountNavRail>` as the first flex child (before `<AssistantChat>`).
- Flip the rail divider `border-l` → `border-r`.

Result: a narrow left-edge activity bar, sitting just left of the chat's own session rail.

## Test Plan
- [x] `npm run check` — 0 errors
- [x] Visual-verified in headless Chrome: icon rail at the far-left edge, session rail + chat to its right