### PR TITLE
fix(sources): render InHire vacancies via /vagas/:jobId/:slug URL

### DIFF
--- a/internal/sources/inhire.go
+++ b/internal/sources/inhire.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"html"
 	"strings"
+
+	"github.com/strelov1/freehire/internal/normalize"
 )
 
 // inhire adapts InHire's public careers API (api.inhire.app), the ATS behind a number of
@@ -17,9 +19,13 @@ type inhire struct {
 }
 
 const (
-	inhireListURL    = "https://api.inhire.app/job-posts/public/pages"
-	inhireDetailURL  = "https://api.inhire.app/job-posts/public/pages/%s"
-	inhireVacancyURL = "https://%s.inhire.app/vagas/%s"
+	inhireListURL   = "https://api.inhire.app/job-posts/public/pages"
+	inhireDetailURL = "https://api.inhire.app/job-posts/public/pages/%s"
+	// inhireVacancyURL is the public vacancy page. InHire's careers SPA routes on
+	// /vagas/:jobId/:slug and renders a blank page when the slug segment is absent, so the
+	// URL must carry a trailing slug. The segment is cosmetic — the SPA fetches the posting
+	// by jobId alone — so any non-empty slug renders the vacancy.
+	inhireVacancyURL = "https://%s.inhire.app/vagas/%s/%s"
 )
 
 // NewInhire builds the InHire adapter over the given HTTP client.
@@ -44,6 +50,18 @@ func (h inhire) Fetch(ctx context.Context, e CompanyEntry) ([]Job, error) {
 	return fetchDetails(posts, defaultDetailWorkers, func(p inhirePost) (Job, bool) {
 		return h.detail(ctx, e, p)
 	}), nil
+}
+
+// inhireVacancyURLFor builds the public vacancy URL, deriving the required trailing slug
+// from the title. The slug is cosmetic (see inhireVacancyURL), so a transliterated title
+// slug is enough; "vaga" stands in when the title yields no slug so the segment is never
+// empty — an empty segment collapses the URL back to /vagas/:jobId, which renders blank.
+func inhireVacancyURLFor(board, jobID, title string) string {
+	slug := normalize.Slug(title)
+	if slug == "" {
+		slug = "vaga"
+	}
+	return fmt.Sprintf(inhireVacancyURL, board, jobID, slug)
 }
 
 // tenantHeader is the per-tenant routing header every InHire call carries.
@@ -76,10 +94,11 @@ func (h inhire) detail(ctx context.Context, e CompanyEntry, p inhirePost) (Job, 
 	}
 
 	mode := workplaceTypeMode(p.WorkplaceType)
+	title := strings.TrimSpace(p.DisplayName)
 	return Job{
 		ExternalID:  p.JobID,
-		URL:         fmt.Sprintf(inhireVacancyURL, e.Board, p.JobID),
-		Title:       strings.TrimSpace(p.DisplayName),
+		URL:         inhireVacancyURLFor(e.Board, p.JobID, title),
+		Title:       title,
 		Company:     e.Company,
 		Location:    p.Location,
 		Description: sanitizeHTML(html.UnescapeString(d.Description)),

--- a/internal/sources/inhire_test.go
+++ b/internal/sources/inhire_test.go
@@ -56,8 +56,8 @@ func TestInhireFetchMapsListAndDetail(t *testing.T) {
 	if j.Location != "São Paulo, BR" {
 		t.Errorf("Location = %q", j.Location)
 	}
-	if j.URL != "https://contaazul.inhire.app/vagas/"+jobID {
-		t.Errorf("URL = %q", j.URL)
+	if j.URL != "https://contaazul.inhire.app/vagas/"+jobID+"/senior-backend-engineer" {
+		t.Errorf("URL = %q, want the vagas/:jobId/:slug shape", j.URL)
 	}
 	if j.WorkMode != "remote" {
 		t.Errorf("WorkMode = %q, want remote", j.WorkMode)
@@ -76,6 +76,25 @@ func TestInhireFetchMapsListAndDetail(t *testing.T) {
 	}
 	if got := j.PostedAt.UTC().Format("2006-01-02"); got != "2026-06-15" {
 		t.Errorf("PostedAt = %s, want 2026-06-15 (publishedAt)", got)
+	}
+}
+
+func TestInhireVacancyURLFor(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{"slugs the title", "Senior Backend Engineer", "https://acme.inhire.app/vagas/j1/senior-backend-engineer"},
+		{"transliterates accents", "Consultor(a) Sênior", "https://acme.inhire.app/vagas/j1/consultor-a-senior"},
+		{"falls back when title yields no slug", "!!!", "https://acme.inhire.app/vagas/j1/vaga"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := inhireVacancyURLFor("acme", "j1", tt.title); got != tt.want {
+				t.Errorf("inhireVacancyURLFor(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

Outbound InHire vacancy links (e.g. `https://iconit.inhire.app/vagas/53ba23a1-…`) rendered a **blank page**. InHire's careers SPA routes on `/vagas/:jobId/:slug`; without the trailing slug segment the page renders nothing but the accessibility widget.

## Root cause

The adapter built `https://<board>.inhire.app/vagas/<jobId>` — missing the required second path segment.

## Verification (browser)

- Same jobId **with** any non-empty slug → vacancy renders fully (title, location, description).
- **Without** slug → blank. The slug content is cosmetic (SPA fetches by `jobId` alone), confirmed by loading garbage slugs (`x`, `job`) which still render.
- End-to-end: the user's real job now renders via the new URL shape.

## Fix

- URL format → `https://%s.inhire.app/vagas/%s/%s`.
- Slug tail derived from the title via existing `normalize.Slug` (ASCII transliteration, lowercase); falls back to `vaga` when the title yields no slug so the segment is never empty.

Existing rows heal on the next `cmd/ingest` run (`UpsertJob` `ON CONFLICT` updates the URL).

## Tests

`TestInhireVacancyURLFor` (slug / accent transliteration / empty-title fallback) + updated URL assertion in `TestInhireFetchMapsListAndDetail`. `go build`/`vet`/tests green.