### PR TITLE
feat(cv): set_stack patch op + intent-label assistant tool calls

### DIFF
--- a/internal/cv/patch.go
+++ b/internal/cv/patch.go
@@ -25,6 +25,7 @@ const (
 	PatchRemoveBullet   PatchOp = "remove_bullet"
 	PatchReorderBullets PatchOp = "reorder_bullets"
 	PatchSetSkillGroup  PatchOp = "set_skill_group"
+	PatchSetStack       PatchOp = "set_stack"
 )
 
 // Patch is one field-level edit to a CV Document. Op selects the operation; the remaining
@@ -40,6 +41,7 @@ type Patch struct {
 	Order      []int    `json:"order,omitempty"`      // permutation of bullet indices (reorder_bullets)
 	Group      string   `json:"group,omitempty"`      // skill group name (set_skill_group)
 	Items      []string `json:"items,omitempty"`      // skill group items (set_skill_group)
+	Stack      []string `json:"stack,omitempty"`      // per-experience technology line (set_stack)
 }
 
 // Apply returns a copy of doc with the patch applied, or ErrInvalidPatch (leaving doc
@@ -58,6 +60,8 @@ func Apply(doc Document, p Patch) (Document, error) {
 		return applyBulletOp(doc, p)
 	case PatchSetSkillGroup:
 		return applySkillGroup(doc, p)
+	case PatchSetStack:
+		return applyStack(doc, p)
 	default:
 		return doc, fmt.Errorf("%w: unknown op %q", ErrInvalidPatch, p.Op)
 	}
@@ -143,6 +147,22 @@ func permute(bullets []string, order []int) ([]string, error) {
 		out[dst] = bullets[src]
 	}
 	return out, nil
+}
+
+// applyStack replaces the whole technology line of one experience entry, mirroring
+// how set_skill_group replaces a group's items. Removing a single technology is a
+// replace with the filtered list, so no dedicated remove op is needed.
+func applyStack(doc Document, p Patch) (Document, error) {
+	if p.Experience < 0 || p.Experience >= len(doc.Experience) {
+		return doc, fmt.Errorf("%w: experience index %d out of range", ErrInvalidPatch, p.Experience)
+	}
+	entry := doc.Experience[p.Experience]
+	entry.Stack = append([]string(nil), p.Stack...) // fresh slice, never alias the caller's
+
+	out := append([]ExperienceItem(nil), doc.Experience...)
+	out[p.Experience] = entry
+	doc.Experience = out
+	return doc, nil
 }
 
 func applySkillGroup(doc Document, p Patch) (Document, error) {

--- a/internal/cv/patch_test.go
+++ b/internal/cv/patch_test.go
@@ -149,6 +149,37 @@ func TestApply_SetSkillGroup(t *testing.T) {
 	})
 }
 
