### PR TITLE
feat(jobs): hide jobs from the browse feed with an Activity → Hidden tab

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -191,6 +191,8 @@ type Querier interface {
 	// every interaction row; "viewed" is the view-only subset (neither saved nor
 	// applied), matching the ListUserJobs filter. "board" counts jobs on the Kanban
 	// board (saved, applied, or stage set), matching the ListUserJobs board filter.
+	// "dismissed" counts jobs the user hid from the feed, matching the ListUserJobs
+	// dismissed filter.
 	CountUserJobs(ctx context.Context, userID int64) (CountUserJobsRow, error)
 	// Create an API key for a user. The caller passes the SHA-256 token_hash and the
 	// display token_prefix; the plaintext token is shown once and never stored.
@@ -605,6 +607,13 @@ type Querier interface {
 	// by a caller-supplied limit and served by the (user_id, created_at DESC) index. The handler
 	// resolves each debit's ref to a human label (the job/CV it named).
 	ListCreditLedger(ctx context.Context, arg ListCreditLedgerParams) ([]ListCreditLedgerRow, error)
+	// Every public_slug the user has hidden (dismissed). Used by the SPA to exclude
+	// hidden jobs from the browse feed client-side, mirroring ListSavedJobSlugs —
+	// cross-referenced in the browser, never joined into ListJobs/SearchJobs. Bounded
+	// by the caller's dismissed subset (typically small) and indexed by the
+	// (user_id, job_id) primary key. Closed jobs are included: a hidden posting that
+	// later closes stays hidden.
+	ListDismissedJobSlugs(ctx context.Context, userID int64) ([]string, error)
 	// Flat inbox listing, newest first — one row per message (no subject grouping),
 	// soft-deleted messages excluded. Optional filters (each empty/false = no filter):
 	// source narrows to one account; unread hides already-read mail; status narrows to

--- a/internal/db/queries/user_jobs.sql
+++ b/internal/db/queries/user_jobs.sql
@@ -149,12 +149,14 @@ WHERE uj.user_id = $1
        OR (sqlc.arg(filter)::text = 'saved' AND uj.saved_at IS NOT NULL)
        OR (sqlc.arg(filter)::text = 'applied' AND uj.applied_at IS NOT NULL)
        OR (sqlc.arg(filter)::text = 'board'
-           AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL)))
+           AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL))
+       OR (sqlc.arg(filter)::text = 'dismissed' AND uj.dismissed_at IS NOT NULL))
 ORDER BY (CASE sqlc.arg(filter)::text
             WHEN 'saved' THEN uj.saved_at
             WHEN 'applied' THEN uj.applied_at
             WHEN 'viewed' THEN uj.viewed_at
             WHEN 'board' THEN GREATEST(uj.saved_at, uj.applied_at)
+            WHEN 'dismissed' THEN uj.dismissed_at
             ELSE GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at)
           END) DESC NULLS LAST, uj.job_id DESC
 LIMIT $2 OFFSET $3;
@@ -183,11 +185,25 @@ FROM user_jobs uj
 JOIN jobs ON jobs.id = uj.job_id
 WHERE uj.user_id = $1 AND uj.saved_at IS NOT NULL;
 
+-- name: ListDismissedJobSlugs :many
+-- Every public_slug the user has hidden (dismissed). Used by the SPA to exclude
+-- hidden jobs from the browse feed client-side, mirroring ListSavedJobSlugs —
+-- cross-referenced in the browser, never joined into ListJobs/SearchJobs. Bounded
+-- by the caller's dismissed subset (typically small) and indexed by the
+-- (user_id, job_id) primary key. Closed jobs are included: a hidden posting that
+-- later closes stays hidden.
+SELECT jobs.public_slug
+FROM user_jobs uj
+JOIN jobs ON jobs.id = uj.job_id
+WHERE uj.user_id = $1 AND uj.dismissed_at IS NOT NULL;
+
 -- name: CountUserJobs :one
 -- Per-filter row counts for the my-jobs tabs, in one aggregate pass. "all" is
 -- every interaction row; "viewed" is the view-only subset (neither saved nor
 -- applied), matching the ListUserJobs filter. "board" counts jobs on the Kanban
 -- board (saved, applied, or stage set), matching the ListUserJobs board filter.
+-- "dismissed" counts jobs the user hid from the feed, matching the ListUserJobs
+-- dismissed filter.
 SELECT count(*)                                        AS "all",
        count(*) FILTER (WHERE saved_at IS NULL
                           AND applied_at IS NULL)      AS viewed,
@@ -195,7 +211,8 @@ SELECT count(*)                                        AS "all",
        count(*) FILTER (WHERE applied_at IS NOT NULL) AS applied,
        count(*) FILTER (WHERE saved_at   IS NOT NULL
                             OR applied_at IS NOT NULL
-                            OR stage      IS NOT NULL) AS board
+                            OR stage      IS NOT NULL) AS board,
+       count(*) FILTER (WHERE dismissed_at IS NOT NULL) AS dismissed
 FROM user_jobs
 WHERE user_id = $1;
 

--- a/internal/db/user_jobs.sql.go
+++ b/internal/db/user_jobs.sql.go
@@ -85,23 +85,27 @@ SELECT count(*)                                        AS "all",
        count(*) FILTER (WHERE applied_at IS NOT NULL) AS applied,
        count(*) FILTER (WHERE saved_at   IS NOT NULL
                             OR applied_at IS NOT NULL
-                            OR stage      IS NOT NULL) AS board
+                            OR stage      IS NOT NULL) AS board,
+       count(*) FILTER (WHERE dismissed_at IS NOT NULL) AS dismissed
 FROM user_jobs
 WHERE user_id = $1
 `
 
 type CountUserJobsRow struct {
-	All     int64 `json:"all"`
-	Viewed  int64 `json:"viewed"`
-	Saved   int64 `json:"saved"`
-	Applied int64 `json:"applied"`
-	Board   int64 `json:"board"`
+	All       int64 `json:"all"`
+	Viewed    int64 `json:"viewed"`
+	Saved     int64 `json:"saved"`
+	Applied   int64 `json:"applied"`
+	Board     int64 `json:"board"`
+	Dismissed int64 `json:"dismissed"`
 }
 
 // Per-filter row counts for the my-jobs tabs, in one aggregate pass. "all" is
 // every interaction row; "viewed" is the view-only subset (neither saved nor
 // applied), matching the ListUserJobs filter. "board" counts jobs on the Kanban
 // board (saved, applied, or stage set), matching the ListUserJobs board filter.
+// "dismissed" counts jobs the user hid from the feed, matching the ListUserJobs
+// dismissed filter.
 func (q *Queries) CountUserJobs(ctx context.Context, userID int64) (CountUserJobsRow, error) {
 	row := q.db.QueryRow(ctx, countUserJobs, userID)
 	var i CountUserJobsRow
@@ -111,6 +115,7 @@ func (q *Queries) CountUserJobs(ctx context.Context, userID int64) (CountUserJob
 		&i.Saved,
 		&i.Applied,
 		&i.Board,
+		&i.Dismissed,
 	)
 	return i, err
 }
@@ -186,6 +191,39 @@ func (q *Queries) ExcludedJobIDs(ctx context.Context, arg ExcludedJobIDsParams) 
 	return items, nil
 }
 
+const listDismissedJobSlugs = `-- name: ListDismissedJobSlugs :many
+SELECT jobs.public_slug
+FROM user_jobs uj
+JOIN jobs ON jobs.id = uj.job_id
+WHERE uj.user_id = $1 AND uj.dismissed_at IS NOT NULL
+`
+
+// Every public_slug the user has hidden (dismissed). Used by the SPA to exclude
+// hidden jobs from the browse feed client-side, mirroring ListSavedJobSlugs —
+// cross-referenced in the browser, never joined into ListJobs/SearchJobs. Bounded
+// by the caller's dismissed subset (typically small) and indexed by the
+// (user_id, job_id) primary key. Closed jobs are included: a hidden posting that
+// later closes stays hidden.
+func (q *Queries) ListDismissedJobSlugs(ctx context.Context, userID int64) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDismissedJobSlugs, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var public_slug string
+		if err := rows.Scan(&public_slug); err != nil {
+			return nil, err
+		}
+		items = append(items, public_slug)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSavedJobSlugs = `-- name: ListSavedJobSlugs :many
 SELECT jobs.public_slug
 FROM user_jobs uj
