### PR TITLE
fix(resume): raise upload limit to 8MB and clarify no-text error

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -59,9 +59,14 @@ func main() {
 		AppName:      "hire",
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
-		// Cap request bodies well under Fiber's 4MB default: the largest write is a
-		// single moderator job description, so 1MB bounds a memory-amplification body.
-		BodyLimit:    1 * 1024 * 1024,
+		// Cap request bodies at 8MB: résumé PDF uploads are the largest write (design-heavy
+		// CVs run past 1MB), and Fiber's BodyLimit is global — there is no per-route limit —
+		// so this ceiling applies to every endpoint. Keep it as tight as the résumé path
+		// allows to bound a memory-amplification body. The web client rejects oversize
+		// résumés up front so users get a clear message instead of a raw 413. Seam: if the
+		// broad ceiling ever matters, add a Content-Length guard middleware on the non-upload
+		// routes rather than lowering this.
+		BodyLimit:    8 * 1024 * 1024,
 		ErrorHandler: handler.RenderError,
 		// The app sits behind the in-network nginx proxy (web/nginx.conf). Key c.IP()
 		// (and thus the rate limiter) on X-Real-IP, which nginx OVERWRITES with the real

--- a/internal/handler/resume.go
+++ b/internal/handler/resume.go
@@ -39,6 +39,12 @@ type cvProfile struct {
 	Categories []string
 }
 
+// errResumeNoText is returned when a résumé file parsed cleanly but yielded no text —
+// a scanned or image-only PDF with no selectable text layer. The message names the real
+// cause (not a bare "empty") so the user knows to upload a text-based PDF or paste the
+// text, rather than assuming the file was rejected for its size.
+const errResumeNoText = "couldn't read any text from this PDF — it looks like a scan or image. Upload a text-based PDF, or paste your résumé text instead."
+
 // headlineRunes bounds the résumé "headline" fed to the title dictionaries: wide enough to
 // clear the name + contact preamble and reach the title (and a few summary words), tight
 // enough that the career-history section below can't reach in and over-promote the grade.
@@ -119,7 +125,7 @@ func resumeProfile(text string) cvProfile {
 // (a hiccup must not fail extraction, this endpoint's contract). When storage is
 // unconfigured the résumé is parsed and discarded (only the derived fields are returned).
 // Behind RequireAuth (cookie-only). Oversize bodies are rejected by the server's global
-// BodyLimit (413) before this handler runs.
+// BodyLimit (413) before this handler runs; the web client also guards the size up front.
 func (a *API) ExtractResumeProfile(c *fiber.Ctx) error {
 	userID, err := requireUserID(c)
 	if err != nil {
@@ -131,7 +137,7 @@ func (a *API) ExtractResumeProfile(c *fiber.Ctx) error {
 		return err
 	}
 	if strings.TrimSpace(up.Text) == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "resume is empty")
+		return fiber.NewError(fiber.StatusBadRequest, errResumeNoText)
 	}
 
 	prof := resumeProfile(up.Text)
@@ -193,7 +199,7 @@ func (a *API) PutResume(c *fiber.Ctx) error {
 		return err
 	}
 	if strings.TrimSpace(up.Text) == "" {
-		return fiber.NewError(fiber.StatusBadRequest, "resume is empty")
+		return fiber.NewError(fiber.StatusBadRequest, errResumeNoText)
 	}
 	meta, err := a.resume.Put(c.Context(), userID, up.ContentType, up.Data)
 	if err != nil {
@@ -334,7 +340,7 @@ func readResumeUpload(c *fiber.Ctx) (resumeUpload, error) {
 	}
 	defer f.Close()
 	// Buffer the upload: the raw bytes go to storage and the same bytes (as a ReaderAt)
-	// feed the PDF parser. The server's 1MB BodyLimit bounds this.
+	// feed the PDF parser. The server's 8MB BodyLimit bounds this.
 	data, err := io.ReadAll(f)
 	if err != nil {
 		return resumeUpload{}, fiber.NewError(fiber.StatusBadRequest, "cannot read resume file")

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -119,6 +119,12 @@ export interface JobCopy {
   posted_at: string | null;
 }
 
+/** Max résumé upload size, mirroring the server's BodyLimit (cmd/server/main.go). The
+ *  web client enforces it up front so an oversize PDF gets a clear message instead of the
+ *  raw 413 the server would emit before the handler runs. The UI also shows it as a hint. */
+export const RESUME_MAX_MB = 8;
+const RESUME_MAX_BYTES = RESUME_MAX_MB * 1024 * 1024;
+
 /** A non-2xx API response. Carries the HTTP status so callers can branch on it
  *  (e.g. 401 invalid credentials, 409 email taken) instead of parsing strings.
  *  `message` is the backend's `{ "error": msg }` text when present, so logs and
@@ -828,6 +834,12 @@ export function createApi(
    *  specializations and seniority resolved, ready to pre-fill a profile or the onboarding
    *  wizard. */
   async function extractResumeProfile(input: File | string): Promise<ResumeProfile> {
+    if (input instanceof File && input.size > RESUME_MAX_BYTES) {
+      throw new ApiError(
+        413,
+        `This PDF is larger than ${RESUME_MAX_MB} MB. Compress it or export a lighter PDF and try again.`,
+      );
+    }
     return requestData<ResumeProfile>(
       '/api/v1/me/resume/extract',
       resumeInit('POST', input),

--- a/web/src/lib/components/ProfileForm.svelte
+++ b/web/src/lib/components/ProfileForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ArrowUp, Check, X } from '@lucide/svelte';
-  import { api, ApiError } from '$lib/api';
+  import { api, ApiError, RESUME_MAX_MB } from '$lib/api';
   import {
     CATEGORY_OPTIONS,
     categoryLabel,
@@ -368,7 +368,7 @@
       {/if}
     </button>
     <span class="text-xs text-muted-foreground">
-      Extracts your skills below · parsed on the server; the file is stored to score its readiness.
+      PDF with selectable text, up to {RESUME_MAX_MB} MB · extracts your skills below; the file is stored to score its readiness.
     </span>
     {#if resumeError}
       <p class="text-sm text-destructive">{resumeError}</p>

--- a/web/src/lib/components/onboarding/OnboardingWizard.svelte
+++ b/web/src/lib/components/onboarding/OnboardingWizard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ArrowLeft, ArrowRight, FileUp, LoaderCircle, X } from '@lucide/svelte';
-  import { api, ApiError } from '$lib/api';
+  import { api, ApiError, RESUME_MAX_MB } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import {
@@ -255,6 +255,8 @@
             <p class="mt-2 text-xs text-destructive">{cvError} Or fill it in below.</p>
           {:else if cvNote}
             <p class="mt-2 text-xs text-muted-foreground">{cvNote}</p>
+          {:else}
+            <p class="mt-2 text-xs text-muted-foreground">PDF with selectable text, up to {RESUME_MAX_MB} MB.</p>
           {/if}
           <div class="my-4 flex items-center gap-3 text-xs text-muted-foreground">
             <span class="h-px flex-1 bg-border"></span> or answer 2 questions <span class="h-px flex-1 bg-border"></span>


### PR DESCRIPTION
## Problem

Two distinct issues surfaced as one user report ("resume is empty" on upload):

1. **Oversize resumes** — design-heavy CV PDFs routinely exceed the old **1MB global `BodyLimit`** and were rejected with a raw `413` *before the handler ran*, with no size hint anywhere in the UI.
2. **Scanned/image PDFs** — a PDF with no selectable text layer parses cleanly but yields no text, which surfaced as the misleading **`resume is empty`**. Users read it as a size problem; it isn't.

## Changes

- **`cmd/server/main.go`** — raise the global Fiber `BodyLimit` **1MB → 8MB**. Fiber v2 has no per-route limit, so this is global; comment notes the seam for a Content-Length guard on non-upload routes if the broad ceiling ever matters.
- **`internal/handler/resume.go`** — replace `resume is empty` with an actionable message naming the real cause (no selectable text → upload a text-based PDF or paste the text).
- **`web/src/lib/api.ts`** — export `RESUME_MAX_MB` and enforce it client-side in `extractResumeProfile`, so an oversize PDF gets a clear message instead of the raw 413. Single guard covers both upload surfaces.
- **`ProfileForm.svelte`, `OnboardingWizard.svelte`** — show "PDF with selectable text, up to 8 MB" hint.

## Verification

`go build ./...`, `go vet`, `go test ./internal/handler/` green; `svelte-check` 0 errors; `gofmt` clean.