### PR TITLE
feat(sources): onboard PowerToFly (boardless remote/diversity aggregator)

### DIFF
--- a/internal/sources/powertofly.go
+++ b/internal/sources/powertofly.go
@@ -1,0 +1,129 @@
+package sources
+
+import (
+	"context"
+	"fmt"
+)
+
+// powertofly adapts powertofly.com, a remote/diversity-focused job board. Like the other
+// aggregators it is boardless (one public API, no per-tenant board) yet lists many
+// employers, so it stays in the source facet and takes each posting's company from the
+// feed. The /api/v1/jobs endpoint carries every posting's body inline and paginates via a
+// numeric meta.next_page, so there is no per-posting detail request. Applications are hosted
+// on powertofly.com itself (no outbound ATS URL), so a posting's identity is its own numeric
+// id — the dedup key namespaces cleanly by board without link resolution.
+type powertofly struct {
+	http JSONGetter
+}
+
+const (
+	powertoflyListURL = "https://powertofly.com/api/v1/jobs/"
+	// powertoflyMaxPages bounds pagination so a feed that never stops handing out a
+	// next_page cannot loop forever (~192 pages at 50/page as of onboarding).
+	powertoflyMaxPages = 400
+)
+
+// NewPowerToFly builds the PowerToFly adapter over the given HTTP client.
+func NewPowerToFly(c JSONGetter) Source { return powertofly{http: c} }
+
+func (powertofly) Provider() string { return "powertofly" }
+
+// powertofly needs no board id (one API), so its config carries no board.
+func (powertofly) boardless() {}
+
+// powertofly aggregates postings from many companies, so it stays in the source facet.
+func (powertofly) aggregator() {}
+
+// powertoflyPlace is a structured country/state/city object; only its title is used.
+type powertoflyPlace struct {
+	Title string `json:"title"`
+}
+
+// powertoflyPosting is one posting from /api/v1/jobs, body inline (no detail call). The
+// free-text "location" field is the work arrangement (Onsite/Hybrid/Remote), NOT geography —
+// the place is carried structurally in city/state/country, with location_regions as a fallback.
+type powertoflyPosting struct {
+	ID             int64    `json:"id"`
+	Title          string   `json:"title"`
+	Description    string   `json:"description"`
+	Location       string   `json:"location"`
+	LocationRegion []string `json:"location_regions"`
+	EmploymentType string   `json:"employment_type"`
+	Company        struct {
+		Name string `json:"name"`
+	} `json:"company"`
+	Country powertoflyPlace `json:"country"`
+	State   powertoflyPlace `json:"state"`
+	City    powertoflyPlace `json:"city"`
+}
+
+func (s powertofly) Fetch(ctx context.Context, _ CompanyEntry) ([]Job, error) {
+	var jobs []Job
+	for page := 1; page <= powertoflyMaxPages; page++ {
+		var resp struct {
+			Data []powertoflyPosting `json:"data"`
+			Meta struct {
+				NextPage *int `json:"next_page"`
+			} `json:"meta"`
+		}
+		url := fmt.Sprintf("%s?page=%d", powertoflyListURL, page)
+		if err := s.http.GetJSON(ctx, url, &resp); err != nil {
+			return nil, fmt.Errorf("powertofly: page %d: %w", page, err)
+		}
+		for _, p := range resp.Data {
+			if job, ok := p.toJob(); ok {
+				jobs = append(jobs, job)
+			}
+		}
+		// next_page is null on the last page; an empty page also terminates defensively.
+		if resp.Meta.NextPage == nil || len(resp.Data) == 0 {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+// toJob maps an inline posting to a Job, returning ok=false for an unusable posting (no
+// native id, which would collide on the dedup key, or no company, which would break the
+// slug). The structured "location" work-arrangement field sets the work mode; geography is
+// built from the city/state/country titles, falling back to the region tags. required_skills
+// is deliberately left off Job.Skills — its titles are free text, not freehire's canonical
+// skill vocabulary, so the pipeline's skilltag dictionary derives skills from the description.
+func (p powertoflyPosting) toJob() (Job, bool) {
+	if p.ID == 0 || p.Company.Name == "" {
+		return Job{}, false
+	}
+	location := joinNonEmpty(p.City.Title, p.State.Title, p.Country.Title)
+	if location == "" {
+		location = joinNonEmpty(p.LocationRegion...)
+	}
+	mode := workplaceTypeMode(p.Location)
+	return Job{
+		ExternalID:     fmt.Sprintf("%d", p.ID),
+		URL:            fmt.Sprintf("https://powertofly.com/jobs/detail/%d", p.ID),
+		Title:          p.Title,
+		Company:        p.Company.Name,
+		Location:       location,
+		Description:    sanitizeHTML(p.Description),
+		Remote:         mode == "remote" || isRemote(p.Location),
+		WorkMode:       mode,
+		EmploymentType: powertoflyEmploymentType(p.EmploymentType),
+	}, true
+}
+
+// powertoflyEmploymentType maps PowerToFly's employment_type text onto the freehire
+// vocabulary, returning "" for an unknown/absent value so the description parser decides.
+func powertoflyEmploymentType(t string) string {
+	switch t {
+	case "Full Time":
+		return "full_time"
+	case "Part Time":
+		return "part_time"
+	case "Contract", "Per Project":
+		return "contract"
+	case "Internship":
+		return "internship"
+	default:
+		return ""
+	}
+}

--- a/internal/sources/powertofly_test.go
+++ b/internal/sources/powertofly_test.go
@@ -1,0 +1,93 @@
+package sources
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestPowerToFlyProvider(t *testing.T) {
+	if got := NewPowerToFly(nil).Provider(); got != "powertofly" {
+		t.Errorf("Provider() = %q, want powertofly", got)
+	}
+}
+
+func TestPowerToFlyIsBoardlessAggregator(t *testing.T) {
+	s := NewPowerToFly(nil)
+	if _, ok := s.(boardless); !ok {
+		t.Error("powertofly should implement the boardless marker")
+	}
+	if _, ok := s.(aggregator); !ok {
+		t.Error("powertofly should implement the aggregator marker")
+	}
+}
+
+func TestPowerToFlyRegisteredAndFilterable(t *testing.T) {
+	if _, ok := All(nil)["powertofly"]; !ok {
+		t.Error("All() should register provider powertofly")
+	}
+	if !slices.Contains(FilterableProviders(), "powertofly") {
+		t.Error("FilterableProviders() should include powertofly")
+	}
+}
+
+func TestPowerToFlyBoardFileValidates(t *testing.T) {
+	cfg, err := LoadConfig("../../sources/powertofly.yml")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if err := cfg.Validate(All(nil)); err != nil {
+		t.Fatalf("sources/powertofly.yml fails validation: %v", err)
+	}
+}
+
+func TestPowerToFlyFetchPaginatesAndMaps(t *testing.T) {
+	page1 := `{"data":[
+{"id":1691729,"title":"Senior Go Engineer","description":"<p>Build &amp; ship.</p>","location":"Remote","location_regions":["USA"],"employment_type":"Full Time","company":{"name":"NASCAR"},"country":{"title":"United States"},"state":{"title":"Alabama"},"city":{"title":"Talladega"}},
+{"id":0,"title":"skip me","company":{"name":"NoID"}}
+],"meta":{"next_page":2}}`
+	page2 := `{"data":[
+{"id":42,"title":"Ops Lead","description":"x","location":"Onsite","location_regions":["USA"],"employment_type":"Per Project","company":{"name":"Acme"},"country":{"title":"United States"}}
+],"meta":{"next_page":null}}`
+	// page=2 routed first so the more specific match wins over the base ?page=1 route.
+	fake := (&routedHTTP{}).route("page=2", page2).route("page=1", page1)
+
+	jobs, err := NewPowerToFly(fake).Fetch(context.Background(), CompanyEntry{})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("got %d jobs, want 2 (the id=0 posting dropped)", len(jobs))
+	}
+
+	j := jobs[0]
+	if j.ExternalID != "1691729" || j.Company != "NASCAR" || j.Title != "Senior Go Engineer" {
+		t.Errorf("bad mapping: %+v", j)
+	}
+	if j.URL != "https://powertofly.com/jobs/detail/1691729" {
+		t.Errorf("URL = %q, want the powertofly detail URL", j.URL)
+	}
+	// "location":"Remote" is the work arrangement, not geography — geography comes from city/state/country.
+	if j.WorkMode != "remote" || !j.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want remote/true", j.WorkMode, j.Remote)
+	}
+	if j.Location != "Talladega, Alabama, United States" {
+		t.Errorf("Location = %q, want the built city/state/country", j.Location)
+	}
+	if j.EmploymentType != "full_time" {
+		t.Errorf("EmploymentType = %q, want full_time", j.EmploymentType)
+	}
+	if !strings.Contains(j.Description, "Build") || !strings.Contains(j.Description, "ship") {
+		t.Errorf("Description lost content: %q", j.Description)
+	}
+
+	// page 2: onsite arrangement, "Per Project" → contract, geography falls back through the chain.
+	j2 := jobs[1]
+	if j2.WorkMode != "onsite" || j2.Remote {
+		t.Errorf("WorkMode=%q Remote=%v, want onsite/false", j2.WorkMode, j2.Remote)
+	}
+	if j2.EmploymentType != "contract" {
+		t.Errorf("EmploymentType = %q, want contract", j2.EmploymentType)
+	}
+}

--- a/internal/sources/source.go
+++ b/internal/sources/source.go
@@ -321,6 +321,7 @@ func All(c HTTPClient) map[string]Source {
 		NewWantedKR(c),
 		NewMyCareersFuture(c),
 		NewWorkingNomads(c),
+		NewPowerToFly(c),
 		NewHimalayas(c),
 		NewRemotive(c),
 		NewJustJoin(c),

--- a/sources/powertofly.yml
+++ b/sources/powertofly.yml
@@ -1,0 +1,5 @@
+# PowerToFly remote/diversity job board. Boardless: one public API
+# (powertofly.com/api/v1/jobs), so the entry carries no board; each job's company comes
+# from the posting, not this placeholder. The adapter paginates the whole catalogue per run.
+- company: PowerToFly
+  provider: powertofly


### PR DESCRIPTION
## What

Onboards **PowerToFly** (powertofly.com) as a boardless + aggregator source adapter.

- Public keyless API `GET /api/v1/jobs/?page=N`, paginated until `meta.next_page` is null (~9555 jobs / 192 pages).
- Body inline, no per-posting detail call. Sequential crawl ≈ 7 min/run (one board slot in the concurrent pool; no per-board timeout).

## Dedup

Applications are hosted on powertofly.com itself (`/jobs/detail/<id>`) with **no outbound ATS URL** in any record. So a posting's identity is its own numeric `id` and the `UNIQUE(source, external_id)` key namespaces cleanly by board — no linksource resolution needed. Cross-source reposts are handled by the existing `role_fingerprint` clustering, same as every other aggregator.

## Mapping notes

- The feed's `location` field is the **work arrangement** (Onsite/Hybrid/Remote) → mapped to `WorkMode`; real geography is built from structured `city/state/country` titles (fallback `location_regions`).
- `required_skills` is free text (not freehire's canonical vocab) → deliberately left off `Job.Skills` so the skilltag dictionary derives from the description.
- No publish-date field → `PostedAt` nil.

## Verification

- `go build ./...`, `go vet`, `gofmt -l` clean.
- Unit tests: provider/markers/registration/yml-validation/pagination+mapping.
- **Live end-to-end** (throwaway test vs real API): fetched **9555 jobs across 192 pages, 0 errors**, natural termination at `next_page=null`; sample mapped correctly (geography, work-mode, employment_type, detail URL). All 9555 carry Location, 5261 EmploymentType, 229 remote.

Spike verdict: VALIDATED.