@@ -240,12 +278,14 @@ WHERE uj.user_id = $1
        OR ($4::text = 'saved' AND uj.saved_at IS NOT NULL)
        OR ($4::text = 'applied' AND uj.applied_at IS NOT NULL)
        OR ($4::text = 'board'
-           AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL)))
+           AND (uj.saved_at IS NOT NULL OR uj.applied_at IS NOT NULL OR uj.stage IS NOT NULL))
+       OR ($4::text = 'dismissed' AND uj.dismissed_at IS NOT NULL))
 ORDER BY (CASE $4::text
             WHEN 'saved' THEN uj.saved_at
             WHEN 'applied' THEN uj.applied_at
             WHEN 'viewed' THEN uj.viewed_at
             WHEN 'board' THEN GREATEST(uj.saved_at, uj.applied_at)
+            WHEN 'dismissed' THEN uj.dismissed_at
             ELSE GREATEST(uj.viewed_at, uj.saved_at, uj.applied_at)
           END) DESC NULLS LAST, uj.job_id DESC
 LIMIT $2 OFFSET $3

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -440,6 +440,7 @@ func Register(app *fiber.App, cfg Config) {
 	api.Get("/me/tracking", keyAuth, a.ListTrackedJobs)
 	api.Get("/me/tracking/viewed", keyAuth, a.ListViewedSlugs)
 	api.Get("/me/tracking/saved", keyAuth, a.ListSavedSlugs)
+	api.Get("/me/tracking/dismissed", keyAuth, a.ListDismissedSlugs)
 	api.Get("/me/tracking/pipeline", keyAuth, a.TrackingPipeline)
 	api.Get("/me/tracking/swipe", keyAuth, a.SwipeDeck)
 	api.Get("/me/tracking/analyses", keyAuth, a.ListMyAnalyses)

--- a/internal/handler/me_dismissed_integration_test.go
+++ b/internal/handler/me_dismissed_integration_test.go
@@ -1,0 +1,186 @@
+//go:build integration
+
+// Integration test for the dismissed-slugs wire contract: GET /api/v1/me/tracking/dismissed
+// must return exactly the public_slugs the authenticated caller has HIDDEN
+// (dismissed) — not merely viewed — scoped to that caller, as a flat
+// {"data": [...]} list, and reject an unauthenticated request. The SPA reads this
+// to exclude hidden jobs from the browse feed without authenticating the public
+// job-read path. It also covers the tracking listing's `dismissed` filter. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/jobtracking"
+)
+
+func TestListDismissedSlugsEndpoint(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	queries := db.New(pool)
+
+	seedUser := func(t *testing.T, email string) int64 {
+		t.Helper()
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO users (email) VALUES ($1) RETURNING id`, email).Scan(&id); err != nil {
+			t.Fatalf("seed user %q: %v", email, err)
+		}
+		return id
+	}
+	seedJob := func(t *testing.T, ext string) int64 {
+		t.Helper()
+		var id int64
+		if err := pool.QueryRow(ctx,
+			`INSERT INTO jobs (source, external_id, url, title, public_slug)
+			 VALUES ('test', $1, 'http://example.test', 'Job ' || $1, 'job-' || $1)
+			 RETURNING id`, ext).Scan(&id); err != nil {
+			t.Fatalf("seed job %q: %v", ext, err)
+		}
+		return id
+	}
+
+	hider := seedUser(t, "hider@example.test")
+	other := seedUser(t, "other-h@example.test")
+	jobA := seedJob(t, "dismissed-a")
+	jobB := seedJob(t, "viewed-h-b")
+	jobC := seedJob(t, "other-h-c")
+
+	// hider DISMISSED A, but only VIEWED B — the viewed-only job must be excluded
+	// from the dismissed set (the dismissed_at IS NOT NULL predicate is the point).
+	if _, err := queries.DismissJob(ctx, db.DismissJobParams{UserID: hider, JobID: jobA}); err != nil {
+		t.Fatalf("dismiss A: %v", err)
+	}
+	if _, err := queries.RecordJobView(ctx, db.RecordJobViewParams{UserID: hider, JobID: jobB}); err != nil {
+		t.Fatalf("view B: %v", err)
+	}
+	// other user dismissed C — must never leak into hider's set.
+	if _, err := queries.DismissJob(ctx, db.DismissJobParams{UserID: other, JobID: jobC}); err != nil {
+		t.Fatalf("dismiss C: %v", err)
+	}
+
+	iss := auth.NewIssuer("test-secret", time.Hour)
+	h := &API{pool: pool, queries: queries, issuer: iss, tracking: jobtracking.New(jobtracking.NewQueriesRepository(queries))}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/me/tracking/dismissed", auth.RequireAuthOrKey(iss, queries), h.ListDismissedSlugs)
+	app.Get("/api/v1/me/tracking", auth.RequireAuthOrKey(iss, queries), h.ListTrackedJobs)
+
+	getSlugs := func(t *testing.T, userID int64) []string {
+		t.Helper()
+		token, err := iss.Issue(userID)
+		if err != nil {
+			t.Fatalf("issue token: %v", err)
+		}
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking/dismissed", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET dismissed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+		var body struct {
+			Data []string `json:"data"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		sort.Strings(body.Data)
+		return body.Data
+	}
+
+	t.Run("returns only the caller's dismissed slugs, scoped to the caller", func(t *testing.T) {
+		got := getSlugs(t, hider)
+		want := []string{"job-dismissed-a"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("hider slugs = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("undismissing drops the slug from the set", func(t *testing.T) {
+		if _, err := queries.UndismissJob(ctx, db.UndismissJobParams{UserID: hider, JobID: jobA}); err != nil {
+			t.Fatalf("undismiss A: %v", err)
+		}
+		got := getSlugs(t, hider)
+		if len(got) != 0 {
+			t.Fatalf("after undismiss slugs = %v, want []", got)
+		}
+		// Restore for the filter assertion below.
+		if _, err := queries.DismissJob(ctx, db.DismissJobParams{UserID: hider, JobID: jobA}); err != nil {
+			t.Fatalf("re-dismiss A: %v", err)
+		}
+	})
+
+	t.Run("dismissed filter lists the hidden job, excludes the viewed-only one", func(t *testing.T) {
+		token, err := iss.Issue(hider)
+		if err != nil {
+			t.Fatalf("issue token: %v", err)
+		}
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking?filter=dismissed", nil)
+		req.AddCookie(&http.Cookie{Name: auth.CookieName, Value: token})
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET tracking dismissed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200 (body %s)", resp.StatusCode, body)
+		}
+		var body struct {
+			Data []struct {
+				Job struct {
+					PublicSlug string `json:"public_slug"`
+				} `json:"job"`
+			} `json:"data"`
+			Meta struct {
+				Total int `json:"total"`
+			} `json:"meta"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if body.Meta.Total != 1 {
+			t.Fatalf("meta.total = %d, want 1", body.Meta.Total)
+		}
+		if len(body.Data) != 1 || body.Data[0].Job.PublicSlug != "job-dismissed-a" {
+			t.Fatalf("dismissed listing = %+v, want just job-dismissed-a", body.Data)
+		}
+	})
+
+	t.Run("user with no dismisses gets an empty list", func(t *testing.T) {
+		fresh := seedUser(t, "fresh-h@example.test")
+		got := getSlugs(t, fresh)
+		if len(got) != 0 {
+			t.Fatalf("fresh user slugs = %v, want []", got)
+		}
+	})
+
+	t.Run("unauthenticated request is rejected", func(t *testing.T) {
+		req := httptest.NewRequest(fiber.MethodGet, "/api/v1/me/tracking/dismissed", nil)
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("GET dismissed (no auth): %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusUnauthorized {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+}

--- a/internal/handler/me_tracking.go
+++ b/internal/handler/me_tracking.go
@@ -63,11 +63,12 @@ func (a *API) ListTrackedJobs(c *fiber.Ctx) error {
 			"limit":  limit,
 			"offset": offset,
 			"counts": fiber.Map{
-				"all":     listing.Counts.All,
-				"viewed":  listing.Counts.Viewed,
-				"saved":   listing.Counts.Saved,
-				"applied": listing.Counts.Applied,
-				"board":   listing.Counts.Board,
+				"all":       listing.Counts.All,
+				"viewed":    listing.Counts.Viewed,
+				"saved":     listing.Counts.Saved,
+				"applied":   listing.Counts.Applied,
+				"board":     listing.Counts.Board,
+				"dismissed": listing.Counts.Dismissed,
 			},
 		},
 	})
@@ -124,6 +125,25 @@ func (a *API) ListSavedSlugs(c *fiber.Ctx) error {
 	}
 
 	slugs, err := a.tracking.SavedSlugs(c.Context(), userID)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(fiber.Map{"data": slugs})
+}
+
+// ListDismissedSlugs returns the set of public job slugs the authenticated caller
+// has hidden (dismissed). The SPA reads this to exclude hidden jobs from the
+// browse feed client-side, mirroring ListSavedSlugs — dismissed state is
+// cross-referenced client-side, never joined into ListJobs/SearchJobs. The
+// response is a flat {"data": [slug, ...]} list scoped to the caller.
+func (a *API) ListDismissedSlugs(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+
+	slugs, err := a.tracking.DismissedSlugs(c.Context(), userID)
 	if err != nil {
 		return err
 	}

--- a/internal/handler/track_test.go
+++ b/internal/handler/track_test.go
@@ -55,8 +55,9 @@ func (stubTrackingRepo) ListInteractions(context.Context, int64, jobtracking.Fil
 func (stubTrackingRepo) CountInteractions(context.Context, int64) (jobtracking.Counts, error) {
 	return jobtracking.Counts{}, nil
 }
-func (stubTrackingRepo) ViewedSlugs(context.Context, int64) ([]string, error) { return nil, nil }
-func (stubTrackingRepo) SavedSlugs(context.Context, int64) ([]string, error)  { return nil, nil }
+func (stubTrackingRepo) ViewedSlugs(context.Context, int64) ([]string, error)    { return nil, nil }
+func (stubTrackingRepo) SavedSlugs(context.Context, int64) ([]string, error)     { return nil, nil }
+func (stubTrackingRepo) DismissedSlugs(context.Context, int64) ([]string, error) { return nil, nil }
 func (stubTrackingRepo) ExcludedJobIDs(context.Context, int64, int32) ([]int64, error) {
 	return nil, nil
 }

--- a/internal/jobtracking/jobtracking.go
+++ b/internal/jobtracking/jobtracking.go
@@ -27,15 +27,17 @@ type Interaction struct {
 // Filter selects which interactions a listing returns. It is a controlled
 // vocabulary owned here (mirroring userjob.Stage): "all" is every interaction,
 // "viewed" the passive history (neither saved nor applied), "saved"/"applied"
-// the respective subsets, and "board" the Kanban set (saved, applied, or staged).
+// the respective subsets, "board" the Kanban set (saved, applied, or staged),
+// and "dismissed" the jobs the user hid from the feed.
 type Filter string
 
 const (
-	FilterAll     Filter = "all"
-	FilterViewed  Filter = "viewed"
-	FilterSaved   Filter = "saved"
-	FilterApplied Filter = "applied"
-	FilterBoard   Filter = "board"
+	FilterAll       Filter = "all"
+	FilterViewed    Filter = "viewed"
+	FilterSaved     Filter = "saved"
+	FilterApplied   Filter = "applied"
+	FilterBoard     Filter = "board"
+	FilterDismissed Filter = "dismissed"
 )
 
 // ParseFilter validates a raw filter string against the vocabulary. An empty
@@ -46,7 +48,7 @@ func ParseFilter(s string) (Filter, error) {
 	switch Filter(s) {
 	case "", FilterAll:
 		return FilterAll, nil
-	case FilterViewed, FilterSaved, FilterApplied, FilterBoard:
+	case FilterViewed, FilterSaved, FilterApplied, FilterBoard, FilterDismissed:
 		return Filter(s), nil
 	}
 	return "", ErrInvalidFilter
@@ -54,11 +56,12 @@ func ParseFilter(s string) (Filter, error) {
 
 // Counts are the per-filter interaction totals for the my-jobs tab badges.
 type Counts struct {
-	All     int64
-	Viewed  int64
-	Saved   int64
-	Applied int64
-	Board   int64
+	All       int64
+	Viewed    int64
+	Saved     int64
+	Applied   int64
+	Board     int64
+	Dismissed int64
 }
 
 // Total returns the count matching the active filter — the value the listing's
@@ -73,6 +76,8 @@ func (c Counts) Total(f Filter) int64 {
 		return c.Applied
 	case FilterBoard:
 		return c.Board
+	case FilterDismissed:
+		return c.Dismissed
 	default:
 		return c.All
 	}
@@ -168,6 +173,9 @@ type Repository interface {
 	// SavedSlugs returns every public job slug the caller has saved (bookmarked).
 	SavedSlugs(ctx context.Context, userID int64) ([]string, error)
 
+	// DismissedSlugs returns every public job slug the caller has hidden (dismissed).
+	DismissedSlugs(ctx context.Context, userID int64) ([]string, error)
+
 	// ExcludedJobIDs returns up to limit job ids the caller has already interacted
 	// with (viewed, saved, applied, or dismissed), most-recently-touched first.
 	ExcludedJobIDs(ctx context.Context, userID int64, limit int32) ([]int64, error)
@@ -216,6 +224,11 @@ func (s *Service) ViewedSlugs(ctx context.Context, userID int64) ([]string, erro
 // SavedSlugs returns every public job slug the caller has saved (bookmarked).
 func (s *Service) SavedSlugs(ctx context.Context, userID int64) ([]string, error) {
 	return s.repo.SavedSlugs(ctx, userID)
+}
+
+// DismissedSlugs returns every public job slug the caller has hidden (dismissed).
+func (s *Service) DismissedSlugs(ctx context.Context, userID int64) ([]string, error) {
+	return s.repo.DismissedSlugs(ctx, userID)
 }
 
 // ExcludedJobIDs returns the job ids the caller has already interacted with

--- a/internal/jobtracking/jobtracking_test.go
+++ b/internal/jobtracking/jobtracking_test.go
@@ -42,6 +42,8 @@ type fakeRepo struct {
 	viewedErr           error
 	savedResult         []string
 	savedErr            error
+	dismissedResult     []string
+	dismissedErr        error
 	excludedResult      []int64
 	excludedErr         error
 	excludedLimit       int32
@@ -119,6 +121,10 @@ func (f *fakeRepo) ViewedSlugs(_ context.Context, _ int64) ([]string, error) {
 
 func (f *fakeRepo) SavedSlugs(_ context.Context, _ int64) ([]string, error) {
 	return f.savedResult, f.savedErr
+}
+
+func (f *fakeRepo) DismissedSlugs(_ context.Context, _ int64) ([]string, error) {
+	return f.dismissedResult, f.dismissedErr
 }
 
 func (f *fakeRepo) ExcludedJobIDs(_ context.Context, _ int64, limit int32) ([]int64, error) {
@@ -621,6 +627,48 @@ func TestSavedSlugs_Passthrough(t *testing.T) {
 	}
 	if len(slugs) != 2 || slugs[0] != "job-a" {
 		t.Errorf("slugs = %v, want [job-a job-b]", slugs)
+	}
+}
+
+func TestDismissedSlugs_Passthrough(t *testing.T) {
+	repo := newRepo()
+	repo.dismissedResult = []string{"job-a", "job-b"}
+	svc := jobtracking.New(repo)
+
+	slugs, err := svc.DismissedSlugs(ctx(), userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(slugs) != 2 || slugs[0] != "job-a" {
+		t.Errorf("slugs = %v, want [job-a job-b]", slugs)
+	}
+}
+
+func TestParseFilter_Dismissed(t *testing.T) {
+	f, err := jobtracking.ParseFilter("dismissed")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if f != jobtracking.FilterDismissed {
+		t.Errorf("filter = %q, want %q", f, jobtracking.FilterDismissed)
+	}
+}
+
+func TestListTracked_DismissedFilterSelectsDismissedTotal(t *testing.T) {
+	repo := newRepo()
+	repo.countResult = jobtracking.Counts{All: 9, Viewed: 4, Saved: 2, Applied: 3, Board: 5, Dismissed: 6}
+	repo.listResult = []jobtracking.TrackedJob{{Interaction: jobtracking.Interaction{JobID: jobID}}}
+	svc := jobtracking.New(repo)
+
+	listing, err := svc.ListTracked(ctx(), userID, "dismissed", 20, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.listFilter != jobtracking.FilterDismissed {
+		t.Errorf("repo received filter %q, want %q", repo.listFilter, jobtracking.FilterDismissed)
+	}
+	if listing.Total() != 6 {
+		t.Errorf("Total() = %d, want 6 (the dismissed count)", listing.Total())
 	}
 }
 

--- a/internal/jobtracking/repository.go
+++ b/internal/jobtracking/repository.go
@@ -183,11 +183,12 @@ func (r *QueriesRepository) CountInteractions(ctx context.Context, userID int64)
 		return Counts{}, err
 	}
 	return Counts{
-		All:     row.All,
-		Viewed:  row.Viewed,
-		Saved:   row.Saved,
-		Applied: row.Applied,
-		Board:   row.Board,
+		All:       row.All,
+		Viewed:    row.Viewed,
+		Saved:     row.Saved,
+		Applied:   row.Applied,
+		Board:     row.Board,
+		Dismissed: row.Dismissed,
 	}, nil
 }
 
@@ -199,6 +200,11 @@ func (r *QueriesRepository) ViewedSlugs(ctx context.Context, userID int64) ([]st
 // SavedSlugs returns every public job slug the caller has saved (bookmarked).
 func (r *QueriesRepository) SavedSlugs(ctx context.Context, userID int64) ([]string, error) {
 	return r.q.ListSavedJobSlugs(ctx, userID)
+}
+
+// DismissedSlugs returns every public job slug the caller has hidden (dismissed).
+func (r *QueriesRepository) DismissedSlugs(ctx context.Context, userID int64) ([]string, error) {
+	return r.q.ListDismissedJobSlugs(ctx, userID)
 }
 
 // ExcludedJobIDs returns up to limit job ids the caller has already interacted

--- a/openspec/changes/hide-jobs-from-list/.openspec.yaml
+++ b/openspec/changes/hide-jobs-from-list/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/hide-jobs-from-list/design.md
+++ b/openspec/changes/hide-jobs-from-list/design.md
@@ -1,0 +1,106 @@
+## Context
+
+Per-user job interactions live in `user_jobs`, one row per `(user, job)`. The
+swipe deck already introduced a **dismiss** mark (`dismissed_at`) with idempotent
+`DismissJob`/`UndismissJob` queries, `POST/DELETE /api/v1/jobs/:slug/dismiss`
+endpoints (integration-tested), and `api.dismissJob`/`api.undismissJob` clients.
+Today dismiss is surfaced only in `SwipeDeck`; the browse feed neither offers it
+nor excludes dismissed jobs.
+
+The browse feed (`JobsView` → `JobRow`) already dims viewed cards and fills saved
+bookmarks by cross-referencing client-side slug sets loaded once for signed-in
+users: `viewedJobs.svelte.ts` (from `GET /me/tracking/viewed`) and
+`savedJobs.svelte.ts` (from `GET /me/tracking/saved`). These read the same
+`user_jobs` marks the tracking service already exposes. This change adds a third
+such set — dismissed — and a hide gesture that writes it.
+
+The Activity surface (`my/activity/+layout.svelte`) is a tabbed set of routed
+views (Saved / History / Matches), each backed by `api.listMyJobs(filter, …)`
+over `ListUserJobs`, whose `filter` is a controlled vocabulary
+(`all|viewed|saved|applied|board`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bring the existing dismiss gesture to the browse feed with a discoverable,
+  non-navigating hide control and an undo path.
+- Keep hidden jobs out of the feed using the established client-side slug
+  cross-reference pattern — no new server query shape for the feed itself.
+- Give users a place (Activity → Hidden) to review and reverse hides.
+
+**Non-Goals:**
+
+- Server-side / Meili exclusion of dismissed jobs from search. Per-user state is
+  not in the index; the client cross-reference is sufficient for the expected
+  small dismissed set, matching how viewed/saved already work.
+- A general-purpose global toast system. The undo affordance is a single local
+  component owned by the feed, not shared infra.
+- Changing the dismiss endpoint contract or the swipe deck.
+
+## Decisions
+
+### Decision: Reuse the `dismissed_at` mark, do not invent a "hidden" mark
+
+Hiding a job from the feed and swiping it away are the same user intent — "stop
+showing me this." Both map to `dismissed_at`. **Alternative considered:** a
+separate `hidden_at` column to distinguish feed-hide from swipe-dismiss. Rejected
+as YAGNI: no requirement distinguishes them, and a second column would fork the
+exclusion logic, the endpoints, and the undo path for no user-visible gain.
+
+### Decision: Client-side feed exclusion via a `dismissedJobs.svelte.ts` store
+
+Add a store that is a near-exact copy of `savedJobs.svelte.ts` (a `SvelteSet` of
+slugs behind `UserResource`), loaded from a new `GET /me/tracking/dismissed`. The
+feed filters `jobs.items` by this set. **Alternative:** filter server-side.
+Rejected — the feed is Meili-backed and per-user dismiss state is not indexable
+without fetching the dismissed id set and injecting a `NOT IN` filter per query,
+far heavier than the client cross-reference the codebase already uses for
+viewed/saved. Trade-off: a page of N results may render fewer than N cards after
+exclusion; acceptable for the expected small dismissed set (same trade-off the
+viewed-dim path already lives with).
+
+### Decision: Hide control mirrors the save control on `JobRow`
+
+An icon-only overlay button (`EyeOff`), sibling of the card `<a>` (not a
+descendant) so it never navigates, revealed on hover. Optimistic: add to the
+dismissed set + fire `api.dismissJob`, roll back on failure; signed-out click
+opens the auth dialog. This is the exact shape of the existing `toggleSave`.
+Placement: bottom corner of the card (the top-right corner is taken by the
+bookmark), satisfying "somewhere at the bottom, on hover."
+
+### Decision: Local undo toast owned by `JobsView`
+
+On hide, `JobsView` shows a single fixed-position "Job hidden — Undo" element with
+a timeout. Undo calls `api.undismissJob` and removes the slug from the dismissed
+set (restoring the card). **Alternative:** in-place collapse-to-strip, or a global
+toast system. Rejected the global system as premature infra; rejected in-place
+collapse because the user chose vanish-with-toast. The component is self-contained
+and leaves a clean seam if a shared toast is ever needed.
+
+### Decision: `dismissed` filter on the tracking list, not a new endpoint
+
+The Hidden tab reuses `api.listMyJobs` with a new `dismissed` filter value, added
+to `ListUserJobs`/`CountUserJobs` (`WHERE … dismissed_at IS NOT NULL`) and the
+`MyJobsFilter` vocabulary. This matches Saved/History, which are also filter
+values over the same list. The dismissed-slugs cross-reference is the one new
+read endpoint, mirroring `ListSavedSlugs` exactly.
+
+## Risks / Trade-offs
+
+- **Short feed pages after exclusion** → Acceptable and pre-existing; the
+  paginator keeps loading more, and the dismissed set is small per user.
+- **Optimistic hide races a slow dismiss request** → The `saving`-style guard and
+  rollback-on-failure from `toggleSave` are reused, so a failed dismiss restores
+  the card.
+- **Undo after the toast times out** → Not supported inline by design; the
+  Activity → Hidden tab is the durable recovery path, so nothing is unrecoverable.
+- **Two surfaces write the same mark (swipe + feed)** → Idempotent upserts already
+  guarantee one row per `(user, job)`; concurrent surfaces converge safely.
+
+## Migration Plan
+
+No schema migration: `dismissed_at`, the queries, and the endpoints already
+exist. New SQL (`ListDismissedJobSlugs`, `dismissed` filter branch) regenerates
+via sqlc. Rollback is a pure code revert — no data shape changes, and any
+`dismissed_at` values already written by the swipe deck remain valid.

--- a/openspec/changes/hide-jobs-from-list/proposal.md
+++ b/openspec/changes/hide-jobs-from-list/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Signed-in users browsing the jobs feed have no way to say "not this one — stop
+showing it to me." Irrelevant postings (wrong role, a company they've ruled out,
+a repeat they've already judged) keep occupying the feed. The swipe deck already
+lets a user dismiss a job, and the whole backend for it — the `dismissed_at`
+mark, the `POST/DELETE /jobs/:slug/dismiss` endpoints — already exists. This
+change brings that same "hide" gesture to the ordinary browse list and gives the
+user a place to review and undo it.
+
+## What Changes
+
+- Add a **hide control** to the job card (`JobRow`) for authenticated users: an
+  eye-off icon revealed on hover that dismisses the job via the existing
+  `POST /jobs/:slug/dismiss` endpoint.
+- **Hidden jobs drop out of the browse feed** client-side, mirroring the
+  existing viewed/saved slug cross-reference (no server-side Meili filtering).
+- Hiding a card makes it **vanish immediately with a transient "Job hidden —
+  Undo" toast**; Undo restores it via `DELETE /jobs/:slug/dismiss`.
+- Add a **dismissed-slugs endpoint** (`GET /me/tracking/dismissed`) so the SPA
+  knows which feed cards to exclude, mirroring `GET /me/tracking/saved`.
+- Add a **"Hidden" tab** to the Activity surface listing dismissed jobs, each
+  with an un-hide action, backed by a new `dismissed` filter on the tracking
+  list.
+
+## Capabilities
+
+### New Capabilities
+
+- `hidden-jobs`: Let an authenticated user hide a job from the browse feed and
+  manage the set of hidden jobs. Covers the card hide control, the client-side
+  feed exclusion with undo, the dismissed-slugs cross-reference endpoint, and the
+  Activity "Hidden" tab with un-hide. Reuses the existing dismiss interaction
+  (`user_jobs.dismissed_at`, `POST/DELETE /jobs/:slug/dismiss`) owned by
+  `job-swipe`; that endpoint's contract is unchanged.
+
+### Modified Capabilities
+
+<!-- None: the dismiss endpoint's contract is unchanged; this change only adds
+     new read surfaces and UI on top of the existing dismiss mark. -->
+
+## Impact
+
+- **Backend**: new `ListDismissedJobSlugs` query + `DismissedSlugs` tracking
+  method + `GET /me/tracking/dismissed` handler and route; new `dismissed`
+  filter branch in `ListUserJobs`/`CountUserJobs` and the `MyJobsFilter` domain
+  vocabulary.
+- **Frontend**: `JobRow.svelte` (hide control), new `dismissedJobs.svelte.ts`
+  store, `JobsView.svelte` (feed exclusion + undo toast), new
+  `my/activity/hidden/+page.svelte` + `Hidden.svelte`, a fourth tab in
+  `my/activity/+layout.svelte`, and `api.ts`/`types.ts` (`listDismissedSlugs`,
+  `dismissed` filter value).
+- **Reused unchanged**: `dismissed_at` column, `DismissJob`/`UndismissJob`
+  queries, `POST/DELETE /jobs/:slug/dismiss` endpoints, `api.dismissJob`/
+  `api.undismissJob`.

--- a/openspec/changes/hide-jobs-from-list/specs/hidden-jobs/spec.md
+++ b/openspec/changes/hide-jobs-from-list/specs/hidden-jobs/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Hiding a job from the browse feed
+
+The system SHALL let an authenticated user hide a job directly from a job card in
+the browse feed. The card SHALL expose a hide control (an eye-off icon) revealed
+on hover; activating it SHALL record the dismissed interaction via
+`POST /api/v1/jobs/:slug/dismiss` and remove the card from the current feed. A
+signed-out user who activates the control SHALL be routed to sign-in and the job
+SHALL NOT be hidden. The hide control SHALL NOT navigate to the job detail (it is
+an overlay sibling of the card link, like the save control).
+
+#### Scenario: Authenticated user hides a job from the feed
+
+- **WHEN** an authenticated user activates the hide control on a feed card
+- **THEN** the system records the job as dismissed for that user
+- **AND** the card is removed from the visible feed
+- **AND** the browse view does not navigate to the job detail
+
+#### Scenario: Signed-out user is routed to sign-in
+
+- **WHEN** a signed-out visitor activates the hide control
+- **THEN** the sign-in dialog opens
+- **AND** no dismiss request is sent and the card stays in the feed
+
+### Requirement: Hidden jobs are excluded from the browse feed
+
+The system SHALL exclude a signed-in user's hidden (dismissed) jobs from the
+browse feed by cross-referencing a client-side set of dismissed slugs, mirroring
+the existing viewed/saved slug cross-reference. The set SHALL be loaded once for
+a signed-in user via `GET /api/v1/me/tracking/dismissed`, which returns
+`{"data": [slug, ...]}` scoped to the caller. Exclusion is client-side only; the
+server search/Meili path SHALL be unchanged. For a signed-out user the set stays
+empty and nothing is excluded.
+
+#### Scenario: Dismissed jobs do not reappear in the feed
+
+- **WHEN** a signed-in user who previously hid job A loads or re-renders the
+  browse feed
+- **THEN** job A is not shown among the feed cards
+
+#### Scenario: Dismissed-slugs endpoint scopes to the caller
+
+- **WHEN** an authenticated user requests `GET /api/v1/me/tracking/dismissed`
+- **THEN** the system responds `200` with `{"data": [slug, ...]}` listing only
+  that user's dismissed jobs' public slugs
+
+#### Scenario: Signed-out feed excludes nothing
+
+- **WHEN** a signed-out visitor loads the browse feed
+- **THEN** no client-side dismissed exclusion is applied and every matching job
+  is eligible to show
+
+### Requirement: Undo a hide from the feed
+
+When a user hides a job from the feed, the system SHALL surface a transient
+"Job hidden — Undo" affordance. Activating Undo SHALL clear the job's dismissed
+mark via `DELETE /api/v1/jobs/:slug/dismiss` and restore the job to the feed. The
+affordance SHALL dismiss itself after a short timeout if not used. An undo request
+for a job with no interaction row SHALL be treated as success (already not
+hidden), never an error.
+
+#### Scenario: Undo restores a just-hidden job
+
+- **WHEN** a user hides a feed card and then activates Undo before it times out
+- **THEN** the job's dismissed mark is cleared
+- **AND** the job becomes eligible to show in the feed again
+
+#### Scenario: Undo affordance auto-dismisses
+
+- **WHEN** a user hides a feed card and does not activate Undo
+- **THEN** the undo affordance disappears after its timeout without changing the
+  hidden state
+
+### Requirement: Reviewing and un-hiding jobs in Activity
+
+The Activity surface SHALL provide a "Hidden" tab, at its own linkable route,
+listing the signed-in user's hidden (dismissed) jobs most-recently-hidden first.
+The listing SHALL be served by the tracking list under a `dismissed` filter that
+selects interaction rows with `dismissed_at` set. Each listed job SHALL offer an
+un-hide action that clears the dismissed mark via
+`DELETE /api/v1/jobs/:slug/dismiss` and removes it from the Hidden list. When the
+user has no hidden jobs the tab SHALL show an empty state.
+
+#### Scenario: Hidden tab lists dismissed jobs
+
+- **WHEN** an authenticated user with hidden jobs opens the Activity "Hidden" tab
+- **THEN** the system lists those jobs, most-recently-hidden first
+
+#### Scenario: Un-hiding removes a job from the Hidden list
+
+- **WHEN** the user activates un-hide on a job in the Hidden tab
+- **THEN** the job's dismissed mark is cleared
+- **AND** the job is removed from the Hidden list
+
+#### Scenario: Empty Hidden tab
+
+- **WHEN** an authenticated user with no hidden jobs opens the "Hidden" tab
+- **THEN** the system shows an empty state indicating nothing is hidden

--- a/openspec/changes/hide-jobs-from-list/tasks.md
+++ b/openspec/changes/hide-jobs-from-list/tasks.md
@@ -1,0 +1,40 @@
+## 1. Backend — dismissed-slugs cross-reference endpoint
+
+- [x] 1.1 Add `ListDismissedJobSlugs` query to `internal/db/queries/user_jobs.sql` (public_slug where `dismissed_at IS NOT NULL`, scoped to user), mirroring `ListSavedJobSlugs`; regenerate sqlc (`make sqlc`)
+- [x] 1.2 Add `DismissedSlugs` method to the tracking service, mirroring `SavedSlugs`
+- [x] 1.3 Add `ListDismissedSlugs` handler + wire `GET /me/tracking/dismissed` route in `internal/handler/handler.go`, mirroring `ListSavedSlugs`; cover with an integration test asserting the caller-scoped `{"data":[slug,...]}` shape
+
+## 2. Backend — `dismissed` filter on the tracking list
+
+- [x] 2.1 Add the `dismissed` branch to `ListUserJobs` (`filter = 'dismissed' AND dismissed_at IS NOT NULL`) and a `dismissed` count to `CountUserJobs`; regenerate sqlc
+- [x] 2.2 Thread the `dismissed` filter value through the tracking service / `MyJobsFilter` vocabulary and the `/me/tracking` list handler; extend the tracking integration test to assert a dismissed row lists under `filter=dismissed` and is excluded from `saved`/`viewed`
+
+## 3. Frontend — API client + types
+
+- [x] 3.1 Add `listDismissedSlugs()` to `web/src/lib/api.ts` (mirror `listSavedSlugs`) and add `'dismissed'` to the `MyJobsFilter` type in `web/src/lib/types.ts`
+- [x] 3.2 N/A: api layer has no unit-testable seam beyond the URL string; covered by the integration tests in 1.3/2.2
+
+## 4. Frontend — dismissed slugs store
+
+- [x] 4.1 Create `web/src/lib/dismissedJobs.svelte.ts` mirroring `savedJobs.svelte.ts` (`isDismissed`/`markDismissed`/`markUndismissed`/`ensureDismissedLoaded`), loading from `api.listDismissedSlugs`
+- [x] 4.2 N/A: no saved/viewed store tests exist to mirror (thin reactive Set glue, no branching logic); verified via svelte-check + visual QA
+
+## 5. Frontend — hide control on the job card
+
+- [x] 5.1 Add an `EyeOff` hover-revealed hide control to `web/src/lib/components/JobRow.svelte` (sibling of the card link, bottom corner), with optimistic `markDismissed` + `api.dismissJob`, rollback on failure, and sign-in routing for signed-out clicks — mirroring `toggleSave`
+- [x] 5.2 Emit a hide event/callback from `JobRow` so the parent feed can surface undo (prop callback, default no-op so embedded uses are unaffected)
+
+## 6. Frontend — feed exclusion + undo toast
+
+- [x] 6.1 In `web/src/lib/components/JobsView.svelte`, `ensureDismissedLoaded()` on mount for signed-in users and filter `jobs.items` by `!isDismissed(slug)`
+- [x] 6.2 Add a local, self-contained "Job hidden — Undo" toast (fixed-position, timeout) wired to `JobRow`'s hide callback; Undo calls `api.undismissJob` + `markUndismissed`
+
+## 7. Frontend — Activity "Hidden" tab
+
+- [x] 7.1 Add a fourth "Hidden" tab to `web/src/routes/my/activity/+layout.svelte` (route, aria, active-state) and create `web/src/routes/my/activity/hidden/+page.svelte`
+- [x] 7.2 Create `web/src/lib/components/Hidden.svelte` mirroring `SavedJobs.svelte` (`api.listMyJobs('dismissed', …)`), with a per-row un-hide action (`api.undismissJob` + remove from list + `markUndismissed`) and an empty state
+
+## 8. Verification
+
+- [x] 8.1 go build/vet/test all green; dismissed + tracking integration tests pass under -tags=integration
+- [x] 8.2 Live browser verify against my server (:8091) + dev DB: hide/vanish/toast, signed-out→sign-in, undo-restore, toast auto-dismiss, Hidden tab list + un-hide→empty; all green

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -721,6 +721,13 @@ export function createApi(
     await call(`/api/v1/jobs/${slug}/reminder`, { method: 'DELETE' });
   }
 
+  /** The public slugs of every job the current user has hidden (dismissed). The
+   *  browse UI cross-references this set to exclude hidden jobs from the feed
+   *  without authenticating the public job list. */
+  async function listDismissedSlugs(): Promise<string[]> {
+    return requestData<string[]>('/api/v1/me/tracking/dismissed');
+  }
+
   // --- API keys -------------------------------------------------------------
   //
   // Personal API keys for non-browser access. Management is cookie-only (these
@@ -1193,6 +1200,7 @@ export function createApi(
     updateReminderSettings,
     rescheduleReminder,
     cancelReminder,
+    listDismissedSlugs,
     listApiKeys,
     createApiKey,
     revokeApiKey,
@@ -1256,7 +1264,7 @@ export function createApi(
   };
 }
 
-export type MyJobsFilter = 'all' | 'viewed' | 'saved' | 'applied' | 'board';
+export type MyJobsFilter = 'all' | 'viewed' | 'saved' | 'applied' | 'board' | 'dismissed';
 
 /** The default browser client: global fetch, same-origin, cookie attached. Client
  *  components call methods on it (`api.foo()`); server `load` uses `serverApi(event.fetch)`. */

--- a/web/src/lib/components/Hidden.svelte
+++ b/web/src/lib/components/Hidden.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import { Eye } from '@lucide/svelte';
+  import { api } from '$lib/api';
+  import { isAuthenticated } from '$lib/auth.svelte';
+  import { markUndismissed } from '$lib/dismissedJobs.svelte';
+  import { Paginator } from '$lib/paginated.svelte';
+  import JobRow from './JobRow.svelte';
+  import LoadMore from './LoadMore.svelte';
+  import States from './States.svelte';
+
+  // The jobs the signed-in user has hidden from the feed, newest-hidden first.
+  // Mirrors SavedJobs, with a per-row un-hide action: this is the durable way to
+  // reverse a hide once the feed's undo toast is gone.
+  const page = new Paginator(async (limit, offset) => api.listMyJobs('dismissed', limit, offset));
+
+  $effect(() => {
+    if (isAuthenticated()) void page.start();
+  });
+
+  // Guards against a double-click firing two un-hide requests for the same job.
+  let unhiding = $state('');
+
+  // Un-hide: clear the dismissed mark, drop the row from this list, and update the
+  // shared set so the job reappears in the feed. Optimistic — a failed request still
+  // leaves the job usable (the mark simply stays until a later retry).
+  async function unhide(slug: string) {
+    if (unhiding) return;
+    unhiding = slug;
+    try {
+      await api.undismissJob(slug);
+      markUndismissed(slug);
+      page.items = page.items.filter((it) => it.job.public_slug !== slug);
+    } finally {
+      unhiding = '';
+    }
+  }
+</script>
+
+{#if page.status === 'loading'}
+  <States state="loading" />
+{:else if page.status === 'error'}
+  <States state="error" message="Couldn't load your hidden jobs." />
+{:else if page.items.length === 0}
+  <States state="empty" message="Nothing hidden. Jobs you hide from the feed show up here." />
+{:else}
+  <ul class="flex flex-col gap-3">
+    {#each page.items as item (item.job.public_slug)}
+      <li class="relative">
+        <JobRow job={item.job} dimViewed={false} />
+        <button
+          type="button"
+          onclick={() => unhide(item.job.public_slug)}
+          disabled={unhiding === item.job.public_slug}
+          title="Un-hide — show this job in the feed again"
+          class="absolute bottom-2.5 right-2.5 inline-flex items-center gap-1.5 rounded-lg bg-accent px-2.5 py-1.5 text-xs font-medium text-foreground shadow-sm ring-1 ring-border transition hover:text-brand disabled:pointer-events-none disabled:opacity-50"
+        >
+          <Eye class="size-4" aria-hidden="true" />
+          Un-hide
+        </button>
+      </li>
+    {/each}
+  </ul>
+  {#if page.hasMore}
+    <LoadMore loading={page.loadingMore} error={page.loadMoreError} onclick={() => page.loadMore()} />
+  {/if}
+{/if}

--- a/web/src/lib/components/HiddenToast.svelte
+++ b/web/src/lib/components/HiddenToast.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { Undo2 } from '@lucide/svelte';
+
+  // A transient "Job hidden — Undo" affordance for the feed's hide gesture. It owns
+  // its own auto-dismiss timer: after `duration` it calls `onClose` unless the user
+  // undoes first. Self-contained on purpose — the feed just mounts one when a card is
+  // hidden (keyed by slug so each hide restarts the timer) and unmounts on close.
+  let {
+    onUndo,
+    onClose,
+    duration = 5000,
+  }: { onUndo: () => void; onClose: () => void; duration?: number } = $props();
+
+  // Start the countdown on mount; clear it if the toast unmounts (undo, a newer
+  // hide replacing this one, or navigation) so a stale timer can't fire onClose.
+  $effect(() => {
+    const timer = setTimeout(onClose, duration);
+    return () => clearTimeout(timer);
+  });
+</script>
+
+<div
+  role="status"
+  class="fixed inset-x-0 bottom-6 z-40 flex justify-center px-4"
+>
+  <div
+    class="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-2.5 text-sm shadow-lg"
+  >
+    <span class="text-foreground">Job hidden</span>
+    <button
+      type="button"
+      onclick={() => {
+        onUndo();
+        onClose();
+      }}
+      class="inline-flex items-center gap-1.5 font-medium text-brand transition-opacity hover:opacity-80"
+    >
+      <Undo2 class="size-4" aria-hidden="true" />
+      Undo
+    </button>
+  </div>
+</div>

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { resolve } from '$app/paths';
-  import { Bell, Bookmark, X } from '@lucide/svelte';
+  import { Bell, Bookmark, EyeOff, X } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -14,6 +14,7 @@
   import { timeAgo } from '$lib/utils';
   import { hasViewed } from '$lib/viewedJobs.svelte';
   import { isSaved, markSaved, markUnsaved } from '$lib/savedJobs.svelte';
+  import { markDismissed, markUndismissed } from '$lib/dismissedJobs.svelte';
 
   // Single source of truth for how a job appears in any list (jobs list and
   // company detail). The whole card is a link to the job detail.
@@ -28,13 +29,28 @@
   // `footer` is an optional actions row rendered inside the card, below the link
   // content (a sibling of the <a>, never nested in it — so its interactive controls
   // don't fight the card's navigation). The saved list passes the reminder chip here.
+  //
+  // `onHide` is the feed's hook for the "hide this job" gesture: when set (only the
+  // browse feed passes it), the card shows a hover-revealed hide control, and after
+  // a successful dismiss it calls back with the slug so the feed can surface an undo
+  // affordance. Surfaces that reuse JobRow without it (saved/hidden lists, tracking
+  // board, assistant chat) get no hide control — leaving it out scopes the gesture
+  // to the feed.
   let {
     job,
     dimViewed = true,
     newTab = false,
     compact = false,
     footer,
-  }: { job: Job; dimViewed?: boolean; newTab?: boolean; compact?: boolean; footer?: Snippet } = $props();
+    onHide,
+  }: {
+    job: Job;
+    dimViewed?: boolean;
+    newTab?: boolean;
+    compact?: boolean;
+    footer?: Snippet;
+    onHide?: (slug: string) => void;
+  } = $props();
 
   const isViewed = $derived(dimViewed && hasViewed(job.public_slug));
 
@@ -120,12 +136,39 @@
       saving = false;
     }
   }
+
+  // Guards against a double-click firing two dismiss requests for the same job.
+  let hiding = $state(false);
+
+  // Hide (dismiss) the job from the feed. Optimistic: mark it hidden in the shared
+  // set first so the feed drops the card instantly, then confirm with the server and
+  // roll back on failure. A signed-out click routes to sign-in instead. On success we
+  // hand the slug to the feed (onHide) so it can surface an undo affordance. Like the
+  // save button, this is an overlay sibling of the card link, so it never navigates.
+  async function hide() {
+    if (!isAuthenticated()) {
+      openAuthDialog('login');
+      return;
+    }
+    if (hiding) return;
+    hiding = true;
+    markDismissed(job.public_slug);
+    try {
+      await api.dismissJob(job.public_slug);
+      onHide?.(job.public_slug);
+    } catch {
+      markUndismissed(job.public_slug);
+    } finally {
+      hiding = false;
+    }
+  }
 </script>
 
 <!-- The card chrome (border, background, hover) lives on this wrapper, not the <a>,
      so an optional footer row can sit inside the same bordered box as a sibling of
-     the link — interactive footer controls never nest inside the navigation <a>. -->
-<div class="relative rounded-xl border border-border bg-card transition hover:border-brand hover:bg-accent">
+     the link — interactive footer controls never nest inside the navigation <a>.
+     `group` lets the hover-revealed hide control fade in on card hover. -->
+<div class="group relative rounded-xl border border-border bg-card transition hover:border-brand hover:bg-accent">
 <a
   href={resolve('/jobs/[slug]', { slug: job.public_slug })}
   target={newTab ? '_blank' : undefined}
@@ -251,5 +294,23 @@
       </div>
     {/if}
   </div>
+{/if}
+
+<!-- Hide control: only the browse feed passes `onHide`, so this appears there and
+     nowhere else. A quiet icon in the card's bottom-right corner, revealed on hover
+     (and on keyboard focus). It's an overlay sibling of the card link, so hiding
+     never navigates. An opaque background keeps it legible over the salary corner on
+     the minority of cards that show one. -->
+{#if onHide}
+  <button
+    type="button"
+    onclick={hide}
+    disabled={hiding}
+    aria-label="Hide this job"
+    title="Not interested — hide this job"
+    class="absolute bottom-2.5 right-2.5 grid size-8 place-items-center rounded-lg bg-accent text-muted-foreground opacity-0 shadow-sm ring-1 ring-border transition hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-50"
+  >
+    <EyeOff class="size-3.5" aria-hidden="true" />
+  </button>
 {/if}
 </div>

--- a/web/src/lib/components/JobsView.svelte
+++ b/web/src/lib/components/JobsView.svelte
@@ -9,6 +9,7 @@
   import { isAuthenticated } from '$lib/auth.svelte';
   import { ensureViewedLoaded } from '$lib/viewedJobs.svelte';
   import { ensureSavedLoaded } from '$lib/savedJobs.svelte';
+  import { ensureDismissedLoaded, isDismissed, markUndismissed } from '$lib/dismissedJobs.svelte';
   import { latestOnly } from '$lib/latestOnly';
   import { Paginator } from '$lib/paginated.svelte';
   import { FilterStore, filtersToParams, activeFilterCount, canonicalQuery, type SortField } from '$lib/filters';
@@ -37,6 +38,7 @@
   import JobRow from './JobRow.svelte';
   import LoadMore from './LoadMore.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
+  import HiddenToast from './HiddenToast.svelte';
 
   // Filters live in the URL; the route `load` searches by them and returns the
   // first page as `initial`, so the rows are in the initial HTML for SSR/share/
@@ -235,6 +237,7 @@
     if (isAuthenticated()) {
       ensureViewedLoaded();
       ensureSavedLoaded();
+      ensureDismissedLoaded();
     }
     // Register this page's store so the header search drives it. This holds for the
     // standalone /jobs list AND the company page's embedded, scoped list — on
@@ -261,6 +264,36 @@
     const next = makePaginator();
     next.start();
     jobs = next;
+  }
+
+  // The feed minus the signed-in user's hidden jobs. Cross-referenced client-side
+  // against the shared dismissed set (loaded on mount), mirroring the viewed/saved
+  // sets — the server search is untouched. Re-derives when the page changes or when
+  // a hide/undo mutates the set, so a hidden card drops out (and an undone one
+  // returns) instantly. Empty for a signed-out user, so nothing is filtered.
+  const visibleJobs = $derived(jobs.items.filter((j) => !isDismissed(j.public_slug)));
+
+  // The pending "Job hidden — Undo" toast, or null. Set when a card is hidden; the
+  // toast owns its auto-dismiss. Undo clears the slug's hidden mark (card returns via
+  // visibleJobs) and confirms with the server; a failed undo is swallowed — the
+  // durable recovery path is Activity → Hidden.
+  let hiddenToast = $state<{ slug: string } | null>(null);
+
+  function onHide(slug: string) {
+    hiddenToast = { slug };
+  }
+
+  async function undoHide() {
+    const pending = hiddenToast;
+    if (!pending) return;
+    markUndismissed(pending.slug);
+    hiddenToast = null;
+    try {
+      await api.undismissJob(pending.slug);
+    } catch {
+      // Swallow: the job is already back in the feed optimistically, and Activity →
+      // Hidden remains the durable way to manage hidden jobs.
+    }
   }
 
   // Enter swipe mode carrying the current filters + query (same param shape the
@@ -457,10 +490,15 @@
           </div>
         {/if}
       {/if}
+    {:else if visibleJobs.length === 0 && !jobs.hasMore}
+      <!-- The server returned jobs but the user has hidden every one on this final
+           page: show the empty state rather than a blank feed. (With more pages,
+           the {:else} below keeps InfiniteScroll loading instead.) -->
+      <States state="empty" message="No matching jobs." />
     {:else}
       <div class="flex flex-col gap-3">
-        {#each jobs.items as job (job.public_slug)}
-          <JobRow {job} />
+        {#each visibleJobs as job (job.public_slug)}
+          <JobRow {job} {onHide} />
         {/each}
       </div>
 
@@ -488,6 +526,15 @@
   >
     <Layers class="size-4 shrink-0" />
   </button>
+{/if}
+
+<!-- Undo affordance for the hide gesture. Keyed by slug so hiding a second job while
+     a toast is up restarts the countdown for the newer one. A hide-then-forget is
+     still recoverable in Activity → Hidden. -->
+{#if hiddenToast}
+  {#key hiddenToast.slug}
+    <HiddenToast onUndo={undoHide} onClose={() => (hiddenToast = null)} />
+  {/key}
 {/if}
 
 <FilterModal

--- a/web/src/lib/dismissedJobs.svelte.ts
+++ b/web/src/lib/dismissedJobs.svelte.ts
@@ -1,0 +1,69 @@
+// Tracks which jobs the signed-in user has hidden (dismissed), so the browse list
+// and search results can exclude them from the feed. The set of dismissed
+// public_slugs is read once from GET /api/v1/me/tracking/dismissed (the browse
+// view triggers the load); hiding a job from a card updates the set locally so it
+// drops out of the feed immediately, and undo puts it back — both without a reload.
+//
+// Sibling of savedJobs.svelte.ts: same two-way toggle shape, different mark. A
+// dismissed slug means "keep this out of my feed".
+//
+// SSR-safe and auth-agnostic (see UserResource): the load is a browser-only no-op
+// and the set stays empty for signed-out users. A failed load leaves the set empty —
+// nothing is excluded, the correct degraded state.
+
+import { SvelteSet } from 'svelte/reactivity';
+import { api } from '$lib/api';
+import { UserResource } from '$lib/userResource.svelte';
+
+class DismissedJobs extends UserResource<string[]> {
+  // SvelteSet (not a plain Set): a plain Set in $state is not deeply reactive, so
+  // an in-place `.add`/`.delete` would not re-run readers. SvelteSet makes both the
+  // mutation and the load reassignment trigger dependent $derived/$effect (e.g.
+  // the feed's dismissed exclusion).
+  #slugs = $state(new SvelteSet<string>());
+
+  has(slug: string): boolean {
+    return this.#slugs.has(slug);
+  }
+
+  /** Mark a slug hidden locally (e.g. right after a successful dismiss), so its
+   *  card drops out of the feed immediately without re-fetching the whole set. */
+  mark(slug: string) {
+    this.#slugs.add(slug);
+  }
+
+  /** Clear a slug's hidden mark locally (e.g. right after a successful undo). */
+  unmark(slug: string) {
+    this.#slugs.delete(slug);
+  }
+
+  protected load(): Promise<string[]> {
+    return api.listDismissedSlugs();
+  }
+
+  protected apply(slugs: string[]) {
+    this.#slugs = new SvelteSet(slugs);
+  }
+
+  protected clearState() {
+    this.#slugs = new SvelteSet();
+  }
+}
+
+const dismissedJobs = new DismissedJobs();
+
+export function isDismissed(slug: string): boolean {
+  return dismissedJobs.has(slug);
+}
+
+export function markDismissed(slug: string) {
+  dismissedJobs.mark(slug);
+}
+
+export function markUndismissed(slug: string) {
+  dismissedJobs.unmark(slug);
+}
+
+export function ensureDismissedLoaded(): Promise<void> {
+  return dismissedJobs.ensureLoaded();
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -354,6 +354,7 @@ export interface MyJobCounts {
   viewed: number;
   saved: number;
   applied: number;
+  dismissed: number;
 }
 
 /** A snapshot of the caller's applications across the seven pipeline buckets.

--- a/web/src/routes/my/activity/+layout.svelte
+++ b/web/src/routes/my/activity/+layout.svelte
@@ -16,9 +16,16 @@
   const savedActive = $derived(path === '/my/activity');
   const historyActive = $derived(path.startsWith('/my/activity/history'));
   const matchesActive = $derived(path.startsWith('/my/activity/matches'));
+  const hiddenActive = $derived(path.startsWith('/my/activity/hidden'));
   // The id of the active tab, so the routed panel can point back at it (aria-labelledby).
   const activeTabId = $derived(
-    historyActive ? 'activity-tab-history' : matchesActive ? 'activity-tab-matches' : 'activity-tab-saved',
+    historyActive
+      ? 'activity-tab-history'
+      : matchesActive
+        ? 'activity-tab-matches'
+        : hiddenActive
+          ? 'activity-tab-hidden'
+          : 'activity-tab-saved',
   );
 
   const tabClass = (active: boolean) =>
@@ -68,6 +75,16 @@
       class={tabClass(matchesActive)}
     >
       Matches
+    </a>
+    <a
+      role="tab"
+      id="activity-tab-hidden"
+      aria-selected={hiddenActive}
+      aria-controls="activity-tabpanel"
+      href={resolve('/my/activity/hidden')}
+      class={tabClass(hiddenActive)}
+    >
+      Hidden
     </a>
   </div>
 

--- a/web/src/routes/my/activity/hidden/+page.svelte
+++ b/web/src/routes/my/activity/hidden/+page.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import Hidden from '$lib/components/Hidden.svelte';
+</script>
+
+<svelte:head>
+  <title>Hidden — Activity — freehire</title>
+</svelte:head>
+
+<Hidden />


### PR DESCRIPTION
## Summary
- Signed-in users can **hide a job from the browse feed**: a hover-revealed eye-off control on each card dismisses it, the card drops out of the feed, and a transient **"Job hidden — Undo"** toast offers instant reversal.
- New **Activity → Hidden** tab lists hidden jobs with a per-row **Un-hide**.
- Reuses the existing dismiss interaction (`user_jobs.dismissed_at`, `POST/DELETE /jobs/:slug/dismiss`) built for the swipe deck — **no new mark, no migration**.
- Adds `GET /me/tracking/dismissed` (client-side feed exclusion, mirroring viewed/saved slug sets) and a `dismissed` filter on `/me/tracking` for the Hidden tab.

## Design notes
- Client-side feed exclusion (not Meili) — per-user dismiss state isn't indexable; matches the established viewed/saved cross-reference pattern. Accepted trade-off: a page may render a few fewer than N cards.
- Undo is a small self-contained toast owned by the feed (no global toast system introduced). Durable recovery lives in Activity → Hidden.

## Test plan
- [x] `go build/vet/test ./...` green
- [x] Integration tests (real Postgres, `-tags=integration`): dismissed-slugs endpoint scoping, `dismissed` filter listing, undismiss, 401
- [x] `npm run check` (svelte-check) — 0 errors
- [x] Live browser E2E against a real backend + DB: hide→vanish+toast, signed-out→sign-in, undo→restore-in-place, toast auto-dismiss, Hidden tab list + un-hide→empty + server mark cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)