### PR TITLE
feat(auth): mobile OAuth one-time-code exchange

### DIFF
--- a/internal/auth/oauth/code.go
+++ b/internal/auth/oauth/code.go
@@ -1,0 +1,81 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"sync"
+	"time"
+)
+
+// MobileCallbackURL is the custom-scheme deep link the mobile app registers.
+// The native OAuth flow finishes by redirecting here with a one-time `?code=…`
+// (or `?auth_error=oauth`); the app then exchanges the code for a session over
+// its own HTTP client, so the session cookie lands in the app's cookie jar.
+const MobileCallbackURL = "freehiremobile://auth-callback"
+
+// codeEntry is a minted one-time code's payload: the user it authenticates and
+// when it stops being valid.
+type codeEntry struct {
+	userID  int64
+	expires time.Time
+}
+
+// CodeStore hands out single-use, short-lived codes that stand in for a freshly
+// authenticated session during the mobile OAuth handshake. It is in-memory:
+// good for a single instance (the exchange happens seconds after minting, on
+// the same client). Behind a horizontally-scaled deployment it would need a
+// shared backing (sticky sessions, Redis, or a DB table) so the exchange can
+// hit the instance that minted the code.
+type CodeStore struct {
+	mu    sync.Mutex
+	codes map[string]codeEntry
+	ttl   time.Duration
+	now   func() time.Time // injectable for tests
+}
+
+// NewCodeStore returns an empty store whose codes live for ttl.
+func NewCodeStore(ttl time.Duration) *CodeStore {
+	return &CodeStore{codes: make(map[string]codeEntry), ttl: ttl, now: time.Now}
+}
+
+// Mint returns a fresh random code bound to userID, valid for the store's TTL.
+// It opportunistically drops expired entries so the map can't grow unbounded
+// from codes that are never exchanged.
+func (s *CodeStore) Mint(userID int64) (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	code := base64.RawURLEncoding.EncodeToString(b)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	for k, e := range s.codes {
+		if !e.expires.After(now) {
+			delete(s.codes, k)
+		}
+	}
+	s.codes[code] = codeEntry{userID: userID, expires: now.Add(s.ttl)}
+	return code, nil
+}
+
+// Consume redeems a code exactly once: it returns the bound user id and deletes
+// the code, or reports ok=false when the code is unknown, already used, or
+// expired.
+func (s *CodeStore) Consume(code string) (int64, bool) {
+	if code == "" {
+		return 0, false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.codes[code]
+	if !ok {
+		return 0, false
+	}
+	delete(s.codes, code) // single-use: gone whether or not it had expired
+	if !e.expires.After(s.now()) {
+		return 0, false
+	}
+	return e.userID, true
+}

--- a/internal/auth/oauth/code_test.go
+++ b/internal/auth/oauth/code_test.go
@@ -1,0 +1,75 @@
+package oauth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCodeStore_MintConsume(t *testing.T) {
+	s := NewCodeStore(time.Minute)
+	code, err := s.Mint(42)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if code == "" {
+		t.Fatal("Mint returned an empty code")
+	}
+	userID, ok := s.Consume(code)
+	if !ok || userID != 42 {
+		t.Fatalf("Consume = (%d, %v), want (42, true)", userID, ok)
+	}
+}
+
+func TestCodeStore_SingleUse(t *testing.T) {
+	s := NewCodeStore(time.Minute)
+	code, _ := s.Mint(7)
+	if _, ok := s.Consume(code); !ok {
+		t.Fatal("first Consume should succeed")
+	}
+	if _, ok := s.Consume(code); ok {
+		t.Fatal("second Consume of the same code must fail")
+	}
+}
+
+func TestCodeStore_Expires(t *testing.T) {
+	s := NewCodeStore(time.Minute)
+	now := time.Unix(1_000, 0)
+	s.now = func() time.Time { return now }
+	code, _ := s.Mint(9)
+
+	now = now.Add(59 * time.Second) // still inside the TTL
+	if _, ok := s.Consume(code); !ok {
+		t.Fatal("code should still be valid before TTL")
+	}
+
+	code2, _ := s.Mint(9)
+	now = now.Add(time.Minute + time.Second) // past the TTL
+	if _, ok := s.Consume(code2); ok {
+		t.Fatal("expired code must not be consumable")
+	}
+}
+
+func TestCodeStore_UnknownCode(t *testing.T) {
+	s := NewCodeStore(time.Minute)
+	if _, ok := s.Consume("nope"); ok {
+		t.Fatal("unknown code must not consume")
+	}
+	if _, ok := s.Consume(""); ok {
+		t.Fatal("empty code must not consume")
+	}
+}
+
+func TestCodeStore_CodesAreUnique(t *testing.T) {
+	s := NewCodeStore(time.Minute)
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		code, err := s.Mint(int64(i))
+		if err != nil {
+			t.Fatalf("Mint: %v", err)
+		}
+		if seen[code] {
+			t.Fatalf("duplicate code minted: %q", code)
+		}
+		seen[code] = true
+	}
+}

