### PR TITLE
feat(referrals): moderation console polish — mobile, deep-link, withdraw, company name/logo

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -322,6 +322,11 @@ type Querier interface {
 	// by the company-info backfill are preserved: they intentionally have no job, so
 	// the NOT is_reference guard keeps the backfill directory from being swept away.
 	DeleteOrphanCompanies(ctx context.Context) (int64, error)
+	// Withdraw ("stop being a referrer"): the owner deletes their own offer. The user_id
+	// guard scopes it to the caller — a non-owner or absent id deletes zero rows, which the
+	// repository maps to ErrOfferNotFound. Hard delete frees the UNIQUE (user_id,
+	// company_slug) so the member can offer again later (fresh proof, fresh moderation).
+	DeleteReferralOffer(ctx context.Context, arg DeleteReferralOfferParams) (int64, error)
 	// Delete a saved search, scoped to its owner so a user can only delete their own.
 	// Returns the affected row count: 0 means it does not exist or is not the caller's
 	// (the handler maps that to 404).
@@ -751,8 +756,8 @@ type Querier interface {
 	// holds closed jobs, so unlike ListJobsUpdatedAfter there is nothing to delete. Served
 	// by jobs_open_enrich_freshness_idx (COALESCE(posted_at, created_at) DESC WHERE open).
 	ListOpenJobsPostedAfter(ctx context.Context, arg ListOpenJobsPostedAfterParams) ([]Job, error)
-	// The moderator queue: offers awaiting a decision, oldest first.
-	ListPendingReferralOffers(ctx context.Context) ([]ReferralOffer, error)
+	// The moderator queue: offers awaiting a decision, oldest first, with display name.
+	ListPendingReferralOffers(ctx context.Context) ([]ListPendingReferralOffersRow, error)
 	// The moderator review queue: every pending report, newest first, with the reporter's email
 	// and the reported job's slug and title so the moderator can judge it and link to it.
 	ListPendingReports(ctx context.Context) ([]ListPendingReportsRow, error)
@@ -760,7 +765,9 @@ type Querier interface {
 	// email so the moderator can judge provenance.
 	ListPendingSubmissions(ctx context.Context) ([]ListPendingSubmissionsRow, error)
 	// The "my offers" list: one member's offers with moderation status, newest first.
-	ListReferralOffersByUser(ctx context.Context, userID int64) ([]ReferralOffer, error)
+	// Joins the catalogue for the company's display name (LEFT so an offer survives a
+	// company the catalogue no longer knows — the UI falls back to the slug).
+	ListReferralOffersByUser(ctx context.Context, userID int64) ([]ListReferralOffersByUserRow, error)
 	// The seeker's "my requests" list: their requests with current status, newest first.
 	ListReferralRequestsBySeeker(ctx context.Context, seekerUserID int64) ([]ReferralRequest, error)
 	// The open postings sharing a role cluster (company_slug + role_fingerprint) with the

--- a/internal/db/queries/referrals.sql
+++ b/internal/db/queries/referrals.sql
@@ -8,15 +8,28 @@ RETURNING *;
 
 -- name: ListReferralOffersByUser :many
 -- The "my offers" list: one member's offers with moderation status, newest first.
-SELECT * FROM referral_offers
-WHERE user_id = $1
-ORDER BY created_at DESC;
+-- Joins the catalogue for the company's display name (LEFT so an offer survives a
+-- company the catalogue no longer knows — the UI falls back to the slug).
+SELECT o.*, c.name AS company_name
+FROM referral_offers o
+LEFT JOIN companies c ON c.slug = o.company_slug
+WHERE o.user_id = $1
+ORDER BY o.created_at DESC;
 
 -- name: ListPendingReferralOffers :many
--- The moderator queue: offers awaiting a decision, oldest first.
-SELECT * FROM referral_offers
-WHERE status = 'pending'
-ORDER BY created_at;
+-- The moderator queue: offers awaiting a decision, oldest first, with display name.
+SELECT o.*, c.name AS company_name
+FROM referral_offers o
+LEFT JOIN companies c ON c.slug = o.company_slug
+WHERE o.status = 'pending'
+ORDER BY o.created_at;
+
+-- name: DeleteReferralOffer :execrows
+-- Withdraw ("stop being a referrer"): the owner deletes their own offer. The user_id
+-- guard scopes it to the caller — a non-owner or absent id deletes zero rows, which the
+-- repository maps to ErrOfferNotFound. Hard delete frees the UNIQUE (user_id,
+-- company_slug) so the member can offer again later (fresh proof, fresh moderation).
+DELETE FROM referral_offers WHERE id = $1 AND user_id = $2;
 
 -- name: DecideReferralOffer :one
 -- Approve or reject a pending offer, recording the deciding moderator and time. The

--- a/internal/db/referrals.sql.go
+++ b/internal/db/referrals.sql.go
@@ -207,6 +207,27 @@ func (q *Queries) DecideReferralOffer(ctx context.Context, arg DecideReferralOff
 	return i, err
 }
 
+const deleteReferralOffer = `-- name: DeleteReferralOffer :execrows
+DELETE FROM referral_offers WHERE id = $1 AND user_id = $2
+`
+
+type DeleteReferralOfferParams struct {
+	ID     int64 `json:"id"`
+	UserID int64 `json:"user_id"`
+}
+
+// Withdraw ("stop being a referrer"): the owner deletes their own offer. The user_id
+// guard scopes it to the caller — a non-owner or absent id deletes zero rows, which the
+// repository maps to ErrOfferNotFound. Hard delete frees the UNIQUE (user_id,
+// company_slug) so the member can offer again later (fresh proof, fresh moderation).
+func (q *Queries) DeleteReferralOffer(ctx context.Context, arg DeleteReferralOfferParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteReferralOffer, arg.ID, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getReferralOffer = `-- name: GetReferralOffer :one
 SELECT id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at FROM referral_offers WHERE id = $1
 `
@@ -336,21 +357,35 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 }
 
 const listPendingReferralOffers = `-- name: ListPendingReferralOffers :many
-SELECT id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at FROM referral_offers
-WHERE status = 'pending'
-ORDER BY created_at
+SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, c.name AS company_name
+FROM referral_offers o
+LEFT JOIN companies c ON c.slug = o.company_slug
+WHERE o.status = 'pending'
+ORDER BY o.created_at
 `
 
-// The moderator queue: offers awaiting a decision, oldest first.
-func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ReferralOffer, error) {
+type ListPendingReferralOffersRow struct {
+	ID             int64              `json:"id"`
+	UserID         int64              `json:"user_id"`
+	CompanySlug    string             `json:"company_slug"`
+	ProofObjectKey string             `json:"proof_object_key"`
+	Status         string             `json:"status"`
+	DecidedBy      pgtype.Int8        `json:"decided_by"`
+	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	CompanyName    pgtype.Text        `json:"company_name"`
+}
+
+// The moderator queue: offers awaiting a decision, oldest first, with display name.
+func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ListPendingReferralOffersRow, error) {
 	rows, err := q.db.Query(ctx, listPendingReferralOffers)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ReferralOffer{}
+	items := []ListPendingReferralOffersRow{}
 	for rows.Next() {
-		var i ReferralOffer
+		var i ListPendingReferralOffersRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.UserID,
@@ -360,6 +395,7 @@ func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ReferralOffe
 			&i.DecidedBy,
 			&i.DecidedAt,
 			&i.CreatedAt,
+			&i.CompanyName,
 		); err != nil {
 			return nil, err
 		}
@@ -372,21 +408,37 @@ func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ReferralOffe
 }
 
 const listReferralOffersByUser = `-- name: ListReferralOffersByUser :many
-SELECT id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at FROM referral_offers
-WHERE user_id = $1
-ORDER BY created_at DESC
+SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, c.name AS company_name
+FROM referral_offers o
+LEFT JOIN companies c ON c.slug = o.company_slug
+WHERE o.user_id = $1
+ORDER BY o.created_at DESC
 `
 
+type ListReferralOffersByUserRow struct {
+	ID             int64              `json:"id"`
+	UserID         int64              `json:"user_id"`
+	CompanySlug    string             `json:"company_slug"`
+	ProofObjectKey string             `json:"proof_object_key"`
+	Status         string             `json:"status"`
+	DecidedBy      pgtype.Int8        `json:"decided_by"`
+	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
+	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	CompanyName    pgtype.Text        `json:"company_name"`
+}
+
 // The "my offers" list: one member's offers with moderation status, newest first.
-func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([]ReferralOffer, error) {
+// Joins the catalogue for the company's display name (LEFT so an offer survives a
+// company the catalogue no longer knows — the UI falls back to the slug).
+func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([]ListReferralOffersByUserRow, error) {
 	rows, err := q.db.Query(ctx, listReferralOffersByUser, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ReferralOffer{}
+	items := []ListReferralOffersByUserRow{}
 	for rows.Next() {
-		var i ReferralOffer
+		var i ListReferralOffersByUserRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.UserID,
@@ -396,6 +448,7 @@ func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([
 			&i.DecidedBy,
 			&i.DecidedAt,
 			&i.CreatedAt,
+			&i.CompanyName,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -468,6 +468,7 @@ func Register(app *fiber.App, cfg Config) {
 	// moderator-gated, mirroring the submissions queue above.
 	api.Post("/me/referrals/offers", keyAuth, a.SubmitReferralOffer)
 	api.Get("/me/referrals/offers", keyAuth, a.ListMyReferralOffers)
+	api.Delete("/me/referrals/offers/:id", keyAuth, a.WithdrawReferralOffer)
 	api.Post("/me/referrals/requests", keyAuth, a.CreateReferralRequest)
 	api.Get("/me/referrals/requests", keyAuth, a.ListMyReferralRequests)
 	api.Get("/me/referrals/incoming", keyAuth, a.ListIncomingReferralRequests)

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -336,7 +336,7 @@ func Register(app *fiber.App, cfg Config) {
 		referralTelegram = a.telegramBot
 	}
 	referralPinger := referral.NewChannelPinger(referralEmail, cfg.NotifyEmailFrom, referralTelegram)
-	referralCabinetURL := strings.TrimRight(cfg.FrontendOrigin, "/") + "/my/referrals/incoming"
+	referralCabinetURL := strings.TrimRight(cfg.FrontendOrigin, "/") + "/my/referrals?tab=incoming"
 	a.referral = referral.New(referral.NewQueriesRepository(queries), referralPinger,
 		referral.Config{CabinetURL: referralCabinetURL})
 

--- a/internal/handler/referrals.go
+++ b/internal/handler/referrals.go
@@ -19,6 +19,7 @@ import (
 type referralOfferResponse struct {
 	ID          int64      `json:"id"`
 	CompanySlug string     `json:"company_slug"`
+	CompanyName string     `json:"company_name"`
 	Status      string     `json:"status"`
 	DecidedAt   *time.Time `json:"decided_at"`
 	CreatedAt   *time.Time `json:"created_at"`
@@ -26,7 +27,7 @@ type referralOfferResponse struct {
 
 func toReferralOfferResponse(o referral.Offer) referralOfferResponse {
 	return referralOfferResponse{
-		ID: o.ID, CompanySlug: o.CompanySlug, Status: o.Status,
+		ID: o.ID, CompanySlug: o.CompanySlug, CompanyName: o.CompanyName, Status: o.Status,
 		DecidedAt: o.DecidedAt, CreatedAt: o.CreatedAt,
 	}
 }
@@ -97,6 +98,8 @@ func referralError(err error) error {
 		return fiber.NewError(fiber.StatusConflict, "you already offered to refer for this company")
 	case errors.Is(err, referral.ErrOfferNotPending):
 		return fiber.NewError(fiber.StatusConflict, "this offer is not pending")
+	case errors.Is(err, referral.ErrOfferNotFound):
+		return fiber.NewError(fiber.StatusNotFound, "offer not found")
 	case errors.Is(err, referral.ErrAlreadyRequested):
 		return fiber.NewError(fiber.StatusConflict, "you already have an active request for this company")
 	case errors.Is(err, referral.ErrRequestNotOpen):
@@ -209,6 +212,23 @@ func (a *API) ListMyReferralOffers(c *fiber.Ctx) error {
 		out[i] = toReferralOfferResponse(o)
 	}
 	return c.JSON(fiber.Map{"data": out})
+}
+
+// WithdrawReferralOffer lets a member stop being a referrer by deleting their own offer.
+// RequireAuth; owner-scoped in the service. 404 when the offer is absent or not theirs.
+func (a *API) WithdrawReferralOffer(c *fiber.Ctx) error {
+	userID, err := requireUserID(c)
+	if err != nil {
+		return err
+	}
+	id, err := c.ParamsInt("id")
+	if err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid offer id")
+	}
+	if err := a.referral.WithdrawOffer(c.Context(), int64(id), userID); err != nil {
+		return referralError(err)
+	}
+	return c.SendStatus(fiber.StatusNoContent)
 }
 
 // ListIncomingReferralRequests returns the open requests for every company the caller is an

--- a/internal/referral/referral.go
+++ b/internal/referral/referral.go
@@ -54,6 +54,10 @@ var (
 	// ErrOfferNotPending is a decision on an offer that is not pending — already decided,
 	// or absent; the repository maps the no-row update to this (409).
 	ErrOfferNotPending = errors.New("referral: offer is not pending")
+
+	// ErrOfferNotFound is returned when withdrawing an offer that does not exist or is
+	// not owned by the caller — the two are indistinguishable on purpose (no IDOR probe).
+	ErrOfferNotFound = errors.New("referral: offer not found")
 	// ErrNoContact is a request with neither a Telegram handle nor an email (422).
 	ErrNoContact = errors.New("referral: at least one contact required")
 	// ErrInvalidCVChoice is a CV choice that violates the kind/id invariant: an original
@@ -84,6 +88,10 @@ type Offer struct {
 	ID          int64
 	UserID      int64
 	CompanySlug string
+	// CompanyName is the catalogue display name for CompanySlug, empty when the offer
+	// is read on a path that doesn't join the catalogue (create/decide) or the company
+	// is unknown. The list paths populate it; callers fall back to the slug.
+	CompanyName string
 	ProofKey    string
 	Status      string
 	DecidedBy   *int64
@@ -146,6 +154,7 @@ type Repository interface {
 	CreateOffer(ctx context.Context, in OfferInput) (Offer, error)
 	DecideOffer(ctx context.Context, offerID, moderatorID int64, status string) (Offer, error)
 	GetOffer(ctx context.Context, offerID int64) (Offer, bool, error)
+	DeleteOffer(ctx context.Context, offerID, userID int64) error
 	ListOffersByUser(ctx context.Context, userID int64) ([]Offer, error)
 	ListPendingOffers(ctx context.Context) ([]Offer, error)
 	CompanyHasApprovedReferrer(ctx context.Context, companySlug string) (bool, error)
@@ -225,6 +234,13 @@ func (s *Service) DecideOffer(ctx context.Context, offerID, moderatorID int64, a
 // the offer does not exist.
 func (s *Service) GetOffer(ctx context.Context, offerID int64) (Offer, bool, error) {
 	return s.repo.GetOffer(ctx, offerID)
+}
+
+// WithdrawOffer lets a member stop being a referrer: it hard-deletes their own offer,
+// owner-scoped by userID. A missing offer or one owned by someone else returns
+// ErrOfferNotFound. Deleting frees the (user, company) slot so they can offer again later.
+func (s *Service) WithdrawOffer(ctx context.Context, offerID, userID int64) error {
+	return s.repo.DeleteOffer(ctx, offerID, userID)
 }
 
 // ListMyOffers returns a member's offers, newest first.

--- a/internal/referral/referral_test.go
+++ b/internal/referral/referral_test.go
@@ -22,16 +22,22 @@ type fakeRepo struct {
 	getRequestOK bool
 	createErr    error
 	resolveErr   error
+	deleteErr    error
 
 	createdReq *RequestInput
 	createdOff *OfferInput
 	decided    *decidedOffer
+	deleted    *deletedOffer
 	resolved   *resolvedRequest
 }
 
 type decidedOffer struct {
 	id, moderator int64
 	status        string
+}
+
+type deletedOffer struct {
+	id, user int64
 }
 
 type resolvedRequest struct {
@@ -74,6 +80,10 @@ func (f *fakeRepo) UserHasResume(context.Context, int64) (bool, error) {
 }
 func (f *fakeRepo) GetOffer(context.Context, int64) (Offer, bool, error) {
 	return Offer{}, false, nil
+}
+func (f *fakeRepo) DeleteOffer(_ context.Context, offerID, userID int64) error {
+	f.deleted = &deletedOffer{offerID, userID}
+	return f.deleteErr
 }
 
 func (f *fakeRepo) CreateRequest(_ context.Context, in RequestInput) (Request, error) {
@@ -146,6 +156,25 @@ func TestDecideOfferMapsApproveReject(t *testing.T) {
 		if repo.decided == nil || repo.decided.status != tc.want || repo.decided.moderator != 9 {
 			t.Errorf("decided = %+v, want status %q by 9", repo.decided, tc.want)
 		}
+	}
+}
+
+func TestWithdrawOfferIsOwnerScoped(t *testing.T) {
+	repo := &fakeRepo{}
+	s := newService(repo, &fakePinger{})
+	if err := s.WithdrawOffer(context.Background(), 5, 42); err != nil {
+		t.Fatalf("withdraw: %v", err)
+	}
+	if repo.deleted == nil || repo.deleted.id != 5 || repo.deleted.user != 42 {
+		t.Errorf("deleted = %+v, want offer 5 by user 42", repo.deleted)
+	}
+}
+
+func TestWithdrawOfferPropagatesNotFound(t *testing.T) {
+	repo := &fakeRepo{deleteErr: ErrOfferNotFound}
+	s := newService(repo, &fakePinger{})
+	if err := s.WithdrawOffer(context.Background(), 5, 42); !errors.Is(err, ErrOfferNotFound) {
+		t.Errorf("err = %v, want ErrOfferNotFound", err)
 	}
 }
 

--- a/internal/referral/repository.go
+++ b/internal/referral/repository.go
@@ -75,22 +75,51 @@ func (r *QueriesRepository) GetOffer(ctx context.Context, offerID int64) (Offer,
 	return offerFromRow(row), true, nil
 }
 
-// ListOffersByUser returns a member's offers, newest first.
+// ListOffersByUser returns a member's offers, newest first, each with its company name.
 func (r *QueriesRepository) ListOffersByUser(ctx context.Context, userID int64) ([]Offer, error) {
 	rows, err := r.q.ListReferralOffersByUser(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	return mapSlice(rows, offerFromRow), nil
+	return mapSlice(rows, func(row db.ListReferralOffersByUserRow) Offer {
+		o := offerFromRow(db.ReferralOffer{
+			ID: row.ID, UserID: row.UserID, CompanySlug: row.CompanySlug,
+			ProofObjectKey: row.ProofObjectKey, Status: row.Status,
+			DecidedBy: row.DecidedBy, DecidedAt: row.DecidedAt, CreatedAt: row.CreatedAt,
+		})
+		o.CompanyName = row.CompanyName.String
+		return o
+	}), nil
 }
 
-// ListPendingOffers returns the moderator queue, oldest first.
+// ListPendingOffers returns the moderator queue, oldest first, each with its company name.
 func (r *QueriesRepository) ListPendingOffers(ctx context.Context) ([]Offer, error) {
 	rows, err := r.q.ListPendingReferralOffers(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return mapSlice(rows, offerFromRow), nil
+	return mapSlice(rows, func(row db.ListPendingReferralOffersRow) Offer {
+		o := offerFromRow(db.ReferralOffer{
+			ID: row.ID, UserID: row.UserID, CompanySlug: row.CompanySlug,
+			ProofObjectKey: row.ProofObjectKey, Status: row.Status,
+			DecidedBy: row.DecidedBy, DecidedAt: row.DecidedAt, CreatedAt: row.CreatedAt,
+		})
+		o.CompanyName = row.CompanyName.String
+		return o
+	}), nil
+}
+
+// DeleteOffer hard-deletes a member's own offer, owner-scoped by userID. A zero-row
+// delete (absent id or another owner) maps to ErrOfferNotFound.
+func (r *QueriesRepository) DeleteOffer(ctx context.Context, offerID, userID int64) error {
+	n, err := r.q.DeleteReferralOffer(ctx, db.DeleteReferralOfferParams{ID: offerID, UserID: userID})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return ErrOfferNotFound
+	}
+	return nil
 }
 
 // CompanyHasApprovedReferrer reports whether the company is referral-eligible.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -982,6 +982,11 @@ export function createApi(
     return requestData<ReferralOffer[]>('/api/v1/me/referrals/offers');
   }
 
+  /** Stop being a referrer: delete one of the caller's own offers. */
+  async function withdrawReferralOffer(id: number): Promise<void> {
+    await call(`/api/v1/me/referrals/offers/${id}`, { method: 'DELETE' });
+  }
+
   /** The referrer inbox: open requests for the companies the caller is approved for. */
   async function listIncomingReferrals(): Promise<IncomingReferralRequest[]> {
     return requestData<IncomingReferralRequest[]>('/api/v1/me/referrals/incoming');
@@ -1301,6 +1306,7 @@ export function createApi(
     listMyReferralRequests,
     submitReferralOffer,
     listMyReferralOffers,
+    withdrawReferralOffer,
     listIncomingReferrals,
     resolveReferral,
     referralCvUrl,

--- a/web/src/lib/components/ReferralReviewView.svelte
+++ b/web/src/lib/components/ReferralReviewView.svelte
@@ -33,35 +33,27 @@
 {:else if pending.value.length === 0}
   <States state="empty" message="No referral offers awaiting review." />
 {:else}
-  <table class="w-full text-sm">
-    <thead>
-      <tr class="text-xs uppercase tracking-wide text-muted-foreground">
-        <th class="pb-2 pr-4 text-left font-semibold">Company</th>
-        <th class="pb-2 pr-4 text-left font-semibold">Submitted</th>
-        <th class="pb-2 pr-4 text-left font-semibold">Proof</th>
-        <th class="pb-2 text-right font-semibold">Decision</th>
-      </tr>
-    </thead>
-    <tbody>
-      {#each pending.value as o (o.id)}
-        <tr class="border-t border-border">
-          <td class="py-3 pr-4 font-medium">{o.company_slug}</td>
-          <td class="py-3 pr-4 text-muted-foreground">{o.created_at ? timeAgo(o.created_at) : ''}</td>
-          <td class="py-3 pr-4">
-            <Button variant="outline" size="sm" href={api.referralProofUrl(o.id)} target="_blank" rel="noopener">
-              <FileText class="size-4" /> View proof
-            </Button>
-          </td>
-          <td class="py-3 text-right">
-            <div class="inline-flex gap-2">
-              <Button variant="primary" size="sm" disabled={busy === o.id} onclick={() => decide(o, true)}>Approve</Button>
-              <Button variant="outline" size="sm" disabled={busy === o.id} onclick={() => decide(o, false)}>Reject</Button>
-            </div>
-          </td>
-        </tr>
-      {/each}
-    </tbody>
-  </table>
+  <!-- Card rows (not a table) so the actions stack cleanly on mobile instead of
+       overflowing, matching the moderation-queue list in the same console. -->
+  <ul class="flex flex-col divide-y divide-border rounded-lg border border-border">
+    {#each pending.value as o (o.id)}
+      <li class="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex min-w-0 flex-col gap-0.5">
+          <span class="truncate text-sm font-medium">{o.company_slug}</span>
+          <span class="truncate text-xs text-muted-foreground">
+            Submitted {o.created_at ? timeAgo(o.created_at) : ''}
+          </span>
+        </div>
+        <div class="flex shrink-0 flex-wrap gap-2">
+          <Button variant="outline" size="sm" href={api.referralProofUrl(o.id)} target="_blank" rel="noopener">
+            <FileText class="size-4" /> View proof
+          </Button>
+          <Button variant="primary" size="sm" disabled={busy === o.id} onclick={() => decide(o, true)}>Approve</Button>
+          <Button variant="outline" size="sm" disabled={busy === o.id} onclick={() => decide(o, false)}>Reject</Button>
+        </div>
+      </li>
+    {/each}
+  </ul>
   <p class="mt-4 text-xs text-muted-foreground">
     Verify the proof shows the person works there — the only trust gate. No automated verification.
   </p>

--- a/web/src/lib/components/ReferralReviewView.svelte
+++ b/web/src/lib/components/ReferralReviewView.svelte
@@ -6,6 +6,7 @@
   import type { ReferralOffer } from '$lib/types';
   import { Button } from '$lib/ui';
   import { timeAgo } from '$lib/utils';
+  import CompanyLogo from './CompanyLogo.svelte';
   import States from './States.svelte';
 
   const pending = new AsyncData<ReferralOffer[]>([]);
@@ -38,11 +39,14 @@
   <ul class="flex flex-col divide-y divide-border rounded-lg border border-border">
     {#each pending.value as o (o.id)}
       <li class="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-        <div class="flex min-w-0 flex-col gap-0.5">
-          <span class="truncate text-sm font-medium">{o.company_slug}</span>
-          <span class="truncate text-xs text-muted-foreground">
-            Submitted {o.created_at ? timeAgo(o.created_at) : ''}
-          </span>
+        <div class="flex min-w-0 items-center gap-2">
+          <CompanyLogo name={o.company_name || o.company_slug} size="size-6" />
+          <div class="flex min-w-0 flex-col gap-0.5">
+            <span class="truncate text-sm font-medium">{o.company_name || o.company_slug}</span>
+            <span class="truncate text-xs text-muted-foreground">
+              Submitted {o.created_at ? timeAgo(o.created_at) : ''}
+            </span>
+          </div>
         </div>
         <div class="flex shrink-0 flex-wrap gap-2">
           <Button variant="outline" size="sm" href={api.referralProofUrl(o.id)} target="_blank" rel="noopener">

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -5,7 +5,6 @@
   import { FileText } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { AsyncData } from '$lib/asyncData.svelte';
-  import { currentUser } from '$lib/auth.svelte';
   import type {
     IncomingReferralRequest,
     ReferralOffer,
@@ -14,6 +13,7 @@
   } from '$lib/types';
   import { Button } from '$lib/ui';
   import { timeAgo } from '$lib/utils';
+  import CompanyLogo from './CompanyLogo.svelte';
   import CompanyPicker from './CompanyPicker.svelte';
   import States from './States.svelte';
 
@@ -37,8 +37,6 @@
   const requests = new AsyncData<SeekerReferralRequest[]>([]);
   const offers = new AsyncData<ReferralOffer[]>([]);
   const incoming = new AsyncData<IncomingReferralRequest[]>([]);
-
-  const isModerator = $derived(['moderator', 'admin'].includes(currentUser()?.role ?? ''));
 
   onMount(() => {
     void requests.run(() => api.listMyReferralRequests());
@@ -98,6 +96,24 @@
     }
   }
 
+  // Stop being a referrer: delete the offer after a confirm, then drop it optimistically
+  // (reloading on failure to resurface it). `withdrawing` disables the acting row's button.
+  let withdrawing = $state<number | null>(null);
+  async function withdrawOffer(o: ReferralOffer) {
+    if (withdrawing !== null) return;
+    const name = o.company_name || o.company_slug;
+    if (!confirm(`Stop being a referrer for ${name}? You can offer again later.`)) return;
+    withdrawing = o.id;
+    try {
+      await api.withdrawReferralOffer(o.id);
+      offers.value = offers.value.filter((x) => x.id !== o.id);
+    } catch {
+      await offers.run(() => api.listMyReferralOffers());
+    } finally {
+      withdrawing = null;
+    }
+  }
+
   // ── Incoming: mark contacted / declined ─────────────────────────────────
   async function resolve(req: IncomingReferralRequest, status: 'contacted' | 'declined') {
     try {
@@ -133,10 +149,6 @@
       </button>
     {/each}
   </div>
-  {#if isModerator}
-    <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- query-bearing link to a static route; resolve() can't carry the ?tab param -->
-    <a href="/moderation?tab=referrals" class="text-sm font-medium text-brand-strong hover:underline">Review offers →</a>
-  {/if}
 </div>
 
 <!-- ── My requests ── -->
@@ -218,11 +230,21 @@
   {:else}
     <ul class="mt-3">
       {#each offers.value as o (o.id)}
-        <li class="flex items-center justify-between border-t border-border py-3 text-sm">
-          <span class="font-medium">{o.company_slug}</span>
+        <li class="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-border py-3 text-sm">
+          <CompanyLogo name={o.company_name || o.company_slug} size="size-6" />
+          <span class="min-w-0 truncate font-medium">{o.company_name || o.company_slug}</span>
           <span class="inline-flex rounded-full px-2.5 py-0.5 text-xs font-semibold {offerPill[o.status] ?? 'bg-muted text-muted-foreground'}">
             {o.status}
           </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            class="ml-auto text-muted-foreground hover:text-destructive"
+            disabled={withdrawing === o.id}
+            onclick={() => withdrawOffer(o)}
+          >
+            {withdrawing === o.id ? 'Removing…' : 'Stop referring'}
+          </Button>
         </li>
       {/each}
     </ul>

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { page } from '$app/state';
+  import { replaceState } from '$app/navigation';
   import { FileText } from '@lucide/svelte';
   import { api, ApiError } from '$lib/api';
   import { AsyncData } from '$lib/asyncData.svelte';
@@ -16,7 +18,21 @@
   import States from './States.svelte';
 
   type Tab = 'requests' | 'offers' | 'incoming';
-  let tab = $state<Tab>('requests');
+  const tabs: Tab[] = ['requests', 'offers', 'incoming'];
+
+  // Open on the tab named in `?tab=` so deep-links land right — notably the
+  // "new referral request" ping, which links approved referrers to `?tab=incoming`.
+  function readTab(): Tab {
+    const t = page.url.searchParams.get('tab');
+    return tabs.includes(t as Tab) ? (t as Tab) : 'requests';
+  }
+  let tab = $state<Tab>(readTab());
+  function selectTab(next: Tab) {
+    if (next === tab) return;
+    tab = next;
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- in-place query write to the current pathname; there is no route to resolve
+    replaceState(`${page.url.pathname}?tab=${next}`, {});
+  }
 
   const requests = new AsyncData<SeekerReferralRequest[]>([]);
   const offers = new AsyncData<ReferralOffer[]>([]);
@@ -102,7 +118,7 @@
         type="button"
         role="tab"
         aria-selected={tab === id}
-        onclick={() => (tab = id as Tab)}
+        onclick={() => selectTab(id as Tab)}
         class={[
           '-mb-px border-b-2 px-3 py-2.5 text-sm font-semibold',
           tab === id ? 'border-brand text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground',

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -190,6 +190,7 @@ export type ReferralCvKind = 'original' | 'built';
 export interface ReferralOffer {
   id: number;
   company_slug: string;
+  company_name: string;
   status: ReferralOfferStatus;
   decided_at: string | null;
   created_at: string | null;


### PR DESCRIPTION
Follow-ups to #969 (moderation console), batched into one deploy.

## 1. Mobile: referral-offer review overflowed
The pending-offers `<table>` didn't reflow on narrow screens — Decision/Approve/Reject clipped off the right. Replaced with the moderation-queue card-row list (`sm:flex-row` stack).

## 2. Telegram/email ping 404
The "new referral request" ping linked to `/my/referrals/incoming` — a client tab, not a route → 404. Now backend links to `/my/referrals?tab=incoming` and `ReferralsView` opens the tab named in `?tab=` (mirrors `/moderation`).

## 3. Stop being a referrer
New `DELETE /me/referrals/offers/:id` (owner-scoped, hard delete → frees the UNIQUE so a member can offer again later). Service `WithdrawOffer`, `ErrOfferNotFound`→404, unit-tested. Frontend "Stop referring" button (confirm + optimistic drop).

## 4. Real company name + logo
The two offer list queries LEFT JOIN `companies` for the display name (→ `company_name` on the offer response). The offers list and the moderator review card render `CompanyLogo` + name (slug fallback) instead of the raw slug.

## 5. Drop the in-cabinet "Review offers →" link
Referral review lives in `/moderation` now (reached from the header), so the moderator-only link in the cabinet is removed.

## Verification
- `go build ./...`, `go vet ./internal/...`, `go test ./internal/referral ./internal/handler`: green. `gofmt` clean. sqlc regenerated.
- `npm run check`: 0 errors. eslint on touched files: clean (only pre-existing `href` errors). `npm run build`: passes.
- Visual: screenshotted offers list (logo + name + status + Stop referring) and referral review at desktop/mobile; measured no horizontal overflow.