### PR TITLE
fix(liveness): detect Russian archived/closed banners

### DIFF
--- a/internal/liveness/liveness.go
+++ b/internal/liveness/liveness.go
@@ -36,8 +36,9 @@ const (
 const minContentChars = 300
 
 // hardExpired matches phrases an employer page shows when a posting is closed
-// (EN/DE/FR). A match on a 2xx body is a definitive death signal. The sub-patterns
-// are top-level alternatives, so a plain "|" join is the whole pattern.
+// (EN/DE/FR/RU). A match on a 2xx body is a definitive death signal. The sub-patterns
+// are top-level alternatives, so a plain "|" join is the whole pattern. The (?i) flag
+// folds case for Cyrillic too, so one lowercase RU pattern covers "Вакансия"/"вакансия".
 var hardExpired = regexp.MustCompile(`(?i)` + strings.Join([]string{
 	`job (is )?no longer available`,
 	`job.*no longer open`,
@@ -52,6 +53,9 @@ var hardExpired = regexp.MustCompile(`(?i)` + strings.Join([]string{
 	`applications?\s+(?:(?:have|are|is)\s+)?closed`,
 	`diese stelle (ist )?(nicht mehr|bereits) besetzt`,
 	`offre (expirée|n'est plus disponible)`,
+	// RU orphan sources (habr_career, geekjob) serve a closed posting as a healthy
+	// 200 whose only death signal is a Russian archived/closed banner.
+	`ваканси\S* (в архиве|закрыта|неактивна)`,
 }, "|"))
 
 // listingPage matches a careers/search index rather than a single posting — the URL

--- a/internal/liveness/liveness_test.go
+++ b/internal/liveness/liveness_test.go
@@ -69,6 +69,20 @@ func TestClassify(t *testing.T) {
 			wantReason:  "expired_body",
 		},
 		{
+			// habr_career serves an archived vacancy as a healthy 200 whose only death
+			// signal is the Russian "Вакансия в архиве" banner — the source's URL is the
+			// posting itself, so this body is all the liveness worker has to close on.
+			name:     "russian archived pattern",
+			status:   200,
+			finalURL: "https://career.habr.com/vacancies/1000166878",
+			body: `Fullstack-Разработчик (PHP/Bitrix/Laravel) в компании Changellenge. Москва,
+Санкт-Петербург. Можно удаленно. Навыки: CMS «1С-Битрикс», Laravel, PHP, Git, Vue.js.
+Квалификация Middle. Полное описание вакансии, требования к кандидату, условия работы и
+контакты работодателя. Вакансия в архиве. Смотрите другие открытые вакансии компании.`,
+			wantVerdict: Expired,
+			wantReason:  "expired_body",
+		},
+		{
 			name:        "listing page instead of posting",
 			status:      200,
 			finalURL:    "https://boards.example.com/careers",


### PR DESCRIPTION
## Problem

The archived habr_career vacancy [fullstack-razrabotchik-php-bitrix-laravel-changellenge](https://freehire.dev/jobs/fullstack-razrabotchik-php-bitrix-laravel-changellenge-ps6cjpht) stays **open** on freehire even though it is in the archive on career.habr.com.

**Root cause:** `habr_career` is a non-board source, so neither the ingest sweep nor stream-self-close can reach it — only the liveness probe can close it. But habr serves an archived vacancy as a healthy **HTTP 200** whose only death signal is the Russian banner `«Вакансия в архиве»`. The `hardExpired` phrase set in `internal/liveness/liveness.go` was **EN/DE/FR-only**, so `Classify` returned `Live`, the `liveness_strikes` counter never accrued, and the job stayed open forever.

This is the exact limitation documented in `docs/agents/job-lifecycle.md`: *a posting that returns a 200 with a closed message in a language not in the curated set stays open.*

## Fix

- Add a Russian alternative `ваканси\S* (в архиве|закрыта|неактивна)` to the `hardExpired` regex. The `(?i)` flag folds Cyrillic case, so one lowercase pattern covers `Вакансия`/`вакансия`. The three phrases are unambiguous closed states that never appear on a live posting.
- Add a `Classify` test on a realistic (>300 char) habr archived body.

## Notes

Even after this ships, the affected job closes only after **two consecutive expired liveness reads** (`closeThreshold=2`) — one strike per cron run, then close — by design (absorbs a transient blip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)