### PR TITLE
feat(web): account-nav rail on the Tailor CV workspace

### DIFF
--- a/openspec/specs/account-navigation/spec.md
+++ b/openspec/specs/account-navigation/spec.md
@@ -71,9 +71,10 @@ any viewport width.
 
 ### Requirement: Full-width surface navigation rail
 
-The Agent surface SHALL present the account section navigation as a compact,
-icon-only rail pinned to the left edge. The Agent page (`/my/assistant`) opts out
-of the account shell and would otherwise have no section navigation. The rail
+A full-width workspace that opts out of the account shell SHALL present the
+account section navigation as a compact, icon-only rail pinned to the left edge,
+so it is not left without section navigation. This covers the Agent page
+(`/my/assistant`) and the Tailor CV workspace (`/tailor/<slug>`). The rail
 SHALL list exactly the sections returned by the shared visible navigation model —
 the same items, order, and beta/moderator gating as the account sidebar — and
 SHALL NOT include create actions or non-account links. Each rail item SHALL
@@ -87,6 +88,12 @@ descendant of it). The rail SHALL be shown only to a signed-in user.
 - **WHEN** a signed-in user opens `/my/assistant`
 - **THEN** a compact icon-only navigation rail is pinned to the left edge, listing
   the same account sections (with the same gating) as the account sidebar
+
+#### Scenario: Tailor CV workspace shows the icon-only rail
+
+- **WHEN** a signed-in user opens a `/tailor/<slug>` CV workspace
+- **THEN** the same compact icon-only navigation rail is pinned to the left edge,
+  and it remains present across the workspace's loading, error, and ready states
 
 #### Scenario: Rail item reflects the active section
 

--- a/web/src/routes/tailor/[slug]/+page.svelte
+++ b/web/src/routes/tailor/[slug]/+page.svelte
@@ -10,6 +10,7 @@
   import { createSession } from '$lib/assistant/api';
   import AssistantChat from '$lib/assistant/AssistantChat.svelte';
   import ArtifactPanel from '$lib/tailor/ArtifactPanel.svelte';
+  import AccountNavRail from '$lib/components/AccountNavRail.svelte';
   import { currentUser } from '$lib/auth.svelte';
   import type { Analysis } from '$lib/generated/contracts';
   import type { Job } from '$lib/types';
@@ -97,24 +98,29 @@
 
 <svelte:head><title>Tailor CV{job ? ` · ${job.title}` : ''} — freehire</title></svelte:head>
 
-{#if status === 'loading'}
-  <div class="flex h-[calc(100svh-3.5rem)] items-center justify-center text-sm text-muted-foreground">
-    {resuming ? 'Re-opening your tailoring session…' : 'Preparing your tailoring session…'}
-  </div>
-{:else if status === 'error'}
-  <div class="flex h-[calc(100svh-3.5rem)] flex-col items-center justify-center gap-3 p-6 text-center">
-    <p class="max-w-md text-sm text-destructive">{errorMsg}</p>
-    <a href={`/match/${slug}`} class="text-sm text-brand hover:underline">Back to the fit analysis</a>
-  </div>
-{:else}
-  <div class="flex h-[calc(100svh-3.5rem)]">
-    <AssistantChat
-      session={sessionId}
-      kickoff={resuming ? undefined : kickoff}
-      {sessionLabel}
-      showSessionRail={false}
-      onTurnComplete={() => (refreshKey += 1)}
-    />
-    <ArtifactPanel {cvId} job={job!} {analysis} {refreshKey} />
-  </div>
-{/if}
+<!-- Full-width workspace loses the account shell nav; the same left-edge icon rail as
+     the Agent page brings the account sections back. It stays put across every state. -->
+<div class="flex h-[calc(100svh-3.5rem)]">
+  <AccountNavRail />
+  {#if status === 'loading'}
+    <div class="flex min-w-0 flex-1 items-center justify-center text-sm text-muted-foreground">
+      {resuming ? 'Re-opening your tailoring session…' : 'Preparing your tailoring session…'}
+    </div>
+  {:else if status === 'error'}
+    <div class="flex min-w-0 flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+      <p class="max-w-md text-sm text-destructive">{errorMsg}</p>
+      <a href={`/match/${slug}`} class="text-sm text-brand hover:underline">Back to the fit analysis</a>
+    </div>
+  {:else}
+    <div class="flex min-w-0 flex-1">
+      <AssistantChat
+        session={sessionId}
+        kickoff={resuming ? undefined : kickoff}
+        {sessionLabel}
+        showSessionRail={false}
+        onTurnComplete={() => (refreshKey += 1)}
+      />
+      <ArtifactPanel {cvId} job={job!} {analysis} {refreshKey} />
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
Follow-up to #916 / #919. Adds the same left-edge, icon-only account-nav rail to the **Tailor CV workspace** (`/tailor/<slug>`) — the other full-width surface that opts out of the account shell.

- `<AccountNavRail>` is the first flex child, pinned to the left edge.
- Rendered across the workspace's **loading, error, and ready** states, so section navigation is always reachable (even while the tailoring session boots or if it errors).
- Reuses the shared `AccountNavRail` component + `visibleAccountNav`/`isSectionActive` — no new logic.
- Generalises the `account-navigation` spec's "Full-width surface navigation rail" requirement to cover both the Agent page and the Tailor workspace (+ a Tailor scenario).

## Test Plan
- [x] `npm run check` — 0 errors
- [x] `openspec validate account-navigation` — valid
- [x] Visual-verified in headless Chrome: icon rail at the far-left edge, chat + artifact panel to its right