### PR TITLE
fix(fit): remote LATAM roles pass location; tailor UI gated on beta_tester

### DIFF
--- a/internal/jobfit/analyzer.go
+++ b/internal/jobfit/analyzer.go
@@ -214,10 +214,14 @@ func stage2SystemPrompt() string {
 	b.WriteString("- \"company_context\": fit with the company's stage/industry (from the company info).\n")
 	b.WriteString("- \"location_fit\": can the candidate actually take the role given the job's location/work ")
 	b.WriteString("mode and their location preferences (accepted work modes, remote reach, base, relocation)? ")
-	b.WriteString("A remote job within their remote reach, or an onsite job where they are based or will ")
-	b.WriteString("relocate, scores high; an onsite job far from their base with no relocation and a remote-only ")
-	b.WriteString("preference scores low. If the candidate stated no preferences, judge on the job alone and ")
-	b.WriteString("do not penalise.\n")
+	b.WriteString("For a REMOTE role, judge ONLY whether its region or countries fall within the candidate's ")
+	b.WriteString("remote reach — a reach of \"global\", or one naming the job's region, covers any city or ")
+	b.WriteString("country in that region; ignore the candidate's physical base and relocation entirely, and ")
+	b.WriteString("never treat a remote posting's office city as a relocation requirement. Relocation matters ")
+	b.WriteString("only for onsite or hybrid roles: an onsite job where they are based or will relocate scores ")
+	b.WriteString("high; an onsite job far from their base with no relocation and a remote-only preference ")
+	b.WriteString("scores low. Honour any NOTE about remote reach in the input. If the candidate stated no ")
+	b.WriteString("preferences, judge on the job alone and do not penalise.\n")
 	b.WriteString("Each of the six is an object {\"score\": int 0-100, \"comment\": string}.\n")
 	b.WriteString("Also return \"strengths\" (array, max 6), \"gaps\" (array, max 6), and a single ")
 	b.WriteString("\"recommendation\" string. Do NOT return an overall score — it is computed separately.\n")
@@ -358,7 +362,50 @@ func writeLocation(b *strings.Builder, in Input) {
 		b.WriteString(llm.TruncateRunes(strings.TrimSpace(in.LocationPreferences), maxCompanyRunes))
 		b.WriteString("\n")
 	}
+	if remoteWithinReach(in) {
+		b.WriteString("- NOTE: this is a remote role and its region is within the candidate's stated ")
+		b.WriteString("remote reach, so they can work it from where they are — score location fit high and ")
+		b.WriteString("do not penalise their base or relocation stance.\n")
+	}
 	b.WriteString("\n")
+}
+
+// remoteWithinReach reports whether the job is remote AND its region falls within the
+// candidate's stated remote reach (their location_preferences remote.regions). A reach of
+// "global", or one naming the job's region, covers the posting regardless of the posted
+// office city/country — a remote worker in that region can take it without relocating. This
+// is deterministic on purpose: it stops the model from reading a remote role's HQ city (e.g.
+// a LATAM-remote job posted from Santo Domingo) as a relocation requirement and scoring
+// location_fit 0. Unset/unparseable prefs or a non-remote job → false (the model judges).
+func remoteWithinReach(in Input) bool {
+	if !in.JobRemote && !strings.EqualFold(in.JobWorkMode, "remote") {
+		return false
+	}
+	for _, r := range candidateRemoteReach(in.LocationPreferences) {
+		if strings.EqualFold(r, "global") {
+			return true
+		}
+		for _, jr := range in.JobRegions {
+			if strings.EqualFold(r, jr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// candidateRemoteReach pulls the remote.regions list out of the raw location_preferences
+// JSON. Empty on unset/unparseable input (the caller then degrades to model judgement).
+func candidateRemoteReach(prefsJSON string) []string {
+	var p struct {
+		Remote struct {
+			Regions []string `json:"regions"`
+		} `json:"remote"`
+	}
+	if json.Unmarshal([]byte(strings.TrimSpace(prefsJSON)), &p) != nil {
+		return nil
+	}
+	return p.Remote.Regions
 }
 
 func writeRequirements(b *strings.Builder, reqs []Requirement) {

--- a/internal/jobfit/prompt_test.go
+++ b/internal/jobfit/prompt_test.go
@@ -23,3 +23,42 @@ func TestStage1Prompt_OmitsStructuredBlockWhenEmpty(t *testing.T) {
 		t.Errorf("stage1 prompt should omit the structured block when empty:\n%s", withEmpty)
 	}
 }
+
+func TestWriteLocation_RemoteWithinReachAddsNote(t *testing.T) {
+	// A LATAM-remote role whose posted office happens to sit in one country (DR) — the
+	// candidate's remote reach names `latam`, so they can take it without relocating. The
+	// prompt must say so deterministically, never leaving the model to read the office city
+	// as a relocation requirement (the false LATAM location-mismatch this guards against).
+	in := Input{
+		JobRemote:           true,
+		JobLocation:         "Santo Domingo, Dominican Republic",
+		JobRegions:          []string{"latam"},
+		JobCountries:        []string{"do"},
+		LocationPreferences: `{"base":{"country":"br"},"remote":{"regions":["global","latam","cis"]},"relocation":{"open":false}}`,
+	}
+	got := stage2UserPrompt(in, nil)
+	if !strings.Contains(got, "within the candidate's stated remote reach") {
+		t.Errorf("expected remote-reach NOTE for a LATAM-remote job matching the candidate's reach:\n%s", got)
+	}
+}
+
+func TestWriteLocation_RemoteOutsideReachNoNote(t *testing.T) {
+	// The candidate's reach is Europe-only; a LATAM-remote role is genuinely out of reach,
+	// so the deterministic vouch must NOT fire — the model judges it (and may score it low).
+	in := Input{
+		JobRemote:           true,
+		JobRegions:          []string{"latam"},
+		LocationPreferences: `{"remote":{"regions":["europe"]}}`,
+	}
+	got := stage2UserPrompt(in, nil)
+	if strings.Contains(got, "within the candidate's stated remote reach") {
+		t.Errorf("must not vouch for a remote job outside the candidate's reach:\n%s", got)
+	}
+}
+
+func TestStage2SystemPrompt_RemoteLocationRule(t *testing.T) {
+	sp := stage2SystemPrompt()
+	if !strings.Contains(sp, "remote reach") || !strings.Contains(sp, "Relocation matters only for onsite") {
+		t.Errorf("stage2 system prompt must instruct remote-only location scoring:\n%s", sp)
+	}
+}

--- a/web/src/routes/match/[slug]/+page.svelte
+++ b/web/src/routes/match/[slug]/+page.svelte
@@ -9,14 +9,12 @@
 
   let { data } = $props();
 
-  // Tailoring is beta-gated (the server re-checks); the CTA shows once an analysis exists for
-  // a stored CV. A stale analysis (CV or job changed since) still tailors — we nudge a
-  // recompute for the sharpest reframing (see below) rather than block, since any CV
-  // re-upload marks every past analysis stale and blocking would hide the feature too often.
+  // Tailoring is a beta-tester feature; the CTA shows once an analysis exists for a stored
+  // CV. A stale analysis (CV or job changed since) still tailors — we nudge a recompute for
+  // the sharpest reframing (see below) rather than block, since any CV re-upload marks every
+  // past analysis stale and blocking would hide the feature too often.
   const canTailor = $derived(
-    !!data.fit?.analysis &&
-      data.fit?.has_cv === true &&
-      (currentUser()?.beta_tester === true || currentUser()?.role === 'moderator'),
+    !!data.fit?.analysis && data.fit?.has_cv === true && currentUser()?.beta_tester === true,
   );
 
   let tailoring = $state(false);

--- a/web/src/routes/my/cvs/+page.svelte
+++ b/web/src/routes/my/cvs/+page.svelte
@@ -2,11 +2,10 @@
   import { currentUser } from '$lib/auth.svelte';
   import CvList from '$lib/components/cv/CvList.svelte';
 
-  // Beta-gated in the UI (the server re-checks via RequireModeratorOrBeta). This just
-  // keeps a non-beta user who navigates here directly from hitting a raw 403.
-  const eligible = $derived(
-    currentUser()?.beta_tester === true || currentUser()?.role === 'moderator',
-  );
+  // Beta-tester-gated in the UI (the server still admits moderators via RequireModeratorOrBeta
+  // as an admin override). This just keeps a non-beta user who navigates here directly from
+  // hitting a raw 403.
+  const eligible = $derived(currentUser()?.beta_tester === true);
 </script>
 
 <svelte:head>

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -16,9 +16,7 @@
 
   const slug = $derived(page.params.slug ?? '');
   const cvParam = $derived(page.url.searchParams.get('cv'));
-  const eligible = $derived(
-    currentUser()?.beta_tester === true || currentUser()?.role === 'moderator',
-  );
+  const eligible = $derived(currentUser()?.beta_tester === true);
 
   let status = $state<'loading' | 'ready' | 'error'>('loading');
   let errorMsg = $state('');


### PR DESCRIPTION
## What

Two fixes to the job-fit / tailoring surface.

### 1. Remote location fit (LATAM false-mismatch)
A remote role whose posted `location` is a single office (e.g. a LATAM-remote job posted from Santo Domingo, DR) was scored `location_fit = 0` whenever the candidate's `relocation.open = false`. The model read the office country as a relocation requirement, ignoring that the job's region (`latam`) sits inside the candidate's stated remote reach — dragging an otherwise Good-Fit verdict down and printing a bogus 'critical location mismatch'.

- `writeLocation` now emits a deterministic **NOTE** when the job is remote and its region falls within the candidate's remote reach (or the reach is `global`).
- The stage-2 system prompt judges **remote** roles solely on region/country overlap with the candidate's remote reach; base and relocation are ignored (they matter only for onsite/hybrid).
- 3 new prompt tests cover the exact LATAM/Santo-Domingo case (NOTE fires) and an out-of-reach case (NOTE stays off).

> Cached analyses won't change until recomputed — the fit cache is triple-stamped and GET never calls the LLM. Existing users see the fix after a **Recompute**.

### 2. Tailoring UI gated on beta_tester only
Dropped the `|| role === 'moderator'` branch from the three tailoring gates (`match/[slug]`, `tailor/[slug]`, `my/cvs`). Tailoring is a beta-tester feature; the server still admits moderators via `RequireModeratorOrBeta` as an admin override.

## Verification
- `go build ./...`, `go test ./internal/jobfit/`, `gofmt` — green
- `svelte-check` — 0 errors