### PR TITLE
fix(web): un-hide in Hidden footer + truncate long role pills

### DIFF
--- a/web/src/lib/components/Hidden.svelte
+++ b/web/src/lib/components/Hidden.svelte
@@ -45,18 +45,26 @@
 {:else}
   <ul class="flex flex-col gap-3">
     {#each page.items as item (item.job.public_slug)}
-      <li class="relative">
-        <JobRow job={item.job} dimViewed={false} />
-        <button
-          type="button"
-          onclick={() => unhide(item.job.public_slug)}
-          disabled={unhiding === item.job.public_slug}
-          title="Un-hide — show this job in the feed again"
-          class="absolute bottom-2.5 right-2.5 inline-flex items-center gap-1.5 rounded-lg bg-accent px-2.5 py-1.5 text-xs font-medium text-foreground shadow-sm ring-1 ring-border transition hover:text-brand disabled:pointer-events-none disabled:opacity-50"
-        >
-          <Eye class="size-4" aria-hidden="true" />
-          Un-hide
-        </button>
+      <li>
+        <!-- Un-hide lives in the card's footer row (a divided sibling of the link),
+             not an overlay, so it never sits on top of the title or blurb on a narrow
+             screen. Mirrors the saved list's reminder chip. -->
+        <JobRow job={item.job} dimViewed={false}>
+          {#snippet footer()}
+            <div class="flex justify-end">
+              <button
+                type="button"
+                onclick={() => unhide(item.job.public_slug)}
+                disabled={unhiding === item.job.public_slug}
+                title="Un-hide — show this job in the feed again"
+                class="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs font-medium text-muted-foreground transition hover:text-brand disabled:pointer-events-none disabled:opacity-50"
+              >
+                <Eye class="size-4" aria-hidden="true" />
+                Un-hide
+              </button>
+            </div>
+          {/snippet}
+        </JobRow>
       </li>
     {/each}
   </ul>

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -103,9 +103,12 @@
         type="button"
         onclick={() => toggle(opt.value)}
         title={pillTitle(included, excluded, excludable)}
-        class={pillClass(included || excluded, excluded, 'px-2.5 py-1 text-sm')}
+        class={pillClass(included || excluded, excluded, 'inline-flex max-w-full items-center px-2.5 py-1 text-sm')}
       >
-        {opt.label}{#if opt.count !== undefined}<span class="ml-1 opacity-60 tabular-nums">{opt.count.toLocaleString()}</span>{/if}
+        <!-- A very long value (roles like "Senior Business Development Representative")
+             truncates to one line with an ellipsis instead of wrapping the pill onto
+             two rows; the full label surfaces on hover via title. -->
+        <span class="min-w-0 truncate" title={opt.label}>{opt.label}</span>{#if opt.count !== undefined}<span class="ml-1 shrink-0 opacity-60 tabular-nums">{opt.count.toLocaleString()}</span>{/if}
       </button>
     {/each}
     {#if shown.length === 0}


### PR DESCRIPTION
Two mobile cosmetic fixes on the account surfaces.

## Activity → Hidden: `Un-hide` no longer overlaps the text
The `Un-hide` button was an `absolute bottom-2.5 right-2.5` overlay on the card, so on a narrow screen it landed on top of the blurb (see the reported screenshot). Moved it into `JobRow`'s `footer` snippet — a divided row that's a sibling of the card link, the same seam the saved list uses for its reminder chip. No overlap, and the click still never navigates.

## Filter modal: long role pills truncate instead of wrapping
Open-vocabulary facet values rendered through `SearchSelect` (roles like *Senior Business Development Representative*) wrapped their pill onto two lines. The label now truncates to one line with an ellipsis, the match count stays visible, and the full name shows on hover via `title`.

Note on the "endless list": the role facet already caps at 8 (`+N more — type to search`) on `main`; the production screenshot showing ~15 roles is just running frontend older than that cap. No change needed there — it resolves on deploy.

## Verification
Both changes driven in a headless-Chrome probe at mobile width (360px):
- Hidden card: `Un-hide` sits in the footer, blurb clamps cleanly above it.
- Role pills: `Senior Business Development Repre… 3` — one line, ellipsis, count preserved.

`svelte-check`: 0 errors.