### PR TITLE
fix(jobs): widen mobile gutter on job detail page

### DIFF
--- a/web/src/routes/jobs/[slug]/+page.svelte
+++ b/web/src/routes/jobs/[slug]/+page.svelte
@@ -39,7 +39,10 @@
   {@html jsonLd}
 </svelte:head>
 
-<div class="mx-auto w-full max-w-6xl px-4 py-6">
+<!-- Slightly wider mobile gutter than the site-wide px-4: the description is dense
+     raw text with no card wrapper, so 16px reads tight against the edge; sm+ falls
+     back to the shared px-4 rhythm. -->
+<div class="mx-auto w-full max-w-6xl px-5 py-6 sm:px-4">
   <JobView job={data.job} />
 
   <JobRelated


### PR DESCRIPTION
## What

Bumps the horizontal gutter on `/jobs/[slug]` from the site-wide `px-4` (16px) to `px-5` (20px) **on mobile only** (`sm:px-4` restores the shared rhythm at ≥640px).

## Why

The job description is dense, server-sanitized raw HTML rendered with no card wrapper, so at 16px the text reads tight against the screen edge on phones (reported on a real posting). Card-based pages don't have this issue because the card's own padding adds inset, so the fix is scoped to this page rather than changed site-wide.

Container change only — the whole `<article>` (title, company, sidebar, description) shifts together, so left-edge alignment is preserved. Desktop is untouched.