### PR TITLE
feat(web): serve company logos via logo.freehire.dev proxy

### DIFF
--- a/web/src/lib/components/CompanyLogo.svelte
+++ b/web/src/lib/components/CompanyLogo.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
   import { Globe } from '@lucide/svelte';
-  import { logoDevUrl } from '$lib/logo';
+  import { companyLogoUrl } from '$lib/logo';
 
-  // A company's logo from logo.dev's name endpoint. `fallback=404` makes the API
-  // return 404 when it has no logo, so the image fails to load and we fall back to
-  // our own monogram (the initial on a colour derived from the name). The globe is
-  // the last resort, only when there's no name to monogram. Shared by the job row,
-  // the job page, and the company page for one look (and by the OG-image card, via
-  // $lib/logo).
+  // A company's logo from our logo.freehire.dev proxy (faviconapi -> logo.dev
+  // fallback, both server-side). On a genuine miss the proxy 404s, so the image
+  // fails to load and we fall back to our own monogram (the initial on a colour
+  // derived from the name). The globe is the last resort, only when there's no
+  // name to monogram. Shared by the job row, the job page, and the company page
+  // for one look (and by the OG-image card, via $lib/logo).
   let { name, size = 'size-4' }: { name: string; size?: string } = $props();
 
   let failed = $state(false);
-  const src = $derived(logoDevUrl(name) ?? undefined);
+  const src = $derived(companyLogoUrl(name) ?? undefined);
 
   // A new company means a fresh attempt — clear a prior failure when the name changes
   // (the company page reuses this instance across navigations).
@@ -21,7 +21,7 @@
   });
 
   // SSR sends the raw <img>, so the browser fetches the logo before hydration wires
-  // `onerror`. When logo.dev 404s (its `fallback=404`), that error event fires before
+  // `onerror`. When the proxy 404s (a genuine miss), that error event fires before
   // the handler exists and is lost — leaving an empty broken image until a reload. On
   // mount, an already-complete image with no intrinsic width is that missed failure,
   // so fall back to the monogram straight away.

--- a/web/src/lib/logo.ts
+++ b/web/src/lib/logo.ts
@@ -1,14 +1,14 @@
-// logo.dev's name endpoint resolves a company logo by name (no domain needed).
-// `fallback=404` makes it return 404 — rather than a generic monogram — when it
-// has no logo, so each consumer can pick its own fallback (the globe icon in the
-// SPA, a monogram tile in the OG card). The token is a logo.dev publishable key,
-// designed to live in a client img src; it is domain-restricted (the allowlist —
-// freehire.dev + localhost for dev — is configured against the key in the logo.dev
-// dashboard, since the browser attaches the page origin as the Referer).
-export const LOGO_DEV_TOKEN = 'pk_fKgOEo0OT4KXvUshjPMGAQ';
+// Company logos are served from our own logo.freehire.dev proxy. It fronts a free
+// favicon service (faviconapi.com) that resolves the real brand mark for most
+// company names; on a miss the proxy returns a clean 404 so each consumer falls
+// back to its own placeholder (the SVG monogram in the SPA, a monogram tile in the
+// OG card). No third-party token or attribution ships in the browser — the proxy
+// owns everything server-side. Resolves by company name, since that is all most
+// call sites carry (job rows, search, referrals).
+export const COMPANY_LOGO_BASE = 'https://logo.freehire.dev';
 
