### PR TITLE
fix(paylocity): read description from server-rendered HTML, not ld+json

### DIFF
--- a/internal/sources/paylocity.go
+++ b/internal/sources/paylocity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"golang.org/x/net/html"
 )
@@ -60,21 +61,28 @@ func (s paylocity) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 }
 
 // detail builds a Job from a listing brief, enriching it with the description from the
-// posting's ld+json detail page. The listing brief is authoritative for the posting's
-// existence and structured fields (id/title/location/date), so a failed detail fetch only
-// costs the description, not the whole posting. ok=false only for a brief with no id (which
-// would collide on the dedup key).
+// posting's detail page. The listing brief is authoritative for the posting's existence and
+// structured fields (id/title/location/date), so a failed detail fetch only costs the
+// description, not the whole posting. ok=false only for a brief with no id (which would
+// collide on the dedup key).
 func (s paylocity) detail(ctx context.Context, e CompanyEntry, b paylocityBrief) (Job, bool) {
 	if b.JobID == 0 {
 		return Job{}, false
 	}
 	detailURL := fmt.Sprintf("%s/Recruiting/Jobs/Details/%d", paylocityBase, b.JobID)
 
-	var p paylocityPosting
 	description, company := "", e.Company
-	if root, err := s.http.GetHTML(ctx, detailURL); err == nil && ldJobPosting(root, &p) {
-		description = sanitizeHTML(html.UnescapeString(p.Description))
-		company = firstNonEmpty(e.Company, p.HiringOrganization.Name)
+	if root, err := s.http.GetHTML(ctx, detailURL); err == nil {
+		description = paylocityDescription(root)
+		if description == "" {
+			// Legacy tenants may still serve the schema.org ld+json the current page dropped.
+			var p paylocityPosting
+			if ldJobPosting(root, &p) {
+				description = html.UnescapeString(p.Description)
+				company = firstNonEmpty(e.Company, p.HiringOrganization.Name)
+			}
+		}
+		description = sanitizeHTML(description)
 	}
 
 	return Job{
@@ -87,6 +95,31 @@ func (s paylocity) detail(ctx context.Context, e CompanyEntry, b paylocityBrief)
 		Remote:      b.IsRemote || isRemote(b.LocationName),
 		PostedAt:    parseRFC3339(b.PublishedDate),
 	}, true
+}
+
+// paylocityDescription extracts the posting body from a detail page. Paylocity's current
+// pages are a client-rendered shell with no ld+json, but the description still renders
+// server-side as the <div> immediately following the "Description" section header
+// (<div class="job-listing-header">Description</div>). Returns "" when the block is absent.
+func paylocityDescription(root *html.Node) string {
+	var out string
+	walk(root, func(n *html.Node) bool {
+		if out != "" {
+			return false
+		}
+		if n.Type == html.ElementNode && n.Data == "div" && hasClass(n, "job-listing-header") &&
+			strings.EqualFold(textContent(n), "Description") {
+			for sib := n.NextSibling; sib != nil; sib = sib.NextSibling {
+				if sib.Type == html.ElementNode {
+					out = strings.TrimSpace(innerHTML(sib))
+					break
+				}
+			}
+			return false
+		}
+		return true
+	})
+	return out
 }
 
 // paylocityBrief is one entry of the listing's window.pageData Jobs[] array.

--- a/internal/sources/paylocity_test.go
+++ b/internal/sources/paylocity_test.go
@@ -15,15 +15,21 @@ const paylocityListingHTML = `<html><body>
 ]};</script>
 </body></html>`
 
-// paylocityDetailHTML is a /Recruiting/Jobs/Details/<id> page: the description we read is the
-// schema.org JobPosting ld+json, whose body embeds a <script> that sanitizeHTML must strip.
-const paylocityDetailHTML = `<html><head>
-<script type="application/ld+json">
-{"@context":"https://schema.org","@type":"JobPosting","title":"Technician Aide",
-"description":"<h2>About</h2><p>Care for animals.</p><script>alert(1)<\/script>",
-"datePosted":"2026-06-29T11:55:56-05:00",
-"hiringOrganization":{"@type":"Organization","name":"Clover Basin Animal Hospital"}}
-</script></head><body></body></html>`
+// paylocityDetailHTML is a /Recruiting/Jobs/Details/<id> page. Paylocity dropped the
+// schema.org ld+json (the page is now a client-rendered shell), but the description still
+// renders server-side as the <div> following the "Description" section header. A trailing
+// <script> in that block must be stripped by sanitizeHTML; the sibling "Job Type" section
+// proves the selector picks the Description block, not the first header.
+const paylocityDetailHTML = `<html><body>
+<div class="job-preview-details">
+  <div class="vertical-padding">
+    <div class="job-listing-header">Job Type</div>
+    <div>Full-time</div>
+  </div>
+  <div class="job-listing-header">Description</div>
+  <div><h2>About</h2><p>Care for animals.</p><script>alert(1)</script></div>
+</div>
+</body></html>`
 
 func TestPaylocityProvider(t *testing.T) {
 	if got := NewPaylocity(nil).Provider(); got != "paylocity" {


### PR DESCRIPTION
## Problem

All `paylocity` postings show **empty descriptions** on prod (e.g. [Tanaq](https://freehire.dev/jobs/full-stack-cloud-developer-tanaq-technical-services-iica6izu)). The URL still 200s — only the body is missing.

Root cause: Paylocity migrated its public job-detail page (`/Recruiting/Jobs/Details/<id>`) to a **client-rendered React shell** and **dropped the schema.org JobPosting ld+json** the adapter parsed. So `ldJobPosting` finds nothing and the description comes back empty for every posting.

## Fix

The description is still **server-rendered** — it's the `<div>` immediately following the `<div class="job-listing-header">Description</div>` section header. `detail()` now extracts that block from the DOM (`paylocityDescription`), keeping the ld+json parse as a fallback for any legacy tenant still serving it.

## Verified against live prod pages

- `4266428` (Tanaq, live) → **3968-char** description recovered.
- `4252344` (Lightology) → redirects to `/Jobs/JobNotFound` ("not currently active") → correctly empty; liveness closes it. Not a parser miss.

## Tests

`TestPaylocityFetch` fixture updated to the real server-rendered shape (with a sibling "Job Type" section to prove the selector picks the Description block) and asserts sanitization. Full `sources` suite green.