### PR TITLE
feat(sources): onboard Lever EU boards CoinsPaid, Mobileye

### DIFF
--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -183,6 +183,9 @@
   board: coingecko
 - company: coinmarketcap
   board: coinmarketcap
+- company: CoinsPaid
+  board: coinspaid
+  region: eu
 - company: commoncause
   board: commoncause
 - company: Commonwealth Fusion Systems
@@ -476,6 +479,9 @@
   board: mistral
 - company: Mixlab
   board: mixlab
+- company: Mobileye
+  board: mobileye
+  region: eu
 - company: Modulate
   board: modulate
 - company: Mom's Meals


### PR DESCRIPTION
Two Lever boards surfaced from the contribution **reject log** (`contribution: unrecognized link` on prod), not the `link_contributions` table — the URL recognizer doesn't know Lever's EU host `jobs.eu.lever.co`, so these submissions were rejected before insert.

| board | company | validated |
|---|---|---|
| `coinspaid` | CoinsPaid | `api.eu.lever.co/v0/postings/coinspaid` → jobs (404 on US host) |
| `mobileye` | Mobileye | `api.eu.lever.co/v0/postings/mobileye` → jobs (404 on US host) |

Both carry `region: eu` so the adapter hits the EU data-residency host.

Follow-up (separate): the recognizer's regional-host blind spot (`jobs.eu.lever.co`, `jobs.personio.de`) rejects submissions for boards we **already crawl** (e.g. valon/ashby, reflex-aerospace-gmbh/personio, franq/gupy were all told "unsupported" despite being in the catalogue).