### PR TITLE
feat(web): country flags instead of ISO codes

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "@sentry/sveltekit": "^10.63.0",
         "clsx": "^2.1.1",
         "easymde": "^2.21.0",
+        "flag-icons": "^7.5.0",
         "isomorphic-dompurify": "^3.18.0",
         "marked": "^18.0.6",
         "posthog-js": "^1.404.1",
@@ -2975,9 +2976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2995,9 +2993,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3015,9 +3010,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3035,9 +3027,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4720,6 +4709,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flag-icons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
+      "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -50,6 +50,7 @@
     "@sentry/sveltekit": "^10.63.0",
     "clsx": "^2.1.1",
     "easymde": "^2.21.0",
+    "flag-icons": "^7.5.0",
     "isomorphic-dompurify": "^3.18.0",
     "marked": "^18.0.6",
     "posthog-js": "^1.404.1",

--- a/web/src/lib/components/CompaniesView.svelte
+++ b/web/src/lib/components/CompaniesView.svelte
@@ -15,6 +15,7 @@
   import LoadMore from './LoadMore.svelte';
   import InfiniteScroll from './InfiniteScroll.svelte';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CountryFlag from './CountryFlag.svelte';
   import CompanyFilterSummary from './filters/CompanyFilterSummary.svelte';
   import CompanyFilterModal from './filters/CompanyFilterModal.svelte';
   import ListToolbar from './ListToolbar.svelte';
