### PR TITLE
feat(web): add /referrals landing for the employee-referral marketplace

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -139,3 +139,23 @@
   margin: 0;
   background: transparent !important;
 }
+
+/* Dotted hero backdrop, shared across landing pages (the pattern HomeView pioneered
+   for /, and /about reuses). A faint dot grid faded toward the edges with a radial
+   mask, so it frames a hero without competing with the copy — visible in both themes
+   because it rides --muted-foreground. Opt in by adding `dot-grid` to a section (it
+   sets its own positioning context); pair with `-mx-4 px-4` to bleed full-width. */
+.dot-grid {
+  position: relative;
+}
+.dot-grid::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background-image: radial-gradient(var(--muted-foreground) 1px, transparent 1.2px);
+  background-size: 22px 22px;
+  opacity: 0.16;
+  -webkit-mask-image: radial-gradient(ellipse 90% 75% at 25% 0%, #000 18%, transparent 80%);
+  mask-image: radial-gradient(ellipse 90% 75% at 25% 0%, #000 18%, transparent 80%);
+}

--- a/web/src/lib/components/ContributeLandingView.svelte
+++ b/web/src/lib/components/ContributeLandingView.svelte
@@ -46,7 +46,7 @@
 
 <div class="flex flex-col gap-16">
   <!-- Hero -->
-  <section class="flex flex-col gap-7">
+  <section class="dot-grid -mx-4 flex flex-col gap-7 px-4 pb-4 pt-2">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
       // contribute
     </p>

--- a/web/src/lib/components/Footer.svelte
+++ b/web/src/lib/components/Footer.svelte
@@ -12,6 +12,7 @@
         { label: 'Jobs', href: resolve('/') },
         { label: 'Companies', href: resolve('/companies') },
         { label: 'Collections', href: resolve('/collections') },
+        { label: 'Referrals', href: resolve('/referrals') },
         { label: 'Recruiters', href: resolve('/recruiters') },
       ],
     },

--- a/web/src/lib/components/ForCompaniesView.svelte
+++ b/web/src/lib/components/ForCompaniesView.svelte
@@ -59,7 +59,7 @@
 
 <div class="flex flex-col gap-16">
   <!-- Hero -->
-  <section class="flex flex-col gap-7">
+  <section class="dot-grid -mx-4 flex flex-col gap-7 px-4 pb-4 pt-2">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
       // for companies &amp; employers
     </p>

--- a/web/src/lib/components/RecruitersView.svelte
+++ b/web/src/lib/components/RecruitersView.svelte
@@ -27,7 +27,7 @@
 
 <div class="flex flex-col gap-16">
   <!-- Hero -->
-  <section class="flex flex-col gap-7">
+  <section class="dot-grid -mx-4 flex flex-col gap-7 px-4 pb-4 pt-2">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
       // for recruiters &amp; hiring teams
     </p>

