### PR TITLE
feat(assistant): freehire tool calls as intent labels, not raw shell

### DIFF
--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -36,6 +36,8 @@
     isExpandable,
     callLine,
     bashCommand,
+    commandLine,
+    isFreehireGroup,
     nonEmptyInput,
     previewToolInput,
     type ToolCall,
@@ -806,7 +808,13 @@
                         <ChevronRight class="chev size-3.5 shrink-0 transition-transform" />
                       </span>
                     </summary>
-                    {#if g.family === 'bash'}
+                    {#if g.family === 'bash' && isFreehireGroup(g.calls)}
+                      <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
+                        {#each g.calls as c, ci (ci)}
+                          <li>{commandLine(c.input)}</li>
+                        {/each}
+                      </ul>
+                    {:else if g.family === 'bash'}
                       <div class="mt-2 overflow-hidden rounded-md border border-border bg-background">
                         <div class="border-b border-border bg-muted/40 px-3 py-1.5 text-[0.65rem] font-medium uppercase tracking-wider text-muted-foreground/80">
                           Shell

--- a/web/src/lib/assistant/tool-formatters.test.ts
+++ b/web/src/lib/assistant/tool-formatters.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyFamily,
+  freehireLabel,
+  isFreehireGroup,
+  commandLine,
+  groupTitle,
+  isExpandable,
+  bashCommand,
+} from './tool-formatters';
+
+describe('tool-formatters — freehire intent labels', () => {
+  it('groups the Terminal tool with bash', () => {
+    expect(classifyFamily('Terminal')).toBe('bash');
+    expect(classifyFamily('Bash')).toBe('bash');
+    expect(classifyFamily('Read')).toBe('fs');
+  });
+
+  it('maps freehire subcommands to friendly labels (longest path wins)', () => {
+    expect(freehireLabel('freehire cv context 12')).toBe('Reading the fit analysis');
+    expect(freehireLabel('freehire cv get 12')).toBe('Reading your CV');
+    expect(freehireLabel('freehire cv edit 12 --patch x')).toBe('Updating your CV');
+    expect(freehireLabel('freehire search golang --json')).toBe('Searching jobs');
+    expect(freehireLabel('freehire whatever-new-cmd')).toBe('Working with freehire');
+    expect(freehireLabel('printenv')).toBeNull();
+    expect(freehireLabel('ls -la')).toBeNull();
+  });
+
+  it('reads the command from command/cmd, an argv array, or a bare string', () => {
+    expect(bashCommand({ command: 'freehire cv get 1' })).toBe('freehire cv get 1');
+    expect(bashCommand({ args: ['freehire', 'cv', 'get', '1'] })).toBe('freehire cv get 1');
+    expect(bashCommand('freehire facets')).toBe('freehire facets');
+    expect(bashCommand({})).toBeNull();
+  });
+
+  it('titles a freehire group with distinct intent labels, not the raw command', () => {
+    const calls = [
+      { name: 'Terminal', input: { command: 'freehire cv context 12' } },
+      { name: 'Terminal', input: { command: 'freehire cv get 12' } },
+    ];
+    expect(isFreehireGroup(calls)).toBe(true);
+    const title = groupTitle('bash', calls);
+    expect(title).toBe('Reading the fit analysis · Reading your CV');
+    expect(title).not.toContain('freehire');
+    expect(title).not.toContain('$');
+  });
+
+  it('caps a long freehire group title', () => {
+    const calls = [
+      { name: 'Terminal', input: { command: 'freehire cv context 1' } },
+      { name: 'Terminal', input: { command: 'freehire cv get 1' } },
+      { name: 'Terminal', input: { command: 'freehire search go' } },
+    ];
+    expect(groupTitle('bash', calls)).toBe('Reading the fit analysis · Reading your CV · +1');
+  });
+
+  it('a single freehire call is a flat chip (not expandable) and hides the command', () => {
+    const calls = [{ name: 'Terminal', input: { command: 'freehire cv get 12' } }];
+    expect(groupTitle('bash', calls)).toBe('Reading your CV');
+    expect(isExpandable('bash', calls)).toBe(false);
+  });
+
+  it('non-freehire shell commands keep the raw shell rendering', () => {
+    const calls = [{ name: 'Bash', input: { command: 'ls -la' } }];
+    expect(isFreehireGroup(calls)).toBe(false);
+    expect(groupTitle('bash', calls)).toBe('Ran ls -la');
+    expect(commandLine({ command: 'ls -la' })).toBe('$ ls -la');
+    expect(commandLine({ command: 'freehire cv get 1' })).toBe('Reading your CV');
+  });
+});

--- a/web/src/lib/assistant/tool-formatters.ts
+++ b/web/src/lib/assistant/tool-formatters.ts
@@ -20,9 +20,56 @@ function truncate(s: string, n: number): string {
 const FS_TOOLS = new Set(['Read', 'Glob', 'Grep', 'LS']);
 
 export function classifyFamily(name: string): ToolFamily {
-  if (name === 'Bash') return 'bash';
+  // The assistant runs the `freehire` CLI through the harness shell tool, which
+  // the ACP layer surfaces as `Terminal` (Claude Code) — group it with `Bash`.
+  if (name === 'Bash' || name === 'Terminal') return 'bash';
   if (FS_TOOLS.has(name)) return 'fs';
   return 'other';
+}
+
+// Map a `freehire <subcommand>` invocation to a neutral, human-readable label so
+// the transcript reads as intent ("Reading your CV") rather than a raw shell line
+// — the assistant's only shell tool is the freehire CLI. Longest sub-command path
+// wins (e.g. `cv context` before `cv`).
+const FREEHIRE_LABELS: Record<string, string> = {
+  'cv context': 'Reading the fit analysis',
+  'cv get': 'Reading your CV',
+  'cv edit': 'Updating your CV',
+  'cv render': 'Rendering your CV',
+  search: 'Searching jobs',
+  job: 'Reading a job posting',
+  company: 'Reading a company',
+  facets: 'Loading filters',
+  'market-fit': 'Analyzing market fit',
+};
+
+/** Friendly label for a `freehire …` command, or `null` if it is not one. */
+export function freehireLabel(command: string): string | null {
+  const parts = command.trim().split(/\s+/);
+  if (parts[0] !== 'freehire') return null;
+  const two = parts.slice(1, 3).join(' ');
+  const one = parts[1] ?? '';
+  return FREEHIRE_LABELS[two] ?? FREEHIRE_LABELS[one] ?? 'Working with freehire';
+}
+
+/** True when every call in the group is a `freehire` command — render as intent
+ *  labels with no shell chrome, and never surface the raw command. */
+export function isFreehireGroup(calls: readonly ToolCall[]): boolean {
+  return (
+    calls.length > 0 &&
+    calls.every((c) => {
+      const cmd = bashCommand(c.input);
+      return cmd != null && freehireLabel(cmd) != null;
+    })
+  );
+}
+
+/** One expanded line for a shell/terminal call: the friendly `freehire` label, or
+ *  `$ <command>` for any other command. */
+export function commandLine(input: unknown): string {
+  const cmd = bashCommand(input);
+  if (!cmd) return 'Command';
+  return freehireLabel(cmd) ?? `$ ${cmd}`;
 }
 
 /** Title shown in the collapsed header. */
@@ -30,6 +77,15 @@ export function groupTitle(family: ToolFamily, calls: readonly ToolCall[]): stri
   const first = calls[0];
   if (!first) return '';
   if (family === 'bash') {
+    if (isFreehireGroup(calls)) {
+      // Collapse to the distinct intent labels ("Reading the fit analysis ·
+      // Reading your CV"), capped so the header stays short.
+      const distinct = [
+        ...new Set(calls.map((c) => freehireLabel(bashCommand(c.input) ?? '') as string)),
+      ];
+      if (distinct.length <= 2) return distinct.join(' · ');
+      return `${distinct.slice(0, 2).join(' · ')} · +${distinct.length - 2}`;
+    }
     if (calls.length === 1) {
       const cmd = bashCommand(first.input);
       return cmd ? `Ran ${shortenCommand(cmd)}` : 'Ran command';
@@ -78,7 +134,18 @@ export function callLine(call: ToolCall): string {
 }
 
 export function bashCommand(input: unknown): string | null {
-  return readField(input, 'command', 'cmd');
+  if (typeof input === 'string') return input.length > 0 ? input : null;
+  const cmd = readField(input, 'command', 'cmd');
+  if (cmd) return cmd;
+  // ACP terminal calls may carry argv instead of a single command string.
+  if (input && typeof input === 'object') {
+    const args = (input as Record<string, unknown>).args;
+    if (Array.isArray(args)) {
+      const parts = args.filter((a): a is string => typeof a === 'string');
+      if (parts.length > 0) return parts.join(' ');
+    }
+  }
+  return null;
 }
 
 export function nonEmptyInput(input: unknown): boolean {
@@ -98,7 +165,11 @@ export function previewToolInput(input: unknown): string {
 /** Whether the group's body adds anything beyond its title — used to decide
  *  between a flat chip and an expandable `<details>` in the renderer. */
 export function isExpandable(family: ToolFamily, calls: readonly ToolCall[]): boolean {
-  if (family === 'bash') return true;
+  if (family === 'bash') {
+    // A single freehire call is fully described by its intent label — flat chip.
+    if (isFreehireGroup(calls) && calls.length === 1) return false;
+    return true;
+  }
   if (family === 'fs') return calls.length > 1;
   return calls.some((c) => nonEmptyInput(c.input));
 }


### PR DESCRIPTION
The tailor/assistant chat showed the harness shell tool as **"Called Terminal × N"** with the raw `freehire cv context 12` command exposed. Since the assistant's only shell tool is the freehire CLI, map each call to a neutral intent label:

- `freehire cv context` → *Reading the fit analysis*
- `freehire cv get` → *Reading your CV*
- `freehire cv edit` → *Updating your CV*
- `freehire search` → *Searching jobs*, etc.

Groups `Terminal` with bash, hides the raw command, renders a single call as a flat chip and a multi-call group as distinct intent labels. Non-freehire shell commands keep the raw `$ …` rendering. Pure-logic, vitest-covered (7 tests); svelte-check clean.