### PR TITLE
docs(openspec): propose companies-meili-search

### DIFF
--- a/openspec/changes/companies-meili-search/.openspec.yaml
+++ b/openspec/changes/companies-meili-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/companies-meili-search/design.md
+++ b/openspec/changes/companies-meili-search/design.md
@@ -1,0 +1,132 @@
+## Context
+
+`GET /api/v1/companies` (handler `internal/handler/companies.go:94` → `queries.ListCompanies`)
+serves every company search/typeahead surface in the product. Today it filters with
+Postgres `ILIKE '%q%'` on `name`/`slug` and orders by `job_count DESC, name` — no
+relevance ranking, no typo tolerance, no prefix bias. An exact-name match with few
+jobs is buried under higher-volume substring matches (the "arb" bug).
+
+The codebase already runs Meilisearch for jobs (`internal/search`, `cmd/reindex`),
+using a two-index atomic swap-rebuild (`jobs` / `jobs_rebuild`) and best-effort
+incremental pushes from the ingest crawler keyed on `content_hash`. The `search`
+package is hardwired to `JobDocument` and the `jobs*` index UIDs — there is no
+generic index abstraction.
+
+All company reads were inventoried: every search/typeahead/ranked-list consumer
+funnels through `listCompanies` → `GET /api/v1/companies` (catalog SSR + client,
+job-filter `company_slug` typeahead, referral `CompanyPicker`, global
+`HeaderSearch`, `meta.total` counts). Point lookups (`GetCompany` by slug), sitemap,
+writes, `RefreshCompanyFacets`, and the `insights` leaderboard do not search.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Relevance-ranked, typo-tolerant, prefix-aware company search with an exact-name
+  match first and `job_count` as the tiebreaker.
+- Cover every company-search surface by migrating the single `/companies` endpoint —
+  zero frontend changes.
+- Zero regression risk to the working jobs search: do not edit jobs code.
+- No new failure point for `/companies`: Postgres path stays as fallback.
+
+**Non-Goals:**
+- Real-time (per-write) index freshness for companies — eventual consistency via a
+  scheduled rebuild is sufficient (companies change slowly).
+- Moving point lookups, sitemap, writes, `insights`, or `GET /companies/subindustries`
+  off Postgres.
+- Generalizing `internal/search` into an index-agnostic abstraction.
+
+## Decisions
+
+### Decision: Separate `CompanyIndex` parallel to jobs, not a generic refactor
+
+Add `internal/search/company.go` with its own `CompanyDocument`, `FromCompany`
+mapper, `companySettings()`, `SearchCompanies()`, and `RebuildCompanies()` methods
+on `*Client`, plus its own UID constants (`companies`, `companies_rebuild`). The
+existing jobs client (`facet`/`semantic` fields, `JobDocument`, `jobs*` UIDs) is
+left byte-for-byte unchanged.
+
+- **Why:** the jobs search is on the critical path and already has a history of
+  Meili incidents (corruption, disk-full during reindex). A parallel type means the
+  jobs path physically cannot regress from this change. Chosen by the user over a
+  generic abstraction.
+- **Alternative — generalize `Rebuild`/`Client` over a document interface:** cleaner
+  long-term, but touches the jobs code path (regression risk) for a second consumer
+  that is small and slow-moving. Deferred; the duplication is modest and honest.
+
+### Decision: Meili ranking rules = default + `job_count:desc` tiebreaker
+
+`companySettings()` uses Meili's default ranking (`words, typo, proximity,
+attribute, exactness`) with `job_count:desc` appended as the final tiebreaker.
+Searchable attributes ordered `name`, `slug`, `tagline` (attribute-rank favors
+`name`). `exactness` gives the exact-name-first behavior the spec requires; the
+appended `job_count:desc` reproduces today's secondary ordering among ties.
+
+- **Why:** matches the spec's exact→prefix→contains + `job_count` tiebreaker with
+  built-in behavior — no hand-rolled scoring.
+- **Alternative — a hand-tuned Postgres `ORDER BY` relevance expression:** solves
+  the "arb" case without new infra, but no typo tolerance and no prefix search, and
+  the user explicitly wants the Meili path for all surfaces.
+
+### Decision: Scheduled full swap-rebuild, no per-write outbox
+
+`cmd/reindex-companies` keyset-scans `companies WHERE job_count > 0`, maps via
+`FromCompany`, pushes into `companies_rebuild`, awaits, and atomically swaps to
+`companies` (mirrors `cmd/reindex`'s `Prepare`/`Push`/`Promote`). Runs on cron with
+its own flock, never stacked with the jobs reindex.
+
+- **Why:** companies are a slow-moving directory (~hundreds of thousands of rows,
+  changed by periodic backfills/recompute). Eventual consistency within the rebuild
+  interval is acceptable; a per-write outbox (as jobs have) is unjustified plumbing.
+- **Alternative — hook company pushes into every company-writing command:** matches
+  jobs' freshness but adds `content_hash` tracking + push calls to `SyncCompanies`,
+  `import-yc`, backfills, `RefreshCompanyFacets`. Not worth it here.
+
+### Decision: Handler reroutes with Postgres fallback
+
+`ListCompanies` uses Meili when search is enabled (`client != nil`) **and** a `q`
+or facet filter is present; otherwise, or on any Meili error, it serves the current
+Postgres path. The response shape (`{data, meta}`), the `job_count > 0` scope, and
+the empty-`q` catalog ordering are preserved so the frontend and contract are
+untouched. `meta.total` comes from Meili's `estimatedTotalHits` on the Meili path,
+from `CountCompanies` on the Postgres path.
+
+- **Why:** `/companies` currently works with no Meili dependency; keeping the
+  fallback means the worst case (Meili down) silently degrades to today's behavior
+  instead of a new outage.
+- **Alternative — hard Meili cutover:** simpler handler, but makes the whole company
+  catalog + every typeahead depend on Meili uptime. Rejected.
+
+## Risks / Trade-offs
+
+- **Facet-value fidelity between Postgres overlap and Meili filters** → Meili filter
+  expressions must reproduce array-overlap (OR within facet, AND across) and scalar
+  membership exactly, including the `NULL`-matches-none rule for `maturity`/
+  `subindustry`. Covered by porting the existing facet scenarios as tests against the
+  Meili path.
+- **Eventual-consistency lag** → a brand-new hiring company or a just-recomputed
+  facet is invisible to search until the next company reindex. Acceptable per the
+  spec; the cron interval bounds the lag. Fallback also masks a cold/empty index by
+  serving Postgres.
+- **Shared Meili host disk during swap** → the rebuild transiently holds old+new
+  index (~2× that index's disk). The companies index is small, but the reindex must
+  not stack with the jobs reindex (own flock) to avoid compounding disk pressure —
+  the same discipline already applied to jobs.
+- **`meta.total` semantics drift** → Meili returns an *estimate* (`estimatedTotalHits`)
+  where Postgres `CountCompanies` is exact. For a typeahead/catalog this is
+  acceptable and matches how jobs search already reports totals.
+
+## Migration Plan
+
+1. Ship `internal/search/company.go` + `cmd/reindex-companies` + handler reroute
+   behind the existing search-enabled gate (no Meili configured → pure Postgres,
+   behavior identical to today).
+2. Deploy; run `reindex-companies` once to build the `companies` index.
+3. Add the cron entry (own flock, off-peak, not overlapping jobs reindex).
+4. Verify ranked search on prod (`?q=arb` returns the exact match first; typo query
+   resolves). Rollback = stop routing to Meili (the fallback path is the old
+   behavior) or drop the `companies` index; jobs search is untouched throughout.
+
+## Open Questions
+
+- Cron cadence for `reindex-companies` (daily vs a few times a day) — decide with
+  ops based on how fresh the directory needs to be; defaults to daily.

--- a/openspec/changes/companies-meili-search/proposal.md
+++ b/openspec/changes/companies-meili-search/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+A company literally named "arb" does not rank first for `GET /api/v1/companies?q=arb`.
+The endpoint filters with a Postgres `ILIKE '%arb%'` substring (on `name` and
+`slug`) and orders purely by `job_count DESC, name` — there is **no relevance
+ranking**, so an exact-name match with few open jobs is buried below every
+higher-volume company whose name or slug merely contains the query. Every company
+search surface in the product (catalog, three typeaheads, header search) is served
+by this one endpoint, so they all inherit the same poor ranking and lack typo
+tolerance and prefix matching.
+
+## What Changes
+
+- Add a **separate Meilisearch `companies` index** (parallel to the existing
+  `jobs` index) built from the `companies` table, carrying the searchable text
+  (`name`, `slug`, `tagline`), the denormalized `job_count`, and the existing
+  facet arrays/scalars as filterable attributes.
+- Route company search behind `GET /api/v1/companies` through Meili when search is
+  enabled and a `q` or facet filter is present — giving relevance ranking (exact →
+  prefix → contains), typo tolerance, and `job_count` as the tiebreaker — so an
+  exact-name match surfaces first.
+- Keep a **Postgres ILIKE fallback**: on any Meili error or when search is
+  disabled/unavailable, the handler serves the current Postgres path, so
+  `/companies` gains no new failure point.
+- Add `cmd/reindex-companies`: a full swap-rebuild worker (reusing the jobs
+  index's atomic `swap-indexes` pattern) over `companies WHERE job_count > 0`,
+  scheduled on cron and never stacked with the jobs reindex. No per-write outbox —
+  companies change slowly, eventual consistency is sufficient.
+- **All company-search consumers are covered by this single endpoint** — catalog
+  page, job-filter company typeahead, referral `CompanyPicker`, global
+  `HeaderSearch`, and the filtered `meta.total` — with no frontend changes.
+- Leave `internal/search`'s jobs code untouched (a parallel `CompanyIndex`, not a
+  refactor of the jobs client), so the jobs search cannot regress.
+
+Non-goals (kept on Postgres): point lookups by slug (`GET /companies/:slug`, OG,
+match-analysis), the sitemap, all writes/maintenance (`RefreshCompanyFacets` etc.),
+the `insights` leaderboard, and the `GET /companies/subindustries` facet vocabulary.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `companies`: the "Company list is served without joining jobs" requirement
+  changes how the `q` search matches and ranks — from a Postgres `ILIKE` substring
+  ordered by `job_count DESC, name` to a Meilisearch-backed ranked search (exact →
+  prefix → contains, typo-tolerant, `job_count` tiebreaker) with a Postgres
+  fallback. The response contract, the `job_count > 0` hiring scope, the facet
+  semantics, and the empty-`q` catalog ordering are preserved.
+
+## Impact
+
+- **Code:** new `internal/search/company.go` (`CompanyDocument`, `FromCompany`,
+  `companySettings`, `SearchCompanies`, `RebuildCompanies`); new
+  `cmd/reindex-companies/main.go`; modified `internal/handler/companies.go`
+  (`ListCompanies` reroute + fallback).
+- **Infra/ops:** a new Meili `companies` index on the existing Meili host; a new
+  cron entry for `reindex-companies` (own flock, not stacked with jobs reindex).
+- **Config:** none new — reuses `MEILI_URL` / `MEILI_MASTER_KEY`.
+- **Frontend:** none — the `GET /api/v1/companies` response contract is unchanged.
+- **Dependencies:** none new — reuses the `meilisearch` Go client already vendored.

--- a/openspec/changes/companies-meili-search/specs/companies/spec.md
+++ b/openspec/changes/companies-meili-search/specs/companies/spec.md
@@ -1,0 +1,214 @@
+## MODIFIED Requirements
+
+### Requirement: Company list is served without joining jobs
+
+The system SHALL expose `GET /api/v1/companies` returning companies read from the
+`companies` table. Each company's job count SHALL be read from the denormalized
+`companies.job_count` column (open jobs only), not computed at query time, so the
+read path performs no join to the `jobs` table. When no search query is present,
+the list SHALL be ordered by `job_count` descending, then `name` ascending, so the
+most active companies surface first.
+
+The endpoint SHALL accept an optional `q` query parameter that searches companies
+by their `name`, `slug`, and `tagline`. When `q` is non-empty, results SHALL be
+ranked by **search relevance** — an exact name match first, then a prefix match,
+then a contains match — with **typo tolerance**, and with `job_count` descending
+used as the relevance tiebreaker so that among equally-relevant matches the most
+active company surfaces first. In particular, a company whose name exactly equals
+`q` SHALL rank ahead of companies that merely contain `q` in their name or slug,
+regardless of the other companies' job counts. An absent or empty `q` SHALL return
+the unfiltered list ordered by `job_count` descending then `name` ascending.
+
+Company search SHALL be served by the Meilisearch companies index (see the
+"Company search is served by a Meilisearch index with a Postgres fallback"
+requirement). When the search index is disabled or unavailable, the endpoint SHALL
+fall back to a case-insensitive substring match on the company `name`/`slug`
+ordered by `job_count` descending then `name` ascending, so the endpoint always
+returns a result.
+
+The endpoint SHALL additionally accept repeatable facet query parameters —
+`collections`, `regions`, `countries`, `domains`, `company_type`, `company_size`,
+`remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, and `yc_flags` — each
+filtering against the company's corresponding denormalized array by **array
+overlap**: a company matches a facet when its array shares at least one value with
+the requested values (OR within a facet), and a company must match every provided
+facet (AND across facets). The `remote_regions` facet filters the job-derived
+remote-hiring regions (a subset of `regions`). The `yc_batch`, `yc_status`,
+`yc_stage`, and `yc_flags` facets filter the curated YC-directory columns (see the
+`yc-company-enrichment` capability); a non-YC company has them empty and matches
+none. Facet filters SHALL compose with the `q` search. An absent facet
+parameter SHALL not constrain the list.
+
+The endpoint SHALL additionally accept the repeatable **scalar** facet parameters
+`maturity` and `subindustries`, each filtering against a single-valued company
+column (`companies.maturity` / `companies.subindustry`) by **membership**: a company
+matches when its scalar value is among the requested values (OR within the facet),
+and each ANDs with the others and with `q` exactly like the array facets. A company
+whose column is `NULL` matches no value for that facet. `maturity` values are
+`government`, `startup`, `scaleup`, `enterprise`; `subindustries` values are the
+YC subindustry leaves served by `GET /api/v1/companies/subindustries`.
+
+The hiring scope is preserved regardless of backend: only companies with
+`job_count > 0` are eligible for the list and search results, exactly as the
+Postgres path scopes today.
+
+When any filter (`q` or a facet) is applied, the list `meta.total` SHALL report
+the count of companies matching the full filter combination, so pagination over
+the filtered results is correct.
+
+#### Scenario: Listing companies most-active first
+
+- **WHEN** a client requests `GET /api/v1/companies`
+- **THEN** the response contains companies under `data` with list `meta`,
+  ordered by `job_count` descending (ties broken by `name`), each carrying its
+  denormalized `job_count`
+
+#### Scenario: Searching companies ranks relevance first
+
+- **WHEN** a client requests `GET /api/v1/companies?q=acme`
+- **THEN** the response contains only companies matching `acme`, ranked by search
+  relevance (exact name, then prefix, then contains) with `job_count` as the
+  tiebreaker, and `meta.total` is the count of matching companies
+
+#### Scenario: An exact-name match ranks first despite a low job count
+
+- **WHEN** a company is named exactly `arb` (few open jobs) and other companies'
+  names or slugs merely contain `arb` (many open jobs), and a client requests
+  `GET /api/v1/companies?q=arb`
+- **THEN** the company named exactly `arb` is the first result
+
+#### Scenario: Search tolerates a typo
+
+- **WHEN** a client requests `GET /api/v1/companies?q=arbnb` and a company named
+  `Airbnb` exists
+- **THEN** `Airbnb` is returned among the results
+
+#### Scenario: Empty query returns the full list
+
+- **WHEN** a client requests `GET /api/v1/companies?q=` (empty or absent)
+- **THEN** the response is the unfiltered company list ordered by `job_count`
+  descending then `name`, identical to omitting the parameter
+
+#### Scenario: Filtering by a single facet
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe`
+- **THEN** the response contains only companies whose `regions` array contains
+  `europe`, and `meta.total` is the count of such companies
+
+#### Scenario: Multiple values within one facet are OR-ed
+
+- **WHEN** a client requests `GET /api/v1/companies?regions=europe&regions=asia`
+- **THEN** the response contains companies whose `regions` overlap
+  `{europe, asia}` (in Europe **or** Asia)
+
+#### Scenario: Different facets are AND-ed and compose with search
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?collections=yc&company_type=startup&q=lab`
+- **THEN** the response contains only companies that are in the `yc` collection
+  **and** have `startup` among their `company_types` **and** whose name matches
+  `lab`
+
+#### Scenario: Filtering by remote-hiring regions
+
+- **WHEN** a client requests `GET /api/v1/companies?remote_regions=eu`
+- **THEN** the response contains only companies whose `remote_regions` array
+  contains `eu`, and `meta.total` is the count of such companies
+
+#### Scenario: Filtering by YC facets
+
+- **WHEN** a client requests `GET /api/v1/companies?yc_stage=Growth&yc_flags=top_company`
+- **THEN** the response contains only companies whose `yc_stage` contains `Growth`
+  **and** whose `yc_flags` contains `top_company`, and `meta.total` is the count of
+  such companies
+
+#### Scenario: Filtering by the scalar maturity facet
+
+- **WHEN** a client requests `GET /api/v1/companies?maturity=startup&maturity=scaleup`
+- **THEN** the response contains only companies whose `maturity` is `startup` **or**
+  `scaleup`, excluding any company whose `maturity` is `NULL`, and `meta.total` is
+  the count of such companies
+
+#### Scenario: Filtering by the scalar subindustry facet
+
+- **WHEN** a client requests
+  `GET /api/v1/companies?subindustries=Payments&subindustries=Diagnostics`
+- **THEN** the response contains only companies whose `subindustry` is `Payments`
+  **or** `Diagnostics`, excluding any company whose `subindustry` is `NULL`, and
+  `meta.total` is the count of such companies
+
+## ADDED Requirements
+
+### Requirement: Company search is served by a Meilisearch index with a Postgres fallback
+
+The system SHALL maintain a Meilisearch **companies** index, separate from the
+jobs index, holding one document per company with `job_count > 0`. Each document
+SHALL carry the searchable text attributes `name`, `slug`, and `tagline`; the
+sortable `job_count`; and, as filterable attributes, the denormalized facet arrays
+(`collections`, `regions`, `countries`, `domains`, `company_types`,
+`company_sizes`, `remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, `yc_flags`)
+and scalars (`maturity`, `subindustry`) used by the list endpoint. The index
+SHALL be keyed by `slug`.
+
+The index SHALL be built and refreshed by a scheduled full rebuild that reads the
+`companies` table (scoped to `job_count > 0`) and atomically swaps the freshly
+built index into place, so the search index is **eventually consistent** with the
+`companies` table within the rebuild interval. The rebuild SHALL reuse the atomic
+index-swap approach used by the jobs reindex and SHALL NOT run concurrently with
+the jobs reindex on the same host.
+
+When the search index is disabled (no Meilisearch configured) or a search request
+against it fails, the list endpoint SHALL fall back to the Postgres substring path
+without surfacing an error to the client, so company search gains no new failure
+point relative to the pre-index behavior.
+
+Building the companies index SHALL NOT modify the jobs index or its code path, so
+the jobs search cannot regress.
+
+#### Scenario: The companies index is rebuilt from Postgres
+
+- **WHEN** the scheduled company reindex runs
+- **THEN** a companies index is rebuilt from `companies` rows with `job_count > 0`
+  and atomically swapped into place, and subsequent searches read the new index
+
+#### Scenario: New company data appears after the next rebuild
+
+- **WHEN** a company's `job_count` or facet arrays change (via the periodic
+  recompute) between company reindex runs
+- **THEN** the search results do not reflect the change until the next company
+  reindex, which then includes it
+
+#### Scenario: Endpoint falls back when the index is unavailable
+
+- **WHEN** the Meilisearch companies index is unreachable and a client requests
+  `GET /api/v1/companies?q=acme`
+- **THEN** the endpoint serves the Postgres substring result (case-insensitive
+  `name`/`slug` match ordered by `job_count` descending) and returns HTTP 200
+
+#### Scenario: Endpoint falls back when search is disabled
+
+- **WHEN** no Meilisearch is configured and a client requests
+  `GET /api/v1/companies?q=acme`
+- **THEN** the endpoint serves the Postgres substring result and returns HTTP 200
+
+### Requirement: All company-search surfaces use the single companies endpoint
+
+Every company search, typeahead, and ranked-list surface in the product SHALL be
+served by `GET /api/v1/companies` and therefore by the Meilisearch companies index
+(with its Postgres fallback). The system SHALL NOT introduce a separate company
+search path that bypasses this endpoint. This covers the company catalog page, the
+job-filter sidebar company typeahead, the referral company picker, and the global
+header search's company results.
+
+#### Scenario: Typeahead surfaces share the ranked search
+
+- **WHEN** a user types a company name into the job-filter company typeahead, the
+  referral company picker, or the global header search
+- **THEN** the suggestions are produced by `GET /api/v1/companies?q=<typed>`, ranked
+  by the same relevance-first ordering as the catalog search
+
+#### Scenario: No bypassing company search path exists
+
+- **WHEN** the codebase serves a company search or typeahead
+- **THEN** it calls `GET /api/v1/companies` rather than a separate ad-hoc company
+  search query

--- a/openspec/changes/companies-meili-search/tasks.md
+++ b/openspec/changes/companies-meili-search/tasks.md
@@ -1,0 +1,37 @@
+## 1. Company document & mapper
+
+- [ ] 1.1 Add `CompanyDocument` type and `FromCompany(db.Company) CompanyDocument` in a new `internal/search/company.go`, mapping `slug` (primary key), `name`, `tagline`, `job_count`, the facet arrays (`collections`, `regions`, `countries`, `domains`, `company_types`, `company_sizes`, `remote_regions`, `yc_batch`, `yc_status`, `yc_stage`, `yc_flags`) and scalars (`maturity`, `subindustry`)
+- [ ] 1.2 Unit-test `FromCompany`: full mapping, empty/`nil` arrays serialize to empty, `NULL` `tagline`/`maturity`/`subindustry` map to zero-values, `job_count` carried through
+
+## 2. Meili companies index (parallel to jobs, no jobs-code edits)
+
+- [ ] 2.1 Add `companyIndexUID = "companies"` / `companyRebuildUID = "companies_rebuild"` constants and bind a `companies` index manager on `*Client` without touching the `facet`/`semantic` jobs fields
+- [ ] 2.2 Add `companySettings()`: searchable `[name, slug, tagline]`, filterable = the 14 facet attrs, sortable `[job_count]`, ranking rules default + `job_count:desc`
+- [ ] 2.3 Add `SearchCompanies(ctx, CompanySearchParams) (CompanyResult, error)`: builds the Meili filter from `q` + facets (array overlap OR-within/AND-across, scalar membership, `NULL`-matches-none), returns docs + `estimatedTotalHits`
+- [ ] 2.4 Unit-test the facet→Meili-filter translation for each facet family (array overlap, scalar membership, `job_count > 0` scope, compose with `q`)
+- [ ] 2.5 Add `RebuildCompanies(ctx, docs)` reusing the atomic swap approach (`companies_rebuild` → `swap-indexes` → `companies`); assert it never references the jobs UIDs
+
+## 3. Reindex worker
+
+- [ ] 3.1 Add `cmd/reindex-companies/main.go`: bootstrap config + DB + search client, keyset-scan `companies WHERE job_count > 0`, map via `FromCompany`, push to `companies_rebuild`, promote (atomic swap)
+- [ ] 3.2 Add a DB query (if none fits) to keyset-page companies for reindex scoped to `job_count > 0`
+- [ ] 3.3 Verify the worker builds and, against a local Meili + seeded rows, produces a searchable `companies` index
+
+## 4. Handler reroute with Postgres fallback
+
+- [ ] 4.1 Reroute `ListCompanies` (`internal/handler/companies.go`): when search is enabled and (`q` or a facet is present) → `SearchCompanies`; on any Meili error or when search is disabled → existing Postgres path. Preserve the `{data, meta}` shape and `job_count > 0` scope; `meta.total` from `estimatedTotalHits` on the Meili path
+- [ ] 4.2 Handler test: `q` routes to Meili and ranks the exact-name match first (the "arb" case)
+- [ ] 4.3 Handler test: Meili error falls back to Postgres and still returns HTTP 200 with the substring result
+- [ ] 4.4 Handler test: empty `q` and no facets returns the catalog ordered `job_count DESC, name` (unchanged), and search-disabled config uses Postgres
+- [ ] 4.5 Handler test: each facet family filters correctly through the Meili path (regions overlap, YC facets, scalar `maturity`/`subindustries` membership) matching the ported spec scenarios
+
+## 5. Wiring, docs & ops
+
+- [ ] 5.1 Confirm no company-search surface bypasses `GET /api/v1/companies` (job-filter typeahead, referral `CompanyPicker`, `HeaderSearch`, catalog) — grep the frontend; no code change expected
+- [ ] 5.2 Update `internal/search/AGENTS.md` (and `CLAUDE.md` command list) to document the companies index + `cmd/reindex-companies`
+- [ ] 5.3 Add the `reindex-companies` cron entry in `../freehire-ops` (own flock, not stacked with the jobs reindex) — note in the change if ops lives outside this repo
+
+## 6. Verify
+
+- [ ] 6.1 `go build ./... && go vet ./... && go test ./...` green
+- [ ] 6.2 End-to-end: build the index locally, hit `GET /api/v1/companies?q=<exact>` and confirm the exact match ranks first and a typo query resolves; confirm fallback by pointing at a dead Meili


### PR DESCRIPTION
## Why
`GET /api/v1/companies` ranks with a Postgres `ILIKE` substring ordered by `job_count DESC, name` — no relevance ranking, so an exact-name match (e.g. company "arb" for `?q=arb`) is buried below higher-volume companies that merely contain the query. Every company-search surface inherits this.

## What
OpenSpec **proposal only** (no code): add a parallel Meilisearch `companies` index for relevance ranking (exact → prefix → contains), typo tolerance, and `job_count` tiebreaker, with a Postgres ILIKE fallback on any Meili error / disabled search. Adds `cmd/reindex-companies` (atomic swap rebuild over `companies WHERE job_count > 0`). No frontend or response-contract changes.

`openspec validate companies-meili-search --strict` passes.