### PR TITLE
feat(sources): add yandexcrowd adapter for crowd.yandex.ru

### DIFF
--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -355,6 +355,8 @@ func All(c HTTPClient) map[string]Source {
 		// RU-domestic single-company adapters (boardless, except Yandex which selects
 		// host+language by board).
 		NewYandex(c),
+		// Yandex Crowd: gig/support catalogue at crowd.yandex.ru, one JSON blob per landing page.
+		NewYandexCrowd(c),
 		NewOzon(c),
 		NewAvito(c),
 		NewRWB(c),

--- a/internal/sources/yandexcrowd.go
+++ b/internal/sources/yandexcrowd.go
@@ -1,0 +1,140 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// yandexcrowd adapts Yandex Crowd's public vacancy catalogue (crowd.yandex.ru/vacancies) — the
+// gig/support arm of Yandex: call-centre, support, moderation, courier, and back-office roles. It
+// is a single-company boardless adapter: the /vacancies landing page server-renders its whole
+// catalogue as one JSON array in a <script id="data"> tag, grouped by direction, so a single GET
+// yields every posting and there is no per-vacancy detail fetch. That array is a STALE catalogue —
+// it keeps taken-down postings whose own pages 404 — so the crawl keeps only entries flagged
+// `available`, which still resolve. Identity is the vacancy's URL path (a stable slug such as
+// "support/finteh_chat"); the float `id` is a positional index and is ignored.
+type yandexcrowd struct {
+	http TextGetter
+}
+
+// NewYandexCrowd builds the Yandex Crowd adapter over the given HTTP client.
+func NewYandexCrowd(c TextGetter) Source { return yandexcrowd{http: c} }
+
+func (yandexcrowd) Provider() string { return "yandexcrowd" }
+
+// yandexcrowd is single-company, so its config entry carries no board.
+func (yandexcrowd) boardless() {}
+
+const (
+	yandexCrowdListURL = "https://crowd.yandex.ru/vacancies"
+	yandexCrowdHost    = "https://crowd.yandex.ru/"
+	yandexCrowdDataKey = `<script id="data" type="application/json">`
+)
+
+// yandexCrowdGroup is one direction section of the catalogue (support, sales, …); only its
+// vacancies matter to the crawl.
+type yandexCrowdGroup struct {
+	Vacancies []yandexCrowdVacancy `json:"vacancies"`
+}
+
+// yandexCrowdVacancy is one posting. URL is both the detail/apply page and the source of the
+// stable external id; Available gates taken-down postings (their pages 404). Tags.Remotely is the
+// structured work-arrangement signal and Tags.Employment the employment-type signal.
+type yandexCrowdVacancy struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Available   bool   `json:"available"`
+	Tags        struct {
+		Remotely   string   `json:"remotely"`
+		Employment []string `json:"employment"`
+	} `json:"tags"`
+}
+
+func (y yandexcrowd) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
+	body, err := y.http.GetText(ctx, yandexCrowdListURL)
+	if err != nil {
+		return nil, fmt.Errorf("yandexcrowd: listing: %w", err)
+	}
+	raw, ok := bracketSlice(body, yandexCrowdDataKey, '[', ']')
+	if !ok {
+		return nil, fmt.Errorf(`yandexcrowd: no <script id="data"> catalogue in listing`)
+	}
+	var groups []yandexCrowdGroup
+	if err := json.Unmarshal([]byte(raw), &groups); err != nil {
+		return nil, fmt.Errorf("yandexcrowd: decode catalogue: %w", err)
+	}
+
+	var jobs []Job
+	for _, g := range groups {
+		for _, v := range g.Vacancies {
+			if j, ok := yandexCrowdJob(e, v); ok {
+				jobs = append(jobs, j)
+			}
+		}
+	}
+	return jobs, nil
+}
+
+// yandexCrowdJob maps one vacancy to a Job, returning ok=false for a taken-down posting (its page
+// 404s, flagged available:false) or one missing the URL that forms its identity.
+func yandexCrowdJob(e CompanyEntry, v yandexCrowdVacancy) (Job, bool) {
+	if !v.Available {
+		return Job{}, false
+	}
+	id := yandexCrowdExternalID(v.URL)
+	if id == "" {
+		return Job{}, false
+	}
+	mode := yandexCrowdWorkMode(v.Tags.Remotely)
+	return Job{
+		ExternalID:     id,
+		URL:            strings.TrimSpace(v.URL),
+		Title:          sanitizeHTML(v.Title),
+		Company:        e.Company,
+		Description:    sanitizeHTML(v.Description),
+		Remote:         mode == "remote",
+		WorkMode:       mode,
+		EmploymentType: yandexCrowdEmployment(v.Tags.Employment),
+	}, true
+}
+
+// yandexCrowdExternalID derives the stable dedup key from a vacancy URL: its path under the crowd
+// host (e.g. "support/finteh_chat"), which is stable across catalogue reordering unlike the float
+// id. Returns "" when the URL is empty or not a crowd host path.
+func yandexCrowdExternalID(rawURL string) string {
+	u := strings.TrimSpace(rawURL)
+	u = strings.TrimPrefix(u, yandexCrowdHost)
+	u = strings.TrimPrefix(u, "http://crowd.yandex.ru/")
+	return strings.Trim(u, "/")
+}
+
+// yandexCrowdWorkMode maps the structured `remotely` tag to the work-mode vocabulary. Observed
+// values are "удалённо" (remote) and "локально" (onsite); anything else is left unknown ("").
+func yandexCrowdWorkMode(remotely string) string {
+	switch r := strings.ToLower(strings.TrimSpace(remotely)); {
+	case strings.Contains(r, "удал"):
+		return "remote"
+	case strings.Contains(r, "локал"):
+		return "onsite"
+	default:
+		return ""
+	}
+}
+
+// yandexCrowdEmployment maps the structured `employment` tag onto the employment-type vocabulary,
+// returning the first recognized value. Observed values are "полная" (full_time) and "частичная"
+// (part_time); an unknown/absent value yields "" so the description parser decides.
+func yandexCrowdEmployment(employment []string) string {
+	for _, e := range employment {
+		switch t := strings.ToLower(strings.TrimSpace(e)); {
+		case strings.Contains(t, "полн"):
+			return "full_time"
+		case strings.Contains(t, "частичн"):
+			return "part_time"
+		}
+	}
+	return ""
+}

