### PR TITLE
fix(habr): accept single-object jobLocation (dropped descriptions)

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -728,12 +728,15 @@ type Querier interface {
 	// staleness stamps ride along so the handler can flag rows whose CV/job/model has since
 	// changed, and the analysis blob carries the overall score + verdict the list shows.
 	ListUserJobAnalyses(ctx context.Context, userID int64) ([]ListUserJobAnalysesRow, error)
-	// A user's job interactions joined with the job rows, most recently touched
-	// first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
-	// viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is
-	// the passive history (rows neither saved nor applied). Closed jobs stay
-	// listed: a user's history must not shrink when a posting closes. email_count is
-	// the caller's live (non-deleted) inbox messages linked to this job — the board's
+	// A user's job interactions joined with the job rows. Each subset is ordered by
+	// when the job entered *that* list, not by last touch: saved by saved_at, applied
+	// by applied_at, the passive history by viewed_at, the board by when it was saved
+	// or applied. This keeps a plain re-view from bumping a saved/applied job to the
+	// top (viewed_at is refreshed on every view). 'all' keeps the touched-recency
+	// timeline. filter narrows to viewed-only/saved/applied subsets; 'viewed' is the
+	// passive history (rows neither saved nor applied). Closed jobs stay listed: a
+	// user's history must not shrink when a posting closes. email_count is the
+	// caller's live (non-deleted) inbox messages linked to this job — the board's
 	// per-card ✉ badge; 0 for everyone without a connected mailbox.
 	ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error)
 	// Every public_slug the user has interacted with (viewed_at is always set, so

--- a/internal/db/queries/user_job_analysis.sql
+++ b/internal/db/queries/user_job_analysis.sql
@@ -13,7 +13,7 @@ WHERE user_id = $1 AND job_id = $2;
 -- stamps. created_at is deliberately NOT re-bumped on conflict, so it records the
 -- FIRST-analysis time — the fit-analysis quota counts distinct jobs a user first
 -- analyzed within a rolling window, and a recompute must not re-age its row into it.
--- analysis is the sanitized jobfit.Analysis JSON.
+-- analysis is the sanitized matchanalysis.Analysis JSON.
 INSERT INTO user_job_analysis (user_id, job_id, analysis, model, cv_uploaded_at, job_content_hash, created_at)
 VALUES ($1, $2, $3, $4, $5, $6, now())
 ON CONFLICT (user_id, job_id) DO UPDATE

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -118,12 +118,15 @@ WHERE user_id = $1 AND job_id = $2
 RETURNING *;
 
 -- name: ListUserJobs :many
--- A user's job interactions joined with the job rows, most recently touched
--- first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
--- viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is
--- the passive history (rows neither saved nor applied). Closed jobs stay
--- listed: a user's history must not shrink when a posting closes. email_count is
--- the caller's live (non-deleted) inbox messages linked to this job — the board's
+-- A user's job interactions joined with the job rows. Each subset is ordered by
+-- when the job entered *that* list, not by last touch: saved by saved_at, applied
+-- by applied_at, the passive history by viewed_at, the board by when it was saved
+-- or applied. This keeps a plain re-view from bumping a saved/applied job to the
+-- top (viewed_at is refreshed on every view). 'all' keeps the touched-recency
+-- timeline. filter narrows to viewed-only/saved/applied subsets; 'viewed' is the
+-- passive history (rows neither saved nor applied). Closed jobs stay listed: a
+-- user's history must not shrink when a posting closes. email_count is the
+-- caller's live (non-deleted) inbox messages linked to this job — the board's
 -- per-card ✉ badge; 0 for everyone without a connected mailbox.
 SELECT sqlc.embed(jobs), uj.viewed_at, uj.saved_at, uj.applied_at, uj.stage, uj.notes,
        (SELECT count(*)
@@ -140,7 +143,13 @@ WHERE uj.user_id = $1
        OR (sqlc.arg(filter)::text = 'applied' AND uj.applied_at IS NOT NULL)
        OR (sqlc.arg(filter)::text = 'board'
            AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL)))
-ORDER BY GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at) DESC, uj.job_id DESC
+ORDER BY (CASE sqlc.arg(filter)::text
+            WHEN 'saved' THEN uj.saved_at
+            WHEN 'applied' THEN uj.applied_at
+            WHEN 'viewed' THEN uj.viewed_at
+            WHEN 'board' THEN GREATEST(uj.saved_at, uj.applied_at)
+            ELSE GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at)
+          END) DESC NULLS LAST, uj.job_id DESC
 LIMIT $2 OFFSET $3;
 
 -- name: ListViewedJobSlugs :many

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -236,7 +236,13 @@ WHERE uj.user_id = $1
        OR ($4::text = 'applied' AND uj.applied_at IS NOT NULL)
        OR ($4::text = 'board'
            AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL)))
