### PR TITLE
feat(filters): default new visitors to remote worldwide + simplify alert heading

### DIFF
--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -13,7 +13,7 @@
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams, activeFilterCount, type SortField } from '$lib/filters';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
-  import { loadJobFilters } from '$lib/filterStorage';
+  import { loadJobFilters, hasChangedFilters, DEFAULT_JOB_FILTERS } from '$lib/filterStorage';
   import {
     bannerVisible,
     loadOnboardingState,
@@ -139,6 +139,11 @@
   // didn't change the filters (back/forward re-seed, CV sign-in prompt toggle)
   // doesn't emit a spurious funnel event.
   let lastSearchKey = '';
+  // True once we seed the first-visit default (remote / worldwide) for a brand-new
+  // visitor on a bare /jobs. Those filters are ours, not the user's choice, so the
+  // onboarding banner still treats the feed as "unfiltered" and the first reload
+  // isn't skipped as a fresh SSR page.
+  let seededDefault = $state(false);
 
   // Onboarding: the one-time nudge banner + wizard, standalone-only. The lifecycle
   // lives in localStorage (client-only); seed it at init on the client so a returning
@@ -154,7 +159,9 @@
   // so a shared search/filter link is never interrupted (activeFilterCount ignores the
   // query, so check it explicitly). Gated on `browser`: never SSR the banner.
   const showBanner = $derived(
-    browser && standalone && bannerVisible(onboardingState, filters.active > 0 || filters.value.q.trim() !== ''),
+    browser &&
+      standalone &&
+      bannerVisible(onboardingState, !seededDefault && (filters.active > 0 || filters.value.q.trim() !== '')),
   );
 
   function dismissBanner() {
@@ -217,6 +224,16 @@
   // sets stay empty). Cleanup: cancel any pending debounced reload so it can't fire
   // after this view is gone.
   onMount(() => {
+    // First-ever visit to the standalone feed: default to fully-remote, worldwide
+    // roles so a new user lands on the most relevant slice. Only on a bare /jobs (a
+    // shared filter/search link is left untouched) and only when this browser has
+    // never changed filters — a cleared set counts as changed, so it stays cleared.
+    // Client-side after hydration: the router is ready for the store's replaceState,
+    // and the seed persists like any filter set (restored normally on later visits).
+    if (standalone && location.search === '' && !hasChangedFilters()) {
+      filters.apply(DEFAULT_JOB_FILTERS);
+      seededDefault = true;
+    }
     if (isAuthenticated()) {
       ensureViewedLoaded();
       ensureSavedLoaded();
@@ -270,9 +287,10 @@
       if (firstRun) {
         started = true;
         // Keep the SSR `initial` page unless it was loaded for a different URL than
-        // the address bar (stale shallow-routing restore) or the feed is in CV mode
-        // — the SSR seed is the newest-sorted keyword feed, wrong for CV ranking.
-        if (!initialStale && !cvMode) return;
+        // the address bar (stale shallow-routing restore), the feed is in CV mode
+        // (the SSR seed is the newest-sorted keyword feed, wrong for CV ranking), or
+        // we seeded the first-visit default (the SSR page is unfiltered, now stale).
+        if (!initialStale && !cvMode && !seededDefault) return;
       }
       if (blocked) return;
       // Funnel search — only when the applied filters actually changed: not the

--- a/web/src/lib/components/SavedSearches.svelte
+++ b/web/src/lib/components/SavedSearches.svelte
@@ -132,10 +132,10 @@
     <!-- Zone 1: alerts for the filters staged right now. Save is the primary action;
          once saved, the channel toggles (Telegram / Email) render in place. -->
     <section class="flex flex-col gap-2">
-      <span class="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-        <Bell class="size-3.5" aria-hidden="true" /> Alerts for the current filters
+      <span class="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <Bell class="size-3.5 shrink-0" aria-hidden="true" /> Notify me when a new job matches these filters
       </span>
-      <SaveSearchAlert query={current} variant="full" />
+      <SaveSearchAlert query={current} variant="full" alertsLabel={false} />
 
       {#if dirty}
         <Button variant="secondary" size="sm" onclick={update} disabled={busy} class="self-start">

--- a/web/src/lib/components/filters/AlertChannels.svelte
+++ b/web/src/lib/components/filters/AlertChannels.svelte
@@ -12,7 +12,7 @@
   //
   // A chip is "on" when a subscription exists for that channel; tapping an on chip turns
   // it off. Telegram hides itself when the feature isn't configured server-side.
-  let { savedSearchId }: { savedSearchId: number } = $props();
+  let { savedSearchId, showLabel = true }: { savedSearchId: number; showLabel?: boolean } = $props();
 
   let busy = $state<'telegram' | 'email' | null>(null);
   // The Telegram deep link was opened; we await the user's "I've connected" recheck.
@@ -97,9 +97,11 @@
 
 <div class="flex flex-col gap-1.5">
   <div class="flex flex-wrap items-center gap-2">
-    <span class="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-      <Bell class="size-3.5" aria-hidden="true" /> Alerts
-    </span>
+    {#if showLabel}
+      <span class="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <Bell class="size-3.5" aria-hidden="true" /> Alerts
+      </span>
+    {/if}
 
     {#if tg.enabled}
       <button type="button" onclick={toggleTelegram} disabled={busy !== null} aria-pressed={tgSub != null} class={chipClass(tgSub != null)}>

--- a/web/src/lib/components/filters/SaveSearchAlert.svelte
+++ b/web/src/lib/components/filters/SaveSearchAlert.svelte
@@ -24,11 +24,14 @@
     query,
     variant = 'full',
     alerts = 'inline',
+    alertsLabel = true,
     autostart = false,
   }: {
     query: string;
     variant?: 'quick' | 'full';
     alerts?: 'inline' | 'manage';
+    /** Show the "Alerts" label above the channel chips; off where a section header already says it. */
+    alertsLabel?: boolean;
     /** Run the save on mount — used to resume a pending save after sign-in. */
     autostart?: boolean;
   } = $props();
@@ -106,7 +109,7 @@
       <ChevronRight class="size-4 text-muted-foreground" aria-hidden="true" />
     </Button>
   {:else}
-    <AlertChannels savedSearchId={matched.id} />
+    <AlertChannels savedSearchId={matched.id} showLabel={alertsLabel} />
   {/if}
 
   {#if error}

--- a/web/src/lib/filterStorage.test.ts
+++ b/web/src/lib/filterStorage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { loadJobFilters, saveJobFilters, JOB_FILTERS_KEY } from './filterStorage';
+import { loadJobFilters, saveJobFilters, hasChangedFilters, JOB_FILTERS_KEY } from './filterStorage';
 
 // A minimal in-memory localStorage stand-in for the Node test environment (where
 // there is no browser storage). Individual tests swap in throwing/undefined
@@ -44,6 +44,34 @@ describe('filterStorage', () => {
 
     expect(store.getItem(JOB_FILTERS_KEY)).toBeNull();
     expect(loadJobFilters()).toBe('');
+  });
+
+  it('reports no filter history for a fresh browser, then history after any change', () => {
+    const store = new MemoryStorage();
+    // @ts-expect-error - install the stand-in
+    globalThis.localStorage = store;
+
+    expect(hasChangedFilters()).toBe(false);
+
+    saveJobFilters('regions=EU');
+    expect(hasChangedFilters()).toBe(true);
+  });
+
+  it('keeps filter history set after a clear, so a cleared set stays distinct from a fresh visit', () => {
+    const store = new MemoryStorage();
+    // @ts-expect-error - install the stand-in
+    globalThis.localStorage = store;
+
+    saveJobFilters('regions=EU');
+    saveJobFilters(''); // clear
+
+    expect(loadJobFilters()).toBe('');
+    expect(hasChangedFilters()).toBe(true);
+  });
+
+  it('reports no filter history when storage is unavailable (SSR)', () => {
+    // No globalThis.localStorage installed.
+    expect(hasChangedFilters()).toBe(false);
   });
 
   it('returns empty and no-ops when storage is unavailable (SSR)', () => {

--- a/web/src/lib/filterStorage.ts
+++ b/web/src/lib/filterStorage.ts
@@ -11,6 +11,16 @@
 
 export const JOB_FILTERS_KEY = 'hire.jobFilters';
 
+// Set once this browser has made any explicit filter change — an edit, an applied
+// saved search, or a clear. It's a separate key because clearing *removes*
+// JOB_FILTERS_KEY, so the filters' absence alone can't tell a first-time visitor
+// (offer the default) from someone who deliberately cleared (respect the empty set).
+const FILTERS_TOUCHED_KEY = 'hire.jobFiltersTouched';
+
+/** The filter set a first-time visitor lands on: fully-remote roles open worldwide.
+ *  Same facet vocabulary as the `remote-worldwide` collection (see collections.ts). */
+export const DEFAULT_JOB_FILTERS = 'work_mode=remote&regions=global';
+
 /** The stored filter query string, or '' when absent/unavailable. */
 export function loadJobFilters(): string {
   if (typeof localStorage === 'undefined') return '';
@@ -21,13 +31,27 @@ export function loadJobFilters(): string {
   }
 }
 
+/** True once the visitor has changed filters at least once (including clearing them).
+ *  Absent only for a browser that has never touched the /jobs filters — the single
+ *  case offered the first-visit default. */
+export function hasChangedFilters(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    return localStorage.getItem(FILTERS_TOUCHED_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
 /** Mirror the applied filters to storage. An empty string removes the key, so a
- *  cleared filter set leaves nothing to restore. */
+ *  cleared filter set leaves nothing to restore. Either way the change marks the
+ *  browser as touched, so the first-visit default is never re-offered. */
 export function saveJobFilters(qs: string): void {
   if (typeof localStorage === 'undefined') return;
   try {
     if (qs) localStorage.setItem(JOB_FILTERS_KEY, qs);
     else localStorage.removeItem(JOB_FILTERS_KEY);
+    localStorage.setItem(FILTERS_TOUCHED_KEY, '1');
   } catch {
     // best-effort: private mode / quota / disabled storage
   }


### PR DESCRIPTION
## What

Two filter-UX changes in the standalone `/jobs` feed, split into two commits.

### 1. `refactor(filters)` — simplify the saved-filters alert heading
The "My filters" modal stacked two bell-labelled headings — the section **"Alerts for the current filters"** and the channel row's **"Alerts"** — reading as a redundant double header in a heavy uppercase font.

- Section heading → plain-weight sentence: **"Notify me when a new job matches these filters"**.
- Hide the inner "Alerts" label in the modal via a new `AlertChannels` `showLabel` prop (default `true`, so `/my/searches` and onboarding are untouched — that label is useful where there's no section header).

### 2. `feat(filters)` — default new visitors to remote / worldwide
A brand-new visitor landing on a bare `/jobs` now starts on fully-remote, worldwide roles (`work_mode=remote&regions=global` — the same set as the `remote-worldwide` collection).

- Seeded **client-side after hydration** (router ready for the store's `replaceState`), only when the URL carries no filters **and** this browser has never changed them.
- Clearing filters removes the persisted key, so absence alone can't distinguish a first-time visitor from someone who deliberately cleared. A new `hire.jobFiltersTouched` marker — set on every explicit filter write, including a clear — draws that line: the default is offered **exactly once**, and a cleared set stays cleared.
- A `seededDefault` flag marks the seed as *ours, not the user's choice*, so the onboarding banner still shows (it reads the feed as unfiltered) and the first list reload isn't skipped as a fresh SSR page — robust to the `onMount` / reload-`$effect` ordering.

## Product decision
New visitors keep the onboarding banner **and** get the default filters (chosen over suppressing the banner or skipping the seed).

## Testing
- `npx svelte-check` → 0 errors.
- `npx vitest run` → 303/303, incl. 3 new `filterStorage` tests (fresh browser has no history; a cleared set keeps history so it stays distinct from a first visit).
- Not yet exercised in a live browser — the seed logic is reasoned robust to both mount/effect orderings; a manual pass (clean localStorage → bare `/jobs` → remote+worldwide + banner; revisit with history → empty) is still worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
