### PR TITLE
feat(web): client-side profile-match bar on job cards

### DIFF
--- a/web/src/lib/components/JobMatchBar.svelte
+++ b/web/src/lib/components/JobMatchBar.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import type { ClientMatch } from '$lib/jobMatch';
+
+  // A card-level profile-match strip: a thin coverage bar + "N% · matched/total skills".
+  // Purely presentational — the owning JobRow computes the client-side match (exact
+  // overlap of the job's skills and the signed-in viewer's profile skills) and passes it
+  // in, so the chips it colours and this bar can't disagree on the score. `match` is null
+  // for guests / no-profile viewers, in which case nothing renders. `gutterRight` reserves
+  // the feed's bottom-right hide control so the percent never slides under that icon.
+  let { match, gutterRight = false }: { match: ClientMatch | null; gutterRight?: boolean } = $props();
+</script>
+
+{#if match}
+  <div
+    class={['mt-3 flex items-center gap-2 border-t border-dashed border-border pt-2.5', gutterRight && 'pr-9']}
+    aria-label="Profile match: {match.percent}%, {match.matched} of {match.total} skills"
+  >
+    <!-- The unfilled remainder is a soft red (the skills you're missing); the fill is the
+         brand tone (the skills you have) — a two-tone have/missing bar in one track. -->
+    <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-destructive/15">
+      <div class="h-full rounded-full bg-brand transition-all" style="width: {match.percent}%"></div>
+    </div>
+    <span class="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">
+      {match.percent}% · {match.matched}/{match.total} skills
+    </span>
+  </div>
+{/if}

--- a/web/src/lib/components/JobRow.svelte
+++ b/web/src/lib/components/JobRow.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { resolve } from '$app/paths';
-  import { Bookmark, EyeOff, X } from '@lucide/svelte';
+  import { Bookmark, Eye, EyeOff, X } from '@lucide/svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import JobMatchBar from './JobMatchBar.svelte';
   import { api } from '$lib/api';
   import { isAuthenticated } from '$lib/auth.svelte';
   import { openAuthDialog } from '$lib/auth-dialog.svelte';
   import { cardTags, formatSalary } from '$lib/enrichment';
+  import { computeClientMatch, resolveMatchState } from '$lib/jobMatch';
+  import { profileStore } from '$lib/profile.svelte';
   import { metaDescription } from '$lib/seo';
   import type { Job } from '$lib/types';
   import { Badge } from '$lib/ui';
@@ -71,6 +74,30 @@
   const MAX_SKILLS = 5;
   const shownSkills = $derived(skills.slice(0, MAX_SKILLS));
   const extraSkills = $derived(skills.length - MAX_SKILLS);
+
+  // Card-level profile match, computed entirely in the browser (no per-card request):
+  // the exact overlap between this job's skills and the signed-in viewer's profile
+  // skills. The job is server-rendered; only the profile hydrates client-side, loaded
+  // once and deduped across every card by the store (SSR-safe no-op for guests).
+  $effect(() => {
+    if (isAuthenticated()) profileStore.ensureLoaded();
+  });
+  const profileSkills = $derived(profileStore.profile?.skills ?? []);
+  const matchState = $derived(
+    resolveMatchState({
+      jobSkills: skills,
+      authenticated: isAuthenticated(),
+      profileLoaded: profileStore.loaded,
+      profileSkills,
+    }),
+  );
+  // The viewer's skills as a lowercase set, only when there's a real match to show —
+  // used to tint each skill chip (a skill you have vs one you're missing). Null for
+  // guests / no-profile viewers, who see the plain brand chips.
+  const haveSet = $derived(
+    matchState === 'ready' ? new Set(profileSkills.map((s) => s.toLowerCase())) : null,
+  );
+  const match = $derived(matchState === 'ready' ? computeClientMatch(skills, profileSkills) : null);
 
   // Whether the signed-in user has saved this job, read from the shared saved set
   // (loaded once on the browse view). The bookmark reflects this and updates the
@@ -177,7 +204,7 @@
     'block hover:opacity-100',
     compact ? 'p-3' : 'p-4',
   ]}
