### PR TITLE
ci(perf): k6 SSR page performance suite + PR smoke & prod watchdog

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -92,16 +92,22 @@ jobs:
           MEILI_MASTER_KEY: dev-insecure-meili-key
         run: go run ./cmd/reindex
 
-      - name: Wait for the SSR frontend to render
+      - name: Wait for the SSR frontend to respond
+        # Readiness only needs the SSR server to answer — a 2xx or 3xx both mean
+        # it's up and routing. Whether a page returns the right final status is
+        # k6's job below (it follows redirects and asserts 200 + HTML). The
+        # response headers are logged so any unexpected redirect is visible.
         if: steps.changes.outputs.relevant == 'true'
         run: |
           for i in $(seq 1 30); do
             web=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8090/ || true)
             echo "attempt $i: web=$web"
-            [ "$web" = "200" ] && exit 0
+            case "$web" in
+              2*|3*) echo "SSR responding:"; curl -sI http://localhost:8090/ | head -6; exit 0 ;;
+            esac
             sleep 3
           done
-          echo "SSR frontend did not render"; docker compose ps; docker compose logs --tail=150 web app; exit 1
+          echo "SSR did not respond"; docker compose ps; docker compose logs --tail=150 web app; exit 1
 
       - name: Create a throwaway user for the authed scenarios
         # A real session exercises the /me + personalized chrome path. Registering

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -126,9 +126,9 @@ jobs:
         # fine-grained latency (a shared runner on empty data can't measure that).
         if: steps.changes.outputs.relevant == 'true'
         env:
-          K6_BASE_URL: http://localhost:8090
-          K6_WINDOW_SEC: '8'
-          K6_VUS: '2'
+          PERF_BASE_URL: http://localhost:8090
+          PERF_WINDOW_SEC: '8'
+          PERF_VUS: '2'
           SLO_HOME: '8000'
           SLO_HOME_FILTERED: '8000'
           SLO_COMPANIES: '8000'
@@ -152,10 +152,10 @@ jobs:
         # Anonymous by default. To also cover the authed path, add a PROD_AUTH_COOKIE
         # repo secret (a real hire_token) and pass it as AUTH_COOKIE below.
         env:
-          K6_BASE_URL: https://freehire.dev
+          PERF_BASE_URL: https://freehire.dev
           ALLOW_NONLOCAL: '1'
-          K6_WINDOW_SEC: '20'
-          K6_VUS: '3'
+          PERF_WINDOW_SEC: '20'
+          PERF_VUS: '3'
           MAX_RPS: '15'
           THINK: '1'
           # Baselines observed ~0.6–1.6s p95; ceilings carry generous headroom so

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -69,27 +69,39 @@ jobs:
         if: steps.changes.outputs.relevant == 'true'
         run: docker compose up -d --build
 
-      - name: Wait for API and SSR to be ready
+      - name: Wait for API and search to be ready
         if: steps.changes.outputs.relevant == 'true'
         run: |
           for i in $(seq 1 60); do
             api=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health || true)
-            web=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8090/ || true)
-            echo "attempt $i: api=$api web=$web"
-            [ "$api" = "200" ] && [ "$web" = "200" ] && exit 0
+            meili=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:7700/health || true)
+            echo "attempt $i: api=$api meili=$meili"
+            [ "$api" = "200" ] && [ "$meili" = "200" ] && exit 0
             sleep 3
           done
-          echo "stack did not become ready"; docker compose logs --tail=100; exit 1
+          echo "API/search did not become ready"; docker compose ps; docker compose logs --tail=100; exit 1
 
       - name: Initialise the search index
-        # The homepage feed reads Meilisearch, so the jobs index must exist even
-        # when empty. reindex builds it from Postgres (here: an empty index).
+        # The homepage feed reads Meilisearch, so the jobs index must exist BEFORE
+        # the SSR homepage is hit — otherwise its search 500s and the frontend
+        # never reports ready. reindex builds it from Postgres (here: empty).
         if: steps.changes.outputs.relevant == 'true'
         env:
           DATABASE_URL: postgres://hire:hire@localhost:5432/hire?sslmode=disable
           MEILI_URL: http://localhost:7700
           MEILI_MASTER_KEY: dev-insecure-meili-key
         run: go run ./cmd/reindex
