### PR TITLE
fix(referrals): Tailored CV select overflows the request modal

### DIFF
--- a/web/src/lib/components/RequestReferralModal.svelte
+++ b/web/src/lib/components/RequestReferralModal.svelte
@@ -173,7 +173,7 @@
               <select
                 bind:value={cvId}
                 onclick={(e) => e.stopPropagation()}
-                class="ml-auto max-w-[55%] rounded-md border border-border bg-background px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                class="ml-auto min-w-0 max-w-[55%] rounded-md border border-border bg-background px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               >
                 {#each tailored as cv (cv.id)}
                   <option value={cv.id}>{cv.job_company ? `${cv.title} — ${cv.job_company}` : cv.title}</option>


### PR DESCRIPTION
The tailored-CV `<select>` in the "Ask for a referral" modal spilled past the
modal's right edge when a tailored CV has a long label (job title — company).

It's a flex child; its default `min-width: auto` floor kept it from shrinking
below its content's min-content width, so `max-w-[55%]` couldn't cap it and the
row overflowed. Add `min-w-0` so it shrinks to fit and the native select clips
its own selected-option text.

Pure Tailwind class change; no logic touched.