+func TestApply_SetStack(t *testing.T) {
+	in := sampleDoc()
+	in.Experience[0].Stack = []string{"Go", "DynamoDB", "AWS"}
+	before := append([]string(nil), in.Experience[0].Stack...)
+
+	out, err := Apply(in, Patch{Op: PatchSetStack, Experience: 0, Stack: []string{"Go", "AWS"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"Go", "AWS"}
+	if !reflect.DeepEqual(out.Experience[0].Stack, want) {
+		t.Errorf("stack = %v, want %v", out.Experience[0].Stack, want)
+	}
+	// The other experience entry is untouched.
+	if !reflect.DeepEqual(out.Experience[1], in.Experience[1]) {
+		t.Errorf("set_stack touched a different experience entry")
+	}
+	// The input's stack is not mutated (fresh slices along the touched path).
+	if !reflect.DeepEqual(in.Experience[0].Stack, before) {
+		t.Errorf("set_stack mutated the input stack: got %v, want %v", in.Experience[0].Stack, before)
+	}
+}
+
+func TestApply_SetStack_outOfRange(t *testing.T) {
+	in := sampleDoc()
+	_, err := Apply(in, Patch{Op: PatchSetStack, Experience: 9, Stack: []string{"Go"}})
+	if !errors.Is(err, ErrInvalidPatch) {
+		t.Errorf("err = %v, want ErrInvalidPatch", err)
+	}
+}
+
 func TestApply_OutOfRangeExperience(t *testing.T) {
 	in := sampleDoc()
 	_, err := Apply(in, Patch{Op: PatchAddBullet, Experience: 5, Value: "x"})

--- a/web/src/lib/assistant/AssistantChat.svelte
+++ b/web/src/lib/assistant/AssistantChat.svelte
@@ -38,6 +38,7 @@
     bashCommand,
     commandLine,
     isFreehireGroup,
+    isNoiseShellCall,
     nonEmptyInput,
     previewToolInput,
     type ToolCall,
@@ -215,7 +216,7 @@
   function groupTools(calls: readonly ToolCall[]): { family: ToolFamily; calls: ToolCall[] }[] {
     const groups: { family: ToolFamily; calls: ToolCall[] }[] = [];
     for (const c of calls) {
-      const family = classifyFamily(c.name);
+      const family = classifyFamily(c);
       const last = groups[groups.length - 1];
       if (last && last.family === family) last.calls.push(c);
       else groups.push({ family, calls: [c] });
@@ -792,7 +793,7 @@
                 </details>
               {/if}
 
-              {#each groupTools(message.tools) as g, t (t)}
+              {#each groupTools(message.tools.filter((c) => !isNoiseShellCall(c))) as g, t (t)}
                 {@const title = groupTitle(g.family, g.calls)}
                 {#if !isExpandable(g.family, g.calls)}
                   <div class="self-start flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
@@ -811,7 +812,7 @@
                     {#if g.family === 'bash' && isFreehireGroup(g.calls)}
                       <ul class="mt-2 ml-6 space-y-1 text-xs text-muted-foreground">
                         {#each g.calls as c, ci (ci)}
-                          <li>{commandLine(c.input)}</li>
+                          <li>{commandLine(c)}</li>
                         {/each}
                       </ul>
                     {:else if g.family === 'bash'}

--- a/web/src/lib/assistant/tool-formatters.test.ts
+++ b/web/src/lib/assistant/tool-formatters.test.ts
@@ -6,14 +6,40 @@ import {
   commandLine,
   groupTitle,
   isExpandable,
+  isNoiseShellCall,
   bashCommand,
 } from './tool-formatters';
 
 describe('tool-formatters — freehire intent labels', () => {
   it('groups the Terminal tool with bash', () => {
-    expect(classifyFamily('Terminal')).toBe('bash');
-    expect(classifyFamily('Bash')).toBe('bash');
-    expect(classifyFamily('Read')).toBe('fs');
+    expect(classifyFamily({ name: 'Terminal', input: {} })).toBe('bash');
+    expect(classifyFamily({ name: 'Bash', input: {} })).toBe('bash');
+    expect(classifyFamily({ name: 'Read', input: {} })).toBe('fs');
+    expect(classifyFamily({ name: 'SomeTool', input: {} })).toBe('other');
+  });
+
+  it('classifies a freehire call as bash even when the tool name IS the command', () => {
+    // roy surfaces a Bash call with the ACP title = the command string, so `name`
+    // is the command itself ("freehire cv context 14"), not "Bash"/"Terminal".
+    const call = {
+      name: 'freehire cv context 14',
+      input: { command: 'freehire cv context 14', description: 'Load fit analysis' },
+    };
+    expect(classifyFamily(call)).toBe('bash');
+    expect(isFreehireGroup([call])).toBe(true);
+    // Flat intent label, no raw command, no JSON dump.
+    expect(groupTitle('bash', [call])).toBe('Reading the fit analysis');
+    expect(isExpandable('bash', [call])).toBe(false);
+  });
+
+  it('drops the empty pending shell frame that precedes a completed call', () => {
+    // ACP emits a pending Bash notification (no command yet) before the settled
+    // one; unfiltered it renders as a bare, empty "Ran command".
+    expect(isNoiseShellCall({ name: 'Bash', input: {} })).toBe(true);
+    expect(isNoiseShellCall({ name: 'Terminal', input: { description: 'x' } })).toBe(true);
+    expect(isNoiseShellCall({ name: 'Terminal', input: { command: 'freehire facets' } })).toBe(false);
+    expect(isNoiseShellCall({ name: 'freehire cv get 1', input: { command: 'freehire cv get 1' } })).toBe(false);
+    expect(isNoiseShellCall({ name: 'Read', input: {} })).toBe(false);
   });
 
   it('maps freehire subcommands to friendly labels (longest path wins)', () => {
@@ -64,7 +90,9 @@ describe('tool-formatters — freehire intent labels', () => {
     const calls = [{ name: 'Bash', input: { command: 'ls -la' } }];
     expect(isFreehireGroup(calls)).toBe(false);
     expect(groupTitle('bash', calls)).toBe('Ran ls -la');
-    expect(commandLine({ command: 'ls -la' })).toBe('$ ls -la');
-    expect(commandLine({ command: 'freehire cv get 1' })).toBe('Reading your CV');
+    expect(commandLine({ name: 'Bash', input: { command: 'ls -la' } })).toBe('$ ls -la');
+    expect(commandLine({ name: 'Terminal', input: { command: 'freehire cv get 1' } })).toBe(
+      'Reading your CV',
+    );
   });
 });

--- a/web/src/lib/assistant/tool-formatters.ts
+++ b/web/src/lib/assistant/tool-formatters.ts
@@ -19,12 +19,35 @@ function truncate(s: string, n: number): string {
 
 const FS_TOOLS = new Set(['Read', 'Glob', 'Grep', 'LS']);
 
-export function classifyFamily(name: string): ToolFamily {
+/** The shell command a call carries. roy surfaces a `freehire` invocation two
+ *  ways: as `{name:'Terminal', input:{command}}` (an explicit shell tool) or —
+ *  when the ACP tool title IS the command — as `{name:'<command>', input:{…}}`.
+ *  Read it from the input, falling back to the name so the command resolves in
+ *  both shapes. */
+function callCommand(call: ToolCall): string | null {
+  return bashCommand(call.input) ?? (call.name || null);
+}
+
+export function classifyFamily(call: ToolCall): ToolFamily {
+  const { name } = call;
   // The assistant runs the `freehire` CLI through the harness shell tool, which
   // the ACP layer surfaces as `Terminal` (Claude Code) — group it with `Bash`.
   if (name === 'Bash' || name === 'Terminal') return 'bash';
   if (FS_TOOLS.has(name)) return 'fs';
+  // A `freehire` call whose ACP title (name) is the command string itself would
+  // otherwise fall through to `other` and render as `Called <command>` + a JSON
+  // dump. Recognize it by its command and group it with bash so it reads as an
+  // intent label.
+  if (labelFor(call) !== null) return 'bash';
   return 'other';
+}
+
+/** A shell tool call carrying no command. roy relays a pending ACP tool
+ *  notification (title `Bash`, no `raw_input`) before the settled one, which
+ *  unfiltered renders as an empty "Ran command". The renderer drops these before
+ *  grouping so only the real, command-bearing call shows. */
+export function isNoiseShellCall(call: ToolCall): boolean {
+  return (call.name === 'Bash' || call.name === 'Terminal') && bashCommand(call.input) === null;
 }
 
 // Map a `freehire <subcommand>` invocation to a neutral, human-readable label so
@@ -54,21 +77,21 @@ export function freehireLabel(command: string): string | null {
 
 /** Intent label for a call's shell command, or `null` when it is not a freehire
  *  call (no command, or a non-freehire program). */
-function labelFor(input: unknown): string | null {
-  const cmd = bashCommand(input);
+function labelFor(call: ToolCall): string | null {
+  const cmd = callCommand(call);
   return cmd ? freehireLabel(cmd) : null;
 }
 
 /** True when every call in the group is a `freehire` command — render as intent
  *  labels with no shell chrome, and never surface the raw command. */
 export function isFreehireGroup(calls: readonly ToolCall[]): boolean {
-  return calls.length > 0 && calls.every((c) => labelFor(c.input) !== null);
+  return calls.length > 0 && calls.every((c) => labelFor(c) !== null);
 }
 
 /** One expanded line for a shell/terminal call: the friendly `freehire` label, or
  *  `$ <command>` for any other command. */
-export function commandLine(input: unknown): string {
-  const cmd = bashCommand(input);
+export function commandLine(call: ToolCall): string {
+  const cmd = callCommand(call);
   if (!cmd) return 'Command';
   return freehireLabel(cmd) ?? `$ ${cmd}`;
 }
@@ -82,7 +105,7 @@ export function groupTitle(family: ToolFamily, calls: readonly ToolCall[]): stri
       // Collapse to the distinct intent labels ("Reading the fit analysis ·
       // Reading your CV"), capped so the header stays short.
       const distinct = [
-        ...new Set(calls.map((c) => labelFor(c.input)).filter((l): l is string => l !== null)),
+        ...new Set(calls.map((c) => labelFor(c)).filter((l): l is string => l !== null)),
       ];
       if (distinct.length <= 2) return distinct.join(' · ');
       return `${distinct.slice(0, 2).join(' · ')} · +${distinct.length - 2}`;

--- a/web/src/lib/generated/contracts.ts
+++ b/web/src/lib/generated/contracts.ts
@@ -594,6 +594,7 @@ export const PatchReplaceBullet: PatchOp = "replace_bullet";
 export const PatchRemoveBullet: PatchOp = "remove_bullet";
 export const PatchReorderBullets: PatchOp = "reorder_bullets";
 export const PatchSetSkillGroup: PatchOp = "set_skill_group";
+export const PatchSetStack: PatchOp = "set_stack";
 /**
  * Patch is one field-level edit to a CV Document. Op selects the operation; the remaining
  * fields are its address and payload, and only the ones an op needs are read. A patch names
@@ -609,6 +610,7 @@ export interface Patch {
   order?: number /* int */[]; // permutation of bullet indices (reorder_bullets)
   group?: string; // skill group name (set_skill_group)
   items?: string[]; // skill group items (set_skill_group)
+  stack?: string[]; // per-experience technology line (set_stack)
 }
 
 export const SOURCE_VALUES = ['telegram', 'workatastartup', 'remoteok', 'arc', '4dayweek', 'adp', 'applicantpro', 'apploi', 'arbeitnow', 'arbeitsagentur', 'ashby', 'ashbygraphql', 'avature', 'bamboohr', 'bayt', 'breezy', 'briefhq', 'bullhorn', 'careerplug', 'careerspage', 'catsone', 'cleverstaff', 'clinch', 'comeet', 'cornerstone', 'crelate', 'deel', 'djinni', 'earcu', 'eightfold', 'enlizt', 'epam', 'erecruiter', 'factorial', 'freshteam', 'functionalworks', 'geekjob', 'gem', 'getmanfred', 'getmatch', 'getonbrd', 'getro', 'globalpayments', 'greenhouse', 'gulftalent', 'gupy', 'habr_career', 'hh', 'himalayas', 'hireology', 'huntflow', 'hurma', 'icims', 'infojobs', 'inhire', 'ismartrecruit', 'isolvedhire', 'itechart', 'jazzhr', 'jibe', 'jobdanmark', 'jobicy', 'jobnet', 'jobscore', 'jobspresso', 'jobstash', 'jobtech', 'jobvite', 'jobylon', 'join', 'justjoin', 'lever', 'likeit', 'loxo', 'luxoft', 'manatal', 'mindsight', 'mycareersfuture', 'neogov', 'nofluffjobs', 'northstone', 'odoo', 'oracle', 'pageup', 'paycom', 'paylocity', 'peopleforce', 'personio', 'phenom', 'pinpoint', 'quickin', 'radancy', 'rapyd', 'recruitee', 'recruitingsolutions', 'remotive', 'rippling', 'senior', 'smartrecruiters', 'solides', 'spark', 'startupandvc', 'successfactors', 'talentadore', 'talentlyft', 'taleo', 'teamex', 'teamtailor', 'tecla', 'thehub', 'topco', 'traffit', 'trakstar', 'trudvsem', 'tyomarkkinatori', 'ukg', 'vagas', 'vention', 'vouch', 'wantapply', 'wantedkr', 'weworkremotely', 'workable', 'workablemarketplace', 'workday', 'workingnomads', 'wpyoast', 'zohorecruit'] as const;


### PR DESCRIPTION
## What

Two fixes for the CV-tailoring assistant:

1. **`set_stack` patch op** (`internal/cv/patch.go`) — the assistant could not edit an experience's technology stack; only `set_summary/replace_bullet/set_skill_group/…` existed. `set_stack` replaces an experience's `Stack` array (mirrors `set_skill_group`; the `Stack` field already existed and was seeded/rendered — only the op was missing). Removing a tech = replace with the filtered list.
2. **Intent-label tool calls** (`web/src/lib/assistant/`) — freehire CLI calls rendered as raw `Called freehire cv context 14` + a JSON dump because `classifyFamily` keyed on `name==='Bash'`, but the ACP tool title IS the command string. Now the call is classified by its command and shows a flat intent chip ("Reading the fit analysis"); the empty pending shell frame ("Ran command") is dropped.

## Tests
- `internal/cv`: new `set_stack` cases (replace, out-of-range, no input mutation) — green.
- `tool-formatters.test.ts`: classify-by-command, noise-frame suppression — 9/9.
- TS contract regenerated (`set_stack` op + `stack?` field).

Part of unblocking assistant CV editing (paired with a bash-guard + prompt fix in freehire-agent).