### PR TITLE
fix(web): show job-card hide control on touch + simplify reminder prompt

### DIFF
--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { resolve } from '$app/paths';
-  import { Bell, Bookmark, EyeOff, X } from '@lucide/svelte';
+  import { Bookmark, EyeOff, X } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
@@ -86,7 +86,6 @@
   // Suppressed in the compact (assistant) card, where the corner has no room.
   let reminderPrompt = $state(false);
   let reminderBusy = $state(false);
-  let reminderSet = $state(false);
 
   const REMINDER_CHOICES: { label: string; days: number }[] = [
     { label: 'Tomorrow', days: 1 },
@@ -99,7 +98,9 @@
     reminderBusy = true;
     try {
       await api.saveJob(job.public_slug, { delay_days: days });
-      reminderSet = true;
+      // Picking a delay is the whole gesture — closing the prompt is the
+      // confirmation, so there's no extra "done" step to dismiss.
+      reminderPrompt = false;
     } catch {
       // Best-effort: leave the prompt so the user can retry.
     } finally {
@@ -124,7 +125,6 @@
     else markSaved(job.public_slug);
     // Unsaving closes any open prompt; a fresh save opens it.
     reminderPrompt = false;
-    reminderSet = false;
     try {
       if (wasSaved) await api.unsaveJob(job.public_slug);
       else await api.saveJob(job.public_slug);
@@ -268,39 +268,33 @@
   <!-- Post-save reminder prompt: a small popover under the bookmark. Non-modal —
        dismissing it (or ignoring the card) leaves the account default in effect. -->
   <div class="absolute right-2.5 top-12 z-10 w-56 rounded-lg border border-border bg-popover p-2.5 shadow-md">
-    {#if reminderSet}
-      <p class="flex items-center gap-1.5 px-1 py-0.5 text-xs text-muted-foreground">
-        <Bell class="size-3.5 text-brand" aria-hidden="true" /> Reminder set.
-        <button type="button" onclick={() => (reminderPrompt = false)} class="ml-auto font-medium text-foreground hover:opacity-80">Done</button>
-      </p>
-    {:else}
-      <div class="flex items-center justify-between px-1 pb-1.5">
-        <span class="text-xs font-semibold">Remind me to apply?</span>
-        <button type="button" onclick={() => (reminderPrompt = false)} aria-label="Dismiss reminder prompt" class="text-muted-foreground hover:text-foreground">
-          <X class="size-3.5" aria-hidden="true" />
+    <div class="flex items-center justify-between px-1 pb-1.5">
+      <span class="text-xs font-semibold">Remind me to apply?</span>
+      <button type="button" onclick={() => (reminderPrompt = false)} aria-label="Dismiss reminder prompt" class="text-muted-foreground hover:text-foreground">
+        <X class="size-3.5" aria-hidden="true" />
+      </button>
+    </div>
+    <div class="flex flex-wrap gap-1.5">
+      {#each REMINDER_CHOICES as c (c.days)}
+        <button
+          type="button"
+          onclick={() => setReminder(c.days)}
+          disabled={reminderBusy}
+          class="rounded-full border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-brand hover:text-brand disabled:opacity-50"
+        >
+          {c.label}
         </button>
-      </div>
-      <div class="flex flex-wrap gap-1.5">
-        {#each REMINDER_CHOICES as c (c.days)}
-          <button
-            type="button"
-            onclick={() => setReminder(c.days)}
-            disabled={reminderBusy}
-            class="rounded-full border border-border bg-background px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:border-brand hover:text-brand disabled:opacity-50"
-          >
-            {c.label}
-          </button>
-        {/each}
-      </div>
-    {/if}
+      {/each}
+    </div>
   </div>
 {/if}
 
 <!-- Hide control: only the browse feed passes `onHide`, so this appears there and
      nowhere else. A quiet icon in the card's bottom-right corner, revealed on hover
-     (and on keyboard focus). It's an overlay sibling of the card link, so hiding
-     never navigates. An opaque background keeps it legible over the salary corner on
-     the minority of cards that show one. -->
+     (and on keyboard focus). Touch devices have no hover, so `pointer-coarse` keeps it
+     always visible there. It's an overlay sibling of the card link, so hiding never
+     navigates. An opaque background keeps it legible over the salary corner on the
+     minority of cards that show one. -->
 {#if onHide}
   <button
     type="button"
@@ -308,7 +302,7 @@
     disabled={hiding}
     aria-label="Hide this job"
     title="Not interested — hide this job"
-    class="absolute bottom-2.5 right-2.5 grid size-8 place-items-center rounded-lg bg-accent text-muted-foreground opacity-0 shadow-sm ring-1 ring-border transition hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-50"
+    class="absolute bottom-2.5 right-2.5 grid size-8 place-items-center rounded-lg bg-accent text-muted-foreground opacity-0 shadow-sm ring-1 ring-border transition hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100 disabled:pointer-events-none disabled:opacity-50"
   >
     <EyeOff class="size-3.5" aria-hidden="true" />
   </button>


### PR DESCRIPTION
## What

Two small mobile/UX fixes on the browse-feed job cards (`JobRow.svelte`):

1. **Hide control missing on mobile.** The bottom-right eye-off "hide this job" button was revealed only through `group-hover:opacity-100`. Touch devices have no `:hover`, so it stayed at `opacity-0` — invisible and unusable on phones. Added `pointer-coarse:opacity-100` (Tailwind v4 native variant → `@media (pointer: coarse)`) so it is always visible on touch, while pointer devices keep the quiet hover-reveal.

2. **Dropped the redundant "Reminder set." step.** After picking a reminder delay, the popover swapped to a `Reminder set. / Done` confirmation that needed a second click to dismiss. Now picking a delay just closes the popover — the close *is* the confirmation. Removes the now-unused `reminderSet` state and the `Bell` import.

## Why

Reported from mobile: no way to hide a job (the desktop eye icon was absent), and the reminder flow had one click too many.

## Verification

- `npx svelte-check` → 0 errors
- `npm run build` → succeeds; confirmed `@media (pointer:coarse)` lands in the generated CSS (validates the variant compiles under Tailwind v4)

## Scope

Single-file change, isolated on a clean branch off `main`.