### PR TITLE
feat(company): no-fill brand outline for Subscribe-to-updates button

### DIFF
--- a/web/src/lib/components/CompanyFollowButton.svelte
+++ b/web/src/lib/components/CompanyFollowButton.svelte
@@ -131,7 +131,10 @@
       <p class="text-xs text-muted-foreground">Opened Telegram — tap “Start”, then confirm.</p>
     {:else}
       <Button
-        variant={subscribed ? 'secondary' : 'primary'}
+        variant={subscribed ? 'secondary' : 'outline'}
+        class={subscribed
+          ? undefined
+          : 'border-brand-strong bg-transparent text-brand-strong hover:bg-brand-muted'}
         size="sm"
         onclick={toggle}
         disabled={busy}


### PR DESCRIPTION
Swap the primary green-fill CTA on the company header for an outline variant: transparent background with brand-strong bell, label and border, plus a soft brand-muted hover. Uses `brand-strong`/`brand-muted` tokens so it reads correctly in both light and dark themes. Mobile stays icon-only via the existing `hidden sm:inline` label.

Frontend-only (web image); no migrations, no reindex.