### PR TITLE
feat(referrals): company name+logo + required LinkedIn on both sides

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -345,6 +345,7 @@ type ReferralOffer struct {
 	DecidedBy      pgtype.Int8        `json:"decided_by"`
 	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	LinkedinUrl    string             `json:"linkedin_url"`
 }
 
 type ReferralRequest struct {
@@ -361,6 +362,7 @@ type ReferralRequest struct {
 	ActedBy         pgtype.Int8        `json:"acted_by"`
 	ActedAt         pgtype.Timestamptz `json:"acted_at"`
 	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	LinkedinUrl     string             `json:"linkedin_url"`
 }
 
 type ReminderSetting struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -670,8 +670,10 @@ type Querier interface {
 	// record-level data.
 	ListFacetStats(ctx context.Context) ([]InsightsFacetStat, error)
 	// The referrer inbox: open (sent) requests for every company the referrer has an approved
-	// offer for. Joins the request pool to the caller's approved offers on company_slug.
-	ListIncomingReferralRequests(ctx context.Context, referrerUserID int64) ([]ReferralRequest, error)
+	// offer for. Joins the request pool to the caller's approved offers on company_slug, and
+	// the catalogue for the company's display name (LEFT so a request survives an unknown
+	// company — the UI falls back to the slug).
+	ListIncomingReferralRequests(ctx context.Context, referrerUserID int64) ([]ListIncomingReferralRequestsRow, error)
 	// The leaderboard read: companies ranked by growth (open_count - open_count_prev),
 	// '-growth' (freezing) reverses it, 'open' ranks by raw size; open_count is the
 	// tiebreak. @min_open floors the current open-count (blunts ingest-artifact spikes).
@@ -774,7 +776,9 @@ type Querier interface {
 	// company the catalogue no longer knows — the UI falls back to the slug).
 	ListReferralOffersByUser(ctx context.Context, userID int64) ([]ListReferralOffersByUserRow, error)
 	// The seeker's "my requests" list: their requests with current status, newest first.
-	ListReferralRequestsBySeeker(ctx context.Context, seekerUserID int64) ([]ReferralRequest, error)
+	// Joins the catalogue for the company's display name (LEFT so a request survives a
+	// company the catalogue no longer knows — the UI falls back to the slug).
+	ListReferralRequestsBySeeker(ctx context.Context, seekerUserID int64) ([]ListReferralRequestsBySeekerRow, error)
 	// The open postings sharing a role cluster (company_slug + role_fingerprint) with the
 	// anchor job — the "N openings across cities" list for a collapsed role. Each copy keeps
 	// its own location and apply URL, so a seeker picks their city; the anchor itself is

--- a/internal/db/queries/referrals.sql
+++ b/internal/db/queries/referrals.sql
@@ -2,8 +2,8 @@
 -- Record a member's offer to refer into a company. The UNIQUE (user_id, company_slug)
 -- constraint rejects a second offer for the same company; the repository maps that unique
 -- violation to a domain "already offered" error. Starts pending, awaiting moderation.
-INSERT INTO referral_offers (user_id, company_slug, proof_object_key)
-VALUES ($1, $2, $3)
+INSERT INTO referral_offers (user_id, company_slug, proof_object_key, linkedin_url)
+VALUES ($1, $2, $3, $4)
 RETURNING *;
 
 -- name: ListReferralOffersByUser :many
@@ -95,22 +95,30 @@ SELECT EXISTS (
 -- the same company; the repository maps that unique violation to "already requested".
 INSERT INTO referral_requests (
     seeker_user_id, company_slug, job_id, cv_kind, cv_id,
-    contact_telegram, contact_email, note
+    contact_telegram, contact_email, note, linkedin_url
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING *;
 
 -- name: ListReferralRequestsBySeeker :many
 -- The seeker's "my requests" list: their requests with current status, newest first.
-SELECT * FROM referral_requests
-WHERE seeker_user_id = $1
-ORDER BY created_at DESC;
+-- Joins the catalogue for the company's display name (LEFT so a request survives a
+-- company the catalogue no longer knows — the UI falls back to the slug).
+SELECT r.*, c.name AS company_name
+FROM referral_requests r
+LEFT JOIN companies c ON c.slug = r.company_slug
+WHERE r.seeker_user_id = $1
+ORDER BY r.created_at DESC;
 
 -- name: ListIncomingReferralRequests :many
 -- The referrer inbox: open (sent) requests for every company the referrer has an approved
--- offer for. Joins the request pool to the caller's approved offers on company_slug.
-SELECT r.* FROM referral_requests r
+-- offer for. Joins the request pool to the caller's approved offers on company_slug, and
+-- the catalogue for the company's display name (LEFT so a request survives an unknown
+-- company — the UI falls back to the slug).
+SELECT r.*, c.name AS company_name
+FROM referral_requests r
 JOIN referral_offers o ON o.company_slug = r.company_slug
+LEFT JOIN companies c ON c.slug = r.company_slug
 WHERE o.user_id = sqlc.arg(referrer_user_id) AND o.status = 'approved' AND r.status = 'sent'
 ORDER BY r.created_at DESC;
 

--- a/internal/db/referrals.sql.go
+++ b/internal/db/referrals.sql.go
@@ -92,22 +92,28 @@ func (q *Queries) CountReferralRequestsSince(ctx context.Context, arg CountRefer
 }
 
 const createReferralOffer = `-- name: CreateReferralOffer :one
-INSERT INTO referral_offers (user_id, company_slug, proof_object_key)
-VALUES ($1, $2, $3)
-RETURNING id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at
+INSERT INTO referral_offers (user_id, company_slug, proof_object_key, linkedin_url)
+VALUES ($1, $2, $3, $4)
+RETURNING id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url
 `
 
 type CreateReferralOfferParams struct {
 	UserID         int64  `json:"user_id"`
 	CompanySlug    string `json:"company_slug"`
 	ProofObjectKey string `json:"proof_object_key"`
+	LinkedinUrl    string `json:"linkedin_url"`
 }
 
 // Record a member's offer to refer into a company. The UNIQUE (user_id, company_slug)
 // constraint rejects a second offer for the same company; the repository maps that unique
 // violation to a domain "already offered" error. Starts pending, awaiting moderation.
 func (q *Queries) CreateReferralOffer(ctx context.Context, arg CreateReferralOfferParams) (ReferralOffer, error) {
-	row := q.db.QueryRow(ctx, createReferralOffer, arg.UserID, arg.CompanySlug, arg.ProofObjectKey)
+	row := q.db.QueryRow(ctx, createReferralOffer,
+		arg.UserID,
+		arg.CompanySlug,
+		arg.ProofObjectKey,
+		arg.LinkedinUrl,
+	)
 	var i ReferralOffer
 	err := row.Scan(
 		&i.ID,
@@ -118,6 +124,7 @@ func (q *Queries) CreateReferralOffer(ctx context.Context, arg CreateReferralOff
 		&i.DecidedBy,
 		&i.DecidedAt,
 		&i.CreatedAt,
+		&i.LinkedinUrl,
 	)
 	return i, err
 }
@@ -125,10 +132,10 @@ func (q *Queries) CreateReferralOffer(ctx context.Context, arg CreateReferralOff
 const createReferralRequest = `-- name: CreateReferralRequest :one
 INSERT INTO referral_requests (
     seeker_user_id, company_slug, job_id, cv_kind, cv_id,
-    contact_telegram, contact_email, note
+    contact_telegram, contact_email, note, linkedin_url
 )
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url
 `
 
 type CreateReferralRequestParams struct {
@@ -140,6 +147,7 @@ type CreateReferralRequestParams struct {
 	ContactTelegram pgtype.Text `json:"contact_telegram"`
 	ContactEmail    pgtype.Text `json:"contact_email"`
 	Note            string      `json:"note"`
+	LinkedinUrl     string      `json:"linkedin_url"`
 }
 
 // Record a seeker's referral request into a company. The partial unique index on
@@ -155,6 +163,7 @@ func (q *Queries) CreateReferralRequest(ctx context.Context, arg CreateReferralR
 		arg.ContactTelegram,
 		arg.ContactEmail,
 		arg.Note,
+		arg.LinkedinUrl,
 	)
 	var i ReferralRequest
 	err := row.Scan(
@@ -171,6 +180,7 @@ func (q *Queries) CreateReferralRequest(ctx context.Context, arg CreateReferralR
 		&i.ActedBy,
 		&i.ActedAt,
 		&i.CreatedAt,
+		&i.LinkedinUrl,
 	)
 	return i, err
 }
@@ -179,7 +189,7 @@ const decideReferralOffer = `-- name: DecideReferralOffer :one
 UPDATE referral_offers
 SET status = $1, decided_by = $2, decided_at = now()
 WHERE id = $3 AND status = 'pending'
-RETURNING id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at
+RETURNING id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url
 `
 
 type DecideReferralOfferParams struct {
@@ -203,6 +213,7 @@ func (q *Queries) DecideReferralOffer(ctx context.Context, arg DecideReferralOff
 		&i.DecidedBy,
 		&i.DecidedAt,
 		&i.CreatedAt,
+		&i.LinkedinUrl,
 	)
 	return i, err
 }
@@ -229,7 +240,7 @@ func (q *Queries) DeleteReferralOffer(ctx context.Context, arg DeleteReferralOff
 }
 
 const getReferralOffer = `-- name: GetReferralOffer :one
-SELECT id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at FROM referral_offers WHERE id = $1
+SELECT id, user_id, company_slug, proof_object_key, status, decided_by, decided_at, created_at, linkedin_url FROM referral_offers WHERE id = $1
 `
 
 // One offer by id — for the moderator's proof-CV view after role authorization.
@@ -245,12 +256,13 @@ func (q *Queries) GetReferralOffer(ctx context.Context, id int64) (ReferralOffer
 		&i.DecidedBy,
 		&i.DecidedAt,
 		&i.CreatedAt,
+		&i.LinkedinUrl,
 	)
 	return i, err
 }
 
 const getReferralRequest = `-- name: GetReferralRequest :one
-SELECT id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at FROM referral_requests WHERE id = $1
+SELECT id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url FROM referral_requests WHERE id = $1
 `
 
 // One referral request by id — for authorized CV access and marking, after the caller is
@@ -272,6 +284,7 @@ func (q *Queries) GetReferralRequest(ctx context.Context, id int64) (ReferralReq
 		&i.ActedBy,
 		&i.ActedAt,
 		&i.CreatedAt,
+		&i.LinkedinUrl,
 	)
 	return i, err
 }
@@ -314,23 +327,45 @@ func (q *Queries) ListApprovedReferrerRecipients(ctx context.Context, companySlu
 }
 
 const listIncomingReferralRequests = `-- name: ListIncomingReferralRequests :many
-SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.cv_id, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at FROM referral_requests r
+SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.cv_id, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, c.name AS company_name
+FROM referral_requests r
 JOIN referral_offers o ON o.company_slug = r.company_slug
+LEFT JOIN companies c ON c.slug = r.company_slug
 WHERE o.user_id = $1 AND o.status = 'approved' AND r.status = 'sent'
 ORDER BY r.created_at DESC
 `
 
+type ListIncomingReferralRequestsRow struct {
+	ID              int64              `json:"id"`
+	SeekerUserID    int64              `json:"seeker_user_id"`
+	CompanySlug     string             `json:"company_slug"`
+	JobID           pgtype.Int8        `json:"job_id"`
+	CvKind          string             `json:"cv_kind"`
+	CvID            pgtype.Int8        `json:"cv_id"`
+	ContactTelegram pgtype.Text        `json:"contact_telegram"`
+	ContactEmail    pgtype.Text        `json:"contact_email"`
+	Note            string             `json:"note"`
+	Status          string             `json:"status"`
+	ActedBy         pgtype.Int8        `json:"acted_by"`
+	ActedAt         pgtype.Timestamptz `json:"acted_at"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	LinkedinUrl     string             `json:"linkedin_url"`
+	CompanyName     pgtype.Text        `json:"company_name"`
+}
+
 // The referrer inbox: open (sent) requests for every company the referrer has an approved
-// offer for. Joins the request pool to the caller's approved offers on company_slug.
-func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUserID int64) ([]ReferralRequest, error) {
+// offer for. Joins the request pool to the caller's approved offers on company_slug, and
+// the catalogue for the company's display name (LEFT so a request survives an unknown
+// company — the UI falls back to the slug).
+func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUserID int64) ([]ListIncomingReferralRequestsRow, error) {
 	rows, err := q.db.Query(ctx, listIncomingReferralRequests, referrerUserID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ReferralRequest{}
+	items := []ListIncomingReferralRequestsRow{}
 	for rows.Next() {
-		var i ReferralRequest
+		var i ListIncomingReferralRequestsRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.SeekerUserID,
@@ -345,6 +380,8 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 			&i.ActedBy,
 			&i.ActedAt,
 			&i.CreatedAt,
+			&i.LinkedinUrl,
+			&i.CompanyName,
 		); err != nil {
 			return nil, err
 		}
@@ -357,7 +394,7 @@ func (q *Queries) ListIncomingReferralRequests(ctx context.Context, referrerUser
 }
 
 const listPendingReferralOffers = `-- name: ListPendingReferralOffers :many
-SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, c.name AS company_name
+SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, o.linkedin_url, c.name AS company_name
 FROM referral_offers o
 LEFT JOIN companies c ON c.slug = o.company_slug
 WHERE o.status = 'pending'
@@ -373,6 +410,7 @@ type ListPendingReferralOffersRow struct {
 	DecidedBy      pgtype.Int8        `json:"decided_by"`
 	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	LinkedinUrl    string             `json:"linkedin_url"`
 	CompanyName    pgtype.Text        `json:"company_name"`
 }
 
@@ -395,6 +433,7 @@ func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ListPendingR
 			&i.DecidedBy,
 			&i.DecidedAt,
 			&i.CreatedAt,
+			&i.LinkedinUrl,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -408,7 +447,7 @@ func (q *Queries) ListPendingReferralOffers(ctx context.Context) ([]ListPendingR
 }
 
 const listReferralOffersByUser = `-- name: ListReferralOffersByUser :many
-SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, c.name AS company_name
+SELECT o.id, o.user_id, o.company_slug, o.proof_object_key, o.status, o.decided_by, o.decided_at, o.created_at, o.linkedin_url, c.name AS company_name
 FROM referral_offers o
 LEFT JOIN companies c ON c.slug = o.company_slug
 WHERE o.user_id = $1
@@ -424,6 +463,7 @@ type ListReferralOffersByUserRow struct {
 	DecidedBy      pgtype.Int8        `json:"decided_by"`
 	DecidedAt      pgtype.Timestamptz `json:"decided_at"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	LinkedinUrl    string             `json:"linkedin_url"`
 	CompanyName    pgtype.Text        `json:"company_name"`
 }
 
@@ -448,6 +488,7 @@ func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([
 			&i.DecidedBy,
 			&i.DecidedAt,
 			&i.CreatedAt,
+			&i.LinkedinUrl,
 			&i.CompanyName,
 		); err != nil {
 			return nil, err
@@ -461,21 +502,43 @@ func (q *Queries) ListReferralOffersByUser(ctx context.Context, userID int64) ([
 }
 
 const listReferralRequestsBySeeker = `-- name: ListReferralRequestsBySeeker :many
-SELECT id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at FROM referral_requests
-WHERE seeker_user_id = $1
-ORDER BY created_at DESC
+SELECT r.id, r.seeker_user_id, r.company_slug, r.job_id, r.cv_kind, r.cv_id, r.contact_telegram, r.contact_email, r.note, r.status, r.acted_by, r.acted_at, r.created_at, r.linkedin_url, c.name AS company_name
+FROM referral_requests r
+LEFT JOIN companies c ON c.slug = r.company_slug
+WHERE r.seeker_user_id = $1
+ORDER BY r.created_at DESC
 `
 
+type ListReferralRequestsBySeekerRow struct {
+	ID              int64              `json:"id"`
+	SeekerUserID    int64              `json:"seeker_user_id"`
+	CompanySlug     string             `json:"company_slug"`
+	JobID           pgtype.Int8        `json:"job_id"`
+	CvKind          string             `json:"cv_kind"`
+	CvID            pgtype.Int8        `json:"cv_id"`
+	ContactTelegram pgtype.Text        `json:"contact_telegram"`
+	ContactEmail    pgtype.Text        `json:"contact_email"`
+	Note            string             `json:"note"`
+	Status          string             `json:"status"`
+	ActedBy         pgtype.Int8        `json:"acted_by"`
+	ActedAt         pgtype.Timestamptz `json:"acted_at"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	LinkedinUrl     string             `json:"linkedin_url"`
+	CompanyName     pgtype.Text        `json:"company_name"`
+}
+
 // The seeker's "my requests" list: their requests with current status, newest first.
-func (q *Queries) ListReferralRequestsBySeeker(ctx context.Context, seekerUserID int64) ([]ReferralRequest, error) {
+// Joins the catalogue for the company's display name (LEFT so a request survives a
+// company the catalogue no longer knows — the UI falls back to the slug).
+func (q *Queries) ListReferralRequestsBySeeker(ctx context.Context, seekerUserID int64) ([]ListReferralRequestsBySeekerRow, error) {
 	rows, err := q.db.Query(ctx, listReferralRequestsBySeeker, seekerUserID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ReferralRequest{}
+	items := []ListReferralRequestsBySeekerRow{}
 	for rows.Next() {
-		var i ReferralRequest
+		var i ListReferralRequestsBySeekerRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.SeekerUserID,
@@ -490,6 +553,8 @@ func (q *Queries) ListReferralRequestsBySeeker(ctx context.Context, seekerUserID
 			&i.ActedBy,
 			&i.ActedAt,
 			&i.CreatedAt,
+			&i.LinkedinUrl,
+			&i.CompanyName,
 		); err != nil {
 			return nil, err
 		}
@@ -526,7 +591,7 @@ const resolveReferralRequest = `-- name: ResolveReferralRequest :one
 UPDATE referral_requests
 SET status = $1, acted_by = $2, acted_at = now()
 WHERE id = $3 AND status = 'sent'
-RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at
+RETURNING id, seeker_user_id, company_slug, job_id, cv_kind, cv_id, contact_telegram, contact_email, note, status, acted_by, acted_at, created_at, linkedin_url
 `
 
 type ResolveReferralRequestParams struct {
@@ -555,6 +620,7 @@ func (q *Queries) ResolveReferralRequest(ctx context.Context, arg ResolveReferra
 		&i.ActedBy,
 		&i.ActedAt,
 		&i.CreatedAt,
+		&i.LinkedinUrl,
 	)
 	return i, err
 }

--- a/internal/handler/referrals.go
+++ b/internal/handler/referrals.go
@@ -20,6 +20,7 @@ type referralOfferResponse struct {
 	ID          int64      `json:"id"`
 	CompanySlug string     `json:"company_slug"`
 	CompanyName string     `json:"company_name"`
+	LinkedInURL string     `json:"linkedin_url"`
 	Status      string     `json:"status"`
 	DecidedAt   *time.Time `json:"decided_at"`
 	CreatedAt   *time.Time `json:"created_at"`
@@ -27,7 +28,8 @@ type referralOfferResponse struct {
 
 func toReferralOfferResponse(o referral.Offer) referralOfferResponse {
 	return referralOfferResponse{
-		ID: o.ID, CompanySlug: o.CompanySlug, CompanyName: o.CompanyName, Status: o.Status,
+		ID: o.ID, CompanySlug: o.CompanySlug, CompanyName: o.CompanyName,
+		LinkedInURL: o.LinkedInURL, Status: o.Status,
 		DecidedAt: o.DecidedAt, CreatedAt: o.CreatedAt,
 	}
 }
@@ -37,6 +39,7 @@ func toReferralOfferResponse(o referral.Offer) referralOfferResponse {
 type seekerRequestResponse struct {
 	ID          int64      `json:"id"`
 	CompanySlug string     `json:"company_slug"`
+	CompanyName string     `json:"company_name"`
 	JobID       *int64     `json:"job_id"`
 	CVKind      string     `json:"cv_kind"`
 	CVID        *int64     `json:"cv_id"`
@@ -46,8 +49,8 @@ type seekerRequestResponse struct {
 
 func toSeekerRequestResponse(r referral.Request) seekerRequestResponse {
 	return seekerRequestResponse{
-		ID: r.ID, CompanySlug: r.CompanySlug, JobID: r.JobID, CVKind: r.CVKind,
-		CVID: r.CVID, Status: r.Status, CreatedAt: r.CreatedAt,
+		ID: r.ID, CompanySlug: r.CompanySlug, CompanyName: r.CompanyName, JobID: r.JobID,
+		CVKind: r.CVKind, CVID: r.CVID, Status: r.Status, CreatedAt: r.CreatedAt,
 	}
 }
 
@@ -57,8 +60,10 @@ func toSeekerRequestResponse(r referral.Request) seekerRequestResponse {
 type incomingRequestResponse struct {
 	ID              int64      `json:"id"`
 	CompanySlug     string     `json:"company_slug"`
+	CompanyName     string     `json:"company_name"`
 	JobID           *int64     `json:"job_id"`
 	CVKind          string     `json:"cv_kind"`
+	LinkedInURL     string     `json:"linkedin_url,omitempty"`
 	ContactTelegram string     `json:"contact_telegram,omitempty"`
 	ContactEmail    string     `json:"contact_email,omitempty"`
 	Note            string     `json:"note,omitempty"`
@@ -68,7 +73,8 @@ type incomingRequestResponse struct {
 
 func toIncomingRequestResponse(r referral.Request) incomingRequestResponse {
 	return incomingRequestResponse{
-		ID: r.ID, CompanySlug: r.CompanySlug, JobID: r.JobID, CVKind: r.CVKind,
+		ID: r.ID, CompanySlug: r.CompanySlug, CompanyName: r.CompanyName, JobID: r.JobID,
+		CVKind: r.CVKind, LinkedInURL: r.LinkedInURL,
 		ContactTelegram: r.ContactTelegram, ContactEmail: r.ContactEmail, Note: r.Note,
 		Status: r.Status, CreatedAt: r.CreatedAt,
 	}
@@ -80,6 +86,7 @@ func toIncomingRequestResponse(r referral.Request) incomingRequestResponse {
 func referralError(err error) error {
 	switch {
 	case errors.Is(err, referral.ErrProofRequired),
+		errors.Is(err, referral.ErrInvalidLinkedIn),
 		errors.Is(err, referral.ErrNoContact),
 		errors.Is(err, referral.ErrInvalidCVChoice),
 		errors.Is(err, referral.ErrNoResume):
@@ -116,6 +123,7 @@ type createReferralRequestBody struct {
 	JobID           *int64 `json:"job_id"`
 	CVKind          string `json:"cv_kind"`
 	CVID            *int64 `json:"cv_id"`
+	LinkedInURL     string `json:"linkedin_url"`
 	ContactTelegram string `json:"contact_telegram"`
 	ContactEmail    string `json:"contact_email"`
 	Note            string `json:"note"`
@@ -138,6 +146,7 @@ func (a *API) CreateReferralRequest(c *fiber.Ctx) error {
 		JobID:           in.JobID,
 		CVKind:          in.CVKind,
 		CVID:            in.CVID,
+		LinkedInURL:     in.LinkedInURL,
 		ContactTelegram: in.ContactTelegram,
 		ContactEmail:    in.ContactEmail,
 		Note:            in.Note,
@@ -189,7 +198,7 @@ func (a *API) SubmitReferralOffer(c *fiber.Ctx) error {
 		return err
 	}
 	offer, err := a.referral.SubmitOffer(c.Context(), referral.OfferInput{
-		UserID: userID, CompanySlug: companySlug, ProofKey: key,
+		UserID: userID, CompanySlug: companySlug, LinkedInURL: c.FormValue("linkedin_url"), ProofKey: key,
 	})
 	if err != nil {
 		return referralError(err)

--- a/internal/handler/referrals_integration_test.go
+++ b/internal/handler/referrals_integration_test.go
@@ -97,7 +97,7 @@ func TestReferralEndpoints(t *testing.T) {
 	}
 
 	// A request into a company with no approved referrer is a 409.
-	reqBody := map[string]any{"company_slug": "acme", "cv_kind": "original", "contact_email": "seeker@example.test", "note": "hi"}
+	reqBody := map[string]any{"company_slug": "acme", "cv_kind": "original", "contact_email": "seeker@example.test", "linkedin_url": "https://www.linkedin.com/in/seeker", "note": "hi"}
 	if code, _ := do(http.MethodPost, "/api/v1/me/referrals/requests", token(seeker), reqBody); code != http.StatusConflict {
 		t.Fatalf("request without referrer: status %d, want 409", code)
 	}
@@ -135,6 +135,9 @@ func TestReferralEndpoints(t *testing.T) {
 		}
 		if rows[0].(map[string]any)["contact_email"] != "seeker@example.test" {
 			t.Errorf("inbox row = %v, want seeker contact", rows[0])
+		}
+		if rows[0].(map[string]any)["linkedin_url"] != "https://www.linkedin.com/in/seeker" {
+			t.Errorf("inbox row = %v, want seeker LinkedIn", rows[0])
 		}
 
 		// CV access is cabinet-only: the seeker (not an approved referrer) is refused.

--- a/internal/referral/referral.go
+++ b/internal/referral/referral.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -45,6 +46,8 @@ const DefaultDailyRequestCap = 10
 var (
 	// ErrProofRequired is an offer submitted without a proof CV (422).
 	ErrProofRequired = errors.New("referral: proof CV required")
+	// ErrInvalidLinkedIn is a missing or non-LinkedIn profile URL on either side (422).
+	ErrInvalidLinkedIn = errors.New("referral: a LinkedIn profile URL is required")
 	// ErrAlreadyOffered is a second offer for a company the member already offered for;
 	// the repository maps the unique violation to this (409).
 	ErrAlreadyOffered = errors.New("referral: already offered for this company")
@@ -92,6 +95,9 @@ type Offer struct {
 	// is read on a path that doesn't join the catalogue (create/decide) or the company
 	// is unknown. The list paths populate it; callers fall back to the slug.
 	CompanyName string
+	// LinkedInURL is the referrer's own profile, backing their "I work here" claim so the
+	// moderator can vet it. Required and shape-validated at submission.
+	LinkedInURL string
 	ProofKey    string
 	Status      string
 	DecidedBy   *int64
@@ -103,12 +109,19 @@ type Offer struct {
 // CVID are nil for "no source vacancy" and an original-CV attachment respectively; ActedBy
 // and ActedAt are nil until a referrer marks it.
 type Request struct {
-	ID              int64
-	SeekerUserID    int64
-	CompanySlug     string
-	JobID           *int64
-	CVKind          string
-	CVID            *int64
+	ID           int64
+	SeekerUserID int64
+	CompanySlug  string
+	// CompanyName is the catalogue display name for CompanySlug, empty on paths that don't
+	// join the catalogue or when the company is unknown. The list paths populate it; callers
+	// fall back to the slug.
+	CompanyName string
+	JobID       *int64
+	CVKind      string
+	CVID        *int64
+	// LinkedInURL is the seeker's own profile, shown to the referrer in the inbox alongside
+	// the contact channels. Required and shape-validated at submission.
+	LinkedInURL     string
 	ContactTelegram string
 	ContactEmail    string
 	Note            string
@@ -130,6 +143,7 @@ type Recipient struct {
 type OfferInput struct {
 	UserID      int64
 	CompanySlug string
+	LinkedInURL string
 	ProofKey    string
 }
 
@@ -141,6 +155,7 @@ type RequestInput struct {
 	JobID           *int64
 	CVKind          string
 	CVID            *int64
+	LinkedInURL     string
 	ContactTelegram string
 	ContactEmail    string
 	Note            string
@@ -217,6 +232,9 @@ func (s *Service) SubmitOffer(ctx context.Context, in OfferInput) (Offer, error)
 	if strings.TrimSpace(in.ProofKey) == "" {
 		return Offer{}, ErrProofRequired
 	}
+	if !validLinkedInURL(in.LinkedInURL) {
+		return Offer{}, ErrInvalidLinkedIn
+	}
 	return s.repo.CreateOffer(ctx, in)
 }
 
@@ -260,6 +278,9 @@ func (s *Service) ListPendingOffers(ctx context.Context) ([]Offer, error) {
 func (s *Service) CreateRequest(ctx context.Context, in RequestInput) (Request, error) {
 	if err := validateContact(in); err != nil {
 		return Request{}, err
+	}
+	if !validLinkedInURL(in.LinkedInURL) {
+		return Request{}, ErrInvalidLinkedIn
 	}
 	if err := validateCVChoice(in); err != nil {
 		return Request{}, err
@@ -380,6 +401,25 @@ func validateContact(in RequestInput) error {
 		return ErrNoContact
 	}
 	return nil
+}
+
+// validLinkedInURL reports whether s is a LinkedIn personal-profile URL: an http(s) URL on
+// linkedin.com (optionally a country/www subdomain) whose path is /in/<handle>. This is a
+// shape check, not a liveness check — it only asserts the link is the right kind of thing.
+func validLinkedInURL(s string) bool {
+	u, err := url.Parse(strings.TrimSpace(s))
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if host != "linkedin.com" && !strings.HasSuffix(host, ".linkedin.com") {
+		return false
+	}
+	path := u.EscapedPath()
+	if !strings.HasPrefix(path, "/in/") {
+		return false
+	}
+	return strings.Trim(strings.TrimPrefix(path, "/in/"), "/") != ""
 }
 
 // validateCVChoice enforces the kind/id invariant the DB CHECK deliberately does not (so a

--- a/internal/referral/referral_test.go
+++ b/internal/referral/referral_test.go
@@ -130,6 +130,9 @@ func newService(repo *fakeRepo, pinger *fakePinger) *Service {
 
 func cvID(n int64) *int64 { return &n }
 
+// linkedInURL is a valid profile URL for fixtures that must clear the required-LinkedIn gate.
+const linkedInURL = "https://www.linkedin.com/in/jane-doe"
+
 // --- offer ---------------------------------------------------------------
 
 func TestSubmitOfferRequiresProof(t *testing.T) {
@@ -140,6 +143,46 @@ func TestSubmitOfferRequiresProof(t *testing.T) {
 	}
 	if repo.createdOff != nil {
 		t.Error("repo.CreateOffer should not run when proof is missing")
+	}
+}
+
+func TestSubmitOfferRequiresLinkedIn(t *testing.T) {
+	repo := &fakeRepo{}
+	s := newService(repo, &fakePinger{})
+	if _, err := s.SubmitOffer(context.Background(), OfferInput{UserID: 1, CompanySlug: "acme", ProofKey: "k", LinkedInURL: "https://twitter.com/jane"}); !errors.Is(err, ErrInvalidLinkedIn) {
+		t.Fatalf("err = %v, want ErrInvalidLinkedIn", err)
+	}
+	if repo.createdOff != nil {
+		t.Error("repo.CreateOffer should not run when the LinkedIn URL is invalid")
+	}
+	if _, err := s.SubmitOffer(context.Background(), OfferInput{UserID: 1, CompanySlug: "acme", ProofKey: "k", LinkedInURL: linkedInURL}); err != nil {
+		t.Fatalf("valid offer: %v", err)
+	}
+	if repo.createdOff == nil || repo.createdOff.LinkedInURL != linkedInURL {
+		t.Errorf("offer LinkedIn not persisted: %+v", repo.createdOff)
+	}
+}
+
+func TestValidLinkedInURL(t *testing.T) {
+	valid := []string{
+		"https://www.linkedin.com/in/jane-doe",
+		"https://linkedin.com/in/jane-doe/",
+		"http://de.linkedin.com/in/hans",
+		"https://www.linkedin.com/in/jane-doe?trk=x",
+	}
+	for _, s := range valid {
+		if !validLinkedInURL(s) {
+			t.Errorf("validLinkedInURL(%q) = false, want true", s)
+		}
+	}
+	invalid := []string{
+		"", "   ", "linkedin.com/in/jane", "https://linkedin.com/", "https://linkedin.com/company/acme",
+		"https://notlinkedin.com/in/jane", "https://linkedin.com.evil.com/in/jane", "ftp://linkedin.com/in/jane",
+	}
+	for _, s := range invalid {
+		if validLinkedInURL(s) {
+			t.Errorf("validLinkedInURL(%q) = true, want false", s)
+		}
 	}
 }
 
@@ -181,7 +224,7 @@ func TestWithdrawOfferPropagatesNotFound(t *testing.T) {
 // --- request creation ----------------------------------------------------
 
 func TestCreateRequestValidation(t *testing.T) {
-	base := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVOriginal, ContactEmail: "s@x.test"}
+	base := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVOriginal, ContactEmail: "s@x.test", LinkedInURL: linkedInURL}
 
 	tests := []struct {
 		name string
@@ -208,7 +251,7 @@ func TestCreateRequestValidation(t *testing.T) {
 }
 
 func TestCreateRequestEligibilityAndCap(t *testing.T) {
-	valid := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVOriginal, ContactEmail: "s@x.test"}
+	valid := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVOriginal, ContactEmail: "s@x.test", LinkedInURL: linkedInURL}
 
 	t.Run("company not eligible", func(t *testing.T) {
 		repo := &fakeRepo{eligible: false, hasResume: true}
@@ -255,7 +298,7 @@ func TestCreateRequestEligibilityAndCap(t *testing.T) {
 }
 
 func TestCreateRequestBuiltCVOwnership(t *testing.T) {
-	built := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVBuilt, CVID: cvID(42), ContactEmail: "s@x.test"}
+	built := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVBuilt, CVID: cvID(42), ContactEmail: "s@x.test", LinkedInURL: linkedInURL}
 
 	t.Run("foreign cv is rejected as an invalid choice", func(t *testing.T) {
 		repo := &fakeRepo{eligible: true, cvOwned: false}
@@ -281,7 +324,7 @@ func TestCreateRequestBuiltCVOwnership(t *testing.T) {
 }
 
 func TestCreateRequestOriginalNeedsResume(t *testing.T) {
-	original := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVOriginal, ContactEmail: "s@x.test"}
+	original := RequestInput{SeekerUserID: 1, CompanySlug: "acme", CVKind: CVOriginal, ContactEmail: "s@x.test", LinkedInURL: linkedInURL}
 	repo := &fakeRepo{eligible: true, hasResume: false}
 	s := newService(repo, &fakePinger{})
 	if _, err := s.CreateRequest(context.Background(), original); !errors.Is(err, ErrNoResume) {

--- a/internal/referral/repository.go
+++ b/internal/referral/repository.go
@@ -33,6 +33,7 @@ func NewQueriesRepository(q *db.Queries) *QueriesRepository {
 func (r *QueriesRepository) CreateOffer(ctx context.Context, in OfferInput) (Offer, error) {
 	row, err := r.q.CreateReferralOffer(ctx, db.CreateReferralOfferParams{
 		UserID: in.UserID, CompanySlug: in.CompanySlug, ProofObjectKey: in.ProofKey,
+		LinkedinUrl: in.LinkedInURL,
 	})
 	if err != nil {
 		if pgerr.IsUniqueViolation(err) {
@@ -84,7 +85,7 @@ func (r *QueriesRepository) ListOffersByUser(ctx context.Context, userID int64) 
 	return mapSlice(rows, func(row db.ListReferralOffersByUserRow) Offer {
 		o := offerFromRow(db.ReferralOffer{
 			ID: row.ID, UserID: row.UserID, CompanySlug: row.CompanySlug,
-			ProofObjectKey: row.ProofObjectKey, Status: row.Status,
+			ProofObjectKey: row.ProofObjectKey, Status: row.Status, LinkedinUrl: row.LinkedinUrl,
 			DecidedBy: row.DecidedBy, DecidedAt: row.DecidedAt, CreatedAt: row.CreatedAt,
 		})
 		o.CompanyName = row.CompanyName.String
@@ -101,7 +102,7 @@ func (r *QueriesRepository) ListPendingOffers(ctx context.Context) ([]Offer, err
 	return mapSlice(rows, func(row db.ListPendingReferralOffersRow) Offer {
 		o := offerFromRow(db.ReferralOffer{
 			ID: row.ID, UserID: row.UserID, CompanySlug: row.CompanySlug,
-			ProofObjectKey: row.ProofObjectKey, Status: row.Status,
+			ProofObjectKey: row.ProofObjectKey, Status: row.Status, LinkedinUrl: row.LinkedinUrl,
 			DecidedBy: row.DecidedBy, DecidedAt: row.DecidedAt, CreatedAt: row.CreatedAt,
 		})
 		o.CompanyName = row.CompanyName.String
@@ -167,6 +168,7 @@ func (r *QueriesRepository) CreateRequest(ctx context.Context, in RequestInput) 
 		JobID:           int8Ptr(in.JobID),
 		CvKind:          in.CVKind,
 		CvID:            int8Ptr(in.CVID),
+		LinkedinUrl:     in.LinkedInURL,
 		ContactTelegram: textOrNull(in.ContactTelegram),
 		ContactEmail:    textOrNull(in.ContactEmail),
 		Note:            in.Note,
@@ -214,22 +216,41 @@ func (r *QueriesRepository) ResolveRequest(ctx context.Context, id, actorID int6
 	return requestFromRow(row), nil
 }
 
-// ListRequestsBySeeker returns a seeker's requests, newest first.
+// ListRequestsBySeeker returns a seeker's requests, newest first, each with its company name.
 func (r *QueriesRepository) ListRequestsBySeeker(ctx context.Context, seekerID int64) ([]Request, error) {
 	rows, err := r.q.ListReferralRequestsBySeeker(ctx, seekerID)
 	if err != nil {
 		return nil, err
 	}
-	return mapSlice(rows, requestFromRow), nil
+	return mapSlice(rows, func(row db.ListReferralRequestsBySeekerRow) Request {
+		req := requestFromRow(db.ReferralRequest{
+			ID: row.ID, SeekerUserID: row.SeekerUserID, CompanySlug: row.CompanySlug,
+			JobID: row.JobID, CvKind: row.CvKind, CvID: row.CvID, LinkedinUrl: row.LinkedinUrl,
+			ContactTelegram: row.ContactTelegram, ContactEmail: row.ContactEmail, Note: row.Note,
+			Status: row.Status, ActedBy: row.ActedBy, ActedAt: row.ActedAt, CreatedAt: row.CreatedAt,
+		})
+		req.CompanyName = row.CompanyName.String
+		return req
+	}), nil
 }
 
-// ListIncomingRequests returns the open requests for the referrer's approved companies.
+// ListIncomingRequests returns the open requests for the referrer's approved companies,
+// each with its company name.
 func (r *QueriesRepository) ListIncomingRequests(ctx context.Context, referrerID int64) ([]Request, error) {
 	rows, err := r.q.ListIncomingReferralRequests(ctx, referrerID)
 	if err != nil {
 		return nil, err
 	}
-	return mapSlice(rows, requestFromRow), nil
+	return mapSlice(rows, func(row db.ListIncomingReferralRequestsRow) Request {
+		req := requestFromRow(db.ReferralRequest{
+			ID: row.ID, SeekerUserID: row.SeekerUserID, CompanySlug: row.CompanySlug,
+			JobID: row.JobID, CvKind: row.CvKind, CvID: row.CvID, LinkedinUrl: row.LinkedinUrl,
+			ContactTelegram: row.ContactTelegram, ContactEmail: row.ContactEmail, Note: row.Note,
+			Status: row.Status, ActedBy: row.ActedBy, ActedAt: row.ActedAt, CreatedAt: row.CreatedAt,
+		})
+		req.CompanyName = row.CompanyName.String
+		return req
+	}), nil
 }
 
 func offerFromRow(row db.ReferralOffer) Offer {
@@ -237,6 +258,7 @@ func offerFromRow(row db.ReferralOffer) Offer {
 		ID:          row.ID,
 		UserID:      row.UserID,
 		CompanySlug: row.CompanySlug,
+		LinkedInURL: row.LinkedinUrl,
 		ProofKey:    row.ProofObjectKey,
 		Status:      row.Status,
 		DecidedBy:   int64PtrFrom(row.DecidedBy),
@@ -253,6 +275,7 @@ func requestFromRow(row db.ReferralRequest) Request {
 		JobID:           int64PtrFrom(row.JobID),
 		CVKind:          row.CvKind,
 		CVID:            int64PtrFrom(row.CvID),
+		LinkedInURL:     row.LinkedinUrl,
 		ContactTelegram: row.ContactTelegram.String,
 		ContactEmail:    row.ContactEmail.String,
 		Note:            row.Note,

--- a/migrations/0036_referral_linkedin.sql
+++ b/migrations/0036_referral_linkedin.sql
@@ -1,0 +1,15 @@
+-- Referral LinkedIn profiles: both sides of a referral now carry a LinkedIn URL so the
+-- other party can vet the person. A referrer's profile backs their "I work here" offer
+-- (helps the moderator verify employment); a seeker's profile is shown to the referrer
+-- in the inbox alongside the contact channels.
+--
+-- Required at submission is enforced in the domain layer (URL shape + presence), not by a
+-- DB NOT NULL: existing rows predate the column, so the column defaults to '' and legacy
+-- rows keep it empty. New submissions always carry a validated value.
+--
+-- Applied to a fresh volume by initdb after 0035; on an existing prod volume run these
+-- statements manually BEFORE deploying code that reads the column.
+
+ALTER TABLE public.referral_offers ADD COLUMN linkedin_url text DEFAULT '' NOT NULL;
+
+ALTER TABLE public.referral_requests ADD COLUMN linkedin_url text DEFAULT '' NOT NULL;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -969,10 +969,16 @@ export function createApi(
   }
 
   /** Submit an offer to refer into a company: a proof CV (PDF) uploaded as multipart, with
-   *  the company slug as a form field. Enters moderation. 409 on a duplicate offer. */
-  async function submitReferralOffer(companySlug: string, file: File): Promise<ReferralOffer> {
+   *  the company slug and the referrer's LinkedIn URL as form fields. Enters moderation.
+   *  409 on a duplicate offer, 422 on a bad LinkedIn URL. */
+  async function submitReferralOffer(
+    companySlug: string,
+    linkedinUrl: string,
+    file: File,
+  ): Promise<ReferralOffer> {
     const form = new FormData();
     form.append('company_slug', companySlug);
+    form.append('linkedin_url', linkedinUrl);
     form.append('file', file);
     return requestData<ReferralOffer>('/api/v1/me/referrals/offers', { method: 'POST', body: form });
   }

--- a/web/src/lib/components/ReferralReviewView.svelte
+++ b/web/src/lib/components/ReferralReviewView.svelte
@@ -49,6 +49,11 @@
           </div>
         </div>
         <div class="flex shrink-0 flex-wrap gap-2">
+          {#if o.linkedin_url}
+            <Button variant="outline" size="sm" href={o.linkedin_url} target="_blank" rel="noopener">
+              LinkedIn ↗
+            </Button>
+          {/if}
           <Button variant="outline" size="sm" href={api.referralProofUrl(o.id)} target="_blank" rel="noopener">
             <FileText class="size-4" /> View proof
           </Button>

--- a/web/src/lib/components/ReferralsView.svelte
+++ b/web/src/lib/components/ReferralsView.svelte
@@ -12,7 +12,7 @@
     SeekerReferralRequest,
   } from '$lib/types';
   import { Button } from '$lib/ui';
-  import { timeAgo } from '$lib/utils';
+  import { isLinkedInUrl, timeAgo } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
   import CompanyPicker from './CompanyPicker.svelte';
   import States from './States.svelte';
@@ -64,14 +64,21 @@
   // ── Offer to refer ──────────────────────────────────────────────────────
   let offerOpen = $state(false);
   let offerSlug = $state('');
+  let offerLinkedin = $state('');
   let offerFile = $state<FileList | null>(null);
   let offerBusy = $state(false);
   let offerError = $state<string | null>(null);
+
+  const offerLinkedinValid = $derived(isLinkedInUrl(offerLinkedin));
+  const canSubmitOffer = $derived(
+    offerSlug.trim() !== '' && offerLinkedinValid && !!offerFile?.[0],
+  );
 
   function offerErrorMessage(err: unknown): string {
     if (err instanceof ApiError) {
       if (err.status === 409) return 'You already offered to refer for this company.';
       if (err.status === 404) return "We don't have that company — check the slug in its page URL.";
+      if (err.status === 422) return 'Enter a valid LinkedIn profile URL.';
       if (err.status === 503) return 'File upload is unavailable right now.';
     }
     return 'Could not submit the offer. Please try again.';
@@ -80,13 +87,14 @@
   async function submitOffer(e: SubmitEvent) {
     e.preventDefault();
     const file = offerFile?.[0];
-    if (!offerSlug.trim() || !file) return;
+    if (!canSubmitOffer || !file) return;
     offerError = null;
     offerBusy = true;
     try {
-      await api.submitReferralOffer(offerSlug.trim(), file);
+      await api.submitReferralOffer(offerSlug.trim(), offerLinkedin.trim(), file);
       offerOpen = false;
       offerSlug = '';
+      offerLinkedin = '';
       offerFile = null;
       await offers.run(() => api.listMyReferralOffers());
     } catch (err) {
@@ -173,7 +181,10 @@
         {#each requests.value as r (r.id)}
           <tr class="border-t border-border">
             <td class="py-3 pr-4 font-medium">
-              <a href="/companies/{r.company_slug}" class="hover:underline">{r.company_slug}</a>
+              <a href="/companies/{r.company_slug}" class="flex items-center gap-2 hover:underline">
+                <CompanyLogo name={r.company_name || r.company_slug} size="size-6" />
+                <span class="min-w-0 truncate">{r.company_name || r.company_slug}</span>
+              </a>
             </td>
             <td class="py-3 pr-4 text-muted-foreground">
               {r.cv_kind === 'built' ? 'Tailored CV' : 'Uploaded CV'}
@@ -208,13 +219,28 @@
         <span class="text-xs text-muted-foreground">Search and pick the company you work at.</span>
       </div>
       <label class="flex flex-col gap-1.5 text-sm">
+        <span class="font-medium">Your LinkedIn profile</span>
+        <input
+          type="url"
+          bind:value={offerLinkedin}
+          placeholder="https://linkedin.com/in/your-handle"
+          aria-invalid={offerLinkedin.trim() !== '' && !offerLinkedinValid}
+          class="rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
+        />
+        {#if offerLinkedin.trim() !== '' && !offerLinkedinValid}
+          <span class="text-xs text-destructive">Enter a full linkedin.com/in/… profile URL.</span>
+        {:else}
+          <span class="text-xs text-muted-foreground">Helps the moderator confirm you work there.</span>
+        {/if}
+      </label>
+      <label class="flex flex-col gap-1.5 text-sm">
         <span class="font-medium">Proof of employment (PDF)</span>
         <input type="file" accept="application/pdf" bind:files={offerFile} class="text-sm" />
         <span class="text-xs text-muted-foreground">A CV or letter showing you work there. A moderator reviews it.</span>
       </label>
       {#if offerError}<p class="text-sm text-destructive">{offerError}</p>{/if}
       <div class="flex justify-end">
-        <Button type="submit" variant="primary" size="sm" disabled={offerBusy || !offerSlug.trim() || !offerFile?.[0]}>
+        <Button type="submit" variant="primary" size="sm" disabled={offerBusy || !canSubmitOffer}>
           {offerBusy ? 'Submitting…' : 'Submit for review'}
         </Button>
       </div>
@@ -263,13 +289,19 @@
       {#each incoming.value as req (req.id)}
         <div class="rounded-lg border border-border p-4">
           <div class="flex items-center justify-between gap-4">
-            <b class="text-sm">Someone wants a referral into {req.company_slug}</b>
+            <b class="flex min-w-0 items-center gap-2 text-sm">
+              <CompanyLogo name={req.company_name || req.company_slug} size="size-6" />
+              <span class="min-w-0 truncate">Someone wants a referral into {req.company_name || req.company_slug}</span>
+            </b>
             <span class="shrink-0 text-xs text-muted-foreground">{req.created_at ? timeAgo(req.created_at) : ''}</span>
           </div>
-          <div class="mt-1.5 text-sm">
-            Contact:
+          <div class="mt-1.5 flex flex-wrap items-center gap-2 text-sm">
+            <span>Contact:</span>
             {#if req.contact_telegram}<code class="rounded bg-muted px-1.5 py-0.5 text-xs">{req.contact_telegram}</code>{/if}
             {#if req.contact_email}<code class="rounded bg-muted px-1.5 py-0.5 text-xs">{req.contact_email}</code>{/if}
+            {#if req.linkedin_url}
+              <a href={req.linkedin_url} target="_blank" rel="noopener" class="text-brand-strong hover:underline">LinkedIn ↗</a>
+            {/if}
           </div>
           {#if req.note}<p class="mt-1 text-sm italic text-muted-foreground">“{req.note}”</p>{/if}
           <div class="mt-3 flex items-center gap-2">

--- a/web/src/lib/components/RequestReferralModal.svelte
+++ b/web/src/lib/components/RequestReferralModal.svelte
@@ -5,6 +5,7 @@
   import type { CvTailoredItem } from '$lib/cv';
   import type { ReferralRequestInput } from '$lib/types';
   import { Button } from '$lib/ui';
+  import { isLinkedInUrl } from '$lib/utils';
 
   // The parent owns open/close; this component owns the request form. jobId is the
   // optional source-vacancy context recorded with the request.
@@ -26,6 +27,7 @@
   let cvId = $state<number | null>(null);
   let tailored = $state<CvTailoredItem[]>([]);
   let hasResume = $state(true);
+  let linkedinUrl = $state('');
   let contactTelegram = $state('');
   let contactEmail = $state('');
   let note = $state('');
@@ -33,8 +35,10 @@
   let error = $state<string | null>(null);
   let done = $state(false);
 
+  const linkedinValid = $derived(isLinkedInUrl(linkedinUrl));
   const canSubmit = $derived(
-    (contactTelegram.trim() !== '' || contactEmail.trim() !== '') &&
+    linkedinValid &&
+      (contactTelegram.trim() !== '' || contactEmail.trim() !== '') &&
       (cvKind === 'original' ? hasResume : cvId !== null),
   );
 
@@ -76,6 +80,7 @@
       job_id: jobId,
       cv_kind: cvKind,
       cv_id: cvKind === 'built' && cvId !== null ? cvId : undefined,
+      linkedin_url: linkedinUrl.trim(),
       contact_telegram: contactTelegram.trim() || undefined,
       contact_email: contactEmail.trim() || undefined,
       note: note.trim() || undefined,
@@ -179,6 +184,22 @@
             {/if}
           </label>
         </fieldset>
+
+        <label class="flex flex-col gap-1.5 text-sm">
+          <span class="font-medium">Your LinkedIn profile</span>
+          <input
+            type="url"
+            bind:value={linkedinUrl}
+            placeholder="https://linkedin.com/in/your-handle"
+            aria-invalid={linkedinUrl.trim() !== '' && !linkedinValid}
+            class="rounded-md border border-border bg-background px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring aria-[invalid=true]:border-destructive"
+          />
+          {#if linkedinUrl.trim() !== '' && !linkedinValid}
+            <span class="text-xs text-destructive">Enter a full linkedin.com/in/… profile URL.</span>
+          {:else}
+            <span class="text-xs text-muted-foreground">The referrer vets you before reaching out.</span>
+          {/if}
+        </label>
 
         <div class="flex flex-col gap-1.5 text-sm">
           <span class="font-medium">

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -191,6 +191,7 @@ export interface ReferralOffer {
   id: number;
   company_slug: string;
   company_name: string;
+  linkedin_url: string;
   status: ReferralOfferStatus;
   decided_at: string | null;
   created_at: string | null;
@@ -200,6 +201,7 @@ export interface ReferralOffer {
 export interface SeekerReferralRequest {
   id: number;
   company_slug: string;
+  company_name: string;
   job_id: number | null;
   cv_kind: ReferralCvKind;
   cv_id: number | null;
@@ -211,8 +213,10 @@ export interface SeekerReferralRequest {
 export interface IncomingReferralRequest {
   id: number;
   company_slug: string;
+  company_name: string;
   job_id: number | null;
   cv_kind: ReferralCvKind;
+  linkedin_url?: string;
   contact_telegram?: string;
   contact_email?: string;
   note?: string;
@@ -226,6 +230,7 @@ export interface ReferralRequestInput {
   job_id?: number;
   cv_kind: ReferralCvKind;
   cv_id?: number;
+  linkedin_url: string;
   contact_telegram?: string;
   contact_email?: string;
   note?: string;

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -14,6 +14,22 @@ export function formatDate(ts: string | null | undefined): string {
   return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
+/** Whether s is a LinkedIn personal-profile URL: an http(s) link on linkedin.com (or a
+ *  country/www subdomain) whose path is /in/<handle>. Mirrors the backend's shape check —
+ *  the server re-validates on submit, so this is just for inline form feedback. */
+export function isLinkedInUrl(s: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(s.trim());
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return false;
+  const host = u.hostname.toLowerCase();
+  if (host !== 'linkedin.com' && !host.endsWith('.linkedin.com')) return false;
+  return /^\/in\/[^/]+/.test(u.pathname);
+}
+
 const TIME_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ['year', 31536000],
   ['month', 2592000],


### PR DESCRIPTION
## What

Two changes to the employee-referral flow:

**1. Company name + logo in My requests / Incoming.** Both tabs showed a bare
`company_slug` and no logo. Added a `LEFT JOIN companies` to the seeker-requests
and incoming-inbox queries (the same pattern the Offers tab already used),
plumbed `company_name` through domain → handler → TS types, and render
`<CompanyLogo>` + name with a slug fallback.

**2. Required, validated LinkedIn URL on both sides.**
- *Offer to refer* (referrer): a LinkedIn input; the URL backs the "I work here"
  claim and is shown to the moderator in the review queue.
- *Request a referral* (seeker): a LinkedIn input; shown to the referrer in the
  inbox alongside the contact channels.
- Validated in the domain (`validLinkedInURL`, source of truth → 422) and
  mirrored client-side (`isLinkedInUrl`) for inline feedback + submit gating.

## Migration

`0036_referral_linkedin.sql` adds `linkedin_url text DEFAULT '' NOT NULL` to
`referral_offers` and `referral_requests`. Expand-only. **Apply by hand to prod
before the flip** (`SET ROLE hire`); legacy rows get `''` (hidden in the UI),
required-ness is enforced only for new submissions.

## Tests

- Unit: `validLinkedInURL` table test + offer/request required-LinkedIn gates.
- Integration: referral handler test now sends & asserts `linkedin_url`.
- `go build/vet/test` green; `svelte-check` 0 errors; web prod build green.