### PR TITLE
fix(reminders): toggle switch + settings polish, chip above the card

### DIFF
--- a/web/src/lib/components/ReminderSettings.svelte
+++ b/web/src/lib/components/ReminderSettings.svelte
@@ -46,6 +46,12 @@
     error = null;
   }
 
+  function toggleEnabled() {
+    if (status !== 'ready') return;
+    enabled = !enabled;
+    dirty();
+  }
+
   function toggleChannel(channel: string) {
     channels = channels.includes(channel) ? channels.filter((c) => c !== channel) : [...channels, channel];
     dirty();
@@ -73,34 +79,55 @@
     }
   }
 
-  const chipClass = (on: boolean) =>
+  const pill = (on: boolean) =>
     cn(
       'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors disabled:opacity-50',
       on
         ? 'border-transparent bg-brand-muted text-brand-strong'
-        : 'border-border bg-background text-muted-foreground hover:border-muted-foreground/40',
+        : 'border-border bg-background text-muted-foreground hover:border-muted-foreground/40 hover:text-foreground',
     );
+
+  const needsChannel = $derived(enabled && channels.length === 0);
 </script>
 
-<section class="rounded-lg border border-border bg-card p-4">
-  <div class="flex items-start justify-between gap-3">
-    <div class="flex flex-col gap-0.5">
-      <h2 class="flex items-center gap-1.5 text-sm font-semibold">
-        <Bell class="size-4" aria-hidden="true" /> Reminders
-      </h2>
+<section class="rounded-xl border border-border bg-card p-5">
+  <div class="flex items-center gap-3">
+    <div class="grid size-9 shrink-0 place-items-center rounded-lg bg-brand-muted text-brand-strong">
+      <Bell class="size-4.5" aria-hidden="true" />
+    </div>
+    <div class="min-w-0 flex-1">
+      <h2 class="text-sm font-semibold leading-tight">Reminders</h2>
       <p class="text-xs text-muted-foreground">Nudge me to come back to a saved job before it goes stale.</p>
     </div>
-    <label class="inline-flex cursor-pointer items-center gap-2 text-xs font-medium">
-      <input type="checkbox" bind:checked={enabled} onchange={dirty} disabled={status !== 'ready'} class="size-4 accent-brand" />
-      {enabled ? 'On' : 'Off'}
-    </label>
+
+    <!-- Toggle switch: the account on/off for reminders. -->
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      aria-label="Enable reminders"
+      onclick={toggleEnabled}
+      disabled={status !== 'ready'}
+      class={cn(
+        'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-ring focus-visible:ring-offset-2 focus-visible:ring-offset-card',
+        enabled ? 'bg-brand' : 'bg-muted',
+      )}
+    >
+      <span
+        class={cn(
+          'inline-block size-5 rounded-full bg-white shadow-sm transition-transform',
+          enabled ? 'translate-x-[22px]' : 'translate-x-0.5',
+        )}
+      ></span>
+    </button>
   </div>
 
   {#if status === 'error'}
-    <p class="mt-3 text-xs text-destructive">Couldn't load your reminder settings.</p>
+    <p class="mt-4 text-xs text-destructive">Couldn't load your reminder settings.</p>
   {:else if enabled && status === 'ready'}
-    <div class="mt-4 flex flex-col gap-4">
-      <div class="flex flex-col gap-1.5">
+    <div class="mt-5 flex flex-col gap-5 border-t border-border pt-5">
+      <div class="flex flex-col gap-2">
         <span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Remind me after</span>
         <div class="flex flex-wrap items-center gap-2">
           {#each presets as d (d)}
@@ -110,7 +137,7 @@
                 delayDays = d;
                 dirty();
               }}
-              class={chipClass(delayDays === d)}
+              class={pill(delayDays === d)}
             >
               {d === 1 ? '1 day' : `${d} days`}
             </button>
@@ -118,11 +145,11 @@
         </div>
       </div>
 
