### PR TITLE
feat(sources): hydrate clinch descriptions via a paced AWS-WAF-challenge-aware layer

### DIFF
--- a/internal/sources/clinch.go
+++ b/internal/sources/clinch.go
@@ -2,62 +2,102 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+
+	"golang.org/x/net/html"
 
 	"github.com/strelov1/freehire/internal/location"
 )
 
 // clinch adapts ClinchTalent / career-pages.com career sites (e.g. careers.withwaymo.com).
-// The board is the career-site host. Unlike the other sitemap adapters (successfactors,
-// meta) it CANNOT fetch the job detail pages: ClinchTalent fronts them with an AWS WAF
-// "challenge" action (an interactive JS proof-of-work), so a plain or fingerprint-spoofed
-// GET is served a 202 challenge, never the posting. The publicly served sitemap is the only
-// reachable surface, so a posting is reconstructed from its URL slug alone:
+// The board is the career-site host. Detail pages sit behind a RATE-BASED AWS-WAF "challenge"
+// action: a cold IP is served a handful of clean pages before the WAF flips to a 202 challenge
+// (marked "x-amzn-waf-action: challenge") and holds a long per-IP penalty. So the sitemap is
+// always parsed — a posting is reconstructed from its URL slug alone:
 //
 //	/jobs/{title-words}-{city}-{state}-{country}[-{uuid}]
 //
-// Title and location are split out of the slug (clinchSplitSlug); the description is left
-// empty (the detail page is unreachable), so enrichment and the description-derived facets
-// stay blank for these jobs while the title-derived facets and the geography facet — the
-// location dictionary resolves the slug's place tail — still populate. This mirrors the
-// sitemap-only approach the ClinchTalent platform forces on every crawler.
+// Title and location are split out of the slug (clinchSplitSlug). The description is then
+// hydrated best-effort from each posting's detail page (div.job-description) through a paced
+// detail getter that holds the run's request rate under the WAF window. The first WAF
+// challenge LATCHES detail hydration off for the rest of the run (hammering a tripped WAF is
+// wasteful and prolongs the penalty), so the remaining postings keep the empty description
+// they would have had before. Coverage is therefore partial and back-fills across runs, and
+// the adapter is never worse than the old sitemap-only reconstruction.
 type clinch struct {
-	http XMLGetter
+	sitemap XMLGetter  // the career-site sitemap.xml (one request per run)
+	detail  HTMLGetter // per-posting detail pages, paced under the WAF window
 }
 
-// NewClinch builds the ClinchTalent adapter over the given XML client.
-func NewClinch(c XMLGetter) Source { return clinch{http: c} }
+// NewClinch builds the ClinchTalent adapter: sitemap fetches the board's sitemap.xml, detail
+// hydrates each posting's description (paced, see pacedClinchGetter).
+func NewClinch(sitemap XMLGetter, detail HTMLGetter) Source {
+	return clinch{sitemap: sitemap, detail: detail}
+}
 
 func (clinch) Provider() string { return "clinch" }
 
 func (c clinch) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	url := fmt.Sprintf("https://%s/sitemap.xml", e.Board)
-	sitemap, err := getSitemap(ctx, c.http, url)
+	sitemap, err := getSitemap(ctx, c.sitemap, url)
 	if err != nil {
 		return nil, fmt.Errorf("clinch: sitemap %s: %w", e.Board, err)
 	}
 
 	var jobs []Job
+	latched := false // set once the WAF challenges — stops further detail fetches this run
 	for _, entry := range sitemap.URLs {
 		slug := clinchJobSlug(entry.Loc)
 		if slug == "" {
 			continue // not a /jobs/ URL (marketing page) or empty slug
 		}
 		title, loc := clinchSplitSlug(slug)
+
+		description := ""
+		if !latched {
+			desc, challenged := c.hydrate(ctx, entry.Loc)
+			if challenged {
+				latched = true // remaining postings stay sitemap-only
+			} else {
+				description = desc // "" when the fetch failed or the block was absent
+			}
+		}
+
 		jobs = append(jobs, Job{
 			ExternalID:  clinchExternalID(slug),
 			URL:         entry.Loc,
 			Title:       title,
 			Company:     e.Company,
 			Location:    loc,
-			Description: "", // detail page is AWS-WAF-blocked; nothing to fetch
+			Description: description,
 			Remote:      isRemote(loc),
 			PostedAt:    parseDate(entry.LastMod),
 		})
 	}
 	return jobs, nil