--- a/web/src/lib/components/ReferralsLandingView.svelte
+++ b/web/src/lib/components/ReferralsLandingView.svelte
@@ -38,8 +38,8 @@
   const trust = [
     {
       n: '01',
-      title: 'Referrers stay anonymous',
-      body: 'A referrer never sees who you are until they choose to contact you, and you never see them. The intro happens on neutral ground.',
+      title: 'Referrers are never on the hook',
+      body: 'A referrer stays anonymous and only surfaces if they choose to reach out — so turning a request down is silent and awkward-free. No name on the line, no burned bridge, no guilt.',
     },
     {
       n: '02',
@@ -102,8 +102,9 @@
     </h1>
 
     <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
-      freehire quietly connects you with someone already inside the company — an employee who can put
-      your name forward. They stay anonymous, you skip the cold apply, and the intro comes warm.
+      Everyone knows a referral is the fastest way in. The hard part is finding someone inside who'll
+      make it. freehire surfaces the companies that already have a willing insider — and connects you
+      to them, so you can stop cold-DMing strangers.
     </p>
 
     <!-- signature glyph: the path in one line, drawn in the muted mono register -->
@@ -157,10 +158,11 @@
       <!-- Seeker -->
       <div class="flex flex-col bg-background p-7 sm:p-8">
         <p class="font-mono text-xs uppercase tracking-wide text-muted-foreground">for seekers</p>
-        <h3 class="mt-4 text-xl font-semibold tracking-tight">Looking for a way in</h3>
+        <h3 class="mt-4 text-xl font-semibold tracking-tight">No one on the inside? Solved.</h3>
         <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
-          Find a company that has a referrer, attach your CV, and ask. If someone takes it up, they
-          reach out to you directly — no application black hole.
+          The hardest part of a referral is finding someone willing to give it. freehire shows you
+          which companies already have a referrer — attach your CV and ask, and if they see a fit they
+          reach out directly. No cold DMs, no application black hole.
         </p>
         <ul class="mt-5 flex flex-col divide-y divide-border border-y border-border">
           {#each seekerPoints as point (point)}
@@ -175,10 +177,11 @@
       <!-- Referrer -->
       <div class="flex flex-col bg-background p-7 sm:p-8">
         <p class="font-mono text-xs uppercase tracking-wide text-muted-foreground">for insiders</p>
-        <h3 class="mt-4 text-xl font-semibold tracking-tight">Already inside</h3>
+        <h3 class="mt-4 text-xl font-semibold tracking-tight">Refer without the awkward "no"</h3>
         <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
-          Refer good people into your company without exposing yourself. Offer once, get vetted
-          requests, and act only on the ones you like.
+          Referring usually means putting your name on the line — and squirming when you have to turn
+          someone down. Here you stay invisible until you decide someone's worth it. Pass on anyone,
+          no explanation, and it's never tied back to you.
         </p>
         <ul class="mt-5 flex flex-col divide-y divide-border border-y border-border">
           {#each referrerPoints as point (point)}

--- a/web/src/lib/components/ReferralsLandingView.svelte
+++ b/web/src/lib/components/ReferralsLandingView.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
-  import { ArrowRight, ShieldCheck, BadgeCheck, Timer, EyeOff, Handshake, Send } from '@lucide/svelte';
   import { Button } from '$lib/ui';
 
   // CTA destinations wired to the real feature (no invite-code program exists):
@@ -38,20 +37,33 @@
   // server-side (moderated proof, rolling 24h per-seeker cap, anonymity).
   const trust = [
     {
-      icon: EyeOff,
+      n: '01',
       title: 'Referrers stay anonymous',
       body: 'A referrer never sees who you are until they choose to contact you, and you never see them. The intro happens on neutral ground.',
     },
     {
-      icon: BadgeCheck,
+      n: '02',
       title: 'Real employees only',
       body: 'Every offer to refer is backed by proof of employment that a moderator reviews before the company becomes referral-eligible.',
     },
     {
-      icon: Timer,
+      n: '03',
       title: 'No spraying',
       body: 'A rolling daily cap keeps requests deliberate — this is a warm introduction, not a mass-apply button.',
     },
+  ];
+
+  const seekerPoints = [
+    'Browse companies and open one with a referrer',
+    'Attach your CV — uploaded or tailored',
+    'Leave a contact and a short note',
+    'Wait for a warm reply',
+  ];
+  const referrerPoints = [
+    'Offer to refer for your company',
+    'Upload proof of employment once — reviewed by a moderator',
+    'Receive matching requests, stay anonymous',
+    'Reach out to the ones worth it',
   ];
 
   const faqs = [
@@ -74,187 +86,152 @@
   ];
 </script>
 
-<div class="flex flex-col gap-20 sm:gap-28">
+<div class="landing">
   <!-- ── Hero ─────────────────────────────────────────────────────────────── -->
-  <section class="reveal-hero relative isolate flex flex-col gap-7 pt-4">
-    <!-- soft brand glow, contained; decorative only -->
-    <div class="glow pointer-events-none absolute -left-24 -top-24 -z-10 h-80 w-80 rounded-full" aria-hidden="true"></div>
-
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
+  <section class="pb-4 pt-14 sm:pt-20">
+    <p class="reveal font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground" style="--d:0ms">
       // referrals · a warm way in
     </p>
 
-    <h1 class="max-w-3xl text-balance text-4xl font-semibold leading-[0.98] tracking-tighter sm:text-6xl">
+    <h1
+      class="reveal mt-6 max-w-3xl text-balance text-5xl font-semibold leading-[0.95] tracking-tighter sm:text-7xl"
+      style="--d:80ms"
+    >
       Referred candidates get seen.
-      <span class="mt-2 block text-muted-foreground sm:ml-[1.5ch]">Everyone else waits in the pile.</span>
+      <span class="mt-2 block text-muted-foreground">Everyone else waits in the pile.</span>
     </h1>
 
-    <p class="max-w-xl text-lg leading-relaxed text-muted-foreground">
+    <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
       freehire quietly connects you with someone already inside the company — an employee who can put
       your name forward. They stay anonymous, you skip the cold apply, and the intro comes warm.
     </p>
 
-    <!-- signature glyph: the path in one line -->
-    <p class="flex flex-wrap items-center gap-2 font-mono text-xs text-muted-foreground">
-      <span class="rounded-md bg-secondary/60 px-2 py-1 text-foreground">you</span>
-      <ArrowRight class="size-3.5" />
-      <span class="rounded-md border border-brand/25 bg-brand-muted px-2 py-1 text-brand-strong">insider</span>
-      <ArrowRight class="size-3.5" />
-      <span class="rounded-md bg-secondary/60 px-2 py-1 text-foreground">interview</span>
+    <!-- signature glyph: the path in one line, drawn in the muted mono register -->
+    <p class="reveal mt-7 flex flex-wrap items-center gap-2 font-mono text-xs text-muted-foreground" style="--d:220ms">
+      <span class="rounded-md border border-border px-2 py-1 text-foreground">you</span>
+      <span aria-hidden="true">→</span>
+      <span class="rounded-md border border-border px-2 py-1 text-foreground">insider</span>
+      <span aria-hidden="true">→</span>
+      <span class="rounded-md border border-border px-2 py-1 text-foreground">interview</span>
     </p>
 
-    <div class="flex flex-wrap items-center gap-3">
+    <div class="reveal mt-9 flex flex-wrap items-center gap-3" style="--d:300ms">
       <Button href={askCta} variant="primary" size="lg">Ask for a referral</Button>
       <Button href={referrerCta} variant="outline" size="lg">Refer someone in</Button>
     </div>
 
-    <p class="font-mono text-xs text-muted-foreground">
+    <p class="reveal mt-6 font-mono text-xs text-muted-foreground" style="--d:360ms">
       free · anonymous referrers · employment verified
     </p>
   </section>
 
   <!-- ── The warm path ────────────────────────────────────────────────────── -->
-  <section class="flex flex-col gap-8">
-    <div class="flex flex-col gap-2">
-      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// how it happens</p>
-      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Three beats from cold list to warm intro</h2>
-    </div>
-
-    <ol class="flex flex-col gap-4 md:flex-row md:items-stretch md:gap-0">
-      {#each steps as step, i (step.n)}
-        <li class="path-node flex flex-1 flex-col gap-3 rounded-xl border border-border p-6">
-          <span class="font-mono text-sm text-brand-strong">{step.n}</span>
-          <h3 class="text-base font-semibold tracking-tight">{step.title}</h3>
-          <p class="text-sm leading-relaxed text-muted-foreground">{step.body}</p>
-        </li>
-        {#if i < steps.length - 1}
-          <div class="hidden shrink-0 items-center justify-center px-3 md:flex" aria-hidden="true">
-            <ArrowRight class="size-5 text-muted-foreground/60" />
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// how it happens</p>
+    <dl class="mt-10 divide-y divide-border border-y border-border">
+      {#each steps as step (step.n)}
+        <div class="grid gap-2 py-6 sm:grid-cols-[auto_1fr] sm:gap-8">
+          <span class="font-mono text-sm text-muted-foreground">{step.n}</span>
+          <div>
+            <dt class="text-lg font-semibold tracking-tight">{step.title}</dt>
+            <dd class="mt-2 max-w-3xl text-sm leading-relaxed text-muted-foreground">{step.body}</dd>
           </div>
-        {/if}
+        </div>
       {/each}
-    </ol>
+    </dl>
   </section>
 
   <!-- ── The one line that matters ────────────────────────────────────────── -->
-  <section class="reveal-stat relative overflow-hidden rounded-xl border border-brand/25 bg-brand-muted px-6 py-12 sm:px-12 sm:py-16">
-    <p class="font-mono text-xs uppercase tracking-[0.2em] text-brand-strong/70">// the whole pitch</p>
-    <p class="mt-4 max-w-3xl text-balance text-3xl font-semibold leading-tight tracking-tight text-brand-strong sm:text-5xl">
-      One warm intro beats a hundred cold applications.
-    </p>
-    <p class="mt-5 flex items-center gap-3 font-mono text-sm text-brand-strong/80">
-      <Handshake class="size-5" />
-      referrals are how most roles are actually filled — this is your side door in.
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// the pitch</p>
+    <p class="mt-6 max-w-3xl text-2xl font-medium leading-snug tracking-tight sm:text-3xl">
+      One warm intro beats a hundred cold applications. Referrals are how most roles are actually
+      filled — this is your side door in.
     </p>
   </section>
 
   <!-- ── Two sides ────────────────────────────────────────────────────────── -->
-  <section class="flex flex-col gap-8">
-    <div class="flex flex-col gap-2">
-      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// pick your side</p>
-      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Two ways to use it</h2>
-    </div>
-
-    <div class="grid gap-6 lg:grid-cols-2">
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// pick your side</p>
+    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border lg:grid-cols-2">
       <!-- Seeker -->
-      <div class="flex flex-col gap-5 rounded-xl border border-border p-7">
-        <div class="flex items-center gap-3">
-          <span class="flex size-9 items-center justify-center rounded-lg bg-secondary/70">
-            <Send class="size-4.5 text-foreground" />
-          </span>
-          <h3 class="text-lg font-semibold tracking-tight">Looking for a way in</h3>
-        </div>
-        <p class="text-sm leading-relaxed text-muted-foreground">
+      <div class="flex flex-col bg-background p-7 sm:p-8">
+        <p class="font-mono text-xs uppercase tracking-wide text-muted-foreground">for seekers</p>
+        <h3 class="mt-4 text-xl font-semibold tracking-tight">Looking for a way in</h3>
+        <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
           Find a company that has a referrer, attach your CV, and ask. If someone takes it up, they
           reach out to you directly — no application black hole.
         </p>
-        <ul class="flex flex-col gap-2.5 text-sm">
-          {#each ['Browse companies and open one with a referrer', 'Attach your CV — uploaded or tailored', 'Leave a contact and a short note', 'Wait for a warm reply'] as point (point)}
-            <li class="flex items-start gap-2.5 leading-relaxed">
-              <ArrowRight class="mt-0.5 size-4 shrink-0 text-brand-strong" />
-              <span class="text-muted-foreground">{point}</span>
-            </li>
+        <ul class="mt-5 flex flex-col divide-y divide-border border-y border-border">
+          {#each seekerPoints as point (point)}
+            <li class="py-2.5 text-sm leading-relaxed text-muted-foreground">{point}</li>
           {/each}
         </ul>
-        <div class="mt-auto pt-1">
+        <div class="mt-7 pt-1">
           <Button href={browseCta} variant="primary" size="md">Find a company to ask</Button>
         </div>
       </div>
 
-      <!-- Referrer — brand-tinted to set it apart -->
-      <div class="flex flex-col gap-5 rounded-xl border border-brand/25 bg-brand-muted/50 p-7">
-        <div class="flex items-center gap-3">
-          <span class="flex size-9 items-center justify-center rounded-lg bg-brand-muted">
-            <Handshake class="size-4.5 text-brand-strong" />
-          </span>
-          <h3 class="text-lg font-semibold tracking-tight text-brand-strong">Already inside</h3>
-        </div>
-        <p class="text-sm leading-relaxed text-brand-strong/80">
+      <!-- Referrer -->
+      <div class="flex flex-col bg-background p-7 sm:p-8">
+        <p class="font-mono text-xs uppercase tracking-wide text-muted-foreground">for insiders</p>
+        <h3 class="mt-4 text-xl font-semibold tracking-tight">Already inside</h3>
+        <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
           Refer good people into your company without exposing yourself. Offer once, get vetted
           requests, and act only on the ones you like.
         </p>
-        <ul class="flex flex-col gap-2.5 text-sm">
-          {#each ['Offer to refer for your company', 'Upload proof of employment once — reviewed by a moderator', 'Receive matching requests, stay anonymous', 'Reach out to the ones worth it'] as point (point)}
-            <li class="flex items-start gap-2.5 leading-relaxed">
-              <ArrowRight class="mt-0.5 size-4 shrink-0 text-brand-strong" />
-              <span class="text-brand-strong/90">{point}</span>
-            </li>
+        <ul class="mt-5 flex flex-col divide-y divide-border border-y border-border">
+          {#each referrerPoints as point (point)}
+            <li class="py-2.5 text-sm leading-relaxed text-muted-foreground">{point}</li>
           {/each}
         </ul>
-        <div class="mt-auto pt-1">
-          <Button href={referrerCta} variant="primary" size="md">Become a referrer</Button>
+        <div class="mt-7 pt-1">
+          <Button href={referrerCta} variant="outline" size="md">Become a referrer</Button>
         </div>
       </div>
     </div>
   </section>
 
   <!-- ── Trust ────────────────────────────────────────────────────────────── -->
-  <section class="flex flex-col gap-8">
-    <div class="flex flex-col gap-2">
-      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// kept clean</p>
-      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Why it stays worth trusting</h2>
-    </div>
-    <div class="grid gap-6 sm:grid-cols-3">
-      {#each trust as t (t.title)}
-        <div class="flex flex-col gap-3 rounded-xl border border-border p-6">
-          <t.icon class="size-5 text-brand-strong" />
-          <h3 class="text-base font-semibold tracking-tight">{t.title}</h3>
-          <p class="text-sm leading-relaxed text-muted-foreground">{t.body}</p>
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// kept clean</p>
+    <div class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-3">
+      {#each trust as t (t.n)}
+        <div class="group bg-background p-6 transition-colors hover:bg-secondary/40 sm:p-7">
+          <span class="font-mono text-sm text-muted-foreground transition-colors group-hover:text-foreground">
+            {t.n}
+          </span>
+          <h3 class="mt-4 text-lg font-semibold tracking-tight">{t.title}</h3>
+          <p class="mt-2 text-sm leading-relaxed text-muted-foreground">{t.body}</p>
         </div>
       {/each}
     </div>
   </section>
 
   <!-- ── FAQ ──────────────────────────────────────────────────────────────── -->
-  <section class="flex flex-col gap-8">
-    <div class="flex flex-col gap-2">
-      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// good to know</p>
-      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Questions people ask first</h2>
-    </div>
-    <div class="grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// faq</p>
+    <dl class="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
       {#each faqs as f (f.q)}
-        <details class="group bg-background p-6">
-          <summary class="flex cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold tracking-tight">
-            {f.q}
-            <ArrowRight class="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
-          </summary>
-          <p class="mt-3 text-sm leading-relaxed text-muted-foreground">{f.a}</p>
-        </details>
+        <div class="bg-background p-6 sm:p-7">
+          <dt class="text-lg font-semibold tracking-tight">{f.q}</dt>
+          <dd class="mt-2 text-sm leading-relaxed text-muted-foreground">{f.a}</dd>
+        </div>
       {/each}
-    </div>
+    </dl>
   </section>
 
   <!-- ── Closing CTA ──────────────────────────────────────────────────────── -->
-  <section class="flex flex-col items-start gap-5 rounded-xl border border-border bg-secondary/40 p-8">
-    <div class="flex items-center gap-3">
-      <ShieldCheck class="size-6 text-brand-strong" />
-      <h2 class="text-xl font-semibold tracking-tight">Skip the pile</h2>
-    </div>
-    <p class="max-w-xl text-sm leading-relaxed text-muted-foreground">
-      Ask an insider to put your name forward, or open the door for someone else. Either way it takes
-      a couple of minutes and stays anonymous.
+  <section class="border-t border-border py-16 sm:py-20">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// skip the pile</p>
+    <h2 class="mt-6 max-w-md text-3xl font-semibold tracking-tight sm:text-4xl">
+      Ask an insider to put your name forward.
+    </h2>
+    <p class="mt-5 max-w-xl leading-relaxed text-muted-foreground">
+      Get referred, or open the door for someone else. Either way it takes a couple of minutes and
+      stays anonymous.
     </p>
-    <div class="flex flex-wrap gap-3">
+    <div class="mt-8 flex flex-wrap gap-3">
       <Button href={askCta} variant="primary" size="lg">Ask for a referral</Button>
       <Button href={referrerCta} variant="outline" size="lg">Refer someone in</Button>
     </div>
@@ -262,60 +239,28 @@
 </div>
 
 <style>
-  /* Motion: one orchestrated page-load reveal. Staggered so the eye lands on the
-     headline first, then the supporting rows. Purely decorative — gated behind
-     prefers-reduced-motion so it never fights assistive settings. */
-  @keyframes fade-up {
+  /* One orchestrated page-load: each .reveal rises in, staggered by its --d.
+     Mirrors HomeView so the landing shares the site's motion language. */
+  .reveal {
+    opacity: 0;
+    animation: rise 0.7s cubic-bezier(0.2, 0.7, 0.2, 1) forwards;
+    animation-delay: var(--d, 0ms);
+  }
+  @keyframes rise {
     from {
       opacity: 0;
-      transform: translateY(12px);
+      transform: translateY(10px);
     }
     to {
       opacity: 1;
-      transform: translateY(0);
+      transform: none;
     }
   }
 
-  .reveal-hero > * {
-    animation: fade-up 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
-  }
-  .reveal-hero > *:nth-child(2) {
-    animation-delay: 0.04s;
-  }
-  .reveal-hero > *:nth-child(3) {
-    animation-delay: 0.1s;
-  }
-  .reveal-hero > *:nth-child(4) {
-    animation-delay: 0.16s;
-  }
-  .reveal-hero > *:nth-child(5) {
-    animation-delay: 0.22s;
-  }
-  .reveal-hero > *:nth-child(6) {
-    animation-delay: 0.28s;
-  }
-
-  /* Soft, contained brand glow behind the hero — atmosphere without a new fill. */
-  .glow {
-    background: radial-gradient(circle at center, var(--brand-ring) 0%, transparent 68%);
-    opacity: 0.16;
-    filter: blur(8px);
-  }
-
-  .path-node {
-    animation: fade-up 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
-  }
-  .path-node:nth-child(3) {
-    animation-delay: 0.06s;
-  }
-  .path-node:nth-child(5) {
-    animation-delay: 0.12s;
-  }
-
   @media (prefers-reduced-motion: reduce) {
-    .reveal-hero > *,
-    .path-node {
+    .reveal {
       animation: none;
+      opacity: 1;
     }
   }
 </style>

--- a/web/src/lib/components/ReferralsLandingView.svelte
+++ b/web/src/lib/components/ReferralsLandingView.svelte
@@ -1,0 +1,321 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { ArrowRight, ShieldCheck, BadgeCheck, Timer, EyeOff, Handshake, Send } from '@lucide/svelte';
+  import { Button } from '$lib/ui';
+
+  // CTA destinations wired to the real feature (no invite-code program exists):
+  //  - The headline "Ask for a referral" points at the referral hub (/my/referrals),
+  //    the account cabinet that gates behind auth and holds both sides of the flow.
+  //  - The seeker card's concrete step is browsing companies: a request is only
+  //    created from a company page, where an approved referrer surfaces ReferralBlock.
+  //  - Insiders offer to refer from that same cabinet's Offers tab.
+  const askCta = resolve('/my/referrals');
+  const browseCta = resolve('/companies');
+  const referrerCta = `${resolve('/my/referrals')}?tab=offers`;
+
+  // The warm path — the honest three beats of an employee referral. Copy mirrors
+  // the mechanics in ReferralsView / RequestReferralModal (anonymous referrer,
+  // seeker-chosen contact channel, moderated proof).
+  const steps = [
+    {
+      n: '01',
+      title: 'You ask',
+      body: 'Pick the company, attach your CV or a tailored one, and leave a contact — Telegram, email, or both. That is the whole request.',
+    },
+    {
+      n: '02',
+      title: 'An insider picks it up',
+      body: 'Your request lands with employees there who offered to refer. They see your CV and note — never your identity — and put your name forward internally.',
+    },
+    {
+      n: '03',
+      title: 'They reach out',
+      body: 'If a referrer takes it on, they contact you directly over the channel you chose. No inbox to check here, no bot in the middle.',
+    },
+  ];
+
+  // Trust rails — why the pool stays real and low-noise. These are enforced
+  // server-side (moderated proof, rolling 24h per-seeker cap, anonymity).
+  const trust = [
+    {
+      icon: EyeOff,
+      title: 'Referrers stay anonymous',
+      body: 'A referrer never sees who you are until they choose to contact you, and you never see them. The intro happens on neutral ground.',
+    },
+    {
+      icon: BadgeCheck,
+      title: 'Real employees only',
+      body: 'Every offer to refer is backed by proof of employment that a moderator reviews before the company becomes referral-eligible.',
+    },
+    {
+      icon: Timer,
+      title: 'No spraying',
+      body: 'A rolling daily cap keeps requests deliberate — this is a warm introduction, not a mass-apply button.',
+    },
+  ];
+
+  const faqs = [
+    {
+      q: 'What does it cost?',
+      a: 'Nothing. freehire is a free, open-source aggregator — referrals included. No fees, no paywall.',
+    },
+    {
+      q: 'Will the referrer see my name?',
+      a: 'No. Referrers only see the CV, note and contact you attach. Your identity is never surfaced — they reach out only if they decide to take your request forward.',
+    },
+    {
+      q: 'How do I know a referrer actually works there?',
+      a: 'Anyone offering to refer uploads proof of employment, and a moderator reviews it before the company appears as referral-available.',
+    },
+    {
+      q: 'I work somewhere great — can I help people in?',
+      a: 'Yes. Offer to refer from your account, upload proof once, and approved requests for your company start reaching you. You stay anonymous throughout.',
+    },
+  ];
+</script>
+
+<div class="flex flex-col gap-20 sm:gap-28">
+  <!-- ── Hero ─────────────────────────────────────────────────────────────── -->
+  <section class="reveal-hero relative isolate flex flex-col gap-7 pt-4">
+    <!-- soft brand glow, contained; decorative only -->
+    <div class="glow pointer-events-none absolute -left-24 -top-24 -z-10 h-80 w-80 rounded-full" aria-hidden="true"></div>
+
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">
+      // referrals · a warm way in
+    </p>
+
+    <h1 class="max-w-3xl text-balance text-4xl font-semibold leading-[0.98] tracking-tighter sm:text-6xl">
+      Referred candidates get seen.
+      <span class="mt-2 block text-muted-foreground sm:ml-[1.5ch]">Everyone else waits in the pile.</span>
+    </h1>
+
+    <p class="max-w-xl text-lg leading-relaxed text-muted-foreground">
+      freehire quietly connects you with someone already inside the company — an employee who can put
+      your name forward. They stay anonymous, you skip the cold apply, and the intro comes warm.
+    </p>
+
+    <!-- signature glyph: the path in one line -->
+    <p class="flex flex-wrap items-center gap-2 font-mono text-xs text-muted-foreground">
+      <span class="rounded-md bg-secondary/60 px-2 py-1 text-foreground">you</span>
+      <ArrowRight class="size-3.5" />
+      <span class="rounded-md border border-brand/25 bg-brand-muted px-2 py-1 text-brand-strong">insider</span>
+      <ArrowRight class="size-3.5" />
+      <span class="rounded-md bg-secondary/60 px-2 py-1 text-foreground">interview</span>
+    </p>
+
+    <div class="flex flex-wrap items-center gap-3">
+      <Button href={askCta} variant="primary" size="lg">Ask for a referral</Button>
+      <Button href={referrerCta} variant="outline" size="lg">Refer someone in</Button>
+    </div>
+
+    <p class="font-mono text-xs text-muted-foreground">
+      free · anonymous referrers · employment verified
+    </p>
+  </section>
+
+  <!-- ── The warm path ────────────────────────────────────────────────────── -->
+  <section class="flex flex-col gap-8">
+    <div class="flex flex-col gap-2">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// how it happens</p>
+      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Three beats from cold list to warm intro</h2>
+    </div>
+
+    <ol class="flex flex-col gap-4 md:flex-row md:items-stretch md:gap-0">
+      {#each steps as step, i (step.n)}
+        <li class="path-node flex flex-1 flex-col gap-3 rounded-xl border border-border p-6">
+          <span class="font-mono text-sm text-brand-strong">{step.n}</span>
+          <h3 class="text-base font-semibold tracking-tight">{step.title}</h3>
+          <p class="text-sm leading-relaxed text-muted-foreground">{step.body}</p>
+        </li>
+        {#if i < steps.length - 1}
+          <div class="hidden shrink-0 items-center justify-center px-3 md:flex" aria-hidden="true">
+            <ArrowRight class="size-5 text-muted-foreground/60" />
+          </div>
+        {/if}
+      {/each}
+    </ol>
+  </section>
+
+  <!-- ── The one line that matters ────────────────────────────────────────── -->
+  <section class="reveal-stat relative overflow-hidden rounded-xl border border-brand/25 bg-brand-muted px-6 py-12 sm:px-12 sm:py-16">
+    <p class="font-mono text-xs uppercase tracking-[0.2em] text-brand-strong/70">// the whole pitch</p>
+    <p class="mt-4 max-w-3xl text-balance text-3xl font-semibold leading-tight tracking-tight text-brand-strong sm:text-5xl">
+      One warm intro beats a hundred cold applications.
+    </p>
+    <p class="mt-5 flex items-center gap-3 font-mono text-sm text-brand-strong/80">
+      <Handshake class="size-5" />
+      referrals are how most roles are actually filled — this is your side door in.
+    </p>
+  </section>
+
+  <!-- ── Two sides ────────────────────────────────────────────────────────── -->
+  <section class="flex flex-col gap-8">
+    <div class="flex flex-col gap-2">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// pick your side</p>
+      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Two ways to use it</h2>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+      <!-- Seeker -->
+      <div class="flex flex-col gap-5 rounded-xl border border-border p-7">
+        <div class="flex items-center gap-3">
+          <span class="flex size-9 items-center justify-center rounded-lg bg-secondary/70">
+            <Send class="size-4.5 text-foreground" />
+          </span>
+          <h3 class="text-lg font-semibold tracking-tight">Looking for a way in</h3>
+        </div>
+        <p class="text-sm leading-relaxed text-muted-foreground">
+          Find a company that has a referrer, attach your CV, and ask. If someone takes it up, they
+          reach out to you directly — no application black hole.
+        </p>
+        <ul class="flex flex-col gap-2.5 text-sm">
+          {#each ['Browse companies and open one with a referrer', 'Attach your CV — uploaded or tailored', 'Leave a contact and a short note', 'Wait for a warm reply'] as point (point)}
+            <li class="flex items-start gap-2.5 leading-relaxed">
+              <ArrowRight class="mt-0.5 size-4 shrink-0 text-brand-strong" />
+              <span class="text-muted-foreground">{point}</span>
+            </li>
+          {/each}
+        </ul>
+        <div class="mt-auto pt-1">
+          <Button href={browseCta} variant="primary" size="md">Find a company to ask</Button>
+        </div>
+      </div>
+
+      <!-- Referrer — brand-tinted to set it apart -->
+      <div class="flex flex-col gap-5 rounded-xl border border-brand/25 bg-brand-muted/50 p-7">
+        <div class="flex items-center gap-3">
+          <span class="flex size-9 items-center justify-center rounded-lg bg-brand-muted">
+            <Handshake class="size-4.5 text-brand-strong" />
+          </span>
+          <h3 class="text-lg font-semibold tracking-tight text-brand-strong">Already inside</h3>
+        </div>
+        <p class="text-sm leading-relaxed text-brand-strong/80">
+          Refer good people into your company without exposing yourself. Offer once, get vetted
+          requests, and act only on the ones you like.
+        </p>
+        <ul class="flex flex-col gap-2.5 text-sm">
+          {#each ['Offer to refer for your company', 'Upload proof of employment once — reviewed by a moderator', 'Receive matching requests, stay anonymous', 'Reach out to the ones worth it'] as point (point)}
+            <li class="flex items-start gap-2.5 leading-relaxed">
+              <ArrowRight class="mt-0.5 size-4 shrink-0 text-brand-strong" />
+              <span class="text-brand-strong/90">{point}</span>
+            </li>
+          {/each}
+        </ul>
+        <div class="mt-auto pt-1">
+          <Button href={referrerCta} variant="primary" size="md">Become a referrer</Button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Trust ────────────────────────────────────────────────────────────── -->
+  <section class="flex flex-col gap-8">
+    <div class="flex flex-col gap-2">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// kept clean</p>
+      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Why it stays worth trusting</h2>
+    </div>
+    <div class="grid gap-6 sm:grid-cols-3">
+      {#each trust as t (t.title)}
+        <div class="flex flex-col gap-3 rounded-xl border border-border p-6">
+          <t.icon class="size-5 text-brand-strong" />
+          <h3 class="text-base font-semibold tracking-tight">{t.title}</h3>
+          <p class="text-sm leading-relaxed text-muted-foreground">{t.body}</p>
+        </div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- ── FAQ ──────────────────────────────────────────────────────────────── -->
+  <section class="flex flex-col gap-8">
+    <div class="flex flex-col gap-2">
+      <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// good to know</p>
+      <h2 class="max-w-xl text-2xl font-semibold tracking-tight">Questions people ask first</h2>
+    </div>
+    <div class="grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2">
+      {#each faqs as f (f.q)}
+        <details class="group bg-background p-6">
+          <summary class="flex cursor-pointer list-none items-center justify-between gap-3 text-sm font-semibold tracking-tight">
+            {f.q}
+            <ArrowRight class="size-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+          </summary>
+          <p class="mt-3 text-sm leading-relaxed text-muted-foreground">{f.a}</p>
+        </details>
+      {/each}
+    </div>
+  </section>
+
+  <!-- ── Closing CTA ──────────────────────────────────────────────────────── -->
+  <section class="flex flex-col items-start gap-5 rounded-xl border border-border bg-secondary/40 p-8">
+    <div class="flex items-center gap-3">
+      <ShieldCheck class="size-6 text-brand-strong" />
+      <h2 class="text-xl font-semibold tracking-tight">Skip the pile</h2>
+    </div>
+    <p class="max-w-xl text-sm leading-relaxed text-muted-foreground">
+      Ask an insider to put your name forward, or open the door for someone else. Either way it takes
+      a couple of minutes and stays anonymous.
+    </p>
+    <div class="flex flex-wrap gap-3">
+      <Button href={askCta} variant="primary" size="lg">Ask for a referral</Button>
+      <Button href={referrerCta} variant="outline" size="lg">Refer someone in</Button>
+    </div>
+  </section>
+</div>
+
+<style>
+  /* Motion: one orchestrated page-load reveal. Staggered so the eye lands on the
+     headline first, then the supporting rows. Purely decorative — gated behind
+     prefers-reduced-motion so it never fights assistive settings. */
+  @keyframes fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .reveal-hero > * {
+    animation: fade-up 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  .reveal-hero > *:nth-child(2) {
+    animation-delay: 0.04s;
+  }
+  .reveal-hero > *:nth-child(3) {
+    animation-delay: 0.1s;
+  }
+  .reveal-hero > *:nth-child(4) {
+    animation-delay: 0.16s;
+  }
+  .reveal-hero > *:nth-child(5) {
+    animation-delay: 0.22s;
+  }
+  .reveal-hero > *:nth-child(6) {
+    animation-delay: 0.28s;
+  }
+
+  /* Soft, contained brand glow behind the hero — atmosphere without a new fill. */
+  .glow {
+    background: radial-gradient(circle at center, var(--brand-ring) 0%, transparent 68%);
+    opacity: 0.16;
+    filter: blur(8px);
+  }
+
+  .path-node {
+    animation: fade-up 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  .path-node:nth-child(3) {
+    animation-delay: 0.06s;
+  }
+  .path-node:nth-child(5) {
+    animation-delay: 0.12s;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .reveal-hero > *,
+    .path-node {
+      animation: none;
+    }
+  }
+</style>

--- a/web/src/lib/components/ReferralsLandingView.svelte
+++ b/web/src/lib/components/ReferralsLandingView.svelte
@@ -12,6 +12,14 @@
   const browseCta = resolve('/companies');
   const referrerCta = `${resolve('/my/referrals')}?tab=offers`;
 
+  // Illustrative referrer inbox for the hero — decorative, not live data. Mirrors
+  // the real incoming-request card (ReferralsView) so the preview shows the actual
+  // anonymized view a referrer acts on: the CV and the role, never who it is.
+  const inbox = [
+    { company: 'Linear', role: 'Senior Backend Engineer', time: '2h' },
+    { company: 'Stripe', role: 'Staff Frontend Engineer', time: '5h' },
+  ];
+
   // The warm path — the honest three beats of an employee referral. Copy mirrors
   // the mechanics in ReferralsView / RequestReferralModal (anonymous referrer,
   // seeker-chosen contact channel, moderated proof).
@@ -88,42 +96,84 @@
 
 <div class="landing">
   <!-- ── Hero ─────────────────────────────────────────────────────────────── -->
-  <section class="pb-4 pt-14 sm:pt-20">
-    <p class="reveal font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground" style="--d:0ms">
-      // referrals · a warm way in
-    </p>
+  <section class="dot-grid -mx-4 px-4 pb-4 pt-14 sm:pt-20">
+    <div class="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
+      <div>
+        <p class="reveal font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground" style="--d:0ms">
+          // referrals · a warm way in
+        </p>
 
-    <h1
-      class="reveal mt-6 max-w-3xl text-balance text-5xl font-semibold leading-[0.95] tracking-tighter sm:text-7xl"
-      style="--d:80ms"
-    >
-      Referred candidates get seen.
-      <span class="mt-2 block text-muted-foreground">Everyone else waits in the pile.</span>
-    </h1>
+        <h1
+          class="reveal mt-6 max-w-2xl text-balance text-5xl font-semibold leading-[0.95] tracking-tighter sm:text-7xl"
+          style="--d:80ms"
+        >
+          Referred candidates get seen.
+          <span class="mt-2 block text-muted-foreground">Everyone else waits in the pile.</span>
+        </h1>
 
-    <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
-      Everyone knows a referral is the fastest way in. The hard part is finding someone inside who'll
-      make it. freehire surfaces the companies that already have a willing insider — and connects you
-      to them, so you can stop cold-DMing strangers.
-    </p>
+        <p class="reveal mt-7 max-w-xl text-lg leading-relaxed text-muted-foreground" style="--d:160ms">
+          Everyone knows a referral is the fastest way in. The hard part is finding someone inside
+          who'll make it. freehire surfaces the companies that already have a willing insider — and
+          connects you to them, so you can stop cold-DMing strangers.
+        </p>
 
-    <!-- signature glyph: the path in one line, drawn in the muted mono register -->
-    <p class="reveal mt-7 flex flex-wrap items-center gap-2 font-mono text-xs text-muted-foreground" style="--d:220ms">
-      <span class="rounded-md border border-border px-2 py-1 text-foreground">you</span>
-      <span aria-hidden="true">→</span>
-      <span class="rounded-md border border-border px-2 py-1 text-foreground">insider</span>
-      <span aria-hidden="true">→</span>
-      <span class="rounded-md border border-border px-2 py-1 text-foreground">interview</span>
-    </p>
+        <!-- signature glyph: the path in one line, drawn in the muted mono register -->
+        <p class="reveal mt-7 flex flex-wrap items-center gap-2 font-mono text-xs text-muted-foreground" style="--d:220ms">
+          <span class="rounded-md border border-border bg-background px-2 py-1 text-foreground">you</span>
+          <span aria-hidden="true">→</span>
+          <span class="rounded-md border border-border bg-background px-2 py-1 text-foreground">insider</span>
+          <span aria-hidden="true">→</span>
+          <span class="rounded-md border border-border bg-background px-2 py-1 text-foreground">interview</span>
+        </p>
 
-    <div class="reveal mt-9 flex flex-wrap items-center gap-3" style="--d:300ms">
-      <Button href={askCta} variant="primary" size="lg">Ask for a referral</Button>
-      <Button href={referrerCta} variant="outline" size="lg">Refer someone in</Button>
+        <div class="reveal mt-9 flex flex-wrap items-center gap-3" style="--d:300ms">
+          <Button href={askCta} variant="primary" size="lg">Ask for a referral</Button>
+          <Button href={referrerCta} variant="outline" size="lg">Refer someone in</Button>
+        </div>
+
+        <p class="reveal mt-6 font-mono text-xs text-muted-foreground" style="--d:360ms">
+          free · anonymous referrers · employment verified
+        </p>
+      </div>
+
+      <!-- Referrer inbox preview: the anonymized view an insider acts on — the CV
+           and role, never who it is. Decorative, not live data. Hidden below lg. -->
+      <div class="reveal hidden lg:block" style="--d:420ms">
+        <figure class="overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+          <figcaption class="flex items-center gap-2 border-b border-border px-4 py-2.5 text-xs text-muted-foreground">
+            <span class="size-2.5 rounded-full bg-muted-foreground/30"></span>
+            Referrals · Inbox
+          </figcaption>
+          <div class="flex flex-col gap-3 p-4">
+            {#each inbox as r (r.company)}
+              <article class="rounded-lg border border-border bg-background p-4">
+                <div class="flex items-center justify-between gap-3">
+                  <p class="text-sm font-medium">Referral request · {r.company}</p>
+                  <span class="shrink-0 font-mono text-[11px] text-muted-foreground">{r.time}</span>
+                </div>
+                <div class="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                  <span
+                    class="grid size-6 shrink-0 place-items-center rounded-full border border-border"
+                    aria-hidden="true"
+                  >
+                    •
+                  </span>
+                  Anonymous candidate · {r.role}
+                </div>
+                <div class="mt-3 flex items-center gap-2">
+                  <span class="rounded-md border border-border px-2 py-0.5 font-mono text-[11px] text-muted-foreground">
+                    CV attached
+                  </span>
+                  <span class="flex-1"></span>
+                  <span class="rounded-md bg-foreground px-2.5 py-1 text-[11px] font-medium text-background">Refer</span>
+                  <span class="rounded-md border border-border px-2.5 py-1 text-[11px] font-medium text-muted-foreground">Pass</span>
+                </div>
+              </article>
+            {/each}
+          </div>
+        </figure>
+      </div>
     </div>
-
-    <p class="reveal mt-6 font-mono text-xs text-muted-foreground" style="--d:360ms">
-      free · anonymous referrers · employment verified
-    </p>
   </section>
 
   <!-- ── The warm path ────────────────────────────────────────────────────── -->

--- a/web/src/lib/sitemap.ts
+++ b/web/src/lib/sitemap.ts
@@ -20,6 +20,7 @@ export const STATIC_PATHS = [
   '/cli',
   '/chatgpt',
   '/recruiters',
+  '/referrals',
 ];
 
 /** The curated collection landing pages (`/collections/:slug`), one per collection.

--- a/web/src/routes/open/+page.svelte
+++ b/web/src/routes/open/+page.svelte
@@ -124,7 +124,7 @@
 
 <div class="mx-auto w-full max-w-4xl px-4 py-10 sm:py-14">
   <!-- Intro -->
-  <header class="mb-12">
+  <header class="dot-grid -mx-4 mb-12 px-4 pb-8 pt-4">
     <p class="font-mono text-xs uppercase tracking-[0.2em] text-muted-foreground">// open startup</p>
     <h1 class="mt-4 text-4xl font-semibold tracking-tighter sm:text-5xl">All our numbers, live.</h1>
     <p class="mt-4 max-w-2xl text-lg leading-relaxed text-muted-foreground">

--- a/web/src/routes/referrals/+page.svelte
+++ b/web/src/routes/referrals/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { page } from '$app/state';
+  import ReferralsLandingView from '$lib/components/ReferralsLandingView.svelte';
+  import Seo from '$lib/components/Seo.svelte';
+
+  const canonical = $derived(`${page.url.origin}/referrals`);
+</script>
+
+<Seo
+  title="Get referred — warm intros over cold applies | freehire"
+  description="Ask an employee inside the company to put your name forward — anonymously, for free. freehire's referral marketplace connects job seekers with verified insiders who can refer them, and lets employees offer to refer good people in."
+  {canonical}
+/>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6">
+  <ReferralsLandingView />
+</div>


### PR DESCRIPTION
## What

Public, two-sided marketing landing at **`/referrals`** for the existing employee-referral feature (seekers ask an insider to refer them; employees offer to refer). The feature had a full backend + account cabinet but no public entry point.

## Design

Follows the `/for-companies` canon (Seo wrapper, `max-w-6xl` container, oats-green brand tokens, system fonts) with an editorial treatment that stays on-brand:

- Stepped hero + signature `you → insider → interview` glyph, contained brand glow
- "Warm path" three-step flow with connectors
- Oversized pitch band on `brand-muted`
- Two-sided seeker / referrer cards (referrer card brand-tinted)
- Trust rails (anonymity / verified employment / daily cap) + native `<details>` FAQ
- CSS-only staggered reveal, gated behind `prefers-reduced-motion`

## CTAs (wired to the real flow, no false promises)

- **Ask for a referral** → `/my/referrals`
- Seeker card **Find a company to ask** → `/companies` (a request is created from a company page via `ReferralBlock`)
- **Become a referrer** → `/my/referrals?tab=offers`

## Discoverability

- Footer "Product" group link
- `STATIC_PATHS` sitemap entry

## Verification

- `svelte-check` — 0 errors
- `sitemap.test.ts` — 4/4 pass
- SSR 200; verified desktop + mobile (390px, no horizontal overflow via CDP)

_Frontend only — no backend changes._