-  class:opacity-60={isViewed}
+  class:opacity-80={isViewed}
 >
   <!-- Company + timestamp rail: a quiet eyebrow that yields the stage to the title.
        The name truncates to a single line, so a long company (e.g. "Veterinary
@@ -192,9 +219,16 @@
         {job.company || 'Unknown company'}
       </span>
     </div>
-    {#if posted}
-      <span class="shrink-0 text-xs tabular-nums text-muted-foreground">{posted}</span>
-    {/if}
+    <div class="flex shrink-0 items-center gap-1.5 text-muted-foreground">
+      {#if isViewed}
+        <!-- A quiet "you've seen this" marker, paired with the lighter dim on the card
+             so viewed jobs recede without becoming hard to read. -->
+        <Eye class="size-3.5" aria-label="Viewed" />
+      {/if}
+      {#if posted}
+        <span class="text-xs tabular-nums">{posted}</span>
+      {/if}
+    </div>
   </div>
 
   <!-- The title is the card's hero — a size up from the body with tight leading, so
@@ -229,7 +263,7 @@
   <div class={['mt-3 flex items-end justify-between gap-3', onHide && 'pr-9']}>
     <div class="flex min-w-0 flex-wrap items-center gap-1.5">
       {#each shownSkills as skill (skill)}
-        <Badge variant="brand">{skill}</Badge>
+        <Badge variant={haveSet && !haveSet.has(skill.toLowerCase()) ? 'missing' : 'brand'}>{skill}</Badge>
       {/each}
       {#if extraSkills > 0}
         <span class="text-xs text-muted-foreground">+{extraSkills} skills</span>
@@ -239,6 +273,11 @@
       <span class="shrink-0 text-base font-bold tabular-nums tracking-tight">{salary}</span>
     {/if}
   </div>
+
+  <!-- Card-level profile match: a thin coverage bar shown only to a signed-in viewer with
+       a skills profile (`match` is null otherwise). `gutterRight` keeps the percent clear
+       of the feed's bottom-right hide control. -->
+  <JobMatchBar {match} gutterRight={!!onHide} />
 </a>
 
 {#if footer}

--- a/web/src/lib/jobMatch.test.ts
+++ b/web/src/lib/jobMatch.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveMatchState, matchBarSegments } from './jobMatch';
+import { resolveMatchState, matchBarSegments, computeClientMatch } from './jobMatch';
 
 describe('resolveMatchState', () => {
   const base = { jobSkills: ['go'], authenticated: true, profileLoaded: true, profileSkills: ['go'] };
@@ -41,5 +41,37 @@ describe('matchBarSegments', () => {
       exact: 0,
       adjacent: 0,
     });
+  });
+});
+
+describe('computeClientMatch', () => {
+  it('counts the exact (case-insensitive) overlap of job skills the user has', () => {
+    // 2 of 4 job skills are in the profile → 50%.
+    expect(computeClientMatch(['go', 'kafka', 'aws', 'spark'], ['go', 'aws', 'react'])).toEqual({
+      total: 4,
+      matched: 2,
+      percent: 50,
+    });
+  });
+
+  it('matches regardless of case so canonical slugs never miss on casing', () => {
+    expect(computeClientMatch(['Go', 'Kafka'], ['go'])).toEqual({ total: 2, matched: 1, percent: 50 });
+  });
+
+  it('rounds the percent to the nearest whole', () => {
+    // 1 of 3 → 33.33 → 33.
+    expect(computeClientMatch(['go', 'kafka', 'aws'], ['go']).percent).toBe(33);
+  });
+
+  it('is a zero match, not a divide-by-zero, when the job has no skills', () => {
+    expect(computeClientMatch([], ['go'])).toEqual({ total: 0, matched: 0, percent: 0 });
+  });
+
+  it('is a zero match when the user has no skills', () => {
+    expect(computeClientMatch(['go', 'kafka'], [])).toEqual({ total: 2, matched: 0, percent: 0 });
+  });
+
+  it('does not let duplicate profile skills inflate the count', () => {
+    expect(computeClientMatch(['go', 'kafka'], ['go', 'go'])).toEqual({ total: 2, matched: 1, percent: 50 });
   });
 });

--- a/web/src/lib/jobMatch.ts
+++ b/web/src/lib/jobMatch.ts
@@ -22,6 +22,23 @@ export function resolveMatchState(input: {
   return 'ready';
 }
 
+/** A card-level match computed entirely in the browser: the exact overlap between a
+ *  job's skills and the viewer's profile skills. No adjacency (that dictionary lives on
+ *  the backend), so this is a lighter, exact-only signal than GET /jobs/:slug/match —
+ *  the trade for computing it client-side, with zero requests per card. */
+export type ClientMatch = { total: number; matched: number; percent: number };
+
+/** Count how many of a job's skills the user already has (case-insensitive set
+ *  intersection over canonical slugs) and the coverage percent. `total` is the job's
+ *  skill count; a job with no skills is a zero match (no divide-by-zero). */
+export function computeClientMatch(jobSkills: string[], profileSkills: string[]): ClientMatch {
+  const have = new Set(profileSkills.map((s) => s.toLowerCase()));
+  const total = jobSkills.length;
+  const matched = jobSkills.filter((s) => have.has(s.toLowerCase())).length;
+  const percent = total === 0 ? 0 : Math.round((matched / total) * 100);
+  return { total, matched, percent };
+}
+
 /** The two progress-bar segment widths (in percent of the track): a full-weight
  *  green segment for exact matches and a half-weight amber segment for adjacent
  *  ones. Their sum is the (unrounded) coverage percent. */

--- a/web/src/lib/ui/badge.svelte
+++ b/web/src/lib/ui/badge.svelte
@@ -8,6 +8,7 @@
         secondary: 'border-transparent bg-secondary text-secondary-foreground',
         outline: 'border-border text-muted-foreground',
         brand: 'border-transparent bg-brand-muted text-brand-strong',
+        missing: 'border-destructive/15 bg-destructive/5 text-destructive/75',
       },
     },
     defaultVariants: { variant: 'secondary' },


### PR DESCRIPTION
## What

Adds a per-card **profile match** signal to `JobRow` for signed-in users with a skills profile:

- **Two-tone bar** — brand fill (skills you have) + soft-red remainder (missing), with `N% · matched/total skills`.
- **Tinted skill chips** — green (have) vs soft-red (missing), new `missing` Badge variant.
- Renders only in the `ready` state (auth + profile-with-skills + a skilled job); guests / no-profile see the plain card.

Plus: soften the **viewed-card dim** (`opacity-60 → 80`) and add a quiet **eye marker** on seen jobs.

## How

- `computeClientMatch(jobSkills, profileSkills)` — pure, unit-tested helper in `jobMatch.ts`. Exact (case-insensitive) set overlap; **no adjacency** (that dict is backend-only) so it's a lighter, exact-only signal than `GET /jobs/:slug/match`.
- Computed **entirely client-side**: `job.skills` (SSR) ∩ `profileStore` skills, loaded once and deduped across every card — **zero extra requests** for a list.
- `JobMatchBar` is presentational; `JobRow` owns the match state so the chips and bar can't disagree.

## Test

- 6 new vitest cases for `computeClientMatch`; full suite green (320/320), svelte-check 0 errors, eslint clean.
- Verified live (light + dark) on the local stack.