### PR TITLE
feat(credits): lower board-contribution reward from 5 to 1 credit

### DIFF
--- a/internal/config/credits.go
+++ b/internal/config/credits.go
@@ -19,7 +19,7 @@ func LoadCredits() Credits {
 		MonthlyGrant:       envInt("CREDITS_MONTHLY_GRANT", 20),
 		CostMatch:          envInt("CREDITS_COST_MATCH", 1),
 		CostTailor:         envInt("CREDITS_COST_TAILOR", 3),
-		ContributionReward: envInt("CREDITS_CONTRIBUTION_REWARD", 5),
+		ContributionReward: envInt("CREDITS_CONTRIBUTION_REWARD", 1),
 	}
 	if c.MonthlyGrant < 0 {
 		c.MonthlyGrant = 0

--- a/internal/config/credits_test.go
+++ b/internal/config/credits_test.go
@@ -6,6 +6,7 @@ func TestLoadCredits_defaults(t *testing.T) {
 	t.Setenv("CREDITS_MONTHLY_GRANT", "")
 	t.Setenv("CREDITS_COST_MATCH", "")
 	t.Setenv("CREDITS_COST_TAILOR", "")
+	t.Setenv("CREDITS_CONTRIBUTION_REWARD", "")
 
 	got := LoadCredits()
 	if got.MonthlyGrant != 20 {
@@ -17,8 +18,8 @@ func TestLoadCredits_defaults(t *testing.T) {
 	if got.CostTailor != 3 {
 		t.Errorf("CostTailor default = %d, want 3", got.CostTailor)
 	}
-	if got.ContributionReward != 5 {
-		t.Errorf("ContributionReward default = %d, want 5", got.ContributionReward)
+	if got.ContributionReward != 1 {
+		t.Errorf("ContributionReward default = %d, want 1", got.ContributionReward)
 	}
 }
 

--- a/internal/handler/telegram.go
+++ b/internal/handler/telegram.go
@@ -202,6 +202,6 @@ func (a *API) processTelegramContribution(chatID int64, rawURL string) {
 		a.sendTelegram(ctx, chatID, "⚠️ Something went wrong. Please try again.")
 	default:
 		a.rewardContribution(ctx, userID, rec.ID)
-		a.sendTelegram(ctx, chatID, "🎉 <b>"+rec.Board+"</b> ("+rec.Source+") is a new board — we'll start crawling it. +5 AI credits!")
+		a.sendTelegram(ctx, chatID, "🎉 <b>"+rec.Board+"</b> ("+rec.Source+") is a new board — we'll start crawling it. +1 AI credit!")
 	}
 }

--- a/web/src/lib/components/ContributeLandingView.svelte
+++ b/web/src/lib/components/ContributeLandingView.svelte
@@ -39,7 +39,7 @@
     {
       n: '03',
       title: 'New board? You’re rewarded',
-      body: 'If it’s a company we don’t track yet — the role isn’t in our catalogue — we add the board, crawl all of its openings, and credit you 5 AI credits.',
+      body: 'If it’s a company we don’t track yet — the role isn’t in our catalogue — we add the board, crawl all of its openings, and credit you 1 AI credit.',
     },
   ];
 </script>
@@ -106,7 +106,7 @@
         <p class="text-sm leading-relaxed text-muted-foreground">
           We simplified that first step down to a single link, and we reward the community for it.
           Spot a company we’re missing? Drop its link and you’ve just made the market a little
-          more complete for everyone — and earned AI credits for it.
+          more complete for everyone — and earned an AI credit for it.
         </p>
         <div class="flex flex-wrap gap-2">
           {#each supportedAts as ats (ats)}
@@ -156,7 +156,7 @@
     <h2 class="text-xl font-semibold tracking-tight">Found a company we’re missing?</h2>
     <p class="max-w-xl text-sm leading-relaxed text-muted-foreground">
       Paste its link — a vacancy or its careers page. If we don’t track it yet, you’ve found
-      new coverage, and the AI credits are yours.
+      new coverage, and the credit is yours.
     </p>
     <div class="flex flex-wrap gap-3">
       <Button href={resolve('/my/contributions')} variant="primary" size="lg">Contribute a board</Button>

--- a/web/src/lib/components/ContributeView.svelte
+++ b/web/src/lib/components/ContributeView.svelte
@@ -66,7 +66,7 @@
       <p class="text-sm text-muted-foreground">
         Found a company we don't cover yet? Paste any link from its ATS careers page — a vacancy
         or the board itself. If it's a board we don't crawl, we add it and you earn
-        <span class="font-medium text-foreground">5 AI credits</span>. We then pull in all of its
+        <span class="font-medium text-foreground">1 AI credit</span>. We then pull in all of its
         jobs. Track your balance on the
         <a href={resolve('/my/credits')} class="font-medium underline underline-offset-4">Credits page</a>.
       </p>
@@ -75,7 +75,7 @@
     {#if accepted}
       <div class="rounded-lg border border-border bg-secondary/40 p-4 text-sm" role="status">
         Thanks — <span class="font-medium">{accepted.board}</span> ({accepted.source}) is a new
-        board for us. We'll start crawling it. <span class="font-medium">+5 AI credits.</span>
+        board for us. We'll start crawling it. <span class="font-medium">+1 AI credit.</span>
       </div>
     {:else if tracked}
       <div class="rounded-lg border border-border bg-secondary/40 p-4 text-sm" role="status">


### PR DESCRIPTION
Lowers the reward for contributing a new board from **5 AI credits** to **1**.

## Changes
- `internal/config/credits.go` — `CREDITS_CONTRIBUTION_REWARD` default `5 → 1` (still env-overridable)
- `internal/config/credits_test.go` — default expectation updated (+ explicit env reset)
- `internal/handler/telegram.go` — TG new-board confirmation: `+5 AI credits` → `+1 AI credit`
- `web/src/lib/components/ContributeView.svelte` — form copy + acceptance: `5 AI credits` → `1 AI credit`
- `web/src/lib/components/ContributeLandingView.svelte` — landing step 03 + easy-path + CTA copy singularised

## Notes
- **Prod:** if `CREDITS_CONTRIBUTION_REWARD` is set explicitly in `freehire-ops`, the env must be updated there too — this only changes the code default.
- Historical `migrations/0034_*.sql` comment and the `unify-points-into-credits` openspec docs still say +5; left untouched as historical records.
- Build + `go test ./internal/config ./internal/handler` green.