### PR TITLE
feat(contribution): recognize Lever EU/Personio DE hosts + resolve ashby_jid embeds

### DIFF
--- a/internal/contribution/board.go
+++ b/internal/contribution/board.go
@@ -37,6 +37,7 @@ var atsBoards = []struct{ host, source, mode string }{
 	// --- path: board = first path segment on a fixed host ---
 	{"greenhouse.io", "greenhouse", modePath},
 	{"jobs.lever.co", "lever", modePath},
+	{"jobs.eu.lever.co", "lever", modePath}, // Lever EU data-residency host; same path shape/board as the US host
 	{"jobs.ashbyhq.com", "ashby", modePath},
 	{"apply.workable.com", "workable", modePath},
 	{"jobs.deel.com", "deel", modePath},
@@ -61,6 +62,7 @@ var atsBoards = []struct{ host, source, mode string }{
 	{"huntflow.io", "huntflow", modeSubdomain},
 	{"peopleforce.io", "peopleforce", modeSubdomain},
 	{"jobs.personio.com", "personio", modeSubdomain},
+	{"jobs.personio.de", "personio", modeSubdomain}, // Personio DE regional host; board = same tenant subdomain
 	{"pinpointhq.com", "pinpoint", modeSubdomain},
 	{"talentlyft.com", "talentlyft", modeSubdomain},
 	{"traffit.com", "traffit", modeSubdomain},
@@ -224,6 +226,26 @@ func greenhouseJobID(rawURL string) (string, bool) {
 	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
 	if last := segs[len(segs)-1]; ghNumericID.MatchString(last) {
 		return last, true
+	}
+	return "", false
+}
+
+// ashbyUUID matches an Ashby job id (a UUID) — the value Ashby's embed widget carries.
+var ashbyUUID = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// ashbyJobID extracts an Ashby job id from a link that embeds an Ashby board on a company's own
+// domain (company.com/careers?ashby_jid=<uuid>): the ashby_jid query param the embed widget
+// carries. The board slug never appears in the URL or the (JS-rendered) markup, so the recognizer
+// and page-fetch resolver both miss it — but external_id is "<board>:<uuid>", so the id resolves
+// the board. ok=false when absent. A non-Ashby UUID won't be found downstream, so a false
+// positive is harmless.
+func ashbyJobID(rawURL string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", false
+	}
+	if id := u.Query().Get("ashby_jid"); ashbyUUID.MatchString(id) {
+		return id, true
 	}
 	return "", false
 }

--- a/internal/contribution/board_test.go
+++ b/internal/contribution/board_test.go
@@ -19,6 +19,7 @@ func TestRecognizeBoard(t *testing.T) {
 		{"greenhouse vacancy strips utm", "https://job-boards.greenhouse.io/alpaca/jobs/5745893004?utm=x#top", "greenhouse", "alpaca", "https://job-boards.greenhouse.io/alpaca/jobs/5745893004", true},
 		{"greenhouse board listing", "https://job-boards.greenhouse.io/alpaca", "greenhouse", "alpaca", "https://job-boards.greenhouse.io/alpaca", true},
 		{"lever strips /apply", "https://jobs.lever.co/offchainlabs/52c01c91/apply", "lever", "offchainlabs", "https://jobs.lever.co/offchainlabs/52c01c91", true},
+		{"lever eu data-residency host", "https://jobs.eu.lever.co/coinspaid/244123b5-ffbb/apply?x=1", "lever", "coinspaid", "https://jobs.eu.lever.co/coinspaid/244123b5-ffbb", true},
 		{"ashby vacancy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799", "ashby", "blitzy", "https://jobs.ashbyhq.com/blitzy/a741b4e8-8799", true},
 		{"deel path", "https://jobs.deel.com/acme/jobs/123", "deel", "acme", "https://jobs.deel.com/acme/jobs/123", true},
 		{"jobvite path", "https://jobs.jobvite.com/acme/job/oABC", "jobvite", "acme", "https://jobs.jobvite.com/acme/job/oABC", true},
@@ -36,6 +37,7 @@ func TestRecognizeBoard(t *testing.T) {
 		{"recruitee board listing", "https://acme.recruitee.com", "recruitee", "acme", "https://acme.recruitee.com", true},
 		{"bamboohr subdomain", "https://acme.bamboohr.com/careers/42", "bamboohr", "acme", "https://acme.bamboohr.com", true},
 		{"personio nested apex subdomain", "https://acme.jobs.personio.com/job/9", "personio", "acme", "https://acme.jobs.personio.com", true},
+		{"personio de host", "https://reflex-aerospace-gmbh.jobs.personio.de/job/2679152?display=en#apply", "personio", "reflex-aerospace-gmbh", "https://reflex-aerospace-gmbh.jobs.personio.de", true},
 
 		// host mode — board is the whole careers host, regional TLD varies
 		{"zoho eu vacancy strips encoded path + query", "https://be-exec.zohorecruit.eu/jobs/Careers/73534000009044079/%D0%9F%D1%80%D0%BE?source=CareerSite", "zohorecruit", "be-exec.zohorecruit.eu", "https://be-exec.zohorecruit.eu", true},

--- a/internal/contribution/contribution.go
+++ b/internal/contribution/contribution.go
@@ -56,6 +56,7 @@ type Repository interface {
 	BoardTracked(ctx context.Context, source, board string) (bool, error)
 	CompanyForBoard(ctx context.Context, source, board string) (name, slug string, ok bool, err error)
 	BoardByGreenhouseJobID(ctx context.Context, jobID string) (board string, ok bool, err error)
+	BoardByAshbyJobID(ctx context.Context, jobID string) (board string, ok bool, err error)
 	Record(ctx context.Context, in RecordInput) (Contribution, error)
 	ListByUser(ctx context.Context, userID int64) ([]Contribution, error)
 }
@@ -113,9 +114,9 @@ func (s *Service) Submit(ctx context.Context, submittedBy int64, rawURL string) 
 
 // resolveBoard finds the (source, board, canonical URL) a pasted link belongs to, trying the
 // cheapest strategy first: the network-free URL recognizer; then a page fetch that detects an
-// ATS embedded on a company's own careers domain; then a Greenhouse job-id lookup, for
-// server-side embeds that expose only the job id (resolves boards we already track). ok=false
-// when none resolve.
+// ATS embedded on a company's own careers domain; then a Greenhouse or Ashby job-id lookup, for
+// embeds that expose only the job id (resolves boards we already track). ok=false when none
+// resolve.
 func (s *Service) resolveBoard(ctx context.Context, rawURL string) (source, board, canonical string, ok bool) {
 	if source, board, canonical, ok := RecognizeBoard(rawURL); ok {
 		return source, board, canonical, true
@@ -128,6 +129,11 @@ func (s *Service) resolveBoard(ctx context.Context, rawURL string) (source, boar
 	if id, has := greenhouseJobID(rawURL); has {
 		if b, found, err := s.repo.BoardByGreenhouseJobID(ctx, id); err == nil && found {
 			return "greenhouse", b, stripQueryFragment(rawURL), true
+		}
+	}
+	if id, has := ashbyJobID(rawURL); has {
+		if b, found, err := s.repo.BoardByAshbyJobID(ctx, id); err == nil && found {
+			return "ashby", b, stripQueryFragment(rawURL), true
 		}
 	}
 	return "", "", "", false

--- a/internal/contribution/contribution_test.go
+++ b/internal/contribution/contribution_test.go
@@ -21,6 +21,7 @@ type fakeRepo struct {
 	companyName   string
 	companySlug   string
 	jobIDBoard    string // BoardByGreenhouseJobID returns this (ok when non-empty)
+	ashbyIDBoard  string // BoardByAshbyJobID returns this (ok when non-empty)
 }
 
 func (f *fakeRepo) BoardTracked(_ context.Context, _, _ string) (bool, error) {
@@ -33,6 +34,10 @@ func (f *fakeRepo) CompanyForBoard(_ context.Context, _, _ string) (string, stri
 
 func (f *fakeRepo) BoardByGreenhouseJobID(_ context.Context, _ string) (string, bool, error) {
 	return f.jobIDBoard, f.jobIDBoard != "", nil
+}
+
+func (f *fakeRepo) BoardByAshbyJobID(_ context.Context, _ string) (string, bool, error) {
+	return f.ashbyIDBoard, f.ashbyIDBoard != "", nil
 }
 
 func (f *fakeRepo) Record(_ context.Context, in RecordInput) (Contribution, error) {
@@ -191,6 +196,25 @@ func TestSubmitResolvesGreenhouseJobIDForServerSideVanity(t *testing.T) {
 	// No id in the URL → not resolved.
 	if _, _, _, err := New(repo, nil).Submit(context.Background(), 7, "https://example.com/careers/about"); !errors.Is(err, ErrUnsupportedATS) {
 		t.Errorf("err = %v, want ErrUnsupportedATS for a URL with no job id", err)
+	}
+}
+
+func TestSubmitResolvesAshbyJobIDForEmbeddedVanity(t *testing.T) {
+	// A company careers page that embeds Ashby on its own domain via the ashby_jid widget param
+	// (company.com/careers?ashby_jid=<uuid>). The slug is never in the URL/markup, but external_id
+	// is "<board>:<uuid>", so the id lookup finds the tracked board.
+	repo := &fakeRepo{ashbyIDBoard: "valon", boardTracked: true}
+	_, source, board, err := New(repo, nil).Submit(context.Background(), 7,
+		"https://www.valon.ai/about?ashby_jid=6052f210-29f1-4ef4-93cc-48029969eaf7&utm_source=x#careers")
+	if !errors.Is(err, ErrBoardAlreadyTracked) {
+		t.Fatalf("err = %v, want ErrBoardAlreadyTracked", err)
+	}
+	if source != "ashby" || board != "valon" {
+		t.Errorf("= (%q,%q), want (ashby, valon)", source, board)
+	}
+	// A non-UUID ashby_jid (or none) → not resolved.
+	if _, _, _, err := New(repo, nil).Submit(context.Background(), 7, "https://www.valon.ai/about?ashby_jid=not-a-uuid"); !errors.Is(err, ErrUnsupportedATS) {
+		t.Errorf("err = %v, want ErrUnsupportedATS for a non-UUID ashby_jid", err)
 	}
 }
 

--- a/internal/contribution/repository.go
+++ b/internal/contribution/repository.go
@@ -46,6 +46,19 @@ func (r *QueriesRepository) BoardByGreenhouseJobID(ctx context.Context, jobID st
 	return board, true, nil
 }
 
+// BoardByAshbyJobID returns the ashby board already carrying a job with the given Ashby job id,
+// or ok=false when none is tracked.
+func (r *QueriesRepository) BoardByAshbyJobID(ctx context.Context, jobID string) (board string, ok bool, err error) {
+	board, err = r.q.BoardByAshbyJobID(ctx, jobID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return board, true, nil
+}
+
 // CompanyForBoard returns the company name + slug already tracked on the board, or ok=false
 // when the board has no job with a resolved company.
 func (r *QueriesRepository) CompanyForBoard(ctx context.Context, source, board string) (name, slug string, ok bool, err error) {

--- a/internal/db/link_contributions.sql.go
+++ b/internal/db/link_contributions.sql.go
@@ -9,6 +9,24 @@ import (
 	"context"
 )
 
+const boardByAshbyJobID = `-- name: BoardByAshbyJobID :one
+SELECT split_part(external_id, ':', 1) AS board
+FROM jobs
+WHERE source = 'ashby' AND split_part(external_id, ':', 2) = $1
+LIMIT 1
+`
+
+// Find the ashby board already carrying a job with this Ashby job id — for company careers
+// pages that embed Ashby via the ashby_jid widget param (the board slug is JS-rendered, absent
+// from the URL/markup). external_id is "<board>:<uuid>"; served by the
+// (split_part(external_id,':',2)) WHERE source='ashby' partial index.
+func (q *Queries) BoardByAshbyJobID(ctx context.Context, jobID string) (string, error) {
+	row := q.db.QueryRow(ctx, boardByAshbyJobID, jobID)
+	var board string
+	err := row.Scan(&board)
+	return board, err
+}
+
 const boardByGreenhouseJobID = `-- name: BoardByGreenhouseJobID :one
 SELECT split_part(external_id, ':', 1) AS board
 FROM jobs

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -18,6 +18,11 @@ type Querier interface {
 	// expiry and touching last_used_at in one atomic statement. No row means the key is
 	// unknown, revoked, or expired; the caller treats pgx.ErrNoRows as 401.
 	AuthenticateAPIKey(ctx context.Context, tokenHash string) (int64, error)
+	// Find the ashby board already carrying a job with this Ashby job id — for company careers
+	// pages that embed Ashby via the ashby_jid widget param (the board slug is JS-rendered, absent
+	// from the URL/markup). external_id is "<board>:<uuid>"; served by the
+	// (split_part(external_id,':',2)) WHERE source='ashby' partial index.
+	BoardByAshbyJobID(ctx context.Context, jobID string) (string, error)
 	// Find the greenhouse board already carrying a job with this Greenhouse job id — for links on
 	// a company's own domain that expose only the ATS job id (server-side embeds, no board token
 	// in the URL/page). external_id is "<board>:<id>"; served by the

--- a/internal/db/queries/link_contributions.sql
+++ b/internal/db/queries/link_contributions.sql
@@ -26,6 +26,16 @@ FROM jobs
 WHERE source = 'greenhouse' AND split_part(external_id, ':', 2) = sqlc.arg(job_id)
 LIMIT 1;
 
+-- name: BoardByAshbyJobID :one
+-- Find the ashby board already carrying a job with this Ashby job id — for company careers
+-- pages that embed Ashby via the ashby_jid widget param (the board slug is JS-rendered, absent
+-- from the URL/markup). external_id is "<board>:<uuid>"; served by the
+-- (split_part(external_id,':',2)) WHERE source='ashby' partial index.
+SELECT split_part(external_id, ':', 1) AS board
+FROM jobs
+WHERE source = 'ashby' AND split_part(external_id, ':', 2) = sqlc.arg(job_id)
+LIMIT 1;
+
 -- name: CompanyForBoard :one
 -- The tracked company on a board — for the "already tracked" reply: a job's company name and
 -- slug so the bot/UI can link to /companies/<slug>. board_pattern is "<escaped board>:%" (same

--- a/migrations/0035_jobs_ashby_jobid_idx.sql
+++ b/migrations/0035_jobs_ashby_jobid_idx.sql
@@ -1,0 +1,15 @@
+-- A partial index for the ashby job-id lookup in link contributions (internal/contribution).
+-- Many companies embed Ashby on their own careers domain via the ashby_jid widget param
+-- (company.com/careers?ashby_jid=<uuid>); the board slug is JS-rendered, so it never appears in
+-- the URL or page — only the Ashby job id. external_id is "<board>:<uuid>", so we find the board
+-- by the id component: split_part(external_id, ':', 2) = '<uuid>'.
+--
+-- Partial on source='ashby', so the index is small (~ashby rows only). The expression must match
+-- the query's exactly (literal ':', not chr(58)) for the planner to use it. Mirrors
+-- 0027_jobs_greenhouse_jobid_idx.
+--
+-- On a fresh initdb volume this plain CREATE INDEX is fine; on the live prod DB apply it
+-- manually as CREATE INDEX CONCURRENTLY.
+CREATE INDEX jobs_ashby_jobid_idx
+    ON public.jobs (split_part(external_id, ':', 2))
+    WHERE source = 'ashby';


### PR DESCRIPTION
Makes previously-rejected contribution links resolve (and, for genuinely new boards, award credits). Both shapes were surfaced from the prod reject log (`contribution: unrecognized link`), where users pasted boards we **already crawl** yet got "That link isn't from a supported ATS board".

## What was failing & why
The URL recognizer (`board.go`, `atsBoards`) is a host-allowlist. It missed:
1. **Regional ATS hosts** — `jobs.eu.lever.co` (Lever EU data-residency) and `jobs.personio.de` (Personio DE). Same provider + board as the US/.com hosts, just a different host.
2. **Ashby embedded on a company's own domain** — `company.com/careers?ashby_jid=<uuid>` (e.g. `valon.ai/about?ashby_jid=…`). The board slug is rendered by Ashby's JS widget, so it's absent from both the URL and the raw HTML — the recognizer and the page-fetch resolver (`boardresolve`) both miss it. Only the job UUID is present.

## Fix
- **Regional hosts:** two `atsBoards` rows (`jobs.eu.lever.co` → lever/path, `jobs.personio.de` → personio/subdomain). Network-free; a new regional board now records + earns a credit.
- **ashby_jid:** mirror the existing `gh_jid` lookup. `external_id` is `<board>:<uuid>`, so the UUID resolves the board via a new `BoardByAshbyJobID` query + `ashbyJobID` extractor. Like `gh_jid`, this resolves boards **already in the catalogue** → correct "we already cover this" reply instead of a false "unsupported".

## Migration
`0035_jobs_ashby_jobid_idx.sql` — partial index on `split_part(external_id,':',2) WHERE source='ashby'`, mirroring `0027` for greenhouse. **Apply manually on prod** as `CREATE INDEX CONCURRENTLY` before/after deploy (initdb-only otherwise).

## Tests
`board_test.go`: Lever EU + Personio DE recognition. `contribution_test.go`: ashby_jid resolves to the tracked board (valon), non-UUID rejected. Full suite + vet + gofmt green.