### PR TITLE
fix: cut Sentry noise from client cancellations/bad queries + cap DB pool

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -3,14 +3,29 @@ package database
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+// defaultMaxConns caps each process's pool when the DSN does not set
+// pool_max_conns. pgxpool otherwise defaults to max(4, NumCPU) connections per
+// pool; with the API server and a dozen cron workers each opening a pool on a
+// many-core host, that sum can exhaust Postgres's non-superuser connection slots
+// (FATAL ... reserved for roles with the SUPERUSER attribute, SQLSTATE 53300). A
+// modest per-process cap keeps the fleet's total bounded, and ops can still raise
+// an individual process by adding pool_max_conns to its DATABASE_URL.
+const defaultMaxConns = 10
+
 // Connect creates a Postgres connection pool and verifies it is reachable.
 func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
-	pool, err := pgxpool.New(ctx, dsn)
+	config, err := poolConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {
 		return nil, fmt.Errorf("create pool: %w", err)
 	}
@@ -23,4 +38,17 @@ func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 	}
 
 	return pool, nil
+}
+
+// poolConfig parses the DSN and applies defaultMaxConns unless the DSN sets its
+// own pool_max_conns, so an explicit override always wins.
+func poolConfig(dsn string) (*pgxpool.Config, error) {
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("parse pool config: %w", err)
+	}
+	if !strings.Contains(dsn, "pool_max_conns") {
+		config.MaxConns = defaultMaxConns
+	}
+	return config, nil
 }

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -1,0 +1,27 @@
+package database
+
+import "testing"
+
+// poolConfig must cap MaxConns when the DSN is silent (so the worker fleet can't
+// exhaust Postgres slots) but yield to an explicit pool_max_conns override.
+func TestPoolConfig_MaxConns(t *testing.T) {
+	t.Run("caps to default when DSN omits pool_max_conns", func(t *testing.T) {
+		cfg, err := poolConfig("postgres://u:p@localhost:5432/db")
+		if err != nil {
+			t.Fatalf("poolConfig: %v", err)
+		}
+		if cfg.MaxConns != defaultMaxConns {
+			t.Errorf("MaxConns = %d, want %d", cfg.MaxConns, defaultMaxConns)
+		}
+	})
+
+	t.Run("respects an explicit pool_max_conns", func(t *testing.T) {
+		cfg, err := poolConfig("postgres://u:p@localhost:5432/db?pool_max_conns=30")
+		if err != nil {
+			t.Fatalf("poolConfig: %v", err)
+		}
+		if cfg.MaxConns != 30 {
+			t.Errorf("MaxConns = %d, want 30", cfg.MaxConns)
+		}
+	})
+}

--- a/internal/handler/errors.go
+++ b/internal/handler/errors.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 
 	sentryfiber "github.com/getsentry/sentry-go/fiber"
@@ -8,7 +9,13 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	"github.com/strelov1/freehire/internal/pgerr"
+	"github.com/strelov1/freehire/internal/search"
 )
+
+// statusClientClosedRequest is nginx's non-standard 499: the client went away
+// before the handler finished. There is no one to receive the body, so it is not
+// an application fault — we classify it away from the reported 500s.
+const statusClientClosedRequest = 499
 
 // LocalPanicReported is a c.Locals key set by the server's recover middleware when
 // it unwinds a panic. The sentryfiber middleware has already captured that panic