+}
+
+// hydrate fetches a posting's detail page and returns its description. challenged reports a WAF
+// ChallengeError — the caller's signal to latch off detail hydration for the rest of the run.
+// Any other fetch failure (or a missing description block) returns an empty description without
+// latching, so a single bad page never drops the posting or stops the crawl.
+func (c clinch) hydrate(ctx context.Context, url string) (description string, challenged bool) {
+	node, err := c.detail.GetHTML(ctx, url)
+	if err != nil {
+		var chErr *ChallengeError
+		return "", errors.As(err, &chErr)
+	}
+	return clinchDescription(node), false
+}
+
+// clinchDescription returns the detail page's div.job-description block as sanitized HTML —
+// preserving its paragraph/list structure like every other adapter's description — or "" when
+// the page has no such block.
+func clinchDescription(root *html.Node) string {
+	return sanitizeHTML(elementInnerHTMLByClass(root, "div", "job-description"))
 }
 
 // clinchJobSlug returns the posting slug from a career-site URL — the path segment after

--- a/internal/sources/clinch_test.go
+++ b/internal/sources/clinch_test.go
@@ -2,9 +2,137 @@ package sources
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/net/html"
 )
+
+// routedDetail is a fake HTMLGetter for clinch's detail path: it matches a URL by substring
+// and returns either a parsed detail page or a WAF ChallengeError (body "CHALLENGE"). It
+// records every URL it was asked to fetch so a test can assert the latch stopped further
+// fetches.
+type routedDetail struct {
+	routes map[string]string
+	calls  []string
+}
+
+func (r *routedDetail) GetHTML(_ context.Context, url string) (*html.Node, error) {
+	r.calls = append(r.calls, url)
+	for sub, body := range r.routes {
+		if strings.Contains(url, sub) {
+			if body == "CHALLENGE" {
+				return nil, &ChallengeError{URL: url}
+			}
+			return html.Parse(strings.NewReader(body))
+		}
+	}
+	return nil, fmt.Errorf("routedDetail: no route for %s", url)
+}
+
+func clinchDetailHTML(descInnerHTML string) string {
+	return `<html><body><h1>irrelevant</h1>` +
+		`<div class="job-description">` + descInnerHTML + `</div>` +
+		`</body></html>`
+}
+
+func TestClinchDescriptionPreservesBlockStructureAsSanitizedHTML(t *testing.T) {
+	// A real posting is multi-block; the description must keep paragraph/list boundaries
+	// (stored as sanitized HTML like every other adapter) rather than flatten to run-together
+	// text.
+	node, err := html.Parse(strings.NewReader(clinchDetailHTML(`<p>First sentence.</p><ul><li>Alpha</li><li>Beta</li></ul><p>Last.</p>`)))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := clinchDescription(node)
+	want := `<p>First sentence.</p><ul><li>Alpha</li><li>Beta</li></ul><p>Last.</p>`
+	if got != want {
+		t.Errorf("clinchDescription = %q, want the block structure preserved as sanitized HTML %q", got, want)
+	}
+}
+
+func TestClinchDescriptionEmptyWhenNoBlock(t *testing.T) {
+	node, err := html.Parse(strings.NewReader(`<html><body><p>no description block here</p></body></html>`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := clinchDescription(node); got != "" {
+		t.Errorf("clinchDescription = %q, want empty", got)
+	}
+}
+
+func TestClinchFetchHydratesDescriptionFromDetail(t *testing.T) {
+	job := "https://careers.withwaymo.com/jobs/software-engineer-mountain-view-california-united-states"
+	sitemap := (&routedHTTP{}).route("/sitemap.xml", clinchSitemapXML(job))
+	detail := &routedDetail{routes: map[string]string{
+		"/jobs/software-engineer": clinchDetailHTML("Own the simulator."),
+	}}
+
+	jobs, err := NewClinch(sitemap, detail).Fetch(context.Background(), CompanyEntry{
+		Company: "Waymo", Board: "careers.withwaymo.com",
+	})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1", len(jobs))
+	}
+	if jobs[0].Description != "Own the simulator." {
+		t.Errorf("Description = %q, want the detail-page text", jobs[0].Description)
+	}
+}
+
+func TestClinchFetchChallengeLatchesRemainingToSitemapOnly(t *testing.T) {
+	j1 := "https://careers.withwaymo.com/jobs/one-mountain-view-california-united-states"
+	j2 := "https://careers.withwaymo.com/jobs/two-london-england-united-kingdom"
+	j3 := "https://careers.withwaymo.com/jobs/three-warsaw-masovian-voivodeship-poland"
+	sitemap := (&routedHTTP{}).route("/sitemap.xml", clinchSitemapXML(j1, j2, j3))
+	detail := &routedDetail{routes: map[string]string{
+		"/jobs/one-":   clinchDetailHTML("First hydrated."),
+		"/jobs/two-":   "CHALLENGE", // WAF trips here
+		"/jobs/three-": clinchDetailHTML("Should never be fetched."),
+	}}
+
+	jobs, err := NewClinch(sitemap, detail).Fetch(context.Background(), CompanyEntry{Board: "careers.withwaymo.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3 (all sitemap postings still emitted)", len(jobs))
+	}
+	if jobs[0].Description != "First hydrated." {
+		t.Errorf("job[0].Description = %q, want the hydrated text", jobs[0].Description)
+	}
+	if jobs[1].Description != "" || jobs[2].Description != "" {
+		t.Errorf("after a challenge, remaining descriptions must be empty; got %q, %q", jobs[1].Description, jobs[2].Description)
+	}
+	// The latch must stop detail fetches: only j1 (ok) and j2 (challenge) are fetched, never j3.
+	if len(detail.calls) != 2 {
+		t.Errorf("detail fetches = %d (%v), want 2 — the latch must skip j3", len(detail.calls), detail.calls)
+	}
+}
+
+func TestClinchFetchDetailErrorKeepsPostingWithEmptyDescription(t *testing.T) {
+	job := "https://careers.withwaymo.com/jobs/backend-engineer-warsaw-masovian-voivodeship-poland"
+	sitemap := (&routedHTTP{}).route("/sitemap.xml", clinchSitemapXML(job))
+	detail := &routedDetail{routes: map[string]string{}} // no route → per-posting error (not a challenge)
+
+	jobs, err := NewClinch(sitemap, detail).Fetch(context.Background(), CompanyEntry{Board: "careers.withwaymo.com"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("got %d jobs, want 1 (a detail error must not drop the posting)", len(jobs))
+	}
+	if jobs[0].Description != "" {
+		t.Errorf("Description = %q, want empty on a detail error", jobs[0].Description)
+	}
+	if jobs[0].Title != "Backend Engineer" {
+		t.Errorf("Title = %q, want the slug-derived title", jobs[0].Title)
+	}
+}
 
 func clinchSitemapXML(locs ...string) string {
 	xml := `<?xml version="1.0"?><urlset>`
@@ -15,7 +143,7 @@ func clinchSitemapXML(locs ...string) string {
 }
 
 func TestClinchProvider(t *testing.T) {
-	if got := NewClinch(nil).Provider(); got != "clinch" {
+	if got := NewClinch(nil, nil).Provider(); got != "clinch" {
 		t.Errorf("Provider() = %q, want %q", got, "clinch")
 	}
 }
@@ -99,7 +227,9 @@ func TestClinchFetchParsesSitemapAndFiltersNonJobURLs(t *testing.T) {
 		job,
 	))
 
-	jobs, err := NewClinch(fake).Fetch(context.Background(), CompanyEntry{
+	// No detail route: hydration fails per-posting (a non-challenge error), so the description
+	// stays empty and the sitemap-only fields are what this test asserts.
+	jobs, err := NewClinch(fake, &routedDetail{routes: map[string]string{}}).Fetch(context.Background(), CompanyEntry{
 		Company: "Waymo", Provider: "clinch", Board: "careers.withwaymo.com",
 	})
 	if err != nil {
@@ -134,7 +264,7 @@ func TestClinchFetchParsesSitemapAndFiltersNonJobURLs(t *testing.T) {
 
 func TestClinchFetchEmptySitemapYieldsNoJobsNoError(t *testing.T) {
 	fake := (&routedHTTP{}).route("/sitemap.xml", clinchSitemapXML())
-	jobs, err := NewClinch(fake).Fetch(context.Background(), CompanyEntry{Board: "careers.withwaymo.com"})
+	jobs, err := NewClinch(fake, &routedDetail{routes: map[string]string{}}).Fetch(context.Background(), CompanyEntry{Board: "careers.withwaymo.com"})
 	if err != nil {
 		t.Fatalf("Fetch: %v", err)
 	}

--- a/internal/sources/http.go
+++ b/internal/sources/http.go
@@ -342,6 +342,20 @@ func (e *StatusError) Error() string {
 	return fmt.Sprintf("sources: GET %s: status %d", e.URL, e.Code)
 }
 
+// ChallengeError is an AWS-WAF Challenge response — a request the WAF answered with an
+// interactive JS proof-of-work shell instead of the real content (marked by the
+// "x-amzn-waf-action: challenge" header, served with HTTP 202). It is NOT a transient
+// failure: a fixed backoff will not clear it, and retrying only deepens the per-IP
+// penalty. Callers behind a rate-based WAF (e.g. clinch) match it with errors.As to
+// stop hydrating for the rest of the run rather than parse the shell as a posting.
+type ChallengeError struct {
+	URL string
+}
+
+func (e *ChallengeError) Error() string {
+	return fmt.Sprintf("sources: GET %s: WAF challenge", e.URL)
+}
+
 // request is the parameters of a single HTTP exchange issued by do. A non-nil body is
 // re-sent on each retry; the standard User-Agent/Accept headers always win over headers.
 type request struct {
@@ -396,6 +410,15 @@ func (c *Client) do(ctx context.Context, r request) error {
 		if err != nil {
 			lastErr = err
 			continue // network error — transient
+		}
+
+		// An AWS-WAF Challenge is served with HTTP 202 (a 2xx that would otherwise be
+		// decoded as content) and its own action header. Catch it before the success
+		// branch and return immediately — it is not transient, so a retry is wasted and
+		// only prolongs the WAF's per-IP penalty.
+		if resp.Header.Get("X-Amzn-Waf-Action") == "challenge" {
+			resp.Body.Close()
+			return &ChallengeError{URL: r.url}
 		}
 
 		switch {

--- a/internal/sources/http_test.go
+++ b/internal/sources/http_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -207,5 +208,49 @@ func TestClientRetriesOn429ThenSucceeds(t *testing.T) {
 	}
 	if attempts != 2 {
 		t.Errorf("attempts = %d, want 2 (429 then 200)", attempts)
+	}
+}
+
+func TestClientGetHTMLSurfacesWAFChallengeAsTypedError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// AWS-WAF Challenge action: a 202 carrying the challenge marker header and a
+		// tiny challenge shell (never the real posting).
+		w.Header().Set("x-amzn-waf-action", "challenge")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`<html><head><script>window.gokuProps={}</script></head><body></body></html>`))
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2}
+
+	node, err := c.GetHTML(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected a challenge error, got nil")
+	}
+	var chErr *ChallengeError
+	if !errors.As(err, &chErr) {
+		t.Fatalf("error = %v, want a *ChallengeError", err)
+	}
+	if node != nil {
+		t.Error("expected nil node: the challenge shell must not be decoded as content")
+	}
+}
+
+func TestClientDoesNotRetryWAFChallenge(t *testing.T) {
+	var attempts int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.Header().Set("x-amzn-waf-action", "challenge")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := &Client{httpClient: srv.Client(), maxRetries: 2}
+
+	if _, err := c.GetHTML(context.Background(), srv.URL); err == nil {
+		t.Fatal("expected a challenge error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1 (a challenge is not a transient failure)", attempts)
 	}
 }

--- a/internal/sources/pacer.go
+++ b/internal/sources/pacer.go
@@ -71,6 +71,28 @@ func pacedVagasGetter(c HTMLGetter) HTMLGetter {
 	}
 }
 
+// ClinchTalent fronts detail pages with a rate-based AWS-WAF Challenge action: a cold IP is
+// served a handful of clean pages (spike observed ~6) before the WAF flips to a 202 challenge
+// and holds a long per-IP penalty. clinch fetches one detail page per new posting, so its
+// aggregate rate — not the worker pool — must stay under that window. The interval is
+// deliberately gentle (well below the observed trip point) because the true budget is unknown
+// and the penalty is punishing: under-shooting only lengthens a run, while over-shooting trips
+// the WAF and latches clinch back to sitemap-only for the rest of the run. Tune from the
+// observed description-fill rate.
+const (
+	clinchRequestInterval = 1500 * time.Millisecond // ~0.67 req/s
+	clinchRequestBurst    = 1
+)
+
+// pacedClinchGetter wraps a getter with a fresh limiter shared across one registry build, so all
+// of clinch's detail requests in a run stay under ClinchTalent's per-IP AWS-WAF challenge window.
+func pacedClinchGetter(c HTMLGetter) HTMLGetter {
+	return rateLimitedHTMLGetter{
+		inner:   c,
+		limiter: rate.NewLimiter(rate.Every(clinchRequestInterval), clinchRequestBurst),
+	}
+}
+
 // concurrencyLimitedJSONGetter bounds how many GetJSON calls are in flight at once via a shared
 // semaphore, independent of the pipeline's board-worker pool. Unlike a rate limiter — which caps
 // the request START rate but lets slow requests pile up concurrently — this caps simultaneous

--- a/internal/sources/pacer_test.go
+++ b/internal/sources/pacer_test.go
@@ -107,3 +107,22 @@ func TestConcurrencyLimitedJSONGetter_CancelledContextShortCircuits(t *testing.T
 		t.Fatalf("inner GetJSON called despite no free slot (%d times)", len(inner.urls))
 	}
 }
+
+// challengingHTMLGetter always fails the fetch with a WAF ChallengeError.
+type challengingHTMLGetter struct{ url string }
+
+func (g challengingHTMLGetter) GetHTML(_ context.Context, _ string) (*html.Node, error) {
+	return nil, &ChallengeError{URL: g.url}
+}
+
+func TestPacedClinchGetter_PropagatesChallengeError(t *testing.T) {
+	g := pacedClinchGetter(challengingHTMLGetter{url: "https://careers.example.com/jobs/x"})
+
+	// The first call is admitted immediately by the limiter's burst, so this exercises the
+	// wiring without any timing dependency.
+	_, err := g.GetHTML(context.Background(), "https://careers.example.com/jobs/x")
+	var chErr *ChallengeError
+	if !errors.As(err, &chErr) {
+		t.Fatalf("GetHTML error = %v, want the inner *ChallengeError to propagate unchanged", err)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -241,7 +241,10 @@ func All(c HTTPClient) map[string]Source {
 		NewADP(c),
 		NewITechArt(c),
 		NewVention(c),
-		NewClinch(c),
+		// Detail hydration is rate-paced (pacedClinchGetter) to hold the run's request rate
+		// under ClinchTalent's per-IP AWS-WAF challenge window; the sitemap fetch is a single
+		// request and needs no pacing.
+		NewClinch(c, pacedClinchGetter(c)),
 		NewOracle(c),
 		NewEightfold(c),
 		NewFreshteam(c),

--- a/openspec/changes/clinch-detail-via-paced-challenge-layer/.openspec.yaml
+++ b/openspec/changes/clinch-detail-via-paced-challenge-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/clinch-detail-via-paced-challenge-layer/design.md
+++ b/openspec/changes/clinch-detail-via-paced-challenge-layer/design.md
@@ -1,0 +1,101 @@
+## Context
+
+`clinch.go` reconstructs postings from sitemap slugs only, because ClinchTalent
+fronts detail pages with an AWS-WAF Challenge action. A spike (memory
+`hire-clinch-awswaf-challenge-spike`) measured the gate precisely on
+`careers.withwaymo.com`:
+
+- It is **rate-based**, not a blanket block. A cold IP (residential *and* the
+  prod datacenter IP `89.167.94.146`) is served ~6 clean HTTP 200 full pages
+  (each ~126 KB, with `div.job-description`) before the WAF flips to HTTP 202.
+- The 202 shell (~2464 B) carries `x-amzn-waf-action: challenge`, `gokuProps`,
+  and the `AwsWafIntegration.getToken()` loader. Its penalty window is long;
+  pacing does not recover a tripped IP within a run.
+- The free token-solver path was rejected: it works from `sa-east-1` but fails
+  deterministically from the prod EU region (region-specific `challenge.js`
+  build), i.e. a maintenance treadmill.
+
+The reusable seam already exists: `pacer.go` `rateLimitedHTMLGetter` +
+`pacedCareerPageGetter/Vagas/HH`, each a thin constructor over a shared
+`golang.org/x/time/rate` limiter. The transport (`http.go` `Client.do`) is where
+the 202 classification bug lives.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Harvest clinch descriptions where the per-run WAF budget allows, with zero new
+  dependency, proxy, or config.
+- Make the challenge-aware layer reusable — any AWS-WAF-challenged source can opt
+  in later.
+- Guarantee non-regression: clinch output is a strict superset of today's.
+
+**Non-Goals:**
+- Solving the WAF challenge / minting `aws-waf-token` (free solver rejected;
+  CapSolver deferred).
+- Full description coverage in a single run — partial, back-filling coverage is
+  the accepted outcome.
+- Recovering a tripped IP mid-run, or per-tenant token/cookie sessions.
+
+## Decisions
+
+**1. Detect the challenge in the transport, surface a typed `ChallengeError`.**
+`Client.do` gains a check *before* the `2xx` success branch: if
+`resp.Header.Get("x-amzn-waf-action") == "challenge"`, close the body and return
+`&ChallengeError{URL: ...}` (a small typed error next to `StatusError`).
+Matching on the header rather than the bare `202` status is precise — 202 is a
+legitimate success elsewhere, and the header is AWS's own challenge marker.
+Return immediately (no retry): a challenge will not clear on a fixed backoff and
+retrying only deepens the penalty. *Alternative considered:* treat 202 as an
+error generically — rejected, it would mis-handle any legitimate 202.
+
+**2. Reuse `rateLimitedHTMLGetter`; add a `pacedClinchGetter` constructor.** No
+new abstraction — the challenge-awareness lives entirely in the transport
+(decision 1), so the pacing layer is exactly the existing wrapper with a
+clinch-tuned interval. *Alternative considered:* a bespoke "challenge-aware
+getter" type — rejected as redundant once `do` surfaces `ChallengeError`, which
+propagates through `GetHTML` unchanged.
+
+**3. Conservative starting interval, tuned from convergence.** Start
+deliberately gentle (the WAF trips at ~6 rapid requests and punishes hard), in
+the spirit of the `careerspage`/`vagas` comments ("under-shooting only lengthens
+a run; over-shooting re-introduces the penalty"). The exact safe sustained rate
+could not be measured (spike poisoned both test IPs), so the latch (decision 4)
+is the real safety net, not the interval.
+
+**4. One-way latch-off on the first `ChallengeError`.** clinch iterates sitemap
+entries; a small `hydrator` helper holds a `latched bool`. Once a detail fetch
+returns a `ChallengeError`, set `latched` and skip all further detail fetches
+this run, emitting the remaining postings sitemap-only. Mirrors
+`tyomarkkinatori.detail(...) rateLimited`. *Alternative considered:* keep trying
+every posting — rejected, it wastes requests and prolongs the penalty.
+
+**5. Only fetch detail for postings that need it.** clinch's description is empty
+today; the hydrator fetches detail per sitemap entry during the run. Because the
+pipeline skips already-seen postings, a mostly-static board (e.g. Waymo)
+back-fills across runs: each run spends its ~budget on the newest/first N
+entries. This is acceptable for slowly-changing boards and needs no persistence.
+
+## Risks / Trade-offs
+
+- **Partial coverage** → Accepted and documented; the latch + per-run budget
+  means a large board hydrates a slice per run. Not a regression (empty
+  description is today's state for 100%).
+- **WAF trips early, near-zero descriptions** → Non-regressing by construction
+  (latch → sitemap-only). Interval is tunable from prod `board_health` / observed
+  description-fill rate without code changes to the contract.
+- **202-as-success elsewhere** → Guarded by matching the `x-amzn-waf-action`
+  header, not the status code, so no other source's legitimate 202 is affected.
+- **Detail HTML shape drift** (`div.job-description`) → Extraction failure yields
+  an empty description, never a dropped posting; covered by a spec scenario.
+
+## Migration Plan
+
+Pure additive code change, no schema/config. Deploy with the normal ingest
+image; the next scheduled `clinch` run begins hydrating. Rollback = revert the
+commit (clinch returns to sitemap-only). Tune the interval by observing the
+description-fill rate over a few runs.
+
+## Open Questions
+
+- Final interval/burst values — start conservative, confirm from the first prod
+  runs' fill rate (no contract change to adjust).

--- a/openspec/changes/clinch-detail-via-paced-challenge-layer/proposal.md
+++ b/openspec/changes/clinch-detail-via-paced-challenge-layer/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`clinch` job postings carry a title and location but no description: ClinchTalent
+fronts every detail page with an AWS-WAF *Challenge* action, so `clinch.go` is
+sitemap-only (`Description: ""`) and every description-derived facet stays blank.
+A spike (memory `hire-clinch-awswaf-challenge-spike`) established the gate is a
+**rate-based** challenge, not a hard block: a cold IP is served ~6 clean HTTP 200
+full pages (with `div.job-description`) before the WAF flips to HTTP 202 with
+`x-amzn-waf-action: challenge`. That headroom is enough to harvest descriptions
+if requests are paced and a trip is handled gracefully — no proxy, no token
+solver, no new dependency.
+
+## What Changes
+
+- **Transport correctness fix**: `Client.do` currently classifies HTTP 202 as
+  success (`>=200 && <300`), so a WAF challenge shell (~2464 B) would be parsed
+  as if it were the posting. Detect the `x-amzn-waf-action: challenge` response
+  and surface it as a typed `ChallengeError` instead of decoding the shell.
+- **Optional challenge-aware pacing layer**: extend the existing `pacer.go`
+  `rateLimitedHTMLGetter` seam with a conservative paced getter that any source
+  behind an AWS-WAF challenge can opt into — the reusable "plug in where needed"
+  layer.
+- **clinch detail hydration**: `clinch` fetches each `/jobs/` detail through the
+  paced getter and extracts the description from `div.job-description`. On the
+  first `ChallengeError` it **latches off** detail hydration for the rest of the
+  run (remaining postings keep the empty description they have today).
+- **Non-regression guarantee**: clinch is never worse than today's sitemap-only
+  behavior. Expected outcome is *partial* description coverage that back-fills
+  across runs; the pacing interval is tunable from observed convergence, matching
+  the `careerspage` / `hh` / `vagas` precedent.
+
+## Capabilities
+
+### New Capabilities
+- `waf-challenge-pacing`: the sources HTTP transport recognizes an AWS-WAF
+  challenge response and surfaces it as a typed error rather than content; an
+  optional rate-limited HTML getter lets a source pace its requests under the
+  challenge's per-IP window and react to a trip.
+- `clinch-source`: the clinch adapter hydrates job descriptions through the
+  paced challenge-aware getter with latch-off on a WAF trip, guaranteeing no
+  regression from the current sitemap-only reconstruction.
+
+### Modified Capabilities
+<!-- None: no existing spec covers the clinch adapter or the sources HTTP transport. -->
+
+## Impact
+
+- **Code**: `internal/sources/http.go` (challenge detection + `ChallengeError`),
+  `internal/sources/pacer.go` (paced clinch getter), `internal/sources/clinch.go`
+  (detail fetch + description extraction + latch), `internal/sources/source.go`
+  (wire clinch to the paced getter). Tests alongside each.
+- **Behavior**: clinch postings gain descriptions where the per-run WAF budget
+  allows; no change to any other source. No new dependency, proxy, or config.
+- **Ops**: a full clinch run makes more requests (one detail GET per new
+  posting, paced); bounded by the shared limiter so aggregate rate stays under
+  the WAF window.

--- a/openspec/changes/clinch-detail-via-paced-challenge-layer/specs/clinch-source/spec.md
+++ b/openspec/changes/clinch-detail-via-paced-challenge-layer/specs/clinch-source/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: clinch hydrates job descriptions through a paced challenge-aware getter
+
+The clinch adapter SHALL attempt to fetch each posting's detail page through a
+paced, challenge-aware HTML getter and populate the job description from the
+detail page's `div.job-description` content. The detail fetch SHALL be paced so
+the run's aggregate request rate stays under ClinchTalent's per-IP AWS-WAF
+challenge window.
+
+#### Scenario: Detail page yields a description
+
+- **WHEN** clinch fetches a posting whose detail page returns HTTP 200 with a `div.job-description`
+- **THEN** the resulting job's `Description` is the text of that block
+- **AND** the title and location reconstructed from the URL slug are unchanged
+
+#### Scenario: Detail page has no description block
+
+- **WHEN** the detail page returns 200 but contains no `div.job-description`
+- **THEN** the job keeps an empty `Description` (the slug-derived title/location still populate)
+
+### Requirement: A WAF trip latches off detail hydration for the rest of the run
+
+When a detail fetch returns a `ChallengeError`, the clinch adapter SHALL stop
+attempting further detail fetches for the remainder of that run and emit the
+remaining postings with the slug-reconstructed fields only. Hammering a tripped
+WAF is both wasteful and prolongs the per-IP penalty, so the latch is one-way
+within a run.
+
+#### Scenario: First challenge latches subsequent postings to sitemap-only
+
+- **WHEN** a detail fetch returns a `ChallengeError` partway through a run
+- **THEN** clinch stops fetching detail pages for the rest of that run
+- **AND** the already-hydrated postings keep their descriptions
+- **AND** the remaining postings are emitted with empty `Description` and the slug-derived title/location
+
+### Requirement: clinch is never worse than sitemap-only reconstruction
+
+Adding detail hydration SHALL NOT regress clinch's existing output. Every posting
+the sitemap-only adapter produced today SHALL still be produced, with the same
+`ExternalID`, `URL`, title, and location; the description is strictly additive.
+
+#### Scenario: All sitemap postings still emitted when detail is unavailable
+
+- **WHEN** every detail fetch fails or challenges
+- **THEN** clinch emits exactly the same postings it emits today, each with an empty `Description`
+
+#### Scenario: Detail-fetch failure does not drop the posting
+
+- **WHEN** a single posting's detail fetch errors (non-challenge, e.g. a 404 or timeout)
+- **THEN** that posting is still emitted with its slug-derived fields and an empty `Description`
+- **AND** the run continues to the next posting

--- a/openspec/changes/clinch-detail-via-paced-challenge-layer/specs/waf-challenge-pacing/spec.md
+++ b/openspec/changes/clinch-detail-via-paced-challenge-layer/specs/waf-challenge-pacing/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: WAF challenge responses are surfaced as a typed error
+
+The sources HTTP transport SHALL treat an AWS-WAF *Challenge* response as a
+retrievable-content failure, not as a successful body. A response is a challenge
+when it carries the `x-amzn-waf-action: challenge` header (AWS returns it with
+HTTP status 202). The transport SHALL NOT hand the challenge shell to the
+response decoder, and SHALL return a typed `ChallengeError` that callers can
+match with `errors.As`.
+
+#### Scenario: Challenge response is not decoded as content
+
+- **WHEN** a request receives a response with header `x-amzn-waf-action: challenge`
+- **THEN** the transport returns a `ChallengeError` (matchable via `errors.As`)
+- **AND** the response body is not passed to the caller's decode function
+
+#### Scenario: A normal 2xx is still decoded
+
+- **WHEN** a request receives HTTP 200 without the challenge header
+- **THEN** the transport decodes the body as it does today, unchanged
+
+#### Scenario: Challenge is not retried as a transient failure
+
+- **WHEN** a request receives a challenge response
+- **THEN** the transport returns the `ChallengeError` immediately without consuming a retry attempt
+
+### Requirement: Optional per-source request pacing under a shared limiter
+
+The transport SHALL provide an optional rate-limited HTML getter that any source
+may opt into, holding that source's aggregate `GetHTML` request rate under a
+configured interval independent of worker concurrency. All requests routed
+through one paced getter — across boards and both listing and detail paths —
+SHALL share a single token bucket, following the existing `rateLimitedHTMLGetter`
+pattern.
+
+#### Scenario: Paced getter gates requests through one shared limiter
+
+- **WHEN** a source is wired to a paced getter with interval `I` and burst `B`
+- **THEN** its `GetHTML` calls are admitted at the shared limiter's rate, regardless of how many workers issue them concurrently
+
+#### Scenario: A cancelled context surfaces before the inner fetch
+
+- **WHEN** the context is cancelled while a request waits on the limiter
+- **THEN** the getter returns the context error and does not perform the inner fetch

--- a/openspec/changes/clinch-detail-via-paced-challenge-layer/tasks.md
+++ b/openspec/changes/clinch-detail-via-paced-challenge-layer/tasks.md
@@ -1,0 +1,26 @@
+## 1. Transport: challenge detection
+
+- [x] 1.1 Add `ChallengeError` type (URL field, `errors.As`-matchable) in `internal/sources/http.go`, next to `StatusError`
+- [x] 1.2 In `Client.do`, before the 2xx success branch, return `ChallengeError` when the response header `x-amzn-waf-action == "challenge"`, closing the body and not decoding; return immediately without consuming a retry
+- [x] 1.3 Tests: challenge header → `ChallengeError` and decode fn is never called; a normal 200 still decodes; a challenge is not retried
+
+## 2. Optional paced challenge-aware getter
+
+- [x] 2.1 Add `pacedClinchGetter(c HTMLGetter) HTMLGetter` in `internal/sources/pacer.go`, reusing `rateLimitedHTMLGetter` with a conservative `clinchRequestInterval`/`clinchRequestBurst` (documented as tunable, per the careerspage/vagas precedent)
+- [x] 2.2 Tests: the paced getter gates `GetHTML` through the shared limiter (fake `waiter`) and propagates a `ChallengeError` from the inner getter unchanged
+
+## 3. clinch detail hydration + latch
+
+- [x] 3.1 Add a description extractor: given the detail page's `*html.Node`, return the text of `div.job-description` (empty string when absent)
+- [x] 3.2 Change `NewClinch` to take the composed getter it needs (sitemap XML + paced HTML detail); update the constructor and `clinch` struct
+- [x] 3.3 In `Fetch`, hydrate each posting's `Description` via the paced `GetHTML`, with a one-way latch: on the first `ChallengeError`, stop fetching detail for the rest of the run; a non-challenge detail error leaves the posting with an empty description and continues
+- [x] 3.4 Tests: 200 with `div.job-description` → description set; 200 without the block → empty description; first `ChallengeError` latches remaining postings to sitemap-only; a per-posting non-challenge error does not drop the posting; all sitemap postings are still emitted in every case (non-regression)
+
+## 4. Wiring
+
+- [x] 4.1 Wire clinch in `internal/sources/source.go` to construct its detail getter via `pacedClinchGetter`, mirroring how careerspage/hh/vagas are wired
+- [x] 4.2 `go build ./... && go vet ./... && go test ./internal/sources/...` green
+
+## 5. Verification
+
+- [x] 5.1 Run the clinch adapter against a live board in isolation (respecting the pace) and confirm at least the first postings carry a non-empty description and a mid-run challenge latches cleanly (no crash, no garbage description, all postings emitted)


### PR DESCRIPTION
## Summary
- `clinch` was sitemap-only (`Description: ""`) because ClinchTalent fronts detail pages with a **rate-based AWS-WAF Challenge** action. A spike established the gate serves ~6 clean pages to a cold IP before flipping to HTTP 202 (`x-amzn-waf-action: challenge`), so descriptions are harvestable with pacing + graceful trip handling — no proxy, token solver, or new dependency.
- **Transport fix** (`http.go`): an AWS-WAF challenge (202 + action header) is now surfaced as a typed `ChallengeError` instead of falling into the 2xx success branch and being decoded as content.
- **Optional pacing layer** (`pacer.go`): `pacedClinchGetter` reuses the existing `rateLimitedHTMLGetter` seam with a conservative interval to hold the run's rate under the WAF window.
- **clinch hydration** (`clinch.go`): each posting's description is pulled from `div.job-description` as sanitized HTML (matching every other adapter), latching detail hydration off on the first `ChallengeError` so remaining postings stay sitemap-only.
- **Non-regressing**: all sitemap postings still emitted; description is strictly additive. Coverage is partial and back-fills across runs (accepted tradeoff of pacing over a paid token).

Planned under OpenSpec (`openspec/changes/clinch-detail-via-paced-challenge-layer/`): proposal, design, two capability specs, tasks.

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` all green
- [x] Unit: challenge → `ChallengeError` (no decode, no retry); paced getter propagates `ChallengeError`; description preserves block structure as sanitized HTML; latch stops fetches after first challenge; detail error never drops a posting; all sitemap postings emitted (non-regression)
- [x] Live drive against `careers.withwaymo.com`: **402/402** postings reconstructed, **6** hydrated with clean block HTML (`<div><p>Waymo is an autonomous driving...`), **0** mashed descriptions, latch fired cleanly at the WAF trip
- [ ] Tune `clinchRequestInterval` from the first prod runs' description-fill rate (no contract change needed)
