### PR TITLE
fix(web): show logo monogram when logo.dev 404s before hydration

### DIFF
--- a/web/src/lib/components/CompanyLogo.svelte
+++ b/web/src/lib/components/CompanyLogo.svelte
@@ -20,6 +20,15 @@
     failed = false;
   });
 
+  // SSR sends the raw <img>, so the browser fetches the logo before hydration wires
+  // `onerror`. When logo.dev 404s (its `fallback=404`), that error event fires before
+  // the handler exists and is lost — leaving an empty broken image until a reload. On
+  // mount, an already-complete image with no intrinsic width is that missed failure,
+  // so fall back to the monogram straight away.
+  function catchMissedError(node: HTMLImageElement) {
+    if (node.complete && node.naturalWidth === 0) failed = true;
+  }
+
   // Monogram fallback: the first letter over a colour hashed from the full name, so
   // a company keeps the same tile everywhere. Drawn as SVG so the glyph scales
   // crisply with whatever `size` the caller passes (16–64px).
@@ -38,6 +47,7 @@
     class="{size} shrink-0 rounded object-contain"
     loading="lazy"
     onerror={() => (failed = true)}
+    {@attach catchMissedError}
   />
 {:else if initial}
   <svg class="{size} shrink-0" viewBox="0 0 32 32" aria-hidden="true">


### PR DESCRIPTION
## Problem

On a fresh SSR load, an unknown company's logo tile rendered **empty**, and only showed the monogram fallback after a page refresh.

## Root cause

SSR ships the raw `<img src=…logo.dev/name/…>`, so the browser starts fetching the logo *before* hydration wires the `onerror` handler. logo.dev's `fallback=404` makes an unknown company (e.g. MercadoLibre — not in its `/name/` index) return **404**. That `error` event fires before the listener exists and is lost, leaving a broken empty `<img>` until the next reload (when the 404 is cached and the handler catches it in time).

## Fix

Add an `{@attach}` that, on mount, treats an already-complete image with no intrinsic width (`complete && naturalWidth === 0`) as the missed failure and flips to the monogram immediately. `onerror` still handles post-hydration failures (e.g. SPA navigation to another company).

- Does **not** touch `fallback=404` — the "404 → own coloured monogram" contract is preserved.
- `npm run check`: 0 errors.

Single-file change in `web/src/lib/components/CompanyLogo.svelte`.