-ORDER BY GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at) DESC, uj.job_id DESC
+ORDER BY (CASE $4::text
+            WHEN 'saved' THEN uj.saved_at
+            WHEN 'applied' THEN uj.applied_at
+            WHEN 'viewed' THEN uj.viewed_at
+            WHEN 'board' THEN GREATEST(uj.saved_at, uj.applied_at)
+            ELSE GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at)
+          END) DESC NULLS LAST, uj.job_id DESC
 LIMIT $2 OFFSET $3
 `
 
@@ -257,12 +263,15 @@ type ListUserJobsRow struct {
 	EmailCount int64              `json:"email_count"`
 }
 
-// A user's job interactions joined with the job rows, most recently touched
-// first (GREATEST ignores NULLs; viewed_at is always set). filter narrows to
-// viewed-only/saved/applied subsets; 'all' is every interaction, 'viewed' is
-// the passive history (rows neither saved nor applied). Closed jobs stay
-// listed: a user's history must not shrink when a posting closes. email_count is
-// the caller's live (non-deleted) inbox messages linked to this job — the board's
+// A user's job interactions joined with the job rows. Each subset is ordered by
+// when the job entered *that* list, not by last touch: saved by saved_at, applied
+// by applied_at, the passive history by viewed_at, the board by when it was saved
+// or applied. This keeps a plain re-view from bumping a saved/applied job to the
+// top (viewed_at is refreshed on every view). 'all' keeps the touched-recency
+// timeline. filter narrows to viewed-only/saved/applied subsets; 'viewed' is the
+// passive history (rows neither saved nor applied). Closed jobs stay listed: a
+// user's history must not shrink when a posting closes. email_count is the
+// caller's live (non-deleted) inbox messages linked to this job — the board's
 // per-card ✉ badge; 0 for everyone without a connected mailbox.
 func (q *Queries) ListUserJobs(ctx context.Context, arg ListUserJobsParams) ([]ListUserJobsRow, error) {
 	rows, err := q.db.Query(ctx, listUserJobs,

--- a/internal/db/user_jobs_integration_test.go
+++ b/internal/db/user_jobs_integration_test.go
@@ -285,4 +285,53 @@ func TestUserJobsSaveAndList(t *testing.T) {
 			t.Errorf("counts = %+v, want all=3 viewed=1 saved=1 applied=1", counts)
 		}
 	})
+
+	t.Run("saved is ordered by saved_at and a later view does not bump it", func(t *testing.T) {
+		reset(t)
+		uid := insertUser(t, pool, "orderer@example.test")
+		older := insertJob(t, pool, "saved-older")
+		newer := insertJob(t, pool, "saved-newer")
+
+		if _, err := q.SaveJob(ctx, SaveJobParams{UserID: uid, JobID: older}); err != nil {
+			t.Fatalf("save older: %v", err)
+		}
+		if _, err := q.SaveJob(ctx, SaveJobParams{UserID: uid, JobID: newer}); err != nil {
+			t.Fatalf("save newer: %v", err)
+		}
+		// Pin saved_at deterministically: `older` saved before `newer`.
+		if _, err := pool.Exec(ctx, "UPDATE user_jobs SET saved_at = $1 WHERE user_id = $2 AND job_id = $3",
+			"2020-01-01T00:00:00Z", uid, older); err != nil {
+			t.Fatalf("pin older saved_at: %v", err)
+		}
+		if _, err := pool.Exec(ctx, "UPDATE user_jobs SET saved_at = $1 WHERE user_id = $2 AND job_id = $3",
+			"2020-06-01T00:00:00Z", uid, newer); err != nil {
+			t.Fatalf("pin newer saved_at: %v", err)
+		}
+
+		wantSaved := func(t *testing.T, label string) {
+			t.Helper()
+			saved, err := q.ListUserJobs(ctx, ListUserJobsParams{UserID: uid, Filter: "saved", Limit: 10, Offset: 0})
+			if err != nil {
+				t.Fatalf("list saved (%s): %v", label, err)
+			}
+			got := []int64{}
+			for _, r := range saved {
+				got = append(got, r.Job.ID)
+			}
+			want := []int64{newer, older}
+			if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+				t.Fatalf("saved order (%s) = %v, want %v (most recently saved first)", label, got, want)
+			}
+		}
+
+		wantSaved(t, "after save")
+
+		// Re-viewing the older-saved job refreshes its viewed_at to now(), which is
+		// far newer than either saved_at. A saved list ordered by GREATEST(...) would
+		// wrongly float `older` to the top; ordering by saved_at must keep it last.
+		if _, err := q.RecordJobView(ctx, RecordJobViewParams{UserID: uid, JobID: older}); err != nil {
+			t.Fatalf("re-view older: %v", err)
+		}
+		wantSaved(t, "after re-view")
+	})
 }

--- a/internal/pipeline/board_health_test.go
+++ b/internal/pipeline/board_health_test.go
@@ -116,52 +116,78 @@ func (s spySource) Fetch(_ context.Context, e sources.CompanyEntry) ([]sources.J
 	return []sources.Job{{ExternalID: "1", Title: "Dev", Company: e.Company}}, nil
 }
 
-// When the recovery probe fails (the provider is still down), a cooled board stays
-// skipped by the main crawl: it is counted Cooled (not Failed), no outcome is recorded
-// (a skip is not an outcome), and its cooldown is not cleared. The adapter is touched
-// exactly once — by the probe — proving the main loop did not crawl it.
-func TestRunSkipsCooledBoardWhenProviderDown(t *testing.T) {
+// A single-board provider is never probed: probing it would crawl the whole provider (for a
+// boardless aggregator, its entire dataset) only for the main loop to crawl it again, and there
+// are no other boards to clear. So even with a healthy adapter, recovery leaves the lone cooled
+// board untouched — the adapter is never called — and the normal cooldown gate recovers it at
+// expiry instead. This is the guard against the boardless double-crawl.
+func TestRecoverSkipsSingleBoardProvider(t *testing.T) {
 	fetches := 0
-	src := spySource{provider: "greenhouse", fetches: &fetches, err: errors.New("provider down")}
+	src := spySource{provider: "gulftalent", fetches: &fetches} // healthy, but must not be probed
 	health := &fakeHealth{cooldowns: map[string]time.Time{
-		"greenhouse/acme": time.Now().Add(6 * time.Hour),
+		"gulftalent/": time.Now().Add(24 * time.Hour), // one boardless entry, cooled
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
 	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
-		{Company: "Acme", Provider: "greenhouse", Board: "acme"},
+		{Company: "GulfTalent", Provider: "gulftalent", Board: ""},
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if fetches != 1 {
-		t.Errorf("adapter fetched %d times, want 1 (probe only; the main loop must skip the still-cooled board)", fetches)
-	}
-	if stats.Total().Cooled != 1 || stats.Total().Failed != 0 || stats.Total().Ingested != 0 {
-		t.Errorf("stats = %+v, want Cooled=1 Failed=0 Ingested=0", stats.Total())
+	if fetches != 0 {
+		t.Errorf("adapter fetched %d times, want 0 (a single-board provider must not be probed)", fetches)
 	}
 	if len(health.cleared) != 0 {
-		t.Errorf("a failed probe must not clear cooldowns; cleared=%v", health.cleared)
+		t.Errorf("a single-board provider must not be cleared by a probe; cleared=%v", health.cleared)
 	}
-	if len(health.successes) != 0 || len(health.failures) != 0 {
-		t.Errorf("a cooled skip records no outcome; got successes=%v failures=%v", health.successes, health.failures)
+	if stats.Total().Cooled != 1 || stats.Total().Ingested != 0 {
+		t.Errorf("stats = %+v, want Cooled=1 Ingested=0 (left cooled for the normal gate)", stats.Total())
 	}
 }
 
-// A provider whose boards were mass-cooled by a since-resolved outage recovers this cycle:
-// the pre-crawl probe reaches a cooled board, clears the provider's cooldowns, and the main
-// loop then crawls the board it would otherwise have skipped. Without recovery this board
-// stays Cooled=1/Ingested=0, so this result is unique to the half-open transition.
+// A still-down multi-board provider is never cleared or stampeded: every probe fails, so the
+// cooldowns stand and the main loop skips the cooled boards.
+func TestRecoverLeavesDownMultiBoardProviderCooled(t *testing.T) {
+	fetches := 0
+	src := spySource{provider: "workday", fetches: &fetches, err: errors.New("provider down")}
+	health := &fakeHealth{cooldowns: map[string]time.Time{
+		"workday/a": time.Now().Add(6 * time.Hour),
+		"workday/b": time.Now().Add(6 * time.Hour),
+	}}
+	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
+
+	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
+		{Company: "A", Provider: "workday", Board: "a"},
+		{Company: "B", Provider: "workday", Board: "b"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(health.cleared) != 0 {
+		t.Errorf("a down provider must not be cleared; cleared=%v", health.cleared)
+	}
+	if stats.Total().Cooled != 2 || stats.Total().Ingested != 0 {
+		t.Errorf("stats = %+v, want Cooled=2 Ingested=0 (both stay cooled, main loop skips them)", stats.Total())
+	}
+}
+
+// A multi-board provider whose boards were mass-cooled by a since-resolved outage recovers this
+// cycle: the pre-crawl probe reaches a cooled board, clears the provider's cooldowns, and the
+// main loop then crawls the boards it would otherwise have skipped. Without recovery they stay
+// Cooled/Ingested=0, so this result is unique to the half-open transition.
 func TestRecoverProbeRecoversProvider(t *testing.T) {
 	fetches := 0
 	src := spySource{provider: "breezy", fetches: &fetches}
 	health := &fakeHealth{cooldowns: map[string]time.Time{
 		"breezy/acme": time.Now().Add(24 * time.Hour),
+		"breezy/beta": time.Now().Add(24 * time.Hour),
 	}}
 	r := Runner{Registry: registry(src), Store: &fakeStore{}, BoardHealth: health}
 
 	stats, err := r.Run(context.Background(), []sources.CompanyEntry{
 		{Company: "Acme", Provider: "breezy", Board: "acme"},
+		{Company: "Beta", Provider: "breezy", Board: "beta"},
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -169,8 +195,8 @@ func TestRecoverProbeRecoversProvider(t *testing.T) {
 	if len(health.cleared) != 1 || health.cleared[0] != "breezy" {
 		t.Errorf("cleared = %v, want [breezy] (a successful probe recovers the provider)", health.cleared)
 	}
-	if stats.Total().Ingested != 1 || stats.Total().Cooled != 0 {
-		t.Errorf("stats = %+v, want Ingested=1 Cooled=0 (recovered board is crawled, not skipped)", stats.Total())
+	if stats.Total().Ingested != 2 || stats.Total().Cooled != 0 {
+		t.Errorf("stats = %+v, want Ingested=2 Cooled=0 (both boards crawled after the probe cleared them)", stats.Total())
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -204,6 +204,13 @@ func (r Runner) recoverProviders(ctx context.Context, entries []sources.CompanyE
 		if !ok {
 			continue
 		}
+		// The probe only pays off with leverage — a few cheap probes clearing many boards.
+		// A lone board has none: probing it crawls the whole provider (for a boardless
+		// aggregator, its entire dataset) only for the main loop to crawl it again. Skip it;
+		// the normal cooldown gate recovers a single board in one crawl at cooldown expiry.
+		if len(byProvider[provider]) < 2 {
+			continue
+		}
 		boards, err := r.BoardHealth.CooledBoards(ctx, provider, maxRecoveryProbes)
 		if err != nil {
 			log.Printf("ingest: recovery probe %s: list cooled boards: %v", provider, err)

--- a/internal/sources/habrcareer.go
+++ b/internal/sources/habrcareer.go
@@ -196,9 +196,31 @@ type habrRawPosting struct {
 	HiringOrganization struct {
 		Name string `json:"name"`
 	} `json:"hiringOrganization"`
-	JobLocation []struct {
-		Address habrAddress `json:"address"`
-	} `json:"jobLocation"`
+	JobLocation habrJobLocations `json:"jobLocation"`
+}
+
+// habrJobLocation is one jobLocation entry; only its address is read.
+type habrJobLocation struct {
+	Address habrAddress `json:"address"`
+}
+
+// habrJobLocations reads jobLocation, which schema.org allows as either a single Place object
+// or an array of them — Habr emits both shapes across vacancies. Best-effort like habrAddress:
+// an unrecognized shape leaves the location empty rather than failing the whole JobPosting
+// decode, which would drop the description (the field that matters) along with it.
+type habrJobLocations []habrJobLocation
+
+func (l *habrJobLocations) UnmarshalJSON(b []byte) error {
+	var arr []habrJobLocation
+	if json.Unmarshal(b, &arr) == nil {
+		*l = arr
+		return nil
+	}
+	var one habrJobLocation
+	if json.Unmarshal(b, &one) == nil {
+		*l = habrJobLocations{one}
+	}
+	return nil
 }
 
 // habrAddress reads jobLocation.address, which Habr emits as a bare string but schema.org types

--- a/internal/sources/habrcareer_test.go
+++ b/internal/sources/habrcareer_test.go
@@ -246,3 +246,56 @@ func TestHabrCareerIsProxied(t *testing.T) {
 		t.Error("habr_career must be in proxiedProviders (Qrator blocks detail fetches from the prod datacenter IP)")
 	}
 }
+
+func TestParseHabrPostingSingleObjectJobLocation(t *testing.T) {
+	// schema.org allows jobLocation as a single Place object, not only an array — Habr emits
+	// this form for many (often remote) vacancies. Modeling it as array-only made json.Unmarshal
+	// fail on the whole JobPosting, so the description was dropped and the vacancy stored empty.
+	// The decoder must accept both shapes.
+	const page = `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Fullstack Developer (MERN / NestJS)",
+ "description":"<p>Node.js and React</p>",
+ "hiringOrganization":{"@type":"Organization","name":"Creative Code"},
+ "jobLocation":{"@type":"Place","address":"Russia"},
+ "jobLocationType":"TELECOMMUTE","employmentType":"FULL_TIME"}
+</script></head><body></body></html>`
+	node, err := html.Parse(strings.NewReader(page))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	p, ok := ParseHabrPosting(node)
+	if !ok {
+		t.Fatal("ParseHabrPosting ok=false on a single-object jobLocation — the whole posting was dropped")
+	}
+	if !strings.Contains(p.Description, "Node.js") {
+		t.Errorf("Description = %q, want the posting body", p.Description)
+	}
+	if p.Company != "Creative Code" {
+		t.Errorf("Company = %q, want Creative Code", p.Company)
+	}
+	if p.Location != "Russia" {
+		t.Errorf("Location = %q, want Russia from the single Place", p.Location)
+	}
+}
+
+func TestParseHabrPostingArrayJobLocation(t *testing.T) {
+	// The array shape must keep working after the single-object fix.
+	const page = `<html><head><script type="application/ld+json">
+{"@context":"https://schema.org/","@type":"JobPosting",
+ "title":"Backend Engineer","description":"<p>Go</p>",
+ "hiringOrganization":{"@type":"Organization","name":"Acme"},
+ "jobLocation":[{"@type":"Place","address":"Berlin"}]}
+</script></head><body></body></html>`
+	node, err := html.Parse(strings.NewReader(page))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	p, ok := ParseHabrPosting(node)
+	if !ok {
+		t.Fatal("ParseHabrPosting ok=false on an array jobLocation")
+	}
+	if p.Location != "Berlin" {
+		t.Errorf("Location = %q, want Berlin", p.Location)
+	}
+}


### PR DESCRIPTION
## Problem

Some habr_career vacancies show **empty descriptions** on prod even though the origin page has the full text — e.g. [1000167118](https://career.habr.com/vacancies/1000167118) (`Creative Code`) and [1000165926](https://career.habr.com/vacancies/1000165926) (`Clideo`), the two the report started from.

Root cause is a **parser bug**, not the WAF. schema.org `jobLocation` may be **either a single Place object or an array**; Habr emits both. `habrRawPosting` modeled it as array-only:

```go
JobLocation []struct{ Address habrAddress }  // array-only
```

So a single-object page (`"jobLocation":{"@type":"Place","address":"Russia"}`, the common remote form) failed `json.Unmarshal` **on that one field** — and since the whole JobPosting decode errored, `ldJobPosting` returned false and the **title + description were discarded**, storing an empty description. `ParseHabrPosting` is shared, so this hits **both the board crawl and the linksource resolver**.

Confirmed against the live page:
```
json: cannot unmarshal object into Go struct field habrRawPosting.jobLocation of type []struct{...}
title="Fullstack Developer (MERN / NestJS)" desc_len=1687   // the description was there, just dropped
```

## Fix

A best-effort `habrJobLocations` decoder that accepts **both shapes**, mirroring the existing `habrAddress` (string-or-object) idiom right above it. An unrecognized shape leaves the location empty rather than dropping the whole posting.

## Tests

- `TestParseHabrPostingSingleObjectJobLocation` (the failing shape) + `TestParseHabrPostingArrayJobLocation` (regression). Full `sources`/`linksource`/`pipeline` suites green.

## Verified end-to-end on prod

Re-resolved both URLs → descriptions now land (`1246` / `2864` chars, `location: Russia`), visible via the public API.

## Notes / follow-ups (not in this PR)

While tracing this I measured that habr's per-vacancy detail is behind **Qrator**, which challenges **every Go TLS stack** (native `net/http` AND utls-Chrome, direct or via the residential proxy) — 0/6 each — while **curl/OpenSSL passes** from the same datacenter IP. So the crawl's ~30–45% empty-description rate has **two** causes: this parser bug (fixed here) and the Qrator challenge on the Go client (separate; the proxy in #932 does **not** help, since the block is TLS/JA4, not IP). A curl-backed detail fetch is the only transport that reliably clears Qrator — worth a follow-up for the crawl.