--- a/internal/auth/oauth/state.go
+++ b/internal/auth/oauth/state.go
@@ -20,6 +20,16 @@ const StateCookieName = "hire_oauth_state"
 // page. It rides the same Lax, short-lived round-trip as the state cookie.
 const ReturnCookieName = "hire_oauth_return"
 
+// PlatformCookieName remembers that a sign-in was started by the mobile app
+// (`?platform=mobile`), so the callback finishes with a custom-scheme deep link
+// carrying a one-time code instead of setting the session cookie and redirecting
+// to the web frontend. Rides the same Lax, short-lived round-trip.
+const PlatformCookieName = "hire_oauth_platform"
+
+// PlatformMobile is the only recognized platform value; anything else means the
+// default web flow.
+const PlatformMobile = "mobile"
+
 // stateTTL bounds how long a started sign-in stays completable. Ten minutes
 // covers a slow consent screen without leaving stale states around.
 const stateTTL = 10 * time.Minute
@@ -51,6 +61,16 @@ func SetReturnCookie(c *fiber.Ctx, path string, secure bool) {
 // ClearReturnCookie removes the return cookie (single-use, like the state).
 func ClearReturnCookie(c *fiber.Ctx, secure bool) {
 	writeCookie(c, ReturnCookieName, "", time.Now().Add(-time.Hour), secure)
+}
+
+// SetPlatformCookie records the initiating platform for the callback to read.
+func SetPlatformCookie(c *fiber.Ctx, platform string, secure bool) {
+	writeCookie(c, PlatformCookieName, platform, time.Now().Add(stateTTL), secure)
+}
+
+// ClearPlatformCookie removes the platform cookie (single-use, like the state).
+func ClearPlatformCookie(c *fiber.Ctx, secure bool) {
+	writeCookie(c, PlatformCookieName, "", time.Now().Add(-time.Hour), secure)
 }
 
 // writeCookie is the single place these short-lived sign-in cookies get their

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -75,6 +75,9 @@ type API struct {
 	// oauth maps enabled OAuth provider names to their implementations; empty
 	// when no provider is configured (the routes then 404 / list empty).
 	oauth map[string]oauth.Provider
+	// oauthCodes hands out the single-use codes that carry a mobile OAuth
+	// sign-in from the browser callback to the app's /exchange call.
+	oauthCodes *oauth.CodeStore
 	// frontendOrigin is where OAuth callbacks send the browser back to.
 	frontendOrigin string
 	// gmailConnector + gmailCipher back the "Connect Gmail" inbox. Both nil when
@@ -263,6 +266,7 @@ func Register(app *fiber.App, cfg Config) {
 		cookieSecure:   cfg.CookieSecure,
 		cookieDomain:   cfg.CookieDomain,
 		oauth:          cfg.OAuthProviders,
+		oauthCodes:     oauth.NewCodeStore(60 * time.Second),
 		frontendOrigin: cfg.FrontendOrigin,
 		gmailConnector: cfg.GmailConnector,
 		gmailCipher:    cfg.GmailCipher,
@@ -646,4 +650,7 @@ func Register(app *fiber.App, cfg Config) {
 	authGroup.Get("/oauth/providers", a.ListOAuthProviders)
 	authGroup.Get("/oauth/:provider/start", a.OAuthStart)
 	authGroup.Get("/oauth/:provider/callback", a.OAuthCallback)
+	// Mobile-only: redeem the one-time code from the custom-scheme callback for a
+	// session. Public; the code is the credential.
+	authGroup.Post("/oauth/exchange", a.OAuthExchange)
 }

--- a/internal/handler/oauth.go
+++ b/internal/handler/oauth.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"log"
+	"net/url"
 	"sort"
 	"strings"
 
@@ -24,7 +25,8 @@ func (a *API) ListOAuthProviders(c *fiber.Ctx) error {
 
 // OAuthStart begins the authorization-code flow: it stores a fresh CSRF state
 // in a short-lived cookie and redirects the browser to the provider's consent
-// page carrying the same state.
+// page carrying the same state. `?platform=mobile` records that the flow was
+// started by the native app, so the callback finishes as a deep link.
 func (a *API) OAuthStart(c *fiber.Ctx) error {
 	p, ok := a.oauth[c.Params("provider")]
 	if !ok {
@@ -39,56 +41,100 @@ func (a *API) OAuthStart(c *fiber.Ctx) error {
 	// Remember where the SPA wants the user back, so sign-in from a deep page
 	// (e.g. a job detail) returns there. Sanitized to a same-origin path.
 	oauth.SetReturnCookie(c, oauth.SafeReturnPath(c.Query("returnTo")), a.cookieSecure)
+	if c.Query("platform") == oauth.PlatformMobile {
+		oauth.SetPlatformCookie(c, oauth.PlatformMobile, a.cookieSecure)
+	}
 	return c.Redirect(p.AuthCodeURL(state), fiber.StatusFound)
 }
 
 // OAuthCallback completes the flow: verify the CSRF state, exchange the code
-// for the provider identity, resolve (or create) the account, start the
-// session, and send the browser back to the SPA. The callback is a top-level
-// navigation, so every failure redirects with auth_error instead of rendering
-// JSON; details go to the server log.
+// for the provider identity, resolve (or create) the account, then finish. On
+// the web it starts the session and redirects to the SPA; for a mobile flow it
+// mints a one-time code and redirects to the app's custom scheme (the session
+// is minted later, by the app's own /exchange call). Every failure redirects
+// with auth_error instead of rendering JSON; details go to the server log.
 func (a *API) OAuthCallback(c *fiber.Ctx) error {
 	p, ok := a.oauth[c.Params("provider")]
 	if !ok {
 		return fiber.NewError(fiber.StatusNotFound, "unknown provider")
 	}
 
-	// The state and return target are single-use: clear both cookies no matter
-	// how the rest goes. Re-sanitize the return path defensively.
+	// The state, return target, and platform are single-use: clear all three
+	// cookies no matter how the rest goes. Re-sanitize the return path.
 	cookieState := c.Cookies(oauth.StateCookieName)
 	returnTo := oauth.SafeReturnPath(c.Cookies(oauth.ReturnCookieName))
+	mobile := c.Cookies(oauth.PlatformCookieName) == oauth.PlatformMobile
 	oauth.ClearStateCookie(c, a.cookieSecure)
 	oauth.ClearReturnCookie(c, a.cookieSecure)
+	oauth.ClearPlatformCookie(c, a.cookieSecure)
 
 	state, code := c.Query("state"), c.Query("code")
 	if state == "" || state != cookieState {
-		return a.oauthFail(c, p.Name(), returnTo, errors.New("state mismatch"))
+		return a.oauthFail(c, p.Name(), returnTo, mobile, errors.New("state mismatch"))
 	}
 	if code == "" {
-		return a.oauthFail(c, p.Name(), returnTo, errors.New("missing code"))
+		return a.oauthFail(c, p.Name(), returnTo, mobile, errors.New("missing code"))
 	}
 
 	identity, err := p.FetchIdentity(c.Context(), code)
 	if err != nil {
-		return a.oauthFail(c, p.Name(), returnTo, err)
+		return a.oauthFail(c, p.Name(), returnTo, mobile, err)
 	}
 
 	userID, err := a.accounts.ResolveOAuthAccount(c.Context(), p.Name(), identity.ProviderUserID, identity.Email, identity.EmailVerified)
 	if err != nil {
-		return a.oauthFail(c, p.Name(), returnTo, err)
+		return a.oauthFail(c, p.Name(), returnTo, mobile, err)
+	}
+
+	if mobile {
+		// Hand the app a single-use code instead of a cookie; the app exchanges
+		// it over its own client so the session cookie lands in its jar.
+		otc, err := a.oauthCodes.Mint(userID)
+		if err != nil {
+			return a.oauthFail(c, p.Name(), returnTo, mobile, err)
+		}
+		return c.Redirect(oauth.MobileCallbackURL+"?code="+url.QueryEscape(otc), fiber.StatusFound)
 	}
 
 	if err := a.setSession(c, userID); err != nil {
-		return a.oauthFail(c, p.Name(), returnTo, err)
+		return a.oauthFail(c, p.Name(), returnTo, mobile, err)
 	}
 	return c.Redirect(a.frontendOrigin+returnTo, fiber.StatusFound)
 }
 
-// oauthFail logs the failure server-side and sends the browser back to where
-// sign-in started with the generic auth_error marker (never a JSON error
-// page), so the dialog can reopen in place. returnTo is a sanitized path.
-func (a *API) oauthFail(c *fiber.Ctx, provider, returnTo string, err error) error {
+// OAuthExchange redeems the one-time code from a mobile OAuth callback for a
+// session. Because the app makes this request, the session cookie set here
+// lands in the app's cookie jar (the whole point of the mobile handshake). A
+// missing/expired/reused code is a generic 401.
+func (a *API) OAuthExchange(c *fiber.Ctx) error {
+	var in struct {
+		Code string `json:"code"`
+	}
+	if err := c.BodyParser(&in); err != nil {
+		return fiber.NewError(fiber.StatusBadRequest, "invalid request body")
+	}
+	userID, ok := a.oauthCodes.Consume(in.Code)
+	if !ok {
+		return fiber.NewError(fiber.StatusUnauthorized, "invalid or expired code")
+	}
+	if err := a.setSession(c, userID); err != nil {
+		return err
+	}
+	user, err := a.accounts.UserByID(c.Context(), userID)
+	if err != nil {
+		return accountsError(err)
+	}
+	return c.JSON(fiber.Map{"data": toUserResponse(user)})
+}
+
+// oauthFail logs the failure server-side and sends the client back to where
+// sign-in started with the generic auth_error marker (never a JSON error page).
+// Mobile flows bounce to the app's custom scheme; web flows to the SPA path.
+func (a *API) oauthFail(c *fiber.Ctx, provider, returnTo string, mobile bool, err error) error {
 	log.Printf("oauth %s: sign-in failed: %v", provider, err)
+	if mobile {
+		return c.Redirect(oauth.MobileCallbackURL+"?auth_error=oauth", fiber.StatusFound)
+	}
 	sep := "?"
 	if strings.Contains(returnTo, "?") {
 		sep = "&"

--- a/internal/handler/oauth_exchange_integration_test.go
+++ b/internal/handler/oauth_exchange_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+// Integration test for the mobile OAuth code exchange against a real Postgres:
+// a minted one-time code exchanges once for a session (setting the auth cookie)
+// and the resolved user, and a reused code is rejected. Run with:
+// go test -tags=integration ./internal/handler/
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/strelov1/freehire/internal/accounts"
+	"github.com/strelov1/freehire/internal/auth"
+	"github.com/strelov1/freehire/internal/auth/oauth"
+	"github.com/strelov1/freehire/internal/db"
+)
+
+func TestOAuthExchangeEndToEnd(t *testing.T) {
+	pool := startPostgres(t)
+	ctx := context.Background()
+
+	var userID int64
+	if err := pool.QueryRow(ctx, `INSERT INTO users (email) VALUES ('oauth@example.test') RETURNING id`).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	queries := db.New(pool)
+	codes := oauth.NewCodeStore(time.Minute)
+	h := &API{
+		pool:       pool,
+		queries:    queries,
+		issuer:     auth.NewIssuer("test-secret", time.Hour),
+		oauthCodes: codes,
+		accounts:   accounts.New(accounts.NewQueriesRepository(queries, pool), authHasher{}),
+	}
+
+	app := fiber.New(fiber.Config{ErrorHandler: RenderError})
+	app.Post("/api/v1/auth/oauth/exchange", h.OAuthExchange)
+
+	code, err := codes.Mint(userID)
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	exchange := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(fiber.MethodPost, "/api/v1/auth/oauth/exchange", strings.NewReader(`{"code":"`+code+`"}`))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := app.Test(req)
+		if err != nil {
+			t.Fatalf("Test: %v", err)
+		}
+		rec := httptest.NewRecorder()
+		rec.Code = resp.StatusCode
+		for k, vs := range resp.Header {
+			for _, v := range vs {
+				rec.Header().Add(k, v)
+			}
+		}
+		if b, _ := io.ReadAll(resp.Body); len(b) > 0 {
+			rec.Body.Write(b)
+		}
+		return rec
+	}
+
+	first := exchange()
+	if first.Code != fiber.StatusOK {
+		t.Fatalf("status = %d, want 200", first.Code)
+	}
+	if sc := strings.Join(first.Header().Values("Set-Cookie"), "\n"); !strings.Contains(sc, auth.CookieName+"=") {
+		t.Errorf("exchange did not set the session cookie: %q", sc)
+	}
+	var out struct {
+		Data struct {
+			Email string `json:"email"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(first.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Data.Email != "oauth@example.test" {
+		t.Errorf("email = %q, want oauth@example.test", out.Data.Email)
+	}
+
+	// Single-use: the same code can't be redeemed twice.
+	if second := exchange(); second.Code != fiber.StatusUnauthorized {
+		t.Errorf("reused code status = %d, want 401", second.Code)
+	}
+}

--- a/internal/handler/oauth_test.go
+++ b/internal/handler/oauth_test.go
@@ -36,12 +36,25 @@ func oauthApp(providers map[string]oauth.Provider) *fiber.App {
 	h := &API{
 		issuer:         auth.NewIssuer("test-secret", time.Hour),
 		oauth:          providers,
+		oauthCodes:     oauth.NewCodeStore(time.Minute),
 		frontendOrigin: "http://app.example",
 	}
 	app.Get("/api/v1/auth/oauth/providers", h.ListOAuthProviders)
 	app.Get("/api/v1/auth/oauth/:provider/start", h.OAuthStart)
 	app.Get("/api/v1/auth/oauth/:provider/callback", h.OAuthCallback)
+	app.Post("/api/v1/auth/oauth/exchange", h.OAuthExchange)
 	return app
+}
+
+func postOAuthJSON(t *testing.T, app *fiber.App, path, body string) *http.Response {
+	t.Helper()
+	req := httptest.NewRequest(fiber.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	return resp
 }
 
 func get(t *testing.T, app *fiber.App, path string, cookies ...string) *http.Response {
@@ -143,5 +156,57 @@ func TestOAuthCallback_MissingCodeRedirectsWithError(t *testing.T) {
 	resp := get(t, app, "/api/v1/auth/oauth/google/callback?state=s", oauth.StateCookieName+"=s")
 	if resp.StatusCode != fiber.StatusFound || resp.Header.Get("Location") != "http://app.example/?auth_error=oauth" {
 		t.Errorf("status/Location = %d %q, want error redirect", resp.StatusCode, resp.Header.Get("Location"))
+	}
+}
+
+// --- Mobile flow ------------------------------------------------------------
+
+func TestOAuthStart_MobileSetsPlatformCookie(t *testing.T) {
+	app := oauthApp(map[string]oauth.Provider{"google": &fakeProvider{name: "google"}})
+
+	resp := get(t, app, "/api/v1/auth/oauth/google/start?platform=mobile")
+	setCookie := strings.Join(resp.Header.Values("Set-Cookie"), "\n")
+	if !strings.Contains(setCookie, oauth.PlatformCookieName+"=mobile") {
+		t.Errorf("Set-Cookie %q missing platform=mobile", setCookie)
+	}
+
+	// A plain (web) start must not set the platform cookie.
+	web := get(t, app, "/api/v1/auth/oauth/google/start")
+	if sc := strings.Join(web.Header.Values("Set-Cookie"), "\n"); strings.Contains(sc, oauth.PlatformCookieName+"=mobile") {
+		t.Errorf("web start unexpectedly set platform cookie: %q", sc)
+	}
+}
+
+func TestOAuthCallback_MobileErrorRedirectsToScheme(t *testing.T) {
+	app := oauthApp(map[string]oauth.Provider{"google": &fakeProvider{name: "google"}})
+	// State mismatch, but the platform cookie marks this a mobile flow → the
+	// error must bounce to the app's custom scheme, not the web frontend.
+	resp := get(t, app, "/api/v1/auth/oauth/google/callback?code=x&state=evil",
+		oauth.StateCookieName+"=good", oauth.PlatformCookieName+"=mobile")
+
+	if resp.StatusCode != fiber.StatusFound {
+		t.Fatalf("status = %d, want 302", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != oauth.MobileCallbackURL+"?auth_error=oauth" {
+		t.Errorf("Location = %q, want mobile auth_error deep link", loc)
+	}
+}
+
+func TestOAuthExchange_InvalidCodeIs401(t *testing.T) {
+	app := oauthApp(map[string]oauth.Provider{})
+	resp := postOAuthJSON(t, app, "/api/v1/auth/oauth/exchange", `{"code":"nope"}`)
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+	if sc := strings.Join(resp.Header.Values("Set-Cookie"), "\n"); strings.Contains(sc, auth.CookieName+"=") {
+		t.Errorf("session cookie set for an invalid code: %q", sc)
+	}
+}
+
+func TestOAuthExchange_BadBodyIs400(t *testing.T) {
+	app := oauthApp(map[string]oauth.Provider{})
+	resp := postOAuthJSON(t, app, "/api/v1/auth/oauth/exchange", `not json`)
+	if resp.StatusCode != fiber.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
## Why

The mobile app (freehire-mobile) needs GitHub / Google / LinkedIn sign-in, but the web OAuth flow can't drive a native app: it finishes by setting an httpOnly cookie after an **https** redirect, which a native in-app browser (`ASWebAuthenticationSession`) can neither complete (it needs a **custom-scheme** redirect to resolve) nor share cookies with the app.

## What

A mobile-aware handshake using a **single-use, short-lived code** — so the app ends up with the same `hire_token` session cookie as email/password, and no long-lived token ever travels in a URL.

- **`OAuthStart`** honors `?platform=mobile` via a short-lived platform cookie.
- **`OAuthCallback`**, for a mobile flow, mints a one-time code (~60s, single-use, bound to the resolved user) and redirects to `freehiremobile://auth-callback?code=…` (or `?auth_error=oauth`) instead of setting the cookie + web redirect. The **web path is unchanged**. Providers need **no** change (their `redirect_uri` stays the backend callback).
- **New `POST /api/v1/auth/oauth/exchange`** consumes the code and issues the session cookie — set on the app's *own* request, so it lands in the app's cookie jar — returning the user. Invalid / expired / reused code → `401`.
- **`oauth.CodeStore`**: in-memory, single-use, TTL'd.

## Tests

- `CodeStore`: 5 unit tests (mint/consume, single-use, expiry, unknown, uniqueness).
- Handler: unit tests for the platform cookie, the mobile error redirect to the custom scheme, and exchange `401`/`400`.
- Integration (real Postgres, `//go:build integration`): the happy-path exchange sets the session cookie + returns the user, and a reused code is `401`. ✅ passing.
- `go build ./...`, `gofmt` clean.

## Deploy / follow-ups

- ⚠️ **Scaling:** `CodeStore` is in-memory — good for a single instance (the exchange happens seconds after minting, on the same client). A horizontally-scaled deploy needs a shared backing (Redis / DB table) or sticky sessions.
- The mobile client lives in `freehire-mobile` (`feat/oauth-social`); it's inert until this deploys.
- Custom scheme `freehiremobile://` is registered in the app; end-to-end is verified on a dev-client/device.