@@ -54,7 +61,8 @@ func RenderError(c *fiber.Ctx, err error) error {
 
 // classify maps an error to its HTTP status and message and reports whether it is
 // an unexpected fault worth sending to Sentry. Only the fall-through 500 is
-// unexpected; a *fiber.Error and the 404-mapped DB errors are routine.
+// unexpected; a *fiber.Error, the 404-mapped DB errors, a client disconnect, and
+// a malformed search query are all routine.
 func classify(err error) (status int, msg string, report bool) {
 	var fe *fiber.Error
 	switch {
@@ -62,6 +70,17 @@ func classify(err error) (status int, msg string, report bool) {
 		return fe.Code, fe.Message, false
 	case errors.Is(err, pgx.ErrNoRows), pgerr.IsForeignKeyViolation(err):
 		return fiber.StatusNotFound, "not found", false
+	// The client cancelled the request (navigated away, closed the tab). The
+	// cancellation propagates through downstream calls (DB, Meilisearch) as
+	// context.Canceled — not a server fault, and there is no one left to answer.
+	// A server-side timeout (context.DeadlineExceeded) is deliberately NOT matched
+	// here: that is our own deadline firing and is worth reporting.
+	case errors.Is(err, context.Canceled):
+		return statusClientClosedRequest, "client closed request", false
+	// Meilisearch rejected the request as malformed (a 400) — e.g. an unparseable
+	// filter value from client input. That is a bad request, not a fault.
+	case errors.Is(err, search.ErrBadQuery):
+		return fiber.StatusBadRequest, "invalid search query", false
 	default:
 		return fiber.StatusInternalServerError, "internal server error", true
 	}

--- a/internal/handler/errors_test.go
+++ b/internal/handler/errors_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"sync"
 	"testing"
@@ -13,6 +14,8 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/strelov1/freehire/internal/search"
 )
 
 // recordingTransport captures the events a Sentry hub would deliver, so a test can
@@ -147,6 +150,10 @@ func TestClassify_ReportsOnlyUnexpected500(t *testing.T) {
 		{"fiber 4xx is routine", fiber.NewError(fiber.StatusBadRequest, "bad"), fiber.StatusBadRequest, false},
 		{"no rows maps to 404", pgx.ErrNoRows, fiber.StatusNotFound, false},
 		{"foreign-key violation maps to 404", &pgconn.PgError{Code: "23503"}, fiber.StatusNotFound, false},
+		{"client disconnect is not a fault", context.Canceled, statusClientClosedRequest, false},
+		{"wrapped client disconnect still 499", fmt.Errorf("search: query: %w", context.Canceled), statusClientClosedRequest, false},
+		{"malformed search query maps to 400", fmt.Errorf("search: query: %w: bad filter", search.ErrBadQuery), fiber.StatusBadRequest, false},
+		{"server-side timeout is still reported", context.DeadlineExceeded, fiber.StatusInternalServerError, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/search/client.go
+++ b/internal/search/client.go
@@ -489,6 +489,20 @@ type SearchResult struct {
 	Total int64
 }
 
+// ErrBadQuery marks a search request Meilisearch rejected as malformed — a 400,
+// e.g. an unparseable filter value passed through from client input. It is a
+// client mistake, not an engine fault, so handlers map it to 400 and skip Sentry
+// (see internal/handler.classify). Callers match it with errors.Is.
+var ErrBadQuery = errors.New("bad query")
+
+// isBadRequest reports whether err is a Meilisearch API rejection with a 400
+// status — the engine refusing a malformed query or filter — as opposed to a
+// transport/engine failure. Such rejections are caused by the request itself.
+func isBadRequest(err error) bool {
+	var me *meilisearch.Error
+	return errors.As(err, &me) && me.StatusCode == http.StatusBadRequest
+}
+
 // Search runs a query against the jobs index and decodes the hits.
 func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, error) {
 	req := &meilisearch.SearchRequest{
@@ -518,6 +532,16 @@ func (c *Client) Search(ctx context.Context, p SearchParams) (SearchResult, erro
 
 	resp, err := idx.SearchWithContext(ctx, p.Query, req)
 	if err != nil {
+		// A cancelled/expired context surfaces here wrapped in a Meilisearch
+		// communication error that does NOT chain to context.Canceled (the SDK's
+		// *Error has no Unwrap), so re-raise the context sentinel directly to keep
+		// errors.Is working upstream — a client disconnect must not read as a fault.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return SearchResult{}, fmt.Errorf("search: query: %w", ctxErr)
+		}
+		if isBadRequest(err) {
+			return SearchResult{}, fmt.Errorf("search: query: %w: %v", ErrBadQuery, err)
+		}
 		return SearchResult{}, fmt.Errorf("search: query: %w", err)
 	}
 
@@ -567,6 +591,12 @@ func (c *Client) SimilarJobs(ctx context.Context, id int64, limit int) ([]JobDoc
 			case similarSourceMissingCode, semanticIndexMissingCode:
 				return nil, nil
 			}
+		}
+		// The caller cancelled (navigated away) — the cancellation is buried in the
+		// SDK's communication error, which has no Unwrap, so re-raise the context
+		// sentinel to keep it out of the reported-fault path upstream.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("search: similar: %w", ctxErr)
 		}
 		return nil, fmt.Errorf("search: similar: %w", err)
 	}

--- a/internal/search/errors_test.go
+++ b/internal/search/errors_test.go
@@ -1,0 +1,34 @@
+package search
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/meilisearch/meilisearch-go"
+)
+
+// A 400 from Meilisearch is the engine rejecting a malformed query or filter —
+// the request's fault. isBadRequest must single it out so Search can tag it with
+// ErrBadQuery (which handlers map to 400 and keep out of Sentry), while transport
+// failures and other status codes stay unexpected faults.
+func TestIsBadRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"meili 400 is a bad request", &meilisearch.Error{StatusCode: http.StatusBadRequest}, true},
+		{"wrapped meili 400 is a bad request", fmt.Errorf("search: query: %w", &meilisearch.Error{StatusCode: http.StatusBadRequest}), true},
+		{"meili 500 is not a bad request", &meilisearch.Error{StatusCode: http.StatusInternalServerError}, false},
+		{"non-meili error is not a bad request", errors.New("context canceled"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBadRequest(tt.err); got != tt.want {
+				t.Errorf("isBadRequest = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Triage of the freehire backend Sentry inbox (`telagon/tg-api`). Fixes the two
top error sources plus the connection-slot exhaustion, all client-caused or
config-caused rather than genuine faults.

## Changes

**`fix(search)` — keep routine client failures out of Sentry**
- `context.Canceled` (client navigated away → cancellation propagates to Meili) →
  now 499 "client closed request", not a reported 500. The Meili SDK's `*Error`
  has no `Unwrap`, so `Search`/`SimilarJobs` re-raise `ctx.Err()` to keep
  `errors.Is` working. `context.DeadlineExceeded` (our own timeout) still reports.
- Malformed filter value from client input (Meili 400) → new `search.ErrBadQuery`
  sentinel → 400 "invalid search query", not reported.

**`fix(db)` — cap pgxpool per process**
- `database.Connect` used `pgxpool.New` with no `MaxConns` (defaults to
  `max(4, NumCPU)` per process). API + ~12 cron workers on a many-core host
  exhausted Postgres non-superuser slots (SQLSTATE 53300). Now caps at 10 unless
  the DSN sets `pool_max_conns`.

## Sentry issues addressed
| Issue | Was | This PR |
|---|---|---|
| TG-API-3 | `context canceled` (~914 ev) | no longer reported |
| TG-API-8 | Meili 400 bad `cities` filter | 400, not reported |
| TG-API-5 | conn-slot exhaustion (245 ev) | pool capped |

Already resolved out-of-band (no code): TG-API-4 (stale migration), TG-API-6
(transient EOF), TG-API-7 (prod table ownership, fixed on host-2 2026-07-17).

## Tests
`go test ./internal/handler/ ./internal/search/ ./internal/database/` — added
table cases for `classify` (cancel/bad-query/deadline), `isBadRequest`, and
`poolConfig` cap/override.