### PR TITLE
feat(sources): onboard 10 companies mined from startup.jobs directory

### DIFF
--- a/sources/greenhouse.yml
+++ b/sources/greenhouse.yml
@@ -1457,6 +1457,8 @@
   board: octaura
 - company: OfferUp
   board: offerup
+- company: Office Ally
+  board: officeally
 - company: Ogilvy
   board: ogilvy
 - company: Okta

--- a/sources/lever.yml
+++ b/sources/lever.yml
@@ -778,6 +778,8 @@
   board: trellis
 - company: Trendyol
   board: trendyol
+- company: Triveni Bio
+  board: trivenibio
 - company: Ubiminds
   board: Ubiminds
 - company: UntilLabs

--- a/sources/personio.yml
+++ b/sources/personio.yml
@@ -25,6 +25,8 @@
   board: gvc2u
 - company: Hololight
   board: holo-light
+- company: Monument Re Group
+  board: monument-re-insurance
 - company: Raw group
   board: raw-group
 - company: Saber Interactive

--- a/sources/rippling.yml
+++ b/sources/rippling.yml
@@ -7,6 +7,14 @@
   board: 3msservicesllc
 - company: 11:FS Group Ltd
   board: 11fs-group-ltd
+- company: Beehive Industries
+  board: beehive-industries
+- company: Compass Mining
+  board: compass-mining
+- company: Drive Social Media
+  board: drivesocialmedia
+- company: D-Wave Quantum
+  board: d-wave-quantum
 - company: Kevel
   board: kevel-careers
 - company: Klir
@@ -51,6 +59,8 @@
   board: sbdo-pm-holdings-pty-ltd
 - company: Forbes Advisor
   board: forbes-advisor
+- company: Tixr
+  board: tixr
 - company: U.S. Department of the Treasury
   board: ihi-terrasun-solutions-inc
 - company: Echelon Front

--- a/sources/workable.yml
+++ b/sources/workable.yml
@@ -19,6 +19,8 @@
   board: bestex-research
 - company: Board of Innovation
   board: boardofinnovation
+- company: Botrista
+  board: botrista
 - company: Burq
   board: burq
 - company: Cause and FX

--- a/sources/workday.yml
+++ b/sources/workday.yml
@@ -1,6 +1,8 @@
 # workday boards. Provider is the filename; each entry is company + board.
 # board = platform-specific id (see internal/sources/workday.go).
 
+- company: Carbon Health
+  board: carbonhealth.wd1.myworkdayjobs.com/Careers
 - company: Equifax
   board: equifax.wd5.myworkdayjobs.com/External
 - company: Fugro


### PR DESCRIPTION
Discovery-mined the startup.jobs company directory (3,193 distinct companies), resolved each genuinely-new company to its real first-party ATS, and live-validated (>0 jobs) before adding.

| company | ATS | board | jobs |
|---|---|---|---|
| D-Wave Quantum | rippling | d-wave-quantum | 68 |
| Beehive Industries | rippling | beehive-industries | 58 |
| Drive Social Media | rippling | drivesocialmedia | 19 |
| Monument Re Group | personio | monument-re-insurance | 14 |
| Tixr | rippling | tixr | 10 |
| Botrista | workable | botrista | 9 |
| Office Ally | greenhouse | officeally | 8 |
| Compass Mining | rippling | compass-mining | 4 |
| Triveni Bio | lever | trivenibio | 3 |
| Carbon Health | workday | carbonhealth.wd1.myworkdayjobs.com/Careers | live |

**Key finding:** even 'new' candidates were ~80% already covered once resolved by ATS token rather than company name — freehire's ATS coverage is near-complete, so aggregators like startup.jobs add little. `go test ./internal/sources/` green.