--- a/internal/sources/yandexcrowd_test.go
+++ b/internal/sources/yandexcrowd_test.go
@@ -1,0 +1,127 @@
+package sources
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// yandexCrowdVacancyJSON builds one vacancy object for the embedded catalogue. remotely and
+// employment are the structured tag values the adapter maps; available gates taken-down postings.
+func yandexCrowdVacancyJSON(id, title, description, url string, available bool, remotely, employment string) string {
+	avail := "false"
+	if available {
+		avail = "true"
+	}
+	return `{"id":` + id +
+		`,"title":"` + title + `"` +
+		`,"description":"` + description + `"` +
+		`,"url":"` + url + `"` +
+		`,"payment":"от&nbsp;47&nbsp;000&nbsp;₽"` +
+		`,"available":` + avail +
+		`,"tags":{"hot":false,"experience":"до года","remotely":"` + remotely +
+		`","direction":["поддержка"],"employment":["` + employment + `"]}}`
+}
+
+// yandexCrowdPage wraps direction groups in the <script id="data"> block the /vacancies page
+// server-renders, mirroring the real host's shape (a JSON array of {vacancies:[…]} groups).
+func yandexCrowdPage(groups ...string) string {
+	return `<html><body><div class="lc-custom-html">` +
+		`<script id="data" type="application/json">` +
+		`[` + strings.Join(groups, ",") + `]` +
+		`</script></div></body></html>`
+}
+
+func yandexCrowdGroupJSON(vacancies ...string) string {
+	return `{"id":1,"direction-name":"Поддержка","direction-title":"support",` +
+		`"vacancies":[` + strings.Join(vacancies, ",") + `]}`
+}
+
+func TestYandexCrowdProvider(t *testing.T) {
+	if got := NewYandexCrowd(nil).Provider(); got != "yandexcrowd" {
+		t.Errorf("Provider() = %q, want %q", got, "yandexcrowd")
+	}
+}
+
+func TestYandexCrowdIsBoardless(t *testing.T) {
+	if _, ok := NewYandexCrowd(nil).(boardless); !ok {
+		t.Error("yandexcrowd must implement boardless: it is a single-company adapter with no per-tenant board")
+	}
+}
+
+func TestYandexCrowdFetchKeepsAvailableAndMaps(t *testing.T) {
+	// The catalogue is a stale list: only available:true vacancies still have a live page, so
+	// the taken-down (available:false) one is dropped. External identity is the URL path slug;
+	// the float id is ignored. remotely/employment tags map to WorkMode/EmploymentType.
+	page := yandexCrowdPage(
+		yandexCrowdGroupJSON(
+			yandexCrowdVacancyJSON("1.1", "Аналитик по&nbsp;соцсетям", "Осваивайте профессию",
+				"https://crowd.yandex.ru/back_office/analytics/analitik_smm", true, "удалённо", "полная"),
+			yandexCrowdVacancyJSON("1.2", "Оператор колл-центра", "Помогайте клиентам",
+				"https://crowd.yandex.ru/support/operator_local", true, "локально", "частичная"),
+			yandexCrowdVacancyJSON("1.3", "Закрытая вакансия", "Её страница 404",
+				"https://crowd.yandex.ru/support/finteh_chat", false, "удалённо", "полная"),
+		),
+	)
+	fake := (&routedHTTP{}).route("/vacancies", page)
+
+	jobs, err := NewYandexCrowd(fake).Fetch(context.Background(), CompanyEntry{Company: "Yandex Crowd", Provider: "yandexcrowd"})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("len(jobs) = %d, want 2 (available:false dropped)", len(jobs))
+	}
+
+	byID := map[string]Job{}
+	for _, j := range jobs {
+		byID[j.ExternalID] = j
+	}
+
+	j, ok := byID["back_office/analytics/analitik_smm"]
+	if !ok {
+		t.Fatalf("missing job keyed by URL path; got ids %v", keysOf(byID))
+	}
+	if j.Company != "Yandex Crowd" {
+		t.Errorf("Company = %q, want Yandex Crowd", j.Company)
+	}
+	if want := "https://crowd.yandex.ru/back_office/analytics/analitik_smm"; j.URL != want {
+		t.Errorf("URL = %q, want %q", j.URL, want)
+	}
+	if strings.Contains(j.Title, "&nbsp;") || !strings.Contains(j.Title, "Аналитик") {
+		t.Errorf("Title = %q, want entity-decoded", j.Title)
+	}
+	if !j.Remote || j.WorkMode != "remote" {
+		t.Errorf("Remote=%v WorkMode=%q, want remote (remotely=удалённо)", j.Remote, j.WorkMode)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time (полная)", j.EmploymentType)
+	}
+
+	local, ok := byID["support/operator_local"]
+	if !ok {
+		t.Fatal("missing local operator job")
+	}
+	if local.Remote || local.WorkMode != "onsite" {
+		t.Errorf("local: Remote=%v WorkMode=%q, want onsite (remotely=локально)", local.Remote, local.WorkMode)
+	}
+	if local.EmploymentType != "part_time" {
+		t.Errorf("local EmploymentType = %q, want part_time (частичная)", local.EmploymentType)
+	}
+}
+
+func TestYandexCrowdMissingCatalogueErrors(t *testing.T) {
+	fake := (&routedHTTP{}).route("/vacancies", "<html><body>no data script</body></html>")
+
+	if _, err := NewYandexCrowd(fake).Fetch(context.Background(), CompanyEntry{Company: "Yandex Crowd"}); err == nil {
+		t.Fatal("Fetch: want error when the <script id=\"data\"> catalogue is absent")
+	}
+}
+
+func keysOf(m map[string]Job) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/sources/custom.yml
+++ b/sources/custom.yml
@@ -70,3 +70,6 @@
 - company: Yandex
   provider: yandex
   board: com
