### PR TITLE
fix(profile): full-width set-up form to match loaded profile width

### DIFF
--- a/web/src/routes/my/profile/+page.svelte
+++ b/web/src/routes/my/profile/+page.svelte
@@ -221,8 +221,9 @@
   {/snippet}
 
   {#if profile === null}
-    <!-- Set-up: the inline form only; coverage appears once a profile exists. -->
-    <div class="mx-auto w-full max-w-2xl">
+    <!-- Set-up: the inline form only; coverage appears once a profile exists. Full-width to
+         match the loaded profile tab, whose main column also spans the container (no aside). -->
+    <div class="w-full">
       <ProfileForm profile={null} {hasCv} onSaved={handleSaved} onCvUploaded={handleCvUploaded} />
     </div>
   {:else}


### PR DESCRIPTION
## What

The profile set-up view (shown before a profile exists / before a CV upload) rendered the form in a centered `max-w-2xl` column, while the loaded profile tab spans the full container width (its right-hand `aside` only renders on the *coverage* tab). Result: uploading a CV visibly jumped the layout width.

## Change

Drop the `max-w-2xl` cap on the set-up wrapper so the pre-upload state matches the loaded profile tab.

Single-file, CSS-class-only change.