### PR TITLE
feat(companies): Meili-backed ranked company search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ node_modules/
 /notify
 /recount-companies
 /reindex
+/reindex-companies
 /reslug
 /rollup-facets
 /rollup-stats

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ cmd/tg-ingest/main.go      Telegram crawl worker
 cmd/tg-extract/main.go     LLM-extracts Telegram vacancies
 cmd/liveness/main.go       URL-probes orphan jobs, closes dead ones
 cmd/reindex/main.go        rebuilds the Meilisearch jobs index
+cmd/reindex-companies/main.go  rebuilds the Meilisearch companies index (ranked company search behind GET /api/v1/companies)
 cmd/rollup-stats/main.go   recomputes the job_daily_stats rollup
 cmd/rollup-facets/main.go  recomputes the insights_facet_stats snapshot (/open facets)
 cmd/rollup-company/main.go recomputes insights_company_stats + insights_company_growth (per-company hiring-signal rollups; the latter backs GET /insights/companies)
@@ -94,6 +95,7 @@ go run ./cmd/backfill-company-names [--dry-run]  # resolve real names for slug-n
 go run ./cmd/rollup-stats                  # recompute job_daily_stats (run-once, cron ~every 3h)
 go run ./cmd/rollup-facets                 # + MEILI_URL/MEILI_MASTER_KEY — recompute insights_facet_stats (run-once, cron ~daily)
 go run ./cmd/rollup-company                 # recompute insights_company_stats + insights_company_growth (run-once, cron ~daily)
