### PR TITLE
fix(filters): apply the first-visit default via SSR redirect, not a post-hydration seed

### DIFF
--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -11,7 +11,7 @@
   import { ensureSavedLoaded } from '$lib/savedJobs.svelte';
   import { latestOnly } from '$lib/latestOnly';
   import { Paginator } from '$lib/paginated.svelte';
-  import { FilterStore, filtersToParams, activeFilterCount, type SortField } from '$lib/filters';
+  import { FilterStore, filtersToParams, activeFilterCount, canonicalQuery, type SortField } from '$lib/filters';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { loadJobFilters, hasChangedFilters, DEFAULT_JOB_FILTERS } from '$lib/filterStorage';
   import {
@@ -139,11 +139,19 @@
   // didn't change the filters (back/forward re-seed, CV sign-in prompt toggle)
   // doesn't emit a spurious funnel event.
   let lastSearchKey = '';
-  // True once we seed the first-visit default (remote / worldwide) for a brand-new
-  // visitor on a bare /jobs. Those filters are ours, not the user's choice, so the
-  // onboarding banner still treats the feed as "unfiltered" and the first reload
-  // isn't skipped as a fresh SSR page.
-  let seededDefault = $state(false);
+  // The visitor is on our server-seeded first-visit default (remote / worldwide, see
+  // +page.server.ts) rather than filters they chose: true only while this browser has
+  // never changed filters and the applied set still equals the default. Those filters
+  // are ours, not the user's choice, so the onboarding banner keeps treating the feed
+  // as "unfiltered" and still shows. Flips to false the moment they touch a filter
+  // (the set diverges and hasChangedFilters latches), retiring the banner as normal.
+  const DEFAULT_FILTERS_CANON = canonicalQuery(DEFAULT_JOB_FILTERS);
+  const seededDefault = $derived(
+    browser &&
+      standalone &&
+      !hasChangedFilters() &&
+      canonicalQuery(filtersToParams(filters.value).toString()) === DEFAULT_FILTERS_CANON,
+  );
 
   // Onboarding: the one-time nudge banner + wizard, standalone-only. The lifecycle
   // lives in localStorage (client-only); seed it at init on the client so a returning
@@ -224,16 +232,6 @@
   // sets stay empty). Cleanup: cancel any pending debounced reload so it can't fire
   // after this view is gone.
   onMount(() => {
-    // First-ever visit to the standalone feed: default to fully-remote, worldwide
-    // roles so a new user lands on the most relevant slice. Only on a bare /jobs (a
-    // shared filter/search link is left untouched) and only when this browser has
-    // never changed filters — a cleared set counts as changed, so it stays cleared.
-    // Client-side after hydration: the router is ready for the store's replaceState,
-    // and the seed persists like any filter set (restored normally on later visits).
-    if (standalone && location.search === '' && !hasChangedFilters()) {
-      filters.apply(DEFAULT_JOB_FILTERS);
-      seededDefault = true;
-    }
     if (isAuthenticated()) {
       ensureViewedLoaded();
       ensureSavedLoaded();
@@ -287,10 +285,11 @@
       if (firstRun) {
         started = true;
         // Keep the SSR `initial` page unless it was loaded for a different URL than
-        // the address bar (stale shallow-routing restore), the feed is in CV mode
-        // (the SSR seed is the newest-sorted keyword feed, wrong for CV ranking), or
-        // we seeded the first-visit default (the SSR page is unfiltered, now stale).
-        if (!initialStale && !cvMode && !seededDefault) return;
+        // the address bar (stale shallow-routing restore) or the feed is in CV mode
+        // (the SSR seed is the newest-sorted keyword feed, wrong for CV ranking). The
+        // first-visit default is server-rendered (see +page.server.ts), so `initial`
+        // already matches the URL here — no forced reload needed.
+        if (!initialStale && !cvMode) return;
       }
       if (blocked) return;
       // Funnel search — only when the applied filters actually changed: not the

--- a/web/src/lib/filterStorage.test.ts
+++ b/web/src/lib/filterStorage.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { loadJobFilters, saveJobFilters, hasChangedFilters, JOB_FILTERS_KEY } from './filterStorage';
+import {
+  loadJobFilters,
+  saveJobFilters,
+  hasChangedFilters,
+  JOB_FILTERS_KEY,
+  FILTERS_TOUCHED_COOKIE,
+} from './filterStorage';
 
 // A minimal in-memory localStorage stand-in for the Node test environment (where
 // there is no browser storage). Individual tests swap in throwing/undefined
@@ -19,8 +25,12 @@ class MemoryStorage {
 
 describe('filterStorage', () => {
   afterEach(() => {
-    // @ts-expect-error - clean up the global we install per test
+    // @ts-expect-error - clean up the globals we install per test
     delete globalThis.localStorage;
+    // @ts-expect-error
+    delete globalThis.document;
+    // @ts-expect-error
+    delete globalThis.location;
   });
 
   it('round-trips a non-empty query string through hire.jobFilters', () => {
@@ -67,6 +77,44 @@ describe('filterStorage', () => {
 
     expect(loadJobFilters()).toBe('');
     expect(hasChangedFilters()).toBe(true);
+  });
+
+  it('mirrors the touched marker into a server-readable cookie on any change', () => {
+    const store = new MemoryStorage();
+    // @ts-expect-error - install the stand-in
+    globalThis.localStorage = store;
+    let written = '';
+    // @ts-expect-error - minimal document stand-in capturing cookie writes
+    globalThis.document = {
+      set cookie(v: string) {
+        written = v;
+      },
+    };
+    // @ts-expect-error - https so the Secure attribute is emitted
+    globalThis.location = { protocol: 'https:' };
+
+    saveJobFilters('regions=EU');
+
+    expect(written).toContain(`${FILTERS_TOUCHED_COOKIE}=1`);
+    expect(written).toContain('path=/');
+    expect(written).toContain('secure');
+  });
+
+  it('sets the touched cookie even when localStorage is unavailable (private mode)', () => {
+    // No localStorage installed; the cookie is written before the storage guard.
+    let written = '';
+    // @ts-expect-error - minimal document stand-in
+    globalThis.document = {
+      set cookie(v: string) {
+        written = v;
+      },
+    };
+
+    saveJobFilters('regions=EU');
+
+    expect(written).toContain(`${FILTERS_TOUCHED_COOKIE}=1`);
+    // http (no location stub) omits Secure so the cookie is usable on localhost.
+    expect(written).not.toContain('secure');
   });
 
   it('reports no filter history when storage is unavailable (SSR)', () => {

--- a/web/src/lib/filterStorage.ts
+++ b/web/src/lib/filterStorage.ts
@@ -17,6 +17,12 @@ export const JOB_FILTERS_KEY = 'hire.jobFilters';
 // (offer the default) from someone who deliberately cleared (respect the empty set).
 const FILTERS_TOUCHED_KEY = 'hire.jobFiltersTouched';
 
+// The same "touched" marker, mirrored into a cookie so the SSR `load` can read it
+// (localStorage is invisible to the server). It gates the first-visit default
+// redirect — see firstVisit.ts. Kept in lockstep with FILTERS_TOUCHED_KEY by
+// saveJobFilters below.
+export const FILTERS_TOUCHED_COOKIE = 'hire_filters_touched';
+
 /** The filter set a first-time visitor lands on: fully-remote roles open worldwide.
  *  Same facet vocabulary as the `remote-worldwide` collection (see collections.ts). */
 export const DEFAULT_JOB_FILTERS = 'work_mode=remote&regions=global';
@@ -45,8 +51,10 @@ export function hasChangedFilters(): boolean {
 
 /** Mirror the applied filters to storage. An empty string removes the key, so a
  *  cleared filter set leaves nothing to restore. Either way the change marks the
- *  browser as touched, so the first-visit default is never re-offered. */
+ *  browser as touched — in both localStorage and the server-readable cookie — so the
+ *  first-visit default is never re-offered. */
 export function saveJobFilters(qs: string): void {
+  markFiltersTouchedCookie();
   if (typeof localStorage === 'undefined') return;
   try {
     if (qs) localStorage.setItem(JOB_FILTERS_KEY, qs);
@@ -55,4 +63,13 @@ export function saveJobFilters(qs: string): void {
   } catch {
     // best-effort: private mode / quota / disabled storage
   }
+}
+
+/** Set the server-readable "touched" cookie so the SSR first-visit redirect stops
+ *  offering the default. One year, path=/, Lax; Secure on https so it isn't sent in
+ *  the clear. Best-effort and browser-only (no document ⇒ SSR/test no-op). */
+function markFiltersTouchedCookie(): void {
+  if (typeof document === 'undefined') return;
+  const secure = typeof location !== 'undefined' && location.protocol === 'https:' ? '; secure' : '';
+  document.cookie = `${FILTERS_TOUCHED_COOKIE}=1; path=/; max-age=31536000; samesite=lax${secure}`;
 }

--- a/web/src/lib/firstVisit.test.ts
+++ b/web/src/lib/firstVisit.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { isCrawler, defaultFilterTarget } from './firstVisit';
+import { DEFAULT_JOB_FILTERS } from './filterStorage';
+
+describe('isCrawler', () => {
+  it('flags common search-engine and social bots', () => {
+    for (const ua of [
+      'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+      'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+      'Mozilla/5.0 (compatible; YandexBot/3.0)',
+      'facebookexternalhit/1.1',
+      'Twitterbot/1.0',
+      'Mozilla/5.0 (compatible; AhrefsBot/7.0)',
+      'DuckDuckBot/1.1',
+    ]) {
+      expect(isCrawler(ua)).toBe(true);
+    }
+  });
+
+  it('treats a real browser UA as not a crawler', () => {
+    expect(
+      isCrawler(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+      ),
+    ).toBe(false);
+  });
+
+  it('treats a missing UA as not a crawler (real users may omit it; bots we care about send one)', () => {
+    expect(isCrawler(null)).toBe(false);
+    expect(isCrawler('')).toBe(false);
+  });
+});
+
+describe('defaultFilterTarget', () => {
+  const target = `/?${DEFAULT_JOB_FILTERS}`;
+
+  it('redirects a brand-new visitor on a bare homepage to the default filter slice', () => {
+    expect(defaultFilterTarget({ search: '', touched: false, crawler: false })).toBe(target);
+  });
+
+  it('does not redirect when the URL already carries filters (a shared link)', () => {
+    expect(defaultFilterTarget({ search: '?regions=cis', touched: false, crawler: false })).toBeNull();
+    // even when the shared link happens to equal the default
+    expect(
+      defaultFilterTarget({ search: `?${DEFAULT_JOB_FILTERS}`, touched: false, crawler: false }),
+    ).toBeNull();
+  });
+
+  it('does not redirect once the visitor has changed filters (cookie set, incl. a clear)', () => {
+    expect(defaultFilterTarget({ search: '', touched: true, crawler: false })).toBeNull();
+  });
+
+  it('does not redirect crawlers, so the homepage still indexes the full catalogue', () => {
+    expect(defaultFilterTarget({ search: '', touched: false, crawler: true })).toBeNull();
+  });
+});

--- a/web/src/lib/firstVisit.ts
+++ b/web/src/lib/firstVisit.ts
@@ -1,0 +1,37 @@
+// First-visit default filter: a brand-new visitor landing on a bare homepage is
+// sent to the remote-worldwide slice so SSR renders the filtered feed directly —
+// no post-hydration seed, no flash. The gate is a cookie (`hire_filters_touched`,
+// see filterStorage) that the server can read, unlike the localStorage marker.
+//
+// Env-neutral and side-effect-free so it unit-tests in plain Node and imports
+// cleanly into the SSR `load`. The two moving parts — "is this a crawler" and
+// "should we redirect" — live here as pure functions.
+
+import { DEFAULT_JOB_FILTERS } from './filterStorage';
+
+// Bots that fetch the homepage for indexing or link previews. Matched loosely on
+// the UA string; the cost of a miss is only that a bot gets the default slice, and
+// the cost of a false positive is only that a rare human keeps the full feed — so a
+// broad, maintenance-light pattern beats an exhaustive list.
+const CRAWLER_UA = /bot|crawl|spider|slurp|mediapartners|facebookexternalhit|embedly|quora|bitlybot|whatsapp|telegram|discord|preview|scanner|archiver/i;
+
+/** True when the User-Agent looks like a crawler/link-preview bot rather than a
+ *  human browser. A missing UA reads as human — the bots we care about all send one,
+ *  and redirecting UA-less clients would risk hiding the full homepage from tools we
+ *  can't identify. */
+export function isCrawler(ua: string | null): boolean {
+  return !!ua && CRAWLER_UA.test(ua);
+}
+
+/** The path to redirect a bare-homepage request to, or null to serve it unchanged.
+ *  Redirect only a first-time human on a param-less URL: a shared filter link
+ *  (`search` set), a returning visitor who changed filters (`touched`), and crawlers
+ *  are all left on the URL they asked for. */
+export function defaultFilterTarget(opts: {
+  search: string;
+  touched: boolean;
+  crawler: boolean;
+}): string | null {
+  if (opts.search !== '' || opts.touched || opts.crawler) return null;
+  return `/?${DEFAULT_JOB_FILTERS}`;
+}

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,4 +1,7 @@
+import { redirect } from '@sveltejs/kit';
 import { serverApi } from '$lib/server/api';
+import { FILTERS_TOUCHED_COOKIE } from '$lib/filterStorage';
+import { defaultFilterTarget, isCrawler } from '$lib/firstVisit';
 import type { PageServerLoad } from './$types';
 
 const LIMIT = 20;
@@ -8,7 +11,18 @@ const LIMIT = 20;
 // query already carries the search params (q, facets, sort) in the shape the
 // search API reads; `searchJobs` adds pagination. Filters/sort/"load more" then
 // run client-side over the same client.
-export const load: PageServerLoad = async ({ url, fetch }) => {
+export const load: PageServerLoad = async ({ url, fetch, cookies, request }) => {
+  // First-visit default: redirect a brand-new human on a bare homepage to the
+  // remote-worldwide slice before render, so the filtered feed is server-rendered
+  // (no flash, no post-hydration store mutation). defaultFilterTarget owns which
+  // requests are exempt (shared links, returning visitors, crawlers).
+  const target = defaultFilterTarget({
+    search: url.search,
+    touched: !!cookies.get(FILTERS_TOUCHED_COOKIE),
+    crawler: isCrawler(request.headers.get('user-agent')),
+  });
+  if (target) redirect(302, target);
+
   const initial = await serverApi(fetch).searchJobs(url.searchParams, LIMIT, 0);
   return { initial };
 };


### PR DESCRIPTION
## Problem

The first-visit default filter (remote / worldwide, #950) is **broken on prod**: a brand-new visitor's URL flips to `?regions=global&work_mode=remote`, but the feed stays **unfiltered** (3.5M jobs) and nothing persists.

Root cause, reproduced with headless Chrome against prod:

| Scenario | Shown | Fetch | Error |
|---|---|---|---|
| First visit (client seed) | **3,510,244** (all) | none | **`Cannot read properties of undefined (reading '$set')`** |
| Direct filtered URL | 19,884 (filtered) | `facets?regions=global&work_mode=remote` | none |

The seed ran in `onMount` by mutating the already-mounted filter store. That mutation crashes a subscriber (`$set` on undefined), which aborts the reload `$effect` — so the URL changes but the list never reloads and the touched marker is never written.

## Fix

Move the decision to the **server** so the filtered feed is server-rendered — no post-hydration store mutation, no flash, no crash:

- `+page.server.ts` — a brand-new human on a bare `/` is `302`'d to `/?work_mode=remote&regions=global` **before render**; SSR returns the filtered feed.
- `firstVisit.ts` — pure `isCrawler()` + `defaultFilterTarget()` (unit-tested).
- `filterStorage.ts` — mirrors the "touched" marker into a server-readable cookie (`hire_filters_touched`) on every explicit filter change, so the SSR `load` can tell a first-timer from someone who changed/cleared filters.
- `JobsView.svelte` — removes the crashing `onMount` seed; `seededDefault` becomes a `$derived` that keeps the onboarding banner visible while the untouched default is showing.
- **Crawlers are exempt** (UA check) so the homepage still indexes the full catalogue (matches today's behaviour — bots don't run the client seed).

## Verification

Local build with the API pointed at prod:

- Redirect matrix (curl): bare `/` + no cookie + browser UA → **302 → default**; with `hire_filters_touched` cookie → **200**; **Googlebot UA → 200** (SEO preserved); already-filtered URL → **200**.
- Headless Chrome, first visit: lands on the filtered URL, **19,897 jobs shown, zero page errors** (the `$set` crash is gone). Returning visitor (cookie) → bare `/`, unfiltered.
- `vitest run` — **314 passed**; `svelte-check` — 0 errors; `oxlint` — clean.