### PR TITLE
perf(companies): estimate unfiltered /companies total instead of count(*)

### DIFF
--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -190,6 +190,22 @@ func (q *Queries) DeleteOrphanCompanies(ctx context.Context) (int64, error) {
 	return result.RowsAffected(), nil
 }
 
+const estimateHiringCompanies = `-- name: EstimateHiringCompanies :one
+SELECT estimate_hiring_companies()::bigint
+`
+
+// Fast approximate hiring-company total (job_count > 0) for the UNFILTERED /companies
+// list's meta.total. An exact count(*) over the ~227k hiring rows is a cold-cache heap
+// scan (~17s on prod, see migration 0034); the planner's estimate is O(1). Only the
+// no-filter catalogue count uses this — every facet/search filter narrows to an index
+// and keeps CountCompanies cheap and exact. Approximate by design, like EstimateOpenJobs.
+func (q *Queries) EstimateHiringCompanies(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, estimateHiringCompanies)
+	var column_1 int64
+	err := row.Scan(&column_1)
+	return column_1, err
+}
+
 const getCompany = `-- name: GetCompany :one
 SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes, industries, year_founded, employee_count, hq_country, organization_type, tagline, company_info, is_reference, company_info_at, remote_regions, yc_batch, yc_status, yc_stage, yc_flags, maturity, subindustry
 FROM companies

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -336,6 +336,12 @@ type Querier interface {
 	// For an existing user the row is left untouched; a stale period is reset later
 	// under the lock. remaining is seeded with the monthly grant for a fresh row.
 	EnsureBalance(ctx context.Context, arg EnsureBalanceParams) error
+	// Fast approximate hiring-company total (job_count > 0) for the UNFILTERED /companies
+	// list's meta.total. An exact count(*) over the ~227k hiring rows is a cold-cache heap
+	// scan (~17s on prod, see migration 0034); the planner's estimate is O(1). Only the
+	// no-filter catalogue count uses this — every facet/search filter narrows to an index
+	// and keeps CountCompanies cheap and exact. Approximate by design, like EstimateOpenJobs.
+	EstimateHiringCompanies(ctx context.Context) (int64, error)
 	// Fast approximate open-job total for the DB-backed /jobs list's meta.total. An
 	// exact count(*) over ~millions of open rows was a per-request full scan; the
 	// planner's estimate (see estimate_open_jobs(), migration 0033) is O(1) and

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -61,6 +61,14 @@ WHERE job_count > 0
   AND (coalesce(cardinality(sqlc.arg('maturity')::text[]), 0) = 0 OR maturity = ANY(sqlc.arg('maturity')::text[]))
   AND (coalesce(cardinality(sqlc.arg('subindustries')::text[]), 0) = 0 OR subindustry = ANY(sqlc.arg('subindustries')::text[]));
 
+-- name: EstimateHiringCompanies :one
+-- Fast approximate hiring-company total (job_count > 0) for the UNFILTERED /companies
+-- list's meta.total. An exact count(*) over the ~227k hiring rows is a cold-cache heap
+-- scan (~17s on prod, see migration 0034); the planner's estimate is O(1). Only the
+-- no-filter catalogue count uses this — every facet/search filter narrows to an index
+-- and keeps CountCompanies cheap and exact. Approximate by design, like EstimateOpenJobs.
+SELECT estimate_hiring_companies()::bigint;
+
 -- name: CompanySubindustries :many
 -- Distinct non-NULL subindustry values with their company counts, most common first
 -- (ties broken by value), serving the searchable option list for the subindustry facet.

--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -133,27 +133,52 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 		return err
 	}
 
-	total, err := a.queries.CountCompanies(c.Context(), db.CountCompaniesParams{
-		Search:        search,
-		Collections:   collections,
-		Regions:       regions,
-		Countries:     countries,
-		Domains:       domains,
-		CompanyTypes:  companyTypes,
-		CompanySizes:  companySizes,
-		RemoteRegions: remoteRegions,
-		YcBatch:       ycBatch,
-		YcStatus:      ycStatus,
-		YcStage:       ycStage,
-		YcFlags:       ycFlags,
-		Maturity:      maturity,
-		Subindustries: subindustries,
-	})
+	// The unfiltered catalogue count(*) is a cold-cache heap scan (~17s on prod — see
+	// EstimateHiringCompanies); every facet/search filter narrows to an index and keeps
+	// it cheap. So a filtered request gets the exact count (accurate pagination total),
+	// and the pathological unfiltered case gets the O(1) planner estimate, as /jobs does.
+	var total int64
+	if isCompanyFilter(search, collections, regions, countries, domains, companyTypes,
+		companySizes, remoteRegions, ycBatch, ycStatus, ycStage, ycFlags, maturity, subindustries) {
+		total, err = a.queries.CountCompanies(c.Context(), db.CountCompaniesParams{
+			Search:        search,
+			Collections:   collections,
+			Regions:       regions,
+			Countries:     countries,
+			Domains:       domains,
+			CompanyTypes:  companyTypes,
+			CompanySizes:  companySizes,
+			RemoteRegions: remoteRegions,
+			YcBatch:       ycBatch,
+			YcStatus:      ycStatus,
+			YcStage:       ycStage,
+			YcFlags:       ycFlags,
+			Maturity:      maturity,
+			Subindustries: subindustries,
+		})
+	} else {
+		total, err = a.queries.EstimateHiringCompanies(c.Context())
+	}
 	if err != nil {
 		return err
 	}
 
 	return listResponse(c, companies, total, limit, offset)
+}
+
+// isCompanyFilter reports whether a /companies request carries any name search or facet
+// constraint — the exact-vs-estimate meta.total gate in ListCompanies. Every facet arrives
+// as a non-nil slice, so len == 0 means unset.
+func isCompanyFilter(search string, facets ...[]string) bool {
+	if search != "" {
+		return true
+	}
+	for _, f := range facets {
+		if len(f) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // subindustryFacet is one option in the company subindustry vocabulary: a clean YC

--- a/internal/handler/companies_integration_test.go
+++ b/internal/handler/companies_integration_test.go
@@ -125,9 +125,12 @@ func TestListCompaniesSearchEndpoint(t *testing.T) {
 	})
 
 	t.Run("empty q returns the full list", func(t *testing.T) {
-		names, total := doList(t, "/api/v1/companies")
-		if len(names) != 3 || total != 3 {
-			t.Errorf("full list: names=%v total=%v, want 3/3", names, total)
+		// The unfiltered catalogue total is a planner estimate (EstimateHiringCompanies),
+		// not an exact count, so only the returned row set is asserted here — on a tiny
+		// seed table the estimate is a fixed planner guess unrelated to the real count.
+		names, _ := doList(t, "/api/v1/companies")
+		if len(names) != 3 {
+			t.Errorf("full list: names=%v, want 3", names)
 		}
 	})
 }
@@ -217,8 +220,12 @@ func TestListCompaniesFacetFilterEndpoint(t *testing.T) {
 	})
 
 	t.Run("no facet params returns the full list", func(t *testing.T) {
-		assertSlugs(t, "/api/v1/companies",
-			[]string{"asia-co", "euro-corp", "euro-lab", "global-lab"})
+		// Unfiltered: meta.total is a planner estimate, so assert only the row set.
+		got, _ := doList(t, "/api/v1/companies")
+		want := []string{"asia-co", "euro-corp", "euro-lab", "global-lab"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("/api/v1/companies → slugs %v, want %v", got, want)
+		}
 	})
 }
 
@@ -245,7 +252,7 @@ func TestListCompaniesSubindustryFacet(t *testing.T) {
 	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
 	app.Get("/api/v1/companies", h.ListCompanies)
 
-	assert := func(t *testing.T, url string, want []string) {
+	query := func(t *testing.T, url string) (slugs []string, total float64) {
 		t.Helper()
 		resp, err := app.Test(httptest.NewRequest("GET", url, nil))
 		if err != nil {
@@ -267,17 +274,22 @@ func TestListCompaniesSubindustryFacet(t *testing.T) {
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		var got []string
 		for _, c := range body.Data {
-			got = append(got, c.Slug)
+			slugs = append(slugs, c.Slug)
 		}
-		sort.Strings(got)
+		sort.Strings(slugs)
+		return slugs, body.Meta.Total
+	}
+
+	assert := func(t *testing.T, url string, want []string) {
+		t.Helper()
+		got, total := query(t, url)
 		sort.Strings(want)
 		if strings.Join(got, ",") != strings.Join(want, ",") {
 			t.Errorf("%s → slugs %v, want %v", url, got, want)
 		}
-		if int(body.Meta.Total) != len(want) {
-			t.Errorf("%s → meta.total %v, want %d", url, body.Meta.Total, len(want))
+		if int(total) != len(want) {
+			t.Errorf("%s → meta.total %v, want %d", url, total, len(want))
 		}
 	}
 
@@ -295,7 +307,12 @@ func TestListCompaniesSubindustryFacet(t *testing.T) {
 	})
 
 	t.Run("no subindustry param returns all", func(t *testing.T) {
-		assert(t, "/api/v1/companies", []string{"diagco", "payco", "payco2", "plainco"})
+		// Unfiltered: meta.total is a planner estimate, so assert only the row set.
+		got, _ := query(t, "/api/v1/companies")
+		want := []string{"diagco", "payco", "payco2", "plainco"}
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("/api/v1/companies → slugs %v, want %v", got, want)
+		}
 	})
 }
 

--- a/migrations/0034_estimate_hiring_companies.sql
+++ b/migrations/0034_estimate_hiring_companies.sql
@@ -1,0 +1,26 @@
+-- Fast approximate count of hiring companies (job_count > 0) for the UNFILTERED
+-- /companies list's meta.total, mirroring estimate_open_jobs() for /jobs.
+--
+-- An exact count(*) FROM companies WHERE job_count > 0 must visit every one of the
+-- ~227k matching rows. The companies table is upserted constantly by the ingest and
+-- backfill workers, so its visibility map is rarely all-visible and an index-only
+-- count falls to the 2.3 GB heap — measured at ~17 s cold on prod, which is what
+-- made the /about stats strip (and the first, unfiltered /companies page) crawl.
+--
+-- The planner's row estimate is O(1) and tracks the job_count > 0 filter. Only the
+-- unfiltered catalogue total uses it (see handler.ListCompanies): every facet/search
+-- filter rides a narrowing index, so its exact count stays cheap and accurate.
+--
+-- Applied to a fresh volume by initdb after 0033. CREATE FUNCTION takes no lock on
+-- companies, so on the live prod volume this runs as a plain statement out of band.
+CREATE FUNCTION public.estimate_hiring_companies() RETURNS bigint
+    LANGUAGE plpgsql
+    AS $$
+DECLARE
+    plan json;
+BEGIN
+    EXECUTE 'EXPLAIN (FORMAT json) SELECT 1 FROM companies WHERE job_count > 0'
+        INTO plan;
+    RETURN (plan -> 0 -> 'Plan' ->> 'Plan Rows')::bigint;
+END;
+$$;


### PR DESCRIPTION
## Problem

`/about` (and the first, unfiltered `/companies` page) was slow — measured ~17s cold on prod for `GET /api/v1/companies`:

| endpoint | cold |
|---|---|
| `/api/v1/jobs` (estimate) | ~1.8s |
| `/api/v1/companies` (`count(*)`) | **~17s** |

The `/about` SSR `load` fires `listJobs(1,0)` + `listCompanies('',1,0)` purely for `meta.total`. `CountCompanies` runs `count(*) FROM companies WHERE job_count > 0` over ~227k hiring rows; the constantly-upserted `companies` table has a rarely all-visible visibility map, so the index-only count falls to the 2.3 GB heap.

The pathological case is exactly the **unfiltered** count — every facet/search filter narrows to an index and stays cheap.

## Fix

Mirror what `/jobs` already does with `estimate_open_jobs()`:

- **migration 0034** — `estimate_hiring_companies()`, an O(1) planner-estimate function (`Plan Rows` from `EXPLAIN (FORMAT json)`).
- **query** `EstimateHiringCompanies` (sqlc regenerated).
- **handler** `ListCompanies` branches on `isCompanyFilter(...)`: any name search or facet → exact `CountCompanies` (accurate pagination); fully unfiltered → planner estimate. Unfiltered total is approximate by design.

## Verification

- `go build`, `go vet`, gofmt clean
- `go test -tags=integration -run TestListCompanies ./internal/handler/` — green (unfiltered assertions relaxed to row-set only, since the tiny-table estimate is a fixed planner guess; filtered totals stay exact)

## ⚠️ Deploy note

The `companies` migration only runs on a fresh volume, so on prod create the function out of band (no lock on `companies`):

```sql
CREATE FUNCTION public.estimate_hiring_companies() RETURNS bigint
    LANGUAGE plpgsql AS $$
DECLARE plan json;
BEGIN
    EXECUTE 'EXPLAIN (FORMAT json) SELECT 1 FROM companies WHERE job_count > 0' INTO plan;
    RETURN (plan -> 0 -> 'Plan' ->> 'Plan Rows')::bigint;
END; $$;
```