### PR TITLE
fix(cv): reject mis-addressed patches loudly (no silent corruption)

### DIFF
--- a/internal/cv/patch.go
+++ b/internal/cv/patch.go
@@ -1,6 +1,8 @@
 package cv
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -42,6 +44,22 @@ type Patch struct {
 	Group      string   `json:"group,omitempty"`      // skill group name (set_skill_group)
 	Items      []string `json:"items,omitempty"`      // skill group items (set_skill_group)
 	Stack      []string `json:"stack,omitempty"`      // per-experience technology line (set_stack)
+}
+
+// DecodePatch parses a patch from its JSON body, rejecting unknown fields and type
+// mismatches with a reason the caller can surface. This matters for LLM callers: a
+// mis-addressed op (e.g. set_stack carrying a stray "skill" field, or set_skill_group
+// with a numeric "group" where a name is expected) would otherwise be silently ignored
+// or mutely rejected — here it fails as ErrInvalidPatch with the offending detail, so the
+// agent can correct itself instead of clobbering the wrong section.
+func DecodePatch(body []byte) (Patch, error) {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	var p Patch
+	if err := dec.Decode(&p); err != nil {
+		return Patch{}, fmt.Errorf("%w: %v", ErrInvalidPatch, err)
+	}
+	return p, nil
 }
 
 // Apply returns a copy of doc with the patch applied, or ErrInvalidPatch (leaving doc

--- a/internal/cv/patch_test.go
+++ b/internal/cv/patch_test.go
@@ -3,8 +3,41 @@ package cv
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestDecodePatch_rejectsUnknownField(t *testing.T) {
+	// The agent mis-addressed the skills section with a "skill" field on set_stack.
+	// A silent ignore + default experience 0 would clobber the wrong experience's
+	// stack, so an unknown field must fail loudly, naming the field.
+	_, err := DecodePatch([]byte(`{"op":"set_stack","skill":0,"stack":["Go"]}`))
+	if !errors.Is(err, ErrInvalidPatch) {
+		t.Fatalf("err = %v, want ErrInvalidPatch", err)
+	}
+	if !strings.Contains(err.Error(), "skill") {
+		t.Errorf("error should name the unknown field, got %q", err.Error())
+	}
+}
+
+func TestDecodePatch_rejectsWrongFieldType(t *testing.T) {
+	// group is the skill-group NAME (string); the agent sent an index (number).
+	// json can't put a number in a string field — reject with a reason.
+	_, err := DecodePatch([]byte(`{"op":"set_skill_group","group":0,"items":["Go"]}`))
+	if !errors.Is(err, ErrInvalidPatch) {
+		t.Fatalf("err = %v, want ErrInvalidPatch", err)
+	}
+}
+
+func TestDecodePatch_valid(t *testing.T) {
+	p, err := DecodePatch([]byte(`{"op":"set_stack","experience":1,"stack":["Go","Rust"]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Op != PatchSetStack || p.Experience != 1 || !reflect.DeepEqual(p.Stack, []string{"Go", "Rust"}) {
+		t.Errorf("parsed = %+v, want set_stack exp1 stack[Go Rust]", p)
+	}
+}
 
 // sampleDoc returns a small but multi-section document for patch tests.
 func sampleDoc() Document {

--- a/internal/handler/cv.go
+++ b/internal/handler/cv.go
@@ -272,7 +272,10 @@ func mapCVError(err error) error {
 	case errors.Is(err, cv.ErrUnknownTemplate):
 		return fiber.NewError(fiber.StatusBadRequest, "unknown template")
 	case errors.Is(err, cv.ErrInvalidPatch):
-		return fiber.NewError(fiber.StatusUnprocessableEntity, "invalid patch")
+		// Surface the specific reason (unknown field, wrong type, out-of-range index)
+		// so an LLM caller can fix the patch instead of retrying against a generic 422.
+		reason := strings.TrimPrefix(err.Error(), cv.ErrInvalidPatch.Error()+": ")
+		return fiber.NewError(fiber.StatusUnprocessableEntity, reason)
 	default:
 		return err
 	}

--- a/internal/handler/cv_tailor.go
+++ b/internal/handler/cv_tailor.go
@@ -176,9 +176,12 @@ func (a *API) PatchCV(c *fiber.Ctx) error {
 	if err != nil {
 		return fiber.NewError(fiber.StatusBadRequest, "invalid id")
 	}
-	var p cv.Patch
-	if err := c.BodyParser(&p); err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	// Decode strictly: reject unknown fields and type mismatches so a mis-addressed
+	// op (a stray "skill" field, a numeric "group") fails with a reason the agent can
+	// act on, instead of being silently ignored and editing the wrong section.
+	p, err := cv.DecodePatch(c.Body())
+	if err != nil {
+		return mapCVError(err)
 	}
 	meta, err := a.cvStore.Patch(c.Context(), int64(id), userID, p)
 	if err != nil {


### PR DESCRIPTION
## Why
Live from the tailoring assistant on CV 16 (root-caused from prod logs + agent journal):

1. **Silent corruption.** The agent sent `{"op":"set_stack","skill":0,"stack":[…]}`. `skill` isn't a `Patch` field, so it was **silently ignored**; `experience` defaulted to **0** → it overwrote the *first* experience's stack with the general skill list, while the section it meant to edit was untouched. The agent got 200 and reported success — false.
2. **Mute 400.** It also sent `{"op":"set_skill_group","group":0,…}` — a numeric `group` where a string name is expected. `json.Unmarshal` failed, handler returned a generic `400 invalid request body` with no reason, so the agent retried blindly (4× in the logs).

Both stem from the parser's silent leniency: unknown fields ignored, missing fields defaulted, errors opaque.

## What
- **`cv.DecodePatch`** — decode with `DisallowUnknownFields`, wrapping parse/type errors as `ErrInvalidPatch` with the offending detail.
- **`PatchCV`** decodes via it (not `c.BodyParser`).
- **`mapCVError`** surfaces the specific `ErrInvalidPatch` reason (unknown field / wrong type / out-of-range index) as the 422 message, so the LLM self-corrects instead of guessing.

Now `skill:0` → `422 json: unknown field "skill"`; `group:0` → `422 … group of type string`. No wrong-section write.

## Tests
- `TestDecodePatch_rejectsUnknownField` / `_rejectsWrongFieldType` / `_valid` — green.
- Existing `cv` + `handler` suites green (out-of-range still 422).

Follow-up to freehire#940.