-/** The logo.dev image URL for a company name, or null when there is no name. */
-export function logoDevUrl(name: string): string | null {
+/** The proxy logo URL for a company name, or null when there is no name. */
+export function companyLogoUrl(name: string): string | null {
   if (!name) return null;
-  return `https://img.logo.dev/name/${encodeURIComponent(name)}?token=${LOGO_DEV_TOKEN}&fallback=404`;
+  return `${COMPANY_LOGO_BASE}/${encodeURIComponent(name)}`;
 }

--- a/web/src/lib/seo.test.ts
+++ b/web/src/lib/seo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { articleJsonLd, collectionPageJsonLd, jobPostingJsonLd, organizationJsonLd } from './seo';
-import { logoDevUrl } from './logo';
+import { companyLogoUrl } from './logo';
 import type { PostMeta } from './blog';
 import type { Company, Job } from './types';
 
@@ -135,7 +135,7 @@ describe('jobPostingJsonLd', () => {
       ORIGIN
     );
 
-    expect((ld.hiringOrganization as Record<string, unknown>).logo).toBe(logoDevUrl('Acme'));
+    expect((ld.hiringOrganization as Record<string, unknown>).logo).toBe(companyLogoUrl('Acme'));
     expect(ld.skills).toBe('Go, Kubernetes');
     expect(ld.experienceRequirements).toEqual({
       '@type': 'OccupationalExperienceRequirements',

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -3,7 +3,7 @@
 // crawlers and Google Jobs see structured data in the initial HTML.
 
 import type { PostMeta } from './blog';
-import { logoDevUrl } from './logo';
+import { companyLogoUrl } from './logo';
 import type { Company, Enrichment, Job } from './types';
 
 const SITE = 'freehire';
@@ -103,9 +103,9 @@ const EDUCATION_CREDENTIAL: Record<string, string> = {
  *  not open. `origin` is the absolute site origin (e.g. https://freehire.dev). */
 export function jobPostingJsonLd(job: Job, origin: string): Record<string, unknown> {
   const e = job.enrichment ?? {};
-  // logo.dev resolves a logo from the company name (404s for unknown companies,
-  // which Google silently ignores); same source the SPA and OG cards use.
-  const logo = logoDevUrl(job.company);
+  // Our logo proxy resolves a logo from the company name (404s for unknown
+  // companies, which Google silently ignores); same source the SPA and OG cards use.
+  const logo = companyLogoUrl(job.company);
   const ld: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'JobPosting',

--- a/web/src/lib/server/og/logo.ts
+++ b/web/src/lib/server/og/logo.ts
@@ -1,15 +1,15 @@
 // Resolves a company logo for the OG card. satori cannot fetch remote images
-// itself, so we fetch logo.dev server-side and hand back a data-URI it can embed.
-// Any failure (404 = no logo, timeout, network) returns null so the card falls back
-// to a monogram — a missing logo must never fail the image render.
+// itself, so we fetch our logo proxy server-side and hand back a data-URI it can
+// embed. Any failure (404 = no logo, timeout, network) returns null so the card
+// falls back to a monogram — a missing logo must never fail the image render.
 
-import { logoDevUrl } from '$lib/logo';
+import { companyLogoUrl } from '$lib/logo';
 
 const TIMEOUT_MS = 2500;
 
 /** A `data:` URI for the company's logo, or null to signal "use the monogram". */
 export async function resolveLogo(company: string): Promise<string | null> {
-  const url = logoDevUrl(company);
+  const url = companyLogoUrl(company);
   if (!url) return null;
 
   try {


### PR DESCRIPTION
## What

Route company logos through our own same-origin `logo.freehire.dev` proxy instead of hitting logo.dev's name endpoint directly from the browser.

- `logo.ts`: `logoDevUrl` → `companyLogoUrl` (proxy base URL, **no token**)
- `CompanyLogo.svelte`, `seo.ts` (JSON-LD), `server/og/logo.ts`: use `companyLogoUrl`
- `seo.test.ts`: updated expectation

## Why

- The logo.dev publishable token was shipped in every browser bundle; it now lives server-side (nginx) — actually, it's gone entirely (see below).
- The proxy fronts the free **faviconapi.com**, which resolves the real brand mark for ~75% of company names and costs $0 with no attribution.
- On a miss the proxy returns a clean 404 → the existing SVG monogram fallback takes over (verified in headless Chrome that a bodyless 404 fires `<img onerror>`).
- logo.dev's *name* endpoint was found to return **wrong** logos for unrecognised names, so it is deliberately not used.

## Depends on

nginx vhost in freehire-ops: `feat/logo-proxy-nginx` (must deploy `logo.freehire.dev` first). Until then this branch points at a host that doesn't resolve yet.

## Verification

`npm run check` (0 errors) · `vitest` seo tests green.