### PR TITLE
feat(sources): onboard 5 contributed boards

### DIFF
--- a/sources/enlizt.yml
+++ b/sources/enlizt.yml
@@ -1,4 +1,6 @@
 # Enlizt boards. Provider is the filename; each entry is company + board.
 # board = the tenant subdomain in <board>.enlizt.me (see internal/sources/enlizt.go).
+- company: PariPassu
+  board: paripassu
 - company: Tributo Devido
   board: tributodevido

--- a/sources/recruitee.yml
+++ b/sources/recruitee.yml
@@ -3667,3 +3667,5 @@
   board: gro
 - company: Tidio
   board: tidiocareer
+- company: Wellis
+  board: wellis

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -19,6 +19,8 @@
   board: bestex-research
 - company: Board of Innovation
   board: boardofinnovation
+- company: Burq
+  board: burq
 - company: Cause and FX
   board: cause-and-fx-ltd
 - company: Climax Studios
@@ -201,6 +203,8 @@
   board: we-are-social-1
 - company: Wingz LatAm
   board: wingz-latam
+- company: Wisedocs AI
+  board: wisedocs-ai
 - company: Workstate
   board: workstate
 - company: ZeptoLab

--- a/sources/zohorecruit.yml
+++ b/sources/zohorecruit.yml
@@ -293,6 +293,8 @@
   board: bluserena.zohorecruit.eu
 - company: Bonami Software
   board: bonamisoftware.zohorecruit.in
+- company: Borders & Gates
+  board: bordersngates.zohorecruit.com
 - company: Boson Motors
   board: bosonmotors.zohorecruit.com
 - company: Botmakers


### PR DESCRIPTION
Drains the pending `link_contributions` backlog into the ingest board files (the manual run of the deferred onboarding worker).

## Onboarded (live-validated, >0 jobs)
| source | board | company |
|---|---|---|
| zohorecruit | `bordersngates.zohorecruit.com` | Borders & Gates |
| workable | `burq` | Burq (15 jobs) |
| workable | `wisedocs-ai` | Wisedocs AI (8 jobs) |
| recruitee | `wellis` | Wellis |
| enlizt | `paripassu` | PariPassu (21 vacancies) |

## Rejected (not added)
- **greenhouse / `embed`** — `job-boards.greenhouse.io/embed` 404s; "embed" is the widget endpoint, not a company board.
- **jobvite / `careers`** — mis-recognized from `jobs.jobvite.com/careers/ness/jobs`; the verbatim board `careers` 302s empty. Real slug is `ness` (could be re-contributed / added separately).

Crawling starts on the next ingest cycle after `sources/` deploys from main. Contribution rows flipped to `onboarded`/`rejected` post-merge.