-      <div class="flex flex-col gap-1.5">
+      <div class="flex flex-col gap-2">
         <span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Deliver over</span>
         <div class="flex flex-wrap items-center gap-2">
           {#if telegramAvailable}
-            <button type="button" onclick={() => toggleChannel('telegram')} aria-pressed={channels.includes('telegram')} class={chipClass(channels.includes('telegram'))}>
+            <button type="button" onclick={() => toggleChannel('telegram')} aria-pressed={channels.includes('telegram')} class={pill(channels.includes('telegram'))}>
               {#if channels.includes('telegram')}
                 <Check class="size-3.5" aria-hidden="true" />
               {:else}
@@ -131,7 +158,7 @@
               Telegram
             </button>
           {/if}
-          <button type="button" onclick={() => toggleChannel('email')} aria-pressed={channels.includes('email')} class={chipClass(channels.includes('email'))}>
+          <button type="button" onclick={() => toggleChannel('email')} aria-pressed={channels.includes('email')} class={pill(channels.includes('email'))}>
             {#if channels.includes('email')}
               <Check class="size-3.5" aria-hidden="true" />
             {:else}
@@ -141,26 +168,26 @@
           </button>
         </div>
         {#if channels.includes('telegram')}
-          <p class="text-xs text-muted-foreground">Telegram reminders need the bot connected on your <a class="underline underline-offset-2" href={resolve('/my/searches')}>notifications</a> page.</p>
+          <p class="text-xs text-muted-foreground">Telegram reminders need the bot connected on your <a class="font-medium text-foreground underline underline-offset-2 hover:opacity-80" href={resolve('/my/searches')}>notifications</a> page.</p>
         {/if}
       </div>
     </div>
   {/if}
 
   {#if status === 'ready'}
-    <div class="mt-4 flex items-center gap-3">
+    <div class="mt-5 flex items-center gap-3">
       <button
         type="button"
         onclick={save}
-        disabled={saving || (enabled && channels.length === 0)}
-        class="rounded-md bg-brand px-3 py-1.5 text-xs font-semibold text-brand-foreground transition-colors hover:opacity-90 disabled:opacity-50"
+        disabled={saving || needsChannel}
+        class="rounded-lg bg-brand px-4 py-1.5 text-xs font-semibold text-brand-foreground transition-colors hover:opacity-90 disabled:opacity-50"
       >
         {saving ? 'Saving…' : 'Save'}
       </button>
-      {#if enabled && channels.length === 0}
+      {#if needsChannel}
         <span class="text-xs text-muted-foreground">Pick at least one channel.</span>
       {:else if savedOk}
-        <span class="flex items-center gap-1 text-xs text-muted-foreground"><Check class="size-3.5" aria-hidden="true" /> Saved</span>
+        <span class="flex items-center gap-1 text-xs text-brand-strong"><Check class="size-3.5" aria-hidden="true" /> Saved</span>
       {:else if error}
         <span class="text-xs text-destructive">{error}</span>
       {/if}

--- a/web/src/lib/components/SavedJobs.svelte
+++ b/web/src/lib/components/SavedJobs.svelte
@@ -27,8 +27,8 @@
   <ul class="flex flex-col gap-3">
     {#each page.items as item (item.job.public_slug)}
       <li class="flex flex-col gap-2">
-        <JobRow job={item.job} dimViewed={false} />
         <ReminderChip slug={item.job.public_slug} fireAt={item.reminder_fire_at} />
+        <JobRow job={item.job} dimViewed={false} />
       </li>
     {/each}
   </ul>


### PR DESCRIPTION
Follow-up UI polish for saved-job reminders:

- **Reminders settings** (`/my/activity`): the enable control is now an on/off **toggle switch** instead of a checkbox; the bell sits in a rounded tile, a divider separates the delay/channel rows, and spacing/hierarchy are tidied.
- **Saved list**: the per-job reminder chip now renders **above** the job card instead of below it.

svelte-check 0 errors, lint clean on changed files.