### PR TITLE
fix(reminders): autosave settings, drop the Save button, narrower block

### DIFF
--- a/web/src/lib/components/ReminderSettings.svelte
+++ b/web/src/lib/components/ReminderSettings.svelte
@@ -8,8 +8,10 @@
 
   // The account-level saved-job reminder rule: turn reminders on, set the default
   // delay applied to new saves, and pick the delivery channels. Reminders are off
-  // until the user enables them here. Scheduling itself happens per-save (with an
-  // optional override); this block governs the default and the channels.
+  // until the user enables them here. Changes autosave — there is no Save button.
+  // The UI keeps the rule valid so an invalid payload never reaches the server:
+  // enabling defaults to the email channel, and the last channel can't be removed
+  // while reminders are on (an enabled rule requires at least one channel).
 
   let enabled = $state(false);
   let delayDays = $state(3);
@@ -17,11 +19,13 @@
   let telegramAvailable = $state(false);
 
   let status = $state<'loading' | 'ready' | 'error'>('loading');
-  let saving = $state(false);
-  let error = $state<string | null>(null);
-  let savedOk = $state(false);
+  let saveState = $state<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  let saveError = $state<string | null>(null);
 
   const presets = [1, 3, 7, 14];
+
+  let saveTimer: ReturnType<typeof setTimeout> | undefined;
+  let savedTimer: ReturnType<typeof setTimeout> | undefined;
 
   $effect(() => {
     if (isAuthenticated()) void load();
@@ -41,56 +45,60 @@
     }
   }
 
-  function dirty() {
-    savedOk = false;
-    error = null;
+  // Debounced autosave: batches rapid clicks into one write, then shows a brief
+  // "Saved". The UI only ever holds valid state, so the write can't 400.
+  function persist() {
+    saveState = 'saving';
+    saveError = null;
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(doSave, 350);
+  }
+
+  async function doSave() {
+    try {
+      await api.updateReminderSettings({ enabled, default_delay_days: delayDays, channels });
+      saveState = 'saved';
+      clearTimeout(savedTimer);
+      savedTimer = setTimeout(() => {
+        if (saveState === 'saved') saveState = 'idle';
+      }, 1500);
+    } catch (e) {
+      saveState = 'error';
+      saveError = e instanceof ApiError ? e.message : 'Could not save.';
+    }
   }
 
   function toggleEnabled() {
     if (status !== 'ready') return;
     enabled = !enabled;
-    dirty();
+    // Enabling needs a channel; default to email (always deliverable to the account).
+    if (enabled && channels.length === 0) channels = ['email'];
+    persist();
   }
 
   function toggleChannel(channel: string) {
-    channels = channels.includes(channel) ? channels.filter((c) => c !== channel) : [...channels, channel];
-    dirty();
+    const has = channels.includes(channel);
+    // Keep at least one channel while reminders are on — the invariant the server enforces.
+    if (has && enabled && channels.length === 1) return;
+    channels = has ? channels.filter((c) => c !== channel) : [...channels, channel];
+    persist();
   }
 
-  async function save() {
-    if (saving) return;
-    saving = true;
-    error = null;
-    savedOk = false;
-    try {
-      const settings = await api.updateReminderSettings({
-        enabled,
-        default_delay_days: delayDays,
-        channels,
-      });
-      enabled = settings.enabled;
-      delayDays = settings.default_delay_days;
-      channels = settings.channels;
-      savedOk = true;
-    } catch (e) {
-      error = e instanceof ApiError ? e.message : 'Could not save your reminder settings.';
-    } finally {
-      saving = false;
-    }
+  function setDelay(d: number) {
+    delayDays = d;
+    persist();
   }
 
   const pill = (on: boolean) =>
     cn(
-      'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors disabled:opacity-50',
+      'inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors',
       on
         ? 'border-transparent bg-brand-muted text-brand-strong'
         : 'border-border bg-background text-muted-foreground hover:border-muted-foreground/40 hover:text-foreground',
     );
-
-  const needsChannel = $derived(enabled && channels.length === 0);
 </script>
 
-<section class="rounded-xl border border-border bg-card p-5">
+<section class="max-w-2xl rounded-xl border border-border bg-card p-4">
   <div class="flex items-center gap-3">
     <div class="grid size-9 shrink-0 place-items-center rounded-lg bg-brand-muted text-brand-strong">
       <Bell class="size-4.5" aria-hidden="true" />
@@ -100,7 +108,15 @@
       <p class="text-xs text-muted-foreground">Nudge me to come back to a saved job before it goes stale.</p>
     </div>
 
-    <!-- Toggle switch: the account on/off for reminders. -->
+    <!-- Autosave status, then the on/off toggle. -->
+    {#if saveState === 'saving'}
+      <span class="text-xs text-muted-foreground">Saving…</span>
+    {:else if saveState === 'saved'}
+      <span class="flex items-center gap-1 text-xs text-brand-strong"><Check class="size-3.5" aria-hidden="true" /> Saved</span>
+    {:else if saveState === 'error'}
+      <span class="text-xs text-destructive">{saveError}</span>
+    {/if}
+
     <button
       type="button"
       role="switch"
@@ -126,19 +142,12 @@
   {#if status === 'error'}
     <p class="mt-4 text-xs text-destructive">Couldn't load your reminder settings.</p>
   {:else if enabled && status === 'ready'}
-    <div class="mt-5 flex flex-col gap-5 border-t border-border pt-5">
+    <div class="mt-4 flex flex-col gap-4 border-t border-border pt-4">
       <div class="flex flex-col gap-2">
         <span class="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Remind me after</span>
         <div class="flex flex-wrap items-center gap-2">
           {#each presets as d (d)}
-            <button
-              type="button"
-              onclick={() => {
-                delayDays = d;
-                dirty();
-              }}
-              class={pill(delayDays === d)}
-            >
+            <button type="button" onclick={() => setDelay(d)} class={pill(delayDays === d)}>
               {d === 1 ? '1 day' : `${d} days`}
             </button>
           {/each}
@@ -171,26 +180,6 @@
           <p class="text-xs text-muted-foreground">Telegram reminders need the bot connected on your <a class="font-medium text-foreground underline underline-offset-2 hover:opacity-80" href={resolve('/my/searches')}>notifications</a> page.</p>
         {/if}
       </div>
-    </div>
-  {/if}
-
-  {#if status === 'ready'}
-    <div class="mt-5 flex items-center gap-3">
-      <button
-        type="button"
-        onclick={save}
-        disabled={saving || needsChannel}
-        class="rounded-lg bg-brand px-4 py-1.5 text-xs font-semibold text-brand-foreground transition-colors hover:opacity-90 disabled:opacity-50"
-      >
-        {saving ? 'Saving…' : 'Save'}
-      </button>
-      {#if needsChannel}
-        <span class="text-xs text-muted-foreground">Pick at least one channel.</span>
-      {:else if savedOk}
-        <span class="flex items-center gap-1 text-xs text-brand-strong"><Check class="size-3.5" aria-hidden="true" /> Saved</span>
-      {:else if error}
-        <span class="text-xs text-destructive">{error}</span>
-      {/if}
     </div>
   {/if}
 </section>


### PR DESCRIPTION
- **Autosave**: the reminder rule saves automatically (debounced) on every change — no more Save button — with a brief inline 'Saved'/'Saving…' status by the toggle.
- **Always-valid**: enabling defaults to the email channel, and the last channel can't be removed while reminders are on, so an enabled-with-no-channels payload never reaches the server (which would 400).
- **Narrower**: the block is constrained to `max-w-2xl` so it reads as a compact settings panel.

svelte-check 0 errors, lint clean.