### PR TITLE
feat(match): coverage meter + quiet checklist for ATS requirements view

### DIFF
--- a/web/src/lib/components/MatchAnalysisFull.svelte
+++ b/web/src/lib/components/MatchAnalysisFull.svelte
@@ -77,12 +77,16 @@
     analysis?.requirement_match?.length ? analysis.requirement_match : stream.requirements,
   );
   // Coverage tally for the ATS-view header: covered folds in synonym-only matches (both are
-  // positive, matching the hero's count), `addit` is the fixable near-miss, `gap` the genuine miss.
+  // positive, matching the hero's count), `addit` is the fixable near-miss, `gap` the genuine
+  // miss. `synonym` is a sub-count of covered, surfaced as a legend note on the coverage meter.
   const reqTally = $derived.by(() => {
-    const t = { covered: 0, addit: 0, gap: 0 };
+    const t = { covered: 0, synonym: 0, addit: 0, gap: 0 };
     for (const r of requirements) {
-      if (r.status === 'covered' || r.status === 'synonym-only') t.covered++;
-      else if (r.status === 'missing-have') t.addit++;
+      if (r.status === 'covered') t.covered++;
+      else if (r.status === 'synonym-only') {
+        t.covered++;
+        t.synonym++;
+      } else if (r.status === 'missing-have') t.addit++;
       else if (r.status === 'missing-gap') t.gap++;
     }
     return t;
@@ -96,6 +100,7 @@
   const coveredReqs = $derived(
     requirements.filter((r) => r.status === 'covered' || r.status === 'synonym-only'),
   );
+  const reqTotal = $derived(reqTally.covered + reqTally.addit + reqTally.gap);
 
   function start() {
     stop();
@@ -405,56 +410,79 @@
 
         <!-- ATS requirements: a light multi-column ledger with a coverage tally, so 29 terse
              rows read as a scannable matrix instead of a boxed-in tower. -->
-        <section class="flex flex-col gap-4">
-          <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1.5">
+        <section class="flex flex-col gap-5">
+          <!-- Coverage meter: the plain text tally becomes a segmented bar, so the
+               covered/gap split reads at a glance instead of as three numbers. -->
+          <div class="flex flex-col gap-2.5">
             <h2 class="{headingClass} text-muted-foreground">Requirements · ATS view</h2>
-            <div class="flex items-center gap-3 text-xs font-medium tabular-nums">
-              {#if reqTally.covered}<span class="text-brand-strong">{reqTally.covered} covered</span>{/if}
-              {#if reqTally.addit}<span class="text-amber-600 dark:text-amber-500">{reqTally.addit} to add</span>{/if}
-              {#if reqTally.gap}<span class="text-destructive">{reqTally.gap} gap</span>{/if}
-            </div>
+            {#if reqTotal}
+              <div class="flex items-baseline gap-2">
+                <span class="text-xl font-bold tabular-nums leading-none"
+                  >{reqTally.covered}<span class="font-medium text-muted-foreground">/{reqTotal}</span></span
+                >
+                <span class="text-sm text-muted-foreground">requirements covered</span>
+              </div>
+              <div class="flex h-2 overflow-hidden rounded-full bg-secondary">
+                {#if reqTally.covered}<div class="fit-meter h-full bg-brand" style="width: {(reqTally.covered / reqTotal) * 100}%"></div>{/if}
+                {#if reqTally.addit}<div class="fit-meter h-full bg-amber-500" style="width: {(reqTally.addit / reqTotal) * 100}%"></div>{/if}
+                {#if reqTally.gap}<div class="fit-meter h-full bg-destructive" style="width: {(reqTally.gap / reqTotal) * 100}%"></div>{/if}
+              </div>
+              <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                {#if reqTally.covered}<span class="flex items-center gap-1.5"><span class="size-2 rounded-full bg-brand"></span>{reqTally.covered} covered</span>{/if}
+                {#if reqTally.addit}<span class="flex items-center gap-1.5"><span class="size-2 rounded-full bg-amber-500"></span>{reqTally.addit} to add</span>{/if}
+                {#if reqTally.gap}<span class="flex items-center gap-1.5"><span class="size-2 rounded-full bg-destructive"></span>{reqTally.gap} gap</span>{/if}
+                {#if reqTally.synonym}<span class="flex items-center gap-1.5"><span class="size-2 rounded-full border border-dotted border-brand-strong"></span>{reqTally.synonym} via synonym</span>{/if}
+              </div>
+            {/if}
           </div>
+
           <!-- Needs attention: the near-misses + genuine gaps pulled out and
                highlighted, so the few misses are seen at a glance instead of hunted
-               for in the covered ledger. -->
+               for in the covered ledger. A tone-coloured rule + label carries the
+               status, replacing the repeated pills. -->
           {#if attentionReqs.length}
             <div class="rounded-xl border border-destructive/25 bg-destructive/5 p-4">
-              <h3 class="mb-2.5 text-[0.7rem] font-semibold uppercase tracking-wider text-destructive/90">
-                Needs attention
+              <h3 class="mb-2 text-[0.7rem] font-semibold uppercase tracking-wider text-destructive/90">
+                Needs attention · {attentionReqs.length}
               </h3>
               <ul class={['grid gap-x-10 gap-y-0.5', !stacked && 'sm:grid-cols-2']}>
                 {#each attentionReqs as r, i (i)}
                   {@const meta = requirementStatusMeta(r.status)}
-                  <li class="flex items-start justify-between gap-3 py-1.5">
-                    <span class="min-w-0 text-sm font-medium leading-snug text-foreground">{r.text}</span>
-                    <span class="mt-px flex shrink-0 items-center gap-2">
-                      {#if r.priority && r.priority.toLowerCase() !== 'required'}
-                        <span class="text-[0.6rem] font-medium lowercase tracking-wide text-muted-foreground/70">{r.priority}</span>
-                      {/if}
-                      <span class="rounded-full border px-2 py-0.5 text-[0.7rem] font-semibold {toneChip[meta.tone]}">{meta.label}</span>
-                    </span>
+                  <li class="flex items-center gap-2.5 py-1.5">
+                    <span class="h-4 w-[3px] shrink-0 rounded-full {toneBar[meta.tone]}"></span>
+                    <span class="min-w-0 flex-1 text-sm font-medium leading-snug text-foreground">{r.text}</span>
+                    {#if r.priority && r.priority.toLowerCase() !== 'required'}
+                      <span class="shrink-0 text-[0.6rem] font-medium lowercase tracking-wide text-muted-foreground/70">{r.priority}</span>
+                    {/if}
+                    <span class="shrink-0 text-xs font-semibold {toneText[meta.tone]}">{meta.label}</span>
                   </li>
                 {/each}
               </ul>
             </div>
           {/if}
 
-          <!-- Covered ledger: text is left-aligned across every row; the `preferred`
-               qualifier sits on the right by the chip so it never shifts the text. -->
-          <ul class={['grid gap-x-10', !stacked && 'sm:grid-cols-2 xl:grid-cols-3']}>
-            {#each coveredReqs as r, i (i)}
-              {@const meta = requirementStatusMeta(r.status)}
-              <li class="flex items-start justify-between gap-3 border-b border-border/60 py-2">
-                <span class="min-w-0 text-sm leading-snug">{r.text}</span>
-                <span class="mt-px flex shrink-0 items-center gap-2">
-                  {#if r.priority && r.priority.toLowerCase() !== 'required'}
-                    <span class="text-[0.6rem] font-medium lowercase tracking-wide text-muted-foreground/60">{r.priority}</span>
-                  {/if}
-                  <span class="rounded-full border px-2 py-0.5 text-[0.7rem] font-semibold {toneChip[meta.tone]}">{meta.label}</span>
-                </span>
-              </li>
-            {/each}
-          </ul>
+          <!-- Covered ledger: a quiet checklist — a tone glyph (✓ / ≈ for a synonym
+               match) carries the status, so 20+ rows read as a scannable matrix
+               instead of a wall of identical pills. `preferred` sits on the right. -->
+          {#if coveredReqs.length}
+            <div class="flex flex-col gap-2.5">
+              <h3 class="text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                Covered · {reqTally.covered}
+              </h3>
+              <ul class={['grid gap-x-10', !stacked && 'sm:grid-cols-2 xl:grid-cols-3']}>
+                {#each coveredReqs as r, i (i)}
+                  {@const syn = r.status === 'synonym-only'}
+                  <li class="flex items-baseline gap-2.5 border-b border-border/60 py-2">
+                    <span class="shrink-0 text-xs leading-snug {syn ? 'text-muted-foreground' : 'text-brand-strong'}">{syn ? '≈' : '✓'}</span>
+                    <span class={['min-w-0 flex-1 text-sm leading-snug', syn && 'border-b border-dotted border-brand-strong/50']}>{r.text}</span>
+                    {#if r.priority && r.priority.toLowerCase() !== 'required'}
+                      <span class="shrink-0 text-[0.6rem] font-medium lowercase tracking-wide text-muted-foreground/60">{r.priority}</span>
+                    {/if}
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
         </section>
       </div>
 


### PR DESCRIPTION
## What

Redesigns the **Requirements · ATS view** section on `/match` (verdict view). The old layout rendered one status pill per requirement — 20+ identical green **Covered** pills that drowned out the handful of real gaps.

New layout (Direction ①, "meter + quiet checklist"):

- **Coverage meter** — a segmented bar (covered / to-add / gap) with a big `covered/total` figure and a legend, incl. a `via synonym` note. Replaces the three-number text tally. Reuses the existing `fit-meter` sweep animation.
- **Needs attention** — a thin tone-coloured rule + a text status label (`Gap` / `Add it`) instead of a pill; colours come from the existing `toneBar`/`toneText` maps. Header now carries a count.
- **Covered ledger** — a quiet checklist: a `✓` (or `≈` for a `synonym-only` match, with a dotted underline) glyph carries the status; `preferred` stays on the right. No more pill-per-row.

## Notes

- `reqTally` gains a `synonym` sub-count (folded into `covered`, surfaced only in the legend).
- The meter denominator is `covered + addit + gap` (new `reqTotal` derived) rather than `requirements.length`, so an unknown/neutral status can't skew the percentages — the three known segments always sum to 100%.
- Purely presentational; no API or contract change.

## Verification

- `svelte-check` — 0 errors.
- `matchAnalysis.test.ts` — 7/7 pass.
- Design validated against an approved standalone mockup in both light and dark themes.