@@ -132,7 +133,7 @@
               {#if industry || hq}
                 <div class="flex flex-wrap gap-1.5">
                   {#if industry}<Badge variant="secondary">{industry}</Badge>{/if}
-                  {#if hq}<Badge variant="secondary">{hq}</Badge>{/if}
+                  {#if hq}<Badge variant="secondary" class="gap-1.5"><CountryFlag code={company.hq_country ?? ''} />{hq}</Badge>{/if}
                 </div>
               {/if}
             </div>

--- a/web/src/lib/components/CompanyFacts.svelte
+++ b/web/src/lib/components/CompanyFacts.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Company } from '$lib/types';
   import { countryLabel } from '$lib/facets';
+  import CountryFlag from './CountryFlag.svelte';
 
   // The company's scalar facts as a self-contained card, shown in the jobs sidebar
   // (desktop) and as a fallback card under the header (mobile, where the sidebar is
@@ -41,20 +42,24 @@
   );
 
   // Ordered {term, value} pairs — present-only, so an absent field drops out of the
-  // definition list rather than showing a blank row.
+  // definition list rather than showing a blank row. `flag` (Headquarters only) makes
+  // the value render a flag icon before the country name.
+  type Fact = { term: string; value: string; flag?: string };
   const facts = $derived(
     [
       company.year_founded ? { term: 'Founded', value: String(company.year_founded) } : null,
       company.employee_count
         ? { term: 'Employees', value: company.employee_count.toLocaleString() }
         : null,
-      company.hq_country ? { term: 'Headquarters', value: countryLabel(company.hq_country) } : null,
+      company.hq_country
+        ? { term: 'Headquarters', value: countryLabel(company.hq_country), flag: company.hq_country }
+        : null,
       company.organization_type ? { term: 'Type', value: company.organization_type } : null,
       stockLine ? { term: 'Listed', value: stockLine } : null,
       fundingLine ? { term: 'Funding', value: fundingLine } : null,
       info.parent ? { term: 'Parent', value: info.parent } : null,
       info.subsidiaries?.length ? { term: 'Subsidiaries', value: info.subsidiaries.join(', ') } : null,
-    ].filter((f): f is { term: string; value: string } => !!f)
+    ].filter((f): f is Fact => !!f)
   );
 </script>
 
@@ -72,7 +77,9 @@
       <dl class="grid grid-cols-[auto_1fr] items-baseline gap-x-3 gap-y-2 text-sm">
         {#each facts as fact (fact.term)}
           <dt class="text-muted-foreground">{fact.term}</dt>
-          <dd class="text-right font-medium">{fact.value}</dd>
+          <dd class="flex items-center justify-end gap-1.5 text-right font-medium">
+            {#if fact.flag}<CountryFlag code={fact.flag} class="text-base" />{/if}{fact.value}
+          </dd>
         {/each}
       </dl>
     {/if}

--- a/web/src/lib/components/CountryFlag.svelte
+++ b/web/src/lib/components/CountryFlag.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { countryLabel } from '$lib/facets';
+  import { cn } from '$lib/utils';
+
+  // A round country flag, backed by the flag-icons sheet (imported once in the root
+  // layout) and shared by the job summary, the location/company filters and company
+  // cards. `code` is an ISO 3166-1 alpha-2 code in any case; the flag scales with the
+  // surrounding font size (flag-icons sizes in `em`). `.fis` picks the square (1:1)
+  // variant so `rounded-full` yields a circle; the ring keeps white flags (Japan,
+  // Nigeria) visible on a light background.
+  //
+  // Codes that aren't two ASCII letters have no flag in the sheet and would render an
+  // empty box — fall back to the upper-cased code as plain text instead, so the value
+  // is never worse than the bare code we showed before.
+  let { code, class: className = '' }: { code: string; class?: string } = $props();
+
+  const cc = $derived(code.trim().toLowerCase());
+  const renderable = $derived(/^[a-z]{2}$/.test(cc));
+  const name = $derived(countryLabel(code));
+</script>
+
+{#if renderable}
+  <span
+    class={cn('fi fis shrink-0 rounded-full ring-1 ring-black/10 dark:ring-white/15', `fi-${cc}`, className)}
+    role="img"
+    aria-label={name}
+    title={name}
+  ></span>
+{:else}
+  <span class={className} title={name}>{code.toUpperCase()}</span>
+{/if}

--- a/web/src/lib/components/JobView.svelte
+++ b/web/src/lib/components/JobView.svelte
@@ -12,6 +12,7 @@
   import { Badge, Button } from '$lib/ui';
   import { formatDate } from '$lib/utils';
   import CompanyLogo from './CompanyLogo.svelte';
+  import CountryFlag from './CountryFlag.svelte';
   import JobDescription from './JobDescription.svelte';
   import JobMatch from './JobMatch.svelte';
   import RealityBadge from './RealityBadge.svelte';
@@ -281,12 +282,26 @@
           {#each facets as facet (facet.label)}
             <div class="flex items-baseline justify-between gap-3">
               <dt class="shrink-0 text-muted-foreground">{facet.label}</dt>
-              <dd class="min-w-0 break-words text-right font-medium"
-                >{#each facet.values as v, i (v.text)}{#if i > 0}, {/if}{#if v.href}<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve --><a
-                      href={v.href}
-                      class="hover:text-foreground hover:underline">{v.text}</a
-                    >{:else}{v.text}{/if}{/each}</dd
-              >
+              {#if facet.values.every((v) => v.flag)}
+                <!-- Flag facet (Country): a wrapping row of round flags, right-aligned,
+                     each linking to its filter. No comma separators — the gap reads the
+                     list on its own and stays compact for many-country remote jobs. -->
+                <dd class="flex min-w-0 flex-wrap justify-end gap-1.5 text-base">
+                  {#each facet.values as v (v.text)}
+                    {#if v.href}
+                      <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve -->
+                      <a href={v.href} class="transition hover:opacity-80"><CountryFlag code={v.flag ?? ''} /></a>
+                    {:else}<CountryFlag code={v.flag ?? ''} />{/if}
+                  {/each}
+                </dd>
+              {:else}
+                <dd class="min-w-0 break-words text-right font-medium"
+                  >{#each facet.values as v, i (v.text)}{#if i > 0}, {/if}{#if v.href}<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- internal filter link from filterHref; query-only, no route to resolve --><a
+                        href={v.href}
+                        class="hover:text-foreground hover:underline">{v.text}</a
+                      >{:else}{v.text}{/if}{/each}</dd
+                >
+              {/if}
             </div>
           {/each}
         </dl>

--- a/web/src/lib/components/facets/SearchSelect.svelte
+++ b/web/src/lib/components/facets/SearchSelect.svelte
@@ -2,6 +2,7 @@
   import { Plus } from '@lucide/svelte';
   import { optionMatches, relatedOptions, uniqueByValue, type FacetOption } from '$lib/facets';
   import { Input } from '$lib/ui';
+  import CountryFlag from '../CountryFlag.svelte';
   import { pillClass, pillTitle } from './pill';
 
   // A searchable multi-select: a filter field over the options rendered as a
@@ -103,8 +104,9 @@
         type="button"
         onclick={() => toggle(opt.value)}
         title={pillTitle(included, excluded, excludable)}
-        class={pillClass(included || excluded, excluded, 'inline-flex max-w-full items-center px-2.5 py-1 text-sm')}
+        class={pillClass(included || excluded, excluded, 'inline-flex max-w-full items-center gap-1.5 px-2.5 py-1 text-sm')}
       >
+        {#if opt.flag}<CountryFlag code={opt.flag} class="text-base" />{/if}
         <!-- A very long value (roles like "Senior Business Development Representative")
              truncates to one line with an ellipsis instead of wrapping the pill onto
              two rows; the full label surfaces on hover via title. -->

--- a/web/src/lib/components/filters/LocationPane.svelte
+++ b/web/src/lib/components/filters/LocationPane.svelte
@@ -5,6 +5,7 @@
   import { REGION_LABELS } from '$lib/labels';
   import { COUNTRY_REGION_MAP } from '$lib/generated/contracts';
   import type { FacetCounts } from '$lib/types';
+  import CountryFlag from '../CountryFlag.svelte';
   import { pillClass, pillTitle } from '../facets/pill';
 
   // Location pane: a region → country tree plus a flat, searchable Cities list.
@@ -215,8 +216,9 @@
             type="button"
             onclick={() => store.cycle('countries', code)}
             title={pillTitle(cInc, cExc, true)}
-            class={pillClass(cInc || cExc, cExc, 'px-3 py-1.5 text-sm')}
+            class={pillClass(cInc || cExc, cExc, 'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm')}
           >
+            <CountryFlag {code} class="text-base" />
             {countryLabel(code)}
           </button>
         {/each}

--- a/web/src/lib/enrichment.ts
+++ b/web/src/lib/enrichment.ts
@@ -4,16 +4,20 @@
 // never renders blank — the SPA never re-validates, it only formats.
 
 import type { Enrichment, Job } from './types';
+import { countryLabel } from './facets';
 import {
   REGION_LABELS, SENIORITY_LABELS, EMPLOYMENT_LABELS, WORK_MODE_LABELS,
   CATEGORY_LABELS, DOMAIN_LABELS, COMPANY_TYPE_LABELS,
 } from './labels';
 
 /** One value within a facet row: its display text and, when the facet maps to a
- *  job-search filter, the /jobs URL that applies it. */
+ *  job-search filter, the /jobs URL that applies it. `flag` carries an ISO 3166-1
+ *  alpha-2 code for the country facet, so the renderer shows a flag icon (with
+ *  `text` as its accessible name) instead of the bare code. */
 export interface FacetValue {
   text: string;
   href?: string;
+  flag?: string;
 }
 
 /** A labelled facet row. Most facets carry a single value; the array-valued ones
@@ -162,15 +166,20 @@ export function summaryFacets(job: Job): Facet[] {
   ) => {
     if (code) facets.push({ label: name, values: [{ text: label(map, code), href: filterHref(param, code) }] });
   };
-  // An array facet (region/country/industry): one clickable value per code.
+  // An array facet (region/country/industry): one clickable value per code. When
+  // `flag` is set, each value also carries its code so the renderer shows a flag icon.
   const links = (
     name: string,
     param: string,
     codes: string[] | undefined,
     toText: (code: string) => string,
+    flag = false,
   ) => {
     if (codes?.length) {
-      facets.push({ label: name, values: codes.map((c) => ({ text: toText(c), href: filterHref(param, c) })) });
+      facets.push({
+        label: name,
+        values: codes.map((c) => ({ text: toText(c), href: filterHref(param, c), ...(flag ? { flag: c } : {}) })),
+      });
     }
   };
   // A facet with no matching filter: plain, non-clickable text.
@@ -188,7 +197,7 @@ export function summaryFacets(job: Job): Facet[] {
   const english = e.english_level && e.english_level !== 'none' ? e.english_level : null;
   link('English', 'english_level', english, ENGLISH_LEVEL);
   link('Category', 'category', e.category, CATEGORY_LABELS);
-  links('Country', 'countries', job.countries, (c) => c.toUpperCase());
+  links('Country', 'countries', job.countries, countryLabel, true);
   link('Relocation', 'relocation', e.relocation, RELOCATION);
   if (e.visa_sponsorship === true) {
     facets.push({ label: 'Visa', values: [{ text: 'Sponsored', href: filterHref('visa_sponsorship', 'true') }] });

--- a/web/src/lib/facets.ts
+++ b/web/src/lib/facets.ts
@@ -31,6 +31,8 @@ export interface FacetOption {
   label: string;
   /** Number of matching jobs, for dynamic (distribution-driven) options. */
   count?: number;
+  /** ISO 3166-1 alpha-2 code for country options, so the pill shows a flag icon. */
+  flag?: string;
 }
 
 export type FacetControl = 'pills' | 'select' | 'tokens' | 'remote';
@@ -436,6 +438,7 @@ const ISO_COUNTRY_CODES = [
 const COUNTRY: FacetOption[] = ISO_COUNTRY_CODES.map((value) => ({
   value,
   label: countryLabel(value),
+  flag: value,
 })).toSorted((a, b) => a.label.localeCompare(b.label));
 
 // The full ISO country select, exported for the profile's location editor (base +

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -14,6 +14,9 @@
   import TopBar from '$lib/components/TopBar.svelte';
   import Footer from '$lib/components/Footer.svelte';
   import '../app.css';
+  // Country-flag icon sheet (used by $lib/components/Flag.svelte). References its
+  // SVGs by URL, so the browser only fetches flags actually rendered.
+  import 'flag-icons/css/flag-icons.min.css';
 
   let { children } = $props();
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
     __SENTRY_DEBUG__: false,
     __SENTRY_TRACING__: false,
   },
+  build: {
+    // Keep flag-icons' ~500 flag SVGs as external files instead of inlining them
+    // as data-URIs into the global CSS. They're each under Vite's 4KB inline
+    // threshold, so the default would embed the whole sheet (~100KB gzip) into the
+    // always-loaded stylesheet even though most pages show no flags. Externalizing
+    // lets the browser fetch only the handful of flags a page actually renders.
+    assetsInlineLimit: (filePath) => (filePath.includes('flag-icons/flags/') ? false : undefined),
+  },
   // SvelteKit owns routing/SSR; it provides the $lib alias, so the manual alias
   // is gone. sentrySvelteKit() must precede sveltekit(); tailwindcss() too.
   //


### PR DESCRIPTION
## What

Show round country flags (via `flag-icons`) wherever a country was rendered as a bare 2-letter ISO code or a plain name.

Places wired up:
- **Job summary** Country row — flags stay compact for many-country remote postings (was a wall of `AE, AL, AM…` codes)
- **Filters** — country pills in both the job Location pane and the company Country facet
- **Company cards** — HQ in the companies list and the company-facts card

## How

- New shared `web/src/lib/components/CountryFlag.svelte` — `fi fis fi-<cc>` (square variant) + `rounded-full` + a subtle ring so white flags (Japan, Nigeria) stay visible. Falls back to the upper-cased code for non-ISO input. Imported once in the root layout.
- `FacetValue.flag` / `FacetOption.flag` carry the ISO code so renderers can show a flag.
- `vite.config.ts` externalizes the flag SVGs (`assetsInlineLimit` returns `false` for `flag-icons/flags/`) — otherwise Vite inlines the whole sheet (~100KB gzip) into the always-loaded global CSS. Now the browser fetches only the handful of flags a page actually renders; global CSS back to ~24KB gzip.

## Verification

- `npm run check` — 0 errors
- `npm run build` — succeeds, flag SVGs emitted as separate assets
- Visual check via headless Chrome on a throwaway route — circular flags render correctly across AE/GB/FR/DE/JP/NG/BR/US/UA/IN/ZA in both bare and pill contexts