### PR TITLE
Propose: fuzzy-description role-dedup (spike VALIDATED — supersedes #996)

### DIFF
--- a/openspec/changes/fuzzy-description-role-dedup/.openspec.yaml
+++ b/openspec/changes/fuzzy-description-role-dedup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/fuzzy-description-role-dedup/design.md
+++ b/openspec/changes/fuzzy-description-role-dedup/design.md
@@ -1,0 +1,77 @@
+## Spike verdict (2026-07-20): ✅ VALIDATED
+
+Read-only prod spike, word-Jaccard of the normalized description (distinct lowercase tokens
+of length >2, `|A∩B|/|A∪B|`):
+
+| Bucket | same-role city variants | distinct roles |
+|---|---|---|
+| Towa `senior fullstack engineer` | 0.976–1.000 | Data Specialist 0.49, Management Consultant 0.48 |
+| speechify `software engineer` | DataInfra 0.954 | Platform 0.44, iOS 0.46 |
+| amazon `software development engineer` | (1 near-dupe) | 261 rows, avg 0.186 |
+
+Wide, consistent gap (true dupes ≥0.95, distinct ≤0.5) — and it works EXACTLY where the
+embedding approach failed (speechify 0.968 vs 0.966; amazon 0.83–0.97). Amazon's generic-title
+bucket correctly does not collapse (avg 0.186 = genuinely distinct jobs). Any threshold in
+0.6–0.9 separates cleanly; ≥0.9 is conservative and safe.
+
+## Context
+
+`ingest-content-dedup` collapses on EXACT description match. Near-identical-but-localized
+descriptions (Towa Kraków/Wien, >98% identical) stay split. The prior embedding follow-up was
+INVALIDATED (`semantic-role-dedup`, shelved). Word-Jaccard of the description is the validated
+signal.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Collapse near-identical-description reposts that exact matching misses.
+- Zero regression to the deterministic exact pass; strictly additive.
+- Bounded cost; reversible; measurable before enabling.
+
+**Non-Goals:**
+- Merging genuinely distinct jobs under a generic title (amazon SDE) — the threshold must
+  leave those split.
+- Cross-company/cross-bucket merging.
+- The `company_slug` duplication issue (`jp-morgan-chase`/`jpmorganchase`) — separate.
+
+## Decisions
+
+### D1 — Signal: word-Jaccard of the normalized description (not embeddings)
+Spike-proven to separate dupes from distinct roles where embeddings could not (boilerplate
+dominates embeddings; word-overlap captures the specialty-specific body). This is the exact-md5
+guard relaxed to ≥T word overlap.
+
+### D2 — Bucket by (company_slug, stripped-title); cluster within
+Same bucketing as the exact pass bounds comparison and prevents cross-role merges. Within the
+bucket, cluster by Jaccard ≥ threshold, `min(id)` canon.
+
+### D3 — After the exact pass, additive only
+Reads only exact-pass leftover canons (`duplicate_of IS NULL`), only adds markers. Reuses the
+column, reindex exclusion, `/copies`, geo-union unchanged.
+
+### D4 — Efficient signature, not naïve O(n²)
+Pairwise Jaccard per bucket is O(n²); large buckets (amazon 261, speechify 305) need a
+signature: MinHash/LSH banding, a shingle simhash, or a `pg_trgm` GIN with `similarity()`.
+Pick during implementation after the spike sizes bucket distribution. Conservative threshold
+≥0.9 (well inside the ≥0.95 true-dupe band, far above ≤0.5 distinct).
+
+### D5 — Grade guard
+Reuse the seniority-grade guard so senior/staff/etc. of one title are not merged even at high
+description similarity.
+
+## Risks / Trade-offs
+
+- **Over-merge of near-but-distinct roles** → bucket + conservative threshold + grade guard;
+  measure false-positive rate on a prod sample before enabling. Spike margin is large.
+- **O(n²) cost on big buckets** → signature/LSH; only buckets with >1 canon; existing reindex
+  cadence.
+- **Threshold drift** → single conservative global threshold first; the spike shows the gap is
+  company-independent so far.
+
+## Open Questions
+
+- Similarity impl: MinHash/LSH vs `pg_trgm` vs precomputed shingle signature — sized by the
+  implementation spike (bucket-size distribution).
+- Exact threshold (0.85 vs 0.9 vs 0.95) — tune on a labelled prod sample; measure recall/FP.
+- How many cards this actually collapses — a real count (within-bucket ≥T pairs), NOT the
+  misleading 849k stripped-title figure (which counted distinct jobs too).

--- a/openspec/changes/fuzzy-description-role-dedup/proposal.md
+++ b/openspec/changes/fuzzy-description-role-dedup/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+The role-cluster collapse (`ingest-content-dedup`) keys on an EXACT description match as
+its over-merge guard, so a role reposted per-city with a slightly localized description
+(a country-specific salary/legal block) does not collapse — e.g. Towa's "Senior Fullstack
+Engineer": Bregenz/Düsseldorf/München (byte-identical) collapsed, but Kraków and Wien
+(~120–200 chars different out of ~11,000, >98% identical) stayed separate cards.
+
+The first follow-up tried **embedding cosine** to bridge this and was **INVALIDATED by a
+spike** (see the shelved `semantic-role-dedup`): boilerplate-dominated embeddings cannot
+separate same-role city variants from distinct roles.
+
+A second spike VALIDATED a better signal — **word-Jaccard of the normalized description**:
+
+| Bucket | same-role city variants | distinct roles in same bucket |
+|---|---|---|
+| Towa `senior fullstack engineer` | 0.976–1.000 | 0.48 (Data Specialist / Consultant) |
+| speechify `software engineer` | 0.954 (DataInfra) | 0.44–0.46 (Platform / iOS) |
+| amazon `software development engineer` | — | avg 0.186 (261 genuinely-distinct jobs) |
+
+The gap is wide and consistent (true dupes ≥0.95, distinct roles ≤0.5) exactly where the
+embedding failed. Crucially, amazon's 228-card "SDE" bucket correctly does NOT collapse
+(avg 0.186) — those are different jobs under a generic title, not dupes.
+
+## What Changes
+
+- Extend the role-cluster collapse with a **fuzzy-description** pass: within a
+  `(company_slug, stripped-title)` bucket, cluster open canonical postings whose normalized
+  descriptions exceed a word-similarity threshold and mark all but one `duplicate_of` the
+  canon — the same collapse mechanism, an exact-match guard relaxed to near-match.
+- Runs AFTER the exact role-cluster recompute, over its leftover canons only, strictly
+  additive: it merges what byte-exact matching left split, never re-splits a deterministic
+  collapse.
+- Guards: the shared stripped-title bucket bounds comparison and prevents cross-role merges;
+  a conservative threshold (spike shows ≥0.9 sits well inside the true-dupe band and far
+  above any distinct-role pair); the existing seniority-grade guard.
+
+## Capabilities
+
+### New Capabilities
+- `fuzzy-description-role-dedup`: collapse near-identical-description reposts that exact
+  matching misses, using a normalized-description word-similarity within a company+title bucket.
+
+### Modified Capabilities
+<!-- none: reuses ingest-content-dedup's duplicate_of column, reindex exclusion, /copies, and geo-union unchanged. -->
+
+## Impact
+
+- **Code:** a fuzzy pass (in `cmd/reindex` after `recomputeRoleDuplicates`, or a dedicated
+  worker), a description word-signature + within-bucket similarity, writing `duplicate_of`.
+- **Efficiency:** pairwise word-Jaccard is O(n²) per bucket; buckets are bounded per company,
+  but large ones (amazon 261, speechify 305) need an efficient signature (MinHash/LSH, a
+  shingle simhash, or `pg_trgm` GIN) rather than naïve pairwise — a design decision.
+- **Data:** more `duplicate_of` rows; reindex/copies/geo-union machinery unchanged; reversible.
+- **Risk:** over-merge of near-but-distinct roles — mitigated by bucket + conservative
+  threshold + grade guard; measure the false-positive rate on a prod sample before enabling.
+- **Supersedes** the shelved `semantic-role-dedup` (embedding approach, INVALIDATED).

--- a/openspec/changes/fuzzy-description-role-dedup/specs/fuzzy-description-role-dedup/spec.md
+++ b/openspec/changes/fuzzy-description-role-dedup/specs/fuzzy-description-role-dedup/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Near-identical-description reposts collapse within a company+title bucket
+
+The system SHALL collapse open canonical postings that share a `company_slug` and a
+normalized (city-suffix-stripped) title AND whose normalized descriptions exceed a
+configured word-similarity threshold, marking all but one `duplicate_of` the chosen canon
+(the deterministic `min(id)`), reusing the existing collapse column and mechanism.
+Comparison SHALL be bucketed by `(company_slug, normalized-title)` so it is bounded per
+bucket and never compares postings of different roles.
+
+#### Scenario: Same role, lightly-localized descriptions, collapses
+
+- **WHEN** a company posts one role in several cities whose descriptions differ only in a
+  small localized block (word-similarity above the threshold)
+- **THEN** the postings collapse to one canonical card, the rest referencing it via
+  `duplicate_of`
+
+#### Scenario: Genuinely distinct jobs under a generic title do not collapse
+
+- **WHEN** postings share a company and a generic stripped title (e.g. "software
+  development engineer") but describe substantially different jobs (word-similarity far
+  below the threshold)
+- **THEN** they remain separate canonical rows
+
+#### Scenario: Distinct specialties under one stripped title do not collapse
+
+- **WHEN** a stripped-title bucket mixes specialties (e.g. "software engineer" over Data
+  Infrastructure vs Platform), whose descriptions overlap only partially
+- **THEN** each specialty stays its own canon; only same-specialty city variants collapse
+
+### Requirement: The fuzzy pass runs after and never overrides the exact pass
+
+The fuzzy-description pass SHALL run AFTER the exact role-cluster recompute and operate only
+over its remaining open canonical rows, so it merges what byte-exact matching left split and
+never re-splits or contradicts a deterministic collapse. It SHALL be idempotent and
+reversible by the standard recompute.
+
+#### Scenario: Exact-collapsed reposts are untouched
+
+- **WHEN** the exact pass has already collapsed byte-identical-description reposts
+- **THEN** the fuzzy pass leaves those `duplicate_of` markers unchanged
+
+#### Scenario: Re-running is stable
+
+- **WHEN** the fuzzy pass runs twice with no new postings
+- **THEN** the second run changes no `duplicate_of` markers
+
+### Requirement: Over-merge guards are enforced
+
+The fuzzy pass SHALL guard against merging distinct roles: a conservative word-similarity
+threshold, the shared stripped-title bucket, and a seniority/grade guard so postings that
+differ only by grade are not merged.
+
+#### Scenario: Different grades of one title are not merged
+
+- **WHEN** two postings share a company and base title but carry different seniority grades
+- **THEN** they are not collapsed together, regardless of description similarity

--- a/openspec/changes/fuzzy-description-role-dedup/tasks.md
+++ b/openspec/changes/fuzzy-description-role-dedup/tasks.md
@@ -1,0 +1,23 @@
+## 1. Sizing spike (feasibility of the impl, not the signal — signal already VALIDATED)
+
+- [ ] 1.1 Measure the bucket-size distribution over `(company_slug, stripped-title)` buckets with >1 open canon (max/median/tail) to decide the similarity impl (naïve pairwise is fine for small buckets; big buckets need MinHash/LSH or `pg_trgm`).
+- [ ] 1.2 Pick and validate the threshold on a labelled prod sample (Towa, speechify, amazon + a random draw): confirm recall on true dupes and near-zero false positives at the chosen T (≥0.9 candidate).
+- [ ] 1.3 Count the REAL collapse potential (within-bucket pairs/clusters ≥ T) — the honest figure, not the 849k stripped-title count.
+
+## 2. Similarity + query layer
+
+- [ ] 2.1 Implement the normalized-description word-signature (distinct lowercase tokens len>2) + the within-bucket similarity (chosen impl), as a pure, unit-tested function.
+- [ ] 2.2 Add SQL to stream `(company_slug, stripped-title)` buckets of exact-pass leftover canons with their description signatures.
+- [ ] 2.3 Reuse/extend the `duplicate_of` writer (idempotent `IS DISTINCT FROM`), mirroring the exact pass.
+
+## 3. Dedup pass
+
+- [ ] 3.1 Per-bucket clustering (similarity ≥ T → same cluster, `min(id)` canon) with the seniority-grade guard, unit-tested.
+- [ ] 3.2 Wire into `cmd/reindex` AFTER `recomputeRoleDuplicates`/`suppressAggregatorDuplicates` (or a dedicated worker), over leftover canons only.
+- [ ] 3.3 Unit tests: near-identical merges; distinct-job (amazon-style) stays split; mixed-specialty (speechify-style) stays split; grade guard; idempotent re-run.
+
+## 4. Verification
+
+- [ ] 4.1 On a prod copy (or read-only dry-run that logs would-merge sets), sample merges for false positives at the chosen T.
+- [ ] 4.2 Confirm the geo-union (`ingest-content-dedup`) still widens the fuzzy-merged canons; confirm Towa Kraków/Wien now fold into the fullstack canon.
+- [ ] 4.3 `go build ./... && go vet ./... && go test ./...` green.


### PR DESCRIPTION
## Summary
Follow-up to #978. The exact role-cluster collapse keys on a **byte-exact description** guard, so a role reposted per-city with a lightly localized description stays split (Towa "Senior Fullstack Engineer": Bregenz/Düsseldorf/München collapsed, but Kraków/Wien — >98% identical text — did not).

The embedding approach (#996) was **INVALIDATED by a spike**. A second spike **VALIDATED** word-Jaccard of the normalized description:

| Bucket | same-role city variants | distinct roles in bucket |
|---|---|---|
| Towa `senior fullstack engineer` | **0.976–1.000** | 0.48 |
| speechify `software engineer` | **0.954** (DataInfra) | 0.44–0.46 (Platform/iOS) |
| amazon `software development engineer` | (1 dupe) | **avg 0.186** (261 distinct jobs) |

Wide, consistent gap (dupes ≥0.95, distinct ≤0.5) — and it separates cleanly **exactly where embeddings failed** (speechify 0.968 vs 0.966). Amazon's 228-card "SDE" bucket correctly stays split (avg 0.186 = genuinely different jobs, not dupes).

## Proposal
A **fuzzy-description** pass: within a `(company_slug, stripped-title)` bucket, cluster exact-pass leftover canons whose normalized descriptions exceed a conservative word-similarity threshold (~0.9) and mark duplicates — same `duplicate_of` mechanism, exact guard relaxed to near-match. Additive to and after the deterministic pass; bucket + threshold + grade guards. Reuses reindex/copies/geo-union unchanged.

**Planning only** — proposal/design/specs/tasks under `openspec/changes/fuzzy-description-role-dedup/`. The signal is spike-validated; task 1 is a sizing spike (bucket distribution → efficient similarity impl like MinHash/LSH or `pg_trgm`) + threshold calibration + the honest collapse count.

Supersedes #996 (shelved).

## Test Plan
- [x] `openspec validate` passes (4/4 artifacts)
- [x] Signal validated on prod (Towa / speechify / amazon)
- [ ] Sizing spike + threshold calibration before implementation