### PR TITLE
feat(sources): onboard Volkswagen Group (SuccessFactors), On That Ass (Teamtailor)

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -1127,7 +1127,7 @@
   board: keensoftwarehouseas
 - company: Kensington
   board: kensingtontours
-- company: khanacademy
+- company: Khan Academy
   board: khanacademy
 - company: KIKOFF Leagues
   board: kikoff

--- a/sources/successfactors.yml
+++ b/sources/successfactors.yml
@@ -23,3 +23,5 @@
   board: careers.dentsplysirona.com
 - company: GFT Technologies
   board: jobs.gft.com
+- company: Volkswagen Group
+  board: jobs.volkswagen-group.com

--- a/sources/teamtailor.yml
+++ b/sources/teamtailor.yml
@@ -3052,3 +3052,5 @@
   board: riipinenrestaurants.teamtailor.com
 - company: cadpool.teamtailor.com
   board: cadpool.teamtailor.com
+- company: On That Ass
+  board: jobs.onthatass.com


### PR DESCRIPTION
Two first-party ATS onboards surfaced from a startup.jobs/JSearch company sweep, resolved to their real ATS and live-validated (>0 jobs):

- **Volkswagen Group** → `jobs.volkswagen-group.com` (SuccessFactors, ~872 jobs in sitemap)
- **On That Ass** → `jobs.onthatass.com` (Teamtailor)

Plus a tidy of Khan Academy's greenhouse entry from the raw slug `khanacademy` to its display name.

Both boards fetch cleanly through the existing successfactors/teamtailor adapters — no new code, just board entries. `go test ./internal/sources/` green.