+
+      - name: Wait for the SSR frontend to render
+        if: steps.changes.outputs.relevant == 'true'
+        run: |
+          for i in $(seq 1 30); do
+            web=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8090/ || true)
+            echo "attempt $i: web=$web"
+            [ "$web" = "200" ] && exit 0
+            sleep 3
+          done
+          echo "SSR frontend did not render"; docker compose ps; docker compose logs --tail=150 web app; exit 1
 
       - name: Create a throwaway user for the authed scenarios
         # A real session exercises the /me + personalized chrome path. Registering

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,161 @@
+name: Performance
+
+# Two complementary guards, per the perf suite in perf/k6/:
+#
+#  • pr-smoke     — spins up the full stack and asserts the key pages still
+#                   render (200 + HTML) within a LOOSE latency ceiling. Safe to
+#                   require as a merge check: it runs on every PR and ALWAYS
+#                   reports a status, but only does the heavy work when the PR
+#                   touches the request path (detected via git diff below). It
+#                   runs on an empty DB, so it gates correctness of the
+#                   SSR→API→Postgres→Meili path, not data-scale performance.
+#
+#  • prod-watchdog — on a schedule, run the same suite against production with
+#                    tight, headroom-based thresholds and enough samples to be
+#                    stable. A breach opens an issue. This is where real
+#                    degradation (query plans at scale, cold caches) is caught.
+#
+# NOTE: no workflow-level `paths:` filter — a path-filtered workflow never
+# reports its check on unrelated PRs, which would leave a required check stuck
+# "Expected" forever. Instead the workflow always runs and skips its own heavy
+# steps when nothing relevant changed.
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * *' # daily 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: perf-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Detect request-path changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | grep -qE '^(internal/handler/|internal/search/|internal/jobview/|web/|perf/|\.github/workflows/perf\.yml)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Request-path files changed — running the full smoke."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No request-path changes — reporting green without the heavy run."
+          fi
+
+      - name: Setup Go
+        if: steps.changes.outputs.relevant == 'true'
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install k6
+        if: steps.changes.outputs.relevant == 'true'
+        uses: grafana/setup-k6-action@v1
+
+      - name: Start the stack
+        if: steps.changes.outputs.relevant == 'true'
+        run: docker compose up -d --build
+
+      - name: Wait for API and SSR to be ready
+        if: steps.changes.outputs.relevant == 'true'
+        run: |
+          for i in $(seq 1 60); do
+            api=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/health || true)
+            web=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8090/ || true)
+            echo "attempt $i: api=$api web=$web"
+            [ "$api" = "200" ] && [ "$web" = "200" ] && exit 0
+            sleep 3
+          done
+          echo "stack did not become ready"; docker compose logs --tail=100; exit 1
+
+      - name: Initialise the search index
+        # The homepage feed reads Meilisearch, so the jobs index must exist even
+        # when empty. reindex builds it from Postgres (here: an empty index).
+        if: steps.changes.outputs.relevant == 'true'
+        env:
+          DATABASE_URL: postgres://hire:hire@localhost:5432/hire?sslmode=disable
+          MEILI_URL: http://localhost:7700
+          MEILI_MASTER_KEY: dev-insecure-meili-key
+        run: go run ./cmd/reindex
+
+      - name: Create a throwaway user for the authed scenarios
+        # A real session exercises the /me + personalized chrome path. Registering
+        # here avoids firing a doomed login (and polluting the error budget).
+        if: steps.changes.outputs.relevant == 'true'
+        run: |
+          cookie=$(curl -s -i -X POST http://localhost:8090/api/v1/auth/register \
+            -H 'Content-Type: application/json' \
+            -d '{"email":"perf-ci@freehire.local","password":"perf-ci-password"}' \
+            | grep -i '^set-cookie: hire_token' | sed -E 's/.*(hire_token=[^;]+);.*/\1/')
+          if [ -z "$cookie" ]; then echo "could not register CI user"; exit 1; fi
+          echo "AUTH_COOKIE=$cookie" >> "$GITHUB_ENV"
+
+      - name: Run functional smoke (loose latency ceiling)
+        # Loose SLOs: this gate catches pages that error or blow up 5–10×, not
+        # fine-grained latency (a shared runner on empty data can't measure that).
+        if: steps.changes.outputs.relevant == 'true'
+        env:
+          K6_BASE_URL: http://localhost:8090
+          K6_WINDOW_SEC: '8'
+          K6_VUS: '2'
+          SLO_HOME: '8000'
+          SLO_HOME_FILTERED: '8000'
+          SLO_COMPANIES: '8000'
+          SLO_COMPANY_CARD: '8000'
+        run: k6 run --quiet perf/k6/pages.js
+
+      - name: Stack logs on failure
+        if: failure() && steps.changes.outputs.relevant == 'true'
+        run: docker compose logs --tail=200
+
+  prod-watchdog:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install k6
+        uses: grafana/setup-k6-action@v1
+
+      - name: Run production smoke (tight, headroom-based thresholds)
+        # Anonymous by default. To also cover the authed path, add a PROD_AUTH_COOKIE
+        # repo secret (a real hire_token) and pass it as AUTH_COOKIE below.
+        env:
+          K6_BASE_URL: https://freehire.dev
+          ALLOW_NONLOCAL: '1'
+          K6_WINDOW_SEC: '20'
+          K6_VUS: '3'
+          MAX_RPS: '15'
+          THINK: '1'
+          # Baselines observed ~0.6–1.6s p95; ceilings carry generous headroom so
+          # only real degradation trips them. Tighten as baselines firm up.
+          SLO_HOME: '4000'
+          SLO_HOME_FILTERED: '5000'
+          SLO_COMPANIES: '3000'
+          SLO_COMPANY_CARD: '3500'
+          AUTH_COOKIE: ${{ secrets.PROD_AUTH_COOKIE }}
+        run: k6 run --quiet perf/k6/pages.js
+
+      - name: Open an issue on regression
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Perf watchdog: prod page latency regression ($(date -u +%Y-%m-%d))" \
+            --label performance \
+            --body "The scheduled production performance smoke breached its latency/error thresholds. See the run: $RUN_URL"

