### PR TITLE
fix(reminders): match settings block width to the job cards

### DIFF
--- a/web/src/lib/components/ReminderSettings.svelte
+++ b/web/src/lib/components/ReminderSettings.svelte
@@ -98,7 +98,7 @@
     );
 </script>
 
-<section class="max-w-2xl rounded-xl border border-border bg-card p-4">
+<section class="rounded-xl border border-border bg-card p-4">
   <div class="flex items-center gap-3">
     <div class="grid size-9 shrink-0 place-items-center rounded-lg bg-brand-muted text-brand-strong">
       <Bell class="size-4.5" aria-hidden="true" />


### PR DESCRIPTION
Drop the `max-w-2xl` cap so the Reminders panel is full-width like the saved job cards below it (it read narrower than the cards on wide screens).