### PR TITLE
fix(match): stepper checkmark on dark theme, company-first masthead, SSE heartbeat

### DIFF
--- a/internal/handler/job_fit_stream.go
+++ b/internal/handler/job_fit_stream.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
@@ -93,10 +94,41 @@ func (a *API) StreamJobFit(c *fiber.Ctx) error {
 		// is already bounded by the client's per-call timeout.
 		ctx := context.Background()
 		events := 0
+
+		// A long stage (a silent LLM call with no thinking tokens) would let the
+		// connection go quiet long enough for nginx's proxy_read_timeout to sever it
+		// mid-analysis — the client sees a bare "Connection lost". A periodic SSE comment
+		// keeps bytes flowing so the stream survives silent stages. The ticker goroutine
+		// and the stage callback both write to w, so a mutex serializes them (bufio.Writer
+		// is not safe for concurrent use).
+		var mu sync.Mutex
+		stopHeartbeat := make(chan struct{})
+		var heartbeat sync.WaitGroup
+		heartbeat.Add(1)
+		go func() {
+			defer heartbeat.Done()
+			t := time.NewTicker(15 * time.Second)
+			defer t.Stop()
+			for {
+				select {
+				case <-stopHeartbeat:
+					return
+				case <-t.C:
+					mu.Lock()
+					writeComment(w, "keepalive")
+					mu.Unlock()
+				}
+			}
+		}()
+
 		analysis, err := a.jobFit.AnalyzeStream(ctx, input, func(e jobfit.Event) {
 			events++
+			mu.Lock()
 			writeSSE(w, string(e.Kind), e)
+			mu.Unlock()
 		})
+		close(stopHeartbeat)
+		heartbeat.Wait()
 		if err != nil {
 			log.Printf("jobfit: stream FAILED user=%d job=%d dur=%s events=%d: %v", userID, job.ID, time.Since(start).Round(time.Millisecond), events, err)
 			writeSSE(w, "stream_error", map[string]string{"message": "analysis failed"})
@@ -123,6 +155,16 @@ func writeSSE(w *bufio.Writer, event string, data any) {
 		return
 	}
 	if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, blob); err != nil {
+		return
+	}
+	_ = w.Flush()
+}
+
+// writeComment writes an SSE comment line — ignored by EventSource — as a heartbeat that
+// keeps the connection producing bytes through long, silent stages. A write error (client
+// gone) is swallowed, exactly like writeSSE.
+func writeComment(w *bufio.Writer, text string) {
+	if _, err := fmt.Fprintf(w, ": %s\n\n", text); err != nil {
 		return
 	}
 	_ = w.Flush()

--- a/web/src/lib/components/JobFitFull.svelte
+++ b/web/src/lib/components/JobFitFull.svelte
@@ -262,8 +262,8 @@
           {#each stream.stages as st (st.n)}
             <div class="relative z-10 flex flex-1 flex-col items-center gap-2">
               <span
-                class="flex size-8 shrink-0 items-center justify-center rounded-full border bg-card text-sm font-semibold transition-colors
-                {st.state === 'done' ? 'border-brand bg-brand text-brand-foreground' : st.state === 'active' ? 'border-brand text-primary' : 'border-border text-muted-foreground'}"
+                class="flex size-8 shrink-0 items-center justify-center rounded-full border text-sm font-semibold transition-colors
+                {st.state === 'done' ? 'border-brand bg-brand text-brand-foreground' : st.state === 'active' ? 'border-brand bg-card text-primary' : 'border-border bg-card text-muted-foreground'}"
               >
                 {#if st.state === 'done'}<Check class="size-4" />
                 {:else if st.state === 'active'}<Loader class="size-4 animate-spin" />

--- a/web/src/routes/match/[slug]/+page.svelte
+++ b/web/src/routes/match/[slug]/+page.svelte
@@ -38,11 +38,11 @@
       <ArrowLeft class="size-3.5" />Back to role
     </a>
     <div class="flex flex-col gap-2.5 border-b border-border pb-6">
-      <h1 class="text-xl font-bold leading-tight tracking-tight sm:text-2xl">{data.job.title}</h1>
       <div class="flex items-center gap-2">
         <CompanyLogo name={data.job.company} size="size-5" />
         <p class="text-sm text-muted-foreground">{data.job.company}</p>
       </div>
+      <h1 class="text-xl font-bold leading-tight tracking-tight sm:text-2xl">{data.job.title}</h1>
     </div>
   </header>
 


### PR DESCRIPTION
Fixes surfaced on `/match/[slug]` (e.g. the SumUp Senior Backend Engineer role).

## 1. Stepper checkmark invisible on the dark theme
The completed-step circle carried **two** `background-color` utilities — `bg-card` (base class) and `bg-brand` (done state). Equal specificity, so the winner is decided by compiled-CSS order, not `class` order. On the dark theme `bg-card` won, leaving the near-black `text-brand-foreground` checkmark on a dark fill → invisible (the lime border still showed because `border-*` and `bg-*` don't collide). Fix: each state now sets exactly one background utility.

## 2. Masthead order
Lead with the company (logo + name), role title beneath it.

## 3. `Connection lost` on the fit stream — root cause
`Connection lost` is the client's own message for a **transport drop** (`stream_error` never arrived), distinct from the LLM-failure `analysis failed` path. A long, silent LLM stage (no thinking tokens) let the SSE connection go quiet past nginx's `proxy_read_timeout 300s`, which then severed it mid-analysis. Fix: emit a periodic SSE comment (`: keepalive`, every 15s) so bytes keep flowing; a mutex serializes the ticker goroutine and the stage callback (`bufio.Writer` isn't concurrency-safe).

## Verification
- `go build ./...`, `go vet`, `gofmt` — clean
- `svelte-check` — 0 errors
- SSE comment lines (`:`-prefixed) are ignored by `EventSource` and by the integration test's `sseEvents` parser, so clients/tests are unaffected.

Not yet run (needs Docker): `go test -race -tags=integration ./internal/handler/ -run JobFitStream`.