--- a/perf/k6/README.md
+++ b/perf/k6/README.md
@@ -1,0 +1,84 @@
+# Page performance suite (k6)
+
+End-to-end SSR performance for freehire's most important pages. Each request
+renders a real page through the full server stack — SvelteKit SSR → `serverApi`
+→ Go API → Postgres/Meili — so the numbers reflect what a user's first byte and
+full HTML actually cost, including the company card's streamed job list.
+
+Pages covered, each **anonymous and authenticated**:
+
+| scenario key   | page                              | route                         |
+| -------------- | --------------------------------- | ----------------------------- |
+| `home`         | homepage job feed (jobview)       | `/`                           |
+| `homeFiltered` | job feed under a heavy filter     | `/?q=…&work_mode=…&…`         |
+| `companies`    | companies catalogue               | `/companies?…`                |
+| `companyCard`  | one company card (streamed jobs)  | `/companies/<slug>`           |
+
+The authenticated variants attach the `hire_token` session cookie, so the layout
+resolves `/me` and the pages render personalized, heavier chrome. The suite
+records `page_body_bytes{auth:…}` so you can see anon vs authed payload size.
+
+## Prerequisites
+
+- [k6](https://k6.io/docs/get-started/installation/) (`brew install k6`)
+- A running target. Locally: `make up` (SSR + API behind nginx on `:8090`).
+
+## Run locally (default)
+
+```bash
+k6 run perf/k6/pages.js
+```
+
+Defaults: `K6_BASE_URL=http://localhost:8090`, `PROFILE=smoke`, authed via the
+local QA account (`qa@freehire.local`). The `smoke` profile runs each
+scenario in its own time window (staggered) so per-page latency doesn't contend.
+
+## Run against prod (env swap only)
+
+All target pages are idempotent GETs. Pointing at a non-local origin requires an
+explicit `ALLOW_NONLOCAL=1` latch so a stray `K6_BASE_URL` can never quietly load
+prod. Prefer a real captured session cookie over prod credentials:
+
+```bash
+K6_BASE_URL=https://freehire.dev \
+ALLOW_NONLOCAL=1 \
+AUTH_COOKIE='<paste hire_token value from your browser>' \
+MAX_RPS=20 \
+k6 run perf/k6/pages.js
+```
+
+Off-local safety is automatic: VUs are clamped low, a global `MAX_RPS` ceiling
+applies (default 20), traffic carries a `freehire-perf-k6` User-Agent, and the
+`load` profile is refused unless `FORCE_LOAD=1`. Anonymous-only prod smoke: just
+omit `AUTH_COOKIE`.
+
+## Blended load test
+
+```bash
+PROFILE=load K6_VUS=20 K6_DURATION=2m k6 run perf/k6/pages.js
+```
+
+Runs all scenarios concurrently under a ramping-VUs profile (local by default;
+`FORCE_LOAD=1` required off-local).
+
+## Key knobs
+
+| env                    | default                       | purpose                                        |
+| ---------------------- | ----------------------------- | ---------------------------------------------- |
+| `K6_BASE_URL`          | `http://localhost:8090`       | target origin (fronts SSR + `/api`)            |
+| `ALLOW_NONLOCAL`       | —                             | must be `1` for any non-localhost origin       |
+| `PROFILE`              | `smoke`                       | `smoke` (isolated) or `load` (blended)         |
+| `AUTH_COOKIE`          | —                             | reuse a `hire_token` instead of logging in     |
+| `QA_EMAIL/QA_PASSWORD` | local QA account              | password login for the authed scenarios        |
+| `MAX_RPS`              | `0` local / `20` off-local    | global request/sec ceiling                     |
+| `FILTER_QUERY`         | `q=engineer&work_mode=…`      | the heavy feed filter (tune to your data)      |
+| `COMPANY_FILTER_QUERY` | `regions=europe&company_type=startup` | companies-list facets                  |
+| `SLO_*`                | see `config.js`               | per-page p95 latency budgets (ms)              |
+
+## Reading results
+
+- `http_req_duration{page:…,auth:…}` — per-page, per-mode latency (p95 gates in
+  `thresholds()`).
+- `http_req_failed` — connection/5xx rate (global gate `< 2%`).
+- `page_body_bytes{auth:…}` — payload size; authed should exceed anon.
+- `checks` — every page must return `200` + real HTML.

--- a/perf/k6/README.md
+++ b/perf/k6/README.md
@@ -29,18 +29,18 @@ records `page_body_bytes{auth:…}` so you can see anon vs authed payload size.
 k6 run perf/k6/pages.js
 ```
 
-Defaults: `K6_BASE_URL=http://localhost:8090`, `PROFILE=smoke`, authed via the
+Defaults: `PERF_BASE_URL=http://localhost:8090`, `PROFILE=smoke`, authed via the
 local QA account (`qa@freehire.local`). The `smoke` profile runs each
 scenario in its own time window (staggered) so per-page latency doesn't contend.
 
 ## Run against prod (env swap only)
 
 All target pages are idempotent GETs. Pointing at a non-local origin requires an
-explicit `ALLOW_NONLOCAL=1` latch so a stray `K6_BASE_URL` can never quietly load
+explicit `ALLOW_NONLOCAL=1` latch so a stray `PERF_BASE_URL` can never quietly load
 prod. Prefer a real captured session cookie over prod credentials:
 
 ```bash
-K6_BASE_URL=https://freehire.dev \
+PERF_BASE_URL=https://freehire.dev \
 ALLOW_NONLOCAL=1 \
 AUTH_COOKIE='<paste hire_token value from your browser>' \
 MAX_RPS=20 \
@@ -55,7 +55,7 @@ omit `AUTH_COOKIE`.
 ## Blended load test
 
 ```bash
-PROFILE=load K6_VUS=20 K6_DURATION=2m k6 run perf/k6/pages.js
+PROFILE=load PERF_VUS=20 PERF_DURATION=2m k6 run perf/k6/pages.js
 ```
 
 Runs all scenarios concurrently under a ramping-VUs profile (local by default;
@@ -65,7 +65,7 @@ Runs all scenarios concurrently under a ramping-VUs profile (local by default;
 
 | env                    | default                       | purpose                                        |
 | ---------------------- | ----------------------------- | ---------------------------------------------- |
-| `K6_BASE_URL`          | `http://localhost:8090`       | target origin (fronts SSR + `/api`)            |
+| `PERF_BASE_URL`        | `http://localhost:8090`       | target origin (fronts SSR + `/api`)            |
 | `ALLOW_NONLOCAL`       | —                             | must be `1` for any non-localhost origin       |
 | `PROFILE`              | `smoke`                       | `smoke` (isolated) or `load` (blended)         |
 | `AUTH_COOKIE`          | —                             | reuse a `hire_token` instead of logging in     |

--- a/perf/k6/config.js
+++ b/perf/k6/config.js
@@ -4,13 +4,17 @@
 // `make up` stack (the default) or any remote origin (staging, prod) with no
 // code changes — you only swap env vars.
 //
-//   K6_BASE_URL   origin that fronts BOTH the SSR pages and /api
+//   PERF_BASE_URL origin that fronts BOTH the SSR pages and /api
 //                 local: http://localhost:8090 (default) — prod: https://freehire.dev
 //   ALLOW_NONLOCAL=1   REQUIRED to target any non-localhost origin (a deliberate
-//                      safety latch so a stray K6_BASE_URL can't hammer prod)
+//                      safety latch so a stray PERF_BASE_URL can't hammer prod)
 //   PROFILE       'smoke' (default, isolated per-page) | 'load' (blended stress)
-//   K6_VUS        virtual users per scenario   (profile default otherwise)
-//   K6_DURATION   duration per scenario        (load profile)
+//   PERF_VUS      virtual users per scenario   (profile default otherwise)
+//   PERF_DURATION duration per scenario        (load profile)
+//
+// NOTE: custom env vars are deliberately NOT prefixed `K6_` — k6 reserves that
+// prefix for its own native options (e.g. K6_VUS would create a rogue "default"
+// scenario and ignore ours), so we use PERF_* instead.
 //   MAX_RPS       global request/sec ceiling   (0 = unlimited; auto-caps off-local)
 //   QA_EMAIL / QA_PASSWORD   credentials the authed scenarios log in with (local)
 //   AUTH_COOKIE   a full `hire_token=...` value to reuse instead of logging in
@@ -22,11 +26,11 @@ const env = (k, fallback) => (__ENV[k] !== undefined && __ENV[k] !== '' ? __ENV[
 // URL covers both the login call and every page navigation — exactly the
 // same-origin shape the browser sees (the Lax auth cookie rides along). Prod is
 // identical in shape: freehire.dev fronts both, so only the origin changes.
-export const BASE_URL = env('K6_BASE_URL', 'http://localhost:8090');
+export const BASE_URL = env('PERF_BASE_URL', 'http://localhost:8090');
 
 // Targeting anything other than localhost is a deliberate act, never an env
 // typo. This latch runs at init (top of every VU + setup), so a wrong
-// K6_BASE_URL aborts the whole run before a single request is fired at prod.
+// PERF_BASE_URL aborts the whole run before a single request is fired at prod.
 export const IS_LOCAL = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/|$)/.test(BASE_URL);
 if (!IS_LOCAL && env('ALLOW_NONLOCAL', '') !== '1') {
   throw new Error(
@@ -132,8 +136,8 @@ export function buildScenarios() {
   const scenarios = {};
 
   if (PROFILE === 'load') {
-    const vus = Number(env('K6_VUS', 15));
-    const dur = env('K6_DURATION', '1m');
+    const vus = Number(env('PERF_VUS', 15));
+    const dur = env('PERF_DURATION', '1m');
     for (const page of pages) {
       for (const auth of MODES) {
         scenarios[`${page}_${auth}`] = {
@@ -153,10 +157,10 @@ export function buildScenarios() {
   }
 
   // smoke: isolate each scenario in its own time window so their latencies don't
-  // contend. Off-local we clamp VUs low regardless of K6_VUS — the rps cap and a
+  // contend. Off-local we clamp VUs low regardless of PERF_VUS — the rps cap and a
   // couple of VUs are plenty to measure latency without pressuring prod.
-  const vus = IS_LOCAL ? Number(env('K6_VUS', 2)) : Math.min(Number(env('K6_VUS', 2)), 2);
-  const windowSec = Number(env('K6_WINDOW_SEC', 15));
+  const vus = IS_LOCAL ? Number(env('PERF_VUS', 2)) : Math.min(Number(env('PERF_VUS', 2)), 2);
+  const windowSec = Number(env('PERF_WINDOW_SEC', 15));
   let i = 0;
   for (const page of pages) {
     for (const auth of MODES) {

--- a/perf/k6/config.js
+++ b/perf/k6/config.js
@@ -1,0 +1,176 @@
+// Shared configuration for the SSR page performance suite.
+//
+// Everything is env-overridable so the SAME script runs against a local
+// `make up` stack (the default) or any remote origin (staging, prod) with no
+// code changes — you only swap env vars.
+//
+//   K6_BASE_URL   origin that fronts BOTH the SSR pages and /api
+//                 local: http://localhost:8090 (default) — prod: https://freehire.dev
+//   ALLOW_NONLOCAL=1   REQUIRED to target any non-localhost origin (a deliberate
+//                      safety latch so a stray K6_BASE_URL can't hammer prod)
+//   PROFILE       'smoke' (default, isolated per-page) | 'load' (blended stress)
+//   K6_VUS        virtual users per scenario   (profile default otherwise)
+//   K6_DURATION   duration per scenario        (load profile)
+//   MAX_RPS       global request/sec ceiling   (0 = unlimited; auto-caps off-local)
+//   QA_EMAIL / QA_PASSWORD   credentials the authed scenarios log in with (local)
+//   AUTH_COOKIE   a full `hire_token=...` value to reuse instead of logging in
+//                 (preferred against prod — no password in env, no /auth/login hit)
+
+const env = (k, fallback) => (__ENV[k] !== undefined && __ENV[k] !== '' ? __ENV[k] : fallback);
+
+// The local stack fronts SSR + /api behind one nginx origin, so a single base
+// URL covers both the login call and every page navigation — exactly the
+// same-origin shape the browser sees (the Lax auth cookie rides along). Prod is
+// identical in shape: freehire.dev fronts both, so only the origin changes.
+export const BASE_URL = env('K6_BASE_URL', 'http://localhost:8090');
+
+// Targeting anything other than localhost is a deliberate act, never an env
+// typo. This latch runs at init (top of every VU + setup), so a wrong
+// K6_BASE_URL aborts the whole run before a single request is fired at prod.
+export const IS_LOCAL = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/|$)/.test(BASE_URL);
+if (!IS_LOCAL && env('ALLOW_NONLOCAL', '') !== '1') {
+  throw new Error(
+    `Refusing to run against non-local origin "${BASE_URL}". All target pages are ` +
+      `idempotent GETs, but this is still live traffic — set ALLOW_NONLOCAL=1 to confirm.`,
+  );
+}
+
+// Think-time (seconds) between page views. Models a real user reading a page
+// rather than machine-gunning the origin, and — crucially — stops a VU from
+// tight-looping into a request storm when a target starts failing fast.
+export const THINK = Number(env('THINK', 1));
+
+export const PROFILE = env('PROFILE', 'smoke');
+// The blended 'load' profile can generate real pressure; block it off-local
+// unless explicitly forced, so a prod smoke can't accidentally become a stress test.
+if (!IS_LOCAL && PROFILE === 'load' && env('FORCE_LOAD', '') !== '1') {
+  throw new Error(`PROFILE=load against a non-local origin needs FORCE_LOAD=1 (this stresses live infra).`);
+}
+
+// Global request-rate ceiling. Off-local we default to a gentle cap so a smoke
+// against prod stays polite regardless of VU count; local defaults to unlimited.
+export const MAX_RPS = Number(env('MAX_RPS', IS_LOCAL ? 0 : 20));
+
+// Identifies suite traffic in access logs / analytics so it's separable from
+// real users (and honest about being a bot to any WAF).
+export const USER_AGENT = env('USER_AGENT', 'freehire-perf-k6/1.0 (+load-test)');
+
+// The QA account is a local-dev fixture, so it's only the default off-nothing
+// when targeting localhost. Against any remote origin, creds must be passed
+// explicitly (or, preferably, AUTH_COOKIE) — otherwise the authed scenarios stay
+// anonymous rather than firing a doomed login at prod.
+export const CREDS = {
+  email: env('QA_EMAIL', IS_LOCAL ? 'qa@freehire.local' : ''),
+  password: env('QA_PASSWORD', IS_LOCAL ? 'tracking-qa-2026' : ''),
+};
+
+// A pre-captured `hire_token=...` cookie. When set, the authed scenarios reuse
+// it verbatim and setup() skips the login POST — the safe path for prod, where
+// the local QA account doesn't exist and you don't want a password in env.
+export const AUTH_COOKIE = env('AUTH_COOKIE', '');
+
+// The two auth modes every page is exercised in. `anon` sends no cookie;
+// `authed` attaches the `hire_token` session, which makes the layout resolve
+// /me and the pages render personalized (heavier) chrome — measurably more data.
+export const MODES = ['anon', 'authed'];
+
+// The representative "worst-case" filtered feed the homepage renders. This is a
+// product-knowledge choice: it should mirror a realistic heavy user query —
+// full-text search + several ANDed facets + a sort — over values that actually
+// return a populated result set (an empty result is a cheap fast path and hides
+// the real cost). Facet param names are the ones the search index accepts
+// (internal/search/query_filter.go).
+export const FILTER_QUERY = env(
+  'FILTER_QUERY',
+  'q=engineer&work_mode=remote&seniority=senior&skills=go&sort=posted_at',
+);
+
+// A representative filtered companies view (?q + sidebar facets). Params match
+// GET /api/v1/companies (internal/handler/companies.go).
+export const COMPANY_FILTER_QUERY = env('COMPANY_FILTER_QUERY', 'regions=europe&company_type=startup');
+
+// The pages under test, in the order the user cares about: the homepage job
+// feed, that same feed under a heavy filter, the companies catalogue, and a
+// single company card (its :slug is resolved from live data in setup()).
+export const PAGES = {
+  home: { label: 'homepage job feed', path: '/' },
+  homeFiltered: { label: 'filtered job feed', path: `/?${FILTER_QUERY}` },
+  companies: { label: 'companies catalogue', path: `/companies?${COMPANY_FILTER_QUERY}` },
+  companyCard: { label: 'company card (streamed jobs)', path: '/companies/__SLUG__' },
+};
+
+// Per-page p95 latency budgets (ms) and a global error budget. Starting SLOs —
+// tune per hardware/data once you have a baseline. The company card is looser
+// because it streams its job list in the same response; the filtered feed is
+// looser because it hits Meili full-text + facets.
+const P95 = {
+  home: Number(env('SLO_HOME', 1500)),
+  homeFiltered: Number(env('SLO_HOME_FILTERED', 2500)),
+  companies: Number(env('SLO_COMPANIES', 2000)),
+  companyCard: Number(env('SLO_COMPANY_CARD', 3000)),
+};
+
+export function thresholds() {
+  const t = {
+    http_req_failed: [{ threshold: 'rate<0.02', abortOnFail: false }],
+    checks: ['rate>0.98'],
+  };
+  for (const page of Object.keys(PAGES)) {
+    for (const auth of MODES) {
+      t[`http_req_duration{page:${page},auth:${auth}}`] = [`p(95)<${P95[page]}`];
+    }
+  }
+  return t;
+}
+
+// buildScenarios wires one k6 scenario per (page × auth) so metrics split cleanly
+// by tag. `smoke` runs them sequentially (staggered startTime, low VUs) to keep
+// per-page latency uncontended — the right shape for regression comparison and
+// for a polite prod smoke. `load` runs them all at once under a ramping profile.
+export function buildScenarios() {
+  const pages = Object.keys(PAGES);
+  const scenarios = {};
+
+  if (PROFILE === 'load') {
+    const vus = Number(env('K6_VUS', 15));
+    const dur = env('K6_DURATION', '1m');
+    for (const page of pages) {
+      for (const auth of MODES) {
+        scenarios[`${page}_${auth}`] = {
+          executor: 'ramping-vus',
+          startVUs: 0,
+          stages: [
+            { target: vus, duration: '15s' },
+            { target: vus, duration: dur },
+            { target: 0, duration: '10s' },
+          ],
+          exec: 'run',
+          tags: { page, auth },
+        };
+      }
+    }
+    return scenarios;
+  }
+
+  // smoke: isolate each scenario in its own time window so their latencies don't
+  // contend. Off-local we clamp VUs low regardless of K6_VUS — the rps cap and a
+  // couple of VUs are plenty to measure latency without pressuring prod.
+  const vus = IS_LOCAL ? Number(env('K6_VUS', 2)) : Math.min(Number(env('K6_VUS', 2)), 2);
+  const windowSec = Number(env('K6_WINDOW_SEC', 15));
+  let i = 0;
+  for (const page of pages) {
+    for (const auth of MODES) {
+      scenarios[`${page}_${auth}`] = {
+        executor: 'constant-vus',
+        vus,
+        duration: `${windowSec}s`,
+        startTime: `${i * windowSec}s`,
+        gracefulStop: '3s',
+        exec: 'run',
+        tags: { page, auth },
+      };
+      i++;
+    }
+  }
+  return scenarios;
+}

--- a/perf/k6/helpers.js
+++ b/perf/k6/helpers.js
@@ -1,0 +1,99 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import { BASE_URL, USER_AGENT, AUTH_COOKIE, CREDS, THINK } from './config.js';
+
+// Body size of every rendered page, tagged by {page, auth}. This makes the
+// "authed pulls more data" claim measurable: in the summary, authed body bytes
+// come out heavier than anon because the layout resolves /me and the pages add
+// signed-in chrome and personalization.
+const bodyBytes = new Trend('page_body_bytes');
+
+// Default request params: identify suite traffic and don't chase redirects
+// silently — an SSR page that 301/302s (e.g. /jobs → /) is a signal we want to
+// see, not swallow.
+function params(pageKey, auth, cookie) {
+  const headers = { 'User-Agent': USER_AGENT };
+  if (auth === 'authed' && cookie) headers['Cookie'] = cookie;
+  return { headers, tags: { page: pageKey, auth }, redirects: 5 };
+}
+
+// resolveSession returns the `hire_token=...` cookie string used by authed
+// scenarios. Preference order: a pre-captured AUTH_COOKIE (the prod-safe path),
+// otherwise a one-shot password login against /api/v1/auth/login. Returns '' if
+// no session could be established — callers then skip the authed path rather
+// than silently measuring an anonymous request mislabeled as authed.
+export function resolveSession() {
+  if (AUTH_COOKIE) {
+    // Accept either a bare token or a full `name=value` pair.
+    return AUTH_COOKIE.includes('=') ? AUTH_COOKIE : `hire_token=${AUTH_COOKIE}`;
+  }
+  // No usable session source: don't hit /auth/login at all. This keeps anon-only
+  // runs (notably prod smokes) from wasting a request — and, since a 401 counts
+  // as a failed http_req, from polluting the error-rate threshold.
+  if (!CREDS.email || !CREDS.password) return '';
+
+  // A few attempts absorb a cold reverse-proxy at t=0 (status 0). A real 401
+  // (bad creds) is terminal — don't retry it.
+  let res;
+  for (let i = 0; i < 3; i++) {
+    res = http.post(
+      `${BASE_URL}/api/v1/auth/login`,
+      JSON.stringify({ email: CREDS.email, password: CREDS.password }),
+      { headers: { 'Content-Type': 'application/json', 'User-Agent': USER_AGENT } },
+    );
+    if (res.status !== 0) break;
+    sleep(1);
+  }
+  const jar = res.cookies['hire_token'];
+  if (res.status !== 200 || !jar || jar.length === 0) {
+    console.warn(
+      `login failed (status ${res.status}) — authed scenarios will be skipped. ` +
+        `On prod, pass AUTH_COOKIE instead of QA creds.`,
+    );
+    return '';
+  }
+  return `hire_token=${jar[0].value}`;
+}
+
+// pickCompanySlug pulls a real company slug from live data so the company-card
+// scenario is never hardcoded/brittle. It prefers a company with open jobs so
+// the streamed job list actually does work (the interesting latency path).
+export function pickCompanySlug() {
+  let res;
+  for (let i = 0; i < 3; i++) {
+    res = http.get(`${BASE_URL}/api/v1/companies?limit=50`, { headers: { 'User-Agent': USER_AGENT } });
+    if (res.status === 200) break;
+    sleep(1);
+  }
+  if (res.status !== 200) {
+    console.warn(`could not list companies (status ${res.status}) — company-card scenarios skipped`);
+    return '';
+  }
+  const rows = (res.json('data') || []);
+  if (rows.length === 0) return '';
+  const withJobs = rows.find((c) => (c.job_count || 0) > 0);
+  return (withJobs || rows[0]).slug || '';
+}
+
+// visit renders one SSR page and records latency (tagged), body size, and
+// content checks. `data` carries the resolved session cookie and company slug
+// from setup(); a scenario with no usable session/slug is skipped, not faked.
+export function visit(pageKey, path, auth, data) {
+  if (auth === 'authed' && !data.cookie) return; // no session — don't mislabel anon as authed
+  const url = BASE_URL + path.replace('__SLUG__', data.slug);
+  if (path.includes('__SLUG__') && !data.slug) return; // no company to render
+
+  const res = http.get(url, params(pageKey, auth, data.cookie));
+  bodyBytes.add(res.body ? res.body.length : 0, { page: pageKey, auth });
+
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'is html document': (r) => typeof r.body === 'string' && r.body.toLowerCase().includes('<!doctype html'),
+    'body is non-trivial': (r) => r.body && r.body.length > 1000,
+  });
+
+  // Think-time between page views: realistic pacing, and a hard brake on the
+  // tight-loop request storm that a fast-failing target would otherwise cause.
+  sleep(THINK);
+}

--- a/perf/k6/pages.js
+++ b/perf/k6/pages.js
@@ -1,0 +1,41 @@
+// SSR page performance suite for freehire's most important pages:
+//   - the homepage job feed (jobview), plain and under a heavy filter
+//   - the companies catalogue
+//   - a single company card (streamed job list)
+// Each is exercised anonymously AND authenticated (the authed path resolves /me
+// and renders heavier, personalized chrome). See README.md to run.
+
+import exec from 'k6/execution';
+import { PAGES, MODES, PROFILE, BASE_URL, MAX_RPS, buildScenarios, thresholds } from './config.js';
+import { resolveSession, pickCompanySlug, visit } from './helpers.js';
+
+export const options = {
+  scenarios: buildScenarios(),
+  thresholds: thresholds(),
+  // Global request-rate ceiling (0 = unlimited). Keeps prod smokes polite.
+  ...(MAX_RPS > 0 ? { rps: MAX_RPS } : {}),
+};
+
+// setup runs once. It establishes the authed session and resolves a real
+// company slug, then hands both to every VU iteration — so the login and the
+// company lookup happen a single time, not per request.
+export function setup() {
+  const cookie = resolveSession();
+  const slug = pickCompanySlug();
+  console.log(
+    `target=${BASE_URL} profile=${PROFILE} authed=${cookie ? 'yes' : 'no'} companySlug=${slug || '(none)'}`,
+  );
+  return { cookie, slug };
+}
+
+// One entry point for every scenario. k6 tells us which scenario is running via
+// exec.scenario.name (e.g. "companyCard_authed"); we split it into page + auth
+// and dispatch — no per-scenario boilerplate.
+export function run(data) {
+  const name = exec.scenario.name;
+  const sep = name.lastIndexOf('_');
+  const page = name.slice(0, sep);
+  const auth = name.slice(sep + 1);
+  if (!PAGES[page] || !MODES.includes(auth)) throw new Error(`unmapped scenario ${name}`);
+  visit(page, PAGES[page].path, auth, data);
+}


### PR DESCRIPTION
## What

A k6 performance suite (`perf/k6/`) for the highest-traffic SSR pages — homepage job feed (jobview), the same feed under a heavy filter, the companies catalogue, and a company card — each exercised **anonymous and authenticated**.

Because one origin fronts both SSR and `/api`, k6 logs in once and reuses the `hire_token` cookie exactly like the browser. The suite records `page_body_bytes{auth}` so the heavier authed payload is measurable, and it streams the company card's job list end to end.

## Env-swappable target
No code change to point elsewhere — only env:
- local default `http://localhost:8090`
- any remote (e.g. prod) requires an explicit `ALLOW_NONLOCAL=1` safety latch; off-local auto-caps VUs/RPS, sets a bot UA, and refuses `load` without `FORCE_LOAD=1`.

## CI (this workflow)
- **pr-smoke** — spins up the full stack on an empty DB and asserts the pages still render (200 + HTML) within a **loose** latency ceiling. Always runs on PRs and always reports (heavy steps gated on a git-diff of the request path), so it's safe to require as a merge check. Gates correctness of the SSR→API→Postgres→Meili path, not data-scale perf.
- **prod-watchdog** — scheduled run against prod with headroom thresholds; opens an issue on regression. This is where real degradation is caught.

## Follow-ups
- Make `backend`, `web`, `pr-smoke` required status checks on `main` (done separately once check names are confirmed from this run).
- Optionally add a `PROD_AUTH_COOKIE` secret to cover the authed path in the watchdog.
- Tune `FILTER_QUERY` / `SLO_*` to real data + product SLOs.

Verified locally against a production build and against prod (anon): all pages 200, per-page p95 tagged, guards abort correctly, think-time fix prevents request-storm.