+# Yandex Crowd: gig/support catalogue (crowd.yandex.ru), single-company boardless.
+- company: Yandex Crowd
+  provider: yandexcrowd


### PR DESCRIPTION
## What

New `yandexcrowd` source adapter for **crowd.yandex.ru/vacancies** — Yandex Crowd, the gig/support arm of Yandex (call-centre, support, moderation, courier, back-office roles).

## How it works

- Single-company **boardless** adapter over `TextGetter`. One GET to `https://crowd.yandex.ru/vacancies`.
- The landing page server-renders its whole catalogue as one clean JSON array in `<script id="data" type="application/json">`, grouped by direction. Extracted via `bracketSlice(..., '[', ']')` — no per-vacancy detail fetch.
- **`available` gate:** the blob is a stale catalogue that keeps ~450 taken-down postings whose own pages return **404**; only `available:true` entries (~31 of 485) still resolve. The crawl keeps just those, so we don't ingest dead links.
- **external_id = URL path slug** (e.g. `support/finteh_chat`) — stable across reordering. The float `id` is a positional index and is ignored.
- `remotely` tag → `WorkMode` (удалённо→remote, локально→onsite); `employment` tag → `EmploymentType` (полная→full_time, частичная→part_time).

## Verification

- `go test ./internal/sources/` green; `go build ./...`, `go vet`, `gofmt` clean.
- Live run against crowd.yandex.ru returned **31 vacancies** with stable ids and correct facet mapping.