### PR TITLE
feat(profile): caption the Market coverage filters sidebar

### DIFF
--- a/web/src/lib/components/filters/FilterSummary.svelte
+++ b/web/src/lib/components/filters/FilterSummary.svelte
@@ -11,7 +11,7 @@
   // save-then-alert control (Save filter → get it in Telegram) sits under the
   // All-filters button on the standalone list (`canSave`); the modal's "My filters"
   // tab drives the same control.
-  let { store, exclude = [], onOpen, canSave = false }: { store: FilterStore; exclude?: string[]; onOpen: () => void; canSave?: boolean } = $props();
+  let { store, exclude = [], onOpen, canSave = false, description }: { store: FilterStore; exclude?: string[]; onOpen: () => void; canSave?: boolean; description?: string } = $props();
 
   // The current filters as the saved-search / alert target (view-only sort dropped).
   const current = $derived(savedSearchQuery(store.value));
@@ -74,7 +74,7 @@
   });
 </script>
 
-<FilterSummaryShell {groups} active={store.active} onReset={() => store.clear()} {onOpen}>
+<FilterSummaryShell {groups} active={store.active} onReset={() => store.clear()} {onOpen} {description}>
   {#snippet afterButton()}
     {#if canSave}
       <SaveSearchAlert query={current} variant="full" />

--- a/web/src/lib/components/filters/FilterSummaryShell.svelte
+++ b/web/src/lib/components/filters/FilterSummaryShell.svelte
@@ -25,12 +25,16 @@
     active,
     onReset,
     onOpen,
+    description,
     afterButton,
   }: {
     groups: SummaryGroup[];
     active: number;
     onReset: () => void;
     onOpen: () => void;
+    /** Optional caption under the "Filters" heading, explaining what refining does in
+     *  this context — the Market coverage tab uses it; other summaries omit it. */
+    description?: string;
     /** Optional content under the All-filters button — the job summary uses it for the
      *  "Save filter" affordance; the company summary omits it. */
     afterButton?: Snippet;
@@ -38,10 +42,15 @@
 </script>
 
 <div class="flex flex-col gap-4">
-  <div class="flex items-center justify-between">
-    <h2 class="text-base font-semibold tracking-tight">Filters</h2>
-    {#if active > 0}
-      <button type="button" class="text-xs text-muted-foreground transition-colors hover:text-foreground" onclick={onReset}>Reset all</button>
+  <div class="flex flex-col gap-1">
+    <div class="flex items-center justify-between">
+      <h2 class="text-base font-semibold tracking-tight">Filters</h2>
+      {#if active > 0}
+        <button type="button" class="text-xs text-muted-foreground transition-colors hover:text-foreground" onclick={onReset}>Reset all</button>
+      {/if}
+    </div>
+    {#if description}
+      <p class="text-xs text-muted-foreground">{description}</p>
     {/if}
   </div>
 

--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -322,7 +322,12 @@
         <aside class="hidden w-72 shrink-0 md:block">
           <div class="sticky top-6 flex max-h-[calc(100vh-5rem)] flex-col gap-4 overflow-y-auto">
             <div class="rounded-xl border border-border bg-card p-4">
-              <FilterSummary store={filters} exclude={excludeFacets} onOpen={() => (modalOpen = true)} />
+              <FilterSummary
+                store={filters}
+                exclude={excludeFacets}
+                onOpen={() => (modalOpen = true)}
+                description="Narrow the market to see how it reshapes your CV — pick roles, regions and seniority to compare against."
+              />
             </div>
           </div>
         </aside>


### PR DESCRIPTION
## What

Adds a short caption under the **Filters** heading on the profile's **Market coverage** tab, explaining what refining the filters does:

> Narrow the market to see how it reshapes your CV — pick roles, regions and seniority to compare against.

## Why

The Filters sidebar had no context — it wasn't obvious that refining changes the pool of vacancies the CV coverage is measured against.

## How

- `FilterSummaryShell` gains an optional `description?: string` prop, rendered as a muted caption under the heading.
- `FilterSummary` passes it through.
- Only the profile page (`tab === 'coverage'`) sets the text — the jobs list, analytics, and companies summaries are unchanged (opt-in, defaults to `undefined`).

## Verify

`svelte-check` — 0 errors.