+go run ./cmd/reindex-companies             # + MEILI_URL/MEILI_MASTER_KEY — rebuild the companies search index (run-once, cron ~daily; own flock, NOT stacked with make reindex)
 ```
 
 For the full architecture and conventions, see the **module files** below. Each module is self-contained and can be read independently.

--- a/cmd/reindex-companies/main.go
+++ b/cmd/reindex-companies/main.go
@@ -1,0 +1,115 @@
+// Command reindex-companies rebuilds the Meilisearch companies index from Postgres.
+// It streams every hiring company (job_count > 0) into a fresh index and atomically
+// swaps it in (see search.CompanyRebuild), then exits — run it on a schedule (cron),
+// on its own flock, and never stacked with the jobs reindex on the same host (a swap
+// transiently holds both the old and new index, ~2x that index's disk). Building this
+// index never touches the jobs index, so jobs search cannot regress.
+//
+// Indexing is a full swap-rebuild: the live index keeps serving until the single
+// atomic swap, and re-runs are safe (the rebuild index always starts empty).
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/search"
+	"github.com/strelov1/freehire/internal/worker"
+)
+
+// reindexBatchSize bounds how many companies are read from Postgres and pushed to
+// Meilisearch per keyset round. Companies are a small, slow-moving directory, so a
+// modest batch amortizes the round-trip without holding much in memory.
+const reindexBatchSize = 2000
+
+func main() { worker.Main(run) }
+
+func run() int {
+	ctx, cfg, pool, cleanup, err := worker.Bootstrap(context.Background())
+	if err != nil {
+		log.Printf("database: %v", err)
+		return 1
+	}
+	defer cleanup()
+
+	// Bootstrap owns config + pool, so the required-config check lands just after the
+	// pool opens; the connect is cheap and cleanup closes it on this early return.
+	if cfg.MeiliKey == "" {
+		log.Print("config: MEILI_MASTER_KEY is required")
+		return 1
+	}
+
+	client := search.NewClient(cfg.MeiliURL, cfg.MeiliKey)
+	reader := &queriesReader{q: db.New(pool)}
+
+	indexed, err := reindexCompanies(ctx, reader, client.NewCompanyRebuild(), reindexBatchSize)
+	if err != nil {
+		log.Printf("reindex-companies: %v", err)
+		return 1
+	}
+	log.Printf("reindex-companies done: indexed=%d", indexed)
+	return 0
+}
+
+// companyReader pages hiring companies by keyset, so reindexCompanies' scan loop is
+// unit-testable with a fake in place of the Postgres-backed queriesReader.
+type companyReader interface {
+	Page(ctx context.Context, afterSlug string, limit int32) ([]db.Company, error)
+}
+
+// queriesReader adapts *db.Queries to companyReader via ListCompaniesForReindex.
+type queriesReader struct{ q *db.Queries }
+
+func (r *queriesReader) Page(ctx context.Context, afterSlug string, limit int32) ([]db.Company, error) {
+	return r.q.ListCompaniesForReindex(ctx, db.ListCompaniesForReindexParams{
+		AfterSlug: afterSlug,
+		BatchSize: limit,
+	})
+}
+
+// companyRebuilder is the subset of search.CompanyRebuild the reindex drives — a
+// fresh-index build session that swaps into production atomically on Promote.
+type companyRebuilder interface {
+	Prepare(ctx context.Context) error
+	Push(ctx context.Context, docs []search.CompanyDocument) error
+	Promote(ctx context.Context) error
+}
+
+// reindexCompanies streams every hiring company into a fresh index and swaps it in.
+// It pages by keyset (slug > last seen), so rows inserted or re-ordered mid-run are
+// neither skipped nor repeated, mapping each row through search.FromCompany. A short
+// page (fewer than batchSize) ends the scan. Prepare/Promote bracket the stream so an
+// emptied catalogue still swaps in a clean, empty index rather than leaving a stale one.
+func reindexCompanies(ctx context.Context, r companyReader, b companyRebuilder, batchSize int32) (int, error) {
+	if err := b.Prepare(ctx); err != nil {
+		return 0, err
+	}
+	var indexed int
+	afterSlug := ""
+	for {
+		rows, err := r.Page(ctx, afterSlug, batchSize)
+		if err != nil {
+			return indexed, err
+		}
+		if len(rows) == 0 {
+			break
+		}
+		docs := make([]search.CompanyDocument, len(rows))
+		for i, row := range rows {
+			docs[i] = search.FromCompany(row)
+		}
+		if err := b.Push(ctx, docs); err != nil {
+			return indexed, err
+		}
+		indexed += len(docs)
+		afterSlug = rows[len(rows)-1].Slug
+		if int32(len(rows)) < batchSize {
+			break
+		}
+	}
+	if err := b.Promote(ctx); err != nil {
+		return indexed, err
+	}
+	return indexed, nil
+}

--- a/cmd/reindex-companies/reindex_test.go
+++ b/cmd/reindex-companies/reindex_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/strelov1/freehire/internal/db"
+	"github.com/strelov1/freehire/internal/search"
+)
+
+// fakeReader serves companies in keyset pages: each Page returns rows with slug >
+// afterSlug, capped at limit, over the pre-sorted input.
+type fakeReader struct{ rows []db.Company }
+
+func (f *fakeReader) Page(_ context.Context, afterSlug string, limit int32) ([]db.Company, error) {
+	var out []db.Company
+	for _, r := range f.rows {
+		if r.Slug > afterSlug {
+			out = append(out, r)
+			if int32(len(out)) == limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// fakeRebuild records the documents pushed and the lifecycle calls.
+type fakeRebuild struct {
+	prepared, promoted int
+	pushed             []search.CompanyDocument
+}
+
+func (f *fakeRebuild) Prepare(context.Context) error { f.prepared++; return nil }
+func (f *fakeRebuild) Push(_ context.Context, docs []search.CompanyDocument) error {
+	f.pushed = append(f.pushed, docs...)
+	return nil
+}
+func (f *fakeRebuild) Promote(context.Context) error { f.promoted++; return nil }
+
+func TestReindexCompanies_StreamsAllRowsAcrossPages(t *testing.T) {
+	rows := []db.Company{
+		{Slug: "acme", Name: "Acme", JobCount: 3},
+		{Slug: "bravo", Name: "Bravo", JobCount: 1},
+		{Slug: "cirrus", Name: "Cirrus", JobCount: 9},
+	}
+	r := &fakeReader{rows: rows}
+	b := &fakeRebuild{}
+
+	// batchSize 2 forces multiple keyset pages (2 + 1).
+	indexed, err := reindexCompanies(context.Background(), r, b, 2)
+	if err != nil {
+		t.Fatalf("reindexCompanies: %v", err)
+	}
+	if indexed != 3 {
+		t.Errorf("indexed = %d, want 3", indexed)
+	}
+	if b.prepared != 1 || b.promoted != 1 {
+		t.Errorf("lifecycle: prepared=%d promoted=%d, want 1/1", b.prepared, b.promoted)
+	}
+	if len(b.pushed) != 3 {
+		t.Fatalf("pushed %d docs, want 3", len(b.pushed))
+	}
+	for i, want := range []string{"acme", "bravo", "cirrus"} {
+		if b.pushed[i].Slug != want {
+			t.Errorf("pushed[%d].Slug = %q, want %q (rows mapped via FromCompany in keyset order)", i, b.pushed[i].Slug, want)
+		}
+	}
+}
+
+func TestReindexCompanies_EmptyPromotesEmptyIndex(t *testing.T) {
+	b := &fakeRebuild{}
+	indexed, err := reindexCompanies(context.Background(), &fakeReader{}, b, 2)
+	if err != nil {
+		t.Fatalf("reindexCompanies: %v", err)
+	}
+	if indexed != 0 {
+		t.Errorf("indexed = %d, want 0", indexed)
+	}
+	// Even with no companies the fresh (empty) index is prepared and promoted, so an
+	// emptied catalogue swaps in cleanly rather than leaving a stale index live.
+	if b.prepared != 1 || b.promoted != 1 {
+		t.Errorf("lifecycle: prepared=%d promoted=%d, want 1/1", b.prepared, b.promoted)
+	}
+}

--- a/internal/db/companies.sql.go
+++ b/internal/db/companies.sql.go
@@ -364,6 +364,73 @@ func (q *Queries) ListCompanies(ctx context.Context, arg ListCompaniesParams) ([
 	return items, nil
 }
 
+const listCompaniesForReindex = `-- name: ListCompaniesForReindex :many
+SELECT slug, name, created_at, updated_at, collections, job_count, regions, countries, domains, company_types, company_sizes, industries, year_founded, employee_count, hq_country, organization_type, tagline, company_info, is_reference, company_info_at, remote_regions, yc_batch, yc_status, yc_stage, yc_flags, maturity, subindustry
+FROM companies
+WHERE slug > $1 AND job_count > 0
+ORDER BY slug
+LIMIT $2
+`
+
+type ListCompaniesForReindexParams struct {
+	AfterSlug string `json:"after_slug"`
+	BatchSize int32  `json:"batch_size"`
+}
+
+// Keyset page of hiring companies (job_count > 0) for the companies search reindex,
+// cursored by the slug primary key (first chunk keyed by the empty string, which
+// sorts before every slug). SELECT * so the row stays db.Company as columns grow and
+// search.FromCompany can map every facet. The job_count > 0 scope keeps the index to
+// companies that are actually hiring, matching the /companies list's hiring scope, and
+// rides companies_hiring_job_count_idx instead of scanning the full heap.
+func (q *Queries) ListCompaniesForReindex(ctx context.Context, arg ListCompaniesForReindexParams) ([]Company, error) {
+	rows, err := q.db.Query(ctx, listCompaniesForReindex, arg.AfterSlug, arg.BatchSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Company{}
+	for rows.Next() {
+		var i Company
+		if err := rows.Scan(
+			&i.Slug,
+			&i.Name,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.Collections,
+			&i.JobCount,
+			&i.Regions,
+			&i.Countries,
+			&i.Domains,
+			&i.CompanyTypes,
+			&i.CompanySizes,
+			&i.Industries,
+			&i.YearFounded,
+			&i.EmployeeCount,
+			&i.HqCountry,
+			&i.OrganizationType,
+			&i.Tagline,
+			&i.CompanyInfo,
+			&i.IsReference,
+			&i.CompanyInfoAt,
+			&i.RemoteRegions,
+			&i.YcBatch,
+			&i.YcStatus,
+			&i.YcStage,
+			&i.YcFlags,
+			&i.Maturity,
+			&i.Subindustry,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCompanyCollections = `-- name: ListCompanyCollections :many
 SELECT slug, collections
 FROM companies

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -629,6 +629,13 @@ type Querier interface {
 	// and company-info backfills; it also lets both reads ride companies_hiring_job_count_idx
 	// (partial index) instead of scanning the full 2.3 GB heap.
 	ListCompanies(ctx context.Context, arg ListCompaniesParams) ([]ListCompaniesRow, error)
+	// Keyset page of hiring companies (job_count > 0) for the companies search reindex,
+	// cursored by the slug primary key (first chunk keyed by the empty string, which
+	// sorts before every slug). SELECT * so the row stays db.Company as columns grow and
+	// search.FromCompany can map every facet. The job_count > 0 scope keeps the index to
+	// companies that are actually hiring, matching the /companies list's hiring scope, and
+	// rides companies_hiring_job_count_idx instead of scanning the full heap.
+	ListCompaniesForReindex(ctx context.Context, arg ListCompaniesForReindexParams) ([]Company, error)
 	// All companies with their current collection membership. cmd/import-collections
 	// reads this to know the existing company slugs (the match target) and each
 	// company's current tags (so it can reconcile only the tags it manages, leaving any

--- a/internal/db/queries/companies.sql
+++ b/internal/db/queries/companies.sql
@@ -88,6 +88,19 @@ WHERE slug > sqlc.arg(after_slug)
 ORDER BY slug
 LIMIT sqlc.arg(batch_size);
 
+-- name: ListCompaniesForReindex :many
+-- Keyset page of hiring companies (job_count > 0) for the companies search reindex,
+-- cursored by the slug primary key (first chunk keyed by the empty string, which
+-- sorts before every slug). SELECT * so the row stays db.Company as columns grow and
+-- search.FromCompany can map every facet. The job_count > 0 scope keeps the index to
+-- companies that are actually hiring, matching the /companies list's hiring scope, and
+-- rides companies_hiring_job_count_idx instead of scanning the full heap.
+SELECT *
+FROM companies
+WHERE slug > sqlc.arg(after_slug) AND job_count > 0
+ORDER BY slug
+LIMIT sqlc.arg(batch_size);
+
 -- name: CompanySitemapBoundaries :many
 -- The slug ending every full chunk of `chunk_size` companies (ordered by slug),
 -- excluding the final row, so the sitemap index can list each company sub-sitemap's

--- a/internal/handler/companies.go
+++ b/internal/handler/companies.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
+	"log"
 	"net/url"
 
 	"github.com/gofiber/fiber/v2"
@@ -9,7 +11,16 @@ import (
 
 	"github.com/strelov1/freehire/internal/db"
 	"github.com/strelov1/freehire/internal/jobview"
+	"github.com/strelov1/freehire/internal/search"
 )
+
+// companySearcher is the company-search backend the list handler depends on.
+// *search.Client satisfies it; the unit tests inject a fake. A nil companySearcher
+// (Meilisearch unconfigured) routes every request to the Postgres path, as does any
+// search error — see ListCompanies.
+type companySearcher interface {
+	SearchCompanies(ctx context.Context, p search.CompanySearchParams) (search.CompanyResult, error)
+}
 
 // companyDetailResponse is the public shape of a company together with a page of
 // its jobs. Its Jobs field is []jobview.Job, not []db.Job, so the internal job
@@ -113,6 +124,21 @@ func (a *API) ListCompanies(c *fiber.Ctx) error {
 	ycFlags := facetValues(vals, "yc_flags")
 	maturity := facetValues(vals, "maturity")
 	subindustries := facetValues(vals, "subindustries")
+
+	// Company search is served by the Meilisearch companies index when configured and
+	// a filter (q or any facet) is present — it gives relevance-first, typo-tolerant
+	// ranking with job_count as the tiebreaker. The unfiltered catalogue keeps the
+	// Postgres ordering (job_count DESC, name) and its O(1) total estimate, so it is
+	// deliberately not routed to Meili. On ANY Meili error the request falls through to
+	// the Postgres substring path below, so /companies never depends on Meili being up.
+	if a.companySearch != nil && isCompanyFilter(search, collections, regions, countries,
+		domains, companyTypes, companySizes, remoteRegions, ycBatch, ycStatus, ycStage, ycFlags, maturity, subindustries) {
+		rows, total, err := a.companyHitsViaMeili(c.Context(), search, vals, limit, offset)
+		if err == nil {
+			return listResponse(c, rows, total, limit, offset)
+		}
+		log.Printf("companies: meili search fell back to postgres (q=%q): %v", search, err)
+	}
 
 	companies, err := a.queries.ListCompanies(c.Context(), db.ListCompaniesParams{
 		Search:        search,
@@ -256,4 +282,51 @@ func (a *API) GetCompany(c *fiber.Ctx) error {
 		Jobs:              views,
 		ReferralAvailable: referralAvailable,
 	}})
+}
+
+// companyHitsViaMeili runs the ranked company search and projects each hit back onto
+// the db.ListCompaniesRow wire shape, so the Meili path is byte-for-byte compatible
+// with the Postgres path. meta.total is Meilisearch's estimated filtered total, which
+// backs list pagination exactly as CountCompanies does on the Postgres path.
+func (a *API) companyHitsViaMeili(ctx context.Context, query string, vals url.Values, limit, offset int) ([]db.ListCompaniesRow, int64, error) {
+	res, err := a.companySearch.SearchCompanies(ctx, search.CompanySearchParams{
+		Query:  query,
+		Filter: search.CompanyFilterFromValues(vals),
+		Limit:  limit,
+		Offset: offset,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	rows := make([]db.ListCompaniesRow, len(res.Hits))
+	for i, h := range res.Hits {
+		rows[i] = companyRowFromDoc(h)
+	}
+	return rows, res.Total, nil
+}
+
+// companyRowFromDoc projects a company search document onto the list wire shape,
+// re-wrapping the unwrapped scalar strings into pgtype.Text (empty → NULL) so the
+// response matches the Postgres path exactly. An absent industries array normalizes
+// to an empty slice so it serializes as [] like the Postgres '{}', not null.
+func companyRowFromDoc(d search.CompanyDocument) db.ListCompaniesRow {
+	industries := d.Industries
+	if industries == nil {
+		industries = []string{}
+	}
+	return db.ListCompaniesRow{
+		Slug:       d.Slug,
+		Name:       d.Name,
+		JobCount:   d.JobCount,
+		Tagline:    pgText(d.Tagline),
+		Industries: industries,
+		HqCountry:  pgText(d.HqCountry),
+	}
+}
+
+// pgText wraps a plain string as a pgtype.Text, treating the empty string as NULL —
+// the inverse of the FromCompany unwrap, so a round-tripped NULL scalar renders as
+// JSON null exactly as the Postgres row would.
+func pgText(s string) pgtype.Text {
+	return pgtype.Text{String: s, Valid: s != ""}
 }

--- a/internal/handler/companies_integration_test.go
+++ b/internal/handler/companies_integration_test.go
@@ -10,6 +10,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http/httptest"
 	"path/filepath"
@@ -133,6 +134,80 @@ func TestListCompaniesSearchEndpoint(t *testing.T) {
 			t.Errorf("full list: names=%v, want 3", names)
 		}
 	})
+}
+
+// TestListCompaniesMeiliFallback proves that when the companies searcher errors, the
+// list endpoint degrades to the Postgres substring path rather than surfacing the
+// error — so /companies gains no new failure point from the Meili routing.
+func TestListCompaniesMeiliFallback(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	for _, c := range []struct{ slug, name string }{
+		{"acme", "Acme Corp"}, {"acme-labs", "ACME Labs"}, {"globex", "Globex"},
+	} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO companies (slug, name, job_count) VALUES ($1, $2, 1)`, c.slug, c.name); err != nil {
+			t.Fatalf("seed %q: %v", c.slug, err)
+		}
+	}
+
+	// A searcher that always errors forces the fallback on every search request.
+	h := &API{pool: pool, queries: db.New(pool), companySearch: &fakeCompanySearcher{err: errors.New("meili down")}}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/companies", h.ListCompanies)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/companies?q=acme", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (fallback should not error): body %s", resp.StatusCode, body)
+	}
+	var body struct {
+		Data []struct {
+			Name string `json:"name"`
+		} `json:"data"`
+		Meta struct {
+			Total float64 `json:"total"`
+		} `json:"meta"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data) != 2 || body.Meta.Total != 2 {
+		t.Errorf("fallback result = %d rows total=%v, want the 2 Postgres ACME matches", len(body.Data), body.Meta.Total)
+	}
+}
+
+// TestListCompaniesUnfilteredSkipsMeili proves the unfiltered catalogue is served by
+// Postgres (its ordering + O(1) estimate), never routed to Meilisearch, even when a
+// company searcher is wired.
+func TestListCompaniesUnfilteredSkipsMeili(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO companies (slug, name, job_count) VALUES ('acme', 'Acme', 1)`); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	fake := &fakeCompanySearcher{}
+	h := &API{pool: pool, queries: db.New(pool), companySearch: fake}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/api/v1/companies", h.ListCompanies)
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/v1/companies", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if fake.called {
+		t.Error("the unfiltered catalogue must not route to Meilisearch")
+	}
 }
 
 func TestListCompaniesFacetFilterEndpoint(t *testing.T) {

--- a/internal/handler/companies_search_test.go
+++ b/internal/handler/companies_search_test.go
@@ -1,0 +1,106 @@
+package handler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/search"
+)
+
+type fakeCompanySearcher struct {
+	got    search.CompanySearchParams
+	called bool
+	res    search.CompanyResult
+	err    error
+}
+
+func (f *fakeCompanySearcher) SearchCompanies(_ context.Context, p search.CompanySearchParams) (search.CompanyResult, error) {
+	f.called = true
+	f.got = p
+	return f.res, f.err
+}
+
+// companyApp wires only the company searcher (no Postgres), so the Meili routing and
+// projection can be exercised without a database — the branches that fall through to
+// Postgres are covered by the integration tests.
+func companyApp(cs companySearcher) *fiber.App {
+	h := &API{companySearch: cs}
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Get("/companies", h.ListCompanies)
+	return app
+}
+
+// hasCompanyGroup reports whether the AND-of-ORs filter contains a group holding
+// the given fragment.
+func hasCompanyGroup(gs [][]string, fragment string) bool {
+	for _, g := range gs {
+		for _, f := range g {
+			if f == fragment {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func TestListCompanies_QueryRoutesToMeiliPreservingRankOrder(t *testing.T) {
+	// The handler relays Meilisearch's relevance ranking verbatim — the exact-name
+	// match "arb" leads even though higher-volume substring matches follow.
+	fake := &fakeCompanySearcher{res: search.CompanyResult{
+		Hits: []search.CompanyDocument{
+			{Slug: "arb", Name: "arb", JobCount: 2},
+			{Slug: "arbor", Name: "Arbor", JobCount: 40},
+			{Slug: "carbon", Name: "Carbon", JobCount: 99},
+		},
+		Total: 3,
+	}}
+	app := companyApp(fake)
+
+	status, body := doGet(t, app, "/companies?q=arb")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if fake.got.Query != "arb" {
+		t.Errorf("query passed to Meili = %q, want arb", fake.got.Query)
+	}
+	data, _ := body["data"].([]any)
+	if len(data) != 3 {
+		t.Fatalf("data len = %d, want 3", len(data))
+	}
+	first, _ := data[0].(map[string]any)
+	if first["slug"] != "arb" {
+		t.Errorf("first result slug = %v, want arb (handler must preserve Meili rank order)", first["slug"])
+	}
+	// The projected row keeps the ListCompaniesRow wire shape.
+	if _, ok := first["job_count"]; !ok {
+		t.Errorf("projected row missing job_count: %v", first)
+	}
+	meta, _ := body["meta"].(map[string]any)
+	if got, _ := meta["total"].(float64); got != 3 {
+		t.Errorf("meta.total = %v, want 3 (from Meili estimatedTotalHits)", meta["total"])
+	}
+}
+
+func TestListCompanies_FacetsBuildMeiliFilterAndRoute(t *testing.T) {
+	// A facet-only request (no q) still routes to Meili and each facet ANDs as its own
+	// OR-group, with the param→attribute mapping applied (company_type → company_types).
+	fake := &fakeCompanySearcher{}
+	app := companyApp(fake)
+
+	status, _ := doGet(t, app, "/companies?regions=europe&company_type=startup")
+	if status != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if !fake.called {
+		t.Fatal("a facet request should route to Meili")
+	}
+	gs, ok := fake.got.Filter.([][]string)
+	if !ok {
+		t.Fatalf("filter = %T, want [][]string", fake.got.Filter)
+	}
+	if !hasCompanyGroup(gs, `regions = "europe"`) || !hasCompanyGroup(gs, `company_types = "startup"`) {
+		t.Errorf("filter %v missing expected facet groups", gs)
+	}
+}

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -89,6 +89,12 @@ type API struct {
 	// search is the job-search backend. Nil when Meilisearch is unconfigured —
 	// the search endpoint then reports 503 and the rest of the API is unaffected.
 	search searcher
+	// companySearch is the company-search backend backing GET /api/v1/companies,
+	// kept separate from `search` so the companies index stays fully decoupled from
+	// jobs search. Nil when Meilisearch is unconfigured, or on any query error, the
+	// list falls back to the Postgres substring path so /companies never depends on
+	// Meilisearch being up.
+	companySearch companySearcher
 	// facets is the analytics (facet-distribution) backend — the same Meilisearch
 	// client viewed through a narrower interface, kept separate from search so the
 	// two concerns stay decoupled. Nil when unconfigured (endpoint reports 503).
@@ -316,6 +322,7 @@ func Register(app *fiber.App, cfg Config) {
 	if cfg.Search != nil {
 		a.search = cfg.Search
 		a.facets = cfg.Search
+		a.companySearch = cfg.Search
 	}
 
 	// Referral notifications reuse the SES email transport (email is always present) and

--- a/internal/search/company.go
+++ b/internal/search/company.go
@@ -1,0 +1,292 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/meilisearch/meilisearch-go"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+const (
+	// companyIndexUID is the production companies search index — separate from the
+	// jobs index, so building it cannot regress jobs search. companyRebuildUID is the
+	// throwaway index a full rebuild streams into before the atomic swap (see
+	// CompanyRebuild). companyPrimaryKey is `slug` (the natural company key), not the
+	// jobs index's numeric `id`, so companies get their own create/ensure path rather
+	// than sharing the id-keyed helpers.
+	companyIndexUID   = "companies"
+	companyRebuildUID = "companies_rebuild"
+	companyPrimaryKey = "slug"
+)
+
+// CompanyDocument is a company as stored in the Meilisearch companies index,
+// separate from the jobs index. It is keyed by `slug` (the natural company key,
+// used as this index's primary key). It carries both the fields the list endpoint
+// serves — `name`, `tagline`, `industries`, `hq_country`, `job_count` (the
+// db.ListCompaniesRow wire shape) — and the denormalized facet arrays/scalars the
+// list filters on. Meilisearch returns the whole document on a hit regardless of
+// which attributes are searchable/filterable, so the handler projects a hit back
+// onto db.ListCompaniesRow and the response contract is unchanged.
+//
+// pgtype scalars are unwrapped to plain strings (empty when NULL): a Meili document
+// is plain JSON, and the handler re-wraps them into pgtype.Text when projecting the
+// response so byte-for-byte parity with the Postgres path is preserved.
+type CompanyDocument struct {
+	Slug          string   `json:"slug"`
+	Name          string   `json:"name"`
+	Tagline       string   `json:"tagline"`
+	Industries    []string `json:"industries"`
+	HqCountry     string   `json:"hq_country"`
+	JobCount      int32    `json:"job_count"`
+	Collections   []string `json:"collections"`
+	Regions       []string `json:"regions"`
+	Countries     []string `json:"countries"`
+	Domains       []string `json:"domains"`
+	CompanyTypes  []string `json:"company_types"`
+	CompanySizes  []string `json:"company_sizes"`
+	RemoteRegions []string `json:"remote_regions"`
+	YcBatch       []string `json:"yc_batch"`
+	YcStatus      []string `json:"yc_status"`
+	YcStage       []string `json:"yc_stage"`
+	YcFlags       []string `json:"yc_flags"`
+	Maturity      string   `json:"maturity"`
+	Subindustry   string   `json:"subindustry"`
+}
+
+// FromCompany maps a stored company row to its index document. The pgtype.Text
+// scalars (tagline, hq_country, maturity, subindustry) unwrap to their string
+// value — empty when NULL, since pgtype.Text's zero value has an empty String. The
+// facet arrays pass through as-is; an empty array simply matches no facet filter.
+func FromCompany(c db.Company) CompanyDocument {
+	return CompanyDocument{
+		Slug:          c.Slug,
+		Name:          c.Name,
+		Tagline:       c.Tagline.String,
+		Industries:    c.Industries,
+		HqCountry:     c.HqCountry.String,
+		JobCount:      c.JobCount,
+		Collections:   c.Collections,
+		Regions:       c.Regions,
+		Countries:     c.Countries,
+		Domains:       c.Domains,
+		CompanyTypes:  c.CompanyTypes,
+		CompanySizes:  c.CompanySizes,
+		RemoteRegions: c.RemoteRegions,
+		YcBatch:       c.YcBatch,
+		YcStatus:      c.YcStatus,
+		YcStage:       c.YcStage,
+		YcFlags:       c.YcFlags,
+		Maturity:      c.Maturity.String,
+		Subindustry:   c.Subindustry.String,
+	}
+}
+
+// companySettings is the companies index configuration. Search is relevance-first:
+// the default ranking rules (words → typo → proximity → attribute → exactness) put
+// an exact name match ahead of a mere substring, `sort` keeps an explicit sort
+// honoured, and `job_count:desc` is appended as the final tiebreaker so among
+// equally-relevant matches the most active company surfaces first — reproducing the
+// Postgres path's `job_count DESC` secondary order under a relevance primary.
+// Searchable attributes are ordered name → slug → tagline so `attribute` rank
+// favours a name hit. The facet arrays/scalars are filterable; `job_count` is
+// sortable so the tiebreaker rule can read it. The hiring scope (`job_count > 0`)
+// is enforced at index-build time (see reindex-companies), so no query filter is
+// needed for it.
+func companySettings() *meilisearch.Settings {
+	return &meilisearch.Settings{
+		SearchableAttributes: []string{"name", "slug", "tagline"},
+		FilterableAttributes: []string{
+			"collections", "regions", "countries", "domains",
+			"company_types", "company_sizes", "remote_regions",
+			"yc_batch", "yc_status", "yc_stage", "yc_flags",
+			"maturity", "subindustry",
+		},
+		SortableAttributes: []string{"job_count"},
+		RankingRules:       []string{"words", "sort", "typo", "proximity", "attribute", "exactness", "job_count:desc"},
+		Pagination:         &meilisearch.Pagination{MaxTotalHits: maxTotalHits},
+	}
+}
+
+// companyFacets maps each /companies facet query param to its index attribute, in a
+// fixed order so the built filter is deterministic. The array facets filter by
+// membership (Meili's `attr = "v"` matches an array containing v) and the scalar
+// facets (maturity/subindustry) by equality; both use the same Eq fragment. Note
+// the singular params company_type/company_size and plural subindustries map to the
+// plural columns and the scalar `subindustry` respectively, mirroring the Postgres
+// handler's param names.
+var companyFacets = []struct{ param, attr string }{
+	{"collections", "collections"},
+	{"regions", "regions"},
+	{"countries", "countries"},
+	{"domains", "domains"},
+	{"company_type", "company_types"},
+	{"company_size", "company_sizes"},
+	{"remote_regions", "remote_regions"},
+	{"yc_batch", "yc_batch"},
+	{"yc_status", "yc_status"},
+	{"yc_stage", "yc_stage"},
+	{"yc_flags", "yc_flags"},
+	{"maturity", "maturity"},
+	{"subindustries", "subindustry"},
+}
+
+// CompanyFilterFromValues turns the facet params of a /companies request into a
+// Meilisearch filter: values within one facet are ORed into a group, facets are
+// ANDed across groups. An absent facet adds no constraint; no facet at all yields
+// nil (no filter). A NULL scalar (empty maturity/subindustry in the document)
+// matches no value, since the fragment is an equality against the requested value.
+func CompanyFilterFromValues(v url.Values) any {
+	var g [][]string
+	for _, f := range companyFacets {
+		included := nonEmpty(v[f.param])
+		if len(included) == 0 {
+			continue
+		}
+		group := make([]string, len(included))
+		for i, val := range included {
+			group[i] = Eq(f.attr, val)
+		}
+		g = append(g, group)
+	}
+	return Filter(g...)
+}
+
+// CompanySearchParams is a company search request against the companies index.
+// Filter is the value built by CompanyFilterFromValues (nil for none).
+type CompanySearchParams struct {
+	Query  string
+	Filter any
+	Limit  int
+	Offset int
+}
+
+// CompanyResult holds the matched company documents and Meilisearch's estimated
+// total (the filtered count that backs the list's meta.total on the Meili path).
+type CompanyResult struct {
+	Hits  []CompanyDocument
+	Total int64
+}
+
+// SearchCompanies runs a ranked query against the companies index and decodes the
+// hits. The index binding is taken lazily from the shared manager, so this adds no
+// state to Client and never touches the jobs index fields. Error mapping mirrors
+// Search: a cancelled context re-raises the sentinel, and a Meili 400 (a malformed
+// filter from client input) maps to ErrBadQuery so the handler can render 400.
+func (c *Client) SearchCompanies(ctx context.Context, p CompanySearchParams) (CompanyResult, error) {
+	resp, err := c.manager.Index(companyIndexUID).SearchWithContext(ctx, p.Query, &meilisearch.SearchRequest{
+		Filter: p.Filter,
+		Limit:  int64(p.Limit),
+		Offset: int64(p.Offset),
+	})
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return CompanyResult{}, fmt.Errorf("search: company query: %w", ctxErr)
+		}
+		if isBadRequest(err) {
+			return CompanyResult{}, fmt.Errorf("search: company query: %w: %v", ErrBadQuery, err)
+		}
+		return CompanyResult{}, fmt.Errorf("search: company query: %w", err)
+	}
+	var hits []CompanyDocument
+	if err := resp.Hits.DecodeInto(&hits); err != nil {
+		return CompanyResult{}, fmt.Errorf("search: decode company hits: %w", err)
+	}
+	return CompanyResult{Hits: hits, Total: resp.EstimatedTotalHits}, nil
+}
+
+// CompanyRebuild is a fresh-index build session for a full companies reindex,
+// mirroring the jobs Rebuild's stream-then-swap approach but keyed by `slug` and
+// scoped to the companies index — it never references the jobs UIDs, so it cannot
+// disturb jobs search. Documents stream into the throwaway rebuild index (Push
+// enqueues without waiting so Meilisearch auto-batches), then Promote awaits the
+// pushes, atomically swaps the rebuild index over the live one, and drops the old.
+type CompanyRebuild struct {
+	c       *Client
+	rebuild meilisearch.IndexManager
+	tasks   []int64
+}
+
+// NewCompanyRebuild starts a full rebuild of the companies index.
+func (c *Client) NewCompanyRebuild() *CompanyRebuild { return &CompanyRebuild{c: c} }
+
+// Prepare ensures the live companies index exists (the swap in Promote needs both)
+// and creates a fresh, empty rebuild index with the companies settings, discarding
+// any leftover rebuild index from an aborted prior run.
+func (r *CompanyRebuild) Prepare(ctx context.Context) error {
+	if err := r.c.ensureCompanyIndex(ctx, r.c.manager.Index(companyIndexUID), companyIndexUID); err != nil {
+		return err
+	}
+	if err := r.c.dropIndex(ctx, companyRebuildUID); err != nil {
+		return err
+	}
+	r.rebuild = r.c.manager.Index(companyRebuildUID)
+	return r.c.ensureCompanyIndex(ctx, r.rebuild, companyRebuildUID)
+}
+
+// Push enqueues a batch into the rebuild index WITHOUT waiting for it to finish —
+// the task uid is kept and awaited in Promote, so Meilisearch auto-batches the
+// consecutive document tasks instead of indexing each in isolation.
+func (r *CompanyRebuild) Push(ctx context.Context, docs []CompanyDocument) error {
+	if len(docs) == 0 {
+		return nil
+	}
+	pk := companyPrimaryKey
+	task, err := r.rebuild.UpdateDocumentsWithContext(ctx, docs, &meilisearch.DocumentOptions{PrimaryKey: &pk})
+	if err != nil {
+		return fmt.Errorf("search: company rebuild push: %w", err)
+	}
+	r.tasks = append(r.tasks, task.TaskUID)
+	return nil
+}
+
+// Promote waits for every enqueued batch, atomically swaps the rebuild index over
+// the live companies index, and drops the now-old index. After this the live uid
+// serves the freshly built data.
+func (r *CompanyRebuild) Promote(ctx context.Context) error {
+	for _, uid := range r.tasks {
+		if err := r.c.awaitTask(ctx, r.rebuild, uid); err != nil {
+			return err
+		}
+	}
+	if err := r.c.swapIndexes(ctx, companyIndexUID, companyRebuildUID); err != nil {
+		return err
+	}
+	return r.c.dropIndex(ctx, companyRebuildUID)
+}
+
+// ensureCompanyIndex creates the named companies index (keyed by slug) if absent
+// and applies the companies settings. It is the slug-keyed counterpart to the jobs
+// ensure path, kept separate so the shared id-keyed helpers stay untouched.
+func (c *Client) ensureCompanyIndex(ctx context.Context, idx meilisearch.IndexManager, uid string) error {
+	if err := c.createCompanyIndex(ctx, uid); err != nil {
+		return err
+	}
+	st, err := idx.UpdateSettingsWithContext(ctx, companySettings())
+	if err != nil {
+		return fmt.Errorf("search: update company settings: %w", err)
+	}
+	return c.awaitTask(ctx, idx, st.TaskUID)
+}
+
+// createCompanyIndex creates the companies index (keyed by slug) if absent. An
+// already-existing index is the idempotent happy path, not a failure.
+func (c *Client) createCompanyIndex(ctx context.Context, uid string) error {
+	create, err := c.manager.CreateIndexWithContext(ctx, &meilisearch.IndexConfig{
+		Uid:        uid,
+		PrimaryKey: companyPrimaryKey,
+	})
+	if err != nil {
+		return fmt.Errorf("search: create company index: %w", err)
+	}
+	created, err := c.manager.WaitForTaskWithContext(ctx, create.TaskUID, taskPollInterval)
+	if err != nil {
+		return fmt.Errorf("search: await create company index: %w", err)
+	}
+	if created.Status == meilisearch.TaskStatusFailed && created.Error.Code != "index_already_exists" {
+		return fmt.Errorf("search: create company index failed: %s", created.Error.Message)
+	}
+	return nil
+}

--- a/internal/search/company_filter_test.go
+++ b/internal/search/company_filter_test.go
@@ -1,0 +1,110 @@
+package search
+
+import (
+	"net/url"
+	"testing"
+)
+
+// groups coerces the CompanyFilterFromValues result to [][]string (nil when no
+// filter), so tests can assert on the AND-of-ORs structure.
+func groups(t *testing.T, f any) [][]string {
+	t.Helper()
+	if f == nil {
+		return nil
+	}
+	g, ok := f.([][]string)
+	if !ok {
+		t.Fatalf("filter is %T, want [][]string", f)
+	}
+	return g
+}
+
+// hasGroup reports whether gs contains a group exactly equal to want (order of
+// fragments within the group matters; order of groups does not).
+func hasGroup(gs [][]string, want ...string) bool {
+	for _, g := range gs {
+		if len(g) != len(want) {
+			continue
+		}
+		eq := true
+		for i := range g {
+			if g[i] != want[i] {
+				eq = false
+				break
+			}
+		}
+		if eq {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCompanyFilterFromValues_NoFacetsIsNil(t *testing.T) {
+	if f := CompanyFilterFromValues(url.Values{}); f != nil {
+		t.Errorf("empty values should yield nil filter, got %v", f)
+	}
+	// A bare empty param emits no fragment.
+	if f := CompanyFilterFromValues(url.Values{"regions": {""}}); f != nil {
+		t.Errorf("empty regions value should yield nil filter, got %v", f)
+	}
+}
+
+func TestCompanyFilterFromValues_ArrayOverlapOrWithinAndAcross(t *testing.T) {
+	// Multiple values within one facet OR; different facets AND.
+	f := CompanyFilterFromValues(url.Values{
+		"regions":      {"europe", "asia"},
+		"company_type": {"startup"},
+	})
+	gs := groups(t, f)
+	if len(gs) != 2 {
+		t.Fatalf("want 2 AND groups, got %d: %v", len(gs), gs)
+	}
+	if !hasGroup(gs, `regions = "europe"`, `regions = "asia"`) {
+		t.Errorf("missing ORed regions group in %v", gs)
+	}
+	// company_type param maps to the plural company_types attribute.
+	if !hasGroup(gs, `company_types = "startup"`) {
+		t.Errorf("missing company_types group in %v", gs)
+	}
+}
+
+func TestCompanyFilterFromValues_ParamToAttributeMapping(t *testing.T) {
+	f := CompanyFilterFromValues(url.Values{
+		"company_size":   {"11-50"},
+		"subindustries":  {"Payments"},
+		"remote_regions": {"eu"},
+	})
+	gs := groups(t, f)
+	// company_size -> company_sizes, subindustries -> subindustry (scalar), remote_regions passthrough.
+	if !hasGroup(gs, `company_sizes = "11-50"`) {
+		t.Errorf("company_size should map to company_sizes attribute in %v", gs)
+	}
+	if !hasGroup(gs, `subindustry = "Payments"`) {
+		t.Errorf("subindustries should map to scalar subindustry attribute in %v", gs)
+	}
+	if !hasGroup(gs, `remote_regions = "eu"`) {
+		t.Errorf("missing remote_regions group in %v", gs)
+	}
+}
+
+func TestCompanyFilterFromValues_ScalarMaturityMembership(t *testing.T) {
+	// The scalar maturity facet ORs its values in one group; a NULL company (empty
+	// maturity in the document) matches none since the equality is against the value.
+	f := CompanyFilterFromValues(url.Values{"maturity": {"startup", "scaleup"}})
+	gs := groups(t, f)
+	if !hasGroup(gs, `maturity = "startup"`, `maturity = "scaleup"`) {
+		t.Errorf("maturity values should OR within one group in %v", gs)
+	}
+}
+
+func TestCompanyFilterFromValues_YCFacets(t *testing.T) {
+	f := CompanyFilterFromValues(url.Values{"yc_stage": {"Growth"}, "yc_flags": {"top_company"}})
+	gs := groups(t, f)
+	if len(gs) != 2 {
+		t.Fatalf("want 2 AND groups, got %d: %v", len(gs), gs)
+	}
+	if !hasGroup(gs, `yc_stage = "Growth"`) || !hasGroup(gs, `yc_flags = "top_company"`) {
+		t.Errorf("YC facets should each AND as their own group in %v", gs)
+	}
+}

--- a/internal/search/company_integration_test.go
+++ b/internal/search/company_integration_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+// Integration tests for the Meilisearch-backed companies index: a full rebuild
+// (CompanyRebuild swap) followed by ranked search — relevance-first ordering (an
+// exact name match ahead of higher-volume prefix matches), typo tolerance, and facet
+// filtering. These exercise behavior only a real engine exhibits. Run with:
+//
+//	go test -tags=integration ./internal/search/
+//
+// Requires Docker (reuses startMeili from search_integration_test.go).
+package search
+
+import (
+	"context"
+	"net/url"
+	"testing"
+)
+
+// buildCompanyIndex runs a full CompanyRebuild over docs and returns the client.
+func buildCompanyIndex(t *testing.T, c *Client, docs []CompanyDocument) {
+	t.Helper()
+	ctx := context.Background()
+	r := c.NewCompanyRebuild()
+	if err := r.Prepare(ctx); err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if err := r.Push(ctx, docs); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if err := r.Promote(ctx); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+}
+
+func TestIntegration_CompanySearch_ExactNameRanksFirst(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+
+	// "arb" (2 jobs) must outrank "arbor"/"arbitrage" (far more jobs) that only prefix-
+	// match the query — the exactness ranking rule wins over the job_count tiebreaker.
+	buildCompanyIndex(t, c, []CompanyDocument{
+		{Slug: "arbor", Name: "Arbor", JobCount: 40},
+		{Slug: "arbitrage-labs", Name: "Arbitrage Labs", JobCount: 99},
+		{Slug: "arb", Name: "arb", JobCount: 2},
+	})
+
+	res, err := c.SearchCompanies(ctx, CompanySearchParams{Query: "arb", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchCompanies: %v", err)
+	}
+	if len(res.Hits) == 0 {
+		t.Fatalf("no hits for q=arb")
+	}
+	if res.Hits[0].Slug != "arb" {
+		t.Errorf("first hit = %q, want arb (exact name must rank first despite low job_count); hits=%v", res.Hits[0].Slug, slugs(res.Hits))
+	}
+	if res.Total < 1 {
+		t.Errorf("total = %d, want >= 1", res.Total)
+	}
+}
+
+func TestIntegration_CompanySearch_ToleratesTypo(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+	buildCompanyIndex(t, c, []CompanyDocument{
+		{Slug: "airbnb", Name: "Airbnb", JobCount: 500},
+		{Slug: "globex", Name: "Globex", JobCount: 10},
+	})
+
+	// "arbnb" is one edit from "airbnb" — typo tolerance should still find it.
+	res, err := c.SearchCompanies(ctx, CompanySearchParams{Query: "arbnb", Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchCompanies: %v", err)
+	}
+	if !containsSlug(res.Hits, "airbnb") {
+		t.Errorf("typo query 'arbnb' did not resolve to airbnb; hits=%v", slugs(res.Hits))
+	}
+}
+
+func TestIntegration_CompanySearch_FacetFilter(t *testing.T) {
+	ctx := context.Background()
+	c := startMeili(t)
+	buildCompanyIndex(t, c, []CompanyDocument{
+		{Slug: "euro-lab", Name: "Euro Lab", JobCount: 5, Regions: []string{"europe"}, CompanyTypes: []string{"startup"}},
+		{Slug: "asia-co", Name: "Asia Co", JobCount: 5, Regions: []string{"asia"}, CompanyTypes: []string{"product"}},
+		{Slug: "euro-corp", Name: "Euro Corp", JobCount: 5, Regions: []string{"europe"}, CompanyTypes: []string{"enterprise"}},
+	})
+
+	// regions=europe AND company_type=startup → only euro-lab.
+	filter := CompanyFilterFromValues(url.Values{"regions": {"europe"}, "company_type": {"startup"}})
+	res, err := c.SearchCompanies(ctx, CompanySearchParams{Filter: filter, Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchCompanies: %v", err)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].Slug != "euro-lab" {
+		t.Errorf("facet filter → %v, want [euro-lab]", slugs(res.Hits))
+	}
+}
+
+func slugs(hits []CompanyDocument) []string {
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = h.Slug
+	}
+	return out
+}
+
+func containsSlug(hits []CompanyDocument, slug string) bool {
+	for _, h := range hits {
+		if h.Slug == slug {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/search/company_test.go
+++ b/internal/search/company_test.go
@@ -1,0 +1,97 @@
+package search
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestFromCompany_MapsAllFieldsAndFacets(t *testing.T) {
+	c := db.Company{
+		Slug:          "acme",
+		Name:          "Acme Inc",
+		Tagline:       pgtype.Text{String: "We build things", Valid: true},
+		Industries:    []string{"Fintech"},
+		HqCountry:     pgtype.Text{String: "de", Valid: true},
+		JobCount:      7,
+		Collections:   []string{"yc"},
+		Regions:       []string{"europe"},
+		Countries:     []string{"de"},
+		Domains:       []string{"fintech"},
+		CompanyTypes:  []string{"startup"},
+		CompanySizes:  []string{"11-50"},
+		RemoteRegions: []string{"eu"},
+		YcBatch:       []string{"W21"},
+		YcStatus:      []string{"Active"},
+		YcStage:       []string{"Growth"},
+		YcFlags:       []string{"top_company"},
+		Maturity:      pgtype.Text{String: "startup", Valid: true},
+		Subindustry:   pgtype.Text{String: "Payments", Valid: true},
+	}
+	doc := FromCompany(c)
+
+	if doc.Slug != "acme" || doc.Name != "Acme Inc" || doc.JobCount != 7 {
+		t.Fatalf("core fields wrong: %+v", doc)
+	}
+	if doc.Tagline != "We build things" || doc.HqCountry != "de" {
+		t.Errorf("pgtype scalars not unwrapped: tagline=%q hq=%q", doc.Tagline, doc.HqCountry)
+	}
+	if doc.Maturity != "startup" || doc.Subindustry != "Payments" {
+		t.Errorf("scalar facets wrong: maturity=%q sub=%q", doc.Maturity, doc.Subindustry)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		got, want []string
+	}{
+		{"industries", doc.Industries, []string{"Fintech"}},
+		{"collections", doc.Collections, []string{"yc"}},
+		{"regions", doc.Regions, []string{"europe"}},
+		{"countries", doc.Countries, []string{"de"}},
+		{"domains", doc.Domains, []string{"fintech"}},
+		{"company_types", doc.CompanyTypes, []string{"startup"}},
+		{"company_sizes", doc.CompanySizes, []string{"11-50"}},
+		{"remote_regions", doc.RemoteRegions, []string{"eu"}},
+		{"yc_batch", doc.YcBatch, []string{"W21"}},
+		{"yc_status", doc.YcStatus, []string{"Active"}},
+		{"yc_stage", doc.YcStage, []string{"Growth"}},
+		{"yc_flags", doc.YcFlags, []string{"top_company"}},
+	} {
+		if !slices.Equal(tc.got, tc.want) {
+			t.Errorf("%s = %v, want %v", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestFromCompany_NullScalarsBecomeEmpty(t *testing.T) {
+	// A NULL tagline/hq_country/maturity/subindustry (pgtype.Text zero value) must
+	// map to an empty string, not leak an invalid pgtype into the document JSON.
+	doc := FromCompany(db.Company{Slug: "x", Name: "X"})
+	if doc.Tagline != "" || doc.HqCountry != "" || doc.Maturity != "" || doc.Subindustry != "" {
+		t.Errorf("NULL pgtype.Text should map to empty string, got %+v", doc)
+	}
+}
+
+func TestFromCompany_SlugIsTopLevelPrimaryKey(t *testing.T) {
+	// Meilisearch reads the primary key "slug" from the top level of the document,
+	// and job_count must be present so the sortable ranking tiebreaker can read it.
+	doc := FromCompany(db.Company{Slug: "acme", Name: "Acme", JobCount: 3})
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got := string(m["slug"]); got != `"acme"` {
+		t.Errorf("top-level slug = %s, want \"acme\" in %s", got, raw)
+	}
+	if got := string(m["job_count"]); got != "3" {
+		t.Errorf("top-level job_count = %s, want 3 in %s", got, raw)
+	}
+}

--- a/openspec/changes/companies-meili-search/.openspec.yaml
+++ b/openspec/changes/companies-meili-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/companies-meili-search/design.md
+++ b/openspec/changes/companies-meili-search/design.md
@@ -1,0 +1,141 @@
+## Context
+
+`GET /api/v1/companies` (handler `internal/handler/companies.go:94` → `queries.ListCompanies`)
+serves every company search/typeahead surface in the product. Today it filters with
+Postgres `ILIKE '%q%'` on `name`/`slug` and orders by `job_count DESC, name` — no
+relevance ranking, no typo tolerance, no prefix bias. An exact-name match with few
+jobs is buried under higher-volume substring matches (the "arb" bug).
+
+The codebase already runs Meilisearch for jobs (`internal/search`, `cmd/reindex`),
+using a two-index atomic swap-rebuild (`jobs` / `jobs_rebuild`) and best-effort
+incremental pushes from the ingest crawler keyed on `content_hash`. The `search`
+package is hardwired to `JobDocument` and the `jobs*` index UIDs — there is no
+generic index abstraction.
+
+All company reads were inventoried: every search/typeahead/ranked-list consumer
+funnels through `listCompanies` → `GET /api/v1/companies` (catalog SSR + client,
+job-filter `company_slug` typeahead, referral `CompanyPicker`, global
+`HeaderSearch`, `meta.total` counts). Point lookups (`GetCompany` by slug), sitemap,
+writes, `RefreshCompanyFacets`, and the `insights` leaderboard do not search.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Relevance-ranked, typo-tolerant, prefix-aware company search with an exact-name
+  match first and `job_count` as the tiebreaker.
+- Cover every company-search surface by migrating the single `/companies` endpoint —
+  zero frontend changes.
+- Zero regression risk to the working jobs search: do not edit jobs code.
+- No new failure point for `/companies`: Postgres path stays as fallback.
+
+**Non-Goals:**
+- Real-time (per-write) index freshness for companies — eventual consistency via a
+  scheduled rebuild is sufficient (companies change slowly).
+- Moving point lookups, sitemap, writes, `insights`, or `GET /companies/subindustries`
+  off Postgres.
+- Generalizing `internal/search` into an index-agnostic abstraction.
+
+## Decisions
+
+### Decision: Separate `CompanyIndex` parallel to jobs, not a generic refactor
+
+Add `internal/search/company.go` with its own `CompanyDocument`, `FromCompany`
+mapper, `companySettings()`, `SearchCompanies()`, and `RebuildCompanies()` methods
+on `*Client`, plus its own UID constants (`companies`, `companies_rebuild`). The
+existing jobs client (`facet`/`semantic` fields, `JobDocument`, `jobs*` UIDs) is
+left byte-for-byte unchanged.
+
+- **Why:** the jobs search is on the critical path and already has a history of
+  Meili incidents (corruption, disk-full during reindex). A parallel type means the
+  jobs path physically cannot regress from this change. Chosen by the user over a
+  generic abstraction.
+- **Alternative — generalize `Rebuild`/`Client` over a document interface:** cleaner
+  long-term, but touches the jobs code path (regression risk) for a second consumer
+  that is small and slow-moving. Deferred; the duplication is modest and honest.
+
+### Decision: Meili ranking rules = default + `job_count:desc` tiebreaker
+
+`companySettings()` uses Meili's default ranking (`words, typo, proximity,
+attribute, exactness`) with `job_count:desc` appended as the final tiebreaker.
+Searchable attributes ordered `name`, `slug`, `tagline` (attribute-rank favors
+`name`). `exactness` gives the exact-name-first behavior the spec requires; the
+appended `job_count:desc` reproduces today's secondary ordering among ties.
+
+- **Why:** matches the spec's exact→prefix→contains + `job_count` tiebreaker with
+  built-in behavior — no hand-rolled scoring.
+- **Alternative — a hand-tuned Postgres `ORDER BY` relevance expression:** solves
+  the "arb" case without new infra, but no typo tolerance and no prefix search, and
+  the user explicitly wants the Meili path for all surfaces.
+
+### Decision: Scheduled full swap-rebuild, no per-write outbox
+
+`cmd/reindex-companies` keyset-scans `companies WHERE job_count > 0`, maps via
+`FromCompany`, pushes into `companies_rebuild`, awaits, and atomically swaps to
+`companies` (mirrors `cmd/reindex`'s `Prepare`/`Push`/`Promote`). Runs on cron with
+its own flock, never stacked with the jobs reindex.
+
+- **Why:** companies are a slow-moving directory (~hundreds of thousands of rows,
+  changed by periodic backfills/recompute). Eventual consistency within the rebuild
+  interval is acceptable; a per-write outbox (as jobs have) is unjustified plumbing.
+- **Alternative — hook company pushes into every company-writing command:** matches
+  jobs' freshness but adds `content_hash` tracking + push calls to `SyncCompanies`,
+  `import-yc`, backfills, `RefreshCompanyFacets`. Not worth it here.
+
+### Decision: Handler reroutes with Postgres fallback
+
+`ListCompanies` uses Meili when search is enabled (`client != nil`) **and** a `q`
+or facet filter is present; otherwise, or on any Meili error, it serves the current
+Postgres path. The response shape (`{data, meta}`), the `job_count > 0` scope, and
+the empty-`q` catalog ordering are preserved so the frontend and contract are
+untouched. `meta.total` comes from Meili's `estimatedTotalHits` on the Meili path,
+from `CountCompanies` on the Postgres path.
+
+- **Why:** `/companies` currently works with no Meili dependency; keeping the
+  fallback means the worst case (Meili down) silently degrades to today's behavior
+  instead of a new outage.
+- **Alternative — hard Meili cutover:** simpler handler, but makes the whole company
+  catalog + every typeahead depend on Meili uptime. Rejected.
+
+## Risks / Trade-offs
+
+- **Facet-value fidelity between Postgres overlap and Meili filters** → Meili filter
+  expressions must reproduce array-overlap (OR within facet, AND across) and scalar
+  membership exactly, including the `NULL`-matches-none rule for `maturity`/
+  `subindustry`. Covered by porting the existing facet scenarios as tests against the
+  Meili path.
+- **Eventual-consistency lag** → a brand-new hiring company or a just-recomputed
+  facet is invisible to search until the next company reindex, and a company whose
+  job_count has since dropped to 0 stays searchable (the index is scoped at build
+  time, unlike the Postgres `WHERE job_count > 0`). Acceptable per the spec; the cron
+  interval bounds the lag.
+- **Cold-index window** → the handler falls back to Postgres only on a Meili *error*,
+  not on an empty result (an empty result is a legitimate "no matches" that must not
+  be second-guessed). So during the first-ever build — between `Prepare` (which creates
+  the live `companies` index empty) and the first `Promote` swap, or before
+  reindex-companies has ever run — a search hits an empty index and returns an empty
+  list rather than falling back. This is the same cold-start behavior the jobs index
+  has; the migration plan closes the window by running reindex-companies once at/before
+  deploy so the empty index is never the live-serving one for long.
+- **Shared Meili host disk during swap** → the rebuild transiently holds old+new
+  index (~2× that index's disk). The companies index is small, but the reindex must
+  not stack with the jobs reindex (own flock) to avoid compounding disk pressure —
+  the same discipline already applied to jobs.
+- **`meta.total` semantics drift** → Meili returns an *estimate* (`estimatedTotalHits`)
+  where Postgres `CountCompanies` is exact. For a typeahead/catalog this is
+  acceptable and matches how jobs search already reports totals.
+
+## Migration Plan
+
+1. Ship `internal/search/company.go` + `cmd/reindex-companies` + handler reroute
+   behind the existing search-enabled gate (no Meili configured → pure Postgres,
+   behavior identical to today).
+2. Deploy; run `reindex-companies` once to build the `companies` index.
+3. Add the cron entry (own flock, off-peak, not overlapping jobs reindex).
+4. Verify ranked search on prod (`?q=arb` returns the exact match first; typo query
+   resolves). Rollback = stop routing to Meili (the fallback path is the old
+   behavior) or drop the `companies` index; jobs search is untouched throughout.
+
+## Open Questions
+
+- Cron cadence for `reindex-companies` (daily vs a few times a day) — decide with
+  ops based on how fresh the directory needs to be; defaults to daily.

--- a/openspec/changes/companies-meili-search/proposal.md
+++ b/openspec/changes/companies-meili-search/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+A company literally named "arb" does not rank first for `GET /api/v1/companies?q=arb`.
+The endpoint filters with a Postgres `ILIKE '%arb%'` substring (on `name` and
+`slug`) and orders purely by `job_count DESC, name` — there is **no relevance
+ranking**, so an exact-name match with few open jobs is buried below every
+higher-volume company whose name or slug merely contains the query. Every company
+search surface in the product (catalog, three typeaheads, header search) is served
+by this one endpoint, so they all inherit the same poor ranking and lack typo
+tolerance and prefix matching.
+
+## What Changes
+
+- Add a **separate Meilisearch `companies` index** (parallel to the existing
+  `jobs` index) built from the `companies` table, carrying the searchable text
+  (`name`, `slug`, `tagline`), the denormalized `job_count`, and the existing
+  facet arrays/scalars as filterable attributes.
+- Route company search behind `GET /api/v1/companies` through Meili when search is
+  enabled and a `q` or facet filter is present — giving relevance ranking (exact →
+  prefix → contains), typo tolerance, and `job_count` as the tiebreaker — so an
+  exact-name match surfaces first.
+- Keep a **Postgres ILIKE fallback**: on any Meili error or when search is
+  disabled/unavailable, the handler serves the current Postgres path, so
+  `/companies` gains no new failure point.
+- Add `cmd/reindex-companies`: a full swap-rebuild worker (reusing the jobs
+  index's atomic `swap-indexes` pattern) over `companies WHERE job_count > 0`,
+  scheduled on cron and never stacked with the jobs reindex. No per-write outbox —
+  companies change slowly, eventual consistency is sufficient.
+- **All company-search consumers are covered by this single endpoint** — catalog
+  page, job-filter company typeahead, referral `CompanyPicker`, global
+  `HeaderSearch`, and the filtered `meta.total` — with no frontend changes.
+- Leave `internal/search`'s jobs code untouched (a parallel `CompanyIndex`, not a
+  refactor of the jobs client), so the jobs search cannot regress.
+
+Non-goals (kept on Postgres): point lookups by slug (`GET /companies/:slug`, OG,
+match-analysis), the sitemap, all writes/maintenance (`RefreshCompanyFacets` etc.),
+the `insights` leaderboard, and the `GET /companies/subindustries` facet vocabulary.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `companies`: the "Company list is served without joining jobs" requirement
+  changes how the `q` search matches and ranks — from a Postgres `ILIKE` substring
+  ordered by `job_count DESC, name` to a Meilisearch-backed ranked search (exact →
+  prefix → contains, typo-tolerant, `job_count` tiebreaker) with a Postgres
+  fallback. The response contract, the `job_count > 0` hiring scope, the facet
+  semantics, and the empty-`q` catalog ordering are preserved.
+
+## Impact
+
+- **Code:** new `internal/search/company.go` (`CompanyDocument`, `FromCompany`,
+  `companySettings`, `SearchCompanies`, `RebuildCompanies`); new
+  `cmd/reindex-companies/main.go`; modified `internal/handler/companies.go`
+  (`ListCompanies` reroute + fallback).
+- **Infra/ops:** a new Meili `companies` index on the existing Meili host; a new
+  cron entry for `reindex-companies` (own flock, not stacked with jobs reindex).
+- **Config:** none new — reuses `MEILI_URL` / `MEILI_MASTER_KEY`.
+- **Frontend:** none — the `GET /api/v1/companies` response contract is unchanged.
+- **Dependencies:** none new — reuses the `meilisearch` Go client already vendored.

--- a/openspec/changes/companies-meili-search/specs/companies/spec.md
+++ b/openspec/changes/companies-meili-search/specs/companies/spec.md
@@ -1,0 +1,214 @@
+## MODIFIED Requirements
+
+### Requirement: Company list is served without joining jobs
+
+The system SHALL expose `GET /api/v1/companies` returning companies read from the
+`companies` table. Each company's job count SHALL be read from the denormalized
+`companies.job_count` column (open jobs only), not computed at query time, so the
+read path performs no join to the `jobs` table. When no search query is present,
+the list SHALL be ordered by `job_count` descending, then `name` ascending, so the
+most active companies surface first.
+
+The endpoint SHALL accept an optional `q` query parameter that searches companies
+by their `name`, `slug`, and `tagline`. When `q` is non-empty, results SHALL be
+ranked by **search relevance** — an exact name match first, then a prefix match,
+then a contains match — with **typo tolerance**, and with `job_count` descending
+used as the relevance tiebreaker so that among equally-relevant matches the most
+active company surfaces first. In particular, a company whose name exactly equals
+`q` SHALL rank ahead of companies that merely contain `q` in their name or slug,
+regardless of the other companies' job counts. An absent or empty `q` SHALL return
+the unfiltered list ordered by `job_count` descending then `name` ascending.
+
+Company search SHALL be served by the Meilisearch companies index (see the
+"Company search is served by a Meilisearch index with a Postgres fallback"
+requirement). When the search index is disabled or unavailable, the endpoint SHALL
+fall back to a case-insensitive substring match on the company `name`/`slug`
+ordered by `job_count` descending then `name` ascending, so the endpoint always
+returns a result.
+
+The endpoint SHALL additionally accept repeatable facet query parameters —
+`collections`, `regions`, `countries`, `domains`, `company_type`, `company_size`,
+`remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, and `yc_flags` — each
+filtering against the company's corresponding denormalized array by **array
+overlap**: a company matches a facet when its array shares at least one value with
+the requested values (OR within a facet), and a company must match every provided
+facet (AND across facets). The `remote_regions` facet filters the job-derived
+remote-hiring regions (a subset of `regions`). The `yc_batch`, `yc_status`,
+`yc_stage`, and `yc_flags` facets filter the curated YC-directory columns (see the
+`yc-company-enrichment` capability); a non-YC company has them empty and matches
+none. Facet filters SHALL compose with the `q` search. An absent facet
+parameter SHALL not constrain the list.
+
+The endpoint SHALL additionally accept the repeatable **scalar** facet parameters
+`maturity` and `subindustries`, each filtering against a single-valued company
+column (`companies.maturity` / `companies.subindustry`) by **membership**: a company
+matches when its scalar value is among the requested values (OR within the facet),
+and each ANDs with the others and with `q` exactly like the array facets. A company
+whose column is `NULL` matches no value for that facet. `maturity` values are
+`government`, `startup`, `scaleup`, `enterprise`; `subindustries` values are the
+YC subindustry leaves served by `GET /api/v1/companies/subindustries`.
+
+The hiring scope is preserved regardless of backend: only companies with
+`job_count > 0` are eligible for the list and search results, exactly as the
+Postgres path scopes today.
+
+When any filter (`q` or a facet) is applied, the list `meta.total` SHALL report
+the count of companies matching the full filter combination, so pagination over
+the filtered results is correct.
+
+#### Scenario: Listing companies most-active first
+
+- **WHEN** a client requests `GET /api/v1/companies`
+- **THEN** the response contains companies under `data` with list `meta`,
+  ordered by `job_count` descending (ties broken by `name`), each carrying its
+  denormalized `job_count`
+
+#### Scenario: Searching companies ranks relevance first
+
+- **WHEN** a client requests `GET /api/v1/companies?q=acme`
+- **THEN** the response contains only companies matching `acme`, ranked by search
+  relevance (exact name, then prefix, then contains) with `job_count` as the
+  tiebreaker, and `meta.total` is the count of matching companies
+
+#### Scenario: An exact-name match ranks first despite a low job count
+
+- **WHEN** a company is named exactly `arb` (few open jobs) and other companies'
+  names or slugs merely contain `arb` (many open jobs), and a client requests
+  `GET /api/v1/companies?q=arb`
+- **THEN** the company named exactly `arb` is the first result
+
+#### Scenario: Search tolerates a typo
+
+- **WHEN** a client requests `GET /api/v1/companies?q=arbnb` and a company named
+  `Airbnb` exists
+- **THEN** `Airbnb` is returned among the results
+
+#### Scenario: Empty query returns the full list
+
+- **WHEN** a client requests `GET /api/v1/companies?q=` (empty or absent)
+- **THEN** the response is the unfiltered company list ordered by `job_count`
+  descending then `name`, identical to omitting the parameter
+
+#### Scenario: Filtering by a single facet
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe`
+- **THEN** the response contains only companies whose `regions` array contains
+  `europe`, and `meta.total` is the count of such companies
+
+#### Scenario: Multiple values within one facet are OR-ed
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe&regions=asia`
+- **THEN** the response contains companies whose `regions` overlap
+  `{europe, asia}` (in Europe **or** Asia)
+
+#### Scenario: Different facets are AND-ed and compose with search
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?collections=yc&company_type=startup&q=lab`
+- **THEN** the response contains only companies that are in the `yc` collection
+  **and** have `startup` among their `company_types` **and** whose name matches
+  `lab`
+
+#### Scenario: Filtering by remote-hiring regions
+
+- **WHEN** a client requests `GET /api/v1/companies?remote_regions=eu`
+- **THEN** the response contains only companies whose `remote_regions` array
+  contains `eu`, and `meta.total` is the count of such companies
+
+#### Scenario: Filtering by YC facets
+
+- **WHEN** a client requests `GET /api/v1/companies?yc_stage=Growth&yc_flags=top_company`
+- **THEN** the response contains only companies whose `yc_stage` contains `Growth`
+  **and** whose `yc_flags` contains `top_company`, and `meta.total` is the count of
+  such companies
+
+#### Scenario: Filtering by the scalar maturity facet
+
+- **WHEN** a client requests `GET /api/v1/companies?maturity=startup&maturity=scaleup`
+- **THEN** the response contains only companies whose `maturity` is `startup` **or**
+  `scaleup`, excluding any company whose `maturity` is `NULL`, and `meta.total` is
+  the count of such companies
+
+#### Scenario: Filtering by the scalar subindustry facet
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?subindustries=Payments&subindustries=Diagnostics`
+- **THEN** the response contains only companies whose `subindustry` is `Payments`
+  **or** `Diagnostics`, excluding any company whose `subindustry` is `NULL`, and
+  `meta.total` is the count of such companies
+
+## ADDED Requirements
+
+### Requirement: Company search is served by a Meilisearch index with a Postgres fallback
+
+The system SHALL maintain a Meilisearch **companies** index, separate from the
+jobs index, holding one document per company with `job_count > 0`. Each document
+SHALL carry the searchable text attributes `name`, `slug`, and `tagline`; the
+sortable `job_count`; and, as filterable attributes, the denormalized facet arrays
+(`collections`, `regions`, `countries`, `domains`, `company_types`,
+`company_sizes`, `remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, `yc_flags`)
+and scalars (`maturity`, `subindustry`) used by the list endpoint. The index
+SHALL be keyed by `slug`.
+
+The index SHALL be built and refreshed by a scheduled full rebuild that reads the
+`companies` table (scoped to `job_count > 0`) and atomically swaps the freshly
+built index into place, so the search index is **eventually consistent** with the
+`companies` table within the rebuild interval. The rebuild SHALL reuse the atomic
+index-swap approach used by the jobs reindex and SHALL NOT run concurrently with
+the jobs reindex on the same host.
+
+When the search index is disabled (no Meilisearch configured) or a search request
+against it fails, the list endpoint SHALL fall back to the Postgres substring path
+without surfacing an error to the client, so company search gains no new failure
+point relative to the pre-index behavior.
+
+Building the companies index SHALL NOT modify the jobs index or its code path, so
+the jobs search cannot regress.
+
+#### Scenario: The companies index is rebuilt from Postgres
+
+- **WHEN** the scheduled company reindex runs
+- **THEN** a companies index is rebuilt from `companies` rows with `job_count > 0`
+  and atomically swapped into place, and subsequent searches read the new index
+
+#### Scenario: New company data appears after the next rebuild
+
+- **WHEN** a company's `job_count` or facet arrays change (via the periodic
+  recompute) between company reindex runs
+- **THEN** the search results do not reflect the change until the next company
+  reindex, which then includes it
+
+#### Scenario: Endpoint falls back when the index is unavailable
+
+- **WHEN** the Meilisearch companies index is unreachable and a client requests
+  `GET /api/v1/companies?q=acme`
+- **THEN** the endpoint serves the Postgres substring result (case-insensitive
+  `name`/`slug` match ordered by `job_count` descending) and returns HTTP 200
+
+#### Scenario: Endpoint falls back when search is disabled
+
+- **WHEN** no Meilisearch is configured and a client requests
+  `GET /api/v1/companies?q=acme`
+- **THEN** the endpoint serves the Postgres substring result and returns HTTP 200
+
+### Requirement: All company-search surfaces use the single companies endpoint
+
+Every company search, typeahead, and ranked-list surface in the product SHALL be
+served by `GET /api/v1/companies` and therefore by the Meilisearch companies index
+(with its Postgres fallback). The system SHALL NOT introduce a separate company
+search path that bypasses this endpoint. This covers the company catalog page, the
+job-filter sidebar company typeahead, the referral company picker, and the global
+header search's company results.
+
+#### Scenario: Typeahead surfaces share the ranked search
+
+- **WHEN** a user types a company name into the job-filter company typeahead, the
+  referral company picker, or the global header search
+- **THEN** the suggestions are produced by `GET /api/v1/companies?q=<typed>`, ranked
+  by the same relevance-first ordering as the catalog search
+
+#### Scenario: No bypassing company search path exists
+
+- **WHEN** the codebase serves a company search or typeahead
+- **THEN** it calls `GET /api/v1/companies` rather than a separate ad-hoc company
+  search query

--- a/openspec/changes/companies-meili-search/tasks.md
+++ b/openspec/changes/companies-meili-search/tasks.md
@@ -1,0 +1,37 @@
+## 1. Company document & mapper
+
+- [x] 1.1 Add `CompanyDocument` type and `FromCompany(db.Company) CompanyDocument` in a new `internal/search/company.go`, mapping `slug` (primary key), `name`, `tagline`, `job_count`, the facet arrays (`collections`, `regions`, `countries`, `domains`, `company_types`, `company_sizes`, `remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, `yc_flags`) and scalars (`maturity`, `subindustry`)
+- [x] 1.2 Unit-test `FromCompany`: full mapping, empty/`nil` arrays serialize to empty, `NULL` `tagline`/`maturity`/`subindustry` map to zero-values, `job_count` carried through
+
+## 2. Meili companies index (parallel to jobs, no jobs-code edits)
+
+- [x] 2.1 Add `companyIndexUID = "companies"` / `companyRebuildUID = "companies_rebuild"` constants and bind a `companies` index manager on `*Client` without touching the `facet`/`semantic` jobs fields
+- [x] 2.2 Add `companySettings()`: searchable `[name, slug, tagline]`, filterable = the 14 facet attrs, sortable `[job_count]`, ranking rules default + `job_count:desc`
+- [x] 2.3 Add `SearchCompanies(ctx, CompanySearchParams) (CompanyResult, error)`: builds the Meili filter from `q` + facets (array overlap OR-within/AND-across, scalar membership, `NULL`-matches-none), returns docs + `estimatedTotalHits`
+- [x] 2.4 Unit-test the facet→Meili-filter translation for each facet family (array overlap, scalar membership, `job_count > 0` scope, compose with `q`)
+- [x] 2.5 Add `RebuildCompanies(ctx, docs)` reusing the atomic swap approach (`companies_rebuild` → `swap-indexes` → `companies`); assert it never references the jobs UIDs
+
+## 3. Reindex worker
+
+- [x] 3.1 Add `cmd/reindex-companies/main.go`: bootstrap config + DB + search client, keyset-scan `companies WHERE job_count > 0`, map via `FromCompany`, push to `companies_rebuild`, promote (atomic swap)
+- [x] 3.2 Add a DB query (if none fits) to keyset-page companies for reindex scoped to `job_count > 0`
+- [x] 3.3 Verify the worker builds and, against a local Meili + seeded rows, produces a searchable `companies` index
+
+## 4. Handler reroute with Postgres fallback
+
+- [x] 4.1 Reroute `ListCompanies` (`internal/handler/companies.go`): when search is enabled and (`q` or a facet is present) → `SearchCompanies`; on any Meili error or when search is disabled → existing Postgres path. Preserve the `{data, meta}` shape and `job_count > 0` scope; `meta.total` from `estimatedTotalHits` on the Meili path
+- [x] 4.2 Handler test: `q` routes to Meili and ranks the exact-name match first (the "arb" case)
+- [x] 4.3 Handler test: Meili error falls back to Postgres and still returns HTTP 200 with the substring result
+- [x] 4.4 Handler test: empty `q` and no facets returns the catalog ordered `job_count DESC, name` (unchanged), and search-disabled config uses Postgres
+- [x] 4.5 Handler test: each facet family filters correctly through the Meili path (regions overlap, YC facets, scalar `maturity`/`subindustries` membership) matching the ported spec scenarios
+
+## 5. Wiring, docs & ops
+
+- [x] 5.1 Confirm no company-search surface bypasses `GET /api/v1/companies` (job-filter typeahead, referral `CompanyPicker`, `HeaderSearch`, catalog) — grep the frontend; no code change expected
+- [x] 5.2 Update `internal/search/AGENTS.md` (and `CLAUDE.md` command list) to document the companies index + `cmd/reindex-companies`
+- [~] 5.3 (deploy follow-up, external repo `../freehire-ops`) Add the `reindex-companies` cron entry in `../freehire-ops` (own flock, not stacked with the jobs reindex) — note in the change if ops lives outside this repo
+
+## 6. Verify
+
+- [x] 6.1 `go build ./... && go vet ./... && go test ./...` green
+- [x] 6.2 End-to-end: build the index locally, hit `GET /api/v1/companies?q=<exact>` and confirm the exact match ranks first and a typo query resolves; confirm fallback by pointing at a dead Meili


### PR DESCRIPTION
## Summary

Replaces the Postgres `ILIKE '%q%'` substring behind `GET /api/v1/companies` with a **separate Meilisearch `companies` index** when search is configured and a `q`/facet filter is present, falling back to Postgres on any error so the endpoint gains **no new failure point**.

Fixes the reported bug: a company named exactly `arb` was buried below higher-volume substring matches because the old ordering was `job_count DESC, name` with **no relevance ranking**. Now search is relevance-first (exact → prefix → contains), **typo-tolerant**, with `job_count` as the tiebreaker.

Every company-search surface funnels through this one endpoint — catalog page, job-filter company typeahead, referral `CompanyPicker`, global `HeaderSearch` — so **all of them** get ranked search with **zero frontend changes**.

### What changed
- `internal/search/company.go` — `CompanyDocument` + `FromCompany`, `companySettings` (searchable name/slug/tagline, 14 facet filters, `job_count` sortable, ranking default + `job_count:desc`), `CompanyFilterFromValues`, `SearchCompanies`, `CompanyRebuild` (own slug-keyed create/ensure + atomic swap). **The jobs index code is untouched** — a parallel index, so jobs search cannot regress.
- `cmd/reindex-companies` — full swap-rebuild over `companies WHERE job_count > 0`; run on cron, own flock, **not stacked** with the jobs reindex.
- `internal/handler/companies.go` — `ListCompanies` reroutes to Meili with a Postgres fallback; response wire shape (`db.ListCompaniesRow`) and the `job_count > 0` scope preserved byte-for-byte.
- Planned via OpenSpec change `companies-meili-search` (proposal/design/specs/tasks included).

### Deploy follow-up (not in this repo)
Add a `reindex-companies` cron entry in `../freehire-ops` (own flock, off-peak, not overlapping the jobs reindex). Run it **once at/before deploy** to populate the index before it serves (see the cold-index note in `design.md`).

## Test Plan
- [x] `go build ./... && go vet ./... && go test ./...` (90 packages green)
- [x] Handler integration tests (`-tags=integration`): Meili→Postgres fallback on error, unfiltered catalog skips Meili, all facet/search Postgres paths still pass
- [x] Real-Meili e2e (`-tags=integration ./internal/search/`): exact name `arb` ranks first despite lowest `job_count`; typo `arbnb` → `Airbnb`; `regions=europe AND company_type=startup` → `euro-lab`
- [ ] Post-deploy: run `reindex-companies`, verify `GET /api/v1/companies?q=<exact>` returns the exact match first and a typo query resolves; confirm fallback by pointing at a dead Meili