### PR TITLE
perf(companies): trigram indexes for name/slug search

### DIFF
--- a/migrations/0033_companies_name_trgm_idx.sql
+++ b/migrations/0033_companies_name_trgm_idx.sql
@@ -1,0 +1,26 @@
+-- Trigram indexes backing the /companies name search (ListCompanies/CountCompanies).
+-- The search predicate is `name ILIKE '%q%' OR slug ILIKE '%q%'` — a leading-wildcard
+-- match, which is non-sargable: no btree can serve it, so the planner falls back to
+-- reading every hiring row (job_count > 0, ~227k of them) out of the 2.3 GB heap and
+-- applying the ILIKE per row. Measured cold that is ~14 s per keystroke (EXPLAIN showed
+-- a parallel bitmap heap scan, ~546 MB read, work_mem-lossy bitmap), and CountCompanies
+-- runs the same predicate again for the page total.
+--
+-- pg_trgm's gin_trgm_ops indexes each string's trigrams, so `ILIKE '%q%'` becomes a GIN
+-- lookup that returns only the matching rows (hundreds) instead of scanning all 227k.
+-- Two single-column indexes let the planner BitmapOr the name/slug arms of the OR.
+--
+-- Applied to a fresh volume by initdb after 0032. On the live prod volume the extension
+-- and both indexes were built out of band — a plain CREATE INDEX would lock the live
+-- companies table (workers upsert into it), so each index went in CONCURRENTLY, which
+-- cannot run inside a transaction:
+--   CREATE EXTENSION IF NOT EXISTS pg_trgm;
+--   CREATE INDEX CONCURRENTLY companies_name_trgm_idx ON public.companies USING gin (name gin_trgm_ops);
+--   CREATE INDEX CONCURRENTLY companies_slug_trgm_idx ON public.companies USING gin (slug gin_trgm_ops);
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS companies_name_trgm_idx
+    ON public.companies USING gin (name gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS companies_slug_trgm_idx
+    ON public.companies USING gin (slug gin_trgm_ops);


### PR DESCRIPTION
## What

Adds `pg_trgm` `gin_trgm_ops` indexes on `companies.name` and `companies.slug` (migration `0033`), backing the `/companies` name search.

## Why

The search predicate `name ILIKE '%q%' OR slug ILIKE '%q%'` is non-sargable — the leading wildcard means no btree can serve it, so the planner reads every hiring row (`job_count > 0`, ~227k of them) out of the 2.3 GB heap and applies the `ILIKE` per row. Both `ListCompanies` and `CountCompanies` run this same predicate per keystroke.

Measured on prod with `EXPLAIN (ANALYZE, BUFFERS)` for `search='data'`:

| | Execution time | Plan |
|---|---|---|
| Before | **13 930 ms** | Parallel bitmap heap scan over 227k rows, ~546 MB read, work_mem-lossy bitmap |
| After | **53 ms** | `BitmapOr` of the two trgm indexes → 473 heap blocks, `job_count > 0` demoted to a cheap post-filter |

~260× faster.

## Prod state

The extension and both indexes were already built on the live prod DB out of band, `CONCURRENTLY` (a plain `CREATE INDEX` would lock the `companies` table while workers upsert into it). This migration file exists so a fresh initdb volume comes up with the same indexes; the `CONCURRENTLY` commands are recorded in the file's comment.

No deploy needed for the speedup — it is already live.